### PR TITLE
Track dependencies of SIL instructions on opened archetypes which they use

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -16,6 +16,7 @@
 #include "swift/SIL/SILDebugScope.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILModule.h"
+#include "swift/SIL/SILOpenedArchetypesTracker.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/StringExtras.h"
 
@@ -39,6 +40,16 @@ class SILBuilder {
   /// If this pointer is non-null, then any inserted instruction is
   /// recorded in this list.
   SmallVectorImpl<SILInstruction *> *InsertedInstrs = nullptr;
+
+  /// An immutable view on the set of available opened archetypes.
+  /// It is passed down to SILInstruction constructors and create
+  /// methods.
+  SILOpenedArchetypesState OpenedArchetypes;
+
+  /// Maps opened archetypes to their definitions. If provided,
+  /// can be used by the builder. It is supposed to be used
+  /// only by SILGen or SIL deserializers.
+  SILOpenedArchetypesTracker *OpenedArchetypesTracker = nullptr;
 
 public:
   SILBuilder(SILFunction &F) : F(F), BB(0) {}
@@ -73,6 +84,19 @@ public:
   ASTContext &getASTContext() const { return F.getASTContext(); }
   const Lowering::TypeLowering &getTypeLowering(SILType T) const {
     return F.getModule().getTypeLowering(T);
+  }
+
+  void setOpenedArchetypesTracker(SILOpenedArchetypesTracker *Tracker) {
+    this->OpenedArchetypesTracker = Tracker;
+    this->OpenedArchetypes.setOpenedArchetypesTracker(OpenedArchetypesTracker);
+  }
+
+  SILOpenedArchetypesTracker *getOpenedArchetypesTracker() const {
+    return OpenedArchetypesTracker;
+  }
+
+  SILOpenedArchetypesState &getOpenedArchetypes() {
+    return OpenedArchetypes;
   }
 
   void setCurrentDebugScope(const SILDebugScope *DS) { CurDebugScope = DS; }
@@ -214,7 +238,8 @@ public:
                                    SILDebugVariable Var = SILDebugVariable()) {
     Loc.markAsPrologue();
     return insert(AllocStackInst::create(getSILDebugLocation(Loc),
-                                         elementType, F, Var));
+                                         elementType, F, OpenedArchetypes,
+                                         Var));
   }
 
   AllocRefInst *createAllocRef(SILLocation Loc, SILType elementType, bool objc,
@@ -222,8 +247,9 @@ public:
     // AllocRefInsts expand to function calls and can therefore not be
     // counted towards the function prologue.
     assert(!Loc.isInPrologue());
-    return insert(new (F.getModule()) AllocRefInst(
-        getSILDebugLocation(Loc), elementType, F, objc, canAllocOnStack));
+    return insert(AllocRefInst::create(getSILDebugLocation(Loc), elementType, F,
+                                       objc, canAllocOnStack,
+                                       OpenedArchetypes));
   }
 
   AllocRefDynamicInst *createAllocRefDynamic(SILLocation Loc, SILValue operand,
@@ -231,21 +257,21 @@ public:
     // AllocRefDynamicInsts expand to function calls and can therefore
     // not be counted towards the function prologue.
     assert(!Loc.isInPrologue());
-    return insert(new (F.getModule()) AllocRefDynamicInst(
-        getSILDebugLocation(Loc), operand, type, objc));
+    return insert(AllocRefDynamicInst::create(getSILDebugLocation(Loc), operand,
+                                              type, objc, F, OpenedArchetypes));
   }
 
   AllocValueBufferInst *
   createAllocValueBuffer(SILLocation Loc, SILType valueType, SILValue operand) {
-    return insert(new (F.getModule()) AllocValueBufferInst(
-        getSILDebugLocation(Loc), valueType, operand));
+    return insert(AllocValueBufferInst::create(
+        getSILDebugLocation(Loc), valueType, operand, F, OpenedArchetypes));
   }
 
   AllocBoxInst *createAllocBox(SILLocation Loc, SILType ElementType,
                                SILDebugVariable Var = SILDebugVariable()) {
     Loc.markAsPrologue();
-    return insert(
-        AllocBoxInst::create(getSILDebugLocation(Loc), ElementType, F, Var));
+    return insert(AllocBoxInst::create(getSILDebugLocation(Loc), ElementType, F,
+                                       OpenedArchetypes, Var));
   }
 
   AllocExistentialBoxInst *
@@ -253,15 +279,16 @@ public:
                             CanType ConcreteType,
                             ArrayRef<ProtocolConformanceRef> Conformances) {
     return insert(AllocExistentialBoxInst::create(
-        getSILDebugLocation(Loc), ExistentialType, ConcreteType,
-        Conformances, &F));
+        getSILDebugLocation(Loc), ExistentialType, ConcreteType, Conformances,
+        &F, OpenedArchetypes));
   }
 
   ApplyInst *createApply(SILLocation Loc, SILValue Fn, SILType SubstFnTy,
                          SILType Result, ArrayRef<Substitution> Subs,
                          ArrayRef<SILValue> Args, bool isNonThrowing) {
     return insert(ApplyInst::create(getSILDebugLocation(Loc), Fn, SubstFnTy,
-                                    Result, Subs, Args, isNonThrowing, F));
+                                    Result, Subs, Args, isNonThrowing, F,
+                                    OpenedArchetypes));
   }
 
   ApplyInst *createApply(SILLocation Loc, SILValue Fn, ArrayRef<SILValue> Args,
@@ -278,7 +305,8 @@ public:
                                SILBasicBlock *errorBB) {
     return insertTerminator(TryApplyInst::create(getSILDebugLocation(Loc),
                                                  fn, substFnTy, subs, args,
-                                                 normalBB, errorBB, F));
+                                                 normalBB, errorBB, F,
+                                                 OpenedArchetypes));
   }
 
   PartialApplyInst *createPartialApply(SILLocation Loc, SILValue Fn,
@@ -286,8 +314,9 @@ public:
                                        ArrayRef<Substitution> Subs,
                                        ArrayRef<SILValue> Args,
                                        SILType ClosureTy) {
-    return insert(PartialApplyInst::create(
-        getSILDebugLocation(Loc), Fn, SubstFnTy, Subs, Args, ClosureTy, F));
+    return insert(PartialApplyInst::create(getSILDebugLocation(Loc), Fn,
+                                           SubstFnTy, Subs, Args, ClosureTy, F,
+                                           OpenedArchetypes));
   }
 
   BuiltinInst *createBuiltin(SILLocation Loc, Identifier Name, SILType ResultTy,
@@ -526,8 +555,8 @@ public:
 
   UncheckedRefCastInst *createUncheckedRefCast(SILLocation Loc, SILValue Op,
                                                SILType Ty) {
-    return insert(new (F.getModule()) UncheckedRefCastInst(
-        getSILDebugLocation(Loc), Op, Ty));
+    return insert(UncheckedRefCastInst::create(getSILDebugLocation(Loc), Op, Ty,
+                                               F, OpenedArchetypes));
   }
 
   UncheckedRefCastAddrInst *
@@ -539,20 +568,20 @@ public:
 
   UncheckedAddrCastInst *createUncheckedAddrCast(SILLocation Loc, SILValue Op,
                                                  SILType Ty) {
-    return insert(new (F.getModule()) UncheckedAddrCastInst(
-        getSILDebugLocation(Loc), Op, Ty));
+    return insert(UncheckedAddrCastInst::create(getSILDebugLocation(Loc), Op,
+                                                Ty, F, OpenedArchetypes));
   }
 
   UncheckedTrivialBitCastInst *
   createUncheckedTrivialBitCast(SILLocation Loc, SILValue Op, SILType Ty) {
-    return insert(new (F.getModule()) UncheckedTrivialBitCastInst(
-        getSILDebugLocation(Loc), Op, Ty));
+    return insert(UncheckedTrivialBitCastInst::create(
+        getSILDebugLocation(Loc), Op, Ty, F, OpenedArchetypes));
   }
 
   UncheckedBitwiseCastInst *
   createUncheckedBitwiseCast(SILLocation Loc, SILValue Op, SILType Ty) {
-    return insert(new (F.getModule()) UncheckedBitwiseCastInst(
-        getSILDebugLocation(Loc), Op, Ty));
+    return insert(UncheckedBitwiseCastInst::create(getSILDebugLocation(Loc), Op,
+                                                   Ty, F, OpenedArchetypes));
   }
 
   RefToBridgeObjectInst *createRefToBridgeObject(SILLocation Loc, SILValue Ref,
@@ -648,8 +677,8 @@ public:
 
   UnconditionalCheckedCastInst *
   createUnconditionalCheckedCast(SILLocation Loc, SILValue op, SILType destTy) {
-    return insert(new (F.getModule()) UnconditionalCheckedCastInst(
-        getSILDebugLocation(Loc), op, destTy));
+    return insert(UnconditionalCheckedCastInst::create(
+        getSILDebugLocation(Loc), op, destTy, F, OpenedArchetypes));
   }
 
   UnconditionalCheckedCastAddrInst *createUnconditionalCheckedCastAddr(
@@ -896,11 +925,10 @@ public:
   WitnessMethodInst *createWitnessMethod(SILLocation Loc, CanType LookupTy,
                                          ProtocolConformanceRef Conformance,
                                          SILDeclRef Member, SILType MethodTy,
-                                         SILValue OptionalOpenedExistential,
                                          bool Volatile = false) {
     return insert(WitnessMethodInst::create(
         getSILDebugLocation(Loc), LookupTy, Conformance, Member, MethodTy,
-        &F, OptionalOpenedExistential, Volatile));
+        &F, OpenedArchetypes, Volatile));
   }
 
   DynamicMethodInst *createDynamicMethod(SILLocation Loc, SILValue Operand,
@@ -912,27 +940,39 @@ public:
 
   OpenExistentialAddrInst *
   createOpenExistentialAddr(SILLocation Loc, SILValue Operand, SILType SelfTy) {
-    return insert(new (F.getModule()) OpenExistentialAddrInst(
+    auto *I = insert(new (F.getModule()) OpenExistentialAddrInst(
         getSILDebugLocation(Loc), Operand, SelfTy));
+    if (OpenedArchetypesTracker)
+      OpenedArchetypesTracker->registerOpenedArchetypes(I);
+    return I;
   }
 
   OpenExistentialMetatypeInst *createOpenExistentialMetatype(SILLocation Loc,
                                                              SILValue operand,
                                                              SILType selfTy) {
-    return insert(new (F.getModule()) OpenExistentialMetatypeInst(
+    auto *I = insert(new (F.getModule()) OpenExistentialMetatypeInst(
         getSILDebugLocation(Loc), operand, selfTy));
+    if (OpenedArchetypesTracker)
+      OpenedArchetypesTracker->registerOpenedArchetypes(I);
+    return I;
   }
 
   OpenExistentialRefInst *
   createOpenExistentialRef(SILLocation Loc, SILValue Operand, SILType Ty) {
-    return insert(new (F.getModule()) OpenExistentialRefInst(
+    auto *I = insert(new (F.getModule()) OpenExistentialRefInst(
         getSILDebugLocation(Loc), Operand, Ty));
+    if (OpenedArchetypesTracker)
+      OpenedArchetypesTracker->registerOpenedArchetypes(I);
+    return I;
   }
 
   OpenExistentialBoxInst *
   createOpenExistentialBox(SILLocation Loc, SILValue Operand, SILType Ty) {
-    return insert(new (F.getModule()) OpenExistentialBoxInst(
+    auto *I = insert(new (F.getModule()) OpenExistentialBoxInst(
         getSILDebugLocation(Loc), Operand, Ty));
+    if (OpenedArchetypesTracker)
+      OpenedArchetypesTracker->registerOpenedArchetypes(I);
+    return I;
   }
 
   InitExistentialAddrInst *
@@ -942,7 +982,7 @@ public:
                             ArrayRef<ProtocolConformanceRef> Conformances) {
     return insert(InitExistentialAddrInst::create(
         getSILDebugLocation(Loc), Existential, FormalConcreteType,
-        LoweredConcreteType, Conformances, &F));
+        LoweredConcreteType, Conformances, &F, OpenedArchetypes));
   }
 
   InitExistentialMetatypeInst *
@@ -950,8 +990,8 @@ public:
                                 SILType existentialType,
                                 ArrayRef<ProtocolConformanceRef> conformances) {
     return insert(InitExistentialMetatypeInst::create(
-        getSILDebugLocation(Loc), existentialType, metatype, conformances,
-        &F));
+        getSILDebugLocation(Loc), existentialType, metatype, conformances, &F,
+        OpenedArchetypes));
   }
 
   InitExistentialRefInst *
@@ -959,8 +999,8 @@ public:
                            CanType FormalConcreteType, SILValue Concrete,
                            ArrayRef<ProtocolConformanceRef> Conformances) {
     return insert(InitExistentialRefInst::create(
-        getSILDebugLocation(Loc), ExistentialType, FormalConcreteType,
-        Concrete, Conformances, &F));
+        getSILDebugLocation(Loc), ExistentialType, FormalConcreteType, Concrete,
+        Conformances, &F, OpenedArchetypes));
   }
 
   DeinitExistentialAddrInst *createDeinitExistentialAddr(SILLocation Loc,
@@ -992,8 +1032,8 @@ public:
   }
 
   MetatypeInst *createMetatype(SILLocation Loc, SILType Metatype) {
-    return insert(new (F.getModule())
-                      MetatypeInst(getSILDebugLocation(Loc), Metatype));
+    return insert(MetatypeInst::create(getSILDebugLocation(Loc), Metatype,
+                                       &F, OpenedArchetypes));
   }
 
   ObjCMetatypeToObjectInst *
@@ -1306,9 +1346,9 @@ public:
                                                  SILValue op, SILType destTy,
                                                  SILBasicBlock *successBB,
                                                  SILBasicBlock *failureBB) {
-    return insertTerminator(new (F.getModule()) CheckedCastBranchInst(
-        getSILDebugLocation(Loc), isExact, op, destTy, successBB,
-        failureBB));
+    return insertTerminator(CheckedCastBranchInst::create(
+        getSILDebugLocation(Loc), isExact, op, destTy, successBB, failureBB, F,
+        OpenedArchetypes));
   }
 
   CheckedCastAddrBranchInst *

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_SIL_SILCLONER_H
 #define SWIFT_SIL_SILCLONER_H
 
