### PR TITLE
Add UnsafeRawPointer type and API.

### DIFF
--- a/docs/ABI.rst
+++ b/docs/ABI.rst
@@ -1221,6 +1221,8 @@ Predefined Substitutions
   known-nominal-type ::= 'Sd'                // Swift.Float64
   known-nominal-type ::= 'Sf'                // Swift.Float32
   known-nominal-type ::= 'Si'                // Swift.Int
+  known-nominal-type ::= 'SV'                // Swift.UnsafeRawPointer
+  known-nominal-type ::= 'Sv'                // Swift.UnsafeMutableRawPointer
   known-nominal-type ::= 'SP'                // Swift.UnsafePointer
   known-nominal-type ::= 'Sp'                // Swift.UnsafeMutablePointer
   known-nominal-type ::= 'SQ'                // Swift.ImplicitlyUnwrappedOptional

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -796,7 +796,7 @@ SILCloner<ImplClass>::visitBindMemoryInst(BindMemoryInst *Inst) {
     getBuilder().createBindMemory(getOpLocation(Inst->getLoc()),
                                   getOpValue(Inst->getBase()),
                                   getOpValue(Inst->getIndex()),
-                                  Inst->getBoundType()));
+                                  getOpType(Inst->getBoundType())));
 }
 
 template<typename ImplClass>

