### PR TITLE
Frontend: add `--dependent-lib=` option to support Windows

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -272,6 +272,9 @@ def Xlinker : Separate<["-"], "Xlinker">,
   Flags<[DoesNotAffectIncrementalBuild]>,
   HelpText<"Specifies an option which should be passed to the linker">;
 
+def autolink_library : Joined<["-"], "autolink-library=">,
+  HelpText<"Add dependent library">, Flags<[FrontendOption]>;
+
 // Optimization levels
 
 def O_Group : OptionGroup<"<optimization level options>">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1285,6 +1285,9 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     Opts.EnableReflectionNames = false;
   }
 
+  for (const auto &Lib : Args.getAllArgValues(options::OPT_autolink_library))
+    Opts.LinkLibraries.push_back(LinkLibrary(Lib, LibraryKind::Library));
+
   return false;
 }
 

--- a/test/IRGen/dependent-library.swift
+++ b/test/IRGen/dependent-library.swift
@@ -1,0 +1,7 @@
+// RUN: %swift -target i686-unknown-windows-msvc -emit-ir -parse-as-library -parse-stdlib -module-name dependent -autolink-library=oldnames -autolink-library=msvcrt %s -o - | FileCheck %s
+
+// CHECK: !{i32 6, !"Linker Options", ![[options:[0-9]+]]}
+// CHECK: ![[options]] = !{![[oldnames:[0-9]+]], ![[msvcrtd:[0-9]+]]}
+// CHECK: ![[oldnames]] = !{!"/DEFAULTLIB:oldnames.lib"}
+// CHECK: ![[msvcrtd]] = !{!"/DEFAULTLIB:msvcrt.lib"}
+


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

All modules on Windows need to link against one of {libcmtd.lib, libcmt.lib,
msvcrtd.lib, msvcrt.lib}.  In addition to being the C library, it is the
equivalent of crtbegin0.o on other targets.  It is responsible for providing the
entry point itself.  Traditionally, cl will embed the linkage requirement into
all objects based on the flags given -- one of {/MTd, /MT, /MDd, /MD}.  clang
emulates this via the `--dependent-lib=` option.  Emulate that behaviour in the
swift driver so that swift objects being compiled for Windows targets can
auto-link to the required libraries.
