### PR TITLE
[SE-0089] [in progress] Rename string reflection init

### DIFF
--- a/benchmark/single-source/unit-tests/ObjectiveCBridging.swift
+++ b/benchmark/single-source/unit-tests/ObjectiveCBridging.swift
@@ -73,7 +73,7 @@ public func run_ObjectiveCBridgeFromNSStringForced(_ N: Int) {
 
 @inline(never)
 func testObjectiveCBridgeToNSString() {
-  let nativeString = String("Native")
+  let nativeString = "Native"
 
   var s: NSString?
   for _ in 0 ..< 10_000 {

--- a/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
+++ b/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
@@ -127,7 +127,7 @@ public func == (lhs: TypeIdentifier, rhs: TypeIdentifier) -> Bool {
 extension TypeIdentifier
   : CustomStringConvertible, CustomDebugStringConvertible {
   public var description: String {
-    return String(value)
+    return String(describing: value)
   }
   public var debugDescription: String {
     return "TypeIdentifier(\(description))"

--- a/stdlib/private/StdlibUnittest/StringConvertible.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StringConvertible.swift.gyb
@@ -112,7 +112,7 @@ extension CustomPrintableValue : CustomDebugStringConvertible {
 public func expectPrinted<T>(
   expectedOneOf patterns: [String], _ object: T, ${TRACE}
 ) {
-  let actual = String(object)
+  let actual = String(describing: object)
   if !patterns.contains(actual) {
     expectationFailure(
       "expected: any of \(String(reflecting: patterns))\n"

--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -146,6 +146,18 @@ extension Bool : Equatable, Hashable {
   }
 }
 
+extension Bool : LosslessStringConvertible {
+  public init?(_ description: String) {
+    if description == "true" {
+      self = true
+    } else if description == "false" {
+      self = false
+    } else {
+      return nil
+    }
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // Operators
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -353,6 +353,14 @@ public struct Character :
   internal var _representation: Representation
 }
 
+extension Character : CustomStringConvertible {
+  public var description: String {
+    return String(self)
+  }
+}
+
+extension Character : LosslessStringConvertible {}
+
 extension Character : CustomDebugStringConvertible {
   /// A textual representation of the character, suitable for debugging.
   public var debugDescription: String {

--- a/stdlib/public/core/ImplicitlyUnwrappedOptional.swift
+++ b/stdlib/public/core/ImplicitlyUnwrappedOptional.swift
@@ -45,7 +45,7 @@ extension ImplicitlyUnwrappedOptional : CustomStringConvertible {
   public var description: String {
     switch self {
     case .some(let value):
-      return String(value)
+      return String(describing: value)
     case .none:
       return "nil"
     }

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -855,7 +855,7 @@ extension String {
   ///     }
   ///
   ///     let p = Point(x: 21, y: 30)
-  ///     print(String(p))
+  ///     print(String(describing: p))
   ///     // Prints "Point(x: 21, y: 30)"
   ///
   /// After adding `CustomStringConvertible` conformance by implementing the
@@ -867,11 +867,11 @@ extension String {
   ///         }
   ///     }
   ///
-  ///     print(String(p))
+  ///     print(String(describing: p))
   ///     // Prints "(21, 30)"
   ///
   /// - SeeAlso: `String.init<Subject>(reflecting: Subject)`
-  public init<Subject>(_ instance: Subject) {
+  public init<Subject>(describing instance: Subject) {
     self.init()
     _print_unlocked(instance, &self)
   }

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -164,6 +164,10 @@ public protocol CustomStringConvertible {
   var description: String { get }
 }
 
+public protocol LosslessStringConvertible : CustomStringConvertible {
+  init?(_ description: String)
+}
+
 /// A type with a customized textual representation suitable for debugging
 /// purposes.
 ///

--- a/stdlib/public/core/StaticString.swift
+++ b/stdlib/public/core/StaticString.swift
@@ -259,7 +259,7 @@ public struct StaticString
 
 extension StaticString {
   public var customMirror: Mirror {
-    return Mirror(reflecting: String(self))
+    return Mirror(reflecting: String(describing: self))
   }
 }
 

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -973,6 +973,23 @@ extension String {
     return _nativeUnicodeUppercaseString(self)
 #endif
   }
+  
+  public // @testable
+  init<T: LosslessStringConvertible>(_ v: T) {
+    self = v.description
+  }
+}
+
+extension String : CustomStringConvertible {
+  public var description: String {
+    return self
+  }
+}
+
+extension String : LosslessStringConvertible {
+  public init?(_ description: String) {
+    self = description
+  }
 }
 
 extension String {

--- a/stdlib/public/core/StringInterpolation.swift.gyb
+++ b/stdlib/public/core/StringInterpolation.swift.gyb
@@ -65,7 +65,7 @@ extension String : StringInterpolationConvertible {
   ///
   /// - SeeAlso: `StringInterpolationConvertible`
   public init<T>(stringInterpolationSegment expr: T) {
-    self = String(expr)
+    self = String(describing: expr)
   }
 
 % for Type in StreamableTypes:

--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -314,7 +314,7 @@ extension String {
       return UTF16View(_core)
     }
     set {
-      self = String(newValue)
+      self = String(describing: newValue)
     }
   }
 

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -352,7 +352,7 @@ extension String {
       return UTF8View(self._core)
     }
     set {
-      self = String(newValue)
+      self = String(describing: newValue)
     }
   }
 

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -249,12 +249,23 @@ public struct UnicodeScalar :
 extension UnicodeScalar : CustomStringConvertible, CustomDebugStringConvertible {
   /// An escaped textual representation of the Unicode scalar.
   public var description: String {
-    return "\"\(escaped(asASCII: false))\""
+    return String(value)
   }
   /// An escaped textual representation of the Unicode scalar, suitable for
   /// debugging.
   public var debugDescription: String {
     return "\"\(escaped(asASCII: true))\""
+  }
+}
+
+extension UnicodeScalar : LosslessStringConvertible {
+  public init?(_ description: String) {
+    if let v = UInt32(description) where (v < 0xD800 || v > 0xDFFF)
+      && v <= 0x10FFFF {
+      self = UnicodeScalar(v)
+    }
+
+    return nil
   }
 }
 

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -219,7 +219,7 @@ extension Unsafe${Mutable}BufferPointer : CustomDebugStringConvertible {
   /// A textual representation of `self`, suitable for debugging.
   public var debugDescription: String {
     return "Unsafe${Mutable}BufferPointer"
-      + "(start: \(_position.map(String.init(_:)) ?? "nil"), count: \(count))"
+      + "(start: \(_position.map(String.init(describing:)) ?? "nil"), count: \(count))"
   }
 }
 %end


### PR DESCRIPTION
Hello @gribozavr 

I just started work on the [proposal](https://github.com/apple/swift-evolution/blob/master/proposals/0089-rename-string-reflection-init.md) and if you could please help me with it. Because I don't really understand how to implement `LosslessStringConvertible` protocol for `String.*` (`String.UTF8View`, `String.UTF16View.`..) and for `FloatingPoint` and `Integer`.

Thanks for any help :)
