### PR TITLE
[Sema] Fix compiler crash when pattern matching optional enum

### DIFF
--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1453,8 +1453,8 @@ bool TypeChecker::coercePatternToType(Pattern *&P, DeclContext *dc, Type type,
                           /*special kind*/0, Rename.str())
                 .fixItReplace(EEP->getLoc(), Rename.str());
 
+              return true;
             }
-            return true;
           }
 
           diagnose(EEP->getLoc(), diag::enum_element_pattern_member_not_found,

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -222,3 +222,13 @@ func ugly(_ a: A<EE>) {
     }
   }
 }
+
+// SR-2057
+
+enum SR2057 {
+  case foo
+}
+
+let sr2057: SR2057? = nil
+if case .foo = sr2057 { } // expected-error{{enum case 'foo' not found in type 'SR2057?'}}
+


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

TypeCheckPattern was able to take the path checking if `Optional.None`
should be renamed to lowercase `Optional.none` and if this wasn't
necessary still failed but without generating a diagnostic.
Now it always provides a diagnostic when failing.
#### Resolved bug numbers: ([SR-2057](https://bugs.swift.org/browse/SR-2057)), ([SR-1919](https://bugs.swift.org/browse/SR-1919)), ([SR-1716](https://bugs.swift.org/browse/SR-1716)), ([SR-1921](https://bugs.swift.org/browse/SR-1921))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
