### PR TITLE
[SyntaxColoring] Tolerating empty spaces between doc-comment openning…

### DIFF
--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -245,7 +245,7 @@ static const char *const RegexStrURL =
 #define MARKUP_SIMPLE_FIELD(Id, Keyword, XMLKind) \
   #Keyword "|"
 static const char *const RegexStrDocCommentField =
-  "^[ ]?- ("
+  "^[ ]*- ("
 #include "swift/Markup/SimpleFields.def"
   "returns):";
 

--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -168,6 +168,18 @@ func foo(n: Float) -> Int {
     return 100009
 }
 
+///- returns: single-line, no space
+// CHECK: ///- <doc-comment-field>returns</doc-comment-field>: single-line, no space
+
+/// - returns: single-line, 1 space
+// CHECK: /// - <doc-comment-field>returns</doc-comment-field>: single-line, 1 space
+
+///  - returns: single-line, 2 spaces
+// CHECK: ///  - <doc-comment-field>returns</doc-comment-field>: single-line, 2 spaces
+
+///       - returns: single-line, more spaces
+// CHECK: ///       - <doc-comment-field>returns</doc-comment-field>: single-line, more spaces
+
 // CHECK: <kw>protocol</kw> Prot {
 protocol Prot {
   // CHECK: <kw>typealias</kw> Blarg

--- a/test/SourceKit/SyntaxMapData/syntaxmap.swift.response
+++ b/test/SourceKit/SyntaxMapData/syntaxmap.swift.response
@@ -361,7 +361,17 @@
     {
       key.kind: source.lang.swift.syntaxtype.doccomment,
       key.offset: 666,
-      key.length: 59
+      key.length: 13
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.doccomment.field,
+      key.offset: 679,
+      key.length: 8
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.doccomment,
+      key.offset: 687,
+      key.length: 38
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->

This patch highlights doc-comment field keywords disregarding of the whitespaces between comment openings and the keywords.

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…s and field keywords. rdar://26310081
