### PR TITLE
Flip the switch on 'private' and 'fileprivate'.

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1017,9 +1017,12 @@ static bool checkAccessibility(const DeclContext *useDC,
   if (!useDC)
     return access == Accessibility::Public;
 
+  assert(sourceDC && "ValueDecl being accessed must have a valid DeclContext");
   switch (access) {
   case Accessibility::Private:
-    // TODO: Implement 'private'.
+    if (sourceDC->getASTContext().LangOpts.EnableSwift3Private)
+      return useDC == sourceDC || useDC->isChildContextOf(sourceDC);
+    SWIFT_FALLTHROUGH;
   case Accessibility::FilePrivate:
     return useDC->getModuleScopeContext() == sourceDC->getModuleScopeContext();
   case Accessibility::Internal: {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6168,7 +6168,9 @@ public:
         const DeclContext *desiredAccessScope;
         switch (AA->getAccess()) {
         case Accessibility::Private:
-          // TODO: Implement 'private'.
+          assert(ED->getDeclContext()->isModuleScopeContext() &&
+                 "non-top-level extensions make 'private' != 'fileprivate'");
+          SWIFT_FALLTHROUGH;
         case Accessibility::FilePrivate:
           desiredAccessScope = ED->getModuleScopeContext();
           break;

--- a/stdlib/public/SDK/Foundation/IndexPath.swift
+++ b/stdlib/public/SDK/Foundation/IndexPath.swift
@@ -26,7 +26,7 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
     public typealias Index = Array<Int>.Index
     public typealias Indices = DefaultRandomAccessIndices<IndexPath>
     
-    private var _indexes : Array<Int>
+    fileprivate var _indexes : Array<Int>
     
     /// Initialize an empty index path.
     public init() {

--- a/test/Sema/accessibility_private.swift
+++ b/test/Sema/accessibility_private.swift
@@ -1,0 +1,112 @@
+// RUN: %target-parse-verify-swift
+
+class Container {
+  private func foo() {} // expected-note * {{declared here}}
+  private var bar = 0 // expected-note * {{declared here}}
+
+  private struct PrivateInner {} // expected-note * {{declared here}}
+
+  func localTest() {
+    foo()
+    self.foo()
+
+    _ = bar
+    bar = 5
+    _ = self.bar
+    self.bar = 5
+
+    privateExtensionMethod() // FIXME expected-error {{use of unresolved identifier 'privateExtensionMethod'}}
+    self.privateExtensionMethod() // expected-error {{'privateExtensionMethod' is inaccessible due to 'private' protection level}}
+
+    _ = PrivateInner()
+    _ = Container.PrivateInner()
+  }
+
+  struct Inner {
+    func test(obj: Container) {
+      obj.foo()
+      _ = obj.bar
+      obj.bar = 5
+      obj.privateExtensionMethod() // expected-error {{'privateExtensionMethod' is inaccessible due to 'private' protection level}}
+
+      _ = PrivateInner()
+      _ = Container.PrivateInner()
+    }
+
+    var inner: PrivateInner? // expected-error {{property must be declared private because its type uses a private type}}
+    var innerQualified: Container.PrivateInner? // expected-error {{property must be declared private because its type uses a private type}}
+  }
+
+  var inner: PrivateInner? // expected-error {{property must be declared private because its type uses a private type}}
+  var innerQualified: Container.PrivateInner? // expected-error {{property must be declared private because its type uses a private type}}
+}
+
+func test(obj: Container) {
+  obj.foo() // expected-error {{'foo' is inaccessible due to 'private' protection level}}
+  _ = obj.bar // expected-error {{'bar' is inaccessible due to 'private' protection level}}
+  obj.bar = 5 // expected-error {{'bar' is inaccessible due to 'private' protection level}}
+  obj.privateExtensionMethod() // expected-error {{'privateExtensionMethod' is inaccessible due to 'private' protection level}}
+
+  _ = Container.PrivateInner() // expected-error {{'PrivateInner' is inaccessible due to 'private' protection level}}
+}
+
+extension Container {
+  private func privateExtensionMethod() {} // expected-note * {{declared here}}
+
+  func extensionTest() {
+    foo() // FIXME expected-error {{use of unresolved identifier 'foo'}}
+    self.foo() // expected-error {{'foo' is inaccessible due to 'private' protection level}}
+
+    _ = bar // FIXME expected-error {{use of unresolved identifier 'bar'}}
+    bar = 5 // FIXME expected-error {{use of unresolved identifier 'bar'}}
+    _ = self.bar // expected-error {{'bar' is inaccessible due to 'private' protection level}}
+    self.bar = 5 // expected-error {{'bar' is inaccessible due to 'private' protection level}}
+
+    privateExtensionMethod()
+    self.privateExtensionMethod()
+
+    _ = PrivateInner() // FIXME expected-error {{use of unresolved identifier 'PrivateInner'}}
+    _ = Container.PrivateInner() // expected-error {{'PrivateInner' is inaccessible due to 'private' protection level}}
+  }
+
+  // FIXME: Why do these errors happen twice?
+  var extensionInner: PrivateInner? { return nil } // FIXME expected-error 2 {{use of undeclared type 'PrivateInner'}}
+  var extensionInnerQualified: Container.PrivateInner? { return nil } // FIXME expected-error 2 {{'PrivateInner' is not a member type of 'Container'}}
+}
+
+extension Container.Inner {
+  func extensionTest(obj: Container) {
+    obj.foo() // expected-error {{'foo' is inaccessible due to 'private' protection level}}
+    _ = obj.bar // expected-error {{'bar' is inaccessible due to 'private' protection level}}
+    obj.bar = 5 // expected-error {{'bar' is inaccessible due to 'private' protection level}}
+    obj.privateExtensionMethod() // expected-error {{'privateExtensionMethod' is inaccessible due to 'private' protection level}}
+
+    _ = PrivateInner() // FIXME expected-error {{use of unresolved identifier 'PrivateInner'}}
+    _ = Container.PrivateInner() // expected-error {{'PrivateInner' is inaccessible due to 'private' protection level}}
+  }
+
+  // FIXME: Why do these errors happen twice?
+  var inner: PrivateInner? { return nil } // FIXME expected-error 2 {{use of undeclared type 'PrivateInner'}}
+  var innerQualified: Container.PrivateInner? { return nil } // FIXME expected-error 2 {{'PrivateInner' is not a member type of 'Container'}}
+}
+
+class Sub : Container {
+  func subTest() {
+    foo() // FIXME expected-error {{use of unresolved identifier 'foo'}}
+    self.foo() // expected-error {{'foo' is inaccessible due to 'private' protection level}}
+
+    _ = bar // FIXME expected-error {{use of unresolved identifier 'bar'}}
+    bar = 5 // FIXME expected-error {{use of unresolved identifier 'bar'}}
+    _ = self.bar // expected-error {{'bar' is inaccessible due to 'private' protection level}}
+    self.bar = 5 // expected-error {{'bar' is inaccessible due to 'private' protection level}}
+
+    privateExtensionMethod() // FIXME expected-error {{use of unresolved identifier 'privateExtensionMethod'}}
+    self.privateExtensionMethod() // expected-error {{'privateExtensionMethod' is inaccessible due to 'private' protection level}}
+
+    _ = PrivateInner() // FIXME expected-error {{use of unresolved identifier 'PrivateInner'}}
+    _ = Container.PrivateInner() // expected-error {{'PrivateInner' is inaccessible due to 'private' protection level}}
+  }
+
+  var subInner: PrivateInner? // FIXME expected-error {{use of undeclared type 'PrivateInner'}}
+  var subInnerQualified: Container.PrivateInner? // FIXME expected-error {{'PrivateInner' is not a member type of 'Container'}}
+}

--- a/validation-test/compiler_crashers_2_fixed/0016-rdar21437203.swift
+++ b/validation-test/compiler_crashers_2_fixed/0016-rdar21437203.swift
@@ -5,7 +5,7 @@ struct Curds {
 }
 
 private class Butter {
-    private func churn<T>(block: () throws -> T) throws -> T {
+    fileprivate func churn<T>(block: () throws -> T) throws -> T {
       return try block()
     }
 }


### PR DESCRIPTION
Activates the main feature of [SE-0025](https://github.com/apple/swift-evolution/blob/master/proposals/0025-scoped-access-level.md): scoped `private`! Tests to come shortly, but I wanted to start CI off early.

There's still a bit of cleanup to do after this commit, but this is the main feature.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
