### PR TITLE
[SourceKit] Implement a new SourceKit request to generate type interface.

### DIFF
--- a/include/swift/IDE/ModuleInterfacePrinting.h
+++ b/include/swift/IDE/ModuleInterfacePrinting.h
@@ -49,10 +49,10 @@ Optional<StringRef>
 findGroupNameForUSR(ModuleDecl *M, StringRef USR);
 
 bool printTypeInterface(ModuleDecl *M, Type Ty, ASTPrinter &Printer,
-                        std::string &Error);
+                        std::string &TypeName, std::string &Error);
 
 bool printTypeInterface(ModuleDecl *M, StringRef TypeUSR, ASTPrinter &Printer,
-                        std::string &Error);
+                        std::string &TyepName, std::string &Error);
 
 void printModuleInterface(ModuleDecl *M, Optional<StringRef> Group,
                           ModuleTraversalOptions TraversalOptions,

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -147,27 +147,38 @@ getUnderlyingClangModuleForImport(ImportDecl *Import) {
   return nullptr;
 }
 
+static void printTypeNameToString(Type Ty, std::string &Text) {
+  SmallString<128> Buffer;
+  llvm::raw_svector_ostream OS(Buffer);
+  Ty->print(OS);
+  Text = OS.str();
+}
+
 bool swift::ide::
 printTypeInterface(ModuleDecl *M, Type Ty, ASTPrinter &Printer,
-                   std::string &Error) {
-  if (!Ty)
-    return false;
+                   std::string &TypeName, std::string &Error) {
+  if (!Ty) {
+    if (Error.empty())
+      Error = "type cannot be null.";
+    return true;
+  }
   Ty = Ty->getRValueType();
   if (auto ND = Ty->getNominalOrBoundGenericNominal()) {
     PrintOptions Options = PrintOptions::printTypeInterface(Ty.getPointer(), M);
     ND->print(Printer, Options);
-    return true;
+    printTypeNameToString(Ty, TypeName);
+    return false;
   }
   Error = "cannot find declaration of type.";
-  return false;
+  return true;
 }
 
 bool swift::ide::
 printTypeInterface(ModuleDecl *M, StringRef TypeUSR, ASTPrinter &Printer,
-                   std::string &Error) {
+                   std::string &TypeName, std::string &Error) {
   return printTypeInterface(M, getTypeFromMangledSymbolname(M->getASTContext(),
                                                             TypeUSR, Error),
-                            Printer, Error);
+                            Printer, TypeName, Error);
 }
 
 void swift::ide::printModuleInterface(Module *M, Optional<StringRef> Group,

--- a/test/SourceKit/InterfaceGen/gen_swift_type.swift
+++ b/test/SourceKit/InterfaceGen/gen_swift_type.swift
@@ -1,0 +1,76 @@
+// RUN: %sourcekitd-test -req=interface-gen -usr _TtGSaSi_ %s -- %s | FileCheck -check-prefix=CHECK1 %s
+// RUN: %sourcekitd-test -req=interface-gen -usr _TtGSaSS_ %s -- %s | FileCheck -check-prefix=CHECK2 %s
+// RUN: %sourcekitd-test -req=interface-gen -usr _TtV14gen_swift_type1A %s -- %s | FileCheck -check-prefix=CHECK3 %s
+// RUN: %sourcekitd-test -req=interface-gen -usr _TtGSaV14gen_swift_type1A_ %s -- %s | FileCheck -check-prefix=CHECK4 %s
+// RUN: %sourcekitd-test -req=interface-gen -usr _TtGC14gen_swift_type1DCS_2T1_ %s -- %s | FileCheck -check-prefix=CHECK5 %s
+// RUN: %sourcekitd-test -req=interface-gen -usr _TtGC14gen_swift_type1DSi_ %s -- %s | FileCheck -check-prefix=CHECK6 %s
+
+public struct A {
+	public func fa() {}
+}
+extension A {
+	public func fea1() {}
+}
+extension A {
+	public func fea2() {}
+}
+
+class C1 {
+	func f1() {
+		var abcd : A
+    abcd.fa()
+		var intarr : [Int]
+		intarr.append(1)
+	}
+}
+
+struct S1 {
+  func f1(a : [A]) {
+    _ = a.count
+  }
+}
+// CHECK1: public struct Array<Int> : RandomAccessCollection, MutableCollection {
+
+// CHECK2: public struct Array<String> : RandomAccessCollection, MutableCollection {
+
+// CHECK3: public struct A
+// CHECK3: public func fa()
+// CHECK3: public func fea1()
+// CHECK3: public func fea2()
+
+// CHECK4: public struct Array<A> : RandomAccessCollection, MutableCollection {
+
+public protocol P1 { }
+public class T1 : P1 { }
+public class D<T> { public func foo() {}}
+
+class C2 {
+  func f() {
+    let D1 = D<T1>()
+    let D2 = D<Int>()
+    D1.foo()
+    D2.foo()
+  }
+}
+
+extension D where T : P1 {
+  public func conditionalFunc1() {}
+  public func conditionalFunc2(t : T) -> T {return t}
+}
+
+extension D {
+  public func unconditionalFunc1(){}
+  public func unconditionalFunc2(t : T) -> T {return t}
+}
+
+// CHECK5: public class D<T1> {
+// CHECK5: public func foo()
+// CHECK5: public func conditionalFunc1()
+// CHECK5: public func conditionalFunc2(t: T1) -> T1
+// CHECK5: public func unconditionalFunc1()
+// CHECK5: public func unconditionalFunc2(t: T1) -> T1
+
+// CHECK6: public class D<Int> {
+// CHECK6: public func foo()
+// CHECK6: public func unconditionalFunc1()
+// CHECK6: public func unconditionalFunc2(t: Int) -> Int

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -413,6 +413,10 @@ public:
                                    bool SynthesizedExtensions,
                                    Optional<StringRef> InterestedUSR) = 0;
 
