### PR TITLE
[SourceKit] Add test case for crash triggered in swift::ArchetypeBuilder::enumerateRequirements(…)

### DIFF
--- a/validation-test/IDE/crashers/073-swift-archetypebuilder-enumeraterequirements.swift
+++ b/validation-test/IDE/crashers/073-swift-archetypebuilder-enumeraterequirements.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+extension{protocol A{case={class A#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 160
swift-ide-test: /path/to/swift/lib/AST/GenericSignature.cpp:283: auto swift::GenericSignature::getCanonicalManglingSignature(swift::ModuleDecl &)::(anonymous class)::operator()(swift::RequirementKind, ArchetypeBuilder::PotentialArchetype *, llvm::PointerUnion<Type, ArchetypeBuilder::PotentialArchetype *>, swift::RequirementSource) const: Assertion `constraintType->isExistentialType()' failed.
10 swift-ide-test  0x0000000000b3bf09 swift::ArchetypeBuilder::enumerateRequirements(llvm::function_ref<void (swift::RequirementKind, swift::ArchetypeBuilder::PotentialArchetype*, llvm::PointerUnion<swift::Type, swift::ArchetypeBuilder::PotentialArchetype*>, swift::RequirementSource)>) + 185
11 swift-ide-test  0x0000000000c313e5 swift::GenericSignature::getCanonicalManglingSignature(swift::ModuleDecl&) const + 405
12 swift-ide-test  0x0000000000c3c335 swift::Mangle::Mangler::bindGenericParameters(swift::DeclContext const*) + 53
13 swift-ide-test  0x0000000000c7d7aa swift::ide::printDeclUSR(swift::ValueDecl const*, llvm::raw_ostream&) + 762
15 swift-ide-test  0x00000000007aef68 copyAssociatedUSRs(llvm::BumpPtrAllocatorImpl<llvm::MallocAllocator, 4096ul, 4096ul>&, swift::Decl const*) + 104
16 swift-ide-test  0x00000000007afdec swift::ide::CodeCompletionResultBuilder::takeResult() + 1676
20 swift-ide-test  0x0000000000c362c0 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 256
23 swift-ide-test  0x00000000008eccf1 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 305
24 swift-ide-test  0x00000000007a67dd swift::CompilerInstance::performSema() + 3597
25 swift-ide-test  0x0000000000749dd0 main + 34176
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
```
