### PR TITLE
[swiftc (72 vs. 5110)] Add crasher in swift::PrintOptions::setArchetypeAndDynamicSelfTransform(...)

### DIFF
--- a/validation-test/compiler_crashers/28372-swift-printoptions-setarchetypeanddynamicselftransform.swift
+++ b/validation-test/compiler_crashers/28372-swift-printoptions-setarchetypeanddynamicselftransform.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+{protocol a{
+func a
+enum S<T>:a


### PR DESCRIPTION
Add test case for crash triggered in `swift::PrintOptions::setArchetypeAndDynamicSelfTransform(...)`.

Current number of unresolved compiler crashers: 72 (5110 resolved)

Assertion failure in [`lib/AST/ASTPrinter.cpp (line 68)`](https://github.com/apple/swift/blob/master/lib/AST/ASTPrinter.cpp#L68):

```
Assertion `ParamDecls.size() == Args.size()' failed.

When executing: std::unique_ptr<llvm::DenseMap<StringRef, Type> > swift::collectNameTypeMap(swift::Type)
```

Assertion context:

```
    if (!D || !D->getGenericParams())
      continue;
    SmallVector<Type, 3> Scrach;
    auto Args = BaseTy->getAllGenericArgs(Scrach);
    const auto ParamDecls = D->getGenericParams()->getParams();
    assert(ParamDecls.size() == Args.size());

    // Map type parameter names with their instantiating arguments.
    for (unsigned I = 0, N = ParamDecls.size(); I < N; I++) {
      (*IdMap)[ParamDecls[I]->getName().str()] = Args[I];
    }
```

Stack trace:

```
swift: /path/to/swift/lib/AST/ASTPrinter.cpp:68: std::unique_ptr<llvm::DenseMap<StringRef, Type> > swift::collectNameTypeMap(swift::Type): Assertion `ParamDecls.size() == Args.size()' failed.
9  swift           0x000000000104b5d2 swift::PrintOptions::setArchetypeAndDynamicSelfTransform(swift::Type, swift::DeclContext*) + 130
13 swift           0x0000000000f11a57 swift::TypeChecker::checkConformance(swift::NormalProtocolConformance*) + 2423
14 swift           0x0000000000f11ec7 swift::TypeChecker::checkConformancesInContext(swift::DeclContext*, swift::IterableDeclContext*) + 471
19 swift           0x0000000000ec9ab6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
22 swift           0x0000000000f32a64 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
23 swift           0x0000000000f5e7ac swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
24 swift           0x0000000000eb7b41 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 769
26 swift           0x0000000000f32ba6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
27 swift           0x0000000000eec48d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
28 swift           0x0000000000c73849 swift::CompilerInstance::performSema() + 3289
30 swift           0x00000000007d95c7 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
31 swift           0x00000000007a55c8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28372-swift-printoptions-setarchetypeanddynamicselftransform.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28372-swift-printoptions-setarchetypeanddynamicselftransform-7809a8.o
1.  While type-checking expression at [validation-test/compiler_crashers/28372-swift-printoptions-setarchetypeanddynamicselftransform.swift:10:1 - line:12:11] RangeText="{protocol a{
2.  While type-checking 'a' at validation-test/compiler_crashers/28372-swift-printoptions-setarchetypeanddynamicselftransform.swift:10:2
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