+#include "swift/SIL/SILOpenedArchetypesTracker.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILDebugScope.h"
 #include "swift/SIL/SILVisitor.h"
@@ -39,9 +40,19 @@ class SILCloner : protected SILVisitor<ImplClass> {
 public:
   using SILVisitor<ImplClass>::asImpl;
 
+  explicit SILCloner(SILFunction &F,
+                     SILOpenedArchetypesTracker &OpenedArchetypesTracker)
+      : Builder(F), InsertBeforeBB(nullptr),
+        OpenedArchetypesTracker(OpenedArchetypesTracker) {
+    Builder.setOpenedArchetypesTracker(&OpenedArchetypesTracker);
+  }
+
   explicit SILCloner(SILFunction &F)
-    : Builder(F), InsertBeforeBB(nullptr) { }
-  
+      : Builder(F), InsertBeforeBB(nullptr),
+        OpenedArchetypesTracker(F) {
+    Builder.setOpenedArchetypesTracker(&OpenedArchetypesTracker);
+  }
+
   /// Clients of SILCloner who want to know about any newly created
   /// instructions can install a SmallVector into the builder to collect them.
   void setTrackingList(SmallVectorImpl<SILInstruction*> *II) {
@@ -199,6 +210,14 @@ protected:
   void cleanUp(SILFunction *F);
 
 public:
+  void doPreProcess(SILInstruction *Orig) {
+    // Extend the set of available opened archetypes by the opened archetypes
+    // used by the instruction being cloned.
+    auto OpenedArchetypeOperands = Orig->getOpenedArchetypeOperands();
+    Builder.getOpenedArchetypes().addOpenedArchetypeOperands(
+        OpenedArchetypeOperands);
+  }
+
   void doPostProcess(SILInstruction *Orig, SILInstruction *Cloned) {
     asImpl().postProcess(Orig, Cloned);
     assert((Orig->getDebugScope() ? Cloned->getDebugScope()!=nullptr : true) &&
@@ -217,6 +236,8 @@ protected:
   llvm::MapVector<SILBasicBlock*, SILBasicBlock*> BBMap;
 
   TypeSubstitutionMap OpenedExistentialSubs;
+  SILOpenedArchetypesTracker OpenedArchetypesTracker;
+
   /// Set of basic blocks where unreachable was inserted.
   SmallPtrSet<SILBasicBlock *, 32> BlocksWithUnreachables;
 };
@@ -253,8 +274,10 @@ template<typename ImplClass>
 class SILClonerWithScopes : public SILCloner<ImplClass> {
   friend class SILCloner<ImplClass>;
 public:
-  SILClonerWithScopes(SILFunction &To, bool Disable = false)
-    : SILCloner<ImplClass>(To) {
+  SILClonerWithScopes(SILFunction &To,
+                      SILOpenedArchetypesTracker &OpenedArchetypesTracker,
+                      bool Disable = false)
+      : SILCloner<ImplClass>(To, OpenedArchetypesTracker) {
 
     // We only want to do this when we generate cloned functions, not
     // when we inline.
@@ -268,6 +291,24 @@ public:
 
     scopeCloner.reset(new ScopeCloner(To));
   }
+
+  SILClonerWithScopes(SILFunction &To,
+                      bool Disable = false)
+      : SILCloner<ImplClass>(To) {
+
+    // We only want to do this when we generate cloned functions, not
+    // when we inline.
+
+    // FIXME: This is due to having TypeSubstCloner inherit from
+    //        SILClonerWithScopes, and having TypeSubstCloner be used
+    //        both by passes that clone whole functions and ones that
+    //        inline functions.
+    if (Disable)
+      return;
+
+    scopeCloner.reset(new ScopeCloner(To));
+  }
+
 
 private:
   std::unique_ptr<ScopeCloner> scopeCloner;
@@ -333,8 +374,12 @@ void
 SILCloner<ImplClass>::visitSILBasicBlock(SILBasicBlock* BB) {
   SILFunction &F = getBuilder().getFunction();
   // Iterate over and visit all instructions other than the terminator to clone.
-  for (auto I = BB->begin(), E = --BB->end(); I != E; ++I)
+  for (auto I = BB->begin(), E = --BB->end(); I != E; ++I) {
+    // Update the set of available opened archetypes with the opned archetypes
+    // used by the current instruction.
+    doPreProcess(&*I);
     asImpl().visit(&*I);
+  }
   // Iterate over successors to do the depth-first search.
   for (auto &Succ : BB->getSuccessors()) {
     auto BBI = BBMap.find(Succ);
@@ -1251,16 +1296,17 @@ template<typename ImplClass>
 void
 SILCloner<ImplClass>::visitWitnessMethodInst(WitnessMethodInst *Inst) {
   auto conformance =
-    getOpConformance(Inst->getLookupType(), Inst->getConformance());
+      getOpConformance(Inst->getLookupType(), Inst->getConformance());
+  auto lookupType = Inst->getLookupType();
+  auto newLookupType = getOpASTType(lookupType);
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   doPostProcess(
       Inst,
       getBuilder()
           .createWitnessMethod(
               getOpLocation(Inst->getLoc()),
-              getOpASTType(Inst->getLookupType()), conformance,
+              newLookupType, conformance,
               Inst->getMember(), getOpType(Inst->getType()),
-              Inst->hasOperand() ? getOpValue(Inst->getOperand()) : SILValue(),
               Inst->isVolatile()));
 }
 

--- a/include/swift/SIL/SILOpenedArchetypesTracker.h
+++ b/include/swift/SIL/SILOpenedArchetypesTracker.h
@@ -1,0 +1,165 @@
+//===- SILOpenedArchetypeTracker.h - Track opened archetypes  ---*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_SILOPENEDARCHETYPESTRACKER_H
+#define SWIFT_SIL_SILOPENEDARCHETYPESTRACKER_H
+
+#include "swift/SIL/Notifications.h"
+#include "swift/SIL/SILModule.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILUndef.h"
+
+namespace swift {
+
+/// SILOpenedArchetypesTracker is a helper class that can be used to create
+/// and maintain a mapping from opened archetypes to instructions
+/// defining them, e.g. open_existential_ref, open_existential_addr,
+/// open_existential_metatype.
+///
+/// This information is useful for representing and maintaining the
+/// dependencies of instructions on opened archetypes they are using.
+///
+/// The intended clients of this class are SILGen, SIL deserializers, etc.
+class SILOpenedArchetypesTracker : public DeleteNotificationHandler {
+public:
+  typedef llvm::DenseMap<Type, SILValue> OpenedArchetypeDefsMap;
+  // Re-use pre-populated map if available.
+  SILOpenedArchetypesTracker(const SILFunction &F,
+                             SILOpenedArchetypesTracker &Tracker)
+      : F(F), OpenedArchetypeDefs(Tracker.OpenedArchetypeDefs) { }
+
+  // Re-use pre-populated map if available.
+  SILOpenedArchetypesTracker(const SILFunction &F,
+                             OpenedArchetypeDefsMap &OpenedArchetypeDefs)
+      : F(F), OpenedArchetypeDefs(OpenedArchetypeDefs) { }
+
+  // Use its own local map if no pre-populated map is provided.
+  SILOpenedArchetypesTracker(const SILFunction &F)
+      : F(F), OpenedArchetypeDefs(LocalOpenedArchetypeDefs) { }
+
+
+  const SILFunction &getFunction() const { return F; }
+
+  void addOpenedArchetypeDef(Type archetype, SILValue Def) {
+    assert(!getOpenedArchetypeDef(archetype) &&
+           "There can be only one definition of an opened archetype");
+    OpenedArchetypeDefs[archetype] = Def;
+  }
+
+  void removeOpenedArchetypeDef(Type archetype, SILValue Def) {
+    auto FoundDef = getOpenedArchetypeDef(archetype);
+    assert(FoundDef &&
+           "Opened archetype definition is not registered in SILFunction");
+    if (FoundDef == Def)
+      OpenedArchetypeDefs.erase(archetype);
+  }
+
+  // Return the SILValue defining a given archetype.
+  // If the defining value is not known, return an empty SILValue.
+  SILValue getOpenedArchetypeDef(Type archetype) const {
+    return OpenedArchetypeDefs.lookup(archetype);
+  }
+
+  const OpenedArchetypeDefsMap &getOpenedArchetypeDefs() const {
+    return OpenedArchetypeDefs;
+  }
+
+  // Register archetypes opened by a given instruction.
+  // Can be used to incrementally populate the mapping, e.g.
+  // if it is done when performing a scan of all instructions
+  // inside a function.
+  void registerOpenedArchetypes(const SILInstruction *I);
+
+  // Register opened archetypes whose definitions are referenced by
+  // the typedef operands of this instruction.
+  void registerUsedOpenedArchetypes(const SILInstruction *I);
+
+  // Unregister archetypes opened by a given instruction.
+  // Should be only called when this instruction is to be removed.
+  void unregisterOpenedArchetypes(const SILInstruction *I);
+
+  // Handling of instruction removal notifications.
+  bool needsNotifications() { return true; }
+
+  // Handle notifications about removals of instructions.
+  void handleDeleteNotification(swift::ValueBase *Value);
+
+  virtual ~SILOpenedArchetypesTracker() {
+    // Unregister the handler.
+    F.getModule().removeDeleteNotificationHandler(this);
+  }
+
+private:
+  /// The function whose opened archetypes are being tracked.
+  /// Used only for verification purposes.
+  const SILFunction &F;
+  /// Mapping from opened archetypes to their definitions.
+  OpenedArchetypeDefsMap &OpenedArchetypeDefs;
+  /// Local map to be used if no other map was provided in the
+  /// constructor.
+  OpenedArchetypeDefsMap LocalOpenedArchetypeDefs;
+};
+
+// A state object containing information about opened archetypes.
+// This information can be used by constructors of SILInstructions,
+// their create methods, etc.
+// The object can be configured to use different sources for providing
+// archetypes, but none of those archetype sets can be modified through
+// this object, which makes it essentially immutable.
+class SILOpenedArchetypesState {
+  // A set of opened archetypes operands for quick lookup.
+  // It usually provides opened archetypes operands of the
+  // instruction being currently processed.
+  ArrayRef<Operand> OpenedArchetypeOperands;
+  // A non-modifiable mapping provided by the tracker.
+  const SILOpenedArchetypesTracker *OpenedArchetypesTracker;
+public:
+  SILOpenedArchetypesState(const SILOpenedArchetypesTracker *Tracker = nullptr)
+      : OpenedArchetypesTracker(Tracker) {}
+
+  SILOpenedArchetypesState(const SILOpenedArchetypesTracker &Tracker)
+      : OpenedArchetypesTracker(&Tracker) { }
+
+  void setOpenedArchetypesTracker(const SILOpenedArchetypesTracker *Tracker) {
+    OpenedArchetypesTracker = Tracker;
+  }
+
+  void addOpenedArchetypeOperands(ArrayRef<Operand> Operands) {
+    OpenedArchetypeOperands = Operands;
+  }
+
+  const SILOpenedArchetypesTracker *getOpenedArchetypesTracker() const {
+    return OpenedArchetypesTracker;
+  }
+
+  /// Lookup the instruction defining an opened archetype by first 
+  /// performing a quick lookup in the opened archetypes operands
+  /// and then in the opened archetypes tracker.
+  SILValue getOpenedArchetypeDef(Type Ty) const;
+};
+
+/// Find an opened archetype defined by an instruction.
+/// \returns The found archetype or empty type otherwise.
+CanType getOpenedArchetypeOf(const SILInstruction *I);
+
+/// Find an opened archetype represented by this type.
+/// It is assumed by this method that the type contains
+/// at most one opened archetype.
+/// Typically, it would be called from a type visitor.
+/// It checks only the type itself, but does not try to
+/// recursively check any children of this type, because
+/// this is the task of the type visitor invoking it.
+/// \returns The found archetype or empty type otherwise.
+CanType getOpenedArchetypeOf(CanType Ty);
+
+} // end swift namespace
+#endif

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -277,6 +277,7 @@ private:
   friend class ValueUseIterator;
   template <unsigned N> friend class FixedOperandList;
   template <unsigned N> friend class TailAllocatedOperandList;
+  friend class TrailingOperandsList;
 };
 
 /// A class which adapts an array of Operands into an array of Values.
@@ -464,6 +465,31 @@ public:
     }
   }
 
+  /// Initialize this operand list.
+  ///
+  /// The dynamic operands are actually out of order: logically they
+  /// will placed after the fixed operands, not before them.  But
+  /// the variadic arguments have to come last.
+  template <class... T>
+  TailAllocatedOperandList(SILInstruction *user,
+                           ArrayRef<SILValue> dynamicArgs,
+                           ArrayRef<SILValue> additionalDynamicArgs,
+                           T&&... fixedArgs)
+      : NumExtra(dynamicArgs.size() + additionalDynamicArgs.size()),
+        Buffer{ { user, std::forward<T>(fixedArgs) }... } {
+    static_assert(sizeof...(fixedArgs) == N, "wrong number of initializers");
+
+    Operand *dynamicSlot = Buffer + N;
+    for (auto value : dynamicArgs) {
+      new (dynamicSlot++) Operand(user, value);
+    }
+
+    for (auto value : additionalDynamicArgs) {
+      new (dynamicSlot++) Operand(user, value);
+    }
+ }
+
+
   ~TailAllocatedOperandList() {
     for (auto &op : getDynamicAsArray()) {
       op.~Operand();
@@ -564,6 +590,27 @@ public:
   /// Indexes into the full list of operands.
   Operand &operator[](unsigned i) { return asArray()[i]; }
   const Operand &operator[](unsigned i) const { return asArray()[i]; }
+};
+
+/// A helper class for initializing the list of trailing operands.
+class TrailingOperandsList {
+public:
+  static void InitOperandsList(Operand *p, SILInstruction *user,
+                               SILValue operand, ArrayRef<SILValue> operands) {
+    assert(p && "Trying to initialize operands using a nullptr");
+    new (p++) Operand(user, operand);
+    for (auto op : operands) {
+      new (p++) Operand(user, op);
+    }
+  }
+
+  static void InitOperandsList(Operand *p, SILInstruction *user,
+                               ArrayRef<SILValue> operands) {
+    assert(p && "Trying to initialize operands using a nullptr");
+    for (auto op : operands) {
+      new (p++) Operand(user, op);
+    }
+  }
 };
 
 /// SILValue hashes just like a pointer.

--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -51,6 +51,20 @@ public:
   using SILClonerWithScopes<ImplClass>::doPostProcess;
   using SILClonerWithScopes<ImplClass>::ValueMap;
   using SILClonerWithScopes<ImplClass>::addBlockWithUnreachable;
+  using SILClonerWithScopes<ImplClass>::OpenedArchetypesTracker;
+
+  TypeSubstCloner(SILFunction &To,
+                  SILFunction &From,
+                  TypeSubstitutionMap &ContextSubs,
+                  ArrayRef<Substitution> ApplySubs,
+                  SILOpenedArchetypesTracker &OpenedArchetypesTracker,
+                  bool Inlining = false)
+    : SILClonerWithScopes<ImplClass>(To, OpenedArchetypesTracker, Inlining),
+      SwiftMod(From.getModule().getSwiftModule()),
+      SubsMap(ContextSubs),
+      Original(From),
+      ApplySubs(ApplySubs),
+      Inlining(Inlining) { }
 
   TypeSubstCloner(SILFunction &To,
                   SILFunction &From,
@@ -63,6 +77,7 @@ public:
       Original(From),
       ApplySubs(ApplySubs),
       Inlining(Inlining) { }
+
 
 protected:
   SILType remapType(SILType Ty) {
@@ -223,7 +238,6 @@ protected:
         getBuilder().createWitnessMethod(
             getOpLocation(Inst->getLoc()), newLookupType, Conformance,
             Inst->getMember(), getOpType(Inst->getType()),
-            Inst->hasOperand() ? getOpValue(Inst->getOperand()) : SILValue(),
             Inst->isVolatile()));
   }
 

--- a/include/swift/SILOptimizer/Utils/SILInliner.h
+++ b/include/swift/SILOptimizer/Utils/SILInliner.h
@@ -47,10 +47,12 @@ public:
 
   SILInliner(SILFunction &To, SILFunction &From, InlineKind IKind,
              TypeSubstitutionMap &ContextSubs, ArrayRef<Substitution> ApplySubs,
-             CloneCollector::CallbackType Callback =nullptr)
-    : TypeSubstCloner<SILInliner>(To, From, ContextSubs, ApplySubs, true),
-    IKind(IKind), CalleeEntryBB(nullptr), CallSiteScope(nullptr),
-    Callback(Callback) {
+             SILOpenedArchetypesTracker &OpenedArchetypesTracker,
+             CloneCollector::CallbackType Callback = nullptr)
+      : TypeSubstCloner<SILInliner>(To, From, ContextSubs, ApplySubs,
+                                    OpenedArchetypesTracker, true),
+        IKind(IKind), CalleeEntryBB(nullptr), CallSiteScope(nullptr),
+        Callback(Callback) {
   }
 
   /// inlineFunction - This method inlines a callee function, assuming that it

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -269,14 +269,14 @@ namespace {
     bool parseScopeRef(SILDebugScope *&DS);
     bool parseSILDebugLocation(SILLocation &L, SILBuilder &B,
                                bool parsedComma = false);
-    bool parseSILInstruction(SILBasicBlock *BB);
+    bool parseSILInstruction(SILBasicBlock *BB, SILBuilder &B);
     bool parseCallInstruction(SILLocation InstLoc,
                               ValueKind Opcode, SILBuilder &B,
                               ValueBase *&ResultVal);
     bool parseSILFunctionRef(SILLocation InstLoc,
                              SILBuilder &B, ValueBase *&ResultVal);
 
-    bool parseSILBasicBlock();
+    bool parseSILBasicBlock(SILBuilder &B);
     
     bool isStartOfSILInstruction();
 
@@ -1539,7 +1539,7 @@ bool SILParser::parseSILDebugLocation(SILLocation &L, SILBuilder &B,
 
 /// sil-instruction-def ::= (sil-value-name '=')? sil-instruction
 ///                         (',' sil-scope-ref)? (',' sil-loc)?
-bool SILParser::parseSILInstruction(SILBasicBlock *BB) {
+bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
   // We require SIL instructions to be at the start of a line to assist
   // recovery.
   if (!P.Tok.isAtStartOfLine()) {
@@ -1567,7 +1567,7 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB) {
   if (parseSILOpcode(Opcode, OpcodeLoc, OpcodeName))
     return true;
 
-  SILBuilder B(BB);
+  B.setInsertionPoint(BB);
   SmallVector<SILValue, 4> OpList;
   SILValue Val;
 
@@ -2909,7 +2909,7 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB) {
     }
     
     ResultVal = B.createWitnessMethod(InstLoc, LookupTy, Conformance, Member,
-                                        MethodTy, Operand, IsVolatile);
+                                      MethodTy, IsVolatile);
     break;
   }
   case ValueKind::CopyAddrInst: {
@@ -3736,7 +3736,7 @@ bool SILParser::isStartOfSILInstruction() {
 ///     identifier sil-bb-argument-list? ':' sil-instruction+
 ///   sil-bb-argument-list:
 ///     '(' sil-typed-valueref (',' sil-typed-valueref)+ ')'
-bool SILParser::parseSILBasicBlock() {
+bool SILParser::parseSILBasicBlock(SILBuilder &B) {
   SILBasicBlock *BB;
 
   // The basic block name is optional.
@@ -3779,7 +3779,7 @@ bool SILParser::parseSILBasicBlock() {
   F->getBlocks().push_back(BB);
 
   do {
-    if (parseSILInstruction(BB))
+    if (parseSILInstruction(BB, B))
       return true;
   } while (isStartOfSILInstruction());
 
@@ -3871,8 +3871,14 @@ bool Parser::parseDeclSIL() {
       }
       
       // Parse the basic block list.
+      SILOpenedArchetypesTracker OpenedArchetypesTracker(*FunctionState.F);
+      SILBuilder B(*FunctionState.F);
+      // Track the archetypes just like SILGen. This
+      // is required for adding typedef operands to instrucitons.
+      B.setOpenedArchetypesTracker(&OpenedArchetypesTracker);
+
       do {
-        if (FunctionState.parseSILBasicBlock())
+        if (FunctionState.parseSILBasicBlock(B))
           return true;
       } while (Tok.isNot(tok::r_brace) && Tok.isNot(tok::eof));
 

--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -23,6 +23,7 @@ add_swift_library(swiftSIL STATIC
   SILInstructions.cpp
   SILLocation.cpp
   SILModule.cpp
+  SILOpenedArchetypesTracker.cpp
   SILPrinter.cpp
   SILSuccessor.cpp
   SILType.cpp

--- a/lib/SIL/SILBuilder.cpp
+++ b/lib/SIL/SILBuilder.cpp
@@ -79,8 +79,8 @@ SILInstruction *SILBuilder::tryCreateUncheckedRefCast(SILLocation Loc,
   if (!SILType::canRefCast(Op->getType(), ResultTy, M))
     return nullptr;
 
-  return insert(
-      new (M) UncheckedRefCastInst(getSILDebugLocation(Loc), Op, ResultTy));
+  return insert(UncheckedRefCastInst::create(getSILDebugLocation(Loc), Op,
+                                             ResultTy, F, OpenedArchetypes));
 }
 
 // Create the appropriate cast instruction based on result type.
@@ -89,16 +89,16 @@ SILInstruction *SILBuilder::createUncheckedBitCast(SILLocation Loc,
                                                    SILType Ty) {
   auto &M = F.getModule();
   if (Ty.isTrivial(M))
-    return insert(
-        new (M) UncheckedTrivialBitCastInst(getSILDebugLocation(Loc), Op, Ty));
+    return insert(UncheckedTrivialBitCastInst::create(
+        getSILDebugLocation(Loc), Op, Ty, F, OpenedArchetypes));
 
   if (auto refCast = tryCreateUncheckedRefCast(Loc, Op, Ty))
-    return refCast;  
+    return refCast;
 
   // The destination type is nontrivial, and may be smaller than the source
   // type, so RC identity cannot be assumed.
-  return insert(
-      new (M) UncheckedBitwiseCastInst(getSILDebugLocation(Loc), Op, Ty));
+  return insert(UncheckedBitwiseCastInst::create(getSILDebugLocation(Loc), Op,
+                                                 Ty, F, OpenedArchetypes));
 }
 
 BranchInst *SILBuilder::createBranch(SILLocation Loc,

--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -662,14 +662,63 @@ namespace {
     }
 #include "swift/SIL/SILNodes.def"
   };
+
+#define IMPLEMENTS_METHOD(DerivedClass, BaseClass, MemberName, ExpectedType)  \
+  (!::std::is_same<BaseClass, GET_IMPLEMENTING_CLASS(DerivedClass, MemberName,\
+                                                     ExpectedType)>::value)
+
+  class OpenedArchetypeOperandsAccessor
+      : public SILVisitor<OpenedArchetypeOperandsAccessor,
+                          ArrayRef<Operand>> {
+  public:
+#define VALUE(CLASS, PARENT) \
+    ArrayRef<Operand> visit##CLASS(const CLASS *I) {                    \
+      llvm_unreachable("accessing non-instruction " #CLASS);            \
+    }
+#define INST(CLASS, PARENT, MEMBEHAVIOR, RELEASINGBEHAVIOR)                    \
+    ArrayRef<Operand> visit##CLASS(const CLASS *I) {                           \
+      if (!IMPLEMENTS_METHOD(CLASS, SILInstruction, getOpenedArchetypeOperands, \
+                             ArrayRef<Operand>() const))                       \
+        return {};                                                             \
+      return I->getOpenedArchetypeOperands();                                 \
+    }
+#include "swift/SIL/SILNodes.def"
+  };
+
+  class OpenedArchetypeOperandsMutableAccessor
+    : public SILVisitor<OpenedArchetypeOperandsMutableAccessor,
+                        MutableArrayRef<Operand> > {
+  public:
+#define VALUE(CLASS, PARENT) \
+    MutableArrayRef<Operand> visit##CLASS(const CLASS *I) {             \
+      llvm_unreachable("accessing non-instruction " #CLASS);            \
+    }
+#define INST(CLASS, PARENT, MEMBEHAVIOR, RELEASINGBEHAVIOR)                    \
+    MutableArrayRef<Operand> visit##CLASS(CLASS *I) {                          \
+      if (!IMPLEMENTS_METHOD(CLASS, SILInstruction, getOpenedArchetypeOperands, \
+                             MutableArrayRef<Operand>()))                      \
+        return {};                                                             \
+      return I->getOpenedArchetypeOperands();                                 \
+    }
+#include "swift/SIL/SILNodes.def"
+  };
 } // end anonymous namespace
 
 ArrayRef<Operand> SILInstruction::getAllOperands() const {
-  return AllOperandsAccessor().visit(const_cast<SILInstruction*>(this));
+  return AllOperandsAccessor().visit(const_cast<SILInstruction *>(this));
 }
 
 MutableArrayRef<Operand> SILInstruction::getAllOperands() {
   return AllOperandsMutableAccessor().visit(this);
+}
+
+ArrayRef<Operand> SILInstruction::getOpenedArchetypeOperands() const {
+  return OpenedArchetypeOperandsAccessor().visit(
+      const_cast<SILInstruction *>(this));
+}
+
+MutableArrayRef<Operand> SILInstruction::getOpenedArchetypeOperands() {
+  return OpenedArchetypeOperandsMutableAccessor().visit(this);
 }
 
 /// getOperandNumber - Return which operand this is in the operand list of the

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -31,13 +31,98 @@
 using namespace swift;
 using namespace Lowering;
 
+// Collect used open archetypes from a given type into the \p openedArchetypes.
+// \p openedArchetyes is being used as a set  We don't use a real set type here
+// for performance reasons.
+static void
+collectOpenedArchetypes(CanType Ty,
+                        SmallVectorImpl<CanType> &openedArchetypes) {
+  if (!Ty || !Ty->hasOpenedExistential())
+    return;
+  Ty.visit([&](Type t) {
+    if (t->isOpenedExistential()) {
+      // Add this opened archetype if it was not seen yet.
+      // We don't use a set here, because the number of open archetypes
+      // is usually very small and using a real set may introduce too
+      // much overhead.
+      if (std::find(openedArchetypes.begin(), openedArchetypes.end(),
+                    t->getCanonicalType()) == openedArchetypes.end())
+        openedArchetypes.push_back(t.getCanonicalTypeOrNull());
+    }
+  });
+}
+
+// Collect used opened archetypes from the list of substitutions.
+static void
+collectOpenedArchetypes(ArrayRef<Substitution> subs,
+                        SmallVectorImpl<CanType> &openedArchetypes) {
+  openedArchetypes.clear();
+  for (auto sub : subs) {
+    auto Ty = sub.getReplacement().getCanonicalTypeOrNull();
+    collectOpenedArchetypes(Ty, openedArchetypes);
+  }
+}
+
+// Takes a set of open archetypes as input and produces a set of
+// references to open archetype definitions.
+static void collectOpenedArchetypeOperands(
+    SmallVectorImpl<CanType> &OpenedArchetypes,
+    SmallVectorImpl<SILValue> &OpenedArchetypeOperands,
+    SILOpenedArchetypesState &OpenedArchetypesState, SILModule &Module) {
+
+  for (auto archetype : OpenedArchetypes) {
+    auto Def = OpenedArchetypesState.getOpenedArchetypeDef(
+        Module.Types.getLoweredType(archetype).getSwiftRValueType());
+    assert(getOpenedArchetypeOf(Def->getType().getSwiftRValueType()) &&
+           "Opened archetype operands should be of an opened existential type");
+    OpenedArchetypeOperands.push_back(Def);
+  }
+}
+
+// Collects all opened archetypes from a substitutions list
+// and form a corresponding list of opened archetype operands.
+// We need to know the number of opened archetypes to estimate
+// the number of opened archetype operands for the instruction
+// being formed, because we need to reserve enough memory
+// for these operands.
+static void
+collectOpenedArchetypeOperands(
+    ArrayRef<Substitution> subs,
+    SmallVectorImpl<SILValue> &openedArchetypeOperands,
+    SILOpenedArchetypesState &OpenedArchetypesState,
+    SILModule &Module) {
+  SmallVector<CanType, 32> openedArchetypes;
+  collectOpenedArchetypes(subs, openedArchetypes);
+  collectOpenedArchetypeOperands(openedArchetypes, openedArchetypeOperands,
+                                 OpenedArchetypesState, Module);
+}
+
+// Collects all opened archetypes from a type and form a corresponding
+// list of opened archetype operands.
+// We need to know the number of opened archetypes to estimate
+// the number of opened archetype operands for the instruction
+// being formed, because we need to reserve enough memory
+// for these operands.
+static void collectOpenedArchetypeOperands(CanType Ty,
+                            SmallVectorImpl<SILValue> &openedArchetypeOperands,
+                            SILOpenedArchetypesState &OpenedArchetypesState,
+                            SILModule &Module) {
+  SmallVector<CanType, 32> openedArchetypes;
+  collectOpenedArchetypes(Ty, openedArchetypes);
+  collectOpenedArchetypeOperands(openedArchetypes, openedArchetypeOperands,
+                                 OpenedArchetypesState, Module);
+}
+
 //===----------------------------------------------------------------------===//
 // SILInstruction Subclasses
 //===----------------------------------------------------------------------===//
 
 template <typename INST>
-static void *allocateDebugVarCarryingInst(SILModule &M, SILDebugVariable Var) {
-  return M.allocateInst(sizeof(INST) + Var.Name.size(), alignof(INST));
+static void *allocateDebugVarCarryingInst(SILModule &M, SILDebugVariable Var,
+                                          ArrayRef<SILValue> Operands = {}) {
+  return M.allocateInst(sizeof(INST) + Var.Name.size() +
+                            sizeof(Operand) * Operands.size(),
+                        alignof(INST));
 }
 
 TailAllocatedDebugVariable::TailAllocatedDebugVariable(SILDebugVariable Var,
@@ -53,17 +138,30 @@ StringRef TailAllocatedDebugVariable::getName(const char *buf) const {
 }
 
 AllocStackInst::AllocStackInst(SILDebugLocation Loc, SILType elementType,
-                               SILFunction &F, SILDebugVariable Var)
+                               ArrayRef<SILValue> OpenedArchetypeOperands,
+                               SILFunction &F,
+                               SILDebugVariable Var)
     : AllocationInst(ValueKind::AllocStackInst, Loc,
                      elementType.getAddressType()),
-      VarInfo(Var, getTrailingObjects<char>()) {}
+      NumOperands(OpenedArchetypeOperands.size()),
+      VarInfo(Var, getTrailingObjects<char>()) {
+  TrailingOperandsList::InitOperandsList(getAllOperands().begin(), this,
+                                         OpenedArchetypeOperands);
+}
 
-AllocStackInst *AllocStackInst::create(SILDebugLocation Loc,
-                                       SILType elementType, SILFunction &F,
-                                       SILDebugVariable Var) {
-  void *buf = allocateDebugVarCarryingInst<AllocStackInst>(F.getModule(), Var);
-  return ::new (buf)
-      AllocStackInst(Loc, elementType, F, Var);
+AllocStackInst *
+AllocStackInst::create(SILDebugLocation Loc,
+                       SILType elementType, SILFunction &F,
+                       SILOpenedArchetypesState &OpenedArchetypes,
+                       SILDebugVariable Var) {
+  SmallVector<SILValue, 8> OpenedArchetypeOperands;
+  collectOpenedArchetypeOperands(elementType.getSwiftRValueType(),
+                                 OpenedArchetypeOperands,
+                                 OpenedArchetypes, F.getModule());
+  void *Buffer = allocateDebugVarCarryingInst<AllocStackInst>(
+      F.getModule(), Var, OpenedArchetypeOperands);
+  return ::new (Buffer)
+      AllocStackInst(Loc, elementType, OpenedArchetypeOperands, F, Var);
 }
 
 /// getDecl - Return the underlying variable declaration associated with this
@@ -73,21 +171,79 @@ VarDecl *AllocStackInst::getDecl() const {
 }
 
 AllocRefInst::AllocRefInst(SILDebugLocation Loc, SILType elementType,
-                           SILFunction &F, bool objc, bool canBeOnStack)
+                           SILFunction &F, bool objc, bool canBeOnStack,
+                           ArrayRef<SILValue> OpenedArchetypeOperands)
     : AllocationInst(ValueKind::AllocRefInst, Loc, elementType),
-      StackPromotable(canBeOnStack), ObjC(objc) {}
+      StackPromotable(canBeOnStack),
+      NumOperands(OpenedArchetypeOperands.size()), ObjC(objc) {
+  TrailingOperandsList::InitOperandsList(getAllOperands().begin(), this,
+                                         OpenedArchetypeOperands);
+}
+
+AllocRefInst *AllocRefInst::create(SILDebugLocation Loc, SILType elementType,
+                           SILFunction &F, bool objc, bool canBeOnStack,
+                           SILOpenedArchetypesState &OpenedArchetypes) {
+  SmallVector<SILValue, 8> OpenedArchetypeOperands;
+  collectOpenedArchetypeOperands(elementType.getSwiftRValueType(),
+                                 OpenedArchetypeOperands,
+                                 OpenedArchetypes, F.getModule());
+  void *Buffer = F.getModule().allocateInst(
+      sizeof(AllocRefInst) +
+          sizeof(Operand) * (OpenedArchetypeOperands.size()),
+      alignof(AllocRefInst));
+  return ::new (Buffer) AllocRefInst(Loc, elementType, F, objc, canBeOnStack,
+                                     OpenedArchetypeOperands);
+}
+
+AllocRefDynamicInst::AllocRefDynamicInst(
+    SILDebugLocation DebugLoc, SILValue operand,
+    ArrayRef<SILValue> OpenedArchetypeOperands, SILType ty, bool objc)
+    : UnaryInstructionWithOpenArchetypesBase(DebugLoc, operand,
+                                             OpenedArchetypeOperands, ty),
+      ObjC(objc) {
+}
+
+AllocRefDynamicInst *
+AllocRefDynamicInst::create(SILDebugLocation DebugLoc, SILValue operand,
+                            SILType ty, bool objc,
+                            SILFunction &F,
+                            SILOpenedArchetypesState &OpenedArchetypes) {
+  SmallVector<SILValue, 8> OpenedArchetypeOperands;
+  collectOpenedArchetypeOperands(ty.getSwiftRValueType(),
+                                 OpenedArchetypeOperands,
+                                 OpenedArchetypes, F.getModule());
+  void *Buffer = F.getModule().allocateInst(
+      sizeof(AllocRefDynamicInst) +
+          sizeof(Operand) * (OpenedArchetypeOperands.size() + 1),
+      alignof(AllocRefDynamicInst));
+  return ::new (Buffer)
+      AllocRefDynamicInst(DebugLoc, operand, OpenedArchetypeOperands, ty, objc);
+}
 
 AllocBoxInst::AllocBoxInst(SILDebugLocation Loc, SILType ElementType,
+                           ArrayRef<SILValue> OpenedArchetypeOperands,
                            SILFunction &F, SILDebugVariable Var)
     : AllocationInst(ValueKind::AllocBoxInst, Loc,
                      SILType::getPrimitiveObjectType(
                        SILBoxType::get(ElementType.getSwiftRValueType()))),
-      VarInfo(Var, getTrailingObjects<char>()) {}
+      NumOperands(OpenedArchetypeOperands.size()),
+      VarInfo(Var, getTrailingObjects<char>()) {
+  TrailingOperandsList::InitOperandsList(getAllOperands().begin(), this,
+                                         OpenedArchetypeOperands);
+}
 
 AllocBoxInst *AllocBoxInst::create(SILDebugLocation Loc, SILType ElementType,
-                                   SILFunction &F, SILDebugVariable Var) {
-  void *buf = allocateDebugVarCarryingInst<AllocStackInst>(F.getModule(), Var);
-  return ::new (buf) AllocBoxInst(Loc, ElementType, F, Var);
+                                   SILFunction &F,
+                                   SILOpenedArchetypesState &OpenedArchetypes,
+                                   SILDebugVariable Var) {
+  SmallVector<SILValue, 8> OpenedArchetypeOperands;
+  collectOpenedArchetypeOperands(ElementType.getSwiftRValueType(),
+                                 OpenedArchetypeOperands,
+                                 OpenedArchetypes, F.getModule());
+  void *Buffer = allocateDebugVarCarryingInst<AllocBoxInst>(
+      F.getModule(), Var, OpenedArchetypeOperands);
+  return ::new (Buffer)
+      AllocBoxInst(Loc, ElementType, OpenedArchetypeOperands, F, Var);
 }
 
 /// getDecl - Return the underlying variable declaration associated with this
@@ -129,10 +285,15 @@ VarDecl *DebugValueAddrInst::getDecl() const {
 
 AllocExistentialBoxInst::AllocExistentialBoxInst(
     SILDebugLocation Loc, SILType ExistentialType, CanType ConcreteType,
-    ArrayRef<ProtocolConformanceRef> Conformances, SILFunction *Parent)
+    ArrayRef<ProtocolConformanceRef> Conformances,
+    ArrayRef<SILValue> OpenedArchetypeOperands, SILFunction *Parent)
     : AllocationInst(ValueKind::AllocExistentialBoxInst, Loc,
                      ExistentialType.getObjectType()),
-      ConcreteType(ConcreteType), Conformances(Conformances) {}
+      NumOperands(OpenedArchetypeOperands.size()),
+      ConcreteType(ConcreteType), Conformances(Conformances) {
+  TrailingOperandsList::InitOperandsList(getAllOperands().begin(), this,
+                                         OpenedArchetypeOperands);
+}
 
 static void declareWitnessTable(SILModule &Mod,
                                 ProtocolConformanceRef conformanceRef) {
@@ -147,16 +308,48 @@ static void declareWitnessTable(SILModule &Mod,
 AllocExistentialBoxInst *AllocExistentialBoxInst::create(
     SILDebugLocation Loc, SILType ExistentialType, CanType ConcreteType,
     ArrayRef<ProtocolConformanceRef> Conformances,
-    SILFunction *F) {
+    SILFunction *F,
+    SILOpenedArchetypesState &OpenedArchetypes) {
+  SmallVector<SILValue, 8> OpenedArchetypeOperands;
+  collectOpenedArchetypeOperands(ConcreteType,
+                                 OpenedArchetypeOperands,
+                                 OpenedArchetypes, F->getModule());
   SILModule &Mod = F->getModule();
-  void *Buffer = Mod.allocateInst(sizeof(AllocExistentialBoxInst),
-                                  alignof(AllocExistentialBoxInst));
+  void *Buffer =
+      Mod.allocateInst(sizeof(AllocExistentialBoxInst) +
+                           sizeof(Operand) * (OpenedArchetypeOperands.size()),
+                       alignof(AllocExistentialBoxInst));
   for (ProtocolConformanceRef C : Conformances)
     declareWitnessTable(Mod, C);
   return ::new (Buffer) AllocExistentialBoxInst(Loc,
                                                 ExistentialType,
                                                 ConcreteType,
-                                                Conformances, F);
+                                                Conformances,
+                                                OpenedArchetypeOperands,
+                                                F);
+}
+
+AllocValueBufferInst::AllocValueBufferInst(
+    SILDebugLocation DebugLoc, SILType valueType, SILValue operand,
+    ArrayRef<SILValue> OpenedArchetypeOperands)
+    : UnaryInstructionWithOpenArchetypesBase(DebugLoc, operand,
+                                             OpenedArchetypeOperands,
+                                             valueType.getAddressType()) {}
+
+AllocValueBufferInst *
+AllocValueBufferInst::create(SILDebugLocation DebugLoc, SILType valueType,
+                             SILValue operand, SILFunction &F,
+                             SILOpenedArchetypesState &OpenedArchetypes) {
+  SmallVector<SILValue, 8> OpenedArchetypeOperands;
+  collectOpenedArchetypeOperands(valueType.getSwiftRValueType(),
+                                 OpenedArchetypeOperands,
+                                 OpenedArchetypes, F.getModule());
+  void *Buffer = F.getModule().allocateInst(
+      sizeof(AllocValueBufferInst) +
+          sizeof(Operand) * (OpenedArchetypeOperands.size() + 1),
+      alignof(AllocValueBufferInst));
+  return ::new (Buffer) AllocValueBufferInst(DebugLoc, valueType, operand,
+                                             OpenedArchetypeOperands);
 }
 
 BuiltinInst *BuiltinInst::create(SILDebugLocation Loc, Identifier Name,
@@ -200,10 +393,11 @@ InitBlockStorageHeaderInst::create(SILFunction &F,
 
 ApplyInst::ApplyInst(SILDebugLocation Loc, SILValue Callee,
                      SILType SubstCalleeTy, SILType Result,
-                     ArrayRef<Substitution> Subs, ArrayRef<SILValue> Args,
+                     ArrayRef<Substitution> Subs,
+                     ArrayRef<SILValue> Args, ArrayRef<SILValue> OpenedArchetypeOperands,
                      bool isNonThrowing)
     : ApplyInstBase(ValueKind::ApplyInst, Loc, Callee, SubstCalleeTy, Subs,
-                    Args, Result) {
+                    Args, OpenedArchetypeOperands, Result) {
   setNonThrowing(isNonThrowing);
 }
 
@@ -211,10 +405,15 @@ ApplyInst *ApplyInst::create(SILDebugLocation Loc, SILValue Callee,
                              SILType SubstCalleeTy, SILType Result,
                              ArrayRef<Substitution> Subs,
                              ArrayRef<SILValue> Args, bool isNonThrowing,
-                             SILFunction &F) {
-  void *Buffer = allocate(F, Subs, Args);
+                             SILFunction &F,
+                             SILOpenedArchetypesState &OpenedArchetypes) {
+  SmallVector<SILValue, 32> OpenedArchetypeOperands;
+  collectOpenedArchetypeOperands(Subs, OpenedArchetypeOperands,
+                                 OpenedArchetypes, F.getModule());
+  void *Buffer = allocate(F, Subs, OpenedArchetypeOperands, Args);
   return ::new(Buffer) ApplyInst(Loc, Callee, SubstCalleeTy,
-                                 Result, Subs, Args, isNonThrowing);
+                                 Result, Subs, Args,
+                                 OpenedArchetypeOperands, isNonThrowing);
 }
 
 bool swift::doesApplyCalleeHaveSemantics(SILValue callee, StringRef semantics) {
@@ -231,22 +430,29 @@ void *swift::allocateApplyInst(SILFunction &F, size_t size, size_t alignment) {
 PartialApplyInst::PartialApplyInst(SILDebugLocation Loc, SILValue Callee,
                                    SILType SubstCalleeTy,
                                    ArrayRef<Substitution> Subs,
-                                   ArrayRef<SILValue> Args, SILType ClosureType)
+                                   ArrayRef<SILValue> Args,
+                                   ArrayRef<SILValue> OpenedArchetypeOperands,
+                                   SILType ClosureType)
     // FIXME: the callee should have a lowered SIL function type, and
     // PartialApplyInst
     // should derive the type of its result by partially applying the callee's
     // type.
     : ApplyInstBase(ValueKind::PartialApplyInst, Loc, Callee, SubstCalleeTy,
-                    Subs, Args, ClosureType) {}
+                    Subs, Args, OpenedArchetypeOperands, ClosureType) {}
 
 PartialApplyInst *
 PartialApplyInst::create(SILDebugLocation Loc, SILValue Callee,
                          SILType SubstCalleeTy, ArrayRef<Substitution> Subs,
                          ArrayRef<SILValue> Args, SILType ClosureType,
-                         SILFunction &F) {
-  void *Buffer = allocate(F, Subs, Args);
+                         SILFunction &F,
+                         SILOpenedArchetypesState &OpenedArchetypes) {
+  SmallVector<SILValue, 32> OpenedArchetypeOperands;
+  collectOpenedArchetypeOperands(Subs, OpenedArchetypeOperands,
+                                 OpenedArchetypes, F.getModule());
+  void *Buffer = allocate(F, Subs, OpenedArchetypeOperands, Args);
   return ::new(Buffer) PartialApplyInst(Loc, Callee, SubstCalleeTy,
-                                        Subs, Args, ClosureType);
+                                        Subs, Args,
+                                        OpenedArchetypeOperands, ClosureType);
 }
 
 TryApplyInstBase::TryApplyInstBase(ValueKind valueKind, SILDebugLocation Loc,
@@ -256,20 +462,27 @@ TryApplyInstBase::TryApplyInstBase(ValueKind valueKind, SILDebugLocation Loc,
 
 TryApplyInst::TryApplyInst(SILDebugLocation Loc, SILValue callee,
                            SILType substCalleeTy, ArrayRef<Substitution> subs,
-                           ArrayRef<SILValue> args, SILBasicBlock *normalBB,
-                           SILBasicBlock *errorBB)
+                           ArrayRef<SILValue> args,
+                           ArrayRef<SILValue> openedArchetypeOperands,
+                           SILBasicBlock *normalBB, SILBasicBlock *errorBB)
     : ApplyInstBase(ValueKind::TryApplyInst, Loc, callee, substCalleeTy, subs,
-                    args, normalBB, errorBB) {}
+                    args, openedArchetypeOperands, normalBB, errorBB) {}
+
 
 TryApplyInst *TryApplyInst::create(SILDebugLocation Loc, SILValue callee,
                                    SILType substCalleeTy,
                                    ArrayRef<Substitution> subs,
                                    ArrayRef<SILValue> args,
                                    SILBasicBlock *normalBB,
-                                   SILBasicBlock *errorBB, SILFunction &F) {
-  void *buffer = allocate(F, subs, args);
-  return ::new (buffer)
-      TryApplyInst(Loc, callee, substCalleeTy, subs, args, normalBB, errorBB);
+                                   SILBasicBlock *errorBB, SILFunction &F,
+                                SILOpenedArchetypesState &OpenedArchetypes) {
+  SmallVector<SILValue, 32> openedArchetypeOperands;
+  collectOpenedArchetypeOperands(subs, openedArchetypeOperands,
+                                 OpenedArchetypes, F.getModule());
+  void *buffer = allocate(F, subs, openedArchetypeOperands, args);
+  return ::new (buffer) TryApplyInst(Loc, callee, substCalleeTy, subs, args,
+                                     openedArchetypeOperands,
+                                     normalBB, errorBB);
 }
 
 FunctionRefInst::FunctionRefInst(SILDebugLocation Loc, SILFunction *F)
@@ -521,8 +734,13 @@ TupleInst::TupleInst(SILDebugLocation Loc, SILType Ty,
                      ArrayRef<SILValue> Elems)
     : SILInstruction(ValueKind::TupleInst, Loc, Ty), Operands(this, Elems) {}
 
-MetatypeInst::MetatypeInst(SILDebugLocation Loc, SILType Metatype)
-    : SILInstruction(ValueKind::MetatypeInst, Loc, Metatype) {}
+MetatypeInst::MetatypeInst(SILDebugLocation Loc, SILType Metatype,
+                           ArrayRef<SILValue> OpenedArchetypeOperands)
+    : SILInstruction(ValueKind::MetatypeInst, Loc, Metatype),
+      NumOperands(OpenedArchetypeOperands.size()) {
+  TrailingOperandsList::InitOperandsList(getAllOperands().begin(), this,
+                                         OpenedArchetypeOperands);
+}
 
 bool TupleExtractInst::isTrivialEltOfOneRCIDTuple() const {
   SILModule &Mod = getModule();
@@ -1213,38 +1431,57 @@ WitnessMethodInst *
 WitnessMethodInst::create(SILDebugLocation Loc, CanType LookupType,
                           ProtocolConformanceRef Conformance, SILDeclRef Member,
                           SILType Ty, SILFunction *F,
-                          SILValue OpenedExistential, bool Volatile) {
+                          SILOpenedArchetypesState &OpenedArchetypes,
+                          bool Volatile) {
   SILModule &Mod = F->getModule();
+  SmallVector<SILValue, 8> OpenedArchetypeOperands;
+  collectOpenedArchetypeOperands(LookupType, OpenedArchetypeOperands,
+                                 OpenedArchetypes, F->getModule());
   void *Buffer =
-      Mod.allocateInst(sizeof(WitnessMethodInst), alignof(WitnessMethodInst));
+      Mod.allocateInst(sizeof(WitnessMethodInst) +
+                           sizeof(Operand) * OpenedArchetypeOperands.size(),
+                       alignof(WitnessMethodInst));
 
   declareWitnessTable(Mod, Conformance);
   return ::new (Buffer) WitnessMethodInst(Loc, LookupType, Conformance, Member,
-                                          Ty, OpenedExistential, Volatile);
+                                          Ty, OpenedArchetypeOperands, Volatile);
 }
 
 InitExistentialAddrInst *InitExistentialAddrInst::create(
     SILDebugLocation Loc, SILValue Existential, CanType ConcreteType,
     SILType ConcreteLoweredType, ArrayRef<ProtocolConformanceRef> Conformances,
-    SILFunction *F) {
+    SILFunction *F, SILOpenedArchetypesState &OpenedArchetypes) {
   SILModule &Mod = F->getModule();
-  void *Buffer = Mod.allocateInst(sizeof(InitExistentialAddrInst),
+  SmallVector<SILValue, 8> OpenedArchetypeOperands;
+  collectOpenedArchetypeOperands(ConcreteType, OpenedArchetypeOperands,
+                                 OpenedArchetypes, F->getModule());
+  unsigned size =
+      totalSizeToAlloc<swift::Operand>(1 + OpenedArchetypeOperands.size());
+  void *Buffer = Mod.allocateInst(size,
                                   alignof(InitExistentialAddrInst));
   for (ProtocolConformanceRef C : Conformances)
     declareWitnessTable(Mod, C);
   return ::new (Buffer) InitExistentialAddrInst(Loc, Existential,
-                                            ConcreteType,
-                                            ConcreteLoweredType,
-                                            Conformances);
+                                                OpenedArchetypeOperands,
+                                                ConcreteType,
+                                                ConcreteLoweredType,
+                                                Conformances);
 }
 
 InitExistentialRefInst *
 InitExistentialRefInst::create(SILDebugLocation Loc, SILType ExistentialType,
                                CanType ConcreteType, SILValue Instance,
                                ArrayRef<ProtocolConformanceRef> Conformances,
-                               SILFunction *F) {
+                               SILFunction *F,
+                               SILOpenedArchetypesState &OpenedArchetypes) {
   SILModule &Mod = F->getModule();
-  void *Buffer = Mod.allocateInst(sizeof(InitExistentialRefInst),
+  SmallVector<SILValue, 8> OpenedArchetypeOperands;
+  collectOpenedArchetypeOperands(ConcreteType, OpenedArchetypeOperands,
+                                 OpenedArchetypes, F->getModule());
+  unsigned size =
+      totalSizeToAlloc<swift::Operand>(1 + OpenedArchetypeOperands.size());
+
+  void *Buffer = Mod.allocateInst(size,
                                   alignof(InitExistentialRefInst));
   for (ProtocolConformanceRef C : Conformances)
     declareWitnessTable(Mod, C);
@@ -1252,13 +1489,17 @@ InitExistentialRefInst::create(SILDebugLocation Loc, SILType ExistentialType,
   return ::new (Buffer) InitExistentialRefInst(Loc, ExistentialType,
                                                ConcreteType,
                                                Instance,
+                                               OpenedArchetypeOperands,
                                                Conformances);
 }
 
 InitExistentialMetatypeInst::InitExistentialMetatypeInst(
     SILDebugLocation Loc, SILType existentialMetatypeType, SILValue metatype,
+    ArrayRef<SILValue> OpenedArchetypeOperands,
     ArrayRef<ProtocolConformanceRef> conformances)
-    : UnaryInstructionBase(Loc, metatype, existentialMetatypeType),
+    : UnaryInstructionWithOpenArchetypesBase(Loc, metatype,
+                                             OpenedArchetypeOperands,
+                                             existentialMetatypeType),
       NumConformances(conformances.size()) {
   std::uninitialized_copy(conformances.begin(), conformances.end(),
                           getTrailingObjects<ProtocolConformanceRef>());
@@ -1266,16 +1507,24 @@ InitExistentialMetatypeInst::InitExistentialMetatypeInst(
 
 InitExistentialMetatypeInst *InitExistentialMetatypeInst::create(
     SILDebugLocation Loc, SILType existentialMetatypeType, SILValue metatype,
-    ArrayRef<ProtocolConformanceRef> conformances, SILFunction *F) {
+    ArrayRef<ProtocolConformanceRef> conformances, SILFunction *F,
+    SILOpenedArchetypesState &OpenedArchetypes) {
   SILModule &M = F->getModule();
-  unsigned size = totalSizeToAlloc<ProtocolConformanceRef>(conformances.size());
+  SmallVector<SILValue, 8> OpenedArchetypeOperands;
+  collectOpenedArchetypeOperands(existentialMetatypeType.getSwiftRValueType(),
+                                 OpenedArchetypeOperands,
+                                 OpenedArchetypes, M);
+
+  unsigned size = totalSizeToAlloc<swift::Operand, ProtocolConformanceRef>(
+      1 + OpenedArchetypeOperands.size(), conformances.size());
 
   void *buffer = M.allocateInst(size, alignof(InitExistentialMetatypeInst));
   for (ProtocolConformanceRef conformance : conformances)
     declareWitnessTable(M, conformance);
 
   return ::new (buffer) InitExistentialMetatypeInst(
-      Loc, existentialMetatypeType, metatype, conformances);
+      Loc, existentialMetatypeType, metatype,
+      OpenedArchetypeOperands, conformances);
 }
 
 ArrayRef<ProtocolConformanceRef>
@@ -1326,4 +1575,137 @@ MarkUninitializedBehaviorInst::MarkUninitializedBehaviorInst(
   for (unsigned i = 0; i < SetterSubs.size(); ++i) {
     ::new ((void*)trailing++) Substitution(SetterSubs[i]);
   }
+}
+
+OpenExistentialAddrInst::OpenExistentialAddrInst(
+    SILDebugLocation DebugLoc, SILValue Operand, SILType SelfTy)
+    : UnaryInstructionBase(DebugLoc, Operand, SelfTy) {
+}
+
+OpenExistentialRefInst::OpenExistentialRefInst(
+    SILDebugLocation DebugLoc, SILValue Operand, SILType Ty)
+    : UnaryInstructionBase(DebugLoc, Operand, Ty) {
+}
+
+OpenExistentialMetatypeInst::OpenExistentialMetatypeInst(
+    SILDebugLocation DebugLoc, SILValue operand, SILType ty)
+    : UnaryInstructionBase(DebugLoc, operand, ty) {
+}
+
+OpenExistentialBoxInst::OpenExistentialBoxInst(
+    SILDebugLocation DebugLoc, SILValue operand, SILType ty)
+    : UnaryInstructionBase(DebugLoc, operand, ty) {
+}
+
+UncheckedRefCastInst *
+UncheckedRefCastInst::create(SILDebugLocation DebugLoc, SILValue Operand,
+                             SILType Ty, SILFunction &F,
+                             SILOpenedArchetypesState &OpenedArchetypes) {
+  SILModule &Mod = F.getModule();
+  SmallVector<SILValue, 8> OpenedArchetypeOperands;
+  collectOpenedArchetypeOperands(Ty.getSwiftRValueType(),
+                                 OpenedArchetypeOperands, OpenedArchetypes,
+                                 F.getModule());
+  unsigned size =
+      totalSizeToAlloc<swift::Operand>(1 + OpenedArchetypeOperands.size());
+  void *Buffer = Mod.allocateInst(size, alignof(UncheckedRefCastInst));
+  return ::new (Buffer) UncheckedRefCastInst(DebugLoc, Operand,
+                                             OpenedArchetypeOperands, Ty);
+}
+
+UncheckedAddrCastInst *
+UncheckedAddrCastInst::create(SILDebugLocation DebugLoc, SILValue Operand,
+                              SILType Ty, SILFunction &F,
+                              SILOpenedArchetypesState &OpenedArchetypes) {
+  SILModule &Mod = F.getModule();
+  SmallVector<SILValue, 8> OpenedArchetypeOperands;
+  collectOpenedArchetypeOperands(Ty.getSwiftRValueType(),
+                                 OpenedArchetypeOperands, OpenedArchetypes,
+                                 F.getModule());
+  unsigned size =
+      totalSizeToAlloc<swift::Operand>(1 + OpenedArchetypeOperands.size());
+  void *Buffer = Mod.allocateInst(size, alignof(UncheckedAddrCastInst));
+  return ::new (Buffer) UncheckedAddrCastInst(DebugLoc, Operand,
+                                              OpenedArchetypeOperands, Ty);
+}
+
+UncheckedTrivialBitCastInst *
+UncheckedTrivialBitCastInst::create(SILDebugLocation DebugLoc, SILValue Operand,
+                              SILType Ty, SILFunction &F,
+                              SILOpenedArchetypesState &OpenedArchetypes) {
+  SILModule &Mod = F.getModule();
+  SmallVector<SILValue, 8> OpenedArchetypeOperands;
+  collectOpenedArchetypeOperands(Ty.getSwiftRValueType(),
+                                 OpenedArchetypeOperands, OpenedArchetypes,
+                                 F.getModule());
+  unsigned size =
+      totalSizeToAlloc<swift::Operand>(1 + OpenedArchetypeOperands.size());
+  void *Buffer = Mod.allocateInst(size, alignof(UncheckedTrivialBitCastInst));
+  return ::new (Buffer) UncheckedTrivialBitCastInst(DebugLoc, Operand,
+                                                    OpenedArchetypeOperands,
+                                                    Ty);
+}
+
+UncheckedBitwiseCastInst *
+UncheckedBitwiseCastInst::create(SILDebugLocation DebugLoc, SILValue Operand,
+                                 SILType Ty, SILFunction &F,
+                                 SILOpenedArchetypesState &OpenedArchetypes) {
+  SILModule &Mod = F.getModule();
+  SmallVector<SILValue, 8> OpenedArchetypeOperands;
+  collectOpenedArchetypeOperands(Ty.getSwiftRValueType(),
+                                 OpenedArchetypeOperands, OpenedArchetypes,
+                                 F.getModule());
+  unsigned size =
+      totalSizeToAlloc<swift::Operand>(1 + OpenedArchetypeOperands.size());
+  void *Buffer = Mod.allocateInst(size, alignof(UncheckedBitwiseCastInst));
+  return ::new (Buffer) UncheckedBitwiseCastInst(DebugLoc, Operand,
+                                                 OpenedArchetypeOperands, Ty);
+}
+
+UnconditionalCheckedCastInst *UnconditionalCheckedCastInst::create(
+    SILDebugLocation DebugLoc, SILValue Operand, SILType DestTy, SILFunction &F,
+    SILOpenedArchetypesState &OpenedArchetypes) {
+  SILModule &Mod = F.getModule();
+  SmallVector<SILValue, 8> OpenedArchetypeOperands;
+  collectOpenedArchetypeOperands(DestTy.getSwiftRValueType(),
+                                 OpenedArchetypeOperands, OpenedArchetypes,
+                                 F.getModule());
+  unsigned size =
+      totalSizeToAlloc<swift::Operand>(1 + OpenedArchetypeOperands.size());
+  void *Buffer = Mod.allocateInst(size, alignof(UnconditionalCheckedCastInst));
+  return ::new (Buffer) UnconditionalCheckedCastInst(DebugLoc, Operand,
+                                                     OpenedArchetypeOperands, DestTy);
+}
+
+CheckedCastBranchInst *CheckedCastBranchInst::create(
+    SILDebugLocation DebugLoc, bool IsExact, SILValue Operand, SILType DestTy,
+    SILBasicBlock *SuccessBB, SILBasicBlock *FailureBB, SILFunction &F,
+    SILOpenedArchetypesState &OpenedArchetypes) {
+  SILModule &Mod = F.getModule();
+  SmallVector<SILValue, 8> OpenedArchetypeOperands;
+  collectOpenedArchetypeOperands(DestTy.getSwiftRValueType(),
+                                 OpenedArchetypeOperands, OpenedArchetypes,
+                                 F.getModule());
+  unsigned size =
+      totalSizeToAlloc<swift::Operand>(1 + OpenedArchetypeOperands.size());
+  void *Buffer = Mod.allocateInst(size, alignof(CheckedCastBranchInst));
+  return ::new (Buffer) CheckedCastBranchInst(DebugLoc, IsExact, Operand,
+                                              OpenedArchetypeOperands, DestTy,
+                                              SuccessBB, FailureBB);
+}
+
+MetatypeInst *MetatypeInst::create(SILDebugLocation Loc, SILType Ty,
+                                   SILFunction *F,
+                                   SILOpenedArchetypesState &OpenedArchetypes) {
+  SILModule &Mod = F->getModule();
+  SmallVector<SILValue, 8> OpenedArchetypeOperands;
+  collectOpenedArchetypeOperands(getOpenedArchetypeOf(Ty.getSwiftRValueType()),
+                                 OpenedArchetypeOperands, OpenedArchetypes,
+                                 F->getModule());
+  void *Buffer =
+      Mod.allocateInst(sizeof(MetatypeInst) +
+                           sizeof(Operand) * OpenedArchetypeOperands.size(),
+                       alignof(MetatypeInst));
+
+  return ::new (Buffer) MetatypeInst(Loc, Ty, OpenedArchetypeOperands);
 }

--- a/lib/SIL/SILOpenedArchetypesTracker.cpp
+++ b/lib/SIL/SILOpenedArchetypesTracker.cpp
@@ -1,0 +1,124 @@
+//==- SILOpenedArchetypeTracker.cpp - Track opened archetypes  ---*- C++ -*-==//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SIL/SILOpenedArchetypesTracker.h"
+
+using namespace swift;
+
+// Register archetypes opened by a given instruction.
+// Can be used to incrementally populate the mapping, e.g.
+// if it is done when performing a scan of all instructions
+// inside a function.
+void SILOpenedArchetypesTracker::registerOpenedArchetypes(
+    const SILInstruction *I) {
+  assert((!I->getParent() || I->getFunction() == &F) &&
+         "Instruction does not belong to a proper SILFunction");
+  auto Archetype = getOpenedArchetypeOf(I);
+  if (Archetype)
+    addOpenedArchetypeDef(Archetype, I);
+}
+
+// Register opened archetypes whose definitions are referenced by
+// the typedef operands of this instruction.
+void SILOpenedArchetypesTracker::registerUsedOpenedArchetypes(
+    const SILInstruction *I) {
+  assert((!I->getParent() || I->getFunction() == &F) &&
+         "Instruction does not belong to a proper SILFunction");
+  for (auto &Op : I->getOpenedArchetypeOperands()) {
+    auto OpenedArchetypeDef = Op.get();
+    assert(isa<SILInstruction>(OpenedArchetypeDef) &&
+           "typedef operand should refer to a SILInstruction");
+    addOpenedArchetypeDef(
+        getOpenedArchetypeOf(cast<SILInstruction>(OpenedArchetypeDef)),
+        OpenedArchetypeDef);
+  }
+}
+
+// Unregister archetypes opened by a given instruction.
+// Should be only called when this instruction is to be removed.
+void SILOpenedArchetypesTracker::unregisterOpenedArchetypes(
+    const SILInstruction *I) {
+  assert(I->getFunction() == &F &&
+         "Instruction does not belong to a proper SILFunction");
+  auto Archetype = getOpenedArchetypeOf(I);
+  if (Archetype)
+    removeOpenedArchetypeDef(Archetype, I);
+}
+
+void SILOpenedArchetypesTracker::handleDeleteNotification(
+    swift::ValueBase *Value) {
+  if (auto I = dyn_cast<SILInstruction>(Value))
+    if (I->getFunction() == &F)
+      unregisterOpenedArchetypes(I);
+}
+
+/// Find an opened archetype defined by an instruction.
+/// \returns The found archetype or empty type otherwise.
+CanType swift::getOpenedArchetypeOf(const SILInstruction *I) {
+  if (isa<OpenExistentialAddrInst>(I) || isa<OpenExistentialRefInst>(I) ||
+      isa<OpenExistentialBoxInst>(I) || isa<OpenExistentialMetatypeInst>(I)) {
+    auto Ty = getOpenedArchetypeOf(I->getType().getSwiftRValueType());
+    assert(Ty->isOpenedExistential() && "Type should be an opened archetype");
+    return Ty;
+  }
+
+  return CanType();
+}
+
+
+bool hasAtMostOneOpenedArchetype(CanType Ty) {
+  int NumOpenedArchetypes = 0;
+  Ty.visit([&](Type t) {
+    if (t->isOpenedExistential()) {
+      NumOpenedArchetypes++;
+    }
+    return;
+  });
+  return NumOpenedArchetypes <= 1;
+}
+
+/// Find an opened archetype represented by this type.
+/// It is assumed by this method that the type contains
+/// at most one opened archetype.
+/// Typically, it would be called from a type visitor.
+/// It checks only the type itself, but does not try to
+/// recursively check any children of this type, because
+/// this is the task of the type visitor invoking it.
+/// \returns The found archetype or empty type otherwise.
+CanType swift::getOpenedArchetypeOf(CanType Ty) {
+  if (!Ty)
+    return CanType();
+  assert(hasAtMostOneOpenedArchetype(Ty) &&
+         "Type should contain at most one opened archetype");
+  while (auto MetaTy = dyn_cast<AnyMetatypeType>(Ty)) {
+    Ty = MetaTy->getInstanceType().getCanonicalTypeOrNull();
+  }
+  if (Ty->isOpenedExistential())
+    return Ty;
+  return CanType();
+}
+
+SILValue SILOpenedArchetypesState::getOpenedArchetypeDef(Type Ty) const {
+  if (!Ty)
+    return SILValue();
+  auto CanTy = Ty.getCanonicalTypeOrNull();
+  // First perform a quick check.
+  for (auto &Op : OpenedArchetypeOperands) {
+    auto Def = Op.get();
+    if (getOpenedArchetypeOf(cast<SILInstruction>(Def)) == CanTy)
+      return Def;
+  }
+  // Then use a regular lookup.
+  if (OpenedArchetypesTracker)
+    return OpenedArchetypesTracker->getOpenedArchetypeDef(Ty);
+  return SILValue();
+}

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1291,9 +1291,9 @@ public:
     if (WMI->isVolatile())
       *this << "[volatile] ";
     *this << "$" << WMI->getLookupType() << ", " << WMI->getMember();
-    if (WMI->hasOperand()) {
+    if (!WMI->getOpenedArchetypeOperands().empty()) {
       *this << ", ";
-      *this << getIDAndType(WMI->getOperand());
+      *this << getIDAndType(WMI->getOpenedArchetypeOperands()[0].get());
     }
     *this << " : " << WMI->getType();
   }

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -547,18 +547,12 @@ public:
       auto proto = Constant.getDecl()->getDeclContext()
                                      ->getAsProtocolOrProtocolExtensionContext();
       auto archetype = getWitnessMethodSelfType();
-      // Get the openend existential value if the archetype is an opened
-      // existential type.
-      SILValue OpenedExistential;
-      if (!archetype->getOpenedExistentialType().isNull())
-        OpenedExistential = SelfValue;
 
       SILValue fn = gen.B.createWitnessMethod(Loc,
                                   archetype,
                                   ProtocolConformanceRef(proto),
                                   *constant,
                                   constantInfo.getSILType(),
-                                  OpenedExistential,
                                   constant->isForeign);
       mv = ManagedValue::forUnmanaged(fn);
       break;

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -35,10 +35,12 @@ using namespace Lowering;
 SILGenFunction::SILGenFunction(SILGenModule &SGM, SILFunction &F)
   : SGM(SGM), F(F),
     B(*this, createBasicBlock()),
+    OpenedArchetypesTracker(F),
     CurrentSILLoc(F.getLocation()),
     Cleanups(*this)
 {
   B.setCurrentDebugScope(F.getDebugScope());
+  B.setOpenedArchetypesTracker(&OpenedArchetypesTracker);
 }
 
 /// SILGenFunction destructor - called after the entire function's AST has been

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -353,6 +353,8 @@ public:
   /// into.
   SILGenBuilder B;
 
+  SILOpenedArchetypesTracker OpenedArchetypesTracker;
+
   struct BreakContinueDest {
     LabeledStmt *Target;
     JumpDest BreakDest;

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -663,6 +663,8 @@ isNonmutatingCapture(SILArgument *BoxArg) {
 static bool
 isNonescapingUse(Operand *O, SmallVectorImpl<SILInstruction*> &Mutations) {
   auto *U = O->getUser();
+  if (U->isOpenedArchetypeOperand(*O))
+    return true;
   // Marking the boxed value as escaping is OK. It's just a DI annotation.
   if (isa<MarkFunctionEscapeInst>(U))
     return true;

--- a/lib/SILOptimizer/LoopTransforms/LICM.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LICM.cpp
@@ -231,13 +231,6 @@ static bool canHoistInstruction(SILInstruction *Inst, SILLoop *Loop,
   if (isa<AllocationInst>(Inst) || isa<DeallocStackInst>(Inst))
     return false;
 
-  // Can't hoist metatype instruction referring to an opened existential,
-  // because it may break the dominance relationship.
-  if (isa<MetatypeInst>(Inst) &&
-      Inst->getType().getSwiftRValueType()->hasOpenedExistential()) {
-    return false;
-  }
-
   // Can't hoist instructions which may have side effects.
   if (!hasNoSideEffect(Inst, SafeReads))
     return false;

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -305,6 +305,7 @@ runOnFunctionRecursively(SILFunction *F, FullApplySite AI,
 
   SmallVector<SILValue, 16> CaptureArgs;
   SmallVector<SILValue, 32> FullArgs;
+
   for (auto FI = F->begin(), FE = F->end(); FI != FE; ++FI) {
     for (auto I = FI->begin(), E = FI->end(); I != E; ++I) {
       FullApplySite InnerAI = FullApplySite::isa(&*I);
@@ -397,9 +398,16 @@ runOnFunctionRecursively(SILFunction *F, FullApplySite AI,
       ContextSubs.copyFrom(CalleeFunction->getContextGenericParams()
                                          ->getSubstitutionMap(ApplySubs));
 
+      SILOpenedArchetypesTracker OpenedArchetypesTracker(*F);
+      F->getModule().registerDeleteNotificationHandler(
+          &OpenedArchetypesTracker);
+      // The callee only needs to know about opened archetypes used in
+      // the substitution list.
+      OpenedArchetypesTracker.registerUsedOpenedArchetypes(InnerAI.getInstruction());
+
       SILInliner Inliner(*F, *CalleeFunction,
-                         SILInliner::InlineKind::MandatoryInline,
-                         ContextSubs, ApplySubs);
+                         SILInliner::InlineKind::MandatoryInline, ContextSubs,
+                         ApplySubs, OpenedArchetypesTracker);
       if (!Inliner.inlineFunction(InnerAI, FullArgs)) {
         I = InnerAI.getInstruction()->getIterator();
         continue;

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -252,6 +252,7 @@ private:
                                                SILValue NewSelf,
                                                SILValue Self,
                                                CanType ConcreteType,
+                                               SILValue ConcreteTypeDef,
                                                ProtocolConformanceRef Conformance,
                                                CanType OpenedArchetype);
   SILInstruction *

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -615,7 +615,8 @@ static SILValue getAddressOfStackInit(AllocStackInst *ASI,
 /// Find the init_existential, which could be used to determine a concrete
 /// type of the \p Self.
 static SILInstruction *findInitExistential(FullApplySite AI, SILValue Self,
-                                           CanType &OpenedArchetype) {
+                                           CanType &OpenedArchetype,
+                                           SILValue &OpenedArchetypeDef) {
   if (auto *Instance = dyn_cast<AllocStackInst>(Self)) {
     // In case the Self operand is an alloc_stack where a copy_addr copies the
     // result of an open_existential_addr to this stack location.
@@ -638,12 +639,14 @@ static SILInstruction *findInitExistential(FullApplySite AI, SILValue Self,
       return nullptr;
 
     OpenedArchetype = Open->getType().getSwiftRValueType();
+    OpenedArchetypeDef = Open;
     return IE;
   }
 
   if (auto *Open = dyn_cast<OpenExistentialRefInst>(Self)) {
     if (auto *IE = dyn_cast<InitExistentialRefInst>(Open->getOperand())) {
       OpenedArchetype = Open->getType().getSwiftRValueType();
+      OpenedArchetypeDef = Open;
       return IE;
     }
     return nullptr;
@@ -655,6 +658,7 @@ static SILInstruction *findInitExistential(FullApplySite AI, SILValue Self,
       OpenedArchetype = Open->getType().getSwiftRValueType();
       while (auto Metatype = dyn_cast<MetatypeType>(OpenedArchetype))
         OpenedArchetype = Metatype.getInstanceType();
+      OpenedArchetypeDef = Open;
       return IE;
     }
     return nullptr;
@@ -669,6 +673,7 @@ SILCombiner::createApplyWithConcreteType(FullApplySite AI,
                                          SILValue NewSelf,
                                          SILValue Self,
                                          CanType ConcreteType,
+                                         SILValue ConcreteTypeDef,
                                          ProtocolConformanceRef Conformance,
                                          CanType OpenedArchetype) {
   // Create a set of arguments.
@@ -737,7 +742,7 @@ SILCombiner::createApplyWithConcreteType(FullApplySite AI,
 
 /// Derive a concrete type of self and conformance from the init_existential
 /// instruction.
-static Optional<std::pair<ProtocolConformanceRef, CanType>>
+static Optional<std::tuple<ProtocolConformanceRef, CanType, SILValue>>
 getConformanceAndConcreteType(FullApplySite AI,
                               SILInstruction *InitExistential,
                               ProtocolDecl *Protocol,
@@ -745,6 +750,7 @@ getConformanceAndConcreteType(FullApplySite AI,
                               ArrayRef<ProtocolConformanceRef> &Conformances) {
   // Try to derive the concrete type of self from the found init_existential.
   CanType ConcreteType;
+  SILValue ConcreteTypeDef;
   if (auto IE = dyn_cast<InitExistentialAddrInst>(InitExistential)) {
     Conformances = IE->getConformances();
     ConcreteType = IE->getFormalConcreteType();
@@ -767,19 +773,25 @@ getConformanceAndConcreteType(FullApplySite AI,
     return None;
   }
 
+  if (ConcreteType->isOpenedExistential()) {
+    assert(!InitExistential->getOpenedArchetypeOperands().empty() &&
+           "init_existential is supposed to have a typedef operand");
+    ConcreteTypeDef = InitExistential->getOpenedArchetypeOperands()[0].get();
+  }
+
   // Find the conformance for the protocol we're interested in.
   for (auto Conformance : Conformances) {
     auto Requirement = Conformance.getRequirement();
     if (Requirement == Protocol) {
-      return std::make_pair(Conformance, ConcreteType);
+      return std::make_tuple(Conformance, ConcreteType, ConcreteTypeDef);
     }
     if (Requirement->inheritsFrom(Protocol)) {
       // If Requirement != Protocol, then the abstract conformance cannot be used
       // as is and we need to create a proper conformance.
-      return std::make_pair(Conformance.isAbstract()
+      return std::make_tuple(Conformance.isAbstract()
                                 ? ProtocolConformanceRef(Protocol)
                                 : Conformance,
-                            ConcreteType);
+                            ConcreteType, ConcreteTypeDef);
     }
   }
 
@@ -811,8 +823,9 @@ SILCombiner::propagateConcreteTypeOfInitExistential(FullApplySite AI,
   // Try to find the init_existential, which could be used to
   // determine a concrete type of the self.
   CanType OpenedArchetype;
+  SILValue OpenedArchetypeDef;
   SILInstruction *InitExistential =
-    findInitExistential(AI, Self, OpenedArchetype);
+    findInitExistential(AI, Self, OpenedArchetype, OpenedArchetypeDef);
   if (!InitExistential)
     return nullptr;
 
@@ -826,17 +839,35 @@ SILCombiner::propagateConcreteTypeOfInitExistential(FullApplySite AI,
   if (!ConformanceAndConcreteType)
     return nullptr;
 
-  auto ConcreteType = ConformanceAndConcreteType->second;
-  auto Conformance = ConformanceAndConcreteType->first;
+  ProtocolConformanceRef Conformance = std::get<0>(*ConformanceAndConcreteType);
+  CanType ConcreteType = std::get<1>(*ConformanceAndConcreteType);
+  SILValue ConcreteTypeDef = std::get<2>(*ConformanceAndConcreteType);
+
+  SILOpenedArchetypesTracker *OldOpenedArchetypesTracker =
+      Builder.getOpenedArchetypesTracker();
+
+  SILOpenedArchetypesTracker OpenedArchetypesTracker(*AI.getFunction());
+
+  if (ConcreteType->isOpenedExistential()) {
+    // Prepare a mini-mapping for opened archetypes.
+    // SILOpenedArchetypesTracker OpenedArchetypesTracker(*AI.getFunction());
+    OpenedArchetypesTracker.addOpenedArchetypeDef(ConcreteType, ConcreteTypeDef);
+    Builder.setOpenedArchetypesTracker(&OpenedArchetypesTracker);
+  }
 
   // Propagate the concrete type into the callee-operand if required.
   Propagate(ConcreteType, Conformance);
 
   // Create a new apply instruction that uses the concrete type instead
   // of the existential type.
-  return createApplyWithConcreteType(AI, NewSelf, Self,
-                                     ConcreteType, Conformance,
-                                     OpenedArchetype);
+  auto *NewAI = createApplyWithConcreteType(AI, NewSelf, Self, ConcreteType,
+                                            ConcreteTypeDef, Conformance,
+                                            OpenedArchetype);
+
+  if (ConcreteType->isOpenedExistential())
+    Builder.setOpenedArchetypesTracker(OldOpenedArchetypesTracker);
+
+  return NewAI;
 }
 
 SILInstruction *
@@ -870,15 +901,10 @@ SILCombiner::propagateConcreteTypeOfInitExistential(FullApplySite AI,
                                            ProtocolConformanceRef Conformance) {
     // Keep around the dependence on the open instruction unless we've
     // actually eliminated the use.
-    SILValue OptionalExistential;
-    if (WMI->hasOperand() && ConcreteType->isOpenedExistential())
-      OptionalExistential = WMI->getOperand();
-
     auto *NewWMI = Builder.createWitnessMethod(WMI->getLoc(),
                                                 ConcreteType,
                                                 Conformance, WMI->getMember(),
                                                 WMI->getType(),
-                                                OptionalExistential,
                                                 WMI->isVolatile());
     replaceInstUsesWith(*WMI, NewWMI);
     eraseInstFromFunction(*WMI);

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -1468,12 +1468,19 @@ bool SILPerformanceInliner::inlineCallsIntoFunction(SILFunction *Caller) {
           Caller->size() << "] " << Callee->getName() << "\n";
     );
 
+    SILOpenedArchetypesTracker OpenedArchetypesTracker(*Caller);
+    Caller->getModule().registerDeleteNotificationHandler(&OpenedArchetypesTracker);
+    // The callee only needs to know about opened archetypes used in
+    // the substitution list.
+    OpenedArchetypesTracker.registerUsedOpenedArchetypes(AI.getInstruction());
+
     // Notice that we will skip all of the newly inlined ApplyInsts. That's
     // okay because we will visit them in our next invocation of the inliner.
     TypeSubstitutionMap ContextSubs;
     SILInliner Inliner(*Caller, *Callee,
                        SILInliner::InlineKind::PerformanceInline, ContextSubs,
-                       AI.getSubstitutions());
+                       AI.getSubstitutions(),
+                       OpenedArchetypesTracker);
 
     auto Success = Inliner.inlineFunction(AI, Args);
     (void) Success;

--- a/lib/SILOptimizer/Transforms/Sink.cpp
+++ b/lib/SILOptimizer/Transforms/Sink.cpp
@@ -67,19 +67,6 @@ public:
     if (II->isAllocatingStack() || II->isDeallocatingStack())
       return false;
 
-    // We don't sink open_existential_* instructions, because
-    // there may be some instructions depending on them, e.g.
-    // metatype_inst, etc. But this kind of dependency
-    // cannot be expressed in SIL yet.
-    switch (II->getKind()) {
-    default: break;
-    case ValueKind::OpenExistentialBoxInst:
-    case ValueKind::OpenExistentialRefInst:
-    case ValueKind::OpenExistentialAddrInst:
-    case ValueKind::OpenExistentialMetatypeInst:
-      return false;
-    }
-
     SILBasicBlock *CurrentBlock = II->getParent();
     SILBasicBlock *Dest = nullptr;
     unsigned InitialLoopDepth = LoopInfo->getLoopDepth(CurrentBlock);

--- a/lib/Serialization/DeserializeSIL.h
+++ b/lib/Serialization/DeserializeSIL.h
@@ -82,6 +82,7 @@ namespace swift {
                                      SmallVectorImpl<uint64_t> &scratch);
     /// Read a SIL instruction within a given SIL basic block.
     bool readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
+                            SILBuilder &Builder,
                             unsigned RecordKind,
                             SmallVectorImpl<uint64_t> &scratch);
 

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -507,7 +507,7 @@ void SILSerializer::writeOneTypeOneOperandLayout(ValueKind valueKind,
 /// Write an instruction that looks exactly like a conversion: all
 /// important information is encoded in the operand and the result type.
 void SILSerializer::writeConversionLikeInstruction(const SILInstruction *I) {
-  assert(I->getNumOperands() == 1);
+  assert(I->getNumOperands() - I->getOpenedArchetypeOperands().size() == 1);
   writeOneTypeOneOperandLayout(I->getKind(), 0, I->getType(),
                                I->getOperand(0));
 }
@@ -1395,15 +1395,9 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     handleSILDeclRef(S, AMI->getMember(), ListOfValues);
 
     // Add an optional operand.
-    TypeID OperandTy =
-        AMI->hasOperand()
-            ? S.addTypeRef(AMI->getOperand()->getType().getSwiftRValueType())
-            : TypeID();
-    unsigned OperandTyCategory =
-        AMI->hasOperand() ? (unsigned)AMI->getOperand()->getType().getCategory()
-                          : 0;
-    SILValue OptionalOpenedExistential =
-        AMI->hasOperand() ? AMI->getOperand() : SILValue();
+    TypeID OperandTy = TypeID();
+    unsigned OperandTyCategory = 0;
+    SILValue OptionalOpenedExistential = SILValue();
     auto OperandValueId = addValueRef(OptionalOpenedExistential);
 
     SILInstWitnessMethodLayout::emitRecord(

--- a/test/SILOptimizer/mandatory_inlining.sil
+++ b/test/SILOptimizer/mandatory_inlining.sil
@@ -7,6 +7,20 @@ protocol CP : class {
   func f() -> Self
 }
 
+protocol P2 {
+  var c: Int32 { get }
+}
+
+extension P2 {
+  func s() -> Int32
+}
+
+struct L {
+  var start: Int32 { get }
+  @sil_stored let o: P2
+  init(o: P2)
+}
+
 sil @plus : $@convention(thin) (Int64, Int64) -> Int64
 sil @fromLiteral : $@convention(thin) (Builtin.Int128, @thin Int64.Type) -> Int64
 
@@ -845,3 +859,47 @@ sil shared [transparent] @identity_closure : $@convention(thin) (Builtin.Int8) -
 bb0(%0 : $Builtin.Int8):
   return %0 : $Builtin.Int8
 }
+
+sil [transparent] @P2_s : $@convention(method) <Self where Self : P2> (@in_guaranteed Self) -> Int32 {
+bb0(%0 : $*Self):
+  %2 = alloc_stack $Self
+  copy_addr %0 to [initialization] %2 : $*Self
+  %4 = witness_method $Self, #P2.c!getter.1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : P2> (@in_guaranteed τ_0_0) -> Int32
+  %5 = apply %4<Self>(%2) : $@convention(witness_method) <τ_0_0 where τ_0_0 : P2> (@in_guaranteed τ_0_0) -> Int32
+  destroy_addr %2 : $*Self
+  %7 = integer_literal $Builtin.Int32, 1
+  %8 = struct_extract %5 : $Int32, #Int32._value
+  %9 = integer_literal $Builtin.Int1, -1
+  %10 = builtin "sadd_with_overflow_Int32"(%8 : $Builtin.Int32, %7 : $Builtin.Int32, %9 : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1)
+  %11 = tuple_extract %10 : $(Builtin.Int32, Builtin.Int1), 0
+  %12 = tuple_extract %10 : $(Builtin.Int32, Builtin.Int1), 1
+  cond_fail %12 : $Builtin.Int1
+  %14 = struct $Int32 (%11 : $Builtin.Int32)
+  dealloc_stack %2 : $*Self
+  return %14 : $Int32
+}
+
+// Check that P2_s call can be properly inlined and the resulting witness_method instruction
+// uses the opned archetype from the caller.
+// CHECK-LABEL: sil hidden @L_start
+// CHECK: open_existential_addr{{.*}}$*@[[OPENED_ARCHETYPE:opened\("[A-Z0-9-]+"\) P2]]
+// CHECK: witness_method $@[[OPENED_ARCHETYPE]], #P2.c!getter.1, %{{[0-9]+}} : $*@[[OPENED_ARCHETYPE]]
+// CHECK: return
+sil hidden @L_start : $@convention(method) (@in_guaranteed L) -> Int32 {
+bb0(%0 : $*L):
+  %2 = struct_element_addr %0 : $*L, #L.o
+  %3 = alloc_stack $P2
+  copy_addr %2 to [initialization] %3 : $*P2
+  %5 = open_existential_addr %3 : $*P2 to $*@opened("5C6E227C-235E-11E6-AA98-B8E856428C60") P2
+  %6 = function_ref @P2_s : $@convention(method) <τ_0_0 where τ_0_0 : P2> (@in_guaranteed τ_0_0) -> Int32
+  %7 = apply %6<@opened("5C6E227C-235E-11E6-AA98-B8E856428C60") P2>(%5) : $@convention(method) <τ_0_0 where τ_0_0 : P2> (@in_guaranteed τ_0_0) -> Int32
+  destroy_addr %5 : $*@opened("5C6E227C-235E-11E6-AA98-B8E856428C60") P2
+  deinit_existential_addr %3 : $*P2
+  dealloc_stack %3 : $*P2
+  return %7 : $Int32
+}
+
+sil_default_witness_table hidden P2 {
+  no_default
+}
+

--- a/test/SILOptimizer/split_critical_edges.sil
+++ b/test/SILOptimizer/split_critical_edges.sil
@@ -142,8 +142,8 @@ lookup2:
   %23 = alloc_box $Optional<() -> ()>
   %24 = load %21a : $*AnyObject
   strong_retain %24 : $AnyObject
-  %26 = open_existential_ref %24 : $AnyObject to $@opened("01234567-89ab-cdef-0123-000000000000") AnyObject
-  %27 = unchecked_ref_cast %26 : $@opened("01234567-89ab-cdef-0123-000000000000") AnyObject to $Builtin.UnknownObject
+  %26 = open_existential_ref %24 : $AnyObject to $@opened("12345678-89ab-cdef-0123-000000000000") AnyObject
+  %27 = unchecked_ref_cast %26 : $@opened("12345678-89ab-cdef-0123-000000000000") AnyObject to $Builtin.UnknownObject
   dynamic_method_br %27 : $Builtin.UnknownObject, #X.f!1.foreign, bb1, bb2
 
 bb1(%8 : $@convention(objc_method) (Builtin.UnknownObject) -> ()):


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

This is essentially the PR #2928, with a small fix for a problem which was reported by the buildbots performing the check-swift-validation-optimize-macosx-x86_64 tests.

This PR includes all my opened archetypes related commits. This should make it easier to revert them in one go, should it be necessary.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Track dependencies of SIL instructions on opened archetypes which they use

Till now there was no way in SIL to explicitly express a dependency of an instruction on any opened archetypes used by it. This was a cause of many errors and correctness issues. In many cases the code was moved around without taking into account these dependencies, which resulted in breaking the invariant that any uses of an opened archetype should be dominated by the definition of this archetype.

This patch does the following:
- Map opened archetypes to the instructions defining them, i.e. to open_existential instructions.
- Introduce a helper class SILOpenedArchetypesTracker for creating and maintaining such mappings.
- Introduce a helper class SILOpenedArchetypesState for providing a read-only API for looking up available opened archetypes.
- Each SIL instruction which uses an opened archetype as a type gets an additional opened archetype operand representing a dependency of the instruction on this archetype. These opened archetypes operands are an in-memory representation. They are not serialized. Instead, they are re-constructed when reading binary or textual SIL files.
- SILVerifier was extended to conduct more thorough checks related to the usage of opened archetypes.
