### PR TITLE
[build-script] Factor out a product config object.

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -12,6 +12,7 @@
 from __future__ import print_function
 
 import argparse
+import json
 import multiprocessing
 import os
 import pipes
@@ -70,6 +71,19 @@ def call_without_sleeping(command, env=None, dry_run=False, echo=False):
         command = ["caffeinate"] + list(command)
 
     shell.call(command, env=env, dry_run=dry_run, echo=echo)
+
+
+class ProductConfiguration(object):
+    """High-level product configuration."""
+
+    def __init__(self, product_class):
+        self.product_class = product_class
+        self.build = False
+
+    def toJSON(self):
+        result = dict(self.__dict__)
+        result["product_class"] = self.product_class.__name__
+        return result
 
 
 class HostSpecificConfiguration(object):
@@ -243,7 +257,7 @@ class BuildScriptInvocation(object):
         # Build LLDB if any LLDB-related options were specified.
         if args.lldb_build_variant is not None or \
            args.lldb_assertions is not None:
-            args.build_lldb = True
+            args.products.lldb.build = True
 
         # Set the default build variant.
         if args.build_variant is None:
@@ -293,18 +307,18 @@ class BuildScriptInvocation(object):
             args.cmake_generator = "Ninja"
 
         ninja_required = (
-            args.cmake_generator == 'Ninja' or args.build_foundation)
+            args.cmake_generator == 'Ninja' or args.products.foundation.build)
         if ninja_required and toolchain.ninja is None:
-            args.build_ninja = True
+            args.products.ninja.build = True
 
         # SwiftPM and XCTest have a dependency on Foundation.
         # On OS X, Foundation is built automatically using xcodebuild.
         # On Linux, we must ensure that it is built manually.
-        if ((args.build_swiftpm or args.build_xctest) and
+        if ((args.products.swiftpm.build or args.products.xctest.build) and
                 platform.system() != "Darwin"):
-            args.build_foundation = True
+            args.products.foundation.build = True
 
-        # Propagate global --skip-build
+        # Propagate global --skip-build.
         if args.skip_build:
             args.skip_build_linux = True
             args.skip_build_freebsd = True
@@ -314,13 +328,9 @@ class BuildScriptInvocation(object):
             args.skip_build_tvos = True
             args.skip_build_watchos = True
             args.skip_build_android = True
+            for cls in products.known_product_classes:
+                args.products[cls.product_name()].build = False
             args.skip_build_benchmarks = True
-            args.build_lldb = False
-            args.build_llbuild = False
-            args.build_swiftpm = False
-            args.build_xctest = False
-            args.build_foundation = False
-            args.build_libdispatch = False
 
         # --skip-{ios,tvos,watchos} or --skip-build-{ios,tvos,watchos} are
         # merely shorthands for --skip-build-{**os}-{device,simulator}
@@ -611,24 +621,13 @@ class BuildScriptInvocation(object):
                 "--install-symroot", os.path.abspath(args.install_symroot)
             ]
 
-        if args.skip_build:
-            impl_args += ["--skip-build-cmark",
-                          "--skip-build-llvm",
-                          "--skip-build-swift"]
+        # Add the per-product skip-build args.
+        for cls in products.known_product_classes:
+            if not args.products[cls.product_name()].build:
+                impl_args += ["--skip-build-{}".format(cls.product_name())]
+
         if args.skip_build_benchmarks:
             impl_args += ["--skip-build-benchmarks"]
-        if not args.build_foundation:
-            impl_args += ["--skip-build-foundation"]
-        if not args.build_xctest:
-            impl_args += ["--skip-build-xctest"]
-        if not args.build_lldb:
-            impl_args += ["--skip-build-lldb"]
-        if not args.build_llbuild:
-            impl_args += ["--skip-build-llbuild"]
-        if not args.build_libdispatch:
-            impl_args += ["--skip-build-libdispatch"]
-        if not args.build_swiftpm:
-            impl_args += ["--skip-build-swiftpm"]
         if args.build_swift_stdlib_unittest_extra:
             impl_args += ["--build-swift-stdlib-unittest-extra"]
 
@@ -813,21 +812,12 @@ class BuildScriptInvocation(object):
         # but it matches the existing structure of the `build-script-impl`.
 
         product_classes = []
-        product_classes.append(products.CMark)
-        product_classes.append(products.LLVM)
-        product_classes.append(products.Swift)
-        if self.args.build_lldb:
-            product_classes.append(products.LLDB)
-        if self.args.build_llbuild:
-            product_classes.append(products.LLBuild)
-        if self.args.build_libdispatch:
-            product_classes.append(products.LibDispatch)
-        if self.args.build_foundation:
-            product_classes.append(products.Foundation)
-        if self.args.build_xctest:
-            product_classes.append(products.XCTest)
-        if self.args.build_swiftpm:
-            product_classes.append(products.SwiftPM)
+        for cls in [products.CMark, products.LLVM, products.Swift,
+                    products.LLDB, products.LLBuild,
+                    products.LibDispatch, products.Foundation, products.XCTest,
+                    products.SwiftPM]:
+            if self.args.products[cls.product_name()].build:
+                product_classes.append(cls)
         return product_classes
 
     def execute(self):
