### PR TITLE
[SE-0127] changes to withUnsafe[Mutable]Pointer

### DIFF
--- a/stdlib/private/SwiftPrivateLibcExtras/Subprocess.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/Subprocess.swift
@@ -118,7 +118,7 @@ public func spawnChild(_ args: [String])
     // parent write pipe.
     let errnoSize = sizeof(errno.dynamicType)
     var execveErrno = errno
-    let writtenBytes = withUnsafePointer(&execveErrno) {
+    let writtenBytes = withUnsafePointer(to: &execveErrno) {
       write(childToParentPipe.writeFD, UnsafePointer($0), errnoSize)
     }
 

--- a/stdlib/public/Platform/tgmath.swift.gyb
+++ b/stdlib/public/Platform/tgmath.swift.gyb
@@ -334,7 +334,7 @@ func _swift_Darwin_lgamma${f}_r(_: ${CT},
 @_transparent
 public func lgamma(_ x: ${T}) -> (${T}, Int) {
   var sign = Int32(0)
-  let value = withUnsafeMutablePointer(&sign) { 
+  let value = withUnsafeMutablePointer(to: &sign) {
     (signp: UnsafeMutablePointer<Int32>) -> ${CT} in
     return _swift_Darwin_lgamma${f}_r(${CT}(x), signp)
   }

--- a/stdlib/public/SDK/Foundation/DateInterval.swift
+++ b/stdlib/public/SDK/Foundation/DateInterval.swift
@@ -156,7 +156,7 @@ public struct DateInterval : ReferenceConvertible, Comparable, Hashable {
     
     public var hashValue: Int {
         var buf: (UInt, UInt) = (UInt(start.timeIntervalSinceReferenceDate), UInt(end.timeIntervalSinceReferenceDate))
-        return withUnsafeMutablePointer(&buf) {
+        return withUnsafeMutablePointer(to: &buf) {
             return Int(bitPattern: CFHashBytes(unsafeBitCast($0, to: UnsafeMutablePointer<UInt8>.self), CFIndex(sizeof(UInt.self) * 2)))
         }
     }

--- a/stdlib/public/SDK/Foundation/UUID.swift
+++ b/stdlib/public/SDK/Foundation/UUID.swift
@@ -22,14 +22,14 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
     
     /* Create a new UUID with RFC 4122 version 4 random bytes */
     public init() {
-        withUnsafeMutablePointer(&uuid) {
+        withUnsafeMutablePointer(to: &uuid) {
             uuid_generate_random(unsafeBitCast($0, to: UnsafeMutablePointer<UInt8>.self))
         }
     }
     
     fileprivate init(reference: NSUUID) {
         var bytes: uuid_t = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-        withUnsafeMutablePointer(&bytes) {
+        withUnsafeMutablePointer(to: &bytes) {
             reference.getBytes(unsafeBitCast($0, to: UnsafeMutablePointer<UInt8>.self))
         }
         uuid = bytes
@@ -39,7 +39,7 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
     /// 
     /// Returns nil for invalid strings.
     public init?(uuidString string: String) {
-        let res = withUnsafeMutablePointer(&uuid) {
+        let res = withUnsafeMutablePointer(to: &uuid) {
             return uuid_parse(string, unsafeBitCast($0, to: UnsafeMutablePointer<UInt8>.self))
         }
         if res != 0 {
@@ -56,8 +56,8 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
     public var uuidString: String {
         var bytes: uuid_string_t = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
         var localValue = uuid
-        return withUnsafeMutablePointer(&localValue) { val in
-            withUnsafeMutablePointer(&bytes) { str in
+        return withUnsafeMutablePointer(to: &localValue) { val in
+            withUnsafeMutablePointer(to: &bytes) { str in
                 uuid_unparse(unsafeBitCast(val, to: UnsafePointer<UInt8>.self), unsafeBitCast(str, to: UnsafeMutablePointer<Int8>.self))
                 return String(cString: unsafeBitCast(str, to: UnsafePointer<CChar>.self), encoding: .utf8)!
             }
@@ -66,7 +66,7 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
     
     public var hashValue: Int {
         var localValue = uuid
-        return withUnsafeMutablePointer(&localValue) {
+        return withUnsafeMutablePointer(to: &localValue) {
             return Int(bitPattern: CFHashBytes(unsafeBitCast($0, to: UnsafeMutablePointer<UInt8>.self), CFIndex(sizeof(uuid_t.self))))
         }
     }
@@ -83,7 +83,7 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
     
     fileprivate var reference: NSUUID {
         var bytes = uuid
-        return withUnsafePointer(&bytes) {
+        return withUnsafePointer(to: &bytes) {
             return NSUUID(uuidBytes: unsafeBitCast($0, to: UnsafePointer<UInt8>.self))
         }
     }

--- a/stdlib/public/SDK/Foundation/UUID.swift
+++ b/stdlib/public/SDK/Foundation/UUID.swift
@@ -56,9 +56,11 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
     public var uuidString: String {
         var bytes: uuid_string_t = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
         var localValue = uuid
-        return withUnsafeMutablePointers(&localValue, &bytes) { val, str -> String in
-            uuid_unparse(unsafeBitCast(val, to: UnsafePointer<UInt8>.self), unsafeBitCast(str, to: UnsafeMutablePointer<Int8>.self))
-            return String(cString: unsafeBitCast(str, to: UnsafePointer<CChar>.self), encoding: .utf8)!
+        return withUnsafeMutablePointer(&localValue) { val in
+            withUnsafeMutablePointer(&bytes) { str in
+                uuid_unparse(unsafeBitCast(val, to: UnsafePointer<UInt8>.self), unsafeBitCast(str, to: UnsafeMutablePointer<Int8>.self))
+                return String(cString: unsafeBitCast(str, to: UnsafePointer<CChar>.self), encoding: .utf8)!
+            }
         }
     }
     

--- a/stdlib/public/core/CocoaArray.swift
+++ b/stdlib/public/core/CocoaArray.swift
@@ -61,7 +61,7 @@ internal struct _CocoaArrayWrapper : RandomAccessCollection {
     // subRange.upperBound items are stored contiguously.  This is an
     // acceptable conservative behavior, but could potentially be
     // optimized for other cases.
-    let contiguousCount = withUnsafeMutablePointer(&enumerationState) {
+    let contiguousCount = withUnsafeMutablePointer(to: &enumerationState) {
       self.buffer.countByEnumerating(with: $0, objects: nil, count: 0)
     }
     

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -56,7 +56,7 @@ extension ${Self} {
     let u16 = text.utf16
     func parseNTBS(_ chars: UnsafePointer<CChar>) -> (${Self}, Int) {
       var result: ${Self} = 0
-      let endPtr = withUnsafeMutablePointer(&result) {
+      let endPtr = withUnsafeMutablePointer(to: &result) {
         _swift_stdlib_strto${cFuncSuffix2[bits]}_clocale(
           chars, UnsafeMutablePointer($0))
       }

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -4777,7 +4777,7 @@ final internal class _Cocoa${Self}Iterator : IteratorProtocol {
     let cocoa${Self} = self.cocoa${Self}
     if itemIndex == itemCount {
       let stackBufCount = _fastEnumerationStackBuf.count
-      // We can't use `withUnsafeMutablePointers` here to get pointers to
+      // We can't use `withUnsafeMutablePointer` here to get pointers to
       // properties, because doing so might introduce a writeback buffer, but
       // fast enumeration relies on the pointer identity of the enumeration
       // state struct.

--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -67,36 +67,6 @@ public func withUnsafeMutablePointer<T, Result>(
   return try body(UnsafeMutablePointer<T>(Builtin.addressof(&arg)))
 }
 
-/// Like `withUnsafeMutablePointer`, but passes pointers to `arg0` and `arg1`.
-public func withUnsafeMutablePointers<A0, A1, Result>(
-  _ arg0: inout A0,
-  _ arg1: inout A1,
-  _ body: @noescape (
-    UnsafeMutablePointer<A0>, UnsafeMutablePointer<A1>) throws -> Result
-) rethrows -> Result {
-  return try body(
-    UnsafeMutablePointer<A0>(Builtin.addressof(&arg0)),
-    UnsafeMutablePointer<A1>(Builtin.addressof(&arg1)))
-}
-
-/// Like `withUnsafeMutablePointer`, but passes pointers to `arg0`, `arg1`,
-/// and `arg2`.
-public func withUnsafeMutablePointers<A0, A1, A2, Result>(
-  _ arg0: inout A0,
-  _ arg1: inout A1,
-  _ arg2: inout A2,
-  _ body: @noescape (
-    UnsafeMutablePointer<A0>,
-    UnsafeMutablePointer<A1>,
-    UnsafeMutablePointer<A2>
-  ) throws -> Result
-) rethrows -> Result {
-  return try body(
-    UnsafeMutablePointer<A0>(Builtin.addressof(&arg0)),
-    UnsafeMutablePointer<A1>(Builtin.addressof(&arg1)),
-    UnsafeMutablePointer<A2>(Builtin.addressof(&arg2)))
-}
-
 /// Invokes `body` with an `UnsafePointer` to `arg` and returns the
 /// result. Useful for calling Objective-C APIs that take "in/out"
 /// parameters (and default-constructible "out" parameters) by pointer.
@@ -106,33 +76,4 @@ public func withUnsafePointer<T, Result>(
 ) rethrows -> Result
 {
   return try body(UnsafePointer<T>(Builtin.addressof(&arg)))
-}
-
-/// Like `withUnsafePointer`, but passes pointers to `arg0` and `arg1`.
-public func withUnsafePointers<A0, A1, Result>(
-  _ arg0: inout A0,
-  _ arg1: inout A1,
-  _ body: @noescape (UnsafePointer<A0>, UnsafePointer<A1>) throws -> Result
-) rethrows -> Result {
-  return try body(
-    UnsafePointer<A0>(Builtin.addressof(&arg0)),
-    UnsafePointer<A1>(Builtin.addressof(&arg1)))
-}
-
-/// Like `withUnsafePointer`, but passes pointers to `arg0`, `arg1`,
-/// and `arg2`.
-public func withUnsafePointers<A0, A1, A2, Result>(
-  _ arg0: inout A0,
-  _ arg1: inout A1,
-  _ arg2: inout A2,
-  _ body: @noescape (
-    UnsafePointer<A0>,
-    UnsafePointer<A1>,
-    UnsafePointer<A2>
-  ) throws -> Result
-) rethrows -> Result {
-  return try body(
-    UnsafePointer<A0>(Builtin.addressof(&arg0)),
-    UnsafePointer<A1>(Builtin.addressof(&arg1)),
-    UnsafePointer<A2>(Builtin.addressof(&arg2)))
 }

--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -60,7 +60,7 @@ public func _fixLifetime<T>(_ x: T) {
 /// result. Useful for calling Objective-C APIs that take "in/out"
 /// parameters (and default-constructible "out" parameters) by pointer.
 public func withUnsafeMutablePointer<T, Result>(
-  _ arg: inout T,
+  to arg: inout T,
   _ body: @noescape (UnsafeMutablePointer<T>) throws -> Result
 ) rethrows -> Result
 {
@@ -71,9 +71,27 @@ public func withUnsafeMutablePointer<T, Result>(
 /// result. Useful for calling Objective-C APIs that take "in/out"
 /// parameters (and default-constructible "out" parameters) by pointer.
 public func withUnsafePointer<T, Result>(
-  _ arg: inout T,
+  to arg: inout T,
   _ body: @noescape (UnsafePointer<T>) throws -> Result
 ) rethrows -> Result
 {
   return try body(UnsafePointer<T>(Builtin.addressof(&arg)))
+}
+
+@available(*, unavailable, renamed: "withUnsafeMutablePointer(to:_:)")
+public func withUnsafeMutablePointer<T, Result>(
+  _ arg: inout T,
+  _ body: @noescape (UnsafeMutablePointer<T>) throws -> Result
+) rethrows -> Result
+{
+  Builtin.unreachable()
+}
+
+@available(*, unavailable, renamed: "withUnsafePointer(to:_:)")
+public func withUnsafePointer<T, Result>(
+  _ arg: inout T,
+  _ body: @noescape (UnsafePointer<T>) throws -> Result
+) rethrows -> Result
+{
+  Builtin.unreachable()
 }

--- a/stdlib/public/core/Runtime.swift.gyb
+++ b/stdlib/public/core/Runtime.swift.gyb
@@ -379,7 +379,7 @@ func _float${bits}ToString(_ value: Float${bits}, debug: Bool) -> String {
   _sanityCheck(sizeof(_Buffer72.self) == 72)
 
   var buffer = _Buffer32()
-  return withUnsafeMutablePointer(&buffer) {
+  return withUnsafeMutablePointer(to: &buffer) {
     (bufferPtr) in
     let bufferUTF8Ptr = UnsafeMutablePointer<UTF8.CodeUnit>(bufferPtr)
     let actualLength = _float${bits}ToStringImpl(bufferUTF8Ptr, 32, value, debug)
@@ -408,7 +408,7 @@ func _int64ToString(
 ) -> String {
   if radix >= 10 {
     var buffer = _Buffer32()
-    return withUnsafeMutablePointer(&buffer) {
+    return withUnsafeMutablePointer(to: &buffer) {
       (bufferPtr) in
       let bufferUTF8Ptr = UnsafeMutablePointer<UTF8.CodeUnit>(bufferPtr)
       let actualLength =
@@ -420,7 +420,7 @@ func _int64ToString(
     }
   } else {
     var buffer = _Buffer72()
-    return withUnsafeMutablePointer(&buffer) {
+    return withUnsafeMutablePointer(to: &buffer) {
       (bufferPtr) in
       let bufferUTF8Ptr = UnsafeMutablePointer<UTF8.CodeUnit>(bufferPtr)
       let actualLength =
@@ -445,7 +445,7 @@ func _uint64ToString(
 ) -> String {
   if radix >= 10 {
     var buffer = _Buffer32()
-    return withUnsafeMutablePointer(&buffer) {
+    return withUnsafeMutablePointer(to: &buffer) {
       (bufferPtr) in
       let bufferUTF8Ptr = UnsafeMutablePointer<UTF8.CodeUnit>(bufferPtr)
       let actualLength =
@@ -457,7 +457,7 @@ func _uint64ToString(
     }
   } else {
     var buffer = _Buffer72()
-    return withUnsafeMutablePointer(&buffer) {
+    return withUnsafeMutablePointer(to: &buffer) {
       (bufferPtr) in
       let bufferUTF8Ptr = UnsafeMutablePointer<UTF8.CodeUnit>(bufferPtr)
       let actualLength =

--- a/stdlib/public/core/UnsafeRawPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawPointer.swift.gyb
@@ -405,7 +405,7 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
       "storeBytes to misaligned raw pointer")
 
     var temp = value
-    withUnsafeMutablePointer(&temp) { source in
+    withUnsafeMutablePointer(to: &temp) { source in
       let rawSrc = UnsafeMutableRawPointer(source)._rawValue
       // FIXME: to be replaced by _memcpy when conversions are implemented.
       Builtin.int_memcpy_RawPointer_RawPointer_Int64(

--- a/test/1_stdlib/AllocRounding.swift
+++ b/test/1_stdlib/AllocRounding.swift
@@ -15,7 +15,7 @@ func foo() -> UInt64 {
   var v0: UInt64 = 1
   var v1: UInt64 = 2
   var b: Bool = true
-  return withUnsafeMutablePointer(&buffer) { bufferPtr in 
+  return withUnsafeMutablePointer(to: &buffer) { bufferPtr in
     bufferPtr.pointee.x0 = 5
     bufferPtr.pointee.x1 = v0
     bufferPtr.pointee.x2 = v1

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -833,7 +833,7 @@ extension Foo23752537 {
 func read2(_ p: UnsafeMutableRawPointer, maxLength: Int) {}
 func read<T : Integer>() -> T? {
   var buffer : T 
-  let n = withUnsafePointer(&buffer) { (p) in
+  let n = withUnsafePointer(to: &buffer) { (p) in
     read2(UnsafePointer(p), maxLength: sizeof(T)) // expected-error {{cannot convert value of type 'UnsafePointer<_>' to expected argument type 'UnsafeMutableRawPointer'}}
   }
 }

--- a/validation-test/stdlib/CUUID.swift
+++ b/validation-test/stdlib/CUUID.swift
@@ -12,7 +12,7 @@ var CUUIDTestSuite = TestSuite("CUUID")
 /// Generates a random UUID
 CUUIDTestSuite.test("uuid") {
   var uuid: uuid_t = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-  withUnsafeMutablePointer(&uuid) {
+  withUnsafeMutablePointer(to: &uuid) {
     uuid_generate_random(unsafeBitCast($0, to: UnsafeMutablePointer<UInt8>.self))
   }
 }

--- a/validation-test/stdlib/OpenCLSDKOverlay.swift
+++ b/validation-test/stdlib/OpenCLSDKOverlay.swift
@@ -131,7 +131,7 @@ tests.test("clSetKernelArgsListAPPLE") {
   program = KernelSource.withCString {
     (p: UnsafePointer<CChar>) -> cl_program in
     var s: UnsafePointer? = p
-    return withUnsafeMutablePointer(&s) {
+    return withUnsafeMutablePointer(to: &s) {
       return clCreateProgramWithSource(context, 1, $0, nil, &err)
     }
   }
@@ -186,9 +186,9 @@ tests.test("clSetKernelArgsListAPPLE") {
   // Set the arguments to our compute kernel
   //
   err = 0
-  err = withUnsafePointer(&input) {
-    inputPtr in withUnsafePointer(&output) {
-      outputPtr in withUnsafePointer(&count) {
+  err = withUnsafePointer(to: &input) {
+    inputPtr in withUnsafePointer(to: &output) {
+      outputPtr in withUnsafePointer(to: &count) {
         countPtr in
         clSetKernelArgsListAPPLE(
           kernel!, 3,

--- a/validation-test/stdlib/OpenCLSDKOverlay.swift
+++ b/validation-test/stdlib/OpenCLSDKOverlay.swift
@@ -186,13 +186,17 @@ tests.test("clSetKernelArgsListAPPLE") {
   // Set the arguments to our compute kernel
   //
   err = 0
-  err = withUnsafePointers(&input, &output, &count) {
-    inputPtr, outputPtr, countPtr in
-    clSetKernelArgsListAPPLE(
-      kernel!, 3,
-      0, sizeof(cl_mem.self), inputPtr,
-      1, sizeof(cl_mem.self), outputPtr,
-      2, sizeofValue(count), countPtr)
+  err = withUnsafePointer(&input) {
+    inputPtr in withUnsafePointer(&output) {
+      outputPtr in withUnsafePointer(&count) {
+        countPtr in
+        clSetKernelArgsListAPPLE(
+          kernel!, 3,
+          0, sizeof(cl_mem.self), inputPtr,
+          1, sizeof(cl_mem.self), outputPtr,
+          2, sizeofValue(count), countPtr)
+      }
+    }
   }
 
   


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

This PR implements the portion of SE-0127 related to the withUnsafe[Mutable]Pointer APIs. It adds a "to:" argument label and removes the 2- and 3-argument versions.
#### Resolved bug number: ([SR-1937](https://bugs.swift.org/browse/SR-1937))