+  virtual void editorOpenTypeInterface(EditorConsumer &Consumer,
+                                       ArrayRef<const char *> Args,
+                                       StringRef TypeUSR) = 0;
+
   virtual void editorOpenHeaderInterface(EditorConsumer &Consumer,
                                          StringRef Name,
                                          StringRef HeaderName,

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -442,6 +442,53 @@ SwiftInterfaceGenContext::create(StringRef DocumentName,
   return IFaceGenCtx;
 }
 
+SwiftInterfaceGenContextRef
+SwiftInterfaceGenContext::createForTypeInterface(CompilerInvocation Invocation,
+                                                 StringRef TypeUSR,
+                                                 std::string &ErrorMsg) {
+  SwiftInterfaceGenContextRef IFaceGenCtx{ new SwiftInterfaceGenContext() };
+  IFaceGenCtx->Impl.IsModule = false;
+  IFaceGenCtx->Impl.ModuleOrHeaderName = TypeUSR;
+  IFaceGenCtx->Impl.Invocation = Invocation;
+  CompilerInstance &CI = IFaceGenCtx->Impl.Instance;
+  SourceTextInfo &Info = IFaceGenCtx->Impl.Info;
+
+  // Display diagnostics to stderr.
+  CI.addDiagnosticConsumer(&IFaceGenCtx->Impl.DiagConsumer);
+
+  if (CI.setup(Invocation)) {
+    ErrorMsg = "Error during invocation setup";
+    return nullptr;
+  }
+  CI.performSema();
+  ASTContext &Ctx = CI.getASTContext();
+  CloseClangModuleFiles scopedCloseFiles(*Ctx.getClangModuleLoader());
+
+  // Load standard library so that Clang importer can use it.
+  auto *Stdlib = getModuleByFullName(Ctx, Ctx.StdlibModuleName);
+  if (!Stdlib) {
+    ErrorMsg = "Could not load the stdlib module";
+    return nullptr;
+  }
+  auto *Module = CI.getMainModule();
+  if (!Module) {
+    ErrorMsg = "Could not load the main module";
+    return nullptr;
+  }
+  SmallString<128> Text;
+  llvm::raw_svector_ostream OS(Text);
+  AnnotatingPrinter Printer(Info, OS);
+  if (ide::printTypeInterface(Module, TypeUSR, Printer,
+                              IFaceGenCtx->Impl.DocumentName, ErrorMsg))
+    return nullptr;
+  IFaceGenCtx->Impl.Info.Text = OS.str();
+  if (makeParserAST(IFaceGenCtx->Impl.TextCI, IFaceGenCtx->Impl.Info.Text)) {
+    ErrorMsg = "Error during syntactic parsing";
+    return nullptr;
+  }
+  return IFaceGenCtx;
+}
+
 SwiftInterfaceGenContext::SwiftInterfaceGenContext()
   : Impl(*new Implementation) {
 }
@@ -593,11 +640,45 @@ SwiftInterfaceGenMap::find(StringRef ModuleName,
   }
   return nullptr;
 }
