### PR TITLE
Mark the Dispatch classes as a new kind of "foreign" class.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -458,8 +458,8 @@ class alignas(1 << DeclAlignInBits) Decl {
     /// This is a value of \c StoredInheritsSuperclassInits.
     unsigned InheritsSuperclassInits : 2;
 
-    /// Whether this class is "foreign".
-    unsigned Foreign : 1;
+    /// \see ClassDecl::ForeignKind
+    unsigned RawForeignKind : 2;
     
     /// Whether this class contains a destructor decl.
     ///
@@ -468,7 +468,7 @@ class alignas(1 << DeclAlignInBits) Decl {
     /// control inserting the implicit destructor.
     unsigned HasDestructorDecl : 1;
   };
-  enum { NumClassDeclBits = NumNominalTypeDeclBits + 7 };
+  enum { NumClassDeclBits = NumNominalTypeDeclBits + 8 };
   static_assert(NumClassDeclBits <= 32, "fits in an unsigned");
 
   class StructDeclBitfields {
@@ -3238,6 +3238,19 @@ public:
     ClassDeclBits.RequiresStoredPropertyInits = requiresInits;
   }
 
+  /// \see getForeignClassKind
+  enum class ForeignKind : uint8_t {
+    /// A normal Swift or Objective-C class.
+    Normal = 0,
+    /// An imported Core Foundation type. These are AnyObject-compatible but
+    /// do not have runtime metadata.
+    CFType,
+    /// An imported Objective-C type whose class and metaclass symbols are not
+    /// both available at link-time but can be accessed through the Objective-C
+    /// runtime.
+    RuntimeOnly
+  };
+
   /// Whether this class is "foreign", meaning that it is implemented
   /// by a runtime that Swift does not have first-class integration
   /// with.  This generally means that:
@@ -3248,11 +3261,18 @@ public:
   ///
   /// We may find ourselves wanting to break this bit into more
   /// precise chunks later.
-  bool isForeign() const {
-    return ClassDeclBits.Foreign;
+  ForeignKind getForeignClassKind() const {
+    return static_cast<ForeignKind>(ClassDeclBits.RawForeignKind);
   }
-  void setForeign(bool isForeign = true) {
-    ClassDeclBits.Foreign = isForeign;
+  void setForeignClassKind(ForeignKind kind) {
+    ClassDeclBits.RawForeignKind = static_cast<unsigned>(kind);
+  }
+
+  /// Returns true if this class is any kind of "foreign class".
+  ///
+  /// \see getForeignClassKind
+  bool isForeign() const {
+    return getForeignClassKind() != ForeignKind::Normal;
   }
 
   /// Find a method of a class that overrides a given method.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3315,10 +3315,6 @@ public:
   /// the Objective-C runtime.
   StringRef getObjCRuntimeName(llvm::SmallVectorImpl<char> &buffer) const;
 
-  /// Determine whether the class is only visible to the Objective-C runtime
-  /// and not to the linker.
-  bool isOnlyObjCRuntimeVisible() const;
-
   /// Returns the appropriate kind of entry point to generate for this class,
   /// based on its attributes.
   ///

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1166,9 +1166,13 @@ NOTE(types_not_equal_requirement,none,
 ERROR(non_class_cannot_conform_to_class_protocol,none,
       "non-class type %0 cannot conform to class protocol %1",
       (Type, Type))
-ERROR(foreign_class_cannot_conform_to_objc_protocol,none,
+ERROR(cf_class_cannot_conform_to_objc_protocol,none,
       "Core Foundation class %0 cannot conform to @objc protocol %1 because "
       "Core Foundation types are not classes in Objective-C",
+      (Type, Type))
+ERROR(objc_runtime_visible_cannot_conform_to_objc_protocol,none,
+      "class %0 cannot conform to @objc protocol %1 because "
+      "the class is only visible via the Objective-C runtime",
       (Type, Type))
 ERROR(protocol_has_missing_requirements,none,
       "type %0 cannot conform to protocol %1 because it has requirements that "
@@ -1577,8 +1581,11 @@ ERROR(inheritance_from_final_class,none,
 ERROR(inheritance_from_unspecialized_objc_generic_class,none,
       "inheritance from a generic Objective-C class %0 must bind "
       "type parameters of %0 to specific concrete types", (Identifier))
+ERROR(inheritance_from_cf_class,none,
+      "cannot inherit from Core Foundation type %0", (Identifier))
 ERROR(inheritance_from_objc_runtime_visible_class,none,
-      "inheritance from an Objective-C class %0 only visible via the runtime", (Identifier))
+      "cannot inherit from class %0 because it is only visible via the "
+      "Objective-C runtime", (Identifier))
 
 
 // Enums
@@ -2606,8 +2613,6 @@ ERROR(objc_in_extension_context,none,
       "members of constrained extensions cannot be declared @objc", ())
 ERROR(objc_in_generic_extension,none,
       "@objc is not supported within extensions of generic classes", ())
-ERROR(objc_in_objc_runtime_visible,none,
-      "@objc is not supported within extensions of classes only visible via the Objective-C runtime", ())
 
 ERROR(objc_for_generic_class,none,
       "generic subclasses of '@objc' classes cannot have an explicit '@objc' "
@@ -2727,6 +2732,11 @@ ERROR(objc_invalid_on_failing_init,none,
       "a failable and throwing initializer cannot be "
       "%" OBJC_ATTR_SELECT "0 because 'nil' indicates failure to Objective-C",
       (unsigned))
+
+ERROR(objc_in_objc_runtime_visible,none,
+      "%0 cannot be %" OBJC_ATTR_SELECT "1 because class %2 is only visible "
+      "via the Objective-C runtime",
+      (DescriptiveDeclKind, unsigned, Identifier))
 
 ERROR(objc_override_method_selector_mismatch,none,
       "Objective-C method has a different selector from the "

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -53,7 +53,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 251; // Last change: SILFunctionType::isPseudogeneric
+const uint16_t VERSION_MINOR = 252; // Last change: remove class's "foreign" field
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;
@@ -816,7 +816,6 @@ namespace decls_block {
     BCFixed<1>,        // implicit?
     BCFixed<1>,        // explicitly objc?
     BCFixed<1>,        // requires stored property initial values
-    BCFixed<1>,        // foreign
     TypeIDField,       // superclass
     AccessibilityKindField, // accessibility
     BCVBR<4>,               // number of conformances

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2398,19 +2398,6 @@ StringRef ClassDecl::getObjCRuntimeName(
   return mangleObjCRuntimeName(this, buffer);
 }
 
-bool ClassDecl::isOnlyObjCRuntimeVisible() const {
-  auto clangDecl = getClangDecl();
-  if (!clangDecl) return false;
-
-  auto objcClass = dyn_cast<clang::ObjCInterfaceDecl>(clangDecl);
-  if (!objcClass) return false;
-
-  if (auto def = objcClass->getDefinition())
-    objcClass = def;
-
-  return objcClass->hasAttr<clang::ObjCRuntimeVisibleAttr>();
-}
-
 ArtificialMainKind ClassDecl::getArtificialMainKind() const {
   if (getAttrs().hasAttribute<UIApplicationMainAttr>())
     return ArtificialMainKind::UIApplicationMain;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2231,7 +2231,7 @@ ClassDecl::ClassDecl(SourceLoc ClassLoc, Identifier Name, SourceLoc NameLoc,
   ClassDeclBits.RequiresStoredPropertyInits = 0;
   ClassDeclBits.InheritsSuperclassInits
     = static_cast<unsigned>(StoredInheritsSuperclassInits::Unchecked);
-  ClassDeclBits.Foreign = false;
+  ClassDeclBits.RawForeignKind = 0;
   ClassDeclBits.HasDestructorDecl = 0;
 }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5660,8 +5660,7 @@ namespace {
           nsObjectTy->getClassOrBoundGenericClass();
 
         auto result = createRootClass(nsObjectDecl->getDeclContext());
-        // FIXME: Should use RuntimeOnly.
-        result->setForeignClassKind(ClassDecl::ForeignKind::CFType);
+        result->setForeignClassKind(ClassDecl::ForeignKind::RuntimeOnly);
         return result;
       }
 
@@ -5732,6 +5731,8 @@ namespace {
 
       if (declaredNative)
         markMissingSwiftDecl(result);
+      if (decl->getAttr<clang::ObjCRuntimeVisibleAttr>())
+        result->setForeignClassKind(ClassDecl::ForeignKind::RuntimeOnly);
 
       // If this Objective-C class has a supertype, import it.
       SmallVector<TypeLoc, 4> inheritedTypes;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1243,7 +1243,7 @@ namespace {
       theClass->setSuperclass(superclass);
       theClass->setCheckedInheritanceClause();
       theClass->setAddedImplicitInitializers(); // suppress all initializers
-      theClass->setForeign(true);
+      theClass->setForeignClassKind(ClassDecl::ForeignKind::CFType);
       addObjCAttribute(theClass, None);
       Impl.registerExternalDecl(theClass);
 
@@ -5660,7 +5660,8 @@ namespace {
           nsObjectTy->getClassOrBoundGenericClass();
 
         auto result = createRootClass(nsObjectDecl->getDeclContext());
-        result->setForeign(true);
+        // FIXME: Should use RuntimeOnly.
+        result->setForeignClassKind(ClassDecl::ForeignKind::CFType);
         return result;
       }
 

--- a/lib/IRGen/GenCast.cpp
+++ b/lib/IRGen/GenCast.cpp
@@ -163,9 +163,10 @@ llvm::Value *irgen::emitClassDowncast(IRGenFunction &IGF, llvm::Value *from,
       break;
     }
 
-  // If the destination type is a foreign class or a non-specific
+  // If the destination type is a CF type or a non-specific
   // class-bounded archetype, use the most general cast entrypoint.
-  } else if (toType.is<ArchetypeType>() || destClass->isForeign()) {
+  } else if (toType.is<ArchetypeType>() ||
+             destClass->getForeignClassKind()==ClassDecl::ForeignKind::CFType) {
     metadataRef = IGF.emitTypeMetadataRef(toType.getSwiftRValueType());
 
     switch (mode) {

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2272,6 +2272,7 @@ Address IRGenModule::getAddrOfObjCClassRef(ClassDecl *theClass) {
 llvm::Constant *IRGenModule::getAddrOfObjCClass(ClassDecl *theClass,
                                                 ForDefinition_t forDefinition) {
   assert(ObjCInterop && "getting address of ObjC class in no-interop mode");
+  assert(!theClass->isForeign());
   LinkEntity entity = LinkEntity::forObjCClass(theClass);
   DebugTypeInfo DbgTy(theClass, ObjCClassPtrTy,
                       getPointerSize(), getPointerAlignment());
@@ -2285,6 +2286,7 @@ llvm::Constant *IRGenModule::getAddrOfObjCClass(ClassDecl *theClass,
 llvm::Constant *IRGenModule::getAddrOfObjCMetaclass(ClassDecl *theClass,
                                                 ForDefinition_t forDefinition) {
   assert(ObjCInterop && "getting address of ObjC metaclass in no-interop mode");
+  assert(!theClass->isForeign());
   LinkEntity entity = LinkEntity::forObjCMetaclass(theClass);
   DebugTypeInfo DbgTy(theClass, ObjCClassPtrTy,
                       getPointerSize(), getPointerAlignment());

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2845,7 +2845,7 @@ void IRGenModule::emitExtension(ExtensionDecl *ext) {
 
   if (shouldEmitCategory(*this, ext)) {
     assert(origClass && !origClass->isForeign() &&
-           "CF types cannot have categories emitted");
+           "foreign types cannot have categories emitted");
     llvm::Constant *category = emitCategoryData(*this, ext);
     category = llvm::ConstantExpr::getBitCast(category, Int8PtrTy);
     ObjCCategories.push_back(category);

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5438,6 +5438,7 @@ IRGenModule::getAddrOfForeignTypeMetadataCandidate(CanType type) {
   if (auto classType = dyn_cast<ClassType>(type)) {
     assert(!classType.getParent());
     auto classDecl = classType->getDecl();
+    // FIXME: Differentiate between the different kinds of foreign classes.
     assert(classDecl->isForeign());
 
     ForeignClassMetadataBuilder builder(*this, classDecl);

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -292,10 +292,8 @@ llvm::Constant *irgen::tryEmitConstantHeapMetadataRef(IRGenModule &IGM,
     if (doesClassMetadataRequireDynamicInitialization(IGM, theDecl))
       return nullptr;
 
-  // Otherwise, just respect genericity and Objective-C runtime visibility.
-  } else if ((theDecl->isGenericContext()
-              && !isTypeErasedGenericClass(theDecl))
-             || theDecl->isOnlyObjCRuntimeVisible()) {
+  // Otherwise, just respect genericity.
+  } else if (theDecl->isGenericContext() && !isTypeErasedGenericClass(theDecl)){
     return nullptr;
   }
 
@@ -331,12 +329,14 @@ llvm::Value *irgen::emitObjCHeapMetadataRef(IRGenFunction &IGF,
                                             bool allowUninitialized) {
   // If the class is visible only through the Objective-C runtime, form the
   // appropriate runtime call.
-  if (theClass->isOnlyObjCRuntimeVisible()) {
+  if (theClass->getForeignClassKind() == ClassDecl::ForeignKind::RuntimeOnly) {
     SmallString<64> scratch;
     auto className =
         IGF.IGM.getAddrOfGlobalString(theClass->getObjCRuntimeName(scratch));
     return IGF.Builder.CreateCall(IGF.IGM.getLookUpClassFn(), className);
   }
+
+  assert(!theClass->isForeign());
 
   Address classRef = IGF.IGM.getAddrOfObjCClassRef(theClass);
   auto classObject = IGF.Builder.CreateLoad(classRef);
@@ -5438,7 +5438,6 @@ IRGenModule::getAddrOfForeignTypeMetadataCandidate(CanType type) {
   if (auto classType = dyn_cast<ClassType>(type)) {
     assert(!classType.getParent());
     auto classDecl = classType->getDecl();
-    // FIXME: Differentiate between the different kinds of foreign classes.
     assert(classDecl->isForeign());
 
     ForeignClassMetadataBuilder builder(*this, classDecl);

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -611,7 +611,8 @@ private:
     if (auto weakTy = ty->getAs<WeakStorageType>()) {
       auto innerTy = weakTy->getReferentType()->getAnyOptionalObjectType();
       auto innerClass = innerTy->getClassOrBoundGenericClass();
-      if ((innerClass && !innerClass->isForeign()) ||
+      if ((innerClass &&
+           innerClass->getForeignClassKind()!=ClassDecl::ForeignKind::CFType) ||
           (innerTy->isObjCExistentialType() && !isCFTypeRef(innerTy))) {
         os << ", weak";
       }
@@ -653,7 +654,8 @@ private:
           break;
         }
       } else if ((dyn_cast_or_null<ClassDecl>(nominal) &&
-                  !cast<ClassDecl>(nominal)->isForeign()) ||
+                  cast<ClassDecl>(nominal)->getForeignClassKind() !=
+                    ClassDecl::ForeignKind::CFType) ||
                  (copyTy->isObjCExistentialType() && !isCFTypeRef(copyTy))) {
         os << ", strong";
       }
@@ -1617,8 +1619,10 @@ public:
   }
 
   bool forwardDeclare(const ClassDecl *CD) {
-    if (!CD->isObjC() || CD->isForeign())
+    if (!CD->isObjC() ||
+        CD->getForeignClassKind() == ClassDecl::ForeignKind::CFType) {
       return false;
+    }
     forwardDeclare(CD, [&]{ os << "@class " << getNameForObjC(CD) << ";\n"; });
     return true;
   }

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -401,18 +401,24 @@ enum class ConventionsKind : uint8_t {
         
         if (clangTy->getPointeeType()->getAs<clang::RecordType>()) {
           // CF type as foreign class
-          if (substTy->getClassOrBoundGenericClass()
-              && substTy->getClassOrBoundGenericClass()->isForeign())
+          if (substTy->getClassOrBoundGenericClass() &&
+              substTy->getClassOrBoundGenericClass()->getForeignClassKind() ==
+                ClassDecl::ForeignKind::CFType) {
             return false;
+          }
           // swift_newtype-ed CF type as foreign class
           if (auto typedefTy = clangTy->getAs<clang::TypedefType>()) {
             if (typedefTy->getDecl()->getAttr<clang::SwiftNewtypeAttr>()) {
               // Make sure that we actually made the struct during import
               if (auto underlyingType =
                       substTy->getSwiftNewtypeUnderlyingType()) {
-                if (underlyingType->getClassOrBoundGenericClass() &&
-                    underlyingType->getClassOrBoundGenericClass()->isForeign())
-                  return false;
+                if (auto underlyingClass =
+                        underlyingType->getClassOrBoundGenericClass()) {
+                  if (underlyingClass->getForeignClassKind() ==
+                          ClassDecl::ForeignKind::CFType) {
+                    return false;
+                  }
+                }
               }
             }
           }

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -459,7 +459,8 @@ ManagedValue Transform::transform(ManagedValue v,
     auto class2 = outputSubstType->getClassOrBoundGenericClass();
 
     // CF <-> Objective-C via toll-free bridging.
-    if (class1->isForeign() != class2->isForeign()) {
+    if ((class1->getForeignClassKind() == ClassDecl::ForeignKind::CFType) ^
+        (class2->getForeignClassKind() == ClassDecl::ForeignKind::CFType)) {
        return ManagedValue(SGF.B.createUncheckedRefCast(Loc,
                                                         v.getValue(),
                                                         loweredResultTy),

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2886,7 +2886,8 @@ namespace {
       case CheckedCastKind::ValueCast:
         // Check the cast target is a non-foreign type
         if (auto cls = toType->getAs<ClassType>()) {
-          if (cls->getDecl()->isForeign()) {
+          if (cls->getDecl()->getForeignClassKind() ==
+                ClassDecl::ForeignKind::CFType) {
             tc.diagnose(expr->getLoc(), diag::isa_is_foreign_check, toType);
           }
         }
@@ -2975,7 +2976,8 @@ namespace {
         if (auto metaTy = destObjectType->getAs<MetatypeType>())
           destObjectType = metaTy->getInstanceType();
         if (auto destClass = destObjectType->getClassOrBoundGenericClass()) {
-          if (destClass->isForeign()) {
+          if (destClass->getForeignClassKind() ==
+                ClassDecl::ForeignKind::CFType) {
             if (SuppressDiagnostics)
               return nullptr;
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1576,14 +1576,16 @@ ConstraintSystem::matchTypes(Type type1, Type type2, TypeMatchKind kind,
         auto class2 = cast<ClassDecl>(nominal2->getDecl());
 
         // CF -> Objective-C via toll-free bridging.
-        if (class1->isForeign() && !class2->isForeign() &&
+        if (class1->getForeignClassKind() == ClassDecl::ForeignKind::CFType &&
+            class2->getForeignClassKind() != ClassDecl::ForeignKind::CFType &&
             class1->getAttrs().hasAttribute<ObjCBridgedAttr>()) {
           conversionsOrFixes.push_back(
             ConversionRestrictionKind::CFTollFreeBridgeToObjC);
         }
 
         // Objective-C -> CF via toll-free bridging.
-        if (class2->isForeign() && !class1->isForeign() &&
+        if (class2->getForeignClassKind() == ClassDecl::ForeignKind::CFType &&
+            class1->getForeignClassKind() != ClassDecl::ForeignKind::CFType &&
             class2->getAttrs().hasAttribute<ObjCBridgedAttr>()) {
           conversionsOrFixes.push_back(
             ConversionRestrictionKind::ObjCTollFreeBridgeToCF);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2856,7 +2856,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
   // This "always fails" diagnosis makes no sense when paired with the CF
   // one.
   auto clas = toType->getClassOrBoundGenericClass();
-  if (clas && clas->isForeign())
+  if (clas && clas->getForeignClassKind() == ClassDecl::ForeignKind::CFType)
     return CheckedCastKind::ValueCast;
   
   // Don't warn on casts that change the generic parameters of ObjC generic

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3951,7 +3951,8 @@ checkConformsToProtocol(TypeChecker &TC,
   if (Proto->isObjC() &&
       !Proto->isSpecificProtocol(KnownProtocolKind::AnyObject)) {
     if (auto clas = canT->getClassOrBoundGenericClass())
-      if (clas->isForeign()) {
+      if (clas->getForeignClassKind() != ClassDecl::ForeignKind::Normal) {
+        // FIXME: Customize the error message for different foreign class kinds.
         TC.diagnose(ComplainLoc,
                     diag::foreign_class_cannot_conform_to_objc_protocol,
                     T, Proto->getDeclaredType());

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3950,15 +3950,26 @@ checkConformsToProtocol(TypeChecker &TC,
   // Foreign classes cannot conform to objc protocols.
   if (Proto->isObjC() &&
       !Proto->isSpecificProtocol(KnownProtocolKind::AnyObject)) {
-    if (auto clas = canT->getClassOrBoundGenericClass())
-      if (clas->getForeignClassKind() != ClassDecl::ForeignKind::Normal) {
-        // FIXME: Customize the error message for different foreign class kinds.
-        TC.diagnose(ComplainLoc,
-                    diag::foreign_class_cannot_conform_to_objc_protocol,
+    if (auto clas = canT->getClassOrBoundGenericClass()) {
+      Optional<decltype(diag::cf_class_cannot_conform_to_objc_protocol)>
+          diagKind;
+      switch (clas->getForeignClassKind()) {
+      case ClassDecl::ForeignKind::Normal:
+        break;
+      case ClassDecl::ForeignKind::CFType:
+        diagKind = diag::cf_class_cannot_conform_to_objc_protocol;
+        break;
+      case ClassDecl::ForeignKind::RuntimeOnly:
+        diagKind = diag::objc_runtime_visible_cannot_conform_to_objc_protocol;
+        break;
+      }
+      if (diagKind) {
+        TC.diagnose(ComplainLoc, diagKind.getValue(),
                     T, Proto->getDeclaredType());
         conformance->setInvalid();
         return conformance;
       }
+    }
   }
 
   // If the protocol contains missing requirements, it can't be conformed to

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2870,7 +2870,7 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
   case decls_block::CLASS_DECL: {
     IdentifierID nameID;
     DeclContextID contextID;
-    bool isImplicit, isObjC, requiresStoredPropertyInits, foreign;
+    bool isImplicit, isObjC, requiresStoredPropertyInits;
     TypeID superclassID;
     uint8_t rawAccessLevel;
     unsigned numConformances;
@@ -2878,7 +2878,7 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
     decls_block::ClassLayout::readRecord(scratch, nameID, contextID,
                                          isImplicit, isObjC,
                                          requiresStoredPropertyInits,
-                                         foreign, superclassID, rawAccessLevel,
+                                         superclassID, rawAccessLevel,
                                          numConformances,
                                          rawInheritedIDs);
 
@@ -2907,8 +2907,6 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
     theClass->setSuperclass(getType(superclassID));
     if (requiresStoredPropertyInits)
       theClass->setRequiresStoredPropertyInits(true);
-    if (foreign)
-      theClass->setForeign();
     if (genericParams) {
       SmallVector<GenericTypeParamType *, 4> paramTypes;
       for (auto &genericParam : *theClass->getGenericParams()) {

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2310,6 +2310,7 @@ void Serializer::writeDecl(const Decl *D) {
   case DeclKind::Class: {
     auto theClass = cast<ClassDecl>(D);
     verifyAttrSerializable(theClass);
+    assert(!theClass->isForeign());
 
     auto contextID = addDeclContextRef(theClass->getDeclContext());
 
@@ -2331,7 +2332,6 @@ void Serializer::writeDecl(const Decl *D) {
                             theClass->isImplicit(),
                             theClass->isObjC(),
                             theClass->requiresStoredPropertyInits(),
-                            theClass->isForeign(),
                             addTypeRef(theClass->getSuperclass()),
                             rawAccessLevel,
                             conformances.size(),

--- a/test/ClangModules/cf.swift
+++ b/test/ClangModules/cf.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -parse -verify -import-cf-types -I %S/Inputs/custom-modules %s
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -parse -verify -import-cf-types -I %S/Inputs/custom-modules %s
 
 // REQUIRES: objc_interop
 
@@ -149,3 +149,14 @@ func testNonConstVoid() {
   let value: Unmanaged<CFNonConstVoidRef> = CFNonConstBottom()!
   assertUnmanaged(value)
 }
+
+class NuclearFridge: CCRefrigerator {} // expected-error {{cannot inherit from Core Foundation type 'CCRefrigerator'}}
+extension CCRefrigerator {
+  @objc func foo() {} // expected-error {{method cannot be marked @objc because Core Foundation types are not classes in Objective-C}}
+  func bar() {} // okay, implicitly non-objc
+}
+
+protocol SwiftProto {}
+@objc protocol ObjCProto {}
+extension CCRefrigerator: ObjCProto {} // expected-error {{Core Foundation class 'CCRefrigerator' cannot conform to @objc protocol 'ObjCProto' because Core Foundation types are not classes in Objective-C}}
+extension CCRefrigerator: SwiftProto {}

--- a/test/ClangModules/objc_runtime_visible.swift
+++ b/test/ClangModules/objc_runtime_visible.swift
@@ -5,7 +5,18 @@
 import ObjCRuntimeVisible
 
 extension A {
-  @objc func foo() { } // expected-error{{@objc is not supported within extensions of classes only visible via the Objective-C runtime}}
+  @objc func foo() { } // expected-error{{instance method cannot be marked @objc because class 'A' is only visible via the Objective-C runtime}}
+  func bar() {} // okay, implicitly non-objc
 }
 
-class B : A { } // expected-error{{inheritance from an Objective-C class 'A' only visible via the runtime}}
+func test(x: AnyObject) {
+  _ = x.bar() // expected-error {{value of type 'AnyObject' has no member 'bar'}}
+}
+
+class B : A { } // expected-error{{cannot inherit from class 'A' because it is only visible via the Objective-C runtime}}
+
+protocol SwiftProto {}
+@objc protocol ObjCProto {}
+
+extension A: ObjCProto {} // expected-error {{class 'A' cannot conform to @objc protocol 'ObjCProto' because the class is only visible via the Objective-C runtime}}
+extension A: SwiftProto {} // okay

--- a/test/Interpreter/Inputs/objc_runtime_visible.h
+++ b/test/Interpreter/Inputs/objc_runtime_visible.h
@@ -1,0 +1,9 @@
+@import Foundation;
+
+__attribute__((visibility("hidden")))
+__attribute__((objc_runtime_visible))
+@interface HiddenClass : NSObject
+@property (readonly, nonnull) NSString *name;
+@end
+
+HiddenClass * _Nonnull createHidden() NS_RETURNS_RETAINED;

--- a/test/Interpreter/Inputs/objc_runtime_visible.m
+++ b/test/Interpreter/Inputs/objc_runtime_visible.m
@@ -1,0 +1,11 @@
+#import "objc_runtime_visible.h"
+
+@implementation HiddenClass
+- (NSString *)name {
+  return @"Beatrice";
+}
+@end
+
+HiddenClass *createHidden() {
+  return [[HiddenClass alloc] init];
+}

--- a/test/Interpreter/objc_runtime_visible.swift
+++ b/test/Interpreter/objc_runtime_visible.swift
@@ -1,0 +1,73 @@
+// RUN: rm -rf %t && mkdir -p %t
+
+// RUN: %clang %target-cc-options -isysroot %sdk -fobjc-arc %S/Inputs/objc_runtime_visible.m -fmodules -dynamiclib -o %t/libobjc_runtime_visible.dylib
+// RUN: nm -g %t/libobjc_runtime_visible.dylib | FileCheck %s
+// RUN: %target-build-swift -import-objc-header %S/Inputs/objc_runtime_visible.h %t/libobjc_runtime_visible.dylib %s -o %t/main
+// RUN: %target-run %t/main
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+// CHECK-NOT: HiddenClass
+
+import Foundation
+import StdlibUnittest
+
+extension HiddenClass {
+  class func create() -> HiddenClass {
+    return createHidden()
+  }
+
+  func normalMethod() -> String {
+    return self.name
+  }
+}
+
+var ObjCRuntimeVisibleTestSuite = TestSuite("ObjCRuntimeVisible")
+
+ObjCRuntimeVisibleTestSuite.test("methods") {
+  let obj = HiddenClass.create()
+  expectEqual("Beatrice", obj.name)
+  expectEqual("Beatrice", obj.normalMethod())
+}
+
+protocol SwiftProto {
+  func doTheThing() -> AnyObject
+}
+extension HiddenClass: SwiftProto {
+  func doTheThing() -> AnyObject { return self }
+}
+
+func callTheThing<T: SwiftProto>(_ instance: T) -> AnyObject {
+  return instance.doTheThing()
+}
+
+ObjCRuntimeVisibleTestSuite.test("downcast") {
+  let obj = HiddenClass.create()
+  let opaque: AnyObject = obj
+  let downcasted = opaque as? HiddenClass
+  expectNotEmpty(downcasted)
+  expectTrue(obj === downcasted)
+}
+
+ObjCRuntimeVisibleTestSuite.test("protocols") {
+  let obj = HiddenClass.create()
+  expectTrue(obj === obj.doTheThing())
+
+  let protoObj: SwiftProto = obj
+  expectTrue(obj === protoObj.doTheThing())
+
+  expectTrue(obj === callTheThing(obj))
+}
+
+ObjCRuntimeVisibleTestSuite.test("protocols/downcast")
+    .xfail(.always("unimplemented"))
+    .code {
+  let obj = HiddenClass.create()
+  let opaque: AnyObject = obj
+  let downcasted = opaque as? SwiftProto
+  expectNotEmpty(downcasted)
+  expectTrue(obj === downcasted!.doTheThing())
+}
+
+runAllTests()


### PR DESCRIPTION
Progress on rdar://problem/26850367, which is that Swift will happily let you extend the new Dispatch classes but then fails to find the symbols at link-time.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
