### PR TITLE
Bugfix: argument label of isTotallyOrdered.

### DIFF
--- a/stdlib/public/SDK/Foundation/Decimal.swift
+++ b/stdlib/public/SDK/Foundation/Decimal.swift
@@ -99,7 +99,7 @@ extension Decimal {
         return order == .orderedAscending || order == .orderedSame
     }
 
-    public func isTotallyOrdered(below other: Decimal) -> Bool {
+    public func isTotallyOrdered(belowOrEqualTo other: Decimal) -> Bool {
         // Notes: Decimal does not have -0 or infinities to worry about
         if self.isNaN {
             return false

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -435,7 +435,7 @@ public protocol FloatingPoint: Comparable, Arithmetic,
   /// values of type `Self`, including non-canonical encodings, signed zeros,
   /// and NaNs.  Because it is used much less frequently than the usual
   /// comparisons, there is no operator form of this relation.
-  func isTotallyOrdered(below other: Self) -> Bool
+  func isTotallyOrdered(belowOrEqualTo other: Self) -> Bool
 
   /// True if and only if `self` is normal.
   ///
@@ -708,7 +708,7 @@ public protocol BinaryFloatingPoint: FloatingPoint, ExpressibleByFloatLiteral {
 
   func isLessThanOrEqualTo<Other: BinaryFloatingPoint>(other: Other) -> Bool
 
-  func isTotallyOrdered<Other: BinaryFloatingPoint>(below other: Other) -> Bool
+  func isTotallyOrdered<Other: BinaryFloatingPoint>(belowOrEqualTo other: Other) -> Bool
   */
 }
 
@@ -852,7 +852,7 @@ extension BinaryFloatingPoint {
       significandBitPattern: magnitudeOf.significandBitPattern)
   }
 
-  public func isTotallyOrdered(below other: Self) -> Bool {
+  public func isTotallyOrdered(belowOrEqualTo other: Self) -> Bool {
     // Quick return when possible.
     if self < other { return true }
     if other > self { return false }
@@ -909,7 +909,7 @@ extension BinaryFloatingPoint {
     return Other(self).isLessThanOrEqualTo(other)
   }
 
-  public func isTotallyOrdered<Other: BinaryFloatingPoint>(before other: Other) -> Bool {
+  public func isTotallyOrdered<Other: BinaryFloatingPoint>(belowOrEqualTo other: Other) -> Bool {
     if Self.significandBitCount >= Other.significandBitCount {
       return self.totalOrder(with: Self(other))
     }


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

The argument label in `isTotallyOrdered(below:)` isn't quite right, because this predicate implements a total <= relation, not <.  This pull request has one possible fix, using `belowOrEqualTo:` instead.  This is a bit unwieldy, but a better solution isn't totally obvious.  One visually cleaner option is `notAbove:`, but that may impose more cognitive load.  Ultimately, I don't think the exact label is terribly important, as most people won't interact with this predicate; they'll use the spaceship operator if they use anything, but we should make it accurate.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
