### PR TITLE
[Core Graphics] Rename several APIs to be more Swifty and consistent

### DIFF
--- a/apinotes/CoreGraphics.apinotes
+++ b/apinotes/CoreGraphics.apinotes
@@ -70,21 +70,23 @@ Functions:
 - Name: CGAffineTransformIsIdentity
   SwiftName: getter:CGAffineTransform.isIdentity(self:)
 - Name: CGAffineTransformTranslate
-  SwiftName: CGAffineTransform.translateBy(self:x:y:)
+  SwiftName: CGAffineTransform.translatedBy(self:x:y:)
 - Name: CGAffineTransformScale
-  SwiftName: CGAffineTransform.scaleBy(self:x:y:)
+  SwiftName: CGAffineTransform.scaledBy(self:x:y:)
 - Name: CGAffineTransformRotate
-  SwiftName: CGAffineTransform.rotate(self:_:)
+  SwiftName: CGAffineTransform.rotated(self:by:)
 - Name: CGAffineTransformConcat
-  SwiftName: CGAffineTransform.concat(self:_:)
+  SwiftName: CGAffineTransform.concatenating(self:_:)
+- Name: CGAffineTransformInvert
+  SwiftName: CGAffineTransform.inverted(self:)
 - Name: CGAffineTransformEqualToTransform
   SwiftName: CGAffineTransform.equalTo(self:_:)
 - Name: CGPointApplyAffineTransform
-  SwiftName: CGPoint.apply(self:transform:)
+  SwiftName: CGPoint.applying(self:_:)
 - Name: CGSizeApplyAffineTransform
-  SwiftName: CGSize.apply(self:transform:)
+  SwiftName: CGSize.applying(self:_:)
 - Name: CGRectApplyAffineTransform
-  SwiftName: CGRect.apply(self:transform:)
+  SwiftName: CGRect.applying(self:_:)
 # CGBitmapContext
 - Name: CGBitmapContextCreateWithData
   SwiftName: CGContext.init(data:width:height:bitsPerComponent:bytesPerRow:space:bitmapInfo:releaseCallback:releaseInfo:)
@@ -126,7 +128,7 @@ Functions:
 # - Name: CGColorCreateCopyWithAlpha
 #   SwiftName: CGColor.init(_:alpha:)
 - Name: CGColorCreateCopyByMatchingToColorSpace
-  SwiftName: CGColor.convert(_:intent:self:options:)
+  SwiftName: CGColor.converted(to:intent:self:options:)
 - Name: CGColorEqualToColor
   SwiftName: CGColor.equalTo(self:_:)
 # CGColorSpace
@@ -141,12 +143,14 @@ Functions:
 - Name: CGColorSpaceCopyICCProfile
   SwiftName: getter:CGColorSpace.iccData(self:)
 # CGContext
+- Name: CGContextConcatCTM
+  SwiftName: CGContext.concatenate(self:_:)
 - Name: CGContextScaleCTM
-  SwiftName: CGContext.scale(self:x:y:)
+  SwiftName: CGContext.scaleBy(self:x:y:)
 - Name: CGContextTranslateCTM
-  SwiftName: CGContext.translate(self:x:y:)
+  SwiftName: CGContext.translateBy(self:x:y:)
 - Name: CGContextRotateCTM
-  SwiftName: CGContext.rotate(self:byAngle:)
+  SwiftName: CGContext.rotate(self:by:)
 - Name: CGContextSetLineWidth
   SwiftName: CGContext.setLineWidth(self:_:)
 - Name: CGContextSetMiterLimit
@@ -206,9 +210,11 @@ Functions:
 - Name: CGContextGetClipBoundingBox
   SwiftName: getter:CGContext.boundingBoxOfClipPath(self:)
 - Name: CGContextClipToRect
-  SwiftName: CGContext.clipTo(self:_:)
+  SwiftName: CGContext.clip(self:to:)
 - Name: CGContextClipToRects
-  SwiftName: CGContext.clipTo(self:_:count:)
+  SwiftName: CGContext.clip(self:to:count:)
+- Name: CGContextClipToMask
+  SwiftName: CGContext.clip(self:to:mask:)
 - Name: CGContextSetFillColor
   SwiftName: CGContext.setFillColor(self:_:)
 - Name: CGContextSetFillColorWithColor
@@ -353,6 +359,8 @@ Functions:
   SwiftName: CGSize.equalTo(self:_:)
 - Name: CGRectEqualToRect
   SwiftName: CGRect.equalTo(self:_:)
+- Name: CGRectDivide
+  SwiftName: CGRect.divided(self:slice:remainder:atDistance:from:)
 # CGGradient
 # - Name: CGGradientCreateWithColorComponents
 #   SwiftName: CGGradient.init(colorComponentsSpace:components:locations:count:)
