### PR TITLE
stdlib: change Collection._copyToNativeArrayBuffer() to be defined in terms of public types

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
@@ -89,7 +89,7 @@ public class SequenceLog {
   public static var split = TypeIndexed(0)
   public static var _customContainsEquatableElement = TypeIndexed(0)
   public static var _preprocessingPass = TypeIndexed(0)
-  public static var _copyToNativeArrayBuffer = TypeIndexed(0)
+  public static var _copyToContiguousArray = TypeIndexed(0)
   public static var _copyContents = TypeIndexed(0)
 }
 
@@ -302,10 +302,10 @@ public struct ${Self}<
 
   /// Create a native array buffer containing the elements of `self`,
   /// in the same order.
-  public func _copyToNativeArrayBuffer()
-    -> _ContiguousArrayBuffer<Base.Iterator.Element> {
-    Log._copyToNativeArrayBuffer[selfType] += 1
-    return base._copyToNativeArrayBuffer()
+  public func _copyToContiguousArray()
+    -> ContiguousArray<Base.Iterator.Element> {
+    Log._copyToContiguousArray[selfType] += 1
+    return base._copyToContiguousArray()
   }
 
   /// Copy a Sequence into an array.

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -936,7 +936,7 @@ extension ${Self} : ArrayLiteralConvertible {
   ///
   /// - Parameter elements: A variadic list of elements of the new array.
   public init(arrayLiteral elements: Element...) {
-    self.init(_buffer: _extractOrCopyToNativeArrayBuffer(elements._buffer))
+    self.init(_buffer: _extractOrCopyToContiguousArray(elements._buffer)._buffer)
   }
 %end
 }
@@ -1037,7 +1037,8 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   public init<S : Sequence>(_ s: S)
     where S.Iterator.Element == Element {
 
-    self = ${Self}(_buffer: _Buffer(s._copyToNativeArrayBuffer(),
+    self = ${Self}(
+      _buffer: _Buffer(s._copyToContiguousArray()._buffer,
       shiftedToStartIndex: 0))
   }
 
@@ -1426,8 +1427,8 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
     }
   }
 
-  public func _copyToNativeArrayBuffer() -> _ContiguousArrayBuffer<Element> {
-    return _extractOrCopyToNativeArrayBuffer(self._buffer)
+  public func _copyToContiguousArray() -> ContiguousArray<Element> {
+    return _extractOrCopyToContiguousArray(self._buffer)
   }
 }
 
@@ -1976,18 +1977,27 @@ internal func _arrayReserve<_Buffer>(
   _arrayOutOfPlaceUpdate(&buffer, &newBuffer, count, 0, _IgnorePointer())
 }
 
-public // SPI(Foundation)
-func _extractOrCopyToNativeArrayBuffer<Buffer>(
+internal func _extractOrCopyToContiguousArray<Buffer>(
+  _ source: Buffer
+) -> ContiguousArray<Buffer.Iterator.Element>
+  where
+  Buffer : _ArrayBufferProtocol,
+  Buffer.Iterator.Element == Buffer.Element {
+
+  if let n = source.requestNativeBuffer() {
+    return ContiguousArray(_buffer: n)
+  }
+  return _copyCollectionToContiguousArray(source)
+}
+
+internal func _extractOrCopyToNativeArrayBuffer<Buffer>(
   _ source: Buffer
 ) -> _ContiguousArrayBuffer<Buffer.Iterator.Element>
   where
   Buffer : _ArrayBufferProtocol,
   Buffer.Iterator.Element == Buffer.Element {
 
-  if let n = source.requestNativeBuffer() {
-    return n
-  }
-  return _copyCollectionToNativeArrayBuffer(source)
+  return _extractOrCopyToContiguousArray(source)._buffer
 }
 
 /// Append items from `newItems` to `buffer`.

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -936,7 +936,7 @@ extension ${Self} : ArrayLiteralConvertible {
   ///
   /// - Parameter elements: A variadic list of elements of the new array.
   public init(arrayLiteral elements: Element...) {
-    self.init(_buffer: _extractOrCopyToContiguousArray(elements._buffer)._buffer)
+    self.init(_buffer: ContiguousArray(elements)._buffer)
   }
 %end
 }
@@ -1428,7 +1428,10 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   }
 
   public func _copyToContiguousArray() -> ContiguousArray<Element> {
-    return _extractOrCopyToContiguousArray(self._buffer)
+    if let n = _buffer.requestNativeBuffer() {
+      return ContiguousArray(_buffer: n)
+    }
+    return _copyCollectionToContiguousArray(_buffer)
   }
 }
 
