### PR TITLE
[SILGen] Directly silgen access of #dsohandle

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -243,9 +243,6 @@ public:
     DebugClient = R;
   }
 
-  /// Retrieve the magic __dso_handle variable.
-  VarDecl *getDSOHandle();
-
   /// Returns true if this module was or is being compiled for testing.
   bool isTestingEnabled() const {
     return Flags.TestingEnabled;

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -367,28 +367,6 @@ void Module::removeFile(FileUnit &existingFile) {
   Files.erase(I.base());
 }
 
-VarDecl *Module::getDSOHandle() {
-  if (DSOHandle)
-    return DSOHandle;
-
-  auto unsafeMutableRawPtr = getASTContext().getUnsafeMutableRawPointerDecl();
-  if (!unsafeMutableRawPtr)
-    return nullptr;
-
-  auto &ctx = getASTContext();
-  auto handleVar = new (ctx) VarDecl(/*IsStatic=*/false, /*IsLet=*/false,
-                                     SourceLoc(),
-                                     ctx.getIdentifier("__dso_handle"),
-                                     unsafeMutableRawPtr->getDeclaredType(),
-                                     Files[0]);
-  handleVar->setImplicit(true);
-  handleVar->getAttrs().add(
-    new (ctx) SILGenNameAttr("__dso_handle", /*Implicit=*/true));
-  handleVar->setAccessibility(Accessibility::Internal);
-  DSOHandle = handleVar;
-  return handleVar;
-}
-
 #define FORWARD(name, args) \
   for (const FileUnit *file : getFiles()) \
     file->name args;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1240,7 +1240,9 @@ namespace {
         if (tc.requirePointerArgumentIntrinsics(expr->getLoc()))
           return nullptr;
 
-        return CS.DC->getParentModule()->getDSOHandle()->getInterfaceType();
+        auto unsafeRawPointer =
+          CS.getASTContext().getUnsafeRawPointerDecl();
+        return unsafeRawPointer->getDeclaredType();
       }
       }
     }

--- a/test/SILGen/default_arguments.swift
+++ b/test/SILGen/default_arguments.swift
@@ -189,11 +189,11 @@ func testTakeDefaultArgUnnamed(_ i: Int) {
   takeDefaultArgUnnamed(i)
 }
 
