### PR TITLE
[SE-0060] Enforcing order of defaulted parameters

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -378,6 +378,10 @@ namespace swift {
     InFlightDiagnostic &fixItRemoveChars(SourceLoc Start, SourceLoc End) {
       return fixItReplaceChars(Start, End, {});
     }
+
+    /// \brief Add two replacement fix-it exchanging source ranges to the
+    /// currently-active diagnostic.
+    InFlightDiagnostic &fixItExchange(SourceRange R1, SourceRange R2);
   };
 
   /// \brief Class to track, map, and remap diagnostic severity and fatality

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -746,10 +746,15 @@ ERROR(wrong_argument_labels,none,
 ERROR(extra_named_single_element_tuple,none,
       "cannot treat single-element named tuple as a scalar; use '.%0' to "
       "access its element", (StringRef))
-ERROR(argument_out_of_order,none,
+ERROR(argument_out_of_order_named_named,none,
       "argument %0 must precede argument %1", (Identifier, Identifier))
 ERROR(argument_out_of_order_named_unnamed,none,
       "argument %0 must precede unnamed parameter #%1", (Identifier, unsigned))
+ERROR(argument_out_of_order_unnamed_named,none,
+      "unnamed parameter #%0 must precede argument %1", (unsigned, Identifier))
+ERROR(argument_out_of_order_unnamed_unnamed,none,
+      "unnamed parameter #%0 must precede unnamed parameter #%1",
+      (unsigned, unsigned))
 
 ERROR(instance_member_use_on_type,none,
       "use of instance member %1 on type %0; "

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -540,19 +540,9 @@ matchCallArguments(ArrayRef<CallArgParam> args,
         continue;
       }
 
-      // The argument binds to a parameter that comes earlier than the
-      // previous argument. This is fine so long as this parameter and all of
-      // those parameters up to (and including) the previously-bound parameter
-      // are either variadic or have a default argument.
-      for (unsigned i = paramIdx; i != prevParamIdx + 1; ++i) {
-        const auto &param = params[i];
-        if (param.Variadic || param.HasDefaultArgument)
-          continue;
-
-        unsigned prevArgIdx = parameterBindings[prevParamIdx].front();
-        listener.outOfOrderArgument(argIdx, prevArgIdx);
-        return true;
-      }
+      unsigned prevArgIdx = parameterBindings[prevParamIdx].front();
+      listener.outOfOrderArgument(argIdx, prevArgIdx);
+      return true;
     }
   }
 

--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceInstance.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceInstance.swift.gyb
@@ -58,8 +58,8 @@ public func checkIterator<
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all
 ) where I.Element == ${Element}, ${Element} : Equatable {
   checkIterator(
-    expected, iterator, ${trace},
-    resiliencyChecks: resiliencyChecks, showFrame: false
+    expected, iterator, ${trace}, showFrame: false,
+    resiliencyChecks: resiliencyChecks
   ) { $0 == $1 }
 }
 
@@ -111,8 +111,8 @@ public func checkSequence<
   S.Iterator.Element : Equatable {
 
   checkSequence(
-    expected, sequence, ${trace},
-    resiliencyChecks: resiliencyChecks, showFrame: false
+    expected, sequence, ${trace}, showFrame: false,
+    resiliencyChecks: resiliencyChecks
   ) { $0 == $1 }
 }
 

--- a/test/1_stdlib/TestAffineTransform.swift
+++ b/test/1_stdlib/TestAffineTransform.swift
@@ -22,7 +22,7 @@ import StdlibUnittest
 class TestAffineTransformSuper { }
 #endif
 
