### PR TITLE
SILGen: Partial codegen for property behaviors with DI initialization.

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -102,6 +102,12 @@ enum class AccessSemantics : unsigned char {
   /// On a property or subscript reference, this is a direct,
   /// non-polymorphic access to the getter/setter accessors.
   DirectToAccessor,
+  
+  /// On a property or subscript reference, this is a access to a property
+  /// behavior that may be an initialization. Reads always go through the
+  /// 'get' accessor on the property. Writes may go through the 'init' or
+  /// 'set' logic of the behavior based on its initialization state.
+  BehaviorInitialization,
 
   /// This is an ordinary access to a declaration, using whatever
   /// polymorphism is expected.

--- a/include/swift/AST/Mangle.h
+++ b/include/swift/AST/Mangle.h
@@ -135,6 +135,8 @@ public:
   /// \param isInitFunc If true it's a globalinit_func, otherwise a
   /// globalinit_token.
   void mangleGlobalInit(const VarDecl *decl, int counter, bool isInitFunc);
+  
+  void mangleBehaviorInitThunk(const VarDecl *decl);
 
   void mangleIdentifier(StringRef ref,
                         OperatorFixity fixity = OperatorFixity::NotOperator,

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1473,6 +1473,7 @@ static raw_ostream &operator<<(raw_ostream &os, AccessSemantics accessKind) {
   case AccessSemantics::Ordinary: return os;
   case AccessSemantics::DirectToStorage: return os << " direct_to_storage";
   case AccessSemantics::DirectToAccessor: return os << " direct_to_accessor";
+  case AccessSemantics::BehaviorInitialization: return os << " behavior_init";
   }
   llvm_unreachable("bad access kind");
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1211,6 +1211,17 @@ AbstractStorageDecl::getAccessStrategy(AccessSemantics semantics,
       return AccessStrategy::DirectToAccessor;
     }
     llvm_unreachable("bad storage kind");
+  case AccessSemantics::BehaviorInitialization:
+    // Behavior initialization writes to the property as if it has storage.
+    // SIL definite initialization will introduce the logical accesses.
+    // Reads or inouts still go through the getter.
+    switch (accessKind) {
+    case AccessKind::Write:
+      return AccessStrategy::BehaviorStorage;
+    case AccessKind::ReadWrite:
+    case AccessKind::Read:
+      return AccessStrategy::DispatchToAccessor;
+    }
   }
   llvm_unreachable("bad access semantics");
 }

--- a/lib/AST/Mangle.cpp
+++ b/lib/AST/Mangle.cpp
@@ -1720,3 +1720,19 @@ void Mangler::mangleGlobalInit(const VarDecl *decl, int counter,
   Buffer << (isInitFunc ? "_func" : "_token");
   Buffer << counter;
 }
+
+void Mangler::mangleBehaviorInitThunk(const VarDecl *decl) {
+  auto topLevelContext = decl->getDeclContext()->getModuleScopeContext();
+  auto fileUnit = cast<FileUnit>(topLevelContext);
+  Identifier discriminator = fileUnit->getDiscriminatorForPrivateValue(decl);
+  assert(!discriminator.empty());
+  assert(!isNonAscii(discriminator.str()) &&
+         "discriminator contains non-ASCII characters");
+  assert(!clang::isDigit(discriminator.str().front()) &&
+         "not a valid identifier");
+  
+  Buffer << "_TTB";
+  mangleIdentifier(discriminator);
+  mangleContextOf(decl);
+  mangleIdentifier(decl->getName());
+}

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1051,16 +1051,6 @@ public:
     auto InitStorageTy = InitStorage->getType().getAs<SILFunctionType>();
     require(InitStorageTy,
             "mark_uninitialized initializer must be a function");
