### PR TITLE
Add 💥 (😢 → 52, 😀 → 5107) in swift::TypeBase::gatherAllSubstitutions(…)

### DIFF
--- a/validation-test/compiler_crashers/28349-swift-typebase-gatherallsubstitutions.swift
+++ b/validation-test/compiler_crashers/28349-swift-typebase-gatherallsubstitutions.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+class B}class B<T{class A{class B:A{var a{b}}func b


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Add test case for crash triggered in `swift::TypeBase::gatherAllSubstitutions(…)`.

<details>
<summary>

Stack trace:</summary>



```
6  swift           0x00000000032b06dd llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) + 461
7  swift           0x00000000010fa10e swift::TypeBase::gatherAllSubstitutions(swift::ModuleDecl*, swift::LazyResolver*, swift::DeclContext*) + 4398
8  swift           0x000000000111fe31 swift::TypeBase::getSuperclass(swift::LazyResolver*) + 193
9  swift           0x0000000000fa0c20 swift::constraints::ConstraintSystem::matchSuperclassTypes(swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 64
10 swift           0x0000000000fa1aeb swift::constraints::ConstraintSystem::simplifyRestrictedConstraint(swift::constraints::ConversionRestrictionKind, swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 1227
11 swift           0x0000000000f9ecd2 swift::constraints::ConstraintSystem::matchTypes(swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 10674
12 swift           0x0000000000fa8712 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 626
13 swift           0x0000000000f3aa77 swift::constraints::ConstraintSystem::addConstraint(swift::constraints::Constraint*, bool, bool) + 23
14 swift           0x0000000000f3d74c swift::constraints::ConstraintSystem::getTypeOfMemberReference(swift::Type, swift::ValueDecl*, bool, bool, swift::constraints::ConstraintLocatorBuilder, swift::DeclRefExpr const*, llvm::DenseMap<swift::CanType, swift::TypeVariableType*, llvm::DenseMapInfo<swift::CanType>, llvm::detail::DenseMapPair<swift::CanType, swift::TypeVariableType*> >*) + 2988
15 swift           0x0000000000f3e134 swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator*, swift::Type, swift::constraints::OverloadChoice) + 516
16 swift           0x0000000000fa8829 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 905
17 swift           0x0000000000f3aa77 swift::constraints::ConstraintSystem::addConstraint(swift::constraints::Constraint*, bool, bool) + 23
18 swift           0x0000000000f3dec7 swift::constraints::ConstraintSystem::addOverloadSet(swift::Type, llvm::ArrayRef<swift::constraints::OverloadChoice>, swift::constraints::ConstraintLocator*, swift::constraints::OverloadChoice*) + 327
19 swift           0x0000000000fa73d3 swift::constraints::ConstraintSystem::simplifyMemberConstraint(swift::constraints::Constraint const&) + 563
20 swift           0x0000000000fa84e4 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 68
21 swift           0x0000000000f3aa77 swift::constraints::ConstraintSystem::addConstraint(swift::constraints::Constraint*, bool, bool) + 23
24 swift           0x0000000001066795 swift::Expr::walk(swift::ASTWalker&) + 69
25 swift           0x0000000000f84738 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) + 200
26 swift           0x0000000000e99333 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 371
27 swift           0x0000000000e9fc72 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
30 swift           0x0000000000f17bca swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
31 swift           0x0000000000f17a2e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
32 swift           0x0000000000f185f3 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
34 swift           0x0000000000ed38e1 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
35 swift           0x0000000000c60b89 swift::CompilerInstance::performSema() + 3289
37 swift           0x00000000007d8429 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
38 swift           0x00000000007a4458 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28349-swift-typebase-gatherallsubstitutions.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28349-swift-typebase-gatherallsubstitutions-4b98db.o
1.  While type-checking getter for a at validation-test/compiler_crashers/28349-swift-typebase-gatherallsubstitutions.swift:9:42
2.  While type-checking expression at [validation-test/compiler_crashers/28349-swift-typebase-gatherallsubstitutions.swift:9:43 - line:9:43] RangeText="b"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```

</details>
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
