### PR TITLE
[stdlib] Generalize array bridge/cast machinery

### DIFF
--- a/stdlib/public/core/ArrayCast.swift
+++ b/stdlib/public/core/ArrayCast.swift
@@ -16,181 +16,49 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if _runtime(_ObjC)
-// FIXME: These need to be implemented even for non-objc:
-// rdar://problem/18881196
-
-internal enum _ValueOrReference {
-  case reference, value
-
-  internal init<T>(_: T.Type) {
-    self = _isClassOrObjCExistential(T.self) ? .reference : .value
-  }
-}
-
-internal enum _BridgeStyle {
-  case verbatim, explicit
-
-  internal init<T>(_: T.Type) {
-   self = _isBridgedVerbatimToObjectiveC(T.self) ? .verbatim : .explicit
-  }
-}
-
-//===--- Forced casts: [T] as! [U] ----------------------------------------===//
-
 /// Implements `source as! [TargetElement]`.
 ///
-/// - Precondition: At least one of `SourceElement` and `TargetElement` is a
-/// class type or ObjC existential.  May trap for other "valid" inputs when
-/// `TargetElement` is not bridged verbatim, if an element can't be converted.
+/// - Note: When SourceElement and TargetElement are both bridged verbatim, type
+///   checking is deferred until elements are actually accessed.
 public func _arrayForceCast<SourceElement, TargetElement>(
   _ source: Array<SourceElement>
 ) -> Array<TargetElement> {
-  switch (
-    _ValueOrReference(SourceElement.self), _BridgeStyle(TargetElement.self)
-  ) {
-  case (.reference, .verbatim):
-    let native = source._buffer.requestNativeBuffer()
-    
-    if _fastPath(native != nil) {
-      if _fastPath(native!.storesOnlyElementsOfType(TargetElement.self)) {
+#if _runtime(_ObjC)
+  if _isClassOrObjCExistential(SourceElement.self)
+  && _isClassOrObjCExistential(TargetElement.self) {
+    let src = source._buffer
+    if let native = src.requestNativeBuffer() {
+      if native.storesOnlyElementsOfType(TargetElement.self) {
         // A native buffer that is known to store only elements of the
         // TargetElement can be used directly
-        return Array(_buffer: source._buffer.cast(toBufferOf: TargetElement.self))
+        return Array(_buffer: src.cast(toBufferOf: TargetElement.self))
       }
       // Other native buffers must use deferred element type checking
       return Array(_buffer:
-        source._buffer.downcast(
-          toBufferWithDeferredTypeCheckOf: TargetElement.self))
+        src.downcast(toBufferWithDeferredTypeCheckOf: TargetElement.self))
     }
-    // All non-native buffers use deferred element typechecking
     return Array(_immutableCocoaArray: source._buffer._asCocoaArray())
-    
-  case (.reference, .explicit):
-    let result: [TargetElement]? = _arrayConditionalBridgeElements(source)
-    _precondition(result != nil, "array cannot be bridged from Objective-C")
-    return result!
-    
-  case (.value, .verbatim):
-    if source.isEmpty {
-      return Array()
-    }
-
-    var buf = _ContiguousArrayBuffer<TargetElement>(
-      uninitializedCount: source.count, minimumCapacity: 0)
-    
-    let _: Void = buf.withUnsafeMutableBufferPointer {
-      var p = $0.baseAddress!
-      for value in source {
-        let bridged: AnyObject? = _bridgeToObjectiveC(value)
-        _precondition(
-          bridged != nil, "array element cannot be bridged to Objective-C")
-        // FIXME: should be an unsafeDowncast.
-        p.initialize(with: unsafeBitCast(bridged!, to: TargetElement.self))
-        p += 1
-      }
-    }
-    return Array(_buffer: _ArrayBuffer(buf, shiftedToStartIndex: 0))
-    
-  case (.value, .explicit):
-    _sanityCheckFailure(
-      "Force-casting between Arrays of value types not prevented at compile-time"
-    )
   }
+#endif
+  return _arrayConditionalCast(source)!
 }
 
-//===--- Conditional casts: [T] as? [U] -----------------------------------===//
+internal struct _UnwrappingFailed : Error {}
 
-/// Implements the semantics of `x as? [TargetElement]` where `x` has type
-/// `[SourceElement]` and `TargetElement` is a verbatim-bridged trivial subtype of
-/// `SourceElement`.
-///
-/// Returns an Array<TargetElement> containing the same elements as a
-///
-/// O(1) if a's buffer elements are dynamically known to have type
-/// TargetElement or a type derived from TargetElement.  O(N)
-/// otherwise.
-internal func _arrayConditionalDownCastElements<SourceElement, TargetElement>(
-  _ a: Array<SourceElement>
-) -> [TargetElement]? {
-  _sanityCheck(_isBridgedVerbatimToObjectiveC(SourceElement.self))
-  _sanityCheck(_isBridgedVerbatimToObjectiveC(TargetElement.self))
-  
-  if _fastPath(!a.isEmpty) {
-    let native = a._buffer.requestNativeBuffer()
-    
-    if _fastPath(native != nil) {
-      if native!.storesOnlyElementsOfType(TargetElement.self) {
-        return Array(_buffer: a._buffer.cast(toBufferOf: TargetElement.self))
-      }
-      return nil
-    }
-    
-    // slow path: we store an NSArray
-    
-    // We can skip the check if TargetElement happens to be AnyObject
-    if !(AnyObject.self is TargetElement.Type) {
-      for element in a {
-        if !(element is TargetElement) {
-          return nil
-        }
-      }
-    }
-    return Array(_buffer: a._buffer.cast(toBufferOf: TargetElement.self))
+extension Optional {
+  internal func unwrappedOrError() throws -> Wrapped {
+    if let x = self { return x }
+    throw _UnwrappingFailed()
   }
-  return []
-}
-
-/// Try to convert the source array of objects to an array of values
-/// produced by bridging the objects from Objective-C to `TargetElement`.
-///
-/// - Precondition: SourceElement is a class type.
-/// - Precondition: TargetElement is bridged non-verbatim to Objective-C.
-///   O(n), because each element must be bridged separately.
-internal func _arrayConditionalBridgeElements<
-  SourceElement,
-  TargetElement
->(_ source: Array<SourceElement>) -> Array<TargetElement>? {
-    
-  _sanityCheck(_isBridgedVerbatimToObjectiveC(SourceElement.self))
-  _sanityCheck(!_isBridgedVerbatimToObjectiveC(TargetElement.self))
-  
-  let buf = _ContiguousArrayBuffer<TargetElement>(
-    uninitializedCount: source.count, minimumCapacity: 0)
-  
-  var p = buf.firstElementAddress
-  
-  // Make sure the resulting array owns anything that is successfully stored
-  // there.
-  defer { buf.count = p - buf.firstElementAddress }
-    
-  for object: SourceElement in source {
-    guard let value = object as? TargetElement else {
-      return nil
-    }
-    p.initialize(with: value)
-    p += 1
-  }
-  return Array(_buffer: _ArrayBuffer(buf, shiftedToStartIndex: 0))
 }
 
 /// Implements `source as? [TargetElement]`: convert each element of
 /// `source` to a `TargetElement` and return the resulting array, or
 /// return `nil` if any element fails to convert.
 ///
-/// - Precondition: `SourceElement` is a class or ObjC existential type.
-/// O(n), because each element must be checked.
+/// - Complexity: O(n), because each element must be checked.
 public func _arrayConditionalCast<SourceElement, TargetElement>(
   _ source: [SourceElement]
 ) -> [TargetElement]? {
-  switch (_ValueOrReference(SourceElement.self), _BridgeStyle(TargetElement.self)) {
-  case (.value, _):
-    _sanityCheckFailure(
-      "Conditional cast from array of value types not prevented at compile-time")
-  case (.reference, .verbatim):
-    return _arrayConditionalDownCastElements(source)
-  case (.reference, .explicit):
-    return _arrayConditionalBridgeElements(source)
-  }
+  return try? source.map { try ($0 as? TargetElement).unwrappedOrError() }
 }
-#endif

--- a/test/1_stdlib/ArrayBridge.swift.gyb
+++ b/test/1_stdlib/ArrayBridge.swift.gyb
@@ -13,8 +13,9 @@
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
 //
+// RUN: %gyb %s -o %t/ArrayBridge.swift
 // RUN: %target-clang %S/Inputs/ArrayBridge/ArrayBridge.m -c -o %t/ArrayBridgeObjC.o -g
-// RUN: %target-build-swift %s -I %S/Inputs/ArrayBridge/ -Xlinker %t/ArrayBridgeObjC.o -o %t/ArrayBridge
+// RUN:  %line-directive %t/ArrayBridge.swift -- %target-build-swift %t/ArrayBridge.swift -I %S/Inputs/ArrayBridge/ -Xlinker %t/ArrayBridgeObjC.o -o %t/ArrayBridge -- 
 
 // RUN: %target-run %t/ArrayBridge
 // REQUIRES: executable_test
@@ -203,25 +204,6 @@ tests.test("testBridgedVerbatim") {
   expectEqual(100, firstBase.value)
   expectEqual(1, firstBase.serialNumber)
 
-  // Create an ordinary NSArray, not a native one
-  let nsArrayOfBase: NSArray = NSArray(object: Base(42))
-
-  // NSArray can be unconditionally cast to [AnyObject]...
-  let nsArrayOfBaseConvertedToAnyObjectArray = nsArrayOfBase as [AnyObject]
-
-  // Capture the representation of the first element
-  let base42: ObjectIdentifier
-  do {
-    let b = nsArrayOfBase.object(at: 0) as! Base
-    expectEqual(42, b.value)
-    base42 = ObjectIdentifier(b)
-  }
-
-  // ...with the same elements
-  expectEqual(
-    base42,
-    ObjectIdentifier(nsArrayOfBaseConvertedToAnyObjectArray[0] as! Base))
-
   // Verify that NSArray class methods are inherited by a Swift bridging class.
   let className = String(reflecting: basesConvertedToNSArray.dynamicType)
   expectTrue(className.hasPrefix("Swift._ContiguousArrayStorage"))
@@ -246,46 +228,72 @@ tests.test("testBridgedVerbatim") {
 
   expectEqual(subclass0, subclassAsBases as! [Subclass])
 
+}
+
+% for Any in 'Any', 'AnyObject':
+
+tests.test("Another/${Any}") {
+  // Create an ordinary NSArray, not a native one
+  let nsArrayOfBase: NSArray = NSArray(object: Base(42))
+
+  // NSArray can be unconditionally cast to [${Any}]...
+  
+  let nsArrayOfBaseConvertedToAnyArray = nsArrayOfBase
+  % if Any == 'Any':
+  // FIXME: nsArrayOfBase as [Any] doesn't typecheck
+  as [AnyObject]
+  % end
+  as [${Any}]
+
+  // Capture the representation of the first element
+  let base42: ObjectIdentifier
+  do {
+    let b = nsArrayOfBase.object(at: 0) as! Base
+    expectEqual(42, b.value)
+    base42 = ObjectIdentifier(b)
+  }
+
+  // ...with the same elements
+  expectEqual(
+    base42,
+    ObjectIdentifier(nsArrayOfBaseConvertedToAnyArray[0] as! Base))
+
   let subclassInBaseBuffer: [Base] = [Subclass(44), Subclass(55)]
   let subclass2 = subclassInBaseBuffer
   
   // Explicit downcast-ability is based on element type, not buffer type
   expectNotEmpty(subclassInBaseBuffer as? [Subclass])
 
-  // We can up-cast to array of AnyObject
-  let subclassAsAnyObjectArray: [AnyObject] = subclassInBaseBuffer
-  expectEqual(subclass2, subclassAsAnyObjectArray.map { $0 as! Base })
+  // We can up-cast to array of Any
+  let subclassAsAnyArray: [${Any}] = subclassInBaseBuffer
+  expectEqual(subclass2, subclassAsAnyArray.map { $0 as! Base })
 
-  let downcastBackToBase = subclassAsAnyObjectArray as? [Base]
+  let downcastBackToBase = subclassAsAnyArray as? [Base]
   expectNotEmpty(downcastBackToBase)
 
-  if let downcastBackToSubclass = expectNotEmpty(subclassAsAnyObjectArray as? [Subclass]) {
+  if let downcastBackToSubclass = expectNotEmpty(subclassAsAnyArray as? [Subclass]) {
     expectEqual(subclass2, downcastBackToSubclass)
   }
 
-  if let downcastToProtocols = expectNotEmpty(subclassAsAnyObjectArray as? [Fooable]) {
+  if let downcastToProtocols = expectNotEmpty(subclassAsAnyArray as? [Fooable]) {
     expectEqual(subclass2, downcastToProtocols.map { $0 as! Subclass })
   }
 
-  if let downcastToProtocols = expectNotEmpty(subclassAsAnyObjectArray as? [Barable]) {
+  if let downcastToProtocols = expectNotEmpty(subclassAsAnyArray as? [Barable]) {
     expectEqual(subclass2, downcastToProtocols.map { $0 as! Subclass })
   }
 
-  if let downcastToProtocols = expectNotEmpty(subclassAsAnyObjectArray as? [protocol<Barable, Fooable>]) {
+  if let downcastToProtocols = expectNotEmpty(subclassAsAnyArray as? [protocol<Barable, Fooable>]) {
     expectEqual(subclass2, downcastToProtocols.map { $0 as! Subclass })
   }
 
-  expectEmpty(subclassAsAnyObjectArray as? [protocol<Barable, Bazable>])
-}
-
-tests.test("doTestSubclass") {
-  testSubclass(Thunks())
+  expectEmpty(subclassAsAnyArray as? [protocol<Barable, Bazable>])
 }
 
 //===--- Explicitly Bridged -----------------------------------------------===//
 // BridgeableValue conforms to _ObjectiveCBridgeable
 //===----------------------------------------------------------------------===//
-tests.test("testExplicitlyBridged") {
+tests.test("testExplicitlyBridged/${Any}") {
   
   let bridgeableValues = [BridgeableValue(42), BridgeableValue(17)]
   
@@ -306,7 +314,14 @@ tests.test("testExplicitlyBridged") {
 
   // Make a real Cocoa NSArray of these...
   let cocoaBridgeableValues = NSArray(
-    array: bridgeableValuesAsNSArray as [AnyObject])
+    array: bridgeableValuesAsNSArray
+    %if Any == 'Any':
+    // FIXME: should just be "as [Any]" but the typechecker doesn't allow it yet
+    as [AnyObject] as [Any] as! [AnyObject]
+    %else:
+    as [${Any}]
+    %end
+  )
 
   // ...and bridge *that* back
   let bridgedBackSwifts = Swift._forceBridgeFromObjectiveC(
@@ -329,10 +344,10 @@ tests.test("testExplicitlyBridged") {
   let bridgeableValuesAsBases: [Base] = bridgeableValues
   expectEqualSequence(expectedBases, bridgeableValuesAsBases)
 
-  let bridgeableValuesAsAnyObjects: [AnyObject] = bridgeableValues
+  let bridgeableValuesAsAnys: [${Any}] = bridgeableValues
   expectEqualSequence(
     expectedBases,
-    bridgeableValuesAsAnyObjects.lazy.map { $0 as! Base })
+    bridgeableValuesAsAnys.lazy.map { $0 as! Base })
 
   // Downcasts of non-verbatim bridged value types to objects.
   do {
@@ -346,23 +361,29 @@ tests.test("testExplicitlyBridged") {
   }
 
   do {
-    let downcasted = bridgeableValues as [AnyObject]
+    let downcasted = bridgeableValues as [${Any}]
     expectEqualSequence(expectedBases, downcasted.map { $0 as! Base })
   }
 
   // Downcasts of up-casted arrays.
   if let downcasted = expectNotEmpty(
-    bridgeableValuesAsAnyObjects as? [Subclass]
+    bridgeableValuesAsAnys as? [Subclass]
   ) {
     expectEqualSequence(expectedSubclasses, downcasted)
   }
 
-  if let downcasted = bridgeableValuesAsAnyObjects as? [Base] {
+  if let downcasted = bridgeableValuesAsAnys as? [Base] {
     expectEqualSequence(expectedBases, downcasted)
   }
 
   // Downcast of Cocoa array to an array of classes.
-  let wrappedCocoaBridgeableValues = cocoaBridgeableValues as [AnyObject]
+  let wrappedCocoaBridgeableValues = cocoaBridgeableValues
+  %if Any == 'Any':
+  // FIXME: should just be "as [Any]" but typechecker doesn't allow it yet.
+  as [AnyObject]
+  %end
+  as [${Any}]
+  
   if let downcasted = wrappedCocoaBridgeableValues as? [Subclass] {
     expectEqualSequence(expectedSubclasses, downcasted)
   }
@@ -375,28 +396,33 @@ tests.test("testExplicitlyBridged") {
   // Downcast of Cocoa array to an array of strings (which should fail)
   expectEmpty(wrappedCocoaBridgeableValues as? [String])
 
-  // Downcast from an implicitly unwrapped optional array of AnyObjects.
-  var wrappedCocoaBridgeableValuesIUO: [AnyObject]! = wrappedCocoaBridgeableValues
+  // Downcast from an implicitly unwrapped optional array of Anys.
+  var wrappedCocoaBridgeableValuesIUO: [${Any}]! = wrappedCocoaBridgeableValues
   if let downcasted = wrappedCocoaBridgeableValuesIUO as? [BridgeableValue] {
     expectEqualSequence(bridgeableValues, downcasted)
   }
 
-  // Downcast from a nil implicitly unwrapped optional array of AnyObjects.
+  // Downcast from a nil implicitly unwrapped optional array of Anys.
   wrappedCocoaBridgeableValuesIUO = nil
   expectEmpty(wrappedCocoaBridgeableValuesIUO as? [BridgeableValue])
 
-  // Downcast from an optional array of AnyObjects.
-  var wrappedCocoaBridgeableValuesOpt: [AnyObject]? = wrappedCocoaBridgeableValues
+  // Downcast from an optional array of Anys.
+  var wrappedCocoaBridgeableValuesOpt: [${Any}]? = wrappedCocoaBridgeableValues
   if let downcasted = wrappedCocoaBridgeableValuesOpt as? [BridgeableValue] {
     expectEqualSequence(bridgeableValues, downcasted)
   }
 
-  // Downcast from a nil optional array of AnyObjects.
+  // Downcast from a nil optional array of Anys.
   wrappedCocoaBridgeableValuesOpt = nil
   expectEmpty(wrappedCocoaBridgeableValuesOpt as? [BridgeableValue])
-  
+}
+% end
+
+tests.test("testThunks") {
+  testSubclass(Thunks())
   testBridgeableValue(Thunks())
 }
+
 
 tests.test("testRoundTrip") {
   class Test : NSObject {

--- a/test/1_stdlib/ArrayTrapsObjC.swift.gyb
+++ b/test/1_stdlib/ArrayTrapsObjC.swift.gyb
@@ -29,7 +29,7 @@ ArrayTraps.test("downcast1")
   let da = ba as! [Derived]
   let d0 = da[0]
   expectCrashLater()
-  da[1]
+  _ = da[1]
 }
 
 ArrayTraps.test("downcast2")
@@ -41,7 +41,7 @@ ArrayTraps.test("downcast2")
   let sa = a as! [NSString]
   let s0 = sa[0]
   expectCrashLater()
-  sa[1]
+  _ = sa[1]
 }
 
 ArrayTraps.test("downcast3")
@@ -56,7 +56,7 @@ ArrayTraps.test("downcast3")
   let d1a0 = d1a[0]
   let d1a1 = d1a[1]
   expectCrashLater()
-  d1a[2]
+  _ = d1a[2]
 }
 
 @objc protocol ObjCProto { }
@@ -72,7 +72,7 @@ ArrayTraps.test("downcast4")
   let da = ba as! [ObjCDerived]
   let d0 = da[0]
   expectCrashLater()
-  da[1]
+  _ = da[1]
 }
 
 ArrayTraps.test("bounds_with_downcast")


### PR DESCRIPTION
Now we support casting and bridging to/from [Any], not just [AnyObject]

Note that the typechecker still doesn't allow all the casts we'd like;
see the FIXMEs in test/1_stdlib/ArrayBridge.swift.gyb.
