### PR TITLE
Add 💥 (😢 → 62, 😀 → 5107) in swift::ArchetypeBuilder::mapTypeOutOfContext(…)

### DIFF
--- a/validation-test/compiler_crashers/28360-swift-archetypebuilder-maptypeoutofcontext.swift
+++ b/validation-test/compiler_crashers/28360-swift-archetypebuilder-maptypeoutofcontext.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+struct A<f{protocol a{typealias f=B}struct B{let c=A.a as a


### PR DESCRIPTION
Add test case for crash triggered in `swift::ArchetypeBuilder::mapTypeOutOfContext(…)`.

Assertion failure in [`lib/AST/ArchetypeBuilder.cpp (line 2096)`](https://github.com/apple/swift/blob/master/lib/AST/ArchetypeBuilder.cpp#L2096):

```
Assertion `genericParams && "dependent type in non-generic context"' failed.

When executing: static swift::Type swift::ArchetypeBuilder::mapTypeOutOfContext(swift::ModuleDecl *, swift::GenericParamList *, swift::Type)
```

<details>
<summary>

Assertion context:</summary>



```

  assert(!type->hasTypeParameter() && "not fully substituted");
  return type;
}

Type
ArchetypeBuilder::mapTypeOutOfContext(const DeclContext *dc, Type type) {
  GenericParamList *genericParams = dc->getGenericParamsOfContext();
  return mapTypeOutOfContext(dc->getParentModule(), genericParams, type);
}

Type ArchetypeBuilder::mapTypeOutOfContext(ModuleDecl *M,
                                           GenericParamList *genericParams,
                                           Type type) {
  auto canType = type->getCanonicalType();
  assert(!canType->hasTypeParameter() && "already have an interface type");
  if (!canType->hasArchetype())
    return type;

  assert(genericParams && "dependent type in non-generic context");

  // Capture the archetype -> interface type mapping.
  TypeSubstitutionMap subs;
  for (auto params = genericParams; params != nullptr;
       params = params->getOuterParameters()) {
    for (auto param : *params) {
      subs[param->getArchetype()] = param->getDeclaredType();
    }
  }

```

</details>
<details>
<summary>

Stack trace:</summary>



```
swift: /path/to/swift/lib/AST/ArchetypeBuilder.cpp:2096: static swift::Type swift::ArchetypeBuilder::mapTypeOutOfContext(swift::ModuleDecl *, swift::GenericParamList *, swift::Type): Assertion `genericParams && "dependent type in non-generic context"' failed.
8  swift           0x0000000000ff26b4 swift::ArchetypeBuilder::mapTypeOutOfContext(swift::ModuleDecl*, swift::GenericParamList*, swift::Type) + 324
11 swift           0x0000000000efd15e swift::TypeChecker::resolveTypeWitness(swift::NormalProtocolConformance const*, swift::AssociatedTypeDecl*) + 254
12 swift           0x0000000001116c16 swift::NormalProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 150
13 swift           0x0000000001116b58 swift::ProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 40
14 swift           0x0000000001117326 swift::ProtocolConformance::getTypeWitness(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 6
17 swift           0x0000000001125fc4 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 36
18 swift           0x000000000111f4d4 swift::Type::subst(swift::ModuleDecl*, llvm::DenseMap<swift::TypeBase*, swift::Type, llvm::DenseMapInfo<swift::TypeBase*>, llvm::detail::DenseMapPair<swift::TypeBase*, swift::Type> >&, swift::OptionSet<swift::SubstFlags, unsigned int>) const + 68
19 swift           0x0000000000f448cf swift::constraints::Solution::computeSubstitutions(swift::Type, swift::DeclContext*, swift::Type, swift::constraints::ConstraintLocator*, llvm::SmallVectorImpl<swift::Substitution>&) const + 943
24 swift           0x0000000001069455 swift::Expr::walk(swift::ASTWalker&) + 69
25 swift           0x0000000000f474f2 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 514
26 swift           0x0000000000ea2121 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 769
28 swift           0x0000000000f63f3f swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 207
29 swift           0x0000000000f6985e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 3998
30 swift           0x0000000000e9b922 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 850
31 swift           0x0000000000ea2082 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
34 swift           0x0000000000f63ed9 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 105
35 swift           0x0000000000f6985e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 3998
36 swift           0x0000000000e9b922 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 850
37 swift           0x0000000000ea2082 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
38 swift           0x0000000000ea3237 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 343
39 swift           0x0000000000ea344b swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
46 swift           0x0000000000eb3a96 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
47 swift           0x0000000000ed5c22 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
48 swift           0x0000000000c624c9 swift::CompilerInstance::performSema() + 3289
50 swift           0x00000000007d85e9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
51 swift           0x00000000007a4608 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28360-swift-archetypebuilder-maptypeoutofcontext.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28360-swift-archetypebuilder-maptypeoutofcontext-089464.o
1.  While type-checking 'A' at validation-test/compiler_crashers/28360-swift-archetypebuilder-maptypeoutofcontext.swift:10:1
2.  While type-checking expression at [validation-test/compiler_crashers/28360-swift-archetypebuilder-maptypeoutofcontext.swift:10:52 - line:10:59] RangeText="A.a as a"
3.  While type-checking expression at [validation-test/compiler_crashers/28360-swift-archetypebuilder-maptypeoutofcontext.swift:10:52 - line:10:54] RangeText="A.a"
4.  While type-checking expression at [validation-test/compiler_crashers/28360-swift-archetypebuilder-maptypeoutofcontext.swift:10:52 - line:10:54] RangeText="A.a"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```

</details>
