### PR TITLE
[Driver] Link arclite on iOS 8 and OS X 10.10.

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -996,11 +996,9 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
   // we wouldn't have to replicate Clang's logic here.
   bool wantsObjCRuntime = false;
   if (Triple.isiOS())
-    wantsObjCRuntime = Triple.isOSVersionLT(8);
-  else if (Triple.isWatchOS())
-    wantsObjCRuntime = Triple.isOSVersionLT(2);
+    wantsObjCRuntime = Triple.isOSVersionLT(9);
   else if (Triple.isMacOSX())
-    wantsObjCRuntime = Triple.isMacOSXVersionLT(10, 10);
+    wantsObjCRuntime = Triple.isMacOSXVersionLT(10, 11);
 
   if (context.Args.hasFlag(options::OPT_link_objc_runtime,
                            options::OPT_no_link_objc_runtime,

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -35,8 +35,18 @@
 // RUN: FileCheck -check-prefix COMPLEX %s < %t.complex.txt
 
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 -g %s | FileCheck -check-prefix DEBUG %s
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.10   %s | FileCheck -check-prefix NO_ARCLITE %s
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-ios8.0        %s | FileCheck -check-prefix NO_ARCLITE %s
+
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.10   %s > %t.simple-macosx10.10.txt
+// RUN: FileCheck %s < %t.simple-macosx10.10.txt
+// RUN: FileCheck -check-prefix SIMPLE %s < %t.simple-macosx10.10.txt
+
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-ios8.0        %s > %t.simple-ios8.txt
+// RUN: FileCheck -check-prefix IOS_ARCLITE %s < %t.simple-ios8.txt
+
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.11   %s | FileCheck -check-prefix NO_ARCLITE %s
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-ios9.0        %s | FileCheck -check-prefix NO_ARCLITE %s
+// RUN: %swiftc_driver -driver-print-jobs -target arm64-apple-tvos9.0        %s | FileCheck -check-prefix NO_ARCLITE %s
+// RUN: %swiftc_driver -driver-print-jobs -target armv7k-apple-watchos2.0    %s | FileCheck -check-prefix NO_ARCLITE %s
 
 // RUN: rm -rf %t && mkdir %t
 // RUN: touch %t/a.o
@@ -224,6 +234,12 @@
 // DEBUG-NEXT: bin/dsymutil
 // DEBUG: linker
 // DEBUG: -o linker.dSYM
+
+
+
+// IOS_ARCLITE: bin/ld{{"? }}
+// IOS_ARCLITE: -force_load {{[^ ]+/lib/arc/libarclite_iphonesimulator.a}}
+// IOS_ARCLITE: -o {{[^ ]+}}
 
 // NO_ARCLITE: bin/ld{{"? }}
 // NO_ARCLITE-NOT: arclite


### PR DESCRIPTION
Noticed by inspection. Xcode doesn't use swiftc to link, and the few things that went into arclite between iOS 7 and iOS 8 weren't critical, but we should still get this right.

("arclite" is a static library that provides backwards-deployment support for Objective-C and a few Foundation features)

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
