### PR TITLE
Remove the global operator '+' family from UnsafePointer and UnsafeRa…

### DIFF
--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -420,12 +420,15 @@ public struct ${Self}<Pointee>
 
   /// Return `end - self`.
   public func distance(to x: ${Self}) -> Int {
-    return x - self
+    return Int(Builtin.sub_Word(Builtin.ptrtoint_Word(x._rawValue),
+        Builtin.ptrtoint_Word(_rawValue)))
+    / strideof(Pointee.self)
   }
 
   /// Return `self + n`.
   public func advanced(by n: Int) -> ${Self} {
-    return self + n
+    return ${Self}(Builtin.gep_Word(
+        _rawValue, (n &* strideof(Pointee.self))._builtinWordValue))
   }
 }
 
@@ -455,6 +458,8 @@ extension ${Self} : CustomPlaygroundQuickLookable {
   }
 }
 
+/// - Note: Strideable's implementation is potentially less efficient and cannot
+///   handle misaligned pointers.
 @_transparent
 public func == <Pointee>(
   lhs: ${Self}<Pointee>, rhs: ${Self}<Pointee>
@@ -462,44 +467,13 @@ public func == <Pointee>(
   return Bool(Builtin.cmp_eq_RawPointer(lhs._rawValue, rhs._rawValue))
 }
 
+/// - Note: Strideable's implementation is potentially less efficient and cannot
+///   handle misaligned pointers.
+///
+/// - Note: This is an unsigned comparison unlike Strideable's implementation.
 @_transparent
 public func < <Pointee>(lhs: ${Self}<Pointee>, rhs: ${Self}<Pointee>) -> Bool {
   return Bool(Builtin.cmp_ult_RawPointer(lhs._rawValue, rhs._rawValue))
-}
-
-@_transparent
-public func + <Pointee>(lhs: ${Self}<Pointee>, rhs: Int) -> ${Self}<Pointee> {
-  return ${Self}(Builtin.gep_Word(
-    lhs._rawValue, (rhs &* strideof(Pointee.self))._builtinWordValue))
-}
-
-@_transparent
-public func + <Pointee>(lhs: Int,
-           rhs: ${Self}<Pointee>) -> ${Self}<Pointee> {
-  return rhs + lhs
-}
-
-@_transparent
-public func - <Pointee>(lhs: ${Self}<Pointee>, rhs: Int) -> ${Self}<Pointee> {
-  return lhs + -rhs
-}
-
-@_transparent
-public func - <Pointee>(lhs: ${Self}<Pointee>, rhs: ${Self}<Pointee>) -> Int {
-  return
-    Int(Builtin.sub_Word(Builtin.ptrtoint_Word(lhs._rawValue),
-                         Builtin.ptrtoint_Word(rhs._rawValue)))
-    / strideof(Pointee.self)
-}
-
-@_transparent
-public func += <Pointee>(lhs: inout ${Self}<Pointee>, rhs: Int) {
-  lhs = lhs + rhs
-}
-
-@_transparent
-public func -= <Pointee>(lhs: inout ${Self}<Pointee>, rhs: Int) {
-  lhs = lhs - rhs
 }
 
 extension ${Self} {

--- a/stdlib/public/core/UnsafeRawPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawPointer.swift.gyb
@@ -194,7 +194,7 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
       "UnsafeMutableRawPointer.initializeMemory: negative count")
 
     Builtin.bindMemory(_rawValue, count._builtinWordValue, type)
-    var nextPtr = self + index * strideof(T.self)
+    var nextPtr = self + index &* strideof(T.self)
     for _ in 0..<count {
       Builtin.initialize(value, nextPtr._rawValue)
       nextPtr += strideof(T.self)
@@ -430,58 +430,29 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
     return Int(bitPattern: self)
   }
 
-  /// Return `end - self`.
+  /// Return `x - self`.
   public func distance(to x: ${Self}) -> Int {
-    return x - self
+    return Int(Builtin.sub_Word(Builtin.ptrtoint_Word(x._rawValue),
+        Builtin.ptrtoint_Word(_rawValue)))
   }
 
   /// Return `self + n`.
   public func advanced(by n: Int) -> ${Self} {
-    return self + n
+    return ${Self}(Builtin.gep_Word(_rawValue, n._builtinWordValue))
   }
 }
 
