### PR TITLE
[stdlib] Stop copying the _ContiguousArrayBuffer when initializing an ArraySlice from a literal

### DIFF
--- a/stdlib/public/core/ArrayCast.swift
+++ b/stdlib/public/core/ArrayCast.swift
@@ -56,10 +56,10 @@ public func _arrayForceCast<SourceElement, TargetElement>(
       if _fastPath(native!.storesOnlyElementsOfType(TargetElement.self)) {
         // A native buffer that is known to store only elements of the
         // TargetElement can be used directly
-        return Array(source._buffer.cast(toBufferOf: TargetElement.self))
+        return Array(_buffer: source._buffer.cast(toBufferOf: TargetElement.self))
       }
       // Other native buffers must use deferred element type checking
-      return Array(
+      return Array(_buffer:
         source._buffer.downcast(
           toBufferWithDeferredTypeCheckOf: TargetElement.self))
     }
@@ -90,7 +90,7 @@ public func _arrayForceCast<SourceElement, TargetElement>(
         p += 1
       }
     }
-    return Array(_ArrayBuffer(buf, shiftedToStartIndex: 0))
+    return Array(_buffer: _ArrayBuffer(buf, shiftedToStartIndex: 0))
     
   case (.value, .explicit):
     _sanityCheckFailure(
@@ -121,7 +121,7 @@ internal func _arrayConditionalDownCastElements<SourceElement, TargetElement>(
     
     if _fastPath(native != nil) {
       if native!.storesOnlyElementsOfType(TargetElement.self) {
-        return Array(a._buffer.cast(toBufferOf: TargetElement.self))
+        return Array(_buffer: a._buffer.cast(toBufferOf: TargetElement.self))
       }
       return nil
     }
@@ -136,7 +136,7 @@ internal func _arrayConditionalDownCastElements<SourceElement, TargetElement>(
         }
       }
     }
-    return Array(a._buffer.cast(toBufferOf: TargetElement.self))
+    return Array(_buffer: a._buffer.cast(toBufferOf: TargetElement.self))
   }
   return []
 }
@@ -169,7 +169,7 @@ ElementwiseBridging:
       p.initialize(with: value!)
       p += 1
     }
-    return Array(_ArrayBuffer(buf, shiftedToStartIndex: 0))
+    return Array(_buffer: _ArrayBuffer(buf, shiftedToStartIndex: 0))
   }
   while false
   

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -884,16 +884,17 @@ public struct ${Self}<Element>
 
   /// Initialization from an existing buffer does not have "array.init"
   /// semantics because the caller may retain an alias to buffer.
-  public init(_buffer: _Buffer) {
+  public // @testable
+  init(_buffer: _Buffer) {
     self._buffer = _buffer
   }
 
 %if Self == 'ArraySlice':
-  // FIXME(ABI): SR-1873 this shim allows the below init(arrayLiteral:) to
-  // compile, but it goes through a general collection initializer instead of
-  // the expected efficient one for _SliceBuffer<Element> above.
-  public init(_buffer: _ContiguousArrayBuffer<Element>) {
-    self.init(_buffer)
+  /// Initialization from an existing buffer does not have "array.init"
+  /// semantics because the caller may retain an alias to buffer.
+  public // @testable
+  init(_buffer: _ContiguousArrayBuffer<Element>) {
+    self.init(_buffer: _Buffer(_buffer, shiftedToStartIndex: 0))
   }
 %end
 

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -732,7 +732,7 @@ public struct ${Self}<Element>
     get {
       _checkIndex(bounds.lowerBound)
       _checkIndex(bounds.upperBound)
-      return ArraySlice(_buffer[bounds])
+      return ArraySlice(_buffer: _buffer[bounds])
     }
     set(rhs) {
       _checkIndex(bounds.lowerBound)
@@ -884,9 +884,18 @@ public struct ${Self}<Element>
 
   /// Initialization from an existing buffer does not have "array.init"
   /// semantics because the caller may retain an alias to buffer.
-  public init(_ _buffer: _Buffer) {
+  public init(_buffer: _Buffer) {
     self._buffer = _buffer
   }
+
+%if Self == 'ArraySlice':
+  // FIXME(ABI): SR-1873 this shim allows the below init(arrayLiteral:) to
+  // compile, but it goes through a general collection initializer instead of
+  // the expected efficient one for _SliceBuffer<Element> above.
+  public init(_buffer: _ContiguousArrayBuffer<Element>) {
+    self.init(_buffer)
+  }
+%end
 
   public var _buffer: _Buffer
 }
@@ -926,7 +935,7 @@ extension ${Self} : ArrayLiteralConvertible {
   ///
   /// - Parameter elements: A variadic list of elements of the new array.
   public init(arrayLiteral elements: Element...) {
-    self.init(_extractOrCopyToNativeArrayBuffer(elements._buffer))
+    self.init(_buffer: _extractOrCopyToNativeArrayBuffer(elements._buffer))
   }
 %end
 }
@@ -1027,7 +1036,7 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   public init<S : Sequence>(_ s: S)
     where S.Iterator.Element == Element {
 
-    self = ${Self}(_Buffer(s._copyToNativeArrayBuffer(),
+    self = ${Self}(_buffer: _Buffer(s._copyToNativeArrayBuffer(),
       shiftedToStartIndex: 0))
   }
 
@@ -1114,7 +1123,7 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
         storage, to: _ContiguousArrayStorage<Element>.self))
     
     return (
-      Array(_Buffer(innerBuffer, shiftedToStartIndex: 0)),
+      Array(_buffer: _Buffer(innerBuffer, shiftedToStartIndex: 0)),
         innerBuffer.firstElementAddress)
   }
 
@@ -2082,7 +2091,7 @@ public func != <Element : Equatable>(
 public func _arrayUpCast<Derived, Base>(_ a: Array<Derived>) -> Array<Base> {
   // FIXME: Dynamic casting is currently not possible without the objc runtime:
   // rdar://problem/18801510
-  return Array(a._buffer.cast(toBufferOf: Base.self))
+  return Array(_buffer: a._buffer.cast(toBufferOf: Base.self))
 }
 #endif
 
@@ -2113,7 +2122,7 @@ extension Array {
   /// * `Element` is bridged verbatim to Objective-C (i.e.,
   ///   is a reference type).
   public init(_immutableCocoaArray: _NSArrayCore) {
-    self = Array(_ArrayBuffer(nsArray: _immutableCocoaArray))
+    self = Array(_buffer: _ArrayBuffer(nsArray: _immutableCocoaArray))
   }
 }
 #endif


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Stop copying the _ContiguousArrayBuffer when initializing an ArraySlice from a literal.  Also, rename stdlib-private init(_ _buffer:) to init(_buffer:).  This is good hygiene, to avoid this issue happening again accidentally.

Thanks to Dmitri for help with this fix!
#### Resolved bug number: ([SR-1873](https://bugs.swift.org/browse/SR-1873))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
