### PR TITLE
Cleanup mapType{Into,OutOf}Context()

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3212,9 +3212,7 @@ public:
   ClassDecl *getSuperclassDecl() const;
 
   /// Set the superclass of this class.
-  void setSuperclass(Type superclass) {
-    LazySemanticInfo.Superclass.setPointerAndInt(superclass, true);
-  }
+  void setSuperclass(Type superclass);
 
   /// Retrieve the status of circularity checking for class inheritance.
   CircularityCheck getCircularityCheck() const {

--- a/include/swift/AST/ParameterList.h
+++ b/include/swift/AST/ParameterList.h
@@ -142,11 +142,14 @@ public:
   /// null type if one of the ParamDecls does not have a type set for it yet.
   Type getType(const ASTContext &C) const;
   
+  /// Return a TupleType or ParenType for this parameter list written in terms
+  /// of interface types.
+  Type getInterfaceType(DeclContext *DC) const;
+
   /// Return the full function type for a set of curried parameter lists that
-  /// returns the specified result type.  This returns a null type if one of the
-  /// ParamDecls does not have a type set for it yet.
-  ///
-  static Type getFullType(Type resultType, ArrayRef<ParameterList*> PL);
+  /// returns the specified result type written in terms of interface types.
+  static Type getFullInterfaceType(Type resultType, ArrayRef<ParameterList*> PL,
+                                   DeclContext *DC);
   
   
   /// Return the full source range of this parameter.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2622,8 +2622,6 @@ BoundGenericType *BoundGenericType::get(NominalTypeDecl *TheDecl,
   ASTContext &C = TheDecl->getDeclContext()->getASTContext();
   llvm::FoldingSetNodeID ID;
   RecursiveTypeProperties properties;
-  if (Parent)
-    properties |= Parent->getRecursiveProperties();
   BoundGenericType::Profile(ID, TheDecl, Parent, GenericArgs, properties);
 
   auto arena = getArena(properties);
@@ -2657,8 +2655,8 @@ BoundGenericType *BoundGenericType::get(NominalTypeDecl *TheDecl,
   } else {
     auto theEnum = cast<EnumDecl>(TheDecl);
     newType = new (C, arena) BoundGenericEnumType(theEnum, Parent, ArgsCopy,
-                                                   IsCanonical ? &C : 0,
-                                                   properties);
+                                                  IsCanonical ? &C : 0,
+                                                  properties);
   }
   C.Impl.getArena(arena).BoundGenericTypes.InsertNode(newType, InsertPos);
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -843,7 +843,7 @@ void ASTPrinter::printTypeRef(Type T, const TypeDecl *RefTo, Identifier Name) {
     if (GP->isProtocolSelf())
       Context = PrintNameContext::GenericParameter;
   } else if (T && T->is<DynamicSelfType>()) {
-    assert(T->getAs<DynamicSelfType>()->getSelfType()->getAnyNominal() &&
+    assert(T->castTo<DynamicSelfType>()->getSelfType()->getAnyNominal() &&
            "protocol Self handled as GenericTypeParamDecl");
     Context = PrintNameContext::ClassDynamicSelf;
   }

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -2020,13 +2020,7 @@ void ArchetypeBuilder::dump(llvm::raw_ostream &out) {
 
 Type ArchetypeBuilder::mapTypeIntoContext(const DeclContext *dc, Type type,
                                           LazyResolver *resolver) {
-  // If the type is not dependent, there's nothing to map.
-  if (!type->hasTypeParameter())
-    return type;
-
   auto genericParams = dc->getGenericParamsOfContext();
-  assert(genericParams && "Missing generic parameters for dependent context");
-  
   return mapTypeIntoContext(dc->getParentModule(), genericParams, type,
                             resolver);
 }
@@ -2035,13 +2029,15 @@ Type ArchetypeBuilder::mapTypeIntoContext(Module *M,
                                           GenericParamList *genericParams,
                                           Type type,
                                           LazyResolver *resolver) {
-  // If the type is not dependent, or we have no generic params, there's nothing
-  // to map.
-  if (!genericParams || !type->hasTypeParameter())
+  auto canType = type->getCanonicalType();
+  assert(!canType->hasArchetype() && "already have a contextual type");
+  if (!canType->hasTypeParameter())
     return type;
 
+  assert(genericParams && "dependent type in non-generic context");
+
   unsigned genericParamsDepth = genericParams->getDepth();
-  return type.transform([&](Type type) -> Type {
+  type = type.transform([&](Type type) -> Type {
     // Map a generic parameter type to its archetype.
     if (auto gpType = type->getAs<GenericTypeParamType>()) {
       auto index = gpType->getIndex();
@@ -2064,7 +2060,7 @@ Type ArchetypeBuilder::mapTypeIntoContext(Module *M,
       if (!myGenericParams->getAllArchetypes().empty())
         return myGenericParams->getPrimaryArchetypes()[index];
 
-      // During type-checking, we may try to mapTypeInContext before
+      // During type-checking, we may try to mapTypeIntoContext before
       // AllArchetypes has been built, so fall back to the generic params.
       return myGenericParams->getParams()[index]->getArchetype();
     }
@@ -2078,6 +2074,9 @@ Type ArchetypeBuilder::mapTypeIntoContext(Module *M,
 
     return type;
   });
+
+  assert(!type->hasTypeParameter() && "not fully substituted");
+  return type;
 }
 
 Type
@@ -2089,9 +2088,12 @@ ArchetypeBuilder::mapTypeOutOfContext(const DeclContext *dc, Type type) {
 Type ArchetypeBuilder::mapTypeOutOfContext(ModuleDecl *M,
                                            GenericParamList *genericParams,
                                            Type type) {
-  // If the context is non-generic, we're done.
-  if (!genericParams)
+  auto canType = type->getCanonicalType();
+  assert(!canType->hasTypeParameter() && "already have an interface type");
+  if (!canType->hasArchetype())
     return type;
+
+  assert(genericParams && "dependent type in non-generic context");
 
   // Capture the archetype -> interface type mapping.
   TypeSubstitutionMap subs;
@@ -2102,7 +2104,10 @@ Type ArchetypeBuilder::mapTypeOutOfContext(ModuleDecl *M,
     }
   }
 
-  return type.subst(M, subs, SubstFlags::AllowLoweredTypes);
+  type = type.subst(M, subs, SubstFlags::AllowLoweredTypes);
+
+  assert(!type->hasArchetype() && "not fully substituted");
+  return type;
 }
 
 bool ArchetypeBuilder::addGenericSignature(GenericSignature *sig,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3687,21 +3687,28 @@ ParamDecl *ParamDecl::createSelf(SourceLoc loc, DeclContext *DC,
                                  bool isStaticMethod, bool isInOut) {
   ASTContext &C = DC->getASTContext();
   auto selfType = DC->getSelfTypeInContext();
+  auto selfInterfaceType = DC->getSelfInterfaceType();
+
+  assert(!!selfType == !!selfInterfaceType);
 
   // If we have a selfType (i.e. we're not in the parser before we know such
   // things, configure it.
-  if (selfType) {
-    if (isStaticMethod)
+  if (selfType && selfInterfaceType) {
+    if (isStaticMethod) {
       selfType = MetatypeType::get(selfType);
+      selfInterfaceType = MetatypeType::get(selfInterfaceType);
+    }
     
-    if (isInOut)
+    if (isInOut) {
       selfType = InOutType::get(selfType);
+      selfInterfaceType = InOutType::get(selfInterfaceType);
+    }
   }
-    
+
   auto *selfDecl = new (C) ParamDecl(/*IsLet*/!isInOut, SourceLoc(),SourceLoc(),
                                      Identifier(), loc, C.Id_self, selfType,DC);
   selfDecl->setImplicit();
-  selfDecl->setInterfaceType(DC->getSelfInterfaceType());
+  selfDecl->setInterfaceType(selfInterfaceType);
   return selfDecl;
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4762,3 +4762,9 @@ ClassDecl *ClassDecl::getSuperclassDecl() const {
     return superclass->getClassOrBoundGenericClass();
     return nullptr;
 }
+
+void ClassDecl::setSuperclass(Type superclass) {
+  assert((!superclass || !superclass->hasArchetype())
+         && "superclass must be interface type");
+  LazySemanticInfo.Superclass.setPointerAndInt(superclass, true);
+}

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -831,7 +831,7 @@ void swift::lookupVisibleDecls(VisibleDeclConsumer &Consumer,
         DC = DC->getParent();
 
         if (DC->getAsProtocolExtensionContext())
-          ExtendedType = DC->getProtocolSelf()->getArchetype();
+          ExtendedType = DC->getSelfTypeInContext();
 
         if (auto *FD = dyn_cast<FuncDecl>(AFD))
           if (FD->isStatic())

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -716,7 +716,7 @@ public:
     }
 
     // Does it make sense to substitute types?
-    bool shouldSubst = !isa<UnboundGenericType>(BaseTy.getPointer()) &&
+    bool shouldSubst = !BaseTy->hasUnboundGenericType() &&
                        !isa<AnyMetatypeType>(BaseTy.getPointer()) &&
                        !BaseTy->isAnyExistentialType();
     ModuleDecl *M = DC->getParentModule();

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -436,8 +436,7 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
 
         if (AFD->getExtensionType()) {
           if (AFD->getDeclContext()->getAsProtocolOrProtocolExtensionContext()) {
-            ExtendedType = AFD->getDeclContext()->getProtocolSelf()
-                             ->getArchetype();
+            ExtendedType = AFD->getDeclContext()->getSelfTypeInContext();
 
             // Fallback path.
             if (!ExtendedType)
@@ -481,11 +480,7 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
         if (!isCascadingUse.hasValue())
           isCascadingUse = ACE->isCascadingContextForLookup(false);
       } else if (ExtensionDecl *ED = dyn_cast<ExtensionDecl>(DC)) {
-        if (ED->getAsProtocolOrProtocolExtensionContext()) {
-          ExtendedType = ED->getProtocolSelf()->getArchetype();
-        } else {
-          ExtendedType = ED->getExtendedType();
-        }
+        ExtendedType = ED->getSelfTypeInContext();
 
         BaseDecl = ED->getAsNominalTypeOrNominalTypeExtensionContext();
         MetaBaseDecl = BaseDecl;

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -296,8 +296,7 @@ ArrayRef<Type> TypeBase::getAllGenericArgs(SmallVectorImpl<Type> &scratch) {
     if (auto protoType = type->getAs<ProtocolType>()) {
       auto proto = protoType->getDecl();
       allGenericArgs.push_back(
-        llvm::makeArrayRef(
-          proto->getProtocolSelf()->getDeclaredInterfaceType()));
+        llvm::makeArrayRef(proto->getSelfInterfaceType()));
 
       // Continue up to the parent.
       type = protoType->getParent();
@@ -2606,8 +2605,8 @@ ArchetypeType::NestedType ArchetypeType::getNestedType(Identifier Name) const {
           conformanceType = metatypeType->getInstanceType().getPointer();
           
           if (auto protocolType = dyn_cast<ProtocolType>(conformanceType)) {
-            conformanceType = protocolType->getDecl()->getProtocolSelf()
-                                ->getArchetype();
+            conformanceType = protocolType->getDecl()
+                                          ->getSelfTypeInContext().getPointer();
           }
         }
         
@@ -2965,8 +2964,9 @@ TypeSubstitutionMap TypeBase::getMemberSubstitutions(const DeclContext *dc) {
   if (dc->getAsProtocolOrProtocolExtensionContext()) {
     // FIXME: This feels painfully inefficient. We're creating a dense map
     // for a single substitution.
-    substitutions[dc->getProtocolSelf()->getDeclaredType()
-                    ->getCanonicalType()->castTo<GenericTypeParamType>()]
+    substitutions[dc->getSelfInterfaceType()
+                    ->getCanonicalType()
+                    ->castTo<GenericTypeParamType>()]
       = baseTy;
     return substitutions;
   }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3644,12 +3644,7 @@ namespace {
       auto selfVar =
         ParamDecl::createSelf(SourceLoc(), dc, /*isStatic*/!isInstance);
       bodyParams.push_back(ParameterList::createWithoutLoc(selfVar));
-      Type selfContextType;
-      if (dc->getAsProtocolOrProtocolExtensionContext()) {
-        selfContextType = dc->getProtocolSelf()->getArchetype();
-      } else {
-        selfContextType = dc->getDeclaredTypeInContext();
-      }
+      Type selfContextType = dc->getSelfTypeInContext();
       if (!isInstance) {
         selfContextType = MetatypeType::get(selfContextType);
       }
@@ -4333,8 +4328,7 @@ namespace {
 
       // Figure out the curried 'self' type for the interface type. It's always
       // either the generic parameter type 'Self' or a metatype thereof.
-      auto selfDecl = dc->getProtocolSelf();
-      auto selfTy = selfDecl->getDeclaredType();
+      auto selfTy = dc->getSelfInterfaceType();
       auto interfaceInputTy = selfTy;
       auto inputTy = fnType->getInput();
       if (auto tupleTy = inputTy->getAs<TupleType>()) {
@@ -4344,7 +4338,7 @@ namespace {
       if (inputTy->is<MetatypeType>())
         interfaceInputTy = MetatypeType::get(interfaceInputTy);
 
-      auto selfArchetype = selfDecl->getArchetype();
+      auto selfArchetype = dc->getSelfTypeInContext();
       auto interfaceResultTy = fnType->getResult().transform(
         [&](Type type) -> Type {
           if (type->is<DynamicSelfType>() || type->isEqual(selfArchetype)) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5740,6 +5740,8 @@ namespace {
                                          isInSystemModule(dc),
                                          /*isFullyBridgeable*/false);
         if (superclassType) {
+          superclassType =
+              ArchetypeBuilder::mapTypeOutOfContext(result, superclassType);
           assert(superclassType->is<ClassType>() ||
                  superclassType->is<BoundGenericClassType>());
           inheritedTypes.push_back(TypeLoc::withoutLoc(superclassType));

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -347,7 +347,7 @@ makeEnumRawValueConstructor(ClangImporter::Implementation &Impl,
   auto enumTy = enumDecl->getDeclaredTypeInContext();
   auto metaTy = MetatypeType::get(enumTy);
   
-  auto selfDecl = ParamDecl::createUnboundSelf(SourceLoc(), enumDecl,
+  auto selfDecl = ParamDecl::createSelf(SourceLoc(), enumDecl,
                                         /*static*/false, /*inout*/true);
 
   auto param = new (C) ParamDecl(/*let*/ true, SourceLoc(),
@@ -413,7 +413,7 @@ static FuncDecl *makeEnumRawValueGetter(ClangImporter::Implementation &Impl,
                                         VarDecl *rawValueDecl) {
   ASTContext &C = Impl.SwiftContext;
   
-  auto selfDecl = ParamDecl::createUnboundSelf(SourceLoc(), enumDecl);
+  auto selfDecl = ParamDecl::createSelf(SourceLoc(), enumDecl);
   
   ParameterList *params[] = {
     ParameterList::createWithoutLoc(selfDecl),
@@ -428,8 +428,8 @@ static FuncDecl *makeEnumRawValueGetter(ClangImporter::Implementation &Impl,
                      /*GenericParams=*/nullptr, params, Type(),
                      TypeLoc::withoutLoc(enumDecl->getRawType()), enumDecl);
   getterDecl->setImplicit();
-  getterDecl->setType(ParameterList::getFullType(enumDecl->getRawType(),
-                                                 params));
+  getterDecl->setType(ParameterList::getFullInterfaceType(enumDecl->getRawType(),
+                                                          params, enumDecl));
   getterDecl->setBodyResultType(enumDecl->getRawType());
   getterDecl->setAccessibility(Accessibility::Public);
 
@@ -470,7 +470,7 @@ static FuncDecl *makeNewtypeBridgedRawValueGetter(
                    VarDecl *storedVar) {
   ASTContext &C = Impl.SwiftContext;
   
-  auto selfDecl = ParamDecl::createUnboundSelf(SourceLoc(), structDecl);
+  auto selfDecl = ParamDecl::createSelf(SourceLoc(), structDecl);
   
   ParameterList *params[] = {
     ParameterList::createWithoutLoc(selfDecl),
@@ -488,7 +488,8 @@ static FuncDecl *makeNewtypeBridgedRawValueGetter(
                      params, Type(),
                      TypeLoc::withoutLoc(computedType), structDecl);
   getterDecl->setImplicit();
-  getterDecl->setType(ParameterList::getFullType(computedType, params));
+  getterDecl->setType(ParameterList::getFullInterfaceType(computedType, params,
+                                                          structDecl));
   getterDecl->setBodyResultType(computedType);
   getterDecl->setAccessibility(Accessibility::Public);
 
@@ -517,7 +518,7 @@ static FuncDecl *makeFieldGetterDecl(ClangImporter::Implementation &Impl,
                                      VarDecl *importedFieldDecl,
                                      ClangNode clangNode = ClangNode()) {
   auto &C = Impl.SwiftContext;
-  auto selfDecl = ParamDecl::createUnboundSelf(SourceLoc(), importedDecl);
+  auto selfDecl = ParamDecl::createSelf(SourceLoc(), importedDecl);
 
   ParameterList *params[] = {
     ParameterList::createWithoutLoc(selfDecl),
@@ -534,7 +535,8 @@ static FuncDecl *makeFieldGetterDecl(ClangImporter::Implementation &Impl,
                      /*GenericParams=*/nullptr, params, Type(),
                      TypeLoc::withoutLoc(getterType), importedDecl, clangNode);
   getterDecl->setAccessibility(Accessibility::Public);
-  getterDecl->setType(ParameterList::getFullType(getterType, params));
+  getterDecl->setType(ParameterList::getFullInterfaceType(getterType, params,
+                                                          importedDecl));
   getterDecl->setBodyResultType(getterType);
 
   return getterDecl;
@@ -545,7 +547,7 @@ static FuncDecl *makeFieldSetterDecl(ClangImporter::Implementation &Impl,
                                      VarDecl *importedFieldDecl,
                                      ClangNode clangNode = ClangNode()) {
   auto &C = Impl.SwiftContext;
-  auto selfDecl = ParamDecl::createUnboundSelf(SourceLoc(), importedDecl,
+  auto selfDecl = ParamDecl::createSelf(SourceLoc(), importedDecl,
                                         /*isStatic*/false, /*isInOut*/true);
   auto newValueDecl = new (C) ParamDecl(/*isLet */ true,SourceLoc(),SourceLoc(),
                                         Identifier(), SourceLoc(), C.Id_value,
@@ -567,7 +569,8 @@ static FuncDecl *makeFieldSetterDecl(ClangImporter::Implementation &Impl,
                      /*GenericParams=*/nullptr, params, Type(),
                      TypeLoc::withoutLoc(voidTy), importedDecl, clangNode);
 
-  setterDecl->setType(ParameterList::getFullType(voidTy, params));
+  setterDecl->setType(ParameterList::getFullInterfaceType(voidTy, params,
+                                                          importedDecl));
   setterDecl->setBodyResultType(voidTy);
   setterDecl->setAccessibility(Accessibility::Public);
   setterDecl->setMutating();
@@ -946,9 +949,10 @@ static bool addErrorDomain(NominalTypeDecl *swiftDecl,
       DeclRefExpr(ConcreteDeclRef(swiftValueDecl), {}, isImplicit);
   ParameterList *params[] = {
       ParameterList::createWithoutLoc(
-          ParamDecl::createUnboundSelf(SourceLoc(), swiftDecl, isStatic)),
+          ParamDecl::createSelf(SourceLoc(), swiftDecl, isStatic)),
       ParameterList::createEmpty(C)};
-  auto toStringTy = ParameterList::getFullType(stringTy, params);
+  auto toStringTy = ParameterList::getFullInterfaceType(stringTy, params,
+                                                        swiftDecl);
 
   FuncDecl *getterDecl =
     FuncDecl::create(C, /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
@@ -1666,7 +1670,7 @@ namespace {
       auto &context = Impl.SwiftContext;
       
       // Create the 'self' declaration.
-      auto selfDecl = ParamDecl::createUnboundSelf(SourceLoc(), structDecl,
+      auto selfDecl = ParamDecl::createSelf(SourceLoc(), structDecl,
                                             /*static*/false, /*inout*/true);
       
       // self & param.
@@ -1907,7 +1911,7 @@ namespace {
       auto &context = Impl.SwiftContext;
 
       // Create the 'self' declaration.
-      auto selfDecl = ParamDecl::createUnboundSelf(SourceLoc(), structDecl,
+      auto selfDecl = ParamDecl::createSelf(SourceLoc(), structDecl,
                                             /*static*/false, /*inout*/true);
 
       // Construct the set of parameters from the list of members.
@@ -2799,9 +2803,9 @@ namespace {
     }
 
     ParameterList *getNonSelfParamList(
-        const clang::FunctionDecl *decl, Optional<unsigned> selfIdx,
-        ArrayRef<Identifier> argNames, bool allowNSUIntegerAsInt,
-        bool isAccessor) {
+        DeclContext *dc, const clang::FunctionDecl *decl,
+        Optional<unsigned> selfIdx, ArrayRef<Identifier> argNames,
+        bool allowNSUIntegerAsInt, bool isAccessor) {
       if (bool(selfIdx)) {
         assert(((decl->getNumParams() == argNames.size() + 1) || isAccessor) &&
                (*selfIdx < decl->getNumParams()) && "where's self?");
@@ -2815,7 +2819,7 @@ namespace {
           continue;
         nonSelfParams.push_back(decl->getParamDecl(i));
       }
-      return Impl.importFunctionParameterList(decl, nonSelfParams,
+      return Impl.importFunctionParameterList(dc, decl, nonSelfParams,
                                               decl->isVariadic(),
                                               allowNSUIntegerAsInt, argNames);
     }
@@ -2852,20 +2856,20 @@ namespace {
                 argNames.front(), Impl.SwiftContext.TheEmptyTupleType, dc));
       } else {
         parameterList = Impl.importFunctionParameterList(
-            decl, {decl->param_begin(), decl->param_end()}, decl->isVariadic(),
-            allowNSUIntegerAsInt, argNames);
+            dc, decl, {decl->param_begin(), decl->param_end()},
+            decl->isVariadic(), allowNSUIntegerAsInt, argNames);
       }
       if (!parameterList)
         return nullptr;
 
       bool selfIsInOut =
-          !dc->getDeclaredTypeOfContext()->hasReferenceSemantics();
-      auto selfParam = ParamDecl::createUnboundSelf(SourceLoc(), dc, /*static=*/false,
+          !dc->getDeclaredInterfaceType()->hasReferenceSemantics();
+      auto selfParam = ParamDecl::createSelf(SourceLoc(), dc, /*static=*/false,
                                              /*inout=*/selfIsInOut);
 
       OptionalTypeKind initOptionality;
       auto resultType = Impl.importFunctionReturnType(
-          decl, decl->getReturnType(), allowNSUIntegerAsInt);
+          dc, decl, decl->getReturnType(), allowNSUIntegerAsInt);
       (void)resultType->getAnyOptionalObjectType(initOptionality);
 
       auto result = Impl.createDeclWithClangNode<ConstructorDecl>(
@@ -2927,14 +2931,15 @@ namespace {
       }
 
       bodyParams.push_back(ParameterList::createWithoutLoc(
-          ParamDecl::createUnboundSelf(SourceLoc(), dc, !selfIdx.hasValue(),
+          ParamDecl::createSelf(SourceLoc(), dc, !selfIdx.hasValue(),
                                 selfIsInOut)));
       bodyParams.push_back(getNonSelfParamList(
-          decl, selfIdx, name.getArgumentNames(), allowNSUIntegerAsInt, !name));
+          dc, decl, selfIdx, name.getArgumentNames(), allowNSUIntegerAsInt, !name));
 
       auto swiftResultTy = Impl.importFunctionReturnType(
-          decl, decl->getReturnType(), allowNSUIntegerAsInt);
-      auto fnType = ParameterList::getFullType(swiftResultTy, bodyParams);
+          dc, decl, decl->getReturnType(), allowNSUIntegerAsInt);
+      auto fnType = ParameterList::getFullInterfaceType(swiftResultTy, bodyParams,
+                                                        dc);
 
       auto loc = Impl.importSourceLoc(decl->getLocation());
       auto nameLoc = Impl.importSourceLoc(decl->getLocation());
@@ -2949,7 +2954,7 @@ namespace {
       if (auto proto = dc->getAsProtocolOrProtocolExtensionContext()) {
         Type interfaceType;
         std::tie(fnType, interfaceType) =
-            getProtocolMethodType(proto, fnType->castTo<AnyFunctionType>());
+            getGenericMethodType(proto, fnType->castTo<AnyFunctionType>());
         result->setType(fnType);
         result->setInterfaceType(interfaceType);
         result->setGenericSignature(proto->getGenericSignature());
@@ -3214,7 +3219,8 @@ namespace {
       // Import the function type. If we have parameters, make sure their names
       // get into the resulting function type.
       ParameterList *bodyParams = nullptr;
-      Type type = Impl.importFunctionType(decl,
+      Type type = Impl.importFunctionType(dc,
+                                          decl,
                                           decl->getReturnType(),
                                           { decl->param_begin(),
                                             decl->param_size() },
@@ -3644,9 +3650,9 @@ namespace {
       auto selfVar =
         ParamDecl::createSelf(SourceLoc(), dc, /*isStatic*/!isInstance);
       bodyParams.push_back(ParameterList::createWithoutLoc(selfVar));
-      Type selfContextType = dc->getSelfTypeInContext();
+      Type selfInterfaceType = dc->getSelfInterfaceType();
       if (!isInstance) {
-        selfContextType = MetatypeType::get(selfContextType);
+        selfInterfaceType = MetatypeType::get(selfInterfaceType);
       }
 
       SpecialMethodKind kind = SpecialMethodKind::Regular;
@@ -3704,7 +3710,7 @@ namespace {
       // in Swift as DynamicSelf, do so.
       if (decl->hasRelatedResultType()) {
         result->setDynamicSelf(true);
-        resultTy = result->getDynamicSelf();
+        resultTy = result->getDynamicSelfInterface();
         assert(resultTy && "failed to get dynamic self");
 
         Type dynamicSelfTy = result->getDynamicSelfInterface();
@@ -3723,23 +3729,14 @@ namespace {
         auto methodTy = type->castTo<FunctionType>();
         type = FunctionType::get(methodTy->getInput(), resultTy, 
                                  methodTy->getExtInfo());
-
-        // Create the interface type of the method.
-        interfaceType = FunctionType::get(methodTy->getInput(), dynamicSelfTy,
-                                          methodTy->getExtInfo());
-        interfaceType = FunctionType::get(selfVar->getType(), interfaceType);
       }
 
       // Add the 'self' parameter to the function type.
-      type = FunctionType::get(selfContextType, type);
+      type = FunctionType::get(selfInterfaceType, type);
 
-      if (auto proto = dyn_cast<ProtocolDecl>(dc)) {
-        std::tie(type, interfaceType)
-          = getProtocolMethodType(proto, type->castTo<AnyFunctionType>());
-      } else if (dc->isGenericContext()) {
+      if (dc->isGenericContext()) {
         std::tie(type, interfaceType)
           = getGenericMethodType(dc, type->castTo<AnyFunctionType>());
-        selfVar->overwriteType(type->castTo<AnyFunctionType>()->getInput());
       }
 
       result->setBodyResultType(resultTy);
@@ -3915,9 +3912,9 @@ namespace {
       }
 
       bool redundant;
-      auto result =  importConstructor(objcMethod, dc, implicit, kind, required,
-                                       selector, importedName, params,
-                                       variadic, redundant);
+      auto result = importConstructor(objcMethod, dc, implicit, kind, required,
+                                      selector, importedName, params,
+                                      variadic, redundant);
 
       // If this is a Swift 2 stub, mark it as such.
       if (result && swift3Name)
@@ -4039,13 +4036,12 @@ namespace {
       redundant = false;
 
       // Figure out the type of the container.
-      auto containerTy = dc->getDeclaredTypeInContext();
-      assert(containerTy && "Method in non-type context?");
-      auto nominalOwner = containerTy->getAnyNominal();
+      auto ownerNominal = dc->getAsNominalTypeOrNominalTypeExtensionContext();
+      assert(ownerNominal && "Method in non-type context?");
 
       // Find the interface, if we can.
       const clang::ObjCInterfaceDecl *interface = nullptr;
-      if (auto classDecl = containerTy->getClassOrBoundGenericClass()) {
+      if (auto classDecl = dyn_cast<ClassDecl>(ownerNominal)) {
         interface = dyn_cast_or_null<clang::ObjCInterfaceDecl>(
                       classDecl->getClangDecl());
       }
@@ -4074,8 +4070,8 @@ namespace {
 
       // Add the implicit 'self' parameter patterns.
       SmallVector<ParameterList*, 4> bodyParams;
-      auto selfMetaVar = ParamDecl::createUnboundSelf(SourceLoc(), dc, /*static*/true);
-      auto selfTy = dc->getDeclaredTypeInContext();
+      auto selfMetaVar = ParamDecl::createSelf(SourceLoc(), dc, /*static*/true);
+      auto selfTy = dc->getSelfInterfaceType();
       auto selfMetaTy = MetatypeType::get(selfTy);
       bodyParams.push_back(ParameterList::createWithoutLoc(selfMetaVar));
 
@@ -4119,7 +4115,7 @@ namespace {
       // the same name.
       Type allocParamType = allocType->castTo<AnyFunctionType>()->getResult()
                               ->castTo<AnyFunctionType>()->getInput();
-      for (auto other : nominalOwner->lookupDirect(name)) {
+      for (auto other : ownerNominal->lookupDirect(name)) {
         auto ctor = dyn_cast<ConstructorDecl>(other);
         if (!ctor || ctor->isInvalid() ||
             ctor->getAttrs().isUnavailable(Impl.SwiftContext) ||
@@ -4192,7 +4188,7 @@ namespace {
       if (known != Impl.Constructors.end())
         return known->second;
 
-      auto *selfVar = ParamDecl::createUnboundSelf(SourceLoc(), dc);
+      auto *selfVar = ParamDecl::createSelf(SourceLoc(), dc);
 
       // Create the actual constructor.
       auto result = Impl.createDeclWithClangNode<ConstructorDecl>(objcMethod,
@@ -4206,23 +4202,12 @@ namespace {
 
       // Make the constructor declaration immediately visible in its
       // class or protocol type.
-      nominalOwner->makeMemberVisible(result);
+      ownerNominal->makeMemberVisible(result);
 
       addObjCAttribute(result, selector);
 
-      // Fix the types when we've imported into a protocol.
-      if (auto proto = dyn_cast<ProtocolDecl>(dc)) {
-        Type interfaceAllocType;
-        Type interfaceInitType;
-        std::tie(allocType, interfaceAllocType)
-          = getProtocolMethodType(proto, allocType->castTo<AnyFunctionType>());
-        std::tie(initType, interfaceInitType)
-          = getProtocolMethodType(proto, initType->castTo<AnyFunctionType>());
-
-        result->setInitializerInterfaceType(interfaceInitType);
-        result->setInterfaceType(interfaceAllocType);
-        result->setGenericSignature(dc->getGenericSignatureOfContext());
-      } else if (dc->isGenericContext()) {
+      // Calculate the function type of the result.
+      if (dc->isGenericContext()) {
         Type interfaceAllocType;
         Type interfaceInitType;
         std::tie(allocType, interfaceAllocType)
@@ -4233,7 +4218,6 @@ namespace {
         result->setInitializerInterfaceType(interfaceInitType);
         result->setInterfaceType(interfaceAllocType);
         result->setGenericSignature(dc->getGenericSignatureOfContext());
-        selfVar->overwriteType(initType->castTo<AnyFunctionType>()->getInput());
       }
 
       result->setType(allocType);
@@ -4317,61 +4301,22 @@ namespace {
       return cast<NamedPattern>(pattern)->getDecl();
     }
 
-    /// Retrieves the type and interface type for a protocol or
-    /// protocol extension method given the computed type of that
-    /// method.
-    std::pair<Type, Type> getProtocolMethodType(DeclContext *dc,
-                                                AnyFunctionType *fnType) {
-      Type type = PolymorphicFunctionType::get(fnType->getInput(),
-                                               fnType->getResult(),
-                                               dc->getGenericParamsOfContext());
-
-      // Figure out the curried 'self' type for the interface type. It's always
-      // either the generic parameter type 'Self' or a metatype thereof.
-      auto selfTy = dc->getSelfInterfaceType();
-      auto interfaceInputTy = selfTy;
-      auto inputTy = fnType->getInput();
-      if (auto tupleTy = inputTy->getAs<TupleType>()) {
-        if (tupleTy->getNumElements() == 1)
-          inputTy = tupleTy->getElementType(0);
-      }
-      if (inputTy->is<MetatypeType>())
-        interfaceInputTy = MetatypeType::get(interfaceInputTy);
-
-      auto selfArchetype = dc->getSelfTypeInContext();
-      auto interfaceResultTy = fnType->getResult().transform(
-        [&](Type type) -> Type {
-          if (type->is<DynamicSelfType>() || type->isEqual(selfArchetype)) {
-            return DynamicSelfType::get(selfTy, Impl.SwiftContext);
-          }
-
-          return type;
-        });
-
-      Type interfaceType = GenericFunctionType::get(
-                             dc->getGenericSignatureOfContext(),
-                             interfaceInputTy,
-                             interfaceResultTy,
-                             AnyFunctionType::ExtInfo());
-      return { type, interfaceType };
-    }
-
-    /// Retrieves the type and interface type for a generic class or class
-    /// extension method, given the computed type of that method.
     std::pair<Type, Type> getGenericMethodType(DeclContext *dc,
                                                AnyFunctionType *fnType) {
-      Type inputType = fnType->getInput();
-      Type interfaceInputType =
-        ArchetypeBuilder::mapTypeOutOfContext(dc, inputType);
-      Type resultType = fnType->getResult();
-      Type interfaceResultType =
-        ArchetypeBuilder::mapTypeOutOfContext(dc, resultType);
+      assert(!fnType->hasArchetype());
 
-      Type interfaceType = GenericFunctionType::get(
-          dc->getGenericSignatureOfContext(), interfaceInputType,
-          interfaceResultType, AnyFunctionType::ExtInfo());
+      Type inputType = ArchetypeBuilder::mapTypeIntoContext(
+          dc, fnType->getInput());
+      Type resultType = ArchetypeBuilder::mapTypeIntoContext(
+          dc, fnType->getResult());
       Type type = PolymorphicFunctionType::get(inputType, resultType,
                                                dc->getGenericParamsOfContext());
+
+      Type interfaceType = GenericFunctionType::get(
+          dc->getGenericSignatureOfContext(),
+          fnType->getInput(), fnType->getResult(),
+          AnyFunctionType::ExtInfo());
+
       return { type, interfaceType };
     }
 
@@ -4389,18 +4334,13 @@ namespace {
       };
 
       // Form the type of the getter.
-      auto getterType = ParameterList::getFullType(elementTy, getterArgs);
+      auto getterType =
+          ParameterList::getFullInterfaceType(elementTy, getterArgs, dc);
 
-      // If we're in a protocol, the getter thunk will be polymorphic.
       Type interfaceType;
-      if (dc->getAsProtocolOrProtocolExtensionContext()) {
-        std::tie(getterType, interfaceType)
-          = getProtocolMethodType(dc, getterType->castTo<AnyFunctionType>());
-      } else if (dc->isGenericContext()) {
+      if (dc->isGenericContext()) {
         std::tie(getterType, interfaceType)
           = getGenericMethodType(dc, getterType->castTo<AnyFunctionType>());
-        getterArgs[0]->get(0)->overwriteType(
-            getterType->castTo<AnyFunctionType>()->getInput());
       }
 
       // Create the getter thunk.
@@ -4426,7 +4366,7 @@ namespace {
     }
 
       /// Build a declaration for an Objective-C subscript setter.
-    FuncDecl *buildSubscriptSetterDecl(const FuncDecl *setter, Type elementTy,
+    FuncDecl *buildSubscriptSetterDecl(const FuncDecl *setter, Type elementInterfaceTy,
                                        DeclContext *dc, ParamDecl *index) {
       auto &C = Impl.SwiftContext;
       auto loc = setter->getLoc();
@@ -4442,13 +4382,15 @@ namespace {
 
       // 'self'
       auto selfDecl = ParamDecl::createSelf(SourceLoc(), dc);
+      auto elementTy = ArchetypeBuilder::mapTypeIntoContext(
+          dc, elementInterfaceTy);
 
       auto paramVarDecl = new (C) ParamDecl(/*isLet=*/false, SourceLoc(),
                                             SourceLoc(), Identifier(),loc,
                                             valueIndex->get(0)->getName(),
                                             elementTy, dc);
-      
-      
+      paramVarDecl->setInterfaceType(elementInterfaceTy);
+
       auto valueIndicesPL = ParameterList::create(C, {
         paramVarDecl,
         index
@@ -4461,20 +4403,15 @@ namespace {
       };
       
       // Form the type of the setter.
-      Type setterType = ParameterList::getFullType(TupleType::getEmpty(C),
-                                                   setterArgs);
+      Type setterType =
+          ParameterList::getFullInterfaceType(TupleType::getEmpty(C),
+                                              setterArgs,
+                                              dc);
 
-      // If we're in a protocol or extension thereof, the setter thunk
-      // will be polymorphic.
       Type interfaceType;
-      if (dc->getAsProtocolOrProtocolExtensionContext()) {
-        std::tie(setterType, interfaceType)
-          = getProtocolMethodType(dc, setterType->castTo<AnyFunctionType>());
-      } else if (dc->isGenericContext()) {
+      if (dc->isGenericContext()) {
         std::tie(setterType, interfaceType)
           = getGenericMethodType(dc, setterType->castTo<AnyFunctionType>());
-        selfDecl->overwriteType(
-            setterType->castTo<AnyFunctionType>()->getInput());
       }
 
       // Create the setter thunk.
@@ -6941,7 +6878,7 @@ ClangImporter::Implementation::createConstant(Identifier name, DeclContext *dc,
   
   // 'self'
   if (dc->isTypeContext()) {
-    auto *selfDecl = ParamDecl::createUnboundSelf(SourceLoc(), dc, isStatic);
+    auto *selfDecl = ParamDecl::createSelf(SourceLoc(), dc, isStatic);
     getterArgs.push_back(ParameterList::createWithoutLoc(selfDecl));
   }
   
@@ -6949,7 +6886,7 @@ ClangImporter::Implementation::createConstant(Identifier name, DeclContext *dc,
   getterArgs.push_back(ParameterList::createEmpty(C));
 
   // Form the type of the getter.
-  auto getterType = ParameterList::getFullType(type, getterArgs);
+  auto getterType = ParameterList::getFullInterfaceType(type, getterArgs, dc);
 
   // Create the getter function declaration.
   auto func =

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1238,7 +1238,8 @@ public:
   ///
   /// \returns the imported function type, or null if the type cannot be
   /// imported.
-  Type importFunctionType(const clang::FunctionDecl *clangDecl,
+  Type importFunctionType(DeclContext *dc,
+                          const clang::FunctionDecl *clangDecl,
                           clang::QualType resultType,
                           ArrayRef<const clang::ParmVarDecl *> params,
                           bool isVariadic, bool isNoReturn,
@@ -1257,7 +1258,8 @@ public:
   ///
   /// \returns the imported function return type, or null if the type cannot be
   /// imported.
-  Type importFunctionReturnType(const clang::FunctionDecl *clangDecl,
+  Type importFunctionReturnType(DeclContext *dc,
+                                const clang::FunctionDecl *clangDecl,
                                 clang::QualType resultType,
                                 bool allowNSUIntegerAsInt);
 
@@ -1273,7 +1275,8 @@ public:
   ///
   /// \returns The imported parameter list on success, or null on failure
   ParameterList *
-  importFunctionParameterList(const clang::FunctionDecl *clangDecl,
+  importFunctionParameterList(DeclContext *dc,
+                              const clang::FunctionDecl *clangDecl,
                               ArrayRef<const clang::ParmVarDecl *> params,
                               bool isVariadic, bool allowNSUIntegerAsInt,
                               ArrayRef<Identifier> argNames);

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -1817,6 +1817,8 @@ static Type replaceDynamicSelfWithSelf(Type t) {
 
 /// Replace any DynamicSelf types with their underlying Self type.
 static CanType replaceDynamicSelfWithSelf(CanType t) {
+  if (!t->hasDynamicSelfType())
+    return t;
   return replaceDynamicSelfWithSelf(Type(t))->getCanonicalType();
 }
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -89,7 +89,7 @@ static Type getExistentialArchetype(SILValue existential) {
   CanType ty = existential->getType().getSwiftRValueType();
   if (ty->is<ArchetypeType>())
     return ty;
-  return cast<ProtocolType>(ty)->getDecl()->getProtocolSelf()->getArchetype();
+  return cast<ProtocolType>(ty)->getDecl()->getSelfTypeInContext();
 }
 
 /// Retrieve the type to use for a method found via dynamic lookup.

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1839,7 +1839,7 @@ SILGenModule::emitProtocolWitness(ProtocolConformance *conformance,
     // For default implementations, Self is the protocol archetype.
     } else {
       auto *proto = cast<ProtocolDecl>(requirement.getDecl()->getDeclContext());
-      selfType = proto->getProtocolSelf()->getArchetype();
+      selfType = proto->getSelfTypeInContext();
     }
   }
 

--- a/lib/SILGen/SILGenMaterializeForSet.cpp
+++ b/lib/SILGen/SILGenMaterializeForSet.cpp
@@ -168,8 +168,8 @@ public:
       selfType = conformance->getType();
     } else {
       auto *proto = cast<ProtocolDecl>(requirement->getDeclContext());
-      selfInterfaceType = proto->getProtocolSelf()->getDeclaredType();
-      selfType = proto->getProtocolSelf()->getArchetype();
+      selfInterfaceType = proto->getSelfInterfaceType();
+      selfType = proto->getSelfTypeInContext();
     }
 
     MaterializeForSetEmitter emitter(SGM, linkage, witness, witnessSubs,
@@ -205,16 +205,9 @@ public:
   forConcreteImplementation(SILGenModule &SGM,
                             FuncDecl *witness,
                             ArrayRef<Substitution> witnessSubs) {
-    Type selfInterfaceType, selfType;
-
     auto *dc = witness->getDeclContext();
-    if (auto *proto = dc->getAsProtocolOrProtocolExtensionContext()) {
-      selfInterfaceType = proto->getProtocolSelf()->getDeclaredType();
-      selfType = ArchetypeBuilder::mapTypeIntoContext(dc, selfInterfaceType);
-    } else {
-      selfInterfaceType = dc->getDeclaredInterfaceType();
-      selfType = dc->getDeclaredTypeInContext();
-    }
+    Type selfInterfaceType = dc->getSelfInterfaceType();
+    Type selfType = dc->getSelfTypeInContext();
 
     SILDeclRef constant(witness);
     auto constantInfo = SGM.Types.getConstantInfo(constant);

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -2106,6 +2106,7 @@ swift::createDesignatedInitOverride(TypeChecker &tc,
         // Apply the superclass substitutions to produce an interface
         // type in terms of the class generic signature.
         auto paramSubstTy = paramTy.subst(moduleDecl, subsMap, SubstOptions());
+        decl->setInterfaceType(paramSubstTy);
 
         // Map it to a contextual type in terms of the class's archetypes.
         decl->overwriteType(ArchetypeBuilder::mapTypeIntoContext(

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -2060,15 +2060,17 @@ swift::createDesignatedInitOverride(TypeChecker &tc,
     return nullptr;
 
   // Lookup will sometimes give us initializers that are from the ancestors of
-  // our immediate superclass.  So, from the superclass constructor, we look 
-  // one level up to the enclosing type context which will either be a class 
+  // our immediate superclass.  So, from the superclass constructor, we look
+  // one level up to the enclosing type context which will either be a class
   // or an extension.  We can use the type declared in that context to check
   // if it's our immediate superclass and give up if we didn't.
-  // 
+  //
   // FIXME: Remove this when lookup of initializers becomes restricted to our
   // immediate superclass.
-  Type superclassTyInCtor = superclassCtor->getDeclContext()->getDeclaredTypeInContext();
+  Type superclassTyInCtor = superclassCtor->getDeclContext()->getDeclaredTypeOfContext();
   Type superclassTy = classDecl->getSuperclass();
+  Type superclassTyInContext = ArchetypeBuilder::mapTypeIntoContext(
+      classDecl, superclassTy);
   NominalTypeDecl *superclassDecl = superclassTy->getAnyNominal();
   if (superclassTyInCtor->getAnyNominal() != superclassDecl) {
     return nullptr;
@@ -2093,7 +2095,7 @@ swift::createDesignatedInitOverride(TypeChecker &tc,
   if (superclassDecl->isGenericContext()) {
     if (auto *superclassSig = superclassDecl->getGenericSignatureOfContext()) {
       auto *moduleDecl = classDecl->getParentModule();
-      auto subs = superclassTy->gatherAllSubstitutions(
+      auto subs = superclassTyInContext->gatherAllSubstitutions(
           moduleDecl, nullptr, nullptr);
       auto subsMap = superclassSig->getSubstitutionMap(subs);
 
@@ -2103,13 +2105,14 @@ swift::createDesignatedInitOverride(TypeChecker &tc,
         auto paramTy = ArchetypeBuilder::mapTypeOutOfContext(
             superclassDecl, decl->getType());
 
-        // Apply the superclass substitutions to produce an interface
-        // type in terms of the class generic signature.
+        // Apply the superclass substitutions to produce a contextual
+        // type in terms of the derived class archetypes.
         auto paramSubstTy = paramTy.subst(moduleDecl, subsMap, SubstOptions());
-        decl->setInterfaceType(paramSubstTy);
+        decl->overwriteType(paramSubstTy);
 
-        // Map it to a contextual type in terms of the class's archetypes.
-        decl->overwriteType(ArchetypeBuilder::mapTypeIntoContext(
+        // Map it to an interface type in terms of the derived class
+        // generic signature.
+        decl->setInterfaceType(ArchetypeBuilder::mapTypeOutOfContext(
             classDecl, paramSubstTy));
       }
     }

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -67,7 +67,7 @@ static ParamDecl *buildArgument(SourceLoc loc, DeclContext *DC,
 }
 
 static ParamDecl *buildLetArgument(SourceLoc loc, DeclContext *DC,
-                                  StringRef name, Type type) {
+                                   StringRef name, Type type) {
   return buildArgument(loc, DC, name, type, /*isLet*/ true);
 }
 
@@ -182,8 +182,8 @@ static FuncDecl *createSetterPrototype(AbstractStorageDecl *storage,
   // Add a "(value : T, indices...)" argument list.
   auto storageType = getTypeOfStorage(storage, TC);
   valueDecl = buildLetArgument(storage->getLoc(),
-                                     storage->getDeclContext(), "value",
-                                     storageType);
+                               storage->getDeclContext(), "value",
+                               storageType);
   params.push_back(buildIndexForwardingParamList(storage, valueDecl));
 
   Type setterRetTy = TupleType::getEmpty(TC.Context);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1016,7 +1016,7 @@ void ConstraintSystem::openGeneric(
       // skip.
       if (skipProtocolSelfConstraint &&
           protoDecl == outerDC->getAsProtocolOrProtocolExtensionContext() &&
-          (protoDecl->getProtocolSelf()->getDeclaredType()->getCanonicalType() ==
+          (protoDecl->getSelfInterfaceType()->getCanonicalType() ==
            req.getFirstType()->getCanonicalType())) {
         break;
       }
@@ -1218,8 +1218,8 @@ ConstraintSystem::getTypeOfMemberReference(
 
       if (outerDC->getAsProtocolOrProtocolExtensionContext()) {
         // Retrieve the type variable for 'Self'.
-        selfTy = replacements[outerDC->getProtocolSelf()->getDeclaredType()
-                                ->getCanonicalType()];
+        selfTy = replacements[outerDC->getSelfInterfaceType()
+                                     ->getCanonicalType()];
       } else {
         // Open the nominal type.
         selfTy = openType(nominal->getDeclaredInterfaceType(), locator,

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -141,8 +141,9 @@ static VarDecl *deriveRawRepresentable_raw(TypeChecker &tc,
   PatternBindingDecl *pbDecl;
   std::tie(propDecl, pbDecl)
     = declareDerivedReadOnlyProperty(tc, parentDecl, enumDecl,
-                                     C.Id_rawValue, rawType,
+                                     C.Id_rawValue,
                                      rawInterfaceType,
+                                     rawType,
                                      getterDecl);
   
   auto dc = cast<IterableDeclContext>(parentDecl);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -372,9 +372,8 @@ void TypeChecker::checkInheritanceClause(Decl *decl,
       continue;
 
     // Retrieve the interface type for this inherited type.
-    if (DC->isGenericContext() && DC->isTypeContext()) {
+    if (inheritedTy->hasArchetype())
       inheritedTy = ArchetypeBuilder::mapTypeOutOfContext(DC, inheritedTy);
-    }
 
     // Check whether we inherited from the same type twice.
     CanType inheritedCanTy = inheritedTy->getCanonicalType();

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4075,7 +4075,8 @@ public:
       return false;
     }
 
-    // 'Self' is only a dynamic self on class methods.
+    // 'Self' is only a dynamic self on class methods and
+    // protocol requirements.
     auto declaredType = dc->getDeclaredTypeOfContext();
     if (declaredType->is<ErrorType>())
       return false;

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -587,15 +587,8 @@ void TypeChecker::configureInterfaceType(AbstractFunctionDecl *func) {
   } else if (auto ctor = dyn_cast<ConstructorDecl>(func)) {
     auto *dc = ctor->getDeclContext();
 
-    // FIXME: shouldn't this just be
-    // ctor->getDeclContext()->getDeclaredInterfaceType()?
-    if (dc->getAsProtocolOrProtocolExtensionContext()) {
-      funcTy = dc->getProtocolSelf()->getDeclaredType();
-    } else {
-      funcTy = dc->getAsNominalTypeOrNominalTypeExtensionContext()
-          ->getDeclaredInterfaceType();
-    }
-    
+    funcTy = dc->getSelfInterfaceType();
+
     // Adjust result type for failability.
     if (ctor->getFailability() != OTK_None)
       funcTy = OptionalType::get(ctor->getFailability(), funcTy);

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -641,9 +641,6 @@ void TypeChecker::configureInterfaceType(AbstractFunctionDecl *func) {
 
     auto info = applyFunctionTypeAttributes(func, i);
 
-    // FIXME: We shouldn't even get here if the function isn't locally generic
-    // to begin with, but fixing that requires a lot of reengineering for local
-    // definitions in generic contexts.
     if (sig && i == e-1) {
       funcTy = GenericFunctionType::get(sig, argTy, funcTy, info);
       if (initFuncTy)

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -626,14 +626,7 @@ void TypeChecker::configureInterfaceType(AbstractFunctionDecl *func) {
         initArgTy = func->computeInterfaceSelfType(/*isInitializingCtor=*/true);
       }
     } else {
-      argTy = paramLists[e - i - 1]->getType(Context);
-
-      // For an implicit declaration, our argument type will be in terms of
-      // archetypes rather than dependent types. Replace the
-      // archetypes with their corresponding dependent types.
-      if (func->isImplicit()) {
-        argTy = ArchetypeBuilder::mapTypeOutOfContext(func, argTy); 
-      }
+      argTy = paramLists[e - i - 1]->getInterfaceType(func);
 
       if (initFuncTy)
         initArgTy = argTy;
@@ -653,9 +646,12 @@ void TypeChecker::configureInterfaceType(AbstractFunctionDecl *func) {
   }
 
   // Record the interface type.
+  assert(!funcTy->hasArchetype());
   func->setInterfaceType(funcTy);
-  if (initFuncTy)
+  if (initFuncTy) {
+    assert(!initFuncTy->hasArchetype());
     cast<ConstructorDecl>(func)->setInitializerInterfaceType(initFuncTy);
+  }
 
   if (func->getGenericParams()) {
     // Collect all generic params referenced in parameter types,

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -925,7 +925,7 @@ matchWitness(TypeChecker &tc,
     // the required type and the witness type.
     cs.emplace(tc, dc, ConstraintSystemOptions());
 
-    Type selfIfaceTy = proto->getProtocolSelf()->getDeclaredType();
+    Type selfIfaceTy = proto->getSelfInterfaceType();
     Type selfTy;
 
     // For a concrete conformance, use the conforming type as the
@@ -2882,7 +2882,7 @@ void ConformanceChecker::resolveTypeWitnesses() {
     // Create a set of type substitutions for all known associated type.
     // FIXME: Base this on dependent types rather than archetypes?
     TypeSubstitutionMap substitutions;
-    substitutions[Proto->getProtocolSelf()->getArchetype()] = Adoptee;
+    substitutions[Proto->getSelfTypeInContext().getPointer()] = Adoptee;
     for (auto member : Proto->getMembers()) {
       if (auto assocType = dyn_cast<AssociatedTypeDecl>(member)) {
         if (Conformance->hasTypeWitness(assocType)) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1889,17 +1889,6 @@ void ConformanceChecker::recordTypeWitness(AssociatedTypeDecl *assocType,
                                            TypeDecl *typeDecl,
                                            DeclContext *fromDC,
                                            bool performRedeclarationCheck) {
-  // If the declaration context from which the type witness was determined
-  // differs from that of the conformance, adjust the type so that it is
-  // based on the declaration context of the conformance.
-  if (fromDC != DC && DC->getGenericSignatureOfContext() &&
-      fromDC->getGenericSignatureOfContext() && !isa<ProtocolDecl>(fromDC)) {
-    // Map the type to an interface type.
-    type = ArchetypeBuilder::mapTypeOutOfContext(fromDC, type);
-
-    // Map the type into the conformance's context.
-    type = Adoptee->getTypeOfMember(DC->getParentModule(), type, fromDC);
-  }
 
   // If we already recoded this type witness, there's nothing to do.
   if (Conformance->hasTypeWitness(assocType)) {

--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -239,7 +239,8 @@ void REPLChecker::generatePrintOfExpression(StringRef NameStr, Expr *E) {
       new (Context) ClosureExpr(params, SourceLoc(), SourceLoc(), SourceLoc(),
                                 TypeLoc(), discriminator, newTopLevel);
 
-  CE->setType(ParameterList::getFullType(TupleType::getEmpty(Context), params));
+  CE->setType(ParameterList::getFullInterfaceType(
+      TupleType::getEmpty(Context), params, newTopLevel));
   
   // Convert the pattern to a string we can print.
   llvm::SmallString<16> PrefixString;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -376,14 +376,11 @@ Type TypeChecker::resolveTypeInContext(
           // instead of the existential type.
           assert(fromType->is<ProtocolType>());
 
-          auto protoSelf = parentDC->getProtocolSelf();
-          if (protoSelf == nullptr)
+          auto selfType = parentDC->getSelfInterfaceType();
+          if (!selfType)
             return ErrorType::get(Context);
-
-          auto selfType = protoSelf
-              ->getDeclaredType()
-              ->castTo<GenericTypeParamType>();
-          fromType = resolver->resolveGenericTypeParamType(selfType);
+          fromType = resolver->resolveGenericTypeParamType(
+              selfType->castTo<GenericTypeParamType>());
 
           if (assocType) {
             // Odd special case, ask Doug to explain it over pizza one day

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -333,7 +333,8 @@ Type TypeChecker::resolveTypeInContext(
       // - Nested type: associated type
       // - Nested type's context: protocol or protocol extension
       //
-      if (assocType && fromProto == nullptr) {
+      if (!fromProto &&
+          ownerNominal->getAsProtocolOrProtocolExtensionContext()) {
         ProtocolConformance *conformance = nullptr;
 
         // If the conformance check failed, the associated type is for a
@@ -344,7 +345,12 @@ Type TypeChecker::resolveTypeInContext(
                                parentDC, ConformanceCheckFlags::Used,
                                &conformance) &&
             conformance) {
-          return conformance->getTypeWitness(assocType, this).getReplacement();
+          if (assocType) {
+            return conformance->getTypeWitness(assocType, this).getReplacement();
+          }
+
+          return substMemberTypeWithBase(parentDC->getParentModule(), typeDecl,
+                                         fromType, /*isTypeReference=*/true);
         }
       }
 

--- a/test/decl/inherit/initializer.swift
+++ b/test/decl/inherit/initializer.swift
@@ -142,3 +142,11 @@ class SuperVariadic {
 
 class SubVariadic : SuperVariadic { } // expected-warning 4{{synthesizing a variadic inherited initializer for subclass 'SubVariadic' is unsupported}}
 
+// Don't crash with invalid nesting of class in generic function
+
+func testClassInGenericFunc<T>(t: T) {
+  class A { init(t: T) {} } // expected-error {{type 'A' cannot be nested in generic function 'testClassInGenericFunc'}}
+  class B : A {} // expected-error {{type 'B' cannot be nested in generic function 'testClassInGenericFunc'}}
+
+  _ = B(t: t)
+}

--- a/test/decl/typealias/protocol.swift
+++ b/test/decl/typealias/protocol.swift
@@ -152,3 +152,22 @@ struct T5 : P5 {
   var v7: T5.T2 // OK
 }
 
+// Unqualified lookup finds typealiases in protocol extensions, though
+protocol P6 {
+  associatedtype A
+}
+
+extension P6 {
+  typealias Y = A
+}
+
+struct S6 : P6 {
+  typealias A = Int
+
+  // FIXME
+  func inTypeContext(y: Y) // expected-error {{use of undeclared type 'Y'}}
+
+  func inExpressionContext() {
+    _ = Y.self
+  }
+}


### PR DESCRIPTION
The goal here is to ensure we don't call mapTypeIntoContext() on a type already containing archetypes, or mapTypeOutOfContext() on a type already containing interface types.

Also, start cleaning up synthesized ParamDecls to have both an interface type and a contextual type, and simplify some ClangImporter logic for Objective-C generics in the process.

Still not done because some compiler_crashers regress.