@@ -1180,6 +1170,16 @@ It is a policy decision aimed at making the builds uniform across all
 environments and easily reproducible by engineers who are not familiar with the
 details of the setups of other systems or automated environments.""")
 
+    # Create the custom argument namespace.
+    namespace = arguments.NestedNamespace()
+    namespace.products = arguments.NestedNamespace()
+    for cls in products.known_product_classes:
+        setattr(namespace.products, cls.product_name(),
+                ProductConfiguration(cls))
+    namespace.products.cmark.build = True
+    namespace.products.llvm.build = True
+    namespace.products.swift.build = True
+
     parser.add_argument(
         "-n", "--dry-run",
         help="print the commands that would be executed, but do not execute "
@@ -1221,42 +1221,22 @@ details of the setups of other systems or automated environments.""")
              "targets to build the Swift standard library for, or 'all'.",
         type=arguments.type.shell_split, default=["all"])
 
+    # Add options to select projects to build.
     projects_group = parser.add_argument_group(
         title="Options to select projects")
-    projects_group.add_argument(
-        "-l", "--lldb",
-        help="build LLDB",
-        action="store_true",
-        dest="build_lldb")
-    projects_group.add_argument(
-        "-b", "--llbuild",
-        help="build llbuild",
-        action="store_true",
-        dest="build_llbuild")
-    projects_group.add_argument(
-        "-p", "--swiftpm",
-        help="build swiftpm",
-        action="store_true",
-        dest="build_swiftpm")
-    projects_group.add_argument(
-        "--xctest",
-        help="build xctest",
-        action=arguments.action.optional_bool,
-        dest="build_xctest")
-    projects_group.add_argument(
-        "--foundation",
-        help="build foundation",
-        action=arguments.action.optional_bool,
-        dest="build_foundation")
-    projects_group.add_argument(
-        "--libdispatch",
-        help="build libdispatch",
-        action=arguments.action.optional_bool,
-        dest="build_libdispatch")
-    projects_group.add_argument(
-        "--build-ninja",
-        help="build the Ninja tool",
-        action=arguments.action.optional_bool)
+    for cls in products.known_product_classes:
+        # Special case for short form aliases.
+        short_alias = {products.LLDB: "l",
+                       products.LLBuild: "b",
+                       products.SwiftPM: "p"}.get(cls)
+        argnames = []
+        if short_alias is not None:
+            argnames.append("-" + short_alias)
+        argnames.append("--" + cls.product_name())
+        projects_group.add_argument(
+            *argnames, help="enable {}".format(cls.__name__),
+            action=arguments.action.optional_bool,
+            dest="products.{}.build".format(cls.product_name()))
 
     extra_actions_group = parser.add_argument_group(
         title="Extra actions to perform before or in addition to building")
@@ -1880,7 +1860,13 @@ details of the setups of other systems or automated environments.""")
         "--skip-test-optimized",
         action=arguments.action.unavailable)
 
-    args = migration.parse_args(parser, sys.argv[1:])
+    # Build script testing support.
+    parser.add_argument(
+        "--dump-argument-state",
+        help="dump information on the build script argument state",
+        action="store_true")
+
+    args = migration.parse_args(parser, sys.argv[1:], namespace)
 
     if args.build_script_impl_args:
         # If we received any impl args, check if `build-script-impl` would
@@ -1914,6 +1900,11 @@ details of the setups of other systems or automated environments.""")
     # Validate the arguments.
     BuildScriptInvocation.validate_arguments(toolchain, args)
 
+    # If we are just dumping the arguments, do so now.
+    if args.dump_argument_state:
+        print(json.dumps(args.toJSON(), indent=2, sort_keys=True))
+        return 0
+
     # Create the build script invocation.
     invocation = BuildScriptInvocation(toolchain, args)
 
@@ -1932,7 +1923,7 @@ details of the setups of other systems or automated environments.""")
     shell.makedirs(invocation.workspace.build_root)
 
     # Build ninja if required, which will update the toolchain.
-    if args.build_ninja:
+    if args.products.ninja.build:
         invocation.build_ninja()
 
     # Execute the underlying build script implementation.

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -105,6 +105,7 @@ KNOWN_SETTINGS=(
     reconfigure                 ""               "force a CMake configuration run even if CMakeCache.txt already exists"
     swift-primary-variant-sdk   ""               "default SDK for target binaries"
     swift-primary-variant-arch  ""               "default arch for target binaries"
+    skip-build-ninja            ""               "set to skip building Ninja"
     skip-build-cmark            ""               "set to skip building CommonMark"
     skip-build-llvm             ""               "set to skip building LLVM/Clang"
     skip-build-swift            ""               "set to skip building Swift"

--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -115,7 +115,7 @@ class CMake(object):
             define("LLVM_VERSION_MINOR:STRING", minor)
             define("LLVM_VERSION_PATCH:STRING", patch)
 
-        if args.build_ninja and args.cmake_generator == 'Ninja':
+        if args.products.ninja.build and args.cmake_generator == 'Ninja':
             define('CMAKE_MAKE_PROGRAM', toolchain.ninja)
 
         return options

--- a/utils/swift_build_support/swift_build_support/migration.py
+++ b/utils/swift_build_support/swift_build_support/migration.py
@@ -17,10 +17,11 @@
 #
 # ----------------------------------------------------------------------------
 
+import argparse
 import subprocess
 
 
-def parse_args(parser, argv):
+def parse_args(parser, argv, namespace=argparse.Namespace()):
     """
     Parse given argument list with given argparse.ArgumentParser.
 
