### PR TITLE
[Code completion] Teach code completion to use declarations for postf…

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -494,7 +494,11 @@ public:
   ///   has an access kind
   void propagateLValueAccessKind(AccessKind accessKind,
                                  bool allowOverwrite = false);
-  
+
+  /// Retrieves the declaration that is being referenced by this
+  /// expression, if any.
+  ConcreteDeclRef getReferencedDecl() const;
+
   /// Determine whether this expression is 'super', possibly converted to
   /// a base class.
   bool isSuperExpr() const;

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -88,10 +88,12 @@ namespace swift {
 
   /// \brief Return the type of an expression parsed during code completion, or
   /// None on error.
-  Optional<Type> getTypeOfCompletionContextExpr(ASTContext &Ctx,
-                                                DeclContext *DC,
-                                                CompletionTypeCheckKind kind,
-                                                Expr *&parsedExpr);
+  Optional<Type> getTypeOfCompletionContextExpr(
+                   ASTContext &Ctx,
+                   DeclContext *DC,
+                   CompletionTypeCheckKind kind,
+                   Expr *&parsedExpr,
+                   ConcreteDeclRef &referencedDecl);
 
   /// Typecheck the sequence expression \p parsedExpr for code completion.
   ///

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -330,6 +330,145 @@ void Expr::propagateLValueAccessKind(AccessKind accessKind,
   PropagateAccessKind(allowOverwrite).visit(this, accessKind);
 }
 
+ConcreteDeclRef Expr::getReferencedDecl() const {
+  switch (getKind()) {
+  // No declaration reference.
+  #define NO_REFERENCE(Id) case ExprKind::Id: return ConcreteDeclRef()
+  #define SIMPLE_REFERENCE(Id, Getter)          \
+    case ExprKind::Id:                          \
+      return cast<Id##Expr>(this)->Getter()
+  #define PASS_THROUGH_REFERENCE(Id, GetSubExpr)                      \
+    case ExprKind::Id:                                                \
+      return cast<Id##Expr>(this)->GetSubExpr()->getReferencedDecl()
+
+  NO_REFERENCE(Error);
+  NO_REFERENCE(NilLiteral);
+  NO_REFERENCE(IntegerLiteral);
+  NO_REFERENCE(FloatLiteral);
+  NO_REFERENCE(BooleanLiteral);
+  NO_REFERENCE(StringLiteral);
+  NO_REFERENCE(InterpolatedStringLiteral);
+  NO_REFERENCE(ObjectLiteral);
+  NO_REFERENCE(MagicIdentifierLiteral);
+  NO_REFERENCE(DiscardAssignment);
+
+  SIMPLE_REFERENCE(DeclRef, getDecl);
+  SIMPLE_REFERENCE(SuperRef, getSelf);
+
+  case ExprKind::Type: {
+    auto typeRepr = cast<TypeExpr>(this)->getTypeRepr();
+    if (!typeRepr) return ConcreteDeclRef();
+    auto ident = dyn_cast<IdentTypeRepr>(typeRepr);
+    if (!ident) return ConcreteDeclRef();
+    return ident->getComponentRange().back()->getBoundDecl();
+  }
+
+  SIMPLE_REFERENCE(OtherConstructorDeclRef, getDecl);
+
+  PASS_THROUGH_REFERENCE(DotSyntaxBaseIgnored, getRHS);
+
+  // FIXME: Return multiple results?
+  case ExprKind::OverloadedDeclRef:
+  case ExprKind::OverloadedMemberRef:
+    return ConcreteDeclRef();
+
+  NO_REFERENCE(UnresolvedDeclRef);
+
+  SIMPLE_REFERENCE(MemberRef, getMember);
+  SIMPLE_REFERENCE(DynamicMemberRef, getMember);
+  SIMPLE_REFERENCE(DynamicSubscript, getMember);
+
+  PASS_THROUGH_REFERENCE(UnresolvedSpecialize, getSubExpr);
+
+  NO_REFERENCE(UnresolvedMember);
+  NO_REFERENCE(UnresolvedDot);
+  NO_REFERENCE(Sequence);
+  PASS_THROUGH_REFERENCE(Paren, getSubExpr);
+  PASS_THROUGH_REFERENCE(DotSelf, getSubExpr);
+  PASS_THROUGH_REFERENCE(Try, getSubExpr);
+  PASS_THROUGH_REFERENCE(ForceTry, getSubExpr);
+  PASS_THROUGH_REFERENCE(OptionalTry, getSubExpr);
+
+  NO_REFERENCE(Tuple);
+  NO_REFERENCE(Array);
+  NO_REFERENCE(Dictionary);
+
+  case ExprKind::Subscript: {
+    auto subscript = cast<SubscriptExpr>(this);
+    if (subscript->hasDecl()) return subscript->getDecl();
+    return ConcreteDeclRef();
+  }
+
+  NO_REFERENCE(TupleElement);
+  NO_REFERENCE(CaptureList);
+  NO_REFERENCE(Closure);
+
+  PASS_THROUGH_REFERENCE(AutoClosure, getSingleExpressionBody);
+  PASS_THROUGH_REFERENCE(InOut, getSubExpr);
+
+  NO_REFERENCE(DynamicType);
+
+  PASS_THROUGH_REFERENCE(RebindSelfInConstructor, getSubExpr);
+
+  NO_REFERENCE(OpaqueValue);
+  PASS_THROUGH_REFERENCE(BindOptional, getSubExpr);
+  PASS_THROUGH_REFERENCE(OptionalEvaluation, getSubExpr);
+  PASS_THROUGH_REFERENCE(ForceValue, getSubExpr);
+  PASS_THROUGH_REFERENCE(OpenExistential, getSubExpr);
+
+  NO_REFERENCE(Call);
+  NO_REFERENCE(PrefixUnary);
+  NO_REFERENCE(PostfixUnary);
+  NO_REFERENCE(Binary);
+  NO_REFERENCE(DotSyntaxCall);
+  NO_REFERENCE(ConstructorRefCall);
+
+  PASS_THROUGH_REFERENCE(Load, getSubExpr);
+  NO_REFERENCE(TupleShuffle);
+  NO_REFERENCE(UnresolvedTypeConversion);
+  PASS_THROUGH_REFERENCE(FunctionConversion, getSubExpr);
+  PASS_THROUGH_REFERENCE(CovariantFunctionConversion, getSubExpr);
+  PASS_THROUGH_REFERENCE(CovariantReturnConversion, getSubExpr);
+  PASS_THROUGH_REFERENCE(MetatypeConversion, getSubExpr);
+  PASS_THROUGH_REFERENCE(CollectionUpcastConversion, getSubExpr);
+  PASS_THROUGH_REFERENCE(Erasure, getSubExpr);
+  PASS_THROUGH_REFERENCE(DerivedToBase, getSubExpr);
+  PASS_THROUGH_REFERENCE(ArchetypeToSuper, getSubExpr);
+  PASS_THROUGH_REFERENCE(InjectIntoOptional, getSubExpr);
+  PASS_THROUGH_REFERENCE(ClassMetatypeToObject, getSubExpr);
+  PASS_THROUGH_REFERENCE(ExistentialMetatypeToObject, getSubExpr);
+  PASS_THROUGH_REFERENCE(ProtocolMetatypeToObject, getSubExpr);
+  PASS_THROUGH_REFERENCE(InOutToPointer, getSubExpr);
+  PASS_THROUGH_REFERENCE(ArrayToPointer, getSubExpr);
+  PASS_THROUGH_REFERENCE(StringToPointer, getSubExpr);
+  PASS_THROUGH_REFERENCE(PointerToPointer, getSubExpr);
+  PASS_THROUGH_REFERENCE(LValueToPointer, getSubExpr);
+  PASS_THROUGH_REFERENCE(ForeignObjectConversion, getSubExpr);
+  PASS_THROUGH_REFERENCE(UnevaluatedInstance, getSubExpr);
+  NO_REFERENCE(Coerce);
+  NO_REFERENCE(ForcedCheckedCast);
+  NO_REFERENCE(ConditionalCheckedCast);
+  NO_REFERENCE(Is);
+
+  NO_REFERENCE(Arrow);
+  NO_REFERENCE(If);
+  NO_REFERENCE(EnumIsCase);
+  NO_REFERENCE(Assign);
+  NO_REFERENCE(DefaultValue);
+  NO_REFERENCE(CodeCompletion);
+  NO_REFERENCE(UnresolvedPattern);
+  NO_REFERENCE(EditorPlaceholder);
+  NO_REFERENCE(ObjCSelector);
+  NO_REFERENCE(ObjCKeyPath);
+
+#undef SIMPLE_REFERENCE
+#undef NO_REFERENCE
+#undef PASS_THROUGH_REFERENCE
+  }
+
+  return ConcreteDeclRef();
+}
+
 /// Enumerate each immediate child expression of this node, invoking the
 /// specific functor on it.  This ignores statements and other non-expression
 /// children.

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1309,7 +1309,7 @@ class CodeCompletionCallbacksImpl : public CodeCompletionCallbacks {
     return typeCheckCompletionDecl(DelayedParsedDecl);
   }
 
-  Optional<Type> getTypeOfParsedExpr() {
+  Optional<std::pair<Type, ConcreteDeclRef>> typeCheckParsedExpr() {
     assert(ParsedExpr && "should have an expression");
 
     // Figure out the kind of type-check we'll be performing.
@@ -1324,16 +1324,19 @@ class CodeCompletionCallbacksImpl : public CodeCompletionCallbacks {
     // typecheck again. rdar://21466394
     if (CheckKind == CompletionTypeCheckKind::Normal &&
         ParsedExpr->getType() && !ParsedExpr->getType()->is<ErrorType>())
-      return ParsedExpr->getType();
+      return std::make_pair(ParsedExpr->getType(),
+                            ParsedExpr->getReferencedDecl());
 
+    ConcreteDeclRef ReferencedDecl = nullptr;
     Expr *ModifiedExpr = ParsedExpr;
     if (auto T = getTypeOfCompletionContextExpr(P.Context, CurDeclContext,
-                                                CheckKind, ModifiedExpr)) {
+                                                CheckKind, ModifiedExpr,
+                                                ReferencedDecl)) {
       // FIXME: even though we don't apply the solution, the type checker may
       // modify the original expression. We should understand what effect that
       // may have on code completion.
       ParsedExpr = ModifiedExpr;
-      return T;
+      return std::make_pair(*T, ReferencedDecl);
     }
     return None;
   }
@@ -2058,16 +2061,17 @@ public:
     addPatternFromTypeImpl(Builder, T, Identifier(), true, /*isVarArg*/false);
   }
 
-  static bool hasInterestingDefaultValues(const AnyFunctionType *AFT) {
-    if (auto *TT = dyn_cast<TupleType>(AFT->getInput().getPointer())) {
-      for (const TupleTypeElt &EltT : TT->getElements()) {
-        switch (EltT.getDefaultArgKind()) {
-        case DefaultArgumentKind::Normal:
-        case DefaultArgumentKind::Inherited: // FIXME: include this?
-          return true;
-        default:
-          break;
-        }
+  static bool hasInterestingDefaultValues(const AbstractFunctionDecl *func) {
+    if (!func) return false;
+
+    bool isMemberOfType = func->getDeclContext()->isTypeContext();
+    for (auto param : *func->getParameterList(isMemberOfType ? 1 : 0)) {
+      switch (param->getDefaultArgumentKind()) {
+      case DefaultArgumentKind::Normal:
+      case DefaultArgumentKind::Inherited: // FIXME: include this?
+        return true;
+      default:
+        break;
       }
     }
     return false;
@@ -2080,8 +2084,25 @@ public:
                                    bool includeDefaultArgs = true) {
 
     const ParameterList *BodyParams = nullptr;
-    if (AFD)
+    if (AFD) {
       BodyParams = AFD->getParameterList(AFD->getImplicitSelfDecl() ? 1 : 0);
+
+      // FIXME: Hack because we don't know which parameter list we're
+      // actually working with.
+      unsigned expectedNumParams;
+      if (auto *TT = dyn_cast<TupleType>(AFT->getInput().getPointer()))
+        expectedNumParams = TT->getNumElements();
+      else
+        expectedNumParams = 1;
+
+      if (expectedNumParams != BodyParams->size()) {
+        // Adjust to the "self" list if that is present, otherwise give up.
+        if (expectedNumParams == 1 && AFD->getImplicitSelfDecl())
+          BodyParams = AFD->getParameterList(0);
+        else
+          BodyParams = nullptr;
+      }
+    }
 
     bool modifiedBuilder = false;
 
@@ -2091,8 +2112,10 @@ public:
       bool NeedComma = false;
       // Iterate over the tuple type fields, corresponding to each parameter.
       for (unsigned i = 0, e = TT->getNumElements(); i != e; ++i) {
-        const auto &TupleElt = TT->getElement(i);
-        switch (TupleElt.getDefaultArgKind()) {
+        auto defArg = DefaultArgumentKind::None;
+        if (BodyParams && i < BodyParams->size())
+          defArg = BodyParams->get(i)->getDefaultArgumentKind();
+        switch (defArg) {
         case DefaultArgumentKind::None:
           break;
 
@@ -2115,6 +2138,8 @@ public:
           // these parameters.
           continue;
         }
+
+        const auto &TupleElt = TT->getElement(i);
         auto ParamType = TupleElt.isVararg() ? TupleElt.getVarargBaseTy()
                                              : TupleElt.getType();
         auto Name = TupleElt.getName();
@@ -2247,7 +2272,7 @@ public:
       addTypeAnnotation(Builder, AFT->getResult());
     };
 
-    if (hasInterestingDefaultValues(AFT))
+    if (hasInterestingDefaultValues(AFD))
       addPattern(/*includeDefaultArgs*/ false);
     addPattern();
   }
@@ -2359,7 +2384,7 @@ public:
     };
 
     if (!FunctionType->is<ErrorType>() &&
-        hasInterestingDefaultValues(FunctionType->castTo<AnyFunctionType>())) {
+        hasInterestingDefaultValues(FD)) {
       addMethodImpl(/*includeDefaultArgs*/ false);
     }
     addMethodImpl();
@@ -2442,7 +2467,7 @@ public:
                                             ConstructorType->getResult());
     };
 
-    if (ConstructorType && hasInterestingDefaultValues(ConstructorType))
+    if (ConstructorType && hasInterestingDefaultValues(CD))
       addConstructorImpl(/*includeDefaultArgs*/ false);
     addConstructorImpl();
   }
@@ -3107,12 +3132,13 @@ public:
                                DeclNameLoc(expr->getSourceRange().End));
     PostfixUnaryExpr opExpr(&UDRE, expr);
     Expr *tempExpr = &opExpr;
