### PR TITLE
Partial apply forwarder fix for going from single ref counted context…

### DIFF
--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -895,13 +895,20 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
 
     llvm::Value *argValue;
     if (isIndirectParameter(argConvention)) {
-      expectedArgTy = expectedArgTy->getPointerElementType();
-      auto temporary = subIGF.createAlloca(expectedArgTy,
+      // We can use rawData's type for the alloca because it is a swift
+      // retainable value. Defensively, give it that type. We can't use the
+      // expectedArgType because it might be a generic parameter and therefore
+      // have opaque storage.
+      auto RetainableValue = rawData;
+      if (RetainableValue->getType() != subIGF.IGM.RefCountedPtrTy)
+        RetainableValue = subIGF.Builder.CreateBitCast(
+            RetainableValue, subIGF.IGM.RefCountedPtrTy);
+      auto temporary = subIGF.createAlloca(RetainableValue->getType(),
                                            subIGF.IGM.getPointerAlignment(),
                                            "partial-apply.context");
-      argValue = subIGF.Builder.CreateBitCast(rawData, expectedArgTy);
-      subIGF.Builder.CreateStore(argValue, temporary);
+      subIGF.Builder.CreateStore(RetainableValue, temporary);
       argValue = temporary.getAddress();
+      argValue = subIGF.Builder.CreateBitCast(argValue, expectedArgTy);
     } else {
       argValue = subIGF.Builder.CreateBitCast(rawData, expectedArgTy);
     }

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -261,13 +261,13 @@ sil public_external @indirect_guaranteed_captured_class_param : $@convention(thi
 // CHECK:         ret {{.*}} [[T0]]
 
 // CHECK:       define internal i64 [[PARTIAL_APPLY_FORWARDER]]
-// CHECK:         [[X_TMP:%.*]] = alloca %C13partial_apply10SwiftClass*
-// CHECK-NEXT:    [[X:%.*]] = bitcast %swift.refcounted* %1 to %C13partial_apply10SwiftClass*
-// CHECK-NEXT:    store %C13partial_apply10SwiftClass* [[X]], %C13partial_apply10SwiftClass** [[X_TMP]], align
+// CHECK:         [[X_TMP:%.*]] = alloca %swift.refcounted*
+// CHECK-NEXT:    store %swift.refcounted* %1, %swift.refcounted** [[X_TMP]], align
+// CHECK-NEXT:    [[X_CAST:%.*]] = bitcast %swift.refcounted** [[X_TMP]] to %C13partial_apply10SwiftClass**
 // CHECK-NOT:     load
 // CHECK-NOT:     retain
 // CHECK-NOT:     release
-// CHECK:         [[RESULT:%.*]] = call i64 @indirect_guaranteed_captured_class_param(i64 %0, %C13partial_apply10SwiftClass** noalias nocapture dereferenceable({{.*}}) [[X_TMP]])
+// CHECK:         [[RESULT:%.*]] = call i64 @indirect_guaranteed_captured_class_param(i64 %0, %C13partial_apply10SwiftClass** noalias nocapture dereferenceable({{.*}}) [[X_CAST]]
 // CHECK-NOT:     retain
 // CHECK:         call void @rt_swift_release(%swift.refcounted* %1)
 // CHECK:         ret i64 [[RESULT]]
@@ -290,13 +290,13 @@ sil public_external @indirect_consumed_captured_class_param : $@convention(thin)
 // CHECK:         ret {{.*}} [[T0]]
 
 // CHECK:       define internal i64 [[PARTIAL_APPLY_FORWARDER]]
-// CHECK:         [[X_TMP:%.*]] = alloca %C13partial_apply10SwiftClass*
-// CHECK-NEXT:    [[X:%.*]] = bitcast %swift.refcounted* %1 to %C13partial_apply10SwiftClass*
-// CHECK-NEXT:    store %C13partial_apply10SwiftClass* [[X]], %C13partial_apply10SwiftClass** [[X_TMP]], align
+// CHECK:         [[X_TMP:%.*]] = alloca %swift.refcounted*
+// CHECK-NEXT:    store %swift.refcounted* %1, %swift.refcounted** [[X_TMP]], align
+// CHECK-NEXT:    [[X_CAST:%.*]] = bitcast %swift.refcounted** [[X_TMP]] to %C13partial_apply10SwiftClass**
 // CHECK-NOT:     load
 // CHECK-NOT:     retain
 // CHECK-NOT:     release
-// CHECK:         [[RESULT:%.*]] = tail call i64 @indirect_consumed_captured_class_param(i64 %0, %C13partial_apply10SwiftClass** noalias nocapture dereferenceable({{.*}}) [[X_TMP]])
+// CHECK:         [[RESULT:%.*]] = tail call i64 @indirect_consumed_captured_class_param(i64 %0, %C13partial_apply10SwiftClass** noalias nocapture dereferenceable({{.*}}) [[X_CAST]])
 // CHECK-NOT:     retain
 // CHECK-NOT:     release
 // CHECK:         ret i64 [[RESULT]]

--- a/test/IRGen/partial_apply_forwarder.sil
+++ b/test/IRGen/partial_apply_forwarder.sil
@@ -20,6 +20,28 @@ bb0(%0 : $E):
 
 sil hidden_external @unspecialized_uncurried : $@convention(method) <τ_0_0 where τ_0_0 : P> (@guaranteed E) -> @owned D<τ_0_0>
 
+
+// CHECK-LABEL: define internal void @_TPA_takingP(%swift.refcounted*
+// CHECK: [[CONTEXT:%.*]] = alloca %swift.refcounted*
+// CHECK: [[TYPE:%.*]]    = call %swift.type* @_TMaC23partial_apply_forwarder1C
+// CHECK: store %swift.refcounted* %0, %swift.refcounted** [[CONTEXT]]
+// CHECK: [[CAST:%.*]] = bitcast %swift.refcounted** [[CONTEXT]] to %swift.opaque*
+// CHECK:  call void @takingP(%swift.type* [[TYPE]], i8**{{.*}}_TWPC23partial_apply_forwarder1CS_1PS_{{.*}}, %swift.opaque* {{.*}} [[CAST]]
+// CHECK:  ret
+sil hidden_external @takingP : $@convention(method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+
+sil hidden @reabstract_context : $@convention(thin) (@owned C) -> () {
+bb0(%0 : $C):
+  %6 = alloc_stack $C
+  store %0 to %6 : $*C
+  %8 = function_ref @takingP : $@convention(method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+  %9 = partial_apply %8<C>(%6) : $@convention(method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %6 : $*C
+  strong_release %9 : $@callee_owned() -> ()
+  %10 = tuple ()
+  return %10 : $()
+}
+
 sil_vtable C {}
 sil_vtable D {}
 sil_vtable E {}


### PR DESCRIPTION
… to a generic argument

In the case we are forwarding from partial apply that captures a concrete ref
counted value to a generic function we need to use the swift retainable type
from the captured value rather than the type of the generic function we are
calling. The type of the generic argument is opaque and we can't allocate
storage for an opaque type.

rdar://24306823
