### PR TITLE
Add basic CString <-> UTF8 API variants.

### DIFF
--- a/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
@@ -26,7 +26,7 @@ public func _stdlib_mkstemps(_ template: inout String, _ suffixlen: CInt) -> CIn
   let (fd, fileName) = utf8.withUnsafeMutableBufferPointer {
     (utf8) -> (CInt, String) in
     let fd = mkstemps(UnsafeMutablePointer(utf8.baseAddress!), suffixlen)
-    let fileName = String(cString: UnsafePointer(utf8.baseAddress!))
+    let fileName = String(cString: utf8.baseAddress!)
     return (fd, fileName)
   }
   template = fileName

--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -44,7 +44,21 @@ extension String {
   ///
   /// - Parameter cString: A pointer to a null-terminated UTF-8 code sequence.
   public init(cString: UnsafePointer<CChar>) {
-    self = String.decodeCString(UnsafePointer(cString), as: UTF8.self,
+    let len = UTF8._nullCodeUnitOffset(in: cString)
+    let (result, _) = cString.withMemoryRebound(to: UInt8.self, capacity: len) {
+      _decodeCString($0, as: UTF8.self, length: len,
+        repairingInvalidCodeUnits: true)!
+    }
+    self = result
+  }
+
+  /// Creates a new string by copying the null-terminated UTF-8 data referenced
+  /// by the given pointer.
+  ///
+  /// This is identical to init(cString: UnsafePointer<CChar> but operates on an
+  /// unsigned sequence of bytes.
+  public init(cString: UnsafePointer<UInt8>) {
+    self = String.decodeCString(cString, as: UTF8.self,
       repairingInvalidCodeUnits: true)!.result
   }
 
@@ -75,10 +89,13 @@ extension String {
   ///
   /// - Parameter cString: A pointer to a null-terminated UTF-8 code sequence.
   public init?(validatingUTF8 cString: UnsafePointer<CChar>) {
-    guard let (result, _) = String.decodeCString(
-        UnsafePointer(cString),
-        as: UTF8.self,
-        repairingInvalidCodeUnits: false) else {
+    let len = UTF8._nullCodeUnitOffset(in: cString)
+    guard let (result, _) =
+    cString.withMemoryRebound(to: UInt8.self, capacity: len, {
+        _decodeCString($0, as: UTF8.self, length: len,
+          repairingInvalidCodeUnits: false)
+      })
+    else {
       return nil
     }
     self = result
@@ -138,14 +155,8 @@ extension String {
       return nil
     }
     let len = encoding._nullCodeUnitOffset(in: cString)
-    let buffer = UnsafeBufferPointer<Encoding.CodeUnit>(
-      start: cString, count: len)
-
-    let (stringBuffer, hadError) = _StringBuffer.fromCodeUnits(
-      buffer, encoding: encoding, repairIllFormedSequences: isRepairing)
-    return stringBuffer.map {
-      (result: String(_storage: $0), repairsMade: hadError)
-    }
+    return _decodeCString(cString, as: encoding, length: len,
+      repairingInvalidCodeUnits: isRepairing)
   }
 
 }
@@ -163,6 +174,26 @@ public func _persistCString(_ p: UnsafePointer<CChar>?) -> [CChar]? {
     result[i] = s[i]
   }
   return result
+}
+
+/// Creates a new string by copying the null-terminated data referenced by
+/// the given pointer using the specified encoding.
+///
+/// This internal helper takes the string length as an argument.
+public func _decodeCString<Encoding : UnicodeCodec>(
+  _ cString: UnsafePointer<Encoding.CodeUnit>,
+  as encoding: Encoding.Type, length: Int,
+  repairingInvalidCodeUnits isRepairing: Bool = true)
+-> (result: String, repairsMade: Bool)? {
+
+  let buffer = UnsafeBufferPointer<Encoding.CodeUnit>(
+    start: cString, count: length)
+
+  let (stringBuffer, hadError) = _StringBuffer.fromCodeUnits(
+    buffer, encoding: encoding, repairIllFormedSequences: isRepairing)
+  return stringBuffer.map {
+    (result: String(_storage: $0), repairsMade: hadError)
+  }
 }
 
 extension String {

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -406,6 +406,21 @@ extension String {
     return result
   }
 
+  /// A contiguously stored null-terminated UTF-8 representation of
+  /// the string.
+  ///
+  /// This is a variation on nulTerminatedUTF8 that creates an array
+  /// of element type CChar for use with CString API's.
+  public var nulTerminatedUTF8CString: ContiguousArray<CChar> {
+    var result = ContiguousArray<CChar>()
+    result.reserveCapacity(utf8.count + 1)
+    for c in utf8 {
+      result.append(CChar(bitPattern: c))
+    }
+    result.append(0)
+    return result
+  }
+
   internal func _withUnsafeBufferPointerToUTF8<R>(
     _ body: @noescape (UnsafeBufferPointer<UTF8.CodeUnit>) throws -> R
   ) rethrows -> R {

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -429,6 +429,10 @@ public struct UTF8 : UnicodeCodec {
   public static func _nullCodeUnitOffset(in input: UnsafePointer<CodeUnit>) -> Int {
     return Int(_swift_stdlib_strlen(UnsafePointer(input)))
   }
+  // Support parsing C strings as-if they are UTF8 strings.
+  public static func _nullCodeUnitOffset(in input: UnsafePointer<CChar>) -> Int {
+    return Int(_swift_stdlib_strlen(input))
+  }
 }
 
 /// A codec for translating between Unicode scalar values and UTF-16 code


### PR DESCRIPTION
As proposed by SE-0107: UnsafeRawPointer:
https://github.com/apple/swift-evolution/blob/master/proposals/0107-unsaferawpointer.md#cstring-conversion
Adds String.init(cString: UnsafePointer<UInt8>)
Adds String.nulTerminatedUTF8CString: ContiguousArray<CChar>

This is necessary for eliminating UnsafePointer conversion.  Such
conversion is extremely common for interoperability between Swift
strings and C strings to bridge the difference between CChar and
UTF8.CodeUnit. The standard library does not provide any convenient
utilities for converting between the differently typed
buffers. These APIs will handle the simplest cases involving C
interoperability. More convenience can be added later.
