### PR TITLE
[validation-test] Remove unused imports

### DIFF
--- a/validation-test/stdlib/Collection/DefaultedBidirectionalCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedBidirectionalCollection.swift
@@ -11,14 +11,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var CollectionTests = TestSuite("Collection")
 
 // Test collections using value types as elements.

--- a/validation-test/stdlib/Collection/DefaultedCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedCollection.swift
@@ -11,14 +11,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var CollectionTests = TestSuite("Collection")
 
 // Test collections using value types as elements.

--- a/validation-test/stdlib/Collection/DefaultedMutableBidirectionalCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableBidirectionalCollection.swift
@@ -11,14 +11,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var CollectionTests = TestSuite("Collection")
 
 // Test collections using value types as elements.

--- a/validation-test/stdlib/Collection/DefaultedMutableCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableCollection.swift
@@ -11,14 +11,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var CollectionTests = TestSuite("Collection")
 
 // Test collections using value types as elements.

--- a/validation-test/stdlib/Collection/DefaultedMutableRandomAccessCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableRandomAccessCollection.swift
@@ -11,14 +11,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var CollectionTests = TestSuite("Collection")
 
 // Test collections using value types as elements.

--- a/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableBidirectionalCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableBidirectionalCollection.swift
@@ -11,14 +11,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var CollectionTests = TestSuite("Collection")
 
 // Test collections using value types as elements.

--- a/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableCollection.swift
@@ -11,14 +11,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var CollectionTests = TestSuite("Collection")
 
 // Test collections using value types as elements.

--- a/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableRandomAccessCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableRandomAccessCollection.swift
@@ -11,14 +11,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var CollectionTests = TestSuite("Collection")
 
 // Test collections using value types as elements.

--- a/validation-test/stdlib/Collection/DefaultedRandomAccessCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedRandomAccessCollection.swift
@@ -11,14 +11,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var CollectionTests = TestSuite("Collection")
 
 // Test collections using value types as elements.

--- a/validation-test/stdlib/Collection/DefaultedRangeReplaceableBidirectionalCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedRangeReplaceableBidirectionalCollection.swift
@@ -11,14 +11,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var CollectionTests = TestSuite("Collection")
 
 // Test collections using value types as elements.

--- a/validation-test/stdlib/Collection/DefaultedRangeReplaceableCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedRangeReplaceableCollection.swift
@@ -11,14 +11,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var CollectionTests = TestSuite("Collection")
 
 // Test collections using value types as elements.

--- a/validation-test/stdlib/Collection/DefaultedRangeReplaceableRandomAccessCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedRangeReplaceableRandomAccessCollection.swift
@@ -11,14 +11,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var CollectionTests = TestSuite("Collection")
 
 // Test collections using value types as elements.

--- a/validation-test/stdlib/Collection/Inputs/Template.swift.gyb
+++ b/validation-test/stdlib/Collection/Inputs/Template.swift.gyb
@@ -72,14 +72,6 @@ def test_methods(test):
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var CollectionTests = TestSuite("Collection")
 
 // Test collections using value types as elements.

--- a/validation-test/stdlib/Collection/MinimalBidirectionalCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalBidirectionalCollection.swift
@@ -11,14 +11,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var CollectionTests = TestSuite("Collection")
 
 // Test collections using value types as elements.

--- a/validation-test/stdlib/Collection/MinimalCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalCollection.swift
@@ -11,14 +11,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var CollectionTests = TestSuite("Collection")
 
 // Test collections using value types as elements.

--- a/validation-test/stdlib/Collection/MinimalMutableBidirectionalCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableBidirectionalCollection.swift
@@ -11,14 +11,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var CollectionTests = TestSuite("Collection")
 
 // Test collections using value types as elements.

--- a/validation-test/stdlib/Collection/MinimalMutableCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableCollection.swift
@@ -11,14 +11,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var CollectionTests = TestSuite("Collection")
 
 // Test collections using value types as elements.

--- a/validation-test/stdlib/Collection/MinimalMutableRandomAccessCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableRandomAccessCollection.swift
@@ -11,14 +11,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var CollectionTests = TestSuite("Collection")
 
 // Test collections using value types as elements.

--- a/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableBidirectionalCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableBidirectionalCollection.swift
@@ -11,14 +11,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var CollectionTests = TestSuite("Collection")
 
 // Test collections using value types as elements.

--- a/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableCollection.swift
@@ -11,14 +11,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var CollectionTests = TestSuite("Collection")
 
 // Test collections using value types as elements.

