### PR TITLE
[SourceKit] Add test case for crash triggered in swift::ArchetypeBuilder::mapTypeIntoContext(…)

### DIFF
--- a/validation-test/IDE/crashers/070-swift-archetypebuilder-maptypeintocontext.swift
+++ b/validation-test/IDE/crashers/070-swift-archetypebuilder-maptypeintocontext.swift
@@ -1,0 +1,4 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+a{func a<U{class B<T{}{B
+#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 151
4  swift-ide-test  0x0000000000b3c793 swift::ArchetypeBuilder::mapTypeIntoContext(swift::ModuleDecl*, swift::GenericParamList*, swift::Type, swift::LazyResolver*) + 163
5  swift-ide-test  0x0000000000a19f1b swift::constraints::ConstraintSystem::openGeneric(swift::DeclContext*, swift::DeclContext*, llvm::ArrayRef<swift::GenericTypeParamType*>, llvm::ArrayRef<swift::Requirement>, bool, swift::constraints::ConstraintLocatorBuilder, llvm::DenseMap<swift::CanType, swift::TypeVariableType*, llvm::DenseMapInfo<swift::CanType>, llvm::detail::DenseMapPair<swift::CanType, swift::TypeVariableType*> >&) + 1051
7  swift-ide-test  0x0000000000c71a83 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 35
8  swift-ide-test  0x0000000000a185fe swift::constraints::ConstraintSystem::openType(swift::Type, swift::constraints::ConstraintLocatorBuilder, llvm::DenseMap<swift::CanType, swift::TypeVariableType*, llvm::DenseMapInfo<swift::CanType>, llvm::detail::DenseMapPair<swift::CanType, swift::TypeVariableType*> >&) + 78
11 swift-ide-test  0x0000000000bb32e5 swift::Expr::walk(swift::ASTWalker&) + 69
12 swift-ide-test  0x0000000000930758 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) + 200
13 swift-ide-test  0x000000000096b353 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 371
14 swift-ide-test  0x0000000000971cf2 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
17 swift-ide-test  0x00000000009ebae4 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
18 swift-ide-test  0x0000000000a229ac swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
19 swift-ide-test  0x0000000000971d91 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 769
22 swift-ide-test  0x00000000009ea75a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
23 swift-ide-test  0x00000000009ea5be swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
24 swift-ide-test  0x00000000009a89af swift::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 655
26 swift-ide-test  0x00000000008ec4e1 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 305
27 swift-ide-test  0x00000000007a668d swift::CompilerInstance::performSema() + 3597
28 swift-ide-test  0x0000000000749c80 main + 34176
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking expression at [<INPUT-FILE>:3:23 - line:4:1] RangeText="{B
"
2.  While type-checking expression at [<INPUT-FILE>:3:24 - line:3:24] RangeText="B"
```
