### PR TITLE
[stdlib] Remove _StringCore from UnicodeScalarIndex

### DIFF
--- a/stdlib/public/SDK/Foundation/NSStringAPI.swift
+++ b/stdlib/public/SDK/Foundation/NSStringAPI.swift
@@ -96,7 +96,10 @@ extension String {
   /// Return an `Index` corresponding to the given offset in our UTF-16
   /// representation.
   func _index(_ utf16Index: Int) -> Index {
-    return Index(_base: String.UnicodeScalarView.Index(utf16Index, _core))
+    return Index(
+      _base: String.UnicodeScalarView.Index(_position: utf16Index),
+      in: characters
+    )
   }
 
   /// Return a `Range<Index>` corresponding to the given `NSRange` of

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -156,10 +156,9 @@ extension String.CharacterView : BidirectionalCollection {
   ///     // Prints "[72, 101, 97, 114, 116, 115]"
   public struct Index : Comparable, CustomPlaygroundQuickLookable {
     public // SPI(Foundation)    
-    init(_base: String.UnicodeScalarView.Index) {
+    init(_base: String.UnicodeScalarView.Index, in c: String.CharacterView) {
       self._base = _base
-      self._countUTF16 =
-          Index._measureExtendedGraphemeClusterForward(from: _base)
+      self._countUTF16 = c._measureExtendedGraphemeClusterForward(from: _base)
     }
 
     internal init(_base: UnicodeScalarView.Index, _countUTF16: Int) {
@@ -181,88 +180,7 @@ extension String.CharacterView : BidirectionalCollection {
     /// The one past end index for this extended grapheme cluster in Unicode
     /// scalars.
     internal var _endBase: UnicodeScalarView.Index {
-      return UnicodeScalarView.Index(
-          _utf16Index + _countUTF16, _base._core)
-    }
-
-    /// Returns the length of the first extended grapheme cluster in UTF-16
-    /// code units.
-    @inline(never)
-    internal static func _measureExtendedGraphemeClusterForward(
-        from start: UnicodeScalarView.Index
-    ) -> Int {
-      var start = start
-      let end = start._viewEndIndex
-      if start == end {
-        return 0
-      }
-
-      let startIndexUTF16 = start._position
-      let unicodeScalars = UnicodeScalarView(start._core)
-      let graphemeClusterBreakProperty =
-          _UnicodeGraphemeClusterBreakPropertyTrie()
-      let segmenter = _UnicodeExtendedGraphemeClusterSegmenter()
-
-      var gcb0 = graphemeClusterBreakProperty.getPropertyRawValue(
-          unicodeScalars[start].value)
-      unicodeScalars.formIndex(after: &start)
-
-      while start != end {
-        // FIXME(performance): consider removing this "fast path".  A branch
-        // that is hard to predict could be worse for performance than a few
-        // loads from cache to fetch the property 'gcb1'.
-        if segmenter.isBoundaryAfter(gcb0) {
-          break
-        }
-        let gcb1 = graphemeClusterBreakProperty.getPropertyRawValue(
-            unicodeScalars[start].value)
-        if segmenter.isBoundary(gcb0, gcb1) {
-          break
-        }
-        gcb0 = gcb1
-        unicodeScalars.formIndex(after: &start)
-      }
-
-      return start._position - startIndexUTF16
-    }
-
-    /// Returns the length of the previous extended grapheme cluster in UTF-16
-    /// code units.
-    @inline(never)
-    internal static func _measureExtendedGraphemeClusterBackward(
-        from end: UnicodeScalarView.Index
-    ) -> Int {
-      let start = end._viewStartIndex
-      if start == end {
-        return 0
-      }
-
-      let endIndexUTF16 = end._position
-      let unicodeScalars = UnicodeScalarView(start._core)
-      let graphemeClusterBreakProperty =
-          _UnicodeGraphemeClusterBreakPropertyTrie()
-      let segmenter = _UnicodeExtendedGraphemeClusterSegmenter()
-
-      var graphemeClusterStart = end
-
-      unicodeScalars.formIndex(before: &graphemeClusterStart)
-      var gcb0 = graphemeClusterBreakProperty.getPropertyRawValue(
-          unicodeScalars[graphemeClusterStart].value)
-
-      var graphemeClusterStartUTF16 = graphemeClusterStart._position
-
-      while graphemeClusterStart != start {
-        unicodeScalars.formIndex(before: &graphemeClusterStart)
-        let gcb1 = graphemeClusterBreakProperty.getPropertyRawValue(
-            unicodeScalars[graphemeClusterStart].value)
-        if segmenter.isBoundary(gcb1, gcb0) {
-          break
-        }
-        gcb0 = gcb1
-        graphemeClusterStartUTF16 = graphemeClusterStart._position
-      }
-
-      return endIndexUTF16 - graphemeClusterStartUTF16
+      return UnicodeScalarView.Index(_position: _utf16Index + _countUTF16)
     }
 
     public var customPlaygroundQuickLook: PlaygroundQuickLook {
@@ -276,7 +194,7 @@ extension String.CharacterView : BidirectionalCollection {
   /// 
   /// In an empty character view, `startIndex` is equal to `endIndex`.
   public var startIndex: Index {
-    return Index(_base: unicodeScalars.startIndex)
+    return Index(_base: unicodeScalars.startIndex, in: self)
   }
 
   /// A character view's "past the end" position---that is, the position one
@@ -284,31 +202,116 @@ extension String.CharacterView : BidirectionalCollection {
   ///
   /// In an empty character view, `endIndex` is equal to `startIndex`.
   public var endIndex: Index {
-    return Index(_base: unicodeScalars.endIndex)
+    return Index(_base: unicodeScalars.endIndex, in: self)
   }
 
   /// Returns the next consecutive position after `i`.
   ///
   /// - Precondition: The next position is valid.
   public func index(after i: Index) -> Index {
-    _precondition(i._base != i._base._viewEndIndex, "cannot increment endIndex")
-    return Index(_base: i._endBase)
+    _precondition(i._base < unicodeScalars.endIndex,
+      "cannot increment beyond endIndex")
+    _precondition(i._base >= unicodeScalars.startIndex,
+      "cannot increment invalid index")
+    return Index(_base: i._endBase, in: self)
   }
 
   /// Returns the previous consecutive position before `i`.
   ///
   /// - Precondition: The previous position is valid.
   public func index(before i: Index) -> Index {
-    // FIXME: swift-3-indexing-model: range check i?
-    _precondition(i._base != i._base._viewStartIndex,
-        "cannot decrement startIndex")
+    _precondition(i._base > unicodeScalars.startIndex,
+      "cannot decrement before startIndex")
+    _precondition(i._base <= unicodeScalars.endIndex,
+      "cannot decrement invalid index")
     let predecessorLengthUTF16 =
-        Index._measureExtendedGraphemeClusterBackward(from: i._base)
+      _measureExtendedGraphemeClusterBackward(from: i._base)
     return Index(
       _base: UnicodeScalarView.Index(
-        i._utf16Index - predecessorLengthUTF16, i._base._core))
+        _position: i._utf16Index - predecessorLengthUTF16
+      ),
+      in: self
+    )
   }
 
+  /// Returns the length of the first extended grapheme cluster in UTF-16
+  /// code units.
+  @inline(never)
+  internal func _measureExtendedGraphemeClusterForward(
+    from start: UnicodeScalarView.Index
+  ) -> Int {
+    var start = start
+    let end = UnicodeScalarView.Index(_position: _core.count)
+    if start == end {
+      return 0
+    }
+    
+    let startIndexUTF16 = start._position
+    let graphemeClusterBreakProperty =
+      _UnicodeGraphemeClusterBreakPropertyTrie()
+    let segmenter = _UnicodeExtendedGraphemeClusterSegmenter()
+    
+    var gcb0 = graphemeClusterBreakProperty.getPropertyRawValue(
+      unicodeScalars[start].value)
+    unicodeScalars.formIndex(after: &start)
+    
+    while start != end {
+      // FIXME(performance): consider removing this "fast path".  A branch
+      // that is hard to predict could be worse for performance than a few
+      // loads from cache to fetch the property 'gcb1'.
+      if segmenter.isBoundaryAfter(gcb0) {
+        break
+      }
+      let gcb1 = graphemeClusterBreakProperty.getPropertyRawValue(
+        unicodeScalars[start].value)
+      if segmenter.isBoundary(gcb0, gcb1) {
+        break
+      }
+      gcb0 = gcb1
+      unicodeScalars.formIndex(after: &start)
+    }
+    
+    return start._position - startIndexUTF16
+  }
+  
+  /// Returns the length of the previous extended grapheme cluster in UTF-16
+  /// code units.
+  @inline(never)
+  internal func _measureExtendedGraphemeClusterBackward(
+    from end: UnicodeScalarView.Index
+  ) -> Int {
+    let start = UnicodeScalarView.Index(_position: 0)
+    if start == end {
+      return 0
+    }
+    
+    let endIndexUTF16 = end._position
+    let graphemeClusterBreakProperty =
+      _UnicodeGraphemeClusterBreakPropertyTrie()
+    let segmenter = _UnicodeExtendedGraphemeClusterSegmenter()
+    
+    var graphemeClusterStart = end
+    
+    unicodeScalars.formIndex(before: &graphemeClusterStart)
+    var gcb0 = graphemeClusterBreakProperty.getPropertyRawValue(
+      unicodeScalars[graphemeClusterStart].value)
+    
+    var graphemeClusterStartUTF16 = graphemeClusterStart._position
+    
+    while graphemeClusterStart != start {
+      unicodeScalars.formIndex(before: &graphemeClusterStart)
+      let gcb1 = graphemeClusterBreakProperty.getPropertyRawValue(
+        unicodeScalars[graphemeClusterStart].value)
+      if segmenter.isBoundary(gcb1, gcb0) {
+        break
+      }
+      gcb0 = gcb1
+      graphemeClusterStartUTF16 = graphemeClusterStart._position
+    }
+    
+    return endIndexUTF16 - graphemeClusterStartUTF16
+  }
+  
   /// Accesses the character at the given position.
   ///
   /// The following example searches a string's character view for a capital

--- a/stdlib/public/core/StringIndexConversions.swift
+++ b/stdlib/public/core/StringIndexConversions.swift
@@ -48,10 +48,10 @@ extension String.Index {
     _ unicodeScalarIndex: String.UnicodeScalarIndex,
     within other: String
   ) {
-    if !unicodeScalarIndex._isOnGraphemeClusterBoundary {
+    if !other.unicodeScalars._isOnGraphemeClusterBoundary(unicodeScalarIndex) {
       return nil
     }
-    self.init(_base: unicodeScalarIndex)
+    self.init(_base: unicodeScalarIndex, in: other.characters)
   }
 
   /// Creates an index in the given string that corresponds exactly to the

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -115,23 +115,12 @@ extension String {
     ///     print(hearts.unicodeScalars[j].value)
     ///     // Prints "9829"
     public struct Index : Comparable {
-      public init(_ _position: Int, _ _core: _StringCore) {
+      public // SPI(Foundation)
+      init(_position: Int) {
         self._position = _position
-        self._core = _core
-      }
-
-      /// The end index that for this view.
-      internal var _viewStartIndex: Index {
-        return Index(_core.startIndex, _core)
-      }
-
-      /// The end index that for this view.
-      internal var _viewEndIndex: Index {
-        return Index(_core.endIndex, _core)
       }
 
       @_versioned internal var _position: Int
-      @_versioned internal var _core: _StringCore
     }
 
     /// The position of the first Unicode scalar value if the string is
@@ -139,7 +128,7 @@ extension String {
     ///
     /// If the string is empty, `startIndex` is equal to `endIndex`.
     public var startIndex: Index {
-      return Index(_core.startIndex, _core)
+      return Index(_position: _core.startIndex)
     }
 
     /// The "past the end" position---that is, the position one greater than
@@ -147,7 +136,7 @@ extension String {
     ///
     /// In an empty Unicode scalars view, `endIndex` is equal to `startIndex`.
     public var endIndex: Index {
-      return Index(_core.endIndex, _core)
+      return Index(_position: _core.endIndex)
     }
 
     /// Returns the next consecutive location after `i`.
@@ -157,21 +146,21 @@ extension String {
       var scratch = _ScratchIterator(_core, i._position)
       var decoder = UTF16()
       let (_, length) = decoder._decodeOne(&scratch)
-      return Index(i._position + length, _core)
+      return Index(_position: i._position + length)
     }
 
     /// Returns the previous consecutive location before `i`.
     ///
     /// - Precondition: The previous location exists.
     public func index(before i: Index) -> Index {
-      var i = i._position-1
+      var i = i._position - 1
       let codeUnit = _core[i]
       if _slowPath((codeUnit >> 10) == 0b1101_11) {
         if i != 0 && (_core[i - 1] >> 10) == 0b1101_10 {
           i -= 1
         }
       }
-      return Index(i, _core)
+      return Index(_position: i)
     }
 
     /// Accesses the Unicode scalar value at the given position.
@@ -455,7 +444,7 @@ extension String.UnicodeScalarIndex {
         return nil
       }
     }
-    self.init(utf16Index._offset, unicodeScalars._core)
+    self.init(_position: utf16Index._offset)
   }
 
   /// Creates an index in the given Unicode scalars view that corresponds
@@ -485,7 +474,7 @@ extension String.UnicodeScalarIndex {
     if !utf8Index._isOnUnicodeScalarBoundary {
       return nil
     }
-    self.init(utf8Index._coreIndex, core)
+    self.init(_position: utf8Index._coreIndex)
   }
 
   /// Creates an index in the given Unicode scalars view that corresponds
@@ -510,7 +499,7 @@ extension String.UnicodeScalarIndex {
     _ characterIndex: String.Index,
     within unicodeScalars: String.UnicodeScalarView
   ) {
-    self.init(characterIndex._base._position, unicodeScalars._core)
+    self.init(_position: characterIndex._base._position)
   }
 
   /// Returns the position in the given UTF-8 view that corresponds exactly to
@@ -581,13 +570,14 @@ extension String.UnicodeScalarIndex {
   public func samePosition(in characters: String) -> String.Index? {
     return String.Index(self, within: characters)
   }
+}
 
-  internal var _isOnGraphemeClusterBoundary: Bool {
-    let scalars = String.UnicodeScalarView(_core)
-    if self == scalars.startIndex || self == scalars.endIndex {
+extension String.UnicodeScalarView {
+  internal func _isOnGraphemeClusterBoundary(_ i: Index) -> Bool {
+    if i == startIndex || i == endIndex {
       return true
     }
-    let precedingScalar = scalars[scalars.index(before: self)]
+    let precedingScalar = self[index(before: i)]
 
     let graphemeClusterBreakProperty =
       _UnicodeGraphemeClusterBreakPropertyTrie()
@@ -600,8 +590,7 @@ extension String.UnicodeScalarIndex {
       return true
     }
 
-    let gcb1 = graphemeClusterBreakProperty.getPropertyRawValue(
-      scalars[self].value)
+    let gcb1 = graphemeClusterBreakProperty.getPropertyRawValue(self[i].value)
 
     return segmenter.isBoundary(gcb0, gcb1)
   }

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -202,7 +202,7 @@ StringTests.test("ForeignIndexes/subscript(Index)/OutOfBoundsTrap") {
 
   let i = donor.index(_nth: 3)
   expectCrashLater()
-  acceptor[i]
+  _ = acceptor[i]
 }
 
 StringTests.test("String/subscript(_:Range)") {
@@ -229,7 +229,7 @@ StringTests.test("ForeignIndexes/subscript(Range)/OutOfBoundsTrap/1") {
 
   let r = donor.startIndex..<donor.index(_nth: 4)
   expectCrashLater()
-  acceptor[r]
+  _ = acceptor[r]
 }
 
 StringTests.test("ForeignIndexes/subscript(Range)/OutOfBoundsTrap/2") {
@@ -240,7 +240,7 @@ StringTests.test("ForeignIndexes/subscript(Range)/OutOfBoundsTrap/2") {
 
   let r = donor.index(_nth: 4)..<donor.index(_nth: 5)
   expectCrashLater()
-  acceptor[r]
+  _ = acceptor[r]
 }
 
 StringTests.test("ForeignIndexes/replaceSubrange/OutOfBoundsTrap/1") {
@@ -497,9 +497,7 @@ StringTests.test("COW/removeSubrange/start") {
 
     // No more reallocations are expected.
     str.removeSubrange(str.startIndex..<str.index(_nth: 1))
-    // FIXME: extra reallocation, should be expectEqual()
-    expectNotEqual(heapStrIdentity, str.bufferID)
-    // end FIXME
+    expectEqual(heapStrIdentity, str.bufferID)
     expectEqual(literalIdentity, slice.bufferID)
     expectEqual("345678", str)
     expectEqual("12345678", slice)
@@ -526,9 +524,7 @@ StringTests.test("COW/removeSubrange/start") {
 
     // No more reallocations are expected.
     str.removeSubrange(str.startIndex..<str.index(_nth: 1))
-    // FIXME: extra reallocation, should be expectEqual()
-    expectNotEqual(heapStrIdentity2, str.bufferID)
-    // end FIXME
+    expectEqual(heapStrIdentity2, str.bufferID)
     expectEqual(heapStrIdentity1, slice.bufferID)
     expectEqual("5678", str)
     expectEqual("345678", slice)
@@ -559,9 +555,7 @@ StringTests.test("COW/removeSubrange/end") {
     // No more reallocations are expected.
     str.append(UnicodeScalar("x"))
     str.removeSubrange(str.index(_nthLast: 1)..<str.endIndex)
-    // FIXME: extra reallocation, should be expectEqual()
-    expectNotEqual(heapStrIdentity, str.bufferID)
-    // end FIXME
+    expectEqual(heapStrIdentity, str.bufferID)
     expectEqual(literalIdentity, slice.bufferID)
     expectEqual("1234567", str)
     expectEqual("12345678", slice)
@@ -569,9 +563,7 @@ StringTests.test("COW/removeSubrange/end") {
     str.removeSubrange(str.index(_nthLast: 1)..<str.endIndex)
     str.append(UnicodeScalar("x"))
     str.removeSubrange(str.index(_nthLast: 1)..<str.endIndex)
-    // FIXME: extra reallocation, should be expectEqual()
-    //expectNotEqual(heapStrIdentity, str.bufferID)
-    // end FIXME
+    expectEqual(heapStrIdentity, str.bufferID)
     expectEqual(literalIdentity, slice.bufferID)
     expectEqual("123456", str)
     expectEqual("12345678", slice)
@@ -599,9 +591,7 @@ StringTests.test("COW/removeSubrange/end") {
     // No more reallocations are expected.
     str.append(UnicodeScalar("x"))
     str.removeSubrange(str.index(_nthLast: 1)..<str.endIndex)
-    // FIXME: extra reallocation, should be expectEqual()
-    expectNotEqual(heapStrIdentity, str.bufferID)
-    // end FIXME
+    expectEqual(heapStrIdentity, str.bufferID)
     expectEqual(heapStrIdentity1, slice.bufferID)
     expectEqual("12345", str)
     expectEqual("123456", slice)
@@ -609,9 +599,7 @@ StringTests.test("COW/removeSubrange/end") {
     str.removeSubrange(str.index(_nthLast: 1)..<str.endIndex)
     str.append(UnicodeScalar("x"))
     str.removeSubrange(str.index(_nthLast: 1)..<str.endIndex)
-    // FIXME: extra reallocation, should be expectEqual()
-    //expectNotEqual(heapStrIdentity, str.bufferID)
-    // end FIXME
+    expectEqual(heapStrIdentity, str.bufferID)
     expectEqual(heapStrIdentity1, slice.bufferID)
     expectEqual("1234", str)
     expectEqual("123456", slice)
@@ -634,16 +622,14 @@ StringTests.test("COW/replaceSubrange/end") {
     slice.replaceSubrange(slice.endIndex..<slice.endIndex, with: "a")
     expectNotEqual(literalIdentity, slice.bufferID)
     expectEqual(literalIdentity, str.bufferID)
-    let heapStrIdentity = str.bufferID
+    let heapStrIdentity = slice.bufferID
     expectEqual("1234567a", slice)
     expectEqual("12345678", str)
 
     // No more reallocations are expected.
     slice.replaceSubrange(
       slice.index(_nthLast: 1)..<slice.endIndex, with: "b")
-    // FIXME: extra reallocation, should be expectEqual()
-    expectNotEqual(heapStrIdentity, slice.bufferID)
-    // end FIXME
+    expectEqual(heapStrIdentity, slice.bufferID)
     expectEqual(literalIdentity, str.bufferID)
 
     expectEqual("1234567b", slice)
@@ -675,9 +661,7 @@ StringTests.test("COW/replaceSubrange/end") {
     // No more reallocations are expected.
     slice.replaceSubrange(
       slice.index(_nthLast: 1)..<slice.endIndex, with: "b")
-    // FIXME: extra reallocation, should be expectEqual()
-    expectNotEqual(heapStrIdentity2, slice.bufferID)
-    // end FIXME
+    expectEqual(heapStrIdentity2, slice.bufferID)
     expectEqual(heapStrIdentity1, str.bufferID)
 
     expectEqual("1234567b", slice)


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

This removes the `_core` property from `UnicodeScalarView.Index` and moves any remaining index-moving logic from the index layer to the view layer in `UnicodeScalarView` and `CharacterView`, which relies on `UnicodeScalarView.Index`. This fixes an extra reallocation, so the CoW test is updated too.

This doesn't address the index-sharing issues but should simplify the resolution of that issue.
#### Resolved bug number: n/a

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
