### PR TITLE
[SourceKit] Add Semaphore to SourceKitSupport's concurrency module

### DIFF
--- a/tools/SourceKit/include/SourceKit/Support/Concurrency.h
+++ b/tools/SourceKit/include/SourceKit/Support/Concurrency.h
@@ -17,6 +17,55 @@
 
 namespace SourceKit {
 
+class Semaphore {
+public:
+  Semaphore(long count) {
+    ImplObj = Impl::create(count);
+  }
+  ~Semaphore() {
+    if (ImplObj)
+      Impl::release(ImplObj);
+  }
+
+  void signal() {
+    Impl::signal(ImplObj);
+  }
+
+  bool wait() {
+    return Impl::wait(ImplObj);
+  }
+
+  bool wait(long milliseconds) {
+    return Impl::wait(ImplObj, milliseconds);
+  }
+
+  Semaphore(const Semaphore &Other) = delete;
+  Semaphore(Semaphore &&Other) {
+    ImplObj = std::move(Other.ImplObj);
+    Other.ImplObj = Impl::Ty();
+  }
+
+  Semaphore &operator=(const Semaphore &Other) = delete;
+  Semaphore &operator=(Semaphore &&Other) {
+    Semaphore Tmp(std::move(Other));
+    std::swap(ImplObj, Tmp.ImplObj);
+    return *this;
+  }
+private:
+  // Platform-specific implementation.
+  struct Impl {
+    typedef void *Ty;
+    static Ty create(long count);
+    static void signal(Ty Obj);
+    static bool wait(Ty Obj);
+    static bool wait(Ty Obj, long milliseconds);
+    static void retain(Ty Obj);
+    static void release(Ty Obj);
+  };
+
+  Impl::Ty ImplObj;
+};
+
 class WorkQueue {
 public:
   enum class Dequeuing {

--- a/tools/SourceKit/lib/Support/Concurrency-Mac.cpp
+++ b/tools/SourceKit/lib/Support/Concurrency-Mac.cpp
@@ -21,6 +21,34 @@
 
 using namespace SourceKit;
 
+void *Semaphore::Impl::create(long count) {
+  return dispatch_semaphore_create(count);
+}
+
+void Semaphore::Impl::signal(Ty Obj) {
+  dispatch_semaphore_signal(dispatch_semaphore_t(Obj));
+}
+
+bool Semaphore::Impl::wait(Ty Obj) {
+  return dispatch_semaphore_wait(dispatch_semaphore_t(Obj), 
+                                 DISPATCH_TIME_FOREVER);
+}
+
+bool Semaphore::Impl::wait(Ty Obj, long milliseconds) {
+  dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 
+                                          milliseconds * NSEC_PER_MSEC);
+  return dispatch_semaphore_wait(dispatch_semaphore_t(Obj), timeout);
+}
+
+void Semaphore::Impl::retain(Ty Obj) {
+  dispatch_retain(dispatch_semaphore_t(Obj));
+}
+
+void Semaphore::Impl::release(Ty Obj) {
+  dispatch_release(dispatch_semaphore_t(Obj));
+}
+
+
 static dispatch_queue_priority_t toDispatchPriority(WorkQueue::Priority Prio) {
   switch (Prio) {
   case WorkQueue::Priority::High: return DISPATCH_QUEUE_PRIORITY_HIGH;

--- a/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 add_sourcekit_executable(sourcekitd-test
   sourcekitd-test.cpp
   TestOptions.cpp
-  DEPENDS ${SOURCEKITD_TEST_DEPEND}
+  DEPENDS ${SOURCEKITD_TEST_DEPEND} SourceKitSupport
     clangRewrite clangLex clangBasic
   COMPONENT_DEPENDS support option
 )

--- a/tools/SourceKit/tools/sourcekitd/bin/InProc/sourcekitdInProc.cpp
+++ b/tools/SourceKit/tools/sourcekitd/bin/InProc/sourcekitdInProc.cpp
@@ -20,7 +20,6 @@
 
 // FIXME: Portability ?
 #include <Block.h>
-#include <dispatch/dispatch.h>
 
 #ifdef LLVM_ON_WIN32
 #define WIN32_LEAN_AND_MEAN
@@ -104,16 +103,15 @@ void sourcekitd::set_interrupted_connection_handler(
 //===----------------------------------------------------------------------===//
 
 sourcekitd_response_t sourcekitd_send_request_sync(sourcekitd_object_t req) {
-  dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+  Semaphore sema(0);
 
   sourcekitd_response_t ReturnedResp;
   sourcekitd::handleRequest(req, [&](sourcekitd_response_t resp) {
     ReturnedResp = resp;
-    dispatch_semaphore_signal(sema);
+    sema.signal();
   });
 
-  dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
-  dispatch_release(sema);
+  sema.wait();
   return ReturnedResp;
 }
 

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -13,12 +13,10 @@
 #include "SourceKit/Core/Context.h"
 #include "SourceKit/Core/LangSupport.h"
 #include "SourceKit/Core/NotificationCenter.h"
+#include "SourceKit/Support/Concurrency.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "gtest/gtest.h"
-
-// FIXME: Portability.
-#include <dispatch/dispatch.h>
 
 using namespace SourceKit;
 using namespace llvm;
@@ -98,18 +96,12 @@ struct TestCursorInfo {
 class CursorInfoTest : public ::testing::Test {
   SourceKit::Context Ctx{ getRuntimeLibPath() };
   std::atomic<int> NumTasks;
-  dispatch_semaphore_t TaskSema = nullptr;
 
 public:
   LangSupport &getLang() { return Ctx.getSwiftLangSupport(); }
 
   void SetUp() {
     NumTasks = 0;
-    TaskSema = dispatch_semaphore_create(0);
-  }
-
-  void TearDown() {
-    dispatch_release(TaskSema);
   }
 
   void addNotificationReceiver(DocumentUpdateNotificationReceiver Receiver) {
@@ -133,7 +125,7 @@ public:
   TestCursorInfo getCursor(const char *DocName, unsigned Offset,
                            ArrayRef<const char *> CArgs) {
     auto Args = makeArgs(DocName, CArgs);
-    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+    Semaphore sema(0);
 
     TestCursorInfo TestInfo;
     getLang().getCursorInfo(DocName, Offset, Args,
@@ -142,38 +134,13 @@ public:
         TestInfo.Typename = Info.TypeName;
         TestInfo.Filename = Info.Filename;
         TestInfo.DeclarationLoc = Info.DeclarationLoc;
-        dispatch_semaphore_signal(sema);
+        sema.signal();
       });
 
-    dispatch_time_t when = dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * 60);
-    bool expired = dispatch_semaphore_wait(sema, when);
+    bool expired = sema.wait(60 * 1000);
     if (expired)
       llvm::report_fatal_error("check took too long");
-    dispatch_release(sema);
     return TestInfo;
-  }
-
-  void checkCursorAsync(const char *DocName, unsigned Offset,
-                        ArrayRef<const char *> CArgs,
-                        StringRef ExpectedName, StringRef ExpectedTypename) {
-    auto Args = makeArgs(DocName, CArgs);
-    ++NumTasks;
-    getLang().getCursorInfo(DocName, Offset, Args,
-      [this, ExpectedName, ExpectedTypename](const CursorInfo &Info) {
-        EXPECT_EQ(ExpectedName, Info.Name);
-        EXPECT_EQ(ExpectedTypename, Info.TypeName);
-
-        int Num = --NumTasks;
-        if (Num == 0)
-          dispatch_semaphore_signal(TaskSema);
-      });
-  }
-
-  void waitForChecks() {
-    dispatch_time_t when = dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * 60);
-    bool expired = dispatch_semaphore_wait(TaskSema, when);
-    if (expired)
-      llvm::report_fatal_error("checks took too long");
   }
 
   unsigned findOffset(StringRef Val, StringRef Text) {


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

This adds a basic semaphore class to the existing concurrency module in `SourceKitSupport`, together with an implementation that uses `libdispatch`. It also migrates several bits of code to use the new class instead of `dispatch_semaphore_t` directly.

The most immediate motivation for this change was to remove all explicit `libdispatch` usage from SourceKit's unit tests which was a barrier to getting them to build on Linux.

This is related to #2793
#### Related bug number: ([SR-1676](https://bugs.swift.org/browse/SR-1676))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

@gribozavr @modocache @benlangmuir 
