### PR TITLE
[stdlib] Remove _StringCore from UTF8View.Index

### DIFF
--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -407,7 +407,7 @@ extension String.UTF16View.Index {
       "Invalid String.UTF8Index for this UTF-16 view")
 
     // Detect positions that have no corresponding index.
-    if !utf8Index._isOnUnicodeScalarBoundary {
+    if !utf8Index._isOnUnicodeScalarBoundary(in: core) {
       return nil
     }
     _offset = utf8Index._coreIndex

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -227,6 +227,25 @@ extension String {
           && _coreIndex == core.endIndex
       }
 
+      /// The number of UTF-8 code units remaining in the buffer before the
+      /// next unicode scalar value is reached. This simulates calling
+      /// `index(after: i)` until `i._coreIndex` is incremented, but doesn't
+      /// need a `_core` reference.
+      internal var _utf8ContinuationBytesUntilNextUnicodeScalar: Int {
+        var buffer = _buffer
+        var count = 0
+        
+        while true {
+          let currentUnit = UTF8.CodeUnit(truncatingBitPattern: buffer)
+          if currentUnit & 0b1100_0000 != 0b1000_0000 {
+            break
+          }
+          count += 1
+          buffer = Index._nextBuffer(after: buffer)
+        }
+        return count
+      }
+
       /// The value of the buffer when it is empty
       internal static var _emptyBuffer: Buffer {
         return ~0
@@ -236,7 +255,7 @@ extension String {
       internal static var _bufferHiByte: Buffer {
         return 0xFF << numericCast((sizeof(Buffer.self) &- 1) &* 8)
       }
-
+      
       /// Consume a byte of the given buffer: shift out the low byte
       /// and put FF in the high byte
       internal static func _nextBuffer(after thisBuffer: Buffer) -> Buffer {
@@ -277,12 +296,21 @@ extension String {
       // FIXME: swift-3-indexing-model: range check i?
       let currentUnit = UTF8.CodeUnit(truncatingBitPattern: i._buffer)
       let hiNibble = currentUnit >> 4
-      // Map the high nibble of the current code unit into the
-      // amount by which to increment the UTF-16 index.  Only when
-      // the high nibble is 1111 do we have a surrogate pair.
+
+      // Amounts to increment the UTF-16 index based on the high nibble of a
+      // UTF-8 code unit. If the high nibble is:
+      //
+      // - 0b0000-0b0111: U+0000...U+007F: increment the UTF-16 pointer by 1
+      // - 0b1000-0b1011: UTF-8 continuation byte, do not increment 
+      //                  the UTF-16 pointer
+      // - 0b1100-0b1110: U+0080...U+FFFF: increment the UTF-16 pointer by 1
+      // - 0b1111:        U+10000...U+1FFFFF: increment the UTF-16 pointer by 2
       let u16Increments = Int(bitPattern:
       // 1111 1110 1101 1100 1011 1010 1001 1000 0111 0110 0101 0100 0011 0010 0001 0000
          0b10___01___01___01___00___00___00___00___01___01___01___01___01___01___01___01)
+      
+      // Map the high nibble of the current code unit into the
+      // amount by which to increment the UTF-16 index.
       let increment = (u16Increments >> numericCast(hiNibble << 1)) & 0x3
       let nextCoreIndex = i._coreIndex &+ increment
       let nextBuffer = Index._nextBuffer(after: i._buffer)
@@ -463,9 +491,11 @@ public func < (
   lhs: String.UTF8View.Index,
   rhs: String.UTF8View.Index
 ) -> Bool {
-  // FIXME: swift-3-indexing-model: tests.
-  // FIXME: swift-3-indexing-model: this implementation is wrong, it is just a
-  // temporary HACK.
+  if lhs._coreIndex == rhs._coreIndex && lhs._buffer != rhs._buffer {
+    // The index with more continuation bytes remaining before the next
+    return lhs._utf8ContinuationBytesUntilNextUnicodeScalar >
+      rhs._utf8ContinuationBytesUntilNextUnicodeScalar
+  }
   return lhs._coreIndex < rhs._coreIndex
 }
 

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -471,7 +471,7 @@ extension String.UnicodeScalarIndex {
       "Invalid String.UTF8Index for this UnicodeScalar view")
 
     // Detect positions that have no corresponding index.
-    if !utf8Index._isOnUnicodeScalarBoundary {
+    if !utf8Index._isOnUnicodeScalarBoundary(in: core) {
       return nil
     }
     self.init(_position: utf8Index._coreIndex)

--- a/validation-test/stdlib/StringViews.swift
+++ b/validation-test/stdlib/StringViews.swift
@@ -687,6 +687,14 @@ tests.test("UTF8 indexes") {
   }
 }
 
+tests.test("index/Comparable")
+  .forEach(in: [summer, winter]) { str in
+  checkComparable(str.characters.indices, oracle: <=>)
+  checkComparable(str.unicodeScalars.indices, oracle: <=>)
+  checkComparable(str.utf16.indices, oracle: <=>)
+  checkComparable(str.utf8.indices, oracle: <=>)
+}
+
 tests.test("UTF16->String") {
   let s = summer + winter + winter + summer
   let v = s.utf16


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

This removes the `_core` property from `UTF8View.Index` instances. I don't think this will reduce as many unnecessary copies as the same change on `UnicodeScalarView.Index` since `UT8View` isn't mutable, but simplifying the index should be a net plus. This also fixes the `Comparable` conformance of the index and adds a test that string view indices are comparable in ascending order. (This isn't currently the case for the `utf8` view.)
#### Resolved bug number: n/a

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
