### PR TITLE
[CodeCompletion] Add image and color literals to results

### DIFF
--- a/test/SourceKit/CodeComplete/complete_literals.swift
+++ b/test/SourceKit/CodeComplete/complete_literals.swift
@@ -1,10 +1,23 @@
 ()
-// RUN: %sourcekitd-test -req=complete -pos=1:2 %s -- %s | FileCheck %s -check-prefix=KEYWORDS
-// RUN: %sourcekitd-test -req=complete.open -pos=1:2 %s -- %s | FileCheck %s -check-prefix=LITERALS
+let var1 = 1
+let var2: Int = 1
+// XFAIL: broken_std_regex
+// RUN: %sourcekitd-test -req=complete -pos=1:2 %s -- %s | FileCheck %s -check-prefix=COMPLETE_1
+// RUN: %sourcekitd-test -req=complete -pos=2:12 %s -- %s | FileCheck %s -check-prefix=COMPLETE_1
+// RUN: %sourcekitd-test -req=complete -pos=3:17 %s -- %s | FileCheck %s -check-prefix=COMPLETE_2
 
-// KEYWORDS-NOT: source.lang.swift.literal
-// KEYWORDS: key.name: "nil"
-// KEYWORDS-NOT: source.lang.swift.literal
+// COMPLETE_1-NOT: source.lang.swift.literal
+// COMPLETE_1: source.lang.swift.literal.color
+// COMPLETE_1: source.lang.swift.literal.image
+// COMPLETE_1-NOT: source.lang.swift.literal
+// COMPLETE_1: key.name: "nil"
+// COMPLETE_1-NOT: source.lang.swift.literal
+
+// COMPLETE_2-NOT: source.lang.swift.literal
+// COMPLETE_2: key.name: "nil"
+// COMPLETE_2-NOT: source.lang.swift.literal
+
+// RUN: %sourcekitd-test -req=complete.open -pos=1:2 %s -- %s | FileCheck %s -check-prefix=LITERALS
 // LITERALS: key.kind: source.lang.swift.literal.string
 // LITERALS: key.sourcetext: "\"<#{{.*}}#>\""
 // LITERALS: key.kind: source.lang.swift.literal.boolean

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -61,12 +61,12 @@ struct SwiftToSourceKitCompletionAdapter {
 
     Completion extended(*result, name, description);
     return handleResult(consumer, &extended, /*leadingPunctuation=*/false,
-                        /*includeLiterals=*/false);
+                        /*legacyLiteralToKeyword=*/true);
   }
 
   static bool handleResult(SourceKit::CodeCompletionConsumer &consumer,
                            Completion *result, bool leadingPunctuation,
-                           bool includeLiterals);
+                           bool legacyLiteralToKeyword);
 
   static void getResultSourceText(const CodeCompletionString *CCStr,
                                   raw_ostream &OS);
@@ -219,9 +219,29 @@ void SwiftLangSupport::codeComplete(llvm::MemoryBuffer *UnresolvedInputFile,
                                     SourceKit::CodeCompletionConsumer &SKConsumer,
                                     ArrayRef<const char *> Args) {
   SwiftCodeCompletionConsumer SwiftConsumer([&](
-      MutableArrayRef<CodeCompletionResult *> Results, SwiftCompletionInfo &) {
+      MutableArrayRef<CodeCompletionResult *> Results,
+      SwiftCompletionInfo &info) {
+    bool hasExpectedType = info.completionContext->HasExpectedTypeRelation;
     CodeCompletionContext::sortCompletionResults(Results);
+    // FIXME: this adhoc filtering should be configurable like it is in the
+    // codeCompleteOpen path.
     for (auto *Result : Results) {
+      if (Result->getKind() == CodeCompletionResult::Literal) {
+        switch (Result->getLiteralKind()) {
+        case CodeCompletionLiteralKind::NilLiteral:
+        case CodeCompletionLiteralKind::BooleanLiteral:
+          break;
+        case CodeCompletionLiteralKind::ImageLiteral:
+        case CodeCompletionLiteralKind::ColorLiteral:
+          if (hasExpectedType &&
+              Result->getExpectedTypeRelation() <
+                  CodeCompletionResult::Convertible)
+            continue;
+          break;
+        default:
+          continue;
+        }
+      }
       if (!SwiftToSourceKitCompletionAdapter::handleResult(SKConsumer, Result))
         break;
     }
@@ -410,7 +430,7 @@ static UIdent KeywordFuncUID("source.lang.swift.keyword.func");
 
 bool SwiftToSourceKitCompletionAdapter::handleResult(
     SourceKit::CodeCompletionConsumer &Consumer, Completion *Result,
-    bool leadingPunctuation, bool includeLiterals) {
+    bool leadingPunctuation, bool legacyLiteralToKeyword) {
 
   static UIdent KeywordUID("source.lang.swift.keyword");
   static UIdent PatternUID("source.lang.swift.pattern");
@@ -428,14 +448,14 @@ bool SwiftToSourceKitCompletionAdapter::handleResult(
     Info.Kind = SwiftLangSupport::getUIDForCodeCompletionDeclKind(
         Result->getAssociatedDeclKind());
   } else if (Result->getKind() == CodeCompletionResult::Literal) {
-    if (includeLiterals) {
-      Info.Kind = getUIDForCodeCompletionLiteralKind(Result->getLiteralKind());
-    } else if (Result->getLiteralKind() ==
-                   CodeCompletionLiteralKind::BooleanLiteral ||
-               Result->getLiteralKind() ==
-                   CodeCompletionLiteralKind::NilLiteral) {
-      // If we're not including literals, fallback to keywords as appropriate.
+    auto literalKind = Result->getLiteralKind();
+    if (legacyLiteralToKeyword &&
+        (literalKind == CodeCompletionLiteralKind::BooleanLiteral ||
+         literalKind == CodeCompletionLiteralKind::NilLiteral)) {
+      // Fallback to keywords as appropriate.
       Info.Kind = KeywordUID;
+    } else {
+      Info.Kind = getUIDForCodeCompletionLiteralKind(literalKind);
     }
   }
 
@@ -761,7 +781,7 @@ public:
   bool handleResult(Completion *result) override {
     return SwiftToSourceKitCompletionAdapter::handleResult(
         consumer, result, /*leadingPunctuation=*/true,
-        /*includeLiterals=*/true);
+        /*legacyLiteralToKeyword=*/false);
   }
   void startGroup(StringRef name) override {
     static UIdent GroupUID("source.lang.swift.codecomplete.group");


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Surface these results in the codecomplete code path (they're already
there in the codecomplete.open code path) so we can use them from IDEs.
For now, just use ad-hoc filtering to show them when the type matches
(or there is no expected type).  Ideally we would make this filtering
configurable like we do in the codecomplete.open code path.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

rdar://problem/25836544

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
