### PR TITLE
[stdlib] Remove optional comparison operators (SE-0121)

### DIFF
--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -380,44 +380,6 @@ public func != <T>(lhs: _OptionalNilComparisonType, rhs: T?) -> Bool {
   }
 }
 
-public func < <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
-  switch (lhs, rhs) {
-  case let (l?, r?):
-    return l < r
-  case (nil, _?):
-    return true
-  default:
-    return false
-  }
-}
-
-public func > <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
-  switch (lhs, rhs) {
-  case let (l?, r?):
-    return l > r
-  default:
-    return rhs < lhs
-  }
-}
-
-public func <= <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
-  switch (lhs, rhs) {
-  case let (l?, r?):
-    return l <= r
-  default:
-    return !(rhs < lhs)
-  }
-}
-
-public func >= <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
-  switch (lhs, rhs) {
-  case let (l?, r?):
-    return l >= r
-  default:
-    return !(lhs < rhs)
-  }
-}
-
 /// Performs a nil-coalescing operation, returning the wrapped value of an
 /// `Optional` instance or a default value.
 ///

--- a/test/1_stdlib/Optional.swift
+++ b/test/1_stdlib/Optional.swift
@@ -73,7 +73,6 @@ func testRelation(_ p: (Int?, Int?) -> Bool) -> [Bool] {
 OptionalTests.test("Equatable") {
   expectEqual([true, false, false, false, false, true], testRelation(==))
   expectEqual([false, true, true, true, true, false], testRelation(!=))
-  expectEqual([false, true, false, false, true, false], testRelation(<))
 }
 
 OptionalTests.test("CustomReflectable") {

--- a/test/1_stdlib/TestCalendar.swift
+++ b/test/1_stdlib/TestCalendar.swift
@@ -219,7 +219,7 @@ class TestCalendar : TestCalendarSuper {
             // Find the days numbered '31' after 'd', allowing the algorithm to move to the next day if required
             c.enumerateDates(startingAfter: d, matching: DateComponents(day: 31), matchingPolicy: .nextTime) { result, exact, stop in
                 // Just stop some arbitrary time in the future
-                if result > d + 86400*365 { stop = true }
+                if result! > d + 86400*365 { stop = true }
                 count += 1
                 if exact { exactCount += 1 }
             }

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -787,15 +787,14 @@ func nilComparison(i: Int, o: AnyObject) {
   _ = i != nil // expected-warning {{comparing non-optional value of type 'Int' to nil always returns true}}
   _ = nil != i // expected-warning {{comparing non-optional value of type 'Int' to nil always returns true}}
   
-  // These should all be illegal when SE-0121 lands.
-  _ = i < nil
-  _ = nil < i
-  _ = i <= nil
-  _ = nil <= i
-  _ = i > nil
-  _ = nil > i
-  _ = i >= nil
-  _ = nil >= i
+  _ = i < nil  // expected-error {{type 'Int' is not optional, value can never be nil}}
+  _ = nil < i  // expected-error {{type 'Int' is not optional, value can never be nil}}
+  _ = i <= nil // expected-error {{type 'Int' is not optional, value can never be nil}}
+  _ = nil <= i // expected-error {{type 'Int' is not optional, value can never be nil}}
+  _ = i > nil  // expected-error {{type 'Int' is not optional, value can never be nil}}
+  _ = nil > i  // expected-error {{type 'Int' is not optional, value can never be nil}}
+  _ = i >= nil // expected-error {{type 'Int' is not optional, value can never be nil}}
+  _ = nil >= i // expected-error {{type 'Int' is not optional, value can never be nil}}
 
   _ = o === nil // expected-warning {{comparing non-optional value of type 'AnyObject' to nil always returns false}}
   _ = o !== nil // expected-warning {{comparing non-optional value of type 'AnyObject' to nil always returns true}}

--- a/test/Parse/try.swift
+++ b/test/Parse/try.swift
@@ -42,10 +42,10 @@ i = try? foo() + bar()
 i ?+= try? foo() + bar()
 i ?+= try? foo() %%%% bar() // expected-error {{'try?' following assignment operator does not cover everything to its right}} // expected-error {{call can throw but is not marked with 'try'}} // expected-warning {{result of operator '%%%%' is unused}}
 i ?+= try? foo() %%% bar()
-_ = foo() < try? bar() // expected-error {{'try?' cannot appear to the right of a non-assignment operator}} // expected-error {{call can throw but is not marked with 'try'}}
-_ = (try? foo()) < bar() // expected-error {{call can throw but is not marked with 'try'}}
-_ = foo() < (try? bar()) // expected-error {{call can throw but is not marked with 'try'}}
-_ = (try? foo()) < (try? bar())
+_ = foo() == try? bar() // expected-error {{'try?' cannot appear to the right of a non-assignment operator}} // expected-error {{call can throw but is not marked with 'try'}}
+_ = (try? foo()) == bar() // expected-error {{call can throw but is not marked with 'try'}}
+_ = foo() == (try? bar()) // expected-error {{call can throw but is not marked with 'try'}}
+_ = (try? foo()) == (try? bar())
 
 let j = true ? try? foo() : try? bar() + 0
 let k = true ? try? foo() : try? bar() %%% 0 // expected-error {{'try?' following conditional operator does not cover everything to its right}}


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

An "implementation" (it's pretty much just deleting code) of [SE-0121](https://github.com/apple/swift-evolution/blob/master/proposals/0121-remove-optional-comparison-operators.md): removing the versions of `<`, `<=`, `>`, and `>=` which accept Optional operands.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
