### PR TITLE
[stdlib/core] hasPrefix/hasSuffix consider the empty string a prefix/suffix of all strings.

### DIFF
--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -114,16 +114,18 @@ extension String {
   ///     // Prints "true"
   ///
   /// - Parameter prefix: A possible prefix to test against this string.
-  ///   Passing an empty string (`""`) as `prefix` always results in `false`.
   /// - Returns: `true` if the string begins with `prefix`, otherwise, `false`.
   public func hasPrefix(_ prefix: String) -> Bool {
     let selfCore = self._core
     let prefixCore = prefix._core
+    let prefixCount = prefixCore.count
+    if prefixCount == 0 {
+      return true
+    }
     if selfCore.hasContiguousStorage && prefixCore.hasContiguousStorage {
       if selfCore.isASCII && prefixCore.isASCII {
         // Prefix longer than self.
-        let prefixCount = prefixCore.count
-        if prefixCount > selfCore.count || prefixCount == 0 {
+        if prefixCount > selfCore.count {
           return false
         }
         return Int(_swift_stdlib_memcmp(
@@ -167,17 +169,19 @@ extension String {
   ///     // Prints "true"
   ///
   /// - Parameter suffix: A possible suffix to test against this string.
-  ///   Passing an empty string (`""`) as `suffix` always results in `false`.
   /// - Returns: `true` if the string ends with `suffix`, otherwise, `false`.
   public func hasSuffix(_ suffix: String) -> Bool {
     let selfCore = self._core
     let suffixCore = suffix._core
+    let suffixCount = suffixCore.count
+    if suffixCount == 0 {
+      return true
+    }
     if selfCore.hasContiguousStorage && suffixCore.hasContiguousStorage {
       if selfCore.isASCII && suffixCore.isASCII {
-        // Prefix longer than self.
-        let suffixCount = suffixCore.count
+        // Suffix longer than self.
         let selfCount = selfCore.count
-        if suffixCount > selfCount || suffixCount == 0 {
+        if suffixCount > selfCount {
           return false
         }
         return Int(_swift_stdlib_memcmp(

--- a/test/1_stdlib/StringAPI.swift
+++ b/test/1_stdlib/StringAPI.swift
@@ -220,10 +220,12 @@ func checkHasPrefixHasSuffix(
   _ lhs: String, _ rhs: String, _ stackTrace: SourceLocStack
 ) {
 #if _runtime(_ObjC)
-  if lhs == "" {
+  if rhs == "" {
+    expectTrue(lhs.hasPrefix(rhs), stackTrace: stackTrace)
+    expectTrue(lhs.hasSuffix(rhs), stackTrace: stackTrace)
     return
   }
-  if rhs == "" {
+  if lhs == "" {
     expectFalse(lhs.hasPrefix(rhs), stackTrace: stackTrace)
     expectFalse(lhs.hasSuffix(rhs), stackTrace: stackTrace)
     return

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -325,9 +325,9 @@ StringTests.test("hasPrefix")
   .skip(.nativeRuntime("String.hasPrefix undefined without _runtime(_ObjC)"))
   .code {
 #if _runtime(_ObjC)
-  expectFalse("".hasPrefix(""))
+  expectTrue("".hasPrefix(""))
   expectFalse("".hasPrefix("a"))
-  expectFalse("a".hasPrefix(""))
+  expectTrue("a".hasPrefix(""))
   expectTrue("a".hasPrefix("a"))
 
   // U+0301 COMBINING ACUTE ACCENT


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

This pull request changes the behavior of hasPrefix/hasSuffix; they will consider the empty string to be a prefix/suffix of all strings.

Inspired by https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160718/024690.html

Passes `utils/build-script -c -r -T` on OS X 10.11.5 with Xcode 8.0b3.
#### Resolved bug number: ([SR-2131](https://bugs.swift.org/browse/SR-2131))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