-    if (auto sig = InitStorageTy->getGenericSignature()) {
-      require(sig->getGenericParams().size()
-              == MU->getInitStorageSubstitutions().size(),
-              "mark_uninitialized initializer must be given right number "
-              "of substitutions");
-    } else {
-      require(MU->getInitStorageSubstitutions().size() == 0,
-              "mark_uninitialized initializer must be given right number "
-              "of substitutions");
-    }
     auto SubstInitStorageTy = InitStorageTy->substGenericArgs(F.getModule(),
                                              F.getModule().getSwiftModule(),
                                              MU->getInitStorageSubstitutions());
@@ -1076,16 +1066,6 @@ public:
     auto SetterTy = Setter->getType().getAs<SILFunctionType>();
     require(SetterTy,
             "mark_uninitialized setter must be a function");
-    if (auto sig = SetterTy->getGenericSignature()) {
-      require(sig->getGenericParams().size()
-              == MU->getSetterSubstitutions().size(),
-              "mark_uninitialized initializer must be given right number "
-              "of substitutions");
-    } else {
-      require(MU->getSetterSubstitutions().size() == 0,
-              "mark_uninitialized initializer must be given right number "
-              "of substitutions");
-    }
     auto SubstSetterTy = SetterTy->substGenericArgs(F.getModule(),
                                                F.getModule().getSwiftModule(),
                                                MU->getSetterSubstitutions());

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -17,12 +17,15 @@
 #include "RValue.h"
 #include "Scope.h"
 #include "swift/AST/AST.h"
+#include "swift/AST/Mangle.h"
 #include "swift/SIL/SILArgument.h"
+#include "swift/SIL/SILUndef.h"
 #include "swift/SIL/TypeLowering.h"
 #include "swift/Basic/Defer.h"
 
 using namespace swift;
 using namespace Lowering;
+using namespace Mangle;
 
 static SILValue emitConstructorMetatypeArg(SILGenFunction &gen,
                                            ValueDecl *ctor) {
@@ -692,6 +695,32 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
   }
 }
 
+static ManagedValue emitSelfForMemberInit(SILGenFunction &SGF, SILLocation loc,
+                                          VarDecl *selfDecl) {
+  CanType selfFormalType = selfDecl->getType()
+      ->getInOutObjectType()->getCanonicalType();
+  if (selfFormalType->hasReferenceSemantics())
+    return SGF.emitRValueForDecl(loc, selfDecl, selfDecl->getType(),
+                                 AccessSemantics::DirectToStorage,
+                                 SGFContext::AllowImmediatePlusZero)
+      .getAsSingleValue(SGF, loc);
+  else
+    return SGF.emitLValueForDecl(loc, selfDecl,
+                                 selfDecl->getType()->getCanonicalType(),
+                                 AccessKind::Write,
+                                 AccessSemantics::DirectToStorage);
+}
+
+static LValue emitLValueForMemberInit(SILGenFunction &SGF, SILLocation loc,
+                                      VarDecl *selfDecl,
+                                      VarDecl *property) {
+  CanType selfFormalType = selfDecl->getType()
+    ->getInOutObjectType()->getCanonicalType();
+  auto self = emitSelfForMemberInit(SGF, loc, selfDecl);
+  return SGF.emitPropertyLValue(loc, self, selfFormalType, property,
+                                AccessKind::Write,
+                                AccessSemantics::DirectToStorage);
+}
 
 /// Emit a member initialization for the members described in the
 /// given pattern from the given source value.
@@ -720,28 +749,11 @@ static void emitMemberInit(SILGenFunction &SGF, VarDecl *selfDecl,
     auto named = cast<NamedPattern>(pattern);
     // Form the lvalue referencing this member.
     WritebackScope scope(SGF);
-    SILLocation loc = pattern;
-    ManagedValue self;
-    CanType selfFormalType = selfDecl->getType()
-        ->getInOutObjectType()->getCanonicalType();
-    if (selfFormalType->hasReferenceSemantics())
-      self = SGF.emitRValueForDecl(loc, selfDecl, selfDecl->getType(),
-                                   AccessSemantics::DirectToStorage,
-                                   SGFContext::AllowImmediatePlusZero)
-        .getAsSingleValue(SGF, loc);
-    else
-      self = SGF.emitLValueForDecl(loc, selfDecl,
-                                   src.getType()->getCanonicalType(),
-                                   AccessKind::Write,
-                                   AccessSemantics::DirectToStorage);
-
-    LValue memberRef =
-      SGF.emitPropertyLValue(loc, self, selfFormalType, named->getDecl(),
-                             AccessKind::Write,
-                             AccessSemantics::DirectToStorage);
+    LValue memberRef = emitLValueForMemberInit(SGF, pattern, selfDecl,
+                                               named->getDecl());
 
     // Assign to it.
-    SGF.emitAssignToLValue(loc, std::move(src), std::move(memberRef));
+    SGF.emitAssignToLValue(pattern, std::move(src), std::move(memberRef));
     return;
   }
 
