### PR TITLE
[swiftc (69 vs. 5108)] Add crasher in swift::DeclContext::isGenericContext(...)

### DIFF
--- a/validation-test/compiler_crashers/28367-swift-declcontext-isgenericcontext.swift
+++ b/validation-test/compiler_crashers/28367-swift-declcontext-isgenericcontext.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+let a{{}protocol A{class A:d class d<U:A>:A


### PR DESCRIPTION
Add test case for crash triggered in `swift::DeclContext::isGenericContext(...)`.

Current number of unresolved compiler crashers: 69 (5108 resolved)

Stack trace:

```
4  swift           0x00000000010e5f27 swift::DeclContext::isGenericContext() const + 23
5  swift           0x00000000010dcea9 swift::ClassDecl::checkObjCAncestry() const + 185
6  swift           0x0000000000ebc685 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 421
7  swift           0x000000000111c5cb swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2667
8  swift           0x000000000111acaf swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2495
9  swift           0x0000000000efe1cb swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
12 swift           0x0000000000f2fd6e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
14 swift           0x0000000000f30cc4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
15 swift           0x0000000000f2fc60 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
16 swift           0x0000000000ebb05a swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 5194
17 swift           0x0000000000ebc658 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 376
22 swift           0x0000000000ec1c86 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
25 swift           0x0000000000f2899a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
26 swift           0x0000000000f287fe swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
27 swift           0x0000000000f293c3 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
29 swift           0x0000000000ee3f41 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
30 swift           0x0000000000c6f749 swift::CompilerInstance::performSema() + 3289
32 swift           0x00000000007d8f39 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
33 swift           0x00000000007a4f58 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28367-swift-declcontext-isgenericcontext.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28367-swift-declcontext-isgenericcontext-30331b.o
1.  While type-checking getter for a at validation-test/compiler_crashers/28367-swift-declcontext-isgenericcontext.swift:9:6
2.  While type-checking 'A' at validation-test/compiler_crashers/28367-swift-declcontext-isgenericcontext.swift:9:9
3.  While resolving type d at [validation-test/compiler_crashers/28367-swift-declcontext-isgenericcontext.swift:9:28 - line:9:28] RangeText="d"
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
