### PR TITLE
[stdlib] Fixing several collection-related tests

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
@@ -349,10 +349,13 @@ public struct IndexOffsetByTest {
 }
 
 public let distanceFromToTests = [
+  // 0 - 1: no distance.
   DistanceFromToTest(start: 0, end: 0),
   DistanceFromToTest(start: 10, end: 10),
+  // 2 - 3: forward distance.
   DistanceFromToTest(start: 10, end: 13),
   DistanceFromToTest(start: 7, end: 10),
+  // 4 - 6: backward distance.
   DistanceFromToTest(start: 12, end: 4),
   DistanceFromToTest(start: 8, end: 2),
   DistanceFromToTest(start: 19, end: 0)
@@ -1594,26 +1597,25 @@ extension TestSuite {
     }
 %   end
     
-    self.test("\(testNamePrefix)/distance(from:to:)/semantics") {
-      let c = toCollection(0..<20)
-      for test in distanceFromToTests {
-        let d = c.distance(
-          from: c.nthIndex(test.startOffset), to: c.nthIndex(test.endOffset))
-
-        let backwards = (test.startOffset < test.endOffset)
+    self.test("\(testNamePrefix)/distance(from:to:)/semantics")
+      .forEach(in: distanceFromToTests) { (test) in
+        let c = toCollection(0..<20)
+        let backwards = (test.startOffset > test.endOffset)
         if backwards && !collectionIsBidirectional {
           expectCrashLater()
         }
+
+        let d = c.distance(
+          from: c.nthIndex(test.startOffset), to: c.nthIndex(test.endOffset))
         expectEqual(
           numericCast(test.expectedDistance),
           d, stackTrace: SourceLocStack().with(test.loc))
-      }
     }
 
-    self.test("\(testNamePrefix)/index(_:offsetBy: n)/semantics") {
-      for test in indexOffsetByTests.filter(
+    self.test("\(testNamePrefix)/index(_:offsetBy: n)/semantics")
+      .forEach(in: indexOffsetByTests.filter(
         {$0.limit == nil && $0.distance >= 0}
-      ) {
+      )) { (test) in
         let max = 10
         let c = toCollection(0..<max)
 
@@ -1630,13 +1632,12 @@ extension TestSuite {
         // contains exactly index offsets.
         expectEqual(test.expectedOffset!, extractValue(c[new]).value,
           stackTrace: SourceLocStack().with(test.loc))
-      }
     }
 
-    self.test("\(testNamePrefix)/formIndex(_:offsetBy: n)/semantics") {
-      for test in indexOffsetByTests.filter(
+    self.test("\(testNamePrefix)/formIndex(_:offsetBy: n)/semantics")
+      .forEach(in: indexOffsetByTests.filter(
         {$0.limit == nil && $0.distance >= 0}
-      ) {
+      )) { (test) in
         let max = 10
         let c = toCollection(0..<max)
 
@@ -1648,14 +1649,13 @@ extension TestSuite {
         c.formIndex(&new, offsetBy: numericCast(test.distance))
         expectEqual(test.expectedOffset!, extractValue(c[new]).value,
           stackTrace: SourceLocStack().with(test.loc))
-      }
     }
 
 %   for function_name in ['index', 'formIndex']:
-    self.test("\(testNamePrefix)/${function_name}(_:offsetBy: -n)/semantics") {
-      for test in indexOffsetByTests.filter(
+    self.test("\(testNamePrefix)/${function_name}(_:offsetBy: -n)/semantics")
+      .forEach(in: indexOffsetByTests.filter(
         {$0.limit == nil && $0.distance < 0}
-      ) {
+      )) { (test) in
         let c = toCollection(0..<20)
 %     if function_name is 'index':
         let start = c.nthIndex(test.startOffset)
@@ -1673,7 +1673,6 @@ extension TestSuite {
 %     end
         expectEqual(test.expectedOffset!, extractValue(c[new]).value,
           stackTrace: SourceLocStack().with(test.loc))
-      }
     }
 %   end
 
@@ -1716,10 +1715,10 @@ extension TestSuite {
       }
     }
 
-    self.test("\(testNamePrefix)/index(_:offsetBy: -n, limitedBy:)/semantics") {
-      for test in indexOffsetByTests.filter(
+    self.test("\(testNamePrefix)/index(_:offsetBy: -n, limitedBy:)/semantics")
+      .forEach(in: indexOffsetByTests.filter(
         {$0.limit != nil && $0.distance < 0}
-      ) {
+      )) { (test) in
         let c = toCollection(0..<20)
         let limit = c.nthIndex(test.limit.unsafelyUnwrapped)
         if collectionIsBidirectional {
@@ -1740,13 +1739,12 @@ extension TestSuite {
             offsetBy: numericCast(test.distance),
             limitedBy: limit)
         }
-      }
     }
 
-    self.test("\(testNamePrefix)/formIndex(_:offsetBy: -n, limitedBy:)/semantics") {
-      for test in indexOffsetByTests.filter(
-        {$0.limit != nil && $0.distance < 0}
-      ) {
+    self.test("\(testNamePrefix)/formIndex(_:offsetBy: -n, limitedBy:)/semantics")
+      .forEach(in: indexOffsetByTests.filter( 
+        {$0.limit != nil && $0.distance < 0} 
+      )) { (test) in
         let c = toCollection(0..<20)
         let limit = c.nthIndex(test.limit.unsafelyUnwrapped)
         var new = c.nthIndex(test.startOffset)
@@ -1767,7 +1765,6 @@ extension TestSuite {
           expectCrashLater()
           _ = c.formIndex(&new, offsetBy: numericCast(test.distance), limitedBy: limit)
         }
-      }
     }
 
   }


### PR DESCRIPTION
#### What's in this pull request?

Several recently written tests could be run with test data expecting a crash. This change parameterizes these tests to ensure that the first crash does not terminate the entire test sequence. (It also fixes a test bug that was masked by the incorrect, prior behavior.)

_Testing_: all tests pass on OS X. Merge when ready.

@gribozavr @moiseev 

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Changes:
- Parameterized a number of tests in CheckCollectionType.swift.gyb expected to crash during one or more runthroughs
