### PR TITLE
Fix optimizer test cases for id-as-any

### DIFF
--- a/test/SILOptimizer/cast_folding_objc_no_foundation.swift
+++ b/test/SILOptimizer/cast_folding_objc_no_foundation.swift
@@ -2,11 +2,10 @@
 // REQUIRES: objc_interop
 
 // TODO: Update optimizer for id-as-Any changes.
-// XFAIL: *
 
 // Note: no 'import Foundation'
 
-struct DoesNotBridgeToObjC {}
+struct PlainStruct {}
 
 // CHECK-LABEL: sil hidden [noinline] @_TTSf4g___TF31cast_folding_objc_no_foundation23testAnyObjectToArrayIntFPs9AnyObject_Sb
 // CHECK: bb0(%0 : $AnyObject):
@@ -28,14 +27,14 @@ func testAnyObjectToArrayString(_ a: AnyObject) -> Bool {
   return a is [String]
 }
 
-// CHECK-LABEL: sil hidden [noinline] @_TTSf4d___TF31cast_folding_objc_no_foundation30testAnyObjectToArrayNotBridgedFPs9AnyObject_Sb
-// CHECK-NEXT: bb0:
-// CHECK: [[VALUE:%.*]] = integer_literal $Builtin.Int1, 0
-// CHECK: [[RESULT:%.*]] = struct $Bool ([[VALUE]] : $Builtin.Int1)
-// CHECK: return [[RESULT]]
+// CHECK-LABEL: sil hidden [noinline] @{{.*}}testAnyObjectToArrayNotBridgedFPs9AnyObject{{.*}}
+// CHECK: bb0(%0 : $AnyObject):
+// CHECK: [[SOURCE:%.*]] = alloc_stack $AnyObject
+// CHECK: [[TARGET:%.*]] = alloc_stack $Array<PlainStruct>
+// CHECK: checked_cast_addr_br take_always AnyObject in [[SOURCE]] : $*AnyObject to Array<PlainStruct> in [[TARGET]] : $*Array<PlainStruct>, bb1, bb2
 @inline(never)
 func testAnyObjectToArrayNotBridged(_ a: AnyObject) -> Bool {
-  return a is [DoesNotBridgeToObjC]
+  return a is [PlainStruct]
 }
 
 // CHECK-LABEL: sil hidden [noinline] @_TTSf4g___TF31cast_folding_objc_no_foundation25testAnyObjectToDictionaryFPs9AnyObject_Sb

--- a/test/SILOptimizer/sil_combine_objc_bridge.sil
+++ b/test/SILOptimizer/sil_combine_objc_bridge.sil
@@ -3,7 +3,6 @@
 // REQUIRES: objc_interop
 
 // TODO: Update optimizer for id-as-Any changes.
-// XFAIL: *
 
 sil_stage canonical
 
@@ -132,30 +131,30 @@ bb0(%0 : $AnArray<AnyObject>):
   return %4 : $AnArray<AnyObject>
 }
 
