### PR TITLE
Fixed buffer overflow in demangler

### DIFF
--- a/tools/swift-reflection-test/swift-reflection-test.c
+++ b/tools/swift-reflection-test/swift-reflection-test.c
@@ -421,8 +421,10 @@ int doDumpHeapInstance(const char *BinaryFilename) {
             return EXIT_SUCCESS;
           break;
         case Existential: {
+          static const char Name[] = "_TtP_";
           swift_typeref_t AnyTR
-            = swift_reflection_typeRefForMangledTypeName(RC, "_TtP_", 5);
+            = swift_reflection_typeRefForMangledTypeName(RC,
+              Name, sizeof(Name)-1);
 
           printf("Reflecting an existential.\n");
           if (!reflectExistential(RC, Pipe, AnyTR))
@@ -430,9 +432,10 @@ int doDumpHeapInstance(const char *BinaryFilename) {
           break;
         }
         case ErrorExistential: {
+          static const char ErrorName[] = "_TtPs5Error_";
           swift_typeref_t ErrorTR
             = swift_reflection_typeRefForMangledTypeName(RC,
-              "_TtPs5Error_", 21);
+              ErrorName, sizeof(ErrorName)-1);
           printf("Reflecting an error existential.\n");
           if (!reflectExistential(RC, Pipe, ErrorTR))
             return EXIT_SUCCESS;


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Changing the name of ErrorProtocol to Error broke this runtime test — causing a buffer overflow.

The mangled name changed from `_TtPs13ErrorProtocol_`->`_TtPs5Error_`  but the strlen didn’t change from 21 to 12.

Error reported is:

```
=================================================================
==88865==ERROR: AddressSanitizer: global-buffer-overflow on address
0x0001028ba40d at pc 0x000103291a1f bp 0x7fff5d3492c0 sp 0x7fff5d348a80
READ of size 9 at 0x0001028ba40d thread T0
   #0 0x103291a1e in wrap_memmove
(libclang_rt.asan_osx_dynamic.dylib+0x42a1e)
   #1 0x7fff8742e224 in std::__1::basic_string<char,
std::__1::char_traits<char>, std::__1::allocator<char> >::__init(char
const*, unsigned long) (libc++.1.dylib+0x3f224)
   #2 0x102907c13 in
swift::Demangle::NodeFactory::create(swift::Demangle::Node::Kind,
llvm::StringRef) string:2044
   #3 0x1028f956b in (anonymous
namespace)::Demangler::demangleTopLevel() Demangle.cpp:358
   #4 0x1028f2e4c in swift::Demangle::demangleSymbolAsNode(char const*,
unsigned long, swift::Demangle::DemangleOptions const&)
Demangle.cpp:2288
   #5 0x1028c425a in swift_reflection_typeRefForMangledTypeName
MetadataReader.h:772
   #6 0x1028b942d in doDumpHeapInstance swift-reflection-test.c:434
   #7 0x1028b9f7a in main swift-reflection-test.c:471
   #8 0x7fff84ab35ac in start (libdyld.dylib+0x35ac)
   #9 0x1  (<unknown module>)

0x0001028ba40d is located 51 bytes to the left of global variable
'<string literal>' defined in
'/Users/buildslave/jenkins/workspace/swift-incremental-asan-RDA/swift/to
ols/swift-reflection-test/swift-reflection-test.c:458:19' (0x1028ba440)
of size 41
 '<string literal>' is ascii string 'swift-reflection-test <binary
filename>
'
0x0001028ba40d is located 0 bytes to the right of global variable
'<string literal>' defined in
'/Users/buildslave/jenkins/workspace/swift-incremental-asan-RDA/swift/to
ols/swift-reflection-test/swift-reflection-test.c:435:15' (0x1028ba400)
of size 13
 '<string literal>' is ascii string '_TtPs5Error_'

SUMMARY: AddressSanitizer: global-buffer-overflow
(libclang_rt.asan_osx_dynamic.dylib+0x42a1e) in wrap_memmove
```

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is build incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
