### PR TITLE
Revert "[ObjC Interop] Map Swift @objc properties named isFoo to ObjC Cocoa conventions"

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4306,6 +4306,11 @@ public:
   /// Return the Objective-C runtime name for this property.
   Identifier getObjCPropertyName() const;
 
+  /// Retrieve the default Objective-C selector for the getter of a
+  /// property of the given name.
+  static ObjCSelector getDefaultObjCGetterSelector(ASTContext &ctx,
+                                                   Identifier propertyName);
+
   /// Retrieve the default Objective-C selector for the setter of a
   /// property of the given name.
   static ObjCSelector getDefaultObjCSetterSelector(ASTContext &ctx,

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -665,7 +665,8 @@ private:
     // Handle custom accessor names.
     llvm::SmallString<64> buffer;
     if (hasReservedName ||
-        VD->getObjCGetterSelector() != ObjCSelector(ctx, 0, { objCName })) {
+        VD->getObjCGetterSelector() !=
+          VarDecl::getDefaultObjCGetterSelector(ctx, objCName)) {
       os << ", getter=" << VD->getObjCGetterSelector().getString(buffer);
     }
     if (isSettable) {

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -420,7 +420,7 @@ public class NonObjCClass { }
 // CHECK-NEXT: + (NSDictionary<NSString *, NSString *> * _Nonnull)staticDictionary;
 // CHECK-NEXT: @property (nonatomic, strong) Properties * _Nullable wobble;
 // CHECK-NEXT: @property (nonatomic, getter=isEnabled, setter=setIsEnabled:) BOOL enabled;
-// CHECK-NEXT: @property (nonatomic, getter=isAnimated) BOOL animated;
+// CHECK-NEXT: @property (nonatomic) BOOL isAnimated;
 // CHECK-NEXT: @property (nonatomic, getter=register, setter=setRegister:) BOOL register_;
 // CHECK-NEXT: @property (nonatomic, readonly, strong, getter=this) Properties * _Nonnull this_;
 // CHECK-NEXT: @property (nonatomic, readonly) NSInteger privateSetter;

--- a/test/SILGen/objc_selector.swift
+++ b/test/SILGen/objc_selector.swift
@@ -21,7 +21,7 @@ func createSelector(foo: Foo) -> Selector {
 
 // CHECK-LABEL: sil hidden @{{.*}}createGetterSelector
 func createGetterSelector() -> Selector {
-  // CHECK: string_literal objc_selector "isProperty"
+  // CHECK: string_literal objc_selector "property"
   return #selector(getter: Foo.isProperty)
 }
 


### PR DESCRIPTION
It sounds good on paper, but in practice we ended up breaking Core Data projects (because people name their boolean properties 'isFoo' rather than the Objective-C 'foo'), forcing an Objective-C-side change when a mixed-source project upgrades to Swift 3, and causing collisions when there are properties named both 'foo' and 'isFoo'. If people care about their Swift boolean properties strictly following the Objective-C Cocoa naming conventions, they'll have to specify them manually.

(We do have a bug to make it easier to rename the getter of a stored property exposed to Objective-C: rdar://problem/21261564.)

This reverts commit 6fe6266c999b036d8c7ab428c1c3c2fe8be1a42e.

rdar://problem/26847223

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
