### PR TITLE
[gardening] Disambiguate the meaning of Expr::getEndLoc() in the doc comment

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -395,7 +395,7 @@ public:
   /// getStartLoc - Return the location of the start of the expression.
   SourceLoc getStartLoc() const;
 
-  /// \brief Retrieve the location of the end of the expression.
+  /// \brief Retrieve the location of the last token of the expression.
   SourceLoc getEndLoc() const;
   
   /// getLoc - Return the caret location of this expression.


### PR DESCRIPTION
#### What's in this pull request?

"end of the expression" is very confusing. `getEndLoc()` actually returns
the start location of the last token of the expression.
