### PR TITLE
[SourceKit] Add test case for crash triggered in llvm::llvm_unreachable_internal(…)

### DIFF
--- a/validation-test/IDE/crashers/082-swift-typebase-gatherallsubstitutions.swift
+++ b/validation-test/IDE/crashers/082-swift-typebase-gatherallsubstitutions.swift
@@ -1,0 +1,5 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+class B<T{
+class A
+class B:A{func b{#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 162
Not a nominal or bound generic type
UNREACHABLE executed at /path/to/swift/lib/AST/Module.cpp:642!
6  swift-ide-test  0x0000000002eca1cd llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) + 461
7  swift-ide-test  0x0000000000c4fbae swift::TypeBase::gatherAllSubstitutions(swift::ModuleDecl*, swift::LazyResolver*, swift::DeclContext*) + 4398
8  swift-ide-test  0x0000000000c76ec1 swift::TypeBase::getSuperclass(swift::LazyResolver*) + 193
17 swift-ide-test  0x0000000000bbbd34 swift::Decl::walk(swift::ASTWalker&) + 20
18 swift-ide-test  0x0000000000c5449e swift::SourceFile::walk(swift::ASTWalker&) + 174
19 swift-ide-test  0x0000000000c535df swift::ModuleDecl::walk(swift::ASTWalker&) + 79
20 swift-ide-test  0x0000000000c2a6db swift::DeclContext::walkContext(swift::ASTWalker&) + 187
21 swift-ide-test  0x00000000008eeb68 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 136
22 swift-ide-test  0x00000000007a6efd swift::CompilerInstance::performSema() + 3597
23 swift-ide-test  0x000000000074a181 main + 34609
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl 'B' at <INPUT-FILE>:3:1
```
