### PR TITLE
[coverage] Add cov2json tool for serializing code coverage

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -6,6 +6,7 @@ add_swift_tool_subdirectory(swift-demangle)
 add_swift_tool_subdirectory(lldb-moduleimport-test)
 add_swift_tool_subdirectory(sil-extract)
 add_swift_tool_subdirectory(swift-llvm-opt)
+add_swift_tool_subdirectory(cov2json)
 
 if(SWIFT_BUILD_SOURCEKIT)
   add_swift_tool_subdirectory(SourceKit)

--- a/tools/cov2json/CMakeLists.txt
+++ b/tools/cov2json/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_swift_executable(cov2json
+  ProfileData.cpp
+  main.cpp
+  LINK_LIBRARIES swiftBasic
+  COMPONENT_DEPENDS support object profiledata "option" core)
+
+swift_install_in_component(testsuite-tools
+    TARGETS cov2json
+    RUNTIME DESTINATION "bin")
+

--- a/tools/cov2json/JSONWriter.h
+++ b/tools/cov2json/JSONWriter.h
@@ -1,0 +1,69 @@
+//===----------- JSONWriter.h - Serializes structures to JSON -----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef JSONWriter_h
+#define JSONWriter_h
+
+#include "swift/Basic/JSONSerialization.h"
+#include "ProfileData.h"
+
+namespace swift {
+namespace json {
+
+template <typename U> struct ArrayTraits<std::vector<U>> {
+  static size_t size(Output &out, std::vector<U> &seq) { return seq.size(); }
+  static U &element(Output &out, std::vector<U> &seq, size_t index) {
+    if (seq.size() <= index) {
+      seq.resize(index + 1);
+    }
+    return seq[index];
+  }
+};
+
+template <> struct ObjectTraits<llvm::cov2json::Function> {
+  static void mapping(Output &out, llvm::cov2json::Function &function) {
+    uint64_t regionCount = function.regionCount();
+    uint64_t executedCount = function.executedRegionCount();
+    if (auto firstLine = function.firstLine()) {
+      out.mapOptional("start_line", firstLine);
+    }
+    out.mapRequired("name", function.name);
+    out.mapRequired("symbol", function.symbol);
+    out.mapRequired("regions", regionCount);
+    out.mapRequired("executed_regions", executedCount);
+  }
+};
+
+template <> struct ObjectTraits<llvm::cov2json::File> {
+  static void mapping(Output &out, llvm::cov2json::File &file) {
+    uint64_t regionCount = file.regionCount();
+    uint64_t executedCount = file.executedRegionCount();
+    out.mapRequired("filename", file.name);
+    out.mapRequired("functions", file.functions);
+    out.mapRequired("regions", regionCount);
+    out.mapRequired("executed_regions", executedCount);
+  }
+};
+
+template <> struct ObjectTraits<llvm::cov2json::Project> {
+  static void mapping(Output &out, llvm::cov2json::Project &project) {
+    uint64_t regionCount = project.regionCount();
+    uint64_t executedCount = project.executedRegionCount();
+    out.mapRequired("files", project.files);
+    out.mapRequired("regions", regionCount);
+    out.mapRequired("executed_regions", executedCount);
+  }
+};
+}
+}
+
+#endif /* JSONWriter_h */