-struct Unbridged {
+struct PlainStruct {
 }
 
-// CHECK-LABEL: sil @failing_bridge_from_to_owned
-// CHECK: apply
-// CHECK: apply
+// CHECK-LABEL: sil @plain_struct_bridge_from_to_owned
+// CHECK-NOT: apply
+// CHECK-NOT: apply
 // CHECK: return
-sil @failing_bridge_from_to_owned : $@convention(thin) (@owned AnNSArray) -> @owned AnNSArray {
+sil @plain_struct_bridge_from_to_owned : $@convention(thin) (@owned AnNSArray) -> @owned AnNSArray {
 bb0(%0 : $AnNSArray):
-  %1 = function_ref @bridgeFromObjectiveC : $@convention(thin) <Unbridged> (@owned AnNSArray) -> @owned AnArray<Unbridged>
-  %2 = apply %1<Unbridged>(%0) : $@convention(thin) <Unbridged> (@owned AnNSArray) -> @owned AnArray<Unbridged>
-  retain_value %2 : $AnArray<Unbridged>
-  release_value %2 : $AnArray<Unbridged>
-  %3 = function_ref @bridgeToObjectiveC : $@convention(method) <Unbridged> (@owned AnArray<Unbridged>) -> @owned AnNSArray
-  %4 = apply %3<Unbridged>(%2) : $@convention(method) <Unbridged> (@owned AnArray<Unbridged>) -> @owned AnNSArray
+  %1 = function_ref @bridgeFromObjectiveC : $@convention(thin) <PlainStruct> (@owned AnNSArray) -> @owned AnArray<PlainStruct>
+  %2 = apply %1<PlainStruct>(%0) : $@convention(thin) <PlainStruct> (@owned AnNSArray) -> @owned AnArray<PlainStruct>
+  retain_value %2 : $AnArray<PlainStruct>
+  release_value %2 : $AnArray<PlainStruct>
+  %3 = function_ref @bridgeToObjectiveC : $@convention(method) <PlainStruct> (@owned AnArray<PlainStruct>) -> @owned AnNSArray
+  %4 = apply %3<PlainStruct>(%2) : $@convention(method) <PlainStruct> (@owned AnArray<PlainStruct>) -> @owned AnNSArray
   return %4 : $AnNSArray
 }
 
-// CHECK-LABEL: sil @failing_bridge_from_to_owned_generic
-// CHECK: apply
-// CHECK: apply
+// CHECK-LABEL: sil @plain_struct_bridge_from_to_owned_generic
+// CHECK-NOT: apply
+// CHECK-NOT: apply
 // CHECK: return
 
-sil @failing_bridge_from_to_owned_generic : $@convention(thin) <T>(@owned AnNSArray) -> @owned AnNSArray {
+sil @plain_struct_bridge_from_to_owned_generic : $@convention(thin) <T>(@owned AnNSArray) -> @owned AnNSArray {
 bb0(%0 : $AnNSArray):
   %1 = function_ref @bridgeFromObjectiveC : $@convention(thin) <T2> (@owned AnNSArray) -> @owned AnArray<T2>
   %2 = apply %1<T>(%0) : $@convention(thin) <T2> (@owned AnNSArray) -> @owned AnArray<T2>
@@ -166,19 +165,19 @@ bb0(%0 : $AnNSArray):
   return %4 : $AnNSArray
 }
 
-// CHECK-LABEL: sil @failing_bridge_from_to_owned_recursive_type
-// CHECK: apply
-// CHECK: apply
+// CHECK-LABEL: sil @plain_struct_from_to_owned_recursive_type
+// CHECK-NOT: apply
+// CHECK-NOT: apply
 // CHECK: return
 
-sil @failing_bridge_from_to_owned_recursive_type : $@convention(thin) (@owned AnNSArray) -> @owned AnNSArray {
+sil @plain_struct_from_to_owned_recursive_type : $@convention(thin) (@owned AnNSArray) -> @owned AnNSArray {
 bb0(%0 : $AnNSArray):
   %1 = function_ref @bridgeFromObjectiveC : $@convention(thin) <T> (@owned AnNSArray) -> @owned AnArray<T>
-  %2 = apply %1<AnArray<Unbridged>>(%0) : $@convention(thin) <T> (@owned AnNSArray) -> @owned AnArray<T>
-  retain_value %2 : $AnArray<AnArray<Unbridged>>
-  release_value %2 : $AnArray<AnArray<Unbridged>>
+  %2 = apply %1<AnArray<PlainStruct>>(%0) : $@convention(thin) <T> (@owned AnNSArray) -> @owned AnArray<T>
+  retain_value %2 : $AnArray<AnArray<PlainStruct>>
+  release_value %2 : $AnArray<AnArray<PlainStruct>>
   %3 = function_ref @bridgeToObjectiveC : $@convention(method) <T> (@owned AnArray<T>) -> @owned AnNSArray
-  %4 = apply %3<AnArray<Unbridged>>(%2) : $@convention(method) <T> (@owned AnArray<T>) -> @owned AnNSArray
+  %4 = apply %3<AnArray<PlainStruct>>(%2) : $@convention(method) <T> (@owned AnArray<T>) -> @owned AnNSArray
   return %4 : $AnNSArray
 }
 


### PR DESCRIPTION
Any struct is now bridged to objC.

rdar://27527684
