### PR TITLE
[Foundation] Update ByteCountFormatter to have a uniform apinotes ann…

### DIFF
--- a/apinotes/Foundation.apinotes
+++ b/apinotes/Foundation.apinotes
@@ -645,7 +645,7 @@ Classes:
 - Name: NSByteCountFormatter
   Methods:
   - Selector: 'stringFromByteCount:'
-    SwiftName: stringFromByteCount(_:)
+    SwiftName: string(fromByteCount:)
     MethodKind: Instance
 - Name: NSLocale
   SwiftName: NSLocale


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

ByteCountFormatter broke the naming rules for the string conversion method because of apinotes. This corrects it to the appropriate name.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

rdar://problem/26481720 NSByteCountFormatter naming inconsistency

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…otation for stringFromByteCount:

rdar://problem/26481720 NSByteCountFormatter naming inconsistency
