### PR TITLE
Handle extension contexts when demangling bound generic arguments

### DIFF
--- a/lib/Basic/Demangle.cpp
+++ b/lib/Basic/Demangle.cpp
@@ -1161,7 +1161,10 @@ private:
   NodePointer demangleBoundGenericArgs(NodePointer nominalType) {
     // Generic arguments for the outermost type come first.
     NodePointer parentOrModule = nominalType->getChild(0);
-    if (parentOrModule->getKind() != Node::Kind::Module) {
+
+    if (parentOrModule->getKind() != Node::Kind::Module &&
+        parentOrModule->getKind() != Node::Kind::Function &&
+        parentOrModule->getKind() != Node::Kind::Extension) {
       parentOrModule = demangleBoundGenericArgs(parentOrModule);
 
       // Rebuild this type with the new parent type, which may have

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -220,3 +220,6 @@ _TF21$__lldb_module_for_E0au3$E0Ps5Error_ ---> $__lldb_module_for_E0.$E0.unsafeM
 _TMps10Comparable ---> protocol descriptor for Swift.Comparable
 _TFC4testP33_83378C430F65473055F1BD53F3ADCDB71C5doFoofT_T_ ---> test.(C in _83378C430F65473055F1BD53F3ADCDB7).doFoo () -> ()
 _TFVV15nested_generics5Lunch6DinnerCfT11firstCoursex12secondCourseGSqqd___9leftoversx14transformationFxqd___GS1_x_qd___ ---> nested_generics.Lunch.Dinner.init (firstCourse : A, secondCourse : A1?, leftovers : A, transformation : (A) -> A1) -> nested_generics.Lunch<A>.Dinner<A1>
+_TFVFC15nested_generics7HotDogs11applyRelishFT_T_L_6RelishCfT8materialx_GS1_x_ ---> nested_generics.HotDogs.(applyRelish () -> ()).(Relish #1).init (material : A) -> nested_generics.HotDogs.(applyRelish () -> ()).(Relish #1)<A>
+_TFVFE15nested_genericsSS3fooFT_T_L_6CheeseCfT8materialx_GS0_x_ ---> (extension in nested_generics):Swift.String.(foo () -> ()).(Cheese #1).init (material : A) -> (extension in nested_generics):Swift.String.(foo () -> ()).(Cheese #1)<A>
+

--- a/test/SILGen/nested_generics.swift
+++ b/test/SILGen/nested_generics.swift
@@ -87,6 +87,31 @@ class HotDogs {
   }
 }
 
+// Local type in extension of type in another module
+extension String {
+  func foo() {
+    // CHECK-LABEL: // (extension in nested_generics):Swift.String.(foo () -> ()).(Cheese #1).init (material : A) -> (extension in nested_generics):Swift.String.(foo () -> ()).(Cheese #1)<A>
+    // CHECK-LABEL: sil shared @_TFVFE15nested_genericsSS3fooFT_T_L_6CheeseCfT8materialx_GS0_x_
+    struct Cheese<Milk> {
+      let material: Milk
+    }
+    let r = Cheese(material: "cow")
+  }
+}
+
+// Local type in extension of type in same module
+extension HotDogs {
+  func applyRelish() {
+    // CHECK-LABEL: // nested_generics.HotDogs.(applyRelish () -> ()).(Relish #1).init (material : A) -> nested_generics.HotDogs.(applyRelish () -> ()).(Relish #1)<A>
+    // CHECK-LABEL: sil shared @_TFVFC15nested_generics7HotDogs11applyRelishFT_T_L_6RelishCfT8materialx_GS1_x_
+
+    struct Relish<Material> {
+      let material: Material
+    }
+    let r = Relish(material: "pickles")
+  }
+}
+
 struct Pepper {}
 struct ChiliFlakes {}
 


### PR DESCRIPTION
Local generic types can appear inside functions inside extensions
of other types. When demangling bound generic arguments, the demangler
assumed that a module was the only other kind of context outside
of nominal types.

rdar://problem/27573079
