### PR TITLE
[SourceKit] For clang enums imported as error domains, make sure to use unique USRs.

### DIFF
--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -18,6 +18,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/Attr.h"
 #include "clang/Index/USRGeneration.h"
 #include "clang/Lex/PreprocessingRecord.h"
 #include "clang/Lex/Preprocessor.h"
@@ -55,7 +56,39 @@ bool ide::printDeclUSR(const ValueDecl *D, raw_ostream &OS) {
 
   ValueDecl *VD = const_cast<ValueDecl *>(D);
 
-  if (ClangNode ClangN = VD->getClangNode()) {
+  auto interpretAsClangNode = [](const ValueDecl *D)->ClangNode {
+    ClangNode ClangN = D->getClangNode();
+    if (auto ClangD = ClangN.getAsDecl()) {
+      // NSErrorDomain causes the clang enum to be imported like this:
+      //
+      // struct MyError {
+      //     enum Code : Int32 {
+      //         case errFirst
+      //         case errSecond
+      //     }
+      //     static var errFirst: MyError.Code { get }
+      //     static var errSecond: MyError.Code { get }
+      // }
+      //
+      // The clang enum and enum constants are associated with both the
+      // struct/nested enum, and the static vars/enum cases.
+      // But we want unique USRs for the above symbols, so use the clang USR
+      // for the enum and enum cases, and the Swift USR for the struct and vars.
+      //
+      if (isa<clang::EnumDecl>(ClangD)) {
+        if (ClangD->hasAttr<clang::NSErrorDomainAttr>() && isa<StructDecl>(D))
+          return ClangNode();
+      } else if (auto *ClangEnumConst = dyn_cast<clang::EnumConstantDecl>(ClangD)) {
+        if (auto *ClangEnum = dyn_cast<clang::EnumDecl>(ClangEnumConst->getDeclContext())) {
+          if (ClangEnum->hasAttr<clang::NSErrorDomainAttr>() && isa<VarDecl>(D))
+            return ClangNode();
+        }
+      }
+    }
+    return ClangN;
+  };
+
+  if (ClangNode ClangN = interpretAsClangNode(D)) {
     llvm::SmallString<128> Buf;
     if (auto ClangD = ClangN.getAsDecl()) {
       bool Ignore = clang::index::generateUSRForDecl(ClangD, Buf);

--- a/test/SourceKit/DocSupport/Inputs/MyError.h
+++ b/test/SourceKit/DocSupport/Inputs/MyError.h
@@ -1,0 +1,14 @@
+@import Foundation;
+
+#define NS_ERROR_ENUM(_type, _name, _domain)  \
+  enum _name : _type _name; enum __attribute__((ns_error_domain(_domain))) _name : _type
+
+@class NSString;
+extern const NSString *const MyErrorDomain;
+/// This is my cool error code.
+typedef NS_ERROR_ENUM(int, MyErrorCode, MyErrorDomain) {
+	/// This is first error.
+	MyErrFirst,
+	/// This is second error.
+	MyErrSecond,
+};

--- a/test/SourceKit/DocSupport/Inputs/module.modulemap
+++ b/test/SourceKit/DocSupport/Inputs/module.modulemap
@@ -1,0 +1,4 @@
+module "MyError" {
+  header "MyError.h"
+  export *
+}

--- a/test/SourceKit/DocSupport/doc_error_domain.swift
+++ b/test/SourceKit/DocSupport/doc_error_domain.swift
@@ -1,0 +1,32 @@
+// REQUIRES: OS=macosx
+// RUN: %sourcekitd-test -req=doc-info -module MyError -- -I %S/Inputs \
+// RUN:         %mcp_opt -sdk %sdk | %sed_clean > %t.response
+// RUN: FileCheck -input-file=%t.response %s
+
+// CHECK: struct MyError {
+// CHECK:     enum Code : Int32 {
+// CHECK:         case errFirst
+// CHECK:         case errSecond
+// CHECK:     }
+// CHECK:     static var errFirst: MyError.Code { get }
+// CHECK:     static var errSecond: MyError.Code { get }
+
+// CHECK:         key.kind: source.lang.swift.decl.struct,
+// CHECK-NEXT:    key.name: "MyError",
+// CHECK-NEXT:    key.usr: "s:VSC7MyError",
+// CHECK-NEXT:    This is my cool error code.
+
+// CHECK:             key.kind: source.lang.swift.decl.enum,
+// CHECK-NEXT:        key.name: "Code",
+// CHECK-NEXT:        key.usr: "c:@E@MyErrorCode",
+// CHECK-NEXT:        This is my cool error code.
+
+// CHECK:                 key.kind: source.lang.swift.decl.enumelement,
+// CHECK-NEXT:            key.name: "errFirst",
+// CHECK-NEXT:            key.usr: "c:@E@MyErrorCode@MyErrFirst",
+// CHECK-NEXT:            This is first error.
+
+// CHECK:             key.kind: source.lang.swift.decl.var.static,
+// CHECK-NEXT:        key.name: "errFirst",
+// CHECK-NEXT:        key.usr: "s:ZvVSC7MyError8errFirstOS_4Code",
+// CHECK-NEXT:        This is first error.


### PR DESCRIPTION
#### What's in this pull request?

Error domain enums are imported with synthesizing extra struct and static vars for enumerators, these need to get a distinct USR from the generated enum.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

```
rdar://27550967
```

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…se unique USRs.

Error domain enums are imported with synthesizing something like this:

 struct MyError {
     enum Code : Int32 {
         case errFirst
         case errSecond
     }
     static var errFirst: MyError.Code { get }
     static var errSecond: MyError.Code { get }
 }

The clang enum and enum constants are associated with both the
struct/nested enum, and the static vars/enum cases.
But we want unique USRs for the above symbols, so use the clang USR
for the enum and enum cases, and the Swift USR for the struct and vars.

rdar://27550967
