### PR TITLE
FreeBSD target is called x86_64 (but machine identifies as amd64)

### DIFF
--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -175,7 +175,7 @@ class StdlibDeploymentTarget(object):
 
         elif system == 'FreeBSD':
             if machine == 'amd64':
-                return StdlibDeploymentTarget.FreeBSD.amd64
+                return StdlibDeploymentTarget.FreeBSD.x86_64
 
         elif system == 'CYGWIN_NT-10.0':
             if machine == 'x86_64':


### PR DESCRIPTION
#### What's in this pull request?

This, at least partially, unbreaks the build process on FreeBSD
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

I didn't file a bug for this, but right now you get the following error when trying to build on FreeBSD:

```
$ ./utils/build-script
Traceback (most recent call last):
  File "./utils/build-script", line 1866, in <module>
    sys.exit(main())
  File "./utils/build-script", line 1862, in main
    return main_normal()
  File "./utils/build-script", line 1077, in main_normal
     default=StdlibDeploymentTarget.host_target().name)
  File "/usr/home/user/development/swift/utils/swift_build_support/swift_build_support/targets.py", line 178, in host_target
    return StdlibDeploymentTarget.FreeBSD.amd64
AttributeError: 'Platform' object has no attribute 'amd64'
```

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
