### PR TITLE
[swiftc] Add 💥 case (😢 → 54, 😀 → 5095) triggered in swift::TypeChecker::addImplicitConstructors(…)

### DIFF
--- a/validation-test/compiler_crashers/28339-swift-typechecker-addimplicitconstructors.swift
+++ b/validation-test/compiler_crashers/28339-swift-typechecker-addimplicitconstructors.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+var d{protocol A{{}class a:A{}typealias e:A.E{{}}class A:a


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Add crash case with stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckDecl.cpp:7344: void swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl *): Assertion `!classDecl->hasSuperclass() || classDecl->getSuperclass()->getAnyNominal()->isInvalid() || classDecl->getSuperclass()->getAnyNominal() ->addedImplicitInitializers()' failed.
8  swift           0x0000000000eb8d5a swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 4506
9  swift           0x0000000000eabbed swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 5885
10 swift           0x0000000000eacf28 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 376
15 swift           0x0000000000eb25a6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
18 swift           0x0000000000f1888a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
19 swift           0x0000000000f186ee swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
20 swift           0x0000000000f192b3 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
22 swift           0x0000000000ed4851 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
23 swift           0x0000000000c62209 swift::CompilerInstance::performSema() + 3289
25 swift           0x00000000007d89b9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
26 swift           0x00000000007a49f8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28339-swift-typechecker-addimplicitconstructors.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28339-swift-typechecker-addimplicitconstructors-bd822a.o
1.  While type-checking getter for d at validation-test/compiler_crashers/28339-swift-typechecker-addimplicitconstructors.swift:10:6
2.  While type-checking 'A' at validation-test/compiler_crashers/28339-swift-typechecker-addimplicitconstructors.swift:10:7
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
