### PR TITLE
Improve diagnostics for comparisons to nil.

### DIFF
--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -777,6 +777,24 @@ class SR1594 {
   }
 }
 
+func nilComparison(i: Int, o: AnyObject) {
+  _ = i == nil  // expected-error {{type 'Int' is not optional, value can never be nil}}
+  _ = nil == i  // expected-error {{type 'Int' is not optional, value can never be nil}}
+  _ = i != nil  // expected-error {{type 'Int' is not optional, value can never be nil}}
+  _ = nil != i  // expected-error {{type 'Int' is not optional, value can never be nil}}
+  _ = i < nil   // expected-error {{type 'Int' is not optional, value can never be nil}}
+  _ = nil < i   // expected-error {{type 'Int' is not optional, value can never be nil}}
+  _ = i <= nil  // expected-error {{type 'Int' is not optional, value can never be nil}}
+  _ = nil <= i  // expected-error {{type 'Int' is not optional, value can never be nil}}
+  _ = i > nil   // expected-error {{type 'Int' is not optional, value can never be nil}}
+  _ = nil > i   // expected-error {{type 'Int' is not optional, value can never be nil}}
+  _ = i >= nil  // expected-error {{type 'Int' is not optional, value can never be nil}}
+  _ = nil >= i  // expected-error {{type 'Int' is not optional, value can never be nil}}
+
+  _ = o === nil // expected-error {{type 'AnyObject' is not optional, value can never be nil}}
+  _ = o !== nil // expected-error {{type 'AnyObject' is not optional, value can never be nil}}
+}
+
 // FIXME: Bad diagnostic
 func secondArgumentNotLabeled(a:Int, _ b: Int) { }
 secondArgumentNotLabeled(10, 20)

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -704,12 +704,9 @@ func invalidDictionaryLiteral() {
 // nil/metatype comparisons
 //===----------------------------------------------------------------------===//
 Int.self == nil // expected-error {{type 'Int.Type' is not optional, value can never be nil}}
-nil == Int.self // expected-error {{binary operator '==' cannot be applied to operands}}
-// expected-note @-1 {{overloads for '==' exist with these partially matching parameter lists}}
+nil == Int.self // expected-error {{type 'Int.Type' is not optional, value can never be nil}}
 Int.self != nil // expected-error {{type 'Int.Type' is not optional, value can never be nil}}
-nil != Int.self // expected-error {{binary operator '!=' cannot be applied to operands}}
-// expected-note @-1 {{overloads for '!=' exist with these partially matching parameter lists}}
-
+nil != Int.self // expected-error {{type 'Int.Type' is not optional, value can never be nil}}
 
 // <rdar://problem/19032294> Disallow postfix ? when not chaining
 func testOptionalChaining(_ a : Int?, b : Int!, c : Int??) {


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Noticed by inspection, the diagnostics for comparing against literal `nil` were not treating the operands symmetrically, so we were only emitting a diagnostic if the `nil` was on the right hand side.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

As implemented the diagnostic specific to nil was only firing when nil
was on the right hand side.
