### PR TITLE
[stdlib] Improving Dictionary/Set tests to use fewer unsafeBitCasts

### DIFF
--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -27,6 +27,12 @@ import Foundation
 import StdlibUnittestFoundationExtras
 #endif
 
+extension Dictionary {
+  func _rawIdentifier() -> Int {
+    return unsafeBitCast(self, to: Int.self)
+  }
+}
+
 // Check that the generic parameters are called 'Key' and 'Value'.
 protocol TestProtocol1 {}
 
@@ -86,7 +92,7 @@ DictionaryTestSuite.test("valueDestruction") {
 
 DictionaryTestSuite.test("COW.Smoke") {
   var d1 = Dictionary<TestKeyTy, TestValueTy>(minimumCapacity: 10)
-  var identity1 = unsafeBitCast(d1, to: Int.self)
+  var identity1 = d1._rawIdentifier()
 
   d1[TestKeyTy(10)] = TestValueTy(1010)
   d1[TestKeyTy(20)] = TestValueTy(1020)
@@ -94,13 +100,13 @@ DictionaryTestSuite.test("COW.Smoke") {
 
   var d2 = d1
   _fixLifetime(d2)
-  assert(identity1 == unsafeBitCast(d2, to: Int.self))
+  assert(identity1 == d2._rawIdentifier())
 
   d2[TestKeyTy(40)] = TestValueTy(2040)
-  assert(identity1 != unsafeBitCast(d2, to: Int.self))
+  assert(identity1 != d2._rawIdentifier())
 
   d1[TestKeyTy(50)] = TestValueTy(1050)
-  assert(identity1 == unsafeBitCast(d1, to: Int.self))
+  assert(identity1 == d1._rawIdentifier())
 
   // Keep variables alive.
   _fixLifetime(d1)
@@ -135,7 +141,7 @@ func getCOWSlowEquatableDictionary()
 
 DictionaryTestSuite.test("COW.Fast.IndexesDontAffectUniquenessCheck") {
   var d = getCOWFastDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
 
   var startIndex = d.startIndex
   var endIndex = d.endIndex
@@ -145,10 +151,10 @@ DictionaryTestSuite.test("COW.Fast.IndexesDontAffectUniquenessCheck") {
   assert(!(startIndex >= endIndex))
   assert(!(startIndex > endIndex))
 
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 
   d[40] = 2040
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 
   // Keep indexes alive during the calls above.
   _fixLifetime(startIndex)
@@ -157,7 +163,7 @@ DictionaryTestSuite.test("COW.Fast.IndexesDontAffectUniquenessCheck") {
 
 DictionaryTestSuite.test("COW.Slow.IndexesDontAffectUniquenessCheck") {
   var d = getCOWSlowDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
 
   var startIndex = d.startIndex
   var endIndex = d.endIndex
@@ -166,10 +172,10 @@ DictionaryTestSuite.test("COW.Slow.IndexesDontAffectUniquenessCheck") {
   assert(startIndex <= endIndex)
   assert(!(startIndex >= endIndex))
   assert(!(startIndex > endIndex))
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 
   d[TestKeyTy(40)] = TestValueTy(2040)
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 
   // Keep indexes alive during the calls above.
   _fixLifetime(startIndex)
@@ -179,7 +185,7 @@ DictionaryTestSuite.test("COW.Slow.IndexesDontAffectUniquenessCheck") {
 
 DictionaryTestSuite.test("COW.Fast.SubscriptWithIndexDoesNotReallocate") {
   var d = getCOWFastDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
 
   var startIndex = d.startIndex
   let empty = startIndex == d.endIndex
@@ -187,15 +193,15 @@ DictionaryTestSuite.test("COW.Fast.SubscriptWithIndexDoesNotReallocate") {
   assert(d.startIndex <= d.endIndex)
   assert((d.startIndex >= d.endIndex) == empty)
   assert(!(d.startIndex > d.endIndex))
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 
   assert(d[startIndex].1 != 0)
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 }
 
 DictionaryTestSuite.test("COW.Slow.SubscriptWithIndexDoesNotReallocate") {
   var d = getCOWSlowDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
 
   var startIndex = d.startIndex
   let empty = startIndex == d.endIndex
@@ -203,23 +209,23 @@ DictionaryTestSuite.test("COW.Slow.SubscriptWithIndexDoesNotReallocate") {
   assert(d.startIndex <= d.endIndex)
   assert((d.startIndex >= d.endIndex) == empty)
   assert(!(d.startIndex > d.endIndex))
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 
   assert(d[startIndex].1.value != 0)
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 }
 
 
 DictionaryTestSuite.test("COW.Fast.SubscriptWithKeyDoesNotReallocate") {
   var d = getCOWFastDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
 
   assert(d[10]! == 1010)
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 
   // Insert a new key-value pair.
   d[40] = 2040
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
   assert(d.count == 4)
   assert(d[10]! == 1010)
   assert(d[20]! == 1020)
@@ -228,7 +234,7 @@ DictionaryTestSuite.test("COW.Fast.SubscriptWithKeyDoesNotReallocate") {
 
   // Overwrite a value in existing binding.
   d[10] = 2010
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
   assert(d.count == 4)
   assert(d[10]! == 2010)
   assert(d[20]! == 1020)
@@ -237,7 +243,7 @@ DictionaryTestSuite.test("COW.Fast.SubscriptWithKeyDoesNotReallocate") {
 
   // Delete an existing key.
   d[10] = nil
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
   assert(d.count == 3)
   assert(d[20]! == 1020)
   assert(d[30]! == 1030)
@@ -245,7 +251,7 @@ DictionaryTestSuite.test("COW.Fast.SubscriptWithKeyDoesNotReallocate") {
 
   // Try to delete a key that does not exist.
   d[42] = nil
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
   assert(d.count == 3)
   assert(d[20]! == 1020)
   assert(d[30]! == 1030)
@@ -266,14 +272,14 @@ DictionaryTestSuite.test("COW.Fast.SubscriptWithKeyDoesNotReallocate") {
 
 DictionaryTestSuite.test("COW.Slow.SubscriptWithKeyDoesNotReallocate") {
   var d = getCOWSlowDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
 
   assert(d[TestKeyTy(10)]!.value == 1010)
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 
   // Insert a new key-value pair.
   d[TestKeyTy(40)] = TestValueTy(2040)
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
   assert(d.count == 4)
   assert(d[TestKeyTy(10)]!.value == 1010)
   assert(d[TestKeyTy(20)]!.value == 1020)
@@ -282,7 +288,7 @@ DictionaryTestSuite.test("COW.Slow.SubscriptWithKeyDoesNotReallocate") {
 
   // Overwrite a value in existing binding.
   d[TestKeyTy(10)] = TestValueTy(2010)
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
   assert(d.count == 4)
   assert(d[TestKeyTy(10)]!.value == 2010)
   assert(d[TestKeyTy(20)]!.value == 1020)
@@ -291,7 +297,7 @@ DictionaryTestSuite.test("COW.Slow.SubscriptWithKeyDoesNotReallocate") {
 
   // Delete an existing key.
   d[TestKeyTy(10)] = nil
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
   assert(d.count == 3)
   assert(d[TestKeyTy(20)]!.value == 1020)
   assert(d[TestKeyTy(30)]!.value == 1030)
@@ -299,7 +305,7 @@ DictionaryTestSuite.test("COW.Slow.SubscriptWithKeyDoesNotReallocate") {
 
   // Try to delete a key that does not exist.
   d[TestKeyTy(42)] = nil
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
   assert(d.count == 3)
   assert(d[TestKeyTy(20)]!.value == 1020)
   assert(d[TestKeyTy(30)]!.value == 1030)
@@ -323,31 +329,31 @@ DictionaryTestSuite.test("COW.Slow.SubscriptWithKeyDoesNotReallocate") {
 DictionaryTestSuite.test("COW.Fast.UpdateValueForKeyDoesNotReallocate") {
   do {
     var d1 = getCOWFastDictionary()
-    var identity1 = unsafeBitCast(d1, to: Int.self)
+    var identity1 = d1._rawIdentifier()
 
     // Insert a new key-value pair.
     assert(d1.updateValue(2040, forKey: 40) == .none)
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
     assert(d1[40]! == 2040)
 
     // Overwrite a value in existing binding.
     assert(d1.updateValue(2010, forKey: 10)! == 1010)
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
     assert(d1[10]! == 2010)
   }
 
   do {
     var d1 = getCOWFastDictionary()
-    var identity1 = unsafeBitCast(d1, to: Int.self)
+    var identity1 = d1._rawIdentifier()
 
     var d2 = d1
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
-    assert(identity1 == unsafeBitCast(d2, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
+    assert(identity1 == d2._rawIdentifier())
 
     // Insert a new key-value pair.
     d2.updateValue(2040, forKey: 40)
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
-    assert(identity1 != unsafeBitCast(d2, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
+    assert(identity1 != d2._rawIdentifier())
 
     assert(d1.count == 3)
     assert(d1[10]! == 1010)
@@ -368,16 +374,16 @@ DictionaryTestSuite.test("COW.Fast.UpdateValueForKeyDoesNotReallocate") {
 
   do {
     var d1 = getCOWFastDictionary()
-    var identity1 = unsafeBitCast(d1, to: Int.self)
+    var identity1 = d1._rawIdentifier()
 
     var d2 = d1
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
-    assert(identity1 == unsafeBitCast(d2, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
+    assert(identity1 == d2._rawIdentifier())
 
     // Overwrite a value in existing binding.
     d2.updateValue(2010, forKey: 10)
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
-    assert(identity1 != unsafeBitCast(d2, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
+    assert(identity1 != d2._rawIdentifier())
 
     assert(d1.count == 3)
     assert(d1[10]! == 1010)
@@ -398,33 +404,33 @@ DictionaryTestSuite.test("COW.Fast.UpdateValueForKeyDoesNotReallocate") {
 DictionaryTestSuite.test("COW.Slow.AddDoesNotReallocate") {
   do {
     var d1 = getCOWSlowDictionary()
-    var identity1 = unsafeBitCast(d1, to: Int.self)
+    var identity1 = d1._rawIdentifier()
 
     // Insert a new key-value pair.
     assert(d1.updateValue(TestValueTy(2040), forKey: TestKeyTy(40)) == nil)
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
     assert(d1.count == 4)
     assert(d1[TestKeyTy(40)]!.value == 2040)
 
     // Overwrite a value in existing binding.
     assert(d1.updateValue(TestValueTy(2010), forKey: TestKeyTy(10))!.value == 1010)
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
     assert(d1.count == 4)
     assert(d1[TestKeyTy(10)]!.value == 2010)
   }
 
   do {
     var d1 = getCOWSlowDictionary()
-    var identity1 = unsafeBitCast(d1, to: Int.self)
+    var identity1 = d1._rawIdentifier()
 
     var d2 = d1
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
-    assert(identity1 == unsafeBitCast(d2, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
+    assert(identity1 == d2._rawIdentifier())
 
     // Insert a new key-value pair.
     d2.updateValue(TestValueTy(2040), forKey: TestKeyTy(40))
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
-    assert(identity1 != unsafeBitCast(d2, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
+    assert(identity1 != d2._rawIdentifier())
 
     assert(d1.count == 3)
     assert(d1[TestKeyTy(10)]!.value == 1010)
@@ -445,16 +451,16 @@ DictionaryTestSuite.test("COW.Slow.AddDoesNotReallocate") {
 
   do {
     var d1 = getCOWSlowDictionary()
-    var identity1 = unsafeBitCast(d1, to: Int.self)
+    var identity1 = d1._rawIdentifier()
 
     var d2 = d1
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
-    assert(identity1 == unsafeBitCast(d2, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
+    assert(identity1 == d2._rawIdentifier())
 
     // Overwrite a value in existing binding.
     d2.updateValue(TestValueTy(2010), forKey: TestKeyTy(10))
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
-    assert(identity1 != unsafeBitCast(d2, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
+    assert(identity1 != d2._rawIdentifier())
 
     assert(d1.count == 3)
     assert(d1[TestKeyTy(10)]!.value == 1010)
@@ -475,26 +481,26 @@ DictionaryTestSuite.test("COW.Slow.AddDoesNotReallocate") {
 
 DictionaryTestSuite.test("COW.Fast.IndexForKeyDoesNotReallocate") {
   var d = getCOWFastDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
 
   // Find an existing key.
   do {
     var foundIndex1 = d.index(forKey: 10)!
-    assert(identity1 == unsafeBitCast(d, to: Int.self))
+    assert(identity1 == d._rawIdentifier())
 
     var foundIndex2 = d.index(forKey: 10)!
     assert(foundIndex1 == foundIndex2)
 
     assert(d[foundIndex1].0 == 10)
     assert(d[foundIndex1].1 == 1010)
-    assert(identity1 == unsafeBitCast(d, to: Int.self))
+    assert(identity1 == d._rawIdentifier())
   }
 
   // Try to find a key that is not present.
   do {
     var foundIndex1 = d.index(forKey: 1111)
     assert(foundIndex1 == nil)
-    assert(identity1 == unsafeBitCast(d, to: Int.self))
+    assert(identity1 == d._rawIdentifier())
   }
 
   do {
@@ -512,26 +518,26 @@ DictionaryTestSuite.test("COW.Fast.IndexForKeyDoesNotReallocate") {
 
 DictionaryTestSuite.test("COW.Slow.IndexForKeyDoesNotReallocate") {
   var d = getCOWSlowDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
 
   // Find an existing key.
   do {
     var foundIndex1 = d.index(forKey: TestKeyTy(10))!
-    assert(identity1 == unsafeBitCast(d, to: Int.self))
+    assert(identity1 == d._rawIdentifier())
 
     var foundIndex2 = d.index(forKey: TestKeyTy(10))!
     assert(foundIndex1 == foundIndex2)
 
     assert(d[foundIndex1].0 == TestKeyTy(10))
     assert(d[foundIndex1].1.value == 1010)
-    assert(identity1 == unsafeBitCast(d, to: Int.self))
+    assert(identity1 == d._rawIdentifier())
   }
 
   // Try to find a key that is not present.
   do {
     var foundIndex1 = d.index(forKey: TestKeyTy(1111))
     assert(foundIndex1 == nil)
-    assert(identity1 == unsafeBitCast(d, to: Int.self))
+    assert(identity1 == d._rawIdentifier())
   }
 
   do {
@@ -551,10 +557,10 @@ DictionaryTestSuite.test("COW.Slow.IndexForKeyDoesNotReallocate") {
 DictionaryTestSuite.test("COW.Fast.RemoveAtDoesNotReallocate") {
   do {
     var d = getCOWFastDictionary()
-    var identity1 = unsafeBitCast(d, to: Int.self)
+    var identity1 = d._rawIdentifier()
 
     let foundIndex1 = d.index(forKey: 10)!
-    assert(identity1 == unsafeBitCast(d, to: Int.self))
+    assert(identity1 == d._rawIdentifier())
 
     assert(d[foundIndex1].0 == 10)
     assert(d[foundIndex1].1 == 1010)
@@ -563,30 +569,30 @@ DictionaryTestSuite.test("COW.Fast.RemoveAtDoesNotReallocate") {
     assert(removed.0 == 10)
     assert(removed.1 == 1010)
 
-    assert(identity1 == unsafeBitCast(d, to: Int.self))
+    assert(identity1 == d._rawIdentifier())
     assert(d.index(forKey: 10) == nil)
   }
 
   do {
     var d1 = getCOWFastDictionary()
-    var identity1 = unsafeBitCast(d1, to: Int.self)
+    var identity1 = d1._rawIdentifier()
 
     var d2 = d1
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
-    assert(identity1 == unsafeBitCast(d2, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
+    assert(identity1 == d2._rawIdentifier())
 
     var foundIndex1 = d2.index(forKey: 10)!
     assert(d2[foundIndex1].0 == 10)
     assert(d2[foundIndex1].1 == 1010)
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
-    assert(identity1 == unsafeBitCast(d2, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
+    assert(identity1 == d2._rawIdentifier())
 
     let removed = d2.remove(at: foundIndex1)
     assert(removed.0 == 10)
     assert(removed.1 == 1010)
 
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
-    assert(identity1 != unsafeBitCast(d2, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
+    assert(identity1 != d2._rawIdentifier())
     assert(d2.index(forKey: 10) == nil)
   }
 }
@@ -594,10 +600,10 @@ DictionaryTestSuite.test("COW.Fast.RemoveAtDoesNotReallocate") {
 DictionaryTestSuite.test("COW.Slow.RemoveAtDoesNotReallocate") {
   do {
     var d = getCOWSlowDictionary()
-    var identity1 = unsafeBitCast(d, to: Int.self)
+    var identity1 = d._rawIdentifier()
 
     var foundIndex1 = d.index(forKey: TestKeyTy(10))!
-    assert(identity1 == unsafeBitCast(d, to: Int.self))
+    assert(identity1 == d._rawIdentifier())
 
     assert(d[foundIndex1].0 == TestKeyTy(10))
     assert(d[foundIndex1].1.value == 1010)
@@ -606,17 +612,17 @@ DictionaryTestSuite.test("COW.Slow.RemoveAtDoesNotReallocate") {
     assert(removed.0 == TestKeyTy(10))
     assert(removed.1.value == 1010)
 
-    assert(identity1 == unsafeBitCast(d, to: Int.self))
+    assert(identity1 == d._rawIdentifier())
     assert(d.index(forKey: TestKeyTy(10)) == nil)
   }
 
   do {
     var d1 = getCOWSlowDictionary()
-    var identity1 = unsafeBitCast(d1, to: Int.self)
+    var identity1 = d1._rawIdentifier()
 
     var d2 = d1
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
-    assert(identity1 == unsafeBitCast(d2, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
+    assert(identity1 == d2._rawIdentifier())
 
     var foundIndex1 = d2.index(forKey: TestKeyTy(10))!
     assert(d2[foundIndex1].0 == TestKeyTy(10))
@@ -626,8 +632,8 @@ DictionaryTestSuite.test("COW.Slow.RemoveAtDoesNotReallocate") {
     assert(removed.0 == TestKeyTy(10))
     assert(removed.1.value == 1010)
 
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
-    assert(identity1 != unsafeBitCast(d2, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
+    assert(identity1 != d2._rawIdentifier())
     assert(d2.index(forKey: TestKeyTy(10)) == nil)
   }
 }
@@ -636,15 +642,15 @@ DictionaryTestSuite.test("COW.Slow.RemoveAtDoesNotReallocate") {
 DictionaryTestSuite.test("COW.Fast.RemoveValueForKeyDoesNotReallocate") {
   do {
     var d1 = getCOWFastDictionary()
-    var identity1 = unsafeBitCast(d1, to: Int.self)
+    var identity1 = d1._rawIdentifier()
 
     var deleted = d1.removeValue(forKey: 0)
     assert(deleted == nil)
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
 
     deleted = d1.removeValue(forKey: 10)
     assert(deleted! == 1010)
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
 
     // Keep variables alive.
     _fixLifetime(d1)
@@ -652,18 +658,18 @@ DictionaryTestSuite.test("COW.Fast.RemoveValueForKeyDoesNotReallocate") {
 
   do {
     var d1 = getCOWFastDictionary()
-    var identity1 = unsafeBitCast(d1, to: Int.self)
+    var identity1 = d1._rawIdentifier()
 
     var d2 = d1
     var deleted = d2.removeValue(forKey: 0)
     assert(deleted == nil)
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
-    assert(identity1 == unsafeBitCast(d2, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
+    assert(identity1 == d2._rawIdentifier())
 
     deleted = d2.removeValue(forKey: 10)
     assert(deleted! == 1010)
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
-    assert(identity1 != unsafeBitCast(d2, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
+    assert(identity1 != d2._rawIdentifier())
 
     // Keep variables alive.
     _fixLifetime(d1)
@@ -674,15 +680,15 @@ DictionaryTestSuite.test("COW.Fast.RemoveValueForKeyDoesNotReallocate") {
 DictionaryTestSuite.test("COW.Slow.RemoveValueForKeyDoesNotReallocate") {
   do {
     var d1 = getCOWSlowDictionary()
-    var identity1 = unsafeBitCast(d1, to: Int.self)
+    var identity1 = d1._rawIdentifier()
 
     var deleted = d1.removeValue(forKey: TestKeyTy(0))
     assert(deleted == nil)
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
 
     deleted = d1.removeValue(forKey: TestKeyTy(10))
     assert(deleted!.value == 1010)
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
 
     // Keep variables alive.
     _fixLifetime(d1)
@@ -690,18 +696,18 @@ DictionaryTestSuite.test("COW.Slow.RemoveValueForKeyDoesNotReallocate") {
 
   do {
     var d1 = getCOWSlowDictionary()
-    var identity1 = unsafeBitCast(d1, to: Int.self)
+    var identity1 = d1._rawIdentifier()
 
     var d2 = d1
     var deleted = d2.removeValue(forKey: TestKeyTy(0))
     assert(deleted == nil)
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
-    assert(identity1 == unsafeBitCast(d2, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
+    assert(identity1 == d2._rawIdentifier())
 
     deleted = d2.removeValue(forKey: TestKeyTy(10))
     assert(deleted!.value == 1010)
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
-    assert(identity1 != unsafeBitCast(d2, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
+    assert(identity1 != d2._rawIdentifier())
 
     // Keep variables alive.
     _fixLifetime(d1)
@@ -720,32 +726,32 @@ DictionaryTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
     d.removeAll()
     // We cannot assert that identity changed, since the new buffer of smaller
     // size can be allocated at the same address as the old one.
-    var identity1 = unsafeBitCast(d, to: Int.self)
+    var identity1 = d._rawIdentifier()
     assert(d._variantStorage.asNative.capacity < originalCapacity)
     assert(d.count == 0)
     assert(d[10] == nil)
 
     d.removeAll()
-    assert(identity1 == unsafeBitCast(d, to: Int.self))
+    assert(identity1 == d._rawIdentifier())
     assert(d.count == 0)
     assert(d[10] == nil)
   }
 
   do {
     var d = getCOWFastDictionary()
-    var identity1 = unsafeBitCast(d, to: Int.self)
+    var identity1 = d._rawIdentifier()
     let originalCapacity = d._variantStorage.asNative.capacity
     assert(d.count == 3)
     assert(d[10]! == 1010)
 
     d.removeAll(keepingCapacity: true)
-    assert(identity1 == unsafeBitCast(d, to: Int.self))
+    assert(identity1 == d._rawIdentifier())
     assert(d._variantStorage.asNative.capacity == originalCapacity)
     assert(d.count == 0)
     assert(d[10] == nil)
 
     d.removeAll(keepingCapacity: true)
-    assert(identity1 == unsafeBitCast(d, to: Int.self))
+    assert(identity1 == d._rawIdentifier())
     assert(d._variantStorage.asNative.capacity == originalCapacity)
     assert(d.count == 0)
     assert(d[10] == nil)
@@ -753,14 +759,14 @@ DictionaryTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
 
   do {
     var d1 = getCOWFastDictionary()
-    var identity1 = unsafeBitCast(d1, to: Int.self)
+    var identity1 = d1._rawIdentifier()
     assert(d1.count == 3)
     assert(d1[10]! == 1010)
 
     var d2 = d1
     d2.removeAll()
-    var identity2 = unsafeBitCast(d2, to: Int.self)
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
+    var identity2 = d2._rawIdentifier()
+    assert(identity1 == d1._rawIdentifier())
     assert(identity2 != identity1)
     assert(d1.count == 3)
     assert(d1[10]! == 1010)
@@ -774,15 +780,15 @@ DictionaryTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
 
   do {
     var d1 = getCOWFastDictionary()
-    var identity1 = unsafeBitCast(d1, to: Int.self)
+    var identity1 = d1._rawIdentifier()
     let originalCapacity = d1._variantStorage.asNative.capacity
     assert(d1.count == 3)
     assert(d1[10] == 1010)
 
     var d2 = d1
     d2.removeAll(keepingCapacity: true)
-    var identity2 = unsafeBitCast(d2, to: Int.self)
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
+    var identity2 = d2._rawIdentifier()
+    assert(identity1 == d1._rawIdentifier())
     assert(identity2 != identity1)
     assert(d1.count == 3)
     assert(d1[10]! == 1010)
@@ -806,32 +812,32 @@ DictionaryTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
     d.removeAll()
     // We cannot assert that identity changed, since the new buffer of smaller
     // size can be allocated at the same address as the old one.
-    var identity1 = unsafeBitCast(d, to: Int.self)
+    var identity1 = d._rawIdentifier()
     assert(d._variantStorage.asNative.capacity < originalCapacity)
     assert(d.count == 0)
     assert(d[TestKeyTy(10)] == nil)
 
     d.removeAll()
-    assert(identity1 == unsafeBitCast(d, to: Int.self))
+    assert(identity1 == d._rawIdentifier())
     assert(d.count == 0)
     assert(d[TestKeyTy(10)] == nil)
   }
 
   do {
     var d = getCOWSlowDictionary()
-    var identity1 = unsafeBitCast(d, to: Int.self)
+    var identity1 = d._rawIdentifier()
     let originalCapacity = d._variantStorage.asNative.capacity
     assert(d.count == 3)
     assert(d[TestKeyTy(10)]!.value == 1010)
 
     d.removeAll(keepingCapacity: true)
-    assert(identity1 == unsafeBitCast(d, to: Int.self))
+    assert(identity1 == d._rawIdentifier())
     assert(d._variantStorage.asNative.capacity == originalCapacity)
     assert(d.count == 0)
     assert(d[TestKeyTy(10)] == nil)
 
     d.removeAll(keepingCapacity: true)
-    assert(identity1 == unsafeBitCast(d, to: Int.self))
+    assert(identity1 == d._rawIdentifier())
     assert(d._variantStorage.asNative.capacity == originalCapacity)
     assert(d.count == 0)
     assert(d[TestKeyTy(10)] == nil)
@@ -839,14 +845,14 @@ DictionaryTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
 
   do {
     var d1 = getCOWSlowDictionary()
-    var identity1 = unsafeBitCast(d1, to: Int.self)
+    var identity1 = d1._rawIdentifier()
     assert(d1.count == 3)
     assert(d1[TestKeyTy(10)]!.value == 1010)
 
     var d2 = d1
     d2.removeAll()
-    var identity2 = unsafeBitCast(d2, to: Int.self)
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
+    var identity2 = d2._rawIdentifier()
+    assert(identity1 == d1._rawIdentifier())
     assert(identity2 != identity1)
     assert(d1.count == 3)
     assert(d1[TestKeyTy(10)]!.value == 1010)
@@ -860,15 +866,15 @@ DictionaryTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
 
   do {
     var d1 = getCOWSlowDictionary()
-    var identity1 = unsafeBitCast(d1, to: Int.self)
+    var identity1 = d1._rawIdentifier()
     let originalCapacity = d1._variantStorage.asNative.capacity
     assert(d1.count == 3)
     assert(d1[TestKeyTy(10)]!.value == 1010)
 
     var d2 = d1
     d2.removeAll(keepingCapacity: true)
-    var identity2 = unsafeBitCast(d2, to: Int.self)
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
+    var identity2 = d2._rawIdentifier()
+    assert(identity1 == d1._rawIdentifier())
     assert(identity2 != identity1)
     assert(d1.count == 3)
     assert(d1[TestKeyTy(10)]!.value == 1010)
@@ -885,24 +891,24 @@ DictionaryTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
 
 DictionaryTestSuite.test("COW.Fast.CountDoesNotReallocate") {
   var d = getCOWFastDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
 
   assert(d.count == 3)
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 }
 
 DictionaryTestSuite.test("COW.Slow.CountDoesNotReallocate") {
   var d = getCOWSlowDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
 
   assert(d.count == 3)
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 }
 
 
 DictionaryTestSuite.test("COW.Fast.GenerateDoesNotReallocate") {
   var d = getCOWFastDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
 
   var iter = d.makeIterator()
   var pairs = Array<(Int, Int)>()
@@ -910,12 +916,12 @@ DictionaryTestSuite.test("COW.Fast.GenerateDoesNotReallocate") {
     pairs += [(key, value)]
   }
   assert(equalsUnordered(pairs, [ (10, 1010), (20, 1020), (30, 1030) ]))
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 }
 
 DictionaryTestSuite.test("COW.Slow.GenerateDoesNotReallocate") {
   var d = getCOWSlowDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
 
   var iter = d.makeIterator()
   var pairs = Array<(Int, Int)>()
@@ -934,42 +940,42 @@ DictionaryTestSuite.test("COW.Slow.GenerateDoesNotReallocate") {
     pairs += [kv]
   }
   assert(equalsUnordered(pairs, [ (10, 1010), (20, 1020), (30, 1030) ]))
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 }
 
 
 DictionaryTestSuite.test("COW.Fast.EqualityTestDoesNotReallocate") {
   var d1 = getCOWFastDictionary()
-  var identity1 = unsafeBitCast(d1, to: Int.self)
+  var identity1 = d1._rawIdentifier()
 
   var d2 = getCOWFastDictionary()
-  var identity2 = unsafeBitCast(d2, to: Int.self)
+  var identity2 = d2._rawIdentifier()
 
   assert(d1 == d2)
-  assert(identity1 == unsafeBitCast(d1, to: Int.self))
-  assert(identity2 == unsafeBitCast(d2, to: Int.self))
+  assert(identity1 == d1._rawIdentifier())
+  assert(identity2 == d2._rawIdentifier())
 
   d2[40] = 2040
   assert(d1 != d2)
-  assert(identity1 == unsafeBitCast(d1, to: Int.self))
-  assert(identity2 == unsafeBitCast(d2, to: Int.self))
+  assert(identity1 == d1._rawIdentifier())
+  assert(identity2 == d2._rawIdentifier())
 }
 
 DictionaryTestSuite.test("COW.Slow.EqualityTestDoesNotReallocate") {
   var d1 = getCOWSlowEquatableDictionary()
-  var identity1 = unsafeBitCast(d1, to: Int.self)
+  var identity1 = d1._rawIdentifier()
 
   var d2 = getCOWSlowEquatableDictionary()
-  var identity2 = unsafeBitCast(d2, to: Int.self)
+  var identity2 = d2._rawIdentifier()
 
   assert(d1 == d2)
-  assert(identity1 == unsafeBitCast(d1, to: Int.self))
-  assert(identity2 == unsafeBitCast(d2, to: Int.self))
+  assert(identity1 == d1._rawIdentifier())
+  assert(identity2 == d2._rawIdentifier())
 
   d2[TestKeyTy(40)] = TestEquatableValueTy(2040)
   assert(d1 != d2)
-  assert(identity1 == unsafeBitCast(d1, to: Int.self))
-  assert(identity2 == unsafeBitCast(d2, to: Int.self))
+  assert(identity1 == d1._rawIdentifier())
+  assert(identity2 == d2._rawIdentifier())
 }
 
 
@@ -1370,7 +1376,7 @@ class CustomImmutableNSDictionary : NSDictionary {
 
 DictionaryTestSuite.test("BridgedFromObjC.Verbatim.DictionaryIsCopied") {
   var (d, nsd) = getBridgedVerbatimDictionaryAndNSMutableDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
   assert(isCocoaDictionary(d))
 
   // Find an existing key.
@@ -1395,7 +1401,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.DictionaryIsCopied") {
 
 DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.DictionaryIsCopied") {
   var (d, nsd) = getBridgedNonverbatimDictionaryAndNSMutableDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
   assert(isNativeDictionary(d))
 
   // Find an existing key.
@@ -1507,7 +1513,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.ImmutableDictionaryIsCopie
 
 DictionaryTestSuite.test("BridgedFromObjC.Verbatim.IndexForKey") {
   var d = getBridgedVerbatimDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
   assert(isCocoaDictionary(d))
 
   // Find an existing key.
@@ -1527,12 +1533,12 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.IndexForKey") {
 
   // Try to find a key that does not exist.
   assert(d.index(forKey: TestObjCKeyTy(40)) == nil)
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 }
 
 DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.IndexForKey") {
   var d = getBridgedNonverbatimDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
   assert(isNativeDictionary(d))
 
   // Find an existing key.
@@ -1552,12 +1558,12 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.IndexForKey") {
 
   // Try to find a key that does not exist.
   assert(d.index(forKey: TestBridgedKeyTy(40)) == nil)
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 }
 
 DictionaryTestSuite.test("BridgedFromObjC.Verbatim.SubscriptWithIndex") {
   var d = getBridgedVerbatimDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
   assert(isCocoaDictionary(d))
 
   var startIndex = d.startIndex
@@ -1567,7 +1573,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.SubscriptWithIndex") {
   assert(startIndex <= endIndex)
   assert(!(startIndex >= endIndex))
   assert(!(startIndex > endIndex))
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 
   var pairs = Array<(Int, Int)>()
   for i in d.indices {
@@ -1576,7 +1582,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.SubscriptWithIndex") {
     pairs += [kv]
   }
   assert(equalsUnordered(pairs, [ (10, 1010), (20, 1020), (30, 1030) ]))
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 
   // Keep indexes alive during the calls above.
   _fixLifetime(startIndex)
@@ -1585,7 +1591,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.SubscriptWithIndex") {
 
 DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithIndex") {
   var d = getBridgedNonverbatimDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
   assert(isNativeDictionary(d))
 
   var startIndex = d.startIndex
@@ -1595,7 +1601,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithIndex") {
   assert(startIndex <= endIndex)
   assert(!(startIndex >= endIndex))
   assert(!(startIndex > endIndex))
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 
   var pairs = Array<(Int, Int)>()
   for i in d.indices {
@@ -1604,7 +1610,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithIndex") {
     pairs += [kv]
   }
   assert(equalsUnordered(pairs, [ (10, 1010), (20, 1020), (30, 1030) ]))
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 
   // Keep indexes alive during the calls above.
   _fixLifetime(startIndex)
@@ -1613,7 +1619,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithIndex") {
 
 DictionaryTestSuite.test("BridgedFromObjC.Verbatim.SubscriptWithIndex_Empty") {
   var d = getBridgedVerbatimDictionary([:])
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
   assert(isCocoaDictionary(d))
 
   var startIndex = d.startIndex
@@ -1623,7 +1629,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.SubscriptWithIndex_Empty") {
   assert(startIndex <= endIndex)
   assert(startIndex >= endIndex)
   assert(!(startIndex > endIndex))
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 
   // Keep indexes alive during the calls above.
   _fixLifetime(startIndex)
@@ -1632,7 +1638,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.SubscriptWithIndex_Empty") {
 
 DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithIndex_Empty") {
   var d = getBridgedNonverbatimDictionary([:])
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
   assert(isNativeDictionary(d))
 
   var startIndex = d.startIndex
@@ -1642,7 +1648,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithIndex_Empty")
   assert(startIndex <= endIndex)
   assert(startIndex >= endIndex)
   assert(!(startIndex > endIndex))
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 
   // Keep indexes alive during the calls above.
   _fixLifetime(startIndex)
@@ -1651,7 +1657,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithIndex_Empty")
 
 DictionaryTestSuite.test("BridgedFromObjC.Verbatim.SubscriptWithKey") {
   var d = getBridgedVerbatimDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
   assert(isCocoaDictionary(d))
 
   // Read existing key-value pairs.
@@ -1664,11 +1670,11 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.SubscriptWithKey") {
   v = d[TestObjCKeyTy(30)] as! TestObjCValueTy
   assert(v.value == 1030)
 
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 
   // Insert a new key-value pair.
   d[TestObjCKeyTy(40)] = TestObjCValueTy(2040)
-  var identity2 = unsafeBitCast(d, to: Int.self)
+  var identity2 = d._rawIdentifier()
   assert(identity1 != identity2)
   assert(isNativeDictionary(d))
   assert(d.count == 4)
@@ -1687,7 +1693,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.SubscriptWithKey") {
 
   // Overwrite value in existing binding.
   d[TestObjCKeyTy(10)] = TestObjCValueTy(2010)
-  assert(identity2 == unsafeBitCast(d, to: Int.self))
+  assert(identity2 == d._rawIdentifier())
   assert(isNativeDictionary(d))
   assert(d.count == 4)
 
@@ -1706,7 +1712,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.SubscriptWithKey") {
 
 DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithKey") {
   var d = getBridgedNonverbatimDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
   assert(isNativeDictionary(d))
 
   // Read existing key-value pairs.
@@ -1719,11 +1725,11 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithKey") {
   v = d[TestBridgedKeyTy(30)]
   assert(v!.value == 1030)
 
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 
   // Insert a new key-value pair.
   d[TestBridgedKeyTy(40)] = TestBridgedValueTy(2040)
-  var identity2 = unsafeBitCast(d, to: Int.self)
+  var identity2 = d._rawIdentifier()
   assert(identity1 != identity2)
   assert(isNativeDictionary(d))
   assert(d.count == 4)
@@ -1742,7 +1748,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithKey") {
 
   // Overwrite value in existing binding.
   d[TestBridgedKeyTy(10)] = TestBridgedValueTy(2010)
-  assert(identity2 == unsafeBitCast(d, to: Int.self))
+  assert(identity2 == d._rawIdentifier())
   assert(isNativeDictionary(d))
   assert(d.count == 4)
 
@@ -1763,13 +1769,13 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.UpdateValueForKey") {
   // Insert a new key-value pair.
   do {
     var d = getBridgedVerbatimDictionary()
-    var identity1 = unsafeBitCast(d, to: Int.self)
+    var identity1 = d._rawIdentifier()
     assert(isCocoaDictionary(d))
 
     var oldValue: AnyObject? =
         d.updateValue(TestObjCValueTy(2040), forKey: TestObjCKeyTy(40))
     assert(oldValue == nil)
-    var identity2 = unsafeBitCast(d, to: Int.self)
+    var identity2 = d._rawIdentifier()
     assert(identity1 != identity2)
     assert(isNativeDictionary(d))
     assert(d.count == 4)
@@ -1783,14 +1789,14 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.UpdateValueForKey") {
   // Overwrite a value in existing binding.
   do {
     var d = getBridgedVerbatimDictionary()
-    var identity1 = unsafeBitCast(d, to: Int.self)
+    var identity1 = d._rawIdentifier()
     assert(isCocoaDictionary(d))
 
     var oldValue: AnyObject? =
         d.updateValue(TestObjCValueTy(2010), forKey: TestObjCKeyTy(10))
     assert((oldValue as! TestObjCValueTy).value == 1010)
 
-    var identity2 = unsafeBitCast(d, to: Int.self)
+    var identity2 = d._rawIdentifier()
     assert(identity1 != identity2)
     assert(isNativeDictionary(d))
     assert(d.count == 3)
@@ -1805,13 +1811,13 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.UpdateValueForKey") {
   // Insert a new key-value pair.
   do {
     var d = getBridgedNonverbatimDictionary()
-    var identity1 = unsafeBitCast(d, to: Int.self)
+    var identity1 = d._rawIdentifier()
     assert(isNativeDictionary(d))
 
     var oldValue =
         d.updateValue(TestBridgedValueTy(2040), forKey: TestBridgedKeyTy(40))
     assert(oldValue == nil)
-    var identity2 = unsafeBitCast(d, to: Int.self)
+    var identity2 = d._rawIdentifier()
     assert(identity1 != identity2)
     assert(isNativeDictionary(d))
     assert(d.count == 4)
@@ -1825,14 +1831,14 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.UpdateValueForKey") {
   // Overwrite a value in existing binding.
   do {
     var d = getBridgedNonverbatimDictionary()
-    var identity1 = unsafeBitCast(d, to: Int.self)
+    var identity1 = d._rawIdentifier()
     assert(isNativeDictionary(d))
 
     var oldValue =
         d.updateValue(TestBridgedValueTy(2010), forKey: TestBridgedKeyTy(10))!
     assert(oldValue.value == 1010)
 
-    var identity2 = unsafeBitCast(d, to: Int.self)
+    var identity2 = d._rawIdentifier()
     assert(identity1 == identity2)
     assert(isNativeDictionary(d))
     assert(d.count == 3)
@@ -1846,16 +1852,16 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.UpdateValueForKey") {
 
 DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveAt") {
   var d = getBridgedVerbatimDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
   assert(isCocoaDictionary(d))
 
   let foundIndex1 = d.index(forKey: TestObjCKeyTy(10))!
   assert(d[foundIndex1].0 == TestObjCKeyTy(10))
   assert((d[foundIndex1].1 as! TestObjCValueTy).value == 1010)
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 
   let removedElement = d.remove(at: foundIndex1)
-  assert(identity1 != unsafeBitCast(d, to: Int.self))
+  assert(identity1 != d._rawIdentifier())
   assert(isNativeDictionary(d))
   assert(removedElement.0 == TestObjCKeyTy(10))
   assert((removedElement.1 as! TestObjCValueTy).value == 1010)
@@ -1865,16 +1871,16 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveAt") {
 
 DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAt") {
   var d = getBridgedNonverbatimDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
   assert(isNativeDictionary(d))
 
   let foundIndex1 = d.index(forKey: TestBridgedKeyTy(10))!
   assert(d[foundIndex1].0 == TestBridgedKeyTy(10))
   assert(d[foundIndex1].1.value == 1010)
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 
   let removedElement = d.remove(at: foundIndex1)
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
   assert(isNativeDictionary(d))
   assert(removedElement.0 == TestObjCKeyTy(10) as TestBridgedKeyTy)
   assert(removedElement.1.value == 1010)
@@ -1886,17 +1892,17 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAt") {
 DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveValueForKey") {
   do {
     var d = getBridgedVerbatimDictionary()
-    var identity1 = unsafeBitCast(d, to: Int.self)
+    var identity1 = d._rawIdentifier()
     assert(isCocoaDictionary(d))
 
     var deleted: AnyObject? = d.removeValue(forKey: TestObjCKeyTy(0))
     assert(deleted == nil)
-    assert(identity1 == unsafeBitCast(d, to: Int.self))
+    assert(identity1 == d._rawIdentifier())
     assert(isCocoaDictionary(d))
 
     deleted = d.removeValue(forKey: TestObjCKeyTy(10))
     assert((deleted as! TestObjCValueTy).value == 1010)
-    var identity2 = unsafeBitCast(d, to: Int.self)
+    var identity2 = d._rawIdentifier()
     assert(identity1 != identity2)
     assert(isNativeDictionary(d))
     assert(d.count == 2)
@@ -1904,12 +1910,12 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveValueForKey") {
     assert(d[TestObjCKeyTy(10)] == nil)
     assert((d[TestObjCKeyTy(20)] as! TestObjCValueTy).value == 1020)
     assert((d[TestObjCKeyTy(30)] as! TestObjCValueTy).value == 1030)
-    assert(identity2 == unsafeBitCast(d, to: Int.self))
+    assert(identity2 == d._rawIdentifier())
   }
 
   do {
     var d1 = getBridgedVerbatimDictionary()
-    var identity1 = unsafeBitCast(d1, to: Int.self)
+    var identity1 = d1._rawIdentifier()
 
     var d2 = d1
     assert(isCocoaDictionary(d1))
@@ -1917,14 +1923,14 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveValueForKey") {
 
     var deleted: AnyObject? = d2.removeValue(forKey: TestObjCKeyTy(0))
     assert(deleted == nil)
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
-    assert(identity1 == unsafeBitCast(d2, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
+    assert(identity1 == d2._rawIdentifier())
     assert(isCocoaDictionary(d1))
     assert(isCocoaDictionary(d2))
 
     deleted = d2.removeValue(forKey: TestObjCKeyTy(10))
     assert((deleted as! TestObjCValueTy).value == 1010)
-    var identity2 = unsafeBitCast(d2, to: Int.self)
+    var identity2 = d2._rawIdentifier()
     assert(identity1 != identity2)
     assert(isCocoaDictionary(d1))
     assert(isNativeDictionary(d2))
@@ -1933,29 +1939,29 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveValueForKey") {
     assert((d1[TestObjCKeyTy(10)] as! TestObjCValueTy).value == 1010)
     assert((d1[TestObjCKeyTy(20)] as! TestObjCValueTy).value == 1020)
     assert((d1[TestObjCKeyTy(30)] as! TestObjCValueTy).value == 1030)
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
 
     assert(d2[TestObjCKeyTy(10)] == nil)
     assert((d2[TestObjCKeyTy(20)] as! TestObjCValueTy).value == 1020)
     assert((d2[TestObjCKeyTy(30)] as! TestObjCValueTy).value == 1030)
-    assert(identity2 == unsafeBitCast(d2, to: Int.self))
+    assert(identity2 == d2._rawIdentifier())
   }
 }
 
 DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveValueForKey") {
   do {
     var d = getBridgedNonverbatimDictionary()
-    var identity1 = unsafeBitCast(d, to: Int.self)
+    var identity1 = d._rawIdentifier()
     assert(isNativeDictionary(d))
 
     var deleted = d.removeValue(forKey: TestBridgedKeyTy(0))
     assert(deleted == nil)
-    assert(identity1 == unsafeBitCast(d, to: Int.self))
+    assert(identity1 == d._rawIdentifier())
     assert(isNativeDictionary(d))
 
     deleted = d.removeValue(forKey: TestBridgedKeyTy(10))
     assert(deleted!.value == 1010)
-    var identity2 = unsafeBitCast(d, to: Int.self)
+    var identity2 = d._rawIdentifier()
     assert(identity1 == identity2)
     assert(isNativeDictionary(d))
     assert(d.count == 2)
@@ -1963,12 +1969,12 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveValueForKey") {
     assert(d[TestBridgedKeyTy(10)] == nil)
     assert(d[TestBridgedKeyTy(20)]!.value == 1020)
     assert(d[TestBridgedKeyTy(30)]!.value == 1030)
-    assert(identity2 == unsafeBitCast(d, to: Int.self))
+    assert(identity2 == d._rawIdentifier())
   }
 
   do {
     var d1 = getBridgedNonverbatimDictionary()
-    var identity1 = unsafeBitCast(d1, to: Int.self)
+    var identity1 = d1._rawIdentifier()
 
     var d2 = d1
     assert(isNativeDictionary(d1))
@@ -1976,14 +1982,14 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveValueForKey") {
 
     var deleted = d2.removeValue(forKey: TestBridgedKeyTy(0))
     assert(deleted == nil)
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
-    assert(identity1 == unsafeBitCast(d2, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
+    assert(identity1 == d2._rawIdentifier())
     assert(isNativeDictionary(d1))
     assert(isNativeDictionary(d2))
 
     deleted = d2.removeValue(forKey: TestBridgedKeyTy(10))
     assert(deleted!.value == 1010)
-    var identity2 = unsafeBitCast(d2, to: Int.self)
+    var identity2 = d2._rawIdentifier()
     assert(identity1 != identity2)
     assert(isNativeDictionary(d1))
     assert(isNativeDictionary(d2))
@@ -1992,12 +1998,12 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveValueForKey") {
     assert(d1[TestBridgedKeyTy(10)]!.value == 1010)
     assert(d1[TestBridgedKeyTy(20)]!.value == 1020)
     assert(d1[TestBridgedKeyTy(30)]!.value == 1030)
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
 
     assert(d2[TestBridgedKeyTy(10)] == nil)
     assert(d2[TestBridgedKeyTy(20)]!.value == 1020)
     assert(d2[TestBridgedKeyTy(30)]!.value == 1030)
-    assert(identity2 == unsafeBitCast(d2, to: Int.self))
+    assert(identity2 == d2._rawIdentifier())
   }
 }
 
@@ -2005,25 +2011,25 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveValueForKey") {
 DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
   do {
     var d = getBridgedVerbatimDictionary([:])
-    var identity1 = unsafeBitCast(d, to: Int.self)
+    var identity1 = d._rawIdentifier()
     assert(isCocoaDictionary(d))
     assert(d.count == 0)
 
     d.removeAll()
-    assert(identity1 == unsafeBitCast(d, to: Int.self))
+    assert(identity1 == d._rawIdentifier())
     assert(d.count == 0)
   }
 
   do {
     var d = getBridgedVerbatimDictionary()
-    var identity1 = unsafeBitCast(d, to: Int.self)
+    var identity1 = d._rawIdentifier()
     assert(isCocoaDictionary(d))
     let originalCapacity = d.count
     assert(d.count == 3)
     assert((d[TestObjCKeyTy(10)] as! TestObjCValueTy).value == 1010)
 
     d.removeAll()
-    assert(identity1 != unsafeBitCast(d, to: Int.self))
+    assert(identity1 != d._rawIdentifier())
     assert(d._variantStorage.asNative.capacity < originalCapacity)
     assert(d.count == 0)
     assert(d[TestObjCKeyTy(10)] == nil)
@@ -2031,14 +2037,14 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
 
   do {
     var d = getBridgedVerbatimDictionary()
-    var identity1 = unsafeBitCast(d, to: Int.self)
+    var identity1 = d._rawIdentifier()
     assert(isCocoaDictionary(d))
     let originalCapacity = d.count
     assert(d.count == 3)
     assert((d[TestObjCKeyTy(10)] as! TestObjCValueTy).value == 1010)
 
     d.removeAll(keepingCapacity: true)
-    assert(identity1 != unsafeBitCast(d, to: Int.self))
+    assert(identity1 != d._rawIdentifier())
     assert(d._variantStorage.asNative.capacity >= originalCapacity)
     assert(d.count == 0)
     assert(d[TestObjCKeyTy(10)] == nil)
@@ -2046,7 +2052,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
 
   do {
     var d1 = getBridgedVerbatimDictionary()
-    var identity1 = unsafeBitCast(d1, to: Int.self)
+    var identity1 = d1._rawIdentifier()
     assert(isCocoaDictionary(d1))
     let originalCapacity = d1.count
     assert(d1.count == 3)
@@ -2054,8 +2060,8 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
 
     var d2 = d1
     d2.removeAll()
-    var identity2 = unsafeBitCast(d2, to: Int.self)
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
+    var identity2 = d2._rawIdentifier()
+    assert(identity1 == d1._rawIdentifier())
     assert(identity2 != identity1)
     assert(d1.count == 3)
     assert((d1[TestObjCKeyTy(10)] as! TestObjCValueTy).value == 1010)
@@ -2066,7 +2072,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
 
   do {
     var d1 = getBridgedVerbatimDictionary()
-    var identity1 = unsafeBitCast(d1, to: Int.self)
+    var identity1 = d1._rawIdentifier()
     assert(isCocoaDictionary(d1))
     let originalCapacity = d1.count
     assert(d1.count == 3)
@@ -2074,8 +2080,8 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
 
     var d2 = d1
     d2.removeAll(keepingCapacity: true)
-    var identity2 = unsafeBitCast(d2, to: Int.self)
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
+    var identity2 = d2._rawIdentifier()
+    assert(identity1 == d1._rawIdentifier())
     assert(identity2 != identity1)
     assert(d1.count == 3)
     assert((d1[TestObjCKeyTy(10)] as! TestObjCValueTy).value == 1010)
@@ -2088,25 +2094,25 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
 DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
   do {
     var d = getBridgedNonverbatimDictionary([:])
-    var identity1 = unsafeBitCast(d, to: Int.self)
+    var identity1 = d._rawIdentifier()
     assert(isNativeDictionary(d))
     assert(d.count == 0)
 
     d.removeAll()
-    assert(identity1 == unsafeBitCast(d, to: Int.self))
+    assert(identity1 == d._rawIdentifier())
     assert(d.count == 0)
   }
 
   do {
     var d = getBridgedNonverbatimDictionary()
-    var identity1 = unsafeBitCast(d, to: Int.self)
+    var identity1 = d._rawIdentifier()
     assert(isNativeDictionary(d))
     let originalCapacity = d.count
     assert(d.count == 3)
     assert(d[TestBridgedKeyTy(10)]!.value == 1010)
 
     d.removeAll()
-    assert(identity1 != unsafeBitCast(d, to: Int.self))
+    assert(identity1 != d._rawIdentifier())
     assert(d._variantStorage.asNative.capacity < originalCapacity)
     assert(d.count == 0)
     assert(d[TestBridgedKeyTy(10)] == nil)
@@ -2114,14 +2120,14 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
 
   do {
     var d = getBridgedNonverbatimDictionary()
-    var identity1 = unsafeBitCast(d, to: Int.self)
+    var identity1 = d._rawIdentifier()
     assert(isNativeDictionary(d))
     let originalCapacity = d.count
     assert(d.count == 3)
     assert(d[TestBridgedKeyTy(10)]!.value == 1010)
 
     d.removeAll(keepingCapacity: true)
-    assert(identity1 == unsafeBitCast(d, to: Int.self))
+    assert(identity1 == d._rawIdentifier())
     assert(d._variantStorage.asNative.capacity >= originalCapacity)
     assert(d.count == 0)
     assert(d[TestBridgedKeyTy(10)] == nil)
@@ -2129,7 +2135,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
 
   do {
     var d1 = getBridgedNonverbatimDictionary()
-    var identity1 = unsafeBitCast(d1, to: Int.self)
+    var identity1 = d1._rawIdentifier()
     assert(isNativeDictionary(d1))
     let originalCapacity = d1.count
     assert(d1.count == 3)
@@ -2137,8 +2143,8 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
 
     var d2 = d1
     d2.removeAll()
-    var identity2 = unsafeBitCast(d2, to: Int.self)
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
+    var identity2 = d2._rawIdentifier()
+    assert(identity1 == d1._rawIdentifier())
     assert(identity2 != identity1)
     assert(d1.count == 3)
     assert(d1[TestBridgedKeyTy(10)]!.value == 1010)
@@ -2149,7 +2155,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
 
   do {
     var d1 = getBridgedNonverbatimDictionary()
-    var identity1 = unsafeBitCast(d1, to: Int.self)
+    var identity1 = d1._rawIdentifier()
     assert(isNativeDictionary(d1))
     let originalCapacity = d1.count
     assert(d1.count == 3)
@@ -2157,8 +2163,8 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
 
     var d2 = d1
     d2.removeAll(keepingCapacity: true)
-    var identity2 = unsafeBitCast(d2, to: Int.self)
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
+    var identity2 = d2._rawIdentifier()
+    assert(identity1 == d1._rawIdentifier())
     assert(identity2 != identity1)
     assert(d1.count == 3)
     assert(d1[TestBridgedKeyTy(10)]!.value == 1010)
@@ -2171,26 +2177,26 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
 
 DictionaryTestSuite.test("BridgedFromObjC.Verbatim.Count") {
   var d = getBridgedVerbatimDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
   assert(isCocoaDictionary(d))
 
   assert(d.count == 3)
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 }
 
 DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.Count") {
   var d = getBridgedNonverbatimDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
   assert(isNativeDictionary(d))
 
   assert(d.count == 3)
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 }
 
 
 DictionaryTestSuite.test("BridgedFromObjC.Verbatim.Generate") {
   var d = getBridgedVerbatimDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
   assert(isCocoaDictionary(d))
 
   var iter = d.makeIterator()
@@ -2205,12 +2211,12 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.Generate") {
   assert(iter.next() == nil)
   assert(iter.next() == nil)
   assert(iter.next() == nil)
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 }
 
 DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.Generate") {
   var d = getBridgedNonverbatimDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
   assert(isNativeDictionary(d))
 
   var iter = d.makeIterator()
@@ -2225,12 +2231,12 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.Generate") {
   assert(iter.next() == nil)
   assert(iter.next() == nil)
   assert(iter.next() == nil)
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 }
 
 DictionaryTestSuite.test("BridgedFromObjC.Verbatim.Generate_Empty") {
   var d = getBridgedVerbatimDictionary([:])
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
   assert(isCocoaDictionary(d))
 
   var iter = d.makeIterator()
@@ -2243,12 +2249,12 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.Generate_Empty") {
   assert(iter.next() == nil)
   assert(iter.next() == nil)
   assert(iter.next() == nil)
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 }
 
 DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.Generate_Empty") {
   var d = getBridgedNonverbatimDictionary([:])
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
   assert(isNativeDictionary(d))
 
   var iter = d.makeIterator()
@@ -2261,13 +2267,13 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.Generate_Empty") {
   assert(iter.next() == nil)
   assert(iter.next() == nil)
   assert(iter.next() == nil)
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 }
 
 
 DictionaryTestSuite.test("BridgedFromObjC.Verbatim.Generate_Huge") {
   var d = getHugeBridgedVerbatimDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
   assert(isCocoaDictionary(d))
 
   var iter = d.makeIterator()
@@ -2286,12 +2292,12 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.Generate_Huge") {
   assert(iter.next() == nil)
   assert(iter.next() == nil)
   assert(iter.next() == nil)
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 }
 
 DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.Generate_Huge") {
   var d = getHugeBridgedNonverbatimDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
   assert(isNativeDictionary(d))
 
   var iter = d.makeIterator()
@@ -2310,7 +2316,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.Generate_Huge") {
   assert(iter.next() == nil)
   assert(iter.next() == nil)
   assert(iter.next() == nil)
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 }
 
 
@@ -2320,7 +2326,7 @@ autoreleasepoolIfUnoptimizedReturnAutoreleased {
   // values in objectForKey.
 
   var d = getParallelArrayBridgedVerbatimDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
   assert(isCocoaDictionary(d))
 
   var iter = d.makeIterator()
@@ -2336,7 +2342,7 @@ autoreleasepoolIfUnoptimizedReturnAutoreleased {
   assert(iter.next() == nil)
   assert(iter.next() == nil)
   assert(iter.next() == nil)
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 }
 }
 
@@ -2346,7 +2352,7 @@ autoreleasepoolIfUnoptimizedReturnAutoreleased {
   // values in objectForKey.
 
   var d = getParallelArrayBridgedNonverbatimDictionary()
-  var identity1 = unsafeBitCast(d, to: Int.self)
+  var identity1 = d._rawIdentifier()
   assert(isNativeDictionary(d))
 
   var iter = d.makeIterator()
@@ -2362,69 +2368,69 @@ autoreleasepoolIfUnoptimizedReturnAutoreleased {
   assert(iter.next() == nil)
   assert(iter.next() == nil)
   assert(iter.next() == nil)
-  assert(identity1 == unsafeBitCast(d, to: Int.self))
+  assert(identity1 == d._rawIdentifier())
 }
 }
 
 
 DictionaryTestSuite.test("BridgedFromObjC.Verbatim.EqualityTest_Empty") {
   var d1 = getBridgedVerbatimEquatableDictionary([:])
-  var identity1 = unsafeBitCast(d1, to: Int.self)
+  var identity1 = d1._rawIdentifier()
   assert(isCocoaDictionary(d1))
 
   var d2 = getBridgedVerbatimEquatableDictionary([:])
-  var identity2 = unsafeBitCast(d2, to: Int.self)
+  var identity2 = d2._rawIdentifier()
   assert(isCocoaDictionary(d2))
 
   // We can't check that `identity1 != identity2` because Foundation might be
   // returning the same singleton NSDictionary for empty dictionaries.
 
   assert(d1 == d2)
-  assert(identity1 == unsafeBitCast(d1, to: Int.self))
-  assert(identity2 == unsafeBitCast(d2, to: Int.self))
+  assert(identity1 == d1._rawIdentifier())
+  assert(identity2 == d2._rawIdentifier())
 
   d2[TestObjCKeyTy(10)] = TestObjCEquatableValueTy(2010)
   assert(isNativeDictionary(d2))
-  assert(identity2 != unsafeBitCast(d2, to: Int.self))
-  identity2 = unsafeBitCast(d2, to: Int.self)
+  assert(identity2 != d2._rawIdentifier())
+  identity2 = d2._rawIdentifier()
 
   assert(d1 != d2)
-  assert(identity1 == unsafeBitCast(d1, to: Int.self))
-  assert(identity2 == unsafeBitCast(d2, to: Int.self))
+  assert(identity1 == d1._rawIdentifier())
+  assert(identity2 == d2._rawIdentifier())
 }
 
 DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.EqualityTest_Empty") {
   var d1 = getBridgedNonverbatimEquatableDictionary([:])
-  var identity1 = unsafeBitCast(d1, to: Int.self)
+  var identity1 = d1._rawIdentifier()
   assert(isNativeDictionary(d1))
 
   var d2 = getBridgedNonverbatimEquatableDictionary([:])
-  var identity2 = unsafeBitCast(d2, to: Int.self)
+  var identity2 = d2._rawIdentifier()
   assert(isNativeDictionary(d2))
   assert(identity1 != identity2)
 
   assert(d1 == d2)
-  assert(identity1 == unsafeBitCast(d1, to: Int.self))
-  assert(identity2 == unsafeBitCast(d2, to: Int.self))
+  assert(identity1 == d1._rawIdentifier())
+  assert(identity2 == d2._rawIdentifier())
 
   d2[TestBridgedKeyTy(10)] = TestBridgedEquatableValueTy(2010)
   assert(isNativeDictionary(d2))
-  assert(identity2 == unsafeBitCast(d2, to: Int.self))
+  assert(identity2 == d2._rawIdentifier())
 
   assert(d1 != d2)
-  assert(identity1 == unsafeBitCast(d1, to: Int.self))
-  assert(identity2 == unsafeBitCast(d2, to: Int.self))
+  assert(identity1 == d1._rawIdentifier())
+  assert(identity2 == d2._rawIdentifier())
 }
 
 
 DictionaryTestSuite.test("BridgedFromObjC.Verbatim.EqualityTest_Small") {
   func helper(_ nd1: Dictionary<Int, Int>, _ nd2: Dictionary<Int, Int>, _ expectedEq: Bool) {
     let d1 = getBridgedVerbatimEquatableDictionary(nd1)
-    let identity1 = unsafeBitCast(d1, to: Int.self)
+    let identity1 = d1._rawIdentifier()
     assert(isCocoaDictionary(d1))
 
     var d2 = getBridgedVerbatimEquatableDictionary(nd2)
-    var identity2 = unsafeBitCast(d2, to: Int.self)
+    var identity2 = d2._rawIdentifier()
     assert(isCocoaDictionary(d2))
 
     do {
@@ -2440,14 +2446,14 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.EqualityTest_Small") {
       let neq2 = (d2 != d1)
       assert(neq2 != expectedEq)
     }
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
-    assert(identity2 == unsafeBitCast(d2, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
+    assert(identity2 == d2._rawIdentifier())
 
     d2[TestObjCKeyTy(1111)] = TestObjCEquatableValueTy(1111)
     d2[TestObjCKeyTy(1111)] = nil
     assert(isNativeDictionary(d2))
-    assert(identity2 != unsafeBitCast(d2, to: Int.self))
-    identity2 = unsafeBitCast(d2, to: Int.self)
+    assert(identity2 != d2._rawIdentifier())
+    identity2 = d2._rawIdentifier()
 
     do {
       let eq1 = (d1 == d2)
@@ -2462,8 +2468,8 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.EqualityTest_Small") {
       let neq2 = (d2 != d1)
       assert(neq2 != expectedEq)
     }
-    assert(identity1 == unsafeBitCast(d1, to: Int.self))
-    assert(identity2 == unsafeBitCast(d2, to: Int.self))
+    assert(identity1 == d1._rawIdentifier())
+    assert(identity2 == d2._rawIdentifier())
   }
 
   helper([:], [:], true)

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -27,6 +27,11 @@ import Glibc
 // For experimental Set operators
 import SwiftExperimental
 
+extension Set {
+  func _rawIdentifier() -> Int {
+    return unsafeBitCast(self, to: Int.self)
+  }
+}
 
 // Check that the generic parameter is called 'Element'.
 protocol TestProtocol1 {}
@@ -329,17 +334,17 @@ SetTestSuite.test("sizeof") {
 SetTestSuite.test("COW.Smoke") {
   var s1 = Set<TestKeyTy>(minimumCapacity: 10)
   for i in [1010, 2020, 3030]{ s1.insert(TestKeyTy(i)) }
-  var identity1 = unsafeBitCast(s1, to: Int.self)
+  var identity1 = s1._rawIdentifier()
 
   var s2 = s1
   _fixLifetime(s2)
-  expectEqual(identity1, unsafeBitCast(s2, to: Int.self))
+  expectEqual(identity1, s2._rawIdentifier())
 
   s2.insert(TestKeyTy(4040))
-  expectNotEqual(identity1, unsafeBitCast(s2, to: Int.self))
+  expectNotEqual(identity1, s2._rawIdentifier())
 
   s2.insert(TestKeyTy(5050))
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 
   // Keep variables alive.
   _fixLifetime(s1)
@@ -348,7 +353,7 @@ SetTestSuite.test("COW.Smoke") {
 
 SetTestSuite.test("COW.Fast.IndexesDontAffectUniquenessCheck") {
   var s = getCOWFastSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
 
   var startIndex = s.startIndex
   var endIndex = s.endIndex
@@ -358,10 +363,10 @@ SetTestSuite.test("COW.Fast.IndexesDontAffectUniquenessCheck") {
   expectFalse(startIndex >= endIndex)
   expectFalse(startIndex > endIndex)
 
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 
   s.insert(4040)
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 
   // Keep indexes alive during the calls above.
   _fixLifetime(startIndex)
@@ -370,7 +375,7 @@ SetTestSuite.test("COW.Fast.IndexesDontAffectUniquenessCheck") {
 
 SetTestSuite.test("COW.Slow.IndexesDontAffectUniquenessCheck") {
   var s = getCOWSlowSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
 
   var startIndex = s.startIndex
   var endIndex = s.endIndex
@@ -380,9 +385,9 @@ SetTestSuite.test("COW.Slow.IndexesDontAffectUniquenessCheck") {
   expectFalse(startIndex >= endIndex)
   expectFalse(startIndex > endIndex)
 
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
   s.insert(TestKeyTy(4040))
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 
   // Keep indexes alive during the calls above.
   _fixLifetime(startIndex)
@@ -391,7 +396,7 @@ SetTestSuite.test("COW.Slow.IndexesDontAffectUniquenessCheck") {
 
 SetTestSuite.test("COW.Fast.SubscriptWithIndexDoesNotReallocate") {
   var s = getCOWFastSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
 
   var startIndex = s.startIndex
   let empty = startIndex == s.endIndex
@@ -399,15 +404,15 @@ SetTestSuite.test("COW.Fast.SubscriptWithIndexDoesNotReallocate") {
   expectTrue(s.startIndex <= s.endIndex)
   expectEqual(empty, (s.startIndex >= s.endIndex))
   expectFalse(s.startIndex > s.endIndex)
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 
   expectNotEqual(0, s[startIndex])
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 }
 
 SetTestSuite.test("COW.Slow.SubscriptWithIndexDoesNotReallocate") {
   var s = getCOWSlowSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
 
   var startIndex = s.startIndex
   let empty = startIndex == s.endIndex
@@ -415,18 +420,18 @@ SetTestSuite.test("COW.Slow.SubscriptWithIndexDoesNotReallocate") {
   expectTrue(s.startIndex <= s.endIndex)
   expectEqual(empty, (s.startIndex >= s.endIndex))
   expectFalse(s.startIndex > s.endIndex)
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 
   expectNotEqual(TestKeyTy(0), s[startIndex])
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 }
 
 SetTestSuite.test("COW.Fast.ContainsDoesNotReallocate") {
   var s = getCOWFastSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
 
   expectTrue(s.contains(1010))
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 
   do {
     var s2: Set<MinimalHashableValue> = []
@@ -443,14 +448,14 @@ SetTestSuite.test("COW.Fast.ContainsDoesNotReallocate") {
 
 SetTestSuite.test("COW.Slow.ContainsDoesNotReallocate") {
   var s = getCOWSlowSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
 
   expectTrue(s.contains(TestKeyTy(1010)))
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 
   // Insert a new key-value pair.
   s.insert(TestKeyTy(4040))
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
   expectEqual(4, s.count)
   expectTrue(s.contains(TestKeyTy(1010)))
   expectTrue(s.contains(TestKeyTy(2020)))
@@ -459,7 +464,7 @@ SetTestSuite.test("COW.Slow.ContainsDoesNotReallocate") {
 
   // Delete an existing key.
   s.remove(TestKeyTy(1010))
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
   expectEqual(3, s.count)
   expectTrue(s.contains(TestKeyTy(2020)))
   expectTrue(s.contains(TestKeyTy(3030)))
@@ -467,7 +472,7 @@ SetTestSuite.test("COW.Slow.ContainsDoesNotReallocate") {
 
   // Try to delete a key that does not exist.
   s.remove(TestKeyTy(777))
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
   expectEqual(3, s.count)
   expectTrue(s.contains(TestKeyTy(2020)))
   expectTrue(s.contains(TestKeyTy(3030)))
@@ -489,51 +494,51 @@ SetTestSuite.test("COW.Slow.ContainsDoesNotReallocate") {
 SetTestSuite.test("COW.Fast.InsertDoesNotReallocate") {
   var s1 = getCOWFastSet()
 
-  let identity1 = unsafeBitCast(s1, to: Int.self)
+  let identity1 = s1._rawIdentifier()
   let count1 = s1.count
 
   // Inserting a redundant element should not create new storage
   s1.insert(2020)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
   expectEqual(count1, s1.count)
 
   s1.insert(4040)
   s1.insert(5050)
   s1.insert(6060)
   expectEqual(count1 + 3, s1.count)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 }
 
 SetTestSuite.test("COW.Slow.InsertDoesNotReallocate") {
   do {
     var s1 = getCOWSlowSet()
 
-    let identity1 = unsafeBitCast(s1, to: Int.self)
+    let identity1 = s1._rawIdentifier()
     let count1 = s1.count
 
     // Inserting a redundant element should not create new storage
     s1.insert(TestKeyTy(2020))
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+    expectEqual(identity1, s1._rawIdentifier())
     expectEqual(count1, s1.count)
 
     s1.insert(TestKeyTy(4040))
     s1.insert(TestKeyTy(5050))
     s1.insert(TestKeyTy(6060))
     expectEqual(count1 + 3, s1.count)
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+    expectEqual(identity1, s1._rawIdentifier())
   }
 
   do {
     var s1 = getCOWSlowSet()
-    var identity1 = unsafeBitCast(s1, to: Int.self)
+    var identity1 = s1._rawIdentifier()
 
     var s2 = s1
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-    expectEqual(identity1, unsafeBitCast(s2, to: Int.self))
+    expectEqual(identity1, s1._rawIdentifier())
+    expectEqual(identity1, s2._rawIdentifier())
 
     s2.insert(TestKeyTy(2040))
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-    expectNotEqual(identity1, unsafeBitCast(s2, to: Int.self))
+    expectEqual(identity1, s1._rawIdentifier())
+    expectNotEqual(identity1, s2._rawIdentifier())
 
     expectEqual(3, s1.count)
     expectTrue(s1.contains(TestKeyTy(1010)))
@@ -554,16 +559,16 @@ SetTestSuite.test("COW.Slow.InsertDoesNotReallocate") {
 
   do {
     var s1 = getCOWSlowSet()
-    var identity1 = unsafeBitCast(s1, to: Int.self)
+    var identity1 = s1._rawIdentifier()
 
     var s2 = s1
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-    expectEqual(identity1, unsafeBitCast(s2, to: Int.self))
+    expectEqual(identity1, s1._rawIdentifier())
+    expectEqual(identity1, s2._rawIdentifier())
 
     // Replace a redundant element.
     s2.update(with: TestKeyTy(2020))
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-    expectNotEqual(identity1, unsafeBitCast(s2, to: Int.self))
+    expectEqual(identity1, s1._rawIdentifier())
+    expectNotEqual(identity1, s2._rawIdentifier())
 
     expectEqual(3, s1.count)
     expectTrue(s1.contains(TestKeyTy(1010)))
@@ -583,25 +588,25 @@ SetTestSuite.test("COW.Slow.InsertDoesNotReallocate") {
 
 SetTestSuite.test("COW.Fast.IndexForMemberDoesNotReallocate") {
   var s = getCOWFastSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
 
   // Find an existing key.
   do {
     var foundIndex1 = s.index(of: 1010)!
-    expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+    expectEqual(identity1, s._rawIdentifier())
 
     var foundIndex2 = s.index(of: 1010)!
     expectEqual(foundIndex1, foundIndex2)
 
     expectEqual(1010, s[foundIndex1])
-    expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+    expectEqual(identity1, s._rawIdentifier())
   }
 
   // Try to find a key that is not present.
   do {
     var foundIndex1 = s.index(of: 1111)
     expectEmpty(foundIndex1)
-    expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+    expectEqual(identity1, s._rawIdentifier())
   }
 
   do {
@@ -619,25 +624,25 @@ SetTestSuite.test("COW.Fast.IndexForMemberDoesNotReallocate") {
 
 SetTestSuite.test("COW.Slow.IndexForMemberDoesNotReallocate") {
   var s = getCOWSlowSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
 
   // Find an existing key.
   do {
     var foundIndex1 = s.index(of: TestKeyTy(1010))!
-    expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+    expectEqual(identity1, s._rawIdentifier())
 
     var foundIndex2 = s.index(of: TestKeyTy(1010))!
     expectEqual(foundIndex1, foundIndex2)
 
     expectEqual(TestKeyTy(1010), s[foundIndex1])
-    expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+    expectEqual(identity1, s._rawIdentifier())
   }
 
   // Try to find a key that is not present.
   do {
     var foundIndex1 = s.index(of: TestKeyTy(1111))
     expectEmpty(foundIndex1)
-    expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+    expectEqual(identity1, s._rawIdentifier())
   }
 
   do {
@@ -656,38 +661,38 @@ SetTestSuite.test("COW.Slow.IndexForMemberDoesNotReallocate") {
 SetTestSuite.test("COW.Fast.RemoveAtDoesNotReallocate") {
   do {
     var s = getCOWFastSet()
-    var identity1 = unsafeBitCast(s, to: Int.self)
+    var identity1 = s._rawIdentifier()
 
     let foundIndex1 = s.index(of: 1010)!
-    expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+    expectEqual(identity1, s._rawIdentifier())
 
     expectEqual(1010, s[foundIndex1])
 
     let removed = s.remove(at: foundIndex1)
     expectEqual(1010, removed)
 
-    expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+    expectEqual(identity1, s._rawIdentifier())
     expectEmpty(s.index(of: 1010))
   }
 
   do {
     var s1 = getCOWFastSet()
-    var identity1 = unsafeBitCast(s1, to: Int.self)
+    var identity1 = s1._rawIdentifier()
 
     var s2 = s1
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-    expectEqual(identity1, unsafeBitCast(s2, to: Int.self))
+    expectEqual(identity1, s1._rawIdentifier())
+    expectEqual(identity1, s2._rawIdentifier())
 
     var foundIndex1 = s2.index(of: 1010)!
     expectEqual(1010, s2[foundIndex1])
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-    expectEqual(identity1, unsafeBitCast(s2, to: Int.self))
+    expectEqual(identity1, s1._rawIdentifier())
+    expectEqual(identity1, s2._rawIdentifier())
 
     let removed = s2.remove(at: foundIndex1)
     expectEqual(1010, removed)
 
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-    expectNotEqual(identity1, unsafeBitCast(s2, to: Int.self))
+    expectEqual(identity1, s1._rawIdentifier())
+    expectNotEqual(identity1, s2._rawIdentifier())
     expectEmpty(s2.index(of: 1010))
   }
 }
@@ -695,38 +700,38 @@ SetTestSuite.test("COW.Fast.RemoveAtDoesNotReallocate") {
 SetTestSuite.test("COW.Slow.RemoveAtDoesNotReallocate") {
   do {
     var s = getCOWSlowSet()
-    var identity1 = unsafeBitCast(s, to: Int.self)
+    var identity1 = s._rawIdentifier()
 
     let foundIndex1 = s.index(of: TestKeyTy(1010))!
-    expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+    expectEqual(identity1, s._rawIdentifier())
 
     expectEqual(TestKeyTy(1010), s[foundIndex1])
 
     let removed = s.remove(at: foundIndex1)
     expectEqual(TestKeyTy(1010), removed)
 
-    expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+    expectEqual(identity1, s._rawIdentifier())
     expectEmpty(s.index(of: TestKeyTy(1010)))
   }
 
   do {
     var s1 = getCOWSlowSet()
-    var identity1 = unsafeBitCast(s1, to: Int.self)
+    var identity1 = s1._rawIdentifier()
 
     var s2 = s1
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-    expectEqual(identity1, unsafeBitCast(s2, to: Int.self))
+    expectEqual(identity1, s1._rawIdentifier())
+    expectEqual(identity1, s2._rawIdentifier())
 
     var foundIndex1 = s2.index(of: TestKeyTy(1010))!
     expectEqual(TestKeyTy(1010), s2[foundIndex1])
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-    expectEqual(identity1, unsafeBitCast(s2, to: Int.self))
+    expectEqual(identity1, s1._rawIdentifier())
+    expectEqual(identity1, s2._rawIdentifier())
 
     let removed = s2.remove(at: foundIndex1)
     expectEqual(TestKeyTy(1010), removed)
 
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-    expectNotEqual(identity1, unsafeBitCast(s2, to: Int.self))
+    expectEqual(identity1, s1._rawIdentifier())
+    expectNotEqual(identity1, s2._rawIdentifier())
     expectEmpty(s2.index(of: TestKeyTy(1010)))
   }
 }
@@ -734,15 +739,15 @@ SetTestSuite.test("COW.Slow.RemoveAtDoesNotReallocate") {
 SetTestSuite.test("COW.Fast.RemoveDoesNotReallocate") {
   do {
     var s1 = getCOWFastSet()
-    var identity1 = unsafeBitCast(s1, to: Int.self)
+    var identity1 = s1._rawIdentifier()
 
     var deleted = s1.remove(0)
     expectEmpty(deleted)
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+    expectEqual(identity1, s1._rawIdentifier())
 
     deleted = s1.remove(1010)
     expectOptionalEqual(1010, deleted)
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+    expectEqual(identity1, s1._rawIdentifier())
 
     // Keep variables alive.
     _fixLifetime(s1)
@@ -750,18 +755,18 @@ SetTestSuite.test("COW.Fast.RemoveDoesNotReallocate") {
 
   do {
     var s1 = getCOWFastSet()
-    var identity1 = unsafeBitCast(s1, to: Int.self)
+    var identity1 = s1._rawIdentifier()
 
     var s2 = s1
     var deleted = s2.remove(0)
     expectEmpty(deleted)
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-    expectEqual(identity1, unsafeBitCast(s2, to: Int.self))
+    expectEqual(identity1, s1._rawIdentifier())
+    expectEqual(identity1, s2._rawIdentifier())
 
     deleted = s2.remove(1010)
     expectOptionalEqual(1010, deleted)
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-    expectNotEqual(identity1, unsafeBitCast(s2, to: Int.self))
+    expectEqual(identity1, s1._rawIdentifier())
+    expectNotEqual(identity1, s2._rawIdentifier())
 
     // Keep variables alive.
     _fixLifetime(s1)
@@ -772,15 +777,15 @@ SetTestSuite.test("COW.Fast.RemoveDoesNotReallocate") {
 SetTestSuite.test("COW.Slow.RemoveDoesNotReallocate") {
   do {
     var s1 = getCOWSlowSet()
-    var identity1 = unsafeBitCast(s1, to: Int.self)
+    var identity1 = s1._rawIdentifier()
 
     var deleted = s1.remove(TestKeyTy(0))
     expectEmpty(deleted)
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+    expectEqual(identity1, s1._rawIdentifier())
 
     deleted = s1.remove(TestKeyTy(1010))
     expectOptionalEqual(TestKeyTy(1010), deleted)
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+    expectEqual(identity1, s1._rawIdentifier())
 
     // Keep variables alive.
     _fixLifetime(s1)
@@ -788,18 +793,18 @@ SetTestSuite.test("COW.Slow.RemoveDoesNotReallocate") {
 
   do {
     var s1 = getCOWSlowSet()
-    var identity1 = unsafeBitCast(s1, to: Int.self)
+    var identity1 = s1._rawIdentifier()
 
     var s2 = s1
     var deleted = s2.remove(TestKeyTy(0))
     expectEmpty(deleted)
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-    expectEqual(identity1, unsafeBitCast(s2, to: Int.self))
+    expectEqual(identity1, s1._rawIdentifier())
+    expectEqual(identity1, s2._rawIdentifier())
 
     deleted = s2.remove(TestKeyTy(1010))
     expectOptionalEqual(TestKeyTy(1010), deleted)
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-    expectNotEqual(identity1, unsafeBitCast(s2, to: Int.self))
+    expectEqual(identity1, s1._rawIdentifier())
+    expectNotEqual(identity1, s2._rawIdentifier())
 
     // Keep variables alive.
     _fixLifetime(s1)
@@ -812,16 +817,16 @@ SetTestSuite.test("COW.Fast.UnionInPlaceSmallSetDoesNotReallocate") {
   let s2 = Set([4040, 5050, 6060])
   let s3 = Set([1010, 2020, 3030, 4040, 5050, 6060])
 
-  let identity1 = unsafeBitCast(s1, to: Int.self)
+  let identity1 = s1._rawIdentifier()
 
   // Adding the empty set should obviously not allocate
   s1.formUnion(Set<Int>())
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 
   // adding a small set shouldn't cause a reallocation
   s1.formUnion(s2)
   expectEqual(s1, s3)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 }
 
 SetTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
@@ -834,32 +839,32 @@ SetTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
     s.removeAll()
     // We cannot expectTrue that identity changed, since the new buffer of
     // smaller size can be allocated at the same address as the old one.
-    var identity1 = unsafeBitCast(s, to: Int.self)
+    var identity1 = s._rawIdentifier()
     expectTrue(s._variantStorage.asNative.capacity < originalCapacity)
     expectEqual(0, s.count)
     expectFalse(s.contains(1010))
 
     s.removeAll()
-    expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+    expectEqual(identity1, s._rawIdentifier())
     expectEqual(0, s.count)
     expectFalse(s.contains(1010))
   }
 
   do {
     var s = getCOWFastSet()
-    var identity1 = unsafeBitCast(s, to: Int.self)
+    var identity1 = s._rawIdentifier()
     let originalCapacity = s._variantStorage.asNative.capacity
     expectEqual(3, s.count)
     expectTrue(s.contains(1010))
 
     s.removeAll(keepingCapacity: true)
-    expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+    expectEqual(identity1, s._rawIdentifier())
     expectEqual(originalCapacity, s._variantStorage.asNative.capacity)
     expectEqual(0, s.count)
     expectFalse(s.contains(1010))
 
     s.removeAll(keepingCapacity: true)
-    expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+    expectEqual(identity1, s._rawIdentifier())
     expectEqual(originalCapacity, s._variantStorage.asNative.capacity)
     expectEqual(0, s.count)
     expectFalse(s.contains(1010))
@@ -867,14 +872,14 @@ SetTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
 
   do {
     var s1 = getCOWFastSet()
-    var identity1 = unsafeBitCast(s1, to: Int.self)
+    var identity1 = s1._rawIdentifier()
     expectEqual(3, s1.count)
     expectTrue(s1.contains(1010))
 
     var s2 = s1
     s2.removeAll()
-    var identity2 = unsafeBitCast(s2, to: Int.self)
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+    var identity2 = s2._rawIdentifier()
+    expectEqual(identity1, s1._rawIdentifier())
     expectNotEqual(identity1, identity2)
     expectEqual(3, s1.count)
     expectTrue(s1.contains(1010))
@@ -888,15 +893,15 @@ SetTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
 
   do {
     var s1 = getCOWFastSet()
-    var identity1 = unsafeBitCast(s1, to: Int.self)
+    var identity1 = s1._rawIdentifier()
     let originalCapacity = s1._variantStorage.asNative.capacity
     expectEqual(3, s1.count)
     expectTrue(s1.contains(1010))
 
     var s2 = s1
     s2.removeAll(keepingCapacity: true)
-    var identity2 = unsafeBitCast(s2, to: Int.self)
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+    var identity2 = s2._rawIdentifier()
+    expectEqual(identity1, s1._rawIdentifier())
     expectNotEqual(identity1, identity2)
     expectEqual(3, s1.count)
     expectTrue(s1.contains(1010))
@@ -920,32 +925,32 @@ SetTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
     s.removeAll()
     // We cannot expectTrue that identity changed, since the new buffer of
     // smaller size can be allocated at the same address as the old one.
-    var identity1 = unsafeBitCast(s, to: Int.self)
+    var identity1 = s._rawIdentifier()
     expectTrue(s._variantStorage.asNative.capacity < originalCapacity)
     expectEqual(0, s.count)
     expectFalse(s.contains(TestKeyTy(1010)))
 
     s.removeAll()
-    expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+    expectEqual(identity1, s._rawIdentifier())
     expectEqual(0, s.count)
     expectFalse(s.contains(TestKeyTy(1010)))
   }
 
   do {
     var s = getCOWSlowSet()
-    var identity1 = unsafeBitCast(s, to: Int.self)
+    var identity1 = s._rawIdentifier()
     let originalCapacity = s._variantStorage.asNative.capacity
     expectEqual(3, s.count)
     expectTrue(s.contains(TestKeyTy(1010)))
 
     s.removeAll(keepingCapacity: true)
-    expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+    expectEqual(identity1, s._rawIdentifier())
     expectEqual(originalCapacity, s._variantStorage.asNative.capacity)
     expectEqual(0, s.count)
     expectFalse(s.contains(TestKeyTy(1010)))
 
     s.removeAll(keepingCapacity: true)
-    expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+    expectEqual(identity1, s._rawIdentifier())
     expectEqual(originalCapacity, s._variantStorage.asNative.capacity)
     expectEqual(0, s.count)
     expectFalse(s.contains(TestKeyTy(1010)))
@@ -953,14 +958,14 @@ SetTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
 
   do {
     var s1 = getCOWSlowSet()
-    var identity1 = unsafeBitCast(s1, to: Int.self)
+    var identity1 = s1._rawIdentifier()
     expectEqual(3, s1.count)
     expectTrue(s1.contains(TestKeyTy(1010)))
 
     var s2 = s1
     s2.removeAll()
-    var identity2 = unsafeBitCast(s2, to: Int.self)
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+    var identity2 = s2._rawIdentifier()
+    expectEqual(identity1, s1._rawIdentifier())
     expectNotEqual(identity1, identity2)
     expectEqual(3, s1.count)
     expectTrue(s1.contains(TestKeyTy(1010)))
@@ -974,15 +979,15 @@ SetTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
 
   do {
     var s1 = getCOWSlowSet()
-    var identity1 = unsafeBitCast(s1, to: Int.self)
+    var identity1 = s1._rawIdentifier()
     let originalCapacity = s1._variantStorage.asNative.capacity
     expectEqual(3, s1.count)
     expectTrue(s1.contains(TestKeyTy(1010)))
 
     var s2 = s1
     s2.removeAll(keepingCapacity: true)
-    var identity2 = unsafeBitCast(s2, to: Int.self)
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+    var identity2 = s2._rawIdentifier()
+    expectEqual(identity1, s1._rawIdentifier())
     expectNotEqual(identity1, identity2)
     expectEqual(3, s1.count)
     expectTrue(s1.contains(TestKeyTy(1010)))
@@ -998,39 +1003,39 @@ SetTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
 
 SetTestSuite.test("COW.Fast.FirstDoesNotReallocate") {
   var s = getCOWFastSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
 
   expectNotEmpty(s.first)
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 }
 
 SetTestSuite.test("COW.Fast.CountDoesNotReallocate") {
   var s = getCOWFastSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
 
   expectEqual(3, s.count)
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 }
 
 SetTestSuite.test("COW.Slow.FirstDoesNotReallocate") {
   var s = getCOWSlowSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
 
   expectNotEmpty(s.first)
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 }
 
 SetTestSuite.test("COW.Slow.CountDoesNotReallocate") {
   var s = getCOWSlowSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
 
   expectEqual(3, s.count)
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 }
 
 SetTestSuite.test("COW.Fast.GenerateDoesNotReallocate") {
   var s = getCOWFastSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
 
   var iter = s.makeIterator()
   var items: [Int] = []
@@ -1038,12 +1043,12 @@ SetTestSuite.test("COW.Fast.GenerateDoesNotReallocate") {
     items += [value]
   }
   expectTrue(equalsUnordered(items, [ 1010, 2020, 3030 ]))
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 }
 
 SetTestSuite.test("COW.Slow.GenerateDoesNotReallocate") {
   var s = getCOWSlowSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
 
   var iter = s.makeIterator()
   var items: [Int] = []
@@ -1051,31 +1056,31 @@ SetTestSuite.test("COW.Slow.GenerateDoesNotReallocate") {
     items.append(value.value)
   }
   expectTrue(equalsUnordered(items, [ 1010, 2020, 3030 ]))
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 }
 
 SetTestSuite.test("COW.Fast.EqualityTestDoesNotReallocate") {
   var s1 = getCOWFastSet()
-  var identity1 = unsafeBitCast(s1, to: Int.self)
+  var identity1 = s1._rawIdentifier()
 
   var s2 = getCOWFastSet()
-  var identity2 = unsafeBitCast(s2, to: Int.self)
+  var identity2 = s2._rawIdentifier()
 
   expectEqual(s1, s2)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-  expectEqual(identity2, unsafeBitCast(s2, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
+  expectEqual(identity2, s2._rawIdentifier())
 }
 
 SetTestSuite.test("COW.Slow.EqualityTestDoesNotReallocate") {
   var s1 = getCOWFastSet()
-  var identity1 = unsafeBitCast(s1, to: Int.self)
+  var identity1 = s1._rawIdentifier()
 
   var s2 = getCOWFastSet()
-  var identity2 = unsafeBitCast(s2, to: Int.self)
+  var identity2 = s2._rawIdentifier()
 
   expectEqual(s1, s2)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-  expectEqual(identity2, unsafeBitCast(s2, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
+  expectEqual(identity2, s2._rawIdentifier())
 }
 
 //===---
@@ -1228,7 +1233,6 @@ class CustomImmutableNSSet : NSSet {
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.SetIsCopied") {
   var (s, nss) = getBridgedVerbatimSetAndNSMutableSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
   expectTrue(isCocoaSet(s))
 
   expectTrue(s.contains(TestObjCKeyTy(1010)))
@@ -1242,7 +1246,6 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.SetIsCopied") {
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.SetIsCopied") {
   var (s, nss) = getBridgedNonverbatimSetAndNSMutableSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
   expectTrue(isNativeSet(s))
 
   expectTrue(s.contains(TestBridgedKeyTy(1010)))
@@ -1337,7 +1340,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.ImmutableSetIsCopied") {
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.IndexForMember") {
   var s = getBridgedVerbatimSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
   expectTrue(isCocoaSet(s))
 
   // Find an existing key.
@@ -1352,12 +1355,12 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.IndexForMember") {
 
   // Try to find a key that does not exist.
   expectEmpty(s.index(of: TestObjCKeyTy(4040)))
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.IndexForMember") {
   var s = getBridgedNonverbatimSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
 
   do {
     var member = s[s.index(of: TestBridgedKeyTy(1010))!]
@@ -1371,19 +1374,19 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.IndexForMember") {
   }
 
   expectEmpty(s.index(of: TestBridgedKeyTy(4040)))
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 }
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.Insert") {
   do {
     var s = getBridgedVerbatimSet()
-    var identity1 = unsafeBitCast(s, to: Int.self)
+    var identity1 = s._rawIdentifier()
     expectTrue(isCocoaSet(s))
 
     expectFalse(s.contains(TestObjCKeyTy(2040)))
     s.insert(TestObjCKeyTy(2040))
 
-    var identity2 = unsafeBitCast(s, to: Int.self)
+    var identity2 = s._rawIdentifier()
     expectNotEqual(identity1, identity2)
     expectTrue(isNativeSet(s))
     expectEqual(4, s.count)
@@ -1398,13 +1401,13 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.Insert") {
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.Insert") {
   do {
     var s = getBridgedNonverbatimSet()
-    var identity1 = unsafeBitCast(s, to: Int.self)
+    var identity1 = s._rawIdentifier()
     expectTrue(isNativeSet(s))
 
     expectFalse(s.contains(TestBridgedKeyTy(2040)))
     s.insert(TestObjCKeyTy(2040) as TestBridgedKeyTy)
 
-    var identity2 = unsafeBitCast(s, to: Int.self)
+    var identity2 = s._rawIdentifier()
     expectNotEqual(identity1, identity2)
     expectTrue(isNativeSet(s))
     expectEqual(4, s.count)
@@ -1418,7 +1421,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Insert") {
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.SubscriptWithIndex") {
   var s = getBridgedVerbatimSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
   expectTrue(isCocoaSet(s))
 
   var startIndex = s.startIndex
@@ -1428,7 +1431,7 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.SubscriptWithIndex") {
   expectTrue(startIndex <= endIndex)
   expectFalse(startIndex >= endIndex)
   expectFalse(startIndex > endIndex)
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 
   var members = [Int]()
   for i in s.indices {
@@ -1437,7 +1440,7 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.SubscriptWithIndex") {
     members.append(member.value)
   }
   expectTrue(equalsUnordered(members, [1010, 2020, 3030]))
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 
   // Keep indexes alive during the calls above.
   _fixLifetime(startIndex)
@@ -1446,7 +1449,7 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.SubscriptWithIndex") {
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithIndex") {
   var s = getBridgedNonverbatimSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
   expectTrue(isNativeSet(s))
 
   var startIndex = s.startIndex
@@ -1456,7 +1459,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithIndex") {
   expectTrue(startIndex <= endIndex)
   expectFalse(startIndex >= endIndex)
   expectFalse(startIndex > endIndex)
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 
   var members = [Int]()
   for i in s.indices {
@@ -1465,7 +1468,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithIndex") {
     members.append(member.value)
   }
   expectTrue(equalsUnordered(members, [1010, 2020, 3030]))
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 
   // Keep indexes alive during the calls above.
   _fixLifetime(startIndex)
@@ -1474,7 +1477,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithIndex") {
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.SubscriptWithIndex_Empty") {
   var s = getBridgedVerbatimSet([])
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
   expectTrue(isCocoaSet(s))
 
   var startIndex = s.startIndex
@@ -1484,7 +1487,7 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.SubscriptWithIndex_Empty") {
   expectTrue(startIndex <= endIndex)
   expectTrue(startIndex >= endIndex)
   expectFalse(startIndex > endIndex)
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 
   // Keep indexes alive during the calls above.
   _fixLifetime(startIndex)
@@ -1493,7 +1496,7 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.SubscriptWithIndex_Empty") {
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithIndex_Empty") {
   var s = getBridgedNonverbatimSet([])
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
   expectTrue(isNativeSet(s))
 
   var startIndex = s.startIndex
@@ -1503,7 +1506,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithIndex_Empty") {
   expectTrue(startIndex <= endIndex)
   expectTrue(startIndex >= endIndex)
   expectFalse(startIndex > endIndex)
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 
   // Keep indexes alive during the calls above.
   _fixLifetime(startIndex)
@@ -1512,18 +1515,18 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithIndex_Empty") {
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.Contains") {
   var s = getBridgedVerbatimSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
   expectTrue(isCocoaSet(s))
 
   expectTrue(s.contains(TestObjCKeyTy(1010)))
   expectTrue(s.contains(TestObjCKeyTy(2020)))
   expectTrue(s.contains(TestObjCKeyTy(3030)))
 
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 
   // Inserting an item should now create storage unique from the bridged set.
   s.insert(TestObjCKeyTy(4040))
-  var identity2 = unsafeBitCast(s, to: Int.self)
+  var identity2 = s._rawIdentifier()
   expectNotEqual(identity1, identity2)
   expectTrue(isNativeSet(s))
   expectEqual(4, s.count)
@@ -1537,7 +1540,7 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.Contains") {
   // Insert a redundant item to the set.
   // A copy should *not* occur here.
   s.insert(TestObjCKeyTy(1010))
-  expectEqual(identity2, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity2, s._rawIdentifier())
   expectTrue(isNativeSet(s))
   expectEqual(4, s.count)
 
@@ -1550,18 +1553,18 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.Contains") {
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.Contains") {
   var s = getBridgedNonverbatimSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
   expectTrue(isNativeSet(s))
 
   expectTrue(s.contains(TestBridgedKeyTy(1010)))
   expectTrue(s.contains(TestBridgedKeyTy(2020)))
   expectTrue(s.contains(TestBridgedKeyTy(3030)))
 
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 
   // Inserting an item should now create storage unique from the bridged set.
   s.insert(TestBridgedKeyTy(4040))
-  var identity2 = unsafeBitCast(s, to: Int.self)
+  var identity2 = s._rawIdentifier()
   expectNotEqual(identity1, identity2)
   expectTrue(isNativeSet(s))
   expectEqual(4, s.count)
@@ -1575,7 +1578,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Contains") {
   // Insert a redundant item to the set.
   // A copy should *not* occur here.
   s.insert(TestBridgedKeyTy(1010))
-  expectEqual(identity2, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity2, s._rawIdentifier())
   expectTrue(isNativeSet(s))
   expectEqual(4, s.count)
 
@@ -1588,19 +1591,19 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Contains") {
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithMember") {
   var s = getBridgedNonverbatimSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
   expectTrue(isNativeSet(s))
 
   expectTrue(s.contains(TestBridgedKeyTy(1010)))
   expectTrue(s.contains(TestBridgedKeyTy(2020)))
   expectTrue(s.contains(TestBridgedKeyTy(3030)))
 
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 
   // Insert a new member.
   // This should trigger a copy.
   s.insert(TestBridgedKeyTy(4040))
-  var identity2 = unsafeBitCast(s, to: Int.self)
+  var identity2 = s._rawIdentifier()
 
   expectTrue(isNativeSet(s))
   expectEqual(4, s.count)
@@ -1614,7 +1617,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithMember") {
   // Insert a redundant member.
   // This should *not* trigger a copy.
   s.insert(TestBridgedKeyTy(1010))
-  expectEqual(identity2, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity2, s._rawIdentifier())
   expectTrue(isNativeSet(s))
   expectEqual(4, s.count)
 
@@ -1627,15 +1630,15 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithMember") {
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.RemoveAt") {
   var s = getBridgedVerbatimSet()
-  let identity1 = unsafeBitCast(s, to: Int.self)
+  let identity1 = s._rawIdentifier()
   expectTrue(isCocoaSet(s))
 
   let foundIndex1 = s.index(of: TestObjCKeyTy(1010))!
   expectEqual(TestObjCKeyTy(1010), s[foundIndex1])
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 
   let removedElement = s.remove(at: foundIndex1)
-  expectNotEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectNotEqual(identity1, s._rawIdentifier())
   expectTrue(isNativeSet(s))
   expectEqual(2, s.count)
   expectEqual(TestObjCKeyTy(1010), removedElement)
@@ -1644,15 +1647,15 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.RemoveAt") {
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAt") {
   var s = getBridgedNonverbatimSet()
-  let identity1 = unsafeBitCast(s, to: Int.self)
+  let identity1 = s._rawIdentifier()
   expectTrue(isNativeSet(s))
 
   let foundIndex1 = s.index(of: TestBridgedKeyTy(1010))!
   expectEqual(1010, s[foundIndex1].value)
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 
   let removedElement = s.remove(at: foundIndex1)
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
   expectTrue(isNativeSet(s))
   expectEqual(1010, removedElement.value)
   expectEqual(2, s.count)
@@ -1662,17 +1665,17 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAt") {
 SetTestSuite.test("BridgedFromObjC.Verbatim.Remove") {
   do {
     var s = getBridgedVerbatimSet()
-    var identity1 = unsafeBitCast(s, to: Int.self)
+    var identity1 = s._rawIdentifier()
     expectTrue(isCocoaSet(s))
 
     var deleted: AnyObject? = s.remove(TestObjCKeyTy(0))
     expectEmpty(deleted)
-    expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+    expectEqual(identity1, s._rawIdentifier())
     expectTrue(isCocoaSet(s))
 
     deleted = s.remove(TestObjCKeyTy(1010))
     expectEqual(1010, deleted!.value)
-    var identity2 = unsafeBitCast(s, to: Int.self)
+    var identity2 = s._rawIdentifier()
     expectNotEqual(identity1, identity2)
     expectTrue(isNativeSet(s))
     expectEqual(2, s.count)
@@ -1680,12 +1683,12 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.Remove") {
     expectFalse(s.contains(TestObjCKeyTy(1010)))
     expectTrue(s.contains(TestObjCKeyTy(2020)))
     expectTrue(s.contains(TestObjCKeyTy(3030)))
-    expectEqual(identity2, unsafeBitCast(s, to: Int.self))
+    expectEqual(identity2, s._rawIdentifier())
   }
 
   do {
     var s1 = getBridgedVerbatimSet()
-    var identity1 = unsafeBitCast(s1, to: Int.self)
+    var identity1 = s1._rawIdentifier()
 
     var s2 = s1
     expectTrue(isCocoaSet(s1))
@@ -1693,14 +1696,14 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.Remove") {
 
     var deleted: AnyObject? = s2.remove(TestObjCKeyTy(0))
     expectEmpty(deleted)
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-    expectEqual(identity1, unsafeBitCast(s2, to: Int.self))
+    expectEqual(identity1, s1._rawIdentifier())
+    expectEqual(identity1, s2._rawIdentifier())
     expectTrue(isCocoaSet(s1))
     expectTrue(isCocoaSet(s2))
 
     deleted = s2.remove(TestObjCKeyTy(1010))
     expectEqual(1010, deleted!.value)
-    var identity2 = unsafeBitCast(s2, to: Int.self)
+    var identity2 = s2._rawIdentifier()
     expectNotEqual(identity1, identity2)
     expectTrue(isCocoaSet(s1))
     expectTrue(isNativeSet(s2))
@@ -1709,34 +1712,34 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.Remove") {
     expectTrue(s1.contains(TestObjCKeyTy(1010)))
     expectTrue(s1.contains(TestObjCKeyTy(2020)))
     expectTrue(s1.contains(TestObjCKeyTy(3030)))
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+    expectEqual(identity1, s1._rawIdentifier())
 
     expectFalse(s2.contains(TestObjCKeyTy(1010)))
     expectTrue(s2.contains(TestObjCKeyTy(2020)))
     expectTrue(s2.contains(TestObjCKeyTy(3030)))
 
-    expectEqual(identity2, unsafeBitCast(s2, to: Int.self))
+    expectEqual(identity2, s2._rawIdentifier())
   }
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.Remove") {
   do {
     var s = getBridgedNonverbatimSet()
-    var identity1 = unsafeBitCast(s, to: Int.self)
+    var identity1 = s._rawIdentifier()
     expectTrue(isNativeSet(s))
 
     // Trying to remove something not in the set should
     // leave it completely unchanged.
     var deleted = s.remove(TestBridgedKeyTy(0))
     expectEmpty(deleted)
-    expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+    expectEqual(identity1, s._rawIdentifier())
     expectTrue(isNativeSet(s))
 
     // Now remove an item that is in the set. This should
     // not create a new set altogether, however.
     deleted = s.remove(TestBridgedKeyTy(1010))
     expectEqual(1010, deleted!.value)
-    var identity2 = unsafeBitCast(s, to: Int.self)
+    var identity2 = s._rawIdentifier()
     expectEqual(identity1, identity2)
     expectTrue(isNativeSet(s))
     expectEqual(2, s.count)
@@ -1749,12 +1752,12 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Remove") {
     expectTrue(s.contains(TestBridgedKeyTy(3030)))
 
     // Triple-check - we should still be working with the same object.
-    expectEqual(identity2, unsafeBitCast(s, to: Int.self))
+    expectEqual(identity2, s._rawIdentifier())
   }
 
   do {
     var s1 = getBridgedNonverbatimSet()
-    let identity1 = unsafeBitCast(s1, to: Int.self)
+    let identity1 = s1._rawIdentifier()
 
     var s2 = s1
     expectTrue(isNativeSet(s1))
@@ -1762,14 +1765,14 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Remove") {
 
     var deleted = s2.remove(TestBridgedKeyTy(0))
     expectEmpty(deleted)
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-    expectEqual(identity1, unsafeBitCast(s2, to: Int.self))
+    expectEqual(identity1, s1._rawIdentifier())
+    expectEqual(identity1, s2._rawIdentifier())
     expectTrue(isNativeSet(s1))
     expectTrue(isNativeSet(s2))
 
     deleted = s2.remove(TestBridgedKeyTy(1010))
     expectEqual(1010, deleted!.value)
-    let identity2 = unsafeBitCast(s2, to: Int.self)
+    let identity2 = s2._rawIdentifier()
     expectNotEqual(identity1, identity2)
     expectTrue(isNativeSet(s1))
     expectTrue(isNativeSet(s2))
@@ -1778,30 +1781,30 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Remove") {
     expectTrue(s1.contains(TestBridgedKeyTy(1010)))
     expectTrue(s1.contains(TestBridgedKeyTy(2020)))
     expectTrue(s1.contains(TestBridgedKeyTy(3030)))
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+    expectEqual(identity1, s1._rawIdentifier())
 
     expectFalse(s2.contains(TestBridgedKeyTy(1010)))
     expectTrue(s2.contains(TestBridgedKeyTy(2020)))
     expectTrue(s2.contains(TestBridgedKeyTy(3030)))
-    expectEqual(identity2, unsafeBitCast(s2, to: Int.self))
+    expectEqual(identity2, s2._rawIdentifier())
   }
 }
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
   do {
     var s = getBridgedVerbatimSet([])
-    var identity1 = unsafeBitCast(s, to: Int.self)
+    var identity1 = s._rawIdentifier()
     expectTrue(isCocoaSet(s))
     expectEqual(0, s.count)
 
     s.removeAll()
-    expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+    expectEqual(identity1, s._rawIdentifier())
     expectEqual(0, s.count)
   }
 
   do {
     var s = getBridgedVerbatimSet()
-    var identity1 = unsafeBitCast(s, to: Int.self)
+    var identity1 = s._rawIdentifier()
     expectTrue(isCocoaSet(s))
     expectEqual(3, s.count)
     expectTrue(s.contains(TestBridgedKeyTy(1010) as NSObject))
@@ -1813,15 +1816,15 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
 
   do {
     var s1 = getBridgedVerbatimSet()
-    var identity1 = unsafeBitCast(s1, to: Int.self)
+    var identity1 = s1._rawIdentifier()
     expectTrue(isCocoaSet(s1))
     expectEqual(3, s1.count)
     expectTrue(s1.contains(TestBridgedKeyTy(1010) as NSObject))
 
     var s2 = s1
     s2.removeAll()
-    var identity2 = unsafeBitCast(s2, to: Int.self)
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+    var identity2 = s2._rawIdentifier()
+    expectEqual(identity1, s1._rawIdentifier())
     expectNotEqual(identity2, identity1)
     expectEqual(3, s1.count)
     expectTrue(s1.contains(TestBridgedKeyTy(1010) as NSObject))
@@ -1831,15 +1834,15 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
 
   do {
     var s1 = getBridgedVerbatimSet()
-    var identity1 = unsafeBitCast(s1, to: Int.self)
+    var identity1 = s1._rawIdentifier()
     expectTrue(isCocoaSet(s1))
     expectEqual(3, s1.count)
     expectTrue(s1.contains(TestBridgedKeyTy(1010) as NSObject))
 
     var s2 = s1
     s2.removeAll(keepingCapacity: true)
-    var identity2 = unsafeBitCast(s2, to: Int.self)
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+    var identity2 = s2._rawIdentifier()
+    expectEqual(identity1, s1._rawIdentifier())
     expectNotEqual(identity2, identity1)
     expectEqual(3, s1.count)
     expectTrue(s1.contains(TestBridgedKeyTy(1010) as NSObject))
@@ -1851,18 +1854,18 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
   do {
     var s = getBridgedNonverbatimSet([])
-    var identity1 = unsafeBitCast(s, to: Int.self)
+    var identity1 = s._rawIdentifier()
     expectTrue(isNativeSet(s))
     expectEqual(0, s.count)
 
     s.removeAll()
-    expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+    expectEqual(identity1, s._rawIdentifier())
     expectEqual(0, s.count)
   }
 
   do {
     var s = getBridgedNonverbatimSet()
-    var identity1 = unsafeBitCast(s, to: Int.self)
+    var identity1 = s._rawIdentifier()
     expectTrue(isNativeSet(s))
     expectEqual(3, s.count)
     expectTrue(s.contains(TestBridgedKeyTy(1010)))
@@ -1874,15 +1877,15 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
 
   do {
     var s1 = getBridgedNonverbatimSet()
-    var identity1 = unsafeBitCast(s1, to: Int.self)
+    var identity1 = s1._rawIdentifier()
     expectTrue(isNativeSet(s1))
     expectEqual(3, s1.count)
     expectTrue(s1.contains(TestBridgedKeyTy(1010)))
 
     var s2 = s1
     s2.removeAll()
-    var identity2 = unsafeBitCast(s2, to: Int.self)
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+    var identity2 = s2._rawIdentifier()
+    expectEqual(identity1, s1._rawIdentifier())
     expectNotEqual(identity2, identity1)
     expectEqual(3, s1.count)
     expectTrue(s1.contains(TestBridgedKeyTy(1010)))
@@ -1892,15 +1895,15 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
 
   do {
     var s1 = getBridgedNonverbatimSet()
-    var identity1 = unsafeBitCast(s1, to: Int.self)
+    var identity1 = s1._rawIdentifier()
     expectTrue(isNativeSet(s1))
     expectEqual(3, s1.count)
     expectTrue(s1.contains(TestBridgedKeyTy(1010)))
 
     var s2 = s1
     s2.removeAll(keepingCapacity: true)
-    var identity2 = unsafeBitCast(s2, to: Int.self)
-    expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+    var identity2 = s2._rawIdentifier()
+    expectEqual(identity1, s1._rawIdentifier())
     expectNotEqual(identity2, identity1)
     expectEqual(3, s1.count)
     expectTrue(s1.contains(TestObjCKeyTy(1010) as TestBridgedKeyTy))
@@ -1911,25 +1914,25 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.Count") {
   var s = getBridgedVerbatimSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
   expectTrue(isCocoaSet(s))
 
   expectEqual(3, s.count)
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.Count") {
   var s = getBridgedNonverbatimSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
   expectTrue(isNativeSet(s))
 
   expectEqual(3, s.count)
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 }
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.Generate") {
   var s = getBridgedVerbatimSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
   expectTrue(isCocoaSet(s))
 
   var iter = s.makeIterator()
@@ -1943,12 +1946,12 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.Generate") {
   expectEmpty(iter.next())
   expectEmpty(iter.next())
   expectEmpty(iter.next())
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.Generate") {
   var s = getBridgedNonverbatimSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
   expectTrue(isNativeSet(s))
 
   var iter = s.makeIterator()
@@ -1962,12 +1965,12 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Generate") {
   expectEmpty(iter.next())
   expectEmpty(iter.next())
   expectEmpty(iter.next())
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 }
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.Generate_Empty") {
   var s = getBridgedVerbatimSet([])
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
   expectTrue(isCocoaSet(s))
 
   var iter = s.makeIterator()
@@ -1977,12 +1980,12 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.Generate_Empty") {
   expectEmpty(iter.next())
   expectEmpty(iter.next())
   expectEmpty(iter.next())
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.Generate_Empty") {
   var s = getBridgedNonverbatimSet([])
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
   expectTrue(isNativeSet(s))
 
   var iter = s.makeIterator()
@@ -1992,12 +1995,12 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Generate_Empty") {
   expectEmpty(iter.next())
   expectEmpty(iter.next())
   expectEmpty(iter.next())
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 }
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.Generate_Huge") {
   var s = getHugeBridgedVerbatimSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
   expectTrue(isCocoaSet(s))
 
   var iter = s.makeIterator()
@@ -2011,12 +2014,12 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.Generate_Huge") {
   expectEmpty(iter.next())
   expectEmpty(iter.next())
   expectEmpty(iter.next())
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.Generate_Huge") {
   var s = getHugeBridgedNonverbatimSet()
-  var identity1 = unsafeBitCast(s, to: Int.self)
+  var identity1 = s._rawIdentifier()
   expectTrue(isNativeSet(s))
 
   var iter = s.makeIterator()
@@ -2030,84 +2033,84 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Generate_Huge") {
   expectEmpty(iter.next())
   expectEmpty(iter.next())
   expectEmpty(iter.next())
-  expectEqual(identity1, unsafeBitCast(s, to: Int.self))
+  expectEqual(identity1, s._rawIdentifier())
 }
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.EqualityTest_Empty") {
   var s1 = getBridgedVerbatimSet([])
-  var identity1 = unsafeBitCast(s1, to: Int.self)
+  var identity1 = s1._rawIdentifier()
   expectTrue(isCocoaSet(s1))
 
   var s2 = getBridgedVerbatimSet([])
-  var identity2 = unsafeBitCast(s2, to: Int.self)
+  var identity2 = s2._rawIdentifier()
   expectTrue(isCocoaSet(s2))
   expectEqual(identity1, identity2)
 
   expectEqual(s1, s2)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-  expectEqual(identity2, unsafeBitCast(s2, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
+  expectEqual(identity2, s2._rawIdentifier())
 
   s2.insert(TestObjCKeyTy(4040))
   expectTrue(isNativeSet(s2))
-  expectNotEqual(identity2, unsafeBitCast(s2, to: Int.self))
-  identity2 = unsafeBitCast(s2, to: Int.self)
+  expectNotEqual(identity2, s2._rawIdentifier())
+  identity2 = s2._rawIdentifier()
 
   expectNotEqual(s1, s2)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-  expectEqual(identity2, unsafeBitCast(s2, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
+  expectEqual(identity2, s2._rawIdentifier())
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.EqualityTest_Empty") {
   var s1 = getBridgedNonverbatimSet([])
-  var identity1 = unsafeBitCast(s1, to: Int.self)
+  var identity1 = s1._rawIdentifier()
   expectTrue(isNativeSet(s1))
 
   var s2 = getBridgedNonverbatimSet([])
-  var identity2 = unsafeBitCast(s2, to: Int.self)
+  var identity2 = s2._rawIdentifier()
   expectTrue(isNativeSet(s2))
   expectNotEqual(identity1, identity2)
 
   expectEqual(s1, s2)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-  expectEqual(identity2, unsafeBitCast(s2, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
+  expectEqual(identity2, s2._rawIdentifier())
 
   s2.insert(TestObjCKeyTy(4040) as TestBridgedKeyTy)
   expectTrue(isNativeSet(s2))
-  expectEqual(identity2, unsafeBitCast(s2, to: Int.self))
+  expectEqual(identity2, s2._rawIdentifier())
 
   expectNotEqual(s1, s2)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-  expectEqual(identity2, unsafeBitCast(s2, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
+  expectEqual(identity2, s2._rawIdentifier())
 }
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.EqualityTest_Small") {
   var s1 = getBridgedVerbatimSet()
-  let identity1 = unsafeBitCast(s1, to: Int.self)
+  let identity1 = s1._rawIdentifier()
   expectTrue(isCocoaSet(s1))
 
   var s2 = getBridgedVerbatimSet()
-  let identity2 = unsafeBitCast(s2, to: Int.self)
+  let identity2 = s2._rawIdentifier()
   expectTrue(isCocoaSet(s2))
   expectNotEqual(identity1, identity2)
 
   expectEqual(s1, s2)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-  expectEqual(identity2, unsafeBitCast(s2, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
+  expectEqual(identity2, s2._rawIdentifier())
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.EqualityTest_Small") {
   var s1 = getBridgedNonverbatimSet()
-  let identity1 = unsafeBitCast(s1, to: Int.self)
+  let identity1 = s1._rawIdentifier()
   expectTrue(isNativeSet(s1))
 
   var s2 = getBridgedNonverbatimSet()
-  let identity2 = unsafeBitCast(s2, to: Int.self)
+  let identity2 = s2._rawIdentifier()
   expectTrue(isNativeSet(s2))
   expectNotEqual(identity1, identity2)
 
   expectEqual(s1, s2)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-  expectEqual(identity2, unsafeBitCast(s2, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
+  expectEqual(identity2, s2._rawIdentifier())
 }
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.ArrayOfSets") {
@@ -3054,22 +3057,22 @@ SetTestSuite.test("union") {
   let s2 = Set([4040, 5050, 6060])
   let s3 = Set([1010, 2020, 3030, 4040, 5050, 6060])
 
-  let identity1 = unsafeBitCast(s1, to: Int.self)
+  let identity1 = s1._rawIdentifier()
 
   let s4 = s1.union(s2)
   expectEqual(s4, s3)
 
   // s1 should be unchanged
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
   expectEqual(Set([1010, 2020, 3030]), s1)
 
   // s4 should be a fresh set
-  expectNotEqual(identity1, unsafeBitCast(s4, to: Int.self))
+  expectNotEqual(identity1, s4._rawIdentifier())
   expectEqual(s4, s3)
 
   let s5 = s1.union(s1)
   expectEqual(s5, s1)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 
   expectEqual(s1, s1.union(Set<Int>()))
   expectEqual(s1, Set<Int>().union(s1))
@@ -3080,22 +3083,22 @@ SetTestSuite.test("∪") {
   let s2 = Set([4040, 5050, 6060])
   let s3 = Set([1010, 2020, 3030, 4040, 5050, 6060])
 
-  let identity1 = unsafeBitCast(s1, to: Int.self)
+  let identity1 = s1._rawIdentifier()
 
   let s4 = s1 ∪ s2
   expectEqual(s4, s3)
 
   // s1 should be unchanged
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
   expectEqual(Set([1010, 2020, 3030]), s1)
 
   // s4 should be a fresh set
-  expectNotEqual(identity1, unsafeBitCast(s4, to: Int.self))
+  expectNotEqual(identity1, s4._rawIdentifier())
   expectEqual(s4, s3)
 
   let s5 = s1 ∪ s1
   expectEqual(s5, s1)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 
   expectEqual(s1, s1 ∪ Set<Int>())
   expectEqual(s1, Set<Int>() ∪ s1)
@@ -3107,19 +3110,19 @@ SetTestSuite.test("formUnion") {
   let s2 = Set("here come dots".characters)
   let s3 = Set("and then dashes".characters)
 
-  let identity1 = unsafeBitCast(s1, to: Int.self)
+  let identity1 = s1._rawIdentifier()
 
   s1.formUnion("".characters)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 
   expectEqual(s1, s2)
   s1.formUnion(s2)
   expectEqual(s1, s2)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 
   s1.formUnion(s3)
   expectNotEqual(s1, s2)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 }
 
 SetTestSuite.test("∪=") {
@@ -3128,19 +3131,19 @@ SetTestSuite.test("∪=") {
   let s2 = Set("here come dots".characters)
   let s3 = Set("and then dashes".characters)
 
-  let identity1 = unsafeBitCast(s1, to: Int.self)
+  let identity1 = s1._rawIdentifier()
 
   s1 ∪= "".characters
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 
   expectEqual(s1, s2)
   s1 ∪= s2
   expectEqual(s1, s2)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 
   s1 ∪= s3
   expectNotEqual(s1, s2)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 }
 
 SetTestSuite.test("subtract") {
@@ -3148,25 +3151,25 @@ SetTestSuite.test("subtract") {
   let s2 = Set([4040, 5050, 6060])
   let s3 = Set([1010, 2020, 3030, 4040, 5050, 6060])
 
-  let identity1 = unsafeBitCast(s1, to: Int.self)
+  let identity1 = s1._rawIdentifier()
 
   // Subtracting a disjoint set should not create a
   // unique reference
   let s4 = s1.subtracting(s2)
   expectEqual(s1, s4)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-  expectEqual(identity1, unsafeBitCast(s4, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
+  expectEqual(identity1, s4._rawIdentifier())
 
   // Subtracting a superset will leave the set empty
   let s5 = s1.subtracting(s3)
   expectTrue(s5.isEmpty)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-  expectNotEqual(identity1, unsafeBitCast(s5, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
+  expectNotEqual(identity1, s5._rawIdentifier())
 
   // Subtracting the empty set does nothing
   expectEqual(s1, s1.subtracting(Set<Int>()))
   expectEqual(Set<Int>(), Set<Int>().subtracting(s1))
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 }
 
 SetTestSuite.test("∖") {
@@ -3174,25 +3177,25 @@ SetTestSuite.test("∖") {
   let s2 = Set([4040, 5050, 6060])
   let s3 = Set([1010, 2020, 3030, 4040, 5050, 6060])
 
-  let identity1 = unsafeBitCast(s1, to: Int.self)
+  let identity1 = s1._rawIdentifier()
 
   // Subtracting a disjoint set should not create a
   // unique reference
   let s4 = s1 ∖ s2
   expectEqual(s1, s4)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-  expectEqual(identity1, unsafeBitCast(s4, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
+  expectEqual(identity1, s4._rawIdentifier())
 
   // Subtracting a superset will leave the set empty
   let s5 = s1 ∖ s3
   expectTrue(s5.isEmpty)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
-  expectNotEqual(identity1, unsafeBitCast(s5, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
+  expectNotEqual(identity1, s5._rawIdentifier())
 
   // Subtracting the empty set does nothing
   expectEqual(s1, s1 ∖ Set<Int>())
   expectEqual(Set<Int>(), Set<Int>() ∖ s1)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 }
 
 SetTestSuite.test("subtract") {
@@ -3200,16 +3203,16 @@ SetTestSuite.test("subtract") {
   let s2 = Set([1010, 2020, 3030])
   let s3 = Set([4040, 5050, 6060])
 
-  let identity1 = unsafeBitCast(s1, to: Int.self)
+  let identity1 = s1._rawIdentifier()
 
   s1.subtract(Set<Int>())
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 
   s1.subtract(s3)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 
   expectEqual(s1, s2)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 }
 
 SetTestSuite.test("∖=") {
@@ -3217,16 +3220,16 @@ SetTestSuite.test("∖=") {
   let s2 = Set([1010, 2020, 3030])
   let s3 = Set([4040, 5050, 6060])
 
-  let identity1 = unsafeBitCast(s1, to: Int.self)
+  let identity1 = s1._rawIdentifier()
 
   s1 ∖= Set<Int>()
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 
   s1 ∖= s3
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 
   expectEqual(s1, s2)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 }
 
 SetTestSuite.test("intersect") {
@@ -3235,13 +3238,13 @@ SetTestSuite.test("intersect") {
   var s3 = Set([1010, 2020, 3030, 4040, 5050, 6060])
   var s4 = Set([1010, 2020, 3030])
 
-  let identity1 = unsafeBitCast(s1, to: Int.self)
+  let identity1 = s1._rawIdentifier()
   expectEqual(Set([1010, 2020, 3030]),
     Set([1010, 2020, 3030]).intersection(Set([1010, 2020, 3030])) as Set<Int>)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 
   expectEqual(s1, s1.intersection(s3))
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 
   expectEqual(Set<Int>(), Set<Int>().intersection(Set<Int>()))
   expectEqual(Set<Int>(), s1.intersection(Set<Int>()))
@@ -3254,13 +3257,13 @@ SetTestSuite.test("∩") {
   var s3 = Set([1010, 2020, 3030, 4040, 5050, 6060])
   var s4 = Set([1010, 2020, 3030])
 
-  let identity1 = unsafeBitCast(s1, to: Int.self)
+  let identity1 = s1._rawIdentifier()
   expectEqual(Set([1010, 2020, 3030]),
     Set([1010, 2020, 3030]) ∩ Set([1010, 2020, 3030]) as Set<Int>)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 
   expectEqual(s1, s1 ∩ s3)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 
   expectEqual(Set<Int>(), Set<Int>() ∩ Set<Int>())
   expectEqual(Set<Int>(), s1 ∩ Set<Int>())
@@ -3273,19 +3276,19 @@ SetTestSuite.test("formIntersection") {
   var s3 = Set([1010, 2020, 3030, 4040, 5050, 6060])
   var s4 = Set([1010, 2020, 3030])
 
-  let identity1 = unsafeBitCast(s1, to: Int.self)
+  let identity1 = s1._rawIdentifier()
   s1.formIntersection(s4)
   expectEqual(s1, s4)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 
   s4.formIntersection(s2)
   expectEqual(Set<Int>(), s4)
 
-  let identity2 = unsafeBitCast(s3, to: Int.self)
+  let identity2 = s3._rawIdentifier()
   s3.formIntersection(s2)
   expectEqual(s3, s2)
   expectTrue(s1.isDisjoint(with: s3))
-  expectNotEqual(identity1, unsafeBitCast(s3, to: Int.self))
+  expectNotEqual(identity1, s3._rawIdentifier())
 
   var s5 = Set<Int>()
   s5.formIntersection(s5)
@@ -3300,19 +3303,19 @@ SetTestSuite.test("∩=") {
   var s3 = Set([1010, 2020, 3030, 4040, 5050, 6060])
   var s4 = Set([1010, 2020, 3030])
 
-  let identity1 = unsafeBitCast(s1, to: Int.self)
+  let identity1 = s1._rawIdentifier()
   s1 ∩= s4
   expectEqual(s1, s4)
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 
   s4 ∩= s2
   expectEqual(Set<Int>(), s4)
 
-  let identity2 = unsafeBitCast(s3, to: Int.self)
+  let identity2 = s3._rawIdentifier()
   s3 ∩= s2
   expectEqual(s3, s2)
   expectTrue(s1.isDisjoint(with: s3))
-  expectNotEqual(identity1, unsafeBitCast(s3, to: Int.self))
+  expectNotEqual(identity1, s3._rawIdentifier())
 
   var s5 = Set<Int>()
   s5 ∩= s5
@@ -3330,11 +3333,11 @@ SetTestSuite.test("symmetricDifference") {
   let universe = Set([1010, 2020, 3030, 4040, 5050, 6060,
                        7070, 8080, 9090])
 
-  let identity1 = unsafeBitCast(s1, to: Int.self)
+  let identity1 = s1._rawIdentifier()
 
   let s3 = s1.symmetricDifference(s2)
 
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 
   expectEqual(s3, result)
 
@@ -3356,11 +3359,11 @@ SetTestSuite.test("⨁") {
   let universe = Set([1010, 2020, 3030, 4040, 5050, 6060,
                        7070, 8080, 9090])
 
-  let identity1 = unsafeBitCast(s1, to: Int.self)
+  let identity1 = s1._rawIdentifier()
 
   let s3 = s1 ⨁ s2
 
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 
   expectEqual(s3, result)
 
@@ -3380,11 +3383,11 @@ SetTestSuite.test("formSymmetricDifference") {
   let result = Set([2020, 3030, 4040, 5050, 6060])
 
   // s1 ⨁ s2 == result
-  let identity1 = unsafeBitCast(s1, to: Int.self)
+  let identity1 = s1._rawIdentifier()
   s1.formSymmetricDifference(s2)
 
   // Removing just one element shouldn't cause an identity change
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 
   expectEqual(s1, result)
 
@@ -3393,7 +3396,7 @@ SetTestSuite.test("formSymmetricDifference") {
   expectTrue(s1.isEmpty)
 
   // Removing all elements should cause an identity change
-  expectNotEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectNotEqual(identity1, s1._rawIdentifier())
 }
 
 SetTestSuite.test("⨁=") {
@@ -3402,11 +3405,11 @@ SetTestSuite.test("⨁=") {
   let s2 = Set([1010])
   let result = Set([2020, 3030, 4040, 5050, 6060])
 
-  let identity1 = unsafeBitCast(s1, to: Int.self)
+  let identity1 = s1._rawIdentifier()
   s1 ⨁= s2
 
   // Removing just one element shouldn't cause an identity change
-  expectEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectEqual(identity1, s1._rawIdentifier())
 
   expectEqual(s1, result)
 
@@ -3414,7 +3417,7 @@ SetTestSuite.test("⨁=") {
   expectTrue(s1.isEmpty)
 
   // Removing all elements should cause an identity change
-  expectNotEqual(identity1, unsafeBitCast(s1, to: Int.self))
+  expectNotEqual(identity1, s1._rawIdentifier())
 }
 
 SetTestSuite.test("removeFirst") {
@@ -3426,7 +3429,7 @@ SetTestSuite.test("removeFirst") {
 
   expectFalse(s1.contains(a1))
   expectTrue(s2.contains(a1))
-  expectNotEqual(unsafeBitCast(s1, to: Int.self), unsafeBitCast(s2, to: Int.self))
+  expectNotEqual(s1._rawIdentifier(), s2._rawIdentifier())
   expectTrue(s1.isSubset(of: s2))
   expectEmpty(empty.first)
 }
@@ -3437,24 +3440,24 @@ SetTestSuite.test("remove(member)") {
   for i in [1010, 2020, 3030] {
     s2.insert(TestKeyTy(i))
   }
-  let identity1 = unsafeBitCast(s2, to: Int.self)
+  let identity1 = s2._rawIdentifier()
   
   // remove something that's not there.
   let fortyForty = s2.remove(4040)
   expectEqual(s2, s1)
   expectEmpty(fortyForty)
-  expectEqual(identity1, unsafeBitCast(s2, to: Int.self))
+  expectEqual(identity1, s2._rawIdentifier())
 
   // Remove things that are there.
   let thirtyThirty = s2.remove(3030)
   expectEqual(3030, thirtyThirty)
-  expectEqual(identity1, unsafeBitCast(s2, to: Int.self))
+  expectEqual(identity1, s2._rawIdentifier())
 
   s2.remove(2020)
-  expectEqual(identity1, unsafeBitCast(s2, to: Int.self))
+  expectEqual(identity1, s2._rawIdentifier())
 
   s2.remove(1010)
-  expectEqual(identity1, unsafeBitCast(s2, to: Int.self))
+  expectEqual(identity1, s2._rawIdentifier())
   expectEqual(Set(), s2)
   expectTrue(s2.isEmpty)
 }


### PR DESCRIPTION
#### What's in this pull request?

@gribozavr @moiseev 

Some stylistic improvements to the `Set` and `Dictionary` validation tests. Test-specific identity checking logic is encapsulated in an extension method, rather than being hundreds of `unsafeBitCast()`s scattered across the code. NFC.

This is part of an attempt to break out parts of #3046. As always, thank you for reviewing my PRs!

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

NFC
