### PR TITLE
[swiftc] Add 💥 case (😢 → 49, 😀 → 5090) triggered in swift::ArchetypeBuilder::PotentialArchetype::getType(…)

### DIFF
--- a/validation-test/compiler_crashers/28329-swift-archetypebuilder-potentialarchetype-gettype.swift
+++ b/validation-test/compiler_crashers/28329-swift-archetypebuilder-potentialarchetype-gettype.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+class n{typealias e:A{}protocol A{class c<a:typealias e:A.c


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Add crash case with stack trace:

```
4  swift           0x0000000000fe597c swift::ArchetypeBuilder::PotentialArchetype::getType(swift::ArchetypeBuilder&) + 28
6  swift           0x000000000111e854 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 36
7  swift           0x000000000111eaf0 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 704
8  swift           0x0000000000fe5bfa swift::ArchetypeBuilder::PotentialArchetype::getType(swift::ArchetypeBuilder&) + 666
9  swift           0x000000000111d3ec swift::ArchetypeType::resolveNestedType(std::pair<swift::Identifier, swift::ArchetypeType::NestedType>&) const + 76
10 swift           0x000000000111d822 swift::ArchetypeType::getNestedTypes(bool) const + 66
11 swift           0x0000000000fe5e3c swift::ArchetypeBuilder::PotentialArchetype::getType(swift::ArchetypeBuilder&) + 1244
12 swift           0x0000000000feaea5 swift::ArchetypeBuilder::getArchetype(swift::GenericTypeParamDecl*) + 53
13 swift           0x0000000000ee815f swift::TypeChecker::finalizeGenericParamList(swift::ArchetypeBuilder&, swift::GenericParamList*, swift::DeclContext*) + 191
14 swift           0x0000000000ee878b swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) + 283
15 swift           0x0000000000ea9a49 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1833
16 swift           0x0000000001105dbb swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2667
17 swift           0x000000000110465b swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2555
18 swift           0x0000000000eea94b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
21 swift           0x0000000000f1bbee swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
23 swift           0x0000000000f1cb34 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
24 swift           0x0000000000f1bae0 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
27 swift           0x0000000000eaa064 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3396
32 swift           0x0000000000eaeb16 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
33 swift           0x0000000000ed0cc2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
34 swift           0x0000000000c60529 swift::CompilerInstance::performSema() + 3289
36 swift           0x00000000007d8109 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
37 swift           0x00000000007a4148 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28329-swift-archetypebuilder-potentialarchetype-gettype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28329-swift-archetypebuilder-potentialarchetype-gettype-abcd3a.o
1.  While type-checking 'n' at validation-test/compiler_crashers/28329-swift-archetypebuilder-potentialarchetype-gettype.swift:9:1
2.  While type-checking 'e' at validation-test/compiler_crashers/28329-swift-archetypebuilder-potentialarchetype-gettype.swift:9:9
3.  While resolving type A at [validation-test/compiler_crashers/28329-swift-archetypebuilder-potentialarchetype-gettype.swift:9:21 - line:9:21] RangeText="A"
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
