### PR TITLE
[SourceKit] Add test case for crash triggered in swift::ValueDecl::getInterfaceType()

### DIFF
--- a/validation-test/IDE/crashers/080-swift-valuedecl-getinterfacetype.swift
+++ b/validation-test/IDE/crashers/080-swift-valuedecl-getinterfacetype.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+let a{protocol e{let t={func b(e=#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 159
swift-ide-test: /path/to/swift/lib/AST/Decl.cpp:1688: swift::Type swift::ValueDecl::getInterfaceType() const: Assertion `!isa<AbstractFunctionDecl>(this) && "functions should have an interface type"' failed.
8  swift-ide-test  0x0000000000c1d666 swift::ValueDecl::getInterfaceType() const + 422
9  swift-ide-test  0x0000000000c481cd swift::Mangle::Mangler::getDeclTypeForMangling(swift::ValueDecl const*, llvm::ArrayRef<swift::GenericTypeParamType*>&, unsigned int&, llvm::ArrayRef<swift::Requirement>&, llvm::SmallVectorImpl<swift::Requirement>&) + 93
10 swift-ide-test  0x0000000000c480c2 swift::Mangle::Mangler::mangleDeclType(swift::ValueDecl const*, unsigned int) + 114
11 swift-ide-test  0x0000000000c86321 swift::ide::printDeclUSR(swift::ValueDecl const*, llvm::raw_ostream&) + 929
13 swift-ide-test  0x00000000007af6d8 copyAssociatedUSRs(llvm::BumpPtrAllocatorImpl<llvm::MallocAllocator, 4096ul, 4096ul>&, swift::Decl const*) + 104
14 swift-ide-test  0x00000000007b055c swift::ide::CodeCompletionResultBuilder::takeResult() + 1676
18 swift-ide-test  0x0000000000c3f7e0 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 256
23 swift-ide-test  0x0000000000bbbd34 swift::Decl::walk(swift::ASTWalker&) + 20
24 swift-ide-test  0x0000000000c5449e swift::SourceFile::walk(swift::ASTWalker&) + 174
25 swift-ide-test  0x0000000000c535df swift::ModuleDecl::walk(swift::ASTWalker&) + 79
26 swift-ide-test  0x0000000000c2a6db swift::DeclContext::walkContext(swift::ASTWalker&) + 187
27 swift-ide-test  0x00000000008eeb68 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 136
28 swift-ide-test  0x00000000007a6efd swift::CompilerInstance::performSema() + 3597
29 swift-ide-test  0x000000000074a181 main + 34609
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl getter for a at <INPUT-FILE>:3:6
```
