### PR TITLE
[CodeCompletion] Rebalance match score and semantic context

### DIFF
--- a/test/SourceKit/CodeComplete/complete_fuzzy.swift
+++ b/test/SourceKit/CodeComplete/complete_fuzzy.swift
@@ -90,7 +90,7 @@ func test3() {
 }
 
 // RUN: %complete-test %s -fuzz -tok=CONTEXT_SORT_1 | FileCheck %s -check-prefix=CONTEXT_SORT_1
-// RUN: %complete-test %s -fuzz -fuzzy-weight=10 -tok=CONTEXT_SORT_1 | FileCheck %s -check-prefix=CONTEXT_SORT_1
+// RUN: %complete-test %s -fuzz -fuzzy-weight=1 -tok=CONTEXT_SORT_1 | FileCheck %s -check-prefix=CONTEXT_SORT_4
 // RUN: %complete-test %s -fuzz -fuzzy-weight=100 -tok=CONTEXT_SORT_1 | FileCheck %s -check-prefix=CONTEXT_SORT_2
 // RUN: %complete-test %s -fuzz -fuzzy-weight=10000 -no-inner-results -tok=CONTEXT_SORT_1 | FileCheck %s -check-prefix=CONTEXT_SORT_3
 let myVar = 1
@@ -101,8 +101,8 @@ struct Test4 {
 
     #^CONTEXT_SORT_1,myVa^#
 // CONTEXT_SORT_1: Results for filterText: myVa [
-// CONTEXT_SORT_1-NEXT: myLocalVar
 // CONTEXT_SORT_1-NEXT: myVarTest4
+// CONTEXT_SORT_1-NEXT: myLocalVar
 // CONTEXT_SORT_1-NEXT: myVar
 
 // CONTEXT_SORT_2: Results for filterText: myVa [
@@ -114,6 +114,11 @@ struct Test4 {
 // CONTEXT_SORT_3-NEXT: myVar
 // CONTEXT_SORT_3-NEXT: myVarTest4
 // CONTEXT_SORT_3-NEXT: myLocalVar
+
+// CONTEXT_SORT_4: Results for filterText: myVa [
+// CONTEXT_SORT_4-NEXT: myLocalVar
+// CONTEXT_SORT_4-NEXT: myVarTest4
+// CONTEXT_SORT_4-NEXT: myVar
   }
 }
 
@@ -149,3 +154,25 @@ func test6(x: S1) {
 // MIN_LENGTH_1-NEXT: ]
 // MIN_LENGTH_1-LABEL: Results for filterText: b [
 // MIN_LENGTH_1-NEXT: ]
+
+// RUN: %complete-test %s -fuzz -tok=MAP | FileCheck %s -check-prefix=MAP
+protocol P {
+  func map()
+}
+extension P {
+  func map() {}
+}
+struct Arr : P {
+  func withUnsafeMutablePointer() {}
+}
+func test7(x: Arr) {
+  x.#^MAP,ma,map^#
+}
+// MAP: Results for filterText: ma [
+// MAP-NEXT: map()
+// MAP-NEXT: withUnsafeMutablePointer()
+// MAP-NEXT: ]
+// MAP-LABEL: Results for filterText: map [
+// MAP-NEXT: map()
+// MAP-NEXT: withUnsafeMutablePointer()
+// MAP-NEXT: ]

--- a/test/SourceKit/CodeComplete/complete_popular_api.swift
+++ b/test/SourceKit/CodeComplete/complete_popular_api.swift
@@ -79,17 +79,15 @@ struct OuterNominal {
 // POPULAR_STMT_0:   localColor
 // POPULAR_STMT_0:   fromDerivedColor
 // POPULAR_STMT_0:   fromSuperColor
-// POPULAR_STMT_0:   fromOuterNominalColor
 // POPULAR_STMT_0:   good()
-// POPULAR_STMT_0:   globalColor
-// POPULAR_STMT_0:   okay()
+// POPULAR_STMT_0:   fromOuterNominalColor
 // POPULAR_STMT_0:   DDModuleColor
 // POPULAR_STMT_0:   CCModuleColor
-// bad() ends up here because it's an unpopular global but that's still
-// generally better than "other module" results.
-// POPULAR_STMT_0:   bad()
 // POPULAR_STMT_0:   EEModuleColor
+// POPULAR_STMT_0:   globalColor
+// POPULAR_STMT_0:   okay()
 // POPULAR_STMT_0:   ModuleCollaborate
+// POPULAR_STMT_0:   bad()
 // POPULAR_STMT_0: ]
 // POPULAR_STMT_0-LABEL: Results for filterText: col [
 // POPULAR_STMT_0:   argColor

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.h
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.h
@@ -41,13 +41,10 @@ struct Options {
   unsigned minFuzzyLength = 2;
   unsigned showTopNonLiteralResults = 3;
 
-  // Options for combining priorities. The defaults are chosen so that a fuzzy
-  // match just breaks ties within a semantic context.  If semanticContextWeight
-  // isn't modified, a fuzzyMatchWeight of N means that a perfect match is worth
-  // the same as the worst possible match N/10 "contexts" ahead of it.
-  unsigned semanticContextWeight = 10 * Completion::numSemanticContexts;
-  unsigned fuzzyMatchWeight = 9;
-  unsigned popularityBonus = 5;
+  // Options for combining priorities.
+  unsigned semanticContextWeight = 15;
+  unsigned fuzzyMatchWeight = 10;
+  unsigned popularityBonus = 2;
 };
 
 struct SwiftCompletionInfo {


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

The high weight on semantic context turns out to give a lot of
unreasonable completions on common types. For example
  [0].ma<here>
was suggesting withUnsafeMutable... over map.

rdar://problem/27393776
