### PR TITLE
[swiftc (69 vs. 5114)] Add crasher in swift::PrintOptions::setArchetypeSelfTransform(…)

### DIFF
--- a/validation-test/compiler_crashers/28373-swift-printoptions-setarchetypeselftransform.swift
+++ b/validation-test/compiler_crashers/28373-swift-printoptions-setarchetypeselftransform.swift
@@ -1,0 +1,16 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+protocol A{
+class a
+func d
+class b<T>:A
+{
+enum B
+enum S<T where B:a


### PR DESCRIPTION
Add test case for crash triggered in `swift::PrintOptions::setArchetypeSelfTransform(...)`.

Current number of unresolved compiler crashers: 69 (5114 resolved)

Assertion failure in [`lib/AST/ASTPrinter.cpp (line 68)`](https://github.com/apple/swift/blob/master/lib/AST/ASTPrinter.cpp#L68):

```
Assertion `ParamDecls.size() == Args.size()' failed.

When executing: std::unique_ptr<llvm::DenseMap<StringRef, Type> > swift::collectNameTypeMap(swift::Type)
```

Assertion context:

```
    if (!D || !D->getGenericParams())
      continue;
    SmallVector<Type, 3> Scrach;
    auto Args = BaseTy->getAllGenericArgs(Scrach);
    const auto ParamDecls = D->getGenericParams()->getParams();
    assert(ParamDecls.size() == Args.size());

    // Map type parameter names with their instantiating arguments.
    for (unsigned I = 0, N = ParamDecls.size(); I < N; I++) {
      (*IdMap)[ParamDecls[I]->getName().str()] = Args[I];
    }
```

Stack trace:

```
swift: /path/to/swift/lib/AST/ASTPrinter.cpp:68: std::unique_ptr<llvm::DenseMap<StringRef, Type> > swift::collectNameTypeMap(swift::Type): Assertion `ParamDecls.size() == Args.size()' failed.
9  swift           0x000000000104a240 swift::PrintOptions::setArchetypeSelfTransform(swift::Type, swift::DeclContext*) + 144
13 swift           0x0000000000f10f97 swift::TypeChecker::checkConformance(swift::NormalProtocolConformance*) + 2423
15 swift           0x0000000000eebee1 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
16 swift           0x0000000000c735c9 swift::CompilerInstance::performSema() + 3289
18 swift           0x00000000007d9277 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
19 swift           0x00000000007a5278 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28373-swift-printoptions-setarchetypeselftransform.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28373-swift-printoptions-setarchetypeselftransform-d50673.o
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