-
+    ConcreteDeclRef referencedDecl;
     if (auto T = getTypeOfCompletionContextExpr(
             CurrDeclContext->getASTContext(),
             const_cast<DeclContext *>(CurrDeclContext),
             CompletionTypeCheckKind::Normal,
-            tempExpr))
+            tempExpr,
+            referencedDecl))
       addPostfixOperatorCompletion(op, *T);
   }
 
@@ -4820,15 +4846,19 @@ void CodeCompletionCallbacksImpl::doneParsing() {
     CurDeclContext = AFD;
 
   Optional<Type> ExprType;
+  ConcreteDeclRef ReferencedDecl = nullptr;
   if (ParsedExpr) {
-    ExprType = getTypeOfParsedExpr();
+    if (auto typechecked = typeCheckParsedExpr()) {
+      ExprType = typechecked->first;
+      ReferencedDecl = typechecked->second;
+      ParsedExpr->setType(*ExprType);
+    }
+
     if (!ExprType && Kind != CompletionKind::PostfixExprParen &&
         Kind != CompletionKind::CallArg &&
         Kind != CompletionKind::KeyPathExpr &&
         Kind != CompletionKind::KeyPathExprDot)
       return;
-    if (ExprType)
-      ParsedExpr->setType(*ExprType);
   }
 
   if (!ParsedTypeLoc.isNull() && !typecheckParsedType())
@@ -4888,7 +4918,7 @@ void CodeCompletionCallbacksImpl::doneParsing() {
     if (TypeAnalyzer.Analyze(PossibleTypes)) {
       Lookup.setExpectedTypes(PossibleTypes);
     }
-    Lookup.getValueExprCompletions(ExprType);
+    Lookup.getValueExprCompletions(ExprType, ReferencedDecl.getDecl());
     break;
   }
 
@@ -4911,7 +4941,7 @@ void CodeCompletionCallbacksImpl::doneParsing() {
     Lookup.setHaveLeadingSpace(HasSpace);
     if (isDynamicLookup(*ExprType))
       Lookup.setIsDynamicLookup();
-    Lookup.getValueExprCompletions(*ExprType);
+    Lookup.getValueExprCompletions(*ExprType, ReferencedDecl.getDecl());
     Lookup.getOperatorCompletions(ParsedExpr, leadingSequenceExprs);
     break;
   }
@@ -4930,7 +4960,7 @@ void CodeCompletionCallbacksImpl::doneParsing() {
     if (ExprType) {
       if (ShouldCompleteCallPatternAfterParen) {
         Lookup.setHaveRParen(HasRParen);
-        Lookup.getValueExprCompletions(*ExprType);
+        Lookup.getValueExprCompletions(*ExprType, ReferencedDecl.getDecl());
       } else {
         // Add argument labels, then fallthrough to get values.
         Lookup.addArgNameCompletionResults(PossibleNames);
@@ -4948,14 +4978,14 @@ void CodeCompletionCallbacksImpl::doneParsing() {
 
   case CompletionKind::SuperExpr: {
     Lookup.setIsSuperRefExpr();
-    Lookup.getValueExprCompletions(*ExprType);
+    Lookup.getValueExprCompletions(*ExprType, ReferencedDecl.getDecl());
     break;
   }
 
   case CompletionKind::SuperExprDot: {
     Lookup.setIsSuperRefExpr();
     Lookup.setHaveDot(SourceLoc());
-    Lookup.getValueExprCompletions(*ExprType);
+    Lookup.getValueExprCompletions(*ExprType, ReferencedDecl.getDecl());
     break;
   }
 
@@ -4971,7 +5001,7 @@ void CodeCompletionCallbacksImpl::doneParsing() {
       if (isDynamicLookup(*ExprType))
         Lookup.setIsDynamicLookup();
 
-      Lookup.getValueExprCompletions(*ExprType);
+      Lookup.getValueExprCompletions(*ExprType, ReferencedDecl.getDecl());
     } else {
       SourceLoc Loc = P.Context.SourceMgr.getCodeCompletionLoc();
       Lookup.getValueCompletionsInDeclContext(Loc, KeyPathFilter,

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -694,6 +694,10 @@ public:
   /// \brief Retrieve the fixed type for the given type variable.
   Type getFixedType(TypeVariableType *typeVar) const;
 
+  /// Try to resolve the given locator to a declaration within this
+  /// solution.
+  ConcreteDeclRef resolveLocatorToDecl(ConstraintLocator *locator) const;
+
   LLVM_ATTRIBUTE_DEPRECATED(
       void dump() const LLVM_ATTRIBUTE_USED,
       "only for use within the debugger");

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1208,6 +1208,9 @@ public:
   ///
   /// \param expr The expression to type-check.
   ///
+  /// \param referencedDecl Will be set to the declaration that is referenced by
+  /// the expression.
+  ///
   /// \param allowFreeTypeVariables Whether free type variables are allowed in
   /// the solution, and what to do with them.
   ///
@@ -1219,6 +1222,7 @@ public:
   /// FIXME: expr may still be modified...
   Optional<Type> getTypeOfExpressionWithoutApplying(
       Expr *&expr, DeclContext *dc,
+      ConcreteDeclRef &referencedDecl,
       FreeTypeVariableBinding allowFreeTypeVariables =
                               FreeTypeVariableBinding::Disallow,
       ExprTypeCheckListener *listener = nullptr);

--- a/test/IDE/complete_at_eof_in_call_1.swift
+++ b/test/IDE/complete_at_eof_in_call_1.swift
@@ -4,7 +4,7 @@
 // Don't add any tests at the end of the file!
 //
 // A: Begin completions
-// A-DAG: Pattern/ExprSpecific:               ['(']{#Int#})[#Void#]{{; name=.+$}}
+// A-DAG: Pattern/ExprSpecific:               ['(']{#(x): Int#})[#Void#]{{; name=.+$}}
 // A: End completions
 func f(_ x: Int) {}
 f(#^A^#

--- a/test/IDE/complete_at_eof_in_call_no_newline_1.swift
+++ b/test/IDE/complete_at_eof_in_call_no_newline_1.swift
@@ -4,7 +4,7 @@
 // Don't add any tests at the end of the file!
 //
 // A: Begin completions
-// A-DAG: Pattern/ExprSpecific:               ['(']{#Int#})[#Void#]{{; name=.+$}}
+// A-DAG: Pattern/ExprSpecific:               ['(']{#(x): Int#})[#Void#]{{; name=.+$}}
 // A: End completions
 func f(_ x: Int) {}
 f(#^A^#

--- a/test/IDE/complete_default_arguments.swift
+++ b/test/IDE/complete_default_arguments.swift
@@ -67,8 +67,8 @@ func testDefaultArgs2() {
   freeFuncWithDefaultArgs1#^DEFAULT_ARGS_2^#
 }
 // DEFAULT_ARGS_2: Begin completions
-// DEFAULT_ARGS_2-DAG: Pattern/ExprSpecific:      ({#Int#})[#Void#]{{; name=.+$}}
-// DEFAULT_ARGS_2-DAG: Pattern/ExprSpecific:      ({#Int#}, {#b: Int#})[#Void#]{{; name=.+$}}
+// DEFAULT_ARGS_2-DAG: Pattern/ExprSpecific:      ({#(a): Int#})[#Void#]{{; name=.+$}}
+// DEFAULT_ARGS_2-DAG: Pattern/ExprSpecific:      ({#(a): Int#}, {#b: Int#})[#Void#]{{; name=.+$}}
 // DEFAULT_ARGS_2: End completions
 
 func testDefaultArgs3() {

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -1814,8 +1814,7 @@ func testThrows002() {
   globalFuncRethrows#^THROWS2^#
 
 // THROWS2: Begin completions
-// FIXME: <rdar://problem/21010193> Fix throws => rethrows in call patterns
-// THROWS2: Pattern/ExprSpecific:               ({#() throws -> ()##() throws -> ()#})[' throws'][#Void#]; name=(() throws -> ()) throws
+// THROWS2: Pattern/ExprSpecific:               ({#(x): () throws -> ()##() throws -> ()#})[' rethrows'][#Void#]; name=(x: () throws -> ()) rethrows
 // THROWS2: End completions
 }
 func testThrows003(_ x: HasThrowingMembers) {
@@ -1834,8 +1833,7 @@ func testThrows004(_ x: HasThrowingMembers) {
 func testThrows005(_ x: HasThrowingMembers) {
   x.memberRethrows#^MEMBER_THROWS3^#
 // MEMBER_THROWS3: Begin completions
-// FIXME: <rdar://problem/21010193> Fix throws => rethrows in call patterns
-// MEMBER_THROWS3: Pattern/ExprSpecific:               ({#() throws -> ()##() throws -> ()#})[' throws'][#Void#]; name=(() throws -> ()) throws
+// MEMBER_THROWS3: Pattern/ExprSpecific: ({#(x): () throws -> ()##() throws -> ()#})[' rethrows'][#Void#]; name=(x: () throws -> ()) rethrows
 // MEMBER_THROWS3: End completions
 }
 func testThrows006() {

--- a/test/SourceKit/CodeComplete/complete_structure.swift
+++ b/test/SourceKit/CodeComplete/complete_structure.swift
@@ -16,7 +16,7 @@ struct S1 {
   func method4(_: Int, _: Int) {}
   func method5(_: inout Int, b: inout Int) {}
   func method6(_ c: Int) throws {}
-  func method7(_ callback: () -> () throws) rethrows {}
+  func method7(_ callback: () throws -> ()) rethrows {}
   func method8<T, U>(_ d: (T, U) -> T, e: T -> U) {}
 
   let v1: Int = 1
@@ -41,8 +41,7 @@ func test1(_ x: S1) {
 // S1_DOT: {name:method5}({params:{t:&Int}, {n:b:}{t: &Int}})
 // FIXME: put throws in a range!
 // S1_DOT: {name:method6}({params:{l:c:}{t: Int}}){throws: throws}
-// FIXME: <rdar://problem/21010193> Fix throws => rethrows in call patterns
-// S1_DOT: {name:method7}({params:{l:callback:}{t: () -> ()}}){throws: throws}
+// S1_DOT: {name:method7}({params:{l:callback:}{t: () throws -> ()}}){throws: rethrows}
 // S1_DOT: {name:method8}({params:{l:d:}{t: (T, U) -> T}, {n:e:}{t: T -> U}})
 // S1_DOT: {name:v1}
 // S1_DOT: {name:v2}


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…ix completions.

Code completion had the ability to use declarations to provide better
code completion results for postfix completions, e.g., calls to
functions/methods, but it wasn't trying to get these declarations from
anywhere. Now, get these declarations from the solution to the
constraint system.

The impetus for this is to use default-argument information from the
declaration rather than the type, but plumbing this information
through also means that we get proper "rethrows" annotations, covered
by rdar://problem/21010193, and more specific completions in a
number of other places.

Fixes rdar://problem/21010193.
