### PR TITLE
Allow inout throwing closures to be parameters of rethrows functions.

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1240,6 +1240,9 @@ void AttributeChecker::visitRequiredAttr(RequiredAttr *attr) {
 }
 
 static bool hasThrowingFunctionParameter(CanType type) {
+  if (auto inoutType = type->getAs<InOutType>())
+    type = inoutType->getInOutObjectType()->getCanonicalType();
+
   // Only consider throwing function types.
   if (auto fnType = dyn_cast<AnyFunctionType>(type)) {
     return fnType->getExtInfo().throws();

--- a/lib/Sema/TypeCheckError.cpp
+++ b/lib/Sema/TypeCheckError.cpp
@@ -136,11 +136,13 @@ public:
   static AbstractFunction decomposeFunction(Expr *fn) {
     assert(fn->getValueProvidingExpr() == fn);
 
-    // Look through Optional unwraps
+    // Look through Optional unwraps as well as lvalue loads.
     while (true) {
       if (auto conversion = dyn_cast<ForceValueExpr>(fn)) {
         fn = conversion->getSubExpr()->getValueProvidingExpr();
       } else if (auto conversion = dyn_cast<BindOptionalExpr>(fn)) {
+        fn = conversion->getSubExpr()->getValueProvidingExpr();
+      } else if (auto conversion = dyn_cast<LoadExpr>(fn)) {
         fn = conversion->getSubExpr()->getValueProvidingExpr();
       } else {
         break;
@@ -490,7 +492,16 @@ private:
 
   Classification classifyThrowingParameterBody(ParamDecl *param,
                                                PotentialReason reason) {
-    assert(param->getType()->lookThroughAllAnyOptionalTypes()->castTo<AnyFunctionType>()->throws());
+    if (param->getType()->is<InOutType>())
+      assert(param->getType()
+                 ->getInOutObjectType()
+                 ->castTo<AnyFunctionType>()
+                 ->throws());
+    else
+      assert(param->getType()
+                 ->lookThroughAllAnyOptionalTypes()
+                 ->castTo<AnyFunctionType>()
+                 ->throws());
 
     // If we're currently doing rethrows-checking on the body of the
     // function which declares the parameter, it's rethrowing-only.

--- a/test/decl/func/rethrows.swift
+++ b/test/decl/func/rethrows.swift
@@ -10,6 +10,7 @@ let r3 : Optional<() rethrows -> ()> = nil // expected-error {{only function dec
 func f1(_ f: () throws -> ()) rethrows { try f() }
 func f2(_ f: () -> ()) rethrows { f() } // expected-error {{'rethrows' function must take a throwing function argument}}
 func f3(_ f: UndeclaredFunctionType) rethrows { f() } // expected-error {{use of undeclared type 'UndeclaredFunctionType'}}
+func f4(_ f: inout () throws -> ()) rethrows { try f() }
 
 /** Protocol conformance checking ********************************************/
 


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Fix an issue where we would fail to consider inout closures declared as throwing as actually being declared as throwing, leading to diagnostics when we attempt to declare a rethrows function as taking an inout throwing closure.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is build incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Fixes rdar://problem/27324850.
