### PR TITLE
[SIL] Add test case for crash triggered in swift::TypeChecker::checkDeclAttributes(…)

### DIFF
--- a/validation-test/SIL/crashers/030-swift-typechecker-checkdeclattributes.sil
+++ b/validation-test/SIL/crashers/030-swift-typechecker-checkdeclattributes.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+@_specialize(h)func f


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:22: error: expected '(' in argument list of function declaration
@_specialize(h)func f
                     ^
5  sil-opt         0x0000000000c16941 swift::TypeChecker::checkDeclAttributes(swift::Decl*) + 49
8  sil-opt         0x0000000000aef886 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
9  sil-opt         0x0000000000b13f92 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
10 sil-opt         0x00000000007726e9 swift::CompilerInstance::performSema() + 3289
11 sil-opt         0x000000000075bb9d main + 1805
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  While type-checking 'f' at <stdin>:3:16
```
