### PR TITLE
Fix "Cannot use Swift.Error protocol in ObjC protocols"

### DIFF
--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -1246,7 +1246,7 @@ private:
     os << (isMetatype ? "Class" : "id");
 
     auto proto = PT->getDecl();
-    assert(proto->isObjC());
+    assert(proto->isObjC() || proto->getKnownProtocolKind() == KnownProtocolKind::Error);
     if (auto knownKind = proto->getKnownProtocolKind()) {
       if (*knownKind == KnownProtocolKind::AnyObject) {
         printNullability(optionalKind);

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -1246,7 +1246,7 @@ private:
     os << (isMetatype ? "Class" : "id");
 
     auto proto = PT->getDecl();
-    assert(proto->isObjC() || proto->getKnownProtocolKind() == KnownProtocolKind::Error);
+    assert(proto->isObjC() || *proto->getKnownProtocolKind() == KnownProtocolKind::Error);
     if (auto knownKind = proto->getKnownProtocolKind()) {
       if (*knownKind == KnownProtocolKind::AnyObject) {
         printNullability(optionalKind);

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -1630,7 +1630,8 @@ public:
 
   void forwardDeclare(const ProtocolDecl *PD) {
     assert(PD->isObjC() ||
-           *PD->getKnownProtocolKind() == KnownProtocolKind::AnyObject);
+           *PD->getKnownProtocolKind() == KnownProtocolKind::AnyObject ||
+           *PD->getKnownProtocolKind() == KnownProtocolKind::Error);
     forwardDeclare(PD, [&]{
       os << "@protocol " << getNameForObjC(PD) << ";\n";
     });

--- a/test/PrintAsObjC/Inputs/error-delegate.h
+++ b/test/PrintAsObjC/Inputs/error-delegate.h
@@ -4,5 +4,6 @@
 @protocol ABCErrorProtocol <NSObject>
 
 - (void)didFail:(NSError * _Nonnull)error;
+- (void)didFailOptional:(NSError * _Nullable)error;
 
 @end

--- a/test/PrintAsObjC/Inputs/error-delegate.h
+++ b/test/PrintAsObjC/Inputs/error-delegate.h
@@ -1,0 +1,8 @@
+// This file is meant to be used with the mock SDK, not the real one.
+#import <Foundation.h>
+
+@protocol ABCErrorProtocol <NSObject>
+
+- (void)didFail:(NSError * _Nonnull)error;
+
+@end

--- a/test/PrintAsObjC/error-delegate.swift
+++ b/test/PrintAsObjC/error-delegate.swift
@@ -1,0 +1,27 @@
+// Please keep this file in alphabetical order!
+
+// REQUIRES: objc_interop
+
+// RUN: rm -rf %t && mkdir %t
+
+// FIXME: BEGIN -enable-source-import hackaround
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+// FIXME: END -enable-source-import hackaround
+
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/error-delegate.h -emit-module -o %t %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/error-delegate.h -parse-as-library %t/error-delegate.swiftmodule -parse -emit-objc-header-path %t/error-delegate.h
+
+// RUN: FileCheck %s < %t/error-delegate.h
+// RUN: %check-in-clang %t/error-delegate.h
+
+import Foundation
+
+// CHECK-LABEL: @interface Test : NSObject <ABCErrorProtocol>
+// CHECK-NEXT: - (void)didFail:(NSError * _Nonnull)error;
+// CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
+// CHECK-NEXT: @end
+class Test : NSObject, ABCErrorProtocol {
+    func didFail(_ error: Swift.Error) {}
+}

--- a/test/PrintAsObjC/error-delegate.swift
+++ b/test/PrintAsObjC/error-delegate.swift
@@ -20,8 +20,10 @@ import Foundation
 
 // CHECK-LABEL: @interface Test : NSObject <ABCErrorProtocol>
 // CHECK-NEXT: - (void)didFail:(NSError * _Nonnull)error;
+// CHECK-NEXT: - (void)didFailOptional:(NSError * _Nullable)error;
 // CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: @end
 class Test : NSObject, ABCErrorProtocol {
     func didFail(_ error: Swift.Error) {}
+    func didFailOptional(_ error: Swift.Error?) {}
 }


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Allows conforming to Objective-C protocols that contain NSError as an argument. This would previously crash the compiler
#### Resolved bug number: ([SR-2159](https://bugs.swift.org/browse/SR-2159))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
