### PR TITLE
Do not type check lazy accessor bodies eagerly.

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1625,6 +1625,7 @@ void TypeChecker::completeLazyVarImplementation(VarDecl *VD) {
 
   // Now that we've got the storage squared away, synthesize the getter.
   auto *Get = completeLazyPropertyGetter(VD, Storage, *this);
+  validateDecl(Get);
 
   // The setter just forwards on to storage without materializing the initial
   // value.
@@ -1643,12 +1644,6 @@ void TypeChecker::completeLazyVarImplementation(VarDecl *VD) {
   Storage->setImplicit();
   Storage->setAccessibility(Accessibility::Private);
   Storage->setSetterAccessibility(Accessibility::Private);
-
-  typeCheckDecl(Get, true);
-  typeCheckDecl(Get, false);
-
-  typeCheckDecl(Set, true);
-  typeCheckDecl(Set, false);
 }
 
 

--- a/test/Sema/Inputs/forbid_typecheck_2.swift
+++ b/test/Sema/Inputs/forbid_typecheck_2.swift
@@ -8,4 +8,5 @@ class NOTYPECHECK_cls {}
 
 class ClsSec {
   let member : Int = NOTYPECHECK_member
+  lazy var lazymember: Int = NOTYPECHECK_lazymember
 }


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Remove some cross-file type checking overhead of lazy property accessors of properties that are typed patterns.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Start chipping away at cross-file type checker performance issues by
avoiding type checking of lazy property accessor bodies when the type in
question is defined in a different file and the lazy property is a typed
pattern.

We still type check these in the file they are defined in when we go to
type check the types defined within that file.

Resolves rdar://problem/26894118.
