### PR TITLE
Runtime: Forward SwiftValue -description and -debugDescription to the boxed value.

### DIFF
--- a/stdlib/public/runtime/SwiftObject.h
+++ b/stdlib/public/runtime/SwiftObject.h
@@ -83,6 +83,15 @@ SWIFT_RUNTIME_EXPORT @interface SwiftObject<NSObject> {
 
 namespace swift {
 
+struct String { void *x, *y, *z; };
+
+/// Helper from the standard library for stringizing an arbitrary object.
+extern "C" SWIFT_CC(swift)
+void swift_getSummary(String *out, OpaqueValue *value, const Metadata *T);
+
+// Convert a Swift String to an NSString.
+NSString *convertStringToNSString(String *swiftString);
+
 #endif
   
 }

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -43,6 +43,7 @@
 #include <unordered_map>
 #if SWIFT_OBJC_INTEROP
 # import <CoreFoundation/CFBase.h> // for CFTypeID
+# import <Foundation/Foundation.h>
 # include <malloc/malloc.h>
 # include <dispatch/dispatch.h>
 #endif
@@ -91,20 +92,13 @@ static SwiftObject *_allocHelper(Class cls) {
     class_getInstanceSize(cls), mask));
 }
 
-// Helper from the standard library for stringizing an arbitrary object.
-namespace {
-  struct String { void *x, *y, *z; };
-}
-
-extern "C" void swift_getSummary(String *out, OpaqueValue *value,
-                                 const Metadata *T);
-
-static NSString *_getDescription(SwiftObject *obj) {
+NSString *swift::convertStringToNSString(String *swiftString) {
   typedef SWIFT_CC(swift) NSString *ConversionFn(void *sx, void *sy, void *sz);
 
   // Cached lookup of swift_convertStringToNSString, which is in Foundation.
-  static ConversionFn *convertStringToNSString = nullptr;
-  
+  static std::atomic<ConversionFn *> TheConvertStringToNSString(nullptr);
+  auto convertStringToNSString =
+    TheConvertStringToNSString.load(std::memory_order_relaxed);
   if (!convertStringToNSString) {
     convertStringToNSString = (ConversionFn *)(uintptr_t)
       dlsym(RTLD_DEFAULT, "swift_convertStringToNSString");
@@ -113,31 +107,25 @@ static NSString *_getDescription(SwiftObject *obj) {
     // ObjC interop is low.
     if (!convertStringToNSString)
       return @"SwiftObject";
+    
+    TheConvertStringToNSString.store(convertStringToNSString,
+                                     std::memory_order_relaxed);
   }
   
+  return convertStringToNSString(swiftString->x,
+                                 swiftString->y,
+                                 swiftString->z);
+}
+
+static NSString *_getDescription(SwiftObject *obj) {
   String tmp;
   swift_retain((HeapObject*)obj);
   swift_getSummary(&tmp, (OpaqueValue*)&obj, _swift_getClassOfAllocated(obj));
-  return [convertStringToNSString(tmp.x, tmp.y, tmp.z) autorelease];
+  return [convertStringToNSString(&tmp) autorelease];
 }
 
 static NSString *_getClassDescription(Class cls) {
-  typedef SWIFT_CC(swift) NSString *ConversionFn(Class cls);
-
-  // Cached lookup of NSStringFromClass, which is in Foundation.
-  static ConversionFn *NSStringFromClass_fn = nullptr;
-  
-  if (!NSStringFromClass_fn) {
-    NSStringFromClass_fn = (ConversionFn *)(uintptr_t)
-      dlsym(RTLD_DEFAULT, "NSStringFromClass");
-    // If Foundation hasn't loaded yet, fall back to returning the static string
-    // "SwiftObject". The likelihood of someone invoking +description without
-    // ObjC interop is low.
-    if (!NSStringFromClass_fn)
-      return @"SwiftObject";
-  }
-  
-  return NSStringFromClass_fn(cls);
+  return NSStringFromClass(cls);
 }
 
 

--- a/stdlib/public/runtime/SwiftValue.mm
+++ b/stdlib/public/runtime/SwiftValue.mm
@@ -180,6 +180,28 @@ SwiftValue *swift::getAsSwiftValue(id object) {
 }
 #pragma clang diagnostic pop
 
+static NSString *getValueDescription(SwiftValue *self) {
+  String tmp;
+  const Metadata *type;
+  const OpaqueValue *value;
+  std::tie(type, value) = getValueFromSwiftValue(self);
+  
+  // Copy the value, since it will be consumed by getSummary.
+  ValueBuffer copyBuf;
+  auto copy = type->vw_initializeBufferWithCopy(&copyBuf,
+                                              const_cast<OpaqueValue*>(value));
+  swift_getSummary(&tmp, copy, type);
+  type->vw_deallocateBuffer(&copyBuf);
+  return convertStringToNSString(&tmp);
+}
+
+- (NSString *)description {
+  return getValueDescription(self);
+}
+- (NSString *)debugDescription {
+  return getValueDescription(self);
+}
+
 // Private methods for debugging purposes.
 
 - (const Metadata *)_swiftTypeMetadata {
@@ -189,7 +211,7 @@ SwiftValue *swift::getAsSwiftValue(id object) {
   return getValueFromSwiftValue(self).second;
 }
 
-// TODO: Forward description, debugDescription, isEqual:, hash, etc. to
+// TODO: Forward isEqual: and hash to
 // corresponding operations on the boxed Swift type.
 
 @end

--- a/test/1_stdlib/BridgeIdAsAny.swift.gyb
+++ b/test/1_stdlib/BridgeIdAsAny.swift.gyb
@@ -32,6 +32,24 @@ func ==(a: KnownUnbridged, b: KnownUnbridged) -> Bool {
   return a.x === b.x && a.y === b.y
 }
 
+struct KnownUnbridgedWithDescription: CustomStringConvertible,
+                                      CustomDebugStringConvertible {
+  var x, y: LifetimeTracked
+
+  init() {
+    x = LifetimeTracked(17)
+    y = LifetimeTracked(38)
+  }
+
+  var description: String {
+    return "\(x)\(y), baby, hey"
+  }
+
+  var debugDescription: String {
+    return "KnownUnbridgedWithDescription(\"\(x)\(y)\" /* baby, hey */)"
+  }
+}
+
 func bridgedObjectPreservesIdentity(original: LifetimeTracked,
                                     bridged: AnyObject) {
   expectTrue(original === bridged)
@@ -114,5 +132,15 @@ BridgeAnything.test("${testName}") {
   expectEqual(0, LifetimeTracked.instances)
 }
 % end
+
+BridgeAnything.test("description of boxed values") {
+  for x in [KnownUnbridged(), KnownUnbridgedWithDescription()] as [Any] {
+    let summary = String(reflecting: x)
+    expectEqual(summary, _bridgeAnythingToObjectiveC(x).description)
+    expectEqual(summary, _bridgeAnythingToObjectiveC(x).debugDescription)
+  }
+
+  expectEqual(0, LifetimeTracked.instances)
+}
 
 runAllTests()


### PR DESCRIPTION
Following the example of SwiftObject, use swift_getSummary to get the description string for a Swift value as the description of a boxed SwiftValue.
