### PR TITLE
Remove type checker hack for suppressing optional coercion

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -627,48 +627,6 @@ matchCallArguments(ConstraintSystem &cs, TypeMatchKind kind,
   auto haveOneNonUserConversion =
           (subKind != TypeMatchKind::OperatorArgumentConversion);
   
-  auto haveNilArgument = false;
-  auto nilLiteralProto = cs.TC.getProtocol(SourceLoc(),
-                                           KnownProtocolKind::
-                                              ExpressibleByNilLiteral);
-  
-  auto isNilLiteral = [&](Type t) -> bool {
-    if (auto tyvar = t->getAs<TypeVariableType>()) {
-      return tyvar->getImpl().literalConformanceProto == nilLiteralProto;
-    }
-    return false;
-  };
-
-  // If we're applying an operator function to a nil literal operand, we
-  // disallow value-to-optional conversions from taking place so as not to
-  // select an overly permissive overload.
-  auto allowOptionalConversion = [&](Type t) -> bool {
-    
-    if (t->isLValueType())
-      t = t->getLValueOrInOutObjectType();
-    
-    if (!t->getAnyOptionalObjectType().isNull())
-      return true;
-    
-    if (isNilLiteral(t))
-      return true;
-    
-    if (auto nt = t->getNominalOrBoundGenericNominal()) {
-      return nt->getName() == cs.TC.Context.Id_OptionalNilComparisonType;
-    }
-    
-    return false;
-  };
-  
-  // Pre-scan operator arguments for nil literals.
-  if (subKind == TypeMatchKind::OperatorArgumentConversion) {
-    for (auto arg : args) {
-      if (isNilLiteral(arg.Ty)) {
-        haveNilArgument = true;
-        break;
-      }
-    }
-  }
   
   for (unsigned paramIdx = 0, numParams = parameterBindings.size();
        paramIdx != numParams; ++paramIdx){
@@ -687,10 +645,6 @@ matchCallArguments(ConstraintSystem &cs, TypeMatchKind kind,
                                                                paramIdx));
       auto argTy = args[argIdx].Ty;
 
-      if (haveNilArgument && !allowOptionalConversion(argTy)) {
-        subflags |= ConstraintSystem::TMF_ApplyingOperatorWithNil;
-      }
-      
       if (!haveOneNonUserConversion) {
         subflags |= ConstraintSystem::TMF_ApplyingOperatorParameter;
       }
@@ -1946,12 +1900,8 @@ ConstraintSystem::matchTypes(Type type1, Type type2, TypeMatchKind kind,
           }
         }
         
-        // Do not attempt a value-to-optional conversion when resolving the
-        // applicable overloads for an operator application with nil operands.
-        if (!(subFlags & TMF_ApplyingOperatorWithNil)) {
-          conversionsOrFixes.push_back(
-              ConversionRestrictionKind::ValueToOptional);
-        }
+        conversionsOrFixes.push_back(
+            ConversionRestrictionKind::ValueToOptional);
       }
     }
   }

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1728,10 +1728,6 @@ public:
     /// Indicates we're unwrapping an optional type for a value-to-optional
     /// conversion.
     TMF_UnwrappingOptional = 0x8,
-    
-    /// Indicates we're applying an operator function with a nil-literal
-    /// argument.
-    TMF_ApplyingOperatorWithNil = 0x10,
   };
 
 private:

