### PR TITLE
[swiftc (71 vs. 5115)] Add crasher in swift::constraints::ConstraintSystem::diagnoseFailureForExpr(...)

### DIFF
--- a/validation-test/compiler_crashers/28376-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
+++ b/validation-test/compiler_crashers/28376-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+class B<enum B{case c
+var:{if c


### PR DESCRIPTION
Add test case for crash triggered in `swift::constraints::ConstraintSystem::diagnoseFailureForExpr(...)`.

Current number of unresolved compiler crashers: 71 (5115 resolved)

Assertion failure in `llvm/include/llvm/Support/Casting.h (line 237)`:

```
Assertion `isa<X>(Val) && "cast<Ty>() argument of incompatible type!"' failed.

When executing: typename cast_retty<X, Y *>::ret_type llvm::cast(Y *) [X = swift::AnyMetatypeType, Y = swift::TypeBase]
```

Assertion context:

```
                          typename simplify_type<Y>::SimpleType>::doit(Val);
}

template <class X, class Y>
inline typename cast_retty<X, Y *>::ret_type cast(Y *Val) {
  assert(isa<X>(Val) && "cast<Ty>() argument of incompatible type!");
  return cast_convert_val<X, Y*,
                          typename simplify_type<Y*>::SimpleType>::doit(Val);
}

// cast_or_null<X> - Functionally identical to cast, except that a null value is
```

Stack trace:

```
swift: /path/to/llvm/include/llvm/Support/Casting.h:237: typename cast_retty<X, Y *>::ret_type llvm::cast(Y *) [X = swift::AnyMetatypeType, Y = swift::TypeBase]: Assertion `isa<X>(Val) && "cast<Ty>() argument of incompatible type!"' failed.
9  swift           0x0000000000f7d2fa swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 8698
10 swift           0x0000000000f8085e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 3998
11 swift           0x0000000000eb0882 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 850
12 swift           0x0000000000eb744d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 621
13 swift           0x0000000000eb9154 swift::TypeChecker::typeCheckCondition(swift::Expr*&, swift::DeclContext*) + 180
14 swift           0x0000000000eb92ab swift::TypeChecker::typeCheckStmtCondition(llvm::MutableArrayRef<swift::StmtConditionElement>&, swift::DeclContext*, swift::Diag<>) + 251
18 swift           0x0000000000f3182a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
19 swift           0x0000000000f3168e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
20 swift           0x0000000000f32253 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
22 swift           0x0000000000eecb01 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
23 swift           0x0000000000c73279 swift::CompilerInstance::performSema() + 3289
25 swift           0x00000000007d94b7 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
26 swift           0x00000000007a54b8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28376-swift-constraints-constraintsystem-diagnosefailureforexpr.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28376-swift-constraints-constraintsystem-diagnosefailureforexpr-9a6535.o
1.  While type-checking declaration 0x5cf0350 at validation-test/compiler_crashers/28376-swift-constraints-constraintsystem-diagnosefailureforexpr.swift:11:5
2.  While type-checking expression at [validation-test/compiler_crashers/28376-swift-constraints-constraintsystem-diagnosefailureforexpr.swift:11:9 - line:11:9] RangeText="c"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