@@ -485,6 +493,8 @@ Globals:
   Availability: nonswift
 - Name: kCGColorSpaceGenericRGB
   Availability: nonswift
+- Name: kCGColorSpaceSRGB
+  SwiftName: CGColorSpace.sRGB
 
 #
 # Enums

--- a/stdlib/public/SDK/CoreGraphics/CoreGraphics.swift
+++ b/stdlib/public/SDK/CoreGraphics/CoreGraphics.swift
@@ -147,43 +147,13 @@ public extension CGRect {
   }
 
   @_transparent // @fragile
-  mutating func standardizeInPlace() {
-    self = standardized
-  }
-
-  @_transparent // @fragile
-  mutating func makeIntegralInPlace() {
-    self = integral
-  }
-
-  @_transparent // @fragile
-  mutating func insetInPlace(dx: CGFloat, dy: CGFloat) {
-    self = insetBy(dx: dx, dy: dy)
-  }
-
-  @_transparent // @fragile
-  mutating func offsetInPlace(dx: CGFloat, dy: CGFloat) {
-    self = offsetBy(dx: dx, dy: dy)
-  }
-
-  @_transparent // @fragile
-  mutating func formUnion(_ rect: CGRect) {
-    self = union(rect)
-  }
-
-  @_transparent // @fragile
-  mutating func formIntersection(_ rect: CGRect) {
-    self = intersection(rect)
-  }
-
-  @_transparent // @fragile
-  func divide(_ atDistance: CGFloat, fromEdge: CGRectEdge)
+  func divided(atDistance: CGFloat, from fromEdge: CGRectEdge)
     -> (slice: CGRect, remainder: CGRect)
   {
     var slice = CGRect.zero
     var remainder = CGRect.zero
-    divide(slice: &slice, remainder: &remainder, amount: atDistance,
-           edge: fromEdge)
+    divided(slice: &slice, remainder: &remainder, atDistance: atDistance,
+           from: fromEdge)
     return (slice, remainder)
   }
 }

--- a/test/1_stdlib/CGGeometry.swift
+++ b/test/1_stdlib/CGGeometry.swift
@@ -167,28 +167,28 @@ assert(unstandard.maxY == 20)
 assert(unstandard == standard)
 assert(unstandard.standardized == standard)
 
-unstandard.standardizeInPlace()
+unstandard = unstandard.standardized
 print_(unstandard, "standardized unstandard")
 // CHECK-NEXT: standardized unstandard -20.0 -30.0 30.0 50.0
 
 rect = CGRect(x: 11.25, y: 22.25, width: 33.25, height: 44.25)
 print_(rect.insetBy(dx: 1, dy: -2), "insetBy")
 // CHECK-NEXT: insetBy 12.25 20.25 31.25 48.25
-rect.insetInPlace(dx: 1, dy: -2)
+rect = rect.insetBy(dx: 1, dy: -2)
 print_(rect, "insetInPlace")
 // CHECK-NEXT: insetInPlace 12.25 20.25 31.25 48.25
 
 rect = CGRect(x: 11.25, y: 22.25, width: 33.25, height: 44.25)
 print_(rect.offsetBy(dx: 3, dy: -4), "offsetBy")
 // CHECK-NEXT: offsetBy 14.25 18.25 33.25 44.25
-rect.offsetInPlace(dx: 3, dy: -4)
+rect = rect.offsetBy(dx: 3, dy: -4)
 print_(rect, "offsetInPlace")
 // CHECK-NEXT: offsetInPlace 14.25 18.25 33.25 44.25
 
 rect = CGRect(x: 11.25, y: 22.25, width: 33.25, height: 44.25)
 print_(rect.integral, "integral")
 // CHECK-NEXT: integral 11.0 22.0 34.0 45.0
-rect.makeIntegralInPlace()
+rect = rect.integral
 print_(rect, "makeIntegralInPlace")
 // CHECK-NEXT: makeIntegralInPlace 11.0 22.0 34.0 45.0
 
@@ -203,9 +203,9 @@ print_(rect.union(distantRect), "union distant")
 // CHECK-NEXT: union small 10.0 20.0 34.5 46.5
 // CHECK-NEXT: union big 1.0 2.0 101.0 102.0
 // CHECK-NEXT: union distant 11.25 22.25 989.75 1978.75
-rect.formUnion(smallRect)
-rect.formUnion(bigRect)
-rect.formUnion(distantRect)
+rect = rect.union(smallRect)
+rect = rect.union(bigRect)
+rect = rect.union(distantRect)
 print_(rect, "formUnion")
 // CHECK-NEXT: formUnion 1.0 2.0 1000.0 1999.0
 
@@ -217,13 +217,13 @@ print_(rect.intersection(distantRect), "intersect distant")
 // CHECK-NEXT: intersect big 11.25 22.25 33.25 44.25
 // CHECK-NEXT: intersect distant inf inf 0.0 0.0
 assert(rect.intersects(smallRect))
