### PR TITLE
build-script: support 4 version components in Clang versions

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -632,7 +632,7 @@ class BuildScriptInvocation(object):
             impl_args += ["--enable-ubsan"]
         if args.clang_compiler_version:
             impl_args += [
-                "--clang-compiler-version=%s.%s.%s" % (
+                "--clang-compiler-version=%s" % (
                     args.clang_compiler_version)
             ]
         if args.verbose_build:

--- a/utils/swift_build_support/swift_build_support/arguments.py
+++ b/utils/swift_build_support/swift_build_support/arguments.py
@@ -73,18 +73,33 @@ def type_shell_split(string):
 _register(type, 'shell_split', type_shell_split)
 
 
+class CompilerVersion(object):
+    """A typed representation of a compiler version."""
+
+    def __init__(self, string_representation, components):
+        self.string_representation = string_representation
+        self.components = components
+
+    def __str__(self):
+        return self.string_representation
+
+
 def type_clang_compiler_version(string):
     """
     Parse version string and split into a tuple of strings
     (major, minor, patch)
 
-    Support only "MAJOR.MINOR.PATCH" format.
+    Supports "MAJOR.MINOR.PATCH" and "MAJOR.MINOR.PATCH.PATCH" formats.
     """
-    m = re.match(r'^([0-9]+)\.([0-9]+)\.([0-9]+)$', string)
+    m = re.match(r'^([0-9]+)\.([0-9]+)\.([0-9]+)(\.([0-9]+))?$', string)
     if m is not None:
-        return m.group(1, 2, 3)
+        return CompilerVersion(
+            string_representation=string,
+            components=m.group(1, 2, 3, 5))
     raise argparse.ArgumentTypeError(
-        "%r is invalid version value. must be 'MAJOR.MINOR.PATCH'" % string)
+        "%r is an invalid version value, "
+        "must be 'MAJOR.MINOR.PATCH' or "
+        "'MAJOR.MINOR.PATCH.PATCH'" % string)
 
 _register(type, 'clang_compiler_version', type_clang_compiler_version)
 

--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -110,7 +110,7 @@ class CMake(object):
                    "Debug;Release;MinSizeRel;RelWithDebInfo")
 
         if args.clang_compiler_version:
-            major, minor, patch = args.clang_compiler_version
+            major, minor, patch, _ = args.clang_compiler_version.components
             define("LLVM_VERSION_MAJOR:STRING", major)
             define("LLVM_VERSION_MINOR:STRING", minor)
             define("LLVM_VERSION_PATCH:STRING", patch)

--- a/utils/swift_build_support/tests/test_arguments.py
+++ b/utils/swift_build_support/tests/test_arguments.py
@@ -49,8 +49,20 @@ class ArgumentsTypeTestCase(unittest.TestCase):
 
     def test_clang_compiler_version(self):
         self.assertEqual(
-            argtype.clang_compiler_version('1.23.456'),
-            ("1", "23", "456"))
+            argtype.clang_compiler_version('1.23.456').components,
+            ("1", "23", "456", None))
+        self.assertEqual(
+            argtype.clang_compiler_version('1.2.3').components,
+            ("1", "2", "3", None))
+        self.assertEqual(
+            argtype.clang_compiler_version('1.2.3.4').components,
+            ("1", "2", "3", "4"))
+        self.assertEqual(
+            argtype.clang_compiler_version('12.34.56').components,
+            ("12", "34", "56", None))
+        self.assertEqual(
+            argtype.clang_compiler_version('12.34.56.78').components,
+            ("12", "34", "56", "78"))
         self.assertRaises(
             argparse.ArgumentTypeError,
             argtype.clang_compiler_version,

--- a/utils/swift_build_support/tests/test_cmake.py
+++ b/utils/swift_build_support/tests/test_cmake.py
@@ -12,6 +12,7 @@ import os
 import unittest
 from argparse import Namespace
 
+from swift_build_support.arguments import CompilerVersion
 from swift_build_support.cmake import CMake, CMakeOptions
 from swift_build_support.toolchain import host_toolchain
 
@@ -132,7 +133,9 @@ class CMakeTestCase(unittest.TestCase):
 
     def test_common_options_clang_compiler_version(self):
         args = self.default_args()
-        args.clang_compiler_version = ("3", "8", "0")
+        args.clang_compiler_version = CompilerVersion(
+            string_representation="3.8.0",
+            components=("3", "8", "0", None))
         cmake = self.cmake(args)
         self.assertEqual(
             list(cmake.common_options()),
@@ -161,7 +164,9 @@ class CMakeTestCase(unittest.TestCase):
         args.export_compile_commands = True
         args.distcc = True
         args.cmake_generator = 'Xcode'
-        args.clang_compiler_version = ("3", "8", "0")
+        args.clang_compiler_version = CompilerVersion(
+            string_representation="3.8.0",
+            components=("3", "8", "0", None))
         args.build_ninja = True
         cmake = self.cmake(args)
         self.assertEqual(


### PR DESCRIPTION
<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
