### PR TITLE
[simplify-cfg] When moving cond_fail to preds, do not bail early.

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -169,6 +169,9 @@ PASS(LSLocationPrinter, "lslocation-dump",
      "Dump LSLocation results from analyzing all accessed locations")
 PASS(MergeCondFails, "merge-cond_fails",
      "Remove redundant overflow checks")
+PASS(MoveCondFailToPreds, "move-cond-fail-to-preds",
+     "Test pass that hoists conditional fails to predecessors blocks when "
+     "profitable")
 PASS(NoReturnFolding, "noreturn-folding",
      "Add 'unreachable' after noreturn calls")
 PASS(RCIdentityDumper, "rc-id-dumper",

--- a/test/SILOptimizer/move_cond_fail_simplify_cfg.sil
+++ b/test/SILOptimizer/move_cond_fail_simplify_cfg.sil
@@ -1,0 +1,45 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -move-cond-fail-to-preds | FileCheck %s
+
+import Builtin
+import Swift
+
+sil_stage canonical
+
+// Make sure that we actually check all predecessors when we try to hoist
+// cond_fails.
+//
+// CHECK-LABEL: sil @check_all_preds_when_hoisting_cond_fails : $@convention(thin) (Builtin.Int1) -> () {
+sil @check_all_preds_when_hoisting_cond_fails : $@convention(thin) (Builtin.Int1) -> () {
+bb0(%0 : $Builtin.Int1):
+  %1 = integer_literal $Builtin.Int1, 0
+  %2 = integer_literal $Builtin.Int64, 1
+  %3 = integer_literal $Builtin.Int64, 3
+  cond_br %0, bb3, bb2
+
+// Make sure that the predecessor order here is not changed. This is necessary
+// for the test to actually test that we are checking /all/ predecessors.
+//
+// CHECK: bb1({{.*}}): // Preds: bb2 bb1
+bb1(%7 : $Builtin.Int64, %8 : $Builtin.Int64, %9 : $Builtin.Int1):
+  %10 = builtin "sadd_with_overflow_Int64"(%8 : $Builtin.Int64, %2 : $Builtin.Int64, %1 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %11 = tuple_extract %10 : $(Builtin.Int64, Builtin.Int1), 0
+  cond_fail %9 : $Builtin.Int1
+  %13 = builtin "sadd_with_overflow_Int64"(%7 : $Builtin.Int64, %2 : $Builtin.Int64, %1 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %14 = tuple_extract %13 : $(Builtin.Int64, Builtin.Int1), 0
+  %15 = tuple_extract %13 : $(Builtin.Int64, Builtin.Int1), 1
+  cond_fail %15 : $Builtin.Int1
+  %17 = builtin "cmp_eq_Int64"(%14 : $Builtin.Int64, %3 : $Builtin.Int64) : $Builtin.Int1
+  %18 = builtin "cmp_eq_Int64"(%11 : $Builtin.Int64, %3 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %18, bb3, bb1(%14 : $Builtin.Int64, %11 : $Builtin.Int64, %17 : $Builtin.Int1)
+
+// Make sure there can not be any cond_fail here.
+// CHECK: bb2:
+// CHECK-NEXT: br bb1
+bb2:
+  br bb1(%2 : $Builtin.Int64, %2 : $Builtin.Int64, %1 : $Builtin.Int1)
+
+// CHECK: bb3:
+bb3:
+  %5 = tuple()
+  return %5 : $()
+}


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

This commit fixes a bug where we were not checking that all predecessors had the
cond_fail block as its only successor. This occured since we were bailing early
when we saw a constant. So if we saw a predecessor with a constant before a
predecessor that had multiple successors, we would optimize even though we would
be introducing an extra cond_fail along a path.

I added a new utility pass to test this code since so much is going on in
SimplifyCFG that it is difficult to construct a test case running the full
pass.

Really this code should be in a different pass (properly SIL Code Motion TBH).
But for now, this commit just fixes the bug.

rdar://26904047
