### PR TITLE
Re-enable NSCoder encodeInt/decodeInt in Swift

### DIFF
--- a/apinotes/Foundation.apinotes
+++ b/apinotes/Foundation.apinotes
@@ -160,6 +160,28 @@ Classes:
   - Selector: 'notificationCenterForType:'
     MethodKind: Class
     FactoryAsInit: C
+- Name: NSKeyedArchiver
+  SwiftName: NSKeyedArchiver
+  Methods:
+  - Selector: 'encodeInt:forKey:'
+    Availability: nonswift
+    AvailabilityMsg: Use 'encodeInt32(_:forKey:)' instead
+    MethodKind: Instance
+  - Selector: 'decodeIntForKey:'
+    Availability: nonswift
+    AvailabilityMsg: Use 'decodeInt32(forKey:)' instead
+    MethodKind: Instance
+- Name: NSKeyedUnarchiver
+  SwiftName: NSKeyedUnarchiver
+  Methods:
+  - Selector: 'encodeInt:forKey:'
+    Availability: nonswift
+    AvailabilityMsg: Use 'encodeInt32(_:forKey:)' instead
+    MethodKind: Instance
+  - Selector: 'decodeIntForKey:'
+    Availability: nonswift
+    AvailabilityMsg: Use 'decodeInt32(forKey:)' instead
+    MethodKind: Instance
 - Name: NSCoder
   SwiftName: NSCoder
   Methods:
@@ -168,10 +190,10 @@ Classes:
     Availability: nonswift
     AvailabilityMsg: use generic 'decodeObjectOfClass(_:forKey:)'
   - Selector: 'encodeInt:forKey:'
-    Availability: nonswift
+    SwiftName: encodeCInt(_:forKey:)
     MethodKind: Instance
   - Selector: 'decodeIntForKey:'
-    Availability: nonswift
+    SwiftName: decodeCInt(forKey:)
     MethodKind: Instance
   - Selector: 'encodeDataObject:'
     SwiftName: encode(_:)
@@ -554,10 +576,6 @@ Classes:
   SwiftName: NSArchiver
 - Name: NSUnarchiver
   SwiftName: NSUnarchiver
-- Name: NSKeyedArchiver
-  SwiftName: NSKeyedArchiver
-- Name: NSKeyedUnarchiver
-  SwiftName: NSKeyedUnarchiver
 - Name: NSUniqueIDSpecifier
   SwiftName: NSUniqueIDSpecifier
 - Name: NSUserActivity


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

When we worked on the first version of naming fixes to the automatic import into Swift, we chose to make `-[NSCoder encodeInt:forKey:]` unavailable, to avoid a conflict with `-[NSCoder encodeInt32:forKey:]`, as they would end up with the same name in Swift.

However, if you wish to subclass `NSCoder` in Swift, then you have to override this method. If it is unavailable, then you cannot do so, and if anyone that is encoded using this coder calls it, `NSCoder` will throw an exception. These methods are abstract in that class:

``` objc
- (void)encodeInt:(int)intv forKey:(NSString *)key;
- (void)encodeInt32:(int32_t)intv forKey:(NSString *)key;
- (void)encodeInt64:(int64_t)intv forKey:(NSString *)key;
```

Therefore, we are bringing the method back, but with a slightly different name to resolve the ambiguity.

Import the C integer primitive encode and decode methods as:

``` swift
extension NSCoder {
    func encodeCInt(_ value: Int32, forKey key: String) // ObjC: -encodeInt:forKey:
    func decodeCInt(forKey key: String) -> Int32 // ObjC: -decodeIntForKey:
}
```

This will join the existing family of methods:

``` swift
extension NSCoder {
    func encode(_ value: Int32, forKey key: String) // ObjC: -encodeInt32:forKey:
    func encode(_ value: Int64, forKey key: String) // ObjC: -encodeInt64:forKey:
    func encode(_ value: Int, forKey key: String) // ObjC: -encodeInteger:forKey:

    func decodeInt32(forKey key: String) -> Int32 // ObjC: -decodeInt32ForKey:
    func decodeInt64(forKey key: String) -> Int64 // ObjC: -decodeInt32ForKey:
    func decodeInteger(forKey key: String) -> Int // ObjC: -decodeIntegerForKey:
}
```

We did not choose to rename `Integer` to `Int` in our APIs for coding.

We will continue to make these two functions unavailable on `NSKeyedArchiver` and `NSKeyedUnarchiver`, to avoid confusion with the other encode/decode methods that use integers.
#### Resolved bug number:

rdar://problem/27425997

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
