### PR TITLE
Use `sizeof` for buffer lengths in snprintf

### DIFF
--- a/lib/Basic/Demangle.cpp
+++ b/lib/Basic/Demangle.cpp
@@ -37,13 +37,13 @@ static void unreachable(const char *Message) {
 
 DemanglerPrinter &DemanglerPrinter::operator<<(unsigned long long n) & {
   char buffer[32];
-  snprintf(buffer, 32, "%llu", n);
+  snprintf(buffer, sizeof(buffer), "%llu", n);
   Stream.append(buffer);
   return *this;
 }
 DemanglerPrinter &DemanglerPrinter::operator<<(long long n) & {
   char buffer[32];
-  snprintf(buffer, 32, "%lld",n);
+  snprintf(buffer, sizeof(buffer), "%lld",n);
   Stream.append(buffer);
   return *this;
 }

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -889,7 +889,7 @@ public:
   std::pair<PatternBindingDecl*, VarDecl*>
     buildPatternAndVariable(Expr *InitExpr) {
     char NameBuf[11] = { 0 };
-    snprintf(NameBuf, 11, "tmp%u", TmpNameIndex);
+    snprintf(NameBuf, sizeof(NameBuf), "tmp%u", TmpNameIndex);
     TmpNameIndex++;
         
     Expr *MaybeLoadInitExpr = nullptr;

--- a/stdlib/public/runtime/Reflection.mm
+++ b/stdlib/public/runtime/Reflection.mm
@@ -437,8 +437,7 @@ void swift_TupleMirror_subscript(String *outString,
   
   // The name is the stringized element number '.0'.
   char buf[32];
-  snprintf(buf, 31, ".%zd", i);
-  buf[31] = 0;
+  snprintf(buf, sizeof(buf), ".%zd", i);
   new (outString) String(buf, strlen(buf));
   
   // Get a Mirror for the nth element.


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Rather than duplicating the constant value, use the `sizeof` operator to have
the value propogate from the static buffer allocation.  Any standards conforming
implementation of `snprintf` will null-terminate the output unless the buffer is
NULL (a zero-sized buffer is passed to the call).  On Windows, where this is not
the case, the function is named `_snprintf` which ensures that we do not
accidentally end up with the incorrect behaviour.
