### PR TITLE
New value types for Calendar, TimeZone, and Locale

### DIFF
--- a/apinotes/Foundation.apinotes
+++ b/apinotes/Foundation.apinotes
@@ -647,7 +647,15 @@ Classes:
   - Selector: 'stringFromByteCount:'
     SwiftName: stringFromByteCount(_:)
     MethodKind: Instance
+- Name: NSLocale
+  SwiftName: NSLocale
+  SwiftBridge: Locale
+- Name: NSTimeZone
+  SwiftName: NSTimeZone
+  SwiftBridge: TimeZone
 - Name: NSCalendar
+  SwiftName: NSCalendar
+  SwiftBridge: Calendar
   Methods:
   - Selector: 'dateWithEra:year:month:day:hour:minute:second:nanosecond:'
     SwiftName: date(era:year:month:day:hour:minute:second:nanosecond:)
@@ -1114,9 +1122,9 @@ Tags:
 - Name: NSByteCountFormatterCountStyle
   SwiftName: ByteCountFormatter.CountStyle
 - Name: NSCalendarUnit
-  SwiftName: Calendar.Unit
+  SwiftName: NSCalendar.Unit
 - Name: NSCalendarOptions
-  SwiftName: Calendar.Options
+  SwiftName: NSCalendar.Options
 - Name: NSDecodingFailurePolicy
   SwiftName: NSCoder.DecodingFailurePolicy
 - Name: NSComparisonPredicateOptions
@@ -1229,7 +1237,7 @@ Tags:
   Availability: nonswift
   AvailabilityMsg: Use 'NSTextCheckingResult.CheckingType'
 - Name: NSTimeZoneNameStyle
-  SwiftName: TimeZone.NameStyle
+  SwiftName: NSTimeZone.NameStyle
 - Name: NSURLCacheStoragePolicy
   SwiftName: URLCache.StoragePolicy
 - Name: NSURLCredentialPersistence
@@ -1281,7 +1289,7 @@ Tags:
 - Name: NSDateComponentsFormatterZeroFormattingBehavior
   SwiftName: DateComponentsFormatter.ZeroFormattingBehavior
 - Name: NSLocaleLanguageDirection
-  SwiftName: Locale.LanguageDirection
+  SwiftName: NSLocale.LanguageDirection
 - Name: NSNetServiceOptions
   SwiftName: NSNetService.Options
 - Name: NSPointerFunctionsOptions
@@ -1348,13 +1356,13 @@ Typedefs:
 - Name: NSBackgroundActivityCompletionHandler
   SwiftName: NSBackgroundActivityScheduler.CompletionHandler
 - Name: NSCalendarIdentifier
-  SwiftName: Calendar.Identifier
+  SwiftName: NSCalendar.Identifier
 - Name: NSItemProviderCompletionHandler
   SwiftName: NSItemProvider.CompletionHandler
 - Name: NSItemProviderLoadHandler
   SwiftName: NSItemProvider.LoadHandler
 - Name: NSLocaleKey
-  SwiftName: Locale.Key
+  SwiftName: NSLocale.Key
 - Name: NSNotificationName
   SwiftName: NSNotification.Name
 - Name: NSProgressFileOperationKind
@@ -1423,7 +1431,7 @@ Globals:
 - Name: NSItemProviderErrorDomain
   SwiftName: NSItemProvider.errorDomain
 - Name: NSCurrentLocaleDidChangeNotification
-  SwiftName: Locale.currentLocaleDidChangeNotification
+  SwiftName: NSLocale.currentLocaleDidChangeNotification
 - Name: NSNetServicesErrorDomain
   SwiftName: NSNetService.errorDomain
 - Name: NSNetServicesErrorCode

--- a/stdlib/private/StdlibUnittestFoundationExtras/StdlibUnittestFoundationExtras.swift
+++ b/stdlib/private/StdlibUnittestFoundationExtras/StdlibUnittestFoundationExtras.swift
@@ -13,25 +13,25 @@
 import ObjectiveC
 import Foundation
 
-internal var _temporaryLocaleCurrentLocale: Locale? = nil
+internal var _temporaryLocaleCurrentLocale: NSLocale? = nil
 
