### PR TITLE
[SR-1813] Fix archetype access path binding

### DIFF
--- a/lib/IRGen/GenProto.h
+++ b/lib/IRGen/GenProto.h
@@ -331,10 +331,6 @@ namespace irgen {
     // Did the convention decide that the parameter at the given index
     // was a class-pointer source?
     bool isClassPointerSource(unsigned paramIndex);
-    
-    void bindArchetypeAccessPaths();
-    void addPotentialArchetypeAccessPath(CanType targetDepType,
-                                         CanType sourceDepType);
   };
 
 } // end namespace irgen

--- a/test/IRGen/same_type_constraints.swift
+++ b/test/IRGen/same_type_constraints.swift
@@ -16,3 +16,9 @@ public extension P where Foo == DefaultFoo<Self> {
 }
 
 // CHECK: define{{( protected)?}} void @_TFe21same_type_constraintsRxS_1Pwx3FoozGVS_10DefaultFoox_rS0_3foofT_GS2_x_
+
+// <rdar://26873036> IRGen crash with derived class declaring same-type constraint on constrained associatedtype.
+public class C1<T: Equatable> { }
+public class C2<T: Equatable, U: P where T == U.Foo>: C1<T> {}
+
+// CHECK: define{{( protected)?}} void @_TFC21same_type_constraints2C1D


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Fixes a regression from Swift 2.2 where the configuration reported in SR-1813 would cause the compiler to forget to setup archetype access paths which would blow up witness table gen.
#### Resolved bug number: ([SR-1813](https://bugs.swift.org/browse/SR-1813))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
