### PR TITLE
[Index] isTestCandidate Linux fixes

### DIFF
--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -806,10 +806,10 @@ static bool isTestCandidate(ValueDecl *D) {
     return false;
 
   // 2. ...on a class or extension (not a struct)...
-  auto NTD = getNominalParent(D);
-  if (!NTD)
+  auto parentNTD = getNominalParent(D);
+  if (!parentNTD)
     return false;
-  if (!isa<ClassDecl>(NTD))
+  if (!isa<ClassDecl>(parentNTD))
     return false;
 
   // 3. ...that returns void...
@@ -825,10 +825,10 @@ static bool isTestCandidate(ValueDecl *D) {
 
   // 5. ...is of at least 'internal' accessibility (unless we can use
   //    Objective-C reflection)...
-#if SWIFT_OBJC_INTEROP
-  if (D->getFormalAccess() < Accessibility::Internal)
+  if (!D->getASTContext().LangOpts.EnableObjCInterop &&
+      (D->getFormalAccess() < Accessibility::Internal ||
+      parentNTD->getFormalAccess() < Accessibility::Internal))
     return false;
-#endif
 
   // 6. ...and starts with "test".
   if (FD->getName().str().startswith("test"))

--- a/test/SourceKit/Indexing/index_is_test_candidate.swift
+++ b/test/SourceKit/Indexing/index_is_test_candidate.swift
@@ -13,7 +13,7 @@ struct MyStruct {
   func test_startsWithTest_takesNoParams_returnsVoid_butIsDefinedOnAStruct() {}
 }
 
-private class MyPrivateClass() {
+private class MyPrivateClass {
   func test_startsWithTest_takesNoParams_returnsVoid_butIsPrivate() {}
 }
 

--- a/test/SourceKit/Indexing/index_is_test_candidate.swift.response
+++ b/test/SourceKit/Indexing/index_is_test_candidate.swift.response
@@ -14,42 +14,67 @@
       key.kind: source.lang.swift.decl.function.free,
       key.name: "test_takesNoParams_andReturnsVoid_butIsNotAnInstanceMethod()",
       key.usr: "s:F23index_is_test_candidate58test_takesNoParams_andReturnsVoid_butIsNotAnInstanceMethodFT_T_",
-      key.line: 4,
+      key.line: 10,
       key.column: 6
+    },
+    {
+      key.kind: source.lang.swift.decl.struct,
+      key.name: "MyStruct",
+      key.usr: "s:V23index_is_test_candidate8MyStruct",
+      key.line: 12,
+      key.column: 8,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "test_startsWithTest_takesNoParams_returnsVoid_butIsDefinedOnAStruct()",
+          key.usr: "s:FV23index_is_test_candidate8MyStruct67test_startsWithTest_takesNoParams_returnsVoid_butIsDefinedOnAStructFT_T_",
+          key.line: 13,
+          key.column: 8
+        }
+      ]
     },
     {
       key.kind: source.lang.swift.decl.class,
       key.name: "MyPrivateClass",
       key.usr: "s:C23index_is_test_candidateP33_E06F4E7BC5F577AB6E2EC6D3ECA1C8B914MyPrivateClass",
-      key.line: 6,
-      key.column: 15
+      key.line: 16,
+      key.column: 15,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "test_startsWithTest_takesNoParams_returnsVoid_butIsPrivate()",
+          key.usr: "s:FC23index_is_test_candidateP33_E06F4E7BC5F577AB6E2EC6D3ECA1C8B914MyPrivateClass58test_startsWithTest_takesNoParams_returnsVoid_butIsPrivateFT_T_",
+          key.line: 17,
+          key.column: 8
+        }
+      ]
     },
     {
       key.kind: source.lang.swift.decl.class,
       key.name: "MyClass",
       key.usr: "s:C23index_is_test_candidate7MyClass",
-      key.line: 10,
+      key.line: 20,
       key.column: 14,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "doesNotStartWithTest()",
           key.usr: "s:FC23index_is_test_candidate7MyClass20doesNotStartWithTestFT_T_",
-          key.line: 11,
+          key.line: 21,
           key.column: 8
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "test_startsWithTest_butTakesAParam(param:)",
           key.usr: "s:FC23index_is_test_candidate7MyClass34test_startsWithTest_butTakesAParamFT5paramSi_T_",
-          key.line: 12,
+          key.line: 22,
           key.column: 8,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
               key.usr: "s:Si",
-              key.line: 12,
+              key.line: 22,
               key.column: 50
             }
           ]
