### PR TITLE
[SourceKit] Add test case for crash triggered in swift::DeclContext::getGenericParamsOfContext()

### DIFF
--- a/validation-test/IDE/crashers/083-swift-declcontext-getgenericparamsofcontext.swift
+++ b/validation-test/IDE/crashers/083-swift-declcontext-getgenericparamsofcontext.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+class B<T{var d{var d:T{class s#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 157
4  swift-ide-test  0x0000000000c29727 swift::DeclContext::getGenericParamsOfContext() const + 23
5  swift-ide-test  0x0000000000b428f0 swift::ArchetypeBuilder::mapTypeOutOfContext(swift::DeclContext const*, swift::Type) + 16
6  swift-ide-test  0x0000000000c46e6c swift::Mangle::Mangler::mangleType(swift::Type, unsigned int) + 4156
7  swift-ide-test  0x0000000000c48142 swift::Mangle::Mangler::mangleDeclType(swift::ValueDecl const*, unsigned int) + 242
8  swift-ide-test  0x0000000000c4528d swift::Mangle::Mangler::mangleNominalType(swift::NominalTypeDecl const*) + 157
9  swift-ide-test  0x0000000000c862c8 swift::ide::printDeclUSR(swift::ValueDecl const*, llvm::raw_ostream&) + 840
11 swift-ide-test  0x00000000007af6d8 copyAssociatedUSRs(llvm::BumpPtrAllocatorImpl<llvm::MallocAllocator, 4096ul, 4096ul>&, swift::Decl const*) + 104
12 swift-ide-test  0x00000000007b055c swift::ide::CodeCompletionResultBuilder::takeResult() + 1676
16 swift-ide-test  0x0000000000c3f912 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 562
23 swift-ide-test  0x0000000000bbbd34 swift::Decl::walk(swift::ASTWalker&) + 20
24 swift-ide-test  0x0000000000c5449e swift::SourceFile::walk(swift::ASTWalker&) + 174
25 swift-ide-test  0x0000000000c535df swift::ModuleDecl::walk(swift::ASTWalker&) + 79
26 swift-ide-test  0x0000000000c2a6db swift::DeclContext::walkContext(swift::ASTWalker&) + 187
27 swift-ide-test  0x00000000008eeb68 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 136
28 swift-ide-test  0x00000000007a6efd swift::CompilerInstance::performSema() + 3597
29 swift-ide-test  0x000000000074a181 main + 34609
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl 'B' at <INPUT-FILE>:3:1
```
