### PR TITLE
Change value of Float.pi so that it's rounded down

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -122,6 +122,9 @@ public protocol FloatingPoint: Comparable, IntegerLiteralConvertible,
 
   /// The mathematical constant pi = 3.14159...
   ///
+  /// This value should be rounded towards zero to keep user computations
+  /// with angles from inadvertently ending up in the wrong quadrant.
+  ///
   /// Extensible floating-point types might provide additional APIs to obtain
   /// this value to caller-specified precision.
   static var pi: Self { get }

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -341,7 +341,12 @@ extension ${Self}: BinaryFloatingPoint {
 
   public static var pi: ${Self} {
 %if bits == 32:
-    return Float(0x1.921fb6p1)
+    // Note: this is not the correctly-rounded (to nearest) value of pi,
+    // because pi would round *up* in Float precision, which can result
+    // in angles in the wrong quadrant if users aren't careful.  This is
+    // not a problem for Double or Float80, as pi rounds down in both of
+    // those formats.
+    return Float(0x1.921fb4p1)
 %elif bits == 64:
     return Double(0x1.921fb54442d18p1)
 %elif bits == 80:

--- a/test/1_stdlib/FloatingPoint.swift.gyb
+++ b/test/1_stdlib/FloatingPoint.swift.gyb
@@ -104,7 +104,7 @@ FloatingPoint.test("Float/staticProperties") {
   expectBitwiseEqual(bitPattern: 0x7fa0_0000, Ty.signalingNaN)
   expectBitwiseEqual(bitPattern: 0x7f80_0000, Ty.infinity)
   expectBitwiseEqual(0x1.ffff_fe__p127, Ty.greatestFiniteMagnitude)
-  expectBitwiseEqual(0x1.921f_b6__p1, Ty.pi)
+  expectBitwiseEqual(0x1.921f_b4__p1, Ty.pi)
   expectBitwiseEqual(0x1.0p-23, Ty.ulpOfOne)
   expectBitwiseEqual(0x1.0p-126, Ty.leastNormalMagnitude)
 #if arch(arm)


### PR DESCRIPTION
#### Change value of `Float.pi` so that it's in [0,pi)

This pull request bumps `Float.pi` down by one ulp so that it is strictly smaller than the mathematical value of pi (this is already the case for Double and Float80).  This makes the representation error of this value a tiny bit bigger, but helps prevent user computations with angles from going out of range.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

… that angles computed via trigonometry end up in the correct quadrant.
