### PR TITLE
[swiftc] Add 💥 case (😢 → 52, 😀 → 5094) triggered in swift::ArchetypeBuilder::addRequirement(…)

### DIFF
--- a/validation-test/compiler_crashers/28336-swift-archetypebuilder-addrequirement.swift
+++ b/validation-test/compiler_crashers/28336-swift-archetypebuilder-addrequirement.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+func b<b{class a<f{func a{struct d<f:a{func g:b{c


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Add crash case with stack trace:

```
swift: /path/to/swift/lib/AST/ArchetypeBuilder.cpp:1476: void swift::ArchetypeBuilder::addRequirement(const swift::Requirement &, swift::RequirementSource): Assertion `pa && "Re-introducing invalid requirement"' failed.
8  swift           0x0000000000fee5fb swift::ArchetypeBuilder::addRequirement(swift::Requirement const&, swift::RequirementSource) + 667
9  swift           0x0000000000ff01c3 swift::ArchetypeBuilder::addGenericSignature(swift::GenericSignature*, bool, bool) + 515
10 swift           0x0000000000ffcc45 swift::ASTContext::getOrCreateArchetypeBuilder(swift::CanGenericSignature, swift::ModuleDecl*) + 181
11 swift           0x00000000010e693b swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 43
12 swift           0x000000000111b56d swift::TypeBase::getCanonicalType() + 1421
17 swift           0x00000000010e9f26 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 1174
18 swift           0x0000000000eefd44 swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) + 260
19 swift           0x0000000000e998c9 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 3881
21 swift           0x0000000001066c43 swift::Expr::walk(swift::ASTWalker&) + 19
22 swift           0x0000000000e9a150 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 224
23 swift           0x0000000000ea0b22 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
26 swift           0x0000000000f1888a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
27 swift           0x0000000000f186ee swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
28 swift           0x0000000000f192b3 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
30 swift           0x0000000000ed4851 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
31 swift           0x0000000000c62209 swift::CompilerInstance::performSema() + 3289
33 swift           0x00000000007d89b9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
34 swift           0x00000000007a49f8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28336-swift-archetypebuilder-addrequirement.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28336-swift-archetypebuilder-addrequirement-728e64.o
1.  While type-checking 'g' at validation-test/compiler_crashers/28336-swift-archetypebuilder-addrequirement.swift:10:40
2.  While type-checking expression at [validation-test/compiler_crashers/28336-swift-archetypebuilder-addrequirement.swift:10:49 - line:10:49] RangeText="c"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
