### PR TITLE
Sema: Gratuitously wrap synthesized bridging calls in ParenExprs.

### DIFF
--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -359,3 +359,9 @@ func bridgeAnyContainerToAnyObject(x: [Any], y: [NSObject: Any]) {
 
   _ = z
 }
+
+func bridgeTupleToAnyObject() {
+  let x = (1, "two")
+  let y = x as AnyObject
+  _ = y
+}


### PR DESCRIPTION
Thwart the tuple splatting checker when converting a value `as AnyObject`.
