### PR TITLE
[SIL] Add test case for crash triggered in swift::Parser::parseSILDefaultWitnessTable()

### DIFF
--- a/validation-test/SIL/crashers/026-swift-parser-parsesildefaultwitnesstable.sil
+++ b/validation-test/SIL/crashers/026-swift-parser-parsesildefaultwitnesstable.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+sil_default_witness_table


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:26: error: expected SIL value name
sil_default_witness_table
                         ^
sil-opt: /path/to/swift/include/swift/Parse/Parser.h:412: swift::SourceLoc swift::Parser::consumeToken(swift::tok): Assertion `Tok.is(K) && "Consuming wrong token kind"' failed.
8  sil-opt         0x0000000000a5d1d8 swift::Parser::parseSILDefaultWitnessTable() + 2248
9  sil-opt         0x0000000000a9452b swift::Parser::parseTopLevel() + 779
10 sil-opt         0x0000000000a4e0c0 swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) + 208
11 sil-opt         0x0000000000772146 swift::CompilerInstance::performSema() + 3254
12 sil-opt         0x000000000075b63d main + 1805
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  With parser at source location: <stdin>:3:26
```