@@ -1488,10 +1491,9 @@ extension ${Self} {
     if _fastPath(p != nil || isEmpty) {
       return (_owner, UnsafePointer(p))
     }
-    let n = _extractOrCopyToNativeArrayBuffer(self._buffer)
+    let n = ContiguousArray(self._buffer)._buffer
     return (n.owner, UnsafePointer(n.firstElementAddress))
   }
-
 }
 
 extension ${Self} {
@@ -1975,29 +1977,6 @@ internal func _arrayReserve<_Buffer>(
   var newBuffer = _forceCreateUniqueMutableBuffer(
     &buffer, newCount: count, requiredCapacity: requiredCapacity)
   _arrayOutOfPlaceUpdate(&buffer, &newBuffer, count, 0, _IgnorePointer())
-}
-
-internal func _extractOrCopyToContiguousArray<Buffer>(
-  _ source: Buffer
-) -> ContiguousArray<Buffer.Iterator.Element>
-  where
-  Buffer : _ArrayBufferProtocol,
-  Buffer.Iterator.Element == Buffer.Element {
-
-  if let n = source.requestNativeBuffer() {
-    return ContiguousArray(_buffer: n)
-  }
-  return _copyCollectionToContiguousArray(source)
-}
-
-internal func _extractOrCopyToNativeArrayBuffer<Buffer>(
-  _ source: Buffer
-) -> _ContiguousArrayBuffer<Buffer.Iterator.Element>
-  where
-  Buffer : _ArrayBufferProtocol,
-  Buffer.Iterator.Element == Buffer.Element {
-
-  return _extractOrCopyToContiguousArray(source)._buffer
 }
 
 /// Append items from `newItems` to `buffer`.

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -174,7 +174,7 @@ internal class _AnyRandomAccessCollectionBox<Element>
     _abstract()
   }
 
-  internal func __copyToNativeArrayBuffer() -> _ContiguousArrayStorageBase {
+  internal func __copyToContiguousArray() -> ContiguousArray<Element> {
     _abstract()
   }
 
@@ -358,8 +358,8 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
   ) rethrows -> R? {
     return try _base._preprocessingPass(preprocess)
   }
