### PR TITLE
Correct Foundation Data initialiser to use Base64DecodingOptions

### DIFF
--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -195,7 +195,7 @@ public struct Data : ReferenceConvertible, CustomStringConvertible, Equatable, H
     /// Returns nil when the input is not recognized as valid Base-64.
     /// - parameter base64String: The string to parse.
     /// - parameter options: Encoding options. Default value is `[]`.
-    public init?(base64Encoded base64String: String, options: Data.Base64EncodingOptions = []) {
+    public init?(base64Encoded base64String: String, options: Data.Base64DecodingOptions = []) {
         if let d = NSData(base64Encoded: base64String, options: Base64DecodingOptions(rawValue: options.rawValue)) {
             _wrapped = _SwiftNSData(immutableObject: d)
         } else {


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

This pull request fixes an issue that one of the Data initialisers is using Base64EncodingOptions rather than Base64DecodingOptions preventing the use of .ignoreUnknownCharacters when decoding a base64 encoded string.

---

Initialising with a base64 encoded string was using Base64EncodingOptions rather than Base64DecodingOptions - this means strings with unknown characters cannot be decoded properly as the .ignoreUnknownCharacters option is unavailable
