### PR TITLE
[gardening] Use "{let,var} c: C" instead of "{let,var} c : C"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5050,15 +5050,15 @@ Swift 2.2
     var x = Int8(-129)
     // error: integer literal overflows when stored into 'Int8'
 
-    var y : Int = 0xFFFF_FFFF_FFFF_FFFF_F
+    var y: Int = 0xFFFF_FFFF_FFFF_FFFF_F
     // error: integer literal overflows when stored into 'Int'
     ```
 
   Overflows in constant integer expressions are also reported by the compiler.
 
     ```swift
-    var x : Int8 = 125
-    var y : Int8 = x + 125
+    var x: Int8 = 125
+    var y: Int8 = x + 125
     // error: arithmetic operation '125 + 125' (on type 'Int8') results in
     //        an overflow
     ```

--- a/benchmark/single-source/ArrayOfGenericPOD.swift
+++ b/benchmark/single-source/ArrayOfGenericPOD.swift
@@ -19,7 +19,7 @@
 // An integer enum takes two words.
 
 class RefArray<T> {
-  var array : [T]
+  var array: [T]
 
   init(_ i:T) {
     array = [T](repeating: i, count: 100000)
@@ -48,8 +48,8 @@ func genIOUArray() {
 // struct has multiple fields of trivial type. Destroying the
 // elements should be a nop.
 struct S<T> {
-  var x : T
-  var y : T
+  var x: T
+  var y: T
 }
 @inline(never)
 func genStructArray() {

--- a/benchmark/single-source/ArrayOfGenericRef.swift
+++ b/benchmark/single-source/ArrayOfGenericRef.swift
@@ -20,7 +20,7 @@ protocol Constructible {
   init(e:Element)
 }
 class ConstructibleArray<T:Constructible> {
-  var array : [T]
+  var array: [T]
 
   init(_ e:T.Element) {
     array = [T]()
@@ -33,7 +33,7 @@ class ConstructibleArray<T:Constructible> {
 
 class GenericRef<T> : Constructible {
   typealias Element=T
-  var x : T
+  var x: T
   required init(e:T) { self.x = e }
 }
 
@@ -56,7 +56,7 @@ func genCommonRefArray() {
 
 // Reuse the same enum value for each element.
 class RefArray<T> {
-  var array : [T]
+  var array: [T]
 
   init(_ i:T, count:Int = 10_000) {
     array = [T](repeating: i, count: count)
@@ -73,7 +73,7 @@ func genRefEnumArray() {
 
 struct GenericVal<T> : Constructible {
   typealias Element=T
-  var x : T
+  var x: T
   init(e:T) { self.x = e }
 }
 

--- a/benchmark/single-source/ArrayOfPOD.swift
+++ b/benchmark/single-source/ArrayOfPOD.swift
@@ -43,8 +43,8 @@ func genEnumArray() {
 }
 
 struct S {
-  var x : Int
-  var y : Int
+  var x: Int
+  var y: Int
 }
 @inline(never)
 func genStructArray() {

--- a/benchmark/single-source/ArrayOfRef.swift
+++ b/benchmark/single-source/ArrayOfRef.swift
@@ -35,7 +35,7 @@ class ConstructibleArray<T:Constructible> {
 // Reference to a POD class.
 class POD : Constructible {
   typealias Element=Int
-  var x : Int
+  var x: Int
   required init(e:Int) { self.x = e }
 }
 
@@ -50,7 +50,7 @@ class Dummy {}
 // Reference to a reference. The nested reference is shared across elements.
 class CommonRef : Constructible {
   typealias Element=Dummy
-  var d : Dummy
+  var d: Dummy
   required init(e:Dummy) { self.d = e }
 }
 
@@ -85,7 +85,7 @@ func genRefEnumArray() {
 // Struct holding a reference.
 struct S : Constructible {
   typealias Element=Dummy
-  var d : Dummy
+  var d: Dummy
   init(e:Dummy) { self.d = e }
 }
 

--- a/benchmark/single-source/BitCount.swift
+++ b/benchmark/single-source/BitCount.swift
@@ -18,7 +18,7 @@ import TestsUtils
 
 func countBitSet(_ num: Int) -> Int {
   let bits = sizeof(Int.self) * 8
-  var cnt : Int = 0
+  var cnt: Int = 0
   var mask: Int = 1
   for _ in 0...bits {
     if num & mask != 0 {

--- a/benchmark/single-source/DictTest.swift
+++ b/benchmark/single-source/DictTest.swift
@@ -153,7 +153,7 @@ class Box<T : Hashable where T : Equatable> : Hashable {
     value = v
   }
 
-  var hashValue : Int {
+  var hashValue: Int {
     return value.hashValue
   }
 }

--- a/benchmark/single-source/DictTest2.swift
+++ b/benchmark/single-source/DictTest2.swift
@@ -44,7 +44,7 @@ class Box<T : Hashable where T : Equatable> : Hashable {
     value = v
   }
 
-  var hashValue : Int {
+  var hashValue: Int {
     return value.hashValue
   }
 }

--- a/benchmark/single-source/DictTest3.swift
+++ b/benchmark/single-source/DictTest3.swift
@@ -51,7 +51,7 @@ class Box<T : Hashable where T : Equatable> : Hashable {
     value = v
   }
 
-  var hashValue : Int {
+  var hashValue: Int {
     return value.hashValue
   }
 }

--- a/benchmark/single-source/DictionaryBridge.swift
+++ b/benchmark/single-source/DictionaryBridge.swift
@@ -45,7 +45,7 @@ class Thing : NSObject {
 }
 
 class Stuff {
-  var c : Thing = Thing.mk()
+  var c: Thing = Thing.mk()
   init() {
 
   }

--- a/benchmark/single-source/DictionaryRemove.swift
+++ b/benchmark/single-source/DictionaryRemove.swift
@@ -49,7 +49,7 @@ class Box<T : Hashable where T : Equatable> : Hashable {
     value = v
   }
 
-  var hashValue : Int {
+  var hashValue: Int {
     return value.hashValue
   }
 }

--- a/benchmark/single-source/DictionarySwap.swift
+++ b/benchmark/single-source/DictionarySwap.swift
@@ -52,7 +52,7 @@ class Box<T : Hashable where T : Equatable> : Hashable {
     value = v
   }
 
-  var hashValue : Int {
+  var hashValue: Int {
     return value.hashValue
   }
 }

--- a/benchmark/single-source/Hanoi.swift
+++ b/benchmark/single-source/Hanoi.swift
@@ -17,7 +17,7 @@ import TestsUtils
 
 struct Move {
    var from: String
-   var to  : String
+   var to: String
    init(from:String, to:String) {
       self.from = from
       self.to = to

--- a/benchmark/single-source/Hash.swift
+++ b/benchmark/single-source/Hash.swift
@@ -62,10 +62,10 @@ class Hash {
   // private:
 
   // Hash state:
-  final var messageLength : Int = 0
-  final var dataLength : Int = 0
+  final var messageLength: Int = 0
+  final var dataLength: Int = 0
   final var data = [UInt8](repeating: 0, count: 64)
-  final var blocksize : Int
+  final var blocksize: Int
 
   /// \brief Hash the internal data.
   func hash() {
@@ -158,10 +158,10 @@ class MD5 : Hash {
                       6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21]
 
   // State
-  var h0 : UInt32 = 0
-  var h1 : UInt32 = 0
-  var h2 : UInt32 = 0
-  var h3 : UInt32 = 0
+  var h0: UInt32 = 0
+  var h1: UInt32 = 0
+  var h2: UInt32 = 0
+  var h3: UInt32 = 0
 
   init() {
     super.init(64)
@@ -240,7 +240,7 @@ class MD5 : Hash {
     var b = h1
     var c = h2
     var d = h3
-    var f, g : UInt32
+    var f, g: UInt32
 
     // Main loop:
     for i in 0..<64 {
@@ -292,7 +292,7 @@ class MD5 : Hash {
   override
   func hashStateFast(_ Res: inout [UInt8]) {
 #if !NO_RANGE
-    var Idx : Int = 0
+    var Idx: Int = 0
     for h in [h0, h1, h2, h3] {
       toHexFast(h, &Res, Idx)
       Idx += 8
@@ -309,11 +309,11 @@ class MD5 : Hash {
 
 class SHA1 : Hash {
   // State
-  var h0 : UInt32 = 0
-  var h1 : UInt32 = 0
-  var h2 : UInt32 = 0
-  var h3 : UInt32 = 0
-  var h4 : UInt32 = 0
+  var h0: UInt32 = 0
+  var h1: UInt32 = 0
+  var h2: UInt32 = 0
+  var h3: UInt32 = 0
+  var h4: UInt32 = 0
 
   init() {
     super.init(64)
@@ -365,7 +365,7 @@ class SHA1 : Hash {
     var w = [UInt32](repeating: 0, count: 80)
 
     // Convert the Byte array to UInt32 array.
-    var word : UInt32 = 0
+    var word: UInt32 = 0
     for i in 0..<64 {
       word = word << 8
       word = word &+ UInt32(data[i])
@@ -387,7 +387,7 @@ class SHA1 : Hash {
     var C = h2
     var D = h3
     var E = h4
-    var K : UInt32, F : UInt32
+    var K: UInt32, F: UInt32
 
     for t in 0..<80 {
       if t < 20 {
@@ -403,7 +403,7 @@ class SHA1 : Hash {
         K = 0xca62c1d6
         F = B ^ C ^ D
       }
-      let Temp : UInt32 = rol(A,5) &+ F &+ E &+ w[t] &+ K
+      let Temp: UInt32 = rol(A,5) &+ F &+ E &+ w[t] &+ K
 
       E = D
       D = C
@@ -421,7 +421,7 @@ class SHA1 : Hash {
 
   override
   func hashState() -> String {
-    var Res : String = ""
+    var Res: String = ""
     for state in [h0, h1, h2, h3, h4] {
       Res += toHex(state)
     }
@@ -431,14 +431,14 @@ class SHA1 : Hash {
 
 class SHA256 :  Hash {
   // State
-  var h0 : UInt32 = 0
-  var h1 : UInt32 = 0
-  var h2 : UInt32 = 0
-  var h3 : UInt32 = 0
-  var h4 : UInt32 = 0
-  var h5 : UInt32 = 0
-  var h6 : UInt32 = 0
-  var h7 : UInt32 = 0
+  var h0: UInt32 = 0
+  var h1: UInt32 = 0
+  var h2: UInt32 = 0
+  var h3: UInt32 = 0
+  var h4: UInt32 = 0
+  var h5: UInt32 = 0
+  var h6: UInt32 = 0
+  var h7: UInt32 = 0
 
   var k : [UInt32] = [
    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
@@ -503,7 +503,7 @@ class SHA256 :  Hash {
     var w = [UInt32](repeating: 0, count: 64)
 
     // Convert the Byte array to UInt32 array.
-    var word : UInt32 = 0
+    var word: UInt32 = 0
     for i in 0..<64 {
       word = word << 8
       word = word &+ UInt32(data[i])
@@ -558,7 +558,7 @@ class SHA256 :  Hash {
 
   override
   func hashState() -> String {
-    var Res : String = ""
+    var Res: String = ""
     for state in [h0, h1, h2, h3, h4, h5, h6, h7] {
       Res += toHex(state)
     }
@@ -600,7 +600,7 @@ public func run_HashTest(_ N: Int) {
     }
 
     // Check that we don't crash on large strings.
-    var S : String = ""
+    var S: String = ""
     for _ in 1...size {
       S += "a"
       MD.reset()
@@ -609,7 +609,7 @@ public func run_HashTest(_ N: Int) {
 
     // Check that the order in which we push values does not change the result.
     MD.reset()
-    var L : String = ""
+    var L: String = ""
     for _ in 1...size {
       L += "a"
       MD.update("a")

--- a/benchmark/single-source/NopDeinit.swift
+++ b/benchmark/single-source/NopDeinit.swift
@@ -15,7 +15,7 @@ import TestsUtils
 
 class X<T : Comparable> {
   let deinitIters = 10000
-  var elem : T
+  var elem: T
   init(_ x : T) {elem = x}
   deinit {
     for _ in 1...deinitIters {

--- a/benchmark/single-source/Phonebook.swift
+++ b/benchmark/single-source/Phonebook.swift
@@ -31,8 +31,8 @@ var words=[
 
 // This is a phone book record.
 struct Record : Comparable {
-  var first : String
-  var last : String
+  var first: String
+  var last: String
 
   init(_ first_ : String,_ last_ : String) {
     first = first_

--- a/benchmark/single-source/PolymorphicCalls.swift
+++ b/benchmark/single-source/PolymorphicCalls.swift
@@ -155,7 +155,7 @@ public class D2 : B2 {
 
 
 public class A3 {
-    let b : B3
+    let b: B3
 
     public init(b:B3) {
         self.b = b
@@ -245,7 +245,7 @@ public class F3 : B3 {
 // on a class without any subclasses
 @inline(never)
 func test(_ a:A, _ UPTO: Int) -> Int64 {
-    var cnt : Int64 = 0
+    var cnt: Int64 = 0
     for _ in 0..<UPTO {
         cnt += a.run2()
     }
@@ -256,7 +256,7 @@ func test(_ a:A, _ UPTO: Int) -> Int64 {
 // on a class with 1 subclass
 @inline(never)
 func test(_ a:A1, _ UPTO: Int) -> Int64 {
-    var cnt : Int64 = 0
+    var cnt: Int64 = 0
     for _ in 0..<UPTO {
         cnt += a.run2()
     }
@@ -267,7 +267,7 @@ func test(_ a:A1, _ UPTO: Int) -> Int64 {
 // on a class with 2 subclasses
 @inline(never)
 func test(_ a:A2, _ UPTO: Int) -> Int64 {
-    var cnt : Int64 = 0
+    var cnt: Int64 = 0
     for _ in 0..<UPTO {
         cnt += a.run2()
     }
@@ -279,7 +279,7 @@ func test(_ a:A2, _ UPTO: Int) -> Int64 {
 // of different subclasses
 @inline(never)
 func test(_ a2_c2:A2, _ a2_d2:A2,  _ UPTO: Int) -> Int64 {
-    var cnt : Int64 = 0
+    var cnt: Int64 = 0
     for _ in 0..<UPTO/2 {
         cnt += a2_c2.run2()
         cnt += a2_d2.run2()
@@ -292,7 +292,7 @@ func test(_ a2_c2:A2, _ a2_d2:A2,  _ UPTO: Int) -> Int64 {
 // of different subclasses
 @inline(never)
 func test(_ a3_c3: A3, _ a3_d3: A3, _ a3_e3: A3, _ a3_f3: A3, _ UPTO: Int) -> Int64 {
-    var cnt : Int64  = 0
+    var cnt: Int64  = 0
     for _ in 0..<UPTO/4 {
         cnt += a3_c3.run2()
         cnt += a3_d3.run2()

--- a/benchmark/single-source/Prims.swift
+++ b/benchmark/single-source/Prims.swift
@@ -23,8 +23,8 @@
 import TestsUtils
 
 class PriorityQueue {
-  final var heap : Array<EdgeCost>
-  final var graphIndexToHeapIndexMap : Array<Int?>
+  final var heap: Array<EdgeCost>
+  final var graphIndexToHeapIndexMap: Array<Int?>
 
   // Create heap for graph with NUM nodes.
   init(Num: Int) {
@@ -132,9 +132,9 @@ class PriorityQueue {
   func dump() {
     print("QUEUE")
     for nodeCost in heap {
-      let to : Int = nodeCost.to
-      let from : Int = nodeCost.from
-      let cost : Double = nodeCost.cost
+      let to: Int = nodeCost.to
+      let from: Int = nodeCost.from
+      let cost: Double = nodeCost.cost
       print("(\(from)->\(to), \(cost))")
     }
   }
@@ -151,8 +151,8 @@ class PriorityQueue {
 }
 
 struct GraphNode {
-  var id : Int
-  var adjList : Array<Int>
+  var id: Int
+  var adjList: Array<Int>
 
   init(i : Int) {
     id = i
@@ -161,14 +161,14 @@ struct GraphNode {
 }
 
 struct EdgeCost {
-  var to : Int
-  var cost : Double
+  var to: Int
+  var cost: Double
   var from: Int
 }
 
 struct Edge : Equatable {
-  var start : Int
-  var end : Int
+  var start: Int
+  var end: Int
 }
 
 func ==(lhs: Edge, rhs: Edge) -> Bool {

--- a/benchmark/single-source/RC4.swift
+++ b/benchmark/single-source/RC4.swift
@@ -16,8 +16,8 @@ import TestsUtils
 
 struct RC4 {
   var State : [UInt8]
-  var I : UInt8 = 0
-  var J : UInt8 = 0
+  var I: UInt8 = 0
+  var J: UInt8 = 0
 
   init() {
     State = [UInt8](repeating: 0, count: 256)
@@ -29,7 +29,7 @@ struct RC4 {
       State[i] = UInt8(i)
     }
 
-    var j : UInt8 = 0
+    var j: UInt8 = 0
     for i in 0..<256 {
       let K : UInt8 = Key[i % Key.count]
       let S : UInt8 = State[i]

--- a/benchmark/single-source/RGBHistogram.swift
+++ b/benchmark/single-source/RGBHistogram.swift
@@ -118,7 +118,7 @@ class Box<T : Hashable where T : Equatable> : Hashable {
     value = v
   }
 
-  var hashValue : Int {
+  var hashValue: Int {
     return value.hashValue
   }
 }

--- a/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
+++ b/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
@@ -39,7 +39,7 @@ public struct ObjCBool : Boolean, BooleanLiteralConvertible {
 
 #else
   // Everywhere else it is C/C++'s "Bool"
-  var _value : Bool
+  var _value: Bool
 
   public init(_ value: Bool) {
     self._value = value
@@ -97,7 +97,7 @@ func _convertObjCBoolToBool(_ x: ObjCBool) -> Bool {
 /// The compiler has special knowledge of this type.
 @_fixed_layout
 public struct Selector : StringLiteralConvertible {
-  var ptr : OpaquePointer
+  var ptr: OpaquePointer
 
   /// Create a selector from a string.
   public init(_ str : String) {
@@ -171,7 +171,7 @@ extension Selector : CustomReflectable {
 
 @_fixed_layout
 public struct NSZone {
-  var pointer : OpaquePointer
+  var pointer: OpaquePointer
 }
 
 // Note: NSZone becomes Zone in Swift 3.

--- a/stdlib/public/SDK/UIKit/UIKit_FoundationExtensions.swift
+++ b/stdlib/public/SDK/UIKit/UIKit_FoundationExtensions.swift
@@ -25,7 +25,7 @@ public extension IndexPath {
     /// The section of this index path, when used with `UITableView`.
     ///
     /// - precondition: The index path must have exactly two elements.
-    public var section : Int {
+    public var section: Int {
         get {
             precondition(count == 2, "Invalid index path for use with UITableView. This index path must contain exactly two indices specifying the section and row.")
             return self[0]
@@ -39,7 +39,7 @@ public extension IndexPath {
     /// The row of this index path, when used with `UITableView`.
     ///
     /// - precondition: The index path must have exactly two elements.
-    public var row : Int {
+    public var row: Int {
         get {
             precondition(count == 2, "Invalid index path for use with UITableView. This index path must contain exactly two indices specifying the section and row.")
             return self[1]
@@ -62,7 +62,7 @@ public extension IndexPath {
     /// The item of this index path, when used with `UICollectionView`.
     ///
     /// - precondition: The index path must have exactly two elements.
-    public var item : Int {
+    public var item: Int {
         get {
             precondition(count == 2, "Invalid index path for use with UICollectionView. This index path must contain exactly two indices specifying the section and item.")
             return self[1]

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -46,7 +46,7 @@ public struct _ArrayBuffer<Element> : _ArrayBufferProtocol {
 
   /// The spare bits that are set when a native array needs deferred
   /// element type checking.
-  var deferredTypeCheckMask : Int { return 1 }
+  var deferredTypeCheckMask: Int { return 1 }
   
   /// Returns an `_ArrayBuffer<U>` containing the same elements,
   /// deferring checking each element's `U`-ness until it is accessed.
@@ -89,7 +89,7 @@ extension _ArrayBuffer {
   }
 
   /// `true`, if the array is native and does not need a deferred type check.
-  var arrayPropertyIsNativeTypeChecked : Bool {
+  var arrayPropertyIsNativeTypeChecked: Bool {
     return _isNativeTypeChecked
   }
 

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -304,7 +304,7 @@ public struct Character :
     /// The position of the first element in a non-empty collection.
     ///
     /// In an empty collection, `startIndex == endIndex`.
-    var startIndex : Int {
+    var startIndex: Int {
       return 0
     }
 
@@ -313,7 +313,7 @@ public struct Character :
     /// `endIndex` is not a valid argument to `subscript`, and is always
     /// reachable from `startIndex` by zero or more applications of
     /// `successor()`.
-    var endIndex : Int {
+    var endIndex: Int {
       return Int(count)
     }
 

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -40,7 +40,7 @@ public struct ClosedRangeIndex<Bound> : Comparable
   internal init(_ x: Bound) { _value = .inRange(x) }
   
   internal var _value: _ClosedRangeIndexRepresentation<Bound>
-  internal var _dereferenced : Bound {
+  internal var _dereferenced: Bound {
     switch _value {
     case .inRange(let x): return x
     case .pastEnd: _preconditionFailure("Index out of range")

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -177,7 +177,7 @@ final class _ContiguousArrayStorage<Element> : _ContiguousArrayStorage1 {
   typealias Manager = ManagedBufferPointer<_ArrayBody, Element>
 
   internal // private
-  var __manager : Manager {
+  var __manager: Manager {
     return Manager(_uncheckedUnsafeBufferObject: self)
   }
 }
@@ -246,7 +246,7 @@ public struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
   }
 
   /// True, if the array is native and does not need a deferred type check.
-  var arrayPropertyIsNativeTypeChecked : Bool {
+  var arrayPropertyIsNativeTypeChecked: Bool {
     return true
   }
 

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -195,7 +195,7 @@ struct _SliceBuffer<Element> : _ArrayBufferProtocol, RandomAccessCollection {
   }
 
   /// True, if the array is native and does not need a deferred type check.
-  var arrayPropertyIsNativeTypeChecked : Bool {
+  var arrayPropertyIsNativeTypeChecked: Bool {
     return _hasNativeBuffer
   }
 

--- a/stdlib/public/core/Sort.swift.gyb
+++ b/stdlib/public/core/Sort.swift.gyb
@@ -306,7 +306,7 @@ public func swap<T>(_ a: inout T, _ b: inout T) {
     "swapping a location with itself is not supported")
 
   // Take from P1.
-  let tmp : T = Builtin.take(p1)
+  let tmp: T = Builtin.take(p1)
   // Transfer P2 into P1.
   Builtin.initialize(Builtin.take(p2) as T, p1)
   // Initialize P2.

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -58,7 +58,7 @@ extension String {
   }
 
   /// A Boolean value indicating whether a string has no characters.
-  public var isEmpty : Bool {
+  public var isEmpty: Bool {
     return _core.count == 0
   }
 }

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -219,14 +219,14 @@ extension String {
 
       /// True iff the index is at the end of its view or if the next
       /// byte begins a new UnicodeScalar.
-      internal var _isOnUnicodeScalarBoundary : Bool {
+      internal var _isOnUnicodeScalarBoundary: Bool {
         let buffer = UInt32(truncatingBitPattern: _buffer)
         let (codePoint, _) = UTF8._decodeOne(buffer)
         return codePoint != nil || _isAtEnd
       }
 
       /// True iff the index is at the end of its view
-      internal var _isAtEnd : Bool {
+      internal var _isAtEnd: Bool {
         return _buffer == Index._emptyBuffer
           && _coreIndex == _core.endIndex
       }

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -330,7 +330,7 @@ extension String {
 
 extension String {
   /// The string's value represented as a collection of Unicode scalar values.
-  public var unicodeScalars : UnicodeScalarView {
+  public var unicodeScalars: UnicodeScalarView {
     get {
       return UnicodeScalarView(_core)
     }

--- a/stdlib/public/core/Unmanaged.swift
+++ b/stdlib/public/core/Unmanaged.swift
@@ -136,7 +136,7 @@ public struct Unmanaged<Instance : AnyObject> {
   ///  }
   ///
   ///  class Owner {
-  ///    final var owned : Owned
+  ///    final var owned: Owned
   ///
   ///    func foo() {
   ///        withExtendedLifetime(self) {
@@ -168,7 +168,7 @@ public struct Unmanaged<Instance : AnyObject> {
   ///   }
   ///
   ///  class Owner {
-  ///    final var owned : Owned
+  ///    final var owned: Owned
   ///
   ///    func foo() {
   ///        withExtendedLifetime(self) {


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Use `{let,var} c: C` instead of `{let,var} c : C`.
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Inspired by @gribozavr:s fix in 1ad666742e6c81d90e7692a5ca64bc4227f97db4
