### PR TITLE
[Syntax] Avoid highlighting keyword-like labels in call arguments as …

### DIFF
--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -490,6 +490,19 @@ let black = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)
 "--\"\(x) --"
 // CHECK: <str>"--\"</str>\<anchor>(</anchor>x<anchor>)</anchor><str> --"</str>
 
+func keywordAsLabel1(in: Int) {}
+// CHECK: <kw>func</kw> keywordAsLabel1(in: <type>Int</type>) {}
+func keywordAsLabel2(for: Int) {}
+// CHECK: <kw>func</kw> keywordAsLabel2(for: <type>Int</type>) {}
+
+func foo1() {
+// CHECK: <kw>func</kw> foo1() {
+  keywordAsLabel1(in: 1)
+// CHECK: keywordAsLabel1(in: <int>1</int>)
+  keywordAsLabel2(for: 1)
+// CHECK: keywordAsLabel2(for: <int>1</int>)
+}
+
 // Keep this as the last test
 /**
   Trailing off ...

--- a/test/SourceKit/SyntaxMapData/syntaxmap-object-literals.swift.response
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-object-literals.swift.response
@@ -29,7 +29,7 @@
       key.length: 40
     },
     {
-      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.kind: source.lang.swift.syntaxtype.identifier,
       key.offset: 165,
       key.length: 3
     },
@@ -44,7 +44,7 @@
       key.length: 50
     },
     {
-      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.kind: source.lang.swift.syntaxtype.identifier,
       key.offset: 228,
       key.length: 3
     },


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->

This patch allows keywords-like labels, like "in" and "for", to be not highlighted as keywords when they appear in function calls.

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…keywords. rdar://24460689
