### PR TITLE
[swiftc (35 vs. 5154)] Add crasher in swift::constraints::ConstraintSystem::diagnoseFailureForExpr(...)

### DIFF
--- a/validation-test/compiler_crashers/28379-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
+++ b/validation-test/compiler_crashers/28379-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+!(


### PR DESCRIPTION
Add test case for crash triggered in `swift::constraints::ConstraintSystem::diagnoseFailureForExpr(...)`.

Current number of unresolved compiler crashers: 35 (5154 resolved)

Assertion failure in `llvm/include/llvm/ADT/ArrayRef.h (line 186)`:

```
Assertion `Index < Length && "Invalid index!"' failed.

When executing: const T &llvm::ArrayRef<swift::Expr *>::operator[](size_t) const [T = swift::Expr *]
```

Assertion context:

```

    /// @}
    /// @name Operator Overloads
    /// @{
    const T &operator[](size_t Index) const {
      assert(Index < Length && "Invalid index!");
      return Data[Index];
    }

    /// @}
    /// @name Expensive Operations
```

Stack trace:

```
swift: /path/to/llvm/include/llvm/ADT/ArrayRef.h:186: const T &llvm::ArrayRef<swift::Expr *>::operator[](size_t) const [T = swift::Expr *]: Assertion `Index < Length && "Invalid index!"' failed.
11 swift           0x0000000000f7be49 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 105
12 swift           0x0000000000f81c8e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 3998
13 swift           0x0000000000eb1812 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 850
14 swift           0x0000000000eb83dd swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 621
19 swift           0x0000000000f7be49 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 105
20 swift           0x0000000000f81c8e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 3998
21 swift           0x0000000000eb1812 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 850
22 swift           0x0000000000eb83dd swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 621
24 swift           0x0000000000f33bb6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
25 swift           0x0000000000eeda1d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
26 swift           0x0000000000c737f9 swift::CompilerInstance::performSema() + 3289
28 swift           0x00000000007d9aa7 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
29 swift           0x00000000007a5988 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28379-swift-constraints-constraintsystem-diagnosefailureforexpr.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28379-swift-constraints-constraintsystem-diagnosefailureforexpr-2c9cbc.o
1.  While type-checking expression at [validation-test/compiler_crashers/28379-swift-constraints-constraintsystem-diagnosefailureforexpr.swift:10:1 - line:10:5] RangeText="!()*0"
2.  While type-checking expression at [validation-test/compiler_crashers/28379-swift-constraints-constraintsystem-diagnosefailureforexpr.swift:10:1 - line:10:3] RangeText="!()"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