--- a/tools/cov2json/ProfileData.cpp
+++ b/tools/cov2json/ProfileData.cpp
@@ -1,0 +1,206 @@
+//===--------- ProfileData.cpp - Tools for loading llvm profdata -----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "ProfileData.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Process.h"
+#include "llvm/Support/FormattedStream.h"
+#include "swift/Basic/Demangle.h"
+#include <cxxabi.h>
+
+namespace llvm {
+namespace cov2json {
+
+/// Runs the provided function with a color set on ferrs().
+void withColor(raw_ostream::Colors color, bool bold, bool bg,
+               std::function<void()> f) {
+  bool colored = sys::Process::StandardErrHasColors();
+  if (colored)
+    ferrs().changeColor(color, bold, bg);
+  f();
+  if (colored)
+    // FIXME: Properly reset state to the previous state,
+    //         instead of resetting the color entirely.
+    ferrs().resetColor();
+}
+
+/// Prints an error message and exits with the error's value.
+void exitWithErrorCode(std::error_code error, StringRef whence) {
+  withColor(raw_ostream::RED, /* bold = */ true, /* bg = */ false,
+            [] { ferrs() << "error: "; });
+  ferrs() << whence << ": " << error.message() << "\n";
+  exit(error.value());
+}
+
+/// Grabs the symbol from a string that's 'File.cpp:symbol',
+/// or just returns the symbol if there's no ':'.
+StringRef extractSymbol(StringRef name) {
+  auto pair = name.split(':');
+  if (pair.second == "") {
+    return pair.first;
+  } else {
+    return pair.second;
+  }
+}
+
+/// Returns the demangled (Swift or C++) version of `symbol`.
+std::string demangle(StringRef symbol) {
+  auto prefix = symbol.substr(0, 2);
+  if (prefix == "_Z") {
+    auto demangled = abi::__cxa_demangle(symbol.data(), 0, 0, NULL);
+    if (demangled) {
+      std::string s(demangled);
+      free(demangled);
+      return s;
+    }
+  } else if (prefix == "_T") {
+    return swift::Demangle::demangleSymbolAsString(symbol);;
+  }
+  return symbol;
+}
+
+/// Opens a stream to a file, or stdout if "" is provided.
+std::unique_ptr<raw_fd_ostream> openStream(StringRef file) {
+  if (file.size()) {
+    std::error_code error;
+    auto os = make_unique<raw_fd_ostream>(file, error, sys::fs::F_RW);
+    if (error) {
+      auto whence = "opening output stream for '" + file + "'";
+      exitWithErrorCode(error, whence.str());
+    }
+    return os;
+  } else {
+    return make_unique<raw_fd_ostream>(fileno(stdout),
+                                       /* shouldClose = */ false);
+  }
+}
+
+/// Creates a Function struct off of a FunctionRecord.
+Function::Function(const coverage::FunctionRecord &record) {
+  this->symbol = extractSymbol(record.Name);
+  this->name = demangle(symbol);
+  for (auto &region : record.CountedRegions) {
+    if (region.FileID != region.ExpandedFileID)
+      continue;
+    if (region.Kind !=
+        llvm::coverage::CounterMappingRegion::RegionKind::CodeRegion)
+      continue;
+    Region r(region.ColumnStart, region.ColumnEnd, region.LineStart,
+             region.LineEnd, region.ExecutionCount);
+    regions.emplace_back(r);
+  }
+  executionCount = record.ExecutionCount;
+}
+
+Optional<unsigned> Function::firstLine() {
+  if (regions.size()) {
+    return regions[0].lineStart;
+  }
+  return None;
+}
+
+uint64_t Function::regionCount() {
+  return regions.size();
+}
+
+uint64_t Function::executedRegionCount() {
+  uint64_t count = 0;
+  for (auto &region : regions) {
+    if (region.executionCount > 0) {
+      count += 1;
+    }
+  }
+  return count;
+}
+  
+uint64_t File::regionCount() {
+  uint64_t counter = 0;
+  for (auto &function : functions) {
+    counter += function.regionCount();
+  }
+  return counter;
+}
+
+uint64_t File::executedRegionCount() {
+  uint64_t counter = 0;
+  for (auto &function : functions) {
+    counter += function.executedRegionCount();
+  }
+  return counter;
+}
+
+uint64_t Project::regionCount() {
+  uint64_t counter = 0;
+  for (auto &file : files) {
+    counter += file.regionCount();
+  }
+  return counter;
+}
+
+uint64_t Project::executedRegionCount() {
+  uint64_t counter = 0;
+  for (auto &file : files) {
+    counter += file.executedRegionCount();
+  }
+  return counter;
+}
+
+/// Loads a CoverageMapping for a CoverageFilePair
+std::unique_ptr<llvm::coverage::CoverageMapping>
+CoverageFilePair::coverageMapping() {
+  auto map = llvm::coverage::CoverageMapping::load(binary, filename);
+  
+  if (auto error = map.getError()) {
+    auto whence = "loading coverage map for '" + filename +
+                  "' with binary '" + binary + "'";
+    exitWithErrorCode(error, whence.str());
+  }
+  
+  return move(map.get());
+}
+
+/// Loads a list of files that are within the provided coveredDir.
+void CoverageFilePair::loadFileMap(Project &project,
+                                   StringRef coveredDir,
+                                   std::vector<std::string> &coveredFiles) {
+  auto mapping = coverageMapping();
+  for (auto &filename : mapping->getUniqueSourceFiles()) {
+    StringRef truncatedFilename = filename;
+    if (coveredDir != "") {
+      if (!filename.startswith(coveredDir)) {
+        continue;
+      }
+      StringRef parentPath = sys::path::parent_path(coveredDir);
+      truncatedFilename = filename.substr(parentPath.size(),
+                                          filename.size() - parentPath.size());
+      truncatedFilename = sys::path::relative_path(truncatedFilename);
+    }
+    if (!coveredFiles.empty()) {
+      bool found = false;
+      for (auto &file : coveredFiles) {
+        if (truncatedFilename.endswith(file)) {
+          found = true;
+          break;
+        }
+      }
+      if (!found) continue;
+    }
+    std::vector<Function> functions;
+    for (auto &func : mapping->getCoveredFunctions(filename)) {
+      functions.emplace_back(func);
+    }
+    project.files.emplace_back(File(truncatedFilename, functions));
+  }
+}
+  
+}
+}

