### PR TITLE
[IRGen] Use hidden visibility for __swift_reflection_version constant

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -938,5 +938,6 @@ void IRGenModule::emitReflectionMetadataVersion() {
                                           llvm::GlobalValue::LinkOnceODRLinkage,
                                           Init,
                                           "__swift_reflection_version");
+  Version->setVisibility(llvm::GlobalValue::HiddenVisibility);
   addUsedGlobal(Version);
 }

--- a/test/IRGen/reflection_metadata.swift
+++ b/test/IRGen/reflection_metadata.swift
@@ -22,6 +22,7 @@
 
 // STRIP_REFLECTION_METADATA-NOT: @"\01l__swift3_reflection_metadata"
 
+// CHECK-DAG: @__swift_reflection_version = linkonce_odr hidden constant i16 {{[0-9]+}}
 // CHECK-DAG: private constant [2 x i8] c"i\00", section "{{[^"]*}}swift3_reflstr{{[^"]*}}"
 // CHECK-DAG: private constant [3 x i8] c"ms\00", section "{{[^"]*}}swift3_reflstr{{[^"]*}}"
 // CHECK-DAG: private constant [3 x i8] c"me\00", section "{{[^"]*}}swift3_reflstr{{[^"]*}}"


### PR DESCRIPTION
This prevents it from having weak external linkage.

rdar://problem/27367632
