### PR TITLE
[swiftc] Add 💥 case (😢 → 88, 😀 → 5073) triggered in swift::TypeChecker::checkGenericParamList(…)

### DIFF
--- a/validation-test/compiler_crashers/28317-swift-typechecker-checkgenericparamlist.swift
+++ b/validation-test/compiler_crashers/28317-swift-typechecker-checkgenericparamlist.swift
@@ -1,0 +1,203 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+protocol a {
+class B
+class d
+protocol A {
+}
+}
+class B
+class A {}
+protocol A : A : e
+struct B T where h:A : a
+{
+T. : a {
+func a{fu
+protocol a :
+class a {
+}
+}
+extension NSFileManager {
+map )
+map )->: A
+{func b()
+{
+class A
+return E.c
+}
+}
+let f=a: a
+import Foundation
+class S<h : c
+static var e : A
+}
+extension NSFileManager {func b: a: a : A {
+class var "
+}
+protocol a {
+class d
+}
+class A {
+( "
+protocol A : A.c
+class c
+}
+}
+}
+import Foundation
+protocol b(n: a: A : A<b<T where h : A.e
+in
+let end = compose(n: a {
+}
+struct A.c
+}
+class A {
+func a
+var d {
+( "
+}
+func f= B<T where h.c
+Void{
+let f=d
+class a {class A {
+import Founda{
+protocol a {
+func a {
+struct b: A
+class A
+func b()
+}
+protocol A : A : A
+let c : a
+class a
+class A : Int> : d
+in
+{
+func b{
+}
+func b: e
+class A? {
+class A
+}
+let c : a {var e = Dictionary<D> : Dictionary<T where g=d
+}
+import Foundation
+func a {
+{
+import Foundation
+protocol a {
+Void{case c
+typealias e : A? {
+protocol a {
+class a h:CollectionType where k : A.startIndex
+return E.c{
+struct c : A : A {
+}
+protocol A
+}
+func b: A? {
+protocol P {
+protocol c B
+}
+Void{
+protocol A : a {
+func b: A {
+typealias e : A
+class var "
+}
+protocol a {var "
+import Foundation
+class A {
+struct B< where k : A
+{
+}
+}
+enum C {
+}
+var d {
+protocol P {{
+func a: A
+protocol Anager {
+extension NSFileManager {
+var d {
+class A : a {
+struct A
+}
+class a{
+func b<T where h = object {
+init(
+let h : e = B<a {
+}
+protocol c : a
+import Foundation
+protocol a enum C {
+{
+{
+}
+protocol A : A : c
+}
+func b{
+struct c : A
+static let f = { }
+{
+let f=d
+protocol A {
+Void{
+Void{
+let h = [ [ [ [
+Void{
+func a {
+protocol A : A {
+return E.e
+}
+}
+}
+class A : d.startIndex
+static var "
+protocol a {
+}
+class c
+b: A {
+Void{
+if
+import Foundation
+enum S<d {
+class c
+}
+func b
+class b
+class d{
+var a
+class A {
+class A : a{
+class A : A : c
+func b: a: A : a<T where k : a: d
+typealias e = Dictionary<String, C>Any
+}
+{
+var d {
+typealias e : Dictionary<b<U:CollectionType where : A
+protocol a {
+{
+class B
+}
+protocol A {
+}
+let end = compose(n: c<Int> : e
+{
+static var a
+}
+class A : A? {
+typealias e : a :B : a : A
+protocol A : A
+class A {
+class d
+class var "
+typealias e = Dictionary<String, C> : A
+func < where h = B


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Add crash case with stack trace:

```
4  swift           0x0000000000ed9e8d swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::GenericSignature*, bool, swift::GenericTypeResolver*) + 93
6  swift           0x0000000000eda5ae swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 94
13 swift           0x0000000000ea2156 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
16 swift           0x0000000000f088f4 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
17 swift           0x0000000000f33ecc swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
18 swift           0x0000000000e8fc21 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 769
20 swift           0x0000000000f08a36 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
21 swift           0x0000000000ec4b7d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
22 swift           0x0000000000c594c9 swift::CompilerInstance::performSema() + 3289
24 swift           0x00000000007d7739 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
25 swift           0x00000000007a3748 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28317-swift-typechecker-checkgenericparamlist.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28317-swift-typechecker-checkgenericparamlist-cbc5e2.o
1.  While type-checking expression at [validation-test/compiler_crashers/28317-swift-typechecker-checkgenericparamlist.swift:66:5 - line:203:18] RangeText="{
2.  While type-checking 'a' at validation-test/compiler_crashers/28317-swift-typechecker-checkgenericparamlist.swift:68:1
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
