### PR TITLE
[SourceKit] Add test case for crash triggered in swift::PrintOptions::setArchetypeSelfTransform(…)

### DIFF
--- a/validation-test/IDE/crashers/075-swift-printoptions-setarchetypeselftransform.swift
+++ b/validation-test/IDE/crashers/075-swift-printoptions-setarchetypeselftransform.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+f{enum B<T{enum S<h{case a#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 152
swift-ide-test: /path/to/swift/lib/AST/ASTPrinter.cpp:68: std::unique_ptr<llvm::DenseMap<StringRef, Type> > swift::collectNameTypeMap(swift::Type): Assertion `ParamDecls.size() == Args.size()' failed.
9  swift-ide-test  0x0000000000b82c80 swift::PrintOptions::setArchetypeSelfTransform(swift::Type, swift::DeclContext*) + 144
14 swift-ide-test  0x00000000008eeaa1 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 305
15 swift-ide-test  0x00000000007a6e9d swift::CompilerInstance::performSema() + 3597
16 swift-ide-test  0x000000000074a001 main + 34609
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
```
