### PR TITLE
[Clang importer] Ignore Class Properties in Swift 2.3

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2050,7 +2050,8 @@ Type ClangImporter::Implementation::importMethodType(
   const clang::ObjCPropertyDecl *property = nullptr;
   bool isPropertyGetter = false;
   bool isPropertySetter = false;
-  if (clangDecl->isPropertyAccessor()) {
+  // Swift 2.2 does not import class properties as properties.
+  if (clangDecl->isPropertyAccessor() && clangDecl->isInstanceMethod()) {
     property = clangDecl->findPropertyDecl();
     if (property) {
       if (property->getGetterMethodDecl() == clangDecl) {

--- a/test/ClangModules/Inputs/custom-modules/ObjCClassPropertiesIgnored.h
+++ b/test/ClangModules/Inputs/custom-modules/ObjCClassPropertiesIgnored.h
@@ -1,0 +1,4 @@
+@interface A
+@property (class) float floatProperty;
+@property (class, readonly) double doubleProperty;
+@end

--- a/test/ClangModules/Inputs/custom-modules/module.map
+++ b/test/ClangModules/Inputs/custom-modules/module.map
@@ -99,6 +99,11 @@ module ObjCSubscripts {
   export *
 }
 
+module ObjCClassPropertiesIgnored {
+  header "ObjCClassPropertiesIgnored.h"
+  export *
+}
+
 module ProtoWithInitializer {
   header "ProtoWithInitializer.h"
   export *

--- a/test/ClangModules/objc_class_properties_ignore.swift
+++ b/test/ClangModules/objc_class_properties_ignore.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse -parse-as-library -verify -I %S/Inputs/custom-modules %s
+
+// REQUIRES: objc_interop
+
+import ObjCClassPropertiesIgnored
+
+func testA() {
+  A.setFloatProperty(3.1415)
+  _ = A.floatProperty()
+  A.floatProperty = 3.14159 // expected-error{{cannot assign to immutable expression of type '() -> Float'}}
+
+  _ = A.doubleProperty()
+}
+


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

This commit ignores Objective-C class properties in the Swift 2.3 Clang importer, maintaining the Swift 2.x behavior of importing them as getters and setters. Without this change, we end up importing them as _instance_ properties, which breaks horribly.
#### Resolved bug number: ([rdar://problem/27258032](rdar://problem/27258032))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Objective-C introduced the notion of class properties post-Swift
2.2. To minimize disruption in Swift 2.2 source code as SDKs adopt
class properties in lieu of getters/setters, teach the Clang importer
to effectively ignore class properties. Fixes rdar://problem/25822005.
