### PR TITLE
[swift-3.0-preview-2-branch][stdlib] unavailable String APIs: use Swift 2.x APIs without first argument labels

### DIFF
--- a/stdlib/public/core/UnavailableStringAPIs.swift.gyb
+++ b/stdlib/public/core/UnavailableStringAPIs.swift.gyb
@@ -131,19 +131,19 @@ extension ${Index} {
   @available(
     *, unavailable,
     message: "To advance an index by n steps call 'index(_:offsetBy:)' on the ${View} instance that produced the index.")
-  public func advancedBy(n: ${Distance}) -> ${Index} {
+  public func advancedBy(_ n: ${Distance}) -> ${Index} {
     Builtin.unreachable()
   }
   @available(
     *, unavailable,
     message: "To advance an index by n steps stopping at a given limit call 'index(_:offsetBy:limitedBy:)' on ${View} instance that produced the index.  Note that the Swift 3 API returns 'nil' when trying to advance past the limit; the Swift 2 API returned the limit.")
-  public func advancedBy(n: ${Distance}, limit: ${Index}) -> ${Index} {
+  public func advancedBy(_ n: ${Distance}, limit: ${Index}) -> ${Index} {
     Builtin.unreachable()
   }
   @available(
     *, unavailable,
     message: "To find the distance between two indices call 'distance(from:to:)' on the ${View} instance that produced the index.")
-  public func distanceTo(end: ${Index}) -> ${Distance} {
+  public func distanceTo(_ end: ${Index}) -> ${Distance} {
     Builtin.unreachable()
   }
 }


### PR DESCRIPTION
Explanation: correct the signatures of the unavailable `advancedBy` and `distanceTo` methods on String indices.

Scope of the issue: migration of code that uses string indices.

Risk: low.

Reviewed by: @moiseev.

Testing: manual.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
