### PR TITLE
[swiftc (70 vs. 5114)] Add crasher in swift::TypeChecker::resolveWitness(...)

### DIFF
--- a/validation-test/compiler_crashers/28374-swift-typechecker-resolvewitness.swift
+++ b/validation-test/compiler_crashers/28374-swift-typechecker-resolvewitness.swift
@@ -1,0 +1,16 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+protocol a{{
+}associatedtype e:a
+struct A:a{
+struct B
+protocol c
+let c=B
+}class B typealias B


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::resolveWitness(...)`.

Current number of unresolved compiler crashers: 70 (5114 resolved)

Assertion failure in [`lib/Sema/TypeCheckProtocol.cpp (line 1813)`](https://github.com/apple/swift/blob/master/lib/Sema/TypeCheckProtocol.cpp#L1813):

```
Assertion `(archetype != nullptr || isError) && "Should have built archetypes already"' failed.

When executing: swift::Substitution getArchetypeSubstitution(swift::TypeChecker &, swift::DeclContext *, swift::ArchetypeType *, swift::Type)
```

Assertion context:

```
  assert(!resultReplacement->isTypeParameter() && "Can't be dependent");
  SmallVector<ProtocolConformanceRef, 4> conformances;

  bool isError = replacement->is<ErrorType>();
  assert((archetype != nullptr || isError) &&
         "Should have built archetypes already");

  // FIXME: Turn the nullptr check into an assertion
  if (archetype != nullptr) {
    for (auto proto : archetype->getConformsTo()) {
      ProtocolConformance *conformance = nullptr;
```

Stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckProtocol.cpp:1813: swift::Substitution getArchetypeSubstitution(swift::TypeChecker &, swift::DeclContext *, swift::ArchetypeType *, swift::Type): Assertion `(archetype != nullptr || isError) && "Should have built archetypes already"' failed.
11 swift           0x0000000000f13609 swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) + 569
12 swift           0x000000000113001b swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const + 171
14 swift           0x0000000000f05d24 swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 404
15 swift           0x0000000000eaf03c swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 108
17 swift           0x000000000108188b swift::Expr::walk(swift::ASTWalker&) + 27
18 swift           0x0000000000eb0770 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 224
19 swift           0x0000000000eb75ad swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 621
20 swift           0x0000000000eb8760 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 352
21 swift           0x0000000000eb897b swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
23 swift           0x0000000000ec4d1d swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3853
29 swift           0x0000000000ec95b6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
30 swift           0x0000000000eebde2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
31 swift           0x0000000000c735c9 swift::CompilerInstance::performSema() + 3289
33 swift           0x00000000007d9277 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
34 swift           0x00000000007a5278 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28374-swift-typechecker-resolvewitness.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28374-swift-typechecker-resolvewitness-9c17ae.o
1.  While type-checking 'a' at validation-test/compiler_crashers/28374-swift-typechecker-resolvewitness.swift:10:1
2.  While type-checking expression at [validation-test/compiler_crashers/28374-swift-typechecker-resolvewitness.swift:15:7 - line:15:7] RangeText="B"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
