### PR TITLE
Cascading Doc Comments: Look up class hierarchy when doc comments are…

### DIFF
--- a/include/swift/AST/Comment.h
+++ b/include/swift/AST/Comment.h
@@ -77,8 +77,14 @@ public:
   void operator delete(void *Data) = delete;
 };
 
-Optional<DocComment *>getDocComment(swift::markup::MarkupContext &Context,
-                                    const Decl *D);
+/// Get a parsed documentation comment for the declaration, if there is one.
+Optional<DocComment *>getSingleDocComment(swift::markup::MarkupContext &Context,
+                                          const Decl *D);
+
+/// Attempt to get a doc comment from the declaration, or other inherited
+/// sources, like from base classes or protocols.
+Optional<DocComment *> getCascadingDocComment(swift::markup::MarkupContext &MC,
+                                             const Decl *D);
 
 } // namespace swift
 

--- a/lib/AST/DocComment.cpp
+++ b/lib/AST/DocComment.cpp
@@ -325,16 +325,87 @@ extractCommentParts(swift::markup::MarkupContext &MC,
   return Parts;
 }
 
-Optional<DocComment *> swift::getDocComment(swift::markup::MarkupContext &MC,
-                                            const Decl *D) {
+Optional<DocComment *>
+swift::getSingleDocComment(swift::markup::MarkupContext &MC, const Decl *D) {
+  PrettyStackTraceDecl StackTrace("parsing comment for", D);
+
   auto RC = D->getRawComment();
   if (RC.isEmpty())
     return None;
-
-  PrettyStackTraceDecl StackTrace("parsing comment for", D);
 
   swift::markup::LineList LL = MC.getLineList(RC);
   auto *Doc = swift::markup::parseDocument(MC, LL);
   auto Parts = extractCommentParts(MC, Doc);
   return new (MC) DocComment(D, Doc, Parts);
+}
+
+static Optional<DocComment *>
+getAnyBaseClassDocComment(swift::markup::MarkupContext &MC,
+                          const ClassDecl *CD,
+                          const Decl *D) {
+  RawComment RC;
+
+  if (const auto *VD = dyn_cast<ValueDecl>(D)) {
+    const auto *BaseDecl = VD->getOverriddenDecl();
+    while (BaseDecl) {
+      RC = BaseDecl->getRawComment();
+      if (!RC.isEmpty()) {
+        swift::markup::LineList LL = MC.getLineList(RC);
+        auto *Doc = swift::markup::parseDocument(MC, LL);
+        auto Parts = extractCommentParts(MC, Doc);
+
+        SmallString<48> RawCascadeText;
+        llvm::raw_svector_ostream OS(RawCascadeText);
+        OS << "This documentation comment was inherited from ";
+
+
+        auto *Text = swift::markup::Text::create(MC, MC.allocateCopy(OS.str()));
+
+        auto BaseClass =
+          BaseDecl->getDeclContext()->getAsClassOrClassExtensionContext();
+
+        auto *BaseClassMonospace =
+          swift::markup::Code::create(MC,
+                                      MC.allocateCopy(BaseClass->getNameStr()));
+
+        auto *Period = swift::markup::Text::create(MC, ".");
+
+        auto *Para = swift::markup::Paragraph::create(MC, {
+          Text, BaseClassMonospace, Period
+        });
+        auto CascadeNote = swift::markup::NoteField::create(MC, {Para});
+
+        SmallVector<const swift::markup::MarkupASTNode *, 8> BodyNodes {
+          Parts.BodyNodes.begin(),
+          Parts.BodyNodes.end()
+        };
+        BodyNodes.push_back(CascadeNote);
+        Parts.BodyNodes = MC.allocateCopy(llvm::makeArrayRef(BodyNodes));
+
+        return new (MC) DocComment(D, Doc, Parts);
+      }
+
+      BaseDecl = BaseDecl->getOverriddenDecl();
+    }
+  }
+  
+  return None;
+}
+
+Optional<DocComment *>
+swift::getCascadingDocComment(swift::markup::MarkupContext &MC, const Decl *D) {
+  auto Doc = getSingleDocComment(MC, D);
+  if (Doc.hasValue())
+    return Doc;
+
+  // If this refers to a class member, check to see if any
+  // base classes have a doc comment and cascade it to here.
+  if (const auto *CD = D->getDeclContext()->getAsClassOrClassExtensionContext())
+    if (auto BaseClassDoc = getAnyBaseClassDocComment(MC, CD, D))
+      return BaseClassDoc;
+
+  // FIXME: Look at protocol requirement declarations if a protocol
+  // extension implementation doesn't have a doc comment.
+
+  return None;
 }

--- a/lib/AST/RawComment.cpp
+++ b/lib/AST/RawComment.cpp
@@ -211,7 +211,7 @@ static StringRef extractBriefComment(ASTContext &Context, RawComment RC,
     return StringRef();
 
   swift::markup::MarkupContext MC;
-  auto DC = getDocComment(MC, D);
+  auto DC = getCascadingDocComment(MC, D);
   if (!DC.hasValue())
     return StringRef();
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -257,7 +257,7 @@ void getSwiftDocKeyword(const Decl* D, CommandWordsPairs &Words) {
   if (!Interested)
     return;
   static swift::markup::MarkupContext MC;
-  auto DC = getDocComment(MC, D);
+  auto DC = getSingleDocComment(MC, D);
   if (!DC.hasValue())
     return;
   SwiftDocWordExtractor Extractor(Words);

--- a/lib/IDE/CommentConversion.cpp
+++ b/lib/IDE/CommentConversion.cpp
@@ -432,7 +432,7 @@ bool ide::getDocumentationCommentAsXML(const Decl *D, raw_ostream &OS) {
   }
 
   swift::markup::MarkupContext MC;
-  auto DC = getDocComment(MC, D);
+  auto DC = getCascadingDocComment(MC, D);
   if (!DC.hasValue())
     return false;
 

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -193,7 +193,7 @@ private:
 
   void printDocumentationComment(Decl *D) {
     swift::markup::MarkupContext MC;
-    auto DC = getDocComment(MC, D);
+    auto DC = getSingleDocComment(MC, D);
     if (DC.hasValue())
       ide::getDocumentationCommentAsDoxygen(DC.getValue(), os);
   }

--- a/test/IDE/comment_inherited_class.swift
+++ b/test/IDE/comment_inherited_class.swift
@@ -1,0 +1,51 @@
+// RUN: %target-swift-ide-test -print-comments -source-filename %s | FileCheck %s
+// REQUIRES: no_asan
+
+class Base {
+  func noComments() {}
+  // CHECK: Func/Base.noComments {{.*}} DocCommentAsXML=none
+
+  /// Base
+  func funcNoDerivedComment() {}
+  // CHECK: Func/Base.funcNoDerivedComment {{.*}} DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>funcNoDerivedComment()</Name><USR>s:FC14swift_ide_test4Base20funcNoDerivedCommentFT_T_</USR><Declaration>func funcNoDerivedComment()</Declaration><Abstract><Para>Base</Para></Abstract></Function>]
+
+  /// Base
+  func funcWithDerivedComment() {}
+  // CHECK: Func/Base.funcWithDerivedComment {{.*}} DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>funcWithDerivedComment()</Name><USR>s:FC14swift_ide_test4Base22funcWithDerivedCommentFT_T_</USR><Declaration>func funcWithDerivedComment()</Declaration><Abstract><Para>Base</Para></Abstract></Function>]
+
+  /// Base
+  var varNoDerivedComment: Bool {
+    return false
+  }
+  // CHECK: Var/Base.varNoDerivedComment {{.*}} DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>varNoDerivedComment</Name><USR>s:vC14swift_ide_test4Base19varNoDerivedCommentSb</USR><Declaration>var varNoDerivedComment: Bool { get }</Declaration><Abstract><Para>Base</Para></Abstract></Other>]
+
+  /// Base
+  var varWithDerivedComment: Bool {
+    return false
+  }
+  // CHECK: Var/Base.varWithDerivedComment {{.*}} DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>varWithDerivedComment</Name><USR>s:vC14swift_ide_test4Base21varWithDerivedCommentSb</USR><Declaration>var varWithDerivedComment: Bool { get }</Declaration><Abstract><Para>Base</Para></Abstract></Other>]
+}
+
+class Derived : Base {
+  override func noComments() {}
+  // CHECK: Func/Derived.noComments {{.*}} DocCommentAsXML=none
+
+  override func funcNoDerivedComment() {}
+  // CHECK: Func/Derived.funcNoDerivedComment {{.*}} DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>funcNoDerivedComment()</Name><USR>s:FC14swift_ide_test7Derived20funcNoDerivedCommentFT_T_</USR><Declaration>override func funcNoDerivedComment()</Declaration><Abstract><Para>Base</Para></Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>Base</codeVoice>.</Para></Note></Discussion></Function>]
+
+  /// Derived
+  override func funcWithDerivedComment() {}
+  // CHECK: Func/Derived.funcWithDerivedComment {{.*}} DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>funcWithDerivedComment()</Name><USR>s:FC14swift_ide_test7Derived22funcWithDerivedCommentFT_T_</USR><Declaration>override func funcWithDerivedComment()</Declaration><Abstract><Para>Derived</Para></Abstract></Function>]
+
+  override var varNoDerivedComment: Bool {
+    return false
+  }
+  // CHECK: Var/Derived.varNoDerivedComment {{.*}} DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>varNoDerivedComment</Name><USR>s:vC14swift_ide_test7Derived19varNoDerivedCommentSb</USR><Declaration>override var varNoDerivedComment: Bool { get }</Declaration><Abstract><Para>Base</Para></Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>Base</codeVoice>.</Para></Note></Discussion></Other>]
+
+  // Derived
+  override var varWithDerivedComment : Bool {
+    return true
+  }
+  // CHECK: Var/Derived.varWithDerivedComment {{.*}} DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>varWithDerivedComment</Name><USR>s:vC14swift_ide_test7Derived21varWithDerivedCommentSb</USR><Declaration>override var varWithDerivedComment: Bool { get }</Declaration><Abstract><Para>Base</Para></Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>Base</codeVoice>.</Para></Note></Discussion></Other>]
+}
+

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1976,7 +1976,7 @@ public:
       return true;
 
     swift::markup::MarkupContext MC;
-    auto DC = getDocComment(MC, D);
+    auto DC = getSingleDocComment(MC, D);
     if (DC.hasValue())
       swift::markup::dump(DC.getValue()->getDocument(), OS);
 


### PR DESCRIPTION
If a class member doesn't have a doc comment but a base class does, show
the base class's comment and add a note about where it came from.

rdar://problem/16512247
