### PR TITLE
[SIL] Add test case for crash triggered in swift::NominalTypeDecl::getDeclaredType()

### DIFF
--- a/validation-test/SIL/crashers/027-swift-nominaltypedecl-getdeclaredtype.sil
+++ b/validation-test/SIL/crashers/027-swift-nominaltypedecl-getdeclaredtype.sil
@@ -1,0 +1,83 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+bb0(@test_existential_metatype : $Int
+%0 to $@callee_owned (thin) -> ("01234567-cdef-> (thin) -> @owned @callee_owned (Int
+bb0:
+import SwiftShims
+%0 : $@convention(thin) -> ()
+strong_retain %0 : $Beth
+%7, bb3
+%0 : $@box Int) : $@_TF6switch1aFT_T_ : $*Spoon
+bb0(%2 : $Builtin.FPIEEE64, 1) ()
+sil [fragile] @guaranteed A)) {
+}
+init()
+%3 : $Builtin.Int32
+inject_enum_addr %0a : $*Spoon
+br bb4
+@convention(thin) -> (Int, bb1, #Optional<Int) -> (thin) ()
+%0 : $Builtin.some!enumelt.Word) (thin) -> ()) (thin) ("01234567-> () (thin) -> Int) ()
+%6 = alloc_box $C
+%5 = function_ref @test_unreachable : $C, @owned @box M
+bb2:
+%14 : $*Foo
+%1 = load_weak [fragile] @test_checked_cast_br_jump_threading_with_entry_bb_arguments : $@globalinit_func0 : $SomeSubclass
+return %2 = project_box %10 = functionref @callee_owned ()) : $@callee_owned ()
+}
+%115 = tuple (%1, @_TFSb21_getBuiltinLogicValuefSbFT_Bi1_ : $ImplicitlyUnwrappedOptional<Int8>
+%v : $@_TF6switch1cFT_T_ : $Int32) (thin) (thin) () : $@callee_owned ()) -0123-> ()
+store %33 = alloc_ref [fragile] @convention(%5 : $@out Bendable, %99 = tuple (thin) -> ():
+cond_br undef, @() (X) -> () (method) -> Int {
+%5 = function_ref @convention(%6 : $Builtin.Int1
+strong_release %17 = unchecked_ref_cast %2 = load %0, U> (method) ():
+}
+store %14 = tuple (thin) -> () (Builtin.Type)
+}
+store %1 = tuple () -000000000000") {
+bb0(thin) -> ()
+%8 : $*Builtin.some!enumelt: $@box Spoon
+strong_retain %1 : $*M
+}
+}
+bb0(thin) : AssocReqt module def_basic {}
+%12 = strong_release %5 : $*Spoon
+%8 = unchecked_addr_cast %101 = tuple(%2 : $*SomeClass.Type) -> (Int, 5
+sil [_semantics "foo(%2 = apply [fragile] @owned A>
+%14 = alloc_box $@convention(thin) : $@owned A, bb1:
+}
+}
+class B
+}
+var free:
+%0 : $SomeProtocol.RawPointer
+init(@owned Optional<C>
+}
+sil [fragile] @call_fn_pointer : $Builtin.Word)
+%6 : $@convention(@test1 : $Int) ClassBound, Float32) () -> Beth, bb2:
+%i") (thin) (Builtin.Type) ():
+%4 = alloc_stack $@box Builtin.RawPointer
+%0 = open_existential_box %1 : $@thick SomeClass
+strong_retain %6 = apply %8 = _ref @convention("once") (thin) P) (Builtin.Int32):
+%13 : $Foo.Int1
+%4 : $A
+dealloc_stack %4 = tuple_element_addr %11 = tuple () () -> Int {
+}
+dealloc_partial_ref %4 : $@test_class_metatype : $X)
+checked_cast_br %6 : $(thin) (Builtin.Word
+%0 : $@convention(%2a : $*Builtin.Int32) -> Int32 {}
+bb4():
+@in Int) (thin) -> ()
+%2 : $A, @bridge_object : $CP>
+%4 : $@_TFSd31_convertFromBuiltinFloatLiteralfMSdFT5valueBf64__Sd : $*ConformingAssoc
+%2 = tuple (thin) -0123-> Builtin.Int1) -> (@convention(thin) -> () () (@_TF18devirt_jump_thread26jumpthread_checked_cast_brFCS_8FooClassSi : $(thin) ()
+%0 : $@owned @callee_owned (%1()
+}
+sil @convention() -> Aleph
+strong_release %2 : $@convention(thin) -> (thin) -0123-> ()
+bb2
+bb0() -> @convention()
+init(thin) (thin) (@public_global : InheritedConformance: $*ClassBound) {
+}
+%118 = apply %20 = function_ref @convention(%3 : $@convention() -> (%3) Int -> (%4 = alloc_box $*Int
+return %3) (thin) {
+%c = apply %0 =

--- a/validation-test/SIL/crashers/027-swift-nominaltypedecl-getdeclaredtype.sil
+++ b/validation-test/SIL/crashers/027-swift-nominaltypedecl-getdeclaredtype.sil
@@ -1,5 +1,5 @@
 // RUN: not --crash %target-sil-opt %s
-// REQUIRES: asserts
+// REQUIRES: asserts, OS=linux-gnu
 bb0(@test_existential_metatype : $Int
 %0 to $@callee_owned (thin) -> ("01234567-cdef-> (thin) -> @owned @callee_owned (Int
 bb0:


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:5: error: expected expression in list of expressions
bb0(@test_existential_metatype : $Int
    ^
<stdin>:3:5: error: expected ',' separator
bb0(@test_existential_metatype : $Int
    ^
    ,
<stdin>:3:5: error: expected ')' in expression list
bb0(@test_existential_metatype : $Int
    ^
<stdin>:3:4: note: to match this opening '('
bb0(@test_existential_metatype : $Int
   ^
<stdin>:3:1: error: expressions are not allowed at the top level
bb0(@test_existential_metatype : $Int
^
<stdin>:3:5: error: consecutive statements on a line must be separated by ';'
bb0(@test_existential_metatype : $Int
    ^
    ;
<stdin>:3:6: error: unknown attribute 'test_existential_metatype'
bb0(@test_existential_metatype : $Int
     ^
<stdin>:3:34: error: expected numeric value following '$'
bb0(@test_existential_metatype : $Int
                                 ^
<stdin>:3:32: error: expected declaration
bb0(@test_existential_metatype : $Int
                               ^
<stdin>:4:9: error: attribute can only be applied to types, not declarations
%0 to $@callee_owned (thin) -> ("01234567-cdef-> (thin) -> @owned @callee_owned (Int
        ^
<stdin>:4:22: error: expected declaration
%0 to $@callee_owned (thin) -> ("01234567-cdef-> (thin) -> @owned @callee_owned (Int
                     ^
<stdin>:4:33: error: unterminated string literal
%0 to $@callee_owned (thin) -> ("01234567-cdef-> (thin) -> @owned @callee_owned (Int
                                ^
<stdin>:7:1: error: expressions are not allowed at the top level
%0 : $@convention(thin) -> ()
^
<stdin>:7:3: error: consecutive statements on a line must be separated by ';'
%0 : $@convention(thin) -> ()
  ^
  ;
<stdin>:7:4: error: expected expression
%0 : $@convention(thin) -> ()
   ^
<stdin>:7:8: error: attribute can only be applied to types, not declarations
%0 : $@convention(thin) -> ()
       ^
<stdin>:7:18: error: expected declaration
%0 : $@convention(thin) -> ()
                 ^
<stdin>:8:20: error: expected numeric value following '$'
strong_retain %0 : $Beth
                   ^
<stdin>:10:8: error: attribute can only be applied to types, not declarations
%0 : $@box Int) : $@_TF6switch1aFT_T_ : $*Spoon
       ^
<stdin>:10:12: error: expected declaration
%0 : $@box Int) : $@_TF6switch1aFT_T_ : $*Spoon
           ^
<stdin>:10:21: error: unknown attribute '_TF6switch1aFT_T_'
%0 : $@box Int) : $@_TF6switch1aFT_T_ : $*Spoon
                    ^
<stdin>:10:39: error: expected declaration
%0 : $@box Int) : $@_TF6switch1aFT_T_ : $*Spoon
                                      ^
<stdin>:11:10: error: expected numeric value following '$'
bb0(%2 : $Builtin.FPIEEE64, 1) ()
         ^
<stdin>:12:16: error: attribute can only be applied to types, not declarations
sil [fragile] @guaranteed A)) {
               ^
<stdin>:12:27: error: expected declaration
sil [fragile] @guaranteed A)) {
                          ^
<stdin>:12:31: error: statement cannot begin with a closure expression
sil [fragile] @guaranteed A)) {
                              ^
<stdin>:12:31: note: explicitly discard the result of the closure by assigning to '_'
sil [fragile] @guaranteed A)) {
                              ^
                              _ =
<stdin>:12:31: error: expressions are not allowed at the top level
sil [fragile] @guaranteed A)) {
                              ^
<stdin>:12:31: error: braced block of statements is an unused closure
sil [fragile] @guaranteed A)) {
                              ^
<stdin>:14:5: error: initializers may only be declared within a type
init()
    ^
<stdin>:15:6: error: expected numeric value following '$'
%3 : $Builtin.Int32
     ^
<stdin>:15:1: error: expressions are not allowed at the top level
%3 : $Builtin.Int32
^
<stdin>:15:3: error: consecutive statements on a line must be separated by ';'
%3 : $Builtin.Int32
  ^
  ;
<stdin>:15:4: error: expected expression
%3 : $Builtin.Int32
   ^
<stdin>:16:20: error: expected a digit after integer literal prefix
inject_enum_addr %0a : $*Spoon
                   ^
<stdin>:18:2: error: attribute can only be applied to types, not declarations
@convention(thin) -> (Int, bb1, #Optional<Int) -> (thin) ()
 ^
<stdin>:18:12: error: expected declaration
@convention(thin) -> (Int, bb1, #Optional<Int) -> (thin) ()
           ^
<stdin>:19:6: error: expected numeric value following '$'
%0 : $Builtin.some!enumelt.Word) (thin) -> ()) (thin) ("01234567-> () (thin) -> Int) ()
     ^
<stdin>:19:56: error: unterminated string literal
%0 : $Builtin.some!enumelt.Word) (thin) -> ()) (thin) ("01234567-> () (thin) -> Int) ()
                                                       ^
<stdin>:20:16: error: expected numeric value following '$'
%6 = alloc_box $C
               ^
<stdin>:21:20: error: unknown attribute 'test_unreachable'
%5 = function_ref @test_unreachable : $C, @owned @box M
                   ^
<stdin>:21:39: error: expected numeric value following '$'
%5 = function_ref @test_unreachable : $C, @owned @box M
                                      ^
<stdin>:21:37: error: expected declaration
%5 = function_ref @test_unreachable : $C, @owned @box M
                                    ^
<stdin>:21:44: error: attribute can only be applied to types, not declarations
%5 = function_ref @test_unreachable : $C, @owned @box M
                                           ^
<stdin>:21:50: error: expected declaration
%5 = function_ref @test_unreachable : $C, @owned @box M
                                                 ^
<stdin>:21:51: error: attribute can only be applied to types, not declarations
%5 = function_ref @test_unreachable : $C, @owned @box M
                                                  ^
<stdin>:21:55: error: expected declaration
%5 = function_ref @test_unreachable : $C, @owned @box M
                                                      ^
<stdin>:24:27: error: unknown attribute 'test_checked_cast_br_jump_threading_with_entry_bb_arguments'
%1 = load_weak [fragile] @test_checked_cast_br_jump_threading_with_entry_bb_arguments : $@globalinit_func0 : $SomeSubclass
                          ^
<stdin>:24:87: error: expected declaration
%1 = load_weak [fragile] @test_checked_cast_br_jump_threading_with_entry_bb_arguments : $@globalinit_func0 : $SomeSubclass
                                                                                      ^
<stdin>:24:91: error: unknown attribute 'globalinit_func0'
%1 = load_weak [fragile] @test_checked_cast_br_jump_threading_with_entry_bb_arguments : $@globalinit_func0 : $SomeSubclass
                                                                                          ^
<stdin>:24:110: error: expected numeric value following '$'
%1 = load_weak [fragile] @test_checked_cast_br_jump_threading_with_entry_bb_arguments : $@globalinit_func0 : $SomeSubclass
                                                                                                             ^
<stdin>:24:108: error: expected declaration
%1 = load_weak [fragile] @test_checked_cast_br_jump_threading_with_entry_bb_arguments : $@globalinit_func0 : $SomeSubclass
                                                                                                           ^
<stdin>:25:1: error: statements are not allowed at the top level
return %2 = project_box %10 = functionref @callee_owned ()) : $@callee_owned ()
^
<stdin>:25:24: error: consecutive statements on a line must be separated by ';'
return %2 = project_box %10 = functionref @callee_owned ()) : $@callee_owned ()
                       ^
                       ;
<stdin>:25:25: error: expressions are not allowed at the top level
return %2 = project_box %10 = functionref @callee_owned ()) : $@callee_owned ()
                        ^
<stdin>:25:42: error: consecutive statements on a line must be separated by ';'
return %2 = project_box %10 = functionref @callee_owned ()) : $@callee_owned ()
                                         ^
                                         ;
<stdin>:25:44: error: attribute can only be applied to types, not declarations
return %2 = project_box %10 = functionref @callee_owned ()) : $@callee_owned ()
                                           ^
<stdin>:25:57: error: expected declaration
return %2 = project_box %10 = functionref @callee_owned ()) : $@callee_owned ()
                                                        ^
<stdin>:25:65: error: attribute can only be applied to types, not declarations
return %2 = project_box %10 = functionref @callee_owned ()) : $@callee_owned ()
                                                                ^
<stdin>:25:78: error: expected declaration
return %2 = project_box %10 = functionref @callee_owned ()) : $@callee_owned ()
                                                                             ^
