### PR TITLE
[stdlib] Better fixit for renamed APIs

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -2154,7 +2154,7 @@ extension ${Self} {
     Builtin.unreachable()
   }
 
-  @available(*, unavailable, renamed: "remove")
+  @available(*, unavailable, renamed: "remove(at:)")
   public mutating func removeAtIndex(_ index: Int) -> Element {
     Builtin.unreachable()
   }

--- a/stdlib/public/core/Join.swift
+++ b/stdlib/public/core/Join.swift
@@ -189,7 +189,7 @@ extension JoinedSequence {
 }
 
 extension Sequence where Iterator.Element : Sequence {
-  @available(*, unavailable, renamed: "joined")
+  @available(*, unavailable, renamed: "joined(separator:)")
   public func joinWithSeparator<Separator : Sequence>(
     _ separator: Separator
   ) -> JoinedSequence<Self>

--- a/stdlib/public/core/RangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/RangeReplaceableCollection.swift.gyb
@@ -1160,7 +1160,7 @@ extension RangeReplaceableCollection {
     Builtin.unreachable()
   }
   
-  @available(*, unavailable, renamed: "removeAt")
+  @available(*, unavailable, renamed: "remove(at:)")
   public mutating func removeAtIndex(_ i: Index) -> Iterator.Element {
     Builtin.unreachable()
   }

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -1008,7 +1008,7 @@ extension String {
     Builtin.unreachable()
   }
   
-  @available(*, unavailable, renamed: "removeAt")
+  @available(*, unavailable, renamed: "remove(at:)")
   public mutating func removeAtIndex(_ i: Index) -> Character {
     Builtin.unreachable()
   }
@@ -1030,7 +1030,7 @@ extension String {
 }
 
 extension Sequence where Iterator.Element == String {
-  @available(*, unavailable, renamed: "joined")
+  @available(*, unavailable, renamed: "joined(separator:)")
   public func joinWithSeparator(_ separator: String) -> String {
     Builtin.unreachable()
   }


### PR DESCRIPTION
#### What's in this pull request?

```
removeAtIndex(_:) => remove(at:)
joinedWithSeparator(_:) => joined(separator:)
```

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