@@ -31,7 +32,7 @@ def parse_args(parser, argv):
         build-script -RT -- --reconfigure
     """
     args, unknown_args = parser.parse_known_args(
-        list(arg for arg in argv if arg != '--'))
+        list(arg for arg in argv if arg != '--'), namespace)
     args.build_script_impl_args = unknown_args
     return args
 

--- a/utils/swift_build_support/swift_build_support/products/__init__.py
+++ b/utils/swift_build_support/swift_build_support/products/__init__.py
@@ -21,16 +21,18 @@ from .swift import Swift
 from .swiftpm import SwiftPM
 from .xctest import XCTest
 
-__all__ = [
-    'CMark',
-    'Ninja',
-    'Foundation',
-    'LibDispatch',
-    'LLBuild',
-    'LLDB',
-    'LLVM',
-    'Ninja',
-    'Swift',
-    'SwiftPM',
-    'XCTest',
+known_product_classes = [
+    CMark,
+    Foundation,
+    LibDispatch,
+    LLBuild,
+    LLDB,
+    LLVM,
+    Ninja,
+    Swift,
+    SwiftPM,
+    XCTest,
 ]
+
+__all__ = [cls.__class__.__name__
+           for cls in known_product_classes]

--- a/utils/swift_build_support/tests/test_build_script.py
+++ b/utils/swift_build_support/tests/test_build_script.py
@@ -1,0 +1,68 @@
+# tests/test_build_script.py ------------------------------------*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ----------------------------------------------------------------------------
+
+import json
+import os
+import unittest
+
+from swift_build_support import arguments
+from swift_build_support import shell
+
+
+class BuildScriptTestCase(unittest.TestCase):
+    build_script_path = os.path.join(os.path.dirname(__file__), "..", "..",
+                                     "build-script")
+
+    @classmethod
+    def get_build_script_argument_state(cls, args):
+        """
+        Get a dumped representation of the build-script argument state for the
+        given arguments.
+        """
+
+        # Test the initialization arguments and propagation of defaults.
+        data = shell.capture(
+            [cls.build_script_path] + args + ["--dump-argument-state"],
+            echo=False)
+        state = json.loads(data)
+
+        # Convert the loaded state into a NestedNamespace, for convenient
+        # access.
+        def convert(item):
+            if isinstance(item, dict):
+                result = arguments.NestedNamespace()
+                for (key, value) in item.items():
+                    result[key] = convert(value)
+                return result
+            else:
+                return item
+        return convert(state)
+
+    def test_product_configuration(self):
+        # Validate which projects are built by default.
+        args = BuildScriptTestCase.get_build_script_argument_state([])
+        self.assertEqual(args.products.cmark.build, True)
+        self.assertEqual(args.products.llvm.build, True)
+        self.assertEqual(args.products.swift.build, True)
+        self.assertEqual(args.products.llbuild.build, False)
+        self.assertEqual(args.products.libdispatch.build, False)
+        self.assertEqual(args.products.swiftpm.build, False)
+
+        # Validate --skip-build propagation.
+        args = BuildScriptTestCase.get_build_script_argument_state([
+            "--skip-build"])
+        self.assertEqual(args.products.cmark.build, False)
+        self.assertEqual(args.products.llvm.build, False)
+        self.assertEqual(args.products.swift.build, False)
+        self.assertEqual(args.products.llbuild.build, False)
+        self.assertEqual(args.products.libdispatch.build, False)
+        self.assertEqual(args.products.swiftpm.build, False)


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
- This factors out a new configuration object to hold the product specific data
  (like which projects to build). This will grow to include additional options
  for test/install, debug/assertions, etc.
- This also introduces three other small new pieces of infrastructure:
  
  o A facility (--dump-argument-state) to dump the internal argument state as
   JSON, for debugging and testing purposes.
  
  o Some minor new tests using the aforementioned.
  
  o A new NestedNamespace class for defining allowing nested, structured
   arguments to be directly initialized as part of the argument parser logic.
- This is related to SR-237, indirectly, because I plan to lift more of the
  product specific arguments into `build-script` and this makes it easier to
  make things generic on the product.
