### PR TITLE
shims: correct __swift_size_t for Windows

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -30,11 +30,17 @@ namespace swift { extern "C" {
 // This declaration is not universally correct.  We verify its correctness for
 // the current platform in the runtime code.
 #if defined(__linux__) && defined (__arm__) && !defined(__android__)
-typedef      int __swift_ssize_t;
+typedef           int __swift_ssize_t;
 #elif defined(_MSC_VER)
-typedef long long __swift_ssize_t;
+#if defined(_M_ARM) || defined(_M_IX86)
+typedef           int __swift_size_t;
+#elif defined(_M_X64)
+typedef long long int __swift_size_t;
 #else
-typedef long int __swift_ssize_t;
+#error unsupported machine type
+#endif
+#else
+typedef      long int __swift_ssize_t;
 #endif
 
 // General utilities <stdlib.h>


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Windows uses `unsigned int` for `__SIZE_TYPE__` on the 32-bit targets and `long
long unsigned int` for 64-bit targets.  Reflect this for the `__swift_size_t`
type definition.
