### PR TITLE
SE-0106: Accept "macOS" as an alias for "OSX" in #available, @available, and #if

### DIFF
--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -269,13 +269,10 @@ public:
   const VersionRange &getAvailableRange() const { return AvailableRange; }
   void setAvailableRange(const VersionRange &Range) { AvailableRange = Range; }
   
-  void getPlatformKeywordRanges(SmallVectorImpl<CharSourceRange>
-                                &PlatformRanges);
+  void getPlatformKeywordLocs(SmallVectorImpl<SourceLoc> &PlatformLocs);
 };
 
-  
 
-  
 /// This represents an entry in an "if" or "while" condition.  Pattern bindings
 /// can bind any number of names in the pattern binding decl, and may have an
 /// associated where clause.  When "if let" is involved, an arbitrary number of

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -235,7 +235,10 @@ namespace swift {
 
     /// Returns true if the 'os' platform condition argument represents
     /// a supported target operating system.
-    static bool isPlatformConditionOSSupported(StringRef OSName);
+    ///
+    /// Note that this also canonicalizes the OS name if the check returns
+    /// true.
+    static bool checkPlatformConditionOS(StringRef &OSName);
 
     /// Returns true if the 'arch' platform condition argument represents
     /// a supported target architecture.

--- a/lib/AST/PlatformKind.cpp
+++ b/lib/AST/PlatformKind.cpp
@@ -51,6 +51,8 @@ Optional<PlatformKind> swift::platformFromString(StringRef Name) {
   return llvm::StringSwitch<Optional<PlatformKind>>(Name)
 #define AVAILABILITY_PLATFORM(X, PrettyName) .Case(#X, PlatformKind::X)
 #include "swift/AST/PlatformKinds.def"
+      .Case("macOS", PlatformKind::OSX)
+      .Case("macOSApplicationExtension", PlatformKind::OSXApplicationExtension)
       .Default(Optional<PlatformKind>());
 }
 

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -284,24 +284,14 @@ SourceLoc PoundAvailableInfo::getEndLoc() const {
 }
 
 void PoundAvailableInfo::
-getPlatformKeywordRanges(SmallVectorImpl<CharSourceRange> &PlatformRanges) {
+getPlatformKeywordLocs(SmallVectorImpl<SourceLoc> &PlatformLocs) {
   for (unsigned i = 0; i < NumQueries; i++) {
     auto *VersionSpec =
       dyn_cast<VersionConstraintAvailabilitySpec>(getQueries()[i]);
     if (!VersionSpec)
       continue;
     
-    auto Loc = VersionSpec->getPlatformLoc();
-    auto Platform = VersionSpec->getPlatform();
-    switch (Platform) {
-    case PlatformKind::none:
-      break;
-#define AVAILABILITY_PLATFORM(X, PrettyName)                          \
-  case PlatformKind::X:                                               \
-    PlatformRanges.push_back(CharSourceRange(Loc, strlen(#X)));       \
-    break;
-#include "swift/AST/PlatformKinds.def"
-    }
+    PlatformLocs.push_back(VersionSpec->getPlatformLoc());
   }
 }
 

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -55,7 +55,9 @@ bool contains(const Type (&Array)[N], const Type &V) {
   return std::find(std::begin(Array), std::end(Array), V) != std::end(Array);
 }
 
-bool LangOptions::isPlatformConditionOSSupported(StringRef OSName) {
+bool LangOptions::checkPlatformConditionOS(StringRef &OSName) {
+  if (OSName == "macOS")
+    OSName = "OSX";
   return contains(SupportedConditionalCompilationOSs, OSName);
 }
 

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -532,12 +532,13 @@ void ModelASTWalker::handleStmtCondition(StmtCondition cond) {
   for (const auto &elt : cond) {
     if (elt.getKind() != StmtConditionElement::CK_Availability) continue;
 
-    SmallVector<CharSourceRange, 5> PlatformRanges;
-    elt.getAvailability()->getPlatformKeywordRanges(PlatformRanges);
-    std::for_each(PlatformRanges.begin(), PlatformRanges.end(),
-                  [&](CharSourceRange &Range) {
-                    passNonTokenNode({SyntaxNodeKind::Keyword, Range});
-                  });
+    SmallVector<SourceLoc, 5> PlatformLocs;
+    elt.getAvailability()->getPlatformKeywordLocs(PlatformLocs);
+    std::for_each(PlatformLocs.begin(), PlatformLocs.end(),
+                  [&](SourceLoc loc) {
+      auto range = charSourceRangeFromSourceRange(SM, loc);
+      passNonTokenNode({SyntaxNodeKind::Keyword, range});
+    });
   }
 }
 

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1683,7 +1683,7 @@ Parser::evaluateConditionalCompilationExpr(Expr *condition) {
           return ConditionalCompilationExprState::error();
         }
         if (fnName == "os") {
-          if (!LangOptions::isPlatformConditionOSSupported(argument)) {
+          if (!LangOptions::checkPlatformConditionOS(argument)) {
             diagnose(UDRE->getLoc(), diag::unknown_platform_condition_argument,
                      "operating system", fnName);
             return ConditionalCompilationExprState::error();

--- a/test/Parse/ConditionalCompilation/x64OSXTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64OSXTarget.swift
@@ -6,3 +6,10 @@ class C {}
 var x = C()
 #endif
 var y = x
+
+
+#if arch(x86_64) && os(macOS) && _runtime(_ObjC) && _endian(little)
+class CC {}
+var xx = CC()
+#endif
+var yy = xx

--- a/test/Parse/availability_query.swift
+++ b/test/Parse/availability_query.swift
@@ -99,5 +99,8 @@ if 1 != 2, #available(iOS 8.0, *) {}
 if case 42 = 42, #available(iOS 8.0, *) {}
 if let x = Optional(42), #available(iOS 8.0, *) {}
 
+// Allow "macOS" as well.
+if #available(macOS 10.51, *) {
+}
 
 

--- a/test/SILGen/availability_query.swift
+++ b/test/SILGen/availability_query.swift
@@ -30,6 +30,14 @@ if #available(OSX 10.52, *) {
 }
 
 // CHECK: [[MAJOR:%.*]] = integer_literal $Builtin.Word, 10
+// CHECK: [[MINOR:%.*]] = integer_literal $Builtin.Word, 52
+// CHECK: [[PATCH:%.*]] = integer_literal $Builtin.Word, 0
+// CHECK: [[QUERY_FUNC:%.*]] = function_ref @_TFs26_stdlib_isOSVersionAtLeastFTBwBwBw_Bi1_ : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK: [[QUERY_RESULT:%.*]] = apply [[QUERY_FUNC]]([[MAJOR]], [[MINOR]], [[PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+if #available(macOS 10.52, *) {
+}
+
+// CHECK: [[MAJOR:%.*]] = integer_literal $Builtin.Word, 10
 // CHECK: [[MINOR:%.*]] = integer_literal $Builtin.Word, 0
 // CHECK: [[PATCH:%.*]] = integer_literal $Builtin.Word, 0
 // CHECK: [[QUERY_FUNC:%.*]] = function_ref @_TFs26_stdlib_isOSVersionAtLeastFTBwBwBw_Bi1_ : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1

--- a/test/Sema/availability.swift
+++ b/test/Sema/availability.swift
@@ -86,7 +86,7 @@ let unavailableOnOSX: Int = 0 // expected-note{{explicitly marked unavailable he
 let unavailableOniOS: Int = 0
 @available(iOS, unavailable) @available(OSX, unavailable)
 let unavailableOnBothA: Int = 0 // expected-note{{explicitly marked unavailable here}}
-@available(OSX, unavailable)
+@available(OSX, unavailable) @available(iOS, unavailable)
 let unavailableOnBothB: Int = 0 // expected-note{{explicitly marked unavailable here}}
 
 @available(OSX, unavailable)
@@ -98,14 +98,35 @@ typealias UnavailableOnBothA = Int // expected-note{{explicitly marked unavailab
 @available(OSX, unavailable) @available(iOS, unavailable)
 typealias UnavailableOnBothB = Int // expected-note{{explicitly marked unavailable here}}
 
+@available(macOS, unavailable)
+let unavailableOnMacOS: Int = 0 // expected-note{{explicitly marked unavailable here}}
+@available(macOS, unavailable)
+typealias UnavailableOnMacOS = Int // expected-note{{explicitly marked unavailable here}}
+
+@available(OSXApplicationExtension, unavailable)
+let unavailableOnOSXAppExt: Int = 0
+@available(macOSApplicationExtension, unavailable)
+let unavailableOnMacOSAppExt: Int = 0
+
+@available(OSXApplicationExtension, unavailable)
+typealias UnavailableOnOSXAppExt = Int
+@available(macOSApplicationExtension, unavailable)
+typealias UnavailableOnMacOSAppExt = Int
+
 func testPlatforms() {
   _ = unavailableOnOSX // expected-error{{unavailable}}
   _ = unavailableOniOS
   _ = unavailableOnBothA // expected-error{{unavailable}}
   _ = unavailableOnBothB // expected-error{{unavailable}}
+  _ = unavailableOnMacOS // expected-error{{unavailable}}
+  _ = unavailableOnOSXAppExt
+  _ = unavailableOnMacOSAppExt
 
   let _: UnavailableOnOSX = 0 // expected-error{{unavailable}}
   let _: UnavailableOniOS = 0
   let _: UnavailableOnBothA = 0 // expected-error{{unavailable}}
   let _: UnavailableOnBothB = 0 // expected-error{{unavailable}}
+  let _: UnavailableOnMacOS = 0 // expected-error{{unavailable}}
+  let _: UnavailableOnOSXAppExt = 0
+  let _: UnavailableOnMacOSAppExt = 0
 }


### PR DESCRIPTION
- **Explanation:** New marketing name, new platform identifier. This is a minimal change that does not affect diagnostics or imported APIs, i.e. those will still use "OSX". We can change that in a later commit.
- **Scope:** Should not affect existing code at all.
- **Issue:** [SE-0106](https://github.com/apple/swift-evolution/blob/master/proposals/0106-rename-osx-to-macos.md), [SR-1887](https://bugs.swift.org/browse/SR-1887), rdar://problem/27109690.
- **Reviewed by:** @bitjammer 
- **Risk:** Very low.
- **Testing:** Added compiler regression tests.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
