### PR TITLE
Add 💥 (😢 → 66, 😀 → 5108) in swift::TypeChecker::addImplicitConstructors(…)

### DIFF
--- a/validation-test/compiler_crashers/28364-swift-typechecker-addimplicitconstructors.swift
+++ b/validation-test/compiler_crashers/28364-swift-typechecker-addimplicitconstructors.swift
@@ -1,0 +1,15 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+{
+protocol d{
+func b:B<T>{}typealias e:AnyObject,b
+class d:b
+class b:d
+struct B<>:b


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::addImplicitConstructors(…)`.

Assertion failure in [`lib/Sema/TypeCheckDecl.cpp (line 7354)`](https://github.com/apple/swift/blob/master/lib/Sema/TypeCheckDecl.cpp#L7354):

```
Assertion `!classDecl->hasSuperclass() || classDecl->getSuperclass()->getAnyNominal()->isInvalid() || classDecl->getSuperclass()->getAnyNominal() ->addedImplicitInitializers()' failed.

When executing: void swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl *)
```

<details>
<summary>

Assertion context:</summary>



```
        && !structDecl->hasUnreferenceableStorage()) {
      // For a struct with memberwise initialized properties, we add a
      // memberwise init.
      if (FoundMemberwiseInitializedProperty) {
        // Create the implicit memberwise constructor.
        auto ctor = createImplicitConstructor(
                      *this, decl, ImplicitConstructorKind::Memberwise);
        decl->addMember(ctor);
      }

      // If we found a stored property, add a default constructor.
      if (!SuppressDefaultInitializer)
        defineDefaultConstructor(decl);
    }
    return;
  }

  // For a class with a superclass, automatically define overrides
  // for all of the superclass's designated initializers.
  // FIXME: Currently skipping generic classes.
  auto classDecl = cast<ClassDecl>(decl);
  assert(!classDecl->hasSuperclass() ||
         classDecl->getSuperclass()->getAnyNominal()->isInvalid() ||
         classDecl->getSuperclass()->getAnyNominal()
           ->addedImplicitInitializers());
  if (classDecl->hasSuperclass()) {
    bool canInheritInitializers = !FoundDesignatedInit;

    // We can't define these overrides if we have any uninitialized
    // stored properties.
```

</details>
<details>
<summary>

Stack trace:</summary>



```
swift: /path/to/swift/lib/Sema/TypeCheckDecl.cpp:7354: void swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl *): Assertion `!classDecl->hasSuperclass() || classDecl->getSuperclass()->getAnyNominal()->isInvalid() || classDecl->getSuperclass()->getAnyNominal() ->addedImplicitInitializers()' failed.
8  swift           0x0000000000ebd54a swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 4506
9  swift           0x0000000000eb044e swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 5854
10 swift           0x0000000000eb1778 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 376
11 swift           0x0000000001110bdb swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2667
12 swift           0x000000000110f2bf swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2495
13 swift           0x0000000000ef32db swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
16 swift           0x0000000000f24b8e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
18 swift           0x0000000000f25ae4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
19 swift           0x0000000000f24a80 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
20 swift           0x0000000000eb017a swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 5130
21 swift           0x0000000000eb1778 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 376
22 swift           0x0000000001110bdb swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2667
23 swift           0x000000000110f2bf swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2495
24 swift           0x0000000000ef32db swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
27 swift           0x0000000000f24b8e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
29 swift           0x0000000000f25ae4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
30 swift           0x0000000000f24a80 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
32 swift           0x0000000000eef09e swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 94
37 swift           0x0000000000eb6da6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
40 swift           0x0000000000f1eb64 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
41 swift           0x0000000000f4aeac swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
42 swift           0x0000000000ea5431 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 769
44 swift           0x0000000000f1eca6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
45 swift           0x0000000000ed8fcd swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
46 swift           0x0000000000c65a49 swift::CompilerInstance::performSema() + 3289
48 swift           0x00000000007d89b9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
49 swift           0x00000000007a49d8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28364-swift-typechecker-addimplicitconstructors.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28364-swift-typechecker-addimplicitconstructors-2a3ab6.o
1.  While type-checking expression at [validation-test/compiler_crashers/28364-swift-typechecker-addimplicitconstructors.swift:10:1 - line:15:12] RangeText="{
2.  While type-checking 'd' at validation-test/compiler_crashers/28364-swift-typechecker-addimplicitconstructors.swift:11:1
3.  While resolving type B<T> at [validation-test/compiler_crashers/28364-swift-typechecker-addimplicitconstructors.swift:12:8 - line:12:11] RangeText="B<T>"
4.  While resolving type b at [validation-test/compiler_crashers/28364-swift-typechecker-addimplicitconstructors.swift:15:12 - line:15:12] RangeText="b"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```

</details>
