### PR TITLE
[SourceKit] Add test case for crash triggered in swift::TypeChecker::typeCheckParameterList(…)

### DIFF
--- a/validation-test/IDE/crashers/069-swift-typechecker-typecheckparameterlist.swift
+++ b/validation-test/IDE/crashers/069-swift-typechecker-typecheckparameterlist.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+func b(e:({#^A^#var e){


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 137
5  swift-ide-test  0x00000000009c30f5 swift::TypeChecker::typeCheckParameterList(swift::ParameterList*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) + 117
8  swift-ide-test  0x0000000000982d96 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
9  swift-ide-test  0x00000000009a6142 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
10 swift-ide-test  0x00000000007a64d9 swift::CompilerInstance::performSema() + 3289
11 swift-ide-test  0x0000000000749c4a main + 34106
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking 'b' at <INPUT-FILE>:3:1
```
