### PR TITLE
Preliminary SILGen and runtime support for id-as-Any.

### DIFF
--- a/include/swift/AST/KnownDecls.def
+++ b/include/swift/AST/KnownDecls.def
@@ -65,6 +65,9 @@ FUNC_DECL(ForceBridgeFromObjectiveCBridgeable,
 FUNC_DECL(ConditionallyBridgeFromObjectiveCBridgeable,
           "_conditionallyBridgeFromObjectiveC_bridgeable")
 
+FUNC_DECL(BridgeAnythingToObjectiveC,
+          "_bridgeAnythingToObjectiveC")
+
 FUNC_DECL(DidEnterMain, "_stdlib_didEnterMain")
 FUNC_DECL(DiagnoseUnexpectedNilOptional, "_diagnoseUnexpectedNilOptional")
 

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/ParameterList.h"
 #include "swift/Basic/Fallthrough.h"
 #include "swift/SIL/SILArgument.h"
+#include "swift/SIL/SILUndef.h"
 #include "swift/SIL/TypeLowering.h"
 
 using namespace swift;
@@ -280,13 +281,26 @@ static void buildFuncToBlockInvokeBody(SILGenFunction &gen,
                                 funcParam.getType()));
   }
 
+  CanType resultType;
+  SILValue indirectResult;
+
+  if (funcTy->getNumAllResults() == 0)
+    resultType = TupleType::getEmpty(gen.SGM.getASTContext());
+  else {
+    auto result = funcTy->getSingleResult();
+    resultType = result.getType();
+
+    auto &tl = gen.getTypeLowering(result.getSILType());
+    if (tl.isAddressOnly()) {
+      assert(result.getConvention() == ResultConvention::Indirect);
+      assert(resultType->isAny() &&
+             "Should not be trying to bridge anything except for Any here");
+    }
+  }
+
   // Call the native function.
-  assert(!funcTy->hasIndirectResults()
-         && "block thunking func with indirect result not supported");
-  assert(funcTy->getNumDirectResults() <= 1
-         && "block thunking func with multiple results not supported");
   ManagedValue result = gen.emitMonomorphicApply(loc, fn, args,
-                         funcTy->getSILResult().getSwiftRValueType(),
+                                                 resultType,
                                                  ApplyOptions::None,
                                                  None, None)
     .getAsSingleValue(gen, loc);
@@ -437,16 +451,43 @@ static ManagedValue emitNativeToCBridgedNonoptionalValue(SILGenFunction &gen,
     return gen.emitNativeToBridgedError(loc, v, loweredBridgedTy);
   }
 
