### PR TITLE
[stdlib] Change String.Index to get new indexes from its own backing

### DIFF
--- a/stdlib/public/SDK/Foundation/NSStringAPI.swift
+++ b/stdlib/public/SDK/Foundation/NSStringAPI.swift
@@ -96,7 +96,7 @@ extension String {
   /// Return an `Index` corresponding to the given offset in our UTF-16
   /// representation.
   func _index(_ utf16Index: Int) -> Index {
-    return Index(_base: String.UnicodeScalarView.Index(utf16Index, _core))
+	return Index(_base: String.UnicodeScalarView.Index(utf16Index, _core), in: unicodeScalars)
   }
 
   /// Return a `Range<Index>` corresponding to the given `NSRange` of

--- a/stdlib/public/core/StringIndexConversions.swift
+++ b/stdlib/public/core/StringIndexConversions.swift
@@ -51,7 +51,7 @@ extension String.Index {
     if !unicodeScalarIndex._isOnGraphemeClusterBoundary {
       return nil
     }
-    self.init(_base: unicodeScalarIndex)
+	self.init(_base: unicodeScalarIndex, in: String.UnicodeScalarView(unicodeScalarIndex._core))
   }
 
   /// Creates an index in the given string that corresponds exactly to the


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Change String.CharacterView.Index to get before/after indexes from its own backing, rather than the internal backing belonging to the underlying unicode scalar index. This means that character indexes could be safely stored. Currently, if you're saving indexes of mutable text (e.g. If you're working with the Cocoa Text API, such as UITextInput, UIKeyInput and UITextPosition), even safe mutations to the underlying string (such as appends) make your saved index completely unsafe.

The snippet from the linked bug report works, but some ASCII comparison tests in `/test/1_stdlib/StringAPI.swift` fail for reasons I can't explain (and which don't reproduce in the interpreter)
#### Resolved bug number: ([SR-1682](https://bugs.swift.org/browse/SR-1682))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…s own backing
