### PR TITLE
[Fixit] Add a fixit to remove type alias self-referring declaration.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3013,6 +3013,10 @@ WARNING(extraneous_default_args_in_call, none,
 //------------------------------------------------------------------------------
 ERROR(circular_reference, none,
       "circular reference", ())
+
+ERROR(redundant_type_alias_define, none,
+"redundant type alias declaration", ())
+
 NOTE(circular_reference_through, none,
      "through reference here", ())
 

--- a/lib/Sema/IterativeTypeChecker.cpp
+++ b/lib/Sema/IterativeTypeChecker.cpp
@@ -112,6 +112,20 @@ void IterativeTypeChecker::satisfy(TypeCheckRequest request) {
   }
 }
 
+static bool isSelfRedefinedTypeAliasDecl(const TypeCheckRequest &Request) {
+  if (Request.getKind() == TypeCheckRequest::Kind::ResolveTypeDecl) {
+    if (auto TAD = dyn_cast<TypeAliasDecl>(Request.getAnchor())) {
+      SourceRange SR = TAD->getUnderlyingTypeLoc().getSourceRange();
+      SourceManager &SM = TAD->getASTContext().SourceMgr;
+      CharSourceRange CR = CharSourceRange(SM, SR.Start,
+                                           Lexer::getLocForEndOfToken(SM,
+                                                                      SR.End));
+      return CR.str() == TAD->getNameStr();
+    }
+  }
+  return false;
+}
+
 //===----------------------------------------------------------------------===//
 // Diagnostics
 //===----------------------------------------------------------------------===//
@@ -119,9 +133,14 @@ void IterativeTypeChecker::diagnoseCircularReference(
        ArrayRef<TypeCheckRequest> requests) {
   bool isFirst = true;
   for (const auto &request : requests) {
-    diagnose(request.getLoc(),
-             isFirst ? diag::circular_reference
-                     : diag::circular_reference_through);
+    if (isSelfRedefinedTypeAliasDecl(request)) {
+      diagnose(request.getLoc(), diag::redundant_type_alias_define).
+        fixItRemove(request.getAnchor()->getSourceRange());
+    } else {
+      diagnose(request.getLoc(),
+               isFirst ? diag::circular_reference :
+                         diag::circular_reference_through);
+    }
 
     isFirst = false;
   }

--- a/test/Sema/diag_typealias.swift
+++ b/test/Sema/diag_typealias.swift
@@ -1,0 +1,6 @@
+// RUN: %target-parse-verify-swift
+
+struct S {}
+
+typealias S = S // expected-error {{redundant type alias declaration}}{{1-17=}}
+

--- a/test/decl/init/basic_init.swift
+++ b/test/decl/init/basic_init.swift
@@ -10,7 +10,7 @@ class C {
 	init() {}
 }
 
-typealias t = t // expected-error {{circular reference}}
+typealias t = t // expected-error {{redundant type alias declaration}}{{1-17=}}
 
 
 


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->

This patch adds a fixit to remove type alias self-referring definitions, like typealias A = A.

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…ke typealias A = A. rdar://24869708
