### PR TITLE
id-as-any SILGen fixups

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -293,8 +293,9 @@ static void buildFuncToBlockInvokeBody(SILGenFunction &gen,
     auto &tl = gen.getTypeLowering(result.getSILType());
     if (tl.isAddressOnly()) {
       assert(result.getConvention() == ResultConvention::Indirect);
-      assert(resultType->isAny() &&
-             "Should not be trying to bridge anything except for Any here");
+      assert((resultType->isAny()
+              || resultType->getAnyOptionalObjectType()->isAny())
+             && "Should not be trying to bridge anything except for Any here");
     }
   }
 
@@ -959,8 +960,9 @@ void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
 
   if (substTy->getNumIndirectResults() > 0) {
     SILResultInfo indirectResult = substTy->getSingleResult();
-    assert(indirectResult.getType()->isAny() &&
-           "Should not be trying to bridge anything except for Any here");
+    assert((indirectResult.getType()->isAny()
+            || indirectResult.getType().getAnyOptionalObjectType()->isAny())
+           && "Should not be trying to bridge anything except for Any here");
     args.push_back(emitTemporaryAllocation(loc, indirectResult.getSILType()));
   }
 

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -308,7 +308,7 @@ ManagedValue
 SILGenFunction::emitOptionalToOptional(SILLocation loc,
                                        ManagedValue input,
                                        SILType resultTy,
-                                       const ValueTransform &transformValue) {
+                                       ValueTransformRef transformValue) {
   auto contBB = createBasicBlock();
   auto isNotPresentBB = createBasicBlock();
   auto isPresentBB = createBasicBlock();

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -862,16 +862,16 @@ public:
                                                  const TypeLowering &optTL,
                                                  SGFContext C = SGFContext());
 
-  typedef std::function<ManagedValue(SILGenFunction &gen,
-                                     SILLocation loc,
-                                     ManagedValue input,
-                                     SILType loweredResultTy)> ValueTransform;
+  typedef llvm::function_ref<ManagedValue(SILGenFunction &gen,
+                                    SILLocation loc,
+                                    ManagedValue input,
+                                    SILType loweredResultTy)> ValueTransformRef;
 
   /// Emit a transformation on the value of an optional type.
   ManagedValue emitOptionalToOptional(SILLocation loc,
                                       ManagedValue input,
                                       SILType loweredResultTy,
-                                      const ValueTransform &transform);
+                                      ValueTransformRef transform);
 
   /// Emit a reinterpret-cast from one pointer type to another, using a library
   /// intrinsic.

