### PR TITLE
[CMake] Only build StdlibUnittest when SDK overlay is built

### DIFF
--- a/stdlib/private/CMakeLists.txt
+++ b/stdlib/private/CMakeLists.txt
@@ -2,23 +2,16 @@ if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_SDK_OVERLAY)
   add_subdirectory(SwiftPrivate)
 endif()
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  if(SWIFT_BUILD_SDK_OVERLAY)
-    # FIXME: there is nothing Darwin-specific in StdlibUnittest, but to use
-    # POSIX APIs it imports the Darwin module on Apple platforms, so it can't
-    # be built separately from the SDK overlay.
-    add_subdirectory(StdlibUnittest)
-    add_subdirectory(StdlibCollectionUnittest)
-    add_subdirectory(StdlibUnittestFoundationExtras)
-    add_subdirectory(SwiftPrivateLibcExtras)
-    add_subdirectory(SwiftPrivatePthreadExtras)
-    add_subdirectory(SwiftReflectionTest)
-  endif()
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+if(SWIFT_BUILD_SDK_OVERLAY)
+  # SwiftPrivatePthreadExtras makes use of Darwin/Glibc, which is part of the
+  # SDK overlay. It can't be built separately from the SDK overlay.
   add_subdirectory(StdlibUnittest)
   add_subdirectory(StdlibCollectionUnittest)
   add_subdirectory(SwiftPrivateLibcExtras)
   add_subdirectory(SwiftPrivatePthreadExtras)
+
+  if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    add_subdirectory(StdlibUnittestFoundationExtras)
+    add_subdirectory(SwiftReflectionTest)
+  endif()
 endif()


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

On Linux it used to be possible to build only the stdlib, without the SDK overlays, like so:

```
utils/build-script -- --build-swift-stdlib --build-swift-sdk-overlay=0
```

However this invocation, as of https://github.com/apple/swift/pull/2057, now results in the following error:

```
+ /usr/bin/cmake --build /home/modocache/GitHub/apple/build/Ninja-ReleaseAssert/swift-linux-x86_64 -- -j8 all swift-stdlib-linux-x86_64
ninja: error: '/home/modocache/GitHub/apple/swift/stdlib/private/SwiftPrivatePthreadExtras/swiftGlibc-linux-x86_64', needed by 'stdlib/private/SwiftPrivatePthreadExtras/linux/x86_64/SwiftPrivatePthreadExtras.o', missing and no known rule to make it
utils/build-script: fatal error: command terminated with a non-zero exit status 1, aborting
```

The problem is that SwiftPrivatePthreadExtras is always built, regardless of whether the SDK overlay is built. I believe there's an explicit check against this for Darwin platforms to prevent the same error.

The solution, implemented here, is to add the same check for Linux.
#### Resolved bug number: None

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
