### PR TITLE
Debug info diet!

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -50,7 +50,7 @@ enum class IRGenDebugInfoKind : unsigned {
   LineTables, /// Line tables only.
   ASTTypes,   /// Line tables + AST type references.
   DwarfTypes, /// Line tables + AST type references + DWARF types.
-  Normal = DwarfTypes /// The setting LLDB prefers.
+  Normal = ASTTypes /// The setting LLDB prefers.
 };
 
 enum class IRGenEmbedMode : unsigned {

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -48,7 +48,9 @@ enum class IRGenOutputKind : unsigned {
 enum class IRGenDebugInfoKind : unsigned {
   None,       /// No debug info.
   LineTables, /// Line tables only.
-  Normal      /// Line tables + DWARF types.
+  ASTTypes,   /// Line tables + AST type references.
+  DwarfTypes, /// Line tables + AST type references + DWARF types.
+  Normal = DwarfTypes /// The setting LLDB prefers.
 };
 
 enum class IRGenEmbedMode : unsigned {

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -293,12 +293,16 @@ def Oplayground : Flag<["-"], "Oplayground">, Group<O_Group>,
 def g_Group : OptionGroup<"<debug info options>">;
 
 def g : Flag<["-"], "g">, Group<g_Group>, Flags<[FrontendOption]>,
-  HelpText<"Emit debug info">;
+  HelpText<"Emit debug info. "
+           "This is the preferred setting for debugging with LLDB.">;
 def gnone : Flag<["-"], "gnone">, Group<g_Group>, Flags<[FrontendOption]>,
   HelpText<"Don't emit debug info">;
 def gline_tables_only : Flag<["-"], "gline-tables-only">,
   Group<g_Group>, Flags<[FrontendOption]>,
   HelpText<"Emit minimal debug info for backtraces only">;
+def gdwarf_types : Flag<["-"], "gdwarf-types">,
+  Group<g_Group>, Flags<[FrontendOption]>,
+  HelpText<"Emit full DWARF type info.">;
 
 // Assert configuration identifiers.
 def AssertConfig : Separate<["-"], "assert-config">,

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -975,6 +975,8 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
       OI.DebugInfoKind = IRGenDebugInfoKind::Normal;
     else if (A->getOption().matches(options::OPT_gline_tables_only))
       OI.DebugInfoKind = IRGenDebugInfoKind::LineTables;
+    else if (A->getOption().matches(options::OPT_gdwarf_types))
+      OI.DebugInfoKind = IRGenDebugInfoKind::DwarfTypes;
     else
       assert(A->getOption().matches(options::OPT_gnone) &&
              "unknown -g<kind> option");
@@ -985,7 +987,7 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
     // top-level output.
     OI.ShouldGenerateModule = true;
     OI.ShouldTreatModuleAsTopLevelOutput = true;
-  } else if ((OI.DebugInfoKind == IRGenDebugInfoKind::Normal &&
+  } else if ((OI.DebugInfoKind > IRGenDebugInfoKind::LineTables &&
               OI.shouldLink()) ||
              Args.hasArg(options::OPT_emit_objc_header,
                          options::OPT_emit_objc_header_path)) {

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -964,7 +964,7 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
 
   addInputsOfType(Arguments, context.InputActions, types::TY_Object);
 
-  if (context.OI.DebugInfoKind == IRGenDebugInfoKind::Normal) {
+  if (context.OI.DebugInfoKind > IRGenDebugInfoKind::LineTables) {
     size_t argCount = Arguments.size();
     if (context.OI.CompilerMode == OutputInfo::Mode::SingleCompile)
       addInputsOfType(Arguments, context.Inputs, types::TY_SwiftModuleFile);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1142,11 +1142,13 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
       Opts.DebugInfoKind = IRGenDebugInfoKind::Normal;
     else if (A->getOption().matches(options::OPT_gline_tables_only))
       Opts.DebugInfoKind = IRGenDebugInfoKind::LineTables;
+    else if (A->getOption().matches(options::OPT_gdwarf_types))
+      Opts.DebugInfoKind = IRGenDebugInfoKind::DwarfTypes;
     else
       assert(A->getOption().matches(options::OPT_gnone) &&
              "unknown -g<kind> option");
 
-    if (Opts.DebugInfoKind == IRGenDebugInfoKind::Normal) {
+    if (Opts.DebugInfoKind > IRGenDebugInfoKind::LineTables) {
       ArgStringList RenderedArgs;
       for (auto A : Args)
         A->render(Args, RenderedArgs);

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1624,16 +1624,26 @@ llvm::DIType *IRGenDebugInfo::createType(DebugTypeInfo DbgTy,
     auto *EnumTy = BaseTy->castTo<EnumType>();
     auto *Decl = EnumTy->getDecl();
     auto L = getDebugLoc(SM, Decl);
-    return createEnumType(DbgTy, Decl, MangledName, Scope,
-                          getOrCreateFile(L.Filename), L.Line, Flags);
+    auto *File = getOrCreateFile(L.Filename);
+    if (Opts.DebugInfoKind > IRGenDebugInfoKind::ASTTypes)
+      return createEnumType(DbgTy, Decl, MangledName, Scope, File, L.Line,
+                            Flags);
+    else
+      return createOpaqueStruct(Scope, Decl->getName().str(), File, L.Line,
+                                SizeInBits, AlignInBits, Flags, MangledName);
   }
 
   case TypeKind::BoundGenericEnum: {
     auto *EnumTy = BaseTy->castTo<BoundGenericEnumType>();
     auto *Decl = EnumTy->getDecl();
     auto L = getDebugLoc(SM, Decl);
-    return createEnumType(DbgTy, Decl, MangledName, Scope,
-                          getOrCreateFile(L.Filename), L.Line, Flags);
+    auto *File = getOrCreateFile(L.Filename);
+    if (Opts.DebugInfoKind > IRGenDebugInfoKind::ASTTypes)
+      return createEnumType(DbgTy, Decl, MangledName, Scope, File, L.Line,
+                            Flags);
+    else
+      return createOpaqueStruct(Scope, Decl->getName().str(), File, L.Line,
+                                SizeInBits, AlignInBits, Flags, MangledName);
   }
 
   case TypeKind::BuiltinVector: {

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1408,11 +1408,15 @@ llvm::DIType *IRGenDebugInfo::createType(DebugTypeInfo DbgTy,
     auto *StructTy = BaseTy->castTo<StructType>();
     auto *Decl = StructTy->getDecl();
     auto L = getDebugLoc(SM, Decl);
-    return createStructType(DbgTy, Decl, StructTy, Scope,
-                            getOrCreateFile(L.Filename), L.Line, SizeInBits,
-                            AlignInBits, Flags,
-                            nullptr, // DerivedFrom
-                            llvm::dwarf::DW_LANG_Swift, MangledName);
+    auto *File = getOrCreateFile(L.Filename);
+    if (Opts.DebugInfoKind > IRGenDebugInfoKind::ASTTypes)
+      return createStructType(DbgTy, Decl, StructTy, Scope, File, L.Line,
+                              SizeInBits, AlignInBits, Flags,
+                              nullptr, // DerivedFrom
+                              llvm::dwarf::DW_LANG_Swift, MangledName);
+    else
+      return createOpaqueStruct(Scope, Decl->getName().str(), File, L.Line,
+                                SizeInBits, AlignInBits, Flags, MangledName);
   }
 
   case TypeKind::Class: {

--- a/lib/IRGen/IRGenDebugInfo.h
+++ b/lib/IRGen/IRGenDebugInfo.h
@@ -318,6 +318,12 @@ private:
   llvm::DIType *createDoublePointerSizedStruct(
       llvm::DIScope *Scope, StringRef Name, llvm::DIType *PointeeTy,
       llvm::DIFile *File, unsigned Line, unsigned Flags, StringRef MangledName);
+
+  /// Create DWARF debug info for a function pointer type.
+  llvm::DIType *createFunctionPointer(DebugTypeInfo DbgTy, llvm::DIScope *Scope,
+                                      unsigned SizeInBits, unsigned AlignInBits,
+                                      unsigned Flags, StringRef MangledName);
+
   /// Create an opaque struct with a mangled name.
   llvm::DIType *createOpaqueStruct(llvm::DIScope *Scope, StringRef Name,
                                    llvm::DIFile *File, unsigned Line,

--- a/lib/IRGen/IRGenDebugInfo.h
+++ b/lib/IRGen/IRGenDebugInfo.h
@@ -324,6 +324,11 @@ private:
                                       unsigned SizeInBits, unsigned AlignInBits,
                                       unsigned Flags, StringRef MangledName);
 
+  /// Create DWARF debug info for a tuple type.
+  llvm::DIType *createTuple(DebugTypeInfo DbgTy, llvm::DIScope *Scope,
+                            unsigned SizeInBits, unsigned AlignInBits,
+                            unsigned Flags, StringRef MangledName);
+
   /// Create an opaque struct with a mangled name.
   llvm::DIType *createOpaqueStruct(llvm::DIScope *Scope, StringRef Name,
                                    llvm::DIFile *File, unsigned Line,

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -92,11 +92,13 @@ static clang::CodeGenerator *createClangCodeGenerator(ASTContext &Context,
   case IRGenDebugInfoKind::LineTables:
     CGO.setDebugInfo(clang::codegenoptions::DebugInfoKind::DebugLineTablesOnly);
     break;
- case IRGenDebugInfoKind::Normal:
+  case IRGenDebugInfoKind::ASTTypes:
+    // TODO: Enable -gmodules for the clang code generator.
+  case IRGenDebugInfoKind::DwarfTypes:
     CGO.setDebugInfo(clang::codegenoptions::DebugInfoKind::FullDebugInfo);
     break;
   }
-  if (Opts.DebugInfoKind != IRGenDebugInfoKind::None) {
+  if (Opts.DebugInfoKind > IRGenDebugInfoKind::None) {
     CGO.DebugCompilationDir = Opts.DebugCompilationDir;
     CGO.DwarfVersion = Opts.DWARFVersion;
     CGO.DwarfDebugFlags = Opts.DWARFDebugFlags;
@@ -383,16 +385,13 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
   // Only use the new calling conventions on platforms that support it.
   auto Arch = Triple.getArch();
   if (SWIFT_RT_USE_RegisterPreservingCC &&
-      Arch == llvm::Triple::ArchType::aarch64) {
+      Arch == llvm::Triple::ArchType::aarch64)
     RegisterPreservingCC = SWIFT_LLVM_CC(RegisterPreservingCC);
-  }
-  else {
+  else
     RegisterPreservingCC = DefaultCC;
-  }
 
-  if (IRGen.Opts.DebugInfoKind != IRGenDebugInfoKind::None) {
+  if (IRGen.Opts.DebugInfoKind > IRGenDebugInfoKind::None)
     DebugInfo = new IRGenDebugInfo(IRGen.Opts, *CI, *this, Module, SF);
-  }
 
   initClangTypeConverter();
 }

--- a/test/DebugInfo/NestedTypes.swift
+++ b/test/DebugInfo/NestedTypes.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir -g -o - | FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -gdwarf-types -o - | FileCheck %s
 
 // Verify that the size of a class that has not been created before
 // its outer type is emitted is emitted correctly.

--- a/test/DebugInfo/basic.swift
+++ b/test/DebugInfo/basic.swift
@@ -1,15 +1,18 @@
 // A (no longer) basic test for debug info.
 // --------------------------------------------------------------------
 // Verify that we don't emit any debug info by default.
-// RUN: %target-swift-frontend %s -emit-ir -o - | FileCheck %s --check-prefix NDEBUG
+// RUN: %target-swift-frontend %s -emit-ir -o - \
+// RUN:   | FileCheck %s --check-prefix NDEBUG
 // NDEBUG-NOT: !dbg
 // NDEBUG-NOT: DW_TAG
 // --------------------------------------------------------------------
 // Verify that we don't emit any debug info with -gnone.
-// RUN: %target-swift-frontend %s -emit-ir -gnone -o - | FileCheck %s --check-prefix NDEBUG
+// RUN: %target-swift-frontend %s -emit-ir -gnone -o - \
+// RUN:   | FileCheck %s --check-prefix NDEBUG
 // --------------------------------------------------------------------
 // Verify that we don't emit any type info with -gline-tables-only.
-// RUN: %target-swift-frontend %s -emit-ir -gline-tables-only -o - | FileCheck %s --check-prefix CHECK-LINETABLES
+// RUN: %target-swift-frontend %s -emit-ir -gline-tables-only -o - \
+// RUN:   | FileCheck %s --check-prefix CHECK-LINETABLES
 // CHECK: !dbg
 // CHECK-LINETABLES-NOT: DW_TAG_{{.*}}variable
 // CHECK-LINETABLES-NOT: DW_TAG_structure_type
@@ -17,7 +20,11 @@
 // --------------------------------------------------------------------
 // Now check that we do generate line+scope info with -g.
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | FileCheck %s
-// RUN: %target-swift-frontend %s -emit-ir -g -o - -disable-sil-linking | FileCheck %s --check-prefix=CHECK-NOSIL
+// RUN: %target-swift-frontend %s -emit-ir -g -o - -disable-sil-linking \
+// RUN:   | FileCheck %s --check-prefix=CHECK-NOSIL
+// --------------------------------------------------------------------
+// Currently -gdwarf-types should give the same results as -g.
+// RUN: %target-swift-frontend %s -emit-ir -gdwarf-types -o - | FileCheck %s
 // --------------------------------------------------------------------
 //
 // CHECK: foo

--- a/test/DebugInfo/bool.swift
+++ b/test/DebugInfo/bool.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-ir -g -o - | FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -gdwarf-types -o - | FileCheck %s
 
 func markUsed<T>(_ t: T) {}
 

--- a/test/DebugInfo/bound-namealiastype.swift
+++ b/test/DebugInfo/bound-namealiastype.swift
@@ -10,6 +10,6 @@ func dispatch_queue_create() -> dispatch_queue_t! {
 
 // CHECK: !DIGlobalVariable(name: "queue",
 // CHECK-SAME:              line: [[@LINE+3]], type: ![[T:[0-9]+]]
-// CHECK: ![[T]] = !DICompositeType(tag: DW_TAG_union_type,
+// CHECK: ![[T]] = !DICompositeType(
 // CHECK-SAME:             identifier: "_TtGSqa4main16dispatch_queue_t_"
 public var queue = dispatch_queue_create()

--- a/test/DebugInfo/enum.swift
+++ b/test/DebugInfo/enum.swift
@@ -7,38 +7,38 @@ protocol P {}
 
 enum Either {
   case First(Int64), Second(P), Neither
-// CHECK: !DICompositeType(tag: DW_TAG_union_type, name: "Either",
+// CHECK: !DICompositeType({{.*}}name: "Either",
 // CHECK-SAME:             line: [[@LINE-3]],
 // CHECK-SAME:             size: {{328|168}},
 }
-// CHECK: ![[INT:.*]] = !DICompositeType({{.*}}identifier: "_TtSi"
+// DWARF: ![[INT:.*]] = !DICompositeType({{.*}}identifier: "_TtSi"
 let E : Either = .Neither;
 
-// CHECK: !DICompositeType(tag: DW_TAG_union_type, name: "Color",
+// CHECK: !DICompositeType({{.*}}name: "Color",
 // CHECK-SAME:             line: [[@LINE+3]]
 // CHECK-SAME:             size: 8, align: 8,
 // CHECK-SAME:             identifier: "_TtO4enum5Color"
 enum Color : UInt64 {
 // This is effectively a 2-bit bitfield:
-// CHECK: !DIDerivedType(tag: DW_TAG_member, name: "Red"
-// CHECK-SAME:           baseType: ![[UINT64:[0-9]+]]
-// CHECK-SAME:           size: 8, align: 8{{[,)]}}
-// CHECK: ![[UINT64]] = !DICompositeType({{.*}}identifier: "_TtVs6UInt64"
+// DWARF: !DIDerivedType(tag: DW_TAG_member, name: "Red"
+// DWARF-SAME:           baseType: ![[UINT64:[0-9]+]]
+// DWARF-SAME:           size: 8, align: 8{{[,)]}}
+// DWARF: ![[UINT64]] = !DICompositeType({{.*}}identifier: "_TtVs6UInt64"
   case Red, Green, Blue
 }
 
-// CHECK: !DICompositeType(tag: DW_TAG_union_type, name: "MaybeIntPair",
+// CHECK: !DICompositeType({{.*}}name: "MaybeIntPair",
 // CHECK-SAME:             line: [[@LINE+3]],
 // CHECK-SAME:             size: 136, align: 64{{[,)]}}
 // CHECK-SAME:             identifier: "_TtO4enum12MaybeIntPair"
 enum MaybeIntPair {
-// CHECK: !DIDerivedType(tag: DW_TAG_member, name: "none"
-// CHECK-SAME:           baseType: ![[INT]], align: 8{{[,)]}}
+// DWARF: !DIDerivedType(tag: DW_TAG_member, name: "none"
+// DWARF-SAME:           baseType: ![[INT]], align: 8{{[,)]}}
   case none
-// CHECK: !DIDerivedType(tag: DW_TAG_member, name: "just"
-// CHECK-SAME:           baseType: ![[INTTUP:[0-9]+]]
-// CHECK-SAME:           size: 128, align: 64{{[,)]}}
-// CHECK: ![[INTTUP]] = !DICompositeType({{.*}}identifier: "_TtTVs5Int64S__"
+// DWARF: !DIDerivedType(tag: DW_TAG_member, name: "just"
+// DWARF-SAME:           baseType: ![[INTTUP:[0-9]+]]
+// DWARF-SAME:           size: 128, align: 64{{[,)]}}
+// DWARF: ![[INTTUP]] = !DICompositeType({{.*}}identifier: "_TtTVs5Int64S__"
   case just(Int64, Int64)
 }
 
@@ -49,7 +49,7 @@ enum Maybe<T> {
 
 let r = Color.Red
 let c = MaybeIntPair.just(74, 75)
-// CHECK: !DICompositeType(tag: DW_TAG_union_type, name: "Maybe",
+// CHECK: !DICompositeType({{.*}}name: "Maybe",
 // CHECK-SAME:             line: [[@LINE-8]],
 // CHECK-SAME:             size: 8, align: 8{{[,)]}}
 // CHECK-SAME:             identifier: "_TtGO4enum5MaybeOS_5Color_"

--- a/test/DebugInfo/enum.swift
+++ b/test/DebugInfo/enum.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-ir -g -o - | FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -gdwarf-types -o - | FileCheck %s --check-prefix=DWARF
 
 // CHECK: ![[EMPTY:.*]] = !{}
 
@@ -62,8 +63,7 @@ public func foo(_ empty : Nothing) { }
 // CHECK-SAME:             {{.*}}identifier: "_TtGO4enum4Rosex_")
 enum Rose<A> {
 	case MkRose(() -> A, () -> [Rose<A>])
-  // CHECK: !DICompositeType({{.*}}name: "Rose", {{.*}}elements: ![[ELTS]],
-  // CHECK-SAME:             {{.*}}identifier: "_TtGO4enum4RoseQq_S0__")
+  // DWARF: !DICompositeType({{.*}}name: "Rose",{{.*}}identifier: "_TtGO4enum4RoseQq_S0__")
 	case IORose(() -> Rose<A>)
 }
 
@@ -72,8 +72,7 @@ func foo<T>(_ x : Rose<T>) -> Rose<T> { return x }
 // CHECK: !DICompositeType({{.*}}name: "Tuple", {{.*}}elements: ![[ELTS:[0-9]+]],
 // CHECK-SAME:             {{.*}}identifier: "_TtGO4enum5Tuplex_")
 public enum Tuple<P> {
-  // CHECK: !DICompositeType({{.*}}name: "Tuple", {{.*}}elements: ![[ELTS]],
-  // CHECK-SAME:             {{.*}}identifier: "_TtGO4enum5TupleQq_S0__")
+  // DWARF: !DICompositeType({{.*}}name: "Tuple",{{.*}}identifier: "_TtGO4enum5TupleQq_S0__")
 	case C(P, () -> Tuple)
 }
 

--- a/test/DebugInfo/enum.swift
+++ b/test/DebugInfo/enum.swift
@@ -78,11 +78,10 @@ public enum Tuple<P> {
 
 func bar<T>(_ x : Tuple<T>) -> Tuple<T> { return x }
 
-// CHECK: ![[LIST:.*]] = !DICompositeType({{.*}}identifier: "_TtGO4enum4ListQq_S0__"
+// CHECK: !DILocalVariable(name: "self", arg: 1, {{.*}} line: [[@LINE+5]], type: ![[LIST:.*]], flags: DIFlagArtificial)
+// CHECK: ![[LIST]] = !DICompositeType({{.*}}identifier: "_TtGO4enum4ListQq_S0__"
 public enum List<T> {
        indirect case Tail(List, T)
        case End
-
-// CHECK: !DILocalVariable(name: "self", arg: 1, {{.*}} line: [[@LINE+1]], type: ![[LIST]], flags: DIFlagArtificial)
        func fooMyList() {}
 }

--- a/test/DebugInfo/enum.swift
+++ b/test/DebugInfo/enum.swift
@@ -70,7 +70,9 @@ enum Rose<A> {
 func foo<T>(_ x : Rose<T>) -> Rose<T> { return x }
 
 // CHECK: !DICompositeType({{.*}}name: "Tuple", {{.*}}elements: ![[ELTS:[0-9]+]],
-// CHECK-SAME:             {{.*}}identifier: "_TtGO4enum5Tuplex_")
+// CHECK-SAME:             {{.*}}identifier: "_TtGO4enum5TupleQq_FS_3barurFGS0_x_GS0_x__")
+// DWARF: !DICompositeType({{.*}}name: "Tuple", {{.*}}elements: ![[ELTS:[0-9]+]],
+// DWARF-SAME:             {{.*}}identifier: "_TtGO4enum5Tuplex_")
 public enum Tuple<P> {
   // DWARF: !DICompositeType({{.*}}name: "Tuple",{{.*}}identifier: "_TtGO4enum5TupleQq_S0__")
 	case C(P, () -> Tuple)

--- a/test/DebugInfo/fnptr.swift
+++ b/test/DebugInfo/fnptr.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend %s -emit-ir -g -o - | FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -gdwarf-types -o - | FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -g -o - | FileCheck %s --check-prefix=AST
 
 // CHECK-DAG: ![[SINODE:.*]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Int64",{{.*}} identifier: [[SI:.*]])
 // CHECK-DAG: ![[SFNODE:.*]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Float",{{.*}} identifier: [[SF:.*]])
@@ -9,9 +10,10 @@ func bar() {
 func baz(_ i: Float) -> Int64 { return 0; }
 func barz(_ i: Float, _ j: Float) -> Int64 { return 0; }
 func main() -> Int64 {
-
-    // CHECK-DAG: !DILocalVariable(name: "bar_function_pointer",{{.*}} line: [[@LINE+1]],{{.*}} type: ![[BARPT:[0-9]+]]
-    var bar_function_pointer = bar
+    // CHECK-DAG: !DILocalVariable(name: "bar_fnptr",{{.*}} line: [[@LINE+3]],{{.*}} type: ![[BARPT:[0-9]+]]
+    // AST-DAG: !DILocalVariable(name: "bar_fnptr",{{.*}} line: [[@LINE+2]],{{.*}} type: ![[BAR_T:[0-9]+]]
+    // AST-DAG: ![[BAR_T]] = !DICompositeType({{.*}}, identifier: "_TtFT_T_")
+    var bar_fnptr = bar
     // CHECK-DAG: ![[BARPT]] = !DICompositeType(tag: DW_TAG_structure_type, {{.*}} elements: ![[BARMEMBERS:[0-9]+]]
     // CHECK-DAG: ![[BARMEMBERS]] = !{![[BARMEMBER:.*]], {{.*}}}
     // CHECK-DAG: ![[BARMEMBER]] = !DIDerivedType(tag: DW_TAG_member,{{.*}} baseType: ![[BARPTR:[0-9]+]]
@@ -19,9 +21,11 @@ func main() -> Int64 {
     // CHECK-DAG: ![[BART]] = !DISubroutineType(types: ![[BARARGS:[0-9]+]])
     // CHECK-DAG: ![[BARARGS]] = !{![[VOID:.*]]}
     // CHECK-DAG: ![[VOID]] = {{.*}}identifier: "_TtT_"
-    bar_function_pointer();// Set breakpoint here
+    bar_fnptr();
 
-    // CHECK-DAG: !DILocalVariable(name: "baz_function_pointer",{{.*}} type: ![[BAZPT:[0-9]+]]
+    // CHECK-DAG: !DILocalVariable(name: "baz_fnptr",{{.*}} type: ![[BAZPT:[0-9]+]]
+    // AST-DAG: !DILocalVariable(name: "baz_fnptr",{{.*}} type: ![[BAZ_T:[0-9]+]]
+    // AST-DAG: ![[BAZ_T]] = !DICompositeType({{.*}}, identifier: "_TtFSfVs5Int64")
     // CHECK-DAG: ![[BAZPT]] = !DICompositeType(tag: DW_TAG_structure_type, {{.*}} elements: ![[BAZMEMBERS:[0-9]+]]
     // CHECK-DAG: ![[BAZMEMBERS]] = !{![[BAZMEMBER:.*]], {{.*}}}
     // CHECK-DAG: ![[BAZMEMBER]] = !DIDerivedType(tag: DW_TAG_member,{{.*}} baseType: ![[BAZPTR:[0-9]+]]
@@ -30,18 +34,20 @@ func main() -> Int64 {
     // CHECK-DAG: ![[BAZARGS]] = !{![[INT:.*]], ![[FLOAT:.*]]}
     // CHECK-DAG: ![[INT]] = {{.*}}identifier: "_TtVs5Int64"
     // CHECK-DAG: ![[FLOAT]] = {{.*}}identifier: "_TtSf"
-    var baz_function_pointer = baz
-    baz_function_pointer(2.89)
+    var baz_fnptr = baz
+    baz_fnptr(2.89)
 
-    // CHECK-DAG: !DILocalVariable(name: "barz_function_pointer",{{.*}} type: ![[BARZPT:[0-9]+]]
+    // CHECK-DAG: !DILocalVariable(name: "barz_fnptr",{{.*}} type: ![[BARZPT:[0-9]+]]
+    // AST_DAG: !DILocalVariable(name: "barz_fnptr",{{.*}} type: ![[BARZ_T:[0-9]+]]
+    // AST-DAG: ![[BARZ_T:[0-9]+]] = !DICompositeType({{.*}}, identifier: "_TtFTSfSf_Vs5Int64")
     // CHECK-DAG: ![[BARZPT]] = !DICompositeType(tag: DW_TAG_structure_type,{{.*}} elements: ![[BARZMEMBERS:[0-9]+]]
     // CHECK-DAG: ![[BARZMEMBERS]] = !{![[BARZMEMBER:.*]], {{.*}}}
     // CHECK-DAG: ![[BARZMEMBER]] = !DIDerivedType(tag: DW_TAG_member,{{.*}} baseType: ![[BARZPTR:[0-9]+]]
     // CHECK-DAG: ![[BARZPTR]] = !DIDerivedType(tag: DW_TAG_pointer_type,{{.*}} baseType: ![[BARZT:[0-9]+]]
     // CHECK-DAG: ![[BARZT]] = !DISubroutineType(types: ![[BARZARGS:.*]])
     // CHECK-DAG: ![[BARZARGS]] = !{![[INT]], ![[FLOAT]], ![[FLOAT]]}
-    var barz_function_pointer = barz
-    return barz_function_pointer(2.89, -1.0)
+    var barz_fnptr = barz
+    return barz_fnptr(2.89, -1.0)
 }
 
 main()

--- a/test/DebugInfo/generic_enum.swift
+++ b/test/DebugInfo/generic_enum.swift
@@ -18,7 +18,7 @@ func wrapTrivialGeneric<T, U>(_ t: T, u: U) -> TrivialGeneric<T, U> {
 }
 // CHECK-DAG: ![[T1:.*]] = !DICompositeType({{.*}}identifier: "_TtGO12generic_enum14TrivialGenericVs5Int64SS_"
 // CHECK-DAG: !DIGlobalVariable(name: "tg",{{.*}} line: [[@LINE+2]],{{.*}} type: ![[T1]],{{.*}} isLocal: false, isDefinition: true
-// CHECK-DAG: !DICompositeType(tag: DW_TAG_union_type, name: "TrivialGeneric", {{.*}}identifier: "_TtGO12generic_enum14TrivialGenericVs5Int64SS_"
+// CHECK-DAG: !DICompositeType({{.*}}, name: "TrivialGeneric", {{.*}}identifier: "_TtGO12generic_enum14TrivialGenericVs5Int64SS_"
 var tg : TrivialGeneric<Int64, String> = .x(23, "skidoo")
 switch tg {
 case .x(var t, var u):

--- a/test/DebugInfo/protocolarg.swift
+++ b/test/DebugInfo/protocolarg.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | FileCheck %s
 
 func markUsed<T>(_ t: T) {}
+func use<T>(_ t: inout T) {}
 
 public protocol IGiveOutInts {
   func callMe() -> Int64
@@ -13,15 +14,16 @@ public protocol IGiveOutInts {
 // CHECK-SAME:              metadata ![[ARG:.*]], metadata ![[DEREF:.*]])
 
 // CHECK: ![[EMPTY]] = !DIExpression()
-// FIXME: Should be DW_TAG_interface_type
-// CHECK: ![[PT:.*]] = !DICompositeType(tag: DW_TAG_structure_type, name: "IGiveOutInts"
 
 public func printSomeNumbers(_ gen: IGiveOutInts) {
   var gen = gen
   // CHECK: ![[VAR]] = !DILocalVariable(name: "gen", {{.*}} line: [[@LINE-1]]
+  // FIXME: Should be DW_TAG_interface_type
+  // CHECK: ![[PT:.*]] = !DICompositeType(tag: DW_TAG_structure_type, name: "IGiveOutInts"
   // CHECK: ![[ARG]] = !DILocalVariable(name: "gen", arg: 1,
-  // CHECK-SAME:                        line: [[@LINE-4]], type: ![[PT]]
+  // CHECK-SAME:                        line: [[@LINE-6]], type: ![[PT]]
   // CHECK: ![[DEREF]] = !DIExpression(DW_OP_deref)
   markUsed(gen.callMe())
+  use(&gen)
 }
 

--- a/test/DebugInfo/tuple.swift
+++ b/test/DebugInfo/tuple.swift
@@ -1,5 +1,26 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-ir -g -o - | FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -gdwarf-types -o - \
+// RUN:   | FileCheck %s --check-prefix=DWARF
+
 // Don't emit a line number for tuple types. They are unnamed
 // and have no declaration, so the line number is nonsensical.
 // CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "_TtTSiSf_"
-let tuple : (Int, Float) = (1, 2.89)
+// CHECK-NOT: line:
+// CHECK-NEXT: =
+let tuple1 : (Int, Float) = (1, 2.89)
+
+// Tuple types.
+var tuple2: (Double, Bool) = (1, true)
+// DWARF: !DIGlobalVariable(name: "tuple2",{{.*}} type: ![[TUPTY:[^,)]+]]
+// DWARF: ![[TUPTY]] = !DICompositeType(tag: DW_TAG_structure_type,
+// DWARF-SAME:                          elements: ![[ELEMS:[0-9]+]]
+// DWARF: ![[ELEMS]] = !{![[MD:[0-9]+]], ![[MB:[0-9]+]]}
+// DWARF: ![[MD]] = !DIDerivedType(tag: DW_TAG_member
+// DWARF-SAME:                     baseType: ![[DBL:[0-9]+]]
+// DWARF: ![[DBL]] = !DICompositeType({{.*}}, name: "Double"
+// DWARF: ![[MB]] = !DIDerivedType(tag: DW_TAG_member,
+// DWARF-SAME:                     baseType: ![[B:[0-9]+]]
+// DWARF: ![[B]] = !DICompositeType({{.*}}, name: "Bool"
+func myprint(_ p: (i: Int, b: Bool)) {
+     print("\(p.i) -> \(p.b)")
+}

--- a/test/DebugInfo/variables.swift
+++ b/test/DebugInfo/variables.swift
@@ -60,11 +60,7 @@ var g = foo(1.0);
 // Tuple types.
 var tuple: (Int, Bool) = (1, true)
 // CHECK-DAG: !DIGlobalVariable(name: "tuple", linkageName: "_Tv{{9variables|4main}}5tupleTSiSb_",{{.*}} type: ![[TUPTY:[^,)]+]]
-// CHECK-DAG: ![[TUPTY]] = !DICompositeType(tag: DW_TAG_structure_type,{{.*}} elements: ![[ELEMS:[0-9]+]]
-// CHECK-DAG: ![[ELEMS]] = !{![[MI64:[0-9]+]], ![[MB:[0-9]+]]}
-// CHECK-DAG: ![[INTTY:.*]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Int"
-// CHECK-DAG: ![[MI64]] = !DIDerivedType(tag: DW_TAG_member,{{.*}} baseType: ![[INTTY]]
-// CHECK-DAG: ![[MB]] = !DIDerivedType(tag: DW_TAG_member,{{.*}} baseType: ![[B]]
+// CHECK-DAG: ![[TUPTY]] = !DICompositeType({{.*}}identifier: "_TtTSiSb_"
 func myprint(_ p: (i: Int, b: Bool)) {
      print("\(p.i) -> \(p.b)")
 }

--- a/test/DebugInfo/variables.swift
+++ b/test/DebugInfo/variables.swift
@@ -102,7 +102,7 @@ enum TriValue {
   case top
 }
 // CHECK-DAG: !DIGlobalVariable(name: "unknown",{{.*}} type: ![[TRIVAL:[0-9]+]]
-// CHECK-DAG: ![[TRIVAL]] = !DICompositeType(tag: DW_TAG_union_type, name: "TriValue",
+// CHECK-DAG: ![[TRIVAL]] = !DICompositeType({{.*}}name: "TriValue",
 var unknown = TriValue.top
 func myprint(_ value: TriValue) {
      switch value {


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Now that Swift AST type support in LLDB has matured, we can stop emitting DWARF
    type information by default to reduce compile time and ibject file size.
    A future commit will change -g to emit only AST type references.

```
The full set of debug options is now
-gnone
-gline-tables-only
-g                 // AST types (= everything that LLDB needs)
-gdwarf-types      // AST types + DWARF types (for legacy debuggers)
```

Note that the size difference between -gdwarf-types and -g is measurable, but not really significant in the bigger picture since DWARF is already a highly compressed format. On a Release Swift.o (x86_64 stdlib) emitting the AST types only saves ~100kb of debug info.

<!-- Description about pull request. -->
#### Resolved bug number: rdar://problem/25498103

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

**Validation Testing**

@swift-ci Please test and merge
</details>

<!-- Thank you for your contribution to Swift! -->
