### PR TITLE
Improvements to the API of struct URL.

### DIFF
--- a/stdlib/public/SDK/Foundation/URL.swift
+++ b/stdlib/public/SDK/Foundation/URL.swift
@@ -275,7 +275,7 @@ public struct URLResourceValues {
     
     /// The document identifier -- a value assigned by the kernel to a document (which can be either a file or directory) and is used to identify the document regardless of where it gets moved on a volume.
     ///
-    /// The document identifier survives "safe save" operations; i.e it is sticky to the path it was assigned to (`replaceItem(at:,withItemAt:,backupItemName:,options:,resultingItem:) throws` is the preferred safe-save API). The document identifier is persistent across system restarts. The document identifier is not transferred when the file is copied. Document identifiers are only unique within a single volume. This property is not supported by all volumes.
+    /// The document identifier survives "safe save” operations; i.e it is sticky to the path it was assigned to (`replaceItem(at:,withItemAt:,backupItemName:,options:,resultingItem:) throws` is the preferred safe-save API). The document identifier is persistent across system restarts. The document identifier is not transferred when the file is copied. Document identifiers are only unique within a single volume. This property is not supported by all volumes.
     @available(OSX 10.10, iOS 8.0, *)
     public var documentIdentifier: Int? { return _get(.documentIdentifierKey) }
     
@@ -484,10 +484,12 @@ public struct URL : ReferenceConvertible, CustomStringConvertible, Equatable {
 
     /// Initialize with string.
     ///
-    /// Returns `nil` if a `URL` cannot be formed with the string.
+    /// Returns `nil` if a `URL` cannot be formed with the string (for example, if the string contains characters that are illegal in a URL, or is an empty string).
     public init?(string: String) {
+        guard !string.isEmpty else { return nil }
+        
         if let inner = NSURL(string: string) {
-            _url = inner
+            _url = URL._converted(from: inner)
         } else {
             return nil
         }
@@ -495,10 +497,12 @@ public struct URL : ReferenceConvertible, CustomStringConvertible, Equatable {
     
     /// Initialize with string, relative to another URL.
     ///
-    /// Returns `nil` if a `URL` cannot be formed with the string.
-    public init?(string: String, relativeTo url: URL) {
+    /// Returns `nil` if a `URL` cannot be formed with the string (for example, if the string contains characters that are illegal in a URL, or is an empty string).
+    public init?(string: String, relativeTo url: URL?) {
+        guard !string.isEmpty else { return nil }
+        
         if let inner = NSURL(string: string, relativeTo: url) {
-            _url = inner
+            _url = URL._converted(from: inner)
         } else {
             return nil
         }
@@ -510,7 +514,7 @@ public struct URL : ReferenceConvertible, CustomStringConvertible, Equatable {
     /// - note: This function avoids an extra file system access to check if the file URL is a directory. You should use it if you know the answer already.
     @available(OSX 10.11, iOS 9.0, *)
     public init(fileURLWithPath path: String, isDirectory: Bool, relativeTo base: URL?) {
-        _url = NSURL(fileURLWithPath: path.isEmpty ? "." : path, isDirectory: isDirectory, relativeTo: base)
+        _url = URL._converted(from: NSURL(fileURLWithPath: path.isEmpty ? "." : path, isDirectory: isDirectory, relativeTo: base))
     }
     
     /// Initializes a newly created file URL referencing the local file or directory at path, relative to a base URL.
@@ -518,7 +522,7 @@ public struct URL : ReferenceConvertible, CustomStringConvertible, Equatable {
     /// If an empty string is used for the path, then the path is assumed to be ".".
     @available(OSX 10.11, iOS 9.0, *)
     public init(fileURLWithPath path: String, relativeTo base: URL?) {
-        _url = NSURL(fileURLWithPath: path.isEmpty ? "." : path, relativeTo: base)
+        _url = URL._converted(from: NSURL(fileURLWithPath: path.isEmpty ? "." : path, relativeTo: base))
     }
     
     /// Initializes a newly created file URL referencing the local file or directory at path.
@@ -526,42 +530,46 @@ public struct URL : ReferenceConvertible, CustomStringConvertible, Equatable {
     /// If an empty string is used for the path, then the path is assumed to be ".".
     /// - note: This function avoids an extra file system access to check if the file URL is a directory. You should use it if you know the answer already.
     public init(fileURLWithPath path: String, isDirectory: Bool) {
-        _url = NSURL(fileURLWithPath: path.isEmpty ? "." : path, isDirectory: isDirectory)
+        _url = URL._converted(from: NSURL(fileURLWithPath: path.isEmpty ? "." : path, isDirectory: isDirectory))
     }
     
     /// Initializes a newly created file URL referencing the local file or directory at path.
     ///
     /// If an empty string is used for the path, then the path is assumed to be ".".
     public init(fileURLWithPath path: String) {
-        _url = NSURL(fileURLWithPath: path.isEmpty ? "." : path)
+        _url = URL._converted(from: NSURL(fileURLWithPath: path.isEmpty ? "." : path))
     }
     
-    /// Initializes a newly created URL using the contents of the given data, relative to a base URL. If the data representation is not a legal URL string as ASCII bytes, the URL object may not behave as expected.
+    /// Initializes a newly created URL using the contents of the given data, relative to a base URL.
+    ///
+    /// If the data representation is not a legal URL string as ASCII bytes, the URL object may not behave as expected. If the URL cannot be formed then this will return nil.
     @available(OSX 10.11, iOS 9.0, *)
-    public init(dataRepresentation: Data, relativeTo url: URL?, isAbsolute: Bool = false) {
+    public init?(dataRepresentation: Data, relativeTo url: URL?, isAbsolute: Bool = false) {
+        guard dataRepresentation.count > 0 else { return nil }
+        
         if isAbsolute {
-            _url = NSURL(absoluteURLWithDataRepresentation: dataRepresentation, relativeTo: url)
+            _url = URL._converted(from: NSURL(absoluteURLWithDataRepresentation: dataRepresentation, relativeTo: url))
         } else {
-            _url = NSURL(dataRepresentation: dataRepresentation, relativeTo: url)
+            _url = URL._converted(from: NSURL(dataRepresentation: dataRepresentation, relativeTo: url))
         }
     }
 
     /// Initializes a URL that refers to a location specified by resolving bookmark data.
     public init?(resolvingBookmarkData data: Data, options: BookmarkResolutionOptions = [], relativeTo url: URL? = nil, bookmarkDataIsStale: inout Bool) throws {
         var stale : ObjCBool = false
-        _url = try NSURL(resolvingBookmarkData: data, options: options, relativeTo: url, bookmarkDataIsStale: &stale)
+        _url = URL._converted(from: try NSURL(resolvingBookmarkData: data, options: options, relativeTo: url, bookmarkDataIsStale: &stale))
         bookmarkDataIsStale = stale.boolValue
     }
     
     /// Creates and initializes a NSURL that refers to the location specified by resolving the alias file at url. If the url argument does not refer to an alias file as defined by the NSURLIsAliasFileKey property, the NSURL returned is the same as url argument. This method fails and returns nil if the url argument is unreachable, or if the original file or directory could not be located or is not reachable, or if the original file or directory is on a volume that could not be located or mounted. The URLBookmarkResolutionWithSecurityScope option is not supported by this method.
     @available(OSX 10.10, iOS 8.0, *)
     public init(resolvingAliasFileAt url: URL, options: BookmarkResolutionOptions = []) throws {
-        _url = try NSURL(resolvingAliasFileAt: url, options: options)
+        self.init(reference: try NSURL(resolvingAliasFileAt: url, options: options))
     }
 
     /// Initializes a newly created URL referencing the local file or directory at the file system representation of the path. File system representation is a null-terminated C string with canonical UTF-8 encoding.
     public init(fileURLWithFileSystemRepresentation path: UnsafePointer<Int8>, isDirectory: Bool, relativeTo baseURL: URL?) {
-        _url = NSURL(fileURLWithFileSystemRepresentation: path, isDirectory: isDirectory, relativeTo: baseURL)
+        _url = URL._converted(from: NSURL(fileURLWithFileSystemRepresentation: path, isDirectory: isDirectory, relativeTo: baseURL))
     }
     
     // MARK: -
@@ -574,266 +582,391 @@ public struct URL : ReferenceConvertible, CustomStringConvertible, Equatable {
         return _url.debugDescription
     }
 
-    public var hashValue : Int {
+    public var hashValue: Int {
         return _url.hash
     }
     
     // MARK: -
     
-    /// Returns the data representation of the URL's relativeString. If the URL was initialized with -initWithData:relativeToURL:, the data representation returned are the same bytes as those used at initialization; otherwise, the data representation returned are the bytes of the relativeString encoded with NSUTF8StringEncoding.
+    /// Returns the data representation of the URL's relativeString. 
+    ///
+    /// If the URL was initialized with `init?(dataRepresentation:relativeTo:isAbsolute:)`, the data representation returned are the same bytes as those used at initialization; otherwise, the data representation returned are the bytes of the `relativeString` encoded with UTF8 string encoding.
     @available(OSX 10.11, iOS 9.0, *)
-    public var dataRepresentation: Data { return _url.dataRepresentation as Data }
+    public var dataRepresentation: Data {
+        return _url.dataRepresentation
+    }
     
-    public var absoluteString: String? { return _url.absoluteString }
+    // MARK: -
     
-    /// The relative portion of a URL.  If baseURL is nil, or if the receiver is itself absolute, this is the same as absoluteString
-    public var relativeString: String { return _url.relativeString }
-    public var baseURL: URL? { return _url.baseURL }
+    // Future implementation note:
+    // NSURL (really CFURL, which provides its implementation) has quite a few quirks in its processing of some more esoteric (and some not so esoteric) strings. We would like to move much of this over to the more modern NSURLComponents, but binary compat concerns have made this difficult.
+    // Hopefully soon, we can replace some of the below delegation to NSURL with delegation to NSURLComponents instead. It cannot be done piecemeal, because otherwise we will get inconsistent results from the API.
     
-    /// If the receiver is itself absolute, this will return self.
-    public var absoluteURL: URL? {  return _url.absoluteURL }
+    /// Returns the absolute string for the URL.
+    public var absoluteString: String {
+        if let string = _url.absoluteString {
+            return string
+        } else {
+            // This should never fail for non-file reference URLs
+            return ""
+        }
+    }
     
-    /// Any URL is composed of these two basic pieces.  The full URL would be the concatenation of `myURL.scheme, ':', myURL.resourceSpecifier`.
-    public var scheme: String? { return _url.scheme }
-    
-    /// Any URL is composed of these two basic pieces.  The full URL would be the concatenation of `myURL.scheme, ':', myURL.resourceSpecifier`.
-    public var resourceSpecifier: String? { return _url.resourceSpecifier }
-    
-    /// If the URL conforms to rfc 1808 (the most common form of URL), returns a component of the URL; otherwise it returns nil.
+    /// The relative portion of a URL.
     ///
-    /// The litmus test for conformance is as recommended in RFC 1808 - whether the first two characters of resourceSpecifier is "//".  In all cases, they return the component's value after resolving the receiver against its base URL.
-    public var host: String? { return _url.host }
+    /// If `baseURL` is nil, or if the receiver is itself absolute, this is the same as `absoluteString`.
+    public var relativeString: String {
+        return _url.relativeString
+    }
     
-    /// If the URL conforms to rfc 1808 (the most common form of URL), returns a component of the URL; otherwise it returns nil.
+    /// Returns the base URL.
     ///
-    /// The litmus test for conformance is as recommended in RFC 1808 - whether the first two characters of resourceSpecifier is "//".  In all cases, they return the component's value after resolving the receiver against its base URL.
-    public var port: Int? { return _url.port?.intValue }
+    /// If the URL is itself absolute, then this value is nil.
+    public var baseURL: URL? {
+        return _url.baseURL
+    }
     
-    /// If the URL conforms to rfc 1808 (the most common form of URL), returns a component of the URL; otherwise it returns nil.
+    /// Returns the absolute URL.
     ///
-    /// The litmus test for conformance is as recommended in RFC 1808 - whether the first two characters of resourceSpecifier is "//".  In all cases, they return the component's value after resolving the receiver against its base URL.
-    public var user: String? { return _url.user }
+    /// If the URL is itself absolute, this will return self.
+    public var absoluteURL: URL {
+        if let url = _url.absoluteURL {
+            return url
+        } else {
+            // This should never fail for non-file reference URLs
+            return self
+        }
+    }
     
-    /// If the URL conforms to rfc 1808 (the most common form of URL), returns a component of the URL; otherwise it returns nil.
+    // MARK: -
+    
+    /// Returns the scheme of the URL.
+    public var scheme: String? {
+        return _url.scheme
+    }
+    
+    /// Returns true if the scheme is `file:`.
+    public var isFileURL: Bool {
+        return _url.isFileURL
+    }
+
+    // This thing was never really part of the URL specs
+    @available(*, unavailable, message: "Use `path`, `query`, and `fragment` instead")
+    public var resourceSpecifier: String {
+        fatalError()
+    }
+    
+    /// If the URL conforms to RFC 1808 (the most common form of URL), returns the host component of the URL; otherwise it returns nil.
     ///
-    /// The litmus test for conformance is as recommended in RFC 1808 - whether the first two characters of resourceSpecifier is "//".  In all cases, they return the component's value after resolving the receiver against its base URL.
-    public var password: String? { return _url.password }
+    /// - note: This function will resolve against the base `URL`.
+    public var host: String? {
+        return _url.host
+    }
     
-    /// If the URL conforms to rfc 1808 (the most common form of URL), returns a component of the URL; otherwise it returns nil.
+    /// If the URL conforms to RFC 1808 (the most common form of URL), returns the port component of the URL; otherwise it returns nil.
     ///
-    /// The litmus test for conformance is as recommended in RFC 1808 - whether the first two characters of resourceSpecifier is "//".  In all cases, they return the component's value after resolving the receiver against its base URL.
-    public var path: String? { return _url.path }
+    /// - note: This function will resolve against the base `URL`.
+    public var port: Int? {
+        return _url.port?.intValue
+    }
     
-    /// If the URL conforms to rfc 1808 (the most common form of URL), returns a component of the URL; otherwise it returns nil.
+    /// If the URL conforms to RFC 1808 (the most common form of URL), returns the user component of the URL; otherwise it returns nil.
     ///
-    /// The litmus test for conformance is as recommended in RFC 1808 - whether the first two characters of resourceSpecifier is "//".  In all cases, they return the component's value after resolving the receiver against its base URL.
-    public var fragment: String? { return _url.fragment }
+    /// - note: This function will resolve against the base `URL`.
+    public var user: String? {
+        return _url.user
+    }
     
-    /// If the URL conforms to rfc 1808 (the most common form of URL), returns a component of the URL; otherwise it returns nil.
+    /// If the URL conforms to RFC 1808 (the most common form of URL), returns the password component of the URL; otherwise it returns nil.
     ///
-    /// The litmus test for conformance is as recommended in RFC 1808 - whether the first two characters of resourceSpecifier is "//".  In all cases, they return the component's value after resolving the receiver against its base URL.
-    public var parameterString: String? { return _url.parameterString }
+    /// - note: This function will resolve against the base `URL`.
+    public var password: String? {
+        return _url.password
+    }
     
-    /// If the URL conforms to rfc 1808 (the most common form of URL), returns a component of the URL; otherwise it returns nil.
+    /// If the URL conforms to RFC 1808 (the most common form of URL), returns the path component of the URL; otherwise it returns an empty string.
     ///
-    /// The litmus test for conformance is as recommended in RFC 1808 - whether the first two characters of resourceSpecifier is "//".  In all cases, they return the component's value after resolving the receiver against its base URL.
-    public var query: String? { return _url.query }
+    /// If the URL contains a parameter string, it is appended to the path with a `;`.
+    /// - note: This function will resolve against the base `URL`.
+    /// - returns: The path, or an empty string if the URL has an empty path.
+    public var path: String {
+        if let parameterString = _url.parameterString {
+            if let path = _url.path {
+                return path + ";" + parameterString
+            } else {
+                return ";" + parameterString
+            }
+        } else if let path = _url.path {
+            return path
+        } else {
+            return ""
+        }
+    }
     
-    /// If the URL conforms to rfc 1808 (the most common form of URL), returns a component of the URL; otherwise it returns nil.
+    /// If the URL conforms to RFC 1808 (the most common form of URL), returns the relative path of the URL; otherwise it returns nil.
     ///
     /// This is the same as path if baseURL is nil.
-    /// The litmus test for conformance is as recommended in RFC 1808 - whether the first two characters of resourceSpecifier is "//".  In all cases, they return the component's value after resolving the receiver against its base URL.
-    public var relativePath: String? { return _url.relativePath }
+    /// If the URL contains a parameter string, it is appended to the path with a `;`.
+    ///
+    /// - note: This function will resolve against the base `URL`.
+    /// - returns: The relative path, or an empty string if the URL has an empty path.
+    public var relativePath: String {
+        if let parameterString = _url.parameterString {
+            if let path = _url.relativePath {
+                return path + ";" + parameterString
+            } else {
+                return ";" + parameterString
+            }
+        } else if let path = _url.relativePath {
+            return path
+        } else {
+            return ""
+        }
+    }
+
+    /// If the URL conforms to RFC 1808 (the most common form of URL), returns the fragment component of the URL; otherwise it returns nil.
+    ///
+    /// - note: This function will resolve against the base `URL`.
+    public var fragment: String? {
+        return _url.fragment
+    }
     
+    @available(*, unavailable, message: "use the 'path' property")
+    public var parameterString: String? {
+        fatalError()
+    }
+    
+    /// If the URL conforms to RFC 1808 (the most common form of URL), returns the query of the URL; otherwise it returns nil.
+    ///
+    /// - note: This function will resolve against the base `URL`.
+    public var query: String? {
+        return _url.query
+    }
+    
+    /// Returns true if the URL path represents a directory.
     @available(OSX 10.11, iOS 9.0, *)
-    public var hasDirectoryPath: Bool { return _url.hasDirectoryPath }
+    public var hasDirectoryPath: Bool {
+        return _url.hasDirectoryPath
+    }
     
     /// Passes the URL's path in file system representation to `block`. 
     /// 
     /// File system representation is a null-terminated C string with canonical UTF-8 encoding.
     /// - note: The pointer is not valid outside the context of the block.
     @available(OSX 10.9, iOS 7.0, *)
-    public func withUnsafeFileSystemRepresentation(_ block: @noescape (UnsafePointer<Int8>) throws -> Void) rethrows {
-        try block(_url.fileSystemRepresentation)
+    public func withUnsafeFileSystemRepresentation<ResultType>(_ block: @noescape (UnsafePointer<Int8>?) throws -> ResultType) rethrows -> ResultType {
+        return try block(_url.fileSystemRepresentation)
     }
     
-    /// Whether the scheme is file:; if `myURL.isFileURL` is `true`, then `myURL.path` is suitable for input into `FileManager` or `PathUtilities`.
-    public var isFileURL: Bool {
-        return _url.isFileURL
+    // MARK: -
+    // MARK: Path manipulation
+    
+    /// Returns the path components of the URL, or an empty array if the path is an empty string.
+    public var pathComponents: [String] {
+        // In accordance with our above change to never return a nil path, here we return an empty array.
+        return _url.pathComponents ?? []
     }
     
-    public func standardized() throws -> URL {
-        if let result = _url.standardized.map({ URL(reference: $0 as NSURL) }) {
-            return result;
-        } else {
-            // TODO: We need to call into CFURL to figure out the error
-            throw NSError(domain: NSCocoaErrorDomain, code: NSFileReadUnknownError, userInfo: [:])
-        }
+    /// Returns the last path component of the URL, or an empty string if the path is an empty string.
+    public var lastPathComponent: String {
+        return _url.lastPathComponent ?? ""
     }
     
-    /// Returns a file reference URL that refers to the same resource as a specified file URL.
+    /// Returns the path extension of the URL, or an empty string if the path is an empty string.
+    public var pathExtension: String {
+        return _url.pathExtension ?? ""
+    }
+    
+    /// Returns a URL constructed by appending the given path component to self.
     ///
-    /// File reference URLs use a URL path syntax that identifies a file system object by reference, not by path. This form of file URL remains valid when the file system path of the URL's underlying resource changes. An error will occur if the url parameter is not a file URL. File reference URLs cannot be created to file system objects which do not exist or are not reachable. In some areas of the file system hierarchy, file reference URLs cannot be generated to the leaf node of the URL path. A file reference URL's path should never be persistently stored because is not valid across system restarts, and across remounts of volumes -- if you want to create a persistent reference to a file system object, use a bookmark.
-    /// - seealso: func bookmarkData(options: BookmarkCreationOptions = [], includingResourceValuesForKeys keys: Set<URLResourceKey>? = nil, relativeTo url: URL? = nil) throws -> Data
-    public func fileReferenceURL() throws -> URL {
-        if let result = _url.fileReferenceURL().map({ URL(reference: $0 as NSURL) }) {
-            return result as URL
-        } else {
-            // TODO: We need to call into CFURL to figure out the error
-            throw NSError(domain: NSCocoaErrorDomain, code: NSFileReadUnknownError, userInfo: [:])
-        }
-    }
-    
-    /// Returns `true` if the URL is a file reference URL.
-    public var isFileReferenceURL : Bool {
-        return _url.isFileReferenceURL()
-    }
-    
-    /// Returns a file path URL that refers to the same resource as a specified URL. 
-    ///
-    /// File path URLs use a file system style path. A file reference URL's resource must exist and be reachable to be converted to a file path URL.
-    public func filePathURL() throws -> URL {
-        if let result = _url.filePathURL.map({ URL(reference: $0 as NSURL) }) {
+    /// - parameter pathComponent: The path component to add.
+    /// - parameter isDirectory: If `true`, then a trailing `/` is added to the resulting path.
+    public func appendingPathComponent(_ pathComponent: String, isDirectory: Bool) -> URL {
+        if let result = _url.appendingPathComponent(pathComponent, isDirectory: isDirectory) {
             return result
         } else {
-            // TODO: We need to call into CFURL to figure out the error
-            throw NSError(domain: NSCocoaErrorDomain, code: NSFileReadUnknownError, userInfo: [:])
+            // Now we need to do something more expensive
+            if var c = URLComponents(url: self, resolvingAgainstBaseURL: true) {
+                c.path = (c.path as NSString).appendingPathComponent(pathComponent)
+                
+                if let result = c.url {
+                    return result
+                } else {
+                    // Couldn't get url from components
+                    // Ultimate fallback:
+                    return self
+                }
+            } else {
+                return self
+            }
         }
     }
     
-    public var pathComponents: [String]? { return _url.pathComponents }
-    
-    public var lastPathComponent: String? { return _url.lastPathComponent }
-    
-    public var pathExtension: String? { return _url.pathExtension }
-    
-    public func appendingPathComponent(_ pathComponent: String, isDirectory: Bool) throws -> URL {
-        // TODO: Use URLComponents to handle an empty-path case
-        /*
-         URLByAppendingPathComponent can return nil if:
-         * the URL does not have a path component. (see note 1)
-         * a mutable copy of the URLs string could not be created.
-         * a percent-encoded string of the new path component could not created using the same encoding as the URL's string. (see note 2)
-         * a new URL object could not be created with the modified URL string.
-         
-         Note 1: If NS/CFURL parsed URLs correctly, this would not occur because URL strings always have a path component. For example, the URL <mailto:user@example.com> should be parsed as Scheme="mailto", and Path= "user@example.com". Instead, CFURL returns false for CFURLCanBeDecomposed(), says Scheme="mailto", Path=nil, and ResourceSpecifier="user@example.com". rdar://problem/15060399
-         
-         Note 2: CFURLCreateWithBytes() and CFURLCreateAbsoluteURLWithBytes() allow URLs to be created with an array of bytes and a CFStringEncoding. All other CFURL functions and URL methods which create URLs use kCFStringEncodingUTF8/NSUTF8StringEncoding. So, the encoding passed to CFURLCreateWithBytes/CFURLCreateAbsoluteURLWithBytes might prevent the percent-encoding of the new path component or path extension.
-         */
-        guard let result = _url.appendingPathComponent(pathComponent, isDirectory: isDirectory) else {
-            throw NSError(domain: NSCocoaErrorDomain, code: NSFileReadUnknownError, userInfo: [:])
+    /// Returns a URL constructed by appending the given path component to self.
+    ///
+    /// - note: This function performs a file system operation to determine if the path component is a directory. If so, it will append a trailing `/`. If you know in advance that the path component is a directory or not, then use `func appendingPathComponent(_:isDirectory:)`.
+    /// - parameter pathComponent: The path component to add.
+    public func appendingPathComponent(_ pathComponent: String) -> URL {
+        if let result = _url.appendingPathComponent(pathComponent) {
+            return result
+        } else {
+            // Now we need to do something more expensive
+            if var c = URLComponents(url: self, resolvingAgainstBaseURL: true) {
+                c.path = (c.path as NSString).appendingPathComponent(pathComponent)
+                
+                if let result = c.url {
+                    return result
+                } else {
+                    // Couldn't get url from components
+                    // Ultimate fallback:
+                    return self
+                }
+            } else {
+                // Ultimate fallback:
+                return self
+            }
         }
-        return result
-    }
-    public mutating func appendPathComponent(_ pathComponent: String, isDirectory: Bool) throws {
-        self = try appendingPathComponent(pathComponent, isDirectory: isDirectory)
     }
     
-    public func appendingPathComponent(_ pathComponent: String) throws -> URL {
-        guard let result = _url.appendingPathComponent(pathComponent) else {
-            throw NSError(domain: NSCocoaErrorDomain, code: NSFileReadUnknownError, userInfo: [:])
+    /// Returns a URL constructed by removing the last path component of self.
+    ///
+    /// This function may either remove a path component or append `/..`.
+    ///
+    /// If the URL has an empty path (e.g., `http://www.example.com`), then this function will return the URL unchanged.
+    public func deletingLastPathComponent() -> URL {
+        // This is a slight behavior change from NSURL, but better than returning "http://www.example.com../".
+        if path.isEmpty {
+            return self
         }
-        return result
-    }
-    public mutating func appendPathComponent(_ pathComponent: String) throws {
-        self = try appendingPathComponent(pathComponent)        
-    }
-
-    public func deletingLastPathComponent() throws -> URL {
-        /*
-         URLByDeletingLastPathComponent can return nil if:
-         * the URL is a file reference URL which cannot be resolved back to a path.
-         * the URL does not have a path component. (see note 1)
-         * a mutable copy of the URLs string could not be created.
-         * a new URL object could not be created with the modified URL string.
-         */
+        
         if let result = _url.deletingLastPathComponent.map({ URL(reference: $0 as NSURL) }) {
             return result
         } else {
-            // TODO: We need to call into CFURL to figure out the error
-            throw NSError(domain: NSCocoaErrorDomain, code: NSFileReadUnknownError, userInfo: [:])
+            return self
         }
     }
-    public mutating func deleteLastPathComponent() throws {
-        let result = try deletingLastPathComponent()
-        self = result
-    }
     
-    public func appendingPathExtension(_ pathExtension: String) throws -> URL {
-        /*
-         URLByAppendingPathExtension can return nil if:
-         * the new path extension is not a valid extension (see _CFExtensionIsValidToAppend)
-         * the URL is a file reference URL which cannot be resolved back to a path.
-         * the URL does not have a path component. (see note 1)
-         * a mutable copy of the URLs string could not be created.
-         * a percent-encoded string of the new path extension could not created using the same encoding as the URL's string. (see note 1))
-         * a new URL object could not be created with the modified URL string.
-         */
-        guard let result = _url.appendingPathExtension(pathExtension) else {
-            throw NSError(domain: NSCocoaErrorDomain, code: NSFileReadUnknownError, userInfo: [:])
+    /// Returns a URL constructed by appending the given path extension to self.
+    ///
+    /// If the URL has an empty path (e.g., `http://www.example.com`), then this function will return the URL unchanged.
+    ///
+    /// Certain special characters (for example, Unicode Right-To-Left marks) cannot be used as path extensions. If any of those are contained in `pathExtension`, the function will return the URL unchanged.
+    /// - parameter pathExtension: The extension to append.
+    public func appendingPathExtension(_ pathExtension: String) -> URL {
+        if path.isEmpty {
+            return self
         }
-        return result
-    }
-    public mutating func appendPathExtension(_ pathExtension: String) throws {
-        self = try appendingPathExtension(pathExtension)
+        
+        if let result = _url.appendingPathExtension(pathExtension) {
+            return result
+        } else {
+            return self
+        }
     }
     
-    public func deletingPathExtension() throws -> URL {
-        /*
-         URLByDeletingPathExtension can return nil if:
-         * the URL is a file reference URL which cannot be resolved back to a path.
-         * the URL does not have a path component. (see note 1)
-         * a mutable copy of the URLs string could not be created.
-         * a new URL object could not be created with the modified URL string.
-         */
+    /// Returns a URL constructed by removing any path extension.
+    ///
+    /// If the URL has an empty path (e.g., `http://www.example.com`), then this function will return the URL unchanged.
+    public func deletingPathExtension() -> URL {
+        if path.isEmpty {
+            return self
+        }
+
         if let result = _url.deletingPathExtension.map({ URL(reference: $0 as NSURL) }) {
             return result
         } else {
-            // TODO: We need to call into CFURL to figure out the error
-            throw NSError(domain: NSCocoaErrorDomain, code: NSFileReadUnknownError, userInfo: [:])
-        }
-    }
-    public mutating func deletePathExtension() throws {
-        let result = try deletingPathExtension()
-        self = result
-    }
-    
-    public func standardizingPath() throws -> URL {
-        /*
-         URLByStandardizingPath can return nil if:
-         * the URL is a file reference URL which cannot be resolved back to a path.
-         * a new URL object could not be created with the standardized path).
-         */
-        if let result = _url.standardizingPath.map({ URL(reference: $0 as NSURL) }) {
-            return result
-        } else {
-            // TODO: We need to call into CFURL to figure out the error
-            throw NSError(domain: NSCocoaErrorDomain, code: NSFileReadUnknownError, userInfo: [:])
-        }
-    }
-    public mutating func standardizePath() throws {
-        let result = try standardizingPath()
-        self = result
-    }
-    
-    public func resolvingSymlinksInPath() throws -> URL {
-        /*
-         URLByResolvingSymlinksInPath can return nil if:
-         * the URL is a file reference URL which cannot be resolved back to a path.
-         * NSPathUtilities' stringByResolvingSymlinksInPath property returns nil.
-         * a new URL object could not be created with the resolved path).
-         */
-        if let result = _url.resolvingSymlinksInPath.map({ URL(reference: $0 as NSURL) }) {
-            return result
-        } else {
-            // TODO: We need to call into CFURL to figure out the error
-            throw NSError(domain: NSCocoaErrorDomain, code: NSFileReadUnknownError, userInfo: [:])
+            return self
         }
     }
 
-    public mutating func resolveSymlinksInPath() throws {
-        let result = try resolvingSymlinksInPath()
-        self = result
+    /// Appends a path component to the URL.
+    ///
+    /// - parameter pathComponent: The path component to add.
+    /// - parameter isDirectory: Use `true` if the resulting path is a directory.
+    public mutating func appendPathComponent(_ pathComponent: String, isDirectory: Bool) {
+        self = appendingPathComponent(pathComponent, isDirectory: isDirectory)
+    }
+    
+    /// Appends a path component to the URL.
+    ///
+    /// - note: This function performs a file system operation to determine if the path component is a directory. If so, it will append a trailing `/`. If you know in advance that the path component is a directory or not, then use `func appendingPathComponent(_:isDirectory:)`.
+    /// - parameter pathComponent: The path component to add.
+    public mutating func appendPathComponent(_ pathComponent: String) {
+        self = appendingPathComponent(pathComponent)
+    }
+    
+    /// Appends the given path extension to self.
+    ///
+    /// If the URL has an empty path (e.g., `http://www.example.com`), then this function will do nothing.
+    /// Certain special characters (for example, Unicode Right-To-Left marks) cannot be used as path extensions. If any of those are contained in `pathExtension`, the function will return the URL unchanged.
+    /// - parameter pathExtension: The extension to append.
+    public mutating func appendPathExtension(_ pathExtension: String) {
+        self = appendingPathExtension(pathExtension)
+    }
+
+    /// Returns a URL constructed by removing the last path component of self.
+    ///
+    /// This function may either remove a path component or append `/..`.
+    ///
+    /// If the URL has an empty path (e.g., `http://www.example.com`), then this function will do nothing.
+    public mutating func deleteLastPathComponent() {
+        self = deletingLastPathComponent()
+    }
+    
+
+    /// Returns a URL constructed by removing any path extension.
+    ///
+    /// If the URL has an empty path (e.g., `http://www.example.com`), then this function will do nothing.
+    public mutating func deletePathExtension() {
+        self = deletingPathExtension()
+    }
+    
+    /// Returns a `URL` with any instances of ".." or "." removed from its path.
+    public var standardized : URL {
+        // The NSURL API can only return nil in case of file reference URL, which we should not be
+        if let result = _url.standardized.map({ URL(reference: $0 as NSURL) }) {
+            return result
+        } else {
+            return self
+        }
+    }
+    
+    /// Standardizes the path of a file URL.
+    ///
+    /// If the `isFileURL` is false, this method does nothing.
+    public mutating func standardize() {
+        self = self.standardized
+    }
+    
+    /// Standardizes the path of a file URL.
+    ///
+    /// If the `isFileURL` is false, this method returns `self`.
+    public var standardizedFileURL : URL {
+        // NSURL should not return nil here unless this is a file reference URL, which should be impossible
+        if let result = _url.standardizingPath.map({ URL(reference: $0 as NSURL) }) {
+            return result
+        } else {
+            return self
+        }
+    }
+    
+    /// Resolves any symlinks in the path of a file URL.
+    ///
+    /// If the `isFileURL` is false, this method returns `self`.
+    public func resolvingSymlinksInPath() -> URL {
+        // NSURL should not return nil here unless this is a file reference URL, which should be impossible
+        if let result = _url.resolvingSymlinksInPath.map({ URL(reference: $0 as NSURL) }) {
+            return result
+        } else {
+            return self
+        }
+    }
+
+    /// Resolves any symlinks in the path of a file URL.
+    ///
+    /// If the `isFileURL` is false, this method does nothing.
+    public mutating func resolveSymlinksInPath() {
+        self = self.resolvingSymlinksInPath()
     }
 
     // MARK: - Reachability
@@ -966,8 +1099,19 @@ public struct URL : ReferenceConvertible, CustomStringConvertible, Equatable {
     
     // MARK: - Bridging Support
     
+    /// We must not store an NSURL without running it through this function. This makes sure that we do not hold a file reference URL, which changes the nullability of many NSURL functions.
+    private static func _converted(from url: NSURL) -> NSURL {
+        // Future readers: file reference URL here is not the same as playgrounds "file reference"
+        if url.isFileReferenceURL() {
+            // Convert to a file path URL, or use an invalid scheme
+            return url.filePathURL ?? URL(string: "com-apple-unresolvable-file-reference-url:")!
+        } else {
+            return url
+        }
+    }
+    
     private init(reference: NSURL) {
-        _url = reference.copy() as! NSURL
+        _url = URL._converted(from: reference).copy() as! NSURL
     }
     
     private var reference : NSURL {
@@ -989,14 +1133,14 @@ extension URL : _ObjectiveCBridgeable {
         return _url
     }
     
-    public static func _forceBridgeFromObjectiveC(_ x: NSURL, result: inout URL?) {
-        if !_conditionallyBridgeFromObjectiveC(x, result: &result) {
+    public static func _forceBridgeFromObjectiveC(_ source: NSURL, result: inout URL?) {
+        if !_conditionallyBridgeFromObjectiveC(source, result: &result) {
             fatalError("Unable to bridge \(_ObjectiveCType.self) to \(self)")
         }
     }
     
-    public static func _conditionallyBridgeFromObjectiveC(_ x: NSURL, result: inout URL?) -> Bool {
-        result = URL(reference: x)
+    public static func _conditionallyBridgeFromObjectiveC(_ source: NSURL, result: inout URL?) -> Bool {
+        result = URL(reference: source)
         return true
     }
 
@@ -1009,11 +1153,7 @@ extension URL : _ObjectiveCBridgeable {
 
 extension URL : CustomPlaygroundQuickLookable {
     public var customPlaygroundQuickLook: PlaygroundQuickLook {
-        if let str = absoluteString {
-            return .url(str)
-        } else {
-            return .text(self.description)
-        }
+        return .url(absoluteString)
     }
 }
 

--- a/stdlib/public/SDK/Foundation/URLComponents.swift
+++ b/stdlib/public/SDK/Foundation/URLComponents.swift
@@ -41,12 +41,16 @@ public struct URLComponents : ReferenceConvertible, Hashable, CustomStringConver
         _handle = _MutableHandle(adoptingReference: result)
     }
     
-    /// Returns a URL created from the NSURLComponents. If the NSURLComponents has an authority component (user, password, host or port) and a path component, then the path must either begin with "/" or be an empty string. If the NSURLComponents does not have an authority component (user, password, host or port) and has a path component, the path component must not start with "//". If those requirements are not met, nil is returned.
+    /// Returns a URL created from the NSURLComponents. 
+    ///
+    /// If the NSURLComponents has an authority component (user, password, host or port) and a path component, then the path must either begin with "/" or be an empty string. If the NSURLComponents does not have an authority component (user, password, host or port) and has a path component, the path component must not start with "//". If those requirements are not met, nil is returned.
     public var url: URL? {
         return _handle.map { $0.url }
     }
     
-    // Returns a URL created from the NSURLComponents relative to a base URL. If the NSURLComponents has an authority component (user, password, host or port) and a path component, then the path must either begin with "/" or be an empty string. If the NSURLComponents does not have an authority component (user, password, host or port) and has a path component, the path component must not start with "//". If those requirements are not met, nil is returned.
+    // Returns a URL created from the NSURLComponents relative to a base URL. 
+    ///
+    /// If the NSURLComponents has an authority component (user, password, host or port) and a path component, then the path must either begin with "/" or be an empty string. If the NSURLComponents does not have an authority component (user, password, host or port) and has a path component, the path component must not start with "//". If those requirements are not met, nil is returned.
     public func url(relativeTo base: URL?) -> URL? {
         return _handle.map { $0.url(relativeTo: base) }
     }
@@ -106,9 +110,14 @@ public struct URLComponents : ReferenceConvertible, Hashable, CustomStringConver
     /// The path subcomponent.
     ///
     /// The getter for this property removes any percent encoding this component may have (if the component allows percent encoding). Setting this property assumes the subcomponent or component string is not percent encoded and will add percent encoding (if the component allows percent encoding).
-    public var path: String? {
-        get { return _handle.map { $0.path } }
-        set { _applyMutation { $0.path = newValue } }
+    public var path: String {
+        get {
+            guard let result = _handle.map({ $0.path }) else { return "" }
+            return result
+        }
+        set {
+            _applyMutation { $0.path = newValue }
+        }
     }
     
     /// The query subcomponent.
@@ -155,9 +164,14 @@ public struct URLComponents : ReferenceConvertible, Hashable, CustomStringConver
     /// The path subcomponent, percent-encoded.
     ///
     /// The getter for this property retains any percent encoding this component may have. Setting this properties assumes the component string is already correctly percent encoded. Attempting to set an incorrectly percent encoded string will cause a `fatalError`. Although ';' is a legal path character, it is recommended that it be percent-encoded for best compatibility with `URL` (`String.addingPercentEncoding(withAllowedCharacters:)` will percent-encode any ';' characters if you pass `CharacterSet.urlPathAllowed`).
-    public var percentEncodedPath: String? {
-        get { return _handle.map { $0.percentEncodedPath } }
-        set { _applyMutation { $0.percentEncodedPath = newValue } }
+    public var percentEncodedPath: String {
+        get {
+            guard let result = _handle.map({ $0.percentEncodedPath }) else { return "" }
+            return result
+        }
+        set {
+            _applyMutation { $0.percentEncodedPath = newValue }
+        }
     }
     
     /// The query subcomponent, percent-encoded.
@@ -270,7 +284,7 @@ public struct URLComponents : ReferenceConvertible, Hashable, CustomStringConver
     ///
     /// The setter combines an array containing any number of `URLQueryItem`s, each of which represents a single key-value pair, into a query string and sets the `URLComponents` query property. Passing an empty array sets the query component of the `URLComponents` to an empty string. Passing nil removes the query component of the `URLComponents`.
     ///
-    /// - note: If a name-value pair in a query is empty (i.e. the query string starts with '&', ends with '&', or has "&&" within it), you get a `URLQueryItem` with a zero-length name and a nil value. If a query's name-value pair has nothing before the equals sign, you get a zero-length name. If a query's name-value pair has nothing after the equals sign, you get a zero-length value. If a query's name-value pair has no equals sign, the query name-value pair string is the name and you get a nil value.
+    /// - note: If a name-value pair in a query is empty (i.e. the query string starts with '&', ends with '&', or has "&&" within it), you get a `URLQueryItem` with a zero-length name and and a nil value. If a query's name-value pair has nothing before the equals sign, you get a zero-length name. If a query's name-value pair has nothing after the equals sign, you get a zero-length value. If a query's name-value pair has no equals sign, the query name-value pair string is the name and you get a nil value.
     @available(OSX 10.10, iOS 8.0, *)
     public var queryItems: [URLQueryItem]? {
         get { return _handle.map { $0.queryItems?.map { return $0 as URLQueryItem } } }

--- a/test/1_stdlib/TestURL.swift
+++ b/test/1_stdlib/TestURL.swift
@@ -25,7 +25,7 @@ class TestURL : TestURLSuper {
     func testBasics() {
         let url = URL(fileURLWithPath: NSTemporaryDirectory())
         
-        expectTrue(url.pathComponents!.count > 0)
+        expectTrue(url.pathComponents.count > 0)
     }
     
     func testProperties() {
@@ -45,7 +45,7 @@ class TestURL : TestURLSuper {
         // Create a temporary file
         var file = URL(fileURLWithPath: NSTemporaryDirectory())
         let name = "my_great_file" + UUID().uuidString
-        try! file.appendPathComponent(name)
+        file.appendPathComponent(name)
         let data = Data(bytes: [1, 2, 3, 4, 5])
         do {
             try data.write(to: file)
@@ -71,7 +71,7 @@ class TestURL : TestURLSuper {
         // Create a temporary file
         var file = URL(fileURLWithPath: NSTemporaryDirectory())
         let name = "my_great_file" + UUID().uuidString
-        try! file.appendPathComponent(name)
+        file.appendPathComponent(name)
         let data = Data(bytes: [1, 2, 3, 4, 5])
         do {
             try data.write(to: file)
@@ -88,7 +88,7 @@ class TestURL : TestURLSuper {
             try file.setResourceValues(resourceValues)
             
             // get label number
-            try file.resourceValues(forKeys: [.labelNumberKey])
+            let _ = try file.resourceValues(forKeys: [.labelNumberKey])
             expectNotEmpty(resourceValues.labelNumber)
             expectEqual(resourceValues.labelNumber!, 1)
         } catch (let e as NSError) {


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

In Snow Leopard, `NSURL` gained the ability to represent file references. However, as is clear from the name, they are fundamentally different from a URL. A URL is effectively a string, and operations like adding path components can never fail. A file reference is a pointer, and validity of the file it points to must be checked when mutating it. The difference between these two concepts has caused some confusion about the proper usage of the `struct URL` type.

Therefore, `struct URL` is no longer used for file references.

As a transition mechanism, `NSURL` may still hold file reference URLs. `struct URL` will always convert to a file path URL upon initialization.

We surveyed the use of file references throughout the OS. Only two public Foundation APIs return file reference URLs. Some key APIs like `NSDocument` do not accept file reference URLs (it converts them to path URLs upon receiving them). `NSDocument` uses file coordination to track changes to files, and we recommend developers who have the same requirement also use file coordination.

As a result of this change, many of the Swift `struct URL` APIs become far simpler.
#### Detailed design

The following properties no longer return nullable values. They cannot return `nil` unless the URL contains a file reference URL, which is no longer possible.

``` diff
-    public var absoluteString: String? { get }
+    public var absoluteString: String { get }

-    public var absoluteURL: URL? { get }
+    public var absoluteURL: URL { get }

-    public var resourceSpecifier: String? { get }
+    public var resourceSpecifier: String { get }
```

`path` and `relativePath` will now always return a value, even if it is an empty string (e.g., the URL `mailto:person@example.com`).

``` diff
-    public var path: String? { get }
+    public var path: String { get }

-    public var relativePath: String? { get }
+    public var relativePath: String { get }

-    public var pathComponents: [String]? { get }
+    public var pathComponents: [String] { get }
```

The following functions no longer need to `throw`, as they could only fail with file reference URLs:

``` diff
-    public func standardized() throws -> URL
-    public func standardizingPath() throws -> URL
-    public mutating func standardizePath() throws
-    public func resolvingSymlinksInPath() throws -> URL
-    public mutating func resolveSymlinksInPath() throws
+    public var standardized: URL { get }
+    public var standardizedFileURL: URL { get } // renamed from standardizingPath
+    public mutating func standardize()
+    public func resolvingSymlinksInPath() -> URL
+    public mutating func resolveSymlinksInPath()
```

The following functions no longer need to `throw`, as they could only fail with file reference URLs.

For URLs with no path (e.g., the URL `http://www.apple.com`), the path component APIs will append a path component, but the path extension APIs will do nothing. 

``` diff
-    public func appendingPathComponent(_ pathComponent: String, isDirectory: Bool) throws -> URL
-    public mutating func appendPathComponent(_ pathComponent: String, isDirectory: Bool) throws
+    public func appendingPathComponent(_ pathComponent: String, isDirectory: Bool) -> URL
+    public mutating func appendPathComponent(_ pathComponent: String, isDirectory: Bool)

-    public func appendingPathComponent(_ pathComponent: String) throws -> URL
-    public mutating func appendPathComponent(_ pathComponent: String) throws
+    public func appendingPathComponent(_ pathComponent: String) -> URL
+    public mutating func appendPathComponent(_ pathComponent: String)

-    public func appendingPathExtension(_ pathExtension: String) throws -> URL
-    public mutating func appendPathExtension(_ pathExtension: String) throws
+    public func appendingPathExtension(_ pathExtension: String) -> URL
+    public mutating func appendPathExtension(_ pathExtension: String) 
```

The following functions no longer need to `throw`, as they could only fail with file reference URLs.

For URLs with no path (e.g., the URL `http://www.apple.com`), these functions will do nothing. 

``` diff
-    public func deletingLastPathComponent() throws -> URL
-    public mutating func deleteLastPathComponent() throws
+    public func deletingLastPathComponent() -> URL
+    public mutating func deleteLastPathComponent()

-    public func deletingPathExtension() throws -> URL
-    public mutating func deletePathExtension() throws
+    public func deletingPathExtension() -> URL
+    public mutating func deletePathExtension()
```
### Other Nullability Fixes

The `init(string:relativeTo:)` initializer now accepts a `nil` relative URL (as does `NSURL`).

``` diff
-    public init?(string: String, relativeTo url: URL)
+    public init?(string: String, relativeTo url: URL?)
```

The `init(dataRepresentation:relativeTo:isAbsolute:)` initializer now correctly returns a nullable result (if the data representation can not be converted).

``` diff
-    public init(dataRepresentation: Data, relativeTo url: URL?, isAbsolute: Bool = default)
+    public init?(dataRepresentation: Data, relativeTo url: URL?, isAbsolute: Bool = default)
```
### Obsolete API

The parameter string method is removed, as it is obsolete. `path` now returns the correct thing if the URL has a parameter string (return the parameter string with a `;` in it).

``` diff
-    public var parameterString: String? { get }
```

As `struct URL` does not hold file reference URLs, the following are removed:

``` diff
-    public func fileReferenceURL() throws -> URL
-    public var isFileReferenceURL: Bool { get }
-    public func filePathURL() throws -> URL
```
#### Resolved bug number

rdar://26495377

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
