### PR TITLE
Debugging: Extend the live ranges of local values at -Onone.

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -969,9 +969,7 @@ void IRGenDebugInfo::emitDbgIntrinsic(llvm::BasicBlock *BB,
   // the variable that is live throughout the function. With SIL
   // optimizations this is not guaranteed and a variable can end up in
   // two allocas (for example, one function inlined twice).
-  if (!Opts.Optimize &&
-      (isa<llvm::AllocaInst>(Storage) ||
-       isa<llvm::UndefValue>(Storage)))
+  if (isa<llvm::AllocaInst>(Storage))
     DBuilder.insertDeclare(Storage, Var, Expr, DL, BB);
   else
     DBuilder.insertDbgValueIntrinsic(Storage, 0, Var, Expr, DL, BB);

--- a/test/DebugInfo/WeakCapture.swift
+++ b/test/DebugInfo/WeakCapture.swift
@@ -10,10 +10,10 @@ func function() {
     let b = B()
 
   // Ensure that the local b and its weak copy are distinct local variables.
-  // CHECK: call void @llvm.dbg.value(metadata %C11WeakCapture1B*
-  // CHECK-SAME:                      metadata [[B:.*]], metadata
-  // CHECK: call void @llvm.dbg.value(metadata %swift.weak*
-  // CHECK-NOT:                       metadata [[B]]
+  // CHECK: call void @llvm.dbg.{{.*}}(metadata %C11WeakCapture1B*
+  // CHECK-SAME:                       metadata [[B:.*]], metadata
+  // CHECK: call void @llvm.dbg.{{.*}}(metadata %swift.weak*
+  // CHECK-NOT:                        metadata [[B]]
   // CHECK: call
     A(handler: { [weak b] _ in
             if b != nil { }

--- a/test/DebugInfo/liverange-extension.swift
+++ b/test/DebugInfo/liverange-extension.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-frontend %s -g -emit-ir -o - | FileCheck %s
+
+func use<T>(_ x: T) {}
+
+func getInt32() -> Int32 { return -1 }
+
+public func rangeExtension(_ b: Bool) {
+  // CHECK: define {{.*}}rangeExtension
+  let i = getInt32()
+  // CHECK: llvm.dbg.value(metadata i32 [[I:.*]], i64 0, metadata
+  use(i)
+  if b {
+    let j = getInt32()
+    // CHECK: llvm.dbg.value(metadata i32 [[J:.*]], i64 0, metadata
+    use(j)
+    // CHECK: asm sideeffect "", "r"
+    // CHECK: {{(asm sideeffect "", "r".*)|(zext i32)}} [[J]]
+  }
+  let z = getInt32()
+  use(z)
+  // CHECK: llvm.dbg.value(metadata i32 [[Z:.*]], i64 0, metadata
+  // CHECK: {{(asm sideeffect "", "r".*)|(zext i32)}} [[I]]
+  // CHECK: asm sideeffect "", "r"
+}

--- a/test/DebugInfo/local-vars.swift.gyb
+++ b/test/DebugInfo/local-vars.swift.gyb
@@ -1,0 +1,146 @@
+// An end-to-end test to ensure local variables have debug info.  This
+// test only verifies that the variables show up in the debug info at
+// all. There are other tests testing liveness and representation.
+
+// RUN: %gyb %s -o %t.swift
+// RUN: %target-swift-frontend %t.swift -g -emit-ir -o - | FileCheck %t.swift
+// RUN: %target-swift-frontend %t.swift -g -c -o %t.o
+// RUN: llvm-dwarfdump --debug-dump=info %t.o \
+// RUN:   | FileCheck %t.swift --check-prefix=DWARF
+
+public class C {
+  let member : Int
+  init(_ i : Int) { member = i }
+  func isZero() -> Boolean { return member == 0 }
+}
+
+public struct S {
+  let i : Int32 = -1
+  let j : Int32 = 2
+}
+
+func use<T>(_ x: T) {}
+func variable_use<T>(_ x: inout T) {}
+
+% def derive_name((type, val)):
+%   return (type.replace('<', '_').replace(' ', '_').replace(',', '_')
+%               .replace('?', '_').replace('>', '_')
+%               .replace('[', '_').replace(']', '_'), type, val)
+% for name, type, val in map(derive_name,
+%   [("UInt64", "64"), ("UInt32", "32"), ("Int64", "64"), ("Int32", "32"),
+%    ("Int", "42"), ("UInt", "42"), ("C", "C(42)"), ("String", '"string"'),
+%    ("Dictionary<UInt64, String>", '[1:"entry"]'),
+%    ("Float", "2.71"), ("Double", "3.14"), ("[UInt64]", "[1, 2, 3]"),
+%    ("S", "S()")]):
+
+public func constant_${name}() -> ${type} {
+  let v : ${type} = ${val}
+  // CHECK: !DILocalVariable(name: "v",{{.*}} line: [[@LINE-1]]
+  // DWARF: DW_TAG_subprogram
+  // DWARF: DW_AT_name {{.*}}constant_${name}
+  // DWARF-NOT: DW_TAG_subprogram
+  // DWARF: DW_TAG_variable
+  // DWARF-NOT: DW_TAG
+  // DWARF: {{(DW_AT_location)|(DW_AT_const_value)}}
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name {{.*}}"v"
+  return v
+}
+
+public func constvar_${name}() {
+  var v : ${type} = ${val}
+  // CHECK: !DILocalVariable(name: "v",{{.*}} line: [[@LINE-1]]
+  // DWARF: DW_TAG_subprogram
+  // DWARF: DW_AT_name {{.*}}constvar_${name}
+  // DWARF-NOT: DW_TAG_subprogram
+  // DWARF: DW_TAG_variable
+  // DWARF-NOT: DW_TAG
+  // DWARF: {{(DW_AT_location)|(DW_AT_const_value)}}
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name {{.*}}"v"
+  variable_use(&v)
+}
+
+public func let_${name}() {
+  let v : ${type} = constant_${name}()
+  // CHECK: !DILocalVariable(name: "v",{{.*}} line: [[@LINE-1]]
+  // DWARF: DW_TAG_subprogram
+  // DWARF: DW_AT_name {{.*}}let_${name}
+  // DWARF-NOT: DW_TAG_subprogram
+  // DWARF: DW_TAG_variable
+  // DWARF-NOT: DW_TAG
+  // DWARF: {{(DW_AT_location)|(DW_AT_const_value)}}
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name {{.*}}"v"
+  use(v)
+}
+
+public func optional_${name}() -> ${type}? {
+  return constant_${name}();
+}
+
+public func guard_let_${name}() {
+  let opt : ${type}? = optional_${name}()
+  // CHECK: !DILocalVariable(name: "opt",{{.*}} line: [[@LINE-1]]
+  // DWARF: DW_TAG_subprogram
+  // DWARF: DW_AT_name {{.*}}guard_let_${name}
+  // DWARF-NOT: DW_TAG_subprogram
+  // DWARF: DW_TAG_variable
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_location
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name
+  // DWARF-SAME: "{{(opt)|(val)}}"
+  guard let val = opt else {
+    use(opt)
+    fatalError()
+  }
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_TAG_variable
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_location
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name
+  // DWARF-SAME: "{{(opt)|(val)}}"
+  use(val)
+}
+
+public func var_${name}() {
+  var v : ${type} = constant_${name}()
+  // CHECK: !DILocalVariable(name: "v",{{.*}} line: [[@LINE-1]]
+  // DWARF: DW_TAG_subprogram
+  // DWARF: DW_AT_name {{.*}}var_${name}
+  // DWARF-NOT: DW_TAG_subprogram
+  // DWARF: DW_TAG_variable
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_location
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name {{.*}}"v"
+  variable_use(&v)
+}
+
+public func arg_${name}(_ v: ${type}) {
+  // CHECK: !DILocalVariable(name: "v",{{.*}} line: [[@LINE-1]]
+  // DWARF: DW_TAG_subprogram
+  // DWARF: DW_AT_name {{.*}}arg_${name}
+  // DWARF-NOT: DW_TAG_subprogram
+  // DWARF: DW_TAG_formal_parameter
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_location
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name {{.*}}"v"
+  use(v)
+}
+
+public func arg_inout_${name}(_ v: inout ${type}) {
+  // CHECK: !DILocalVariable(name: "v",{{.*}} line: [[@LINE-1]]
+  // DWARF: DW_TAG_subprogram
+  // DWARF: DW_AT_name {{.*}}arg_inout_${name}
+  // DWARF-NOT: DW_TAG_subprogram
+  // DWARF: DW_TAG_formal_parameter
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_location
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name {{.*}}"v"
+  variable_use(&v)
+}

--- a/test/DebugInfo/patternmatching.swift
+++ b/test/DebugInfo/patternmatching.swift
@@ -25,14 +25,14 @@ switch p {
       // Verify that the branch has a location >= the cleanup.
       // SIL-CHECK-NEXT:  br{{.*}}line:[[@LINE-3]]:17:cleanup
       // CHECK-SCOPES: call {{.*}}markUsed
-      // CHECK-SCOPES: call void @llvm.dbg.value({{.*}}metadata ![[X1:[0-9]+]]
-      // CHECK-SCOPES-SAME:                        !dbg ![[X1LOC:[0-9]+]]
-      // CHECK-SCOPES: call void @llvm.dbg.value
-      // CHECK-SCOPES: call void @llvm.dbg.value({{.*}}metadata ![[X2:[0-9]+]]
-      // CHECK-SCOPES-SAME:                        !dbg ![[X2LOC:[0-9]+]]
-      // CHECK-SCOPES: call void @llvm.dbg.value
-      // CHECK-SCOPES: call void @llvm.dbg.value({{.*}}metadata ![[X3:[0-9]+]]
-      // CHECK-SCOPES-SAME:                        !dbg ![[X3LOC:[0-9]+]]
+      // CHECK-SCOPES: call void @llvm.dbg{{.*}}metadata ![[X1:[0-9]+]],
+      // CHECK-SCOPES-SAME:                         !dbg ![[X1LOC:[0-9]+]]
+      // CHECK-SCOPES: call void @llvm.dbg
+      // CHECK-SCOPES: call void @llvm.dbg{{.*}}metadata ![[X2:[0-9]+]],
+      // CHECK-SCOPES-SAME:                         !dbg ![[X2LOC:[0-9]+]]
+      // CHECK-SCOPES: call void @llvm.dbg
+      // CHECK-SCOPES: call void @llvm.dbg{{.*}}metadata ![[X3:[0-9]+]],
+      // CHECK-SCOPES-SAME:                         !dbg ![[X3LOC:[0-9]+]]
       // CHECK-SCOPES: !DILocalVariable(name: "x",
     case (let x, let y) where x == -y:
       // Verify that all variables end up in separate appropriate scopes.


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

```
Debugging: Extend the live ranges of local values at -Onone.

For many local values we can avoid a shadow alloca by directly
describing them with a dbg.value. This also enables precise liveness
so variables don't show up in the debugger before they are
initialized. Unfortunately this also means that values will disappear
when they are no longer needed.

This patch inserts an empty inline assembler expression depending on
the llvm::Value that is being described in the blocks dominated by it.
This uses less stack space than full shadow copies *and* allows us to
track the liveness of the variable completely. It may cause values to
be spilled onto the stack, though.

<rdar://problem/26627376>
```
#### Resolved bug number: rdar://problem/26627376

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



@swift-ci Please test and merge

<!-- Thank you for your contribution to Swift! -->
