### PR TITLE
[libdispatch-data-leak] DisaptchData never calls destructor

### DIFF
--- a/lib/ClangImporter/MappedTypes.def
+++ b/lib/ClangImporter/MappedTypes.def
@@ -138,6 +138,8 @@ MAP_TYPE("dispatch_block_t", Block, 0, "Dispatch", "dispatch_block_t",
          true, DoNothing)
 MAP_TYPE("__swift_shims_dispatch_block_t", Block, 0, "Dispatch", "_DispatchBlock", 
          true, DoNothing)
+MAP_TYPE("__swift_shims_dispatch_data_t", ObjCId, 0, "Dispatch", "dispatch_data_t",
+         true, DoNothing)
 
 // Objective-C types.
 MAP_TYPE("BOOL", ObjCBool, 8, "ObjectiveC", "ObjCBool", false, DoNothing)

--- a/stdlib/public/SDK/Dispatch/Data.swift
+++ b/stdlib/public/SDK/Dispatch/Data.swift
@@ -84,12 +84,12 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	public func enumerateBytes(
 		block: @noescape (buffer: UnsafeBufferPointer<UInt8>, byteIndex: Int, stop: inout Bool) -> Void) 
 	{
-		_swift_dispatch_data_apply(__wrapped) { (data: __DispatchData, offset: Int, ptr: UnsafeRawPointer, size: Int) in
+		_swift_dispatch_data_apply(__wrapped) { (_, offset: Int, ptr: UnsafeRawPointer, size: Int) in
             let bytePtr = ptr.bindMemory(to: UInt8.self, capacity: size)
 			let bp = UnsafeBufferPointer(start: bytePtr, count: size)
 			var stop = false
 			block(buffer: bp, byteIndex: offset, stop: &stop)
-			return !stop
+			return stop ? 0 : 1
 		}
 	}
 
@@ -284,11 +284,6 @@ extension DispatchData {
 		return result!
 	}
 }
-
-typealias _swift_data_applier = @convention(block) @noescape (__DispatchData, Int, UnsafeRawPointer, Int) -> Bool
-
-@_silgen_name("_swift_dispatch_data_apply")
-internal func _swift_dispatch_data_apply(_ data: __DispatchData, _ block: _swift_data_applier)
 
 @_silgen_name("_swift_dispatch_data_empty")
 internal func _swift_dispatch_data_empty() -> __DispatchData

--- a/stdlib/public/SDK/Dispatch/Dispatch.mm
+++ b/stdlib/public/SDK/Dispatch/Dispatch.mm
@@ -87,18 +87,6 @@ _swift_dispatch_data_destructor_munmap(void) {
   return _dispatch_data_destructor_munmap;
 }
 
-SWIFT_CC(swift) DISPATCH_RUNTIME_STDLIB_INTERFACE
-extern "C" bool
-_swift_dispatch_data_apply(dispatch_data_t data, bool (^applier)(dispatch_data_t, size_t, const void *, size_t)) {
-  return dispatch_data_apply(data, applier);
-}
-
-// DISPATCH_RUNTIME_STDLIB_INTERFACE
-// extern "C" dispatch_queue_t
-// _swift_apply_current_root_queue() {
-//   return DISPATCH_APPLY_CURRENT_ROOT_QUEUE;
-// }
-
 #define SOURCE(t)                                                              \
   SWIFT_CC(swift)                                                              \
   DISPATCH_RUNTIME_STDLIB_INTERFACE extern "C" dispatch_source_type_t  \

