### PR TITLE
Don't emit line table entries for SIL functions marked as thunks.

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -327,16 +327,18 @@ void IRGenDebugInfo::setCurrentLoc(IRBuilder &Builder, const SILDebugScope *DS,
   //  })
   //
   // The actual closure has a closure expression as scope.
-  if (Loc && isAbstractClosure(*Loc) && DS && !isAbstractClosure(DS->Loc)
-      && !Loc->is<ImplicitReturnLocation>()) {
+  if (Loc && isAbstractClosure(*Loc) && DS && !isAbstractClosure(DS->Loc) &&
+      !Loc->is<ImplicitReturnLocation>())
     L.Line = L.Column = 0;
-  }
 
-  if (L.Line == 0 && DS == LastScope) {
-    // Reuse the last source location if we are still in the same
-    // scope to get a more contiguous line table.
+  if (auto *Fn = DS->getInlinedFunction())
+    if (Fn->isThunk())
+      L.Line = L.Column = 0;
+
+  // Reuse the last source location if we are still in the same
+  // scope to get a more contiguous line table.
+  if (L.Line == 0 && DS == LastScope)
     L = LastDebugLoc;
-  }
 
   // FIXME: Enable this assertion.
   //assert(lineNumberIsSane(Builder, L.Line) &&

--- a/test/DebugInfo/closure-arg-linetable.swift
+++ b/test/DebugInfo/closure-arg-linetable.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend %s -emit-ir -g -o - | FileCheck %s
+
+public class C {
+
+  // Test that curry thunks don't have line table entries.
+  // CHECK: define {{.*}}@_TFC4main1C11someHandlerFT_T_(%C4main1C*)
+  // CHECK-SAME:         !dbg ![[CURRY_THUNK:[0-9]+]]
+  // CHECK-NOT: ret {{.*}},
+  // CHECK: {{.*}}, !dbg ![[DBG:[0-9]+]]
+  // CHECK: ret {{.*}}, !dbg ![[DBG]]
+  // CHECK: ![[DBG]] = !DILocation(line: 0, scope: ![[CURRY_THUNK]])
+  func someHandler() { }
+
+  func doSomethingWithHandler(_ theHandler: ((Void) -> Void)!) -> Void {
+	  theHandler()
+  }
+
+  public func entry() {
+	  doSomethingWithHandler(someHandler)
+  }
+}


### PR DESCRIPTION
This eliminates all sorts of unexpected stepping behavior.
rdar://problem/26221951