-func takeDSOHandle(_ handle: UnsafeMutableRawPointer = #dsohandle) { }
+func takeDSOHandle(_ handle: UnsafeRawPointer = #dsohandle) { }
 
 // CHECK-LABEL: sil hidden @_TF17default_arguments13testDSOHandleFT_T_
 func testDSOHandle() {
-  // CHECK: [[DSO_HANDLE:%[0-9]+]] = global_addr @__dso_handle : $*UnsafeMutableRawPointer
+  // CHECK: [[DSO_HANDLE:%[0-9]+]] = global_addr @__dso_handle : $*Builtin.RawPointer
   takeDSOHandle()
 }
 
@@ -225,7 +225,7 @@ class ReabstractDefaultArgument<T> {
 // CHECK-NEXT: apply [[INITFN]]<Int>(%7, 
 
 func testDefaultArgumentReabstraction() {
-  ReabstractDefaultArgument<Int>()
+  _ = ReabstractDefaultArgument<Int>()
 }
 
 // <rdar://problem/20494437> SILGen crash handling default arguments

--- a/test/SILGen/dso_handle.swift
+++ b/test/SILGen/dso_handle.swift
@@ -1,18 +1,23 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen %s | FileCheck %s
 
-// CHECK: sil_global hidden_external @__dso_handle : $UnsafeMutableRawPointer
+// CHECK: sil_global hidden_external [[DSO:@__dso_handle]] : $Builtin.RawPointer
 
 // CHECK-LABEL: sil @main : $@convention(c)
 // CHECK: bb0
-// CHECK: [[DSO:%[0-9]+]] = global_addr @__dso_handle : $*UnsafeMutableRawPointer
-// CHECK: load [[DSO]]
+// CHECK: [[DSOAddr:%[0-9]+]] = global_addr [[DSO]] : $*Builtin.RawPointer
+// CHECK-NEXT: [[DSOPtr:%[0-9]+]] = address_to_pointer [[DSOAddr]] : $*Builtin.RawPointer to $Builtin.RawPointer
+// CHECK-NEXT: [[DSOPtrStruct:[0-9]+]] = struct $UnsafeRawPointer ([[DSOPtr]] : $Builtin.RawPointer)
 
-// CHECK-LABEL: sil hidden @_TIF10dso_handle14printDSOHandleFT3dsoSv_SvA_
-// CHECK: [[DSO:%[0-9]+]] = global_addr @__dso_handle : $*UnsafeMutableRawPointer
-// CHECK: load [[DSO]]
-func printDSOHandle(dso: UnsafeMutableRawPointer = #dsohandle) -> UnsafeMutableRawPointer {
+
+// CHECK-LABEL: sil hidden @_TIF10dso_handle14printDSOHandleFT3dsoSV_SVA_
+// CHECK: [[DSOAddr:%[0-9]+]] = global_addr [[DSO]] : $*Builtin.RawPointer
+// CHECK-NEXT: [[DSOPtr:%[0-9]+]] = address_to_pointer [[DSOAddr]] : $*Builtin.RawPointer to $Builtin.RawPointer
+// CHECK-NEXT: [[DSOPtrStruct:%[0-9]+]] = struct $UnsafeRawPointer ([[DSOPtr]] : $Builtin.RawPointer)
+// CHECK-NEXT: return [[DSOPtrStruct]] : $UnsafeRawPointer
+func printDSOHandle(dso: UnsafeRawPointer = #dsohandle) -> UnsafeRawPointer {
   print(dso)
+  return dso
 }
 
-printDSOHandle()
+_ = printDSOHandle()
 

--- a/validation-test/execution/Inputs/dsohandle-first.swift
+++ b/validation-test/execution/Inputs/dsohandle-first.swift
@@ -1,0 +1,3 @@
+public func getFirstDSOHandle() -> UnsafeRawPointer {
+  return #dsohandle
+}

--- a/validation-test/execution/Inputs/dsohandle-second.swift
+++ b/validation-test/execution/Inputs/dsohandle-second.swift
@@ -1,0 +1,3 @@
+public func getSecondDSOHandle() -> UnsafeRawPointer {
+  return #dsohandle
+}

--- a/validation-test/execution/dsohandle-multi-module.swift
+++ b/validation-test/execution/dsohandle-multi-module.swift
@@ -1,0 +1,22 @@
+// RUN: rm -rf %t && mkdir %t
+
+// RUN: (cd %t && %target-build-swift %S/Inputs/dsohandle-first.swift -emit-library -emit-module -module-name first)
+// RUN: (cd %t && %target-build-swift %S/Inputs/dsohandle-second.swift -emit-library -emit-module -module-name second)
+// RUN: %target-build-swift -I %t -L %t -lfirst -lsecond %s -o %t/main
+// RUN: env LD_LIBRARY_PATH=%t DYLD_LIBRARY_PATH=%t %target-run %t/main
+// REQUIRES: executable_test
+
+import first
+import second
+
+import StdlibUnittest
+
+let DSOHandleTests = TestSuite("DSOHandle")
+
+DSOHandleTests.test("Unique handles for different images") {
+  let firstHandle = getFirstDSOHandle()
+  let secondHandle = getSecondDSOHandle()
+  expectNotEqual(firstHandle, secondHandle)
+}
+
+runAllTests()


### PR DESCRIPTION
Synthesizing a VarDecl for #dsohandle causes some unwanted accessors to
be expected, but we really don't need them: this is a global variable
for the start of the image. There are only two uses of getDSOHandle:
getting the type and emitting the SIL for it. Rather than perform
acrobatics to turn off switches, just emit access directly where it's
needed.

rdar://problem/26565092
