### PR TITLE
[SourceKit] Add test case for crash triggered in swift::ArchetypeBuilder::mapTypeOutOfContext(…)

### DIFF
--- a/validation-test/IDE/crashers/079-swift-archetypebuilder-maptypeoutofcontext.swift
+++ b/validation-test/IDE/crashers/079-swift-archetypebuilder-maptypeoutofcontext.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+struct B<T{class B<T:B<T>n#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 152
swift-ide-test: /path/to/swift/lib/AST/ArchetypeBuilder.cpp:2086: static swift::Type swift::ArchetypeBuilder::mapTypeOutOfContext(swift::ModuleDecl *, swift::GenericParamList *, swift::Type): Assertion `!canType->hasTypeParameter() && "already have an interface type"' failed.
8  swift-ide-test  0x0000000000b42a35 swift::ArchetypeBuilder::mapTypeOutOfContext(swift::ModuleDecl*, swift::GenericParamList*, swift::Type) + 293
9  swift-ide-test  0x000000000098019f swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 5471
10 swift-ide-test  0x00000000009c07f5 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::GenericSignature*, bool, swift::GenericTypeResolver*) + 389
11 swift-ide-test  0x00000000009c2d09 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) + 265
12 swift-ide-test  0x00000000009816eb swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 363
17 swift-ide-test  0x0000000000986ee6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
18 swift-ide-test  0x00000000009ab6d2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
19 swift-ide-test  0x00000000007a6dc9 swift::CompilerInstance::performSema() + 3289
20 swift-ide-test  0x000000000074a181 main + 34609
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking 'B' at <INPUT-FILE>:3:1
```
