### PR TITLE
[Android] Specify default device deploy path

### DIFF
--- a/docs/Android.md
+++ b/docs/Android.md
@@ -191,7 +191,6 @@ $ utils/build-script \
   -R \                                           # Build in ReleaseAssert mode.
   -T \                                           # Run all tests.
   --android \                                    # Build for Android.
-  --android-deploy-device-path /data/local/tmp \ # Temporary directory on the device where Android tests are run.
   --android-ndk ~/android-ndk-r12 \              # Path to an Android NDK.
   --android-ndk-version 21 \
   --android-icu-uc ~/libicu-android/armeabi-v7a/libicuuc.so \

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -205,6 +205,12 @@ if(PYTHONINTERP_FOUND)
         # These are supported testing SDKs, but their implementation of
         # `command_upload_stdlib` is hidden.
       elseif("${SDK}" STREQUAL "ANDROID")
+        if("${SWIFT_ANDROID_DEPLOY_DEVICE_PATH}" STREQUAL "")
+          message(FATAL_ERROR
+              "When running Android host tests, you must specify the directory on the device "
+              "to which Swift build products will be deployed.")
+        endif()
+
         # Warning: This step will fail if you do not have an Android device
         #          connected via USB. See docs/Android.md for details on
         #          how to run the test suite for Android.

--- a/utils/build-script
+++ b/utils/build-script
@@ -1769,6 +1769,7 @@ details of the setups of other systems or automated environments.""")
         help="Path on an Android device to which built Swift stdlib products "
              "will be deployed. If running host tests, specify the '{}' "
              "directory.".format(adb.commands.DEVICE_TEMP_DIR),
+        default=adb.commands.DEVICE_TEMP_DIR,
         metavar="PATH")
 
     parser.add_argument(


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

When the `--android-deploy-device-path` option was first added, build products would only be deployed to a connected Android device if the option was specified. Now, we use `command_upload_stdlib` to upload every time the Android tests are being run.

As a result, running the test suite for Android without specifying a deploy path leads to a subtle error, in which the `command_upload_stdlib` CMake command fails. End users may find this difficult to debug.

Add a default argument to the deployment path, and check for a valid path before executing the CMake command.
#### Resolved bug number: None

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
