### PR TITLE
CSE and RLE based of mark_dependence instructions

### DIFF
--- a/include/swift/SIL/InstructionUtils.h
+++ b/include/swift/SIL/InstructionUtils.h
@@ -20,12 +20,17 @@ namespace swift {
 /// Strip off casts/indexing insts/address projections from V until there is
 /// nothing left to strip.
 SILValue getUnderlyingObject(SILValue V);
+SILValue getUnderlyingObjectStopAtMarkDependence(SILValue V);
 
 SILValue stripSinglePredecessorArgs(SILValue V);
 
 /// Return the underlying SILValue after stripping off all casts from the
 /// current SILValue.
 SILValue stripCasts(SILValue V);
+
+/// Return the underlying SILValue after stripping off all casts (but
+/// mark_dependence) from the current SILValue.
+SILValue stripCastsWithoutMarkDependence(SILValue V);
 
 /// Return the underlying SILValue after stripping off all upcasts from the
 /// current SILValue.

--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -619,6 +619,10 @@ namespace {
       return true;
     }
 
+    bool visitMarkDependenceInst(const MarkDependenceInst *RHS) {
+      return true;
+    }
+
   private:
     const SILInstruction *LHS;
   };

--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -362,6 +362,12 @@ public:
                               Operands.begin(),
                               Operands.end()));
   }
+  hash_code visitMarkDependenceInst(MarkDependenceInst *X) {
+    OperandValueArrayRef Operands(X->getAllOperands());
+    return llvm::hash_combine(
+        X->getKind(), X->getType(),
+        llvm::hash_combine_range(Operands.begin(), Operands.end()));
+  }
 };
 } // end anonymous namespace
 
@@ -680,6 +686,7 @@ bool CSE::canHandle(SILInstruction *Inst) {
     case ValueKind::BridgeObjectToWordInst:
     case ValueKind::ThinFunctionToPointerInst:
     case ValueKind::PointerToThinFunctionInst:
+    case ValueKind::MarkDependenceInst:
       return true;
     default:
       return false;

--- a/lib/SILOptimizer/Utils/LoadStoreOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/LoadStoreOptUtils.cpp
@@ -214,7 +214,11 @@ LSLocation::enumerateLSLocation(SILModule *M, SILValue Mem,
     return;
 
   // Construct a Location to represent the memory written by this instruction.
-  SILValue UO = getUnderlyingObject(Mem);
+  // ProjectionPath currently does not handle mark_dependence so stop our
+  // underlying object search at these instructions.
+  // We still get a benefit if we cse mark_dependence instructions and then
+  // merge loads from them.
+  SILValue UO = getUnderlyingObjectStopAtMarkDependence(Mem);
   LSLocation L(UO, ProjectionPath::getProjectionPath(UO, Mem));
 
   // If we can't figure out the Base or Projection Path for the memory location,

--- a/test/SILOptimizer/cse.sil
+++ b/test/SILOptimizer/cse.sil
@@ -1306,3 +1306,16 @@ bb2:                                              // Preds: bb0 bb1
   return %19 : $()                                // id: %20
 }
 
+// CHECK-LABEL: sil @cse_mark_dependence
+// CHECK: mark_dependence
+// CHECK-NOT: mark_dependence
+// CHECK: return
+sil @cse_mark_dependence : $@convention(thin) (@inout Builtin.Int64, @guaranteed Builtin.NativeObject) -> (Builtin.Int64, Builtin.Int64) {
+bb0(%0 : $*Builtin.Int64, %1 : $Builtin.NativeObject):
+  %2 = mark_dependence %0 : $*Builtin.Int64 on %1 : $Builtin.NativeObject
+  %3 = mark_dependence %0 : $*Builtin.Int64 on %1 : $Builtin.NativeObject
+  %4 = load %2 : $*Builtin.Int64
+  %5 = load %3 : $*Builtin.Int64
+  %6 = tuple(%4 : $Builtin.Int64, %5 : $Builtin.Int64)
+  return %6 : $(Builtin.Int64, Builtin.Int64)
+}

--- a/test/SILOptimizer/redundant_load_elim.sil
+++ b/test/SILOptimizer/redundant_load_elim.sil
@@ -1146,3 +1146,12 @@ bb0(%0 : $*Builtin.Int64, %1 : $*Builtin.Int64):
   %4 = load %1 : $*Builtin.Int64
   return %4 : $Builtin.Int64
 }
+
+sil @redundant_load_mark_dependence : $@convention(thin) (@inout Builtin.Int64, @guaranteed Builtin.NativeObject) -> (Builtin.Int64, Builtin.Int64) {
+bb0(%0 : $*Builtin.Int64, %1 : $Builtin.NativeObject):
+  %2 = mark_dependence %0 : $*Builtin.Int64 on %1 : $Builtin.NativeObject
+  %4 = load %2 : $*Builtin.Int64
+  %5 = load %2 : $*Builtin.Int64
+  %6 = tuple(%4 : $Builtin.Int64, %5 : $Builtin.Int64)
+  return %6 : $(Builtin.Int64, Builtin.Int64)
+}


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

After we merge pull request 3270 we will see a regression because ownerWithAddress will generate mark_dependence instructions. Loads of these mark_dependence instructions will not get redundancy eliminated. This patch set teaches CSE about mark_dependence instructions and LSLocation to stop its underlying object search at mark_dependence instructions until we fix ProjectionPath to not bail on mark_dependence instructions.
#### Resolved bug number: rdar://27138023
