### PR TITLE
[PrintAsObjC] Put "copy" in the property decls for value types.

### DIFF
--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -437,6 +437,7 @@ public class NonObjCClass { }
 // CHECK-NEXT: - (BOOL)initGetter SWIFT_METHOD_FAMILY(none);
 // CHECK-NEXT: @property (nonatomic, setter=initSetter:) BOOL setterIsInit;
 // CHECK-NEXT: - (void)initSetter:(BOOL)newValue SWIFT_METHOD_FAMILY(none);
+// CHECK-NEXT: @property (nonatomic, copy) NSURL * _Nullable customValueTypeProp;
 // CHECK-NEXT: init
 // CHECK-NEXT: @end
 @objc class Properties {
@@ -542,6 +543,8 @@ public class NonObjCClass { }
     get { return true }
     @objc(initSetter:) set {}
   }
+
+  var customValueTypeProp: URL?
 }
 
 // CHECK-LABEL: @interface PropertiesOverridden


### PR DESCRIPTION
Bridged value types are implicitly copied as part of bridging, so we should be using `@property (copy)` instead of the default `assign` or `strong`.

This isn't 100% correct because it doesn't handle bridged types that _don't_ conform to NSCopying, but there aren't any of those today and there probably shouldn't be.

rdar://problem/26917017

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
