### PR TITLE
[SourceKit] Add test case for crash triggered in swift::ArchetypeBuilder::PotentialArchetype::getType(…)

### DIFF
--- a/validation-test/IDE/crashers/077-swift-archetypebuilder-potentialarchetype-gettype.swift
+++ b/validation-test/IDE/crashers/077-swift-archetypebuilder-potentialarchetype-gettype.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+o{class d<a{let e{protocol b{func a<e:d let s=ty#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 174
4  swift-ide-test  0x0000000000b3b23c swift::ArchetypeBuilder::PotentialArchetype::getType(swift::ArchetypeBuilder&) + 28
6  swift-ide-test  0x0000000000c78e43 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 35
7  swift-ide-test  0x0000000000c790de swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 702
8  swift-ide-test  0x0000000000b3b4ba swift::ArchetypeBuilder::PotentialArchetype::getType(swift::ArchetypeBuilder&) + 666
9  swift-ide-test  0x0000000000b40715 swift::ArchetypeBuilder::getArchetype(swift::GenericTypeParamDecl*) + 53
10 swift-ide-test  0x00000000009c174f swift::TypeChecker::finalizeGenericParamList(swift::ArchetypeBuilder&, swift::GenericParamList*, swift::DeclContext*) + 191
13 swift-ide-test  0x0000000000981713 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 947
18 swift-ide-test  0x0000000000c3e2d5 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 1189
19 swift-ide-test  0x00000000009c5442 swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::Type, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) + 290
20 swift-ide-test  0x000000000096db59 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 3865
22 swift-ide-test  0x0000000000bba3ab swift::Expr::walk(swift::ASTWalker&) + 27
23 swift-ide-test  0x000000000096e3e0 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 224
24 swift-ide-test  0x000000000097570c swift::TypeChecker::getTypeOfExpressionWithoutApplying(swift::Expr*&, swift::DeclContext*, swift::ConcreteDeclRef&, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*) + 316
26 swift-ide-test  0x00000000009ac125 swift::getTypeOfCompletionContextExpr(swift::ASTContext&, swift::DeclContext*, swift::CompletionTypeCheckKind, swift::Expr*&, swift::ConcreteDeclRef&) + 693
38 swift-ide-test  0x0000000000bba7f4 swift::Decl::walk(swift::ASTWalker&) + 20
39 swift-ide-test  0x0000000000c52b0e swift::SourceFile::walk(swift::ASTWalker&) + 174
40 swift-ide-test  0x0000000000c51c4f swift::ModuleDecl::walk(swift::ASTWalker&) + 79
41 swift-ide-test  0x0000000000c28e2b swift::DeclContext::walkContext(swift::ASTWalker&) + 187
42 swift-ide-test  0x00000000008ee9f8 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 136
43 swift-ide-test  0x00000000007a6e9d swift::CompilerInstance::performSema() + 3597
44 swift-ide-test  0x000000000074a001 main + 34609
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl declaration 0x4ebffb0 at <INPUT-FILE>:3:1
2.  While type-checking expression at [<INPUT-FILE>:3:47 - line:3:47] RangeText="t"
3.  While type-checking 'a' at <INPUT-FILE>:3:30
```
