### PR TITLE
Add fixit for '-> throws' to 'throws ->'

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -604,9 +604,9 @@ ERROR(generic_non_function,PointsToFirstBadToken,
       "only syntactic function types can be generic", ())
 ERROR(rethrowing_function_type,PointsToFirstBadToken,
       "only function declarations may be marked 'rethrows'", ())
-ERROR(throws_after_function_result,none,
+ERROR(throws_in_wrong_position,none,
       "'throws' may only occur before '->'", ())
-ERROR(rethrows_after_function_result,none,
+ERROR(rethrows_in_wrong_position,none,
       "'rethrows' may only occur before '->'", ())
 ERROR(throw_in_function_type,none,
       "expected throwing specifier; did you mean 'throws'?", ())

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -186,13 +186,13 @@ ParserResult<Expr> Parser::parseExprArrow() {
   if (Tok.is(tok::kw_throws)) {
     throwsLoc = consumeToken(tok::kw_throws);
     if (!Tok.is(tok::arrow)) {
-      diagnose(throwsLoc, diag::throws_after_function_result);
+      diagnose(throwsLoc, diag::throws_in_wrong_position);
       return nullptr;
     }
   }
   arrowLoc = consumeToken(tok::arrow);
   if (Tok.is(tok::kw_throws)) {
-    diagnose(Tok.getLoc(), diag::throws_after_function_result);
+    diagnose(Tok.getLoc(), diag::throws_in_wrong_position);
     throwsLoc = consumeToken(tok::kw_throws);
   }
   auto arrow = new (Context) ArrowExpr(throwsLoc, arrowLoc);

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -648,6 +648,26 @@ Parser::parseFunctionSignature(Identifier SimpleName,
   }
 
   SourceLoc arrowLoc;
+
+  auto diagnoseInvalidThrows = [&]() -> Optional<InFlightDiagnostic> {
+    if (throwsLoc.isValid())
+      return None;
+
+    if (Tok.is(tok::kw_throws)) {
+      throwsLoc = consumeToken();
+    } else if (Tok.is(tok::kw_rethrows)) {
+      throwsLoc = consumeToken();
+      rethrows = true;
+    }
+
+    if (!throwsLoc.isValid())
+      return None;
+
+    auto diag = rethrows ? diag::rethrows_in_wrong_position
+                         : diag::throws_in_wrong_position;
+    return diagnose(Tok, diag);
+  };
+
   // If there's a trailing arrow, parse the rest as the result type.
   if (Tok.isAny(tok::arrow, tok::colon)) {
     if (!consumeIf(tok::arrow, arrowLoc)) {
@@ -655,6 +675,15 @@ Parser::parseFunctionSignature(Identifier SimpleName,
       diagnose(Tok, diag::func_decl_expected_arrow)
           .fixItReplace(SourceRange(Tok.getLoc()), "->");
       arrowLoc = consumeToken(tok::colon);
+    }
+
+    // Check for 'throws' and 'rethrows' after the arrow, but
+    // before the type, and correct it.
+    if (auto diagOpt = diagnoseInvalidThrows()) {
+      assert(arrowLoc.isValid());
+      assert(throwsLoc.isValid());
+      (*diagOpt).fixItExchange(SourceRange(arrowLoc),
+                               SourceRange(throwsLoc));
     }
 
     ParserResult<TypeRepr> ResultType =
@@ -672,26 +701,14 @@ Parser::parseFunctionSignature(Identifier SimpleName,
   }
 
   // Check for 'throws' and 'rethrows' after the type and correct it.
-  if (!throwsLoc.isValid()) {
-    if (Tok.is(tok::kw_throws)) {
-      throwsLoc = consumeToken();
-    } else if (Tok.is(tok::kw_rethrows)) {
-      throwsLoc = consumeToken();
-      rethrows = true;
-    }
-
-    if (throwsLoc.isValid()) {
-      assert(arrowLoc.isValid());
-      assert(retType);
-      auto diag = rethrows ? diag::rethrows_after_function_result
-                           : diag::throws_after_function_result;
-      SourceLoc typeEndLoc = Lexer::getLocForEndOfToken(SourceMgr,
-                                                        retType->getEndLoc());
-      SourceLoc throwsEndLoc = Lexer::getLocForEndOfToken(SourceMgr, throwsLoc);
-      diagnose(Tok, diag)
-        .fixItInsert(arrowLoc, rethrows ? "rethrows " : "throws ")
-        .fixItRemoveChars(typeEndLoc, throwsEndLoc);
-    }
+  if (auto diagOpt = diagnoseInvalidThrows()) {
+    assert(arrowLoc.isValid());
+    assert(retType);
+    SourceLoc typeEndLoc = Lexer::getLocForEndOfToken(SourceMgr,
+                                                      retType->getEndLoc());
+    SourceLoc throwsEndLoc = Lexer::getLocForEndOfToken(SourceMgr, throwsLoc);
+    (*diagOpt).fixItInsert(arrowLoc, rethrows ? "rethrows " : "throws ")
+              .fixItRemoveChars(typeEndLoc, throwsEndLoc);
   }
 
   return Status;

--- a/test/Parse/errors.swift
+++ b/test/Parse/errors.swift
@@ -110,7 +110,15 @@ func postThrows() -> Int throws { // expected-error{{'throws' may only occur bef
   return 5
 }
 
+func postThrows2() -> throws Int { // expected-error{{'throws' may only occur before '->'}}{{20-22=throws}}{{23-29=->}}
+  return try postThrows()
+}
+
 func postRethrows(_ f: () throws -> Int) -> Int rethrows { // expected-error{{'rethrows' may only occur before '->'}}{{42-42=rethrows }}{{48-57=}}
+  return try f()
+}
+
+func postRethrows2(_ f: () throws -> Int) -> rethrows Int { // expected-error{{'rethrows' may only occur before '->'}}{{43-45=rethrows}}{{46-54=->}}
   return try f()
 }
 


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Update function signature parsing to handle `throws` between the arrow and the type.

This will fix:

``` swift
func foo() -> throws Int
```

to

``` swift
func foo() throws -> Int
```

and remove the bogus parse errors that are produced for this now.
#### Resolved bug number: ([SR-1940](https://bugs.swift.org/browse/SR-1940))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
