### PR TITLE
Frontend: address some late comments from Jordan

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -108,6 +108,9 @@ def print_clang_stats : Flag<["-"], "print-clang-stats">,
 def serialize_debugging_options : Flag<["-"], "serialize-debugging-options">,
   HelpText<"Always serialize options for debugging (default: only for apps)">;
 
+def autolink_library : Separate<["-"], "autolink-library">,
+  HelpText<"Add dependent library">, Flags<[FrontendOption]>;
+
 } // end let Flags = [FrontendOption, NoDriverOption]
 
 def debug_crash_Group : OptionGroup<"<automatic crashing options>">;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -272,9 +272,6 @@ def Xlinker : Separate<["-"], "Xlinker">,
   Flags<[DoesNotAffectIncrementalBuild]>,
   HelpText<"Specifies an option which should be passed to the linker">;
 
-def autolink_library : Joined<["-"], "autolink-library=">,
-  HelpText<"Add dependent library">, Flags<[FrontendOption]>;
-
 // Optimization levels
 
 def O_Group : OptionGroup<"<optimization level options>">;

--- a/test/IRGen/dependent-library.swift
+++ b/test/IRGen/dependent-library.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target i686-unknown-windows-msvc -emit-ir -parse-as-library -parse-stdlib -module-name dependent -autolink-library=oldnames -autolink-library=msvcrt %s -o - | FileCheck %s
+// RUN: %swift -target i686-unknown-windows-msvc -emit-ir -parse-as-library -parse-stdlib -module-name dependent -autolink-library oldnames -autolink-library msvcrt %s -o - | FileCheck %s
 
 // CHECK: !{i32 6, !"Linker Options", ![[options:[0-9]+]]}
 // CHECK: ![[options]] = !{![[oldnames:[0-9]+]], ![[msvcrtd:[0-9]+]]}


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Move the option definition into FrontendOptions.td as it no longer can be passed
to the driver.  Use the single-dash separate form for the argument which is more
uniform with the rest of the options (and is arguably aesthetically more
pleasing).  NFC.
