### PR TITLE
Fix a build error caused my missing #include <string>

### DIFF
--- a/include/swift/IDE/ModuleInterfacePrinting.h
+++ b/include/swift/IDE/ModuleInterfacePrinting.h
@@ -16,6 +16,7 @@
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/OptionSet.h"
 
+#include <string>
 #include <vector>
 
 namespace swift {


### PR DESCRIPTION
(on some versions of LLVM apparently)
