### PR TITLE
Split 'fileprivate' and 'private', but give them the same behavior for now

### DIFF
--- a/include/swift/AST/AttrKind.h
+++ b/include/swift/AST/AttrKind.h
@@ -46,10 +46,13 @@ enum class UnaryOperatorKind : uint8_t {
 };
 
 /// Access control levels.
-// These are used in diagnostics, so please do not reorder existing values.
+// These are used in diagnostics and with < and similar operations,
+// so please do not reorder existing values.
 enum class Accessibility : uint8_t {
-  /// Private access is limited to the current file.
+  /// Private access is limited to the current scope.
   Private = 0,
+  /// File-private access is limited to the current file.
+  FilePrivate,
   /// Internal access is limited to the current module.
   Internal,
   /// Public access is not limited.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -108,12 +108,14 @@ ERROR(could_not_use_member_on_existential,none,
       (Type, DeclName))
 
 ERROR(candidate_inaccessible,none,
-      "%0 is inaccessible due to '%select{private|internal|PUBLIC}1' "
-      "protection level", (DeclName, Accessibility))
+      "%0 is inaccessible due to "
+      "'%select{private|fileprivate|internal|PUBLIC}1' protection level",
+      (DeclName, Accessibility))
 
 ERROR(init_candidate_inaccessible,none,
-    "%0 initializer is inaccessible due to '%select{private|internal|PUBLIC}1' "
-      "protection level", (Type, Accessibility))
+      "%0 initializer is inaccessible due to "
+      "'%select{private|fileprivate|internal|PUBLIC}1' protection level",
+      (Type, Accessibility))
 
 
 ERROR(cannot_pass_rvalue_mutating_subelement,none,
@@ -940,30 +942,31 @@ ERROR(attr_methods_only,none,
 ERROR(access_control_in_protocol,none,
       "%0 modifier cannot be used in protocols", (DeclAttribute))
 ERROR(access_control_setter,none,
-      "'%select{private|internal|public}0(set)' modifier can only be applied "
-      "to variables and subscripts",
+      "'%select{private|fileprivate|internal|public}0(set)' modifier can only "
+      "be applied to variables and subscripts",
       (Accessibility))
 ERROR(access_control_setter_read_only,none,
-      "'%select{private|internal|public}0(set)' modifier cannot be applied to "
-      "%select{constants|read-only variables|read-only properties"
+      "'%select{private|fileprivate|internal|public}0(set)' modifier cannot be "
+      "applied to %select{constants|read-only variables|read-only properties"
       "|read-only subscripts}1",
       (Accessibility, unsigned))
 ERROR(access_control_setter_more,none,
-      "%select{private|internal|PUBLIC}0 "
+      "%select{private|fileprivate|internal|PUBLIC}0 "
       "%select{variable|property|subscript}1 cannot have "
-      "%select{PRIVATE|an internal|a public}2 setter",
+      "%select{PRIVATE|a fileprivate|an internal|a public}2 setter",
       (Accessibility, unsigned, Accessibility))
 WARNING(access_control_ext_member_more,none,
-    "declaring %select{PRIVATE|an internal|a public}0 %1 in "
-    "%select{a private|an internal|PUBLIC}2 extension",
+    "declaring %select{PRIVATE|a fileprivate|an internal|a public}0 %1 in "
+    "%select{a private|a fileprivate|an internal|PUBLIC}2 extension",
     (Accessibility, DescriptiveDeclKind, Accessibility))
 ERROR(access_control_ext_requirement_member_more,none,
-    "cannot declare %select{PRIVATE|an internal|a public}0 %1 in "
-    "an extension with %select{private|internal|PUBLIC}2 requirements",
+    "cannot declare %select{PRIVATE|a fileprivate|an internal|a public}0 %1 "
+    "in an extension with %select{private|fileprivate|internal|PUBLIC}2 "
+    "requirements",
     (Accessibility, DescriptiveDeclKind, Accessibility))
 ERROR(access_control_extension_more,none,
-      "extension of %select{private|internal|PUBLIC}0 %1 cannot be "
-      "declared %select{PRIVATE|internal|public}2",
+      "extension of %select{private|fileprivate|internal|PUBLIC}0 %1 cannot "
+      "be declared %select{PRIVATE|fileprivate|internal|public}2",
       (Accessibility, DescriptiveDeclKind, Accessibility))
 
 ERROR(invalid_decl_attribute_simple,none,
@@ -1051,15 +1054,17 @@ ERROR(static_requires_initializer,none,
       "expression or getter/setter specifier", (StaticSpellingKind))
 ERROR(pattern_type_access,none,
       "%select{%select{variable|constant}0|property}1 "
-      "%select{must be declared %select{private|internal|PUBLIC}4"
-      "|cannot be declared %select{PRIVATE|internal|public}3}2 because its "
-      "type uses %select{a private|an internal|PUBLIC}4 type",
+      "%select{must be declared %select{private|fileprivate|internal|PUBLIC}4"
+      "|cannot be declared %select{PRIVATE|fileprivate|internal|public}3}2 "
+      "because its type uses "
+      "%select{a private|a fileprivate|an internal|PUBLIC}4 type",
       (bool, bool, bool, Accessibility, Accessibility))
 ERROR(pattern_type_access_inferred,none,
       "%select{%select{variable|constant}0|property}1 "
-      "%select{must be declared %select{private|internal|PUBLIC}4"
-      "|cannot be declared %select{PRIVATE|internal|public}3}2 because its "
-      "type %5 uses %select{a private|an internal|PUBLIC}4 type",
+      "%select{must be declared %select{private|fileprivate|internal|PUBLIC}4"
+      "|cannot be declared %select{PRIVATE|fileprivate|internal|public}3}2 "
+      "because its type %5 uses "
+      "%select{a private|a fileprivate|an internal|PUBLIC}4 type",
       (bool, bool, bool, Accessibility, Accessibility, Type))
 ERROR(pattern_binds_no_variables,none,
       "%select{property|global variable}0 declaration does not bind any "
@@ -1094,26 +1099,29 @@ ERROR(unsupported_nested_protocol,none,
 ERROR(circular_type_alias,none,
       "type alias %0 circularly references itself", (Identifier))
 ERROR(type_alias_underlying_type_access,none,
-      "type alias %select{must be declared %select{private|internal|PUBLIC}2"
-      "|cannot be declared %select{PRIVATE|internal|public}1}0 because its "
-      "underlying type uses %select{a private|an internal|PUBLIC}2 type",
+      "type alias %select{must be declared "
+      "%select{private|fileprivate|internal|PUBLIC}2"
+      "|cannot be declared %select{PRIVATE|fileprivate|internal|public}1}0 "
+      "because its underlying type uses "
+      "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
       (bool, Accessibility, Accessibility))
 
 // Subscripts
 ERROR(subscript_type_access,none,
-      "subscript %select{must be declared %select{private|internal|PUBLIC}2"
-      "|cannot be declared %select{PRIVATE|internal|public}1}0 because its "
-      "%select{index|element type}3 uses "
-      "%select{a private|an internal|PUBLIC}2 type",
+      "subscript %select{must be declared "
+      "%select{private|fileprivate|internal|PUBLIC}2"
+      "|cannot be declared %select{PRIVATE|fileprivate|internal|public}1}0 "
+      "because its %select{index|element type}3 uses "
+      "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
       (bool, Accessibility, Accessibility, bool))
 
 // Functions
 ERROR(function_type_access,none,
       "%select{function|method|initializer}3 "
-      "%select{must be declared %select{private|internal|PUBLIC}2"
-      "|cannot be declared %select{PRIVATE|internal|public}1}0 because its "
-      "%select{parameter|result}4 uses "
-      "%select{a private|an internal|PUBLIC}2 type",
+      "%select{must be declared %select{private|fileprivate|internal|PUBLIC}2"
+      "|cannot be declared %select{PRIVATE|fileprivate|internal|public}1}0 "
+      "because its %select{parameter|result}4 uses "
+      "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
       (bool, Accessibility, Accessibility, unsigned, bool))
 WARNING(non_trailing_closure_before_default_args,none,
         "closure parameter prior to parameters with default arguments will "
@@ -1220,8 +1228,9 @@ ERROR(witness_requires_dynamic_self,none,
 ERROR(witness_not_accessible_proto,none,
       "%select{initializer %1|method %1|%select{|setter for }2property %1"
       "|subscript%select{| setter}2}0 must be declared "
-      "%select{PRIVATE|internal|public}3 because it matches a requirement "
-      "in %select{PRIVATE|internal|public}3 protocol %4",
+      "%select{PRIVATE|fileprivate|internal|public}3 because it matches a "
+      "requirement in %select{PRIVATE|fileprivate|internal|public}3 protocol "
+      "%4",
       (RequirementKind, DeclName, bool, Accessibility, DeclName))
 ERROR(witness_not_accessible_type,none,
       "%select{initializer %1|method %1|%select{|setter for }2property %1"
@@ -1229,8 +1238,9 @@ ERROR(witness_not_accessible_type,none,
       "type because it matches a requirement in protocol %4",
       (RequirementKind, DeclName, bool, Accessibility, DeclName))
 ERROR(type_witness_not_accessible_proto,none,
-      "%0 %1 must be declared %select{PRIVATE|internal|public}2 because it "
-      "matches a requirement in %select{PRIVATE|internal|public}2 protocol %3",
+      "%0 %1 must be declared %select{PRIVATE|fileprivate|internal|public}2 "
+      "because it matches a requirement in "
+      "%select{PRIVATE|fileprivate|internal|public}2 protocol %3",
       (DescriptiveDeclKind, DeclName, Accessibility, DeclName))
 ERROR(type_witness_not_accessible_type,none,
       "%0 %1 must be as accessible as its enclosing type because it "
@@ -1238,10 +1248,10 @@ ERROR(type_witness_not_accessible_type,none,
       (DescriptiveDeclKind, DeclName, Accessibility, DeclName))
 
 ERROR(protocol_refine_access,none,
-      "%select{protocol must be declared %select{private|internal|PUBLIC}2 "
-      "because it refines"
-      "|%select{PRIVATE|internal|public}1 protocol cannot refine}0 "
-      "%select{a private|an internal|PUBLIC}2 protocol",
+      "%select{protocol must be declared "
+      "%select{private|fileprivate|internal|PUBLIC}2 because it refines"
+      "|%select{PRIVATE|fileprivate|internal|public}1 protocol cannot "
+      "refine}0 %select{a private|a fileprivate|an internal|PUBLIC}2 protocol",
       (bool, Accessibility, Accessibility))
 ERROR(protocol_property_must_be_computed_var,none,
       "immutable property requirement must be declared as 'var' with a "
@@ -1270,8 +1280,9 @@ NOTE(default_associated_type_req_fail,none,
      "does not conform to %3",
      (Type, DeclName, Type, Type))
 ERROR(associated_type_access,none,
-      "associated type in %select{PRIVATE|an internal|a public}0 protocol "
-      "uses %select{a private|an internal|PUBLIC}1 type in its "
+      "associated type in "
+      "%select{PRIVATE|a fileprivate|an internal|a public}0 protocol uses "
+      "%select{a private|a fileprivate|an internal|PUBLIC}1 type in its "
       "%select{default definition|requirement}2 ",
       (Accessibility, Accessibility, unsigned))
 
@@ -1373,7 +1384,7 @@ NOTE(optional_req_near_match_move,none,
 NOTE(optional_req_near_match_nonobjc,none,
      "add '@nonobjc' to silence this %select{warning|error}0", (bool))
 NOTE(optional_req_near_match_accessibility,none,
-     "make %0 %select{ERROR|private|private or internal}1 to silence this "
+     "make %0 %select{ERROR|private|private|non-public}1 to silence this "
      "warning", (DeclName, Accessibility))
 
 // Protocols and existentials
@@ -1425,10 +1436,11 @@ ERROR(requires_generic_param_same_type_does_not_conform,none,
       (Type, Identifier))
 
 ERROR(generic_param_access,none,
-      "%0 %select{must be declared %select{private|internal|PUBLIC}3"
-      "|cannot be declared %select{PRIVATE|internal|public}2}1 because its "
-      "generic %select{parameter|requirement}4 uses "
-      "%select{a private|an internal|PUBLIC}3 type",
+      "%0 %select{must be declared "
+      "%select{private|fileprivate|internal|PUBLIC}3"
+      "|cannot be declared %select{PRIVATE|fileprivate|internal|public}2}1 "
+      "because its generic %select{parameter|requirement}4 uses "
+      "%select{a private|a fileprivate|an internal|PUBLIC}3 type",
       (DescriptiveDeclKind, bool, Accessibility, Accessibility, bool))
 
 ERROR(override_multiple_decls_base,none,
@@ -1607,8 +1619,8 @@ ERROR(inheritance_from_objc_runtime_visible_class,none,
 
 // Enums
 ERROR(enum_case_access,none,
-      "enum case in %select{PRIVATE|an internal|a public}0 enum uses "
-      "%select{a private|an internal|PUBLIC}1 type",
+      "enum case in %select{PRIVATE|a fileprivate|an internal|a public}0 enum "
+      "uses %select{a private|a fileprivate|an internal|PUBLIC}1 type",
       (Accessibility, Accessibility))
 ERROR(enum_stored_property,none,
       "enums may not contain stored properties", ())
@@ -1627,9 +1639,11 @@ ERROR(enum_raw_type_not_equatable,none,
       "RawRepresentable 'init' cannot be synthesized because raw type %0 is not "
       "Equatable", (Type))
 ERROR(enum_raw_type_access,none,
-      "enum %select{must be declared %select{private|internal|PUBLIC}2"
-      "|cannot be declared %select{PRIVATE|internal|public}1}0 because its "
-      "raw type uses %select{a private|an internal|PUBLIC}2 type",
+      "enum %select{must be declared "
+      "%select{private|fileprivate|internal|PUBLIC}2"
+      "|cannot be declared %select{PRIVATE|fileprivate|internal|public}1}0 "
+      "because its raw type uses "
+      "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
       (bool, Accessibility, Accessibility))
 
 NOTE(enum_here,none,
@@ -2538,9 +2552,11 @@ ERROR(self_in_nominal,none,
       "'Self' is only available in a protocol or as the result of a "
       "method in a class; did you mean %0?", (Identifier))
 ERROR(class_super_access,none,
-      "class %select{must be declared %select{private|internal|PUBLIC}2"
-      "|cannot be declared %select{PRIVATE|internal|public}1}0 because its "
-      "superclass is %select{private|internal|PUBLIC}2",
+      "class %select{must be declared "
+      "%select{private|fileprivate|internal|PUBLIC}2"
+      "|cannot be declared %select{PRIVATE|fileprivate|internal|public}1}0 "
+      "because its superclass is "
+      "%select{private|fileprivate|internal|PUBLIC}2",
       (bool, Accessibility, Accessibility))
 ERROR(dot_protocol_on_non_existential,none,
       "cannot use 'Protocol' with non-protocol type %0", (Type))

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -150,6 +150,10 @@ namespace swift {
     /// new enough?
     bool EnableTargetOSChecking = true;
 
+    /// Should 'private' use Swift 3's lexical scoping, or the Swift 2 behavior
+    /// of 'fileprivate'?
+    bool EnableSwift3Private = true;
+
     /// Whether to use the import as member inference system
     ///
     /// When importing a global, try to infer whether we can import it as a

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -53,7 +53,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 256; // Last change: remove noreturn bit
+const uint16_t VERSION_MINOR = 257; // Last change: private/fileprivate
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;
@@ -287,6 +287,7 @@ using LibraryKindField = BCFixed<1>;
 // VERSION_MAJOR.
 enum class AccessibilityKind : uint8_t {
   Private = 0,
+  FilePrivate,
   Internal,
   Public,
 };

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -570,6 +570,9 @@ namespace {
         case Accessibility::Private:
           OS << "private";
           break;
+        case Accessibility::FilePrivate:
+          OS << "fileprivate";
+          break;
         case Accessibility::Internal:
           OS << "internal";
           break;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1135,6 +1135,9 @@ class PrintAST : public ASTVisitor<PrintAST> {
     case Accessibility::Private:
       Printer << tok::kw_private;
       break;
+    case Accessibility::FilePrivate:
+      Printer << tok::kw_fileprivate;
+      break;
     case Accessibility::Internal:
       if (!Options.PrintInternalAccessibilityKeyword)
         return;

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -689,6 +689,21 @@ struct ASTNodeBase {};
       if (D->hasType())
         verifyChecked(D->getType());
 
+      if (D->hasAccessibility()) {
+        PrettyStackTraceDecl debugStack("verifying access", D);
+        if (D->getFormalAccessScope() == nullptr &&
+            D->getFormalAccess() != Accessibility::Public) {
+          Out << "non-public decl has no formal access scope\n";
+          D->dump(Out);
+          abort();
+        }
+        if (D->getEffectiveAccess() == Accessibility::Private) {
+          Out << "effective access should use 'fileprivate' for 'private'\n";
+          D->dump(Out);
+          abort();
+        }
+      }
+
       if (auto Overridden = D->getOverriddenDecl()) {
         if (D->getDeclContext() == Overridden->getDeclContext()) {
           PrettyStackTraceDecl debugStack("verifying overridden", D);

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -547,6 +547,8 @@ StringRef DeclAttribute::getAttrName() const {
     switch (cast<AbstractAccessibilityAttr>(this)->getAccess()) {
     case Accessibility::Private:
       return "private";
+    case Accessibility::FilePrivate:
+      return "fileprivate";
     case Accessibility::Internal:
       return "internal";
     case Accessibility::Public:

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1822,7 +1822,10 @@ Accessibility ValueDecl::getEffectiveAccess() const {
     if (isInternalDeclEffectivelyPublic(this))
       effectiveAccess = Accessibility::Public;
     break;
+  case Accessibility::FilePrivate:
+    break;
   case Accessibility::Private:
+    effectiveAccess = Accessibility::FilePrivate;
     break;
   }
 
@@ -1841,7 +1844,7 @@ Accessibility ValueDecl::getEffectiveAccess() const {
     }
 
   } else if (getDeclContext()->isLocalContext()) {
-    effectiveAccess = Accessibility::Private;
+    effectiveAccess = Accessibility::FilePrivate;
   }
 
   return effectiveAccess;
@@ -1887,6 +1890,8 @@ ValueDecl::getFormalAccessScope(const DeclContext *useDC) const {
 
   switch (access) {
   case Accessibility::Private:
+    // TODO: Implement 'private'
+  case Accessibility::FilePrivate:
     assert(result->isModuleScopeContext());
     return result;
   case Accessibility::Internal:

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -488,14 +488,14 @@ DeclContext::isCascadingContextForLookup(bool functionsAreNonCascading) const {
       return false;
     auto *AFD = cast<AbstractFunctionDecl>(this);
     if (AFD->hasAccessibility())
-      return AFD->getFormalAccess() > Accessibility::Private;
+      return AFD->getFormalAccess() > Accessibility::FilePrivate;
     break;
   }
 
   case DeclContextKind::SubscriptDecl: {
     auto *SD = cast<SubscriptDecl>(this);
     if (SD->hasAccessibility())
-      return SD->getFormalAccess() > Accessibility::Private;
+      return SD->getFormalAccess() > Accessibility::FilePrivate;
     break;
   }
       
@@ -506,17 +506,17 @@ DeclContext::isCascadingContextForLookup(bool functionsAreNonCascading) const {
   case DeclContextKind::GenericTypeDecl: {
     auto *nominal = cast<GenericTypeDecl>(this);
     if (nominal->hasAccessibility())
-      return nominal->getFormalAccess() > Accessibility::Private;
+      return nominal->getFormalAccess() > Accessibility::FilePrivate;
     break;
   }
 
   case DeclContextKind::ExtensionDecl: {
     auto *extension = cast<ExtensionDecl>(this);
     if (extension->hasDefaultAccessibility())
-      return extension->getDefaultAccessibility() > Accessibility::Private;
+      return extension->getDefaultAccessibility() > Accessibility::FilePrivate;
     // FIXME: duplicated from computeDefaultAccessibility in TypeCheckDecl.cpp.
     if (auto *AA = extension->getAttrs().getAttribute<AccessibilityAttr>())
-      return AA->getAccess() > Accessibility::Private;
+      return AA->getAccess() > Accessibility::FilePrivate;
     if (Type extendedTy = extension->getExtendedType()) {
 
       // Need to check if extendedTy is ErrorType

--- a/lib/AST/Mangle.cpp
+++ b/lib/AST/Mangle.cpp
@@ -394,7 +394,7 @@ static bool isInPrivateOrLocalContext(const ValueDecl *D) {
     return false;
 
   auto *nominal = declaredType->getAnyNominal();
-  if (nominal->getFormalAccess() == Accessibility::Private)
+  if (nominal->getFormalAccess() <= Accessibility::FilePrivate)
     return true;
   return isInPrivateOrLocalContext(nominal);
 }
@@ -407,7 +407,7 @@ void Mangler::mangleDeclName(const ValueDecl *decl) {
     // Fall through to mangle the <identifier>.
 
   } else if (decl->hasAccessibility() &&
-             decl->getFormalAccess() == Accessibility::Private &&
+             decl->getFormalAccess() <= Accessibility::FilePrivate &&
              !isInPrivateOrLocalContext(decl)) {
     // Mangle non-local private declarations with a textual discriminator
     // based on their enclosing file.

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -329,7 +329,7 @@ bool swift::removeShadowedDecls(SmallVectorImpl<ValueDecl*> &decls,
 
 static bool matchesDiscriminator(Identifier discriminator,
                                  const ValueDecl *value) {
-  if (value->getFormalAccess() != Accessibility::Private)
+  if (value->getFormalAccess() > Accessibility::FilePrivate)
     return false;
 
   auto containingFile =
@@ -1019,6 +1019,8 @@ static bool checkAccessibility(const DeclContext *useDC,
 
   switch (access) {
   case Accessibility::Private:
+    // TODO: Implement 'private'.
+  case Accessibility::FilePrivate:
     return useDC->getModuleScopeContext() == sourceDC->getModuleScopeContext();
   case Accessibility::Internal: {
     const Module *sourceModule = sourceDC->getParentModule();

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1391,10 +1391,16 @@ public:
     auto D = ::new (DeclPtr) DeclTy(std::forward<Targs>(Args)...);
     D->setClangNode(ClangN);
     D->setEarlyAttrValidation(true);
-    if (auto VD = dyn_cast<ValueDecl>(D))
-      VD->setAccessibility(Accessibility::Public);
-    if (auto ASD = dyn_cast<AbstractStorageDecl>(D))
-      ASD->setSetterAccessibility(Accessibility::Public);
+    if (auto VD = dyn_cast<ValueDecl>(D)) {
+      if (auto *param = dyn_cast<ParamDecl>(D)) {
+        param->setAccessibility(Accessibility::Private);
+        param->setSetterAccessibility(Accessibility::Private);
+      } else {
+        VD->setAccessibility(Accessibility::Public);
+        if (auto ASD = dyn_cast<AbstractStorageDecl>(D))
+          ASD->setSetterAccessibility(Accessibility::Public);
+      }
+    }
     return D;
   }
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -158,7 +158,7 @@ static bool declIsPrivate(const Decl *member) {
     }
   }
 
-  return VD->getFormalAccess() == Accessibility::Private;
+  return VD->getFormalAccess() <= Accessibility::FilePrivate;
 }
 
 static bool extendedTypeIsPrivate(TypeLoc inheritedType) {
@@ -227,7 +227,7 @@ static bool emitReferenceDependencies(DiagnosticEngine &diags,
       if (!NTD)
         break;
       if (NTD->hasAccessibility() &&
-          NTD->getFormalAccess() == Accessibility::Private) {
+          NTD->getFormalAccess() <= Accessibility::FilePrivate) {
         break;
       }
 
@@ -261,7 +261,7 @@ static bool emitReferenceDependencies(DiagnosticEngine &diags,
       if (!NTD->hasName())
         break;
       if (NTD->hasAccessibility() &&
-          NTD->getFormalAccess() == Accessibility::Private) {
+          NTD->getFormalAccess() <= Accessibility::FilePrivate) {
         break;
       }
       out << "- \"" << escape(NTD->getName()) << "\"\n";
@@ -277,7 +277,7 @@ static bool emitReferenceDependencies(DiagnosticEngine &diags,
       if (!VD->hasName())
         break;
       if (VD->hasAccessibility() &&
-          VD->getFormalAccess() == Accessibility::Private) {
+          VD->getFormalAccess() <= Accessibility::FilePrivate) {
         break;
       }
       out << "- \"" << escape(VD->getName()) << "\"\n";
@@ -326,7 +326,7 @@ static bool emitReferenceDependencies(DiagnosticEngine &diags,
     for (auto *member : ED->getMembers()) {
       auto *VD = dyn_cast<ValueDecl>(member);
       if (!VD || !VD->hasName() ||
-          VD->getFormalAccess() == Accessibility::Private) {
+          VD->getFormalAccess() <= Accessibility::FilePrivate) {
         continue;
       }
       out << "- [\"" << mangledName << "\", \""
@@ -391,7 +391,7 @@ static bool emitReferenceDependencies(DiagnosticEngine &diags,
   for (auto &entry : sortedMembers) {
     assert(entry.first.first != nullptr);
     if (entry.first.first->hasAccessibility() &&
-        entry.first.first->getFormalAccess() == Accessibility::Private)
+        entry.first.first->getFormalAccess() <= Accessibility::FilePrivate)
       continue;
 
     out << "- ";
@@ -414,7 +414,7 @@ static bool emitReferenceDependencies(DiagnosticEngine &diags,
     }
 
     if (i->first.first->hasAccessibility() &&
-        i->first.first->getFormalAccess() == Accessibility::Private)
+        i->first.first->getFormalAccess() <= Accessibility::FilePrivate)
       continue;
 
     out << "- ";

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -115,6 +115,11 @@ public:
           CodeCompletionString::Chunk::ChunkKind::AccessControlKeyword,
           "private ");
       break;
+    case Accessibility::FilePrivate:
+      addChunkWithTextNoCopy(
+          CodeCompletionString::Chunk::ChunkKind::AccessControlKeyword,
+          "fileprivate ");
+      break;
     case Accessibility::Internal:
       // 'internal' is the default, don't add it.
       break;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -500,11 +500,16 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
       diagnose(Loc, diag::attr_only_at_non_local_scope, AttrName);
     }
 
-    auto access = llvm::StringSwitch<Accessibility>(AttrName)
+    Accessibility access = llvm::StringSwitch<Accessibility>(AttrName)
       .Case("private", Accessibility::Private)
       .Case("fileprivate", Accessibility::FilePrivate)
       .Case("internal", Accessibility::Internal)
       .Case("public", Accessibility::Public);
+
+    if (access == Accessibility::FilePrivate &&
+        !Context.LangOpts.EnableSwift3Private) {
+      access = Accessibility::Private;
+    }
 
     if (!consumeIf(tok::l_paren)) {
       // Normal accessibility attribute.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -502,7 +502,7 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
 
     auto access = llvm::StringSwitch<Accessibility>(AttrName)
       .Case("private", Accessibility::Private)
-      .Case("fileprivate", Accessibility::Private) // FIXME: For migration purposes.
+      .Case("fileprivate", Accessibility::FilePrivate)
       .Case("internal", Accessibility::Internal)
       .Case("public", Accessibility::Public);
 

--- a/lib/SIL/DynamicCasts.cpp
+++ b/lib/SIL/DynamicCasts.cpp
@@ -122,12 +122,12 @@ classifyDynamicCastToProtocol(CanType source,
     }
   }
 
-  // If the source type is private or target protocol is private,
+  // If the source type is file-private or target protocol is file-private,
   // then conformances cannot be changed at run-time, because only this
   // file could have implemented them, but no conformances were found.
   // Therefore it is safe to make a negative decision at compile-time.
-  if (SourceNominalTy->getEffectiveAccess() == Accessibility::Private ||
-      TargetProtocol->getEffectiveAccess() == Accessibility::Private) {
+  if (SourceNominalTy->getEffectiveAccess() <= Accessibility::FilePrivate ||
+      TargetProtocol->getEffectiveAccess() <= Accessibility::FilePrivate) {
     // This cast is always false. Replace it with a branch to the
     // failure block.
     return DynamicCastFeasibility::WillFail;
@@ -139,8 +139,8 @@ classifyDynamicCastToProtocol(CanType source,
   // module could have implemented them, but no conformances were found.
   // Therefore it is safe to make a negative decision at compile-time.
   if (isWholeModuleOpts &&
-      (SourceNominalTy->getEffectiveAccess() == Accessibility::Internal ||
-       TargetProtocol->getEffectiveAccess() == Accessibility::Internal)) {
+      (SourceNominalTy->getEffectiveAccess() <= Accessibility::Internal ||
+       TargetProtocol->getEffectiveAccess() <= Accessibility::Internal)) {
     return DynamicCastFeasibility::WillFail;
   }
 

--- a/lib/SIL/SIL.cpp
+++ b/lib/SIL/SIL.cpp
@@ -69,6 +69,7 @@ FormalLinkage swift::getDeclLinkage(const ValueDecl *D) {
         == ResilienceStrategy::Fragile)
       return FormalLinkage::PublicUnique;
     return FormalLinkage::HiddenUnique;
+  case Accessibility::FilePrivate:
   case Accessibility::Private:
     // Why "hidden" instead of "private"? Because the debugger may need to
     // access these symbols.
@@ -145,6 +146,7 @@ swift::getLinkageForProtocolConformance(const NormalProtocolConformance *C,
   // FIXME: This should be using std::min(protocol's access, type's access).
   switch (C->getProtocol()->getEffectiveAccess()) {
     case Accessibility::Private:
+    case Accessibility::FilePrivate:
       return (definition ? SILLinkage::Private : SILLinkage::PrivateExternal);
 
     case Accessibility::Internal:

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -328,6 +328,7 @@ SILLinkage SILDeclRef::getLinkage(ForDefinition_t forDefinition) const {
   // Otherwise, we have external linkage.
   switch (d->getEffectiveAccess()) {
     case Accessibility::Private:
+    case Accessibility::FilePrivate:
       return (forDefinition ? SILLinkage::Private : SILLinkage::PrivateExternal);
 
     case Accessibility::Internal:

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -269,6 +269,7 @@ static SILFunction::ClassVisibility_t getClassVisibility(SILDeclRef constant) {
 
   switch (classType->getEffectiveAccess()) {
     case Accessibility::Private:
+    case Accessibility::FilePrivate:
       return SILFunction::NotRelevant;
     case Accessibility::Internal:
       return SILFunction::InternalClass;

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -202,6 +202,7 @@ protected:
     SILLinkage linkage;
     switch (accessibility) {
     case Accessibility::Private:
+    case Accessibility::FilePrivate:
       linkage = SILLinkage::Private;
       break;
     case Accessibility::Internal:

--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -742,6 +742,7 @@ static bool canBeChangedExternally(SILGlobalVariable *SILG) {
   if (auto *Decl = SILG->getDecl()) {
     switch (Decl->getEffectiveAccess()) {
     case Accessibility::Private:
+    case Accessibility::FilePrivate:
       return false;
     case Accessibility::Internal:
       return !SILG->getModule().isWholeModule();

--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -740,13 +740,14 @@ static bool canBeChangedExternally(SILGlobalVariable *SILG) {
   // Use access specifiers from the declarations,
   // if possible.
   if (auto *Decl = SILG->getDecl()) {
-    auto Access = Decl->getFormalAccess();
-    if (Access == Accessibility::Private)
+    switch (Decl->getEffectiveAccess()) {
+    case Accessibility::Private:
       return false;
-    if (Access == Accessibility::Internal &&
-        SILG->getModule().isWholeModule())
-      return false;
-    return true;
+    case Accessibility::Internal:
+      return !SILG->getModule().isWholeModule();
+    case Accessibility::Public:
+      return true;
+    }
   }
 
   if (SILG->getLinkage() == SILLinkage::Private)

--- a/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
@@ -134,6 +134,7 @@ class GlobalPropertyOpt {
     SILLinkage linkage;
     switch (accessibility) {
       case Accessibility::Private:
+      case Accessibility::FilePrivate:
         linkage = SILLinkage::Private;
         break;
       case Accessibility::Internal:

--- a/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
+++ b/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
@@ -162,10 +162,10 @@ void LetPropertiesOpt::optimizeLetPropertyAccess(VarDecl *Property,
   // Check if a given let property can be removed, because it
   // is not accessible elsewhere. This can happen if this property
   // is private or if it is internal and WMO mode is used.
-  if (TypeAccess == Accessibility::Private ||
-      PropertyAccess == Accessibility::Private
-      || ((TypeAccess == Accessibility::Internal ||
-          PropertyAccess == Accessibility::Internal) &&
+  if (TypeAccess <= Accessibility::FilePrivate ||
+      PropertyAccess <= Accessibility::FilePrivate
+      || ((TypeAccess <= Accessibility::Internal ||
+          PropertyAccess <= Accessibility::Internal) &&
           Module->isWholeModule())) {
     CanRemove = true;
     DEBUG(llvm::dbgs() << "Storage for property '" << *Property
@@ -280,6 +280,7 @@ static bool isAssignableExternally(VarDecl *Property, SILModule *Module) {
   SILLinkage linkage;
   switch (accessibility) {
   case Accessibility::Private:
+  case Accessibility::FilePrivate:
     linkage = SILLinkage::Private;
     DEBUG(llvm::dbgs() << "Property " << *Property << " has private access\n");
     break;
@@ -317,8 +318,8 @@ static bool isAssignableExternally(VarDecl *Property, SILModule *Module) {
     // may exist.
     for (auto SP : Ty->getStoredProperties()) {
       auto storedPropertyAccessibility = SP->getEffectiveAccess();
-      if (storedPropertyAccessibility == Accessibility::Private ||
-          (storedPropertyAccessibility == Accessibility::Internal &&
+      if (storedPropertyAccessibility <= Accessibility::FilePrivate ||
+          (storedPropertyAccessibility <= Accessibility::Internal &&
            Module->isWholeModule())) {
        DEBUG(llvm::dbgs() << "Property " << *Property
                        << " cannot be set externally\n");

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -251,6 +251,7 @@ static bool isDefaultCaseKnown(ClassHierarchyAnalysis *CHA,
     if (!AI.getModule().isWholeModule())
       return false;
     break;
+  case Accessibility::FilePrivate:
   case Accessibility::Private:
     break;
   }

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -184,6 +184,7 @@ static bool isKnownFinalClass(ClassDecl *CD, SILModule &M,
     if (!M.isWholeModule())
       return false;
     break;
+  case Accessibility::FilePrivate:
   case Accessibility::Private:
     break;
   }
@@ -203,6 +204,7 @@ static bool isKnownFinalClass(ClassDecl *CD, SILModule &M,
         if (!M.isWholeModule())
           return false;
         break;
+      case Accessibility::FilePrivate:
       case Accessibility::Private:
         break;
       }

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -2594,6 +2594,7 @@ bool swift::calleesAreStaticallyKnowable(SILModule &M, SILDeclRef Decl) {
     return false;
   case Accessibility::Internal:
     return M.isWholeModule();
+  case Accessibility::FilePrivate:
   case Accessibility::Private:
     return true;
   }

--- a/lib/Sema/ITCDecl.cpp
+++ b/lib/Sema/ITCDecl.cpp
@@ -319,7 +319,7 @@ void IterativeTypeChecker::processResolveTypeDecl(
       
       TypeResolutionOptions options;
       options |= TR_GlobalTypeAlias;
-      if (typeAliasDecl->getFormalAccess() == Accessibility::Private)
+      if (typeAliasDecl->getFormalAccess() <= Accessibility::FilePrivate)
         options |= TR_KnownNonCascadingDependency;
 
       // Note: recursion into old type checker is okay when passing in an

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3472,9 +3472,10 @@ void swift::fixItAccessibility(InFlightDiagnostic &diag, ValueDecl *VD,
                                Accessibility desiredAccess, bool isForSetter) {
   StringRef fixItString;
   switch (desiredAccess) {
-  case Accessibility::Private:  fixItString = "private ";  break;
-  case Accessibility::Internal: fixItString = "internal "; break;
-  case Accessibility::Public:   fixItString = "public ";   break;
+  case Accessibility::Private:      fixItString = "private ";      break;
+  case Accessibility::FilePrivate:  fixItString = "fileprivate ";  break;
+  case Accessibility::Internal:     fixItString = "internal ";     break;
+  case Accessibility::Public:       fixItString = "public ";       break;
   }
 
   DeclAttributes &attrs = VD->getAttrs();

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4555,8 +4555,8 @@ static void diagnosePotentialWitness(TypeChecker &tc,
                 witness->getFullName(), static_cast<unsigned>(*move));
   }
 
-  // If adding 'private' or 'internal' can help, suggest that.
-  if (accessibility != Accessibility::Private &&
+  // If adding 'private', 'fileprivate', or 'internal' can help, suggest that.
+  if (accessibility > Accessibility::FilePrivate &&
       !witness->getAttrs().hasAttribute<AccessibilityAttr>()) {
     tc.diagnose(witness, diag::optional_req_near_match_accessibility,
                 witness->getFullName(),
@@ -4654,7 +4654,7 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
 
     if (tracker)
       tracker->addUsedMember({conformance->getProtocol(), Identifier()},
-                             defaultAccessibility != Accessibility::Private);
+                             defaultAccessibility > Accessibility::FilePrivate);
   }
 
   // Diagnose any conflicts attributed to this declaration context.

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1655,6 +1655,7 @@ getActualAccessibility(uint8_t raw) {
   case serialization::AccessibilityKind::NAME: \
     return Accessibility::NAME;
   CASE(Private)
+  CASE(FilePrivate)
   CASE(Internal)
   CASE(Public)
 #undef CASE

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1545,6 +1545,7 @@ static uint8_t getRawStableAccessibility(Accessibility access) {
   case Accessibility::NAME: \
     return static_cast<uint8_t>(serialization::AccessibilityKind::NAME);
   CASE(Private)
+  CASE(FilePrivate)
   CASE(Internal)
   CASE(Public)
 #undef CASE
@@ -2020,7 +2021,7 @@ void Serializer::writeDecl(const Decl *D) {
 
   if (auto *value = dyn_cast<ValueDecl>(D)) {
     if (value->hasAccessibility() &&
-        value->getFormalAccess() == Accessibility::Private &&
+        value->getFormalAccess() <= Accessibility::FilePrivate &&
         !value->getDeclContext()->isLocalContext()) {
       // FIXME: We shouldn't need to encode this for /all/ private decls.
       // In theory we can follow the same rules as mangling and only include

--- a/test/NameBinding/accessibility.swift
+++ b/test/NameBinding/accessibility.swift
@@ -129,8 +129,8 @@ private class PrivateBox<T> { // expected-note 2 {{type declared here}}
   typealias AlwaysFloat = Float
 }
 
-let boxUnboxInt: PrivateBox<Int>.ValueType = 0 // expected-error {{constant must be declared private because its type uses a private type}}
-let boxFloat: PrivateBox<Int>.AlwaysFloat = 0 // expected-error {{constant must be declared private because its type uses a private type}}
+let boxUnboxInt: PrivateBox<Int>.ValueType = 0 // expected-error {{constant must be declared fileprivate because its type uses a fileprivate type}}
+let boxFloat: PrivateBox<Int>.AlwaysFloat = 0 // expected-error {{constant must be declared fileprivate because its type uses a fileprivate type}}
 #endif
 
 

--- a/test/Sema/accessibility.swift
+++ b/test/Sema/accessibility.swift
@@ -21,7 +21,7 @@ private protocol PrivateProto {
 public struct PublicStruct: PublicProto, InternalProto, FilePrivateProto, PrivateProto {
   private func publicReq() {} // expected-error {{method 'publicReq()' must be declared public because it matches a requirement in public protocol 'PublicProto'}} {{3-10=public}}
   private func internalReq() {} // expected-error {{method 'internalReq()' must be declared internal because it matches a requirement in internal protocol 'InternalProto'}} {{3-10=internal}}
-  private func filePrivateReq() {}
+  private func filePrivateReq() {} // expected-error {{method 'filePrivateReq()' must be declared fileprivate because it matches a requirement in fileprivate protocol 'FilePrivateProto'}} {{3-10=fileprivate}}
   private func privateReq() {}
 
   public var publicVar = 0
@@ -31,7 +31,7 @@ public struct PublicStruct: PublicProto, InternalProto, FilePrivateProto, Privat
 internal struct InternalStruct: PublicProto, InternalProto, FilePrivateProto, PrivateProto {
   private func publicReq() {} // expected-error {{method 'publicReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'PublicProto'}} {{3-10=internal}}
   private func internalReq() {} // expected-error {{method 'internalReq()' must be declared internal because it matches a requirement in internal protocol 'InternalProto'}} {{3-10=internal}}
-  private func filePrivateReq() {}
+  private func filePrivateReq() {} // expected-error {{method 'filePrivateReq()' must be declared fileprivate because it matches a requirement in fileprivate protocol 'FilePrivateProto'}} {{3-10=fileprivate}}
   private func privateReq() {}
 
   public var publicVar = 0
@@ -39,9 +39,9 @@ internal struct InternalStruct: PublicProto, InternalProto, FilePrivateProto, Pr
 
 // expected-note@+1 * {{type declared here}}
 fileprivate struct FilePrivateStruct: PublicProto, InternalProto, FilePrivateProto, PrivateProto {
-  private func publicReq() {}
-  private func internalReq() {}
-  private func filePrivateReq() {}
+  private func publicReq() {} // expected-error {{method 'publicReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'PublicProto'}} {{3-10=fileprivate}}
+  private func internalReq() {} // expected-error {{method 'internalReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'InternalProto'}} {{3-10=fileprivate}}
+  private func filePrivateReq() {} // expected-error {{method 'filePrivateReq()' must be declared fileprivate because it matches a requirement in fileprivate protocol 'FilePrivateProto'}} {{3-10=fileprivate}}
   private func privateReq() {}
 
   public var publicVar = 0
@@ -86,7 +86,7 @@ private extension PublicStruct {
   private func extImplPrivate() {}
 }
 fileprivate extension PublicStruct {
-  public func extMemberFilePrivate() {} // expected-warning {{declaring a public instance method in a private extension}} {{3-9=private}}
+  public func extMemberFilePrivate() {} // expected-warning {{declaring a public instance method in a fileprivate extension}} {{3-9=fileprivate}}
   private func extImplFilePrivate() {}
 }
 public extension InternalStruct { // expected-error {{extension of internal struct cannot be declared public}} {{1-8=}}
@@ -98,23 +98,23 @@ internal extension InternalStruct {
   private func extImplInternal() {}
 }
 fileprivate extension InternalStruct {
-  public func extMemberFilePrivate() {} // expected-warning {{declaring a public instance method in a private extension}} {{3-9=private}}
+  public func extMemberFilePrivate() {} // expected-warning {{declaring a public instance method in a fileprivate extension}} {{3-9=fileprivate}}
   private func extImplFilePrivate() {}
 }
 private extension InternalStruct {
   public func extMemberPrivate() {} // expected-warning {{declaring a public instance method in a private extension}} {{3-9=private}}
   private func extImplPrivate() {}
 }
-public extension FilePrivateStruct { // expected-error {{extension of private struct cannot be declared public}} {{1-8=}}
+public extension FilePrivateStruct { // expected-error {{extension of fileprivate struct cannot be declared public}} {{1-8=}}
   public func extMemberPublic() {}
   private func extImplPublic() {}
 }
-internal extension FilePrivateStruct { // expected-error {{extension of private struct cannot be declared internal}} {{1-10=}}
+internal extension FilePrivateStruct { // expected-error {{extension of fileprivate struct cannot be declared internal}} {{1-10=}}
   public func extMemberInternal() {} // expected-warning {{declaring a public instance method in an internal extension}} {{3-9=internal}}
   private func extImplInternal() {}
 }
 fileprivate extension FilePrivateStruct {
-  public func extMemberFilePrivate() {} // expected-warning {{declaring a public instance method in a private extension}} {{3-9=private}}
+  public func extMemberFilePrivate() {} // expected-warning {{declaring a public instance method in a fileprivate extension}} {{3-9=fileprivate}}
   private func extImplFilePrivate() {}
 }
 private extension FilePrivateStruct {
@@ -129,8 +129,8 @@ internal extension PrivateStruct { // expected-error {{extension of private stru
   public func extMemberInternal() {} // expected-warning {{declaring a public instance method in an internal extension}} {{3-9=internal}}
   private func extImplInternal() {}
 }
-fileprivate extension PrivateStruct {
-  public func extMemberFilePrivate() {} // expected-warning {{declaring a public instance method in a private extension}} {{3-9=private}}
+fileprivate extension PrivateStruct { // expected-error {{extension of private struct cannot be declared fileprivate}} {{1-13=}}
+  public func extMemberFilePrivate() {} // expected-warning {{declaring a public instance method in a fileprivate extension}} {{3-9=fileprivate}}
   private func extImplFilePrivate() {}
 }
 private extension PrivateStruct {
@@ -201,24 +201,29 @@ internal class InternalSubPrivateSet: Base {
 
 public typealias PublicTA1 = PublicStruct
 public typealias PublicTA2 = InternalStruct // expected-error {{type alias cannot be declared public because its underlying type uses an internal type}}
-public typealias PublicTA3 = FilePrivateStruct // expected-error {{type alias cannot be declared public because its underlying type uses a private type}}
-public typealias PublicTA4 = PrivateStruct // expected-error {{type alias cannot be declared public because its underlying type uses a private type}}
+public typealias PublicTA3 = FilePrivateStruct // expected-error {{type alias cannot be declared public because its underlying type uses a fileprivate type}}
+// FIXME: This type is actually private; it's just being reported as fileprivate because it's top-level.
+public typealias PublicTA4 = PrivateStruct // expected-error {{type alias cannot be declared public because its underlying type uses a fileprivate type}}
 
 // expected-note@+1 {{type declared here}}
 internal typealias InternalTA1 = PublicStruct
 internal typealias InternalTA2 = InternalStruct
-internal typealias InternalTA3 = FilePrivateStruct // expected-error {{type alias cannot be declared internal because its underlying type uses a private type}}
-internal typealias InternalTA4 = PrivateStruct // expected-error {{type alias cannot be declared internal because its underlying type uses a private type}}
+internal typealias InternalTA3 = FilePrivateStruct // expected-error {{type alias cannot be declared internal because its underlying type uses a fileprivate type}}
+// FIXME: This type is actually private; it's just being reported as
+// fileprivate because it's top-level.
+internal typealias InternalTA4 = PrivateStruct // expected-error {{type alias cannot be declared internal because its underlying type uses a fileprivate type}}
 
 public typealias PublicFromInternal = InternalTA1 // expected-error {{type alias cannot be declared public because its underlying type uses an internal type}}
 
-typealias FunctionType1 = (PrivateStruct) -> PublicStruct // expected-error {{type alias must be declared private because its underlying type uses a private type}}
-typealias FunctionType2 = (PublicStruct) -> PrivateStruct // expected-error {{type alias must be declared private because its underlying type uses a private type}}
-typealias FunctionType3 = (PrivateStruct) -> PrivateStruct // expected-error {{type alias must be declared private because its underlying type uses a private type}}
+// FIXME: These types are actually private; they're just being reported as
+// fileprivate because they're top-level.
+typealias FunctionType1 = (PrivateStruct) -> PublicStruct // expected-error {{type alias must be declared fileprivate because its underlying type uses a fileprivate type}}
+typealias FunctionType2 = (PublicStruct) -> PrivateStruct // expected-error {{type alias must be declared fileprivate because its underlying type uses a fileprivate type}}
+typealias FunctionType3 = (PrivateStruct) -> PrivateStruct // expected-error {{type alias must be declared fileprivate because its underlying type uses a fileprivate type}}
 
-typealias ArrayType = [PrivateStruct] // expected-error {{type alias must be declared private because its underlying type uses a private type}}
-typealias DictType = [String : PrivateStruct] // expected-error {{type alias must be declared private because its underlying type uses a private type}}
-typealias GenericArgs = Optional<PrivateStruct> // expected-error {{type alias must be declared private because its underlying type uses a private type}}
+typealias ArrayType = [PrivateStruct] // expected-error {{type alias must be declared fileprivate because its underlying type uses a fileprivate type}}
+typealias DictType = [String : PrivateStruct] // expected-error {{type alias must be declared fileprivate because its underlying type uses a fileprivate type}}
+typealias GenericArgs = Optional<PrivateStruct> // expected-error {{type alias must be declared fileprivate because its underlying type uses a fileprivate type}}
 
 
 public protocol HasAssocType {
@@ -232,53 +237,65 @@ public struct AssocTypeImpl: HasAssocType {
 public let _: AssocTypeImpl.Inferred?
 
 
-public let x: PrivateStruct = PrivateStruct() // expected-error {{constant cannot be declared public because its type uses a private type}}
-public var a: PrivateStruct?, b: PrivateStruct? // expected-error 2 {{variable cannot be declared public because its type uses a private type}}
-public var (c, d): (PrivateStruct?, PrivateStruct?) // expected-error {{variable cannot be declared public because its type uses a private type}}
+// FIXME: These types are actually private; they're just being reported as
+// fileprivate because they're top-level.
+public let x: PrivateStruct = PrivateStruct() // expected-error {{constant cannot be declared public because its type uses a fileprivate type}}
+public var a: PrivateStruct?, b: PrivateStruct? // expected-error 2 {{variable cannot be declared public because its type uses a fileprivate type}}
+public var (c, d): (PrivateStruct?, PrivateStruct?) // expected-error {{variable cannot be declared public because its type uses a fileprivate type}}
 
-var internalVar: PrivateStruct? // expected-error {{variable must be declared private because its type uses a private type}}
+var internalVar: PrivateStruct? // expected-error {{variable must be declared fileprivate because its type uses a fileprivate type}}
 
-let internalConstant = PrivateStruct() // expected-error {{constant must be declared private because its type 'PrivateStruct' uses a private type}}
+let internalConstant = PrivateStruct() // expected-error {{constant must be declared fileprivate because its type 'PrivateStruct' uses a fileprivate type}}
 public let publicConstant = [InternalStruct]() // expected-error {{constant cannot be declared public because its type '[InternalStruct]' uses an internal type}}
 
 public struct Properties {
-  public let x: PrivateStruct = PrivateStruct() // expected-error {{property cannot be declared public because its type uses a private type}}
-  public var a: PrivateStruct?, b: PrivateStruct? // expected-error 2 {{property cannot be declared public because its type uses a private type}}
-  public var (c, d): (PrivateStruct?, PrivateStruct?) // expected-error {{property cannot be declared public because its type uses a private type}}
+  // FIXME: These types are actually private; they're just being reported as
+  // fileprivate because they're top-level.
+  public let x: PrivateStruct = PrivateStruct() // expected-error {{property cannot be declared public because its type uses a fileprivate type}}
+  public var a: PrivateStruct?, b: PrivateStruct? // expected-error 2 {{property cannot be declared public because its type uses a fileprivate type}}
+  public var (c, d): (PrivateStruct?, PrivateStruct?) // expected-error {{property cannot be declared public because its type uses a fileprivate type}}
 
-  let y = PrivateStruct() // expected-error {{property must be declared private because its type 'PrivateStruct' uses a private type}}
+  let y = PrivateStruct() // expected-error {{property must be declared fileprivate because its type 'PrivateStruct' uses a fileprivate type}}
 }
 
 public struct Subscripts {
-  subscript (a: PrivateStruct) -> Int { return 0 } // expected-error {{subscript must be declared private because its index uses a private type}}
-  subscript (a: Int) -> PrivateStruct { return PrivateStruct() } // expected-error {{subscript must be declared private because its element type uses a private type}}
+  // FIXME: These types are actually private; they're just being reported as
+  // fileprivate because they're top-level.
+  subscript (a: PrivateStruct) -> Int { return 0 } // expected-error {{subscript must be declared fileprivate because its index uses a fileprivate type}}
+  subscript (a: Int) -> PrivateStruct { return PrivateStruct() } // expected-error {{subscript must be declared fileprivate because its element type uses a fileprivate type}}
 
-  public subscript (a: PrivateStruct, b: Int) -> Int { return 0 } // expected-error {{subscript cannot be declared public because its index uses a private type}}
-  public subscript (a: Int, b: PrivateStruct) -> Int { return 0 } // expected-error {{subscript cannot be declared public because its index uses a private type}}
-  public subscript (a: InternalStruct, b: PrivateStruct) -> InternalStruct { return InternalStruct() } // expected-error {{subscript cannot be declared public because its index uses a private type}}
-  public subscript (a: PrivateStruct, b: InternalStruct) -> PrivateStruct { return PrivateStruct() } // expected-error {{subscript cannot be declared public because its index uses a private type}}
+  public subscript (a: PrivateStruct, b: Int) -> Int { return 0 } // expected-error {{subscript cannot be declared public because its index uses a fileprivate type}}
+  public subscript (a: Int, b: PrivateStruct) -> Int { return 0 } // expected-error {{subscript cannot be declared public because its index uses a fileprivate type}}
+  public subscript (a: InternalStruct, b: PrivateStruct) -> InternalStruct { return InternalStruct() } // expected-error {{subscript cannot be declared public because its index uses a fileprivate type}}
+  public subscript (a: PrivateStruct, b: InternalStruct) -> PrivateStruct { return PrivateStruct() } // expected-error {{subscript cannot be declared public because its index uses a fileprivate type}}
   public subscript (a: Int, b: Int) -> InternalStruct { return InternalStruct() } // expected-error {{subscript cannot be declared public because its element type uses an internal type}}
 }
 
 public struct Methods {
-  func foo(a: PrivateStruct) -> Int { return 0 } // expected-error {{method must be declared private because its parameter uses a private type}}
-  func bar(a: Int) -> PrivateStruct { return PrivateStruct() } // expected-error {{method must be declared private because its result uses a private type}}
+  // FIXME: These types are actually private; they're just being reported as
+  // fileprivate because they're top-level.
+  func foo(a: PrivateStruct) -> Int { return 0 } // expected-error {{method must be declared fileprivate because its parameter uses a fileprivate type}}
+  func bar(a: Int) -> PrivateStruct { return PrivateStruct() } // expected-error {{method must be declared fileprivate because its result uses a fileprivate type}}
 
-  public func a(a: PrivateStruct, b: Int) -> Int { return 0 } // expected-error {{method cannot be declared public because its parameter uses a private type}}
-  public func b(a: Int, b: PrivateStruct) -> Int { return 0 } // expected-error {{method cannot be declared public because its parameter uses a private type}}
-  public func c(a: InternalStruct, b: PrivateStruct) -> InternalStruct { return InternalStruct() } // expected-error {{method cannot be declared public because its parameter uses a private type}}
-  public func d(a: PrivateStruct, b: InternalStruct) -> PrivateStruct { return PrivateStruct() } // expected-error {{method cannot be declared public because its parameter uses a private type}}
+  public func a(a: PrivateStruct, b: Int) -> Int { return 0 } // expected-error {{method cannot be declared public because its parameter uses a fileprivate type}}
+  public func b(a: Int, b: PrivateStruct) -> Int { return 0 } // expected-error {{method cannot be declared public because its parameter uses a fileprivate type}}
+  public func c(a: InternalStruct, b: PrivateStruct) -> InternalStruct { return InternalStruct() } // expected-error {{method cannot be declared public because its parameter uses a fileprivate type}}
+  public func d(a: PrivateStruct, b: InternalStruct) -> PrivateStruct { return PrivateStruct() } // expected-error {{method cannot be declared public because its parameter uses a fileprivate type}}
   public func e(a: Int, b: Int) -> InternalStruct { return InternalStruct() } // expected-error {{method cannot be declared public because its result uses an internal type}}
 }
-func privateParam(a: PrivateStruct) {} // expected-error {{function must be declared private because its parameter uses a private type}}
+// FIXME: This type is actually private; it's just being reported as
+// fileprivate because it's top-level.
+func privateParam(a: PrivateStruct) {} // expected-error {{function must be declared fileprivate because its parameter uses a fileprivate type}}
 
 public struct Initializers {
-  init(a: PrivateStruct) {} // expected-error {{initializer must be declared private because its parameter uses a private type}}
+  // FIXME: These types are actually private; they're just being reported as
+  // fileprivate because they're top-level.
+  init(a: PrivateStruct) {} // expected-error {{initializer must be declared fileprivate because its parameter uses a fileprivate type}}
 
-  public init(a: PrivateStruct, b: Int) {} // expected-error {{initializer cannot be declared public because its parameter uses a private type}}
-  public init(a: Int, b: PrivateStruct) {} // expected-error {{initializer cannot be declared public because its parameter uses a private type}}
-  public init(a: InternalStruct, b: PrivateStruct) {} // expected-error {{initializer cannot be declared public because its parameter uses a private type}}
-  public init(a: PrivateStruct, b: InternalStruct) { } // expected-error {{initializer cannot be declared public because its parameter uses a private type}}
+  public init(a: PrivateStruct, b: Int) {} // expected-error {{initializer cannot be declared public because its parameter uses a fileprivate type}}
+  public init(a: Int, b: PrivateStruct) {} // expected-error {{initializer cannot be declared public because its parameter uses a fileprivate type}}
+  public init(a: InternalStruct, b: PrivateStruct) {} // expected-error {{initializer cannot be declared public because its parameter uses a fileprivate type}}
+  public init(a: PrivateStruct, b: InternalStruct) { } // expected-error {{initializer cannot be declared public because its parameter uses a fileprivate type}}
 }
 
 
@@ -293,86 +310,108 @@ public protocol AssocTypes {
 
   associatedtype Internal: InternalClass // expected-error {{associated type in a public protocol uses an internal type in its requirement}}
   associatedtype InternalConformer: InternalProto // expected-error {{associated type in a public protocol uses an internal type in its requirement}}
-  associatedtype PrivateConformer: PrivateProto // expected-error {{associated type in a public protocol uses a private type in its requirement}}
-  associatedtype PI: PrivateProto, InternalProto // expected-error {{associated type in a public protocol uses a private type in its requirement}}
-  associatedtype IP: InternalProto, PrivateProto // expected-error {{associated type in a public protocol uses a private type in its requirement}}
+  // FIXME: These types are actually private; they're just being reported as
+  // fileprivate because they're top-level.
+  associatedtype PrivateConformer: PrivateProto // expected-error {{associated type in a public protocol uses a fileprivate type in its requirement}}
+  associatedtype PI: PrivateProto, InternalProto // expected-error {{associated type in a public protocol uses a fileprivate type in its requirement}}
+  associatedtype IP: InternalProto, PrivateProto // expected-error {{associated type in a public protocol uses a fileprivate type in its requirement}}
 
-  associatedtype PrivateDefault = PrivateStruct // expected-error {{associated type in a public protocol uses a private type in its default definition}}
+  associatedtype PrivateDefault = PrivateStruct // expected-error {{associated type in a public protocol uses a fileprivate type in its default definition}}
   associatedtype PublicDefault = PublicStruct
-  associatedtype PrivateDefaultConformer: PublicProto = PrivateStruct // expected-error {{associated type in a public protocol uses a private type in its default definition}}
-  associatedtype PublicDefaultConformer: PrivateProto = PublicStruct // expected-error {{associated type in a public protocol uses a private type in its requirement}}
-  associatedtype PrivatePrivateDefaultConformer: PrivateProto = PrivateStruct // expected-error {{associated type in a public protocol uses a private type in its requirement}}
+  associatedtype PrivateDefaultConformer: PublicProto = PrivateStruct // expected-error {{associated type in a public protocol uses a fileprivate type in its default definition}}
+  associatedtype PublicDefaultConformer: PrivateProto = PublicStruct // expected-error {{associated type in a public protocol uses a fileprivate type in its requirement}}
+  associatedtype PrivatePrivateDefaultConformer: PrivateProto = PrivateStruct // expected-error {{associated type in a public protocol uses a fileprivate type in its requirement}}
   associatedtype PublicPublicDefaultConformer: PublicProto = PublicStruct
 }
 
 public protocol RequirementTypes {
-  var x: PrivateStruct { get } // expected-error {{property cannot be declared public because its type uses a private type}}
+  // FIXME: These types are actually private; they're just being reported as
+  // fileprivate because they're top-level.
+  var x: PrivateStruct { get } // expected-error {{property cannot be declared public because its type uses a fileprivate type}}
   subscript(x: Int) -> InternalStruct { get set } // expected-error {{subscript cannot be declared public because its element type uses an internal type}}
-  func foo() -> PrivateStruct // expected-error {{method cannot be declared public because its result uses a private type}}
-  init(x: PrivateStruct) // expected-error {{initializer cannot be declared public because its parameter uses a private type}}
+  func foo() -> PrivateStruct // expected-error {{method cannot be declared public because its result uses a fileprivate type}}
+  init(x: PrivateStruct) // expected-error {{initializer cannot be declared public because its parameter uses a fileprivate type}}
 }
 
-protocol DefaultRefinesPrivate : PrivateProto {} // expected-error {{protocol must be declared private because it refines a private protocol}}
-public protocol PublicRefinesPrivate : PrivateProto {} // expected-error {{public protocol cannot refine a private protocol}}
+// FIXME: These types are actually private; they're just being reported as
+// fileprivate because they're top-level.
+protocol DefaultRefinesPrivate : PrivateProto {} // expected-error {{protocol must be declared fileprivate because it refines a fileprivate protocol}}
+public protocol PublicRefinesPrivate : PrivateProto {} // expected-error {{public protocol cannot refine a fileprivate protocol}}
 public protocol PublicRefinesInternal : InternalProto {} // expected-error {{public protocol cannot refine an internal protocol}}
-public protocol PublicRefinesPI : PrivateProto, InternalProto {} // expected-error {{public protocol cannot refine a private protocol}}
-public protocol PublicRefinesIP : InternalProto, PrivateProto {} // expected-error {{public protocol cannot refine a private protocol}}
+public protocol PublicRefinesPI : PrivateProto, InternalProto {} // expected-error {{public protocol cannot refine a fileprivate protocol}}
+public protocol PublicRefinesIP : InternalProto, PrivateProto {} // expected-error {{public protocol cannot refine a fileprivate protocol}}
 
 
+// FIXME: These types are actually private; they're just being reported as
+// fileprivate because they're top-level.
 // expected-note@+1 * {{type declared here}}
 private typealias PrivateInt = Int
-enum DefaultRawPrivate : PrivateInt { // expected-error {{enum must be declared private because its raw type uses a private type}}
+enum DefaultRawPrivate : PrivateInt { // expected-error {{enum must be declared fileprivate because its raw type uses a fileprivate type}}
   case A
 }
-public enum PublicRawPrivate : PrivateInt { // expected-error {{enum cannot be declared public because its raw type uses a private type}}
+public enum PublicRawPrivate : PrivateInt { // expected-error {{enum cannot be declared public because its raw type uses a fileprivate type}}
   case A
 }
-public enum MultipleConformance : PrivateProto, PrivateInt { // expected-error {{enum cannot be declared public because its raw type uses a private type}} expected-error {{must appear first}} {{35-35=PrivateInt, }} {{47-59=}}
+public enum MultipleConformance : PrivateProto, PrivateInt { // expected-error {{enum cannot be declared public because its raw type uses a fileprivate type}} expected-error {{must appear first}} {{35-35=PrivateInt, }} {{47-59=}}
   case A
   func privateReq() {}
 }
 
+// FIXME: These types are actually private; they're just being reported as
+// fileprivate because they're top-level.
 public class PublicSubclassPublic : PublicClass {}
 public class PublicSubclassInternal : InternalClass {} // expected-error {{class cannot be declared public because its superclass is internal}}
-public class PublicSubclassPrivate : PrivateClass {} // expected-error {{class cannot be declared public because its superclass is private}}
+public class PublicSubclassPrivate : PrivateClass {} // expected-error {{class cannot be declared public because its superclass is fileprivate}}
 
 class DefaultSubclassPublic : PublicClass {}
 class DefaultSubclassInternal : InternalClass {}
-class DefaultSubclassPrivate : PrivateClass {} // expected-error {{class must be declared private because its superclass is private}}
+class DefaultSubclassPrivate : PrivateClass {} // expected-error {{class must be declared fileprivate because its superclass is fileprivate}}
 
 
 public enum PublicEnumPrivate {
-  case A(PrivateStruct) // expected-error {{enum case in a public enum uses a private type}}
+  // FIXME: These types is actually private; it's just being reported as
+  // fileprivate because it's top-level.
+  case A(PrivateStruct) // expected-error {{enum case in a public enum uses a fileprivate type}}
 }
 enum DefaultEnumPrivate {
-  case A(PrivateStruct) // expected-error {{enum case in an internal enum uses a private type}}
+  // FIXME: This types is actually private; it's just being reported as
+  // fileprivate because it's top-level.
+  case A(PrivateStruct) // expected-error {{enum case in an internal enum uses a fileprivate type}}
 }
 public enum PublicEnumPI {
   case A(InternalStruct) // expected-error {{enum case in a public enum uses an internal type}}
-  case B(PrivateStruct, InternalStruct) // expected-error {{enum case in a public enum uses a private type}}
-  case C(InternalStruct, PrivateStruct) // expected-error {{enum case in a public enum uses a private type}}
+  // FIXME: These types are actually private; they're just being reported as
+  // fileprivate because they're top-level.
+  case B(PrivateStruct, InternalStruct) // expected-error {{enum case in a public enum uses a fileprivate type}}
+  case C(InternalStruct, PrivateStruct) // expected-error {{enum case in a public enum uses a fileprivate type}}
 }
 enum DefaultEnumPublic {
   case A(PublicStruct) // no-warning
 }
 
 struct DefaultGeneric<T> {}
-struct DefaultGenericPrivate<T: PrivateProto> {} // expected-error {{generic struct must be declared private because its generic parameter uses a private type}}
-struct DefaultGenericPrivate2<T: PrivateClass> {} // expected-error {{generic struct must be declared private because its generic parameter uses a private type}}
+// FIXME: These types are actually private; they're just being reported as
+// fileprivate because they're top-level.
+struct DefaultGenericPrivate<T: PrivateProto> {} // expected-error {{generic struct must be declared fileprivate because its generic parameter uses a fileprivate type}}
+struct DefaultGenericPrivate2<T: PrivateClass> {} // expected-error {{generic struct must be declared fileprivate because its generic parameter uses a fileprivate type}}
 struct DefaultGenericPrivateReq<T where T == PrivateClass> {} // expected-error {{same-type requirement makes generic parameter 'T' non-generic}}
-// expected-error@-1 {{generic struct must be declared private because its generic requirement uses a private type}}
-struct DefaultGenericPrivateReq2<T where T: PrivateProto> {} // expected-error {{generic struct must be declared private because its generic requirement uses a private type}}
+// expected-error@-1 {{generic struct must be declared fileprivate because its generic requirement uses a fileprivate type}}
+struct DefaultGenericPrivateReq2<T where T: PrivateProto> {} // expected-error {{generic struct must be declared fileprivate because its generic requirement uses a fileprivate type}}
 
 public struct PublicGenericInternal<T: InternalProto> {} // expected-error {{generic struct cannot be declared public because its generic parameter uses an internal type}}
-public struct PublicGenericPI<T: PrivateProto, U: InternalProto> {} // expected-error {{generic struct cannot be declared public because its generic parameter uses a private type}}
-public struct PublicGenericIP<T: InternalProto, U: PrivateProto> {} // expected-error {{generic struct cannot be declared public because its generic parameter uses a private type}}
-public struct PublicGenericPIReq<T: PrivateProto where T: InternalProto> {} // expected-error {{generic struct cannot be declared public because its generic parameter uses a private type}}
-public struct PublicGenericIPReq<T: InternalProto where T: PrivateProto> {} // expected-error {{generic struct cannot be declared public because its generic requirement uses a private type}}
+// FIXME: These types are actually private; they're just being reported as
+// fileprivate because they're top-level.
+public struct PublicGenericPI<T: PrivateProto, U: InternalProto> {} // expected-error {{generic struct cannot be declared public because its generic parameter uses a fileprivate type}}
+public struct PublicGenericIP<T: InternalProto, U: PrivateProto> {} // expected-error {{generic struct cannot be declared public because its generic parameter uses a fileprivate type}}
+public struct PublicGenericPIReq<T: PrivateProto where T: InternalProto> {} // expected-error {{generic struct cannot be declared public because its generic parameter uses a fileprivate type}}
+public struct PublicGenericIPReq<T: InternalProto where T: PrivateProto> {} // expected-error {{generic struct cannot be declared public because its generic requirement uses a fileprivate type}}
 
 public func genericFunc<T: InternalProto>(_: T) {} // expected-error {{function cannot be declared public because its generic parameter uses an internal type}} {}
 public class GenericClass<T: InternalProto> { // expected-error {{generic class cannot be declared public because its generic parameter uses an internal type}}
-  public init<T: PrivateProto>(_: T) {} // expected-error {{initializer cannot be declared public because its generic parameter uses a private type}}
-  public func genericMethod<T: PrivateProto>(_: T) {} // expected-error {{instance method cannot be declared public because its generic parameter uses a private type}}
+  // FIXME: These types are actually private; they're just being reported as
+  // fileprivate because they're top-level.
+  public init<T: PrivateProto>(_: T) {} // expected-error {{initializer cannot be declared public because its generic parameter uses a fileprivate type}}
+  public func genericMethod<T: PrivateProto>(_: T) {} // expected-error {{instance method cannot be declared public because its generic parameter uses a fileprivate type}}
 }
 public enum GenericEnum<T: InternalProto> { // expected-error {{generic enum cannot be declared public because its generic parameter uses an internal type}}
   case A

--- a/test/Sema/accessibility.swift
+++ b/test/Sema/accessibility.swift
@@ -476,3 +476,63 @@ public struct PrivateSettersForReadOnlyPublic : PublicReadOnlyOperations {
   }
 }
 
+
+public protocol PublicOperatorProto {
+  static prefix func !(_: Self) -> Self
+}
+
+internal protocol InternalOperatorProto {
+  static prefix func !(_: Self) -> Self
+}
+
+fileprivate protocol FilePrivateOperatorProto {
+  static prefix func !(_: Self) -> Self
+}
+
+private protocol PrivateOperatorProto {
+  static prefix func !(_: Self) -> Self
+}
+
+public struct PublicOperatorAdopter : PublicOperatorProto {
+  fileprivate struct Inner : PublicOperatorProto {
+  }
+}
+private prefix func !(input: PublicOperatorAdopter) -> PublicOperatorAdopter { // expected-error {{method '!' must be declared public because it matches a requirement in public protocol 'PublicOperatorProto'}} {{1-8=public}}
+  return input
+}
+private prefix func !(input: PublicOperatorAdopter.Inner) -> PublicOperatorAdopter.Inner {
+  return input
+}
+
+public struct InternalOperatorAdopter : InternalOperatorProto {
+  fileprivate struct Inner : InternalOperatorProto {
+  }
+}
+private prefix func !(input: InternalOperatorAdopter) -> InternalOperatorAdopter { // expected-error {{method '!' must be declared internal because it matches a requirement in internal protocol 'InternalOperatorProto'}} {{1-8=internal}}
+  return input
+}
+private prefix func !(input: InternalOperatorAdopter.Inner) -> InternalOperatorAdopter.Inner {
+  return input
+}
+
+public struct FilePrivateOperatorAdopter : FilePrivateOperatorProto {
+  fileprivate struct Inner : FilePrivateOperatorProto {
+  }
+}
+private prefix func !(input: FilePrivateOperatorAdopter) -> FilePrivateOperatorAdopter {
+  return input
+}
+private prefix func !(input: FilePrivateOperatorAdopter.Inner) -> FilePrivateOperatorAdopter.Inner {
+  return input
+}
+
+public struct PrivateOperatorAdopter : PrivateOperatorProto {
+  fileprivate struct Inner : PrivateOperatorProto {
+  }
+}
+private prefix func !(input: PrivateOperatorAdopter) -> PrivateOperatorAdopter {
+  return input
+}
+private prefix func !(input: PrivateOperatorAdopter.Inner) -> PrivateOperatorAdopter.Inner {
+  return input
+}

--- a/test/SourceKit/DocumentStructure/access_parse.swift.response
+++ b/test/SourceKit/DocumentStructure/access_parse.swift.response
@@ -61,7 +61,7 @@
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.accessibility: source.lang.swift.accessibility.private,
+          key.accessibility: source.lang.swift.accessibility.fileprivate,
           key.name: "fpFunc()",
           key.offset: 149,
           key.length: 16,
@@ -130,7 +130,7 @@
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.accessibility: source.lang.swift.accessibility.private,
+          key.accessibility: source.lang.swift.accessibility.fileprivate,
           key.name: "fpFunc()",
           key.offset: 325,
           key.length: 16,
@@ -223,7 +223,7 @@
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.accessibility: source.lang.swift.accessibility.private,
+          key.accessibility: source.lang.swift.accessibility.fileprivate,
           key.name: "fpFunc()",
           key.offset: 547,
           key.length: 16,
@@ -292,7 +292,7 @@
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
-          key.accessibility: source.lang.swift.accessibility.private,
+          key.accessibility: source.lang.swift.accessibility.fileprivate,
           key.name: "fpFunc()",
           key.offset: 725,
           key.length: 16,
@@ -447,7 +447,7 @@
     {
       key.kind: source.lang.swift.decl.var.global,
       key.accessibility: source.lang.swift.accessibility.public,
-      key.setter_accessibility: source.lang.swift.accessibility.private,
+      key.setter_accessibility: source.lang.swift.accessibility.fileprivate,
       key.name: "pubFPSetProp",
       key.offset: 1083,
       key.length: 22,

--- a/test/attr/accessibility.swift
+++ b/test/attr/accessibility.swift
@@ -163,7 +163,7 @@ protocol InternalProto { // expected-note * {{declared here}}
 public extension InternalProto {} // expected-error {{extension of internal protocol cannot be declared public}} {{1-8=}}
 internal extension InternalProto where Assoc == PublicStruct {}
 internal extension InternalProto where Assoc == InternalStruct {}
-internal extension InternalProto where Assoc == PrivateStruct {} // expected-error {{extension cannot be declared internal because its generic requirement uses a private type}}
+internal extension InternalProto where Assoc == PrivateStruct {} // expected-error {{extension cannot be declared internal because its generic requirement uses a fileprivate type}}
 private extension InternalProto where Assoc == PublicStruct {}
 private extension InternalProto where Assoc == InternalStruct {}
 private extension InternalProto where Assoc == PrivateStruct {}
@@ -174,10 +174,10 @@ public protocol PublicProto {
 public extension PublicProto {}
 public extension PublicProto where Assoc == PublicStruct {}
 public extension PublicProto where Assoc == InternalStruct {} // expected-error {{extension cannot be declared public because its generic requirement uses an internal type}}
-public extension PublicProto where Assoc == PrivateStruct {} // expected-error {{extension cannot be declared public because its generic requirement uses a private type}}
+public extension PublicProto where Assoc == PrivateStruct {} // expected-error {{extension cannot be declared public because its generic requirement uses a fileprivate type}}
 internal extension PublicProto where Assoc == PublicStruct {}
 internal extension PublicProto where Assoc == InternalStruct {}
-internal extension PublicProto where Assoc == PrivateStruct {} // expected-error {{extension cannot be declared internal because its generic requirement uses a private type}}
+internal extension PublicProto where Assoc == PrivateStruct {} // expected-error {{extension cannot be declared internal because its generic requirement uses a fileprivate type}}
 private extension PublicProto where Assoc == PublicStruct {}
 private extension PublicProto where Assoc == InternalStruct {}
 private extension PublicProto where Assoc == PrivateStruct {}

--- a/test/attr/accessibility_print.swift
+++ b/test/attr/accessibility_print.swift
@@ -9,10 +9,10 @@
 // CHECK-LABEL: internal var AA_defaultGlobal
 var AA_defaultGlobal = 0
 
-// CHECK: private{{(\*/)?}} var AB_privateGlobal
-// CHECK: internal{{(\*/)?}} var AC_internalGlobal
-// CHECK: public{{(\*/)?}} var AD_publicGlobal
-// CHECK: {{^}}private{{(\*/)?}} var AE_fileprivateGlobal
+// CHECK: {{^}}private{{(\*/)?}} var AB_privateGlobal
+// CHECK: {{^}}internal{{(\*/)?}} var AC_internalGlobal
+// CHECK: {{^}}public{{(\*/)?}} var AD_publicGlobal
+// CHECK: {{^}}fileprivate{{(\*/)?}} var AE_fileprivateGlobal
 private var AB_privateGlobal = 0
 internal var AC_internalGlobal = 0
 public var AD_publicGlobal = 0
@@ -56,12 +56,12 @@ public struct BE_PublicStructPrivateMembers {
   // CHECK: internal init()
 } // CHECK: {{^[}]}}
 
-// CHECK-LABEL: {{^}}private{{(\*/)?}} struct BF_FilePrivateStruct {
+// CHECK-LABEL: {{^}}fileprivate{{(\*/)?}} struct BF_FilePrivateStruct {
 fileprivate struct BF_FilePrivateStruct {
   // CHECK: {{^}} internal var x
   var x = 0
-  // CHECK: {{^}} private init(x: Int)
-  // CHECK: {{^}} private init()
+  // CHECK: {{^}} fileprivate init(x: Int)
+  // CHECK: {{^}} fileprivate init()
 } // CHECK: {{^[}]}}
 
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -958,11 +958,14 @@ namespace  {
 static UIdent getAccessibilityUID(Accessibility Access) {
   static UIdent AccessPublic("source.lang.swift.accessibility.public");
   static UIdent AccessInternal("source.lang.swift.accessibility.internal");
+  static UIdent AccessFilePrivate("source.lang.swift.accessibility.fileprivate");
   static UIdent AccessPrivate("source.lang.swift.accessibility.private");
 
   switch (Access) {
   case Accessibility::Private:
     return AccessPrivate;
+  case Accessibility::FilePrivate:
+    return AccessFilePrivate;
   case Accessibility::Internal:
     return AccessInternal;
   case Accessibility::Public:


### PR DESCRIPTION
`fileprivate` is considered a broader level of access than `private`, but for now both of them are still available to the entire file. This is intended as a migration aid.

One interesting fallout of the "access scope" model described in 758cf64 is that something declared `private` at file scope is actually treated as `fileprivate` for diagnostic purposes. This is something
we can fix later, once the full model is in place. (It's not really _wrong_ in that they have identical behavior, but diagnostics still shouldn't refer to a type explicitly declared `private` as `fileprivate`.)

As a note, ValueDecl::getEffectiveAccess will always return `FilePrivate` rather than `Private`; for purposes of optimization and code generation, we should never try to distinguish these two cases.

This should have essentially no effect on code that's _not_ using `fileprivate` other than altered diagnostics, but if we need to back out I've put the interesting changes behind a new LangOptions flag, EnableSwift3Private.

Progress on [SE-0025](https://github.com/apple/swift-evolution/blob/master/proposals/0025-scoped-access-level.md)

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
