### PR TITLE
[swiftc] Add 💥 case (😢 → 57, 😀 → 5073) triggered in swift::constraints::ConstraintGraphNode::getMemberType(…)

### DIFF
--- a/validation-test/compiler_crashers/28318-swift-constraints-constraintgraphnode-getmembertype.swift
+++ b/validation-test/compiler_crashers/28318-swift-constraints-constraintgraphnode-getmembertype.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+protocol A{
+protocol A typealias e:A}struct c<I:A
+for c


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Add crash case with stack trace:

```
swift: /path/to/swift/lib/Sema/ConstraintSystem.h:1350: void swift::constraints::ConstraintSystem::addConstraint(swift::constraints::ConstraintKind, swift::Type, swift::Type, swift::constraints::ConstraintLocator *, bool): Assertion `second && "Missing second type"' failed.
10 swift           0x0000000000fca006 swift::constraints::ConstraintGraphNode::getMemberType(swift::Identifier, std::function<swift::TypeVariableType* ()>) + 182
11 swift           0x0000000000fcabca swift::constraints::ConstraintGraph::getMemberType(swift::TypeVariableType*, swift::Identifier, std::function<swift::TypeVariableType* ()>) + 154
13 swift           0x0000000001110674 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 36
14 swift           0x0000000000f2b71b swift::constraints::ConstraintSystem::openGeneric(swift::DeclContext*, swift::DeclContext*, llvm::ArrayRef<swift::GenericTypeParamType*>, llvm::ArrayRef<swift::Requirement>, bool, swift::constraints::ConstraintLocatorBuilder, llvm::DenseMap<swift::CanType, swift::TypeVariableType*, llvm::DenseMapInfo<swift::CanType>, llvm::detail::DenseMapPair<swift::CanType, swift::TypeVariableType*> >&) + 1611
16 swift           0x0000000001110674 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 36
17 swift           0x0000000000f29bce swift::constraints::ConstraintSystem::openType(swift::Type, swift::constraints::ConstraintLocatorBuilder, llvm::DenseMap<swift::CanType, swift::TypeVariableType*, llvm::DenseMapInfo<swift::CanType>, llvm::detail::DenseMapPair<swift::CanType, swift::TypeVariableType*> >&) + 78
20 swift           0x0000000001054835 swift::Expr::walk(swift::ASTWalker&) + 69
21 swift           0x0000000000f729d8 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) + 200
22 swift           0x0000000000e88d93 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 371
23 swift           0x0000000000e8f6d2 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
26 swift           0x0000000000f08536 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
27 swift           0x0000000000ec477d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
28 swift           0x0000000000c58f89 swift::CompilerInstance::performSema() + 3289
30 swift           0x00000000007d7139 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
31 swift           0x00000000007a3148 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28318-swift-constraints-constraintgraphnode-getmembertype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28318-swift-constraints-constraintgraphnode-getmembertype-792685.o
1.  While type-checking expression at [validation-test/compiler_crashers/28318-swift-constraints-constraintgraphnode-getmembertype.swift:12:5 - line:12:5] RangeText="c"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
