### PR TITLE
[Fixit] Provide fixit when converting expressions of type T to [T] or…

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3480,8 +3480,7 @@ bool FailureDiagnosis::diagnoseContextualConversionError() {
   // When converting from T to [T] or UnsafePointer<T>, we can offer fixit to wrap
   // the expr with brackets.
   if (auto *contextDecl = contextualType->getAnyNominal()) {
-    if (contextDecl == CS->TC.Context.getArrayDecl() ||
-        contextDecl == CS->TC.Context.getUnsafePointerDecl()) {
+    if (contextDecl == CS->TC.Context.getArrayDecl()) {
       SmallVector<Type, 4> scratch;
       for (Type arg : contextualType->getAllGenericArgs(scratch)) {
         if (arg->isEqual(exprType)) {
@@ -3489,6 +3488,15 @@ bool FailureDiagnosis::diagnoseContextualConversionError() {
             fixItInsert(expr->getStartLoc(), "[").fixItInsert(
               Lexer::getLocForEndOfToken(CS->TC.Context.SourceMgr,
                                          expr->getEndLoc()), "]");
+          return true;
+        }
+      }
+    } else if (contextDecl == CS->TC.Context.getUnsafePointerDecl()) {
+      SmallVector<Type, 4> scratch;
+      for (Type arg : contextualType->getAllGenericArgs(scratch)) {
+        if (arg->isEqual(exprType)) {
+          diagnose(expr->getLoc(), diagID, exprType, contextualType).
+            fixItInsert(expr->getStartLoc(), "&");
           return true;
         }
       }

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3491,7 +3491,8 @@ bool FailureDiagnosis::diagnoseContextualConversionError() {
           return true;
         }
       }
-    } else if (contextDecl == CS->TC.Context.getUnsafePointerDecl()) {
+    } else if (contextDecl == CS->TC.Context.getUnsafePointerDecl() ||
+               contextDecl == CS->TC.Context.getUnsafeMutablePointerDecl()) {
       SmallVector<Type, 4> scratch;
       for (Type arg : contextualType->getAllGenericArgs(scratch)) {
         if (arg->isEqual(exprType)) {

--- a/test/Sema/diag_type_conversion.swift
+++ b/test/Sema/diag_type_conversion.swift
@@ -2,9 +2,11 @@
 
 func foo1(_ a: [Int]) {}
 func foo2(_ a : UnsafePointer<Int>) {}
+func foo4(_ a : UnsafeMutablePointer<Int>) {}
 func foo3 () {
   foo1(1) // expected-error {{cannot convert value of type 'Int' to expected argument type '[Int]'}} {{8-8=[}} {{9-9=]}}
   foo2(1) // expected-error {{cannot convert value of type 'Int' to expected argument type 'UnsafePointer<Int>'}} {{8-8=&}}
   var j = 3
   foo2(j) // expected-error {{cannot convert value of type 'Int' to expected argument type 'UnsafePointer<Int>'}} {{8-8=&}}
+  foo4(j) // expected-error {{cannot convert value of type 'Int' to expected argument type 'UnsafeMutablePointer<Int>'}} {{8-8=&}}
 }

--- a/test/Sema/diag_type_conversion.swift
+++ b/test/Sema/diag_type_conversion.swift
@@ -4,5 +4,7 @@ func foo1(_ a: [Int]) {}
 func foo2(_ a : UnsafePointer<Int>) {}
 func foo3 () {
   foo1(1) // expected-error {{cannot convert value of type 'Int' to expected argument type '[Int]'}} {{8-8=[}} {{9-9=]}}
-  foo2(1) // expected-error {{cannot convert value of type 'Int' to expected argument type 'UnsafePointer<Int>'}} {{8-8=[}} {{9-9=]}}
+  foo2(1) // expected-error {{cannot convert value of type 'Int' to expected argument type 'UnsafePointer<Int>'}} {{8-8=&}}
+  var j = 3
+  foo2(j) // expected-error {{cannot convert value of type 'Int' to expected argument type 'UnsafePointer<Int>'}} {{8-8=&}}
 }

--- a/test/Sema/diag_type_conversion.swift
+++ b/test/Sema/diag_type_conversion.swift
@@ -1,0 +1,8 @@
+// RUN: %target-parse-verify-swift
+
+func foo1(_ a: [Int]) {}
+func foo2(_ a : UnsafePointer<Int>) {}
+func foo3 () {
+  foo1(1) // expected-error {{cannot convert value of type 'Int' to expected argument type '[Int]'}} {{8-8=[}} {{9-9=]}}
+  foo2(1) // expected-error {{cannot convert value of type 'Int' to expected argument type 'UnsafePointer<Int>'}} {{8-8=[}} {{9-9=]}}
+}


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->

This another fixit I found useful when helping developers migrate. When an expected argument is of type [T] or UnsafePointer<T>, however the developer feeds an expression of Type T, the fixit adds brackets to the expression.

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

… UnsafePointer<T>.