@@ -58,14 +83,14 @@
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "test_startsWithTest_andTakesNoParams_butReturnsNonVoid()",
           key.usr: "s:FC23index_is_test_candidate7MyClass54test_startsWithTest_andTakesNoParams_butReturnsNonVoidFT_Si",
-          key.line: 13,
+          key.line: 23,
           key.column: 8,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
               key.usr: "s:Si",
-              key.line: 13,
+              key.line: 23,
               key.column: 68
             }
           ]
@@ -74,14 +99,14 @@
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "test_startsWithTest_takesNoParams_andReturnsVoid_butIsPrivate()",
           key.usr: "s:FC23index_is_test_candidate7MyClassP33_E06F4E7BC5F577AB6E2EC6D3ECA1C8B961test_startsWithTest_takesNoParams_andReturnsVoid_butIsPrivateFT_T_",
-          key.line: 14,
-          key.column: 16,
+          key.line: 24,
+          key.column: 16
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "test_startsWithTest_takesNoParams_returnsVoid()",
           key.usr: "s:FC23index_is_test_candidate7MyClass45test_startsWithTest_takesNoParams_returnsVoidFT_T_",
-          key.line: 15,
+          key.line: 25,
           key.column: 8,
           key.is_test_candidate: 1
         },
@@ -89,7 +114,7 @@
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "test_startsWithTest_takesNoParams_returnsVoid_andThrows()",
           key.usr: "s:FC23index_is_test_candidate7MyClass55test_startsWithTest_takesNoParams_returnsVoid_andThrowsFzT_T_",
-          key.line: 16,
+          key.line: 26,
           key.column: 8,
           key.is_test_candidate: 1
         }

--- a/test/SourceKit/Indexing/index_is_test_candidate_objc.swift
+++ b/test/SourceKit/Indexing/index_is_test_candidate_objc.swift
@@ -12,7 +12,7 @@ struct MyStruct {
   func test_startsWithTest_takesNoParams_returnsVoid_butIsDefinedOnAStruct() {}
 }
 
-private class MyPrivateClass() {
+private class MyPrivateClass {
   func test_startsWithTest_takesNoParams_returnsVoid_andIsPrivate() {}
 }
 

--- a/test/SourceKit/Indexing/index_is_test_candidate_objc.swift.response
+++ b/test/SourceKit/Indexing/index_is_test_candidate_objc.swift.response
@@ -38,7 +38,17 @@
       key.name: "MyPrivateClass",
       key.usr: "s:C28index_is_test_candidate_objcP33_32FED72643814BE1A523406CD2E729AA14MyPrivateClass",
       key.line: 15,
-      key.column: 15
+      key.column: 15,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "test_startsWithTest_takesNoParams_returnsVoid_andIsPrivate()",
+          key.usr: "s:FC28index_is_test_candidate_objcP33_32FED72643814BE1A523406CD2E729AA14MyPrivateClass58test_startsWithTest_takesNoParams_returnsVoid_andIsPrivateFT_T_",
+          key.line: 16,
+          key.column: 8,
+          key.is_test_candidate: 1
+        }
+      ]
     },
     {
       key.kind: source.lang.swift.decl.class,


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?
#2518 introduced a compile-time conditional had previously to prevent `private` test methods from being considered test candidates on Linux, because the methods need to be accessed from external manifest code for the `corelibs-xctest` framework. While working on getting SourceKit tests running on Linux (additional PRs forthcoming), I discovered that this conditional was not working as intended because the header providing the required preprocessor flag was not being included. I have fixed up that logic to ensure that there is no behavioral change when ObjC interop is available, but private methods (or methods in private classes) are indeed rejected when it is not available.

I have also included a couple of fixes to the relevant tests, especially the Linux variant.

cc @benlangmuir @modocache 

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