@@ -765,20 +777,117 @@ static void emitMemberInit(SILGenFunction &SGF, VarDecl *selfDecl,
   }
 }
 
+static SILValue getBehaviorInitStorageFn(SILGenFunction &gen,
+                                         VarDecl *behaviorVar) {
+  std::string behaviorInitName;
+  {
+    Mangler m;
+    m.mangleBehaviorInitThunk(behaviorVar);
+    behaviorInitName = m.finalize();
+  }
+  
+  SILFunction *thunkFn;
+  // Skip out early if we already emitted this thunk.
+  if (auto existing = gen.SGM.M.lookUpFunction(behaviorInitName)) {
+    thunkFn = existing;
+  } else {
+    auto init = behaviorVar->getBehavior()->InitStorageDecl.getDecl();
+    auto initFn = gen.SGM.getFunction(SILDeclRef(init), NotForDefinition);
+    
+    // Emit a thunk to inject the `self` metatype and implode tuples.
+    auto storageVar = behaviorVar->getBehavior()->StorageDecl;
+    auto selfTy = behaviorVar->getDeclContext()->getDeclaredInterfaceType();
+    auto initTy = gen.getLoweredType(selfTy).getFieldType(behaviorVar,
+                                                          gen.SGM.M);
+    auto storageTy = gen.getLoweredType(selfTy).getFieldType(storageVar,
+                                                             gen.SGM.M);
+    
+    auto initConstantTy = initFn->getLoweredType().castTo<SILFunctionType>();
+    
+    auto param = SILParameterInfo(initTy.getSwiftRValueType(),
+                        initTy.isAddress() ? ParameterConvention::Indirect_In
+                                           : ParameterConvention::Direct_Owned);
+    auto result = SILResultInfo(storageTy.getSwiftRValueType(),
+                              storageTy.isAddress() ? ResultConvention::Indirect
+                                                    : ResultConvention::Owned);
+    
+    initConstantTy = SILFunctionType::get(initConstantTy->getGenericSignature(),
+                                          initConstantTy->getExtInfo(),
+                                          ParameterConvention::Direct_Unowned,
+                                          param,
+                                          result,
+                                          // TODO: throwing initializer?
+                                          None,
+                                          gen.getASTContext());
+    
+    // TODO: Generate the body of the thunk.
+    thunkFn = gen.SGM.M.getOrCreateFunction(SILLocation(behaviorVar),
+                                            behaviorInitName,
+                                            SILLinkage::PrivateExternal,
+                                            initConstantTy,
+                                            IsBare, IsTransparent, IsFragile);
+    
+    
+  }
+  return gen.B.createFunctionRef(behaviorVar, thunkFn);
+}
+
+static SILValue getBehaviorSetterFn(SILGenFunction &gen, VarDecl *behaviorVar) {
+  auto set = behaviorVar->getSetter();
+  auto setFn = gen.SGM.getFunction(SILDeclRef(set), NotForDefinition);
+
+  // TODO: The setter may need to be a thunk, to implode tuples or perform
+  // reabstractions.
+  return gen.B.createFunctionRef(behaviorVar, setFn);
+}
+
 void SILGenFunction::emitMemberInitializers(VarDecl *selfDecl,
                                             NominalTypeDecl *nominal) {
   for (auto member : nominal->getMembers()) {
-    // Find pattern binding declarations that have initializers.
-    auto pbd = dyn_cast<PatternBindingDecl>(member);
-    if (!pbd || pbd->isStatic()) continue;
+    // Find instance pattern binding declarations that have initializers.
+    if (auto pbd = dyn_cast<PatternBindingDecl>(member)) {
+      if (pbd->isStatic()) continue;
 
-    for (auto entry : pbd->getPatternList()) {
-      auto init = entry.getInit();
-      if (!init) continue;
+      for (auto entry : pbd->getPatternList()) {
+        auto init = entry.getInit();
+        if (!init) continue;
 
-      // Cleanup after this initialization.
-      FullExpr scope(Cleanups, entry.getPattern());
-      emitMemberInit(*this, selfDecl, entry.getPattern(), emitRValue(init));
+        // Cleanup after this initialization.
+        FullExpr scope(Cleanups, entry.getPattern());
+        emitMemberInit(*this, selfDecl, entry.getPattern(), emitRValue(init));
+      }
+    }
+    
+    // Introduce behavior initialization markers for properties that need them.
+    if (auto var = dyn_cast<VarDecl>(member)) {
+      if (var->isStatic()) continue;
+      if (!var->hasBehaviorNeedingInitialization()) continue;
+      
+      // Get the initializer method for behavior.
+      auto init = var->getBehavior()->InitStorageDecl;
+      SILValue initFn = getBehaviorInitStorageFn(*this, var);
+      
+      // Get the behavior's storage we need to initialize.
+      auto storage = var->getBehavior()->StorageDecl;
+      LValue storageRef = emitLValueForMemberInit(*this, var, selfDecl,storage);
+      // Shed any reabstraction over the member.
+      while (storageRef.isLastComponentTranslation())
+        storageRef.dropLastTranslationComponent();
+      
+      auto storageAddr = emitAddressOfLValue(var, std::move(storageRef),
+                                             AccessKind::ReadWrite);
+      
+      // Get the setter.
+      auto setterFn = getBehaviorSetterFn(*this, var);
+      auto self = emitSelfForMemberInit(*this, var, selfDecl);
+      
+      auto mark = B.createMarkUninitializedBehavior(var,
+               initFn, init.getSubstitutions(), storageAddr.getValue(),
+               setterFn, getForwardingSubstitutions(), self.getValue(),
+               getLoweredType(var->getType()).getAddressType());
+      
+      // The mark instruction stands in for the behavior property.
+      VarLocs[var].value = mark;
     }
   }
 }

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -284,6 +284,10 @@ ManagedValue SILGenFunction::emitLValueForDecl(SILLocation loc, VarDecl *var,
   case AccessStrategy::DirectToAccessor:
   case AccessStrategy::DispatchToAccessor:
     return ManagedValue();
+    
+  case AccessStrategy::BehaviorStorage:
+    // TODO: Behaviors aren't supported on non-instance properties yet.
+    llvm_unreachable("not implemented");
   }
   llvm_unreachable("bad access strategy");
 }
