### PR TITLE
[SourceKit] CMake dependency fixes

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/CMakeLists.txt
+++ b/tools/SourceKit/lib/SwiftLang/CMakeLists.txt
@@ -13,20 +13,20 @@ add_sourcekit_library(SourceKitSwiftLang
           swiftSema swiftBasic swiftSerialization
           swiftOption cmark
     # Clang dependencies.
+      clangIndex
       clangFormat
       clangToolingCore
-      clangIndex
-      clangDriver
       clangFrontendTool
       clangFrontend
+      clangDriver
       clangCodeGen
       clangSerialization
       clangParse
       clangSema
       clangAnalysis
       clangEdit
-      clangRewrite
       clangRewriteFrontend
+      clangRewrite
       clangLex
       clangAST
       clangAPINotes

--- a/tools/SourceKit/tools/sourcekitd/lib/API/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/CMakeLists.txt
@@ -18,6 +18,4 @@ add_sourcekit_library(sourcekitdAPI
   ${sourcekitdAPI_sources}
   DEPENDS
       SourceKitSupport SourceKitSwiftLang
-      # Clang dependencies, required by SourceKitSwiftLang
-      clangFormat clangToolingCore clangDriver
 )


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

While SourceKit building on Linux, I encountered some `unresolved reference` linker errors that seem to stem from a different linker behavior with respect to the ordering of libraries on the command line invocation. I've made two changes here that resolve several of these issues:
- Explicitly declare that `SourceKitCore` depends on `SourceKitSwiftLang`. This circular dependency exists in the source files but wasn't declared in the `CMakeLists`. Adding this here causes CMake to include the libraries multiple times in the invocation which lets the linker resolve the references.
- #2766 added some explicit clang dependencies to the `sourcekitdAPI` target to fix similar linker issues there. I discovered that those errors could instead be fixed by reordering some of the clang dependencies in `SourceKitSwiftLang`.

<!-- Description about pull request. -->
#### Related bug number: ([SR-1676](https://bugs.swift.org/browse/SR-1676))

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

@modocache @llvm-beanz @gribozavr 
