### PR TITLE
[Sema] Remove 'deployment target ensures guard will always be true'

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2938,10 +2938,6 @@ ERROR(availability_inout_accessor_only_version_newer, none,
 ERROR(availability_query_required_for_platform, none,
       "condition required for target platform '%0'", (StringRef))
 
-WARNING(availability_query_useless_min_deployment, none,
-        "unnecessary check for '%0'; minimum deployment target ensures guard "
-        "will always be true", (StringRef))
-
 WARNING(availability_query_useless_enclosing_scope, none,
         "unnecessary check for '%0'; enclosing scope ensures guard "
         "will always be true", (StringRef))

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -1316,19 +1316,15 @@ private:
       // spec is useless. If so, report this.
       if (CurrentInfo.isContainedIn(NewConstraint)) {
         DiagnosticEngine &Diags = TC.Diags;
-        if (CurrentTRC->getReason() == TypeRefinementContext::Reason::Root) {
-          // Diagnose for checks that are useless because the minimum deployment
-          // target ensures they will never be false. We suppress this warning
-          // when compiling for playgrounds because the developer cannot
-          // cannot explicitly set the minimum deployment target to silence
-          // the alarm. We also suppress in script mode (where setting the
-          // minimum deployment target requires a target triple).
-          if (!TC.getLangOpts().Playground && !TC.getInImmediateMode()) {
-            Diags.diagnose(Query->getLoc(),
-                           diag::availability_query_useless_min_deployment,
-                           platformString(targetPlatform(TC.getLangOpts())));
-          }
-        } else {
+        // Some availability checks will always pass because the minimum
+        // deployment target gurantees they will never be false. We don't
+        // diagnose these checks as useless because the source file may
+        // be shared with other projects/targets having older deployment
+        // targets. We don't currently have a mechanism for the user to
+        // suppress these warnings (for example, by indicating when the
+        // required compatibility version is different than the deployment
+        // target).
+        if (CurrentTRC->getReason() != TypeRefinementContext::Reason::Root) {
           Diags.diagnose(Query->getLoc(),
                          diag::availability_query_useless_enclosing_scope,
                          platformString(targetPlatform(TC.getLangOpts())));

--- a/test/SILGen/availability_query.swift
+++ b/test/SILGen/availability_query.swift
@@ -42,7 +42,7 @@ if #available(macOS 10.52, *) {
 // CHECK: [[PATCH:%.*]] = integer_literal $Builtin.Word, 0
 // CHECK: [[QUERY_FUNC:%.*]] = function_ref @_TFs26_stdlib_isOSVersionAtLeastFTBwBwBw_Bi1_ : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
 // CHECK: [[QUERY_RESULT:%.*]] = apply [[QUERY_FUNC]]([[MAJOR]], [[MINOR]], [[PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
-if #available(OSX 10, *) { // expected-warning {{minimum deployment target ensures guard will always be true}}
+if #available(OSX 10, *) {
 }
 
 // CHECK: }
@@ -50,7 +50,7 @@ if #available(OSX 10, *) { // expected-warning {{minimum deployment target ensur
 func doThing() {}
 
 func testUnreachableVersionAvailable(condition: Bool) {
-  if #available(OSX 10.0, *) { // expected-warning {{minimum deployment target ensures guard will always be true}}
+  if #available(OSX 10.0, *) {
     doThing() // no-warning
     return
   } else {

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -1011,7 +1011,7 @@ func useUnavailableExtension() {
 func functionWithDefaultAvailabilityAndUselessCheck(_ p: Bool) {
 // Default availability reflects minimum deployment: 10.9 and up
 
-  if #available(OSX 10.9, *) { // expected-warning {{unnecessary check for 'OSX'; minimum deployment target ensures guard will always be true}}
+  if #available(OSX 10.9, *) { // no-warning
     let _ = globalFuncAvailableOn10_9()
   }
   
@@ -1023,7 +1023,7 @@ func functionWithDefaultAvailabilityAndUselessCheck(_ p: Bool) {
     }
   }
 
-  if #available(OSX 10.9, *) { // expected-note {{enclosing scope here}} expected-warning {{unnecessary check for 'OSX'; minimum deployment target ensures guard will always be true}}
+  if #available(OSX 10.9, *) { // expected-note {{enclosing scope here}}
   } else {
     // Make sure we generate a warning about an unnecessary check even if the else branch of if is dead.
     if #available(OSX 10.51, *) { // expected-warning {{unnecessary check for 'OSX'; enclosing scope ensures guard will always be true}}
@@ -1032,7 +1032,7 @@ func functionWithDefaultAvailabilityAndUselessCheck(_ p: Bool) {
 
   // This 'if' is strictly to limit the scope of the guard fallthrough
   if p {
-    guard #available(OSX 10.9, *) else { // expected-note {{enclosing scope here}} expected-warning {{unnecessary check for 'OSX'; minimum deployment target ensures guard will always be true}}
+    guard #available(OSX 10.9, *) else { // expected-note {{enclosing scope here}}
       // Make sure we generate a warning about an unnecessary check even if the else branch of guard is dead.
       if #available(OSX 10.51, *) { // expected-warning {{unnecessary check for 'OSX'; enclosing scope ensures guard will always be true}}
       }

--- a/test/Sema/deprecation_osx.swift
+++ b/test/Sema/deprecation_osx.swift
@@ -156,7 +156,7 @@ func functionWithDeprecatedMethodInDeadElseBranch() {
     let _ = ClassDeprecatedIn10_9()  // no-warning
   }
 
-  if #available(OSX 10.9, *) { // expected-warning {{unnecessary check for 'OSX'; minimum deployment target ensures guard will always be true}}
+  if #available(OSX 10.9, *) { // no-warning
   } else {
     // This branch is dead because our minimum deployment target is 10.51.
     let _ = ClassDeprecatedIn10_9()  // no-warning

--- a/test/attr/attr_availability_tvos.swift
+++ b/test/attr/attr_availability_tvos.swift
@@ -70,7 +70,7 @@ if #available(iOS 9.1, tvOS 9.2, *) {
 if #available(iOS 8.0, tvOS 9.2, *) {
 }
 
-if #available(iOS 9.2, tvOS 8.0, *) { // expected-warning {{unnecessary check for 'tvOS'; minimum deployment target ensures guard will always be true}}
+if #available(iOS 9.2, tvOS 8.0, *) { // no-warning
 }
 
 

--- a/test/attr/attr_availability_watchos.swift
+++ b/test/attr/attr_availability_watchos.swift
@@ -70,7 +70,7 @@ if #available(iOS 9.1, watchOS 2.2, *) {
 if #available(iOS 8.0, watchOS 2.2, *) {
 }
 
-if #available(iOS 9.2, watchOS 1.0, *) { // expected-warning {{unnecessary check for 'watchOS'; minimum deployment target ensures guard will always be true}}
+if #available(iOS 9.2, watchOS 1.0, *) { // no-warning
 }
 
 


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?
- **Explanation:** This removes the warning when an availability check is useless because of the minimum deployment target. We don't have a good way to suppress this warning yet, so it is better to remove the warning.
- **Scope:** Affects Swift users who share source files between targets or projects with different minimum deployment targets.
- **Issue:** rdar://problem/22337402 (There is no SR corresponding to this issue)
- **Reviewed by:** @jrose-apple  
- **Risk:** Very low. This only removes a warning
- **Testing:** Modified compiler regression tests.
  ---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Remove the diagnostic that warns when an availability check is unnecessary
because the minimum deployment target ensures it will always be true. This
diagnostic is valuable (it tells users that they have dead fallback code) but
can also be super annoying when a source file is shared between projects with
different deployment targets. There is not currently a good mechanism to
suppress these warnings (for example, by expressing a "compatibility version" in
the source or as a build setting) and so it is better to turn the diagnostic
off.

rdar://problem/22337402
(cherry picked from commit c553de44787d41362495fcd045b718690b8ae7ad)
