### PR TITLE
[SourceKit] Document source.request.demangle

### DIFF
--- a/tools/SourceKit/docs/Protocol.md
+++ b/tools/SourceKit/docs/Protocol.md
@@ -393,6 +393,68 @@ range ::=
 
 Sub-diagnostics are only diagnostic notes currently.
 
+# Demangling
+
+SourceKit is capable of "demangling" mangled Swift symbols. In other words,
+it's capable of taking the symbol `_TF13MyCoolPackageg6raichuVS_7Pokemon` as
+input, and returning the human-readable
+`MyCoolPackage.raichu.getter : MyCoolPackage.Pokemon`.
+
+### Request
+
+```
+{
+    <key.request>: (UID) <source.request.demangle>,
+    <key.names>:   [string*] // An array of names to demangle.
+}
+```
+
+### Response
+
+```
+{
+    <key.results>: (array) [demangle-result+] // The results for each
+                                              // demangling, in the order in
+                                              // which they were requested.
+}
+```
+
+```
+demangle-result ::=
+{
+    <key.name>: (string) // The demangled name.
+}
+```
+
+### Testing
+
+```
+$ sourcekitd-test -req=demangle [<names>]
+```
+
+For example, to demangle the symbol `_TF13MyCoolPackageg6raichuVS_7Pokemon`:
+
+```
+$ sourcekitd-test -req=demangle _TF13MyCoolPackageg6raichuVS_7Pokemon
+```
+
+Note that when using `sourcekitd-test`, the output is output in an ad hoc text
+format, not JSON.
+
+You could also issue the following request in the `sourcekitd-repl`, which
+produces JSON:
+
+```
+$ sourcekitd-repl
+Welcome to SourceKit.  Type ':help' for assistance.
+(SourceKit) {
+    key.request: source.request.demangle,
+    key.names: [
+      "_TF13MyCoolPackageg6raichuVS_7Pokemon"
+    ]
+}
+```
+
 # UIDs
 
 ## Keys
@@ -410,4 +472,3 @@ Sub-diagnostics are only diagnostic notes currently.
 - `key.sourcetext`
 - `key.typename`
 - `key.usr`
-


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Additional docs for `source.request.demangle`.

/cc @akyrtzi @benlangmuir @briancroom 

---

By the way, I noticed this isn't the only SourceKit request that doesn't return JSON, instead returning something like the following:

```
DELIMITER
One item
Another item
DELIMITER
```

`sourcekitd-test -req=cursor` also returns information in this format. Is this the intended behavior? Or should these be converted to return JSON, like the other request types documented in `tools/SourceKit/docs/Protocol.md`?
#### Related bug number: [SR-2117](https://bugs.swift.org/browse/SR-2117)

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
