### PR TITLE
[swiftc (71 vs. 5114)] Add crasher in swift::TypeChecker::lookupMemberType(...)

### DIFF
--- a/validation-test/compiler_crashers/28375-swift-typechecker-lookupmembertype.swift
+++ b/validation-test/compiler_crashers/28375-swift-typechecker-lookupmembertype.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+{struct S<T{var:e=d func g:e.a
+typealias e=T.Type


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::lookupMemberType(...)`.

Current number of unresolved compiler crashers: 71 (5114 resolved)

Assertion failure in [`lib/Sema/TypeCheckNameLookup.cpp (line 328)`](https://github.com/apple/swift/blob/master/lib/Sema/TypeCheckNameLookup.cpp#L328):

```
Assertion `!type->isTypeParameter()' failed.

When executing: swift::LookupTypeResult swift::TypeChecker::lookupMemberType(swift::DeclContext *, swift::Type, swift::Identifier, NameLookupOptions)
```

Assertion context:

```
  // Look through the metatype.
  if (auto metaT = type->getAs<AnyMetatypeType>())
    type = metaT->getInstanceType();

  // Callers must cope with dependent types directly.
  assert(!type->isTypeParameter());

  // Look for members with the given name.
  SmallVector<ValueDecl *, 4> decls;
  NLOptions subOptions = NL_QualifiedDefault | NL_OnlyTypes;

```

Stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckNameLookup.cpp:328: swift::LookupTypeResult swift::TypeChecker::lookupMemberType(swift::DeclContext *, swift::Type, swift::Identifier, NameLookupOptions): Assertion `!type->isTypeParameter()' failed.
8  swift           0x0000000000f06e74 swift::TypeChecker::lookupMemberType(swift::DeclContext*, swift::Type, swift::Identifier, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 1572
10 swift           0x0000000000f3800e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
12 swift           0x0000000000f38f64 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
13 swift           0x0000000000f37f00 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
15 swift           0x0000000000f01b9e swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 94
18 swift           0x0000000000ec41c3 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 947
23 swift           0x00000000011057b5 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 1189
24 swift           0x0000000000f07102 swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::Type, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) + 290
25 swift           0x0000000000eafee9 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 3865
27 swift           0x000000000108188b swift::Expr::walk(swift::ASTWalker&) + 27
28 swift           0x0000000000eb0770 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 224
29 swift           0x0000000000eb75ad swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 621
30 swift           0x0000000000eb8760 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 352
31 swift           0x0000000000eb897b swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
35 swift           0x0000000000ec95b6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
38 swift           0x0000000000f31f44 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
39 swift           0x0000000000f5da0c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
40 swift           0x0000000000eb764a swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 778
42 swift           0x0000000000f32086 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
43 swift           0x0000000000eebe4d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
44 swift           0x0000000000c735c9 swift::CompilerInstance::performSema() + 3289
46 swift           0x00000000007d9277 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
47 swift           0x00000000007a5278 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28375-swift-typechecker-lookupmembertype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28375-swift-typechecker-lookupmembertype-f72c36.o
1.  While type-checking expression at [validation-test/compiler_crashers/28375-swift-typechecker-lookupmembertype.swift:10:1 - line:11:15] RangeText="{struct S<T{var:e=d func g:e.a
2.  While type-checking 'S' at validation-test/compiler_crashers/28375-swift-typechecker-lookupmembertype.swift:10:2
3.  While type-checking expression at [validation-test/compiler_crashers/28375-swift-typechecker-lookupmembertype.swift:10:19 - line:10:19] RangeText="d"
4.  While type-checking 'g' at validation-test/compiler_crashers/28375-swift-typechecker-lookupmembertype.swift:10:21
5.  While resolving type e.a at [validation-test/compiler_crashers/28375-swift-typechecker-lookupmembertype.swift:10:28 - line:10:30] RangeText="e.a"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
