### PR TITLE
Initial 'id as Any' Clang importer implementation

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -402,6 +402,9 @@ public:
   /// hasReferenceSemantics() - Do objects of this type have reference
   /// semantics?
   bool hasReferenceSemantics();
+  
+  /// Is this the 'Any' type?
+  bool isAny();
 
   /// Are values of this type essentially just class references,
   /// possibly with some sort of additional information?

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -157,6 +157,9 @@ namespace swift {
     /// Whether we are stripping the "NS" prefix from Foundation et al.
     bool StripNSPrefix = true;
 
+    /// Should 'id' in Objective-C be imported as 'Any' in Swift?
+    bool EnableIdAsAny = false;
+
     /// Enable the Swift 3 migration via Fix-Its.
     bool Swift3Migration = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -347,5 +347,8 @@ def group_info_path : Separate<["-"], "group-info-path">,
 
 def enable_protocol_typealiases: Flag<["-"], "enable-protocol-typealiases">,
   HelpText<"Enable typealiases inside protocol declarations">;
+  
+def enable_id_as_any: Flag<["-"], "enable-id-as-any">,
+  HelpText<"Enable importing ObjC 'id' as Swift 'Any' type">;
 
 } // end let Flags = [FrontendOption, NoDriverOption, HelpHidden]

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -89,6 +89,14 @@ bool TypeBase::hasReferenceSemantics() {
   return getCanonicalType().hasReferenceSemantics();
 }
 
+bool TypeBase::isAny() {
+  if (auto comp = getAs<ProtocolCompositionType>())
+    if (comp->getProtocols().empty())
+      return true;
+  
+  return false;
+}
+
 bool TypeBase::isAnyClassReferenceType() {
   return getCanonicalType().isAnyClassReferenceType();
 }
@@ -1953,9 +1961,8 @@ getObjCObjectRepresentable(Type type, const DeclContext *dc) {
   
   // Any can be bridged to id.
   if (type->getASTContext().LangOpts.EnableIdAsAny) {
-    if (auto protoCompTy = type->getAs<ProtocolCompositionType>()) {
-      if (protoCompTy->getProtocols().empty())
-        return ForeignRepresentableKind::Bridged;
+    if (type->isAny()) {
+      return ForeignRepresentableKind::Bridged;
     }
   }
   

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1951,6 +1951,14 @@ getObjCObjectRepresentable(Type type, const DeclContext *dc) {
   if (type->isObjCExistentialType())
     return ForeignRepresentableKind::Object;
   
+  // Any can be bridged to id.
+  if (type->getASTContext().LangOpts.EnableIdAsAny) {
+    if (auto protoCompTy = type->getAs<ProtocolCompositionType>()) {
+      if (protoCompTy->getProtocols().empty())
+        return ForeignRepresentableKind::Bridged;
+    }
+  }
+  
   // Class-constrained generic parameters, from ObjC generic classes.
   if (auto tyContext = dc->getInnermostTypeContext())
     if (auto clas = tyContext->getAsClassOrClassExtensionContext())

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1500,6 +1500,16 @@ namespace {
 
       Type SwiftType;
       if (Decl->getDeclContext()->getRedeclContext()->isTranslationUnit()) {
+        // Ignore the 'id' typedef. We want to bridge the underlying
+        // ObjCId type.
+        //
+        // When we remove the EnableIdAsAny staging flag, the 'id' entry
+        // should be removed from MappedTypes.def, and this conditional should
+        // become unnecessary.
+        if (Name.str() == "id" && Impl.SwiftContext.LangOpts.EnableIdAsAny) {
+          return nullptr;
+        }
+      
         bool IsError;
         StringRef StdlibTypeName;
         MappedTypeNameKind NameMapping;

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -926,9 +926,15 @@ namespace {
       if (!proto)
         return Type();
 
-      // id maps to AnyObject.
+      // id maps to Any in bridgeable contexts, AnyObject otherwise.
       if (type->isObjCIdType()) {
-        return { proto->getDeclaredType(), ImportHint::ObjCPointer };
+        if (Impl.SwiftContext.LangOpts.EnableIdAsAny) {
+          return { proto->getDeclaredType(),
+                 ImportHint(ImportHint::ObjCBridged,
+                         ProtocolCompositionType::get(Impl.SwiftContext, {})) };
+        } else {
+          return { proto->getDeclaredType(), ImportHint::ObjCPointer };
+        }
       }
 
       // Class maps to AnyObject.Type.

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1213,9 +1213,13 @@ static Type adjustTypeForConcreteImport(ClangImporter::Implementation &impl,
 
   // If we have a bridged Objective-C type and we are allowed to
   // bridge, do so.
-  if (hint == ImportHint::ObjCBridged && canBridgeTypes(importKind) &&
-      (impl.tryLoadFoundationModule() || impl.ImportForwardDeclarations))
-    importedType = hint.BridgedType;
+  if (hint == ImportHint::ObjCBridged && canBridgeTypes(importKind))
+    // id and Any can be bridged without Foundation. There would be
+    // bootstrapping issues with the ObjectiveC module otherwise.
+    if (hint.BridgedType->isAny()
+        || impl.tryLoadFoundationModule()
+        || impl.ImportForwardDeclarations)
+      importedType = hint.BridgedType;
 
   if (!importedType)
     return importedType;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -776,6 +776,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.EnableThrowWithoutTry |= Args.hasArg(OPT_enable_throw_without_try);
   Opts.EnableProtocolTypealiases |= Args.hasArg(OPT_enable_protocol_typealiases);
+  Opts.EnableIdAsAny |= Args.hasArg(OPT_enable_id_as_any);
 
   if (auto A = Args.getLastArg(OPT_enable_objc_attr_requires_foundation_module,
                                OPT_disable_objc_attr_requires_foundation_module)) {

--- a/test/ClangModules/objc_id_as_any.swift
+++ b/test/ClangModules/objc_id_as_any.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse -verify -enable-id-as-any %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+func assertTypeIsAny(_: Any.Protocol) {}
+func staticType<T>(_: T) -> T.Type { return T.self }
+
+let idLover = IdLover()
+
+let t1 = staticType(idLover.makesId())
+assertTypeIsAny(t1)
+
+struct ArbitraryThing {}
+idLover.takesId(ArbitraryThing())
+
+var x: AnyObject = NSObject()
+idLover.takesArray(ofId: &x)
+var y: Any = NSObject()
+idLover.takesArray(ofId: &y) // expected-error{{}}

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -1034,6 +1034,14 @@ extern NSString *NSHTTPRequestKey;
 
 @end
 
+@interface NSIdLover: NSObject
+
+- (id _Nonnull)makesId;
+- (void)takesId:(id _Nonnull)x;
+- (void)takesArrayOfId:(const id _Nonnull * _Nonnull)x;
+
+@end
+
 #define NSTimeIntervalSince1970 978307200.0
 #define NS_DO_SOMETHING 17
 

--- a/test/attr/attr_objc_any.swift
+++ b/test/attr/attr_objc_any.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -parse -verify %s -enable-id-as-any
+// REQUIRES: objc_interop
+
+import Foundation
+
+@objc var foo: Any // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+
+class Foo: NSObject {
+  override init() {}
+
+  @objc var property: Any
+
+  @objc func method(x: Any) -> Any { return x }
+
+  @objc func indirectAny(x: UnsafePointer<Any>) {} // expected-error{{type of the parameter cannot be represented in Objective-C}}
+}


### PR DESCRIPTION
Adds a frontend flag `-enable-id-as-any` to gate importing ObjC `id` as the Swift `Any` type. Initial Clang importer and representable-in-ObjC support.