<stdin>:26:1: error: extraneous '}' at top level
}
^
<stdin>:27:19: error: expected expression in list of expressions
%115 = tuple (%1, @_TFSb21_getBuiltinLogicValuefSbFT_Bi1_ : $ImplicitlyUnwrappedOptional<Int8>
                  ^
<stdin>:27:19: error: expected ',' separator
%115 = tuple (%1, @_TFSb21_getBuiltinLogicValuefSbFT_Bi1_ : $ImplicitlyUnwrappedOptional<Int8>
                  ^
                 ,
<stdin>:27:19: error: expected ')' in expression list
%115 = tuple (%1, @_TFSb21_getBuiltinLogicValuefSbFT_Bi1_ : $ImplicitlyUnwrappedOptional<Int8>
                  ^
<stdin>:27:14: note: to match this opening '('
%115 = tuple (%1, @_TFSb21_getBuiltinLogicValuefSbFT_Bi1_ : $ImplicitlyUnwrappedOptional<Int8>
             ^
<stdin>:27:1: error: expressions are not allowed at the top level
%115 = tuple (%1, @_TFSb21_getBuiltinLogicValuefSbFT_Bi1_ : $ImplicitlyUnwrappedOptional<Int8>
^
<stdin>:27:18: error: consecutive statements on a line must be separated by ';'
%115 = tuple (%1, @_TFSb21_getBuiltinLogicValuefSbFT_Bi1_ : $ImplicitlyUnwrappedOptional<Int8>
                 ^
                 ;
<stdin>:27:20: error: unknown attribute '_TFSb21_getBuiltinLogicValuefSbFT_Bi1_'
%115 = tuple (%1, @_TFSb21_getBuiltinLogicValuefSbFT_Bi1_ : $ImplicitlyUnwrappedOptional<Int8>
                   ^
<stdin>:27:61: error: expected numeric value following '$'
%115 = tuple (%1, @_TFSb21_getBuiltinLogicValuefSbFT_Bi1_ : $ImplicitlyUnwrappedOptional<Int8>
                                                            ^
<stdin>:27:59: error: expected declaration
%115 = tuple (%1, @_TFSb21_getBuiltinLogicValuefSbFT_Bi1_ : $ImplicitlyUnwrappedOptional<Int8>
                                                          ^
<stdin>:28:8: error: unknown attribute '_TF6switch1cFT_T_'
%v : $@_TF6switch1cFT_T_ : $Int32) (thin) (thin) () : $@callee_owned ()) -0123-> ()
       ^
<stdin>:28:28: error: expected numeric value following '$'
%v : $@_TF6switch1cFT_T_ : $Int32) (thin) (thin) () : $@callee_owned ()) -0123-> ()
                           ^
<stdin>:28:26: error: expected declaration
%v : $@_TF6switch1cFT_T_ : $Int32) (thin) (thin) () : $@callee_owned ()) -0123-> ()
                         ^
<stdin>:28:57: error: attribute can only be applied to types, not declarations
%v : $@_TF6switch1cFT_T_ : $Int32) (thin) (thin) () : $@callee_owned ()) -0123-> ()
                                                        ^
<stdin>:28:70: error: expected declaration
%v : $@_TF6switch1cFT_T_ : $Int32) (thin) (thin) () : $@callee_owned ()) -0123-> ()
                                                                     ^
