### PR TITLE
[SourceKit] Add test case for crash triggered in swift::ValueDecl::getEffectiveAccess()

### DIFF
--- a/validation-test/IDE/crashers/074-swift-valuedecl-geteffectiveaccess.swift
+++ b/validation-test/IDE/crashers/074-swift-valuedecl-geteffectiveaccess.swift
@@ -1,0 +1,4 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+init{let a{a
+#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 139
swift-ide-test: /path/to/swift/include/swift/AST/Decl.h:2176: swift::Accessibility swift::ValueDecl::getFormalAccess() const: Assertion `hasAccessibility() && "accessibility not computed yet"' failed.
8  swift-ide-test  0x0000000000c1bbae swift::ValueDecl::getEffectiveAccess() const + 606
9  swift-ide-test  0x0000000000c2953d swift::DeclContext::getResilienceExpansion() const + 125
10 swift-ide-test  0x0000000000c1b1b2 swift::ValueDecl::getAccessSemanticsFromContext(swift::DeclContext const*) const + 18
11 swift-ide-test  0x00000000009bcd2d swift::TypeChecker::buildRefExpr(llvm::ArrayRef<swift::ValueDecl*>, swift::DeclContext*, swift::DeclNameLoc, bool, bool) + 125
12 swift-ide-test  0x000000000096e2bd swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 3437
14 swift-ide-test  0x0000000000bbadfb swift::Expr::walk(swift::ASTWalker&) + 27
15 swift-ide-test  0x000000000096ed30 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 224
16 swift-ide-test  0x0000000000975b62 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
19 swift-ide-test  0x00000000009efbca swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
20 swift-ide-test  0x00000000009efa2e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
21 swift-ide-test  0x00000000009ad5ff swift::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 655
25 swift-ide-test  0x0000000000bbb244 swift::Decl::walk(swift::ASTWalker&) + 20
26 swift-ide-test  0x0000000000c53dbe swift::SourceFile::walk(swift::ASTWalker&) + 174
27 swift-ide-test  0x0000000000c52eff swift::ModuleDecl::walk(swift::ASTWalker&) + 79
28 swift-ide-test  0x0000000000c298eb swift::DeclContext::walkContext(swift::ASTWalker&) + 187
29 swift-ide-test  0x00000000008eed68 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 136
30 swift-ide-test  0x00000000007a71ed swift::CompilerInstance::performSema() + 3597
31 swift-ide-test  0x000000000074a351 main + 34593
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl 'init' at <INPUT-FILE>:3:1
2.  While type-checking expression at [<INPUT-FILE>:3:12 - line:3:12] RangeText="a"
```
