### PR TITLE
Adding macOS alias for conditional compilation blocks

### DIFF
--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -25,6 +25,7 @@ using namespace swift;
 
 static const StringRef SupportedConditionalCompilationOSs[] = {
   "OSX",
+  "macOS",
   "tvOS",
   "watchOS",
   "iOS",
@@ -112,8 +113,10 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
   bool UnsupportedOS = false;
 
   // Set the "os" platform condition.
-  if (Target.isMacOSX())
+  if (Target.isMacOSX()) {
     addPlatformConditionValue("os", "OSX");
+    addPlatformConditionValue("os", "macOS");
+  }
   else if (triple.isTvOS())
     addPlatformConditionValue("os", "tvOS");
   else if (triple.isWatchOS())

--- a/test/Parse/ConditionalCompilation/x64OSXTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64OSXTarget.swift
@@ -6,3 +6,9 @@ class C {}
 var x = C()
 #endif
 var y = x
+
+#if arch(x86_64) && os(macOS) && _runtime(_ObjC) && _endian(little)
+class D {}
+var z = D()
+#endif
+var w = z


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->

Alias OSX to macOS for conditional compilation blocks `os()` test

<!-- Description about pull request. -->

Starting in Sierra, Apple's Mac-based OS (OS X) will be renamed "macOS".
The `#if os(OSX)` test should be aliased to `#if os(macOS)`.

With any luck, I've managed to do this right.. 
#### Resolved bug number: ([SR-1823](https://bugs.swift.org/browse/SR-1823))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
