### PR TITLE
WIP: DONT MERGE Don't change public external symbols to shared

### DIFF
--- a/lib/SILOptimizer/Transforms/SILCleanup.cpp
+++ b/lib/SILOptimizer/Transforms/SILCleanup.cpp
@@ -44,12 +44,6 @@ static void cleanFunction(SILFunction &Fn) {
       }
     }
   }
-
-  // Rename functions with public_external linkage to prevent symbol conflict
-  // with stdlib.
-  if (Fn.isDefinition() && Fn.getLinkage() == SILLinkage::PublicExternal) {
-    Fn.setLinkage(SILLinkage::SharedExternal);
-  }
 }
 
 void swift::performSILCleanup(SILModule *M) {


### PR DESCRIPTION
This causes duplicate versions of unspecialized code from the stdlib in object
files. We did this for performance reasons. The debug code gets removed. The
code size trade off of doing this is questionable though. We can get performance
back later by other means.
