### PR TITLE
Add 💥 (😢 → 50, 😀 → 5107) in swift::TypeChecker::validateDecl(…)

### DIFF
--- a/validation-test/compiler_crashers/28348-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers/28348-swift-typechecker-validatedecl.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+var:{{enum S<T{{
+}typealias d<T>:T
+struct T{var f:d


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Add test case for crash triggered in `swift::TypeChecker::validateDecl(…)`.

Assertion failure:

```
swift: /path/to/swift/lib/AST/ArchetypeBuilder.cpp:2109: static swift::Type swift::ArchetypeBuilder::mapTypeOutOfContext(swift::ModuleDecl *, swift::GenericParamList *, swift::Type): Assertion `!type->hasArchetype() && "not fully substituted"' failed.
```

<details>
<summary>

Stack trace:</summary>



```
swift: /path/to/swift/lib/AST/ArchetypeBuilder.cpp:2109: static swift::Type swift::ArchetypeBuilder::mapTypeOutOfContext(swift::ModuleDecl *, swift::GenericParamList *, swift::Type): Assertion `!type->hasArchetype() && "not fully substituted"' failed.
11 swift           0x0000000000eac9cd swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3853
12 swift           0x0000000000f3117d swift::createImplicitConstructor(swift::TypeChecker&, swift::NominalTypeDecl*, swift::ImplicitConstructorKind) + 413
13 swift           0x0000000000eb6e70 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 1536
18 swift           0x0000000000eb1266 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
21 swift           0x0000000000f18b24 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
22 swift           0x0000000000f44e3c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
23 swift           0x0000000000e9f8f1 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 769
26 swift           0x0000000000f177aa swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
27 swift           0x0000000000f1760e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
28 swift           0x0000000000f181d3 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
30 swift           0x0000000000ed34c1 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
31 swift           0x0000000000c60769 swift::CompilerInstance::performSema() + 3289
33 swift           0x00000000007d8429 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
34 swift           0x00000000007a4458 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28348-swift-typechecker-validatedecl.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28348-swift-typechecker-validatedecl-2bcb22.o
1.  While type-checking declaration 0x6a96ac0 at validation-test/compiler_crashers/28348-swift-typechecker-validatedecl.swift:10:5
2.  While type-checking expression at [validation-test/compiler_crashers/28348-swift-typechecker-validatedecl.swift:10:6 - line:12:16] RangeText="{enum S<T{{
3.  While type-checking 'S' at validation-test/compiler_crashers/28348-swift-typechecker-validatedecl.swift:10:7
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```

</details>
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
