### PR TITLE
[SE-2007][Sema] Don't subject protocol 'Self' to availability checks in lookup

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -271,13 +271,18 @@ void TypeChecker::checkInheritanceClause(Decl *decl,
   } else if (auto ext = dyn_cast<ExtensionDecl>(decl)) {
     DC = ext;
     options |= TR_GenericSignature | TR_InheritanceClause;
-  } else if (isa<GenericTypeParamDecl>(decl)) {
+  } else if (auto GP = dyn_cast<GenericTypeParamDecl>(decl)) {
     // For generic parameters, we want name lookup to look at just the
     // signature of the enclosing entity.
     DC = decl->getDeclContext();
     if (auto nominal = dyn_cast<NominalTypeDecl>(DC)) {
       DC = nominal;
       options |= TR_GenericSignature;
+      // When looking up protocol 'Self' accessibility checks are disabled to
+      // head off spurious unavailable diagnostics.
+      if (isa<ProtocolDecl>(DC) && GP->isProtocolSelf()) {
+        options |= TR_AllowUnavailable;
+      }
     } else if (auto ext = dyn_cast<ExtensionDecl>(DC)) {
       DC = ext;
       options |= TR_GenericSignature;

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -31,6 +31,13 @@ typealias int = Int // expected-note {{'int' has been explicitly marked unavaila
 @available(*, unavailable, renamed: "Float")
 typealias float = Float // expected-note {{'float' has been explicitly marked unavailable here}}
 
+protocol MyNewerProtocol {}
+
+@available(*, unavailable, renamed: "MyNewerProtocol")
+protocol MyOlderProtocol {} // expected-note {{'MyOlderProtocol' has been explicitly marked unavailable here}}
+
+extension Int: MyOlderProtocol {} // expected-error {{'MyOlderProtocol' has been renamed to 'MyNewerProtocol'}} 
+
 struct MyCollection<Element> {
   @available(*, unavailable, renamed: "Element")
   typealias T = Element // expected-note 2{{'T' has been explicitly marked unavailable here}}


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

It used to be impossible to ship anything with an unavailable protocol definition because in the process of verifying and type-checking its generic signature, invariably `Self` would resolve to an unavailable type.  Detect this and cut off diagnostic production by not subjecting `Self` to availability checks.
#### Resolved bug number: ([SR-2007](https://bugs.swift.org/browse/SR-2007))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
