### PR TITLE
[Do not pull] [stdlib] SE-0132 renamings

### DIFF
--- a/benchmark/single-source/DropFirst.swift
+++ b/benchmark/single-source/DropFirst.swift
@@ -88,7 +88,7 @@ public func run_DropFirstCountableRange(_ N: Int) {
   let s = 0..<sequenceCount
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropFirst(dropCount) {
+    for element in s.removingPrefix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)
@@ -99,7 +99,7 @@ public func run_DropFirstSequence(_ N: Int) {
   let s = sequence(first: 0) { $0 < sequenceCount - 1 ? $0 &+ 1 : nil }
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropFirst(dropCount) {
+    for element in s.removingPrefix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)
@@ -110,7 +110,7 @@ public func run_DropFirstAnySequence(_ N: Int) {
   let s = AnySequence(sequence(first: 0) { $0 < sequenceCount - 1 ? $0 &+ 1 : nil })
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropFirst(dropCount) {
+    for element in s.removingPrefix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)
@@ -121,7 +121,7 @@ public func run_DropFirstAnySeqCntRange(_ N: Int) {
   let s = AnySequence(0..<sequenceCount)
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropFirst(dropCount) {
+    for element in s.removingPrefix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)
@@ -132,7 +132,7 @@ public func run_DropFirstAnySeqCRangeIter(_ N: Int) {
   let s = AnySequence((0..<sequenceCount).makeIterator())
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropFirst(dropCount) {
+    for element in s.removingPrefix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)
@@ -143,7 +143,7 @@ public func run_DropFirstAnyCollection(_ N: Int) {
   let s = AnyCollection(0..<sequenceCount)
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropFirst(dropCount) {
+    for element in s.removingPrefix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)
@@ -154,7 +154,7 @@ public func run_DropFirstArray(_ N: Int) {
   let s = Array(0..<sequenceCount)
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropFirst(dropCount) {
+    for element in s.removingPrefix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)
@@ -165,7 +165,7 @@ public func run_DropFirstCountableRangeLazy(_ N: Int) {
   let s = (0..<sequenceCount).lazy
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropFirst(dropCount) {
+    for element in s.removingPrefix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)
@@ -176,7 +176,7 @@ public func run_DropFirstSequenceLazy(_ N: Int) {
   let s = (sequence(first: 0) { $0 < sequenceCount - 1 ? $0 &+ 1 : nil }).lazy
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropFirst(dropCount) {
+    for element in s.removingPrefix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)
@@ -187,7 +187,7 @@ public func run_DropFirstAnySequenceLazy(_ N: Int) {
   let s = (AnySequence(sequence(first: 0) { $0 < sequenceCount - 1 ? $0 &+ 1 : nil })).lazy
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropFirst(dropCount) {
+    for element in s.removingPrefix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)
@@ -198,7 +198,7 @@ public func run_DropFirstAnySeqCntRangeLazy(_ N: Int) {
   let s = (AnySequence(0..<sequenceCount)).lazy
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropFirst(dropCount) {
+    for element in s.removingPrefix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)
@@ -209,7 +209,7 @@ public func run_DropFirstAnySeqCRangeIterLazy(_ N: Int) {
   let s = (AnySequence((0..<sequenceCount).makeIterator())).lazy
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropFirst(dropCount) {
+    for element in s.removingPrefix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)
@@ -220,7 +220,7 @@ public func run_DropFirstAnyCollectionLazy(_ N: Int) {
   let s = (AnyCollection(0..<sequenceCount)).lazy
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropFirst(dropCount) {
+    for element in s.removingPrefix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)
@@ -231,7 +231,7 @@ public func run_DropFirstArrayLazy(_ N: Int) {
   let s = (Array(0..<sequenceCount)).lazy
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropFirst(dropCount) {
+    for element in s.removingPrefix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)

--- a/benchmark/single-source/DropFirst.swift.gyb
+++ b/benchmark/single-source/DropFirst.swift.gyb
@@ -58,7 +58,7 @@ public func run_DropFirst${Name}(_ N: Int) {
   let s = ${Expr}
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropFirst(dropCount) {
+    for element in s.removingPrefix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)

--- a/benchmark/single-source/DropLast.swift
+++ b/benchmark/single-source/DropLast.swift
@@ -87,7 +87,7 @@ public func run_DropLastCountableRange(_ N: Int) {
   let s = 0..<sequenceCount
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropLast(dropCount) {
+    for element in s.removingSuffix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)
@@ -98,7 +98,7 @@ public func run_DropLastSequence(_ N: Int) {
   let s = sequence(first: 0) { $0 < sequenceCount - 1 ? $0 &+ 1 : nil }
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropLast(dropCount) {
+    for element in s.removingSuffix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)
@@ -109,7 +109,7 @@ public func run_DropLastAnySequence(_ N: Int) {
   let s = AnySequence(sequence(first: 0) { $0 < sequenceCount - 1 ? $0 &+ 1 : nil })
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropLast(dropCount) {
+    for element in s.removingSuffix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)
@@ -120,7 +120,7 @@ public func run_DropLastAnySeqCntRange(_ N: Int) {
   let s = AnySequence(0..<sequenceCount)
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropLast(dropCount) {
+    for element in s.removingSuffix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)
@@ -131,7 +131,7 @@ public func run_DropLastAnySeqCRangeIter(_ N: Int) {
   let s = AnySequence((0..<sequenceCount).makeIterator())
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropLast(dropCount) {
+    for element in s.removingSuffix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)
@@ -142,7 +142,7 @@ public func run_DropLastAnyCollection(_ N: Int) {
   let s = AnyCollection(0..<sequenceCount)
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropLast(dropCount) {
+    for element in s.removingSuffix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)
@@ -153,7 +153,7 @@ public func run_DropLastArray(_ N: Int) {
   let s = Array(0..<sequenceCount)
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropLast(dropCount) {
+    for element in s.removingSuffix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)
@@ -164,7 +164,7 @@ public func run_DropLastCountableRangeLazy(_ N: Int) {
   let s = (0..<sequenceCount).lazy
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropLast(dropCount) {
+    for element in s.removingSuffix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)
@@ -175,7 +175,7 @@ public func run_DropLastSequenceLazy(_ N: Int) {
   let s = (sequence(first: 0) { $0 < sequenceCount - 1 ? $0 &+ 1 : nil }).lazy
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropLast(dropCount) {
+    for element in s.removingSuffix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)
@@ -186,7 +186,7 @@ public func run_DropLastAnySequenceLazy(_ N: Int) {
   let s = (AnySequence(sequence(first: 0) { $0 < sequenceCount - 1 ? $0 &+ 1 : nil })).lazy
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropLast(dropCount) {
+    for element in s.removingSuffix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)
@@ -197,7 +197,7 @@ public func run_DropLastAnySeqCntRangeLazy(_ N: Int) {
   let s = (AnySequence(0..<sequenceCount)).lazy
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropLast(dropCount) {
+    for element in s.removingSuffix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)
@@ -208,7 +208,7 @@ public func run_DropLastAnySeqCRangeIterLazy(_ N: Int) {
   let s = (AnySequence((0..<sequenceCount).makeIterator())).lazy
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropLast(dropCount) {
+    for element in s.removingSuffix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)
@@ -219,7 +219,7 @@ public func run_DropLastAnyCollectionLazy(_ N: Int) {
   let s = (AnyCollection(0..<sequenceCount)).lazy
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropLast(dropCount) {
+    for element in s.removingSuffix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)
@@ -230,7 +230,7 @@ public func run_DropLastArrayLazy(_ N: Int) {
   let s = (Array(0..<sequenceCount)).lazy
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropLast(dropCount) {
+    for element in s.removingSuffix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)

--- a/benchmark/single-source/DropLast.swift.gyb
+++ b/benchmark/single-source/DropLast.swift.gyb
@@ -57,7 +57,7 @@ public func run_DropLast${Name}(_ N: Int) {
   let s = ${Expr}
   for _ in 1...20*N {
     var result = 0
-    for element in s.dropLast(dropCount) {
+    for element in s.removingSuffix(dropCount) {
       result += element
     }
     CheckResults(result == sumCount)

--- a/benchmark/single-source/StringEdits.swift
+++ b/benchmark/single-source/StringEdits.swift
@@ -39,19 +39,19 @@ func edits(_ word: String) -> Set<String> {
   
   for (left, right) in splits {
     // drop a character
-    result.append(left + right.dropFirst())
+    result.append(left + right.removingFirst())
     
     // transpose two characters
     if let fst = right.first {
-      let drop1 = right.dropFirst()
+      let drop1 = right.removingFirst()
       if let snd = drop1.first {
-        result.append(left + [snd,fst] + drop1.dropFirst())
+        result.append(left + [snd,fst] + drop1.removingFirst())
       }
     }
     
     // replace each character with another
     for letter in alphabet {
-      result.append(left + [letter] + right.dropFirst())
+      result.append(left + [letter] + right.removingFirst())
     }
     
     // insert rogue characters

--- a/benchmark/single-source/StringMatch.swift
+++ b/benchmark/single-source/StringMatch.swift
@@ -24,7 +24,7 @@ public let StringMatch = BenchmarkInfo(
 
 extension String {
   @inline(__always)
-  func dropFirst(_ n: Int = 1) -> String {
+  func removingPrefix(_ n: Int = 1) -> String {
     let startIndex = self.index(self.startIndex, offsetBy: n)
     return self[startIndex ..< self.endIndex]
   }
@@ -33,7 +33,7 @@ extension String {
 /* match: search for regexp anywhere in text */
 func match(regexp: String, text: String) -> Bool {
   if regexp.first == "^" {
-    return matchHere(regexp.dropFirst(), text)
+    return matchHere(regexp.removingFirst(), text)
   }
   
   var idx = text.startIndex
@@ -55,16 +55,16 @@ func matchHere(_ regexp: String, _ text: String) -> Bool {
     return true
   }
   
-  if let c = regexp.first, regexp.dropFirst().first == "*" {
-    return matchStar(c, regexp.dropFirst(2), text)
+  if let c = regexp.first, regexp.removingFirst().first == "*" {
+    return matchStar(c, regexp.removingPrefix(2), text)
   }
   
-  if regexp.first == "$" && regexp.dropFirst().isEmpty {
+  if regexp.first == "$" && regexp.removingFirst().isEmpty {
     return text.isEmpty
   }
   
   if let tc = text.first, let rc = regexp.first, rc == "." || tc == rc {
-    return matchHere(regexp.dropFirst(), text.dropFirst())
+    return matchHere(regexp.removingFirst(), text.removingFirst())
   }
   
   return false

--- a/benchmark/single-source/Substring.swift
+++ b/benchmark/single-source/Substring.swift
@@ -81,7 +81,7 @@ private func equivalentWithDistinctBuffers() -> (String, Substring) {
   s0 += "!"
   
   // These two should be equal but with distinct buffers, both refcounted.
-  let a = Substring(s0).dropFirst()
+  let a = Substring(s0).removingFirst()
   let b = String(a)
   return (b, a)
 }

--- a/benchmark/utils/ArgParse.swift
+++ b/benchmark/utils/ArgParse.swift
@@ -46,7 +46,7 @@ public func parseArgs(_ validOptions: [String]? = nil)
   for arg in CommandLine.arguments[1..<CommandLine.arguments.count] {
     // If the argument doesn't match the optional argument pattern. Add
     // it to the positional argument list and continue...
-    if passThroughArgs || !arg.starts(with: "-") {
+    if passThroughArgs || !arg.hasPrefix("-") {
       positionalArgs.append(arg)
       continue
     }

--- a/docs/StdlibRationales.rst
+++ b/docs/StdlibRationales.rst
@@ -135,7 +135,7 @@ The `remove*()` method family on collections
 --------------------------------------------
 
 Protocol extensions for ``RangeReplaceableCollectionType`` define
-``removeFirst(n: Int)`` and ``removeLast(n: Int)``.  These functions remove
+``removePrefix(n: Int)`` and ``removeSuffix(n: Int)``.  These functions remove
 exactly ``n`` elements; they don't clamp ``n`` to ``count`` or they could be
 masking bugs.
 
@@ -146,7 +146,7 @@ overloads have a precondition that the collection is not empty.  Another
 possible design would be that they don't have preconditions and return
 ``Element?``.  Doing so would make the overload set inconsistent: semantics of
 different overloads would be significantly different.  It would be surprising
-that ``myData.removeFirst()`` and ``myData.removeFirst(1)`` are not equivalent.
+that ``myData.removeFirst()`` and ``myData.removePrefix(1)`` are not equivalent.
 
 Lazy functions that operate on sequences and collections
 --------------------------------------------------------

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
@@ -903,13 +903,13 @@ extension TestSuite {
     }
 
     //===------------------------------------------------------------------===//
-    // dropFirst()
+    // removingPrefix()
     //===------------------------------------------------------------------===//
 
-    self.test("\(testNamePrefix).dropFirst/semantics") {
-      for test in dropFirstTests {
+    self.test("\(testNamePrefix).removingPrefix/semantics") {
+      for test in removingPrefixTests {
         let s = makeWrappedCollection(test.sequence.map(OpaqueValue.init))
-        let result = s.dropFirst(test.dropElements)
+        let result = s.removingPrefix(test.dropElements)
         expectEqualSequence(
           test.expected, result.map(extractValue).map { $0.value },
           stackTrace: SourceLocStack().with(test.loc))
@@ -917,13 +917,13 @@ extension TestSuite {
     }
 
     //===------------------------------------------------------------------===//
-    // dropLast()
+    // removingSuffix()
     //===------------------------------------------------------------------===//
 
-    self.test("\(testNamePrefix).dropLast/semantics") {
-      for test in dropLastTests {
+    self.test("\(testNamePrefix).removingSuffix/semantics") {
+      for test in removingSuffixTests {
         let s = makeWrappedCollection(test.sequence.map(OpaqueValue.init))
-        let result = s.dropLast(test.dropElements)
+        let result = s.removingSuffix(test.dropElements)
         expectEqualSequence(
           test.expected, result.map(extractValue).map { $0.value },
           stackTrace: SourceLocStack().with(test.loc))
@@ -1455,13 +1455,13 @@ extension TestSuite {
     }
 
     //===------------------------------------------------------------------===//
-    // dropLast()
+    // removingSuffix()
     //===------------------------------------------------------------------===//
 
-    self.test("\(testNamePrefix).dropLast/semantics") {
-      for test in dropLastTests {
+    self.test("\(testNamePrefix).removingSuffix/semantics") {
+      for test in removingSuffixTests {
         let s = makeWrappedCollection(test.sequence.map(OpaqueValue.init))
-        let result = s.dropLast(test.dropElements)
+        let result = s.removingSuffix(test.dropElements)
         expectEqualSequence(
           test.expected, result.map(extractValue).map { $0.value },
           stackTrace: SourceLocStack().with(test.loc))

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
@@ -76,7 +76,7 @@ public struct PrefixUpToTest {
   }
 }
 
-internal struct RemoveFirstNTest {
+internal struct RemovePrefixTest {
   let collection: [Int]
   let numberToRemove: Int
   let expectedCollection: [Int]
@@ -89,7 +89,7 @@ internal struct RemoveFirstNTest {
     self.collection = collection
     self.numberToRemove = numberToRemove
     self.expectedCollection = expectedCollection
-    self.loc = SourceLoc(file, line, comment: "removeFirst(n: Int) test data")
+    self.loc = SourceLoc(file, line, comment: "removePrefix(n: Int) test data")
   }
 }
 
@@ -262,43 +262,43 @@ public let suffixFromTests = [
   ),
 ]
 
-let removeFirstTests: [RemoveFirstNTest] = [
-  RemoveFirstNTest(
+let removePrefixTests: [RemovePrefixTest] = [
+  RemovePrefixTest(
     collection: [1010],
     numberToRemove: 0,
     expectedCollection: [1010]
   ),
-  RemoveFirstNTest(
+  RemovePrefixTest(
     collection: [1010],
     numberToRemove: 1,
     expectedCollection: []
   ),
-  RemoveFirstNTest(
+  RemovePrefixTest(
     collection: [1010, 2020, 3030, 4040, 5050],
     numberToRemove: 0,
     expectedCollection: [1010, 2020, 3030, 4040, 5050]
   ),
-  RemoveFirstNTest(
+  RemovePrefixTest(
     collection: [1010, 2020, 3030, 4040, 5050],
     numberToRemove: 1,
     expectedCollection: [2020, 3030, 4040, 5050]
   ),
-  RemoveFirstNTest(
+  RemovePrefixTest(
     collection: [1010, 2020, 3030, 4040, 5050],
     numberToRemove: 2,
     expectedCollection: [3030, 4040, 5050]
   ),
-  RemoveFirstNTest(
+  RemovePrefixTest(
     collection: [1010, 2020, 3030, 4040, 5050],
     numberToRemove: 3,
     expectedCollection: [4040, 5050]
   ),
-  RemoveFirstNTest(
+  RemovePrefixTest(
     collection: [1010, 2020, 3030, 4040, 5050],
     numberToRemove: 4,
     expectedCollection: [5050]
   ),
-  RemoveFirstNTest(
+  RemovePrefixTest(
     collection: [1010, 2020, 3030, 4040, 5050],
     numberToRemove: 5,
     expectedCollection: []
@@ -1032,7 +1032,7 @@ extension TestSuite {
     //===------------------------------------------------------------------===//
 
     self.test("\(testNamePrefix).removeFirst()/slice/semantics") {
-      for test in removeFirstTests.filter({ $0.numberToRemove == 1 }) {
+      for test in removePrefixTests.filter({ $0.numberToRemove == 1 }) {
         let c = makeWrappedCollection(test.collection.map(OpaqueValue.init))
         var slice = c[...]
         let survivingIndices = _allIndices(
@@ -1068,11 +1068,11 @@ extension TestSuite {
     }
 
     //===------------------------------------------------------------------===//
-    // removeFirst(n: Int)/slice
+    // removePrefix(n: Int)/slice
     //===------------------------------------------------------------------===//
 
-    self.test("\(testNamePrefix).removeFirst(n: Int)/slice/semantics") {
-      for test in removeFirstTests {
+    self.test("\(testNamePrefix).removePrefix(n: Int)/slice/semantics") {
+      for test in removePrefixTests {
         let c = makeWrappedCollection(test.collection.map(OpaqueValue.init))
         var slice = c[...]
         let survivingIndices = _allIndices(
@@ -1081,48 +1081,48 @@ extension TestSuite {
             slice.startIndex,
             offsetBy: numericCast(test.numberToRemove)) ..< slice.endIndex
         )
-        slice.removeFirst(test.numberToRemove)
+        slice.removePrefix(test.numberToRemove)
         expectEqualSequence(
           test.expectedCollection,
           slice.map { extractValue($0).value },
-          "removeFirst() shouldn't mutate the tail of the slice",
+          "removePrefix(_:) shouldn't mutate the tail of the slice",
           stackTrace: SourceLocStack().with(test.loc)
         )
         expectEqualSequence(
           test.expectedCollection,
           survivingIndices.map { extractValue(slice[$0]).value },
-          "removeFirst() shouldn't invalidate indices",
+          "removePrefix(_:) shouldn't invalidate indices",
           stackTrace: SourceLocStack().with(test.loc)
         )
         expectEqualSequence(
           test.collection,
           c.map { extractValue($0).value },
-          "removeFirst() shouldn't mutate the collection that was sliced",
+          "removePrefix(_:) shouldn't mutate the collection that was sliced",
           stackTrace: SourceLocStack().with(test.loc))
       }
     }
 
-    self.test("\(testNamePrefix).removeFirst(n: Int)/slice/empty/semantics") {
+    self.test("\(testNamePrefix).removePrefix(n: Int)/slice/empty/semantics") {
       let c = makeWrappedCollection(Array<OpaqueValue<Int>>())
       var slice = c[c.startIndex..<c.startIndex]
       expectCrashLater()
-      slice.removeFirst(1) // Should trap.
+      slice.removePrefix(1) // Should trap.
     }
 
     self.test(
-      "\(testNamePrefix).removeFirst(n: Int)/slice/removeNegative/semantics") {
+      "\(testNamePrefix).removePrefix(n: Int)/slice/removeNegative/semantics") {
       let c = makeWrappedCollection([1010, 2020].map(OpaqueValue.init))
       var slice = c[c.startIndex..<c.startIndex]
       expectCrashLater()
-      slice.removeFirst(-1) // Should trap.
+      slice.removePrefix(-1) // Should trap.
     }
 
     self.test(
-      "\(testNamePrefix).removeFirst(n: Int)/slice/removeTooMany/semantics") {
+      "\(testNamePrefix).removePrefix(n: Int)/slice/removeTooMany/semantics") {
       let c = makeWrappedCollection([1010, 2020].map(OpaqueValue.init))
       var slice = c[c.startIndex..<c.startIndex]
       expectCrashLater()
-      slice.removeFirst(3) // Should trap.
+      slice.removePrefix(3) // Should trap.
     }
 
     //===------------------------------------------------------------------===//
@@ -1131,7 +1131,7 @@ extension TestSuite {
 
     self.test("\(testNamePrefix).popFirst()/slice/semantics") {
       // This can just reuse the test data for removeFirst()
-      for test in removeFirstTests.filter({ $0.numberToRemove == 1 }) {
+      for test in removePrefixTests.filter({ $0.numberToRemove == 1 }) {
         let c = makeWrappedCollection(test.collection.map(OpaqueValue.init))
         var slice = c[...]
         let survivingIndices = _allIndices(
@@ -1227,7 +1227,7 @@ extension TestSuite {
     //===------------------------------------------------------------------===//
 
     self.test("\(testNamePrefix).removeLast()/slice/semantics") {
-      for test in removeLastTests.filter({ $0.numberToRemove == 1 }) {
+      for test in removeSuffixTests.filter({ $0.numberToRemove == 1 }) {
         let c = makeWrappedCollection(test.collection)
         var slice = c[...]
         let survivingIndices = _allIndices(
@@ -1268,11 +1268,11 @@ extension TestSuite {
     }
 
     //===------------------------------------------------------------------===//
-    // removeLast(n: Int)/slice
+    // removeSuffix(n: Int)/slice
     //===------------------------------------------------------------------===//
 
-    self.test("\(testNamePrefix).removeLast(n: Int)/slice/semantics") {
-      for test in removeLastTests {
+    self.test("\(testNamePrefix).removeSuffix(n: Int)/slice/semantics") {
+      for test in removeSuffixTests {
         let c = makeWrappedCollection(test.collection)
         var slice = c[...]
         let survivingIndices = _allIndices(
@@ -1281,50 +1281,50 @@ extension TestSuite {
             ..< slice.index(
                   slice.endIndex, offsetBy: numericCast(-test.numberToRemove))
         )
-        slice.removeLast(test.numberToRemove)
+        slice.removeSuffix(test.numberToRemove)
         expectEqualSequence(
           test.expectedCollection,
           slice.map { extractValue($0).value },
-          "removeLast() shouldn't mutate the head of the slice",
+          "removeSuffix(_:) shouldn't mutate the head of the slice",
           stackTrace: SourceLocStack().with(test.loc)
         )
         expectEqualSequence(
           test.expectedCollection,
           survivingIndices.map { extractValue(slice[$0]).value },
-          "removeLast() shouldn't invalidate indices",
+          "removeSuffix(_:) shouldn't invalidate indices",
           stackTrace: SourceLocStack().with(test.loc)
         )
         expectEqualSequence(
           test.collection.map { $0.value },
           c.map { extractValue($0).value },
-          "removeLast() shouldn't mutate the collection that was sliced",
+          "removeSuffix(_:) shouldn't mutate the collection that was sliced",
           stackTrace: SourceLocStack().with(test.loc))
       }
     }
 
-    self.test("\(testNamePrefix).removeLast(n: Int)/slice/empty/semantics") {
+    self.test("\(testNamePrefix).removeSuffix(n: Int)/slice/empty/semantics") {
       let c = makeWrappedCollection(Array<OpaqueValue<Int>>())
       var slice = c[c.startIndex..<c.startIndex]
       expectCrashLater()
-      slice.removeLast(1) // Should trap.
+      slice.removeSuffix(1) // Should trap.
     }
 
     self.test(
-      "\(testNamePrefix).removeLast(n: Int)/slice/removeNegative/semantics"
+      "\(testNamePrefix).removeSuffix(n: Int)/slice/removeNegative/semantics"
     ) {
       let c = makeWrappedCollection([1010, 2020].map(OpaqueValue.init))
       var slice = c[c.startIndex..<c.startIndex]
       expectCrashLater()
-      slice.removeLast(-1) // Should trap.
+      slice.removeSuffix(-1) // Should trap.
     }
 
     self.test(
-      "\(testNamePrefix).removeLast(n: Int)/slice/removeTooMany/semantics"
+      "\(testNamePrefix).removeSuffix(n: Int)/slice/removeTooMany/semantics"
     ) {
       let c = makeWrappedCollection([1010, 2020].map(OpaqueValue.init))
       var slice = c[c.startIndex..<c.startIndex]
       expectCrashLater()
-      slice.removeLast(3) // Should trap.
+      slice.removeSuffix(3) // Should trap.
     }
 
     //===------------------------------------------------------------------===//
@@ -1333,7 +1333,7 @@ extension TestSuite {
 
     self.test("\(testNamePrefix).popLast()/slice/semantics") {
       // This can just reuse the test data for removeLast()
-      for test in removeLastTests.filter({ $0.numberToRemove == 1 }) {
+      for test in removeSuffixTests.filter({ $0.numberToRemove == 1 }) {
         let c = makeWrappedCollection(test.collection)
         var slice = c[...]
         let survivingIndices = _allIndices(

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
@@ -827,13 +827,13 @@ extension TestSuite {
     }
 
     //===------------------------------------------------------------------===//
-    // index(of:)/index(where:)
+    // firstIndex(of:)/firstIndex(where:)
     //===------------------------------------------------------------------===//
 
-    self.test("\(testNamePrefix).index(of:)/semantics") {
+    self.test("\(testNamePrefix).firstIndex(of:)/semantics") {
       for test in findTests {
         let c = makeWrappedCollectionWithEquatableElement(test.sequence)
-        var result = c.index(of: wrapValueIntoEquatable(test.element))
+        var result = c.firstIndex(of: wrapValueIntoEquatable(test.element))
         expectType(
           Optional<CollectionWithEquatableElement.Index>.self,
           &result)
@@ -847,12 +847,12 @@ extension TestSuite {
       }
     }
 
-    self.test("\(testNamePrefix).index(where:)/semantics") {
+    self.test("\(testNamePrefix).firstIndex(where:)/semantics") {
       for test in findTests {
         let closureLifetimeTracker = LifetimeTracked(0)
         expectEqual(1, LifetimeTracked.instances)
         let c = makeWrappedCollectionWithEquatableElement(test.sequence)
-        let result = c.index {
+        let result = c.firstIndex {
           (candidate) in
           _blackHole(closureLifetimeTracker)
           return

--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
@@ -142,7 +142,7 @@ internal struct RemoveAtIndexTest {
   }
 }
 
-internal struct RemoveLastNTest {
+internal struct RemoveSuffixTest {
   let collection: [OpaqueValue<Int>]
   let numberToRemove: Int
   let expectedCollection: [Int]
@@ -155,7 +155,7 @@ internal struct RemoveLastNTest {
     self.collection = collection.map(OpaqueValue.init)
     self.numberToRemove = numberToRemove
     self.expectedCollection = expectedCollection
-    self.loc = SourceLoc(file, line, comment: "removeLast(n: Int) test data")
+    self.loc = SourceLoc(file, line, comment: "removeSuffix(n: Int) test data")
   }
 }
 
@@ -223,43 +223,43 @@ internal struct OperatorPlusTest {
   }
 }
 
-let removeLastTests: [RemoveLastNTest] = [
-  RemoveLastNTest(
+let removeSuffixTests: [RemoveSuffixTest] = [
+  RemoveSuffixTest(
     collection: [1010],
     numberToRemove: 0,
     expectedCollection: [1010]
   ),
-  RemoveLastNTest(
+  RemoveSuffixTest(
     collection: [1010],
     numberToRemove: 1,
     expectedCollection: []
   ),
-  RemoveLastNTest(
+  RemoveSuffixTest(
     collection: [1010, 2020, 3030, 4040, 5050],
     numberToRemove: 0,
     expectedCollection: [1010, 2020, 3030, 4040, 5050]
   ),
-  RemoveLastNTest(
+  RemoveSuffixTest(
     collection: [1010, 2020, 3030, 4040, 5050],
     numberToRemove: 1,
     expectedCollection: [1010, 2020, 3030, 4040]
   ),
-  RemoveLastNTest(
+  RemoveSuffixTest(
     collection: [1010, 2020, 3030, 4040, 5050],
     numberToRemove: 2,
     expectedCollection: [1010, 2020, 3030]
   ),
-  RemoveLastNTest(
+  RemoveSuffixTest(
     collection: [1010, 2020, 3030, 4040, 5050],
     numberToRemove: 3,
     expectedCollection: [1010, 2020]
   ),
-  RemoveLastNTest(
+  RemoveSuffixTest(
     collection: [1010, 2020, 3030, 4040, 5050],
     numberToRemove: 4,
     expectedCollection: [1010]
   ),
-  RemoveLastNTest(
+  RemoveSuffixTest(
     collection: [1010, 2020, 3030, 4040, 5050],
     numberToRemove: 5,
     expectedCollection: []
@@ -798,7 +798,7 @@ self.test("\(testNamePrefix).remove(at:)/semantics") {
 //===----------------------------------------------------------------------===//
 
 self.test("\(testNamePrefix).removeFirst()/semantics") {
-  for test in removeFirstTests.filter({ $0.numberToRemove == 1 }) {
+  for test in removePrefixTests.filter({ $0.numberToRemove == 1 }) {
     var c = makeWrappedCollection(test.collection.map(OpaqueValue.init))
     let removedElement = c.removeFirst()
     expectEqual(test.collection.first, extractValue(removedElement).value)
@@ -817,13 +817,13 @@ self.test("\(testNamePrefix).removeFirst()/empty/semantics") {
 }
 
 //===----------------------------------------------------------------------===//
-// removeFirst(n: Int)
+// removePrefix(n: Int)
 //===----------------------------------------------------------------------===//
 
-self.test("\(testNamePrefix).removeFirst(n: Int)/semantics") {
-  for test in removeFirstTests {
+self.test("\(testNamePrefix).removePrefix(n: Int)/semantics") {
+  for test in removePrefixTests {
     var c = makeWrappedCollection(test.collection.map(OpaqueValue.init))
-    c.removeFirst(test.numberToRemove)
+    c.removePrefix(test.numberToRemove)
     expectEqualSequence(
       test.expectedCollection,
       c.map { extractValue($0).value },
@@ -833,22 +833,22 @@ self.test("\(testNamePrefix).removeFirst(n: Int)/semantics") {
   }
 }
 
-self.test("\(testNamePrefix).removeFirst(n: Int)/empty/semantics") {
+self.test("\(testNamePrefix).removePrefix(n: Int)/empty/semantics") {
   var c = makeWrappedCollection(Array<OpaqueValue<Int>>())
   expectCrashLater()
-  c.removeFirst(1) // Should trap.
+  c.removePrefix(1) // Should trap.
 }
 
-self.test("\(testNamePrefix).removeFirst(n: Int)/removeNegative/semantics") {
+self.test("\(testNamePrefix).removePrefix(n: Int)/removeNegative/semantics") {
   var c = makeWrappedCollection([1010, 2020, 3030].map(OpaqueValue.init))
   expectCrashLater()
-  c.removeFirst(-1) // Should trap.
+  c.removePrefix(-1) // Should trap.
 }
 
-self.test("\(testNamePrefix).removeFirst(n: Int)/removeTooMany/semantics") {
+self.test("\(testNamePrefix).removePrefix(n: Int)/removeTooMany/semantics") {
   var c = makeWrappedCollection([1010, 2020, 3030].map(OpaqueValue.init))
   expectCrashLater()
-  c.removeFirst(5) // Should trap.
+  c.removePrefix(5) // Should trap.
 }
 
 //===----------------------------------------------------------------------===//
@@ -1222,7 +1222,7 @@ self.test("\(testNamePrefix).OperatorPlus") {
 //===----------------------------------------------------------------------===//
 
 self.test("\(testNamePrefix).removeLast()/whereIndexIsBidirectional/semantics") {
-  for test in removeLastTests.filter({ $0.numberToRemove == 1 }) {
+  for test in removeSuffixTests.filter({ $0.numberToRemove == 1 }) {
     var c = makeWrappedCollection(test.collection)
     let removedElement = c.removeLast()
     expectEqual(
@@ -1244,37 +1244,37 @@ self.test("\(testNamePrefix).removeLast()/whereIndexIsBidirectional/empty/semant
 }
 
 //===----------------------------------------------------------------------===//
-// removeLast(n: Int)
+// removeSuffix(n: Int)
 //===----------------------------------------------------------------------===//
 
-self.test("\(testNamePrefix).removeLast(n: Int)/whereIndexIsBidirectional/semantics") {
-  for test in removeLastTests {
+self.test("\(testNamePrefix).removeSuffix(n: Int)/whereIndexIsBidirectional/semantics") {
+  for test in removeSuffixTests {
     var c = makeWrappedCollection(test.collection)
-    c.removeLast(test.numberToRemove)
+    c.removeSuffix(test.numberToRemove)
     expectEqualSequence(
       test.expectedCollection,
       c.map { extractValue($0).value },
-      "removeLast() shouldn't mutate the head of the collection",
+      "removeSuffix(_:) shouldn't mutate the head of the collection",
       stackTrace: SourceLocStack().with(test.loc))
   }
 }
 
-self.test("\(testNamePrefix).removeLast(n: Int)/whereIndexIsBidirectional/empty/semantics") {
+self.test("\(testNamePrefix).removeSuffix(n: Int)/whereIndexIsBidirectional/empty/semantics") {
   var c = makeWrappedCollection([])
   expectCrashLater()
-  c.removeLast(1) // Should trap.
+  c.removeSuffix(1) // Should trap.
 }
 
-self.test("\(testNamePrefix).removeLast(n: Int)/whereIndexIsBidirectional/removeNegative/semantics") {
+self.test("\(testNamePrefix).removeSuffix(n: Int)/whereIndexIsBidirectional/removeNegative/semantics") {
   var c = makeWrappedCollection([1010, 2020].map(OpaqueValue.init))
   expectCrashLater()
-  c.removeLast(-1) // Should trap.
+  c.removeSuffix(-1) // Should trap.
 }
 
-self.test("\(testNamePrefix).removeLast(n: Int)/whereIndexIsBidirectional/removeTooMany/semantics") {
+self.test("\(testNamePrefix).removeSuffix(n: Int)/whereIndexIsBidirectional/removeTooMany/semantics") {
   var c = makeWrappedCollection([1010, 2020].map(OpaqueValue.init))
   expectCrashLater()
-  c.removeLast(3) // Should trap.
+  c.removeSuffix(3) // Should trap.
 }
 
 //===----------------------------------------------------------------------===//

--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableSliceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableSliceType.swift
@@ -69,7 +69,7 @@ extension TestSuite {
     //===------------------------------------------------------------------===//
 
     self.test("\(testNamePrefix).removeFirst()/semantics") {
-      for test in removeFirstTests.filter({ $0.numberToRemove == 1 }) {
+      for test in removePrefixTests.filter({ $0.numberToRemove == 1 }) {
         var c = makeWrappedCollection(test.collection.map(OpaqueValue.init))
         let survivingIndices = _allIndices(
           into: c,
@@ -98,49 +98,49 @@ extension TestSuite {
     }
 
     //===----------------------------------------------------------------------===//
-    // removeFirst(n: Int)
+    // removePrefix(n: Int)
     //===----------------------------------------------------------------------===//
 
-    self.test("\(testNamePrefix).removeFirst(n: Int)/semantics") {
-      for test in removeFirstTests {
+    self.test("\(testNamePrefix).removePrefix(n: Int)/semantics") {
+      for test in removePrefixTests {
         var c = makeWrappedCollection(test.collection.map(OpaqueValue.init))
         let survivingIndices = _allIndices(
           into: c,
           in: c.index(c.startIndex, offsetBy: numericCast(test.numberToRemove)) ..<
             c.endIndex
         )
-        c.removeFirst(test.numberToRemove)
+        c.removePrefix(test.numberToRemove)
         expectEqualSequence(
           test.expectedCollection,
           c.map { extractValue($0).value },
-          "removeFirst() shouldn't mutate the tail of the collection",
+          "removePrefix(_:) shouldn't mutate the tail of the collection",
           stackTrace: SourceLocStack().with(test.loc)
         )
         expectEqualSequence(
           test.expectedCollection,
           survivingIndices.map { extractValue(c[$0]).value },
-          "removeFirst() shouldn't invalidate indices",
+          "removePrefix(_:) shouldn't invalidate indices",
           stackTrace: SourceLocStack().with(test.loc)
         )
       }
     }
 
-    self.test("\(testNamePrefix).removeFirst(n: Int)/empty/semantics") {
+    self.test("\(testNamePrefix).removePrefix(n: Int)/empty/semantics") {
       var c = makeWrappedCollection(Array<OpaqueValue<Int>>())
       expectCrashLater()
-      c.removeFirst(1) // Should trap.
+      c.removePrefix(1) // Should trap.
     }
 
-    self.test("\(testNamePrefix).removeFirst(n: Int)/removeNegative/semantics") {
+    self.test("\(testNamePrefix).removePrefix(n: Int)/removeNegative/semantics") {
       var c = makeWrappedCollection([1010, 2020].map(OpaqueValue.init))
       expectCrashLater()
-      c.removeFirst(-1) // Should trap.
+      c.removePrefix(-1) // Should trap.
     }
 
-    self.test("\(testNamePrefix).removeFirst(n: Int)/removeTooMany/semantics") {
+    self.test("\(testNamePrefix).removePrefix(n: Int)/removeTooMany/semantics") {
       var c = makeWrappedCollection([1010, 2020].map(OpaqueValue.init))
       expectCrashLater()
-      c.removeFirst(3) // Should trap.
+      c.removePrefix(3) // Should trap.
     }
 
     //===----------------------------------------------------------------------===//
@@ -211,7 +211,7 @@ extension TestSuite {
     //===------------------------------------------------------------------===//
 
     self.test("\(testNamePrefix).removeLast()/semantics") {
-      for test in removeLastTests.filter({ $0.numberToRemove == 1 }) {
+      for test in removeSuffixTests.filter({ $0.numberToRemove == 1 }) {
         var c = makeWrappedCollection(test.collection)
         let survivingIndices = _allIndices(
           into: c,
@@ -242,49 +242,49 @@ extension TestSuite {
     }
 
     //===----------------------------------------------------------------------===//
-    // removeLast(n: Int)
+    // removeSuffix(n: Int)
     //===----------------------------------------------------------------------===//
 
-    self.test("\(testNamePrefix).removeLast(n: Int)/semantics") {
-      for test in removeLastTests {
+    self.test("\(testNamePrefix).removeSuffix(n: Int)/semantics") {
+      for test in removeSuffixTests {
         var c = makeWrappedCollection(test.collection)
         let survivingIndices = _allIndices(
           into: c,
           in: c.startIndex ..<
             c.index(c.endIndex, offsetBy: numericCast(-test.numberToRemove))
         )
-        c.removeLast(test.numberToRemove)
+        c.removeSuffix(test.numberToRemove)
         expectEqualSequence(
           test.expectedCollection,
           c.map { extractValue($0).value },
-          "removeLast() shouldn't mutate the head of the collection",
+          "removeSuffix(_:) shouldn't mutate the head of the collection",
           stackTrace: SourceLocStack().with(test.loc)
         )
         expectEqualSequence(
           test.expectedCollection,
           survivingIndices.map { extractValue(c[$0]).value },
-          "removeLast() shouldn't invalidate indices",
+          "removeSuffix(_:) shouldn't invalidate indices",
           stackTrace: SourceLocStack().with(test.loc)
         )
       }
     }
 
-    self.test("\(testNamePrefix).removeLast(n: Int)/empty/semantics") {
+    self.test("\(testNamePrefix).removeSuffix(n: Int)/empty/semantics") {
       var c = makeWrappedCollection(Array<OpaqueValue<Int>>())
       expectCrashLater()
-      c.removeLast(1) // Should trap.
+      c.removeSuffix(1) // Should trap.
     }
 
-    self.test("\(testNamePrefix).removeLast(n: Int)/removeNegative/semantics") {
+    self.test("\(testNamePrefix).removeSuffix(n: Int)/removeNegative/semantics") {
       var c = makeWrappedCollection([1010, 2020].map(OpaqueValue.init))
       expectCrashLater()
-      c.removeLast(-1) // Should trap.
+      c.removeSuffix(-1) // Should trap.
     }
 
-    self.test("\(testNamePrefix).removeLast(n: Int)/removeTooMany/semantics") {
+    self.test("\(testNamePrefix).removeSuffix(n: Int)/removeTooMany/semantics") {
       var c = makeWrappedCollection([1010, 2020].map(OpaqueValue.init))
       expectCrashLater()
-      c.removeLast(3) // Should trap.
+      c.removeSuffix(3) // Should trap.
     }
 
     //===----------------------------------------------------------------------===//

--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
@@ -1687,14 +1687,14 @@ self.test("\(testNamePrefix).removingSuffix/semantics/negative") {
 }
 
 //===----------------------------------------------------------------------===//
-// drop(while:)
+// removingPrefix(while:)
 //===----------------------------------------------------------------------===//
 
-self.test("\(testNamePrefix).drop(while:)/semantics").forEach(in: findTests) {
+self.test("\(testNamePrefix).removingPrefix(while:)/semantics").forEach(in: findTests) {
   test in
   let s = makeWrappedSequenceWithEquatableElement(test.sequence)
   let closureLifetimeTracker = LifetimeTracked(0)
-  let remainingSequence = s.drop {
+  let remainingSequence = s.removingPrefix {
     _blackHole(closureLifetimeTracker)
     return $0 != wrapValueIntoEquatable(test.element)
   }

--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
@@ -17,7 +17,7 @@ internal enum TestError : Error {
   case error2
 }
 
-public struct DropFirstTest {
+public struct RemovingPrefixTest {
   public var sequence: [Int]
   public let dropElements: Int
   public let expected: [Int]
@@ -28,11 +28,11 @@ public struct DropFirstTest {
     self.sequence = sequence
     self.dropElements = dropElements
     self.expected = expected
-    self.loc = SourceLoc(file, line, comment: "dropFirst() test data")
+    self.loc = SourceLoc(file, line, comment: "removingPrefix() test data")
   }
 }
 
-public struct DropLastTest {
+public struct RemovingSuffixTest {
   public var sequence: [Int]
   public let dropElements: Int
   public let expected: [Int]
@@ -43,7 +43,7 @@ public struct DropLastTest {
     self.sequence = sequence
     self.dropElements = dropElements
     self.expected = expected
-    self.loc = SourceLoc(file, line, comment: "dropLast() test data")
+    self.loc = SourceLoc(file, line, comment: "removingSuffix() test data")
   }
 }
 
@@ -680,66 +680,66 @@ public let flatMapToOptionalTests = [
 ]
 
 
-public let dropFirstTests = [
-  DropFirstTest(
+public let removingPrefixTests = [
+  RemovingPrefixTest(
     sequence: [],
     dropElements: 0,
     expected: []
   ),
-  DropFirstTest(
+  RemovingPrefixTest(
     sequence: [1010, 2020, 3030],
     dropElements: 1,
     expected: [2020, 3030]
   ),
-  DropFirstTest(
+  RemovingPrefixTest(
     sequence: [1010, 2020, 3030],
     dropElements: 2,
     expected: [3030]
   ),
-  DropFirstTest(
+  RemovingPrefixTest(
     sequence: [1010, 2020, 3030],
     dropElements: 3,
     expected: []
   ),
-  DropFirstTest(
+  RemovingPrefixTest(
     sequence: [1010, 2020, 3030],
     dropElements: 777,
     expected: []
   ),
-  DropFirstTest(
+  RemovingPrefixTest(
     sequence: [1010, 2020, 3030],
     dropElements: 0,
     expected: [1010, 2020, 3030]
   ),
 ]
 
-public let dropLastTests = [
-  DropLastTest(
+public let removingSuffixTests = [
+  RemovingSuffixTest(
     sequence: [],
     dropElements: 0,
     expected: []
   ),
-  DropLastTest(
+  RemovingSuffixTest(
     sequence: [1010, 2020, 3030],
     dropElements: 1,
     expected: [1010, 2020]
   ),
-  DropLastTest(
+  RemovingSuffixTest(
     sequence: [1010, 2020, 3030],
     dropElements: 2,
     expected: [1010]
   ),
-  DropLastTest(
+  RemovingSuffixTest(
     sequence: [1010, 2020, 3030],
     dropElements: 3,
     expected: []
   ),
-  DropLastTest(
+  RemovingSuffixTest(
     sequence: [1010, 2020, 3030],
     dropElements: 777,
     expected: []
   ),
-  DropLastTest(
+  RemovingSuffixTest(
     sequence: [1010, 2020, 3030],
     dropElements: 0,
     expected: [1010, 2020, 3030]
@@ -1592,28 +1592,28 @@ self.test("\(testNamePrefix).contains()/WhereElementIsEquatable/semantics") {
 }
 
 //===----------------------------------------------------------------------===//
-// dropFirst()
+// removingPrefix()
 //===----------------------------------------------------------------------===//
-self.test("\(testNamePrefix).dropFirst/semantics") {
-  for test in dropFirstTests {
+self.test("\(testNamePrefix).removingPrefix/semantics") {
+  for test in removingPrefixTests {
     let s = makeWrappedSequence(test.sequence.map(OpaqueValue.init))
-    let result = s.dropFirst(test.dropElements)
+    let result = s.removingPrefix(test.dropElements)
     expectEqualSequence(
       test.expected, result.map { extractValue($0).value },
       stackTrace: SourceLocStack().with(test.loc))
   }
 }
 
-self.test("\(testNamePrefix).dropFirst/semantics/equivalence") {
-  // Calling dropFirst(1) twice on a sequence should be the same as
-  // calling dropFirst(2) once on an equivalent sequence.
+self.test("\(testNamePrefix).removingPrefix/semantics/equivalence") {
+  // Calling removingPrefix(1) twice on a sequence should be the same as
+  // calling removingPrefix(2) once on an equivalent sequence.
   if true {
     let s1 = makeWrappedSequence([1010, 2020, 3030, 4040].map(OpaqueValue.init))
     let s2 = makeWrappedSequence([1010, 2020, 3030, 4040].map(OpaqueValue.init))
 
-    let result0 = s1.dropFirst(1)
-    let result1 = result0.dropFirst(1)
-    let result2 = s2.dropFirst(2)
+    let result0 = s1.removingPrefix(1)
+    let result1 = result0.removingPrefix(1)
+    let result2 = s2.removingPrefix(2)
 
     expectEqualSequence(
       result1.map { extractValue($0).value },
@@ -1622,12 +1622,12 @@ self.test("\(testNamePrefix).dropFirst/semantics/equivalence") {
   }
 }
 
-self.test("\(testNamePrefix).dropFirst/semantics/dropFirst()==dropFirst(1)") {
+self.test("\(testNamePrefix).removingPrefix/semantics/removingFirst()==removingPrefix(1)") {
   let s1 = makeWrappedSequence([1010, 2020, 3030].map(OpaqueValue.init))
   let s2 = makeWrappedSequence([1010, 2020, 3030].map(OpaqueValue.init))
 
-  let result1 = s1.dropFirst()
-  let result2 = s2.dropFirst(1)
+  let result1 = s1.removingFirst()
+  let result2 = s2.removingPrefix(1)
 
   expectEqualSequence(
     result1.map { extractValue($0).value },
@@ -1635,44 +1635,44 @@ self.test("\(testNamePrefix).dropFirst/semantics/dropFirst()==dropFirst(1)") {
   )
 }
 
-self.test("\(testNamePrefix).dropFirst/semantics/negative") {
+self.test("\(testNamePrefix).removingPrefix/semantics/negative") {
   let s = makeWrappedSequence([1010, 2020, 3030].map(OpaqueValue.init))
   expectCrashLater()
-  _ = s.dropFirst(-1)
+  _ = s.removingPrefix(-1)
 }
 
 //===----------------------------------------------------------------------===//
-// dropLast()
+// removingSuffix()
 //===----------------------------------------------------------------------===//
 
-self.test("\(testNamePrefix).dropLast/semantics") {
-  for test in dropLastTests {
+self.test("\(testNamePrefix).removingSuffix/semantics") {
+  for test in removingSuffixTests {
     let s = makeWrappedSequence(test.sequence.map(OpaqueValue.init))
-    let result = s.dropLast(test.dropElements)
+    let result = s.removingSuffix(test.dropElements)
     expectEqualSequence(test.expected, result.map { extractValue($0).value },
       stackTrace: SourceLocStack().with(test.loc))
   }
 }
 
-self.test("\(testNamePrefix).dropLast/semantics/equivalence") {
-  // Calling `dropLast(2)` twice on a sequence is equivalent to calling
-  // `dropLast(4)` once.
+self.test("\(testNamePrefix).removingSuffix/semantics/equivalence") {
+  // Calling `removingSuffix(2)` twice on a sequence is equivalent to calling
+  // `removingSuffix(4)` once.
   if true {
     let s1 = makeWrappedSequence(
       [1010, 2020, 3030, 4040, 5050].map(OpaqueValue.init))
     let s2 = makeWrappedSequence(
       [1010, 2020, 3030, 4040, 5050].map(OpaqueValue.init))
 
-    let droppedOnce = s1.dropLast(4)
+    let droppedOnce = s1.removingSuffix(4)
 
     // FIXME: this line should read:
     //
-    //   let droppedTwice_ = s2.dropLast(2).dropLast(2)
+    //   let droppedTwice_ = s2.removingSuffix(2).removingSuffix(2)
     //
     // We can change it when we have real default implementations in protocols
     // that don't affect regular name lookup.
-    let droppedTwice_ = s2.dropLast(2)
-    let droppedTwice = droppedTwice_.dropLast(2)
+    let droppedTwice_ = s2.removingSuffix(2)
+    let droppedTwice = droppedTwice_.removingSuffix(2)
 
     expectEqualSequence(droppedOnce, droppedTwice) {
       extractValue($0).value == extractValue($1).value
@@ -1680,10 +1680,10 @@ self.test("\(testNamePrefix).dropLast/semantics/equivalence") {
   }
 }
 
-self.test("\(testNamePrefix).dropLast/semantics/negative") {
+self.test("\(testNamePrefix).removingSuffix/semantics/negative") {
   let s = makeWrappedSequence([1010, 2020, 3030].map(OpaqueValue.init))
   expectCrashLater()
-  _ = s.dropLast(-1)
+  _ = s.removingSuffix(-1)
 }
 
 //===----------------------------------------------------------------------===//

--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
@@ -389,7 +389,7 @@ public struct SplitTest {
   }
 }
 
-public struct StartsWithTest {
+public struct HasPrefixTest {
   public let expected: Bool
   public let sequence: [Int]
   public let prefix: [Int]
@@ -1410,30 +1410,30 @@ public let prefixTests = [
   ),
 ]
 
-public let startsWithTests = [
+public let hasPrefixTests = [
   // Corner cases.
-  StartsWithTest(true, [], [], [], []),
+  HasPrefixTest(true, [], [], [], []),
 
-  StartsWithTest(false, [], [ 1 ], [], []),
-  StartsWithTest(true, [ 1 ], [], [], []),
+  HasPrefixTest(false, [], [ 1 ], [], []),
+  HasPrefixTest(true, [ 1 ], [], [], []),
 
   // Equal sequences.
-  StartsWithTest(true, [ 1 ], [ 1 ], [], []),
-  StartsWithTest(true, [ 1, 2 ], [ 1, 2 ], [], []),
+  HasPrefixTest(true, [ 1 ], [ 1 ], [], []),
+  HasPrefixTest(true, [ 1, 2 ], [ 1, 2 ], [], []),
 
   // Proper prefix.
-  StartsWithTest(true, [ 0, 1, 2 ], [ 0, 1 ], [], []),
-  StartsWithTest(false, [ 0, 1 ], [ 0, 1, 2 ], [], []),
+  HasPrefixTest(true, [ 0, 1, 2 ], [ 0, 1 ], [], []),
+  HasPrefixTest(false, [ 0, 1 ], [ 0, 1, 2 ], [], []),
 
-  StartsWithTest(true, [ 1, 2, 3, 4 ], [ 1, 2 ], [ 4 ], []),
-  StartsWithTest(false, [ 1, 2 ], [ 1, 2, 3, 4 ], [], [ 4 ]),
+  HasPrefixTest(true, [ 1, 2, 3, 4 ], [ 1, 2 ], [ 4 ], []),
+  HasPrefixTest(false, [ 1, 2 ], [ 1, 2, 3, 4 ], [], [ 4 ]),
 
   // Not a prefix.
-  StartsWithTest(false, [ 1, 2, 3, 4 ], [ 1, 2, 10 ], [ 4 ], []),
-  StartsWithTest(false, [ 1, 2, 10 ], [ 1, 2, 3, 4 ], [], [ 4 ]),
+  HasPrefixTest(false, [ 1, 2, 3, 4 ], [ 1, 2, 10 ], [ 4 ], []),
+  HasPrefixTest(false, [ 1, 2, 10 ], [ 1, 2, 3, 4 ], [], [ 4 ]),
 
-  StartsWithTest(false, [ 1, 2, 3, 4, 10 ], [ 1, 2, 10 ], [ 4, 10 ], []),
-  StartsWithTest(false, [ 1, 2, 10 ], [ 1, 2, 3, 4, 10 ], [], [ 4, 10 ]),
+  HasPrefixTest(false, [ 1, 2, 3, 4, 10 ], [ 1, 2, 10 ], [ 4, 10 ], []),
+  HasPrefixTest(false, [ 1, 2, 10 ], [ 1, 2, 3, 4, 10 ], [], [ 4, 10 ]),
 ]
 
 

--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
@@ -82,8 +82,8 @@ public class SequenceLog {
   public static var map = TypeIndexed(0)
   public static var filter = TypeIndexed(0)
   public static var forEach = TypeIndexed(0)
-  public static var dropFirst = TypeIndexed(0)
-  public static var dropLast = TypeIndexed(0)
+  public static var removingPrefix = TypeIndexed(0)
+  public static var removingSuffix = TypeIndexed(0)
   public static var dropWhile = TypeIndexed(0)
   public static var prefixWhile = TypeIndexed(0)
   public static var prefixMaxLength = TypeIndexed(0)
@@ -248,14 +248,14 @@ public struct ${Self}<
 
   public typealias SubSequence = Base.SubSequence
 
-  public func dropFirst(_ n: Int) -> SubSequence {
-    Log.dropFirst[selfType] += 1
-    return base.dropFirst(n)
+  public func removingPrefix(_ n: Int) -> SubSequence {
+    Log.removingPrefix[selfType] += 1
+    return base.removingPrefix(n)
   }
 
-  public func dropLast(_ n: Int) -> SubSequence {
-    Log.dropLast[selfType] += 1
-    return base.dropLast(n)
+  public func removingSuffix(_ n: Int) -> SubSequence {
+    Log.removingSuffix[selfType] += 1
+    return base.removingSuffix(n)
   }
 
   public func drop(

--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
@@ -84,7 +84,7 @@ public class SequenceLog {
   public static var forEach = TypeIndexed(0)
   public static var removingPrefix = TypeIndexed(0)
   public static var removingSuffix = TypeIndexed(0)
-  public static var dropWhile = TypeIndexed(0)
+  public static var removingPrefixWhile = TypeIndexed(0)
   public static var prefixWhile = TypeIndexed(0)
   public static var prefixMaxLength = TypeIndexed(0)
   public static var suffixMaxLength = TypeIndexed(0)
@@ -258,11 +258,11 @@ public struct ${Self}<
     return base.removingSuffix(n)
   }
 
-  public func drop(
+  public func removingPrefix(
     while predicate: (Base.Iterator.Element) throws -> Bool
   ) rethrows -> SubSequence {
-    Log.dropWhile[selfType] += 1
-    return try base.drop(while: predicate)
+    Log.removingPrefixWhile[selfType] += 1
+    return try base.removingPrefix(while: predicate)
   }
 
   public func prefix(_ maxLength: Int) -> SubSequence {

--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
@@ -493,9 +493,9 @@ public struct ${Self}<
     return base._customRemoveLast()
   }
 
-  public mutating func _customRemoveLast(_ n: Int) -> Bool {
+  public mutating func _customRemoveSuffix(_ n: Int) -> Bool {
     Log._customRemoveLastN[selfType] += 1
-    return base._customRemoveLast(n)
+    return base._customRemoveSuffix(n)
   }
 
   public mutating func append(_ newElement: Base.Iterator.Element) {
@@ -541,9 +541,9 @@ public struct ${Self}<
     return base.removeFirst()
   }
 
-  public mutating func removeFirst(_ n: Int) {
+  public mutating func removePrefix(_ n: Int) {
     Log.removeFirstN[selfType] += 1
-    base.removeFirst(n)
+    base.removePrefix(n)
   }
 
   public mutating func removeSubrange(_ bounds: Range<Index>) {

--- a/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
@@ -343,7 +343,7 @@ internal struct _CollectionStateTransition {
       transitions = Box<[_CollectionStateTransition]>([])
       _CollectionStateTransition._allTransitions[previousState] = transitions
     }
-    if let i = transitions!.value.index(where: { $0._operation == operation }) {
+    if let i = transitions!.value.firstIndex(where: { $0._operation == operation }) {
       self = transitions!.value[i]
       return
     }

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -99,7 +99,7 @@ public struct SourceLocStack {
   public func print() {
     let top = locs.first!
     Swift.print("check failed at \(top.file), line \(top.line)")
-    _printStackTrace(SourceLocStack(_locs: Array(locs.dropFirst())))
+    _printStackTrace(SourceLocStack(_locs: Array(locs.removingFirst())))
   }
 }
 

--- a/stdlib/private/SwiftPrivate/IO.swift
+++ b/stdlib/private/SwiftPrivate/IO.swift
@@ -25,7 +25,7 @@ public struct _FDInputStream {
 
   public mutating func getline() -> String? {
     if let newlineIndex =
-      _buffer[0..<_bufferUsed].index(of: UInt8(Unicode.Scalar("\n").value)) {
+      _buffer[0..<_bufferUsed].firstIndex(of: UInt8(Unicode.Scalar("\n").value)) {
       let result = String._fromWellFormedCodeUnitSequence(
         UTF8.self, input: _buffer[0..<newlineIndex])
       _buffer.removeSubrange(0...newlineIndex)

--- a/stdlib/public/SDK/Foundation/IndexPath.swift
+++ b/stdlib/public/SDK/Foundation/IndexPath.swift
@@ -52,7 +52,7 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
             }
         }
         
-        func dropLast() -> Storage {
+        func removingLast() -> Storage {
             switch self {
             case .empty:
                 return .empty
@@ -65,7 +65,7 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
                 case 3:
                     return .pair(indexes[0], indexes[1])
                 default:
-                    return .array(Array<Int>(indexes.dropLast()))
+                    return .array(Array<Int>(indexes.removingLast()))
                 }
             }
         }
@@ -563,8 +563,8 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
     }
     
     /// Return a new `IndexPath` containing all but the last element.
-    public func dropLast() -> IndexPath {
-        return IndexPath(storage: _indexes.dropLast())
+    public func removingLast() -> IndexPath {
+        return IndexPath(storage: _indexes.removingLast())
     }
     
     /// Append an `IndexPath` to `self`.

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -137,11 +137,11 @@ if True:
 /// tasked with finding the first two days with absences in the session. To
 /// find the indices of the two days in question, follow these steps:
 ///
-/// 1) Call `index(where:)` to find the index of the first element in the
+/// 1) Call `firstIndex(where:)` to find the index of the first element in the
 ///    `absences` array that is greater than zero.
 /// 2) Create a slice of the `absences` array starting after the index found in
 ///    step 1.
-/// 3) Call `index(where:)` again, this time on the slice created in step 2.
+/// 3) Call `firstIndex(where:)` again, this time on the slice created in step 2.
 ///    Where in some languages you might pass a starting index into an
 ///    `indexOf` method to find the second day, in Swift you perform the same
 ///    operation on a slice of the original array.
@@ -150,9 +150,9 @@ if True:
 ///
 /// Here's an implementation of those steps:
 ///
-///     if let i = absences.index(where: { $0 > 0 }) {                      // 1
+///     if let i = absences.firstIndex(where: { $0 > 0 }) {                 // 1
 ///         let absencesAfterFirst = absences[(i + 1)...]                   // 2
-///         if let j = absencesAfterFirst.index(where: { $0 > 0 }) {        // 3
+///         if let j = absencesAfterFirst.firstIndex(where: { $0 > 0 }) {   // 3
 ///             print("The first day with absences had \(absences[i]).")    // 4
 ///             print("The second day with absences had \(absences[j]).")
 ///         }
@@ -293,7 +293,7 @@ if True:
 /// You can replace an existing element with a new value by assigning the new
 /// value to the subscript.
 ///
-///     if let i = students.index(of: "Maxime") {
+///     if let i = students.firstIndex(of: "Maxime") {
 ///         students[i] = "Max"
 ///     }
 ///     // ["Ivy", "Jordell", "Liam", "Max", "Shakia"]
@@ -492,7 +492,7 @@ public struct ${Self}<Element>
   /// safe to use with `endIndex`. For example:
   ///
   ///     let numbers = [10, 20, 30, 40, 50]
-  ///     if let i = numbers.index(of: 30) {
+  ///     if let i = numbers.firstIndex(of: 30) {
   ///         print(numbers[i ..< numbers.endIndex])
   ///     }
   ///     // Prints "[30, 40, 50]"
@@ -727,7 +727,7 @@ public struct ${Self}<Element>
   ///     print(streetsSlice)
   ///     // Prints "["Channing", "Douglas", "Evarts"]"
   ///
-  ///     let i = streetsSlice.index(of: "Evarts")    // 4
+  ///     let i = streetsSlice.firstIndex(of: "Evarts")    // 4
   ///     print(streets[i!])
   ///     // Prints "Evarts"
   ///

--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -257,12 +257,18 @@ extension BidirectionalCollection where SubSequence == Self {
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the length
   ///   of the collection.
   @_inlineable // FIXME(sil-serialize-all)
-  public mutating func removeLast(_ n: Int) {
+  public mutating func removeSuffix(_ n: Int) {
     if n == 0 { return }
     _precondition(n >= 0, "Number of elements to remove should be non-negative")
     _precondition(count >= numericCast(n),
       "Can't remove more items from a collection than it contains")
     self = self[startIndex..<index(endIndex, offsetBy: numericCast(-n))]
+  }
+  
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removeSuffix(_:)")
+  @_inlineable
+  public mutating func removeLast(_ n: Int) {
+    removeSuffix(n)
   }
 }
 

--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -123,7 +123,7 @@ public protocol BidirectionalCollection : Collection
   ///     print(streetsSlice)
   ///     // Prints "["Channing", "Douglas", "Evarts"]"
   ///
-  ///     let index = streetsSlice.index(of: "Evarts")    // 4
+  ///     let index = streetsSlice.firstIndex(of: "Evarts")    // 4
   ///     print(streets[index!])
   ///     // Prints "Evarts"
   ///

--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -280,9 +280,9 @@ extension BidirectionalCollection {
   /// collection, the result is an empty subsequence.
   ///
   ///     let numbers = [1, 2, 3, 4, 5]
-  ///     print(numbers.dropLast(2))
+  ///     print(numbers.removingSuffix(2))
   ///     // Prints "[1, 2, 3]"
-  ///     print(numbers.dropLast(10))
+  ///     print(numbers.removingSuffix(10))
   ///     // Prints "[]"
   ///
   /// - Parameter n: The number of elements to drop off the end of the
@@ -291,7 +291,7 @@ extension BidirectionalCollection {
   ///
   /// - Complexity: O(*n*), where *n* is the number of elements to drop.
   @_inlineable // FIXME(sil-serialize-all)
-  public func dropLast(_ n: Int) -> SubSequence {
+  public func removingSuffix(_ n: Int) -> SubSequence {
     _precondition(
       n >= 0, "Can't drop a negative number of elements from a collection")
     let end = index(
@@ -299,6 +299,12 @@ extension BidirectionalCollection {
       offsetBy: numericCast(-n),
       limitedBy: startIndex) ?? startIndex
     return self[startIndex..<end]
+  }
+  
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingSuffix(_:)")
+  @_inlineable // FIXME(sil-serialize-all)
+  public func dropLast(_ n: Int) -> SubSequence {
+    return removingSuffix(n)
   }
 
   /// Returns a subsequence, up to the given maximum length, containing the

--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -335,11 +335,3 @@ extension BidirectionalCollection where SubSequence == Self {
     removeSuffix(n)
   }
 }
-
-extension BidirectionalCollection {
-  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingSuffix(_:)")
-  @_inlineable // FIXME(sil-serialize-all)
-  public func dropLast(_ n: Int) -> SubSequence {
-    return removingSuffix(n)
-  }
-}

--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -264,12 +264,6 @@ extension BidirectionalCollection where SubSequence == Self {
       "Can't remove more items from a collection than it contains")
     self = self[startIndex..<index(endIndex, offsetBy: numericCast(-n))]
   }
-  
-  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removeSuffix(_:)")
-  @_inlineable
-  public mutating func removeLast(_ n: Int) {
-    removeSuffix(n)
-  }
 }
 
 extension BidirectionalCollection {
@@ -301,12 +295,6 @@ extension BidirectionalCollection {
     return self[startIndex..<end]
   }
   
-  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingSuffix(_:)")
-  @_inlineable // FIXME(sil-serialize-all)
-  public func dropLast(_ n: Int) -> SubSequence {
-    return removingSuffix(n)
-  }
-
   /// Returns a subsequence, up to the given maximum length, containing the
   /// final elements of the collection.
   ///
@@ -338,3 +326,20 @@ extension BidirectionalCollection {
   }
 }
 
+// Compatibility aliases for Swift 4 names (see SE-0132)
+
+extension BidirectionalCollection where SubSequence == Self {
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removeSuffix(_:)")
+  @_inlineable
+  public mutating func removeLast(_ n: Int) {
+    removeSuffix(n)
+  }
+}
+
+extension BidirectionalCollection {
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingSuffix(_:)")
+  @_inlineable // FIXME(sil-serialize-all)
+  public func dropLast(_ n: Int) -> SubSequence {
+    return removingSuffix(n)
+  }
+}

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1260,12 +1260,6 @@ extension Collection {
     return self[start..<endIndex]
   }
     
-  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingPrefix(_:)")
-  @_inlineable
-  public func dropFirst(_ n: Int) -> SubSequence {
-    return removingPrefix(n)
-  }
-
   /// Returns a subsequence containing all but the specified number of final
   /// elements.
   ///
@@ -1294,12 +1288,6 @@ extension Collection {
     return self[startIndex..<end]
   }
   
-  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingSuffix(_:)")
-  @_inlineable
-  public func dropLast(_ n: Int) -> SubSequence {
-    return removingSuffix(n)
-  }
-  
   /// Returns a subsequence by skipping elements while `predicate` returns
   /// `true` and returning the remaining elements.
   ///
@@ -1320,14 +1308,6 @@ extension Collection {
     return self[start..<endIndex]
   }
   
-  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingPrefix(while:)")
-  @_inlineable
-  public func drop(
-    while predicate: (Element) throws -> Bool
-  ) rethrows -> SubSequence {
-    return try removingPrefix(while: predicate)
-  }
-
   /// Returns a subsequence, up to the specified maximum length, containing
   /// the initial elements of the collection.
   ///
@@ -1724,4 +1704,36 @@ extension Collection {
 extension Collection {
   @available(swift, deprecated: 3.2, renamed: "Element")
   public typealias _Element = Element
+}
+
+// Compatibility aliases for Swift 4 names (see SE-0132)
+
+extension Collection {
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingPrefix(_:)")
+  @_inlineable
+  public func dropFirst(_ n: Int) -> SubSequence {
+    return removingPrefix(n)
+  }
+
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingSuffix(_:)")
+  @_inlineable
+  public func dropLast(_ n: Int) -> SubSequence {
+    return removingSuffix(n)
+  }
+  
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingPrefix(while:)")
+  @_inlineable
+  public func drop(
+    while predicate: (Element) throws -> Bool
+  ) rethrows -> SubSequence {
+    return try removingPrefix(while: predicate)
+  }
+}
+
+extension Collection where SubSequence == Self {
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removePrefix(_:)")
+  @_inlineable
+  public mutating func removeFirst(_ n: Int) {
+    return removePrefix(n)
+  }
 }

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1708,28 +1708,6 @@ extension Collection {
 
 // Compatibility aliases for Swift 4 names (see SE-0132)
 
-extension Collection {
-  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingPrefix(_:)")
-  @_inlineable
-  public func dropFirst(_ n: Int) -> SubSequence {
-    return removingPrefix(n)
-  }
-
-  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingSuffix(_:)")
-  @_inlineable
-  public func dropLast(_ n: Int) -> SubSequence {
-    return removingSuffix(n)
-  }
-  
-  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingPrefix(while:)")
-  @_inlineable
-  public func drop(
-    while predicate: (Element) throws -> Bool
-  ) rethrows -> SubSequence {
-    return try removingPrefix(while: predicate)
-  }
-}
-
 extension Collection where SubSequence == Self {
   @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removePrefix(_:)")
   @_inlineable

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1240,9 +1240,9 @@ extension Collection {
   /// the collection, the result is an empty subsequence.
   ///
   ///     let numbers = [1, 2, 3, 4, 5]
-  ///     print(numbers.dropFirst(2))
+  ///     print(numbers.removingPrefix(2))
   ///     // Prints "[3, 4, 5]"
-  ///     print(numbers.dropFirst(10))
+  ///     print(numbers.removingPrefix(10))
   ///     // Prints "[]"
   ///
   /// - Parameter n: The number of elements to drop from the beginning of
@@ -1253,11 +1253,17 @@ extension Collection {
   /// - Complexity: O(*n*), where *n* is the number of elements to drop from
   ///   the beginning of the collection.
   @_inlineable
-  public func dropFirst(_ n: Int) -> SubSequence {
+  public func removingPrefix(_ n: Int) -> SubSequence {
     _precondition(n >= 0, "Can't drop a negative number of elements from a collection")
     let start = index(startIndex,
       offsetBy: numericCast(n), limitedBy: endIndex) ?? endIndex
     return self[start..<endIndex]
+  }
+    
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingPrefix(_:)")
+  @_inlineable
+  public func dropFirst(_ n: Int) -> SubSequence {
+    return removingPrefix(n)
   }
 
   /// Returns a subsequence containing all but the specified number of final
@@ -1267,9 +1273,9 @@ extension Collection {
   /// collection, the result is an empty subsequence.
   ///
   ///     let numbers = [1, 2, 3, 4, 5]
-  ///     print(numbers.dropLast(2))
+  ///     print(numbers.removingSuffix(2))
   ///     // Prints "[1, 2, 3]"
-  ///     print(numbers.dropLast(10))
+  ///     print(numbers.removingSuffix(10))
   ///     // Prints "[]"
   ///
   /// - Parameter n: The number of elements to drop off the end of the
@@ -1279,13 +1285,19 @@ extension Collection {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   @_inlineable
-  public func dropLast(_ n: Int) -> SubSequence {
+  public func removingSuffix(_ n: Int) -> SubSequence {
     _precondition(
       n >= 0, "Can't drop a negative number of elements from a collection")
     let amount = Swift.max(0, numericCast(count) - n)
     let end = index(startIndex,
       offsetBy: numericCast(amount), limitedBy: endIndex) ?? endIndex
     return self[startIndex..<end]
+  }
+  
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingSuffix(_:)")
+  @_inlineable
+  public func dropLast(_ n: Int) -> SubSequence {
+    return removingSuffix(n)
   }
   
   /// Returns a subsequence by skipping elements while `predicate` returns

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -158,7 +158,7 @@ public struct IndexingIterator<
 /// that position.
 ///
 ///     let text = "Buffalo buffalo buffalo buffalo."
-///     if let firstSpace = text.index(of: " ") {
+///     if let firstSpace = text.firstIndex(of: " ") {
 ///         print(text[..<firstSpace])
 ///     }
 ///     // Prints "Buffalo"
@@ -223,7 +223,7 @@ public struct IndexingIterator<
 /// You can retrieve the same slice using the string's ranged subscript, which
 /// takes a range expression.
 ///
-///     if let firstSpace = text.index(of: " ") {
+///     if let firstSpace = text.firstIndex(of: " ") {
 ///         print(text[..<firstSpace]
 ///         // Prints "Buffalo"
 ///     }
@@ -371,7 +371,7 @@ public protocol Collection : Sequence
   /// safe to use with `endIndex`. For example:
   ///
   ///     let numbers = [10, 20, 30, 40, 50]
-  ///     if let index = numbers.index(of: 30) {
+  ///     if let index = numbers.firstIndex(of: 30) {
   ///         print(numbers[index ..< numbers.endIndex])
   ///     }
   ///     // Prints "[30, 40, 50]"
@@ -443,7 +443,7 @@ public protocol Collection : Sequence
   ///     print(streetsSlice)
   ///     // Prints "["Channing", "Douglas", "Evarts"]"
   ///
-  ///     let index = streetsSlice.index(of: "Evarts")    // 4
+  ///     let index = streetsSlice.firstIndex(of: "Evarts")    // 4
   ///     print(streets[index!])
   ///     // Prints "Evarts"
   ///
@@ -488,7 +488,7 @@ public protocol Collection : Sequence
   /// but not including, that index:
   ///
   ///     let numbers = [10, 20, 30, 40, 50, 60]
-  ///     if let i = numbers.index(of: 40) {
+  ///     if let i = numbers.firstIndex(of: 40) {
   ///         print(numbers.prefix(upTo: i))
   ///     }
   ///     // Prints "[10, 20, 30]"
@@ -503,7 +503,7 @@ public protocol Collection : Sequence
   /// half-open range as the collection's subscript. The subscript notation is
   /// preferred over `prefix(upTo:)`.
   ///
-  ///     if let i = numbers.index(of: 40) {
+  ///     if let i = numbers.firstIndex(of: 40) {
   ///         print(numbers[..<i])
   ///     }
   ///     // Prints "[10, 20, 30]"
@@ -523,7 +523,7 @@ public protocol Collection : Sequence
   /// that index:
   ///
   ///     let numbers = [10, 20, 30, 40, 50, 60]
-  ///     if let i = numbers.index(of: 40) {
+  ///     if let i = numbers.firstIndex(of: 40) {
   ///         print(numbers.suffix(from: i))
   ///     }
   ///     // Prints "[40, 50, 60]"
@@ -538,7 +538,7 @@ public protocol Collection : Sequence
   /// from the index as the collection's subscript. The subscript notation is
   /// preferred over `suffix(from:)`.
   ///
-  ///     if let i = numbers.index(of: 40) {
+  ///     if let i = numbers.firstIndex(of: 40) {
   ///         print(numbers[i...])
   ///     }
   ///     // Prints "[40, 50, 60]"
@@ -559,7 +559,7 @@ public protocol Collection : Sequence
   /// including, that index:
   ///
   ///     let numbers = [10, 20, 30, 40, 50, 60]
-  ///     if let i = numbers.index(of: 40) {
+  ///     if let i = numbers.firstIndex(of: 40) {
   ///         print(numbers.prefix(through: i))
   ///     }
   ///     // Prints "[10, 20, 30, 40]"
@@ -568,7 +568,7 @@ public protocol Collection : Sequence
   /// closed range as the collection's subscript. The subscript notation is
   /// preferred over `prefix(through:)`.
   ///
-  ///     if let i = numbers.index(of: 40) {
+  ///     if let i = numbers.firstIndex(of: 40) {
   ///         print(numbers[...i])
   ///     }
   ///     // Prints "[10, 20, 30, 40]"
@@ -612,7 +612,7 @@ public protocol Collection : Sequence
   ///   of the collection.
   var count: IndexDistance { get }
   
-  // The following requirement enables dispatching for index(of:) when
+  // The following requirement enables dispatching for firstIndex(of:) when
   // the element type is Equatable.
   /// Returns `Optional(Optional(index))` if an element was found
   /// or `Optional(nil)` if an element was determined to be missing;
@@ -1057,7 +1057,7 @@ extension Collection where SubSequence == Slice<Self> {
   ///     print(streetsSlice)
   ///     // Prints "["Channing", "Douglas", "Evarts"]"
   ///
-  ///     let index = streetsSlice.index(of: "Evarts")    // 4
+  ///     let index = streetsSlice.firstIndex(of: "Evarts")    // 4
   ///     print(streets[index!])
   ///     // Prints "Evarts"
   ///
@@ -1170,7 +1170,7 @@ extension Collection {
   }
 
   // TODO: swift-3-indexing-model - rename the following to _customIndexOfEquatable(element)?
-  /// Customization point for `Collection.index(of:)`.
+  /// Customization point for `Collection.firstIndex(of:)`.
   ///
   /// Define this method if the collection can find an element in less than
   /// O(*n*) by exploiting collection-specific knowledge.
@@ -1392,7 +1392,7 @@ extension Collection {
   /// but not including, that index:
   ///
   ///     let numbers = [10, 20, 30, 40, 50, 60]
-  ///     if let i = numbers.index(of: 40) {
+  ///     if let i = numbers.firstIndex(of: 40) {
   ///         print(numbers.prefix(upTo: i))
   ///     }
   ///     // Prints "[10, 20, 30]"
@@ -1407,7 +1407,7 @@ extension Collection {
   /// half-open range as the collection's subscript. The subscript notation is
   /// preferred over `prefix(upTo:)`.
   ///
-  ///     if let i = numbers.index(of: 40) {
+  ///     if let i = numbers.firstIndex(of: 40) {
   ///         print(numbers[..<i])
   ///     }
   ///     // Prints "[10, 20, 30]"
@@ -1430,7 +1430,7 @@ extension Collection {
   /// that index:
   ///
   ///     let numbers = [10, 20, 30, 40, 50, 60]
-  ///     if let i = numbers.index(of: 40) {
+  ///     if let i = numbers.firstIndex(of: 40) {
   ///         print(numbers.suffix(from: i))
   ///     }
   ///     // Prints "[40, 50, 60]"
@@ -1445,7 +1445,7 @@ extension Collection {
   /// from the index as the collection's subscript. The subscript notation is
   /// preferred over `suffix(from:)`.
   ///
-  ///     if let i = numbers.index(of: 40) {
+  ///     if let i = numbers.firstIndex(of: 40) {
   ///         print(numbers[i...])
   ///     }
   ///     // Prints "[40, 50, 60]"
@@ -1469,7 +1469,7 @@ extension Collection {
   /// including, that index:
   ///
   ///     let numbers = [10, 20, 30, 40, 50, 60]
-  ///     if let i = numbers.index(of: 40) {
+  ///     if let i = numbers.firstIndex(of: 40) {
   ///         print(numbers.prefix(through: i))
   ///     }
   ///     // Prints "[10, 20, 30, 40]"
@@ -1478,7 +1478,7 @@ extension Collection {
   /// closed range as the collection's subscript. The subscript notation is
   /// preferred over `prefix(through:)`.
   ///
-  ///     if let i = numbers.index(of: 40) {
+  ///     if let i = numbers.firstIndex(of: 40) {
   ///         print(numbers[...i])
   ///     }
   ///     // Prints "[10, 20, 30, 40]"

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1310,7 +1310,7 @@ extension Collection {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   @_inlineable
-  public func drop(
+  public func removingPrefix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> SubSequence {
     var start = startIndex
@@ -1318,6 +1318,14 @@ extension Collection {
       formIndex(after: &start)
     } 
     return self[start..<endIndex]
+  }
+  
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingPrefix(while:)")
+  @_inlineable
+  public func drop(
+    while predicate: (Element) throws -> Bool
+  ) rethrows -> SubSequence {
+    return try removingPrefix(while: predicate)
   }
 
   /// Returns a subsequence, up to the specified maximum length, containing

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1675,7 +1675,7 @@ extension Collection where SubSequence == Self {
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*).
   @_inlineable
-  public mutating func removeFirst(_ n: Int) {
+  public mutating func removePrefix(_ n: Int) {
     if n == 0 { return }
     _precondition(n >= 0, "Number of elements to remove should be non-negative")
     _precondition(count >= numericCast(n),

--- a/stdlib/public/core/CollectionAlgorithms.swift.gyb
+++ b/stdlib/public/core/CollectionAlgorithms.swift.gyb
@@ -68,12 +68,6 @@ extension Collection where Element : Equatable {
     }
     return nil
   }
-  
-  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "firstIndex(of:)")
-  @_inlineable
-  public func index(of element: Element) -> Index? {
-    return firstIndex(of: element)
-  }
 }
 
 extension Collection {
@@ -109,14 +103,6 @@ extension Collection {
       self.formIndex(after: &i)
     }
     return nil
-  }
-  
-  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "firstIndex(where:)")
-  @_inlineable
-  public func index(
-    where predicate: (Element) throws -> Bool
-  ) rethrows -> Index? {
-    return try firstIndex(where: predicate)
   }
 }
 
@@ -463,5 +449,25 @@ ${orderingExplanation}
         subRange: startIndex..<endIndex,
         by: areInIncreasingOrder)
     }
+  }
+}
+
+// Compatibility aliases for Swift 4 names (see SE-0132)
+
+extension Collection where Element : Equatable {
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "firstIndex(of:)")
+  @_inlineable
+  public func index(of element: Element) -> Index? {
+    return firstIndex(of: element)
+  }
+}
+  
+extension Collection {
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "firstIndex(where:)")
+  @_inlineable
+  public func index(
+    where predicate: (Element) throws -> Bool
+  ) rethrows -> Index? {
+    return try firstIndex(where: predicate)
   }
 }

--- a/stdlib/public/core/CollectionAlgorithms.swift.gyb
+++ b/stdlib/public/core/CollectionAlgorithms.swift.gyb
@@ -31,20 +31,20 @@ extension BidirectionalCollection {
 }
 
 //===----------------------------------------------------------------------===//
-// index(of:)/index(where:)
+// firstIndex(of:)/firstIndex(where:)
 //===----------------------------------------------------------------------===//
 
 extension Collection where Element : Equatable {
   /// Returns the first index where the specified value appears in the
   /// collection.
   ///
-  /// After using `index(of:)` to find the position of a particular element in
+  /// After using `firstIndex(of:)` to find the position of a particular element in
   /// a collection, you can use it to access the element by subscripting. This
   /// example shows how you can modify one of the names in an array of
   /// students.
   ///
   ///     var students = ["Ben", "Ivy", "Jordell", "Maxime"]
-  ///     if let i = students.index(of: "Maxime") {
+  ///     if let i = students.firstIndex(of: "Maxime") {
   ///         students[i] = "Max"
   ///     }
   ///     print(students)
@@ -54,7 +54,7 @@ extension Collection where Element : Equatable {
   /// - Returns: The first index where `element` is found. If `element` is not
   ///   found in the collection, returns `nil`.
   @_inlineable
-  public func index(of element: Element) -> Index? {
+  public func firstIndex(of element: Element) -> Index? {
     if let result = _customIndexOfEquatableElement(element) {
       return result
     }
@@ -68,6 +68,12 @@ extension Collection where Element : Equatable {
     }
     return nil
   }
+  
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "firstIndex(of:)")
+  @_inlineable
+  public func index(of element: Element) -> Index? {
+    return firstIndex(of: element)
+  }
 }
 
 extension Collection {
@@ -80,7 +86,7 @@ extension Collection {
   /// begins with the letter "A":
   ///
   ///     let students = ["Kofi", "Abena", "Peter", "Kweku", "Akosua"]
-  ///     if let i = students.index(where: { $0.hasPrefix("A") }) {
+  ///     if let i = students.firstIndex(where: { $0.hasPrefix("A") }) {
   ///         print("\(students[i]) starts with 'A'!")
   ///     }
   ///     // Prints "Abena starts with 'A'!"
@@ -92,7 +98,7 @@ extension Collection {
   ///   `true`. If no elements in the collection satisfy the given predicate,
   ///   returns `nil`.
   @_inlineable
-  public func index(
+  public func firstIndex(
     where predicate: (Element) throws -> Bool
   ) rethrows -> Index? {
     var i = self.startIndex
@@ -103,6 +109,14 @@ extension Collection {
       self.formIndex(after: &i)
     }
     return nil
+  }
+  
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "firstIndex(where:)")
+  @_inlineable
+  public func index(
+    where predicate: (Element) throws -> Bool
+  ) rethrows -> Index? {
+    return try firstIndex(where: predicate)
   }
 }
 

--- a/stdlib/public/core/DropWhile.swift.gyb
+++ b/stdlib/public/core/DropWhile.swift.gyb
@@ -1,4 +1,4 @@
-//===--- DropWhile.swift.gyb - Lazy views for drop(while:) ----*- swift -*-===//
+//===--- DropWhile.swift.gyb - Lazy views for removingPrefix(while:) ----*- swift -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -103,7 +103,7 @@ extension LazySequenceProtocol {
   ///   `false` otherwise. Once `predicate` returns `false` it will not be
   ///   called again.
   @_inlineable // FIXME(sil-serialize-all)
-  public func drop(
+  public func removingPrefix(
     while predicate: @escaping (Elements.Element) -> Bool
   ) -> LazyDropWhileSequence<Self.Elements> {
     return LazyDropWhileSequence(_base: self.elements, predicate: predicate)
@@ -231,7 +231,7 @@ Elements : ${Collection}
   ///   `false` otherwise. Once `predicate` returns `false` it will not be
   ///   called again.
   @_inlineable // FIXME(sil-serialize-all)
-  public func drop(
+  public func removingPrefix(
     while predicate: @escaping (Elements.Element) -> Bool
   ) -> LazyDropWhile${Collection}<Self.Elements> {
     return LazyDropWhile${Collection}(

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -274,13 +274,13 @@ internal class _AnyRandomAccessCollectionBox<Element>
 
   @_versioned
   @_inlineable
-  internal ${override} func _dropFirst(_ n: Int) -> _Any${Kind}Box<Element> {
+  internal ${override} func _removingPrefix(_ n: Int) -> _Any${Kind}Box<Element> {
     _abstract()
   }
 
   @_versioned
   @_inlineable
-  internal ${override} func _dropLast(_ n: Int) -> _Any${Kind}Box<Element> {
+  internal ${override} func _removingSuffix(_ n: Int) -> _Any${Kind}Box<Element> {
     _abstract()
   }
 
@@ -519,13 +519,13 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
   }
   @_versioned
   @_inlineable
-  internal override func _dropFirst(_ n: Int) -> _Any${Kind}Box<Element> {
-    return _${Kind}Box<S.SubSequence>(_base: _base.dropFirst(n))
+  internal override func _removingPrefix(_ n: Int) -> _Any${Kind}Box<Element> {
+    return _${Kind}Box<S.SubSequence>(_base: _base.removingPrefix(n))
   }
   @_versioned
   @_inlineable
-  internal override func _dropLast(_ n: Int) -> _Any${Kind}Box<Element> {
-    return _${Kind}Box<S.SubSequence>(_base: _base.dropLast(n))
+  internal override func _removingSuffix(_ n: Int) -> _Any${Kind}Box<Element> {
+    return _${Kind}Box<S.SubSequence>(_base: _base.removingSuffix(n))
   }
   @_versioned
   @_inlineable
@@ -824,13 +824,13 @@ extension Any${Kind} {
   }
 
   @_inlineable
-  public func dropFirst(_ n: Int) -> Any${Kind}<Element> {
-    return Any${Kind}(_box: _box._dropFirst(n))
+  public func removingPrefix(_ n: Int) -> Any${Kind}<Element> {
+    return Any${Kind}(_box: _box._removingPrefix(n))
   }
 
   @_inlineable
-  public func dropLast(_ n: Int) -> Any${Kind}<Element> {
-    return Any${Kind}(_box: _box._dropLast(n))
+  public func removingSuffix(_ n: Int) -> Any${Kind}<Element> {
+    return Any${Kind}(_box: _box._removingSuffix(n))
   }
 
   @_inlineable

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -266,7 +266,7 @@ internal class _AnyRandomAccessCollectionBox<Element>
 %   override = 'override' if Kind != 'Sequence' else ''
   @_versioned
   @_inlineable
-  internal ${override} func _drop(
+  internal ${override} func _removingPrefix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> _Any${Kind}Box<Element> {
     _abstract()
@@ -512,10 +512,10 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
   }
   @_versioned
   @_inlineable
-  internal override func _drop(
+  internal override func _removingPrefix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> _Any${Kind}Box<Element> {
-    return try _${Kind}Box<S.SubSequence>(_base: _base.drop(while: predicate))
+    return try _${Kind}Box<S.SubSequence>(_base: _base.removingPrefix(while: predicate))
   }
   @_versioned
   @_inlineable
@@ -817,10 +817,10 @@ extension Any${Kind} {
   }
 
   @_inlineable
-  public func drop(
+  public func removingPrefix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> Any${Kind}<Element> {
-    return try Any${Kind}(_box: _box._drop(while: predicate))
+    return try Any${Kind}(_box: _box._removingPrefix(while: predicate))
   }
 
   @_inlineable

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -568,12 +568,6 @@ public struct Set<Element : Hashable> :
     return _variantBuffer.index(forKey: member)
   }
   
-  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "firstIndex(of:)")
-  @_inlineable // FIXME(sil-serialize-all)
-  public func index(of member: Element) -> Index? {
-    return firstIndex(of: member)
-  }
-  
   /// Inserts the given element in the set if it is not already present.
   ///
   /// If an element equal to `newMember` is already contained in the set, this
@@ -6638,5 +6632,15 @@ extension Set {
         insert(member)
       }
     }
+  }
+}
+
+// Compatibility aliases for Swift 4 names (see SE-0132)
+
+extension Set {
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "firstIndex(of:)")
+  @_inlineable // FIXME(sil-serialize-all)
+  public func index(of member: Element) -> Index? {
+    return firstIndex(of: member)
   }
 }

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -564,10 +564,16 @@ public struct Set<Element : Hashable> :
   /// - Returns: The index of `member` if it exists in the set; otherwise,
   ///   `nil`.
   @_inlineable // FIXME(sil-serialize-all)
-  public func index(of member: Element) -> Index? {
+  public func firstIndex(of member: Element) -> Index? {
     return _variantBuffer.index(forKey: member)
   }
-
+  
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "firstIndex(of:)")
+  @_inlineable // FIXME(sil-serialize-all)
+  public func index(of member: Element) -> Index? {
+    return firstIndex(of: member)
+  }
+  
   /// Inserts the given element in the set if it is not already present.
   ///
   /// If an element equal to `newMember` is already contained in the set, this
@@ -1206,7 +1212,7 @@ public struct Set<Element : Hashable> :
   public func _customIndexOfEquatableElement(
      _ member: Element
     ) -> Index?? {
-    return Optional(index(of: member))
+    return Optional(firstIndex(of: member))
   }
 
   //
@@ -1660,7 +1666,7 @@ public func _setBridgeFromObjectiveCConditional<
 /// provides, see the `DictionaryLiteral` type for an alternative.
 ///
 /// You can search a dictionary's contents for a particular value using the
-/// `contains(where:)` or `index(where:)` methods supplied by default
+/// `contains(where:)` or `firstIndex(where:)` methods supplied by default
 /// implementation. The following example checks to see if `imagePaths` contains
 /// any paths in the `"/glyphs"` directory:
 ///
@@ -1951,10 +1957,10 @@ public struct Dictionary<Key : Hashable, Value> :
   /// this subscript with the resulting value.
   ///
   /// For example, to find the key for a particular value in a dictionary, use
-  /// the `index(where:)` method.
+  /// the `firstIndex(where:)` method.
   ///
   ///     let countryCodes = ["BR": "Brazil", "GH": "Ghana", "JP": "Japan"]
-  ///     if let index = countryCodes.index(where: { $0.value == "Japan" }) {
+  ///     if let index = countryCodes.firstIndex(where: { $0.value == "Japan" }) {
   ///         print(countryCodes[index])
   ///         print("Japan's country code is '\(countryCodes[index].key)'.")
   ///     } else {

--- a/stdlib/public/core/LazyCollection.swift.gyb
+++ b/stdlib/public/core/LazyCollection.swift.gyb
@@ -186,7 +186,7 @@ extension ${Self} : ${TraversalCollection} {
     return _base.count
   }
 
-  // The following requirement enables dispatching for index(of:) when
+  // The following requirement enables dispatching for firstIndex(of:) when
   // the element type is Equatable.
 
   /// Returns `Optional(Optional(index))` if an element was found;

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -446,7 +446,7 @@ extension Mirror {
   ///         i0 != children.endIndex
   ///     {
   ///         let grandChildren = Mirror(reflecting: children[i0].value).children
-  ///         if let i1 = grandChildren.index(where: { $0.label == "two" }) {
+  ///         if let i1 = grandChildren.firstIndex(where: { $0.label == "two" }) {
   ///             let greatGrandChildren =
   ///                 Mirror(reflecting: grandChildren[i1].value).children
   ///             if let i2 = greatGrandChildren.index(
@@ -811,11 +811,11 @@ public protocol _DefaultCustomPlaygroundQuickLookable {
 /// Some operations that are efficient on a dictionary are slower when using
 /// `DictionaryLiteral`. In particular, to find the value matching a key, you
 /// must search through every element of the collection. The call to
-/// `index(where:)` in the following example must traverse the whole
+/// `firstIndex(where:)` in the following example must traverse the whole
 /// collection to find the element that matches the predicate:
 ///
 ///     let runner = "Marlies Gohr"
-///     if let index = recordTimes.index(where: { $0.0 == runner }) {
+///     if let index = recordTimes.firstIndex(where: { $0.0 == runner }) {
 ///         let time = recordTimes[index].1
 ///         print("\(runner) set a 100m record of \(time) seconds.")
 ///     } else {

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -25,7 +25,7 @@ public typealias MutableIndexable = MutableCollection
 /// modify one of the names in an array of students.
 ///
 ///     var students = ["Ben", "Ivy", "Jordell", "Maxime"]
-///     if let i = students.index(of: "Maxime") {
+///     if let i = students.firstIndex(of: "Maxime") {
 ///         students[i] = "Max"
 ///     }
 ///     print(students)
@@ -110,7 +110,7 @@ public protocol MutableCollection : Collection
   ///     print(streetsSlice)
   ///     // Prints "["Channing", "Douglas", "Evarts"]"
   ///
-  ///     let index = streetsSlice.index(of: "Evarts")    // 4
+  ///     let index = streetsSlice.firstIndex(of: "Evarts")    // 4
   ///     streets[index!] = "Eustace"
   ///     print(streets[index!])
   ///     // Prints "Eustace"
@@ -209,7 +209,7 @@ extension MutableCollection {
   ///     print(streetsSlice)
   ///     // Prints "["Channing", "Douglas", "Evarts"]"
   ///
-  ///     let index = streetsSlice.index(of: "Evarts")    // 4
+  ///     let index = streetsSlice.firstIndex(of: "Evarts")    // 4
   ///     streets[index!] = "Eustace"
   ///     print(streets[index!])
   ///     // Prints "Eustace"

--- a/stdlib/public/core/RandomAccessCollection.swift
+++ b/stdlib/public/core/RandomAccessCollection.swift
@@ -90,7 +90,7 @@ public protocol RandomAccessCollection : BidirectionalCollection
   ///     print(streetsSlice)
   ///     // Prints "["Channing", "Douglas", "Evarts"]"
   ///
-  ///     let index = streetsSlice.index(of: "Evarts")    // 4
+  ///     let index = streetsSlice.firstIndex(of: "Evarts")    // 4
   ///     print(streets[index!])
   ///     // Prints "Evarts"
   ///
@@ -127,7 +127,7 @@ extension RandomAccessCollection where SubSequence == RandomAccessSlice<Self> {
   ///     print(streetsSlice)
   ///     // Prints "["Channing", "Douglas", "Evarts"]"
   ///
-  ///     let index = streetsSlice.index(of: "Evarts")    // 4
+  ///     let index = streetsSlice.firstIndex(of: "Evarts")    // 4
   ///     print(streets[index!])
   ///     // Prints "Evarts"
   ///

--- a/stdlib/public/core/Range.swift.gyb
+++ b/stdlib/public/core/Range.swift.gyb
@@ -970,7 +970,7 @@ public struct PartialRangeFrom<Bound: Comparable>: RangeExpression {
 /// do not use one with methods that read the entire sequence before
 /// returning, such as `map(_:)`, `filter(_:)`, or `suffix(_:)`. It is safe to
 /// use operations that put an upper limit on the number of elements they
-/// access, such as `prefix(_:)` or `dropFirst(_:)`, and operations that you
+/// access, such as `prefix(_:)` or `removingPrefix(_:)`, and operations that you
 /// can guarantee will terminate, such as passing a closure you know will
 /// eventually return `true` to `first(where:)`.
 ///
@@ -1168,7 +1168,7 @@ extension Strideable where Stride: SignedInteger {
   /// indefinitely, do not use one with methods such as `map(_:)`,
   /// `filter(_:)`, or `suffix(_:)` that read the entire sequence before
   /// returning. It is safe to use operations that put an upper limit on the
-  /// number of elements they access, such as `prefix(_:)` or `dropFirst(_:)`,
+  /// number of elements they access, such as `prefix(_:)` or `removingPrefix(_:)`,
   /// and operations that you can guarantee will terminate, such as passing a
   /// closure you know will eventually return `true` to `first(where:)`.
   ///

--- a/stdlib/public/core/RangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/RangeReplaceableCollection.swift.gyb
@@ -595,12 +595,6 @@ extension RangeReplaceableCollection {
     removeSubrange(startIndex..<end)
   }
   
-  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removePrefix(_:)")
-  @_inlineable
-  public mutating func removeFirst(_ n: Int) {
-      removePrefix(n)
-  }
-
   /// Removes and returns the first element of the collection.
   ///
   /// The collection must not be empty.
@@ -893,12 +887,6 @@ extension RangeReplaceableCollection where Self : BidirectionalCollection {
     let end = endIndex
     removeSubrange(index(end, offsetBy: numericCast(-n))..<end)
   }
-  
-  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removeSuffix(_:)")
-  @_inlineable
-  public mutating func removeLast(_ n: Int) {
-    removeSuffix(n)
-  }
 }
 
 // FIXME: swift-3-indexing-model: file a bug for the compiler?
@@ -955,12 +943,6 @@ extension RangeReplaceableCollection
     }
     let end = endIndex
     removeSubrange(index(end, offsetBy: numericCast(-n))..<end)
-  }
-  
-  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removeSuffix(_:)")
-  @_inlineable
-  public mutating func removeLast(_ n: Int) {
-    removeSuffix(n)
   }
 }
 
@@ -1098,5 +1080,35 @@ extension RangeReplaceableCollection {
     _ isIncluded: (Element) throws -> Bool
   ) rethrows -> Self {
     return try Self(self.lazy.filter(isIncluded))
+  }
+}
+
+// Compatibility aliases for Swift 4 names (see SE-0132)
+
+extension RangeReplaceableCollection {
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removePrefix(_:)")
+  @_inlineable
+  public mutating func removeFirst(_ n: Int) {
+      removePrefix(n)
+  }
+}
+
+extension RangeReplaceableCollection where Self : BidirectionalCollection {
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removeSuffix(_:)")
+  @_inlineable
+  public mutating func removeLast(_ n: Int) {
+    removeSuffix(n)
+  }
+}
+
+extension RangeReplaceableCollection
+  where
+  Self : BidirectionalCollection,
+  SubSequence == Self
+{
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removeSuffix(_:)")
+  @_inlineable
+  public mutating func removeLast(_ n: Int) {
+    removeSuffix(n)
   }
 }

--- a/stdlib/public/core/RangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/RangeReplaceableCollection.swift.gyb
@@ -298,11 +298,11 @@ public protocol RangeReplaceableCollection : Collection
   /// - Returns: A non-nil value if the operation was performed.
   mutating func _customRemoveLast() -> Element?
 
-  /// Customization point for `removeLast(_:)`.  Implement this function if you
+  /// Customization point for `removeSuffix(_:)`.  Implement this function if you
   /// want to replace the default implementation.
   ///
   /// - Returns: `true` if the operation was performed.
-  mutating func _customRemoveLast(_ n: Int) -> Bool
+  mutating func _customRemoveSuffix(_ n: Int) -> Bool
 
   /// Removes and returns the first element of the collection.
   ///
@@ -326,7 +326,7 @@ public protocol RangeReplaceableCollection : Collection
   /// collection.
   ///
   ///     var bugs = ["Aphid", "Bumblebee", "Cicada", "Damselfly", "Earwig"]
-  ///     bugs.removeFirst(3)
+  ///     bugs.removePrefix(3)
   ///     print(bugs)
   ///     // Prints "["Damselfly", "Earwig"]"
   ///
@@ -338,7 +338,7 @@ public protocol RangeReplaceableCollection : Collection
   ///   number of elements in the collection.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
-  mutating func removeFirst(_ n: Int)
+  mutating func removePrefix(_ n: Int)
 
   /// Removes all elements from the collection.
   ///
@@ -573,7 +573,7 @@ extension RangeReplaceableCollection {
   /// collection.
   ///
   ///     var bugs = ["Aphid", "Bumblebee", "Cicada", "Damselfly", "Earwig"]
-  ///     bugs.removeFirst(3)
+  ///     bugs.removePrefix(3)
   ///     print(bugs)
   ///     // Prints "["Damselfly", "Earwig"]"
   ///
@@ -586,13 +586,19 @@ extension RangeReplaceableCollection {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   @_inlineable
-  public mutating func removeFirst(_ n: Int) {
+  public mutating func removePrefix(_ n: Int) {
     if n == 0 { return }
     _precondition(n >= 0, "Number of elements to remove should be non-negative")
     _precondition(count >= numericCast(n),
       "Can't remove more items from a collection than it has")
     let end = index(startIndex, offsetBy: numericCast(n))
     removeSubrange(startIndex..<end)
+  }
+  
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removePrefix(_:)")
+  @_inlineable
+  public mutating func removeFirst(_ n: Int) {
+      removePrefix(n)
   }
 
   /// Removes and returns the first element of the collection.
@@ -616,7 +622,7 @@ extension RangeReplaceableCollection {
     _precondition(!isEmpty,
       "Can't remove first element from an empty collection")
     let firstElement = first!
-    removeFirst(1)
+    removePrefix(1)
     return firstElement
   }
 
@@ -727,7 +733,7 @@ extension RangeReplaceableCollection where SubSequence == Self {
   ///
   /// - Complexity: O(1)
   @_inlineable
-  public mutating func removeFirst(_ n: Int) {
+  public mutating func removePrefix(_ n: Int) {
     if n == 0 { return }
     _precondition(n >= 0, "Number of elements to remove should be non-negative")
     _precondition(count >= numericCast(n),
@@ -814,7 +820,7 @@ extension RangeReplaceableCollection {
   }
 
   @_inlineable
-  public mutating func _customRemoveLast(_ n: Int) -> Bool {
+  public mutating func _customRemoveSuffix(_ n: Int) -> Bool {
     return false
   }
 }
@@ -832,7 +838,7 @@ extension RangeReplaceableCollection
   }
 
   @_inlineable
-  public mutating func _customRemoveLast(_ n: Int) -> Bool {
+  public mutating func _customRemoveSuffix(_ n: Int) -> Bool {
     self = self[startIndex..<index(endIndex, offsetBy: numericCast(-n))]
     return true
   }
@@ -876,16 +882,22 @@ extension RangeReplaceableCollection where Self : BidirectionalCollection {
   ///
   /// - Complexity: O(*n*), where *n* is the specified number of elements.
   @_inlineable
-  public mutating func removeLast(_ n: Int) {
+  public mutating func removeSuffix(_ n: Int) {
     if n == 0 { return }
     _precondition(n >= 0, "Number of elements to remove should be non-negative")
     _precondition(count >= numericCast(n),
       "Can't remove more items from a collection than it contains")
-    if _customRemoveLast(n) {
+    if _customRemoveSuffix(n) {
       return
     }
     let end = endIndex
     removeSubrange(index(end, offsetBy: numericCast(-n))..<end)
+  }
+  
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removeSuffix(_:)")
+  @_inlineable
+  public mutating func removeLast(_ n: Int) {
+    removeSuffix(n)
   }
 }
 
@@ -933,16 +945,22 @@ extension RangeReplaceableCollection
   ///
   /// - Complexity: O(*n*), where *n* is the specified number of elements.
   @_inlineable
-  public mutating func removeLast(_ n: Int) {
+  public mutating func removeSuffix(_ n: Int) {
     if n == 0 { return }
     _precondition(n >= 0, "Number of elements to remove should be non-negative")
     _precondition(count >= numericCast(n),
       "Can't remove more items from a collection than it contains")
-    if _customRemoveLast(n) {
+    if _customRemoveSuffix(n) {
       return
     }
     let end = endIndex
     removeSubrange(index(end, offsetBy: numericCast(-n))..<end)
+  }
+  
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removeSuffix(_:)")
+  @_inlineable
+  public mutating func removeLast(_ n: Int) {
+    removeSuffix(n)
   }
 }
 

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -87,7 +87,7 @@ public struct ReversedIndex<Base : Collection> : Comparable {
   /// `"a"` character in a string's character view.
   ///
   ///     let name = "Horatio"
-  ///     let aIndex = name.index(of: "a")!
+  ///     let aIndex = name.firstIndex(of: "a")!
   ///     // name[aIndex] == "a"
   ///
   ///     let reversedName = name.reversed()
@@ -118,7 +118,7 @@ public struct ReversedIndex<Base : Collection> : Comparable {
   ///
   ///     func indexOfLastEven(_ numbers: [Int]) -> Int? {
   ///         let reversedNumbers = numbers.reversed()
-  ///         guard let i = reversedNumbers.index(where: { $0 % 2 == 0 })
+  ///         guard let i = reversedNumbers.firstIndex(where: { $0 % 2 == 0 })
   ///             else { return nil }
   ///
   ///         return numbers.index(before: i.base)
@@ -285,7 +285,7 @@ public struct ReversedRandomAccessIndex<
   /// index of the `"a"` character in a string's character view.
   ///
   ///     let name = "Horatio"
-  ///     let aIndex = name.index(of: "a")!
+  ///     let aIndex = name.firstIndex(of: "a")!
   ///     // name[aIndex] == "a"
   ///
   ///     let reversedName = name.reversed()
@@ -318,7 +318,7 @@ public struct ReversedRandomAccessIndex<
   ///
   ///     func indexOfLastEven(_ numbers: [Int]) -> Int? {
   ///         let reversedNumbers = numbers.reversed()
-  ///         guard let i = reversedNumbers.index(where: { $0 % 2 == 0 })
+  ///         guard let i = reversedNumbers.firstIndex(where: { $0 % 2 == 0 })
   ///             else { return nil }
   ///
   ///         return numbers.index(before: i.base)

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -468,7 +468,7 @@ public protocol Sequence {
   ///   whether the element is a match.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
-  func drop(
+  func removingPrefix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> SubSequence
 
@@ -785,7 +785,7 @@ internal struct _DropWhileSequence<Base : IteratorProtocol>
 
   @_versioned
   @_inlineable
-  internal func drop(
+  internal func removingPrefix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> AnySequence<Element> {
     // If this is already a _DropWhileSequence, avoid multiple
@@ -1271,13 +1271,13 @@ extension Sequence where SubSequence == AnySequence<Element> {
   /// Returns a subsequence by skipping the initial, consecutive elements that
   /// satisfy the given predicate.
   ///
-  /// The following example uses the `drop(while:)` method to skip over the
+  /// The following example uses the `removingPrefix(while:)` method to skip over the
   /// positive numbers at the beginning of the `numbers` array. The result
   /// begins with the first element of `numbers` that does not satisfy
   /// `predicate`.
   ///
   ///     let numbers = [3, 7, 4, -2, 9, -6, 10, 1]
-  ///     let startingWithNegative = numbers.drop(while: { $0 > 0 })
+  ///     let startingWithNegative = numbers.removingPrefix(while: { $0 > 0 })
   ///     // startingWithNegative == [-2, 9, -6, 10, 1]
   ///
   /// If `predicate` matches every element in the sequence, the result is an
@@ -1291,12 +1291,20 @@ extension Sequence where SubSequence == AnySequence<Element> {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   @_inlineable
-  public func drop(
+  public func removingPrefix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> AnySequence<Element> {
     return try AnySequence(
       _DropWhileSequence(
         iterator: makeIterator(), nextElement: nil, predicate: predicate))
+  }
+  
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingPrefix(while:)")
+  @_inlineable
+  public func drop(
+    while predicate: (Element) throws -> Bool
+  ) rethrows -> AnySequence<Element> {
+    return try removingPrefix(while: predicate)
   }
 
   /// Returns a subsequence, up to the specified maximum length, containing the

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -1460,16 +1460,16 @@ public struct IteratorSequence<
 
 // Compatibility aliases for Swift 4 names (see SE-0132)
 
-extension Sequence where SubSequence == AnySequence<Element> {
+extension Sequence {
   @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingPrefix(_:)")
   @_inlineable
-  public func dropFirst(_ n: Int) -> AnySequence<Element> {
+  public func dropFirst(_ n: Int) -> SubSequence {
     return removingPrefix(n)
   }
-  
+
   @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingSuffix(_:)")
   @_inlineable
-  public func dropLast(_ n: Int) -> AnySequence<Element> {
+  public func dropLast(_ n: Int) -> SubSequence {
     return removingSuffix(n)
   }
   
@@ -1477,12 +1477,10 @@ extension Sequence where SubSequence == AnySequence<Element> {
   @_inlineable
   public func drop(
     while predicate: (Element) throws -> Bool
-  ) rethrows -> AnySequence<Element> {
+  ) rethrows -> SubSequence {
     return try removingPrefix(while: predicate)
   }
-}
-
-extension Sequence {
+  
   @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingFirst()")
   @_inlineable
   public func dropFirst() -> SubSequence { return removingFirst() }

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -1210,12 +1210,6 @@ extension Sequence where SubSequence == AnySequence<Element> {
     if n == 0 { return AnySequence(self) }
     return AnySequence(_RemovingPrefixSequence(_iterator: makeIterator(), limit: n))
   }
-
-  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingPrefix(_:)")
-  @_inlineable
-  public func dropFirst(_ n: Int) -> AnySequence<Element> {
-    return removingPrefix(n)
-  }
   
   /// Returns a subsequence containing all but the given number of final
   /// elements.
@@ -1262,12 +1256,6 @@ extension Sequence where SubSequence == AnySequence<Element> {
     return AnySequence(result)
   }
   
-  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingSuffix(_:)")
-  @_inlineable
-  public func dropLast(_ n: Int) -> AnySequence<Element> {
-    return removingSuffix(n)
-  }
-
   /// Returns a subsequence by skipping the initial, consecutive elements that
   /// satisfy the given predicate.
   ///
@@ -1299,14 +1287,6 @@ extension Sequence where SubSequence == AnySequence<Element> {
         iterator: makeIterator(), nextElement: nil, predicate: predicate))
   }
   
-  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingPrefix(while:)")
-  @_inlineable
-  public func drop(
-    while predicate: (Element) throws -> Bool
-  ) rethrows -> AnySequence<Element> {
-    return try removingPrefix(while: predicate)
-  }
-
   /// Returns a subsequence, up to the specified maximum length, containing the
   /// initial elements of the sequence.
   ///
@@ -1395,10 +1375,6 @@ extension Sequence {
   /// - Complexity: O(1)
   @_inlineable
   public func removingFirst() -> SubSequence { return removingPrefix(1) }
-
-  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingFirst()")
-  @_inlineable
-  public func dropFirst() -> SubSequence { return removingFirst() }
     
   /// Returns a subsequence containing all but the last element of the
   /// sequence.
@@ -1420,10 +1396,6 @@ extension Sequence {
   /// - Complexity: O(*n*), where *n* is the length of the sequence.
   @_inlineable
   public func removingLast() -> SubSequence  { return removingSuffix(1) }
-
-  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingLast()")
-  @_inlineable
-  public func dropLast() -> SubSequence { return removingLast() }
 }
 
 extension Sequence {
@@ -1484,4 +1456,38 @@ public struct IteratorSequence<
 
   @_versioned
   internal var _base: Base
+}
+
+// Compatibility aliases for Swift 4 names (see SE-0132)
+
+extension Sequence where SubSequence == AnySequence<Element> {
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingPrefix(_:)")
+  @_inlineable
+  public func dropFirst(_ n: Int) -> AnySequence<Element> {
+    return removingPrefix(n)
+  }
+  
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingSuffix(_:)")
+  @_inlineable
+  public func dropLast(_ n: Int) -> AnySequence<Element> {
+    return removingSuffix(n)
+  }
+  
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingPrefix(while:)")
+  @_inlineable
+  public func drop(
+    while predicate: (Element) throws -> Bool
+  ) rethrows -> AnySequence<Element> {
+    return try removingPrefix(while: predicate)
+  }
+}
+
+extension Sequence {
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingFirst()")
+  @_inlineable
+  public func dropFirst() -> SubSequence { return removingFirst() }
+
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "removingLast()")
+  @_inlineable
+  public func dropLast() -> SubSequence { return removingLast() }
 }

--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -213,7 +213,7 @@ ${orderingExplanation}
 % end
 
 //===----------------------------------------------------------------------===//
-// starts(with:)
+// hasPrefix(_:)
 //===----------------------------------------------------------------------===//
 
 % # Generate two versions: with explicit predicates and with
@@ -246,13 +246,13 @@ ${equivalenceExplanation}
   ///     let a = 1...3
   ///     let b = 1...10
   ///
-  ///     print(b.starts(with: a))
+  ///     print(b.hasPrefix(a))
   ///     // Prints "true"
   ///
   /// Passing a sequence with no elements or an empty collection as
   /// `possiblePrefix` always results in `true`.
   ///
-  ///     print(b.starts(with: []))
+  ///     print(b.hasPrefix([]))
   ///     // Prints "true"
   ///
   /// - Parameter possiblePrefix: A sequence to compare to this sequence.
@@ -261,8 +261,8 @@ ${equivalenceExplanation}
   ///   `possiblePrefix` has no elements, the return value is `true`.
 %   end
   @_inlineable
-  public func starts<PossiblePrefix>(
-    with possiblePrefix: PossiblePrefix${"," if preds else ""}
+  public func hasPrefix<PossiblePrefix>(
+    _ possiblePrefix: PossiblePrefix${"," if preds else ""}
 %   if preds:
     by areEquivalent: (Element, Element) throws -> Bool
 %   end
@@ -283,6 +283,24 @@ ${equivalenceExplanation}
       }
     }
     return possiblePrefixIterator.next() == nil
+  }
+    
+  @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "hasPrefix(_:${"by:" if preds else ""})")
+  @_inlineable
+  public func starts<PossiblePrefix>(
+    with possiblePrefix: PossiblePrefix${"," if preds else ""}
+%   if preds:
+    by areEquivalent: (Element, Element) throws -> Bool
+%   end
+  ) ${rethrows_}-> Bool
+    where
+    PossiblePrefix : Sequence,
+    PossiblePrefix.Element == Element {
+%   if preds:
+    return try hasPrefix(possiblePrefix, by: areEquivalent)
+%   else:
+    return hasPrefix(possiblePrefix)
+%   end
   }
 }
 

--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -285,6 +285,7 @@ ${equivalenceExplanation}
     return possiblePrefixIterator.next() == nil
   }
     
+  // Compatibility alias for Swift 4 name (see SE-0132)
   @available(swift, deprecated: 4.1, obsoleted: 5.0, renamed: "hasPrefix(_:${"by:" if preds else ""})")
   @_inlineable
   public func starts<PossiblePrefix>(

--- a/stdlib/public/core/SequenceWrapper.swift
+++ b/stdlib/public/core/SequenceWrapper.swift
@@ -108,10 +108,10 @@ extension _SequenceWrapper where SubSequence == Base.SubSequence {
   }
 
   @_inlineable // FIXME(sil-serialize-all)
-  public func drop(
+  public func removingPrefix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> SubSequence {
-    return try _base.drop(while: predicate)
+    return try _base.removingPrefix(while: predicate)
   }
 
   @_inlineable // FIXME(sil-serialize-all)

--- a/stdlib/public/core/SequenceWrapper.swift
+++ b/stdlib/public/core/SequenceWrapper.swift
@@ -91,12 +91,12 @@ extension _SequenceWrapper {
 
 extension _SequenceWrapper where SubSequence == Base.SubSequence {
   @_inlineable // FIXME(sil-serialize-all)
-  public func dropFirst(_ n: Int) -> SubSequence {
-    return _base.dropFirst(n)
+  public func removingPrefix(_ n: Int) -> SubSequence {
+    return _base.removingPrefix(n)
   }
   @_inlineable // FIXME(sil-serialize-all)
-  public func dropLast(_ n: Int) -> SubSequence {
-    return _base.dropLast(n)
+  public func removingSuffix(_ n: Int) -> SubSequence {
+    return _base.removingSuffix(n)
   }
   @_inlineable // FIXME(sil-serialize-all)
   public func prefix(_ maxLength: Int) -> SubSequence {

--- a/stdlib/public/core/Slice.swift.gyb
+++ b/stdlib/public/core/Slice.swift.gyb
@@ -434,11 +434,11 @@ public struct ${Self}<Base : ${BaseRequirements}>
   /// by using methods that return a subsequence.
   ///
   ///     let singleDigits = 0...9
-  ///     let subSequence = singleDigits.dropFirst(5)
+  ///     let subSequence = singleDigits.removingPrefix(5)
   ///     print(Array(subSequence))
   ///     // Prints "[5, 6, 7, 8, 9]"
   ///
-  /// In this example, the expression `singleDigits.dropFirst(5))` is
+  /// In this example, the expression `singleDigits.removingPrefix(5))` is
   /// equivalent to calling this initializer with `singleDigits` and a
   /// range covering the last five items of `singleDigits.indices`.
   ///
@@ -468,7 +468,7 @@ public struct ${Self}<Base : ${BaseRequirements}>
   /// to `singleDigits`.
   ///
   ///     let singleDigits = 0..<10
-  ///     let singleNonZeroDigits = singleDigits.dropFirst()
+  ///     let singleNonZeroDigits = singleDigits.removingFirst()
   ///     // singleNonZeroDigits is a RandomAccessSlice<CountableRange<Int>>
   ///
   ///     print(singleNonZeroDigits.count)

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -436,7 +436,7 @@ extension String {
 /// that point:
 ///
 ///     let name = "Marie Curie"
-///     let firstSpace = name.index(of: " ") ?? name.endIndex
+///     let firstSpace = name.firstIndex(of: " ") ?? name.endIndex
 ///     let firstName = name[..<firstSpace]
 ///     // firstName == "Marie"
 ///
@@ -587,7 +587,7 @@ extension String {
 /// of the string up to that point.
 ///
 ///     let name = "Marie Curie"
-///     let firstSpace = name.index(of: " ") ?? name.endIndex
+///     let firstSpace = name.firstIndex(of: " ") ?? name.endIndex
 ///     let firstName = name[..<firstSpace]
 ///     print(firstName)
 ///     // Prints "Marie"

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -56,7 +56,7 @@ extension String {
   /// using the `String` type's `init(_:)` initializer.
   ///
   ///     let name = "Marie Curie"
-  ///     if let firstSpace = name.characters.index(of: " ") {
+  ///     if let firstSpace = name.characters.firstIndex(of: " ") {
   ///         let firstName = String(name.characters[..<firstSpace])
   ///         print(firstName)
   ///     }
@@ -116,7 +116,7 @@ extension String {
   ///     var str = "All this happened, more or less."
   ///     let afterSpace = str.withMutableCharacters {
   ///         chars -> String.CharacterView in
-  ///         if let i = chars.index(of: " ") {
+  ///         if let i = chars.firstIndex(of: " ") {
   ///             let result = chars[chars.index(after: i)...]
   ///             chars.removeSubrange(i...)
   ///             return result
@@ -631,7 +631,7 @@ extension String.CharacterView : BidirectionalCollection {
   /// letter and then prints the character at the found index:
   ///
   ///     let greeting = "Hello, friend!"
-  ///     if let i = greeting.characters.index(where: { "A"..."Z" ~= $0 }) {
+  ///     if let i = greeting.characters.firstIndex(where: { "A"..."Z" ~= $0 }) {
   ///         print("First capital letter: \(greeting.characters[i])")
   ///     }
   ///     // Prints "First capital letter: H"
@@ -764,7 +764,7 @@ extension String.CharacterView {
   /// not including, the first comma (`","`) in the string.
   ///
   ///     let str = "All this happened, more or less."
-  ///     let i = str.characters.index(of: ",")!
+  ///     let i = str.characters.firstIndex(of: ",")!
   ///     let substring = str.characters[str.characters.startIndex ..< i]
   ///     print(String(substring))
   ///     // Prints "All this happened"

--- a/stdlib/public/core/StringIndexConversions.swift
+++ b/stdlib/public/core/StringIndexConversions.swift
@@ -26,7 +26,7 @@ extension String.Index {
   ///     print(cafe)
   ///     // Prints "Café"
   ///
-  ///     let scalarsIndex = cafe.unicodeScalars.index(of: "e")!
+  ///     let scalarsIndex = cafe.unicodeScalars.firstIndex(of: "e")!
   ///     let stringIndex = String.Index(scalarsIndex, within: cafe)!
   ///
   ///     print(cafe[...stringIndex])
@@ -68,7 +68,7 @@ extension String.Index {
   /// uses this method find the same position in the string's `utf8` view.
   ///
   ///     let cafe = "Café"
-  ///     if let i = cafe.index(of: "é") {
+  ///     if let i = cafe.firstIndex(of: "é") {
   ///         let j = i.samePosition(in: cafe.utf8)!
   ///         print(Array(cafe.utf8[j...]))
   ///     }
@@ -97,7 +97,7 @@ extension String.Index {
   /// uses this method find the same position in the string's `utf16` view.
   ///
   ///     let cafe = "Café"
-  ///     if let i = cafe.index(of: "é") {
+  ///     if let i = cafe.firstIndex(of: "é") {
   ///         let j = i.samePosition(in: cafe.utf16)!
   ///         print(cafe.utf16[j])
   ///     }

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -196,9 +196,9 @@ extension String : StringProtocol, RangeReplaceableCollection {
   /// For example, this code finds the first letter after the first space:
   ///
   ///     let str = "Greetings, friend! How are you?"
-  ///     let firstSpace = str.index(of: " ") ?? str.endIndex
+  ///     let firstSpace = str.firstIndex(of: " ") ?? str.endIndex
   ///     let substr = str[firstSpace...]
-  ///     if let nextCapital = substr.index(where: { $0 >= "A" && $0 <= "Z" }) {
+  ///     if let nextCapital = substr.firstIndex(where: { $0 >= "A" && $0 <= "Z" }) {
   ///         print("Capital after a space: \(str[nextCapital])")
   ///     }
   ///     // Prints "Capital after a space: H"
@@ -350,7 +350,7 @@ extension String {
   /// removes the hyphen from the middle of a string.
   ///
   ///     var nonempty = "non-empty"
-  ///     if let i = nonempty.index(of: "-") {
+  ///     if let i = nonempty.firstIndex(of: "-") {
   ///         nonempty.remove(at: i)
   ///     }
   ///     print(nonempty)

--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -55,7 +55,7 @@ extension String {
   /// `String` type's `init(_:)` initializer.
   ///
   ///     let favemoji = "My favorite emoji is 🎉"
-  ///     if let i = favemoji.utf16.index(where: { $0 >= 128 }) {
+  ///     if let i = favemoji.utf16.firstIndex(where: { $0 >= 128 }) {
   ///         let asciiPrefix = String(favemoji.utf16[..<i])
   ///         print(asciiPrefix)
   ///     }
@@ -310,7 +310,7 @@ extension String {
   /// another string's `utf16` view.
   ///
   ///     let picnicGuest = "Deserving porcupine"
-  ///     if let i = picnicGuest.utf16.index(of: 32) {
+  ///     if let i = picnicGuest.utf16.firstIndex(of: 32) {
   ///         let adjective = String(picnicGuest.utf16[..<i])
   ///         print(adjective)
   ///     }
@@ -381,7 +381,7 @@ extension String.UTF16View.Index {
   ///
   ///     let cafe = "Café 🍵"
   ///
-  ///     let stringIndex = cafe.index(of: "é")!
+  ///     let stringIndex = cafe.firstIndex(of: "é")!
   ///     let utf16Index = String.Index(stringIndex, within: cafe.utf16)!
   ///
   ///     print(cafe.utf16[...utf16Index])
@@ -409,7 +409,7 @@ extension String.UTF16View.Index {
   /// position in the string's `unicodeScalars` view.
   ///
   ///     let cafe = "Café 🍵"
-  ///     let i = cafe.utf16.index(of: 32)!
+  ///     let i = cafe.utf16.firstIndex(of: 32)!
   ///     let j = i.samePosition(in: cafe.unicodeScalars)!
   ///     print(cafe.unicodeScalars[..<j])
   ///     // Prints "Café"

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -224,7 +224,7 @@ extension String {
         // We reached a scalar boundary; compute the underlying utf16's width
         // based on the number of utf8 code units
         scalarLength16 = n8 >> 2 + 1
-        nextBuffer.removeFirst(n8)
+        nextBuffer.removePrefix(n8)
       }
 
       if _fastPath(!nextBuffer.isEmpty) {        

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -398,7 +398,7 @@ extension String {
   /// another string's `utf8` view.
   ///
   ///     let picnicGuest = "Deserving porcupine"
-  ///     if let i = picnicGuest.utf8.index(of: 32) {
+  ///     if let i = picnicGuest.utf8.firstIndex(of: 32) {
   ///         let adjective = String(picnicGuest.utf8[..<i])
   ///         print(adjective)
   ///     }
@@ -606,7 +606,7 @@ extension String.UTF8View.Index {
   ///
   ///     let cafe = "Café 🍵"
   ///
-  ///     let utf16Index = cafe.utf16.index(of: 32)!
+  ///     let utf16Index = cafe.utf16.firstIndex(of: 32)!
   ///     let utf8Index = String.UTF8View.Index(utf16Index, within: cafe.utf8)!
   ///
   ///     print(Array(cafe.utf8[..<utf8Index]))

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -52,7 +52,7 @@ extension String {
   /// using the `String` type's `init(_:)` initializer.
   ///
   ///     let favemoji = "My favorite emoji is 🎉"
-  ///     if let i = favemoji.unicodeScalars.index(where: { $0.value >= 128 }) {
+  ///     if let i = favemoji.unicodeScalars.firstIndex(where: { $0.value >= 128 }) {
   ///         let asciiPrefix = String(favemoji.unicodeScalars[..<i])
   ///         print(asciiPrefix)
   ///     }
@@ -166,7 +166,7 @@ extension String {
     /// at the found index:
     ///
     ///     let greeting = "Hello, friend!"
-    ///     if let i = greeting.unicodeScalars.index(where: { "A"..."Z" ~= $0 }) {
+    ///     if let i = greeting.unicodeScalars.firstIndex(where: { "A"..."Z" ~= $0 }) {
     ///         print("First capital letter: \(greeting.unicodeScalars[i])")
     ///         print("Unicode scalar value: \(greeting.unicodeScalars[i].value)")
     ///     }
@@ -301,7 +301,7 @@ extension String {
   /// another string's `unicodeScalars` view.
   ///
   ///     let picnicGuest = "Deserving porcupine"
-  ///     if let i = picnicGuest.unicodeScalars.index(of: " ") {
+  ///     if let i = picnicGuest.unicodeScalars.firstIndex(of: " ") {
   ///         let adjective = String(picnicGuest.unicodeScalars[..<i])
   ///         print(adjective)
   ///     }
@@ -420,7 +420,7 @@ extension String.UnicodeScalarIndex {
   ///
   ///     let cafe = "Café 🍵"
   ///
-  ///     let utf16Index = cafe.utf16.index(of: 32)!
+  ///     let utf16Index = cafe.utf16.firstIndex(of: 32)!
   ///     let scalarIndex = String.Index(utf16Index, within: cafe.unicodeScalars)!
   ///
   ///     print(String(cafe.unicodeScalars[..<scalarIndex]))
@@ -453,7 +453,7 @@ extension String.UnicodeScalarIndex {
   /// in the string.
   ///
   ///     let cafe = "Café 🍵"
-  ///     let i = cafe.unicodeScalars.index(of: "🍵")
+  ///     let i = cafe.unicodeScalars.firstIndex(of: "🍵")
   ///     let j = i.samePosition(in: cafe)!
   ///     print(cafe[j...])
   ///     // Prints "🍵"
@@ -572,7 +572,7 @@ extension String.UnicodeScalarView {
   /// to, but not including, the first comma (`","`) in the string.
   ///
   ///     let str = "All this happened, more or less."
-  ///     let i = str.unicodeScalars.index(of: ",")!
+  ///     let i = str.unicodeScalars.firstIndex(of: ",")!
   ///     let substring = str.unicodeScalars[str.unicodeScalars.startIndex ..< i]
   ///     print(String(substring))
   ///     // Prints "All this happened"

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -703,7 +703,7 @@ extension Substring {
 extension String {
   @_inlineable // FIXME(sil-serialize-all)
   @available(swift, deprecated: 3.2, obsoleted: 4, message:
-    "Please use 'first', 'dropFirst()', or 'Substring.popFirst()'.")
+    "Please use 'first', 'removingFirst()', or 'Substring.popFirst()'.")
   public mutating func popFirst() -> String.Element? {
     guard !isEmpty else { return nil }
     let element = first!
@@ -715,7 +715,7 @@ extension String {
 extension String.CharacterView {
   @_inlineable // FIXME(sil-serialize-all)
   @available(swift, deprecated: 3.2, obsoleted: 4, message:
-    "Please use 'first', 'dropFirst()', or 'Substring.CharacterView.popFirst()'.")
+    "Please use 'first', 'removingFirst()', or 'Substring.CharacterView.popFirst()'.")
   public mutating func popFirst() -> String.CharacterView.Element? {
     guard !isEmpty else { return nil }
     let element = first!
@@ -727,7 +727,7 @@ extension String.CharacterView {
 extension String.UnicodeScalarView {
   @_inlineable // FIXME(sil-serialize-all)
   @available(swift, deprecated: 3.2, obsoleted: 4, message:
-    "Please use 'first', 'dropFirst()', or 'Substring.UnicodeScalarView.popFirst()'.")
+    "Please use 'first', 'removingFirst()', or 'Substring.UnicodeScalarView.popFirst()'.")
   public mutating func popFirst() -> String.UnicodeScalarView.Element? {
     guard !isEmpty else { return nil }
     let element = first!

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -46,7 +46,7 @@ extension String {
 /// substring of the first sentence:
 ///
 ///     let greeting = "Hi there! It's nice to meet you! 👋"
-///     let endOfSentence = greeting.index(of: "!")!
+///     let endOfSentence = greeting.firstIndex(of: "!")!
 ///     let firstSentence = greeting[...endOfSentence]
 ///     // firstSentence == "Hi there!"
 ///

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -499,8 +499,8 @@ extension Sequence {
 
 func rdar27700622<E: Comparable>(_ input: [E]) -> [E] {
   let pivot = input.first!
-  let lhs = input.dropFirst().filter { $0 <= pivot }
-  let rhs = input.dropFirst().filter { $0 > pivot }
+  let lhs = input.removingFirst().filter { $0 <= pivot }
+  let rhs = input.removingFirst().filter { $0 > pivot }
 
   return rdar27700622(lhs) + [pivot] + rdar27700622(rhs) // Ok
 }

--- a/test/IDE/complete_from_stdlib.swift
+++ b/test/IDE/complete_from_stdlib.swift
@@ -135,8 +135,8 @@ func testArchetypeReplacement1<FOO : Equatable>(_ a: [FOO]) {
 // PRIVATE_NOMINAL_MEMBERS_5-DAG: Decl[InstanceMethod]/CurrNominal:   popLast()[#Equatable?#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_5-DAG: Decl[InstanceVar]/Super:            isEmpty[#Bool#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_5-DAG: Decl[InstanceVar]/Super:            first[#Equatable?#]{{; name=.+}}
-// PRIVATE_NOMINAL_MEMBERS_5-DAG: Decl[InstanceMethod]/Super:         dropFirst({#(n): Int#})[#ArraySlice<Equatable>#]{{; name=.+}}
-// PRIVATE_NOMINAL_MEMBERS_5-DAG: Decl[InstanceMethod]/Super:         dropLast({#(n): Int#})[#ArraySlice<Equatable>#]{{; name=.+}}
+// PRIVATE_NOMINAL_MEMBERS_5-DAG: Decl[InstanceMethod]/Super:         removingPrefix({#(n): Int#})[#ArraySlice<Equatable>#]{{; name=.+}}
+// PRIVATE_NOMINAL_MEMBERS_5-DAG: Decl[InstanceMethod]/Super:         removingSuffix({#(n): Int#})[#ArraySlice<Equatable>#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_5-DAG: Decl[InstanceMethod]/Super:         prefix({#(maxLength): Int#})[#ArraySlice<Equatable>#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_5-DAG: Decl[InstanceMethod]/Super:         suffix({#(maxLength): Int#})[#ArraySlice<Equatable>#]{{; name=.+}}
 
@@ -149,14 +149,14 @@ func testArchetypeReplacement2<BAR : Equatable>(_ a: [BAR]) {
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/CurrNominal:   append({#(newElement): Equatable#})[#Void#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/CurrNominal:   insert({#(newElement): Equatable#}, {#at: Int#})[#Void#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/CurrNominal:   popLast()[#Equatable?#]{{; name=.+}}
-// PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         dropFirst()[#ArraySlice<Equatable>#]{{; name=.+}}
-// PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         dropLast()[#ArraySlice<Equatable>#]{{; name=.+}}
+// PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         removingFirst()[#ArraySlice<Equatable>#]{{; name=.+}}
+// PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         removingLast()[#ArraySlice<Equatable>#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         enumerated()[#EnumeratedSequence<[Equatable]>#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         min({#by: (Equatable, Equatable) throws -> Bool##(Equatable, Equatable) throws -> Bool#})[' rethrows'][#Equatable?#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         max({#by: (Equatable, Equatable) throws -> Bool##(Equatable, Equatable) throws -> Bool#})[' rethrows'][#Equatable?#]{{; name=.+}}
 // FIXME: The following should include 'partialResult' as local parameter name: "(nextPartialResult): (_ partialResult: Result, Equatable)"
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         reduce({#(initialResult): Result#}, {#(nextPartialResult): (Result, Equatable) throws -> Result##(Result, Equatable) throws -> Result#})[' rethrows'][#Result#]{{; name=.+}}
-// PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         dropFirst({#(n): Int#})[#ArraySlice<Equatable>#]{{; name=.+}}
+// PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         removingPrefix({#(n): Int#})[#ArraySlice<Equatable>#]{{; name=.+}}
 // FIXME: restore Decl[InstanceMethod]/Super:         flatMap({#(transform): (Equatable) throws -> Sequence##(Equatable) throws -> Sequence#})[' rethrows'][#[IteratorProtocol.Element]#]{{; name=.+}}
 
 func testArchetypeReplacement3 (_ a : [Int]) {
@@ -169,7 +169,7 @@ func testArchetypeReplacement3 (_ a : [Int]) {
 // PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceMethod]/CurrNominal:   popLast()[#Int?#]
 // PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceVar]/Super:            first[#Int?#]
 // PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceMethod]/Super:         map({#(transform): (Int) throws -> T##(Int) throws -> T#})[' rethrows'][#[T]#]
-// PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceMethod]/Super:         dropLast({#(n): Int#})[#ArraySlice<Int>#]
+// PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceMethod]/Super:         removingSuffix({#(n): Int#})[#ArraySlice<Int>#]
 // PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceMethod]/Super:         elementsEqual({#(other): Sequence#}, {#by: (Int, Int) throws -> Bool##(Int, Int) throws -> Bool#})[' rethrows'][#Bool#]
 
 
@@ -222,7 +222,7 @@ func testArchetypeReplacement6() {
 struct Test1000 : Sequence {
   func #^RETURNS_ANY_SEQUENCE^#
 }
-// RETURNS_ANY_SEQUENCE: Decl[InstanceMethod]/Super:         dropFirst(_ n: Int)
+// RETURNS_ANY_SEQUENCE: Decl[InstanceMethod]/Super:         removingPrefix(_ n: Int)
 
 func testPostfixOperator1(_ x: Int) {
   x#^POSTFIX_INT_1^#

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -192,7 +192,7 @@ public struct MUseStruct {
 // CHECK: ret void
 public func stringAndSubstring() -> (String, Substring) {
   let s = "Hello, World"
-  let a = Substring(s).dropFirst()
+  let a = Substring(s).removingFirst()
   return (s, a)
 }
 

--- a/test/Interpreter/SDK/Foundation_test.swift
+++ b/test/Interpreter/SDK/Foundation_test.swift
@@ -163,8 +163,8 @@ FoundationTestSuite.test("RangeConversion") {
   expectEqual("{0, 5}", NSStringFromRange(nsrFromPartial))
 
   let s = "Hello, 🌎!"
-  let b = s.index(of: ",")!
-  let e = s.index(of: "!")!
+  let b = s.firstIndex(of: ",")!
+  let e = s.firstIndex(of: "!")!
   let nsr = NSRange(b..<e, in: s)
   expectEqual(nsr.location, 5)
   expectEqual(nsr.length, 4)

--- a/test/Interpreter/SDK/equatable_hashable.swift
+++ b/test/Interpreter/SDK/equatable_hashable.swift
@@ -29,7 +29,7 @@ func testEquatable<E: Equatable>(_ x: E) {}
 func test_Equatable() {
   // CHECK-NEXT: Found 2.5 at index 1
   let array: [NSNumber] = [1, 2.5, 3.14159]
-  if let index = array.index(of: 2.5) {
+  if let index = array.firstIndex(of: 2.5) {
     print("Found \(array[index]) at index \(index)")
   } else {
     print("Did not find 2.5?")

--- a/test/Prototypes/BigInt.swift
+++ b/test/Prototypes/BigInt.swift
@@ -712,7 +712,7 @@ public struct _BigInt<Word: FixedWidthInteger & UnsignedInteger> :
       return 0
     }
 
-    let i = _data.index(where: { $0 != 0 })!
+    let i = _data.firstIndex(where: { $0 != 0 })!
     _sanityCheck(_data[i] != 0)
     return i * Word.bitWidth + _data[i].trailingZeroBitCount
   }

--- a/test/Prototypes/BigInt.swift
+++ b/test/Prototypes/BigInt.swift
@@ -935,7 +935,7 @@ public struct _BigInt<Word: FixedWidthInteger & UnsignedInteger> :
     // Check for a single prefixing hyphen
     let negative = source.hasPrefix("-")
     if negative {
-      source = String(source.characters.dropFirst())
+      source = String(source.characters.removingFirst())
     }
 
     // Loop through characters, multiplying

--- a/test/Prototypes/CollectionTransformers.swift
+++ b/test/Prototypes/CollectionTransformers.swift
@@ -815,7 +815,7 @@ final public class ForkJoinPool {
     if ForkJoinPool._getCurrentThread() != nil {
       // Run the first task in this thread, fork the rest.
       let first = tasks.first
-      for t in tasks.dropFirst() {
+      for t in tasks.removingFirst() {
         // FIXME: optimize forking in bulk.
         t.fork()
       }

--- a/test/Prototypes/PatternMatching.swift
+++ b/test/Prototypes/PatternMatching.swift
@@ -144,7 +144,7 @@ where M0.Element == M1.Element, M0.Index == M1.Index {
             return .notFound(resumeAt: nil)
           }
           // backtrack
-          src0 = src0.dropLast()
+          src0 = src0.removingLast()
         }
       case .notFound(let j):
         return .notFound(resumeAt: j)
@@ -170,7 +170,7 @@ struct RepeatMatch<M0: Pattern> : Pattern {
   , C.SubSequence : Collection  
   {
     var lastEnd = c.startIndex
-    var rest = c.dropFirst(0)
+    var rest = c.removingPrefix(0)
     var data: MatchData = []
 
   searchLoop:

--- a/test/Prototypes/UnicodeDecoders.swift
+++ b/test/Prototypes/UnicodeDecoders.swift
@@ -280,7 +280,7 @@ func checkDecodeUTF<Codec : UnicodeCodec>(
       expectEqual(1, errorCount)
       let x = (expected + expectedRepairedTail).reversed()
       expectTrue(
-        x.starts(with: decoded),
+        x.hasPrefix(decoded),
         "reverse, repairing: false\n\t\(Array(x)) does not start with \(decoded)")
       decoded.removeAll(keepingCapacity: true)
     }

--- a/test/Prototypes/UnicodeDecoders.swift
+++ b/test/Prototypes/UnicodeDecoders.swift
@@ -321,10 +321,10 @@ func checkDecodeUTF<Codec : UnicodeCodec>(
   
   do {
     let s0 = "\n" + String(decoding: utfStr, as: Codec.self) + "\n"
-    let s = s0.dropFirst().dropLast()
+    let s = s0.removingFirst().removingLast()
     expectEqualSequence(expected, utf32(s), "Sliced Substring")
     checkStringProtocol(
-      s0.dropFirst().dropLast(),
+      s0.removingFirst().removingLast(),
       utfStr, encodedAs: Codec.self, expectingUTF32: expected)
   }
 

--- a/test/stdlib/ArrayDiagnostics.swift
+++ b/test/stdlib/ArrayDiagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -swift-version 4.1
 
 class NotEquatable {}
 
@@ -9,3 +9,15 @@ func test_ArrayOfNotEquatableIsNotEquatable() {
   // expected-note @-1 {{overloads for '==' exist with these partially matching parameter lists: }}
 }
 
+func test_SE0132Deprecations() {
+  let a = [1, 2, 3]
+  
+  _ = a.index(of: 2)  // expected-warning {{'index(of:)' is deprecated: renamed to 'firstIndex(of:)'}}
+  // expected-note @-1 {{use 'firstIndex(of:)' instead}} {{9-14=firstIndex}}
+  
+  _ = a.index(where: { $0 == 2})  // expected-warning {{'index(where:)' is deprecated: renamed to 'firstIndex(where:)'}}
+  // expected-note @-1 {{use 'firstIndex(where:)' instead}} {{9-14=firstIndex}}
+  
+  _ = a.index { $0 == 2 }  // expected-warning {{'index(where:)' is deprecated: renamed to 'firstIndex(where:)'}}
+  // expected-note @-1 {{use 'firstIndex(where:)' instead}} {{9-14=firstIndex}}
+}

--- a/test/stdlib/ArrayDiagnostics.swift
+++ b/test/stdlib/ArrayDiagnostics.swift
@@ -44,4 +44,10 @@ func test_SE0132Deprecations() {
   
   _ = a.dropLast() // expected-warning {{'dropLast()' is deprecated: renamed to 'removingLast()'}}
   // expected-note @-1 {{use 'removingLast()' instead}} {{9-17=removingLast}}
+  
+  _ = a.drop(while: { $0 == 2 }) // expected-warning {{'drop(while:)' is deprecated: renamed to 'removingPrefix(while:)'}}
+  // expected-note @-1 {{use 'removingPrefix(while:)' instead}} {{9-13=removingPrefix}}
+  
+  _ = a.drop { $0 == 2 } // expected-warning {{'drop(while:)' is deprecated: renamed to 'removingPrefix(while:)'}}
+  // expected-note @-1 {{use 'removingPrefix(while:)' instead}} {{9-13=removingPrefix}}
 }

--- a/test/stdlib/ArrayDiagnostics.swift
+++ b/test/stdlib/ArrayDiagnostics.swift
@@ -32,4 +32,16 @@ func test_SE0132Deprecations() {
   
   _ = a.removeLast(1) // expected-warning {{'removeLast' is deprecated: renamed to 'removeSuffix(_:)'}}
   // expected-note @-1 {{use 'removeSuffix(_:)' instead}} {{9-19=removeSuffix}}
+  
+  _ = a.dropFirst(1) // expected-warning {{'dropFirst' is deprecated: renamed to 'removingPrefix(_:)'}}
+  // expected-note @-1 {{use 'removingPrefix(_:)' instead}} {{9-18=removingPrefix}}
+  
+  _ = a.dropLast(1) // expected-warning {{'dropLast' is deprecated: renamed to 'removingSuffix(_:)'}}
+  // expected-note @-1 {{use 'removingSuffix(_:)' instead}} {{9-17=removingSuffix}}
+  
+  _ = a.dropFirst() // expected-warning {{'dropFirst()' is deprecated: renamed to 'removingFirst()'}}
+  // expected-note @-1 {{use 'removingFirst()' instead}} {{9-18=removingFirst}}
+  
+  _ = a.dropLast() // expected-warning {{'dropLast()' is deprecated: renamed to 'removingLast()'}}
+  // expected-note @-1 {{use 'removingLast()' instead}} {{9-17=removingLast}}
 }

--- a/test/stdlib/ArrayDiagnostics.swift
+++ b/test/stdlib/ArrayDiagnostics.swift
@@ -10,7 +10,7 @@ func test_ArrayOfNotEquatableIsNotEquatable() {
 }
 
 func test_SE0132Deprecations() {
-  let a = [1, 2, 3]
+  var a = [1, 2, 3]
   
   _ = a.index(of: 2)  // expected-warning {{'index(of:)' is deprecated: renamed to 'firstIndex(of:)'}}
   // expected-note @-1 {{use 'firstIndex(of:)' instead}} {{9-14=firstIndex}}
@@ -26,4 +26,10 @@ func test_SE0132Deprecations() {
   
   _ = a.starts(with: [1, 2], by: ==) // expected-warning {{'starts(with:by:)' is deprecated: renamed to 'hasPrefix(_:by:)'}}
   // expected-note @-1 {{use 'hasPrefix(_:by:)' instead}} {{9-15=hasPrefix}} {{16-22=}}
+  
+  _ = a.removeFirst(1) // expected-warning {{'removeFirst' is deprecated: renamed to 'removePrefix(_:)'}}
+  // expected-note @-1 {{use 'removePrefix(_:)' instead}} {{9-20=removePrefix}}
+  
+  _ = a.removeLast(1) // expected-warning {{'removeLast' is deprecated: renamed to 'removeSuffix(_:)'}}
+  // expected-note @-1 {{use 'removeSuffix(_:)' instead}} {{9-19=removeSuffix}}
 }

--- a/test/stdlib/ArrayDiagnostics.swift
+++ b/test/stdlib/ArrayDiagnostics.swift
@@ -20,4 +20,10 @@ func test_SE0132Deprecations() {
   
   _ = a.index { $0 == 2 }  // expected-warning {{'index(where:)' is deprecated: renamed to 'firstIndex(where:)'}}
   // expected-note @-1 {{use 'firstIndex(where:)' instead}} {{9-14=firstIndex}}
+  
+  _ = a.starts(with: [1, 2]) // expected-warning {{'starts(with:)' is deprecated: renamed to 'hasPrefix(_:)'}}
+  // expected-note @-1 {{use 'hasPrefix(_:)' instead}} {{9-15=hasPrefix}} {{16-22=}}
+  
+  _ = a.starts(with: [1, 2], by: ==) // expected-warning {{'starts(with:by:)' is deprecated: renamed to 'hasPrefix(_:by:)'}}
+  // expected-note @-1 {{use 'hasPrefix(_:by:)' instead}} {{9-15=hasPrefix}} {{16-22=}}
 }

--- a/test/stdlib/ErrorHandling.swift
+++ b/test/stdlib/ErrorHandling.swift
@@ -95,9 +95,9 @@ ErrorHandlingTests.test("ErrorHandling/withCString extends lifetime") {
   // TODO: Some way to check string was deallocated?
 }
 
-ErrorHandlingTests.test("ErrorHandling/index(where:)") {
+ErrorHandlingTests.test("ErrorHandling/firstIndex(where:)") {
   do {
-    let _: Int? = try [1, 2, 3].index {
+    let _: Int? = try [1, 2, 3].firstIndex {
       throw SillyError.JazzHands
       return $0 == $0
     }

--- a/test/stdlib/ErrorHandling.swift
+++ b/test/stdlib/ErrorHandling.swift
@@ -190,9 +190,9 @@ ErrorHandlingTests.test("ErrorHandling/min") {
   } catch {}
 }
 
-ErrorHandlingTests.test("ErrorHandling/starts(with:)") {
+ErrorHandlingTests.test("ErrorHandling/hasPrefix(_:)") {
   do {
-    let x: Bool = try [1, 2, 3].starts(with: [1, 2]) { _, _ in
+    let x: Bool = try [1, 2, 3].hasPrefix([1, 2]) { _, _ in
       throw SillyError.JazzHands
       return false
     }

--- a/test/stdlib/Mirror.swift
+++ b/test/stdlib/Mirror.swift
@@ -111,7 +111,7 @@ mirrors.test("BidirectionalStructure") {
   let description = y.testDescription
   expectEqual(
     "[nil: \"a\", nil: \"b\", nil: \"c\", nil: \"",
-    description[description.startIndex..<description.characters.index(of: "d")!])
+    description[description.startIndex..<description.characters.firstIndex(of: "d")!])
 }
 
 mirrors.test("LabeledStructure") {

--- a/test/stdlib/NSSlowString.swift
+++ b/test/stdlib/NSSlowString.swift
@@ -37,9 +37,9 @@ func check(
 
 	// Substring tests
 	checkSingleForm(s[...], expectedCount: count, expectedCodeUnitCount: cuCount)
-	checkSingleForm(s.dropFirst(), expectedCount: count-1, expectedCodeUnitCount: nil)
-	checkSingleForm(s.dropLast(), expectedCount: count-1, expectedCodeUnitCount: nil)
-	checkSingleForm(s.dropLast().dropFirst(), expectedCount: count-2, expectedCodeUnitCount: nil)
+	checkSingleForm(s.removingFirst(), expectedCount: count-1, expectedCodeUnitCount: nil)
+	checkSingleForm(s.removingLast(), expectedCount: count-1, expectedCodeUnitCount: nil)
+	checkSingleForm(s.removingLast().removingFirst(), expectedCount: count-2, expectedCodeUnitCount: nil)
 }
 
 tests.test("Unicode 9 grapheme breaking") {

--- a/test/stdlib/PrintFloat.swift
+++ b/test/stdlib/PrintFloat.swift
@@ -17,7 +17,7 @@ import PrintTestTypes
 let PrintTests = TestSuite("PrintFloat")
 
 PrintTests.setUp {
-  if let localeArgIndex = CommandLine.arguments.index(of: "--locale") {
+  if let localeArgIndex = CommandLine.arguments.firstIndex(of: "--locale") {
     let locale = CommandLine.arguments[localeArgIndex + 1]
     expectEqual("ru_RU.UTF-8", locale)
     setlocale(LC_ALL, locale)

--- a/test/stdlib/SetTraps.swift
+++ b/test/stdlib/SetTraps.swift
@@ -51,7 +51,7 @@ SetTraps.test("RemoveInvalidIndex4")
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
   .code {
   var s: Set<Int> = [ 10 ]
-  let index = s.index(of: 10)!
+  let index = s.firstIndex(of: 10)!
   s.remove(at: index)
   expectFalse(s.contains(10))
   expectCrashLater()

--- a/test/stdlib/StringAPI.swift
+++ b/test/stdlib/StringAPI.swift
@@ -269,11 +269,11 @@ func checkHasPrefixHasSuffix(
     rhs.decomposedStringWithCanonicalMapping.characters.map {
       Array(String($0).unicodeScalars)
     }
-  let expectHasPrefix = lhsNFDGraphemeClusters.starts(
-    with: rhsNFDGraphemeClusters, by: (==))
+  let expectHasPrefix = lhsNFDGraphemeClusters.hasPrefix(
+    rhsNFDGraphemeClusters, by: (==))
 
   let expectHasSuffix = lhsNFDGraphemeClusters.lazy.reversed()
-    .starts(with: rhsNFDGraphemeClusters.lazy.reversed(), by: (==))
+    .hasPrefix(rhsNFDGraphemeClusters.lazy.reversed(), by: (==))
 
   expectEqual(expectHasPrefix, lhs.hasPrefix(rhs), stackTrace: stackTrace)
   expectEqual(expectHasSuffix, lhs.hasSuffix(rhs), stackTrace: stackTrace)

--- a/test/stdlib/StringAPI.swift
+++ b/test/stdlib/StringAPI.swift
@@ -377,7 +377,7 @@ StringTests.test("UnicodeScalarView.Iterator.Lifetime") {
   for s in sources {
     // Append something to s so that it creates a dynamically-allocated buffer.
     let i = (s + "X").unicodeScalars.makeIterator()
-    expectEqualSequence(s.unicodeScalars, IteratorSequence(i).dropLast(),
+    expectEqualSequence(s.unicodeScalars, IteratorSequence(i).removingLast(),
       "Actual Contents: \(Array(IteratorSequence(i)))")
   }
 }

--- a/test/stdlib/StringCompatibilityDiagnostics.swift
+++ b/test/stdlib/StringCompatibilityDiagnostics.swift
@@ -2,9 +2,9 @@
 
 func testPopFirst() {
   var str = "abc"
-  _ = str.popFirst() // expected-error{{'popFirst()' is unavailable: Please use 'first', 'dropFirst()', or 'Substring.popFirst()'}}
+  _ = str.popFirst() // expected-error{{'popFirst()' is unavailable: Please use 'first', 'removingFirst()', or 'Substring.popFirst()'}}
   _ = str.characters.popFirst() // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
-  _ = str.unicodeScalars.popFirst() // expected-error{{'popFirst()' is unavailable: Please use 'first', 'dropFirst()', or 'Substring.UnicodeScalarView.popFirst()'}}
+  _ = str.unicodeScalars.popFirst() // expected-error{{'popFirst()' is unavailable: Please use 'first', 'removingFirst()', or 'Substring.UnicodeScalarView.popFirst()'}}
 
   var charView: String.CharacterView // expected-warning{{'CharacterView' is deprecated: Please use String or Substring directly}}
   charView = str.characters // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}

--- a/test/stdlib/StringCompatibilityDiagnostics3.swift
+++ b/test/stdlib/StringCompatibilityDiagnostics3.swift
@@ -2,10 +2,10 @@
 
 func testPopFirst() {
   var str = "abc"
-  _ = str.popFirst() // expected-warning{{'popFirst()' is deprecated: Please use 'first', 'dropFirst()', or 'Substring.popFirst()'}}
+  _ = str.popFirst() // expected-warning{{'popFirst()' is deprecated: Please use 'first', 'removingFirst()', or 'Substring.popFirst()'}}
   _ = str.characters.popFirst() // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
-    // expected-warning@-1{{'popFirst()' is deprecated: Please use 'first', 'dropFirst()', or 'Substring.CharacterView.popFirst()'}}
-  _ = str.unicodeScalars.popFirst() // expected-warning{{'popFirst()' is deprecated: Please use 'first', 'dropFirst()', or 'Substring.UnicodeScalarView.popFirst()'}}
+    // expected-warning@-1{{'popFirst()' is deprecated: Please use 'first', 'removingFirst()', or 'Substring.CharacterView.popFirst()'}}
+  _ = str.unicodeScalars.popFirst() // expected-warning{{'popFirst()' is deprecated: Please use 'first', 'removingFirst()', or 'Substring.UnicodeScalarView.popFirst()'}}
 
   var charView: String.CharacterView // expected-warning{{'CharacterView' is deprecated: Please use String or Substring directly}}
   charView = str.characters // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}

--- a/test/stdlib/StringCompatibilityDiagnostics4.swift
+++ b/test/stdlib/StringCompatibilityDiagnostics4.swift
@@ -2,10 +2,10 @@
 
 func testPopFirst() {
   var str = "abc"
-  _ = str.popFirst() // expected-error{{'popFirst()' is unavailable: Please use 'first', 'dropFirst()', or 'Substring.popFirst()'}}
+  _ = str.popFirst() // expected-error{{'popFirst()' is unavailable: Please use 'first', 'removingFirst()', or 'Substring.popFirst()'}}
   _ = str.characters.popFirst() // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
-  _ = str.popFirst() // expected-error{{'popFirst()' is unavailable: Please use 'first', 'dropFirst()', or 'Substring.popFirst()'}}
-  _ = str.unicodeScalars.popFirst() // expected-error{{'popFirst()' is unavailable: Please use 'first', 'dropFirst()', or 'Substring.UnicodeScalarView.popFirst()'}}
+  _ = str.popFirst() // expected-error{{'popFirst()' is unavailable: Please use 'first', 'removingFirst()', or 'Substring.popFirst()'}}
+  _ = str.unicodeScalars.popFirst() // expected-error{{'popFirst()' is unavailable: Please use 'first', 'removingFirst()', or 'Substring.UnicodeScalarView.popFirst()'}}
 
   var charView: String.CharacterView // expected-warning{{'CharacterView' is deprecated: Please use String or Substring directly}}
   charView = str.characters // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}

--- a/test/stdlib/TestData.swift
+++ b/test/stdlib/TestData.swift
@@ -1152,9 +1152,9 @@ class TestData : TestDataSuper {
         expectEqual(expected, actual)
     }
 
-    func test_dropFirst() {
+    func test_removingFirst() {
         var data = Data([0, 1, 2, 3, 4, 5])
-        let sliced = data.dropFirst()
+        let sliced = data.removingFirst()
         expectEqual(data.count - 1, sliced.count)
         expectEqual(UInt8(1), sliced[1])
         expectEqual(UInt8(2), sliced[2])
@@ -1163,9 +1163,9 @@ class TestData : TestDataSuper {
         expectEqual(UInt8(5), sliced[5])
     }
 
-    func test_dropFirst2() {
+    func test_removingPrefix2() {
         var data = Data([0, 1, 2, 3, 4, 5])
-        let sliced = data.dropFirst(2)
+        let sliced = data.removingPrefix(2)
         expectEqual(data.count - 2, sliced.count)
         expectEqual(UInt8(2), sliced[2])
         expectEqual(UInt8(3), sliced[3])
@@ -3733,8 +3733,8 @@ DataTests.test("test_sliceEquality") { TestData().test_sliceEquality() }
 DataTests.test("test_sliceEquality2") { TestData().test_sliceEquality2() }
 DataTests.test("test_splittingHttp") { TestData().test_splittingHttp() }
 DataTests.test("test_map") { TestData().test_map() }
-DataTests.test("test_dropFirst") { TestData().test_dropFirst() }
-DataTests.test("test_dropFirst2") { TestData().test_dropFirst2() }
+DataTests.test("test_removingPrefix") { TestData().test_removingFirst() }
+DataTests.test("test_removingPrefix2") { TestData().test_removingPrefix2() }
 DataTests.test("test_copyBytes1") { TestData().test_copyBytes1() }
 DataTests.test("test_copyBytes2") { TestData().test_copyBytes2() }
 DataTests.test("test_sliceOfSliceViaRangeExpression") { TestData().test_sliceOfSliceViaRangeExpression() }

--- a/test/stdlib/TestIndexPath.swift
+++ b/test/stdlib/TestIndexPath.swift
@@ -77,7 +77,7 @@ class TestIndexPath: TestIndexPathSuper {
     
     func testDropLast() {
         let ip: IndexPath = [1, 2, 3, 4]
-        let ip2 = ip.dropLast()
+        let ip2 = ip.removingLast()
         expectEqual(ip2.count, 3)
         expectEqual(ip2[0], 1)
         expectEqual(ip2[1], 2)
@@ -86,26 +86,26 @@ class TestIndexPath: TestIndexPathSuper {
     
     func testDropLastFromEmpty() {
         let ip: IndexPath = []
-        let ip2 = ip.dropLast()
+        let ip2 = ip.removingLast()
         expectEqual(ip2.count, 0)
     }
     
     func testDropLastFromSingle() {
         let ip: IndexPath = [1]
-        let ip2 = ip.dropLast()
+        let ip2 = ip.removingLast()
         expectEqual(ip2.count, 0)
     }
     
     func testDropLastFromPair() {
         let ip: IndexPath = [1, 2]
-        let ip2 = ip.dropLast()
+        let ip2 = ip.removingLast()
         expectEqual(ip2.count, 1)
         expectEqual(ip2[0], 1)
     }
     
     func testDropLastFromTriple() {
         let ip: IndexPath = [1, 2, 3]
-        let ip2 = ip.dropLast()
+        let ip2 = ip.removingLast()
         expectEqual(ip2.count, 2)
         expectEqual(ip2[0], 1)
         expectEqual(ip2[1], 2)
@@ -714,18 +714,18 @@ class TestIndexPath: TestIndexPathSuper {
 
     func test_slice_1ary() {
         let indexPath: IndexPath = [0]
-        let res = indexPath.dropFirst()
+        let res = indexPath.removingFirst()
         expectEqual(0, res.count)
 
         let slice = indexPath[1..<1]
         expectEqual(0, slice.count)
     }
 
-    func test_dropFirst() {
+    func test_removingFirst() {
         var pth = IndexPath(indexes:[1,2,3,4])
         while !pth.isEmpty {
             // this should not crash 
-            pth = pth.dropFirst()
+            pth = pth.removingFirst()
         }
     }
 }
@@ -780,6 +780,6 @@ IndexPathTests.test("test_AnyHashableContainingIndexPath") { TestIndexPath().tes
 IndexPathTests.test("test_AnyHashableCreatedFromNSIndexPath") { TestIndexPath().test_AnyHashableCreatedFromNSIndexPath() }
 IndexPathTests.test("test_unconditionallyBridgeFromObjectiveC") { TestIndexPath().test_unconditionallyBridgeFromObjectiveC() }
 IndexPathTests.test("test_slice_1ary") { TestIndexPath().test_slice_1ary() }
-IndexPathTests.test("test_dropFirst") { TestIndexPath().test_dropFirst() }
+IndexPathTests.test("test_removingPrefix") { TestIndexPath().test_removingFirst() }
 runAllTests()
 #endif

--- a/test/stdlib/subString.swift
+++ b/test/stdlib/subString.swift
@@ -43,7 +43,7 @@ SubstringTests.test("Equality") {
   expectNotEqual(s.dropLast(2), s.dropLast(1))
   expectEqual(s.dropFirst(1), s.dropFirst(1))
   expectTrue(s != s[...].dropFirst(1))
-  let i = emoji.index(of: "😄")!
+  let i = emoji.firstIndex(of: "😄")!
   expectEqual("😄👍🏽" as String, emoji[i...].prefix(2))
   expectTrue("😄👍🏽🇫🇷👩‍👩‍👧‍👦🙈😡🇧🇪" as String == emoji[i...].dropLast(2))
   expectTrue("🇫🇷👩‍👩‍👧‍👦🙈😡🇧🇪" as String == emoji[i...].dropLast(2).dropFirst(2))

--- a/test/stdlib/subString.swift
+++ b/test/stdlib/subString.swift
@@ -22,8 +22,8 @@ SubstringTests.test("Equality") {
   expectEqual(s1, "cd")
   expectEqual(s2, "cd")
   expectEqual(s3, "cd")
-	expectTrue("" == s.dropFirst(s.count))
-	expectTrue(s.dropFirst().dropFirst(s.count) == s.dropFirst(s.count))
+	expectTrue("" == s.removingPrefix(s.count))
+	expectTrue(s.removingFirst().removingPrefix(s.count) == s.removingPrefix(s.count))
   
   expectEqual("ab" as String, s.prefix(2))
   expectEqual("fg" as String, s.suffix(2))
@@ -32,24 +32,24 @@ SubstringTests.test("Equality") {
   let emoji: String = s + "😄👍🏽🇫🇷👩‍👩‍👧‍👦🙈" + "😡🇧🇪🇨🇦🇮🇳"
   expectTrue(s == s[...])
   expectTrue(s[...] == s)
-  expectTrue(s.dropFirst(2) != s)
-  expectTrue(s == s.dropFirst(0))
-  expectTrue(s != s.dropFirst(1))
-  expectTrue(s != s.dropLast(1))
+  expectTrue(s.removingPrefix(2) != s)
+  expectTrue(s == s.removingPrefix(0))
+  expectTrue(s != s.removingPrefix(1))
+  expectTrue(s != s.removingSuffix(1))
   expectEqual(s[...], s[...])
-  expectEqual(s.dropFirst(0), s.dropFirst(0))
-  expectTrue(s == s.dropFirst(0))
-  expectTrue(s.dropFirst(2) != s.dropFirst(1))
-  expectNotEqual(s.dropLast(2), s.dropLast(1))
-  expectEqual(s.dropFirst(1), s.dropFirst(1))
-  expectTrue(s != s[...].dropFirst(1))
+  expectEqual(s.removingPrefix(0), s.removingPrefix(0))
+  expectTrue(s == s.removingPrefix(0))
+  expectTrue(s.removingPrefix(2) != s.removingPrefix(1))
+  expectNotEqual(s.removingSuffix(2), s.removingSuffix(1))
+  expectEqual(s.removingPrefix(1), s.removingPrefix(1))
+  expectTrue(s != s[...].removingPrefix(1))
   let i = emoji.firstIndex(of: "😄")!
   expectEqual("😄👍🏽" as String, emoji[i...].prefix(2))
-  expectTrue("😄👍🏽🇫🇷👩‍👩‍👧‍👦🙈😡🇧🇪" as String == emoji[i...].dropLast(2))
-  expectTrue("🇫🇷👩‍👩‍👧‍👦🙈😡🇧🇪" as String == emoji[i...].dropLast(2).dropFirst(2))
-  expectTrue(s as String != emoji[i...].dropLast(2).dropFirst(2))
-  expectEqualSequence("😄👍🏽🇫🇷👩‍👩‍👧‍👦🙈😡🇧🇪" as String, emoji[i...].dropLast(2))
-  expectEqualSequence("🇫🇷👩‍👩‍👧‍👦🙈😡🇧🇪" as String, emoji[i...].dropLast(2).dropFirst(2))
+  expectTrue("😄👍🏽🇫🇷👩‍👩‍👧‍👦🙈😡🇧🇪" as String == emoji[i...].removingSuffix(2))
+  expectTrue("🇫🇷👩‍👩‍👧‍👦🙈😡🇧🇪" as String == emoji[i...].removingSuffix(2).removingPrefix(2))
+  expectTrue(s as String != emoji[i...].removingSuffix(2).removingPrefix(2))
+  expectEqualSequence("😄👍🏽🇫🇷👩‍👩‍👧‍👦🙈😡🇧🇪" as String, emoji[i...].removingSuffix(2))
+  expectEqualSequence("🇫🇷👩‍👩‍👧‍👦🙈😡🇧🇪" as String, emoji[i...].removingSuffix(2).removingPrefix(2))
 #endif
 	// equatable conformance
 	expectTrue("one,two,three".split(separator: ",").contains("two"))
@@ -72,20 +72,20 @@ SubstringTests.test("Comparison") {
 	expectTrue(s[...] >= s[...])
 	expectFalse(s[...] > s[...])
 
-	expectTrue(s < s.dropFirst())
-	expectFalse(s > s.dropFirst())
-	expectFalse(s < s.dropLast())
-	expectTrue(s > s.dropLast())
-	expectTrue(s.dropFirst() < s.dropFirst(2))
-	expectFalse(s.dropFirst() > s.dropFirst(2))
-	expectFalse(s.dropLast() < s.dropLast(2))
-	expectTrue(s.dropLast() > s.dropLast(2))
-	expectFalse(s.dropFirst() < s.dropFirst().dropLast())
-	expectTrue(s.dropFirst() > s.dropFirst().dropLast())
-	expectTrue(s.dropFirst() > s)
-	expectTrue(s.dropFirst() > s[...])
+	expectTrue(s < s.removingFirst())
+	expectFalse(s > s.removingFirst())
+	expectFalse(s < s.removingLast())
+	expectTrue(s > s.removingLast())
+	expectTrue(s.removingFirst() < s.removingPrefix(2))
+	expectFalse(s.removingFirst() > s.removingPrefix(2))
+	expectFalse(s.removingLast() < s.removingSuffix(2))
+	expectTrue(s.removingLast() > s.removingSuffix(2))
+	expectFalse(s.removingFirst() < s.removingFirst().removingLast())
+	expectTrue(s.removingFirst() > s.removingFirst().removingLast())
+	expectTrue(s.removingFirst() > s)
+	expectTrue(s.removingFirst() > s[...])
 	expectTrue(s >= s[...])
-	expectTrue(s.dropFirst() >= s.dropFirst())
+	expectTrue(s.removingFirst() >= s.removingFirst())
 
 	// comparable conformance
 	expectEqualSequence("pen,pineapple,apple,pen".split(separator: ",").sorted(),
@@ -93,7 +93,7 @@ SubstringTests.test("Comparison") {
 }
 
 SubstringTests.test("Filter") {
-  var name = "😂Edward Woodward".dropFirst()
+  var name = "😂Edward Woodward".removingFirst()
   var filtered = name.filter { $0 != "d" }
   expectType(Substring.self, &name)
   expectType(String.self, &filtered)
@@ -102,8 +102,8 @@ SubstringTests.test("Filter") {
 
 SubstringTests.test("CharacterView") {
   let s = "abcdefg"
-  var t = s.characters.dropFirst(2)
-  var u = t.dropFirst(2)
+  var t = s.characters.removingPrefix(2)
+  var u = t.removingPrefix(2)
   
   checkMatch(s.characters, t, t.startIndex)
   checkMatch(s.characters, t, t.index(after: t.startIndex))
@@ -114,10 +114,10 @@ SubstringTests.test("CharacterView") {
   checkMatch(t, u, u.index(after: u.startIndex))
   checkMatch(t, u, u.index(before: u.endIndex))
   
-  expectEqual("", String(t.dropFirst(10)))
-  expectEqual("", String(t.dropLast(10)))
-  expectEqual("", String(u.dropFirst(10)))
-  expectEqual("", String(u.dropLast(10)))
+  expectEqual("", String(t.removingPrefix(10)))
+  expectEqual("", String(t.removingSuffix(10)))
+  expectEqual("", String(u.removingPrefix(10)))
+  expectEqual("", String(u.removingSuffix(10)))
   
   t.replaceSubrange(t.startIndex...t.startIndex, with: ["C"])
   u.replaceSubrange(u.startIndex...u.startIndex, with: ["E"])
@@ -128,8 +128,8 @@ SubstringTests.test("CharacterView") {
 
 SubstringTests.test("UnicodeScalars") {
   let s = "abcdefg"
-  var t = s.unicodeScalars.dropFirst(2)
-  var u = t.dropFirst(2)
+  var t = s.unicodeScalars.removingPrefix(2)
+  var u = t.removingPrefix(2)
   
   checkMatch(s.unicodeScalars, t, t.startIndex)
   checkMatch(s.unicodeScalars, t, t.index(after: t.startIndex))
@@ -140,10 +140,10 @@ SubstringTests.test("UnicodeScalars") {
   checkMatch(t, u, u.index(after: u.startIndex))
   checkMatch(t, u, u.index(before: u.endIndex))
   
-  expectEqual("", String(t.dropFirst(10)))
-  expectEqual("", String(t.dropLast(10)))
-  expectEqual("", String(u.dropFirst(10)))
-  expectEqual("", String(u.dropLast(10)))
+  expectEqual("", String(t.removingPrefix(10)))
+  expectEqual("", String(t.removingSuffix(10)))
+  expectEqual("", String(u.removingPrefix(10)))
+  expectEqual("", String(u.removingSuffix(10)))
   
   t.replaceSubrange(t.startIndex...t.startIndex, with: ["C"])
   u.replaceSubrange(u.startIndex...u.startIndex, with: ["E"])
@@ -154,8 +154,8 @@ SubstringTests.test("UnicodeScalars") {
 
 SubstringTests.test("UTF16View") {
   let s = "abcdefg"
-  let t = s.utf16.dropFirst(2)
-  let u = t.dropFirst(2)
+  let t = s.utf16.removingPrefix(2)
+  let u = t.removingPrefix(2)
   
   checkMatch(s.utf16, t, t.startIndex)
   checkMatch(s.utf16, t, t.index(after: t.startIndex))
@@ -166,16 +166,16 @@ SubstringTests.test("UTF16View") {
   checkMatch(t, u, u.index(after: u.startIndex))
   checkMatch(t, u, u.index(before: u.endIndex))
   
-  expectEqual("", String(t.dropFirst(10))!)
-  expectEqual("", String(t.dropLast(10))!)
-  expectEqual("", String(u.dropFirst(10))!)
-  expectEqual("", String(u.dropLast(10))!)
+  expectEqual("", String(t.removingPrefix(10))!)
+  expectEqual("", String(t.removingSuffix(10))!)
+  expectEqual("", String(u.removingPrefix(10))!)
+  expectEqual("", String(u.removingSuffix(10))!)
 }
 
 SubstringTests.test("UTF8View") {
   let s = "abcdefg"
-  let t = s.utf8.dropFirst(2)
-  let u = t.dropFirst(2)
+  let t = s.utf8.removingPrefix(2)
+  let u = t.removingPrefix(2)
   
   checkMatch(s.utf8, t, t.startIndex)
   checkMatch(s.utf8, t, t.index(after: t.startIndex))
@@ -184,17 +184,17 @@ SubstringTests.test("UTF8View") {
   checkMatch(t, u, u.startIndex)
   checkMatch(t, u, u.index(after: u.startIndex))
 
-  expectEqual("", String(t.dropFirst(10))!)
-  expectEqual("", String(t.dropLast(10))!)
-  expectEqual("", String(u.dropFirst(10))!)
-  expectEqual("", String(u.dropLast(10))!)
+  expectEqual("", String(t.removingPrefix(10))!)
+  expectEqual("", String(t.removingSuffix(10))!)
+  expectEqual("", String(u.removingPrefix(10))!)
+  expectEqual("", String(u.removingSuffix(10))!)
 }
 
 SubstringTests.test("Persistent Content") {
   var str = "abc"
   str += "def"
-  expectEqual("bcdefg", str.dropFirst(1) + "g")
-  expectEqual("bcdefg", (str.dropFirst(1) + "g") as String)
+  expectEqual("bcdefg", str.removingPrefix(1) + "g")
+  expectEqual("bcdefg", (str.removingPrefix(1) + "g") as String)
 }
 
 runAllTests()

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar28145033.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar28145033.swift
@@ -1,4 +1,4 @@
 // RUN: not %target-swift-frontend %s -typecheck
 
 let a = [1]
-_ = a.index(of: a.min()) // a.min() returns an optional
+_ = a.firstIndex(of: a.min()) // a.min() returns an optional

--- a/validation-test/compiler_crashers_2_fixed/0109-sr4737.swift
+++ b/validation-test/compiler_crashers_2_fixed/0109-sr4737.swift
@@ -933,7 +933,7 @@ func checkDecodeUTF<Codec : UnicodeCodec & UnicodeEncoding>(
       expectEqual(1, errorCount)
       let x = (expected + expectedRepairedTail).reversed()
       expectTrue(
-        x.starts(with: decoded),
+        x.hasPrefix(decoded),
         "reverse, repairing: false\n\t\(Array(x)) does not start with \(decoded)")
       decoded.removeAll(keepingCapacity: true)
     }

--- a/validation-test/stdlib/Algorithm.swift
+++ b/validation-test/stdlib/Algorithm.swift
@@ -234,7 +234,7 @@ Algorithm.test("sort3/simple")
 }
 
 func isSorted<T>(_ a: [T], by areInIncreasingOrder: (T, T) -> Bool) -> Bool {
-  return !a.dropFirst().enumerated().contains(where: { (offset, element) in
+  return !a.removingFirst().enumerated().contains(where: { (offset, element) in
     areInIncreasingOrder(element, a[offset])
   })
 }

--- a/validation-test/stdlib/CollectionType.swift.gyb
+++ b/validation-test/stdlib/CollectionType.swift.gyb
@@ -628,12 +628,12 @@ CollectionTypeTests.test("count/dispatch") {
 }
 
 //===----------------------------------------------------------------------===//
-// index(of:)
+// firstIndex(of:)
 //===----------------------------------------------------------------------===//
 
-CollectionTypeTests.test("index(of:)/WhereElementIsEquatable/dispatch") {
+CollectionTypeTests.test("firstIndex(of:)/WhereElementIsEquatable/dispatch") {
   let tester = CollectionLog.dispatchTester([MinimalEquatableValue(1)])
-  _ = tester.index(of: MinimalEquatableValue(1))
+  _ = tester.firstIndex(of: MinimalEquatableValue(1))
   expectCustomizable(tester, tester.log._customIndexOfEquatableElement)
 }
 
@@ -644,14 +644,14 @@ func callGenericFind_<
   C : Collection
 >(_ collection: C, _ element: C.Iterator.Element) -> C.Index? 
 where C.Iterator.Element : Equatable {
-  return collection.index(of: element)
+  return collection.firstIndex(of: element)
 }
 
 func callStaticFind_(
   _ set: Set<MinimalHashableValue>,
   _ element: MinimalHashableValue
 ) -> Set<MinimalHashableValue>.Index? {
-  return set.index(of: element)
+  return set.firstIndex(of: element)
 }
 
 % for dispatch in [ 'Static', 'Generic' ]:
@@ -706,7 +706,7 @@ extension Collection where
   func _test_indicesOf(_ element: Iterator.Element) -> [Index] {
     var result: [Index] = []
     var tail = self[startIndex..<endIndex]
-    while let foundIndex = tail.index(of: element) {
+    while let foundIndex = tail.firstIndex(of: element) {
       result.append(foundIndex)
       tail = tail[index(after: foundIndex)..<endIndex]
     }
@@ -714,7 +714,7 @@ extension Collection where
   }
 }
 
-CollectionTypeTests.test("index(of:)/ContinueSearch") {
+CollectionTypeTests.test("firstIndex(of:)/ContinueSearch") {
   do {
     let c = MinimalCollection(elements: [] as [MinimalEquatableValue])
     expectEqualSequence(

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -1374,9 +1374,9 @@ DictionaryTestSuite.test("COW.Fast.KeysAccessDoesNotReallocate") {
     var lastKey: MinimalHashableValue = d2.first!.key
     for i in d2.indices { lastKey = d2[i].key }
 
-    // index(where:) - linear search
+    // firstIndex(where:) - linear search
     MinimalHashableValue.timesEqualEqualWasCalled = 0
-    let j = d2.index(where: { (k, _) in k == lastKey })!
+    let j = d2.firstIndex(where: { (k, _) in k == lastKey })!
     expectGE(MinimalHashableValue.timesEqualEqualWasCalled, 8)
 
     // index(forKey:) - O(1) bucket + linear search
@@ -1384,9 +1384,9 @@ DictionaryTestSuite.test("COW.Fast.KeysAccessDoesNotReallocate") {
     let k = d2.index(forKey: lastKey)!
     expectLE(MinimalHashableValue.timesEqualEqualWasCalled, 4)
     
-    // keys.index(of:) - O(1) bucket + linear search
+    // keys.firstIndex(of:) - O(1) bucket + linear search
     MinimalHashableValue.timesEqualEqualWasCalled = 0
-    let l = d2.keys.index(of: lastKey)!
+    let l = d2.keys.firstIndex(of: lastKey)!
 #if swift(>=4.0)
     expectLE(MinimalHashableValue.timesEqualEqualWasCalled, 4)
 #endif
@@ -4397,11 +4397,11 @@ DictionaryTestSuite.test("misc") {
     expectOptionalEqual(4, d3["four"])
     expectOptionalEqual(5, d3["five"])
 
-    expectEqual(3, d.values[d.keys.index(of: "three")!])
-    expectEqual(4, d.values[d.keys.index(of: "four")!])
+    expectEqual(3, d.values[d.keys.firstIndex(of: "three")!])
+    expectEqual(4, d.values[d.keys.firstIndex(of: "four")!])
 
-    expectEqual(3, d3.values[d3.keys.index(of: "three")!])
-    expectEqual(4, d3.values[d3.keys.index(of: "four")!])
+    expectEqual(3, d3.values[d3.keys.firstIndex(of: "three")!])
+    expectEqual(4, d3.values[d3.keys.firstIndex(of: "four")!])
   }
 }
 

--- a/validation-test/stdlib/ExistentialCollection.swift.gyb
+++ b/validation-test/stdlib/ExistentialCollection.swift.gyb
@@ -358,7 +358,7 @@ tests.test("ForwardCollection") {
   let a1 = ContiguousArray(fc0)
   expectEqual(a0, a1)
   for e in a0 {
-    let i = fc0.index(of: e)
+    let i = fc0.firstIndex(of: e)
     expectNotNil(i)
     expectEqual(e, fc0[i!])
   }
@@ -386,7 +386,7 @@ tests.test("BidirectionalCollection") {
   let a1 = ContiguousArray(bc0.lazy.reversed())
   expectEqual(a0, a1)
   for e in a0 {
-    let i = bc0.index(of: e)
+    let i = bc0.firstIndex(of: e)
     expectNotNil(i)
     expectEqual(e, bc0[i!])
   }
@@ -421,7 +421,7 @@ tests.test("RandomAccessCollection") {
   let a1 = ContiguousArray(rc0.lazy.reversed())
   expectEqual(a0, a1)
   for e in a0 {
-    let i = rc0.index(of: e)
+    let i = rc0.firstIndex(of: e)
     expectNotNil(i)
     expectEqual(e, rc0[i!])
   }

--- a/validation-test/stdlib/ExistentialCollection.swift.gyb
+++ b/validation-test/stdlib/ExistentialCollection.swift.gyb
@@ -171,8 +171,8 @@ tests.test("${TestedType}: dispatch to wrapped, SequenceLog") {
     _ = s.removingSuffix(0)
   }
 
-  Log.dropWhile.expectIncrement(Base.self) {
-    _ = s.drop { (_) in true }
+  Log.removingPrefixWhile.expectIncrement(Base.self) {
+    _ = s.removingPrefix { (_) in true }
   }
 
   Log.prefixWhile.expectIncrement(Base.self) {

--- a/validation-test/stdlib/ExistentialCollection.swift.gyb
+++ b/validation-test/stdlib/ExistentialCollection.swift.gyb
@@ -163,12 +163,12 @@ tests.test("${TestedType}: dispatch to wrapped, SequenceLog") {
     _ = s.forEach { (_) in }
   }
 
-  Log.dropFirst.expectIncrement(Base.self) {
-    _ = s.dropFirst(0)
+  Log.removingPrefix.expectIncrement(Base.self) {
+    _ = s.removingPrefix(0)
   }
 
-  Log.dropLast.expectIncrement(Base.self) {
-    _ = s.dropLast(0)
+  Log.removingSuffix.expectIncrement(Base.self) {
+    _ = s.removingSuffix(0)
   }
 
   Log.dropWhile.expectIncrement(Base.self) {

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -1389,7 +1389,7 @@ tests.test("LazyDropWhile${Self}").forEach(in: prefixDropWhileTests) {
   let base = Minimal${Self}(elements: data)
 
   var calls1 = 0
-  let dropped = base.lazy.drop(while: { calls1 += 1; return $0 != value })
+  let dropped = base.lazy.removingPrefix(while: { calls1 += 1; return $0 != value })
   let expected = data.suffix(from: pivot)
   expectEqual(0, calls1)
   check${checkKind}(expected, dropped)

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -943,23 +943,23 @@ SequenceTypeTests.test("forEach/dispatch") {
 }
 
 //===----------------------------------------------------------------------===//
-// dropFirst()
+// removingPrefix()
 //===----------------------------------------------------------------------===//
 
-SequenceTypeTests.test("dropFirst/dispatch") {
+SequenceTypeTests.test("removingPrefix/dispatch") {
   var tester = SequenceLog.dispatchTester([OpaqueValue(1)])
-  _ = tester.dropFirst(1)
-  expectCustomizable(tester, tester.log.dropFirst)
+  _ = tester.removingPrefix(1)
+  expectCustomizable(tester, tester.log.removingPrefix)
 }
 
 //===----------------------------------------------------------------------===//
-// dropLast()
+// removingSuffix()
 //===----------------------------------------------------------------------===//
 
-SequenceTypeTests.test("dropLast/dispatch") {
+SequenceTypeTests.test("removingSuffix/dispatch") {
   var tester = SequenceLog.dispatchTester([OpaqueValue(1)])
-  _ = tester.dropLast(1)
-  expectCustomizable(tester, tester.log.dropLast)
+  _ = tester.removingSuffix(1)
+  expectCustomizable(tester, tester.log.removingSuffix)
 }
 
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -963,13 +963,13 @@ SequenceTypeTests.test("removingSuffix/dispatch") {
 }
 
 //===----------------------------------------------------------------------===//
-// drop(while:)
+// removingPrefix(while:)
 //===----------------------------------------------------------------------===//
 
-SequenceTypeTests.test("drop(while:)/dispatch") {
+SequenceTypeTests.test("removingPrefix(while:)/dispatch") {
   var tester = SequenceLog.dispatchTester([OpaqueValue(1)])
-  tester.drop { _ in return false }
-  expectCustomizable(tester, tester.log.dropWhile)
+  tester.removingPrefix { _ in return false }
+  expectCustomizable(tester, tester.log.removingPrefixWhile)
 }
 
 //===----------------------------------------------------------------------===//
@@ -982,9 +982,9 @@ SequenceTypeTests.test("prefix/dispatch") {
   expectCustomizable(tester, tester.log.prefixMaxLength)
 }
 
-SequenceTypeTests.test("prefix/drop/dispatch") {
+SequenceTypeTests.test("prefix/removingPrefix/dispatch") {
   let xs = sequence(first: 1, next: {$0 < 10 ? $0 + 1 : nil})
-  expectEqualSequence([], Array(xs.prefix(3).drop(while: {$0 < 7})))
+  expectEqualSequence([], Array(xs.prefix(3).removingPrefix(while: {$0 < 7})))
 }
 
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -49,7 +49,7 @@ var SequenceTypeTests = TestSuite("Sequence")
 //
 // - NaN behavior of floating point types, combined with these generic
 // algorithms, should make sense if possible.  For example,
-// [1.0, Double.nan].starts(with: [1.0, 2.0]) should be false.
+// [1.0, Double.nan].hasPrefix([1.0, 2.0]) should be false.
 
 //===----------------------------------------------------------------------===//
 // min(), max()
@@ -274,11 +274,11 @@ SequenceTypeTests.test("enumerated()") {
 }
 
 //===----------------------------------------------------------------------===//
-// starts(with:)
+// hasPrefix(_:)
 //===----------------------------------------------------------------------===//
 
-SequenceTypeTests.test("starts(with:)/WhereElementIsEquatable") {
-  for test in startsWithTests {
+SequenceTypeTests.test("hasPrefix(_:)/WhereElementIsEquatable") {
+  for test in hasPrefixTests {
     do {
       let s = MinimalSequence<MinimalEquatableValue>(
         elements: test.sequence.map(MinimalEquatableValue.init))
@@ -286,7 +286,7 @@ SequenceTypeTests.test("starts(with:)/WhereElementIsEquatable") {
         elements: test.prefix.map(MinimalEquatableValue.init))
       expectEqual(
         test.expected,
-        s.starts(with: prefix),
+        s.hasPrefix(prefix),
         stackTrace: SourceLocStack().with(test.loc))
       expectEqual(
         test.expectedLeftoverSequence, s.map { $0.value },
@@ -304,7 +304,7 @@ SequenceTypeTests.test("starts(with:)/WhereElementIsEquatable") {
         elements: test.prefix.map(MinimalEquatableValue.init))
       expectEqual(
         test.expected,
-        s.starts(with: prefix),
+        s.hasPrefix(prefix),
         stackTrace: SourceLocStack().with(test.loc))
       expectEqual(
         test.sequence, s.map { $0.value },
@@ -316,8 +316,8 @@ SequenceTypeTests.test("starts(with:)/WhereElementIsEquatable") {
   }
 }
 
-SequenceTypeTests.test("starts(with:)/Predicate") {
-  for test in startsWithTests {
+SequenceTypeTests.test("hasPrefix(_:)/Predicate") {
+  for test in hasPrefixTests {
     do {
       let s = MinimalSequence<OpaqueValue<Int>>(
         elements: test.sequence.map(OpaqueValue.init))
@@ -325,7 +325,7 @@ SequenceTypeTests.test("starts(with:)/Predicate") {
         elements: test.prefix.map(OpaqueValue.init))
       expectEqual(
         test.expected,
-        s.starts(with: prefix) { $0.value == $1.value },
+        s.hasPrefix(prefix) { $0.value == $1.value },
         stackTrace: SourceLocStack().with(test.loc))
       expectEqual(
         test.expectedLeftoverSequence, s.map { $0.value },
@@ -341,7 +341,7 @@ SequenceTypeTests.test("starts(with:)/Predicate") {
         elements: test.prefix.map(OpaqueValue.init))
       expectEqual(
         test.expected,
-        s.starts(with: prefix) { $0.value / 2 == $1.value },
+        s.hasPrefix(prefix) { $0.value / 2 == $1.value },
         stackTrace: SourceLocStack().with(test.loc))
       expectEqual(
         test.expectedLeftoverSequence, s.map { $0.value / 2 },
@@ -359,7 +359,7 @@ SequenceTypeTests.test("starts(with:)/Predicate") {
         elements: test.prefix.map(OpaqueValue.init))
       expectEqual(
         test.expected,
-        s.starts(with: prefix) { $0.value == $1.value },
+        s.hasPrefix(prefix) { $0.value == $1.value },
         stackTrace: SourceLocStack().with(test.loc))
       expectEqual(
         test.sequence, s.map { $0.value },

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -598,10 +598,10 @@ SetTestSuite.test("COW.Fast.IndexForMemberDoesNotReallocate") {
 
   // Find an existing key.
   do {
-    var foundIndex1 = s.index(of: 1010)!
+    var foundIndex1 = s.firstIndex(of: 1010)!
     expectEqual(identity1, s._rawIdentifier())
 
-    var foundIndex2 = s.index(of: 1010)!
+    var foundIndex2 = s.firstIndex(of: 1010)!
     expectEqual(foundIndex1, foundIndex2)
 
     expectEqual(1010, s[foundIndex1])
@@ -610,7 +610,7 @@ SetTestSuite.test("COW.Fast.IndexForMemberDoesNotReallocate") {
 
   // Try to find a key that is not present.
   do {
-    var foundIndex1 = s.index(of: 1111)
+    var foundIndex1 = s.firstIndex(of: 1111)
     expectNil(foundIndex1)
     expectEqual(identity1, s._rawIdentifier())
   }
@@ -619,7 +619,7 @@ SetTestSuite.test("COW.Fast.IndexForMemberDoesNotReallocate") {
     var s2: Set<MinimalHashableValue> = []
     MinimalHashableValue.timesEqualEqualWasCalled = 0
     MinimalHashableValue.timesHashValueWasCalled = 0
-    expectNil(s2.index(of: MinimalHashableValue(42)))
+    expectNil(s2.firstIndex(of: MinimalHashableValue(42)))
 
     // If the set is empty, we shouldn't be computing the hash value of the
     // provided key.
@@ -634,10 +634,10 @@ SetTestSuite.test("COW.Slow.IndexForMemberDoesNotReallocate") {
 
   // Find an existing key.
   do {
-    var foundIndex1 = s.index(of: TestKeyTy(1010))!
+    var foundIndex1 = s.firstIndex(of: TestKeyTy(1010))!
     expectEqual(identity1, s._rawIdentifier())
 
-    var foundIndex2 = s.index(of: TestKeyTy(1010))!
+    var foundIndex2 = s.firstIndex(of: TestKeyTy(1010))!
     expectEqual(foundIndex1, foundIndex2)
 
     expectEqual(TestKeyTy(1010), s[foundIndex1])
@@ -646,7 +646,7 @@ SetTestSuite.test("COW.Slow.IndexForMemberDoesNotReallocate") {
 
   // Try to find a key that is not present.
   do {
-    var foundIndex1 = s.index(of: TestKeyTy(1111))
+    var foundIndex1 = s.firstIndex(of: TestKeyTy(1111))
     expectNil(foundIndex1)
     expectEqual(identity1, s._rawIdentifier())
   }
@@ -655,7 +655,7 @@ SetTestSuite.test("COW.Slow.IndexForMemberDoesNotReallocate") {
     var s2: Set<MinimalHashableClass> = []
     MinimalHashableClass.timesEqualEqualWasCalled = 0
     MinimalHashableClass.timesHashValueWasCalled = 0
-    expectNil(s2.index(of: MinimalHashableClass(42)))
+    expectNil(s2.firstIndex(of: MinimalHashableClass(42)))
 
     // If the set is empty, we shouldn't be computing the hash value of the
     // provided key.
@@ -672,7 +672,7 @@ SetTestSuite.test("COW.Fast.RemoveAtDoesNotReallocate")
     var s = getCOWFastSet()
     var identity1 = s._rawIdentifier()
 
-    let foundIndex1 = s.index(of: 1010)!
+    let foundIndex1 = s.firstIndex(of: 1010)!
     expectEqual(identity1, s._rawIdentifier())
 
     expectEqual(1010, s[foundIndex1])
@@ -681,7 +681,7 @@ SetTestSuite.test("COW.Fast.RemoveAtDoesNotReallocate")
     expectEqual(1010, removed)
 
     expectEqual(identity1, s._rawIdentifier())
-    expectNil(s.index(of: 1010))
+    expectNil(s.firstIndex(of: 1010))
   }
 
   do {
@@ -692,7 +692,7 @@ SetTestSuite.test("COW.Fast.RemoveAtDoesNotReallocate")
     expectEqual(identity1, s1._rawIdentifier())
     expectEqual(identity1, s2._rawIdentifier())
 
-    var foundIndex1 = s2.index(of: 1010)!
+    var foundIndex1 = s2.firstIndex(of: 1010)!
     expectEqual(1010, s2[foundIndex1])
     expectEqual(identity1, s1._rawIdentifier())
     expectEqual(identity1, s2._rawIdentifier())
@@ -702,7 +702,7 @@ SetTestSuite.test("COW.Fast.RemoveAtDoesNotReallocate")
 
     expectEqual(identity1, s1._rawIdentifier())
     expectNotEqual(identity1, s2._rawIdentifier())
-    expectNil(s2.index(of: 1010))
+    expectNil(s2.firstIndex(of: 1010))
   }
 }
 
@@ -714,7 +714,7 @@ SetTestSuite.test("COW.Slow.RemoveAtDoesNotReallocate")
     var s = getCOWSlowSet()
     var identity1 = s._rawIdentifier()
 
-    let foundIndex1 = s.index(of: TestKeyTy(1010))!
+    let foundIndex1 = s.firstIndex(of: TestKeyTy(1010))!
     expectEqual(identity1, s._rawIdentifier())
 
     expectEqual(TestKeyTy(1010), s[foundIndex1])
@@ -723,7 +723,7 @@ SetTestSuite.test("COW.Slow.RemoveAtDoesNotReallocate")
     expectEqual(TestKeyTy(1010), removed)
 
     expectEqual(identity1, s._rawIdentifier())
-    expectNil(s.index(of: TestKeyTy(1010)))
+    expectNil(s.firstIndex(of: TestKeyTy(1010)))
   }
 
   do {
@@ -734,7 +734,7 @@ SetTestSuite.test("COW.Slow.RemoveAtDoesNotReallocate")
     expectEqual(identity1, s1._rawIdentifier())
     expectEqual(identity1, s2._rawIdentifier())
 
-    var foundIndex1 = s2.index(of: TestKeyTy(1010))!
+    var foundIndex1 = s2.firstIndex(of: TestKeyTy(1010))!
     expectEqual(TestKeyTy(1010), s2[foundIndex1])
     expectEqual(identity1, s1._rawIdentifier())
     expectEqual(identity1, s2._rawIdentifier())
@@ -744,7 +744,7 @@ SetTestSuite.test("COW.Slow.RemoveAtDoesNotReallocate")
 
     expectEqual(identity1, s1._rawIdentifier())
     expectNotEqual(identity1, s2._rawIdentifier())
-    expectNil(s2.index(of: TestKeyTy(1010)))
+    expectNil(s2.firstIndex(of: TestKeyTy(1010)))
   }
 }
 
@@ -1361,17 +1361,17 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.IndexForMember") {
   expectTrue(isCocoaSet(s))
 
   // Find an existing key.
-  var member = s[s.index(of: TestObjCKeyTy(1010))!]
+  var member = s[s.firstIndex(of: TestObjCKeyTy(1010))!]
   expectEqual(TestObjCKeyTy(1010), member)
 
-  member = s[s.index(of: TestObjCKeyTy(2020))!]
+  member = s[s.firstIndex(of: TestObjCKeyTy(2020))!]
   expectEqual(TestObjCKeyTy(2020), member)
 
-  member = s[s.index(of: TestObjCKeyTy(3030))!]
+  member = s[s.firstIndex(of: TestObjCKeyTy(3030))!]
   expectEqual(TestObjCKeyTy(3030), member)
 
   // Try to find a key that does not exist.
-  expectNil(s.index(of: TestObjCKeyTy(4040)))
+  expectNil(s.firstIndex(of: TestObjCKeyTy(4040)))
   expectEqual(identity1, s._rawIdentifier())
 }
 
@@ -1380,17 +1380,17 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.IndexForMember") {
   var identity1 = s._rawIdentifier()
 
   do {
-    var member = s[s.index(of: TestBridgedKeyTy(1010))!]
+    var member = s[s.firstIndex(of: TestBridgedKeyTy(1010))!]
     expectEqual(TestBridgedKeyTy(1010), member)
 
-    member = s[s.index(of: TestBridgedKeyTy(2020))!]
+    member = s[s.firstIndex(of: TestBridgedKeyTy(2020))!]
     expectEqual(TestBridgedKeyTy(2020), member)
 
-    member = s[s.index(of: TestBridgedKeyTy(3030))!]
+    member = s[s.firstIndex(of: TestBridgedKeyTy(3030))!]
     expectEqual(TestBridgedKeyTy(3030), member)
   }
 
-  expectNil(s.index(of: TestBridgedKeyTy(4040)))
+  expectNil(s.firstIndex(of: TestBridgedKeyTy(4040)))
   expectEqual(identity1, s._rawIdentifier())
 }
 
@@ -1650,7 +1650,7 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.RemoveAt") {
   let identity1 = s._rawIdentifier()
   expectTrue(isCocoaSet(s))
 
-  let foundIndex1 = s.index(of: TestObjCKeyTy(1010))!
+  let foundIndex1 = s.firstIndex(of: TestObjCKeyTy(1010))!
   expectEqual(TestObjCKeyTy(1010), s[foundIndex1])
   expectEqual(identity1, s._rawIdentifier())
 
@@ -1659,7 +1659,7 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.RemoveAt") {
   expectTrue(isNativeSet(s))
   expectEqual(2, s.count)
   expectEqual(TestObjCKeyTy(1010), removedElement)
-  expectNil(s.index(of: TestObjCKeyTy(1010)))
+  expectNil(s.firstIndex(of: TestObjCKeyTy(1010)))
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAt")
@@ -1670,7 +1670,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAt")
   let identity1 = s._rawIdentifier()
   expectTrue(isNativeSet(s))
 
-  let foundIndex1 = s.index(of: TestBridgedKeyTy(1010))!
+  let foundIndex1 = s.firstIndex(of: TestBridgedKeyTy(1010))!
   expectEqual(1010, s[foundIndex1].value)
   expectEqual(identity1, s._rawIdentifier())
 
@@ -1679,7 +1679,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAt")
   expectTrue(isNativeSet(s))
   expectEqual(1010, removedElement.value)
   expectEqual(2, s.count)
-  expectNil(s.index(of: TestBridgedKeyTy(1010)))
+  expectNil(s.firstIndex(of: TestBridgedKeyTy(1010)))
 }
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.Remove") {
@@ -3162,7 +3162,7 @@ SetTestSuite.test("contains") {
 SetTestSuite.test("memberAtIndex") {
   let s1 = Set([1010, 2020, 3030])
 
-  let foundIndex = s1.index(of: 1010)!
+  let foundIndex = s1.firstIndex(of: 1010)!
   expectEqual(1010, s1[foundIndex])
 }
 
@@ -3313,12 +3313,12 @@ SetTestSuite.test("_customContainsEquatableElement") {
   expectFalse(Set<Int>()._customContainsEquatableElement(1010)!)
 }
 
-SetTestSuite.test("index(of:)") {
+SetTestSuite.test("firstIndex(of:)") {
   let s1 = Set([1010, 2020, 3030, 4040, 5050, 6060])
-  let foundIndex1 = s1.index(of: 1010)!
+  let foundIndex1 = s1.firstIndex(of: 1010)!
   expectEqual(1010, s1[foundIndex1])
 
-  expectNil(s1.index(of: 999))
+  expectNil(s1.firstIndex(of: 999))
 }
 
 SetTestSuite.test("popFirst") {
@@ -3346,10 +3346,10 @@ SetTestSuite.test("removeAt") {
   // Test removing from the startIndex, the middle, and the end of a set.
   for i in 1...3 {
     var s = Set<Int>([1010, 2020, 3030])
-    let removed = s.remove(at: s.index(of: i*1010)!)
+    let removed = s.remove(at: s.firstIndex(of: i*1010)!)
     expectEqual(i*1010, removed)
     expectEqual(2, s.count)
-    expectNil(s.index(of: i*1010))
+    expectNil(s.firstIndex(of: i*1010))
     let origKeys: [Int] = [1010, 2020, 3030]
     expectEqual(origKeys.filter { $0 != (i*1010) }, [Int](s).sorted())
   }

--- a/validation-test/stdlib/SetAnyHashableExtensions.swift
+++ b/validation-test/stdlib/SetAnyHashableExtensions.swift
@@ -43,13 +43,13 @@ SetTests.test("index<Hashable>(of:)") {
   let s: Set<AnyHashable> = [
     AnyHashable(1010), AnyHashable(2020), AnyHashable(3030.0)
   ]
-  expectEqual(AnyHashable(1010), s[s.index(of: 1010)!])
-  expectEqual(AnyHashable(2020), s[s.index(of: 2020)!])
-  expectEqual(AnyHashable(3030.0), s[s.index(of: 3030.0)!])
+  expectEqual(AnyHashable(1010), s[s.firstIndex(of: 1010)!])
+  expectEqual(AnyHashable(2020), s[s.firstIndex(of: 2020)!])
+  expectEqual(AnyHashable(3030.0), s[s.firstIndex(of: 3030.0)!])
 
-  expectNil(s.index(of: 1010.0))
-  expectNil(s.index(of: 2020.0))
-  expectNil(s.index(of: 3030))
+  expectNil(s.firstIndex(of: 1010.0))
+  expectNil(s.firstIndex(of: 2020.0))
+  expectNil(s.firstIndex(of: 3030))
 }
 
 SetTests.test("insert<Hashable>(_:)") {

--- a/validation-test/stdlib/StringHashableComparable.swift.gyb
+++ b/validation-test/stdlib/StringHashableComparable.swift.gyb
@@ -36,7 +36,7 @@ func calculateSortOrder(_ tests: inout [StringComparisonTest]) {
   }
 
   tests[0].order = 0
-  for i in tests.indices.dropFirst() {
+  for i in tests.indices.removingFirst() {
     if collationElements(
       tests[i - 1].collationElements,
       areLessThan: tests[i].collationElements


### PR DESCRIPTION
#### What's in this pull request?

This pull request renames the ten methods listed in the under-review proposal [SE-0132](https://github.com/apple/swift-evolution/blob/master/proposals/0132-sequence-end-ops.md). (There are only ten because `drop(while:)` has not yet been implemented.)

It includes:
- Renaming of the ten methods specified in the "Sequence-end operations" section of the detailed design.
- Renaming of related private symbols, like `_DropFirstSequence` and `_customIndexOfEquatableElement`.
- Stub methods at the old names with `@available` attributes to produce correct fix-its.
- Updates to existing tests so that they use the new names.
- Updates to documentation.

It does not include:
- Incomplete ranges, the RangeExpression protocol, or the new range operators. Those are all in #3737. 
- Removal of `prefix(upTo:)`, `prefix(through:)`, or `suffix(from:)`. (Note that this is not in **either** pull request.)
- Tests of the new name stubs.

Outstanding issues:
- I have included stubs for some names, like `index(of:)`, which have not shipped in a release version of Swift but have been in development versions of Swift since the API Guidelines were adopted. You may not want to keep these.
- I have not attempted to merge the changes in #3737 with this pull request. I suspect there will be minor conflicts in the documentation, but I don't think there will be anything that's too difficult to resolve.
- ~~I am still running the long tests on my Mac, so I can't be sure this passes the entire test suite.~~
- SE-0132 has not been approved and may still be rejected or modified.

Since the deadline is close, it's worth noting that I probably won't be available tomorrow until the early afternoon. If minor changes are needed (for instance, the core team changes some of the names in the proposal), it may be best to make the final changes to this pull request yourselves instead of waiting for me.

CC: @lattner @dabrahams 

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
