### PR TITLE
[Sema] fix ParenPattern resolution when subexpression is a NilLiteralExpr

### DIFF
--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -385,10 +385,9 @@ public:
   
   // Convert a paren expr to a pattern if it contains a pattern.
   Pattern *visitParenExpr(ParenExpr *E) {
-    if (Pattern *subPattern = visit(E->getSubExpr()))
-      return new (TC.Context) ParenPattern(E->getLParenLoc(), subPattern,
-                                           E->getRParenLoc());
-    return nullptr;
+    Pattern *subPattern = getSubExprPattern(E->getSubExpr());
+    return new (TC.Context) ParenPattern(E->getLParenLoc(), subPattern,
+                                         E->getRParenLoc());
   }
   
   // Convert all tuples to patterns.

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -127,6 +127,22 @@ case let x?: break
 case nil: break
 }
 
+func SR2066(x: Int?) {
+    // nil literals should still work when wrapped in parentheses
+    switch x {
+    case (nil): break
+    case _?: break
+    }
+    switch x {
+    case ((nil)): break
+    case _?: break
+    }
+    switch (x, x) {
+    case ((nil), _): break
+    case (_?, _): break
+    }
+}
+
 // Test x???? patterns.
 switch (nil as Int???) {
 case let x???: print(x, terminator: "")


### PR DESCRIPTION
#### What's in this pull request?

A minor fix to the `ResolvePattern` ASTVisitor used in TypeCheckPattern.cpp.

Previously, if a ParenExpr's subexpression returned nullptr when passed to `visit()` (which happens for `nil` literals, since `visitNilLiteralExpr()` isn't defined), then `visitParenExpr()` itself would return nullptr, so the ParenExpr was just wrapped in an ExprPattern. This broke the ability of `coercePatternToType()` to peek at the ExprPattern's expression and convert `NilLiteralExpr` to an `EnumElementPattern`, because instead of finding a NilLiteralExpr, it'd just find the ParenExpr.

With this fix, `visitParenExpr()` reuses existing logic from `getSubExprPattern()`, which wraps **the subexpression** in an ExprPattern, even when there's no special visitor for it, rather than wrapping the whole ParenExpr in an ExprPattern.
#### Resolved bug number: [SR-2066](https://bugs.swift.org/browse/SR-2066)

_"Parenthesized nil in a case statement breaks exhaustivity checking"_ filed by @gregomni 

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