--- a/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableRandomAccessCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableRandomAccessCollection.swift
@@ -11,14 +11,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var CollectionTests = TestSuite("Collection")
 
 // Test collections using value types as elements.

--- a/validation-test/stdlib/Collection/MinimalRandomAccessCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalRandomAccessCollection.swift
@@ -11,14 +11,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var CollectionTests = TestSuite("Collection")
 
 // Test collections using value types as elements.

--- a/validation-test/stdlib/Collection/MinimalRangeReplaceableBidirectionalCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalRangeReplaceableBidirectionalCollection.swift
@@ -11,14 +11,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var CollectionTests = TestSuite("Collection")
 
 // Test collections using value types as elements.

--- a/validation-test/stdlib/Collection/MinimalRangeReplaceableCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalRangeReplaceableCollection.swift
@@ -11,14 +11,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var CollectionTests = TestSuite("Collection")
 
 // Test collections using value types as elements.

--- a/validation-test/stdlib/Collection/MinimalRangeReplaceableRandomAccessCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalRangeReplaceableRandomAccessCollection.swift
@@ -11,14 +11,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var CollectionTests = TestSuite("Collection")
 
 // Test collections using value types as elements.

--- a/validation-test/stdlib/CollectionType.swift.gyb
+++ b/validation-test/stdlib/CollectionType.swift.gyb
@@ -11,7 +11,6 @@
 
 import StdlibUnittest
 import StdlibCollectionUnittest
-import SwiftPrivate
 
 
 var CollectionTypeTests = TestSuite("Collection")

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -7,7 +7,6 @@
 
 import StdlibUnittest
 import StdlibCollectionUnittest
-import SwiftPrivate
 
 
 // Extend LoggingSequence to shadow the new operation.  When

--- a/validation-test/stdlib/Slice.swift.gyb
+++ b/validation-test/stdlib/Slice.swift.gyb
@@ -12,7 +12,6 @@ from gyb_stdlib_support import (
 
 import StdlibUnittest
 import StdlibCollectionUnittest
-import SwiftPrivate
 
 
 /// Reference-type collection for testing the `base` property.

--- a/validation-test/stdlib/Slice/BidirectionalSlice_Of_DefaultedBidirectionalCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/BidirectionalSlice_Of_DefaultedBidirectionalCollection_FullWidth.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/BidirectionalSlice_Of_DefaultedBidirectionalCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/BidirectionalSlice_Of_DefaultedBidirectionalCollection_WithPrefix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997]

--- a/validation-test/stdlib/Slice/BidirectionalSlice_Of_DefaultedBidirectionalCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/BidirectionalSlice_Of_DefaultedBidirectionalCollection_WithPrefixAndSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997, -9996, -9995]

--- a/validation-test/stdlib/Slice/BidirectionalSlice_Of_DefaultedBidirectionalCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/BidirectionalSlice_Of_DefaultedBidirectionalCollection_WithSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/BidirectionalSlice_Of_MinimalBidirectionalCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/BidirectionalSlice_Of_MinimalBidirectionalCollection_FullWidth.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/BidirectionalSlice_Of_MinimalBidirectionalCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/BidirectionalSlice_Of_MinimalBidirectionalCollection_WithPrefix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997]

--- a/validation-test/stdlib/Slice/BidirectionalSlice_Of_MinimalBidirectionalCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/BidirectionalSlice_Of_MinimalBidirectionalCollection_WithPrefixAndSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997, -9996, -9995]

--- a/validation-test/stdlib/Slice/BidirectionalSlice_Of_MinimalBidirectionalCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/BidirectionalSlice_Of_MinimalBidirectionalCollection_WithSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/Inputs/Template.swift.gyb
+++ b/validation-test/stdlib/Slice/Inputs/Template.swift.gyb
@@ -88,14 +88,6 @@ def test_methods(test):
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = ${test.prefix}

--- a/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_FullWidth.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_WithPrefix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997]

--- a/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_WithPrefixAndSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997, -9996, -9995]

--- a/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_WithSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_FullWidth.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_WithPrefix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997]

--- a/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_WithPrefixAndSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997, -9996, -9995]

--- a/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_WithSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_FullWidth.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_WithPrefix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997]

--- a/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_WithPrefixAndSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997, -9996, -9995]

--- a/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_WithSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_FullWidth.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_WithPrefix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997]

--- a/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_WithPrefixAndSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997, -9996, -9995]

