### PR TITLE
[sil-serializer] Do not use RPOT order for serializing SIL basic blocks

### DIFF
--- a/include/swift/SIL/SILOpenedArchetypesTracker.h
+++ b/include/swift/SIL/SILOpenedArchetypesTracker.h
@@ -49,11 +49,8 @@ public:
 
   const SILFunction &getFunction() const { return F; }
 
-  void addOpenedArchetypeDef(Type archetype, SILValue Def) {
-    assert(!getOpenedArchetypeDef(archetype) &&
-           "There can be only one definition of an opened archetype");
-    OpenedArchetypeDefs[archetype] = Def;
-  }
+  // Register a definiton of a given opened archetype.
+  void addOpenedArchetypeDef(Type archetype, SILValue Def);
 
   void removeOpenedArchetypeDef(Type archetype, SILValue Def) {
     auto FoundDef = getOpenedArchetypeDef(archetype);
@@ -83,9 +80,18 @@ public:
   // the typedef operands of this instruction.
   void registerUsedOpenedArchetypes(const SILInstruction *I);
 
+  // Register opened archetypes referenced by this type, if they
+  // are not registered yet. Create placeholders representing forward
+  // definitions of these opened archetypes.
+  void registerUsedOpenedArchetypes(Type Ty);
+
   // Unregister archetypes opened by a given instruction.
   // Should be only called when this instruction is to be removed.
   void unregisterOpenedArchetypes(const SILInstruction *I);
+
+  // Returns true of some of the forward opened archetype definitions
+  // are unresolved.
+  bool hasUnresolvedOpenedArchetypeDefinitions();
 
   // Handling of instruction removal notifications.
   bool needsNotifications() { return true; }

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -43,6 +43,7 @@ class ProtocolConformance;
 /// A serialized module, along with the tools to access it.
 class ModuleFile : public LazyMemberLoader {
   friend class SerializedASTFile;
+  friend class SILDeserializer;
   using Status = serialization::Status;
 
   /// A reference back to the AST representation of the file.
@@ -75,6 +76,9 @@ class ModuleFile : public LazyMemberLoader {
 
   /// The data blob containing all of the module's identifiers.
   StringRef IdentifierData;
+
+  /// A callback to be invoked every time a type was deserialized.
+  llvm::function_ref<void(Type)> DeserializedTypeCallback;
 
 public:
   /// Represents another module that has been imported as a dependency.

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4072,6 +4072,9 @@ Type ModuleFile::getType(TypeID TID) {
     return nullptr;
   }
 
+  // Invoke the callback on the deserialized type.
+  DeserializedTypeCallback(typeOrOffset);
+
   return typeOrOffset;
 }
 

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -755,7 +755,8 @@ ModuleFile::ModuleFile(
       ModuleInputReader(getStartBytePtr(this->ModuleInputBuffer.get()),
                         getEndBytePtr(this->ModuleInputBuffer.get())),
       ModuleDocInputReader(getStartBytePtr(this->ModuleDocInputBuffer.get()),
-                           getEndBytePtr(this->ModuleDocInputBuffer.get())) {
+                           getEndBytePtr(this->ModuleDocInputBuffer.get())),
+      DeserializedTypeCallback([](Type ty) {}) {
   assert(getStatus() == Status::Valid);
   Bits.IsFramework = isFramework;
 


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is build incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

My earlier patch started serializing SIL basic blocks using the RPOT order. While it works, changing the existing order of BBs during the serialization may be very surprising for users. After all, serialization is not supposed to transform the code.

Therefore, this patch follows a different approach. It uses the existing order of BBs during the serialization. When it deserializes/parses SIL and detects a use of an opened archetype before its definition, it basically introduced a forward definition of this opened archetype. Later on, when the actual definition of the opened archetype is found, it replaces the forward definition. There is a correctness check at the end of a SIL function deserialization, which verifies that there are no forward definitions of opened archetypes left unresolved.
