### PR TITLE
Add 💥 (😢 → 65, 😀 → 5108) in swift::Expr::walk(…)

### DIFF
--- a/validation-test/compiler_crashers/28363-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers/28363-swift-expr-walk.swift
@@ -1,0 +1,14 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+class A
+enum A<A{
+func a
+case c
+let a=c


### PR DESCRIPTION
Add test case for crash triggered in `swift::Expr::walk(…)`.

Assertion failure in `llvm/include/llvm/Support/Casting.h (line 237)`:

```
Assertion `isa<X>(Val) && "cast<Ty>() argument of incompatible type!"' failed.

When executing: typename cast_retty<X, Y *>::ret_type llvm::cast(Y *) [X = swift::EnumType, Y = swift::TypeBase]
```

<details>
<summary>

Assertion context:</summary>



```
//
template <class X, class Y>
inline typename std::enable_if<!is_simple_type<Y>::value,
                               typename cast_retty<X, const Y>::ret_type>::type
cast(const Y &Val) {
  assert(isa<X>(Val) && "cast<Ty>() argument of incompatible type!");
  return cast_convert_val<
      X, const Y, typename simplify_type<const Y>::SimpleType>::doit(Val);
}

template <class X, class Y>
inline typename cast_retty<X, Y>::ret_type cast(Y &Val) {
  assert(isa<X>(Val) && "cast<Ty>() argument of incompatible type!");
  return cast_convert_val<X, Y,
                          typename simplify_type<Y>::SimpleType>::doit(Val);
}

template <class X, class Y>
inline typename cast_retty<X, Y *>::ret_type cast(Y *Val) {
  assert(isa<X>(Val) && "cast<Ty>() argument of incompatible type!");
  return cast_convert_val<X, Y*,
                          typename simplify_type<Y*>::SimpleType>::doit(Val);
}

// cast_or_null<X> - Functionally identical to cast, except that a null value is
// accepted.
//
template <class X, class Y>
LLVM_ATTRIBUTE_UNUSED_RESULT inline typename std::enable_if<
    !is_simple_type<Y>::value, typename cast_retty<X, const Y>::ret_type>::type
```

</details>
<details>
<summary>

Stack trace:</summary>



```
swift: /path/to/llvm/include/llvm/Support/Casting.h:237: typename cast_retty<X, Y *>::ret_type llvm::cast(Y *) [X = swift::EnumType, Y = swift::TypeBase]: Assertion `isa<X>(Val) && "cast<Ty>() argument of incompatible type!"' failed.
11 swift           0x000000000106cca5 swift::Expr::walk(swift::ASTWalker&) + 69
12 swift           0x0000000000f4ad42 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 514
13 swift           0x0000000000ea5431 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 769
14 swift           0x0000000000ea6547 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 343
15 swift           0x0000000000ea675b swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
17 swift           0x0000000000eb250d swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3853
21 swift           0x0000000000eb6da6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
22 swift           0x0000000000ed8f62 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
23 swift           0x0000000000c65a49 swift::CompilerInstance::performSema() + 3289
25 swift           0x00000000007d89b9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
26 swift           0x00000000007a49d8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28363-swift-expr-walk.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28363-swift-expr-walk-b823a6.o
1.  While type-checking 'A' at validation-test/compiler_crashers/28363-swift-expr-walk.swift:11:1
2.  While type-checking expression at [validation-test/compiler_crashers/28363-swift-expr-walk.swift:14:7 - line:14:7] RangeText="c"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```

</details>
