### PR TITLE
Swift 2.3: Try to ensure we generate unique trap locations.

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -19,6 +19,7 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/InlineAsm.h"
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SmallBitVector.h"
@@ -316,6 +317,7 @@ public:
   llvm::SmallDenseMap<StackSlotKey, Address, 8> ShadowStackSlots;
   llvm::SmallDenseMap<Decl *, SmallString<4>, 8> AnonymousVariables;
   unsigned NumAnonVars = 0;
+  unsigned NumCondFails = 0;
 
   /// Accumulative amount of allocated bytes on the stack. Used to limit the
   /// size for stack promoted objects.
@@ -4571,6 +4573,22 @@ void IRGenSILFunction::visitCondFailInst(swift::CondFailInst *i) {
   llvm::BasicBlock *contBB = llvm::BasicBlock::Create(IGM.getLLVMContext());
   Builder.CreateCondBr(cond, failBB, contBB);
   Builder.emitBlock(failBB);
+
+  // Emit unique side-effecting inline asm calls in order to eliminate
+  // the possibility that an LLVM optimization or code generation pass
+  // will merge these blocks back together again. We emit an empty asm
+  // string with the side-effect flag set, and with a unique integer
+  // argument for each cond_fail we see in the function.
+  llvm::IntegerType *asmArgTy = IGM.Int32Ty;
+  llvm::Type *argTys = { asmArgTy };
+  llvm::FunctionType *asmFnTy =
+    llvm::FunctionType::get(IGM.VoidTy, argTys, false /* = isVarArg */);
+  llvm::InlineAsm *inlineAsm =
+    llvm::InlineAsm::get(asmFnTy, "", "n", true /* = SideEffects */);
+  Builder.CreateCall(inlineAsm,
+                     llvm::ConstantInt::get(asmArgTy, NumCondFails++));
+
+  // Emit the trap instruction.
   llvm::Function *trapIntrinsic =
       llvm::Intrinsic::getDeclaration(&IGM.Module, llvm::Intrinsic::ID::trap);
   Builder.CreateCall(trapIntrinsic, {});

--- a/test/IRGen/condfail.sil
+++ b/test/IRGen/condfail.sil
@@ -1,15 +1,22 @@
-// RUN: %target-swift-frontend -primary-file %s -g -emit-ir  | FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -O -g -S  | FileCheck %s --check-prefix=CHECK-%target-cpu
 
 import Builtin
 import Swift
 
 // Make sure we emit two traps.
 
-// CHECK-LABEL: define {{.*}} @test_cond_fail({{.*}}) {{.*}} {
-// CHECK:  call void @llvm.trap()
-// CHECK:  call void @llvm.trap()
-// CHECK: }
-
+// CHECK-LABEL:  _test_cond_fail:
+// CHECK:        .cfi_startproc
+// CHECK-x86_64: ud2
+// CHECK-i386:   ud2
+// CHECK-arm64:  brk
+// CHECK-armv7:  trap
+// CHECK-NOT:    .cfi_endproc
+// CHECK-x86_64: ud2
+// CHECK-i386:   ud2
+// CHECK-arm64:  brk
+// CHECK-armv7:  trap
+// CHECK:        .cfi_endproc
 sil hidden @test_cond_fail : $@convention(thin) (Int32) -> Int32 {
 bb0(%0 : $Int32):
   %2 = integer_literal $Builtin.Int32, 1
@@ -20,8 +27,9 @@ bb0(%0 : $Int32):
   %7 = tuple_extract %5 : $(Builtin.Int32, Builtin.Int1), 1
   cond_fail %7 : $Builtin.Int1
   %8 = builtin "sadd_with_overflow_Int32"(%6 : $Builtin.Int32, %2 : $Builtin.Int32, %4 : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1)
-  %9 = tuple_extract %5 : $(Builtin.Int32, Builtin.Int1), 1
-  cond_fail %9 : $Builtin.Int1
-  %10 = struct $Int32 (%6 : $Builtin.Int32)
-  return %10 : $Int32
+  %9 = tuple_extract %8 : $(Builtin.Int32, Builtin.Int1), 0
+  %10 = tuple_extract %8 : $(Builtin.Int32, Builtin.Int1), 1
+  cond_fail %10 : $Builtin.Int1
+  %11 = struct $Int32 (%9 : $Builtin.Int32)
+  return %11 : $Int32
 }


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?
- **Explanation:** We generate individual trap blocks for trapping locations, but LLVM merges these together, making it impossible to do post-mortem examination and determine why a failure happens. This change, cherry-picked from Swift 3.0, attempts to block LLVMs merging of these blocks, resulting in unique trap locations and the correspondingly correct debug information, making it more likely for a user to determine the source of a failure.
- **Scope:** Very limited. The only effect is a modification of the IR generated for SIL's cond_fail instruction.
- **Issue:** rdar://problem/26924765
- **Risk:** Very low. We shipped this in Swift 3.0 beta 1, and it's had significant bake-time with no reported issues.
- **Testing:** New regression test to ensure we generate unique blocks.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

In 2e3c0b6, code was added to emit unique trap blocks for each
cond_fail, in order to make post-mortem debugging simpler (e.g. stack
traces have correct line/column information for the trapping location,
and it's easy to trace back to the specific jump that reaches the trap).

We didn't, however, do anything to ensure that LLVM wouldn't merge these
back together again. This is an attempt to do exactly that, after seeing
BranchFolding in the code generator merging traps into a single block.

The idea here is to emit empty inline asm strings marked as
side-effecting, and taking a unique integer argument. These come before
the trap call, so they should block any valid attempt at merging the
blocks back together.

Ideally trap would take an argument which uniquely identifies it, but
that isn't possible today.

This solution is potentially brittle in that in theory LLVM could still
merge the trap/unreachable and then branch to those after the unique asm
calls. We cannot fix that by putting another asm call after the trap,
because LLVM's CFG simplification will delete code after a trap.

rdar://problem/25216969
(cherry picked from commit b21a9e7fd0d8425195e24c61c7efbe2f9e071552)
