### PR TITLE
Revert "Fix ASTContext::getBridgedToObjC to not return None under id-as-any"

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3945,9 +3945,6 @@ ASTContext::getBridgedToObjC(const DeclContext *dc, Type type,
           return None;
       }
     }
-  } else {
-    // Under id-as-any, anything is bridged to objective c.
-    knownBridgedToObjC = true;
   }
 
   if (auto metaTy = type->getAs<MetatypeType>())

--- a/lib/SIL/DynamicCasts.cpp
+++ b/lib/SIL/DynamicCasts.cpp
@@ -45,32 +45,6 @@ mayBridgeToObjectiveC(Module *M, CanType T) {
   return false;
 }
 
-static bool
-mustBridgeToSwiftValueBox(Module *M, CanType T) {
-  // If the target type is either an unknown dynamic type, or statically
-  // known to bridge, the cast may succeed.
-  if (T->hasArchetype())
-    return false;
-
-  if (T->isAnyExistentialType())
-    return false;
-
-  // getBridgedToObjC() might return a null-type for bridged foundation types
-  // during compiling the standard library. Exclude this case here.
-  if (auto N = T->getAnyNominal())
-    if (M->getASTContext().isStandardLibraryTypeBridgedInFoundation(N))
-      return false;
-
-  auto bridgeTy  = M->getASTContext().getBridgedToObjC(M, T, nullptr);
-  if (!bridgeTy.hasValue())
-    return false;
-
-  if (bridgeTy->isNull())
-    return true;
-
-  return false;
-}
-
 static bool canClassOrSuperclassesHaveExtensions(ClassDecl *CD,
                                                  bool isWholeModuleOpts) {
   while (CD) {
@@ -440,24 +414,6 @@ swift::classifyDynamicCast(Module *M,
       return DynamicCastFeasibility::WillFail;
     }
 
-    // Casts from a class into a non-class can never succeed if the target must
-    // be bridged to a SwiftValueBox. You would need an AnyObject source for
-    // that.
-    if (!target.isAnyExistentialType() &&
-        !target.getClassOrBoundGenericClass() &&
-        !isa<ArchetypeType>(target) &&
-        mustBridgeToSwiftValueBox(M, target)) {
-      assert((target.getEnumOrBoundGenericEnum() ||
-              target.getStructOrBoundGenericStruct() ||
-              isa<TupleType>(target) ||
-              isa<SILFunctionType>(target) ||
-              isa<FunctionType>(target) ||
-              isa<MetatypeType>(target)) &&
-             "Target should be an enum, struct, tuple, metatype or function type");
-      return DynamicCastFeasibility::WillFail;
-    }
-
-
     // In the Objective-C runtime, class metatypes are also class instances.
     // The cast may succeed if the target type can be inhabited by a class
     // metatype.
@@ -482,22 +438,6 @@ swift::classifyDynamicCast(Module *M,
 
   // FIXME: Be more careful with bridging conversions from
   // NSArray, NSDictionary and NSSet as they may fail?
-
-  // We know that a cast from Int -> class foobar will fail.
-  if (targetClass &&
-      !source.isAnyExistentialType() &&
-      !source.getClassOrBoundGenericClass() &&
-      !isa<ArchetypeType>(source) &&
-      mustBridgeToSwiftValueBox(M, source)) {
-      assert((source.getEnumOrBoundGenericEnum() ||
-              source.getStructOrBoundGenericStruct() ||
-              isa<TupleType>(source) ||
-              isa<SILFunctionType>(source) ||
-              isa<FunctionType>(source) ||
-              isa<MetatypeType>(source)) &&
-             "Source should be an enum, struct, tuple, metatype or function type");
-    return DynamicCastFeasibility::WillFail;
-  }
 
   // Check if there might be a bridging conversion.
   if (source->isBridgeableObjectType() && mayBridgeToObjectiveC(M, target)) {

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1751,8 +1751,6 @@ optimizeBridgedCasts(SILInstruction *Inst,
     return nullptr;
 
   auto BridgedSourceTy = getCastFromObjC(M, target, source);
-  if (!BridgedSourceTy)
-    return nullptr;
 
   CanType CanBridgedTargetTy(BridgedTargetTy);
   CanType CanBridgedSourceTy(BridgedSourceTy);

--- a/test/SILOptimizer/cast_folding_objc.swift
+++ b/test/SILOptimizer/cast_folding_objc.swift
@@ -205,7 +205,7 @@ print("test0=\(test0())")
 // CHECK:         unconditional_checked_cast_addr
 
 // CHECK-LABEL: sil [noinline] @{{.*}}testCastAnyObjectToNonClassType
-// CHECK-NOT:         builtin "int_trap"
+// CHECK:         builtin "int_trap"
 
 // CHECK-LABEL: sil [noinline] @{{.*}}testCastAnyToAnyClass{{.*}}
 // CHECK:         unconditional_checked_cast_addr

--- a/test/SILOptimizer/specialize_unconditional_checked_cast.swift
+++ b/test/SILOptimizer/specialize_unconditional_checked_cast.swift
@@ -343,9 +343,9 @@ public func ExistentialToArchetype<T>(o o : AnyObject, t : T) -> T {
 
 // AnyObject -> Non Class (should always fail)
 // CHECK-LABEL: sil shared [noinline] @_TTSg5Vs5UInt8___TF37specialize_unconditional_checked_cast22ExistentialToArchetype{{.*}} : $@convention(thin) (@owned AnyObject, UInt8) -> UInt8 {
-// CHECK-NOT: builtin "int_trap"()
-// CHECK-NOT: unreachable
-// CHECK: return
+// CHECK: builtin "int_trap"()
+// CHECK: unreachable
+// CHECK-NEXT: }
 
 // AnyObject -> AnyObject
 // CHECK-LABEL: sil shared [noinline] @_TTSg5Ps9AnyObject____TF37specialize_unconditional_checked_cast22ExistentialToArchetype{{.*}} : $@convention(thin) (@owned AnyObject, @owned AnyObject) -> @owned AnyObject {


### PR DESCRIPTION
Reverts apple/swift#3783
