### PR TITLE
Switch to an artificial debug location before emitting a shadow copy store.

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -653,6 +653,8 @@ public:
     auto &Alloca = ShadowStackSlots[{ArgNo, {Scope, Name}}];
     if (!Alloca.isValid())
       Alloca = createAlloca(Ty, Align, Name+".addr");
+
+    ArtificialLocation AutoRestore(Scope, IGM.DebugInfo, Builder);
     Builder.CreateStore(Storage, Alloca.getAddress(), Align);
     return Alloca.getAddress();
   }

--- a/test/DebugInfo/guard-let.swift
+++ b/test/DebugInfo/guard-let.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend %s -emit-ir -g -o - | FileCheck %s
+func use<T>(_ t: T) {}
+
+public func f(_ i : Int?)
+{
+  // CHECK: define {{.*}}@_TF4main1fFGSqSi_T_
+  // CHECK: %[[PHI:.*]] = phi
+  // The shadow copy store should not have a location.
+  // CHECK: store i64 %[[PHI]], i64* %val.addr, align 8, !dbg ![[DBG0:.*]]
+  // CHECK: @llvm.dbg.declare(metadata i64* %val.addr, {{.*}}, !dbg ![[DBG1:.*]]
+  // CHECK: ![[DBG0]] = !DILocation(line: 0,
+  // CHECK: ![[DBG1]] = !DILocation(line: [[@LINE+1]],
+  guard let val = i else { return }
+  use(val)
+}


### PR DESCRIPTION
This prevents (among other things) an unexpected step to the end of the scope while initializing a guard variable.

rdar://problem/25427596
