### PR TITLE
Add 💥 (😢 → 60, 😀 → 5107) in swift::TypeChecker::validateDecl(…)

### DIFF
--- a/validation-test/compiler_crashers/28358-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers/28358-swift-typechecker-validatedecl.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+{struct B<h{typealias B<T>:T>var d=B


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Add test case for crash triggered in `swift::TypeChecker::validateDecl(…)`.

Assertion failure in [`lib/AST/ArchetypeBuilder.cpp (line 2109)`](https://github.com/apple/swift/blob/master/lib/AST/ArchetypeBuilder.cpp#L2109):

```
Assertion `!type->hasArchetype() && "not fully substituted"' failed.

When executing: static swift::Type swift::ArchetypeBuilder::mapTypeOutOfContext(swift::ModuleDecl *, swift::GenericParamList *, swift::Type)
```

<details>
<summary>

Assertion context:</summary>



```
                                           Type type) {
  auto canType = type->getCanonicalType();
  assert(!canType->hasTypeParameter() && "already have an interface type");
  if (!canType->hasArchetype())
    return type;

  assert(genericParams && "dependent type in non-generic context");

  // Capture the archetype -> interface type mapping.
  TypeSubstitutionMap subs;
  for (auto params = genericParams; params != nullptr;
       params = params->getOuterParameters()) {
    for (auto param : *params) {
      subs[param->getArchetype()] = param->getDeclaredType();
    }
  }

  type = type.subst(M, subs, SubstFlags::AllowLoweredTypes);

  assert(!type->hasArchetype() && "not fully substituted");
  return type;
}

bool ArchetypeBuilder::addGenericSignature(GenericSignature *sig,
                                           bool adoptArchetypes,
                                           bool treatRequirementsAsExplicit) {
  if (!sig) return false;

  RequirementSource::Kind sourceKind = treatRequirementsAsExplicit
    ? RequirementSource::Explicit
```

</details>
<details>
<summary>

Stack trace:</summary>



```
swift: /path/to/swift/lib/AST/ArchetypeBuilder.cpp:2109: static swift::Type swift::ArchetypeBuilder::mapTypeOutOfContext(swift::ModuleDecl *, swift::GenericParamList *, swift::Type): Assertion `!type->hasArchetype() && "not fully substituted"' failed.
11 swift           0x0000000000eaefdd swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3853
12 swift           0x0000000000f3377d swift::createImplicitConstructor(swift::TypeChecker&, swift::NominalTypeDecl*, swift::ImplicitConstructorKind) + 413
13 swift           0x0000000000eb9480 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 1536
16 swift           0x0000000000eb3876 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
19 swift           0x0000000000f1b164 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
20 swift           0x0000000000f4743c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
21 swift           0x0000000000ea1f01 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 769
23 swift           0x0000000000f1b2a6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
24 swift           0x0000000000ed5a6d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
25 swift           0x0000000000c62229 swift::CompilerInstance::performSema() + 3289
27 swift           0x00000000007d85a9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
28 swift           0x00000000007a45c8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28358-swift-typechecker-validatedecl.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28358-swift-typechecker-validatedecl-0ed663.o
1.  While type-checking expression at [validation-test/compiler_crashers/28358-swift-typechecker-validatedecl.swift:10:1 - line:10:36] RangeText="{struct B<h{typealias B<T>:T>var d=B"
2.  While type-checking 'B' at validation-test/compiler_crashers/28358-swift-typechecker-validatedecl.swift:10:2
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```

</details>
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
