### PR TITLE
[SourceKit] Add test case for crash triggered in swift::GenericSignature::getSubstitutionMap(…)

### DIFF
--- a/validation-test/IDE/crashers/081-swift-genericsignature-getsubstitutionmap.swift
+++ b/validation-test/IDE/crashers/081-swift-genericsignature-getsubstitutionmap.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+let a{func a<T{(){func a<T{class a class A:a#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 170
swift-ide-test: /path/to/llvm/include/llvm/ADT/ArrayRef.h:139: const T &llvm::ArrayRef<swift::Substitution>::front() const [T = swift::Substitution]: Assertion `!empty()' failed.
8  swift-ide-test  0x0000000000c3bb56 swift::GenericSignature::getSubstitutionMap(llvm::ArrayRef<swift::Substitution>) const + 566
9  swift-ide-test  0x0000000000a09d01 swift::createDesignatedInitOverride(swift::TypeChecker&, swift::ClassDecl*, swift::ConstructorDecl*, swift::DesignatedInitKind) + 385
10 swift-ide-test  0x000000000098cde2 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 3250
13 swift-ide-test  0x0000000000986ee6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
16 swift-ide-test  0x00000000009efc4a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
17 swift-ide-test  0x00000000009efaae swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
18 swift-ide-test  0x00000000009adb0f swift::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 655
23 swift-ide-test  0x0000000000bbbd34 swift::Decl::walk(swift::ASTWalker&) + 20
24 swift-ide-test  0x0000000000c5449e swift::SourceFile::walk(swift::ASTWalker&) + 174
25 swift-ide-test  0x0000000000c535df swift::ModuleDecl::walk(swift::ASTWalker&) + 79
26 swift-ide-test  0x0000000000c2a6db swift::DeclContext::walkContext(swift::ASTWalker&) + 187
27 swift-ide-test  0x00000000008eeb68 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 136
28 swift-ide-test  0x00000000007a6efd swift::CompilerInstance::performSema() + 3597
29 swift-ide-test  0x000000000074a181 main + 34609
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl getter for a at <INPUT-FILE>:3:6
2.  While type-checking 'A' at <INPUT-FILE>:3:36
```
