### PR TITLE
Use builtins instead of shims in FloatingPointTypes.

### DIFF
--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -3263,7 +3263,7 @@ public:
       assert(F->isAvailableExternally() &&
              "external declaration of internal SILFunction not allowed");
       assert(!hasSharedVisibility(F->getLinkage()) &&
-             "external declarations of SILFunctions with shared visibility is not "
+             "external declaration of SILFunction with shared visibility is not "
              "allowed");
       // If F is an external declaration, there is nothing further to do,
       // return.

--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -84,29 +84,35 @@ __swift_uint32_t
 _swift_stdlib_cxx11_mt19937_uniform(__swift_uint32_t upper_bound);
   
 // Math library functions
+SWIFT_RUNTIME_STDLIB_INLINE
 static inline float _swift_stdlib_remainderf(float x, float y) {
   return __builtin_remainderf(x, y);
 }
-  
+ 
+SWIFT_RUNTIME_STDLIB_INLINE
 static inline float _swift_stdlib_sqrtf(float x) {
   return __builtin_sqrtf(x);
 }
-  
+
+SWIFT_RUNTIME_STDLIB_INLINE
 static inline double _swift_stdlib_remainder(double x, double y) {
   return __builtin_remainder(x, y);
 }
-  
+
+SWIFT_RUNTIME_STDLIB_INLINE
 static inline double _swift_stdlib_sqrt(double x) {
   return __builtin_sqrt(x);
 }
   
 // TODO: Remove horrible workaround when importer does Float80 <-> long double.
 #if (defined __i386__ || defined __x86_64__) && !defined _MSC_VER
+SWIFT_RUNTIME_STDLIB_INLINE
 static inline void _swift_stdlib_remainderl(void *x, const void *y) {
   long double *ptr = (long double *)x;
   *ptr = __builtin_remainderl(*ptr, *(const long double *)y);
 }
 
