### PR TITLE
[stdlib] Bounds checks and tests for Unsafe*BufferPointer

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/RangeSelection.swift
+++ b/stdlib/private/StdlibCollectionUnittest/RangeSelection.swift
@@ -19,6 +19,7 @@ public enum RangeSelection {
   case middle
   case leftHalf
   case rightHalf
+  case full
   case offsets(Int, Int)
 
   public var isEmpty: Bool {
@@ -45,6 +46,8 @@ public enum RangeSelection {
         let start = c.index(c.startIndex, offsetBy: c.count / 2)
         let end = c.endIndex
         return start..<end
+      case .full:
+        return c.startIndex..<c.endIndex
       case let .offsets(lowerBound, upperBound):
         let start = c.index(c.startIndex, offsetBy: numericCast(lowerBound))
         let end = c.index(c.startIndex, offsetBy: numericCast(upperBound))
@@ -75,6 +78,9 @@ public enum RangeSelection {
         let start = c.index(c.startIndex, offsetBy: c.count / 2)
         let beforeEnd = c.index(c.startIndex, offsetBy: c.count - 1)
         return start...beforeEnd
+      case .full:
+        let beforeEnd = c.index(c.startIndex, offsetBy: c.count - 1)
+        return c.startIndex...beforeEnd
       case let .offsets(lowerBound, upperBound):
         let start = c.index(c.startIndex, offsetBy: numericCast(lowerBound))
         let end = c.index(c.startIndex, offsetBy: numericCast(upperBound))

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -162,14 +162,15 @@ public struct Unsafe${Mutable}BufferPointer<Element>
     -> ${Mutable}RandomAccessSlice<Unsafe${Mutable}BufferPointer<Element>>
   {
     get {
-      // FIXME: swift-3-indexing-model: range check.
-      // FIXME: swift-3-indexing-model: tests.
+      _debugPrecondition(bounds.lowerBound >= startIndex)
+      _debugPrecondition(bounds.upperBound <= endIndex)
       return ${Mutable}RandomAccessSlice(
         base: self, bounds: bounds)
     }
 %  if Mutable:
     set {
-      // FIXME: swift-3-indexing-model: range check.
+      _debugPrecondition(bounds.lowerBound >= startIndex)
+      _debugPrecondition(bounds.upperBound <= endIndex)
       // FIXME: swift-3-indexing-model: tests.
       _writeBackMutableSlice(&self, bounds: bounds, slice: newValue)
     }

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -4,6 +4,81 @@
 import StdlibUnittest
 import StdlibCollectionUnittest
 
+// Tests
+
+struct SubscriptGetTest {
+  // SubscriptGetTest operates on a `(end - start)` sized buffer containing
+  // monotonically increasing integers from `start` to `end - 1`.
+  static let start = 0
+  static let end = 20
+  let rangeSelection: RangeSelection
+  /// The values that should be expected by slicing the UBP, or `nil` if the
+  /// test is expected to crash.
+  let expectedValues: [Int]?
+  let loc: SourceLoc
+
+  static var elementCount = (end - start)
+
+% for SelfType in ['UnsafeBufferPointer', 'UnsafeMutableBufferPointer']:
+  /// Create and populate an `${SelfType}` for use with unit tests.
+  /// PRECONDITION: `memory` must be allocated with space for
+  /// `SubscriptGetTest.elementCount` elements. 
+  func create${SelfType}(from memory: UnsafeMutablePointer<OpaqueValue<Int>>) 
+    -> ${SelfType}<OpaqueValue<Int>> 
+  {
+    for i in SubscriptGetTest.start..<SubscriptGetTest.end {
+      memory[i] = OpaqueValue(i)  
+    }
+    return ${SelfType}(start: memory, count: SubscriptGetTest.elementCount)
+  }
+% end
+
+  init(
+    rangeSelection: RangeSelection, expectedValues: [Int]? = nil,
+    file: String = #file, line: UInt = #line
+  ) {
+    self.rangeSelection = rangeSelection
+    self.expectedValues = expectedValues
+    self.loc = SourceLoc(file, line, comment: "test data")
+  }
+}
+
+let subscriptGetTests : [SubscriptGetTest] = [
+  // Valid, empty.
+  SubscriptGetTest(rangeSelection: .emptyRange, expectedValues: []),
+
+  // Valid, edges.
+  SubscriptGetTest(rangeSelection: .leftEdge, expectedValues: [0]),
+  SubscriptGetTest(rangeSelection: .rightEdge, expectedValues: [19]),
+
+  // Valid, internal.
+  SubscriptGetTest(rangeSelection: .leftHalf, 
+    expectedValues: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+  SubscriptGetTest(rangeSelection: .rightHalf,
+    expectedValues: [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]),
+  SubscriptGetTest(rangeSelection: .middle,
+    expectedValues: [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+  SubscriptGetTest(rangeSelection: .full,
+    expectedValues: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]),
+
+  // Invalid, bottom out of bounds.
+  SubscriptGetTest(rangeSelection: .offsets(-1, -1)),
+  SubscriptGetTest(rangeSelection: .offsets(-1, 0)),
+  SubscriptGetTest(rangeSelection: .offsets(-100, 5)),
+
+  // Invalid, top out of bounds.
+  SubscriptGetTest(rangeSelection: .offsets(20, 20)),
+  SubscriptGetTest(rangeSelection: .offsets(19, 20)),
+  SubscriptGetTest(rangeSelection: .offsets(5, 100)),
+
+  // Invalid, both out of bounds.
+  SubscriptGetTest(rangeSelection: .offsets(-1, 20)),
+  SubscriptGetTest(rangeSelection: .offsets(-100, 100)),
+]
+
+
+// Test Suites
+
 var UnsafeBufferPointerTestSuite = TestSuite("UnsafeBufferPointer")
 var UnsafeMutableBufferPointerTestSuite = TestSuite("UnsafeMutableBufferPointer")
 
@@ -104,6 +179,34 @@ ${SelfName}TestSuite.test("badNilCount")
   let buffer = ${SelfType}(start: nil, count: 1)
   _ = buffer
 }
+
+%   for RangeName in ['range', 'countableRange', 'closedRange', 'countableClosedRange']:
+${SelfName}TestSuite.test("subscript/get").forEach(in: subscriptGetTests) { 
+  (test) in
+
+%      if 'closed' in RangeName.lower():
+  if test.rangeSelection.isEmpty {
+    return
+  }
+%      end
+
+  let elementCount = SubscriptGetTest.elementCount
+
+  var memory = UnsafeMutablePointer<OpaqueValue<Int>>(allocatingCapacity: elementCount)
+  let buffer = test.create${SelfName}(from: memory)
+  defer { memory.deallocateCapacity(elementCount) }
+
+  let range = test.rangeSelection.${RangeName}(in: buffer)
+
+  if test.expectedValues == nil { expectCrashLater() }
+  let slice = buffer[range]
+  expectEqual(
+    test.expectedValues!,
+    slice.map { $0.value },
+    stackTrace: SourceLocStack().with(test.loc)
+  )
+}
+%    end
 
 % end
 


### PR DESCRIPTION
#### What's in this pull request?

Bounds checks for `Unsafe*Buffer`'s subscript, and tests for the subscript getter. Setter tests will be in a forthcoming commit.

The stdlib test suite passes. Running all tests now...

@moiseev @gribozavr 

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Changes:
- Added bounds checks to Unsafe*BufferPointer's subscript getter and setter
- Added tests for Unsafe*BufferPointer's subscript getter
