### PR TITLE
Glibc validation test now performed also on FreeBSD

### DIFF
--- a/validation-test/stdlib/Glibc.swift
+++ b/validation-test/stdlib/Glibc.swift
@@ -1,27 +1,34 @@
 // RUN: %target-run-stdlib-swift
 // REQUIRES: executable_test
 
-// REQUIRES: OS=linux-gnu
-
 import Swift
 import StdlibUnittest
 
-
+#if os(Linux) || os(FreeBSD)
 import Glibc
+#endif
 
 var GlibcTestSuite = TestSuite("Glibc")
 
-GlibcTestSuite.test("errno") {
-  errno = 0
-  expectEqual(0, errno)
-  close(-1)
-  expectEqual(EBADF, errno)
+GlibcTestSuite.test("errno")
+  .skip(.custom({
+    !( linuxAny(reason: "").evaluate() || freeBSDAny(reason: "").evaluate() ) 
+  }, reason: "Only Linux and FreeBSD are supported")).code {
+    errno = 0
+    expectEqual(0, errno)
+    close(-1)
+    expectEqual(EBADF, errno)
 }
+
 
 var GlibcIoctlConstants = TestSuite("GlibcIoctlConstants")
 
-GlibcIoctlConstants.test("tty ioctl constants availability") {
-  let aConstant = TIOCGWINSZ
+GlibcIoctlConstants.test("tty ioctl constants availability") 
+  .skip(.custom({
+    !( linuxAny(reason: "").evaluate() || freeBSDAny(reason: "").evaluate() ) 
+  }, reason: "Only Linux and FreeBSD are supported")).code {
+    let aConstant = TIOCGWINSZ
 }
+
 
 runAllTests()


### PR DESCRIPTION
#### What's in this pull request?

As discussed in #3276, the glibc validation tests could be performed at least on FreeBSD too, this PR removes the requirement for a Linux OS. 
I didn't build on FreeBSD but I've verified these two tests with a small c program, so both should pass (closing an invalid fd gives EBADF, presence of the TIOCGWINSZ tty ioctl constant).
Couldn't verify it on Android (and that's why it's not included here) since i don't have a device ATM, but both tests should pass.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
