### PR TITLE
[swiftc] Add 💥 case (😢 → 53, 😀 → 5094) triggered in swift::TypeBase::getCanonicalType(…)

### DIFF
--- a/validation-test/compiler_crashers/28337-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28337-swift-typebase-getcanonicaltype.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+{
+class a{protocol A{
+}class d
+class C<c:A{
+class A:d{deinit{


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Add crash case with stack trace:

```
4  swift           0x000000000111aff4 swift::TypeBase::getCanonicalType() + 20
5  swift           0x0000000001133a7d swift::ConformanceLookupTable::getConformance(swift::NominalTypeDecl*, swift::LazyResolver*, swift::ConformanceLookupTable::ConformanceEntry*) + 301
7  swift           0x0000000001134194 swift::ConformanceLookupTable::lookupConformances(swift::NominalTypeDecl*, swift::DeclContext*, swift::LazyResolver*, swift::ConformanceLookupKind, llvm::SmallVectorImpl<swift::ProtocolDecl*>*, llvm::SmallVectorImpl<swift::ProtocolConformance*>*, llvm::SmallVectorImpl<swift::ConformanceDiagnostic>*) + 692
8  swift           0x00000000011167e4 swift::DeclContext::getLocalConformances(swift::ConformanceLookupKind, llvm::SmallVectorImpl<swift::ConformanceDiagnostic>*, bool) const + 212
9  swift           0x0000000000ef996e swift::TypeChecker::checkConformancesInContext(swift::DeclContext*, swift::IterableDeclContext*) + 334
16 swift           0x0000000000eb25a6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
19 swift           0x0000000000f19c04 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
20 swift           0x0000000000f45a2c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
21 swift           0x0000000000ea0bc1 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 769
23 swift           0x0000000000f19d46 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
24 swift           0x0000000000ed47bd swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
25 swift           0x0000000000c62209 swift::CompilerInstance::performSema() + 3289
27 swift           0x00000000007d89b9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
28 swift           0x00000000007a49f8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28337-swift-typebase-getcanonicaltype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28337-swift-typebase-getcanonicaltype-1d42b8.o
1.  While type-checking expression at [validation-test/compiler_crashers/28337-swift-typebase-getcanonicaltype.swift:9:1 - line:13:17] RangeText="{
2.  While type-checking 'a' at validation-test/compiler_crashers/28337-swift-typebase-getcanonicaltype.swift:10:1
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