<stdin>:29:34: error: attribute can only be applied to types, not declarations
store %33 = alloc_ref [fragile] @convention(%5 : $@out Bendable, %99 = tuple (thin) -> ():
                                 ^
<stdin>:29:44: error: expected declaration
store %33 = alloc_ref [fragile] @convention(%5 : $@out Bendable, %99 = tuple (thin) -> ():
                                           ^
<stdin>:31:36: error: expected numeric value following '$'
%5 = function_ref @convention(%6 : $Builtin.Int1
                                   ^
<stdin>:36:34: error: unterminated string literal
store %1 = tuple () -000000000000") {
                                 ^
<stdin>:38:32: error: attribute can only be applied to types, not declarations
%8 : $*Builtin.some!enumelt: $@box Spoon
                               ^
<stdin>:38:36: error: expected declaration
%8 : $*Builtin.some!enumelt: $@box Spoon
                                   ^
<stdin>:40:1: error: extraneous '}' at top level
}
^
<stdin>:41:1: error: extraneous '}' at top level
}
^
<stdin>:42:1: error: expressions are not allowed at the top level
bb0(thin) : AssocReqt module def_basic {}
^
<stdin>:42:10: error: consecutive statements on a line must be separated by ';'
bb0(thin) : AssocReqt module def_basic {}
         ^
         ;
<stdin>:42:11: error: expected expression
bb0(thin) : AssocReqt module def_basic {}
          ^
<stdin>:42:40: error: statement cannot begin with a closure expression
bb0(thin) : AssocReqt module def_basic {}
                                       ^
<stdin>:42:40: note: explicitly discard the result of the closure by assigning to '_'
bb0(thin) : AssocReqt module def_basic {}
                                       ^
                                       _ =
<stdin>:42:40: error: expressions are not allowed at the top level
bb0(thin) : AssocReqt module def_basic {}
                                       ^
<stdin>:42:40: error: braced block of statements is an unused closure
bb0(thin) : AssocReqt module def_basic {}
                                       ^
<stdin>:43:1: error: expressions are not allowed at the top level
%12 = strong_release %5 : $*Spoon
^
<stdin>:43:21: error: consecutive statements on a line must be separated by ';'
%12 = strong_release %5 : $*Spoon
                    ^
                    ;
<stdin>:43:22: error: expressions are not allowed at the top level
%12 = strong_release %5 : $*Spoon
                     ^
<stdin>:43:24: error: consecutive statements on a line must be separated by ';'
%12 = strong_release %5 : $*Spoon
                       ^
                       ;
<stdin>:43:25: error: expected expression
%12 = strong_release %5 : $*Spoon
                        ^
<stdin>:45:17: error: unterminated string literal
sil [_semantics "foo(%2 = apply [fragile] @owned A>
                ^
<stdin>:46:19: error: attribute can only be applied to types, not declarations
%14 = alloc_box $@convention(thin) : $@owned A, bb1:
                  ^
<stdin>:46:29: error: expected declaration
%14 = alloc_box $@convention(thin) : $@owned A, bb1:
                            ^
<stdin>:46:40: error: attribute can only be applied to types, not declarations
%14 = alloc_box $@convention(thin) : $@owned A, bb1:
                                       ^
<stdin>:46:46: error: expected declaration
%14 = alloc_box $@convention(thin) : $@owned A, bb1:
                                             ^
<stdin>:47:1: error: extraneous '}' at top level
}
^
<stdin>:48:1: error: extraneous '}' at top level
}
^
<stdin>:49:8: error: expected '{' in class
class B
       ^
