### PR TITLE
[SourceKit] Add test case for crash triggered in swift::PrintOptions::setArchetypeTransform(…)

### DIFF
--- a/validation-test/IDE/crashers/071-swift-printoptions-setarchetypetransform.swift
+++ b/validation-test/IDE/crashers/071-swift-printoptions-setarchetypetransform.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+var b{class d<a{enum S<a>:C{#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 154
swift-ide-test: /path/to/swift/lib/AST/ASTPrinter.cpp:68: std::unique_ptr<llvm::DenseMap<StringRef, Type> > swift::collectNameTypeMap(swift::Type): Assertion `ParamDecls.size() == Args.size()' failed.
9  swift-ide-test  0x0000000000b7da00 swift::PrintOptions::setArchetypeTransform(swift::Type, swift::DeclContext*) + 144
16 swift-ide-test  0x0000000000bb3694 swift::Decl::walk(swift::ASTWalker&) + 20
17 swift-ide-test  0x0000000000c4b40e swift::SourceFile::walk(swift::ASTWalker&) + 174
18 swift-ide-test  0x0000000000c4a54f swift::ModuleDecl::walk(swift::ASTWalker&) + 79
19 swift-ide-test  0x0000000000c2113b swift::DeclContext::walkContext(swift::ASTWalker&) + 187
20 swift-ide-test  0x00000000008ec438 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 136
21 swift-ide-test  0x00000000007a668d swift::CompilerInstance::performSema() + 3597
22 swift-ide-test  0x0000000000749c80 main + 34176
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl getter for b at <INPUT-FILE>:3:6
```
