### PR TITLE
stubs: export symbols properly

### DIFF
--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -93,7 +93,7 @@ size_t swift::_swift_stdlib_malloc_size(const void *ptr) {
 }
 #elif defined(_MSC_VER)
 #include <malloc.h>
-size_t _swift_stdlib_malloc_size(const void *ptr) {
+size_t swift::_swift_stdlib_malloc_size(const void *ptr) {
   return _msize(const_cast<void *>(ptr));
 }
 #elif defined(__FreeBSD__)

--- a/stdlib/public/stubs/UnicodeExtendedGraphemeClusters.cpp.gyb
+++ b/stdlib/public/stubs/UnicodeExtendedGraphemeClusters.cpp.gyb
@@ -131,6 +131,7 @@ const uint16_t _swift_stdlib_ExtendedGraphemeClusterNoBoundaryRulesMatrixImpl[] 
 % end
 };
 
+extern "C"
 SWIFT_RUNTIME_STDLIB_INTERFACE
 const uint16_t *_swift_stdlib_ExtendedGraphemeClusterNoBoundaryRulesMatrix =
     _swift_stdlib_ExtendedGraphemeClusterNoBoundaryRulesMatrixImpl;


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

These two symbols were not correctly scoped, placing them inside of the swift
namespace.  This would change the linkage names and fail to link as a result.
Scope one as the header properly places it in an extern "C" block.  The gyb file
is unable to find the desired runtime header, so explicitly mark the exported
symbol as being exposed with C linkage.
