### PR TITLE
[swiftc] Add 💥 case (😢 → 48, 😀 → 5090) triggered in swift::TypeBase::getDesugaredType(…)

### DIFF
--- a/validation-test/compiler_crashers/28328-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers/28328-swift-typebase-getdesugaredtype.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+let a{extension{enum k:String{{{}}case


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Add crash case with stack trace:

```
4  swift           0x000000000111a170 swift::TypeBase::getDesugaredType() + 32
5  swift           0x00000000010ce6f9 swift::EnumElementDecl::computeType() + 137
7  swift           0x0000000000ea96d3 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 947
13 swift           0x0000000000eaeb16 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
16 swift           0x0000000000f1491a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
17 swift           0x0000000000f1477e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
18 swift           0x0000000000f15343 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
20 swift           0x0000000000ed0dc1 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
21 swift           0x0000000000c60529 swift::CompilerInstance::performSema() + 3289
23 swift           0x00000000007d8109 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
24 swift           0x00000000007a4148 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28328-swift-typebase-getdesugaredtype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28328-swift-typebase-getdesugaredtype-247a61.o
1.  While type-checking getter for a at validation-test/compiler_crashers/28328-swift-typebase-getdesugaredtype.swift:9:6
2.  While type-checking declaration 0x6274b00 at validation-test/compiler_crashers/28328-swift-typebase-getdesugaredtype.swift:9:7
3.  While type-checking declaration 0x628a408 at validation-test/compiler_crashers/28328-swift-typebase-getdesugaredtype.swift:9:35
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
