### PR TITLE
Cache the previous result of IRGenDebugInfo::createInlinedAt().

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.h
+++ b/lib/IRGen/IRGenDebugInfo.h
@@ -67,6 +67,8 @@ class IRGenDebugInfo {
   llvm::DenseMap<TypeBase *, llvm::TrackingMDNodeRef> DITypeCache;
   llvm::StringMap<llvm::TrackingMDNodeRef> DIModuleCache;
   TrackingDIRefMap DIRefMap;
+  std::vector<std::pair<const SILDebugScope *, llvm::TrackingMDNodeRef>>
+      LastInlineChain;
 
   llvm::BumpPtrAllocator DebugInfoNames;
   StringRef CWDName;                    /// The current working directory.


### PR DESCRIPTION
This saves ~4 seconds of a -r --no-assertions stdlib build and lowers
the contribution of llvm::SourceMgr::getLineAndColumn() to the total
runtime from 6% to 2%.

rdar://problem/27016577
