### PR TITLE
[WIP] [stdlib] [SE-0089] Rename String.init(_:)

### DIFF
--- a/benchmark/single-source/unit-tests/ObjectiveCBridging.swift
+++ b/benchmark/single-source/unit-tests/ObjectiveCBridging.swift
@@ -73,7 +73,7 @@ public func run_ObjectiveCBridgeFromNSStringForced(_ N: Int) {
 
 @inline(never)
 func testObjectiveCBridgeToNSString() {
-  let nativeString = String("Native")
+  let nativeString = "Native"
 
   var s: NSString?
   for _ in 0 ..< 10_000 {

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
@@ -561,7 +561,7 @@ extension TestSuite {
       return makeCollectionOfEquatable(elements.map(wrapValueIntoEquatable))
     }
 
-    testNamePrefix += String(C.Type.self)
+    testNamePrefix += String(describing: C.Type.self)
 
     //===------------------------------------------------------------------===//
     // generate()
@@ -1209,7 +1209,7 @@ extension TestSuite {
       return makeCollection(elements.map(wrapValue))
     }
 
-    testNamePrefix += String(C.Type.self)
+    testNamePrefix += String(describing: C.Type.self)
 
     // FIXME: swift-3-indexing-model - add tests for the follow?
     //          index(before: of i: Index) -> Index
@@ -1522,7 +1522,7 @@ extension TestSuite {
 
     addBidirectionalCollectionTests(${forwardTestArgs})
     
-    testNamePrefix += String(C.Type.self)
+    testNamePrefix += String(describing: C.Type.self)
 
     func makeWrappedCollection(_ elements: [OpaqueValue<Int>]) -> C {
       return makeCollection(elements.map(wrapValue))

--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
@@ -136,7 +136,7 @@ extension TestSuite {
       return makeCollectionOfComparable(elements.map(wrapValueIntoComparable))
     }
 
-    testNamePrefix += String(C.Type.self)
+    testNamePrefix += String(describing: C.Type.self)
 
 //===----------------------------------------------------------------------===//
 // subscript(_: Index)
@@ -657,7 +657,7 @@ self.test("\(testNamePrefix).sorted/${'Predicate' if predicate else 'WhereElemen
       return makeCollection(elements.map(wrapValue))
     }
 
-    testNamePrefix += String(C.Type.self)
+    testNamePrefix += String(describing: C.Type.self)
 
 //===----------------------------------------------------------------------===//
 // subscript(_: Index)
@@ -783,7 +783,7 @@ self.test("\(testNamePrefix).reverse()") {
       return makeCollectionOfComparable(elements.map(wrapValueIntoComparable))
     }
 
-    testNamePrefix += String(C.Type.self)
+    testNamePrefix += String(describing: C.Type.self)
 
 //===----------------------------------------------------------------------===//
 // sort()

--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
@@ -497,7 +497,7 @@ extension TestSuite {
       return makeCollection(elements.map(wrapValue))
     }
 
-    testNamePrefix += String(C.Type.self)
+    testNamePrefix += String(describing: C.Type.self)
 
 //===----------------------------------------------------------------------===//
 // init()
@@ -1218,7 +1218,7 @@ self.test("\(testNamePrefix).OperatorPlus") {
       return makeCollection(elements.map(wrapValue))
     }
 
-    testNamePrefix += String(C.Type.self)
+    testNamePrefix += String(describing: C.Type.self)
 
 //===----------------------------------------------------------------------===//
 // removeLast()
@@ -1340,7 +1340,7 @@ self.test("\(testNamePrefix).removeLast(n: Int)/whereIndexIsBidirectional/remove
       resiliencyChecks: resiliencyChecks,
       outOfBoundsIndexOffset: outOfBoundsIndexOffset)
 
-    testNamePrefix += String(C.Type.self)
+    testNamePrefix += String(describing: C.Type.self)
 
     // No extra checks for collections with random access traversal so far.
   } // addRangeReplaceableRandomAccessCollectionTests

--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableSliceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableSliceType.swift
@@ -65,7 +65,7 @@ extension TestSuite {
       return makeCollection(elements.map(wrapValue))
     }
 
-    testNamePrefix += String(C.Type.self)
+    testNamePrefix += String(describing: C.Type.self)
 
     //===------------------------------------------------------------------===//
     // removeFirst()
@@ -210,7 +210,7 @@ extension TestSuite {
       return makeCollection(elements.map(wrapValue))
     }
 
-    testNamePrefix += String(C.Type.self)
+    testNamePrefix += String(describing: C.Type.self)
 
     //===------------------------------------------------------------------===//
     // removeLast()
@@ -351,7 +351,7 @@ extension TestSuite {
       resiliencyChecks: resiliencyChecks,
       outOfBoundsIndexOffset: outOfBoundsIndexOffset)
 
-    testNamePrefix += String(C.Type.self)
+    testNamePrefix += String(describing: C.Type.self)
 
     // No tests yet.
   } // addRangeReplaceableRandomAccessSliceTests

--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
@@ -1484,7 +1484,7 @@ extension TestSuite {
       return makeSequenceOfEquatable(elements.map(wrapValueIntoEquatable))
     }
 
-    testNamePrefix += String(S.Type.self)
+    testNamePrefix += String(describing: S.Type.self)
 
     let isMultiPass = makeSequence([])
       ._preprocessingPass { true } ?? false

--- a/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
+++ b/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
@@ -127,7 +127,7 @@ public func == (lhs: TypeIdentifier, rhs: TypeIdentifier) -> Bool {
 extension TypeIdentifier
   : CustomStringConvertible, CustomDebugStringConvertible {
   public var description: String {
-    return String(value)
+    return String(describing: value)
   }
   public var debugDescription: String {
     return "TypeIdentifier(\(description))"

--- a/stdlib/private/StdlibUnittest/StringConvertible.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StringConvertible.swift.gyb
@@ -112,7 +112,7 @@ extension CustomPrintableValue : CustomDebugStringConvertible {
 public func expectPrinted<T>(
   expectedOneOf patterns: [String], _ object: T, ${TRACE}
 ) {
-  let actual = String(object)
+  let actual = String(describing: object)
   if !patterns.contains(actual) {
     expectationFailure(
       "expected: any of \(String(reflecting: patterns))\n"

--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -146,6 +146,18 @@ extension Bool : Equatable, Hashable {
   }
 }
 
+extension Bool : LosslessStringConvertible {
+  public init?(_ description: String) {
+    if description == "true" {
+      self = true
+    } else if description == "false" {
+      self = false
+    } else {
+      return nil
+    }
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // Operators
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -353,6 +353,14 @@ public struct Character :
   internal var _representation: Representation
 }
 
+extension Character : CustomStringConvertible {
+  public var description: String {
+    return String(self)
+  }
+}
+
+extension Character : LosslessStringConvertible {}
+
 extension Character : CustomDebugStringConvertible {
   /// A textual representation of the character, suitable for debugging.
   public var debugDescription: String {

--- a/stdlib/public/core/ImplicitlyUnwrappedOptional.swift
+++ b/stdlib/public/core/ImplicitlyUnwrappedOptional.swift
@@ -45,7 +45,7 @@ extension ImplicitlyUnwrappedOptional : CustomStringConvertible {
   public var description: String {
     switch self {
     case .some(let value):
-      return String(value)
+      return String(describing: value)
     case .none:
       return "nil"
     }

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -688,7 +688,7 @@ public protocol SignedInteger_ : BinaryInteger, SignedArithmetic {
 
 extension SignedInteger_ {
   public var description: String {
-    let base = String(magnitude)
+    let base = String(describing: magnitude)
     return self < 0 ? "-" + base : base
   }
 

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -855,7 +855,7 @@ extension String {
   ///     }
   ///
   ///     let p = Point(x: 21, y: 30)
-  ///     print(String(p))
+  ///     print(String(describing: p))
   ///     // Prints "Point(x: 21, y: 30)"
   ///
   /// After adding `CustomStringConvertible` conformance by implementing the
@@ -867,11 +867,11 @@ extension String {
   ///         }
   ///     }
   ///
-  ///     print(String(p))
+  ///     print(String(describing: p))
   ///     // Prints "(21, 30)"
   ///
   /// - SeeAlso: `String.init<Subject>(reflecting: Subject)`
-  public init<Subject>(_ instance: Subject) {
+  public init<Subject>(describing instance: Subject) {
     self.init()
     _print_unlocked(instance, &self)
   }

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -164,7 +164,17 @@ public protocol CustomStringConvertible {
   var description: String { get }
 }
 
+/// A type that can be represented as a string in a lossless, unambiguous way.
+///
+/// For example, the integer value 1050 can be represented in its entirety as
+/// the string "1050".
+///
+/// The description property of a conforming type must be a value-preserving
+/// representation of the original value. As such, it should be possible to
+/// attempt to re-create an instance from its string representation.
 public protocol LosslessStringConvertible : CustomStringConvertible {
+  /// Instantiates an instance of the conforming type from a string
+  /// representation.
   init?(_ description: String)
 }
 

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -164,6 +164,10 @@ public protocol CustomStringConvertible {
   var description: String { get }
 }
 
+public protocol LosslessStringConvertible : CustomStringConvertible {
+  init?(_ description: String)
+}
+
 /// A type with a customized textual representation suitable for debugging
 /// purposes.
 ///

--- a/stdlib/public/core/StaticString.swift
+++ b/stdlib/public/core/StaticString.swift
@@ -255,7 +255,7 @@ public struct StaticString
 
 extension StaticString {
   public var customMirror: Mirror {
-    return Mirror(reflecting: String(describing: self))
+    return Mirror(reflecting: description)
   }
 }
 

--- a/stdlib/public/core/StaticString.swift
+++ b/stdlib/public/core/StaticString.swift
@@ -255,7 +255,7 @@ public struct StaticString
 
 extension StaticString {
   public var customMirror: Mirror {
-    return Mirror(reflecting: String(self))
+    return Mirror(reflecting: String(describing: self))
   }
 }
 

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -974,6 +974,23 @@ extension String {
     return _nativeUnicodeUppercaseString(self)
 #endif
   }
+  
+  public // @testable
+  init<T: LosslessStringConvertible>(_ v: T) {
+    self = v.description
+  }
+}
+
+extension String : CustomStringConvertible {
+  public var description: String {
+    return self
+  }
+}
+
+extension String : LosslessStringConvertible {
+  public init?(_ description: String) {
+    self = description
+  }
 }
 
 extension String {

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -975,9 +975,10 @@ extension String {
 #endif
   }
   
-  public // @testable
-  init<T: LosslessStringConvertible>(_ v: T) {
-    self = v.description
+  /// Creates an instance from the description of a given
+  /// LosslessStringConvertible instance.
+  public init<T : LosslessStringConvertible>(_ value: T) {
+    self = value.description
   }
 }
 

--- a/stdlib/public/core/StringInterpolation.swift.gyb
+++ b/stdlib/public/core/StringInterpolation.swift.gyb
@@ -65,7 +65,7 @@ extension String : ExpressibleByStringInterpolation {
   ///
   /// - SeeAlso: `ExpressibleByStringInterpolation`
   public init<T>(stringInterpolationSegment expr: T) {
-    self = String(expr)
+    self = String(describing: expr)
   }
 
 % for Type in StreamableTypes:

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -63,12 +63,6 @@ extension String {
   }
 }
 
-extension String {
-  public init(_ _c: UnicodeScalar) {
-    self = String(repeating: _c, count: 1)
-  }
-}
-
 #if _runtime(_ObjC)
 /// Determines if `theString` starts with `prefix` comparing the strings under
 /// canonical equivalence.

--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -314,7 +314,7 @@ extension String {
       return UTF16View(_core)
     }
     set {
-      self = String(newValue)
+      self = String(describing: newValue)
     }
   }
 

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -375,7 +375,7 @@ extension String {
       return UTF8View(self._core)
     }
     set {
-      self = String(newValue)
+      self = String(describing: newValue)
     }
   }
 

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -263,9 +263,9 @@ extension UnicodeScalar : LosslessStringConvertible {
     if let v = UInt32(description) where (v < 0xD800 || v > 0xDFFF)
       && v <= 0x10FFFF {
       self = UnicodeScalar(v)
+    } else {
+      return nil
     }
-
-    return nil
   }
 }
 

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -249,12 +249,23 @@ public struct UnicodeScalar :
 extension UnicodeScalar : CustomStringConvertible, CustomDebugStringConvertible {
   /// An escaped textual representation of the Unicode scalar.
   public var description: String {
-    return "\"\(escaped(asASCII: false))\""
+    return String(value)
   }
   /// An escaped textual representation of the Unicode scalar, suitable for
   /// debugging.
   public var debugDescription: String {
     return "\"\(escaped(asASCII: true))\""
+  }
+}
+
+extension UnicodeScalar : LosslessStringConvertible {
+  public init?(_ description: String) {
+    if let v = UInt32(description) where (v < 0xD800 || v > 0xDFFF)
+      && v <= 0x10FFFF {
+      self = UnicodeScalar(v)
+    }
+
+    return nil
   }
 }
 

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -219,7 +219,7 @@ extension Unsafe${Mutable}BufferPointer : CustomDebugStringConvertible {
   /// A textual representation of `self`, suitable for debugging.
   public var debugDescription: String {
     return "Unsafe${Mutable}BufferPointer"
-      + "(start: \(_position.map(String.init(_:)) ?? "nil"), count: \(count))"
+      + "(start: \(_position.map(String.init(describing:)) ?? "nil"), count: \(count))"
   }
 }
 %end

--- a/test/1_stdlib/Unicode.swift
+++ b/test/1_stdlib/Unicode.swift
@@ -57,4 +57,12 @@ UnicodeAPIs.test("UnicodeDecodingResult/Equatable") {
   checkEquatable(instances, oracle: ==)
 }
 
+let UnicodeScalarTests = TestSuite("UnicodeScalar")
+
+UnicodeScalarTests.test("lossless conversion") {
+  let scalar: UnicodeScalar = "a"
+  let actual = UnicodeScalar(String(scalar))
+  expectOptionalEqual(scalar, actual)
+}
+
 runAllTests()


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Continuation of the work started by @frootloops in #3212.
PR comments have been addressed.

More work needs to be performed to update all the tests to use the new `String.init(describing:)` instead of `String.init(_:)`.

Besides, as `UnicodeScalar.description` has been changed to return the integer value of a code point, `StaticString` now behaves in a weird way. Here is the example of this behavior from the REPL:

``` swift
(swift) let us: UnicodeScalar = "a"; us.description
// us : UnicodeScalar = "97"
// r0 : String = "5755"
```

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-1881](https://bugs.swift.org/browse/SR-1881))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
