### PR TITLE
[SourceKit] Add test case for crash triggered in swift::TypeChecker::checkInheritanceClause(…)

### DIFF
--- a/validation-test/IDE/crashers/076-swift-typechecker-checkinheritanceclause.swift
+++ b/validation-test/IDE/crashers/076-swift-typechecker-checkinheritanceclause.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+struct S<e{let e={func d<T{{enum a:e)#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 163
swift-ide-test: /path/to/swift/lib/AST/ArchetypeBuilder.cpp:2103: static swift::Type swift::ArchetypeBuilder::mapTypeOutOfContext(swift::ModuleDecl *, swift::GenericParamList *, swift::Type): Assertion `!type->hasArchetype() && "not fully substituted"' failed.
9  swift-ide-test  0x000000000097ff7f swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 5471
10 swift-ide-test  0x00000000009814d8 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 376
13 swift-ide-test  0x0000000000986d16 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
16 swift-ide-test  0x00000000009effe4 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
17 swift-ide-test  0x0000000000a268cc swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
18 swift-ide-test  0x00000000009752ba swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 778
21 swift-ide-test  0x00000000009eec5a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
22 swift-ide-test  0x00000000009eeabe swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
23 swift-ide-test  0x00000000009acb6f swift::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 655
25 swift-ide-test  0x00000000008eeaa1 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 305
26 swift-ide-test  0x00000000007a6e9d swift::CompilerInstance::performSema() + 3597
27 swift-ide-test  0x000000000074a001 main + 34609
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking expression at [<INPUT-FILE>:3:28 - line:3:38] RangeText="{enum a:e)"
2.  While type-checking 'a' at <INPUT-FILE>:3:29
```
