### PR TITLE
Add 💥 (😢 → 61, 😀 → 5107) in swift::constraints::ConstraintSystem::addTypeVariableConstraintsToWorkList(…)

### DIFF
--- a/validation-test/compiler_crashers/28359-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
+++ b/validation-test/compiler_crashers/28359-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+{class a{}func a(a)class c{func b{{{a(a{


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Add test case for crash triggered in `swift::constraints::ConstraintSystem::addTypeVariableConstraintsToWorkList(…)`.

<details>
<summary>

Stack trace:</summary>



```
4  swift           0x0000000000f3b8e1 swift::constraints::ConstraintSystem::addTypeVariableConstraintsToWorkList(swift::TypeVariableType*) + 113
5  swift           0x0000000000f3bae9 swift::constraints::ConstraintSystem::assignFixedType(swift::TypeVariableType*, swift::Type, bool) + 377
6  swift           0x0000000000fabea8 swift::constraints::ConstraintSystem::finalize(swift::FreeTypeVariableBinding) + 792
7  swift           0x0000000000fb5933 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 11843
8  swift           0x0000000000fb11d5 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 325
9  swift           0x0000000000fb4ec3 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 9171
10 swift           0x0000000000fb11d5 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 325
11 swift           0x0000000000fb4ec3 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 9171
12 swift           0x0000000000fb1d29 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 3225
13 swift           0x0000000000fb3840 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 3408
14 swift           0x0000000000fb11d5 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 325
15 swift           0x0000000000fb0f89 swift::constraints::ConstraintSystem::solve(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 73
16 swift           0x0000000000e9b6d0 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 800
17 swift           0x0000000000ea1e62 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
20 swift           0x0000000000f63cb9 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 105
21 swift           0x0000000000f6963e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 3998
22 swift           0x0000000000e9b702 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 850
23 swift           0x0000000000ea1e62 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
26 swift           0x0000000000f19dea swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
27 swift           0x0000000000f19c4e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
28 swift           0x0000000000f1a813 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
30 swift           0x0000000000ed5b01 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
31 swift           0x0000000000c62229 swift::CompilerInstance::performSema() + 3289
33 swift           0x00000000007d85a9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
34 swift           0x00000000007a45c8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28359-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28359-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist-e0b297.o
1.  While type-checking 'b' at validation-test/compiler_crashers/28359-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift:9:28
2.  While type-checking expression at [validation-test/compiler_crashers/28359-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift:9:35 - line:9:40] RangeText="{{a(a{"
3.  While type-checking expression at [validation-test/compiler_crashers/28359-swift-constraints-constraintsystem-addtypevariableconstraintstoworklist.swift:9:36 - line:9:40] RangeText="{a(a{"
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```

</details>
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
