### PR TITLE
Debug Info: Unique forward declarations generated for scopes and types.

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.h
+++ b/lib/IRGen/IRGenDebugInfo.h
@@ -70,6 +70,9 @@ class IRGenDebugInfo {
   std::vector<std::pair<const SILDebugScope *, llvm::TrackingMDNodeRef>>
       LastInlineChain;
 
+  /// A list of replaceable fwddecls that need to be RAUWed at the end.
+  std::vector<std::pair<TypeBase *, llvm::TrackingMDRef>> ReplaceMap;
+
   llvm::BumpPtrAllocator DebugInfoNames;
   StringRef CWDName;                    /// The current working directory.
   llvm::DICompileUnit *TheCU = nullptr; /// The current compilation unit.

--- a/test/DebugInfo/parent-scope.swift
+++ b/test/DebugInfo/parent-scope.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend -g -emit-ir %s | FileCheck %s
+
+public protocol P {
+  associatedtype AT;
+}
+
+// A generic declcontext cannot be shared, so we expect a
+// forward-declared type.
+// CHECK-GEN: ![[FWD:.*]] = !DICompositeType({{.*}}, name: "Generic",
+// CHECK-GEN-SAME:                           flags: DIFlagFwdDecl
+// CHECK-GEN: linkageName: "_TFV4main7Generic3setfwx2ATT_", scope: ![[FWD]],
+public struct Generic<T : P> {
+  public func get() -> T.AT? {
+    return nil
+  }
+  public func set(_ t: T.AT) {}
+}
+
+// But only one concrete type is expected.
+// CHECK: !DISubprogram({{.*}}linkageName: "_TFV4main8Concrete3getfT_GSqSi_",
+// CHECK-SAME:          scope: ![[CONC:[0-9]+]],
+// CHECK: ![[CONC]] = !DICompositeType({{.*}}, name: "Concrete",
+// CHECK-SAME-NOT: DIFlagFwdDecl
+public struct Concrete {
+  public func get() -> Int? {
+    return nil
+  }
+  public func set(_ t: Int) {}
+}
+
+public func getConcrete() -> Concrete? { return nil; }


### PR DESCRIPTION
This is mostly a cleanup and results slightly more efficient debug info.

rdar://problem/25965038
