### PR TITLE
Migrate from UnsafePointer<Void> to UnsafeRawPointer.

### DIFF
--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -220,9 +220,9 @@ func internalMedian(_ inputs: [UInt64]) -> UInt64 {
 #if SWIFT_RUNTIME_ENABLE_LEAK_CHECKER
 
 @_silgen_name("swift_leaks_startTrackingObjects")
-func startTrackingObjects(_: UnsafeMutablePointer<Void>) -> ()
+func startTrackingObjects(_: UnsafeMutableRawPointer) -> ()
 @_silgen_name("swift_leaks_stopTrackingObjects")
-func stopTrackingObjects(_: UnsafeMutablePointer<Void>) -> Int
+func stopTrackingObjects(_: UnsafeMutableRawPointer) -> Int
 
 #endif
 
@@ -235,14 +235,14 @@ class SampleRunner {
     // Start the timer.
 #if SWIFT_RUNTIME_ENABLE_LEAK_CHECKER
     var str = name
-    startTrackingObjects(UnsafeMutablePointer<Void>(str._core.startASCII))
+    startTrackingObjects(UnsafeMutableRawPointer(str._core.startASCII))
 #endif
     let start_ticks = mach_absolute_time()
     fn(Int(num_iters))
     // Stop the timer.
     let end_ticks = mach_absolute_time()
 #if SWIFT_RUNTIME_ENABLE_LEAK_CHECKER
-    stopTrackingObjects(UnsafeMutablePointer<Void>(str._core.startASCII))
+    stopTrackingObjects(UnsafeMutableRawPointer(str._core.startASCII))
 #endif
 
     // Compute the spent time and the scaling factor.

--- a/docs/proposals/CPointerInteropLanguageModel.rst
+++ b/docs/proposals/CPointerInteropLanguageModel.rst
@@ -61,7 +61,7 @@ accept any of the following:
   array, and lifetime-extended for the duration of the callee.
 
 As a special case, when a function is declared as taking an
-``UnsafeMutablePointer<Void>`` argument, it can accept the same operands as
+``UnsafeMutableRawPointer`` argument, it can accept the same operands as
 ``UnsafeMutablePointer<T>`` for any type T.
 
 So if you have a function declared::
@@ -80,7 +80,7 @@ You can call it as any of::
 
 And if you have a function declared::
 
-  func bar(_ x: UnsafeMutablePointer<Void>)
+  func bar(_ x: UnsafeMutableRawPointer)
 
 You can call it as any of::
 
@@ -139,7 +139,7 @@ accept any of the following:
   array, and lifetime-extended for the duration of the callee.
 
 As a special case, when a function is declared as taking an
-``UnsafePointer<Void>`` argument, it can accept the same operands as
+``UnsafeRawPointer`` argument, it can accept the same operands as
 ``UnsafePointer<T>`` for any type ``T``. Pointers to certain integer
 types can furthermore interoperate with strings; see `Strings`_ below.
 
@@ -158,7 +158,7 @@ You can call it as any of::
 
 And if you have a function declared::
 
-  func zang(_ x: UnsafePointer<Void>)
+  func zang(_ x: UnsafeRawPointer)
 
 You can call it as any of::
 
@@ -175,7 +175,7 @@ You can call it as any of::
   zang(ints)
 
 A type checker limitation prevents array literals from being passed directly
-to ``UnsafePointer<Void>`` arguments without type annotation. As a
+to ``UnsafeRawPointer`` arguments without type annotation. As a
 workaround, you can bind the array literal to a constant, as above, or 
 specify the array type with ``as``::
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -371,23 +371,16 @@ VarDecl *Module::getDSOHandle() {
   if (DSOHandle)
     return DSOHandle;
 
-  auto unsafeMutablePtr = getASTContext().getUnsafeMutablePointerDecl();
-  if (!unsafeMutablePtr)
+  auto unsafeMutableRawPtr = getASTContext().getUnsafeMutableRawPointerDecl();
+  if (!unsafeMutableRawPtr)
     return nullptr;
 
-  Type arg;
   auto &ctx = getASTContext();
-  if (auto voidDecl = ctx.getVoidDecl()) {
-    arg = voidDecl->getDeclaredInterfaceType();
-  } else {
-    arg = TupleType::getEmpty(ctx);
-  }
-  
-  Type type = BoundGenericType::get(unsafeMutablePtr, Type(), { arg });
   auto handleVar = new (ctx) VarDecl(/*IsStatic=*/false, /*IsLet=*/false,
                                      SourceLoc(),
                                      ctx.getIdentifier("__dso_handle"),
-                                     type, Files[0]);
+                                     unsafeMutableRawPtr->getDeclaredType(),
+                                     Files[0]);
   handleVar->setImplicit(true);
   handleVar->getAttrs().add(
     new (ctx) SILGenNameAttr("__dso_handle", /*Implicit=*/true));

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -4656,7 +4656,7 @@ static void addExprKeywords(CodeCompletionResultSink &Sink) {
   // Same: Swift.IntegerLiteralType.
   AddKeyword("#line", "Int", CodeCompletionKeywordKind::pound_line);
   AddKeyword("#column", "Int", CodeCompletionKeywordKind::pound_column);
-  AddKeyword("#dsohandle", "UnsafeMutablePointer<Void>", CodeCompletionKeywordKind::pound_dsohandle);
+  AddKeyword("#dsohandle", "UnsafeMutableRawPointer", CodeCompletionKeywordKind::pound_dsohandle);
 }
 
 static void addAnyTypeKeyword(CodeCompletionResultSink &Sink) {

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -949,6 +949,8 @@ private:
       MAP(Bool, "BOOL", false);
 
       MAP(OpaquePointer, "void *", true);
+      MAP(UnsafeRawPointer, "void const *", true);
+      MAP(UnsafeMutableRawPointer, "void *", true);
 
       Identifier ID_ObjectiveC = ctx.Id_ObjectiveC;
       specialNames[{ID_ObjectiveC, ctx.getIdentifier("ObjCBool")}] 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1227,7 +1227,7 @@ namespace {
         return visitLiteralExpr(expr);
 
       case MagicIdentifierLiteralExpr::DSOHandle: {
-        // #dsohandle has type UnsafeMutablePointer<Void>.
+        // #dsohandle has type UnsafeMutableRawPointer.
         auto &tc = CS.getTypeChecker();
         if (tc.requirePointerArgumentIntrinsics(expr->getLoc()))
           return nullptr;

--- a/stdlib/private/SwiftPrivatePthreadExtras/SwiftPrivatePthreadExtras.swift
+++ b/stdlib/private/SwiftPrivatePthreadExtras/SwiftPrivatePthreadExtras.swift
@@ -27,7 +27,7 @@ internal class PthreadBlockContext {
   /// Execute the block, and return an `UnsafeMutablePointer` to memory
   /// allocated with `UnsafeMutablePointer.alloc` containing the result of the
   /// block.
-  func run() -> UnsafeMutablePointer<Void> { fatalError("abstract") }
+  func run() -> UnsafeMutableRawPointer { fatalError("abstract") }
 }
 
 internal class PthreadBlockContextImpl<Argument, Result>: PthreadBlockContext {
@@ -40,7 +40,7 @@ internal class PthreadBlockContextImpl<Argument, Result>: PthreadBlockContext {
     super.init()
   }
 
-  override func run() -> UnsafeMutablePointer<Void> {
+  override func run() -> UnsafeMutableRawPointer {
     let result = UnsafeMutablePointer<Result>.allocate(capacity: 1)
     result.initialize(to: block(arg))
     return UnsafeMutablePointer(result)
@@ -49,8 +49,8 @@ internal class PthreadBlockContextImpl<Argument, Result>: PthreadBlockContext {
 
 /// Entry point for `pthread_create` that invokes a block context.
 internal func invokeBlockContext(
-  _ contextAsVoidPointer: UnsafeMutablePointer<Void>?
-) -> UnsafeMutablePointer<Void>! {
+  _ contextAsVoidPointer: UnsafeMutableRawPointer?
+) -> UnsafeMutableRawPointer! {
   // The context is passed in +1; we're responsible for releasing it.
   let context = Unmanaged<PthreadBlockContext>
     .fromOpaque(contextAsVoidPointer!)
@@ -95,7 +95,7 @@ public func _stdlib_pthread_join<Result>(
   _ thread: pthread_t,
   _ resultType: Result.Type
 ) -> (CInt, Result?) {
-  var threadResultPtr: UnsafeMutablePointer<Void>? = nil
+  var threadResultPtr: UnsafeMutableRawPointer? = nil
   let result = pthread_join(thread, &threadResultPtr)
   if result == 0 {
     let threadResult = UnsafeMutablePointer<Result>(threadResultPtr!).pointee

--- a/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
+++ b/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
@@ -48,7 +48,7 @@ public enum InstanceKind : UInt8 {
 /// Represents a section in a loaded image in this process.
 internal struct Section {
   /// The absolute start address of the section's data in this address space.
-  let startAddress: UnsafePointer<Void>
+  let startAddress: UnsafeRawPointer
 
   /// The size of the section in bytes.
   let size: UInt
@@ -211,7 +211,7 @@ internal func sendBytes() {
   let count = Int(readUInt())
   debugLog("Parent requested \(count) bytes from \(address)")
   var totalBytesWritten = 0
-  var pointer = unsafeBitCast(address, to: UnsafeMutablePointer<Void>.self)
+  var pointer = unsafeBitCast(address, to: UnsafeMutableRawPointer.self)
   while totalBytesWritten < count {
     let bytesWritten = Int(fwrite(pointer, 1, Int(count), stdout))
     fflush(stdout)
@@ -228,7 +228,7 @@ internal func sendSymbolAddress() {
   debugLog("BEGIN \(#function)"); defer { debugLog("END \(#function)") }
   let name = readLine()!
   name.withCString {
-    let handle = unsafeBitCast(Int(-2), to: UnsafeMutablePointer<Void>.self)
+    let handle = unsafeBitCast(Int(-2), to: UnsafeMutableRawPointer.self)
     let symbol = dlsym(handle, $0)
     let symbolAddress = unsafeBitCast(symbol, to: UInt.self)
     sendValue(symbolAddress)
@@ -247,7 +247,7 @@ internal func sendStringLength() {
 /// Send the size of this architecture's pointer type.
 internal func sendPointerSize() {
   debugLog("BEGIN \(#function)"); defer { debugLog("END \(#function)") }
-  let pointerSize = UInt8(sizeof(UnsafePointer<Void>.self))
+  let pointerSize = UInt8(sizeof(UnsafeRawPointer.self))
   sendValue(pointerSize)
 }
 
@@ -412,8 +412,8 @@ struct ThickFunction3 {
 }
 
 struct ThickFunctionParts {
-  var function: UnsafePointer<Void>
-  var context: Optional<UnsafePointer<Void>>
+  var function: UnsafeRawPointer
+  var context: Optional<UnsafeRawPointer>
 }
 
 /// Reflect a closure context. The given function must be a Swift-native

--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -219,7 +219,7 @@ internal func _swift_Platform_fcntl(
 internal func _swift_Platform_fcntlPtr(
   _ fd: Int32,
   _ cmd: Int32,
-  _ ptr: UnsafeMutablePointer<Void>
+  _ ptr: UnsafeMutableRawPointer
 ) -> Int32
 
 public func fcntl(
@@ -240,7 +240,7 @@ public func fcntl(
 public func fcntl(
   _ fd: Int32,
   _ cmd: Int32,
-  _ ptr: UnsafeMutablePointer<Void>
+  _ ptr: UnsafeMutableRawPointer
 ) -> Int32 {
   return _swift_Platform_fcntlPtr(fd, cmd, ptr)
 }
@@ -313,7 +313,7 @@ internal func _swift_Platform_ioctl(
 internal func _swift_Platform_ioctlPtr(
   _ fd: CInt,
   _ request: UInt,
-  _ ptr: UnsafeMutablePointer<Void>
+  _ ptr: UnsafeMutableRawPointer
 ) -> CInt
 
 public func ioctl(
@@ -327,7 +327,7 @@ public func ioctl(
 public func ioctl(
   _ fd: CInt,
   _ request: UInt,
-  _ ptr: UnsafeMutablePointer<Void>
+  _ ptr: UnsafeMutableRawPointer
 ) -> CInt {
   return _swift_Platform_ioctlPtr(fd, request, ptr)
 }

--- a/stdlib/public/SDK/CoreAudio/CoreAudio.swift
+++ b/stdlib/public/SDK/CoreAudio/CoreAudio.swift
@@ -39,7 +39,7 @@ extension AudioBuffer {
     numberOfChannels: Int
   ) {
     self.mNumberChannels = UInt32(numberOfChannels)
-    self.mData = UnsafeMutablePointer<Void>(typedBuffer.baseAddress)
+    self.mData = UnsafeMutableRawPointer(typedBuffer.baseAddress)
     self.mDataByteSize = UInt32(typedBuffer.count * strideof(Element.self))
   }
 }

--- a/stdlib/public/SDK/CoreAudio/CoreAudio.swift
+++ b/stdlib/public/SDK/CoreAudio/CoreAudio.swift
@@ -14,10 +14,12 @@
 
 extension UnsafeBufferPointer {
   /// Initialize an `UnsafeBufferPointer<Element>` from an `AudioBuffer`.
+  /// Binds the the buffer's memory type to `Element`.
   public init(_ audioBuffer: AudioBuffer) {
-    self.init(
-      start: UnsafePointer<Element>(audioBuffer.mData),
-      count: Int(audioBuffer.mDataByteSize) / strideof(Element.self))
+    let count = Int(audioBuffer.mDataByteSize) / strideof(Element.self)
+    let elementPtr = audioBuffer.mData?.bindMemory(
+      to: Element.self, capacity: count)
+    self.init(start: elementPtr, count: count)
   }
 }
 
@@ -25,9 +27,10 @@ extension UnsafeMutableBufferPointer {
   /// Initialize an `UnsafeMutableBufferPointer<Element>` from an
   /// `AudioBuffer`.
   public init(_ audioBuffer: AudioBuffer) {
-    self.init(
-      start: UnsafeMutablePointer<Element>(audioBuffer.mData),
-      count: Int(audioBuffer.mDataByteSize) / strideof(Element.self))
+    let count = Int(audioBuffer.mDataByteSize) / strideof(Element.self)
+    let elementPtr = audioBuffer.mData?.bindMemory(
+      to: Element.self, capacity: count)
+    self.init(start: elementPtr, count: count)
   }
 }
 
@@ -68,8 +71,10 @@ extension AudioBufferList {
     _precondition(ablMemory != nil,
       "failed to allocate memory for an AudioBufferList")
 
-    let abl = UnsafeMutableAudioBufferListPointer(
-        UnsafeMutablePointer<AudioBufferList>(ablMemory!))
+    let listPtr = ablMemory!.bindMemory(to: AudioBufferList.self, capacity: 1)
+    (ablMemory! + strideof(AudioBufferList.self)).bindMemory(
+      to: AudioBuffer.self, capacity: maximumBuffers)
+    let abl = UnsafeMutableAudioBufferListPointer(listPtr)
     abl.count = maximumBuffers
     return abl
   }
@@ -108,7 +113,8 @@ public struct UnsafeMutableAudioBufferListPointer {
     // AudioBufferList has one AudioBuffer in a "flexible array member".
     // Position the pointer after that, and skip one AudioBuffer back.  This
     // brings us to the start of AudioBuffer array.
-    return UnsafeMutablePointer<AudioBuffer>(unsafeMutablePointer + 1) - 1
+    let rawPtr = UnsafeMutableRawPointer(unsafeMutablePointer + 1)
+    return rawPtr.assumingMemoryBound(to: AudioBuffer.self) - 1
   }
 
   // FIXME: the properties 'unsafePointer' and 'unsafeMutablePointer' should be

--- a/stdlib/public/SDK/Dispatch/Data.swift
+++ b/stdlib/public/SDK/Dispatch/Data.swift
@@ -75,15 +75,18 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 		var ptr: UnsafeRawPointer? = nil
 		var size = 0
 		let data = __dispatch_data_create_map(__wrapped, &ptr, &size)
+        let contentPtr = ptr!.bindMemory(
+          to: ContentType.self, capacity: size / strideof(ContentType.self))
 		defer { _fixLifetime(data) }
-		return try body(UnsafePointer<ContentType>(ptr!))
+		return try body(contentPtr)
 	}
 
 	public func enumerateBytes(
 		block: @noescape (buffer: UnsafeBufferPointer<UInt8>, byteIndex: Int, stop: inout Bool) -> Void) 
 	{
 		_swift_dispatch_data_apply(__wrapped) { (data: __DispatchData, offset: Int, ptr: UnsafeRawPointer, size: Int) in
-			let bp = UnsafeBufferPointer(start: UnsafePointer<UInt8>(ptr), count: size)
+            let bytePtr = ptr.bindMemory(to: UInt8.self, capacity: size)
+			let bp = UnsafeBufferPointer(start: bytePtr, count: size)
 			var stop = false
 			block(buffer: bp, byteIndex: offset, stop: &stop)
 			return !stop
@@ -184,8 +187,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 		let map = __dispatch_data_create_map(subdata, &ptr, &size)
 		defer { _fixLifetime(map) }
 
-		let pptr = UnsafePointer<UInt8>(ptr!)
-		return pptr[index - offset]
+		return ptr!.load(fromByteOffset: index - offset, as: UInt8.self)
 	}
 
 	public subscript(bounds: Range<Int>) -> RandomAccessSlice<DispatchData> {
@@ -239,7 +241,7 @@ public struct DispatchDataIterator : IteratorProtocol, Sequence {
 		self._count = 0
 		self._data = __dispatch_data_create_map(
 			_data as __DispatchData, &ptr, &self._count)
-		self._ptr = UnsafePointer(ptr)
+		self._ptr = ptr
 		self._position = _data.startIndex
 
 		// The only time we expect a 'nil' pointer is when the data is empty.
@@ -250,13 +252,13 @@ public struct DispatchDataIterator : IteratorProtocol, Sequence {
 	/// element exists.
 	public mutating func next() -> DispatchData._Element? {
 		if _position == _count { return nil }
-		let element = _ptr[_position]
+		let element = _ptr.load(fromByteOffset: _position, as: UInt8.self)
 		_position = _position + 1
 		return element
 	}
 
 	internal let _data: __DispatchData
-	internal var _ptr: UnsafePointer<UInt8>!
+	internal var _ptr: UnsafeRawPointer!
 	internal var _count: Int
 	internal var _position: DispatchData.Index
 }

--- a/stdlib/public/SDK/Dispatch/Data.swift
+++ b/stdlib/public/SDK/Dispatch/Data.swift
@@ -72,7 +72,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	public func withUnsafeBytes<Result, ContentType>(
 		body: @noescape (UnsafePointer<ContentType>) throws -> Result) rethrows -> Result
 	{
-		var ptr: UnsafePointer<Void>? = nil
+		var ptr: UnsafeRawPointer? = nil
 		var size = 0
 		let data = __dispatch_data_create_map(__wrapped, &ptr, &size)
 		defer { _fixLifetime(data) }
@@ -82,7 +82,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	public func enumerateBytes(
 		block: @noescape (buffer: UnsafeBufferPointer<UInt8>, byteIndex: Int, stop: inout Bool) -> Void) 
 	{
-		_swift_dispatch_data_apply(__wrapped) { (data: __DispatchData, offset: Int, ptr: UnsafePointer<Void>, size: Int) in
+		_swift_dispatch_data_apply(__wrapped) { (data: __DispatchData, offset: Int, ptr: UnsafeRawPointer, size: Int) in
 			let bp = UnsafeBufferPointer(start: UnsafePointer<UInt8>(ptr), count: size)
 			var stop = false
 			block(buffer: bp, byteIndex: offset, stop: &stop)
@@ -116,7 +116,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 
 	private func _copyBytesHelper(to pointer: UnsafeMutablePointer<UInt8>, from range: CountableRange<Index>) {
 		var copiedCount = 0
-		__dispatch_data_apply(__wrapped) { (data: __DispatchData, offset: Int, ptr: UnsafePointer<Void>, size: Int) in
+		__dispatch_data_apply(__wrapped) { (data: __DispatchData, offset: Int, ptr: UnsafeRawPointer, size: Int) in
 			let limit = Swift.min((range.endIndex - range.startIndex) - copiedCount, size)
 			memcpy(pointer + copiedCount, ptr, limit)
 			copiedCount += limit
@@ -179,7 +179,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 		var offset = 0
 		let subdata = __dispatch_data_copy_region(__wrapped, index, &offset)
 
-		var ptr: UnsafePointer<Void>? = nil
+		var ptr: UnsafeRawPointer? = nil
 		var size = 0
 		let map = __dispatch_data_create_map(subdata, &ptr, &size)
 		defer { _fixLifetime(map) }
@@ -235,7 +235,7 @@ public struct DispatchDataIterator : IteratorProtocol, Sequence {
 
 	/// Create an iterator over the given DispatchData
 	public init(_data: DispatchData) {
-		var ptr: UnsafePointer<Void>?
+		var ptr: UnsafeRawPointer?
 		self._count = 0
 		self._data = __dispatch_data_create_map(
 			_data as __DispatchData, &ptr, &self._count)
@@ -283,7 +283,7 @@ extension DispatchData {
 	}
 }
 
-typealias _swift_data_applier = @convention(block) @noescape (__DispatchData, Int, UnsafePointer<Void>, Int) -> Bool
+typealias _swift_data_applier = @convention(block) @noescape (__DispatchData, Int, UnsafeRawPointer, Int) -> Bool
 
 @_silgen_name("_swift_dispatch_data_apply")
 internal func _swift_dispatch_data_apply(_ data: __DispatchData, _ block: _swift_data_applier)

--- a/stdlib/public/SDK/Dispatch/Private.swift
+++ b/stdlib/public/SDK/Dispatch/Private.swift
@@ -67,7 +67,7 @@ func dispatch_write(_ fd: Int32, _ data: __DispatchData, _ queue: DispatchQueue,
 }
 
 @available(*, unavailable, renamed:"DispatchData.init(bytes:)")
-public func dispatch_data_create(_ buffer: UnsafePointer<Void>, _ size: Int, _ queue: DispatchQueue?, _ destructor: (() -> Void)?) -> __DispatchData
+public func dispatch_data_create(_ buffer: UnsafeRawPointer, _ size: Int, _ queue: DispatchQueue?, _ destructor: (() -> Void)?) -> __DispatchData
 {
 	fatalError()
 }
@@ -79,7 +79,7 @@ public func dispatch_data_get_size(_ data: __DispatchData) -> Int
 }
 
 @available(*, unavailable, renamed:"DispatchData.withUnsafeBytes(self:body:)")
-public func dispatch_data_create_map(_ data: __DispatchData, _ buffer_ptr: UnsafeMutablePointer<UnsafePointer<Void>?>?, _ size_ptr: UnsafeMutablePointer<Int>?) -> __DispatchData
+public func dispatch_data_create_map(_ data: __DispatchData, _ buffer_ptr: UnsafeMutablePointer<UnsafeRawPointer?>?, _ size_ptr: UnsafeMutablePointer<Int>?) -> __DispatchData
 {
 	fatalError()
 }
@@ -97,7 +97,7 @@ public func dispatch_data_create_subrange(_ data: __DispatchData, _ offset: Int,
 }
 
 @available(*, unavailable, renamed:"DispatchData.enumerateBytes(self:block:)")
-public func dispatch_data_apply(_ data: __DispatchData, _ applier: (__DispatchData, Int, UnsafePointer<Void>, Int) -> Bool) -> Bool
+public func dispatch_data_apply(_ data: __DispatchData, _ applier: (__DispatchData, Int, UnsafeRawPointer, Int) -> Bool) -> Bool
 {
 	fatalError()
 }
@@ -211,19 +211,19 @@ public func dispatch_barrier_sync(_ queue: DispatchQueue, _ block: @noescape () 
 }
 
 @available(*, unavailable, renamed:"DispatchQueue.setSpecific(self:key:value:)")
-public func dispatch_queue_set_specific(_ queue: DispatchQueue, _ key: UnsafePointer<Void>, _ context: UnsafeMutablePointer<Void>?, _ destructor: (@convention(c) (UnsafeMutablePointer<Void>?) -> Void)?)
+public func dispatch_queue_set_specific(_ queue: DispatchQueue, _ key: UnsafeRawPointer, _ context: UnsafeMutableRawPointer?, _ destructor: (@convention(c) (UnsafeMutableRawPointer?) -> Void)?)
 {
 	fatalError()
 }
 
 @available(*, unavailable, renamed:"DispatchQueue.getSpecific(self:key:)")
-public func dispatch_queue_get_specific(_ queue: DispatchQueue, _ key: UnsafePointer<Void>) -> UnsafeMutablePointer<Void>?
+public func dispatch_queue_get_specific(_ queue: DispatchQueue, _ key: UnsafeRawPointer) -> UnsafeMutableRawPointer?
 {
 	fatalError()
 }
 
 @available(*, unavailable, renamed:"DispatchQueue.getSpecific(key:)")
-public func dispatch_get_specific(_ key: UnsafePointer<Void>) -> UnsafeMutablePointer<Void>?
+public func dispatch_get_specific(_ key: UnsafeRawPointer) -> UnsafeMutableRawPointer?
 {
 	fatalError()
 }

--- a/stdlib/public/SDK/Dispatch/Queue.swift
+++ b/stdlib/public/SDK/Dispatch/Queue.swift
@@ -333,7 +333,7 @@ public extension DispatchQueue {
 	}
 }
 
-private func _destructDispatchSpecificValue(ptr: UnsafeMutablePointer<Void>?) {
+private func _destructDispatchSpecificValue(ptr: UnsafeMutableRawPointer?) {
 	if let p = ptr {
 		Unmanaged<AnyObject>.fromOpaque(p).release()
 	}

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -13,13 +13,13 @@
 @_exported import Foundation // Clang module
 
 @_silgen_name("__NSDataInvokeDeallocatorVM")
-internal func __NSDataInvokeDeallocatorVM(_ mem: UnsafeMutablePointer<Void>, _ length: Int) -> Void
+internal func __NSDataInvokeDeallocatorVM(_ mem: UnsafeMutableRawPointer, _ length: Int) -> Void
 
 @_silgen_name("__NSDataInvokeDeallocatorUnmap")
-internal func __NSDataInvokeDeallocatorUnmap(_ mem: UnsafeMutablePointer<Void>, _ length: Int) -> Void
+internal func __NSDataInvokeDeallocatorUnmap(_ mem: UnsafeMutableRawPointer, _ length: Int) -> Void
 
 @_silgen_name("__NSDataInvokeDeallocatorFree")
-internal func __NSDataInvokeDeallocatorFree(_ mem: UnsafeMutablePointer<Void>, _ length: Int) -> Void
+internal func __NSDataInvokeDeallocatorFree(_ mem: UnsafeMutableRawPointer, _ length: Int) -> Void
 
 @_silgen_name("_NSWriteDataToFile_Swift")
 internal func _NSWriteDataToFile_Swift(url: URL, data: NSData, options: UInt, error: NSErrorPointer) -> Bool
@@ -104,7 +104,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         /// A custom deallocator.
         case custom((UnsafeMutablePointer<UInt8>, Int) -> Void)
         
-        fileprivate var _deallocator : ((UnsafeMutablePointer<Void>, Int) -> Void)? {
+        fileprivate var _deallocator : ((UnsafeMutableRawPointer, Int) -> Void)? {
             switch self {
             case .virtualMemory:
                 return { __NSDataInvokeDeallocatorVM($0, $1) }
@@ -271,7 +271,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     }
 
 
-    private func _getUnsafeBytesPointer() -> UnsafePointer<Void> {
+    private func _getUnsafeBytesPointer() -> UnsafeRawPointer {
         return _mapUnmanaged { return $0.bytes }
     }
     
@@ -284,7 +284,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         return try body(UnsafePointer(bytes))
     }
     
-    private mutating func _getUnsafeMutableBytesPointer() -> UnsafeMutablePointer<Void> {
+    private mutating func _getUnsafeMutableBytesPointer() -> UnsafeMutableRawPointer {
         return _applyUnmanagedMutation {
             return $0.mutableBytes
         }
@@ -657,10 +657,10 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     }
     
     @available(*, unavailable, message: "use withUnsafeBytes instead")
-    public var bytes: UnsafePointer<Void> { fatalError() }
+    public var bytes: UnsafeRawPointer { fatalError() }
     
     @available(*, unavailable, message: "use withUnsafeMutableBytes instead")
-    public var mutableBytes: UnsafeMutablePointer<Void> { fatalError() }
+    public var mutableBytes: UnsafeMutableRawPointer { fatalError() }
 
     /// Returns `true` if the two `Data` arguments are equal.
     public static func ==(d1 : Data, d2 : Data) -> Bool {
@@ -746,7 +746,7 @@ extension _SwiftNSData {
     }
     
     @objc(bytes)
-    var bytes : UnsafePointer<Void> {
+    var bytes : UnsafeRawPointer {
         return _mapUnmanaged { $0.bytes }
     }
     
@@ -756,12 +756,12 @@ extension _SwiftNSData {
     }
     
     @objc(getBytes:length:)
-    func getBytes(_ buffer: UnsafeMutablePointer<Void>, length: Int) {
+    func getBytes(_ buffer: UnsafeMutableRawPointer, length: Int) {
         return _mapUnmanaged { $0.getBytes(buffer, length: length) }
     }
     
     @objc(getBytes:range:)
-    func getBytes(_ buffer: UnsafeMutablePointer<Void>, range: NSRange) {
+    func getBytes(_ buffer: UnsafeMutableRawPointer, range: NSRange) {
         return _mapUnmanaged { $0.getBytes(buffer, range: range) }
     }
     
@@ -783,7 +783,7 @@ extension _SwiftNSData {
     }
     
     @objc(enumerateByteRangesUsingBlock:)
-    func enumerateByteRanges(using block: @noescape (UnsafePointer<Void>, NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) {
+    func enumerateByteRanges(using block: @noescape (UnsafeRawPointer, NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) {
         return _mapUnmanaged { $0.enumerateBytes(block) }
     }
     

--- a/stdlib/public/SDK/Foundation/Foundation.swift
+++ b/stdlib/public/SDK/Foundation/Foundation.swift
@@ -56,7 +56,7 @@ extension NSString : ExpressibleByStringLiteral {
     var immutableResult: NSString
     if value.hasPointerRepresentation {
       immutableResult = NSString(
-        bytesNoCopy: UnsafeMutableRawPointer(value.utf8Start),
+        bytesNoCopy: UnsafeMutableRawPointer(mutating: value.utf8Start),
         length: Int(value.utf8CodeUnitCount),
         encoding: value.isASCII ? String.Encoding.ascii.rawValue : String.Encoding.utf8.rawValue,
         freeWhenDone: false)!

--- a/stdlib/public/SDK/Foundation/Foundation.swift
+++ b/stdlib/public/SDK/Foundation/Foundation.swift
@@ -56,7 +56,7 @@ extension NSString : ExpressibleByStringLiteral {
     var immutableResult: NSString
     if value.hasPointerRepresentation {
       immutableResult = NSString(
-        bytesNoCopy: UnsafeMutablePointer<Void>(value.utf8Start),
+        bytesNoCopy: UnsafeMutableRawPointer(value.utf8Start),
         length: Int(value.utf8CodeUnitCount),
         encoding: value.isASCII ? String.Encoding.ascii.rawValue : String.Encoding.utf8.rawValue,
         freeWhenDone: false)!

--- a/stdlib/public/SDK/Foundation/IndexPath.swift
+++ b/stdlib/public/SDK/Foundation/IndexPath.swift
@@ -154,12 +154,13 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
         if count == 0 {
             _indexes = []
         } else {
-            var ptr = UnsafeMutablePointer<Element>(malloc(count * sizeof(Element.self)))
+            var ptr = malloc(count * sizeof(Element.self))
             defer { free(ptr) }
+
+            let elementPtr = ptr!.bindMemory(to: Element.self, capacity: count)
+            nsIndexPath.getIndexes(elementPtr, range: NSMakeRange(0, count))
             
-            nsIndexPath.getIndexes(ptr!, range: NSMakeRange(0, count))
-            
-            let buffer = UnsafeBufferPointer(start: ptr, count: count)
+            let buffer = UnsafeBufferPointer(start: elementPtr, count: count)
             _indexes = buffer.map { $0 }
         }
     }

--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -41,7 +41,7 @@ internal func NS_Swift_performErrorRecoverySelector(
   delegate: AnyObject?,
   selector: Selector,
   success: ObjCBool,
-  contextInfo: UnsafeMutablePointer<Void>?)
+  contextInfo: UnsafeMutableRawPointer?)
 
 /// Class that implements the informal protocol
 /// NSErrorRecoveryAttempting, which is used by NSError when it
@@ -52,7 +52,7 @@ class _NSErrorRecoveryAttempter {
                        optionIndex recoveryOptionIndex: Int,
                        delegate: AnyObject?,
                        didRecoverSelector: Selector,
-                       contextInfo: UnsafeMutablePointer<Void>?) {
+                       contextInfo: UnsafeMutableRawPointer?) {
     let error = nsError as Error as! RecoverableError
     error.attemptRecovery(optionIndex: recoveryOptionIndex) { success in
       NS_Swift_performErrorRecoverySelector(

--- a/stdlib/public/SDK/Foundation/NSStringAPI.swift
+++ b/stdlib/public/SDK/Foundation/NSStringAPI.swift
@@ -782,7 +782,7 @@ extension String {
   /// in a given encoding, and optionally frees the buffer.  WARNING:
   /// this initializer is not memory-safe!
   public init?(
-    bytesNoCopy bytes: UnsafeMutablePointer<Void>, length: Int,
+    bytesNoCopy bytes: UnsafeMutableRawPointer, length: Int,
     encoding: Encoding, freeWhenDone flag: Bool
   ) {
     if let ns = NSString(

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -432,7 +432,7 @@ extension _ArrayBuffer {
   /// A value that identifies the storage used by the buffer.  Two
   /// buffers address the same elements when they have the same
   /// identity and count.
-  public var identity: UnsafePointer<Void> {
+  public var identity: UnsafeRawPointer {
     if _isNative {
       return _native.identity
     }

--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -120,7 +120,7 @@ public protocol _ArrayBufferProtocol
   /// A value that identifies the storage used by the buffer.  Two
   /// buffers address the same elements when they have the same
   /// identity and count.
-  var identity: UnsafePointer<Void> { get }
+  var identity: UnsafeRawPointer { get }
 
   var startIndex: Int { get }
 }

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1489,10 +1489,10 @@ extension ${Self} {
   internal func _cPointerArgs() -> (AnyObject?, UnsafeRawPointer?) {
     let p = _baseAddressIfContiguous
     if _fastPath(p != nil || isEmpty) {
-      return (_owner, UnsafePointer(p))
+      return (_owner, UnsafeRawPointer(p))
     }
     let n = ContiguousArray(self._buffer)._buffer
-    return (n.owner, UnsafePointer(n.firstElementAddress))
+    return (n.owner, UnsafeRawPointer(n.firstElementAddress))
   }
 }
 

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1486,7 +1486,7 @@ extension ${Self} : CustomStringConvertible, CustomDebugStringConvertible {
 extension ${Self} {
   @_versioned
   @_transparent
-  internal func _cPointerArgs() -> (AnyObject?, UnsafePointer<Void>?) {
+  internal func _cPointerArgs() -> (AnyObject?, UnsafeRawPointer?) {
     let p = _baseAddressIfContiguous
     if _fastPath(p != nil || isEmpty) {
       return (_owner, UnsafePointer(p))

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -467,22 +467,22 @@ public func == <Pointee>(
 @_fixed_layout
 internal struct _CocoaFastEnumerationStackBuf {
   // Clang uses 16 pointers.  So do we.
-  internal var _item0: UnsafePointer<Void>?
-  internal var _item1: UnsafePointer<Void>?
-  internal var _item2: UnsafePointer<Void>?
-  internal var _item3: UnsafePointer<Void>?
-  internal var _item4: UnsafePointer<Void>?
-  internal var _item5: UnsafePointer<Void>?
-  internal var _item6: UnsafePointer<Void>?
-  internal var _item7: UnsafePointer<Void>?
-  internal var _item8: UnsafePointer<Void>?
-  internal var _item9: UnsafePointer<Void>?
-  internal var _item10: UnsafePointer<Void>?
-  internal var _item11: UnsafePointer<Void>?
-  internal var _item12: UnsafePointer<Void>?
-  internal var _item13: UnsafePointer<Void>?
-  internal var _item14: UnsafePointer<Void>?
-  internal var _item15: UnsafePointer<Void>?
+  internal var _item0: UnsafeRawPointer?
+  internal var _item1: UnsafeRawPointer?
+  internal var _item2: UnsafeRawPointer?
+  internal var _item3: UnsafeRawPointer?
+  internal var _item4: UnsafeRawPointer?
+  internal var _item5: UnsafeRawPointer?
+  internal var _item6: UnsafeRawPointer?
+  internal var _item7: UnsafeRawPointer?
+  internal var _item8: UnsafeRawPointer?
+  internal var _item9: UnsafeRawPointer?
+  internal var _item10: UnsafeRawPointer?
+  internal var _item11: UnsafeRawPointer?
+  internal var _item12: UnsafeRawPointer?
+  internal var _item13: UnsafeRawPointer?
+  internal var _item14: UnsafeRawPointer?
+  internal var _item15: UnsafeRawPointer?
 
   @_transparent
   internal var count: Int {
@@ -508,7 +508,7 @@ internal struct _CocoaFastEnumerationStackBuf {
     _item15 = _item0
 
     _sanityCheck(sizeofValue(self) >=
-                   sizeof(Optional<UnsafePointer<Void>>.self) * count)
+                   sizeof(Optional<UnsafeRawPointer>.self) * count)
   }
 }
 

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -208,7 +208,7 @@ internal func _isClassOrObjCExistential<T>(_ x: T.Type) -> Bool {
 /// object.
 @_transparent
 public func unsafeAddress(of object: AnyObject) -> UnsafeRawPointer {
-  return UnsafePointer(Builtin.bridgeToRawPointer(object))
+  return UnsafeRawPointer(Builtin.bridgeToRawPointer(object))
 }
 
 @available(*, unavailable, renamed: "unsafeAddress(of:)")

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -207,12 +207,12 @@ internal func _isClassOrObjCExistential<T>(_ x: T.Type) -> Bool {
 /// not much you can do with this other than use it to identify the
 /// object.
 @_transparent
-public func unsafeAddress(of object: AnyObject) -> UnsafePointer<Void> {
+public func unsafeAddress(of object: AnyObject) -> UnsafeRawPointer {
   return UnsafePointer(Builtin.bridgeToRawPointer(object))
 }
 
 @available(*, unavailable, renamed: "unsafeAddress(of:)")
-public func unsafeAddressOf(_ object: AnyObject) -> UnsafePointer<Void> {
+public func unsafeAddressOf(_ object: AnyObject) -> UnsafeRawPointer {
   Builtin.unreachable()
 }
 

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -151,13 +151,13 @@ extension OpaquePointer : CustomDebugStringConvertible {
 
 extension Int {
   public init(bitPattern pointer: OpaquePointer?) {
-    self.init(bitPattern: UnsafePointer<Void>(pointer))
+    self.init(bitPattern: UnsafeRawPointer(pointer))
   }
 }
 
 extension UInt {
   public init(bitPattern pointer: OpaquePointer?) {
-    self.init(bitPattern: UnsafePointer<Void>(pointer))
+    self.init(bitPattern: UnsafeRawPointer(pointer))
   }
 }
 
@@ -170,10 +170,10 @@ extension OpaquePointer : Equatable {
 /// The corresponding Swift type to `va_list` in imported C APIs.
 @_fixed_layout
 public struct CVaListPointer {
-  var value: UnsafeMutablePointer<Void>
+  var value: UnsafeMutableRawPointer
 
   public // @testable
-  init(_fromUnsafeMutablePointer from: UnsafeMutablePointer<Void>) {
+  init(_fromUnsafeMutablePointer from: UnsafeMutableRawPointer) {
     value = from
   }
 }
@@ -186,8 +186,8 @@ extension CVaListPointer : CustomDebugStringConvertible {
 }
 
 func _memcpy(
-  dest destination: UnsafeMutablePointer<Void>,
-  src: UnsafeMutablePointer<Void>,
+  dest destination: UnsafeMutableRawPointer,
+  src: UnsafeMutableRawPointer,
   size: UInt
 ) {
   let dest = destination._rawValue

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -453,7 +453,7 @@ struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
   /// Two buffers address the same elements when they have the same
   /// identity and count.
   public var identity: UnsafeRawPointer {
-    return UnsafePointer(firstElementAddress)
+    return UnsafeRawPointer(firstElementAddress)
   }
   
   /// Returns `true` iff we have storage for elements of the given

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -452,7 +452,7 @@ struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
   ///
   /// Two buffers address the same elements when they have the same
   /// identity and count.
-  public var identity: UnsafePointer<Void> {
+  public var identity: UnsafeRawPointer {
     return UnsafePointer(firstElementAddress)
   }
   

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -3319,7 +3319,7 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
   @objc
   internal required init(
     objects: UnsafePointer<AnyObject?>,
-    forKeys: UnsafePointer<Void>,
+    forKeys: UnsafeRawPointer,
     count: Int
   ) {
     _sanityCheckFailure("don't call this designated initializer")

--- a/stdlib/public/core/Pointer.swift
+++ b/stdlib/public/core/Pointer.swift
@@ -57,7 +57,7 @@ func _convertConstArrayToPointerArgument<
     validPointer = ToPointer(addr._rawValue)
   } else {
     let lastAlignedValue = ~(alignof(FromElement.self) - 1)
-    let lastAlignedPointer = UnsafePointer<Void>(bitPattern: lastAlignedValue)!
+    let lastAlignedPointer = UnsafeRawPointer(bitPattern: lastAlignedValue)!
     validPointer = ToPointer(lastAlignedPointer._rawValue)
   }
   return (owner, validPointer)

--- a/stdlib/public/core/Runtime.swift.gyb
+++ b/stdlib/public/core/Runtime.swift.gyb
@@ -32,7 +32,7 @@ func _stdlib_atomicCompareExchangeStrongPtrImpl(
     target._rawValue,
     UInt(bitPattern: expected.pointee)._builtinWordValue,
     UInt(bitPattern: desired)._builtinWordValue)
-  expected.pointee = UnsafeMutablePointer(bitPattern: Int(oldValue))
+  expected.pointee = UnsafeMutableRawPointer(bitPattern: Int(oldValue))
   return Bool(won)
 }
 

--- a/stdlib/public/core/Runtime.swift.gyb
+++ b/stdlib/public/core/Runtime.swift.gyb
@@ -23,9 +23,9 @@ import SwiftShims
 @_transparent
 public // @testable
 func _stdlib_atomicCompareExchangeStrongPtrImpl(
-  object target: UnsafeMutablePointer<UnsafeMutablePointer<Void>?>,
-  expected: UnsafeMutablePointer<UnsafeMutablePointer<Void>?>,
-  desired: UnsafeMutablePointer<Void>?) -> Bool {
+  object target: UnsafeMutablePointer<UnsafeMutableRawPointer?>,
+  expected: UnsafeMutablePointer<UnsafeMutableRawPointer?>,
+  desired: UnsafeMutableRawPointer?) -> Bool {
 
   // We use Builtin.Word here because Builtin.RawPointer can't be nil.
   let (oldValue, won) = Builtin.cmpxchg_seqcst_seqcst_Word(
@@ -83,7 +83,7 @@ public // @testable
 func _stdlib_atomicInitializeARCRef(
   object target: UnsafeMutablePointer<AnyObject?>,
   desired: AnyObject) -> Bool {
-  var expected: UnsafeMutablePointer<Void>? = nil
+  var expected: UnsafeMutableRawPointer? = nil
   let desiredPtr = Unmanaged.passRetained(desired).toOpaque()
   let wonRace = _stdlib_atomicCompareExchangeStrongPtrImpl(
     object: UnsafeMutablePointer(target),
@@ -473,11 +473,11 @@ func _uint64ToString(
 func _rawPointerToString(_ value: Builtin.RawPointer) -> String {
   var result = _uint64ToString(
     UInt64(
-      UInt(bitPattern: UnsafePointer<Void>(value))),
+      UInt(bitPattern: UnsafeRawPointer(value))),
       radix: 16,
       uppercase: false
     )
-  for _ in 0..<(2 * sizeof(UnsafePointer<Void>.self) - result.utf16.count) {
+  for _ in 0..<(2 * sizeof(UnsafeRawPointer.self) - result.utf16.count) {
     result = "0" + result
   }
   return "0x" + result

--- a/stdlib/public/core/ShadowProtocols.swift
+++ b/stdlib/public/core/ShadowProtocols.swift
@@ -89,7 +89,7 @@ public protocol _NSDictionaryCore :
   // The designated initializer of `NSDictionary`.
   init(
     objects: UnsafePointer<AnyObject?>,
-    forKeys: UnsafePointer<Void>, count: Int)
+    forKeys: UnsafeRawPointer, count: Int)
 
   var count: Int { get }
 

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -111,7 +111,7 @@ struct _SliceBuffer<Element> : _ArrayBufferProtocol, RandomAccessCollection {
   /// A value that identifies the storage used by the buffer.  Two
   /// buffers address the same elements when they have the same
   /// identity and count.
-  public var identity: UnsafePointer<Void> {
+  public var identity: UnsafeRawPointer {
     return UnsafePointer(firstElementAddress)
   }
 

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -112,7 +112,7 @@ struct _SliceBuffer<Element> : _ArrayBufferProtocol, RandomAccessCollection {
   /// buffers address the same elements when they have the same
   /// identity and count.
   public var identity: UnsafeRawPointer {
-    return UnsafePointer(firstElementAddress)
+    return UnsafeRawPointer(firstElementAddress)
   }
 
   /// An object that keeps the elements stored in this buffer alive.

--- a/stdlib/public/core/Unmanaged.swift
+++ b/stdlib/public/core/Unmanaged.swift
@@ -29,7 +29,7 @@ public struct Unmanaged<Instance : AnyObject> {
   ///
   ///     let str: CFString = Unmanaged.fromOpaque(ptr).takeUnretainedValue()
   @_transparent
-  public static func fromOpaque(_ value: UnsafePointer<Void>) -> Unmanaged {
+  public static func fromOpaque(_ value: UnsafeRawPointer) -> Unmanaged {
     return Unmanaged(_private: unsafeBitCast(value, to: Instance.self))
   }
 
@@ -41,8 +41,8 @@ public struct Unmanaged<Instance : AnyObject> {
   ///     let bits = Unmanaged.passUnretained(str0)
   ///     let ptr = bits.toOpaque()
   @_transparent
-  public func toOpaque() -> UnsafeMutablePointer<Void> {
-    return unsafeBitCast(_value, to: UnsafeMutablePointer<Void>.self)
+  public func toOpaque() -> UnsafeMutableRawPointer {
+    return unsafeBitCast(_value, to: UnsafeMutableRawPointer.self)
   }
 
   /// Create an unmanaged reference with an unbalanced retain.
@@ -216,13 +216,13 @@ public struct Unmanaged<Instance : AnyObject> {
 
 extension Unmanaged {
   @available(*, unavailable, 
-    message:"use 'fromOpaque(_: UnsafePointer<Void>)' instead")
+    message:"use 'fromOpaque(_: UnsafeRawPointer)' instead")
   public static func fromOpaque(_ value: OpaquePointer) -> Unmanaged {
     Builtin.unreachable()
   }
   
   @available(*, unavailable, 
-    message:"use 'toOpaque() -> UnsafePointer<Void>' instead")
+    message:"use 'toOpaque() -> UnsafeRawPointer' instead")
   public func toOpaque() -> OpaquePointer {
     Builtin.unreachable()
   }

--- a/stdlib/public/core/UnsafeRawPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawPointer.swift.gyb
@@ -27,6 +27,13 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
   /// Implements conformance to the public protocol `_Pointer`.
   public let _rawValue: Builtin.RawPointer
 
+  // Construct ${a_Self} from another ${a_Self}.
+  // FIXME: Why is this necessary?
+  @_transparent
+  public init(_ other: Unsafe${Mutable}RawPointer) {
+    self._rawValue = other._rawValue
+  }
+
   /// Convert a builtin raw pointer to ${a_Self}.
   @_transparent
   public init(_ _rawValue: Builtin.RawPointer) {

--- a/stdlib/public/core/UnsafeRawPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawPointer.swift.gyb
@@ -31,7 +31,7 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
   // FIXME: Why is this necessary?
   @_transparent
   public init(_ other: Unsafe${Mutable}RawPointer) {
-    self._rawValue = other._rawValue
+    self = other
   }
 
   /// Convert a builtin raw pointer to ${a_Self}.

--- a/stdlib/public/core/UnsafeRawPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawPointer.swift.gyb
@@ -158,6 +158,7 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
   /// - Warning: Binding memory to a type is potentially undefined if the
   ///   memory is ever accessed as an unrelated type.
   @_transparent
+  @discardableResult
   public func bindMemory<T>(to type: T.Type, capacity count: Int)
   -> Unsafe${Mutable}Pointer<T> {
     Builtin.bindMemory(_rawValue, count._builtinWordValue, type)

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -429,7 +429,7 @@ final internal class _VaListBuilder {
     header.overflow_arg_area
       = storage._baseAddress + _x86_64RegisterSaveWords
     return CVaListPointer(
-             _fromUnsafeMutablePointer: UnsafeMutablePointer<Void>(
+             _fromUnsafeMutablePointer: UnsafeMutableRawPointer(
                Builtin.addressof(&self.header)))
   }
 

--- a/test/1_stdlib/ErrorBridged.swift
+++ b/test/1_stdlib/ErrorBridged.swift
@@ -438,7 +438,7 @@ extension MySwiftCustomizedError : RecoverableError {
                        optionIndex recoveryOptionIndex: Int,
                        delegate: AnyObject?,
                        didRecoverSelector: Selector,
-                       contextInfo: UnsafeMutablePointer<Void>?)
+                       contextInfo: UnsafeMutableRawPointer?)
 
   @objc(attemptRecoveryFromError:optionIndex:)
   func attemptRecovery(fromError nsError: Error,
@@ -447,16 +447,16 @@ extension MySwiftCustomizedError : RecoverableError {
 
 class RecoveryDelegate {
   let expectedSuccess: Bool
-  let expectedContextInfo: UnsafeMutablePointer<Void>?
+  let expectedContextInfo: UnsafeMutableRawPointer?
   var called = false
 
   init(expectedSuccess: Bool,
-       expectedContextInfo: UnsafeMutablePointer<Void>?) {
+       expectedContextInfo: UnsafeMutableRawPointer?) {
     self.expectedSuccess = expectedSuccess
     self.expectedContextInfo = expectedContextInfo
   }
 
-  @objc func recover(success: Bool, contextInfo: UnsafeMutablePointer<Void>?) {
+  @objc func recover(success: Bool, contextInfo: UnsafeMutableRawPointer?) {
     expectEqual(expectedSuccess, success)
     expectEqual(expectedContextInfo, contextInfo)
     called = true

--- a/test/1_stdlib/KVO.swift
+++ b/test/1_stdlib/KVO.swift
@@ -53,7 +53,7 @@ class Observer : NSObject {
   override func observeValue(forKeyPath:String?,
                              of obj:Any?,
                              change:Dictionary<NSKeyValueChangeKey, Any>?,
-                             context:UnsafeMutablePointer<Void>?) {
+                             context:UnsafeMutableRawPointer?) {
     target!.print()
   }
 }
@@ -102,7 +102,7 @@ class ObserverKVO : NSObject {
   override func observeValue(forKeyPath:String?,
                              of obj:Any?,
                              change:Dictionary<NSKeyValueChangeKey, Any>?,
-                             context:UnsafeMutablePointer<Void>?) {
+                             context:UnsafeMutableRawPointer?) {
     if context == &kvoContext {
       target!.print()
     }

--- a/test/1_stdlib/POSIX.swift
+++ b/test/1_stdlib/POSIX.swift
@@ -100,7 +100,7 @@ POSIXTests.test("ioctl(CInt, UInt, CInt): fail") {
 
 #if os(Linux)
 // Successful creation of a socket and listing interfaces
-POSIXTests.test("ioctl(CInt, UInt, UnsafeMutablePointer<Void>): listing interfaces success") {
+POSIXTests.test("ioctl(CInt, UInt, UnsafeMutableRawPointer): listing interfaces success") {
   // Create a socket
   let sock = socket(PF_INET, 1, 0)
   expectGT(Int(sock), 0)
@@ -184,7 +184,7 @@ POSIXTests.test("fcntl(CInt, CInt, CInt): block and unblocking sockets success")
   expectEqual(0, rc)
 }
 
-POSIXTests.test("fcntl(CInt, CInt, UnsafeMutablePointer<Void>): locking and unlocking success") {
+POSIXTests.test("fcntl(CInt, CInt, UnsafeMutableRawPointer): locking and unlocking success") {
   // Create the file and add data to it...
   var fd = open(fn, O_CREAT | O_WRONLY, 0o666)
   expectGT(Int(fd), 0)

--- a/test/1_stdlib/Renames.swift
+++ b/test/1_stdlib/Renames.swift
@@ -481,8 +481,8 @@ func _UnicodeScalar(s: UnicodeScalar) {
 }
 
 func _Unmanaged<T>(x: Unmanaged<T>, p: OpaquePointer) {
-  _ = Unmanaged<T>.fromOpaque(p) // expected-error {{'fromOpaque' is unavailable: use 'fromOpaque(_: UnsafePointer<Void>)' instead}} {{none}}
-  let _: OpaquePointer = x.toOpaque() // expected-error {{'toOpaque()' is unavailable: use 'toOpaque() -> UnsafePointer<Void>' instead}} {{none}}
+  _ = Unmanaged<T>.fromOpaque(p) // expected-error {{'fromOpaque' is unavailable: use 'fromOpaque(_: UnsafeRawPointer)' instead}} {{none}}
+  let _: OpaquePointer = x.toOpaque() // expected-error {{'toOpaque()' is unavailable: use 'toOpaque() -> UnsafeRawPointer' instead}} {{none}}
 }
 
 func _UnsafeBufferPointer() {

--- a/test/1_stdlib/Runtime.swift.gyb
+++ b/test/1_stdlib/Runtime.swift.gyb
@@ -992,9 +992,9 @@ Reflection.test("ObjectIdentifier/CustomDebugStringConvertible") {
   expectEqual(String(reflecting: oi1), String(reflecting: oi1))
   expectNotEqual(String(reflecting: oi1), String(reflecting: oi2))
 
-  let p1 = UnsafePointer<Void>(bitPattern: UInt(bitPattern: oi1))!
+  let p1 = UnsafeRawPointer(bitPattern: UInt(bitPattern: oi1))!
   expectPrinted("ObjectIdentifier(\(p1))", oi1)
-  let p2 = UnsafePointer<Void>(bitPattern: Int(bitPattern: oi1))!
+  let p2 = UnsafeRawPointer(bitPattern: Int(bitPattern: oi1))!
   expectPrinted("ObjectIdentifier(\(p2))", oi1)
 
 }

--- a/test/1_stdlib/TestData.swift
+++ b/test/1_stdlib/TestData.swift
@@ -90,7 +90,7 @@ class TestData : TestDataSuper {
                 let bytePtr = buffer!.bindMemory(to: UInt8.self, capacity: length)
                 let result = UnsafeMutableBufferPointer(start: bytePtr, count: length)
                 _pointer = result
-                return UnsafePointer(result.baseAddress!)
+                return UnsafeRawPointer(result.baseAddress!)
             }
         }
         
@@ -108,7 +108,7 @@ class TestData : TestDataSuper {
             let result = UnsafeMutableBufferPointer(start: bytePtr, count: newBufferLength)
             _pointer = result
             _length = newBufferLength
-            return result.baseAddress!
+            return UnsafeMutableRawPointer(result.baseAddress!)
         }
         
         override func getBytes(_ buffer: UnsafeMutableRawPointer, length: Int) {
@@ -457,7 +457,7 @@ class TestData : TestDataSuper {
     func testCopyBytes() {
         let c = 10
         let underlyingBuffer = malloc(c * strideof(UInt16.self))!
-        let u16Ptr = buffer!.bindMemory(to: UInt16.self, capacity: c)
+        let u16Ptr = underlyingBuffer.bindMemory(to: UInt16.self, capacity: c)
         let buffer = UnsafeMutableBufferPointer<UInt16>(start: u16Ptr, count: c)
         
         buffer[0] = 0
@@ -637,8 +637,8 @@ class TestData : TestDataSuper {
 
         let count = 1 << 24
         let randomMemory = malloc(count)!
-        let ptr = randomMemory!.bindMemory(to: UInt8.self, capacity: count)
-        let data = Data(bytesNoCopy: ptr!, count: count, deallocator: .free)
+        let ptr = randomMemory.bindMemory(to: UInt8.self, capacity: count)
+        let data = Data(bytesNoCopy: ptr, count: count, deallocator: .free)
         do {
             try data.write(to: url)
             let readData = try Data(contentsOf: url)
@@ -824,7 +824,7 @@ class TestData : TestDataSuper {
             let underlyingBuffer = malloc(6 * strideof(MyStruct.self))!
             defer { free(underlyingBuffer) }
 
-            let ptr = underlyingBuffer!.bindMemory(to: MyStruct.self, capacity: 6)
+            let ptr = underlyingBuffer.bindMemory(to: MyStruct.self, capacity: 6)
             let buffer = UnsafeMutableBufferPointer<MyStruct>(start: ptr, count: 6)
             
             let byteCount = data.copyBytes(to: buffer)
@@ -836,7 +836,7 @@ class TestData : TestDataSuper {
             let underlyingBuffer = malloc(3 * strideof(MyStruct.self))!
             defer { free(underlyingBuffer) }
 
-            let ptr = underlyingBuffer!.bindMemory(to: MyStruct.self, capacity: 3)
+            let ptr = underlyingBuffer.bindMemory(to: MyStruct.self, capacity: 3)
             let buffer = UnsafeMutableBufferPointer<MyStruct>(start: ptr, count: 3)
             
             let byteCount = data.copyBytes(to: buffer)
@@ -848,7 +848,7 @@ class TestData : TestDataSuper {
             let underlyingBuffer = malloc(12 * strideof(MyStruct.self))!
             defer { free(underlyingBuffer) }
             
-            let ptr = underlyingBuffer!.bindMemory(to: MyStruct.self, capacity: 6)
+            let ptr = underlyingBuffer.bindMemory(to: MyStruct.self, capacity: 6)
             let buffer = UnsafeMutableBufferPointer<MyStruct>(start: ptr, count: 6)
             
             let byteCount = data.copyBytes(to: buffer)

--- a/test/1_stdlib/TestData.swift
+++ b/test/1_stdlib/TestData.swift
@@ -71,7 +71,8 @@ class TestData : TestDataSuper {
                         memmove(newBuffer, ptr.baseAddress, _length)
                         memset(newBuffer + _length, 1, newValue - _length)
                     }
-                    _pointer = UnsafeMutableBufferPointer(start: newBuffer, count: newValue)
+                    let bytePtr = newBuffer.bindMemory(to: UInt8.self, capacity: newValue)
+                    _pointer = UnsafeMutableBufferPointer(start: bytePtr, count: newValue)
                 } else {
                     _length = newValue
                 }
@@ -80,13 +81,14 @@ class TestData : TestDataSuper {
         
         override var bytes : UnsafeRawPointer {
             if let d = _pointer {
-                return UnsafePointer(d.baseAddress!)
+                return UnsafeRawPointer(d.baseAddress!)
             } else {
                 // Need to allocate the buffer now.
                 // It doesn't matter if the buffer is uniquely referenced or not here.
                 let buffer = malloc(length)
                 memset(buffer, 1, length)
-                let result = UnsafeMutableBufferPointer(start: buffer, count: length)
+                let bytePtr = buffer!.bindMemory(to: UInt8.self, capacity: length)
+                let result = UnsafeMutableBufferPointer(start: bytePtr, count: length)
                 _pointer = result
                 return UnsafePointer(result.baseAddress!)
             }
@@ -102,8 +104,8 @@ class TestData : TestDataSuper {
                 // Set new data to 1s
                 memset(newBuffer, 1, newBufferLength)
             }
-            
-            let result = UnsafeMutableBufferPointer(start: newBuffer, count: newBufferLength)
+            let bytePtr = newBuffer!.bindMemory(to: UInt8.self, capacity: newBufferLength)
+            let result = UnsafeMutableBufferPointer(start: bytePtr, count: newBufferLength)
             _pointer = result
             _length = newBufferLength
             return result.baseAddress!
@@ -440,7 +442,8 @@ class TestData : TestDataSuper {
         // Scope the data to a block to control lifecycle
         do {
             let buffer = malloc(16)!
-            var data = Data(bytesNoCopy: UnsafeMutablePointer<UInt8>(buffer), count: 16, deallocator: .custom({ (ptr, size) in
+            let bytePtr = buffer.bindMemory(to: UInt8.self, capacity: 16)
+            var data = Data(bytesNoCopy: bytePtr, count: 16, deallocator: .custom({ (ptr, size) in
                 deallocatorCalled = true
                 free(UnsafeMutableRawPointer(ptr))
             }))
@@ -454,7 +457,8 @@ class TestData : TestDataSuper {
     func testCopyBytes() {
         let c = 10
         let underlyingBuffer = malloc(c * strideof(UInt16.self))!
-        let buffer = UnsafeMutableBufferPointer<UInt16>(start: UnsafeMutablePointer<UInt16>(underlyingBuffer), count: c)
+        let u16Ptr = buffer!.bindMemory(to: UInt16.self, capacity: c)
+        let buffer = UnsafeMutableBufferPointer<UInt16>(start: u16Ptr, count: c)
         
         buffer[0] = 0
         buffer[1] = 0
@@ -633,8 +637,8 @@ class TestData : TestDataSuper {
 
         let count = 1 << 24
         let randomMemory = malloc(count)!
-        let ptr = UnsafeMutablePointer<UInt8>(randomMemory)!
-        let data = Data(bytesNoCopy: ptr, count: count, deallocator: .free)
+        let ptr = randomMemory!.bindMemory(to: UInt8.self, capacity: count)
+        let data = Data(bytesNoCopy: ptr!, count: count, deallocator: .free)
         do {
             try data.write(to: url)
             let readData = try Data(contentsOf: url)
@@ -819,8 +823,9 @@ class TestData : TestDataSuper {
             // equal size
             let underlyingBuffer = malloc(6 * strideof(MyStruct.self))!
             defer { free(underlyingBuffer) }
-            
-            let buffer = UnsafeMutableBufferPointer<MyStruct>(start: UnsafeMutablePointer<MyStruct>(underlyingBuffer), count: 6)
+
+            let ptr = underlyingBuffer!.bindMemory(to: MyStruct.self, capacity: 6)
+            let buffer = UnsafeMutableBufferPointer<MyStruct>(start: ptr, count: 6)
             
             let byteCount = data.copyBytes(to: buffer)
             expectEqual(6 * strideof(MyStruct.self), byteCount)
@@ -830,8 +835,9 @@ class TestData : TestDataSuper {
             // undersized
             let underlyingBuffer = malloc(3 * strideof(MyStruct.self))!
             defer { free(underlyingBuffer) }
-            
-            let buffer = UnsafeMutableBufferPointer<MyStruct>(start: UnsafeMutablePointer<MyStruct>(underlyingBuffer), count: 3)
+
+            let ptr = underlyingBuffer!.bindMemory(to: MyStruct.self, capacity: 3)
+            let buffer = UnsafeMutableBufferPointer<MyStruct>(start: ptr, count: 3)
             
             let byteCount = data.copyBytes(to: buffer)
             expectEqual(3 * strideof(MyStruct.self), byteCount)
@@ -842,7 +848,8 @@ class TestData : TestDataSuper {
             let underlyingBuffer = malloc(12 * strideof(MyStruct.self))!
             defer { free(underlyingBuffer) }
             
-            let buffer = UnsafeMutableBufferPointer<MyStruct>(start: UnsafeMutablePointer<MyStruct>(underlyingBuffer), count: 6)
+            let ptr = underlyingBuffer!.bindMemory(to: MyStruct.self, capacity: 6)
+            let buffer = UnsafeMutableBufferPointer<MyStruct>(start: ptr, count: 6)
             
             let byteCount = data.copyBytes(to: buffer)
             expectEqual(6 * strideof(MyStruct.self), byteCount)

--- a/test/1_stdlib/TestData.swift
+++ b/test/1_stdlib/TestData.swift
@@ -35,7 +35,7 @@ class TestData : TestDataSuper {
     class AllOnesData : NSMutableData {
         
         private var _length : Int
-        var _pointer : UnsafeMutableBufferPointer<Void>? {
+        var _pointer : UnsafeMutableBufferPointer<UInt8>? {
             willSet {
                 if let p = _pointer { free(p.baseAddress) }
             }
@@ -78,7 +78,7 @@ class TestData : TestDataSuper {
             }
         }
         
-        override var bytes : UnsafePointer<Void> {
+        override var bytes : UnsafeRawPointer {
             if let d = _pointer {
                 return UnsafePointer(d.baseAddress!)
             } else {
@@ -92,7 +92,7 @@ class TestData : TestDataSuper {
             }
         }
         
-        override var mutableBytes: UnsafeMutablePointer<Void> {
+        override var mutableBytes: UnsafeMutableRawPointer {
             let newBufferLength = _length
             let newBuffer = malloc(newBufferLength)
             if let ptr = _pointer {
@@ -109,7 +109,7 @@ class TestData : TestDataSuper {
             return result.baseAddress!
         }
         
-        override func getBytes(_ buffer: UnsafeMutablePointer<Void>, length: Int) {
+        override func getBytes(_ buffer: UnsafeMutableRawPointer, length: Int) {
             if let d = _pointer {
                 // Get the real data from the buffer
                 memmove(buffer, d.baseAddress, length)
@@ -442,7 +442,7 @@ class TestData : TestDataSuper {
             let buffer = malloc(16)!
             var data = Data(bytesNoCopy: UnsafeMutablePointer<UInt8>(buffer), count: 16, deallocator: .custom({ (ptr, size) in
                 deallocatorCalled = true
-                free(UnsafeMutablePointer<Void>(ptr))
+                free(UnsafeMutableRawPointer(ptr))
             }))
             // Use the data
             data[0] = 1

--- a/test/1_stdlib/Unmanaged.swift
+++ b/test/1_stdlib/Unmanaged.swift
@@ -59,7 +59,7 @@ UnmanagedTests.test("Opaque") {
   let opaquePtr = Unmanaged.passUnretained(ref).toOpaque()
   
   let unknownPtr = Int(bitPattern: opaquePtr)
-  let voidPtr = UnsafePointer<Void>(bitPattern: unknownPtr)
+  let voidPtr = UnsafeRawPointer(bitPattern: unknownPtr)
   expectNotEmpty(voidPtr, "toOpaque must not return null pointer")
   
   let unmanaged = Unmanaged<Foobar>.fromOpaque(voidPtr!)

--- a/test/ClangModules/cfuncs_parse.swift
+++ b/test/ClangModules/cfuncs_parse.swift
@@ -85,7 +85,7 @@ func test_pointer() {
   param_const_pointer(ia)
   param_const_pointer([1, 2, 3])
 
-  param_void_pointer(nil as UnsafeMutablePointer<Void>?)
+  param_void_pointer(nil as UnsafeMutableRawPointer?)
   param_void_pointer(nil as UnsafeMutablePointer<CInt>?)
   param_void_pointer(nil as UnsafeMutablePointer<CFloat>?)
   param_void_pointer(&i)
@@ -93,10 +93,10 @@ func test_pointer() {
   param_void_pointer(&f)
   param_void_pointer(&fa)
 
-  param_const_void_pointer(nil as UnsafeMutablePointer<Void>?)
+  param_const_void_pointer(nil as UnsafeMutableRawPointer?)
   param_const_void_pointer(nil as UnsafeMutablePointer<CInt>?)
   param_const_void_pointer(nil as UnsafeMutablePointer<CFloat>?)
-  param_const_void_pointer(nil as UnsafePointer<Void>?)
+  param_const_void_pointer(nil as UnsafeRawPointer?)
   param_const_void_pointer(nil as UnsafePointer<CInt>?)
   param_const_void_pointer(nil as UnsafePointer<CFloat>?)
   param_const_void_pointer(&i)

--- a/test/ClangModules/ctypes_parse.swift
+++ b/test/ClangModules/ctypes_parse.swift
@@ -200,11 +200,11 @@ func testFunctionPointers() {
   useFunctionPointer(wrapper.a)
   _ = wrapper.b as (@convention(c) (CInt) -> CInt)
 
-  var anotherFP: @convention(c) (CInt, CLong, UnsafeMutablePointer<Void>?) -> Void
+  var anotherFP: @convention(c) (CInt, CLong, UnsafeMutableRawPointer?) -> Void
     = getFunctionPointer2()
 
   useFunctionPointer2(anotherFP)
-  anotherFP = fp // expected-error {{cannot assign value of type 'fptr?' to type '@convention(c) (CInt, CLong, UnsafeMutablePointer<Void>?) -> Void'}}
+  anotherFP = fp // expected-error {{cannot assign value of type 'fptr?' to type '@convention(c) (CInt, CLong, UnsafeMutableRawPointer?) -> Void'}}
 }
 
 func testStructDefaultInit() {

--- a/test/ClangModules/cvars_parse.swift
+++ b/test/ClangModules/cvars_parse.swift
@@ -8,7 +8,7 @@ func getPI() -> Float {
 
 func testPointers() {
   let cp = globalConstPointer
-  cp.abcde() // expected-error {{value of type 'UnsafePointer<Void>?' has no member 'abcde'}}
+  cp.abcde() // expected-error {{value of type 'UnsafeRawPointer?' has no member 'abcde'}}
   let mp = globalPointer
-  mp.abcde() // expected-error {{value of type 'UnsafeMutablePointer<Void>?' has no member 'abcde'}}
+  mp.abcde() // expected-error {{value of type 'UnsafeMutableRawPointer?' has no member 'abcde'}}
 }

--- a/test/ClangModules/objc_bridging.swift
+++ b/test/ClangModules/objc_bridging.swift
@@ -43,7 +43,7 @@ func foo() {
   DummyClass().setProperty.onlyOnSet()
 }
 
-func allocateMagic(_ zone: NSZone) -> UnsafeMutablePointer<Void> {
+func allocateMagic(_ zone: NSZone) -> UnsafeMutableRawPointer {
   return allocate(zone)
 }
 

--- a/test/ClangModules/objc_ir.swift
+++ b/test/ClangModules/objc_ir.swift
@@ -158,8 +158,8 @@ func pointerProperties(_ obj: PointerWrapper) {
   // CHECK: load i8*, i8** @"\01L_selector(setVoidPtr:)"
   // CHECK: load i8*, i8** @"\01L_selector(setIntPtr:)"
   // CHECK: load i8*, i8** @"\01L_selector(setIdPtr:)"
-  obj.voidPtr = nil as UnsafeMutablePointer?
-  obj.intPtr = nil as UnsafeMutablePointer?
+  obj.voidPtr = nil as UnsafeMutableRawPointer?
+  obj.intPtr = nil as UnsafeMutableRawPointer?
   obj.idPtr = nil as AutoreleasingUnsafeMutablePointer?
 }
 

--- a/test/ClangModules/objc_ir.swift
+++ b/test/ClangModules/objc_ir.swift
@@ -159,7 +159,7 @@ func pointerProperties(_ obj: PointerWrapper) {
   // CHECK: load i8*, i8** @"\01L_selector(setIntPtr:)"
   // CHECK: load i8*, i8** @"\01L_selector(setIdPtr:)"
   obj.voidPtr = nil as UnsafeMutableRawPointer?
-  obj.intPtr = nil as UnsafeMutableRawPointer?
+  obj.intPtr = nil as UnsafeMutablePointer?
   obj.idPtr = nil as AutoreleasingUnsafeMutablePointer?
 }
 

--- a/test/ClangModules/serialization-sil.swift
+++ b/test/ClangModules/serialization-sil.swift
@@ -20,10 +20,10 @@ public func testPartialApply(_ obj: Test) {
   if let curried2 = obj.innerPointer {
     // CHECK: dynamic_method_br [[CURRIED2_OBJ:%.+]] : $@opened([[CURRIED2_EXISTENTIAL:.+]]) Test, #Test.innerPointer!1.foreign, [[CURRIED2_TRUE:[^,]+]], [[CURRIED2_FALSE:[^,]+]]
     // CHECK: [[CURRIED2_FALSE]]:
-    // CHECK: [[CURRIED2_TRUE]]([[CURRIED2_METHOD:%.+]] : $@convention(objc_method) (@opened([[CURRIED2_EXISTENTIAL]]) Test) -> @unowned_inner_pointer UnsafeMutablePointer<()>):
-    // CHECK: [[CURRIED2_PARTIAL:%.+]] = partial_apply [[CURRIED2_METHOD]]([[CURRIED2_OBJ]]) : $@convention(objc_method) (@opened([[CURRIED2_EXISTENTIAL]]) Test) -> @unowned_inner_pointer UnsafeMutablePointer<()>
-    // CHECK: [[CURRIED2_THUNK:%.+]] = function_ref @_TTRXFo__dGSpT___XFo_iT__iGSpT___ : $@convention(thin) (@in (), @owned @callee_owned () -> UnsafeMutablePointer<()>) -> @out UnsafeMutablePointer<()>
-    // CHECK: = partial_apply [[CURRIED2_THUNK]]([[CURRIED2_PARTIAL]]) : $@convention(thin) (@in (), @owned @callee_owned () -> UnsafeMutablePointer<()>) -> @out UnsafeMutablePointer<()>
+    // CHECK: [[CURRIED2_TRUE]]([[CURRIED2_METHOD:%.+]] : $@convention(objc_method) (@opened([[CURRIED2_EXISTENTIAL]]) Test) -> @unowned_inner_pointer UnsafeMutableRawPointer):
+    // CHECK: [[CURRIED2_PARTIAL:%.+]] = partial_apply [[CURRIED2_METHOD]]([[CURRIED2_OBJ]]) : $@convention(objc_method) (@opened([[CURRIED2_EXISTENTIAL]]) Test) -> @unowned_inner_pointer UnsafeMutableRawPointer
+    // CHECK: [[CURRIED2_THUNK:%.+]] = function_ref @_TTRXFo__dGSpT___XFo_iT__iSv_ : $@convention(thin) (@in (), @owned @callee_owned () -> UnsafeMutableRawPointer) -> @out UnsafeMutableRawPointer
+    // CHECK: = partial_apply [[CURRIED2_THUNK]]([[CURRIED2_PARTIAL]]) : $@convention(thin) (@in (), @owned @callee_owned () -> UnsafeMutableRawPointer) -> @out UnsafeMutableRawPointer
     curried2()
   }
   if let prop1 = obj.normalObjectProp {
@@ -37,9 +37,9 @@ public func testPartialApply(_ obj: Test) {
   if let prop2 = obj.innerPointerProp {
     // CHECK: dynamic_method_br [[PROP2_OBJ:%.+]] : $@opened([[PROP2_EXISTENTIAL:.+]]) Test, #Test.innerPointerProp!getter.1.foreign, [[PROP2_TRUE:[^,]+]], [[PROP2_FALSE:[^,]+]]
     // CHECK: [[PROP2_FALSE]]:
-    // CHECK: [[PROP2_TRUE]]([[PROP2_METHOD:%.+]] : $@convention(objc_method) (@opened([[PROP2_EXISTENTIAL]]) Test) -> @unowned_inner_pointer UnsafeMutablePointer<()>):
-    // CHECK: [[PROP2_PARTIAL:%.+]] = partial_apply [[PROP2_METHOD]]([[PROP2_OBJ]]) : $@convention(objc_method) (@opened([[PROP2_EXISTENTIAL]]) Test) -> @unowned_inner_pointer UnsafeMutablePointer<()>
-    // CHECK: = apply [[PROP2_PARTIAL]]() : $@callee_owned () -> UnsafeMutablePointer<()>
+    // CHECK: [[PROP2_TRUE]]([[PROP2_METHOD:%.+]] : $@convention(objc_method) (@opened([[PROP2_EXISTENTIAL]]) Test) -> @unowned_inner_pointer UnsafeMutableRawPointer):
+    // CHECK: [[PROP2_PARTIAL:%.+]] = partial_apply [[PROP2_METHOD]]([[PROP2_OBJ]]) : $@convention(objc_method) (@opened([[PROP2_EXISTENTIAL]]) Test) -> @unowned_inner_pointer UnsafeMutableRawPointer
+    // CHECK: = apply [[PROP2_PARTIAL]]() : $@callee_owned () -> UnsafeMutableRawPointer
     _ = prop2
   }
 } // CHECK: {{^}$}}

--- a/test/ClangModules/serialization-sil.swift
+++ b/test/ClangModules/serialization-sil.swift
@@ -22,7 +22,7 @@ public func testPartialApply(_ obj: Test) {
     // CHECK: [[CURRIED2_FALSE]]:
     // CHECK: [[CURRIED2_TRUE]]([[CURRIED2_METHOD:%.+]] : $@convention(objc_method) (@opened([[CURRIED2_EXISTENTIAL]]) Test) -> @unowned_inner_pointer UnsafeMutableRawPointer):
     // CHECK: [[CURRIED2_PARTIAL:%.+]] = partial_apply [[CURRIED2_METHOD]]([[CURRIED2_OBJ]]) : $@convention(objc_method) (@opened([[CURRIED2_EXISTENTIAL]]) Test) -> @unowned_inner_pointer UnsafeMutableRawPointer
-    // CHECK: [[CURRIED2_THUNK:%.+]] = function_ref @_TTRXFo__dGSpT___XFo_iT__iSv_ : $@convention(thin) (@in (), @owned @callee_owned () -> UnsafeMutableRawPointer) -> @out UnsafeMutableRawPointer
+    // CHECK: [[CURRIED2_THUNK:%.+]] = function_ref @_TTRXFo__dSv_XFo_iT__iSv_ : $@convention(thin) (@in (), @owned @callee_owned () -> UnsafeMutableRawPointer) -> @out UnsafeMutableRawPointer
     // CHECK: = partial_apply [[CURRIED2_THUNK]]([[CURRIED2_PARTIAL]]) : $@convention(thin) (@in (), @owned @callee_owned () -> UnsafeMutableRawPointer) -> @out UnsafeMutableRawPointer
     curried2()
   }

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -704,7 +704,7 @@ _ = -UnaryOp() // expected-error {{unary operator '-' cannot be applied to an op
 // <rdar://problem/23433271> Swift compiler segfault in failure diagnosis
 func f23433271(_ x : UnsafePointer<Int>) {}
 func segfault23433271(_ a : UnsafeMutableRawPointer) {
-  f23433271(a[0])  // expected-error {{cannot convert value of type 'Void' (aka '()') to expected argument type 'UnsafePointer<Int>'}}
+  f23433271(a[0])  // expected-error {{type 'UnsafeMutableRawPointer' has no subscript members}}
 }
 
 // <rdar://problem/22058555> crash in cs diags in withCString
@@ -835,7 +835,7 @@ func read2(_ p: UnsafeMutableRawPointer, maxLength: Int) {}
 func read<T : Integer>() -> T? {
   var buffer : T 
   let n = withUnsafePointer(&buffer) { (p) in
-    read2(UnsafePointer(p), maxLength: sizeof(T)) // expected-error {{cannot convert value of type 'UnsafePointer<_>' to expected argument type 'UnsafeMutableRawPointer' (aka 'UnsafeMutablePointer<()>')}}
+    read2(UnsafePointer(p), maxLength: sizeof(T)) // expected-error {{cannot convert value of type 'UnsafePointer<_>' to expected argument type 'UnsafeMutableRawPointer')}}
   }
 }
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -835,7 +835,7 @@ func read2(_ p: UnsafeMutableRawPointer, maxLength: Int) {}
 func read<T : Integer>() -> T? {
   var buffer : T 
   let n = withUnsafePointer(&buffer) { (p) in
-    read2(UnsafePointer(p), maxLength: sizeof(T)) // expected-error {{cannot convert value of type 'UnsafePointer<_>' to expected argument type 'UnsafeMutableRawPointer')}}
+    read2(UnsafePointer(p), maxLength: sizeof(T)) // expected-error {{cannot convert value of type 'UnsafePointer<_>' to expected argument type 'UnsafeMutableRawPointer'}}
   }
 }
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -703,7 +703,7 @@ _ = -UnaryOp() // expected-error {{unary operator '-' cannot be applied to an op
 
 // <rdar://problem/23433271> Swift compiler segfault in failure diagnosis
 func f23433271(_ x : UnsafePointer<Int>) {}
-func segfault23433271(_ a : UnsafeMutablePointer<Void>) {
+func segfault23433271(_ a : UnsafeMutableRawPointer) {
   f23433271(a[0])  // expected-error {{cannot convert value of type 'Void' (aka '()') to expected argument type 'UnsafePointer<Int>'}}
 }
 
@@ -831,11 +831,11 @@ extension Foo23752537 {
 
 
 // <rdar://problem/22276040> QoI: not great error message with "withUnsafePointer" sametype constraints
-func read2(_ p: UnsafeMutablePointer<Void>, maxLength: Int) {}
+func read2(_ p: UnsafeMutableRawPointer, maxLength: Int) {}
 func read<T : Integer>() -> T? {
   var buffer : T 
   let n = withUnsafePointer(&buffer) { (p) in
-    read2(UnsafePointer(p), maxLength: sizeof(T)) // expected-error {{cannot convert value of type 'UnsafePointer<_>' to expected argument type 'UnsafeMutablePointer<Void>' (aka 'UnsafeMutablePointer<()>')}}
+    read2(UnsafePointer(p), maxLength: sizeof(T)) // expected-error {{cannot convert value of type 'UnsafePointer<_>' to expected argument type 'UnsafeMutableRawPointer' (aka 'UnsafeMutablePointer<()>')}}
   }
 }
 

--- a/test/Constraints/lvalues.swift
+++ b/test/Constraints/lvalues.swift
@@ -172,7 +172,7 @@ takeArrayRef(["asdf", "1234"]) // expected-error{{contextual type 'inout Array<S
 
 // <rdar://problem/19835413> Reference to value from array changed
 func rdar19835413() {
-  func f1(_ p: UnsafeMutablePointer<Void>) {}
+  func f1(_ p: UnsafeMutableRawPointer) {}
   func f2(_ a: [Int], i: Int, pi: UnsafeMutablePointer<Int>) {
     var a = a
     f1(&a)

--- a/test/Generics/slice_test.swift
+++ b/test/Generics/slice_test.swift
@@ -42,8 +42,8 @@ class Vector<T> {
     if length == capacity {
       let newcapacity = capacity * 2 + 2
       let size = Int(Builtin.sizeof(T.self))
-      let newbase = UnsafeMutablePointer<T>(c_malloc(newcapacity * size)!
-        .bindMemory(to: T.self, capacity: newCapacity))
+      let newbase = UnsafeMutablePointer<T>(c_malloc(newcapacity * size)
+        .bindMemory(to: T.self, capacity: newcapacity))
       for i in 0..<length {
         (newbase + i).initialize(to: (base+i).move())
       }

--- a/test/Generics/slice_test.swift
+++ b/test/Generics/slice_test.swift
@@ -42,7 +42,8 @@ class Vector<T> {
     if length == capacity {
       let newcapacity = capacity * 2 + 2
       let size = Int(Builtin.sizeof(T.self))
-      let newbase = UnsafeMutablePointer<T>(c_malloc(newcapacity * size))
+      let newbase = UnsafeMutablePointer<T>(c_malloc(newcapacity * size)!
+        .bindMemory(to: T.self, capacity: newCapacity))
       for i in 0..<length {
         (newbase + i).initialize(to: (base+i).move())
       }

--- a/test/Generics/slice_test.swift
+++ b/test/Generics/slice_test.swift
@@ -24,8 +24,8 @@ func testslice(_ s: Array<Int>) {
   _ = s[0...1]
 }
 
-@_silgen_name("malloc") func c_malloc(_ size: Int) -> UnsafeMutablePointer<Void>
-@_silgen_name("free") func c_free(_ p: UnsafeMutablePointer<Void>)
+@_silgen_name("malloc") func c_malloc(_ size: Int) -> UnsafeMutableRawPointer
+@_silgen_name("free") func c_free(_ p: UnsafeMutableRawPointer)
 
 class Vector<T> {
   var length : Int

--- a/test/IRGen/objc_pointers.swift
+++ b/test/IRGen/objc_pointers.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @objc class Foo : NSObject {
-  // CHECK: define internal void @_TToFC13objc_pointers3Foo16pointerArgumentsfTGSpSi_1yGSpT__1zGSPSi_1wGVs33AutoreleasingUnsafeMutablePointerGSqS0____T_(%0*, i8*, i64*, i8*, i64*, %0**)
+  // CHECK: define internal void @_TToFC13objc_pointers3Foo16pointerArgumentsfTGSpSi_1ySv1zGSPSi_1wGVs33AutoreleasingUnsafeMutablePointerGSqS0____T_(%0*, i8*, i64*, i8*, i64*, %0**)
   @objc func pointerArguments(_ x: UnsafeMutablePointer<Int>,
                               y: UnsafeMutableRawPointer,
                               z: UnsafePointer<Int>,

--- a/test/IRGen/objc_pointers.swift
+++ b/test/IRGen/objc_pointers.swift
@@ -10,7 +10,7 @@ import Foundation
 @objc class Foo : NSObject {
   // CHECK: define internal void @_TToFC13objc_pointers3Foo16pointerArgumentsfTGSpSi_1yGSpT__1zGSPSi_1wGVs33AutoreleasingUnsafeMutablePointerGSqS0____T_(%0*, i8*, i64*, i8*, i64*, %0**)
   @objc func pointerArguments(_ x: UnsafeMutablePointer<Int>,
-                              y: UnsafeMutablePointer<Void>,
+                              y: UnsafeMutableRawPointer,
                               z: UnsafePointer<Int>,
                               w: AutoreleasingUnsafeMutablePointer<Foo?>) {}
 }

--- a/test/Interpreter/SDK/KVO.swift
+++ b/test/Interpreter/SDK/KVO.swift
@@ -31,7 +31,7 @@ class Observer : NSObject {
     model.number = 42
   }
 
-  override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutablePointer<Void>?) {
+  override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
     if context != &kvoContext {
       // FIXME: we shouldn't need to unwrap these here, but it doesn't work on
       // older SDKs where these are non-optional types.

--- a/test/Interpreter/SDK/Reflection_KVO.swift
+++ b/test/Interpreter/SDK/Reflection_KVO.swift
@@ -25,7 +25,7 @@ class ValueObserver: NSObject {
 		observedValue.removeObserver(self, forKeyPath: "amount")
 	}
 	
-	override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutablePointer<Void>?) {
+	override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
 		if context == &observeContext {
       if let change_ = change {
         if let amount = change_[.newKey] as? Int {

--- a/test/Interpreter/SDK/autolinking.swift
+++ b/test/Interpreter/SDK/autolinking.swift
@@ -34,7 +34,7 @@ if global() != 42 {
 
 #else
 
-let RTLD_DEFAULT = UnsafeMutablePointer<Void>(bitPattern: -2)
+let RTLD_DEFAULT = UnsafeMutableRawPointer(bitPattern: -2)
 if dlsym(RTLD_DEFAULT, "global") == nil {
   print(String(cString: dlerror()))
   exit(EXIT_FAILURE)

--- a/test/Interpreter/SDK/c_pointers.swift
+++ b/test/Interpreter/SDK/c_pointers.swift
@@ -128,7 +128,7 @@ puts(s)
 
 var unsorted = [3, 14, 15, 9, 2, 6, 5]
 qsort(&unsorted, unsorted.count, sizeofValue(unsorted[0])) { a, b in
-  return Int32(a!.load(as: Int.self) - b!.load(as: Int.self))
+  return Int32(a.load(as: Int.self) - b.load(as: Int.self))
 }
 // CHECK-NEXT: [2, 3, 5, 6, 9, 14, 15]
 print(unsorted)

--- a/test/Interpreter/SDK/c_pointers.swift
+++ b/test/Interpreter/SDK/c_pointers.swift
@@ -128,7 +128,7 @@ puts(s)
 
 var unsorted = [3, 14, 15, 9, 2, 6, 5]
 qsort(&unsorted, unsorted.count, sizeofValue(unsorted[0])) { a, b in
-  return Int32(a.load(as: Int.self) - b.load(as: Int.self))
+  return Int32(a!.load(as: Int.self) - b!.load(as: Int.self))
 }
 // CHECK-NEXT: [2, 3, 5, 6, 9, 14, 15]
 print(unsorted)

--- a/test/Interpreter/SDK/c_pointers.swift
+++ b/test/Interpreter/SDK/c_pointers.swift
@@ -128,7 +128,7 @@ puts(s)
 
 var unsorted = [3, 14, 15, 9, 2, 6, 5]
 qsort(&unsorted, unsorted.count, sizeofValue(unsorted[0])) { a, b in
-  return Int32(UnsafePointer<Int>(a!).pointee - UnsafePointer<Int>(b!).pointee)
+  return Int32(a!.load(as: Int.self) - b!.load(as: Int.self))
 }
 // CHECK-NEXT: [2, 3, 5, 6, 9, 14, 15]
 print(unsorted)

--- a/test/Interpreter/SDK/objc_inner_pointer.swift
+++ b/test/Interpreter/SDK/objc_inner_pointer.swift
@@ -28,7 +28,7 @@ autoreleasepool {
   repeat {
     let data = NSData(bytes: [2, 3, 5, 7] as [UInt8], length: 4)
     hangCanary(data)
-    bytes = UnsafeMutablePointer<UInt8>(data.bytes)
+    bytes = UnsafeMutablePointer<UInt8>(data.bytes.assumingMemoryBound(to: UInt8.self))
   } while false // CHECK-NOT: died
   print(bytes[0]) // CHECK:      2
   print(bytes[1]) // CHECK-NEXT: 3
@@ -44,7 +44,7 @@ autoreleasepool {
     let data = NSData(bytes: [11, 13, 17, 19] as [UInt8], length: 4)
     hangCanary(data)
     let dataAsAny: AnyObject = data
-    bytes = UnsafeMutablePointer<UInt8>(dataAsAny.bytes!)
+    bytes = UnsafeMutablePointer<UInt8>(dataAsAny.bytes!.assumingMemoryBound(to: UInt8.self))
   } while false // CHECK-NOT: died
   print(bytes[0]) // CHECK:      11
   print(bytes[1]) // CHECK-NEXT: 13

--- a/test/Interpreter/errors_imported.swift
+++ b/test/Interpreter/errors_imported.swift
@@ -34,7 +34,7 @@ ErrorHandlingTests.test("pointerFailure") {
 ErrorHandlingTests.test("pointerSuccess") {
   do {
     var pointer = try TestingNSError.maybeThrow(false)
-    expectType(UnsafeMutablePointer<Void>.self, &pointer)
+    expectType(UnsafeMutableRawPointer.self, &pointer)
     expectEqual(UnsafeMutablePointer(bitPattern: 42)!, pointer)
   } catch {
     expectUnreachableCatch(error)

--- a/test/Parse/pointer_conversion.swift.gyb
+++ b/test/Parse/pointer_conversion.swift.gyb
@@ -22,7 +22,7 @@ class C {}
 class D {}
 
 func takesMutablePointer(_ x: UnsafeMutablePointer<Int>${suffix}) {}
-func takesMutableVoidPointer(_ x: UnsafeMutablePointer<Void>${suffix}) {}
+func takesMutableVoidPointer(_ x: UnsafeMutableRawPointer${suffix}) {}
 func takesMutableRawPointer(_ x: UnsafeMutableRawPointer${suffix}) {}
 func takesMutableInt8Pointer(_ x: UnsafeMutablePointer<Int8>${suffix}) {}
 func takesMutableArrayPointer(_ x: UnsafeMutablePointer<[Int]>${suffix}) {}
@@ -30,7 +30,7 @@ func takesMutableArrayPointer(_ x: UnsafeMutablePointer<[Int]>${suffix}) {}
 func takesConstPointer(_ x: UnsafePointer<Int>${suffix}) -> Character { return "x" }
 func takesConstInt8Pointer(_ x: UnsafePointer<Int8>${suffix}) {}
 func takesConstUInt8Pointer(_ x: UnsafePointer<UInt8>${suffix}) {}
-func takesConstVoidPointer(_ x: UnsafePointer<Void>${suffix}) {}
+func takesConstVoidPointer(_ x: UnsafeRawPointer${suffix}) {}
 func takesConstRawPointer(_ x: UnsafeRawPointer${suffix}) {}
 
 func mutablePointerArguments(_ p: UnsafeMutablePointer<Int>,
@@ -74,26 +74,26 @@ func mutableVoidPointerArguments(_ p: UnsafeMutablePointer<Int>,
 
   takesMutableVoidPointer(p)
   takesMutableVoidPointer(fp)
-  takesMutableVoidPointer(cp) // expected-error{{cannot convert value of type 'UnsafePointer<Int>' to expected argument type 'UnsafeMutablePointer<Void>${suffix}'}}
+  takesMutableVoidPointer(cp) // expected-error{{cannot convert value of type 'UnsafePointer<Int>' to expected argument type 'UnsafeMutableRawPointer${suffix}'}}
   var i: Int = 0
   var f: Float = 0
   takesMutableVoidPointer(&i)
   takesMutableVoidPointer(&f)
-  takesMutableVoidPointer(i) // expected-error{{cannot convert value of type 'Int' to expected argument type 'UnsafeMutablePointer<Void>${suffix}'}}
-  takesMutableVoidPointer(f) // expected-error{{cannot convert value of type 'Float' to expected argument type 'UnsafeMutablePointer<Void>${suffix}'}}
+  takesMutableVoidPointer(i) // expected-error{{cannot convert value of type 'Int' to expected argument type 'UnsafeMutableRawPointer${suffix}'}}
+  takesMutableVoidPointer(f) // expected-error{{cannot convert value of type 'Float' to expected argument type 'UnsafeMutableRawPointer${suffix}'}}
   var ii: [Int] = [0, 1, 2]
   var dd: [CInt] = [1, 2, 3]
   var ff: [Int] = [0, 1, 2]
   takesMutableVoidPointer(&ii)
   takesMutableVoidPointer(&dd)
   takesMutableVoidPointer(&ff)
-  takesMutableVoidPointer(ii) // expected-error{{cannot convert value of type '[Int]' to expected argument type 'UnsafeMutablePointer<Void>${suffix}'}}
-  takesMutableVoidPointer(ff) // expected-error{{cannot convert value of type '[Int]' to expected argument type 'UnsafeMutablePointer<Void>${suffix}'}}
+  takesMutableVoidPointer(ii) // expected-error{{cannot convert value of type '[Int]' to expected argument type 'UnsafeMutableRawPointer${suffix}'}}
+  takesMutableVoidPointer(ff) // expected-error{{cannot convert value of type '[Int]' to expected argument type 'UnsafeMutableRawPointer${suffix}'}}
 
   // We don't allow these conversions outside of function arguments.
-  var x: UnsafeMutablePointer<Void> = &i // expected-error{{cannot convert value of type 'inout Int' to specified type 'UnsafeMutablePointer<Void>'}}
-  x = p // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Int>' to type 'UnsafeMutablePointer<Void>'}}
-  x = &ii // expected-error{{cannot assign value of type 'inout [Int]' (aka 'inout Array<Int>') to type 'UnsafeMutablePointer<Void>'}}
+  var x: UnsafeMutableRawPointer = &i // expected-error{{cannot convert value of type 'inout Int' to specified type 'UnsafeMutableRawPointer'}}
+  x = p // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Int>' to type 'UnsafeMutableRawPointer'}}
+  x = &ii // expected-error{{cannot assign value of type 'inout [Int]' (aka 'inout Array<Int>') to type 'UnsafeMutableRawPointer'}}
   _ = x
 }
 
@@ -192,12 +192,12 @@ func constVoidPointerArguments(_ p: UnsafeMutablePointer<Int>,
   takesConstVoidPointer([0.0, 1.0, 2.0])  // expected-error {{cannot convert value of type 'Double' to expected element type '()'}}
 
   // We don't allow these conversions outside of function arguments.
-  var x: UnsafePointer<Void> = &i // expected-error{{cannot convert value of type 'inout Int' to specified type 'UnsafePointer<Void>' (aka 'UnsafePointer<()>')}}
-  x = ii // expected-error{{cannot assign value of type '[Int]' to type 'UnsafePointer<Void>' (aka 'UnsafePointer<()>')}}
-  x = p // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Int>' to type 'UnsafePointer<Void>' (aka 'UnsafePointer<()>')}}
-  x = fp // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Float>' to type 'UnsafePointer<Void>' (aka 'UnsafePointer<()>')}}
-  x = cp // expected-error{{cannot assign value of type 'UnsafePointer<Int>' to type 'UnsafePointer<Void>' (aka 'UnsafePointer<()>')}}
-  x = cfp // expected-error{{cannot assign value of type 'UnsafePointer<Float>' to type 'UnsafePointer<Void>' (aka 'UnsafePointer<()>')}}
+  var x: UnsafeRawPointer = &i // expected-error{{cannot convert value of type 'inout Int' to specified type 'UnsafeRawPointer' (aka 'UnsafePointer<()>')}}
+  x = ii // expected-error{{cannot assign value of type '[Int]' to type 'UnsafeRawPointer' (aka 'UnsafePointer<()>')}}
+  x = p // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Int>' to type 'UnsafeRawPointer' (aka 'UnsafePointer<()>')}}
+  x = fp // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Float>' to type 'UnsafeRawPointer' (aka 'UnsafePointer<()>')}}
+  x = cp // expected-error{{cannot assign value of type 'UnsafePointer<Int>' to type 'UnsafeRawPointer' (aka 'UnsafePointer<()>')}}
+  x = cfp // expected-error{{cannot assign value of type 'UnsafePointer<Float>' to type 'UnsafeRawPointer' (aka 'UnsafePointer<()>')}}
   _ = x
 }
 
@@ -250,7 +250,7 @@ func stringArguments(_ s: String) {
   takesConstUInt8Pointer(s)
   takesConstPointer(s) // expected-error{{cannot convert value of type 'String' to expected argument type 'UnsafePointer<Int>${suffix}'}}
 
-  takesMutableVoidPointer(s) // expected-error{{cannot convert value of type 'String' to expected argument type 'UnsafeMutablePointer<Void>${suffix}'}}
+  takesMutableVoidPointer(s) // expected-error{{cannot convert value of type 'String' to expected argument type 'UnsafeMutableRawPointer${suffix}'}}
   takesMutableRawPointer(s) // expected-error{{cannot convert value of type 'String' to expected argument type 'UnsafeMutableRawPointer${suffix}'}}
   takesMutableInt8Pointer(s) // expected-error{{cannot convert value of type 'String' to expected argument type 'UnsafeMutablePointer<Int8>${suffix}'}}
   takesMutableInt8Pointer(&s) // expected-error{{cannot convert value of type 'String' to expected argument type 'Int8'}}
@@ -315,8 +315,8 @@ func f19478919() {
   GLKProject(&viewport)  // expected-error {{cannot convert value of type 'Int' to expected argument type 'Int32'}}
 
   func GLKProjectUP(_ a : UnsafePointer<Int32>) {}
-  func UP_Void(_ a : UnsafePointer<Void>) {}
-  func UMP_Void(_ a : UnsafeMutablePointer<Void>) {}
+  func UP_Void(_ a : UnsafeRawPointer) {}
+  func UMP_Void(_ a : UnsafeMutableRawPointer) {}
   UP_Void(&viewport)
   UMP_Void(&viewport)
 

--- a/test/Parse/pointer_conversion.swift.gyb
+++ b/test/Parse/pointer_conversion.swift.gyb
@@ -192,7 +192,7 @@ func constVoidPointerArguments(_ p: UnsafeMutablePointer<Int>,
   takesConstVoidPointer([0.0, 1.0, 2.0])  // expected-error {{contextual type 'UnsafeRawPointer' cannot be used with array literal}}
 
   // We don't allow these conversions outside of function arguments.
-  var x: UnsafeRawPointer = &i // expected-error{{cannot convert value of type 'inout Int' to specified type 'UnsafeRawPointer')}}
+  var x: UnsafeRawPointer = &i // expected-error{{cannot convert value of type 'inout Int' to specified type 'UnsafeRawPointer'}}
   x = ii // expected-error{{cannot assign value of type '[Int]' to type 'UnsafeRawPointer'}}
   x = p // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Int>' to type 'UnsafeRawPointer'}}
   x = fp // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Float>' to type 'UnsafeRawPointer'}}

--- a/test/Parse/pointer_conversion.swift.gyb
+++ b/test/Parse/pointer_conversion.swift.gyb
@@ -188,16 +188,16 @@ func constVoidPointerArguments(_ p: UnsafeMutablePointer<Int>,
   takesConstVoidPointer(ff)
 
   // TODO: These two should be accepted, tracked by rdar://17444930.
-  takesConstVoidPointer([0, 1, 2]) // expected-error {{cannot convert value of type 'Int' to expected element type '()'}}
-  takesConstVoidPointer([0.0, 1.0, 2.0])  // expected-error {{cannot convert value of type 'Double' to expected element type '()'}}
+  takesConstVoidPointer([0, 1, 2]) // expected-error {{contextual type 'UnsafeRawPointer' cannot be used with array literal}}
+  takesConstVoidPointer([0.0, 1.0, 2.0])  // expected-error {{contextual type 'UnsafeRawPointer' cannot be used with array literal}}
 
   // We don't allow these conversions outside of function arguments.
-  var x: UnsafeRawPointer = &i // expected-error{{cannot convert value of type 'inout Int' to specified type 'UnsafeRawPointer' (aka 'UnsafePointer<()>')}}
-  x = ii // expected-error{{cannot assign value of type '[Int]' to type 'UnsafeRawPointer' (aka 'UnsafePointer<()>')}}
-  x = p // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Int>' to type 'UnsafeRawPointer' (aka 'UnsafePointer<()>')}}
-  x = fp // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Float>' to type 'UnsafeRawPointer' (aka 'UnsafePointer<()>')}}
-  x = cp // expected-error{{cannot assign value of type 'UnsafePointer<Int>' to type 'UnsafeRawPointer' (aka 'UnsafePointer<()>')}}
-  x = cfp // expected-error{{cannot assign value of type 'UnsafePointer<Float>' to type 'UnsafeRawPointer' (aka 'UnsafePointer<()>')}}
+  var x: UnsafeRawPointer = &i // expected-error{{cannot convert value of type 'inout Int' to specified type 'UnsafeRawPointer')}}
+  x = ii // expected-error{{cannot assign value of type '[Int]' to type 'UnsafeRawPointer'}}
+  x = p // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Int>' to type 'UnsafeRawPointer'}}
+  x = fp // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Float>' to type 'UnsafeRawPointer'}}
+  x = cp // expected-error{{cannot assign value of type 'UnsafePointer<Int>' to type 'UnsafeRawPointer'}}
+  x = cfp // expected-error{{cannot assign value of type 'UnsafePointer<Float>' to type 'UnsafeRawPointer'}}
   _ = x
 }
 

--- a/test/Parse/pointer_conversion_objc.swift.gyb
+++ b/test/Parse/pointer_conversion_objc.swift.gyb
@@ -40,7 +40,7 @@ func pointerArgumentsObjC(ap: AutoreleasingUnsafeMutablePointer<Int>,
   takesConstVoidPointer(afp)
 
   var x: UnsafeRawPointer
-  x = ap // expected-error{{cannot assign value of type 'AutoreleasingUnsafeMutablePointer<Int>' to type 'UnsafeRawPointer' (aka 'UnsafePointer<()>')}}
+  x = ap // expected-error{{cannot assign value of type 'AutoreleasingUnsafeMutablePointer<Int>' to type 'UnsafeRawPointer'}}
   _ = x
 }
 

--- a/test/Parse/pointer_conversion_objc.swift.gyb
+++ b/test/Parse/pointer_conversion_objc.swift.gyb
@@ -24,23 +24,23 @@ class C {}
 class D {}
 
 func takesMutablePointer(_ x: UnsafeMutablePointer<Int>${suffix}) {}
-func takesMutableVoidPointer(_ x: UnsafeMutablePointer<Void>${suffix}) {}
+func takesMutableVoidPointer(_ x: UnsafeMutableRawPointer${suffix}) {}
 @discardableResult
 func takesConstPointer(_ x: UnsafePointer<Int>${suffix}) -> Character { return "x" }
-func takesConstVoidPointer(_ x: UnsafePointer<Void>${suffix}) {}
+func takesConstVoidPointer(_ x: UnsafeRawPointer${suffix}) {}
 
 func takesAutoreleasingPointer(_ x: AutoreleasingUnsafeMutablePointer<C>${suffix}) {}
 
 func pointerArgumentsObjC(ap: AutoreleasingUnsafeMutablePointer<Int>,
                           afp: AutoreleasingUnsafeMutablePointer<Float>) {
   takesMutablePointer(ap) // expected-error{{cannot convert value of type 'AutoreleasingUnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutablePointer<Int>${suffix}'}}
-  takesMutableVoidPointer(ap) // expected-error{{cannot convert value of type 'AutoreleasingUnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutablePointer<Void>${suffix}'}}
+  takesMutableVoidPointer(ap) // expected-error{{cannot convert value of type 'AutoreleasingUnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutableRawPointer${suffix}'}}
   takesConstPointer(ap)
   takesConstVoidPointer(ap)
   takesConstVoidPointer(afp)
 
-  var x: UnsafePointer<Void>
-  x = ap // expected-error{{cannot assign value of type 'AutoreleasingUnsafeMutablePointer<Int>' to type 'UnsafePointer<Void>' (aka 'UnsafePointer<()>')}}
+  var x: UnsafeRawPointer
+  x = ap // expected-error{{cannot assign value of type 'AutoreleasingUnsafeMutablePointer<Int>' to type 'UnsafeRawPointer' (aka 'UnsafePointer<()>')}}
   _ = x
 }
 

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -278,7 +278,7 @@ typealias AliasForNSRect = NSRect
   func testNested(_ a: UnsafeMutablePointer<UnsafeMutablePointer<Int>>) {}
 
   func testBridging(_ a: UnsafePointer<Int>, b: UnsafeMutablePointer<Int>, c: AutoreleasingUnsafeMutablePointer<Methods>) {}
-  func testBridgingVoid(_ a: UnsafeMutablePointer<Void>, b: UnsafePointer<Void>) {}
+  func testBridgingVoid(_ a: UnsafeMutableRawPointer, b: UnsafeRawPointer) {}
 
   func testBridgingOptionality(_ a: UnsafePointer<Int>?, b: UnsafeMutablePointer<Int>!, c: AutoreleasingUnsafeMutablePointer<Methods?>?) {}
 }

--- a/test/SILGen/default_arguments.swift
+++ b/test/SILGen/default_arguments.swift
@@ -193,7 +193,7 @@ func takeDSOHandle(_ handle: UnsafeMutableRawPointer = #dsohandle) { }
 
 // CHECK-LABEL: sil hidden @_TF17default_arguments13testDSOHandleFT_T_
 func testDSOHandle() {
-  // CHECK: [[DSO_HANDLE:%[0-9]+]] = global_addr @__dso_handle : $*UnsafeMutablePointer<()>
+  // CHECK: [[DSO_HANDLE:%[0-9]+]] = global_addr @__dso_handle : $*UnsafeMutableRawPointer
   takeDSOHandle()
 }
 

--- a/test/SILGen/default_arguments.swift
+++ b/test/SILGen/default_arguments.swift
@@ -189,7 +189,7 @@ func testTakeDefaultArgUnnamed(_ i: Int) {
   takeDefaultArgUnnamed(i)
 }
 
-func takeDSOHandle(_ handle: UnsafeMutablePointer<Void> = #dsohandle) { }
+func takeDSOHandle(_ handle: UnsafeMutableRawPointer = #dsohandle) { }
 
 // CHECK-LABEL: sil hidden @_TF17default_arguments13testDSOHandleFT_T_
 func testDSOHandle() {

--- a/test/SILGen/dso_handle.swift
+++ b/test/SILGen/dso_handle.swift
@@ -10,7 +10,7 @@
 // CHECK-LABEL: sil hidden @_TIF10dso_handle14printDSOHandleFT3dsoGSpT___GSpT__A_
 // CHECK: [[DSO:%[0-9]+]] = global_addr @__dso_handle : $*UnsafeMutablePointer<()>
 // CHECK: load [[DSO]]
-func printDSOHandle(dso: UnsafeMutablePointer<Void> = #dsohandle) -> UnsafeMutablePointer<Void> {
+func printDSOHandle(dso: UnsafeMutableRawPointer = #dsohandle) -> UnsafeMutableRawPointer {
   print(dso)
 }
 

--- a/test/SILGen/dso_handle.swift
+++ b/test/SILGen/dso_handle.swift
@@ -1,14 +1,14 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen %s | FileCheck %s
 
-// CHECK: sil_global hidden_external @__dso_handle : $UnsafeMutablePointer<()>
+// CHECK: sil_global hidden_external @__dso_handle : $UnsafeMutableRawPointer
 
 // CHECK-LABEL: sil @main : $@convention(c)
 // CHECK: bb0
-// CHECK: [[DSO:%[0-9]+]] = global_addr @__dso_handle : $*UnsafeMutablePointer<()>
+// CHECK: [[DSO:%[0-9]+]] = global_addr @__dso_handle : $*UnsafeMutableRawPointer
 // CHECK: load [[DSO]]
 
-// CHECK-LABEL: sil hidden @_TIF10dso_handle14printDSOHandleFT3dsoGSpT___GSpT__A_
-// CHECK: [[DSO:%[0-9]+]] = global_addr @__dso_handle : $*UnsafeMutablePointer<()>
+// CHECK-LABEL: sil hidden @_TIF10dso_handle14printDSOHandleFT3dsoSv_SvA_
+// CHECK: [[DSO:%[0-9]+]] = global_addr @__dso_handle : $*UnsafeMutableRawPointer
 // CHECK: load [[DSO]]
 func printDSOHandle(dso: UnsafeMutableRawPointer = #dsohandle) -> UnsafeMutableRawPointer {
   print(dso)

--- a/test/SILGen/lying_about_optional_return.swift
+++ b/test/SILGen/lying_about_optional_return.swift
@@ -15,7 +15,7 @@ func optionalChainingForeignFunctionTypeProperties(a: SomeCallbacks?) {
 
   // CHECK: enum $Optional<()>, #Optional.some!enumelt.1, {{%.*}} : $()
   a?.voidReturning()
-  // CHECK: unchecked_trivial_bit_cast {{%.*}} : $UnsafeMutablePointer<()> to $Optional<UnsafeMutablePointer<()>>
+  // CHECK: unchecked_trivial_bit_cast {{%.*}} : $UnsafeMutableRawPointer to $Optional<UnsafeMutableRawPointer>
   a?.voidPointerReturning()
   // CHECK: unchecked_trivial_bit_cast {{%.*}} : $UnsafeMutablePointer<Int8> to $Optional<UnsafeMutablePointer<Int8>>
   a?.pointerReturning()

--- a/test/SILGen/lying_about_optional_return.swift
+++ b/test/SILGen/lying_about_optional_return.swift
@@ -4,7 +4,7 @@
 func optionalChainingForeignFunctionTypeProperties(a: SomeCallbacks?) {
   // CHECK: enum $Optional<()>, #Optional.some!enumelt.1, {{%.*}} : $()
   let _: ()? = voidReturning()
-  // CHECK: unchecked_trivial_bit_cast {{%.*}} : $UnsafeMutablePointer<()> to $Optional<UnsafeMutablePointer<()>>
+  // CHECK: unchecked_trivial_bit_cast {{%.*}} : $UnsafeMutableRawPointer to $Optional<UnsafeMutableRawPointer>
   let _: UnsafeMutableRawPointer? = voidPointerReturning()
   // CHECK: unchecked_trivial_bit_cast {{%.*}} : $UnsafeMutablePointer<Int8> to $Optional<UnsafeMutablePointer<Int8>>
   let _: UnsafeMutablePointer<Int8>? = pointerReturning()

--- a/test/SILGen/lying_about_optional_return.swift
+++ b/test/SILGen/lying_about_optional_return.swift
@@ -5,7 +5,7 @@ func optionalChainingForeignFunctionTypeProperties(a: SomeCallbacks?) {
   // CHECK: enum $Optional<()>, #Optional.some!enumelt.1, {{%.*}} : $()
   let _: ()? = voidReturning()
   // CHECK: unchecked_trivial_bit_cast {{%.*}} : $UnsafeMutablePointer<()> to $Optional<UnsafeMutablePointer<()>>
-  let _: UnsafeMutablePointer<Void>? = voidPointerReturning()
+  let _: UnsafeMutableRawPointer? = voidPointerReturning()
   // CHECK: unchecked_trivial_bit_cast {{%.*}} : $UnsafeMutablePointer<Int8> to $Optional<UnsafeMutablePointer<Int8>>
   let _: UnsafeMutablePointer<Int8>? = pointerReturning()
   // CHECK: unchecked_trivial_bit_cast {{%.*}} : $UnsafePointer<Int8> to $Optional<UnsafePointer<Int8>>

--- a/test/SILGen/objc_currying.swift
+++ b/test/SILGen/objc_currying.swift
@@ -55,21 +55,21 @@ func curry_bridged(_ x: CurryTest) -> (String!) -> String! {
 func curry_returnsInnerPointer(_ x: CurryTest) -> () -> UnsafeMutableRawPointer! {
   return x.returnsInnerPointer
 }
-// CHECK-LABEL: sil hidden @_TF13objc_currying25curry_returnsInnerPointerFCSo9CurryTestFT_GSQSv_ : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned () -> ImplicitlyUnwrappedOptional<UnsafeMutablePointer<()>> {
-// CHECK:         [[THUNK:%.*]] = function_ref [[THUNK_RETURNSINNERPOINTER:@_TTOFCSo9CurryTest19returnsInnerPointerFT_GSQGSpT___]]
+// CHECK-LABEL: sil hidden @_TF13objc_currying25curry_returnsInnerPointerFCSo9CurryTestFT_GSQSv_ : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned () -> ImplicitlyUnwrappedOptional<UnsafeMutableRawPointer> {
+// CHECK:         [[THUNK:%.*]] = function_ref [[THUNK_RETURNSINNERPOINTER:@_TTOFCSo9CurryTest19returnsInnerPointerFT_GSQSv_]]
 // CHECK:         [[FN:%.*]] = apply [[THUNK]](%0)
 // CHECK:         return [[FN]]
 
-// CHECK: sil shared [thunk] [[THUNK_RETURNSINNERPOINTER]] : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned () -> ImplicitlyUnwrappedOptional<UnsafeMutablePointer<()>>
-// CHECK:   [[THUNK:%.*]] = function_ref [[THUNK_RETURNSINNERPOINTER_2:@_TTOFCSo9CurryTest19returnsInnerPointerfT_GSQGSpT___]]
+// CHECK: sil shared [thunk] [[THUNK_RETURNSINNERPOINTER]] : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned () -> ImplicitlyUnwrappedOptional<UnsafeMutableRawPointer>
+// CHECK:   [[THUNK:%.*]] = function_ref [[THUNK_RETURNSINNERPOINTER_2:@_TTOFCSo9CurryTest19returnsInnerPointerfT_GSQSv_]]
 // CHECK:   [[FN:%.*]] = partial_apply [[THUNK]](%0)
 // CHECK:   return [[FN]]
 
-// CHECK: sil shared [thunk] @_TTOFCSo9CurryTest19returnsInnerPointerfT_GSQGSpT___ : $@convention(method) (@guaranteed CurryTest) -> ImplicitlyUnwrappedOptional<UnsafeMutablePointer<()>>
+// CHECK: sil shared [thunk] @_TTOFCSo9CurryTest19returnsInnerPointerfT_GSQSv_ : $@convention(method) (@guaranteed CurryTest) -> ImplicitlyUnwrappedOptional<UnsafeMutableRawPointer>
 // CHECK:  bb0([[ARG1:%.*]] : 
 // CHECK:   strong_retain [[ARG1]]
 // CHECK:   [[METHOD:%.*]] = class_method [volatile] %0 : $CurryTest, #CurryTest.returnsInnerPointer!1.foreign
-// CHECK:   [[RES:%.*]] = apply [[METHOD]](%0) : $@convention(objc_method) (CurryTest) -> @unowned_inner_pointer ImplicitlyUnwrappedOptional<UnsafeMutablePointer<()>>
+// CHECK:   [[RES:%.*]] = apply [[METHOD]](%0) : $@convention(objc_method) (CurryTest) -> @unowned_inner_pointer ImplicitlyUnwrappedOptional<UnsafeMutableRawPointer>
 // CHECK:   autorelease_value %0
 // CHECK:   return [[RES]]
 
@@ -125,11 +125,11 @@ func curry_returnsSelf_AnyObject(_ x: AnyObject) -> () -> AnyObject! {
   return x.returnsSelf!
 }
 
-// CHECK-LABEL: sil hidden @_TF13objc_currying35curry_returnsInnerPointer_AnyObjectFPs9AnyObject_FT_GSQGSpT___
+// CHECK-LABEL: sil hidden @_TF13objc_currying35curry_returnsInnerPointer_AnyObjectFPs9AnyObject_FT_GSQSv_
 // CHECK:         dynamic_method_br [[SELF:%.*]] : $@opened({{.*}}) AnyObject, #CurryTest.returnsInnerPointer!1.foreign, [[HAS_METHOD:bb[0-9]+]]
-// CHECK:       [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> @unowned_inner_pointer ImplicitlyUnwrappedOptional<UnsafeMutablePointer<()>>):
+// CHECK:       [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> @unowned_inner_pointer ImplicitlyUnwrappedOptional<UnsafeMutableRawPointer>):
 // CHECK:         [[PA:%.*]] = partial_apply [[METHOD]]([[SELF]])
-// CHECK:         [[PA]]{{.*}}@owned @callee_owned () -> ImplicitlyUnwrappedOptional<UnsafeMutablePointer<()>>
+// CHECK:         [[PA]]{{.*}}@owned @callee_owned () -> ImplicitlyUnwrappedOptional<UnsafeMutableRawPointer>
 
 func curry_returnsInnerPointer_AnyObject(_ x: AnyObject) -> () -> UnsafeMutableRawPointer! {
   return x.returnsInnerPointer!

--- a/test/SILGen/objc_currying.swift
+++ b/test/SILGen/objc_currying.swift
@@ -55,7 +55,7 @@ func curry_bridged(_ x: CurryTest) -> (String!) -> String! {
 func curry_returnsInnerPointer(_ x: CurryTest) -> () -> UnsafeMutableRawPointer! {
   return x.returnsInnerPointer
 }
-// CHECK-LABEL: sil hidden @_TF13objc_currying25curry_returnsInnerPointerFCSo9CurryTestFT_GSQGSpT___ : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned () -> ImplicitlyUnwrappedOptional<UnsafeMutablePointer<()>> {
+// CHECK-LABEL: sil hidden @_TF13objc_currying25curry_returnsInnerPointerFCSo9CurryTestFT_GSQSv_ : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned () -> ImplicitlyUnwrappedOptional<UnsafeMutablePointer<()>> {
 // CHECK:         [[THUNK:%.*]] = function_ref [[THUNK_RETURNSINNERPOINTER:@_TTOFCSo9CurryTest19returnsInnerPointerFT_GSQGSpT___]]
 // CHECK:         [[FN:%.*]] = apply [[THUNK]](%0)
 // CHECK:         return [[FN]]

--- a/test/SILGen/objc_currying.swift
+++ b/test/SILGen/objc_currying.swift
@@ -52,7 +52,7 @@ func curry_bridged(_ x: CurryTest) -> (String!) -> String! {
 // CHECK:   strong_release %1
 // CHECK:   return {{%.*}} : $ImplicitlyUnwrappedOptional<String>
 
-func curry_returnsInnerPointer(_ x: CurryTest) -> () -> UnsafeMutablePointer<Void>! {
+func curry_returnsInnerPointer(_ x: CurryTest) -> () -> UnsafeMutableRawPointer! {
   return x.returnsInnerPointer
 }
 // CHECK-LABEL: sil hidden @_TF13objc_currying25curry_returnsInnerPointerFCSo9CurryTestFT_GSQGSpT___ : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned () -> ImplicitlyUnwrappedOptional<UnsafeMutablePointer<()>> {
@@ -131,6 +131,6 @@ func curry_returnsSelf_AnyObject(_ x: AnyObject) -> () -> AnyObject! {
 // CHECK:         [[PA:%.*]] = partial_apply [[METHOD]]([[SELF]])
 // CHECK:         [[PA]]{{.*}}@owned @callee_owned () -> ImplicitlyUnwrappedOptional<UnsafeMutablePointer<()>>
 
-func curry_returnsInnerPointer_AnyObject(_ x: AnyObject) -> () -> UnsafeMutablePointer<Void>! {
+func curry_returnsInnerPointer_AnyObject(_ x: AnyObject) -> () -> UnsafeMutableRawPointer! {
   return x.returnsInnerPointer!
 }

--- a/test/SILGen/objc_ownership_conventions.swift
+++ b/test/SILGen/objc_ownership_conventions.swift
@@ -154,7 +154,7 @@ func maybeApplyBlock(_ f: (@convention(block) (Gizmo) -> Gizmo)?, x: Gizmo) -> G
   return f?(x)
 }
 
-func useInnerPointer(_ p: UnsafeMutablePointer<Void>) {}
+func useInnerPointer(_ p: UnsafeMutableRawPointer) {}
 
 // Handle inner-pointer methods by autoreleasing self after the call.
 // CHECK-LABEL: sil hidden @_TF26objc_ownership_conventions18innerPointerMethod

--- a/test/SILGen/objc_ownership_conventions.swift
+++ b/test/SILGen/objc_ownership_conventions.swift
@@ -159,7 +159,7 @@ func useInnerPointer(_ p: UnsafeMutableRawPointer) {}
 // Handle inner-pointer methods by autoreleasing self after the call.
 // CHECK-LABEL: sil hidden @_TF26objc_ownership_conventions18innerPointerMethod
 // CHECK:         [[USE:%.*]] = function_ref @_TF26objc_ownership_conventions15useInnerPointer
-// CHECK:         [[METHOD:%.*]] = class_method [volatile] %0 : $Gizmo, #Gizmo.getBytes!1.foreign : (Gizmo) -> () -> UnsafeMutablePointer<()> , $@convention(objc_method) (Gizmo) -> @unowned_inner_pointer UnsafeMutablePointer<()>
+// CHECK:         [[METHOD:%.*]] = class_method [volatile] %0 : $Gizmo, #Gizmo.getBytes!1.foreign : (Gizmo) -> () -> UnsafeMutableRawPointer , $@convention(objc_method) (Gizmo) -> @unowned_inner_pointer UnsafeMutableRawPointer
 // CHECK:         strong_retain %0
 // CHECK:         [[PTR:%.*]] = apply [[METHOD]](%0)
 // CHECK:         autorelease_value %0
@@ -171,7 +171,7 @@ func innerPointerMethod(_ g: Gizmo) {
 
 // CHECK-LABEL: sil hidden @_TF26objc_ownership_conventions20innerPointerProperty
 // CHECK:         [[USE:%.*]] = function_ref @_TF26objc_ownership_conventions15useInnerPointer
-// CHECK:         [[METHOD:%.*]] = class_method [volatile] %0 : $Gizmo, #Gizmo.innerProperty!getter.1.foreign : (Gizmo) -> () -> UnsafeMutablePointer<()> , $@convention(objc_method) (Gizmo) -> @unowned_inner_pointer UnsafeMutablePointer<()>
+// CHECK:         [[METHOD:%.*]] = class_method [volatile] %0 : $Gizmo, #Gizmo.innerProperty!getter.1.foreign : (Gizmo) -> () -> UnsafeMutableRawPointer , $@convention(objc_method) (Gizmo) -> @unowned_inner_pointer UnsafeMutableRawPointer
 // CHECK:         strong_retain %0
 // CHECK:         [[PTR:%.*]] = apply [[METHOD]](%0)
 // CHECK:         autorelease_value %0

--- a/test/SILGen/pointer_conversion.swift
+++ b/test/SILGen/pointer_conversion.swift
@@ -25,7 +25,7 @@ func pointerToPointer(_ mp: UnsafeMutablePointer<Int>,
   takesMutableVoidPointer(mp)
   // CHECK: [[TAKES_MUTABLE_VOID_POINTER:%.*]] = function_ref @_TF18pointer_conversion23takesMutableVoidPointer
   // CHECK: [[CONVERT:%.*]] = function_ref @_TFs32_convertPointerToPointerArgument
-  // CHECK: apply [[CONVERT]]<UnsafeMutablePointer<Int>, UnsafeMutablePointer<()>>
+  // CHECK: apply [[CONVERT]]<UnsafeMutablePointer<Int>, UnsafeMutableRawPointer>
   // CHECK: apply [[TAKES_MUTABLE_VOID_POINTER]]
 
   takesMutableRawPointer(mp)
@@ -115,7 +115,7 @@ func arrayToPointer() {
 // CHECK-LABEL: sil hidden @_TF18pointer_conversion15stringToPointerFSST_ 
 func stringToPointer(_ s: String) {
   takesConstVoidPointer(s)
-  // CHECK: [[TAKES_CONST_VOID_POINTER:%.*]] = function_ref @_TF18pointer_conversion21takesConstVoidPointerFGSPT__T_
+  // CHECK: [[TAKES_CONST_VOID_POINTER:%.*]] = function_ref @_TF18pointer_conversion21takesConstVoidPointerFSV
   // CHECK: [[CONVERT_STRING:%.*]] = function_ref @_TFs40_convertConstStringToUTF8PointerArgument
   // CHECK: [[OWNER:%.*]] = apply [[CONVERT_STRING]]<UnsafePointer<()>>([[POINTER_BUF:%[0-9]*]],
   // CHECK: [[POINTER:%.*]] = load [[POINTER_BUF]]

--- a/test/SILGen/pointer_conversion.swift
+++ b/test/SILGen/pointer_conversion.swift
@@ -41,9 +41,9 @@ func pointerToPointer(_ mp: UnsafeMutablePointer<Int>,
   // CHECK: apply [[TAKES_CONST_POINTER]]
 
   takesConstVoidPointer(mp)
-  // CHECK: [[TAKES_CONST_VOID_POINTER:%.*]] = function_ref @_TF18pointer_conversion21takesConstVoidPointerFGSPT__T_
+  // CHECK: [[TAKES_CONST_VOID_POINTER:%.*]] = function_ref @_TF18pointer_conversion21takesConstVoidPointerFSVT_
   // CHECK: [[CONVERT:%.*]] = function_ref @_TFs32_convertPointerToPointerArgument
-  // CHECK: apply [[CONVERT]]<UnsafeMutablePointer<Int>, UnsafePointer<()>>
+  // CHECK: apply [[CONVERT]]<UnsafeMutablePointer<Int>, UnsafeRawPointer>
   // CHECK: apply [[TAKES_CONST_VOID_POINTER]]
 
   takesConstRawPointer(mp)
@@ -57,9 +57,9 @@ func pointerToPointer(_ mp: UnsafeMutablePointer<Int>,
   // CHECK: apply [[TAKES_CONST_POINTER]]([[CP]])
 
   takesConstVoidPointer(cp)
-  // CHECK: [[TAKES_CONST_VOID_POINTER:%.*]] = function_ref @_TF18pointer_conversion21takesConstVoidPointerFGSPT__T_
+  // CHECK: [[TAKES_CONST_VOID_POINTER:%.*]] = function_ref @_TF18pointer_conversion21takesConstVoidPointerFSVT_
   // CHECK: [[CONVERT:%.*]] = function_ref @_TFs32_convertPointerToPointerArgument
-  // CHECK: apply [[CONVERT]]<UnsafePointer<Int>, UnsafePointer<()>>
+  // CHECK: apply [[CONVERT]]<UnsafePointer<Int>, UnsafeRawPointer>
   // CHECK: apply [[TAKES_CONST_VOID_POINTER]]
 
   takesConstRawPointer(cp)
@@ -117,7 +117,7 @@ func stringToPointer(_ s: String) {
   takesConstVoidPointer(s)
   // CHECK: [[TAKES_CONST_VOID_POINTER:%.*]] = function_ref @_TF18pointer_conversion21takesConstVoidPointerFSV
   // CHECK: [[CONVERT_STRING:%.*]] = function_ref @_TFs40_convertConstStringToUTF8PointerArgument
-  // CHECK: [[OWNER:%.*]] = apply [[CONVERT_STRING]]<UnsafePointer<()>>([[POINTER_BUF:%[0-9]*]],
+  // CHECK: [[OWNER:%.*]] = apply [[CONVERT_STRING]]<UnsafeRawPointer>([[POINTER_BUF:%[0-9]*]],
   // CHECK: [[POINTER:%.*]] = load [[POINTER_BUF]]
   // CHECK: apply [[TAKES_CONST_VOID_POINTER]]([[POINTER]])
   // CHECK: release_value [[OWNER]]

--- a/test/SILGen/pointer_conversion.swift
+++ b/test/SILGen/pointer_conversion.swift
@@ -7,8 +7,8 @@ import Foundation
 
 func takesMutablePointer(_ x: UnsafeMutablePointer<Int>) {}
 func takesConstPointer(_ x: UnsafePointer<Int>) {}
-func takesMutableVoidPointer(_ x: UnsafeMutablePointer<Void>) {}
-func takesConstVoidPointer(_ x: UnsafePointer<Void>) {}
+func takesMutableVoidPointer(_ x: UnsafeMutableRawPointer) {}
+func takesConstVoidPointer(_ x: UnsafeRawPointer) {}
 func takesMutableRawPointer(_ x: UnsafeMutableRawPointer) {}
 func takesConstRawPointer(_ x: UnsafeRawPointer) {}
 

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -1069,7 +1069,7 @@ class infer_instanceVar1 {
   var var_UnsafeMutablePointer12: UnsafeMutablePointer<AnyObject>
   var var_UnsafeMutablePointer13: UnsafeMutablePointer<AnyObject.Type>
   var var_UnsafeMutablePointer100: UnsafeMutablePointer<()>
-  var var_UnsafeMutablePointer101: UnsafeMutablePointer<Void>
+  var var_UnsafeMutablePointer101: UnsafeMutableRawPointer
   var var_UnsafeMutablePointer102: UnsafeMutablePointer<(Int, Int)>
 // CHECK-LABEL: @objc var var_UnsafeMutablePointer1: UnsafeMutablePointer<Int>
 // CHECK-LABEL: @objc var var_UnsafeMutablePointer2: UnsafeMutablePointer<Bool>
@@ -1085,7 +1085,7 @@ class infer_instanceVar1 {
 // CHECK-LABEL: @objc var var_UnsafeMutablePointer12: UnsafeMutablePointer<AnyObject>
 // CHECK-LABEL: var var_UnsafeMutablePointer13: UnsafeMutablePointer<AnyObject.Type>
 // CHECK-LABEL: {{^}} @objc var var_UnsafeMutablePointer100: UnsafeMutablePointer<()>
-// CHECK-LABEL: {{^}} @objc var var_UnsafeMutablePointer101: UnsafeMutablePointer<Void>
+// CHECK-LABEL: {{^}} @objc var var_UnsafeMutablePointer101: UnsafeMutableRawPointer
 // CHECK-LABEL: {{^}}  var var_UnsafeMutablePointer102: UnsafeMutablePointer<(Int, Int)>
 
   var var_Optional1: Class_ObjC1?

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -1068,7 +1068,7 @@ class infer_instanceVar1 {
   var var_UnsafeMutablePointer11: UnsafeMutablePointer<PlainProtocol>
   var var_UnsafeMutablePointer12: UnsafeMutablePointer<AnyObject>
   var var_UnsafeMutablePointer13: UnsafeMutablePointer<AnyObject.Type>
-  var var_UnsafeMutablePointer100: UnsafeMutablePointer<()>
+  var var_UnsafeMutablePointer100: UnsafeMutableRawPointer
   var var_UnsafeMutablePointer101: UnsafeMutableRawPointer
   var var_UnsafeMutablePointer102: UnsafeMutablePointer<(Int, Int)>
 // CHECK-LABEL: @objc var var_UnsafeMutablePointer1: UnsafeMutablePointer<Int>
@@ -1084,7 +1084,7 @@ class infer_instanceVar1 {
 // CHECK-LABEL: {{^}}  var var_UnsafeMutablePointer11: UnsafeMutablePointer<PlainProtocol>
 // CHECK-LABEL: @objc var var_UnsafeMutablePointer12: UnsafeMutablePointer<AnyObject>
 // CHECK-LABEL: var var_UnsafeMutablePointer13: UnsafeMutablePointer<AnyObject.Type>
-// CHECK-LABEL: {{^}} @objc var var_UnsafeMutablePointer100: UnsafeMutablePointer<()>
+// CHECK-LABEL: {{^}} @objc var var_UnsafeMutablePointer100: UnsafeMutableRawPointer
 // CHECK-LABEL: {{^}} @objc var var_UnsafeMutablePointer101: UnsafeMutableRawPointer
 // CHECK-LABEL: {{^}}  var var_UnsafeMutablePointer102: UnsafeMutablePointer<(Int, Int)>
 

--- a/validation-test/IDE/complete_from_cocoa.swift
+++ b/validation-test/IDE/complete_from_cocoa.swift
@@ -13,7 +13,7 @@ import Cocoa
 func testUnqualified() {
   #^T1^#
 // T1: Begin completions
-// T1-DAG: Decl[FreeFunction]/OtherModule[CoreFoundation.CFArray]: CFArrayCreate({#(allocator): CFAllocator!#}, {#(values): UnsafeMutablePointer<UnsafePointer<Void>?>!#}, {#(numValues): CFIndex#}, {#(callBacks): UnsafePointer<CFArrayCallBacks>!#})[#CFArray!#]{{; name=.+$}}
+// T1-DAG: Decl[FreeFunction]/OtherModule[CoreFoundation.CFArray]: CFArrayCreate({#(allocator): CFAllocator!#}, {#(values): UnsafeMutablePointer<UnsafeRawPointer?>!#}, {#(numValues): CFIndex#}, {#(callBacks): UnsafePointer<CFArrayCallBacks>!#})[#CFArray!#]{{; name=.+$}}
 // T1-DAG: Decl[FreeFunction]/OtherModule[CoreFoundation.CFArray]: CFArrayGetCount({#(theArray): CFArray!#})[#CFIndex#]{{; name=.+$}}
 // T1-DAG: Decl[Class]/OtherModule[ObjectiveC.NSObject]:        NSObject[#NSObject#]{{; name=.+$}}
 // T1: End completions

--- a/validation-test/IDE/complete_from_cocoa_2.swift
+++ b/validation-test/IDE/complete_from_cocoa_2.swift
@@ -13,7 +13,7 @@ import Cocoa
 func testQualifiedWithDot() {
   Cocoa.#^T1^#
 // T1: Begin completions
-// T1-DAG: Decl[FreeFunction]/OtherModule[CoreFoundation.CFArray]: CFArrayCreate({#(allocator): CFAllocator!#}, {#(values): UnsafeMutablePointer<UnsafePointer<Void>?>!#}, {#(numValues): CFIndex#}, {#(callBacks): UnsafePointer<CFArrayCallBacks>!#})[#CFArray!#]{{; name=.+$}}
+// T1-DAG: Decl[FreeFunction]/OtherModule[CoreFoundation.CFArray]: CFArrayCreate({#(allocator): CFAllocator!#}, {#(values): UnsafeMutablePointer<UnsafeRawPointer?>!#}, {#(numValues): CFIndex#}, {#(callBacks): UnsafePointer<CFArrayCallBacks>!#})[#CFArray!#]{{; name=.+$}}
 // T1-DAG: Decl[FreeFunction]/OtherModule[CoreFoundation.CFArray]: CFArrayGetCount({#(theArray): CFArray!#})[#CFIndex#]{{; name=.+$}}
 // T1-DAG: Decl[Class]/OtherModule[ObjectiveC.NSObject]:        NSObject[#NSObject#]{{; name=.+$}}
 // T1: End completions
@@ -22,7 +22,7 @@ func testQualifiedWithDot() {
 func testQualifiedWithoutDot() {
   Cocoa#^T2^#
 // T2: Begin completions
-// T2-DAG: Decl[FreeFunction]/OtherModule[CoreFoundation.CFArray]: .CFArrayCreate({#(allocator): CFAllocator!#}, {#(values): UnsafeMutablePointer<UnsafePointer<Void>?>!#}, {#(numValues): CFIndex#}, {#(callBacks): UnsafePointer<CFArrayCallBacks>!#})[#CFArray!#]{{; name=.+$}}
+// T2-DAG: Decl[FreeFunction]/OtherModule[CoreFoundation.CFArray]: .CFArrayCreate({#(allocator): CFAllocator!#}, {#(values): UnsafeMutablePointer<UnsafeRawPointer?>!#}, {#(numValues): CFIndex#}, {#(callBacks): UnsafePointer<CFArrayCallBacks>!#})[#CFArray!#]{{; name=.+$}}
 // T2-DAG: Decl[FreeFunction]/OtherModule[CoreFoundation.CFArray]: .CFArrayGetCount({#(theArray): CFArray!#})[#CFIndex#]{{; name=.+$}}
 // T2-DAG: Decl[Class]/OtherModule[ObjectiveC.NSObject]:        .NSObject[#NSObject#]{{; name=.+$}}
 // T2: End completions

--- a/validation-test/stdlib/ArrayNew.swift.gyb
+++ b/validation-test/stdlib/ArrayNew.swift.gyb
@@ -20,19 +20,19 @@ all_array_types = ['ContiguousArray', 'ArraySlice', 'Array']
 }%
 
 extension Array {
-  var identity: UnsafePointer<Void> {
+  var identity: UnsafeRawPointer {
     return self._buffer.identity
   }
 }
 
 extension ArraySlice {
-  var identity: UnsafePointer<Void> {
+  var identity: UnsafeRawPointer {
     return self._buffer.identity
   }
 }
 
 extension ContiguousArray {
-  var identity: UnsafePointer<Void> {
+  var identity: UnsafeRawPointer {
     return self._buffer.identity
   }
 }

--- a/validation-test/stdlib/Arrays.swift.gyb
+++ b/validation-test/stdlib/Arrays.swift.gyb
@@ -74,19 +74,19 @@ all_array_types = ['ContiguousArray', 'ArraySlice', 'Array']
 }%
 
 extension Array {
-  var identity: UnsafePointer<Void> {
+  var identity: UnsafeRawPointer {
     return self._buffer.identity
   }
 }
 
 extension ArraySlice {
-  var identity: UnsafePointer<Void> {
+  var identity: UnsafeRawPointer {
     return self._buffer.identity
   }
 }
 
 extension ContiguousArray {
-  var identity: UnsafePointer<Void> {
+  var identity: UnsafeRawPointer {
     return self._buffer.identity
   }
 }

--- a/validation-test/stdlib/CoreAudio.swift
+++ b/validation-test/stdlib/CoreAudio.swift
@@ -40,7 +40,7 @@ CoreAudioTestSuite.test("UnsafeBufferPointer.init(_: AudioBuffer)") {
   do {
     let audioBuffer = AudioBuffer(
       mNumberChannels: 2, mDataByteSize: 1024,
-      mData: UnsafeMutablePointer<Void>(bitPattern: 0x1234_5678))
+      mData: UnsafeMutableRawPointer(bitPattern: 0x1234_5678))
     let result: UnsafeBufferPointer<Float> = UnsafeBufferPointer(audioBuffer)
     expectEqual(
       UnsafePointer<Float>(audioBuffer.mData!),
@@ -62,7 +62,7 @@ CoreAudioTestSuite.test("UnsafeMutableBufferPointer.init(_: AudioBuffer)") {
   do {
     let audioBuffer = AudioBuffer(
       mNumberChannels: 2, mDataByteSize: 1024,
-      mData: UnsafeMutablePointer<Void>(bitPattern: 0x1234_5678))
+      mData: UnsafeMutableRawPointer(bitPattern: 0x1234_5678))
     let result: UnsafeMutableBufferPointer<Float> =
       UnsafeMutableBufferPointer(audioBuffer)
     expectEqual(
@@ -236,7 +236,7 @@ CoreAudioTestSuite.test("UnsafeMutableAudioBufferListPointer.subscript(_: Int)")
     // Test getter.
     let audioBuffer = AudioBuffer(
       mNumberChannels: 2, mDataByteSize: 1024,
-      mData: UnsafeMutablePointer<Void>(bitPattern: 0x1234_5678))
+      mData: UnsafeMutableRawPointer(bitPattern: 0x1234_5678))
 
     UnsafeMutablePointer<AudioBuffer>(
         UnsafeMutablePointer<UInt8>(ablPtr) + ablHeaderSize
@@ -252,7 +252,7 @@ CoreAudioTestSuite.test("UnsafeMutableAudioBufferListPointer.subscript(_: Int)")
     // Test setter.
     let audioBuffer = AudioBuffer(
       mNumberChannels: 5, mDataByteSize: 256,
-      mData: UnsafeMutablePointer<Void>(bitPattern: 0x8765_4321 as UInt))
+      mData: UnsafeMutableRawPointer(bitPattern: 0x8765_4321 as UInt))
 
     ablPtrWrapper.count = 2
     ablPtrWrapper[1] = audioBuffer
@@ -287,7 +287,7 @@ CoreAudioTestSuite.test("UnsafeMutableAudioBufferListPointer/Collection") {
   for i in 0..<16 {
     let audioBuffer = AudioBuffer(
       mNumberChannels: UInt32(2 + i), mDataByteSize: UInt32(1024 * i),
-      mData: UnsafeMutablePointer<Void>(bitPattern: 0x1234_5678 + i * 10))
+      mData: UnsafeMutableRawPointer(bitPattern: 0x1234_5678 + i * 10))
 
     ablPtrWrapper[i] = audioBuffer
     expected.append(audioBuffer)

--- a/validation-test/stdlib/CoreAudio.swift
+++ b/validation-test/stdlib/CoreAudio.swift
@@ -42,9 +42,7 @@ CoreAudioTestSuite.test("UnsafeBufferPointer.init(_: AudioBuffer)") {
       mNumberChannels: 2, mDataByteSize: 1024,
       mData: UnsafeMutableRawPointer(bitPattern: 0x1234_5678))
     let result: UnsafeBufferPointer<Float> = UnsafeBufferPointer(audioBuffer)
-    expectEqual(
-      UnsafePointer<Float>(audioBuffer.mData!),
-      result.baseAddress)
+    expectEqual(audioBuffer.mData, UnsafeRawPointer(result.baseAddress!))
     expectEqual(256, result.count)
   }
 }
@@ -65,9 +63,7 @@ CoreAudioTestSuite.test("UnsafeMutableBufferPointer.init(_: AudioBuffer)") {
       mData: UnsafeMutableRawPointer(bitPattern: 0x1234_5678))
     let result: UnsafeMutableBufferPointer<Float> =
       UnsafeMutableBufferPointer(audioBuffer)
-    expectEqual(
-      UnsafeMutablePointer<Float>(audioBuffer.mData!),
-      result.baseAddress)
+    expectEqual(audioBuffer.mData!, UnsafeMutableRawPointer(result.baseAddress!))
     expectEqual(256, result.count)
   }
 }

--- a/validation-test/stdlib/NewArray.swift.gyb
+++ b/validation-test/stdlib/NewArray.swift.gyb
@@ -32,7 +32,7 @@ func printSequence<T : Sequence>(_ x: T) {
   print("]")
 }
 
-typealias BufferID = UnsafePointer<Void>?
+typealias BufferID = UnsafeRawPointer?
 
 func bufferID<T : _ArrayProtocol>(_ x: T) -> BufferID {
   return x._buffer.identity

--- a/validation-test/stdlib/SceneKit.swift
+++ b/validation-test/stdlib/SceneKit.swift
@@ -20,7 +20,7 @@ func bytesFromNSData(_ data: NSData) -> [UInt8] {
 
 func floatsFromNSData(_ data: NSData) -> [Float] {
   let floatPtr = data.bytes.bindMemory(to: Float.self, capacity: data.length)
-  return Array(UnsafeBufferPointer(floatPtr, count: data.length / sizeof(Float)))
+  return Array(UnsafeBufferPointer(start: floatPtr, count: data.length / sizeof(Float)))
 }
 
 if #available(iOS 8.0, *) {

--- a/validation-test/stdlib/SceneKit.swift
+++ b/validation-test/stdlib/SceneKit.swift
@@ -14,15 +14,13 @@ import SceneKit
 var SceneKitTests = TestSuite("SceneKit")
 
 func bytesFromNSData(_ data: NSData) -> [UInt8] {
-  return Array(UnsafeBufferPointer(
-    start: UnsafePointer<UInt8>(data.bytes),
-    count: data.length))
+  let bytePtr = data.bytes.bindMemory(to: UInt8.self, capacity: data.length)
+  return Array(UnsafeBufferPointer(start: bytePtr, count: data.length))
 }
 
 func floatsFromNSData(_ data: NSData) -> [Float] {
-  return Array(UnsafeBufferPointer(
-    start: UnsafePointer<Float>(data.bytes),
-    count: data.length / sizeof(Float)))
+  let floatPtr = data.bytes.bindMemory(to: Float.self, capacity: data.length)
+  return Array(UnsafeBufferPointer(floatPtr, count: data.length / sizeof(Float)))
 }
 
 if #available(iOS 8.0, *) {


### PR DESCRIPTION
Previously:
https://github.com/apple/swift/pull/3724

The lldb errors on the linux bots were not related to these changes.
