### PR TITLE
[swiftc] Add 💥 case (😢 → 51, 😀 → 5090) triggered in swift::createDesignatedInitOverride(…)

### DIFF
--- a/validation-test/compiler_crashers/28331-swift-createdesignatedinitoverride.swift
+++ b/validation-test/compiler_crashers/28331-swift-createdesignatedinitoverride.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+let:{{class a{enum S<U:a{class B:a{init}}class a


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Add crash case with stack trace:

```
5  swift           0x0000000000f21393 swift::createDesignatedInitOverride(swift::TypeChecker&, swift::ClassDecl*, swift::ConstructorDecl*, swift::DesignatedInitKind) + 2003
6  swift           0x0000000000ea76a3 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 3187
13 swift           0x0000000000ea1416 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
16 swift           0x0000000000f08594 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
17 swift           0x0000000000f342dc swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
18 swift           0x0000000000e8fa31 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 769
21 swift           0x0000000000f0721a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
22 swift           0x0000000000f0707e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
23 swift           0x0000000000f07c43 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
25 swift           0x0000000000ec36c1 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
26 swift           0x0000000000c590c9 swift::CompilerInstance::performSema() + 3289
28 swift           0x00000000007d73e9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
29 swift           0x00000000007a3428 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28331-swift-createdesignatedinitoverride.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28331-swift-createdesignatedinitoverride-86a961.o
1.  While type-checking declaration 0x50f5a00 at validation-test/compiler_crashers/28331-swift-createdesignatedinitoverride.swift:9:5
2.  While type-checking expression at [validation-test/compiler_crashers/28331-swift-createdesignatedinitoverride.swift:9:6 - line:9:48] RangeText="{class a{enum S<U:a{class B:a{init}}class a"
3.  While type-checking 'a' at validation-test/compiler_crashers/28331-swift-createdesignatedinitoverride.swift:9:7
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
