### PR TITLE
Rework access checking in terms of "access scopes", and default to 'internal'

### DIFF
--- a/lib/AST/Mangle.cpp
+++ b/lib/AST/Mangle.cpp
@@ -379,6 +379,26 @@ static OperatorFixity getDeclFixity(const ValueDecl *decl) {
   llvm_unreachable("bad UnaryOperatorKind");
 }
 
+/// Returns true if one of the ancestor DeclContexts of \p D is either marked
+/// private or is a local context.
+static bool isInPrivateOrLocalContext(const ValueDecl *D) {
+  const DeclContext *DC = D->getDeclContext();
+  if (!DC->isTypeContext()) {
+    assert((DC->isModuleScopeContext() || DC->isLocalContext()) &&
+           "unexpected context kind");
+    return DC->isLocalContext();
+  }
+
+  auto declaredType = DC->getDeclaredTypeOfContext();
+  if (!declaredType || declaredType->is<ErrorType>())
+    return false;
+
+  auto *nominal = declaredType->getAnyNominal();
+  if (nominal->getFormalAccess() == Accessibility::Private)
+    return true;
+  return isInPrivateOrLocalContext(nominal);
+}
+
 void Mangler::mangleDeclName(const ValueDecl *decl) {
   if (decl->getDeclContext()->isLocalContext()) {
     // Mangle local declarations with a numeric discriminator.
@@ -387,47 +407,28 @@ void Mangler::mangleDeclName(const ValueDecl *decl) {
     // Fall through to mangle the <identifier>.
 
   } else if (decl->hasAccessibility() &&
-             decl->getFormalAccess() == Accessibility::Private) {
+             decl->getFormalAccess() == Accessibility::Private &&
+             !isInPrivateOrLocalContext(decl)) {
     // Mangle non-local private declarations with a textual discriminator
     // based on their enclosing file.
     // decl-name ::= 'P' identifier identifier
 
-    // Don't bother to use the private discriminator if the enclosing context
-    // is also private.
-    auto isWithinPrivateNominal = [](const Decl *D) -> bool {
-      const DeclContext *DC = D->getDeclContext();
-      if (!DC->isTypeContext()) {
-        assert((DC->isModuleScopeContext() || DC->isLocalContext()) &&
-               "do we need a private discriminator for this context?");
-        return false;
-      }
+    // The first <identifier> is a discriminator string unique to the decl's
+    // original source file.
+    auto topLevelContext = decl->getDeclContext()->getModuleScopeContext();
+    auto fileUnit = cast<FileUnit>(topLevelContext);
 
-      auto declaredType = DC->getDeclaredTypeOfContext();
-      if (!declaredType || declaredType->is<ErrorType>())
-        return false;
+    Identifier discriminator =
+      fileUnit->getDiscriminatorForPrivateValue(decl);
+    assert(!discriminator.empty());
+    assert(!isNonAscii(discriminator.str()) &&
+           "discriminator contains non-ASCII characters");
+    (void)isNonAscii;
+    assert(!clang::isDigit(discriminator.str().front()) &&
+           "not a valid identifier");
 
-      return (declaredType->getAnyNominal()->getFormalAccess()
-              == Accessibility::Private);
-    };
-
-    if (!isWithinPrivateNominal(decl)) {
-      // The first <identifier> is a discriminator string unique to the decl's
-      // original source file.
-      auto topLevelContext = decl->getDeclContext()->getModuleScopeContext();
-      auto fileUnit = cast<FileUnit>(topLevelContext);
-
-      Identifier discriminator =
-        fileUnit->getDiscriminatorForPrivateValue(decl);
-      assert(!discriminator.empty());
-      assert(!isNonAscii(discriminator.str()) &&
-             "discriminator contains non-ASCII characters");
-      (void) isNonAscii;
-      assert(!clang::isDigit(discriminator.str().front()) &&
-             "not a valid identifier");
-
-      Buffer << 'P';
-      mangleIdentifier(discriminator);
-    }
+    Buffer << 'P';
+    mangleIdentifier(discriminator);
     // Fall through to mangle the name.
   }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1311,7 +1311,7 @@ void TypeChecker::computeDefaultAccessibility(ExtensionDecl *ED) {
   if (auto *AA = ED->getAttrs().getAttribute<AccessibilityAttr>())
     defaultAccess = AA->getAccess();
   else
-    defaultAccess = std::min(maxAccess, Accessibility::Internal);
+    defaultAccess = Accessibility::Internal;
 
   // Normally putting a public member in an internal extension is harmless,
   // because that member can never be used elsewhere. But if some of the types
@@ -1368,9 +1368,9 @@ void TypeChecker::computeAccessibility(ValueDecl *D) {
     case DeclContextKind::GenericTypeDecl: {
       auto generic = cast<GenericTypeDecl>(DC);
       validateAccessibility(generic);
-      Accessibility access = generic->getFormalAccess();
-      if (!isa<ProtocolDecl>(generic))
-        access = std::min(access, Accessibility::Internal);
+      Accessibility access = Accessibility::Internal;
+      if (isa<ProtocolDecl>(generic))
+        access = generic->getFormalAccess();
       D->setAccessibility(access);
       break;
     }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1231,7 +1231,7 @@ checkWitnessAccessibility(Accessibility *requiredAccess,
   *requiredAccess = std::min(Proto->getFormalAccess(), *requiredAccess);
 
   if (*requiredAccess > Accessibility::Private) {
-    if (witness->getFormalAccess() < *requiredAccess)
+    if (witness->getFormalAccess(DC) < *requiredAccess)
       return true;
 
     if (requirement->isSettable(DC)) {
@@ -4609,7 +4609,13 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
     // For anything with a Clang node, lazily check conformances.
     if (ext->hasClangNode()) return;
 
-    defaultAccessibility = ext->getDefaultAccessibility();
+    Type extendedTy = ext->getExtendedType();
+    if (!extendedTy)
+      return;
+    const NominalTypeDecl *nominal = extendedTy->getAnyNominal();
+    if (!nominal)
+      return;
+    defaultAccessibility = nominal->getFormalAccess();
   } else {
     // For anything with a Clang node, lazily check conformances.
     auto nominal = cast<NominalTypeDecl>(dc);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -460,12 +460,18 @@ public:
   /// during type checking.
   llvm::SetVector<NominalTypeDecl *> ValidatedTypes;
 
-  /// Caches whether a particular type is accessible from a particular file
-  /// unit.
+  using TypeAccessScopeCacheMap = llvm::DenseMap<Type, const DeclContext *>;
+
+  /// Caches the outermost scope where a particular type can be used, relative
+  /// to a particular file.
+  ///
+  /// The file is used to handle things like \c \@testable. A null-but-present
+  /// value means the type is public.
   ///
   /// This can't use CanTypes because typealiases may have more limited types
   /// than their underlying types.
-  llvm::DenseMap<Type, Accessibility> TypeAccessibilityCache;
+  llvm::DenseMap<const SourceFile *, TypeAccessScopeCacheMap>
+    TypeAccessScopeCache;
 
   // Caches whether a given declaration is "as specialized" as another.
   llvm::DenseMap<std::pair<ValueDecl*, ValueDecl*>, bool> 

--- a/test/NameBinding/reference-dependencies.swift
+++ b/test/NameBinding/reference-dependencies.swift
@@ -307,7 +307,9 @@ private extension Use4 {
 // CHECK-DAG: !private "PrivateTopLevelTy2"
 // CHECK-DAG: "PrivateProto2"
 extension Private2 : PrivateProto2 {
-  var privateTy2: PrivateTopLevelTy2? { return nil }
+  // FIXME: This test is supposed to check that we get this behavior /without/
+  // marking the property private, just from the base type.
+  private var privateTy2: PrivateTopLevelTy2? { return nil }
 }
 // CHECK-DAG: !private "PrivateTopLevelTy3"
 func outerPrivateTy3() {

--- a/test/attr/accessibility.swift
+++ b/test/attr/accessibility.swift
@@ -158,7 +158,7 @@ internal struct InternalStruct {} // expected-note * {{declared here}}
 private struct PrivateStruct {} // expected-note * {{declared here}}
 
 protocol InternalProto { // expected-note * {{declared here}}
-  associatedtype Assoc // expected-note {{type declared here}}
+  associatedtype Assoc
 }
 public extension InternalProto {} // expected-error {{extension of internal protocol cannot be declared public}} {{1-8=}}
 internal extension InternalProto where Assoc == PublicStruct {}
@@ -169,7 +169,7 @@ private extension InternalProto where Assoc == InternalStruct {}
 private extension InternalProto where Assoc == PrivateStruct {}
 
 public protocol PublicProto {
-  associatedtype Assoc // expected-note * {{type declared here}}
+  associatedtype Assoc
 }
 public extension PublicProto {}
 public extension PublicProto where Assoc == PublicStruct {}

--- a/test/attr/accessibility_print.swift
+++ b/test/attr/accessibility_print.swift
@@ -27,7 +27,7 @@ struct BA_DefaultStruct {
 
 // CHECK-LABEL: private{{(\*/)?}} struct BB_PrivateStruct {
 private struct BB_PrivateStruct {
-  // CHECK: private var x
+  // CHECK: internal var x
   var x = 0
   // CHECK: private init(x: Int)
   // CHECK: private init()
@@ -58,7 +58,7 @@ public struct BE_PublicStructPrivateMembers {
 
 // CHECK-LABEL: {{^}}private{{(\*/)?}} struct BF_FilePrivateStruct {
 fileprivate struct BF_FilePrivateStruct {
-  // CHECK: {{^}} private var x
+  // CHECK: {{^}} internal var x
   var x = 0
   // CHECK: {{^}} private init(x: Int)
   // CHECK: {{^}} private init()
@@ -92,7 +92,7 @@ private enum DA_PrivateEnum {
   // CHECK: {{^}} case Foo
   // CHECK: Bar
   case Foo, Bar
-  // CHECK: private init()
+  // CHECK: internal init()
   init() { self = .Foo }
   // CHECK: private var hashValue
 } // CHECK: {{^[}]}}
@@ -145,7 +145,7 @@ public class FC_PublicClass {}
 // CHECK-SRC: {{^}}ex
 // CHECK-LABEL: tension FA_PrivateClass {
 extension FA_PrivateClass {
-  // CHECK: private func a()
+  // CHECK: internal func a()
   func a() {}
 } // CHECK: {{^[}]}}
 
@@ -179,7 +179,7 @@ private extension FE_PublicClass {
   func explicitPrivateExt() {}
   // CHECK: private struct PrivateNested {
   struct PrivateNested {
-    // CHECK: private var x
+    // CHECK: internal var x
     var x: Int
   } // CHECK: }
 } // CHECK: {{^[}]}}
@@ -213,7 +213,7 @@ public extension FE_PublicClass {
 func GA_localTypes() {
   // CHECK-SRC: private struct Local {
   struct Local {
-    // CHECK-SRC: private let x
+    // CHECK-SRC: internal let x
     let x = 0
   }
   _ = Local()
@@ -240,11 +240,11 @@ public struct GB_NestedOuter {
 
 // CHECK-LABEL: private{{(\*/)?}} struct GC_NestedOuterPrivate {
 private struct GC_NestedOuterPrivate {
-  // CHECK: private struct Inner {
+  // CHECK: internal struct Inner {
   struct Inner {
     // CHECK: private{{(\*/)?}} let x
     private let x = 0
-    // CHECK: private let y
+    // CHECK: internal let y
     let y = 0
   }
 } // CHECK: {{^[}]}}
@@ -306,7 +306,7 @@ extension HB_InternalProtocol where Assoc == HC_PrivateStruct {
 } // CHECK: {{^[}]}}
 // CHECK-LABEL: extension HC_PrivateProtocol {
 extension HC_PrivateProtocol {
-  // CHECK: private func unconstrained()
+  // CHECK: internal func unconstrained()
   func unconstrained() {}
 } // CHECK: {{^[}]}}
 // CHECK-LABEL: extension HC_PrivateProtocol where Assoc == HA_PublicStruct {

--- a/validation-test/compiler_crashers_fixed/28198-swift-typerepr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/28198-swift-typerepr-walk.swift
@@ -5,7 +5,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
 private class B
 class d<T where B<T>:w


### PR DESCRIPTION
Rework access checking in terms of "access scopes" (in preparation for the private/fileprivate split), then set the default access level to `internal`, as specified by [SE-0025](https://github.com/apple/swift-evolution/blob/master/proposals/0025-scoped-access-level.md#complications-with-private-types).

An "access scope" is the outermost DeclContext where a particular declaration may be referenced: for a `fileprivate` declaration it's the enclosing file, and for an `internal` declaration it's the module.
`public` corresponds to a scope of "everything", represented by a null DeclContext.

This model extends naturally to the (not-yet-implemented) SE-0025 notion of [`private`](https://github.com/apple/swift-evolution/blob/master/proposals/0025-scoped-access-level.md#proposed-solution), where the access scope is a declaration's immediately enclosing DeclContext.

Complicating this model is the revised rules that allow, e.g., a public declaration to be declared within an internal type. The access scope for this declaration is still just the module, not "everything".

This commit reworks formal access control checking in terms of this model, including tightening up some of the handling for `@testable`. This implements the rule that you must be able to access a declaration's type everywhere you can reference the declaration.

This was not intended to change compiler behavior, but in practice it has made cross-file dependency tracking a bit more conservative (unnecessarily), caught a mistake in diagnosing access violations, and fixed a fuzzer-based crasher (see test changes).

Progress on SE-0025 (`private` and `fileprivate`)

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
