### PR TITLE
[Parse] Improve diagnostic for deprecated protocol<...> syntax

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -655,6 +655,8 @@ ERROR(disallowed_protocol_composition,PointsToFirstBadToken,
 
 WARNING(deprecated_protocol_composition,none,
         "'protocol<...>' composition syntax is deprecated; join the protocols using '&'", ())
+WARNING(deprecated_protocol_composition_single,none,
+        "'protocol<...>' composition syntax is deprecated and not needed here", ())
 WARNING(deprecated_any_composition,none,
         "'protocol<>' syntax is deprecated; use 'Any' instead", ())
 

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -281,7 +281,7 @@ struct ErrorTypeInVarDecl7 {
 }
 
 struct ErrorTypeInVarDecl8 {
-  var v1 : protocol<FooProtocol // expected-error {{expected '>' to complete protocol composition type}} expected-note {{to match this opening '<'}} expected-warning{{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}}
+  var v1 : protocol<FooProtocol // expected-error {{expected '>' to complete protocol composition type}} expected-note {{to match this opening '<'}}
   var v2 : Int
 }
 
@@ -291,25 +291,22 @@ struct ErrorTypeInVarDecl9 {
 }
 
 struct ErrorTypeInVarDecl10 {
-  var v1 : protocol<FooProtocol // expected-error {{expected '>' to complete protocol composition type}} expected-note {{to match this opening '<'}} expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}}
+  var v1 : protocol<FooProtocol // expected-error {{expected '>' to complete protocol composition type}} expected-note {{to match this opening '<'}}
   var v2 : Int
 }
 
 struct ErrorTypeInVarDecl11 {
-  var v1 : protocol<FooProtocol, // expected-error {{expected identifier for type name}} expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}}
+  var v1 : protocol<FooProtocol, // expected-error {{expected identifier for type name}}
   var v2 : Int
 }
 
 func ErrorTypeInPattern1(_: protocol<) { } // expected-error {{expected identifier for type name}}
-                                           // expected-warning @-1 {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}}
-func ErrorTypeInPattern2(_: protocol<F) { } // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}}
-                                            // expected-error@-1 {{expected '>' to complete protocol composition type}}
-                                            // expected-note@-2 {{to match this opening '<'}}
-                                            // expected-error@-3 {{use of undeclared type 'F'}}
+func ErrorTypeInPattern2(_: protocol<F) { } // expected-error {{expected '>' to complete protocol composition type}}
+                                            // expected-note@-1 {{to match this opening '<'}}
+                                            // expected-error@-2 {{use of undeclared type 'F'}}
 
 func ErrorTypeInPattern3(_: protocol<F,) { } // expected-error {{expected identifier for type name}}
                                              // expected-error@-1 {{use of undeclared type 'F'}}
-                                             // expected-warning@-2 {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}}
 
 struct ErrorTypeInVarDecl12 {
   var v1 : FooProtocol & // expected-error{{expected identifier for type name}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -230,7 +230,7 @@ func test_lambda() {
 
 func test_lambda2() {
   { () -> protocol<Int> in
-    // expected-warning @-1 {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}}
+    // expected-warning @-1 {{'protocol<...>' composition syntax is deprecated and not needed here}} {{11-20=}} {{23-24=}}
     // expected-error @-2 {{non-protocol type 'Int' cannot be used within a protocol composition}}
     // expected-warning @-3 {{result of call is unused}}
     return 1

--- a/test/type/protocol_composition.swift
+++ b/test/type/protocol_composition.swift
@@ -111,7 +111,7 @@ func testConversion() {
   accept_manyPrintable(sp)
 
   // Conversions among existential types.
-  var x2 : protocol<SuperREPLPrintable, FooProtocol> // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}}
+  var x2 : protocol<SuperREPLPrintable, FooProtocol> // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{12-21=}} {{39-40= &}} {{52-53=}}
   x2 = x // expected-error{{value of type 'FooProtocol & REPLPrintable' does not conform to 'FooProtocol & SuperREPLPrintable' in assignment}}
   x = x2
 
@@ -119,14 +119,13 @@ func testConversion() {
   var _ : () -> FooProtocol & SuperREPLPrintable = return_superPrintable
 
   // FIXME: closures make ABI conversions explicit. rdar://problem/19517003
-  var _ : () -> protocol<FooProtocol, REPLPrintable> = { return_superPrintable() } // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}}
+  var _ : () -> protocol<FooProtocol, REPLPrintable> = { return_superPrintable() } // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{17-26=}} {{37-38= &}} {{52-53=}}
 }
 
 // Test the parser's splitting of >= into > and =.
-var x : protocol<P5>= 17 // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}}
+var x : protocol<P5>= 17 // expected-warning {{'protocol<...>' composition syntax is deprecated and not needed here}} {{9-18=}} {{20-22=}}
 
 typealias A = protocol<> // expected-warning {{'protocol<>' syntax is deprecated; use 'Any' instead}} {{15-25=Any}}
 typealias B = protocol<P1, P2> // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{15-24=}} {{26-27= &}} {{30-31=}}
 
-
-
+typealias C = protocol<P1> // expected-warning {{'protocol<...>' composition syntax is deprecated and not needed here}} {{15-24=}} {{26-27=}}


### PR DESCRIPTION
#### What's in this pull request?
- Don't emit deprecated warnings for incomplete protocol<...>.
  
  ```
  func fn(x: protocol<P) {}
  ```
  
  Because other _error_ diagnostics are already emitted
  Moreover, the current fix-it tries to remove `)` after `P`
- Different message for single protocol compostion.
  
  ```
  typealias MyError = protocol<Error>
  ```
  
  Because `"join the protocols using '&'"` is not relevant in this case

CC: @DougGregor, @joewillsher 

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is build incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
