### PR TITLE
Revert "Turning SE-0066 error back to warning" the failures it was responding to are already fixed.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2669,7 +2669,7 @@ ERROR(objc_invalid_with_generic_params,none,
 ERROR(objc_convention_invalid,none,
       "%0 is not representable in Objective-C, so it cannot be used"
       " with '@convention(%1)'", (Type, StringRef))
-WARNING(function_type_no_parens,none,
+ERROR(function_type_no_parens,none,
       "single argument function types require parentheses", ())
 NOTE(not_objc_empty_protocol_composition,none,
      "'protocol<>' is not considered '@objc'; use 'AnyObject' instead", ())

--- a/test/type/types.swift
+++ b/test/type/types.swift
@@ -157,7 +157,7 @@ class r21949448 {
 }
 
 // SE-0066 - Standardize function type argument syntax to require parentheses
-let _ : Int -> Float // expected-warning {{single argument function types require parentheses}} {{9-9=(}} {{12-12=)}}
+let _ : Int -> Float // expected-error {{single argument function types require parentheses}} {{9-9=(}} {{12-12=)}}
 
 
 


### PR DESCRIPTION
Reverts apple/swift#3330
