### PR TITLE
[SourceKit] Remove dependency of SwiftLang on Core

### DIFF
--- a/tools/SourceKit/include/SourceKit/Core/Context.h
+++ b/tools/SourceKit/include/SourceKit/Core/Context.h
@@ -15,6 +15,7 @@
 
 #include "SourceKit/Core/LLVM.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/STLExtras.h"
 #include <memory>
 #include <string>
 
@@ -32,7 +33,9 @@ class Context {
   std::unique_ptr<NotificationCenter> NotificationCtr;
 
 public:
-  explicit Context(StringRef RuntimeLibPath);
+  Context(StringRef RuntimeLibPath,
+          llvm::function_ref<
+              std::unique_ptr<LangSupport>(Context &)> LangSupportFactoryFn);
   ~Context();
 
   StringRef getRuntimeLibPath() const { return RuntimeLibPath; }

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -27,7 +27,6 @@ namespace llvm {
   class MemoryBuffer;
 }
 namespace SourceKit {
-  class Context;
 
 struct EntityInfo {
   UIdent Kind;
@@ -472,9 +471,6 @@ public:
                           StringRef ModuleName,
                           ArrayRef<const char *> Args,
                           DocInfoConsumer &Consumer) = 0;
-
-  static std::unique_ptr<LangSupport> createSwiftLangSupport(
-                                                     SourceKit::Context &SKCtx);
 };
 
 } // namespace SourceKit

--- a/tools/SourceKit/include/SourceKit/SwiftLang/Factory.h
+++ b/tools/SourceKit/include/SourceKit/SwiftLang/Factory.h
@@ -1,0 +1,26 @@
+//===--- Factory.h - --------------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SOURCEKIT_SWIFTLANG_FACTORY_H
+#define LLVM_SOURCEKIT_SWIFTLANG_FACTORY_H
+
+#include <memory>
+
+namespace SourceKit {
+class LangSupport;
+class Context;
+
+std::unique_ptr<LangSupport> createSwiftLangSupport(Context &SKCtx);
+
+}
+
+#endif

--- a/tools/SourceKit/lib/Core/Context.cpp
+++ b/tools/SourceKit/lib/Core/Context.cpp
@@ -16,10 +16,13 @@
 
 using namespace SourceKit;
 
-SourceKit::Context::Context(StringRef RuntimeLibPath)
+SourceKit::Context::Context(StringRef RuntimeLibPath,
+    		llvm::function_ref<
+    			std::unique_ptr<LangSupport>(Context &)> LangSupportFactoryFn)
   : RuntimeLibPath(RuntimeLibPath),
-    SwiftLang(LangSupport::createSwiftLangSupport(*this)),
     NotificationCtr(new NotificationCenter()) {
+  // Should be called last after everything is initialized.
+  SwiftLang = LangSupportFactoryFn(*this);
 }
 
 SourceKit::Context::~Context() {

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -13,6 +13,7 @@
 #include "SwiftLangSupport.h"
 #include "SwiftASTManager.h"
 #include "SourceKit/Core/Context.h"
+#include "SourceKit/SwiftLang/Factory.h"
 #include "SourceKit/Support/UIdent.h"
 
 #include "swift/AST/AST.h"
@@ -151,7 +152,7 @@ static UIdent KindStructureElemTypeRef("source.lang.swift.structure.elem.typeref
 
 
 std::unique_ptr<LangSupport>
-LangSupport::createSwiftLangSupport(SourceKit::Context &SKCtx) {
+SourceKit::createSwiftLangSupport(SourceKit::Context &SKCtx) {
   return std::unique_ptr<LangSupport>(new SwiftLangSupport(SKCtx));
 }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -55,6 +55,7 @@ namespace SourceKit {
   typedef RefPtr<ImmutableTextSnapshot> ImmutableTextSnapshotRef;
   class SwiftASTManager;
   class SwiftLangSupport;
+  class Context;
 
 class SwiftEditorDocument :
     public ThreadSafeRefCountedBase<SwiftEditorDocument> {

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -21,6 +21,7 @@
 #include "SourceKit/Support/Concurrency.h"
 #include "SourceKit/Support/Logging.h"
 #include "SourceKit/Support/UIdent.h"
+#include "SourceKit/SwiftLang/Factory.h"
 
 #include "swift/Basic/DemangleWrappers.h"
 
@@ -132,7 +133,8 @@ static void onDocumentUpdateNotification(StringRef DocumentName) {
 static SourceKit::Context *GlobalCtx = nullptr;
 
 void sourcekitd::initialize() {
-  GlobalCtx = new SourceKit::Context(sourcekitd::getRuntimeLibPath());
+  GlobalCtx = new SourceKit::Context(sourcekitd::getRuntimeLibPath(),
+                                     SourceKit::createSwiftLangSupport);
   GlobalCtx->getNotificationCenter().addDocumentUpdateNotificationReceiver(
     onDocumentUpdateNotification);
 }

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -14,6 +14,7 @@
 #include "SourceKit/Core/LangSupport.h"
 #include "SourceKit/Core/NotificationCenter.h"
 #include "SourceKit/Support/Concurrency.h"
+#include "SourceKit/SwiftLang/Factory.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "gtest/gtest.h"
@@ -94,7 +95,7 @@ struct TestCursorInfo {
 };
 
 class CursorInfoTest : public ::testing::Test {
-  SourceKit::Context Ctx{ getRuntimeLibPath() };
+  SourceKit::Context Ctx{ getRuntimeLibPath(), SourceKit::createSwiftLangSupport };
   std::atomic<int> NumTasks;
 
 public:


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

SourceKit's `SwiftLang` (`SwiftLangSupport` class) and `Core` (`Context` class) libraries currently depend on each other. At @jrose-apple's suggestion, I have broken this coupling by requiring `SwiftLangSupport` to be injected into `Context`.

See also: https://github.com/apple/swift/pull/3080

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