-  internal override func __copyToNativeArrayBuffer() -> _ContiguousArrayStorageBase {
-    return _base._copyToNativeArrayBuffer()._storage
+  internal override func __copyToContiguousArray() -> ContiguousArray<Element> {
+    return _base._copyToContiguousArray()
   }
   internal override func __copyContents(initializing ptr: UnsafeMutablePointer<Element>)
     -> UnsafeMutablePointer<Element> {
@@ -627,8 +627,8 @@ extension Any${Kind} {
     return try _box.__preprocessingPass(preprocess)
   }
 
-  public func _copyToNativeArrayBuffer() -> _ContiguousArrayBuffer<Element> {
-    return _ContiguousArrayBuffer(self._box.__copyToNativeArrayBuffer())
+  public func _copyToContiguousArray() -> ContiguousArray<Element> {
+    return self._box.__copyToContiguousArray()
   }
 
   public func _copyContents(initializing ptr: UnsafeMutablePointer<Element>)

--- a/stdlib/public/core/Flatten.swift.gyb
+++ b/stdlib/public/core/Flatten.swift.gyb
@@ -336,14 +336,14 @@ public struct ${Collection}<Base> : ${collectionForTraversal(traversal)}
   // just return zero.
   public var underestimatedCount: Int { return 0 }
 
-  public func _copyToNativeArrayBuffer()
-    -> _ContiguousArrayBuffer<Base.Iterator.Element.Iterator.Element> {
+  public func _copyToContiguousArray()
+    -> ContiguousArray<Base.Iterator.Element.Iterator.Element> {
 
-    // The default implementation of `_copyToNativeArrayBuffer` queries the
+    // The default implementation of `_copyToContiguousArray` queries the
     // `count` property, which materializes every inner collection.  This is a
     // bad default for `flatMap()`.  So we treat `self` as a sequence and only
     // rely on underestimated count.
-    return _copySequenceToNativeArrayBuffer(self)
+    return _copySequenceToContiguousArray(self)
   }
 
   // TODO: swift-3-indexing-model - add docs

--- a/stdlib/public/core/Join.swift
+++ b/stdlib/public/core/Join.swift
@@ -110,8 +110,8 @@ public struct JoinedSequence<Base : Sequence> : Sequence
       separator: _separator)
   }
 
-  public func _copyToNativeArrayBuffer()
-    -> _ContiguousArrayBuffer<Base.Iterator.Element.Iterator.Element> {
+  public func _copyToContiguousArray()
+    -> ContiguousArray<Base.Iterator.Element.Iterator.Element> {
     var result = ContiguousArray<Iterator.Element>()
     let separatorSize: Int = numericCast(_separator.count)
 
@@ -132,7 +132,7 @@ public struct JoinedSequence<Base : Sequence> : Sequence
       for x in _base {
         result.append(contentsOf: x)
       }
-      return result._buffer
+      return result
     }
 
     var iter = _base.makeIterator()
@@ -144,7 +144,7 @@ public struct JoinedSequence<Base : Sequence> : Sequence
       }
     }
 
-    return result._buffer
+    return result
   }
 
   internal var _base: Base

