### PR TITLE
[swiftc (72 vs. 5109)] Add crasher in swift::GenericParamList::getSubstitutionMap(...)

### DIFF
--- a/validation-test/compiler_crashers/28371-swift-genericparamlist-getsubstitutionmap.swift
+++ b/validation-test/compiler_crashers/28371-swift-genericparamlist-getsubstitutionmap.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+{protocol a{protocol b>class B<g:b>:a{func d:e}typealias e


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericParamList::getSubstitutionMap(...)`.

Current number of unresolved compiler crashers: 72 (5109 resolved)

Assertion failure in `llvm/include/llvm/ADT/ArrayRef.h (line 139)`:

```
Assertion `!empty()' failed.

When executing: const T &llvm::ArrayRef<swift::Substitution>::front() const [T = swift::Substitution]
```

Assertion context:

```
    /// size - Get the array size.
    size_t size() const { return Length; }

    /// front - Get the first element.
    const T &front() const {
      assert(!empty());
      return Data[0];
    }

    /// back - Get the last element.
    const T &back() const {
```

Stack trace:

```
swift: /path/to/llvm/include/llvm/ADT/ArrayRef.h:139: const T &llvm::ArrayRef<swift::Substitution>::front() const [T = swift::Substitution]: Assertion `!empty()' failed.
8  swift           0x0000000001136748 swift::GenericParamList::getSubstitutionMap(llvm::ArrayRef<swift::Substitution>) const + 1080
9  swift           0x0000000001127b57 swift::SpecializedProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 215
10 swift           0x0000000001127862 swift::ProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 18
11 swift           0x0000000001128046 swift::ProtocolConformance::getTypeWitness(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 6
12 swift           0x0000000000f32531 swift::TypeChecker::resolveTypeInContext(swift::TypeDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 2401
16 swift           0x0000000000f3362e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
18 swift           0x0000000000f34584 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
19 swift           0x0000000000f33520 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
21 swift           0x0000000000efd7be swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 94
28 swift           0x0000000000ec55e6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
31 swift           0x0000000000f2d5e4 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
32 swift           0x0000000000f593ac swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
33 swift           0x0000000000eb3c81 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 769
35 swift           0x0000000000f2d726 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
36 swift           0x0000000000ee77cd swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
37 swift           0x0000000000c71a09 swift::CompilerInstance::performSema() + 3289
39 swift           0x00000000007d91c9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2857
40 swift           0x00000000007a51e8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28371-swift-genericparamlist-getsubstitutionmap.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28371-swift-genericparamlist-getsubstitutionmap-a3baf5.o
1.  While type-checking expression at [validation-test/compiler_crashers/28371-swift-genericparamlist-getsubstitutionmap.swift:10:1 - line:10:58] RangeText="{protocol a{protocol b>class B<g:b>:a{func d:e}typealias e"
2.  While type-checking 'a' at validation-test/compiler_crashers/28371-swift-genericparamlist-getsubstitutionmap.swift:10:2
3.  While resolving type e at [validation-test/compiler_crashers/28371-swift-genericparamlist-getsubstitutionmap.swift:10:46 - line:10:46] RangeText="e"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
