### PR TITLE
Return ErrorType for type on invalid extension

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1994,10 +1994,8 @@ Type NominalTypeDecl::getDeclaredTypeInContext() const {
     return DeclaredTyInContext;
 
   auto *decl = const_cast<NominalTypeDecl *>(this);
-  auto Ty = computeNominalType(decl, DeclTypeKind::DeclaredTypeInContext);
-  if (!Ty)
-    Ty = ErrorType::get(getASTContext());
-  decl->DeclaredTyInContext = Ty;
+  decl->DeclaredTyInContext = computeNominalType(decl,
+                                                 DeclTypeKind::DeclaredTypeInContext);
   return DeclaredTyInContext;
 }
 

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -127,8 +127,10 @@ enum class DeclTypeKind : unsigned {
 };
 
 static Type computeExtensionType(const ExtensionDecl *ED, DeclTypeKind kind) {
-  auto type = ED->getExtendedType();
+  if (ED->isInvalid())
+    return ErrorType::get(ED->getASTContext());
 
+  auto type = ED->getExtendedType();
   if (!type)
     return Type();
 

--- a/validation-test/compiler_crashers_fixed/28324-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/28324-swift-diagnosticengine-emitdiagnostic.swift
@@ -5,5 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
-class d{init(){{extension{{}protocol a{struct B{let a
+// RUN: not %target-swift-frontend %s -parse
+// REQUIRES: asserts
+protocol a{extension{@objc protocol A:a

--- a/validation-test/compiler_crashers_fixed/28326-swift-typebase-getmembersubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/28326-swift-typebase-getmembersubstitutions.swift
@@ -5,6 +5,5 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
-// REQUIRES: asserts
-protocol a{extension{@objc protocol A:a
+// RUN: not %target-swift-frontend %s -parse
+class d{init(){{extension{{}protocol a{struct B{let a


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

This is a better and more targeted fix for crash 28328 than commit a870bdbd23ed0f461e9a6b5fe0d9f6d37e134cb3. Also fixes additional
crashers.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
