### PR TITLE
Remove `isUniquelyReferenced` and the `NonObjectiveCBase` class

### DIFF
--- a/stdlib/public/SDK/Foundation/Boxing.swift
+++ b/stdlib/public/SDK/Foundation/Boxing.swift
@@ -54,7 +54,7 @@ extension _MutableBoxing {
     @inline(__always)
     mutating func _applyMutation<ReturnType>(_ whatToDo : @noescape(ReferenceType) -> ReturnType) -> ReturnType {
         // Only create a new box if we are not uniquely referenced
-        if !isUniquelyReferencedNonObjC(&_handle) {
+        if !isKnownUniquelyReferenced(&_handle) {
             let ref = _handle._pointer
             _handle = _MutableHandle(reference: ref)
         }
@@ -187,7 +187,7 @@ extension _MutablePairBoxing {
         case .Immutable(_):
             break
         case .Mutable(_):
-            unique = isUniquelyReferencedNonObjC(&_wrapped)
+            unique = isKnownUniquelyReferenced(&_wrapped)
         }
 
         switch (wrapper) {

--- a/stdlib/public/SDK/Foundation/IndexSet.swift
+++ b/stdlib/public/SDK/Foundation/IndexSet.swift
@@ -734,7 +734,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
         case .Default(_):
             break
         case .Mutable(_):
-            unique = isUniquelyReferencedNonObjC(&_handle)
+            unique = isKnownUniquelyReferenced(&_handle)
         }
         
         switch _handle._pointer {

--- a/stdlib/public/SDK/Foundation/URLRequest.swift
+++ b/stdlib/public/SDK/Foundation/URLRequest.swift
@@ -26,7 +26,7 @@ public struct URLRequest : ReferenceConvertible, Equatable, Hashable {
     internal var _handle: _MutableHandle<NSMutableURLRequest>
     
     internal mutating func _applyMutation<ReturnType>(_ whatToDo : @noescape (NSMutableURLRequest) -> ReturnType) -> ReturnType {
-        if !isUniquelyReferencedNonObjC(&_handle) {
+        if !isKnownUniquelyReferenced(&_handle) {
             let ref = _handle._uncopiedReference()
             _handle = _MutableHandle(reference: ref)
         }

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -411,14 +411,14 @@ struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
   ///   may need to be considered, such as whether the buffer could be
   ///   some immutable Cocoa container.
   public mutating func isUniquelyReferenced() -> Bool {
-    return __bufferPointer.holdsUniqueReference()
+    return __bufferPointer.isUniqueReference()
   }
 
   /// Returns `true` iff this buffer's storage is either
   /// uniquely-referenced or pinned.  NOTE: this does not mean
   /// the buffer is mutable; see the comment on isUniquelyReferenced.
   public mutating func isUniquelyReferencedOrPinned() -> Bool {
-    return __bufferPointer.holdsUniqueOrPinnedReference()
+    return __bufferPointer._isUniqueOrPinnedReference()
   }
 
 #if _runtime(_ObjC)

--- a/stdlib/public/core/HeapBuffer.swift
+++ b/stdlib/public/core/HeapBuffer.swift
@@ -40,8 +40,8 @@ internal func _swift_bufferAllocate(
 /// either in a derived class, or it can be in some manager object
 /// that owns the _HeapBuffer.
 public // @testable (test/Prototypes/MutableIndexableDict.swift)
-class _HeapBufferStorage<Value, Element> : NonObjectiveCBase {
-  public override init() {}
+class _HeapBufferStorage<Value, Element> {
+  public init() {}
 
   /// The type used to actually manage instances of
   /// `_HeapBufferStorage<Value, Element>`.

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -235,11 +235,11 @@ struct _SliceBuffer<Element> : _ArrayBufferProtocol, RandomAccessCollection {
   }
 
   mutating func isUniquelyReferenced() -> Bool {
-    return isUniquelyReferencedNonObjC(&owner)
+    return isKnownUniquelyReferenced(&owner)
   }
 
   mutating func isUniquelyReferencedOrPinned() -> Bool {
-    return isUniquelyReferencedOrPinnedNonObjC(&owner)
+    return _isKnownUniquelyReferencedOrPinned(&owner)
   }
 
   @_versioned

--- a/stdlib/public/core/StringCore.swift
+++ b/stdlib/public/core/StringCore.swift
@@ -614,7 +614,7 @@ extension _StringCore : RangeReplaceableCollection {
     let appending = bounds.lowerBound == endIndex
 
     let existingStorage = !hasCocoaBuffer && (
-      appending || isUniquelyReferencedNonObjC(&_owner)
+      appending || isKnownUniquelyReferenced(&_owner)
     ) ? _claimCapacity(newCount, minElementWidth: width).1 : nil
 
     if _fastPath(existingStorage != nil) {
@@ -666,7 +666,7 @@ extension _StringCore : RangeReplaceableCollection {
 
   public mutating func reserveCapacity(_ n: Int) {
     if _fastPath(!hasCocoaBuffer) {
-      if _fastPath(isUniquelyReferencedNonObjC(&_owner)) {
+      if _fastPath(isKnownUniquelyReferenced(&_owner)) {
 
         let bounds: Range<UnsafePointer<_RawByte>>
           = UnsafePointer(_pointer(toElementAt:0))..<UnsafePointer(_pointer(toElementAt:count))

--- a/test/1_stdlib/ManagedBuffer.swift
+++ b/test/1_stdlib/ManagedBuffer.swift
@@ -19,15 +19,6 @@ import StdlibUnittest
 import Foundation
 #endif
 
-// Check that `NonObjectiveCBase` can be subclassed and the subclass can be
-// created.
-public class SubclassOfNonObjectiveCBase : NonObjectiveCBase {
-  public override init() {}
-}
-func createSubclassOfNonObjectiveCBase() {
-  _ = SubclassOfNonObjectiveCBase()
-}
-
 // Check that the generic parameters are called 'Header' and 'Element'.
 protocol TestProtocol1 {}
 
@@ -199,11 +190,11 @@ tests.test("ManagedBufferPointer") {
       CountAndCapacity(
         count: LifetimeTracked(0), capacity: getRealCapacity(buffer))
     }
-    expectTrue(mgr.holdsUniqueReference())
+    expectTrue(mgr.isUniqueReference())
 
     let buf = mgr.buffer as? TestManagedBuffer<LifetimeTracked>
     expectTrue(buf != nil)
-    expectFalse(mgr.holdsUniqueReference())
+    expectFalse(mgr.isUniqueReference())
     
     let s = buf!
     expectEqual(0, s.count)
@@ -232,12 +223,12 @@ tests.test("ManagedBufferPointer") {
       minimumCapacity: 0
     ) { _, _ in CountAndCapacity(count: LifetimeTracked(0), capacity: 99) }
 
-    expectTrue(mgr.holdsUniqueReference())
+    expectTrue(mgr.isUniqueReference())
     expectEqual(mgr.header.count.value, 0)
     expectEqual(mgr.header.capacity, 99)
 
     let s2 = mgr.buffer as! MyBuffer<LifetimeTracked>
-    expectFalse(mgr.holdsUniqueReference())
+    expectFalse(mgr.isUniqueReference())
     
     let val = mgr.withUnsafeMutablePointerToHeader { $0 }.pointee
     expectEqual(val.count.value, 0)
@@ -245,25 +236,15 @@ tests.test("ManagedBufferPointer") {
   }
 }
 
-tests.test("isUniquelyReferenced") {
+tests.test("isKnownUniquelyReferenced") {
   var s = TestManagedBuffer<LifetimeTracked>.create(0)
-  expectTrue(isUniquelyReferenced(&s))
+  expectTrue(isKnownUniquelyReferenced(&s))
   var s2 = s
-  expectFalse(isUniquelyReferenced(&s))
-  expectFalse(isUniquelyReferenced(&s2))
-  _fixLifetime(s)
-  _fixLifetime(s2)
-}
-
-tests.test("isUniquelyReferencedNonObjC") {
-  var s = TestManagedBuffer<LifetimeTracked>.create(0)
-  expectTrue(isUniquelyReferencedNonObjC(&s))
-  var s2 = s
-  expectFalse(isUniquelyReferencedNonObjC(&s))
-  expectFalse(isUniquelyReferencedNonObjC(&s2))
+  expectFalse(isKnownUniquelyReferenced(&s))
+  expectFalse(isKnownUniquelyReferenced(&s2))
 #if _runtime(_ObjC)
   var s3 = NSArray()
-  expectFalse(isUniquelyReferencedNonObjC(&s3))
+  expectFalse(isKnownUniquelyReferenced(&s3))
 #endif
   _fixLifetime(s)
   _fixLifetime(s2)

--- a/test/1_stdlib/Runtime.swift.gyb
+++ b/test/1_stdlib/Runtime.swift.gyb
@@ -349,9 +349,6 @@ Runtime.test("typeByName") {
   expectTrue(_typeByName("a.SomeSubclass") == SomeSubclass.self)
   // name lookup will be via protocol conformance table
   expectTrue(_typeByName("a.SomeConformingClass") == SomeConformingClass.self)
-  // FIXME: NonObjectiveCBase is slated to die, but I can't think of another
-  // nongeneric public class in the stdlib...
-  expectTrue(_typeByName("Swift.NonObjectiveCBase") == NonObjectiveCBase.self)
 }
 
 Runtime.test("demangleName") {

--- a/validation-test/stdlib/Prototypes/PersistentVector.swift.gyb
+++ b/validation-test/stdlib/Prototypes/PersistentVector.swift.gyb
@@ -1676,13 +1676,12 @@ func == <Key, Value> (
   return lhs.taggedPointer == rhs.taggedPointer
 }
 
-final class _NativePVDictionaryStorageRef<Key : Hashable, Value>
-  : NonObjectiveCBase {
+final internal class _NativePVDictionaryStorageRef<Key : Hashable, Value> {
 
   var _rootNode: _PVAnyNodePointer<Key, Value>?
   var _count: Int
 
-  override init() {
+  init() {
     self._rootNode = nil
     self._count = 0
   }
@@ -1788,7 +1787,7 @@ struct _NativePVDictionaryStorage<Key : Hashable, Value> {
       count = 1
       return nil
     }
-    let isUnique = isUniquelyReferenced(&_storageRef)
+    let isUnique = isKnownUniquelyReferenced(&_storageRef)
     let (oldValue, newRootNode, wasInserted) = oldRootNode.updateValue(
       value,
       forKey: key,
@@ -1811,7 +1810,7 @@ struct _NativePVDictionaryStorage<Key : Hashable, Value> {
       return nil
     }
     let hashValue = key.hashValue
-    let isUnique = isUniquelyReferenced(&_storageRef)
+    let isUnique = isKnownUniquelyReferenced(&_storageRef)
     let (oldValue, newRootNode) = oldRootNode.removeValue(
       forKey: key,
       hashValue: hashValue,

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -742,7 +742,7 @@ StringTests.test("stringCoreReserve")
     
     var originalBuffer = base.bufferID
     let startedUnique = startedNative && base._core._owner != nil
-      && isUniquelyReferencedNonObjC(&base._core._owner!)
+      && isKnownUniquelyReferenced(&base._core._owner!)
     
     base._core.reserveCapacity(0)
     // Now it's unique


### PR DESCRIPTION
We can express the same using the `isUniquelyReferencedNonObjC` API.

With changes for version 2 of the proposal: rename isUniquelyReferencedNonObjC
to isKnownUniquelyReferenced. Cleanup ManagedBufferPointer.

Resolves #44571

This needs to be merged in sync with changes to apple/swift-corelibs-foundation#467