--- a/tools/cov2json/ProfileData.h
+++ b/tools/cov2json/ProfileData.h
@@ -1,0 +1,115 @@
+//===----- ProfileData.h - Data structures for serializing profdata -----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ProfileData_h
+#define ProfileData_h
+
+#include <stdio.h>
+#include <iostream>
+#include "llvm/ProfileData/InstrProfReader.h"
+#include "llvm/ProfileData/CoverageMapping.h"
+#include "llvm/ProfileData/CoverageMappingReader.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/FormattedStream.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/Path.h"
+#include <map>
+#include <set>
+
+namespace llvm {
+namespace cov2json {
+
+struct Region {
+public:
+  unsigned columnStart, columnEnd, lineStart, lineEnd;
+  uint64_t executionCount;
+
+  Region(unsigned columnStart, unsigned columnEnd, unsigned lineStart,
+         unsigned lineEnd, uint64_t executionCount)
+      : columnStart(columnStart), columnEnd(columnEnd), lineStart(lineStart),
+        lineEnd(lineEnd), executionCount(executionCount) {}
+  Region(llvm::coverage::CountedRegion &region)
+      : Region(region.ColumnStart, region.ColumnEnd, region.LineStart,
+               region.LineEnd, region.ExecutionCount) {}
+  Region() {}
+};
+
+struct Function {
+public:
+  std::string name;
+  std::string symbol;
+  std::vector<Region> regions;
+  uint64_t executionCount;
+  Function(StringRef name, std::vector<Region> regions,
+           uint64_t executionCount)
+      : name(name), regions(regions), executionCount(executionCount) {}
+
+  uint64_t regionCount();
+  uint64_t executedRegionCount();
+  Optional<unsigned> firstLine();
+  
+  Function(const llvm::coverage::FunctionRecord &record);
+  Function() {}
+};
+
+/// A struct that stores all functions associated with a given source file.
+struct File {
+public:
+  std::string name;
+  std::vector<Function> functions;
+  
+  uint64_t regionCount();
+  uint64_t executedRegionCount();
+
+  File(StringRef name, std::vector<Function> functions)
+      : name(name), functions(functions) {}
+  File() {}
+};
+  
+struct Project {
+  std::vector<File> files;
+  uint64_t regionCount();
+  uint64_t executedRegionCount();
+  
+  Project(std::vector<File> files): files(files) {}
+  Project() {}
+};
+
+
+/// A struct that represents a pair of binary file and profdata file,
+/// which reads and digests the contents of those files.
+struct CoverageFilePair {
+public:
+  /// The .profdata file path.
+  StringRef filename;
+
+  /// The binary file path that generated the .profdata.
+  StringRef binary;
+
+  /// \returns A CoverageMapping object corresponding
+  /// to the binary and profdata.
+  std::unique_ptr<llvm::coverage::CoverageMapping> coverageMapping();
+
+  /// Loads a vector of File objects that are covered in this profdata.
+  void loadFileMap(Project &project, StringRef coveredDir,
+                   std::vector<std::string> &coveredFiles);
+
+  CoverageFilePair(StringRef filename, StringRef binary)
+      : filename(filename), binary(binary) {}
+};
+
+std::unique_ptr<raw_fd_ostream> openStream(StringRef file);
+
+} // namespace cov2json;
+} // namespace llvm;
+
+#endif /* ProfileData_h */

--- a/tools/cov2json/main.cpp
+++ b/tools/cov2json/main.cpp
@@ -1,0 +1,50 @@
+//===---------- main.cpp - Tools for analyzing llvm profdata --------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/CommandLine.h"
+#include "ProfileData.h"
+#include "JSONWriter.h"
+
+using namespace llvm;
+using namespace cov2json;
+
+int main(int argc, const char **argv) {
+  cl::opt<std::string> output("output", cl::desc("<output filename>"),
+                              cl::value_desc("The output file to write. "),
+                              cl::init(""));
+  cl::opt<std::string> file("instr-profile", cl::desc("<profdata file>"),
+                            cl::Required);
+  cl::opt<std::string> binary(cl::Positional, cl::desc("<binary file>"),
+                              cl::Required);
+  cl::opt<std::string> coveredDir("covered-dir", cl::Optional,
+                                  cl::desc("Restrict output to a certain "
+                                           "covered subdirectory."));
+  cl::list<std::string> coveredFiles("covered-files", cl::Optional,
+                                     cl::Positional,
+                                     cl::PositionalEatsArgs,
+                                     cl::desc("Restrict output to a certain "
+                                              "set of files within the "
+                                              "provided subdirectory"),
+                                     cl::ZeroOrMore);
+  
+  cl::ParseCommandLineOptions(argc, argv);
+  
+  CoverageFilePair filePair(file, binary);
+  Project project;
+  
+  filePair.loadFileMap(project, coveredDir, coveredFiles);
+  
+  std::unique_ptr<raw_ostream> os = openStream(output);
+  
+  swift::json::Output jout(*os, false);
+  jout << project;
+}


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

A tool that serializes code coverage information to JSON so other programs can consume the information without needing to link with `libLLVMProfileData`.
#### Relevant bug number: ([rdar://25206821](rdar://25206821))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
