### PR TITLE
Fix Enums with multiple payloads of < 32bit and empty payloads.

### DIFF
--- a/lib/IRGen/EnumPayload.h
+++ b/lib/IRGen/EnumPayload.h
@@ -117,8 +117,12 @@ public:
   /// Insert a value into the enum payload.
   ///
   /// The current payload value at the given offset is assumed to be zero.
+  /// If \p numBitsUsedInValue is non-negative denotes the actual number of bits
+  /// that need storing in \p value otherwise the full bit-width of \p value
+  /// will be stored.
   void insertValue(IRGenFunction &IGF,
-                   llvm::Value *value, unsigned bitOffset);
+                   llvm::Value *value, unsigned bitOffset,
+                   int numBitsUsedInValue = -1);
   
   /// Extract a value from the enum payload.
   llvm::Value *extractValue(IRGenFunction &IGF,

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -3570,7 +3570,10 @@ namespace {
       } else if (CommonSpareBits.size() > 0) {
         // Otherwise the payload is just the index.
         payload = EnumPayload::zero(IGM, PayloadSchema);
-        payload.insertValue(IGF, tagIndex, 0);
+        // We know we won't use more than numCaseBits from tagIndex's value:
+        // We made sure of this in the logic above.
+        payload.insertValue(IGF, tagIndex, 0,
+                            numCaseBits >= 32 ? -1 : numCaseBits);
       }
 
       // If the tag bits do not fit in the spare bits, the remaining tag bits

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -97,6 +97,8 @@ import Swift
 
 // CHECK: [[DYNAMIC_SINGLETON:%O4enum16DynamicSingleton.*]] = type <{}>
 
+// CHECK: %O4enum40MultiPayloadLessThan32BitsWithEmptyCases = type <{ [1 x i8], [1 x i8] }>
+
 // -- Dynamic metadata template carries a value witness table pattern
 //    we fill in on instantiation.
 //    The witness table pattern includes extra inhabitant witness
@@ -2628,3 +2630,51 @@ bb4:
 // CHECK-64:         %5 = or i128 %2, %4
 // --                             0x1__0000_0000_0000_0000
 // CHECK-64:         %6 = or i128 %5, 18446744073709551616
+
+// CHECK-LABEL: define linkonce_odr hidden i32 @_TwugO4enum40MultiPayloadLessThan32BitsWithEmptyCases(%swift.opaque* %value
+// CHECK:  [[VAL00:%.*]] = bitcast %swift.opaque* %value to %O4enum40MultiPayloadLessThan32BitsWithEmptyCases*
+// CHECK:  [[VAL01:%.*]] = bitcast %O4enum40MultiPayloadLessThan32BitsWithEmptyCases* [[VAL00]] to i8*
+// CHECK:  [[VAL02:%.*]] = load {{.*}} [[VAL01]]
+// CHECK:  [[VAL03:%.*]] = getelementptr inbounds {{.*}} [[VAL00]], i32 0, i32 1
+// CHECK:  [[VAL04:%.*]] = bitcast {{.*}} [[VAL03]] to i2*
+// CHECK:  [[VAL05:%.*]] = load {{.*}} [[VAL04]]
+// CHECK:  [[VAL06:%.*]] = zext i2 [[VAL05]] to i32
+// CHECK:  [[VAL07:%.*]] = sub i32 [[VAL06]], 2
+// CHECK:  [[VAL08:%.*]] = zext i8 [[VAL02]] to i32
+// CHECK:  [[VAL09:%.*]] = and i32 [[VAL08]], 255
+// CHECK:  [[VAL10:%.*]] = icmp sge i32 [[VAL07]], 0
+// CHECK:  [[VAL11:%.*]] = select i1 [[VAL10]], i32 [[VAL09]], i32 [[VAL07]]
+// CHECK:  ret i32 [[VAL11]]
+
+// CHECK-LABEL: define linkonce_odr hidden void @_TwuiO4enum40MultiPayloadLessThan32BitsWithEmptyCases(%swift.opaque* %value, i32 %tag
+// CHECK: entry:
+// CHECK:  [[VAL00:%.*]] = bitcast %swift.opaque* %value
+// CHECK:  [[VAL01:%.*]] = icmp sge i32 %tag, 0
+// CHECK:  br i1 [[VAL01]], label %[[TLABEL:.*]], label %[[FLABEL:.*]]
+
+// CHECK: <label>:[[TLABEL]]
+// CHECK:  [[VAL03:%.*]] = trunc i32 %tag to i8
+// CHECK:  [[VAL04:%.*]] = bitcast %O4enum40MultiPayloadLessThan32BitsWithEmptyCases* [[VAL00]] to i8*
+// CHECK:  store i8 [[VAL03]], i8* [[VAL04]]
+// CHECK:  [[VAL05:%.*]] = getelementptr inbounds {{.*}} [[VAL00]], i32 0, i32 1
+// CHECK:  [[VAL06:%.*]] = bitcast [1 x i8]* [[VAL05]] to i2*
+// CHECK:  store i2 -2, i2* [[VAL06]]
+// CHECK:  br label %[[RLABEL:.*]]
+
+// CHECK: <label>:[[FLABEL]]
+// CHECK:  [[VAL08:%.*]] = add i32 %tag, 2
+// CHECK:  [[VAL09:%.*]] = trunc i32 [[VAL08]] to i2
+// CHECK:  [[VAL10:%.*]] = getelementptr inbounds {{.*}} [[VAL00]], i32 0, i32 1
+// CHECK:  [[VAL11:%.*]] = bitcast [1 x i8]* [[VAL10]] to i2*
+// CHECK:  store i2 [[VAL09]], i2* [[VAL11]]
+// CHECK:  br label %[[RLABEL]]
+
+// CHECK: <label>:[[RLABEL]]
+// CHECK:  ret void
+
+enum MultiPayloadLessThan32BitsWithEmptyCases {
+  case A
+  case B
+  case C(Builtin.Int8)
+  case D(Builtin.Int8)
+}


### PR DESCRIPTION
This used to crash because the code storing empty payload enum tag values would
use the bit width of the tag (32 bit) as minimun tag unit to store to the
payload even if the actual bits required to store the biggest tag value in the
payload was much smaller.

With payload bitwidths < 32bit we would run out of space crashing looking for new
payload to store the value to ...

Instead pass the maximum size of the bits that need storing down.

rdar://27162564
