### PR TITLE
Add 💥 (😢 → 56, 😀 → 5107) in swift::removeOverriddenDecls(…)

### DIFF
--- a/validation-test/compiler_crashers/28353-swift-removeoverriddendecls.swift
+++ b/validation-test/compiler_crashers/28353-swift-removeoverriddendecls.swift
@@ -1,0 +1,14 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+let E{enum
+C{{
+}
+protocol E{
+typealias B<>:A}}class A:A{init()


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Add test case for crash triggered in `swift::removeOverriddenDecls(…)`.

Assertion failure in [`lib/AST/NameLookup.cpp (line 76)`](https://github.com/apple/swift/blob/master/lib/AST/NameLookup.cpp#L76):

```
Assertion `decl != overrides && "Circular class inheritance?"' failed.

When executing: bool swift::removeOverriddenDecls(SmallVectorImpl<swift::ValueDecl *> &)
```

<details>
<summary>

Assertion context:</summary>



```
bool swift::removeOverriddenDecls(SmallVectorImpl<ValueDecl*> &decls) {
  if (decls.empty())
    return false;

  ASTContext &ctx = decls.front()->getASTContext();
  llvm::SmallPtrSet<ValueDecl*, 8> overridden;
  for (auto decl : decls) {
    while (auto overrides = decl->getOverriddenDecl()) {
      overridden.insert(overrides);

      // Because initializers from Objective-C base classes have greater
      // visibility than initializers written in Swift classes, we can
      // have a "break" in the set of declarations we found, where
      // C.init overrides B.init overrides A.init, but only C.init and
      // A.init are in the chain. Make sure we still remove A.init from the
      // set in this case.
      if (decl->getFullName().getBaseName() == ctx.Id_init) {
        /// FIXME: Avoid the possibility of an infinite loop by fixing the root
        ///        cause instead (incomplete circularity detection).
        assert(decl != overrides && "Circular class inheritance?");
```

</details>
<details>
<summary>

Stack trace:</summary>



```
swift: /path/to/swift/lib/AST/NameLookup.cpp:76: bool swift::removeOverriddenDecls(SmallVectorImpl<swift::ValueDecl *> &): Assertion `decl != overrides && "Circular class inheritance?"' failed.
8  swift           0x0000000001106dd8 swift::removeOverriddenDecls(llvm::SmallVectorImpl<swift::ValueDecl*>&) + 1432
11 swift           0x0000000000eee438 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 408
12 swift           0x0000000000eeed9d swift::TypeChecker::lookupConstructors(swift::DeclContext*, swift::Type, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 45
13 swift           0x0000000000eb71d6 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 1350
14 swift           0x0000000000eaad2e swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 5854
15 swift           0x0000000000eac058 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 376
19 swift           0x0000000000f1ef6e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
21 swift           0x0000000000f1fec4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
22 swift           0x0000000000f1ee60 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
23 swift           0x0000000000fe586f swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 159
24 swift           0x0000000000fbd8ad swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
25 swift           0x0000000000ea9609 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) + 137
26 swift           0x0000000000eac37f swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1183
31 swift           0x0000000000eb1686 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
34 swift           0x0000000000f17bca swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
35 swift           0x0000000000f17a2e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
36 swift           0x0000000000f185f3 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
38 swift           0x0000000000ed38e1 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
39 swift           0x0000000000c60b89 swift::CompilerInstance::performSema() + 3289
41 swift           0x00000000007d8429 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
42 swift           0x00000000007a4458 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28353-swift-removeoverriddendecls.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28353-swift-removeoverriddendecls-e20d37.o
1.  While type-checking getter for E at validation-test/compiler_crashers/28353-swift-removeoverriddendecls.swift:10:6
2.  While type-checking 'C' at validation-test/compiler_crashers/28353-swift-removeoverriddendecls.swift:10:7
3.  While resolving type A at [validation-test/compiler_crashers/28353-swift-removeoverriddendecls.swift:14:15 - line:14:15] RangeText="A"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```

</details>
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
