### PR TITLE
Intrinsics instead of shims

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -86,25 +86,9 @@ _swift_stdlib_cxx11_mt19937_uniform(__swift_uint32_t upper_bound);
 // Math library functions
 SWIFT_RUNTIME_STDLIB_INTERFACE float _swift_stdlib_remainderf(float, float);
 SWIFT_RUNTIME_STDLIB_INTERFACE float _swift_stdlib_squareRootf(float);
-SWIFT_RUNTIME_STDLIB_INTERFACE
-float _swift_stdlib_addProductf(float, float, float);
-SWIFT_RUNTIME_STDLIB_INTERFACE float _swift_stdlib_roundf(float);
-SWIFT_RUNTIME_STDLIB_INTERFACE float _swift_stdlib_roundevenf(float);
-SWIFT_RUNTIME_STDLIB_INTERFACE float _swift_stdlib_truncf(float);
-SWIFT_RUNTIME_STDLIB_INTERFACE float _swift_stdlib_roundawayf(float);
-SWIFT_RUNTIME_STDLIB_INTERFACE float _swift_stdlib_ceilf(float);
-SWIFT_RUNTIME_STDLIB_INTERFACE float _swift_stdlib_floorf(float);
   
 SWIFT_RUNTIME_STDLIB_INTERFACE double _swift_stdlib_remainder(double, double);
 SWIFT_RUNTIME_STDLIB_INTERFACE double _swift_stdlib_squareRoot(double);
-SWIFT_RUNTIME_STDLIB_INTERFACE
-double _swift_stdlib_addProduct(double, double, double);
-SWIFT_RUNTIME_STDLIB_INTERFACE double _swift_stdlib_round(double);
-SWIFT_RUNTIME_STDLIB_INTERFACE double _swift_stdlib_roundeven(double);
-SWIFT_RUNTIME_STDLIB_INTERFACE double _swift_stdlib_trunc(double);
-SWIFT_RUNTIME_STDLIB_INTERFACE double _swift_stdlib_roundaway(double);
-SWIFT_RUNTIME_STDLIB_INTERFACE double _swift_stdlib_ceil(double);
-SWIFT_RUNTIME_STDLIB_INTERFACE double _swift_stdlib_floor(double);
   
 // TODO: Remove horrible workaround when importer does Float80 <-> long double.
 #if (defined __i386__ || defined __x86_64__) && !defined _MSC_VER
@@ -112,14 +96,6 @@ SWIFT_RUNTIME_STDLIB_INTERFACE
 void _swift_stdlib_remainderl(void *_self, const void *_other);
 SWIFT_RUNTIME_STDLIB_INTERFACE
 void _swift_stdlib_squareRootl(void *_self);