-rect.formIntersection(smallRect)
+rect = rect.intersection(smallRect)
 assert(!rect.isEmpty)
 assert(rect.intersects(bigRect))
-rect.formIntersection(bigRect)
+rect = rect.intersection(bigRect)
 assert(!rect.isEmpty)
 assert(!rect.intersects(distantRect))
-rect.formIntersection(distantRect)
+rect = rect.intersection(distantRect)
 assert(rect.isEmpty)
 
 
@@ -235,7 +235,7 @@ assert(!rect.contains(bigRect))
 
 
 rect = CGRect(x: 11.25, y: 22.25, width: 33.25, height: 44.25)
-var (slice, remainder) = rect.divide(5, fromEdge:CGRectEdge.minXEdge)
+var (slice, remainder) = rect.divided(atDistance: 5, from:CGRectEdge.minXEdge)
 print_(slice, "slice")
 print_(remainder, "remainder")
 // CHECK-NEXT: slice 11.25 22.25 5.0 44.25

--- a/test/ClangModules/CoreGraphics_test.swift
+++ b/test/ClangModules/CoreGraphics_test.swift
@@ -1,24 +1,27 @@
-// RUN: %target-swift-frontend -emit-ir -O %s | FileCheck %s
+// RUN: %target-swift-frontend -target x86_64-apple-macosx10.11 -emit-ir -O %s | FileCheck %s
 
 // Test some imported CG APIs
 import CoreGraphics
 
 // REQUIRES: OS=macosx
 
+// CHECK-LABEL: define void {{.*}}rotationAround{{.*}} {
 // Get a transform that will rotate around a given offset
 public func rotationAround(offset: CGPoint, angle: CGFloat,
         transform: CGAffineTransform = .identity) -> CGAffineTransform {
   // FIXME: consistent API namings
-  return transform.translateBy(x: offset.x, y: offset.y)
-                  .rotate(angle)
-                  .translateBy(x: -offset.x, y: -offset.y)
+  return transform.translatedBy(x: offset.x, y: offset.y)
+                  .rotated(by: angle)
+                  .translatedBy(x: -offset.x, y: -offset.y)
 
 // CHECK:   call void @CGAffineTransformTranslate(%{{.*}}.CGAffineTransform* {{.*}}, %{{.*}}.CGAffineTransform* {{.*}},{{.*}}, {{.*}})
 // CHECK:   call void @CGAffineTransformRotate(%{{.*}}.CGAffineTransform* {{.*}}, %{{.*}}.CGAffineTransform* {{.*}},{{.*}})
 // CHECK:   call void @CGAffineTransformTranslate(%{{.*}}.CGAffineTransform* {{.*}}, %{{.*}}.CGAffineTransform* {{.*}},{{.*}}, {{.*}})
+//
+// CHECK:   ret void
 }
 