+/// - Note: This may be more efficient than Strideable's implementation
+///   calling ${Self}.distance().
 @_transparent
 public func == (lhs: ${Self}, rhs: ${Self}) -> Bool {
   return Bool(Builtin.cmp_eq_RawPointer(lhs._rawValue, rhs._rawValue))
 }
 
+/// - Note: This is an unsigned comparison unlike Strideable's implementation.
 @_transparent
 public func < (lhs: ${Self}, rhs: ${Self}) -> Bool {
   return Bool(Builtin.cmp_ult_RawPointer(lhs._rawValue, rhs._rawValue))
-}
-
-@_transparent
-public func + (lhs: ${Self}, rhs: Int) -> ${Self} {
-  return ${Self}(Builtin.gep_Word(
-      lhs._rawValue, rhs._builtinWordValue))
-}
-
-@_transparent
-public func + (lhs: Int, rhs: ${Self}) -> ${Self} {
-  return rhs + lhs
-}
-
-@_transparent
-public func - (lhs: ${Self}, rhs: Int) -> ${Self} {
-  return lhs + -rhs
-}
-
-@_transparent
-public func - (lhs: ${Self}, rhs: ${Self}) -> Int {
-  return
-    Int(Builtin.sub_Word(Builtin.ptrtoint_Word(lhs._rawValue),
-                         Builtin.ptrtoint_Word(rhs._rawValue)))
-}
-
-@_transparent
-public func += (lhs: inout ${Self}, rhs: Int) {
-  lhs = lhs + rhs
-}
-
-@_transparent
-public func -= (lhs: inout ${Self}, rhs: Int) {
-  lhs = lhs - rhs
 }
 
 extension Unsafe${Mutable}RawPointer : CustomDebugStringConvertible {

--- a/test/1_stdlib/UnicodeScalarDiagnostics.swift
+++ b/test/1_stdlib/UnicodeScalarDiagnostics.swift
@@ -21,12 +21,12 @@ func test_UnicodeScalarDoesNotImplementArithmetic(_ us: UnicodeScalar, i: Int) {
   let b4 = us / us // expected-error {{binary operator '/' cannot be applied to two 'UnicodeScalar' operands}}
   // expected-note @-1 {{overloads for '/' exist with these partially matching parameter lists:}}
 
-  let c1 = us + i // expected-error {{binary operator '+' cannot be applied to operands of type 'UnicodeScalar' and 'Int'}} expected-note{{overloads for '+' exist with these partially matching parameter lists:}}
-  let c2 = us - i // expected-error {{binary operator '-' cannot be applied to operands of type 'UnicodeScalar' and 'Int'}} expected-note{{overloads for '-' exist with these partially matching parameter lists:}}
+  let c1 = us + i // expected-error {{binary operator '+' cannot be applied to operands of type 'UnicodeScalar' and 'Int'}} expected-note{{expected an argument list of type '(Int, Int)'}}
+  let c2 = us - i // expected-error {{binary operator '-' cannot be applied to operands of type 'UnicodeScalar' and 'Int'}} expected-note{{expected an argument list of type '(Int, Int)'}}
   let c3 = us * i // expected-error {{binary operator '*' cannot be applied to operands of type 'UnicodeScalar' and 'Int'}} expected-note {{expected an argument list of type '(Int, Int)'}}
   let c4 = us / i // expected-error {{binary operator '/' cannot be applied to operands of type 'UnicodeScalar' and 'Int'}} expected-note {{expected an argument list of type '(Int, Int)'}}
 
-  let d1 = i + us // expected-error {{binary operator '+' cannot be applied to operands of type 'Int' and 'UnicodeScalar'}} expected-note{{overloads for '+' exist with these partially matching parameter lists:}}
+  let d1 = i + us // expected-error {{binary operator '+' cannot be applied to operands of type 'Int' and 'UnicodeScalar'}} expected-note{{expected an argument list of type '(Int, Int)'}}
   let d2 = i - us // expected-error {{binary operator '-' cannot be applied to operands of type 'Int' and 'UnicodeScalar'}} expected-note {{expected an argument list of type '(Int, Int)'}}
   let d3 = i * us // expected-error {{binary operator '*' cannot be applied to operands of type 'Int' and 'UnicodeScalar'}} expected-note {{expected an argument list of type '(Int, Int)'}}
   let d4 = i / us // expected-error {{binary operator '/' cannot be applied to operands of type 'Int' and 'UnicodeScalar'}} expected-note {{expected an argument list of type '(Int, Int)'}}

--- a/test/1_stdlib/UnsafePointer.swift.gyb
+++ b/test/1_stdlib/UnsafePointer.swift.gyb
@@ -291,7 +291,7 @@ func checkPtr(
   }
 }
 
-UnsafeMutablePointerTestSuite.test("moveAssign:from") {
+UnsafeMutablePointerTestSuite.test("moveAssign:from:") {
   let check = checkPtr(UnsafeMutablePointer.moveAssign, true)
   check(Check.Disjoint)
   // This check relies on _debugPrecondition() so will only trigger in -Onone mode.
@@ -301,7 +301,7 @@ UnsafeMutablePointerTestSuite.test("moveAssign:from") {
   }
 }
 
-UnsafeMutablePointerTestSuite.test("moveAssign:from.Right") {
+UnsafeMutablePointerTestSuite.test("moveAssign:from:.Right") {
   let check = checkPtr(UnsafeMutablePointer.moveAssign, true)
   // This check relies on _debugPrecondition() so will only trigger in -Onone mode.
   if _isDebugAssertConfiguration() {
@@ -310,21 +310,21 @@ UnsafeMutablePointerTestSuite.test("moveAssign:from.Right") {
   }
 }
 
-UnsafeMutablePointerTestSuite.test("assign:from") {
+UnsafeMutablePointerTestSuite.test("assign:from:") {
   let check = checkPtr(UnsafeMutablePointer.assign, true)
   check(Check.LeftOverlap)
   check(Check.Disjoint)
   check(Check.RightOverlap)
 }
 
-UnsafeMutablePointerTestSuite.test("moveInitialize:from") {
+UnsafeMutablePointerTestSuite.test("moveInitialize:from:") {
   let check = checkPtr(UnsafeMutablePointer.moveInitialize, false)
   check(Check.LeftOverlap)
   check(Check.Disjoint)
   check(Check.RightOverlap)
 }
 
-UnsafeMutablePointerTestSuite.test("initialize:from") {
+UnsafeMutablePointerTestSuite.test("initialize:from:") {
   let check = checkPtr(UnsafeMutablePointer.initialize(from:count:), false)
   check(Check.Disjoint)
   // This check relies on _debugPrecondition() so will only trigger in -Onone mode.
@@ -334,7 +334,7 @@ UnsafeMutablePointerTestSuite.test("initialize:from") {
   }
 }
 
-UnsafeMutablePointerTestSuite.test("initialize:from.Right") {
+UnsafeMutablePointerTestSuite.test("initialize:from:.Right") {
   let check = checkPtr(UnsafeMutablePointer.initialize(from:count:), false)
   // This check relies on _debugPrecondition() so will only trigger in -Onone mode.
   if _isDebugAssertConfiguration() {
@@ -343,7 +343,7 @@ UnsafeMutablePointerTestSuite.test("initialize:from.Right") {
   }
 }
 
-UnsafeMutablePointerTestSuite.test("initialize:from/immutable") {
+UnsafeMutablePointerTestSuite.test("initialize:from:/immutable") {
   var ptr = UnsafeMutablePointer<Missile>.allocate(capacity: 3)
   defer {
     ptr.deinitialize(count: 3)

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -260,12 +260,12 @@ func rdar19770981(_ s: String, ns: NSString) {
 
 // <rdar://problem/19831919> Fixit offers as! conversions that are known to always fail
 func rdar19831919() {
-  var s1 = 1 + "str"; // expected-error{{binary operator '+' cannot be applied to operands of type 'Int' and 'String'}} expected-note{{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (Int, UnsafeMutableRawPointer), (Int, UnsafeRawPointer), (String, String), (Int, UnsafeMutablePointer<Pointee>), (Int, UnsafePointer<Pointee>)}}
+  var s1 = 1 + "str"; // expected-error{{binary operator '+' cannot be applied to operands of type 'Int' and 'String'}} expected-note{{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (String, String)}}
 }
 
 // <rdar://problem/19831698> Incorrect 'as' fixits offered for invalid literal expressions
 func rdar19831698() {
-  var v70 = true + 1 // expected-error{{binary operator '+' cannot be applied to operands of type 'Bool' and 'Int'}} expected-note {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (UnsafeMutableRawPointer, Int), (UnsafeRawPointer, Int), (UnsafeMutablePointer<Pointee>, Int), (UnsafePointer<Pointee>, Int)}}
+  var v70 = true + 1 // expected-error{{binary operator '+' cannot be applied to operands of type 'Bool' and 'Int'}} expected-note {{expected an argument list of type '(Int, Int)'}}
   var v71 = true + 1.0 // expected-error{{binary operator '+' cannot be applied to operands of type 'Bool' and 'Double'}}
 // expected-note@-1{{overloads for '+'}}
   var v72 = true + true // expected-error{{binary operator '+' cannot be applied to two 'Bool' operands}}

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -94,7 +94,7 @@ func r22162441(_ lines: [String]) {
 func testMap() {
   let a = 42
   [1,a].map { $0 + 1.0 } // expected-error {{binary operator '+' cannot be applied to operands of type 'Int' and 'Double'}}
-  // expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (Double, Double), (Int, UnsafeMutableRawPointer), (Int, UnsafeRawPointer), (Int, UnsafeMutablePointer<Pointee>), (Int, UnsafePointer<Pointee>)}}
+  // expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (Double, Double)}}
 }
 
 // <rdar://problem/22414757> "UnresolvedDot" "in wrong phase" assertion from verifier

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -186,7 +186,7 @@ func recArea(_ h: Int, w : Int) {
 // <rdar://problem/17224804> QoI: Error In Ternary Condition is Wrong
 func r17224804(_ monthNumber : Int) {
   // expected-error @+2 {{binary operator '+' cannot be applied to operands of type 'String' and 'Int'}}
-  // expected-note @+1 {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (UnsafeMutableRawPointer, Int), (UnsafeRawPointer, Int), (String, String), (UnsafeMutablePointer<Pointee>, Int), (UnsafePointer<Pointee>, Int)}}
+  // expected-note @+1 {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (String, String)}}
   let monthString = (monthNumber <= 9) ? ("0" + monthNumber) : String(monthNumber)
 }
 
@@ -534,13 +534,13 @@ func testTypeSugar(_ a : Int) {
 
   let x = Stride(a)
   x+"foo"            // expected-error {{binary operator '+' cannot be applied to operands of type 'Stride' (aka 'Int') and 'String'}}
-// expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (Int, UnsafeMutableRawPointer), (Int, UnsafeRawPointer), (String, String), (Int, UnsafeMutablePointer<Pointee>), (Int, UnsafePointer<Pointee>)}}
+// expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (String, String)}}
 }
 
 // <rdar://problem/21974772> SegFault in FailureDiagnosis::visitInOutExpr
 func r21974772(_ y : Int) {
   let x = &(1.0 + y)  // expected-error {{binary operator '+' cannot be applied to operands of type 'Double' and 'Int'}}
-   //expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (Double, Double), (UnsafeMutableRawPointer, Int), (UnsafeRawPointer, Int), (UnsafeMutablePointer<Pointee>, Int), (UnsafePointer<Pointee>, Int)}}
+   //expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (Double, Double)}}
 }
 
 // <rdar://problem/22020088> QoI: missing member diagnostic on optional gives worse error message than existential/bound generic/etc


### PR DESCRIPTION
…wPointer.

Generic versions of these functions are provided by Strideable.

This is required for SE-0107: UnsafeRawPointer. Otherwise, the presence
of non-generic operator overloads will conflict with existing operators
on String.
