### PR TITLE
SwiftRemoteMirror: Add reflection metadata version query API

### DIFF
--- a/include/swift/Reflection/Records.h
+++ b/include/swift/Reflection/Records.h
@@ -19,6 +19,8 @@
 
 #include "swift/Basic/RelativePointer.h"
 
+const uint16_t SWIFT_REFLECTION_METADATA_VERSION = 1;
+
 namespace swift {
 namespace reflection {
 

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
@@ -36,6 +36,10 @@
 extern "C" {
 #endif
 
+/// Get the metadata version supported by the Remote Mirror library.
+uint16_t
+swift_reflection_getSupportedMetadataVersion();
+
 /// \returns An opaque reflection context.
 SwiftReflectionContextRef
 swift_reflection_createReflectionContext(

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -930,3 +930,13 @@ void IRGenModule::emitFieldMetadataRecord(const NominalTypeDecl *Decl) {
   if (var)
     addUsedGlobal(var);
 }
+
+void IRGenModule::emitReflectionMetadataVersion() {
+  auto Init =
+    llvm::ConstantInt::get(Int16Ty, SWIFT_REFLECTION_METADATA_VERSION);
+  auto Version = new llvm::GlobalVariable(Module, Int16Ty, /*constant*/ true,
+                                          llvm::GlobalValue::LinkOnceODRLinkage,
+                                          Init,
+                                          "__swift_reflection_version");
+  addUsedGlobal(Version);
+}

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -623,6 +623,7 @@ static std::unique_ptr<llvm::Module> performIRGeneration(IRGenOptions &Opts,
       IGM.emitProtocolConformances();
       IGM.emitTypeMetadataRecords();
       IGM.emitBuiltinReflectionMetadata();
+      IGM.emitReflectionMetadataVersion();
     }
 
     // Okay, emit any definitions that we suddenly need.

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -743,6 +743,7 @@ public:
   void emitAssociatedTypeMetadataRecord(const ProtocolConformance *Conformance);
   void emitFieldMetadataRecord(const NominalTypeDecl *Decl);
   void emitBuiltinReflectionMetadata();
+  void emitReflectionMetadataVersion();
   std::string getBuiltinTypeMetadataSectionName();
   std::string getFieldTypeMetadataSectionName();
   std::string getAssociatedTypeMetadataSectionName();

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -22,6 +22,11 @@ using namespace swift::remote;
 using NativeReflectionContext
   = ReflectionContext<External<RuntimeTarget<sizeof(uintptr_t)>>>;
 
+uint16_t
+swift_reflection_getSupportedMetadataVersion() {
+  return SWIFT_REFLECTION_METADATA_VERSION;
+}
+
 SwiftReflectionContextRef
 swift_reflection_createReflectionContext(void *ReaderContext,
                                          PointerSizeFunction getPointerSize,

--- a/test/IRGen/unused.sil
+++ b/test/IRGen/unused.sil
@@ -45,8 +45,8 @@ bb0:
   return %1 : $()
 }
 
-// CHECK-macho: @llvm.used = appending global [1 x i8*] [i8* bitcast (void ()* @frieda to i8*)], section "llvm.metadata", align 8
-// CHECK-elf: @llvm.used = appending global [2 x i8*] [i8* bitcast (void ()* @frieda to i8*), i8* getelementptr inbounds ([0 x i8], [0 x i8]* @_swift1_autolink_entries, i32 0, i32 0)], section "llvm.metadata", align 8
+// CHECK-macho: @llvm.used = appending global [2 x i8*] [i8* bitcast (void ()* @frieda to i8*), i8* bitcast (i16* @__swift_reflection_version to i8*)], section "llvm.metadata"
+// CHECK-elf: @llvm.used = appending global [3 x i8*] [i8* bitcast (void ()* @frieda to i8*), i8* bitcast (i16* @__swift_reflection_version to i8*), i8* getelementptr inbounds ([0 x i8], [0 x i8]* @_swift1_autolink_entries, i32 0, i32 0)], section "llvm.metadata"
 
 // CHECK: define linkonce_odr hidden void @qux()
 // CHECK: define hidden void @fred()

--- a/tools/swift-reflection-test/swift-reflection-test.c
+++ b/tools/swift-reflection-test/swift-reflection-test.c
@@ -465,5 +465,8 @@ int main(int argc, char *argv[]) {
 
   const char *BinaryFilename = argv[1];
 
+  uint16_t Version = swift_reflection_getSupportedMetadataVersion();
+  printf("Metadata version: %u\n", Version);
+
   return doDumpHeapInstance(BinaryFilename);
 }


### PR DESCRIPTION
Add a major/minor version API to the SwiftRemoteMirror library. These numbers will correspond to some constants emitted in Swift binaries.

rdar://problem/27251582
