### PR TITLE
[sil-printer] Only sort the PredIds, UserIDs that we put in comments …

### DIFF
--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -480,12 +480,17 @@ public:
           *this << 's';
         *this << ": ";
 
-        // Display the user ids sorted to give a stable use order in the printer's
-        // output. This makes diffing large sections of SIL significantly easier.
         llvm::SmallVector<ID, 32> UserIDs;
         for (auto *Op : V->getUses())
           UserIDs.push_back(getID(Op->getUser()));
-        std::sort(UserIDs.begin(), UserIDs.end());
+
+        // Display the user ids sorted to give a stable use order in the
+        // printer's output if we are asked to do so. This makes diffing large
+        // sections of SIL significantly easier at the expense of not showing
+        // the _TRUE_ order of the users in the use list.
+        if (Ctx.sortSIL()) {
+          std::sort(UserIDs.begin(), UserIDs.end());
+        }
 
         interleave(UserIDs.begin(), UserIDs.end(),
             [&] (ID id) { *this << id; },
@@ -512,13 +517,18 @@ public:
       
       *this << "// Preds:";
 
-      // Display the predecessors ids sorted to give a stable use order in the
-      // printer's output. This makes diffing large sections of SIL
-      // significantly easier.
       llvm::SmallVector<ID, 32> PredIDs;
       for (auto *BBI : BB->getPreds())
         PredIDs.push_back(getID(BBI));
-      std::sort(PredIDs.begin(), PredIDs.end());
+
+      // Display the pred ids sorted to give a stable use order in the printer's
+      // output if we are asked to do so. This makes diffing large sections of
+      // SIL significantly easier at the expense of not showing the _TRUE_ order
+      // of the users in the use list.
+      if (Ctx.sortSIL()) {
+        std::sort(PredIDs.begin(), PredIDs.end());
+      }
+
       for (auto Id : PredIDs)
         *this << ' ' << Id;
     }
@@ -551,12 +561,16 @@ public:
       *this << 's';
     *this << ": ";
 
-    // Display the user ids sorted to give a stable use order in the printer's
-    // output. This makes diffing large sections of SIL significantly easier.
     llvm::SmallVector<ID, 32> UserIDs;
     for (auto *Op : V->getUses())
       UserIDs.push_back(getID(Op->getUser()));
-    std::sort(UserIDs.begin(), UserIDs.end());
+
+    // If we are asked to, display the user ids sorted to give a stable use
+    // order in the printer's output. This makes diffing large sections of SIL
+    // significantly easier.
+    if (Ctx.sortSIL()) {
+      std::sort(UserIDs.begin(), UserIDs.end());
+    }
 
     interleave(UserIDs.begin(), UserIDs.end(), [&](ID id) { *this << id; },
                [&] { *this << ", "; });

--- a/test/SILGen/if_while_binding.swift
+++ b/test/SILGen/if_while_binding.swift
@@ -329,7 +329,7 @@ func testCaseBool(_ value : Bool?) {
     marker_1()
   }
 
-  // CHECK:   bb3:                                              // Preds: bb0 bb1 bb2
+  // CHECK:   bb3:                                              // Preds: bb2 bb1 bb0
   // CHECK:   switch_enum %0 : $Optional<Bool>, case #Optional.some!enumelt.1: bb4, default bb6
 
   // CHECK:   bb4(
