### PR TITLE
Platform: port to msvcrt, add msvcrt module

### DIFF
--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -54,6 +54,9 @@ function(handle_swift_sources
   if (NOT SWIFTSOURCES_IS_MAIN)
     list(APPEND swift_compile_flags "-module-link-name" "${name}")
   endif()
+  if("${SWIFTSOURCES_SDK}" STREQUAL "CYGWIN")
+    list(APPEND swift_compile_flags -DCYGWIN)
+  endif()
 
   if(swift_sources)
     # Special-case hack to create Swift.o for the core standard library.

--- a/stdlib/private/SwiftPrivateLibcExtras/Subprocess.c
+++ b/stdlib/private/SwiftPrivateLibcExtras/Subprocess.c
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Spawn is not available on Android.
-#if !defined(__ANDROID__)
+// posix_spawn is not available on Android or Windows (MSVC).
+#if !defined(__ANDROID__) && (!defined(_WIN32) || defined(__CYGWIN__))
 
 #include "swift/Runtime/Config.h"
 
@@ -65,5 +65,5 @@ char ***swift_SwiftPrivateLibcExtras_NSGetEnviron(void) {
   return _NSGetEnviron();
 }
 #endif // defined(__APPLE__)
-#endif // defined(__ANDROID__)
+#endif // !defined(__ANDROID__) && (!defined(_WIN32) || defined(__CGYWIN__))
 

--- a/stdlib/private/SwiftPrivateLibcExtras/Subprocess.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/Subprocess.swift
@@ -18,7 +18,8 @@ import Glibc
 #endif
 
 
-// posix_spawn is not available on Android.
+#if !os(Windows) || CYGWIN
+// posix_spawn is not available on Android or Windows.
 #if !os(Android)
 // swift_posix_spawn isn't available in the public watchOS SDK, we sneak by the
 // unavailable attribute declaration here of the APIs that we need.
@@ -293,3 +294,5 @@ internal func _getEnviron() -> UnsafeMutablePointer<UnsafeMutablePointer<CChar>?
   return __environ
 #endif
 }
+#endif
+

--- a/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
@@ -17,6 +17,7 @@ import Darwin
 import Glibc
 #endif
 
+#if !os(Windows) || CYGWIN
 public func _stdlib_mkstemps(_ template: inout String, _ suffixlen: CInt) -> CInt {
 #if os(Android)
   preconditionFailure("mkstemps doesn't work on Android")
@@ -32,6 +33,7 @@ public func _stdlib_mkstemps(_ template: inout String, _ suffixlen: CInt) -> CIn
   return fd
 #endif
 }
+#endif
 
 public var _stdlib_FD_SETSIZE: CInt {
   return 1024
@@ -81,6 +83,7 @@ public struct _stdlib_fd_set {
   }
 }
 
+#if !os(Windows) || CYGWIN
 public func _stdlib_select(
   _ readfds: inout _stdlib_fd_set, _ writefds: inout _stdlib_fd_set,
   _ errorfds: inout _stdlib_fd_set, _ timeout: UnsafeMutablePointer<timeval>?
@@ -104,6 +107,7 @@ public func _stdlib_select(
     }
   }
 }
+#endif
 
 //
 // Functions missing in `Darwin` module.

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -22,6 +22,11 @@ add_swift_library(swiftGlibc ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
     TARGET_SDKS ANDROID CYGWIN FREEBSD LINUX
     DEPENDS glibc_modulemap)
 
