### PR TITLE
Add s390x support in FloatingPointInterchange

### DIFF
--- a/test/Prototypes/FloatingPoint.swift
+++ b/test/Prototypes/FloatingPoint.swift
@@ -858,7 +858,7 @@ public protocol FloatingPointInterchange: FloatingPoint {
 
 extension FloatingPointInterchange {
   public init(littleEndian encoding: BitPattern) {
-#if arch(i386) || arch(x86_64) || arch(arm) || arch(arm64) || arch(powerpc64le)
+#if arch(i386) || arch(x86_64) || arch(arm) || arch(arm64) || arch(powerpc64le) || arch(s390x)
     self = unsafeBitCast(encoding, to: Self.self)
 #else
     _UnsupportedArchitectureError()
@@ -868,7 +868,8 @@ extension FloatingPointInterchange {
     fatalError("TODO: with low-level generic integer type support for bswap.")
   }
   public var littleEndian: BitPattern {
-#if arch(i386) || arch(x86_64) || arch(arm) || arch(arm64) || arch(powerpc64le)
+#if arch(i386) || arch(x86_64) || arch(arm) || arch(arm64) || arch(powerpc64le) || arch(s390x)
+
     return unsafeBitCast(self, to: BitPattern.self)
 #else
     _UnsupportedArchitectureError()


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Enable s390x testing in test/Prototypes/FloatingPoint.swift, extracting from https://github.com/apple/swift/pull/3193
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
