### PR TITLE
Don't generate code for transparent functions.

### DIFF
--- a/lib/IRGen/Linking.h
+++ b/lib/IRGen/Linking.h
@@ -520,7 +520,17 @@ public:
     assert(getKind() == Kind::SILFunction);
     return reinterpret_cast<SILFunction*>(Pointer);
   }
-  
+
+  /// Returns true if this function is only serialized, but not necessarily
+  /// code-gen'd. These are fragile transparent functions.
+  bool isSILOnly() const {
+    if (getKind() != Kind::SILFunction)
+      return false;
+
+    SILFunction *F = getSILFunction();
+    return F->isTransparent() && F->isDefinition() && F->isFragile();
+  }
+
   SILGlobalVariable *getSILGlobalVariable() const {
     assert(getKind() == Kind::SILGlobalVariable);
     return reinterpret_cast<SILGlobalVariable*>(Pointer);

--- a/lib/SILOptimizer/IPO/ExternalDefsToDecls.cpp
+++ b/lib/SILOptimizer/IPO/ExternalDefsToDecls.cpp
@@ -26,7 +26,7 @@ class ExternalDefsToDecls : public SILModuleTransform {
     for (auto &F : *getModule()) {
       SILLinkage linkage = F.getLinkage();
       if (isAvailableExternally(linkage) && F.isDefinition() &&
-          !hasSharedVisibility(linkage)) {
+          !hasSharedVisibility(linkage) && !F.isTransparent()) {
         F.convertToDeclaration();
         invalidateAnalysis(&F, SILAnalysis::InvalidationKind::FunctionBody);
       }

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -464,6 +464,15 @@ class MandatoryInlining : public SILModuleTransform {
                                SetFactory, SetFactory.getEmptySet(), CHA);
     }
 
+    // Make sure that we de-serialize all transparent functions,
+    // even if we didn't inline them for some reason.
+    // Transparent functions are not available externally, so we
+    // have to generate code for them.
+    for (auto &F : *M) {
+      if (F.isTransparent())
+        M->linkFunction(&F, Mode);
+    }
+    
     if (!ShouldCleanup)
       return;
 

--- a/test/IRGen/Inputs/multithread_module/main.swift
+++ b/test/IRGen/Inputs/multithread_module/main.swift
@@ -19,6 +19,10 @@ private struct MyStruct : MyProto {
 	}
 }
 
+@_transparent public func transparentfunc(_ x: Int) -> Int {
+	return x + 3
+}
+
 public var g1 = 234
 
 let i = testit(27)

--- a/test/IRGen/multithread_module.swift
+++ b/test/IRGen/multithread_module.swift
@@ -45,6 +45,9 @@ func callPrivInc(_ x: Int) -> Int {
 	return privateInc(x)
 }
 
+// Check if we use the correct linkage for a transparent function
+public var transparentfuncptr = transparentfunc
+
 protocol MyProto {
 	func protofunc() -> Int
 }

--- a/test/IRGen/sil_linkage.sil
+++ b/test/IRGen/sil_linkage.sil
@@ -3,6 +3,8 @@
 sil_stage canonical
 
 // CHECK: define{{( protected)?}} void @public_fragile_function_test() {{.*}} {
+// CHECK: define{{( protected)?}} internal void @public_transparent_fragile_function_test() {{.*}} {
+// CHECK: define{{( protected)?}} void @public_transparent_function_test() {{.*}} {
 // CHECK: define{{( protected)?}} void @hidden_fragile_function_test() {{.*}} {
 // CHECK: define linkonce_odr hidden void @shared_fragile_function_test() {{.*}} {
 // CHECK: define{{( protected)?}} void @private_fragile_function_test() {{.*}} {
@@ -19,6 +21,16 @@ sil_stage canonical
 // CHECK: define linkonce_odr hidden void @shared_external_resilient_function_def_test() {{.*}} {
 
 sil public [fragile] @public_fragile_function_test : $@convention(thin) () -> () {
+  %0 = tuple()
+  return %0 : $()
+}
+
+sil public [transparent] [fragile] @public_transparent_fragile_function_test : $@convention(thin) () -> () {
+  %0 = tuple()
+  return %0 : $()
+}
+
+sil public [transparent] @public_transparent_function_test : $@convention(thin) () -> () {
   %0 = tuple()
   return %0 : $()
 }
@@ -122,6 +134,8 @@ sil hidden_external @hidden_external_resilient_function_decl_test : $@convention
 
 sil public @use_all_symbols : $@convention(thin) () -> () {
   %0 = function_ref @public_fragile_function_test : $@convention(thin) () -> ()
+  %t0 = function_ref @public_transparent_fragile_function_test : $@convention(thin) () -> ()
+  %t1 = function_ref @public_transparent_function_test : $@convention(thin) () -> ()
   %1 = function_ref @hidden_fragile_function_test : $@convention(thin) () -> ()
   %2 = function_ref @shared_fragile_function_test : $@convention(thin) () -> ()
   %3 = function_ref @private_fragile_function_test : $@convention(thin) () -> ()


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

They are mandatory inlined anyway. Therefore the binary code of transparent functions is not used in most cases.
In case the address of a transparent function is taken, the main program (which deserialized the transparent function) generates code for it and treats it as shared function.

This reduces the stdlib code size by 2.8%.
