### PR TITLE
[swiftc (68 vs. 5108)] Add crasher in swift::ArchetypeBuilder::finalize(...)

### DIFF
--- a/validation-test/compiler_crashers/28366-swift-archetypebuilder-finalize.swift
+++ b/validation-test/compiler_crashers/28366-swift-archetypebuilder-finalize.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+extension A{{}typealias e:f
+}protocol A{struct B<T where T.E=a
+typealias e


### PR DESCRIPTION
Add test case for crash triggered in `swift::ArchetypeBuilder::finalize(...)`.

Current number of unresolved compiler crashers: 68 (5108 resolved)

Assertion failure in [`lib/AST/ArchetypeBuilder.cpp (line 1686)`](https://github.com/apple/swift/blob/master/lib/AST/ArchetypeBuilder.cpp#L1686):

```
Assertion `dist > 0 && "nested type should have matched associated type"' failed.

When executing: swift::Identifier typoCorrectNestedType(ArchetypeBuilder::PotentialArchetype *)
```

Assertion context:

```
        continue;

      unsigned dist = name.edit_distance(assocType->getName().str(),
                                         /*allowReplacements=*/true,
                                         maxScore);
      assert(dist > 0 && "nested type should have matched associated type");
      if (bestEditDistance == 0 || dist == bestEditDistance) {
        bestEditDistance = dist;
        maxScore = bestEditDistance;
        bestMatches.push_back(assocType->getName());
      } else if (dist < bestEditDistance) {
```

Stack trace:

```
swift: /path/to/swift/lib/AST/ArchetypeBuilder.cpp:1686: swift::Identifier typoCorrectNestedType(ArchetypeBuilder::PotentialArchetype *): Assertion `dist > 0 && "nested type should have matched associated type"' failed.
8  swift           0x0000000000ff6e37 swift::ArchetypeBuilder::finalize(swift::SourceLoc) + 2231
9  swift           0x0000000000ef1ee7 swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 183
10 swift           0x0000000000ef2a1f swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) + 111
11 swift           0x0000000000eb32fb swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 363
16 swift           0x0000000000eb8936 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
17 swift           0x0000000000edaaf2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
18 swift           0x0000000000c66849 swift::CompilerInstance::performSema() + 3289
20 swift           0x00000000007d8bb9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
21 swift           0x00000000007a4bd8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28366-swift-archetypebuilder-finalize.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28366-swift-archetypebuilder-finalize-f3dc29.o
1.  While type-checking 'A' at validation-test/compiler_crashers/28366-swift-archetypebuilder-finalize.swift:11:2
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
