### PR TITLE
build-script: strip debug info from libraries and executables

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2904,7 +2904,7 @@ for host in "${ALL_HOSTS[@]}"; do
             # Strip executables, shared libraries and static libraries in
             # `host_install_destdir`.
             find "${host_install_destdir}${TOOLCHAIN_PREFIX}/" \
-              -perm -0111 -or -name "*.a" -type f -print | \
+              '(' -perm -0111 -or -name "*.a" ')' -type f -print | \
               xargs -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool strip) -S
 
             { set +x; } 2>/dev/null


### PR DESCRIPTION
One of the recent build-script refactorings has dropped the parentheses,
restore them.

rdar://problem/27083605

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
