### PR TITLE
Add 💥 (😢 → 64, 😀 → 5107) in swift::constraints::ConstraintGraphNode::getAdjacency(…)

### DIFF
--- a/validation-test/compiler_crashers/28362-swift-constraints-constraintgraphnode-getadjacency.swift
+++ b/validation-test/compiler_crashers/28362-swift-constraints-constraintgraphnode-getadjacency.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+[1,{[1,{[]


### PR DESCRIPTION
Add test case for crash triggered in `swift::constraints::ConstraintGraphNode::getAdjacency(…)`.

Assertion failure in [`lib/Sema/ConstraintGraph.cpp (line 129)`](https://github.com/apple/swift/blob/master/lib/Sema/ConstraintGraph.cpp#L129):

```
Assertion `typeVar != TypeVar && "Cannot be adjacent to oneself"' failed.

When executing: ConstraintGraphNode::Adjacency &swift::constraints::ConstraintGraphNode::getAdjacency(swift::TypeVariableType *)
```

<details>
<summary>

Assertion context:</summary>



```

  // If this is the last constraint, just pop it off the list and we're done.
  unsigned lastIndex = Constraints.size()-1;
  if (index == lastIndex) {
    Constraints.pop_back();
    return;
  }

  // This constraint is somewhere in the middle; swap it with the last
  // constraint, so we can remove the constraint from the vector in O(1)
  // time rather than O(n) time.
  auto lastConstraint = Constraints[lastIndex];
  Constraints[index] = lastConstraint;
  ConstraintIndex[lastConstraint] = index;
  Constraints.pop_back();
}

ConstraintGraphNode::Adjacency &
ConstraintGraphNode::getAdjacency(TypeVariableType *typeVar) {
  assert(typeVar != TypeVar && "Cannot be adjacent to oneself");

  // Look for existing adjacency information.
  auto pos = AdjacencyInfo.find(typeVar);

  if (pos != AdjacencyInfo.end())
    return pos->second;

  // If we weren't already adjacent to this type variable, add it to the
  // list of adjacencies.
  pos = AdjacencyInfo.insert(
```

</details>
<details>
<summary>

Stack trace:</summary>



```
swift: /path/to/swift/lib/Sema/ConstraintGraph.cpp:129: ConstraintGraphNode::Adjacency &swift::constraints::ConstraintGraphNode::getAdjacency(swift::TypeVariableType *): Assertion `typeVar != TypeVar && "Cannot be adjacent to oneself"' failed.
8  swift           0x0000000000fe1be8 swift::constraints::ConstraintGraphNode::getAdjacency(swift::TypeVariableType*) + 296
9  swift           0x0000000000fe15e2 swift::constraints::ConstraintGraph::bindTypeVariable(swift::TypeVariableType*, swift::Type) + 242
10 swift           0x0000000000f3f4de swift::constraints::ConstraintSystem::assignFixedType(swift::TypeVariableType*, swift::Type, bool) + 366
11 swift           0x0000000000fa2fdc swift::constraints::ConstraintSystem::matchTypes(swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 3404
12 swift           0x0000000000fa702d swift::constraints::ConstraintSystem::matchDeepEqualityTypes(swift::Type, swift::Type, swift::constraints::ConstraintLocatorBuilder) + 877
13 swift           0x0000000000fa7a43 swift::constraints::ConstraintSystem::simplifyRestrictedConstraint(swift::constraints::ConversionRestrictionKind, swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 1091
14 swift           0x0000000000fa4c92 swift::constraints::ConstraintSystem::matchTypes(swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 10754
15 swift           0x0000000000fa6b40 swift::constraints::ConstraintSystem::matchFunctionTypes(swift::FunctionType*, swift::FunctionType*, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 672
16 swift           0x0000000000fa5d81 swift::constraints::ConstraintSystem::matchTypes(swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 15089
17 swift           0x0000000000fae6f2 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 626
18 swift           0x0000000000fb1a79 swift::constraints::ConstraintSystem::simplify(bool) + 105
19 swift           0x0000000000fb4e80 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 48
20 swift           0x0000000000fb8c83 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 9171
21 swift           0x0000000000fb4f95 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 325
22 swift           0x0000000000fb8c83 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 9171
23 swift           0x0000000000fb4f95 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 325
24 swift           0x0000000000fb7600 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 3408
25 swift           0x0000000000fb4f95 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 325
26 swift           0x0000000000fb8c83 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 9171
27 swift           0x0000000000fb4f95 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 325
28 swift           0x0000000000fb8c83 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 9171
29 swift           0x0000000000fb4f95 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 325
30 swift           0x0000000000fb7600 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 3408
31 swift           0x0000000000fb4f95 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 325
32 swift           0x0000000000fb8c83 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 9171
33 swift           0x0000000000fb4f95 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 325
34 swift           0x0000000000fb8c83 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 9171
35 swift           0x0000000000fb4f95 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 325
36 swift           0x0000000000fb8c83 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 9171
37 swift           0x0000000000fb4f95 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 325
38 swift           0x0000000000fb8c83 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 9171
39 swift           0x0000000000fb4f95 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 325
40 swift           0x0000000000fb4d49 swift::constraints::ConstraintSystem::solve(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 73
41 swift           0x0000000000e9ec00 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 800
42 swift           0x0000000000ea5392 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
44 swift           0x0000000000f1eca6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
45 swift           0x0000000000ed8fcd swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
46 swift           0x0000000000c65a49 swift::CompilerInstance::performSema() + 3289
48 swift           0x00000000007d89b9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
49 swift           0x00000000007a49d8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28362-swift-constraints-constraintgraphnode-getadjacency.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28362-swift-constraints-constraintgraphnode-getadjacency-2beaa7.o
1.  While type-checking expression at [validation-test/compiler_crashers/28362-swift-constraints-constraintgraphnode-getadjacency.swift:10:1 - line:10:10] RangeText="[1,{[1,{[]"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```

</details>
