### PR TITLE
[Core Graphics] Disambiguate the CGContext PDF endPage

### DIFF
--- a/apinotes/CoreGraphics.apinotes
+++ b/apinotes/CoreGraphics.apinotes
@@ -386,9 +386,9 @@ Functions:
 - Name: CGPDFContextClose
   SwiftName: CGContext.closePDF(self:)
 - Name: CGPDFContextBeginPage
-  SwiftName: CGContext.beginPage(self:_:)
+  SwiftName: CGContext.beginPDFPage(self:_:)
 - Name: CGPDFContextEndPage
-  SwiftName: CGContext.endPage(self:)
+  SwiftName: CGContext.endPDFPage(self:)
 - Name: CGPDFContextAddDocumentMetadata
   SwiftName: CGContext.addDocumentMetadata(self:_:)
 - Name: CGPDFContextSetURLForRect


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Explanation:  We currently import CGPDFContext[Begin|End]Page as CGContext.[begin|end]Page, however this conflicts with the import of CGContext[Begin|End]Page. With this change, we will import CGPDFContext[Begin|End]Page as CGContext.[begin|end]PDFPage. Without this, any code trying to begin or end a PDF page would not compile.

Scope: Only affects people trying to call CGPDFContextBeginPage or CGPDFContextEndPage in Swift 3.

Issue: rdar://problem/26746287

Risk: Low. Anyone who was trying to begin or end PDF pages prior to this was unable to compile with Swift 3. Now they can.

Testing: Compiler test suite
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

This changes how we import CGPDFContextEndPage to be
CGContext.endPDFPage(), instead of .endPage() which conflicts with
another CGContext function. Also does .beginPDFPage() for consistency,
which is consistent with e.g. drawPDFPage().
