### PR TITLE
[swiftc (71 vs. 5109)] Add crasher in swift::decomposeParamType(...)

### DIFF
--- a/validation-test/compiler_crashers/28370-swift-decomposeparamtype.swift
+++ b/validation-test/compiler_crashers/28370-swift-decomposeparamtype.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+func c(n:Any
+func c<T{c(


### PR DESCRIPTION
Add test case for crash triggered in `swift::decomposeParamType(...)`.

Current number of unresolved compiler crashers: 71 (5109 resolved)

Assertion failure in `llvm/include/llvm/ADT/ArrayRef.h (line 186)`:

```
Assertion `Index < Length && "Invalid index!"' failed.

When executing: const T &llvm::ArrayRef<swift::ParamDecl *>::operator[](size_t) const [T = swift::ParamDecl *]
```

Assertion context:

```

    /// @}
    /// @name Operator Overloads
    /// @{
    const T &operator[](size_t Index) const {
      assert(Index < Length && "Invalid index!");
      return Data[Index];
    }

    /// @}
    /// @name Expensive Operations
```

Stack trace:

```
swift: /path/to/llvm/include/llvm/ADT/ArrayRef.h:186: const T &llvm::ArrayRef<swift::ParamDecl *>::operator[](size_t) const [T = swift::ParamDecl *]: Assertion `Index < Length && "Invalid index!"' failed.
8  swift           0x0000000001131544 swift::decomposeParamType(swift::Type, swift::ValueDecl const*, unsigned int) + 708
12 swift           0x0000000000f75433 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 99
13 swift           0x0000000000f7aabe swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 3998
14 swift           0x0000000000ead422 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 850
15 swift           0x0000000000eb3be2 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
18 swift           0x0000000000f2c25a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
19 swift           0x0000000000f2c0be swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
20 swift           0x0000000000f2cc83 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
22 swift           0x0000000000ee7861 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
23 swift           0x0000000000c71a09 swift::CompilerInstance::performSema() + 3289
25 swift           0x00000000007d91c9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
26 swift           0x00000000007a51e8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28370-swift-decomposeparamtype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28370-swift-decomposeparamtype-654b39.o
1.  While type-checking 'c' at validation-test/compiler_crashers/28370-swift-decomposeparamtype.swift:11:1
2.  While type-checking expression at [validation-test/compiler_crashers/28370-swift-decomposeparamtype.swift:11:10 - line:11:11] RangeText="c("
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
