### PR TITLE
Type system support for raw pointer conversion.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -424,7 +424,13 @@ public:
   
   /// Retrieve the declaration of Swift.COpaquePointer.
   NominalTypeDecl *getOpaquePointerDecl() const;
-  
+
+  /// Retrieve the declaration of Swift.UnsafeMutableRawPointer.
+  NominalTypeDecl *getUnsafeMutableRawPointerDecl() const;
+
+  /// Retrieve the declaration of Swift.UnsafeRawPointer.
+  NominalTypeDecl *getUnsafeRawPointerDecl() const;
+
   /// Retrieve the declaration of Swift.UnsafeMutablePointer<T>.
   NominalTypeDecl *getUnsafeMutablePointerDecl() const;
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2712,6 +2712,8 @@ enum { NumOptionalTypeKinds = 2 };
   
 // Kinds of pointer types.
 enum PointerTypeKind : unsigned {
+  PTK_UnsafeMutableRawPointer,
+  PTK_UnsafeRawPointer,
   PTK_UnsafeMutablePointer,
   PTK_UnsafePointer,
   PTK_AutoreleasingUnsafeMutablePointer,

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1162,7 +1162,7 @@ struct ASTNodeBase {};
         Out << "\n";
         abort();
       }
-      if (PTK != PTK_UnsafePointer) {
+      if (PTK != PTK_UnsafePointer && PTK != PTK_UnsafeRawPointer) {
         Out << "StringToPointer converts to non-const pointer:\n";
         E->print(Out);
         Out << "\n";

--- a/lib/IRGen/GenClangType.cpp
+++ b/lib/IRGen/GenClangType.cpp
@@ -213,6 +213,8 @@ clang::CanQualType GenClangType::visitStructType(CanStructType type) {
                    ctx.VoidPtrTy);
   CHECK_NAMED_TYPE("ObjCBool", ctx.ObjCBuiltinBoolTy);
   CHECK_NAMED_TYPE("Selector", getClangSelectorType(ctx));
+  CHECK_NAMED_TYPE("UnsafeRawPointer", ctx.VoidPtrTy);
+  CHECK_NAMED_TYPE("UnsafeMutableRawPointer", ctx.VoidPtrTy);
 #undef CHECK_NAMED_TYPE
 
   // Map vector types to the corresponding C vectors.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3299,7 +3299,7 @@ RValue RValueEmitter::visitInOutToPointerExpr(InOutToPointerExpr *E,
   (void)elt;
 
   AccessKind accessKind =
-    (pointerKind == PTK_UnsafePointer
+    ((pointerKind == PTK_UnsafePointer || pointerKind == PTK_UnsafeRawPointer)
        ? AccessKind::Read : AccessKind::ReadWrite);
 
   // Get the original lvalue.
@@ -3327,10 +3327,11 @@ ManagedValue SILGenFunction::emitLValueToPointer(SILLocation loc,
         != loweredTy.getSwiftRValueType()) {
     lv.addSubstToOrigComponent(opaqueTy, loweredTy);
   }
-
   switch (pointerKind) {
   case PTK_UnsafeMutablePointer:
   case PTK_UnsafePointer:
+  case PTK_UnsafeMutableRawPointer:
+  case PTK_UnsafeRawPointer:
     // +1 is fine.
     break;
 

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3692,7 +3692,9 @@ bool FailureDiagnosis::diagnoseContextualConversionError() {
         }
       }
     } else if (contextDecl == CS->TC.Context.getUnsafePointerDecl() ||
-               contextDecl == CS->TC.Context.getUnsafeMutablePointerDecl()) {
+               contextDecl == CS->TC.Context.getUnsafeMutablePointerDecl() ||
+               contextDecl == CS->TC.Context.getUnsafeRawPointerDecl() ||
+               contextDecl == CS->TC.Context.getUnsafeMutableRawPointerDecl()) {
       SmallVector<Type, 4> scratch;
       for (Type arg : contextualType->getAllGenericArgs(scratch)) {
         if (arg->isEqual(exprType) && expr->getType()->isLValueType()) {
@@ -5080,7 +5082,7 @@ bool FailureDiagnosis::visitInOutExpr(InOutExpr *IOE) {
           unwrappedType->getAnyPointerElementType(pointerKind)) {
 
       // If the element type is Void, then we allow any input type, since
-      // everything is convertible to UnsafePointer<Void>
+      // everything is convertible to UnsafeRawPointer
       if (pointerEltType->isVoid())
         contextualType = Type();
       else
@@ -5094,7 +5096,7 @@ bool FailureDiagnosis::visitInOutExpr(InOutExpr *IOE) {
         // it is mutable.
         if (pointerKind == PTK_UnsafeMutablePointer) {
           contextualType = ArraySliceType::get(contextualType);
-        } else if (pointerKind == PTK_UnsafePointer) {
+        } else if (pointerKind == PTK_UnsafePointer || pointerKind == PTK_UnsafeRawPointer) {
           // If we're converting to an UnsafePointer, then the programmer
           // specified an & unnecessarily.  Produce a fixit hint to remove it.
           diagnose(IOE->getLoc(), diag::extra_address_of_unsafepointer,

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionInstance.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionInstance.swift.gyb
@@ -388,7 +388,7 @@ public func check${Traversal}Collection<
         successor3 = succ(successor3)
         for s in [ successor1, successor2, successor3 ] {
           expectEqual(allIndices[i + 1], s, ${trace})
-          expectEqual(
+          expectEqualTest(
             expectedArray[i + 1], collection[s], ${trace}, sameValue: sameValue)
         }
       }
@@ -403,14 +403,14 @@ public func check${Traversal}Collection<
         predecessor3 = pred(predecessor3)
         for p in [ predecessor1, predecessor2, predecessor3 ] {
           expectEqual(allIndices[i - 1], p, ${trace})
-          expectEqual(
+          expectEqualTest(
             expectedArray[i - 1], collection[p], ${trace}, sameValue: sameValue)
         }
       }
       for i in 1..<allIndices.count {
         let index = succ(pred(allIndices[i]))
         expectEqual(allIndices[i], index, ${trace})
-        expectEqual(
+        expectEqualTest(
           expectedArray[i], collection[index], ${trace}, sameValue: sameValue)
       }
 

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -134,20 +134,20 @@ public func identityComp(_ element: MinimalComparableValue)
 }
 
 public func expectEqual<T : Equatable>(_ expected: T, _ actual: T, ${TRACE}) {
-  expectEqual(expected, actual, ${trace}, showFrame: false) {$0 == $1}
+  expectEqualTest(expected, actual, ${trace}, showFrame: false) {$0 == $1}
 }
 
 public func expectEqual<T : Equatable, U : Equatable>(
   _ expected: (T, U), _ actual: (T, U), ${TRACE}) {
-  expectEqual(expected.0, actual.0, ${trace}, showFrame: false) {$0 == $1}
-  expectEqual(expected.1, actual.1, ${trace}, showFrame: false) {$0 == $1}
+  expectEqualTest(expected.0, actual.0, ${trace}, showFrame: false) {$0 == $1}
+  expectEqualTest(expected.1, actual.1, ${trace}, showFrame: false) {$0 == $1}
 }
 
 public func expectEqual<T : Equatable, U : Equatable, V : Equatable>(
   _ expected: (T, U, V), _ actual: (T, U, V), ${TRACE}) {
-  expectEqual(expected.0, actual.0, ${trace}, showFrame: false) {$0 == $1}
-  expectEqual(expected.1, actual.1, ${trace}, showFrame: false) {$0 == $1}
-  expectEqual(expected.2, actual.2, ${trace}, showFrame: false) {$0 == $1}
+  expectEqualTest(expected.0, actual.0, ${trace}, showFrame: false) {$0 == $1}
+  expectEqualTest(expected.1, actual.1, ${trace}, showFrame: false) {$0 == $1}
+  expectEqualTest(expected.2, actual.2, ${trace}, showFrame: false) {$0 == $1}
 }
 
 public func expectationFailure(
@@ -160,7 +160,10 @@ public func expectationFailure(
   print(message, terminator: message == "" ? "" : "\n")
 }
 
-public func expectEqual<T>(
+// Renamed to avoid collision with expectEqual(_, _, TRACE).
+// See <rdar://26058520> Generic type constraints incorrectly applied to
+// functions with the same name
+public func expectEqualTest<T>(
   _ expected: T, _ actual: T, ${TRACE}, sameValue equal: (T, T) -> Bool
 ) {
   if !equal(expected, actual) {
@@ -230,7 +233,7 @@ public func expectNotEqual<T : Equatable>(
 public func expectEqual${Generic}(
   _ expected: ${EquatableType}, _ actual: ${EquatableType}, ${TRACE}
 ) {
-  expectEqual(expected, actual, ${trace}, showFrame: false) { $0 == $1 }
+  expectEqualTest(expected, actual, ${trace}, showFrame: false) { $0 == $1 }
 }
 
 public func expectOptionalEqual${Generic}(

--- a/test/1_stdlib/simd.swift.gyb
+++ b/test/1_stdlib/simd.swift.gyb
@@ -99,24 +99,24 @@ simdTestSuite.test("vector init") {
 
   //  Check empty initializer.
   var ${vec} = ${vectype}()
-  expectEqual(${[0]*size}, ${vec}, sameValue: same)
+  expectEqualTest(${[0]*size}, ${vec}, sameValue: same)
 
   //  Check literal initializer.
   ${vec} = ${vectype}(2)
-  expectEqual(${[2]*size}, ${vec}, sameValue: same)
+  expectEqualTest(${[2]*size}, ${vec}, sameValue: same)
 
   //  Check scalar initializer.
-  expectEqual(${vectype}(${type}(2)), ${vec}, sameValue: same)
+  expectEqualTest(${vectype}(${type}(2)), ${vec}, sameValue: same)
 
   //  Check elementwise initializer.
   ${vec} = ${vectype}(${', '.join(map(lambda i: str(i), range(size)))})
-  expectEqual(${range(size)}, ${vec}, sameValue: same)
+  expectEqualTest(${range(size)}, ${vec}, sameValue: same)
 
   //  Check labeled elementwise initializer.
   ${vec} = ${vectype}(${', '.join(map(lambda i:
                       component[i][1:] + ':' + str(i),
                       range(size)))})
-  expectEqual(${range(size)}, ${vec}, sameValue: same)
+  expectEqualTest(${range(size)}, ${vec}, sameValue: same)
 
   //  Previous checks implicitly use the array initializer, so we're good
   //  with that one already.
@@ -141,7 +141,7 @@ simdTestSuite.test("vector elements") {
 
   //  Check getting and setting [i]
   for i in 0..<${size} { ${vec}[i] = ${vec}[i]/2 }
-  expectEqual(${vec}, ${range(size)}, sameValue: same)
+  expectEqualTest(${vec}, ${range(size)}, sameValue: same)
 
 %   end # for size in [2,3,4]
 % end # for type in scalar_types
@@ -245,7 +245,7 @@ simdTestSuite.test("matrix init") {
 
   //  Check empty initializer.
   var ${mat} = ${mattype}()
-  expectEqual(${mat}, ${mattype}(${[[0]*rows]*cols}), sameValue: same)
+  expectEqualTest(${mat}, ${mattype}(${[[0]*rows]*cols}), sameValue: same)
 
   //  Check scalar initializer.
   ${mat} = ${mattype}(2)
@@ -280,7 +280,7 @@ simdTestSuite.test("matrix init") {
   }
 
   //  Round-trip through C matrix type.
-  expectEqual(${mat}, ${mattype}(${mat}.cmatrix), sameValue: same)
+  expectEqualTest(${mat}, ${mattype}(${mat}.cmatrix), sameValue: same)
 
 %     end # for rows
 %   end # for cols
@@ -311,10 +311,10 @@ simdTestSuite.test("matrix elements") {
   for i in 0..<${cols} {
     ${mat}[i] = ${type}(i+1)*${basis}[i]
   }
-  expectEqual(
+  expectEqualTest(
     ${mat}, ${mattype}(diagonal:${range(1, diagsize + 1)}), sameValue: same)
   for i in 0..<${cols} {
-    expectEqual(${mat}[i], ${type}(i + 1)*${basis}[i], sameValue: same)
+    expectEqualTest(${mat}[i], ${type}(i + 1)*${basis}[i], sameValue: same)
   }
 
   //  Check getting and setting elements (and transpose).

--- a/test/Parse/pointer_conversion.swift.gyb
+++ b/test/Parse/pointer_conversion.swift.gyb
@@ -23,6 +23,7 @@ class D {}
 
 func takesMutablePointer(_ x: UnsafeMutablePointer<Int>${suffix}) {}
 func takesMutableVoidPointer(_ x: UnsafeMutablePointer<Void>${suffix}) {}
+func takesMutableRawPointer(_ x: UnsafeMutableRawPointer${suffix}) {}
 func takesMutableInt8Pointer(_ x: UnsafeMutablePointer<Int8>${suffix}) {}
 func takesMutableArrayPointer(_ x: UnsafeMutablePointer<[Int]>${suffix}) {}
 @discardableResult
@@ -30,6 +31,7 @@ func takesConstPointer(_ x: UnsafePointer<Int>${suffix}) -> Character { return "
 func takesConstInt8Pointer(_ x: UnsafePointer<Int8>${suffix}) {}
 func takesConstUInt8Pointer(_ x: UnsafePointer<UInt8>${suffix}) {}
 func takesConstVoidPointer(_ x: UnsafePointer<Void>${suffix}) {}
+func takesConstRawPointer(_ x: UnsafeRawPointer${suffix}) {}
 
 func mutablePointerArguments(_ p: UnsafeMutablePointer<Int>,
                              cp: UnsafePointer<Int>) {
@@ -92,6 +94,41 @@ func mutableVoidPointerArguments(_ p: UnsafeMutablePointer<Int>,
   var x: UnsafeMutablePointer<Void> = &i // expected-error{{cannot convert value of type 'inout Int' to specified type 'UnsafeMutablePointer<Void>'}}
   x = p // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Int>' to type 'UnsafeMutablePointer<Void>'}}
   x = &ii // expected-error{{cannot assign value of type 'inout [Int]' (aka 'inout Array<Int>') to type 'UnsafeMutablePointer<Void>'}}
+  _ = x
+}
+
+func mutableRawPointerArguments(_ p: UnsafeMutablePointer<Int>,
+                                cp: UnsafePointer<Int>,
+                                fp: UnsafeMutablePointer<Float>,
+                                rp: UnsafeRawPointer) {
+  takesMutableRawPointer(nil)
+% if not suffix:
+  // expected-error@-2 {{nil is not compatible with expected argument type}}
+% end
+
+  takesMutableRawPointer(p)
+  takesMutableRawPointer(fp)
+  takesMutableRawPointer(cp) // expected-error{{cannot convert value of type 'UnsafePointer<Int>' to expected argument type 'UnsafeMutableRawPointer${suffix}'}}
+  takesMutableRawPointer(rp) // expected-error{{cannot convert value of type 'UnsafeRawPointer' to expected argument type 'UnsafeMutableRawPointer${suffix}'}}
+  var i: Int = 0
+  var f: Float = 0
+  takesMutableRawPointer(&i)
+  takesMutableRawPointer(&f)
+  takesMutableRawPointer(i) // expected-error{{cannot convert value of type 'Int' to expected argument type 'UnsafeMutableRawPointer${suffix}'}}
+  takesMutableRawPointer(f) // expected-error{{cannot convert value of type 'Float' to expected argument type 'UnsafeMutableRawPointer${suffix}'}}
+  var ii: [Int] = [0, 1, 2]
+  var dd: [CInt] = [1, 2, 3]
+  var ff: [Int] = [0, 1, 2]
+  takesMutableRawPointer(&ii)
+  takesMutableRawPointer(&dd)
+  takesMutableRawPointer(&ff)
+  takesMutableRawPointer(ii) // expected-error{{cannot convert value of type '[Int]' to expected argument type 'UnsafeMutableRawPointer${suffix}'}}
+  takesMutableRawPointer(ff) // expected-error{{cannot convert value of type '[Int]' to expected argument type 'UnsafeMutableRawPointer${suffix}'}}
+
+  // We don't allow these conversions outside of function arguments.
+  var x: UnsafeMutableRawPointer = &i // expected-error{{cannot convert value of type 'inout Int' to specified type 'UnsafeMutableRawPointer'}}
+  x = p // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Int>' to type 'UnsafeMutableRawPointer'}}
+  x = &ii // expected-error{{cannot assign value of type 'inout [Int]' (aka 'inout Array<Int>') to type 'UnsafeMutableRawPointer'}}
   _ = x
 }
 
@@ -164,14 +201,57 @@ func constVoidPointerArguments(_ p: UnsafeMutablePointer<Int>,
   _ = x
 }
 
+func constRawPointerArguments(_ p: UnsafeMutablePointer<Int>,
+                               fp: UnsafeMutablePointer<Float>,
+                               cp: UnsafePointer<Int>,
+                               cfp: UnsafePointer<Float>,
+                               mrp: UnsafeMutableRawPointer) {
+  takesConstRawPointer(nil)
+% if not suffix:
+  // expected-error@-2 {{nil is not compatible with expected argument type}}
+% end
+
+  takesConstRawPointer(p)
+  takesConstRawPointer(fp)
+  takesConstRawPointer(cp)
+  takesConstRawPointer(cfp)
+  takesConstRawPointer(mrp)
+
+  var i: Int = 0
+  var f: Float = 0
+  takesConstRawPointer(&i)
+  takesConstRawPointer(&f)
+  var ii: [Int] = [0, 1, 2]
+  var ff: [Float] = [0, 1, 2]
+  takesConstRawPointer(&ii)
+  takesConstRawPointer(&ff)
+  takesConstRawPointer(ii)
+  takesConstRawPointer(ff)
+
+  // TODO: These two should be accepted, tracked by rdar://17444930.
+  takesConstRawPointer([0, 1, 2]) // expected-error {{contextual type 'UnsafeRawPointer' cannot be used with array literal}}
+  takesConstRawPointer([0.0, 1.0, 2.0])  // expected-error {{contextual type 'UnsafeRawPointer' cannot be used with array literal}}
+
+  // We don't allow these conversions outside of function arguments.
+  var x: UnsafeRawPointer = &i // expected-error{{cannot convert value of type 'inout Int' to specified type 'UnsafeRawPointer'}}
+  x = ii // expected-error{{cannot assign value of type '[Int]' to type 'UnsafeRawPointer'}}
+  x = p // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Int>' to type 'UnsafeRawPointer'}}
+  x = fp // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Float>' to type 'UnsafeRawPointer'}}
+  x = cp // expected-error{{cannot assign value of type 'UnsafePointer<Int>' to type 'UnsafeRawPointer'}}
+  x = cfp // expected-error{{cannot assign value of type 'UnsafePointer<Float>' to type 'UnsafeRawPointer'}}
+  _ = x
+}
+
 func stringArguments(_ s: String) {
   var s = s
   takesConstVoidPointer(s)
+  takesConstRawPointer(s)
   takesConstInt8Pointer(s)
   takesConstUInt8Pointer(s)
   takesConstPointer(s) // expected-error{{cannot convert value of type 'String' to expected argument type 'UnsafePointer<Int>${suffix}'}}
 
   takesMutableVoidPointer(s) // expected-error{{cannot convert value of type 'String' to expected argument type 'UnsafeMutablePointer<Void>${suffix}'}}
+  takesMutableRawPointer(s) // expected-error{{cannot convert value of type 'String' to expected argument type 'UnsafeMutableRawPointer${suffix}'}}
   takesMutableInt8Pointer(s) // expected-error{{cannot convert value of type 'String' to expected argument type 'UnsafeMutablePointer<Int8>${suffix}'}}
   takesMutableInt8Pointer(&s) // expected-error{{cannot convert value of type 'String' to expected argument type 'Int8'}}
   takesMutablePointer(s) // expected-error{{cannot convert value of type 'String' to expected argument type 'UnsafeMutablePointer<Int>${suffix}'}}

--- a/test/SILGen/pointer_conversion.swift
+++ b/test/SILGen/pointer_conversion.swift
@@ -9,11 +9,14 @@ func takesMutablePointer(_ x: UnsafeMutablePointer<Int>) {}
 func takesConstPointer(_ x: UnsafePointer<Int>) {}
 func takesMutableVoidPointer(_ x: UnsafeMutablePointer<Void>) {}
 func takesConstVoidPointer(_ x: UnsafePointer<Void>) {}
+func takesMutableRawPointer(_ x: UnsafeMutableRawPointer) {}
+func takesConstRawPointer(_ x: UnsafeRawPointer) {}
 
-// CHECK-LABEL: sil hidden @_TF18pointer_conversion16pointerToPointerFTGSpSi_GSPSi__T_
-// CHECK: bb0([[MP:%.*]] : $UnsafeMutablePointer<Int>, [[CP:%.*]] : $UnsafePointer<Int>):
+// CHECK-LABEL: sil hidden @_TF18pointer_conversion16pointerToPointerFTGSpSi_GSPSi_Sv_T_
+// CHECK: bb0([[MP:%.*]] : $UnsafeMutablePointer<Int>, [[CP:%.*]] : $UnsafePointer<Int>, [[MRP:%.*]] : $UnsafeMutableRawPointer):
 func pointerToPointer(_ mp: UnsafeMutablePointer<Int>,
-                      _ cp: UnsafePointer<Int>) {
+  _ cp: UnsafePointer<Int>, _ mrp: UnsafeMutableRawPointer) {
+
   // There should be no conversion here
   takesMutablePointer(mp)
   // CHECK: [[TAKES_MUTABLE_POINTER:%.*]] = function_ref @_TF18pointer_conversion19takesMutablePointer
@@ -24,6 +27,12 @@ func pointerToPointer(_ mp: UnsafeMutablePointer<Int>,
   // CHECK: [[CONVERT:%.*]] = function_ref @_TFs32_convertPointerToPointerArgument
   // CHECK: apply [[CONVERT]]<UnsafeMutablePointer<Int>, UnsafeMutablePointer<()>>
   // CHECK: apply [[TAKES_MUTABLE_VOID_POINTER]]
+
+  takesMutableRawPointer(mp)
+  // CHECK: [[TAKES_MUTABLE_RAW_POINTER:%.*]] = function_ref @_TF18pointer_conversion22takesMutableRawPointerFSvT_ :
+  // CHECK: [[CONVERT:%.*]] = function_ref @_TFs32_convertPointerToPointerArgument
+  // CHECK: apply [[CONVERT]]<UnsafeMutablePointer<Int>, UnsafeMutableRawPointer>
+  // CHECK: apply [[TAKES_MUTABLE_RAW_POINTER]]
 
   takesConstPointer(mp)
   // CHECK: [[TAKES_CONST_POINTER:%.*]] = function_ref @_TF18pointer_conversion17takesConstPointerFGSPSi_T_
@@ -36,6 +45,34 @@ func pointerToPointer(_ mp: UnsafeMutablePointer<Int>,
   // CHECK: [[CONVERT:%.*]] = function_ref @_TFs32_convertPointerToPointerArgument
   // CHECK: apply [[CONVERT]]<UnsafeMutablePointer<Int>, UnsafePointer<()>>
   // CHECK: apply [[TAKES_CONST_VOID_POINTER]]
+
+  takesConstRawPointer(mp)
+  // CHECK: [[TAKES_CONST_RAW_POINTER:%.*]] = function_ref @_TF18pointer_conversion20takesConstRawPointerFSVT_ :
+  // CHECK: [[CONVERT:%.*]] = function_ref @_TFs32_convertPointerToPointerArgument
+  // CHECK: apply [[CONVERT]]<UnsafeMutablePointer<Int>, UnsafeRawPointer>
+  // CHECK: apply [[TAKES_CONST_RAW_POINTER]]
+
+  takesConstPointer(cp)
+  // CHECK: [[TAKES_CONST_POINTER:%.*]] = function_ref @_TF18pointer_conversion17takesConstPointerFGSPSi_T_
+  // CHECK: apply [[TAKES_CONST_POINTER]]([[CP]])
+
+  takesConstVoidPointer(cp)
+  // CHECK: [[TAKES_CONST_VOID_POINTER:%.*]] = function_ref @_TF18pointer_conversion21takesConstVoidPointerFGSPT__T_
+  // CHECK: [[CONVERT:%.*]] = function_ref @_TFs32_convertPointerToPointerArgument
+  // CHECK: apply [[CONVERT]]<UnsafePointer<Int>, UnsafePointer<()>>
+  // CHECK: apply [[TAKES_CONST_VOID_POINTER]]
+
+  takesConstRawPointer(cp)
+  // CHECK: [[TAKES_CONST_RAW_POINTER:%.*]] = function_ref @_TF18pointer_conversion20takesConstRawPointerFSVT_
+  // CHECK: [[CONVERT:%.*]] = function_ref @_TFs32_convertPointerToPointerArgument
+  // CHECK: apply [[CONVERT]]<UnsafePointer<Int>, UnsafeRawPointer>
+  // CHECK: apply [[TAKES_CONST_RAW_POINTER]]
+
+  takesConstRawPointer(mrp)
+  // CHECK: [[TAKES_CONST_RAW_POINTER:%.*]] = function_ref @_TF18pointer_conversion20takesConstRawPointerFSVT_
+  // CHECK: [[CONVERT:%.*]] = function_ref @_TFs32_convertPointerToPointerArgument
+  // CHECK: apply [[CONVERT]]<UnsafeMutableRawPointer, UnsafeRawPointer>
+  // CHECK: apply [[TAKES_CONST_RAW_POINTER]]
 }
 
 // CHECK-LABEL: sil hidden @_TF18pointer_conversion14arrayToPointerFT_T_
@@ -57,6 +94,22 @@ func arrayToPointer() {
   // CHECK: [[POINTER:%.*]] = load [[POINTER_BUF]]
   // CHECK: apply [[TAKES_CONST_POINTER]]([[POINTER]])
   // CHECK: release_value [[OWNER]]
+
+  takesMutableRawPointer(&ints)
+  // CHECK: [[TAKES_MUTABLE_RAW_POINTER:%.*]] = function_ref @_TF18pointer_conversion22takesMutableRawPointerFSvT_ :
+  // CHECK: [[CONVERT_MUTABLE:%.*]] = function_ref @_TFs37_convertMutableArrayToPointerArgument
+  // CHECK: [[OWNER:%.*]] = apply [[CONVERT_MUTABLE]]<Int, UnsafeMutableRawPointer>([[POINTER_BUF:%[0-9]*]],
+  // CHECK: [[POINTER:%.*]] = load [[POINTER_BUF]]
+  // CHECK: apply [[TAKES_MUTABLE_RAW_POINTER]]([[POINTER]])
+  // CHECK: release_value [[OWNER]]
+
+  takesConstRawPointer(ints)
+  // CHECK: [[TAKES_CONST_RAW_POINTER:%.*]] = function_ref @_TF18pointer_conversion20takesConstRawPointerFSVT_ :
+  // CHECK: [[CONVERT_CONST:%.*]] = function_ref @_TFs35_convertConstArrayToPointerArgument
+  // CHECK: [[OWNER:%.*]] = apply [[CONVERT_CONST]]<Int, UnsafeRawPointer>([[POINTER_BUF:%[0-9]*]],
+  // CHECK: [[POINTER:%.*]] = load [[POINTER_BUF]]
+  // CHECK: apply [[TAKES_CONST_RAW_POINTER]]([[POINTER]])
+  // CHECK: release_value [[OWNER]]
 }
 
 // CHECK-LABEL: sil hidden @_TF18pointer_conversion15stringToPointerFSST_ 
@@ -67,6 +120,14 @@ func stringToPointer(_ s: String) {
   // CHECK: [[OWNER:%.*]] = apply [[CONVERT_STRING]]<UnsafePointer<()>>([[POINTER_BUF:%[0-9]*]],
   // CHECK: [[POINTER:%.*]] = load [[POINTER_BUF]]
   // CHECK: apply [[TAKES_CONST_VOID_POINTER]]([[POINTER]])
+  // CHECK: release_value [[OWNER]]
+
+  takesConstRawPointer(s)
+  // CHECK: [[TAKES_CONST_RAW_POINTER:%.*]] = function_ref @_TF18pointer_conversion20takesConstRawPointerFSV
+  // CHECK: [[CONVERT_STRING:%.*]] = function_ref @_TFs40_convertConstStringToUTF8PointerArgument
+  // CHECK: [[OWNER:%.*]] = apply [[CONVERT_STRING]]<UnsafeRawPointer>([[POINTER_BUF:%[0-9]*]],
+  // CHECK: [[POINTER:%.*]] = load [[POINTER_BUF]]
+  // CHECK: apply [[TAKES_CONST_RAW_POINTER]]([[POINTER]])
   // CHECK: release_value [[OWNER]]
 }
 
@@ -92,6 +153,23 @@ func inoutToPointer() {
   // CHECK: apply [[GETTER]]
   // CHECK: [[CONVERT:%.*]] = function_ref @_TFs30_convertInOutToPointerArgument
   // CHECK: apply [[CONVERT]]<UnsafeMutablePointer<Int>>
+  // CHECK: apply [[TAKES_MUTABLE]]
+  // CHECK: [[SETTER:%.*]] = function_ref @_TFF18pointer_conversion14inoutToPointerFT_T_sL_10logicalIntSi
+  // CHECK: apply [[SETTER]]
+
+  takesMutableRawPointer(&int)
+  // CHECK: [[TAKES_MUTABLE:%.*]] = function_ref @_TF18pointer_conversion22takesMutableRawPointer
+  // CHECK: [[POINTER:%.*]] = address_to_pointer [[PB]]
+  // CHECK: [[CONVERT:%.*]] = function_ref @_TFs30_convertInOutToPointerArgument
+  // CHECK: apply [[CONVERT]]<UnsafeMutableRawPointer>({{%.*}}, [[POINTER]])
+  // CHECK: apply [[TAKES_MUTABLE]]
+
+  takesMutableRawPointer(&logicalInt)
+  // CHECK: [[TAKES_MUTABLE:%.*]] = function_ref @_TF18pointer_conversion22takesMutableRawPointer
+  // CHECK: [[GETTER:%.*]] = function_ref @_TFF18pointer_conversion14inoutToPointerFT_T_gL_10logicalIntSi
+  // CHECK: apply [[GETTER]]
+  // CHECK: [[CONVERT:%.*]] = function_ref @_TFs30_convertInOutToPointerArgument
+  // CHECK: apply [[CONVERT]]<UnsafeMutableRawPointer>
   // CHECK: apply [[TAKES_MUTABLE]]
   // CHECK: [[SETTER:%.*]] = function_ref @_TFF18pointer_conversion14inoutToPointerFT_T_sL_10logicalIntSi
   // CHECK: apply [[SETTER]]

--- a/validation-test/stdlib/StringViews.swift
+++ b/validation-test/stdlib/StringViews.swift
@@ -676,7 +676,7 @@ tests.test("UTF8 indexes") {
       for n0 in 0..<8 {
         var u8i1b = u8i1
         for n1 in 0..<8 {
-          expectEqual(u8i0b, u8i1b, sameValue: n0 == n1 ? (==) : (!=))
+          expectEqualTest(u8i0b, u8i1b, sameValue: n0 == n1 ? (==) : (!=))
           if u8i1b == u8.endIndex { break }
           u8i1b = u8.index(u8i1b, offsetBy: 1)
         }

--- a/validation-test/stdlib/UnicodeUTFEncoders.swift
+++ b/validation-test/stdlib/UnicodeUTFEncoders.swift
@@ -122,7 +122,7 @@ final class CodecTest<Codec : TestableUnicodeCodec> {
     default:
       fatalError("decoding failed")
     }
-    expectEqual(
+    expectEqualTest(
       scalar, decoded,
       "Decoding failed: \(asHex(scalar.value)) => " +
       "\(asHex(nsEncoded)) => \(asHex(decoded.value))"
@@ -130,7 +130,7 @@ final class CodecTest<Codec : TestableUnicodeCodec> {
 
     encodeIndex = encodeBuffer.startIndex
     Codec.encode(scalar, into: encodeOutput)
-    expectEqual(
+    expectEqualTest(
       nsEncoded, encodeBuffer[0..<encodeIndex],
       "Decoding failed: \(asHex(nsEncoded)) => " +
         "\(asHex(scalar.value)) => \(asHex(self.encodeBuffer[0]))"


### PR DESCRIPTION
```
[Type System] Handle raw pointer conversion.

As proposed in SE-0107: UnsafeRawPointer.
https://github.com/apple/swift-evolution/blob/master/proposals/0107-unsaferawpointer.md#implicit-argument-conversion

UnsafeMutablePointer<T> -> UnsafeMutableRawPointer
UnsafeMutablePointer<T> -> UnsafeRawPointer
UnsafePointer<T> -> UnsafeRawPointer
UnsafeMutableRawPointer -> UnsafeRawPointer

inout:
&anyVar -> UnsafeMutableRawPointer
&anyVar -> UnsafeRawPointer

array -> UnsafeRawPointer
string -> UnsafeRawPointer

varArray -> UnsafeMutableRawPointer
```