-  return v;
+  // Fall back to dynamic Any-to-id bridging.
+  // The destination type should be AnyObject in this case.
+  //
+  // TODO: Should only get here if -enable-id-as-any is active.
+  assert(gen.getASTContext().LangOpts.EnableIdAsAny
+         && loweredBridgedTy->isEqual(
+              gen.getASTContext().getProtocol(KnownProtocolKind::AnyObject)
+                ->getDeclaredType()));
+
+  // If the input argument is known to be an existential, save the runtime
+  // some work by opening it.
+  if (loweredNativeTy->isExistentialType()) {
+    auto openedTy = ArchetypeType::getOpened(loweredNativeTy);
+    
+    auto openedExistential = gen.emitOpenExistential(loc, v, openedTy,
+                                                 gen.getLoweredType(openedTy));
+    v = openedExistential.Value;
+    loweredNativeTy = openedTy;
+  }
+
+  // Call into the stdlib intrinsic.
+  if (auto bridgeAnything =
+        gen.getASTContext().getBridgeAnythingToObjectiveC(nullptr)) {
+    Substitution sub(loweredNativeTy, {});
+    return gen.emitApplyOfLibraryIntrinsic(loc, bridgeAnything, sub, v,
+                                           SGFContext())
+      .getAsSingleValue(gen, loc);
+  }
+  
+  // Shouldn't get here unless the standard library is busted.
+  return gen.emitUndef(loc, bridgedTy);
 }
 
 static ManagedValue emitNativeToCBridgedValue(SILGenFunction &gen,
                                               SILLocation loc,
                                               ManagedValue v,
                                               SILType bridgedTy) {
-  assert(v.getType().isLoadable(gen.F.getModule()) &&
-         "Cannot bridge address-only types");
-
   CanType loweredBridgedTy = bridgedTy.getSwiftRValueType();
   CanType loweredNativeTy = v.getType().getSwiftRValueType();
   if (loweredNativeTy == loweredBridgedTy)
@@ -472,9 +513,9 @@ static ManagedValue emitNativeToCBridgedValue(SILGenFunction &gen,
 }
 
 ManagedValue SILGenFunction::emitNativeToBridgedValue(SILLocation loc,
-                                                      ManagedValue v,
-                                                SILFunctionTypeRepresentation destRep,
-                                                      CanType loweredBridgedTy){
+                                          ManagedValue v,
+                                          SILFunctionTypeRepresentation destRep,
+                                          CanType loweredBridgedTy){
   switch (getSILFunctionLanguage(destRep)) {
   case SILFunctionLanguage::Swift:
     // No additional bridging needed for native functions.
@@ -499,15 +540,29 @@ static void buildBlockToFuncThunkBody(SILGenFunction &gen,
 
   SmallVector<ManagedValue, 4> args;
   SILBasicBlock *entry = &*gen.F.begin();
+
+  CanType resultType;
+  SILValue indirectResult;
+
+  if (funcTy->getNumAllResults() == 0)
+    resultType = TupleType::getEmpty(gen.SGM.getASTContext());
+  else {
+    auto result = funcTy->getSingleResult();
+    resultType = result.getType();
+
+    auto &tl = gen.getTypeLowering(result.getSILType());
+    if (tl.isAddressOnly()) {
+      assert(result.getConvention() == ResultConvention::Indirect);
+
+      indirectResult = new (gen.SGM.M) SILArgument(entry, result.getSILType());
+    }
+  }
+
   for (unsigned i : indices(funcTy->getParameters())) {
     auto &param = funcTy->getParameters()[i];
     auto &blockParam = blockTy->getParameters()[i];
 
     auto &tl = gen.getTypeLowering(param.getSILType());
-    assert((tl.isTrivial()
-              ? param.getConvention() == ParameterConvention::Direct_Unowned
-              : param.getConvention() == ParameterConvention::Direct_Owned)
-           && "nonstandard conventions for native functions not implemented");
     SILValue v = new (gen.SGM.M) SILArgument(entry, param.getSILType());
     auto mv = gen.emitManagedRValueWithCleanup(v, tl);
     args.push_back(gen.emitNativeToBridgedValue(loc, mv,
@@ -522,26 +577,22 @@ static void buildBlockToFuncThunkBody(SILGenFunction &gen,
   ManagedValue block = gen.emitManagedRValueWithCleanup(blockV);
 
   // Call the block.
-  assert(!funcTy->hasIndirectResults()
-         && "block thunking func with indirect result not supported");
   ManagedValue result = gen.emitMonomorphicApply(loc, block, args,
-                         funcTy->getSILResult().getSwiftRValueType(),
-                         ApplyOptions::None,
-                         /*override CC*/ SILFunctionTypeRepresentation::Block,
-                         /*foreign error*/ None)
+                           resultType,
+                           ApplyOptions::None,
+                           /*override CC*/ SILFunctionTypeRepresentation::Block,
+                           /*foreign error*/ None)
     .getAsSingleValue(gen, loc);
 
   // Return the result at +1.
-#ifndef NDEBUG
-  for (auto result : funcTy->getDirectResults()) {
-    assert((gen.getTypeLowering(result.getSILType()).isTrivial()
-             ? result.getConvention() == ResultConvention::Unowned
-             : result.getConvention() == ResultConvention::Owned)
-           && "nonstandard conventions for return not implemented");
-  }
-#endif
-
   auto r = result.forward(gen);
+
+  if (indirectResult) {
+    gen.B.createCopyAddr(loc, r, indirectResult,
+                         IsTake, IsInitialization);
+    r = gen.B.createTuple(loc, funcTy->getSILResult(), {});
+  }
+
   scope.pop();
   gen.B.createReturn(loc, r);
 }
@@ -584,9 +635,6 @@ static ManagedValue emitCBridgedToNativeValue(SILGenFunction &gen,
                                               SILLocation loc,
                                               ManagedValue v,
                                               SILType nativeTy) {
-  assert(nativeTy.isLoadable(gen.F.getModule()) &&
-         "Cannot bridge address-only types");
-
   CanType loweredNativeTy = nativeTy.getSwiftRValueType();
   CanType loweredBridgedTy = v.getType().getSwiftRValueType();
   if (loweredNativeTy == loweredBridgedTy)
@@ -640,8 +688,29 @@ static ManagedValue emitCBridgedToNativeValue(SILGenFunction &gen,
   }
 
   // Bridge NSError to Error.
-  if (loweredBridgedTy == gen.SGM.Types.getNSErrorType()) {
+  if (loweredBridgedTy == gen.SGM.Types.getNSErrorType())
     return gen.emitBridgedToNativeError(loc, v);
+
+  // id-to-Any bridging.
+  if (loweredNativeTy->isAny()) {
+    assert(loweredBridgedTy->isEqual(
+      gen.getASTContext().getProtocol(KnownProtocolKind::AnyObject)
+        ->getDeclaredType())
+      && "Any should bridge to AnyObject");
+    
+    // Open the type of the reference and use it to build an Any.
+    auto openedTy = ArchetypeType::getOpened(loweredBridgedTy);
+    auto openedSILTy = SILType::getPrimitiveObjectType(openedTy);
+    // TODO: Ever need to handle +0 values here?
+    assert(v.hasCleanup());
+    auto opened = gen.B.createOpenExistentialRef(loc, v.forward(gen),
+                                                 openedSILTy);
+    auto result = gen.emitTemporaryAllocation(loc, nativeTy);
+    auto resultVal = gen.B.createInitExistentialAddr(loc, result,
+                                                     openedTy, openedSILTy,
+                                                     {});
+    gen.B.createStore(loc, opened, resultVal);
+    return gen.emitManagedRValueWithCleanup(result);
   }
 
   return v;
@@ -779,13 +848,9 @@ static SILFunctionType *emitObjCThunkArguments(SILGenFunction &gen,
     assert(foreignError && "couldn't find foreign error convention!");
   }
 
-  // Emit the indirect result arguments, if any.
-  // FIXME: we're just assuming that these match up exactly?
-  for (auto indirectResult : objcFnTy->getIndirectResults()) {
-    SILType argTy = indirectResult.getSILType();
-    auto arg = new (gen.F.getModule()) SILArgument(gen.F.begin(), argTy);
-    args.push_back(arg);
-  }
+  // We don't know what to do with indirect results from the Objective-C side.
+  assert(objcFnTy->getNumIndirectResults() == 0 &&
+         "Objective-C methods cannot have indirect results");
 
   // Emit the other arguments, taking ownership of arguments if necessary.
   auto inputs = objcFnTy->getParameters();
@@ -839,7 +904,13 @@ static SILFunctionType *emitObjCThunkArguments(SILGenFunction &gen,
          "didn't find foreign error slot");
 
   // Bridge the input types.
-  Scope scope(gen.Cleanups, CleanupLocation::get(loc));
+
+  // FIXME: We really want alloc_stacks to outlive this scope, because
+  // bridging id-to-Any requires allocating an Any which gets passed to
+  // the native entry point.
+
+  // Scope scope(gen.Cleanups, CleanupLocation::get(loc));
+
   assert(bridgedArgs.size() == nativeInputs.size());
   for (unsigned i = 0, size = bridgedArgs.size(); i < size; ++i) {
     SILType argTy = swiftFnTy->getParameters()[i].getSILType();
@@ -864,28 +935,43 @@ static SILFunctionType *emitObjCThunkArguments(SILGenFunction &gen,
 void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
   assert(thunk.isForeign);
   SILDeclRef native = thunk.asForeign(false);
-
+  auto nativeInfo = getConstantInfo(native);
+  auto subs = F.getForwardingSubstitutions();
+  auto substTy = nativeInfo.SILFnType->substGenericArgs(
+    SGM.M, SGM.M.getSwiftModule(), subs);
+  SILType substSILTy = SILType::getPrimitiveObjectType(substTy);
+  
   auto loc = thunk.getAsRegularLocation();
   loc.markAutoGenerated();
   Scope scope(Cleanups, CleanupLocation::get(loc));
 
-  // Bridge the arguments.
+  // If we are bridging a Swift method with an Any return value, create a
+  // stack allocation to hold the result, since Any is address-only.
   SmallVector<SILValue, 4> args;
+
+  if (substTy->getNumIndirectResults() > 0) {
+    SILResultInfo indirectResult = substTy->getSingleResult();
+    assert(indirectResult.getType()->isAny() &&
+           "Should not be trying to bridge anything except for Any here");
+    args.push_back(emitTemporaryAllocation(loc, indirectResult.getSILType()));
+  }
+
+  // Now, enter a cleanup used for bridging the arguments. Note that if we
+  // have an indirect result, it must be outside of this scope, otherwise
+  // we will deallocate it too early.
+  Scope argScope(Cleanups, CleanupLocation::get(loc));
+
+  // Bridge the arguments.
   Optional<ForeignErrorConvention> foreignError;
   SILValue foreignErrorSlot;
   auto objcFnTy = emitObjCThunkArguments(*this, loc, thunk, args,
                                          foreignErrorSlot, foreignError);
-  auto nativeInfo = getConstantInfo(native);
   auto swiftResultTy =
     F.mapTypeIntoContext(nativeInfo.SILFnType->getSILResult());
   auto objcResultTy = objcFnTy->getSILResult();
 
   // Call the native entry point.
   SILValue nativeFn = emitGlobalFunctionRef(loc, native, nativeInfo);
-  auto subs = F.getForwardingSubstitutions();
-  auto substTy = nativeInfo.SILFnType->substGenericArgs(
-    SGM.M, SGM.M.getSwiftModule(), subs);
-  SILType substSILTy = SILType::getPrimitiveObjectType(substTy);
 
   CanType bridgedResultType = objcResultTy.getSwiftRValueType();
 
@@ -896,9 +982,14 @@ void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
     result = B.createApply(loc, nativeFn, substSILTy,
                            swiftResultTy, subs, args);
 
-    // Leave the scope immediately.  This isn't really necessary; it
-    // just limits lifetimes a little bit more.
-    scope.pop();
+    if (substTy->hasIndirectResults()) {
+      assert(substTy->getNumAllResults() == 1);
+      result = args[0];
+    }
+
+    // Leave the argument cleanup scope immediately.  This isn't really
+    // necessary; it just limits lifetimes a little bit more.
+    argScope.pop();
 
     // Now bridge the return value.
     result = emitBridgeReturnValue(*this, loc, result,
@@ -946,9 +1037,10 @@ void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
     result = contBB->createBBArg(objcResultTy);
 
     // Leave the scope now.
-    scope.pop();
+    argScope.pop();
   }
 
+  scope.pop();
   B.createReturn(loc, result);
 }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3517,16 +3517,11 @@ ManagedValue SILGenFunction::emitRValueAsSingleValue(Expr *E, SGFContext C) {
   return std::move(rv).getAsSingleValue(*this, E);
 }
 
-static ManagedValue emitUndef(SILGenFunction &gen, SILLocation loc,
-                              const TypeLowering &undefTL) {
-  SILValue undef = SILUndef::get(undefTL.getLoweredType(), gen.SGM.M);
-  return gen.emitManagedRValueWithCleanup(undef, undefTL);
-}
-
 ManagedValue SILGenFunction::emitUndef(SILLocation loc, Type type) {
-  return ::emitUndef(*this, loc, getTypeLowering(type));
+  return emitUndef(loc, getLoweredType(type));
 }
 
 ManagedValue SILGenFunction::emitUndef(SILLocation loc, SILType type) {
-  return ::emitUndef(*this, loc, getTypeLowering(type));
+  SILValue undef = SILUndef::get(type, SGM.M);
+  return ManagedValue::forUnmanaged(undef);
 }

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -209,7 +209,7 @@ func _bridgeNonVerbatimToObjectiveC<T>(_ x: T) -> AnyObject?
 ///   the boxed value, but is otherwise opaque.
 ///
 /// TODO: This should subsume `_bridgeToObjectiveC` above.
-func _bridgeAnythingToObjectiveC<T>(_: T) -> AnyObject {
+func _bridgeAnythingToObjectiveC<T>(_ x: T) -> AnyObject {
   if _fastPath(_isClassOrObjCExistential(T.self)) {
     return unsafeBitCast(x, to: AnyObject.self)
   }

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -209,7 +209,8 @@ func _bridgeNonVerbatimToObjectiveC<T>(_ x: T) -> AnyObject?
 ///   the boxed value, but is otherwise opaque.
 ///
 /// TODO: This should subsume `_bridgeToObjectiveC` above.
-func _bridgeAnythingToObjectiveC<T>(_ x: T) -> AnyObject {
+/// COMPILER_INTRINSIC
+public func _bridgeAnythingToObjectiveC<T>(_ x: T) -> AnyObject {
   if _fastPath(_isClassOrObjCExistential(T.self)) {
     return unsafeBitCast(x, to: AnyObject.self)
   }
@@ -217,8 +218,9 @@ func _bridgeAnythingToObjectiveC<T>(_ x: T) -> AnyObject {
 }
 
 // TODO: This should subsume `_bridgeNonVerbatimToObjectiveC` above.
+/// COMPILER_INTRINSIC
 @_silgen_name("_swift_bridgeAnythingNonVerbatimToObjectiveC")
-func _bridgeAnythingNonVerbatimToObjectiveC<T>(_ x: T) -> AnyObject
+public func _bridgeAnythingNonVerbatimToObjectiveC<T>(_ x: T) -> AnyObject
 
 /// Convert `x` from its Objective-C representation to its Swift
 /// representation.

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -193,6 +193,33 @@ func _bridgeToObjectiveCUnconditionalAutorelease<T>(_ x: T) -> AnyObject
 @_silgen_name("_swift_bridgeNonVerbatimToObjectiveC")
 func _bridgeNonVerbatimToObjectiveC<T>(_ x: T) -> AnyObject?
 
+/// Bridge an arbitrary value to an Objective-C object.
+///
+/// - If `T` is a class type, it is always bridged verbatim, the function
+///   returns `x`;
+///
+/// - otherwise, `T` conforms to `_ObjectiveCBridgeable`:
+///   + if `T._isBridgedToObjectiveC()` returns `false`, then
+///     we fall back to boxing (below);
+///   + otherwise, returns the result of `x._bridgeToObjectiveC()`;
+///
+/// - otherwise, we use **boxing** to bring the value into Objective-C.
+///   The value is wrapped in an instance of a private Objective-C class
+///   that is `id`-compatible and dynamically castable back to the type of
+///   the boxed value, but is otherwise opaque.
+///
+/// TODO: This should subsume `_bridgeToObjectiveC` above.
+func _bridgeAnythingToObjectiveC<T>(_: T) -> AnyObject {
+  if _fastPath(_isClassOrObjCExistential(T.self)) {
+    return unsafeBitCast(x, to: AnyObject.self)
+  }
+  return _bridgeAnythingNonVerbatimToObjectiveC(x)
+}
+
+// TODO: This should subsume `_bridgeNonVerbatimToObjectiveC` above.
+@_silgen_name("_swift_bridgeAnythingNonVerbatimToObjectiveC")
+func _bridgeAnythingNonVerbatimToObjectiveC<T>(_ x: T) -> AnyObject
+
 /// Convert `x` from its Objective-C representation to its Swift
 /// representation.
 ///
@@ -523,4 +550,5 @@ extension AutoreleasingUnsafeMutablePointer {
     Builtin.unreachable()
   }
 }
+
 #endif

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -1557,6 +1557,50 @@ static bool _dynamicCastToUnknownClassFromExistential(OpaqueValue *dest,
   }
 }
 
+static void unwrapExistential(OpaqueValue *src,
+                              const ExistentialTypeMetadata *srcType,
+                              OpaqueValue *&srcValue,
+                              const Metadata *&srcCapturedType,
+                              bool &isOutOfLine,
+                              bool &canTake) {
+  switch (srcType->getRepresentation()) {
+    case ExistentialTypeRepresentation::Class: {
+      auto classContainer =
+      reinterpret_cast<const ClassExistentialContainer*>(src);
+      srcValue = (OpaqueValue*) &classContainer->Value;
+      void *obj = classContainer->Value;
+      srcCapturedType = swift_getObjectType(reinterpret_cast<HeapObject*>(obj));
+      isOutOfLine = false;
+      canTake = true;
+      break;
+    }
+    case ExistentialTypeRepresentation::Opaque: {
+      auto opaqueContainer = reinterpret_cast<OpaqueExistentialContainer*>(src);
+      srcCapturedType = opaqueContainer->Type;
+      srcValue = srcCapturedType->vw_projectBuffer(&opaqueContainer->Buffer);
+      isOutOfLine = (src != srcValue);
+      canTake = true;
+      break;
+    }
+    case ExistentialTypeRepresentation::Error: {
+      const SwiftError *errorBox
+      = *reinterpret_cast<const SwiftError * const *>(src);
+      
+      srcCapturedType = errorBox->getType();
+      // A bridged NSError is itself the value.
+      if (errorBox->isPureNSError())
+        srcValue = src;
+      else
+        srcValue = const_cast<OpaqueValue*>(errorBox->getValue());
+      
+      // The value is out-of-line, but we can't take it, since it may be shared.
+      isOutOfLine = true;
+      canTake = false;
+      break;
+    }
+  }
+}
+
 /// Perform a dynamic cast from an existential type to a
 /// non-existential type.
 static bool _dynamicCastFromExistential(OpaqueValue *dest,
@@ -1569,42 +1613,8 @@ static bool _dynamicCastFromExistential(OpaqueValue *dest,
   bool isOutOfLine;
   bool canTake;
 
-  switch (srcType->getRepresentation()) {
-  case ExistentialTypeRepresentation::Class: {
-    auto classContainer =
-      reinterpret_cast<const ClassExistentialContainer*>(src);
-    srcValue = (OpaqueValue*) &classContainer->Value;
-    void *obj = classContainer->Value;
-    srcCapturedType = swift_getObjectType(reinterpret_cast<HeapObject*>(obj));
-    isOutOfLine = false;
-    canTake = true;
-    break;
-  }
-  case ExistentialTypeRepresentation::Opaque: {
-    auto opaqueContainer = reinterpret_cast<OpaqueExistentialContainer*>(src);
-    srcCapturedType = opaqueContainer->Type;
-    srcValue = srcCapturedType->vw_projectBuffer(&opaqueContainer->Buffer);
-    isOutOfLine = (src != srcValue);
-    canTake = true;
-    break;
-  }
-  case ExistentialTypeRepresentation::Error: {
-    const SwiftError *errorBox
-      = *reinterpret_cast<const SwiftError * const *>(src);
-    
-    srcCapturedType = errorBox->getType();
-    // A bridged NSError is itself the value.
-    if (errorBox->isPureNSError())
-      srcValue = src;
-    else
-      srcValue = const_cast<OpaqueValue*>(errorBox->getValue());
-
-    // The value is out-of-line, but we can't take it, since it may be shared.
-    isOutOfLine = true;
-    canTake = false;
-    break;
-  }
-  }
+  unwrapExistential(src, srcType,
+                    srcValue, srcCapturedType, isOutOfLine, canTake);
   
   auto subFlags = flags;
   if (!canTake)
@@ -1622,8 +1632,11 @@ static bool _dynamicCastFromExistential(OpaqueValue *dest,
   } else {
     // swift_dynamicCast took or destroyed the value as per the original request
     // We may still have an opaque existential container to deallocate.
-    if (isOutOfLine)
+    if (isOutOfLine) {
+      assert(srcType->getRepresentation()
+               == ExistentialTypeRepresentation::Opaque);
       _maybeDeallocateOpaqueExistential(src, result, flags);
+    }
   }
 
   return result;
@@ -2515,16 +2528,48 @@ static bool _dynamicCastClassToValueViaObjCBridgeable(
   return success;
 }
 
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C"
-id _swift_bridgeAnythingNonVerbatimToObjectiveC(OpaqueValue *src,
-                                                const Metadata *srcType) {
+static id bridgeAnythingNonVerbatimToObjectiveC(OpaqueValue *src,
+                                                const Metadata *srcType,
+                                                bool consume) {
   // We can always bridge objects verbatim.
   if (srcType->isAnyClass()) {
-    return *(id*)src;
+    id result;
+    memcpy(&result, src, sizeof(id));
+    if (!consume)
+      swift_unknownRetain(result);
+    return result;
   }
   
-  // TODO: Look through existential containers.
+  // Dig through existential types.
+  if (auto srcExistentialTy = dyn_cast<ExistentialTypeMetadata>(srcType)) {
+    OpaqueValue *srcInnerValue;
+    const Metadata *srcInnerType;
+    bool isOutOfLine;
+    bool canTake;
+    
+    unwrapExistential(src, srcExistentialTy,
+                      srcInnerValue, srcInnerType, isOutOfLine, canTake);
+    auto result = bridgeAnythingNonVerbatimToObjectiveC(srcInnerValue,
+                                                        srcInnerType,
+                                                        consume && canTake);
+    // Clean up the existential, or its remains after taking the value from
+    // it.
+    if (consume) {
+      if (canTake) {
+        if (isOutOfLine) {
+          // Should only be true of opaque existentials.
+          assert(srcExistentialTy->getRepresentation()
+                   == ExistentialTypeRepresentation::Opaque);
+          auto container = reinterpret_cast<OpaqueExistentialContainer*>(src);
+          srcInnerType->vw_deallocateBuffer(&container->Buffer);
+        }
+      } else {
+        // We didn't take the value, so clean up the existential value.
+        srcType->vw_destroy(src);
+      }
+    }
+    return result;
+  }
   
   if (auto srcBridgeWitness = findBridgeWitness(srcType)) {
     // Check whether the source is bridged to Objective-C.
@@ -2537,14 +2582,22 @@ id _swift_bridgeAnythingNonVerbatimToObjectiveC(OpaqueValue *src,
     auto srcBridgedObject =
       srcBridgeWitness->bridgeToObjectiveC(src, srcType, srcBridgeWitness);
 
-    // The source object was passed in +1.
-    srcType->vw_destroy(src);
+    // Consume if the source object was passed in +1.
+    if (consume)
+      srcType->vw_destroy(src);
 
     return (id)srcBridgedObject;
   }
 
   // TODO: Fall back to boxing here.
-  crash("unimplemented universal bridging conversion");
+  crash("unimplemented boxing bridge");
+}
+
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
+extern "C"
+id _swift_bridgeAnythingNonVerbatimToObjectiveC(OpaqueValue *src,
+                                                const Metadata *srcType) {
+  return bridgeAnythingNonVerbatimToObjectiveC(src, srcType, /*consume*/ true);
 }
 
 //===--- Bridging helpers for the Swift stdlib ----------------------------===//

--- a/test/1_stdlib/BridgeIdAsAny.swift.gyb
+++ b/test/1_stdlib/BridgeIdAsAny.swift.gyb
@@ -1,0 +1,51 @@
+// RUN: rm -rf %t  &&  mkdir %t
+//
+// RUN: %gyb %s -o %t/BridgeIdAsAny.swift
+// RUN: %target-build-swift -module-name a %t/BridgeIdAsAny.swift -o %t.out
+// RUN: %target-run %t.out
+// REQUIRES: executable_test
+//
+// REQUIRES: objc_interop
+
+import StdlibUnittest
+import Foundation
+
+var BridgeAnything = TestSuite("BridgeAnything")
+
+func wantonlyWrapInAny<T>(_ x: T) -> Any {
+  return x
+}
+
+// Professional runtime testers on a closed course. Do not attempt at home.
+extension LifetimeTracked: Error {}
+extension String: Error {}
+
+% for testName, valueExpr, testExpr in [("classes", "LifetimeTracked(0)", " === x"), ("strings", '"vitameatavegamin"', '.isEqual(to: "vitameatavegamin")')]:
+BridgeAnything.test("${testName}") {
+  do {
+    let x = ${valueExpr}
+    expectTrue(_bridgeAnythingToObjectiveC(x)${testExpr})
+    expectTrue(_bridgeAnythingNonVerbatimToObjectiveC(x)${testExpr})
+
+    let xInAny: Any = x
+    expectTrue(_bridgeAnythingToObjectiveC(xInAny)${testExpr})
+    expectTrue(_bridgeAnythingNonVerbatimToObjectiveC(xInAny)${testExpr})
+
+    let xInAnyInAny = wantonlyWrapInAny(xInAny)
+    expectTrue(_bridgeAnythingToObjectiveC(xInAnyInAny)${testExpr})
+    expectTrue(_bridgeAnythingNonVerbatimToObjectiveC(xInAnyInAny)${testExpr})
+
+    let xInError: Error = x
+    expectTrue(_bridgeAnythingToObjectiveC(xInError)${testExpr})
+    expectTrue(_bridgeAnythingNonVerbatimToObjectiveC(xInError)${testExpr})
+
+    let xInErrorInAny = wantonlyWrapInAny(xInError)
+    expectTrue(_bridgeAnythingToObjectiveC(xInErrorInAny)${testExpr})
+    expectTrue(_bridgeAnythingNonVerbatimToObjectiveC(xInErrorInAny)${testExpr})
+  }
+
+  expectEqual(0, LifetimeTracked.instances)
+}
+% end
+
+runAllTests()

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -16,7 +16,7 @@ func passingToId<T: CP, U>(receiver: IdLover,
                            generic: U,
                            existential: P,
                            any: Any) {
-  // CHECK: bb0([[SELF:%.*]] : $IdLover, [[STRING:%.*]] : $String, [[NSSTRING:%.*]] : $NSString, [[OBJECT:%.*]] : $AnyObject, [[CLASS_GENERIC:%.*]] : $T, [[CLASS_EXISTENTIAL:%.*]] : $CP
+  // CHECK: bb0([[SELF:%.*]] : $IdLover, [[STRING:%.*]] : $String, [[NSSTRING:%.*]] : $NSString, [[OBJECT:%.*]] : $AnyObject, [[CLASS_GENERIC:%.*]] : $T, [[CLASS_EXISTENTIAL:%.*]] : $CP, [[GENERIC:%.*]] : $*U, [[EXISTENTIAL:%.*]] : $*P, [[ANY:%.*]] : $*protocol<>
 
   // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]]
   // CHECK: [[BRIDGE_STRING:%.*]] = function_ref @_TFE10FoundationSS19_bridgeToObjectiveC
@@ -45,13 +45,44 @@ func passingToId<T: CP, U>(receiver: IdLover,
   // CHECK: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
   receiver.takesId(classExistential)
 
-  // TODO: These cases need to perform a (to-be-implemented) universal
-  // bridging conversion.
-  /*
+  // These cases perform a universal bridging conversion.
+
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $IdLover,
+  // CHECK-NEXT: [[COPY:%.*]] = alloc_stack $U
+  // CHECK-NEXT: copy_addr [[GENERIC]] to [initialization] [[COPY]]
+  // CHECK-NEXT: // function_ref _bridgeAnythingToObjectiveC
+  // CHECK-NEXT: [[BRIDGE_ANYTHING:%.*]] = function_ref
+  // CHECK-NEXT: [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<U>([[COPY]])
+  // CHECK-NEXT: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK-NEXT: strong_release [[ANYOBJECT]]
+  // CHECK-NEXT: dealloc_stack [[COPY]]
   receiver.takesId(generic)
+
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $IdLover,
+  // CHECK-NEXT: [[COPY:%.*]] = alloc_stack $P
+  // CHECK-NEXT: copy_addr [[EXISTENTIAL]] to [initialization] [[COPY]]
+  // CHECK-NEXT: [[OPENED_COPY:%.*]] = open_existential_addr [[COPY]] : $*P to $*[[OPENED_TYPE:@opened.*P]],
+  // CHECK-NEXT: // function_ref _bridgeAnythingToObjectiveC
+  // CHECK-NEXT: [[BRIDGE_ANYTHING:%.*]] = function_ref
+  // CHECK-NEXT: [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<[[OPENED_TYPE]]>([[OPENED_COPY]])
+  // CHECK-NEXT: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK-NEXT: strong_release [[ANYOBJECT]]
+  // CHECK-NEXT: deinit_existential_addr [[COPY]]
+  // CHECK-NEXT: dealloc_stack [[COPY]]
   receiver.takesId(existential)
+
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $IdLover,
+  // CHECK-NEXT: [[COPY:%.*]] = alloc_stack $protocol<>
+  // CHECK-NEXT: copy_addr [[ANY]] to [initialization] [[COPY]]
+  // CHECK-NEXT: [[OPENED_COPY:%.*]] = open_existential_addr [[COPY]] : $*protocol<> to $*[[OPENED_TYPE:@opened.*protocol<>]],
+  // CHECK-NEXT: // function_ref _bridgeAnythingToObjectiveC
+  // CHECK-NEXT: [[BRIDGE_ANYTHING:%.*]] = function_ref
+  // CHECK-NEXT: [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<[[OPENED_TYPE]]>([[OPENED_COPY]])
+  // CHECK-NEXT: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK-NEXT: strong_release [[ANYOBJECT]]
+  // CHECK-NEXT: deinit_existential_addr [[COPY]]
+  // CHECK-NEXT: dealloc_stack [[COPY]]
   receiver.takesId(any)
-   */
 
   // TODO: Property and subscript setters
 }
@@ -80,3 +111,161 @@ func passingToNullableId(receiver: IdLover,
  */
 
 // TODO: casting from id, nullable or not
+
+// Make sure we generate correct bridging thunks
+class SwiftIdLover : NSObject {
+
+  func methodReturningAny() -> Any {}
+  // CHECK-LABEL: sil hidden @_TFC17objc_bridging_any12SwiftIdLover18methodReturningAnyfT_P_ : $@convention(method) (@guaranteed SwiftIdLover) -> @out protocol<>
+  // CHECK: [[NATIVE_RESULT:%.*]] = alloc_stack $protocol<>
+  // CHECK: [[NATIVE_IMP:%.*]] = function_ref @_TFC17objc_bridging_any12SwiftIdLover18methodReturningAny
+  // CHECK: apply [[NATIVE_IMP]]([[NATIVE_RESULT]], %0)
+  // CHECK: [[OPEN_RESULT:%.*]] = open_existential_addr [[NATIVE_RESULT]]
+  // CHECK: [[BRIDGE_ANYTHING:%.*]] = function_ref @_TFs27_bridgeAnythingToObjectiveC
+  // CHECK: [[OBJC_RESULT:%.*]] = apply [[BRIDGE_ANYTHING]]<{{.*}}>([[OPEN_RESULT]])
+  // CHECK: return [[OBJC_RESULT]]
+
+  func methodTakingAny(a: Any) {}
+  // CHECK-LABEL: sil hidden [thunk] @_TToFC17objc_bridging_any12SwiftIdLover15methodTakingAnyfT1aP__T_ : $@convention(objc_method) (AnyObject, SwiftIdLover) -> ()
+  // CHECK:     bb0(%0 : $AnyObject, %1 : $SwiftIdLover):
+  // CHECK-NEXT:  strong_retain %0
+  // CHECK-NEXT:  strong_retain %1
+  // CHECK-NEXT:  [[OPENED:%.*]] = open_existential_ref %0
+  // CHECK-NEXT:  [[RESULT:%.*]] = alloc_stack $protocol<>
+  // CHECK-NEXT:  [[RESULT_VAL:%.*]] = init_existential_addr [[RESULT]]
+  // CHECK-NEXT:  store [[OPENED]] to [[RESULT_VAL]]
+  // CHECK-NEXT:  // function_ref
+  // CHECK-NEXT:  [[METHOD:%.*]] = function_ref @_TFC17objc_bridging_any12SwiftIdLover15methodTakingAnyfT1aP__T_
+  // CHECK-NEXT:  apply [[METHOD]]([[RESULT]], %1)
+  // CHECK-NEXT:  dealloc_stack [[RESULT]]
+  // CHECK-NEXT:  strong_release %1
+  // CHECK-NEXT:  return
+
+  // CHECK-LABEL: sil hidden @_TFC17objc_bridging_any12SwiftIdLover26methodTakingBlockTakingAnyfFP_T_T_ : $@convention(method) (@owned @callee_owned (@in protocol<>) -> (), @guaranteed SwiftIdLover) -> ()
+
+  // CHECK-LABEL: sil hidden [thunk] @_TToFC17objc_bridging_any12SwiftIdLover26methodTakingBlockTakingAnyfFP_T_T_ : $@convention(objc_method) (@convention(block) (AnyObject) -> (), SwiftIdLover) -> ()
+  // CHECK:    bb0(%0 : $@convention(block) (AnyObject) -> (), %1 : $SwiftIdLover):
+  // CHECK-NEXT:  [[BLOCK:%.*]] = copy_block %0
+  // CHECK-NEXT:  strong_retain %1
+  // CHECK:       [[THUNK_FN:%.*]] = function_ref @_TTRXFdCb_dPs9AnyObject___XFo_iP___
+  // CHECK-NEXT:  [[THUNK:%.*]] = partial_apply [[THUNK_FN]]([[BLOCK]])
+  // CHECK:       [[METHOD:%.*]] = function_ref @_TFC17objc_bridging_any12SwiftIdLover26methodTakingBlockTakingAnyfFP_T_T_
+  // CHECK-NEXT:  [[RESULT:%.*]] = apply [[METHOD]]([[THUNK]], %1)
+  // CHECK-NEXT:  strong_release %1
+  // CHECK-NEXT:  return [[RESULT]]
+
+  // CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @_TTRXFdCb_dPs9AnyObject___XFo_iP___
+  // CHECK:     bb0(%0 : $*protocol<>, %1 : $@convention(block) (AnyObject) -> ()):
+  // CHECK-NEXT:  [[OPENED:%.*]] = open_existential_addr %0 : $*protocol<> to $*[[OPENED_TYPE:@opened.*protocol<>]],
+  // CHECK-NEXT:  // function_ref _bridgeAnythingToObjectiveC
+  // CHECK-NEXT:  [[BRIDGE_ANYTHING:%.*]] = function_ref
+  // CHECK-NEXT:  [[BRIDGED:%.*]] = apply [[BRIDGE_ANYTHING]]<[[OPENED_TYPE]]>([[OPENED]])
+  // CHECK-NEXT:  apply %1([[BRIDGED]])
+  // CHECK-NEXT:  [[VOID:%.*]] = tuple ()
+  // CHECK-NEXT:  strong_release %1
+  // CHECK-NEXT:  strong_release [[BRIDGED]]
+  // CHECK-NEXT:  deinit_existential_addr %0
+  // CHECK-NEXT:  return [[VOID]]
+
+  func methodTakingBlockTakingAny(_: (Any) -> ()) {}
+
+  // CHECK-LABEL: sil hidden @_TFC17objc_bridging_any12SwiftIdLover29methodReturningBlockTakingAnyfT_FP_T_ : $@convention(method) (@guaranteed SwiftIdLover) -> @owned @callee_owned (@in protocol<>) -> ()
+
+  // CHECK-LABEL: sil hidden [thunk] @_TToFC17objc_bridging_any12SwiftIdLover29methodReturningBlockTakingAnyfT_FP_T_ : $@convention(objc_method) (SwiftIdLover) -> @autoreleased @convention(block) (AnyObject) -> ()
+  // CHECK:     bb0(%0 : $SwiftIdLover):
+  // CHECK-NEXT:  strong_retain %0
+  // CHECK:       [[METHOD:%.*]] = function_ref @_TFC17objc_bridging_any12SwiftIdLover29methodReturningBlockTakingAnyfT_FP_T_
+  // CHECK-NEXT:  [[RESULT:%.*]] = apply [[METHOD:%.*]](%0)
+  // CHECK-NEXT:  strong_release %0
+  // CHECK-NEXT:  [[BLOCK_STORAGE:%.*]] = alloc_stack $@block_storage @callee_owned (@in protocol<>) -> ()
+  // CHECK-NEXT:  [[BLOCK_STORAGE_ADDR:%.*]] = project_block_storage [[BLOCK_STORAGE]]
+  // CHECK-NEXT:  store [[RESULT:%.*]] to [[BLOCK_STORAGE_ADDR]]
+  // CHECK:       [[THUNK_FN:%.*]] = function_ref @_TTRXFo_iP___XFdCb_dPs9AnyObject___
+  // CHECK-NEXT:  [[BLOCK_HEADER:%.*]] = init_block_storage_header [[BLOCK_STORAGE]] : $*@block_storage @callee_owned (@in protocol<>) -> (), invoke [[THUNK_FN]]
+  // CHECK-NEXT:  [[BLOCK:%.*]] = copy_block [[BLOCK_HEADER]]
+  // CHECK-NEXT:  dealloc_stack [[BLOCK_STORAGE]]
+  // CHECK-NEXT:  strong_release [[RESULT]]
+  // CHECK-NEXT:  return [[BLOCK]]
+
+  // CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @_TTRXFo_iP___XFdCb_dPs9AnyObject___ : $@convention(c) @pseudogeneric (@inout_aliasable @block_storage @callee_owned (@in protocol<>) -> (), AnyObject) -> ()
+  // CHECK:     bb0(%0 : $*@block_storage @callee_owned (@in protocol<>) -> (), %1 : $AnyObject):
+  // CHECK-NEXT:  [[BLOCK_STORAGE_ADDR:%.*]] = project_block_storage %0
+  // CHECK-NEXT:  [[FUNCTION:%.*]] = load [[BLOCK_STORAGE_ADDR]]
+  // CHECK-NEXT:  strong_retain [[FUNCTION]]
+  // CHECK-NEXT:  strong_retain %1
+  // CHECK-NEXT:  [[OPENED:%.*]] = open_existential_ref %1
+  // CHECK-NEXT:  [[RESULT:%.*]] = alloc_stack $protocol<>
+  // CHECK-NEXT:  [[RESULT_VAL:%.*]] = init_existential_addr [[RESULT]] : $*protocol<>
+  // CHECK-NEXT:  store [[OPENED]] to [[RESULT_VAL]]
+  // CHECK-NEXT:  apply [[FUNCTION]]([[RESULT]])
+  // CHECK-NEXT:  [[VOID:%.*]] = tuple ()
+  // CHECK-NEXT:  dealloc_stack [[RESULT]]
+  // CHECK-NEXT:  return [[VOID]] : $()
+
+  func methodReturningBlockTakingAny() -> ((Any) -> ()) {}
+
+  // CHECK-LABEL: sil hidden @_TFC17objc_bridging_any12SwiftIdLover29methodTakingBlockReturningAnyfFT_P_T_ : $@convention(method) (@owned @callee_owned () -> @out protocol<>, @guaranteed SwiftIdLover) -> () {
+
+  // CHECK-LABEL: sil hidden [thunk] @_TToFC17objc_bridging_any12SwiftIdLover29methodTakingBlockReturningAnyfFT_P_T_ : $@convention(objc_method) (@convention(block) () -> @autoreleased AnyObject, SwiftIdLover) -> ()
+  // CHECK:     bb0(%0 : $@convention(block) () -> @autoreleased AnyObject, %1 : $SwiftIdLover):
+  // CHECK-NEXT:  [[BLOCK:%.*]] = copy_block %0
+  // CHECK-NEXT:  strong_retain %1
+  // CHECK:       [[THUNK_FN:%.*]] = function_ref @_TTRXFdCb__aPs9AnyObject__XFo__iP__
+  // CHECK-NEXT:  [[THUNK:%.*]] = partial_apply [[THUNK_FN]]([[BLOCK]])
+  // CHECK:       [[METHOD:%.*]] = function_ref @_TFC17objc_bridging_any12SwiftIdLover29methodTakingBlockReturningAnyfFT_P_T_
+  // CHECK-NEXT:  [[RESULT:%.*]] = apply [[METHOD]]([[THUNK]], %1)
+  // CHECK-NEXT:  strong_release %1
+  // CHECK-NEXT:  return [[RESULT]]
+
+  // CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @_TTRXFdCb__aPs9AnyObject__XFo__iP__ : $@convention(thin) (@owned @convention(block) () -> @autoreleased AnyObject) -> @out protocol<>
+  // CHECK:     bb0(%0 : $*protocol<>, %1 : $@convention(block) () -> @autoreleased AnyObject):
+  // CHECK-NEXT:  [[BRIDGED:%.*]] = apply %1()
+  // CHECK-NEXT:  [[OPENED:%.*]] = open_existential_ref [[BRIDGED]]
+  // CHECK-NEXT:  [[RESULT:%.*]] = alloc_stack $protocol<>
+  // CHECK-NEXT:  [[RESULT_VAL:%.*]] = init_existential_addr [[RESULT]]
+  // CHECK-NEXT:  store [[OPENED]] to [[RESULT_VAL]]
+
+  // TODO: Should elide the copy
+  // CHECK-NEXT:  copy_addr [take] [[RESULT]] to [initialization] %0
+  // CHECK-NEXT:  [[EMPTY:%.*]] = tuple ()
+  // CHECK-NEXT:  dealloc_stack [[RESULT]]
+  // CHECK-NEXT:  strong_release %1
+  // CHECK-NEXT:  return [[EMPTY]]
+
+  func methodTakingBlockReturningAny(_: () -> Any) {}
+
+  // CHECK-LABEL: sil hidden @_TFC17objc_bridging_any12SwiftIdLover32methodReturningBlockReturningAnyfT_FT_P_ : $@convention(method) (@guaranteed SwiftIdLover) -> @owned @callee_owned () -> @out protocol<>
+
+  // CHECK-LABEL: sil hidden [thunk] @_TToFC17objc_bridging_any12SwiftIdLover32methodReturningBlockReturningAnyfT_FT_P_ : $@convention(objc_method) (SwiftIdLover) -> @autoreleased @convention(block) () -> @autoreleased AnyObject
+  // CHECK:     bb0(%0 : $SwiftIdLover):
+  // CHECK-NEXT:  strong_retain %0
+  // CHECK:       [[METHOD:%.*]] = function_ref @_TFC17objc_bridging_any12SwiftIdLover32methodReturningBlockReturningAnyfT_FT_P_
+  // CHECK-NEXT:  [[FUNCTION:%.*]] = apply [[METHOD]](%0)
+  // CHECK-NEXT:  strong_release %0
+  // CHECK-NEXT:  [[BLOCK_STORAGE:%.*]] = alloc_stack $@block_storage @callee_owned () -> @out protocol<>
+  // CHECK-NEXT:  [[BLOCK_STORAGE_ADDR:%.*]] = project_block_storage [[BLOCK_STORAGE]]
+  // CHECK-NEXT:  store [[FUNCTION]] to [[BLOCK_STORAGE_ADDR]]
+  // CHECK:       [[THUNK_FN:%.*]] = function_ref @_TTRXFo__iP__XFdCb__aPs9AnyObject__
+  // CHECK-NEXT:  [[BLOCK_HEADER:%.*]] = init_block_storage_header [[BLOCK_STORAGE]] : $*@block_storage @callee_owned () -> @out protocol<>, invoke [[THUNK_FN]]
+  // CHECK-NEXT:  [[BLOCK:%.*]] = copy_block [[BLOCK_HEADER]]
+  // CHECK-NEXT:  dealloc_stack [[BLOCK_STORAGE]]
+  // CHECK-NEXT:  strong_release [[FUNCTION]]
+  // CHECK-NEXT:  return [[BLOCK]]
+
+  // CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @_TTRXFo__iP__XFdCb__aPs9AnyObject__ : $@convention(c) @pseudogeneric (@inout_aliasable @block_storage @callee_owned () -> @out protocol<>) -> @autoreleased AnyObject
+  // CHECK:     bb0(%0 : $*@block_storage @callee_owned () -> @out protocol<>):
+  // CHECK-NEXT:  [[BLOCK_STORAGE_ADDR:%.*]] = project_block_storage %0
+  // CHECK-NEXT:  [[FUNCTION:%.*]] = load [[BLOCK_STORAGE_ADDR]]
+  // CHECK-NEXT:  strong_retain [[FUNCTION]]
+  // CHECK-NEXT:  [[RESULT:%.*]] = alloc_stack $protocol<>
+  // CHECK-NEXT:  apply [[FUNCTION]]([[RESULT]])
+  // CHECK-NEXT:  [[OPENED:%.*]] = open_existential_addr [[RESULT]] : $*protocol<> to $*[[OPENED_TYPE:@opened.*protocol<>]],
+  // CHECK-NEXT:  // function_ref _bridgeAnythingToObjectiveC
+  // CHECK-NEXT:  [[BRIDGE_ANYTHING:%.*]] = function_ref
+  // CHECK-NEXT:  [[BRIDGED:%.*]] = apply [[BRIDGE_ANYTHING]]<[[OPENED_TYPE]]>([[OPENED]])
+  // CHECK-NEXT:  deinit_existential_addr [[RESULT]]
+  // CHECK-NEXT:  dealloc_stack [[RESULT]]
+  // CHECK-NEXT:  return [[BRIDGED]]
+
+  func methodReturningBlockReturningAny() -> (() -> Any) {}
+}


### PR DESCRIPTION
Stub out a `_bridgeAnythingToObjectiveC` entry point and use it in SILGen to bridge something to an object when we don't otherwise know how to.
