### PR TITLE
stdlib: repair windows build

### DIFF
--- a/stdlib/public/stubs/CommandLine.cpp
+++ b/stdlib/public/stubs/CommandLine.cpp
@@ -90,8 +90,7 @@ extern "C" char ** _swift_stdlib_getUnsafeArgvArgc(int *outArgLen) {
   return outBuf;
 }
 #elif defined (_MSC_VER)
-extern int *__argc;
-extern char **__argv;
+#include <stdlib.h>
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" char ** _swift_stdlib_getUnsafeArgvArgc(int *outArgLen) {


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

When building for a pure windows environment, we build against a newer CRT which
does not provide direct access to __argc, __argv.  They are hidden behind
macros which use a function call.  Use the header (stdlib) to get access to
these rather than declaring them extern.  This also makes the swift runtime more
portable across various Windows environments.

From stdlib.h in ucrt 10.0.10586.0:
  #ifdef _CRT_DECLARE_GLOBAL_VARIABLES_DIRECTLY
    extern int __argc;
    extern char*\* __argv;
  #else
    #define __argc (___p___argc())
    #define __argv (___p___argv())
  #endif

The indirection is particularly nice on COFF where all module external variables
are indirectly addressed.