--- a/lib/AST/Mangle.cpp
+++ b/lib/AST/Mangle.cpp
@@ -1392,6 +1392,12 @@ bool Mangler::tryMangleStandardSubstitution(const NominalTypeDecl *decl) {
   } else if (name == "Float") {
     Buffer << "Sf";
     return true;
+  } else if (name == "UnsafeRawPointer") {
+    Buffer << "SV";
+    return true;
+  } else if (name == "UnsafeMutableRawPointer") {
+    Buffer << "Sv";
+    return true;
   } else if (name == "UnsafePointer") {
     Buffer << "SP";
     return true;

--- a/lib/Basic/Demangle.cpp
+++ b/lib/Basic/Demangle.cpp
@@ -1037,6 +1037,10 @@ private:
       return createSwiftType(Node::Kind::Structure, "Float");
     if (Mangled.nextIf('i'))
       return createSwiftType(Node::Kind::Structure, "Int");
+    if (Mangled.nextIf('V'))
+      return createSwiftType(Node::Kind::Structure, "UnsafeRawPointer");
+    if (Mangled.nextIf('v'))
+      return createSwiftType(Node::Kind::Structure, "UnsafeMutableRawPointer");
     if (Mangled.nextIf('P'))
       return createSwiftType(Node::Kind::Structure, "UnsafePointer");
     if (Mangled.nextIf('p'))

--- a/lib/Basic/Remangle.cpp
+++ b/lib/Basic/Remangle.cpp
@@ -354,6 +354,8 @@ bool Remangler::trySubstitution(Node *node, SubstitutionEntry &entry) {
       SUCCESS_IF_DECLNAME_IS("Double", "Sd");
       SUCCESS_IF_DECLNAME_IS("Float", "Sf");
       SUCCESS_IF_DECLNAME_IS("Int", "Si");
+      SUCCESS_IF_DECLNAME_IS("UnsafeRawPointer", "SV");
+      SUCCESS_IF_DECLNAME_IS("UnsafeMutableRawPointer", "Sv");
       SUCCESS_IF_DECLNAME_IS("UnsafePointer", "SP");
       SUCCESS_IF_DECLNAME_IS("UnsafeMutablePointer", "Sp");
       SUCCESS_IF_DECLNAME_IS("UnsafeBufferPointer", "SR");

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -121,6 +121,7 @@ set(SWIFTLIB_ESSENTIAL
   UnsafeBitMap.swift
   UnsafeBufferPointer.swift.gyb
   UnsafePointer.swift.gyb
+  UnsafeRawPointer.swift.gyb
   WriteBackMutableSlice.swift
   )
 

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -199,6 +199,24 @@ func _memcpy(
     /*volatile:*/ false._value)
 }
 
+/// Copy `count` bytes of memory from `src` into `dest`.
+///
+/// The memory regions `source..<source + count` and
+/// `dest..<dest + count` may overlap.
+func _memmove(
+  dest destination: UnsafeMutableRawPointer,
+  src: UnsafeRawPointer,
+  size: UInt
+) {
+  let dest = destination._rawValue
+  let src = src._rawValue
+  let size = UInt64(size)._value
+  Builtin.int_memmove_RawPointer_RawPointer_Int64(
+    dest, src, size,
+    /*alignment:*/ Int32()._value,
+    /*volatile:*/ false._value)
+}
+
 @available(*, unavailable, renamed: "OpaquePointer")
 public struct COpaquePointer {}
 

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -115,6 +115,7 @@
   "Pointer": [
     "Pointer.swift",
     "UnsafePointer.swift",
+    "UnsafeRawPointer.swift",
     "UnsafeBufferPointer.swift"
   ],
   "Protocols": [

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -117,7 +117,7 @@ public class ManagedBuffer<Header, Element>
   /// Destroy the stored Header.
   deinit {
     ManagedBufferPointer(self).withUnsafeMutablePointerToHeader {
-      $0.deinitialize()
+      _ = $0.deinitialize()
     }
   }
 

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -322,7 +322,7 @@ public struct ${Self}<Pointee>
   ///   are uninitialized.
   public func moveAssign(from source: ${Self}, count: Int) {
     _debugPrecondition(
-      count >= 0, "${Self}.moveAssignFrom with negative count")
+      count >= 0, "${Self}.moveAssign(from:) with negative count")
     _debugPrecondition(
       self + count <= source || source + count <= self,
       "moveAssign overlapping range")
@@ -363,8 +363,8 @@ public struct ${Self}<Pointee>
   /// - Precondition: The memory `self..<self + count * strideof(T.self)`
   ///   is bound to `Pointee`.
   public func withMemoryRebound<T, Result>(to: T.Type, capacity count: Int,
-    _ body: @noescape (UnsafeMutablePointer<T>) throws -> Result) rethrows
-  -> Result {
+    _ body: @noescape (UnsafeMutablePointer<T>) throws -> Result
+  ) rethrows -> Result {
     Builtin.bindMemory(_rawValue, count._builtinWordValue, T.self)
     defer {
       Builtin.bindMemory(_rawValue, count._builtinWordValue, Pointee.self)
@@ -405,7 +405,7 @@ public struct ${Self}<Pointee>
   ///   different invocations of the same program.  Do not persist the
   ///   hash value across program runs.
   public var hashValue: Int {
-    return Int(Builtin.ptrtoint_Word(_rawValue))
+    return Int(bitPattern: self)
   }
 
   /// Returns the next consecutive position.

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -129,8 +129,10 @@ public struct ${Self}<Pointee>
   static public func allocate(capacity count: Int)
     -> UnsafeMutablePointer<Pointee> {
     let size = strideof(Pointee.self) * count
-    return UnsafeMutablePointer(
-      Builtin.allocRaw(size._builtinWordValue, Builtin.alignof(Pointee.self)))
+    let rawPtr =
+      Builtin.allocRaw(size._builtinWordValue, Builtin.alignof(Pointee.self))
+    Builtin.bindMemory(rawPtr, count._builtinWordValue, Pointee.self)
+    return UnsafeMutablePointer(rawPtr)
   }
 
   /// Deallocate uninitialized memory allocated for `count` instances
@@ -169,7 +171,8 @@ public struct ${Self}<Pointee>
   /// Initialize `self.pointee` with `count` consecutive copies of `newValue`
   ///
   /// - Precondition: The pointee is not initialized.
-  ///             `count` is non-negative.
+  ///
+  /// - Precondition: `count` is non-negative.
   ///
   /// - Postcondition: The pointee is initialized; the value should eventually
   ///   be destroyed or moved from to avoid leaks.
@@ -262,8 +265,7 @@ public struct ${Self}<Pointee>
   }
 
   /// Initialize memory starting at `self` with `count` `Pointee`s
-  /// beginning at `source`, proceeding forward from `self` to `self +
-  /// count - 1`.
+  /// beginning at `source`.
   ///
   /// - Precondition: `count >= 0`
   ///
@@ -336,17 +338,39 @@ public struct ${Self}<Pointee>
   /// De-initialize the `count` `Pointee`s starting at `self`, returning
   /// their memory to an uninitialized state.
   ///
+  /// Returns an UnsafeMutableRawPointer to this memory.
+  ///
   /// - Precondition: The `Pointee`s at `self..<self + count` are
   ///   initialized.
   ///
   /// - Postcondition: The memory is uninitialized.
-  public func deinitialize(count: Int = 1) {
+  @discardableResult
+  public func deinitialize(count: Int = 1) -> UnsafeMutableRawPointer {
     _debugPrecondition(count >= 0, "${Self}.deinitialize with negative count")
     // FIXME: optimization should be implemented, where if the `count` value
     // is 1, the `Builtin.destroy(Pointee.self, _rawValue)` gets called.
     Builtin.destroyArray(Pointee.self, _rawValue, count._builtinWordValue)
+    return UnsafeMutableRawPointer(self)
   }
 %  end
+
+  /// Rebind memory at `self` to type `T` with capacity to hold `count` adjacent
+  /// `T` values while executing the `body` closure. After executing the
+  /// closure, rebind memory back to `Pointee`.
+  ///
+  /// - Precondition: Type 'T' is layout compatible with type 'Pointee'.
+  ///
+  /// - Precondition: The memory `self..<self + count * strideof(T.self)`
+  ///   is bound to `Pointee`.
+  public func withMemoryRebound<T, Result>(to: T.Type, capacity count: Int,
+    _ body: @noescape (UnsafeMutablePointer<T>) throws -> Result) rethrows
+  -> Result {
+    Builtin.bindMemory(_rawValue, count._builtinWordValue, T.self)
+    defer {
+      Builtin.bindMemory(_rawValue, count._builtinWordValue, Pointee.self)
+    }
+    return try body(UnsafeMutablePointer<T>(_rawValue))
+  }
 
   /// Access the pointee at `self + i`.
   ///

--- a/stdlib/public/core/UnsafeRawPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawPointer.swift.gyb
@@ -27,7 +27,7 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
   /// Implements conformance to the public protocol `_Pointer`.
   public let _rawValue: Builtin.RawPointer
 
-  /// Convert a builtin raw pointer to a Unsafe${Mutable}RawPointer.
+  /// Convert a builtin raw pointer to ${a_Self}.
   @_transparent
   public init(_ _rawValue: Builtin.RawPointer) {
     self._rawValue = _rawValue
@@ -48,21 +48,21 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
     _rawValue = unwrapped._rawValue
   }
 
-  /// Construct ${a_Self} with a given pattern of bits.
+  /// Convert a pattern of bits to ${a_Self}.
   @_transparent
   public init?(bitPattern: Int) {
     if bitPattern == 0 { return nil }
     _rawValue = Builtin.inttoptr_Word(bitPattern._builtinWordValue)
   }
 
-  /// Construct ${a_Self} with a given pattern of bits.
+  /// Convert a pattern of bits to ${a_Self}.
   @_transparent
   public init?(bitPattern: UInt) {
     if bitPattern == 0 { return nil }
     _rawValue = Builtin.inttoptr_Word(bitPattern._builtinWordValue)
   }
 
-  /// Convert an Unsafe${Mutable}Pointer ${a_Self}.
+  /// Convert an Unsafe${Mutable}Pointer to ${a_Self}.
   @_transparent
   public init<T>(_ other: Unsafe${Mutable}Pointer<T>) {
     _rawValue = other._rawValue
@@ -138,7 +138,7 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
   /// - Precondition: The memory is uninitialized.
   ///
   /// - Postcondition: The memory is bound to 'T' starting at `self` continuing
-  ///   through `self` + `capacity` * `strideof(T.self)`
+  ///   through `self` + `count` * `strideof(T.self)`
   ///
   /// - Warning: Binding memory to a type is potentially undefined if the
   ///   memory is ever accessed as an unrelated type.
@@ -336,6 +336,10 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
   /// - Precondition: The memory is initialized to a value of some type, `U`,
   ///   such that `T` is layout compatible with `U`.
   public func load<T>(fromByteOffset offset: Int = 0, as type: T.Type) -> T {
+    _debugPrecondition(0 == (UInt(bitPattern: self + offset)
+        & (UInt(alignof(T.self)) - 1)),
+      "load from misaligned raw pointer")
+
     return Builtin.load((self + offset)._rawValue)
   }
 
@@ -373,9 +377,14 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
   public func storeBytes<T>(
     of value: T, toByteOffset offset: Int = 0, as: T.Type
   ) {
+    _debugPrecondition(0 == (UInt(bitPattern: self + offset)
+        & (UInt(alignof(T.self)) - 1)),
+      "storeBytes to misaligned raw pointer")
+
     var temp = value
     withUnsafeMutablePointer(&temp) { source in
       let rawSrc = UnsafeMutableRawPointer(source)._rawValue
+      // FIXME: to be replaced by _memcpy when conversions are implemented.
       Builtin.int_memcpy_RawPointer_RawPointer_Int64(
         (self + offset)._rawValue, rawSrc, UInt64(sizeof(T.self))._value,
         /*alignment:*/ Int32(0)._value,
@@ -385,6 +394,8 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
   
   /// Copy `count` bytes from `source` into memory at `self`.
   ///  
+  /// - Precondition: `count` is non-negative.
+  ///
   /// - Precondition: The memory at `source..<source + count` is
   ///   initialized to some trivial type `T`.
   ///
@@ -399,27 +410,8 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
   public func copyBytes(from source: UnsafeRawPointer, count: Int) {
     _debugPrecondition(
       count >= 0, "UnsafeMutableRawPointer.copyBytes with negative count")
-    if UnsafeRawPointer(self) < source
-       || (source + count) <= UnsafeRawPointer(self) {
-      // copy forward from a disjoint or following overlapping range.
-      Builtin.int_memcpy_RawPointer_RawPointer_Int64(
-        _rawValue, source._rawValue, UInt64(count)._value,
-        /*alignment:*/ Int32(0)._value,
-        /*volatile:*/ false._value)
-    }
-    else {
-      // copy backward from a non-following overlapping range.
-      var destPtr = self + (count - 1)
-      var srcPtr = source + (count - 1)
-      while destPtr >= self {
-        Builtin.int_memcpy_RawPointer_RawPointer_Int64(
-          destPtr._rawValue, srcPtr._rawValue, Int64(1)._value,
-          /*alignment:*/ Int32(0)._value,
-          /*volatile:*/ false._value)
-        destPtr -= 1
-        srcPtr -= 1
-      }
-    }
+
+    _memmove(dest: self, src: source, size: UInt(count))
   }
 %  end # mutable
 
@@ -435,7 +427,7 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
   ///   different invocations of the same program.  Do not persist the
   ///   hash value across program runs.
   public var hashValue: Int {
-    return Int(Builtin.ptrtoint_Word(_rawValue))
+    return Int(bitPattern: self)
   }
 
   /// Return `end - self`.

--- a/stdlib/public/core/UnsafeRawPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawPointer.swift.gyb
@@ -1,0 +1,557 @@
+//===--- UnsafeRawPointer.swift.gyb --------------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+%import gyb
+
+% for mutable in (True, False):
+%  Self = 'UnsafeMutableRawPointer' if mutable else 'UnsafeRawPointer'
+%  a_Self = 'an `UnsafeMutableRawPointer`' if mutable else 'an `UnsafeRawPointer`'
+%  Mutable = 'Mutable' if mutable else ''
+
+/// A raw pointer for accessing untyped data. This provides no
+/// automatic memory management, no type safety, and no alignment
+/// guarantees. This implements Strideable to provide a view
+/// of byte-addressable memory.
+@_fixed_layout
+public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
+  /// The underlying raw pointer.
+  /// Implements conformance to the public protocol `_Pointer`.
+  public let _rawValue: Builtin.RawPointer
+
+  /// Convert a builtin raw pointer to a Unsafe${Mutable}RawPointer.
+  @_transparent
+  public init(_ _rawValue: Builtin.RawPointer) {
+    self._rawValue = _rawValue
+  }
+
+  /// Convert an opaque pointer to ${a_Self}.
+  @_transparent
+  public init(_ other: OpaquePointer) {
+    _rawValue = other._rawValue
+  }
+
+  /// Convert an opaque pointer to ${a_Self}.
+  ///
+  /// Returns nil if `from` is nil.
+  @_transparent
+  public init?(_ other: OpaquePointer?) {
+    guard let unwrapped = other else { return nil }
+    _rawValue = unwrapped._rawValue
+  }
+
+  /// Construct ${a_Self} with a given pattern of bits.
+  @_transparent
+  public init?(bitPattern: Int) {
+    if bitPattern == 0 { return nil }
+    _rawValue = Builtin.inttoptr_Word(bitPattern._builtinWordValue)
+  }
+
+  /// Construct ${a_Self} with a given pattern of bits.
+  @_transparent
+  public init?(bitPattern: UInt) {
+    if bitPattern == 0 { return nil }
+    _rawValue = Builtin.inttoptr_Word(bitPattern._builtinWordValue)
+  }
+
+  /// Convert an Unsafe${Mutable}Pointer ${a_Self}.
+  @_transparent
+  public init<T>(_ other: Unsafe${Mutable}Pointer<T>) {
+    _rawValue = other._rawValue
+  }
+
+  /// Convert an Unsafe${Mutable}Pointer ${a_Self}.
+  ///
+  /// Returns nil if `other` is nil.
+  @_transparent
+  public init?<T>(_ other: Unsafe${Mutable}Pointer<T>?) {
+    guard let unwrapped = other else { return nil }
+    _rawValue = unwrapped._rawValue
+  }
+
+%  if not mutable:
+  /// Convert an UnsafeMutableRawPointer ${a_Self}.
+  @_transparent
+  public init(_ other: UnsafeMutableRawPointer) {
+    _rawValue = other._rawValue
+  }
+
+  /// Convert an UnsafeMutableRawPointer ${a_Self}.
+  ///
+  /// Returns nil if `other` is nil.
+  @_transparent
+  public init?(_ other: UnsafeMutableRawPointer?) {
+    guard let unwrapped = other else { return nil }
+    _rawValue = unwrapped._rawValue
+  }
+
+  /// Convert an UnsafeMutablePointer ${a_Self}.
+  @_transparent
+  public init<T>(_ other: UnsafeMutablePointer<T>) {
+    _rawValue = other._rawValue
+  }
+
+  /// Convert an UnsafeMutablePointer ${a_Self}.
+  ///
+  /// Returns nil if `other` is nil.
+  @_transparent
+  public init?<T>(_ other: UnsafeMutablePointer<T>?) {
+    guard let unwrapped = other else { return nil }
+    _rawValue = unwrapped._rawValue
+  }
+%  end # !mutable
+
+%  if mutable:
+  /// Allocate and point at uninitialized memory for `size` bytes with
+  /// `alignedTo` alignment.
+  ///
+  /// - Postcondition: The memory is allocated, but not initialized.
+  public static func allocate(bytes size: Int, alignedTo: Int)
+  -> UnsafeMutableRawPointer {
+    return UnsafeMutableRawPointer(Builtin.allocRaw(
+        size._builtinWordValue, alignedTo._builtinWordValue))
+  }
+%  end # mutable
+
+  /// Deallocate uninitialized memory allocated for `bytes` number of bytes with
+  /// `alignedTo` alignment.
+  ///
+  /// - Precondition: The memory is not initialized.
+  ///
+  /// - Postcondition: The memory has been deallocated.
+  public func deallocate(bytes: Int, alignedTo: Int) {
+    Builtin.deallocRaw(
+      _rawValue, bytes._builtinWordValue, alignedTo._builtinWordValue)
+  }
+  
+  /// Binding the allocated memory to type `T`.
+  /// Returns an Unsafe${Mutable}Pointer<T> to the bound memory at `self`.
+  ///  
+  /// - Precondition: The memory is uninitialized.
+  ///
+  /// - Postcondition: The memory is bound to 'T' starting at `self` continuing
+  ///   through `self` + `capacity` * `strideof(T.self)`
+  ///
+  /// - Warning: Binding memory to a type is potentially undefined if the
+  ///   memory is ever accessed as an unrelated type.
+  @_transparent
+  public func bindMemory<T>(to type: T.Type, capacity count: Int)
+  -> Unsafe${Mutable}Pointer<T> {
+    Builtin.bindMemory(_rawValue, count._builtinWordValue, type)
+    return Unsafe${Mutable}Pointer<T>(_rawValue)
+  }
+
+  /// Convert from ${a_Self} to Unsafe${Mutable}Pointer<T> given that
+  /// the region of memory starting at `self` is already bound to type `T`.
+  ///
+  /// - Precondition: The memory is bound to 'T' starting at `self` for some
+  ///   unspecified capacity.
+  ///
+  /// - Warning: Accessing memory via the returned pointer is undefined if the
+  ///   if the memory has not been bound to `T`.
+  @_transparent
+  public func assumingMemoryBound<T>(to: T.Type) -> Unsafe${Mutable}Pointer<T> {
+    return Unsafe${Mutable}Pointer<T>(_rawValue)
+  }
+
+%  if mutable:
+  /// Initialize this memory location `self + strideof(T) * index`
+  /// with `count` consecutive copies `value`, and bind the
+  /// initialized memory to type `T`.
+  ///
+  /// Returns an `UnsafeMutablePointer<T>` to this memory.
+  ///
+  /// - Precondition: The memory at
+  ///  `self + index * strideof(T)..<self + (index + count) * strideof(T)`
+  ///  is uninitialized.
+  ///
+  /// - Precondition: The underlying pointer is properly aligned for
+  ///                 accessing `T`.
+  ///
+  /// - Precondition: `index` is non-negative.
+  ///
+  /// - Precondition: `count` is non-negative.
+  ///
+  /// - Postcondition: The memory at
+  ///  `(self + strideof(T) * index)..<(self + strideof(T) * index) + count`
+  ///  is bound to type `T` and initialized; the value should eventually be
+  ///  destroyed or moved from to avoid leaks.
+  @discardableResult
+  public func initializeMemory<T>(as type: T.Type, at index: Int = 0,
+    count: Int = 1, to value: T
+  ) -> UnsafeMutablePointer<T> {
+    _debugPrecondition(index >= 0,
+      "UnsafeMutableRawPointer.initializeMemory: negative index")
+    _debugPrecondition(count >= 0,
+      "UnsafeMutableRawPointer.initializeMemory: negative count")
+
+    Builtin.bindMemory(_rawValue, count._builtinWordValue, type)
+    var nextPtr = self + index * strideof(T.self)
+    for _ in 0..<count {
+      Builtin.initialize(value, nextPtr._rawValue)
+      nextPtr += strideof(T.self)
+    }
+    return UnsafeMutablePointer(_rawValue)
+  }
+
+  /// Initialize memory starting at `self` with `count` `T` values
+  /// beginning at `source`, and bind the initialized memory to type
+  /// `T`.
+  ///
+  /// Returns an `UnsafeMutablePointer<T>` this memory.
+  ///
+  /// - Precondition: `count >= 0`
+  ///
+  /// - Precondition: The memory regions `source..<source + count` and
+  ///   `self..<self + count * strideof(T.self)` do not overlap.
+  ///
+  /// - Precondition: The memory at `self..<self + count * strideof(T.self)`
+  ///   is uninitialized, and the `T` values at `source..<source + count` are
+  ///   initialized.
+  ///
+  /// - Precondition: The underlying pointer is properly aligned for
+  ///                 accessing `T`.
+  ///
+  /// - Postcondition: The memory at `self..<self + count * strideof(T.self)`
+  ///   is bound to type `T`.
+  ///
+  /// - Postcondition: The `T` values at `self..<self + count *
+  ///   strideof(T.self)` and `source..<source + count` are initialized.
+  @discardableResult
+  public func initializeMemory<T>(
+    as type: T.Type, from source: UnsafePointer<T>, count: Int
+  ) -> UnsafeMutablePointer<T> {
+    _debugPrecondition(
+      count >= 0,
+      "UnsafeMutableRawPointer.initializeMemory with negative count")
+    _debugPrecondition(
+      (UnsafeRawPointer(self + count * strideof(T.self))
+        <= UnsafeRawPointer(source))
+      || UnsafeRawPointer(source + count) <= UnsafeRawPointer(self),
+      "UnsafeMutableRawPointer.initializeMemory overlapping range")
+
+    Builtin.bindMemory(_rawValue, count._builtinWordValue, type)
+    Builtin.copyArray(
+      T.self, self._rawValue, source._rawValue, count._builtinWordValue)
+    // This builtin is equivalent to:
+    // for i in 0..<count {
+    //   (self.assumingMemoryBound(to: T.self) + i).initialize(to: source[i])
+    // }
+    return UnsafeMutablePointer(_rawValue)
+  }
+
+  /// Initialize memory starting at `self` with the elements of
+  /// `source`, and bind the initialized memory to type `T`.
+  ///
+  /// Returns an `UnsafeMutablePointer<T>` this memory.
+  ///
+  /// - Precondition: The memory at `self..<self + source.count *
+  ///   strideof(T.self)` is uninitialized.
+  ///
+  /// - Postcondition: The memory at `self..<self + source.count *
+  ///   strideof(T.self)` is bound to type `T`.
+  ///
+  /// - Postcondition: The `T` values at `self..<self + source.count *
+  ///   strideof(T.self)` are initialized.
+  ///
+  /// TODO: Optimize where `C` is a `ContiguousArrayBuffer`.
+  @discardableResult
+  public func initializeMemory<C : Collection>(
+    as: C.Iterator.Element.Type, from source: C
+  ) -> UnsafeMutablePointer<C.Iterator.Element> {
+    // Initialize and bind each element of the container.
+    for (index, element) in source.enumerated() {
+      self.initializeMemory(as: C.Iterator.Element.self, at: index, to: element)
+    }
+    return UnsafeMutablePointer(_rawValue)
+  }
+
+  /// Initialize memory starting at `self` with `count` `T` values
+  /// beginning at `source`, bind the initialized memory to type `T`,
+  /// and return the source memory to an uninitialized state.
+  ///
+  /// Returns an `UnsafeMutablePointer<T>` this memory.
+  ///
+  /// - Precondition: `count >= 0`
+  ///
+  /// - Precondition: The memory at `self..<self + count *
+  ///   strideof(T.self)` is uninitialized and the `T` values at
+  ///   `source..<source + count` are initialized.
+  ///
+  /// - Postcondition: The memory at `self..<self + count *
+  ///   strideof(T.self)` is bound to type `T`.
+  ///
+  /// - Postcondition: The `T` values at `self..<self + count *
+  ///   strideof(T.self)` are initialized and the memory at
+  ///   `source..<source + count` is uninitialized.
+  @discardableResult
+  public func moveInitializeMemory<T>(
+    as type: T.Type, from source: UnsafeMutablePointer<T>, count: Int
+  ) -> UnsafeMutablePointer<T> {
+    _debugPrecondition(
+      count >= 0,
+      "UnsafeMutableRawPointer.moveInitializeMemory with negative count")
+
+    Builtin.bindMemory(_rawValue, count._builtinWordValue, type)
+    if self < UnsafeMutableRawPointer(source)
+       || self >= UnsafeMutableRawPointer(source + count) {
+      // initialize forward from a disjoint or following overlapping range.
+      Builtin.takeArrayFrontToBack(
+        T.self, self._rawValue, source._rawValue, count._builtinWordValue)
+      // This builtin is equivalent to:
+      // for i in 0..<count {
+      //   (self.assumingMemoryBound(to: T.self) + i)
+      //   .initialize(to: (source + i).move())
+      // }
+    }
+    else {
+      // initialize backward from a non-following overlapping range.
+      Builtin.takeArrayBackToFront(
+        T.self, self._rawValue, source._rawValue, count._builtinWordValue)
+      // This builtin is equivalent to:
+      // var src = source + count
+      // var dst = self.assumingMemoryBound(to: T.self) + count
+      // while dst != self {
+      //   (--dst).initialize(to: (--src).move())
+      // }
+    }
+    return UnsafeMutablePointer(_rawValue)
+  }
+%  end # mutable
+
+  /// Read raw bytes from memory at `self + offset` and construct a
+  /// value of type `T`.
+  ///
+  /// - Precondition: The underlying pointer plus `offset` is properly
+  ///   aligned for accessing `T`.
+  ///
+  /// - Precondition: The memory is initialized to a value of some type, `U`,
+  ///   such that `T` is layout compatible with `U`.
+  public func load<T>(fromByteOffset offset: Int = 0, as type: T.Type) -> T {
+    return Builtin.load((self + offset)._rawValue)
+  }
+
+%  if mutable:
+  /// Store a value's bytes into raw memory at `self + offset`.
+  ///  
+  /// - Precondition: The underlying pointer plus `offset` is properly
+  ///   aligned for storing type `T`.
+  ///
+  /// - Precondition: `T` is a trivial type.
+  ///
+  /// - Precondition: The memory is uninitialized, or initialized to
+  ///   some trivial type `U` such that `T` and `U` are mutually layout
+  ///   compatible.
+  /// 
+  /// - Postcondition: The memory is initialized to raw bytes. If the
+  ///   memory is bound to type `U`, then it now contains a value of
+  ///   type `U`.
+  ///
+  /// - Note: A trivial type can be copied with just a bit-for-bit
+  ///   copy without any indirection or reference-counting operations.
+  ///   Generally, native Swift types that do not contain strong or
+  ///   weak references or other forms of indirection are trivial, as
+  ///   are imported C structs and enums.
+  ///
+  /// - Note: Storing a copy of a nontrivial value into memory
+  ///   requires that the user know the type of value previously in
+  ///   memory, and requires initialization or assignment of the
+  ///   memory. This can be acheived via a typed `UnsafeMutablePointer`
+  ///   or via a raw pointer `self`, as follows, where `U` is the
+  ///   previous type and `T` is the copied value's type:
+  ///   `let typedPtr = self.bindMemory(to: U.self, capacity: 1)`
+  ///   `typedPtr.deinitialize(count: 1)`
+  ///   `self.initializeMemory(as: T.self, to: newValue)`
+  public func storeBytes<T>(
+    of value: T, toByteOffset offset: Int = 0, as: T.Type
+  ) {
+    var temp = value
+    withUnsafeMutablePointer(&temp) { source in
+      let rawSrc = UnsafeMutableRawPointer(source)._rawValue
+      Builtin.int_memcpy_RawPointer_RawPointer_Int64(
+        (self + offset)._rawValue, rawSrc, UInt64(sizeof(T.self))._value,
+        /*alignment:*/ Int32(0)._value,
+        /*volatile:*/ false._value)
+    }
+  }
+  
+  /// Copy `count` bytes from `source` into memory at `self`.
+  ///  
+  /// - Precondition: The memory at `source..<source + count` is
+  ///   initialized to some trivial type `T`.
+  ///
+  /// - Precondition: If the memory at `self..<self+count` is bound to
+  ///   a type `U`, then `U` is a trivial type, the underlying
+  ///   pointers `source` and `self` are properly aligned for type
+  ///   `U`, and `count` is a multiple of `strideof(U.self)`.
+  ///
+  /// - Postcondition: The memory at `self..<self+count` is
+  ///   initialized to raw bytes. If the memory is bound to type `U`,
+  ///   then it contains values of type `U`.
+  public func copyBytes(from source: UnsafeRawPointer, count: Int) {
+    _debugPrecondition(
+      count >= 0, "UnsafeMutableRawPointer.copyBytes with negative count")
+    if UnsafeRawPointer(self) < source
+       || (source + count) <= UnsafeRawPointer(self) {
+      // copy forward from a disjoint or following overlapping range.
+      Builtin.int_memcpy_RawPointer_RawPointer_Int64(
+        _rawValue, source._rawValue, UInt64(count)._value,
+        /*alignment:*/ Int32(0)._value,
+        /*volatile:*/ false._value)
+    }
+    else {
+      // copy backward from a non-following overlapping range.
+      var destPtr = self + (count - 1)
+      var srcPtr = source + (count - 1)
+      while destPtr >= self {
+        Builtin.int_memcpy_RawPointer_RawPointer_Int64(
+          destPtr._rawValue, srcPtr._rawValue, Int64(1)._value,
+          /*alignment:*/ Int32(0)._value,
+          /*volatile:*/ false._value)
+        destPtr -= 1
+        srcPtr -= 1
+      }
+    }
+  }
+%  end # mutable
+
+  //
+  // Protocol conformance
+  //
+
+  /// The hash value.
+  ///
+  /// **Axiom:** `x == y` implies `x.hashValue == y.hashValue`.
+  ///
+  /// - Note: The hash value is not guaranteed to be stable across
+  ///   different invocations of the same program.  Do not persist the
+  ///   hash value across program runs.
+  public var hashValue: Int {
+    return Int(Builtin.ptrtoint_Word(_rawValue))
+  }
+
+  /// Return `end - self`.
+  public func distance(to x: ${Self}) -> Int {
+    return x - self
+  }
+
+  /// Return `self + n`.
+  public func advanced(by n: Int) -> ${Self} {
+    return self + n
+  }
+}
+
+@_transparent
+public func == (lhs: ${Self}, rhs: ${Self}) -> Bool {
+  return Bool(Builtin.cmp_eq_RawPointer(lhs._rawValue, rhs._rawValue))
+}
+
+@_transparent
+public func < (lhs: ${Self}, rhs: ${Self}) -> Bool {
+  return Bool(Builtin.cmp_ult_RawPointer(lhs._rawValue, rhs._rawValue))
+}
+
+@_transparent
+public func + (lhs: ${Self}, rhs: Int) -> ${Self} {
+  return ${Self}(Builtin.gep_Word(
+      lhs._rawValue, rhs._builtinWordValue))
+}
+
+@_transparent
+public func + (lhs: Int, rhs: ${Self}) -> ${Self} {
+  return rhs + lhs
+}
+
+@_transparent
+public func - (lhs: ${Self}, rhs: Int) -> ${Self} {
+  return lhs + -rhs
+}
+
+@_transparent
+public func - (lhs: ${Self}, rhs: ${Self}) -> Int {
+  return
+    Int(Builtin.sub_Word(Builtin.ptrtoint_Word(lhs._rawValue),
+                         Builtin.ptrtoint_Word(rhs._rawValue)))
+}
+
+@_transparent
+public func += (lhs: inout ${Self}, rhs: Int) {
+  lhs = lhs + rhs
+}
+
+@_transparent
+public func -= (lhs: inout ${Self}, rhs: Int) {
+  lhs = lhs - rhs
+}
+
+extension Unsafe${Mutable}RawPointer : CustomDebugStringConvertible {
+  /// A textual representation of `self`, suitable for debugging.
+  public var debugDescription: String {
+    return _rawPointerToString(_rawValue)
+  }
+}
+
+extension Unsafe${Mutable}RawPointer : CustomReflectable {
+  public var customMirror: Mirror {
+    let ptrValue = UInt64(
+      bitPattern: Int64(Int(Builtin.ptrtoint_Word(_rawValue))))
+    return Mirror(self, children: ["pointerValue": ptrValue])
+  }
+}
+
+extension Unsafe${Mutable}RawPointer : CustomPlaygroundQuickLookable {
+  var summary: String {
+    let selfType = "${Self}"
+    let ptrValue = UInt64(
+      bitPattern: Int64(Int(Builtin.ptrtoint_Word(_rawValue))))
+    return ptrValue == 0
+    ? "\(selfType)(nil)"
+    : "\(selfType)(0x\(_uint64ToString(ptrValue, radix:16, uppercase:true)))"
+  }
+
+  public var customPlaygroundQuickLook: PlaygroundQuickLook {
+    return .text(summary)
+  }
+}
+
+extension OpaquePointer {
+  public init(_ from: Unsafe${Mutable}RawPointer) {
+    self._rawValue = from._rawValue
+  }
+
+  public init?(_ from: Unsafe${Mutable}RawPointer?) {
+    guard let unwrapped = from else { return nil }
+    self._rawValue = unwrapped._rawValue
+  }
+}
+
+extension Int {
+  public init(bitPattern: Unsafe${Mutable}RawPointer?) {
+    if let bitPattern = bitPattern {
+      self = Int(Builtin.ptrtoint_Word(bitPattern._rawValue))
+    } else {
+      self = 0
+    }
+  }
+}
+
+extension UInt {
+  public init(bitPattern: Unsafe${Mutable}RawPointer?) {
+    if let bitPattern = bitPattern {
+      self = UInt(Builtin.ptrtoint_Word(bitPattern._rawValue))
+    } else {
+      self = 0
+    }
+  }
+}
+
+% end # for mutable
+

--- a/test/1_stdlib/UnsafePointer.swift.gyb
+++ b/test/1_stdlib/UnsafePointer.swift.gyb
@@ -48,61 +48,43 @@ extension UnsafeMutableBufferPointer where Element : TestProtocol1 {
 
 var UnsafePointerTestSuite = TestSuite("UnsafePointer")
 var UnsafeMutablePointerTestSuite = TestSuite("UnsafeMutablePointer")
+var UnsafeRawPointerTestSuite = TestSuite("UnsafeRawPointer")
+var UnsafeMutableRawPointerTestSuite = TestSuite("UnsafeMutableRawPointer")
 var OpaquePointerTestSuite = TestSuite("OpaquePointer")
 
 % for (SelfName, SelfType) in [
 %         ('UnsafePointer', 'UnsafePointer<Float>'),
 %         ('UnsafeMutablePointer', 'UnsafeMutablePointer<Float>'),
+%         ('UnsafeRawPointer', 'UnsafeRawPointer'),
+%         ('UnsafeMutableRawPointer', 'UnsafeMutableRawPointer')]:
+
+${SelfName}TestSuite.test("initFromOpaquePointer") {
+  let other = OpaquePointer(bitPattern: 0x12345678)!
+  let ptr = ${SelfType}(other)
+  expectEqual(0x12345678, unsafeBitCast(ptr, to: Int.self))
+
+  let optionalOther: Optional = other
+  let optionalPointer = ${SelfType}(optionalOther)
+  expectNotEmpty(optionalPointer)
+  expectEqual(0x12345678, unsafeBitCast(optionalPointer, to: Int.self))
+
+  let nilOther: Optional<OpaquePointer> = nil
+  let nilPointer = ${SelfType}(nilOther)
+  expectEmpty(nilPointer)
+}
+
+% end
+
+% for (SelfName, SelfType) in [
+%         ('UnsafePointer', 'UnsafePointer<Float>'),
+%         ('UnsafeMutablePointer', 'UnsafeMutablePointer<Float>'),
+%         ('UnsafeRawPointer', 'UnsafeRawPointer'),
+%         ('UnsafeMutableRawPointer', 'UnsafeMutableRawPointer'),
 %         ('OpaquePointer', 'OpaquePointer')]:
 
 ${SelfName}TestSuite.test("convertFromNil") {
   let ptr: ${SelfType}? = nil
   expectEqual(0, unsafeBitCast(ptr, to: Int.self))
-}
-
-${SelfName}TestSuite.test("initFromOpaquePointer") {
-  let other = OpaquePointer(bitPattern: 0x12345678)!
-  let ptr = UnsafePointer<Float>(other)
-  expectEqual(0x12345678, unsafeBitCast(ptr, to: Int.self))
-
-  let optionalOther: Optional = other
-  let optionalPointer = UnsafePointer<Float>(optionalOther)
-  expectNotEmpty(optionalPointer)
-  expectEqual(0x12345678, unsafeBitCast(optionalPointer, to: Int.self))
-
-  let nilOther: Optional<OpaquePointer> = nil
-  let nilPointer = UnsafePointer<Float>(nilOther)
-  expectEmpty(nilPointer)
-}
-
-${SelfName}TestSuite.test("initFromUnsafePointer") {
-  let other = UnsafePointer<Double>(bitPattern: 0x12345678)!
-  let ptr = ${SelfType}(other)
-  expectEqual(0x12345678, unsafeBitCast(ptr, to: Int.self))
-
-  let optionalOther: Optional = other
-  let optionalPointer = ${SelfType}(optionalOther)
-  expectNotEmpty(optionalPointer)
-  expectEqual(0x12345678, unsafeBitCast(optionalPointer, to: Int.self))
-
-  let nilOther: Optional<UnsafePointer<Double>> = nil
-  let nilPointer = ${SelfType}(nilOther)
-  expectEmpty(nilPointer)
-}
-
-${SelfName}TestSuite.test("initFromUnsafeMutablePointer") {
-  let other = UnsafeMutablePointer<Double>(bitPattern: 0x12345678)!
-  let ptr = ${SelfType}(other)
-  expectEqual(0x12345678, unsafeBitCast(ptr, to: Int.self))
-
-  let optionalOther: Optional = other
-  let optionalPointer = ${SelfType}(optionalOther)
-  expectNotEmpty(optionalPointer)
-  expectEqual(0x12345678, unsafeBitCast(optionalPointer, to: Int.self))
-
-  let nilOther: Optional<UnsafeMutablePointer<Double>> = nil
-  let nilPointer = ${SelfType}(nilOther)
-  expectEmpty(nilPointer)
 }
 
 ${SelfName}TestSuite.test("initFromInteger") {
@@ -171,6 +153,64 @@ ${SelfName}TestSuite.test("toInteger") {
 }
 
 % end
+
+% for (SelfName, SelfType) in [
+%         ('UnsafePointer', 'UnsafePointer<Float>'),
+%         ('UnsafeRawPointer', 'UnsafeRawPointer'),
+%         ('UnsafeMutableRawPointer', 'UnsafeMutableRawPointer')]:
+
+${SelfName}TestSuite.test("initFromUnsafeMutablePointer") {
+  let other = UnsafeMutablePointer<Float>(bitPattern: 0x12345678)!
+  let ptr = ${SelfType}(other)
+  expectEqual(0x12345678, unsafeBitCast(ptr, to: Int.self))
+
+  let optionalOther: Optional = other
+  let optionalPointer = ${SelfType}(optionalOther)
+  expectNotEmpty(optionalPointer)
+  expectEqual(0x12345678, unsafeBitCast(optionalPointer, to: Int.self))
+
+  let nilOther: Optional<UnsafeMutablePointer<Float>> = nil
+  let nilPointer = ${SelfType}(nilOther)
+  expectEmpty(nilPointer)
+}
+
+% end
+
+% for (SelfName, SelfType) in [
+%         ('UnsafePointer', 'UnsafePointer<Float>'),
+%         ('UnsafeRawPointer', 'UnsafeRawPointer')]:
+
+${SelfName}TestSuite.test("initFromUnsafePointer") {
+  let other = UnsafePointer<Float>(bitPattern: 0x12345678)!
+  let ptr = ${SelfType}(other)
+  expectEqual(0x12345678, unsafeBitCast(ptr, to: Int.self))
+
+  let optionalOther: Optional = other
+  let optionalPointer = ${SelfType}(optionalOther)
+  expectNotEmpty(optionalPointer)
+  expectEqual(0x12345678, unsafeBitCast(optionalPointer, to: Int.self))
+
+  let nilOther: Optional<UnsafePointer<Float>> = nil
+  let nilPointer = ${SelfType}(nilOther)
+  expectEmpty(nilPointer)
+}
+
+% end
+
+UnsafeRawPointerTestSuite.test("initFromUnsafeMutableRawPointer") {
+  let other = UnsafeMutableRawPointer(bitPattern: 0x12345678)!
+  let ptr = UnsafeRawPointer(other)
+  expectEqual(0x12345678, unsafeBitCast(ptr, to: Int.self))
+
+  let optionalOther: Optional = other
+  let optionalPointer = UnsafeRawPointer(optionalOther)
+  expectNotEmpty(optionalPointer)
+  expectEqual(0x12345678, unsafeBitCast(optionalPointer, to: Int.self))
+
+  let nilOther: Optional<UnsafeMutableRawPointer> = nil
+  let nilPointer = UnsafeRawPointer(nilOther)
+  expectEmpty(nilPointer)
+}
 
 enum Check {
   case LeftOverlap
@@ -334,11 +374,17 @@ UnsafeMutablePointerTestSuite.test("assign/immutable") {
   }
 }
 
-UnsafePointerTestSuite.test("customMirror") {
+% for (SelfName, SelfType) in [
+%         ('UnsafePointer', 'UnsafePointer<Float>'),
+%         ('UnsafeMutablePointer', 'UnsafeMutablePointer<Float>'),
+%         ('UnsafeRawPointer', 'UnsafeRawPointer'),
+%         ('UnsafeMutableRawPointer', 'UnsafeMutableRawPointer')]:
+
+${SelfName}TestSuite.test("customMirror") {
   // Ensure that the custom mirror works properly, including when the raw value
   // is greater than Int.max
   let reallyBigInt: UInt = UInt(Int.max) + 1
-  let ptr = UnsafePointer<Float>(bitPattern: reallyBigInt)!
+  let ptr = ${SelfType}(bitPattern: reallyBigInt)!
   let mirror = ptr.customMirror
   expectEqual(1, mirror.children.count)
 #if arch(i386) || arch(arm)
@@ -350,16 +396,16 @@ UnsafePointerTestSuite.test("customMirror") {
 #endif
 }
 
-UnsafePointerTestSuite.test("customPlaygroundQuickLook") {
+${SelfName}TestSuite.test("customPlaygroundQuickLook") {
   // Ensure that the custom playground quicklook works properly, including when
   // the raw value is greater than Int.max
   let reallyBigInt: UInt = UInt(Int.max) + 1
-  let ptr = UnsafePointer<Float>(bitPattern: reallyBigInt)!
+  let ptr = ${SelfType}(bitPattern: reallyBigInt)!
   if case let .text(desc) = ptr.customPlaygroundQuickLook {
 #if arch(i386) || arch(arm)
-    expectEqual("UnsafePointer(0xFFFFFFFF80000000)", desc)
+    expectEqual("${SelfName}(0xFFFFFFFF80000000)", desc)
 #elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
-    expectEqual("UnsafePointer(0x8000000000000000)", desc)
+    expectEqual("${SelfName}(0x8000000000000000)", desc)
 #else
     fatalError("Unimplemented")
 #endif
@@ -367,41 +413,6 @@ UnsafePointerTestSuite.test("customPlaygroundQuickLook") {
     expectTrue(false)
   }
 }
-
-UnsafeMutablePointerTestSuite.test("customMirror") {
-  let reallyBigInt: UInt = UInt(Int.max) + 1
-  let ptr = UnsafeMutablePointer<Float>(bitPattern: reallyBigInt)!
-  let mirror = ptr.customMirror
-  expectEqual(1, mirror.children.count)
-#if arch(i386) || arch(arm)
-  expectEqual("18446744071562067968", String(mirror.children.first!.1))
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
-  expectEqual("9223372036854775808", String(mirror.children.first!.1))
-#else
-  fatalError("Unimplemented")
-#endif
-}
-
-UnsafeMutablePointerTestSuite.test("customPlaygroundQuickLook") {
-  let reallyBigInt: UInt = UInt(Int.max) + 1
-  let ptr = UnsafeMutablePointer<Float>(bitPattern: reallyBigInt)!
-  let isProperDisposition : Bool
-  if case let .text(desc) = ptr.customPlaygroundQuickLook {
-#if arch(i386) || arch(arm)
-    expectEqual("UnsafeMutablePointer(0xFFFFFFFF80000000)", desc)
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
-    expectEqual("UnsafeMutablePointer(0x8000000000000000)", desc)
-#else
-    fatalError("Unimplemented")
-#endif
-  } else {
-    expectTrue(false)
-  }
-}
-
-% for (SelfName, SelfType) in [
-%         ('UnsafePointer', 'UnsafePointer<Int>'),
-%         ('UnsafeMutablePointer', 'UnsafeMutablePointer<Int>')]:
 
 ${SelfName}TestSuite.test("Comparable") {
   var addresses: [UInt] = [
@@ -426,6 +437,19 @@ ${SelfName}TestSuite.test("Comparable") {
     return instances[i].0 <=> instances[j].0
   }
   checkComparable(instances.map { $0.1 }, oracle: comparisonOracle)
+}
+
+% end
+
+% for SelfName in ['UnsafePointer', 'UnsafeMutablePointer']:
+
+${SelfName}TestSuite.test("withMemoryRebound") {
+  let mutablePtr = UnsafeMutablePointer<Int>.allocate(capacity: 4)
+  let ptrI = ${SelfName}<Int>(mutablePtr)
+  ptrI.withMemoryRebound(to: UInt.self, capacity: 4) {
+    expectType(UInt.self, &$0.pointee)
+  }
+  mutablePtr.deallocate(capacity: 4)
 }
 
 % end

--- a/test/1_stdlib/UnsafeRawPointer.swift
+++ b/test/1_stdlib/UnsafeRawPointer.swift
@@ -199,7 +199,7 @@ func checkPtr(
   }
 }
 
-UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory:as:from:count") {
+UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory:as:from:count:") {
   let check = checkPtr(UnsafeMutableRawPointer.initializeMemory(as:from:count:))
   check(Check.Disjoint)
   // This check relies on _debugPrecondition() so will only trigger in
@@ -210,7 +210,7 @@ UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory:as:from:count") {
   }
 }
 
-UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory:as:from:count.Right") {
+UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory:as:from:count:.Right") {
   let check = checkPtr(UnsafeMutableRawPointer.initializeMemory(as:from:count:))
   // This check relies on _debugPrecondition() so will only trigger in
   // -Onone mode.
@@ -220,7 +220,7 @@ UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory:as:from:count.Right
   }
 }
 
-UnsafeMutableRawPointerExtraTestSuite.test("moveInitialize:from") {
+UnsafeMutableRawPointerExtraTestSuite.test("moveInitialize:from:") {
   let check =
     checkPtr(UnsafeMutableRawPointer.moveInitializeMemory(as:from:count:))
   check(Check.LeftOverlap)

--- a/test/1_stdlib/UnsafeRawPointer.swift
+++ b/test/1_stdlib/UnsafeRawPointer.swift
@@ -1,0 +1,231 @@
+// RUN: %target-run-simple-swiftgyb
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var UnsafeMutableRawPointerExtraTestSuite =
+  TestSuite("UnsafeMutableRawPointerExtra")
+
+class Missile {
+  static var missilesLaunched = 0
+  let number: Int
+  init(_ number: Int) { self.number = number }
+  deinit { Missile.missilesLaunched += 1 }
+}
+
+UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory") {
+  Missile.missilesLaunched = 0
+  do {
+    let sizeInBytes = 3 * strideof(Missile.self)
+    var p1 = UnsafeMutableRawPointer.allocate(
+      bytes: sizeInBytes, alignedTo: alignof(Missile.self))
+    defer {
+      p1.deallocate(bytes: sizeInBytes, alignedTo: alignof(Missile.self))
+    }
+    var ptrM = p1.initializeMemory(as: Missile.self, to: Missile(1))
+    p1.initializeMemory(as: Missile.self, at: 1, count: 2, to: Missile(2))
+    expectEqual(1, ptrM[0].number)
+    expectEqual(2, ptrM[1].number)
+    expectEqual(2, ptrM[2].number)
+
+    var p2 = UnsafeMutableRawPointer.allocate(
+      bytes: sizeInBytes, alignedTo: alignof(Missile.self))
+    defer {
+      p2.deallocate(bytes: sizeInBytes, alignedTo: alignof(Missile.self))
+    }
+    let ptrM2 = p2.moveInitializeMemory(as: Missile.self, from: ptrM, count: 3)
+    defer {
+      ptrM2.deinitialize(count: 3)
+    }
+    // p1 is now deinitialized.
+    expectEqual(1, ptrM2[0].number)
+    expectEqual(2, ptrM2[1].number)
+    expectEqual(2, ptrM2[2].number)
+
+    ptrM = p1.initializeMemory(
+      as: Missile.self, from: (1...3).map(Missile.init))
+    defer {
+      ptrM.deinitialize(count: 3)
+    }
+    expectEqual(1, ptrM[0].number)
+    expectEqual(2, ptrM[1].number)
+    expectEqual(3, ptrM[2].number)
+  }
+  expectEqual(5, Missile.missilesLaunched)
+}
+
+UnsafeMutableRawPointerExtraTestSuite.test("bindMemory") {
+  let sizeInBytes = 3 * strideof(Int.self)
+  var p1 = UnsafeMutableRawPointer.allocate(
+    bytes: sizeInBytes, alignedTo: alignof(Int.self))
+  defer {
+    p1.deallocate(bytes: sizeInBytes, alignedTo: alignof(Int.self))
+  }
+  let ptrI = p1.bindMemory(to: Int.self, capacity: 3)
+  ptrI.initialize(from: 1...3)
+  let ptrU = p1.bindMemory(to: UInt.self, capacity: 3)
+  expectEqual(1, ptrU[0])
+  expectEqual(2, ptrU[1])
+  expectEqual(3, ptrU[2])
+  let ptrU2 = p1.assumingMemoryBound(to: UInt.self)
+  expectEqual(1, ptrU[0])
+}
+
+UnsafeMutableRawPointerExtraTestSuite.test("load/store") {
+  let sizeInBytes = 3 * strideof(Int.self)
+  var p1 = UnsafeMutableRawPointer.allocate(
+    bytes: sizeInBytes, alignedTo: alignof(Int.self))
+  defer {
+    p1.deallocate(bytes: sizeInBytes, alignedTo: alignof(Int.self))
+  }
+  let ptrI = p1.initializeMemory(as: Int.self, from: 1...3)
+  defer {
+    ptrI.deinitialize(count: 3)
+  }
+  expectEqual(1, p1.load(as: Int.self))
+  expectEqual(2, p1.load(fromByteOffset: strideof(Int.self), as: Int.self))
+  expectEqual(3, p1.load(fromByteOffset: 2*strideof(Int.self), as: Int.self))
+  p1.storeBytes(of: 4, as: Int.self)
+  p1.storeBytes(of: 5, toByteOffset: strideof(Int.self), as: Int.self)
+  p1.storeBytes(of: 6, toByteOffset: 2 * strideof(Int.self), as: Int.self)
+  expectEqual(4, p1.load(as: Int.self))
+  expectEqual(5, p1.load(fromByteOffset: strideof(Int.self), as: Int.self))
+  expectEqual(6, p1.load(fromByteOffset: 2 * strideof(Int.self), as: Int.self))
+}
+
+UnsafeMutableRawPointerExtraTestSuite.test("copyBytes") {
+  let sizeInBytes = 4 * strideof(Int.self)
+  var rawPtr = UnsafeMutableRawPointer.allocate(
+    bytes: sizeInBytes, alignedTo: alignof(Int.self))
+  defer {
+    rawPtr.deallocate(bytes: sizeInBytes, alignedTo: alignof(Int.self))
+  }
+  let ptrI = rawPtr.initializeMemory(as: Int.self, count: 4, to: 42)
+  defer {
+    ptrI.deinitialize(count: 4)
+  }
+  let roPtr = UnsafeRawPointer(rawPtr)
+  // Right overlap
+  ptrI[0] = 1
+  ptrI[1] = 2
+  (rawPtr + strideof(Int.self)).copyBytes(
+    from: roPtr, count: 2 * strideof(Int.self))
+  expectEqual(1, ptrI[1])
+  expectEqual(2, ptrI[2])
+
+  // Left overlap
+  ptrI[1] = 2
+  ptrI[2] = 3
+  rawPtr.copyBytes(
+    from: roPtr + strideof(Int.self), count: 2 * strideof(Int.self))
+  expectEqual(2, ptrI[0])
+  expectEqual(3, ptrI[1])
+
+  // Disjoint:
+  ptrI[2] = 2
+  ptrI[3] = 3
+  rawPtr.copyBytes(
+    from: roPtr + 2 * strideof(Int.self), count: 2 * strideof(Int.self))
+  expectEqual(2, ptrI[0])
+  expectEqual(3, ptrI[1])
+
+  // Backwards
+  ptrI[0] = 0
+  ptrI[1] = 1
+  (rawPtr + 2 * strideof(Int.self)).copyBytes(
+    from: roPtr, count: 2 * strideof(Int.self))
+  expectEqual(0, ptrI[2])
+  expectEqual(1, ptrI[3])
+}
+
+// --------------------------------------------
+// Test bulk initialization from UnsafePointer.
+
+enum Check {
+  case LeftOverlap
+  case RightOverlap
+  case Disjoint
+}
+
+func checkRawPointerCorrectness(_ check: Check,
+  _ f: (UnsafeMutableRawPointer) -> (as: Int.Type, from: UnsafeMutablePointer<Int>, count: Int) -> UnsafeMutablePointer<Int>) {
+  let ptr = UnsafeMutablePointer<Int>.allocate(capacity: 4)
+  switch check {
+  case .RightOverlap:
+    ptr.initialize(to: 1)
+    (ptr + 1).initialize(to: 2)
+    _ = f(UnsafeMutableRawPointer(ptr + 1))(as: Int.self, from: ptr, count: 2)
+    expectEqual(1, ptr[1])
+    expectEqual(2, ptr[2])
+  case .LeftOverlap:
+    (ptr + 1).initialize(to: 2)
+    (ptr + 2).initialize(to: 3)
+    _ = f(UnsafeMutableRawPointer(ptr))(as: Int.self, from: ptr + 1, count: 2)
+    expectEqual(2, ptr[0])
+    expectEqual(3, ptr[1])
+  case .Disjoint:
+    (ptr + 2).initialize(to: 2)
+    (ptr + 3).initialize(to: 3)
+    _ = f(UnsafeMutableRawPointer(ptr))(as: Int.self, from: ptr + 2, count: 2)
+    expectEqual(2, ptr[0])
+    expectEqual(3, ptr[1])
+    // backwards
+    let ptr2 = UnsafeMutablePointer<Int>.allocate(capacity: 4)
+    ptr2.initialize(to: 0)
+    (ptr2 + 1).initialize(to: 1)
+    _ = f(UnsafeMutableRawPointer(ptr2 + 2))(as: Int.self, from: ptr2, count: 2)
+    expectEqual(0, ptr2[2])
+    expectEqual(1, ptr2[3])
+  }
+}
+
+func checkPtr(
+  _ f: ((UnsafeMutableRawPointer)
+    -> (as: Int.Type, from: UnsafeMutablePointer<Int>, count: Int)
+    -> UnsafeMutablePointer<Int>)
+) -> (Check) -> Void {
+  return { checkRawPointerCorrectness($0, f) }
+}
+
+func checkPtr(
+  _ f: ((UnsafeMutableRawPointer)
+    -> (as: Int.Type, from: UnsafePointer<Int>, count: Int)
+    -> UnsafeMutablePointer<Int>)
+) -> (Check) -> Void {
+  return {
+    checkRawPointerCorrectness($0) { destPtr in 
+      return { f(destPtr)(as: $0, from: UnsafeMutablePointer($1), count: $2) }
+    }
+  }
+}
+
+UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory:as:from:count") {
+  let check = checkPtr(UnsafeMutableRawPointer.initializeMemory(as:from:count:))
+  check(Check.Disjoint)
+  // This check relies on _debugPrecondition() so will only trigger in
+  // -Onone mode.
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+    check(Check.LeftOverlap)
+  }
+}
+
+UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory:as:from:count.Right") {
+  let check = checkPtr(UnsafeMutableRawPointer.initializeMemory(as:from:count:))
+  // This check relies on _debugPrecondition() so will only trigger in
+  // -Onone mode.
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+    check(Check.RightOverlap)
+  }
+}
+
+UnsafeMutableRawPointerExtraTestSuite.test("moveInitialize:from") {
+  let check =
+    checkPtr(UnsafeMutableRawPointer.moveInitializeMemory(as:from:count:))
+  check(Check.LeftOverlap)
+  check(Check.Disjoint)
+  check(Check.RightOverlap)
+}
+
+runAllTests()

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -260,12 +260,12 @@ func rdar19770981(_ s: String, ns: NSString) {
 
 // <rdar://problem/19831919> Fixit offers as! conversions that are known to always fail
 func rdar19831919() {
-  var s1 = 1 + "str"; // expected-error{{binary operator '+' cannot be applied to operands of type 'Int' and 'String'}} expected-note{{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (String, String), (Int, UnsafeMutablePointer<Pointee>), (Int, UnsafePointer<Pointee>)}}
+  var s1 = 1 + "str"; // expected-error{{binary operator '+' cannot be applied to operands of type 'Int' and 'String'}} expected-note{{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (Int, UnsafeMutableRawPointer), (Int, UnsafeRawPointer), (String, String), (Int, UnsafeMutablePointer<Pointee>), (Int, UnsafePointer<Pointee>)}}
 }
 
 // <rdar://problem/19831698> Incorrect 'as' fixits offered for invalid literal expressions
 func rdar19831698() {
-  var v70 = true + 1 // expected-error{{binary operator '+' cannot be applied to operands of type 'Bool' and 'Int'}} expected-note {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (UnsafeMutablePointer<Pointee>, Int), (UnsafePointer<Pointee>, Int)}}
+  var v70 = true + 1 // expected-error{{binary operator '+' cannot be applied to operands of type 'Bool' and 'Int'}} expected-note {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (UnsafeMutableRawPointer, Int), (UnsafeRawPointer, Int), (UnsafeMutablePointer<Pointee>, Int), (UnsafePointer<Pointee>, Int)}}
   var v71 = true + 1.0 // expected-error{{binary operator '+' cannot be applied to operands of type 'Bool' and 'Double'}}
 // expected-note@-1{{overloads for '+'}}
   var v72 = true + true // expected-error{{binary operator '+' cannot be applied to two 'Bool' operands}}

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -94,7 +94,7 @@ func r22162441(_ lines: [String]) {
 func testMap() {
   let a = 42
   [1,a].map { $0 + 1.0 } // expected-error {{binary operator '+' cannot be applied to operands of type 'Int' and 'Double'}}
-  // expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (Double, Double), (Int, UnsafeMutablePointer<Pointee>), (Int, UnsafePointer<Pointee>)}}
+  // expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (Double, Double), (Int, UnsafeMutableRawPointer), (Int, UnsafeRawPointer), (Int, UnsafeMutablePointer<Pointee>), (Int, UnsafePointer<Pointee>)}}
 }
 
 // <rdar://problem/22414757> "UnresolvedDot" "in wrong phase" assertion from verifier

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -186,7 +186,7 @@ func recArea(_ h: Int, w : Int) {
 // <rdar://problem/17224804> QoI: Error In Ternary Condition is Wrong
 func r17224804(_ monthNumber : Int) {
   // expected-error @+2 {{binary operator '+' cannot be applied to operands of type 'String' and 'Int'}}
-  // expected-note @+1 {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (String, String), (UnsafeMutablePointer<Pointee>, Int), (UnsafePointer<Pointee>, Int)}}
+  // expected-note @+1 {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (UnsafeMutableRawPointer, Int), (UnsafeRawPointer, Int), (String, String), (UnsafeMutablePointer<Pointee>, Int), (UnsafePointer<Pointee>, Int)}}
   let monthString = (monthNumber <= 9) ? ("0" + monthNumber) : String(monthNumber)
 }
 
@@ -534,13 +534,13 @@ func testTypeSugar(_ a : Int) {
 
   let x = Stride(a)
   x+"foo"            // expected-error {{binary operator '+' cannot be applied to operands of type 'Stride' (aka 'Int') and 'String'}}
-// expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (String, String), (Int, UnsafeMutablePointer<Pointee>), (Int, UnsafePointer<Pointee>)}}
+// expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (Int, UnsafeMutableRawPointer), (Int, UnsafeRawPointer), (String, String), (Int, UnsafeMutablePointer<Pointee>), (Int, UnsafePointer<Pointee>)}}
 }
 
 // <rdar://problem/21974772> SegFault in FailureDiagnosis::visitInOutExpr
 func r21974772(_ y : Int) {
   let x = &(1.0 + y)  // expected-error {{binary operator '+' cannot be applied to operands of type 'Double' and 'Int'}}
-   //expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (Double, Double), (UnsafeMutablePointer<Pointee>, Int), (UnsafePointer<Pointee>, Int)}}
+   //expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (Double, Double), (UnsafeMutableRawPointer, Int), (UnsafeRawPointer, Int), (UnsafeMutablePointer<Pointee>, Int), (UnsafePointer<Pointee>, Int)}}
 }
 
 // <rdar://problem/22020088> QoI: missing member diagnostic on optional gives worse error message than existential/bound generic/etc

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -16,8 +16,8 @@ _TtSi ---> Swift.Int
 _TtSq ---> Swift.Optional
 _TtSS ---> Swift.String
 _TtSu ---> Swift.UInt
-_TtGSP ---> Swift.UnsafePointer
-_TtGSp ---> Swift.UnsafeMutablePointer
+_TtGSPSi_ ---> Swift.UnsafePointer<Swift.Int>
+_TtGSpSi_ ---> Swift.UnsafeMutablePointer<Swift.Int>
 _TtSV ---> Swift.UnsafeRawPointer
 _TtSv ---> Swift.UnsafeMutableRawPointer
 _TtGSaSS_ ---> [Swift.String]

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -16,6 +16,10 @@ _TtSi ---> Swift.Int
 _TtSq ---> Swift.Optional
 _TtSS ---> Swift.String
 _TtSu ---> Swift.UInt
+_TtGSP ---> Swift.UnsafePointer
+_TtGSp ---> Swift.UnsafeMutablePointer
+_TtSV ---> Swift.UnsafeRawPointer
+_TtSv ---> Swift.UnsafeMutableRawPointer
 _TtGSaSS_ ---> [Swift.String]
 _TtGSqSS_ ---> Swift.String?
 _TtGSQSS_ ---> Swift.String!

--- a/test/Demangle/Inputs/simplified-manglings.txt
+++ b/test/Demangle/Inputs/simplified-manglings.txt
@@ -16,6 +16,10 @@ _TtSi ---> Int
 _TtSq ---> Optional
 _TtSS ---> String
 _TtSu ---> UInt
+_TtGSP ---> UnsafePointer
+_TtGSp ---> UnsafeMutablePointer
+_TtSV ---> UnsafeRawPointer
+_TtSv ---> UnsafeMutableRawPointer
 _TtGSaSS_ ---> [String]
 _TtGSqSS_ ---> String?
 _TtGSQSS_ ---> String!

--- a/test/Demangle/Inputs/simplified-manglings.txt
+++ b/test/Demangle/Inputs/simplified-manglings.txt
@@ -16,8 +16,8 @@ _TtSi ---> Int
 _TtSq ---> Optional
 _TtSS ---> String
 _TtSu ---> UInt
-_TtGSP ---> UnsafePointer
-_TtGSp ---> UnsafeMutablePointer
+_TtGSPSi_ ---> UnsafePointer<Int>
+_TtGSpSi_ ---> UnsafeMutablePointer<Int>
 _TtSV ---> UnsafeRawPointer
 _TtSv ---> UnsafeMutableRawPointer
 _TtGSaSS_ ---> [String]

--- a/test/IDE/print_stdlib.swift
+++ b/test/IDE/print_stdlib.swift
@@ -37,7 +37,6 @@
 // CHECK-NOT: func ~>
 // CHECK-NOT: _builtin
 // CHECK-NOT: Builtin.
-// CHECK-NOT: RawPointer
 // CHECK-NOT: extension [
 // CHECK-NOT: extension {{.*}}?
 // CHECK-NOT: extension {{.*}}!

--- a/test/SILOptimizer/globalredundantloadelimination.sil
+++ b/test/SILOptimizer/globalredundantloadelimination.sil
@@ -1,8 +1,13 @@
 // RUN: %target-sil-opt -enable-sil-verify-all %s -module-name Swift -redundant-load-elim
+// FIXME: This test is not FileCheck'd
 
 import Builtin
 
 struct A {
+  var i : Builtin.Int32
+}
+
+struct A2 {
   var i : Builtin.Int32
 }
 
@@ -73,6 +78,44 @@ bb0(%0 : $B, %1 : $*Agg1):
   %11 = return %10 : $()
 }
 
+// FIXME: When RLE uses TBAA it should remove the second load.
+// CHECK-LABEL: sil @tbaa_struct
+// CHECK: load
+// CHECK: store
+// CHECK: load
+// CHECK: return
+sil @tbaa_struct : $@convention(thin) (Builtin.RawPointer, A2) -> (A, A) {
+bb0(%0 : $Builtin.RawPointer, %1 : $A2):
+  %2 = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*A
+  %3 = load %2 : $*A
+  %5 = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*A2
+  store %1 to %5 : $*A2
+  %20 = load %2 : $*A
+  %30 = tuple(%3 : $A, %20 : $A)
+  %31 = return %30 : $(A, A)
+}
+
+// Even with TBAA, RLE should not remove the second load.
+// CHECK-LABEL: sil @tbaa_bind_memory
+// CHECK: load
+// CHECK: bind_memory
+// CHECK: store
+// CHECK: bind_memory
+// CHECK: load
+// CHECK: return
+sil @tbaa_bind_memory : $@convention(thin) (Builtin.RawPointer, A2) -> (A, A) {
+bb0(%0 : $Builtin.RawPointer, %1 : $A2):
+  %2 = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*A
+  %3 = load %2 : $*A
+  %4 = integer_literal $Builtin.Word, 1
+  bind_memory %0 : $Builtin.RawPointer, %4 : $Builtin.Word to $A2
+  %5 = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*A2
+  store %1 to %5 : $*A2
+  bind_memory %0 : $Builtin.RawPointer, %4 : $Builtin.Word to $A
+  %20 = load %2 : $*A
+  %30 = tuple(%3 : $A, %20 : $A)
+  %31 = return %30 : $(A, A)
+}
 
 // *NOTE* This does not handle raw pointer since raw pointer is only layout compatible with heap references.
 // CHECK-LABEL: sil @store_to_load_forward_unchecked_addr_cast_struct : $@convention(thin) (Optional<A>) -> () {

--- a/test/SILOptimizer/specialize.sil
+++ b/test/SILOptimizer/specialize.sil
@@ -18,7 +18,7 @@ import Swift
 
 struct XXX<T> {
   init(t: T)
-  mutating func foo(t t: T) -> Int32
+  mutating func foo(t: T) -> Int32
   var m_t: T
 }
 
@@ -511,4 +511,30 @@ bb0:
   strong_release %8 : $@callee_owned (Int32) -> Int32 // id: %15
   dealloc_stack %0 : $*@callee_owned (Int32) -> Int32 // id: %16
   return %14 : $Int32                             // id: %17
+}
+
+// test_bind<A> (Builtin.RawPointer, A.Type) -> ()
+// Check that this is specialized as T=Int.
+// CHECK-LABEL: sil shared @_TTSg5Si___TF5test9test_bindurFTBpMx_T_ 
+// CHECK: bind_memory %0 : $Builtin.RawPointer, {{%.*}} : $Builtin.Word to $*Int
+// CHECK: return
+sil hidden @_TF5test9test_bindurFTBpMx_T_ : $@convention(thin) <T> (Builtin.RawPointer, @thick T.Type) -> () {
+bb0(%0 : $Builtin.RawPointer, %1 : $@thick T.Type):
+  %4 = integer_literal $Builtin.Word, 1
+  %5 = metatype $@thick T.Type
+  bind_memory %0 : $Builtin.RawPointer, %4 : $Builtin.Word to $*T
+  %7 = tuple ()
+  %8 = tuple ()
+  return %8 : $()
+}
+
+// Invoke test_bind with T=Int.
+sil @_TF5test8call_bindFT1pBp_T_ : $@convention(thin) (Builtin.RawPointer) -> () {
+bb0(%0 : $Builtin.RawPointer):
+  // function_ref test_bind<A> (Builtin.RawPointer, A.Type) -> ()
+  %2 = function_ref @_TF5test9test_bindurFTBpMx_T_ : $@convention(thin) <τ_0_0> (Builtin.RawPointer, @thick τ_0_0.Type) -> ()
+  %3 = metatype $@thick Int.Type
+  %4 = apply %2<Int>(%0, %3) : $@convention(thin) <τ_0_0> (Builtin.RawPointer, @thick τ_0_0.Type) -> ()
+  %5 = tuple ()
+  return %5 : $()
 }


### PR DESCRIPTION
As proposed in SE-0107:   UnsafeRawPointer.
https://github.com/apple/swift-evolution/blob/master/proposals/0107-unsaferawpointer.md

The fundamental difference between Unsafe[Mutable]RawPointer and
Unsafe[Mutable]Pointer<Pointee> is simply that the former is used for "untyped"
memory access, and the later is used for "typed" memory access. Let's refer to
these as "raw pointers" and "typed pointers". Because operations on raw pointers
access untyped memory, the compiler cannot make assumptions about the underlying
type of memory and must be conservative. With operations on typed pointers, the
compiler may make strict assumptions about the type of the underlying memory,
which allows more aggressive optimization.

Memory can only be accessed by a typed pointer when it is currently
bound to the Pointee type. Memory can be bound to type `T` via:
- `UnsafePointer<T>.allocate(capacity: n)`
- `UnsafePointer<Pointee>.withMemoryRebound(to: T.self, capacity: n) {...}`
- `UnsafeMutableRawPointer.initializeMemory(as: T.self, at: i, count: n, to: x)`
- `UnsafeMutableRawPointer.initializeMemory(as: T.self, from: p, count: n)`
- `UnsafeMutableRawPointer.moveInitializeMemory(as: T.self, from: p, count: n)`
- `UnsafeMutableRawPointer.bindMemory(to: T.self, capacity: n)`

Mangle UnsafeRawPointer as predefined substitution 'Sv' for Swift void
pointer ([urp] are taken).
