### PR TITLE
[SIL] Add test case for crash triggered in swift::GenericSignature::getCanonicalSignature()

### DIFF
--- a/validation-test/SIL/crashers/028-swift-genericsignature-getcanonicalsignature.sil
+++ b/validation-test/SIL/crashers/028-swift-genericsignature-getcanonicalsignature.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+sil_global@d:$(<τ>()->(


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:25: error: expected type
sil_global@d:$(<τ>()->(
<stdin>:3:25: error: expected ',' separator
sil_global@d:$(<τ>()->(
<stdin>:3:25: error: expected ',' separator
sil_global@d:$(<τ>()->(
<stdin>:3:25: error: expected type
sil_global@d:$(<τ>()->(
<stdin>:3:25: error: expected ',' separator
sil_global@d:$(<τ>()->(
4  sil-opt         0x0000000000e2b537 swift::GenericSignature::getCanonicalSignature() const + 7
7  sil-opt         0x0000000000b617b4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
8  sil-opt         0x0000000000b60750 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
9  sil-opt         0x0000000000b14911 swift::performTypeLocChecking(swift::ASTContext&, swift::TypeLoc&, bool, swift::DeclContext*, bool) + 561
11 sil-opt         0x0000000000a5c2b4 swift::Parser::parseSILGlobal() + 548
12 sil-opt         0x0000000000a982fb swift::Parser::parseTopLevel() + 731
13 sil-opt         0x0000000000a51170 swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) + 208
14 sil-opt         0x00000000007726c6 swift::CompilerInstance::performSema() + 3254
15 sil-opt         0x000000000075bb9d main + 1805
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  With parser at source location: <stdin>:3:25
2.  While resolving type (() -> ()) at [<stdin>:3:15 - line:3:24] RangeText="(<τ>()->("
```
