### PR TITLE
[swiftc (73 vs. 5115)] Add crasher in swift::TypeChecker::resolveWitness(...)

### DIFF
--- a/validation-test/compiler_crashers/28378-swift-typechecker-resolvewitness.swift
+++ b/validation-test/compiler_crashers/28378-swift-typechecker-resolvewitness.swift
@@ -1,0 +1,15 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+func<{@objc protocol C{
+func a
+protocol a{class B<b:a{
+protocol A{enum S<T{
+struct D:C{
+func a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::resolveWitness(...)`.

Current number of unresolved compiler crashers: 73 (5115 resolved)

Assertion failure in [`lib/Sema/CSApply.cpp (line 148)`](https://github.com/apple/swift/blob/master/lib/Sema/CSApply.cpp#L148):

```
Assertion `(conforms || replacement->is<ErrorType>() || firstArchetype->getIsRecursive() || isOpenedAnyObject(replacement) || replacement->is<GenericTypeParamType>()) && "Constraint system missed a conformance?"' failed.

When executing: swift::Type swift::constraints::Solution::computeSubstitutions(swift::Type, swift::DeclContext *, swift::Type, swift::constraints::ConstraintLocator *, SmallVectorImpl<swift::Substitution> &) const
```

Assertion context:

```
      assert((conforms ||
              replacement->is<ErrorType>() ||
              firstArchetype->getIsRecursive() ||
              isOpenedAnyObject(replacement) ||
              replacement->is<GenericTypeParamType>()) &&
             "Constraint system missed a conformance?");
      (void)conforms;

      assert(conformance ||
             replacement->is<ErrorType>() ||
             replacement->hasDependentProtocolConformances());
```

Stack trace:

```
swift: /path/to/swift/lib/Sema/CSApply.cpp:148: swift::Type swift::constraints::Solution::computeSubstitutions(swift::Type, swift::DeclContext *, swift::Type, swift::constraints::ConstraintLocator *, SmallVectorImpl<swift::Substitution> &) const: Assertion `(conforms || replacement->is<ErrorType>() || firstArchetype->getIsRecursive() || isOpenedAnyObject(replacement) || replacement->is<GenericTypeParamType>()) && "Constraint system missed a conformance?"' failed.
14 swift           0x0000000000f1428c swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) + 668
15 swift           0x000000000113166b swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const + 171
16 swift           0x0000000000f13c20 swift::TypeChecker::findWitnessedObjCRequirements(swift::ValueDecl const*, bool) + 368
32 swift           0x0000000000ec9406 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
35 swift           0x0000000000f3182a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
36 swift           0x0000000000f3168e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
37 swift           0x0000000000f32253 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
39 swift           0x0000000000eecb01 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
40 swift           0x0000000000c73279 swift::CompilerInstance::performSema() + 3289
42 swift           0x00000000007d94b7 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
43 swift           0x00000000007a54b8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28378-swift-typechecker-resolvewitness.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28378-swift-typechecker-resolvewitness-1fc026.o
1.  While type-checking '<' at validation-test/compiler_crashers/28378-swift-typechecker-resolvewitness.swift:10:1
2.  While type-checking 'C' at validation-test/compiler_crashers/28378-swift-typechecker-resolvewitness.swift:10:13
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
