### PR TITLE
Adding @warn_unqualified_access to ambiguous APIs

### DIFF
--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -117,6 +117,7 @@ ${orderingExplanation}
   ///
   /// - SeeAlso: `min(isOrderedBefore:)`
 %   end
+  @warn_unqualified_access
   public func min(
 %   if preds:
     isOrderedBefore: @noescape (${GElement}, ${GElement}) throws -> Bool
@@ -169,6 +170,7 @@ ${orderingExplanation}
   ///
   /// - SeeAlso: `max(isOrderedBefore:)`
 %   end
+  @warn_unqualified_access
   public func max(
 %   if preds:
     isOrderedBefore: @noescape (${GElement}, ${GElement}) throws -> Bool

--- a/stdlib/public/core/Stride.swift.gyb
+++ b/stdlib/public/core/Stride.swift.gyb
@@ -310,6 +310,7 @@ extension Strideable {
     Builtin.unreachable()
   }
 
+  @warn_unqualified_access
   @available(*, unavailable, message: "Use stride(from:through:by:) free function instead")
   public func stride(
     through end: Self, by stride: Stride


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Producing a compile time warning to help resolve ambiguity when using `stride` in an extension to `Strideable`, same for `min` and `max` in `Sequence` extensions.
#### Resolved bug number: ([SR-1798](https://bugs.swift.org/browse/SR-1798))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>
