### PR TITLE
Rename OutputStream to OutputStreamable [SE-0086]

### DIFF
--- a/docs/StringDesign.rst
+++ b/docs/StringDesign.rst
@@ -993,7 +993,7 @@ Building
 .. sidebar:: ``append``
 
    the ``append`` method is a consequence of ``String``\ 's
-   conformance to ``OutputStream``.  See the *Swift
+   conformance to ``TextOutputStream``.  See the *Swift
    formatting proposal* for details.
 
 :Swift:

--- a/docs/TextFormatting.rst
+++ b/docs/TextFormatting.rst
@@ -109,18 +109,18 @@ Design Details
 Output Streams
 ..............
 
-The most fundamental part of this design is ``OutputStream``, a thing
+The most fundamental part of this design is ``TextOutputStream``, a thing
 into which we can stream text: [#character1]_
 
 ::
 
-  protocol OutputStream {
+  protocol TextOutputStream {
     func append(_ text: String)
   }
 
-Every ``String`` can be used as an ``OutputStream`` directly::
+Every ``String`` can be used as an ``TextOutputStream`` directly::
 
-  extension String : OutputStream {
+  extension String : TextOutputStream {
     func append(_ text: String)
   }
 
@@ -142,7 +142,7 @@ need to declare conformance: simply give the type a ``debugFormat()``::
 
 Because ``String`` is a ``Streamable``, your implementation of
 ``debugFormat`` can just return a ``String``. If want to write
-directly to the ``OutputStream`` for efficiency reasons,
+directly to the ``TextOutputStream`` for efficiency reasons,
 (e.g. if your representation is huge), you can return a custom
 ``DebugRepresentation`` type.
 
@@ -197,11 +197,11 @@ implement::
 Because it's not always efficient to construct a ``String``
 representation before writing an object to a stream, we provide a
 ``Streamable`` protocol, for types that can write themselves into an
-``OutputStream``. Every ``Streamable`` is also a ``CustomStringConvertible``,
+``TextOutputStream``. Every ``Streamable`` is also a ``CustomStringConvertible``,
 naturally::
 
   protocol Streamable : CustomStringConvertible {
-    func writeTo<T: OutputStream>(_ target: [inout] T)
+    func writeTo<T: TextOutputStream>(_ target: [inout] T)
 
     // You'll never want to reimplement this
     func format() -> PrintRepresentation {
@@ -224,7 +224,7 @@ adds surrounding quotes and escapes special characters::
   struct EscapedStringRepresentation : Streamable {
     var _value: String
 
-    func writeTo<T: OutputStream>(_ target: [inout] T) {
+    func writeTo<T: TextOutputStream>(_ target: [inout] T) {
       target.append("\"")
       for c in _value {
         target.append(c.escape())
@@ -233,11 +233,11 @@ adds surrounding quotes and escapes special characters::
     }
   }
 
-Besides modeling ``OutputStream``, ``String`` also conforms to
+Besides modeling ``TextOutputStream``, ``String`` also conforms to
 ``Streamable``::
 
   extension String : Streamable {
-    func writeTo<T: OutputStream>(_ target: [inout] T) {
+    func writeTo<T: TextOutputStream>(_ target: [inout] T) {
       target.append(self) // Append yourself to the stream
     }
 
@@ -275,12 +275,12 @@ complicated ``format(…)`` might be written::
   struct RadixFormat<T: CustomStringConvertibleInteger> : Streamable {
     var value: T, radix = 10, fill = " ", width = 0
 
-    func writeTo<S: OutputStream>(_ target: [inout] S) {
+    func writeTo<S: TextOutputStream>(_ target: [inout] S) {
       _writeSigned(value, &target)
     }
 
     // Write the given positive value to stream
-    func _writePositive<T:CustomStringConvertibleInteger, S: OutputStream>( 
+    func _writePositive<T:CustomStringConvertibleInteger, S: TextOutputStream>(
       _ value: T, stream: [inout] S
     ) -> Int {
       if value == 0 { return 0 }
@@ -293,7 +293,7 @@ complicated ``format(…)`` might be written::
       return nDigits + 1
     }
 
-    func _writeSigned<T:CustomStringConvertibleInteger, S: OutputStream>(
+    func _writeSigned<T:CustomStringConvertibleInteger, S: TextOutputStream>(
       _ value: T, target: [inout] S
     ) {
       var width = 0
@@ -333,15 +333,15 @@ considerable thought, they are included here for completeness and to
 ensure our proposed design doesn't rule out important directions of
 evolution.
 
-``OutputStream`` Adapters
+``TextOutputStream`` Adapters
 .........................
 
 Most text transformations can be expressed as adapters over generic
-``OutputStream``\ s. For example, it's easy to imagine an upcasing
+``TextOutputStream``\ s. For example, it's easy to imagine an upcasing
 adapter that transforms its input to upper case before writing it to
 an underlying stream::
 
-  struct UpperStream<UnderlyingStream:OutputStream> : OutputStream {
+  struct UpperStream<UnderlyingStream:TextOutputStream> : TextOutputStream {
     func append(_ x: String) { base.append(x.toUpper()) }
     var base: UnderlyingStream
   }
@@ -353,26 +353,26 @@ processed and written to the underlying stream:
 
 .. parsed-literal::
 
-  struct TrimStream<UnderlyingStream:OutputStream> : OutputStream {
+  struct TrimStream<UnderlyingStream:TextOutputStream> : TextOutputStream {
     func append(_ x: String) { ... }
     **func close() { ... }**
     var base: UnderlyingStream
     var bufferedWhitespace: String
   }
 
-This makes general ``OutputStream`` adapters more complicated to write
-and use than ordinary ``OutputStream``\ s.
+This makes general ``TextOutputStream`` adapters more complicated to write
+and use than ordinary ``TextOutputStream``\ s.
 
 ``Streamable`` Adapters
 .......................
 
-For every conceivable ``OutputStream`` adaptor there's a corresponding
+For every conceivable ``TextOutputStream`` adaptor there's a corresponding
 ``Streamable`` adaptor. For example::
 
   struct UpperStreamable<UnderlyingStreamable:Streamable> {
     var base: UnderlyingStreamable
 
-    func writeTo<T: OutputStream>(_ target: [inout] T) {
+    func writeTo<T: TextOutputStream>(_ target: [inout] T) {
       var adaptedStream = UpperStream(target)
       self.base.writeTo(&adaptedStream)
       target = adaptedStream.base
@@ -418,12 +418,12 @@ least until we do, we opt not to trade away any CPU, memory, and
 power.
 
 If we were willing to say that only ``class``\ es can conform to
-``OutputStream``, we could eliminate the explicit ``[inout]`` where
-``OutputStream``\ s are passed around. Then, we'd simply need a
+``TextOutputStream``, we could eliminate the explicit ``[inout]`` where
+``TextOutputStream``\ s are passed around. Then, we'd simply need a
 ``class StringStream`` for creating ``String`` representations. It
-would also make ``OutputStream`` adapters a *bit* simpler to use
+would also make ``TextOutputStream`` adapters a *bit* simpler to use
 because you'd never need to "write back" explicitly onto the target
-stream. However, stateful ``OutputStream`` adapters would still need a
+stream. However, stateful ``TextOutputStream`` adapters would still need a
 ``close()`` method, which makes a perfect place to return a copy of
 the underlying stream, which can then be "written back":
 
@@ -431,7 +431,7 @@ the underlying stream, which can then be "written back":
 
   struct AdaptedStreamable<T:Streamable> {
     ...
-    func writeTo<Target: OutputStream>(_ target: [inout] Target) {
+    func writeTo<Target: TextOutputStream>(_ target: [inout] Target) {
       // create the stream that transforms the representation
       var adaptedTarget = adapt(target, adapter);
       // write the Base object to the target stream
@@ -444,7 +444,7 @@ the underlying stream, which can then be "written back":
   }
 
 We think anyone writing such adapters can handle the need for explicit
-write-back, and the ability to use ``String`` as an ``OutputStream``
+write-back, and the ability to use ``String`` as an ``TextOutputStream``
 without additionally allocating a ``StringStream`` on the heap seems
 to tip the balance in favor of the current design.
 

--- a/stdlib/private/SwiftPrivate/IO.swift
+++ b/stdlib/private/SwiftPrivate/IO.swift
@@ -81,7 +81,7 @@ public struct _FDInputStream {
   }
 }
 
-public struct _Stderr : OutputStream {
+public struct _Stderr : TextOutputStream {
   public init() {}
 
   public mutating func write(_ string: String) {
@@ -91,7 +91,7 @@ public struct _Stderr : OutputStream {
   }
 }
 
-public struct _FDOutputStream : OutputStream {
+public struct _FDOutputStream : TextOutputStream {
   public let fd: CInt
   public var isClosed: Bool = false
 

--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -158,7 +158,7 @@ public enum _DebuggerSupport {
     }
   }
 
-  internal static func printForDebuggerImpl<StreamType : OutputStream>(
+  internal static func printForDebuggerImpl<StreamType : TextOutputStream>(
     value: Any?,
     mirror: Mirror,
     name: String?,

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -73,6 +73,9 @@ public protocol TextOutputStream {
   mutating func write(_ string: String)
 }
 
+/// Temporary typealias
+public typealias OutputStream = TextOutputStream
+
 extension TextOutputStream {
   public mutating func _lock() {}
   public mutating func _unlock() {}

--- a/stdlib/public/core/Print.swift
+++ b/stdlib/public/core/Print.swift
@@ -82,7 +82,7 @@ public func debugPrint(
 /// - SeeAlso: `debugPrint`, `Streamable`, `CustomStringConvertible`,
 ///   `CustomDebugStringConvertible`
 @inline(__always)
-public func print<Target : OutputStream>(
+public func print<Target : TextOutputStream>(
   _ items: Any...,
   separator: String = " ",
   terminator: String = "\n",
@@ -103,7 +103,7 @@ public func print<Target : OutputStream>(
 /// - SeeAlso: `print`, `Streamable`, `CustomStringConvertible`,
 ///   `CustomDebugStringConvertible`
 @inline(__always)
-public func debugPrint<Target : OutputStream>(
+public func debugPrint<Target : TextOutputStream>(
   _ items: Any...,
   separator: String = " ",
   terminator: String = "\n",
@@ -116,7 +116,7 @@ public func debugPrint<Target : OutputStream>(
 @_versioned
 @inline(never)
 @_semantics("stdlib_binary_only")
-internal func _print<Target : OutputStream>(
+internal func _print<Target : TextOutputStream>(
   _ items: [Any],
   separator: String = " ",
   terminator: String = "\n",
@@ -136,7 +136,7 @@ internal func _print<Target : OutputStream>(
 @_versioned
 @inline(never)
 @_semantics("stdlib_binary_only")
-internal func _debugPrint<Target : OutputStream>(
+internal func _debugPrint<Target : TextOutputStream>(
   _ items: [Any],
   separator: String = " ",
   terminator: String = "\n",
@@ -164,15 +164,15 @@ public func debugPrint<T>(_: T, appendNewline: Bool = true) {}
 
 //===--- FIXME: Not working due to <rdar://22101775> ----------------------===//
 @available(*, unavailable, message: "Please use the 'to' label for the target stream: 'print((...), to: &...)'")
-public func print<T>(_: T, _: inout OutputStream) {}
+public func print<T>(_: T, _: inout TextOutputStream) {}
 @available(*, unavailable, message: "Please use the 'to' label for the target stream: 'debugPrint((...), to: &...))'")
-public func debugPrint<T>(_: T, _: inout OutputStream) {}
+public func debugPrint<T>(_: T, _: inout TextOutputStream) {}
 
 @available(*, unavailable, message: "Please use 'terminator: \"\"' instead of 'appendNewline: false' and use the 'to' label for the target stream: 'print((...), terminator: \"\", to: &...)'")
-public func print<T>(_: T, _: inout OutputStream, appendNewline: Bool = true) {}
+public func print<T>(_: T, _: inout TextOutputStream, appendNewline: Bool = true) {}
 @available(*, unavailable, message: "Please use 'terminator: \"\"' instead of 'appendNewline: false' and use the 'to' label for the target stream: 'debugPrint((...), terminator: \"\", to: &...)'")
 public func debugPrint<T>(
-  _: T, _: inout OutputStream, appendNewline: Bool = true
+  _: T, _: inout TextOutputStream, appendNewline: Bool = true
 ) {}
 //===----------------------------------------------------------------------===//
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/core/Reflection.swift
+++ b/stdlib/public/core/Reflection.swift
@@ -140,7 +140,7 @@ internal func _reflect<T>(_ x: T) -> _Mirror
 
 /// Dump an object's contents using its mirror to the specified output stream.
 @discardableResult
-public func dump<T, TargetStream : OutputStream>(
+public func dump<T, TargetStream : TextOutputStream>(
   _ value: T,
   to target: inout TargetStream,
   name: String? = nil,
@@ -183,7 +183,7 @@ public func dump<T>(
 }
 
 /// Dump an object's contents. User code should use dump().
-internal func _dump_unlocked<TargetStream : OutputStream>(
+internal func _dump_unlocked<TargetStream : TextOutputStream>(
   _ value: Any,
   to target: inout TargetStream,
   name: String?,
@@ -282,7 +282,7 @@ internal func _dump_unlocked<TargetStream : OutputStream>(
 
 /// Dump information about an object's superclass, given a mirror reflecting
 /// that superclass.
-internal func _dumpSuperclass_unlocked<TargetStream : OutputStream>(
+internal func _dumpSuperclass_unlocked<TargetStream : TextOutputStream>(
   mirror: Mirror,
   to target: inout TargetStream,
   indent: Int,

--- a/test/1_stdlib/Optional.swift
+++ b/test/1_stdlib/Optional.swift
@@ -353,7 +353,7 @@ class TestString : CustomStringConvertible, CustomDebugStringConvertible {
   }
 }
 class TestStream : Streamable {
-  func write<Target : OutputStream>(to target: inout Target) {
+  func write<Target : TextOutputStream>(to target: inout Target) {
     target.write("AStream")
   }
 }
@@ -368,7 +368,7 @@ func debugPrintStr<T>(_ a: T) -> String {
 // Furthermore, printing an Optional should always print the debug
 // description regardless of whether the wrapper type conforms to an
 // output stream protocol.
-OptionalTests.test("Optional OutputStream") {
+OptionalTests.test("Optional TextOutputStream") {
   let optNoString: TestNoString? = TestNoString()
   expectFalse(optNoString is CustomStringConvertible)
   expectFalse(canGenericCast(optNoString, CustomStringConvertible.self))

--- a/test/1_stdlib/PrintDiagnostics.swift
+++ b/test/1_stdlib/PrintDiagnostics.swift
@@ -4,7 +4,7 @@ var stream = ""
 
 print(3, &stream) // expected-error{{'&' used with non-inout argument of type 'Any'}}
 debugPrint(3, &stream) // expected-error{{'&' used with non-inout argument of type 'Any'}}
-print(3, &stream, appendNewline: false) // expected-error {{cannot pass immutable value as inout argument: implicit conversion from 'String' to 'OutputStream' requires a temporary}}
-debugPrint(3, &stream, appendNewline: false) // expected-error {{cannot pass immutable value as inout argument: implicit conversion from 'String' to 'OutputStream' requires a temporary}} 
+print(3, &stream, appendNewline: false) // expected-error {{cannot pass immutable value as inout argument: implicit conversion from 'String' to 'TextOutputStream' requires a temporary}}
+debugPrint(3, &stream, appendNewline: false) // expected-error {{cannot pass immutable value as inout argument: implicit conversion from 'String' to 'TextOutputStream' requires a temporary}}
 print(4, quack: 5) // expected-error {{argument labels '(_:, quack:)' do not match any available overloads}}
-// expected-note@-1{{overloads for 'print' exist with these partially matching parameter lists: (Any..., separator: String, terminator: String), (T, appendNewline: Bool), (T, inout OutputStream), (T, inout OutputStream, appendNewline: Bool)}}
+// expected-note@-1{{overloads for 'print' exist with these partially matching parameter lists: (Any..., separator: String, terminator: String), (T, appendNewline: Bool), (T, inout TextOutputStream), (T, inout TextOutputStream, appendNewline: Bool)}}

--- a/test/1_stdlib/Renames.swift
+++ b/test/1_stdlib/Renames.swift
@@ -295,10 +295,10 @@ func _Optional<T>(x: T) {
   _ = Optional<T>.Some(x) // expected-error {{'Some' has been renamed to 'some'}} {{19-23=some}} {{none}}
 }
 
-func _OutputStream() {
-  func fn<S : OutputStreamType>(_: S) {} // expected-error {{'OutputStreamType' has been renamed to 'OutputStream'}} {{15-31=OutputStream}} {{none}}
+func _TextOutputStream() {
+  func fn<S : OutputStreamType>(_: S) {} // expected-error {{'OutputStreamType' has been renamed to 'TextOutputStream'}} {{15-31=TextOutputStream}} {{none}}
 }
-func _OutputStream<S : Streamable, O : OutputStream>(s: S, o: O) {
+func _TextOutputStream<S : Streamable, O : TextOutputStream>(s: S, o: O) {
   var o = o
   s.writeTo(&o) // expected-error {{'writeTo' has been renamed to 'write(to:)'}} {{5-12=write}} {{13-13=to: }} {{none}}
 }
@@ -312,7 +312,7 @@ func _Print<T>(x: T) {
   debugPrint(x, appendNewline: true) // expected-error {{'debugPrint(_:appendNewline:)' is unavailable: Please use 'terminator: ""' instead of 'appendNewline: false': 'debugPrint((...), terminator: "")'}} {{none}}
 }
 
-func _Print<T, O : OutputStream>(x: T, o: O) {
+func _Print<T, O : TextOutputStream>(x: T, o: O) {
   // FIXME: Not working due to <rdar://22101775>
   //var o = o
   //print(x, &o) // xpected-error {{}} {{none}}

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -233,7 +233,7 @@ func someFuncUsingOldAttribute() { }
 
 
 // <rdar://problem/23853709> Compiler crash on call to unavailable "print"
-func OutputStreamTest(message: String, to: inout OutputStream) {
+func TextOutputStreamTest(message: String, to: inout TextOutputStream) {
   print(message, &to)  // expected-error {{'print' is unavailable: Please use the 'to' label for the target stream: 'print((...), to: &...)'}}
 }
 

--- a/validation-test/stdlib/Prototypes/PersistentVector.swift.gyb
+++ b/validation-test/stdlib/Prototypes/PersistentVector.swift.gyb
@@ -164,7 +164,7 @@ func _dumpRec(
   }
 }
 
-struct _Stdout : OutputStream {
+struct _Stdout : TextOutputStream {
   mutating func _lock() {
     _swift_stdlib_flockfile_stdout()
   }


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Per the accepted [SE-0086](https://github.com/apple/swift-evolution/blob/master/proposals/0086-drop-foundation-ns.md), rename the standard library `OutputStream` type to `OutputStreamable`. `NSOutputStream` will become `OutputStream` in a different commit.
#### Resolved bug number

rdar://27355220

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
