### PR TITLE
Rename UnsafePointer assign/initialize and eliminate Backward variants.

### DIFF
--- a/benchmark/single-source/PopFront.swift
+++ b/benchmark/single-source/PopFront.swift
@@ -45,7 +45,7 @@ public func run_PopFrontUnsafePointer(_ N: Int) {
       var count = arrayCount
       while count != 0 {
         result += a[0]
-        a.assignFrom(a + 1, count: count - 1)
+        a.assign(from: a + 1, count: count - 1)
         count -= 1
       }
       CheckResults(result == arrayCount, "IncorrectResults in StringInterpolation: \(result) != \(arrayCount)")

--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -153,7 +153,7 @@ extension _ArrayBufferProtocol where Index == Int {
     if growth > 0 {
       // Slide the tail part of the buffer forwards, in reverse order
       // so as not to self-clobber.
-      newTailStart.moveInitializeBackwardFrom(oldTailStart, count: tailCount)
+      newTailStart.moveInitialize(from: oldTailStart, count: tailCount)
 
       // Assign over the original subRange
       var i = newValues.startIndex
@@ -190,15 +190,15 @@ extension _ArrayBufferProtocol where Index == Int {
 
         // Assign over the rest of the replaced range with the first
         // part of the tail.
-        newTailStart.moveAssignFrom(oldTailStart, count: shrinkage)
+        newTailStart.moveAssign(from: oldTailStart, count: shrinkage)
 
         // Slide the rest of the tail back
-        oldTailStart.moveInitializeFrom(
-          oldTailStart + shrinkage, count: tailCount - shrinkage)
+        oldTailStart.moveInitialize(
+          from: oldTailStart + shrinkage, count: tailCount - shrinkage)
       }
       else {                      // Tail fits within erased elements
         // Assign over the start of the replaced range with the tail
-        newTailStart.moveAssignFrom(oldTailStart, count: tailCount)
+        newTailStart.moveAssign(from: oldTailStart, count: tailCount)
 
         // Destroy elements remaining after the tail in subRange
         (newTailStart + tailCount).deinitialize(

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1333,7 +1333,7 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
       Swift.max(newCount, _growArrayCapacity(capacity))
       : newCount)
 
-    (self._buffer.firstElementAddress + oldCount).initializeFrom(newElements)
+    (self._buffer.firstElementAddress + oldCount).initialize(from: newElements)
     self._buffer.count = newCount
   }
 
@@ -1888,7 +1888,7 @@ internal func _arrayOutOfPlaceUpdate<_Buffer, Initializer>(
     backingStart.deinitialize(count: sourceOffset)
 
     // Move the head items
-    destStart.moveInitializeFrom(sourceStart, count: headCount)
+    destStart.moveInitialize(from: sourceStart, count: headCount)
 
     // Destroy unused source items
     oldStart.deinitialize(count: oldCount)
@@ -1896,7 +1896,7 @@ internal func _arrayOutOfPlaceUpdate<_Buffer, Initializer>(
     initializeNewElements.call(newStart, count: newCount)
 
     // Move the tail items
-    newEnd.moveInitializeFrom(oldStart + oldCount, count: tailCount)
+    newEnd.moveInitialize(from: oldStart + oldCount, count: tailCount)
 
     // Destroy any items that may be lurking in a _SliceBuffer after
     // its real last element

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1674,7 +1674,7 @@ extension Sequence
   ) -> UnsafeMutablePointer<Iterator.Element> {
     if let s = self._baseAddressIfContiguous {
       let count = self.count
-      ptr.initializeFrom(s, count: count)
+      ptr.initialize(from: s, count: count)
       _fixLifetime(self._owner)
       return ptr + count
     } else {

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -384,9 +384,8 @@ struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
     _sanityCheck(bounds.upperBound <= count)
 
     let initializedCount = bounds.upperBound - bounds.lowerBound
-    target.initializeFrom(
-      firstElementAddress + bounds.lowerBound,
-      count: initializedCount)
+    target.initialize(
+      from: firstElementAddress + bounds.lowerBound, count: initializedCount)
     _fixLifetime(owner)
     return target + initializedCount
   }
@@ -507,18 +506,18 @@ public func += <Element, C : Collection>(
 
   if _fastPath(newCount <= lhs.capacity) {
     lhs.count = newCount
-    (lhs.firstElementAddress + oldCount).initializeFrom(rhs)
+    (lhs.firstElementAddress + oldCount).initialize(from: rhs)
   }
   else {
     var newLHS = _ContiguousArrayBuffer<Element>(
       uninitializedCount: newCount,
       minimumCapacity: _growArrayCapacity(lhs.capacity))
 
-    newLHS.firstElementAddress.moveInitializeFrom(
-      lhs.firstElementAddress, count: oldCount)
+    newLHS.firstElementAddress.moveInitialize(
+      from: lhs.firstElementAddress, count: oldCount)
     lhs.count = 0
     swap(&lhs, &newLHS)
-    (lhs.firstElementAddress + oldCount).initializeFrom(rhs)
+    (lhs.firstElementAddress + oldCount).initialize(from: rhs)
   }
 }
 
@@ -653,9 +652,8 @@ internal struct _UnsafePartiallyInitializedContiguousArrayBuffer<Element> {
         uninitializedCount: newCapacity, minimumCapacity: 0)
       p = newResult.firstElementAddress + result.capacity
       remainingCapacity = newResult.capacity - result.capacity
-      newResult.firstElementAddress.moveInitializeFrom(
-        result.firstElementAddress,
-        count: result.capacity)
+      newResult.firstElementAddress.moveInitialize(
+        from: result.firstElementAddress, count: result.capacity)
       result.count = 0
       swap(&result, &newResult)
     }

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -190,7 +190,7 @@ struct _SliceBuffer<Element> : _ArrayBufferProtocol, RandomAccessCollection {
     _sanityCheck(bounds.upperBound >= bounds.lowerBound)
     _sanityCheck(bounds.upperBound <= endIndex)
     let c = bounds.count
-    target.initializeFrom(subscriptBaseAddress + bounds.lowerBound, count: c)
+    target.initialize(from: subscriptBaseAddress + bounds.lowerBound, count: c)
     return target + c
   }
 
@@ -338,8 +338,8 @@ extension _SliceBuffer {
     let result = _ContiguousArrayBuffer<Element>(
       uninitializedCount: count,
       minimumCapacity: 0)
-    result.firstElementAddress.initializeFrom(
-      firstElementAddress, count: count)
+    result.firstElementAddress.initialize(
+      from: firstElementAddress, count: count)
     return ContiguousArray(_buffer: result)
   }
 }

--- a/stdlib/public/core/StringCore.swift
+++ b/stdlib/public/core/StringCore.swift
@@ -623,8 +623,8 @@ extension _StringCore : RangeReplaceableCollection {
       let tailStart = rangeStart + (replacedCount << elementShift)
 
       if growth > 0 {
-        (tailStart + (growth << elementShift)).assignBackwardFrom(
-          tailStart, count: tailCount << elementShift)
+        (tailStart + (growth << elementShift)).assign(
+          from: tailStart, count: tailCount << elementShift)
       }
 
       if _fastPath(elementWidth == 1) {
@@ -643,8 +643,8 @@ extension _StringCore : RangeReplaceableCollection {
       }
 
       if growth < 0 {
-        (tailStart + (growth << elementShift)).assignFrom(
-          tailStart, count: tailCount << elementShift)
+        (tailStart + (growth << elementShift)).assign(
+          from: tailStart, count: tailCount << elementShift)
       }
     }
     else {

--- a/stdlib/public/core/SwiftNativeNSArray.swift
+++ b/stdlib/public/core/SwiftNativeNSArray.swift
@@ -84,7 +84,7 @@ extension _SwiftNativeNSArrayWithContiguousStorage : _NSArrayCore {
 
       // These objects are "returned" at +0, so treat them as values to
       // avoid retains.
-      UnsafeMutablePointer<Int>(aBuffer).initializeFrom(
+      UnsafeMutablePointer<Int>(aBuffer).initialize(from: 
         UnsafeMutablePointer(objects.baseAddress! + range.location),
         count: range.length)
     }

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -197,63 +197,36 @@ public struct ${Self}<Pointee>
   }
 
   /// Replace `count` initialized `Pointee`s starting at `self` with
-  /// the `count` `Pointee`s at `source`, proceeding forward from
-  /// `self` to `self + count - 1`.
+  /// the `count` `Pointee`s at `source`.
   ///
   /// - Precondition: `count >= 0`
   ///
-  /// - Precondition: `self` either precedes `source` or follows
-  ///   `source + count - 1`.
-  ///
   /// - Precondition: The `Pointee`s at `self..<self + count` and
   ///   `source..<source + count` are initialized.
-  public func assignFrom(_ source: UnsafePointer<Pointee>, count: Int) {
+  public func assign(from source: UnsafePointer<Pointee>, count: Int) {
     _debugPrecondition(
-      count >= 0, "${Self}.assignFrom with negative count")
-    _debugPrecondition(
-      UnsafePointer(self) < source || UnsafePointer(self) >= source + count,
-      "assignFrom non-following overlapping range; use assignBackwardFrom")
-    for i in 0..<count {
-      self[i] = source[i]
+      count >= 0, "${Self}.assign with negative count")
+    if UnsafePointer(self) < source || UnsafePointer(self) >= source + count {
+      // assign forward from a disjoint or following overlapping range.
+      for i in 0..<count {
+        self[i] = source[i]
+      }
     }
-  }
-
-  /// Replace `count` initialized `Pointee`s starting at `self` with
-  /// the `count` `Pointee`s at `source`, proceeding backward from
-  /// `self + count - 1` to `self`.
-  ///
-  /// Use `assignBackwardFrom` when copying elements into later memory
-  /// that may overlap with the source range.
-  ///
-  /// - Precondition: `count >= 0`
-  ///
-  /// - Precondition: `source` either precedes `self` or follows
-  ///   `self + count - 1`.
-  ///
-  /// - Precondition: The `Pointee`s at `self..<self + count` and
-  ///   `source..<source + count` are initialized.
-  public func assignBackwardFrom(_ source: UnsafePointer<Pointee>, count: Int) {
-    _debugPrecondition(
-      count >= 0, "${Self}.assignBackwardFrom with negative count")
-    _debugPrecondition(
-      source < UnsafePointer(self) || source >= UnsafePointer(self) + count,
-      "${Self}.assignBackwardFrom non-preceding overlapping range; use assignFrom instead")
-    var i = count-1
-    while i >= 0 {
-      self[i] = source[i]
-      i -= 1
+    else {
+      // assign backward from a non-following overlapping range.
+      var i = count-1
+      while i >= 0 {
+        self[i] = source[i]
+        i -= 1
+      }
     }
   }
 
   /// Initialize memory starting at `self` with `count` `Pointee`s
-  /// beginning at `source`, proceeding forward from `self` to `self +
-  /// count - 1`, and returning the source memory to an uninitialized
-  /// state.
+  /// beginning at `source`, and returning the source memory to an
+  /// uninitialized state.
   ///
   /// - Precondition: `count >= 0`
-  ///
-  /// - Precondition: `self` either precedes `source` or follows `source +
-  ///   count - 1`.
   ///
   /// - Precondition: The memory at `self..<self + count` is uninitialized
   ///   and the `Pointees` at `source..<source + count` are
@@ -262,51 +235,29 @@ public struct ${Self}<Pointee>
   /// - Postcondition: The `Pointee`s at `self..<self + count` are
   ///   initialized and the memory at `source..<source + count` is
   ///   uninitialized.
-  public func moveInitializeFrom(_ source: ${Self}, count: Int) {
+  public func moveInitialize(from source: ${Self}, count: Int) {
     _debugPrecondition(
-      count >= 0, "${Self}.moveInitializeFrom with negative count")
-    _debugPrecondition(
-      self < source || self >= source + count,
-      "${Self}.moveInitializeFrom non-following overlapping range; use moveInitializeBackwardFrom")
-    Builtin.takeArrayFrontToBack(
-      Pointee.self, self._rawValue, source._rawValue, count._builtinWordValue)
-    // This builtin is equivalent to:
-    // for i in 0..<count {
-    //   (self + i).initialize(with: (source + i).move())
-    // }
-  }
-
-  /// Initialize memory starting at `self` with `count` `Pointee`s
-  /// beginning at `source`, proceeding backward from `self + count - 1`
-  /// to `self`, and returning the source memory to an uninitialized
-  /// state.
-  ///
-  /// - Precondition: `count >= 0`
-  ///
-  /// - Precondition: `source` either precedes `self` or follows
-  ///   `self + count - 1`.
-  ///
-  /// - Precondition: The memory at `self..<self + count` is uninitialized
-  ///   and the `Pointees` at `source..<source + count` are
-  ///   initialized.
-  ///
-  /// - Postcondition: The `Pointee`s at `self..<self + count` are
-  ///   initialized and the memory at `source..<source + count` is
-  ///   uninitialized.
-  public func moveInitializeBackwardFrom(_ source: ${Self}, count: Int) {
-    _debugPrecondition(
-      count >= 0, "${Self}.moveInitializeBackwardFrom with negative count")
-    _debugPrecondition(
-      source < self || source >= self + count,
-      "${Self}.moveInitializeBackwardFrom non-preceding overlapping range; use moveInitializeFrom instead")
-    Builtin.takeArrayBackToFront(
-      Pointee.self, self._rawValue, source._rawValue, count._builtinWordValue)
-    // This builtin is equivalent to:
-    // var src = source + count
-    // var dst = self + count
-    // while dst != self {
-    //   (--dst).initialize(with: (--src).move())
-    // }
+      count >= 0, "${Self}.moveInitialize with negative count")
+    if self < source || self >= source + count {
+      // initialize forward from a disjoint or following overlapping range.
+      Builtin.takeArrayFrontToBack(
+        Pointee.self, self._rawValue, source._rawValue, count._builtinWordValue)
+      // This builtin is equivalent to:
+      // for i in 0..<count {
+      //   (self + i).initialize(with: (source + i).move())
+      // }
+    }
+    else {
+      // initialize backward from a non-following overlapping range.
+      Builtin.takeArrayBackToFront(
+        Pointee.self, self._rawValue, source._rawValue, count._builtinWordValue)
+      // This builtin is equivalent to:
+      // var src = source + count
+      // var dst = self + count
+      // while dst != self {
+      //   (--dst).initialize(with: (--src).move())
+      // }
+    }
   }
 
   /// Initialize memory starting at `self` with `count` `Pointee`s
@@ -315,8 +266,8 @@ public struct ${Self}<Pointee>
   ///
   /// - Precondition: `count >= 0`
   ///
-  /// - Precondition: `self` either precedes `source` or follows `source +
-  ///   count - 1`.
+  /// - Precondition: The memory regions `source..<source + count`
+  ///   and `self..<self + count` do not overlap.
   ///
   /// - Precondition: The memory at `self..<self + count` is uninitialized
   ///   and the `Pointees` at `source..<source + count` are
@@ -324,13 +275,13 @@ public struct ${Self}<Pointee>
   ///
   /// - Postcondition: The `Pointee`s at `self..<self + count` and
   ///   `source..<source + count` are initialized.
-  public func initializeFrom(_ source: UnsafePointer<Pointee>, count: Int) {
+  public func initialize(from source: UnsafePointer<Pointee>, count: Int) {
     _debugPrecondition(
-      count >= 0, "${Self}.initializeFrom with negative count")
+      count >= 0, "${Self}.initialize with negative count")
     _debugPrecondition(
       UnsafePointer(self) + count <= source || 
       source + count <= UnsafePointer(self),
-      "${Self}.initializeFrom non-following overlapping range")
+      "${Self}.initialize overlapping range")
     Builtin.copyArray(
       Pointee.self, self._rawValue, source._rawValue, count._builtinWordValue)
     // This builtin is equivalent to:
@@ -346,7 +297,7 @@ public struct ${Self}<Pointee>
   ///
   /// - Postcondition: The `Pointee`s at `self..<self + count` are
   ///   initialized.
-  public func initializeFrom<C : Collection>(_ source: C)
+  public func initialize<C : Collection>(from source: C)
     where C.Iterator.Element == Pointee {
     source._copyContents(initializing: self)
   }
@@ -357,7 +308,8 @@ public struct ${Self}<Pointee>
   ///
   /// - Precondition: `count >= 0`
   ///
-  /// - Precondition: The source and destination ranges do not overlap
+  /// - Precondition: The memory regions `source..<source + count`
+  ///   and `self..<self + count` do not overlap.
   ///
   /// - Precondition: The `Pointee`s at `self..<self + count` and
   ///   `source..<source + count` are initialized.
@@ -365,12 +317,12 @@ public struct ${Self}<Pointee>
   /// - Postcondition: The `Pointee`s at `self..<self + count` are
   ///   initialized and the `Pointees` at `source..<source + count`
   ///   are uninitialized.
-  public func moveAssignFrom(_ source: ${Self}, count: Int) {
+  public func moveAssign(from source: ${Self}, count: Int) {
     _debugPrecondition(
       count >= 0, "${Self}.moveAssignFrom with negative count")
     _debugPrecondition(
       self + count <= source || source + count <= self,
-      "moveAssignFrom overlapping range")
+      "moveAssign overlapping range")
     Builtin.destroyArray(Pointee.self, self._rawValue, count._builtinWordValue)
     Builtin.takeArrayFrontToBack(
       Pointee.self, self._rawValue, source._rawValue, count._builtinWordValue)
@@ -571,6 +523,37 @@ extension ${Self} {
 
   @available(*, unavailable, renamed: "deinitialize(count:)")
   public func destroy(_ count: Int) {
+    Builtin.unreachable()
+  }
+
+  @available(*, unavailable, renamed: "initialize(from:count:)")
+  public func initializeFrom(_ source: UnsafePointer<Pointee>, count: Int) {
+    Builtin.unreachable()
+  }
+
+  @available(*, unavailable, renamed: "assign(from:count:)")
+  public func assignFrom(_ source: UnsafePointer<Pointee>, count: Int) {
+    Builtin.unreachable()
+  }
+
+  @available(*, unavailable, renamed: "assign(from:count:)")
+  public func assignBackwardFrom(_ source: UnsafePointer<Pointee>, count: Int) {
+    Builtin.unreachable()
+  }
+
+  @available(*, unavailable, renamed: "moveInitialize(from:count:)")
+  public func moveInitializeFrom(_ source: UnsafePointer<Pointee>, count: Int) {
+    Builtin.unreachable()
+  }
+
+  @available(*, unavailable, renamed: "moveInitialize(from:count:)")
+  public func moveInitializeBackwardFrom(_ source: UnsafePointer<Pointee>,
+    count: Int) {
+    Builtin.unreachable()
+  }
+  
+  @available(*, unavailable, renamed: "moveAssign(from:count:)")
+  public func moveAssignFrom(_ source: UnsafePointer<Pointee>, count: Int) {
     Builtin.unreachable()
   }
 % end

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -113,7 +113,7 @@ public func _encodeBitsAsWords<T : CVarArg>(_ x: T) -> [Int] {
     count: (sizeof(T.self) + sizeof(Int.self) - 1) / sizeof(Int.self))
   _sanityCheck(result.count > 0)
   var tmp = x
-  // FIXME: use UnsafeMutablePointer.assignFrom() instead of memcpy.
+  // FIXME: use UnsafeMutablePointer.assign(from:) instead of memcpy.
   _memcpy(dest: UnsafeMutablePointer(result._baseAddressIfContiguous!),
           src: UnsafeMutablePointer(Builtin.addressof(&tmp)),
           size: UInt(sizeof(T.self)))
@@ -336,7 +336,7 @@ final internal class _VaListBuilder {
       // count is updated below
 
       if let allocatedOldStorage = oldStorage {
-        newStorage.moveInitializeFrom(allocatedOldStorage, count: oldCount)
+        newStorage.moveInitialize(from: allocatedOldStorage, count: oldCount)
         deallocStorage(wordCount: oldAllocated, storage: allocatedOldStorage)
       }
     }

--- a/test/1_stdlib/Renames.swift
+++ b/test/1_stdlib/Renames.swift
@@ -504,6 +504,20 @@ func _UnsafePointer<T>(x: UnsafeMutablePointer<T>, e: T) {
   x.initialize(e) // expected-error {{'initialize' has been renamed to 'initialize(with:)'}} {{5-15=initialize}} {{16-16=with: }} {{none}}
   x.destroy() // expected-error {{'destroy()' has been renamed to 'deinitialize(count:)'}} {{5-12=deinitialize}} {{none}}
   x.destroy(1) // expected-error {{'destroy' has been renamed to 'deinitialize(count:)'}} {{5-12=deinitialize}} {{13-13=count: }} {{none}}
+
+  let ptr1 = UnsafeMutablePointer<T>(allocatingCapacity: 1)
+  ptr1.initialize(with: e, count: 1)
+  let ptr2 = UnsafeMutablePointer<T>(allocatingCapacity: 1)
+  ptr2.initializeFrom(ptr1, count: 1) // expected-error {{'initializeFrom(_:count:)' has been renamed to 'initialize(from:count:)'}}
+  ptr1.assignFrom(ptr2, count: 1) // expected-error {{'assignFrom(_:count:)' has been renamed to 'assign(from:count:)'}}
+  ptr1.assignFrom(ptr2, count: 1) // expected-error {{'assignFrom(_:count:)' has been renamed to 'assign(from:count:)'}}
+  ptr2.assignBackwardFrom(ptr1, count: 1) // expected-error {{'assignBackwardFrom(_:count:)' has been renamed to 'assign(from:count:)'}}
+  ptr1.moveAssignFrom(ptr2, count: 1) // expected-error {{'moveAssignFrom(_:count:)' has been renamed to 'moveAssign(from:count:)'}}
+  ptr2.moveInitializeFrom(ptr1, count: 1) // expected-error {{'moveInitializeFrom(_:count:)' has been renamed to 'moveInitialize(from:count:)'}}
+  ptr1.moveInitializeBackwardFrom(ptr1, count: 1) // expected-error {{'moveInitializeBackwardFrom(_:count:)' has been renamed to 'moveInitialize(from:count:)'}}
+  ptr1.deinitialize(count:1)
+  ptr1.deallocateCapacity(1)
+  ptr2.deallocateCapacity(1)
 }
 
 func _VarArgs() {

--- a/test/1_stdlib/UnsafePointer.swift.gyb
+++ b/test/1_stdlib/UnsafePointer.swift.gyb
@@ -251,20 +251,8 @@ func checkPtr(
   }
 }
 
-UnsafeMutablePointerTestSuite.test("moveInitializeBackwardFrom") {
-  let check = checkPtr(UnsafeMutablePointer.moveInitializeBackwardFrom, false)
-  check(Check.RightOverlap)
-  check(Check.Disjoint)
-
-  // This check relies on _debugPrecondition() so will only trigger in -Onone mode.
-  if _isDebugAssertConfiguration() {
-    expectCrashLater()
-    check(Check.LeftOverlap)
-  }
-}
-
-UnsafeMutablePointerTestSuite.test("moveAssignFrom") {
-  let check = checkPtr(UnsafeMutablePointer.moveAssignFrom, true)
+UnsafeMutablePointerTestSuite.test("moveAssign:from") {
+  let check = checkPtr(UnsafeMutablePointer.moveAssign, true)
   check(Check.Disjoint)
   // This check relies on _debugPrecondition() so will only trigger in -Onone mode.
   if _isDebugAssertConfiguration() {
@@ -273,8 +261,8 @@ UnsafeMutablePointerTestSuite.test("moveAssignFrom") {
   }
 }
 
-UnsafeMutablePointerTestSuite.test("moveAssignFrom.Right") {
-  let check = checkPtr(UnsafeMutablePointer.moveAssignFrom, true)
+UnsafeMutablePointerTestSuite.test("moveAssign:from.Right") {
+  let check = checkPtr(UnsafeMutablePointer.moveAssign, true)
   // This check relies on _debugPrecondition() so will only trigger in -Onone mode.
   if _isDebugAssertConfiguration() {
     expectCrashLater()
@@ -282,41 +270,22 @@ UnsafeMutablePointerTestSuite.test("moveAssignFrom.Right") {
   }
 }
 
-UnsafeMutablePointerTestSuite.test("assignFrom") {
-  let check = checkPtr(UnsafeMutablePointer.assignFrom, true)
+UnsafeMutablePointerTestSuite.test("assign:from") {
+  let check = checkPtr(UnsafeMutablePointer.assign, true)
   check(Check.LeftOverlap)
   check(Check.Disjoint)
-  // This check relies on _debugPrecondition() so will only trigger in -Onone mode.
-  if _isDebugAssertConfiguration() {
-    expectCrashLater()
-    check(Check.RightOverlap)
-  }
-}
-
-UnsafeMutablePointerTestSuite.test("assignBackwardFrom") {
-  let check = checkPtr(UnsafeMutablePointer.assignBackwardFrom, true)
   check(Check.RightOverlap)
-  check(Check.Disjoint)
-  // This check relies on _debugPrecondition() so will only trigger in -Onone mode.
-  if _isDebugAssertConfiguration() {
-    expectCrashLater()
-    check(Check.LeftOverlap)
-  }
 }
 
-UnsafeMutablePointerTestSuite.test("moveInitializeFrom") {
-  let check = checkPtr(UnsafeMutablePointer.moveInitializeFrom, false)
+UnsafeMutablePointerTestSuite.test("moveInitialize:from") {
+  let check = checkPtr(UnsafeMutablePointer.moveInitialize, false)
   check(Check.LeftOverlap)
   check(Check.Disjoint)
-  // This check relies on _debugPrecondition() so will only trigger in -Onone mode.
-  if _isDebugAssertConfiguration() {
-    expectCrashLater()
-    check(Check.RightOverlap)
-  }
+  check(Check.RightOverlap)
 }
 
-UnsafeMutablePointerTestSuite.test("initializeFrom") {
-  let check = checkPtr(UnsafeMutablePointer.initializeFrom, false)
+UnsafeMutablePointerTestSuite.test("initialize:from") {
+  let check = checkPtr(UnsafeMutablePointer.initialize(from:count:), false)
   check(Check.Disjoint)
   // This check relies on _debugPrecondition() so will only trigger in -Onone mode.
   if _isDebugAssertConfiguration() {
@@ -325,8 +294,8 @@ UnsafeMutablePointerTestSuite.test("initializeFrom") {
   }
 }
 
-UnsafeMutablePointerTestSuite.test("initializeFrom.Right") {
-  let check = checkPtr(UnsafeMutablePointer.initializeFrom, false)
+UnsafeMutablePointerTestSuite.test("initialize:from.Right") {
+  let check = checkPtr(UnsafeMutablePointer.initialize(from:count:), false)
   // This check relies on _debugPrecondition() so will only trigger in -Onone mode.
   if _isDebugAssertConfiguration() {
     expectCrashLater()
@@ -334,7 +303,7 @@ UnsafeMutablePointerTestSuite.test("initializeFrom.Right") {
   }
 }
 
-UnsafeMutablePointerTestSuite.test("initializeFrom/immutable") {  
+UnsafeMutablePointerTestSuite.test("initialize:from/immutable") {
   var ptr = UnsafeMutablePointer<Missile>(allocatingCapacity: 3)
   defer {
     ptr.deinitialize(count: 3)
@@ -342,16 +311,14 @@ UnsafeMutablePointerTestSuite.test("initializeFrom/immutable") {
   }
   let source = (0..<3).map(Missile.init)
   source.withUnsafeBufferPointer { bufferPtr in
-    ptr.initializeFrom(bufferPtr.baseAddress!, count: 3)
+    ptr.initialize(from: bufferPtr.baseAddress!, count: 3)
     expectEqual(0, ptr[0].number)
     expectEqual(1, ptr[1].number)
     expectEqual(2, ptr[2].number)
   }
 }
 
-% for assign in ['assignFrom', 'assignBackwardFrom']:
-
-UnsafeMutablePointerTestSuite.test("${assign}/immutable") {  
+UnsafeMutablePointerTestSuite.test("assign/immutable") {
   var ptr = UnsafeMutablePointer<Missile>(allocatingCapacity: 2)
   defer {
     ptr.deinitialize(count: 2)
@@ -361,13 +328,11 @@ UnsafeMutablePointerTestSuite.test("${assign}/immutable") {
   (ptr + 1).initialize(with: Missile(2))
   let source = (3..<5).map(Missile.init)
   source.withUnsafeBufferPointer { bufferPtr in
-    ptr.${assign}(bufferPtr.baseAddress!, count: 2)
+    ptr.assign(from: bufferPtr.baseAddress!, count: 2)
     expectEqual(3, ptr[0].number)
     expectEqual(4, ptr[1].number)
   }
 }
-
-% end
 
 UnsafePointerTestSuite.test("customMirror") {
   // Ensure that the custom mirror works properly, including when the raw value

--- a/validation-test/stdlib/Prototypes/PersistentVector.swift.gyb
+++ b/validation-test/stdlib/Prototypes/PersistentVector.swift.gyb
@@ -503,7 +503,7 @@ struct _PVSparseVectorNodePointer<Key : Hashable, Value>
   func initializeChildNodes(
     from newChildNodes: UnsafeMutablePointer<_PVAnyNodePointer<Key, Value>?>
   ) {
-    _childNodeVector.initializeFrom(newChildNodes, count: childNodeCount)
+    _childNodeVector.initialize(from: newChildNodes, count: childNodeCount)
     for childNode in childNodes {
       childNode!.retain()
     }
@@ -520,7 +520,7 @@ struct _PVSparseVectorNodePointer<Key : Hashable, Value>
     precondition(bucket >= 0 && bucket < 32) // sanity check
     let i = childNodePopulationBitmap.countBitsSetBelow(bucket)
     let childNodeVector = _childNodeVector
-    childNodeVector.initializeFrom(newChildNodes, count: i)
+    childNodeVector.initialize(from: newChildNodes, count: i)
     for childNode in
       UnsafeMutableBufferPointer(
         start: childNodeVector, count: i)
@@ -531,7 +531,7 @@ struct _PVSparseVectorNodePointer<Key : Hashable, Value>
     childNodeVector[i] = newChildNode
 
     let destPointer = childNodeVector + i + 1
-    destPointer.initializeFrom(
+    destPointer.initialize(from: 
       newChildNodes + i + 1, count: childNodeCount - i - 1)
     for childNode in
       UnsafeMutableBufferPointer(
@@ -552,7 +552,7 @@ struct _PVSparseVectorNodePointer<Key : Hashable, Value>
     precondition(bucket >= 0 && bucket < 32) // sanity check
     let i = childNodePopulationBitmap.countBitsSetBelow(bucket)
     let childNodeVector = _childNodeVector
-    childNodeVector.initializeFrom(newChildNodes, count: i)
+    childNodeVector.initialize(from: newChildNodes, count: i)
     for childNode in
       UnsafeMutableBufferPointer(
         start: childNodeVector, count: i)
@@ -563,7 +563,7 @@ struct _PVSparseVectorNodePointer<Key : Hashable, Value>
     childNodeVector[i] = newChildNode
 
     let destPointer = childNodeVector + i + 1
-    destPointer.initializeFrom(
+    destPointer.initialize(from: 
       newChildNodes + i, count: childNodeCount - i - 1)
     for childNode in
       UnsafeMutableBufferPointer(
@@ -577,7 +577,7 @@ struct _PVSparseVectorNodePointer<Key : Hashable, Value>
     from newKeys: UnsafeMutablePointer<Key>,
     layout: _PVSparseVectorNodeLayoutParameters
   ) {
-    _keyVector(layout: layout).initializeFrom(newKeys, count: layout.keyCount)
+    _keyVector(layout: layout).initialize(from: newKeys, count: layout.keyCount)
   }
 
   func copyKeys(
@@ -589,11 +589,11 @@ struct _PVSparseVectorNodePointer<Key : Hashable, Value>
     precondition(bucket >= 0 && bucket < 32) // sanity check
     let keyVector = _keyVector(layout: layout)
     let i = keyPopulationBitmap.countBitsSetBelow(bucket)
-    keyVector.initializeFrom(newKeys, count: i)
+    keyVector.initialize(from: newKeys, count: i)
     keyVector[i] = newKey
 
     let destPointer = keyVector + i + 1
-    destPointer.initializeFrom(
+    destPointer.initialize(from: 
       newKeys + i + 1, count: layout.keyCount - i - 1)
   }
 
@@ -601,7 +601,7 @@ struct _PVSparseVectorNodePointer<Key : Hashable, Value>
     from newValues: UnsafeMutablePointer<Value>,
     layout: _PVSparseVectorNodeLayoutParameters
   ) {
-    _valueVector(layout: layout).initializeFrom(newValues, count: layout.keyCount)
+    _valueVector(layout: layout).initialize(from: newValues, count: layout.keyCount)
   }
 
   func copyValues(
@@ -613,11 +613,11 @@ struct _PVSparseVectorNodePointer<Key : Hashable, Value>
     precondition(bucket >= 0 && bucket < 32) // sanity check
     let valueVector = _valueVector(layout: layout)
     let i = keyPopulationBitmap.countBitsSetBelow(bucket)
-    valueVector.initializeFrom(newValues, count: i)
+    valueVector.initialize(from: newValues, count: i)
     valueVector[i] = newValue
 
     let destPointer = valueVector + i + 1
-    destPointer.initializeFrom(
+    destPointer.initialize(from: 
       newValues + i + 1, count: layout.keyCount - i - 1)
   }
 
@@ -636,18 +636,18 @@ struct _PVSparseVectorNodePointer<Key : Hashable, Value>
     let i = keyPopulationBitmap.countBitsSetBelow(bucket)
     do {
       let keyVector = _keyVector(layout: layout)
-      keyVector.initializeFrom(newKeys, count: i)
+      keyVector.initialize(from: newKeys, count: i)
 
       let destPointer = keyVector + i
-      destPointer.initializeFrom(
+      destPointer.initialize(from: 
         newKeys + i + 1, count: layout.keyCount - i)
     }
     do {
       let valueVector = _valueVector(layout: layout)
-      valueVector.initializeFrom(newValues, count: i)
+      valueVector.initialize(from: newValues, count: i)
 
       let destPointer = valueVector + i
-      destPointer.initializeFrom(
+      destPointer.initialize(from: 
         newValues + i + 1, count: layout.keyCount - i)
     }
   }
@@ -665,22 +665,22 @@ struct _PVSparseVectorNodePointer<Key : Hashable, Value>
     let i = keyPopulationBitmap.countBitsSetBelow(bucket)
     do {
       let keyVector = _keyVector(layout: layout)
-      keyVector.initializeFrom(newKeys, count: i)
+      keyVector.initialize(from: newKeys, count: i)
 
       keyVector[i] = newKey
 
       let destPointer = keyVector + i + 1
-      destPointer.initializeFrom(
+      destPointer.initialize(from: 
         newKeys + i, count: layout.keyCount - i - 1)
     }
     do {
       let valueVector = _valueVector(layout: layout)
-      valueVector.initializeFrom(newValues, count: i)
+      valueVector.initialize(from: newValues, count: i)
 
       valueVector[i] = newValue
 
       let destPointer = valueVector + i + 1
-      destPointer.initializeFrom(
+      destPointer.initialize(from: 
         newValues + i, count: layout.keyCount - i - 1)
     }
   }
@@ -1353,11 +1353,11 @@ struct _PVCollisionNodePointer<Key : Hashable, Value>
     layout: _PVCollisionNodePointerLayoutParameters
   ) {
     let valueArray = _valueArray(layout: layout)
-    valueArray.initializeFrom(newValues, count: i)
+    valueArray.initialize(from: newValues, count: i)
     valueArray[i] = newValue
 
     let destPointer = valueArray + i + 1
-    destPointer.initializeFrom(
+    destPointer.initialize(from: 
       newValues + i + 1, count: layout.keyCount - i - 1)
   }
 
@@ -1371,11 +1371,11 @@ struct _PVCollisionNodePointer<Key : Hashable, Value>
     precondition(layout.keyCount >= 1)
 
     let keyArray = _keyArray
-    keyArray.initializeFrom(newKeys, count: layout.keyCount - 1)
+    keyArray.initialize(from: newKeys, count: layout.keyCount - 1)
     (keyArray + layout.keyCount - 1).initialize(with: appendKey)
 
     let valueArray = _valueArray(layout: layout)
-    valueArray.initializeFrom(newValues, count: layout.keyCount - 1)
+    valueArray.initialize(from: newValues, count: layout.keyCount - 1)
     (valueArray + layout.keyCount - 1).initialize(with: appendValue)
   }
 
@@ -1414,7 +1414,7 @@ struct _PVCollisionNodePointer<Key : Hashable, Value>
         } else {
           // Create a new node.
           let newNode = _PVCollisionNodePointer(uninitializedNodeFor: layout)
-          newNode._keyArray.initializeFrom(
+          newNode._keyArray.initialize(from: 
             keyArray, count: layout.keyCount)
           newNode.copyValues(
             from: valueArray,


### PR DESCRIPTION
As proposed in SE-0107: UnsafeRawPointer.

Also fixes the comments to clarify that source and self memory
must be disjoint.
