### PR TITLE
[swiftc (72 vs. 5115)] Add crasher in swift::Expr::walk(...)

### DIFF
--- a/validation-test/compiler_crashers/28377-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers/28377-swift-expr-walk.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+struct A{init(){protocol A{init()func a}guard let c=A().a{


### PR DESCRIPTION
Add test case for crash triggered in `swift::Expr::walk(...)`.

Current number of unresolved compiler crashers: 72 (5115 resolved)

Assertion failure in [`lib/Sema/CSApply.cpp (line 683)`](https://github.com/apple/swift/blob/master/lib/Sema/CSApply.cpp#L683):

```
Assertion `baseTy->isAnyExistentialType() && "Type must be existential"' failed.

When executing: swift::Expr *(anonymous namespace)::ExprRewriter::openExistentialReference(swift::Expr *, swift::ArchetypeType *, swift::ValueDecl *)
```

Assertion context:

```
      if (auto metaTy = baseTy->getAs<AnyMetatypeType>()) {
        isMetatype = true;
        baseTy = metaTy->getInstanceType();
      }

      assert(baseTy->isAnyExistentialType() && "Type must be existential");

      // If the base was an lvalue but it will only be treated as an
      // rvalue, turn the base into an rvalue now. This results in
      // better SILGen.
      if (isLValue &&
```

Stack trace:

```
swift: /path/to/swift/lib/Sema/CSApply.cpp:683: swift::Expr *(anonymous namespace)::ExprRewriter::openExistentialReference(swift::Expr *, swift::ArchetypeType *, swift::ValueDecl *): Assertion `baseTy->isAnyExistentialType() && "Type must be existential"' failed.
13 swift           0x0000000001082adc swift::Expr::walk(swift::ASTWalker&) + 108
14 swift           0x0000000000f5e782 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 514
15 swift           0x0000000000eb74ea swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 778
16 swift           0x0000000000eb8600 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 352
17 swift           0x0000000000eb9325 swift::TypeChecker::typeCheckStmtCondition(llvm::MutableArrayRef<swift::StmtConditionElement>&, swift::DeclContext*, swift::Diag<>) + 373
21 swift           0x0000000000f31c7d swift::TypeChecker::typeCheckConstructorBodyUntil(swift::ConstructorDecl*, swift::SourceLoc) + 845
22 swift           0x0000000000f31682 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 34
23 swift           0x0000000000f32253 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
25 swift           0x0000000000eecb01 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
26 swift           0x0000000000c73279 swift::CompilerInstance::performSema() + 3289
28 swift           0x00000000007d94b7 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
29 swift           0x00000000007a54b8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28377-swift-expr-walk.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28377-swift-expr-walk-38fbfa.o
1.  While type-checking 'init' at validation-test/compiler_crashers/28377-swift-expr-walk.swift:10:10
2.  While type-checking expression at [validation-test/compiler_crashers/28377-swift-expr-walk.swift:10:53 - line:10:57] RangeText="A().a"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
