### PR TITLE
Fix ThreadSafeRefCountedBase*::Release()

### DIFF
--- a/include/swift/IDE/CodeCompletionCache.h
+++ b/include/swift/IDE/CodeCompletionCache.h
@@ -49,7 +49,7 @@ public:
     }
   };
 
-  struct Value : public ThreadSafeRefCountedBase<Value> {
+  struct Value : public llvm::ThreadSafeRefCountedBase<Value> {
     llvm::sys::TimeValue ModuleModificationTime;
     CodeCompletionResultSink Sink;
   };

--- a/tools/SourceKit/include/SourceKit/Core/LLVM.h
+++ b/tools/SourceKit/include/SourceKit/Core/LLVM.h
@@ -43,6 +43,7 @@ namespace llvm {
   // Reference counting.
   template <typename T> class IntrusiveRefCntPtr;
   template <typename T> struct IntrusiveRefCntPtrInfo;
+  template <class Derived> class ThreadSafeRefCountedBase;
 
   class raw_ostream;
   // TODO: DenseMap, ...
@@ -69,7 +70,6 @@ namespace llvm {
 }
 
 namespace swift {
-  template <class Derived> class ThreadSafeRefCountedBase;
   class ThreadSafeRefCountedBaseVPTR;
 }
 
@@ -95,7 +95,7 @@ namespace SourceKit {
   // Reference counting.
   using llvm::IntrusiveRefCntPtr;
   using llvm::IntrusiveRefCntPtrInfo;
-  using swift::ThreadSafeRefCountedBase;
+  using llvm::ThreadSafeRefCountedBase;
   using swift::ThreadSafeRefCountedBaseVPTR;
   template <typename T> class ThreadSafeRefCntPtr;
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftInterfaceGenContext.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftInterfaceGenContext.h
@@ -31,7 +31,7 @@ namespace SourceKit {
   typedef IntrusiveRefCntPtr<ASTUnit> ASTUnitRef;
 
 class SwiftInterfaceGenContext :
-  public swift::ThreadSafeRefCountedBase<SwiftInterfaceGenContext> {
+  public llvm::ThreadSafeRefCountedBase<SwiftInterfaceGenContext> {
 public:
   static SwiftInterfaceGenContextRef create(StringRef DocumentName,
                                             bool IsModule,

--- a/tools/SourceKit/lib/SwiftLang/SwiftInvocation.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftInvocation.h
@@ -26,7 +26,7 @@ namespace SourceKit {
 
 /// Encompasses an invocation for getting an AST. This is used to control AST
 /// sharing among different requests.
-class SwiftInvocation : public swift::ThreadSafeRefCountedBase<SwiftInvocation> {
+class SwiftInvocation : public llvm::ThreadSafeRefCountedBase<SwiftInvocation> {
 public:
   ~SwiftInvocation();
 

--- a/unittests/Basic/CMakeLists.txt
+++ b/unittests/Basic/CMakeLists.txt
@@ -19,6 +19,7 @@ add_swift_unittest(SwiftBasicTests
   SourceManager.cpp
   StringExtrasTest.cpp
   SuccessorMapTest.cpp
+  ThreadSafeRefCntPointerTests.cpp
   TreeScopedHashTableTests.cpp
   Unicode.cpp
   ${generated_tests}

--- a/unittests/Basic/ThreadSafeRefCntPointerTests.cpp
+++ b/unittests/Basic/ThreadSafeRefCntPointerTests.cpp
@@ -1,0 +1,51 @@
+#include "swift/Basic/ThreadSafeRefCounted.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "gtest/gtest.h"
+
+using llvm::IntrusiveRefCntPtr;
+
+struct TestRelease : llvm::ThreadSafeRefCountedBase<TestRelease> {
+  bool &destroy;
+  TestRelease(bool &destroy) : destroy(destroy) {}
+  ~TestRelease() { destroy = true; }
+};
+
+TEST(ThreadSafeRefCountedBase, ReleaseSimple) {
+  bool destroyed = false;
+  {
+    IntrusiveRefCntPtr<TestRelease> ref = new TestRelease(destroyed);
+  }
+  EXPECT_TRUE(destroyed);
+}
+TEST(ThreadSafeRefCountedBase, Release) {
+  bool destroyed = false;
+  {
+    IntrusiveRefCntPtr<TestRelease> ref = new TestRelease(destroyed);
+    ref->Retain();
+    ref->Release();
+  }
+  EXPECT_TRUE(destroyed);
+}
+
+struct TestReleaseVPTR : swift::ThreadSafeRefCountedBaseVPTR {
+  bool &destroy;
+  TestReleaseVPTR(bool &destroy) : destroy(destroy) {}
+  virtual ~TestReleaseVPTR() { destroy = true; }
+};
+
+TEST(ThreadSafeRefCountedBaseVPTR, ReleaseSimple) {
+  bool destroyed = false;
+  {
+    IntrusiveRefCntPtr<TestReleaseVPTR> ref = new TestReleaseVPTR(destroyed);
+  }
+  EXPECT_TRUE(destroyed);
+}
+TEST(ThreadSafeRefCountedBaseVPTR, Release) {
+  bool destroyed = false;
+  {
+    IntrusiveRefCntPtr<TestReleaseVPTR> ref = new TestReleaseVPTR(destroyed);
+    ref->Retain();
+    ref->Release();
+  }
+  EXPECT_TRUE(destroyed);
+}


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
- Explanation: The `ThreadSafeRefCountedBase::Retain` function was broken in preview-3 by using a fetch_and_sub instead of sub_and_fetch atomic decrement.  This caused ASTs (and various other objects) in SourceKit to leak, easily leading to 10GB+ memory usage after editing many files.
- Scope: This is a regression in preview-3 and affects all SourceKit users.
- Risk: Low; in the case of the `ThreadSafeRefCountedBase` type, we switch to using the version in llvm, which is already correct.  For `ThreadSafeRefCountedBaseVPTR` we switch to the same implementation using `--` and `+=` instead of `fetch_sub` and `fetch_add`. A future change can move `ThreadSafeRefCountedBaseVPTR` into llvm.
- Reviewed by: Argyrios Kyrtzidis
- Testing: Unit tests added; verified memory usage is no longer growing indefinitely.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
