### PR TITLE
Conform ObjectIdentifier to CustomDebugStringConvertible [SR-2014]

### DIFF
--- a/stdlib/public/core/Reflection.swift
+++ b/stdlib/public/core/Reflection.swift
@@ -40,6 +40,13 @@ public struct ObjectIdentifier : Hashable, Comparable {
   }
 }
 
+extension ObjectIdentifier : CustomStringConvertible {
+  /// A textual representation of `self`.
+  public var description: String {
+    return "ObjectIdentifier(\(_rawPointerToString(_value)))"
+  }
+}
+
 public func <(lhs: ObjectIdentifier, rhs: ObjectIdentifier) -> Bool {
   return UInt(lhs) < UInt(rhs)
 }

--- a/stdlib/public/core/Reflection.swift
+++ b/stdlib/public/core/Reflection.swift
@@ -40,9 +40,9 @@ public struct ObjectIdentifier : Hashable, Comparable {
   }
 }
 
-extension ObjectIdentifier : CustomStringConvertible {
-  /// A textual representation of `self`.
-  public var description: String {
+extension ObjectIdentifier : CustomDebugStringConvertible {
+  /// A textual representation of `self`, suitable for debugging.
+  public var debugDescription: String {
     return "ObjectIdentifier(\(_rawPointerToString(_value)))"
   }
 }

--- a/test/1_stdlib/Runtime.swift.gyb
+++ b/test/1_stdlib/Runtime.swift.gyb
@@ -975,6 +975,14 @@ Reflection.test("CustomMirror") {
     expectEqual(
       [ ObjectIdentifier(a), ObjectIdentifier(b), ObjectIdentifier(c) ].sorted(),
       [ ObjectIdentifier(c), ObjectIdentifier(b), ObjectIdentifier(a) ].sorted())
+
+    // CustomDebugStringConvertible
+    expectEqual(
+      String(reflecting: ObjectIdentifier(a)),
+      String(reflecting: ObjectIdentifier(a)))
+    expectNotEqual(
+      String(reflecting: ObjectIdentifier(a)),
+      String(reflecting: ObjectIdentifier(b)))
   }
 }
 


### PR DESCRIPTION
#### What's in this pull request?

Made ObjectIdentifier conform to CustomDebugStringConvertible, printing something useful.

```
import Foundation
let obj = NSObject()
print(String(reflecting: ObjectIdentifier(obj)))
```

Prints something like: `ObjectIdentifier(0x00007f8d6db99130)`
#### Resolved bug number: ([SR-2014](https://bugs.swift.org/browse/SR-2014))

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
