### PR TITLE
[swiftc] Add 💥 case (😢 → 52, 😀 → 5091) triggered in swift::TypeDecl::getDeclaredType(…)

### DIFF
--- a/validation-test/compiler_crashers/28333-swift-typedecl-getdeclaredtype.swift
+++ b/validation-test/compiler_crashers/28333-swift-typedecl-getdeclaredtype.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+protocol c{{}
+func c:f.a
+typealias f:A
+protocol A{typealias f


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Add crash case with stack trace:

```
swift: /path/to/llvm/include/llvm/Support/Casting.h:95: static bool llvm::isa_impl_cl<swift::TypeAliasDecl, const swift::TypeDecl *>::doit(const From *) [To = swift::TypeAliasDecl, From = const swift::TypeDecl *]: Assertion `Val && "isa<> used on a null pointer"' failed.
8  swift           0x00000000010c6972 swift::TypeDecl::getDeclaredType() const + 290
9  swift           0x000000000112329c swift::TypeBase::getMemberSubstitutions(swift::DeclContext const*) + 140
10 swift           0x0000000001123666 swift::TypeBase::getTypeOfMember(swift::ModuleDecl*, swift::Type, swift::DeclContext const*) + 54
12 swift           0x0000000000f1e40e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
14 swift           0x0000000000f1f364 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
15 swift           0x0000000000f1e300 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
20 swift           0x0000000000eb12b6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
21 swift           0x0000000000ed3462 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
22 swift           0x0000000000c613b9 swift::CompilerInstance::performSema() + 3289
24 swift           0x00000000007d86c9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
25 swift           0x00000000007a4708 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28333-swift-typedecl-getdeclaredtype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28333-swift-typedecl-getdeclaredtype-1b3d4b.o
1.  While type-checking 'c' at validation-test/compiler_crashers/28333-swift-typedecl-getdeclaredtype.swift:10:1
2.  While resolving type f.f at [validation-test/compiler_crashers/28333-swift-typedecl-getdeclaredtype.swift:11:8 - line:11:10] RangeText="f.a"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