-// Trace a path in red
+// CHECK-LABEL: define void {{.*}}trace{{.*}} {
 public func trace(in context: CGContext, path: CGPath) {
   let red = CGColor(red: 1, green: 0, blue: 0, alpha: 1)
   context.saveGState()
@@ -32,8 +35,11 @@ public func trace(in context: CGContext, path: CGPath) {
 // CHECK:   call void @CGContextSetStrokeColorWithColor(%{{.*}}.CGContext* %{{.*}}, %{{.*}}.CGColor* %{{.*}})
 // CHECK:   call void @CGContextStrokePath(%{{.*}}.CGContext* %{{.*}})
 // CHECK:   call void @CGContextRestoreGState(%{{.*}}.CGContext* %{{.*}})
+//
+// CHECK:   ret void
 }
 
+// CHECK-LABEL: define void {{.*}}pdfOperations{{.*}} {
 public func pdfOperations(_ context: CGContext) {
 	context.beginPDFPage(nil)
 	context.endPDFPage()
@@ -41,6 +47,65 @@ public func pdfOperations(_ context: CGContext) {
 // CHECK:   call void @CGPDFContextBeginPage(%{{.*}}.CGContext* %{{.*}}, %{{.*}}.__CFDictionary* {{.*}})
 // CHECK:   call void @CGPDFContextEndPage(%{{.*}}.CGContext* %{{.*}})
 // CHECK:   call void @CGPDFContextClose(%{{.*}}.CGContext* %{{.*}})
+//
+// CHECK:   ret void
+}
 
+// Test some more recently renamed APIs
+
+// CHECK-LABEL: define void {{.*}}testColorRenames{{.*}} {
+public func testColorRenames(color: CGColor,
+                             intent: CGColorRenderingIntent) {
+  let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
+// CHECK:   %{{.*}} = load {{.*}}%struct.__CFString** @kCGColorSpaceSRGB {{.*}}, align 8
+// CHECK:   %{{.*}} = {{.*}} call %struct.CGColorSpace* @CGColorSpaceCreateWithName(%struct.__CFString* %{{.*}})
+
+  let _ = color.converted(to: colorSpace, intent: intent, options: nil)
+// CHECK:   %{{.*}} = {{.*}} call %struct.CGColor* @CGColorCreateCopyByMatchingToColorSpace(%struct.CGColorSpace* %{{.*}}, i32 %{{.*}}, %struct.CGColor* %{{.*}}, %struct.__CFDictionary* null)
+//
+// CHECK:   ret void
+}
+
+// CHECK-LABEL: define void {{.*}}testRenames{{.*}} {
+public func testRenames(transform: CGAffineTransform, context: CGContext,
+                        point: CGPoint, size: CGSize, rect: CGRect,
+                        image: CGImage,
+                        edge: CGRectEdge) {
+  let transform = transform.inverted().concatenating(transform)
+// CHECK:   call void @CGAffineTransformInvert(%struct.CGAffineTransform* {{.*}}, %struct.CGAffineTransform* {{.*}})
+// CHECK:   call void @CGAffineTransformConcat(%struct.CGAffineTransform* {{.*}}, %struct.CGAffineTransform* {{.*}}, %struct.CGAffineTransform* {{.*}})
+
+  let _ = point.applying(transform)
+  var rect = rect.applying(transform)
+  let _ = size.applying(transform)
+// CHECK:   %{{.*}} = call { double, double } @CGPointApplyAffineTransform(double %{{.*}}, double %{{.*}}, %struct.CGAffineTransform* {{.*}})
+// CHECK:   call void @CGRectApplyAffineTransform(%struct.CGRect* {{.*}}, %struct.CGRect* {{.*}}, %struct.CGAffineTransform* {{.*}})
+// CHECK:   %{{.*}} = call { double, double } @CGSizeApplyAffineTransform(double %{{.*}}, double %{{.*}}, %struct.CGAffineTransform* {{.*}})
+
+  context.concatenate(transform)
+  context.rotate(by: CGFloat.pi)
+  context.scaleBy(x: 1.0, y: 1.0)
+  context.translateBy(x: 1.0, y: 1.0)
+// CHECK:   call void @CGContextConcatCTM(%struct.CGContext* [[CONTEXT:%[0-9]+]], %struct.CGAffineTransform* {{.*}})
+// CHECK:   call void @CGContextRotateCTM(%struct.CGContext* [[CONTEXT]], double {{.*}})
+// CHECK:   call void @CGContextScaleCTM(%struct.CGContext* [[CONTEXT]], double {{1\.0+.*}}, double {{1\.0+.*}})
+// CHECK:   call void @CGContextTranslateCTM(%struct.CGContext* [[CONTEXT]], double {{1\.0+.*}}, double {{1\.0+.*}})
+
+  context.clip(to: rect)
+  context.clip(to: &rect, count: 2)
+  context.clip(to: rect, mask: image)
+// CHECK:   call void @CGContextClipToRect(%struct.CGContext* [[CONTEXT]], %struct.CGRect* byval nonnull align 8 %{{.*}})
+// CHECK:   call void @CGContextClipToRects(%struct.CGContext* [[CONTEXT]], %struct.CGRect* nonnull %rect, i64 2)
+// CHECK:   call void @CGContextClipToMask(%struct.CGContext* [[CONTEXT]], %struct.CGRect* byval nonnull align 8 %{{.*}}, %struct.CGImage* %{{.*}})
+
+  var slice = CGRect.zero
+  var remainder = CGRect.zero
+  rect.divided(slice: &slice, remainder: &remainder, atDistance: CGFloat(2.0),
+          from: edge)
+  assert((slice, remainder) == rect.divided(atDistance: CGFloat(2.0),
+                                            from: edge))
+// CHECK:   call void @CGRectDivide(%struct.CGRect* byval nonnull align 8 %{{.*}}, %struct.CGRect* nonnull %slice, %struct.CGRect* nonnull %remainder, double {{2\.0+.*}}, i32 %{{.*}})
+//
+// CHECK:   ret void
 }
 


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

This renames several APIs off of CGAffineTransform, CGPoint, CGSize,
CGColor, CGContext, CGRect, and CGColorSpace to have more consistent
names and Swifty names, in accordance with the Swift API Design
Guidelines.

At the same time, we drop many of the special mutating variants from
the overlays, as they are not typical CG usage and a historical
artifact. Test cases added for each.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

This renames several APIs off of CGAffineTransform, CGPoint, CGSize,
CGColor, CGContext, CGRect, and CGColorSpace to have more consistent
names and Swifty names, in accordance with the Swift API Design
Guidelines.

At the same time, we drop many of the special mutating variants from
the overlays, as they are not typical CG usage and a historical
artifact. Test cases added for each.
