### PR TITLE
[Sema] Add notes to all unresolved witness types.

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3413,16 +3413,14 @@ void ConformanceChecker::resolveTypeWitnesses() {
       return;
     }
 
-    // Complain that we couldn't find anything.
-    if (!missingTypeWitness)
-      missingTypeWitness = *unresolvedAssocTypes.begin();
-
-    diagnoseOrDefer(missingTypeWitness, true,
-      [missingTypeWitness](TypeChecker &tc,
-                           NormalProtocolConformance *conformance) {
-      tc.diagnose(missingTypeWitness, diag::no_witnesses_type,
-                  missingTypeWitness->getName());
-    });
+    for (auto missingTypeWitness : unresolvedAssocTypes) {
+      diagnoseOrDefer(missingTypeWitness, true,
+        [missingTypeWitness](TypeChecker &tc,
+                             NormalProtocolConformance *conformance) {
+          tc.diagnose(missingTypeWitness, diag::no_witnesses_type,
+                      missingTypeWitness->getName());
+        });
+    }
 
     return;
   }

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -899,3 +899,11 @@ class BadClass1 : BadProto1 {
   func foo() { }
   override var prop: Int { return 5 } // expected-error{{property does not override any property from its superclass}}
 }
+
+protocol BadProto5 {
+  associatedtype T1 // expected-note{{protocol requires nested type 'T1'}}
+  associatedtype T2 // expected-note{{protocol requires nested type 'T2'}}
+  associatedtype T3 // expected-note{{protocol requires nested type 'T3'}}
+}
+
+class BadClass5 : BadProto5 {} // expected-error{{type 'BadClass5' does not conform to protocol 'BadProto5'}}


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->

```
[Sema] Add note to all unresolved witness types instead of just the first one.

When issuing the error of "not conforming to a protocol P", we used to only note the first
unresolved witness type. This is inconsistent with the situation when the conformance
fails due to unimplemented functions, which we note all of the unimplemented functions.
This patch fixed this by noting all unresolved witness types.
```

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…irst one.

When issuing the error of "not conforming to a protocol P", we used to only note the first
unresolved witness type. This is inconsistent with the situation when the conformance
fails due to unimplemented functions, which we note all of the unimplemented functions.
This patch fixed this by noting all unresolved witness types.
