### PR TITLE
[CMake] Add upload-stdlib-{variant} build target

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -199,6 +199,38 @@ if(PYTHONINTERP_FOUND)
       set(validation_test_dependencies
           "swiftStdlibCollectionUnittest-${SWIFT_SDK_${SDK}_LIB_SUBDIR}")
 
+      set(command_upload_stdlib)
+      set(command_upload_swift_reflection_test)
+      if("${SDK}" STREQUAL "IOS" OR "${SDK}" STREQUAL "TVOS" OR "${SDK}" STREQUAL "WATCHOS")
+        # These are supported testing SDKs, but their implementation of
+        # `command_upload_stdlib` is hidden.
+      elseif("${SDK}" STREQUAL "ANDROID")
+        # Warning: This step will fail if you do not have an Android device
+        #          connected via USB. See docs/Android.md for details on
+        #          how to run the test suite for Android.
+        set(command_upload_stdlib
+            COMMAND
+                # Reboot the device and remove everything in its tmp
+                # directory. Build products and test executables are pushed
+                # to that directory when running the test suite.
+                ${PYTHON_EXECUTABLE} "${SWIFT_SOURCE_DIR}/utils/android/adb_clean.py"
+            COMMAND
+                ${PYTHON_EXECUTABLE} "${SWIFT_SOURCE_DIR}/utils/android/adb_push_built_products.py"
+                --ndk "${SWIFT_ANDROID_NDK_PATH}"
+                --destination "${SWIFT_ANDROID_DEPLOY_DEVICE_PATH}"
+                # Build products like libswiftCore.so.
+                "${SWIFTLIB_DIR}/android"
+                # These two directories may contain the same libraries,
+                # but upload both to device just in case. Duplicates will be
+                # overwritten, and uploading doesn't take very long anyway.
+                "${SWIFT_ANDROID_ICU_UC}"
+                "${SWIFT_ANDROID_ICU_I18N}")
+      endif()
+      add_custom_target("upload-stdlib${VARIANT_SUFFIX}"
+          ${command_upload_stdlib}
+          ${command_upload_swift_reflection_test}
+          COMMENT "Uploading stdlib")
+
       foreach(test_mode ${TEST_MODES})
         set(LIT_ARGS "${SWIFT_TEST_EXTRA_ARGS} ${LLVM_LIT_ARGS}")
         separate_arguments(LIT_ARGS)
@@ -209,34 +241,6 @@ if(PYTHONINTERP_FOUND)
         endif()
 
         list(APPEND LIT_ARGS "--xunit-xml-output=${swift_test_results_dir}/lit-tests.xml")
-
-        set(command_upload_stdlib)
-        set(command_upload_swift_reflection_test)
-        if("${SDK}" STREQUAL "IOS" OR "${SDK}" STREQUAL "TVOS" OR "${SDK}" STREQUAL "WATCHOS")
-          # These are supported testing SDKs, but their implementation of
-          # `command_upload_stdlib` is hidden.
-        elseif("${SDK}" STREQUAL "ANDROID")
-          # Warning: This step will fail if you do not have an Android device
-          #          connected via USB. See docs/Android.md for details on
-          #          how to run the test suite for Android.
-          set(command_upload_stdlib
-              COMMAND
-                  # Reboot the device and remove everything in its tmp
-                  # directory. Build products and test executables are pushed
-                  # to that directory when running the test suite.
-                  ${PYTHON_EXECUTABLE} "${SWIFT_SOURCE_DIR}/utils/android/adb_clean.py"
-              COMMAND
-                  ${PYTHON_EXECUTABLE} "${SWIFT_SOURCE_DIR}/utils/android/adb_push_built_products.py"
-                  --ndk "${SWIFT_ANDROID_NDK_PATH}"
-                  --destination "${SWIFT_ANDROID_DEPLOY_DEVICE_PATH}"
-                  # Build products like libswiftCore.so.
-                  "${SWIFTLIB_DIR}/android"
-                  # These two directories may contain the same libraries,
-                  # but upload both to device just in case. Duplicates will be
-                  # overwritten, and uploading doesn't take very long anyway.
-                  "${SWIFT_ANDROID_ICU_UC}"
-                  "${SWIFT_ANDROID_ICU_I18N}")
-        endif()
 
         foreach(test_subset ${TEST_SUBSETS})
           set(directories)


### PR DESCRIPTION
#### What's in this pull request?

Add independent `upload-stdlib-*` build target for `command_upload_stdlib`.
So that we can easily execute specific test cases on the device.

```
utils/build-script <without -t or -T>
cmake --build ${SWIFT_BUILD_DIR} -- upload-stdlib-android-armv7
${LLVM_SOURCE_DIR}/utils/lit/lit.py -sv <test_path>...
```

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
