### PR TITLE
[CodeCompletion] Fix a crash when completing typealiases for protocol…

### DIFF
--- a/test/SourceKit/CodeComplete/complete_structure.swift
+++ b/test/SourceKit/CodeComplete/complete_structure.swift
@@ -7,6 +7,7 @@
 // RUN: %complete-test %s -group=none -fuzz -structure -tok=OVERRIDE_0 | FileCheck %s -check-prefix=OVERRIDE_0
 // RUN: %complete-test %s -group=none -fuzz -structure -tok=S1_INNER_0 | FileCheck %s -check-prefix=S1_INNER_0
 // RUN: %complete-test %s -group=none -fuzz -structure -tok=INT_INNER_0 | FileCheck %s -check-prefix=INT_INNER_0
+// RUN: %complete-test %s -group=none -fuzz -structure -tok=ASSOCIATED_TYPE_1 | FileCheck %s -check-prefix=ASSOCIATED_TYPE_1
 
 struct S1 {
   func method1() {}
@@ -119,3 +120,11 @@ func test9(_ x: inout Int) {
 // INT_INNER_0: {name:x++}
 // INT_INNER_0: {name:x>>}
 // INT_INNER_0: {name:x..<}
+
+protocol P1 {
+  associatedtype T
+}
+struct S2: P1 {
+  #^ASSOCIATED_TYPE_1^#
+}
+// ASSOCIATED_TYPE_1: {name:T = }{params:{l:Type}}

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -372,7 +372,7 @@ static void getResultStructure(
       if (!param.range().empty())
         parameters.push_back(std::move(param));
 
-      if (chunks[i].hasText())
+      if (i < chunks.size() && chunks[i].hasText())
         textSize += chunks[i].getText().size();
     }
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

… conformance

The index may be at the end of the ArrayRef of chunks if the completion
ends with a simple parameter with no type annotation.  Check that the
index is in-bounds before adding text.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

rdar://problem/26273906

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
