### PR TITLE
[stdlib] add simple tests for past-the-end behavior of stride iterators

### DIFF
--- a/test/1_stdlib/Strideable.swift
+++ b/test/1_stdlib/Strideable.swift
@@ -204,5 +204,33 @@ StrideTestSuite.test("ErrorAccumulation") {
   expectEqual(10, b.count)
 }
 
+func strideIteratorTest<
+  Stride : Sequence
+>(_ stride: Stride, nonNilResults: Int) {
+  var i = stride.makeIterator()
+  for _ in 0..<nonNilResults {
+     expectNotEmpty(i.next())
+  }
+  for _ in 0..<10 {
+    expectEmpty(i.next())
+  }
+}
+
+StrideTestSuite.test("StrideThroughIterator/past end") {
+  strideIteratorTest(stride(from: 0, through: 3, by: 1), nonNilResults: 4)
+}
+
+StrideTestSuite.test("StrideThroughIterator/past end/backward") {
+  strideIteratorTest(stride(from: 3, through: 0, by: -1), nonNilResults: 4)
+}
+
+StrideTestSuite.test("StrideToIterator/past end") {
+  strideIteratorTest(stride(from: 0, to: 3, by: 1), nonNilResults: 3)
+}
+
+StrideTestSuite.test("StrideToIterator/past end/backward") {
+  strideIteratorTest(stride(from: 3, to: 0, by: -1), nonNilResults: 3)
+}
+
 runAllTests()
 


### PR DESCRIPTION
Making sure that iterators produced by `StrideTo` and `StrideThrough` sequences keep returning `nil` after the end has been reached.
