### PR TITLE
Only emit empty inline asm instructions for cond_fail when optimizing.

### DIFF
--- a/test/IRGen/condfail.sil
+++ b/test/IRGen/condfail.sil
@@ -1,12 +1,21 @@
-// RUN: %target-swift-frontend -primary-file %s -O -g -S  | FileCheck %s --check-prefix=CHECK-%target-cpu
+// RUN: %target-swift-frontend -primary-file %s -O -g -S  | FileCheck %s --check-prefix CHECK --check-prefix CHECK-%target-cpu --check-prefix CHECK-OPT-%target-os
+// RUN: %target-swift-frontend -primary-file %s -g -S  | FileCheck %s --check-prefix CHECK --check-prefix CHECK-%target-cpu --check-prefix CHECK-NOOPT-%target-os
 
 import Builtin
 import Swift
 
 // Make sure we emit two traps.
 
-// CHECK-LABEL:       _test_cond_fail:
+// CHECK-LABEL:       test_cond_fail:
 // CHECK:             .cfi_startproc
+// CHECK-OPT-macosx:  ## InlineAsm Start
+// CHECK-OPT-macosx:  ## InlineAsm End
+// CHECK-OPT-linux:   ##APP
+// CHECK-OPT-linux:   ##NO_APP
+// CHECK-NOOPT-macosx-NOT: ## InlineAsm Start
+// CHECK-NOOPT-macosx-NOT: ## InlineAsm End
+// CHECK-NOOPT-linux-NOT:  ##APP
+// CHECK-NOOPT-linux-NOT:  ##NO_APP
 // CHECK-x86_64:      ud2
 // CHECK-i386:        ud2
 // CHECK-arm64:       brk
@@ -16,6 +25,14 @@ import Swift
 // CHECK-powerpc64le: trap
 // CHECK-s390x:       trap
 // CHECK-NOT:         .cfi_endproc
+// CHECK-OPT-macosx:  ## InlineAsm Start
+// CHECK-OPT-macosx:  ## InlineAsm End
+// CHECK-OPT-linux:   ##APP
+// CHECK-OPT-linux:   ##NO_APP
+// CHECK-NOOPT-macosx-NOT: ## InlineAsm Start
+// CHECK-NOOPT-macosx-NOT: ## InlineAsm End
+// CHECK-NOOPT-linux-NOT:  ##APP
+// CHECK-NOOPT-linux-NOT:  ##NO_APP
 // CHECK-x86_64:      ud2
 // CHECK-i386:        ud2
 // CHECK-arm64:       brk


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

We currently emit empty inline asm instructions before traps in order to block code merging and retain unique trap locations.

We don't need to do this when not optimizing, and doing this can block fast isel, so limit this to when we are optimizing.

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

These inline asm instructions are used to block branch folding when
optimizing, to ensure that we have unique trap locations (and associated
debug info) for each cond_fail.

We only need these when we're optimizing, and emitting them can block
fast isel, so only emit them when optimizing.
