### PR TITLE
[Validation-Test] Fix some compiler crashers

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6487,6 +6487,11 @@ void TypeChecker::validateDecl(ValueDecl *D, bool resolveTypeParams) {
       }
     }
 
+    // No sense diagnosing type errors for an invalid protocol.
+    if (proto->isInvalid()) {
+      return;
+    }
+
     // If the protocol is @objc, it may only refine other @objc protocols.
     // FIXME: Revisit this restriction.
     if (proto->getAttrs().hasAttribute<ObjCAttr>()) {

--- a/validation-test/compiler_crashers_fixed/28319-swift-typechecker-checkconformance.swift
+++ b/validation-test/compiler_crashers_fixed/28319-swift-typechecker-checkconformance.swift
@@ -5,6 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
-extension{protocol c{struct c{let e={enum T{case
+protocol A{enum B:A{let:e var _=B}typealias e

--- a/validation-test/compiler_crashers_fixed/28320-swift-archetypebuilder-enumeraterequirements.swift
+++ b/validation-test/compiler_crashers_fixed/28320-swift-archetypebuilder-enumeraterequirements.swift
@@ -5,6 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
-protocol A{enum B:A{let:e var _=B}typealias e
+extension{protocol c{struct c{let e={enum T{case

--- a/validation-test/compiler_crashers_fixed/28321-swift-constraints-constraintsystem-resolveoverload.swift
+++ b/validation-test/compiler_crashers_fixed/28321-swift-constraints-constraintsystem-resolveoverload.swift
@@ -5,7 +5,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
 class B:A.a
 protocol A{class a

--- a/validation-test/compiler_crashers_fixed/28323-swift-typebase-getstring.swift
+++ b/validation-test/compiler_crashers_fixed/28323-swift-typebase-getstring.swift
@@ -5,6 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
-protocol a{extension{@objc protocol A:a
+{protocol e{typealias e enum b{case func a{{enum B:e

--- a/validation-test/compiler_crashers_fixed/28324-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/28324-swift-diagnosticengine-emitdiagnostic.swift
@@ -5,6 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend -parse %s
 // REQUIRES: asserts
-{protocol e{typealias e enum b{case func a{{enum B:e
+protocol a{extension{@objc protocol A:a


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

When diagnosing bad protocols, if the underlying type was invalid, we would dereference a null pointer when we went to produce diagnostics.  Instead, we need to cut off diagnostic production before we emit the more semantically meaningful ones for protocols with valid types.  Notably, this provides a fix for the recently-introduced #3109.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
