### PR TITLE
Import @compatibility_alias as typealias

### DIFF
--- a/test/IDE/Inputs/custom-modules/CompatibilityAlias.h
+++ b/test/IDE/Inputs/custom-modules/CompatibilityAlias.h
@@ -1,0 +1,4 @@
+@import Foundation;
+
+@compatibility_alias StringCheese NSString;
+

--- a/test/IDE/Inputs/custom-modules/module.map
+++ b/test/IDE/Inputs/custom-modules/module.map
@@ -58,3 +58,9 @@ module InferImportAsMember {
   export *
   header "InferImportAsMember.h"
 }
+
+module CompatibilityAlias {
+  header "CompatibilityAlias.h"
+  export *
+}
+

--- a/test/IDE/compatibility_alias.swift
+++ b/test/IDE/compatibility_alias.swift
@@ -1,0 +1,18 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: %build-clang-importer-objc-overlays
+
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk-nosource) -I %t -I %S/Inputs/custom-modules -print-module -source-filename %s -module-to-print=CompatibilityAlias > %t.printed.CompatibilityAlias.txt
+// RUN: FileCheck %s -check-prefix=PRINT -strict-whitespace < %t.printed.CompatibilityAlias.txt
+// RUN: %target-parse-verify-swift -sdk %clang-importer-sdk -I %S/Inputs/custom-modules -I %t %s
+
+// REQUIRES: objc_interop
+
+// PRINT: typealias StringCheese = NSString
+
+import CompatibilityAlias
+
+func dontMove(cheese: StringCheese) -> StringCheese {
+  return cheese
+}
+


### PR DESCRIPTION
#### What's in this pull request?

Objective-C’s `@compatibility_alias` compiler directive is imported as
a Swift `typealias`.

Note: For some reason the test that I wrote for this isn’t passing on my machine but @CodaFi said that it passes for him locally. A bit spooky so I’m curious how it does against CI.
#### Resolved bug number: ([SR-1963](https://bugs.swift.org/browse/SR-1963))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
