### PR TITLE
basic: introduce the _environment compilation conditional

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -242,6 +242,10 @@ namespace swift {
     /// a supported target endianness.
     static bool isPlatformConditionEndiannessSupported(StringRef endianness);
 
+    /// Returns true if the 'environment' platform condition argument represents
+    /// a supported target environment.
+    static bool isPlatformConditionEnvironmentSupported(StringRef Environment);
+
   private:
     llvm::SmallVector<std::pair<std::string, std::string>, 3>
         PlatformConditionValues;

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -50,6 +50,13 @@ static const StringRef SupportedConditionalCompilationEndianness[] = {
   "big"
 };
 
+static const StringRef SupportedConditionalCompilationEnvironment[] = {
+  "cygnus",
+  "gnu",
+  "msvc",
+  "itanium",
+};
+
 template <typename Type, size_t N>
 bool contains(const Type (&Array)[N], const Type &V) {
   return std::find(std::begin(Array), std::end(Array), V) != std::end(Array);
@@ -67,6 +74,11 @@ LangOptions::isPlatformConditionArchSupported(StringRef ArchName) {
 bool
 LangOptions::isPlatformConditionEndiannessSupported(StringRef Endianness) {
   return contains(SupportedConditionalCompilationEndianness, Endianness);
+}
+
+bool
+LangOptions::isPlatformConditionEnvironmentSupported(StringRef Environment) {
+  return contains(SupportedConditionalCompilationEnvironment, Environment);
 }
 
 StringRef
@@ -189,6 +201,24 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
     break;
   default:
     llvm_unreachable("undefined architecture endianness");
+  }
+
+  // Set the "_environment" platform condition.
+  switch (Target.getEnvironment()) {
+  default: break;
+  case llvm::Triple::MSVC:
+    addPlatformConditionValue("_environment", "msvc");
+    break;
+  case llvm::Triple::Itanium:
+    addPlatformConditionValue("_environment", "itanium");
+    break;
+  case llvm::Triple::Cygnus:
+    addPlatformConditionValue("_environment", "cygnus");
+    break;
+  case llvm::Triple::GNU:
+    if (triple.isOSWindows())
+      addPlatformConditionValue("_environment", "gnu");
+    break;
   }
 
   // Set the "runtime" platform condition.

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1603,9 +1603,8 @@ Parser::evaluateConditionalCompilationExpr(Expr *condition) {
     }
 
     if (!fnName.equals("arch") && !fnName.equals("os") &&
-        !fnName.equals("_endian") &&
-        !fnName.equals("_runtime") &&
-        !fnName.equals("swift") &&
+        !fnName.equals("_endian") && !fnName.equals("_environment") &&
+        !fnName.equals("_runtime") && !fnName.equals("swift") &&
         !fnName.equals("_compiler_version")) {
       diagnose(CE->getLoc(), diag::unsupported_platform_condition_expression);
       return ConditionalCompilationExprState::error();
@@ -1698,6 +1697,11 @@ Parser::evaluateConditionalCompilationExpr(Expr *condition) {
           if (!LangOptions::isPlatformConditionEndiannessSupported(argument)) {
             diagnose(UDRE->getLoc(), diag::unknown_platform_condition_argument,
                      "endianness", fnName);
+          }
+        } else if (fnName == "_environment") {
+          if (!LangOptions::isPlatformConditionEnvironmentSupported(argument)) {
+            diagnose(UDRE->getLoc(), diag::unknown_platform_condition_argument,
+                     "environment", fnName);
           }
         }
         auto target = Context.LangOpts.getPlatformConditionValue(fnName);

--- a/test/Parse/ConditionalCompilation/cygwinTarget.swift
+++ b/test/Parse/ConditionalCompilation/cygwinTarget.swift
@@ -1,0 +1,9 @@
+// RUN: %swift -parse %s -target x86_64-unknown-windows-cygnus -parse-as-library -parse-stdlib -verify
+
+#if _environment(cygnus)
+public class cygwin {
+}
+#endif
+
+let instance = cygwin()
+

--- a/test/Parse/ConditionalCompilation/mingwTarget.swift
+++ b/test/Parse/ConditionalCompilation/mingwTarget.swift
@@ -1,0 +1,9 @@
+// RUN: %swift -parse %s -target i686-unknown-windows-gnu -parse-as-library -parse-stdlib -verify
+
+#if _environment(gnu)
+public class MinGW {
+}
+#endif
+
+let instance = MinGW()
+

--- a/test/Parse/ConditionalCompilation/windowsItaniumEnvironment.swift
+++ b/test/Parse/ConditionalCompilation/windowsItaniumEnvironment.swift
@@ -1,0 +1,9 @@
+// RUN: %swift -parse %s -target i686-unknown-windows-itanium -parse-as-library -parse-stdlib -verify
+
+#if _environment(itanium)
+public class itanium {
+}
+#endif
+
+let instance = itanium()
+

--- a/test/Parse/ConditionalCompilation/windowsMSVCenvironment.swift
+++ b/test/Parse/ConditionalCompilation/windowsMSVCenvironment.swift
@@ -1,0 +1,9 @@
+// RUN: %swift -parse %s -target i686-unknown-windows-msvc -parse-as-library -parse-stdlib -verify
+
+#if _environment(msvc)
+public class msvc {
+}
+#endif
+
+let instance = msvc()
+


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Windows has multiple environment flavours, each of which are different.  cygwin
provides a glibc based environment, MinGW provides a msvcrt based GNU
environment, itanium provides a msvc environment with an itanium C++ ABI, and
msvc is the pure msvc, msvcprt based environment as vended by Microsoft.  Due to
the differences in the environment, we need a means to differentiate them at the
stdlib level.  Provide the _environment conditional which would allow you to
query what environment is being targeted.
