### PR TITLE
Add 💥 (😢 → 63, 😀 → 5107) in swift::ArchetypeBuilder::mapTypeIntoContext(…)

### DIFF
--- a/validation-test/compiler_crashers/28361-swift-archetypebuilder-maptypeintocontext.swift
+++ b/validation-test/compiler_crashers/28361-swift-archetypebuilder-maptypeintocontext.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+struct B<c
+class a{let f={associatedtype e
+<T
+enum S:B<T>


### PR DESCRIPTION
Add test case for crash triggered in `swift::ArchetypeBuilder::mapTypeIntoContext(…)`.

Assertion failure in [`lib/AST/ArchetypeBuilder.cpp (line 2037)`](https://github.com/apple/swift/blob/master/lib/AST/ArchetypeBuilder.cpp#L2037):

```
Assertion `genericParams && "dependent type in non-generic context"' failed.

When executing: static swift::Type swift::ArchetypeBuilder::mapTypeIntoContext(Module *, swift::GenericParamList *, swift::Type, swift::LazyResolver *)
```

<details>
<summary>

Assertion context:</summary>



```
  out << "\n";
}

Type ArchetypeBuilder::mapTypeIntoContext(const DeclContext *dc, Type type,
                                          LazyResolver *resolver) {
  auto genericParams = dc->getGenericParamsOfContext();
  return mapTypeIntoContext(dc->getParentModule(), genericParams, type,
                            resolver);
}

Type ArchetypeBuilder::mapTypeIntoContext(Module *M,
                                          GenericParamList *genericParams,
                                          Type type,
                                          LazyResolver *resolver) {
  auto canType = type->getCanonicalType();
  assert(!canType->hasArchetype() && "already have a contextual type");
  if (!canType->hasTypeParameter())
    return type;

  assert(genericParams && "dependent type in non-generic context");

  unsigned genericParamsDepth = genericParams->getDepth();
  type = type.transform([&](Type type) -> Type {
    // Map a generic parameter type to its archetype.
    if (auto gpType = type->getAs<GenericTypeParamType>()) {
      auto index = gpType->getIndex();
      unsigned depth = gpType->getDepth();

      // Skip down to the generic parameter list that houses the corresponding
      // generic parameter.
```

</details>
<details>
<summary>

Stack trace:</summary>



```
swift: /path/to/swift/lib/AST/ArchetypeBuilder.cpp:2037: static swift::Type swift::ArchetypeBuilder::mapTypeIntoContext(Module *, swift::GenericParamList *, swift::Type, swift::LazyResolver *): Assertion `genericParams && "dependent type in non-generic context"' failed.
8  swift           0x0000000000ff2e93 swift::ArchetypeBuilder::mapTypeIntoContext(swift::ModuleDecl*, swift::GenericParamList*, swift::Type, swift::LazyResolver*) + 243
12 swift           0x0000000000eb3b36 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
15 swift           0x0000000000f1b9e4 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
16 swift           0x0000000000f47d2c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
17 swift           0x0000000000ea21c1 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 769
18 swift           0x0000000000ea32d7 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 343
19 swift           0x0000000000ea34eb swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
24 swift           0x0000000000eb3b36 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
25 swift           0x0000000000ed5cf2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
26 swift           0x0000000000c62529 swift::CompilerInstance::performSema() + 3289
28 swift           0x00000000007d8649 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
29 swift           0x00000000007a4668 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28361-swift-archetypebuilder-maptypeintocontext.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28361-swift-archetypebuilder-maptypeintocontext-8b9576.o
1.  While type-checking 'a' at validation-test/compiler_crashers/28361-swift-archetypebuilder-maptypeintocontext.swift:11:1
2.  While type-checking expression at [validation-test/compiler_crashers/28361-swift-archetypebuilder-maptypeintocontext.swift:11:15 - line:13:11] RangeText="{associatedtype e
3.  While type-checking 'S' at validation-test/compiler_crashers/28361-swift-archetypebuilder-maptypeintocontext.swift:13:1
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```

</details>