--- a/stdlib/public/SDK/Dispatch/IO.swift
+++ b/stdlib/public/SDK/Dispatch/IO.swift
@@ -86,7 +86,7 @@ public extension DispatchIO {
 	}
 
 	public func setInterval(interval: DispatchTimeInterval, flags: IntervalFlags = []) {
-		__dispatch_io_set_interval(self, interval.rawValue, flags.rawValue)
+		__dispatch_io_set_interval(self, UInt64(interval.rawValue), flags.rawValue)
 	}
 
 	public func close(flags: CloseFlags = []) {

--- a/stdlib/public/SDK/Dispatch/Queue.swift
+++ b/stdlib/public/SDK/Dispatch/Queue.swift
@@ -344,7 +344,3 @@ internal func _swift_dispatch_queue_concurrent() -> __OS_dispatch_queue_attr
 
 @_silgen_name("_swift_dispatch_get_main_queue")
 internal func _swift_dispatch_get_main_queue() -> DispatchQueue
-
-@_silgen_name("_swift_dispatch_apply_current_root_queue")
-internal func _swift_dispatch_apply_current_root_queue() -> DispatchQueue
-

--- a/stdlib/public/SDK/Dispatch/Source.swift
+++ b/stdlib/public/SDK/Dispatch/Source.swift
@@ -257,15 +257,15 @@ public extension DispatchSourceProcess {
 
 public extension DispatchSourceTimer {
 	public func scheduleOneshot(deadline: DispatchTime, leeway: DispatchTimeInterval = .nanoseconds(0)) {
-		__dispatch_source_set_timer(self as! DispatchSource, deadline.rawValue, ~0, UInt64(leeway.rawValue))
+		__dispatch_source_set_timer(self as! DispatchSource, UInt64(deadline.rawValue), ~0, UInt64(leeway.rawValue))
 	}
 
 	public func scheduleOneshot(wallDeadline: DispatchWallTime, leeway: DispatchTimeInterval = .nanoseconds(0)) {
-		__dispatch_source_set_timer(self as! DispatchSource, wallDeadline.rawValue, ~0, UInt64(leeway.rawValue))
+		__dispatch_source_set_timer(self as! DispatchSource, UInt64(wallDeadline.rawValue), ~0, UInt64(leeway.rawValue))
 	}
 
 	public func scheduleRepeating(deadline: DispatchTime, interval: DispatchTimeInterval, leeway: DispatchTimeInterval = .nanoseconds(0)) {
-		__dispatch_source_set_timer(self as! DispatchSource, deadline.rawValue, interval.rawValue, UInt64(leeway.rawValue))
+		__dispatch_source_set_timer(self as! DispatchSource, deadline.rawValue, UInt64(interval.rawValue), UInt64(leeway.rawValue))
 	}
 
 	public func scheduleRepeating(deadline: DispatchTime, interval: Double, leeway: DispatchTimeInterval = .nanoseconds(0)) {
@@ -273,7 +273,7 @@ public extension DispatchSourceTimer {
 	}
 
 	public func scheduleRepeating(wallDeadline: DispatchWallTime, interval: DispatchTimeInterval, leeway: DispatchTimeInterval = .nanoseconds(0)) {
-		__dispatch_source_set_timer(self as! DispatchSource, wallDeadline.rawValue, interval.rawValue, UInt64(leeway.rawValue))
+		__dispatch_source_set_timer(self as! DispatchSource, wallDeadline.rawValue, UInt64(interval.rawValue), UInt64(leeway.rawValue))
 	}
 
 	public func scheduleRepeating(wallDeadline: DispatchWallTime, interval: Double, leeway: DispatchTimeInterval = .nanoseconds(0)) {

--- a/stdlib/public/SDK/Dispatch/Time.swift
+++ b/stdlib/public/SDK/Dispatch/Time.swift
@@ -85,23 +85,23 @@ public enum DispatchTimeInterval {
 	case microseconds(Int)
 	case nanoseconds(Int)
 
-	internal var rawValue: UInt64 {
+	internal var rawValue: Int64 {
 		switch self {
-		case .seconds(let s): return UInt64(s) * NSEC_PER_SEC
-		case .milliseconds(let ms): return UInt64(ms) * NSEC_PER_MSEC
-		case .microseconds(let us): return UInt64(us) * NSEC_PER_USEC
-		case .nanoseconds(let ns): return UInt64(ns)
+		case .seconds(let s): return Int64(s) * Int64(NSEC_PER_SEC)
+		case .milliseconds(let ms): return Int64(ms) * Int64(NSEC_PER_MSEC)
+		case .microseconds(let us): return Int64(us) * Int64(NSEC_PER_USEC)
+		case .nanoseconds(let ns): return Int64(ns)
 		}
 	}
 }
 
 public func +(time: DispatchTime, interval: DispatchTimeInterval) -> DispatchTime {
-	let t = __dispatch_time(time.rawValue, Int64(interval.rawValue))
+	let t = __dispatch_time(time.rawValue, interval.rawValue)
 	return DispatchTime(rawValue: t)
 }
 
 public func -(time: DispatchTime, interval: DispatchTimeInterval) -> DispatchTime {
-	let t = __dispatch_time(time.rawValue, -Int64(interval.rawValue))
+	let t = __dispatch_time(time.rawValue, -interval.rawValue)
 	return DispatchTime(rawValue: t)
 }
 
@@ -116,12 +116,12 @@ public func -(time: DispatchTime, seconds: Double) -> DispatchTime {
 }
 
 public func +(time: DispatchWallTime, interval: DispatchTimeInterval) -> DispatchWallTime {
-	let t = __dispatch_time(time.rawValue, Int64(interval.rawValue))
+	let t = __dispatch_time(time.rawValue, interval.rawValue)
 	return DispatchWallTime(rawValue: t)
 }
 
 public func -(time: DispatchWallTime, interval: DispatchTimeInterval) -> DispatchWallTime {
-	let t = __dispatch_time(time.rawValue, -Int64(interval.rawValue))
+	let t = __dispatch_time(time.rawValue, -interval.rawValue)
 	return DispatchWallTime(rawValue: t)
 }
 

--- a/stdlib/public/SwiftShims/DispatchShims.h
+++ b/stdlib/public/SwiftShims/DispatchShims.h
@@ -25,8 +25,14 @@
 #include "SwiftStddef.h"
 #include "Visibility.h"
 
-#define SWIFT_DISPATCH_RETURNS_RETAINED_BLOCK __attribute__((__ns_returns_retained__))
+#define SWIFT_DISPATCH_RETURNS_RETAINED __attribute__((__ns_returns_retained__))
 #define SWIFT_DISPATCH_NOESCAPE __attribute__((__noescape__))
+#define SWIFT_DISPATCH_NONNULL _Nonnull
+#define SWIFT_DISPATCH_NULLABLE _Nullable
+#define SWIFT_DISPATCH_ASSUME_NONNULL_BEGIN _Pragma("clang assume_nonnull begin")
+#define SWIFT_DISPATCH_ASSUME_NONNULL_END _Pragma("clang assume_nonnull end")
+
+SWIFT_DISPATCH_ASSUME_NONNULL_BEGIN
 
 #ifdef __cplusplus
 namespace swift { extern "C" {
@@ -40,16 +46,16 @@ typedef id __swift_shims_dispatch_group_t;
 typedef id __swift_shims_dispatch_data_t;
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
-SWIFT_DISPATCH_RETURNS_RETAINED_BLOCK 
+SWIFT_DISPATCH_RETURNS_RETAINED
 __swift_shims_dispatch_block_t
 _swift_dispatch_block_create_with_qos_class(
 		__swift_shims_dispatch_block_flags_t flags, 
 		__swift_shims_qos_class_t qos,
 		int relative_priority, 
-		__swift_shims_dispatch_block_t block);
+		__swift_shims_dispatch_block_t SWIFT_DISPATCH_NONNULL block);
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
-SWIFT_DISPATCH_RETURNS_RETAINED_BLOCK
+SWIFT_DISPATCH_RETURNS_RETAINED
 __swift_shims_dispatch_block_t
 _swift_dispatch_block_create_noescape(
 		__swift_shims_dispatch_block_flags_t flags,
@@ -96,16 +102,27 @@ void _swift_dispatch_apply_current(
 		void SWIFT_DISPATCH_NOESCAPE (^block)(long));
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
+SWIFT_DISPATCH_RETURNS_RETAINED
 __swift_shims_dispatch_data_t 
 _swift_dispatch_data_create(
 		const void *buffer,
 		__swift_size_t size,
-		__swift_shims_dispatch_queue_t queue,
-		__swift_shims_dispatch_block_t destructor);
+		__swift_shims_dispatch_queue_t SWIFT_DISPATCH_NULLABLE queue,
+		__swift_shims_dispatch_block_t SWIFT_DISPATCH_NULLABLE destructor);
+
+typedef unsigned int (^__swift_shims_dispatch_data_applier)(__swift_shims_dispatch_data_t, __swift_size_t, const void *, __swift_size_t);
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+unsigned int
+_swift_dispatch_data_apply(
+		__swift_shims_dispatch_data_t data, 
+		__swift_shims_dispatch_data_applier SWIFT_DISPATCH_NOESCAPE applier);
 
 #ifdef __cplusplus
 }} // extern "C", namespace swift
 #endif
+
+SWIFT_DISPATCH_ASSUME_NONNULL_END
 
 #endif // __OBJC2__
 

--- a/stdlib/public/stubs/DispatchShims.mm
+++ b/stdlib/public/stubs/DispatchShims.mm
@@ -131,3 +131,12 @@ swift::_swift_dispatch_data_create(
 	return dispatch_data_create(buffer, size, cast(queue), cast(destructor));
 }
 
+unsigned int
+swift::_swift_dispatch_data_apply(
+		__swift_shims_dispatch_data_t data, 
+		__swift_shims_dispatch_data_applier SWIFT_DISPATCH_NOESCAPE applier)
+{
+	return dispatch_data_apply(data, ^bool(dispatch_data_t data, size_t off, const void *loc, size_t size){
+		return applier(data, off, loc, size);
+	});
+}

--- a/test/1_stdlib/Dispatch.swift
+++ b/test/1_stdlib/Dispatch.swift
@@ -68,3 +68,20 @@ DispatchAPI.test("dispatch_data_t enumeration") {
 		_ = 1
 	}
 }
+
+DispatchAPI.test("dispatch_data_t deallocator") {
+	let q = DispatchQueue(label: "dealloc queue")
+	var t = 0
+
+	autoreleasepool {
+		let size = 1024
+		let p = UnsafeMutablePointer<UInt8>.allocate(capacity: size)
+		let d = DispatchData(bytesNoCopy: UnsafeBufferPointer(start: p, count: size), deallocator: .custom(q, {
+			t = 1
+		}))
+	}
+
+	q.sync {
+		expectEqual(1, t)
+	}
+}


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

```
* _swift_dispatch_data_create should have been marked as returning a
retained object, otherwise the object is never fully released and
the destructor is never executed.
```
#### Resolved bug number:

```
Fixes: <rdar://problem/27577958>
```

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
