### PR TITLE
SILGen: Look through ErasureExprs when bridging to AnyObject.

### DIFF
--- a/lib/SIL/Bridging.cpp
+++ b/lib/SIL/Bridging.cpp
@@ -170,6 +170,11 @@ Type TypeConverter::getLoweredCBridgedType(AbstractionPattern pattern,
     }
   }
   
+  // `Any` can bridge to `AnyObject` (`id` in ObjC).
+  if (Context.LangOpts.EnableIdAsAny && t->isAny()) {
+    return Context.getProtocol(KnownProtocolKind::AnyObject)->getDeclaredType();
+  }
+  
   if (auto funTy = t->getAs<FunctionType>()) {
     switch (funTy->getExtInfo().getSILRepresentation()) {
     // Functions that are already represented as blocks or C function pointers

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3053,16 +3053,30 @@ namespace {
                                       emitted.contextForReabstraction);
     }
     
+    CanType getAnyObjectType() {
+      return SGF.getASTContext()
+        .getProtocol(KnownProtocolKind::AnyObject)
+        ->getDeclaredType()
+        ->getCanonicalType();
+    }
+    bool isAnyObjectType(CanType t) {
+      return t == getAnyObjectType();
+    }
+    
     ManagedValue emitNativeToBridgedArgument(ArgumentSource &&arg,
                                              SILType loweredSubstArgType,
                                              AbstractionPattern origParamType,
                                              SILParameterInfo param) {
-      // TODO: We should take the opportunity to peephole certain sequences
-      // here. For instance, when going from concrete type -> Any -> id, we
-      // can skip the intermediate 'Any' boxing and directly bridge the concrete
-      // type to its object representation. Similarly, when bridging from
-      // NSFoo -> Foo -> NSFoo, we should elide the bridge altogether and pass
-      // the original object.
+      // If we're bridging a concrete type to `id` via Any, skip the Any
+      // boxing.
+      // TODO: Generalize. Similarly, when bridging from NSFoo -> Foo -> NSFoo,
+      // we should elide the bridge altogether and pass the original object.
+      if (isAnyObjectType(param.getType()) && !arg.isRValue()) {
+        return emitNativeToBridgedObjectArgument(std::move(arg).asKnownExpr(),
+                                                 loweredSubstArgType,
+                                                 origParamType, param);
+      }
+      
       auto emitted = emitArgumentFromSource(std::move(arg), loweredSubstArgType,
                                             origParamType, param);
       
@@ -3070,6 +3084,67 @@ namespace {
                                       std::move(emitted.value).getScalarValue(),
                                       Rep, param.getType());
                                       
+    }
+    
+    /// Emit an argument expression that we know will be bridged to an
+    /// Objective-C object.
+    ManagedValue emitNativeToBridgedObjectArgument(Expr *argExpr,
+                                               SILType loweredSubstArgType,
+                                               AbstractionPattern origParamType,
+                                               SILParameterInfo param) {
+      argExpr = argExpr->getSemanticsProvidingExpr();
+      
+      // Look through ErasureExprs and try to bridge the underlying
+      // concrete value instead.
+      while (auto erasure = dyn_cast<ErasureExpr>(argExpr))
+        argExpr = erasure->getSubExpr();
+      
+      // Emit the argument.
+      auto contexts = getRValueEmissionContexts(loweredSubstArgType, param);
+      ManagedValue emittedArg = SGF.emitRValue(argExpr, contexts.ForEmission)
+        .getScalarValue();
+      
+      // If the argument is not already a class instance, bridge it.
+      if (!argExpr->getType()->mayHaveSuperclass()
+          && !argExpr->getType()->isClassExistentialType()) {
+        emittedArg = SGF.emitNativeToBridgedValue(argExpr, emittedArg,
+                                                  Rep, param.getType());
+      }
+      auto emittedArgTy = emittedArg.getType().getSwiftRValueType();
+      assert(emittedArgTy->mayHaveSuperclass()
+        || emittedArgTy->isClassExistentialType());
+      
+      // Upcast reference types to AnyObject.
+      if (!isAnyObjectType(emittedArgTy)) {
+        // Open class existentials first to upcast the reference inside.
+        if (emittedArgTy->isClassExistentialType()) {
+          emittedArgTy = ArchetypeType::getOpened(emittedArgTy);
+          auto opened = SGF.B.createOpenExistentialRef(argExpr,
+                                 emittedArg.getValue(),
+                                 SILType::getPrimitiveObjectType(emittedArgTy));
+          emittedArg = ManagedValue(opened, emittedArg.getCleanup());
+        }
+        
+        // Erase to AnyObject.
+        auto conformance = SGF.SGM.SwiftModule->lookupConformance(
+          emittedArgTy,
+          SGF.getASTContext().getProtocol(KnownProtocolKind::AnyObject),
+          nullptr);
+        assert(conformance &&
+               "no AnyObject conformance for class?!");
+        
+        ArrayRef<ProtocolConformanceRef> conformances(*conformance);
+        auto ctxConformances = SGF.getASTContext().AllocateCopy(conformances);
+        
+        auto erased = SGF.B.createInitExistentialRef(argExpr,
+                           SILType::getPrimitiveObjectType(getAnyObjectType()),
+                           emittedArgTy, emittedArg.getValue(),
+                           ctxConformances);
+        emittedArg = ManagedValue(erased, emittedArg.getCleanup());
+      }
+      
+      assert(isAnyObjectType(emittedArg.getSwiftType()));
+      return emittedArg;
     }
     
     struct EmittedArgument {

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -1039,6 +1039,9 @@ extern NSString *NSHTTPRequestKey;
 - (id _Nonnull)makesId;
 - (void)takesId:(id _Nonnull)x;
 - (void)takesArrayOfId:(const id _Nonnull * _Nonnull)x;
+- (void)takesNullableId:(id _Nullable)x;
+
+@property (strong) id propertyOfId;
 
 @end
 

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -1,0 +1,77 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-id-as-any -emit-silgen %s | FileCheck %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+protocol P {}
+protocol CP: class {}
+
+// CHECK-LABEL: sil hidden @_TF17objc_bridging_any11passingToId
+func passingToId<T: CP, U>(receiver: IdLover,
+                           string: String,
+                           nsString: NSString,
+                           object: AnyObject,
+                           classGeneric: T,
+                           classExistential: CP,
+                           generic: U,
+                           existential: P,
+                           any: Any) {
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF:%.*]] : $IdLover,
+  // CHECK: [[BRIDGE_STRING:%.*]] = function_ref @_TFE10FoundationSS19_bridgeToObjectiveC
+  // CHECK: [[NSSTRING:%.*]] = apply [[BRIDGE_STRING]]
+  // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref [[NSSTRING]] : $NSString : $NSString, $AnyObject
+  // CHECK: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  receiver.takesId(string)
+
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF:%.*]] : $IdLover,
+  // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref {{%.*}} : $NSString : $NSString, $AnyObject
+  // CHECK: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  receiver.takesId(nsString)
+
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF:%.*]] : $IdLover,
+  // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref {{%.*}} : $T : $T, $AnyObject
+  // CHECK: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  receiver.takesId(classGeneric)
+
+  // TODO: Need to look through an (open_existential (erasure)) combo to upcast
+  // an existential to Any.
+  /*
+  receiver.takesId(object)
+  receiver.takesId(classExistential)
+   */
+
+  // TODO: These cases need to perform a (to-be-implemented) universal
+  // bridging conversion.
+  /*
+  receiver.takesId(generic)
+  receiver.takesId(existential)
+  receiver.takesId(any)
+   */
+
+  // TODO: Property and subscript setters
+}
+
+// TODO: Look through value-to-optional and optional-to-optional conversions.
+/*
+func passingToNullableId(receiver: IdLover,
+                         string: String,
+                         nsString: NSString,
+                         object: AnyObject,
+                         any: Any,
+                         optString: String?,
+                         optNSString: NSString?,
+                         optObject: AnyObject?,
+                         optAny: Any?)
+{
+  receiver.takesNullableId(string)
+  receiver.takesNullableId(nsString)
+  receiver.takesNullableId(object)
+  receiver.takesNullableId(any)
+  receiver.takesNullableId(optString)
+  receiver.takesNullableId(optNSString)
+  receiver.takesNullableId(optObject)
+  receiver.takesNullableId(optAny)
+}
+ */
+
+// TODO: casting from id, nullable or not


### PR DESCRIPTION
When we have an argument expr of type Any that's being emitted as a bridged ObjC object parameter, look through any ErasureExprs and directly bridge the concrete value. This saves us emitting an intermediate 'Any' value in the common case where a value of known concrete type is passed in from Swift.
