### PR TITLE
build: only use gold on ELF targets

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -76,6 +76,25 @@ function(is_darwin_based_sdk sdk_name out_var)
   endif()
 endfunction()
 
+function(is_windows_based_sdk sdk_name out_var)
+  if("${sdk_name}" STREQUAL "WINDOWS" OR
+     "${sdk_name}" STREQUAL "CYGWIN")
+   set(${out_var} TRUE PARENT_SCOPE)
+ else()
+   set(${out_var} FALSE PARENT_SCOPE)
+ endif()
+endfunction()
+
+function(is_elfish_sdk sdk_name out_var)
+  is_darwin_based_sdk("${sdk_name}" IS_DARWIN)
+  is_windows_based_sdk("${sdk_name}" IS_WINDOWS)
+  if(IS_DARWIN OR IS_WINDOWS)
+    set(${out_var} FALSE PARENT_SCOPE)
+  else()
+    set(${out_var} TRUE PARENT_SCOPE)
+  endif()
+endfunction()
+
 # Usage:
 # _add_variant_c_compile_link_flags(
 #   SDK sdk
@@ -871,7 +890,8 @@ function(_add_swift_library_single target name)
     RESULT_VAR_NAME link_flags
       )
 
-  if(SWIFT_ENABLE_GOLD_LINKER)
+  is_elfish_sdk("${SWIFTLIB_SINGLE_SDK}" IS_ELFISH)
+  if(SWIFT_ENABLE_GOLD_LINKER AND IS_ELFISH)
     list(APPEND link_flags "-fuse-ld=gold")
   endif()
 
@@ -1512,9 +1532,8 @@ function(_add_swift_executable_single name)
         "-Xlinker" "@executable_path/../lib/swift/${SWIFT_SDK_${SWIFTEXE_SINGLE_SDK}_LIB_SUBDIR}")
   endif()
 
-  if(SWIFT_ENABLE_GOLD_LINKER AND
-     ( "${SWIFTEXE_SINGLE_SDK}" STREQUAL "LINUX" ) )
-    # Extend the link_flags for the gold linker.
+  is_elfish_sdk("${SWIFTLIB_SINGLE_SDK}" IS_ELFISH)
+  if(SWIFT_ENABLE_GOLD_LINKER AND IS_ELFISH)
     list(APPEND link_flags "-fuse-ld=gold")
   endif()
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

gold only supports ELF.  This adds two new helper functions
(is_windows_based_sdk and is_elfish_sdk) to ensure that we dont try to use gold
on non-ELF targets.  This comes up when trying to setup cross-compilation for
the standard library for Windows.

The ELF check is implemented as the negation of Darwin (which uses MachO) and
Windows (which uses COFF).  The reason for this is that there are additional
targets which also use ELF.  Rather than enumerating the larger set, enumerate
the smaller set (windows) and use the negation.
