### PR TITLE
dprintf's format argument is read-only

### DIFF
--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -123,7 +123,7 @@ public var stderr : UnsafeMutablePointer<FILE> {
   }
 }
 
-public func dprintf(_ fd: Int, _ format: UnsafeMutablePointer<Int8>, _ args: CVarArg...) -> Int32 {
+public func dprintf(_ fd: Int, _ format: UnsafePointer<Int8>, _ args: CVarArg...) -> Int32 {
   let va_args = getVaList(args)
   return vdprintf(Int32(fd), format, va_args)
 }


### PR DESCRIPTION
Change

``` swift
dprintf(_ fd: Int, _ format: UnsafeMutablePointer<Int8>, _ args: CVarArg...)
```

to

``` swift
dprintf(_ fd: Int, _ format: UnsafePointer<Int8>, _ args: CVarArg...)
```

SR-1958
