### PR TITLE
[SIL] Add test case for crash triggered in swift::Parser::parseSILScope()

### DIFF
--- a/validation-test/SIL/crashers/029-swift-parser-parsesilscope.sil
+++ b/validation-test/SIL/crashers/029-swift-parser-parsesilscope.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+sil_scope 2


### PR DESCRIPTION
Stack trace:

```
sil-opt: /path/to/swift/include/swift/Parse/Parser.h:412: swift::SourceLoc swift::Parser::consumeToken(swift::tok): Assertion `Tok.is(K) && "Consuming wrong token kind"' failed.
8  sil-opt         0x0000000000a62cae swift::Parser::parseSILScope() + 2478
9  sil-opt         0x0000000000a9835b swift::Parser::parseTopLevel() + 827
10 sil-opt         0x0000000000a51170 swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) + 208
11 sil-opt         0x00000000007726c6 swift::CompilerInstance::performSema() + 3254
12 sil-opt         0x000000000075bb9d main + 1805
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  With parser at source location: <stdin>:3:12
```
