### PR TITLE
[swiftc (67 vs. 5108)] Add crasher in swift::constraints::ConstraintGraphNode::getMemberType(…)

### DIFF
--- a/validation-test/compiler_crashers/28365-swift-constraints-constraintgraphnode-getmembertype.swift
+++ b/validation-test/compiler_crashers/28365-swift-constraints-constraintgraphnode-getmembertype.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+enum B<g:a,func d var d=B{}protocol a{{}typealias e:a]typealias d:a


### PR DESCRIPTION
Add test case for crash triggered in `swift::constraints::ConstraintGraphNode::getMemberType(…)`.

Current number of unresolved compiler crashers: 67 (5108 resolved)

Stack trace:

```
6  swift           0x0000000000fe3696 swift::constraints::ConstraintGraphNode::getMemberType(swift::Identifier, std::function<swift::TypeVariableType* ()>) + 182
7  swift           0x0000000000fe425a swift::constraints::ConstraintGraph::getMemberType(swift::TypeVariableType*, swift::Identifier, std::function<swift::TypeVariableType* ()>) + 154
9  swift           0x000000000112b4e4 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 36
10 swift           0x0000000000f438eb swift::constraints::ConstraintSystem::openGeneric(swift::DeclContext*, swift::DeclContext*, llvm::ArrayRef<swift::GenericTypeParamType*>, llvm::ArrayRef<swift::Requirement>, bool, swift::constraints::ConstraintLocatorBuilder, llvm::DenseMap<swift::CanType, swift::TypeVariableType*, llvm::DenseMapInfo<swift::CanType>, llvm::detail::DenseMapPair<swift::CanType, swift::TypeVariableType*> >&) + 1611
12 swift           0x000000000112b4e4 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 36
13 swift           0x0000000000f41d9e swift::constraints::ConstraintSystem::openType(swift::Type, swift::constraints::ConstraintLocatorBuilder, llvm::DenseMap<swift::CanType, swift::TypeVariableType*, llvm::DenseMapInfo<swift::CanType>, llvm::detail::DenseMapPair<swift::CanType, swift::TypeVariableType*> >&) + 78
18 swift           0x000000000106e4be swift::Expr::walk(swift::ASTWalker&) + 46
19 swift           0x0000000000f8ba78 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) + 200
20 swift           0x0000000000e9fb53 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 371
21 swift           0x0000000000ea6492 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
22 swift           0x0000000000ea7647 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 343
23 swift           0x0000000000ea785b swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
25 swift           0x0000000000eb363d swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3853
27 swift           0x0000000000eb7ed6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
28 swift           0x0000000000eda092 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
29 swift           0x0000000000c65ea9 swift::CompilerInstance::performSema() + 3289
31 swift           0x00000000007d8b49 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
32 swift           0x00000000007a4b68 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28365-swift-constraints-constraintgraphnode-getmembertype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28365-swift-constraints-constraintgraphnode-getmembertype-b3e759.o
1.  While type-checking 'd' at validation-test/compiler_crashers/28365-swift-constraints-constraintgraphnode-getmembertype.swift:9:12
2.  While type-checking expression at [validation-test/compiler_crashers/28365-swift-constraints-constraintgraphnode-getmembertype.swift:9:25 - line:9:27] RangeText="B{}"
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
