### PR TITLE
[SourceKit] Add test case for crash triggered in swift::constraints::ConstraintSystem::openGeneric(…)

### DIFF
--- a/validation-test/IDE/crashers/072-swift-constraints-constraintsystem-opengeneric.swift
+++ b/validation-test/IDE/crashers/072-swift-constraints-constraintsystem-opengeneric.swift
@@ -1,0 +1,6 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+e{protocol c{
+class A{let a{
+let a=B
+struct B<T{let b=#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 180
4  swift-ide-test  0x0000000000a19f12 swift::constraints::ConstraintSystem::openGeneric(swift::DeclContext*, swift::DeclContext*, llvm::ArrayRef<swift::GenericTypeParamType*>, llvm::ArrayRef<swift::Requirement>, bool, swift::constraints::ConstraintLocatorBuilder, llvm::DenseMap<swift::CanType, swift::TypeVariableType*, llvm::DenseMapInfo<swift::CanType>, llvm::detail::DenseMapPair<swift::CanType, swift::TypeVariableType*> >&) + 994
6  swift-ide-test  0x0000000000c76783 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 35
7  swift-ide-test  0x0000000000a1862e swift::constraints::ConstraintSystem::openType(swift::Type, swift::constraints::ConstraintLocatorBuilder, llvm::DenseMap<swift::CanType, swift::TypeVariableType*, llvm::DenseMapInfo<swift::CanType>, llvm::detail::DenseMapPair<swift::CanType, swift::TypeVariableType*> >&) + 78
10 swift-ide-test  0x0000000000bb7fd5 swift::Expr::walk(swift::ASTWalker&) + 69
11 swift-ide-test  0x0000000000930838 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) + 200
12 swift-ide-test  0x000000000096b3b3 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 371
13 swift-ide-test  0x0000000000971d52 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
14 swift-ide-test  0x0000000000972f07 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 343
15 swift-ide-test  0x000000000097311b swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
17 swift-ide-test  0x000000000097e79d swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3853
20 swift-ide-test  0x0000000000c3ae22 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 562
36 swift-ide-test  0x0000000000bb8384 swift::Decl::walk(swift::ASTWalker&) + 20
37 swift-ide-test  0x0000000000c500fe swift::SourceFile::walk(swift::ASTWalker&) + 174
38 swift-ide-test  0x0000000000c4f23f swift::ModuleDecl::walk(swift::ASTWalker&) + 79
39 swift-ide-test  0x0000000000c25e2b swift::DeclContext::walkContext(swift::ASTWalker&) + 187
40 swift-ide-test  0x00000000008ec518 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 136
41 swift-ide-test  0x00000000007a672d swift::CompilerInstance::performSema() + 3597
42 swift-ide-test  0x0000000000749d20 main + 34176
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl declaration 0x4e04dd0 at <INPUT-FILE>:3:1
2.  While type-checking expression at [<INPUT-FILE>:5:7 - line:5:7] RangeText="B"
```
