### PR TITLE
Generic typealias fixes

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -760,6 +760,7 @@ namespace decls_block {
     TypeIDField, // interface type
     BCFixed<1>,  // implicit flag
     AccessibilityKindField // accessibility
+    // Trailed by generic parameters (if any).
   >;
 
   using GenericTypeParamDeclLayout = BCRecordLayout<

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -593,8 +593,8 @@ namespace {
         // pointing at a generic TypeAliasDecl here. If we find a way to
         // handle generic TypeAliases elsewhere, this can just become a
         // call to BoundGenericType::get().
-        return cs.TC.applyUnboundGenericArguments(unbound, SourceLoc(), cs.DC,
-                                                  arguments,
+        return cs.TC.applyUnboundGenericArguments(unbound, unboundDecl,
+                                                  SourceLoc(), cs.DC, arguments,
                                                   /*isGenericSignature*/false,
                                                   /*resolver*/nullptr);
       }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1017,13 +1017,17 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
     return;
   }
 
-  // Drill through noop expressions we don't care about, like ParanExprs.
+  // Drill through noop expressions we don't care about.
   auto valueE = E;
   while (1) {
     valueE = valueE->getValueProvidingExpr();
     
     if (auto *OEE = dyn_cast<OpenExistentialExpr>(valueE))
       valueE = OEE->getSubExpr();
+    else if (auto *CRCE = dyn_cast<CovariantReturnConversionExpr>(valueE))
+      valueE = CRCE->getSubExpr();
+    else if (auto *EE = dyn_cast<ErasureExpr>(valueE))
+      valueE = EE->getSubExpr();
     else
       break;
   }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -774,6 +774,7 @@ public:
   /// to be in a correct and valid form.
   ///
   /// \param type The generic type to which to apply arguments.
+  /// \param decl The declaration of the type.
   /// \param loc The source location for diagnostic reporting.
   /// \param dc The context where the arguments are applied.
   /// \param generic The arguments to apply with the angle bracket range for
@@ -786,8 +787,8 @@ public:
   /// error.
   ///
   /// \see applyUnboundGenericArguments
-  Type applyGenericArguments(Type type, SourceLoc loc, DeclContext *dc,
-                             GenericIdentTypeRepr *generic,
+  Type applyGenericArguments(Type type, TypeDecl *decl, SourceLoc loc,
+                             DeclContext *dc, GenericIdentTypeRepr *generic,
                              bool isGenericSignature,
                              GenericTypeResolver *resolver);
 
@@ -797,7 +798,8 @@ public:
   /// number of generic arguments given, whereas applyGenericArguments emits
   /// diagnostics in those cases.
   ///
-  /// \param unbound The unbound generic type to which to apply arguments.
+  /// \param type The unbound generic type to which to apply arguments.
+  /// \param decl The declaration of the type.
   /// \param loc The source location for diagnostic reporting.
   /// \param dc The context where the arguments are applied.
   /// \param genericArgs The list of generic arguments to apply to the type.
@@ -809,8 +811,8 @@ public:
   /// error.
   ///
   /// \see applyGenericArguments
-  Type applyUnboundGenericArguments(UnboundGenericType *unbound, SourceLoc loc,
-                                    DeclContext *dc,
+  Type applyUnboundGenericArguments(Type type, GenericTypeDecl *decl,
+                                    SourceLoc loc, DeclContext *dc,
                                     MutableArrayRef<TypeLoc> genericArgs,
                                     bool isGenericSignature,
                                     GenericTypeResolver *resolver);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2163,6 +2163,21 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
                                            genericParams, DC);
     declOrOffset = alias;
 
+    if (genericParams) {
+      SmallVector<GenericTypeParamType *, 4> paramTypes;
+      for (auto &genericParam : *genericParams) {
+        paramTypes.push_back(genericParam->getDeclaredType()
+                               ->castTo<GenericTypeParamType>());
+      }
+
+      // Read the generic requirements.
+      SmallVector<Requirement, 4> requirements;
+      readGenericRequirements(requirements);
+
+      auto sig = GenericSignature::get(paramTypes, requirements);
+      alias->setGenericSignature(sig);
+    }
+
     alias->computeType();
 
     if (auto accessLevel = getActualAccessibility(rawAccessLevel)) {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1556,6 +1556,8 @@ DeclContext *ModuleFile::getDeclContext(DeclContextID DCID) {
     declContextOrOffset = AFD;
   } else if (auto SD = dyn_cast<SubscriptDecl>(D)) {
     declContextOrOffset = SD;
+  } else if (auto TAD = dyn_cast<TypeAliasDecl>(D)) {
+    declContextOrOffset = TAD;
   } else {
     llvm_unreachable("Unknown Decl : DeclContext kind");
   }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2191,6 +2191,7 @@ void Serializer::writeDecl(const Decl *D) {
                                 typeAlias->isImplicit(),
                                 rawAccessLevel);
     writeGenericParams(typeAlias->getGenericParams(), DeclTypeAbbrCodes);
+    writeRequirements(typeAlias->getGenericRequirements());
     break;
   }
 

--- a/test/ClangModules/AppKit_test.swift
+++ b/test/ClangModules/AppKit_test.swift
@@ -16,7 +16,7 @@ class MyDocument : NSDocument {
 
 func test(_ url: URL, controller: NSDocumentController) {
   try! NSDocument(contentsOf: url, ofType: "") // expected-warning{{result of 'NSDocument' initializer is unused}}
-  try! MyDocument(contentsOf: url, ofType: "") // expected-warning {{expression of type 'MyDocument' is unused}}
+  try! MyDocument(contentsOf: url, ofType: "") // expected-warning{{result of 'NSDocument' initializer is unused}}
 
   try! controller.makeDocument(withContentsOf: url, ofType: "")
 }

--- a/test/attr/attr_discardableResult.swift
+++ b/test/attr/attr_discardableResult.swift
@@ -41,9 +41,16 @@ class C1 {
   func f1() -> Int { }
 
   func f2() -> Int { }
+
+  @discardableResult
+  func me() -> Self { return self }
+
+  func reallyMe() -> Self { return self }
 }
 
-func testFunctionsInClass(c1 : C1) {
+class C2 : C1 {}
+
+func testFunctionsInClass(c1 : C1, c2: C2) {
   C1.f1Static()     // okay
   C1.f2Static()     // expected-warning {{result of call to 'f2Static()' is unused}}
   _ = C1.f2Static() // okay
@@ -60,6 +67,15 @@ func testFunctionsInClass(c1 : C1) {
   c1.f1()           // okay
   c1.f2()           // expected-warning {{result of call to 'f2()' is unused}}
   _ = c1.f2()       // okay
+
+  c1.me()           // okay
+  c2.me()           // okay
+
+  c1.reallyMe()     // expected-warning {{result of call to 'reallyMe()' is unused}}
+  c2.reallyMe()     // expected-warning {{result of call to 'reallyMe()' is unused}}
+
+  _ = c1.reallyMe() // okay
+  _ = c2.reallyMe() // okay
 }
 
 struct S1 {
@@ -92,6 +108,18 @@ func testFunctionsInStruct(s1 : S1) {
   _ = s1.f2()       // okay
 }
 
+protocol P1 {
+  @discardableResult
+  func me() -> Self
+
+  func reallyMe() -> Self
+}
+
+func testFunctionsInExistential(p1 : P1) {
+  p1.me()           // okay
+  p1.reallyMe()     // expected-warning {{result of call to 'reallyMe()' is unused}}
+  _ = p1.reallyMe() // okay
+}
 
 let x = 4
 "Hello \(x+1) world"  // expected-warning {{expression of type 'String' is unused}}

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -1,8 +1,30 @@
-// RUN: %target-parse-verify-swift
+// RUN: %target-parse-verify-swift -enable-experimental-nested-generic-types
 
-struct MyType<TyA, TyB> {
+struct MyType<TyA, TyB> { // expected-note {{declared here}}
   var a : TyA, b : TyB
 }
+
+//
+// Type aliases that reference unbound generic types -- not really generic,
+// but they behave as such, in the sense that you can apply generic
+// arguments to them.
+//
+
+// FIXME: This should work?
+typealias OurType = MyType  // expected-error {{reference to generic type 'MyType' requires arguments in <...>}}
+
+typealias YourType = Swift.Optional
+
+struct Container {
+  typealias YourType = Swift.Optional
+}
+
+let _ : YourType<Int>
+let _ : Container.YourType<Int>
+
+//
+// Bona-fide generic type aliases
+//
 
 typealias DS<T> = MyType<String, T>
 
@@ -94,20 +116,104 @@ func f(a : MyTypeWithHashable<Int, Int>) {
 }
 
 
-
-
-// FIXME: Nested generic typealiases aren't working yet.
-struct GenericStruct<T> {
+// Unqualified lookup of generic typealiases nested inside generic contexts
+class GenericClass<T> {
   typealias TA<U> = MyType<T, U>
+  typealias TAI<U> = MyType<Int, U>
   
-  func testCapture<S>(s : S, t : T) -> TA<S> {  // expected-error {{cannot specialize non-generic type 'MyType<T, U>'}}
-    return TA<S>(a: t, b : s)
+  func testCapture<S>(s: S, t: T) -> TA<S> {
+    return TA<S>(a: t, b: s)
+  }
+
+  func testCaptureUnbound<S>(s: S, t: T) -> TA<S> {
+    return TA(a: t, b: s)
+  }
+
+  func testConcrete1(s: Int, t: T) -> TA<Int> {
+    return TA<Int>(a: t, b: s)
+  }
+
+  func testConcreteUnbound1(s: Int, t: T) -> TA<Int> {
+    return TA(a: t, b: s)
+  }
+
+  func testConcrete2(s: Float, t: Int) -> TAI<Float> {
+    return TAI<Float>(a: t, b: s)
+  }
+
+  func testConcreteUnbound2(s: Float, t: Int) -> TAI<Float> {
+    return TAI(a: t, b: s)
+  }
+
+  // FIXME: Would be nice to preserve sugar here
+
+  func testCaptureInvalid1<S>(s: S, t: T) -> TA<Int> {
+    return TA<S>(a: t, b: s) // expected-error {{cannot convert return expression of type 'MyType<T, S>' to return type 'MyType<T, Int>'}}
+  }
+
+  func testCaptureInvalid2<S>(s: Int, t: T) -> TA<S> {
+    return TA(a: t, b: s) // expected-error {{cannot convert return expression of type 'MyType<T, Int>' to return type 'MyType<T, S>'}}
+  }
+
+  struct NestedStruct<U> {
+    typealias TA<V> = MyType<(T, V), (U, V)>
+
+    func testCapture<S>(x: (T, S), y: (U, S)) -> TA<S> {
+      return TA(a: x, b: y)
+    }
   }
 }
 
-let _ = GenericStruct<Int>.TA<Float>(a: 4.0, b: 1)  // expected-error {{'Int' is not convertible to 'Float'}}
+// Make sure we apply base substitutions to the interface type of the typealias
+class ConcreteClass : GenericClass<String> {
+  func testSubstitutedCapture1<S>(s: S, t: String) -> TA<S> {
+    return TA<S>(a: t, b: s)
+  }
 
-let _ : GenericStruct<Int>.TA<Float>  // expected-error {{cannot specialize non-generic type 'MyType<Int, U>'}}
+  func testSubstitutedCapture2<S>(s: S, t: String) -> TA<S> {
+    return TA(a: t, b: s)
+  }
+
+  func testSubstitutedCapture3(s: Int, t: String) -> TA<Int> {
+    return TA<Int>(a: t, b: s)
+  }
+
+  func testSubstitutedCapture4(s: Int, t: String) -> TA<Int> {
+    return TA(a: t, b: s)
+  }
+
+  func testSubstitutedCapture5(s: Float, t: Int) -> TAI<Float> {
+    return TAI<Float>(a: t, b: s)
+  }
+
+  func testSubstitutedCapture6(s: Float, t: Int) -> TAI<Float> {
+    return TAI(a: t, b: s)
+  }
+}
+
+// Qualified lookup of generic typealiases nested inside concrete contexts
+struct ConcreteStruct {
+  typealias O<T> = Optional<T>
+}
+
+func takesUnsugaredType1(m: MyType<String, Float>) {}
+func takesSugaredType1(m: ConcreteClass.TA<Float>) {
+  takesUnsugaredType1(m: m)
+}
+
+// FIXME: Something's wrong with SpecializeExpr here
+let _ = ConcreteStruct.O<Int>(123) // expected-error {{cannot invoke value of type 'Optional<Int>.Type' with argument list '(Int)'}}
+
+// Qualified lookup of generic typealiases nested inside generic contexts
+
+// FIXME: Something's wrong with SpecializeExpr here
+let _ = GenericClass<Int>.TA<Float>(a: 4.0, b: 1)  // expected-error {{'Int' is not convertible to 'Float'}}
+let _ = GenericClass<Int>.TA<Float>(a: 1, b: 4.0)  // expected-error {{'Int' is not convertible to 'Float'}}
+
+func takesUnsugaredType2(m: MyType<Int, Float>) {}
+func takesSugaredType2(m: GenericClass<Int>.TA<Float>) {
+  takesUnsugaredType2(m: m)
+}
 
 
 

--- a/test/multifile/typealias/two-modules/library.swift
+++ b/test/multifile/typealias/two-modules/library.swift
@@ -1,0 +1,9 @@
+// RUN: true
+
+public enum Result<T, U>
+{
+    case success(T)
+    case failure(U)
+}
+
+public typealias GenericResult<T> = Result<T, ErrorProtocol>

--- a/test/multifile/typealias/two-modules/main.swift
+++ b/test/multifile/typealias/two-modules/main.swift
@@ -1,0 +1,13 @@
+// RUN: rm -rf %t && mkdir %t
+
+// RUN: mkdir %t/linker
+// RUN: %target-build-swift -emit-module -c %S/library.swift -o %t/linker/library.o
+// RUN: %target-build-swift -emit-library -c %S/library.swift -o %t/linker/library.o
+// RUN: %target-build-swift %S/main.swift %t/linker/library.o -I %t/linker/ -L %t/linker/ -o %t/linker/main
+
+// REQUIRES: executable_test
+
+import library
+
+func testFunction<T>(withCompletion completion: (Result<T, ErrorProtocol>) -> Void) { }
+testFunction { (result: GenericResult<Int>) in }

--- a/validation-test/compiler_crashers_fixed/28330-swift-genericparamlist-getsubstitutionmap.swift
+++ b/validation-test/compiler_crashers_fixed/28330-swift-genericparamlist-getsubstitutionmap.swift
@@ -5,7 +5,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
 protocol a{
 typealias e


### PR DESCRIPTION
- Fix crash when referencing generic typealias from another module (https://bugs.swift.org/browse/SR-1889)
- Fix crash when generic typealias is declared inside a nested generic type
- Fix type checking failures when the underlying type of a generic typealias references generic parameters from the outer context
- Also a small fix for an issue I came across in @discardableResult while working on the above
