### PR TITLE
[SILGen] Remove XFAIL: linux from collection_cast_crash test case

### DIFF
--- a/test/SILGen/collection_cast_crash.swift
+++ b/test/SILGen/collection_cast_crash.swift
@@ -1,7 +1,5 @@
 // RUN: %target-swift-frontend -O -primary-file %s -emit-sil -o - | FileCheck %s
 
-// XFAIL: linux
-
 // check if the compiler does not crash if a function is specialized
 // which contains a collection cast
 
@@ -54,15 +52,15 @@ func setDownCast<Ct : KeyClass>(_ s : Set<KeyClass>) -> Set<Ct> {
 
 let arr: [MyClass] = [MyClass()]
 
-arrayUpCast(arr)
-arrayDownCast(arr)
+_ = arrayUpCast(arr)
+_ = arrayDownCast(arr)
 
 let dict: [KeyClass:MyClass] = [KeyClass() : MyClass()]
 
-dictUpCast(dict)
-dictDownCast(dict)
+_ = dictUpCast(dict)
+_ = dictDownCast(dict)
 
 let s: Set<KeyClass> = Set()
 
-setUpCast(s)
-setDownCast(s)
+_ = setUpCast(s)
+_ = setDownCast(s)


### PR DESCRIPTION
#### What's in this pull request?

This test case no longer fails on Linux.

CC: @rjmccall 
It seems the problem was solved by your [series of changes](https://github.com/apple/swift/compare/598690b594...f4d7ce84d8) and [reverting Xcode 8 beta 3 changes](https://github.com/apple/swift/commit/74e04980159410f42fc904e28269c2df2f3288ba/stdlib/public/core/ArrayCast.swift)

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is build incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
