### PR TITLE
[preview-4][overlay] adding if #available(...) to Intents test

### DIFF
--- a/test/1_stdlib/Intents.swift
+++ b/test/1_stdlib/Intents.swift
@@ -5,22 +5,20 @@
 // UNSUPPORTED: OS=watchos
 // UNSUPPORTED: OS=tvos
 
-// FIXME: due to the lack of availability attributes in the SDK this test does
-//        not fail on macOS Sierra, but does fail on El Capitan. Marking macOS
-//        as unsupported for now.
-// UNSUPPORTED: OS=macosx
-
 import Intents
 import StdlibUnittest
 
 let IntentsTestSuite = TestSuite("Intents")
 
-IntentsTestSuite.test("ErrorDomain") {
-  expectEqual("IntentsErrorDomain", INIntentErrorDomain)
-}
+if #available(OSX 10.12, iOS 10.0, *) {
 
-IntentsTestSuite.test("extension") {
-  expectEqual("IntentsErrorDomain", INIntentError._nsErrorDomain)
+  IntentsTestSuite.test("ErrorDomain") {
+    expectEqual("IntentsErrorDomain", INIntentErrorDomain)
+  }
+
+  IntentsTestSuite.test("extension") {
+    expectEqual("IntentsErrorDomain", INIntentError._nsErrorDomain)
+  }
 }
 
 runAllTests()


### PR DESCRIPTION
test/1_stdlib/Intents.swift is failing on the preview-4 branch because of missing #available information. This was already fixed on master, so this PR is just a cherry-pick of the fix to the preview-4 branch.
