### PR TITLE
[SILGen] Utilize _silgen_name for implicit global variables

### DIFF
--- a/lib/SILGen/SILGenGlobalVariable.cpp
+++ b/lib/SILGen/SILGenGlobalVariable.cpp
@@ -26,7 +26,10 @@ SILGlobalVariable *SILGenModule::getSILGlobalVariable(VarDecl *gDecl,
                                                       ForDefinition_t forDef) {
   // First, get a mangled name for the declaration.
   std::string mangledName;
-  {
+
+  if (auto SILGenName = gDecl->getAttrs().getAttribute<SILGenNameAttr>()) {
+    mangledName = SILGenName->Name;
+  } else {
     Mangler mangler;
     mangler.mangleGlobalVariableFull(gDecl);
     mangledName = mangler.finalize();

--- a/test/SILGen/default_arguments.swift
+++ b/test/SILGen/default_arguments.swift
@@ -193,7 +193,7 @@ func takeDSOHandle(_ handle: UnsafeMutablePointer<Void> = #dsohandle) { }
 
 // CHECK-LABEL: sil hidden @_TF17default_arguments13testDSOHandleFT_T_
 func testDSOHandle() {
-  // CHECK: [[DSO_HANDLE:%[0-9]+]] = global_addr @_Tv17default_arguments12__dso_handleGSpT__ : $*UnsafeMutablePointer<()>
+  // CHECK: [[DSO_HANDLE:%[0-9]+]] = global_addr @__dso_handle : $*UnsafeMutablePointer<()>
   takeDSOHandle()
 }
 

--- a/test/SILGen/dso_handle.swift
+++ b/test/SILGen/dso_handle.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen %s | FileCheck %s
+
+// CHECK: sil_global hidden_external @__dso_handle : $UnsafeMutablePointer<()>
+
+// CHECK-LABEL: sil @main : $@convention(c)
+// CHECK: bb0
+// CHECK: [[DSO:%[0-9]+]] = global_addr @__dso_handle : $*UnsafeMutablePointer<()>
+// CHECK: load [[DSO]]
+
+// CHECK-LABEL: sil hidden @_TIF10dso_handle14printDSOHandleFT3dsoGSpT___GSpT__A_
+// CHECK: [[DSO:%[0-9]+]] = global_addr @__dso_handle : $*UnsafeMutablePointer<()>
+// CHECK: load [[DSO]]
+func printDSOHandle(dso: UnsafeMutablePointer<Void> = #dsohandle) -> UnsafeMutablePointer<Void> {
+  print(dso)
+}
+
+printDSOHandle()
+


### PR DESCRIPTION
The known __dso_handle symbol name wasn't getting used when emitting
references to #dsohandle, causing link time failures for a mangled
name that didn't exist.

rdar://problem/26565092
