### PR TITLE
[llvm-config-removal] Instead of maintaining our own LLVM_LIBRARY_DIR…

### DIFF
--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -117,10 +117,6 @@ macro(swift_common_standalone_build_config product is_cross_compiling)
   if(${is_cross_compiling})
     # Can't run llvm-config from the cross-compiled LLVM.
     set(LLVM_TOOLS_BINARY_DIR "" CACHE PATH "Path to llvm/bin")
-    set(LLVM_LIBRARY_DIR "" CACHE PATH "Path to llvm/lib")
-    set(LLVM_MAIN_INCLUDE_DIR "" CACHE PATH "Path to llvm/include")
-    set(LLVM_BINARY_DIR "" CACHE PATH "Path to LLVM build tree")
-    set(LLVM_MAIN_SRC_DIR "" CACHE PATH "Path to LLVM source tree")
   else()
     # Rely on llvm-config.
     _swift_llvm_config_info(
@@ -138,10 +134,6 @@ macro(swift_common_standalone_build_config product is_cross_compiling)
     mark_as_advanced(LLVM_ENABLE_ASSERTIONS)
 
     set(LLVM_TOOLS_BINARY_DIR "${llvm_config_tools_binary_dir}" CACHE PATH "Path to llvm/bin")
-    set(LLVM_LIBRARY_DIR "${llvm_config_library_dir}" CACHE PATH "Path to llvm/lib")
-    set(LLVM_MAIN_INCLUDE_DIR "${llvm_config_include_dir}" CACHE PATH "Path to llvm/include")
-    set(LLVM_BINARY_DIR "${llvm_config_obj_root}" CACHE PATH "Path to LLVM build tree")
-    set(LLVM_MAIN_SRC_DIR "${llvm_config_src_dir}" CACHE PATH "Path to LLVM source tree")
 
     set(${product}_NATIVE_LLVM_TOOLS_PATH "${LLVM_TOOLS_BINARY_DIR}")
     set(${product}_NATIVE_CLANG_TOOLS_PATH "${LLVM_TOOLS_BINARY_DIR}")
@@ -174,6 +166,11 @@ macro(swift_common_standalone_build_config product is_cross_compiling)
   include(${LLVMCONFIG_FILE})
   set(LLVM_TOOLS_BINARY_DIR "${LLVM_TOOLS_BINARY_DIR_saved}")
   set(LLVM_ENABLE_ASSERTIONS "${LLVM_ENABLE_ASSERTIONS_saved}")
+
+  precondition_translate_flag(LLVM_BUILD_LIBRARY_DIR LLVM_LIBRARY_DIR)
+  precondition_translate_flag(LLVM_BUILD_MAIN_INCLUDE_DIR LLVM_MAIN_INCLUDE_DIR)
+  precondition_translate_flag(LLVM_BUILD_BINARY_DIR LLVM_BINARY_DIR)
+  precondition_translate_flag(LLVM_BUILD_MAIN_SRC_DIR LLVM_MAIN_SRC_DIR)
 
   # Clang
   set(${product}_PATH_TO_CLANG_SOURCE "${PATH_TO_LLVM_SOURCE}/tools/clang"

--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -111,6 +111,9 @@ endfunction()
 macro(swift_common_standalone_build_config product is_cross_compiling)
   option(LLVM_ENABLE_WARNINGS "Enable compiler warnings." ON)
 
+  precondition_translate_flag(${product}_PATH_TO_LLVM_SOURCE PATH_TO_LLVM_SOURCE)
+  precondition_translate_flag(${product}_PATH_TO_LLVM_BUILD PATH_TO_LLVM_BUILD)
+
   if(${is_cross_compiling})
     # Can't run llvm-config from the cross-compiled LLVM.
     set(LLVM_TOOLS_BINARY_DIR "" CACHE PATH "Path to llvm/bin")
@@ -148,8 +151,8 @@ macro(swift_common_standalone_build_config product is_cross_compiling)
     NO_DEFAULT_PATH)
 
   set(LLVM_CMAKE_PATHS
-      "${LLVM_BINARY_DIR}/share/llvm/cmake"
-      "${LLVM_BINARY_DIR}/lib/cmake/llvm")
+      "${PATH_TO_LLVM_BUILD}/share/llvm/cmake"
+      "${PATH_TO_LLVM_BUILD}/lib/cmake/llvm")
 
   set(LLVMCONFIG_FILE)
   foreach(CMAKE_PATH ${LLVM_CMAKE_PATHS})
@@ -173,15 +176,9 @@ macro(swift_common_standalone_build_config product is_cross_compiling)
   set(LLVM_ENABLE_ASSERTIONS "${LLVM_ENABLE_ASSERTIONS_saved}")
 
   # Clang
