### PR TITLE
[swiftc] Add 💥 case (😢 → 56, 😀 → 5096) triggered in swift::irgen::IRGenModule::emitSILFunction(…)

### DIFF
--- a/validation-test/compiler_crashers/28342-getpointerelementtype-is-not-storagetype.swift
+++ b/validation-test/compiler_crashers/28342-getpointerelementtype-is-not-storagetype.swift
@@ -1,0 +1,23 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-silgen
+// REQUIRES: asserts
+protocol A {
+    associatedtype B
+}
+struct C<T: A> {
+    let d: T
+}
+protocol E {
+    associatedtype F
+    func g<T where F == T.B>(_: C<T>)
+}
+struct H: E {
+    typealias F = Void
+    func g<T where F == T.B>(_: C<T>) {}
+}

--- a/validation-test/compiler_crashers/28342-getpointerelementtype-is-not-storagetype.swift
+++ b/validation-test/compiler_crashers/28342-getpointerelementtype-is-not-storagetype.swift
@@ -5,7 +5,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-silgen
+// RUN: not --crash %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 protocol A {
     associatedtype B


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Add crash case with stack trace:

```
swift: /path/to/swift/lib/IRGen/GenType.cpp:84: swift::irgen::Address swift::irgen::TypeInfo::getAddressForPointer(llvm::Value *) const: Assertion `ptr->getType()->getPointerElementType() == StorageType' failed.
11 swift           0x00000000008af5e9 swift::irgen::IRGenModule::emitSILFunction(swift::SILFunction*) + 1241
12 swift           0x000000000080d028 swift::irgen::IRGenerator::emitGlobalTopLevel() + 408
14 swift           0x00000000007e6954 swift::performIRGeneration(swift::IRGenOptions&, swift::SourceFile&, swift::SILModule*, llvm::StringRef, llvm::LLVMContext&, unsigned int) + 68
16 swift           0x00000000007d82c9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
17 swift           0x00000000007a4308 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28342-getpointerelementtype-is-not-storagetype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28342-getpointerelementtype-is-not-storagetype-7b6cf1.o
1.  While emitting IR SIL function @_TTWV4main1HS_1ES_FS1_1guRd__S_1Awx1Fzwd__1BrfGVS_1Cqd___T_ for 'g' at validation-test/compiler_crashers/28342-getpointerelementtype-is-not-storagetype.swift:22:5
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
