### PR TITLE
[swiftc] Add 💥 case (😢 → 56, 😀 → 5099) triggered in swift::IterativeTypeChecker::processTypeCheckSuperclass(…)

### DIFF
--- a/validation-test/compiler_crashers/28345-swift-iterativetypechecker-processtypechecksuperclass.swift
+++ b/validation-test/compiler_crashers/28345-swift-iterativetypechecker-processtypechecksuperclass.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+struct A<A{class a{protocol A{struct B{}class B<T where B:T>:a


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Add test case for crash triggered in `swift::IterativeTypeChecker::processTypeCheckSuperclass(…)`.

<details>
<summary>

Stack trace:</summary>



```
swift: /path/to/swift/lib/AST/Decl.cpp:4773: void swift::ClassDecl::setSuperclass(swift::Type): Assertion `(!superclass || !superclass->hasArchetype()) && "superclass must be interface type"' failed.
9  swift           0x0000000000fe609b swift::IterativeTypeChecker::processTypeCheckSuperclass(swift::ClassDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 235
10 swift           0x0000000000fbdf4d swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
11 swift           0x0000000000ea9cc0 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) + 64
12 swift           0x00000000011307b9 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) + 217
13 swift           0x0000000001134042 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) + 50
14 swift           0x00000000010facbf swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) + 1103
15 swift           0x0000000000ef80aa swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::ProtocolConformance**, swift::SourceLoc) + 106
16 swift           0x0000000000f1e14d swift::TypeChecker::resolveTypeInContext(swift::TypeDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 1309
20 swift           0x0000000000f1f68e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
22 swift           0x0000000000f205e4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
23 swift           0x0000000000f1f580 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
24 swift           0x0000000000ee9e82 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::GenericSignature*, bool, swift::GenericTypeResolver*) + 722
25 swift           0x0000000000eeb577 swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 135
26 swift           0x0000000000eec0df swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) + 111
27 swift           0x0000000000eac86b swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 363
35 swift           0x0000000000eb1ef6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
36 swift           0x0000000000ed4102 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
37 swift           0x0000000000c61489 swift::CompilerInstance::performSema() + 3289
39 swift           0x00000000007d82c9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
40 swift           0x00000000007a4308 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28345-swift-iterativetypechecker-processtypechecksuperclass.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28345-swift-iterativetypechecker-processtypechecksuperclass-a5f844.o
1.  While type-checking 'A' at validation-test/compiler_crashers/28345-swift-iterativetypechecker-processtypechecksuperclass.swift:10:1
2.  While resolving type B at [validation-test/compiler_crashers/28345-swift-iterativetypechecker-processtypechecksuperclass.swift:10:57 - line:10:57] RangeText="B"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```

</details>
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
