### PR TITLE
[stdlib] Add ContiguousArray -> Array non-copying initialiser

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -898,6 +898,15 @@ public struct ${Self}<Element>
   }
 %end
 
+%if Self == 'Array':
+  /// Creates an Array pointing to the same underlying storage
+  /// as a ContiguousArray.
+  public // @testable
+  init(_ other: ContiguousArray<Element>) {
+      self.init(_buffer: _Buffer(other._buffer, shiftedToStartIndex: 0))
+  }
+%end
+
   public var _buffer: _Buffer
 }
 


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

As I understand it, Array<T> may be backed by contiguous storage (if native) or it may be backed by some exotic NSArray subclass. We provide a related type with stronger backing guarantees: ContiguousArray<T> (and indeed, in my algorithmic code, I can see a total execution time halve by switching from one to the other -- which may be a bug, but in any case there are differences which is why we have the type in the first place).

Unfortunately, there is no way to vend a ContiguousArray<T> as a regular Array<T>. If you wish to make use of the stronger guarantees of ContiguousArray<T> in your algorithm, everybody who uses those results must also use ContiguousArray<T> or else you will have to copy the data.

I know it's late for Swift 3. I literally only noticed this today, otherwise I would have mentioned it earlier.

It seems like a reasonably large hole with a simple fix. Going from ContiguousArray<T> to Array<T> is a kind-of upcasting conversion and should be allowed -- it seems like that's almost the whole point of the type.
#### Related bug number: ([SR-2196](https://bugs.swift.org/browse/SR-2196))

(Not resolved: related)

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
