### PR TITLE
ClosureSpecializer: Enable specialization of closures with indirect results

### DIFF
--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -475,12 +475,11 @@ static bool isSupportedClosure(const SILInstruction *Closure) {
   }
 
   // Make sure that it is a simple partial apply (i.e. its callee is a
-  // function_ref). We also do not handle indirect results currently in the
-  // closure so make sure that does not happen at this point.
+  // function_ref).
   //
   // TODO: We can probably handle other partial applies here.
   auto *FRI = dyn_cast<FunctionRefInst>(Callee);
-  if (!FRI || FRI->getFunctionType()->hasIndirectResults())
+  if (!FRI)
     return false;
 
   // Otherwise, we do support specializing this closure.

--- a/test/SILOptimizer/closure_specialize_simple.sil
+++ b/test/SILOptimizer/closure_specialize_simple.sil
@@ -141,12 +141,12 @@ bb2:
   return %9999 : $()
 }
 
-sil @indirect_parameter_partial_apply_caller6 : $@convention(thin) (@callee_owned () -> ()) -> @out Builtin.Int1 {
-bb0(%1 : $*Builtin.Int1, %0 : $@callee_owned () -> ()):
+sil @indirect_parameter_partial_apply_caller6 : $@convention(thin) (@callee_owned () -> @out Builtin.Int1) -> @out Builtin.Int1 {
+bb0(%1 : $*Builtin.Int1, %0 : $@callee_owned () -> @out Builtin.Int1):
   br bb1
 
 bb1:
-  apply %0() : $@callee_owned () -> ()
+  apply %0(%1) : $@callee_owned () -> @out Builtin.Int1
   cond_br undef, bb1, bb2
 
 bb2:
@@ -154,12 +154,21 @@ bb2:
   return %9999 : $()
 }
 
-sil @indirect_parameter_partial_apply_caller7 : $@convention(thin) (@callee_owned () -> ()) -> @out (Builtin.Int1, Builtin.Int1) {
-bb0(%1 : $*(Builtin.Int1, Builtin.Int1), %0 : $@callee_owned () -> ()):
+sil @indirect_parameter_partial_apply_caller7 : $@convention(thin) (@callee_owned () -> @out Builtin.Int1) -> @out (Builtin.Int1, Builtin.Int1) {
+bb0(%1 : $*(Builtin.Int1, Builtin.Int1), %0 : $@callee_owned () -> @out Builtin.Int1):
   br bb1
 
 bb1:
-  apply %0() : $@callee_owned () -> ()
+  %2 = alloc_stack $Builtin.Int1
+  %3 = alloc_stack $Builtin.Int1
+  apply %0(%2) : $@callee_owned () -> @out Builtin.Int1
+  apply %0(%3) : $@callee_owned () -> @out Builtin.Int1
+  %4 = load %2: $*Builtin.Int1
+  %5 = load %3: $*Builtin.Int1
+  %6 = tuple(%4 : $Builtin.Int1, %5: $Builtin.Int1)
+  store %6 to %1 : $*(Builtin.Int1, Builtin.Int1)
+  dealloc_stack %3: $*Builtin.Int1
+  dealloc_stack %2: $*Builtin.Int1
   cond_br undef, bb1, bb2
 
 bb2:
@@ -174,6 +183,34 @@ bb2:
 // We can't call this one b/c it is just a declaration.
 // CHECK: [[UNSPECIALIZED_FUN_DECL:%.*]] = function_ref @simple_partial_apply_caller_decl : $@convention(thin) (@owned @callee_owned (Builtin.Int1) -> Builtin.Int1) -> Builtin.Int1
 // CHECK: apply [[UNSPECIALIZED_FUN_DECL]]
+
+// We handle closures with indirect results.
+// CHECK: [[CLOSUREFUN:%.*]] = function_ref @indirect_parameter_partial_apply_fun
+// CHECK-NOT: partial_apply [[CLOSUREFUN]]()
+// CHECK: [[INLINEDCLOSURE_CALLER1:%.*]] = function_ref @{{.*}}indirect_parameter_partial_apply_fun__indirect_parameter_partial_apply_caller1
+// CHECK-NOT: partial_apply [[CLOSUREFUN]]()
+
+// We don't handle captured indirect parameters yet.
+// CHECK: [[CLOSURE2:%.*]] = partial_apply [[CLOSUREFUN]](%{{.*}})
+// CHECK: [[CLOSURE3:%.*]] = partial_apply [[CLOSUREFUN]](%{{.*}})
+// CHECK: [[CLOSURE4:%.*]] = partial_apply [[CLOSUREFUN]](%{{.*}})
+
+// CHECK:  [[CALLER1:%.*]] = function_ref @indirect_parameter_partial_apply_caller1
+// CHECK:  [[CALLER2:%.*]] = function_ref @indirect_parameter_partial_apply_caller2
+// CHECK:  [[CALLER3:%.*]] = function_ref @indirect_parameter_partial_apply_caller3
+// CHECK:  [[CALLER4:%.*]] = function_ref @indirect_parameter_partial_apply_caller4
+
+// Closure with indirect result but no captured indirect parameter.
+// CHECK-NOT: apply [[CALLER1]]
+// apply [[INLINEDCLOSURE_CALLER1]]()
+// CHECK-NOT: apply [[CALLER1]]
+
+// Closures with captured indirect parameters.
+// apply [[CALLER2]]([[CLOSURE2]])
+// apply [[CALLER3]]([[CLOSURE3]])
+// apply [[CALLER4]]([[CLOSURE4]])
+
+// CHECK: return
 sil @loop_driver : $@convention(thin) (Builtin.Int1, Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1, %1 : $Builtin.Int1):
   %2 = function_ref @simple_partial_apply_fun : $@convention(thin) (Builtin.Int1, Builtin.Int1) -> Builtin.Int1
@@ -203,16 +240,15 @@ bb0(%0 : $Builtin.Int1, %1 : $Builtin.Int1):
   apply %17(%12) : $@convention(thin) (@callee_owned (@in Builtin.Int1, Builtin.Int1) -> @out Builtin.Int1) -> ()
   apply %18(%13) : $@convention(thin) (@callee_owned (@in Builtin.Int1) -> @out Builtin.Int1) -> ()
   apply %19(%14) : $@convention(thin) (@callee_owned () -> @out Builtin.Int1) -> ()
-  //apply %20(%15) : $@convention(thin) (@callee_owned () -> ()) -> ()
 
   // Make sure we handle when we already have an out parameter correctly.
   %21 = alloc_stack $(Builtin.Int1, Builtin.Int1)
-  %22 = function_ref @indirect_parameter_partial_apply_caller6 : $@convention(thin) (@callee_owned () -> ()) -> @out Builtin.Int1
-  %23 = function_ref @indirect_parameter_partial_apply_caller7 : $@convention(thin) (@callee_owned () -> ()) -> @out (Builtin.Int1, Builtin.Int1)
+  %22 = function_ref @indirect_parameter_partial_apply_caller6 : $@convention(thin) (@callee_owned () -> @out Builtin.Int1) -> @out Builtin.Int1
+  %23 = function_ref @indirect_parameter_partial_apply_caller7 : $@convention(thin) (@callee_owned () -> @out Builtin.Int1) -> @out (Builtin.Int1, Builtin.Int1)
   %24 = partial_apply %10(%9, %1, %9) : $@convention(thin) (@in Builtin.Int1, Builtin.Int1, @in Builtin.Int1) -> @out Builtin.Int1
   %25 = partial_apply %10(%9, %1, %9) : $@convention(thin) (@in Builtin.Int1, Builtin.Int1, @in Builtin.Int1) -> @out Builtin.Int1
-  //apply %22(%9, %24) : $@convention(thin) (@callee_owned () -> ()) -> @out Builtin.Int1
-  //apply %23(%21, %25) : $@convention(thin) (@callee_owned () -> ()) -> @out (Builtin.Int1, Builtin.Int1)
+  apply %22(%9, %24) : $@convention(thin) (@callee_owned () -> @out Builtin.Int1) -> @out Builtin.Int1
+  apply %23(%21, %25) : $@convention(thin) (@callee_owned () -> @out Builtin.Int1) -> @out (Builtin.Int1, Builtin.Int1)
 
   dealloc_stack %21 : $*(Builtin.Int1, Builtin.Int1)
   dealloc_stack %9 : $*Builtin.Int1


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

ClosureSpecializer: Enable specialization of closures with indirect result values

After John's changes that separate parameters from indirect results this just
works.

rdar://26900080
