### PR TITLE
[SIL] Add test case for crash triggered in swift::IterativeTypeChecker::satisfy(…)

### DIFF
--- a/validation-test/SIL/crashers/032-swift-iterativetypechecker-satisfy.sil
+++ b/validation-test/SIL/crashers/032-swift-iterativetypechecker-satisfy.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+typealias E:<__>__


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:12: error: expected '=' in typealias declaration
typealias E:<__>__
           ^
           =
<stdin>:3:13: error: only syntactic function types can be generic
typealias E:<__>__
            ^
sil-opt: /path/to/swift/lib/Sema/IterativeTypeChecker.cpp:103: void swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest): Assertion `isSatisfied(request)' failed.
9  sil-opt         0x0000000000bff669 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 889
12 sil-opt         0x0000000000aeac64 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3396
15 sil-opt         0x0000000000aef886 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
16 sil-opt         0x0000000000b13f92 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
17 sil-opt         0x00000000007726e9 swift::CompilerInstance::performSema() + 3289
18 sil-opt         0x000000000075bb9d main + 1805
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  While type-checking 'E' at <stdin>:3:1
2.  While type-checking 'E' at <stdin>:3:1
```
