### PR TITLE
Store argument labels + locations in directly in call and call-like expressions

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2093,6 +2093,12 @@ public:
       OS << " super";
     if (E->isThrowsSet())
       OS << (E->throws() ? " throws" : " nothrow");
+    if (auto call = dyn_cast<CallExpr>(E)) {
+      OS << "  arg_labels=";
+      for (auto label : call->getArgumentLabels()) 
+        OS << (label.empty() ? "_" : label.str()) << ":";
+    }
+
     OS << '\n';
     printRec(E->getFn());
     OS << '\n';

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1252,9 +1252,177 @@ ValueDecl *ApplyExpr::getCalledValue() const {
   return ::getCalledValue(Fn);
 }
 
-ArrayRef<Identifier> SubscriptExpr::getArgumentLabels(
-    SmallVectorImpl<Identifier> &scratch) const {
-  return getArgumentLabelsFromArgument(getIndex(), scratch);
+/// Compute the type of an argument to a call (or call-like) AST
+static void computeSingleArgumentType(ASTContext &ctx, Expr *arg,
+                                      bool implicit) {
+  // Propagate 'implicit' to the argument.
+  if (implicit)
+    arg->setImplicit(true);
+
+  // Handle parenthesized expressions.
+  if (auto paren = dyn_cast<ParenExpr>(arg)) {
+    if (auto type = paren->getSubExpr()->getType()) {
+      arg->setType(ParenType::get(ctx, type));
+    }
+    return;
+  }
+
+  // Handle tuples.
+  auto tuple = dyn_cast<TupleExpr>(arg);
+  SmallVector<TupleTypeElt, 4> typeElements;
+  for (unsigned i = 0, n = tuple->getNumElements(); i != n; ++i) {
+    auto type = tuple->getElement(i)->getType();
+    if (!type) return;
+
+    typeElements.push_back(TupleTypeElt(type, tuple->getElementName(i)));
+  }
+  arg->setType(TupleType::get(typeElements, ctx));
+}
+
+/// Pack the argument information into a single argument, to match the
+/// representation expected by the AST.
+///
+/// \param argLabels The argument labels, which might be updated by this
+/// function.
+///
+/// \param argLabelLocs The argument label locations, which might be updated by
+/// this function.
+static Expr *packSingleArgument(
+    ASTContext &ctx,
+    SourceLoc lParenLoc,
+    ArrayRef<Expr *> args,
+    ArrayRef<Identifier> &argLabels,
+    ArrayRef<SourceLoc> &argLabelLocs,
+    SourceLoc rParenLoc,
+    Expr *trailingClosure,
+    bool implicit,
+    SmallVectorImpl<Identifier> &argLabelsScratch,
+    SmallVectorImpl<SourceLoc> &argLabelLocsScratch) {
+  // Clear out our scratch space.
+  argLabelsScratch.clear();
+  argLabelLocsScratch.clear();
+
+  // Construct a TupleExpr or ParenExpr, as appropriate, for the argument.
+  if (!trailingClosure) {
+    // Do we have a single, unlabeled argument?
+    if (args.size() == 1 && (argLabels.empty() || argLabels[0].empty())) {
+      auto arg = new (ctx) ParenExpr(lParenLoc, args[0], rParenLoc,
+                                     /*hasTrailingClosure=*/false);
+      computeSingleArgumentType(ctx, arg, implicit);
+      argLabelsScratch.push_back(Identifier());
+      argLabels = argLabelsScratch;
+      argLabelLocs = { };
+      return arg;
+    }
+
+    // Construct the argument tuple.
+    auto arg = TupleExpr::create(ctx, lParenLoc, args, argLabels, argLabelLocs,
+                                 rParenLoc, /*hasTrailingClosure=*/false,
+                                 /*implicit=*/false);
+    computeSingleArgumentType(ctx, arg, implicit);
+    return arg;
+  }
+
+  // If we have no other arguments, represent the trailing closure as a
+  // parenthesized expression.
+  if (args.size() == 0) {
+    auto arg = new (ctx) ParenExpr(lParenLoc, trailingClosure, rParenLoc,
+                                   /*hasTrailingClosure=*/true);
+    computeSingleArgumentType(ctx, arg, implicit);
+    argLabelsScratch.push_back(Identifier());
+    argLabels = argLabelsScratch;
+    argLabelLocs = { };
+    return arg;
+  }
+
+  // Form a tuple, including the trailing closure.
+  SmallVector<Expr *, 4> argsScratch;
+  argsScratch.reserve(args.size() + 1);
+  argsScratch.append(args.begin(), args.end());
+  argsScratch.push_back(trailingClosure);
+  auto arg = TupleExpr::create(ctx, lParenLoc, argsScratch, argLabels,
+                               argLabelLocs, rParenLoc,
+                               /*hasTrailingClosure=*/true,
+                               /*implicit=*/false);
+  computeSingleArgumentType(ctx, arg, implicit);
+
+  argLabelsScratch.reserve(argLabelsScratch.size() + 1);
+  argLabelsScratch.append(argLabels.begin(), argLabels.end());
+  argLabelsScratch.push_back(Identifier());
+  argLabels = argLabelsScratch;
+
+  if (!argLabelLocs.empty() || argLabels.empty()) {
+    argLabelLocsScratch.reserve(argLabelLocs.size() + 1);
+    argLabelLocsScratch.append(argLabelLocs.begin(), argLabelLocs.end());
+    argLabelLocsScratch.push_back(SourceLoc());
+  }
+  argLabelLocs = argLabelLocsScratch;
+
+  return arg;
+}
+
+SubscriptExpr::SubscriptExpr(Expr *base, Expr *index,
+                             ArrayRef<Identifier> argLabels,
+                             ArrayRef<SourceLoc> argLabelLocs,
+                             bool hasTrailingClosure,
+                             ConcreteDeclRef decl,
+                             bool implicit, AccessSemantics semantics)
+    : Expr(ExprKind::Subscript, implicit, Type()),
+      TheDecl(decl), Base(base), Index(index) {
+  SubscriptExprBits.Semantics = (unsigned) semantics;
+  SubscriptExprBits.IsSuper = false;
+  SubscriptExprBits.NumArgLabels = argLabels.size();
+  SubscriptExprBits.HasArgLabelLocs = !argLabelLocs.empty();
+  SubscriptExprBits.HasTrailingClosure = hasTrailingClosure;
+  initializeCallArguments(argLabels, argLabelLocs, hasTrailingClosure);
+}
+
+SubscriptExpr *SubscriptExpr::create(ASTContext &ctx, Expr *base, Expr *index,
+                                     ConcreteDeclRef decl, bool implicit,
+                                     AccessSemantics semantics) {
+  // Inspect the argument to dig out the argument labels, their location, and
+  // whether there is a trailing closure.
+  SmallVector<Identifier, 4> argLabelsScratch;
+  SmallVector<SourceLoc, 4> argLabelLocs;
+  bool hasTrailingClosure = false;
+  auto argLabels = getArgumentLabelsFromArgument(index, argLabelsScratch,
+                                                 &argLabelLocs,
+                                                 &hasTrailingClosure);
+
+  size_t size = totalSizeToAlloc(argLabels, argLabelLocs, hasTrailingClosure);
+
+  void *memory = ctx.Allocate(size, alignof(SubscriptExpr));
+  return new (memory) SubscriptExpr(base, index, argLabels, argLabelLocs,
+                                    hasTrailingClosure, decl, implicit,
+                                    semantics);
+}
+
+SubscriptExpr *SubscriptExpr::create(ASTContext &ctx, Expr *base,
+                                     SourceLoc lSquareLoc,
+                                     ArrayRef<Expr *> indexArgs,
+                                     ArrayRef<Identifier> indexArgLabels,
+                                     ArrayRef<SourceLoc> indexArgLabelLocs,
+                                     SourceLoc rSquareLoc,
+                                     Expr *trailingClosure,
+                                     ConcreteDeclRef decl,
+                                     bool implicit,
+                                     AccessSemantics semantics) {
+  SmallVector<Identifier, 4> indexArgLabelsScratch;
+  SmallVector<SourceLoc, 4> indexArgLabelLocsScratch;
+  Expr *index = packSingleArgument(ctx, lSquareLoc, indexArgs, indexArgLabels,
+                                   indexArgLabelLocs, rSquareLoc,
+                                   trailingClosure, implicit,
+                                   indexArgLabelsScratch,
+                                   indexArgLabelLocsScratch);
+
+  size_t size = totalSizeToAlloc(indexArgLabels, indexArgLabelLocs,
+                                 trailingClosure != nullptr);
+
+  void *memory = ctx.Allocate(size, alignof(SubscriptExpr));
+  return new (memory) SubscriptExpr(base, index, indexArgLabels,
+                                    indexArgLabelLocs,
+                                    trailingClosure != nullptr,
+                                    decl, implicit, semantics);
 }
 
 ArrayRef<Identifier> DynamicSubscriptExpr::getArgumentLabels(
@@ -1300,17 +1468,9 @@ CallExpr::CallExpr(Expr *fn, Expr *arg, bool Implicit,
     : ApplyExpr(ExprKind::Call, fn, arg, Implicit, ty)
 {
   CallExprBits.NumArgLabels = argLabels.size();
-  if (!argLabels.empty()) {
-    std::uninitialized_copy(argLabels.begin(), argLabels.end(),
-                            getTrailingObjects<Identifier>());
-  }
-
   CallExprBits.HasArgLabelLocs = !argLabelLocs.empty();
-  if (!argLabelLocs.empty())
-    std::uninitialized_copy(argLabelLocs.begin(), argLabelLocs.end(),
-                            getTrailingObjects<SourceLoc>());
-
   CallExprBits.HasTrailingClosure = hasTrailingClosure;
+  initializeCallArguments(argLabels, argLabelLocs, hasTrailingClosure);
 }
 
 CallExpr *CallExpr::create(ASTContext &ctx, Expr *fn, Expr *arg,
@@ -1324,8 +1484,7 @@ CallExpr *CallExpr::create(ASTContext &ctx, Expr *fn, Expr *arg,
                                                  &argLabelLocs,
                                                  &hasTrailingClosure);
 
-  size_t size = totalSizeToAlloc<Identifier, SourceLoc>(argLabels.size(),
-                                                        argLabelLocs.size());
+  size_t size = totalSizeToAlloc(argLabels, argLabelLocs, hasTrailingClosure);
 
   void *memory = ctx.Allocate(size, alignof(CallExpr));
   return new (memory) CallExpr(fn, arg, implicit, argLabels, argLabelLocs,
@@ -1340,96 +1499,18 @@ CallExpr *CallExpr::create(ASTContext &ctx, Expr *fn,
                            SourceLoc rParenLoc,
                            Expr *trailingClosure,
                            bool implicit) {
-  // Local function to compute the type of the argument, if all of its pieces
-  // have a type.
-  auto computeArgType = [&](Expr *arg) {
-    // Propagate 'implicit' to the argument.
-    if (implicit)
-      arg->setImplicit(true);
+  SmallVector<Identifier, 4> argLabelsScratch;
+  SmallVector<SourceLoc, 4> argLabelLocsScratch;
+  Expr *arg = packSingleArgument(ctx, lParenLoc, args, argLabels, argLabelLocs,
+                                 rParenLoc, trailingClosure, implicit,
+                                 argLabelsScratch, argLabelLocsScratch);
 
-    // Handle parenthesized expressions.
-    if (auto paren = dyn_cast<ParenExpr>(arg)) {
-      if (auto type = paren->getSubExpr()->getType()) {
-        arg->setType(ParenType::get(ctx, type));
-      }
-      return;
-    }
+  size_t size = totalSizeToAlloc(argLabels, argLabelLocs,
+                                 trailingClosure != nullptr);
 
-    // Handle tuples.
-    auto tuple = dyn_cast<TupleExpr>(arg);
-    SmallVector<TupleTypeElt, 4> typeElements;
-    for (unsigned i = 0, n = tuple->getNumElements(); i != n; ++i) {
-      auto type = tuple->getElement(i)->getType();
-      if (!type) return;
-
-      typeElements.push_back(TupleTypeElt(type, tuple->getElementName(i)));
-    }
-    arg->setType(TupleType::get(typeElements, ctx));
-  };
-
-  /// Form the resulting call expression.
-  auto formCallExpr = [&](Expr *arg,
-                          ArrayRef<Identifier> argLabels,
-                          ArrayRef<SourceLoc> argLabelLocs) {
-    size_t size = totalSizeToAlloc<Identifier, SourceLoc>(argLabels.size(),
-                                                          argLabelLocs.size());
-
-    void *memory = ctx.Allocate(size, alignof(CallExpr));
-    return new (memory) CallExpr(fn, arg, implicit, argLabels, argLabelLocs,
-                                 trailingClosure != nullptr, Type());
-  };
-
-  // Construct a TupleExpr or ParenExpr, as appropriate, for the argument.
-  if (!trailingClosure) {
-    // Do we have a single, unlabeled argument?
-    if (args.size() == 1 && (argLabels.empty() || argLabels[0].empty())) {
-      auto arg = new (ctx) ParenExpr(lParenLoc, args[0], rParenLoc,
-                                     /*hasTrailingClosure=*/false);
-      computeArgType(arg);
-      return formCallExpr(arg, { Identifier() }, { });
-    }
-
-    // Construct the argument tuple.
-    auto arg = TupleExpr::create(ctx, lParenLoc, args, argLabels, argLabelLocs,
-                                 rParenLoc, /*hasTrailingClosure=*/false,
-                                 /*implicit=*/false);
-    computeArgType(arg);
-    return formCallExpr(arg, argLabels, argLabelLocs);
-  }
-
-  // If we have no other arguments, represent the trailing closure as a
-  // parenthesized expression.
-  if (args.size() == 0) {
-    auto arg = new (ctx) ParenExpr(lParenLoc, trailingClosure, rParenLoc,
-                                   /*hasTrailingClosure=*/true);
-    computeArgType(arg);
-    return formCallExpr(arg, { Identifier() }, { });
-  }
-
-  // Form a tuple, including the trailing closure.
-  SmallVector<Expr *, 4> completeArgs;
-  completeArgs.reserve(args.size() + 1);
-  completeArgs.append(args.begin(), args.end());
-  completeArgs.push_back(trailingClosure);
-  auto arg = TupleExpr::create(ctx, lParenLoc, completeArgs, argLabels,
-                               argLabelLocs, rParenLoc,
-                               /*hasTrailingClosure=*/true,
-                               /*implicit=*/false);
-  computeArgType(arg);
-
-  SmallVector<Identifier, 4> completeArgLabels;
-  completeArgLabels.reserve(completeArgLabels.size() + 1);
-  completeArgLabels.append(argLabels.begin(), argLabels.end());
-  completeArgLabels.push_back(Identifier());
-
-  SmallVector<SourceLoc, 4> completeArgLabelLocs;
-  if (!argLabelLocs.empty() || argLabels.empty()) {
-    completeArgLabelLocs.reserve(argLabelLocs.size() + 1);
-    completeArgLabelLocs.append(argLabelLocs.begin(), argLabelLocs.end());
-    completeArgLabelLocs.push_back(SourceLoc());
-  }
-
-  return formCallExpr(arg, completeArgLabels, completeArgLabelLocs);
+  void *memory = ctx.Allocate(size, alignof(CallExpr));
+  return new (memory) CallExpr(fn, arg, implicit, argLabels, argLabelLocs,
+                               trailingClosure != nullptr, Type());
 }
 
 Expr *CallExpr::getDirectCallee() const {

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -845,7 +845,8 @@ ParserResult<Expr> Parser::parseExprSuper() {
       return makeParserCodeCompletionResult<Expr>();
     if (idx.isNull())
       return nullptr;
-    return makeParserResult(new (Context) SubscriptExpr(superRef, idx.get()));
+    return makeParserResult(
+             SubscriptExpr::create(Context, superRef, idx.get()));
   }
 
   if (Tok.is(tok::code_complete)) {
@@ -1529,7 +1530,7 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
       if (Idx.isNull() || Result.isNull())
         return nullptr;
       Result = makeParserResult(
-          new (Context) SubscriptExpr(Result.get(), Idx.get()));
+                 SubscriptExpr::create(Context, Result.get(), Idx.get()));
       continue;
     }
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2646,8 +2646,8 @@ Parser::parseExprObjectLiteral(ObjectLiteralExpr::LiteralKind LitKind,
   }
 
   return makeParserResult(
-    new (Context) ObjectLiteralExpr(PoundLoc, LitKind, Arg.get(),
-                                    /*implicit=*/false));
+    ObjectLiteralExpr::create(Context, PoundLoc, LitKind, Arg.get(),
+                              /*implicit=*/false));
 }
 
 /// \brief Parse an expression call suffix.

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1232,10 +1232,9 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
     DeclNameLoc NameLoc;
 
     if (Tok.is(tok::code_complete)) {
-      auto Expr = new (Context) UnresolvedMemberExpr(
-                                  DotLoc,
-                                  DeclNameLoc(DotLoc.getAdvancedLoc(1)),
-                                  Context.getIdentifier("_"), nullptr);
+      auto Expr = UnresolvedMemberExpr::create(
+                    Context, DotLoc, DeclNameLoc(DotLoc.getAdvancedLoc(1)),
+                    Context.getIdentifier("_"), /*implicit=*/false);
       Result = makeParserResult(Expr);
       if (CodeCompletion) {
         std::vector<StringRef> Identifiers;
@@ -1280,8 +1279,9 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
 
     // Handle .foo by just making an AST node.
     Result = makeParserResult(
-               new (Context) UnresolvedMemberExpr(DotLoc, NameLoc, Name,
-                                                  Arg.getPtrOrNull()));
+               UnresolvedMemberExpr::create(Context, DotLoc, NameLoc, Name,
+                                            Arg.getPtrOrNull(),
+                                            /*implicit=*/false));
     break;
   }
       

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1291,11 +1291,10 @@ namespace {
           return nullptr;
 
         // TODO: diagnose if semantics != AccessSemantics::Ordinary?
-        auto subscriptExpr = new (tc.Context) DynamicSubscriptExpr(base,
-                                                                   index,
-                                                                   subscript);
+        auto subscriptExpr = DynamicSubscriptExpr::create(tc.Context, base,
+                                                          index, subscript,
+                                                          isImplicit);
         subscriptExpr->setType(resultTy);
-        subscriptExpr->setImplicit(isImplicit);
         Expr *result = subscriptExpr;
         closeExistential(result);
         return result;
@@ -2762,9 +2761,8 @@ namespace {
     }
 
     Expr *visitDynamicSubscriptExpr(DynamicSubscriptExpr *expr) {
-      SmallVector<Identifier, 2> argLabelsScratch;
       return buildSubscript(expr->getBase(), expr->getIndex(),
-                            expr->getArgumentLabels(argLabelsScratch),
+                            expr->getArgumentLabels(),
                             cs.getConstraintLocator(expr),
                             expr->isImplicit(), AccessSemantics::Ordinary);
     }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1327,12 +1327,11 @@ namespace {
 
         // Form the generic subscript expression.
         auto subscriptExpr
-          = new (tc.Context) SubscriptExpr(base, index,
-                                           ConcreteDeclRef(tc.Context,
-                                                           subscript,
-                                                           substitutions),
-                                           isImplicit,
-                                           semantics);
+          = SubscriptExpr::create(tc.Context, base, index,
+                                  ConcreteDeclRef(tc.Context, subscript,
+                                                  substitutions),
+                                  isImplicit,
+                                  semantics);
         subscriptExpr->setType(resultTy);
         subscriptExpr->setIsSuper(isSuper);
 
@@ -1354,8 +1353,8 @@ namespace {
 
       // Form a normal subscript.
       auto *subscriptExpr
-        = new (tc.Context) SubscriptExpr(base, index, subscript,
-                                         isImplicit, semantics);
+        = SubscriptExpr::create(tc.Context, base, index, subscript,
+                                isImplicit, semantics);
       subscriptExpr->setType(resultTy);
       subscriptExpr->setIsSuper(isSuper);
       Expr *result = subscriptExpr;
@@ -2620,9 +2619,8 @@ namespace {
     }
 
     Expr *visitSubscriptExpr(SubscriptExpr *expr) {
-      SmallVector<Identifier, 2> argLabelsScratch;
       return buildSubscript(expr->getBase(), expr->getIndex(),
-                            expr->getArgumentLabels(argLabelsScratch),
+                            expr->getArgumentLabels(),
                             cs.getConstraintLocator(expr),
                             expr->isImplicit(),
                             expr->getAccessSemantics());

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4577,8 +4577,7 @@ bool FailureDiagnosis::visitSubscriptExpr(SubscriptExpr *SE) {
   for (unsigned i = 0, e = calleeInfo.size(); i != e; ++i)
     --calleeInfo.candidates[i].level;
 
-  SmallVector<Identifier, 2> argLabelsScratch;
-  ArrayRef<Identifier> argLabels = SE->getArgumentLabels(argLabelsScratch);
+  ArrayRef<Identifier> argLabels = SE->getArgumentLabels();
   if (diagnoseParameterErrors(calleeInfo, SE, indexExpr, argLabels))
     return true;
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -467,19 +467,6 @@ matchCallArguments(ArrayRef<CallArgParam> args,
   return listener.relabelArguments(actualArgNames);
 }
 
-/// Determine whether the given expression has a trailing closure.
-static bool hasTrailingClosure(Expr *expr) {
-  if (!expr) return false;
-
-  if (ParenExpr *parenExpr = dyn_cast<ParenExpr>(expr))
-    return parenExpr->hasTrailingClosure();
-
-  if (TupleExpr *tupleExpr = dyn_cast<TupleExpr>(expr))
-   return tupleExpr->hasTrailingClosure();
-
-  return false;
-}
-
 /// Find the callee declaration and uncurry level for a given call
 /// locator.
 static std::tuple<ValueDecl *, unsigned, ArrayRef<Identifier>, bool>
@@ -523,10 +510,10 @@ getCalleeDeclAndArgs(ConstraintSystem &cs,
   } else {
     if (auto apply = dyn_cast<ApplyExpr>(callExpr)) {
       argLabels = apply->getArgumentLabels(argLabelsScratch);
-      assert(! ::hasTrailingClosure(apply->getArg()));
+      assert(!apply->hasTrailingClosure());
     } else if (auto objectLiteral = dyn_cast<ObjectLiteralExpr>(callExpr)) {
-      argLabels = objectLiteral->getArgumentLabels(argLabelsScratch);
-      hasTrailingClosure = ::hasTrailingClosure(objectLiteral->getArg());
+      argLabels = objectLiteral->getArgumentLabels();
+      hasTrailingClosure = objectLiteral->hasTrailingClosure();
     }
     return std::make_tuple(nullptr, 0, argLabels, hasTrailingClosure);
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -510,8 +510,8 @@ getCalleeDeclAndArgs(ConstraintSystem &cs,
     hasTrailingClosure = call->hasTrailingClosure();
   } else if (auto unresolved = dyn_cast<UnresolvedMemberExpr>(callExpr)) {
     calleeExpr = callExpr;
-    argLabels = unresolved->getArgumentLabels(argLabelsScratch);
-    hasTrailingClosure = ::hasTrailingClosure(unresolved->getArgument());
+    argLabels = unresolved->getArgumentLabels();
+    hasTrailingClosure = unresolved->hasTrailingClosure();
   } else if (auto subscript = dyn_cast<SubscriptExpr>(callExpr)) {
     calleeExpr = callExpr;
     argLabels = subscript->getArgumentLabels();

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -518,8 +518,8 @@ getCalleeDeclAndArgs(ConstraintSystem &cs,
     hasTrailingClosure = subscript->hasTrailingClosure();
   } else if (auto dynSubscript = dyn_cast<DynamicSubscriptExpr>(callExpr)) {
     calleeExpr = callExpr;
-    argLabels = dynSubscript->getArgumentLabels(argLabelsScratch);
-    hasTrailingClosure = ::hasTrailingClosure(dynSubscript->getIndex());
+    argLabels = dynSubscript->getArgumentLabels();
+    hasTrailingClosure = dynSubscript->hasTrailingClosure();
   } else {
     if (auto apply = dyn_cast<ApplyExpr>(callExpr)) {
       argLabels = apply->getArgumentLabels(argLabelsScratch);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -514,8 +514,8 @@ getCalleeDeclAndArgs(ConstraintSystem &cs,
     hasTrailingClosure = ::hasTrailingClosure(unresolved->getArgument());
   } else if (auto subscript = dyn_cast<SubscriptExpr>(callExpr)) {
     calleeExpr = callExpr;
-    argLabels = subscript->getArgumentLabels(argLabelsScratch);
-    hasTrailingClosure = ::hasTrailingClosure(subscript->getIndex());
+    argLabels = subscript->getArgumentLabels();
+    hasTrailingClosure = subscript->hasTrailingClosure();
   } else if (auto dynSubscript = dyn_cast<DynamicSubscriptExpr>(callExpr)) {
     calleeExpr = callExpr;
     argLabels = dynSubscript->getArgumentLabels(argLabelsScratch);

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -354,9 +354,11 @@ static Expr *buildArgumentForwardingExpr(ArrayRef<ParamDecl*> params,
     labelLocs.push_back(SourceLoc());
   }
   
-  // A single unlabelled value is not a tuple.
-  if (args.size() == 1 && labels[0].empty())
-    return args[0];
+  // A single unlabeled value is not a tuple.
+  if (args.size() == 1 && labels[0].empty()) {
+    return new (ctx) ParenExpr(SourceLoc(), args[0], SourceLoc(),
+                               /*hasTrailingClosure=*/false);
+  }
   
   return TupleExpr::create(ctx, SourceLoc(), args, labels, labelLocs,
                            SourceLoc(), false, IsImplicit);

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -479,8 +479,8 @@ static Expr *buildStorageReference(
 
   if (auto subscript = dyn_cast<SubscriptDecl>(storage)) {
     Expr *indices = referenceContext.getIndexRefExpr(ctx, subscript);
-    return new (ctx) SubscriptExpr(selfDRE, indices, storage,
-                                   IsImplicit, semantics);
+    return SubscriptExpr::create(ctx, selfDRE, indices, storage,
+                                 IsImplicit, semantics);
   }
 
   // This is a potentially polymorphic access, which is unnecessary;

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2129,11 +2129,6 @@ static inline bool computeTupleShuffle(TupleType *fromTuple,
                              sources, variadicArgs);
 }
 
-
-/// \brief Return whether the function argument indicated by `locator` has a
-/// trailing closure.
-bool hasTrailingClosure(const ConstraintLocatorBuilder &locator);
-
 /// Describes the arguments to which a parameter binds.
 /// FIXME: This is an awful data structure. We want the equivalent of a
 /// TinyPtrVector for unsigned values.

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -1009,8 +1009,11 @@ public:
 
     LoggerRef->setImplicit(true);
 
+    SmallVector<Identifier, 4> ArgLabels(ArgsWithSourceRange.size(),
+                                         Identifier());
     ApplyExpr *LoggerCall = CallExpr::createImplicit(Context, LoggerRef,
-                                                     ArgsWithSourceRange, { });
+                                                     ArgsWithSourceRange,
+                                                     ArgLabels);
     Added<ApplyExpr*> AddedLogger(LoggerCall);
 
     if (!doTypeCheck(Context, TypeCheckDC, AddedLogger)) {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -226,17 +226,6 @@ Expr *ConstraintLocatorBuilder::trySimplifyToExpr() const {
   return (path.empty() ? anchor : nullptr);
 }
 
-bool constraints::hasTrailingClosure(const ConstraintLocatorBuilder &locator) {
-  if (Expr *e = locator.trySimplifyToExpr()) {
-    if (ParenExpr *parenExpr = dyn_cast<ParenExpr>(e)) {
-      return parenExpr->hasTrailingClosure();
-    } else if (TupleExpr *tupleExpr = dyn_cast<TupleExpr>(e)) {
-      return tupleExpr->hasTrailingClosure();
-    }
-  }
-  return false;
-}
-
 //===----------------------------------------------------------------------===//
 // High-level entry points.
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Swift's current expression representation places call argument labels (and their locations) within TupleExprs buried in the arguments, which is inconvenient for the removal of argument labels from function type (SE-0111). Start storing the argument labels (and their locations) on CallExpr itself, as well as on other call-like expressions (subscripts, unresolved members, etc.), separately from the actual arguments (which will stay the same--ParenExpr or CallExpr).

There is some shimming going on here, so we can extract the argument labels from the ParenExpr or TupleExpr argument. Over time, the shimming will go away.

This whole thing should be NFC, except for a few places where we now properly wrap up single arguments in ParenExpr or are more consistent about 'implicit' bits.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
