### PR TITLE
Add 💥 (😢 → 53, 😀 → 5107) in swift::TypeChecker::performTypoCorrection(…)

### DIFF
--- a/validation-test/compiler_crashers/28350-swift-typechecker-performtypocorrection.swift
+++ b/validation-test/compiler_crashers/28350-swift-typechecker-performtypocorrection.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+struct c{class A:A{}var f=A.s


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Add test case for crash triggered in `swift::TypeChecker::performTypoCorrection(…)`.

Assertion failure in [`lib/AST/LookupVisibleDecls.cpp (line 566)`](https://github.com/apple/swift/blob/master/lib/AST/LookupVisibleDecls.cpp#L566):

```
Assertion `BaseTy.getPointer() != CurClass->getSuperclass().getPointer() && "type is its own superclass"' failed.

When executing: void lookupVisibleMemberDeclsImpl(swift::Type, swift::VisibleDeclConsumer &, const swift::DeclContext *, (anonymous namespace)::LookupState, swift::DeclVisibilityKind, swift::LazyResolver *, VisitedSet &)
```

<details>
<summary>

Assertion context:</summary>



```
                                   Visited);
    return;
  }

  do {
    NominalTypeDecl *CurNominal = BaseTy->getAnyNominal();
    if (!CurNominal)
      break;

    // Look in for members of a nominal type.
    lookupTypeMembers(BaseTy, BaseTy, Consumer, CurrDC, LS, Reason,
                      TypeResolver);
    lookupDeclsFromProtocolsBeingConformedTo(BaseTy, Consumer, LS, CurrDC,
                                             Reason, TypeResolver, Visited);
    // If we have a class type, look into its superclass.
    ClassDecl *CurClass = dyn_cast<ClassDecl>(CurNominal);

    if (CurClass && CurClass->hasSuperclass()) {
      assert(BaseTy.getPointer() != CurClass->getSuperclass().getPointer() &&
             "type is its own superclass");
```

</details>
<details>
<summary>

Stack trace:</summary>



```
swift: /path/to/swift/lib/AST/LookupVisibleDecls.cpp:566: void lookupVisibleMemberDeclsImpl(swift::Type, swift::VisibleDeclConsumer &, const swift::DeclContext *, (anonymous namespace)::LookupState, swift::DeclVisibilityKind, swift::LazyResolver *, VisitedSet &): Assertion `BaseTy.getPointer() != CurClass->getSuperclass().getPointer() && "type is its own superclass"' failed.
10 swift           0x0000000000eeeeeb swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::Type, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) + 267
12 swift           0x0000000000f63c52 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 8738
13 swift           0x0000000000f6741e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 3998
14 swift           0x0000000000e99512 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 850
15 swift           0x0000000000e9fc72 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
16 swift           0x0000000000ea0e27 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 343
17 swift           0x0000000000ea103b swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
19 swift           0x0000000000eacded swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3853
20 swift           0x0000000000f3155d swift::createImplicitConstructor(swift::TypeChecker&, swift::NominalTypeDecl*, swift::ImplicitConstructorKind) + 413
21 swift           0x0000000000eb7290 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 1536
24 swift           0x0000000000eb1686 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
25 swift           0x0000000000ed37e2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
26 swift           0x0000000000c60b89 swift::CompilerInstance::performSema() + 3289
28 swift           0x00000000007d8429 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
29 swift           0x00000000007a4458 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28350-swift-typechecker-performtypocorrection.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28350-swift-typechecker-performtypocorrection-9b1949.o
1.  While type-checking 'c' at validation-test/compiler_crashers/28350-swift-typechecker-performtypocorrection.swift:10:1
2.  While type-checking expression at [validation-test/compiler_crashers/28350-swift-typechecker-performtypocorrection.swift:10:27 - line:10:29] RangeText="A.s"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```

</details>
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