@@ -340,7 +340,7 @@ func testCaseBool(_ value : Bool?) {
   // CHECK: function_ref @_TF16if_while_binding8marker_2FT_T_
   // CHECK: br bb6{{.*}}                                      // id: %15
 
-  // CHECK: bb6:                                              // Preds: bb3 bb4 bb5
+  // CHECK: bb6:                                              // Preds: bb5 bb4 bb3
   if case false? = value {
     marker_2()
   }

--- a/test/SILOptimizer/basic-aa.sil
+++ b/test/SILOptimizer/basic-aa.sil
@@ -563,7 +563,7 @@ bb0(%0 : $X):
 
 // CHECK-LABEL: @alloc_stack_and_addr_cast
 // CHECK: PAIR #1.
-// CHECK-NEXT:   %0 = alloc_stack $C{{.*}}                             // users: %1, %2
+// CHECK-NEXT:   %0 = alloc_stack $C{{.*}}                             // users: %2, %1
 // CHECK-NEXT:   %1 = unchecked_addr_cast %0 : $*C to $*Optional<C>
 // CHECK-NEXT: MayAlias
 sil @alloc_stack_and_addr_cast : $@convention(thin) () -> () {

--- a/test/SILOptimizer/diagnose_unreachable.sil
+++ b/test/SILOptimizer/diagnose_unreachable.sil
@@ -118,7 +118,7 @@ bb6:
 // CHECK-LABEL:sil @InfLoop
 // CHECK: bb0:
 // CHECK-NEXT:  br bb1
-// CHECK:bb1:                                              // Preds: bb0 bb3
+// CHECK:bb1:                                              // Preds: bb3 bb0
 // CHECK-NEXT:  br bb2
 // CHECK:bb2:                                              // Preds: bb1
 // CHECK-NEXT:  br bb3

--- a/test/SILOptimizer/eager_specialize.sil
+++ b/test/SILOptimizer/eager_specialize.sil
@@ -116,7 +116,7 @@ bb0(%0 : $*T, %1 : $G<T>, %2 : $*T.Elt):
 // CHECK:   %10 = apply %9<T, T.Elt>(%0, %2, %1) : $@convention(method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, G<τ_0_0>) -> @out τ_0_0
 // CHECK:   br bb2
 
-// CHECK: bb2:                                              // Preds: bb1 bb3
+// CHECK: bb2:                                              // Preds: bb3 bb1
 // CHECK:   %12 = tuple ()
 // CHECK:   return %12 : $()
 
@@ -219,7 +219,7 @@ bb2:                                              // Preds: bb0
 // CHECK: bb2:                                              // Preds: bb1
 // CHECK:   br bb3(%{{.*}} : $Error)
 
-// CHECK: bb3(%{{.*}} : $Error):                        // Preds: bb2 bb7
+// CHECK: bb3(%{{.*}} : $Error):                        // Preds: bb7 bb2
 // CHECK:   throw %{{.*}} : $Error
 
 // CHECK: bb4:                                              // Preds: bb1
@@ -227,7 +227,7 @@ bb2:                                              // Preds: bb0
 // CHECK:   apply %{{.*}}<T>({{.*}}) : $@convention(witness_method) <τ_0_0 where τ_0_0 : IntegerArithmetic> (@in τ_0_0, @in τ_0_0, @thick τ_0_0.Type) -> @out τ_0_0
 // CHECK:   br bb5
 
-// CHECK: bb5:                                              // Preds: bb4 bb8
+// CHECK: bb5:                                              // Preds: bb8 bb4
 // CHECK:   %{{.*}} = tuple ()
 // CHECK:   return %{{.*}} : $()
 
@@ -307,7 +307,7 @@ bb0(%0 : $*T):
 // CHECK:   apply %13<T>(%0) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int64
 // CHECK:   br bb3
 
-// CHECK: bb3:                                              // Preds: bb2 bb4 bb5
+// CHECK: bb3:                                              // Preds: bb5 bb4 bb2
 // CHECK:   tuple ()
 // CHECK:   return
 
@@ -361,7 +361,7 @@ sil_scope 37 {  parent 36 }
 // CHECK:   apply %13<T>
 // CHECK:   br bb3(%{{.*}} : $Int64)
 
-// CHECK: bb3(%{{.*}} : $Int64):                                  // Preds: bb2 bb4 bb5
+// CHECK: bb3(%{{.*}} : $Int64):                                  // Preds: bb5 bb4 bb2
 // CHECK:   return %{{.*}} : $Int64
 
 // CHECK: bb4:                                              // Preds: bb1

--- a/test/SILOptimizer/lslocation_expansion.sil
+++ b/test/SILOptimizer/lslocation_expansion.sil
@@ -287,7 +287,7 @@ bb0:
 
 // CHECK-LABEL: self_loop 
 // CHECK: #0 store
-// CHECK-NEXT: alloc_stack $S5, var, name "b"{{.*}}  // users: %4, %7
+// CHECK-NEXT: alloc_stack $S5, var, name "b"{{.*}}  // users: %7, %4
 // CHECK-NEXT: Address Projection Type: $*SelfLoop
 // CHECK-NEXT: Field Type: var a: SelfLoop
 sil hidden @self_loop : $@convention(thin) () -> () {

--- a/test/SILOptimizer/lslocation_reduction.sil
+++ b/test/SILOptimizer/lslocation_reduction.sil
@@ -157,7 +157,7 @@ bb0:
 
 // CHECK-LABEL: self_loop 
 // CHECK: #0 store
-// CHECK-NEXT: alloc_stack $S5, var, name "b"{{.*}}   // users: %4, %7
+// CHECK-NEXT: alloc_stack $S5, var, name "b"{{.*}}   // users: %7, %4
 sil hidden @self_loop : $@convention(thin) () -> () {
 bb0:
   %0 = alloc_stack $S5, var, name "b"             // users: %4, %7

--- a/test/SILOptimizer/mem-behavior.sil
+++ b/test/SILOptimizer/mem-behavior.sil
@@ -130,7 +130,7 @@ bb0(%0 : $Int32):
 // CHECK-LABEL: @allocstack_apply_no_escaping
 // CHECK: PAIR #1.
 // CHECK-NEXT:   %3 = apply %2() : $@convention(thin) () -> ()
-// CHECK-NEXT:   %1 = alloc_stack $Int32{{.*}}                    // users: %5, %7
+// CHECK-NEXT:   %1 = alloc_stack $Int32{{.*}}                    // users: %7, %5
 // CHECK-NEXT:  r=0,w=0,se=0
 sil @allocstack_apply_no_escaping : $@convention(thin) (Int32) -> () {
 bb0(%0 : $Int32):
@@ -147,7 +147,7 @@ bb0(%0 : $Int32):
 // CHECK-LABEL: @allocstack_apply_read_only
 // CHECK:     PAIR #1.
 // CHECK-NEXT:   %4 = apply %3(%1) : $@convention(thin) (@in X) -> ()
-// CHECK-NEXT:   %1 = alloc_stack $X{{.*}}                      // users: %2, %4, %5
+// CHECK-NEXT:   %1 = alloc_stack $X{{.*}}                      // users: %5, %4, %2
 // CHECK-NEXT: r=1,w=0,se=0
 sil @allocstack_apply_read_only : $@convention(thin) (X) -> () {
 bb0(%0 : $X):
@@ -175,7 +175,7 @@ struct TwoInts {
 // CHECK-LABEL: @combination_of_read_and_write_effects
 // CHECK:     PAIR #0.
 // CHECK-NEXT:   %4 = apply %3(%1, %2) : $@convention(thin) (@inout Int32, @inout Int32) -> ()
-// CHECK-NEXT:   %0 = alloc_stack $TwoInts{{.*}}                // users: %1, %2, %5
+// CHECK-NEXT:   %0 = alloc_stack $TwoInts{{.*}}                // users: %5, %2, %1
 // CHECK-NEXT: r=1,w=1,se=1
 sil @combination_of_read_and_write_effects : $@convention(thin) () -> () {
 bb0:


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…if we are supposed to emit sorted SIL.

This was done some time ago to make it easier to diff large amounts of SIL
output. The problem is that it makes it difficult to know the _true_ memory
order that the predecessor list is in which can lead to surprise when working
with SIL and create test cases.

I believe some time after that point we added the notion of "sorted" sil, i.e.
SIL that does not guarantee any relation to the actual memory representation of
the SIL and is meant to ease diffing. This fits nicely with the true intention
of this sort of sorting.

Thus this commit puts sorting PredIDs, UserIDs behind that flag.