+//===----------------------------------------------------------------------===//
+// EditorOpenTypeInterface
+//===----------------------------------------------------------------------===//
+void SwiftLangSupport::editorOpenTypeInterface(EditorConsumer &Consumer,
+                                               ArrayRef<const char *> Args,
+                                               StringRef TypeUSR) {
+  CompilerInstance CI;
+  // Display diagnostics to stderr.
+  PrintingDiagnosticConsumer PrintDiags;
+  CI.addDiagnosticConsumer(&PrintDiags);
+
+  CompilerInvocation Invocation;
+  std::string Error;
+  if (getASTManager().initCompilerInvocation(Invocation, Args, CI.getDiags(),
+                                             StringRef(), Error)) {
+    Consumer.handleRequestError(Error.c_str());
+    return;
+  }
+  Invocation.getClangImporterOptions().ImportForwardDeclarations = true;
+
+  std::string ErrMsg;
+  auto IFaceGenRef = SwiftInterfaceGenContext::createForTypeInterface(
+                                                      Invocation,
+                                                      TypeUSR,
+                                                      ErrMsg);
+  if (!IFaceGenRef) {
+    Consumer.handleRequestError(ErrMsg.c_str());
+    return;
+  }
+
+  IFaceGenRef->reportEditorInfo(Consumer);
+  // reportEditorInfo requires exclusive access to the AST, so don't add this
+  // to the service cache until it has returned.
+  IFaceGenContexts.set(TypeUSR, IFaceGenRef);
+}
 
 //===----------------------------------------------------------------------===//
 // EditorOpenInterface
 //===----------------------------------------------------------------------===//
-
 void SwiftLangSupport::editorOpenInterface(EditorConsumer &Consumer,
                                            StringRef Name,
                                            StringRef ModuleName,

--- a/tools/SourceKit/lib/SwiftLang/SwiftInterfaceGenContext.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftInterfaceGenContext.h
@@ -42,6 +42,11 @@ public:
                                             bool SynthesizedExtensions,
                                             Optional<StringRef> InterestedUSR);
 
+  static SwiftInterfaceGenContextRef
+    createForTypeInterface(swift::CompilerInvocation Invocation,
+                           StringRef TypeUSR,
+                           std::string &ErrorMsg);
+
   static SwiftInterfaceGenContextRef createForSwiftSource(StringRef DocumentName,
                                                           StringRef SourceFileName,
                                                           ASTUnitRef AstUnit,

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -340,6 +340,10 @@ public:
                            bool SynthesizedExtensions,
                            Optional<StringRef> InterestedUSR) override;
 
