### PR TITLE
Update stdlib for renaming initialize(with:) to initialize(to:).

### DIFF
--- a/stdlib/public/core/ArrayCast.swift
+++ b/stdlib/public/core/ArrayCast.swift
@@ -86,7 +86,7 @@ public func _arrayForceCast<SourceElement, TargetElement>(
         _precondition(
           bridged != nil, "array element cannot be bridged to Objective-C")
         // FIXME: should be an unsafeDowncast.
-        p.initialize(with: unsafeBitCast(bridged!, to: TargetElement.self))
+        p.initialize(to: unsafeBitCast(bridged!, to: TargetElement.self))
         p += 1
       }
     }
@@ -168,7 +168,7 @@ internal func _arrayConditionalBridgeElements<
     guard let value = object as? TargetElement else {
       return nil
     }
-    p.initialize(with: value)
+    p.initialize(to: value)
     p += 1
   }
   return Array(_buffer: _ArrayBuffer(buf, shiftedToStartIndex: 0))

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -273,7 +273,7 @@ public struct ${Self}<Pointee>
       Pointee.self, self._rawValue, source._rawValue, count._builtinWordValue)
     // This builtin is equivalent to:
     // for i in 0..<count {
-    //   (self + i).initialize(with: (source + i).move())
+    //   (self + i).initialize(to: (source + i).move())
     // }
   }
 
@@ -306,7 +306,7 @@ public struct ${Self}<Pointee>
     // var src = source + count
     // var dst = self + count
     // while dst != self {
-    //   (--dst).initialize(with: (--src).move())
+    //   (--dst).initialize(to: (--src).move())
     // }
   }
 


### PR DESCRIPTION
I noticed these breaking on the latest trunk build.
They should have been fixed in this PR:
https://github.com/apple/swift/pull/3601