<stdin>:50:1: error: extraneous '}' at top level
}
^
<stdin>:51:10: error: expected type
var free:
         ^
<stdin>:52:6: error: expected numeric value following '$'
%0 : $SomeProtocol.RawPointer
     ^
<stdin>:52:1: error: expressions are not allowed at the top level
%0 : $SomeProtocol.RawPointer
^
<stdin>:52:3: error: consecutive statements on a line must be separated by ';'
%0 : $SomeProtocol.RawPointer
  ^
  ;
<stdin>:52:4: error: expected expression
%0 : $SomeProtocol.RawPointer
   ^
<stdin>:53:5: error: initializers may only be declared within a type
init(@owned Optional<C>
    ^
<stdin>:53:6: error: expected parameter name followed by ':'
init(@owned Optional<C>
     ^
<stdin>:53:6: error: expected ',' separator
init(@owned Optional<C>
     ^
     ,
<stdin>:53:6: error: expected ')' in parameter
init(@owned Optional<C>
     ^
<stdin>:53:5: note: to match this opening '('
init(@owned Optional<C>
    ^
<stdin>:53:6: error: consecutive statements on a line must be separated by ';'
init(@owned Optional<C>
     ^
     ;
<stdin>:53:7: error: attribute can only be applied to types, not declarations
init(@owned Optional<C>
      ^
<stdin>:53:13: error: expected declaration
init(@owned Optional<C>
            ^
<stdin>:54:1: error: extraneous '}' at top level
}
^
4  sil-opt         0x0000000000e07de4 swift::NominalTypeDecl::getDeclaredType() const + 4
15 sil-opt         0x0000000000ccf99d swift::ClangModuleUnit::lookupVisibleDecls(llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::VisibleDeclConsumer&, swift::NLKind) const + 317
16 sil-opt         0x0000000000e35bb6 swift::ModuleDecl::lookupVisibleDecls(llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::VisibleDeclConsumer&, swift::NLKind) const + 70
19 sil-opt         0x0000000000e4081d swift::namelookup::lookupVisibleDeclsInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >) + 1101
20 sil-opt         0x0000000000e26ce2 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 1746
21 sil-opt         0x0000000000b29962 swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::Type, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) + 290
22 sil-opt         0x0000000000ad1d09 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 3929
26 sil-opt         0x0000000000da552e swift::Expr::walk(swift::ASTWalker&) + 46
27 sil-opt         0x0000000000ad2590 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 224
28 sil-opt         0x0000000000ad8fc2 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
30 sil-opt         0x0000000000b542e6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
31 sil-opt         0x0000000000b0e0ed swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
32 sil-opt         0x0000000000772169 swift::CompilerInstance::performSema() + 3289
33 sil-opt         0x000000000075b63d main + 1805
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  While type-checking expression at [<stdin>:3:1 - line:3:4] RangeText="bb0("
2.  /usr/local/bin/swift/lib/swift/shims/HeapObject.h:38:8: importing 'HeapObject'
3.  /usr/local/bin/swift/lib/swift/shims/HeapObject.h:40:23: importing 'HeapObject::metadata'
```
