### PR TITLE
Foundation: stop exporting certain overlay methods to Objective-C

### DIFF
--- a/stdlib/public/SDK/Foundation/Foundation.swift
+++ b/stdlib/public/SDK/Foundation/Foundation.swift
@@ -1209,7 +1209,7 @@ extension NSArray {
   ///
   /// Discussion: After an immutable array has been initialized in
   /// this way, it cannot be modified.
-  @objc(_swiftInitWithArray_NSArray:)
+  @nonobjc
   public convenience init(array anArray: NSArray) {
     self.init(array: anArray as Array)
   }
@@ -1222,7 +1222,7 @@ extension NSString {
   /// - Returns: An `NSString` object initialized by copying the
   ///   characters from `aString`. The returned object may be different
   ///   from the original receiver.
-  @objc(_swiftInitWithString_NSString:)
+  @nonobjc
   public convenience init(string aString: NSString) {
     self.init(string: aString as String)
   }
@@ -1235,7 +1235,7 @@ extension NSSet {
   /// - Returns: An initialized objects set containing the objects from
   ///   `set`. The returned set might be different than the original
   ///   receiver.
-  @objc(_swiftInitWithSet_NSSet:)
+  @nonobjc
   public convenience init(set anSet: NSSet) {
     // FIXME: This is a bit weird. Maybe there's a better way?
     self.init(set: anSet as Set<NSObject> as Set<AnyHashable>)
@@ -1354,6 +1354,7 @@ extension NSCoder {
     return NS_Swift_NSCoder_decodeObjectOfClassesForKey(self as AnyObject, classesAsNSObjects, key as AnyObject, nil).map { $0 as Any }
   }
 
+  @nonobjc
   @available(OSX 10.11, iOS 9.0, *)
   public func decodeTopLevelObject() throws -> Any? {
     var error: NSError?
@@ -1367,6 +1368,7 @@ extension NSCoder {
     fatalError("This API has been renamed")
   }
 
+  @nonobjc
   @available(OSX 10.11, iOS 9.0, *)
   public func decodeTopLevelObject(forKey key: String) throws -> AnyObject? {
     var error: NSError?
@@ -1394,11 +1396,13 @@ extension NSCoder {
     return result as? DecodedObjectType
   }
 
+  @nonobjc
   @available(*, unavailable, renamed: "decodeTopLevelObject(of:forKey:)")
   public func decodeTopLevelObjectOfClasses(_ classes: NSSet?, forKey key: String) throws -> AnyObject? {
     fatalError("This API has been renamed")
   }
 
+  @nonobjc
   @available(OSX 10.11, iOS 9.0, *)
   public func decodeTopLevelObject(of classes: [AnyClass]?, forKey key: String) throws -> Any? {
     var error: NSError? = nil
@@ -1424,6 +1428,7 @@ internal func NS_Swift_NSKeyedUnarchiver_unarchiveObjectWithData(
 
 extension NSKeyedUnarchiver {
   @available(OSX 10.11, iOS 9.0, *)
+  @nonobjc
   public class func unarchiveTopLevelObjectWithData(_ data: NSData) throws -> AnyObject? {
     var error: NSError?
     let result = NS_Swift_NSKeyedUnarchiver_unarchiveObjectWithData(self, data as AnyObject, &error)


### PR DESCRIPTION
These methods don't need to be visible to Objective-C.  This change decreases code size a little.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
