### PR TITLE
[stdlib] Better diagnosis for unavailable APIs

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -2156,7 +2156,7 @@ extension ${Self} {
     Builtin.unreachable()
   }
 
-  @available(*, unavailable, renamed: "replaceSubrange")
+  @available(*, unavailable, renamed: "replaceSubrange(_:with:)")
   public mutating func replaceRange<C>(
     _ subRange: Range<Int>,
     with newElements: C

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1709,7 +1709,7 @@ extension Collection {
   @available(*, unavailable, renamed: "Iterator")
   public typealias Generator = Iterator
 
-  @available(*, unavailable, renamed: "makeIterator")
+  @available(*, unavailable, renamed: "makeIterator()")
   public func generate() -> Iterator {
     Builtin.unreachable()
   }

--- a/stdlib/public/core/CollectionAlgorithms.swift.gyb
+++ b/stdlib/public/core/CollectionAlgorithms.swift.gyb
@@ -656,7 +656,7 @@ extension MutableCollection
   Self : RandomAccessCollection,
   Self.Iterator.Element : Comparable {
 
-  @available(*, unavailable, renamed: "sort")
+  @available(*, unavailable, renamed: "sort()")
   public mutating func sortInPlace() {
     Builtin.unreachable()
   }

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -136,7 +136,7 @@ extension CollectionOfOne : CustomReflectable {
 public struct GeneratorOfOne<Element> {}
 
 extension IteratorOverOne {
-  @available(*, unavailable, renamed: "makeIterator")
+  @available(*, unavailable, renamed: "makeIterator()")
   public func generate() -> IteratorOverOne<Element> {
     Builtin.unreachable()
   }

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -155,7 +155,7 @@ public func == <Element>(
 public struct EmptyGenerator<Element> {}
 
 extension EmptyIterator {
-  @available(*, unavailable, renamed: "makeIterator")
+  @available(*, unavailable, renamed: "makeIterator()")
   public func generate() -> EmptyIterator<Element> {
     Builtin.unreachable()
   }

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -1010,7 +1010,7 @@ public struct ${Self}<Element>
 public struct AnyGenerator<Element> {}
 
 extension AnyIterator {
-  @available(*, unavailable, renamed: "makeIterator")
+  @available(*, unavailable, renamed: "makeIterator()")
   public func generate() -> AnyIterator<Element> {
     Builtin.unreachable()
   }
@@ -1020,7 +1020,7 @@ extension AnyIterator {
 extension Any${Kind} {
 
   @available(*, unavailable, message: "Please use underestimatedCount property instead.")
-  public var underestimateCount: Int {
+  public func underestimateCount() -> Int {
     Builtin.unreachable()
   }
 }
@@ -1030,7 +1030,7 @@ extension Any${Kind} {
 public typealias AnyCollectionType = AnyCollectionProtocol
 
 extension AnyCollectionProtocol {
-  @available(*, unavailable, renamed: "makeIterator")
+  @available(*, unavailable, renamed: "makeIterator()")
   public func generate() -> AnyIterator<Iterator.Element> {
     Builtin.unreachable()
   }

--- a/stdlib/public/core/Filter.swift.gyb
+++ b/stdlib/public/core/Filter.swift.gyb
@@ -350,7 +350,7 @@ extension LazyFilterSequence {
     Builtin.unreachable()
   }
 
-  @available(*, unavailable, renamed: "makeIterator")
+  @available(*, unavailable, renamed: "makeIterator()")
   public func generate() -> LazyFilterIterator<Base.Iterator> {
     Builtin.unreachable()
   }
@@ -365,7 +365,7 @@ extension LazyFilterCollection {
     Builtin.unreachable()
   }
 
-  @available(*, unavailable, renamed: "makeIterator")
+  @available(*, unavailable, renamed: "makeIterator()")
   public func generate() -> LazyFilterIterator<Base.Iterator> {
     Builtin.unreachable()
   }

--- a/stdlib/public/core/Flatten.swift.gyb
+++ b/stdlib/public/core/Flatten.swift.gyb
@@ -415,7 +415,7 @@ public struct FlattenGenerator<
 > {}
 
 extension FlattenSequence {
-  @available(*, unavailable, renamed: "makeIterator")
+  @available(*, unavailable, renamed: "makeIterator()")
   public func generate() -> FlattenIterator<Base.Iterator> {
     Builtin.unreachable()
   }

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -5206,7 +5206,7 @@ extension Set {
     Builtin.unreachable()
   }
 
-  @available(*, unavailable, renamed: "makeIterator")
+  @available(*, unavailable, renamed: "makeIterator()")
   public func generate() -> SetIterator<Element> {
     Builtin.unreachable()
   }
@@ -5233,7 +5233,7 @@ extension Dictionary {
     Builtin.unreachable()
   }
 
-  @available(*, unavailable, renamed: "makeIterator")
+  @available(*, unavailable, renamed: "makeIterator()")
   public func generate() -> DictionaryIterator<Key, Value> {
     Builtin.unreachable()
   }

--- a/stdlib/public/core/Join.swift
+++ b/stdlib/public/core/Join.swift
@@ -182,7 +182,7 @@ public struct JoinGenerator<Base : IteratorProtocol>
   where Base.Element : Sequence {}
 
 extension JoinedSequence {
-  @available(*, unavailable, renamed: "makeIterator")
+  @available(*, unavailable, renamed: "makeIterator()")
   public func generate() -> JoinedIterator<Base.Iterator> {
     Builtin.unreachable()
   }

--- a/stdlib/public/core/LazySequence.swift
+++ b/stdlib/public/core/LazySequence.swift
@@ -197,7 +197,7 @@ extension LazySequenceProtocol {
   }
 }
 
-@available(*, unavailable, renamed: "LazyCollectionProtocol")
+@available(*, unavailable, renamed: "LazySequenceProtocol")
 public typealias LazySequenceType = LazySequenceProtocol
 
 extension LazySequenceProtocol {

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -553,7 +553,7 @@ public typealias OutputStreamType = OutputStream
 
 extension Streamable {
   @available(*, unavailable, renamed: "write(to:)")
-  public func writeTo<Target : OutputStream>(target: inout Target) {
+  public func writeTo<Target : OutputStream>(_ target: inout Target) {
     Builtin.unreachable()
   }
 }

--- a/stdlib/public/core/Print.swift
+++ b/stdlib/public/core/Print.swift
@@ -168,9 +168,9 @@ public func print<T>(_: T, _: inout OutputStream) {}
 @available(*, unavailable, message: "Please use the 'to' label for the target stream: 'debugPrint((...), to: &...))'")
 public func debugPrint<T>(_: T, _: inout OutputStream) {}
 
-@available(*, unavailable, message: "Please use 'terminator: \"\"' instead of 'appendNewline: false' and use the 'toStream' label for the target stream: 'print((...), terminator: \"\", toStream: &...)'")
+@available(*, unavailable, message: "Please use 'terminator: \"\"' instead of 'appendNewline: false' and use the 'to' label for the target stream: 'print((...), terminator: \"\", to: &...)'")
 public func print<T>(_: T, _: inout OutputStream, appendNewline: Bool = true) {}
-@available(*, unavailable, message: "Please use 'terminator: \"\"' instead of 'appendNewline: false' and use the 'toStream' label for the target stream: 'debugPrint((...), terminator: \"\", toStream: &...)'")
+@available(*, unavailable, message: "Please use 'terminator: \"\"' instead of 'appendNewline: false' and use the 'to' label for the target stream: 'debugPrint((...), terminator: \"\", to: &...)'")
 public func debugPrint<T>(
   _: T, _: inout OutputStream, appendNewline: Bool = true
 ) {}

--- a/stdlib/public/core/RangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/RangeReplaceableCollection.swift.gyb
@@ -1151,7 +1151,7 @@ public func +<
 public typealias RangeReplaceableCollectionType = RangeReplaceableCollection
 
 extension RangeReplaceableCollection {
-  @available(*, unavailable, renamed: "replaceSubrange")
+  @available(*, unavailable, renamed: "replaceSubrange(_:with:)")
   public mutating func replaceRange<C>(
     _ subrange: Range<Index>,
     with newElements: C

--- a/stdlib/public/core/Repeat.swift
+++ b/stdlib/public/core/Repeat.swift
@@ -66,7 +66,7 @@ public func repeatElement<T>(_ element: T, count n: Int) -> Repeated<T> {
 public struct Repeat<Element> {}
 
 extension Repeated {
-  @available(*, unavailable, renamed: "repeatElement")
+  @available(*, unavailable, message: "Please use repeatElement(_:count:) function instead")
   public init(count: Int, repeatedValue: Element) {
     Builtin.unreachable()
   }

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -366,14 +366,14 @@ extension ReversedRandomAccessCollection {
 }
 
 extension BidirectionalCollection {
-  @available(*, unavailable, renamed: "reversed")
+  @available(*, unavailable, renamed: "reversed()")
   public func reverse() -> ReversedCollection<Self> {
     Builtin.unreachable()
   }
 }
 
 extension RandomAccessCollection {
-  @available(*, unavailable, renamed: "reversed")
+  @available(*, unavailable, renamed: "reversed()")
   public func reverse() -> ReversedRandomAccessCollection<Self> {
     Builtin.unreachable()
   }
@@ -385,7 +385,7 @@ extension LazyCollectionProtocol
   Elements : BidirectionalCollection
 {
 
-  @available(*, unavailable, renamed: "reversed")
+  @available(*, unavailable, renamed: "reversed()")
   public func reverse() -> LazyCollection<
     ReversedCollection<Elements>
   > {
@@ -398,7 +398,7 @@ extension LazyCollectionProtocol
   Self : RandomAccessCollection,
   Elements : RandomAccessCollection
 {
-  @available(*, unavailable, renamed: "reversed")
+  @available(*, unavailable, renamed: "reversed()")
   public func reverse() -> LazyCollection<
     ReversedRandomAccessCollection<Elements>
   > {

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -1223,17 +1223,17 @@ public typealias SequenceType = Sequence
 
 extension Sequence {
   @available(*, unavailable, renamed: "makeIterator()")
-  func generate() -> Iterator {
+  public func generate() -> Iterator {
     Builtin.unreachable()
   }
 
   @available(*, unavailable, message: "it became a property 'underestimatedCount'")
-  func underestimateCount() -> Int {
+  public func underestimateCount() -> Int {
     Builtin.unreachable()
   }
 
-  @available(*, unavailable, message: "call 'split(_:omittingEmptySubsequences:isSeparator:)' and invert the 'allowEmptySlices' argument")
-  func split(_ maxSplit: Int, allowEmptySlices: Bool,
+  @available(*, unavailable, message: "call 'split(maxSplits:omittingEmptySubsequences:isSeparator:)' and invert the 'allowEmptySlices' argument")
+  public func split(_ maxSplit: Int, allowEmptySlices: Bool,
     isSeparator: @noescape (Iterator.Element) throws -> Bool
   ) rethrows -> [SubSequence] {
     Builtin.unreachable()
@@ -1241,7 +1241,7 @@ extension Sequence {
 }
 
 extension Sequence where Iterator.Element : Equatable {
-  @available(*, unavailable, message: "call 'split(separator:omittingEmptySubsequences:isSeparator:)' and invert the 'allowEmptySlices' argument")
+  @available(*, unavailable, message: "call 'split(separator:maxSplits:omittingEmptySubsequences:)' and invert the 'allowEmptySlices' argument")
   public func split(
     _ separator: Iterator.Element,
     maxSplit: Int = Int.max,

--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -666,33 +666,33 @@ extension Sequence {
 }
 
 extension Sequence {
-  @available(*, unavailable, renamed: "enumerated")
+  @available(*, unavailable, renamed: "enumerated()")
   public func enumerate() -> EnumeratedSequence<Self> {
     Builtin.unreachable()
   }
 
-  @available(*, unavailable, renamed: "min")
+  @available(*, unavailable, renamed: "min(isOrderedBefore:)")
   public func minElement(
     _ isOrderedBefore: @noescape (Iterator.Element, Iterator.Element) throws -> Bool
   ) rethrows -> Iterator.Element? {
     Builtin.unreachable()
   }
 
-  @available(*, unavailable, renamed: "max")
+  @available(*, unavailable, renamed: "max(isOrderedBefore:)")
   public func maxElement(
     _ isOrderedBefore: @noescape (Iterator.Element, Iterator.Element) throws -> Bool
   ) rethrows -> Iterator.Element? {
     Builtin.unreachable()
   }
 
-  @available(*, unavailable, renamed: "reversed")
+  @available(*, unavailable, renamed: "reversed()")
   public func reverse() -> [Iterator.Element] {
     Builtin.unreachable()
   }
 
-  @available(*, unavailable, renamed: "starts")
+  @available(*, unavailable, renamed: "starts(with:isEquivalent:)")
   public func startsWith<PossiblePrefix>(
-    with possiblePrefix: PossiblePrefix,
+    _ possiblePrefix: PossiblePrefix,
     isEquivalent: @noescape (Iterator.Element, Iterator.Element) throws -> Bool
   ) rethrows-> Bool
     where
@@ -701,7 +701,7 @@ extension Sequence {
     Builtin.unreachable()
   }
 
-  @available(*, unavailable, renamed: "lexicographicallyPrecedes")
+  @available(*, unavailable, renamed: "lexicographicallyPrecedes(_:isOrderedBefore:)")
   public func lexicographicalCompare<
     OtherSequence
   >(
@@ -716,19 +716,19 @@ extension Sequence {
 }
 
 extension Sequence where Iterator.Element : Comparable {
-  @available(*, unavailable, renamed: "min")
+  @available(*, unavailable, renamed: "min()")
   public func minElement() -> Iterator.Element? {
     Builtin.unreachable()
   }
 
-  @available(*, unavailable, renamed: "max")
+  @available(*, unavailable, renamed: "max()")
   public func maxElement() -> Iterator.Element? {
     Builtin.unreachable()
   }
 
-  @available(*, unavailable, renamed: "starts")
+  @available(*, unavailable, renamed: "starts(with:)")
   public func startsWith<PossiblePrefix>(
-    with possiblePrefix: PossiblePrefix
+    _ possiblePrefix: PossiblePrefix
   ) -> Bool
     where
     PossiblePrefix : Sequence,

--- a/stdlib/public/core/SetAlgebra.swift
+++ b/stdlib/public/core/SetAlgebra.swift
@@ -549,27 +549,27 @@ extension SetAlgebra {
 public typealias SetAlgebraType = SetAlgebra
 
 extension SetAlgebra {
-  @available(*, unavailable, renamed: "intersection")
+  @available(*, unavailable, renamed: "intersection(_:)")
   public func intersect(_ other: Self) -> Self {
     Builtin.unreachable()
   }
 
-  @available(*, unavailable, renamed: "symmetricDifference")
+  @available(*, unavailable, renamed: "symmetricDifference(_:)")
   public func exclusiveOr(_ other: Self) -> Self {
     Builtin.unreachable()
   }
 
-  @available(*, unavailable, renamed: "formUnion")
+  @available(*, unavailable, renamed: "formUnion(_:)")
   public mutating func unionInPlace(_ other: Self) {
     Builtin.unreachable()
   }
 
-  @available(*, unavailable, renamed: "formIntersection")
+  @available(*, unavailable, renamed: "formIntersection(_:)")
   public mutating func intersectInPlace(_ other: Self) {
     Builtin.unreachable()
   }
 
-  @available(*, unavailable, renamed: "formSymmetricDifference")
+  @available(*, unavailable, renamed: "formSymmetricDifference(_:)")
   public mutating func exclusiveOrInPlace(_ other: Self) {
     Builtin.unreachable()
   }
@@ -589,7 +589,7 @@ extension SetAlgebra {
     Builtin.unreachable()
   }
 
-  @available(*, unavailable, renamed: "subtract")
+  @available(*, unavailable, renamed: "subtract(_:)")
   public mutating func subtractInPlace(_ other: Self) {
     Builtin.unreachable()
   }

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -976,7 +976,7 @@ extension String {
 }
 
 extension String {
-  @available(*, unavailable, renamed: "append")
+  @available(*, unavailable, renamed: "append(_:)")
   public mutating func appendContentsOf(_ other: String) {
     Builtin.unreachable()
   }

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -1186,7 +1186,7 @@ public typealias UnicodeCodecType = UnicodeCodec
 public func transcode<Input, InputEncoding, OutputEncoding>(
   _ inputEncoding: InputEncoding.Type, _ outputEncoding: OutputEncoding.Type,
   _ input: Input, _ output: (OutputEncoding.CodeUnit) -> Void,
-  stoppingOnError stopOnError: Bool
+  stopOnError: Bool
 ) -> Bool
   where
   Input : IteratorProtocol,

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -377,7 +377,7 @@ extension UnicodeScalar {
     Builtin.unreachable()
   }
 
-  @available(*, unavailable, renamed: "escaped")
+  @available(*, unavailable, renamed: "escaped(asASCII:)")
   public func escape(asASCII forceASCII: Bool) -> String {
     Builtin.unreachable()
   }

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -534,6 +534,7 @@ extension ${Self} {
     Builtin.unreachable()
   }
 
+% if mutable:
   @available(*, unavailable, message: "use the '${Self}(allocatingCapacity:)' initializer")
   public static func alloc(_ num: Int) -> ${Self} {
     Builtin.unreachable()
@@ -543,17 +544,21 @@ extension ${Self} {
   public func dealloc(_ num: Int) {
     Builtin.unreachable()
   }
+% end
 
   @available(*, unavailable, renamed: "pointee")
   public var memory: Pointee {
     get {
       Builtin.unreachable()
     }
+% if mutable:
     set {
       Builtin.unreachable()
     }
+% end
   }
 
+% if mutable:
   @available(*, unavailable, renamed: "initialize(with:)")
   public func initialize(_ newvalue: Pointee) {
     Builtin.unreachable()
@@ -568,6 +573,7 @@ extension ${Self} {
   public func destroy(_ count: Int) {
     Builtin.unreachable()
   }
+% end
 }
 
 extension Int {

--- a/test/1_stdlib/Renames.swift
+++ b/test/1_stdlib/Renames.swift
@@ -1,0 +1,513 @@
+// RUN: %target-parse-verify-swift
+
+
+func _Algorithm<I : IteratorProtocol, S : Sequence>(i: I, s: S) {
+  func fn1(_: EnumerateGenerator<I>) {} // expected-error {{'EnumerateGenerator' has been renamed to 'EnumeratedIterator'}} {{15-33=EnumeratedIterator}} {{none}}
+  func fn2(_: EnumerateSequence<S>) {} // expected-error {{'EnumerateSequence' has been renamed to 'EnumeratedSequence'}} {{15-32=EnumeratedSequence}} {{none}}
+  _ = EnumeratedIterator(i) // expected-error {{use the 'enumerated()' method on the sequence}} {{none}}
+  _ = EnumeratedSequence(s) // expected-error {{use the 'enumerated()' method on the sequence}} {{none}}
+}
+
+func _Arrays<T>(e: T) {
+  // _ = ContiguousArray(count: 1, repeatedValue: e) // xpected-error {{Please use init(repeating:count:) instead}} {{none}}
+  // _ = ArraySlice(count: 1, repeatedValue: e) // xpected-error {{Please use init(repeating:count:) instead}} {{none}}
+  // _ = Array(count: 1, repeatedValue: e) // xpected-error {{Please use init(repeating:count:) instead}} {{none}}
+  // The acutall error is: {{argument 'repeatedValue' must precede argument 'count'}}
+
+  var a = ContiguousArray<T>()
+  _ = a.removeAtIndex(0) // expected-error {{'removeAtIndex' has been renamed to 'remove(at:)'}} {{9-22=remove}} {{23-23=at: }} {{none}}
+  _ = a.replaceRange(0..<1, with: []) // expected-error {{'replaceRange(_:with:)' has been renamed to 'replaceSubrange(_:with:)'}} {{9-21=replaceSubrange}} {{none}}
+  _ = a.appendContentsOf([]) // expected-error {{'appendContentsOf' has been renamed to 'append(contentsOf:)'}} {{9-25=append}} {{26-26=contentsOf: }} {{none}}
+
+  var b = ArraySlice<T>()
+  _ = b.removeAtIndex(0) // expected-error {{'removeAtIndex' has been renamed to 'remove(at:)'}} {{9-22=remove}} {{23-23=at: }} {{none}}
+  _ = b.replaceRange(0..<1, with: []) // expected-error {{'replaceRange(_:with:)' has been renamed to 'replaceSubrange(_:with:)'}} {{9-21=replaceSubrange}} {{none}}
+  _ = b.appendContentsOf([]) // expected-error {{'appendContentsOf' has been renamed to 'append(contentsOf:)'}} {{9-25=append}} {{26-26=contentsOf: }} {{none}}
+
+  var c = Array<T>()
+  _ = c.removeAtIndex(0) // expected-error {{'removeAtIndex' has been renamed to 'remove(at:)'}} {{9-22=remove}} {{23-23=at: }} {{none}}
+  _ = c.replaceRange(0..<1, with: []) // expected-error {{'replaceRange(_:with:)' has been renamed to 'replaceSubrange(_:with:)'}} {{9-21=replaceSubrange}} {{none}}
+  _ = c.appendContentsOf([]) // expected-error {{'appendContentsOf' has been renamed to 'append(contentsOf:)'}} {{9-25=append}} {{26-26=contentsOf: }} {{none}}
+}
+
+func _Builtin(o: AnyObject, oo: AnyObject?) {
+  _ = unsafeAddressOf(o) // expected-error {{'unsafeAddressOf' has been renamed to 'unsafeAddress(of:)'}} {{7-22=unsafeAddress}} {{23-23=of: }} {{none}}
+  _ = unsafeUnwrap(oo) // expected-error {{Removed in Swift 3. Please use Optional.unsafelyUnwrapped instead.}} {{none}}
+}
+
+func _CString() {
+  _ = String.fromCString([]) // expected-error {{'fromCString' is unavailable: Please use String.init?(validatingUTF8:) instead. Note that it no longer accepts NULL as a valid input. Also consider using String(cString:), that will attempt to repair ill-formed code units.}} {{none}}
+  _ = String.fromCStringRepairingIllFormedUTF8([]) // expected-error {{'fromCStringRepairingIllFormedUTF8' is unavailable: Please use String.init(cString:) instead. Note that it no longer accepts NULL as a valid input. See also String.decodeCString if you need more control.}} {{none}}
+}
+
+func _CTypes<T>(x: Unmanaged<T>) {
+  func fn(_: COpaquePointer) {} // expected-error {{'COpaquePointer' has been renamed to 'OpaquePointer'}} {{14-28=OpaquePointer}} {{none}}
+  _ = OpaquePointer(bitPattern: x) // expected-error {{'init(bitPattern:)' is unavailable: use 'Unmanaged.toOpaque()' instead}} {{none}}
+}
+
+func _ClosedRange(x: ClosedRange<Int>) {
+  _ = x.startIndex // expected-error {{'startIndex' has been renamed to 'lowerBound'}} {{9-19=lowerBound}} {{none}}
+  _ = x.endIndex // expected-error {{'endIndex' has been renamed to 'upperBound'}} {{9-17=upperBound}} {{none}}
+}
+
+func _Collection() {
+  func fn(a: Bit) {} // expected-error {{'Bit' is unavailable: Bit enum has been removed. Please use Int instead.}} {{none}}
+  func fn<T>(b: IndexingGenerator<T>) {} // expected-error {{'IndexingGenerator' has been renamed to 'IndexingIterator'}} {{17-34=IndexingIterator}} {{none}}
+  func fn<T : CollectionType>(c: T) {} // expected-error {{'CollectionType' has been renamed to 'Collection'}} {{15-29=Collection}} {{none}}
+  func fn<T>(d: PermutationGenerator<T, T>) {} // expected-error {{'PermutationGenerator' is unavailable: PermutationGenerator has been removed in Swift 3}}
+}
+
+func _Collection<C : Collection>(c: C) {
+  func fn<T : Collection, U>(_: T, _: U) where T.Generator == U {} // expected-error {{'T' does not have a member type named 'Generator'; did you mean 'Iterator'?}} {{50-59=Iterator}} {{none}} 
+  _ = c.generate() // expected-error {{'generate()' has been renamed to 'makeIterator()'}} {{9-17=makeIterator}} {{none}}
+  _ = c.underestimateCount() // expected-error {{'underestimateCount()' is unavailable: Removed in Swift 3. Please use underestimatedCount property.}} {{none}}
+  _ = c.split(1) { _ in return true} // expected-error {{'split(_:allowEmptySlices:isSeparator:)' is unavailable: Please use split(maxSplits:omittingEmptySubsequences:isSeparator:) instead}} {{none}}
+}
+
+func _Collection<C : Collection, E>(c: C, e: E) where C.Iterator.Element: Equatable, C.Iterator.Element == E {
+  _ = c.split(e) // expected-error {{'split(_:maxSplit:allowEmptySlices:)' is unavailable: Please use split(separator:maxSplits:omittingEmptySubsequences:) instead}} {{none}}
+}
+
+func _CollectionAlgorithms<C : MutableCollection, I>(c: C, i: I) where C : RandomAccessCollection, C.Index == I {
+  var c = c
+  _ = c.partition(i..<i) { _, _ in true } // expected-error {{slice the collection using the range, and call partition(isOrderedBefore:)}} {{none}}
+  c.sortInPlace { _, _ in true } // expected-error {{'sortInPlace' has been renamed to 'sort(isOrderedBefore:)'}} {{5-16=sort}} {{none}}
+}
+
+func _CollectionAlgorithms<C : MutableCollection, I>(c: C, i: I) where C : RandomAccessCollection, C.Iterator.Element : Comparable, C.Index == I {
+  var c = c
+  _ = c.partition(i..<i) // expected-error {{slice the collection using the range, and call partition()}} {{none}}
+  c.sortInPlace() // expected-error {{'sortInPlace()' has been renamed to 'sort()'}} {{5-16=sort}} {{none}}
+}
+
+func _CollectionAlgorithms<C : Collection, E>(c: C, e: E) where C.Iterator.Element : Equatable, C.Iterator.Element == E {
+  _ = c.indexOf(e)  // expected-error {{'indexOf' has been renamed to 'index(of:)'}} {{9-16=index}} {{17-17=of: }} {{none}}
+}
+
+func _CollectionAlgorithms<C : Collection>(c: C) {
+  _ = c.indexOf { _ in true } // expected-error {{'indexOf' has been renamed to 'index(where:)'}} {{9-16=index}} {{none}}
+}
+
+func _CollectionOfOne<T>(i: IteratorOverOne<T>) {
+  func fn(_: GeneratorOfOne<T>) {} // expected-error {{'GeneratorOfOne' has been renamed to 'IteratorOverOne'}} {{14-28=IteratorOverOne}} {{none}}
+  _ = i.generate() // expected-error {{'generate()' has been renamed to 'makeIterator()'}} {{9-17=makeIterator}} {{none}}
+}
+
+func _CompilerProtocols() {
+  func fn(_: BooleanType) {} // expected-error {{'BooleanType' has been renamed to 'Boolean'}} {{14-25=Boolean}} {{none}}
+}
+
+func _EmptyCollection<T>(i: EmptyIterator<T>) {
+  func fn(_: EmptyGenerator<T>) {} // expected-error {{'EmptyGenerator' has been renamed to 'EmptyIterator'}} {{14-28=EmptyIterator}} {{none}}
+  _ = i.generate() // expected-error {{'generate()' has been renamed to 'makeIterator()'}} {{9-17=makeIterator}} {{none}}
+}
+
+func _ErrorType() {
+  func fn(_: ErrorType) {} // expected-error {{'ErrorType' has been renamed to 'ErrorProtocol'}} {{14-23=ErrorProtocol}}
+}
+
+func _ExistentialCollection<T>(i: AnyIterator<T>) {
+  func fn1<T>(_: AnyGenerator<T>) {} // expected-error {{'AnyGenerator' has been renamed to 'AnyIterator'}} {{18-30=AnyIterator}} {{none}}
+  func fn2<T : AnyCollectionType>(_: T) {} // expected-error {{'AnyCollectionType' has been renamed to 'AnyCollectionProtocol'}} {{16-33=AnyCollectionProtocol}} {{none}}
+  func fn3(_: AnyForwardIndex) {} // expected-error {{'AnyForwardIndex' has been renamed to 'AnyIndex'}} {{15-30=AnyIndex}} {{none}}
+  func fn4(_: AnyBidirectionalIndex) {} // expected-error {{'AnyBidirectionalIndex' has been renamed to 'AnyIndex'}} {{15-36=AnyIndex}} {{none}}
+  func fn5(_: AnyRandomAccessIndex) {} // expected-error {{'AnyRandomAccessIndex' has been renamed to 'AnyIndex'}} {{15-35=AnyIndex}} {{none}}
+}
+func _ExistentialCollection<T>(s: AnySequence<T>) {
+  _ = s.underestimateCount() // expected-error {{'underestimateCount()' is unavailable: Please use underestimatedCount property instead.}} {{none}}
+}
+func _ExistentialCollection<T>(c: AnyCollection<T>) {
+  _ = c.underestimateCount() // expected-error {{'underestimateCount()' is unavailable: Please use underestimatedCount property instead.}} {{none}}
+}
+func _ExistentialCollection<T>(c: AnyBidirectionalCollection<T>) {
+  _ = c.underestimateCount() // expected-error {{'underestimateCount()' is unavailable: Please use underestimatedCount property instead.}} {{none}}
+}
+func _ExistentialCollection<T>(c: AnyRandomAccessCollection<T>) {
+  _ = c.underestimateCount() // expected-error {{'underestimateCount()' is unavailable: Please use underestimatedCount property instead.}} {{none}}
+}
+func _ExistentialCollection<C : AnyCollectionProtocol>(c: C) {
+  _ = c.generate() // expected-error {{'generate()' has been renamed to 'makeIterator()'}} {{9-17=makeIterator}} {{none}}
+}
+
+func _Filter() {
+  func fn<T>(_: LazyFilterGenerator<T>) {} // expected-error {{'LazyFilterGenerator' has been renamed to 'LazyFilterIterator'}} {{17-36=LazyFilterIterator}} {{none}}
+}
+func _Filter<I : IteratorProtocol>(i: I) {
+  _ = LazyFilterIterator(i) { _ in true } // expected-error {{'init(_:whereElementsSatisfy:)' is unavailable: use '.lazy.filter' on the sequence}}
+}
+func _Filter<S : Sequence>(s: S) {
+  _ = LazyFilterSequence(s) { _ in true } // expected-error {{'init(_:whereElementsSatisfy:)' is unavailable: use '.lazy.filter' on the sequence}}
+}
+func _Filter<S>(s: LazyFilterSequence<S>) {
+  _ = s.generate() // expected-error {{'generate()' has been renamed to 'makeIterator()'}} {{9-17=makeIterator}} {{none}}
+}
+func _Filter<C : Collection>(c: C) {
+  _ = LazyFilterCollection(c) { _ in true} // expected-error {{'init(_:whereElementsSatisfy:)' is unavailable: use '.lazy.filter' on the collection}}
+}
+func _Filter<C>(c: LazyFilterCollection<C>) {
+  _ = c.generate() // expected-error {{'generate()' has been renamed to 'makeIterator()'}} {{9-17=makeIterator}} {{none}}
+}
+
+func _FixedPoint() {
+  var i: Int = 0
+  var u: UInt = 0
+  i++ // expected-error {{'++' is unavailable: it has been removed in Swift 3}} {{4-6= += 1}} {{none}}
+  ++i // expected-error {{'++' is unavailable: it has been removed in Swift 3}} {{3-5=}} {{6-6= += 1}} {{none}}
+  i-- // expected-error {{'--' is unavailable: it has been removed in Swift 3}} {{4-6= -= 1}} {{none}}
+  --i // expected-error {{'--' is unavailable: it has been removed in Swift 3}} {{3-5=}} {{6-6= -= 1}} {{none}}
+  u++ // expected-error {{'++' is unavailable: it has been removed in Swift 3}} {{4-6= += 1}} {{none}}
+  ++u // expected-error {{'++' is unavailable: it has been removed in Swift 3}} {{3-5=}} {{6-6= += 1}} {{none}}
+  u-- // expected-error {{'--' is unavailable: it has been removed in Swift 3}} {{4-6= -= 1}} {{none}}
+  --u // expected-error {{'--' is unavailable: it has been removed in Swift 3}} {{3-5=}} {{6-6= -= 1}} {{none}}
+
+  func fn1<T: IntegerType>(i: T) {} // expected-error {{'IntegerType' has been renamed to 'Integer'}} {{15-26=Integer}} {{none}}
+  func fn2<T: SignedIntegerType>(i: T) {} // expected-error {{'SignedIntegerType' has been renamed to 'SignedInteger'}} {{15-32=SignedInteger}} {{none}}
+  func fn3<T: UnsignedIntegerType>(i: T) {} // expected-error {{'UnsignedIntegerType' has been renamed to 'UnsignedInteger'}} {{15-34=UnsignedInteger}} {{none}}
+}
+
+func _Flatten() {
+  func fn<T>(i: FlattenGenerator<T>) {} // expected-error {{'FlattenGenerator' has been renamed to 'FlattenIterator'}} {{17-33=FlattenIterator}} {{none}}
+}
+func _Flatten<T>(s: FlattenSequence<T>) {
+  _ = s.generate() // expected-error {{'generate()' has been renamed to 'makeIterator()'}} {{9-17=makeIterator}} {{none}}
+}
+func _Flatten<T>(c: FlattenCollection<T>) {
+  _ = c.underestimateCount() // expected-error {{'underestimateCount()' is unavailable: Please use underestimatedCount property instead.}} {{none}}
+}
+func _Flatten<T>(c: FlattenBidirectionalCollection<T>) {
+  _ = c.underestimateCount() // expected-error {{'underestimateCount()' is unavailable: Please use underestimatedCount property instead.}} {{none}}
+}
+
+func _FloatingPoint() {
+  func fn<F : FloatingPointType>(f: F) {} // expected-error {{'FloatingPointType' has been renamed to 'FloatingPoint'}} {{15-32=FloatingPoint}} {{none}}
+}
+func _FloatingPoint<F : BinaryFloatingPoint>(f: F) {
+  _ = f.isSignaling // expected-error {{'isSignaling' has been renamed to 'isSignalingNaN'}} {{9-20=isSignalingNaN}} {{none}}
+}
+
+func _FloatingPointTypes() {
+  var x: Float = 1, y: Float = 1
+  // FIXME: isSignMinus -> sign is OK? different type.
+  _ = x.isSignMinus // expected-error {{'isSignMinus' has been renamed to 'sign'}} {{9-20=sign}} {{none}}
+  _ = x % y // expected-error {{'%' is unavailable: Use truncatingRemainder instead}} {{none}}
+  x %= y // expected-error {{'%=' is unavailable: Use formTruncatingRemainder instead}} {{none}}
+  ++x // expected-error {{'++' is unavailable: it has been removed in Swift 3}} {{3-5=}} {{6-6= += 1}} {{none}}
+  --x // expected-error {{'--' is unavailable: it has been removed in Swift 3}} {{3-5=}} {{6-6= -= 1}} {{none}}
+  x++ // expected-error {{'++' is unavailable: it has been removed in Swift 3}} {{4-6= += 1}} {{none}}
+  x-- // expected-error {{'--' is unavailable: it has been removed in Swift 3}} {{4-6= -= 1}} {{none}}
+}
+
+func _HashedCollection<T>(x: Set<T>, i: Set<T>.Index, e: T) {
+  var x = x
+  _ = x.removeAtIndex(i) // expected-error {{'removeAtIndex' has been renamed to 'remove(at:)'}} {{9-22=remove}} {{23-23=at: }} {{none}}
+  _ = x.generate() // expected-error {{'generate()' has been renamed to 'makeIterator()'}} {{9-17=makeIterator}} {{none}}
+  _ = x.indexOf(e) // expected-error {{'indexOf' has been renamed to 'index(of:)'}} {{9-16=index}} {{17-17=of: }} {{none}}
+}
+func _HashedCollection<K, V>(x: Dictionary<K, V>, i: Dictionary<K, V>.Index, k: K) {
+  var x = x
+  _ = x.removeAtIndex(i) // expected-error {{'removeAtIndex' has been renamed to 'remove(at:)'}} {{9-22=remove}} {{23-23=at: }} {{none}}
+  _ = x.indexForKey(k) // expected-error {{'indexForKey' has been renamed to 'index(forKey:)'}} {{9-20=index}} {{21-21=forKey: }} {{none}}
+  _ = x.removeValueForKey(k) // expected-error {{'removeValueForKey' has been renamed to 'removeValue(forKey:)'}} {{9-26=removeValue}} {{27-27=forKey: }} {{none}}
+  _ = x.generate() // expected-error {{'generate()' has been renamed to 'makeIterator()'}} {{9-17=makeIterator}} {{none}}
+}
+
+func _ImplicitlyUnwrappedOptional<T>(x: ImplicitlyUnwrappedOptional<T>) {
+  _ = ImplicitlyUnwrappedOptional<T>() // expected-error {{'init()' is unavailable: Please use nil literal instead.}} {{none}}
+  try! _ = ImplicitlyUnwrappedOptional<T>.map(x)() { _ in true } // expected-error {{'map' is unavailable: Has been removed in Swift 3.}}
+  try! _ = ImplicitlyUnwrappedOptional<T>.flatMap(x)() { _ in true } // expected-error {{'flatMap' is unavailable: Has been removed in Swift 3.}}
+  // FIXME: No way to call map and flatMap as method?
+  // _ = (x as ImplicitlyUnwrappedOptional).map { _ in true } // xpected-error {{}} {{none}}
+  // _ = (x as ImplicitlyUnwrappedOptional).flatMap { _ in true } // xpected-error {{}} {{none}}
+}
+
+func _Index<T : _Incrementable>(i: T) {
+  var i = i
+  --i // expected-error {{'--' is unavailable: it has been removed in Swift 3}} {{3-5=}} {{6-6= = i.predecessor()}} {{none}}
+  i-- // expected-error {{'--' is unavailable: it has been removed in Swift 3}} {{4-6= = i.predecessor()}} {{none}}
+  ++i // expected-error {{'++' is unavailable: it has been removed in Swift 3}} {{3-5=}} {{6-6= = i.successor()}} {{none}}
+  i++ // expected-error {{'++' is unavailable: it has been removed in Swift 3}} {{4-6= = i.successor()}} {{none}}
+}
+
+func _Index() {
+  func fn1<T : ForwardIndexType>(_: T) {} // expected-error {{'ForwardIndexType' has been renamed to 'Comparable'}} {{16-32=Comparable}} {{none}}
+  func fn2<T : BidirectionalIndexType>(_: T) {} // expected-error {{'BidirectionalIndexType' has been renamed to 'Comparable'}} {{16-38=Comparable}} {{none}}
+  func fn3<T : RandomAccessIndexType>(_: T) {} // expected-error {{'RandomAccessIndexType' has been renamed to 'Strideable'}} {{16-37=Strideable}} {{none}}
+}
+
+func _IntegerArithmetic() {
+  func fn1<T : IntegerArithmeticType>(_: T) {} // expected-error {{'IntegerArithmeticType' has been renamed to 'IntegerArithmetic'}} {{16-37=IntegerArithmetic}} {{none}}
+  func fn2<T : SignedNumberType>(_: T) {} // expected-error {{'SignedNumberType' has been renamed to 'SignedNumber'}} {{16-32=SignedNumber}} {{none}}
+}
+
+func _Join() {
+  func fn<T>(_: JoinGenerator<T>) {} // expected-error {{'JoinGenerator' has been renamed to 'JoinedIterator'}} {{17-30=JoinedIterator}} {{none}}
+}
+func _Join<T>(s: JoinedSequence<T>) {
+  _ = s.generate() // expected-error {{'generate()' has been renamed to 'makeIterator()'}} {{9-17=makeIterator}} {{none}}
+}
+func _Join<S : Sequence>(s: S) where S.Iterator.Element : Sequence {
+  _ = s.joinWithSeparator(s) // expected-error {{'joinWithSeparator' has been renamed to 'joined(separator:)'}} {{9-26=joined}} {{27-27=separator: }} {{none}}
+}
+
+func _LazyCollection() {
+  func fn<T : LazyCollectionType>(_: T) {} // expected-error {{'LazyCollectionType' has been renamed to 'LazyCollectionProtocol'}} {{15-33=LazyCollectionProtocol}} {{none}}
+}
+
+func _LazySequence() {
+  func fn<T : LazySequenceType>(_: T) {} // expected-error {{'LazySequenceType' has been renamed to 'LazySequenceProtocol'}} {{15-31=LazySequenceProtocol}} {{none}}
+}
+func _LazySequence<S : LazySequenceProtocol>(s: S) {
+  _ = s.array // expected-error {{'array' is unavailable: Please use Array initializer instead.}} {{none}}
+}
+
+func _ManagedBuffer<V, E>(x: ManagedBufferPointer<V, E>) {
+  _ = x.allocatedElementCount // expected-error {{'allocatedElementCount' has been renamed to 'capacity'}} {{9-30=capacity}} {{none}}
+}
+
+func _Map() {
+  func fn<B, E>(_: LazyMapGenerator<B, E>) {} // expected-error {{'LazyMapGenerator' has been renamed to 'LazyMapIterator'}} {{20-36=LazyMapIterator}} {{none}}
+}
+func _Map<S : Sequence>(s: S) {
+  _ = LazyMapSequence(s) { _ in true } // expected-error {{'init(_:transform:)' is unavailable: use '.lazy.map' on the sequence}} {{none}}
+}
+func _Map<C : Collection>(c: C) {
+  _ = LazyMapCollection(c) { _ in true } // expected-error {{'init(_:transform:)' is unavailable: use '.lazy.map' on the collection}} {{none}}
+}
+
+func _Mirror() {
+  func fn<M : MirrorPathType>(_: M) {} // expected-error {{'MirrorPathType' has been renamed to 'MirrorPath'}} {{15-29=MirrorPath}} {{none}}
+}
+
+func _MutableCollection() {
+  func fn1<C : MutableCollectionType>(_: C) {} // expected-error {{'MutableCollectionType' has been renamed to 'MutableCollection'}} {{16-37=MutableCollection}} {{none}}
+  func fn2<C : MutableSliceable>(_: C) {} // expected-error {{'MutableSliceable' is unavailable: Please use 'Collection where SubSequence : MutableCollection'}} {{none}}
+}
+
+func _OptionSet() {
+  func fn<O : OptionSetType>(_: O) {} // expected-error {{'OptionSetType' has been renamed to 'OptionSet'}} {{15-28=OptionSet}} {{none}}
+}
+
+func _Optional<T>(x: T) {
+  _ = Optional<T>.None // expected-error {{'None' has been renamed to 'none'}} {{19-23=none}} {{none}}
+  _ = Optional<T>.Some(x) // expected-error {{'Some' has been renamed to 'some'}} {{19-23=some}} {{none}}
+}
+
+func _OutputStream() {
+  func fn<S : OutputStreamType>(_: S) {} // expected-error {{'OutputStreamType' has been renamed to 'OutputStream'}} {{15-31=OutputStream}} {{none}}
+}
+func _OutputStream<S : Streamable, O : OutputStream>(s: S, o: O) {
+  var o = o
+  s.writeTo(&o) // expected-error {{'writeTo' has been renamed to 'write(to:)'}} {{5-12=write}} {{13-13=to: }} {{none}}
+}
+
+func _Policy() {
+  func fn<O : BitwiseOperationsType>(_: O) {} // expected-error {{'BitwiseOperationsType' has been renamed to 'BitwiseOperations'}} {{15-36=BitwiseOperations}} {{none}}
+}
+
+func _Print<T>(x: T) {
+  print(x, appendNewline: true) // expected-error {{'print(_:appendNewline:)' is unavailable: Please use 'terminator: ""' instead of 'appendNewline: false': 'print((...), terminator: "")'}} {{none}}
+  debugPrint(x, appendNewline: true) // expected-error {{'debugPrint(_:appendNewline:)' is unavailable: Please use 'terminator: ""' instead of 'appendNewline: false': 'debugPrint((...), terminator: "")'}} {{none}}
+}
+
+func _Print<T, O : OutputStream>(x: T, o: O) {
+  // FIXME: Not working due to <rdar://22101775>
+  //var o = o
+  //print(x, &o) // xpected-error {{}} {{none}}
+  //debugPrint(x, &o) // xpected-error {{}} {{none}}
+  //print(x, &o, appendNewline: true) // xpected-error {{}} {{none}}
+  //debugPrint(x, &o, appendNewline: true) // xpected-error {{}} {{none}}
+}
+
+func _Range() {
+  func fn1<B>(_: RangeGenerator<B>) {} // expected-error {{'RangeGenerator' has been renamed to 'IndexingIterator'}} {{18-32=IndexingIterator}} {{none}}
+  func fn2<I : IntervalType>(_: I) {} // expected-error {{'IntervalType' is unavailable: IntervalType has been removed in Swift 3. Use ranges instead.}} {{none}}
+  func fn3<B>(_: HalfOpenInterval<B>) {} // expected-error {{'HalfOpenInterval' has been renamed to 'Range'}} {{18-34=Range}} {{none}}
+  func fn4<B>(_: ClosedInterval<B>) {} // expected-error {{'ClosedInterval' has been renamed to 'ClosedRange'}} {{18-32=ClosedRange}} {{none}}
+}
+func _Range<T>(r: Range<T>) {
+  _ = r.startIndex // expected-error {{'startIndex' has been renamed to 'lowerBound'}} {{9-19=lowerBound}} {{none}}
+  _ = r.endIndex // expected-error {{'endIndex' has been renamed to 'upperBound'}} {{9-17=upperBound}} {{none}}
+}
+func _Range<T>(r: ClosedRange<T>) {
+  _ = r.clamp(r) // expected-error {{'clamp' is unavailable: Call clamped(to:) and swap the argument and the receiver.  For example, x.clamp(y) becomes y.clamped(to: x) in Swift 3.}} {{none}}
+}
+func _Range<T>(r: CountableClosedRange<T>) {
+  _ = r.clamp(r) // expected-error {{'clamp' is unavailable: Call clamped(to:) and swap the argument and the receiver.  For example, x.clamp(y) becomes y.clamped(to: x) in Swift 3.}} {{none}}
+}
+
+func _RangeReplaceableCollection() {
+  func fn<I : RangeReplaceableCollectionType>(_: I) {} // expected-error {{'RangeReplaceableCollectionType' has been renamed to 'RangeReplaceableCollection'}} {{15-45=RangeReplaceableCollection}} {{none}}
+}
+func _RangeReplaceableCollection<C : RangeReplaceableCollection>(c: C, i: C.Index) {
+  var c = c
+  c.replaceRange(i..<i, with: []) // expected-error {{'replaceRange(_:with:)' has been renamed to 'replaceSubrange(_:with:)'}} {{5-17=replaceSubrange}} {{none}}
+  _ = c.removeAtIndex(i) // expected-error {{'removeAtIndex' has been renamed to 'remove(at:)'}} {{9-22=remove}} {{23-23=at: }} {{none}}
+  c.removeRange(i..<i) // expected-error {{'removeRange' has been renamed to 'removeSubrange'}} {{5-16=removeSubrange}} {{none}}
+  c.appendContentsOf([]) // expected-error {{'appendContentsOf' has been renamed to 'append(contentsOf:)'}} {{5-21=append}} {{22-22=contentsOf: }} {{none}}
+  c.insertContentsOf(c, at: i) // expected-error {{'insertContentsOf(_:at:)' has been renamed to 'insert(contentsOf:at:)'}} {{5-21=insert}} {{22-22=contentsOf: }} {{none}}
+}
+
+func _Reflection(x: ObjectIdentifier) {
+  _ = x.uintValue // expected-error {{'uintValue' is unavailable: use the 'UInt(_:)' initializer}} {{none}}
+}
+
+func _Repeat() {
+  func fn<E>(_: Repeat<E>) {} // expected-error {{'Repeat' has been renamed to 'Repeated'}} {{17-23=Repeated}} {{none}}
+}
+func _Repeat<E>(e: E) {
+  _ = Repeated(count: 0, repeatedValue: e) // expected-error {{'init(count:repeatedValue:)' is unavailable: Please use repeatElement(_:count:) function instead}} {{none}}
+}
+
+func _Reverse<C : BidirectionalCollection>(c: C) {
+  _ = ReversedCollection(c) // expected-error {{'init' is unavailable: use the 'reversed()' method on the collection}} {{none}}
+  _ = c.reverse() // expected-error {{'reverse()' has been renamed to 'reversed()'}} {{9-16=reversed}} {{none}}
+}
+func _Reverse<C : RandomAccessCollection>(c: C) {
+  _ = ReversedRandomAccessCollection(c) // expected-error {{'init' is unavailable: use the 'reversed()' method on the collection}} {{none}}
+  _ = c.reverse() // expected-error {{'reverse()' has been renamed to 'reversed()'}} {{9-16=reversed}} {{none}}
+}
+func _Reverse<C : LazyCollectionProtocol>(c: C) where C : BidirectionalCollection, C.Elements : BidirectionalCollection {
+  _ = c.reverse() // expected-error {{'reverse()' has been renamed to 'reversed()'}} {{9-16=reversed}} {{none}}
+}
+func _Reverse<C : LazyCollectionProtocol>(c: C) where C : RandomAccessCollection, C.Elements : RandomAccessCollection {
+  _ = c.reverse() // expected-error {{'reverse()' has been renamed to 'reversed()'}} {{9-16=reversed}} {{none}}
+}
+
+func _Sequence() {
+  func fn1<G : GeneratorType>(_: G) {} // expected-error {{'GeneratorType' has been renamed to 'IteratorProtocol'}} {{16-29=IteratorProtocol}} {{none}}
+  func fn2<S : SequenceType>(_: S) {} // expected-error {{'SequenceType' has been renamed to 'Sequence'}} {{16-28=Sequence}} {{none}}
+  func fn3<I : IteratorProtocol>(_: GeneratorSequence<I>) {} // expected-error {{'GeneratorSequence' has been renamed to 'IteratorSequence'}} {{37-54=IteratorSequence}} {{none}}
+}
+func _Sequence<S : Sequence>(s: S) {
+  _ = s.generate() // expected-error {{'generate()' has been renamed to 'makeIterator()'}} {{9-17=makeIterator}} {{none}}
+  _ = s.underestimateCount() // expected-error {{'underestimateCount()' is unavailable: it became a property 'underestimatedCount'}} {{none}}
+  _ = s.split(1, allowEmptySlices: true) { _ in true } // expected-error {{'split(_:allowEmptySlices:isSeparator:)' is unavailable: call 'split(maxSplits:omittingEmptySubsequences:isSeparator:)' and invert the 'allowEmptySlices' argument}} {{none}}
+}
+func _Sequence<S : Sequence>(s: S, e: S.Iterator.Element) where S.Iterator.Element : Equatable {
+  _ = s.split(e, maxSplit: 1, allowEmptySlices: true) // expected-error {{'split(_:maxSplit:allowEmptySlices:)' is unavailable: call 'split(separator:maxSplits:omittingEmptySubsequences:)' and invert the 'allowEmptySlices' argument}} {{none}}
+}
+
+func _SequenceAlgorithms<S : Sequence>(x: S) {
+  _ = x.enumerate() // expected-error {{'enumerate()' has been renamed to 'enumerated()'}} {{9-18=enumerated}} {{none}}
+  _ = x.minElement { _, _ in true } // expected-error {{'minElement' has been renamed to 'min(isOrderedBefore:)'}} {{9-19=min}} {{none}}
+  _ = x.maxElement { _, _ in true } // expected-error {{'maxElement' has been renamed to 'max(isOrderedBefore:)'}} {{9-19=max}} {{none}}
+  _ = x.reverse() // expected-error {{'reverse()' has been renamed to 'reversed()'}} {{9-16=reversed}} {{none}}
+  _ = x.startsWith([]) { _ in true } // expected-error {{'startsWith(_:isEquivalent:)' has been renamed to 'starts(with:isEquivalent:)'}} {{9-19=starts}} {{20-20=with: }} {{none}}
+  _ = x.lexicographicalCompare([]) { _, _ in true } // expected-error {{'lexicographicalCompare(_:isOrderedBefore:)' has been renamed to 'lexicographicallyPrecedes(_:isOrderedBefore:)'}} {{9-31=lexicographicallyPrecedes}}{{none}}
+}
+func _SequenceAlgorithms<S : Sequence>(x: S) where S.Iterator.Element : Comparable {
+  _ = x.minElement() // expected-error {{'minElement()' has been renamed to 'min()'}} {{9-19=min}} {{none}}
+  _ = x.maxElement() // expected-error {{'maxElement()' has been renamed to 'max()'}} {{9-19=max}} {{none}}
+  _ = x.startsWith([]) // expected-error {{'startsWith' has been renamed to 'starts(with:)'}} {{9-19=starts}} {{20-20=with: }} {{none}}
+  _ = x.lexicographicalCompare([]) // expected-error {{'lexicographicalCompare' has been renamed to 'lexicographicallyPrecedes'}} {{9-31=lexicographicallyPrecedes}}{{none}}
+}
+
+func _SetAlgebra() {
+  func fn<S : SetAlgebraType>(_: S) {} // expected-error {{'SetAlgebraType' has been renamed to 'SetAlgebra'}} {{15-29=SetAlgebra}} {{none}}
+}
+func _SetAlgebra<S : SetAlgebra>(s: S) {
+  var s = s
+  _ = s.intersect(s) // expected-error {{'intersect' has been renamed to 'intersection(_:)'}} {{9-18=intersection}} {{none}}
+  _ = s.exclusiveOr(s) // expected-error {{'exclusiveOr' has been renamed to 'symmetricDifference(_:)'}} {{9-20=symmetricDifference}} {{none}}
+  s.unionInPlace(s) // expected-error {{'unionInPlace' has been renamed to 'formUnion(_:)'}} {{5-17=formUnion}} {{none}}
+  s.intersectInPlace(s) // expected-error {{'intersectInPlace' has been renamed to 'formIntersection(_:)'}} {{5-21=formIntersection}} {{none}}
+  s.exclusiveOrInPlace(s) // expected-error {{'exclusiveOrInPlace' has been renamed to 'formSymmetricDifference(_:)'}} {{5-23=formSymmetricDifference}} {{none}}
+  _ = s.isSubsetOf(s) // expected-error {{'isSubsetOf' has been renamed to 'isSubset(of:)'}} {{9-19=isSubset}} {{20-20=of: }} {{none}}
+  _ = s.isDisjointWith(s) // expected-error {{'isDisjointWith' has been renamed to 'isDisjoint(with:)'}} {{9-23=isDisjoint}} {{24-24=with: }} {{none}}
+  s.subtractInPlace(s) // expected-error {{'subtractInPlace' has been renamed to 'subtract(_:)'}} {{5-20=subtract}} {{none}}
+  _ = s.isStrictSupersetOf(s) // expected-error {{'isStrictSupersetOf' has been renamed to 'isStrictSuperset(of:)'}} {{9-27=isStrictSuperset}} {{28-28=of: }} {{none}}
+  _ = s.isStrictSubsetOf(s) // expected-error {{'isStrictSubsetOf' has been renamed to 'isStrictSubset(of:)'}} {{9-25=isStrictSubset}} {{26-26=of: }} {{none}}
+}
+
+func _StaticString(x: StaticString) {
+  _ = x.byteSize // expected-error {{'byteSize' has been renamed to 'utf8CodeUnitCount'}} {{9-17=utf8CodeUnitCount}} {{none}}
+  _ = x.stringValue // expected-error {{'stringValue' is unavailable: use the 'String(_:)' initializer}} {{none}}
+}
+
+func _Stride<T : Strideable>(x: T, d: T.Stride) {
+  func fn1<T>(_: StrideToGenerator<T>) {} // expected-error {{'StrideToGenerator' has been renamed to 'StrideToIterator'}} {{18-35=StrideToIterator}} {{none}}
+  func fn2<T>(_: StrideThroughGenerator<T>) {} // expected-error {{'StrideThroughGenerator' has been renamed to 'StrideThroughIterator'}} {{18-40=StrideThroughIterator}} {{none}}
+
+  _ = x.stride(to: x, by: d) // expected-error {{'stride(to:by:)' is unavailable: Use stride(from:to:by:) free function instead}} {{none}}
+  _ = x.stride(through: x, by: d) // expected-error {{'stride(through:by:)' is unavailable: Use stride(from:through:by:) free function instead}}
+}
+
+func _String<S, C>(x: String, s: S, c: C, i: String.Index)
+  where S : Sequence, S.Iterator.Element == Character, C : Collection, C.Iterator.Element == Character {
+  var x = x
+  x.appendContentsOf(x) // expected-error {{'appendContentsOf' has been renamed to 'append(_:)'}} {{5-21=append}} {{none}}
+  x.appendContentsOf(s) // expected-error {{'appendContentsOf' has been renamed to 'append(contentsOf:)'}} {{5-21=append}} {{22-22=contentsOf: }} {{none}}
+  x.insertContentsOf(c, at: i) // expected-error {{'insertContentsOf(_:at:)' has been renamed to 'insert(contentsOf:at:)'}} {{5-21=insert}} {{22-22=contentsOf: }} {{none}}
+  x.replaceRange(i..<i, with: c) // expected-error {{'replaceRange(_:with:)' has been renamed to 'replaceSubrange'}} {{5-17=replaceSubrange}} {{none}}
+  x.replaceRange(i..<i, with: x) // expected-error {{'replaceRange(_:with:)' has been renamed to 'replaceSubrange'}} {{5-17=replaceSubrange}} {{none}}
+  _ = x.removeAtIndex(i) // expected-error {{'removeAtIndex' has been renamed to 'remove(at:)'}} {{9-22=remove}} {{23-23=at: }} {{none}}
+  x.removeRange(i..<i) // expected-error {{'removeRange' has been renamed to 'removeSubrange'}} {{5-16=removeSubrange}} {{none}}
+  _ = x.lowercaseString // expected-error {{'lowercaseString' has been renamed to 'lowercased()'}} {{9-24=lowercased}} {{none}}
+  _ = x.uppercaseString // expected-error {{'uppercaseString' has been renamed to 'uppercased()'}} {{9-24=uppercased}} {{none}}
+  // FIXME: SR-1649 <rdar://problem/26563343>; We should suggest to add '()'
+}
+func _String<S : Sequence>(s: S, sep: String) where S.Iterator.Element == String {
+  _ = s.joinWithSeparator(sep) // expected-error {{'joinWithSeparator' has been renamed to 'joined(separator:)'}} {{9-26=joined}} {{27-27=separator: }} {{none}}
+}
+
+func _StringCharacterView<S, C>(x: String.CharacterView, s: S, c: C, i: String.CharacterView.Index)
+  where S : Sequence, S.Iterator.Element == Character, C : Collection, C.Iterator.Element == Character {
+  var x = x
+  x.replaceRange(i..<i, with: c) // expected-error {{'replaceRange(_:with:)' has been renamed to 'replaceSubrange'}} {{5-17=replaceSubrange}} {{none}}
+  x.appendContentsOf(s) // expected-error {{'appendContentsOf' has been renamed to 'append(contentsOf:)'}} {{5-21=append}} {{22-22=contentsOf: }} {{none}}
+}
+
+func _StringLegacy(c: Character, u: UnicodeScalar) {
+  _ = String(count: 1, repeatedValue: c) // expected-error {{'init(count:repeatedValue:)' is unavailable: Renamed to init(repeating:count:) and reordered parameters}} {{none}}
+  _ = String(count: 1, repeatedValue: u) // expected-error {{'init(count:repeatedValue:)' is unavailable: Renamed to init(repeating:count:) and reordered parameters}} {{none}}
+}
+
+func _Unicode() {
+  func fn<T : UnicodeCodecType>(_: T) {} // expected-error {{'UnicodeCodecType' has been renamed to 'UnicodeCodec'}} {{15-31=UnicodeCodec}} {{none}}
+}
+func _Unicode<I : IteratorProtocol, E : UnicodeCodec>(i: I, e: E.Type) where I.Element == E.CodeUnit {
+  _ = transcode(e, e, i, { _ in }, stopOnError: true) // expected-error {{'transcode(_:_:_:_:stopOnError:)' is unavailable: use 'transcode(_:from:to:stoppingOnError:sendingOutputTo:)'}} {{none}}
+  _ = UTF16.measure(e, input: i, repairIllFormedSequences: true) // expected-error {{'measure(_:input:repairIllFormedSequences:)' is unavailable: use 'transcodedLength(of:decodedAs:repairingIllFormedSequences:)'}} {{none}}
+}
+
+func _UnicodeScalar(s: UnicodeScalar) {
+  _ = UnicodeScalar() // expected-error {{'init()' is unavailable: use 'UnicodeScalar(0)'}} {{none}}
+  _ = s.escape(asASCII: true) // expected-error {{'escape(asASCII:)' has been renamed to 'escaped(asASCII:)'}} {{9-15=escaped}} {{none}}
+}
+
+func _Unmanaged<T>(x: Unmanaged<T>, p: OpaquePointer) {
+  _ = Unmanaged<T>.fromOpaque(p) // expected-error {{'fromOpaque' is unavailable: use 'fromOpaque(_: UnsafePointer<Void>)' instead}} {{none}}
+  let _: OpaquePointer = x.toOpaque() // expected-error {{'toOpaque()' is unavailable: use 'toOpaque() -> UnsafePointer<Void>' instead}} {{none}}
+}
+
+func _UnsafeBufferPointer() {
+  func fn<T>(x: UnsafeBufferPointerGenerator<T>) {} // expected-error {{'UnsafeBufferPointerGenerator' has been renamed to 'UnsafeBufferPointerIterator'}} {{17-45=UnsafeBufferPointerIterator}} {{none}}
+}
+
+func _UnsafePointer<T>(x: UnsafePointer<T>) {
+  _ = UnsafePointer<T>.Memory.self // expected-error {{'Memory' has been renamed to 'Pointee'}} {{24-30=Pointee}} {{none}}
+  _ = UnsafePointer<T>() // expected-error {{'init()' is unavailable: use 'nil' literal}} {{none}}
+  _ = x.memory // expected-error {{'memory' has been renamed to 'pointee'}} {{9-15=pointee}} {{none}}
+}
+
+func _UnsafePointer<T>(x: UnsafeMutablePointer<T>, e: T) {
+  var x = x
+  _ = UnsafeMutablePointer<T>.Memory.self // expected-error {{'Memory' has been renamed to 'Pointee'}} {{31-37=Pointee}} {{none}}
+  _ = UnsafeMutablePointer<T>() // expected-error {{'init()' is unavailable: use 'nil' literal}} {{none}}
+  _ = x.memory // expected-error {{'memory' has been renamed to 'pointee'}} {{9-15=pointee}} {{none}}
+  _ = UnsafeMutablePointer<T>.alloc(1) // expected-error {{'alloc' is unavailable: use the 'UnsafeMutablePointer(allocatingCapacity:)' initializer}} {{none}}
+  x.dealloc(1) // expected-error {{'dealloc' has been renamed to 'deallocateCapacity'}} {{5-12=deallocateCapacity}} {{none}}
+  x.memory = e // expected-error {{'memory' has been renamed to 'pointee'}} {{5-11=pointee}} {{none}}
+  x.initialize(e) // expected-error {{'initialize' has been renamed to 'initialize(with:)'}} {{5-15=initialize}} {{16-16=with: }} {{none}}
+  x.destroy() // expected-error {{'destroy()' has been renamed to 'deinitialize(count:)'}} {{5-12=deinitialize}} {{none}}
+  x.destroy(1) // expected-error {{'destroy' has been renamed to 'deinitialize(count:)'}} {{5-12=deinitialize}} {{13-13=count: }} {{none}}
+}
+
+func _VarArgs() {
+  func fn1(_: CVarArgType) {} // expected-error {{'CVarArgType' has been renamed to 'CVarArg'}} {{15-26=CVarArg}}{{none}}
+  func fn2(_: VaListBuilder) {} // expected-error {{'VaListBuilder' is unavailable}} {{none}}
+}
+
+func _Zip<S1 : Sequence, S2: Sequence>(_: S1, _: S2) {
+  _ = Zip2Sequence<S1, S2>.Generator.self // expected-error {{'Generator' has been renamed to 'Iterator'}} {{28-37=Iterator}} {{none}}
+}

--- a/test/1_stdlib/RenamesObjC.swift
+++ b/test/1_stdlib/RenamesObjC.swift
@@ -1,0 +1,8 @@
+// RUN: %target-parse-verify-swift
+// REQUIRES: objc_interop
+
+func _BridgeObjectiveC<T>(x: AutoreleasingUnsafeMutablePointer<T>) {
+  _ = AutoreleasingUnsafeMutablePointer<T>.Memory.self // expected-error {{'Memory' has been renamed to 'Pointee'}} {{44-50=Pointee}} {{none}}
+  _ = AutoreleasingUnsafeMutablePointer<T>() // expected-error {{'init()' is unavailable: Removed in Swift 3. Please use nil literal instead.}} {{none}}
+  _ = x.memory // expected-error {{'memory' has been renamed to 'pointee'}} {{9-15=pointee}} {{none}}
+}


### PR DESCRIPTION
**WARNING: DO NOT MERGE THIS before #3040**
#### What's in this pull request?

Added test cases for expected-error and fix-its.

Changes to stdlib code:
- Add arguments signature regardless that is the same as before.
  Because the error message looks more natural.
  e.g. `"makeIterator"` => `"makeIterator()"`,
  `"replaceSubrange"` => `"replaceSubrange(_:with:)"`
  compare:
  
  ```
  'generate()' has been renamed to 'makeIterator'
  'generate()' has been renamed to 'makeIterator()'
  ```
- `Any${ExistentialCollection}.underestimateCount` was a method, not computed property.
- `LazySequenceType` has been renamed to `LazySequenceProtocol`, but not
  `LazyCollectionProtocol`
- `Streamable.writeTo(_:)` had no argument label. (not `writeTo(target:)`)
- Fixed typo in `print()` and `debugPrint()` error message (not working for now)
- `Repeated.init()`: `renamed: "..."` to `message: "..."` because the argument
  order has changed.
- Marked `public` for some unavailable method on `Sequence`
- `Sequence.split(_:maxSplit:allowEmptySlices)` has been replaced with
  `split(separator:maxSplits:omittingEmptySubsequences:)`,
  not `split(separator:omittingEmptySubsequences:isSeparator:)`
- `Sequence.startsWith(_:isEquivalent:)` or `startsWith(_:)` had no label on
  the first argument.
- `transcode(_:_:_:_:stopOnError:)`, not `transcode(_:_:_:_:stoppingOnError:)`
- Remove mutating methods from UnsafePointer.
  `alloc(_:)`, `dealloc(_:)`, `setter:memory`, `initialize(_:)`, `destroy()`,
  and `destroy(_:)`

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
