### PR TITLE
[Diag] Fixits for missing protocol requirements

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -274,6 +274,20 @@ public:
   void printText(StringRef Text) override;
 };
 
+/// AST stream printer that adds extra indentation to each line.
+class ExtraIndentStreamPrinter : public StreamPrinter {
+  StringRef ExtraIndent;
+
+public:
+  ExtraIndentStreamPrinter(raw_ostream &out, StringRef extraIndent)
+  : StreamPrinter(out), ExtraIndent(extraIndent) { }
+
+  virtual void printIndent() {
+    printText(ExtraIndent);
+    StreamPrinter::printIndent();
+  }
+};
+
 bool shouldPrint(const Decl *D, PrintOptions &Options);
 bool shouldPrintPattern(const Pattern *P, PrintOptions &Options);
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1251,7 +1251,8 @@ NOTE(inherited_protocol_does_not_conform,none,
      "type %0 does not conform to inherited protocol %1", (Type, Type))
 NOTE(no_witnesses,none,
      "protocol requires %select{initializer %1|function %1|property %1|"
-     "subscript}0 with type %2", (RequirementKind, DeclName, Type))
+     "subscript}0 with type %2; do you want to add a stub?",
+     (RequirementKind, DeclName, Type))
 NOTE(ambiguous_witnesses,none,
      "multiple matching "
      "%select{initializers named %1|functions named %1|properties named %1|"
@@ -1261,7 +1262,7 @@ NOTE(ambiguous_witnesses_wrong_name,none,
      "%select{initializers named %1|functions named %1|properties named %1|"
      "subscript operators}0 with type %2", (RequirementKind, DeclName, Type))
 NOTE(no_witnesses_type,none,
-     "protocol requires nested type %0", (Identifier))
+     "protocol requires nested type %0; do you want to add it?", (Identifier))
 NOTE(default_associated_type_req_fail,none,
      "default type %0 for associated type %1 (from protocol %2) "
      "does not conform to %3",

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -28,6 +28,7 @@ class NominalTypeDecl;
 class TypeBase;
 class DeclContext;
 class Type;
+class ModuleDecl;
 enum DeclAttrKind : unsigned;
 class PrinterTypeTransformer;
 class SynthesizedExtensionAnalyzer;
@@ -305,8 +306,17 @@ struct PrintOptions {
   /// \brief Print types with alternative names from their canonical names.
   llvm::DenseMap<CanType, Identifier> *AlternativeTypeNames = nullptr;
 
+  /// \brief The module in which the printer is used. Determines if the module
+  /// name should be printed when printing a type.
+  ModuleDecl *CurrentModule;
+
   /// \brief The information for converting archetypes to specialized types.
   std::shared_ptr<TypeTransformContext> TransformContext;
+
+  /// \brief If this is not \c nullptr then functions (incuding accessors and
+  /// constructors) will be printed with a body that is determined by this
+  /// function.
+  std::function<std::string(const ValueDecl *)> FunctionBody;
 
   BracketOptions BracketOptions;
 
@@ -360,6 +370,8 @@ struct PrintOptions {
   void setArchetypeSelfTransform(Type T, DeclContext *DC);
 
   void setArchetypeSelfTransformForQuickHelp(Type T, DeclContext *DC);
+
+  void setArchetypeAndDynamicSelfTransform(Type T, DeclContext *DC);
 
   void initArchetypeTransformerForSynthesizedExtensions(NominalTypeDecl *D,
                                     SynthesizedExtensionAnalyzer *SynAnalyzer);

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -29,21 +29,21 @@ class TypeBase;
 class DeclContext;
 class Type;
 enum DeclAttrKind : unsigned;
-class PrinterArchetypeTransformer;
+class PrinterTypeTransformer;
 class SynthesizedExtensionAnalyzer;
 struct PrintOptions;
 
 /// Necessary information for archetype transformation during printing.
-struct ArchetypeTransformContext {
+struct TypeTransformContext {
   Type getTypeBase();
   NominalTypeDecl *getNominal();
-  PrinterArchetypeTransformer *getTransformer();
+  PrinterTypeTransformer *getTransformer();
   bool isPrintingSynthesizedExtension();
   bool isPrintingTypeInterface();
-  ArchetypeTransformContext(PrinterArchetypeTransformer *Transformer);
-  ArchetypeTransformContext(PrinterArchetypeTransformer *Transformer,
+  TypeTransformContext(PrinterTypeTransformer *Transformer);
+  TypeTransformContext(PrinterTypeTransformer *Transformer,
                             Type T);
-  ArchetypeTransformContext(PrinterArchetypeTransformer *Transformer,
+  TypeTransformContext(PrinterTypeTransformer *Transformer,
                             NominalTypeDecl *NTD,
                             SynthesizedExtensionAnalyzer *Analyzer);
   Type transform(Type Input);
@@ -51,7 +51,7 @@ struct ArchetypeTransformContext {
 
   bool shouldPrintRequirement(ExtensionDecl *ED, StringRef Req);
 
-  ~ArchetypeTransformContext();
+  ~TypeTransformContext();
 private:
   struct Implementation;
   Implementation &Impl;
@@ -306,7 +306,7 @@ struct PrintOptions {
   llvm::DenseMap<CanType, Identifier> *AlternativeTypeNames = nullptr;
 
   /// \brief The information for converting archetypes to specialized types.
-  std::shared_ptr<ArchetypeTransformContext> TransformContext;
+  std::shared_ptr<TypeTransformContext> TransformContext;
 
   BracketOptions BracketOptions;
 
@@ -357,9 +357,9 @@ struct PrintOptions {
 
   static PrintOptions printTypeInterface(Type T, DeclContext *DC);
 
-  void setArchetypeTransform(Type T, DeclContext *DC);
+  void setArchetypeSelfTransform(Type T, DeclContext *DC);
 
-  void setArchetypeTransformForQuickHelp(Type T, DeclContext *DC);
+  void setArchetypeSelfTransformForQuickHelp(Type T, DeclContext *DC);
 
   void initArchetypeTransformerForSynthesizedExtensions(NominalTypeDecl *D,
                                     SynthesizedExtensionAnalyzer *SynAnalyzer);

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2636,8 +2636,6 @@ void PrintAST::visitFuncDecl(FuncDecl *decl) {
     case AccessorKind::IsAddressor:
       recordDeclLoc(decl,
         [&]{
-          if (decl->isMutating())
-            Printer << "mutating ";
           Printer << (kind == AccessorKind::IsGetter
                         ? "get" : getAddressorLabel(decl));
         });
@@ -2648,8 +2646,6 @@ void PrintAST::visitFuncDecl(FuncDecl *decl) {
     case AccessorKind::IsMutableAddressor:
       recordDeclLoc(decl,
         [&]{
-          if (decl->isExplicitNonMutating())
-            Printer << "nonmutating ";
           Printer << (kind == AccessorKind::IsDidSet ? "didSet" :
                       kind == AccessorKind::IsMaterializeForSet
                         ? "materializeForSet"
@@ -2661,8 +2657,6 @@ void PrintAST::visitFuncDecl(FuncDecl *decl) {
     case AccessorKind::IsWillSet:
       recordDeclLoc(decl,
         [&]{
-          if (decl->isExplicitNonMutating())
-            Printer << "nonmutating ";
           Printer << (decl->isSetter() ? "set" : "willSet");
 
           auto params = decl->getParameterLists().back();

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -4049,7 +4049,7 @@ public:
       DeclNameOffsetLocatorPrinter Printer(OS);
       PrintOptions Options;
       if (auto transformType = CurrDeclContext->getDeclaredTypeInContext())
-        Options.setArchetypeTransform(transformType, VD->getDeclContext());
+        Options.setArchetypeSelfTransform(transformType, VD->getDeclContext());
       Options.PrintDefaultParameterPlaceholder = false;
       Options.PrintImplicitAttrs = false;
       Options.ExclusiveAttrList.push_back(DAK_NoReturn);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7148,22 +7148,6 @@ static void diagnoseClassWithoutInitializers(TypeChecker &tc,
   }
 }
 
-namespace {
-  /// AST stream printer that adds extra indentation to each line.
-  class ExtraIndentStreamPrinter : public StreamPrinter {
-    StringRef ExtraIndent;
-
-  public:
-    ExtraIndentStreamPrinter(raw_ostream &out, StringRef extraIndent)
-    : StreamPrinter(out), ExtraIndent(extraIndent) { }
-
-    virtual void printIndent() {
-      printText(ExtraIndent);
-      StreamPrinter::printIndent();
-    }
-  };
-}
-
 /// Diagnose a missing required initializer.
 static void diagnoseMissingRequiredInitializer(
               TypeChecker &TC,

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1509,8 +1509,7 @@ static void addAssocTypeDeductionString(llvm::SmallString<128> &str,
 }
 
 /// Clean up the given declaration type for display purposes.
-static Type getTypeForDisplay(TypeChecker &tc, Module *module,
-                              ValueDecl *decl) {
+static Type getTypeForDisplay(Module *module, ValueDecl *decl) {
   // If we're not in a type context, just grab the interface type.
   Type type = decl->getInterfaceType();
   if (!decl->getDeclContext()->isTypeContext() ||
@@ -1543,7 +1542,7 @@ static Type getTypeForDisplay(TypeChecker &tc, Module *module,
 static Type getRequirementTypeForDisplay(TypeChecker &tc, Module *module,
                                          NormalProtocolConformance *conformance,
                                          ValueDecl *req) {
-  auto type = getTypeForDisplay(tc, module, req);
+  auto type = getTypeForDisplay(module, req);
 
   // Replace generic type parameters and associated types with their
   // witnesses, when we have them.
@@ -1737,7 +1736,7 @@ diagnoseMatch(TypeChecker &tc, Module *module,
 
   case MatchKind::TypeConflict: {
     auto diag = tc.diagnose(match.Witness, diag::protocol_witness_type_conflict,
-                            getTypeForDisplay(tc, module, match.Witness),
+                            getTypeForDisplay(module, match.Witness),
                             withAssocTypes);
     if (!isa<TypeDecl>(req))
       fixItOverrideDeclarationTypes(tc, diag, match.Witness, req);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -22,6 +22,7 @@
 #include "swift/Basic/StringExtras.h"
 #include "swift/AST/ArchetypeBuilder.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/ASTPrinter.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/ReferencedNameTracker.h"
@@ -1988,6 +1989,77 @@ void ConformanceChecker::recordTypeWitness(AssociatedTypeDecl *assocType,
     typeDecl);
 }
 
+/// Generates a note for a protocol requirement for which no witness was found
+/// and provides a fixit to add a stub to the adopter
+static void diagnoseNoWitness(ValueDecl *Requirement, Type RequirementType,
+                              NormalProtocolConformance *Conformance,
+                              TypeChecker &TC) {
+  SourceLoc FixitLocation;
+  SourceLoc TypeLoc;
+  if (auto Extension = dyn_cast<ExtensionDecl>(Conformance->getDeclContext())) {
+    FixitLocation = Extension->getBraces().Start.getAdvancedLocOrInvalid(1);
+    TypeLoc = Extension->getStartLoc();
+  } else if (auto Nominal =
+               dyn_cast<NominalTypeDecl>(Conformance->getDeclContext())) {
+    FixitLocation = Nominal->getBraces().Start.getAdvancedLocOrInvalid(1);
+    TypeLoc = Nominal->getStartLoc();
+  } else {
+    llvm_unreachable("Unknown adopter kind");
+  }
+
+  // FIXME: Infer body indention from the source rather than hard-coding
+  // 4 spaces.
+  std::string ExtraIndent = "    ";
+  StringRef CurrentIndent = Lexer::getIndentationForLine(TC.Context.SourceMgr,
+                                                         TypeLoc);
+  std::string StubIndent = CurrentIndent.str() + ExtraIndent;
+
+  std::string FixitString;
+  llvm::raw_string_ostream FixitStream(FixitString);
+  ExtraIndentStreamPrinter Printer(FixitStream, StubIndent);
+
+  if (auto MissingTypeWitness = dyn_cast<AssociatedTypeDecl>(Requirement)) {
+    Printer.printNewline();
+    Printer << "typealias " << MissingTypeWitness->getName() << " = <#type#>";
+    Printer << "\n";
+
+    TC.diagnose(MissingTypeWitness, diag::no_witnesses_type,
+                MissingTypeWitness->getName())
+      .fixItInsert(FixitLocation, FixitStream.str());
+  } else {
+
+    PrintOptions Options = PrintOptions::printForDiagnostics();
+    Options.AccessibilityFilter = Accessibility::Private;
+    Options.FunctionBody = [](const ValueDecl *VD) { return "<#code#>"; };
+    if (isa<ClassDecl>(Conformance->getDeclContext())) {
+      Type SelfType = Conformance->getDeclContext()->getSelfTypeInContext();
+      DeclContext *Adopter = Conformance->getDeclContext();
+      Options.setArchetypeSelfTransform(SelfType, Adopter);
+    } else {
+      Type SelfType = Conformance->getDeclContext()->getSelfTypeInContext();
+      DeclContext *Adopter = Conformance->getDeclContext();
+      Options.setArchetypeAndDynamicSelfTransform(SelfType, Adopter);
+    }
+    Options.CurrentModule = Conformance->getDeclContext()->getParentModule();
+    if (isa<NominalTypeDecl>(Conformance->getDeclContext())) {
+      // Create a variable declaration instead of a computed property in nominal
+      // types
+      Options.PrintPropertyAccessors = false;
+    }
+
+    Printer.printNewline();
+    Requirement->print(Printer, Options);
+    Printer << "\n";
+
+    // Point out the requirement that wasn't met.
+    TC.diagnose(Requirement, diag::no_witnesses,
+                            getRequirementKind(Requirement),
+                            Requirement->getFullName(),
+                            RequirementType)
+      .fixItInsert(FixitLocation, FixitStream.str());
+  }
+}
+
 ResolveWitnessResult
 ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
   assert(!isa<AssociatedTypeDecl>(requirement) && "Use resolveTypeWitnessVia*");
@@ -2292,24 +2364,26 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
       Type reqType = getRequirementTypeForDisplay(tc, dc->getParentModule(),
                                                   conformance, requirement);
 
-      // Point out the requirement that wasn't met.
-      tc.diagnose(requirement,
-                  numViable > 0 ? (ignoringNames
-                                   ? diag::ambiguous_witnesses_wrong_name
-                                   : diag::ambiguous_witnesses)
-                                : diag::no_witnesses,
-                  getRequirementKind(requirement),
-                  requirement->getFullName(),
-                  reqType);
+      if (numViable > 0) {
+        auto diagnosticMessage = diag::ambiguous_witnesses;
+        if (ignoringNames) {
+          diagnosticMessage = diag::ambiguous_witnesses_wrong_name;
+        }
+        tc.diagnose(requirement, diagnosticMessage,
+                    getRequirementKind(requirement),
+                    requirement->getFullName(),
+                    reqType);
+      } else {
+        // Generate diagnostics for the missing requirement and a fixit to add
+        // it
+        diagnoseNoWitness(requirement, reqType, conformance, tc);
+      }
 
       // Diagnose each of the matches.
       for (const auto &match : matches)
         diagnoseMatch(tc, dc->getParentModule(), conformance, requirement,
                       match);
     });
-
-
-  // FIXME: Suggest a new declaration that does match?
 
   return ResolveWitnessResult::ExplicitFailed;
 }
@@ -3418,8 +3492,7 @@ void ConformanceChecker::resolveTypeWitnesses() {
       diagnoseOrDefer(missingTypeWitness, true,
         [missingTypeWitness](TypeChecker &tc,
                              NormalProtocolConformance *conformance) {
-          tc.diagnose(missingTypeWitness, diag::no_witnesses_type,
-                      missingTypeWitness->getName());
+          diagnoseNoWitness(missingTypeWitness, Type(), conformance, tc);
         });
     }
 

--- a/test/ClangModules/objc_bridging_custom.swift
+++ b/test/ClangModules/objc_bridging_custom.swift
@@ -87,21 +87,21 @@ class Sub : Base {
 }
 
 protocol TestProto {
-  func test(a: Refrigerator, b: Refrigerator) -> Refrigerator? // expected-note {{protocol requires}} {{none}}
-  func testGeneric(a: ManufacturerInfo<NSString>, b: ManufacturerInfo<NSString>) -> ManufacturerInfo<NSString>? // expected-note {{protocol requires}} {{none}}
-  static func testInout(_: inout Refrigerator) // expected-note {{protocol requires}} {{none}}
-  func testUnmigrated(a: RuncingMode, b: Refrigerator, c: NSCoding) // expected-note {{protocol requires}} {{none}}
-  func testPartialMigrated(a: RuncingMode, b: Refrigerator) // expected-note {{protocol requires}} {{none}}
+  func test(a: Refrigerator, b: Refrigerator) -> Refrigerator? // expected-note {{protocol requires}}
+  func testGeneric(a: ManufacturerInfo<NSString>, b: ManufacturerInfo<NSString>) -> ManufacturerInfo<NSString>? // expected-note {{protocol requires}}
+  static func testInout(_: inout Refrigerator) // expected-note {{protocol requires}}
+  func testUnmigrated(a: RuncingMode, b: Refrigerator, c: NSCoding) // expected-note {{protocol requires}}
+  func testPartialMigrated(a: RuncingMode, b: Refrigerator) // expected-note {{protocol requires}}
 
-  subscript(a a: Refrigerator, b b: Refrigerator) -> Refrigerator? { get } // expected-note {{protocol requires}} {{none}}
-  subscript(generic a: ManufacturerInfo<NSString>, b b: ManufacturerInfo<NSString>) -> ManufacturerInfo<NSString>? { get } // expected-note {{protocol requires}} {{none}}
+  subscript(a a: Refrigerator, b b: Refrigerator) -> Refrigerator? { get } // expected-note {{protocol requires}}
+  subscript(generic a: ManufacturerInfo<NSString>, b b: ManufacturerInfo<NSString>) -> ManufacturerInfo<NSString>? { get } // expected-note {{protocol requires}}
 
-  init?(a: Refrigerator, b: Refrigerator) // expected-note {{protocol requires}} {{none}}
-  init?(generic: ManufacturerInfo<NSString>, b: ManufacturerInfo<NSString>) // expected-note {{protocol requires}} {{none}}
-  init(singleArgument: Refrigerator) // expected-note {{protocol requires}} {{none}}
+  init?(a: Refrigerator, b: Refrigerator) // expected-note {{protocol requires}}
+  init?(generic: ManufacturerInfo<NSString>, b: ManufacturerInfo<NSString>) // expected-note {{protocol requires}}
+  init(singleArgument: Refrigerator) // expected-note {{protocol requires}}
 
-  var prop: Refrigerator? { get } // expected-note {{protocol requires}} {{none}}
-  var propGeneric: ManufacturerInfo<NSString>? { get } // expected-note {{protocol requires}} {{none}}
+  var prop: Refrigerator? { get } // expected-note {{protocol requires}}
+  var propGeneric: ManufacturerInfo<NSString>? { get } // expected-note {{protocol requires}}
 }
 
 class TestProtoImpl : NSObject, TestProto { // expected-error {{type 'TestProtoImpl' does not conform to protocol 'TestProto'}}

--- a/test/decl/protocol/conforms/fixit_stub.swift
+++ b/test/decl/protocol/conforms/fixit_stub.swift
@@ -1,0 +1,83 @@
+// RUN: %target-parse-verify-swift
+
+protocol Protocol1 {
+  func foo(arg1: Int, arg2: String) -> String // expected-note{{protocol requires function 'foo(arg1:arg2:)' with type '(arg1: Int, arg2: String) -> String'; do you want to add a stub?}} {{27-27=\n    internal func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n}}
+  func bar() throws -> String // expected-note{{protocol requires function 'bar()' with type '() throws -> String'; do you want to add a stub?}} {{27-27=\n    internal func bar() throws -> String {\n        <#code#>\n    \}\n}}
+  init(arg: Int) // expected-note{{protocol requires initializer 'init(arg:)' with type '(arg: Int)'; do you want to add a stub?}} {{27-27=\n    internal init(arg: Int) {\n        <#code#>\n    \}\n}}
+  var baz: Int { get } // expected-note{{protocol requires property 'baz' with type 'Int'; do you want to add a stub?}} {{27-27=\n    internal var baz: Int\n}}
+  var baz2: Int { get set } // expected-note{{protocol requires property 'baz2' with type 'Int'; do you want to add a stub?}} {{27-27=\n    internal var baz2: Int\n}}
+  subscript(arg: Int) -> String { get } //expected-note{{rotocol requires subscript with type '(Int) -> String'; do you want to add a stub?}} {{27-27=\n    internal subscript(arg: Int) -> String {\n        <#code#>\n    \}\n}}
+  subscript(arg1: Int, arg2: Int) -> String { get set } //expected-note{{protocol requires subscript with type '(Int, Int) -> String'; do you want to add a stub?}} {{27-27=\n    internal subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
+}
+
+class Adopter: Protocol1 { // expected-error{{type 'Adopter' does not conform to protocol 'Protocol1'}} expected-note{{candidate has non-matching type '()'}}
+}
+
+
+
+protocol Protocol2 {
+  func foo(arg1: Int, arg2: String) -> String // expected-note{{protocol requires function 'foo(arg1:arg2:)' with type '(arg1: Int, arg2: String) -> String'; do you want to add a stub?}} {{32-32=\n    internal func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n}}
+  func bar() throws -> String // expected-note{{protocol requires function 'bar()' with type '() throws -> String'; do you want to add a stub?}} {{32-32=\n    internal func bar() throws -> String {\n        <#code#>\n    \}\n}}
+  init(arg: Int) // expected-note{{protocol requires initializer 'init(arg:)' with type '(arg: Int)'; do you want to add a stub?}} {{32-32=\n    internal init(arg: Int) {\n        <#code#>\n    \}\n}}
+  var baz: Int { get } // expected-note{{protocol requires property 'baz' with type 'Int'; do you want to add a stub?}} {{32-32=\n    internal var baz: Int {\n        <#code#>\n    \}\n}}
+  var baz2: Int { get set } // expected-note{{protocol requires property 'baz2' with type 'Int'; do you want to add a stub?}} {{32-32=\n    internal var baz2: Int {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
+  subscript(arg: Int) -> String { get } //expected-note{{rotocol requires subscript with type '(Int) -> String'; do you want to add a stub?}} {{32-32=\n    internal subscript(arg: Int) -> String {\n        <#code#>\n    \}\n}}
+  subscript(arg1: Int, arg2: Int) -> String { get set } //expected-note{{protocol requires subscript with type '(Int, Int) -> String'; do you want to add a stub?}} {{32-32=\n    internal subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
+}
+
+class Adopter2 {} //  expected-note{{candidate has non-matching type '()'}}
+
+extension Adopter2: Protocol2 { // expected-error{{ype 'Adopter2' does not conform to protocol 'Protocol2'}}
+}
+
+
+
+protocol ProtocolWithAssocType {
+  associatedtype AssocType //expected-note{{protocol requires nested type 'AssocType'}} {{41-41=\n    typealias AssocType = <#type#>\n}}
+}
+
+struct Adopter3: ProtocolWithAssocType { //expected-error{{type 'Adopter3' does not conform to protocol 'ProtocolWithAssocType'}}
+}
+
+
+
+protocol ProtocolWithAssocType2 {
+  associatedtype AssocType //expected-note{{protocol requires nested type 'AssocType'; do you want to add it?}} {{45-45=\n    typealias AssocType = <#type#>\n}}
+}
+
+struct Adopter4 {
+}
+
+extension Adopter4: ProtocolWithAssocType2 { //expected-error{{type 'Adopter4' does not conform to protocol 'ProtocolWithAssocType2'}}
+}
+
+
+
+protocol ProtocolWithSelfRequirement {
+  func foo() -> Self // expected-note{{protocol requires function 'foo()' with type '() -> Self'; do you want to add a stub?}} {{47-47=\n    internal func foo() -> Adopter5 {\n        <#code#>\n    \}\n}}
+  func foo(lhs: Self, rhs: Self) -> Self //expected-note{{protocol requires function 'foo(lhs:rhs:)' with type '(lhs: Adopter5, rhs: Adopter5) -> Self'; do you want to add a stub?}} {{47-47=\n    internal func foo(lhs: Adopter5, rhs: Adopter5) -> Adopter5 {\n        <#code#>\n    \}\n}}
+}
+
+struct Adopter5: ProtocolWithSelfRequirement { //expected-error{{type 'Adopter5' does not conform to protocol 'ProtocolWithSelfRequirement'}}
+}
+
+
+
+protocol ProtocolWithSelfRequirement2 {
+  func foo() -> Self // expected-note{{protocol requires function 'foo()' with type '() -> Self'; do you want to add a stub?}} {{51-51=\n    internal func foo() -> Adopter6 {\n        <#code#>\n    \}\n}}
+  func foo(lhs: Self, rhs: Self) -> Self //expected-note{{protocol requires function 'foo(lhs:rhs:)' with type '(lhs: Adopter6, rhs: Adopter6) -> Self'; do you want to add a stub?}} {{51-51=\n    internal func foo(lhs: Adopter6, rhs: Adopter6) -> Adopter6 {\n        <#code#>\n    \}\n}}
+}
+
+struct Adopter6 {}
+
+extension Adopter6: ProtocolWithSelfRequirement2 { //expected-error{{type 'Adopter6' does not conform to protocol 'ProtocolWithSelfRequirement2'}}
+}
+
+
+protocol ProtocolWithSelfRequirement3 {
+  func foo() -> Self // expected-note{{protocol requires function 'foo()' with type '() -> Self'; do you want to add a stub?}} {{47-47=\n    internal func foo() -> Self {\n        <#code#>\n    \}\n}}
+  func foo(lhs: Self, rhs: Self) -> Self //expected-note{{protocol requires function 'foo(lhs:rhs:)' with type '(lhs: Adopter7, rhs: Adopter7) -> Self'; do you want to add a stub?}} {{47-47=\n    internal func foo(lhs: Adopter7, rhs: Adopter7) -> Self {\n        <#code#>\n    \}\n}}
+}
+
+class Adopter7: ProtocolWithSelfRequirement3 { //expected-error{{type 'Adopter7' does not conform to protocol 'ProtocolWithSelfRequirement3'}}
+}

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -403,7 +403,7 @@ static void printAnnotatedDeclaration(const ValueDecl *VD,
   AnnotatedDeclarationPrinter Printer(OS);
   PrintOptions PO = PrintOptions::printQuickHelpDeclaration();
   if (BaseTy)
-    PO.setArchetypeTransformForQuickHelp(BaseTy, VD->getDeclContext());
+    PO.setArchetypeSelfTransformForQuickHelp(BaseTy, VD->getDeclContext());
 
   // If it's implicit, try to find an overridden ValueDecl that's not implicit.
   // This will ensure we can properly annotate TypeRepr with a usr
@@ -423,7 +423,7 @@ void SwiftLangSupport::printFullyAnnotatedDeclaration(const ValueDecl *VD,
   FullyAnnotatedDeclarationPrinter Printer(OS);
   PrintOptions PO = PrintOptions::printQuickHelpDeclaration();
   if (BaseTy)
-    PO.setArchetypeTransformForQuickHelp(BaseTy, VD->getDeclContext());
+    PO.setArchetypeSelfTransformForQuickHelp(BaseTy, VD->getDeclContext());
 
   // If it's implicit, try to find an overridden ValueDecl that's not implicit.
   // This will ensure we can properly annotate TypeRepr with a usr
@@ -750,7 +750,7 @@ static bool passCursorInfoForDecl(const ValueDecl *VD,
         PO.ArgAndParamPrinting = PrintOptions::ArgAndParamPrintingMode::ArgumentOnly;
         XMLEscapingPrinter Printer(OS);
         if (BaseType)
-          PO.setArchetypeTransform(BaseType, VD->getDeclContext());
+          PO.setArchetypeSelfTransform(BaseType, VD->getDeclContext());
         RelatedDecl->print(Printer, PO);
       } else {
         llvm::SmallString<128> Buf;


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

To each note with a protocol requirement that is not met, we will now add a fixit that adds a stub to the end of the adoptee's declaration. In particular, that is:
- For missing function requirements: Function with same signature and `fatalError` implementation
- For missing constructors: Constructor with `fatalError` implementation
- For missing subscripts: New subscript with getter and/or setter. Both with `fatalError` implementation
- For missing variables: A variable (always `var`) with the specified type

A few minor questions are still open:
- Should we rather add the stub at the beginning of the declaration than on the end?
- Should the default implementation be an editor placeholder `<#code#>` instead of `fatalError`. `fatalError` seems to be the approach swift has taken so far but editor placeholders seem more friendly to me (at least when using Xcode)
- I'm currently always using 4 spaces for indention, as it is done in several other fixits. Is that a no-go for such fixits that will probably often be applied? If so, inferring the current indentation settings will be my next task. Otherwise, I'll probably postpone this a little. I filed [SR-2086](https://bugs.swift.org/browse/SR-2086) to track this issue.
- I haven't added any tests for this yet because I don't know how to specify the line at which the fixit should occur. Simply specifying the column and a huge fixit didn't seem the right approach to me.
#### Resolved bug number: ([SR-2077](https://bugs.swift.org/browse/SR-2077))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
