### PR TITLE
Remove unnecessary type annotations.

### DIFF
--- a/validation-test/stdlib/Stride.swift
+++ b/validation-test/stdlib/Stride.swift
@@ -8,14 +8,12 @@ var StrideTestSuite = TestSuite("Stride")
 
 StrideTestSuite.test("to") {
   checkSequence(Array(0...4), stride(from: 0, to: 5, by: 1))
-  // FIXME: 'as Array' should not be necessary for disambiguation
-  checkSequence(Array(1...5).reversed() as [Int], stride(from: 5, to: 0, by: -1))
+  checkSequence(Array(1...5).reversed(), stride(from: 5, to: 0, by: -1))
 }
 
 StrideTestSuite.test("through") {
   checkSequence(Array(0...5), stride(from: 0, through: 5, by: 1))
-  // FIXME: 'as Array' should not be necessary for disambiguation
-  checkSequence(Array(0...5).reversed() as [Int], stride(from: 5, through: 0, by: -1))
+  checkSequence(Array(0...5).reversed(), stride(from: 5, through: 0, by: -1))
 }
 
 runAllTests()


### PR DESCRIPTION
Scoring collection conversions should hopefully make these coercions unnecessary now.
