### PR TITLE
[swiftc (70 vs. 5108)] Add crasher in swift::Expr::propagateLValueAccessKind(...)

### DIFF
--- a/validation-test/compiler_crashers/28368-swift-expr-propagatelvalueaccesskind.swift
+++ b/validation-test/compiler_crashers/28368-swift-expr-propagatelvalueaccesskind.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+guard let f=.h.a=[]{


### PR DESCRIPTION
Add test case for crash triggered in `swift::Expr::propagateLValueAccessKind(...)`.

Current number of unresolved compiler crashers: 70 (5108 resolved)

Stack trace:

```
6  swift           0x00000000032c80ad llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) + 461
8  swift           0x00000000010f4c67 swift::Expr::propagateLValueAccessKind(swift::AccessKind, bool) + 23
12 swift           0x000000000107c7d5 swift::Expr::walk(swift::ASTWalker&) + 69
13 swift           0x0000000000f5bed2 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 514
14 swift           0x0000000000eb6971 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 769
17 swift           0x0000000000f7b572 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 13586
18 swift           0x0000000000f7d74e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 3998
19 swift           0x0000000000eb0112 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 850
20 swift           0x0000000000eb68d2 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
21 swift           0x0000000000eb7a87 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 343
22 swift           0x0000000000eb8785 swift::TypeChecker::typeCheckStmtCondition(llvm::MutableArrayRef<swift::StmtConditionElement>&, swift::DeclContext*, swift::Diag<>) + 373
25 swift           0x0000000000f303b6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
26 swift           0x0000000000eea4bd swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
27 swift           0x0000000000c6f629 swift::CompilerInstance::performSema() + 3289
29 swift           0x00000000007d8f39 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
30 swift           0x00000000007a4f58 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28368-swift-expr-propagatelvalueaccesskind.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28368-swift-expr-propagatelvalueaccesskind-c5a6ea.o
1.  While type-checking expression at [validation-test/compiler_crashers/28368-swift-expr-propagatelvalueaccesskind.swift:9:13 - line:9:19] RangeText=".h.a=[]"
2.  While type-checking expression at [validation-test/compiler_crashers/28368-swift-expr-propagatelvalueaccesskind.swift:9:13 - line:9:19] RangeText=".h.a=[]"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
