### PR TITLE
[ClangImporter] Import macros with cast to builtin type

### DIFF
--- a/test/IDE/Inputs/mock-sdk/Foo.annotated.txt
+++ b/test/IDE/Inputs/mock-sdk/Foo.annotated.txt
@@ -189,6 +189,10 @@ class <loc>FooClassDerived</loc> : <ref:Class>FooClassBase</ref>, <ref:Protocol>
 <decl:Var>var <loc>FOO_MACRO_5</loc>: <ref:Struct>UInt64</ref> { get }</decl>
 <decl:Var>var <loc>FOO_MACRO_6</loc>: <ref:TypeAlias>typedef_int_t</ref> { get }</decl>
 <decl:Var>var <loc>FOO_MACRO_7</loc>: <ref:TypeAlias>typedef_int_t</ref> { get }</decl>
+<decl:Var>var <loc>FOO_MACRO_8</loc>: <ref:Struct>Int8</ref> { get }</decl>
+<decl:Var>var <loc>FOO_MACRO_9</loc>: <ref:Struct>Int32</ref> { get }</decl>
+<decl:Var>var <loc>FOO_MACRO_10</loc>: <ref:Struct>Int16</ref> { get }</decl>
+<decl:Var>var <loc>FOO_MACRO_11</loc>: <ref:Struct>Int</ref> { get }</decl>
 <decl:Var>var <loc>FOO_MACRO_OR</loc>: <ref:Struct>Int32</ref> { get }</decl>
 <decl:Var>var <loc>FOO_MACRO_AND</loc>: <ref:Struct>Int32</ref> { get }</decl>
 <decl:Var>var <loc>FOO_MACRO_REDEF_1</loc>: <ref:Struct>Int32</ref> { get }</decl>

--- a/test/IDE/Inputs/mock-sdk/Foo.framework/Headers/Foo.h
+++ b/test/IDE/Inputs/mock-sdk/Foo.framework/Headers/Foo.h
@@ -190,6 +190,10 @@ typedef int typedef_int_t;
 #define FOO_MACRO_5 0xffffffffffffffffull
 #define FOO_MACRO_6 ((typedef_int_t) 42)
 #define FOO_MACRO_7 ((typedef_int_t) -1)
+#define FOO_MACRO_8 ((char) 8)
+#define FOO_MACRO_9 ((int) 9)
+#define FOO_MACRO_10 ((short) 10)
+#define FOO_MACRO_11 ((long) 11)
 #define FOO_MACRO_OR (FOO_MACRO_2 | FOO_MACRO_6)
 #define FOO_MACRO_AND (FOO_MACRO_2 & FOO_MACRO_6)
 #define FOO_MACRO_BITWIDTH (FOO_MACRO_4 & FOO_MACRO_5)

--- a/test/IDE/Inputs/mock-sdk/Foo.printed.recursive.txt
+++ b/test/IDE/Inputs/mock-sdk/Foo.printed.recursive.txt
@@ -189,6 +189,10 @@ var FOO_MACRO_4: UInt32 { get }
 var FOO_MACRO_5: UInt64 { get }
 var FOO_MACRO_6: typedef_int_t { get }
 var FOO_MACRO_7: typedef_int_t { get }
+var FOO_MACRO_8: Int8 { get }
+var FOO_MACRO_9: Int32 { get }
+var FOO_MACRO_10: Int16 { get }
+var FOO_MACRO_11: Int { get }
 var FOO_MACRO_OR: Int32 { get }
 var FOO_MACRO_AND: Int32 { get }
 var FOO_MACRO_REDEF_1: Int32 { get }

--- a/test/IDE/Inputs/mock-sdk/Foo.printed.txt
+++ b/test/IDE/Inputs/mock-sdk/Foo.printed.txt
@@ -227,6 +227,10 @@ var FOO_MACRO_4: UInt32 { get }
 var FOO_MACRO_5: UInt64 { get }
 var FOO_MACRO_6: typedef_int_t { get }
 var FOO_MACRO_7: typedef_int_t { get }
+var FOO_MACRO_8: Int8 { get }
+var FOO_MACRO_9: Int32 { get }
+var FOO_MACRO_10: Int16 { get }
+var FOO_MACRO_11: Int { get }
 var FOO_MACRO_OR: Int32 { get }
 var FOO_MACRO_AND: Int32 { get }
 

--- a/test/IDE/complete_from_clang_framework.swift
+++ b/test/IDE/complete_from_clang_framework.swift
@@ -146,7 +146,7 @@ func testCompleteModuleQualifiedFoo2() {
   Foo#^CLANG_QUAL_FOO_2^#
 // If the number of results below changes, then you need to add a result to the
 // list below.
-// CLANG_QUAL_FOO_2: Begin completions, 69 items
+// CLANG_QUAL_FOO_2: Begin completions, 73 items
 // CLANG_QUAL_FOO_2-DAG: Decl[Class]/OtherModule[Foo]:        .FooClassBase[#FooClassBase#]{{; name=.+$}}
 // CLANG_QUAL_FOO_2-DAG: Decl[Class]/OtherModule[Foo]:        .FooClassDerived[#FooClassDerived#]{{; name=.+$}}
 // CLANG_QUAL_FOO_2-DAG: Decl[Class]/OtherModule[Foo]:        .ClassWithInternalProt[#ClassWithInternalProt#]{{; name=.+$}}


### PR DESCRIPTION
#### What's in this pull request?

This PR builds on #2538 by adding support for type casts to some builtin types (mostly those consisting of a single token, e.g. 'short', 'long', etc.).

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