--- a/test/ClangModules/nullability.swift
+++ b/test/ClangModules/nullability.swift
@@ -5,16 +5,21 @@
 import CoreCooling
 
 func testSomeClass(_ sc: SomeClass, osc: SomeClass?) {
-  var ao1: AnyObject = sc.methodA(osc)
+  let ao1: AnyObject = sc.methodA(osc)
+  _ = ao1
   if sc.methodA(osc) == nil { } // expected-error{{type 'AnyObject' is not optional, value can never be nil}}
 
-  var ao2: AnyObject = sc.methodB(nil)
+  let ao2: AnyObject = sc.methodB(nil)
+  _ = ao2
   if sc.methodA(osc) == nil { } // expected-error{{type 'AnyObject' is not optional, value can never be nil}}
 
-  var ao3: AnyObject = sc.property // expected-error{{value of optional type 'AnyObject?' not unwrapped; did you mean to use '!' or '?'?}} {{35-35=!}}
-  var ao3_ok: AnyObject? = sc.property // okay
+  let ao3: AnyObject = sc.property // expected-error{{value of optional type 'AnyObject?' not unwrapped; did you mean to use '!' or '?'?}} {{35-35=!}}
+  _ = ao3
+  let ao3_ok: AnyObject? = sc.property // okay
+  _ = ao3_ok
 
-  var ao4: AnyObject = sc.methodD()
+  let ao4: AnyObject = sc.methodD()
+  _ = ao4
   if sc.methodD() == nil { } // expected-error{{type 'AnyObject' is not optional, value can never be nil}}
 
   sc.methodE(sc)
@@ -29,16 +34,19 @@ func testSomeClass(_ sc: SomeClass, osc: SomeClass?) {
   sc.methodG(sc, second: osc) 
 
   let ci: CInt = 1
-  var sc2 = SomeClass(int: ci)
-  var sc2a: SomeClass = sc2
+  let sc2 = SomeClass(int: ci)
+  let sc2a: SomeClass = sc2
+  _ = sc2a
   if sc2 == nil { } // expected-error{{type 'SomeClass' is not optional, value can never be nil}}
 
-  var sc3 = SomeClass(double: 1.5)
+  let sc3 = SomeClass(double: 1.5)
   if sc3 == nil { } // okay
-  var sc3a: SomeClass = sc3 // expected-error{{value of optional type 'SomeClass?' not unwrapped}} {{28-28=!}}
+  let sc3a: SomeClass = sc3 // expected-error{{value of optional type 'SomeClass?' not unwrapped}} {{28-28=!}}
+  _ = sc3a
 
-  var sc4 = sc.returnMe()
-  var sc4a: SomeClass = sc4
+  let sc4 = sc.returnMe()
+  let sc4a: SomeClass = sc4
+  _ = sc4a
   if sc4 == nil { } // expected-error{{type 'SomeClass' is not optional, value can never be nil}}
 }
 

--- a/test/ClangModules/nullability.swift
+++ b/test/ClangModules/nullability.swift
@@ -7,11 +7,11 @@ import CoreCooling
 func testSomeClass(_ sc: SomeClass, osc: SomeClass?) {
   let ao1: AnyObject = sc.methodA(osc)
   _ = ao1
-  if sc.methodA(osc) == nil { } // expected-error{{type 'AnyObject' is not optional, value can never be nil}}
+  if sc.methodA(osc) == nil { }
 
   let ao2: AnyObject = sc.methodB(nil)
   _ = ao2
-  if sc.methodA(osc) == nil { } // expected-error{{type 'AnyObject' is not optional, value can never be nil}}
+  if sc.methodA(osc) == nil { }
 
   let ao3: AnyObject = sc.property // expected-error{{value of optional type 'AnyObject?' not unwrapped; did you mean to use '!' or '?'?}} {{35-35=!}}
   _ = ao3
@@ -20,7 +20,7 @@ func testSomeClass(_ sc: SomeClass, osc: SomeClass?) {
 
   let ao4: AnyObject = sc.methodD()
   _ = ao4
-  if sc.methodD() == nil { } // expected-error{{type 'AnyObject' is not optional, value can never be nil}}
+  if sc.methodD() == nil { }
 
   sc.methodE(sc)
   sc.methodE(osc) // expected-error{{value of optional type 'SomeClass?' not unwrapped; did you mean to use '!' or '?'?}} {{17-17=!}}
@@ -37,7 +37,7 @@ func testSomeClass(_ sc: SomeClass, osc: SomeClass?) {
   let sc2 = SomeClass(int: ci)
   let sc2a: SomeClass = sc2
   _ = sc2a
-  if sc2 == nil { } // expected-error{{type 'SomeClass' is not optional, value can never be nil}}
+  if sc2 == nil { }
 
   let sc3 = SomeClass(double: 1.5)
   if sc3 == nil { } // okay
@@ -47,7 +47,7 @@ func testSomeClass(_ sc: SomeClass, osc: SomeClass?) {
   let sc4 = sc.returnMe()
   let sc4a: SomeClass = sc4
   _ = sc4a
-  if sc4 == nil { } // expected-error{{type 'SomeClass' is not optional, value can never be nil}}
+  if sc4 == nil { }
 }
 
 // Nullability with CF types.

--- a/test/ClangModules/objc_failable_inits.swift
+++ b/test/ClangModules/objc_failable_inits.swift
@@ -7,7 +7,7 @@ import Foundation
 func testDictionary() {
   // -[NSDictionary init] returns non-nil.
   var dictNonOpt = NSDictionary()
-  if dictNonOpt == nil { } // expected-error{{type 'NSDictionary' is not optional, value can never be nil}}
+  _ = dictNonOpt! // expected-error {{cannot force unwrap value of non-optional type 'NSDictionary'}}
 }
 
 func testString() throws {

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -213,7 +213,7 @@ class r20201968C {
 
 // <rdar://problem/21459429> QoI: Poor compilation error calling assert
 func r21459429(_ a : Int) {
-  assert(a != nil, "ASSERT COMPILATION ERROR") // expected-error {{type 'Int' is not optional, value can never be nil}}
+  assert(a != nil, "ASSERT COMPILATION ERROR")
 }
 
 
@@ -590,7 +590,7 @@ func r21684487() {
 func r18397777(_ d : r21447318?) {
   let c = r21447318()
 
-  if c != nil { // expected-error {{type 'r21447318' is not optional, value can never be nil}}
+  if c != nil {
   }
   
   if d {  // expected-error {{optional type 'r21447318?' cannot be used as a boolean; test for '!= nil' instead}} {{6-6=(}} {{7-7= != nil)}}
@@ -773,29 +773,29 @@ class SR1594 {
   func sr1594(bytes : UnsafeMutablePointer<Int>, _ i : Int?) {
     _ = (i === nil) // expected-error {{value of type 'Int?' cannot be compared by reference; did you mean to compare by value?}} {{12-15===}}
     _ = (bytes === nil) // expected-error {{type 'UnsafeMutablePointer<Int>' is not optional, value can never be nil}}
-    _ = (self === nil) // expected-error {{type 'SR1594' is not optional, value can never be nil}}
+    _ = (self === nil)
     _ = (i !== nil) // expected-error {{value of type 'Int?' cannot be compared by reference; did you mean to compare by value?}} {{12-15=!=}}
     _ = (bytes !== nil) // expected-error {{type 'UnsafeMutablePointer<Int>' is not optional, value can never be nil}}
-    _ = (self !== nil) // expected-error {{type 'SR1594' is not optional, value can never be nil}}
+    _ = (self !== nil)
   }
 }
 
 func nilComparison(i: Int, o: AnyObject) {
-  _ = i == nil  // expected-error {{type 'Int' is not optional, value can never be nil}}
-  _ = nil == i  // expected-error {{type 'Int' is not optional, value can never be nil}}
-  _ = i != nil  // expected-error {{type 'Int' is not optional, value can never be nil}}
-  _ = nil != i  // expected-error {{type 'Int' is not optional, value can never be nil}}
-  _ = i < nil   // expected-error {{type 'Int' is not optional, value can never be nil}}
-  _ = nil < i   // expected-error {{type 'Int' is not optional, value can never be nil}}
-  _ = i <= nil  // expected-error {{type 'Int' is not optional, value can never be nil}}
-  _ = nil <= i  // expected-error {{type 'Int' is not optional, value can never be nil}}
-  _ = i > nil   // expected-error {{type 'Int' is not optional, value can never be nil}}
-  _ = nil > i   // expected-error {{type 'Int' is not optional, value can never be nil}}
-  _ = i >= nil  // expected-error {{type 'Int' is not optional, value can never be nil}}
-  _ = nil >= i  // expected-error {{type 'Int' is not optional, value can never be nil}}
+  _ = i == nil
+  _ = nil == i
+  _ = i != nil
+  _ = nil != i
+  _ = i < nil
+  _ = nil < i
+  _ = i <= nil
+  _ = nil <= i
+  _ = i > nil
+  _ = nil > i
+  _ = i >= nil
+  _ = nil >= i
 
-  _ = o === nil // expected-error {{type 'AnyObject' is not optional, value can never be nil}}
-  _ = o !== nil // expected-error {{type 'AnyObject' is not optional, value can never be nil}}
+  _ = o === nil
+  _ = o !== nil
 }
 
 // FIXME: Bad diagnostic

--- a/test/expr/cast/nil_value_to_optional.swift
+++ b/test/expr/cast/nil_value_to_optional.swift
@@ -5,8 +5,8 @@ var f = false
 
 func markUsed<T>(_ t: T) {}
 
-markUsed(t != nil) // expected-error {{type 'Bool' is not optional, value can never be nil}}
-markUsed(f != nil) // expected-error {{type 'Bool' is not optional, value can never be nil}}
+markUsed(t != nil)
+markUsed(f != nil)
 
 class C : Equatable {}
 
@@ -15,7 +15,7 @@ func == (lhs: C, rhs: C) -> Bool {
 }
 
 func test(_ c: C) {
-  if c == nil {} // expected-error {{type 'C' is not optional, value can never be nil}}
+  if c == nil {}
 }
 
 class D {}
@@ -24,6 +24,6 @@ var d = D()
 var dopt: D? = nil
 var diuopt: D! = nil
 
-_ = d == nil // expected-error{{type 'D' is not optional, value can never be nil}}
+_ = d! // expected-error {{cannot force unwrap value of non-optional type 'D'}}
 _ = dopt == nil
 _ = diuopt == nil

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -705,10 +705,10 @@ func invalidDictionaryLiteral() {
 //===----------------------------------------------------------------------===//
 // nil/metatype comparisons
 //===----------------------------------------------------------------------===//
-Int.self == nil // expected-error {{type 'Int.Type' is not optional, value can never be nil}}
-nil == Int.self // expected-error {{type 'Int.Type' is not optional, value can never be nil}}
-Int.self != nil // expected-error {{type 'Int.Type' is not optional, value can never be nil}}
-nil != Int.self // expected-error {{type 'Int.Type' is not optional, value can never be nil}}
+_ = Int.self == nil
+_ = nil == Int.self
+_ = Int.self != nil
+_ = nil != Int.self
 
 // <rdar://problem/19032294> Disallow postfix ? when not chaining
 func testOptionalChaining(_ a : Int?, b : Int!, c : Int??) {


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Remove the type checker hack that was used to generate diagnostics for comparing non-optional values for nil. These will be replaced with a new warning to express that the comparisons always return the same result for any non-optional operand.
