### PR TITLE
[vim] Support highlighting 'MARK' in comments

### DIFF
--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -155,7 +155,7 @@ syn region swiftPreprocFalse start="^\s*#\<if\>\s\+\<false\>" end="^\s*#\(\<else
 
 syn match swiftAttribute /@\<\w\+\>/ skipwhite nextgroup=swiftType
 
-syn keyword swiftTodo TODO FIXME contained
+syn keyword swiftTodo MARK TODO FIXME contained
 
 syn match swiftCastOp "\<is\>" skipwhite nextgroup=swiftType
 syn match swiftCastOp "\<as\>[!?]\?" skipwhite nextgroup=swiftType


### PR DESCRIPTION
#### What's in this pull request?

Support highlighting 'MARK' in comments like latest version of Xcode.
#### Resolved bug number: None

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