+SWIFT_RUNTIME_STDLIB_INLINE
 static inline void _swift_stdlib_sqrtl(void *x) {
   long double *ptr = (long double *)x;
   *ptr = __builtin_sqrtl(*ptr);

--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -84,14 +84,29 @@ __swift_uint32_t
 _swift_stdlib_cxx11_mt19937_uniform(__swift_uint32_t upper_bound);
   
 // Math library functions
-SWIFT_RUNTIME_STDLIB_INTERFACE float _swift_stdlib_remainderf(float, float);
-static inline float _swift_stdlib_sqrtf(float x) { return __builtin_sqrtf(x); }
-SWIFT_RUNTIME_STDLIB_INTERFACE double _swift_stdlib_remainder(double, double);
-static inline double _swift_stdlib_sqrt(double x) { return __builtin_sqrt(x); }
+static inline float _swift_stdlib_remainderf(float x, float y) {
+  return __builtin_remainderf(x, y);
+}
+  
+static inline float _swift_stdlib_sqrtf(float x) {
+  return __builtin_sqrtf(x);
+}
+  
+static inline double _swift_stdlib_remainder(double x, double y) {
+  return __builtin_remainder(x, y);
+}
+  
+static inline double _swift_stdlib_sqrt(double x) {
+  return __builtin_sqrt(x);
+}
+  
 // TODO: Remove horrible workaround when importer does Float80 <-> long double.
 #if (defined __i386__ || defined __x86_64__) && !defined _MSC_VER
-SWIFT_RUNTIME_STDLIB_INTERFACE
-void _swift_stdlib_remainderl(void *_self, const void *_other);
+static inline void _swift_stdlib_remainderl(void *x, const void *y) {
+  long double *ptr = (long double *)x;
+  *ptr = __builtin_remainderl(*ptr, *(const long double *)y);
+}
+
 static inline void _swift_stdlib_sqrtl(void *x) {
   long double *ptr = (long double *)x;
   *ptr = __builtin_sqrtl(*ptr);
@@ -103,4 +118,3 @@ static inline void _swift_stdlib_sqrtl(void *x) {
 #endif
 
 #endif // SWIFT_STDLIB_SHIMS_LIBCSHIMS_H
-

--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -85,23 +85,11 @@ _swift_stdlib_cxx11_mt19937_uniform(__swift_uint32_t upper_bound);
   
 // Math library functions
 SWIFT_RUNTIME_STDLIB_INTERFACE float _swift_stdlib_remainderf(float, float);
-SWIFT_RUNTIME_STDLIB_INTERFACE float _swift_stdlib_squareRootf(float);
-SWIFT_RUNTIME_STDLIB_INTERFACE
-float _swift_stdlib_addProductf(float, float, float);
-  
 SWIFT_RUNTIME_STDLIB_INTERFACE double _swift_stdlib_remainder(double, double);
-SWIFT_RUNTIME_STDLIB_INTERFACE double _swift_stdlib_squareRoot(double);
-SWIFT_RUNTIME_STDLIB_INTERFACE
-double _swift_stdlib_addProduct(double, double, double);
-  
 // TODO: Remove horrible workaround when importer does Float80 <-> long double.
 #if (defined __i386__ || defined __x86_64__) && !defined _MSC_VER
 SWIFT_RUNTIME_STDLIB_INTERFACE
 void _swift_stdlib_remainderl(void *_self, const void *_other);
-SWIFT_RUNTIME_STDLIB_INTERFACE
-void _swift_stdlib_squareRootl(void *_self);
-SWIFT_RUNTIME_STDLIB_INTERFACE
-void _swift_stdlib_addProductl(void *_self, const void *_lhs, const void *_rhs);
 #endif
 
 #ifdef __cplusplus

--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -83,40 +83,63 @@ SWIFT_RUNTIME_STDLIB_INTERFACE
 __swift_uint32_t
 _swift_stdlib_cxx11_mt19937_uniform(__swift_uint32_t upper_bound);
   
-// Math library functions
-SWIFT_RUNTIME_STDLIB_INTERFACE
+#if defined __APPLE__
 static inline float _swift_stdlib_remainderf(float x, float y) {
   return __builtin_remainderf(x, y);
 }
- 
-SWIFT_RUNTIME_STDLIB_INTERFACE
+
 static inline float _swift_stdlib_sqrtf(float x) {
   return __builtin_sqrtf(x);
 }
 
-SWIFT_RUNTIME_STDLIB_INTERFACE
 static inline double _swift_stdlib_remainder(double x, double y) {
   return __builtin_remainder(x, y);
 }
 
-SWIFT_RUNTIME_STDLIB_INTERFACE
 static inline double _swift_stdlib_sqrt(double x) {
   return __builtin_sqrt(x);
 }
-  
-// TODO: Remove horrible workaround when importer does Float80 <-> long double.
-#if (defined __i386__ || defined __x86_64__) && !defined _MSC_VER
-SWIFT_RUNTIME_STDLIB_INTERFACE
+
+# if defined __i386__ || defined __x86_64__
+// We use void* for these because the importer doesn't know how to map Float80
+// to long double.
 static inline void _swift_stdlib_remainderl(void *x, const void *y) {
   long double *ptr = (long double *)x;
   *ptr = __builtin_remainderl(*ptr, *(const long double *)y);
 }
 
-SWIFT_RUNTIME_STDLIB_INTERFACE
 static inline void _swift_stdlib_sqrtl(void *x) {
   long double *ptr = (long double *)x;
   *ptr = __builtin_sqrtl(*ptr);
 }
+# endif // defined __i386__ || defined __x86_64__
+#else
+// We want the math shims to be static inline for performance reasons, but
+// that causes test failures on Linux at present, and depends on a compiler
+// feature (__builtin_xxxx) that may not be available on other platforms.
+// They are therefore declared as SWIFT_RUNTIME_STDLIB_INTERFACE functions
+// on non-Apple platforms for now.
+SWIFT_RUNTIME_STDLIB_INTERFACE
+float _swift_stdlib_remainderf(float x, float y);
+ 
+SWIFT_RUNTIME_STDLIB_INTERFACE
+float _swift_stdlib_sqrtf(float x);
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+double _swift_stdlib_remainder(double x, double y);
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+double _swift_stdlib_sqrt(double x);
+
+# if (defined __i386__ || defined __x86_64__) && !defined _MSC_VER
+// We use void* for these because the importer doesn't know how to map Float80
+// to long double.
+SWIFT_RUNTIME_STDLIB_INTERFACE
+void _swift_stdlib_remainderl(void *x, const void *y);
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+void _swift_stdlib_sqrtl(void *x);
+# endif // defined __i386__ || defined __x86_64__
 #endif
 
 #ifdef __cplusplus

--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -84,35 +84,35 @@ __swift_uint32_t
 _swift_stdlib_cxx11_mt19937_uniform(__swift_uint32_t upper_bound);
   
 // Math library functions
-SWIFT_RUNTIME_STDLIB_INLINE
+SWIFT_RUNTIME_STDLIB_INTERFACE
 static inline float _swift_stdlib_remainderf(float x, float y) {
   return __builtin_remainderf(x, y);
 }
  
-SWIFT_RUNTIME_STDLIB_INLINE
+SWIFT_RUNTIME_STDLIB_INTERFACE
 static inline float _swift_stdlib_sqrtf(float x) {
   return __builtin_sqrtf(x);
 }
 
-SWIFT_RUNTIME_STDLIB_INLINE
+SWIFT_RUNTIME_STDLIB_INTERFACE
 static inline double _swift_stdlib_remainder(double x, double y) {
   return __builtin_remainder(x, y);
 }
 
-SWIFT_RUNTIME_STDLIB_INLINE
+SWIFT_RUNTIME_STDLIB_INTERFACE
 static inline double _swift_stdlib_sqrt(double x) {
   return __builtin_sqrt(x);
 }
   
 // TODO: Remove horrible workaround when importer does Float80 <-> long double.
 #if (defined __i386__ || defined __x86_64__) && !defined _MSC_VER
-SWIFT_RUNTIME_STDLIB_INLINE
+SWIFT_RUNTIME_STDLIB_INTERFACE
 static inline void _swift_stdlib_remainderl(void *x, const void *y) {
   long double *ptr = (long double *)x;
   *ptr = __builtin_remainderl(*ptr, *(const long double *)y);
 }
 
-SWIFT_RUNTIME_STDLIB_INLINE
+SWIFT_RUNTIME_STDLIB_INTERFACE
 static inline void _swift_stdlib_sqrtl(void *x) {
   long double *ptr = (long double *)x;
   *ptr = __builtin_sqrtl(*ptr);

--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -85,11 +85,17 @@ _swift_stdlib_cxx11_mt19937_uniform(__swift_uint32_t upper_bound);
   
 // Math library functions
 SWIFT_RUNTIME_STDLIB_INTERFACE float _swift_stdlib_remainderf(float, float);
+static inline float _swift_stdlib_sqrtf(float x) { return __builtin_sqrtf(x); }
 SWIFT_RUNTIME_STDLIB_INTERFACE double _swift_stdlib_remainder(double, double);
+static inline double _swift_stdlib_sqrt(double x) { return __builtin_sqrt(x); }
 // TODO: Remove horrible workaround when importer does Float80 <-> long double.
 #if (defined __i386__ || defined __x86_64__) && !defined _MSC_VER
 SWIFT_RUNTIME_STDLIB_INTERFACE
 void _swift_stdlib_remainderl(void *_self, const void *_other);
+static inline void _swift_stdlib_sqrtl(void *x) {
+  long double *ptr = (long double *)x;
+  *ptr = __builtin_sqrtl(*ptr);
+}
 #endif
 
 #ifdef __cplusplus

--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -88,23 +88,11 @@ SWIFT_RUNTIME_STDLIB_INTERFACE float _swift_stdlib_remainderf(float, float);
 SWIFT_RUNTIME_STDLIB_INTERFACE float _swift_stdlib_squareRootf(float);
 SWIFT_RUNTIME_STDLIB_INTERFACE
 float _swift_stdlib_addProductf(float, float, float);
-SWIFT_RUNTIME_STDLIB_INTERFACE float _swift_stdlib_roundf(float);
-SWIFT_RUNTIME_STDLIB_INTERFACE float _swift_stdlib_roundevenf(float);
-SWIFT_RUNTIME_STDLIB_INTERFACE float _swift_stdlib_truncf(float);
-SWIFT_RUNTIME_STDLIB_INTERFACE float _swift_stdlib_roundawayf(float);
-SWIFT_RUNTIME_STDLIB_INTERFACE float _swift_stdlib_ceilf(float);
-SWIFT_RUNTIME_STDLIB_INTERFACE float _swift_stdlib_floorf(float);
   
 SWIFT_RUNTIME_STDLIB_INTERFACE double _swift_stdlib_remainder(double, double);
 SWIFT_RUNTIME_STDLIB_INTERFACE double _swift_stdlib_squareRoot(double);
 SWIFT_RUNTIME_STDLIB_INTERFACE
 double _swift_stdlib_addProduct(double, double, double);
-SWIFT_RUNTIME_STDLIB_INTERFACE double _swift_stdlib_round(double);
-SWIFT_RUNTIME_STDLIB_INTERFACE double _swift_stdlib_roundeven(double);
-SWIFT_RUNTIME_STDLIB_INTERFACE double _swift_stdlib_trunc(double);
-SWIFT_RUNTIME_STDLIB_INTERFACE double _swift_stdlib_roundaway(double);
-SWIFT_RUNTIME_STDLIB_INTERFACE double _swift_stdlib_ceil(double);
-SWIFT_RUNTIME_STDLIB_INTERFACE double _swift_stdlib_floor(double);
   
 // TODO: Remove horrible workaround when importer does Float80 <-> long double.
 #if (defined __i386__ || defined __x86_64__) && !defined _MSC_VER

--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -102,12 +102,6 @@ SWIFT_RUNTIME_STDLIB_INTERFACE
 void _swift_stdlib_squareRootl(void *_self);
 SWIFT_RUNTIME_STDLIB_INTERFACE
 void _swift_stdlib_addProductl(void *_self, const void *_lhs, const void *_rhs);
-SWIFT_RUNTIME_STDLIB_INTERFACE void _swift_stdlib_roundl(void *_self);
-SWIFT_RUNTIME_STDLIB_INTERFACE void _swift_stdlib_roundevenl(void *_self);
-SWIFT_RUNTIME_STDLIB_INTERFACE void _swift_stdlib_truncl(void *_self);
-SWIFT_RUNTIME_STDLIB_INTERFACE void _swift_stdlib_roundawayl(void *_self);
-SWIFT_RUNTIME_STDLIB_INTERFACE void _swift_stdlib_ceill(void *_self);
-SWIFT_RUNTIME_STDLIB_INTERFACE void _swift_stdlib_floorl(void *_self);
 #endif
 
 #ifdef __cplusplus

--- a/stdlib/public/SwiftShims/Visibility.h
+++ b/stdlib/public/SwiftShims/Visibility.h
@@ -78,4 +78,14 @@
 /// resilience we may be able to make this hidden.
 #define SWIFT_RUNTIME_STDLIB_INTERFACE SWIFT_RUNTIME_EXPORT
 
+/// Attribute for stdlib stdlib inline interfaces.
+///
+/// Since these are static inline, there's no need for them to be exported, and
+/// in fact they shouldn't be.
+#if __MACH__ || __ELF__
+# define SWIFT_RUNTIME_STDLIB_INLINE __attribute__((__visibility__("hidden")))
+#else
+# define SWIFT_RUNTIME_STDLIB_INLINE /* nothing?? */
+#endif
+
 #endif

--- a/stdlib/public/SwiftShims/Visibility.h
+++ b/stdlib/public/SwiftShims/Visibility.h
@@ -78,14 +78,4 @@
 /// resilience we may be able to make this hidden.
 #define SWIFT_RUNTIME_STDLIB_INTERFACE SWIFT_RUNTIME_EXPORT
 
-/// Attribute for stdlib stdlib inline interfaces.
-///
-/// Since these are static inline, there's no need for them to be exported, and
-/// in fact they shouldn't be.
-#if __MACH__ || __ELF__
-# define SWIFT_RUNTIME_STDLIB_INLINE __attribute__((__visibility__("hidden")))
-#else
-# define SWIFT_RUNTIME_STDLIB_INLINE /* nothing?? */
-#endif
-
 #endif

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -528,17 +528,27 @@ extension ${Self}: BinaryFloatingPoint {
 %else:
     switch rule {
     case .toNearestOrAwayFromZero:
-      self = _swift_stdlib_round${cFuncSuffix(bits)}(self)
+      self._value = Builtin.int_round_FPIEEE${bits}(self._value)
     case .toNearestOrEven:
-      self = _swift_stdlib_roundeven${cFuncSuffix(bits)}(self)
+      //  TODO: switch to roundeven( ) or corresponding builtin when
+      //  available; rint assumes default floating-point environment.
+      //  This is pretty OK at present, since there's no Swifty way
+      //  to fuss with the environment, but we should fix it in the
+      //  long term.
+      self._value = Builtin.int_rint_FPIEEE${bits}(self._value)
     case .towardZero:
-      self = _swift_stdlib_trunc${cFuncSuffix(bits)}(self)
+      self._value = Builtin.int_trunc_FPIEEE${bits}(self._value)
     case .awayFromZero:
-      self = _swift_stdlib_roundaway${cFuncSuffix(bits)}(self)
+      if self < 0 {
+        self._value = Builtin.int_floor_FPIEEE${bits}(self._value)
+      }
+      else {
+        self._value = Builtin.int_ceil_FPIEEE${bits}(self._value)
+      }
     case .up:
-      self = _swift_stdlib_ceil${cFuncSuffix(bits)}(self)
+      self._value = Builtin.int_ceil_FPIEEE${bits}(self._value)
     case .down:
-      self = _swift_stdlib_floor${cFuncSuffix(bits)}(self)
+      self._value = Builtin.int_floor_FPIEEE${bits}(self._value)
     }
 %end
   }

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -510,47 +510,30 @@ extension ${Self}: BinaryFloatingPoint {
 
   @_transparent
   public mutating func round(_ rule: FloatingPointRoundingRule) {
-%if bits == 80:
     switch rule {
     case .toNearestOrAwayFromZero:
-      _swift_stdlib_roundl(&self)
-    case .toNearestOrEven:
-      _swift_stdlib_roundevenl(&self)
-    case .towardZero:
-      _swift_stdlib_truncl(&self)
-    case .awayFromZero:
-      _swift_stdlib_roundawayl(&self)
-    case .up:
-      _swift_stdlib_ceill(&self)
-    case .down:
-      _swift_stdlib_floorl(&self)
-    }
-%else:
-    switch rule {
-    case .toNearestOrAwayFromZero:
-      self._value = Builtin.int_round_FPIEEE${bits}(self._value)
+      _value = Builtin.int_round_FPIEEE${bits}(_value)
     case .toNearestOrEven:
       //  TODO: switch to roundeven( ) or corresponding builtin when
       //  available; rint assumes default floating-point environment.
       //  This is pretty OK at present, since there's no Swifty way
       //  to fuss with the environment, but we should fix it in the
       //  long term.
-      self._value = Builtin.int_rint_FPIEEE${bits}(self._value)
+      _value = Builtin.int_rint_FPIEEE${bits}(_value)
     case .towardZero:
-      self._value = Builtin.int_trunc_FPIEEE${bits}(self._value)
+      _value = Builtin.int_trunc_FPIEEE${bits}(_value)
     case .awayFromZero:
-      if self < 0 {
-        self._value = Builtin.int_floor_FPIEEE${bits}(self._value)
+      if sign == .minus {
+        _value = Builtin.int_floor_FPIEEE${bits}(_value)
       }
       else {
-        self._value = Builtin.int_ceil_FPIEEE${bits}(self._value)
+        _value = Builtin.int_ceil_FPIEEE${bits}(_value)
       }
     case .up:
-      self._value = Builtin.int_ceil_FPIEEE${bits}(self._value)
+      _value = Builtin.int_ceil_FPIEEE${bits}(_value)
     case .down:
-      self._value = Builtin.int_floor_FPIEEE${bits}(self._value)
+      _value = Builtin.int_floor_FPIEEE${bits}(_value)
     }
-%end
   }
 
   @_transparent

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -578,7 +578,12 @@ extension ${Self}: BinaryFloatingPoint {
 
   @_transparent
   public mutating func formSquareRoot( ) {
-    _value = Builtin.int_sqrt_FPIEEE${bits}(_value)
+%if bits == 80:
+    _swift_stdlib_sqrtl(&self)
+%else:
+    self = _swift_stdlib_sqrt${cFuncSuffix(bits)}(self)
+%end
+
   }
 
   @_transparent

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -578,22 +578,12 @@ extension ${Self}: BinaryFloatingPoint {
 
   @_transparent
   public mutating func formSquareRoot( ) {
-%if bits == 80:
-    _swift_stdlib_squareRootl(&self)
-%else:
-    self = _swift_stdlib_squareRoot${cFuncSuffix(bits)}(self)
-%end
+    _value = Builtin.int_sqrt_FPIEEE${bits}(_value)
   }
 
   @_transparent
   public mutating func addProduct(_ lhs: ${Self}, _ rhs: ${Self}) {
-%if bits == 80:
-    var lhs = lhs
-    var rhs = rhs
-    _swift_stdlib_addProductl(&self, &lhs, &rhs)
-%else:
-    self = _swift_stdlib_addProduct${cFuncSuffix(bits)}(self, lhs, rhs)
-%end
+    _value = Builtin.int_fma_FPIEEE${bits}(lhs._value, rhs._value, _value)
   }
 
   @_transparent

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -124,18 +124,3 @@ swift::_swift_stdlib_cxx11_mt19937_uniform(__swift_uint32_t upper_bound) {
   std::uniform_int_distribution<__swift_uint32_t> RandomUniform(0, upper_bound);
   return RandomUniform(getGlobalMT19937());
 }
-
-float swift::_swift_stdlib_remainderf(float dividend, float divisor) {
-  return std::remainder(dividend, divisor);
-}
-
-double swift::_swift_stdlib_remainder(double dividend, double divisor) {
-  return std::remainder(dividend, divisor);
-}
-
-#if (defined __i386__ || defined __x86_64__) && !defined _MSC_VER
-void swift::_swift_stdlib_remainderl(void *_self, const void *_other) {
-  *(long double *)_self = std::remainder(*(long double *)_self,
-                                         *(const long double *)_other);
-}
-#endif // Have Float80

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -129,37 +129,13 @@ float swift::_swift_stdlib_remainderf(float dividend, float divisor) {
   return std::remainder(dividend, divisor);
 }
 
-float swift::_swift_stdlib_squareRootf(float x) { return std::sqrt(x); }
-
-float swift::_swift_stdlib_addProductf(float addend, float lhs, float rhs) {
-  return std::fma(lhs, rhs, addend);
-}
-
 double swift::_swift_stdlib_remainder(double dividend, double divisor) {
   return std::remainder(dividend, divisor);
-}
-
-double swift::_swift_stdlib_squareRoot(double x) { return std::sqrt(x); }
-
-double swift::_swift_stdlib_addProduct(double addend, double lhs, double rhs) {
-  return std::fma(lhs, rhs, addend);
 }
 
 #if (defined __i386__ || defined __x86_64__) && !defined _MSC_VER
 void swift::_swift_stdlib_remainderl(void *_self, const void *_other) {
   *(long double *)_self = std::remainder(*(long double *)_self,
                                          *(const long double *)_other);
-}
-
-void swift::_swift_stdlib_squareRootl(void *_self) {
-  *(long double *)_self = std::sqrt(*(long double *)_self);
-}
-
-void
-swift::_swift_stdlib_addProductl(void *_self,
-                                 const void *_lhs, const void *_rhs) {
-  *(long double *)_self = std::fma(*(const long double *)_lhs,
-                                   *(const long double *)_rhs,
-                                   *(long double *)_self);
 }
 #endif // Have Float80

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -133,7 +133,7 @@ float swift::_swift_stdlib_remainderf(float x, float y) {
   return std::remainder(x, y);
 }
 
-float _swift_stdlib_sqrtf(float x) {
+float swift::_swift_stdlib_sqrtf(float x) {
   return std::sqrt(x);
 }
 
@@ -141,19 +141,19 @@ double swift::_swift_stdlib_remainder(double x, double y) {
   return std::remainder(x, y);
 }
 
-double _swift_stdlib_sqrt(double x) {
+double swift::_swift_stdlib_sqrt(double x) {
   return std::sqrt(x);
 }
 
 # if (defined __i386__ || defined __x86_64__) && !defined _MSC_VER
 // We use void* for these because the importer doesn't know how to map Float80
 // to long double.
-void _swift_stdlib_remainderl(void *x, const void *y) {
+void swift::_swift_stdlib_remainderl(void *x, const void *y) {
   long double *ptr = (long double *)x;
   *ptr = std::remainder(*ptr, *(const long double *)y);
 }
 
-void _swift_stdlib_sqrtl(void *x) {
+void swift::_swift_stdlib_sqrtl(void *x) {
   long double *ptr = (long double *)x;
   *ptr = std::sqrt(*ptr);
 }

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -135,25 +135,6 @@ float swift::_swift_stdlib_addProductf(float addend, float lhs, float rhs) {
   return std::fma(lhs, rhs, addend);
 }
 
-float swift::_swift_stdlib_roundf(float x) { return std::round(x); }
-
-float swift::_swift_stdlib_roundevenf(float x) {
-  //  TODO: switch to roundevenf( ) when available in backing C libraries, or
-  //  open-code here to correctly handle non-default fenv.
-  return std::rint(x);
-}
-
-float swift::_swift_stdlib_truncf(float x) { return std::trunc(x); }
-
-float swift::_swift_stdlib_roundawayf(float x) {
-  //  No corresponding C function, but trivial to fake.
-  return x < 0 ? std::floor(x) : std::ceil(x);
-}
-
-float swift::_swift_stdlib_ceilf(float x) { return std::ceil(x); }
-
-float swift::_swift_stdlib_floorf(float x) { return std::floor(x); }
-
 double swift::_swift_stdlib_remainder(double dividend, double divisor) {
   return std::remainder(dividend, divisor);
 }
@@ -163,25 +144,6 @@ double swift::_swift_stdlib_squareRoot(double x) { return std::sqrt(x); }
 double swift::_swift_stdlib_addProduct(double addend, double lhs, double rhs) {
   return std::fma(lhs, rhs, addend);
 }
-
-double swift::_swift_stdlib_round(double x) { return std::round(x); }
-
-double swift::_swift_stdlib_roundeven(double x) {
-  //  TODO: switch to roundevenf( ) when available in backing C libraries, or
-  //  open-code here to correctly handle non-default fenv.
-  return std::rint(x);
-}
-
-double swift::_swift_stdlib_trunc(double x) { return std::trunc(x); }
-
-double swift::_swift_stdlib_roundaway(double x) {
-  //  No corresponding C function, but trivial to fake.
-  return x < 0 ? std::floor(x) : std::ceil(x);
-}
-
-double swift::_swift_stdlib_ceil(double x) { return std::ceil(x); }
-
-double swift::_swift_stdlib_floor(double x) { return std::floor(x); }
 
 #if (defined __i386__ || defined __x86_64__) && !defined _MSC_VER
 void swift::_swift_stdlib_remainderl(void *_self, const void *_other) {

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -12,7 +12,6 @@
 
 #include <random>
 #include <type_traits>
-#include <cmath>
 #if defined(_MSC_VER)
 #include <io.h>
 #else

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -162,29 +162,4 @@ swift::_swift_stdlib_addProductl(void *_self,
                                    *(const long double *)_rhs,
                                    *(long double *)_self);
 }
-
-void swift::_swift_stdlib_roundl(void *_self) {
-  *(long double *)_self = std::round(*(long double *)_self);
-}
-
-void swift::_swift_stdlib_roundevenl(void *_self) {
-  *(long double *)_self = std::rint(*(long double *)_self);
-}
-
-void swift::_swift_stdlib_truncl(void *_self) {
-  *(long double *)_self = std::trunc(*(long double *)_self);
-}
-
-void swift::_swift_stdlib_roundawayl(void *_self) {
-  long double *ptr = (long double *)_self;
-  *ptr =  *ptr < 0 ? std::floor(*ptr) : std::ceil(*ptr);
-}
-
-void swift::_swift_stdlib_ceill(void *_self) {
-  *(long double *)_self = std::ceil(*(long double *)_self);
-}
-
-void swift::_swift_stdlib_floorl(void *_self) {
-  *(long double *)_self = std::floor(*(long double *)_self);
-}
 #endif // Have Float80

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -12,6 +12,7 @@
 
 #include <random>
 #include <type_traits>
+#include <cmath>
 #if defined(_MSC_VER)
 #include <io.h>
 #else
@@ -123,3 +124,38 @@ swift::_swift_stdlib_cxx11_mt19937_uniform(__swift_uint32_t upper_bound) {
   std::uniform_int_distribution<__swift_uint32_t> RandomUniform(0, upper_bound);
   return RandomUniform(getGlobalMT19937());
 }
+
+#if !defined __APPLE__
+//  These functions are static inline on Apple platforms, and therefore
+//  function bodies are not needed here.  They should ideally be made static
+//  inlines on other platforms as well.
+float swift::_swift_stdlib_remainderf(float x, float y) {
+  return std::remainder(x, y);
+}
+
+float _swift_stdlib_sqrtf(float x) {
+  return std::sqrt(x);
+}
+
+double swift::_swift_stdlib_remainder(double x, double y) {
+  return std::remainder(x, y);
+}
+
+double _swift_stdlib_sqrt(double x) {
+  return std::sqrt(x);
+}
+
+# if (defined __i386__ || defined __x86_64__) && !defined _MSC_VER
+// We use void* for these because the importer doesn't know how to map Float80
+// to long double.
+void _swift_stdlib_remainderl(void *x, const void *y) {
+  long double *ptr = (long double *)x;
+  *ptr = std::remainder(*ptr, *(const long double *)y);
+}
+
+void _swift_stdlib_sqrtl(void *x) {
+  long double *ptr = (long double *)x;
+  *ptr = std::sqrt(*ptr);
+}
+# endif
+#endif // !defined __APPLE__


### PR DESCRIPTION
#### What's in this pull request?

Replace shims for `ceil`, `floor`, `round`, etc. with `Builtins` to eliminate a level of indirection.
#### Resolved bug number: ([SR-2045](https://bugs.swift.org/browse/SR-2045))

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
