### PR TITLE
[DO NOT MERGE] [stdlib] Move the public API of AutoreleasingUnsafeMutablePointer to …

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -753,7 +753,7 @@ NominalTypeDecl *ASTContext::getUnsafePointerDecl() const {
 NominalTypeDecl *ASTContext::getAutoreleasingUnsafeMutablePointerDecl() const {
   if (!Impl.AutoreleasingUnsafeMutablePointerDecl)
     Impl.AutoreleasingUnsafeMutablePointerDecl
-      = findStdlibType(*this, "AutoreleasingUnsafeMutablePointer", 1);
+      = findStdlibType(*this, "_AutoreleasingUnsafeMutablePointer", 1);
   
   return Impl.AutoreleasingUnsafeMutablePointerDecl;
 }

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -351,7 +351,7 @@ namespace {
           quals.getObjCLifetime() == clang::Qualifiers::OCL_ExplicitNone) {
         return {
           Impl.getNamedSwiftTypeSpecialization(
-            Impl.getStdlibModule(), "AutoreleasingUnsafeMutablePointer",
+            Impl.getStdlibModule(), "_AutoreleasingUnsafeMutablePointer",
             pointeeType),
           ImportHint::OtherPointer};
       }
@@ -1179,7 +1179,7 @@ static Type adjustTypeForConcreteImport(ClangImporter::Implementation &impl,
     if (importKind == ImportTypeKind::CFRetainedOutParameter)
       pointerName = "UnsafeMutablePointer";
     else
-      pointerName = "AutoreleasingUnsafeMutablePointer";
+      pointerName = "_AutoreleasingUnsafeMutablePointer";
 
     resultTy = impl.getNamedSwiftTypeSpecialization(impl.getStdlibModule(),
                                                     pointerName,

--- a/lib/IRGen/GenClangType.cpp
+++ b/lib/IRGen/GenClangType.cpp
@@ -442,7 +442,7 @@ GenClangType::visitBoundGenericType(CanBoundGenericType type) {
     .Case("UnsafeMutablePointer", StructKind::UnsafeMutablePointer)
     .Case("UnsafePointer", StructKind::UnsafePointer)
     .Case(
-      "AutoreleasingUnsafeMutablePointer",
+      "_AutoreleasingUnsafeMutablePointer",
         StructKind::AutoreleasingUnsafeMutablePointer)
     .Case("Unmanaged", StructKind::Unmanaged)
     .Case("CFunctionPointer", StructKind::CFunctionPointer)

--- a/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
+++ b/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
@@ -243,3 +243,29 @@ extension NSObject : CVarArg {
   }
 }
 
+//===----------------------------------------------------------------------===//
+// AutoreleasingUnsafeMutablePointer
+//===----------------------------------------------------------------------===//
+
+/// A mutable pointer-to-ObjC-pointer argument.
+///
+/// This type has implicit conversions to allow passing any of the following
+/// to a C or ObjC API:
+///
+/// - `nil`, which gets passed as a null pointer,
+/// - an inout argument of the referenced type, which gets passed as a pointer
+///   to a writeback temporary with autoreleasing ownership semantics,
+/// - an `UnsafeMutablePointer<Pointee>`, which is passed as-is.
+///
+/// Passing pointers to mutable arrays of ObjC class pointers is not
+/// directly supported. Unlike `UnsafeMutablePointer<Pointee>`,
+/// `AutoreleasingUnsafeMutablePointer<Pointee>` must reference storage that
+/// does not own a reference count to the referenced
+/// value. UnsafeMutablePointer's operations, by contrast, assume that
+/// the referenced storage owns values loaded from or stored to it.
+///
+/// This type does not carry an owner pointer unlike the other C*Pointer types
+/// because it only needs to reference the results of inout conversions, which
+/// already have writeback-scoped lifetime.
+public typealias AutoreleasingUnsafeMutablePointer<Pointee> =
+  _AutoreleasingUnsafeMutablePointer<Pointee>

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -369,7 +369,7 @@ internal var _nilNativeObject: AnyObject? {
 ///
 /// Passing pointers to mutable arrays of ObjC class pointers is not
 /// directly supported. Unlike `UnsafeMutablePointer<Pointee>`,
-/// `AutoreleasingUnsafeMutablePointer<Pointee>` must reference storage that
+/// `_AutoreleasingUnsafeMutablePointer<Pointee>` must reference storage that
 /// does not own a reference count to the referenced
 /// value. UnsafeMutablePointer's operations, by contrast, assume that
 /// the referenced storage owns values loaded from or stored to it.
@@ -378,7 +378,7 @@ internal var _nilNativeObject: AnyObject? {
 /// because it only needs to reference the results of inout conversions, which
 /// already have writeback-scoped lifetime.
 @_fixed_layout
-public struct AutoreleasingUnsafeMutablePointer<Pointee /* TODO : class */>
+public struct _AutoreleasingUnsafeMutablePointer<Pointee /* TODO : class */>
   : Equatable, _Pointer {
 
   public let _rawValue: Builtin.RawPointer
@@ -401,7 +401,7 @@ public struct AutoreleasingUnsafeMutablePointer<Pointee /* TODO : class */>
     }
     /// Set the value the pointer points to, copying over the previous value.
     ///
-    /// AutoreleasingUnsafeMutablePointers are assumed to reference a
+    /// _AutoreleasingUnsafeMutablePointers are assumed to reference a
     /// value with __autoreleasing ownership semantics, like 'NSFoo**'
     /// in ARC. This autoreleases the argument before trivially
     /// storing it to the referenced memory.
@@ -436,7 +436,7 @@ public struct AutoreleasingUnsafeMutablePointer<Pointee /* TODO : class */>
   ///
   /// This is inherently unsafe; UnsafeMutablePointer assumes the
   /// referenced memory has +1 strong ownership semantics, whereas
-  /// AutoreleasingUnsafeMutablePointer implies +0 semantics.
+  /// _AutoreleasingUnsafeMutablePointer implies +0 semantics.
   @_transparent public
   init<U>(_ from: UnsafeMutablePointer<U>) {
     self._rawValue = from._rawValue
@@ -448,7 +448,7 @@ public struct AutoreleasingUnsafeMutablePointer<Pointee /* TODO : class */>
   ///
   /// This is inherently unsafe; UnsafeMutablePointer assumes the
   /// referenced memory has +1 strong ownership semantics, whereas
-  /// AutoreleasingUnsafeMutablePointer implies +0 semantics.
+  /// _AutoreleasingUnsafeMutablePointer implies +0 semantics.
   @_transparent public
   init?<U>(_ from: UnsafeMutablePointer<U>?) {
     guard let unwrapped = from else { return nil }
@@ -477,7 +477,7 @@ public struct AutoreleasingUnsafeMutablePointer<Pointee /* TODO : class */>
   }
 }
 
-extension AutoreleasingUnsafeMutablePointer : CustomDebugStringConvertible {
+extension _AutoreleasingUnsafeMutablePointer : CustomDebugStringConvertible {
   /// A textual representation of `self`, suitable for debugging.
   public var debugDescription: String {
     return _rawPointerToString(_rawValue)
@@ -486,8 +486,8 @@ extension AutoreleasingUnsafeMutablePointer : CustomDebugStringConvertible {
 
 @_transparent
 public func == <Pointee>(
-  lhs: AutoreleasingUnsafeMutablePointer<Pointee>,
-  rhs: AutoreleasingUnsafeMutablePointer<Pointee>
+  lhs: _AutoreleasingUnsafeMutablePointer<Pointee>,
+  rhs: _AutoreleasingUnsafeMutablePointer<Pointee>
 ) -> Bool {
   return Bool(Builtin.cmp_eq_RawPointer(lhs._rawValue, rhs._rawValue))
 }
@@ -540,7 +540,7 @@ internal struct _CocoaFastEnumerationStackBuf {
   }
 }
 
-extension AutoreleasingUnsafeMutablePointer {
+extension _AutoreleasingUnsafeMutablePointer {
   @available(*, unavailable, renamed: "Pointee")
   public typealias Memory = Pointee
 

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -3215,7 +3215,7 @@ final internal class _Native${Self}StorageKeyNSEnumerator<
     var theState = state.pointee
     if theState.state == 0 {
       theState.state = 1 // Arbitrary non-zero value.
-      theState.itemsPtr = AutoreleasingUnsafeMutablePointer(objects)
+      theState.itemsPtr = _AutoreleasingUnsafeMutablePointer(objects)
       theState.mutationsPtr = _fastEnumerationStorageMutationsPtr
     }
 
@@ -3548,7 +3548,7 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
     var theState = state.pointee
     if theState.state == 0 {
       theState.state = 1 // Arbitrary non-zero value.
-      theState.itemsPtr = AutoreleasingUnsafeMutablePointer(objects)
+      theState.itemsPtr = _AutoreleasingUnsafeMutablePointer(objects)
       theState.mutationsPtr = _fastEnumerationStorageMutationsPtr
       theState.extra.0 = CUnsignedLong(nativeStorage.startIndex.offset)
     }

--- a/stdlib/public/core/Pointer.swift
+++ b/stdlib/public/core/Pointer.swift
@@ -12,7 +12,7 @@
 
 /// A stdlib-internal protocol modeled by the intrinsic pointer types,
 /// UnsafeMutablePointer, UnsafePointer, and
-/// AutoreleasingUnsafeMutablePointer.
+/// _AutoreleasingUnsafeMutablePointer.
 public protocol _Pointer {
   /// The underlying raw pointer value.
   var _rawValue: Builtin.RawPointer { get }

--- a/stdlib/public/core/SwiftNativeNSArray.swift
+++ b/stdlib/public/core/SwiftNativeNSArray.swift
@@ -105,7 +105,7 @@ extension _SwiftNativeNSArrayWithContiguousStorage : _NSArrayCore {
       objects in
       enumerationState.mutationsPtr = _fastEnumerationStorageMutationsPtr
       enumerationState.itemsPtr =
-        AutoreleasingUnsafeMutablePointer(objects.baseAddress)
+        _AutoreleasingUnsafeMutablePointer(objects.baseAddress)
       enumerationState.state = 1
       state.pointee = enumerationState
       return objects.count

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -245,7 +245,7 @@ extension UnsafeMutablePointer : CVarArg {
 }
 
 #if _runtime(_ObjC)
-extension AutoreleasingUnsafeMutablePointer : CVarArg {
+extension _AutoreleasingUnsafeMutablePointer : CVarArg {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
   public var _cVarArgEncoding: [Int] {


### PR DESCRIPTION
…the ObjectiveC overlay from StdlibCore.
