### PR TITLE
Fix _bridgeToObjectiveC lookup code in optimizeBridgedSwiftToObjCCast

### DIFF
--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -316,8 +316,10 @@ SILFunction *SILModule::getOrCreateFunction(SILLocation loc,
 
   if (auto fn = lookUpFunction(name)) {
     assert(fn->getLoweredFunctionType() == constantType);
-    assert(fn->getLinkage() == constant.getLinkage(ForDefinition)
-           || fn->getLinkage() == constant.getLinkage(NotForDefinition));
+    assert(fn->getLinkage() == linkage ||
+           (forDefinition == ForDefinition_t::NotForDefinition &&
+            fn->getLinkage() ==
+                constant.getLinkage(ForDefinition_t::ForDefinition)));
     if (forDefinition) {
       // In all the cases where getConstantLinkage returns something
       // different for ForDefinition, it returns an available-externally

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1624,8 +1624,6 @@ optimizeBridgedSwiftToObjCCast(SILInstruction *Inst,
   assert(Conf && "_ObjectiveCBridgeable conformance should exist");
   (void) Conf;
 
-  bool isCurrentModuleBridgeToObjectiveC = false;
-
   // Generate code to invoke _bridgeToObjectiveC
   SILBuilderWithScope Builder(Inst);
 
@@ -1647,16 +1645,13 @@ optimizeBridgedSwiftToObjCCast(SILInstruction *Inst,
     M.getSwiftModule()->lookupMember(Results, Source.getNominalOrBoundGenericNominal(),
                       M.getASTContext().Id_bridgeToObjectiveC, Identifier());
     ResultsRef = Results;
-    isCurrentModuleBridgeToObjectiveC = true;
   }
   if (ResultsRef.size() != 1)
     return nullptr;
 
   auto MemberDeclRef = SILDeclRef(Results.front());
-  auto Linkage = (isCurrentModuleBridgeToObjectiveC)
-                     ? ForDefinition_t::ForDefinition
-                     : ForDefinition_t::NotForDefinition;
-  auto *BridgedFunc = M.getOrCreateFunction(Loc, MemberDeclRef, Linkage);
+  auto *BridgedFunc = M.getOrCreateFunction(Loc, MemberDeclRef,
+                                            ForDefinition_t::NotForDefinition);
   assert(BridgedFunc &&
          "Implementation of _bridgeToObjectiveC could not be found");
 

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -12,9 +12,6 @@
 // RUN: %line-directive %t/main.swift -- %target-run %t/Dictionary
 // REQUIRES: executable_test
 
-// rdar://27547957
-// XFAIL: swift_test_mode_optimize
-
 #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS)
 import Darwin
 #else

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -12,9 +12,6 @@
 // RUN: %line-directive %t/main.swift -- %target-run %t/Set
 // REQUIRES: executable_test
 
-// rdar://27547957
-// XFAIL: swift_test_mode_optimize
-
 import StdlibUnittest
 import StdlibCollectionUnittest
 


### PR DESCRIPTION
Previously it assumed that if we succeed in looking up the method in the current
module we must be able to request a definition (vs a declaration).

This is not true. It could be that we had declared the type in a different
module. Always ask for a declaration.

rdar://27547957
