### PR TITLE
Rename initialize(with:count:) to initialize(to:count:).

### DIFF
--- a/stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.swift
+++ b/stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.swift
@@ -15,7 +15,7 @@ func _stdlib_getPointer(_ x: OpaquePointer) -> OpaquePointer
 
 public func _opaqueIdentity<T>(_ x: T) -> T {
   let ptr = UnsafeMutablePointer<T>(allocatingCapacity: 1)
-  ptr.initialize(with: x)
+  ptr.initialize(to: x)
   let result =
     UnsafeMutablePointer<T>(_stdlib_getPointer(OpaquePointer(ptr))).pointee
   ptr.deinitialize()

--- a/stdlib/private/SwiftPrivate/ShardedAtomicCounter.swift
+++ b/stdlib/private/SwiftPrivate/ShardedAtomicCounter.swift
@@ -35,7 +35,7 @@ public struct _stdlib_ShardedAtomicCounter {
     let count = max(8, hardwareConcurrency * hardwareConcurrency)
     let shards = UnsafeMutablePointer<Int>(allocatingCapacity: count)
     for i in 0..<count {
-      (shards + i).initialize(with: 0)
+      (shards + i).initialize(to: 0)
     }
     self._shardsPtr = shards
     self._shardsCount = count

--- a/stdlib/private/SwiftPrivatePthreadExtras/SwiftPrivatePthreadExtras.swift
+++ b/stdlib/private/SwiftPrivatePthreadExtras/SwiftPrivatePthreadExtras.swift
@@ -42,7 +42,7 @@ internal class PthreadBlockContextImpl<Argument, Result>: PthreadBlockContext {
 
   override func run() -> UnsafeMutablePointer<Void> {
     let result = UnsafeMutablePointer<Result>(allocatingCapacity: 1)
-    result.initialize(with: block(arg))
+    result.initialize(to: block(arg))
     return UnsafeMutablePointer(result)
   }
 }

--- a/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
+++ b/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
@@ -357,7 +357,7 @@ public func reflect(object: AnyObject) {
 public func reflect<T>(any: T) {
   let any: Any = any
   let anyPointer = UnsafeMutablePointer<Any>(allocatingCapacity: sizeof(Any.self))
-  anyPointer.initialize(with: any)
+  anyPointer.initialize(to: any)
   let anyPointerValue = unsafeBitCast(anyPointer, to: UInt.self)
   reflect(instanceAddress: anyPointerValue, kind: .Existential)
   anyPointer.deallocateCapacity(sizeof(Any.self))
@@ -421,7 +421,7 @@ struct ThickFunctionParts {
 public func reflect(function: () -> ()) {
   let fn = UnsafeMutablePointer<ThickFunction0>(
       allocatingCapacity: sizeof(ThickFunction0.self))
-  fn.initialize(with: ThickFunction0(function: function))
+  fn.initialize(to: ThickFunction0(function: function))
 
   let parts = unsafeBitCast(fn, to: UnsafePointer<ThickFunctionParts>.self)
   let contextPointer = unsafeBitCast(parts.pointee.context, to: UInt.self)
@@ -436,7 +436,7 @@ public func reflect(function: () -> ()) {
 public func reflect(function: (Int) -> ()) {
   let fn = UnsafeMutablePointer<ThickFunction1>(
       allocatingCapacity: sizeof(ThickFunction1.self))
-  fn.initialize(with: ThickFunction1(function: function))
+  fn.initialize(to: ThickFunction1(function: function))
 
   let parts = unsafeBitCast(fn, to: UnsafePointer<ThickFunctionParts>.self)
   let contextPointer = unsafeBitCast(parts.pointee.context, to: UInt.self)
@@ -451,7 +451,7 @@ public func reflect(function: (Int) -> ()) {
 public func reflect(function: (Int, String) -> ()) {
   let fn = UnsafeMutablePointer<ThickFunction2>(
       allocatingCapacity: sizeof(ThickFunction2.self))
-  fn.initialize(with: ThickFunction2(function: function))
+  fn.initialize(to: ThickFunction2(function: function))
 
   let parts = unsafeBitCast(fn, to: UnsafePointer<ThickFunctionParts>.self)
   let contextPointer = unsafeBitCast(parts.pointee.context, to: UInt.self)
@@ -466,7 +466,7 @@ public func reflect(function: (Int, String) -> ()) {
 public func reflect(function: (Int, String, AnyObject?) -> ()) {
   let fn = UnsafeMutablePointer<ThickFunction3>(
       allocatingCapacity: sizeof(ThickFunction3.self))
-  fn.initialize(with: ThickFunction3(function: function))
+  fn.initialize(to: ThickFunction3(function: function))
 
   let parts = unsafeBitCast(fn, to: UnsafePointer<ThickFunctionParts>.self)
   let contextPointer = unsafeBitCast(parts.pointee.context, to: UInt.self)

--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -282,7 +282,7 @@ public func _stdlib_bridgeNSErrorToError<
   T : _ObjectiveCBridgeableError
 >(_ error: NSError, out: UnsafeMutablePointer<T>) -> Bool {
   if let bridged = T(_bridgedNSError: error) {
-    out.initialize(with: bridged)
+    out.initialize(to: bridged)
     return true
   } else {
     return false

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -217,7 +217,7 @@ extension _ArrayBuffer {
     // Make another pass to retain the copied objects
     var result = target
     for _ in CountableRange(bounds) {
-      result.initialize(with: result.pointee)
+      result.initialize(to: result.pointee)
       result += 1
     }
     return result

--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -163,7 +163,7 @@ extension _ArrayBufferProtocol where Index == Int {
       }
       // Initialize the hole left by sliding the tail forward
       for j in oldTailIndex..<newTailIndex {
-        (elements + j).initialize(with: newValues[i])
+        (elements + j).initialize(to: newValues[i])
         newValues.formIndex(after: &i)
       }
       _expectEnd(i, newValues)

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1061,7 +1061,7 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
     var p: UnsafeMutablePointer<Element>
     (self, p) = ${Self}._allocateUninitialized(count)
     for _ in 0..<count {
-      p.initialize(with: repeatedValue)
+      p.initialize(to: repeatedValue)
       p += 1
     }
   }
@@ -1252,7 +1252,7 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
     _sanityCheck(_buffer.capacity >= _buffer.count + 1)
 
     _buffer.count = oldCount + 1
-    (_buffer.firstElementAddress + oldCount).initialize(with: newElement)
+    (_buffer.firstElementAddress + oldCount).initialize(to: newElement)
   }
 
   /// Adds a new element at the end of the array.
@@ -1616,7 +1616,7 @@ internal struct _InitializeMemoryFromCollection<
     var p = rawMemory
     var q = newValues.startIndex
     for _ in 0..<count {
-      p.initialize(with: newValues[q])
+      p.initialize(to: newValues[q])
       newValues.formIndex(after: &q)
       p += 1
     }
@@ -1923,7 +1923,7 @@ internal struct _InitializePointer<T> : _PointerFunction {
   internal func call(_ rawMemory: UnsafeMutablePointer<T>, count: Int) {
     _sanityCheck(count == 1)
     // FIXME: it would be better if we could find a way to move, here
-    rawMemory.initialize(with: newValue)
+    rawMemory.initialize(to: newValue)
   }
 
   @_transparent
@@ -2003,7 +2003,7 @@ internal func _arrayAppendSequence<Buffer, S>(
     let base = buffer.firstElementAddress
 
     while (nextItem != nil) && count < capacity {
-      (base + count).initialize(with: nextItem!)
+      (base + count).initialize(to: nextItem!)
       count += 1
       nextItem = stream.next()
     }

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1680,7 +1680,7 @@ extension Sequence
     } else {
       var p = ptr
       for x in self {
-        p.initialize(with: x)
+        p.initialize(to: x)
         p += 1
       }
       return p

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -145,7 +145,7 @@ final class _ContiguousArrayStorage<Element> : _ContiguousArrayStorage1 {
     let resultPtr = result.baseAddress
     let p = __manager._elementPointer
     for i in 0..<count {
-      (resultPtr + i).initialize(with: _bridgeToObjectiveCUnconditional(p[i]))
+      (resultPtr + i).initialize(to: _bridgeToObjectiveCUnconditional(p[i]))
     }
     _fixLifetime(__manager)
     return result
@@ -239,7 +239,7 @@ struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
     let verbatim = false
 #endif
 
-    __bufferPointer._headerPointer.initialize(with: 
+    __bufferPointer._headerPointer.initialize(to: 
       _ArrayBody(
         count: count,
         capacity: capacity,
@@ -608,7 +608,7 @@ internal func _copyCollectionToContiguousArray<
   var i = source.startIndex
   for _ in 0..<count {
     // FIXME(performance): use _copyContents(initializing:).
-    p.initialize(with: source[i])
+    p.initialize(to: source[i])
     source.formIndex(after: &i)
     p += 1
   }
@@ -667,7 +667,7 @@ internal struct _UnsafePartiallyInitializedContiguousArrayBuffer<Element> {
       "_UnsafePartiallyInitializedContiguousArrayBuffer has no more capacity")
     remainingCapacity -= 1
 
-    p.initialize(with: element)
+    p.initialize(to: element)
     p += 1
   }
 

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -2719,7 +2719,7 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
   internal func initializeKey(_ k: Key, at i: Int) {
     _sanityCheck(!isInitializedEntry(at: i))
 
-    (keys + i).initialize(with: k)
+    (keys + i).initialize(to: k)
     initializedEntries[i] = true
     _fixLifetime(self)
   }
@@ -2727,7 +2727,7 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
   @_transparent
   internal func moveInitializeEntry(from: Storage, at: Int, toEntryAt: Int) {
     _sanityCheck(!isInitializedEntry(at: toEntryAt))
-    (keys + toEntryAt).initialize(with: (from.keys + at).move())
+    (keys + toEntryAt).initialize(to: (from.keys + at).move())
     from.initializedEntries[at] = false
     initializedEntries[toEntryAt] = true
   }
@@ -2745,8 +2745,8 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
   internal func initializeKey(_ k: Key, value v: Value, at i: Int) {
     _sanityCheck(!isInitializedEntry(at: i))
 
-    (keys + i).initialize(with: k)
-    (values + i).initialize(with: v)
+    (keys + i).initialize(to: k)
+    (values + i).initialize(to: v)
     initializedEntries[i] = true
     _fixLifetime(self)
   }
@@ -2754,8 +2754,8 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
   @_transparent
   internal func moveInitializeEntry(from: Storage, at: Int, toEntryAt: Int) {
     _sanityCheck(!isInitializedEntry(at: toEntryAt))
-    (keys + toEntryAt).initialize(with: (from.keys + at).move())
-    (values + toEntryAt).initialize(with: (from.values + at).move())
+    (keys + toEntryAt).initialize(to: (from.keys + at).move())
+    (values + toEntryAt).initialize(to: (from.values + at).move())
     from.initializedEntries[at] = false
     initializedEntries[toEntryAt] = true
   }
@@ -3093,7 +3093,7 @@ internal struct _BridgedNative${Self}Storage {
   internal func initializeKey(_ k: AnyObject, at i: Int) {
     _sanityCheck(!isInitializedEntry(at: i))
 
-    (keys + i).initialize(with: k)
+    (keys + i).initialize(to: k)
     initializedEntries[i] = true
     _fixLifetime(self)
   }
@@ -3103,8 +3103,8 @@ internal struct _BridgedNative${Self}Storage {
   ) {
     _sanityCheck(!isInitializedEntry(at: i))
 
-    (keys + i).initialize(with: k)
-    (values + i).initialize(with: v)
+    (keys + i).initialize(to: k)
+    (values + i).initialize(to: v)
     initializedEntries[i] = true
     _fixLifetime(self)
   }

--- a/stdlib/public/core/HeapBuffer.swift
+++ b/stdlib/public/core/HeapBuffer.swift
@@ -172,7 +172,7 @@ struct _HeapBuffer<Value, Element> : Equatable {
       size: totalSize,
       alignmentMask: alignMask)
     self._storage = Builtin.castToNativeObject(object)
-    self._value.initialize(with: initializer)
+    self._value.initialize(to: initializer)
   }
 
   public // @testable

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -195,7 +195,7 @@ public struct ManagedBufferPointer<Header, Element> : Equatable {
 
     // initialize the header field
     try withUnsafeMutablePointerToHeader {
-      $0.initialize(with: 
+      $0.initialize(to: 
         try initialHeader(
           buffer: self.buffer,
           capacity: {

--- a/stdlib/public/core/Reflection.swift
+++ b/stdlib/public/core/Reflection.swift
@@ -130,7 +130,7 @@ public protocol _Mirror {
 @_silgen_name("swift_getSummary")
 public // COMPILER_INTRINSIC
 func _getSummary<T>(_ out: UnsafeMutablePointer<String>, x: T) {
-  out.initialize(with: String(reflecting: x))
+  out.initialize(to: String(reflecting: x))
 }
 
 /// Produce a mirror for any value.  The runtime produces a mirror that

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -1178,7 +1178,7 @@ extension Sequence {
   ) -> UnsafeMutablePointer<Iterator.Element> {
     var p = UnsafeMutablePointer<Iterator.Element>(ptr)
     for x in IteratorSequence(self.makeIterator()) {
-      p.initialize(with: x)
+      p.initialize(to: x)
       p += 1
     }
     return p

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -744,7 +744,7 @@ extension String {
     start: UnsafeMutablePointer<UTF8.CodeUnit>,
     utf8CodeUnitCount: Int
   ) {
-    resultStorage.initialize(with: 
+    resultStorage.initialize(to: 
       String._fromWellFormedCodeUnitSequence(
         UTF8.self,
         input: UnsafeBufferPointer(start: start, count: utf8CodeUnitCount)))

--- a/stdlib/public/core/UnsafeBitMap.swift
+++ b/stdlib/public/core/UnsafeBitMap.swift
@@ -51,7 +51,7 @@ struct _UnsafeBitMap {
 
   public // @testable
   func initializeToZero() {
-    values.initialize(with: 0, count: numberOfWords)
+    values.initialize(to: 0, count: numberOfWords)
   }
 
   public // @testable

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -172,10 +172,10 @@ public struct ${Self}<Pointee>
   ///
   /// - Postcondition: The pointee is initialized; the value should eventually
   ///   be destroyed or moved from to avoid leaks.
-  public func initialize(with newValue: Pointee, count: Int = 1) {
+  public func initialize(to newValue: Pointee, count: Int = 1) {
     // FIXME: add tests (since the `count` has been added)
     _debugPrecondition(count >= 0,
-      "${Self}.initialize(with:): negative count")
+      "${Self}.initialize(to:): negative count")
     // Must not use `initializeFrom` with a `Collection` as that will introduce
     // a cycle.
     for offset in 0..<count {
@@ -244,7 +244,7 @@ public struct ${Self}<Pointee>
         Pointee.self, self._rawValue, source._rawValue, count._builtinWordValue)
       // This builtin is equivalent to:
       // for i in 0..<count {
-      //   (self + i).initialize(with: (source + i).move())
+      //   (self + i).initialize(to: (source + i).move())
       // }
     }
     else {
@@ -255,7 +255,7 @@ public struct ${Self}<Pointee>
       // var src = source + count
       // var dst = self + count
       // while dst != self {
-      //   (--dst).initialize(with: (--src).move())
+      //   (--dst).initialize(to: (--src).move())
       // }
     }
   }
@@ -286,7 +286,7 @@ public struct ${Self}<Pointee>
       Pointee.self, self._rawValue, source._rawValue, count._builtinWordValue)
     // This builtin is equivalent to:
     // for i in 0..<count {
-    //   (self + i).initialize(with: source[i])
+    //   (self + i).initialize(to: source[i])
     // }
   }
 
@@ -511,8 +511,13 @@ extension ${Self} {
   }
 
 % if mutable:
-  @available(*, unavailable, renamed: "initialize(with:)")
+  @available(*, unavailable, renamed: "initialize(to:)")
   public func initialize(_ newvalue: Pointee) {
+    Builtin.unreachable()
+  }
+
+  @available(*, unavailable, renamed: "initialize(to:count:)")
+  public func initialize(with newvalue: Pointee, count: Int = 1) {
     Builtin.unreachable()
   }
 

--- a/test/1_stdlib/Builtins.swift
+++ b/test/1_stdlib/Builtins.swift
@@ -130,8 +130,8 @@ struct ContainsP { var p: P }
 func exerciseArrayValueWitnesses<T>(_ value: T) {
   let buf = UnsafeMutablePointer<T>(allocatingCapacity: 5)
 
-  (buf + 0).initialize(with: value)
-  (buf + 1).initialize(with: value)
+  (buf + 0).initialize(to: value)
+  (buf + 1).initialize(to: value)
   
   Builtin.copyArray(T.self, (buf + 2)._rawValue, buf._rawValue, 2._builtinWordValue)
   Builtin.takeArrayBackToFront(T.self, (buf + 1)._rawValue, buf._rawValue, 4._builtinWordValue)

--- a/test/1_stdlib/HeapBuffer.swift
+++ b/test/1_stdlib/HeapBuffer.swift
@@ -20,7 +20,7 @@ a.value.name = "DaveA"
 a.value.locations.append("Princeton")
 a.value.locations.append("San Jose")
 for x in 0..<10 {
-  (a.baseAddress + x).initialize(with: x)
+  (a.baseAddress + x).initialize(to: x)
 }
 
 print("buffer has storage: \(a.storage != nil)")

--- a/test/1_stdlib/ManagedBuffer.swift
+++ b/test/1_stdlib/ManagedBuffer.swift
@@ -109,7 +109,7 @@ final class TestManagedBuffer<T> : ManagedBuffer<CountAndCapacity, T> {
     
     withUnsafeMutablePointerToElements {
       (p: UnsafeMutablePointer<T>) -> () in
-      (p + count).initialize(with: x)
+      (p + count).initialize(to: x)
     }
     self.count = count + 2
   }

--- a/test/1_stdlib/Reflection.swift
+++ b/test/1_stdlib/Reflection.swift
@@ -182,7 +182,7 @@ dump(randomUnsafeMutablePointerString)
 
 // CHECK-NEXT: Hello panda
 var sanePointerString = UnsafeMutablePointer<String>(allocatingCapacity: 1)
-sanePointerString.initialize(with: "Hello panda")
+sanePointerString.initialize(to: "Hello panda")
 dump(sanePointerString.pointee)
 sanePointerString.deinitialize()
 sanePointerString.deallocateCapacity(1)

--- a/test/1_stdlib/Renames.swift
+++ b/test/1_stdlib/Renames.swift
@@ -501,12 +501,13 @@ func _UnsafePointer<T>(x: UnsafeMutablePointer<T>, e: T) {
   _ = UnsafeMutablePointer<T>.alloc(1) // expected-error {{'alloc' is unavailable: use the 'UnsafeMutablePointer(allocatingCapacity:)' initializer}} {{none}}
   x.dealloc(1) // expected-error {{'dealloc' has been renamed to 'deallocateCapacity'}} {{5-12=deallocateCapacity}} {{none}}
   x.memory = e // expected-error {{'memory' has been renamed to 'pointee'}} {{5-11=pointee}} {{none}}
-  x.initialize(e) // expected-error {{'initialize' has been renamed to 'initialize(with:)'}} {{5-15=initialize}} {{16-16=with: }} {{none}}
+  x.initialize(e) // expected-error {{'initialize' has been renamed to 'initialize(to:)'}} {{5-15=initialize}} {{16-16=to: }} {{none}}
   x.destroy() // expected-error {{'destroy()' has been renamed to 'deinitialize(count:)'}} {{5-12=deinitialize}} {{none}}
   x.destroy(1) // expected-error {{'destroy' has been renamed to 'deinitialize(count:)'}} {{5-12=deinitialize}} {{13-13=count: }} {{none}}
+  x.initialize(with: e) // expected-error {{'initialize(with:count:)' has been renamed to 'initialize(to:count:)'}} {{5-15=initialize}}
 
   let ptr1 = UnsafeMutablePointer<T>(allocatingCapacity: 1)
-  ptr1.initialize(with: e, count: 1)
+  ptr1.initialize(with: e, count: 1) // expected-error {{'initialize(with:count:)' has been renamed to 'initialize(to:count:)'}}
   let ptr2 = UnsafeMutablePointer<T>(allocatingCapacity: 1)
   ptr2.initializeFrom(ptr1, count: 1) // expected-error {{'initializeFrom(_:count:)' has been renamed to 'initialize(from:count:)'}}
   ptr1.assignFrom(ptr2, count: 1) // expected-error {{'assignFrom(_:count:)' has been renamed to 'assign(from:count:)'}}

--- a/test/1_stdlib/UnsafePointer.swift.gyb
+++ b/test/1_stdlib/UnsafePointer.swift.gyb
@@ -192,40 +192,40 @@ func checkPointerCorrectness(_ check: Check,
   let ptr = UnsafeMutablePointer<Missile>(allocatingCapacity: 4)
   switch check {
   case .RightOverlap:
-    ptr.initialize(with: Missile(1))
-    (ptr + 1).initialize(with: Missile(2))
+    ptr.initialize(to: Missile(1))
+    (ptr + 1).initialize(to: Missile(2))
     if withMissiles {
-      (ptr + 2).initialize(with: Missile(3))
+      (ptr + 2).initialize(to: Missile(3))
     }
     f(ptr + 1)(ptr, count: 2)
     expectEqual(1, ptr[1].number)
     expectEqual(2, ptr[2].number)
   case .LeftOverlap:
     if withMissiles {
-      ptr.initialize(with: Missile(1))
+      ptr.initialize(to: Missile(1))
     }
-    (ptr + 1).initialize(with: Missile(2))
-    (ptr + 2).initialize(with: Missile(3))
+    (ptr + 1).initialize(to: Missile(2))
+    (ptr + 2).initialize(to: Missile(3))
     f(ptr)(ptr + 1, count: 2)
     expectEqual(2, ptr[0].number)
     expectEqual(3, ptr[1].number)
   case .Disjoint:
     if withMissiles {
-      ptr.initialize(with: Missile(0))
-      (ptr + 1).initialize(with: Missile(1))
+      ptr.initialize(to: Missile(0))
+      (ptr + 1).initialize(to: Missile(1))
     }
-    (ptr + 2).initialize(with: Missile(2))
-    (ptr + 3).initialize(with: Missile(3))
+    (ptr + 2).initialize(to: Missile(2))
+    (ptr + 3).initialize(to: Missile(3))
     f(ptr)(ptr + 2, count: 2)
     expectEqual(2, ptr[0].number)
     expectEqual(3, ptr[1].number)
     // backwards
     let ptr2 = UnsafeMutablePointer<Missile>(allocatingCapacity: 4)
-    ptr2.initialize(with: Missile(0))
-    (ptr2 + 1).initialize(with: Missile(1))
+    ptr2.initialize(to: Missile(0))
+    (ptr2 + 1).initialize(to: Missile(1))
     if withMissiles {
-      (ptr2 + 2).initialize(with: Missile(2))
-      (ptr2 + 3).initialize(with: Missile(3))
+      (ptr2 + 2).initialize(to: Missile(2))
+      (ptr2 + 3).initialize(to: Missile(3))
     }
     f(ptr2 + 2)(ptr2, count: 2)
     expectEqual(0, ptr2[2].number)
@@ -324,8 +324,8 @@ UnsafeMutablePointerTestSuite.test("assign/immutable") {
     ptr.deinitialize(count: 2)
     ptr.deallocateCapacity(2)
   }
-  ptr.initialize(with: Missile(1))
-  (ptr + 1).initialize(with: Missile(2))
+  ptr.initialize(to: Missile(1))
+  (ptr + 1).initialize(to: Missile(2))
   let source = (3..<5).map(Missile.init)
   source.withUnsafeBufferPointer { bufferPtr in
     ptr.assign(from: bufferPtr.baseAddress!, count: 2)

--- a/test/Generics/slice_test.swift
+++ b/test/Generics/slice_test.swift
@@ -44,13 +44,13 @@ class Vector<T> {
       let size = Int(Builtin.sizeof(T.self))
       let newbase = UnsafeMutablePointer<T>(c_malloc(newcapacity * size))
       for i in 0..<length {
-        (newbase + i).initialize(with: (base+i).move())
+        (newbase + i).initialize(to: (base+i).move())
       }
       c_free(base)
       base = newbase
       capacity = newcapacity
     }
-    (base+length).initialize(with: elem)
+    (base+length).initialize(to: elem)
     length += 1
   }
 

--- a/test/Parse/pointer_conversion.swift.gyb
+++ b/test/Parse/pointer_conversion.swift.gyb
@@ -203,7 +203,7 @@ func pointerArithmetic(_ x: UnsafeMutablePointer<Int>, y: UnsafeMutablePointer<I
 
 func genericPointerArithmetic<T>(_ x: UnsafeMutablePointer<T>, i: Int, t: T) -> UnsafeMutablePointer<T> {
   let p = x + i
-  p.initialize(with: t)
+  p.initialize(to: t)
 }
 
 func passPointerToClosure(_ f: (UnsafeMutablePointer<Float>) -> Int) -> Int { }

--- a/test/Sanitizers/asan.swift
+++ b/test/Sanitizers/asan.swift
@@ -8,7 +8,7 @@
 // Test AddressSanitizer execution end-to-end.
 
 var a = UnsafeMutablePointer<Int>(allocatingCapacity: 1)
-a.initialize(with: 5)
+a.initialize(to: 5)
 a.deinitialize(count: 1)
 a.deallocateCapacity(1)
 print(a.pointee)

--- a/validation-test/compiler_crashers_2_fixed/0003-rdar20564378.swift
+++ b/validation-test/compiler_crashers_2_fixed/0003-rdar20564378.swift
@@ -35,7 +35,7 @@ extension Q_SequenceDefaults {
     var p = baseAddress
     var iter = self.makeIterator()
     while let element = iter.next() {
-      p.initialize(with: element)
+      p.initialize(to: element)
       p += 1
     }
   }

--- a/validation-test/compiler_crashers_2_fixed/0004-rdar20564605.swift
+++ b/validation-test/compiler_crashers_2_fixed/0004-rdar20564605.swift
@@ -35,7 +35,7 @@ extension Q_SequenceDefaults {
     var p = baseAddress
     var iter = self.makeIterator()
     while let element = iter.next() {
-      p.initialize(with: element)
+      p.initialize(to: element)
       p += 1
     }
   }

--- a/validation-test/compiler_crashers_2_fixed/0006-rdar20588474.swift
+++ b/validation-test/compiler_crashers_2_fixed/0006-rdar20588474.swift
@@ -35,7 +35,7 @@ extension Q_SequenceDefaults {
     var p = baseAddress
     var iter = self.makeIterator()
     while let element = iter.next() {
-      p.initialize(with: element)
+      p.initialize(to: element)
       p += 1
     }
   }

--- a/validation-test/compiler_crashers_2_fixed/0010-rdar20638881.swift
+++ b/validation-test/compiler_crashers_2_fixed/0010-rdar20638881.swift
@@ -36,7 +36,7 @@ extension Q_SequenceDefaults {
     var p = baseAddress
     var iter = self.makeIterator()
     while let element? = iter.next() {
-      p.initialize(with: element)
+      p.initialize(to: element)
       p += 1
     }
   }

--- a/validation-test/stdlib/Prototypes/PersistentVector.swift.gyb
+++ b/validation-test/stdlib/Prototypes/PersistentVector.swift.gyb
@@ -493,8 +493,8 @@ struct _PVSparseVectorNodePointer<Key : Hashable, Value>
     precondition(!childNodePopulationBitmap[i]) // sanity check
     precondition(!keyPopulationBitmap[i]) // sanity check
 
-    (_keyVector(layout: layout) + keyCount).initialize(with: key)
-    (_valueVector(layout: layout) + keyCount).initialize(with: value)
+    (_keyVector(layout: layout) + keyCount).initialize(to: key)
+    (_valueVector(layout: layout) + keyCount).initialize(to: value)
 
     keyPopulationBitmap[i] = true
   }
@@ -1140,8 +1140,8 @@ struct _PVArrayNodePointer<Key : Hashable, Value>
 
     UnsafeMutablePointer<Key>(
       _childNodeOrKeyArray + _Self._childNodeOrKeyStride * i)
-      .initialize(with: key)
-    (_valueArray + i).initialize(with: value)
+      .initialize(to: key)
+    (_valueArray + i).initialize(to: value)
 
     keyPopulationBitmap[i] = true
   }
@@ -1326,12 +1326,12 @@ struct _PVCollisionNodePointer<Key : Hashable, Value>
     self = _Self(uninitializedNodeFor: layout)
 
     let keyArray = self._keyArray
-    keyArray.initialize(with: key0)
-    (keyArray + 1).initialize(with: key1)
+    keyArray.initialize(to: key0)
+    (keyArray + 1).initialize(to: key1)
 
     let valueArray = self._valueArray(layout: layout)
-    valueArray.initialize(with: value0)
-    (valueArray + 1).initialize(with: value1)
+    valueArray.initialize(to: value0)
+    (valueArray + 1).initialize(to: value1)
   }
 
   func initializeKey(
@@ -1342,8 +1342,8 @@ struct _PVCollisionNodePointer<Key : Hashable, Value>
   ) {
     precondition(i >= 0 && i < layout.keyCount) // sanity check
 
-    (_keyArray + i).initialize(with: key)
-    (_valueArray(layout: layout) + i).initialize(with: value)
+    (_keyArray + i).initialize(to: key)
+    (_valueArray(layout: layout) + i).initialize(to: value)
   }
 
   func copyValues(
@@ -1372,11 +1372,11 @@ struct _PVCollisionNodePointer<Key : Hashable, Value>
 
     let keyArray = _keyArray
     keyArray.initialize(from: newKeys, count: layout.keyCount - 1)
-    (keyArray + layout.keyCount - 1).initialize(with: appendKey)
+    (keyArray + layout.keyCount - 1).initialize(to: appendKey)
 
     let valueArray = _valueArray(layout: layout)
     valueArray.initialize(from: newValues, count: layout.keyCount - 1)
-    (valueArray + layout.keyCount - 1).initialize(with: appendValue)
+    (valueArray + layout.keyCount - 1).initialize(to: appendValue)
   }
 
   func unsafeMaybeGet(

--- a/validation-test/stdlib/StringSlicesConcurrentAppend.swift
+++ b/validation-test/stdlib/StringSlicesConcurrentAppend.swift
@@ -89,7 +89,7 @@ func sliceConcurrentAppendThread(_ tid: ThreadID) {
 
 StringTestSuite.test("SliceConcurrentAppend") {
   barrierVar = UnsafeMutablePointer(allocatingCapacity: 1)
-  barrierVar!.initialize(with: _stdlib_pthread_barrier_t())
+  barrierVar!.initialize(to: _stdlib_pthread_barrier_t())
   var ret = _stdlib_pthread_barrier_init(barrierVar!, nil, 2)
   expectEqual(0, ret)
 

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -317,7 +317,7 @@ ${SelfName}TestSuite.test("nonNilNonEmpty") {
   let count = 4
   let allocated = UnsafeMutablePointer<Float>(allocatingCapacity: count)
   defer { allocated.deallocateCapacity(count) }
-  allocated.initialize(with: 1.0, count: count)
+  allocated.initialize(to: 1.0, count: count)
   allocated[count - 1] = 2.0
 
   let buffer = ${SelfType}(start: ${PointerType}(allocated), count: count - 1)
@@ -448,7 +448,7 @@ UnsafeMutableBufferPointerTestSuite.test("changeElementViaBuffer") {
   let count = 4
   let allocated = UnsafeMutablePointer<Float>(allocatingCapacity: count)
   defer { allocated.deallocateCapacity(count) }
-  allocated.initialize(with: 1.0, count: count)
+  allocated.initialize(to: 1.0, count: count)
   allocated[count-1] = -1.0
 
   var buffer = UnsafeMutableBufferPointer(start: allocated, count: count - 1)


### PR DESCRIPTION
As proposed in SE-0107: UnsafeRawPointer.

"with" is considered a vacuous preposition. "to" implies direction.

Do not merge without the corresponding corelibs-foundation PR.
