### PR TITLE
Check for lazy signature resolution failure when deciding overloadabi…

### DIFF
--- a/lib/AST/ModuleNameLookup.cpp
+++ b/lib/AST/ModuleNameLookup.cpp
@@ -108,10 +108,13 @@ static ResolutionKind recordImportDecls(LazyResolver *typeResolver,
     std::copy_if(newDecls.begin(), newDecls.end(), std::back_inserter(results),
                  [&](ValueDecl *result) -> bool {
       if (!result->hasType()) {
-        if (typeResolver)
+        if (typeResolver) {
           typeResolver->resolveDeclSignature(result);
-        else
+          if (result->isInvalid())
+            return true;
+        } else {
           return true;
+        }
       }
       return isValidOverload(overloads, result);
     });

--- a/validation-test/compiler_crashers_fixed/28295-swift-namelookup-lookupvisibledeclsinmodule.swift
+++ b/validation-test/compiler_crashers_fixed/28295-swift-namelookup-lookupvisibledeclsinmodule.swift
@@ -5,6 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
 struct a{var f={H:{}}}init


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

A bugfix to lazy symbol lookup that fixes a compiler crasher arising from typo correction.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…lity.
