### PR TITLE
[cmake] Remove direct computation of dependencies on LLVM libraries a…

### DIFF
--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -376,32 +376,6 @@ function(swift_common_llvm_config target)
   if((SWIFT_BUILT_STANDALONE OR SOURCEKIT_BUILT_STANDALONE) AND NOT "${CMAKE_CFG_INTDIR}" STREQUAL ".")
     llvm_map_components_to_libnames(libnames ${link_components})
 
-    # Collect dependencies.
-    set(new_libnames)
-    foreach(lib ${libnames})
-      list(APPEND new_libnames "${lib}")
-      get_target_property(extra_libraries "${lib}" INTERFACE_LINK_LIBRARIES)
-      foreach(dep ${extra_libraries})
-        if(NOT "${new_libnames}" STREQUAL "")
-          list(REMOVE_ITEM new_libnames "${dep}")
-        endif()
-        list(APPEND new_libnames "${dep}")
-      endforeach()
-    endforeach()
-    set(libnames "${new_libnames}")
-
-    # Translate library names into full path names.
-    set(new_libnames)
-    foreach(dep ${libnames})
-      if("${dep}" MATCHES "^LLVM")
-        list(APPEND new_libnames
-            "${LLVM_LIBRARY_OUTPUT_INTDIR}/lib${dep}.a")
-      else()
-        list(APPEND new_libnames "${dep}")
-      endif()
-    endforeach()
-    set(libnames "${new_libnames}")
-
     get_target_property(target_type "${target}" TYPE)
     if("${target_type}" STREQUAL "STATIC_LIBRARY")
       target_link_libraries("${target}" INTERFACE ${libnames})


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…nd exact paths to those libraries.

Now that we have the full dependency information from LLVM/Clang, this is no
longer necessary. We will just do the _right_ thing.

Additionally, since we were passing these libraries as absolute paths, cmake was
always passing through all of the given libraries even if CMake had already
added them to the link line in its non-absolute form. It is not clear to me how
if all linkers would be smart about this.

Regardless, now we just translate components to libraries and continue on our
merry way. In the future, we can even remove the llvm-build code period by just
specifying LLVM dependencies directly via LINK_LIBRARIES instead of having to do
anything with COMPONENT_DEPENDS.

But that is for a future commit.
