### PR TITLE
[SourceKit] Mark more tests as needing Obj-C interop

### DIFF
--- a/test/SourceKit/CodeComplete/complete_filter_rules.swift
+++ b/test/SourceKit/CodeComplete/complete_filter_rules.swift
@@ -10,7 +10,7 @@ struct TestHideName {
   func hideThis4(namedParam1 x: Int, namedParam2: Int) {}
   func dontHideThisByName() {}
 
-// XFAIL: broken_std_regex
+// REQUIRES: objc_interop
 
 // RUN: %complete-test -filter-rules=%S/Inputs/filter-rules/hideNames.json -tok=HIDE_NAMES_1 %s -- -F %S/../Inputs/libIDE-mock-sdk | FileCheck %s -check-prefix=HIDE_NAMES
   func testHideName01() {

--- a/test/SourceKit/CodeComplete/complete_hide_low_priority.swift
+++ b/test/SourceKit/CodeComplete/complete_hide_low_priority.swift
@@ -1,4 +1,4 @@
-// XFAIL: broken_std_regex
+// REQUIRES: objc_interop
 // RUN: %complete-test -hide-low-priority=1 -tok=TOP_LEVEL_0 %s -- -I %S/Inputs > %t.on
 // RUN: %complete-test -hide-low-priority=0 -tok=TOP_LEVEL_0 %s -- -I %S/Inputs > %t.off
 

--- a/test/SourceKit/CodeComplete/complete_popular_api.swift
+++ b/test/SourceKit/CodeComplete/complete_popular_api.swift
@@ -17,7 +17,7 @@ struct Foo {
   var zmeh: Int
 }
 
-// XFAIL: broken_std_regex
+// REQUIRES: objc_interop
 // RUN: %sourcekitd-test -req=complete.open -pos=2:1 -req-opts=hidelowpriority=0 %s -- %s > %t.nopopular.top
 // RUN: %sourcekitd-test -req=complete.open -pos=3:5 %s -- %s > %t.nopopular.foo
 // RUN: FileCheck %s -check-prefix=NOPOP_TOP < %t.nopopular.top

--- a/test/SourceKit/CodeComplete/complete_underscores.swift
+++ b/test/SourceKit/CodeComplete/complete_underscores.swift
@@ -32,7 +32,7 @@ enum Norf {
 func test001() {
   #^TOP_LEVEL_0,,_^#
 }
-// XFAIL: broken_std_regex
+// REQUIRES: objc_interop
 // RUN: %complete-test %s -hide-none -tok=TOP_LEVEL_0  -- -F %S/../Inputs/libIDE-mock-sdk | FileCheck %s -check-prefix=TOP_LEVEL_0
 // TOP_LEVEL_0-LABEL: Results for filterText: [
 // TOP_LEVEL_0-DAG: Foo


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Follow-up to #3019. When running the tests on Ubuntu 15.10 (which has a working `std::regex`), I discovered a few more tests which actually should have been marked as needing Obj-C interop.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
