### PR TITLE
test: correct DebugInfo test

### DIFF
--- a/test/DebugInfo/parent-scope.swift
+++ b/test/DebugInfo/parent-scope.swift
@@ -19,8 +19,7 @@ public struct Generic<T : P> {
 // But only one concrete type is expected.
 // CHECK: !DISubprogram({{.*}}linkageName: "_TFV4main8Concrete3getfT_GSqSi_",
 // CHECK-SAME:          scope: ![[CONC:[0-9]+]],
-// CHECK: ![[CONC]] = !DICompositeType({{.*}}, name: "Concrete",
-// CHECK-SAME-NOT: DIFlagFwdDecl
+// CHECK: ![[CONC]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Concrete", scope: !{{[0-9]+}}, file: !{{[0-9]+}}, line: {{[0-9]+}}, align: {{[0-9]+}}, elements: !{{[0-9]+}}, runtimeLang: DW_LANG_Swift, identifier: "_TtV4main8Concrete")
 public struct Concrete {
   public func get() -> Int? {
     return nil


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Fix a test case which did not test what it thought it did.  The `-SAME-NOT`
suffix is not supported.  Make the test more strict to check the entire entry to
ensure that errant flags are not propagated instead.  This makes the test less
resilient to encoding changes, but ensures that the test performs the desired
check.  NFC.
