### PR TITLE
Small debug output improvements

### DIFF
--- a/include/swift/SILOptimizer/PassManager/PrettyStackTrace.h
+++ b/include/swift/SILOptimizer/PassManager/PrettyStackTrace.h
@@ -23,17 +23,23 @@ class SILModuleTransform;
 class PrettyStackTraceSILFunctionTransform
     : public llvm::PrettyStackTraceEntry {
   SILFunctionTransform *SFT;
+  unsigned PassNumber;
 
 public:
-  PrettyStackTraceSILFunctionTransform(SILFunctionTransform *SFT) : SFT(SFT) {}
+  PrettyStackTraceSILFunctionTransform(SILFunctionTransform *SFT,
+                                       unsigned PassNumber)
+      : SFT(SFT), PassNumber(PassNumber) {}
   virtual void print(llvm::raw_ostream &OS) const;
 };
 
 class PrettyStackTraceSILModuleTransform : public llvm::PrettyStackTraceEntry {
   SILModuleTransform *SMT;
+  unsigned PassNumber;
 
 public:
-  PrettyStackTraceSILModuleTransform(SILModuleTransform *SMT) : SMT(SMT) {}
+  PrettyStackTraceSILModuleTransform(SILModuleTransform *SMT,
+                                     unsigned PassNumber)
+      : SMT(SMT), PassNumber(PassNumber) {}
   virtual void print(llvm::raw_ostream &OS) const;
 };
 

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -25,6 +25,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/TimeValue.h"
 #include "llvm/Support/GraphWriter.h"
 
@@ -93,6 +94,40 @@ llvm::cl::list<std::string>
 llvm::cl::opt<bool> SILVerifyWithoutInvalidation(
     "sil-verify-without-invalidation", llvm::cl::init(false),
     llvm::cl::desc("Verify after passes even if the pass has not invalidated"));
+
+
+static llvm::ManagedStatic<std::vector<unsigned>> DebugPassNumbers;
+
+namespace {
+
+struct DebugOnlyPassNumberOpt {
+  void operator=(const std::string &Val) const {
+    if (Val.empty())
+      return;
+    SmallVector<StringRef, 8> dbgPassNumbers;
+    StringRef(Val).split(dbgPassNumbers, ',', -1, false);
+    for (auto dbgPassNumber : dbgPassNumbers) {
+      int PassNumber;
+      if (dbgPassNumber.getAsInteger(10, PassNumber) || PassNumber < 0)
+        llvm_unreachable("The pass number should be an integer number >= 0");
+      DebugPassNumbers->push_back(static_cast<unsigned>(PassNumber));
+    }
+  }
+};
+
+}
+
+static DebugOnlyPassNumberOpt DebugOnlyPassNumberOptLoc;
+
+static llvm::cl::opt<DebugOnlyPassNumberOpt, true,
+                     llvm::cl::parser<std::string>>
+    DebugOnly("debug-only-pass-number",
+              llvm::cl::desc("Enable a specific type of debug output (comma "
+                             "separated list pass numbers)"),
+              llvm::cl::Hidden, llvm::cl::ZeroOrMore,
+              llvm::cl::value_desc("pass number"),
+              llvm::cl::location(DebugOnlyPassNumberOptLoc),
+              llvm::cl::ValueRequired);
 
 static bool doPrintBefore(SILTransform *T, SILFunction *F) {
   if (!SILPrintOnlyFun.empty() && F && F->getName() != SILPrintOnlyFun)
@@ -163,6 +198,31 @@ static void printModule(SILModule *Mod, bool EmitVerboseSIL) {
   }
 }
 
+class DebugPrintEnabler {
+  bool OldDebugFlag;
+public:
+  DebugPrintEnabler(unsigned PassNumber) {
+    OldDebugFlag = llvm::DebugFlag;
+    if (llvm::DebugFlag)
+      return;
+    if (DebugPassNumbers->empty())
+      return;
+    // Enable debug printing if the pass number matches
+    // one of the pass numbers provided as a command line option.
+    for (auto DebugPassNumber : *DebugPassNumbers) {
+      if (DebugPassNumber == PassNumber) {
+        llvm::DebugFlag = true;
+        return;
+      }
+    }
+  }
+
+  ~DebugPrintEnabler() {
+    llvm::DebugFlag = OldDebugFlag;
+  }
+};
+
+
 SILPassManager::SILPassManager(SILModule *M, llvm::StringRef Stage) :
   Mod(M), StageName(Stage) {
   
@@ -217,6 +277,8 @@ void SILPassManager::runPassesOnFunction(PassList FuncTransforms,
 
   for (auto SFT : FuncTransforms) {
     PrettyStackTraceSILFunctionTransform X(SFT, NumPassesRun);
+    DebugPrintEnabler DebugPrint(NumPassesRun);
+
     SFT->injectPassManager(this);
     SFT->injectFunction(F);
 
@@ -410,6 +472,7 @@ void SILPassManager::runModulePass(SILModuleTransform *SMT) {
   const SILOptions &Options = getOptions();
 
   PrettyStackTraceSILModuleTransform X(SMT, NumPassesRun);
+  DebugPrintEnabler DebugPrint(NumPassesRun);
 
   SMT->injectPassManager(this);
   SMT->injectModule(Mod);

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -216,7 +216,7 @@ void SILPassManager::runPassesOnFunction(PassList FuncTransforms,
   assert(analysesUnlocked() && "Expected all analyses to be unlocked!");
 
   for (auto SFT : FuncTransforms) {
-    PrettyStackTraceSILFunctionTransform X(SFT);
+    PrettyStackTraceSILFunctionTransform X(SFT, NumPassesRun);
     SFT->injectPassManager(this);
     SFT->injectFunction(F);
 
@@ -409,7 +409,7 @@ void SILPassManager::runModulePass(SILModuleTransform *SMT) {
 
   const SILOptions &Options = getOptions();
 
-  PrettyStackTraceSILModuleTransform X(SMT);
+  PrettyStackTraceSILModuleTransform X(SMT, NumPassesRun);
 
   SMT->injectPassManager(this);
   SMT->injectModule(Mod);

--- a/lib/SILOptimizer/PassManager/PrettyStackTrace.cpp
+++ b/lib/SILOptimizer/PassManager/PrettyStackTrace.cpp
@@ -18,7 +18,8 @@
 using namespace swift;
 
 void PrettyStackTraceSILFunctionTransform::print(llvm::raw_ostream &out) const {
-  out << "While running SILFunctionTransform \"" << SFT->getName()
+  out << "While running pass #" << PassNumber
+      << " SILFunctionTransform \"" << SFT->getName()
       << "\" on SILFunction ";
   if (!SFT->getFunction()) {
     out << " <<null>>";
@@ -30,5 +31,6 @@ void PrettyStackTraceSILFunctionTransform::print(llvm::raw_ostream &out) const {
 }
 
 void PrettyStackTraceSILModuleTransform::print(llvm::raw_ostream &out) const {
-  out << "While running SILModuleTransform \"" << SMT->getName() << "\".\n";
+  out << "While running pass #" << PassNumber
+      << " SILModuleTransform \"" << SMT->getName() << "\".\n";
 }


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
- Print the current pass number when a compiler crashes
- Add a new `-debug-only-pass-number option` for debugging the compiler
  The option is supposed to be used as follows and takes a comma-seprataed list of SIL pass numbers as input:
  `-Xllvm -debug-only-pass-number=passnumber1[,passnumber2,..,passnumberN]`
  
  It enables the debug printing (i.e. prints inside DEBUG statements ) when one of the mentioned passes is being run.
