### PR TITLE
Use alternate implementation of Data.write() on macOS and iOS version…

### DIFF
--- a/stdlib/public/SDK/Foundation/DataThunks.m
+++ b/stdlib/public/SDK/Foundation/DataThunks.m
@@ -11,6 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #import <Foundation/Foundation.h>
+#import <sys/fcntl.h>
+
+#include "swift/Runtime/Config.h"
 
 typedef void (^NSDataDeallocator)(void *, NSUInteger);
 extern const NSDataDeallocator NSDataDeallocatorVM;
@@ -28,4 +31,134 @@ void __NSDataInvokeDeallocatorUnmap(void *mem, NSUInteger length) {
 
 void __NSDataInvokeDeallocatorFree(void *mem, NSUInteger length) {
   NSDataDeallocatorFree(mem, length);
+}
+
+
+#if TARGET_OS_IPHONE && !TARGET_OS_SIMULATOR
+static int __NSFileProtectionClassForOptions(NSUInteger options) {
+    int result;
+    switch (options & NSDataWritingFileProtectionMask) {
+        case NSDataWritingFileProtectionComplete:	// Class A
+            result = 1;
+            break;
+        case NSDataWritingFileProtectionCompleteUnlessOpen:	// Class B
+            result = 2;
+            break;
+        case NSDataWritingFileProtectionCompleteUntilFirstUserAuthentication:	// Class C
+            result = 3;
+            break;
+        case NSDataWritingFileProtectionNone:	// Class D
+            result = 4;
+            break;
+        default:
+            result = 0;
+            break;
+    }
+    return result;
+}
+#endif
+
+static int32_t _NSOpenFileDescriptor(const char *path, NSInteger flags, int protectionClass, NSInteger mode) {
+    int fd = -1;
+    if (protectionClass != 0) {
+        fd = open_dprotected_np(path, flags, protectionClass, 0, mode);
+    } else {
+        fd = open(path, flags, mode);
+    }
+    return fd;
+}
+
+static NSInteger _NSWriteToFileDescriptor(int32_t fd, const void *buffer, NSUInteger length) {
+    size_t preferredChunkSize = (size_t)length;
+    size_t numBytesRemaining = (size_t)length;
+    while (numBytesRemaining > 0UL) {
+        size_t numBytesRequested = (preferredChunkSize < (1LL << 31)) ? preferredChunkSize : ((1LL << 31) - 1);
+        if (numBytesRequested > numBytesRemaining) numBytesRequested = numBytesRemaining;
+        ssize_t numBytesWritten;
+        do {
+            numBytesWritten = write(fd, buffer, numBytesRequested);
+        } while (numBytesWritten < 0L && errno == EINTR);
+        if (numBytesWritten < 0L) {
+            return -1;
+        } else if (numBytesWritten == 0L) {
+            break;
+        } else {
+            numBytesRemaining -= numBytesWritten;
+            if ((size_t)numBytesWritten < numBytesRequested) break;
+            buffer = (char *)buffer + numBytesWritten;
+        }
+    }
+    return length - numBytesRemaining;
+}
+
+extern NSError *_NSErrorWithFilePath(NSInteger code, id pathOrURL);
+extern NSError *_NSErrorWithFilePathAndErrno(NSInteger posixErrno, id pathOrURL, BOOL reading);
+
+SWIFT_CC(swift)
+BOOL _NSWriteDataToFile_Swift(NSURL * NS_RELEASES_ARGUMENT url, NSData * NS_RELEASES_ARGUMENT data, NSDataWritingOptions writingOptions, NSError **errorPtr) {
+    assert((writingOptions & NSDataWritingAtomic) == 0);
+    
+    NSString *path = url.path;
+    char cpath[1026];
+    
+    if (![path getFileSystemRepresentation:cpath maxLength:1024]) {
+        if (errorPtr) *errorPtr = _NSErrorWithFilePath(NSFileWriteInvalidFileNameError, path);
+        return NO;
+    }
+    
+    int protectionClass = 0;
+#if TARGET_OS_IPHONE && !TARGET_OS_SIMULATOR
+    protectionClass = __NSFileProtectionClassForOptions(writingOptions);
+#endif
+    
+    int flags = O_WRONLY|O_CREAT|O_TRUNC;
+    if (writingOptions & NSDataWritingWithoutOverwriting) {
+        flags |= O_EXCL;
+    }
+    int32_t fd = _NSOpenFileDescriptor(cpath, flags, protectionClass, 0666);
+    if (fd < 0) {
+        if (errorPtr) *errorPtr = _NSErrorWithFilePathAndErrno(errno, path, NO);
+        [url release];
+        [data release];
+        return NO;
+    }
+    
+    __block BOOL writingFailed = NO;
+    __block int32_t saveerr = 0;
+    NSUInteger dataLength = [data length];
+    [data enumerateByteRangesUsingBlock:^(const void *bytes, NSRange byteRange, BOOL *stop) {
+        NSUInteger length = byteRange.length;
+        BOOL success = NO;
+        if (length > 0) {
+            NSInteger writtenLength = _NSWriteToFileDescriptor(fd, bytes, length);
+            success = writtenLength > 0 && (NSUInteger)writtenLength == length;
+        } else {
+            success = YES; // Writing nothing always succeeds.
+        }
+        if (!success) {
+            saveerr = errno;
+            writingFailed = YES;
+            *stop = YES;
+        }
+    }];
+    if (dataLength && !writingFailed) {
+        if (fsync(fd) < 0) {
+            writingFailed = YES;
+            saveerr = errno;
+        }
+    }
+    if (writingFailed) {
+        close(fd);
+        errno = (saveerr);
+        if (errorPtr) {
+            *errorPtr = _NSErrorWithFilePathAndErrno(errno, path, NO);
+        }
+        [url release];
+        [data release];
+        return NO;
+    }
+    close(fd);
+    [url release];
+    [data release];
+    return YES;
 }


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

This contains a limited alternate implementation of `Data.write()` for the purpose of fixing an otherwise unavoidable crash on iOS 9.0 / macOS 10.11 or earlier.

This crash is caused by the standard implementation calling `-[NSData enumerateByteRangesUsingBlock:]`, passing in a block to an uninitialized NSString. This doesn't crash normally in Objective-C, but if the implementation of that method ends up copying the block (which it does with a Swift Data), it will.
#### Resolved bug number

rdar://problem/26278731 Runtime crash using Data <-> NSData on 10.11

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…s where the provided implementation would crash

rdar://26278731