-  set(${product}_PATH_TO_LLVM_SOURCE "${LLVM_MAIN_SRC_DIR}")
-  set(${product}_PATH_TO_LLVM_BUILD "${LLVM_BINARY_DIR}")
-
-  set(PATH_TO_LLVM_SOURCE "${${product}_PATH_TO_LLVM_SOURCE}")
-  set(PATH_TO_LLVM_BUILD "${${product}_PATH_TO_LLVM_BUILD}")
-
-  set(${product}_PATH_TO_CLANG_SOURCE "${${product}_PATH_TO_LLVM_SOURCE}/tools/clang"
+  set(${product}_PATH_TO_CLANG_SOURCE "${PATH_TO_LLVM_SOURCE}/tools/clang"
       CACHE PATH "Path to Clang source code.")
-  set(${product}_PATH_TO_CLANG_BUILD "${${product}_PATH_TO_LLVM_BUILD}" CACHE PATH
+  set(${product}_PATH_TO_CLANG_BUILD "${PATH_TO_LLVM_BUILD}" CACHE PATH
     "Path to the directory where Clang was built or installed.")
 
   set(${product}_PATH_TO_CMARK_SOURCE "${${product}_PATH_TO_CMARK_SOURCE}"
@@ -217,11 +214,6 @@ macro(swift_common_standalone_build_config product is_cross_compiling)
   endif()
 
   list(APPEND CMAKE_MODULE_PATH "${${product}_PATH_TO_LLVM_BUILD}/share/llvm/cmake")
-
-  get_filename_component(PATH_TO_LLVM_BUILD "${${product}_PATH_TO_LLVM_BUILD}"
-    ABSOLUTE)
-  get_filename_component(PATH_TO_CLANG_BUILD "${${product}_PATH_TO_CLANG_BUILD}"
-    ABSOLUTE)
 
   set(LLVM_ABI_BREAKING_CHECKS "WITH_ASSERTS")
 

--- a/cmake/modules/SwiftTranslateFlag.cmake
+++ b/cmake/modules/SwiftTranslateFlag.cmake
@@ -1,3 +1,5 @@
+include(SwiftUtils)
+
 # Translate a yes/no variable to the presence of a given string in a
 # variable.
 #
@@ -20,3 +22,8 @@ macro(translate_flags prefix options)
   endforeach()
 endmacro()
 
+# Set ${outvar} to ${${invar}}, asserting if ${invar} is not set.
+function(precondition_translate_flag invar outvar)
+  precondition(${invar})
+  set(${outvar} "${${invar}}" PARENT_SCOPE)
+endfunction()

--- a/cmake/modules/SwiftUtils.cmake
+++ b/cmake/modules/SwiftUtils.cmake
@@ -1,0 +1,5 @@
+function(precondition var)
+  if (NOT ${var})
+    message(FATAL_ERROR "Error! Variable ${var} is false or not set!")
+  endif()
+endfunction()

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1836,10 +1836,6 @@ for host in "${ALL_HOSTS[@]}"; do
                     cmake_options=(
                         "${cmake_options[@]}"
                         -DLLVM_TOOLS_BINARY_DIR:PATH=$(build_directory ${host} llvm)/bin
-                        -DLLVM_LIBRARY_DIR:PATH=$(build_directory ${host} llvm)/lib
-                        -DLLVM_MAIN_INCLUDE_DIR:PATH=$(build_directory ${host} llvm)/include
-                        -DLLVM_BINARY_DIR:PATH=$(build_directory ${host} llvm)
-                        -DLLVM_MAIN_SRC_DIR:PATH="${LLVM_SOURCE_DIR}"
                     )
                 else
                     build_perf_testsuite_this_time=$(true_false "$(not ${SKIP_BUILD_BENCHMARKS})")
@@ -1862,10 +1858,6 @@ for host in "${ALL_HOSTS[@]}"; do
                     cmake_options=(
                         "${cmake_options[@]}"
                         -DLLVM_TOOLS_BINARY_DIR:PATH=/tmp/dummy
-                        -DLLVM_LIBRARY_DIR:PATH="${build_dir}"
-                        -DLLVM_MAIN_INCLUDE_DIR:PATH=/tmp/dummy
-                        -DLLVM_BINARY_DIR:PATH=$(build_directory ${host} llvm)
-                        -DLLVM_MAIN_SRC_DIR:PATH="${LLVM_SOURCE_DIR}"
                     )
                 fi
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…, use LLVM_BUILD_LIBRARY_DIR from LLVMConfig.cmake.

LLVM_LIBRARY_DIR is a variable that was added to enable build-script to find the
location of llvm's library dir even if

The reason why LLVM_LIBRARY_DIR variable was passed in from the command line
historically was b/c we did not use LLVMConfig.cmake and instead relied on
llvm-config. This meant when cross-compiling llvm, we could not get the llvm
build information via llvm-config.

LLVM_LIBRARY_DIR is meant to point to the the llvm library directory for the
LLVM that we just compiled. The only reason why it is set as an option when cross compiling is b/c a cross compiled

rdar://26154980
