### PR TITLE
Re-add the optional overload for atomic ptr swaps

### DIFF
--- a/stdlib/public/core/Runtime.swift.gyb
+++ b/stdlib/public/core/Runtime.swift.gyb
@@ -36,6 +36,7 @@ func _stdlib_atomicCompareExchangeStrongPtrImpl(
   return Bool(won)
 }
 
+% for optional in ['', '?']:
 /// Atomic compare and exchange of `UnsafeMutablePointer<T>` with sequentially
 /// consistent memory ordering.  Precise semantics are defined in C++11 or C11.
 ///
@@ -66,14 +67,15 @@ func _stdlib_atomicCompareExchangeStrongPtrImpl(
 @_transparent
 public // @testable
 func _stdlib_atomicCompareExchangeStrongPtr<T>(
-  object target: UnsafeMutablePointer<UnsafeMutablePointer<T>>,
-  expected: UnsafeMutablePointer<UnsafeMutablePointer<T>>,
-  desired: UnsafeMutablePointer<T>) -> Bool {
+  object target: UnsafeMutablePointer<UnsafeMutablePointer<T>${optional}>,
+  expected: UnsafeMutablePointer<UnsafeMutablePointer<T>${optional}>,
+  desired: UnsafeMutablePointer<T>${optional}) -> Bool {
   return _stdlib_atomicCompareExchangeStrongPtrImpl(
     object: UnsafeMutablePointer(target),
     expected: UnsafeMutablePointer(expected),
     desired: UnsafeMutablePointer(desired))
 }
+% end
 
 @_transparent
 @discardableResult

--- a/test/1_stdlib/Runtime.swift.gyb
+++ b/test/1_stdlib/Runtime.swift.gyb
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t  &&  mkdir %t
 //
-// RUN: %target-build-swift -parse-stdlib -module-name a %s -o %t.out
+// RUN: %gyb %s -o %t/Runtime.swift
+// RUN: %target-build-swift -parse-stdlib -module-name a %t/Runtime.swift -o %t.out
 // RUN: %target-run %t.out
 // REQUIRES: executable_test
 
@@ -356,11 +357,12 @@ Runtime.test("demangleName") {
   expectEqual("Foobar", _stdlib_demangleName("_TtC13__lldb_expr_46Foobar"))
 }
 
+% for optionality in ['', '?']:
 Runtime.test("_stdlib_atomicCompareExchangeStrongPtr") {
   typealias IntPtr = UnsafeMutablePointer<Int>
-  var origP1 = IntPtr(bitPattern: 0x10101010)!
-  var origP2 = IntPtr(bitPattern: 0x20202020)!
-  var origP3 = IntPtr(bitPattern: 0x30303030)!
+  var origP1: IntPtr${optionality} = IntPtr(bitPattern: 0x10101010)!
+  var origP2: IntPtr${optionality} = IntPtr(bitPattern: 0x20202020)!
+  var origP3: IntPtr${optionality} = IntPtr(bitPattern: 0x30303030)!
 
   do {
     var object = origP1
@@ -383,17 +385,17 @@ Runtime.test("_stdlib_atomicCompareExchangeStrongPtr") {
 
   struct FooStruct {
     var i: Int
-    var object: IntPtr
-    var expected: IntPtr
+    var object: IntPtr${optionality}
+    var expected: IntPtr${optionality}
 
-    init(_ object: IntPtr, _ expected: IntPtr) {
+    init(object: IntPtr${optionality}, expected: IntPtr${optionality}) {
       self.i = 0
       self.object = object
       self.expected = expected
     }
   }
   do {
-    var foo = FooStruct(origP1, origP1)
+    var foo = FooStruct(object: origP1, expected: origP1)
     let r = _stdlib_atomicCompareExchangeStrongPtr(
       object: &foo.object, expected: &foo.expected, desired: origP2)
     expectTrue(r)
@@ -401,7 +403,7 @@ Runtime.test("_stdlib_atomicCompareExchangeStrongPtr") {
     expectEqual(origP1, foo.expected)
   }
   do {
-    var foo = FooStruct(origP1, origP2)
+    var foo = FooStruct(object: origP1, expected: origP2)
     let r = _stdlib_atomicCompareExchangeStrongPtr(
       object: &foo.object, expected: &foo.expected, desired: origP3)
     expectFalse(r)
@@ -409,6 +411,7 @@ Runtime.test("_stdlib_atomicCompareExchangeStrongPtr") {
     expectEqual(origP1, foo.expected)
   }
 }
+% end
 
 Runtime.test("casting AnyObject to class metatypes") {
   do {


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

@gribozavr Noticed the optional overload for `_stdlib_atomicCompareExchangeStrongPtr` was missing.  Let's gyb it back in.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
