### PR TITLE
[SourceKit] Share common object printer code

### DIFF
--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/RequestResponsePrinterBase.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/RequestResponsePrinterBase.h
@@ -1,0 +1,110 @@
+//===--- RequestResponsePrinterBase.h - -------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SOURCEKITD_REQUESTRESPONSEPRINTERBASE_H
+#define LLVM_SOURCEKITD_REQUESTRESPONSEPRINTERBASE_H
+
+#include "sourcekitd/sourcekitd.h"
+#include "sourcekitd/Logging.h"
+#include <vector>
+
+namespace llvm {
+  class StringRef;
+  template <typename T> class ArrayRef;
+  class raw_ostream;
+}
+namespace SourceKit {
+  class UIdent;
+}
+
+namespace sourcekitd {
+
+template <typename VisitorImplClass, typename VisitedType>
+class RequestResponsePrinterBase {
+  llvm::raw_ostream &OS;
+  unsigned Indent;
+  bool PrintAsJSON;
+public:
+  typedef std::vector<std::pair<SourceKit::UIdent, VisitedType>> DictMap;
+
+  RequestResponsePrinterBase(llvm::raw_ostream &OS, unsigned Indent = 0, 
+                             bool PrintAsJSON = false)
+    : OS(OS), Indent(Indent), PrintAsJSON(PrintAsJSON) { }
+
+  void visitNull() {
+    OS << "<<NULL>>";
+  }
+
+  void visitDictionary(const DictMap &Map) {
+    OS << "{\n";
+    Indent += 2;
+    for (unsigned i = 0, e = Map.size(); i != e; ++i) {
+      auto &Pair = Map[i];
+      OS.indent(Indent);
+      if (PrintAsJSON) {
+        visitString(Pair.first.getName());
+      } else {
+        OSColor(OS, DictKeyColor) << Pair.first.getName();
+      }
+      OS << ": ";
+      static_cast<VisitorImplClass *>(this)->visit(Pair.second);
+      if (i < e-1)
+        OS << ',';
+      OS << '\n';
+    }
+    Indent -= 2;
+    OS.indent(Indent) << '}';
+  }
+
+  void visitArray(llvm::ArrayRef<VisitedType> Arr) {
+    OS << "[\n";
+    Indent += 2;
+    for (unsigned i = 0, e = Arr.size(); i != e; ++i) {
+      auto Obj = Arr[i];
+      OS.indent(Indent);
+      static_cast<VisitorImplClass *>(this)->visit(Obj);
+      if (i < e-1)
+        OS << ',';
+      OS << '\n';
+    }
+    Indent -= 2;
+    OS.indent(Indent) << ']';
+  }
+
+  void visitInt64(int64_t Val) {
+    OS << Val;
+  }
+
+  void visitBool(bool Val) {
+    OS << Val;
+  }
+
+  void visitString(llvm::StringRef Str) {
+    OS << '\"';
+    // Avoid raw_ostream's write_escaped, we don't want to escape unicode
+    // characters because it will be invalid JSON.
+    writeEscaped(Str, OS);
+    OS << '\"';
+  }
+
+  void visitUID(llvm::StringRef UID) {
+    if (PrintAsJSON) {
+      visitString(UID);
+    } else {
+      OSColor(OS, UIDColor) << UID;
+    }
+  }
+};
+
+}
+
+#endif


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

I thought it would make sense to open a new PR for a subset of the changes being discussed in #3026. 

This is my attempt at implementing @akyrtzi's suggestion [here](https://github.com/apple/swift/pull/3026#discussion_r68163780). I didn't see how it would be possible to do it exactly as proposed, since the `SKDObjectPrinterBase` class needs access to the `visit` method to dispatch based on the type of arbitrary elements in a dictionary or array. I used a slightly different structure here which seemed to make sense, however the previous design of the classes `SKDObjectVisitor` and `SKDObjectPrinter` classes seemed confusing to me to begin with, so it's quite possible that some original design goals haven't been preserved with my changes.

I also noticed that the code duplication being discussed in relation to the InProc additions in #3026 already existed with the XPC `SKDObjectPrinter` and the `VariantPrinter` classes which I am addressing here.

<!-- Description about pull request. -->
#### Related bug number: ([SR-1639](https://bugs.swift.org/browse/SR-1639))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

This is an attempt to clean up code duplication around printing SourceKit
request and response objects.
