### PR TITLE
Generic implementations of math functions implementable on FloatingPoint

### DIFF
--- a/stdlib/public/Platform/tgmath.swift.gyb
+++ b/stdlib/public/Platform/tgmath.swift.gyb
@@ -10,6 +10,52 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Generic functions implementable directly on FloatingPoint.
+@_transparent
+public func fabs<T: FloatingPoint>(_ x: T) -> T {
+  return abs(x)
+}
+
+@_transparent
+public func sqrt<T: FloatingPoint>(_ x: T) -> T {
+  return x.squareRoot()
+}
+
+@_transparent
+public func fma<T: FloatingPoint>(_ x: T, _ y: T, _ z: T) -> T {
+  return z.addingProduct(x,y)
+}
+
+@_transparent
+public func remainder<T: FloatingPoint>(_ x: T, _ y: T) -> T {
+  return x.remainder(dividingBy: y)
+}
+
+@_transparent
+public func fmod<T: FloatingPoint>(_ x: T, _ y: T) -> T {
+  return x.truncatingRemainder(dividingBy: y)
+}
+
+@_transparent
+public func ceil<T: FloatingPoint>(_ x: T) -> T {
+  return x.rounded(.up)
+}
+
+@_transparent
+public func floor<T: FloatingPoint>(_ x: T) -> T {
+  return x.rounded(.down)
+}
+
+@_transparent
+public func round<T: FloatingPoint>(_ x: T) -> T {
+  return x.rounded()
+}
+
+@_transparent
+public func trunc<T: FloatingPoint>(_ x: T) -> T {
+  return x.rounded(.towardZero)
+}
+
 %{
 
 # Don't need 64-bit (Double/CDouble) overlays. The ordinary C imports work fine.
@@ -50,7 +96,7 @@ UnaryFunctions = [
     'acosh', 'asinh', 'atanh', 'cosh', 'sinh', 'tanh',
     'expm1',
     'log1p', 'logb',
-    'cbrt', 'sqrt', 'erf', 'erfc', 'tgamma',
+    'cbrt', 'erf', 'erfc', 'tgamma',
 ]
 
 # These functions have a corresponding LLVM intrinsic
@@ -60,14 +106,13 @@ UnaryIntrinsicFunctions = [
     'cos', 'sin',
     'exp', 'exp2',
     'log', 'log10', 'log2',
-    'fabs',
-    'ceil', 'floor', 'nearbyint', 'rint', 'round', 'trunc',
+    'nearbyint', 'rint',
 ]
 
 # (T, T) -> T
 BinaryFunctions = [
-    'atan2', 'hypot', 'pow', 'fmod',
-    'remainder', 'copysign', 'nextafter', 'fdim', 'fmax', 'fmin'
+    'atan2', 'hypot', 'pow',
+    'copysign', 'nextafter', 'fdim', 'fmax', 'fmin'
 ]
 
 # These functions have special implementations.
@@ -75,7 +120,7 @@ OtherFunctions = [
     'fpclassify',
     'isnormal', 'isfinite', 'isinf', 'isnan', 'signbit',
     'modf', 'ldexp', 'frexp', 'ilogb', 'scalbn', 'lgamma',
-    'remquo', 'nan', 'fma',
+    'remquo', 'nan',
     'jn', 'yn'
 ]
 
@@ -116,7 +161,6 @@ def TypedBinaryFunctions():
             yield floatName(bits), cFloatName(bits), cFuncSuffix(bits), bfunc
 
 }%
-
 
 // Unary functions
 // Note these do not have a corresponding LLVM intrinsic
@@ -315,14 +359,6 @@ public func remquo(_ x: ${T}, _ y: ${T}) -> (${T}, Int) {
 @_transparent
 public func nan(_ tag: String) -> ${T} {
   return ${T}(nan${f}(tag))
-}
-
-% end
-
-% for T, CT, f in OverlayFloatTypes():
-@_transparent
-public func fma(_ x: ${T}, _ y: ${T}, _ z: ${T}) -> ${T} {
-  return ${T}(fma${f}(${CT}(x), ${CT}(y), ${CT}(z)))
 }
 
 % end

--- a/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
@@ -606,26 +606,6 @@ public func tgamma(_ x: CGFloat) -> CGFloat {
 }
 
 @_transparent
-public func fabs(_ x: CGFloat) -> CGFloat {
-  return CGFloat(fabs(x.native))
-}
-
-@_transparent
-public func sqrt(_ x: CGFloat) -> CGFloat {
-  return CGFloat(sqrt(x.native))
-}
-
-@_transparent
-public func ceil(_ x: CGFloat) -> CGFloat {
-  return CGFloat(ceil(x.native))
-}
-
-@_transparent
-public func floor(_ x: CGFloat) -> CGFloat {
-  return CGFloat(floor(x.native))
-}
-
-@_transparent
 public func nearbyint(_ x: CGFloat) -> CGFloat {
   return CGFloat(nearbyint(x.native))
 }
@@ -633,16 +613,6 @@ public func nearbyint(_ x: CGFloat) -> CGFloat {
 @_transparent
 public func rint(_ x: CGFloat) -> CGFloat {
   return CGFloat(rint(x.native))
-}
-
-@_transparent
-public func round(_ x: CGFloat) -> CGFloat {
-  return CGFloat(round(x.native))
-}
-
-@_transparent
-public func trunc(_ x: CGFloat) -> CGFloat {
-  return CGFloat(trunc(x.native))
 }
 
 @_transparent
@@ -658,16 +628,6 @@ public func hypot(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
 @_transparent
 public func pow(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
   return CGFloat(pow(lhs.native, rhs.native))
-}
-
-@_transparent
-public func fmod(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
-  return CGFloat(fmod(lhs.native, rhs.native))
-}
-
-@_transparent
-public func remainder(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
-  return CGFloat(remainder(lhs.native, rhs.native))
 }
 
 @_transparent
@@ -758,11 +718,6 @@ public func remquo(_ x: CGFloat, _ y: CGFloat) -> (CGFloat, Int) {
 @_transparent
 public func nan(_ tag: String) -> CGFloat {
   return CGFloat(nan(tag) as CGFloat.NativeType)
-}
-
-@_transparent
-public func fma(_ x: CGFloat, _ y: CGFloat, _ z: CGFloat) -> CGFloat {
-  return CGFloat(fma(x.native, y.native, z.native))
 }
 
 @_transparent

--- a/stdlib/public/core/BuiltinMath.swift.gyb
+++ b/stdlib/public/core/BuiltinMath.swift.gyb
@@ -49,8 +49,7 @@ UnaryIntrinsicFunctions = [
     'cos', 'sin',
     'exp', 'exp2',
     'log', 'log10', 'log2',
-    'fabs',
-    'ceil', 'floor', 'nearbyint', 'rint', 'round', 'trunc',
+    'nearbyint', 'rint',
 ]
 
 def TypedUnaryIntrinsicFunctions():

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -573,11 +573,6 @@ public func ${op[0]}=<T : FloatingPoint>(lhs: inout T, rhs: T) {
 %end
 
 @_transparent
-public func sqrt<T : FloatingPoint>(_ rhs: T) -> T {
-  return rhs.squareRoot()
-}
-
-@_transparent
 public func ==<T : FloatingPoint>(lhs: T, rhs: T) -> Bool {
   return lhs.isEqual(to: rhs)
 }


### PR DESCRIPTION
#### What's in this pull request?

Replace the non-generic tgmath functions with generic `<T: FloatingPoint>`
implementations where possible, and move the global `sqrt()` operation
into `tgmath`.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
