### PR TITLE
Sema: Allow explicitly bridging anything `as AnyObject`.

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1986,11 +1986,11 @@ static ForeignRepresentableKind
 getObjCObjectRepresentable(Type type, const DeclContext *dc) {
   // @objc metatypes are representable when their instance type is.
   if (auto metatype = type->getAs<AnyMetatypeType>()) {
-    // If the instance type is not representable, the metatype is not
+    // If the instance type is not representable verbatim, the metatype is not
     // representable.
     auto instanceType = metatype->getInstanceType();
     if (getObjCObjectRepresentable(instanceType, dc)
-          == ForeignRepresentableKind::None)
+          != ForeignRepresentableKind::Object)
       return ForeignRepresentableKind::None;
 
     // Objective-C metatypes are trivially representable.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1371,6 +1371,10 @@ namespace {
     ///
     /// \param value The value to be bridged.
     Expr *bridgeToObjectiveC(Expr *value) {
+      // TODO: It would be nicer to represent this as a special AST node
+      // instead of inlining the bridging calls in the AST. Doing so would
+      // simplify the AST and make it easier for SILGen to peephole bridging
+      // conversions.
       auto &tc = cs.getTypeChecker();
 
       // Find the _ObjectiveCBridgeable protocol.
@@ -1380,25 +1384,45 @@ namespace {
       // Find the conformance of the value type to _ObjectiveCBridgeable.
       ProtocolConformance *conformance = nullptr;
       Type valueType = value->getType()->getRValueType();
-      bool conforms =
+      bool conformsToBridgeable =
         tc.conformsToProtocol(valueType, bridgedProto, cs.DC,
                               (ConformanceCheckFlags::InExpression|
                                ConformanceCheckFlags::Used),
                               &conformance);
 
-      // If there is no _ObjectiveCBridgeable conformance, treat this
-      // as bridging an error.
-      if (!conforms)
+      if (conformsToBridgeable) {
+        // Form the call.
+        return tc.callWitness(value, cs.DC, bridgedProto,
+                              conformance,
+                              tc.Context.Id_bridgeToObjectiveC,
+                              { }, diag::broken_bridged_to_objc_protocol);
+      }
+      
+      // If there is an Error conformance, try bridging as an error.
+      if (tc.isConvertibleTo(valueType,
+                             tc.Context.getProtocol(KnownProtocolKind::Error)
+                               ->getDeclaredType(),
+                             cs.DC))
         return bridgeErrorToObjectiveC(value);
 
-      assert(conforms && "Should already have checked the conformance");
-      (void)conforms;
-
-      // Form the call.
-      return tc.callWitness(value, cs.DC, bridgedProto,
-                            conformance,
-                            tc.Context.Id_bridgeToObjectiveC,
-                            { }, diag::broken_bridged_to_objc_protocol);
+      // Fall back to universal bridging.
+      auto bridgeAnything = tc.Context.getBridgeAnythingToObjectiveC(&tc);
+      value = tc.coerceToRValue(value);
+      auto valueSub = Substitution(valueType, {});
+      auto bridgeAnythingRef = ConcreteDeclRef(tc.Context, bridgeAnything,
+                                               valueSub);
+      auto bridgeTy = tc.Context.getProtocol(KnownProtocolKind::AnyObject)
+        ->getDeclaredType();
+      auto bridgeFnTy = FunctionType::get(valueType, bridgeTy);
+      auto fnRef = new (tc.Context) DeclRefExpr(bridgeAnythingRef,
+                                                DeclNameLoc(),
+                                                /*implicit*/ true,
+                                                AccessSemantics::Ordinary,
+                                                bridgeFnTy);
+      Expr *call = new (tc.Context) CallExpr(fnRef, value,
+                                             /*implicit*/ true,
+                                             bridgeTy);
+      return call;
     }
 
     /// Bridge the given object from Objective-C to its value type.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1736,6 +1736,17 @@ ConstraintSystem::matchTypes(Type type1, Type type2, TypeMatchKind kind,
     }
 
     if (kind == TypeMatchKind::ExplicitConversion) {
+      // Anything can be explicitly converted to AnyObject using the universal
+      // bridging conversion.
+      if (auto protoType2 = type2->getAs<ProtocolType>()) {
+        if (TC.Context.LangOpts.EnableIdAsAny
+            && protoType2->getDecl()
+              == TC.Context.getProtocol(KnownProtocolKind::AnyObject)
+            && !type1->mayHaveSuperclass()
+            && !type1->isClassExistentialType())
+          conversionsOrFixes.push_back(ConversionRestrictionKind::BridgeToObjC);
+      }
+
       // Bridging from an Objective-C class type to a value type.
       // Note that specifically require a class or class-constrained archetype
       // here, because archetypes cannot be bridged.
@@ -4082,7 +4093,15 @@ ConstraintSystem::simplifyRestrictedConstraint(ConversionRestrictionKind restric
   // T bridges to C and C < U ===> T <c U
   case ConversionRestrictionKind::BridgeToObjC: {
     auto objcClass = TC.getBridgedToObjC(DC, type1);
-    assert(objcClass && "type is not bridged to Objective-C?");
+    // If the type doesn't bridge any other way, we can still go straight to
+    // AnyObject by universal bridging.
+    if (!objcClass) {
+      assert(TC.Context.LangOpts.EnableIdAsAny
+             && "should only happen in id-as-any mode");
+      objcClass = TC.Context.getProtocol(KnownProtocolKind::AnyObject)
+        ->getDeclaredType();
+    }
+
     addContextualScore();
     increaseScore(SK_UserConversion); // FIXME: Use separate score kind?
     if (worseThanBestSolution()) {

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -1,4 +1,4 @@
-// RUN: %target-parse-verify-swift
+// RUN: %target-swift-frontend -parse -verify %s -enable-id-as-any
 
 // REQUIRES: objc_interop
 
@@ -6,7 +6,7 @@ import Foundation
 
 public class BridgedClass : NSObject, NSCopying {
   @objc(copyWithZone:)
-  public func copy(with zone: NSZone?) -> AnyObject {
+  public func copy(with zone: NSZone?) -> Any {
     return self
   }
 }
@@ -325,4 +325,29 @@ func forceBridgeDiag(_ obj: BridgedClass!) -> BridgedStruct {
   return obj // expected-error{{'BridgedClass!' is not implicitly convertible to 'BridgedStruct'; did you mean to use 'as' to explicitly convert?}}{{13-13= as BridgedStruct}}
 }
 
+struct KnownUnbridged {}
+class KnownClass {}
+protocol KnownClassProtocol: class {}
 
+func forceUniversalBridgeToAnyObject<T, U: KnownClassProtocol>(a: T, b: U, c: Any, d: KnownUnbridged, e: KnownClass, f: KnownClassProtocol, g: AnyObject, h: String) {
+  var z: AnyObject
+  z = a as AnyObject
+  z = b as AnyObject
+  z = c as AnyObject
+  z = d as AnyObject
+  z = e as AnyObject
+  z = f as AnyObject
+  z = g as AnyObject
+  z = h as AnyObject
+
+  z = a // expected-error{{does not conform to 'AnyObject'}}
+  z = b
+  z = c // expected-error{{does not conform to 'AnyObject'}}
+  z = d // expected-error{{does not conform to 'AnyObject'}}
+  z = e
+  z = f
+  z = g
+  z = h // todo{{does not conform to 'AnyObject'}}
+
+  _ = z
+}


### PR DESCRIPTION
If something isn't a class or bridgeable by value or error bridging, we can still fall back to universal bridging by the runtime. Make this available for manual use by an explicit `as AnyObject` cast.
