### PR TITLE
stdlib: COFF variant of "visibility" macro

### DIFF
--- a/stdlib/public/SwiftShims/Visibility.h
+++ b/stdlib/public/SwiftShims/Visibility.h
@@ -59,11 +59,16 @@
 # define SWIFT_RUNTIME_EXPORT __attribute__((__visibility__("default")))
 #endif
 
-#elif __CYGWIN__
-# define SWIFT_RUNTIME_EXPORT 
 #else
-// __dllexport/__dllimport for Windows?
-# error "Unimplemented object format"
+# if defined(__CYGWIN__)
+#  define SWIFT_RUNTIME_EXPORT
+# else
+#  if defined(__SWIFT_CURRENT_DYLIB)
+#   define SWIFT_RUNTIME_EXPORT __declspec(dllexport)
+#  else
+#   define SWIFT_RUNTIME_EXPORT
+#  endif
+# endif
 #endif
 
 /// Attribute for runtime-stdlib SPI interfaces.


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Currently, LLVM supports the current three common object file formats (COFF,
ELF, MachO).  Unfortunately, COFF does not provide a compiler macro to identify
the object file format.  If neither `__MACH__` nor `__ELF__` is defined, then
assume that the object file format being used is COFF.  Within the COFF target
handling, do not use `__declspec(dllexport)` for cygwin targets.
