### PR TITLE
UnsafeGuaranteedPeephole: Handle exception edges correctly

### DIFF
--- a/lib/SILOptimizer/Transforms/UnsafeGuaranteedPeephole.cpp
+++ b/lib/SILOptimizer/Transforms/UnsafeGuaranteedPeephole.cpp
@@ -37,6 +37,7 @@
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SILOptimizer/Analysis/ARCAnalysis.h"
+#include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
 #include "swift/SILOptimizer/Analysis/RCIdentityAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/Local.h"
@@ -46,9 +47,14 @@ using namespace swift;
 /// Remove retain/release pairs around builtin "unsafeGuaranteed" instruction
 /// sequences.
 static bool removeGuaranteedRetainReleasePairs(SILFunction &F,
-                                               RCIdentityFunctionInfo &RCIA) {
+                                               RCIdentityFunctionInfo &RCIA,
+                                               PostDominanceAnalysis *PDA) {
   DEBUG(llvm::dbgs() << "Running on function " << F.getName() << "\n");
   bool Changed = false;
+
+  // Lazily compute post-dominance info only when we really need it.
+  PostDominanceInfo *PDI = nullptr;
+
   for (auto &BB : F) {
     auto It = BB.begin(), End = BB.end();
     llvm::DenseMap<SILValue, SILInstruction *> LastRetain;
@@ -119,6 +125,15 @@ static bool removeGuaranteedRetainReleasePairs(SILFunction &F,
         continue;
       }
 
+      if (!PDI)
+        PDI = PDA->get(&F);
+
+      // It needs to post-dominated the end instruction, since we need to remove
+      // the release along all paths to exit.
+      if (!PDI->properlyDominates(UnsafeGuaranteedEndI, UnsafeGuaranteedI))
+        continue;
+
+
       // Find the release to match with the unsafeGuaranteedValue.
       auto &UnsafeGuaranteedEndBB = *UnsafeGuaranteedEndI->getParent();
       auto LastRelease = findReleaseToMatchUnsafeGuaranteedValue(
@@ -165,7 +180,8 @@ class UnsafeGuaranteedPeephole : public swift::SILFunctionTransform {
 
   void run() override {
     auto &RCIA = *getAnalysis<RCIdentityAnalysis>()->get(getFunction());
-    if (removeGuaranteedRetainReleasePairs(*getFunction(), RCIA))
+    auto *PostDominance = getAnalysis<PostDominanceAnalysis>();
+    if (removeGuaranteedRetainReleasePairs(*getFunction(), RCIA, PostDominance))
       invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
   }
 

--- a/test/SILOptimizer/unsafe_guaranteed_peephole.sil
+++ b/test/SILOptimizer/unsafe_guaranteed_peephole.sil
@@ -523,14 +523,14 @@ bb0(%0 : $AnyObject, %1: $Builtin.Int32):
 // CHECK: return
 // CHECK:bb2
 // CHECK: throw
-sil @testUnsafeGuaranteed_throw : $@convention(method) (@guaranteed Foo) -> @error Error {
+sil @testUnsafeGuaranteed_throw : $@convention(method) (@guaranteed Foo) -> @error ErrorProtocol {
 bb0(%0 : $Foo):
   strong_retain %0 : $Foo
   %4 = builtin "unsafeGuaranteed"<Foo>(%0 : $Foo) : $(Foo, Builtin.Int8)
   %5 = tuple_extract %4 : $(Foo, Builtin.Int8), 0
   %6 = tuple_extract %4 : $(Foo, Builtin.Int8), 1
-  %7 = function_ref @beep_or_throw : $@convention(thin) () -> @error Error
-  %8 = try_apply %7() : $@convention(thin) () -> @error Error, normal bb1, error bb2
+  %7 = function_ref @beep_or_throw : $@convention(thin) () -> @error ErrorProtocol
+  %8 = try_apply %7() : $@convention(thin) () -> @error ErrorProtocol, normal bb1, error bb2
 
 bb1(%15: $()):
   strong_release %5 : $Foo
@@ -538,7 +538,7 @@ bb1(%15: $()):
   %17 = tuple ()
   return %17 : $()
 
-bb2(%9: $Error):
+bb2(%9: $ErrorProtocol):
   strong_release %5 : $Foo
-  throw  %9: $Error
+  throw  %9: $ErrorProtocol
 }

--- a/test/SILOptimizer/unsafe_guaranteed_peephole.sil
+++ b/test/SILOptimizer/unsafe_guaranteed_peephole.sil
@@ -14,6 +14,7 @@ public class Foo : Base {
 
 sil @beep : $@convention(thin) () -> ()
 sil @beep2 : $@convention(thin) (@owned Foo) -> ()
+sil @beep_or_throw : $@convention(thin) () -> @error ErrorProtocol
 
 // CHECK-LABEL: sil @testUnsafeGuaranteed_simple
 // CHECK: bb0([[P:%.*]] : $Foo):
@@ -512,4 +513,32 @@ bb0(%0 : $AnyObject, %1: $Builtin.Int32):
   %16 = builtin "unsafeGuaranteedEnd"(%6 : $Builtin.Int8) : $()
   %17 = tuple ()
   return %17 : $()
+}
+
+// CHECK-LABEL: sil @testUnsafeGuaranteed_throw
+// CHECK:bb0
+// CHECK: unsafeGuaranteed
+// CHECK:bb1
+// CHECK: unsafeGuaranteedEnd
+// CHECK: return
+// CHECK:bb2
+// CHECK: throw
+sil @testUnsafeGuaranteed_throw : $@convention(method) (@guaranteed Foo) -> @error Error {
+bb0(%0 : $Foo):
+  strong_retain %0 : $Foo
+  %4 = builtin "unsafeGuaranteed"<Foo>(%0 : $Foo) : $(Foo, Builtin.Int8)
+  %5 = tuple_extract %4 : $(Foo, Builtin.Int8), 0
+  %6 = tuple_extract %4 : $(Foo, Builtin.Int8), 1
+  %7 = function_ref @beep_or_throw : $@convention(thin) () -> @error Error
+  %8 = try_apply %7() : $@convention(thin) () -> @error Error, normal bb1, error bb2
+
+bb1(%15: $()):
+  strong_release %5 : $Foo
+  %16 = builtin "unsafeGuaranteedEnd"(%6 : $Builtin.Int8) : $()
+  %17 = tuple ()
+  return %17 : $()
+
+bb2(%9: $Error):
+  strong_release %5 : $Foo
+  throw  %9: $Error
 }


### PR DESCRIPTION
#### What's in this pull request?

• Explanation: The UnsafeGuaranteedPeephole removes a pair of retain release based on an assertion that there is a surrounding retain/release pair. This is marked by a group of calls to the builtins unsafeGuaranteed/unsafeGuaranteedEnd. The optimization unconditionally assumed that the unsafeGuaranteedEnd builtin would post-dominated the unsafeGuaranteed builtin. This was an assumption that does not hold in the presence of throwing calls which exit to a throw edge before the unsafeGuaranteedEnd builtin call. After optimization this edge would now have an unbalanced release causing overrelease.

The fix is to query that the unsafeGuaranteedEnd builtin truly post dominates.

The bug gets exposed in Foundation’s Data.write implementation which has such a throwing call. Causing users of this api to crash because of over releasing when the throwing edge is exectued.

• Scope: Affects Swift users using Foundation's Data.write() method.

• Issue: rdar://problem/26890751 Writing an instance of Data to an invalid URL causes a crash

• Reviewed by: Roman

• Risk: Low. This only adds an additional check that prevents optimization.

• Testing: Modified compiler regression test

Exceptions can cause an exit before hitting the unsafeGuaranteedEnd instruction.
Make sure that we check post dominance to find such cases.

rdar://26890751
(cherry picked from commit 7cc447c7c7cac6d6c52e44cf7670fae8ee0631a3)