--- a/stdlib/public/core/LazyCollection.swift.gyb
+++ b/stdlib/public/core/LazyCollection.swift.gyb
@@ -89,9 +89,9 @@ extension ${Self} : Sequence {
   /// - Complexity: O(N).
   public var underestimatedCount: Int { return _base.underestimatedCount }
 
-  public func _copyToNativeArrayBuffer() 
-     -> _ContiguousArrayBuffer<Base.Iterator.Element> {
-    return _base._copyToNativeArrayBuffer()
+  public func _copyToContiguousArray()
+     -> ContiguousArray<Base.Iterator.Element> {
+    return _base._copyToContiguousArray()
   }
   
   @discardableResult

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -584,7 +584,7 @@ public protocol Sequence {
 
   /// Create a native array buffer containing the elements of `self`,
   /// in the same order.
-  func _copyToNativeArrayBuffer() -> _ContiguousArrayBuffer<Iterator.Element>
+  func _copyToContiguousArray() -> ContiguousArray<Iterator.Element>
 
   /// Copy a Sequence into an array, returning one past the last
   /// element initialized.

--- a/stdlib/public/core/SequenceWrapper.swift
+++ b/stdlib/public/core/SequenceWrapper.swift
@@ -110,9 +110,9 @@ extension Sequence
 
   /// Create a native array buffer containing the elements of `self`,
   /// in the same order.
-  public func _copyToNativeArrayBuffer()
-    -> _ContiguousArrayBuffer<Base.Iterator.Element> {
-    return _base._copyToNativeArrayBuffer()
+  public func _copyToContiguousArray()
+    -> ContiguousArray<Base.Iterator.Element> {
+    return _base._copyToContiguousArray()
   }
 
   /// Copy a Sequence into an array, returning one past the last

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -327,11 +327,11 @@ struct _SliceBuffer<Element> : _ArrayBufferProtocol, RandomAccessCollection {
 }
 
 extension _SliceBuffer {
-  public func _copyToNativeArrayBuffer() -> _ContiguousArrayBuffer<Element> {
+  public func _copyToContiguousArray() -> ContiguousArray<Element> {
     if _hasNativeBuffer {
       let n = nativeBuffer
       if count == n.count {
-        return n
+        return ContiguousArray(_buffer: n)
       }
     }
 
@@ -340,6 +340,6 @@ extension _SliceBuffer {
       minimumCapacity: 0)
     result.firstElementAddress.initializeFrom(
       firstElementAddress, count: count)
-    return result
+    return ContiguousArray(_buffer: result)
   }
 }

--- a/validation-test/stdlib/Arrays.swift.gyb
+++ b/validation-test/stdlib/Arrays.swift.gyb
@@ -6,18 +6,18 @@ import StdlibCollectionUnittest
 
 let CopyToNativeArrayBufferTests = TestSuite("CopyToNativeArrayBufferTests")
 
-CopyToNativeArrayBufferTests.test("Sequence._copyToNativeArrayBuffer()") {
+CopyToNativeArrayBufferTests.test("Sequence._copyToContiguousArray()") {
   do {
     // Call from a static context.
     let s =
       MinimalSequence(elements: LifetimeTracked(10)..<LifetimeTracked(27))
 
     expectEqual(0, s.timesMakeIteratorCalled.value)
-    let buffer = s._copyToNativeArrayBuffer()
+    let copy = s._copyToContiguousArray()
     expectEqual(1, s.timesMakeIteratorCalled.value)
     expectEqualSequence(
       Array(10..<27),
-      buffer.map { $0.value })
+      copy.map { $0.value })
   }
   do {
     // Call from a generic context.
@@ -25,15 +25,15 @@ CopyToNativeArrayBufferTests.test("Sequence._copyToNativeArrayBuffer()") {
     let s = LoggingSequence(wrapping: wrapped)
 
     expectEqual(0, wrapped.timesMakeIteratorCalled.value)
-    let buffer = s._copyToNativeArrayBuffer()
+    let copy = s._copyToContiguousArray()
     expectEqual(1, wrapped.timesMakeIteratorCalled.value)
     expectEqualSequence(
       Array(10..<27),
-      buffer.map { $0.value })
+      copy.map { $0.value })
   }
 }
 
-CopyToNativeArrayBufferTests.test("Collection._copyToNativeArrayBuffer()") {
+CopyToNativeArrayBufferTests.test("Collection._copyToContiguousArray()") {
   // Check that collections are handled with the collection-specific API.  This
   // means that we are calling the right default implementation (one for
   // collections, not the one for sequences).
@@ -45,12 +45,12 @@ CopyToNativeArrayBufferTests.test("Collection._copyToNativeArrayBuffer()") {
 
     expectEqual(0, c.timesMakeIteratorCalled.value)
     expectEqual(0, c.timesStartIndexCalled.value)
-    let buffer = c._copyToNativeArrayBuffer()
+    let copy = c._copyToContiguousArray()
     expectEqual(0, c.timesMakeIteratorCalled.value)
     expectNotEqual(0, c.timesStartIndexCalled.value)
     expectEqualSequence(
       Array(10..<27),
-      buffer.map { $0.value })
+      copy.map { $0.value })
   }
   do {
     // Call from a generic context.
@@ -59,13 +59,13 @@ CopyToNativeArrayBufferTests.test("Collection._copyToNativeArrayBuffer()") {
     let s = LoggingSequence(wrapping: wrapped)
     expectEqual(0, wrapped.timesMakeIteratorCalled.value)
     expectEqual(0, wrapped.timesStartIndexCalled.value)
-    let buffer = s._copyToNativeArrayBuffer()
+    let copy = s._copyToContiguousArray()
     expectEqual(0, wrapped.timesMakeIteratorCalled.value)
     expectNotEqual(0, wrapped.timesStartIndexCalled.value)
 
     expectEqualSequence(
       Array(10..<27),
-      buffer.map { $0.value })
+      copy.map { $0.value })
   }
 }
 

--- a/validation-test/stdlib/ExistentialCollection.swift.gyb
+++ b/validation-test/stdlib/ExistentialCollection.swift.gyb
@@ -181,8 +181,8 @@ tests.test("${TestedType}: dispatch to wrapped") {
     _ = s._preprocessingPass {}
   }
 
-  Log._copyToNativeArrayBuffer.expectIncrement(Base.self) {
-    _ = s._copyToNativeArrayBuffer()
+  Log._copyToContiguousArray.expectIncrement(Base.self) {
+    _ = s._copyToContiguousArray()
   }
 
   do {

--- a/validation-test/stdlib/Join.swift.gyb
+++ b/validation-test/stdlib/Join.swift.gyb
@@ -288,7 +288,7 @@ JoinTestSuite.test("${Base}.join()") {
   }
 }
 
-JoinTestSuite.test("${Base}.join()/_copyToNativeArrayBuffer()") {
+JoinTestSuite.test("${Base}.join()/_copyToContiguousArray()") {
   for test in joinWithSeparatorTests {
     let elements = ${Base}(${label} test.elements.map {
       ${Base}(${label} $0)

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -633,8 +633,8 @@ func expectSequencePassthrough<
   SequenceLog._customContainsEquatableElement.expectIncrement(baseType) {
     _ = s._customContainsEquatableElement(arbitraryElement)
   }
-  SequenceLog._copyToNativeArrayBuffer.expectIncrement(baseType) {
-    _ = s._copyToNativeArrayBuffer()
+  SequenceLog._copyToContiguousArray.expectIncrement(baseType) {
+    _ = s._copyToContiguousArray()
   }
 
   SequenceLog._copyContents.expectIncrement(baseType) { () -> Void in

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -1108,9 +1108,9 @@ SequenceTypeTests.test("underestimatedCount/Sequence/CustomImplementation") {
 }
 
 //===----------------------------------------------------------------------===//
-// _copyToNativeArrayBuffer()
+// _copyToContiguousArray()
 //===----------------------------------------------------------------------===//
-SequenceTypeTests.test("_copyToNativeArrayBuffer/OverestimatedCount")
+SequenceTypeTests.test("_copyToContiguousArray/OverestimatedCount")
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
@@ -1119,7 +1119,7 @@ SequenceTypeTests.test("_copyToNativeArrayBuffer/OverestimatedCount")
     elements: [ 1, 2, 3 ].map(OpaqueValue.init),
     underestimatedCount: .value(4))
   expectCrashLater()
-  let array = s._copyToNativeArrayBuffer()
+  let array = s._copyToContiguousArray()
   _blackHole(array)
 }
 

--- a/validation-test/stdlib/SequenceWrapperTest.swift
+++ b/validation-test/stdlib/SequenceWrapperTest.swift
@@ -85,10 +85,10 @@ sequenceWrapperTests.test("Dispatch/_preprocessingPass") {
     dispatchLog._preprocessingPass)
 }
 
-sequenceWrapperTests.test("Dispatch/_copyToNativeArrayBuffer") {
+sequenceWrapperTests.test("Dispatch/_copyToContiguousArray") {
   expectWrapperDispatch(
-    direct._copyToNativeArrayBuffer(), indirect._copyToNativeArrayBuffer(),
-    dispatchLog._copyToNativeArrayBuffer)
+    direct._copyToContiguousArray(), indirect._copyToContiguousArray(),
+    dispatchLog._copyToContiguousArray)
 }
 
 runAllTests()


### PR DESCRIPTION
This PR will allow us to hide `_ContiguousArrayBuffer` in future.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
