### PR TITLE
Add 💥 (😢 → 59, 😀 → 5107) in swift::IterativeTypeChecker::processTypeCheckSuperclass(…)

### DIFF
--- a/validation-test/compiler_crashers/28357-swift-iterativetypechecker-processtypechecksuperclass.swift
+++ b/validation-test/compiler_crashers/28357-swift-iterativetypechecker-processtypechecksuperclass.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+class B<T{class a{func d:A.h{}class A:d typealias d:a


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Add test case for crash triggered in `swift::IterativeTypeChecker::processTypeCheckSuperclass(…)`.

Assertion failure in [`lib/AST/Decl.cpp (line 4765)`](https://github.com/apple/swift/blob/master/lib/AST/Decl.cpp#L4765):

```
Assertion `(!superclass || !superclass->hasArchetype()) && "superclass must be interface type"' failed.

When executing: void swift::ClassDecl::setSuperclass(swift::Type)
```

<details>
<summary>

Assertion context:</summary>



```
  // Make sure the clang node has swift_newtype attribute
  if (!structDecl->getClangNode())
    return {};
  auto clangNode = structDecl->getClangNode();
  if (!clangNode.getAsDecl() ||
      !clangNode.castAsDecl()->getAttr<clang::SwiftNewtypeAttr>())
    return {};

  // Underlying type is the type of rawValue
  for (auto member : structDecl->getMembers())
    if (auto varDecl = dyn_cast<VarDecl>(member))
      if (varDecl->getName().str() == "rawValue")
        return varDecl->getType();

  return {};
}

ClassDecl *ClassDecl::getSuperclassDecl() const {
  if (auto superclass = getSuperclass())
    return superclass->getClassOrBoundGenericClass();
  return nullptr;
}

void ClassDecl::setSuperclass(Type superclass) {
  assert((!superclass || !superclass->hasArchetype())
         && "superclass must be interface type");
  LazySemanticInfo.Superclass.setPointerAndInt(superclass, true);
}
```

</details>
<details>
<summary>

Stack trace:</summary>



```
swift: /path/to/swift/lib/AST/Decl.cpp:4765: void swift::ClassDecl::setSuperclass(swift::Type): Assertion `(!superclass || !superclass->hasArchetype()) && "superclass must be interface type"' failed.
9  swift           0x0000000000fe724d swift::IterativeTypeChecker::processTypeCheckSuperclass(swift::ClassDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 269
10 swift           0x0000000000fbf0dd swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
11 swift           0x0000000000eaaca0 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) + 64
12 swift           0x0000000001131899 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) + 217
13 swift           0x0000000001131df2 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) + 1586
14 swift           0x0000000001135a3e swift::ConformanceLookupTable::getAllProtocols(swift::NominalTypeDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolDecl*>&) + 30
15 swift           0x000000000111756f swift::NominalTypeDecl::getAllProtocols() const + 95
16 swift           0x000000000110bf10 swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 3104
17 swift           0x0000000000eeffaa swift::TypeChecker::lookupMemberType(swift::DeclContext*, swift::Type, swift::Identifier, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 298
19 swift           0x0000000000f2079e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
21 swift           0x0000000000f216f4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
22 swift           0x0000000000f20690 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
24 swift           0x0000000000eeb21e swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 94
27 swift           0x0000000000eada93 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 947
29 swift           0x0000000000eae424 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3396
30 swift           0x000000000110bd5b swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2667
31 swift           0x000000000110a5fb swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2491
32 swift           0x0000000000eef27b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
35 swift           0x0000000000f2079e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
37 swift           0x0000000000f216f4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
38 swift           0x0000000000f20690 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
39 swift           0x0000000000eac25a swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 5130
40 swift           0x0000000000ead858 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 376
41 swift           0x000000000110bd5b swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2667
42 swift           0x000000000110a5fb swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2491
43 swift           0x0000000000eef27b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
47 swift           0x0000000000f2079e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
49 swift           0x0000000000f216f4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
50 swift           0x0000000000f20690 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
52 swift           0x0000000000eeb21e swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 94
59 swift           0x0000000000eb2e86 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
60 swift           0x0000000000ed5012 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
61 swift           0x0000000000c61999 swift::CompilerInstance::performSema() + 3289
63 swift           0x00000000007d8599 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
64 swift           0x00000000007a45b8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28357-swift-iterativetypechecker-processtypechecksuperclass.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28357-swift-iterativetypechecker-processtypechecksuperclass-de5782.o
1.  While type-checking 'B' at validation-test/compiler_crashers/28357-swift-iterativetypechecker-processtypechecksuperclass.swift:10:1
2.  While resolving type A.h at [validation-test/compiler_crashers/28357-swift-iterativetypechecker-processtypechecksuperclass.swift:10:26 - line:10:28] RangeText="A.h"
3.  While resolving type d at [validation-test/compiler_crashers/28357-swift-iterativetypechecker-processtypechecksuperclass.swift:10:39 - line:10:39] RangeText="d"
4.  While type-checking 'd' at validation-test/compiler_crashers/28357-swift-iterativetypechecker-processtypechecksuperclass.swift:10:41
5.  While type-checking 'd' at validation-test/compiler_crashers/28357-swift-iterativetypechecker-processtypechecksuperclass.swift:10:19
6.  While resolving type A.h at [validation-test/compiler_crashers/28357-swift-iterativetypechecker-processtypechecksuperclass.swift:10:26 - line:10:28] RangeText="A.h"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```

</details>
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
