### PR TITLE
[Importer] define SWIFT_SDK_OVERLAY_DISPATCH_EPOCH on non-Darwin platforms

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -390,6 +390,11 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
       //
       // Just use the most feature-rich C language mode.
       "-x", "c", "-std=gnu11",
+
+      // Define macros that Swift bridging headers use.
+
+      // Request new APIs from libdispatch.
+      "-DSWIFT_SDK_OVERLAY_DISPATCH_EPOCH=2",
     });
 
     // The module map used for Glibc depends on the target we're compiling for,


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

The clang importer also processes libdispatch headers on non-Darwin platforms;
define SWIFT_SDK_OVERLAY_DISPATCH_EPOCH on them as well.  This enables
code in the dispatch header files to determine on all platforms that (1) an overlay is
being built and (2) what level of dispatch overlay is desired.

It enables libdispatch pull request https://github.com/apple/swift-corelibs-libdispatch/pull/97
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

None.

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
