### PR TITLE
[stdlib] Improvements for AnyHashable tests

### DIFF
--- a/stdlib/private/StdlibUnittest/CMakeLists.txt
+++ b/stdlib/private/StdlibUnittest/CMakeLists.txt
@@ -15,6 +15,8 @@ add_swift_library(swiftStdlibUnittest ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STD
   # filename.
   StdlibUnittest.swift.gyb
 
+  InspectValue.cpp
+  InspectValue.swift
   InterceptTraps.cpp
   LifetimeTracked.swift
   MinimalTypes.swift.gyb

--- a/stdlib/private/StdlibUnittest/InspectValue.cpp
+++ b/stdlib/private/StdlibUnittest/InspectValue.cpp
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Runtime/Config.h"
+#include "swift/Runtime/Metadata.h"
+
+using namespace swift;
+
+SWIFT_CC(swift)
+extern "C"
+uint32_t swift_StdlibUnittest_getMetadataKindOf(
+    OpaqueValue *value,
+    const Metadata *type
+) {
+  auto result = uint32_t(type->getKind());
+  type->vw_destroy(value);
+  return result;
+}
+

--- a/stdlib/private/StdlibUnittest/InspectValue.swift
+++ b/stdlib/private/StdlibUnittest/InspectValue.swift
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// namespace
+public enum SwiftRuntime {
+  public enum MetadataKind : Int {
+    case `class` = 0
+    case `struct` = 1
+    case `enum` = 2
+    case optional = 3
+    case opaque = 8
+    case tuple = 9
+    case function = 10
+    case existential = 12
+    case metatype = 13
+    case objCClassWrapper = 14
+    case existentialMetatype = 15
+    case foreignClass = 16
+    case heapLocalVariable = 64
+    case heapGenericLocalVariable = 65
+    case errorObject = 128
+  }
+
+  @_silgen_name("swift_StdlibUnittest_getMetadataKindOf")
+  static func _metadataKindImpl<T>(of value: T) -> UInt32
+
+  public static func metadataKind<T>(of value: T) -> MetadataKind {
+    return MetadataKind(rawValue: Int(_metadataKindImpl(of: value)))!
+  }
+}
+

--- a/stdlib/public/stubs/AnyHashableSupport.cpp
+++ b/stdlib/public/stubs/AnyHashableSupport.cpp
@@ -103,7 +103,6 @@ extern "C" void _swift_stdlib_makeAnyHashableUpcastingToHashableBaseType(
   case MetadataKind::Class:
   case MetadataKind::ObjCClassWrapper:
   case MetadataKind::ForeignClass: {
-    // FIXME(id-as-any): handle ForeignClass.
     _swift_stdlib_makeAnyHashableUsingDefaultRepresentation(
         value, anyHashableResultPointer, findHashableBaseType(type),
         hashableWT);

--- a/stdlib/public/stubs/AnyHashableSupport.cpp
+++ b/stdlib/public/stubs/AnyHashableSupport.cpp
@@ -117,7 +117,8 @@ extern "C" void _swift_stdlib_makeAnyHashableUpcastingToHashableBaseType(
     return;
 
   case MetadataKind::ErrorObject:
-    // FIXME(id-as-any): handle ErrorObject.
+    // ErrorObject metadata is not used for any Swift-level values, so
+    // this case is unreachable.
     _failCorruptType(type);
 
   case MetadataKind::Opaque:

--- a/validation-test/stdlib/AnyHashable.swift.gyb
+++ b/validation-test/stdlib/AnyHashable.swift.gyb
@@ -1,11 +1,6 @@
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 
-// FIXME(id-as-any): add tests that use Swift errors and
-// Objective-C errors.
-
-// FIXME(id-as-any): add tests for enums.
-
 // FIXME(id-as-any): add tests for unboxing.
 
 %{
@@ -525,6 +520,104 @@ AnyHashableTests.test("AnyHashable with CFMutableBitVector") {
     equalityOracle: { $0 == $1 })
 }
 
+#endif
+
+enum MinimalHashablePODSwiftError : Error, Hashable {
+  case caseA
+  case caseB
+  case caseC
+}
+
+enum MinimalHashableRCSwiftError : Error, Hashable {
+  case caseA(LifetimeTracked)
+  case caseB(LifetimeTracked)
+  case caseC(LifetimeTracked)
+
+  var hashValue: Int {
+    return 0
+  }
+
+  static func == (
+    lhs: MinimalHashableRCSwiftError,
+    rhs: MinimalHashableRCSwiftError
+  ) -> Bool {
+    switch (lhs, rhs) {
+    case (.caseA(let lhs), .caseA(let rhs)):
+      return lhs == rhs
+    case (.caseB(let lhs), .caseB(let rhs)):
+      return lhs == rhs
+    case (.caseC(let lhs), .caseC(let rhs)):
+      return lhs == rhs
+    default:
+      return false
+    }
+  }
+}
+
+AnyHashableTests.test("AnyHashable containing MinimalHashablePODSwiftError") {
+  let xs: [MinimalHashablePODSwiftError] = [
+    .caseA, .caseA,
+    .caseB, .caseB,
+    .caseC, .caseC,
+  ]
+  expectEqual(.enum, SwiftRuntime.metadataKind(of: xs.first!))
+  checkHashable(xs, equalityOracle: { $0 / 2 == $1 / 2 })
+  checkHashable(
+    xs.map(AnyHashable.init),
+    equalityOracle: { $0 / 2 == $1 / 2 })
+}
+
+AnyHashableTests.test("AnyHashable containing MinimalHashableRCSwiftError") {
+  let xs: [MinimalHashableRCSwiftError] = [
+    .caseA(LifetimeTracked(1)), .caseA(LifetimeTracked(1)),
+    .caseA(LifetimeTracked(2)), .caseA(LifetimeTracked(2)),
+    .caseB(LifetimeTracked(1)), .caseB(LifetimeTracked(1)),
+    .caseB(LifetimeTracked(2)), .caseB(LifetimeTracked(2)),
+    .caseC(LifetimeTracked(1)), .caseC(LifetimeTracked(1)),
+    .caseC(LifetimeTracked(2)), .caseC(LifetimeTracked(2)),
+  ]
+  expectEqual(.enum, SwiftRuntime.metadataKind(of: xs.first!))
+  checkHashable(xs, equalityOracle: { $0 / 2 == $1 / 2 })
+  checkHashable(
+    xs.map(AnyHashable.init),
+    equalityOracle: { $0 / 2 == $1 / 2 })
+}
+
+#if _runtime(_ObjC)
+AnyHashableTests.test("AnyHashable containing _SwiftNativeNSError") {
+  let swiftErrors: [MinimalHashablePODSwiftError] = [
+    .caseA, .caseA,
+    .caseB, .caseB,
+    .caseC, .caseC,
+  ]
+  let nsErrors: [NSError] = swiftErrors.map { $0 as NSError }
+  expectEqual(
+    .objCClassWrapper,
+    SwiftRuntime.metadataKind(of: nsErrors.first!))
+  expectEqual("_SwiftNativeNSError", String(nsErrors[0].dynamicType))
+  checkHashable(nsErrors, equalityOracle: { $0 / 2 == $1 / 2 })
+  checkHashable(
+    nsErrors.map(AnyHashable.init),
+    equalityOracle: { $0 / 2 == $1 / 2 })
+}
+
+AnyHashableTests.test("AnyHashable containing NSError") {
+  let nsErrors: [NSError] = [
+    NSError(domain: "Foo", code: 0),
+    NSError(domain: "Foo", code: 0),
+    NSError(domain: "Foo", code: 1),
+    NSError(domain: "Foo", code: 1),
+    NSError(domain: "Foo", code: 2),
+    NSError(domain: "Foo", code: 2),
+  ]
+  expectEqual(
+    .objCClassWrapper,
+    SwiftRuntime.metadataKind(of: nsErrors.first!))
+  checkHashable(nsErrors, equalityOracle: { $0 / 2 == $1 / 2 })
+  checkHashable(
+    nsErrors.map(AnyHashable.init),
+    equalityOracle: { $0 / 2 == $1 / 2 })
+}
 #endif
 
 runAllTests()

--- a/validation-test/stdlib/AnyHashable.swift.gyb
+++ b/validation-test/stdlib/AnyHashable.swift.gyb
@@ -1,9 +1,6 @@
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 
-// FIXME(id-as-any): add tests that use CF objects (is this even
-// possible?)
-
 // FIXME(id-as-any): add tests that use Swift errors and
 // Objective-C errors.
 
@@ -471,20 +468,37 @@ let interestingBitVectorArrays: [[UInt8]] = [
   [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
 ]
 
-AnyHashableTests.test("CFBitVector/Hashable") {
-  let bitVectors = interestingBitVectorArrays.map(CFBitVector.makeImmutable)
+AnyHashableTests.test("AnyHashable with CFBitVector") {
+  let bitVectors: [CFBitVector] =
+    interestingBitVectorArrays.map(CFBitVector.makeImmutable)
   let arrays = bitVectors.map { $0.asArray }
   func isEq(_ lhs: [[UInt8]], _ rhs: [[UInt8]]) -> Bool {
     return zip(lhs, rhs).map { $0 == $1 }.reduce(true, { $0 && $1 })
   }
   expectEqualTest(interestingBitVectorArrays, arrays, sameValue: isEq)
   checkHashable(bitVectors, equalityOracle: { $0 == $1 })
+
+  expectEqual(.foreignClass, SwiftRuntime.metadataKind(of: bitVectors.first!))
+
+  checkHashable(
+    bitVectors.map(AnyHashable.init),
+    equalityOracle: { $0 == $1 })
+
+  let bitVectorsAsAnyObjects: [NSObject] = bitVectors.map {
+    ($0 as AnyObject) as! NSObject
+  }
+  expectEqual(
+    .objCClassWrapper,
+    SwiftRuntime.metadataKind(of: bitVectorsAsAnyObjects.first!))
+  checkHashable(
+    bitVectorsAsAnyObjects.map(AnyHashable.init),
+    equalityOracle: { $0 == $1 })
 }
 
-AnyHashableTests.test("CFMutableBitVector/Hashable") {
+AnyHashableTests.test("AnyHashable with CFMutableBitVector") {
   // CFMutableBitVector inherits the Hashable conformance from
   // CFBitVector.
-  let bitVectors =
+  let bitVectors: [CFMutableBitVector] =
     interestingBitVectorArrays.map(CFMutableBitVector.makeMutable)
   let arrays = bitVectors.map { $0.asArray }
   func isEq(_ lhs: [[UInt8]], _ rhs: [[UInt8]]) -> Bool {
@@ -492,6 +506,23 @@ AnyHashableTests.test("CFMutableBitVector/Hashable") {
   }
   expectEqualTest(interestingBitVectorArrays, arrays, sameValue: isEq)
   checkHashable(bitVectors, equalityOracle: { $0 == $1 })
+
+  expectEqual(.foreignClass, SwiftRuntime.metadataKind(of: bitVectors.first!))
+
+  checkHashable(
+    bitVectors.map(AnyHashable.init),
+    equalityOracle: { $0 == $1 })
+
+  let bitVectorsAsAnyObjects: [NSObject] = bitVectors.map {
+    ($0 as AnyObject) as! NSObject
+  }
+  checkHashable(bitVectors, equalityOracle: { $0 == $1 })
+  expectEqual(
+    .objCClassWrapper,
+    SwiftRuntime.metadataKind(of: bitVectorsAsAnyObjects.first!))
+  checkHashable(
+    bitVectorsAsAnyObjects.map(AnyHashable.init),
+    equalityOracle: { $0 == $1 })
 }
 
 #endif

--- a/validation-test/stdlib/AnyHashable.swift.gyb
+++ b/validation-test/stdlib/AnyHashable.swift.gyb
@@ -3,6 +3,8 @@
 
 // FIXME(id-as-any): add tests for unboxing.
 
+// FIXME(id-as-any): add tests for the _ObjectiveCBridgeable conformance.
+
 %{
 import re
 

--- a/validation-test/stdlib/AnyHashable.swift.gyb
+++ b/validation-test/stdlib/AnyHashable.swift.gyb
@@ -190,7 +190,7 @@ ${kw} HasCustomRepresentation_Generic${name}<Wrapped>
 % for name in [ 'Class', 'PODStruct', 'RCStruct' ]:
 %   wrapped = 'HasCustomRepresentation_%s' % name
 %   genericWrapped = 'HasCustomRepresentation_Generic%s' % name
-AnyHashableTests.test("AnyHashable with ${wrapped}") {
+AnyHashableTests.test("AnyHashable containing ${wrapped}") {
   let xs = (-2...2).flatMap {
     [ ${wrapped}(
         $0, identity: 0,
@@ -207,7 +207,7 @@ AnyHashableTests.test("AnyHashable with ${wrapped}") {
 }
 
 %   for payload in [ 'OpaqueValue<Int>', 'LifetimeTracked' ]:
-AnyHashableTests.test("AnyHashable with ${genericWrapped} with ${payload}") {
+AnyHashableTests.test("AnyHashable containing ${genericWrapped} with ${payload}") {
   GenericMinimalHashableValue_equalImpl.value = {
     ($0 as! ${payload}).value == ($1 as! ${payload}).value
   }
@@ -256,7 +256,7 @@ struct HasCustomRepresentationRecursively
   }
 }
 
-AnyHashableTests.test("AnyHashable with recursive custom representations") {
+AnyHashableTests.test("AnyHashable containing values with recursive custom representations") {
   GenericMinimalHashableValue_equalImpl.value = {
     ($0 as! ${payload}).value == ($1 as! ${payload}).value
   }
@@ -386,7 +386,7 @@ class ${Self.full_name} : ${Super.full_name} {}
 %   end
 % end
 
-AnyHashableTests.test("AnyHashable with classes from the ${prefix} hierarchy") {
+AnyHashableTests.test("AnyHashable containing classes from the ${prefix} hierarchy") {
   typealias T = Int
   let xs = [
 % for (i, (Self, _)) in enumerate(types):
@@ -463,7 +463,7 @@ let interestingBitVectorArrays: [[UInt8]] = [
   [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
 ]
 
-AnyHashableTests.test("AnyHashable with CFBitVector") {
+AnyHashableTests.test("AnyHashable containing CFBitVector") {
   let bitVectors: [CFBitVector] =
     interestingBitVectorArrays.map(CFBitVector.makeImmutable)
   let arrays = bitVectors.map { $0.asArray }
@@ -490,7 +490,7 @@ AnyHashableTests.test("AnyHashable with CFBitVector") {
     equalityOracle: { $0 == $1 })
 }
 
-AnyHashableTests.test("AnyHashable with CFMutableBitVector") {
+AnyHashableTests.test("AnyHashable containing CFMutableBitVector") {
   // CFMutableBitVector inherits the Hashable conformance from
   // CFBitVector.
   let bitVectors: [CFMutableBitVector] =

--- a/validation-test/stdlib/AnyHashable.swift.gyb
+++ b/validation-test/stdlib/AnyHashable.swift.gyb
@@ -81,8 +81,9 @@ AnyHashableTests.test("AnyHashable(${wrapped})/Hashable") {
   }
   checkHashable(xs, equalityOracle: { $0 / 2 == $1 / 2 })
 
-  let anyHashableXs = xs.map(AnyHashable.init)
-  checkHashable(anyHashableXs, equalityOracle: { $0 / 2 == $1 / 2 })
+  checkHashable(
+    xs.map(AnyHashable.init),
+    equalityOracle: { $0 / 2 == $1 / 2 })
 }
 % end
 
@@ -101,8 +102,9 @@ AnyHashableTests.test("AnyHashable(${wrapped}<OpaqueValue<Int>>)/Hashable") {
   }
   checkHashable(xs, equalityOracle: { $0 / 2 == $1 / 2 })
 
-  let anyHashableXs = xs.map(AnyHashable.init)
-  checkHashable(anyHashableXs, equalityOracle: { $0 / 2 == $1 / 2 })
+  checkHashable(
+    xs.map(AnyHashable.init),
+    equalityOracle: { $0 / 2 == $1 / 2 })
 }
 %   end
 % end
@@ -207,8 +209,9 @@ AnyHashableTests.test("AnyHashable with ${wrapped}") {
   }
   checkHashable(xs, equalityOracle: { $0 / 2 == $1 / 2 })
 
-  let anyHashableXs = xs.map(AnyHashable.init)
-  checkHashable(anyHashableXs, equalityOracle: { $0 / 2 == $1 / 2 })
+  checkHashable(
+    xs.map(AnyHashable.init),
+    equalityOracle: { $0 / 2 == $1 / 2 })
 }
 
 %   for payload in [ 'OpaqueValue<Int>', 'LifetimeTracked' ]:
@@ -229,8 +232,9 @@ AnyHashableTests.test("AnyHashable with ${genericWrapped} with ${payload}") {
   }
   checkHashable(xs, equalityOracle: { $0 / 2 == $1 / 2 })
 
-  let anyHashableXs = xs.map(AnyHashable.init)
-  checkHashable(anyHashableXs, equalityOracle: { $0 / 2 == $1 / 2 })
+  checkHashable(
+    xs.map(AnyHashable.init),
+    equalityOracle: { $0 / 2 == $1 / 2 })
 }
 %   end
 % end
@@ -416,8 +420,9 @@ AnyHashableTests.test("AnyHashable with classes from the ${prefix} hierarchy") {
   }
   checkHashable(xs, equalityOracle: equalityOracle)
 
-  let anyHashableXs = xs.map(AnyHashable.init)
-  checkHashable(anyHashableXs, equalityOracle: equalityOracle)
+  checkHashable(
+    xs.map(AnyHashable.init),
+    equalityOracle: equalityOracle)
 }
 ${'#endif' if 'ObjC' in prefix else ''}
 


### PR DESCRIPTION
Added tests for CF types, enums, and NSErrors.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
