### PR TITLE
stdlib: move a function from runtime to stubs

### DIFF
--- a/stdlib/public/core/Reflection.swift
+++ b/stdlib/public/core/Reflection.swift
@@ -506,15 +506,15 @@ func _getClassChild<T>(_: Int, _: _MagicMirrorData) -> (T, _Mirror)
 @_silgen_name("swift_ClassMirror_quickLookObject")
 public func _swift_ClassMirror_quickLookObject(_: _MagicMirrorData) -> AnyObject
 
-@_silgen_name("swift_isKind")
-func _swift_isKind(_ object: AnyObject, of: AnyObject) -> Bool
+@_silgen_name("_swift_stdlib_NSObject_isKindOfClass")
+internal func _swift_NSObject_isImpl(_ object: AnyObject, kindOf: AnyObject) -> Bool
 
-func _isKind(_ object: AnyObject, of: String) -> Bool {
-  return _swift_isKind(object, of: _bridgeAnythingToObjectiveC(of))
+internal func _is(_ object: AnyObject, kindOf `class`: String) -> Bool {
+  return _swift_NSObject_isImpl(object, kindOf: `class` as AnyObject)
 }
 
 func _getClassPlaygroundQuickLook(_ object: AnyObject) -> PlaygroundQuickLook? {
-  if _isKind(object, of: "NSNumber") {
+  if _is(object, kindOf: "NSNumber") {
     let number: _NSNumber = unsafeBitCast(object, to: _NSNumber.self)
     switch UInt8(number.objCType[0]) {
     case UInt8(ascii: "d"):
@@ -526,22 +526,22 @@ func _getClassPlaygroundQuickLook(_ object: AnyObject) -> PlaygroundQuickLook? {
     default:
       return .int(number.longLongValue)
     }
-  } else if _isKind(object, of: "NSAttributedString") {
+  } else if _is(object, kindOf: "NSAttributedString") {
     return .attributedString(object)
-  } else if _isKind(object, of: "NSImage") ||
-            _isKind(object, of: "UIImage") ||
-            _isKind(object, of: "NSImageView") ||
-            _isKind(object, of: "UIImageView") ||
-            _isKind(object, of: "CIImage") ||
-            _isKind(object, of: "NSBitmapImageRep") {
+  } else if _is(object, kindOf: "NSImage") ||
+            _is(object, kindOf: "UIImage") ||
+            _is(object, kindOf: "NSImageView") ||
+            _is(object, kindOf: "UIImageView") ||
+            _is(object, kindOf: "CIImage") ||
+            _is(object, kindOf: "NSBitmapImageRep") {
     return .image(object)
-  } else if _isKind(object, of: "NSColor") ||
-            _isKind(object, of: "UIColor") {
+  } else if _is(object, kindOf: "NSColor") ||
+            _is(object, kindOf: "UIColor") {
     return .color(object)
-  } else if _isKind(object, of: "NSBezierPath") ||
-            _isKind(object, of: "UIBezierPath") {
+  } else if _is(object, kindOf: "NSBezierPath") ||
+            _is(object, kindOf: "UIBezierPath") {
     return .bezierPath(object)
-  } else if _isKind(object, of: "NSString") {
+  } else if _is(object, kindOf: "NSString") {
     return .text(_forceBridgeFromObjectiveC(object, String.self))
   }
 

--- a/stdlib/public/runtime/Reflection.mm
+++ b/stdlib/public/runtime/Reflection.mm
@@ -845,15 +845,6 @@ swift_ClassMirror_quickLookObject(HeapObject *owner, const OpaqueValue *value,
   return object;
 }
 
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" bool swift_isKind(id object, NSString *className) {
-  bool result = [object isKindOfClass:NSClassFromString(className)];
-  [object release];
-  [className release];
-
-  return result;
-}
-
 #endif
   
 // -- MagicMirror implementation.

--- a/stdlib/public/stubs/CMakeLists.txt
+++ b/stdlib/public/stubs/CMakeLists.txt
@@ -6,6 +6,7 @@ if(SWIFT_HOST_VARIANT MATCHES "${SWIFT_DARWIN_VARIANTS}")
       Availability.mm
       DispatchShims.mm
       FoundationHelpers.mm
+      Reflection.mm
       SwiftNativeNSXXXBase.mm.gyb)
   set(LLVM_OPTIONAL_SOURCES
       UnicodeNormalization.cpp)

--- a/stdlib/public/stubs/Reflection.mm
+++ b/stdlib/public/stubs/Reflection.mm
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Runtime/Config.h"
+#import <Foundation/Foundation.h>
+
+SWIFT_CC(swift)
+SWIFT_RUNTIME_STDLIB_INTERFACE
+extern "C" bool _swift_stdlib_NSObject_isKindOfClass(
+    id NS_RELEASES_ARGUMENT _Nonnull object,
+    NSString *NS_RELEASES_ARGUMENT _Nonnull className) {
+  bool result = [object isKindOfClass:NSClassFromString(className)];
+  [object release];
+  [className release];
+
+  return result;
+}
+


### PR DESCRIPTION
This function is not needed in the runtime.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
