### PR TITLE
[Sema][SR-720] Fallback to ExprPattern if enum element not found for UnresolvedDotExpr

### DIFF
--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -454,6 +454,8 @@ public:
     EnumElementDecl *referencedElement
       = lookupEnumMemberElement(TC, DC, ty, ude->getName().getBaseName(),
                                 ude->getLoc());
+    if (!referencedElement)
+      return nullptr;
     
     // Build a TypeRepr from the head of the full path.
     // FIXME: Compound names.

--- a/test/ClangModules/enum-with-target.swift
+++ b/test/ClangModules/enum-with-target.swift
@@ -14,7 +14,7 @@ let calendarUnitsDep: CalendarUnitDeprecated = [.eraCalendarUnitDeprecated, .yea
 // rdar://problem/21081557
 func pokeRawValue(_ random: SomeRandomEnum) {
   switch (random) {
-  case SomeRandomEnum.RawValue // expected-error{{enum case 'RawValue' not found in type 'SomeRandomEnum'}}
+  case SomeRandomEnum.RawValue // expected-error{{expression pattern of type 'RawValue.Type' (aka 'Int.Type') cannot match values of type 'SomeRandomEnum'}}
     // expected-error@-1{{expected ':' after 'case'}}
   }
 }

--- a/test/Parse/switch.swift
+++ b/test/Parse/switch.swift
@@ -279,3 +279,30 @@ func f0(values: [Whatever]) { // expected-note {{did you mean 'values'?}}
         break
     }
 }
+
+// sr-720
+enum Whichever {
+  case Thing
+  static let title = "title"
+  static let alias: Whichever = .Thing
+}
+func f1(x: String, y: Whichever) {
+  switch x {
+    case Whichever.title: // Ok. Don't emit diagnostics for static member of enum.
+        break
+    case Whichever.buzz: // expected-error {{type 'Whichever' has no member 'buzz'}}
+        break
+    case Whichever.alias: // expected-error {{expression pattern of type 'Whichever' cannot match values of type 'String'}}
+        break
+    default:
+      break
+  }
+  switch y {
+    case Whichever.Thing: // Ok.
+        break
+    case Whichever.alias: // Ok. Don't emit diagnostics for static member of enum.
+        break
+    case Whichever.title: // expected-error {{expression pattern of type 'String' cannot match values of type 'Whichever'}}
+        break
+  }
+}


### PR DESCRIPTION
#### What's in this pull request?

In `TypeChecker::resolvePattern`.
So that the pattern can refer arbitrary static member of enum type.
#### Resolved bug number: ([SR-720](https://bugs.swift.org/browse/SR-720))

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
