### PR TITLE
[SR-1724][Lexer] Handle hex letters after '.' on hex number literal

### DIFF
--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -324,6 +324,12 @@ func tuple_of_rvalues(_ a:Int, b:Int) -> Int {
 extension Int {
   func testLexingMethodAfterIntLiteral() {}
   func _0() {}
+  // Hex letters + non hex.
+  func describe() {}
+  // Hex letters + 'p'.
+  func eap() {}
+  // Hex letters + 'p' + non hex.
+  func fpValue() {}
 }
 
 123.testLexingMethodAfterIntLiteral()
@@ -335,6 +341,10 @@ extension Int {
 0b101._0()
 0o123._0()
 0x1FFF._0()
+
+0x1FFF.describe()
+0x1FFF.eap()
+0x1FFF.fpValue()
 
 var separator1: Int = 1_
 var separator2: Int = 1_000


### PR DESCRIPTION
#### What's in this pull request?

This case used to emit an error:

```
extension Int {
    var asUiColor: UIColor { ... }
}
0xfff.asUiColor
```

If `[a-fA-F]` follows `.`, it can be valid int literal followed by dot expression: e.g. `0xff.description`, `0xff.fpValue`
#### Resolved bug number: ([SR-1724](https://bugs.swift.org/browse/SR-1724))

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>
