### PR TITLE
[id as Any] Import with the proper Any type

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -90,11 +90,7 @@ bool TypeBase::hasReferenceSemantics() {
 }
 
 bool TypeBase::isAny() {
-  if (auto comp = getAs<ProtocolCompositionType>())
-    if (comp->getProtocols().empty())
-      return true;
-  
-  return false;
+  return isEqual(getASTContext().getAnyDecl()->getDeclaredType());
 }
 
 bool TypeBase::isAnyClassReferenceType() {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1532,7 +1532,9 @@ namespace {
         // should be removed from MappedTypes.def, and this conditional should
         // become unnecessary.
         if (Name.str() == "id" && Impl.SwiftContext.LangOpts.EnableIdAsAny) {
-          return nullptr;
+          Impl.SpecialTypedefNames[Decl->getCanonicalDecl()] =
+              MappedTypeNameKind::DoNothing;
+          return Impl.SwiftContext.getAnyDecl();
         }
       
         bool IsError;

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -928,13 +928,12 @@ namespace {
 
       // id maps to Any in bridgeable contexts, AnyObject otherwise.
       if (type->isObjCIdType()) {
-        if (Impl.SwiftContext.LangOpts.EnableIdAsAny) {
-          return { proto->getDeclaredType(),
-                 ImportHint(ImportHint::ObjCBridged,
-                         ProtocolCompositionType::get(Impl.SwiftContext, {})) };
-        } else {
-          return { proto->getDeclaredType(), ImportHint::ObjCPointer };
-        }
+        if (Impl.SwiftContext.LangOpts.EnableIdAsAny)
+          return {
+              proto->getDeclaredType(),
+              ImportHint(ImportHint::ObjCBridged,
+                         Impl.SwiftContext.getAnyDecl()->getDeclaredType())};
+        return {proto->getDeclaredType(), ImportHint::ObjCPointer};
       }
 
       // Class maps to AnyObject.Type.

--- a/test/ClangModules/objc_id_as_any.swift
+++ b/test/ClangModules/objc_id_as_any.swift
@@ -15,6 +15,12 @@ struct ArbitraryThing {}
 idLover.takesId(ArbitraryThing())
 
 var x: AnyObject = NSObject()
-idLover.takesArray(ofId: &x)
+idLover.takesArray(ofId: &x) // expected-error{{cannot pass immutable value as inout argument: implicit conversion from 'AnyObject' to 'Any' requires a temporary}}
+var xAsAny = x as Any
+idLover.takesArray(ofId: &xAsAny)
+
 var y: Any = NSObject()
-idLover.takesArray(ofId: &y) // expected-error{{}}
+idLover.takesArray(ofId: &y)
+
+idLover.takesId(x)
+idLover.takesId(y)


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

```
Changes how we import from just protocol<> to the proper Any
type. This means that uses of AnyObject will either implicitly cast up
to Any, or must be explicitly cast through a temporary if used as an
lvalue. id as Any is still predicated on the id-as-any flags.
```
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Changes how we import from just protocol<> to the proper Any
type. This means that uses of AnyObject will either implicitly cast up
to Any, or must be explicitly cast through a temporary if used as an
lvalue. id as Any is still predicated on the id-as-any flags.
