### PR TITLE
[build-script] Make libdispatch available to TestFoundation and XCTest tests if built

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2393,6 +2393,11 @@ for host in "${ALL_HOSTS[@]}"; do
                 if [[ "${SKIP_TEST_XCTEST}" ]]; then
                     continue
                 fi
+                # If libdispatch is being built then XCTest will need access to it
+                if [[ ! "${SKIP_BUILD_LIBDISPATCH}" ]] ; then
+                    LIBDISPATCH_BUILD_DIR="$(build_directory ${host} libdispatch)"
+                    LIBDISPATCH_BUILD_ARGS="--libdispatch-src-dir=${LIBDISPATCH_SOURCE_DIR} --libdispatch-build-dir=${LIBDISPATCH_BUILD_DIR}"
+                fi
                 echo "--- Running tests for ${product} ---"
                 SWIFTC_BIN="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
                 FOUNDATION_BUILD_DIR=$(build_directory ${host} foundation)
@@ -2400,6 +2405,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 call "${XCTEST_SOURCE_DIR}"/build_script.py test \
                     --swiftc="${SWIFTC_BIN}" \
                     --foundation-build-dir="${FOUNDATION_BUILD_DIR}/Foundation" \
+                    ${LIBDISPATCH_BUILD_ARGS} \
                     "${XCTEST_BUILD_DIR}"
                 echo "--- Finished tests for ${product} ---"
                 continue
@@ -2413,12 +2419,18 @@ for host in "${ALL_HOSTS[@]}"; do
                 if [[ "${SKIP_TEST_FOUNDATION}" ]]; then
                     continue
                 fi
+                # If libdispatch is being built, TestFoundation will need access to it
+                if [[ ! "${SKIP_BUILD_LIBDISPATCH}" ]] ; then
+                    LIBDISPATCH_LIB_DIR=":$(build_directory ${host} libdispatch)/src/.libs"
+                else
+                    LIBDISPATCH_LIB_DIR=""
+                fi
                 echo "--- Running tests for ${product} ---"
                 build_dir=$(build_directory ${host} ${product})
                 XCTEST_BUILD_DIR=$(build_directory ${host} xctest)
                 with_pushd "${FOUNDATION_SOURCE_DIR}" \
                     call ${NINJA_BIN} TestFoundation
-                call env LD_LIBRARY_PATH="$(get_host_install_destdir ${host})$(get_host_install_prefix ${host})"/lib/swift/:"${build_dir}/Foundation":"${XCTEST_BUILD_DIR}":${LD_LIBRARY_PATH} "${build_dir}"/TestFoundation/TestFoundation
+                call env LD_LIBRARY_PATH="$(get_host_install_destdir ${host})$(get_host_install_prefix ${host})"/lib/swift/:"${build_dir}/Foundation":"${XCTEST_BUILD_DIR}""${LIBDISPATCH_LIB_DIR}":${LD_LIBRARY_PATH} "${build_dir}"/TestFoundation/TestFoundation
                 echo "--- Finished tests for ${product} ---"
                 continue
                 ;;


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

We currently working on enabling libdispatch to be used by Foundation and installed into the toolchain. When this happens, the downstream dependencies also need access to libdispatch at build time (before its installed into the toolchain). This has been enabled already for Foundation, XCTest and Swift PM, but also needs to be done for TestFoundation and the XCTest function tests.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

N/A

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
