### PR TITLE
[Sema] Fix crashers due to invalid generic decls inside non-generic decls and vice versa

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4757,7 +4757,7 @@ Type TypeBase::getSwiftNewtypeUnderlyingType() {
 ClassDecl *ClassDecl::getSuperclassDecl() const {
   if (auto superclass = getSuperclass())
     return superclass->getClassOrBoundGenericClass();
-    return nullptr;
+  return nullptr;
 }
 
 void ClassDecl::setSuperclass(Type superclass) {

--- a/lib/Sema/ITCDecl.cpp
+++ b/lib/Sema/ITCDecl.cpp
@@ -153,6 +153,8 @@ void IterativeTypeChecker::processTypeCheckSuperclass(
   }
 
   // Set the superclass type.
+  if (classDecl->isInvalid())
+    superclassType = ErrorType::get(getASTContext());
   classDecl->setSuperclass(superclassType);
 }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3418,6 +3418,7 @@ public:
                       NTD->getName(),
                       proto->getName());
         }
+        NTD->setInvalid();
         return true;
       }
 
@@ -3432,6 +3433,7 @@ public:
                         diag::unsupported_type_nested_in_generic_type,
                         NTD->getName(),
                         parent->getName());
+          NTD->setInvalid();
           return true;
         } else if (auto ED = dyn_cast<ExtensionDecl>(DC)) {
           auto *parent = ED->getAsNominalTypeOrNominalTypeExtensionContext();

--- a/test/Parse/matching_patterns.swift
+++ b/test/Parse/matching_patterns.swift
@@ -151,7 +151,7 @@ struct ContainsEnum {
 
   func member(_ n: Possible<Int>) {
     switch n {
-    case ContainsEnum.Possible<Int>.Naught,
+    case ContainsEnum.Possible<Int>.Naught, // expected-error{{cannot specialize a non-generic definition}} expected-note {{while parsing this '<' as a type parameter bracket}}
          ContainsEnum.Possible.Naught,
          Possible<Int>.Naught,
          Possible.Naught,
@@ -163,7 +163,7 @@ struct ContainsEnum {
 
 func nonmemberAccessesMemberType(_ n: ContainsEnum.Possible<Int>) {
   switch n {
-  case ContainsEnum.Possible<Int>.Naught,
+  case ContainsEnum.Possible<Int>.Naught, // expected-error{{cannot specialize a non-generic definition}} expected-note {{while parsing this '<' as a type parameter bracket}}
        .Naught:
     ()
   }

--- a/test/Parse/type_expr.swift
+++ b/test/Parse/type_expr.swift
@@ -105,8 +105,8 @@ func genQualifiedType() {
   let _ : () = Gen<Foo>.Bar.meth()
   _ = Gen<Foo>.Bar.instMeth
 
-  _ = Gen<Foo>.Bar // expected-error{{expected member name or constructor call after type name}} expected-note{{add arguments}} {{19-19=()}} expected-note{{use '.self'}} {{19-19=.self}}
-  _ = Gen<Foo>.Bar.dynamicType // expected-error{{'.dynamicType' is not allowed after a type name}} {{20-31=self}}
+  _ = Gen<Foo>.Bar
+  _ = Gen<Foo>.Bar.dynamicType
 }
 
 func archetype<T: Zim>(_: T) {

--- a/test/decl/func/default-values.swift
+++ b/test/decl/func/default-values.swift
@@ -48,9 +48,9 @@ struct Outer<T> {
     }
   }
 }
-Outer<Int>.Inner.VeryInner() // expected-warning{{unused}}
-Outer<Int>.Inner.VeryInner(i: 12) // expected-warning{{unused}}
-Outer<Int>.Inner.VeryInner(f:12.5) // expected-warning{{unused}}
+Outer<Int>.Inner.VeryInner()
+Outer<Int>.Inner.VeryInner(i: 12)
+Outer<Int>.Inner.VeryInner(f:12.5)
 Outer<Int>.Inner.VeryInner.f()
 Outer<Int>.Inner.VeryInner.f(i: 12)
 Outer<Int>.Inner.VeryInner.f(f:12.5)

--- a/test/decl/nested/type_in_type.swift
+++ b/test/decl/nested/type_in_type.swift
@@ -128,7 +128,7 @@ struct AnyStream<T : Sequence> {
   // Conform to the enumerable protocol.
   typealias Elements = StreamRange<T.Iterator>
   func getElements() -> Elements {
-    return Elements(index: 0, elements: input.makeIterator())
+    return Elements(index: 0, elements: input.makeIterator()) // expected-error {{'AnyStream<T>.StreamRange<T.Iterator>' cannot be constructed because it has no accessible initializers}}
   }
 }
 
@@ -177,7 +177,7 @@ extension Bar {
 class X6<T> {
   let d: D<T>
   init(_ value: T) {
-    d = D(value)
+    d = D(value) // expected-error{{'<<error type>>' cannot be constructed because it has no accessible initializers}}
   }
   class D<T2> { // expected-error{{generic type 'D' cannot be nested in type 'X6'}}
     init(_ value: T2) {}
@@ -203,7 +203,7 @@ struct GS<T> {
   struct NestedGeneric<U> { // expected-note{{generic type 'NestedGeneric' declared here}} // expected-error{{generic type 'NestedGeneric' cannot be nested in type 'GS'}}
     func fff() -> (GS, NestedGeneric) {
       let gs = GS()
-      let ns = NestedGeneric()
+      let ns = NestedGeneric() // expected-error {{'GS<T>.NestedGeneric<U>' cannot be constructed because it has no accessible initializers}}
       return (gs, ns)
     }
   }
@@ -245,7 +245,7 @@ func useNested(_ ii: Int, hni: HasNested<Int>,
   typealias InnerI = HasNested<Int>.Inner
   var innerI = InnerI(5)
   typealias InnerF = HasNested<Float>.Inner
-  var innerF : InnerF = innerI // expected-error{{cannot convert value of type 'InnerI' (aka 'HasNested<Int>.Inner') to specified type 'InnerF' (aka 'HasNested<Float>.Inner')}}
+  var innerF : InnerF = innerI
 
   _ = innerI.identity(i)
   i = innerI.identity(i)
@@ -265,6 +265,6 @@ func useNested(_ ii: Int, hni: HasNested<Int>,
   var ids = xis.g(1, u: "Hello", v: 3.14159)
   ids = (2, "world", 2.71828)
 
-  xis = xfs // expected-error{{cannot assign value of type 'HasNested<Float>.InnerGeneric<String>' to type 'HasNested<Int>.InnerGeneric<String>'}}
+  xis = xfs
 }
 

--- a/validation-test/compiler_crashers_fixed/28291-swift-constraints-constraintsystem-comparesolutions.swift
+++ b/validation-test/compiler_crashers_fixed/28291-swift-constraints-constraintsystem-comparesolutions.swift
@@ -5,6 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
-var d{protocol A{{}class a:A{}typealias e:A.E{{}}class A:a
+class T,struct A{func b{}struct A{class B<T}func b:A.B{var _=b<T

--- a/validation-test/compiler_crashers_fixed/28319-swift-typechecker-checkconformance.swift
+++ b/validation-test/compiler_crashers_fixed/28319-swift-typechecker-checkconformance.swift
@@ -5,6 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
-class T,struct A{func b{}struct A{class B<T}func b:A.B{var _=b<T
+protocol A{enum B:A{let:e var _=B}typealias e

--- a/validation-test/compiler_crashers_fixed/28331-swift-createdesignatedinitoverride.swift
+++ b/validation-test/compiler_crashers_fixed/28331-swift-createdesignatedinitoverride.swift
@@ -5,6 +5,5 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
-// REQUIRES: asserts
-func a{protocol A{class b<T=class d:A.b
+// RUN: not %target-swift-frontend %s -parse
+let:{{class a{enum S<U:a{class B:a{init}}class a

--- a/validation-test/compiler_crashers_fixed/28334-swift-typechecker-resolvetypewitness.swift
+++ b/validation-test/compiler_crashers_fixed/28334-swift-typechecker-resolvetypewitness.swift
@@ -5,7 +5,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
 {
 enum S<H:A{

--- a/validation-test/compiler_crashers_fixed/28338-swift-genericsignature-getsubstitutionmap.swift
+++ b/validation-test/compiler_crashers_fixed/28338-swift-genericsignature-getsubstitutionmap.swift
@@ -5,7 +5,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
 if{
 protocol A{

--- a/validation-test/compiler_crashers_fixed/28339-swift-typechecker-addimplicitconstructors.swift
+++ b/validation-test/compiler_crashers_fixed/28339-swift-typechecker-addimplicitconstructors.swift
@@ -5,6 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
-struct A<A{class a{protocol A{struct B{}class B<T where B:T>:a
+var d{protocol A{{}class a:A{}typealias e:A.E{{}}class A:a

--- a/validation-test/compiler_crashers_fixed/28344-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/28344-swift-type-transform.swift
@@ -5,5 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
-let:{{class a{enum S<U:a{class B:a{init}}class a
+// RUN: not %target-swift-frontend %s -parse
+// REQUIRES: asserts
+func a{protocol A{class b<T=class d:A.b

--- a/validation-test/compiler_crashers_fixed/28345-swift-iterativetypechecker-processtypechecksuperclass.swift
+++ b/validation-test/compiler_crashers_fixed/28345-swift-iterativetypechecker-processtypechecksuperclass.swift
@@ -5,6 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
-protocol A{enum B:A{let:e var _=B}typealias e
+struct A<A{class a{protocol A{struct B{}class B<T where B:T>:a


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Mark decls that are illegal due to generic inside non-generic decl or non-generic inside generic decl with setInvalid(), and avoid assertions trying to set the superclass on classes in such situations by setting the superclass of an invalid decl to the error type.

This fixes 8 of the validation test compiler crashes, and also changes some errors in other tests where the main error is the invalid declaration and now the downstream errors can be a bit different because the decl has been invalidated.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
