### PR TITLE
ClangImporter: enable -fblocks on non-Darwin platforms

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -332,6 +332,9 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
           // Don't emit LLVM IR.
           "-fsyntax-only",
 
+          // enable block support
+          "-fblocks",
+
           "-fretain-comments-from-system-headers",
 
           SHIMS_INCLUDE_FLAG, searchPathOpts.RuntimeResourcePath,
@@ -341,7 +344,7 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
   if (triple.isOSDarwin()) {
     invocationArgStrs.insert(invocationArgStrs.end(), {
       // Darwin uses Objective-C ARC.
-      "-x", "objective-c", "-std=gnu11", "-fobjc-arc", "-fblocks",
+      "-x", "objective-c", "-std=gnu11", "-fobjc-arc",
 
       // Define macros that Swift bridging headers use.
       "-DSWIFT_CLASS_EXTRA=__attribute__((annotate(\""

--- a/test/ClangModules/cfuncs_parse.swift
+++ b/test/ClangModules/cfuncs_parse.swift
@@ -1,7 +1,5 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse -verify -I %S/Inputs %s
 
-// XFAIL: linux
-
 import cfuncs
 
 func test_cfunc1(_ i: Int) {

--- a/test/ClangModules/cstring_parse.swift
+++ b/test/ClangModules/cstring_parse.swift
@@ -5,8 +5,6 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse -verify -module-cache-path %t/clang-module-cache -I %S/Inputs %s
 // RUN: ls -lR %t/clang-module-cache | %FileCheck %s
 
-// XFAIL: linux
-
 // CHECK: cfuncs{{.*}}.pcm
 
 import cfuncs


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

swift-corelibs-libdispatch requires block support when importing the dispatch
header files.  This pull request enables block support in the ClangImporter
unconditionally on non-Darwin platforms (as is already done on Darwin platforms).

Without this change (or a more complex change that would look at the name
of the module being imported and only enable -fblocks if the module name was CDispatch),
the user must explicitly give -Xcc -fblocks as command line arguments to swiftc when 
compiling any Swift program that imports Dispatch or Foundation on non-Darwin platforms.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

We need to enable blocks support in the ClangImporter on
non-Darwin platforms for libdispatch (and transitively foundation).
The simplest way to do this is to just enable blocks unconditionally.
