### PR TITLE
Improve wording of diagnostic about escaping closures capturing inout…

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2160,7 +2160,7 @@ NOTE(transitive_capture_through_here,none,
      (Identifier, Identifier))
 
 ERROR(closure_implicit_capture_without_noescape,none,
-      "closure cannot implicitly capture an inout parameter unless @noescape",
+      "escaping closures can only capture inout parameters explicitly by value",
       ())
 ERROR(closure_implicit_capture_mutating_self,none,
       "closure cannot implicitly capture a mutating self parameter",

--- a/test/SILOptimizer/allocbox_to_stack_not_crash.swift
+++ b/test/SILOptimizer/allocbox_to_stack_not_crash.swift
@@ -6,10 +6,10 @@ infix operator ~> { precedence 255 }
 protocol Target {}
 
 func ~> <Target, Arg0, Result>(x: inout Target, f: (_: inout Target, _: Arg0) -> Result) -> (Arg0) -> Result {
-  return { f(&x, $0) } // expected-error {{closure cannot implicitly capture an inout parameter unless @noescape}}
+  return { f(&x, $0) } // expected-error {{escaping closures can only capture inout parameters explicitly by value}}
 }
 
 func ~> (x: inout Int, f: (_: inout Int, _: Target) -> Target) -> (Target) -> Target {
-  return { f(&x, $0) } // expected-error {{closure cannot implicitly capture an inout parameter unless @noescape}}
+  return { f(&x, $0) } // expected-error {{escaping closures can only capture inout parameters explicitly by value}}
 }
 

--- a/test/Sema/diag_invalid_inout_captures.swift
+++ b/test/Sema/diag_invalid_inout_captures.swift
@@ -12,7 +12,8 @@ struct you_cry_in_your_tea {
 
 func why_so_sad(line: inout String) {
     no_escape { line = "Remember we made an arrangement when you went away" } // OK
-    do_escape { line = "now you're making me mad" } // expected-error {{closure cannot implicitly capture an inout parameter unless @noescape}}
+    do_escape { line = "now you're making me mad" } // expected-error {{escaping closures can only capture inout parameters explicitly by value}}
+    do_escape { [line] in _ = line } // OK
 }
 
 func remember(line: inout String) -> () -> Void {


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Reword a slightly awkward diagnostic regarding capturing inout parameters in escaping closures.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

… params.

Fixes: rdar://problem/27208711
