### PR TITLE
[swiftc] Add 💥 case (😢 → 55, 😀 → 5096) triggered in swift::TypeChecker::typeCheckDecl(…)

### DIFF
--- a/validation-test/compiler_crashers/28341-swift-typechecker-typecheckdecl.swift
+++ b/validation-test/compiler_crashers/28341-swift-typechecker-typecheckdecl.swift
@@ -1,0 +1,18 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+struct S<a{
+let f=othe
+class a
+{
+}
+var d={
+class A{
+typealias e:a
+func f:e


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

…
Add crash case with stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckDecl.cpp:4247: void (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl *): Assertion `!FD->getType()->hasTypeParameter()' failed.
12 swift           0x0000000000eb1ea6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
15 swift           0x0000000000f19614 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
16 swift           0x0000000000f4594c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
17 swift           0x0000000000ea04e1 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 769
18 swift           0x0000000000ea15f7 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 343
19 swift           0x0000000000ea180b swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
21 swift           0x0000000000ead5bd swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3853
26 swift           0x00000000010e9f35 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 1189
27 swift           0x0000000000eef7c1 swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::Type, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) + 305
28 swift           0x0000000000e991e9 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 3865
30 swift           0x0000000001066c53 swift::Expr::walk(swift::ASTWalker&) + 19
31 swift           0x0000000000e99a70 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 224
32 swift           0x0000000000ea0442 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
33 swift           0x0000000000ea15f7 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 343
34 swift           0x0000000000ea180b swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
36 swift           0x0000000000ead5bd swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3853
37 swift           0x0000000000f31c6d swift::createImplicitConstructor(swift::TypeChecker&, swift::NominalTypeDecl*, swift::ImplicitConstructorKind) + 413
38 swift           0x0000000000eb7ab0 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 1536
41 swift           0x0000000000eb1ea6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
42 swift           0x0000000000ed40b2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
43 swift           0x0000000000c61489 swift::CompilerInstance::performSema() + 3289
45 swift           0x00000000007d82c9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
46 swift           0x00000000007a4308 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28341-swift-typechecker-typecheckdecl.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28341-swift-typechecker-typecheckdecl-658f4b.o
1.  While type-checking 'S' at validation-test/compiler_crashers/28341-swift-typechecker-typecheckdecl.swift:10:1
2.  While type-checking expression at [validation-test/compiler_crashers/28341-swift-typechecker-typecheckdecl.swift:11:7 - line:11:7] RangeText="o"
3.  While type-checking expression at [validation-test/compiler_crashers/28341-swift-typechecker-typecheckdecl.swift:15:7 - line:18:8] RangeText="{
4.  While type-checking 'A' at validation-test/compiler_crashers/28341-swift-typechecker-typecheckdecl.swift:16:1
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
