### PR TITLE
Migrate parts of the stdlib to UnsafeRawPointer.

### DIFF
--- a/stdlib/private/SwiftPrivate/SwiftPrivate.swift
+++ b/stdlib/private/SwiftPrivate/SwiftPrivate.swift
@@ -81,7 +81,8 @@ public func withArrayOfCStrings<R>(
 
   return argsBuffer.withUnsafeMutableBufferPointer {
     (argsBuffer) in
-    let ptr = UnsafeMutablePointer<CChar>(argsBuffer.baseAddress!)
+    let ptr = UnsafeMutableRawPointer(argsBuffer.baseAddress!).bindMemory(
+      to: CChar.self, capacity: argsBuffer.count)
     var cStrings: [UnsafeMutablePointer<CChar>?] = argsOffsets.map { ptr + $0 }
     cStrings[cStrings.count - 1] = nil
     return body(cStrings)

--- a/stdlib/public/SDK/GLKit/GLKit.swift.gyb
+++ b/stdlib/public/SDK/GLKit/GLKit.swift.gyb
@@ -34,7 +34,8 @@ vectorElementNames = [
 @inline(__always)
 public func _indexHomogeneousValue<TTT, T>(_ aggregate: UnsafePointer<TTT>,
                                            _ index: Int) -> T {
-  return UnsafePointer<T>(aggregate)[index]
+  return UnsafeRawPointer(aggregate).load(
+    fromByteOffset: index * strideof(T), as: T.self)
 }
 
 %{

--- a/stdlib/public/SDK/GLKit/GLKit.swift.gyb
+++ b/stdlib/public/SDK/GLKit/GLKit.swift.gyb
@@ -35,7 +35,7 @@ vectorElementNames = [
 public func _indexHomogeneousValue<TTT, T>(_ aggregate: UnsafePointer<TTT>,
                                            _ index: Int) -> T {
   return UnsafeRawPointer(aggregate).load(
-    fromByteOffset: index * strideof(T), as: T.self)
+    fromByteOffset: index * strideof(T.self), as: T.self)
 }
 
 %{

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -183,7 +183,7 @@ public struct Character :
     }
     else {
       if let native = s._core.nativeBuffer,
-         native.start == UnsafeMutablePointer(s._core._baseAddress!) {
+         native.start == s._core._baseAddress! {
         _representation = .large(native._storage)
         return
       }

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -265,11 +265,11 @@ internal func _stdlib_NSObject_isEqual(_ lhs: AnyObject, _ rhs: AnyObject) -> Bo
 /// Like `UnsafeMutablePointer<Unmanaged<AnyObject>>`, or `id
 /// __unsafe_unretained *` in Objective-C ARC.
 internal struct _UnmanagedAnyObjectArray {
-  /// Underlying pointer, Unmanaged to escape reference counting.
-  internal var value: UnsafeMutablePointer<Unmanaged<AnyObject>>
+  /// Underlying pointer.
+  internal var value: UnsafeMutableRawPointer
 
   internal init(_ up: UnsafeMutablePointer<AnyObject>) {
-    self.value = UnsafeMutablePointer(up)
+    self.value = UnsafeMutableRawPointer(up)
   }
 
   internal init?(_ up: UnsafeMutablePointer<AnyObject>?) {
@@ -279,10 +279,16 @@ internal struct _UnmanagedAnyObjectArray {
 
   internal subscript(i: Int) -> AnyObject {
     get {
-      return value[i].takeUnretainedValue()
+      let unmanaged = value.load(
+        fromByteOffset: i * strideof(AnyObject.self),
+        as: Unmanaged<AnyObject>.self)
+      return unmanaged.takeUnretainedValue()
     }
     nonmutating set(newValue) {
-      value[i] = Unmanaged.passUnretained(newValue)
+      let unmanaged = Unmanaged.passUnretained(newValue)
+      value.storeBytes(of: unmanaged,
+        toByteOffset: i * strideof(AnyObject.self),
+        as: Unmanaged<AnyObject>.self)
     }
   }
 }

--- a/stdlib/public/core/Runtime.swift.gyb
+++ b/stdlib/public/core/Runtime.swift.gyb
@@ -20,19 +20,21 @@ import SwiftShims
 // Atomics
 //===----------------------------------------------------------------------===//
 
+public typealias _PointerToPointer = UnsafeMutablePointer<UnsafeRawPointer?>
+
 @_transparent
 public // @testable
-func _stdlib_atomicCompareExchangeStrongPtrImpl(
-  object target: UnsafeMutablePointer<UnsafeMutableRawPointer?>,
-  expected: UnsafeMutablePointer<UnsafeMutableRawPointer?>,
-  desired: UnsafeMutableRawPointer?) -> Bool {
+func _stdlib_atomicCompareExchangeStrongPtr(
+  object target: _PointerToPointer,
+  expected: _PointerToPointer,
+  desired: UnsafeRawPointer?) -> Bool {
 
   // We use Builtin.Word here because Builtin.RawPointer can't be nil.
   let (oldValue, won) = Builtin.cmpxchg_seqcst_seqcst_Word(
     target._rawValue,
     UInt(bitPattern: expected.pointee)._builtinWordValue,
     UInt(bitPattern: desired)._builtinWordValue)
-  expected.pointee = UnsafeMutableRawPointer(bitPattern: Int(oldValue))
+  expected.pointee = UnsafeRawPointer(bitPattern: Int(oldValue))
   return Bool(won)
 }
 
@@ -70,12 +72,12 @@ func _stdlib_atomicCompareExchangeStrongPtr<T>(
   object target: UnsafeMutablePointer<UnsafeMutablePointer<T>${optional}>,
   expected: UnsafeMutablePointer<UnsafeMutablePointer<T>${optional}>,
   desired: UnsafeMutablePointer<T>${optional}) -> Bool {
-  return _stdlib_atomicCompareExchangeStrongPtrImpl(
-    object: UnsafeMutablePointer(target),
-    expected: UnsafeMutablePointer(expected),
-    desired: UnsafeMutablePointer(desired))
+  return _stdlib_atomicCompareExchangeStrongPtr(
+    object: unsafeBitCast(target, to: _PointerToPointer.self),
+    expected: unsafeBitCast(expected, to: _PointerToPointer.self),
+    desired: unsafeBitCast(desired, to: Optional<UnsafeRawPointer>.self))
 }
-% end
+% end # optional
 
 @_transparent
 @discardableResult
@@ -83,10 +85,10 @@ public // @testable
 func _stdlib_atomicInitializeARCRef(
   object target: UnsafeMutablePointer<AnyObject?>,
   desired: AnyObject) -> Bool {
-  var expected: UnsafeMutableRawPointer? = nil
+  var expected: UnsafeRawPointer? = nil
   let desiredPtr = Unmanaged.passRetained(desired).toOpaque()
-  let wonRace = _stdlib_atomicCompareExchangeStrongPtrImpl(
-    object: UnsafeMutablePointer(target),
+  let wonRace = _stdlib_atomicCompareExchangeStrongPtr(
+    object: unsafeBitCast(target, to: _PointerToPointer.self),
     expected: &expected,
     desired: desiredPtr)
   if !wonRace {

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -54,7 +54,7 @@ func _cocoaStringToSwiftString_NonASCII(
   let start = _stdlib_binary_CFStringGetCharactersPtr(cfImmutableValue)
 
   return String(_StringCore(
-    baseAddress: OpaquePointer(start),
+    baseAddress: start,
     count: length,
     elementShift: 1,
     hasCocoaBuffer: true,
@@ -81,7 +81,7 @@ internal func _cocoaStringToContiguous(
 
   _swift_stdlib_CFStringGetCharacters(
     source, _swift_shims_CFRange(location: startIndex, length: count), 
-    UnsafeMutablePointer<_swift_shims_UniChar>(buffer.start))
+    buffer.start.assumingMemoryBound(to: _swift_shims_UniChar.self))
   
   return buffer
 }
@@ -163,13 +163,13 @@ extension String {
 
     // start will hold the base pointer of contiguous storage, if it
     // is found.
-    var start: OpaquePointer?
+    var start: UnsafeMutableRawPointer?
     let isUTF16 = (nulTerminatedASCII == nil)
     if isUTF16 {
       let utf16Buf = _swift_stdlib_CFStringGetCharactersPtr(cfImmutableValue)
-      start = OpaquePointer(utf16Buf)
+      start = UnsafeMutableRawPointer(mutating: utf16Buf)
     } else {
-      start = OpaquePointer(nulTerminatedASCII)
+      start = UnsafeMutableRawPointer(mutating: nulTerminatedASCII)
     }
 
     self._core = _StringCore(

--- a/stdlib/public/core/StringBuffer.swift
+++ b/stdlib/public/core/StringBuffer.swift
@@ -19,7 +19,7 @@ struct _StringBufferIVars {
   }
 
   internal init(
-    _usedEnd: UnsafeMutablePointer<_RawByte>,
+    _usedEnd: UnsafeMutableRawPointer,
     byteCapacity: Int,
     elementWidth: Int
   ) {
@@ -31,7 +31,7 @@ struct _StringBufferIVars {
 
   // This stored property should be stored at offset zero.  We perform atomic
   // operations on it using _HeapBuffer's pointer.
-  var usedEnd: UnsafeMutablePointer<_RawByte>?
+  var usedEnd: UnsafeMutableRawPointer?
 
   var capacityAndElementShift: Int
   var byteCapacity: Int {
@@ -78,6 +78,14 @@ public struct _StringBuffer {
       _StringBufferIVars(_elementWidth: elementWidth),
       (capacity + capacityBump + divRound) >> divRound
     )
+    // This conditional branch should fold away during code gen.
+    if elementShift == 0 {
+      start.bindMemory(to: UTF8.CodeUnit.self, capacity: initialSize)
+    }
+    else {
+      start.bindMemory(to: UTF16.CodeUnit.self, capacity: initialSize)
+    }
+
     self.usedEnd = start + (initialSize << elementShift)
     _storage.value.capacityAndElementShift
       = ((_storage._capacity() - capacityBump) << 1) + elementShift
@@ -107,7 +115,7 @@ public struct _StringBuffer {
         elementWidth: isAscii ? 1 : 2)
 
     if isAscii {
-      var p = UnsafeMutablePointer<UTF8.CodeUnit>(result.start)
+      var p = result.start.assumingMemoryBound(to: UTF8.CodeUnit.self)
       let sink: (UTF32.CodeUnit) -> Void = {
         p.pointee = UTF8.CodeUnit($0)
         p += 1
@@ -137,12 +145,12 @@ public struct _StringBuffer {
 
   /// A pointer to the start of this buffer's data area.
   public // @testable
-  var start: UnsafeMutablePointer<_RawByte> {
-    return UnsafeMutablePointer(_storage.baseAddress)
+  var start: UnsafeMutableRawPointer {
+    return UnsafeMutableRawPointer(_storage.baseAddress)
   }
 
   /// A past-the-end pointer for this buffer's stored data.
-  var usedEnd: UnsafeMutablePointer<_RawByte> {
+  var usedEnd: UnsafeMutableRawPointer {
     get {
       return _storage.value.usedEnd!
     }
@@ -156,7 +164,7 @@ public struct _StringBuffer {
   }
 
   /// A past-the-end pointer for this buffer's available storage.
-  var capacityEnd: UnsafeMutablePointer<_RawByte> {
+  var capacityEnd: UnsafeMutableRawPointer {
     return start + _storage.value.byteCapacity
   }
 
@@ -181,11 +189,11 @@ public struct _StringBuffer {
   // two separate phases.  Operations with one-phase growth should use
   // "grow()," below.
   func hasCapacity(
-    _ cap: Int, forSubRange r: Range<UnsafePointer<_RawByte>>
+    _ cap: Int, forSubRange r: Range<UnsafeRawPointer>
   ) -> Bool {
     // The substring to be grown could be pointing in the middle of this
     // _StringBuffer.
-    let offset = (r.lowerBound - UnsafePointer(start)) >> elementShift
+    let offset = (r.lowerBound - UnsafeRawPointer(start)) >> elementShift
     return cap + offset <= capacity
   }
 
@@ -202,13 +210,14 @@ public struct _StringBuffer {
   @inline(__always)
   @discardableResult
   mutating func grow(
-    oldBounds bounds: Range<UnsafePointer<_RawByte>>, newUsedCount: Int
+    oldBounds bounds: Range<UnsafeRawPointer>, newUsedCount: Int
   ) -> Bool {
     var newUsedCount = newUsedCount
     // The substring to be grown could be pointing in the middle of this
     // _StringBuffer.  Adjust the size so that it covers the imaginary
     // substring from the start of the buffer to `oldUsedEnd`.
-    newUsedCount += (bounds.lowerBound - UnsafePointer(start)) >> elementShift
+    newUsedCount
+      += (bounds.lowerBound - UnsafeRawPointer(start)) >> elementShift
 
     if _slowPath(newUsedCount > capacity) {
       return false
@@ -230,11 +239,14 @@ public struct _StringBuffer {
     //  usedEnd = newUsedEnd
     //  return true
     // }
-    let usedEndPhysicalPtr =
-      UnsafeMutablePointer<UnsafeMutablePointer<_RawByte>>(_storage._value)
-    var expected = UnsafeMutablePointer<_RawByte>(bounds.upperBound)
+
+    // &StringBufferIVars.usedEnd
+    let usedEndPhysicalPtr = _PointerToPointer(_storage._value)
+    // Create a temp var to hold the exchanged `expected` value.
+    var expected : UnsafeRawPointer? = bounds.upperBound
     if _stdlib_atomicCompareExchangeStrongPtr(
-      object: usedEndPhysicalPtr, expected: &expected, desired: newUsedEnd) {
+      object: usedEndPhysicalPtr, expected: &expected,
+      desired: UnsafeRawPointer(newUsedEnd)) {
       return true
     }
 

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -43,8 +43,8 @@ extension _StringCore {
       var result: _UTF8Chunk = ~0 // Start with all bits set
 
       _memcpy(
-        dest: UnsafeMutablePointer(Builtin.addressof(&result)),
-        src: UnsafeMutablePointer(startASCII + i),
+        dest: UnsafeMutableRawPointer(Builtin.addressof(&result)),
+        src: startASCII + i,
         size: numericCast(utf16Count))
 
       // Convert the _UTF8Chunk into host endianness.

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -204,13 +204,15 @@ extension String {
             self._baseSet = true
           if _base.isASCII {
             self._ascii = true
-            self._asciiBase = UnsafeBufferPointer<UInt8>(
-              start: UnsafePointer(_base._baseAddress),
+            self._asciiBase = UnsafeBufferPointer(
+              start: _base._baseAddress?.assumingMemoryBound(
+                to: UTF8.CodeUnit.self),
               count: _base.count).makeIterator()
           } else {
             self._ascii = false
             self._base = UnsafeBufferPointer<UInt16>(
-              start: UnsafePointer(_base._baseAddress),
+              start: _base._baseAddress?.assumingMemoryBound(
+                to: UTF16.CodeUnit.self),
               count: _base.count).makeIterator()
           }
         } else {

--- a/stdlib/public/core/SwiftNativeNSArray.swift
+++ b/stdlib/public/core/SwiftNativeNSArray.swift
@@ -82,11 +82,12 @@ extension _SwiftNativeNSArrayWithContiguousStorage : _NSArrayCore {
 
       if objects.isEmpty { return }
 
-      // These objects are "returned" at +0, so treat them as values to
-      // avoid retains.
-      UnsafeMutablePointer<Int>(aBuffer).initialize(from: 
-        UnsafeMutablePointer(objects.baseAddress! + range.location),
-        count: range.length)
+      // These objects are "returned" at +0, so treat them as pointer values to
+      // avoid retains. Copy bytes via a raw pointer to circumvent reference
+      // counting while correctly aliasing with all other pointer types.
+      UnsafeMutableRawPointer(aBuffer).copyBytes(
+        from: objects.baseAddress! + range.location,
+        count: range.length * strideof(AnyObject.self))
     }
   }
 

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -629,16 +629,6 @@ extension UInt {
 }
 % end # for mutable
 
-/// A byte-sized thing that isn't designed to interoperate with
-/// any other types; it makes a decent parameter to
-/// `UnsafeMutablePointer<Pointee>` when you just want to do bytewise
-/// pointer arithmetic.
-@_fixed_layout
-public // @testable
-struct _RawByte {
-  let _inaccessible: UInt8
-}
-
 // ${'Local Variables'}:
 // eval: (read-only-mode 1)
 // End:

--- a/test/1_stdlib/NewString.swift
+++ b/test/1_stdlib/NewString.swift
@@ -37,8 +37,8 @@ func repr(_ x: _StringCore) -> String {
   if x.hasContiguousStorage {
     if let b = x.nativeBuffer {
     var offset = x.elementWidth == 2
-      ? UnsafeMutablePointer(b.start) - x.startUTF16
-      : UnsafeMutablePointer(b.start) - x.startASCII
+      ? b.start - UnsafeMutableRawPointer(x.startUTF16)
+      : b.start - UnsafeMutableRawPointer(x.startASCII)
       return "Contiguous(owner: "
       + "\(hexAddr(x._owner))[\(offset)...\(x.count + offset)]"
       + ", capacity = \(b.capacity))"

--- a/test/1_stdlib/NewStringAppending.swift
+++ b/test/1_stdlib/NewStringAppending.swift
@@ -39,8 +39,8 @@ func repr(_ x: _StringCore) -> String {
   if x.hasContiguousStorage {
     if let b = x.nativeBuffer {
     var offset = x.elementWidth == 2
-      ? UnsafeMutablePointer(b.start) - x.startUTF16
-      : UnsafeMutablePointer(b.start) - x.startASCII
+      ? b.start - UnsafeMutableRawPointer(x.startUTF16)
+      : b.start - UnsafeMutableRawPointer(x.startASCII)
       return "Contiguous(owner: "
       + "\(hexAddr(x._owner))[\(offset)...\(x.count + offset)]"
       + ", capacity = \(b.capacity))"


### PR DESCRIPTION
Required for SE-0107: UnsafeRawPointer.

This is necessary to implement the proposed UnsafePointer initializers.

Lots of changes to StringCore here.
