### PR TITLE
Add 💥 (😢 → 58, 😀 → 5107) in swift::GenericSignature::getSubstitutionMap(…)

### DIFF
--- a/validation-test/compiler_crashers/28355-swift-genericsignature-getsubstitutionmap.swift
+++ b/validation-test/compiler_crashers/28355-swift-genericsignature-getsubstitutionmap.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+func a{enum A{enum A protocol A{typealias e:a{}class a<b{class A:a{init(T)


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Add test case for crash triggered in `swift::GenericSignature::getSubstitutionMap(…)`.

Assertion failure in [`lib/AST/GenericSignature.cpp (line 413)`](https://github.com/apple/swift/blob/master/lib/AST/GenericSignature.cpp#L413):

```
Assertion `args.empty() && "did not use all substitutions?!"' failed.

When executing: TypeSubstitutionMap swift::GenericSignature::getSubstitutionMap(ArrayRef<swift::Substitution>) const
```

<details>
<summary>

Assertion context:</summary>



```
  // An empty parameter list gives an empty map.
  if (getGenericParams().empty()) {
    assert(args.empty() && "substitutions but no generic params?!");
    return subs;
  }

  // Seed the type map with pre-existing substitutions.
  for (auto depTy : getAllDependentTypes()) {
    auto replacement = args.front().getReplacement();
    args = args.slice(1);

    if (auto subTy = depTy->getAs<SubstitutableType>()) {
      subs[subTy->getCanonicalType().getPointer()] = replacement;
    }
    else if (auto dTy = depTy->getAs<DependentMemberType>()) {
      subs[dTy->getCanonicalType().getPointer()] = replacement;
    }
  }

  assert(args.empty() && "did not use all substitutions?!");
```

</details>
<details>
<summary>

Stack trace:</summary>



```
swift: /path/to/swift/lib/AST/GenericSignature.cpp:413: TypeSubstitutionMap swift::GenericSignature::getSubstitutionMap(ArrayRef<swift::Substitution>) const: Assertion `args.empty() && "did not use all substitutions?!"' failed.
8  swift           0x00000000010e5a13 swift::GenericSignature::getSubstitutionMap(llvm::ArrayRef<swift::Substitution>) const + 659
9  swift           0x000000000111fe47 swift::TypeBase::getSuperclass(swift::LazyResolver*) + 215
10 swift           0x00000000011337d2 swift::ConformanceLookupTable::getConformance(swift::NominalTypeDecl*, swift::LazyResolver*, swift::ConformanceLookupTable::ConformanceEntry*) + 290
12 swift           0x0000000001133ef4 swift::ConformanceLookupTable::lookupConformances(swift::NominalTypeDecl*, swift::DeclContext*, swift::LazyResolver*, swift::ConformanceLookupKind, llvm::SmallVectorImpl<swift::ProtocolDecl*>*, llvm::SmallVectorImpl<swift::ProtocolConformance*>*, llvm::SmallVectorImpl<swift::ConformanceDiagnostic>*) + 692
13 swift           0x0000000001116274 swift::DeclContext::getLocalConformances(swift::ConformanceLookupKind, llvm::SmallVectorImpl<swift::ConformanceDiagnostic>*, bool) const + 212
14 swift           0x0000000000efa8fa swift::TypeChecker::findWitnessedObjCRequirements(swift::ValueDecl const*, bool) + 122
26 swift           0x0000000000eb1686 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
29 swift           0x0000000000f17bca swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
30 swift           0x0000000000f17a2e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
31 swift           0x0000000000f185f3 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
33 swift           0x0000000000ed38e1 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
34 swift           0x0000000000c60b89 swift::CompilerInstance::performSema() + 3289
36 swift           0x00000000007d8429 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
37 swift           0x00000000007a4458 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28355-swift-genericsignature-getsubstitutionmap.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28355-swift-genericsignature-getsubstitutionmap-792793.o
1.  While type-checking 'a' at validation-test/compiler_crashers/28355-swift-genericsignature-getsubstitutionmap.swift:10:1
2.  While type-checking 'A' at validation-test/compiler_crashers/28355-swift-genericsignature-getsubstitutionmap.swift:10:8
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```

</details>
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
