### PR TITLE
[swiftc] Add 💥 case (😢 → 50, 😀 → 5090) triggered in swift::GenericParamList::getSubstitutionMap(…)

### DIFF
--- a/validation-test/compiler_crashers/28330-swift-genericparamlist-getsubstitutionmap.swift
+++ b/validation-test/compiler_crashers/28330-swift-genericparamlist-getsubstitutionmap.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+protocol a{
+typealias e
+class A{typealias B<S>:a
+let e=B


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Add crash case with stack trace:

```
swift: /path/to/llvm/include/llvm/ADT/ArrayRef.h:139: const T &llvm::ArrayRef<swift::Substitution>::front() const [T = swift::Substitution]: Assertion `!empty()' failed.
8  swift           0x000000000111e0e8 swift::GenericParamList::getSubstitutionMap(llvm::ArrayRef<swift::Substitution>) const + 1080
9  swift           0x0000000000f1b80b swift::TypeChecker::applyUnboundGenericArguments(swift::UnboundGenericType*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) + 1195
11 swift           0x000000000111e854 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 36
12 swift           0x0000000000f3748e swift::constraints::ConstraintSystem::openType(swift::Type, swift::constraints::ConstraintLocatorBuilder, llvm::DenseMap<swift::CanType, swift::TypeVariableType*, llvm::DenseMapInfo<swift::CanType>, llvm::detail::DenseMapPair<swift::CanType, swift::TypeVariableType*> >&) + 78
15 swift           0x0000000001062965 swift::Expr::walk(swift::ASTWalker&) + 69
16 swift           0x0000000000f805b8 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) + 200
17 swift           0x0000000000e96753 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 371
18 swift           0x0000000000e9d092 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
19 swift           0x0000000000e9e247 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 343
20 swift           0x0000000000e9e45b swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
27 swift           0x0000000000eaeb16 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
28 swift           0x0000000000ed0cc2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
29 swift           0x0000000000c60529 swift::CompilerInstance::performSema() + 3289
31 swift           0x00000000007d8109 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
32 swift           0x00000000007a4148 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28330-swift-genericparamlist-getsubstitutionmap.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28330-swift-genericparamlist-getsubstitutionmap-3230b0.o
1.  While type-checking 'a' at validation-test/compiler_crashers/28330-swift-genericparamlist-getsubstitutionmap.swift:10:1
2.  While type-checking expression at [validation-test/compiler_crashers/28330-swift-genericparamlist-getsubstitutionmap.swift:13:7 - line:13:7] RangeText="B"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
