### PR TITLE
[swiftc] Add 💥 case (😢 → 53, 😀 → 5091) triggered in swift::TypeChecker::resolveTypeWitness(…)

### DIFF
--- a/validation-test/compiler_crashers/28334-swift-typechecker-resolvetypewitness.swift
+++ b/validation-test/compiler_crashers/28334-swift-typechecker-resolvetypewitness.swift
@@ -1,0 +1,21 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+{
+enum S<H:A{
+protocol c{
+{
+}
+class A
+class B:A{
+}}
+}
+protocol A{
+typealias e:A
+typealias d


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Add crash case with stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckProtocol.cpp:1811: swift::Substitution getArchetypeSubstitution(swift::TypeChecker &, swift::DeclContext *, swift::ArchetypeType *, swift::Type): Assertion `(archetype != nullptr || isError) && "Should have built archetypes already"' failed.
10 swift           0x0000000000efa15e swift::TypeChecker::resolveTypeWitness(swift::NormalProtocolConformance const*, swift::AssociatedTypeDecl*) + 254
11 swift           0x0000000001112376 swift::NormalProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 150
12 swift           0x00000000011122b8 swift::ProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 40
13 swift           0x0000000001112a86 swift::ProtocolConformance::getTypeWitness(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 6
16 swift           0x0000000001121674 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 36
17 swift           0x000000000111ad74 swift::Type::subst(swift::ModuleDecl*, llvm::DenseMap<swift::TypeBase*, swift::Type, llvm::DenseMapInfo<swift::TypeBase*>, llvm::detail::DenseMapPair<swift::TypeBase*, swift::Type> >&, swift::OptionSet<swift::SubstFlags, unsigned int>) const + 68
18 swift           0x0000000000f414df swift::constraints::Solution::computeSubstitutions(swift::Type, swift::DeclContext*, swift::Type, swift::constraints::ConstraintLocator*, llvm::SmallVectorImpl<swift::Substitution>&) const + 943
21 swift           0x00000000010651f5 swift::Expr::walk(swift::ASTWalker&) + 69
22 swift           0x0000000000f44102 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 514
23 swift           0x0000000000e9f8d1 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 769
27 swift           0x0000000000f60ab9 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 105
28 swift           0x0000000000f6643e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 3998
29 swift           0x0000000000e990d2 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 850
30 swift           0x0000000000e9f832 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
33 swift           0x0000000000f1751d swift::TypeChecker::typeCheckConstructorBodyUntil(swift::ConstructorDecl*, swift::SourceLoc) + 845
34 swift           0x0000000000f16f22 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 34
35 swift           0x0000000000f17af3 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
37 swift           0x0000000000ed3561 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
38 swift           0x0000000000c613b9 swift::CompilerInstance::performSema() + 3289
40 swift           0x00000000007d86c9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
41 swift           0x00000000007a4708 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28334-swift-typechecker-resolvetypewitness.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28334-swift-typechecker-resolvetypewitness-1605d2.o
1.  While type-checking 'init' at validation-test/compiler_crashers/28334-swift-typechecker-resolvetypewitness.swift:16:10
2.  While type-checking expression at [<invalid loc> - <invalid loc>]
3.  While type-checking expression at [<invalid loc> - <invalid loc>]
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
