### PR TITLE
rdar://problem/27558151 Disable cast optimization for address-only types harder.

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -424,6 +424,7 @@ public:
   }
 
   LoadInst *createLoad(SILLocation Loc, SILValue LV) {
+    assert(LV->getType().isLoadable(F.getModule()));
     return insert(new (F.getModule())
                       LoadInst(getSILDebugLocation(Loc), LV));
   }

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1426,10 +1426,10 @@ optimizeBridgedObjCToSwiftCast(SILInstruction *Inst,
   assert(Src->getType().isAddress() && "Source should have an address type");
   assert(Dest->getType().isAddress() && "Source should have an address type");
 
-  auto srcIsLoadable = Src->getType().isLoadable(M);
-  // TODO: Handle address-only types.
-  if (!srcIsLoadable)
+  if (!Src->getType().isLoadable(M) || !Dest->getType().isLoadable(M)) {
+    // TODO: Handle address only types.
     return nullptr;
+  }
 
   if (SILBridgedTy != Src->getType()) {
     // Check if we can simplify a cast into:
@@ -1608,6 +1608,11 @@ optimizeBridgedSwiftToObjCCast(SILInstruction *Inst,
 
   auto &M = Inst->getModule();
   auto Loc = Inst->getLoc();
+  
+  if (!Src->getType().isLoadable(M) || !Dest->getType().isLoadable(M)) {
+    // TODO: Handle address-only types.
+    return nullptr;
+  }
 
   // Find the _BridgedToObjectiveC protocol.
   auto BridgedProto =


### PR DESCRIPTION
The version of this got out of sync with master. This more completely
avoids unimplemented cases.