+add_swift_library(swiftMSVCRT ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+    msvcrt.swift
+    ${swift_platform_sources}
+    TARGET_SDKS WINDOWS)
+
 set(glibc_modulemap_target_list)
 foreach(sdk ${SWIFT_SDKS})
   if("${sdk}" STREQUAL "LINUX" OR

--- a/stdlib/public/Platform/Misc.c
+++ b/stdlib/public/Platform/Misc.c
@@ -11,18 +11,33 @@
 //===----------------------------------------------------------------------===//
 
 #include <fcntl.h>
+#if !defined(_WIN32) || defined(__CYGWIN__)
 #include <semaphore.h>
+#endif
+#if defined(_WIN32) && !defined(__CYGWIN__)
+#include <io.h>
+#endif
 #include <sys/types.h>
 #include <sys/stat.h>
+#if !defined(_WIN32) || defined(__CYGWIN__)
 #include <sys/ioctl.h>
+#endif
 
 #include "swift/Runtime/Config.h"
 
+#if !defined(_WIN32) || defined(__CYGWIN__)
 SWIFT_CC(swift)
 extern int _swift_Platform_open(const char *path, int oflag, mode_t mode) {
   return open(path, oflag, mode);
 }
+#else
+SWIFT_CC(swift)
+extern int _swift_Platform_open(const char *path, int oflag, int mode) {
+  return _open(path, oflag, mode);
+}
+#endif
 
+#if !defined(_WIN32) || defined(__CYGWIN__)
 SWIFT_CC(swift)
 extern int _swift_Platform_openat(int fd, const char *path, int oflag,
                                   mode_t mode) {
@@ -61,7 +76,8 @@ extern int
 _swift_Platform_ioctlPtr(int fd, unsigned long int request, void* ptr) {
   return ioctl(fd, request, ptr);
 }
- 
+#endif
+
 #if defined(__APPLE__)
 #define _REENTRANT
 #include <math.h>

--- a/stdlib/public/Platform/msvcrt.swift
+++ b/stdlib/public/Platform/msvcrt.swift
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import ucrt // Clang module
+@_exported import visualc // Clang module
+

--- a/stdlib/public/Platform/tgmath.swift.gyb
+++ b/stdlib/public/Platform/tgmath.swift.gyb
@@ -171,11 +171,25 @@ public func fpclassify(_ value: ${T}) -> Int {
 %if T == 'Double':
 #if os(Linux)
   return Int(__fpclassify(CDouble(value)))
+#elseif os(Windows)
+#if CYGWIN
+  return Int(__fpclassify(CDouble(value)))
+#else
+  return Int(_dclass(CDouble(value)))
+#endif
 #else
   return Int(__fpclassifyd(CDouble(value)))
 #endif
 %else:
+#if os(Windows)
+#if CYGWIN
   return Int(__fpclassify${f}(${CT}(value)))
+#else
+  return Int(_${f}dclass(${CT}(value)))
+#endif
+#else
+  return Int(__fpclassify${f}(${CT}(value)))
+#endif
 %end
 }
 
@@ -247,13 +261,24 @@ public func scalbn(_ x: ${T}, _ n: Int) -> ${T} {
 
 % # This is AllFloatTypes not OverlayFloatTypes because of the tuple return.
 % for T, CT, f in AllFloatTypes():
-#if os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Windows)
+#if os(Linux) || os(FreeBSD) || os(PS4) || os(Android)
 @_transparent
 public func lgamma(_ x: ${T}) -> (${T}, Int) {
   var sign = Int32(0)
   let value = lgamma${f}_r(${CT}(x), &sign)
   return (${T}(value), Int(sign))
 }
+#elseif os(Windows)
+#if CYGWIN
+@_transparent
+public func lgamma(_ x: ${T}) -> (${T}, Int) {
+  var sign = Int32(0)
+  let value = lgamma${f}_r(${CT}(x), &sign)
+  return (${T}(value), Int(sign))
+}
+#else
+// TODO(compnerd): implement
+#endif
 #else
 % # On Darwin platform,
 % # The real lgamma_r is not imported because it hides behind macro _REENTRANT.
@@ -305,12 +330,28 @@ public func fma(_ x: ${T}, _ y: ${T}, _ z: ${T}) -> ${T} {
 % # These C functions only support double. The overlay fixes the Int parameter.
 @_transparent
 public func jn(_ n: Int, _ x: Double) -> Double {
+#if os(Windows)
+#if CYGWIN
   return jn(Int32(n), x)
+#else
+  return _jn(Int32(n), x)
+#endif
+#else
+  return jn(Int32(n), x)
+#endif
 }
 
 @_transparent
 public func yn(_ n: Int, _ x: Double) -> Double {
+#if os(Windows)
+#if CYGWIN
   return yn(Int32(n), x)
+#else
+  return _yn(Int32(n), x)
+#endif
+#else
+  return yn(Int32(n), x)
+#endif
 }
 
 % end

--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -1,0 +1,102 @@
+//===--- ucrt.modulemap ---------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+module ucrt [system] {
+  module C {
+    module complex {
+      header "complex.h"
+      export *
+    }
+
+    module ctype {
+      header "ctype.h"
+      export *
+    }
+
+    module errno {
+      header "errno.h"
+      export *
+    }
+
+    module fenv {
+      header "fenv.h"
+      export *
+    }
+
+    module inttypes {
+      header "inttypes.h"
+      export *
+    }
+
+    module locale {
+      header "locale.h"
+      export *
+    }
+
+    module math {
+      header "math.h"
+      export *
+    }
+
+    module signal {
+      header "signal.h"
+      export *
+    }
+
+    module stddef {
+      header "stddef.h"
+      export *
+    }
+
+    module stdio {
+      header "stdio.h"
+      export *
+    }
+
+    module stdlib {
+      header "stdlib.h"
+      export *
+    }
+
+    module string {
+      header "string.h"
+      export *
+    }
+
+    module time {
+      header "time.h"
+      export *
+    }
+
+    module POSIX {
+      module sys {
+        export *
+
+        module stat {
+          header "sys/stat.h"
+          export *
+        }
+
+        module types {
+          header "sys/types.h"
+          export *
+        }
+
+        module utime {
+          header "sys/utime.h"
+          export *
+        }
+      }
+    }
+  }
+}
+

--- a/stdlib/public/Platform/visualc.modulemap
+++ b/stdlib/public/Platform/visualc.modulemap
@@ -1,0 +1,19 @@
+//===--- vc.modulemap -----------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+module visualc [system] {
+  module SAL {
+    header "sal.h"
+    export *
+  }
+}
+


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

This adds the swiftMSVCRT module which is similar in spirit to swiftGlibc and
swiftDarwin, exposing the Microsoft C Runtime library to swift.  Furthermore,
disable pieces of the standard library which are not immediately trivially
portable to Windows.  A lot of this functionality can still be implemented and
exposed to the user, however, this is the quickest means to a PoC for native
windows support.

As a temporary solution, add a -DCYGWIN flag to indicate that we are building
for the cygwin windows target.  This allows us to continue supporting the cygwin
environment whilst making the windows port work natively against the windows
environment (msvc).  Eventually, that will hopefully be replaced with an
environment check in swift.
