### PR TITLE
[SceneKit] Add apinotes to swift_private some decls

### DIFF
--- a/apinotes/CMakeLists.txt
+++ b/apinotes/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SWIFT_API_NOTES_INPUTS
   PassKit
   QuartzCore
   QuickLook
+  SceneKit
   SpriteKit
   StoreKit
   TVMLKit

--- a/apinotes/SceneKit.apinotes
+++ b/apinotes/SceneKit.apinotes
@@ -1,0 +1,17 @@
+---
+Name: SceneKit
+
+Protocols:
+# The below are methods for which overlays provide better implementations
+- Name: SCNBoundingVolume
+  Methods:
+  - Selector: 'getBoundingBoxMin:max:'
+    SwiftPrivate: true
+    MethodKind: Instance
+  - Selector: 'setBoundingBoxMin:max:'
+    SwiftPrivate: true
+    MethodKind: Instance
+  - Selector: 'getBoundingSphereCenter:radius:'
+    SwiftPrivate: true
+    MethodKind: Instance
+

--- a/stdlib/public/SDK/SceneKit/SceneKit.swift
+++ b/stdlib/public/SDK/SceneKit/SceneKit.swift
@@ -199,19 +199,19 @@ extension SCNBoundingVolume {
     get {
       var min = SCNVector3Zero
       var max = SCNVector3Zero
-      getBoundingBoxMin(&min, max: &max)
+      __getBoundingBoxMin(&min, max: &max)
       return (min: min, max: max)
     }
     set {
       var min = newValue.min
       var max = newValue.max
-      setBoundingBoxMin(&min, max: &max)
+      __setBoundingBoxMin(&min, max: &max)
     }
   }
   public var boundingSphere: (center: SCNVector3, radius: Float) {
     var center = SCNVector3Zero
     var radius = CGFloat(0.0)
-    getBoundingSphereCenter(&center, radius: &radius)
+    __getBoundingSphereCenter(&center, radius: &radius)
     return (center: center, radius: Float(radius))
   }
 }


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

```
These apinotes will swift_private many of the bounding box methods,
and adjust the overlays appropriately. Those APIs have better
alternatives provided by the overlays, and thus shouldln't be exposed.
```
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

These apinotes will swift_private many of the bounding box methods,
and adjust the overlays appropriately. Those APIs have better
alternatives provided by the overlays, and thus shouldln't be exposed.
