### PR TITLE
[stdlib] default separator for joining strings (SE-0133)

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -767,9 +767,9 @@ extension Sequence where Iterator.Element == String {
   ///     // Prints "Vivien, Marlon, Kim, Karl"
   ///
   /// - Parameter separator: A string to insert between each of the elements
-  ///   in this sequence.
+  ///   in this sequence. The default separator is an empty string.
   /// - Returns: A single, concatenated string.
-  public func joined(separator: String) -> String {
+  public func joined(separator: String = "") -> String {
     var result = ""
 
     // FIXME(performance): this code assumes UTF-16 in-memory representation.

--- a/test/IDE/print_type_interface.swift
+++ b/test/IDE/print_type_interface.swift
@@ -83,4 +83,4 @@ extension D {
 // TYPE5-DAG: public func split(separator: String, maxSplits: Int = default, omittingEmptySubsequences: Bool = default) -> [ArraySlice<String>]
 // TYPE5-DAG: public func formIndex(_ i: inout Int, offsetBy n: Int)
 // TYPE5-DAG: public func distance(from start: Int, to end: Int) -> Int
-// TYPE5-DAG: public func joined(separator: String) -> String
+// TYPE5-DAG: public func joined(separator: String = default) -> String

--- a/validation-test/stdlib/Join.swift.gyb
+++ b/validation-test/stdlib/Join.swift.gyb
@@ -277,7 +277,7 @@ collections += [(array, 'RandomAccess') for array in other_array_types]
 %     label = ''
 %   end
 
-JoinTestSuite.test("${Base}.join()") {
+JoinTestSuite.test("${Base}.joined(separator:)") {
   for test in joinWithSeparatorTests {
     let elements = ${Base}(${label} test.elements.map {
       ${Base}(${label} $0)
@@ -288,7 +288,7 @@ JoinTestSuite.test("${Base}.join()") {
   }
 }
 
-JoinTestSuite.test("${Base}.join()/_copyToContiguousArray()") {
+JoinTestSuite.test("${Base}.joined(separator:)/_copyToContiguousArray()") {
   for test in joinWithSeparatorTests {
     let elements = ${Base}(${label} test.elements.map {
       ${Base}(${label} $0)
@@ -301,47 +301,43 @@ JoinTestSuite.test("${Base}.join()/_copyToContiguousArray()") {
 
 % end
 
-func join(_ separator: String, _ elements: [String]) -> String {
-  return elements.joined(separator: separator)
-}
-
-JoinTestSuite.test("String.joined(separator:)") {
-  //
-  // Test the free function.
-  //
+JoinTestSuite.test("Sequence<String>.joined(separator:)") {
+  // Default separator (empty).
+  expectEqual("",       [].joined())
+  expectEqual("",       [""].joined())
+  expectEqual("",       ["", ""].joined())
+  expectEqual("",       ["", "", ""].joined())
+  expectEqual("a",      ["a"].joined())
+  expectEqual("ab",     ["a", "b"].joined())
+  expectEqual("abc",    ["a", "b", "c"].joined())
+  expectEqual("abcdef", ["ab", "cd", "ef"].joined())
 
   // Empty separator.
-  expectEqual("",    join("", []))
-  expectEqual("",    join("", [""]))
-  expectEqual("",    join("", ["", ""]))
-  expectEqual("",    join("", ["", "", ""]))
-  expectEqual("a",   join("", ["a"]))
-  expectEqual("ab",  join("", ["a", "b"]))
-  expectEqual("abc", join("", ["a", "b", "c"]))
-  expectEqual("abcdef", join("", ["ab", "cd", "ef"]))
+  expectEqual("",       [].joined(separator: ""))
+  expectEqual("",       [""].joined(separator: ""))
+  expectEqual("",       ["", ""].joined(separator: ""))
+  expectEqual("",       ["", "", ""].joined(separator: ""))
+  expectEqual("a",      ["a"].joined(separator: ""))
+  expectEqual("ab",     ["a", "b"].joined(separator: ""))
+  expectEqual("abc",    ["a", "b", "c"].joined(separator: ""))
+  expectEqual("abcdef", ["ab", "cd", "ef"].joined(separator: ""))
 
   // 1-element separator.
-  expectEqual("",      join("x", [""]))
-  expectEqual("x",     join("x", ["", ""]))
-  expectEqual("xx",    join("x", ["", "", ""]))
-  expectEqual("a",     join("x", ["a"]))
-  expectEqual("axb",   join("x", ["a", "b"]))
-  expectEqual("axbxc", join("x", ["a", "b", "c"]))
-  expectEqual("abxcdxef", join("x", ["ab", "cd", "ef"]))
+  expectEqual("",         [""].joined(separator: "x"))
+  expectEqual("x",        ["", ""].joined(separator: "x"))
+  expectEqual("xx",       ["", "", ""].joined(separator: "x"))
+  expectEqual("a",        ["a"].joined(separator: "x"))
+  expectEqual("axb",      ["a", "b"].joined(separator: "x"))
+  expectEqual("axbxc",    ["a", "b", "c"].joined(separator: "x"))
+  expectEqual("abxcdxef", ["ab", "cd", "ef"].joined(separator: "x"))
 
   // 2-element separator.
-  expectEqual("",        join("xy", [""]))
-  expectEqual("xy",      join("xy", ["", ""]))
-  expectEqual("xyxy",    join("xy", ["", "", ""]))
-  expectEqual("a",       join("xy", ["a"]))
-  expectEqual("axyb",    join("xy", ["a", "b"]))
-  expectEqual("axybxyc", join("xy", ["a", "b", "c"]))
-  expectEqual("abxycdxyef", join("xy", ["ab", "cd", "ef"]))
-
-  //
-  // Test forwarding instance function.
-  //
-
+  expectEqual("",           [""].joined(separator: "xy"))
+  expectEqual("xy",         ["", ""].joined(separator: "xy"))
+  expectEqual("xyxy",       ["", "", ""].joined(separator: "xy"))
+  expectEqual("a",          ["a"].joined(separator: "xy"))
+  expectEqual("axyb",       ["a", "b"].joined(separator: "xy"))
+  expectEqual("axybxyc",    ["a", "b", "c"].joined(separator: "xy"))
   expectEqual("abxycdxyef", ["ab", "cd", "ef"].joined(separator: "xy"))
 }
 


### PR DESCRIPTION
Per [SE-0133 rename `flatten()` to `joined()`](https://github.com/apple/swift-evolution/blob/master/proposals/0133-rename-flatten-to-joined.md),  `Sequence<String>.joined(separator:)` should have a default separator of `""`.

Cleaned up the Join tests slightly; they were weirdly-structured due to organic growth back when `join` was a free function.

cc @dabrahams @tkremenek 

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