--- a/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_WithSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_FullWidth.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithPrefix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997]

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997, -9996, -9995]

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_FullWidth.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithPrefix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997]

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997, -9996, -9995]

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_FullWidth.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithPrefix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997]

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997, -9996, -9995]

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_FullWidth.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithPrefix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997]

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997, -9996, -9995]

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_FullWidth.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_WithPrefix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997]

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_WithPrefixAndSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997, -9996, -9995]

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_WithSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_FullWidth.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_WithPrefix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997]

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_WithPrefixAndSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997, -9996, -9995]

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_WithSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedMutableCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedMutableCollection_FullWidth.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedMutableCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedMutableCollection_WithPrefix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997]

--- a/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedMutableCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedMutableCollection_WithPrefixAndSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997, -9996, -9995]

--- a/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedMutableCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedMutableCollection_WithSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/MutableSlice_Of_MinimalMutableCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_MinimalMutableCollection_FullWidth.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/MutableSlice_Of_MinimalMutableCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_MinimalMutableCollection_WithPrefix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997]

--- a/validation-test/stdlib/Slice/MutableSlice_Of_MinimalMutableCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_MinimalMutableCollection_WithPrefixAndSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997, -9996, -9995]

--- a/validation-test/stdlib/Slice/MutableSlice_Of_MinimalMutableCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_MinimalMutableCollection_WithSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/RandomAccessSlice_Of_DefaultedRandomAccessCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/RandomAccessSlice_Of_DefaultedRandomAccessCollection_FullWidth.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/RandomAccessSlice_Of_DefaultedRandomAccessCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/RandomAccessSlice_Of_DefaultedRandomAccessCollection_WithPrefix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997]

--- a/validation-test/stdlib/Slice/RandomAccessSlice_Of_DefaultedRandomAccessCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/RandomAccessSlice_Of_DefaultedRandomAccessCollection_WithPrefixAndSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997, -9996, -9995]

--- a/validation-test/stdlib/Slice/RandomAccessSlice_Of_DefaultedRandomAccessCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/RandomAccessSlice_Of_DefaultedRandomAccessCollection_WithSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/RandomAccessSlice_Of_MinimalRandomAccessCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/RandomAccessSlice_Of_MinimalRandomAccessCollection_FullWidth.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/RandomAccessSlice_Of_MinimalRandomAccessCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/RandomAccessSlice_Of_MinimalRandomAccessCollection_WithPrefix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997]

--- a/validation-test/stdlib/Slice/RandomAccessSlice_Of_MinimalRandomAccessCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/RandomAccessSlice_Of_MinimalRandomAccessCollection_WithPrefixAndSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997, -9996, -9995]

--- a/validation-test/stdlib/Slice/RandomAccessSlice_Of_MinimalRandomAccessCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/RandomAccessSlice_Of_MinimalRandomAccessCollection_WithSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_FullWidth.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithPrefix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997]

--- a/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997, -9996, -9995]

--- a/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_FullWidth.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_WithPrefix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997]

--- a/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997, -9996, -9995]

--- a/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_WithSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_FullWidth.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithPrefix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997]

--- a/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997, -9996, -9995]

--- a/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_FullWidth.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_WithPrefix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997]

--- a/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997, -9996, -9995]

--- a/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_WithSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_FullWidth.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_WithPrefix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997]

--- a/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_WithPrefixAndSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997, -9996, -9995]

--- a/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_WithSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_FullWidth.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_WithPrefix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997]

--- a/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_WithPrefixAndSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997, -9996, -9995]

--- a/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_WithSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedCollection_FullWidth.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedCollection_WithPrefix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997]

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedCollection_WithPrefixAndSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997, -9996, -9995]

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedCollection_WithSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalCollection_FullWidth.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalCollection_WithPrefix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalCollection_WithPrefix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997]

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalCollection_WithPrefixAndSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalCollection_WithPrefixAndSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = [-9999, -9998, -9997, -9996, -9995]

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalCollection_WithSuffix.swift
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalCollection_WithSuffix.swift
@@ -14,14 +14,6 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
-// Also import modules which are used by StdlibUnittest internally. This
-// workaround is needed to link all required libraries in case we compile
-// StdlibUnittest with -sil-serialize-all.
-import SwiftPrivate
-#if _runtime(_ObjC)
-import ObjectiveC
-#endif
-
 var SliceTests = TestSuite("Collection")
 
 let prefix: [Int] = []


### PR DESCRIPTION
#### What's in this pull request?
- Remove `-sil-serialize-all` workaround from Collection and Sequence tests.
  I believe these workaround is not needed anymore since 49c54870c1f99bbdbce0b20ee723a82c8bb8ea6d
- Remove `import SwiftPrivate` from `SequenceType`, `CollectionType`, `Slice` tests. It's unused.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
