### PR TITLE
Add 💥 (😢 → 55, 😀 → 5107) in swift::TypeChecker::configureInterfaceType(…)

### DIFF
--- a/validation-test/compiler_crashers/28352-swift-typechecker-configureinterfacetype.swift
+++ b/validation-test/compiler_crashers/28352-swift-typechecker-configureinterfacetype.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+extension RawRepresentable{func a{struct A{let e:A.B)typealias B<T>:T


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Add test case for crash triggered in `swift::TypeChecker::configureInterfaceType(…)`.

Assertion failure in [`lib/AST/Parameter.cpp (line 154)`](https://github.com/apple/swift/blob/master/lib/AST/Parameter.cpp#L154):

```
Assertion `!type->hasArchetype()' failed.

When executing: swift::Type swift::ParameterList::getInterfaceType(swift::DeclContext *) const
```

<details>
<summary>

Assertion context:</summary>



```
/// containing contextual types.
Type ParameterList::getInterfaceType(DeclContext *DC) const {
  auto &C = DC->getASTContext();

  if (size() == 0)
    return TupleType::getEmpty(C);

  SmallVector<TupleTypeElt, 8> argumentInfo;

  for (auto P : *this) {
    assert(P->hasType());

    Type type;
    if (P->hasInterfaceType())
      type = P->getInterfaceType();
    else if (!P->getTypeLoc().hasLocation())
      type = ArchetypeBuilder::mapTypeOutOfContext(DC, P->getType());
    else
      type = P->getType();
    assert(!type->hasArchetype());
```

</details>
<details>
<summary>

Stack trace:</summary>



```
swift: /path/to/swift/lib/AST/Parameter.cpp:154: swift::Type swift::ParameterList::getInterfaceType(swift::DeclContext *) const: Assertion `!type->hasArchetype()' failed.
9  swift           0x0000000000eea501 swift::TypeChecker::configureInterfaceType(swift::AbstractFunctionDecl*) + 625
10 swift           0x0000000000ee9d31 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 929
13 swift           0x0000000000eb1686 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
14 swift           0x0000000000f3191b swift::createImplicitConstructor(swift::TypeChecker&, swift::NominalTypeDecl*, swift::ImplicitConstructorKind) + 1371
15 swift           0x0000000000eb7290 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 1536
18 swift           0x0000000000eb1686 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
21 swift           0x0000000000f17bca swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
22 swift           0x0000000000f17a2e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
23 swift           0x0000000000f185f3 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
25 swift           0x0000000000ed38e1 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
26 swift           0x0000000000c60b89 swift::CompilerInstance::performSema() + 3289
28 swift           0x00000000007d8429 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
29 swift           0x00000000007a4458 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28352-swift-typechecker-configureinterfacetype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28352-swift-typechecker-configureinterfacetype-226407.o
1.  While type-checking 'a' at validation-test/compiler_crashers/28352-swift-typechecker-configureinterfacetype.swift:10:28
2.  While type-checking 'A' at validation-test/compiler_crashers/28352-swift-typechecker-configureinterfacetype.swift:10:35
3.  While type-checking 'init' at validation-test/compiler_crashers/28352-swift-typechecker-configureinterfacetype.swift:10:42
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```

</details>
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
