### PR TITLE
Fix IndexSet.contains(integersIn:) documentation

### DIFF
--- a/stdlib/public/SDK/Foundation/IndexSet.swift
+++ b/stdlib/public/SDK/Foundation/IndexSet.swift
@@ -414,7 +414,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     public func contains(integersIn range: CountableClosedRange<Element>) -> Bool { return self.contains(integersIn: Range(range)) }
 
     
-    /// Returns `true` if `self` contains any of the integers in `indexSet`.
+    /// Returns `true` if `self` contains all of the integers in `indexSet`.
     public func contains(integersIn indexSet: IndexSet) -> Bool {
         return _handle.map { $0.contains(indexSet) }
     }


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

This fixes an error in the documentation for `IndexSet.contains(integersIn:)`. The documentation currently states that the method "Returns `true` if `self` contains any of the integers in `indexSet`." However, the callee must contain _all_ elements of `indexSet` for the method to return `true`:

```
let s1 = IndexSet(1...5)
let s2 = IndexSet(1...10)
s1.contains(integersIn: s2) // false
s2.contains(integersIn: s1) // true
```
#### Resolved bug number: n/a

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
