### PR TITLE
Make #selector a primary expression

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -480,7 +480,6 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
 ///     expr-postfix(Mode)
 ///     operator-prefix expr-unary(Mode)
 ///     '&' expr-unary(Mode)
-///     expr-selector
 ///
 ParserResult<Expr> Parser::parseExprUnary(Diag<> Message, bool isExprBasic) {
   UnresolvedDeclRefExpr *Operator;
@@ -503,9 +502,6 @@ ParserResult<Expr> Parser::parseExprUnary(Diag<> Message, bool isExprBasic) {
 
   case tok::pound_keyPath:
     return parseExprKeyPath();
-
-  case tok::pound_selector:
-    return parseExprSelector();
 
   case tok::oper_postfix:
     // Postfix operators cannot start a subexpression, but can happen
@@ -1030,6 +1026,7 @@ getMagicIdentifierLiteralKind(tok Kind) {
 ///     expr-paren
 ///     expr-super
 ///     expr-discard
+///     expr-selector
 ///
 ///   expr-delayed-identifier:
 ///     '.' identifier
@@ -1189,6 +1186,10 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
   case tok::kw__:
     Result = makeParserResult(
       new (Context) DiscardAssignmentExpr(consumeToken(), /*Implicit=*/false));
+    break;
+
+  case tok::pound_selector: // expr-selector
+    Result = parseExprSelector();
     break;
 
   case tok::l_brace:     // expr-closure

--- a/test/Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift
@@ -63,6 +63,12 @@ public struct Selector : StringLiteralConvertible {
   }
 }
 
+extension Selector : Equatable {}
+
+public func ==(lhs: Selector, rhs: Selector) -> Bool {
+  return sel_isEqual(lhs, rhs)
+}
+
 public struct NSZone {
   public var pointer : OpaquePointer
 }

--- a/test/Inputs/clang-importer-sdk/usr/include/objc/objc.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/objc/objc.h
@@ -16,6 +16,7 @@ typedef __typeof__(__objc_yes) BOOL;
 
 typedef struct objc_selector    *SEL;
 SEL sel_registerName(const char *str);
+BOOL sel_isEqual(SEL sel1, SEL sel2);
 
 void NSDeallocateObject(id object) NS_AUTOMATED_REFCOUNT_UNAVAILABLE;
 

--- a/test/expr/unary/selector/selector.swift
+++ b/test/expr/unary/selector/selector.swift
@@ -111,3 +111,12 @@ func testParseErrors4() {
   // Subscripts
   _ = #selector(C1.subscript) // expected-error{{type 'C1.Type' has no subscript members}}
 }
+
+// SR-1827
+
+let optionalSel: Selector? = nil
+
+switch optionalSel {
+case #selector(C1.method1)?:
+  break
+}


### PR DESCRIPTION
#### What's in this pull request?

This changes the grammar of Swift to make `#selector` a primary expression instead of a unary expression. 
This allows case statements on selectors to be amended with a trailing `?` to match optionals, e.g.

```
let optionalSel: Selector? = nil

switch optionalSel {
case #selector(Foo.bar)?:
  break
}
```
#### This partially resolves ([SR-1827](https://bugs.swift.org/browse/SR-1827))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
