### PR TITLE
[libdispatch] Fix deprecation annotations for macOS, watchOS.

### DIFF
--- a/stdlib/public/SDK/Dispatch/Queue.swift
+++ b/stdlib/public/SDK/Dispatch/Queue.swift
@@ -50,19 +50,27 @@ public extension DispatchQueue {
 
 	public enum GlobalQueuePriority {
 		@available(OSX, deprecated: 10.10, message: "Use qos attributes instead")
-		@available(*, deprecated: 8.0, message: "Use qos attributes instead")
+		@available(iOS, deprecated: 8.0, message: "Use qos attributes instead")
+		@available(tvOS, deprecated, message: "Use qos attributes instead")
+		@available(watchOS, deprecated, message: "Use qos attributes instead")
 		case high
 
 		@available(OSX, deprecated: 10.10, message: "Use qos attributes instead")
-		@available(*, deprecated: 8.0, message: "Use qos attributes instead")
+		@available(iOS, deprecated: 8.0, message: "Use qos attributes instead")
+		@available(tvOS, deprecated, message: "Use qos attributes instead")
+		@available(watchOS, deprecated, message: "Use qos attributes instead")
 		case `default`
 
 		@available(OSX, deprecated: 10.10, message: "Use qos attributes instead")
-		@available(*, deprecated: 8.0, message: "Use qos attributes instead")
+		@available(iOS, deprecated: 8.0, message: "Use qos attributes instead")
+		@available(tvOS, deprecated, message: "Use qos attributes instead")
+		@available(watchOS, deprecated, message: "Use qos attributes instead")
 		case low
 
 		@available(OSX, deprecated: 10.10, message: "Use qos attributes instead")
-		@available(*, deprecated: 8.0, message: "Use qos attributes instead")
+		@available(iOS, deprecated: 8.0, message: "Use qos attributes instead")
+		@available(tvOS, deprecated, message: "Use qos attributes instead")
+		@available(watchOS, deprecated, message: "Use qos attributes instead")
 		case background
 
 		internal var _translatedValue: Int {
@@ -111,8 +119,10 @@ public extension DispatchQueue {
 		return _swift_dispatch_get_main_queue()
 	}
 
-	@available(OSX, deprecated: 10.10, message: "")
-	@available(*, deprecated: 8.0, message: "")
+	@available(OSX, deprecated: 10.10)
+	@available(iOS, deprecated: 8.0)
+	@available(tvOS, deprecated)
+	@available(watchOS, deprecated)
 	public class func global(priority: GlobalQueuePriority) -> DispatchQueue {
 		return __dispatch_get_global_queue(priority._translatedValue, 0)
 	}

--- a/test/1_stdlib/DispatchDeprecationMacOS.swift
+++ b/test/1_stdlib/DispatchDeprecationMacOS.swift
@@ -1,0 +1,15 @@
+// RUN: %swift -parse -target x86_64-apple-macosx10.9 -verify -sdk %sdk %s
+// REQUIRES: OS=macosx
+// REQUIRES: objc_interop
+
+import Foundation
+import Dispatch
+
+// Don't warn because these APIs were deprecated in macOS 10.10 and the
+// minimum deployment target is 10.9.
+_ = DispatchQueue.GlobalQueuePriority.high // no-warning
+_ = DispatchQueue.GlobalQueuePriority.default // no-warning
+_ = DispatchQueue.GlobalQueuePriority.low // no-warning
+_ = DispatchQueue.GlobalQueuePriority.background // no-warning
+
+_ = DispatchQueue.global(priority:DispatchQueue.GlobalQueuePriority.background)  // no-warning

--- a/test/1_stdlib/DispatchDeprecationWatchOS.swift
+++ b/test/1_stdlib/DispatchDeprecationWatchOS.swift
@@ -1,0 +1,14 @@
+// RUN: %swift -parse -target i386-apple-watchos2.0 -verify -sdk %sdk %s
+// REQUIRES: OS=watchos
+// REQUIRES: objc_interop
+
+import Foundation
+import Dispatch
+
+// These are deprecated on all versions of watchOS.
+_ = DispatchQueue.GlobalQueuePriority.high // expected-warning {{'high' is deprecated on watchOS: Use qos attributes instead}}
+_ = DispatchQueue.GlobalQueuePriority.default // expected-warning {{'default' is deprecated on watchOS: Use qos attributes instead}}
+_ = DispatchQueue.GlobalQueuePriority.low // expected-warning {{'low' is deprecated on watchOS: Use qos attributes instead}}
+let b = DispatchQueue.GlobalQueuePriority.background // expected-warning {{'background' is deprecated on watchOS: Use qos attributes instead}}
+
+_ = DispatchQueue.global(priority:b)   // expected-warning {{'global(priority:)' is deprecated on watchOS}}


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

[libdispatch] Fix deprecation annotations for macOS, watchOS.

Several libdispatch APIs in Queue.swift are annotated as:

public enum GlobalQueuePriority {
  @available(OSX, deprecated: 10.10, message: "Use qos attributes instead")
  @available(*, deprecated: 8.0, message: "Use qos attributes instead")
  case high

This annotation means ".high is deprecated on all OSes in version 8.0 and
above", so the compiler had false positive deprecation warnings on macOS
when the minimum deployment target is 10.9 and false negatives on watchOS
when the deployment target is 2.0.

The fix is to explicitly enumerate the platforms the API is deprecated on. This
is not ideal (see SR-2155) but avoids the false positives and negatives.

This fixes https://bugs.swift.org/browse/SR-2153
#### Resolved bug number: ([SR-2153](https://bugs.swift.org/browse/SR-2153))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