-SWIFT_RUNTIME_STDLIB_INTERFACE
-void _swift_stdlib_addProductl(void *_self, const void *_lhs, const void *_rhs);
-SWIFT_RUNTIME_STDLIB_INTERFACE void _swift_stdlib_roundl(void *_self);
-SWIFT_RUNTIME_STDLIB_INTERFACE void _swift_stdlib_roundevenl(void *_self);
-SWIFT_RUNTIME_STDLIB_INTERFACE void _swift_stdlib_truncl(void *_self);
-SWIFT_RUNTIME_STDLIB_INTERFACE void _swift_stdlib_roundawayl(void *_self);
-SWIFT_RUNTIME_STDLIB_INTERFACE void _swift_stdlib_ceill(void *_self);
-SWIFT_RUNTIME_STDLIB_INTERFACE void _swift_stdlib_floorl(void *_self);
 #endif
 
 #ifdef __cplusplus

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -510,37 +510,25 @@ extension ${Self}: BinaryFloatingPoint {
 
   @_transparent
   public mutating func round(_ rule: FloatingPointRoundingRule) {
-%if bits == 80:
     switch rule {
     case .toNearestOrAwayFromZero:
-      _swift_stdlib_roundl(&self)
+      _value = Builtin.int_round_FPIEEE${bits}(_value)
     case .toNearestOrEven:
-      _swift_stdlib_roundevenl(&self)
+      _value = Builtin.int_rint_FPIEEE${bits}(_value)
     case .towardZero:
-      _swift_stdlib_truncl(&self)
+      _value = Builtin.int_trunc_FPIEEE${bits}(_value)
     case .awayFromZero:
-      _swift_stdlib_roundawayl(&self)
+      if sign == .minus {
+        _value = Builtin.int_floor_FPIEEE${bits}(_value)
+      }
+      else {
+        _value = Builtin.int_ceil_FPIEEE${bits}(_value)
+      }
     case .up:
-      _swift_stdlib_ceill(&self)
+      _value = Builtin.int_ceil_FPIEEE${bits}(_value)
     case .down:
-      _swift_stdlib_floorl(&self)
+      _value = Builtin.int_floor_FPIEEE${bits}(_value)
     }
-%else:
-    switch rule {
-    case .toNearestOrAwayFromZero:
-      self = _swift_stdlib_round${cFuncSuffix(bits)}(self)
-    case .toNearestOrEven:
-      self = _swift_stdlib_roundeven${cFuncSuffix(bits)}(self)
-    case .towardZero:
-      self = _swift_stdlib_trunc${cFuncSuffix(bits)}(self)
-    case .awayFromZero:
-      self = _swift_stdlib_roundaway${cFuncSuffix(bits)}(self)
-    case .up:
-      self = _swift_stdlib_ceil${cFuncSuffix(bits)}(self)
-    case .down:
-      self = _swift_stdlib_floor${cFuncSuffix(bits)}(self)
-    }
-%end
   }
 
   @_transparent
@@ -594,13 +582,7 @@ extension ${Self}: BinaryFloatingPoint {
 
   @_transparent
   public mutating func addProduct(_ lhs: ${Self}, _ rhs: ${Self}) {
-%if bits == 80:
-    var lhs = lhs
-    var rhs = rhs
-    _swift_stdlib_addProductl(&self, &lhs, &rhs)
-%else:
-    self = _swift_stdlib_addProduct${cFuncSuffix(bits)}(self, lhs, rhs)
-%end
+    _value = Builtin.int_fma_FPIEEE${bits}(lhs._value, rhs._value, _value)
   }
 
   @_transparent

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -131,57 +131,11 @@ float swift::_swift_stdlib_remainderf(float dividend, float divisor) {
 
 float swift::_swift_stdlib_squareRootf(float x) { return std::sqrt(x); }
 
-float swift::_swift_stdlib_addProductf(float addend, float lhs, float rhs) {
-  return std::fma(lhs, rhs, addend);
-}
-
-float swift::_swift_stdlib_roundf(float x) { return std::round(x); }
-
-float swift::_swift_stdlib_roundevenf(float x) {
-  //  TODO: switch to roundevenf( ) when available in backing C libraries, or
-  //  open-code here to correctly handle non-default fenv.
-  return std::rint(x);
-}
-
-float swift::_swift_stdlib_truncf(float x) { return std::trunc(x); }
-
-float swift::_swift_stdlib_roundawayf(float x) {
-  //  No corresponding C function, but trivial to fake.
-  return x < 0 ? std::floor(x) : std::ceil(x);
-}
-
-float swift::_swift_stdlib_ceilf(float x) { return std::ceil(x); }
-
-float swift::_swift_stdlib_floorf(float x) { return std::floor(x); }
-
 double swift::_swift_stdlib_remainder(double dividend, double divisor) {
   return std::remainder(dividend, divisor);
 }
 
 double swift::_swift_stdlib_squareRoot(double x) { return std::sqrt(x); }
-
-double swift::_swift_stdlib_addProduct(double addend, double lhs, double rhs) {
-  return std::fma(lhs, rhs, addend);
-}
-
-double swift::_swift_stdlib_round(double x) { return std::round(x); }
-
-double swift::_swift_stdlib_roundeven(double x) {
-  //  TODO: switch to roundevenf( ) when available in backing C libraries, or
-  //  open-code here to correctly handle non-default fenv.
-  return std::rint(x);
-}
-
-double swift::_swift_stdlib_trunc(double x) { return std::trunc(x); }
-
-double swift::_swift_stdlib_roundaway(double x) {
-  //  No corresponding C function, but trivial to fake.
-  return x < 0 ? std::floor(x) : std::ceil(x);
-}
-
-double swift::_swift_stdlib_ceil(double x) { return std::ceil(x); }
-
-double swift::_swift_stdlib_floor(double x) { return std::floor(x); }
 
 #if (defined __i386__ || defined __x86_64__) && !defined _MSC_VER
 void swift::_swift_stdlib_remainderl(void *_self, const void *_other) {
@@ -191,38 +145,5 @@ void swift::_swift_stdlib_remainderl(void *_self, const void *_other) {
 
 void swift::_swift_stdlib_squareRootl(void *_self) {
   *(long double *)_self = std::sqrt(*(long double *)_self);
-}
-
-void
-swift::_swift_stdlib_addProductl(void *_self,
-                                 const void *_lhs, const void *_rhs) {
-  *(long double *)_self = std::fma(*(const long double *)_lhs,
-                                   *(const long double *)_rhs,
-                                   *(long double *)_self);
-}
-
-void swift::_swift_stdlib_roundl(void *_self) {
-  *(long double *)_self = std::round(*(long double *)_self);
-}
-
-void swift::_swift_stdlib_roundevenl(void *_self) {
-  *(long double *)_self = std::rint(*(long double *)_self);
-}
-
-void swift::_swift_stdlib_truncl(void *_self) {
-  *(long double *)_self = std::trunc(*(long double *)_self);
-}
-
-void swift::_swift_stdlib_roundawayl(void *_self) {
-  long double *ptr = (long double *)_self;
-  *ptr =  *ptr < 0 ? std::floor(*ptr) : std::ceil(*ptr);
-}
-
-void swift::_swift_stdlib_ceill(void *_self) {
-  *(long double *)_self = std::ceil(*(long double *)_self);
-}
-
-void swift::_swift_stdlib_floorl(void *_self) {
-  *(long double *)_self = std::floor(*(long double *)_self);
 }
 #endif // Have Float80

--- a/test/IRGen/builtin_math.swift
+++ b/test/IRGen/builtin_math.swift
@@ -21,16 +21,18 @@ public func test2(f : Double) -> Double {
 }
 
 // LLVM's sqrt intrinsic does not have the same semantics as libm's sqrt.
+// In particular, llvm.sqrt(negative) is documented as being undef, but
+// we want sqrt(negative) to be defined to be NaN for IEEE 754 conformance.
 
 // CHECK-LABEL: define {{.*}}test3
-// CHECK: call double @sqrt
+// CHECK-NOT: call double @llvm.sqrt.f64
 
 public func test3(d : Double) -> Double {
   return sqrt(d)
 }
 
 // CHECK-LABEL: define {{.*}}test4
-// CHECK: call float @sqrtf
+// CHECK-NOT: call float @llvm.sqrt.f32
 
 public func test4(f : Float) -> Float {
   return sqrt(f)


### PR DESCRIPTION
#### What's in this pull request?

This replaces most of the stubs used for basic operations on these types with intrinsics, eliminating a level of indirection for fma, ceil, floor, round, trunc.

square root and remainder still require stubs because there is no remainder intrinsic and we can't use the square root intrinsic because its behavior is undefined for negative inputs.  A previous commit
apparently either the compiler annotates static inline stubs wrong or the SIL verifier can't handle them, so that change was backed out.

This also fixes the break introduced by reverting #3454.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