-extension Locale {
+extension NSLocale {
   @objc
-  public class func _swiftUnittest_currentLocale() -> Locale {
+  public class func _swiftUnittest_currentLocale() -> NSLocale {
     return _temporaryLocaleCurrentLocale!
   }
 }
 
 public func withOverriddenLocaleCurrentLocale<Result>(
-  _ temporaryLocale: Locale,
+  _ temporaryLocale: NSLocale,
   _ body: @noescape () -> Result
 ) -> Result {
   let oldMethod = class_getClassMethod(
-    Locale.self, #selector(getter: Locale.current))
+    NSLocale.self, #selector(getter: NSLocale.current))
   precondition(oldMethod != nil, "could not find +[Locale currentLocale]")
 
   let newMethod = class_getClassMethod(
-    Locale.self, #selector(Locale._swiftUnittest_currentLocale))
+    NSLocale.self, #selector(NSLocale._swiftUnittest_currentLocale))
   precondition(newMethod != nil, "could not find +[Locale _swiftUnittest_currentLocale]")
 
   precondition(_temporaryLocaleCurrentLocale == nil,
@@ -51,11 +51,11 @@ public func withOverriddenLocaleCurrentLocale<Result>(
   _ body: @noescape () -> Result
 ) -> Result {
   precondition(
-    Locale.availableLocaleIdentifiers.contains(temporaryLocaleIdentifier),
+    NSLocale.availableLocaleIdentifiers.contains(temporaryLocaleIdentifier),
     "requested locale \(temporaryLocaleIdentifier) is not available")
 
   return withOverriddenLocaleCurrentLocale(
-    Locale(localeIdentifier: temporaryLocaleIdentifier), body)
+    NSLocale(localeIdentifier: temporaryLocaleIdentifier), body)
 }
 
 /// Executes the `body` in an autorelease pool if the platform does not

--- a/stdlib/public/SDK/Foundation/CMakeLists.txt
+++ b/stdlib/public/SDK/Foundation/CMakeLists.txt
@@ -7,6 +7,9 @@ add_swift_library(swiftFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SD
   ExtraStringAPIs.swift
   ReferenceConvertible.swift
   AffineTransform.swift
+  Calendar.swift
+  TimeZone.swift
+  Locale.swift
   CharacterSet.swift
   Date.swift
   DateComponents.swift

--- a/stdlib/public/SDK/Foundation/Calendar.swift
+++ b/stdlib/public/SDK/Foundation/Calendar.swift
@@ -21,6 +21,9 @@ internal func __NSCalendarAutoupdating() -> NSCalendar
 @_silgen_name("__NSCalendarCurrent")
 internal func __NSCalendarCurrent() -> NSCalendar
 
+@_silgen_name("__NSCalendarInit")
+internal func __NSCalendarInit(_ identifier : NSString) -> NSCalendar?
+
 /**
  `Calendar` encapsulates information about systems of reckoning time in which the beginning, length, and divisions of a year are defined. It provides information about the calendar and support for calendrical computations such as determining the range of a given calendrical unit and adding units to a given absolute time.
 */
@@ -104,7 +107,8 @@ public struct Calendar : CustomStringConvertible, CustomDebugStringConvertible, 
     ///
     /// - parameter identifier: The kind of calendar to use.
     public init(identifier: Identifier) {
-        _handle = _MutableHandle(adoptingReference: NSCalendar(identifier: Calendar._toNSCalendarIdentifier(identifier))!)
+        let result = __NSCalendarInit(Calendar._toNSCalendarIdentifier(identifier))!
+        _handle = _MutableHandle(adoptingReference: result)
         _autoupdating = false
     }
     

--- a/stdlib/public/SDK/Foundation/Calendar.swift
+++ b/stdlib/public/SDK/Foundation/Calendar.swift
@@ -1,0 +1,1106 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+@_silgen_name("__NSCalendarIsAutoupdating")
+internal func __NSCalendarIsAutoupdating(_ calendar: NSCalendar) -> Bool
+
+@_silgen_name("__NSCalendarAutoupdating")
+internal func __NSCalendarAutoupdating() -> NSCalendar
+
+@_silgen_name("__NSCalendarCurrent")
+internal func __NSCalendarCurrent() -> NSCalendar
+
+/**
+ `Calendar` encapsulates information about systems of reckoning time in which the beginning, length, and divisions of a year are defined. It provides information about the calendar and support for calendrical computations such as determining the range of a given calendrical unit and adding units to a given absolute time.
+*/
+public struct Calendar : CustomStringConvertible, CustomDebugStringConvertible, Hashable, Equatable, ReferenceConvertible, _MutableBoxing {
+    public typealias ReferenceType = NSCalendar
+    
+    private var _autoupdating: Bool
+    internal var _handle: _MutableHandle<NSCalendar>
+
+    /// Calendar supports many different kinds of calendars. Each is identified by an identifier here.
+    public enum Identifier {
+        /// The common calendar in Europe, the Western Hemisphere, and elsewhere.
+        case gregorian
+        
+        case buddhist
+        case chinese
+        case coptic
+        case ethiopicAmeteMihret
+        case ethiopicAmeteAlem
+        case hebrew
+        case iso8601
+        case indian
+        case islamic
+        case islamicCivil
+        case japanese
+        case persian
+        case republicOfChina
+        
+        /// A simple tabular Islamic calendar using the astronomical/Thursday epoch of CE 622 July 15
+        @available(OSX 10.10, iOS 8.0, *)
+        case islamicTabular
+        
+        /// The Islamic Umm al-Qura calendar used in Saudi Arabia. This is based on astronomical calculation, instead of tabular behavior.
+        @available(OSX 10.10, iOS 8.0, *)
+        case islamicUmmAlQura
+        
+    }
+    
+    /// An enumeration for the various components of a calendar date.
+    ///
+    /// Several `Calendar` APIs use either a single unit or a set of units as input to a search algorithm.
+    ///
+    /// - seealso: `DateComponents`
+    public enum Component {
+        case era
+        case year
+        case month
+        case day
+        case hour
+        case minute
+        case second
+        case weekday
+        case weekdayOrdinal
+        case quarter
+        case weekOfMonth
+        case weekOfYear
+        case yearForWeekOfYear
+        case nanosecond
+        case calendar
+        case timeZone
+    }
+    
+    /// Returns the user's current calendar. This calendar does not track changes that the user makes to their preferences.
+    public static var current : Calendar {
+        return Calendar(adoptingReference: __NSCalendarCurrent(), autoupdating: false)
+    }
+    
+    /// A Calendar that tracks changes to user's preferred calendar identifier.
+    ///
+    /// If mutated, this calendar will no longer autoupdate.
+    ///
+    /// - note: The autoupdating Calendar will only compare equal to another autoupdating calendar.
+    public static var autoupdatingCurrent : Calendar {
+        return Calendar(adoptingReference: __NSCalendarAutoupdating(), autoupdating: true)
+    }
+
+    // MARK: -
+    // MARK: init
+    
+    /// Returns a new Calendar.
+    ///
+    /// - parameter identifier: The kind of calendar to use.
+    public init(identifier: Identifier) {
+        _handle = _MutableHandle(adoptingReference: NSCalendar(identifier: Calendar._toNSCalendarIdentifier(identifier))!)
+        _autoupdating = false
+    }
+    
+    // MARK: -
+    // MARK: Bridging
+    
+    private init(reference : NSCalendar) {
+        _handle = _MutableHandle(reference: reference)
+        if __NSCalendarIsAutoupdating(reference) {
+            _autoupdating = true
+        } else {
+            _autoupdating = false
+        }
+    }
+
+    private init(adoptingReference reference: NSCalendar, autoupdating: Bool) {
+        _handle = _MutableHandle(adoptingReference: reference)
+        _autoupdating = autoupdating
+    }
+
+    // MARK: -
+    // 
+    
+    /// The identifier of the calendar.
+    public var identifier : Identifier {
+        return Calendar._fromNSCalendarIdentifier(_handle.map({ $0.calendarIdentifier }))
+    }
+
+    /// The locale of the calendar.
+    public var locale : Locale? {
+        get {
+            return _handle.map { $0.locale }
+        }
+        set {
+            _applyMutation { $0.locale = newValue }
+        }
+    }
+    
+    /// The time zone of the calendar.
+    public var timeZone : TimeZone {
+        get {
+            return _handle.map { $0.timeZone }
+        }
+        set {
+            _applyMutation { $0.timeZone = newValue }
+        }
+    }
+    
+    /// The first weekday of the calendar.
+    public var firstWeekday : Int {
+        get {
+            return _handle.map { $0.firstWeekday }
+        }
+        set {
+            _applyMutation { $0.firstWeekday = newValue }
+        }
+    }
+    
+    /// The number of minimum days in the first week.
+    public var minimumDaysInFirstWeek : Int {
+        get {
+            return _handle.map { $0.minimumDaysInFirstWeek }
+        }
+        set {
+            _applyMutation { $0.minimumDaysInFirstWeek = newValue }
+        }
+    }
+    
+    /// A list of eras in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["BC", "AD"]`.
+    ///
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var eraSymbols: [String] {
+        return _handle.map { $0.eraSymbols }
+    }
+    
+    /// A list of longer-named eras in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["Before Christ", "Anno Domini"]`.
+    ///
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var longEraSymbols: [String] {
+        return _handle.map { $0.longEraSymbols }
+    }
+    
+    /// A list of months in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]`.
+    ///
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var monthSymbols: [String] {
+        return _handle.map { $0.monthSymbols }
+    }
+    
+    /// A list of shorter-named months in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]`.
+    ///
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var shortMonthSymbols: [String] {
+        return _handle.map { $0.shortMonthSymbols }
+    }
+    
+    /// A list of very-shortly-named months in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"]`.
+    ///
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var veryShortMonthSymbols: [String] {
+        return _handle.map { $0.veryShortMonthSymbols }
+    }
+    
+    /// A list of standalone months in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]`.
+    /// - note: Stand-alone properties are for use in places like calendar headers. Non-stand-alone properties are for use in context (for example, "Saturday, November 12th").
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var standaloneMonthSymbols: [String] {
+        return _handle.map { $0.standaloneMonthSymbols }
+    }
+    
+    /// A list of shorter-named standalone months in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]`.
+    /// - note: Stand-alone properties are for use in places like calendar headers. Non-stand-alone properties are for use in context (for example, "Saturday, November 12th").
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var shortStandaloneMonthSymbols: [String] {
+        return _handle.map { $0.shortStandaloneMonthSymbols }
+    }
+    
+    /// A list of very-shortly-named standalone months in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"]`.
+    /// - note: Stand-alone properties are for use in places like calendar headers. Non-stand-alone properties are for use in context (for example, "Saturday, November 12th").
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var veryShortStandaloneMonthSymbols: [String] {
+        return _handle.map { $0.veryShortStandaloneMonthSymbols }
+    }
+    
+    /// A list of weekdays in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]`.
+    ///
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var weekdaySymbols: [String] {
+        return _handle.map { $0.weekdaySymbols }
+    }
+    
+    /// A list of shorter-named weekdays in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]`.
+    ///
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var shortWeekdaySymbols: [String] {
+        return _handle.map { $0.shortWeekdaySymbols }
+    }
+    
+    /// A list of very-shortly-named weekdays in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["S", "M", "T", "W", "T", "F", "S"]`.
+    ///
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var veryShortWeekdaySymbols: [String] {
+        return _handle.map { $0.veryShortWeekdaySymbols }
+    }
+    
+    /// A list of standalone weekday names in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]`.
+    /// - note: Stand-alone properties are for use in places like calendar headers. Non-stand-alone properties are for use in context (for example, "Saturday, November 12th").
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var standaloneWeekdaySymbols: [String] {
+        return _handle.map { $0.standaloneWeekdaySymbols }
+    }
+    
+    /// A list of shorter-named standalone weekdays in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]`.
+    /// - note: Stand-alone properties are for use in places like calendar headers. Non-stand-alone properties are for use in context (for example, "Saturday, November 12th").
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var shortStandaloneWeekdaySymbols: [String] {
+        return _handle.map { $0.shortStandaloneWeekdaySymbols }
+    }
+    
+    /// A list of very-shortly-named weekdays in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["S", "M", "T", "W", "T", "F", "S"]`.
+    /// - note: Stand-alone properties are for use in places like calendar headers. Non-stand-alone properties are for use in context (for example, "Saturday, November 12th").
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var veryShortStandaloneWeekdaySymbols: [String] {
+        return _handle.map { $0.veryShortStandaloneWeekdaySymbols }
+    }
+    
+    /// A list of quarter names in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["1st quarter", "2nd quarter", "3rd quarter", "4th quarter"]`.
+    ///
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var quarterSymbols: [String] {
+        return _handle.map { $0.quarterSymbols }
+    }
+    
+    /// A list of shorter-named quarters in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["Q1", "Q2", "Q3", "Q4"]`.
+    ///
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var shortQuarterSymbols: [String] {
+        return _handle.map { $0.shortQuarterSymbols }
+    }
+    
+    /// A list of standalone quarter names in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["1st quarter", "2nd quarter", "3rd quarter", "4th quarter"]`.
+    /// - note: Stand-alone properties are for use in places like calendar headers. Non-stand-alone properties are for use in context (for example, "Saturday, November 12th").
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var standaloneQuarterSymbols: [String] {
+        return _handle.map { $0.standaloneQuarterSymbols }
+    }
+    
+    /// A list of shorter-named standalone quarters in this calendar, localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `["Q1", "Q2", "Q3", "Q4"]`.
+    /// - note: Stand-alone properties are for use in places like calendar headers. Non-stand-alone properties are for use in context (for example, "Saturday, November 12th").
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var shortStandaloneQuarterSymbols: [String] {
+        return _handle.map { $0.shortStandaloneQuarterSymbols }
+    }
+    
+    /// The symbol used to represent "AM", localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `"AM"`.
+    ///
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var amSymbol: String {
+        return _handle.map { $0.amSymbol }
+    }
+    
+    /// The symbol used to represent "PM", localized to the Calendar's `locale`.
+    ///
+    /// For example, for English in the Gregorian calendar, returns `"PM"`.
+    ///
+    /// - note: By default, Calendars have no locale set. If you wish to receive a localized answer, be sure to set the `locale` property first - most likely to `Locale.autoupdatingCurrent`.
+    public var pmSymbol: String {
+        return _handle.map { $0.pmSymbol }
+    }
+    
+    // MARK: -
+    //
+    
+    /// Returns the minimum range limits of the values that a given component can take on in the receiver.
+    ///
+    /// As an example, in the Gregorian calendar the minimum range of values for the Day component is 1-28.
+    /// - parameter component: A component to calculate a range for.
+    /// - returns: The range, or nil if it could not be calculated.
+    public func minimumRange(of component: Component) -> Range<Int>? {
+        return _handle.map { $0.minimumRange(of: Calendar._toCalendarUnit([component])).toRange() }
+    }
+    
+    /// The maximum range limits of the values that a given component can take on in the receive
+    ///
+    /// As an example, in the Gregorian calendar the maximum range of values for the Day component is 1-31.
+    /// - parameter component: A component to calculate a range for.
+    /// - returns: The range, or nil if it could not be calculated.
+    public func maximumRange(of component: Component) -> Range<Int>? {
+        return _handle.map { $0.maximumRange(of: Calendar._toCalendarUnit([component])).toRange() }
+    }
+    
+    
+    @available(*, unavailable, message: "use range(of:in:for:) instead")
+    public func range(of smaller: NSCalendar.Unit, in larger: NSCalendar.Unit, for date: Date) -> NSRange {
+        fatalError()
+    }
+    
+    /// Returns the range of absolute time values that a smaller calendar component (such as a day) can take on in a larger calendar component (such as a month) that includes a specified absolute time.
+    ///
+    /// You can use this method to calculate, for example, the range the `day` component can take on in the `month` in which `date` lies.
+    /// - parameter smaller: The smaller calendar component.
+    /// - parameter larger: The larger calendar component.
+    /// - parameter date: The absolute time for which the calculation is performed.
+    /// - returns: The range of absolute time values smaller can take on in larger at the time specified by date. Returns `nil` if larger is not logically bigger than smaller in the calendar, or the given combination of components does not make sense (or is a computation which is undefined).
+    public func range(of smaller: Component, in larger: Component, for date: Date) -> Range<Int>? {
+        return _handle.map { $0.range(of: Calendar._toCalendarUnit([smaller]), in: Calendar._toCalendarUnit([larger]), for: date).toRange() }
+    }
+    
+    @available(*, unavailable, message: "use range(of:in:for:) instead")
+    public func range(of unit: NSCalendar.Unit, start datep: AutoreleasingUnsafeMutablePointer<NSDate?>?, interval tip: UnsafeMutablePointer<TimeInterval>?, for date: Date) -> Bool {
+        fatalError()
+    }
+    
+    /// Returns, via two inout parameters, the starting time and duration of a given calendar component that contains a given date.
+    ///
+    /// - seealso: `range(of:for:)`
+    /// - seealso: `dateInterval(of:for:)`
+    /// - parameter component: A calendar component.
+    /// - parameter start: Upon return, the starting time of the calendar component that contains the date.
+    /// - parameter interval: Upon return, the duration of the calendar component that contains the date.
+    /// - parameter date: The specified date.
+    /// - returns: `true` if the starting time and duration of a component could be calculated, otherwise `false`.
+    public func dateInterval(of component: Component, start: inout Date, interval: inout TimeInterval, for date: Date) -> Bool {
+        var nsDate : NSDate? = nil
+        var ti : TimeInterval = 0
+        if _handle.map({ $0.range(of: Calendar._toCalendarUnit([component]), start: &nsDate, interval: &ti, for: date) }) {
+            start = nsDate as! Date
+            interval = ti
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    /// Returns the starting time and duration of a given calendar component that contains a given date.
+    ///
+    /// - parameter component: A calendar component.
+    /// - parameter date: The specified date.
+    /// - returns: A new `DateInterval` if the starting time and duration of a component could be calculated, otherwise `nil`.
+    @available(OSX 10.12, iOS 10.0, tvOS 12.0, watchOS 3.0, *)
+    public func dateInterval(of component: Component, for date: Date) -> DateInterval? {
+        var start : Date = Date(timeIntervalSinceReferenceDate: 0)
+        var interval : TimeInterval = 0
+        if self.dateInterval(of: component, start: &start, interval: &interval, for: date) {
+            return DateInterval(start: start, duration: interval)
+        } else {
+            return nil
+        }
+    }
+    
+    /// Returns, for a given absolute time, the ordinal number of a smaller calendar component (such as a day) within a specified larger calendar component (such as a week).
+    ///
+    /// The ordinality is in most cases not the same as the decomposed value of the component. Typically return values are 1 and greater. For example, the time 00:45 is in the first hour of the day, and for components `hour` and `day` respectively, the result would be 1. An exception is the week-in-month calculation, which returns 0 for days before the first week in the month containing the date.
+    ///
+    /// - note: Some computations can take a relatively long time.
+    /// - parameter smaller: The smaller calendar component.
+    /// - parameter larger: The larger calendar component.
+    /// - parameter date: The absolute time for which the calculation is performed.
+    /// - returns: The ordinal number of smaller within larger at the time specified by date. Returns `nil` if larger is not logically bigger than smaller in the calendar, or the given combination of components does not make sense (or is a computation which is undefined).
+    public func ordinality(of smaller: Component, in larger: Component, for date: Date) -> Int? {
+        let result = _handle.map { $0.ordinality(of: Calendar._toCalendarUnit([smaller]), in: Calendar._toCalendarUnit([larger]), for: date) }
+        if result == NSNotFound { return nil }
+        return result
+    }
+    
+    // MARK: -
+    //
+    
+    @available(*, unavailable, message: "use dateComponents(_:from:) instead")
+    public func getEra(_ eraValuePointer: UnsafeMutablePointer<Int>?, year yearValuePointer: UnsafeMutablePointer<Int>?, month monthValuePointer: UnsafeMutablePointer<Int>?, day dayValuePointer: UnsafeMutablePointer<Int>?, from date: Date) { fatalError() }
+    
+    @available(*, unavailable, message: "use dateComponents(_:from:) instead")
+    public func getEra(_ eraValuePointer: UnsafeMutablePointer<Int>?, yearForWeekOfYear yearValuePointer: UnsafeMutablePointer<Int>?, weekOfYear weekValuePointer: UnsafeMutablePointer<Int>?, weekday weekdayValuePointer: UnsafeMutablePointer<Int>?, from date: Date) { fatalError() }
+    
+    @available(*, unavailable, message: "use dateComponents(_:from:) instead")
+    public func getHour(_ hourValuePointer: UnsafeMutablePointer<Int>?, minute minuteValuePointer: UnsafeMutablePointer<Int>?, second secondValuePointer: UnsafeMutablePointer<Int>?, nanosecond nanosecondValuePointer: UnsafeMutablePointer<Int>?, from date: Date) { fatalError() }
+    
+    // MARK: -
+    //
+    
+    
+    @available(*, unavailable, message: "use date(byAdding:to:wrappingComponents:) instead")
+    public func date(byAdding unit: NSCalendar.Unit, value: Int, to date: Date, options: NSCalendar.Options = []) -> Date? { fatalError() }
+    
+    /// Returns a new `Date` representing the date calculated by adding components to a given date.
+    ///
+    /// - parameter components: A set of values to add to the date.
+    /// - parameter date: The starting date.
+    /// - parameter wrappingComponents: If `true`, the component should be incremented and wrap around to zero/one on overflow, and should not cause higher components to be incremented. The default value is `false`.
+    /// - returns: A new date, or nil if a date could not be calculated with the given input.
+    public func date(byAdding components: DateComponents, to date: Date, wrappingComponents: Bool = false) -> Date? {
+        return _handle.map { $0.date(byAdding: components, to: date, options: wrappingComponents ? [.wrapComponents] : []) }
+    }
+    
+    
+    @available(*, unavailable, message: "use date(byAdding:to:wrappingComponents:) instead")
+    public func date(byAdding comps: DateComponents, to date: Date, options opts: NSCalendar.Options = []) -> Date? { fatalError() }
+    
+    /// Returns a new `Date` representing the date calculated by adding an amount of a specific component to a given date.
+    ///
+    /// - parameter component: A single component to add.
+    /// - parameter value: The value of the specified component to add.
+    /// - parameter date: The starting date.
+    /// - parameter wrappingComponents: If `true`, the component should be incremented and wrap around to zero/one on overflow, and should not cause higher components to be incremented. The default value is `false`.
+    /// - returns: A new date, or nil if a date could not be calculated with the given input.
+    @available(iOS 8.0, *)
+    public func date(byAdding component: Component, value: Int, to date: Date, wrappingComponents: Bool = false) -> Date? {
+        return _handle.map { $0.date(byAdding: Calendar._toCalendarUnit([component]), value: value, to: date, options: wrappingComponents ? [.wrapComponents] : []) }
+    }
+    
+    /// Returns a date created from the specified components.
+    ///
+    /// - parameter components: Used as input to the search algorithm for finding a corresponding date.
+    /// - returns: A new `Date`, or nil if a date could not be found which matches the components.
+    public func date(from components: DateComponents) -> Date? {
+        return _handle.map { $0.date(from: components) }
+    }
+    
+    @available(*, unavailable, renamed: "dateComponents(_:from:)")
+    public func components(_ unitFlags: NSCalendar.Unit, from date: Date) -> DateComponents { fatalError() }
+    
+    /// Returns all the date components of a date, using the calendar time zone.
+    ///
+    /// - note: If you want "date information in a given time zone" in order to display it, you should use `DateFormatter` to format the date.
+    /// - parameter date: The `Date` to use.
+    /// - returns: The date components of the specified date.
+    public func dateComponents(_ components: Set<Component>, from date: Date) -> DateComponents {
+        return _handle.map { $0.components(Calendar._toCalendarUnit(components), from: date) }
+    }
+    
+    
+    @available(*, unavailable, renamed: "dateComponents(in:from:)")
+    public func components(in timezone: TimeZone, from date: Date) -> DateComponents { fatalError() }
+    
+    /// Returns all the date components of a date, as if in a given time zone (instead of the `Calendar` time zone).
+    ///
+    /// The time zone overrides the time zone of the `Calendar` for the purposes of this calculation.
+    /// - note: If you want "date information in a given time zone" in order to display it, you should use `DateFormatter` to format the date.
+    /// - parameter timeZone: The `TimeZone` to use.
+    /// - parameter date: The `Date` to use.
+    /// - returns: All components, calculated using the `Calendar` and `TimeZone`.
+    @available(iOS 8.0, *)
+    public func dateComponents(in timeZone: TimeZone, from date: Date) -> DateComponents {
+        return _handle.map { $0.components(in: timeZone, from: date) }
+    }
+    
+    @available(*, unavailable, renamed: "dateComponents(_:from:to:)")
+    public func components(_ unitFlags: NSCalendar.Unit, from startingDate: Date, to resultDate: Date, options opts: NSCalendar.Options = []) -> DateComponents { fatalError() }
+    
+    /// Returns the difference between two dates.
+    ///
+    /// - parameter components: Which components to compare.
+    /// - parameter start: The starting date.
+    /// - parameter end: The ending date.
+    /// - returns: The result of calculating the difference from start to end.
+    public func dateComponents(_ components: Set<Component>, from start: Date, to end: Date) -> DateComponents {
+        return _handle.map { $0.components(Calendar._toCalendarUnit(components), from: start, to: end, options: []) }
+    }
+    
+    @available(*, unavailable, renamed: "dateComponents(_:from:to:)")
+    public func components(_ unitFlags: NSCalendar.Unit, from startingDateComp: DateComponents, to resultDateComp: DateComponents, options: NSCalendar.Options = []) -> DateComponents { fatalError() }
+    
+    /// Returns the difference between two dates specified as `DateComponents`.
+    ///
+    /// For components which are not specified in each `DateComponents`, but required to specify an absolute date, the base value of the component is assumed.  For example, for an `DateComponents` with just a `year` and a `month` specified, a `day` of 1, and an `hour`, `minute`, `second`, and `nanosecond` of 0 are assumed.
+    /// Calendrical calculations with unspecified `year` or `year` value prior to the start of a calendar are not advised.
+    /// For each `DateComponents`, if its `timeZone` property is set, that time zone is used for it. If the `calendar` property is set, that is used rather than the receiving calendar, and if both the `calendar` and `timeZone` are set, the `timeZone` property value overrides the time zone of the `calendar` property.
+    ///
+    /// - parameter components: Which components to compare.
+    /// - parameter start: The starting date components.
+    /// - parameter end: The ending date components.
+    /// - returns: The result of calculating the difference from start to end.
+    @available(iOS 8.0, *)
+    public func dateComponents(_ components: Set<Component>, from start: DateComponents, to end: DateComponents) -> DateComponents {
+        return _handle.map { $0.components(Calendar._toCalendarUnit(components), from: start, to: end, options: []) }
+    }
+    
+    
+    /// Returns the value for one component of a date.
+    ///
+    /// - parameter component: The component to calculate.
+    /// - parameter date: The date to use.
+    /// - returns: The value for the component.
+    @available(iOS 8.0, *)
+    public func component(_ component: Component, from date: Date) -> Int {
+        return _handle.map { $0.component(Calendar._toCalendarUnit([component]), from: date) }
+    }
+    
+    
+    @available(*, unavailable, message: "Use date(from:) instead")
+    public func date(era: Int, year: Int, month: Int, day: Int, hour: Int, minute: Int, second: Int, nanosecond: Int) -> Date? { fatalError() }
+    
+    
+    @available(*, unavailable, message: "Use date(from:) instead")
+    public func date(era: Int, yearForWeekOfYear: Int, weekOfYear: Int, weekday: Int, hour: Int, minute: Int, second: Int, nanosecond: Int) -> Date? { fatalError() }
+    
+    
+    /// Returns the first moment of a given Date, as a Date.
+    ///
+    /// For example, pass in `Date()`, if you want the start of today.
+    /// If there were two midnights, it returns the first.  If there was none, it returns the first moment that did exist.
+    /// - parameter date: The date to search.
+    /// - returns: The first moment of the given date.
+    @available(iOS 8.0, *)
+    public func startOfDay(for date: Date) -> Date {
+        return _handle.map { $0.startOfDay(for: date) }
+    }
+    
+    
+    @available(*, unavailable, renamed: "compare(_:to:toGranularity:)")
+    public func compare(_ date1: Date, to date2: Date, toUnitGranularity unit: NSCalendar.Unit) -> ComparisonResult { fatalError() }
+    
+    
+    /// Compares the given dates down to the given component, reporting them `orderedSame` if they are the same in the given component and all larger components, otherwise either `orderedAscending` or `orderedAscending`.
+    ///
+    /// - parameter date1: A date to compare.
+    /// - parameter date2: A date to compare.
+    /// - parameter: component: A granularity to compare. For example, pass `.hour` to check if two dates are in the same hour.
+    @available(iOS 8.0, *)
+    public func compare(_ date1: Date, to date2: Date, toGranularity component: Component) -> ComparisonResult {
+        return _handle.map { $0.compare(date1, to: date2, toUnitGranularity: Calendar._toCalendarUnit([component])) }
+    }
+    
+    
+    @available(*, unavailable, renamed: "isDate(_:equalTo:toGranularity:)")
+    public func isDate(_ date1: Date, equalTo date2: Date, toUnitGranularity unit: NSCalendar.Unit) -> Bool { fatalError() }
+    
+    /// Compares the given dates down to the given component, reporting them equal if they are the same in the given component and all larger components.
+    ///
+    /// - parameter date1: A date to compare.
+    /// - parameter date2: A date to compare.
+    /// - parameter component: A granularity to compare. For example, pass `.hour` to check if two dates are in the same hour.
+    /// - returns: `true` if the given date is within tomorrow.
+    @available(iOS 8.0, *)
+    public func isDate(_ date1: Date, equalTo date2: Date, toGranularity component: Component) -> Bool {
+        return _handle.map { $0.isDate(date1, equalTo: date2, toUnitGranularity: Calendar._toCalendarUnit([component])) }
+    }
+    
+    
+    /// Returns `true` if the given date is within the same day as another date, as defined by the calendar and calendar's locale.
+    ///
+    /// - parameter date1: A date to check for containment.
+    /// - parameter date2: A date to check for containment.
+    /// - returns: `true` if `date1` and `date2` are in the same day.
+    @available(iOS 8.0, *)
+    public func isDate(_ date1: Date, inSameDayAs date2: Date) -> Bool {
+        return _handle.map { $0.isDate(date1, inSameDayAs: date2) }
+    }
+    
+    
+    /// Returns `true` if the given date is within today, as defined by the calendar and calendar's locale.
+    ///
+    /// - parameter date: The specified date.
+    /// - returns: `true` if the given date is within today.
+    @available(iOS 8.0, *)
+    public func isDateInToday(_ date: Date) -> Bool {
+        return _handle.map { $0.isDateInToday(date) }
+    }
+    
+    
+    /// Returns `true` if the given date is within yesterday, as defined by the calendar and calendar's locale.
+    ///
+    /// - parameter date: The specified date.
+    /// - returns: `true` if the given date is within yesterday.
+    @available(iOS 8.0, *)
+    public func isDateInYesterday(_ date: Date) -> Bool {
+        return _handle.map { $0.isDateInYesterday(date) }
+    }
+    
+    
+    /// Returns `true` if the given date is within tomorrow, as defined by the calendar and calendar's locale.
+    ///
+    /// - parameter date: The specified date.
+    /// - returns: `true` if the given date is within tomorrow.
+    @available(iOS 8.0, *)
+    public func isDateInTomorrow(_ date: Date) -> Bool {
+        return _handle.map { $0.isDateInTomorrow(date) }
+    }
+    
+    
+    /// Returns `true` if the given date is within a weekend period, as defined by the calendar and calendar's locale.
+    ///
+    /// - parameter date: The specified date.
+    /// - returns: `true` if the given date is within a weekend.
+    @available(iOS 8.0, *)
+    public func isDateInWeekend(_ date: Date) -> Bool {
+        return _handle.map { $0.isDateInWeekend(date) }
+    }
+    
+    @available(*, unavailable, message: "use dateIntervalOfWeekend(containing:start:interval:) instead")
+    public func range(ofWeekendStart datep: AutoreleasingUnsafeMutablePointer<NSDate?>?, interval tip: UnsafeMutablePointer<TimeInterval>?, containing date: Date) -> Bool { fatalError() }
+    
+    /// Find the range of the weekend around the given date, returned via two by-reference parameters.
+    ///
+    /// Note that a given entire day within a calendar is not necessarily all in a weekend or not; weekends can start in the middle of a day in some calendars and locales.
+    /// - seealso: `dateIntervalOfWeekend(containing:)`
+    /// - parameter date: The date at which to start the search.
+    /// - parameter start: When the result is `true`, set
+    /// - returns: `true` if a date range could be found, and `false` if the date is not in a weekend.
+    @available(iOS 8.0, *)
+    public func dateIntervalOfWeekend(containing date: Date, start: inout Date, interval: inout TimeInterval) -> Bool {
+        var nsDate : NSDate? = nil
+        var ti : TimeInterval = 0
+        if _handle.map({ $0.range(ofWeekendStart: &nsDate, interval: &ti, containing: date) }) {
+            start = nsDate as! Date
+            interval = ti
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    /// Returns a `DateInterval` of the weekend contained by the given date, or nil if the date is not in a weekend.
+    ///
+    /// - parameter date: The date contained in the weekend.
+    /// - returns: A `DateInterval`, or nil if the date is not in a weekend.
+    @available(OSX 10.12, iOS 10.0, tvOS 12.0, watchOS 3.0, *)
+    public func dateIntervalOfWeekend(containing date: Date) -> DateInterval? {
+        var nsDate : NSDate? = nil
+        var ti : TimeInterval = 0
+        if _handle.map({ $0.range(ofWeekendStart: &nsDate, interval: &ti, containing: date) }) {
+            return DateInterval(start: nsDate as! Date, duration: ti)
+        } else {
+            return nil
+        }
+    }
+    
+    
+    @available(*, unavailable, message: "use nextWeekend(startingAfter:start:interval:direction:) instead")
+    public func nextWeekendStart(_ datep: AutoreleasingUnsafeMutablePointer<NSDate?>?, interval tip: UnsafeMutablePointer<TimeInterval>?, options: NSCalendar.Options = [], after date: Date) -> Bool { fatalError() }
+    
+    /// Returns the range of the next weekend via two inout parameters. The weekend starts strictly after the given date.
+    ///
+    /// If `direction` is `.backward`, then finds the previous weekend range strictly before the given date.
+    ///
+    /// Note that a given entire Day within a calendar is not necessarily all in a weekend or not; weekends can start in the middle of a day in some calendars and locales.
+    /// - parameter date: The date at which to begin the search.
+    /// - parameter direction: Which direction in time to search. The default value is `.forward`.
+    /// - returns: A `DateInterval`, or nil if the weekend could not be found.
+    @available(iOS 8.0, *)
+    public func nextWeekend(startingAfter date: Date, start: inout Date, interval: inout TimeInterval, direction: SearchDirection = .forward) -> Bool {
+        // The implementation actually overrides previousKeepSmaller and nextKeepSmaller with matchNext, always - but strict still trumps all.
+        var nsDate : NSDate? = nil
+        var ti : TimeInterval = 0
+        if _handle.map({ $0.nextWeekendStart(&nsDate, interval: &ti, options: direction == .backward ? [.searchBackwards] : [], after: date) }) {
+            start = nsDate as! Date
+            interval = ti
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    /// Returns a `DateInterval` of the next weekend, which starts strictly after the given date.
+    ///
+    /// If `direction` is `.backward`, then finds the previous weekend range strictly before the given date.
+    ///
+    /// Note that a given entire Day within a calendar is not necessarily all in a weekend or not; weekends can start in the middle of a day in some calendars and locales.
+    /// - parameter date: The date at which to begin the search.
+    /// - parameter direction: Which direction in time to search. The default value is `.forward`.
+    /// - returns: A `DateInterval`, or nil if weekends do not exist in the specific calendar or locale.
+    @available(OSX 10.12, iOS 10.0, tvOS 12.0, watchOS 3.0, *)
+    public func nextWeekend(startingAfter date: Date, direction: SearchDirection = .forward) -> DateInterval? {
+        // The implementation actually overrides previousKeepSmaller and nextKeepSmaller with matchNext, always - but strict still trumps all.
+        var nsDate : NSDate? = nil
+        var ti : TimeInterval = 0
+        if _handle.map({ $0.nextWeekendStart(&nsDate, interval: &ti, options: direction == .backward ? [.searchBackwards] : [], after: date) }) {
+            /// WARNING: searching backwards is totally broken! 26643365
+            return DateInterval(start: nsDate as! Date, duration: ti)
+        } else {
+            return nil
+        }
+    }
+    
+    // MARK: -
+    // MARK: Searching
+    
+    /// The direction in time to search.
+    public enum SearchDirection {
+        /// Search for a date later in time than the start date.
+        case forward
+        
+        /// Search for a date earlier in time than the start date.
+        case backward
+    }
+    
+    /// Determines which result to use when a time is repeated on a day in a calendar (for example, during a daylight saving transition when the times between 2:00am and 3:00am may happen twice).
+    public enum RepeatedTimePolicy {
+        /// If there are two or more matching times (all the components are the same, including isLeapMonth) before the end of the next instance of the next higher component to the highest specified component, then the algorithm will return the first occurrence.
+        case first
+        
+        /// If there are two or more matching times (all the components are the same, including isLeapMonth) before the end of the next instance of the next higher component to the highest specified component, then the algorithm will return the last occurrence.
+        case last
+    }
+    
+    /// A hint to the search algorithm to control the method used for searching for dates.
+    public enum MatchingPolicy {
+        /// If there is no matching time before the end of the next instance of the next higher component to the highest specified component in the `DateComponents` argument, the algorithm will return the next existing time which exists.
+        ///
+        /// For example, during a daylight saving transition there may be no 2:37am. The result would then be 3:00am, if that does exist.
+        case nextTime
+        
+        /// If specified, and there is no matching time before the end of the next instance of the next higher component to the highest specified component in the `DateComponents` argument, the method will return the next existing value of the missing component and preserves the lower components' values (e.g., no 2:37am results in 3:37am, if that exists).
+        case nextTimePreservingSmallerComponents
+        
+        /// If there is no matching time before the end of the next instance of the next higher component to the highest specified component in the `DateComponents` argument, the algorithm will return the previous existing value of the missing component and preserves the lower components' values.
+        ///
+        /// For example, during a daylight saving transition there may be no 2:37am. The result would then be 1:37am, if that does exist.
+        case previousTimePreservingSmallerComponents
+        
+        /// If specified, the algorithm travels as far forward or backward as necessary looking for a match.
+        ///
+        /// For example, if searching for Feb 29 in the Gregorian calendar, the algorithm may choose March 1 instead (for example, if the year is not a leap year). If you wish to find the next Feb 29 without the algorithm adjusting the next higher component in the specified `DateComponents`, then use the `strict` option.
+        /// - note: There are ultimately implementation-defined limits in how far distant the search will go.
+        case strict
+    }
+    
+    @available(*, unavailable, message: "use nextWeekend(startingAfter:matching:matchingPolicy:repeatedTimePolicy:direction:using:) instead")
+    public func enumerateDates(startingAfter start: Date, matching comps: DateComponents, options opts: NSCalendar.Options = [], using block: @noescape (Date?, Bool, UnsafeMutablePointer<ObjCBool>) -> Swift.Void) { fatalError() }
+    
+    /// Computes the dates which match (or most closely match) a given set of components, and calls the closure once for each of them, until the enumeration is stopped.
+    ///
+    /// There will be at least one intervening date which does not match all the components (or the given date itself must not match) between the given date and any result.
+    ///
+    /// If `direction` is set to `.backward`, this method finds the previous match before the given date. The intent is that the same matches as for a `.forward` search will be found (that is, if you are enumerating forwards or backwards for each hour with minute "27", the seconds in the date you will get in forwards search would obviously be 00, and the same will be true in a backwards search in order to implement this rule.  Similarly for DST backwards jumps which repeats times, you'll get the first match by default, where "first" is defined from the point of view of searching forwards.  So, when searching backwards looking for a particular hour, with no minute and second specified, you don't get a minute and second of 59:59 for the matching hour (which would be the nominal first match within a given hour, given the other rules here, when searching backwards).
+    ///
+    /// If an exact match is not possible, and requested with the `strict` option, nil is passed to the closure and the enumeration ends.  (Logically, since an exact match searches indefinitely into the future, if no match is found there's no point in continuing the enumeration.)
+    ///
+    /// Result dates have an integer number of seconds (as if 0 was specified for the nanoseconds property of the `DateComponents` matching parameter), unless a value was set in the nanoseconds property, in which case the result date will have that number of nanoseconds (or as close as possible with floating point numbers).
+    ///
+    /// The enumeration is stopped by setting `stop` to `true` in the closure and returning. It is not necessary to set `stop` to `false` to keep the enumeration going.
+    /// - parameter start: The `Date` at which to start the search.
+    /// - parameter components: The `DateComponents` to use as input to the search algorithm.
+    /// - parameter matchingPolicy: Determines the behavior of the search algorithm when the input produces an ambiguous result.
+    /// - parameter repeatedTimePolicy: Determines the behavior of the search algorithm when the input produces a time that occurs twice on a particular day.
+    /// - parameter direction: Which direction in time to search. The default value is `.forward`, which means later in time.
+    /// - parameter block: A closure that is called with search results.
+    @available(iOS 8.0, *)
+    public func enumerateDates(startingAfter start: Date, matching components: DateComponents, matchingPolicy: MatchingPolicy, repeatedTimePolicy: RepeatedTimePolicy = .first, direction: SearchDirection = .forward, using block: @noescape (result: Date?, exactMatch: Bool, stop: inout Bool) -> Void) {
+        _handle.map {
+            $0.enumerateDates(startingAfter: start, matching: components, options: Calendar._toCalendarOptions(matchingPolicy: matchingPolicy, repeatedTimePolicy: repeatedTimePolicy, direction: direction)) { (result, exactMatch, stop) in
+                var stopv = false
+                block(result: result, exactMatch: exactMatch, stop: &stopv)
+                if stopv {
+                    stop.pointee = true
+                }
+            }
+        }
+    }
+    
+    
+    @available(*, unavailable, message: "use nextDate(after:matching:matchingPolicy:repeatedTimePolicy:direction:) instead")
+    public func nextDate(after date: Date, matching comps: DateComponents, options: NSCalendar.Options = []) -> Date? { fatalError() }
+    
+    /// Computes the next date which matches (or most closely matches) a given set of components.
+    ///
+    /// The general semantics follow those of the `enumerateDates` function.
+    /// To compute a sequence of results, use the `enumerateDates` function, rather than looping and calling this method with the previous loop iteration's result.
+    /// - parameter date: The starting date.
+    /// - parameter components: The components to search for.
+    /// - parameter matchingPolicy: Specifies the technique the search algorithm uses to find results. Default value is `.nextTime`.
+    /// - parameter repeatedTimePolicy: Specifies the behavior when multiple matches are found. Default value is `.first`.
+    /// - parameter direction: Specifies the direction in time to search. Default is `.forward`.
+    /// - returns: A `Date` representing the result of the search, or `nil` if a result could not be found.
+    @available(iOS 8.0, *)
+    public func nextDate(after date: Date, matching components: DateComponents, matchingPolicy: MatchingPolicy, repeatedTimePolicy: RepeatedTimePolicy = .first, direction: SearchDirection = .forward) -> Date? {
+        return _handle.map { $0.nextDate(after: date, matching: components, options: Calendar._toCalendarOptions(matchingPolicy: matchingPolicy, repeatedTimePolicy: repeatedTimePolicy, direction: direction)) }
+    }
+    
+    @available(*, unavailable, message: "use nextDate(after:matching:matchingPolicy:repeatedTimePolicy:direction:) instead")
+    public func nextDate(after date: Date, matchingHour hourValue: Int, minute minuteValue: Int, second secondValue: Int, options: NSCalendar.Options = []) -> Date? { fatalError() }
+
+    // MARK: -
+    //
+    
+    @available(*, unavailable, renamed: "date(bySetting:value:of:)")
+    public func date(bySettingUnit unit: NSCalendar.Unit, value v: Int, of date: Date, options opts: NSCalendar.Options = []) -> Date? { fatalError() }
+    
+    /// Returns a new `Date` representing the date calculated by setting a specific component to a given time, and trying to keep lower components the same.  If the component already has that value, this may result in a date which is the same as the given date.
+    ///
+    /// Changing a component's value often will require higher or coupled components to change as well.  For example, setting the Weekday to Thursday usually will require the Day component to change its value, and possibly the Month and Year as well.
+    /// If no such time exists, the next available time is returned (which could, for example, be in a different day, week, month, ... than the nominal target date).  Setting a component to something which would be inconsistent forces other components to change; for example, setting the Weekday to Thursday probably shifts the Day and possibly Month and Year.
+    /// The exact behavior of this method is implementation-defined. For example, if changing the weekday to Thursday, does that move forward to the next, backward to the previous, or to the nearest Thursday? The algorithm will try to produce a result which is in the next-larger component to the one given (there's a table of this mapping at the top of this document).  So for the "set to Thursday" example, find the Thursday in the Week in which the given date resides (which could be a forwards or backwards move, and not necessarily the nearest Thursday). For more control over the exact behavior, use `nextDate(after:matching:matchingPolicy:behavior:direction:)`.
+    @available(iOS 8.0, *)
+    public func date(bySetting component: Component, value: Int, of date: Date) -> Date? {
+        return _handle.map { $0.date(bySettingUnit: Calendar._toCalendarUnit([component]), value: value, of: date, options: []) }
+    }
+    
+    
+    @available(*, unavailable, message: "use date(bySettingHour:minute:second:of:matchingPolicy:repeatedTimePolicy:direction:) instead")
+    public func date(bySettingHour h: Int, minute m: Int, second s: Int, of date: Date, options opts: NSCalendar.Options = []) -> Date? { fatalError() }
+    
+    /// Returns a new `Date` representing the date calculated by setting hour, minute, and second to a given time on a specified `Date`.
+    ///
+    /// If no such time exists, the next available time is returned (which could, for example, be in a different day than the nominal target date).
+    /// The intent is to return a date on the same day as the original date argument.  This may result in a date which is backward than the given date, of course.
+    /// - parameter hour: A specified hour.
+    /// - parameter minute: A specified minute.
+    /// - parameter second: A specified second.
+    /// - parameter date: The date to start calculation with.
+    /// - parameter matchingPolicy: Specifies the technique the search algorithm uses to find results. Default value is `.nextTime`.
+    /// - parameter repeatedTimePolicy: Specifies the behavior when multiple matches are found. Default value is `.first`.
+    /// - parameter direction: Specifies the direction in time to search. Default is `.forward`.
+    /// - returns: A `Date` representing the result of the search, or `nil` if a result could not be found.
+    @available(iOS 8.0, *)
+    public func date(bySettingHour hour: Int, minute: Int, second: Int, of date: Date, matchingPolicy: MatchingPolicy = .nextTime, repeatedTimePolicy: RepeatedTimePolicy = .first, direction: SearchDirection = .forward) -> Date? {
+        return _handle.map { $0.date(bySettingHour: hour, minute: minute, second: second, of: date, options: Calendar._toCalendarOptions(matchingPolicy: matchingPolicy, repeatedTimePolicy: repeatedTimePolicy, direction: direction)) }
+    }
+    
+    /// Determine if the `Date` has all of the specified `DateComponents`.
+    ///
+    /// It may be useful to test the return value of `nextDate(after:matching:matchingPolicy:behavior:direction:)` to find out if the components were obeyed or if the method had to fudge the result value due to missing time (for example, a daylight saving time transition).
+    ///
+    /// - returns: `true` if the date matches all of the components, otherwise `false`.
+    @available(iOS 8.0, *)
+    public func date(_ date: Date, matchesComponents components: DateComponents) -> Bool {
+        return _handle.map { $0.date(date, matchesComponents: components) }
+    }
+    
+    // MARK: -
+    
+    public var description: String {
+        return _handle.map { $0.description }
+    }
+    
+    public var debugDescription : String {
+        return _handle.map { $0.debugDescription }
+    }
+    
+    public var hashValue : Int {
+        // We implement hash ourselves, because we need to make sure autoupdating calendars have the same hash
+        if _autoupdating {
+            return 1
+        } else {
+            return _handle.map { $0.hash }
+        }
+    }
+    
+    // MARK: -
+    // MARK: Conversion Functions
+    
+    /// Turn our more-specific options into the big bucket option set of NSCalendar
+    private static func _toCalendarOptions(matchingPolicy: MatchingPolicy, repeatedTimePolicy: RepeatedTimePolicy, direction: SearchDirection) -> NSCalendar.Options {
+        var result : NSCalendar.Options = []
+        
+        switch matchingPolicy {
+        case .nextTime:
+            let _ = result.insert(.matchNextTime)
+        case .nextTimePreservingSmallerComponents:
+            let _ = result.insert(.matchNextTimePreservingSmallerUnits)
+        case .previousTimePreservingSmallerComponents:
+            let _ = result.insert(.matchPreviousTimePreservingSmallerUnits)
+        case .strict:
+            let _ = result.insert(.matchStrictly)
+        }
+        
+        switch repeatedTimePolicy {
+        case .first:
+            let _ = result.insert(.matchFirst)
+        case .last:
+            let _ = result.insert(.matchLast)
+        }
+        
+        switch direction {
+        case .backward:
+            let _ = result.insert(.searchBackwards)
+        case .forward:
+            break
+        }
+        
+        return result
+    }
+    
+    internal static func _toCalendarUnit(_ units : Set<Component>) -> NSCalendar.Unit {
+        let unitMap : [Component : NSCalendar.Unit] =
+            [.era : .era,
+             .year : .year,
+             .month : .month,
+             .day : .day,
+             .hour : .hour,
+             .minute : .minute,
+             .second : .second,
+             .weekday : .weekday,
+             .weekdayOrdinal : .weekdayOrdinal,
+             .quarter : .quarter,
+             .weekOfMonth : .weekOfMonth,
+             .weekOfYear : .weekOfYear,
+             .yearForWeekOfYear : .yearForWeekOfYear,
+             .nanosecond : .nanosecond,
+             .calendar : .calendar,
+             .timeZone : .timeZone]
+        
+        var result = NSCalendar.Unit()
+        for u in units {
+            let _ = result.insert(unitMap[u]!)
+        }
+        return result
+    }
+    
+    internal static func _toNSCalendarIdentifier(_ identifier : Identifier) -> NSCalendar.Identifier {
+        if #available(OSX 10.10, iOS 8.0, *) {
+            let identifierMap : [Identifier : NSCalendar.Identifier] =
+                [.gregorian : .gregorian,
+                 .buddhist : .buddhist,
+                 .chinese : .chinese,
+                 .coptic : .coptic,
+                 .ethiopicAmeteMihret : .ethiopicAmeteMihret,
+                 .ethiopicAmeteAlem : .ethiopicAmeteAlem,
+                 .hebrew : .hebrew,
+                 .iso8601 : .ISO8601,
+                 .indian : .indian,
+                 .islamic : .islamic,
+                 .islamicCivil : .islamicCivil,
+                 .japanese : .japanese,
+                 .persian : .persian,
+                 .republicOfChina : .republicOfChina,
+                 .islamicTabular : .islamicTabular,
+                 .islamicUmmAlQura : .islamicUmmAlQura]
+            return identifierMap[identifier]!
+        } else {
+            let identifierMap : [Identifier : NSCalendar.Identifier] =
+                [.gregorian : .gregorian,
+                 .buddhist : .buddhist,
+                 .chinese : .chinese,
+                 .coptic : .coptic,
+                 .ethiopicAmeteMihret : .ethiopicAmeteMihret,
+                 .ethiopicAmeteAlem : .ethiopicAmeteAlem,
+                 .hebrew : .hebrew,
+                 .iso8601 : .ISO8601,
+                 .indian : .indian,
+                 .islamic : .islamic,
+                 .islamicCivil : .islamicCivil,
+                 .japanese : .japanese,
+                 .persian : .persian,
+                 .republicOfChina : .republicOfChina]
+            return identifierMap[identifier]!
+        }
+    }
+    
+    private static func _fromNSCalendarIdentifier(_ identifier : NSCalendar.Identifier) -> Identifier {
+        if #available(OSX 10.10, iOS 8.0, *) {
+            let identifierMap : [NSCalendar.Identifier : Identifier] =
+                [.gregorian : .gregorian,
+                 .buddhist : .buddhist,
+                 .chinese : .chinese,
+                 .coptic : .coptic,
+                 .ethiopicAmeteMihret : .ethiopicAmeteMihret,
+                 .ethiopicAmeteAlem : .ethiopicAmeteAlem,
+                 .hebrew : .hebrew,
+                 .ISO8601 : .iso8601,
+                 .indian : .indian,
+                 .islamic : .islamic,
+                 .islamicCivil : .islamicCivil,
+                 .japanese : .japanese,
+                 .persian : .persian,
+                 .republicOfChina : .republicOfChina,
+                 .islamicTabular : .islamicTabular,
+                 .islamicUmmAlQura : .islamicUmmAlQura]
+            return identifierMap[identifier]!
+        } else {
+            let identifierMap : [NSCalendar.Identifier : Identifier] =
+                [.gregorian : .gregorian,
+                 .buddhist : .buddhist,
+                 .chinese : .chinese,
+                 .coptic : .coptic,
+                 .ethiopicAmeteMihret : .ethiopicAmeteMihret,
+                 .ethiopicAmeteAlem : .ethiopicAmeteAlem,
+                 .hebrew : .hebrew,
+                 .ISO8601 : .iso8601,
+                 .indian : .indian,
+                 .islamic : .islamic,
+                 .islamicCivil : .islamicCivil,
+                 .japanese : .japanese,
+                 .persian : .persian,
+                 .republicOfChina : .republicOfChina]
+            return identifierMap[identifier]!
+        }
+    }
+}
+
+public func ==(lhs: Calendar, rhs: Calendar) -> Bool {
+    if lhs._autoupdating || rhs._autoupdating {
+        return lhs._autoupdating == rhs._autoupdating
+    } else {
+        // NSCalendar's isEqual is broken (27019864) so we must implement this ourselves
+        return lhs.identifier == rhs.identifier &&
+            lhs.locale == rhs.locale &&
+            lhs.timeZone == rhs.timeZone &&
+            lhs.firstWeekday == rhs.firstWeekday &&
+            lhs.minimumDaysInFirstWeek == rhs.minimumDaysInFirstWeek
+    }
+}
+
+extension Calendar : _ObjectiveCBridgeable {
+    public static func _isBridgedToObjectiveC() -> Bool {
+        return true
+    }
+    
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSCalendar {
+        return _handle._copiedReference()
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ input: NSCalendar, result: inout Calendar?) {
+        if !_conditionallyBridgeFromObjectiveC(input, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ input: NSCalendar, result: inout Calendar?) -> Bool {
+        result = Calendar(reference: input)
+        return true
+    }
+    
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSCalendar?) -> Calendar {
+        var result: Calendar? = nil
+        _forceBridgeFromObjectiveC(source!, result: &result)
+        return result!
+    }
+}
+

--- a/stdlib/public/SDK/Foundation/Calendar.swift
+++ b/stdlib/public/SDK/Foundation/Calendar.swift
@@ -426,7 +426,7 @@ public struct Calendar : CustomStringConvertible, CustomDebugStringConvertible, 
     /// - parameter component: A calendar component.
     /// - parameter date: The specified date.
     /// - returns: A new `DateInterval` if the starting time and duration of a component could be calculated, otherwise `nil`.
-    @available(OSX 10.12, iOS 10.0, tvOS 12.0, watchOS 3.0, *)
+    @available(OSX 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
     public func dateInterval(of component: Component, for date: Date) -> DateInterval? {
         var start : Date = Date(timeIntervalSinceReferenceDate: 0)
         var interval : TimeInterval = 0
@@ -703,7 +703,7 @@ public struct Calendar : CustomStringConvertible, CustomDebugStringConvertible, 
     ///
     /// - parameter date: The date contained in the weekend.
     /// - returns: A `DateInterval`, or nil if the date is not in a weekend.
-    @available(OSX 10.12, iOS 10.0, tvOS 12.0, watchOS 3.0, *)
+    @available(OSX 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
     public func dateIntervalOfWeekend(containing date: Date) -> DateInterval? {
         var nsDate : NSDate? = nil
         var ti : TimeInterval = 0
@@ -748,7 +748,7 @@ public struct Calendar : CustomStringConvertible, CustomDebugStringConvertible, 
     /// - parameter date: The date at which to begin the search.
     /// - parameter direction: Which direction in time to search. The default value is `.forward`.
     /// - returns: A `DateInterval`, or nil if weekends do not exist in the specific calendar or locale.
-    @available(OSX 10.12, iOS 10.0, tvOS 12.0, watchOS 3.0, *)
+    @available(OSX 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
     public func nextWeekend(startingAfter date: Date, direction: SearchDirection = .forward) -> DateInterval? {
         // The implementation actually overrides previousKeepSmaller and nextKeepSmaller with matchNext, always - but strict still trumps all.
         var nsDate : NSDate? = nil

--- a/stdlib/public/SDK/Foundation/DateComponents.swift
+++ b/stdlib/public/SDK/Foundation/DateComponents.swift
@@ -217,16 +217,20 @@ public struct DateComponents : ReferenceConvertible, Hashable, Equatable, _Mutab
     ///
     /// The calendar and timeZone and isLeapMonth properties cannot be set by this method.
     @available(OSX 10.9, iOS 8.0, *)
-    public mutating func setValue(_ value: Int?, forComponent unit: Calendar.Unit) {
-        _applyMutation { $0.setValue(_setter(value), forComponent: unit) }
+    public mutating func setValue(_ value: Int?, for component: Calendar.Component) {
+        _applyMutation {
+            $0.setValue(_setter(value), forComponent: Calendar._toCalendarUnit([component]))
+        }
     }
     
     /// Returns the value of one of the properties, using an enumeration value instead of a property name.
     ///
     /// The calendar and timeZone and isLeapMonth property values cannot be retrieved by this method.
     @available(OSX 10.9, iOS 8.0, *)
-    public func value(forComponent unit: Calendar.Unit) -> Int? {
-        return _handle.map { $0.value(forComponent: unit) }
+    public func value(for component: Calendar.Component) -> Int? {
+        return _handle.map {
+            $0.value(forComponent: Calendar._toCalendarUnit([component]))
+        }
     }
     
     // MARK: -

--- a/stdlib/public/SDK/Foundation/Locale.swift
+++ b/stdlib/public/SDK/Foundation/Locale.swift
@@ -1,0 +1,469 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+@_silgen_name("__NSLocaleIsAutoupdating")
+internal func __NSLocaleIsAutoupdating(_ locale: NSLocale) -> Bool
+
+@_silgen_name("__NSLocaleAutoupdating")
+internal func __NSLocaleAutoupdating() -> NSLocale
+
+@_silgen_name("__NSLocaleCurrent")
+internal func __NSLocaleCurrent() -> NSLocale
+
+@_silgen_name("__NSLocaleBackstop")
+internal func __NSLocaleBackstop() -> NSLocale
+
+/**
+ `Locale` encapsulates information about linguistic, cultural, and technological conventions and standards. Examples of information encapsulated by a locale include the symbol used for the decimal separator in numbers and the way dates are formatted.
+ 
+ Locales are typically used to provide, format, and interpret information about and according to the user’s customs and preferences. They are frequently used in conjunction with formatters. Although you can use many locales, you usually use the one associated with the current user.
+*/
+public struct Locale : CustomStringConvertible, CustomDebugStringConvertible, Hashable, Equatable, ReferenceConvertible {
+    public typealias ReferenceType = NSLocale
+    
+    public typealias LanguageDirection = NSLocale.LanguageDirection
+    
+    private var _wrapped : NSLocale
+    private var _autoupdating : Bool
+
+    /// Returns a locale which tracks the user's current preferences.
+    ///
+    /// The autoupdatingCurrent locale will stop auto-updating if mutated. It only compares equal to itself.
+    public static var autoupdatingCurrent : Locale {
+        return Locale(adoptingReference: __NSLocaleAutoupdating(), autoupdating: true)
+    }
+    
+    /// Returns the user's current locale.
+    public static var current : Locale {
+        return Locale(adoptingReference: __NSLocaleCurrent(), autoupdating: false)
+    }
+    
+    @available(*, unavailable, message: "Consider using the user's locale or nil instead, depending on use case")
+    public static var system : Locale { fatalError() }
+    
+    // MARK: -
+    //
+    
+    /// Return a locale with the specified identifier.
+    public init(identifier: String) {
+        _wrapped = NSLocale(localeIdentifier: identifier)
+        _autoupdating = false
+    }
+    
+    private init(reference: NSLocale) {
+        _wrapped = reference.copy() as! NSLocale
+        if __NSLocaleIsAutoupdating(reference) {
+            _autoupdating = true
+        } else {
+            _autoupdating = false
+        }
+    }
+    
+    private init(adoptingReference reference: NSLocale, autoupdating: Bool) {
+        _wrapped = reference
+        _autoupdating = autoupdating
+    }
+
+    // MARK: -
+    //
+    
+    /// Returns a localized string for a specified identifier.
+    ///
+    /// For example, in the "en" locale, the result for `"en"` is `"Spanish"`.
+    public func localizedString(forIdentifier identifier: String) -> String? {
+        return _wrapped.displayName(forKey: .identifier, value: identifier)
+    }
+    
+    /// Returns a localized string for a specified language code.
+    ///
+    /// For example, in the "en" locale, the result for `"es"` is `"Spanish"`.
+    public func localizedString(forLanguageCode languageCode: String) -> String? {
+        return _wrapped.displayName(forKey: .languageCode, value: languageCode)
+    }
+
+    /// Returns a localized string for a specified region code.
+    ///
+    /// For example, in the "en" locale, the result for `"fr"` is `"French"`.
+    public func localizedString(forRegionCode regionCode: String) -> String? {
+        return _wrapped.displayName(forKey: .countryCode, value: regionCode)
+    }
+    
+    /// Returns a localized string for a specified script code.
+    ///
+    /// For example, in the "en" locale, the result for `"Hans"` is `"Simplified Han"`.
+    public func localizedString(forScriptCode scriptCode: String) -> String? {
+        return _wrapped.displayName(forKey: .scriptCode, value: scriptCode)
+    }
+
+    /// Returns a localized string for a specified variant code.
+    ///
+    /// For example, in the "en" locale, the result for `"POSIX"` is `"Computer"`.
+    public func localizedString(forVariantCode variantCode: String) -> String? {
+        return _wrapped.displayName(forKey: .variantCode, value: variantCode)
+    }
+    
+    /// Returns a localized string for a specified `Calendar.Identifier`.
+    ///
+    /// For example, in the "en" locale, the result for `.buddhist` is `"Buddhist Calendar"`.
+    public func localizedString(for calendarIdentifier: Calendar.Identifier) -> String? {
+        // NSLocale doesn't export a constant for this
+        let result = CFLocaleCopyDisplayNameForPropertyValue(unsafeBitCast(_wrapped, to: CFLocale.self), .calendarIdentifier, Calendar._toNSCalendarIdentifier(calendarIdentifier)) as String
+        return result
+    }
+
+    /// Returns a localized string for a specified ISO 4217 currency code.
+    ///
+    /// For example, in the "en" locale, the result for `"USD"` is `"US Dollar"`.
+    /// - seealso: `Locale.isoCurrencyCodes`
+    public func localizedString(forCurrencyCode currencyCode: String) -> String? {
+        return _wrapped.displayName(forKey: .currencyCode, value: currencyCode)
+    }
+
+    /// Returns a localized string for a specified ICU collation identifier.
+    ///
+    /// For example, in the "en" locale, the result for `"phonebook"` is `"Phonebook Sort Order"`.
+    public func localizedString(forCollationIdentifier collationIdentifier: String) -> String? {
+        return _wrapped.displayName(forKey: .collationIdentifier, value: collationIdentifier)
+    }
+
+    /// Returns a localized string for a specified ICU collator identifier.
+    public func localizedString(forCollatorIdentifier collatorIdentifier: String) -> String? {
+        return _wrapped.displayName(forKey: .collatorIdentifier, value: collatorIdentifier)
+    }
+
+    // MARK: -
+    //
+
+    /// Returns the identifier of the locale.
+    public var identifier: String {
+        return _wrapped.localeIdentifier
+    }
+    
+    /// Returns the language code of the locale, or nil if has none.
+    ///
+    /// For example, for the locale "zh-Hant-HK", returns "zh".
+    public var languageCode: String? {
+        return _wrapped.object(forKey: .languageCode) as? String
+    }
+
+    /// Returns the region code of the locale, or nil if it has none.
+    ///
+    /// For example, for the locale "zh-Hant-HK", returns "HK".
+    public var regionCode: String? {
+        // n.b. this is called countryCode in ObjC
+        if let result = _wrapped.object(forKey: .countryCode) as? String {
+            if result.isEmpty {
+                return nil
+            } else {
+                return result
+            }
+        } else {
+            return nil
+        }
+    }
+    
+    /// Returns the script code of the locale, or nil if has none.
+    ///
+    /// For example, for the locale "zh-Hant-HK", returns "Hant".
+    public var scriptCode: String? {
+        return _wrapped.object(forKey: .scriptCode) as? String
+    }
+    
+    /// Returns the variant code for the locale, or nil if it has none.
+    ///
+    /// For example, for the locale "en_POSIX", returns "POSIX".
+    public var variantCode: String? {
+        if let result = _wrapped.object(forKey: .variantCode) as? String {
+            if result.isEmpty {
+                return nil
+            } else {
+                return result
+            }
+        } else {
+            return nil
+        }
+    }
+    
+    /// Returns the exemplar character set for the locale, or nil if has none.
+    public var exemplarCharacterSet: CharacterSet? {
+        return _wrapped.object(forKey: .exemplarCharacterSet) as? CharacterSet
+    }
+    
+    /// Returns the calendar for the locale, or the Gregorian calendar as a fallback.
+    public var calendar: Calendar {
+        // NSLocale should not return nil here
+        if let result = _wrapped.object(forKey: .calendar) as? Calendar {
+            return result
+        } else {
+            return Calendar(identifier: .gregorian)
+        }
+    }
+    
+    /// Returns the collation identifier for the locale, or nil if it has none.
+    ///
+    /// For example, for the locale "en_US@collation=phonebook", returns "phonebook".
+    public var collationIdentifier: String? {
+        return _wrapped.object(forKey: .collationIdentifier) as? String
+    }
+    
+    /// Returns true if the locale uses the metric system.
+    ///
+    /// -seealso: MeasurementFormatter
+    public var usesMetricSystem: Bool {
+        // NSLocale should not return nil here, but just in case
+        if let result = (_wrapped.object(forKey: .usesMetricSystem) as? NSNumber)?.boolValue {
+            return result
+        } else {
+            return false
+        }
+    }
+    
+    /// Returns the decimal separator of the locale.
+    ///
+    /// For example, for "en_US", returns ".".
+    public var decimalSeparator: String? {
+        return _wrapped.object(forKey: .decimalSeparator) as? String
+    }
+    
+    /// Returns the grouping separator of the locale.
+    ///
+    /// For example, for "en_US", returns ",".
+    public var groupingSeparator: String? {
+        return _wrapped.object(forKey: .groupingSeparator) as? String
+    }
+    
+    /// Returns the currency symbol of the locale.
+    ///
+    /// For example, for "zh-Hant-HK", returns "HK$".
+    public var currencySymbol: String? {
+        return _wrapped.object(forKey: .currencySymbol) as? String
+    }
+    
+    /// Returns the currency code of the locale.
+    ///
+    /// For example, for "zh-Hant-HK", returns "HKD".
+    public var currencyCode: String? {
+        return _wrapped.object(forKey: .currencyCode) as? String
+    }
+    
+    /// Returns the collator identifier of the locale.
+    public var collatorIdentifier: String? {
+        return _wrapped.object(forKey: .collatorIdentifier) as? String
+    }
+    
+    /// Returns the quotation begin delimiter of the locale.
+    ///
+    /// For example, returns `“` for "en_US", and `「` for "zh-Hant-HK".
+    public var quotationBeginDelimiter: String? {
+        return _wrapped.object(forKey: .quotationBeginDelimiterKey) as? String
+    }
+    
+    /// Returns the quotation end delimiter of the locale.
+    ///
+    /// For example, returns `”` for "en_US", and `」` for "zh-Hant-HK".
+    public var quotationEndDelimiter: String? {
+        return _wrapped.object(forKey: .quotationEndDelimiterKey) as? String
+    }
+    
+    /// Returns the alternate quotation begin delimiter of the locale.
+    ///
+    /// For example, returns `‘` for "en_US", and `『` for "zh-Hant-HK".
+    public var alternateQuotationBeginDelimiter: String? {
+        return _wrapped.object(forKey: .alternateQuotationBeginDelimiterKey) as? String
+    }
+    
+    /// Returns the alternate quotation end delimiter of the locale.
+    ///
+    /// For example, returns `’` for "en_US", and `』` for "zh-Hant-HK".
+    public var alternateQuotationEndDelimiter: String? {
+        return _wrapped.object(forKey: .alternateQuotationEndDelimiterKey) as? String
+    }
+    
+    // MARK: -
+    // 
+    
+    /// Returns a list of available `Locale` identifiers.
+    public static var availableIdentifiers: [String] {
+        return NSLocale.availableLocaleIdentifiers
+    }
+    
+    /// Returns a list of available `Locale` language codes.
+    public static var isoLanguageCodes: [String] {
+        return NSLocale.isoLanguageCodes
+    }
+    
+    /// Returns a list of available `Locale` region codes.
+    public static var isoRegionCodes: [String] {
+        // This was renamed from Obj-C
+        return NSLocale.isoCountryCodes
+    }
+    
+    /// Returns a list of available `Locale` currency codes.
+    public static var isoCurrencyCodes: [String] {
+        return NSLocale.isoCurrencyCodes
+    }
+    
+    /// Returns a list of common `Locale` currency codes.
+    public static var commonISOCurrencyCodes: [String] {
+        return NSLocale.commonISOCurrencyCodes
+    }
+    
+    /// Returns a list of the user's preferred languages.
+    ///
+    /// - note: `Bundle` is responsible for determining the language that your application will run in, based on the result of this API and combined with the languages your application supports.
+    /// - seealso: `Bundle.preferredLocalizations(from:)`
+    /// - seealso: `Bundle.preferredLocalizations(from:forPreferences:)`
+    public static var preferredLanguages: [String] {
+        return NSLocale.preferredLanguages
+    }
+    
+    /// Returns a dictionary that splits an identifier into its component pieces.
+    public static func components(fromIdentifier string: String) -> [String : String] {
+        return NSLocale.components(fromLocaleIdentifier: string)
+    }
+    
+    /// Constructs an identifier from a dictionary of components.
+    public static func identifier(fromComponents components: [String : String]) -> String {
+        return NSLocale.localeIdentifier(fromComponents: components)
+    }
+    
+    /// Returns a canonical identifier from the given string.
+    public static func canonicalIdentifier(from string: String) -> String {
+        return NSLocale.canonicalLocaleIdentifier(from: string)
+    }
+    
+    /// Returns a canonical language identifier from the given string.
+    public static func canonicalLanguageIdentifier(from string: String) -> String {
+        return NSLocale.canonicalLanguageIdentifier(from: string)
+    }
+    
+    /// Returns the `Locale` identifier from a given Windows locale code, or nil if it could not be converted.
+    public static func identifier(fromWindowsLocaleCode code: Int) -> String? {
+        return NSLocale.localeIdentifier(fromWindowsLocaleCode: UInt32(code))
+    }
+    
+    /// Returns the Windows locale code from a given identifier, or nil if it could not be converted.
+    public static func windowsLocaleCode(fromIdentifier identifier: String) -> Int? {
+        let result = NSLocale.windowsLocaleCode(fromLocaleIdentifier: identifier)
+        if result == 0 {
+            return nil
+        } else {
+            return Int(result)
+        }
+    }
+    
+    /// Returns the character direction for a specified language code.
+    public static func characterDirection(forLanguage isoLangCode: String) -> Locale.LanguageDirection {
+        return NSLocale.characterDirection(forLanguage: isoLangCode)
+    }
+    
+    /// Returns the line direction for a specified language code.
+    public static func lineDirection(forLanguage isoLangCode: String) -> Locale.LanguageDirection {
+        return NSLocale.lineDirection(forLanguage: isoLangCode)
+    }
+    
+    // MARK: -
+    
+    @available(*, unavailable, renamed: "init(identifier:)")
+    public init(localeIdentifier: String) { fatalError() }
+    
+    @available(*, unavailable, renamed: "identifier")
+    public var localeIdentifier: String { fatalError() }
+    
+    @available(*, unavailable, renamed: "localizedString(forIdentifier:)")
+    public func localizedString(forLocaleIdentifier localeIdentifier: String) -> String { fatalError() }
+    
+    @available(*, unavailable, renamed: "availableIdentifiers")
+    public static var availableLocaleIdentifiers: [String] { fatalError() }
+    
+    @available(*, unavailable, renamed: "components(fromIdentifier:)")
+    public static func components(fromLocaleIdentifier string: String) -> [String : String] { fatalError() }
+    
+    @available(*, unavailable, renamed: "identifier(fromComponents:)")
+    public static func localeIdentifier(fromComponents dict: [String : String]) -> String { fatalError() }
+    
+    @available(*, unavailable, renamed: "canonicalIdentifier(from:)")
+    public static func canonicalLocaleIdentifier(from string: String) -> String { fatalError() }
+    
+    @available(*, unavailable, renamed: "identifier(fromWindowsLocaleCode:)")
+    public static func localeIdentifier(fromWindowsLocaleCode lcid: UInt32) -> String? { fatalError() }
+    
+    @available(*, unavailable, renamed: "windowsLocaleCode(fromIdentifier:)")
+    public static func windowsLocaleCode(fromLocaleIdentifier localeIdentifier: String) -> UInt32 { fatalError() }
+    
+    @available(*, unavailable, message: "use regionCode instead")
+    public var countryCode: String { fatalError() }
+    
+    @available(*, unavailable, message: "use localizedString(forRegionCode:) instead")
+    public func localizedString(forCountryCode countryCode: String) -> String { fatalError() }
+
+    @available(*, unavailable, renamed: "isoRegionCodes")
+    public static var isoCountryCodes: [String] { fatalError() }
+
+    // MARK: -
+    //
+    
+    public var description: String {
+        return _wrapped.description
+    }
+    
+    public var debugDescription : String {
+        return _wrapped.debugDescription
+    }
+    
+    public var hashValue : Int {
+        if _autoupdating {
+            return 1
+        } else {
+            return _wrapped.hash
+        }
+    }
+}
+
+public func ==(lhs: Locale, rhs: Locale) -> Bool {
+    if lhs._autoupdating || rhs._autoupdating {
+        return lhs._autoupdating == rhs._autoupdating
+    } else {
+        return lhs._wrapped.isEqual(rhs._wrapped)
+    }
+}
+
+
+extension Locale : _ObjectiveCBridgeable {
+    public static func _isBridgedToObjectiveC() -> Bool {
+        return true
+    }
+    
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSLocale {
+        return _wrapped
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ input: NSLocale, result: inout Locale?) {
+        if !_conditionallyBridgeFromObjectiveC(input, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ input: NSLocale, result: inout Locale?) -> Bool {
+        result = Locale(reference: input)
+        return true
+    }
+    
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSLocale?) -> Locale {
+        var result: Locale? = nil
+        _forceBridgeFromObjectiveC(source!, result: &result)
+        return result!
+    }
+}

--- a/stdlib/public/SDK/Foundation/Thunks.mm
+++ b/stdlib/public/SDK/Foundation/Thunks.mm
@@ -122,6 +122,14 @@ NS_Swift_NSKeyedUnarchiver_unarchiveObjectWithData(
 
 // A way to get various Calendar, Locale, and TimeZone singletons without bridging twice
 
+// Unfortunately the importer does not realize that [NSCalendar initWithIdentifier:] has been around forever, and only sees the iOS 8 availability of [NSCalendar calendarWithIdentifier:].
+SWIFT_CC(swift)
+extern "C" NS_RETURNS_RETAINED NSCalendar * __nullable __NSCalendarInit(NSString * NS_RELEASES_ARGUMENT __nonnull identifier) {
+    NSCalendar *result = [[NSCalendar alloc] initWithCalendarIdentifier:identifier];
+    [identifier release];
+    return result;
+}
+
 SWIFT_CC(swift)
 extern "C" NS_RETURNS_RETAINED NSCalendar *__NSCalendarAutoupdating() {
     return [[NSCalendar autoupdatingCurrentCalendar] retain];

--- a/stdlib/public/SDK/Foundation/TimeZone.swift
+++ b/stdlib/public/SDK/Foundation/TimeZone.swift
@@ -1,0 +1,260 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+@_silgen_name("__NSTimeZoneIsAutoupdating")
+internal func __NSTimeZoneIsAutoupdating(_ timezone: NSTimeZone) -> Bool
+
+@_silgen_name("__NSTimeZoneAutoupdating")
+internal func __NSTimeZoneAutoupdating() -> NSTimeZone
+
+@_silgen_name("__NSTimeZoneCurrent")
+internal func __NSTimeZoneCurrent() -> NSTimeZone
+
+/**
+ `TimeZone` defines the behavior of a time zone. Time zone values represent geopolitical regions. Consequently, these values have names for these regions. Time zone values also represent a temporal offset, either plus or minus, from Greenwich Mean Time (GMT) and an abbreviation (such as PST for Pacific Standard Time).
+ 
+ `TimeZone` provides two static functions to get time zone values: `current` and `autoupdatingCurrent`. The `autoupdatingCurrent` time zone automatically tracks updates made by the user.
+ 
+ Note that time zone database entries such as “America/Los_Angeles” are IDs, not names. An example of a time zone name is “Pacific Daylight Time”. Although many `TimeZone` functions include the word “name”, they refer to IDs.
+ 
+ Cocoa does not provide any API to change the time zone of the computer, or of other applications.
+ */
+public struct TimeZone : CustomStringConvertible, CustomDebugStringConvertible, Hashable, Equatable, ReferenceConvertible {
+    public typealias ReferenceType = NSTimeZone
+    
+    private var _wrapped : NSTimeZone
+    private var _autoupdating : Bool
+    
+    /// The time zone currently used by the system.
+    public static var current : TimeZone {
+        return TimeZone(adoptingReference: __NSTimeZoneCurrent(), autoupdating: false)
+    }
+    
+    /// The time zone currently used by the system, automatically updating to the user's current preference.
+    ///
+    /// If this time zone is mutated, then it no longer tracks the application time zone.
+    ///
+    /// The autoupdating time zone only compares equal to itself.
+    public static var autoupdatingCurrent : TimeZone {
+        return TimeZone(adoptingReference: __NSTimeZoneAutoupdating(), autoupdating: true)
+    }
+    
+    // MARK: -
+    //
+    
+    /// Returns a time zone initialized with a given identifier.
+    ///
+    /// An example identifier is "America/Los_Angeles".
+    ///
+    /// If `identifier` is an unknown identifier, then returns `nil`.
+    public init?(identifier: String) {
+        if let r = NSTimeZone(name: identifier) {
+            _wrapped = r
+            _autoupdating = false
+        } else {
+            return nil
+        }
+    }
+    
+    @available(*, unavailable, renamed: "init(secondsFromGMT:)")
+    public init(forSecondsFromGMT seconds: Int) { fatalError() }
+    
+    /// Returns a time zone initialized with a specific number of seconds from GMT.
+    ///
+    /// Time zones created with this never have daylight savings and the offset is constant no matter the date. The identifier and abbreviation do NOT follow the POSIX convention (of minutes-west).
+    ///
+    /// - parameter seconds: The number of seconds from GMT.
+    /// - returns: A time zone, or `nil` if a valid time zone could not be created from `seconds`.
+    public init?(secondsFromGMT seconds: Int) {
+        if let r = NSTimeZone(forSecondsFromGMT: seconds) as TimeZone? {
+            _wrapped = r
+            _autoupdating = false
+        } else {
+            return nil
+        }
+    }
+    
+    /// Returns a time zone identified by a given abbreviation.
+    ///
+    /// In general, you are discouraged from using abbreviations except for unique instances such as “GMT”. Time Zone abbreviations are not standardized and so a given abbreviation may have multiple meanings—for example, “EST” refers to Eastern Time in both the United States and Australia
+    ///
+    /// - parameter abbreviation: The abbreviation for the time zone.
+    /// - returns: A time zone identified by abbreviation determined by resolving the abbreviation to a identifier using the abbreviation dictionary and then returning the time zone for that identifier. Returns `nil` if there is no match for abbreviation.
+    public init?(abbreviation: String) {
+        if let r = NSTimeZone(abbreviation: abbreviation) {
+            _wrapped = r
+            _autoupdating = false
+        } else {
+            return nil
+        }
+    }
+    
+    private init(reference: NSTimeZone) {
+        if __NSTimeZoneIsAutoupdating(reference) {
+            // we can't copy this or we lose its auto-ness (27048257)
+            // fortunately it's immutable
+            _autoupdating = true
+            _wrapped = reference
+        } else {
+            _autoupdating = false
+            _wrapped = reference.copy() as! NSTimeZone
+        }
+    }
+
+    private init(adoptingReference reference: NSTimeZone, autoupdating: Bool) {
+        // this path is only used for types we do not need to copy (we are adopting the ref)
+        _wrapped = reference
+        _autoupdating = autoupdating
+    }
+
+    // MARK: -
+    //
+    
+    @available(*, unavailable, renamed: "identifier")
+    public var name: String { fatalError() }
+
+    /// The geopolitical region identifier that identifies the time zone.
+    public var identifier: String {
+        return _wrapped.name
+    }
+    
+    @available(*, unavailable, message: "use the identifier instead")
+    public var data: Data { fatalError() }
+    
+    /// The current difference in seconds between the time zone and Greenwich Mean Time.
+    ///
+    /// - parameter date: The date to use for the calculation. The default value is the current date.
+    public func secondsFromGMT(for date: Date = Date()) -> Int {
+        return _wrapped.secondsFromGMT(for: date)
+    }
+    
+    /// Returns the abbreviation for the time zone at a given date.
+    ///
+    /// Note that the abbreviation may be different at different dates. For example, during daylight saving time the US/Eastern time zone has an abbreviation of “EDT.” At other times, its abbreviation is “EST.”
+    /// - parameter date: The date to use for the calculation. The default value is the current date.
+    public func abbreviation(for date: Date = Date()) -> String? {
+        return _wrapped.abbreviation(for: date)
+    }
+    
+    /// Returns a Boolean value that indicates whether the receiver uses daylight saving time at a given date.
+    ///
+    /// - parameter date: The date to use for the calculation. The default value is the current date.
+    public func isDaylightSavingTime(for date: Date = Date()) -> Bool {
+        return _wrapped.isDaylightSavingTime(for: date)
+    }
+    
+    /// Returns the daylight saving time offset for a given date.
+    ///
+    /// - parameter date: The date to use for the calculation. The default value is the current date.
+    public func daylightSavingTimeOffset(for date: Date = Date()) -> TimeInterval {
+        return _wrapped.daylightSavingTimeOffset(for: date)
+    }
+    
+    /// Returns the next daylight saving time transition after a given date.
+    ///
+    /// - parameter date: A date.
+    /// - returns: The next daylight saving time transition after `date`. Depending on the time zone, this function may return a change of the time zone's offset from GMT. Returns `nil` if the time zone of the receiver does not observe daylight savings time as of `date`.
+    public func nextDaylightSavingTimeTransition(after date: Date) -> Date? {
+        return _wrapped.nextDaylightSavingTimeTransition(after: date)
+    }
+    
+    /// Returns an array of strings listing the identifier of all the time zones known to the system.
+    public static var knownTimeZoneIdentifiers : [String] {
+        return NSTimeZone.knownTimeZoneNames
+    }
+    
+    /// Returns the mapping of abbreviations to time zone identifiers.
+    public static var abbreviationDictionary : [String : String] {
+        get {
+            return NSTimeZone.abbreviationDictionary
+        }
+        set {
+            NSTimeZone.abbreviationDictionary = newValue
+        }
+    }
+    
+    /// Returns the time zone data version.
+    public static var timeZoneDataVersion : String {
+        return NSTimeZone.timeZoneDataVersion
+    }
+    
+    /// Returns the date of the next (after the current instant) daylight saving time transition for the time zone. Depending on the time zone, the value of this property may represent a change of the time zone's offset from GMT. Returns `nil` if the time zone does not currently observe daylight saving time.
+    public var nextDaylightSavingTimeTransition: Date? {
+        return _wrapped.nextDaylightSavingTimeTransition
+    }
+
+    @available(*, unavailable, renamed: "localizedName(for:locale:)")
+    public func localizedName(_ style: NSTimeZone.NameStyle, locale: Locale?) -> String? { fatalError() }
+
+    /// Returns the name of the receiver localized for a given locale.
+    public func localizedName(for style: NSTimeZone.NameStyle, locale: Locale?) -> String? {
+        return _wrapped.localizedName(style, locale: locale)
+    }
+    
+    // MARK: -
+    
+    public var description: String {
+        return _wrapped.description
+    }
+    
+    public var debugDescription : String {
+        return _wrapped.debugDescription
+    }
+    
+    public var hashValue : Int {
+        if _autoupdating {
+            return 1
+        } else {
+            return _wrapped.hash
+        }
+    }
+}
+
+public func ==(lhs: TimeZone, rhs: TimeZone) -> Bool {
+    if lhs._autoupdating || rhs._autoupdating {
+        return lhs._autoupdating == rhs._autoupdating
+    } else {
+        return lhs._wrapped.isEqual(rhs._wrapped)
+    }
+}
+
+extension TimeZone : _ObjectiveCBridgeable {
+    public static func _isBridgedToObjectiveC() -> Bool {
+        return true
+    }
+    
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> NSTimeZone {
+        // _wrapped is immutable
+        return _wrapped
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ input: NSTimeZone, result: inout TimeZone?) {
+        if !_conditionallyBridgeFromObjectiveC(input, result: &result) {
+            fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
+        }
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ input: NSTimeZone, result: inout TimeZone?) -> Bool {
+        result = TimeZone(reference: input)
+        return true
+    }
+    
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSTimeZone?) -> TimeZone {
+        var result: TimeZone? = nil
+        _forceBridgeFromObjectiveC(source!, result: &result)
+        return result!
+    }
+}
+

--- a/test/1_stdlib/Inputs/FoundationBridge/FoundationBridge.h
+++ b/test/1_stdlib/Inputs/FoundationBridge/FoundationBridge.h
@@ -1,4 +1,4 @@
-//===--- FoundationBridge.h -------------------------------------*- C++ -*-===//
+//===--- FoundationBridge.h -----------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -51,5 +51,22 @@ typedef NS_ENUM(NSInteger, ObjectBehaviorAction) {
 void takesData(NSData *object);
 NSData *returnsData();
 BOOL identityOfData(NSData *data);
+
+#pragma mark - NSCalendar verification
+
+@interface CalendarBridgingTester : NSObject
+- (NSCalendar *)autoupdatingCurrentCalendar;
+- (BOOL)verifyAutoupdatingCalendar:(NSCalendar *)calendar;
+@end
+
+@interface TimeZoneBridgingTester : NSObject
+- (NSTimeZone *)autoupdatingCurrentTimeZone;
+- (BOOL)verifyAutoupdatingTimeZone:(NSTimeZone *)tz;
+@end
+
+@interface LocaleBridgingTester : NSObject
+- (NSLocale *)autoupdatingCurrentLocale;
+- (BOOL)verifyAutoupdatingLocale:(NSLocale *)locale;
+@end
 
 NS_ASSUME_NONNULL_END

--- a/test/1_stdlib/Inputs/FoundationBridge/FoundationBridge.m
+++ b/test/1_stdlib/Inputs/FoundationBridge/FoundationBridge.m
@@ -1,4 +1,17 @@
+//===--- FoundationBridge.m -----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
 #import "FoundationBridge.h"
+#import <objc/runtime.h>
 
 @implementation ObjectBehaviorVerifier {
     NSMutableArray *_actions;
@@ -184,3 +197,50 @@ NSData *returnsData() {
 BOOL identityOfData(NSData *data) {
     return data == returnsData();
 }
+
+
+@implementation CalendarBridgingTester
+
+- (NSCalendar *)autoupdatingCurrentCalendar {
+    return [NSCalendar autoupdatingCurrentCalendar];
+}
+
+- (BOOL)verifyAutoupdatingCalendar:(NSCalendar *)calendar {
+    Class autoCalendarClass = (Class)objc_lookUpClass("_NSAutoCalendar");
+    if (autoCalendarClass && [calendar isKindOfClass:autoCalendarClass]) {
+        return YES;
+    } else {
+        autoCalendarClass = (Class)objc_lookUpClass("NSAutoCalendar");
+        return [calendar isKindOfClass:autoCalendarClass];
+    }
+}
+
+@end
+
+@implementation TimeZoneBridgingTester
+
+- (NSTimeZone *)autoupdatingCurrentTimeZone {
+    return [NSTimeZone localTimeZone];
+}
+
+- (BOOL)verifyAutoupdatingTimeZone:(NSTimeZone *)tz {
+    Class autoTimeZoneClass = (Class)objc_lookUpClass("__NSLocalTimeZone");
+    return [tz isKindOfClass:autoTimeZoneClass];
+
+}
+@end
+
+@implementation LocaleBridgingTester
+
+- (NSLocale *)autoupdatingCurrentLocale {
+    return [NSLocale autoupdatingCurrentLocale];
+}
+
+- (BOOL)verifyAutoupdatingLocale:(NSLocale *)locale {
+    Class autoLocaleClass = (Class)objc_lookUpClass("NSAutoLocale");
+    return [locale isKindOfClass:autoLocaleClass];
+}
+
+@end
+
+

--- a/test/1_stdlib/NSStringAPI.swift
+++ b/test/1_stdlib/NSStringAPI.swift
@@ -262,22 +262,18 @@ func expectLocalizedEquality(
   _ localeID: String? = nil,
   _ message: @autoclosure () -> String = "",
   showFrame: Bool = true,
-  stackTrace: SourceLocStack = SourceLocStack(),  
+  stackTrace: SourceLocStack = SourceLocStack(),
   file: String = #file, line: UInt = #line
 ) {
   let trace = stackTrace.pushIf(showFrame, file: file, line: line)
 
   let locale = localeID.map {
-    Locale(localeIdentifier: $0)
+    Locale(identifier: $0)
   } ?? Locale.current
   
   expectEqual(
     expected, op(locale),
-    message(), stackTrace: trace)
-  
-  expectEqual(
-    op(Locale.system), op(nil),
-    message(), stackTrace: trace)
+    message(), stackTrace: trace)  
 }
 
 NSStringAPIs.test("capitalizedString(with:)") {
@@ -834,8 +830,6 @@ NSStringAPIs.test("init(format:locale:_:...)") {
   var world: NSString = "world"
   expectEqual("Hello, world!%42", String(format: "Hello, %@!%%%ld",
       locale: nil, world, 42))
-  expectEqual("Hello, world!%42", String(format: "Hello, %@!%%%ld",
-      locale: Locale.system, world, 42))
 }
 
 NSStringAPIs.test("init(format:locale:arguments:)") {
@@ -843,8 +837,6 @@ NSStringAPIs.test("init(format:locale:arguments:)") {
   let args: [CVarArg] = [ world, 42 ]
   expectEqual("Hello, world!%42", String(format: "Hello, %@!%%%ld",
       locale: nil, arguments: args))
-  expectEqual("Hello, world!%42", String(format: "Hello, %@!%%%ld",
-      locale: Locale.system, arguments: args))
 }
 
 NSStringAPIs.test("lastPathComponent") {

--- a/test/1_stdlib/TestCalendar.swift
+++ b/test/1_stdlib/TestCalendar.swift
@@ -109,149 +109,150 @@ class TestCalendar : TestCalendarSuper {
     
     func test_properties() {
         // Mainly we want to just make sure these go through to the NSCalendar implementation at this point.
-        
-        var c = Calendar(identifier: .gregorian)
-        // Use english localization
-        c.locale = Locale(identifier: "en_US")
-        
-        expectEqual("AM", c.amSymbol)
-        expectEqual("PM", c.pmSymbol)
-        expectEqual(["1st quarter", "2nd quarter", "3rd quarter", "4th quarter"], c.quarterSymbols)
-        expectEqual(["1st quarter", "2nd quarter", "3rd quarter", "4th quarter"], c.standaloneQuarterSymbols)
-        expectEqual(["BC", "AD"], c.eraSymbols)
-        expectEqual(["Before Christ", "Anno Domini"], c.longEraSymbols)
-        expectEqual(["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"], c.veryShortMonthSymbols)
-        expectEqual(["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"], c.veryShortStandaloneMonthSymbols)
-        expectEqual(["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"], c.shortMonthSymbols)
-        expectEqual(["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"], c.shortStandaloneMonthSymbols)
-        expectEqual(["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"], c.monthSymbols)
-        expectEqual(["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"], c.standaloneMonthSymbols)
-        expectEqual(["Q1", "Q2", "Q3", "Q4"], c.shortQuarterSymbols)
-        expectEqual(["Q1", "Q2", "Q3", "Q4"], c.shortStandaloneQuarterSymbols)
-        expectEqual(["S", "M", "T", "W", "T", "F", "S"], c.veryShortStandaloneWeekdaySymbols)
-        expectEqual(["S", "M", "T", "W", "T", "F", "S"], c.veryShortWeekdaySymbols)
-        expectEqual(["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"], c.shortStandaloneWeekdaySymbols)
-        expectEqual(["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"], c.shortWeekdaySymbols)
-        expectEqual(["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"], c.standaloneWeekdaySymbols)
-        expectEqual(["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"], c.weekdaySymbols)
-        
-        // The idea behind these tests is not to test calendrical math, but to simply verify that we are getting some kind of result from calling through to the underlying Foundation and ICU logic. If we move that logic into this struct in the future, then we will need to expand the test cases.
-        
-        // This is a very special Date in my life: the exact moment when I wrote these test cases and therefore knew all of the answers.
-        let d = Date(timeIntervalSince1970: 1468705593.2533731)
-        let earlierD = c.date(byAdding: DateComponents(day: -10), to: d)!
+        if #available(iOS 8.0, OSX 10.7, *) {
+            var c = Calendar(identifier: .gregorian)
+            // Use english localization
+            c.locale = Locale(identifier: "en_US")
             
-        expectEqual(1..<29, c.minimumRange(of: .day))
-        expectEqual(1..<54, c.maximumRange(of: .weekOfYear))
-        expectEqual(0..<60, c.range(of: .second, in: .minute, for: d))
-        
-        var d1 = Date()
-        var ti : TimeInterval = 0
-        
-        expectTrue(c.dateInterval(of: .day, start: &d1, interval: &ti, for: d))
-        expectEqual(Date(timeIntervalSince1970: 1468652400.0), d1)
-        expectEqual(86400, ti)
-        
-        if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
-            let dateInterval = c.dateInterval(of: .day, for: d)
-            expectEqual(DateInterval(start: d1, duration: ti), dateInterval)
-        }
-        
-        expectEqual(15, c.ordinality(of: .hour, in: .day, for: d))
-        
-        expectEqual(Date(timeIntervalSince1970: 1468791993.2533731), c.date(byAdding: .day, value: 1, to: d))
-        expectEqual(Date(timeIntervalSince1970: 1468791993.2533731), c.date(byAdding: DateComponents(day: 1),  to: d))
-        
-        expectEqual(Date(timeIntervalSince1970: 946627200.0), c.date(from: DateComponents(year: 1999, month: 12, day: 31)))
-        
-        let comps = c.dateComponents([.year, .month, .day], from: Date(timeIntervalSince1970: 946627200.0))
-        expectEqual(1999, comps.year)
-        expectEqual(12, comps.month)
-        expectEqual(31, comps.day)
-        
-        expectEqual(10, c.dateComponents([.day], from: d, to: c.date(byAdding: DateComponents(day: 10), to: d)!).day)
-        
-        expectEqual(30, c.dateComponents([.day], from: DateComponents(year: 1999, month: 12, day: 1), to: DateComponents(year: 1999, month: 12, day: 31)).day)
-        
-        expectEqual(2016, c.component(.year, from: d))
-        
-        expectEqual(Date(timeIntervalSince1970: 1468652400.0), c.startOfDay(for: d))
-        
-        expectEqual(.orderedSame, c.compare(d, to: d + 10, toGranularity: .minute))
-        
-        expectFalse(c.isDate(d, equalTo: d + 10, toGranularity: .second))
-        expectTrue(c.isDate(d, equalTo: d + 10, toGranularity: .day))
-        
-        expectFalse(c.isDate(earlierD, inSameDayAs: d))
-        expectTrue(c.isDate(d, inSameDayAs: d))
-        
-        expectFalse(c.isDateInToday(earlierD))
-        expectFalse(c.isDateInYesterday(earlierD))
-        expectFalse(c.isDateInTomorrow(earlierD))
-        
-        expectTrue(c.isDateInWeekend(d)) // 😢
-        
-        expectTrue(c.dateIntervalOfWeekend(containing: d, start: &d1, interval: &ti))
-        
-        if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
-            let thisWeekend = DateInterval(start: Date(timeIntervalSince1970: 1468652400.0), duration: 172800.0)
+            expectEqual("AM", c.amSymbol)
+            expectEqual("PM", c.pmSymbol)
+            expectEqual(["1st quarter", "2nd quarter", "3rd quarter", "4th quarter"], c.quarterSymbols)
+            expectEqual(["1st quarter", "2nd quarter", "3rd quarter", "4th quarter"], c.standaloneQuarterSymbols)
+            expectEqual(["BC", "AD"], c.eraSymbols)
+            expectEqual(["Before Christ", "Anno Domini"], c.longEraSymbols)
+            expectEqual(["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"], c.veryShortMonthSymbols)
+            expectEqual(["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"], c.veryShortStandaloneMonthSymbols)
+            expectEqual(["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"], c.shortMonthSymbols)
+            expectEqual(["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"], c.shortStandaloneMonthSymbols)
+            expectEqual(["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"], c.monthSymbols)
+            expectEqual(["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"], c.standaloneMonthSymbols)
+            expectEqual(["Q1", "Q2", "Q3", "Q4"], c.shortQuarterSymbols)
+            expectEqual(["Q1", "Q2", "Q3", "Q4"], c.shortStandaloneQuarterSymbols)
+            expectEqual(["S", "M", "T", "W", "T", "F", "S"], c.veryShortStandaloneWeekdaySymbols)
+            expectEqual(["S", "M", "T", "W", "T", "F", "S"], c.veryShortWeekdaySymbols)
+            expectEqual(["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"], c.shortStandaloneWeekdaySymbols)
+            expectEqual(["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"], c.shortWeekdaySymbols)
+            expectEqual(["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"], c.standaloneWeekdaySymbols)
+            expectEqual(["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"], c.weekdaySymbols)
             
-            expectEqual(thisWeekend, DateInterval(start: d1, duration: ti))
-            expectEqual(thisWeekend, c.dateIntervalOfWeekend(containing: d))
-        }
-        
+            // The idea behind these tests is not to test calendrical math, but to simply verify that we are getting some kind of result from calling through to the underlying Foundation and ICU logic. If we move that logic into this struct in the future, then we will need to expand the test cases.
+            
+            // This is a very special Date in my life: the exact moment when I wrote these test cases and therefore knew all of the answers.
+            let d = Date(timeIntervalSince1970: 1468705593.2533731)
+            let earlierD = c.date(byAdding: DateComponents(day: -10), to: d)!
+                
+            expectEqual(1..<29, c.minimumRange(of: .day))
+            expectEqual(1..<54, c.maximumRange(of: .weekOfYear))
+            expectEqual(0..<60, c.range(of: .second, in: .minute, for: d))
+            
+            var d1 = Date()
+            var ti : TimeInterval = 0
+            
+            expectTrue(c.dateInterval(of: .day, start: &d1, interval: &ti, for: d))
+            expectEqual(Date(timeIntervalSince1970: 1468652400.0), d1)
+            expectEqual(86400, ti)
+            
+            if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+                let dateInterval = c.dateInterval(of: .day, for: d)
+                expectEqual(DateInterval(start: d1, duration: ti), dateInterval)
+            }
+            
+            expectEqual(15, c.ordinality(of: .hour, in: .day, for: d))
+            
+            expectEqual(Date(timeIntervalSince1970: 1468791993.2533731), c.date(byAdding: .day, value: 1, to: d))
+            expectEqual(Date(timeIntervalSince1970: 1468791993.2533731), c.date(byAdding: DateComponents(day: 1),  to: d))
+            
+            expectEqual(Date(timeIntervalSince1970: 946627200.0), c.date(from: DateComponents(year: 1999, month: 12, day: 31)))
+            
+            let comps = c.dateComponents([.year, .month, .day], from: Date(timeIntervalSince1970: 946627200.0))
+            expectEqual(1999, comps.year)
+            expectEqual(12, comps.month)
+            expectEqual(31, comps.day)
+            
+            expectEqual(10, c.dateComponents([.day], from: d, to: c.date(byAdding: DateComponents(day: 10), to: d)!).day)
+            
+            expectEqual(30, c.dateComponents([.day], from: DateComponents(year: 1999, month: 12, day: 1), to: DateComponents(year: 1999, month: 12, day: 31)).day)
+            
+            expectEqual(2016, c.component(.year, from: d))
+            
+            expectEqual(Date(timeIntervalSince1970: 1468652400.0), c.startOfDay(for: d))
+            
+            expectEqual(.orderedSame, c.compare(d, to: d + 10, toGranularity: .minute))
+            
+            expectFalse(c.isDate(d, equalTo: d + 10, toGranularity: .second))
+            expectTrue(c.isDate(d, equalTo: d + 10, toGranularity: .day))
+            
+            expectFalse(c.isDate(earlierD, inSameDayAs: d))
+            expectTrue(c.isDate(d, inSameDayAs: d))
+            
+            expectFalse(c.isDateInToday(earlierD))
+            expectFalse(c.isDateInYesterday(earlierD))
+            expectFalse(c.isDateInTomorrow(earlierD))
+            
+            expectTrue(c.isDateInWeekend(d)) // 😢
+            
+            expectTrue(c.dateIntervalOfWeekend(containing: d, start: &d1, interval: &ti))
+            
+            if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+                let thisWeekend = DateInterval(start: Date(timeIntervalSince1970: 1468652400.0), duration: 172800.0)
+                
+                expectEqual(thisWeekend, DateInterval(start: d1, duration: ti))
+                expectEqual(thisWeekend, c.dateIntervalOfWeekend(containing: d))
+            }
+            
 
-        expectTrue(c.nextWeekend(startingAfter: d, start: &d1, interval: &ti))
-        
-        if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
-            let nextWeekend = DateInterval(start: Date(timeIntervalSince1970: 1469257200.0), duration: 172800.0)
-        
-            expectEqual(nextWeekend, DateInterval(start: d1, duration: ti))
-            expectEqual(nextWeekend, c.nextWeekend(startingAfter: d))
-        }
-        
-        // Enumeration
-        
-        var count = 0
-        var exactCount = 0
-        
-        // Find the days numbered '31' after 'd', allowing the algorithm to move to the next day if required
-        c.enumerateDates(startingAfter: d, matching: DateComponents(day: 31), matchingPolicy: .nextTime) { result, exact, stop in
-            // Just stop some arbitrary time in the future
-            if result > d + 86400*365 { stop = true }
-            count += 1
-            if exact { exactCount += 1 }
-        }
-        
-        /*
-         Optional(2016-07-31 07:00:00 +0000)
-         Optional(2016-08-31 07:00:00 +0000)
-         Optional(2016-10-01 07:00:00 +0000)
-         Optional(2016-10-31 07:00:00 +0000)
-         Optional(2016-12-01 08:00:00 +0000)
-         Optional(2016-12-31 08:00:00 +0000)
-         Optional(2017-01-31 08:00:00 +0000)
-         Optional(2017-03-01 08:00:00 +0000)
-         Optional(2017-03-31 07:00:00 +0000)
-         Optional(2017-05-01 07:00:00 +0000)
-         Optional(2017-05-31 07:00:00 +0000)
-         Optional(2017-07-01 07:00:00 +0000)
-         Optional(2017-07-31 07:00:00 +0000)
-         */
+            expectTrue(c.nextWeekend(startingAfter: d, start: &d1, interval: &ti))
+            
+            if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+                let nextWeekend = DateInterval(start: Date(timeIntervalSince1970: 1469257200.0), duration: 172800.0)
+            
+                expectEqual(nextWeekend, DateInterval(start: d1, duration: ti))
+                expectEqual(nextWeekend, c.nextWeekend(startingAfter: d))
+            }
+            
+            // Enumeration
+            
+            var count = 0
+            var exactCount = 0
+            
+            // Find the days numbered '31' after 'd', allowing the algorithm to move to the next day if required
+            c.enumerateDates(startingAfter: d, matching: DateComponents(day: 31), matchingPolicy: .nextTime) { result, exact, stop in
+                // Just stop some arbitrary time in the future
+                if result > d + 86400*365 { stop = true }
+                count += 1
+                if exact { exactCount += 1 }
+            }
+            
+            /*
+             Optional(2016-07-31 07:00:00 +0000)
+             Optional(2016-08-31 07:00:00 +0000)
+             Optional(2016-10-01 07:00:00 +0000)
+             Optional(2016-10-31 07:00:00 +0000)
+             Optional(2016-12-01 08:00:00 +0000)
+             Optional(2016-12-31 08:00:00 +0000)
+             Optional(2017-01-31 08:00:00 +0000)
+             Optional(2017-03-01 08:00:00 +0000)
+             Optional(2017-03-31 07:00:00 +0000)
+             Optional(2017-05-01 07:00:00 +0000)
+             Optional(2017-05-31 07:00:00 +0000)
+             Optional(2017-07-01 07:00:00 +0000)
+             Optional(2017-07-31 07:00:00 +0000)
+             */
 
-        expectEqual(count, 13)
-        expectEqual(exactCount, 8)
-        
-        
-        expectEqual(Date(timeIntervalSince1970: 1469948400.0), c.nextDate(after: d, matching: DateComponents(day: 31), matchingPolicy: .nextTime))
-        
-        
-        expectEqual(Date(timeIntervalSince1970: 1468742400.0),  c.date(bySetting: .hour, value: 1, of: d))
-        
-        expectEqual(Date(timeIntervalSince1970: 1468656123.0), c.date(bySettingHour: 1, minute: 2, second: 3, of: d, matchingPolicy: .nextTime))
-        
-        expectTrue(c.date(d, matchesComponents: DateComponents(month: 7)))
-        expectFalse(c.date(d, matchesComponents: DateComponents(month: 7, day: 31)))
+            expectEqual(count, 13)
+            expectEqual(exactCount, 8)
+            
+            
+            expectEqual(Date(timeIntervalSince1970: 1469948400.0), c.nextDate(after: d, matching: DateComponents(day: 31), matchingPolicy: .nextTime))
+            
+            
+            expectEqual(Date(timeIntervalSince1970: 1468742400.0),  c.date(bySetting: .hour, value: 1, of: d))
+            
+            expectEqual(Date(timeIntervalSince1970: 1468656123.0), c.date(bySettingHour: 1, minute: 2, second: 3, of: d, matchingPolicy: .nextTime))
+            
+            expectTrue(c.date(d, matchesComponents: DateComponents(month: 7)))
+            expectFalse(c.date(d, matchesComponents: DateComponents(month: 7, day: 31)))
+        }
     }
 }
 

--- a/test/1_stdlib/TestCalendar.swift
+++ b/test/1_stdlib/TestCalendar.swift
@@ -1,0 +1,265 @@
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+//
+// RUN: %target-clang %S/Inputs/FoundationBridge/FoundationBridge.m -c -o %t/FoundationBridgeObjC.o -g
+// RUN: %target-build-swift %s -I %S/Inputs/FoundationBridge/ -Xlinker %t/FoundationBridgeObjC.o -o %t/TestCalendar
+
+// RUN: %target-run %t/TestCalendar > %t.txt
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+import FoundationBridgeObjC
+
+#if FOUNDATION_XCTEST
+    import XCTest
+    class TestCalendarSuper : XCTestCase { }
+#else
+    import StdlibUnittest
+    class TestCalendarSuper { }
+#endif
+
+class TestCalendar : TestCalendarSuper {
+    
+    func test_copyOnWrite() {
+        var c = Calendar(identifier: .gregorian)
+        let c2 = c
+        expectEqual(c, c2)
+        
+        // Change the weekday and check result
+        let firstWeekday = c.firstWeekday
+        let newFirstWeekday = firstWeekday < 7 ? firstWeekday + 1 : firstWeekday - 1
+        
+        c.firstWeekday = newFirstWeekday
+        expectEqual(newFirstWeekday, c.firstWeekday)
+        expectEqual(c2.firstWeekday, firstWeekday)
+        
+        expectNotEqual(c, c2)
+        
+        // Change the time zone and check result
+        let c3 = c
+        expectEqual(c, c3)
+        
+        let tz = c.timeZone
+        // Use two different identifiers so we don't fail if the current time zone happens to be the one returned
+        let aTimeZoneId = TimeZone.knownTimeZoneIdentifiers[1]
+        let anotherTimeZoneId = TimeZone.knownTimeZoneIdentifiers[0]
+        
+        let newTz = tz.identifier == aTimeZoneId ? TimeZone(identifier: anotherTimeZoneId)! : TimeZone(identifier: aTimeZoneId)!
+        
+        c.timeZone = newTz
+        expectNotEqual(c, c3)
+        
+    }
+    
+    func test_bridgingAutoupdating() {
+        let tester = CalendarBridgingTester()
+        
+        do {
+            let c = Calendar.autoupdatingCurrent
+            let result = tester.verifyAutoupdating(c)
+            expectTrue(result)
+        }
+        
+        // Round trip an autoupdating calendar
+        do {
+            let c = tester.autoupdatingCurrentCalendar()
+            let result = tester.verifyAutoupdating(c)
+            expectTrue(result)
+        }
+    }
+    
+    func test_equality() {
+        let autoupdating = Calendar.autoupdatingCurrent
+        let autoupdating2 = Calendar.autoupdatingCurrent
+
+        expectEqual(autoupdating, autoupdating2)
+        
+        let current = Calendar.current
+        
+        expectNotEqual(autoupdating, current)
+        
+        // Make a copy of current
+        var current2 = current
+        expectEqual(current, current2)
+        
+        // Mutate something (making sure we don't use the current time zone)
+        if current2.timeZone.identifier == "America/Los_Angeles" {
+            current2.timeZone = TimeZone(identifier: "America/New_York")!
+        } else {
+            current2.timeZone = TimeZone(identifier: "America/Los_Angeles")!
+        }
+        expectNotEqual(current, current2)
+        
+        // Mutate something else
+        current2 = current
+        expectEqual(current, current2)
+        
+        current2.locale = Locale(identifier: "MyMadeUpLocale")
+        expectNotEqual(current, current2)
+    }
+    
+    func test_properties() {
+        // Mainly we want to just make sure these go through to the NSCalendar implementation at this point.
+        
+        var c = Calendar(identifier: .gregorian)
+        // Use english localization
+        c.locale = Locale(identifier: "en_US")
+        
+        expectEqual("AM", c.amSymbol)
+        expectEqual("PM", c.pmSymbol)
+        expectEqual(["1st quarter", "2nd quarter", "3rd quarter", "4th quarter"], c.quarterSymbols)
+        expectEqual(["1st quarter", "2nd quarter", "3rd quarter", "4th quarter"], c.standaloneQuarterSymbols)
+        expectEqual(["BC", "AD"], c.eraSymbols)
+        expectEqual(["Before Christ", "Anno Domini"], c.longEraSymbols)
+        expectEqual(["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"], c.veryShortMonthSymbols)
+        expectEqual(["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"], c.veryShortStandaloneMonthSymbols)
+        expectEqual(["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"], c.shortMonthSymbols)
+        expectEqual(["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"], c.shortStandaloneMonthSymbols)
+        expectEqual(["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"], c.monthSymbols)
+        expectEqual(["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"], c.standaloneMonthSymbols)
+        expectEqual(["Q1", "Q2", "Q3", "Q4"], c.shortQuarterSymbols)
+        expectEqual(["Q1", "Q2", "Q3", "Q4"], c.shortStandaloneQuarterSymbols)
+        expectEqual(["S", "M", "T", "W", "T", "F", "S"], c.veryShortStandaloneWeekdaySymbols)
+        expectEqual(["S", "M", "T", "W", "T", "F", "S"], c.veryShortWeekdaySymbols)
+        expectEqual(["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"], c.shortStandaloneWeekdaySymbols)
+        expectEqual(["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"], c.shortWeekdaySymbols)
+        expectEqual(["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"], c.standaloneWeekdaySymbols)
+        expectEqual(["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"], c.weekdaySymbols)
+        
+        // The idea behind these tests is not to test calendrical math, but to simply verify that we are getting some kind of result from calling through to the underlying Foundation and ICU logic. If we move that logic into this struct in the future, then we will need to expand the test cases.
+        
+        // This is a very special Date in my life: the exact moment when I wrote these test cases and therefore knew all of the answers.
+        let d = Date(timeIntervalSince1970: 1468705593.2533731)
+        let earlierD = c.date(byAdding: DateComponents(day: -10), to: d)!
+            
+        expectEqual(1..<29, c.minimumRange(of: .day))
+        expectEqual(1..<54, c.maximumRange(of: .weekOfYear))
+        expectEqual(0..<60, c.range(of: .second, in: .minute, for: d))
+        
+        var d1 = Date()
+        var ti : TimeInterval = 0
+        
+        expectTrue(c.dateInterval(of: .day, start: &d1, interval: &ti, for: d))
+        expectEqual(Date(timeIntervalSince1970: 1468652400.0), d1)
+        expectEqual(86400, ti)
+        
+        if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+            let dateInterval = c.dateInterval(of: .day, for: d)
+            expectEqual(DateInterval(start: d1, duration: ti), dateInterval)
+        }
+        
+        expectEqual(15, c.ordinality(of: .hour, in: .day, for: d))
+        
+        expectEqual(Date(timeIntervalSince1970: 1468791993.2533731), c.date(byAdding: .day, value: 1, to: d))
+        expectEqual(Date(timeIntervalSince1970: 1468791993.2533731), c.date(byAdding: DateComponents(day: 1),  to: d))
+        
+        expectEqual(Date(timeIntervalSince1970: 946627200.0), c.date(from: DateComponents(year: 1999, month: 12, day: 31)))
+        
+        let comps = c.dateComponents([.year, .month, .day], from: Date(timeIntervalSince1970: 946627200.0))
+        expectEqual(1999, comps.year)
+        expectEqual(12, comps.month)
+        expectEqual(31, comps.day)
+        
+        expectEqual(10, c.dateComponents([.day], from: d, to: c.date(byAdding: DateComponents(day: 10), to: d)!).day)
+        
+        expectEqual(30, c.dateComponents([.day], from: DateComponents(year: 1999, month: 12, day: 1), to: DateComponents(year: 1999, month: 12, day: 31)).day)
+        
+        expectEqual(2016, c.component(.year, from: d))
+        
+        expectEqual(Date(timeIntervalSince1970: 1468652400.0), c.startOfDay(for: d))
+        
+        expectEqual(.orderedSame, c.compare(d, to: d + 10, toGranularity: .minute))
+        
+        expectFalse(c.isDate(d, equalTo: d + 10, toGranularity: .second))
+        expectTrue(c.isDate(d, equalTo: d + 10, toGranularity: .day))
+        
+        expectFalse(c.isDate(earlierD, inSameDayAs: d))
+        expectTrue(c.isDate(d, inSameDayAs: d))
+        
+        expectFalse(c.isDateInToday(earlierD))
+        expectFalse(c.isDateInYesterday(earlierD))
+        expectFalse(c.isDateInTomorrow(earlierD))
+        
+        expectTrue(c.isDateInWeekend(d)) // 😢
+        
+        expectTrue(c.dateIntervalOfWeekend(containing: d, start: &d1, interval: &ti))
+        
+        if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+            let thisWeekend = DateInterval(start: Date(timeIntervalSince1970: 1468652400.0), duration: 172800.0)
+            
+            expectEqual(thisWeekend, DateInterval(start: d1, duration: ti))
+            expectEqual(thisWeekend, c.dateIntervalOfWeekend(containing: d))
+        }
+        
+
+        expectTrue(c.nextWeekend(startingAfter: d, start: &d1, interval: &ti))
+        
+        if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+            let nextWeekend = DateInterval(start: Date(timeIntervalSince1970: 1469257200.0), duration: 172800.0)
+        
+            expectEqual(nextWeekend, DateInterval(start: d1, duration: ti))
+            expectEqual(nextWeekend, c.nextWeekend(startingAfter: d))
+        }
+        
+        // Enumeration
+        
+        var count = 0
+        var exactCount = 0
+        
+        // Find the days numbered '31' after 'd', allowing the algorithm to move to the next day if required
+        c.enumerateDates(startingAfter: d, matching: DateComponents(day: 31), matchingPolicy: .nextTime) { result, exact, stop in
+            // Just stop some arbitrary time in the future
+            if result > d + 86400*365 { stop = true }
+            count += 1
+            if exact { exactCount += 1 }
+        }
+        
+        /*
+         Optional(2016-07-31 07:00:00 +0000)
+         Optional(2016-08-31 07:00:00 +0000)
+         Optional(2016-10-01 07:00:00 +0000)
+         Optional(2016-10-31 07:00:00 +0000)
+         Optional(2016-12-01 08:00:00 +0000)
+         Optional(2016-12-31 08:00:00 +0000)
+         Optional(2017-01-31 08:00:00 +0000)
+         Optional(2017-03-01 08:00:00 +0000)
+         Optional(2017-03-31 07:00:00 +0000)
+         Optional(2017-05-01 07:00:00 +0000)
+         Optional(2017-05-31 07:00:00 +0000)
+         Optional(2017-07-01 07:00:00 +0000)
+         Optional(2017-07-31 07:00:00 +0000)
+         */
+
+        expectEqual(count, 13)
+        expectEqual(exactCount, 8)
+        
+        
+        expectEqual(Date(timeIntervalSince1970: 1469948400.0), c.nextDate(after: d, matching: DateComponents(day: 31), matchingPolicy: .nextTime))
+        
+        
+        expectEqual(Date(timeIntervalSince1970: 1468742400.0),  c.date(bySetting: .hour, value: 1, of: d))
+        
+        expectEqual(Date(timeIntervalSince1970: 1468656123.0), c.date(bySettingHour: 1, minute: 2, second: 3, of: d, matchingPolicy: .nextTime))
+        
+        expectTrue(c.date(d, matchesComponents: DateComponents(month: 7)))
+        expectFalse(c.date(d, matchesComponents: DateComponents(month: 7, day: 31)))
+    }
+}
+
+#if !FOUNDATION_XCTEST
+var CalendarTests = TestSuite("TestCalendar")
+CalendarTests.test("test_copyOnWrite") { TestCalendar().test_copyOnWrite() }
+CalendarTests.test("test_bridgingAutoupdating") { TestCalendar().test_bridgingAutoupdating() }
+CalendarTests.test("test_equality") { TestCalendar().test_equality() }
+CalendarTests.test("test_properties") { TestCalendar().test_properties() }
+runAllTests()
+#endif

--- a/test/1_stdlib/TestDate.swift
+++ b/test/1_stdlib/TestDate.swift
@@ -83,8 +83,8 @@ class TestDate : TestDateSuper {
     func dateWithString(_ str: String) -> Date {
         let formatter = DateFormatter()
         // Note: Calendar(identifier:) is OSX 10.9+ and iOS 8.0+ whereas the CF version has always been available
-        formatter.calendar = CFCalendarCreateWithIdentifier(kCFAllocatorSystemDefault, .gregorianCalendar)! as Calendar
-        formatter.locale = Locale(localeIdentifier: "en_US")
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US")
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
         return formatter.date(from: str)! as Date
     }

--- a/test/1_stdlib/TestDateInterval.swift
+++ b/test/1_stdlib/TestDateInterval.swift
@@ -23,12 +23,8 @@ class TestDateIntervalSuper { }
 class TestDateInterval : TestDateIntervalSuper {
     func dateWithString(_ str: String) -> Date {
         let formatter = DateFormatter()
-	if #available(iOS 9, *){
-           formatter.calendar = Calendar(identifier: .gregorian)!
-	}else{
-	   formatter.calendar = Calendar(calendarIdentifier: .gregorian)!
-	}
-        formatter.locale = Locale(localeIdentifier: "en_US")
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US")
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
         return formatter.date(from: str)! as Date
     }

--- a/test/1_stdlib/TestLocale.swift
+++ b/test/1_stdlib/TestLocale.swift
@@ -1,0 +1,120 @@
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+//
+// RUN: %target-clang %S/Inputs/FoundationBridge/FoundationBridge.m -c -o %t/FoundationBridgeObjC.o -g
+// RUN: %target-build-swift %s -I %S/Inputs/FoundationBridge/ -Xlinker %t/FoundationBridgeObjC.o -o %t/TestLocale
+
+// RUN: %target-run %t/TestLocale > %t.txt
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+import FoundationBridgeObjC
+
+#if FOUNDATION_XCTEST
+    import XCTest
+    class TestLocaleSuper : XCTestCase { }
+#else
+    import StdlibUnittest
+    class TestLocaleSuper { }
+#endif
+
+class TestLocale : TestLocaleSuper {
+    
+    func test_bridgingAutoupdating() {
+        let tester = LocaleBridgingTester()
+        
+        do {
+            let loc = Locale.autoupdatingCurrent
+            let result = tester.verifyAutoupdating(loc)
+            expectTrue(result)
+        }
+        
+        do {
+            let loc = tester.autoupdatingCurrentLocale()
+            let result = tester.verifyAutoupdating(loc)
+            expectTrue(result)
+        }
+    }
+    
+    func test_equality() {
+        let autoupdating = Locale.autoupdatingCurrent
+        let autoupdating2 = Locale.autoupdatingCurrent
+
+        expectEqual(autoupdating, autoupdating2)
+        
+        let current = Locale.current
+        
+        expectNotEqual(autoupdating, current)
+    }
+    
+    func test_localizedStringFunctions() {
+        let locale = Locale(identifier: "en")
+
+        expectEqual("English", locale.localizedString(forIdentifier: "en"))
+        expectEqual("France", locale.localizedString(forRegionCode: "fr"))
+        expectEqual("Spanish", locale.localizedString(forLanguageCode: "es"))
+        expectEqual("Simplified Han", locale.localizedString(forScriptCode: "Hans"))
+        expectEqual("Computer", locale.localizedString(forVariantCode: "POSIX"))
+        expectEqual("Buddhist Calendar", locale.localizedString(for: .buddhist))
+        expectEqual("US Dollar", locale.localizedString(forCurrencyCode: "USD"))
+        expectEqual("Phonebook Sort Order", locale.localizedString(forCollationIdentifier: "phonebook"))
+        // Need to find a good test case for collator identifier
+        // expectEqual("something", locale.localizedString(forCollatorIdentifier: "en"))
+    }
+    
+    func test_properties() {
+        let locale = Locale(identifier: "zh-Hant-HK")
+        
+        expectEqual("zh-Hant-HK", locale.identifier)
+        expectEqual("zh", locale.languageCode)
+        expectEqual("HK", locale.regionCode)
+        expectEqual("Hant", locale.scriptCode)
+        expectEqual("POSIX", Locale(identifier: "en_POSIX").variantCode)
+        expectTrue(locale.exemplarCharacterSet != nil)
+        // The calendar we get back from Locale has the locale set, but not the one we create with Calendar(identifier:). So we configure our comparison calendar first.
+        var c = Calendar(identifier: .gregorian)
+        c.locale = Locale(identifier: "en_US")
+        expectEqual(c, Locale(identifier: "en_US").calendar)
+        expectEqual("「", locale.quotationBeginDelimiter)
+        expectEqual("」", locale.quotationEndDelimiter)
+        expectEqual("『", locale.alternateQuotationBeginDelimiter)
+        expectEqual("』", locale.alternateQuotationEndDelimiter)
+        expectEqual("phonebook", Locale(identifier: "en_US@collation=phonebook").collationIdentifier)
+        expectEqual(".", locale.decimalSeparator)
+
+        
+        expectEqual(".", locale.decimalSeparator)
+        expectEqual(",", locale.groupingSeparator)
+        expectEqual("HK$", locale.currencySymbol)
+        expectEqual("HKD", locale.currencyCode)
+        
+        expectTrue(Locale.availableIdentifiers.count > 0)
+        expectTrue(Locale.isoLanguageCodes.count > 0)
+        expectTrue(Locale.isoRegionCodes.count > 0)
+        expectTrue(Locale.isoCurrencyCodes.count > 0)
+        expectTrue(Locale.commonISOCurrencyCodes.count > 0)
+        
+        expectTrue(Locale.preferredLanguages.count > 0)
+        
+        // Need to find a good test case for collator identifier
+        // expectEqual("something", locale.collatorIdentifier)
+    }
+}
+
+#if !FOUNDATION_XCTEST
+var LocaleTests = TestSuite("TestLocale")
+LocaleTests.test("test_bridgingAutoupdating") { TestLocale().test_bridgingAutoupdating() }
+LocaleTests.test("test_equality") { TestLocale().test_equality() }
+LocaleTests.test("test_localizedStringFunctions") { TestLocale().test_localizedStringFunctions() }
+LocaleTests.test("test_properties") { TestLocale().test_properties() }
+runAllTests()
+#endif

--- a/test/1_stdlib/TestTimeZone.swift
+++ b/test/1_stdlib/TestTimeZone.swift
@@ -1,0 +1,73 @@
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+//
+// RUN: %target-clang %S/Inputs/FoundationBridge/FoundationBridge.m -c -o %t/FoundationBridgeObjC.o -g
+// RUN: %target-build-swift %s -I %S/Inputs/FoundationBridge/ -Xlinker %t/FoundationBridgeObjC.o -o %t/TestTimeZone
+
+// RUN: %target-run %t/TestTimeZone > %t.txt
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+import FoundationBridgeObjC
+
+#if FOUNDATION_XCTEST
+    import XCTest
+    class TestTimeZoneSuper : XCTestCase { }
+#else
+    import StdlibUnittest
+    class TestTimeZoneSuper { }
+#endif
+
+class TestTimeZone : TestTimeZoneSuper {
+    
+    func test_timeZoneBasics() {
+        let tz = TimeZone(identifier: "America/Los_Angeles")!
+        
+        expectTrue(!tz.identifier.isEmpty)
+    }
+    
+    func test_bridgingAutoupdating() {
+        let tester = TimeZoneBridgingTester()
+        
+        do {
+            let tz = TimeZone.autoupdatingCurrent
+            let result = tester.verifyAutoupdating(tz)
+            expectTrue(result)
+        }
+        
+        // Round trip an autoupdating calendar
+        do {
+            let tz = tester.autoupdatingCurrentTimeZone()
+            let result = tester.verifyAutoupdating(tz)
+            expectTrue(result)
+        }
+    }
+    
+    func test_equality() {
+        let autoupdating = TimeZone.autoupdatingCurrent
+        let autoupdating2 = TimeZone.autoupdatingCurrent
+
+        expectEqual(autoupdating, autoupdating2)
+        
+        let current = TimeZone.current
+        
+        expectNotEqual(autoupdating, current)
+    }
+}
+
+#if !FOUNDATION_XCTEST
+var TimeZoneTests = TestSuite("TestTimeZone")
+TimeZoneTests.test("test_timeZoneBasics") { TestTimeZone().test_timeZoneBasics() }
+TimeZoneTests.test("test_bridgingAutoupdating") { TestTimeZone().test_bridgingAutoupdating() }
+TimeZoneTests.test("test_equality") { TestTimeZone().test_equality() }
+runAllTests()
+#endif

--- a/test/ClangModules/enum-with-target.swift
+++ b/test/ClangModules/enum-with-target.swift
@@ -6,8 +6,8 @@ import Foundation
 import user_objc
 
 // Ignore deprecated constants in prefix stripping, even if they aren't deprecated /yet/.
-let calendarUnits: Calendar.Unit = [.era, .year, .calendar]
-let calendarUnits2: Calendar.Unit = [.NSMonthCalendarUnit, .NSYearCalendarUnit] // expected-error 2 {{unavailable}}
+let calendarUnits: NSCalendar.Unit = [.era, .year, .calendar]
+let calendarUnits2: NSCalendar.Unit = [.NSMonthCalendarUnit, .NSYearCalendarUnit] // expected-error 2 {{unavailable}}
   // ...unless they're all deprecated.
 let calendarUnitsDep: CalendarUnitDeprecated = [.eraCalendarUnitDeprecated, .yearCalendarUnitDeprecated] // expected-error 2 {{unavailable}}
 

--- a/test/IDE/print_omit_needless_words.swift
+++ b/test/IDE/print_omit_needless_words.swift
@@ -119,8 +119,8 @@
 // Note: Noun phrase puts preposition inside.
 // CHECK-FOUNDATION: func url(withAddedString: String) -> NSURL?
 
-// Note: CalendarUnits is not a set of "Options".
-// CHECK-FOUNDATION: class func forCalendarUnits(_: Calendar.Unit) -> String!
+// Note: NSCalendarUnits is not a set of "Options".
+// CHECK-FOUNDATION: class func forCalendarUnits(_: NSCalendar.Unit) -> String!
 
 // Note: <property type>By<gerund> --> <gerund>.
 // CHECK-FOUNDATION: var deletingLastPathComponent: NSURL? { get }

--- a/test/Interpreter/SDK/Foundation_NSString.swift
+++ b/test/Interpreter/SDK/Foundation_NSString.swift
@@ -140,7 +140,7 @@ print(NSString(format: "%@ %@", "x", "y"))
 // CHECK-NEXT: 1{{.*}}024,25
 print(NSString(
   format: "%g",
-  locale: Locale(localeIdentifier: "fr_FR"),
+  locale: Locale(identifier: "fr_FR"),
   1024.25
 ))
 // CHECK-NEXT: x y z

--- a/validation-test/StdlibUnittest/FoundationExtras.swift
+++ b/validation-test/StdlibUnittest/FoundationExtras.swift
@@ -16,18 +16,18 @@ FoundationExtrasTests.test("withOverriddenLocaleCurrentLocale(Locale)") {
   // these locales happens to be the same as the actual current locale.
   do {
     let result = withOverriddenLocaleCurrentLocale(
-      Locale(localeIdentifier: "en_US")) {
+      Locale(identifier: "en_US")) {
       () -> Int in
-      expectEqual("en_US", Locale.current.localeIdentifier)
+      expectEqual("en_US", Locale.current.identifier)
       return 42
     }
     expectEqual(42, result)
   }
   do {
     let result = withOverriddenLocaleCurrentLocale(
-      Locale(localeIdentifier: "uk")) {
+      Locale(identifier: "uk")) {
       () -> Int in
-      expectEqual("uk", Locale.current.localeIdentifier)
+      expectEqual("uk", Locale.current.identifier)
       return 42
     }
     expectEqual(42, result)
@@ -36,13 +36,13 @@ FoundationExtrasTests.test("withOverriddenLocaleCurrentLocale(Locale)") {
 
 FoundationExtrasTests.test("withOverriddenLocaleCurrentLocale(Locale)/nested") {
   withOverriddenLocaleCurrentLocale(
-    Locale(localeIdentifier: "uk")) {
+    Locale(identifier: "uk")) {
     () -> Void in
 
     expectCrashLater()
 
     withOverriddenLocaleCurrentLocale(
-      Locale(localeIdentifier: "uk")) {
+      Locale(identifier: "uk")) {
       () -> Void in
 
       return ()
@@ -56,7 +56,7 @@ FoundationExtrasTests.test("withOverriddenLocaleCurrentLocale(String)") {
   do {
     let result = withOverriddenLocaleCurrentLocale("en_US") {
       () -> Int in
-      expectEqual("en_US", Locale.current.localeIdentifier)
+      expectEqual("en_US", Locale.current.identifier)
       return 42
     }
     expectEqual(42, result)
@@ -64,7 +64,7 @@ FoundationExtrasTests.test("withOverriddenLocaleCurrentLocale(String)") {
   do {
     let result = withOverriddenLocaleCurrentLocale("uk") {
       () -> Int in
-      expectEqual("uk", Locale.current.localeIdentifier)
+      expectEqual("uk", Locale.current.identifier)
       return 42
     }
     expectEqual(42, result)


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

New value types for Calendar, TimeZone, and Locale

As part of the extensive work on value types in Foundation this year, we decided to also add value types for these three key classes. In addition to adding value semantics, the API was extensively audited to improve Swift interop (especially Calendar).
#### Resolved bugs

<!-- If this pull request resolves any bugs from Swift bug tracker -->

rdar://26628184

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
