### PR TITLE
Rename UnsafePointer allocate & deallocate.

### DIFF
--- a/benchmark/single-source/PopFront.swift
+++ b/benchmark/single-source/PopFront.swift
@@ -35,7 +35,7 @@ public func run_PopFrontArray(_ N: Int) {
 @inline(never)
 public func run_PopFrontUnsafePointer(_ N: Int) {
   var orig = Array(repeating: 1, count: arrayCount)
-  let a = UnsafeMutablePointer<Int>(allocatingCapacity: arrayCount)
+  let a = UnsafeMutablePointer<Int>.allocate(capacity: arrayCount)
   for _ in 1...100*N {
     for _ in 1...reps {
       for i in 0..<arrayCount {
@@ -51,6 +51,6 @@ public func run_PopFrontUnsafePointer(_ N: Int) {
       CheckResults(result == arrayCount, "IncorrectResults in StringInterpolation: \(result) != \(arrayCount)")
     }
   }
-  a.deallocateCapacity(arrayCount)
+  a.deallocate(capacity: arrayCount)
 }
 

--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceInstance.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceInstance.swift.gyb
@@ -86,7 +86,7 @@ public func checkSequence<
   _ = sequence._preprocessingPass { () -> Void in
     var count = 0
     for _ in sequence { count += 1 }
-    let buf = UnsafeMutablePointer<S.Iterator.Element>(allocatingCapacity: count)
+    let buf = UnsafeMutablePointer<S.Iterator.Element>.allocate(capacity: count)
     let end = sequence._copyContents(initializing: buf)
     expectTrue(end == buf + count, "_copyContents returned the wrong value")
     var j = expected.startIndex
@@ -95,7 +95,7 @@ public func checkSequence<
       j = expected.index(after: j)
     }
     buf.deinitialize(count: end - buf)
-    buf.deallocateCapacity(count)
+    buf.deallocate(capacity: count)
   }
 }
 

--- a/stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.swift
+++ b/stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.swift
@@ -14,12 +14,12 @@
 func _stdlib_getPointer(_ x: OpaquePointer) -> OpaquePointer
 
 public func _opaqueIdentity<T>(_ x: T) -> T {
-  let ptr = UnsafeMutablePointer<T>(allocatingCapacity: 1)
+  let ptr = UnsafeMutablePointer<T>.allocate(capacity: 1)
   ptr.initialize(to: x)
   let result =
     UnsafeMutablePointer<T>(_stdlib_getPointer(OpaquePointer(ptr))).pointee
   ptr.deinitialize()
-  ptr.deallocateCapacity(1)
+  ptr.deallocate(capacity: 1)
   return result
 }
 

--- a/stdlib/private/SwiftPrivate/ShardedAtomicCounter.swift
+++ b/stdlib/private/SwiftPrivate/ShardedAtomicCounter.swift
@@ -33,7 +33,7 @@ public struct _stdlib_ShardedAtomicCounter {
   public init() {
     let hardwareConcurrency = _stdlib_getHardwareConcurrency()
     let count = max(8, hardwareConcurrency * hardwareConcurrency)
-    let shards = UnsafeMutablePointer<Int>(allocatingCapacity: count)
+    let shards = UnsafeMutablePointer<Int>.allocate(capacity: count)
     for i in 0..<count {
       (shards + i).initialize(to: 0)
     }
@@ -43,7 +43,7 @@ public struct _stdlib_ShardedAtomicCounter {
 
   public func `deinit`() {
     self._shardsPtr.deinitialize(count: self._shardsCount)
-    self._shardsPtr.deallocateCapacity(self._shardsCount)
+    self._shardsPtr.deallocate(capacity: self._shardsCount)
   }
 
   public func add(_ operand: Int, randomInt: Int) {

--- a/stdlib/private/SwiftPrivatePthreadExtras/PthreadBarriers.swift
+++ b/stdlib/private/SwiftPrivatePthreadExtras/PthreadBarriers.swift
@@ -67,12 +67,12 @@ public func _stdlib_pthread_barrier_init(
     errno = EINVAL
     return -1
   }
-  barrier.pointee.mutex = UnsafeMutablePointer(allocatingCapacity: 1)
+  barrier.pointee.mutex = UnsafeMutablePointer.allocate(capacity: 1)
   if pthread_mutex_init(barrier.pointee.mutex!, nil) != 0 {
     // FIXME: leaking memory.
     return -1
   }
-  barrier.pointee.cond = UnsafeMutablePointer(allocatingCapacity: 1)
+  barrier.pointee.cond = UnsafeMutablePointer.allocate(capacity: 1)
   if pthread_cond_init(barrier.pointee.cond!, nil) != 0 {
     // FIXME: leaking memory, leaking a mutex.
     return -1
@@ -93,9 +93,9 @@ public func _stdlib_pthread_barrier_destroy(
     return -1
   }
   barrier.pointee.cond!.deinitialize()
-  barrier.pointee.cond!.deallocateCapacity(1)
+  barrier.pointee.cond!.deallocate(capacity: 1)
   barrier.pointee.mutex!.deinitialize()
-  barrier.pointee.mutex!.deallocateCapacity(1)
+  barrier.pointee.mutex!.deallocate(capacity: 1)
   return 0
 }
 

--- a/stdlib/private/SwiftPrivatePthreadExtras/SwiftPrivatePthreadExtras.swift
+++ b/stdlib/private/SwiftPrivatePthreadExtras/SwiftPrivatePthreadExtras.swift
@@ -41,7 +41,7 @@ internal class PthreadBlockContextImpl<Argument, Result>: PthreadBlockContext {
   }
 
   override func run() -> UnsafeMutablePointer<Void> {
-    let result = UnsafeMutablePointer<Result>(allocatingCapacity: 1)
+    let result = UnsafeMutablePointer<Result>.allocate(capacity: 1)
     result.initialize(to: block(arg))
     return UnsafeMutablePointer(result)
   }
@@ -100,7 +100,7 @@ public func _stdlib_pthread_join<Result>(
   if result == 0 {
     let threadResult = UnsafeMutablePointer<Result>(threadResultPtr!).pointee
     threadResultPtr!.deinitialize()
-    threadResultPtr!.deallocateCapacity(1)
+    threadResultPtr!.deallocate(capacity: 1)
     return (result, threadResult)
   } else {
     return (result, nil)

--- a/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
+++ b/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
@@ -356,11 +356,11 @@ public func reflect(object: AnyObject) {
 /// an Any existential.
 public func reflect<T>(any: T) {
   let any: Any = any
-  let anyPointer = UnsafeMutablePointer<Any>(allocatingCapacity: sizeof(Any.self))
+  let anyPointer = UnsafeMutablePointer<Any>.allocate(capacity: sizeof(Any.self))
   anyPointer.initialize(to: any)
   let anyPointerValue = unsafeBitCast(anyPointer, to: UInt.self)
   reflect(instanceAddress: anyPointerValue, kind: .Existential)
-  anyPointer.deallocateCapacity(sizeof(Any.self))
+  anyPointer.deallocate(capacity: sizeof(Any.self))
 }
 
 // Reflect an `Error`, a.k.a. an "error existential".
@@ -419,8 +419,8 @@ struct ThickFunctionParts {
 /// Reflect a closure context. The given function must be a Swift-native
 /// @convention(thick) function value.
 public func reflect(function: () -> ()) {
-  let fn = UnsafeMutablePointer<ThickFunction0>(
-      allocatingCapacity: sizeof(ThickFunction0.self))
+  let fn = UnsafeMutablePointer<ThickFunction0>.allocate(
+    capacity: sizeof(ThickFunction0.self))
   fn.initialize(to: ThickFunction0(function: function))
 
   let parts = unsafeBitCast(fn, to: UnsafePointer<ThickFunctionParts>.self)
@@ -428,14 +428,15 @@ public func reflect(function: () -> ()) {
 
   reflect(instanceAddress: contextPointer, kind: .Object)
 
-  fn.deallocateCapacity(sizeof(ThickFunction0.self))
+  fn.deallocate(capacity: sizeof(ThickFunction0.self))
 }
 
 /// Reflect a closure context. The given function must be a Swift-native
 /// @convention(thick) function value.
 public func reflect(function: (Int) -> ()) {
-  let fn = UnsafeMutablePointer<ThickFunction1>(
-      allocatingCapacity: sizeof(ThickFunction1.self))
+  let fn =
+  UnsafeMutablePointer<ThickFunction1>.allocate(
+    capacity: sizeof(ThickFunction1.self))
   fn.initialize(to: ThickFunction1(function: function))
 
   let parts = unsafeBitCast(fn, to: UnsafePointer<ThickFunctionParts>.self)
@@ -443,14 +444,14 @@ public func reflect(function: (Int) -> ()) {
 
   reflect(instanceAddress: contextPointer, kind: .Object)
 
-  fn.deallocateCapacity(sizeof(ThickFunction1.self))
+  fn.deallocate(capacity: sizeof(ThickFunction1.self))
 }
 
 /// Reflect a closure context. The given function must be a Swift-native
 /// @convention(thick) function value.
 public func reflect(function: (Int, String) -> ()) {
-  let fn = UnsafeMutablePointer<ThickFunction2>(
-      allocatingCapacity: sizeof(ThickFunction2.self))
+  let fn = UnsafeMutablePointer<ThickFunction2>.allocate(
+      capacity: sizeof(ThickFunction2.self))
   fn.initialize(to: ThickFunction2(function: function))
 
   let parts = unsafeBitCast(fn, to: UnsafePointer<ThickFunctionParts>.self)
@@ -458,14 +459,14 @@ public func reflect(function: (Int, String) -> ()) {
 
   reflect(instanceAddress: contextPointer, kind: .Object)
 
-  fn.deallocateCapacity(sizeof(ThickFunction2.self))
+  fn.deallocate(capacity: sizeof(ThickFunction2.self))
 }
 
 /// Reflect a closure context. The given function must be a Swift-native
 /// @convention(thick) function value.
 public func reflect(function: (Int, String, AnyObject?) -> ()) {
-  let fn = UnsafeMutablePointer<ThickFunction3>(
-      allocatingCapacity: sizeof(ThickFunction3.self))
+  let fn = UnsafeMutablePointer<ThickFunction3>.allocate(
+      capacity: sizeof(ThickFunction3.self))
   fn.initialize(to: ThickFunction3(function: function))
 
   let parts = unsafeBitCast(fn, to: UnsafePointer<ThickFunctionParts>.self)
@@ -473,7 +474,7 @@ public func reflect(function: (Int, String, AnyObject?) -> ()) {
 
   reflect(instanceAddress: contextPointer, kind: .Object)
 
-  fn.deallocateCapacity(sizeof(ThickFunction3.self))
+  fn.deallocate(capacity: sizeof(ThickFunction3.self))
 }
 
 /// Call this function to indicate to the parent that there are

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -60,10 +60,10 @@ public func _autorelease(_ x: AnyObject) {
 func _withUninitializedString<R>(
   _ body: (UnsafeMutablePointer<String>) -> R
 ) -> (R, String) {
-  let stringPtr = UnsafeMutablePointer<String>(allocatingCapacity: 1)
+  let stringPtr = UnsafeMutablePointer<String>.allocate(capacity: 1)
   let bodyResult = body(stringPtr)
   let stringResult = stringPtr.move()
-  stringPtr.deallocateCapacity(1)
+  stringPtr.deallocate(capacity: 1)
   return (bodyResult, stringResult)
 }
 

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -126,10 +126,11 @@ public struct ${Self}<Pointee>
   /// instances of `Pointee`.
   ///
   /// - Postcondition: The pointee is allocated, but not initialized.
-  public init(allocatingCapacity count: Int) {
+  static public func allocate(capacity count: Int)
+    -> UnsafeMutablePointer<Pointee> {
     let size = strideof(Pointee.self) * count
-    self._rawValue =
-      Builtin.allocRaw(size._builtinWordValue, Builtin.alignof(Pointee.self))
+    return UnsafeMutablePointer(
+      Builtin.allocRaw(size._builtinWordValue, Builtin.alignof(Pointee.self)))
   }
 
   /// Deallocate uninitialized memory allocated for `count` instances
@@ -138,8 +139,8 @@ public struct ${Self}<Pointee>
   /// - Precondition: The memory is not initialized.
   ///
   /// - Postcondition: The memory has been deallocated.
-  public func deallocateCapacity(_ num: Int) {
-    let size = strideof(Pointee.self) * num
+  public func deallocate(capacity: Int) {
+    let size = strideof(Pointee.self) * capacity
     Builtin.deallocRaw(
       _rawValue, size._builtinWordValue, Builtin.alignof(Pointee.self))
   }
@@ -487,13 +488,23 @@ extension ${Self} {
   }
 
 % if mutable:
-  @available(*, unavailable, message: "use the '${Self}(allocatingCapacity:)' initializer")
+  @available(*, unavailable, renamed: "allocate(capacity:)")
   public static func alloc(_ num: Int) -> ${Self} {
     Builtin.unreachable()
   }
 
-  @available(*, unavailable, renamed: "deallocateCapacity")
+  @available(*, unavailable, message: "use '${Self}.allocate(capacity:)'")
+  public init(allocatingCapacity: Int) {
+    Builtin.unreachable()
+  }
+
+  @available(*, unavailable, renamed: "deallocate(capacity:)")
   public func dealloc(_ num: Int) {
+    Builtin.unreachable()
+  }
+
+  @available(*, unavailable, renamed: "deallocate(capacity:)")
+  public func deallocateCapacity(_ num: Int) {
     Builtin.unreachable()
   }
 % end

--- a/test/1_stdlib/Builtins.swift
+++ b/test/1_stdlib/Builtins.swift
@@ -128,7 +128,7 @@ struct Large : P {
 struct ContainsP { var p: P }
 
 func exerciseArrayValueWitnesses<T>(_ value: T) {
-  let buf = UnsafeMutablePointer<T>(allocatingCapacity: 5)
+  let buf = UnsafeMutablePointer<T>.allocate(capacity: 5)
 
   (buf + 0).initialize(to: value)
   (buf + 1).initialize(to: value)
@@ -138,7 +138,7 @@ func exerciseArrayValueWitnesses<T>(_ value: T) {
   Builtin.takeArrayFrontToBack(T.self, buf._rawValue, (buf + 1)._rawValue, 4._builtinWordValue)
   Builtin.destroyArray(T.self, buf._rawValue, 4._builtinWordValue)
 
-  buf.deallocateCapacity(5)
+  buf.deallocate(capacity: 5)
 }
 
 tests.test("array value witnesses") {

--- a/test/1_stdlib/NSStringAPI.swift
+++ b/test/1_stdlib/NSStringAPI.swift
@@ -197,7 +197,7 @@ NSStringAPIs.test("init(cString_:encoding:)") {
 
 NSStringAPIs.test("init(utf8String:)") {
   var s = "foo あいう"
-  var up = UnsafeMutablePointer<UInt8>(allocatingCapacity: 100)
+  var up = UnsafeMutablePointer<UInt8>.allocate(capacity: 100)
   var i = 0
   for b in s.utf8 {
     up[i] = b
@@ -205,7 +205,7 @@ NSStringAPIs.test("init(utf8String:)") {
   }
   up[i] = 0
   expectOptionalEqual(s, String(utf8String: UnsafePointer(up)))
-  up.deallocateCapacity(100)
+  up.deallocate(capacity: 100)
 }
 
 NSStringAPIs.test("canBeConvertedToEncoding(_:)") {

--- a/test/1_stdlib/Reflection.swift
+++ b/test/1_stdlib/Reflection.swift
@@ -181,11 +181,11 @@ var randomUnsafeMutablePointerString = UnsafeMutablePointer<String>(
 dump(randomUnsafeMutablePointerString)
 
 // CHECK-NEXT: Hello panda
-var sanePointerString = UnsafeMutablePointer<String>(allocatingCapacity: 1)
+var sanePointerString = UnsafeMutablePointer<String>.allocate(capacity: 1)
 sanePointerString.initialize(to: "Hello panda")
 dump(sanePointerString.pointee)
 sanePointerString.deinitialize()
-sanePointerString.deallocateCapacity(1)
+sanePointerString.deallocate(capacity: 1)
 
 // Don't crash on types with opaque metadata. rdar://problem/19791252
 // CHECK-NEXT: (Opaque Value)

--- a/test/1_stdlib/Renames.swift
+++ b/test/1_stdlib/Renames.swift
@@ -498,17 +498,17 @@ func _UnsafePointer<T>(x: UnsafeMutablePointer<T>, e: T) {
   _ = UnsafeMutablePointer<T>.Memory.self // expected-error {{'Memory' has been renamed to 'Pointee'}} {{31-37=Pointee}} {{none}}
   _ = UnsafeMutablePointer<T>() // expected-error {{'init()' is unavailable: use 'nil' literal}} {{none}}
   _ = x.memory // expected-error {{'memory' has been renamed to 'pointee'}} {{9-15=pointee}} {{none}}
-  _ = UnsafeMutablePointer<T>.alloc(1) // expected-error {{'alloc' is unavailable: use the 'UnsafeMutablePointer(allocatingCapacity:)' initializer}} {{none}}
-  x.dealloc(1) // expected-error {{'dealloc' has been renamed to 'deallocateCapacity'}} {{5-12=deallocateCapacity}} {{none}}
+  _ = UnsafeMutablePointer<T>.alloc(1) // expected-error {{'alloc' has been renamed to 'allocate(capacity:)'}} {{31-36=allocate}} {{37-37=capacity: }} {{none}}
+  x.dealloc(1) // expected-error {{'dealloc' has been renamed to 'deallocate(capacity:)'}} {{5-12=deallocate}} {{13-13=capacity: }} {{none}}
   x.memory = e // expected-error {{'memory' has been renamed to 'pointee'}} {{5-11=pointee}} {{none}}
   x.initialize(e) // expected-error {{'initialize' has been renamed to 'initialize(to:)'}} {{5-15=initialize}} {{16-16=to: }} {{none}}
   x.destroy() // expected-error {{'destroy()' has been renamed to 'deinitialize(count:)'}} {{5-12=deinitialize}} {{none}}
   x.destroy(1) // expected-error {{'destroy' has been renamed to 'deinitialize(count:)'}} {{5-12=deinitialize}} {{13-13=count: }} {{none}}
   x.initialize(with: e) // expected-error {{'initialize(with:count:)' has been renamed to 'initialize(to:count:)'}} {{5-15=initialize}}
 
-  let ptr1 = UnsafeMutablePointer<T>(allocatingCapacity: 1)
+  let ptr1 = UnsafeMutablePointer<T>(allocatingCapacity: 1) // expected-error {{'init(allocatingCapacity:)' is unavailable: use 'UnsafeMutablePointer.allocate(capacity:)'}} {{none}}
   ptr1.initialize(with: e, count: 1) // expected-error {{'initialize(with:count:)' has been renamed to 'initialize(to:count:)'}}
-  let ptr2 = UnsafeMutablePointer<T>(allocatingCapacity: 1)
+  let ptr2 = UnsafeMutablePointer<T>.allocate(capacity: 1)
   ptr2.initializeFrom(ptr1, count: 1) // expected-error {{'initializeFrom(_:count:)' has been renamed to 'initialize(from:count:)'}}
   ptr1.assignFrom(ptr2, count: 1) // expected-error {{'assignFrom(_:count:)' has been renamed to 'assign(from:count:)'}}
   ptr1.assignFrom(ptr2, count: 1) // expected-error {{'assignFrom(_:count:)' has been renamed to 'assign(from:count:)'}}
@@ -517,8 +517,8 @@ func _UnsafePointer<T>(x: UnsafeMutablePointer<T>, e: T) {
   ptr2.moveInitializeFrom(ptr1, count: 1) // expected-error {{'moveInitializeFrom(_:count:)' has been renamed to 'moveInitialize(from:count:)'}}
   ptr1.moveInitializeBackwardFrom(ptr1, count: 1) // expected-error {{'moveInitializeBackwardFrom(_:count:)' has been renamed to 'moveInitialize(from:count:)'}}
   ptr1.deinitialize(count:1)
-  ptr1.deallocateCapacity(1)
-  ptr2.deallocateCapacity(1)
+  ptr1.deallocateCapacity(1) // expected-error {{'deallocateCapacity' has been renamed to 'deallocate(capacity:)'}} {{8-26=deallocate}} {{27-27=capacity: }} {{none}}
+  ptr2.deallocate(capacity: 1)
 }
 
 func _VarArgs() {

--- a/test/1_stdlib/StringAPI.swift
+++ b/test/1_stdlib/StringAPI.swift
@@ -323,38 +323,38 @@ func getNullCString() -> UnsafeMutablePointer<CChar>? {
 }
 
 func getASCIICString() -> (UnsafeMutablePointer<CChar>, dealloc: () -> ()) {
-  let up = UnsafeMutablePointer<CChar>(allocatingCapacity: 100)
+  let up = UnsafeMutablePointer<CChar>.allocate(capacity: 100)
   up[0] = 0x61
   up[1] = 0x62
   up[2] = 0
-  return (up, { up.deallocateCapacity(100) })
+  return (up, { up.deallocate(capacity: 100) })
 }
 
 func getNonASCIICString() -> (UnsafeMutablePointer<CChar>, dealloc: () -> ()) {
-  let up = UnsafeMutablePointer<UInt8>(allocatingCapacity: 100)
+  let up = UnsafeMutablePointer<UInt8>.allocate(capacity: 100)
   up[0] = 0xd0
   up[1] = 0xb0
   up[2] = 0xd0
   up[3] = 0xb1
   up[4] = 0
-  return (UnsafeMutablePointer(up), { up.deallocateCapacity(100) })
+  return (UnsafeMutablePointer(up), { up.deallocate(capacity: 100) })
 }
 
 func getIllFormedUTF8String1(
 ) -> (UnsafeMutablePointer<CChar>, dealloc: () -> ()) {
-  let up = UnsafeMutablePointer<UInt8>(allocatingCapacity: 100)
+  let up = UnsafeMutablePointer<UInt8>.allocate(capacity: 100)
   up[0] = 0x41
   up[1] = 0xed
   up[2] = 0xa0
   up[3] = 0x80
   up[4] = 0x41
   up[5] = 0
-  return (UnsafeMutablePointer(up), { up.deallocateCapacity(100) })
+  return (UnsafeMutablePointer(up), { up.deallocate(capacity: 100) })
 }
 
 func getIllFormedUTF8String2(
 ) -> (UnsafeMutablePointer<CChar>, dealloc: () -> ()) {
-  let up = UnsafeMutablePointer<UInt8>(allocatingCapacity: 100)
+  let up = UnsafeMutablePointer<UInt8>.allocate(capacity: 100)
   up[0] = 0x41
   up[0] = 0x41
   up[1] = 0xed
@@ -362,7 +362,7 @@ func getIllFormedUTF8String2(
   up[3] = 0x81
   up[4] = 0x41
   up[5] = 0
-  return (UnsafeMutablePointer(up), { up.deallocateCapacity(100) })
+  return (UnsafeMutablePointer(up), { up.deallocate(capacity: 100) })
 }
 
 func asCCharArray(_ a: [UInt8]) -> [CChar] {

--- a/test/1_stdlib/UnsafePointer.swift.gyb
+++ b/test/1_stdlib/UnsafePointer.swift.gyb
@@ -189,7 +189,7 @@ func checkPointerCorrectness(_ check: Check,
   _ withMissiles: Bool = false,
   _ f: (UnsafeMutablePointer<Missile>) ->
     (UnsafeMutablePointer<Missile>, count: Int) -> Void) {
-  let ptr = UnsafeMutablePointer<Missile>(allocatingCapacity: 4)
+  let ptr = UnsafeMutablePointer<Missile>.allocate(capacity: 4)
   switch check {
   case .RightOverlap:
     ptr.initialize(to: Missile(1))
@@ -220,7 +220,7 @@ func checkPointerCorrectness(_ check: Check,
     expectEqual(2, ptr[0].number)
     expectEqual(3, ptr[1].number)
     // backwards
-    let ptr2 = UnsafeMutablePointer<Missile>(allocatingCapacity: 4)
+    let ptr2 = UnsafeMutablePointer<Missile>.allocate(capacity: 4)
     ptr2.initialize(to: Missile(0))
     (ptr2 + 1).initialize(to: Missile(1))
     if withMissiles {
@@ -304,10 +304,10 @@ UnsafeMutablePointerTestSuite.test("initialize:from.Right") {
 }
 
 UnsafeMutablePointerTestSuite.test("initialize:from/immutable") {
-  var ptr = UnsafeMutablePointer<Missile>(allocatingCapacity: 3)
+  var ptr = UnsafeMutablePointer<Missile>.allocate(capacity: 3)
   defer {
     ptr.deinitialize(count: 3)
-    ptr.deallocateCapacity(3)
+    ptr.deallocate(capacity: 3)
   }
   let source = (0..<3).map(Missile.init)
   source.withUnsafeBufferPointer { bufferPtr in
@@ -319,10 +319,10 @@ UnsafeMutablePointerTestSuite.test("initialize:from/immutable") {
 }
 
 UnsafeMutablePointerTestSuite.test("assign/immutable") {
-  var ptr = UnsafeMutablePointer<Missile>(allocatingCapacity: 2)
+  var ptr = UnsafeMutablePointer<Missile>.allocate(capacity: 2)
   defer {
     ptr.deinitialize(count: 2)
-    ptr.deallocateCapacity(2)
+    ptr.deallocate(capacity: 2)
   }
   ptr.initialize(to: Missile(1))
   (ptr + 1).initialize(to: Missile(2))

--- a/test/Interpreter/SDK/libc.swift
+++ b/test/Interpreter/SDK/libc.swift
@@ -25,7 +25,7 @@ print("\(UINT32_MAX)")
 // CHECK: the magic word is ///* magic *///
 let sourceFile = open(sourcePath, O_RDONLY)
 assert(sourceFile >= 0)
-var bytes = UnsafeMutablePointer<CChar>(allocatingCapacity: 12)
+var bytes = UnsafeMutablePointer<CChar>.allocate(capacity: 12)
 var readed = read(sourceFile, bytes, 11)
 close(sourceFile)
 assert(readed == 11)

--- a/test/Prototypes/CollectionTransformers.swift
+++ b/test/Prototypes/CollectionTransformers.swift
@@ -219,7 +219,7 @@ struct _ForkJoinMutex {
   var _mutex: UnsafeMutablePointer<pthread_mutex_t>
 
   init() {
-    _mutex = UnsafeMutablePointer(allocatingCapacity: 1)
+    _mutex = UnsafeMutablePointer.allocate(capacity: 1)
     if pthread_mutex_init(_mutex, nil) != 0 {
       fatalError("pthread_mutex_init")
     }
@@ -230,7 +230,7 @@ struct _ForkJoinMutex {
       fatalError("pthread_mutex_init")
     }
     _mutex.deinitialize()
-    _mutex.deallocateCapacity(1)
+    _mutex.deallocate(capacity: 1)
   }
 
   func withLock<Result>(_ body: @noescape () -> Result) -> Result {
@@ -249,7 +249,7 @@ struct _ForkJoinCond {
   var _cond: UnsafeMutablePointer<pthread_cond_t>
 
   init() {
-    _cond = UnsafeMutablePointer(allocatingCapacity: 1)
+    _cond = UnsafeMutablePointer.allocate(capacity: 1)
     if pthread_cond_init(_cond, nil) != 0 {
       fatalError("pthread_cond_init")
     }
@@ -260,7 +260,7 @@ struct _ForkJoinCond {
       fatalError("pthread_cond_destroy")
     }
     _cond.deinitialize()
-    _cond.deallocateCapacity(1)
+    _cond.deallocate(capacity: 1)
   }
 
   func signal() {

--- a/test/SILGen/addressors.swift
+++ b/test/SILGen/addressors.swift
@@ -79,7 +79,7 @@ func test1() -> Int32 {
   return A()[0]
 }
 
-let uninitAddr = UnsafeMutablePointer<Int32>(allocatingCapacity: 1)
+let uninitAddr = UnsafeMutablePointer<Int32>.allocate(capacity: 1)
 var global: Int32 {
   unsafeAddress {
     return UnsafePointer(uninitAddr)
@@ -246,7 +246,7 @@ func test_e(_ e: E) {
 }
 
 class F {
-  var data: UnsafeMutablePointer<Int32> = UnsafeMutablePointer(allocatingCapacity: 100)
+  var data: UnsafeMutablePointer<Int32> = UnsafeMutablePointer.allocate(capacity: 100)
 
   final var value: Int32 {
     addressWithNativeOwner {
@@ -297,7 +297,7 @@ func test_f1(_ f: F) {
 // CHECK:   strong_release [[SELF]] : $F
 
 class G {
-  var data: UnsafeMutablePointer<Int32> = UnsafeMutablePointer(allocatingCapacity: 100)
+  var data: UnsafeMutablePointer<Int32> = UnsafeMutablePointer.allocate(capacity: 100)
 
   var value: Int32 {
     addressWithNativeOwner {
@@ -366,7 +366,7 @@ class G {
 // CHECK:   dealloc_value_buffer $Builtin.NativeObject in [[STORAGE]] : $*Builtin.UnsafeValueBuffer
 
 class H {
-  var data: UnsafeMutablePointer<Int32> = UnsafeMutablePointer(allocatingCapacity: 100)
+  var data: UnsafeMutablePointer<Int32> = UnsafeMutablePointer.allocate(capacity: 100)
 
   final var value: Int32 {
     addressWithPinnedNativeOwner {
@@ -417,7 +417,7 @@ func test_h1(_ f: H) {
 // CHECK:   strong_release [[SELF]] : $H
 
 class I {
-  var data: UnsafeMutablePointer<Int32> = UnsafeMutablePointer(allocatingCapacity: 100)
+  var data: UnsafeMutablePointer<Int32> = UnsafeMutablePointer.allocate(capacity: 100)
 
   var value: Int32 {
     addressWithPinnedNativeOwner {
@@ -493,7 +493,7 @@ struct RecMiddle {
   var inner: RecInner
 }
 class RecOuter {
-  var data: UnsafeMutablePointer<RecMiddle> = UnsafeMutablePointer(allocatingCapacity: 100)
+  var data: UnsafeMutablePointer<RecMiddle> = UnsafeMutablePointer.allocate(capacity: 100)
   final var middle: RecMiddle {
     addressWithPinnedNativeOwner {
       return (UnsafePointer(data), Builtin.tryPin(Builtin.castToNativeObject(self)))

--- a/test/SILGen/specialize_attr.swift
+++ b/test/SILGen/specialize_attr.swift
@@ -48,7 +48,7 @@ public class ASubscriptable<Element> : TestSubscriptable {
   var storage: UnsafeMutablePointer<Element>
 
   init(capacity: Int) {
-    storage = UnsafeMutablePointer<Element>(allocatingCapacity: capacity)
+    storage = UnsafeMutablePointer<Element>.allocate(capacity: capacity)
   }
 
   public subscript(i: Int) -> Element {
@@ -76,7 +76,7 @@ public class Addressable<Element> : TestSubscriptable {
   var storage: UnsafeMutablePointer<Element>
 
   init(capacity: Int) {
-    storage = UnsafeMutablePointer<Element>(allocatingCapacity: capacity)
+    storage = UnsafeMutablePointer<Element>.allocate(capacity: capacity)
   }
 
   public subscript(i: Int) -> Element {

--- a/test/Sanitizers/asan.swift
+++ b/test/Sanitizers/asan.swift
@@ -7,12 +7,12 @@
 
 // Test AddressSanitizer execution end-to-end.
 
-var a = UnsafeMutablePointer<Int>(allocatingCapacity: 1)
+var a = UnsafeMutablePointer<Int>.allocate(capacity: 1)
 a.initialize(to: 5)
 a.deinitialize(count: 1)
-a.deallocateCapacity(1)
+a.deallocate(capacity: 1)
 print(a.pointee)
 a.deinitialize(count: 1)
-a.deallocateCapacity(1)
+a.deallocate(capacity: 1)
 
 // CHECK: AddressSanitizer: heap-use-after-free

--- a/validation-test/stdlib/ArrayNew.swift.gyb
+++ b/validation-test/stdlib/ArrayNew.swift.gyb
@@ -565,7 +565,7 @@ for indexRange in [
     .code {
     let a = getBridgedNSArrayOfRefTypeVerbatimBridged(
       numElements: 0, capacity: 16)
-    let buffer = UnsafeMutablePointer<AnyObject>(allocatingCapacity: 16)
+    let buffer = UnsafeMutablePointer<AnyObject>.allocate(capacity: 16)
     a.available_getObjects(
       AutoreleasingUnsafeMutablePointer(buffer), range: NSRange(0..<0))
     expectCrashLater()
@@ -580,7 +580,7 @@ for indexRange in [ 0..<4, -2..<(-1), -1..<2, 2..<4, 4..<5 ] as [Range<Int>] {
     .code {
     let a = getBridgedNSArrayOfRefTypeVerbatimBridged(
       numElements: 3, capacity: 16)
-    let buffer = UnsafeMutablePointer<AnyObject>(allocatingCapacity: 16)
+    let buffer = UnsafeMutablePointer<AnyObject>.allocate(capacity: 16)
     a.available_getObjects(
       AutoreleasingUnsafeMutablePointer(buffer), range: NSRange(0..<3))
     expectCrashLater()
@@ -591,7 +591,7 @@ for indexRange in [ 0..<4, -2..<(-1), -1..<2, 2..<4, 4..<5 ] as [Range<Int>] {
 
 ArrayTestSuite.test("BridgedToObjC/Verbatim/getObjects") {
   let a = getBridgedNSArrayOfRefTypeVerbatimBridged(numElements: 3)
-  let buffer = UnsafeMutablePointer<AnyObject>(allocatingCapacity: 16)
+  let buffer = UnsafeMutablePointer<AnyObject>.allocate(capacity: 16)
   a.available_getObjects(
     AutoreleasingUnsafeMutablePointer(buffer), range: NSRange(0..<3))
 
@@ -613,7 +613,7 @@ ArrayTestSuite.test("BridgedToObjC/Verbatim/getObjects") {
     expectEqual(idValue2, unsafeBitCast(a.object(at: 2), to: UInt.self))
   }
 
-  buffer.deallocateCapacity(3)
+  buffer.deallocate(capacity: 3)
   _fixLifetime(a)
 
   expectAutoreleasedKeysAndValues(unopt: (0, 3))
@@ -839,7 +839,7 @@ for indexRange in [
     .code {
     let a = getBridgedNSArrayOfValueTypeCustomBridged(
       numElements: 0, capacity: 16)
-    let buffer = UnsafeMutablePointer<AnyObject>(allocatingCapacity: 16)
+    let buffer = UnsafeMutablePointer<AnyObject>.allocate(capacity: 16)
     a.available_getObjects(
       AutoreleasingUnsafeMutablePointer(buffer), range: NSRange(0..<0))
     expectCrashLater()
@@ -854,7 +854,7 @@ for indexRange in [ 0..<4, -2..<(-1), -1..<2, 2..<4, 4..<5 ] as [Range<Int>] {
     .code {
     let a = getBridgedNSArrayOfValueTypeCustomBridged(
       numElements: 3, capacity: 16)
-    let buffer = UnsafeMutablePointer<AnyObject>(allocatingCapacity: 16)
+    let buffer = UnsafeMutablePointer<AnyObject>.allocate(capacity: 16)
     a.available_getObjects(
       AutoreleasingUnsafeMutablePointer(buffer), range: NSRange(0..<3))
     expectCrashLater()
@@ -865,7 +865,7 @@ for indexRange in [ 0..<4, -2..<(-1), -1..<2, 2..<4, 4..<5 ] as [Range<Int>] {
 
 ArrayTestSuite.test("BridgedToObjC/Custom/getObjects") {
   let a = getBridgedNSArrayOfValueTypeCustomBridged(numElements: 3)
-  let buffer = UnsafeMutablePointer<AnyObject>(allocatingCapacity: 16)
+  let buffer = UnsafeMutablePointer<AnyObject>.allocate(capacity: 16)
   a.available_getObjects(
     AutoreleasingUnsafeMutablePointer(buffer), range: NSRange(0..<3))
 
@@ -887,7 +887,7 @@ ArrayTestSuite.test("BridgedToObjC/Custom/getObjects") {
     expectEqual(idValue2, unsafeBitCast(a.object(at: 2), to: UInt.self))
   }
 
-  buffer.deallocateCapacity(3)
+  buffer.deallocate(capacity: 3)
   _fixLifetime(a)
 
   expectEqual(3, TestBridgedValueTy.bridgeOperations)

--- a/validation-test/stdlib/CoreAudio.swift
+++ b/validation-test/stdlib/CoreAudio.swift
@@ -206,7 +206,7 @@ CoreAudioTestSuite.test(
 CoreAudioTestSuite.test("UnsafeMutableAudioBufferListPointer.count") {
   let sizeInBytes = AudioBufferList.sizeInBytes(maximumBuffers: 16)
   let ablPtr = UnsafeMutablePointer<AudioBufferList>(
-    UnsafeMutablePointer<UInt8>(allocatingCapacity: sizeInBytes))
+    UnsafeMutablePointer<UInt8>.allocate(capacity: sizeInBytes))
 
   // It is important that 'ablPtrWrapper' is a 'let'.  We are verifying that
   // the 'count' property has a nonmutating setter.
@@ -220,13 +220,13 @@ CoreAudioTestSuite.test("UnsafeMutableAudioBufferListPointer.count") {
   ablPtrWrapper.count = 0x7765_4321
   expectEqual(0x7765_4321, UnsafeMutablePointer<UInt32>(ablPtr).pointee)
 
-  ablPtr.deallocateCapacity(sizeInBytes)
+  ablPtr.deallocate(capacity: sizeInBytes)
 }
 
 CoreAudioTestSuite.test("UnsafeMutableAudioBufferListPointer.subscript(_: Int)") {
   let sizeInBytes = AudioBufferList.sizeInBytes(maximumBuffers: 16)
   let ablPtr = UnsafeMutablePointer<AudioBufferList>(
-    UnsafeMutablePointer<UInt8>(allocatingCapacity: sizeInBytes))
+    UnsafeMutablePointer<UInt8>.allocate(capacity: sizeInBytes))
 
   // It is important that 'ablPtrWrapper' is a 'let'.  We are verifying that
   // the subscript has a nonmutating setter.
@@ -264,7 +264,7 @@ CoreAudioTestSuite.test("UnsafeMutableAudioBufferListPointer.subscript(_: Int)")
     expectEqual(audioBuffer.mData, audioBufferPtr.pointee.mData)
   }
 
-  ablPtr.deallocateCapacity(sizeInBytes)
+  ablPtr.deallocate(capacity: sizeInBytes)
 }
 
 CoreAudioTestSuite.test("UnsafeMutableAudioBufferListPointer.subscript(_: Int)/trap") {

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -3875,9 +3875,9 @@ DictionaryTestSuite.test("dropsBridgedCache") {
 DictionaryTestSuite.test("getObjects:andKeys:") {
   let d = ([1: "one", 2: "two"] as Dictionary<Int, String>) as NSDictionary
   var keys = UnsafeMutableBufferPointer(
-    start: UnsafeMutablePointer<NSNumber>(allocatingCapacity: 2), count: 2)
+    start: UnsafeMutablePointer<NSNumber>.allocate(capacity: 2), count: 2)
   var values = UnsafeMutableBufferPointer(
-    start: UnsafeMutablePointer<NSString>(allocatingCapacity: 2), count: 2)
+    start: UnsafeMutablePointer<NSString>.allocate(capacity: 2), count: 2)
   var kp = AutoreleasingUnsafeMutablePointer<AnyObject?>(keys.baseAddress!)
   var vp = AutoreleasingUnsafeMutablePointer<AnyObject?>(values.baseAddress!)
   var null: AutoreleasingUnsafeMutablePointer<AnyObject?>? = nil

--- a/validation-test/stdlib/HashingAvalanche.swift
+++ b/validation-test/stdlib/HashingAvalanche.swift
@@ -15,7 +15,7 @@ func avalancheTest(_ bits: Int, _ hashUnderTest: (UInt64) -> UInt64, _ pValue: D
 
   for inputBit in 0..<bits {
     // Using an array here makes the test too slow.
-    var bitFlips = UnsafeMutablePointer<Int>(allocatingCapacity: bits)
+    var bitFlips = UnsafeMutablePointer<Int>.allocate(capacity: bits)
     for i in 0..<bits {
       bitFlips[i] = 0
     }
@@ -37,7 +37,7 @@ func avalancheTest(_ bits: Int, _ hashUnderTest: (UInt64) -> UInt64, _ pValue: D
         chiSquaredUniform2(testsInBatch, bitFlips[outputBit], pValue),
         "inputBit: \(inputBit), outputBit: \(outputBit)")
     }
-    bitFlips.deallocateCapacity(bits)
+    bitFlips.deallocate(capacity: bits)
   }
 }
 

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -638,12 +638,12 @@ func expectSequencePassthrough<
   }
 
   SequenceLog._copyContents.expectIncrement(baseType) { () -> Void in
-    let buf = UnsafeMutablePointer<S.Iterator.Element>(allocatingCapacity: count)
+    let buf = UnsafeMutablePointer<S.Iterator.Element>.allocate(capacity: count)
   
     let end = s._copyContents(initializing: buf)
     expectTrue(end <= buf + count)
     buf.deinitialize(count: end - buf)
-    buf.deallocateCapacity(count)
+    buf.deallocate(capacity: count)
   }
 }
 

--- a/validation-test/stdlib/StringSlicesConcurrentAppend.swift
+++ b/validation-test/stdlib/StringSlicesConcurrentAppend.swift
@@ -88,7 +88,7 @@ func sliceConcurrentAppendThread(_ tid: ThreadID) {
 }
 
 StringTestSuite.test("SliceConcurrentAppend") {
-  barrierVar = UnsafeMutablePointer(allocatingCapacity: 1)
+  barrierVar = UnsafeMutablePointer.allocate(capacity: 1)
   barrierVar!.initialize(to: _stdlib_pthread_barrier_t())
   var ret = _stdlib_pthread_barrier_init(barrierVar!, nil, 2)
   expectEqual(0, ret)
@@ -111,7 +111,7 @@ StringTestSuite.test("SliceConcurrentAppend") {
   expectEqual(0, ret)
 
   barrierVar!.deinitialize()
-  barrierVar!.deallocateCapacity(1)
+  barrierVar!.deallocate(capacity: 1)
 }
 
 runAllTests()

--- a/validation-test/stdlib/UnsafeBitMap.swift
+++ b/validation-test/stdlib/UnsafeBitMap.swift
@@ -77,7 +77,7 @@ let sizes = [
 
 func make(sizeInBits: Int) -> _UnsafeBitMap {
   let sizeInWords = _UnsafeBitMap.sizeInWords(forSizeInBits: sizeInBits)
-  let storage = UnsafeMutablePointer<UInt>(allocatingCapacity: sizeInWords)
+  let storage = UnsafeMutablePointer<UInt>.allocate(capacity: sizeInWords)
   let bitMap = _UnsafeBitMap(storage: storage, bitCount: sizeInBits)
   expectEqual(sizeInWords, bitMap.numberOfWords)
   return bitMap
@@ -87,7 +87,7 @@ UnsafeBitMapTests.test("initializeToZero()")
   .forEach(in: sizes) {
   sizeInBits in
   let bitMap = make(sizeInBits: sizeInBits)
-  defer { bitMap.values.deallocateCapacity(bitMap.numberOfWords) }
+  defer { bitMap.values.deallocate(capacity: bitMap.numberOfWords) }
 
   bitMap.initializeToZero()
   for i in 0..<sizeInBits {
@@ -99,7 +99,7 @@ UnsafeBitMapTests.test("subscript")
   .forEach(in: sizes) {
   sizeInBits in
   let bitMap = make(sizeInBits: sizeInBits)
-  defer { bitMap.values.deallocateCapacity(bitMap.numberOfWords) }
+  defer { bitMap.values.deallocate(capacity: bitMap.numberOfWords) }
 
   if sizeInBits != 0 {
     bitMap.initializeToZero()

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -299,8 +299,8 @@ ${SelfName}TestSuite.test("nilBaseAddress") {
 }
 
 ${SelfName}TestSuite.test("nonNilButEmpty") {
-  let emptyAllocated = UnsafeMutablePointer<Float>(allocatingCapacity: 0)
-  defer { emptyAllocated.deallocateCapacity(0) }
+  let emptyAllocated = UnsafeMutablePointer<Float>.allocate(capacity: 0)
+  defer { emptyAllocated.deallocate(capacity: 0) }
 
   let emptyBuffer = ${SelfType}(start: ${PointerType}(emptyAllocated), count: 0)
   expectEqual(emptyAllocated, emptyBuffer.baseAddress)
@@ -315,8 +315,8 @@ ${SelfName}TestSuite.test("nonNilButEmpty") {
 
 ${SelfName}TestSuite.test("nonNilNonEmpty") {
   let count = 4
-  let allocated = UnsafeMutablePointer<Float>(allocatingCapacity: count)
-  defer { allocated.deallocateCapacity(count) }
+  let allocated = UnsafeMutablePointer<Float>.allocate(capacity: count)
+  defer { allocated.deallocate(capacity: count) }
   allocated.initialize(to: 1.0, count: count)
   allocated[count - 1] = 2.0
 
@@ -348,8 +348,8 @@ ${SelfName}TestSuite.test("badCount")
   .code {
   expectCrashLater()
 
-  let emptyAllocated = UnsafeMutablePointer<Float>(allocatingCapacity: 0)
-  defer { emptyAllocated.deallocateCapacity(0) }
+  let emptyAllocated = UnsafeMutablePointer<Float>.allocate(capacity: 0)
+  defer { emptyAllocated.deallocate(capacity: 0) }
 
   let buffer = ${SelfType}(start: ${PointerType}(emptyAllocated), count: -1)
   _ = buffer
@@ -382,9 +382,9 @@ ${SelfName}TestSuite.test("subscript/${RangeName}/get").forEach(in: subscriptGet
 
   let elementCount = SubscriptGetTest.elementCount
 
-  var memory = UnsafeMutablePointer<OpaqueValue<Int>>(allocatingCapacity: elementCount)
+  var memory = UnsafeMutablePointer<OpaqueValue<Int>>.allocate(capacity: elementCount)
   let buffer = test.create${SelfName}(from: memory)
-  defer { memory.deallocateCapacity(elementCount) }
+  defer { memory.deallocate(capacity: elementCount) }
 
   let range = test.rangeSelection.${RangeName}(in: buffer)
 
@@ -419,14 +419,14 @@ UnsafeMutableBufferPointerTestSuite.test("subscript/${RangeName}/set")
 
   let elementCount = SubscriptSetTest.elementCount
 
-  var memory = UnsafeMutablePointer<OpaqueValue<Int>>(
-    allocatingCapacity: elementCount)
-  var sliceMemory = UnsafeMutablePointer<OpaqueValue<Int>>(
-    allocatingCapacity: replacementValues.count)
+  var memory = UnsafeMutablePointer<OpaqueValue<Int>>.allocate(
+    capacity: elementCount)
+  var sliceMemory = UnsafeMutablePointer<OpaqueValue<Int>>.allocate(
+    capacity: replacementValues.count)
   var buffer = test.createUnsafeMutableBufferPointer(from: memory)
   defer { 
-    memory.deallocateCapacity(elementCount) 
-    sliceMemory.deallocateCapacity(replacementValues.count)
+    memory.deallocate(capacity: elementCount) 
+    sliceMemory.deallocate(capacity: replacementValues.count)
   }
 
   let range = test.rangeSelection.${RangeName}(in: buffer)
@@ -446,8 +446,8 @@ UnsafeMutableBufferPointerTestSuite.test("subscript/${RangeName}/set")
 
 UnsafeMutableBufferPointerTestSuite.test("changeElementViaBuffer") {
   let count = 4
-  let allocated = UnsafeMutablePointer<Float>(allocatingCapacity: count)
-  defer { allocated.deallocateCapacity(count) }
+  let allocated = UnsafeMutablePointer<Float>.allocate(capacity: count)
+  defer { allocated.deallocate(capacity: count) }
   allocated.initialize(to: 1.0, count: count)
   allocated[count-1] = -1.0
 


### PR DESCRIPTION
As proposed in SE-0107: UnsafeRawPointer:
Rename 'init(allocatingCapacity:)' to 'UnsafeMutablePointer.allocate(capacity:)'
Rename 'deallocateCapacity' to 'deallocate(capacity:)'

`allocate` should not be an initializer. It's primary function is to allocate
memory, not initialize a pointer.

Do not merge without foundation and playground PRs.
