### PR TITLE
StdlibStubs: Favor swift::Lazy over static local initialization.

### DIFF
--- a/include/swift/Basic/Lazy.h
+++ b/include/swift/Basic/Lazy.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_BASIC_LAZY_H
 #define SWIFT_BASIC_LAZY_H
 
+#include <memory>
 #ifdef __APPLE__
 #include <dispatch/dispatch.h>
 #else

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include "swift/Basic/Lazy.h"
 #include "../SwiftShims/LibcShims.h"
 #include "llvm/Support/DataTypes.h"
 
@@ -105,9 +106,10 @@ size_t swift::_swift_stdlib_malloc_size(const void *ptr) {
 #error No malloc_size analog known for this platform/libc.
 #endif
 
+static Lazy<std::mt19937> theGlobalMT19937;
+
 static std::mt19937 &getGlobalMT19937() {
-  static std::mt19937 MersenneRandom;
-  return MersenneRandom;
+  return theGlobalMT19937.get();
 }
 
 __swift_uint32_t swift::_swift_stdlib_cxx11_mt19937() {

--- a/stdlib/public/stubs/UnicodeNormalization.cpp
+++ b/stdlib/public/stubs/UnicodeNormalization.cpp
@@ -14,6 +14,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/Basic/Lazy.h"
 #include "swift/Runtime/Config.h"
 #include "swift/Runtime/Debug.h"
 
@@ -63,8 +64,7 @@ static const UCollator *MakeRootCollator() {
 // const here to make sure we don't misuse it.
 // http://sourceforge.net/p/icu/mailman/message/27427062/
 static const UCollator *GetRootCollator() {
-  static const UCollator *RootCollator = MakeRootCollator();
-  return RootCollator;
+  return SWIFT_LAZY_CONSTANT(MakeRootCollator());
 }
 
 /// This class caches the collation element results for the ASCII subset of
@@ -72,12 +72,11 @@ static const UCollator *GetRootCollator() {
 class ASCIICollation {
   int32_t CollationTable[128];
 public:
+  friend class swift::Lazy<ASCIICollation>;
 
+  static swift::Lazy<ASCIICollation> theTable;
   static const ASCIICollation *getTable() {
-    // We are reallying on C++11's guaranteed of thread safe static variable
-    // initialization.
-    static ASCIICollation collation;
-    return &collation;
+    return &theTable.get();
   }
 
   /// Maps an ASCII character to a collation element priority as would be
@@ -343,3 +342,5 @@ swift::_swift_stdlib_unicode_strToLower(uint16_t *Destination,
   }
   return OutputLength;
 }
+
+swift::Lazy<ASCIICollation> ASCIICollation::theTable;


### PR DESCRIPTION
To minimize code size and VM live set, we try to funnel all one-time initialization through swift_once instead of mixing it with the C++ runtime's support for lazy static initialization.
