### PR TITLE
Implement SE-0091: Operators in types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,33 @@ Note: This is in reverse chronological order, so newer entries are added to the 
 Swift 3.0
 ---------
 
+* [SE-0091](https://github.com/apple/swift-evolution/blob/master/proposals/0091-improving-operators-in-protocols.md):
+  Operators can now be defined within types or extensions thereof. For example:
+
+  ```swift
+  struct Foo: Equatable {
+    let value: Int
+
+    static func ==(lhs: Foo, rhs: Foo) -> Bool {
+      return lhs.value == rhs.value
+    }
+  }
+  ```
+
+  Such operators must be declared as `static` (or, within a class, `class
+  final`), and have the same signature as their global counterparts. As part of
+  this change, operator requirements declared in protocols must also be
+  explicitly declared `static`:
+
+  ```swift
+  protocol Equatable {
+    static func ==(lhs: Self, rhs: Self) -> Bool
+  }
+  ```
+
+  Note that the type checker performance optimization described by SE-0091 is
+  not yet implemented.
+
 * [SE-0099](https://github.com/apple/swift-evolution/blob/master/proposals/0099-conditionclauses.md):
   Condition clauses in `if`, `guard`, and `while` statements now use a more
   regular syntax. Each pattern or optional binding must be prefixed with `case`

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4988,7 +4988,8 @@ class FuncDecl final : public AbstractFunctionDecl,
       AccessorKeywordLoc(AccessorKeywordLoc),
       OverriddenOrDerivedForOrBehaviorParamDecl(),
       OperatorAndAddressorKind(nullptr, AddressorKind::NotAddressor) {
-    FuncDeclBits.IsStatic = StaticLoc.isValid() || getName().isOperator();
+    FuncDeclBits.IsStatic =
+      StaticLoc.isValid() || StaticSpelling != StaticSpellingKind::None;
     FuncDeclBits.StaticSpelling = static_cast<unsigned>(StaticSpelling);
     assert(NumParameterLists > 0 && "Must have at least an empty tuple arg");
     setType(Ty);

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -289,8 +289,6 @@ ERROR(associated_type_generic_parameter_list,PointsToFirstBadToken,
 
 
 // Func
-ERROR(func_decl_nonglobal_operator,none,
-      "operators are only allowed at global scope", ())
 ERROR(func_decl_without_paren,PointsToFirstBadToken,
       "expected '(' in argument list of function declaration", ())
 ERROR(static_func_decl_global_scope,none,
@@ -298,6 +296,9 @@ ERROR(static_func_decl_global_scope,none,
       (StaticSpellingKind))
 ERROR(func_decl_expected_arrow,none,
       "expected '->' after function parameter tuple", ())
+WARNING(operator_static_in_protocol,none,
+        "operator '%0' declared in protocol must be 'static'",
+        (StringRef))
 
 // Enum
 ERROR(expected_lbrace_enum,PointsToFirstBadToken,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -616,6 +616,13 @@ NOTE(unary_operator_declaration_here,none,
    "%select{prefix|postfix}0 operator found here", (bool))
 ERROR(invalid_arg_count_for_operator,none,
       "operators must have one or two arguments", ())
+ERROR(operator_in_local_scope,none,
+      "operator functions can only be declared at global or in type scope", ())
+ERROR(nonstatic_operator_in_type,none,
+      "operator %0 declared in type %1 must be 'static'", (Identifier, Type))
+ERROR(nonfinal_operator_in_class,none,
+      "operator %0 declared in non-final class %1 must be 'final'",
+      (Identifier, Type))
 
 //------------------------------------------------------------------------------
 // Type Check Coercions

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2704,7 +2704,7 @@ void PrintAST::visitFuncDecl(FuncDecl *decl) {
       printSourceRange(Range, Ctx);
     } else {
       if (!Options.SkipIntroducerKeywords) {
-        if (decl->isStatic() && !decl->isOperator())
+        if (decl->isStatic())
           printStaticKeyword(decl->getCorrectStaticSpelling());
         if (decl->isMutating() && !decl->getAttrs().hasAttribute<MutatingAttr>()) {
           Printer.printKeyword("mutating");

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4377,10 +4377,7 @@ bool FuncDecl::isUnaryOperator() const {
   if (!isOperator())
     return false;
   
-  unsigned opArgIndex
-    = getDeclContext()->getAsProtocolOrProtocolExtensionContext() ? 1 : 0;
-  
-  auto *params = getParameterList(opArgIndex);
+  auto *params = getParameterList(getDeclContext()->isTypeContext());
   return params->size() == 1 && !params->get(0)->isVariadic();
 }
 
@@ -4388,11 +4385,10 @@ bool FuncDecl::isBinaryOperator() const {
   if (!isOperator())
     return false;
   
-  unsigned opArgIndex
-    = getDeclContext()->getAsProtocolOrProtocolExtensionContext() ? 1 : 0;
-  
-  auto *params = getParameterList(opArgIndex);
-  return params->size() == 2 && !params->get(1)->isVariadic();
+  auto *params = getParameterList(getDeclContext()->isTypeContext());
+  return params->size() == 2 &&
+    !params->get(0)->isVariadic() &&
+    !params->get(1)->isVariadic();
 }
 
 ConstructorDecl::ConstructorDecl(DeclName Name, SourceLoc ConstructorLoc,

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3898,6 +3898,41 @@ public:
   void bindFuncDeclToOperator(FuncDecl *FD) {
     OperatorDecl *op = nullptr;
     auto operatorName = FD->getFullName().getBaseName();
+
+    // Check for static/final/class when we're in a type.
+    auto dc = FD->getDeclContext();
+    if (dc->isTypeContext()) {
+      // Within a class, operator functions must be 'static' or 'final'.
+      if (auto classDecl = dc->getAsClassOrClassExtensionContext()) {
+        // For a class, we also need the function or class to be 'final'.
+        if (!classDecl->isFinal() && !FD->isFinal() &&
+            FD->getStaticSpelling() != StaticSpellingKind::KeywordStatic) {
+          if (!FD->isStatic()) {
+            TC.diagnose(FD->getLoc(), diag::nonstatic_operator_in_type,
+                        operatorName,
+                        dc->getDeclaredInterfaceType())
+              .fixItInsert(FD->getAttributeInsertionLoc(/*forModifier=*/true),
+                           "static ");
+          } else {
+            TC.diagnose(FD->getLoc(), diag::nonfinal_operator_in_class,
+                        operatorName, dc->getDeclaredInterfaceType())
+              .fixItInsert(FD->getAttributeInsertionLoc(/*forModifier=*/true),
+                           "final ");
+            FD->getAttrs().add(new (TC.Context) FinalAttr(/*IsImplicit=*/true));
+          }
+        }
+      } else if (!FD->isStatic()) {
+        // Operator functions must be static.
+        TC.diagnose(FD, diag::nonstatic_operator_in_type,
+                    operatorName,
+                    dc->getDeclaredInterfaceType())
+          .fixItInsert(FD->getAttributeInsertionLoc(/*forModifier=*/true),
+                       "static ");
+      }
+    } else if (!dc->isModuleScopeContext()) {
+      TC.diagnose(FD, diag::operator_in_local_scope);
+    }
+
     SourceFile &SF = *FD->getDeclContext()->getParentSourceFile();
     if (FD->isUnaryOperator()) {
       if (FD->getAttrs().hasAttribute<PrefixAttr>()) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -707,7 +707,9 @@ matchWitness(TypeChecker &tc,
     auto funcWitness = cast<FuncDecl>(witness);
 
     // Either both must be 'static' or neither.
-    if (funcReq->isStatic() != funcWitness->isStatic())
+    if (funcReq->isStatic() != funcWitness->isStatic() &&
+        !(funcReq->isOperator() &&
+          !funcWitness->getDeclContext()->isTypeContext()))
       return RequirementMatch(witness, MatchKind::StaticNonStaticConflict);
 
     // If we require a prefix operator and the witness is not a prefix operator,

--- a/stdlib/public/SDK/Foundation/AffineTransform.swift
+++ b/stdlib/public/SDK/Foundation/AffineTransform.swift
@@ -254,12 +254,13 @@ extension AffineTransform : ReferenceConvertible, Hashable, CustomStringConverti
     public var debugDescription: String {
         return description
     }
-}
 
-public func ==(lhs: AffineTransform, rhs: AffineTransform) -> Bool {
-    return lhs.m11 == rhs.m11 && lhs.m12 == rhs.m12 &&
-           lhs.m21 == rhs.m21 && lhs.m22 == rhs.m22 &&
-           lhs.tX == rhs.tX && lhs.tY == rhs.tY
+    public static func ==(lhs: AffineTransform, rhs: AffineTransform) -> Bool {
+        return lhs.m11 == rhs.m11 && lhs.m12 == rhs.m12 &&
+               lhs.m21 == rhs.m21 && lhs.m22 == rhs.m22 &&
+               lhs.tX == rhs.tX && lhs.tY == rhs.tY
+    }
+
 }
 
 extension AffineTransform : _ObjectiveCBridgeable {

--- a/stdlib/public/SDK/Foundation/Calendar.swift
+++ b/stdlib/public/SDK/Foundation/Calendar.swift
@@ -1065,19 +1065,20 @@ public struct Calendar : CustomStringConvertible, CustomDebugStringConvertible, 
             return identifierMap[identifier]!
         }
     }
-}
 
-public func ==(lhs: Calendar, rhs: Calendar) -> Bool {
-    if lhs._autoupdating || rhs._autoupdating {
-        return lhs._autoupdating == rhs._autoupdating
-    } else {
-        // NSCalendar's isEqual is broken (27019864) so we must implement this ourselves
-        return lhs.identifier == rhs.identifier &&
-            lhs.locale == rhs.locale &&
-            lhs.timeZone == rhs.timeZone &&
-            lhs.firstWeekday == rhs.firstWeekday &&
-            lhs.minimumDaysInFirstWeek == rhs.minimumDaysInFirstWeek
+    public static func ==(lhs: Calendar, rhs: Calendar) -> Bool {
+        if lhs._autoupdating || rhs._autoupdating {
+            return lhs._autoupdating == rhs._autoupdating
+        } else {
+            // NSCalendar's isEqual is broken (27019864) so we must implement this ourselves
+            return lhs.identifier == rhs.identifier &&
+                lhs.locale == rhs.locale &&
+                lhs.timeZone == rhs.timeZone &&
+                lhs.firstWeekday == rhs.firstWeekday &&
+                lhs.minimumDaysInFirstWeek == rhs.minimumDaysInFirstWeek
+        }
     }
+
 }
 
 extension Calendar : _ObjectiveCBridgeable {

--- a/stdlib/public/SDK/Foundation/CharacterSet.swift
+++ b/stdlib/public/SDK/Foundation/CharacterSet.swift
@@ -424,11 +424,11 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
     public func isSuperset(of other: CharacterSet) -> Bool {
         return _mapUnmanaged { $0.isSuperset(of: other) }
     }
-}
 
-/// Returns true if the two `CharacterSet`s are equal.
-public func ==(lhs : CharacterSet, rhs: CharacterSet) -> Bool {
-    return lhs._wrapped.isEqual(rhs as NSCharacterSet)
+    /// Returns true if the two `CharacterSet`s are equal.
+    public static func ==(lhs : CharacterSet, rhs: CharacterSet) -> Bool {
+        return lhs._wrapped.isEqual(rhs as NSCharacterSet)
+    }
 }
 
 

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -644,11 +644,11 @@ public struct Data : ReferenceConvertible, CustomStringConvertible, Equatable, H
     
     @available(*, unavailable, message: "use withUnsafeMutableBytes instead")
     public var mutableBytes: UnsafeMutablePointer<Void> { fatalError() }
-}
 
-/// Returns `true` if the two `Data` arguments are equal.
-public func ==(d1 : Data, d2 : Data) -> Bool {
-    return d1._wrapped.isEqual(to: d2)
+    /// Returns `true` if the two `Data` arguments are equal.
+    public static func ==(d1 : Data, d2 : Data) -> Bool {
+        return d1._wrapped.isEqual(to: d2)
+    }
 }
 
 /// Provides bridging functionality for struct Data to class NSData and vice-versa.

--- a/stdlib/public/SDK/Foundation/Date.swift
+++ b/stdlib/public/SDK/Foundation/Date.swift
@@ -186,45 +186,46 @@ public struct Date : ReferenceConvertible, Comparable, Equatable, CustomStringCo
     }
     
     public var debugDescription: String { return description }
-}
 
-/// Returns true if the two `Date` values represent the same point in time.
-public func ==(lhs: Date, rhs: Date) -> Bool {
-    return lhs.timeIntervalSinceReferenceDate == rhs.timeIntervalSinceReferenceDate
-}
+    /// Returns true if the two `Date` values represent the same point in time.
+    public static func ==(lhs: Date, rhs: Date) -> Bool {
+        return lhs.timeIntervalSinceReferenceDate == rhs.timeIntervalSinceReferenceDate
+    }
 
-/// Returns true if the left hand `Date` is earlier in time than the right hand `Date`.
-public func <(lhs: Date, rhs: Date) -> Bool {
-    return lhs.timeIntervalSinceReferenceDate < rhs.timeIntervalSinceReferenceDate
-}
+    /// Returns true if the left hand `Date` is earlier in time than the right hand `Date`.
+    public static func <(lhs: Date, rhs: Date) -> Bool {
+        return lhs.timeIntervalSinceReferenceDate < rhs.timeIntervalSinceReferenceDate
+    }
 
-/// Returns true if the left hand `Date` is later in time than the right hand `Date`.
-public func >(lhs: Date, rhs: Date) -> Bool {
-    return lhs.timeIntervalSinceReferenceDate > rhs.timeIntervalSinceReferenceDate
-}
+    /// Returns true if the left hand `Date` is later in time than the right hand `Date`.
+    public static func >(lhs: Date, rhs: Date) -> Bool {
+        return lhs.timeIntervalSinceReferenceDate > rhs.timeIntervalSinceReferenceDate
+    }
 
-/// Returns a `Date` with a specified amount of time added to it.
-public func +(lhs: Date, rhs: TimeInterval) -> Date {
-    return Date(timeIntervalSinceReferenceDate: lhs.timeIntervalSinceReferenceDate + rhs)
-}
+    /// Returns a `Date` with a specified amount of time added to it.
+    public static func +(lhs: Date, rhs: TimeInterval) -> Date {
+        return Date(timeIntervalSinceReferenceDate: lhs.timeIntervalSinceReferenceDate + rhs)
+    }
 
-/// Returns a `Date` with a specified amount of time subtracted from it.
-public func -(lhs: Date, rhs: TimeInterval) -> Date {
-    return Date(timeIntervalSinceReferenceDate: lhs.timeIntervalSinceReferenceDate - rhs)
-}
+    /// Returns a `Date` with a specified amount of time subtracted from it.
+    public static func -(lhs: Date, rhs: TimeInterval) -> Date {
+        return Date(timeIntervalSinceReferenceDate: lhs.timeIntervalSinceReferenceDate - rhs)
+    }
 
-/// Add a `TimeInterval` to a `Date`.
-///
-/// - warning: This only adjusts an absolute value. If you wish to add calendrical concepts like hours, days, months then you must use a `Calendar`. That will take into account complexities like daylight saving time, months with different numbers of days, and more.
-public func +=(lhs: inout Date, rhs: TimeInterval) {
-    lhs = lhs + rhs
-}
+    /// Add a `TimeInterval` to a `Date`.
+    ///
+    /// - warning: This only adjusts an absolute value. If you wish to add calendrical concepts like hours, days, months then you must use a `Calendar`. That will take into account complexities like daylight saving time, months with different numbers of days, and more.
+    public static func +=(lhs: inout Date, rhs: TimeInterval) {
+        lhs = lhs + rhs
+    }
 
-/// Subtract a `TimeInterval` from a `Date`.
-///
-/// - warning: This only adjusts an absolute value. If you wish to add calendrical concepts like hours, days, months then you must use a `Calendar`. That will take into account complexities like daylight saving time, months with different numbers of days, and more.
-public func -=(lhs: inout Date, rhs: TimeInterval) {
-    lhs = lhs - rhs
+    /// Subtract a `TimeInterval` from a `Date`.
+    ///
+    /// - warning: This only adjusts an absolute value. If you wish to add calendrical concepts like hours, days, months then you must use a `Calendar`. That will take into account complexities like daylight saving time, months with different numbers of days, and more.
+    public static func -=(lhs: inout Date, rhs: TimeInterval) {
+        lhs = lhs - rhs
+    }
+
 }
 
 extension Date : _ObjectiveCBridgeable {

--- a/stdlib/public/SDK/Foundation/DateComponents.swift
+++ b/stdlib/public/SDK/Foundation/DateComponents.swift
@@ -281,12 +281,13 @@ public struct DateComponents : ReferenceConvertible, Hashable, Equatable, _Mutab
         _handle = _MutableHandle(reference: reference)
     }
 
+    public static func ==(lhs : DateComponents, rhs: DateComponents) -> Bool {
+        // Don't copy references here; no one should be storing anything
+        return lhs._handle._uncopiedReference().isEqual(rhs._handle._uncopiedReference())
+    }
+
 }
 
-public func ==(lhs : DateComponents, rhs: DateComponents) -> Bool {
-    // Don't copy references here; no one should be storing anything
-    return lhs._handle._uncopiedReference().isEqual(rhs._handle._uncopiedReference())
-}
 
 // MARK: - Bridging
 

--- a/stdlib/public/SDK/Foundation/DateInterval.swift
+++ b/stdlib/public/SDK/Foundation/DateInterval.swift
@@ -168,16 +168,17 @@ public struct DateInterval : ReferenceConvertible, Comparable, Hashable {
     public var debugDescription: String {
         return description
     }
-}
 
-@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-public func ==(lhs: DateInterval, rhs: DateInterval) -> Bool {
-    return lhs.start == rhs.start && lhs.duration == rhs.duration
-}
+    @available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+    public static func ==(lhs: DateInterval, rhs: DateInterval) -> Bool {
+        return lhs.start == rhs.start && lhs.duration == rhs.duration
+    }
 
-@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-public func <(lhs: DateInterval, rhs: DateInterval) -> Bool {
-    return lhs.compare(rhs) == .orderedAscending
+    @available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+    public static func <(lhs: DateInterval, rhs: DateInterval) -> Bool {
+        return lhs.compare(rhs) == .orderedAscending
+    }
+
 }
 
 @available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)

--- a/stdlib/public/SDK/Foundation/Decimal.swift
+++ b/stdlib/public/SDK/Foundation/Decimal.swift
@@ -123,38 +123,39 @@ extension Decimal {
     public var nextDown: Decimal {
         return self - Decimal(_exponent: _exponent, _length: 1, _isNegative: 0, _isCompact: 1, _reserved: 0, _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000))
     }
-}
 
-public func +(lhs: Decimal, rhs: Decimal) -> Decimal {
-    var res = Decimal()
-    var leftOp = lhs
-    var rightOp = rhs
-    NSDecimalAdd(&res, &leftOp, &rightOp, .plain)
-    return res
-}
+    public static func +(lhs: Decimal, rhs: Decimal) -> Decimal {
+        var res = Decimal()
+        var leftOp = lhs
+        var rightOp = rhs
+        NSDecimalAdd(&res, &leftOp, &rightOp, .plain)
+        return res
+    }
 
-public func -(lhs: Decimal, rhs: Decimal) -> Decimal {
-    var res = Decimal()
-    var leftOp = lhs
-    var rightOp = rhs
-    NSDecimalSubtract(&res, &leftOp, &rightOp, .plain)
-    return res
-}
+    public static func -(lhs: Decimal, rhs: Decimal) -> Decimal {
+        var res = Decimal()
+        var leftOp = lhs
+        var rightOp = rhs
+        NSDecimalSubtract(&res, &leftOp, &rightOp, .plain)
+        return res
+    }
 
-public func /(lhs: Decimal, rhs: Decimal) -> Decimal {
-    var res = Decimal()
-    var leftOp = lhs
-    var rightOp = rhs
-    NSDecimalDivide(&res, &leftOp, &rightOp, .plain)
-    return res
-}
+    public static func /(lhs: Decimal, rhs: Decimal) -> Decimal {
+        var res = Decimal()
+        var leftOp = lhs
+        var rightOp = rhs
+        NSDecimalDivide(&res, &leftOp, &rightOp, .plain)
+        return res
+    }
 
-public func *(lhs: Decimal, rhs: Decimal) -> Decimal {
-    var res = Decimal()
-    var leftOp = lhs
-    var rightOp = rhs
-    NSDecimalMultiply(&res, &leftOp, &rightOp, .plain)
-    return res
+    public static func *(lhs: Decimal, rhs: Decimal) -> Decimal {
+        var res = Decimal()
+        var leftOp = lhs
+        var rightOp = rhs
+        NSDecimalMultiply(&res, &leftOp, &rightOp, .plain)
+        return res
+    }
+
 }
 
 public func pow(_ x: Decimal, _ y: Int) -> Decimal {
@@ -218,18 +219,18 @@ extension Decimal : Hashable, Comparable {
     public var hashValue: Int {
         return Int(bitPattern: __CFHashDouble(doubleValue))
     }
-}
 
-public func ==(lhs: Decimal, rhs: Decimal) -> Bool {
-    var lhsVal = lhs
-    var rhsVal = rhs
-    return NSDecimalCompare(&lhsVal, &rhsVal) == .orderedSame
-}
+    public static func ==(lhs: Decimal, rhs: Decimal) -> Bool {
+        var lhsVal = lhs
+        var rhsVal = rhs
+        return NSDecimalCompare(&lhsVal, &rhsVal) == .orderedSame
+    }
 
-public func <(lhs: Decimal, rhs: Decimal) -> Bool {
-    var lhsVal = lhs
-    var rhsVal = rhs
-    return NSDecimalCompare(&lhsVal, &rhsVal) == .orderedAscending
+    public static func <(lhs: Decimal, rhs: Decimal) -> Bool {
+        var lhsVal = lhs
+        var rhsVal = rhs
+        return NSDecimalCompare(&lhsVal, &rhsVal) == .orderedAscending
+    }
 }
 
 extension Decimal : ExpressibleByFloatLiteral {

--- a/stdlib/public/SDK/Foundation/IndexPath.swift
+++ b/stdlib/public/SDK/Foundation/IndexPath.swift
@@ -177,36 +177,35 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
         }
     }
 
-}
+    public static func ==(lhs: IndexPath, rhs: IndexPath) -> Bool {
+        return lhs._indexes == rhs._indexes
+    }
 
-public func ==(lhs: IndexPath, rhs: IndexPath) -> Bool {
-    return lhs._indexes == rhs._indexes
-}
+    public static func +(lhs: IndexPath, rhs: IndexPath) -> IndexPath {
+        return lhs.appending(rhs)
+    }
 
-public func +(lhs: IndexPath, rhs: IndexPath) -> IndexPath {
-    return lhs.appending(rhs)
-}
+    public static func +=(lhs: inout IndexPath, rhs: IndexPath) {
+        lhs.append(rhs)
+    }
 
-public func +=(lhs: inout IndexPath, rhs: IndexPath) {
-    lhs.append(rhs)
-}
+    public static func <(lhs: IndexPath, rhs: IndexPath) -> Bool {
+        return lhs.compare(rhs) == ComparisonResult.orderedAscending
+    }
 
-public func <(lhs: IndexPath, rhs: IndexPath) -> Bool {
-    return lhs.compare(rhs) == ComparisonResult.orderedAscending
-}
+    public static func <=(lhs: IndexPath, rhs: IndexPath) -> Bool {
+        let order = lhs.compare(rhs)
+        return order == ComparisonResult.orderedAscending || order == ComparisonResult.orderedSame
+    }
 
-public func <=(lhs: IndexPath, rhs: IndexPath) -> Bool {
-    let order = lhs.compare(rhs)
-    return order == ComparisonResult.orderedAscending || order == ComparisonResult.orderedSame
-}
+    public static func >(lhs: IndexPath, rhs: IndexPath) -> Bool {
+        return lhs.compare(rhs) == ComparisonResult.orderedDescending
+    }
 
-public func >(lhs: IndexPath, rhs: IndexPath) -> Bool {
-    return lhs.compare(rhs) == ComparisonResult.orderedDescending
-}
-
-public func >=(lhs: IndexPath, rhs: IndexPath) -> Bool {
-    let order = lhs.compare(rhs)
-    return order == ComparisonResult.orderedDescending || order == ComparisonResult.orderedSame
+    public static func >=(lhs: IndexPath, rhs: IndexPath) -> Bool {
+        let order = lhs.compare(rhs)
+        return order == ComparisonResult.orderedDescending || order == ComparisonResult.orderedSame
+    }
 }
 
 extension IndexPath : _ObjectiveCBridgeable {

--- a/stdlib/public/SDK/Foundation/IndexSet.swift
+++ b/stdlib/public/SDK/Foundation/IndexSet.swift
@@ -12,28 +12,32 @@
 
 @_exported import Foundation // Clang module
 
-public func ==(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
-    return lhs.value == rhs.value && rhs.rangeIndex == rhs.rangeIndex
+extension IndexSet.Index {
+    public static func ==(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
+        return lhs.value == rhs.value && rhs.rangeIndex == rhs.rangeIndex
+    }
+
+    public static func <(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
+        return lhs.value < rhs.value && rhs.rangeIndex <= rhs.rangeIndex
+    }
+
+    public static func <=(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
+        return lhs.value <= rhs.value && rhs.rangeIndex <= rhs.rangeIndex
+    }
+
+    public static func >(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
+        return lhs.value > rhs.value && rhs.rangeIndex >= rhs.rangeIndex
+    }
+
+    public static func >=(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
+        return lhs.value >= rhs.value && rhs.rangeIndex >= rhs.rangeIndex
+    }
 }
 
-public func <(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
-    return lhs.value < rhs.value && rhs.rangeIndex <= rhs.rangeIndex
-}
-
-public func <=(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
-    return lhs.value <= rhs.value && rhs.rangeIndex <= rhs.rangeIndex
-}
-
-public func >(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
-    return lhs.value > rhs.value && rhs.rangeIndex >= rhs.rangeIndex
-}
-
-public func >=(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
-    return lhs.value >= rhs.value && rhs.rangeIndex >= rhs.rangeIndex
-}
-
-public func ==(lhs: IndexSet.RangeView, rhs: IndexSet.RangeView) -> Bool {
-    return lhs.startIndex == rhs.startIndex && lhs.endIndex == rhs.endIndex && lhs.indexSet == rhs.indexSet
+extension IndexSet.RangeView {
+    public static func ==(lhs: IndexSet.RangeView, rhs: IndexSet.RangeView) -> Bool {
+        return lhs.startIndex == rhs.startIndex && lhs.endIndex == rhs.endIndex && lhs.indexSet == rhs.indexSet
+    }
 }
 
 // We currently cannot use this mechanism because NSIndexSet is not abstract; it has its own ivars and therefore subclassing it using the same trick as NSData, etc. does not work.
@@ -837,8 +841,10 @@ private struct IndexSetBoundaryIterator : IteratorProtocol {
     }
 }
 
-public func ==(lhs: IndexSet, rhs: IndexSet) -> Bool {
-    return lhs._handle.map { $0.isEqual(to: rhs) }
+extension IndexSet {
+    public static func ==(lhs: IndexSet, rhs: IndexSet) -> Bool {
+        return lhs._handle.map { $0.isEqual(to: rhs) }
+    }
 }
 
 private func _toNSRange(_ r : Range<IndexSet.Element>) -> NSRange {

--- a/stdlib/public/SDK/Foundation/Locale.swift
+++ b/stdlib/public/SDK/Foundation/Locale.swift
@@ -429,13 +429,13 @@ public struct Locale : CustomStringConvertible, CustomDebugStringConvertible, Ha
             return _wrapped.hash
         }
     }
-}
 
-public func ==(lhs: Locale, rhs: Locale) -> Bool {
-    if lhs._autoupdating || rhs._autoupdating {
-        return lhs._autoupdating == rhs._autoupdating
-    } else {
-        return lhs._wrapped.isEqual(rhs._wrapped)
+    public static func ==(lhs: Locale, rhs: Locale) -> Bool {
+        if lhs._autoupdating || rhs._autoupdating {
+            return lhs._autoupdating == rhs._autoupdating
+        } else {
+            return lhs._wrapped.isEqual(rhs._wrapped)
+        }
     }
 }
 

--- a/stdlib/public/SDK/Foundation/Measurement.swift
+++ b/stdlib/public/SDK/Foundation/Measurement.swift
@@ -72,196 +72,180 @@ extension Measurement where UnitType : Dimension {
         self = converted(to: otherUnit)
     }
 
-}
+    /// Add two measurements of the same Dimension.
+    /// 
+    /// If the `unit` of the `lhs` and `rhs` are `isEqual`, then this returns the result of adding the `value` of each `Measurement`. If they are not equal, then this will convert both to the base unit of the `Dimension` and return the result as a `Measurement` of that base unit.
+    /// - returns: The result of adding the two measurements.
+    public static func +(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Measurement<UnitType> {
+        if lhs.unit.isEqual(rhs.unit) {
+            return Measurement(value: lhs.value + rhs.value, unit: lhs.unit)
+        } else {
+            let lhsValueInTermsOfBase = lhs.unit.converter.baseUnitValue(fromValue: lhs.value)
+            let rhsValueInTermsOfBase = rhs.unit.converter.baseUnitValue(fromValue: rhs.value)
+            return Measurement(value: lhsValueInTermsOfBase + rhsValueInTermsOfBase, unit: lhs.unit.dynamicType.baseUnit())
+        }
+    }
 
-/// Add two measurements of the same Unit.
-/// - precondition: The `unit` of `lhs` and `rhs` must be `isEqual`.
-/// - returns: A measurement of value `lhs.value + rhs.value` and unit `lhs.unit`.
-@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-public func +<UnitType : Unit>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Measurement<UnitType> {
-    if lhs.unit.isEqual(rhs.unit) {
-        return Measurement(value: lhs.value + rhs.value, unit: lhs.unit)
-    } else {
-        fatalError("Attempt to add measurements with non-equal units")
+    /// Subtract two measurements of the same Dimension.
+    ///
+    /// If the `unit` of the `lhs` and `rhs` are `==`, then this returns the result of subtracting the `value` of each `Measurement`. If they are not equal, then this will convert both to the base unit of the `Dimension` and return the result as a `Measurement` of that base unit.
+    /// - returns: The result of adding the two measurements.
+    public static func -(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Measurement<UnitType> {
+        if lhs.unit == rhs.unit {
+            return Measurement(value: lhs.value - rhs.value, unit: lhs.unit)
+        } else {
+            let lhsValueInTermsOfBase = lhs.unit.converter.baseUnitValue(fromValue: lhs.value)
+            let rhsValueInTermsOfBase = rhs.unit.converter.baseUnitValue(fromValue: rhs.value)
+            return Measurement(value: lhsValueInTermsOfBase - rhsValueInTermsOfBase, unit: lhs.unit.dynamicType.baseUnit())
+        }
+    }
+
+    /// Compare two measurements of the same `Dimension`.
+    ///
+    /// If `lhs.unit == rhs.unit`, returns `lhs.value == rhs.value`. Otherwise, converts `rhs` to the same unit as `lhs` and then compares the resulting values.
+    /// - returns: `true` if the measurements are equal.
+    public static func ==(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
+        if lhs.unit == rhs.unit {
+            return lhs.value == rhs.value
+        } else {
+            let rhsInLhs = rhs.converted(to: lhs.unit)
+            return lhs.value == rhsInLhs.value
+        }
+    }
+
+    /// Compare two measurements of the same `Dimension`.
+    ///
+    /// If `lhs.unit == rhs.unit`, returns `lhs.value < rhs.value`. Otherwise, converts `rhs` to the same unit as `lhs` and then compares the resulting values.
+    /// - returns: `true` if `lhs` is less than `rhs`.
+    public static func <(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
+        if lhs.unit == rhs.unit {
+            return lhs.value < rhs.value
+        } else {
+            let rhsInLhs = rhs.converted(to: lhs.unit)
+            return lhs.value < rhsInLhs.value
+        }
+    }
+
+    /// Compare two measurements of the same `Dimension`.
+    ///
+    /// If `lhs.unit == rhs.unit`, returns `lhs.value > rhs.value`. Otherwise, converts `rhs` to the same unit as `lhs` and then compares the resulting values.
+    /// - returns: `true` if `lhs` is greater than `rhs`.
+    public static func >(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
+        if lhs.unit == rhs.unit {
+            return lhs.value > rhs.value
+        } else {
+            let rhsInLhs = rhs.converted(to: lhs.unit)
+            return lhs.value > rhsInLhs.value
+        }
+    }
+
+    /// Compare two measurements of the same `Dimension`.
+    ///
+    /// If `lhs.unit == rhs.unit`, returns `lhs.value < rhs.value`. Otherwise, converts `rhs` to the same unit as `lhs` and then compares the resulting values.
+    /// - returns: `true` if `lhs` is less than or equal to `rhs`.
+    public static func <=(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
+        if lhs.unit == rhs.unit {
+            return lhs.value <= rhs.value
+        } else {
+            let rhsInLhs = rhs.converted(to: lhs.unit)
+            return lhs.value <= rhsInLhs.value
+        }
+    }
+
+    /// Compare two measurements of the same `Dimension`.
+    ///
+    /// If `lhs.unit == rhs.unit`, returns `lhs.value >= rhs.value`. Otherwise, converts `rhs` to the same unit as `lhs` and then compares the resulting values.
+    /// - returns: `true` if `lhs` is greater or equal to `rhs`.
+    public static func >=(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
+        if lhs.unit == rhs.unit {
+            return lhs.value >= rhs.value
+        } else {
+            let rhsInLhs = rhs.converted(to: lhs.unit)
+            return lhs.value >= rhsInLhs.value
+        }
     }
 }
 
-/// Add two measurements of the same Dimension.
-/// 
-/// If the `unit` of the `lhs` and `rhs` are `isEqual`, then this returns the result of adding the `value` of each `Measurement`. If they are not equal, then this will convert both to the base unit of the `Dimension` and return the result as a `Measurement` of that base unit.
-/// - returns: The result of adding the two measurements.
 @available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-public func +<UnitType : Dimension>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Measurement<UnitType> {
-    if lhs.unit.isEqual(rhs.unit) {
-        return Measurement(value: lhs.value + rhs.value, unit: lhs.unit)
-    } else {
-        let lhsValueInTermsOfBase = lhs.unit.converter.baseUnitValue(fromValue: lhs.value)
-        let rhsValueInTermsOfBase = rhs.unit.converter.baseUnitValue(fromValue: rhs.value)
-        return Measurement(value: lhsValueInTermsOfBase + rhsValueInTermsOfBase, unit: lhs.unit.dynamicType.baseUnit())
+extension Measurement {
+    /// Add two measurements of the same Unit.
+    /// - precondition: The `unit` of `lhs` and `rhs` must be `isEqual`.
+    /// - returns: A measurement of value `lhs.value + rhs.value` and unit `lhs.unit`.
+    public static func +(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Measurement<UnitType> {
+        if lhs.unit.isEqual(rhs.unit) {
+            return Measurement(value: lhs.value + rhs.value, unit: lhs.unit)
+        } else {
+            fatalError("Attempt to add measurements with non-equal units")
+        }
     }
-}
 
-/// Subtract two measurements of the same Unit.
-/// - precondition: The `unit` of `lhs` and `rhs` must be `isEqual`.
-/// - returns: A measurement of value `lhs.value - rhs.value` and unit `lhs.unit`.
-@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-public func -<UnitType : Unit>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Measurement<UnitType> {
-    if lhs.unit.isEqual(rhs.unit) {
-        return Measurement(value: lhs.value - rhs.value, unit: lhs.unit)
-    } else {
-        fatalError("Attempt to subtract measurements with non-equal units")
+    /// Subtract two measurements of the same Unit.
+    /// - precondition: The `unit` of `lhs` and `rhs` must be `isEqual`.
+    /// - returns: A measurement of value `lhs.value - rhs.value` and unit `lhs.unit`.
+    public static func -(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Measurement<UnitType> {
+        if lhs.unit.isEqual(rhs.unit) {
+            return Measurement(value: lhs.value - rhs.value, unit: lhs.unit)
+        } else {
+            fatalError("Attempt to subtract measurements with non-equal units")
+        }
     }
-}
 
-/// Subtract two measurements of the same Dimension.
-///
-/// If the `unit` of the `lhs` and `rhs` are `==`, then this returns the result of subtracting the `value` of each `Measurement`. If they are not equal, then this will convert both to the base unit of the `Dimension` and return the result as a `Measurement` of that base unit.
-/// - returns: The result of adding the two measurements.
-@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-public func -<UnitType : Dimension>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Measurement<UnitType> {
-    if lhs.unit == rhs.unit {
-        return Measurement(value: lhs.value - rhs.value, unit: lhs.unit)
-    } else {
-        let lhsValueInTermsOfBase = lhs.unit.converter.baseUnitValue(fromValue: lhs.value)
-        let rhsValueInTermsOfBase = rhs.unit.converter.baseUnitValue(fromValue: rhs.value)
-        return Measurement(value: lhsValueInTermsOfBase - rhsValueInTermsOfBase, unit: lhs.unit.dynamicType.baseUnit())
+    /// Multiply a measurement by a scalar value.
+    /// - returns: A measurement of value `lhs.value * rhs` with the same unit as `lhs`.
+    public static func *(lhs: Measurement<UnitType>, rhs: Double) -> Measurement<UnitType> {
+        return Measurement(value: lhs.value * rhs, unit: lhs.unit)
     }
-}
 
-/// Multiply a measurement by a scalar value.
-/// - returns: A measurement of value `lhs.value * rhs` with the same unit as `lhs`.
-@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-public func *<UnitType : Unit>(lhs: Measurement<UnitType>, rhs: Double) -> Measurement<UnitType> {
-    return Measurement(value: lhs.value * rhs, unit: lhs.unit)
-}
-
-/// Multiply a scalar value by a measurement.
-/// - returns: A measurement of value `lhs * rhs.value` with the same unit as `rhs`.
-@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-public func *<UnitType : Unit>(lhs: Double, rhs: Measurement<UnitType>) -> Measurement<UnitType> {
-    return Measurement(value: lhs * rhs.value, unit: rhs.unit)
-}
-
-/// Divide a measurement by a scalar value.
-/// - returns: A measurement of value `lhs.value / rhs` with the same unit as `lhs`.
-@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-public func /<UnitType : Unit>(lhs: Measurement<UnitType>, rhs: Double) -> Measurement<UnitType> {
-    return Measurement(value: lhs.value / rhs, unit: lhs.unit)
-}
-
-/// Divide a scalar value by a measurement.
-/// - returns: A measurement of value `lhs / rhs.value` with the same unit as `rhs`.
-@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-public func /<UnitType : Unit>(lhs: Double, rhs: Measurement<UnitType>) -> Measurement<UnitType> {
-    return Measurement(value: lhs / rhs.value, unit: rhs.unit)
-}
-
-/// Compare two measurements of the same `Unit`.
-/// - returns: `true` if `lhs.value == rhs.value && lhs.unit == rhs.unit`.
-@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-public func ==<UnitType : Unit>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
-    return lhs.value == rhs.value && lhs.unit == rhs.unit
-}
-
-/// Compare two measurements of the same `Dimension`.
-///
-/// If `lhs.unit == rhs.unit`, returns `lhs.value == rhs.value`. Otherwise, converts `rhs` to the same unit as `lhs` and then compares the resulting values.
-/// - returns: `true` if the measurements are equal.
-@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-public func ==<UnitType : Dimension>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
-    if lhs.unit == rhs.unit {
-        return lhs.value == rhs.value
-    } else {
-        let rhsInLhs = rhs.converted(to: lhs.unit)
-        return lhs.value == rhsInLhs.value
+    /// Multiply a scalar value by a measurement.
+    /// - returns: A measurement of value `lhs * rhs.value` with the same unit as `rhs`.
+    public static func *(lhs: Double, rhs: Measurement<UnitType>) -> Measurement<UnitType> {
+        return Measurement(value: lhs * rhs.value, unit: rhs.unit)
     }
-}
 
-/// Compare two measurements of the same `Unit`.
-/// - note: This function does not check `==` for the `unit` property of `lhs` and `rhs`.
-/// - returns: `lhs.value < rhs.value`
-@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-public func <<UnitType : Unit>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
-    return lhs.value < rhs.value
-}
+    /// Divide a measurement by a scalar value.
+    /// - returns: A measurement of value `lhs.value / rhs` with the same unit as `lhs`.
+    public static func /(lhs: Measurement<UnitType>, rhs: Double) -> Measurement<UnitType> {
+        return Measurement(value: lhs.value / rhs, unit: lhs.unit)
+    }
 
-/// Compare two measurements of the same `Dimension`.
-///
-/// If `lhs.unit == rhs.unit`, returns `lhs.value < rhs.value`. Otherwise, converts `rhs` to the same unit as `lhs` and then compares the resulting values.
-/// - returns: `true` if `lhs` is less than `rhs`.
-@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-public func <<UnitType : Dimension>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
-    if lhs.unit == rhs.unit {
+    /// Divide a scalar value by a measurement.
+    /// - returns: A measurement of value `lhs / rhs.value` with the same unit as `rhs`.
+    public static func /(lhs: Double, rhs: Measurement<UnitType>) -> Measurement<UnitType> {
+        return Measurement(value: lhs / rhs.value, unit: rhs.unit)
+    }
+
+    /// Compare two measurements of the same `Unit`.
+    /// - returns: `true` if `lhs.value == rhs.value && lhs.unit == rhs.unit`.
+    public static func ==(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
+        return lhs.value == rhs.value && lhs.unit == rhs.unit
+    }
+
+    /// Compare two measurements of the same `Unit`.
+    /// - note: This function does not check `==` for the `unit` property of `lhs` and `rhs`.
+    /// - returns: `lhs.value < rhs.value`
+    public static func <(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
         return lhs.value < rhs.value
-    } else {
-        let rhsInLhs = rhs.converted(to: lhs.unit)
-        return lhs.value < rhsInLhs.value
     }
-}
 
-/// Compare two measurements of the same `Unit`.
-/// - note: This function does not check `==` for the `unit` property of `lhs` and `rhs`.
-/// - returns: `lhs.value > rhs.value`
-@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-public func ><UnitType : Unit>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
-    return lhs.value > rhs.value
-}
-
-/// Compare two measurements of the same `Dimension`.
-///
-/// If `lhs.unit == rhs.unit`, returns `lhs.value > rhs.value`. Otherwise, converts `rhs` to the same unit as `lhs` and then compares the resulting values.
-/// - returns: `true` if `lhs` is greater than `rhs`.
-@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-public func ><UnitType : Dimension>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
-    if lhs.unit == rhs.unit {
+    /// Compare two measurements of the same `Unit`.
+    /// - note: This function does not check `==` for the `unit` property of `lhs` and `rhs`.
+    /// - returns: `lhs.value > rhs.value`
+    public static func >(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
         return lhs.value > rhs.value
-    } else {
-        let rhsInLhs = rhs.converted(to: lhs.unit)
-        return lhs.value > rhsInLhs.value
     }
-}
 
-/// Compare two measurements of the same `Unit`.
-/// - note: This function does not check `==` for the `unit` property of `lhs` and `rhs`.
-/// - returns: `lhs.value <= rhs.value`
-@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-public func <=<UnitType : Unit>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
-    return lhs.value <= rhs.value
-}
-
-/// Compare two measurements of the same `Dimension`.
-///
-/// If `lhs.unit == rhs.unit`, returns `lhs.value < rhs.value`. Otherwise, converts `rhs` to the same unit as `lhs` and then compares the resulting values.
-/// - returns: `true` if `lhs` is less than or equal to `rhs`.
-@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-public func <=<UnitType : Dimension>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
-    if lhs.unit == rhs.unit {
+    /// Compare two measurements of the same `Unit`.
+    /// - note: This function does not check `==` for the `unit` property of `lhs` and `rhs`.
+    /// - returns: `lhs.value <= rhs.value`
+    public static func <=(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
         return lhs.value <= rhs.value
-    } else {
-        let rhsInLhs = rhs.converted(to: lhs.unit)
-        return lhs.value <= rhsInLhs.value
     }
-}
 
-/// Compare two measurements of the same `Unit`.
-/// - note: This function does not check `==` for the `unit` property of `lhs` and `rhs`.
-/// - returns: `lhs.value >= rhs.value`
-@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-public func >=<UnitType : Unit>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
-    return lhs.value >= rhs.value
-}
-
-/// Compare two measurements of the same `Dimension`.
-///
-/// If `lhs.unit == rhs.unit`, returns `lhs.value >= rhs.value`. Otherwise, converts `rhs` to the same unit as `lhs` and then compares the resulting values.
-/// - returns: `true` if `lhs` is greater or equal to `rhs`.
-@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-public func >=<UnitType : Dimension>(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
-    if lhs.unit == rhs.unit {
+    /// Compare two measurements of the same `Unit`.
+    /// - note: This function does not check `==` for the `unit` property of `lhs` and `rhs`.
+    /// - returns: `lhs.value >= rhs.value`
+    public static func >=(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
         return lhs.value >= rhs.value
-    } else {
-        let rhsInLhs = rhs.converted(to: lhs.unit)
-        return lhs.value >= rhsInLhs.value
     }
 }
 

--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -296,9 +296,11 @@ public protocol __BridgedNSError : Error {
 }
 
 // Allow two bridged NSError types to be compared.
-public func ==<T: __BridgedNSError>(lhs: T, rhs: T) -> Bool
-  where T: RawRepresentable, T.RawValue: SignedInteger {
-  return lhs.rawValue.toIntMax() == rhs.rawValue.toIntMax()
+extension __BridgedNSError
+    where Self: RawRepresentable, Self.RawValue: SignedInteger {
+  public static func ==(lhs: Self, rhs: Self) -> Bool {
+    return lhs.rawValue.toIntMax() == rhs.rawValue.toIntMax()
+  }
 }
 
 public extension __BridgedNSError 
@@ -322,11 +324,12 @@ public extension __BridgedNSError
 }
 
 // Allow two bridged NSError types to be compared.
-public func ==<T: __BridgedNSError>(lhs: T, rhs: T) -> Bool
-  where T: RawRepresentable, T.RawValue: UnsignedInteger {
-  return lhs.rawValue.toUIntMax() == rhs.rawValue.toUIntMax()
+extension __BridgedNSError
+    where Self: RawRepresentable, Self.RawValue: UnsignedInteger {
+  public static func ==(lhs: Self, rhs: Self) -> Bool {
+    return lhs.rawValue.toUIntMax() == rhs.rawValue.toUIntMax()
+  }
 }
-
 
 public extension __BridgedNSError
     where Self: RawRepresentable, Self.RawValue: UnsignedInteger {
@@ -471,19 +474,21 @@ public protocol _ErrorCodeProtocol : Equatable {
   // Code match Self, but we cannot express those requirements yet.
 }
 
-/// Allow one to match an error code against an arbitrary error.
-public func ~= <Code: _ErrorCodeProtocol>(match: Code, error: Error)
-    -> Bool
-    where Code._ErrorType: _BridgedStoredNSError {
-  guard let specificError = error as? Code._ErrorType else { return false }
+extension _ErrorCodeProtocol where Self._ErrorType: _BridgedStoredNSError {
+  /// Allow one to match an error code against an arbitrary error.
+  public static func ~=(match: Self, error: Error) -> Bool {
+    guard let specificError = error as? Self._ErrorType else { return false }
 
-  // FIXME: Work around IRGen crash when we set Code == Code._ErrorType.Code.
-  let specificCode = specificError.code as! Code
-  return match == specificCode
+    // FIXME: Work around IRGen crash when we set Code == Code._ErrorType.Code.
+    let specificCode = specificError.code as! Self
+    return match == specificCode
+  }
 }
 
-public func == <T: _BridgedStoredNSError>(lhs: T, rhs: T) -> Bool {
-  return lhs._nsError.isEqual(rhs._nsError)
+extension _BridgedStoredNSError {
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    return lhs._nsError.isEqual(rhs._nsError)
+  }
 }
 
 @available(*, unavailable, renamed: "CocoaError")

--- a/stdlib/public/SDK/Foundation/NSStringEncodings.swift
+++ b/stdlib/public/SDK/Foundation/NSStringEncodings.swift
@@ -51,13 +51,13 @@ extension String {
 }
 
 extension String.Encoding : Hashable {
-  public var hashValue : Int {
-    return rawValue.hashValue
-  }
-}
+    public var hashValue : Int {
+        return rawValue.hashValue
+    }
 
-public func ==(lhs: String.Encoding, rhs: String.Encoding) -> Bool {
-  return lhs.rawValue == rhs.rawValue
+    public static func ==(lhs: String.Encoding, rhs: String.Encoding) -> Bool {
+        return lhs.rawValue == rhs.rawValue
+    }
 }
 
 extension String.Encoding : CustomStringConvertible {

--- a/stdlib/public/SDK/Foundation/Notification.swift
+++ b/stdlib/public/SDK/Foundation/Notification.swift
@@ -59,39 +59,39 @@ public struct Notification : ReferenceConvertible, Equatable, Hashable {
 
     // FIXME: Handle directly via API Notes
     public typealias Name = NSNotification.Name
-}
 
-/// Compare two notifications for equality.
-///
-/// - note: Notifications that contain non NSObject values in userInfo will never compare as equal. This is because the type information is not preserved in the `userInfo` dictionary.
-public func ==(lhs: Notification, rhs: Notification) -> Bool {
-    if lhs.name.rawValue != rhs.name.rawValue {
-        return false
-    }
-    if let lhsObj = lhs.object {
-        if let rhsObj = rhs.object {
-            if lhsObj !== rhsObj {
-                return false
-            }
-        } else {
+    /// Compare two notifications for equality.
+    ///
+    /// - note: Notifications that contain non NSObject values in userInfo will never compare as equal. This is because the type information is not preserved in the `userInfo` dictionary.
+    public static func ==(lhs: Notification, rhs: Notification) -> Bool {
+        if lhs.name.rawValue != rhs.name.rawValue {
             return false
         }
-    } else if rhs.object != nil {
-        return false
-    }
-    if let lhsUserInfo = lhs.userInfo {
-        if let rhsUserInfo = rhs.userInfo {
-            if lhsUserInfo.count != rhsUserInfo.count {
+        if let lhsObj = lhs.object {
+            if let rhsObj = rhs.object {
+                if lhsObj !== rhsObj {
+                    return false
+                }
+            } else {
                 return false
             }
-            return _NSUserInfoDictionary.compare(lhsUserInfo, rhsUserInfo)
-        } else {
+        } else if rhs.object != nil {
             return false
         }
-    } else if rhs.userInfo != nil {
-        return false
+        if let lhsUserInfo = lhs.userInfo {
+            if let rhsUserInfo = rhs.userInfo {
+                if lhsUserInfo.count != rhsUserInfo.count {
+                    return false
+                }
+                return _NSUserInfoDictionary.compare(lhsUserInfo, rhsUserInfo)
+            } else {
+                return false
+            }
+        } else if rhs.userInfo != nil {
+            return false
+        }
+        return true
     }
-    return true
 }
 
 extension Notification : _ObjectiveCBridgeable {

--- a/stdlib/public/SDK/Foundation/PersonNameComponents.swift
+++ b/stdlib/public/SDK/Foundation/PersonNameComponents.swift
@@ -77,12 +77,12 @@ public struct PersonNameComponents : ReferenceConvertible, Hashable, Equatable, 
     
     public var description: String { return _handle.map { $0.description } }
     public var debugDescription: String { return _handle.map { $0.debugDescription } }
-}
 
-@available(OSX 10.11, iOS 9.0, *)
-public func ==(lhs : PersonNameComponents, rhs: PersonNameComponents) -> Bool {
-    // Don't copy references here; no one should be storing anything
-    return lhs._handle._uncopiedReference().isEqual(rhs._handle._uncopiedReference())
+    @available(OSX 10.11, iOS 9.0, *)
+    public static func ==(lhs : PersonNameComponents, rhs: PersonNameComponents) -> Bool {
+        // Don't copy references here; no one should be storing anything
+        return lhs._handle._uncopiedReference().isEqual(rhs._handle._uncopiedReference())
+    }
 }
 
 @available(OSX 10.11, iOS 9.0, *)

--- a/stdlib/public/SDK/Foundation/TimeZone.swift
+++ b/stdlib/public/SDK/Foundation/TimeZone.swift
@@ -219,13 +219,13 @@ public struct TimeZone : CustomStringConvertible, CustomDebugStringConvertible, 
             return _wrapped.hash
         }
     }
-}
 
-public func ==(lhs: TimeZone, rhs: TimeZone) -> Bool {
-    if lhs._autoupdating || rhs._autoupdating {
-        return lhs._autoupdating == rhs._autoupdating
-    } else {
-        return lhs._wrapped.isEqual(rhs._wrapped)
+    public static func ==(lhs: TimeZone, rhs: TimeZone) -> Bool {
+        if lhs._autoupdating || rhs._autoupdating {
+            return lhs._autoupdating == rhs._autoupdating
+        } else {
+            return lhs._wrapped.isEqual(rhs._wrapped)
+        }
     }
 }
 

--- a/stdlib/public/SDK/Foundation/URL.swift
+++ b/stdlib/public/SDK/Foundation/URL.swift
@@ -1117,10 +1117,10 @@ public struct URL : ReferenceConvertible, CustomStringConvertible, Equatable {
     private var reference : NSURL {
         return _url
     }
-}
 
-public func ==(lhs: URL, rhs: URL) -> Bool {
-    return lhs.reference.isEqual(rhs.reference)
+    public static func ==(lhs: URL, rhs: URL) -> Bool {
+        return lhs.reference.isEqual(rhs.reference)
+    }
 }
 
 extension URL : _ObjectiveCBridgeable {

--- a/stdlib/public/SDK/Foundation/URLComponents.swift
+++ b/stdlib/public/SDK/Foundation/URLComponents.swift
@@ -309,11 +309,10 @@ public struct URLComponents : ReferenceConvertible, Hashable, CustomStringConver
         _handle = _MutableHandle(reference: reference)
     }
     
-}
-
-public func ==(lhs: URLComponents, rhs: URLComponents) -> Bool {
-    // Don't copy references here; no one should be storing anything
-    return lhs._handle._uncopiedReference().isEqual(rhs._handle._uncopiedReference())
+    public static func ==(lhs: URLComponents, rhs: URLComponents) -> Bool {
+        // Don't copy references here; no one should be storing anything
+        return lhs._handle._uncopiedReference().isEqual(rhs._handle._uncopiedReference())
+    }
 }
 
 extension URLComponents : _ObjectiveCBridgeable {
@@ -376,11 +375,11 @@ public struct URLQueryItem : ReferenceConvertible, Hashable, Equatable, CustomSt
     public var description: String { return _queryItem.description }
     public var debugDescription: String { return _queryItem.debugDescription }
     public var hashValue: Int { return _queryItem.hash }
-}
 
-@available(OSX 10.10, iOS 8.0, *)
-public func ==(lhs: URLQueryItem, rhs: URLQueryItem) -> Bool {
-    return lhs._queryItem.isEqual(rhs as NSURLQueryItem)
+    @available(OSX 10.10, iOS 8.0, *)
+    public static func ==(lhs: URLQueryItem, rhs: URLQueryItem) -> Bool {
+        return lhs._queryItem.isEqual(rhs as NSURLQueryItem)
+    }
 }
 
 @available(OSX 10.10, iOS 8.0, *)

--- a/stdlib/public/SDK/Foundation/URLRequest.swift
+++ b/stdlib/public/SDK/Foundation/URLRequest.swift
@@ -240,10 +240,10 @@ public struct URLRequest : ReferenceConvertible, CustomStringConvertible, Equata
     public var debugDescription: String {
         return _handle.map { $0.debugDescription }
     }
-}
 
-public func ==(lhs: URLRequest, rhs: URLRequest) -> Bool {
-    return lhs._handle._uncopiedReference().isEqual(rhs._handle._uncopiedReference())
+    public static func ==(lhs: URLRequest, rhs: URLRequest) -> Bool {
+        return lhs._handle._uncopiedReference().isEqual(rhs._handle._uncopiedReference())
+    }
 }
 
 extension URLRequest : _ObjectiveCBridgeable {

--- a/stdlib/public/SDK/Foundation/UUID.swift
+++ b/stdlib/public/SDK/Foundation/UUID.swift
@@ -85,25 +85,25 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
             return NSUUID(uuidBytes: unsafeBitCast($0, to: UnsafePointer<UInt8>.self))
         }
     }
-}
 
-public func ==(lhs: UUID, rhs: UUID) -> Bool {
-    return lhs.uuid.0 == rhs.uuid.0 &&
-        lhs.uuid.1 == rhs.uuid.1 &&
-        lhs.uuid.2 == rhs.uuid.2 &&
-        lhs.uuid.3 == rhs.uuid.3 &&
-        lhs.uuid.4 == rhs.uuid.4 &&
-        lhs.uuid.5 == rhs.uuid.5 &&
-        lhs.uuid.6 == rhs.uuid.6 &&
-        lhs.uuid.7 == rhs.uuid.7 &&
-        lhs.uuid.8 == rhs.uuid.8 &&
-        lhs.uuid.9 == rhs.uuid.9 &&
-        lhs.uuid.10 == rhs.uuid.10 &&
-        lhs.uuid.11 == rhs.uuid.11 &&
-        lhs.uuid.12 == rhs.uuid.12 &&
-        lhs.uuid.13 == rhs.uuid.13 &&
-        lhs.uuid.14 == rhs.uuid.14 &&
-        lhs.uuid.15 == rhs.uuid.15
+    public static func ==(lhs: UUID, rhs: UUID) -> Bool {
+        return lhs.uuid.0 == rhs.uuid.0 &&
+            lhs.uuid.1 == rhs.uuid.1 &&
+            lhs.uuid.2 == rhs.uuid.2 &&
+            lhs.uuid.3 == rhs.uuid.3 &&
+            lhs.uuid.4 == rhs.uuid.4 &&
+            lhs.uuid.5 == rhs.uuid.5 &&
+            lhs.uuid.6 == rhs.uuid.6 &&
+            lhs.uuid.7 == rhs.uuid.7 &&
+            lhs.uuid.8 == rhs.uuid.8 &&
+            lhs.uuid.9 == rhs.uuid.9 &&
+            lhs.uuid.10 == rhs.uuid.10 &&
+            lhs.uuid.11 == rhs.uuid.11 &&
+            lhs.uuid.12 == rhs.uuid.12 &&
+            lhs.uuid.13 == rhs.uuid.13 &&
+            lhs.uuid.14 == rhs.uuid.14 &&
+            lhs.uuid.15 == rhs.uuid.15
+    }
 }
 
 extension UUID : _ObjectiveCBridgeable {

--- a/stdlib/public/core/ArrayType.swift
+++ b/stdlib/public/core/ArrayType.swift
@@ -45,7 +45,7 @@ protocol _ArrayProtocol
   mutating func reserveCapacity(_ minimumCapacity: Int)
 
   /// Operator form of `append(contentsOf:)`.
-  func += <S : Sequence>(lhs: inout Self, rhs: S)
+  static func += <S : Sequence>(lhs: inout Self, rhs: S)
     where S.Iterator.Element == Iterator.Element
 
   /// Insert `newElement` at index `i`.

--- a/stdlib/public/core/Comparable.swift
+++ b/stdlib/public/core/Comparable.swift
@@ -145,7 +145,7 @@ public protocol Comparable : Equatable {
   /// - Parameters:
   ///   - lhs: A value to compare.
   ///   - rhs: Another value to compare.
-  func < (lhs: Self, rhs: Self) -> Bool
+  static func < (lhs: Self, rhs: Self) -> Bool
 
   /// Returns a Boolean value indicating whether the value of the first
   /// argument is less than or equal to that of the second argument.
@@ -153,7 +153,7 @@ public protocol Comparable : Equatable {
   /// - Parameters:
   ///   - lhs: A value to compare.
   ///   - rhs: Another value to compare.
-  func <= (lhs: Self, rhs: Self) -> Bool
+  static func <= (lhs: Self, rhs: Self) -> Bool
 
   /// Returns a Boolean value indicating whether the value of the first
   /// argument is greater than or equal to that of the second argument.
@@ -161,7 +161,7 @@ public protocol Comparable : Equatable {
   /// - Parameters:
   ///   - lhs: A value to compare.
   ///   - rhs: Another value to compare.
-  func >= (lhs: Self, rhs: Self) -> Bool
+  static func >= (lhs: Self, rhs: Self) -> Bool
 
   /// Returns a Boolean value indicating whether the value of the first
   /// argument is greater than that of the second argument.
@@ -169,7 +169,7 @@ public protocol Comparable : Equatable {
   /// - Parameters:
   ///   - lhs: A value to compare.
   ///   - rhs: Another value to compare.
-  func > (lhs: Self, rhs: Self) -> Bool
+  static func > (lhs: Self, rhs: Self) -> Bool
 }
 
 /// Returns a Boolean value indicating whether the value of the first argument

--- a/stdlib/public/core/Equatable.swift
+++ b/stdlib/public/core/Equatable.swift
@@ -161,7 +161,7 @@ public protocol Equatable {
   /// - Parameters:
   ///   - lhs: A value to compare.
   ///   - rhs: Another value to compare.
-  func == (lhs: Self, rhs: Self) -> Bool
+  static func == (lhs: Self, rhs: Self) -> Bool
 }
 
 /// Returns a Boolean value indicating whether two values are not equal.

--- a/stdlib/public/core/IntegerArithmetic.swift.gyb
+++ b/stdlib/public/core/IntegerArithmetic.swift.gyb
@@ -45,7 +45,7 @@ public protocol IntegerArithmetic : _IntegerArithmetic, Comparable {
 % for name, op, Action, result in integerBinaryOps:
   /// ${Action} `lhs` and `rhs`, returning ${result} and trapping in case of
   /// arithmetic overflow (except in -Ounchecked builds).
-  func ${op} (lhs: Self, rhs: Self) -> Self
+  static func ${op} (lhs: Self, rhs: Self) -> Self
 % end
   
   /// Explicitly convert to `IntMax`, trapping on overflow (except in
@@ -93,13 +93,13 @@ public func ${op}= <T : _IntegerArithmetic>(lhs: inout T, rhs: T) {
 /// - `-(-x) == x`
 public protocol SignedNumber : Comparable, ExpressibleByIntegerLiteral {
   /// Returns the result of negating `x`.
-  prefix func - (x: Self) -> Self
+  static prefix func - (x: Self) -> Self
 
   /// Returns the difference between `lhs` and `rhs`.
-  func - (lhs: Self, rhs: Self) -> Self
+  static func - (lhs: Self, rhs: Self) -> Self
   
   // Do not use this operator directly; call abs(x) instead
-  func ~> (_:Self,_:(_Abs, ())) -> Self
+  static func ~> (_:Self,_:(_Abs, ())) -> Self
 }
 
 // Unary negation in terms of subtraction.  This is a default

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -474,7 +474,7 @@ public protocol BitwiseOperations {
   ///     // Prints "0"
   ///
   /// - Complexity: O(1).
-  func & (lhs: Self, rhs: Self) -> Self
+  static func & (lhs: Self, rhs: Self) -> Self
 
   /// Returns the union of bits set in the two arguments.
   ///
@@ -493,7 +493,7 @@ public protocol BitwiseOperations {
   ///     // Prints "5"
   ///
   /// - Complexity: O(1).
-  func | (lhs: Self, rhs: Self) -> Self
+  static func | (lhs: Self, rhs: Self) -> Self
 
   /// Returns the bits that are set in exactly one of the two arguments.
   ///
@@ -513,7 +513,7 @@ public protocol BitwiseOperations {
   ///     // Prints "5"
   ///
   /// - Complexity: O(1).
-  func ^ (lhs: Self, rhs: Self) -> Self
+  static func ^ (lhs: Self, rhs: Self) -> Self
 
   /// Returns the inverse of the bits set in the argument.
   ///
@@ -532,7 +532,7 @@ public protocol BitwiseOperations {
   ///     let allOnes = ~UInt8.allZeros   // 0b11111111
   ///
   /// - Complexity: O(1).
-  prefix func ~ (x: Self) -> Self
+  static prefix func ~ (x: Self) -> Self
 
   /// The empty bitset.
   ///

--- a/test/Constraints/associated_self_types.swift
+++ b/test/Constraints/associated_self_types.swift
@@ -23,7 +23,7 @@ postfix func ~>> <_Self : MySequence, A : P where _Self.Iterator.Element == A.It
 }
 
 protocol _ExtendedSequence : MySequence {
-  postfix func ~>> <A : P where Self.Iterator.Element == A.Iterator.Element>(s: Self) -> A
+  static postfix func ~>> <A : P where Self.Iterator.Element == A.Iterator.Element>(s: Self) -> A
 }
 
 struct MyRangeIterator<T> : MyIteratorProtocol {

--- a/test/Constraints/generic_protocol_witness.swift
+++ b/test/Constraints/generic_protocol_witness.swift
@@ -14,7 +14,7 @@ protocol NeedsGenericMethods {
   func twoArgsOneVar<T>(x: T, y: T) // expected-note {{protocol requires function 'twoArgsOneVar(x:y:)' with type '<T> (x: T, y: T) -> ()'}}
   func twoArgsTwoVars<T, U>(x: T, y: U) // expected-note {{protocol requires function 'twoArgsTwoVars(x:y:)' with type '<T, U> (x: T, y: U) -> ()'}}
 
-  func •<T : Fungible>(x: Self, y: T) // expected-note {{protocol requires function '•' with type '<T> (TooTightConstraints, T) -> ()'}}
+  static func •<T : Fungible>(x: Self, y: T) // expected-note {{protocol requires function '•' with type '<T> (TooTightConstraints, T) -> ()'}}
 }
 
 class EqualConstraints : NeedsGenericMethods {

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -3,7 +3,7 @@
 infix operator +++ {}
 
 protocol ConcatToAnything {
-  func +++ <T>(lhs: Self, other: T)
+  static func +++ <T>(lhs: Self, other: T)
 }
 
 func min<T : Comparable>(_ x: T, y: T) -> T {

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -372,7 +372,7 @@ func testPreferClassMethodToCurriedInstanceMethod(_ obj: InstanceOrClassMethod) 
 }
 
 protocol Numeric {
-  func +(x: Self, y: Self) -> Self
+  static func +(x: Self, y: Self) -> Self
 }
 
 func acceptBinaryFunc<T>(_ x: T, _ fn: (T, T) -> T) { }

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -1,0 +1,114 @@
+// RUN: %target-parse-verify-swift
+
+// Use operators defined within a type.
+struct S0 {
+  static func +(lhs: S0, rhs: S0) -> S0 { return lhs }
+}
+
+func useS0(lhs: S0, rhs: S0) { 
+  _ = lhs + rhs
+}
+
+// Use operators defined within a generic type.
+struct S0b<T> {
+  static func + <U>(lhs: S0b<T>, rhs: U) -> S0b<U> { return S0b<U>() }
+}
+
+func useS0b(s1i: S0b<Int>, s: String) {
+  var s1s = s1i + s
+  s1s = S0b<String>()
+  _ = s1s
+}
+
+// Use operators defined within a protocol extension.
+infix operator %%% { }
+infix operator %%%% { }
+
+protocol P1 {
+  static func %%%(lhs: Self, rhs: Self) -> Bool
+}
+
+extension P1 {
+  static func %%%%(lhs: Self, rhs: Self) -> Bool {
+    return !(lhs %%% rhs)
+  }
+}
+
+func useP1Directly<T : P1>(lhs: T, rhs: T) {
+  _ = lhs %%% rhs
+  _ = lhs %%%% rhs
+}
+
+struct S1 : P1 {
+  static func %%%(lhs: S1, rhs: S1) -> Bool { return false }
+}
+
+func useP1Model(lhs: S1, rhs: S1) {
+  _ = lhs %%% rhs
+  _ = lhs %%%% rhs
+}
+
+struct S1b<T> : P1 {
+  static func %%%(lhs: S1b<T>, rhs: S1b<T>) -> Bool { return false }
+}
+
+func useP1ModelB(lhs: S1b<Int>, rhs: S1b<Int>) {
+  _ = lhs %%% rhs
+  _ = lhs %%%% rhs
+}
+
+func useP1ModelBGeneric<T>(lhs: S1b<T>, rhs: S1b<T>) {
+  _ = lhs %%% rhs
+  _ = lhs %%%% rhs
+}
+
+// Use operators defined within a protocol extension to satisfy a requirement.
+protocol P2 {
+  static func %%%(lhs: Self, rhs: Self) -> Bool
+  static func %%%%(lhs: Self, rhs: Self) -> Bool
+}
+
+extension P2 {
+  static func %%%%(lhs: Self, rhs: Self) -> Bool {
+    return !(lhs %%% rhs)
+  }
+}
+
+func useP2Directly<T : P2>(lhs: T, rhs: T) {
+  _ = lhs %%% rhs
+  _ = lhs %%%% rhs
+}
+
+struct S2 : P2 {
+  static func %%%(lhs: S2, rhs: S2) -> Bool { return false }
+}
+
+func useP2Model(lhs: S2, rhs: S2) {
+  _ = lhs %%% rhs
+  _ = lhs %%%% rhs
+}
+
+struct S2b<T> : P2 {
+  static func %%%(lhs: S2b<T>, rhs: S2b<T>) -> Bool { return false }
+}
+
+func useP2Model2(lhs: S2b<Int>, rhs: S2b<Int>) {
+  _ = lhs %%% rhs
+  _ = lhs %%%% rhs
+}
+
+func useP2Model2Generic<T>(lhs: S2b<T>, rhs: S2b<T>) {
+  _ = lhs %%% rhs
+  _ = lhs %%%% rhs
+}
+
+// Using an extension of one protocol to satisfy another conformance.
+protocol P3 { }
+
+extension P3 {
+  static func ==(lhs: Self, rhs: Self) -> Bool {
+    return true
+  }  
+}
+
+struct S3 : P3, Equatable { }

--- a/test/DebugInfo/basic.swift
+++ b/test/DebugInfo/basic.swift
@@ -51,7 +51,7 @@ func foo(_ a: Int64, _ b: Int64) -> Int64 {
        // CHECK-DAG: smul{{.*}}, !dbg ![[MUL:[0-9]+]]
        // CHECK-DAG: [[MUL]] = !DILocation(line: [[@LINE+4]], column: 16,
        // Runtime call to multiply function:
-       // CHECK-NOSIL: @_TZFsoi1mFTVs5Int64S__S_{{.*}}, !dbg ![[MUL:[0-9]+]]
+       // CHECK-NOSIL: @_TFsoi1mFTVs5Int64S__S_{{.*}}, !dbg ![[MUL:[0-9]+]]
        // CHECK-NOSIL: [[MUL]] = !DILocation(line: [[@LINE+1]], column: 16,
        return a*b
      } else {

--- a/test/Generics/algorithms.swift
+++ b/test/Generics/algorithms.swift
@@ -1,15 +1,15 @@
 // RUN: %target-parse-verify-swift
 
 protocol Eq {
-  func ==(lhs: Self, rhs: Self) -> Bool
-  func !=(lhs: Self, rhs: Self) -> Bool
+  static func ==(lhs: Self, rhs: Self) -> Bool
+  static func !=(lhs: Self, rhs: Self) -> Bool
 }
 
 protocol Comparable: Eq {
-  func <(lhs: Self, rhs: Self) -> Bool
-  func <=(lhs: Self, rhs: Self) -> Bool
-  func >=(lhs: Self, rhs: Self) -> Bool
-  func >(lhs: Self, rhs: Self) -> Bool
+  static func <(lhs: Self, rhs: Self) -> Bool
+  static func <=(lhs: Self, rhs: Self) -> Bool
+  static func >=(lhs: Self, rhs: Self) -> Bool
+  static func >(lhs: Self, rhs: Self) -> Bool
 }
 
 func find<R : IteratorProtocol where R.Element : Eq>

--- a/test/Generics/associated_types.swift
+++ b/test/Generics/associated_types.swift
@@ -51,7 +51,7 @@ prefix operator % {}
 
 protocol P2 {
   associatedtype Assoc2
-  prefix func %(target: Self) -> Assoc2
+  static prefix func %(target: Self) -> Assoc2
 }
 
 prefix func % <P:P1>(target: P) -> P.Assoc1 {
@@ -94,7 +94,7 @@ protocol P6 {
 
 protocol P7 : P6 {
   associatedtype Assoc : P6
-  func ~> (x: Self, _: S7a) -> Assoc
+  static func ~> (x: Self, _: S7a) -> Assoc
 }
 
 func ~> <T:P6>(x: T, _: S7a) -> S7b { return S7b() }

--- a/test/Generics/deduction.swift
+++ b/test/Generics/deduction.swift
@@ -221,7 +221,7 @@ func callRangeOfIsBefore(_ ia: [Int], da: [Double]) {
 // Deduction for member operators
 //===----------------------------------------------------------------------===//
 protocol Addable {
-  func +(x: Self, y: Self) -> Self
+  static func +(x: Self, y: Self) -> Self
 }
 func addAddables<T : Addable, U>(_ x: T, y: T, u: U) -> T {
   u + u // expected-error{{binary operator '+' cannot be applied to two 'U' operands}}
@@ -265,7 +265,7 @@ postfix operator <*> {}
 
 protocol MetaFunction {
   associatedtype Result
-  postfix func <*> (_: Self) -> Result?
+  static postfix func <*> (_: Self) -> Result?
 }
 
 protocol Bool_ {}

--- a/test/Generics/function_defs.swift
+++ b/test/Generics/function_defs.swift
@@ -178,7 +178,7 @@ func staticEqCheck<T : StaticEq, U : StaticEq>(_ t: T, u: U) {
 // Operators
 //===----------------------------------------------------------------------===//
 protocol Ordered {
-  func <(lhs: Self, rhs: Self) -> Bool
+  static func <(lhs: Self, rhs: Self) -> Bool
 }
 
 func testOrdered<T : Ordered>(_ x: T, y: Int) {

--- a/test/Generics/slice_test.swift
+++ b/test/Generics/slice_test.swift
@@ -83,7 +83,7 @@ class Vector<T> {
 }
 
 protocol Comparable {
-  func <(lhs: Self, rhs: Self) -> Bool
+  static func <(lhs: Self, rhs: Self) -> Bool
 }
 
 func sort<T : Comparable>(_ array: inout [T]) {
@@ -117,6 +117,6 @@ func findIf<T>(_ array: [T], fn: (T) -> Bool) -> Int {
 }
 
 protocol Eq {
-  func ==(lhs: Self, rhs: Self) -> Bool
-  func !=(lhs: Self, rhs: Self) -> Bool
+  static func ==(lhs: Self, rhs: Self) -> Bool
+  static func !=(lhs: Self, rhs: Self) -> Bool
 }

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -1109,10 +1109,10 @@ postfix operator <*> {}
 // PASS_2500-NEXT: {{^}}}{{$}}
 
 protocol d2600_ProtocolWithOperator1 {
-  postfix func <*>(_: Int)
+  static postfix func <*>(_: Int)
 }
 // PASS_2500: {{^}}protocol d2600_ProtocolWithOperator1 {{{$}}
-// PASS_2500-NEXT: {{^}}  postfix func <*>(_: Int){{$}}
+// PASS_2500-NEXT: {{^}}  postfix static func <*>(_: Int){{$}}
 // PASS_2500-NEXT: {{^}}}{{$}}
 
 struct d2601_TestAssignment {}

--- a/test/IRGen/enum_derived.swift
+++ b/test/IRGen/enum_derived.swift
@@ -25,8 +25,8 @@ enum E {
 
 // Check if the == comparison can be compiled to a simple icmp instruction.
 
-// CHECK-NORMAL-LABEL:define hidden i1 @_TZF12enum_derivedoi2eeFTOS_1ES0__Sb(i2, i2)
-// CHECK-TESTABLE-LABEL:define{{( protected)?}} i1 @_TZF12enum_derivedoi2eeFTOS_1ES0__Sb(i2, i2)
+// CHECK-NORMAL-LABEL:define hidden i1 @_TF12enum_derivedoi2eeFTOS_1ES0__Sb(i2, i2)
+// CHECK-TESTABLE-LABEL:define{{( protected)?}} i1 @_TF12enum_derivedoi2eeFTOS_1ES0__Sb(i2, i2)
 // CHECK: %2 = icmp eq i2 %0, %1
 // CHECK: ret i1 %2
 

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -178,7 +178,7 @@ func small_closure_capture_with_argument(_ x: Int) -> (y: Int) -> Int {
 // CHECK: sil shared @[[CLOSURE_NAME]] : $@convention(thin) (Int, @owned @box Int) -> Int
 // CHECK: bb0([[DOLLAR0:%[0-9]+]] : $Int, [[XBOX:%[0-9]+]] : $@box Int):
 // CHECK: [[XADDR:%[0-9]+]] = project_box [[XBOX]]
-// CHECK: [[PLUS:%[0-9]+]] = function_ref @_TZFsoi1pFTSiSi_Si{{.*}}
+// CHECK: [[PLUS:%[0-9]+]] = function_ref @_TFsoi1pFTSiSi_Si{{.*}}
 // CHECK: [[LHS:%[0-9]+]] = load [[XADDR]]
 // CHECK: [[RET:%[0-9]+]] = apply [[PLUS]]([[LHS]], [[DOLLAR0]])
 // CHECK: release [[XBOX]]

--- a/test/SILGen/mangling.swift
+++ b/test/SILGen/mangling.swift
@@ -32,22 +32,22 @@ prefix operator +- {}
 postfix operator +- {}
 infix operator +- {}
 
-// CHECK-LABEL: sil hidden @_TZF8manglingop2psurFxT_
+// CHECK-LABEL: sil hidden @_TF8manglingop2psurFxT_
 prefix func +- <T>(a: T) {}
-// CHECK-LABEL: sil hidden @_TZF8manglingoP2psurFxT_
+// CHECK-LABEL: sil hidden @_TF8manglingoP2psurFxT_
 postfix func +- <T>(a: T) {}
 
-// CHECK-LABEL: sil hidden @_TZF8manglingoi2psurFTxx_T_
+// CHECK-LABEL: sil hidden @_TF8manglingoi2psurFTxx_T_
 func +- <T>(a: T, b: T) {}
 
-// CHECK-LABEL: sil hidden @_TZF8manglingop2psurFT1ax1bx_T_
+// CHECK-LABEL: sil hidden @_TF8manglingop2psurFT1ax1bx_T_
 prefix func +- <T>(_: (a: T, b: T)) {}
-// CHECK-LABEL: sil hidden @_TZF8manglingoP2psurFT1ax1bx_T_
+// CHECK-LABEL: sil hidden @_TF8manglingoP2psurFT1ax1bx_T_
 postfix func +- <T>(_: (a: T, b: T)) {}
 
 infix operator «+» {}
 
-// CHECK-LABEL: sil hidden @_TZF8manglingXoi7p_qcaDcFTSiSi_Si
+// CHECK-LABEL: sil hidden @_TF8manglingXoi7p_qcaDcFTSiSi_Si
 func «+»(a: Int, b: Int) -> Int { return a + b }
 
 protocol Foo {}
@@ -134,7 +134,7 @@ func fooA<T: HasAssocType>(_: T) {}
 // CHECK-LABEL: sil hidden @_TF8mangling4fooBuRxS_12HasAssocTypewx5AssocS_9AssocReqtrFxT_ : $@convention(thin) <T where T : HasAssocType, T.Assoc : AssocReqt> (@in T) -> ()
 func fooB<T: HasAssocType where T.Assoc: AssocReqt>(_: T) {}
 
-// CHECK-LABEL: sil hidden @_TZF8manglingoi2qqFTSiSi_T_
+// CHECK-LABEL: sil hidden @_TF8manglingoi2qqFTSiSi_T_
 func ??(x: Int, y: Int) {}
 
 struct InstanceAndClassProperty {

--- a/test/SILGen/objc_bridging.swift
+++ b/test/SILGen/objc_bridging.swift
@@ -453,7 +453,7 @@ func getFridge(_ home: APPHouse) -> Refrigerator {
 // CHECK: bb0([[HOME:%[0-9]+]] : $APPHouse, [[DELTA:%[0-9]+]] : $Double):
 func updateFridgeTemp(_ home: APPHouse, delta: Double) {
   // +=
-  // CHECK: [[PLUS_EQ:%[0-9]+]] = function_ref @_TZFsoi2peFTRSdSd_T_
+  // CHECK: [[PLUS_EQ:%[0-9]+]] = function_ref @_TFsoi2peFTRSdSd_T_
 
   // Temporary fridge
   // CHECK: [[TEMP_FRIDGE:%[0-9]+]]  = alloc_stack $Refrigerator

--- a/test/SILGen/protocol_resilience.swift
+++ b/test/SILGen/protocol_resilience.swift
@@ -174,29 +174,29 @@ extension ResilientStorage {
 public protocol ResilientOperators {
   associatedtype AssocType : P
 
-  prefix func ~~~(s: Self)
-  func <*><T>(s: Self, t: T)
-  func <**><T>(t: T, s: Self) -> AssocType
-  func <===><T : ResilientOperators>(t: T, s: Self) -> T.AssocType
+  static prefix func ~~~(s: Self)
+  static func <*><T>(s: Self, t: T)
+  static func <**><T>(t: T, s: Self) -> AssocType
+  static func <===><T : ResilientOperators>(t: T, s: Self) -> T.AssocType
 }
 
 // CHECK-LABEL: sil [transparent] [thunk] @_TZFP19protocol_resilience18ResilientOperatorsop3tttfxT_
-// CHECK-LABEL: sil @_TZF19protocol_resilienceop3ttturFxT_
+// CHECK-LABEL: sil @_TF19protocol_resilienceop3ttturFxT_
 public prefix func ~~~<S>(s: S) {}
 
 // CHECK-LABEL: sil [transparent] [thunk] @_TZFP19protocol_resilience18ResilientOperatorsoi3lmgurfTxqd___T_
-// CHECK-LABEL: sil @_TZF19protocol_resilienceoi3lmgu0_rFTq_x_T_
+// CHECK-LABEL: sil @_TF19protocol_resilienceoi3lmgu0_rFTq_x_T_
 public func <*><T, S>(s: S, t: T) {}
 
 // Swap the generic parameters to make sure we don't mix up our DeclContexts
 // when mapping interface types in and out
 
 // CHECK-LABEL: sil [transparent] [thunk] @_TZFP19protocol_resilience18ResilientOperatorsoi4lmmgurfTqd__x_wx9AssocType
-// CHECK-LABEL: sil @_TZF19protocol_resilienceoi4lmmgu0_RxS_18ResilientOperatorsrFTq_x_wx9AssocType
+// CHECK-LABEL: sil @_TF19protocol_resilienceoi4lmmgu0_RxS_18ResilientOperatorsrFTq_x_wx9AssocType
 public func <**><S : ResilientOperators, T>(t: T, s: S) -> S.AssocType {}
 
 // CHECK-LABEL: sil [transparent] [thunk] @_TZFP19protocol_resilience18ResilientOperatorsoi5leeeguRd__S0_rfTqd__x_wd__9AssocType
-// CHECK-LABEL: sil @_TZF19protocol_resilienceoi5leeegu0_RxS_18ResilientOperators_S0_rFTxq__wx9AssocType
+// CHECK-LABEL: sil @_TF19protocol_resilienceoi5leeegu0_RxS_18ResilientOperators_S0_rFTxq__wx9AssocType
 public func <===><T : ResilientOperators, S : ResilientOperators>(t: T, s: S) -> T.AssocType {}
 
 

--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -529,7 +529,7 @@ func testRequireExprPattern(_ a : Int) {
   // CHECK: [[M1:%[0-9]+]] = function_ref @_TF10statements8marker_1FT_T_ : $@convention(thin) () -> ()
   // CHECK-NEXT: apply [[M1]]() : $@convention(thin) () -> ()
 
-  // CHECK: function_ref static Swift.~= infix <A where A: Swift.Equatable> (A, A) -> Swift.Bool
+  // CHECK: function_ref Swift.~= infix <A where A: Swift.Equatable> (A, A) -> Swift.Bool
   // CHECK: cond_br {{.*}}, bb1, bb2
   guard case 4 = a else { marker_2(); return }
 

--- a/test/SILGen/switch_objc.swift
+++ b/test/SILGen/switch_objc.swift
@@ -5,14 +5,14 @@
 import Foundation
 
 // CHECK-LABEL: sil hidden @_TF11switch_objc13matchesEitherFT5inputCSo4Hive1aS0_1bS0__Sb :
-func matchesEither(input input: Hive, a: Hive, b: Hive) -> Bool {
+func matchesEither(input: Hive, a: Hive, b: Hive) -> Bool {
   switch input {
-  // CHECK:   function_ref @_TZF10ObjectiveCoi2teFTCSo8NSObjectS0__Sb
+  // CHECK:   function_ref @_TF10ObjectiveCoi2teFTCSo8NSObjectS0__Sb
   // CHECK:   cond_br {{%.*}}, [[YES_CASE1:bb[0-9]+]], [[NOT_CASE1:bb[0-9]+]]
   // CHECK: [[YES_CASE1]]:
   // CHECK:   br [[RET_TRUE:bb[0-9]+]]
   // CHECK: [[NOT_CASE1]]:
-  // CHECK:   function_ref @_TZF10ObjectiveCoi2teFTCSo8NSObjectS0__Sb
+  // CHECK:   function_ref @_TF10ObjectiveCoi2teFTCSo8NSObjectS0__Sb
   // CHECK:   cond_br {{%.*}}, [[YES_CASE2:bb[0-9]+]], [[NOT_CASE2:bb[0-9]+]]
   // CHECK: [[YES_CASE2]]:
   case a, b:

--- a/test/SILGen/witnesses.swift
+++ b/test/SILGen/witnesses.swift
@@ -2,7 +2,7 @@
 
 infix operator <~> {}
 
-func archetype_method<T: X>(x x: T, y: T) -> T {
+func archetype_method<T: X>(x: T, y: T) -> T {
   var x = x
   var y = y
   return x.selfTypes(x: y)
@@ -12,7 +12,7 @@ func archetype_method<T: X>(x x: T, y: T) -> T {
 // CHECK:         apply [[METHOD]]<T>({{%.*}}, {{%.*}}, {{%.*}}) : $@convention(witness_method) <τ_0_0 where τ_0_0 : X> (@in τ_0_0, @inout τ_0_0) -> @out τ_0_0
 // CHECK:       }
 
-func archetype_generic_method<T: X>(x x: T, y: Loadable) -> Loadable {
+func archetype_generic_method<T: X>(x: T, y: Loadable) -> Loadable {
   var x = x
   return x.generic(x: y)
 }
@@ -23,14 +23,14 @@ func archetype_generic_method<T: X>(x x: T, y: Loadable) -> Loadable {
 
 // CHECK-LABEL: sil hidden @_TF9witnesses32archetype_associated_type_method{{.*}} : $@convention(thin) <T where T : WithAssoc> (@in T, @in T.AssocType) -> @out T
 // CHECK:         apply %{{[0-9]+}}<T, T.AssocType>
-func archetype_associated_type_method<T: WithAssoc>(x x: T, y: T.AssocType) -> T {
+func archetype_associated_type_method<T: WithAssoc>(x: T, y: T.AssocType) -> T {
   return x.useAssocType(x: y)
 }
 
 protocol StaticMethod { static func staticMethod() }
 
 // CHECK-LABEL: sil hidden @_TF9witnesses23archetype_static_method{{.*}} : $@convention(thin) <T where T : StaticMethod> (@in T) -> ()
-func archetype_static_method<T: StaticMethod>(x x: T) {
+func archetype_static_method<T: StaticMethod>(x: T) {
   // CHECK: [[METHOD:%.*]] = witness_method $T, #StaticMethod.staticMethod!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : StaticMethod> (@thick τ_0_0.Type) -> ()
   // CHECK: apply [[METHOD]]<T>
   T.staticMethod()
@@ -41,7 +41,7 @@ protocol Existentiable {
   func generic<T>() -> T
 }
 
-func protocol_method(x x: Existentiable) -> Loadable {
+func protocol_method(x: Existentiable) -> Loadable {
   return x.foo()
 }
 // CHECK-LABEL: sil hidden @_TF9witnesses15protocol_methodFT1xPS_13Existentiable__VS_8Loadable : $@convention(thin) (@in Existentiable) -> Loadable {
@@ -49,7 +49,7 @@ func protocol_method(x x: Existentiable) -> Loadable {
 // CHECK:         apply [[METHOD]]<[[OPENED]]>({{%.*}})
 // CHECK:       }
 
-func protocol_generic_method(x x: Existentiable) -> Loadable {
+func protocol_generic_method(x: Existentiable) -> Loadable {
   return x.generic()
 }
 // CHECK-LABEL: sil hidden @_TF9witnesses23protocol_generic_methodFT1xPS_13Existentiable__VS_8Loadable : $@convention(thin) (@in Existentiable) -> Loadable {
@@ -63,7 +63,7 @@ func protocol_generic_method(x x: Existentiable) -> Loadable {
 
 // CHECK-LABEL: sil hidden @_TF9witnesses20protocol_objc_methodFT1xPS_8ObjCAble__T_ : $@convention(thin) (@owned ObjCAble) -> ()
 // CHECK:         witness_method [volatile] $@opened({{.*}}) ObjCAble, #ObjCAble.foo!1.foreign
-func protocol_objc_method(x x: ObjCAble) {
+func protocol_objc_method(x: ObjCAble) {
   x.foo()
 }
 
@@ -73,31 +73,31 @@ protocol Classes : class {}
 
 protocol X {
   mutating
-  func selfTypes(x x: Self) -> Self
+  func selfTypes(x: Self) -> Self
   mutating
-  func loadable(x x: Loadable) -> Loadable
+  func loadable(x: Loadable) -> Loadable
   mutating
-  func addrOnly(x x: AddrOnly) -> AddrOnly
+  func addrOnly(x: AddrOnly) -> AddrOnly
   mutating
-  func generic<A>(x x: A) -> A
+  func generic<A>(x: A) -> A
   mutating
-  func classes<A2: Classes>(x x: A2) -> A2
-  func <~>(_ x: Self, y: Self) -> Self
+  func classes<A2: Classes>(x: A2) -> A2
+  static func <~>(_ x: Self, y: Self) -> Self
 }
 protocol Y {}
 
 protocol WithAssoc {
   associatedtype AssocType
-  func useAssocType(x x: AssocType) -> Self
+  func useAssocType(x: AssocType) -> Self
 }
 
 protocol ClassBounded : class {
-  func selfTypes(x x: Self) -> Self
+  func selfTypes(x: Self) -> Self
 }
 
 struct ConformingStruct : X {
   mutating
-  func selfTypes(x x: ConformingStruct) -> ConformingStruct { return x }
+  func selfTypes(x: ConformingStruct) -> ConformingStruct { return x }
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWV9witnesses16ConformingStructS_1XS_FS1_9selfTypes{{.*}} : $@convention(witness_method) (@in ConformingStruct, @inout ConformingStruct) -> @out ConformingStruct {
   // CHECK:       bb0(%0 : $*ConformingStruct, %1 : $*ConformingStruct, %2 : $*ConformingStruct):
   // CHECK-NEXT:    %3 = load %1 : $*ConformingStruct
@@ -110,7 +110,7 @@ struct ConformingStruct : X {
   // CHECK-NEXT:  }
   
   mutating
-  func loadable(x x: Loadable) -> Loadable { return x }
+  func loadable(x: Loadable) -> Loadable { return x }
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWV9witnesses16ConformingStructS_1XS_FS1_8loadable{{.*}} : $@convention(witness_method) (Loadable, @inout ConformingStruct) -> Loadable {
   // CHECK:       bb0(%0 : $Loadable, %1 : $*ConformingStruct):
   // CHECK-NEXT:    // function_ref
@@ -120,7 +120,7 @@ struct ConformingStruct : X {
   // CHECK-NEXT:  }
   
   mutating
-  func addrOnly(x x: AddrOnly) -> AddrOnly { return x }
+  func addrOnly(x: AddrOnly) -> AddrOnly { return x }
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWV9witnesses16ConformingStructS_1XS_FS1_8addrOnly{{.*}} : $@convention(witness_method) (@in AddrOnly, @inout ConformingStruct) -> @out AddrOnly {
   // CHECK:       bb0(%0 : $*AddrOnly, %1 : $*AddrOnly, %2 : $*ConformingStruct):
   // CHECK-NEXT:    // function_ref
@@ -131,7 +131,7 @@ struct ConformingStruct : X {
   // CHECK-NEXT:  }
   
   mutating
-  func generic<C>(x x: C) -> C { return x }
+  func generic<C>(x: C) -> C { return x }
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWV9witnesses16ConformingStructS_1XS_FS1_7generic{{.*}} : $@convention(witness_method) <A> (@in A, @inout ConformingStruct) -> @out A {
   // CHECK:       bb0(%0 : $*A, %1 : $*A, %2 : $*ConformingStruct):
   // CHECK-NEXT:    // function_ref
@@ -141,7 +141,7 @@ struct ConformingStruct : X {
   // CHECK-NEXT:    return %5 : $()
   // CHECK-NEXT:  }
   mutating
-  func classes<C2: Classes>(x x: C2) -> C2 { return x }
+  func classes<C2: Classes>(x: C2) -> C2 { return x }
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWV9witnesses16ConformingStructS_1XS_FS1_7classes{{.*}} : $@convention(witness_method) <A2 where A2 : Classes> (@owned A2, @inout ConformingStruct) -> @owned A2 {
   // CHECK:       bb0(%0 : $A2, %1 : $*ConformingStruct):
   // CHECK-NEXT:    // function_ref
@@ -156,7 +156,7 @@ func <~>(_ x: ConformingStruct, y: ConformingStruct) -> ConformingStruct { retur
 // CHECK-NEXT:    %4 = load %1 : $*ConformingStruct
 // CHECK-NEXT:    %5 = load %2 : $*ConformingStruct
 // CHECK-NEXT:    // function_ref
-// CHECK-NEXT:    %6 = function_ref @_TZF9witnessesoi3ltgFTVS_16ConformingStructS0__S0_ : $@convention(thin) (ConformingStruct, ConformingStruct) -> ConformingStruct
+// CHECK-NEXT:    %6 = function_ref @_TF9witnessesoi3ltgFTVS_16ConformingStructS0__S0_ : $@convention(thin) (ConformingStruct, ConformingStruct) -> ConformingStruct
 // CHECK-NEXT:    %7 = apply %6(%4, %5) : $@convention(thin) (ConformingStruct, ConformingStruct) -> ConformingStruct
 // CHECK-NEXT:    store %7 to %0 : $*ConformingStruct
 // CHECK-NEXT:    %9 = tuple ()
@@ -164,7 +164,7 @@ func <~>(_ x: ConformingStruct, y: ConformingStruct) -> ConformingStruct { retur
 // CHECK-NEXT:  }
 
 final class ConformingClass : X {
-  func selfTypes(x x: ConformingClass) -> ConformingClass { return x }
+  func selfTypes(x: ConformingClass) -> ConformingClass { return x }
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWC9witnesses15ConformingClassS_1XS_FS1_9selfTypes{{.*}} : $@convention(witness_method) (@in ConformingClass, @inout ConformingClass) -> @out ConformingClass {
   // CHECK:       bb0(%0 : $*ConformingClass, %1 : $*ConformingClass, %2 : $*ConformingClass):
   // -- load and retain 'self' from inout witness 'self' parameter
@@ -178,10 +178,10 @@ final class ConformingClass : X {
   // CHECK-NEXT:    strong_release %3
   // CHECK-NEXT:    return %9 : $()
   // CHECK-NEXT:  }
-  func loadable(x x: Loadable) -> Loadable { return x }
-  func addrOnly(x x: AddrOnly) -> AddrOnly { return x }
-  func generic<D>(x x: D) -> D { return x }
-  func classes<D2: Classes>(x x: D2) -> D2 { return x }
+  func loadable(x: Loadable) -> Loadable { return x }
+  func addrOnly(x: AddrOnly) -> AddrOnly { return x }
+  func generic<D>(x: D) -> D { return x }
+  func classes<D2: Classes>(x: D2) -> D2 { return x }
 }
 func <~>(_ x: ConformingClass, y: ConformingClass) -> ConformingClass { return x }
 
@@ -200,7 +200,7 @@ struct ConformingAOStruct : X {
   var makeMeAO : AddrOnly
 
   mutating
-  func selfTypes(x x: ConformingAOStruct) -> ConformingAOStruct { return x }
+  func selfTypes(x: ConformingAOStruct) -> ConformingAOStruct { return x }
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWV9witnesses18ConformingAOStructS_1XS_FS1_9selfTypes{{.*}} : $@convention(witness_method) (@in ConformingAOStruct, @inout ConformingAOStruct) -> @out ConformingAOStruct {
   // CHECK:       bb0(%0 : $*ConformingAOStruct, %1 : $*ConformingAOStruct, %2 : $*ConformingAOStruct):
   // CHECK-NEXT:    // function_ref
@@ -209,16 +209,16 @@ struct ConformingAOStruct : X {
   // CHECK-NEXT:    %5 = tuple ()
   // CHECK-NEXT:    return %5 : $()
   // CHECK-NEXT:  }
-  func loadable(x x: Loadable) -> Loadable { return x }
-  func addrOnly(x x: AddrOnly) -> AddrOnly { return x }
-  func generic<D>(x x: D) -> D { return x }
-  func classes<D2: Classes>(x x: D2) -> D2 { return x }
+  func loadable(x: Loadable) -> Loadable { return x }
+  func addrOnly(x: AddrOnly) -> AddrOnly { return x }
+  func generic<D>(x: D) -> D { return x }
+  func classes<D2: Classes>(x: D2) -> D2 { return x }
 }
 func <~>(_ x: ConformingAOStruct, y: ConformingAOStruct) -> ConformingAOStruct { return x }
 
 struct ConformsWithMoreGeneric : X, Y {
   mutating
-  func selfTypes<E>(x x: E) -> E { return x }
+  func selfTypes<E>(x: E) -> E { return x }
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWV9witnesses23ConformsWithMoreGenericS_1XS_FS1_9selfTypes{{.*}} : $@convention(witness_method) (@in ConformsWithMoreGeneric, @inout ConformsWithMoreGeneric) -> @out ConformsWithMoreGeneric {
   // CHECK:       bb0(%0 : $*ConformsWithMoreGeneric, %1 : $*ConformsWithMoreGeneric, %2 : $*ConformsWithMoreGeneric):
   // CHECK-NEXT:    // function_ref
@@ -227,9 +227,9 @@ struct ConformsWithMoreGeneric : X, Y {
   // CHECK-NEXT:    [[RESULT:%.*]] = tuple ()
   // CHECK-NEXT:    return [[RESULT]] : $()
   // CHECK-NEXT:  }
-  func loadable<F>(x x: F) -> F { return x }
+  func loadable<F>(x: F) -> F { return x }
   mutating
-  func addrOnly<G>(x x: G) -> G { return x }
+  func addrOnly<G>(x: G) -> G { return x }
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWV9witnesses23ConformsWithMoreGenericS_1XS_FS1_8addrOnly{{.*}} : $@convention(witness_method) (@in AddrOnly, @inout ConformsWithMoreGeneric) -> @out AddrOnly {
   // CHECK:       bb0(%0 : $*AddrOnly, %1 : $*AddrOnly, %2 : $*ConformsWithMoreGeneric):
   // CHECK-NEXT:    // function_ref
@@ -240,7 +240,7 @@ struct ConformsWithMoreGeneric : X, Y {
   // CHECK-NEXT:  }
 
   mutating
-  func generic<H>(x x: H) -> H { return x }
+  func generic<H>(x: H) -> H { return x }
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWV9witnesses23ConformsWithMoreGenericS_1XS_FS1_7generic{{.*}} : $@convention(witness_method) <A> (@in A, @inout ConformsWithMoreGeneric) -> @out A {
   // CHECK:       bb0(%0 : $*A, %1 : $*A, %2 : $*ConformsWithMoreGeneric):
   // CHECK-NEXT:    // function_ref
@@ -251,7 +251,7 @@ struct ConformsWithMoreGeneric : X, Y {
   // CHECK-NEXT:  }
 
   mutating
-  func classes<I>(x x: I) -> I { return x }
+  func classes<I>(x: I) -> I { return x }
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWV9witnesses23ConformsWithMoreGenericS_1XS_FS1_7classes{{.*}} : $@convention(witness_method) <A2 where A2 : Classes> (@owned A2, @inout ConformsWithMoreGeneric) -> @owned A2 {
   // CHECK:       bb0(%0 : $A2, %1 : $*ConformsWithMoreGeneric):
   // CHECK-NEXT:    [[SELF_BOX:%.*]] = alloc_stack $A2
@@ -270,14 +270,14 @@ func <~> <J: Y, K: Y>(_ x: J, y: K) -> K { return y }
 // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWV9witnesses23ConformsWithMoreGenericS_1XS_ZFS1_oi3ltg{{.*}} : $@convention(witness_method) (@in ConformsWithMoreGeneric, @in ConformsWithMoreGeneric, @thick ConformsWithMoreGeneric.Type) -> @out ConformsWithMoreGeneric {
 // CHECK:       bb0(%0 : $*ConformsWithMoreGeneric, %1 : $*ConformsWithMoreGeneric, %2 : $*ConformsWithMoreGeneric, %3 : $@thick ConformsWithMoreGeneric.Type):
 // CHECK-NEXT:    // function_ref
-// CHECK-NEXT:    [[WITNESS_FN:%.*]] = function_ref @_TZF9witnessesoi3ltg{{.*}} : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Y, τ_0_1 : Y> (@in τ_0_0, @in τ_0_1) -> @out τ_0_1
+// CHECK-NEXT:    [[WITNESS_FN:%.*]] = function_ref @_TF9witnessesoi3ltg{{.*}} : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Y, τ_0_1 : Y> (@in τ_0_0, @in τ_0_1) -> @out τ_0_1
 // CHECK-NEXT:    [[RESULT:%.*]] = apply [[WITNESS_FN]]<ConformsWithMoreGeneric, ConformsWithMoreGeneric>(%0, %1, %2) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Y, τ_0_1 : Y> (@in τ_0_0, @in τ_0_1) -> @out τ_0_1
 // CHECK-NEXT:    [[RESULT:%.*]] = tuple ()
 // CHECK-NEXT:    return [[RESULT]] : $()
 // CHECK-NEXT:  }
 
 protocol LabeledRequirement {
-  func method(x x: Loadable)
+  func method(x: Loadable)
 }
 
 struct UnlabeledWitness : LabeledRequirement {
@@ -286,7 +286,7 @@ struct UnlabeledWitness : LabeledRequirement {
 }
 
 protocol LabeledSelfRequirement {
-  func method(x x: Self)
+  func method(x: Self)
 }
 
 struct UnlabeledSelfWitness : LabeledSelfRequirement {
@@ -300,7 +300,7 @@ protocol UnlabeledRequirement {
 
 struct LabeledWitness : UnlabeledRequirement {
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWV9witnesses14LabeledWitnessS_20UnlabeledRequirementS_FS1_6method{{.*}} : $@convention(witness_method) (Loadable, @in_guaranteed LabeledWitness) -> ()
-  func method(x x: Loadable) {}
+  func method(x: Loadable) {}
 }
 
 protocol UnlabeledSelfRequirement {

--- a/test/SILOptimizer/specialize_anyobject.swift
+++ b/test/SILOptimizer/specialize_anyobject.swift
@@ -17,6 +17,6 @@ struct S<A: PB> {
 
 // CHECK-LABEL: sil hidden @_TF20specialize_anyobject6callit
 func callit(s: S<CB>) {
-  // CHECK: function_ref @_TZFsoi3eeeFTGSqPs9AnyObject__GSqPS____Sb : $@convention(thin) (@owned Optional<AnyObject>, @owned Optional<AnyObject>) -> Bool
+  // CHECK: function_ref @_TFsoi3eeeFTGSqPs9AnyObject__GSqPS____Sb : $@convention(thin) (@owned Optional<AnyObject>, @owned Optional<AnyObject>) -> Bool
   s.crash()
 }

--- a/test/Serialization/class-roundtrip-module.swift
+++ b/test/Serialization/class-roundtrip-module.swift
@@ -4,4 +4,4 @@
 // RUN: %target-swift-frontend -emit-module -parse-as-library -o %t/def_class.swiftmodule %t/stage1.swiftmodule
 // RUN: %target-swift-frontend -emit-sil -Xllvm -sil-disable-pass="External Defs To Decls" -sil-debug-serialization -I %t %S/class.swift | FileCheck %s -check-prefix=SIL
 
-// SIL-LABEL: sil public_external [transparent] [fragile] @_TZFsoi1pFTSiSi_Si : $@convention(thin) (Int, Int) -> Int {
+// SIL-LABEL: sil public_external [transparent] [fragile] @_TFsoi1pFTSiSi_Si : $@convention(thin) (Int, Int) -> Int {

--- a/test/Serialization/class.swift
+++ b/test/Serialization/class.swift
@@ -77,7 +77,7 @@ var rsrc = Resource()
 
 getReqPairLike()
 
-// SIL-LABEL: sil public_external [transparent] [fragile] @_TZFsoi1pFTSiSi_Si : $@convention(thin) (Int, Int) -> Int {
+// SIL-LABEL: sil public_external [transparent] [fragile] @_TFsoi1pFTSiSi_Si : $@convention(thin) (Int, Int) -> Int {
 
 func test(_ sharer: ResourceSharer) {}
 

--- a/test/SourceKit/CursorInfo/cursor_info.swift
+++ b/test/SourceKit/CursorInfo/cursor_info.swift
@@ -210,7 +210,7 @@ func rethrowingFunction1(_: (Int) throws -> Void) rethrows -> Void {}
 // RUN: %sourcekitd-test -req=cursor -pos=9:11 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | FileCheck -check-prefix=CHECK2 %s
 // CHECK2:      source.lang.swift.ref.function.operator.infix ()
 // CHECK2-NEXT: +
-// CHECK2-NEXT: s:ZFsoi1pFTSiSi_Si
+// CHECK2-NEXT: s:Fsoi1pFTSiSi_Si
 // CHECK2-NEXT: (Int, Int) -> Int{{$}}
 // CHECK2-NEXT: _TtFTSiSi_Si
 // CHECK2-NEXT: Swift{{$}}

--- a/test/SourceKit/DocSupport/Inputs/main.swift
+++ b/test/SourceKit/DocSupport/Inputs/main.swift
@@ -151,5 +151,5 @@ struct S1 : Prot2 {
 func genfoo<T : Prot2 where T.Element == Int>(_ x: T) {}
 
 protocol Prot3 {
-  func +(x: Self, y: Self)
+  static func +(x: Self, y: Self)
 }

--- a/test/SourceKit/DocSupport/doc_source_file.swift.response
+++ b/test/SourceKit/DocSupport/doc_source_file.swift.response
@@ -522,7 +522,7 @@
   {
     key.kind: source.lang.swift.ref.function.operator.infix,
     key.name: "+(_:_:)",
-    key.usr: "s:ZF8__main__oi1pFTCS_2CCCS_3CC0_S0_",
+    key.usr: "s:F8__main__oi1pFTCS_2CCCS_3CC0_S0_",
     key.offset: 526,
     key.length: 1
   },
@@ -1083,7 +1083,7 @@
   {
     key.kind: source.lang.swift.ref.function.operator.infix,
     key.name: "+(_:_:)",
-    key.usr: "s:ZFsoi1pFTSiSi_Si",
+    key.usr: "s:Fsoi1pFTSiSi_Si",
     key.offset: 1217,
     key.length: 1
   },
@@ -1218,7 +1218,7 @@
   {
     key.kind: source.lang.swift.ref.function.operator.infix,
     key.name: "+=(_:_:)",
-    key.usr: "s:ZFsoi2peFTRSiSi_T_",
+    key.usr: "s:Fsoi2peFTRSiSi_T_",
     key.offset: 1343,
     key.length: 2
   },
@@ -1317,7 +1317,7 @@
   {
     key.kind: source.lang.swift.ref.function.operator.infix,
     key.name: "+=(_:_:)",
-    key.usr: "s:ZFsoi2peFTRSiSi_T_",
+    key.usr: "s:Fsoi2peFTRSiSi_T_",
     key.offset: 1383,
     key.length: 2
   },
@@ -1808,40 +1808,45 @@
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 1973,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1980,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1980,
+    key.offset: 1987,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1980,
+    key.offset: 1987,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "Self",
     key.usr: "s:tP8__main__5Prot34SelfMx",
-    key.offset: 1983,
+    key.offset: 1990,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1989,
+    key.offset: 1996,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1989,
+    key.offset: 1996,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "Self",
     key.usr: "s:tP8__main__5Prot34SelfMx",
-    key.offset: 1992,
+    key.offset: 1999,
     key.length: 4
   }
 ]
@@ -1959,7 +1964,7 @@
   {
     key.kind: source.lang.swift.decl.function.operator.infix,
     key.name: "+(_:_:)",
-    key.usr: "s:ZF8__main__oi1pFTCS_2CCCS_3CC0_S0_",
+    key.usr: "s:F8__main__oi1pFTCS_2CCCS_3CC0_S0_",
     key.offset: 288,
     key.length: 42,
     key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>+</decl.name>(<decl.var.parameter><decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.class usr=\"s:C8__main__2CC\">CC</ref.class></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>b</decl.var.parameter.name>: <decl.var.parameter.type><ref.class usr=\"s:C8__main__3CC0\">CC0</ref.class></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.class usr=\"s:C8__main__2CC\">CC</ref.class></decl.function.returntype></decl.function.operator.infix>",
@@ -2665,7 +2670,7 @@
     key.name: "Prot3",
     key.usr: "s:P8__main__5Prot3",
     key.offset: 1954,
-    key.length: 44,
+    key.length: 51,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>Prot3</decl.name></decl.protocol>",
     key.entities: [
       {
@@ -2673,21 +2678,21 @@
         key.name: "+(_:_:)",
         key.usr: "s:ZFP8__main__5Prot3oi1pFTxx_T_",
         key.offset: 1973,
-        key.length: 23,
-        key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>+</decl.name>(<decl.var.parameter><decl.var.parameter.name>x</decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:tP8__main__5Prot34SelfMx\">Self</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>y</decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:tP8__main__5Prot34SelfMx\">Self</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>)</decl.function.operator.infix>",
+        key.length: 30,
+        key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>+</decl.name>(<decl.var.parameter><decl.var.parameter.name>x</decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:tP8__main__5Prot34SelfMx\">Self</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>y</decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:tP8__main__5Prot34SelfMx\">Self</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>)</decl.function.operator.infix>",
         key.entities: [
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "x",
-            key.offset: 1983,
+            key.offset: 1990,
             key.length: 4
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "y",
-            key.offset: 1992,
+            key.offset: 1999,
             key.length: 4
           }
         ]

--- a/test/SourceKit/Indexing/index.swift.response
+++ b/test/SourceKit/Indexing/index.swift.response
@@ -145,7 +145,7 @@
     {
       key.kind: source.lang.swift.decl.function.operator.infix,
       key.name: "+(_:_:)",
-      key.usr: "s:ZF5indexoi1pFTCS_2CCS0__S0_",
+      key.usr: "s:F5indexoi1pFTCS_2CCS0__S0_",
       key.line: 19,
       key.column: 6,
       key.entities: [
@@ -275,7 +275,7 @@
         {
           key.kind: source.lang.swift.ref.function.operator.infix,
           key.name: "+(_:_:)",
-          key.usr: "s:ZF5indexoi1pFTCS_2CCS0__S0_",
+          key.usr: "s:F5indexoi1pFTCS_2CCS0__S0_",
           key.line: 38,
           key.column: 5
         },
@@ -704,7 +704,7 @@
                 {
                   key.kind: source.lang.swift.ref.function.operator.infix,
                   key.name: "+(_:_:)",
-                  key.usr: "s:ZFsoi1pFTSiSi_Si",
+                  key.usr: "s:Fsoi1pFTSiSi_Si",
                   key.line: 86,
                   key.column: 8
                 }
@@ -789,7 +789,7 @@
         {
           key.kind: source.lang.swift.ref.function.operator.prefix,
           key.name: "++(_:)",
-          key.usr: "s:ZFsop2ppFRSiSi",
+          key.usr: "s:Fsop2ppFRSiSi",
           key.line: 95,
           key.column: 3
         },
@@ -855,7 +855,7 @@
         {
           key.kind: source.lang.swift.ref.function.operator.prefix,
           key.name: "++(_:)",
-          key.usr: "s:ZFsop2ppFRSiSi",
+          key.usr: "s:Fsop2ppFRSiSi",
           key.line: 98,
           key.column: 3
         },

--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -52,7 +52,7 @@ prefix operator ~~~ {} // expected-note 2{{prefix operator found here}}
 func ~~~(x: Float) {} // expected-error{{prefix unary operator missing 'prefix' modifier}}{{1-1=prefix }}
 
 protocol P {
-  func ~~~(x: Self) // expected-error{{prefix unary operator missing 'prefix' modifier}}{{3-3=prefix }}
+  static func ~~~(x: Self) // expected-error{{prefix unary operator missing 'prefix' modifier}}{{10-10=prefix }}
 }
 
 prefix func +// this should be a comment, not an operator
@@ -159,8 +159,7 @@ prefix func & (x: Int) {} // expected-error {{cannot declare a custom prefix '&'
 
 // Only allow operators at global scope:
 func operator_in_func_bad () {
-    prefix func + (input: String) -> String { return "+" + input } // expected-error {{operators are only allowed at global scope}} expected-error{{braced block of statements is an unused closure}} \
-                                                                    // expected-error {{use of unresolved identifier 'input'}}
+    prefix func + (input: String) -> String { return "+" + input } // expected-error {{operator functions can only be declared at global or in type scope}}
 }
 
 infix operator ? {}  // expected-error {{expected operator name in operator declaration}} 
@@ -196,3 +195,47 @@ _ = -++n // expected-error {{unary operators may not be juxtaposed; parenthesize
 // <rdar://problem/16230507> Cannot use a negative constant as the second operator of ... operator
 _ = 3...-5  // expected-error {{missing whitespace between '...' and '-' operators}}
 
+
+protocol P0 {
+  static func %%%(lhs: Self, rhs: Self) -> Self
+}
+
+protocol P1 {
+  func %%%(lhs: Self, rhs: Self) -> Self // expected-warning{{operator '%%%' declared in protocol must be 'static'}}{{3-3=static }}
+}
+
+struct S0 {
+  static func %%%(lhs: S0, rhs: S0) -> S0 { return lhs }
+}
+
+extension S0 {
+  static func %%%%(lhs: S0, rhs: S0) -> S0 { return lhs }
+}
+
+struct S1 {
+  func %%%(lhs: S0, rhs: S0) -> S0 { return lhs } // expected-error{{operator '%%%' declared in type 'S1' must be 'static'}}{{3-3=static }}
+}
+
+extension S1 {
+  func %%%%(lhs: S0, rhs: S0) -> S0 { return lhs } // expected-error{{operator '%%%%' declared in type 'S1' must be 'static'}}{{3-3=static }}
+}
+
+class C0 {
+  static func %%%(lhs: S0, rhs: S0) -> S0 { return lhs }
+}
+
+class C1 {
+  final func %%%(lhs: S0, rhs: S0) -> S0 { return lhs }
+}
+
+final class C2 {
+  class func %%%(lhs: S0, rhs: S0) -> S0 { return lhs }
+}
+
+class C3 {
+  class func %%%(lhs: S0, rhs: S0) -> S0 { return lhs } // expected-error{{operator '%%%' declared in non-final class 'C3' must be 'final'}}{{3-3=final }}
+}
+
+class C4 {
+  func %%%(lhs: S0, rhs: S0) -> S0 { return lhs } // expected-error{{operator '%%%' declared in type 'C4' must be 'static'}}{{3-3=static }}
+}

--- a/test/decl/protocol/conforms/inherited.swift
+++ b/test/decl/protocol/conforms/inherited.swift
@@ -43,7 +43,7 @@ protocol P8 {
 
 // Inheritable: operator requirement.
 protocol P9 {
-  func ==(x: Self, y: Self) -> Bool 
+  static func ==(x: Self, y: Self) -> Bool 
 }
 
 // Never inheritable: method with 'Self' in a non-contravariant position.

--- a/test/decl/protocol/conforms/operator.swift
+++ b/test/decl/protocol/conforms/operator.swift
@@ -1,0 +1,19 @@
+// RUN: %target-parse-verify-swift
+
+protocol P0 {
+  static func << (lhs: Self, rhs: Self) -> Self
+}
+
+// Satisfy operator requirement with a global function.
+struct S0a : P0 { } 
+func <<(lhs: S0a, rhs: S0a) -> S0a { return lhs }
+
+// Satisfy operator requirement with a static method.
+struct S0b : P0 { 
+  static func <<(lhs: S0b, rhs: S0b) -> S0b { return lhs }
+}
+
+// Satisfy operator requirement with a static method in a generic struct.
+struct S0c<T> : P0 {
+  static func <<(lhs: S0c<T>, rhs: S0c<T>) -> S0c<T> { return lhs }
+}

--- a/test/decl/protocol/operators_in_protocols.swift
+++ b/test/decl/protocol/operators_in_protocols.swift
@@ -1,8 +1,8 @@
 // RUN: %target-parse-verify-swift
 
 protocol P {
-  func << (lhs: Self, rhs: Self) -> Self
-  func >> (lhs: Self, rhs: Self) -> Self
-  func <<= (lhs: inout Self, rhs: Self)
-  func >>= (lhs: inout Self, rhs: Self)
+  static func << (lhs: Self, rhs: Self) -> Self
+  static func >> (lhs: Self, rhs: Self) -> Self
+  static func <<= (lhs: inout Self, rhs: Self)
+  static func >>= (lhs: inout Self, rhs: Self)
 }

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -311,7 +311,7 @@ func StaticProtocolGenericFunc<t : StaticP>(_: t) {
 // Operators
 //===----------------------------------------------------------------------===//
 protocol Eq {
-  func ==(lhs: Self, rhs: Self) -> Bool
+  static func ==(lhs: Self, rhs: Self) -> Bool
 }
 
 extension Int : Eq { }
@@ -321,8 +321,8 @@ prefix operator <> {}
 postfix operator <> {}
 
 protocol IndexValue {
-  prefix func <> (_ max: Self) -> Int
-  postfix func <> (min: Self) -> Int
+  static prefix func <> (_ max: Self) -> Int
+  static postfix func <> (min: Self) -> Int
 }
 
 prefix func <> (max: Int) -> Int  { return 0 }

--- a/test/decl/protocol/req/func.swift
+++ b/test/decl/protocol/req/func.swift
@@ -88,7 +88,7 @@ prefix operator ~~ {}
 
 protocol P3 {
   associatedtype Assoc : P1
-  prefix func ~~(_: Self) -> Assoc // expected-note{{protocol requires function '~~' with type '(X3z) -> Assoc'}}
+  static prefix func ~~(_: Self) -> Assoc // expected-note{{protocol requires function '~~' with type '(X3z) -> Assoc'}}
 }
 
 // Global operator match
@@ -111,7 +111,7 @@ postfix func ~~(_: X3z) -> X1a {} // expected-note{{candidate is postfix, not pr
 postfix operator ~~ {}
 protocol P4 {
   associatedtype Assoc : P1
-  postfix func ~~ (_: Self) -> Assoc // expected-note{{protocol requires function '~~' with type '(X4z) -> Assoc'}}
+  static postfix func ~~ (_: Self) -> Assoc // expected-note{{protocol requires function '~~' with type '(X4z) -> Assoc'}}
 }
 
 // Global operator match
@@ -178,8 +178,8 @@ func ~>> (x: Int, args: T1) {}
 3~>>T1(2, "Hi")
 
 protocol Crankable {
-  func ~>> (x: Self, args: T0)
-  func ~>> (x: Self, args: T1)
+  static func ~>> (x: Self, args: T0)
+  static func ~>> (x: Self, args: T1)
 }
 
 extension Int : Crankable {}
@@ -210,7 +210,7 @@ protocol P8 {
 prefix func %%% <T : P8>(x: T) -> T { }
 
 protocol P9 : P8 {
-  prefix func %%% (x: Self) -> Self
+  static prefix func %%% (x: Self) -> Self
 }
 
 struct X9 : P9 {
@@ -231,7 +231,7 @@ struct X10 : P10 {
 }
 
 protocol P11 {
-  func ==(x: Self, y: Self) -> Bool
+  static func ==(x: Self, y: Self) -> Bool
 }
 
 protocol P12 {

--- a/validation-test/compiler_crashers_fixed/26725-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
+++ b/validation-test/compiler_crashers_fixed/26725-llvm-smallvectorimpl-swift-diagnosticargument-operator.swift
@@ -5,7 +5,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // This test fails in the AST verifier, which can be turned off.
 // REQUIRES: swift_ast_verifier
 class a<T where g:d{class A{class A<T>:A{init(){T{


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Implements the syntactic changes of SE-0091, including the ability to define operators within types and extensions thereof, and the syntactic requirement that operator requirements in protocols be declared 'static'.
#### Resolved bug number: ([rdar://problem/13002566](rdar://problem/13002566))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
