### PR TITLE
[SDK] Backwards-deployment support for Core Data's generics.

### DIFF
--- a/stdlib/public/SDK/CoreData/CMakeLists.txt
+++ b/stdlib/public/SDK/CoreData/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_swift_library(swiftCoreData IS_SDK_OVERLAY
   CoreData.swift
+  CoreData.mm
 
   SWIFT_MODULE_DEPENDS Foundation
   FRAMEWORK_DEPENDS CoreData)

--- a/stdlib/public/SDK/CoreData/CoreData.mm
+++ b/stdlib/public/SDK/CoreData/CoreData.mm
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#import <CoreData/CoreData.h>
+
+// Make sure -conformsToProtocol: checks succeed even on older OSs.
+// This only works because NSFetchRequestResult doesn't have any method
+// requirements.
+
+#define CONFORMS_TO_NSFETCHREQUESTRESULT(TYPE) \
+@interface TYPE (_SwiftNSFetchRequestResult) <NSFetchRequestResult> \
+@end \
+@implementation TYPE (_SwiftNSFetchRequestResult) \
+@end
+
+CONFORMS_TO_NSFETCHREQUESTRESULT(NSNumber)
+CONFORMS_TO_NSFETCHREQUESTRESULT(NSDictionary)
+CONFORMS_TO_NSFETCHREQUESTRESULT(NSManagedObject)
+CONFORMS_TO_NSFETCHREQUESTRESULT(NSManagedObjectID)

--- a/test/1_stdlib/Inputs/CoreDataHelper/CoreDataHelper.h
+++ b/test/1_stdlib/Inputs/CoreDataHelper/CoreDataHelper.h
@@ -1,0 +1,9 @@
+@import CoreData;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSFetchRequest<__covariant ResultType: id<NSFetchRequestResult>> (SwiftTesting)
++ (NSArray<ResultType> *)testGettingSomeDictionaries;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/test/1_stdlib/Inputs/CoreDataHelper/CoreDataHelper.m
+++ b/test/1_stdlib/Inputs/CoreDataHelper/CoreDataHelper.m
@@ -1,0 +1,7 @@
+#import "CoreDataHelper.h"
+
+@implementation NSFetchRequest (SwiftTesting)
++ (NSArray<id<NSFetchRequestResult>> *)testGettingSomeDictionaries {
+  return @[ @{}, @{} ];
+}
+@end

--- a/validation-test/stdlib/CoreData.swift
+++ b/validation-test/stdlib/CoreData.swift
@@ -1,0 +1,41 @@
+// RUN: rm -rf %t && mkdir -p %t
+
+// RUN: %target-clang %S/Inputs/CoreDataHelper/CoreDataHelper.m -c -o %t/CoreDataHelper.o -g -fmodules
+// RUN: %target-build-swift %s -import-objc-header %S/Inputs/CoreDataHelper/CoreDataHelper.h -Xlinker %t/CoreDataHelper.o -o %t/main
+// RUN: %target-run %t/main
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import CoreData
+import StdlibUnittest
+
+var CoreDataTests = TestSuite("CoreData")
+
+CoreDataTests.test("conformsToProtocol") {
+  expectTrue(NSDictionary.conforms(to: NSFetchRequestResult.self))
+  expectTrue(NSManagedObject.conforms(to: NSFetchRequestResult.self))
+}
+
+CoreDataTests.test("downcasting") {
+  var dictionaries = NSFetchRequest<NSFetchRequestResult>.testGettingSomeDictionaries()
+  expectType([NSFetchRequestResult].self, &dictionaries)
+
+  let casted = dictionaries as? [[NSObject: AnyObject]]
+  expectNotEmpty(casted)
+  expectEqual([[:], [:]], casted!)
+  expectEqual([[:], [:]], dictionaries as! [[NSObject: AnyObject]])
+}
+
+CoreDataTests.test("bridging") {
+  var dictionaries = NSFetchRequest<NSDictionary>.testGettingSomeDictionaries()
+  expectType([NSDictionary].self, &dictionaries)
+  expectEqual([[:], [:]], dictionaries)
+
+  let casted = dictionaries as? [[NSObject: AnyObject]]
+  expectNotEmpty(casted)
+  expectEqual([[:], [:]], casted!)
+  expectEqual([[:], [:]], dictionaries as! [[NSObject: AnyObject]])
+}
+
+runAllTests()


### PR DESCRIPTION
The Swift 3.0 version of #3173. This is slightly less critical because generics will get you around the problem in most cases, but still important.

rdar://problem/26980075.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
