### PR TITLE
[swiftc] Add 💥 case (😢 → 51, 😀 → 5091) triggered in swift::ArchetypeBuilder::getGenericSignature(…)

### DIFF
--- a/validation-test/compiler_crashers/28332-swift-archetypebuilder-getgenericsignature.swift
+++ b/validation-test/compiler_crashers/28332-swift-archetypebuilder-getgenericsignature.swift
@@ -1,0 +1,23 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+class A{var b=a
+struct Q<h{
+enum a<T{
+extension{
+{{
+}}
+protocol c:a{
+extension{
+{
+}
+protocol A{
+func<
+typealias e:
+Q


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Add crash case with stack trace:

```
swift: /path/to/swift/lib/AST/ArchetypeBuilder.cpp:2250: void collectRequirements(swift::ArchetypeBuilder &, ArrayRef<swift::GenericTypeParamType *>, SmallVectorImpl<swift::Requirement> &): Assertion `pa && "Missing potential archetype for generic parameter"' failed.
8  swift           0x0000000000feee54 swift::ArchetypeBuilder::getGenericSignature(llvm::ArrayRef<swift::GenericTypeParamType*>) + 1604
9  swift           0x0000000000eea3ce swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 318
10 swift           0x0000000000eeae7f swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) + 111
11 swift           0x0000000000eac1e9 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1833
12 swift           0x00000000011073d3 swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2387
13 swift           0x0000000000eed0eb swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
16 swift           0x0000000000f1e40e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
18 swift           0x0000000000f1f364 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
19 swift           0x0000000000f1e300 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
20 swift           0x0000000000fe43af swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 159
21 swift           0x0000000000fbc69d swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
22 swift           0x0000000000ea91b9 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) + 137
23 swift           0x0000000000eabf5f swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1183
24 swift           0x0000000000eabb91 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 209
27 swift           0x0000000001101c7d swift::namelookup::lookupVisibleDeclsInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >) + 1101
28 swift           0x00000000010e7fb2 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 1730
29 swift           0x0000000000eee584 swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) + 260
30 swift           0x0000000000e985d9 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 3881
32 swift           0x00000000010651c3 swift::Expr::walk(swift::ASTWalker&) + 19
33 swift           0x0000000000e98e60 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 224
34 swift           0x0000000000e9f832 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
35 swift           0x0000000000ea09e7 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 343
36 swift           0x0000000000ea0bfb swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
41 swift           0x0000000000eb12b6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
42 swift           0x0000000000ed3462 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
43 swift           0x0000000000c613b9 swift::CompilerInstance::performSema() + 3289
45 swift           0x00000000007d86c9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
46 swift           0x00000000007a4708 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28332-swift-archetypebuilder-getgenericsignature.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28332-swift-archetypebuilder-getgenericsignature-9505f7.o
1.  While type-checking 'A' at validation-test/compiler_crashers/28332-swift-archetypebuilder-getgenericsignature.swift:10:1
2.  While type-checking expression at [validation-test/compiler_crashers/28332-swift-archetypebuilder-getgenericsignature.swift:10:15 - line:10:15] RangeText="a"
3.  While resolving type Q at [validation-test/compiler_crashers/28332-swift-archetypebuilder-getgenericsignature.swift:23:1 - line:23:1] RangeText="Q"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
