### PR TITLE
Disable typo-correction in 3.0 preview 2

### DIFF
--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -525,6 +525,8 @@ void TypeChecker::performTypoCorrection(DeclContext *DC, DeclRefKind refKind,
                                         NameLookupOptions lookupOptions,
                                         LookupResult &result,
                                         unsigned maxResults) {
+  // Temporarily disable.
+#if 0
   // Fill in a collection of the most reasonable entries.
   TopCollection<unsigned, ValueDecl*> entries(maxResults);
   auto consumer = makeDeclConsumer([&](ValueDecl *decl,
@@ -563,6 +565,7 @@ void TypeChecker::performTypoCorrection(DeclContext *DC, DeclRefKind refKind,
 
   for (auto &entry : entries)
     result.add({ entry.Value, nullptr });
+#endif
 }
 
 static InFlightDiagnostic

--- a/test/Parse/foreach.swift
+++ b/test/Parse/foreach.swift
@@ -8,7 +8,7 @@ struct IntRange<Int> : Sequence, IteratorProtocol {
   func makeIterator() -> IntRange<Int> { return self }
 }
 
-func for_each(r: Range<Int>, iir: IntRange<Int>) { // expected-note 2 {{did you mean 'r'?}}
+func for_each(r: Range<Int>, iir: IntRange<Int>) {
   var sum = 0
 
   // Simple foreach loop, using the variable in the body

--- a/test/Parse/implicit_getter_incomplete.swift
+++ b/test/Parse/implicit_getter_incomplete.swift
@@ -12,7 +12,7 @@ func test1() {
 
 // Would trigger assertion when AST verifier checks source ranges ("child source range not contained within its parent")
 func test2() { // expected-note {{match}}
-  var a : Int { // expected-note {{match}} expected-note {{did you mean 'a'?}}
+  var a : Int { // expected-note {{match}}
     switch i { // expected-error {{unresolved identifier}}
 } // expected-error {{'switch' statement body must have at least one}}
 // expected-error 2 {{expected '}'}}

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -17,7 +17,7 @@ func test3() {
   undeclared_func( // expected-error {{use of unresolved identifier 'undeclared_func'}} expected-note {{to match this opening '('}} expected-error {{expected ',' separator}} {{19-19=,}}
 } // expected-error {{expected expression in list of expressions}} expected-error {{expected ')' in expression list}}
 
-func runAction() {} // expected-note {{did you mean 'runAction'?}}
+func runAction() {}
 
 // rdar://16601779
 func foo() {

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -488,9 +488,9 @@ public enum TestB {
 class bar {}
 var baz: bar
 // expected-error@+1{{unnamed parameters must be written with the empty name '_'}}
-func foo1(bar!=baz) {} // expected-note {{did you mean 'foo1'?}}
+func foo1(bar!=baz) {}
 // expected-error@+1{{unnamed parameters must be written with the empty name '_'}}
-func foo2(bar! = baz) {}// expected-note {{did you mean 'foo2'?}}
+func foo2(bar! = baz) {}
 
 // rdar://19605567
 // expected-error@+1{{use of unresolved identifier 'esp'}}
@@ -524,13 +524,13 @@ func a(s: S[{{g) -> Int {}  // expected-note {{to match this opening '('}}
 // expected-error@+3{{expected '(' for initializer parameters}}
 // expected-error@+2{{initializers may only be declared within a type}}
 // expected-error@+1{{expected an identifier to name generic parameter}}
-func F() { init<( } )} // expected-note {{did you mean 'F'?}}
+func F() { init<( } )}
 
 // rdar://20337695
 func f1() {
 
   // expected-error @+6 {{use of unresolved identifier 'C'}}
-  // expected-note @+5 {{did you mean 'n'?}}
+  //
   // expected-error @+4 {{unary operator cannot be separated from its operand}} {{11-12=}}
   // expected-error @+3 {{'==' is not a prefix unary operator}}
   // expected-error @+2 {{consecutive statements on a line must be separated by ';'}} {{8-8=;}}

--- a/test/Parse/switch.swift
+++ b/test/Parse/switch.swift
@@ -273,7 +273,7 @@ func enumElementSyntaxOnTuple() {
 
 // sr-176
 enum Whatever { case Thing }
-func f0(values: [Whatever]) { // expected-note {{did you mean 'values'?}}
+func f0(values: [Whatever]) {
     switch value { // expected-error {{use of unresolved identifier 'value'}}
     case .Thing: // Ok. Don't emit diagnostics about enum case not found in type <<error type>>.
         break

--- a/test/Parse/toplevel_library_invalid.swift
+++ b/test/Parse/toplevel_library_invalid.swift
@@ -1,6 +1,6 @@
 // RUN: %target-parse-verify-swift -parse-as-library
 
-let x = 42 // expected-note{{did you mean 'x'?}}
+let x = 42
 x + x; // expected-error {{expressions are not allowed at the top level}} expected-warning {{result of operator '+' is unused}}
 x + x; // expected-error {{expressions are not allowed at the top level}} expected-warning {{result of operator '+' is unused}}
 // Make sure we don't crash on closures at the top level

--- a/test/Sema/typo_correction.swift
+++ b/test/Sema/typo_correction.swift
@@ -2,7 +2,7 @@
 
 // This is close enough to get typo-correction.
 func test_short_and_close() {
-  let foo = 4 // expected-note {{did you mean 'foo'?}}
+  let foo = 4
   let bab = fob + 1 // expected-error {{use of unresolved identifier}}
 }
 
@@ -18,7 +18,7 @@ func *(x: Whatever, y: Whatever) {}
 // This works even for single-character identifiers.
 func test_very_short() {
   // Note that we don't suggest operators.
-  let x = 0 // expected-note {{did you mean 'x'?}}
+  let x = 0
   let longer = y // expected-error {{use of unresolved identifier 'y'}}
 }
 
@@ -29,21 +29,21 @@ func test_own_initializer() {
 
 // Report candidates that are the same distance in different ways.
 func test_close_matches() {
-  let match1 = 0 // expected-note {{did you mean 'match1'?}}
-  let match22 = 0 // expected-note {{did you mean 'match22'?}}
+  let match1 = 0
+  let match22 = 0
   let x = match2 // expected-error {{use of unresolved identifier 'match2'}}
 }
 
 // Report not-as-good matches if they're still close enough to the best.
 func test_keep_if_not_too_much_worse() {
-  let longmatch1 = 0 // expected-note {{did you mean 'longmatch1'?}}
-  let longmatch22 = 0 // expected-note {{did you mean 'longmatch22'?}}
+  let longmatch1 = 0
+  let longmatch22 = 0
   let x = longmatch // expected-error {{use of unresolved identifier 'longmatch'}}
 }
 
 // Report not-as-good matches if they're still close enough to the best.
 func test_drop_if_too_different() {
-  let longlongmatch1 = 0 // expected-note {{did you mean 'longlongmatch1'?}}
+  let longlongmatch1 = 0
   let longlongmatch2222 = 0
   let x = longlongmatch // expected-error {{use of unresolved identifier 'longlongmatch'}}
 }
@@ -61,8 +61,8 @@ func test_too_many_same() {
 
 // But if some are better than others, just drop the worse tier.
 func test_too_many_but_some_better() {
-  let mtch1 = 0 // expected-note {{did you mean 'mtch1'?}}
-  let mtch2 = 0 // expected-note {{did you mean 'mtch2'?}}
+  let mtch1 = 0
+  let mtch2 = 0
   let match3 = 0
   let match4 = 0
   let match5 = 0

--- a/test/Serialization/top-level-code.swift
+++ b/test/Serialization/top-level-code.swift
@@ -7,7 +7,7 @@
 
 // CHECK-NOT: UnknownCode
 
-let a: Int? = 1 // expected-note {{did you mean 'a'?}}
+let a: Int? = 1
 guard let b = a else {
   fatalError()
 }

--- a/test/SourceKit/Sema/sema_symlink.swift.response
+++ b/test/SourceKit/Sema/sema_symlink.swift.response
@@ -19,15 +19,6 @@
         key.offset: 15,
         key.length: 3
       }
-    ],
-    key.diagnostics: [
-      {
-        key.line: 1,
-        key.column: 16,
-        key.filepath: real.swift,
-        key.severity: source.diagnostic.severity.note,
-        key.description: "did you mean 'Bool'? (Swift.Bool)"
-      }
     ]
   }
 ]

--- a/test/decl/func/dynamic_self.swift
+++ b/test/decl/func/dynamic_self.swift
@@ -65,7 +65,7 @@ class C1 {
 
     if b { return self.init(int: 5) }
 
-    return Self() // expected-error{{use of unresolved identifier 'Self'}} expected-note {{did you mean 'self'?}}
+    return Self() // expected-error{{use of unresolved identifier 'Self'}}
   }
 }
 

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -141,7 +141,7 @@ var test1b = { 42 }
 var test1c = { { 42 } }
 var test1d = { { { 42 } } }
 
-func test2(_ a: Int, b: Int) -> (c: Int) { // expected-error{{cannot create a single-element tuple with an element label}} {{34-37=}} expected-note {{did you mean 'a'?}} expected-note {{did you mean 'b'?}}
+func test2(_ a: Int, b: Int) -> (c: Int) { // expected-error{{cannot create a single-element tuple with an element label}} {{34-37=}}
  _ = a+b
  a+b+c // expected-error{{use of unresolved identifier 'c'}}
  return a+b

--- a/test/expr/unary/selector/property.swift
+++ b/test/expr/unary/selector/property.swift
@@ -173,7 +173,7 @@ class InstanceStaticTestClass {
 
   @objc static func staticMethod() {}
 
-  @objc func instanceMethod() {} // expected-note {{did you mean 'instanceMethod'?}}
+  @objc func instanceMethod() {}
 
   @objc func instanceAndStaticMethod() {}
   @objc class func instanceAndStaticMethod() {}

--- a/test/stmt/if_while_var.swift
+++ b/test/stmt/if_while_var.swift
@@ -36,7 +36,7 @@ if let x = foo() {
 
 if let x = foo() {
   use(x)
-} else if let y = foo() { // expected-note {{did you mean 'y'?}}
+} else if let y = foo() {
   use(x) // expected-error{{unresolved identifier 'x'}}
   use(y)
 } else {
@@ -119,7 +119,7 @@ func testShadowing(_ a: Int?, b: Int?, c: Int?, d: Int?) {
 
 func useInt(_ x: Int) {}
 
-func testWhileScoping(_ a: Int?) {// expected-note {{did you mean 'a'?}}
+func testWhileScoping(_ a: Int?) {
   while let x = a { }
   useInt(x) // expected-error{{use of unresolved identifier 'x'}}
 }

--- a/validation-test/compiler_crashers/28295-swift-namelookup-lookupvisibledeclsinmodule.swift
+++ b/validation-test/compiler_crashers/28295-swift-namelookup-lookupvisibledeclsinmodule.swift
@@ -5,6 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
 struct a{var f={H:{}}}init

--- a/validation-test/compiler_crashers/28297-swift-lookupvisibledecls.swift
+++ b/validation-test/compiler_crashers/28297-swift-lookupvisibledecls.swift
@@ -5,6 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
 {} ?? {let a{p

--- a/validation-test/compiler_crashers/28306-swift-lookupvisibledecls.swift
+++ b/validation-test/compiler_crashers/28306-swift-lookupvisibledecls.swift
@@ -5,7 +5,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
 {
 var:A.a


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

This pull request disables the experimental typo-correction support in Swift 3.0 Preview 2.  We've seen some stability regressions (on invalid code) from this feature that we haven't had time to fully address.

rdar://27059700

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