+  void editorOpenTypeInterface(EditorConsumer &Consumer,
+                               ArrayRef<const char *> Args,
+                               StringRef TypeUSR) override;
+
   void editorOpenHeaderInterface(EditorConsumer &Consumer,
                                  StringRef Name,
                                  StringRef HeaderName,

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -142,6 +142,7 @@ static sourcekitd_uid_t RequestRelatedIdents;
 static sourcekitd_uid_t RequestEditorOpen;
 static sourcekitd_uid_t RequestEditorOpenInterface;
 static sourcekitd_uid_t RequestEditorOpenSwiftSourceInterface;
+static sourcekitd_uid_t RequestEditorOpenSwiftTypeInterface;
 static sourcekitd_uid_t RequestEditorOpenHeaderInterface;
 static sourcekitd_uid_t RequestEditorExtractTextFromComment;
 static sourcekitd_uid_t RequestEditorReplaceText;
@@ -258,6 +259,7 @@ static int skt_main(int argc, const char **argv) {
   RequestEditorOpen = sourcekitd_uid_get_from_cstr("source.request.editor.open");
   RequestEditorOpenInterface = sourcekitd_uid_get_from_cstr("source.request.editor.open.interface");
   RequestEditorOpenSwiftSourceInterface = sourcekitd_uid_get_from_cstr("source.request.editor.open.interface.swiftsource");
+  RequestEditorOpenSwiftTypeInterface = sourcekitd_uid_get_from_cstr("source.request.editor.open.interface.swifttype");
   RequestEditorOpenHeaderInterface = sourcekitd_uid_get_from_cstr("source.request.editor.open.interface.header");
   RequestEditorExtractTextFromComment = sourcekitd_uid_get_from_cstr("source.request.editor.extract.comment");
   RequestEditorReplaceText = sourcekitd_uid_get_from_cstr("source.request.editor.replacetext");
@@ -615,20 +617,26 @@ static int handleTestInvocation(ArrayRef<const char *> Args,
   case SourceKitRequest::InterfaceGenOpen:
     sourcekitd_request_dictionary_set_int64(Req, KeySynthesizedExtension,
                                             Opts.SynthesizedExtensions);
-    if (Opts.ModuleName.empty() && Opts.HeaderPath.empty() && Opts.SourceFile.empty()) {
-      llvm::errs() << "Missing '-module <module name>' or '-header <path>' or '<source-file>' \n";
+    if (Opts.ModuleName.empty() && Opts.HeaderPath.empty() &&
+        Opts.SourceFile.empty() && Opts.USR.empty()) {
+      llvm::errs() << "Missing '-module <module name>' or '-header <path>'" <<
+        "or '<source-file>' or '-usr <USR>' \n";
       return 1;
     }
     if (!Opts.ModuleName.empty()) {
       sourcekitd_request_dictionary_set_uid(Req, KeyRequest,
                                             RequestEditorOpenInterface);
-    } else if (Opts.SourceFile.empty()){
+    } else if (!Opts.USR.empty()) {
       sourcekitd_request_dictionary_set_uid(Req, KeyRequest,
-                                            RequestEditorOpenHeaderInterface);
-    } else {
+                                            RequestEditorOpenSwiftTypeInterface);
+    } else if (!Opts.SourceFile.empty()) {
       sourcekitd_request_dictionary_set_uid(Req, KeyRequest,
                                             RequestEditorOpenSwiftSourceInterface);
+    } else {
+      sourcekitd_request_dictionary_set_uid(Req, KeyRequest,
+                                            RequestEditorOpenHeaderInterface);
     }
+
     sourcekitd_request_dictionary_set_string(Req, KeyName, getInterfaceGenDocumentName());
     if (!Opts.ModuleGroupName.empty())
       sourcekitd_request_dictionary_set_string(Req, KeyGroupName,
@@ -636,6 +644,8 @@ static int handleTestInvocation(ArrayRef<const char *> Args,
     if (!Opts.InterestedUSR.empty())
       sourcekitd_request_dictionary_set_string(Req, KeyInterestedUSR,
                                                Opts.InterestedUSR.c_str());
+    if (!Opts.USR.empty())
+      sourcekitd_request_dictionary_set_string(Req, KeyUSR, Opts.USR.c_str());
     break;
 
   case SourceKitRequest::FindInterfaceDoc:

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2367,10 +2367,13 @@ static int doPrintTypeInterface(const CompilerInvocation &InitInvok,
   }
   StreamPrinter Printer(llvm::outs());
   std::string Error;
-  if (printTypeInterface(SemaT.DC->getParentModule(), SemaT.Ty, Printer, Error))
-    return 0;
-  llvm::errs() << Error;
-  return 1;
+  std::string TypeName;
+  if (printTypeInterface(SemaT.DC->getParentModule(), SemaT.Ty, Printer,
+                         TypeName, Error)) {
+    llvm::errs() << Error;
+    return 1;
+  }
+  return 0;
 }
 
 static int doPrintTypeInterfaceForTypeUsr(const CompilerInvocation &InitInvok,
@@ -2385,11 +2388,14 @@ static int doPrintTypeInterfaceForTypeUsr(const CompilerInvocation &InitInvok,
   DeclContext *DC = CI.getMainModule()->getModuleContext();
   assert(DC && "no decl context?");
   StreamPrinter Printer(llvm::outs());
+  std::string TypeName;
   std::string Error;
-  if (printTypeInterface(DC->getParentModule(), Usr, Printer, Error))
-    return 0;
-  llvm::errs() << Error;
-  return 1;
+  if (printTypeInterface(DC->getParentModule(), Usr, Printer, TypeName,
+                         Error)) {
+    llvm::errs() << Error;
+    return 1;
+  }
+  return 0;
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->

```
[SourceKit] Implement a new SourceKit request to generate the interface for a given type. rdar://27306890
```

This patch allows SourceKit to generate the interface for a given type specified by its mangled name. Type interface is refined decl printing with type parameters localized and unusable members hidden.

Required field:
  "key.request": "source.request.editor.open.interface.swifttype"
  "key.usr": the mangled name of the given type.

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…ce for a given type. rdar://27306890

This patch allows SourceKit to generate the interface for a given type specified by its mangled name.
Type interface is refined decl printing with type parameters localized and unusable members hidden.

Required field:
   "key.request": "source.request.editor.open.interface.swifttype"
   "key.usr": the mangled name of the given type.