@@ -462,6 +466,9 @@ static SILDeclRef getRValueAccessorDeclRef(SILGenFunction &SGF,
                                            AbstractStorageDecl *storage,
                                            AccessStrategy strategy) {
   switch (strategy) {
+  case AccessStrategy::BehaviorStorage:
+    llvm_unreachable("shouldn't load an rvalue via behavior storage!");
+  
   case AccessStrategy::Storage:
     llvm_unreachable("should already have been filtered out!");
 
@@ -491,6 +498,9 @@ emitRValueWithAccessor(SILGenFunction &SGF, SILLocation loc,
   bool isDirectUse = (strategy == AccessStrategy::DirectToAccessor);
 
   switch (strategy) {
+  case AccessStrategy::BehaviorStorage:
+    llvm_unreachable("shouldn't load an rvalue via behavior storage!");
+  
   case AccessStrategy::Storage:
     llvm_unreachable("should already have been filtered out!");
 

--- a/lib/SILGen/SILGenMaterializeForSet.cpp
+++ b/lib/SILGen/SILGenMaterializeForSet.cpp
@@ -437,6 +437,9 @@ void MaterializeForSetEmitter::emit(SILGenFunction &gen) {
   SILValue address;
   SILFunction *callbackFn = nullptr;
   switch (strategy) {
+  case AccessStrategy::BehaviorStorage:
+    llvm_unreachable("materializeForSet should never engage in behavior init");
+  
   case AccessStrategy::Storage:
     address = emitUsingStorage(gen, loc, self, std::move(indicesRV));
     break;

--- a/test/SILGen/property_behavior_init.swift
+++ b/test/SILGen/property_behavior_init.swift
@@ -1,0 +1,56 @@
+// RUN: %target-swift-frontend -emit-silgen %s | FileCheck %s
+protocol diBehavior {
+  associatedtype Value
+  var storage: Value { get set }
+}
+extension diBehavior {
+  var value: Value {
+    get { }
+    set { }
+  }
+
+  static func initStorage(_ initial: Value) -> Value { }
+}
+
+func whack<T>(_ x: inout T) {}
+
+struct Foo {
+  var x: Int __behavior diBehavior
+
+  // TODO
+  // var xx: (Int, Int) __behavior diBehavior
+
+  // CHECK-LABEL: sil hidden @_TFV22property_behavior_init3FooC
+  // CHECK:       bb0([[X:%.*]] : $Int,
+  init(x: Int) {
+    // CHECK: [[UNINIT_SELF:%.*]] = mark_uninitialized [rootself]
+    // CHECK: [[UNINIT_STORAGE:%.*]] = struct_element_addr [[UNINIT_SELF]]
+    // CHECK: [[UNINIT_BEHAVIOR:%.*]] = mark_uninitialized_behavior {{.*}}<Foo, Int>([[UNINIT_STORAGE]]) : {{.*}}, {{%.*}}([[UNINIT_SELF]])
+
+    // Pure assignments undergo DI analysis so assign to the marking proxy.
+
+    // CHECK: assign [[X]] to [[UNINIT_BEHAVIOR]]
+    self.x = x
+    // CHECK: assign [[X]] to [[UNINIT_BEHAVIOR]]
+    self.x = x
+
+    // Reads or inouts use the accessors normally.
+
+    // CHECK: [[SELF:%.*]] = load [[UNINIT_SELF]]
+    // CHECK: [[GETTER:%.*]] = function_ref @_TFV22property_behavior_init3Foog1xSi
+    // CHECK: apply [[GETTER]]([[SELF]])
+    _ = self.x
+
+    // CHECK: [[WHACK:%.*]] = function_ref @_TF22property_behavior_init5whackurFRxT_
+    // CHECK: [[INOUT:%.*]] = alloc_stack
+    // CHECK: [[SELF:%.*]] = load [[UNINIT_SELF]]
+    // CHECK: [[GETTER:%.*]] = function_ref @_TFV22property_behavior_init3Foog1xSi
+    // CHECK: [[VALUE:%.*]] = apply [[GETTER]]([[SELF]])
+    // CHECK: store [[VALUE]] to [[INOUT]]
+    // CHECK: apply [[WHACK]]<Int>([[INOUT]])
+    // CHECK: [[VALUE:%.*]] = load [[INOUT]]
+    // CHECK: [[SETTER:%.*]] = function_ref @_TFV22property_behavior_init3Foos1xSi
+    // CHECK: apply [[SETTER]]([[VALUE]], [[UNINIT_SELF]])
+    whack(&self.x)
+  }
+}


### PR DESCRIPTION
If a behavior has storage that can be initialized out-of-line, generate code in SILGen that uses stores to mark_uninitialized_behavior for eventual analysis by DI.

This is incomplete, particularly, it's missing code generation of glue thunks for accessors that require reabstraction, but I wanted to make sure the progress here didn't bitrot.
