### PR TITLE
[CMake] Include CMAKE_CURRENT_BINARY_DIR in lib/Basic

### DIFF
--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -55,6 +55,7 @@ generate_revision_inc(llvm_revision_inc LLVM "${LLVM_MAIN_SRC_DIR}")
 generate_revision_inc(clang_revision_inc Clang "${CLANG_MAIN_SRC_DIR}")
 generate_revision_inc(swift_revision_inc Swift "${SWIFT_SOURCE_DIR}")
 
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 set(version_inc_files
   ${llvm_revision_inc} ${clang_revision_inc} ${swift_revision_inc})
 

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -45,12 +45,18 @@
 
 #if __has_include("LLVMRevision.inc")
 # include "LLVMRevision.inc"
+#else
+#warning "LLVMRevision.inc" is missing.
 #endif
 #if __has_include("ClangRevision.inc")
 # include "ClangRevision.inc"
+#else
+#warning "ClangRevision.inc" is missing.
 #endif
 #if __has_include("SwiftRevision.inc")
 # include "SwiftRevision.inc"
+#else
+#warning "SwiftRevision.inc" is missing.
 #endif
 
 namespace swift {


### PR DESCRIPTION
#### What's in this pull request?

CC: @gottesmm 
I believe this was accidentally dropped from 3168df8c1187367cbbcbe35b56eb081d3a4efbc2.

Also, added `#warning` for missing `XXXRevision.inc`.

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
