### PR TITLE
stdlib: Fix lifetime issues in ManagedBuffer.value

### DIFF
--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -120,11 +120,15 @@ public class ManagedBuffer<Value, Element>
 
   /// The stored `Value` instance.
   public final var value: Value {
-    unsafeAddress {
-      return ManagedBufferPointer(self).withUnsafeMutablePointerToValue { UnsafePointer($0) }
+    addressWithNativeOwner {
+      return (
+        ManagedBufferPointer(self).withUnsafeMutablePointerToValue { UnsafePointer($0) },
+        Builtin.castToNativeObject(self))
     }
-    unsafeMutableAddress {
-      return ManagedBufferPointer(self).withUnsafeMutablePointerToValue { $0 }
+    mutableAddressWithNativeOwner {
+      return (
+        ManagedBufferPointer(self).withUnsafeMutablePointerToValue { $0 },
+        Builtin.castToNativeObject(self))
     }
   }
 }
@@ -229,11 +233,11 @@ public struct ManagedBufferPointer<Value, Element> : Equatable {
 
   /// The stored `Value` instance.
   public var value: Value {
-    unsafeAddress {
-      return UnsafePointer(_valuePointer)
+    addressWithNativeOwner {
+      return (UnsafePointer(_valuePointer), _nativeBuffer)
     }
-    unsafeMutableAddress {
-      return _valuePointer
+    mutableAddressWithNativeOwner {
+      return (_valuePointer, _nativeBuffer)
     }
   }
 


### PR DESCRIPTION
This property had unsafe addressors, but there was nothing that kept the memory owner (the `self` reference) alive.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
