### PR TITLE
Basic: support `_aligned_malloc` on Windows

### DIFF
--- a/include/swift/Basic/Malloc.h
+++ b/include/swift/Basic/Malloc.h
@@ -23,7 +23,7 @@
 
 namespace swift {
 
-// FIXME: Use C11 aligned_alloc or Windows _aligned_malloc if available.
+// FIXME: Use C11 aligned_alloc if available.
 inline void *AlignedAlloc(size_t size, size_t align) {
   // posix_memalign only accepts alignments greater than sizeof(void*).
   // 
@@ -31,17 +31,25 @@ inline void *AlignedAlloc(size_t size, size_t align) {
     align = sizeof(void*);
   
   void *r;
+#if defined(_WIN32)
+  r = _aligned_malloc(size, align);
+  assert(r && "_aligned_malloc failed");
+#else
   int res = posix_memalign(&r, align, size);
   assert(res == 0 && "posix_memalign failed");
   (void)res; // Silence the unused variable warning.
+#endif
   return r;
 }
-  
-// FIXME: Use Windows _aligned_free if available.
+
 inline void AlignedFree(void *p) {
+#if defined(_WIN32)
+  _aligned_free(p);
+#else
   free(p);
+#endif
 }
-  
+
 } // end namespace swift
 
 #endif // SWIFT_BASIC_MALLOC_H


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Use `_aligned_malloc` and `_aligned_free` on Windows as it does not have the
POSIX interfaces `posix_memalign`.  `_aligned_malloc` has an associated
`_aligned_free` instead of the normal `free` call.
