### PR TITLE
[swiftc] Add 💥 case (😢 → 55, 😀 → 5098) triggered in swift::GenericFunctionType::get(…)

### DIFF
--- a/validation-test/compiler_crashers/28343-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers/28343-swift-genericfunctiontype-get.swift
@@ -1,0 +1,14 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+class A<c{
+func p{enum b<T{
+func p(T:c
+let a{{
+let a=p{


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Add crash case with stack trace:

```
swift: /path/to/swift/lib/AST/ASTContext.cpp:3041: static swift::GenericFunctionType *swift::GenericFunctionType::get(swift::GenericSignature *, swift::Type, swift::Type, const swift::AnyFunctionType::ExtInfo &): Assertion `!input->hasTypeVariable() && !output->hasTypeVariable()' failed.
8  swift           0x00000000010064db swift::GenericFunctionType::get(swift::GenericSignature*, swift::Type, swift::Type, swift::AnyFunctionType::ExtInfo const&) + 603
9  swift           0x00000000011251e3 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 5747
10 swift           0x0000000001125be8 swift::TypeBase::getTypeOfMember(swift::ModuleDecl*, swift::Type, swift::DeclContext const*) + 136
14 swift           0x0000000000f62209 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 105
15 swift           0x0000000000f67b8e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 3998
16 swift           0x0000000000e99d32 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 850
17 swift           0x0000000000ea0492 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
19 swift           0x0000000000f64652 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 9394
20 swift           0x0000000000f67b8e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 3998
21 swift           0x0000000000e99d32 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 850
22 swift           0x0000000000ea0492 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
23 swift           0x0000000000ea1647 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 343
24 swift           0x0000000000ea185b swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
27 swift           0x0000000000eb1ef6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
30 swift           0x0000000000f19664 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
31 swift           0x0000000000f4599c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
32 swift           0x0000000000ea0531 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 769
35 swift           0x0000000000f182ea swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
36 swift           0x0000000000f1814e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
37 swift           0x0000000000f18d13 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
39 swift           0x0000000000ed4201 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
40 swift           0x0000000000c61489 swift::CompilerInstance::performSema() + 3289
42 swift           0x00000000007d82c9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
43 swift           0x00000000007a4308 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28343-swift-genericfunctiontype-get.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28343-swift-genericfunctiontype-get-849f66.o
1.  While type-checking getter for a at validation-test/compiler_crashers/28343-swift-genericfunctiontype-get.swift:13:6
2.  While type-checking expression at [validation-test/compiler_crashers/28343-swift-genericfunctiontype-get.swift:13:7 - line:14:8] RangeText="{
3.  While type-checking declaration 0x58b5180 at validation-test/compiler_crashers/28343-swift-genericfunctiontype-get.swift:14:1
4.  While type-checking expression at [validation-test/compiler_crashers/28343-swift-genericfunctiontype-get.swift:14:7 - line:14:8] RangeText="p{"
5.  While type-checking expression at [validation-test/compiler_crashers/28343-swift-genericfunctiontype-get.swift:14:7 - line:14:8] RangeText="p{"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
