### PR TITLE
Fixit to remove empty argument for non-function calls

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4355,9 +4355,20 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
         }
       }
     
-    diagnose(callExpr->getArg()->getStartLoc(),
-             diag::cannot_call_non_function_value, fnExpr->getType())
-    .highlight(fnExpr->getSourceRange());
+    auto arg = callExpr->getArg();
+    auto diag = diagnose(arg->getStartLoc(),
+                         diag::cannot_call_non_function_value,
+                         fnExpr->getType());
+    diag.highlight(fnExpr->getSourceRange());
+    
+    // If the argument is an empty tuple, then offer a
+    // fix-it to remove the empty tuple and use the value
+    // directly.
+    if (auto tuple = dyn_cast<TupleExpr>(arg)) {
+      if (tuple->getNumElements() == 0) {
+        diag.fixItRemove(arg->getSourceRange());
+      }
+    }
     return true;
   }
   

--- a/test/ClangModules/objc_parse.swift
+++ b/test/ClangModules/objc_parse.swift
@@ -305,7 +305,7 @@ class NSObjectable : NSObjectProtocol {
 // Properties with custom accessors
 func customAccessors(_ hive: Hive, bee: Bee) {
   markUsed(hive.isMakingHoney)
-  markUsed(hive.makingHoney()) // expected-error{{cannot call value of non-function type 'Bool'}}
+  markUsed(hive.makingHoney()) // expected-error{{cannot call value of non-function type 'Bool'}}{{28-30=}}
   hive.setMakingHoney(true) // expected-error{{value of type 'Hive' has no member 'setMakingHoney'}}
 
   _ = hive.`guard`.description // okay

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -164,7 +164,7 @@ func rdar20142523() {
 // <rdar://problem/21080030> Bad diagnostic for invalid method call in boolean expression: (_, IntegerLiteralConvertible)' is not convertible to 'IntegerLiteralConvertible
 func rdar21080030() {
   var s = "Hello"
-  if s.characters.count() == 0 {} // expected-error{{cannot call value of non-function type 'IndexDistance'}}
+  if s.characters.count() == 0 {} // expected-error{{cannot call value of non-function type 'IndexDistance'}}{{24-26=}}
 }
 
 // <rdar://problem/21248136> QoI: problem with return type inference mis-diagnosed as invalid arguments
@@ -290,7 +290,7 @@ _ = { $0 }  // expected-error {{unable to infer closure return type in current c
 
 
 
-_ = 4()   // expected-error {{cannot call value of non-function type 'Int'}}
+_ = 4()   // expected-error {{cannot call value of non-function type 'Int'}}{{6-8=}}
 _ = 4(1)  // expected-error {{cannot call value of non-function type 'Int'}}
 
 

--- a/test/Constraints/fixes.swift
+++ b/test/Constraints/fixes.swift
@@ -87,7 +87,7 @@ func maybeFn() -> ((Int) -> Int)? { }
 
 func extraCall() {
   var i = 7
-  i = i() // expected-error{{cannot call value of non-function type 'Int'}}
+  i = i() // expected-error{{cannot call value of non-function type 'Int'}}{{8-10=}}
 
   maybeFn()(5) // expected-error{{value of optional type '((Int) -> Int)?' not unwrapped; did you mean to use '!' or '?'?}}{{12-12=!}}
 }

--- a/test/Sema/circular_decl_checking.swift
+++ b/test/Sema/circular_decl_checking.swift
@@ -25,7 +25,7 @@ class HasGenericFunc {
 
 class HasProp {
   var HasProp: HasProp {
-    return HasProp() // expected-error {{cannot call value of non-function type 'HasProp'}}
+    return HasProp() // expected-error {{cannot call value of non-function type 'HasProp'}}{{19-21=}}
   }
   var SomethingElse: SomethingElse? { // expected-error 2 {{use of undeclared type 'SomethingElse'}}
     return nil

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -50,7 +50,7 @@ func funcdecl5(_ a: Int, _ y: Int) {
   funcdecl1(123, 444)
   
   // Calls.
-  4()  // expected-error {{cannot call value of non-function type 'Int'}}
+  4()  // expected-error {{cannot call value of non-function type 'Int'}}{{4-6=}}
   
   
   // rdar://12017658 - Infer some argument types from func6.

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -76,7 +76,7 @@ func basictest() {
   var call3 : () = func3()()
 
   // Cannot call an integer.
-  bind_test2() // expected-error {{cannot call value of non-function type 'Int'}}
+  bind_test2() // expected-error {{cannot call value of non-function type 'Int'}}{{13-15=}}
 }
 
 // Infix operators and attribute lists.

--- a/test/expr/postfix/dot/init_ref_delegation.swift
+++ b/test/expr/postfix/dot/init_ref_delegation.swift
@@ -277,7 +277,7 @@ func foo<T: C where T: P>(_ x: T, y: T.Type) {
 
   var ci1a = x(required: 0) // expected-error{{cannot call value of non-function type 'T'}}
   var ci2a = x(x: 0) // expected-error{{cannot call value of non-function type 'T'}}
-  var ci3a = x() // expected-error{{cannot call value of non-function type 'T'}}
+  var ci3a = x() // expected-error{{cannot call value of non-function type 'T'}}{{15-17=}}
   var ci4a = x(proto: "") // expected-error{{cannot call value of non-function type 'T'}}
 
   var cm1 = y.init(required: 0)


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

When attempting to call a non-function type with an empty tuple as arguments, remove the empty tuple and use the value directly.

This will be a big help to people who mistakenly use class methods that are now `class var`s in Objective-C.
#### Resolved bug number: (N/A)

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
