### PR TITLE
[SIL] Add test case for crash triggered in swift::TypeChecker::configureInterfaceType(…)

### DIFF
--- a/validation-test/SIL/crashers/031-swift-typechecker-configureinterfacetype.sil
+++ b/validation-test/SIL/crashers/031-swift-typechecker-configureinterfacetype.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+func y:@opened(Any


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:7: error: expected '(' in argument list of function declaration
func y:@opened(Any
      ^
<stdin>:3:7: error: expected '->' after function parameter tuple
func y:@opened(Any
      ^
      ->
<stdin>:3:16: error: known id for 'opened' attribute must be a UUID string
func y:@opened(Any
               ^
<stdin>:3:16: error: expected ')' after id value for 'opened' attribute
func y:@opened(Any
               ^
<stdin>:3:15: note: to match this opening '('
func y:@opened(Any
              ^
sil-opt: /path/to/swift/lib/Sema/TypeCheckGeneric.cpp:650: void swift::TypeChecker::configureInterfaceType(swift::AbstractFunctionDecl *): Assertion `!funcTy->hasArchetype()' failed.
8  sil-opt         0x0000000000b2aedf swift::TypeChecker::configureInterfaceType(swift::AbstractFunctionDecl*) + 2047
11 sil-opt         0x0000000000aef886 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
12 sil-opt         0x0000000000b13f92 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
13 sil-opt         0x00000000007726e9 swift::CompilerInstance::performSema() + 3289
14 sil-opt         0x000000000075bb9d main + 1805
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  While type-checking 'y' at <stdin>:3:1
```
