### PR TITLE
[WIP] [2.3] [ClangImporter] Import class properties as class methods.

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3090,6 +3090,9 @@ bool ClangImporter::Implementation::shouldSuppressDeclImport(
     // getter/setter pairs instead.
     if (isAccessibilityDecl(objcProperty))
       return true;
+    // Class properties are imported as methods in Swift 2.3.
+    if (objcProperty->isClassProperty())
+      return true;
 
     // Check whether there is a superclass method for the getter that
     // is *not* suppressed, in which case we will need to suppress
@@ -3896,7 +3899,7 @@ void ClangModuleUnit::lookupObjCMethods(
     if (owningClangModule != clangModule) continue;
 
     // If we found a property accessor, import the property.
-    if (objcMethod->isPropertyAccessor())
+    if (objcMethod->isPropertyAccessor() && objcMethod->isInstanceMethod())
       (void)owner.Impl.importDecl(objcMethod->findPropertyDecl(true));
 
     // Import it.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2849,7 +2849,7 @@ namespace {
 
       SpecialMethodKind kind = SpecialMethodKind::Regular;
       // FIXME: This doesn't handle implicit properties.
-      if (decl->isPropertyAccessor())
+      if (decl->isPropertyAccessor() && decl->isInstanceMethod())
         kind = SpecialMethodKind::PropertyAccessor;
       else if (isNSDictionaryMethod(decl, Impl.objectForKeyedSubscript))
         kind = SpecialMethodKind::NSDictionarySubscriptGetter;
@@ -4776,6 +4776,9 @@ namespace {
       if (Impl.isAccessibilityDecl(decl))
         return nullptr;
 
+      if (!decl->isInstanceProperty())
+        return nullptr;
+
       // Check whether there is a function with the same name as this
       // property. If so, suppress the property; the user will have to use
       // the methods directly, to avoid ambiguities.
@@ -4786,7 +4789,8 @@ namespace {
                           NL_QualifiedDefault | NL_KnownNoDependency,
                           Impl.getTypeResolver(), lookup);
       for (auto result : lookup) {
-        if (isa<FuncDecl>(result) && result->isInstanceMember() &&
+        if (isa<FuncDecl>(result) &&
+            result->isInstanceMember() == decl->isInstanceProperty() &&
             result->getFullName().getArgumentNames().empty())
           return nullptr;
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2050,7 +2050,7 @@ Type ClangImporter::Implementation::importMethodType(
   const clang::ObjCPropertyDecl *property = nullptr;
   bool isPropertyGetter = false;
   bool isPropertySetter = false;
-  if (clangDecl->isPropertyAccessor()) {
+  if (clangDecl->isPropertyAccessor() && clangDecl->isInstanceMethod()) {
     property = clangDecl->findPropertyDecl();
     if (property) {
       if (property->getGetterMethodDecl() == clangDecl) {

--- a/test/ClangModules/Inputs/SwiftPrivateAttr.txt
+++ b/test/ClangModules/Inputs/SwiftPrivateAttr.txt
@@ -4,6 +4,7 @@ protocol __PrivProto {
 }
 class Foo : NSObject, __PrivProto {
   var __privValue: AnyObject!
+  class var __privClassValue: AnyObject!
   func __noArgs()
   func __oneArg(arg: Int32)
   func __twoArgs(arg: Int32, other arg2: Int32)

--- a/test/ClangModules/Inputs/custom-modules/ObjCIRExtras.h
+++ b/test/ClangModules/Inputs/custom-modules/ObjCIRExtras.h
@@ -30,6 +30,7 @@
 - (void)methodInt:(NSInteger)value SWIFT_NAME(theMethod(number:));
 
 @property (readonly) int someProp SWIFT_NAME(renamedSomeProp);
+@property (readonly, class) int classProp SWIFT_NAME(renamedClassProp);
 @end
 
 @interface SwiftNameTestError : NSObject

--- a/test/ClangModules/Inputs/custom-modules/ObjCParseExtras.h
+++ b/test/ClangModules/Inputs/custom-modules/ObjCParseExtras.h
@@ -8,28 +8,36 @@ __attribute__((objc_root_class))
 
 @interface PropertyAndMethodCollisionBase
 - (void)object:(id)obj doSomething:(SEL)selector;
++ (void)classRef:(id)obj doSomething:(SEL)selector;
 @end
 
 @interface PropertyAndMethodCollision : PropertyAndMethodCollisionBase
 @property id object;
+@property (class) id classRef;
 @end
 
 @interface PropertyAndMethodReverseCollisionBase
 @property id object;
+@property (class) id classRef;
 @end
 
 @interface PropertyAndMethodReverseCollision : PropertyAndMethodReverseCollisionBase
 - (void)object:(id)obj doSomething:(SEL)selector;
++ (void)classRef:(id)obj doSomething:(SEL)selector;
 @end
 
 @protocol PropertyProto
 @property id protoProp;
 @property(readonly) id protoPropRO;
+@property(class) id protoClassProp;
+@property(class, readonly) id protoClassPropRO;
 @end
 
 @interface PropertyAndMethodCollision () <PropertyProto>
 - (id)protoProp;
 - (id)protoPropRO;
++ (id)protoClassProp;
++ (id)protoClassPropRO;
 @end
 
 

--- a/test/ClangModules/Inputs/custom-modules/SwiftPrivateAttr.h
+++ b/test/ClangModules/Inputs/custom-modules/SwiftPrivateAttr.h
@@ -8,6 +8,7 @@ NS_REFINED_FOR_SWIFT
   
 @interface Foo : NSObject <PrivProto>
 @property id privValue NS_REFINED_FOR_SWIFT;
+@property (class) id privClassValue NS_REFINED_FOR_SWIFT;
 
 - (void)noArgs NS_REFINED_FOR_SWIFT;
 - (void)oneArg:(int)arg NS_REFINED_FOR_SWIFT;

--- a/test/ClangModules/attr-swift_name.swift
+++ b/test/ClangModules/attr-swift_name.swift
@@ -12,13 +12,16 @@ func test(i: Int) {
   t.theMethod(number: i)
 
   _ = t.renamedSomeProp
+  _ = t.dynamicType.renamedClassProp
 
   // We only see these two warnings because Clang can catch the other invalid
   // cases, and marks the attribute as invalid ahead of time.
   
   // CHECK: warning: too few parameters in swift_name attribute (expected 2; got 1)
   // CHECK: + (instancetype)g:(id)x outParam:(int *)foo SWIFT_NAME(init(g:));
-  
+
+  // CHECK-NOT: warning:
+
   // CHECK: warning: too few parameters in swift_name attribute (expected 2; got 1)
   // CHECK: + (instancetype)testW:(id)x out:(id *)outObject SWIFT_NAME(ww(_:));
 }

--- a/test/ClangModules/attr-swift_private.swift
+++ b/test/ClangModules/attr-swift_private.swift
@@ -21,6 +21,10 @@ public func testProperty(foo: Foo) {
   // CHECK: @"\01L_selector(setPrivValue:)"
   _ = foo.__privValue
   foo.__privValue = foo
+
+  // CHECK: @"\01L_selector(setPrivClassValue:)"
+  _ = Foo.__privClassValue
+  Foo.__privClassValue = foo
   
 #if !IRGEN
   _ = foo.privValue // expected-error {{value of type 'Foo' has no member 'privValue'}}

--- a/test/ClangModules/objc_ir.swift
+++ b/test/ClangModules/objc_ir.swift
@@ -70,6 +70,12 @@ func propertyAccess(b b: B) {
    // CHECK: load i8*, i8** @"\01L_selector(counter)"
    // CHECK: load i8*, i8** @"\01L_selector(setCounter:)"
    b.counter = b.counter + 1
+
+   // CHECK: call %swift.type* @_TMaCSo1B()
+   // CHECK: bitcast %swift.type* {{%.+}} to %objc_class*
+   // CHECK: load i8*, i8** @"\01L_selector(sharedCounter)"
+   // CHECK: load i8*, i8** @"\01L_selector(setSharedCounter:)"
+   B.setSharedCounter(B.sharedCounter() + 1)
 }
 
 // CHECK: define hidden [[B]]* @_TF7objc_ir8downcastFT1aCSo1A_CSo1B(

--- a/test/ClangModules/objc_parse.swift
+++ b/test/ClangModules/objc_parse.swift
@@ -379,11 +379,20 @@ func testPropertyAndMethodCollision(obj: PropertyAndMethodCollision,
   obj.object = nil
   obj.object(obj, doSomething:Selector("action"))
 
+  _ = obj.dynamicType.classRef()
+  obj.dynamicType.classRef(obj, doSomething:Selector("action"))
+
   rev.object = nil
   rev.object(rev, doSomething:Selector("action"))
 
-  var value: AnyObject = obj.protoProp()
+  _ = rev.dynamicType.classRef()
+  rev.dynamicType.classRef(rev, doSomething:Selector("action"))
+
+  var value: AnyObject
+  value = obj.protoProp()
   value = obj.protoPropRO()
+  value = obj.dynamicType.protoClassProp()
+  value = obj.dynamicType.protoClassPropRO()
   _ = value
 }
 

--- a/test/IDE/Inputs/mock-sdk/Foo.annotated.txt
+++ b/test/IDE/Inputs/mock-sdk/Foo.annotated.txt
@@ -224,6 +224,17 @@ class <loc>FooClassDerived</loc> : <ref:Class>FooClassBase</ref>, <ref:Protocol>
   <decl:Constructor><loc>init!()</loc></decl>
   <decl:Constructor>convenience <loc>init!(float f: <ref:Struct>Float</ref>)</loc></decl>
 }</decl>
+<decl:Class>class <loc>FooClassWithClassProperties</loc> : <ref:Class>FooClassBase</ref> {
+  <decl:Var>unowned(unsafe) class var <loc>assignable</loc>: @sil_unmanaged <ref:Protocol>AnyObject</ref>!</decl>
+  <decl:Var>unowned(unsafe) class var <loc>unsafeAssignable</loc>: @sil_unmanaged <ref:Protocol>AnyObject</ref>!</decl>
+  <decl:Var>class var <loc>retainable</loc>: <ref:Protocol>AnyObject</ref>!</decl>
+  <decl:Var>class var <loc>strongRef</loc>: <ref:Protocol>AnyObject</ref>!</decl>
+  <decl:Var>@NSCopying class var <loc>copyable</loc>: <ref:Protocol>AnyObject</ref>!</decl>
+  <decl:Var>weak class var <loc>weakRef</loc>: @sil_weak <ref:Protocol>AnyObject</ref>!</decl>
+  <decl:Var>class var <loc>scalar</loc>: <ref:Struct>Int32</ref></decl>
+  <decl:Constructor><loc>init!()</loc></decl>
+  <decl:Constructor>convenience <loc>init!(<decl:Param>float f: <ref:Struct>Float</ref></decl>)</loc></decl>
+}</decl>
 <decl:Class>class <loc>FooUnavailableMembers</loc> : <ref:Class>FooClassBase</ref> {
   <decl:Constructor>convenience <loc>init!(int i: <ref:Struct>Int32</ref>)</loc></decl>
   <decl:Func>@available(*, unavailable, message="use object construction 'FooUnavailableMembers(int:)'")

--- a/test/IDE/Inputs/mock-sdk/Foo.framework/Headers/Foo.h
+++ b/test/IDE/Inputs/mock-sdk/Foo.framework/Headers/Foo.h
@@ -238,6 +238,16 @@ struct _InternalStruct {
 @property (assign) int scalar;
 @end
 
+@interface FooClassWithClassProperties : FooClassBase
+@property (class, assign) id assignable;
+@property (class, unsafe_unretained) id unsafeAssignable;
+@property (class, retain) id retainable;
+@property (class, strong) id strongRef;
+@property (class, copy) id copyable;
+@property (class, weak) id weakRef;
+@property (class, assign) int scalar;
+@end
+
 #define FOO_NIL ((id)0)
 
 @interface FooUnavailableMembers : FooClassBase

--- a/test/IDE/Inputs/mock-sdk/Foo.printed.recursive.txt
+++ b/test/IDE/Inputs/mock-sdk/Foo.printed.recursive.txt
@@ -224,6 +224,17 @@ class FooClassPropertyOwnership : FooClassBase {
   init!()
   convenience init!(float f: Float)
 }
+class FooClassWithClassProperties : FooClassBase {
+  unowned(unsafe) class var assignable: @sil_unmanaged AnyObject!
+  unowned(unsafe) class var unsafeAssignable: @sil_unmanaged AnyObject!
+  class var retainable: AnyObject!
+  class var strongRef: AnyObject!
+  @NSCopying class var copyable: AnyObject!
+  weak class var weakRef: @sil_weak AnyObject!
+  class var scalar: Int32
+  init!()
+  convenience init!(float f: Float)
+}
 class FooUnavailableMembers : FooClassBase {
   convenience init!(int i: Int32)
   @available(*, unavailable, message="use object construction 'FooUnavailableMembers(int:)'")

--- a/test/IDE/Inputs/mock-sdk/Foo.printed.txt
+++ b/test/IDE/Inputs/mock-sdk/Foo.printed.txt
@@ -274,6 +274,18 @@ class FooClassPropertyOwnership : FooClassBase {
   convenience init!(float f: Float)
 }
 
+class FooClassWithClassProperties : FooClassBase {
+  unowned(unsafe) class var assignable: @sil_unmanaged AnyObject!
+  unowned(unsafe) class var unsafeAssignable: @sil_unmanaged AnyObject!
+  class var retainable: AnyObject!
+  class var strongRef: AnyObject!
+  @NSCopying class var copyable: AnyObject!
+  weak class var weakRef: @sil_weak AnyObject!
+  class var scalar: Int32
+  init!()
+  convenience init!(float f: Float)
+}
+
 class FooUnavailableMembers : FooClassBase {
   convenience init!(int i: Int32)
   @available(*, unavailable, message="use object construction 'FooUnavailableMembers(int:)'")

--- a/test/Inputs/clang-importer-sdk/usr/include/objc/NSObject.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/objc/NSObject.h
@@ -61,6 +61,7 @@
 - performMultiplyWithValue:(int)x value:(int)y;
 - moveFor:(int)x;
 @property (readonly) int readCounter;
+@property (class) int sharedCounter;
 
 @property int informalMadeFormal;
 

--- a/test/Interpreter/Inputs/ObjCClasses/ObjCClasses.h
+++ b/test/Interpreter/Inputs/ObjCClasses/ObjCClasses.h
@@ -18,4 +18,33 @@
 @end
 
 
+#if __has_feature(objc_class_property)
+@protocol ProtoWithClassProperty
++ (void)reset;
+@property (class) int value;
+
+@optional
+@property (class, readonly) BOOL optionalClassProp;
+@end
+
+@interface ClassWithClassProperty : NSObject <ProtoWithClassProperty>
+@end
+
+@interface ObjCSubclassWithClassProperty : ClassWithClassProperty
+// Deliberately redeclared.
+@property (class) int value;
+@end
+
+@protocol PropertyNamingConflictProto
+@property (nullable) id protoProp;
+@property (class, nullable) id protoProp;
+@end
+
+@interface PropertyNamingConflict : NSObject
+@property (readonly, nullable) id prop;
+@property (class, readonly, nullable) id prop;
+@end
+
+#endif // __has_feature(objc_class_property)
+
 #endif

--- a/test/Interpreter/Inputs/ObjCClasses/ObjCClasses.m
+++ b/test/Interpreter/Inputs/ObjCClasses/ObjCClasses.m
@@ -12,3 +12,31 @@
   return 0;
 }
 @end
+
+
+#if __has_feature(objc_class_property)
+static int _value = 0;
+@implementation ClassWithClassProperty
++ (int)value {
+  return _value;
+}
++ (void)setValue:(int)newValue {
+  _value = newValue;
+}
++ (void)reset {
+  _value = 0;
+}
+@end
+
+@implementation ObjCSubclassWithClassProperty
++ (BOOL)optionalClassProp {
+  return YES;
+}
+@end
+
+@implementation PropertyNamingConflict
+- (id)prop { return self; }
++ (id)prop { return nil; }
+@end
+
+#endif

--- a/test/Interpreter/objc_class_properties.swift
+++ b/test/Interpreter/objc_class_properties.swift
@@ -1,0 +1,171 @@
+// RUN: rm -rf %t && mkdir -p %t
+
+// RUN: %clang %target-cc-options -isysroot %sdk -fobjc-arc %S/Inputs/ObjCClasses/ObjCClasses.m -c -o %t/ObjCClasses.o
+// RUN: %target-build-swift -I %S/Inputs/ObjCClasses/ %t/ObjCClasses.o %s -o %t/a.out
+// RUN: %target-run %t/a.out
+
+// REQUIRES: executable_test
+// XFAIL: interpret
+// REQUIRES: objc_interop
+
+import Foundation
+import StdlibUnittest
+import ObjCClasses
+
+class SwiftClass : ProtoWithClassProperty {
+  static var getCount = 0
+  static var setCount = 0
+
+  private static var _value: CInt = 0
+
+  @objc class func reset() {
+    getCount = 0
+    setCount = 0
+    _value = 0
+  }
+
+  @objc class func value() -> CInt {
+    getCount += 1
+    return _value
+  }
+  @objc class func setValue(_ newValue: CInt) {
+    setCount += 1
+    _value = newValue
+  }
+
+  @objc class func optionalClassProp() -> Bool {
+    return true
+  }
+}
+
+class Subclass : ClassWithClassProperty {
+  static var getCount = 0
+  static var setCount = 0
+  
+  override class func reset() {
+    getCount = 0
+    setCount = 0
+    super.reset()
+  }
+
+  override class func value() -> CInt {
+    getCount += 1
+    return super.value()
+  }
+  override class func setValue(_ newValue: CInt) {
+    setCount += 1
+    super.setValue(newValue)
+  }
+
+  override class func optionalClassProp() -> Bool {
+    return true
+  }
+}
+
+var ClassProperties = TestSuite("ClassProperties")
+
+ClassProperties.test("direct") {
+  ClassWithClassProperty.reset()
+  expectEqual(0, ClassWithClassProperty.value())
+  ClassWithClassProperty.setValue(4)
+  expectEqual(4, ClassWithClassProperty.value())
+
+  Subclass.reset()
+  expectEqual(0, Subclass.value())
+  Subclass.setValue(4)
+  expectEqual(4, Subclass.value())
+  expectEqual(2, Subclass.getCount)
+  expectEqual(1, Subclass.setCount)
+}
+
+func testExistential(e: ProtoWithClassProperty.Type) {
+  e.reset()
+  expectEqual(0, e.value())
+  e.setValue(4)
+  expectEqual(4, e.value())
+}
+
+ClassProperties.test("existentials") {
+  testExistential(ClassWithClassProperty.self)
+  testExistential(ObjCSubclassWithClassProperty.self)
+
+  testExistential(SwiftClass.self)
+  expectEqual(2, SwiftClass.getCount)
+  expectEqual(1, SwiftClass.setCount)
+
+  testExistential(Subclass.self)
+  expectEqual(2, Subclass.getCount)
+  expectEqual(1, Subclass.setCount)
+}
+
+func testGeneric<T: ProtoWithClassProperty>(e: T.Type) {
+  e.reset()
+  expectEqual(0, e.value())
+  e.setValue(4)
+  expectEqual(4, e.value())
+}
+
+ClassProperties.test("generics") {
+  testGeneric(ClassWithClassProperty.self)
+  testGeneric(ObjCSubclassWithClassProperty.self)
+
+  testGeneric(SwiftClass.self)
+  expectEqual(2, SwiftClass.getCount)
+  expectEqual(1, SwiftClass.setCount)
+
+  testGeneric(Subclass.self)
+  expectEqual(2, Subclass.getCount)
+  expectEqual(1, Subclass.setCount)
+}
+
+func testInheritance(e: ClassWithClassProperty.Type) {
+  e.reset()
+  expectEqual(0, e.value())
+  e.setValue(4)
+  expectEqual(4, e.value())
+}
+
+ClassProperties.test("inheritance") {
+  testInheritance(ClassWithClassProperty.self)
+  testInheritance(ObjCSubclassWithClassProperty.self)
+
+  testInheritance(Subclass.self)
+  expectEqual(2, Subclass.getCount)
+  expectEqual(1, Subclass.setCount)
+}
+
+func testInheritanceGeneric<T: ClassWithClassProperty>(e: T.Type) {
+  e.reset()
+  expectEqual(0, e.value())
+  e.setValue(4)
+  expectEqual(4, e.value())
+}
+
+ClassProperties.test("inheritance/generic") {
+  testInheritanceGeneric(ClassWithClassProperty.self)
+  testInheritanceGeneric(ObjCSubclassWithClassProperty.self)
+
+  testInheritanceGeneric(Subclass.self)
+  expectEqual(2, Subclass.getCount)
+  expectEqual(1, Subclass.setCount)
+}
+
+ClassProperties.test("optionalProp") {
+  let noProp: ProtoWithClassProperty.Type = ClassWithClassProperty.self
+  expectEmpty(noProp.optionalClassProp)
+
+  let hasProp: ProtoWithClassProperty.Type = Subclass.self
+  expectNotEmpty(hasProp.optionalClassProp)
+  expectEqual(true, hasProp.optionalClassProp!())
+
+  let hasOwnProp: ProtoWithClassProperty.Type = SwiftClass.self
+  expectNotEmpty(hasOwnProp.optionalClassProp)
+  expectEqual(true, hasOwnProp.optionalClassProp!())
+
+  let hasPropObjC: ProtoWithClassProperty.Type = ObjCSubclassWithClassProperty.self
+  expectNotEmpty(hasPropObjC.optionalClassProp)
+  expectEqual(true, hasPropObjC.optionalClassProp!())
+}
+
+runAllTests()
+

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -360,6 +360,7 @@ public class NonObjCClass { }
 // CHECK-NEXT: @property (nonatomic) NSInteger computed;
 // CHECK-NEXT: + (Properties * _Nonnull)shared;
 // CHECK-NEXT: + (void)setShared:(Properties * _Nonnull)newValue;
+// CHECK-NEXT: + (Properties * _Nonnull)sharedRO;
 // CHECK-NEXT: @property (nonatomic, weak) Properties * _Nullable weakOther;
 // CHECK-NEXT: @property (nonatomic, assign) Properties * _Nonnull unownedOther;
 // CHECK-NEXT: @property (nonatomic, unsafe_unretained) Properties * _Nonnull unmanagedOther;
@@ -416,6 +417,10 @@ public class NonObjCClass { }
   class var shared: Properties {
     get { return Properties() }
     set { }
+  }
+
+  class var sharedRO: Properties {
+    get { return Properties() }
   }
 
   weak var weakOther: Properties?

--- a/test/SILGen/Inputs/objc_bridged_results.h
+++ b/test/SILGen/Inputs/objc_bridged_results.h
@@ -9,6 +9,8 @@
 @property (nonnull, readonly) NSSet *nonnullSet;
 @property (nonnull, readonly) NSString *nonnullString;
 
+@property (class, nonnull, readonly) NSString *nonnullSharedString;
+
 // Subscripts still have thunks wrapped around them.
 - (nonnull NSArray *)objectAtIndexedSubscript:(long)index;
 @end

--- a/test/SILGen/objc_bridged_results.swift
+++ b/test/SILGen/objc_bridged_results.swift
@@ -100,6 +100,18 @@ func testNonnullString(obj: Test) -> String {
   return obj.nonnullString
 } // CHECK: {{^}$}}
 
+// CHECK-LABEL: sil hidden @_TF20objc_bridged_results13testClassPropFT_SS
+func testClassProp() -> String {
+  // CHECK: [[CLASS:%.+]] = metatype $@thick Test.Type
+  // CHECK: [[METHOD:%.+]] = class_method [volatile] [[CLASS]] : $@thick Test.Type, #Test.nonnullSharedString!1.foreign : Test.Type -> () -> String , $@convention(objc_method) (@objc_metatype Test.Type) -> @autoreleased Optional<NSString>
+  // CHECK: [[OBJC_CLASS:%.+]] = thick_to_objc_metatype [[CLASS]] : $@thick Test.Type to $@objc_metatype Test.Type
+  // CHECK: [[COCOA_VAL:%[0-9]+]] = apply [[METHOD]]([[OBJC_CLASS]]) : $@convention(objc_method) (@objc_metatype Test.Type) -> @autoreleased Optional<NSString>
+  // CHECK: [[CONVERT:%[0-9]+]] = function_ref @swift_NSStringToString : $@convention(thin) (@owned Optional<NSString>) -> @owned String
+  // CHECK: [[RESULT:%[0-9]+]] = apply [[CONVERT]]([[COCOA_VAL]]) : $@convention(thin) (@owned Optional<NSString>) -> @owned String
+  // CHECK: return [[RESULT]] : $String
+  return Test.nonnullSharedString()
+} // CHECK: {{^}$}}
+
 
 // Note: This doesn't really "work" in that it doesn't accept a nil value the
 // way the others do, because subscripts are thunked. But the main thing is


### PR DESCRIPTION
Currently Swift 2.3 is completely broken here, importing class properties as instance properties.

Importing class properties as class methods in Swift 2.3 means less churn for existing Swift 2 code.

rdar://problem/26485190

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
