### PR TITLE
Add UnsafeMutableRawPointer.init(mutating:)

### DIFF
--- a/stdlib/public/core/UnsafeRawPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawPointer.swift.gyb
@@ -68,7 +68,7 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
     _rawValue = other._rawValue
   }
 
-  /// Convert an Unsafe${Mutable}Pointer ${a_Self}.
+  /// Convert an Unsafe${Mutable}Pointer to ${a_Self}.
   ///
   /// Returns nil if `other` is nil.
   @_transparent
@@ -77,14 +77,29 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
     _rawValue = unwrapped._rawValue
   }
 
-%  if not mutable:
-  /// Convert an UnsafeMutableRawPointer ${a_Self}.
+%  if mutable:
+  /// Convert an UnsafeRawPointer to ${a_Self}.
+  @_transparent
+  public init(mutating other: UnsafeRawPointer) {
+    _rawValue = other._rawValue
+  }
+
+  /// Convert an UnsafeRawPointer to ${a_Self}.
+  ///
+  /// Returns nil if `other` is nil.
+  @_transparent
+  public init?(mutating other: UnsafeRawPointer?) {
+    guard let unwrapped = other else { return nil }
+    _rawValue = unwrapped._rawValue
+  }
+%  else: # !mutable
+  /// Convert an UnsafeMutableRawPointer to ${a_Self}.
   @_transparent
   public init(_ other: UnsafeMutableRawPointer) {
     _rawValue = other._rawValue
   }
 
-  /// Convert an UnsafeMutableRawPointer ${a_Self}.
+  /// Convert an UnsafeMutableRawPointer to ${a_Self}.
   ///
   /// Returns nil if `other` is nil.
   @_transparent
@@ -93,13 +108,13 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
     _rawValue = unwrapped._rawValue
   }
 
-  /// Convert an UnsafeMutablePointer ${a_Self}.
+  /// Convert an UnsafeMutablePointer to ${a_Self}.
   @_transparent
   public init<T>(_ other: UnsafeMutablePointer<T>) {
     _rawValue = other._rawValue
   }
 
-  /// Convert an UnsafeMutablePointer ${a_Self}.
+  /// Convert an UnsafeMutablePointer to ${a_Self}.
   ///
   /// Returns nil if `other` is nil.
   @_transparent

--- a/test/1_stdlib/UnsafePointer.swift.gyb
+++ b/test/1_stdlib/UnsafePointer.swift.gyb
@@ -76,6 +76,25 @@ ${SelfName}TestSuite.test("initFromOpaquePointer") {
 % end
 
 % for (SelfName, SelfType) in [
+%         ('UnsafeRawPointer', 'UnsafeRawPointer'),
+%         ('UnsafeMutableRawPointer', 'UnsafeMutableRawPointer')]:
+UnsafeMutableRawPointerTestSuite.test("initFromMutating") {
+  let other = UnsafeRawPointer(bitPattern: 0x12345678)!
+  let ptr = UnsafeMutableRawPointer(mutating: other)
+  expectEqual(0x12345678, unsafeBitCast(ptr, to: Int.self))
+
+  let optionalOther: Optional = other
+  let optionalPointer = UnsafeMutableRawPointer(mutating: optionalOther)
+  expectNotEmpty(optionalPointer)
+  expectEqual(0x12345678, unsafeBitCast(optionalPointer, to: Int.self))
+
+  let nilOther: Optional<UnsafeRawPointer> = nil
+  let nilPointer = UnsafeMutableRawPointer(mutating: nilOther)
+  expectEmpty(nilPointer)
+}
+% end
+
+% for (SelfName, SelfType) in [
 %         ('UnsafePointer', 'UnsafePointer<Float>'),
 %         ('UnsafeMutablePointer', 'UnsafeMutablePointer<Float>'),
 %         ('UnsafeRawPointer', 'UnsafeRawPointer'),


### PR DESCRIPTION
As proposed in SE-0107: UnsafeRawPointer.

Allow immutable raw pointers to be explicitly cast
into mutable raw pointers.
