### PR TITLE
stdlib: shim errno access

### DIFF
--- a/stdlib/public/Platform/Misc.c
+++ b/stdlib/public/Platform/Misc.c
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <errno.h>
 #include <fcntl.h>
 #if !defined(_WIN32) || defined(__CYGWIN__)
 #include <semaphore.h>
@@ -104,3 +105,14 @@ SWIFT_CC(swift) extern char **_swift_FreeBSD_getEnv() {
   return environ;
 }
 #endif // defined(__FreeBSD__)
+
+SWIFT_CC(swift)
+extern int _swift_Platform_getErrno() {
+  return errno;
+}
+
+SWIFT_CC(swift)
+extern void _swift_Platform_setErrno(int value) {
+  errno = value;
+}
+

--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -94,36 +94,18 @@ public func || <T : Boolean>(
 // sys/errno.h
 //===----------------------------------------------------------------------===//
 
+@_silgen_name("_swift_Platform_getErrno")
+func _swift_Platform_getErrno() -> Int32
+
+@_silgen_name("_swift_Platform_setErrno")
+func _swift_Platform_setErrno(_: Int32)
+
 public var errno : Int32 {
   get {
-#if os(OSX) || os(iOS) || os(watchOS) || os(tvOS) || os(FreeBSD) || os(PS4)
-    return __error().pointee
-#elseif os(Android)
-    return __errno().pointee
-#elseif os(Windows)
-#if CYGWIN
-    return __errno().pointee
-#else
-    return _errno().pointee
-#endif
-#else
-    return __errno_location().pointee
-#endif
+    return _swift_Platform_getErrno()
   }
   set(val) {
-#if os(OSX) || os(iOS) || os(watchOS) || os(tvOS) || os(FreeBSD) || os(PS4)
-    return __error().pointee = val
-#elseif os(Android)
-    return __errno().pointee = val
-#elseif os(Windows)
-#if CYGWIN
-    return __errno().pointee = val
-#else
-    return _errno().pointee = val
-#endif
-#else
-    return __errno_location().pointee = val
-#endif
+    return _swift_Platform_setErrno(val)
   }
 }
 


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

errno is implemented as a macro in many environments.  The accessor hidden
behind the macro is not a standard function, so we ended up with an
implementation specific handling across all the targets.  Shim the function in C
where it can be hidden behind the CPP.  This simplifies the implementation on
the swift side.
