### PR TITLE
[swiftc] Add 💥 case (😢 → 93, 😀 → 5067) triggered in swift::TypeCheck::checkGenericParamList(…)

### DIFF
--- a/validation-test/compiler_crashers/28316-swift-typechecker-checkgenericparamlist.swift
+++ b/validation-test/compiler_crashers/28316-swift-typechecker-checkgenericparamlist.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+{class B{init(T)}class T where g:a


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Add crash case with stack trace:

```
4  swift           0x0000000000ed9e8d swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::GenericSignature*, bool, swift::GenericTypeResolver*) + 93
5  swift           0x0000000000edb6a7 swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 135
6  swift           0x0000000000edba46 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) + 102
7  swift           0x0000000000e9c90f swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 367
11 swift           0x0000000000f0e6de swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
13 swift           0x0000000000f0f7b4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
14 swift           0x0000000000f0e5d0 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
16 swift           0x0000000000ee05e5 swift::TypeChecker::typeCheckParameterList(swift::ParameterList*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) + 117
19 swift           0x0000000000e9cbe1 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1089
20 swift           0x0000000000ea79cf swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 607
23 swift           0x0000000000ea2156 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
26 swift           0x0000000000f088f4 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
27 swift           0x0000000000f33ecc swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
28 swift           0x0000000000e8fc21 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 769
30 swift           0x0000000000f08a36 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
31 swift           0x0000000000ec4b7d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
32 swift           0x0000000000c594c9 swift::CompilerInstance::performSema() + 3289
34 swift           0x00000000007d7739 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
35 swift           0x00000000007a3748 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28316-swift-typechecker-checkgenericparamlist.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28316-swift-typechecker-checkgenericparamlist-2ebf90.o
1.  While type-checking expression at [validation-test/compiler_crashers/28316-swift-typechecker-checkgenericparamlist.swift:9:1 - line:9:34] RangeText="{class B{init(T)}class T where g:a"
2.  While type-checking 'B' at validation-test/compiler_crashers/28316-swift-typechecker-checkgenericparamlist.swift:9:2
3.  While type-checking 'init' at validation-test/compiler_crashers/28316-swift-typechecker-checkgenericparamlist.swift:9:10
4.  While resolving type T at [validation-test/compiler_crashers/28316-swift-typechecker-checkgenericparamlist.swift:9:15 - line:9:15] RangeText="T"
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
