### PR TITLE
[SR-1752] Fix warning about unused result if return type is Void?

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1041,9 +1041,9 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
     return;
   }
 
-  // If the result of this expression is of type "()", then it is safe to
-  // ignore.
-  if (valueE->getType()->isVoid() ||
+  // If the result of this expression is of type "()" potentially wrapped in
+  // optionals, then it is safe to ignore.
+  if (valueE->getType()->lookThroughAllAnyOptionalTypes()->isVoid() ||
       valueE->getType()->is<ErrorType>())
     return;
   

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -822,3 +822,12 @@ func rdar24202058(a : Int) {
   return a <= 480 // expected-error {{'<=' produces 'Bool', not the expected contextual result type '()'}}
 }
 
+// SR-1752: Warning about unused result with ternary operator
+
+struct SR1752 {
+  func foo() {}
+}
+
+let sr1752: SR1752? = nil
+
+true ? nil : sr1752?.foo() // don't generate a warning about unused result since foo returns Void

--- a/test/Parse/try.swift
+++ b/test/Parse/try.swift
@@ -110,11 +110,11 @@ let _: String = doubleOptional // expected-error {{cannot convert value of type 
 func maybeThrow() throws {}
 try maybeThrow() // okay
 try! maybeThrow() // okay
-try? maybeThrow() // expected-warning {{result of 'try?' is unused}}
+try? maybeThrow() // okay since return type of maybeThrow is Void
 _ = try? maybeThrow() // okay
 
 let _: () -> Void = { try! maybeThrow() } // okay
-let _: () -> Void = { try? maybeThrow() } // expected-warning {{result of 'try?' is unused}}
+let _: () -> Void = { try? maybeThrow() } // okay since return type of maybeThrow is Void
 
 
 if try? maybeThrow() { // expected-error {{cannot be used as a boolean}} {{4-4=((}} {{21-21=) != nil)}}


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Right now, if a function has a return value of `Optional<Void>` a warning about an unused result is generated. This also applies for the use of optional chaining inside a ternary operator, e.g. if `c.f()` returns `Void` and you do `true ? c?.f() : c?.f()` a warning saying `Expression of type '()?' is unused` is generated.
#### Resolved bug number: ([SR-1752](https://bugs.swift.org/browse/SR-1752))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