--- a/test/PrintAsObjC/any_as_id.swift
+++ b/test/PrintAsObjC/any_as_id.swift
@@ -1,0 +1,57 @@
+// Please keep this file in alphabetical order!
+
+// REQUIRES: objc_interop
+
+// RUN: rm -rf %t && mkdir %t
+
+// FIXME: BEGIN -enable-source-import hackaround
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+// FIXME: END -enable-source-import hackaround
+
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -enable-id-as-any -emit-module -o %t %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -enable-id-as-any -parse-as-library %t/any_as_id.swiftmodule -parse -emit-objc-header-path %t/any_as_id.h
+
+// RUN: FileCheck %s < %t/any_as_id.h
+
+// RUN: %check-in-clang %t/any_as_id.h
+// RUN: %check-in-clang -fno-modules -Qunused-arguments %t/any_as_id.h
+
+import Foundation
+
+
+// CHECK-LABEL: SWIFT_CLASS("_TtC9any_as_id11AnyAsIdTest")
+// CHECK-NEXT:  @interface AnyAsIdTest : NSObject
+class AnyAsIdTest : NSObject {
+
+// CHECK-NEXT:  - (void)takesId:(id _Nonnull)x;
+	func takesId(_ x: Any) {}
+
+// CHECK-NEXT:  - (id _Nonnull)getAny;
+  func getAny() -> Any { return 1 as Any }
+
+// CHECK-NEXT:  - (id _Nonnull)passThroughAny:(id _Nonnull)x;
+  func passThroughAny(_ x: Any) -> Any { return x }
+
+// CHECK-NEXT: - (id _Nonnull)unwrapAny:(id _Nullable)x;
+  func unwrapAny(_ x : Any?) -> Any { return x! }
+
+// CHECK-NEXT: - (id _Nullable)getAnyMaybe;
+  func getAnyMaybe() -> Any? { return nil }
+// CHECK-NEXT: - (id _Nullable)getAnyProbably;
+  func getAnyProbably() -> Any? { return 1 as Any }
+// CHECK-NEXT: - (id _Nullable)passThroughAnyMaybe:(id _Nullable)x;
+  func passThroughAnyMaybe(_ x: Any?) -> Any? { return x }
+// CHECK-NEXT: - (id _Nullable)getAnyConstructively;
+  func getAnyConstructively() -> Any? { return Optional<Any>(1 as Any) }
+// CHECK-NEXT: - (id _Nullable)wrapAny:(id _Nonnull)x;
+  func wrapAny(_ x : Any) -> Any? { return x }
+
+// CHECK-NEXT:  - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
+	/* implicit inherited init() */
+}
+// CHECK-NEXT:  @end
+
+
+

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -309,10 +309,10 @@ class SwiftIdLover : NSObject {
   // CHECK: [[OBJC_RESULT:%.*]] = apply [[BRIDGE_ANYTHING]]<{{.*}}>([[OPEN_RESULT]])
   // CHECK: return [[OBJC_RESULT]]
 
-// TODO
-#if false
   func methodReturningOptionalAny() -> Any? {}
-#endif
+  // CHECK-LABEL: sil hidden @_TFC17objc_bridging_any12SwiftIdLover26methodReturningOptionalAny
+  // CHECK-LABEL: sil hidden [thunk] @_TToFC17objc_bridging_any12SwiftIdLover26methodReturningOptionalAny
+  // CHECK:       function_ref @_TFs27_bridgeAnythingToObjectiveC
 
   func methodTakingAny(a: Any) {}
   // CHECK-LABEL: sil hidden [thunk] @_TToFC17objc_bridging_any12SwiftIdLover15methodTakingAnyfT1aP__T_ : $@convention(objc_method) (AnyObject, SwiftIdLover) -> ()
@@ -330,9 +330,11 @@ class SwiftIdLover : NSObject {
   // CHECK-NEXT:  strong_release %1
   // CHECK-NEXT:  return
 
-#if false
   func methodTakingOptionalAny(a: Any?) {}
-#endif
+  // CHECK-LABEL: sil hidden @_TFC17objc_bridging_any12SwiftIdLover23methodTakingOptionalAny
+
+  // CHECK-LABEL: sil hidden [thunk] @_TToFC17objc_bridging_any12SwiftIdLover23methodTakingOptionalAny
+  // CHECK: init_existential_addr %11 : $*Any, $@opened({{.*}}) AnyObject
 
   // CHECK-LABEL: sil hidden @_TFC17objc_bridging_any12SwiftIdLover26methodTakingBlockTakingAnyfFP_T_T_ : $@convention(method) (@owned @callee_owned (@in Any) -> (), @guaranteed SwiftIdLover) -> ()
 
@@ -395,9 +397,7 @@ class SwiftIdLover : NSObject {
   // CHECK-NEXT:  dealloc_stack [[RESULT]]
   // CHECK-NEXT:  return [[VOID]] : $()
 
-#if false
   func methodTakingBlockTakingOptionalAny(_: (Any?) -> ()) {}
-#endif
 
   func methodReturningBlockTakingAny() -> ((Any) -> ()) {}
 
@@ -429,9 +429,7 @@ class SwiftIdLover : NSObject {
   // CHECK-NEXT:  strong_release %1
   // CHECK-NEXT:  return [[EMPTY]]
 
-#if false
   func methodReturningBlockTakingOptionalAny() -> ((Any?) -> ()) {}
-#endif
 
   func methodTakingBlockReturningAny(_: () -> Any) {}
 
@@ -468,13 +466,11 @@ class SwiftIdLover : NSObject {
   // CHECK-NEXT:  dealloc_stack [[RESULT]]
   // CHECK-NEXT:  return [[BRIDGED]]
 
-#if false
   func methodTakingBlockReturningOptionalAny(_: () -> Any?) {}
-#endif
 
   func methodReturningBlockReturningAny() -> (() -> Any) {}
 
-#if false
   func methodReturningBlockReturningOptionalAny() -> (() -> Any?) {}
-#endif
+  // CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @_TTRXFo__iGSqP___XFdCb__aGSqPs9AnyObject___
+  // CHECK: function_ref @_TFs27_bridgeAnythingToObjectiveC
 }

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -6,6 +6,8 @@ import Foundation
 protocol P {}
 protocol CP: class {}
 
+struct KnownUnbridged {}
+
 // CHECK-LABEL: sil hidden @_TF17objc_bridging_any11passingToId
 func passingToId<T: CP, U>(receiver: IdLover,
                            string: String,
@@ -15,8 +17,24 @@ func passingToId<T: CP, U>(receiver: IdLover,
                            classExistential: CP,
                            generic: U,
                            existential: P,
-                           any: Any) {
-  // CHECK: bb0([[SELF:%.*]] : $IdLover, [[STRING:%.*]] : $String, [[NSSTRING:%.*]] : $NSString, [[OBJECT:%.*]] : $AnyObject, [[CLASS_GENERIC:%.*]] : $T, [[CLASS_EXISTENTIAL:%.*]] : $CP, [[GENERIC:%.*]] : $*U, [[EXISTENTIAL:%.*]] : $*P, [[ANY:%.*]] : $*Any
+                           any: Any,
+                           knownUnbridged: KnownUnbridged,
+                           optionalA: String?,
+                           optionalB: NSString?,
+                           optionalC: Any?) {
+  // CHECK: bb0([[SELF:%.*]] : $IdLover,
+  // CHECK: [[STRING:%.*]] : $String
+  // CHECK: [[NSSTRING:%.*]] : $NSString
+  // CHECK: [[OBJECT:%.*]] : $AnyObject
+  // CHECK: [[CLASS_GENERIC:%.*]] : $T
+  // CHECK: [[CLASS_EXISTENTIAL:%.*]] : $CP
+  // CHECK: [[GENERIC:%.*]] : $*U
+  // CHECK: [[EXISTENTIAL:%.*]] : $*P
+  // CHECK: [[ANY:%.*]] : $*Any
+  // CHECK: [[KNOWN_UNBRIDGED:%.*]] : $KnownUnbridged
+  // CHECK: [[OPT_STRING:%.*]] : $Optional<String>
+  // CHECK: [[OPT_NSSTRING:%.*]] : $Optional<NSString>
+  // CHECK: [[OPT_ANY:%.*]] : $*Optional<Any>
 
   // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]]
   // CHECK: [[BRIDGE_STRING:%.*]] = function_ref @_TFE10FoundationSS19_bridgeToObjectiveC
@@ -84,33 +102,199 @@ func passingToId<T: CP, U>(receiver: IdLover,
   // CHECK-NEXT: dealloc_stack [[COPY]]
   receiver.takesId(any)
 
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $IdLover,
+  // CHECK: [[TMP:%.*]] = alloc_stack $KnownUnbridged
+  // CHECK: store [[KNOWN_UNBRIDGED]] to [[TMP]]
+  // CHECK: [[BRIDGE_ANYTHING:%.*]] = function_ref @_TFs27_bridgeAnythingToObjectiveC
+  // CHECK: [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<KnownUnbridged>([[TMP]])
+  // CHECK: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  receiver.takesId(knownUnbridged)
+
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $IdLover,
+  // CHECK: [[TMP:%.*]] = alloc_stack $Optional<String>
+  // CHECK: store [[OPT_STRING]] to [[TMP]]
+  // CHECK: [[BRIDGE_ANYTHING:%.*]] = function_ref @_TFs27_bridgeAnythingToObjectiveC
+  // CHECK: [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<Optional<String>>([[TMP]])
+  // CHECK: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  receiver.takesId(optionalA)
+
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $IdLover,
+  // CHECK: [[TMP:%.*]] = alloc_stack $Optional<NSString>
+  // CHECK: store [[OPT_NSSTRING]] to [[TMP]]
+  // CHECK: [[BRIDGE_ANYTHING:%.*]] = function_ref @_TFs27_bridgeAnythingToObjectiveC
+  // CHECK: [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<Optional<NSString>>([[TMP]])
+  // CHECK: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  receiver.takesId(optionalB)
+
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $IdLover,
+  // CHECK: [[TMP:%.*]] = alloc_stack $Optional<Any>
+  // CHECK: copy_addr [[OPT_ANY]] to [initialization] [[TMP]]
+  // CHECK: [[BRIDGE_ANYTHING:%.*]] = function_ref @_TFs27_bridgeAnythingToObjectiveC
+  // CHECK: [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<Optional<Any>>([[TMP]])
+  // CHECK: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  receiver.takesId(optionalC)
+
   // TODO: Property and subscript setters
 }
 
-// TODO: Look through value-to-optional and optional-to-optional conversions.
-/*
-func passingToNullableId(receiver: IdLover,
-                         string: String,
-                         nsString: NSString,
-                         object: AnyObject,
-                         any: Any,
-                         optString: String?,
-                         optNSString: NSString?,
-                         optObject: AnyObject?,
-                         optAny: Any?)
+// CHECK-LABEL: sil hidden @_TF17objc_bridging_any19passingToNullableId
+func passingToNullableId<T: CP, U>(receiver: IdLover,
+                                   string: String,
+                                   nsString: NSString,
+                                   object: AnyObject,
+                                   classGeneric: T,
+                                   classExistential: CP,
+                                   generic: U,
+                                   existential: P,
+                                   any: Any,
+                                   knownUnbridged: KnownUnbridged,
+                                   optString: String?,
+                                   optNSString: NSString?,
+                                   optObject: AnyObject?,
+                                   optClassGeneric: T?,
+                                   optClassExistential: CP?,
+                                   optGeneric: U?,
+                                   optExistential: P?,
+                                   optAny: Any?,
+                                   optKnownUnbridged: KnownUnbridged?,
+                                   optOptA: String??,
+                                   optOptB: NSString??,
+                                   optOptC: Any??)
 {
-  receiver.takesNullableId(string)
-  receiver.takesNullableId(nsString)
-  receiver.takesNullableId(object)
-  receiver.takesNullableId(any)
-  receiver.takesNullableId(optString)
-  receiver.takesNullableId(optNSString)
-  receiver.takesNullableId(optObject)
-  receiver.takesNullableId(optAny)
-}
- */
+  // CHECK: bb0([[SELF:%.*]] : $IdLover,
+  // CHECK: [[STRING:%.*]] : $String,
+  // CHECK: [[NSSTRING:%.*]] : $NSString
+  // CHECK: [[OBJECT:%.*]] : $AnyObject
+  // CHECK: [[CLASS_GENERIC:%.*]] : $T
+  // CHECK: [[CLASS_EXISTENTIAL:%.*]] : $CP
+  // CHECK: [[GENERIC:%.*]] : $*U
+  // CHECK: [[EXISTENTIAL:%.*]] : $*P
+  // CHECK: [[ANY:%.*]] : $*Any,
+  // CHECK: [[KNOWN_UNBRIDGED:%.*]] : $KnownUnbridged,
+  // CHECK: [[OPT_STRING:%.*]] : $Optional<String>,
+  // CHECK: [[OPT_NSSTRING:%.*]] : $Optional<NSString>
+  // CHECK: [[OPT_OBJECT:%.*]] : $Optional<AnyObject>
+  // CHECK: [[OPT_CLASS_GENERIC:%.*]] : $Optional<T>
+  // CHECK: [[OPT_CLASS_EXISTENTIAL:%.*]] : $Optional<CP>
+  // CHECK: [[OPT_GENERIC:%.*]] : $*Optional<U>
+  // CHECK: [[OPT_EXISTENTIAL:%.*]] : $*Optional<P>
+  // CHECK: [[OPT_ANY:%.*]] : $*Optional<Any>
+  // CHECK: [[OPT_KNOWN_UNBRIDGED:%.*]] : $Optional<KnownUnbridged>
+  // CHECK: [[OPT_OPT_A:%.*]] : $Optional<Optional<String>>
+  // CHECK: [[OPT_OPT_B:%.*]] : $Optional<Optional<NSString>>
+  // CHECK: [[OPT_OPT_C:%.*]] : $*Optional<Optional<Any>>
 
-// TODO: casting from id, nullable or not
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]]
+  // CHECK: [[BRIDGE_STRING:%.*]] = function_ref @_TFE10FoundationSS19_bridgeToObjectiveC
+  // CHECK: [[BRIDGED:%.*]] = apply [[BRIDGE_STRING]]([[STRING]])
+  // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref [[BRIDGED]] : $NSString : $NSString, $AnyObject
+  // CHECK: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[ANYOBJECT]]
+  // CHECK: apply [[METHOD]]([[OPT_ANYOBJECT]], [[SELF]])
+  receiver.takesNullableId(string)
+
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $IdLover,
+  // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref [[NSSTRING]] : $NSString : $NSString, $AnyObject
+  // CHECK: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[ANYOBJECT]]
+  // CHECK: apply [[METHOD]]([[OPT_ANYOBJECT]], [[SELF]])
+  receiver.takesNullableId(nsString)
+
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $IdLover,
+  // CHECK: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[OBJECT]]
+  // CHECK: apply [[METHOD]]([[OPT_ANYOBJECT]], [[SELF]])
+  receiver.takesNullableId(object)
+
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $IdLover,
+  // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref [[CLASS_GENERIC]] : $T : $T, $AnyObject
+  // CHECK: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[ANYOBJECT]]
+  // CHECK: apply [[METHOD]]([[OPT_ANYOBJECT]], [[SELF]])
+  receiver.takesNullableId(classGeneric)
+
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $IdLover,
+  // CHECK: [[OPENED:%.*]] = open_existential_ref [[CLASS_EXISTENTIAL]] : $CP
+  // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref [[OPENED]]
+  // CHECK: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[ANYOBJECT]]
+  // CHECK: apply [[METHOD]]([[OPT_ANYOBJECT]], [[SELF]])
+  receiver.takesNullableId(classExistential)
+
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $IdLover,
+  // CHECK-NEXT: [[COPY:%.*]] = alloc_stack $U
+  // CHECK-NEXT: copy_addr [[GENERIC]] to [initialization] [[COPY]]
+  // CHECK-NEXT: // function_ref _bridgeAnythingToObjectiveC
+  // CHECK-NEXT: [[BRIDGE_ANYTHING:%.*]] = function_ref
+  // CHECK-NEXT: [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<U>([[COPY]])
+  // CHECK-NEXT: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[ANYOBJECT]]
+  // CHECK-NEXT: apply [[METHOD]]([[OPT_ANYOBJECT]], [[SELF]])
+  // CHECK-NEXT: strong_release [[ANYOBJECT]]
+  // CHECK-NEXT: dealloc_stack [[COPY]]
+  receiver.takesNullableId(generic)
+
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $IdLover,
+  // CHECK-NEXT: [[COPY:%.*]] = alloc_stack $P
+  // CHECK-NEXT: copy_addr [[EXISTENTIAL]] to [initialization] [[COPY]]
+  // CHECK-NEXT: [[OPENED_COPY:%.*]] = open_existential_addr [[COPY]] : $*P to $*[[OPENED_TYPE:@opened.*P]],
+  // CHECK-NEXT: // function_ref _bridgeAnythingToObjectiveC
+  // CHECK-NEXT: [[BRIDGE_ANYTHING:%.*]] = function_ref
+  // CHECK-NEXT: [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<[[OPENED_TYPE]]>([[OPENED_COPY]])
+  // CHECK-NEXT: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[ANYOBJECT]]
+  // CHECK-NEXT: apply [[METHOD]]([[OPT_ANYOBJECT]], [[SELF]])
+  // CHECK-NEXT: strong_release [[ANYOBJECT]]
+  // CHECK-NEXT: deinit_existential_addr [[COPY]]
+  // CHECK-NEXT: dealloc_stack [[COPY]]
+  receiver.takesNullableId(existential)
+
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $IdLover,
+  // CHECK-NEXT: [[COPY:%.*]] = alloc_stack $Any
+  // CHECK-NEXT: copy_addr [[ANY]] to [initialization] [[COPY]]
+  // CHECK-NEXT: [[OPENED_COPY:%.*]] = open_existential_addr [[COPY]] : $*Any to $*[[OPENED_TYPE:@opened.*Any]],
+  // CHECK-NEXT: // function_ref _bridgeAnythingToObjectiveC
+  // CHECK-NEXT: [[BRIDGE_ANYTHING:%.*]] = function_ref
+  // CHECK-NEXT: [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<[[OPENED_TYPE]]>([[OPENED_COPY]])
+  // CHECK-NEXT: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[ANYOBJECT]]
+  // CHECK-NEXT: apply [[METHOD]]([[OPT_ANYOBJECT]], [[SELF]])
+  // CHECK-NEXT: strong_release [[ANYOBJECT]]
+  // CHECK-NEXT: deinit_existential_addr [[COPY]]
+  // CHECK-NEXT: dealloc_stack [[COPY]]
+  receiver.takesNullableId(any)
+
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $IdLover,
+  // CHECK: [[TMP:%.*]] = alloc_stack $KnownUnbridged
+  // CHECK: store [[KNOWN_UNBRIDGED]] to [[TMP]]
+  // CHECK: [[BRIDGE_ANYTHING:%.*]] = function_ref @_TFs27_bridgeAnythingToObjectiveC
+  // CHECK: [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<KnownUnbridged>([[TMP]])
+  // CHECK: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[ANYOBJECT]]
+  // CHECK: apply [[METHOD]]([[OPT_ANYOBJECT]], [[SELF]])
+  receiver.takesNullableId(knownUnbridged)
+
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]]
+  // CHECK: select_enum [[OPT_STRING]]
+  // CHECK: cond_br
+  // CHECK: [[STRING_DATA:%.*]] = unchecked_enum_data [[OPT_STRING]]
+  // CHECK: [[BRIDGE_STRING:%.*]] = function_ref @_TFE10FoundationSS19_bridgeToObjectiveC
+  // CHECK: [[BRIDGED:%.*]] = apply [[BRIDGE_STRING]]([[STRING_DATA]])
+  // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref [[BRIDGED]] : $NSString : $NSString, $AnyObject
+  // CHECK: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[ANYOBJECT]]
+  // CHECK: br [[JOIN:bb.*]]([[OPT_ANYOBJECT]]
+  // CHECK: [[JOIN]]([[PHI:%.*]] : $Optional<AnyObject>):
+  // CHECK: apply [[METHOD]]([[PHI]], [[SELF]])
+  receiver.takesNullableId(optString)
+
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]]
+  receiver.takesNullableId(optNSString)
+
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]]
+  // CHECK: apply [[METHOD]]([[OPT_OBJECT]], [[SELF]])
+  receiver.takesNullableId(optObject)
+  receiver.takesNullableId(optClassGeneric)
+  receiver.takesNullableId(optClassExistential)
+  receiver.takesNullableId(optGeneric)
+  receiver.takesNullableId(optExistential)
+  receiver.takesNullableId(optAny)
+  receiver.takesNullableId(optKnownUnbridged)
+
+  receiver.takesNullableId(optOptA)
+  receiver.takesNullableId(optOptB)
+  receiver.takesNullableId(optOptC)
+}
 
 // Make sure we generate correct bridging thunks
 class SwiftIdLover : NSObject {
@@ -124,6 +308,11 @@ class SwiftIdLover : NSObject {
   // CHECK: [[BRIDGE_ANYTHING:%.*]] = function_ref @_TFs27_bridgeAnythingToObjectiveC
   // CHECK: [[OBJC_RESULT:%.*]] = apply [[BRIDGE_ANYTHING]]<{{.*}}>([[OPEN_RESULT]])
   // CHECK: return [[OBJC_RESULT]]
+
+// TODO
+#if false
+  func methodReturningOptionalAny() -> Any? {}
+#endif
 
   func methodTakingAny(a: Any) {}
   // CHECK-LABEL: sil hidden [thunk] @_TToFC17objc_bridging_any12SwiftIdLover15methodTakingAnyfT1aP__T_ : $@convention(objc_method) (AnyObject, SwiftIdLover) -> ()
@@ -140,6 +329,10 @@ class SwiftIdLover : NSObject {
   // CHECK-NEXT:  dealloc_stack [[RESULT]]
   // CHECK-NEXT:  strong_release %1
   // CHECK-NEXT:  return
+
+#if false
+  func methodTakingOptionalAny(a: Any?) {}
+#endif
 
   // CHECK-LABEL: sil hidden @_TFC17objc_bridging_any12SwiftIdLover26methodTakingBlockTakingAnyfFP_T_T_ : $@convention(method) (@owned @callee_owned (@in Any) -> (), @guaranteed SwiftIdLover) -> ()
 
@@ -202,6 +395,10 @@ class SwiftIdLover : NSObject {
   // CHECK-NEXT:  dealloc_stack [[RESULT]]
   // CHECK-NEXT:  return [[VOID]] : $()
 
+#if false
+  func methodTakingBlockTakingOptionalAny(_: (Any?) -> ()) {}
+#endif
+
   func methodReturningBlockTakingAny() -> ((Any) -> ()) {}
 
   // CHECK-LABEL: sil hidden @_TFC17objc_bridging_any12SwiftIdLover29methodTakingBlockReturningAnyfFT_P_T_ : $@convention(method) (@owned @callee_owned () -> @out Any, @guaranteed SwiftIdLover) -> () {
@@ -231,6 +428,10 @@ class SwiftIdLover : NSObject {
   // CHECK-NEXT:  dealloc_stack [[RESULT]]
   // CHECK-NEXT:  strong_release %1
   // CHECK-NEXT:  return [[EMPTY]]
+
+#if false
+  func methodReturningBlockTakingOptionalAny() -> ((Any?) -> ()) {}
+#endif
 
   func methodTakingBlockReturningAny(_: () -> Any) {}
 
@@ -267,5 +468,13 @@ class SwiftIdLover : NSObject {
   // CHECK-NEXT:  dealloc_stack [[RESULT]]
   // CHECK-NEXT:  return [[BRIDGED]]
 
+#if false
+  func methodTakingBlockReturningOptionalAny(_: () -> Any?) {}
+#endif
+
   func methodReturningBlockReturningAny() -> (() -> Any) {}
+
+#if false
+  func methodReturningBlockReturningOptionalAny() -> (() -> Any?) {}
+#endif
 }


### PR DESCRIPTION
@milseman added some tests for PrintAsObjC behavior which exposed crasher bugs in SILGen related to bridging `Any?` optionals. This includes fixes as well as peephole improvements to cover those cases.
