### PR TITLE
[stdlib] Fix incorrect sort result on small collections with NaN values

### DIFF
--- a/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
@@ -363,6 +363,8 @@ extension CGFloat : CustomReflectable {
   }
 }
 
+extension CGFloat: _SupportsNaNCheck {}
+
 //===----------------------------------------------------------------------===//
 // Standard Operator Table
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -755,6 +755,8 @@ extension ${Self} : Arithmetic {
   }
 }
 
+extension ${Self} : _SupportsNaNCheck {}
+
 @_transparent
 public prefix func + (x: ${Self}) -> ${Self} {
   return x

--- a/stdlib/public/core/Sort.swift.gyb
+++ b/stdlib/public/core/Sort.swift.gyb
@@ -19,6 +19,16 @@ def cmp(a, b, p):
 
 }%
 
+/// Used to fix incorrect sorting result when NaN values are involved.
+/// While the FloatingPoint protocol has this same definition, its
+/// Self requirements mean we cannot use the `is` or `as` operators
+/// to check if a variable conforms. Marking the floating point types
+/// as conforming to this protocol allows us to both check if a variable
+/// supports the NaN check and to actually perform that check.
+public protocol _SupportsNaNCheck {
+  var isNaN: Bool { get }
+}
+
 // Generate two versions of sorting functions: one with an explicitly passed
 // predicate 'areInIncreasingOrder' and the other for Comparable types that don't
 // need such a predicate.
@@ -43,9 +53,39 @@ func _insertionSort<C>(
     // One element is trivially already-sorted, thus pre-increment
     // Continue until the sorted elements cover the whole sequence
     elements.formIndex(after: &sortedEnd)
+
+%     if not p:
+    // If NaN is encountered, we move it out of the way and
+    // update the range to be sorted; so we need variable access
+    // to range
+    var range = range
+
+    // If the elements in this collection can't be represented
+    // as NaN, don't attempt to repeatedly check for it later.
+    // Safe to find type from first element as the Comporable
+    // requirement forces a homogeneous array
+    let needsNaNCheck = elements[start] is _SupportsNaNCheck
+%     end
+
     while sortedEnd != range.upperBound {
       // get the first unsorted element
       let x: C.Iterator.Element = elements[sortedEnd]
+
+%       if not p:
+      // If checking for NaN was deemed a necesity, check if the value
+      // is equal to NaN. If so, move it to the end of the range being
+      // sorted and decrement the upper bound of the range; the position
+      // where the NaN is now held is no longer considered part of the
+      // continued sort
+      if needsNaNCheck && (x as? _SupportsNaNCheck)?.isNaN == true {
+        var newUpperBound = range.upperBound
+        elements.formIndex(before: &newUpperBound)
+
+        range = range.lowerBound ..< newUpperBound
+        swap(&elements[sortedEnd], &elements[range.upperBound])
+        continue
+      }
+%       end
 
       // Look backwards for x's position in the sorted sequence,
       // moving elements forward to make room.

--- a/validation-test/stdlib/Sort.swift.gyb
+++ b/validation-test/stdlib/Sort.swift.gyb
@@ -13,10 +13,10 @@ var Algorithm = TestSuite("Algorithm")
 // Check if one array is a correctly sorted version of another array.
 // We can't simply sort both arrays and compare them, because it is needed to
 // check correctness of sorting itself.
-func expectSortedCollection(_ sortedAry: [Int], _ originalAry: [Int]) {
+func expectSortedCollection<T where T: Comparable, T: Hashable>(_ sortedAry: [T], _ originalAry: [T]) {
   expectEqual(sortedAry.count, originalAry.count)
-  var sortedVals = [Int:Int]()
-  var originalVals = [Int:Int]()
+  var sortedVals = [T:Int]()
+  var originalVals = [T:Int]()
   // Keep track of what values we have in sortedAry.
   for e in sortedAry {
     if let v = sortedVals[e] {
@@ -54,6 +54,21 @@ func expectSortedCollection(
 
 func expectSortedCollection(_ sortedAry: ArraySlice<Int>, _ originalAry: ArraySlice<Int>) {
   expectSortedCollection([Int](sortedAry), [Int](originalAry))
+}
+
+func expectSortedCollectionIgnoringNaN(_ sortedAry: [Double]) {
+  // Perform check for sorted array while ignoring NaN
+  // values, as standard check of each element against the
+  // previous breaks given NaN inequality rules
+  var minElementFound = Double(Int.min)-1
+  for i in 0..<sortedAry.count {
+    guard !sortedAry[i].isNaN else {
+      continue
+    }
+
+    expectTrue(minElementFound <= sortedAry[i])
+    minElementFound = sortedAry[i]
+  }
 }
 
 class OffsetCollection : MutableCollection, RandomAccessCollection {
@@ -155,6 +170,22 @@ Algorithm.test("partition/CrashOnSingleElement") {
   var a = DefaultedMutableRandomAccessCollection([10])
   let first = a.first!
   expectEqual(a.startIndex, a.partition(by: {$0 >= first}))
+}
+
+Algorithm.test("sort/SmallCollectionsWithNaNValues") {
+  // Count must be < 20 to trigger insertion sort
+  let count = 18
+  var ary = randArray(count).map { return Double($0) }
+
+  // Add NaN values throughout the array
+  let nanCount = 4
+  for _ in 0 ..< nanCount {
+      let aryInd = (abs(randInt()) % count)
+      ary[aryInd] = .nan
+  }
+
+  let sortedAry = ary.sorted()
+  expectSortedCollectionIgnoringNaN(sortedAry)
 }
 
 runAllTests()


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Calling sort() or sorted() on a small collection (count < 20)
containing NaN values could return incorrect results, sorting
the individual ranges in the collection between the NaN values
but not the collection as a whole.

E.g.:
`[7.0, 6.0, 5.0, .nan, 3.0, 2.0, 1.0].sorted()`
would return
`[5.0, 6.0, 7.0, .nan, 1.0, 2.0, 3.0]`

This case is already inherently handled by the heap sort implementation used for collections with at least 20 elements — this pull request just updates the insertion sort implementation to mirror that behavior and cut down on unexpected behavior.
#### Resolved bug number: ([SR-1990](https://bugs.swift.org/browse/SR-1990))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
