### PR TITLE
[swiftc] Add 💥 case (😢 → 46, 😀 → 5089) triggered in swift::TypeBase::getCanonicalType(…)

### DIFF
--- a/validation-test/compiler_crashers/28325-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28325-swift-typebase-getcanonicaltype.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+{extension{let h{B{}{var _=super.i


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Add crash case with stack trace:

```
4  swift           0x0000000001108734 swift::TypeBase::getCanonicalType() + 20
8  swift           0x000000000105534e swift::Expr::walk(swift::ASTWalker&) + 46
9  swift           0x0000000000f73028 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) + 200
10 swift           0x0000000000e891c3 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 371
11 swift           0x0000000000e8fb02 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
12 swift           0x0000000000e90cb7 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 343
13 swift           0x0000000000e90ecb swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
16 swift           0x0000000000ea1586 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
19 swift           0x0000000000f08704 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
20 swift           0x0000000000f3444c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
21 swift           0x0000000000e8fba1 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 769
24 swift           0x0000000000f0738a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
25 swift           0x0000000000f071ee swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
26 swift           0x0000000000f07db3 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
28 swift           0x0000000000ec3831 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
29 swift           0x0000000000c59299 swift::CompilerInstance::performSema() + 3289
31 swift           0x00000000007d72b9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
32 swift           0x00000000007a32c8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28325-swift-typebase-getcanonicaltype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28325-swift-typebase-getcanonicaltype-2ce21e.o
1.  While type-checking getter for h at validation-test/compiler_crashers/28325-swift-typebase-getcanonicaltype.swift:9:17
2.  While type-checking expression at [validation-test/compiler_crashers/28325-swift-typebase-getcanonicaltype.swift:9:21 - line:9:34] RangeText="{var _=super.i"
3.  While type-checking declaration 0x6522900 at validation-test/compiler_crashers/28325-swift-typebase-getcanonicaltype.swift:9:22
4.  While type-checking expression at [validation-test/compiler_crashers/28325-swift-typebase-getcanonicaltype.swift:9:28 - line:9:34] RangeText="super.i"
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