-func expectEqualWithAccuracy(_ lhs: Double, _ rhs: Double, accuracy: Double, file: String = #file, line: UInt = #line, _ message: String = "") {
+func expectEqualWithAccuracy(_ lhs: Double, _ rhs: Double, accuracy: Double, _ message: String = "", file: String = #file, line: UInt = #line) {
     expectTrue(fabs(lhs - rhs) < accuracy, message, file: file, line: line)
 }
 
@@ -37,27 +37,27 @@ class TestAffineTransform : TestAffineTransformSuper {
     
     func checkPointTransformation(_ transform: AffineTransform, point: NSPoint, expectedPoint: NSPoint, _ message: String = "", file: String = #file, line: UInt = #line) {
         let newPoint = transform.transform(point)
-        expectEqualWithAccuracy(Double(newPoint.x), Double(expectedPoint.x), accuracy: accuracyThreshold, file: file, line: line,
-                                   "x (expected: \(expectedPoint.x), was: \(newPoint.x)): \(message)")
-        expectEqualWithAccuracy(Double(newPoint.y), Double(expectedPoint.y), accuracy: accuracyThreshold, file: file, line: line,
-                                   "y (expected: \(expectedPoint.y), was: \(newPoint.y)): \(message)")
+        expectEqualWithAccuracy(Double(newPoint.x), Double(expectedPoint.x), accuracy: accuracyThreshold,
+                                   "x (expected: \(expectedPoint.x), was: \(newPoint.x)): \(message)", file: file, line: line)
+        expectEqualWithAccuracy(Double(newPoint.y), Double(expectedPoint.y), accuracy: accuracyThreshold,
+                                   "y (expected: \(expectedPoint.y), was: \(newPoint.y)): \(message)", file: file, line: line)
     }
     
     func checkSizeTransformation(_ transform: AffineTransform, size: NSSize, expectedSize: NSSize, _ message: String = "", file: String = #file, line: UInt = #line) {
         let newSize = transform.transform(size)
-        expectEqualWithAccuracy(Double(newSize.width), Double(expectedSize.width), accuracy: accuracyThreshold, file: file, line: line,
-                                   "width (expected: \(expectedSize.width), was: \(newSize.width)): \(message)")
-        expectEqualWithAccuracy(Double(newSize.height), Double(expectedSize.height), accuracy: accuracyThreshold, file: file, line: line,
-                                   "height (expected: \(expectedSize.height), was: \(newSize.height)): \(message)")
+        expectEqualWithAccuracy(Double(newSize.width), Double(expectedSize.width), accuracy: accuracyThreshold,
+                                   "width (expected: \(expectedSize.width), was: \(newSize.width)): \(message)", file: file, line: line)
+        expectEqualWithAccuracy(Double(newSize.height), Double(expectedSize.height), accuracy: accuracyThreshold,
+                                   "height (expected: \(expectedSize.height), was: \(newSize.height)): \(message)", file: file, line: line)
     }
     
     func checkRectTransformation(_ transform: AffineTransform, rect: NSRect, expectedRect: NSRect, _ message: String = "", file: String = #file, line: UInt = #line) {
         let newRect = transform.transform(rect)
         
-        checkPointTransformation(transform, point: newRect.origin, expectedPoint: expectedRect.origin, file: file, line: line,
-                                 "origin (expected: \(expectedRect.origin), was: \(newRect.origin)): \(message)")
-        checkSizeTransformation(transform, size: newRect.size, expectedSize: expectedRect.size, file: file, line: line,
-                                "size (expected: \(expectedRect.size), was: \(newRect.size)): \(message)")
+        checkPointTransformation(transform, point: newRect.origin, expectedPoint: expectedRect.origin,
+                                 "origin (expected: \(expectedRect.origin), was: \(newRect.origin)): \(message)", file: file, line: line)
+        checkSizeTransformation(transform, size: newRect.size, expectedSize: expectedRect.size,
+                                "size (expected: \(expectedRect.size), was: \(newRect.size)): \(message)", file: file, line: line)
     }
     
     func test_BasicConstruction() {

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -780,4 +780,4 @@ class SR1594 {
 // FIXME: Bad diagnostic
 func secondArgumentNotLabeled(a:Int, _ b: Int) { }
 secondArgumentNotLabeled(10, 20)
-// expected-error@-1 {{argument '_' must precede unnamed parameter #0}}
+// expected-error@-1 {{unnamed parameter #1 must precede unnamed parameter #0}}

--- a/test/Constraints/function.swift
+++ b/test/Constraints/function.swift
@@ -36,7 +36,7 @@ var s: String = optFunc("hi")
 // <rdar://problem/17652759> Default arguments cause crash with tuple permutation
 func testArgumentShuffle(_ first: Int = 7, third: Int = 9) {
 }
-testArgumentShuffle(third: 1, 2) // expected-error {{argument '_' must precede argument 'third'}} {{none}}
+testArgumentShuffle(third: 1, 2) // expected-error {{unnamed parameter #1 must precede argument 'third'}} {{21-29=2}} {{31-32=third: 1}}
 
 
 

--- a/test/Constraints/function.swift
+++ b/test/Constraints/function.swift
@@ -36,7 +36,7 @@ var s: String = optFunc("hi")
 // <rdar://problem/17652759> Default arguments cause crash with tuple permutation
 func testArgumentShuffle(_ first: Int = 7, third: Int = 9) {
 }
-testArgumentShuffle(third: 1, 2)
+testArgumentShuffle(third: 1, 2) // expected-error {{argument '_' must precede argument 'third'}} {{none}}
 
 
 

--- a/test/Constraints/keyword_arguments.swift
+++ b/test/Constraints/keyword_arguments.swift
@@ -82,7 +82,7 @@ somekeywords1(x: 1, 2, z: 3) // expected-error{{incorrect argument labels in cal
 // -------------------------------------------
 // Out-of-order keywords
 // -------------------------------------------
-allkeywords1(y: 1, x: 2) // expected-error{{argument 'x' must precede argument 'y'}}
+allkeywords1(y: 1, x: 2) // expected-error{{argument 'x' must precede argument 'y'}} {{14-18=x: 2}} {{20-24=y: 1}}
 
 // -------------------------------------------
 // Default arguments
@@ -102,9 +102,9 @@ defargs1(z: 3)
 defargs1(x: 1, z: 3)
 
 // Using defaults (out-of-order, error by SE-0060)
-defargs1(z: 3, y: 2, x: 1) // expected-error{{argument 'y' must precede argument 'z'}}
-defargs1(x: 1, z: 3, y: 2) // expected-error{{argument 'y' must precede argument 'z'}}
-defargs1(y: 2, x: 1) // expected-error{{argument 'x' must precede argument 'y'}}
+defargs1(z: 3, y: 2, x: 1) // expected-error{{argument 'y' must precede argument 'z'}} {{10-14=y: 2}} {{16-20=z: 3}}
+defargs1(x: 1, z: 3, y: 2) // expected-error{{argument 'y' must precede argument 'z'}} {{16-20=y: 2}} {{22-26=z: 3}}
+defargs1(y: 2, x: 1) // expected-error{{argument 'x' must precede argument 'y'}} {{10-14=x: 1}} {{16-20=y: 2}}
 
 // Default arguments "boxed in".
 func defargs2(first: Int, x: Int = 1, y: Int = 2, z: Int = 3, last: Int) { }
@@ -116,12 +116,12 @@ defargs2(first: 1, y: 2, z: 3, last: 4)
 defargs2(first: 1, last: 4)
 
 // Using defaults in the middle (out-of-order, error by SE-0060)
-defargs2(first: 1, z: 3, x: 1, last: 4) // expected-error{{argument 'x' must precede argument 'z'}}
-defargs2(first: 1, z: 3, y: 2, last: 4) // expected-error{{argument 'y' must precede argument 'z'}}
+defargs2(first: 1, z: 3, x: 1, last: 4) // expected-error{{argument 'x' must precede argument 'z'}} {{20-24=x: 1}} {{26-30=z: 3}}
+defargs2(first: 1, z: 3, y: 2, last: 4) // expected-error{{argument 'y' must precede argument 'z'}} {{20-24=y: 2}} {{26-30=z: 3}}
 
 // Using defaults that have moved past a non-defaulted parameter
-defargs2(x: 1, first: 1, last: 4) // expected-error{{argument 'first' must precede argument 'x'}}
-defargs2(first: 1, last: 4, x: 1) // expected-error{{argument 'x' must precede argument 'last'}}
+defargs2(x: 1, first: 1, last: 4) // expected-error{{argument 'first' must precede argument 'x'}} {{10-14=first: 1}} {{16-24=x: 1}}
+defargs2(first: 1, last: 4, x: 1) // expected-error{{argument 'x' must precede argument 'last'}} {{20-27=x: 1}} {{29-33=last: 4}}
 
 // -------------------------------------------
 // Variadics
@@ -135,7 +135,7 @@ variadics1(x: 1, y: 2, 1, 2)
 variadics1(x: 1, y: 2, 1, 2, 3)
 
 // Using various (out-of-order)
-variadics1(1, 2, 3, 4, 5, x: 6, y: 7) // expected-error{{argument 'x' must precede unnamed parameter #0}}
+variadics1(1, 2, 3, 4, 5, x: 6, y: 7) // expected-error{{argument 'x' must precede unnamed parameter #0}} {{12-25=x: 6}} {{27-31=1, 2, 3, 4, 5}}
 
 func variadics2(x: Int, y: Int = 2, z: Int...) { }
 
@@ -150,7 +150,7 @@ variadics2(x: 1)
 
 // Using variadics (out-of-order)
 variadics2(z: 1, 2, 3, y: 2) // expected-error{{missing argument for parameter 'x' in call}}
-variadics2(z: 1, 2, 3, x: 1) // expected-error{{argument 'x' must precede argument 'z'}}
+variadics2(z: 1, 2, 3, x: 1) // expected-error{{argument 'x' must precede argument 'z'}} {{12-22=x: 1}} {{24-28=z: 1, 2, 3}}
 
 func variadics3(_ x: Int..., y: Int = 2, z: Int = 3) { }
 
@@ -173,8 +173,8 @@ variadics3(1)
 variadics3()
 
 // Using variadics (out-of-order)
-variadics3(y: 0, 1, 2, 3) // expected-error{{argument '_' must precede argument 'y'}}
-variadics3(z: 1, 1) // expected-error{{argument '_' must precede argument 'z'}}
+variadics3(y: 0, 1, 2, 3) // expected-error{{unnamed parameter #1 must precede argument 'y'}} {{12-16=1, 2, 3}} {{18-25=y: 0}}
+variadics3(z: 1, 1) // expected-error{{unnamed parameter #1 must precede argument 'z'}} {{12-16=1}} {{18-19=z: 1}}
 
 func variadics4(x: Int..., y: Int = 2, z: Int = 3) { }
 
@@ -198,7 +198,7 @@ variadics4()
 
 // Using variadics (in-order, some missing)
 variadics4(y: 0, x: 1, 2, 3) // expected-error{{extra argument in call}}
-variadics4(z: 1, x: 1) // expected-error{{argument 'x' must precede argument 'z'}}
+variadics4(z: 1, x: 1) // expected-error{{argument 'x' must precede argument 'z'}} {{12-16=x: 1}} {{18-22=z: 1}}
 
 func variadics5(_ x: Int, y: Int, _ z: Int...) { }
 
@@ -209,7 +209,7 @@ variadics5(1, y: 2, 1, 2)
 variadics5(1, y: 2, 1, 2, 3)
 
 // Using various (out-of-order)
-variadics5(1, 2, 3, 4, 5, 6, y: 7) // expected-error{{argument 'y' must precede unnamed parameter #1}}
+variadics5(1, 2, 3, 4, 5, 6, y: 7) // expected-error{{argument 'y' must precede unnamed parameter #1}} {{15-28=y: 7}} {{30-34=2, 3, 4, 5, 6}}
 variadics5(y: 1, 2, 3, 4, 5, 6, 7) // expected-error{{missing argument for parameter #1 in call}}
 
 func variadics6(x: Int..., y: Int = 2, z: Int) { }
@@ -233,7 +233,7 @@ variadics6(x: 1) // expected-error{{missing argument for parameter 'z' in call}}
 variadics6() // expected-error{{missing argument for parameter 'z' in call}}
 
 func outOfOrder(_ a : Int, b: Int) {
-  outOfOrder(b: 42, 52)  // expected-error {{argument '_' must precede argument 'b'}}
+  outOfOrder(b: 42, 52)  // expected-error {{unnamed parameter #1 must precede argument 'b'}} {{14-19=52}} {{21-23=b: 42}}
 }
 
 // -------------------------------------------

--- a/test/Constraints/keyword_arguments.swift
+++ b/test/Constraints/keyword_arguments.swift
@@ -101,10 +101,10 @@ defargs1(y: 2, z: 3)
 defargs1(z: 3)
 defargs1(x: 1, z: 3)
 
-// Using defaults (out-of-order, allowed)
-defargs1(z: 3, y: 2, x: 1)
-defargs1(x: 1, z: 3, y: 2)
-defargs1(y: 2, x: 1)
+// Using defaults (out-of-order, error by SE-0060)
+defargs1(z: 3, y: 2, x: 1) // expected-error{{argument 'y' must precede argument 'z'}}
+defargs1(x: 1, z: 3, y: 2) // expected-error{{argument 'y' must precede argument 'z'}}
+defargs1(y: 2, x: 1) // expected-error{{argument 'x' must precede argument 'y'}}
 
 // Default arguments "boxed in".
 func defargs2(first: Int, x: Int = 1, y: Int = 2, z: Int = 3, last: Int) { }
@@ -115,9 +115,9 @@ defargs2(first: 1, x: 1, last: 4)
 defargs2(first: 1, y: 2, z: 3, last: 4)
 defargs2(first: 1, last: 4)
 
-// Using defaults in the middle (out-of-order, allowed)
-defargs2(first: 1, z: 3, x: 1, last: 4)
-defargs2(first: 1, z: 3, y: 2, last: 4)
+// Using defaults in the middle (out-of-order, error by SE-0060)
+defargs2(first: 1, z: 3, x: 1, last: 4) // expected-error{{argument 'x' must precede argument 'z'}}
+defargs2(first: 1, z: 3, y: 2, last: 4) // expected-error{{argument 'y' must precede argument 'z'}}
 
 // Using defaults that have moved past a non-defaulted parameter
 defargs2(x: 1, first: 1, last: 4) // expected-error{{argument 'first' must precede argument 'x'}}
@@ -173,8 +173,8 @@ variadics3(1)
 variadics3()
 
 // Using variadics (out-of-order)
-variadics3(y: 0, 1, 2, 3) // FIXME: error here
-variadics3(z: 1, 1) // FIXME: error here?
+variadics3(y: 0, 1, 2, 3) // expected-error{{argument '_' must precede argument 'y'}}
+variadics3(z: 1, 1) // expected-error{{argument '_' must precede argument 'z'}}
 
 func variadics4(x: Int..., y: Int = 2, z: Int = 3) { }
 
@@ -198,7 +198,7 @@ variadics4()
 
 // Using variadics (in-order, some missing)
 variadics4(y: 0, x: 1, 2, 3) // expected-error{{extra argument in call}}
-variadics4(z: 1, x: 1) // FIXME: error
+variadics4(z: 1, x: 1) // expected-error{{argument 'x' must precede argument 'z'}}
 
 func variadics5(_ x: Int, y: Int, _ z: Int...) { }
 
@@ -211,6 +211,26 @@ variadics5(1, y: 2, 1, 2, 3)
 // Using various (out-of-order)
 variadics5(1, 2, 3, 4, 5, 6, y: 7) // expected-error{{argument 'y' must precede unnamed parameter #1}}
 variadics5(y: 1, 2, 3, 4, 5, 6, 7) // expected-error{{missing argument for parameter #1 in call}}
+
+func variadics6(x: Int..., y: Int = 2, z: Int) { }
+
+// Using variadics (in-order, complete)
+variadics6(x: 1, 2, 3, y: 0, z: 1)
+variadics6(x: 1, y: 0, z: 1)
+variadics6(y: 0, z: 1)
+
+// Using variadics (in-order, some missing)
+variadics6(x: 1, 2, 3, y: 0) // expected-error{{missing argument for parameter 'z' in call}}
+variadics6(x: 1, z: 1)
+variadics6(z: 1)
+
+variadics6(x: 1, 2, 3, z: 1)
+variadics6(x: 1, z: 1)
+variadics6(z: 1)
+
+variadics6(x: 1, 2, 3) // expected-error{{missing argument for parameter 'z' in call}}
+variadics6(x: 1) // expected-error{{missing argument for parameter 'z' in call}}
+variadics6() // expected-error{{missing argument for parameter 'z' in call}}
 
 func outOfOrder(_ a : Int, b: Int) {
   outOfOrder(b: 42, 52)  // expected-error {{argument '_' must precede argument 'b'}}

--- a/test/Prototypes/Integers.swift.gyb
+++ b/test/Prototypes/Integers.swift.gyb
@@ -1282,8 +1282,8 @@ import StdlibUnittest
 func expectEqual<T : FixedWidthInteger>(
   _ expected: T, _ actual: T,
   _ message: @autoclosure () -> String = "",
-  showFrame: Bool = true,
   stackTrace: SourceLocStack = SourceLocStack(),
+  showFrame: Bool = true,
   file: String = #file, line: UInt = #line
 ) {
   if expected != actual {
@@ -1302,15 +1302,15 @@ func expectEqual<T : FixedWidthInteger>(
 func expectEqual<T : FixedWidthInteger>(
   _ expected: (T, ArithmeticOverflow), _ actual: (T, ArithmeticOverflow),
   _ message: @autoclosure () -> String = "",
-  showFrame: Bool = true,
   stackTrace: SourceLocStack = SourceLocStack(),
+  showFrame: Bool = true,
   file: String = #file, line: UInt = #line
 ) {
 % for i in 0, 1:
   expectEqual(
     expected.${i}, actual.${i}, message(),
-    showFrame: false,
-    stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))
+    stackTrace: stackTrace.pushIf(showFrame, file: file, line: line),
+    showFrame: false)
 % end
 }
 

--- a/test/Prototypes/TextFormatting.swift
+++ b/test/Prototypes/TextFormatting.swift
@@ -349,7 +349,7 @@ xprintln(toPrettyString(424242~>format(radix:16, width:8)))
 // CHECK-NEXT: |   67932|
 
 var zero = "0"
-xprintln(toPrettyString(-434343~>format(width:8, fill:zero)))
+xprintln(toPrettyString(-434343~>format(fill:zero, width:8)))
 // CHECK-NEXT: |-0434343|
 
 xprintln(toPrettyString(-42~>format(radix:13, width:8)))

--- a/test/SILGen/arguments.swift
+++ b/test/SILGen/arguments.swift
@@ -52,7 +52,6 @@ func arg_default_tuple(x x: Int = i, y: Float = f) {}
 arg_default_tuple()
 arg_default_tuple(x:i)
 arg_default_tuple(y:f)
-arg_default_tuple(y:f, x:i)
 arg_default_tuple(x:i, y:f)
 
 

--- a/utils/gyb_stdlib_unittest_support.py
+++ b/utils/gyb_stdlib_unittest_support.py
@@ -8,9 +8,10 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-TRACE = '''_ message: @autoclosure () -> String = "",
-  showFrame: Bool = true,
+TRACE = '''
+  _ message: @autoclosure () -> String = "",
   stackTrace: SourceLocStack = SourceLocStack(),
+  showFrame: Bool = true,
   file: String = #file, line: UInt = #line'''
 
 stackTrace = 'stackTrace.pushIf(showFrame, file: file, line: line)'


### PR DESCRIPTION
#### What's in this pull request?

Implement [[SE-0060] Enforcing order of defaulted parameters](https://github.com/apple/swift-evolution/blob/master/proposals/0060-defaulted-parameter-order.md).

Commit 1,2: Ground work: Eliminate existing out of order arguments in Swift source tree.
Commit 3: Disallow out-of-order arguments regardless of whether they have default arguments.
Commit 4: Add `fixItExchange()` facility in `InFlightDiagnostic`
Commit 5: Improve diagnostics for out-of-order arguments. Added fix-it.

With this PR:

``` swift
func fn(_ x: Int, y: Int, _ z: Int...) { }
fn(1, 2, 3, 4, 5, 6, y: 7)
```

emits a diagnostic:

``` swift
test.swift:2:22: error: argument 'y' must precede unnamed parameter #1
fn(1, 2, 3, 4, 5, 6, y: 7)
      ~~~~~~~~~~~~~  ^~~~
      y: 7           2, 3, 4, 5, 6
```
#### Resolved bug number: ([SR-1489](https://bugs.swift.org/browse/SR-1489))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
