### PR TITLE
[SIL] Add test case for crash triggered in swift::TypeChecker::resolveType(…)

### DIFF
--- a/validation-test/SIL/crashers/025-swift-typechecker-resolvetype.sil
+++ b/validation-test/SIL/crashers/025-swift-typechecker-resolvetype.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+protocol l{func t-> <T>()->(


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:18: error: expected '(' in argument list of function declaration
protocol l{func t-> <T>()->(
                 ^
<stdin>:3:29: error: expected type
protocol l{func t-> <T>()->(
                            ^
<stdin>:3:29: error: expected ',' separator
protocol l{func t-> <T>()->(
                            ^
                            ,
<stdin>:3:29: error: consecutive declarations on a line must be separated by ';'
protocol l{func t-> <T>()->(
                            ^
                            ;
<stdin>:3:29: error: expected declaration
protocol l{func t-> <T>()->(
                            ^
<stdin>:3:10: note: in declaration of 'l'
protocol l{func t-> <T>()->(
         ^
sil-opt: /path/to/swift/lib/Sema/TypeCheckType.cpp:1964: swift::Type (anonymous namespace)::TypeResolver::resolveASTFunctionType(swift::FunctionTypeRepr *, TypeResolutionOptions, FunctionType::ExtInfo): Assertion `genericSig != nullptr && "Did not call handleSILGenericParams()?"' failed.
9  sil-opt         0x0000000000b5a904 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
10 sil-opt         0x0000000000b598a0 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
12 sil-opt         0x0000000000b2398e swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 94
17 sil-opt         0x0000000000aea496 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
18 sil-opt         0x0000000000b0d762 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
19 sil-opt         0x0000000000772259 swift::CompilerInstance::performSema() + 3289
20 sil-opt         0x000000000075b72d main + 1805
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  While type-checking 'l' at <stdin>:3:1
2.  While resolving type () -> () at [<stdin>:3:24 - line:3:28] RangeText="()->("
```
