### PR TITLE
[PrintAsObjC] Add unavailable attribute to unavailable obj-c initializers

### DIFF
--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -122,6 +122,25 @@ class ClassWithCustomNameSub : ClassWithCustomName {}
   init(forFun: ()) { }
 }
 
+// CHECK-LABEL: @interface InheritedInitializers
+// CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
+// CHECK-NEXT: - (nonnull instancetype)initForFun SWIFT_UNAVAILABLE;
+// CHECK-NEXT: @end
+@objc class InheritedInitializers : Initializers {
+  override init() {
+    super.init()
+  }
+}
+
+// CHECK-LABEL: @interface InheritedInitializersAgain
+// CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
+// CHECK-NEXT: @end
+@objc class InheritedInitializersAgain : InheritedInitializers {
+  override init() {
+    super.init()
+  }
+}
+
 // NEGATIVE-NOT: NotObjC
 class NotObjC {}
 

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -108,6 +108,8 @@ class ClassWithCustomNameSub : ClassWithCustomName {}
 // CHECK-NEXT: - (nonnull instancetype)initWithString:(NSString * _Nonnull)s boolean:(BOOL)b;
 // CHECK-NEXT: - (nullable instancetype)initWithBoolean:(BOOL)b;
 // CHECK-NEXT: - (nonnull instancetype)initForFun OBJC_DESIGNATED_INITIALIZER;
+// CHECK-NEXT: - (nonnull instancetype)initWithMoreFun OBJC_DESIGNATED_INITIALIZER;
+// CHECK-NEXT: - (nonnull instancetype)initWithEvenMoreFun OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: @end
 @objc class Initializers {
   init() {}
@@ -120,25 +122,39 @@ class ClassWithCustomNameSub : ClassWithCustomName {}
   convenience init?(boolean b: ObjCBool) { self.init() }
 
   init(forFun: ()) { }
+
+  init(moreFun: ()) { }
+
+  init(evenMoreFun: ()) { }
 }
 
 // CHECK-LABEL: @interface InheritedInitializers
 // CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
+// CHECK-NEXT: - (nonnull instancetype)initWithFloat:(float)f SWIFT_UNAVAILABLE;
+// CHECK-NEXT: - (nonnull instancetype)initWithMoreFun SWIFT_UNAVAILABLE;
 // CHECK-NEXT: - (nonnull instancetype)initForFun SWIFT_UNAVAILABLE;
+// CHECK-NEXT: - (nonnull instancetype)initWithEvenMoreFun SWIFT_UNAVAILABLE;
 // CHECK-NEXT: @end
 @objc class InheritedInitializers : Initializers {
   override init() {
     super.init()
   }
+
+  private convenience init(float f: Float) { self.init() }
+
+  private override init(moreFun: ()) { super.init() }
 }
 
 // CHECK-LABEL: @interface InheritedInitializersAgain
 // CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
+// CHECK-NEXT: - (nonnull instancetype)initWithEvenMoreFun OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: @end
 @objc class InheritedInitializersAgain : InheritedInitializers {
   override init() {
     super.init()
   }
+
+  init(evenMoreFun: ()) { super.init() }
 }
 
 // NEGATIVE-NOT: NotObjC

--- a/test/PrintAsObjC/protocols.swift
+++ b/test/PrintAsObjC/protocols.swift
@@ -75,7 +75,8 @@ protocol CustomNameType2 {}
 }
 
 // CHECK-LABEL: @interface MyObject : NSObject <NSCoding>
-// CHECK-NEXT: init
+// CHECK-NEXT: initWithCoder
+// CHECK-NEXT: init SWIFT_UNAVAILABLE
 // CHECK-NEXT: @end
 // NEGATIVE-NOT: @protocol NSCoding
 class MyObject : NSObject, NSCoding {


### PR DESCRIPTION
#### What's in this pull request?

Fixes PrintAsObjC to declare unavailable initializers with `__attribute__((unavailable))` so they can't be called from Obj-C. This covers non-inherited designated initializers as well as initializers overridden by `private` declarations.

Notably, this does not include non-inherited convenience initializers. This is because non-inherited convenience initializers do not get Obj-C stub implementations (filed as [SR-2211](https://bugs.swift.org/browse/SR-2211)).
#### Resolved bug number: ([SR-746](https://bugs.swift.org/browse/SR-746))

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
