### PR TITLE
SE-0103 Noescape by default

### DIFF
--- a/benchmark/single-source/Integrate.swift
+++ b/benchmark/single-source/Integrate.swift
@@ -20,7 +20,7 @@ class Integrate {
 
   let fun: (Double) -> Double
 
-  init (f: (Double) -> Double) {
+  init (f: @escaping (Double) -> Double) {
     fun = f
   }
     

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -50,7 +50,7 @@ struct Test {
   let index: Int
   let f: (Int) -> ()
   var run: Bool
-  init(name: String, n: Int, f: (Int) -> ()) {
+  init(name: String, n: Int, f: @escaping (Int) -> ()) {
     self.name = name
     self.index = n
     self.f = f

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1821,6 +1821,8 @@ ERROR(autoclosure_function_type,none,
       ())
 ERROR(autoclosure_function_input_nonunit,none,
       "autoclosure argument type must be '()'", ())
+
+// FIXME: drop these when we drop @noescape
 ERROR(noescape_function_type,none,
       "@noescape may only be applied to parameters of function type",
       ())
@@ -1829,6 +1831,7 @@ ERROR(noescape_implied_by_autoclosure,none,
       "redundantly specified", ())
 ERROR(noescape_conflicts_escaping_autoclosure,none,
       "@noescape conflicts with @autoclosure(escaping)", ())
+
 ERROR(escaping_function_type,none,
       "@escaping may only be applied to parameters of function type", ())
 
@@ -2271,17 +2274,20 @@ WARNING(optional_pattern_match_promotion,none,
 ERROR(type_of_metatype,none,
       "'.dynamicType' is not allowed after a type name", ())
 ERROR(invalid_noescape_use,none,
-      "@noescape %select{value|parameter}1 %0 may only be called",
+      "non-escaping %select{value|parameter}1 %0 may only be called",
       (Identifier, bool))
 NOTE(noescape_autoclosure,none,
-    "parameter %0 is implicitly @noescape because it was declared @autoclosure",
+    "parameter %0 is implicitly non-escaping because it was declared @autoclosure",
+     (Identifier))
+NOTE(noescape_parameter,none,
+    "parameter %0 is implicitly non-escaping",
      (Identifier))
 
 ERROR(closure_noescape_use,none,
-      "closure use of @noescape parameter %0 may allow it to escape",
+      "closure use of non-escaping parameter %0 may allow it to escape",
       (Identifier))
 ERROR(decl_closure_noescape_use,none,
-      "declaration closing over @noescape parameter %0 may allow it to escape",
+      "declaration closing over non-escaping parameter %0 may allow it to escape",
       (Identifier))
 
 ERROR(capture_across_type_decl,none,

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -261,6 +261,12 @@ struct PrintOptions {
   /// Whether we are printing part of SIL body.
   bool PrintInSILBody = false;
 
+  /// Whether to print the types as if they appear as function parameters. This
+  /// governs whether we print a function type with an explicit @escaping. This
+  /// is also set and restored internally when visiting a type in a parameter
+  /// position.
+  bool PrintAsInParamType = false;
+
   /// Whether to use an empty line to separate two members in a single decl.
   bool EmptyLineBetweenMembers = false;
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2132,7 +2132,6 @@ public:
     enum : uint16_t { AutoClosureMask        = 0x010 };
     enum : uint16_t { NoEscapeMask           = 0x020 };
     enum : uint16_t { ThrowsMask             = 0x040 };
-    enum : uint16_t { ExplicitlyEscapingMask = 0x080 };
 
     uint16_t Bits;
 
@@ -2153,17 +2152,15 @@ public:
 
     // Constructor with no defaults.
     ExtInfo(Representation Rep,
-            bool IsAutoClosure, bool IsNoEscape, bool IsExplicitlyEscaping,
+            bool IsAutoClosure, bool IsNoEscape,
             bool Throws)
       : ExtInfo(Rep, Throws) {
       Bits |= (IsAutoClosure ? AutoClosureMask : 0);
       Bits |= (IsNoEscape ? NoEscapeMask : 0);
-      Bits |= (IsExplicitlyEscaping ? ExplicitlyEscapingMask : 0);
     }
 
     bool isAutoClosure() const { return Bits & AutoClosureMask; }
     bool isNoEscape() const { return Bits & NoEscapeMask; }
-    bool isExplicitlyEscaping() const { return Bits & ExplicitlyEscapingMask; }
     bool throws() const { return Bits & ThrowsMask; }
     Representation getRepresentation() const {
       unsigned rawRep = Bits & RepresentationMask;
@@ -2287,12 +2284,6 @@ public:
     return getExtInfo().isNoEscape();
   }
 
-  /// \brief True if the parameter declaration it is attached to has explicitly
-  /// been marked with the @escaping attribute. This is a temporary measure.
-  bool isExplicitlyEscaping() const {
-    return getExtInfo().isExplicitlyEscaping();
-  }
-  
   bool throws() const {
     return getExtInfo().throws();
   }

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -53,7 +53,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 258; // Last change: precedencegroup
+const uint16_t VERSION_MINOR = 259; // Last change: drop explicitlyEscaping
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;
@@ -590,7 +590,6 @@ namespace decls_block {
     FunctionTypeRepresentationField, // representation
     BCFixed<1>,  // auto-closure?
     BCFixed<1>,  // noescape?
-    BCFixed<1>,  // explicitlyEscaping?
     BCFixed<1>   // throws?
   >;
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2916,8 +2916,11 @@ namespace {
       }
 
       printFlag(T->isAutoClosure(), "autoclosure");
-      printFlag(T->isNoEscape(), "noescape");
-      printFlag(T->isExplicitlyEscaping(), "escaping");
+
+      // Dump out either @noescape or @escaping
+      printFlag(T->isNoEscape(), "@noescape");
+      printFlag(!T->isNoEscape(), "@escaping");
+
       printFlag(T->throws(), "throws");
 
       printRec("input", T->getInput());

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3748,8 +3748,9 @@ public:
     } else if (info.isNoEscape()) {
       // autoclosure implies noescape.
       Printer << "@noescape ";
-    } else if (info.isExplicitlyEscaping()) {
-      Printer << "@escaping ";
+    } else {
+        Printer << "@escaping ";
+    }
     }
 
     if (Options.PrintFunctionRepresentationAttrs) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5587,7 +5587,6 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
         swift::AnyFunctionType::ExtInfo newEI(fromEI.getRepresentation(),
                                         toEI.isAutoClosure(),
                                         toEI.isNoEscape() | fromEI.isNoEscape(),
-                                        toEI.isExplicitlyEscaping() | fromEI.isExplicitlyEscaping(),
                                         toEI.throws() & fromEI.throws());
         auto newToType = FunctionType::get(fromFunc->getInput(),
                                            fromFunc->getResult(), newEI);

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -464,7 +464,16 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
 
       TC.diagnose(DRE->getStartLoc(), diag::invalid_noescape_use,
                   DRE->getDecl()->getName(), isa<ParamDecl>(DRE->getDecl()));
-      if (AFT->isAutoClosure())
+
+      // If we're a parameter, emit a helpful fixit to add @escaping
+      auto paramDecl = dyn_cast<ParamDecl>(DRE->getDecl());
+      auto isAutoClosure = AFT->isAutoClosure();
+      if (paramDecl && !isAutoClosure) {
+        TC.diagnose(paramDecl->getStartLoc(), diag::noescape_parameter,
+                    paramDecl->getName())
+            .fixItInsert(paramDecl->getTypeLoc().getLoc(), "@escaping ");
+      } else if (isAutoClosure)
+        // TODO: add in a fixit for autoclosure
         TC.diagnose(DRE->getDecl()->getLoc(), diag::noescape_autoclosure,
                     DRE->getDecl()->getName());
     }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1628,10 +1628,6 @@ void TypeChecker::checkNoEscapeAttr(ParamDecl *PD, NoEscapeAttr *attr) {
     return;
   }
 
-  // Just stop if we've already applied this attribute.
-  if (FTy->isNoEscape())
-    return;
-
   // This range can be implicit e.g. if we're in the middle of diagnosing
   // @autoclosure.
   auto attrRemovalRange = attr->getRangeWithAt();
@@ -1644,6 +1640,10 @@ void TypeChecker::checkNoEscapeAttr(ParamDecl *PD, NoEscapeAttr *attr) {
   diagnose(attr->getLocation(), diag::attr_decl_attr_now_on_type, "@noescape")
     .fixItRemove(attrRemovalRange) 
     .fixItInsert(PD->getTypeLoc().getSourceRange().Start, "@noescape ");
+
+  // Stop if we've already applied this attribute.
+  if (FTy->isNoEscape())
+    return;
 
   // Change the type to include the noescape bit.
   PD->overwriteType(FunctionType::get(FTy->getInput(), FTy->getResult(),

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1579,12 +1579,24 @@ Type TypeChecker::resolveType(TypeRepr *TyR, DeclContext *DC,
   return result;
 }
 
+/// Whether the given DC is a noescape-by-default context, i.e. not a property
+/// setter
+static bool isDefaultNoEscapeContext(const DeclContext *DC) {
+  auto funcDecl = dyn_cast<FuncDecl>(DC);
+  return !funcDecl || !funcDecl->isSetter();
+}
+
 Type TypeResolver::resolveType(TypeRepr *repr, TypeResolutionOptions options) {
   assert(repr && "Cannot validate null TypeReprs!");
 
   // If we know the type representation is invalid, just return an
   // error type.
   if (repr->isInvalid()) return ErrorType::get(TC.Context);
+
+  // Remember whether this is a function parameter.
+  bool isFunctionParam =
+    options.contains(TR_FunctionInput) ||
+    options.contains(TR_ImmediateFunctionInput);
 
   // Strip the "is function input" bits unless this is a type that knows about
   // them.
@@ -1611,8 +1623,14 @@ Type TypeResolver::resolveType(TypeRepr *repr, TypeResolutionOptions options) {
                                     UnsatisfiedDependency);
 
   case TypeReprKind::Function:
-    if (!(options & TR_SILType))
-      return resolveASTFunctionType(cast<FunctionTypeRepr>(repr), options);
+    if (!(options & TR_SILType)) {
+      // Default non-escaping for closure parameters
+      auto info = AnyFunctionType::ExtInfo().withNoEscape(
+          isFunctionParam &&
+          isDefaultNoEscapeContext(DC));
+      return resolveASTFunctionType(cast<FunctionTypeRepr>(repr), options,
+                                    info);
+    }
     return resolveSILFunctionType(cast<FunctionTypeRepr>(repr), options);
 
   case TypeReprKind::Array:
@@ -1870,10 +1888,22 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
           .fixItReplace(resultRange, "Never");
     }
 
+    bool defaultNoEscape = false;
+    // TODO: Get rid of the need for checking autoclosure, by refactoring
+    // special autoclosure knowledge to just as "isEscaping" or similar.
+    if (isFunctionParam && !attrs.has(TAK_autoclosure)) {
+      // Closure params default to non-escaping
+      if (attrs.has(TAK_noescape)) {
+        // FIXME: diagnostic to tell user this is redundant and drop it
+      } else if (!attrs.has(TAK_escaping)) {
+        defaultNoEscape = isDefaultNoEscapeContext(DC);
+      }
+    }
+
     // Resolve the function type directly with these attributes.
     FunctionType::ExtInfo extInfo(rep,
                                   attrs.has(TAK_autoclosure),
-                                  attrs.has(TAK_noescape),
+                                  defaultNoEscape | attrs.has(TAK_noescape),
                                   fnRepr->throws());
 
     ty = resolveASTFunctionType(fnRepr, options, extInfo);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1874,7 +1874,6 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
     FunctionType::ExtInfo extInfo(rep,
                                   attrs.has(TAK_autoclosure),
                                   attrs.has(TAK_noescape),
-                                  attrs.has(TAK_escaping),
                                   fnRepr->throws());
 
     ty = resolveASTFunctionType(fnRepr, options, extInfo);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3493,13 +3493,12 @@ Type ModuleFile::getType(TypeID TID) {
     TypeID inputID;
     TypeID resultID;
     uint8_t rawRepresentation;
-    bool autoClosure, noescape, explicitlyEscaping, throws;
+    bool autoClosure, noescape, throws;
 
     decls_block::FunctionTypeLayout::readRecord(scratch, inputID, resultID,
                                                 rawRepresentation,
                                                 autoClosure,
                                                 noescape,
-                                                explicitlyEscaping,
                                                 throws);
     auto representation = getActualFunctionTypeRepresentation(rawRepresentation);
     if (!representation.hasValue()) {
@@ -3509,7 +3508,7 @@ Type ModuleFile::getType(TypeID TID) {
     
     auto Info = FunctionType::ExtInfo(*representation,
                                autoClosure, noescape,
-                               explicitlyEscaping, throws);
+                               throws);
     
     typeOrOffset = FunctionType::get(getType(inputID), getType(resultID),
                                      Info);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2984,7 +2984,6 @@ void Serializer::writeType(Type ty) {
            getRawStableFunctionTypeRepresentation(fnTy->getRepresentation()),
            fnTy->isAutoClosure(),
            fnTy->isNoEscape(),
-           fnTy->isExplicitlyEscaping(),
            fnTy->throws());
     break;
   }

--- a/stdlib/internal/SwiftExperimental/SwiftExperimental.swift
+++ b/stdlib/internal/SwiftExperimental/SwiftExperimental.swift
@@ -41,7 +41,7 @@ precedencegroup CompositionPrecedence {
 ///
 /// - Returns: a function that applies ``g`` to the result of applying ``f``
 ///   to the argument of the new function.
-public func ∘<T, U, V>(g: (U) -> V, f: (T) -> U) -> ((T) -> V) {
+public func ∘<T, U, V>(g: @escaping (U) -> V, f: @escaping (T) -> U) -> ((T) -> V) {
   return { g(f($0)) }
 }
 

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionInstance.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionInstance.swift.gyb
@@ -514,7 +514,7 @@ public func checkSliceableWithBidirectionalIndex<
 
 
 public func checkRangeReplaceable<C, N>(
-  _ makeCollection: () -> C,
+  _ makeCollection: @escaping () -> C,
   _ makeNewValues: (Int) -> N
 ) where
   C : RangeReplaceableCollection,

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
@@ -500,15 +500,15 @@ internal func _product<C1 : Collection, C2 : Collection>(
 
   testParams = '''
     _ testNamePrefix: String = "",
-    makeCollection: ([C.Iterator.Element]) -> C,
-    wrapValue: (OpaqueValue<Int>) -> C.Iterator.Element,
-    extractValue: (C.Iterator.Element) -> OpaqueValue<Int>,
+    makeCollection: @escaping ([C.Iterator.Element]) -> C,
+    wrapValue: @escaping (OpaqueValue<Int>) -> C.Iterator.Element,
+    extractValue: @escaping (C.Iterator.Element) -> OpaqueValue<Int>,
 
-    makeCollectionOfEquatable: (
+    makeCollectionOfEquatable: @escaping (
       [CollectionWithEquatableElement.Iterator.Element]
     ) -> CollectionWithEquatableElement,
 
-    wrapValueIntoEquatable: (
+    wrapValueIntoEquatable: @escaping (
       MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
 
     extractValueFromEquatable:

--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
@@ -48,7 +48,7 @@ public let partitionExhaustiveTests = [
   PartitionExhaustiveTest([ 10, 20, 30, 40, 50, 60 ]),
 ]
 
-public func withInvalidOrderings(_ body: ((Int, Int) -> Bool) -> Void) {
+public func withInvalidOrderings(_ body: (@escaping (Int, Int) -> Bool) -> Void) {
   // Test some ordering predicates that don't create strict weak orderings
   body { (_,_) in true }
   body { (_,_) in false }
@@ -86,16 +86,16 @@ extension TestSuite {
     CollectionWithComparableElement : MutableCollection
   >(
     _ testNamePrefix: String = "",
-    makeCollection: ([C.Iterator.Element]) -> C,
-    wrapValue: (OpaqueValue<Int>) -> C.Iterator.Element,
-    extractValue: (C.Iterator.Element) -> OpaqueValue<Int>,
+    makeCollection: @escaping ([C.Iterator.Element]) -> C,
+    wrapValue: @escaping (OpaqueValue<Int>) -> C.Iterator.Element,
+    extractValue: @escaping (C.Iterator.Element) -> OpaqueValue<Int>,
 
-    makeCollectionOfEquatable: ([CollectionWithEquatableElement.Iterator.Element]) -> CollectionWithEquatableElement,
-    wrapValueIntoEquatable: (MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
+    makeCollectionOfEquatable: @escaping ([CollectionWithEquatableElement.Iterator.Element]) -> CollectionWithEquatableElement,
+    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
     extractValueFromEquatable: ((CollectionWithEquatableElement.Iterator.Element) -> MinimalEquatableValue),
 
-    makeCollectionOfComparable: ([CollectionWithComparableElement.Iterator.Element]) -> CollectionWithComparableElement,
-    wrapValueIntoComparable: (MinimalComparableValue) -> CollectionWithComparableElement.Iterator.Element,
+    makeCollectionOfComparable: @escaping ([CollectionWithComparableElement.Iterator.Element]) -> CollectionWithComparableElement,
+    wrapValueIntoComparable: @escaping (MinimalComparableValue) -> CollectionWithComparableElement.Iterator.Element,
     extractValueFromComparable: ((CollectionWithComparableElement.Iterator.Element) -> MinimalComparableValue),
 
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
@@ -568,7 +568,7 @@ self.test("\(testNamePrefix).sorted/${'Predicate' if predicate else 'WhereElemen
 }
 
 self.test("\(testNamePrefix).sorted/${'Predicate' if predicate else 'WhereElementIsComparable'}/InvalidOrderings") {
-  withInvalidOrderings { (comparisonPredicate) in
+  withInvalidOrderings { (comparisonPredicate: @escaping (Int, Int) -> Bool) in
     for i in 0..<7 {
       forAllPermutations(i) { (sequence) in
         checkSort_${'Predicate' if predicate else 'WhereElementIsComparable'}(
@@ -676,16 +676,16 @@ self.test("\(testNamePrefix).partition/InvalidOrderings") {
     CollectionWithComparableElement : BidirectionalCollection & MutableCollection
   >(
     _ testNamePrefix: String = "",
-    makeCollection: ([C.Iterator.Element]) -> C,
-    wrapValue: (OpaqueValue<Int>) -> C.Iterator.Element,
-    extractValue: (C.Iterator.Element) -> OpaqueValue<Int>,
+    makeCollection: @escaping ([C.Iterator.Element]) -> C,
+    wrapValue: @escaping (OpaqueValue<Int>) -> C.Iterator.Element,
+    extractValue: @escaping (C.Iterator.Element) -> OpaqueValue<Int>,
 
-    makeCollectionOfEquatable: ([CollectionWithEquatableElement.Iterator.Element]) -> CollectionWithEquatableElement,
-    wrapValueIntoEquatable: (MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
+    makeCollectionOfEquatable: @escaping ([CollectionWithEquatableElement.Iterator.Element]) -> CollectionWithEquatableElement,
+    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
     extractValueFromEquatable: ((CollectionWithEquatableElement.Iterator.Element) -> MinimalEquatableValue),
 
-    makeCollectionOfComparable: ([CollectionWithComparableElement.Iterator.Element]) -> CollectionWithComparableElement,
-    wrapValueIntoComparable: (MinimalComparableValue) -> CollectionWithComparableElement.Iterator.Element,
+    makeCollectionOfComparable: @escaping ([CollectionWithComparableElement.Iterator.Element]) -> CollectionWithComparableElement,
+    wrapValueIntoComparable: @escaping (MinimalComparableValue) -> CollectionWithComparableElement.Iterator.Element,
     extractValueFromComparable: ((CollectionWithComparableElement.Iterator.Element) -> MinimalComparableValue),
 
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
@@ -828,16 +828,16 @@ self.test("\(testNamePrefix).partition/DispatchesThrough_withUnsafeMutableBuffer
     CollectionWithComparableElement : RandomAccessCollection & MutableCollection
   >(
     _ testNamePrefix: String = "",
-    makeCollection: ([C.Iterator.Element]) -> C,
-    wrapValue: (OpaqueValue<Int>) -> C.Iterator.Element,
-    extractValue: (C.Iterator.Element) -> OpaqueValue<Int>,
+    makeCollection: @escaping ([C.Iterator.Element]) -> C,
+    wrapValue: @escaping (OpaqueValue<Int>) -> C.Iterator.Element,
+    extractValue: @escaping (C.Iterator.Element) -> OpaqueValue<Int>,
 
-    makeCollectionOfEquatable: ([CollectionWithEquatableElement.Iterator.Element]) -> CollectionWithEquatableElement,
-    wrapValueIntoEquatable: (MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
+    makeCollectionOfEquatable: @escaping ([CollectionWithEquatableElement.Iterator.Element]) -> CollectionWithEquatableElement,
+    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
     extractValueFromEquatable: ((CollectionWithEquatableElement.Iterator.Element) -> MinimalEquatableValue),
 
-    makeCollectionOfComparable: ([CollectionWithComparableElement.Iterator.Element]) -> CollectionWithComparableElement,
-    wrapValueIntoComparable: (MinimalComparableValue) -> CollectionWithComparableElement.Iterator.Element,
+    makeCollectionOfComparable: @escaping ([CollectionWithComparableElement.Iterator.Element]) -> CollectionWithComparableElement,
+    wrapValueIntoComparable: @escaping (MinimalComparableValue) -> CollectionWithComparableElement.Iterator.Element,
     extractValueFromComparable: ((CollectionWithComparableElement.Iterator.Element) -> MinimalComparableValue),
 
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
@@ -980,7 +980,7 @@ self.test("\(testNamePrefix).sort/${'Predicate' if predicate else 'WhereElementI
 }
 
 self.test("\(testNamePrefix).sort/${'Predicate' if predicate else 'WhereElementIsEquatable'}/InvalidOrderings") {
-  withInvalidOrderings { (comparisonPredicate) in
+  withInvalidOrderings { (comparisonPredicate : @escaping (Int, Int) -> Bool) in
     for i in 0..<7 {
       forAllPermutations(i) { (sequence) in
         checkSortInPlace_${'Predicate' if predicate else 'WhereElementIsComparable'}(

--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
@@ -450,12 +450,12 @@ extension TestSuite {
     CollectionWithEquatableElement : RangeReplaceableCollection
   >(
     _ testNamePrefix: String = "",
-    makeCollection: ([C.Iterator.Element]) -> C,
-    wrapValue: (OpaqueValue<Int>) -> C.Iterator.Element,
-    extractValue: (C.Iterator.Element) -> OpaqueValue<Int>,
+    makeCollection: @escaping ([C.Iterator.Element]) -> C,
+    wrapValue: @escaping (OpaqueValue<Int>) -> C.Iterator.Element,
+    extractValue: @escaping (C.Iterator.Element) -> OpaqueValue<Int>,
 
-    makeCollectionOfEquatable: ([CollectionWithEquatableElement.Iterator.Element]) -> CollectionWithEquatableElement,
-    wrapValueIntoEquatable: (MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
+    makeCollectionOfEquatable: @escaping ([CollectionWithEquatableElement.Iterator.Element]) -> CollectionWithEquatableElement,
+    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
     extractValueFromEquatable: ((CollectionWithEquatableElement.Iterator.Element) -> MinimalEquatableValue),
 
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
@@ -1161,12 +1161,12 @@ self.test("\(testNamePrefix).OperatorPlus") {
     CollectionWithEquatableElement : BidirectionalCollection & RangeReplaceableCollection
   >(
     _ testNamePrefix: String = "",
-    makeCollection: ([C.Iterator.Element]) -> C,
-    wrapValue: (OpaqueValue<Int>) -> C.Iterator.Element,
-    extractValue: (C.Iterator.Element) -> OpaqueValue<Int>,
+    makeCollection: @escaping ([C.Iterator.Element]) -> C,
+    wrapValue: @escaping (OpaqueValue<Int>) -> C.Iterator.Element,
+    extractValue: @escaping (C.Iterator.Element) -> OpaqueValue<Int>,
 
-    makeCollectionOfEquatable: ([CollectionWithEquatableElement.Iterator.Element]) -> CollectionWithEquatableElement,
-    wrapValueIntoEquatable: (MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
+    makeCollectionOfEquatable: @escaping ([CollectionWithEquatableElement.Iterator.Element]) -> CollectionWithEquatableElement,
+    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
     extractValueFromEquatable: ((CollectionWithEquatableElement.Iterator.Element) -> MinimalEquatableValue),
 
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
@@ -1289,12 +1289,12 @@ self.test("\(testNamePrefix).removeLast(n: Int)/whereIndexIsBidirectional/remove
     CollectionWithEquatableElement : RandomAccessCollection & RangeReplaceableCollection
   >(
     _ testNamePrefix: String = "",
-    makeCollection: ([C.Iterator.Element]) -> C,
-    wrapValue: (OpaqueValue<Int>) -> C.Iterator.Element,
-    extractValue: (C.Iterator.Element) -> OpaqueValue<Int>,
+    makeCollection: @escaping ([C.Iterator.Element]) -> C,
+    wrapValue: @escaping (OpaqueValue<Int>) -> C.Iterator.Element,
+    extractValue: @escaping (C.Iterator.Element) -> OpaqueValue<Int>,
 
-    makeCollectionOfEquatable: ([CollectionWithEquatableElement.Iterator.Element]) -> CollectionWithEquatableElement,
-    wrapValueIntoEquatable: (MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
+    makeCollectionOfEquatable: @escaping ([CollectionWithEquatableElement.Iterator.Element]) -> CollectionWithEquatableElement,
+    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
     extractValueFromEquatable: ((CollectionWithEquatableElement.Iterator.Element) -> MinimalEquatableValue),
 
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,

--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableSliceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableSliceType.swift
@@ -20,12 +20,12 @@ extension TestSuite {
     CollectionWithEquatableElement : RangeReplaceableCollection
   >(
     _ testNamePrefix: String = "",
-    makeCollection: ([C.Iterator.Element]) -> C,
-    wrapValue: (OpaqueValue<Int>) -> C.Iterator.Element,
-    extractValue: (C.Iterator.Element) -> OpaqueValue<Int>,
+    makeCollection: @escaping ([C.Iterator.Element]) -> C,
+    wrapValue: @escaping (OpaqueValue<Int>) -> C.Iterator.Element,
+    extractValue: @escaping (C.Iterator.Element) -> OpaqueValue<Int>,
 
-    makeCollectionOfEquatable: ([CollectionWithEquatableElement.Iterator.Element]) -> CollectionWithEquatableElement,
-    wrapValueIntoEquatable: (MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
+    makeCollectionOfEquatable: @escaping ([CollectionWithEquatableElement.Iterator.Element]) -> CollectionWithEquatableElement,
+    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
     extractValueFromEquatable: ((CollectionWithEquatableElement.Iterator.Element) -> MinimalEquatableValue),
 
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
@@ -155,12 +155,12 @@ extension TestSuite {
     CollectionWithEquatableElement : BidirectionalCollection & RangeReplaceableCollection
   >(
     _ testNamePrefix: String = "",
-    makeCollection: ([C.Iterator.Element]) -> C,
-    wrapValue: (OpaqueValue<Int>) -> C.Iterator.Element,
-    extractValue: (C.Iterator.Element) -> OpaqueValue<Int>,
+    makeCollection: @escaping ([C.Iterator.Element]) -> C,
+    wrapValue: @escaping (OpaqueValue<Int>) -> C.Iterator.Element,
+    extractValue: @escaping (C.Iterator.Element) -> OpaqueValue<Int>,
 
-    makeCollectionOfEquatable: ([CollectionWithEquatableElement.Iterator.Element]) -> CollectionWithEquatableElement,
-    wrapValueIntoEquatable: (MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
+    makeCollectionOfEquatable: @escaping ([CollectionWithEquatableElement.Iterator.Element]) -> CollectionWithEquatableElement,
+    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
     extractValueFromEquatable: ((CollectionWithEquatableElement.Iterator.Element) -> MinimalEquatableValue),
 
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
@@ -302,12 +302,12 @@ extension TestSuite {
     CollectionWithEquatableElement : RandomAccessCollection & RangeReplaceableCollection
   >(
     _ testNamePrefix: String = "",
-    makeCollection: ([C.Iterator.Element]) -> C,
-    wrapValue: (OpaqueValue<Int>) -> C.Iterator.Element,
-    extractValue: (C.Iterator.Element) -> OpaqueValue<Int>,
+    makeCollection: @escaping ([C.Iterator.Element]) -> C,
+    wrapValue: @escaping (OpaqueValue<Int>) -> C.Iterator.Element,
+    extractValue: @escaping (C.Iterator.Element) -> OpaqueValue<Int>,
 
-    makeCollectionOfEquatable: ([CollectionWithEquatableElement.Iterator.Element]) -> CollectionWithEquatableElement,
-    wrapValueIntoEquatable: (MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
+    makeCollectionOfEquatable: @escaping ([CollectionWithEquatableElement.Iterator.Element]) -> CollectionWithEquatableElement,
+    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
     extractValueFromEquatable: ((CollectionWithEquatableElement.Iterator.Element) -> MinimalEquatableValue),
 
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,

--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
@@ -97,13 +97,13 @@ public struct EnumerateTest {
 public struct FilterTest {
   public let expected: [Int]
   public let sequence: [Int]
-  public let includeElement: (Int) -> Bool
+  public let includeElement: @escaping (Int) -> Bool
   public let loc: SourceLoc
 
   public init(
     _ expected: [Int],
     _ sequence: [Int],
-    _ includeElement: (Int) -> Bool,
+    _ includeElement: @escaping (Int) -> Bool,
     file: String = #file, line: UInt = #line
   ) {
     self.expected = expected
@@ -139,13 +139,13 @@ public struct FindTest {
 public struct FlatMapTest {
   public let expected: [Int32]
   public let sequence: [Int]
-  public let transform: (Int) -> [Int32]
+  public let transform: @escaping (Int) -> [Int32]
   public let loc: SourceLoc
 
   public init(
     expected: [Int32],
     sequence: [Int],
-    transform: (Int) -> [Int32],
+    transform: @escaping (Int) -> [Int32],
     file: String = #file, line: UInt = #line
   ) {
     self.expected = expected
@@ -158,13 +158,13 @@ public struct FlatMapTest {
 public struct FlatMapToOptionalTest {
   public let expected: [Int32]
   public let sequence: [Int]
-  public let transform: (Int) -> Int32?
+  public let transform: @escaping (Int) -> Int32?
   public let loc: SourceLoc
 
   public init(
     _ expected: [Int32],
     _ sequence: [Int],
-    _ transform: (Int) -> Int32?,
+    _ transform: @escaping (Int) -> Int32?,
     file: String = #file, line: UInt = #line
   ) {
     self.expected = expected
@@ -224,13 +224,13 @@ public struct LexicographicallyPrecedesTest {
 public struct MapTest {
   public let expected: [Int32]
   public let sequence: [Int]
-  public let transform: (Int) -> Int32
+  public let transform: @escaping (Int) -> Int32
   public let loc: SourceLoc
 
   public init(
     _ expected: [Int32],
     _ sequence: [Int],
-    _ transform: (Int) -> Int32,
+    _ transform: @escaping (Int) -> Int32,
     file: String = #file, line: UInt = #line
   ) {
     self.expected = expected
@@ -1452,12 +1452,12 @@ extension TestSuite {
     SequenceWithEquatableElement : Sequence
   >(
     _ testNamePrefix: String = "",
-    makeSequence: ([S.Iterator.Element]) -> S,
-    wrapValue: (OpaqueValue<Int>) -> S.Iterator.Element,
-    extractValue: (S.Iterator.Element) -> OpaqueValue<Int>,
+    makeSequence: @escaping ([S.Iterator.Element]) -> S,
+    wrapValue: @escaping (OpaqueValue<Int>) -> S.Iterator.Element,
+    extractValue: @escaping (S.Iterator.Element) -> OpaqueValue<Int>,
 
-    makeSequenceOfEquatable: ([SequenceWithEquatableElement.Iterator.Element]) -> SequenceWithEquatableElement,
-    wrapValueIntoEquatable: (MinimalEquatableValue) -> SequenceWithEquatableElement.Iterator.Element,
+    makeSequenceOfEquatable: @escaping ([SequenceWithEquatableElement.Iterator.Element]) -> SequenceWithEquatableElement,
+    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> SequenceWithEquatableElement.Iterator.Element,
     extractValueFromEquatable: ((SequenceWithEquatableElement.Iterator.Element) -> MinimalEquatableValue),
 
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all

--- a/stdlib/private/StdlibUnittest/RaceTest.swift
+++ b/stdlib/private/StdlibUnittest/RaceTest.swift
@@ -597,7 +597,7 @@ internal struct ClosureBasedRaceTest : RaceTestWithPerTrialData {
 }
 
 public func runRaceTest(
-  trials: Int, threads: Int? = nil, invoking body: () -> ()
+  trials: Int, threads: Int? = nil, invoking body: @escaping () -> ()
 ) {
   ClosureBasedRaceTest.thread = body
   runRaceTest(ClosureBasedRaceTest.self, trials: trials, threads: threads)

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -538,7 +538,7 @@ func _defaultTestSuiteFailedCallback() {
 
 var _testSuiteFailedCallback: () -> Void = _defaultTestSuiteFailedCallback
 
-public func _setTestSuiteFailedCallback(_ callback: () -> Void) {
+public func _setTestSuiteFailedCallback(_ callback: @escaping () -> Void) {
   _testSuiteFailedCallback = callback
 }
 
@@ -549,7 +549,7 @@ func _defaultTrappingExpectationFailedCallback() {
 var _trappingExpectationFailedCallback: () -> Void
   = _defaultTrappingExpectationFailedCallback
 
-public func _setTrappingExpectationFailedCallback(callback: () -> Void) {
+public func _setTrappingExpectationFailedCallback(callback: @escaping () -> Void) {
   _trappingExpectationFailedCallback = callback
 }
 
@@ -1201,7 +1201,7 @@ public final class TestSuite {
   public func test(
     _ name: String,
     file: String = #file, line: UInt = #line,
-    _ testFunction: () -> Void
+    _ testFunction: @escaping () -> Void
   ) {
     _TestBuilder(testSuite: self, name: name, loc: SourceLoc(file, line))
     .code(testFunction)
@@ -1219,12 +1219,12 @@ public final class TestSuite {
     return _TestBuilder(testSuite: self, name: name, loc: SourceLoc(file, line))
   }
 
-  public func setUp(_ code: () -> Void) {
+  public func setUp(_ code: @escaping () -> Void) {
     _precondition(_testSetUpCode == nil, "set-up code already set")
     _testSetUpCode = code
   }
 
-  public func tearDown(_ code: () -> Void) {
+  public func tearDown(_ code: @escaping () -> Void) {
     _precondition(_testTearDownCode == nil, "tear-down code already set")
     _testTearDownCode = code
   }
@@ -1362,13 +1362,13 @@ public final class TestSuite {
       _testSuite._testNameToIndex[_name] = _testSuite._tests.count - 1
     }
 
-    public func code(_ testFunction: () -> Void) {
+    public func code(_ testFunction: @escaping () -> Void) {
       _build(.single(code: testFunction))
     }
 
     public func forEach<Data>(
       in parameterSets: [Data],
-      testFunction: (Data) -> Void
+      testFunction: @escaping (Data) -> Void
     ) {
       _build(.parameterized(
         code: { (i: Int) in testFunction(parameterSets[i]) },
@@ -2280,7 +2280,7 @@ public func expectEqualsUnordered<
   Actual : Sequence
 >(
   _ expected: Expected, _ actual: Actual, ${TRACE},
-  compare: (Expected.Iterator.Element, Expected.Iterator.Element)
+  compare: @escaping (Expected.Iterator.Element, Expected.Iterator.Element)
     -> ExpectedComparisonResult
 ) where
   Expected.Iterator.Element == Actual.Iterator.Element {
@@ -2440,7 +2440,7 @@ public func expectEqualUnicodeScalars(
   }
 }
 
-func compose<A, B, C>(_ f: (A) -> B, _ g: (B) -> C) -> (A) -> C {
+func compose<A, B, C>(_ f: @escaping (A) -> B, _ g: @escaping (B) -> C) -> (A) -> C {
   return { a in
     return g(f(a))
   }

--- a/stdlib/private/SwiftPrivatePthreadExtras/SwiftPrivatePthreadExtras.swift
+++ b/stdlib/private/SwiftPrivatePthreadExtras/SwiftPrivatePthreadExtras.swift
@@ -34,7 +34,7 @@ internal class PthreadBlockContextImpl<Argument, Result>: PthreadBlockContext {
   let block: (Argument) -> Result
   let arg: Argument
 
-  init(block: (Argument) -> Result, arg: Argument) {
+  init(block: @escaping (Argument) -> Result, arg: Argument) {
     self.block = block
     self.arg = arg
     super.init()
@@ -62,7 +62,7 @@ internal func invokeBlockContext(
 /// Block-based wrapper for `pthread_create`.
 public func _stdlib_pthread_create_block<Argument, Result>(
   _ attr: UnsafePointer<pthread_attr_t>?,
-  _ start_routine: (Argument) -> Result,
+  _ start_routine: @escaping (Argument) -> Result,
   _ arg: Argument
 ) -> (CInt, pthread_t?) {
   let context = PthreadBlockContextImpl(block: start_routine, arg: arg)

--- a/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
+++ b/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
@@ -419,7 +419,7 @@ struct ThickFunctionParts {
 
 /// Reflect a closure context. The given function must be a Swift-native
 /// @convention(thick) function value.
-public func reflect(function: () -> ()) {
+public func reflect(function: @escaping () -> ()) {
   let fn = UnsafeMutablePointer<ThickFunction0>.allocate(
     capacity: sizeof(ThickFunction0.self))
   fn.initialize(to: ThickFunction0(function: function))
@@ -434,7 +434,7 @@ public func reflect(function: () -> ()) {
 
 /// Reflect a closure context. The given function must be a Swift-native
 /// @convention(thick) function value.
-public func reflect(function: (Int) -> ()) {
+public func reflect(function: @escaping (Int) -> ()) {
   let fn =
   UnsafeMutablePointer<ThickFunction1>.allocate(
     capacity: sizeof(ThickFunction1.self))
@@ -450,7 +450,7 @@ public func reflect(function: (Int) -> ()) {
 
 /// Reflect a closure context. The given function must be a Swift-native
 /// @convention(thick) function value.
-public func reflect(function: (Int, String) -> ()) {
+public func reflect(function: @escaping (Int, String) -> ()) {
   let fn = UnsafeMutablePointer<ThickFunction2>.allocate(
       capacity: sizeof(ThickFunction2.self))
   fn.initialize(to: ThickFunction2(function: function))
@@ -465,7 +465,7 @@ public func reflect(function: (Int, String) -> ()) {
 
 /// Reflect a closure context. The given function must be a Swift-native
 /// @convention(thick) function value.
-public func reflect(function: (Int, String, AnyObject?) -> ()) {
+public func reflect(function: @escaping (Int, String, AnyObject?) -> ()) {
   let fn = UnsafeMutablePointer<ThickFunction3>.allocate(
       capacity: sizeof(ThickFunction3.self))
   fn.initialize(to: ThickFunction3(function: function))

--- a/stdlib/public/SDK/Dispatch/Block.swift
+++ b/stdlib/public/SDK/Dispatch/Block.swift
@@ -38,7 +38,7 @@ public struct DispatchWorkItemFlags : OptionSet, RawRepresentable {
 public class DispatchWorkItem {
 	internal var _block: _DispatchBlock
 
-	public init(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], block: @convention(block) () -> ()) {
+	public init(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], block: @escaping @convention(block) () -> ()) {
 		_block =  _swift_dispatch_block_create_with_qos_class(flags.rawValue,
 			qos.qosClass.rawValue.rawValue, Int32(qos.relativePriority), block)
 	}
@@ -69,7 +69,7 @@ public class DispatchWorkItem {
 		qos: DispatchQoS = .unspecified, 
 		flags: DispatchWorkItemFlags = [], 
 		queue: DispatchQueue, 
-		execute: @convention(block) () -> Void) 
+		execute: @escaping @convention(block) () -> Void) 
 	{
 		if qos != .unspecified || !flags.isEmpty {
 			let item = DispatchWorkItem(qos: qos, flags: flags, block: execute)

--- a/stdlib/public/SDK/Dispatch/Dispatch.swift
+++ b/stdlib/public/SDK/Dispatch/Dispatch.swift
@@ -129,7 +129,7 @@ public enum DispatchTimeoutResult {
 /// dispatch_group
 
 public extension DispatchGroup {
-	public func notify(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], queue: DispatchQueue, execute work: @convention(block) () -> ()) {
+	public func notify(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], queue: DispatchQueue, execute work: @escaping @convention(block) () -> ()) {
 		if #available(OSX 10.10, iOS 8.0, *), qos != .unspecified || !flags.isEmpty {
 			let item = DispatchWorkItem(qos: qos, flags: flags, block: work)
 			__dispatch_group_notify(self, queue, item._block)

--- a/stdlib/public/SDK/Dispatch/IO.swift
+++ b/stdlib/public/SDK/Dispatch/IO.swift
@@ -32,13 +32,13 @@ public extension DispatchIO {
 		public static let strictInterval = IntervalFlags(rawValue: 1)
 	}
 
-	public class func read(fromFileDescriptor: Int32, maxLength: Int, runningHandlerOn queue: DispatchQueue, handler: (data: DispatchData, error: Int32) -> Void) {
+	public class func read(fromFileDescriptor: Int32, maxLength: Int, runningHandlerOn queue: DispatchQueue, handler: @escaping (data: DispatchData, error: Int32) -> Void) {
 		__dispatch_read(fromFileDescriptor, maxLength, queue) { (data: __DispatchData, error: Int32) in
 			handler(data: DispatchData(data: data), error: error)
 		}
 	}
 
-	public class func write(toFileDescriptor: Int32, data: DispatchData, runningHandlerOn queue: DispatchQueue, handler: (data: DispatchData?, error: Int32) -> Void) {
+	public class func write(toFileDescriptor: Int32, data: DispatchData, runningHandlerOn queue: DispatchQueue, handler: @escaping (data: DispatchData?, error: Int32) -> Void) {
 		__dispatch_write(toFileDescriptor, data as __DispatchData, queue) { (data: __DispatchData?, error: Int32) in
 			handler(data: data.flatMap { DispatchData(data: $0) }, error: error)
 		}
@@ -48,7 +48,7 @@ public extension DispatchIO {
 		type: StreamType,
 		fileDescriptor: Int32,
 		queue: DispatchQueue,
-		cleanupHandler: (error: Int32) -> Void)
+		cleanupHandler: @escaping (error: Int32) -> Void)
 	{
 		self.init(__type: type.rawValue, fd: fileDescriptor, queue: queue, handler: cleanupHandler)
 	}
@@ -59,7 +59,7 @@ public extension DispatchIO {
 		oflag: Int32,
 		mode: mode_t,
 		queue: DispatchQueue,
-		cleanupHandler: (error: Int32) -> Void)
+		cleanupHandler: @escaping (error: Int32) -> Void)
 	{
 		self.init(__type: type.rawValue, path: path, oflag: oflag, mode: mode, queue: queue, handler: cleanupHandler)
 	}
@@ -68,18 +68,18 @@ public extension DispatchIO {
 		type: StreamType,
 		io: DispatchIO,
 		queue: DispatchQueue,
-		cleanupHandler: (error: Int32) -> Void)
+		cleanupHandler: @escaping (error: Int32) -> Void)
 	{
 		self.init(__type: type.rawValue, io: io, queue: queue, handler: cleanupHandler)
 	}
 
-	public func read(offset: off_t, length: Int, queue: DispatchQueue, ioHandler: (done: Bool, data: DispatchData?, error: Int32) -> Void) {
+	public func read(offset: off_t, length: Int, queue: DispatchQueue, ioHandler: @escaping (done: Bool, data: DispatchData?, error: Int32) -> Void) {
 		__dispatch_io_read(self, offset, length, queue) { (done: Bool, data: __DispatchData?, error: Int32) in
 			ioHandler(done: done, data: data.flatMap { DispatchData(data: $0) }, error: error)
 		}
 	}
 
-	public func write(offset: off_t, data: DispatchData, queue: DispatchQueue, ioHandler: (done: Bool, data: DispatchData?, error: Int32) -> Void) {
+	public func write(offset: off_t, data: DispatchData, queue: DispatchQueue, ioHandler: @escaping (done: Bool, data: DispatchData?, error: Int32) -> Void) {
 		__dispatch_io_write(self, offset, data as __DispatchData, queue) { (done: Bool, data: __DispatchData?, error: Int32) in
 			ioHandler(done: done, data: data.flatMap { DispatchData(data: $0) }, error: error)
 		}

--- a/stdlib/public/SDK/Dispatch/Queue.swift
+++ b/stdlib/public/SDK/Dispatch/Queue.swift
@@ -195,7 +195,7 @@ public extension DispatchQueue {
 		group: DispatchGroup? = nil, 
 		qos: DispatchQoS = .unspecified, 
 		flags: DispatchWorkItemFlags = [], 
-		execute work: @convention(block) () -> Void) 
+		execute work: @escaping @convention(block) () -> Void) 
 	{
 		if group == nil && qos == .unspecified && flags.isEmpty {
 			// Fast-path route for the most common API usage
@@ -283,7 +283,7 @@ public extension DispatchQueue {
 		deadline: DispatchTime, 
 		qos: DispatchQoS = .unspecified, 
 		flags: DispatchWorkItemFlags = [], 
-		execute work: @convention(block) () -> Void) 
+		execute work: @escaping @convention(block) () -> Void) 
 	{
 		if #available(OSX 10.10, iOS 8.0, *), qos != .unspecified || !flags.isEmpty {
 			let item = DispatchWorkItem(qos: qos, flags: flags, block: work)
@@ -297,7 +297,7 @@ public extension DispatchQueue {
 		wallDeadline: DispatchWallTime,
 		qos: DispatchQoS = .unspecified, 
 		flags: DispatchWorkItemFlags = [], 
-		execute work: @convention(block) () -> Void) 
+		execute work: @escaping @convention(block) () -> Void) 
 	{
 		if #available(OSX 10.10, iOS 8.0, *), qos != .unspecified || !flags.isEmpty {
 			let item = DispatchWorkItem(qos: qos, flags: flags, block: work)

--- a/stdlib/public/SDK/Foundation/Foundation.swift
+++ b/stdlib/public/SDK/Foundation/Foundation.swift
@@ -1270,7 +1270,7 @@ extension NSDictionary {
 internal func NS_Swift_NSUndoManager_registerUndoWithTargetHandler(
   _ self_: AnyObject,
   _ target: AnyObject,
-  _ handler: @convention(block) (AnyObject) -> Void)
+  _ handler: @escaping @convention(block) (AnyObject) -> Void)
 
 extension UndoManager {
   @available(*, unavailable, renamed: "registerUndo(withTarget:handler:)")
@@ -1279,7 +1279,7 @@ extension UndoManager {
   }
 
   @available(OSX 10.11, iOS 9.0, *)
-  public func registerUndo<TargetType : AnyObject>(withTarget target: TargetType, handler: (TargetType) -> Void) {
+  public func registerUndo<TargetType : AnyObject>(withTarget target: TargetType, handler: @escaping (TargetType) -> Void) {
     // The generic blocks use a different ABI, so we need to wrap the provided
     // handler in something ObjC compatible.
     let objcCompatibleHandler: (AnyObject) -> Void = { internalTarget in

--- a/stdlib/public/SDK/Foundation/NSStringAPI.swift
+++ b/stdlib/public/SDK/Foundation/NSStringAPI.swift
@@ -495,7 +495,7 @@ extension String {
 
   /// Enumerates all the lines in a string.
   public func enumerateLines(
-    invoking body: (line: String, stop: inout Bool) -> ()
+    invoking body: @escaping (line: String, stop: inout Bool) -> ()
   ) {
     _ns.enumerateLines {
       (line: String, stop: UnsafeMutablePointer<ObjCBool>)
@@ -560,7 +560,7 @@ extension String {
   public func enumerateSubstrings(
     in range: Range<Index>,
     options opts: EnumerationOptions = [],
-    _ body: (
+    _ body: @escaping (
       substring: String?, substringRange: Range<Index>,
       enclosingRange: Range<Index>, inout Bool
     ) -> ()

--- a/stdlib/public/core/Existential.swift
+++ b/stdlib/public/core/Existential.swift
@@ -20,7 +20,7 @@ internal struct _CollectionOf<
 
   internal init(
     _startIndex: IndexType, endIndex: IndexType,
-    _ subscriptImpl: (IndexType) -> Element
+    _ subscriptImpl: @escaping (IndexType) -> Element
   ) {
     self.startIndex = _startIndex
     self.endIndex = endIndex

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -69,7 +69,7 @@ public struct AnyIterator<Element> : IteratorProtocol {
   ///     var x = 7
   ///     let iterator = AnyIterator { x < 15 ? x++ : nil }
   ///     let a = Array(iterator) // [ 7, 8, 9, 10, 11, 12, 13, 14 ]
-  public init(_ body: () -> Element?) {
+  public init(_ body: @escaping () -> Element?) {
     self._box = _IteratorBox(_ClosureBasedIterator(body))
   }
 
@@ -93,7 +93,7 @@ public struct AnyIterator<Element> : IteratorProtocol {
 extension AnyIterator : Sequence {}
 
 internal struct _ClosureBasedIterator<Element> : IteratorProtocol {
-  internal init(_ body: () -> Element?) {
+  internal init(_ body: @escaping () -> Element?) {
     self._body = body
   }
   internal func next() -> Element? { return _body() }
@@ -514,7 +514,7 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
 internal struct _ClosureBasedSequence<Iterator : IteratorProtocol>
   : Sequence {
 
-  internal init(_ makeUnderlyingIterator: () -> Iterator) {
+  internal init(_ makeUnderlyingIterator: @escaping () -> Iterator) {
     self._makeUnderlyingIterator = makeUnderlyingIterator
   }
 
@@ -522,7 +522,7 @@ internal struct _ClosureBasedSequence<Iterator : IteratorProtocol>
     return _makeUnderlyingIterator()
   }
 
-  internal var _makeUnderlyingIterator: () -> Iterator
+  internal var _makeUnderlyingIterator: @escaping () -> Iterator
 }
 
 /// A type-erased sequence.
@@ -546,7 +546,7 @@ public struct AnySequence<Element> : Sequence {
   /// Creates a sequence whose `makeIterator()` method forwards to
   /// `makeUnderlyingIterator`.
   public init<I : IteratorProtocol>(
-    _ makeUnderlyingIterator: () -> I
+    _ makeUnderlyingIterator: @escaping () -> I
   ) where I.Element == Element {
     self.init(_ClosureBasedSequence(makeUnderlyingIterator))
   }

--- a/stdlib/public/core/Filter.swift.gyb
+++ b/stdlib/public/core/Filter.swift.gyb
@@ -46,7 +46,7 @@ public struct LazyFilterIterator<
   /// for which `isIncluded(x) == true`.
   internal init(
     _base: Base,
-    _ isIncluded: (Base.Element) -> Bool
+    _ isIncluded: @escaping (Base.Element) -> Bool
   ) {
     self._base = _base
     self._predicate = isIncluded
@@ -83,7 +83,7 @@ public struct LazyFilterSequence<Base : Sequence>
   public // @testable
   init(
     _base base: Base,
-    _ isIncluded: (Base.Iterator.Element) -> Bool
+    _ isIncluded: @escaping (Base.Iterator.Element) -> Bool
   ) {
     self.base = base
     self._include = isIncluded
@@ -192,7 +192,7 @@ public struct ${Self}<
   public // @testable
   init(
     _base: Base,
-    _ isIncluded: (Base.Iterator.Element) -> Bool
+    _ isIncluded: @escaping (Base.Iterator.Element) -> Bool
   ) {
     self._base = _base
     self._predicate = isIncluded
@@ -300,7 +300,7 @@ extension LazySequenceProtocol {
   ///   traversal step invokes `predicate` on one or more underlying
   ///   elements.
   public func filter(
-    _ isIncluded: (Elements.Iterator.Element) -> Bool
+    _ isIncluded: @escaping (Elements.Iterator.Element) -> Bool
   ) -> LazyFilterSequence<Self.Elements> {
     return LazyFilterSequence(
       _base: self.elements, isIncluded)
@@ -321,7 +321,7 @@ extension LazyCollectionProtocol
   ///   traversal step invokes `predicate` on one or more underlying
   ///   elements.
   public func filter(
-    _ isIncluded: (Elements.Iterator.Element) -> Bool
+    _ isIncluded: @escaping (Elements.Iterator.Element) -> Bool
   ) -> LazyFilter${collectionForTraversal(Traversal)}<Self.Elements> {
     return LazyFilter${collectionForTraversal(Traversal)}(
       _base: self.elements, isIncluded)

--- a/stdlib/public/core/FlatMap.swift
+++ b/stdlib/public/core/FlatMap.swift
@@ -18,7 +18,7 @@ extension LazySequenceProtocol {
   ///
   /// - Complexity: O(1)
   public func flatMap<SegmentOfResult : Sequence>(
-    _ transform: (Elements.Iterator.Element) -> SegmentOfResult
+    _ transform: @escaping (Elements.Iterator.Element) -> SegmentOfResult
   ) -> LazySequence<
     FlattenSequence<LazyMapSequence<Elements, SegmentOfResult>>> {
     return self.map(transform).joined()
@@ -33,7 +33,7 @@ extension LazySequenceProtocol {
   /// - Parameter transform: A closure that accepts an element of this
   /// sequence as its argument and returns an optional value.
   public func flatMap<ElementOfResult>(
-    _ transform: (Elements.Iterator.Element) -> ElementOfResult?
+    _ transform: @escaping (Elements.Iterator.Element) -> ElementOfResult?
   ) -> LazyMapSequence<
     LazyFilterSequence<
       LazyMapSequence<Elements, ElementOfResult?>>,
@@ -51,7 +51,7 @@ extension LazyCollectionProtocol {
   ///
   /// - Complexity: O(1)
   public func flatMap<SegmentOfResult : Collection>(
-    _ transform: (Elements.Iterator.Element) -> SegmentOfResult
+    _ transform: @escaping (Elements.Iterator.Element) -> SegmentOfResult
   ) -> LazyCollection<
     FlattenCollection<
       LazyMapCollection<Elements, SegmentOfResult>>
@@ -68,7 +68,7 @@ extension LazyCollectionProtocol {
   /// - Parameter transform: A closure that accepts an element of this
   /// collection as its argument and returns an optional value.
   public func flatMap<ElementOfResult>(
-    _ transform: (Elements.Iterator.Element) -> ElementOfResult?
+    _ transform: @escaping (Elements.Iterator.Element) -> ElementOfResult?
   ) -> LazyMapCollection<
     LazyFilterCollection<
       LazyMapCollection<Elements, ElementOfResult?>>,
@@ -90,7 +90,7 @@ extension LazyCollectionProtocol
   ///
   /// - Complexity: O(1)
   public func flatMap<SegmentOfResult : Collection>(
-    _ transform: (Elements.Iterator.Element) -> SegmentOfResult
+    _ transform: @escaping (Elements.Iterator.Element) -> SegmentOfResult
   ) -> LazyCollection<
     FlattenBidirectionalCollection<
       LazyMapBidirectionalCollection<Elements, SegmentOfResult>>>
@@ -107,7 +107,7 @@ extension LazyCollectionProtocol
   /// - Parameter transform: A closure that accepts an element of this
   /// collection as its argument and returns an optional value.
   public func flatMap<ElementOfResult>(
-    _ transform: (Elements.Iterator.Element) -> ElementOfResult?
+    _ transform: @escaping (Elements.Iterator.Element) -> ElementOfResult?
   ) -> LazyMapBidirectionalCollection<
     LazyFilterBidirectionalCollection<
       LazyMapBidirectionalCollection<Elements, ElementOfResult?>>,

--- a/stdlib/public/core/Map.swift.gyb
+++ b/stdlib/public/core/Map.swift.gyb
@@ -67,7 +67,7 @@ public struct LazyMapSequence<Base : Sequence, Element>
 
   /// Create an instance with elements `transform(x)` for each element
   /// `x` of base.
-  internal init(_base: Base, transform: (Base.Iterator.Element) -> Element) {
+  internal init(_base: Base, transform: @escaping (Base.Iterator.Element) -> Element) {
     self._base = _base
     self._transform = transform
   }
@@ -188,7 +188,7 @@ public struct ${Self}<
 
   /// Create an instance with elements `transform(x)` for each element
   /// `x` of base.
-  internal init(_base: Base, transform: (Base.Iterator.Element) -> Element) {
+  internal init(_base: Base, transform: @escaping (Base.Iterator.Element) -> Element) {
     self._base = _base
     self._transform = transform
   }
@@ -206,7 +206,7 @@ extension LazySequenceProtocol {
   /// the result are computed lazily, each time they are read, by
   /// calling `transform` function on a base element.
   public func map<U>(
-    _ transform: (Elements.Iterator.Element) -> U
+    _ transform: @escaping (Elements.Iterator.Element) -> U
   ) -> LazyMapSequence<Self.Elements, U> {
     return LazyMapSequence(_base: self.elements, transform: transform)
   }
@@ -223,7 +223,7 @@ extension LazyCollectionProtocol
   /// the result are computed lazily, each time they are read, by
   /// calling `transform` function on a base element.
   public func map<U>(
-    _ transform: (Elements.Iterator.Element) -> U
+    _ transform: @escaping (Elements.Iterator.Element) -> U
   ) -> LazyMap${collectionForTraversal(Traversal)}<Self.Elements, U> {
     return LazyMap${collectionForTraversal(Traversal)}(
       _base: self.elements,

--- a/stdlib/public/core/Sort.swift.gyb
+++ b/stdlib/public/core/Sort.swift.gyb
@@ -131,7 +131,7 @@ public // @testable
 func _introSort<C>(
   _ elements: inout C,
   subRange range: Range<C.Index>
-  ${", by areInIncreasingOrder: (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
+  ${", by areInIncreasingOrder: @escaping (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
 ) where
   C : MutableCollection & RandomAccessCollection
   ${"" if p else ", C.Iterator.Element : Comparable"} {

--- a/stdlib/public/core/UnfoldSequence.swift
+++ b/stdlib/public/core/UnfoldSequence.swift
@@ -40,7 +40,7 @@
 ///   value returned by passing the previous element to `next`.
 ///
 /// - SeeAlso: `sequence(state:next:)`
-public func sequence<T>(first: T, next: (T) -> T?) -> UnfoldFirstSequence<T> {
+public func sequence<T>(first: T, next: @escaping (T) -> T?) -> UnfoldFirstSequence<T> {
   // The trivial implementation where the state is the next value to return
   // has the downside of being unnecessarily eager (it evaluates `next` one
   // step in advance). We solve this by using a boolean value to disambiguate
@@ -86,7 +86,7 @@ public func sequence<T>(first: T, next: (T) -> T?) -> UnfoldFirstSequence<T> {
 /// - Returns: A sequence that yields each successive value from `next`.
 ///
 /// - SeeAlso: `sequence(first:next:)`
-public func sequence<T, State>(state: State, next: (inout State) -> T?)
+public func sequence<T, State>(state: State, next: @escaping (inout State) -> T?)
   -> UnfoldSequence<T, State> {
   return UnfoldSequence(_state: state, _next: next)
 }
@@ -115,7 +115,7 @@ public struct UnfoldSequence<Element, State> : Sequence, IteratorProtocol {
     }
   }
 
-  internal init(_state: State, _next: (inout State) -> Element?) {
+  internal init(_state: State, _next: @escaping (inout State) -> Element?) {
     self._state = _state
     self._next = _next
   }

--- a/test/1_stdlib/Inputs/DictionaryKeyValueTypesObjC.swift
+++ b/test/1_stdlib/Inputs/DictionaryKeyValueTypesObjC.swift
@@ -632,7 +632,7 @@ typealias AnyObjectTuple2 = (AnyObject, AnyObject)
   _ a: NSArray,
   _ makeEnumerator: () -> NSFastEnumeration,
   _ useEnumerator: (NSArray, NSFastEnumeration, (AnyObject) -> ()) -> Void,
-  _ convertValue: (AnyObject) -> Int
+  _ convertValue: @escaping (AnyObject) -> Int
 ) {
   let expectedContentsWithoutIdentity =
   _makeExpectedArrayContents(expected)
@@ -667,7 +667,7 @@ typealias AnyObjectTuple2 = (AnyObject, AnyObject)
  func checkArrayFastEnumerationFromSwift(
   _ expected: [Int],
   _ a: NSArray, _ makeEnumerator: () -> NSFastEnumeration,
-  _ convertValue: (AnyObject) -> Int
+  _ convertValue: @escaping (AnyObject) -> Int
 ) {
   _checkArrayFastEnumerationImpl(
     expected, a, makeEnumerator,
@@ -680,7 +680,7 @@ typealias AnyObjectTuple2 = (AnyObject, AnyObject)
  func checkArrayFastEnumerationFromObjC(
   _ expected: [Int],
   _ a: NSArray, _ makeEnumerator: () -> NSFastEnumeration,
-  _ convertValue: (AnyObject) -> Int
+  _ convertValue: @escaping (AnyObject) -> Int
 ) {
   _checkArrayFastEnumerationImpl(
     expected, a, makeEnumerator,
@@ -694,7 +694,7 @@ typealias AnyObjectTuple2 = (AnyObject, AnyObject)
   _ expected: [Int],
   _ a: NSArray,
   maxFastEnumerationItems: Int,
-  _ convertValue: (AnyObject) -> Int
+  _ convertValue: @escaping (AnyObject) -> Int
 ) {
   _checkArrayFastEnumerationImpl(
     expected, a, { a.objectEnumerator() },
@@ -711,7 +711,7 @@ typealias AnyObjectTuple2 = (AnyObject, AnyObject)
   _ s: NSSet,
   _ makeEnumerator: () -> NSFastEnumeration,
   _ useEnumerator: (NSSet, NSFastEnumeration, (AnyObject) -> ()) -> Void,
-  _ convertMember: (AnyObject) -> Int
+  _ convertMember: @escaping (AnyObject) -> Int
 ) {
   let expectedContentsWithoutIdentity =
     _makeExpectedSetContents(expected)
@@ -805,7 +805,7 @@ typealias AnyObjectTuple2 = (AnyObject, AnyObject)
  func checkSetFastEnumerationFromSwift(
   _ expected: [Int],
   _ s: NSSet, _ makeEnumerator: () -> NSFastEnumeration,
-  _ convertMember: (AnyObject) -> Int
+  _ convertMember: @escaping (AnyObject) -> Int
 ) {
   _checkSetFastEnumerationImpl(
     expected, s, makeEnumerator,
@@ -818,7 +818,7 @@ typealias AnyObjectTuple2 = (AnyObject, AnyObject)
  func checkSetFastEnumerationFromObjC(
   _ expected: [Int],
   _ s: NSSet, _ makeEnumerator: () -> NSFastEnumeration,
-  _ convertMember: (AnyObject) -> Int
+  _ convertMember: @escaping (AnyObject) -> Int
 ) {
   _checkSetFastEnumerationImpl(
     expected, s, makeEnumerator,
@@ -832,7 +832,7 @@ typealias AnyObjectTuple2 = (AnyObject, AnyObject)
   _ expected: [Int],
   _ s: NSSet,
   maxFastEnumerationItems: Int,
-  _ convertMember: (AnyObject) -> Int
+  _ convertMember: @escaping (AnyObject) -> Int
 ) {
   _checkSetFastEnumerationImpl(
     expected, s, { s.objectEnumerator() },
@@ -862,8 +862,8 @@ typealias AnyObjectTuple2 = (AnyObject, AnyObject)
   _ d: NSDictionary,
   _ makeEnumerator: () -> NSFastEnumeration,
   _ useEnumerator: (NSDictionary, NSFastEnumeration, (AnyObjectTuple2) -> ()) -> Void,
-  _ convertKey: (AnyObject) -> Int,
-  _ convertValue: (AnyObject) -> Int
+  _ convertKey: @escaping (AnyObject) -> Int,
+  _ convertValue: @escaping (AnyObject) -> Int
 ) {
   let expectedContentsWithoutIdentity =
     _makeExpectedDictionaryContents(expected)
@@ -898,8 +898,8 @@ typealias AnyObjectTuple2 = (AnyObject, AnyObject)
  func checkDictionaryFastEnumerationFromSwift(
   _ expected: [(Int, Int)],
   _ d: NSDictionary, _ makeEnumerator: () -> NSFastEnumeration,
-  _ convertKey: (AnyObject) -> Int,
-  _ convertValue: (AnyObject) -> Int
+  _ convertKey: @escaping (AnyObject) -> Int,
+  _ convertValue: @escaping (AnyObject) -> Int
 ) {
   _checkDictionaryFastEnumerationImpl(
     expected, d, makeEnumerator,
@@ -912,8 +912,8 @@ typealias AnyObjectTuple2 = (AnyObject, AnyObject)
  func checkDictionaryFastEnumerationFromObjC(
   _ expected: [(Int, Int)],
   _ d: NSDictionary, _ makeEnumerator: () -> NSFastEnumeration,
-  _ convertKey: (AnyObject) -> Int,
-  _ convertValue: (AnyObject) -> Int
+  _ convertKey: @escaping (AnyObject) -> Int,
+  _ convertValue: @escaping (AnyObject) -> Int
 ) {
   _checkDictionaryFastEnumerationImpl(
     expected, d, makeEnumerator,
@@ -927,8 +927,8 @@ typealias AnyObjectTuple2 = (AnyObject, AnyObject)
   _ expected: [(Int, Int)],
   _ d: NSDictionary,
   maxFastEnumerationItems: Int,
-  _ convertKey: (AnyObject) -> Int,
-  _ convertValue: (AnyObject) -> Int
+  _ convertKey: @escaping (AnyObject) -> Int,
+  _ convertValue: @escaping (AnyObject) -> Int
 ) {
   _checkDictionaryFastEnumerationImpl(
     expected, d, { d.keyEnumerator() },

--- a/test/ClangModules/Dispatch_test.swift
+++ b/test/ClangModules/Dispatch_test.swift
@@ -21,7 +21,7 @@ extension dispatch_queue_t {} // expected-error {{'dispatch_queue_t' is unavaila
 
 // Make sure you can extend a dispatch type via its common name.
 extension DispatchQueue {
-  func myAsync(_ block: () -> Void) {
+  func myAsync(_ block: @escaping () -> Void) {
     async(execute: block)
   }
 }

--- a/test/ClangModules/blocks_parse.swift
+++ b/test/ClangModules/blocks_parse.swift
@@ -23,7 +23,7 @@ func testNoEscape(f: @noescape @convention(block) () -> Void, nsStr: NSString,
   // rdar://problem/19818617
   nsStr.enumerateLines(fStr) // okay due to @noescape
 
-  _ = nsStr.enumerateLines as Int // expected-error{{cannot convert value of type '(@noescape (String) -> Void) -> Void' to type 'Int' in coercion}}
+  _ = nsStr.enumerateLines as Int // expected-error{{cannot convert value of type '((String) -> Void) -> Void' to type 'Int' in coercion}}
 }
 
 func checkTypeImpl<T>(_ a: inout T, _: T.Type) {}

--- a/test/Constraints/array_literal.swift
+++ b/test/Constraints/array_literal.swift
@@ -102,7 +102,7 @@ func longArray() {
   var _=["1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1"]
 }
 
-[1,2].map // expected-error {{expression type '(@noescape (Int) throws -> _) throws -> [_]' is ambiguous without more context}}
+[1,2].map // expected-error {{expression type '((Int) throws -> _) throws -> [_]' is ambiguous without more context}}
 
 
 // <rdar://problem/25563498> Type checker crash assigning array literal to type conforming to _ArrayProtocol

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -176,7 +176,8 @@ func typeCheckMultiStmtClosureCrash() {
 }
 
 // SR-832 - both these should be ok
-func someFunc(_ foo: ((String) -> String)?, bar: (String) -> String) {
+func someFunc(_ foo: (@escaping (String) -> String)?, 
+              bar: @escaping (String) -> String) {
     let _: (String) -> String = foo != nil ? foo! : bar
     let _: (String) -> String = foo ?? bar
 }

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -200,8 +200,8 @@ struct S<T> {
 // Make sure we cannot infer an () argument from an empty parameter list.
 func acceptNothingToInt (_: @noescape () -> Int) {}
 func testAcceptNothingToInt(ac1: @autoclosure () -> Int) {
-  // expected-note@-1{{parameter 'ac1' is implicitly @noescape because it was declared @autoclosure}}
+  // expected-note@-1{{parameter 'ac1' is implicitly non-escaping because it was declared @autoclosure}}
   acceptNothingToInt({ac1($0)})
   // expected-error@-1{{cannot convert value of type '(_) -> Int' to expected argument type '() -> Int'}}
-  // FIXME: expected-error@-2{{closure use of @noescape parameter 'ac1' may allow it to escape}}
+  // FIXME: expected-error@-2{{closure use of non-escaping parameter 'ac1' may allow it to escape}}
 }

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -19,11 +19,11 @@ extension Double : P {
 func f0(_ x: Int, 
         _ y: Float) { }
 
-func f1(_: (Int, Float) -> Int) { }
+func f1(_: @escaping (Int, Float) -> Int) { }
 
-func f2(_: (_: (Int) -> Int)) -> Int {}
+func f2(_: (_: @escaping (Int) -> Int)) -> Int {}
 
-func f3(_: (_: (Int) -> Float) -> Int) {}
+func f3(_: @escaping (_: @escaping (Int) -> Float) -> Int) {}
 
 func f4(_ x: Int) -> Int { }
 
@@ -60,7 +60,7 @@ f1(
    )
 
 f3(
-   f2 // expected-error {{cannot convert value of type '(((Int) -> Int)) -> Int' to expected argument type '((Int) -> Float) -> Int'}}
+   f2 // expected-error {{cannot convert value of type '((@escaping (Int) -> Int)) -> Int' to expected argument type '(@escaping (Int) -> Float) -> Int'}}
    )
 
 f4(i, d) // expected-error {{extra argument in call}}
@@ -93,7 +93,7 @@ func f7() -> (c: Int, v: A) {
   return f6(g) // expected-error {{cannot convert return expression of type '(c: Int, i: A)' to return type '(c: Int, v: A)'}}
 }
 
-func f8<T:P2>(_ n: T, _ f: (T) -> T) {}
+func f8<T:P2>(_ n: T, _ f: @escaping (T) -> T) {}
 f8(3, f4) // expected-error {{in argument type '(Int) -> Int', 'Int' does not conform to expected type 'P2'}}
 typealias Tup = (Int, Double)
 func f9(_ x: Tup) -> Tup { return x }

--- a/test/Constraints/fixes.swift
+++ b/test/Constraints/fixes.swift
@@ -17,7 +17,7 @@ func f6(_ a: A, _: Int) { }
 func createB() -> B { }  // expected-note {{found this candidate}}
 func createB(_ i: Int) -> B { } // expected-note {{found this candidate}}
 
-func f7(_ a: A, _: () -> Int) -> B { }
+func f7(_ a: A, _: @escaping () -> Int) -> B { }
 func f7(_ a: A, _: Int) -> Int { }
 
 // Forgot the '()' to call a function.

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -178,7 +178,7 @@ func r22459135() {
     g(h([3]))
   }
 
-  func f2<TargetType: AnyObject>(_ target: TargetType, handler: (TargetType) -> ()) {
+  func f2<TargetType: AnyObject>(_ target: TargetType, handler: @escaping (TargetType) -> ()) {
     let _: (AnyObject) -> () = { internalTarget in
       handler(internalTarget as! TargetType)
     }

--- a/test/Constraints/tuple.swift
+++ b/test/Constraints/tuple.swift
@@ -72,7 +72,7 @@ extension Int : PosixErrorReturn {
 }
 
 func posixCantFail<A, T : Comparable & PosixErrorReturn>
-  (_ f:(A) -> T) -> (args:A) -> T
+  (_ f: @escaping (A) -> T) -> (args:A) -> T
 {
   return { args in
     let result = f(args)

--- a/test/DebugInfo/linetable.swift
+++ b/test/DebugInfo/linetable.swift
@@ -16,7 +16,7 @@ class MyClass
     }
 }
 
-func call_me(_ code: () -> Void)
+func call_me(_ code: @escaping () -> Void)
 {
     code ()
 }

--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -115,7 +115,7 @@ func ftest1() {
   let myvar = 0
 }
 
-func ftest2(x x: Int -> Int) {}
+func ftest2(x x: @escaping Int -> Int) {}
 
 protocol SomeProt {
   func protMeth(p: Int)

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -118,7 +118,7 @@ func ftest1() {
   let myvar = 0
 }
 
-func ftest2(x: (Int) -> Int) {}
+func ftest2(x: @escaping (Int) -> Int) {}
 
 protocol SomeProt {
   func protMeth(p: Int)

--- a/test/Generics/same_type_constraints.swift
+++ b/test/Generics/same_type_constraints.swift
@@ -48,7 +48,7 @@ struct SatisfySameTypeAssocTypeRequirementDependent<T>
 public struct GeneratorOf<T> : IteratorProtocol, Sequence {
 
   /// Construct an instance whose `next()` method calls `nextElement`.
-  public init(_ nextElement: () -> T?) {
+  public init(_ nextElement: @escaping () -> T?) {
     self._next = nextElement
   }
   
@@ -85,7 +85,7 @@ public struct LazySequenceOf<S : Sequence, A> : Sequence where S.Iterator.Elemen
   public subscript(i : A) -> A { return i }
 }
 
-public func iterate<A>(_ f : (A) -> A) -> (x : A) -> LazySequenceOf<Iterate<A>, A>? {
+public func iterate<A>(_ f : @escaping (A) -> A) -> (x : A) -> LazySequenceOf<Iterate<A>, A>? {
   return { x in nil }
 }
 
@@ -105,7 +105,7 @@ public final class IterateGenerator<A> : IteratorProtocol {
 // rdar://problem/18475138
 public protocol Observable : class {
     associatedtype Output
-    func addObserver(_ obj : (Output) -> Void)
+    func addObserver(_ obj : @escaping (Output) -> Void)
 }
 
 public protocol Bindable : class {
@@ -124,7 +124,7 @@ infix operator <- : AssignmentPrecedence
 
 func <- <
     Right : Observable
-    >(lhs:(Right.Output) -> Void, rhs: Right) -> Composed<SideEffect<Right>, Right>?
+    >(lhs: @escaping (Right.Output) -> Void, rhs: Right) -> Composed<SideEffect<Right>, Right>?
 {
   return nil
 }

--- a/test/IDE/Inputs/mock-sdk/Foo.annotated.txt
+++ b/test/IDE/Inputs/mock-sdk/Foo.annotated.txt
@@ -73,8 +73,8 @@ var <loc>fooIntVar</loc>: <ref:Struct>Int32</ref></decl>
 func <loc>fooFunc1(<decl:Param>_ a: <ref:Struct>Int32</ref></decl>)</loc> -> <ref:Struct>Int32</ref></decl>
 <decl:Func>func <loc>fooFunc1AnonymousParam(<decl:Param>_: <ref:Struct>Int32</ref></decl>)</loc> -> <ref:Struct>Int32</ref></decl>
 <decl:Func>func <loc>fooFunc3(<decl:Param>_ a: <ref:Struct>Int32</ref></decl>, <decl:Param>_ b: <ref:Struct>Float</ref></decl>, <decl:Param>_ c: <ref:Struct>Double</ref></decl>, <decl:Param>_ d: <ref:Struct>UnsafeMutablePointer</ref><<ref:Struct>Int32</ref>>!</decl>)</loc> -> <ref:Struct>Int32</ref></decl>
-<decl:Func>func <loc>fooFuncWithBlock(<decl:Param>_ blk: ((<ref:Struct>Float</ref>) -> <ref:Struct>Int32</ref>)!</decl>)</loc></decl>
-<decl:Func>func <loc>fooFuncWithFunctionPointer(<decl:Param>_ fptr: (@convention(c) (<ref:Struct>Float</ref>) -> <ref:Struct>Int32</ref>)!</decl>)</loc></decl>
+<decl:Func>func <loc>fooFuncWithBlock(<decl:Param>_ blk: (@escaping (<ref:Struct>Float</ref>) -> <ref:Struct>Int32</ref>)!</decl>)</loc></decl>
+<decl:Func>func <loc>fooFuncWithFunctionPointer(<decl:Param>_ fptr: (@escaping @convention(c) (<ref:Struct>Float</ref>) -> <ref:Struct>Int32</ref>)!</decl>)</loc></decl>
 <decl:Func>func <loc>fooFuncNoreturn1()</loc> -> <ref:Enum>Never</ref></decl>
 <decl:Func>func <loc>fooFuncNoreturn2()</loc> -> <ref:Enum>Never</ref></decl>
 

--- a/test/IDE/Inputs/mock-sdk/Foo.printed.recursive.txt
+++ b/test/IDE/Inputs/mock-sdk/Foo.printed.recursive.txt
@@ -73,8 +73,8 @@ var fooIntVar: Int32
 func fooFunc1(_ a: Int32) -> Int32
 func fooFunc1AnonymousParam(_: Int32) -> Int32
 func fooFunc3(_ a: Int32, _ b: Float, _ c: Double, _ d: UnsafeMutablePointer<Int32>!) -> Int32
-func fooFuncWithBlock(_ blk: ((Float) -> Int32)!)
-func fooFuncWithFunctionPointer(_ fptr: (@convention(c) (Float) -> Int32)!)
+func fooFuncWithBlock(_ blk: (@escaping (Float) -> Int32)!)
+func fooFuncWithFunctionPointer(_ fptr: (@escaping @convention(c) (Float) -> Int32)!)
 func fooFuncNoreturn1() -> Never
 func fooFuncNoreturn2() -> Never
 

--- a/test/IDE/Inputs/mock-sdk/Foo.printed.txt
+++ b/test/IDE/Inputs/mock-sdk/Foo.printed.txt
@@ -95,9 +95,9 @@ func fooFunc3(_ a: Int32, _ b: Float, _ c: Double, _ d: UnsafeMutablePointer<Int
   Very good
   fooFuncWithBlock function.
 */
-func fooFuncWithBlock(_ blk: ((Float) -> Int32)!)
+func fooFuncWithBlock(_ blk: (@escaping (Float) -> Int32)!)
 
-func fooFuncWithFunctionPointer(_ fptr: (@convention(c) (Float) -> Int32)!)
+func fooFuncWithFunctionPointer(_ fptr: (@escaping @convention(c) (Float) -> Int32)!)
 
 func fooFuncNoreturn1() -> Never
 func fooFuncNoreturn2() -> Never

--- a/test/IDE/complete_override.swift
+++ b/test/IDE/complete_override.swift
@@ -463,7 +463,7 @@ class TestClassWithThrows : HasThrowing, HasThrowingProtocol {
 // HAS_THROWING: Begin completions
 // HAS_THROWING-DAG: Decl[InstanceMethod]/Super:         func foo() throws {|}; name=foo() throws
 // HAS_THROWING-DAG: Decl[InstanceMethod]/Super:         override func bar() throws {|}; name=bar() throws
-// FIXME: make the below require to print @escaping
+// FIXME: SR-2214 make the below require printing @escaping 
 // HAS_THROWING-DAG: Decl[InstanceMethod]/Super:         override func baz(x: {{(@escaping )?}}() throws -> ()) rethrows {|}; name=baz(x: {{(@escaping )?}}() throws -> ()) rethrows
 // HAS_THROWING-DAG: Decl[Constructor]/Super:            init() throws {|}; name=init() throws
 // HAS_THROWING: End completions

--- a/test/IDE/complete_override.swift
+++ b/test/IDE/complete_override.swift
@@ -454,7 +454,7 @@ protocol HasThrowingProtocol {
 
 class HasThrowing {
   func bar() throws {}
-  func baz(x: () throws -> ()) rethrows {}
+  func baz(x: @escaping () throws -> ()) rethrows {}
   init() throws {}
 }
 class TestClassWithThrows : HasThrowing, HasThrowingProtocol {
@@ -463,7 +463,8 @@ class TestClassWithThrows : HasThrowing, HasThrowingProtocol {
 // HAS_THROWING: Begin completions
 // HAS_THROWING-DAG: Decl[InstanceMethod]/Super:         func foo() throws {|}; name=foo() throws
 // HAS_THROWING-DAG: Decl[InstanceMethod]/Super:         override func bar() throws {|}; name=bar() throws
-// HAS_THROWING-DAG: Decl[InstanceMethod]/Super:         override func baz(x: () throws -> ()) rethrows {|}; name=baz(x: () throws -> ()) rethrows
+// FIXME: make the below require to print @escaping
+// HAS_THROWING-DAG: Decl[InstanceMethod]/Super:         override func baz(x: {{(@escaping )?}}() throws -> ()) rethrows {|}; name=baz(x: {{(@escaping )?}}() throws -> ()) rethrows
 // HAS_THROWING-DAG: Decl[Constructor]/Super:            init() throws {|}; name=init() throws
 // HAS_THROWING: End completions
 

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -1298,8 +1298,8 @@ public func ParamAttrs2(a : @autoclosure(escaping) () -> ()) {
   a()
 }
 
-// PASS_PRINT_AST: public func ParamAttrs3(a: @noescape () -> ())
-public func ParamAttrs3(a : @noescape () -> ()) {
+// PASS_PRINT_AST: public func ParamAttrs3(a: () -> ())
+public func ParamAttrs3(a : () -> ()) {
   a()
 }
 

--- a/test/IDE/print_clang_bool_bridging.swift
+++ b/test/IDE/print_clang_bool_bridging.swift
@@ -34,9 +34,9 @@ typealias CBoolBlock = (Bool) -> Bool
 typealias ObjCBoolBlock = (Bool) -> Bool
 typealias DarwinBooleanBlock = (Bool) -> Bool
 
-func testCBoolFnToBlock(_: @convention(c) (Bool) -> Bool) -> (Bool) -> Bool
-func testObjCBoolFnToBlock(_: @convention(c) (ObjCBool) -> ObjCBool) -> (Bool) -> Bool
-func testDarwinBooleanFnToBlock(_: @convention(c) (DarwinBoolean) -> DarwinBoolean) -> (Bool) -> Bool
+func testCBoolFnToBlock(_: @escaping @convention(c) (Bool) -> Bool) -> (Bool) -> Bool
+func testObjCBoolFnToBlock(_: @escaping @convention(c) (ObjCBool) -> ObjCBool) -> (Bool) -> Bool
+func testDarwinBooleanFnToBlock(_: @escaping @convention(c) (DarwinBoolean) -> DarwinBoolean) -> (Bool) -> Bool
 
 func testCBoolFnToBlockTypedef(_: CBoolFn) -> CBoolBlock
 func testObjCBoolFnToBlockTypedef(_: ObjCBoolFn) -> ObjCBoolBlock
@@ -67,13 +67,13 @@ class Test : NSObject {
   var propObjCBoolBlock: (Bool) -> Bool
   var propDarwinBooleanBlock: (Bool) -> Bool
   
-  func testCBoolFn(toBlock fp: @convention(c) (Bool) -> Bool) -> (Bool) -> Bool
-  func testObjCBoolFn(toBlock fp: @convention(c) (ObjCBool) -> ObjCBool) -> (Bool) -> Bool
-  func testDarwinBooleanFn(toBlock fp: @convention(c) (DarwinBoolean) -> DarwinBoolean) -> (Bool) -> Bool
+  func testCBoolFn(toBlock fp: @escaping @convention(c) (Bool) -> Bool) -> (Bool) -> Bool
+  func testObjCBoolFn(toBlock fp: @escaping @convention(c) (ObjCBool) -> ObjCBool) -> (Bool) -> Bool
+  func testDarwinBooleanFn(toBlock fp: @escaping @convention(c) (DarwinBoolean) -> DarwinBoolean) -> (Bool) -> Bool
   
-  func produceCBoolBlockTypedef(_ outBlock: AutoreleasingUnsafeMutablePointer<(@convention(block) (Bool) -> Bool)?>)
-  func produceObjCBoolBlockTypedef(_ outBlock: AutoreleasingUnsafeMutablePointer<(@convention(block) (ObjCBool) -> ObjCBool)?>)
-  func produceDarwinBooleanBlockTypedef(_ outBlock: AutoreleasingUnsafeMutablePointer<(@convention(block) (DarwinBoolean) -> DarwinBoolean)?>)
+  func produceCBoolBlockTypedef(_ outBlock: AutoreleasingUnsafeMutablePointer<(@escaping @convention(block) (Bool) -> Bool)?>)
+  func produceObjCBoolBlockTypedef(_ outBlock: AutoreleasingUnsafeMutablePointer<(@escaping @convention(block) (ObjCBool) -> ObjCBool)?>)
+  func produceDarwinBooleanBlockTypedef(_ outBlock: AutoreleasingUnsafeMutablePointer<(@escaping @convention(block) (DarwinBoolean) -> DarwinBoolean)?>)
   
   init()
 }

--- a/test/IDE/print_clang_decls.swift
+++ b/test/IDE/print_clang_decls.swift
@@ -120,8 +120,8 @@
 // CHECK-NULLABILITY: class SomeClass {
 // CHECK-NULLABILITY:   class func methodA(_ obj: SomeClass?) -> Any{{$}}
 // CHECK-NULLABILITY:   func methodA(_ obj: SomeClass?) -> Any{{$}}
-// CHECK-NULLABILITY:   class func methodB(_ block: ((Int32, Int32) -> Int32)? = nil) -> Any{{$}}
-// CHECK-NULLABILITY:   func methodB(_ block: ((Int32, Int32) -> Int32)? = nil) -> Any{{$}}
+// CHECK-NULLABILITY:   class func methodB(_ block: (@escaping (Int32, Int32) -> Int32)? = nil) -> Any{{$}}
+// CHECK-NULLABILITY:   func methodB(_ block: (@escaping (Int32, Int32) -> Int32)? = nil) -> Any{{$}}
 // CHECK-NULLABILITY:   func methodC() -> Any?
 // CHECK-NULLABILITY:   var property: Any?
 // CHECK-NULLABILITY:   func stringMethod() -> String{{$}}

--- a/test/IDE/print_clang_swift_name.swift
+++ b/test/IDE/print_clang_swift_name.swift
@@ -51,22 +51,22 @@ class TestError : NSObject {
   convenience init(aa x: Any?, error: ()) throws
   @available(*, unavailable, message: "use object construction 'TestError(aa:error:)'")
   class func err2(_ x: Any?) throws -> Self
-  convenience init(aa x: Any?, error: (), block: () -> Void) throws
+  convenience init(aa x: Any?, error: (), block: @escaping () -> Void) throws
   @available(*, unavailable, message: "use object construction 'TestError(aa:error:block:)'")
-  class func err3(_ x: Any?, callback block: () -> Void) throws -> Self
-  convenience init(error: (), block: () -> Void) throws
+  class func err3(_ x: Any?, callback block: @escaping () -> Void) throws -> Self
+  convenience init(error: (), block: @escaping () -> Void) throws
   @available(*, unavailable, message: "use object construction 'TestError(error:block:)'")
-  class func err4(callback block: () -> Void) throws -> Self
+  class func err4(callback block: @escaping () -> Void) throws -> Self
   
   convenience init(aa x: Any?) throws
   @available(*, unavailable, message: "use object construction 'TestError(aa:)'")
   class func err5(_ x: Any?) throws -> Self
-  convenience init(aa x: Any?, block: () -> Void) throws
+  convenience init(aa x: Any?, block: @escaping () -> Void) throws
   @available(*, unavailable, message: "use object construction 'TestError(aa:block:)'")
-  class func err6(_ x: Any?, callback block: () -> Void) throws -> Self
-  convenience init(block: () -> Void) throws
+  class func err6(_ x: Any?, callback block: @escaping () -> Void) throws -> Self
+  convenience init(block: @escaping () -> Void) throws
   @available(*, unavailable, message: "use object construction 'TestError(block:)'")
-  class func err7(callback block: () -> Void) throws -> Self
+  class func err7(callback block: @escaping () -> Void) throws -> Self
   
   // Would-be initializers.
   class func ww(_ x: Any?) throws -> Self
@@ -89,10 +89,10 @@ class TestSub : Test {
 class TestErrorSub : TestError {
   convenience init(error: ()) throws
   convenience init(aa x: Any?, error: ()) throws
-  convenience init(aa x: Any?, error: (), block: () -> Void) throws
-  convenience init(error: (), block: () -> Void) throws
+  convenience init(aa x: Any?, error: (), block: @escaping () -> Void) throws
+  convenience init(error: (), block: @escaping () -> Void) throws
   convenience init(aa x: Any?) throws
-  convenience init(aa x: Any?, block: () -> Void) throws
-  convenience init(block: () -> Void) throws
+  convenience init(aa x: Any?, block: @escaping () -> Void) throws
+  convenience init(block: @escaping () -> Void) throws
   init()
 }

--- a/test/IDE/print_module_without_deinit.swift
+++ b/test/IDE/print_module_without_deinit.swift
@@ -40,6 +40,8 @@ public class ImplicitOptionalInitContainer {
 public class AttributeContainer1 {
   // ATTR1: func m1(a: @autoclosure () -> Int)
   public func m1(a : @autoclosure () -> Int) {}
-  // ATTR1: func m2(a: @noescape () -> Int)
-  public func m2(a : @noescape () -> Int) {}
+  // ATTR1: func m2(a: () -> Int)
+  public func m2(a : @noescape () -> Int) {} // TODO: drop @noescape
+  // ATTR1: func m3(a: @escaping () -> Int)
+  public func m3(a : @escaping () -> Int) {}
 }

--- a/test/IDE/print_omit_needless_words.swift
+++ b/test/IDE/print_omit_needless_words.swift
@@ -93,7 +93,7 @@
 // CHECK-FOUNDATION-NEXT: case binary
 
 // Note: Make sure NSURL works in various places
-// CHECK-FOUNDATION: open(_: NSURL!, completionHandler: ((Bool) -> Void)!)
+// CHECK-FOUNDATION: open(_: NSURL!, completionHandler: (@escaping (Bool) -> Void)!)
 
 // Note: property name stripping property type.
 // CHECK-FOUNDATION: var uppercased: String
@@ -136,11 +136,11 @@
 // CHECK-FOUNDATION: static var reverse: EnumerationOptions
 
 // Note: usingBlock -> body
-// CHECK-FOUNDATION: func enumerateObjects(_: ((Any?, Int, UnsafeMutablePointer<ObjCBool>?) -> Void)!)
-// CHECK-FOUNDATION: func enumerateObjects(options: EnumerationOptions = [], using: ((Any?, Int, UnsafeMutablePointer<ObjCBool>?) -> Void)!)
+// CHECK-FOUNDATION: func enumerateObjects(_: (@escaping (Any?, Int, UnsafeMutablePointer<ObjCBool>?) -> Void)!)
+// CHECK-FOUNDATION: func enumerateObjects(options: EnumerationOptions = [], using: (@escaping (Any?, Int, UnsafeMutablePointer<ObjCBool>?) -> Void)!)
 
 // Note: WithBlock -> body, nullable closures default to nil.
-// CHECK-FOUNDATION: func enumerateObjectsRandomly(block: ((Any?, Int, UnsafeMutablePointer<ObjCBool>?) -> Void)? = nil)
+// CHECK-FOUNDATION: func enumerateObjectsRandomly(block: (@escaping (Any?, Int, UnsafeMutablePointer<ObjCBool>?) -> Void)? = nil)
 
 // Note: id<Proto> treated as "Proto".
 // CHECK-FOUNDATION: func doSomething(with: NSCopying)
@@ -149,7 +149,7 @@
 // CHECK-FOUNDATION: func doSomethingElse(with: NSCopying & NSObjectProtocol)
 
 // Note: Function type -> "Function".
-// CHECK-FOUNDATION: func sort(_: @convention(c) (Any, Any) -> Int)
+// CHECK-FOUNDATION: func sort(_: @escaping @convention(c) (Any, Any) -> Int)
 
 // Note: Plural: NSArray without type arguments -> "Objects".
 // CHECK-FOUNDATION: func remove(_: [Any])

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -396,7 +396,7 @@ func testCondFail(_ b: Bool, c: Bool) {
 // CHECK-objc:    [[IS_DONE:%.*]] = icmp eq [[WORD]] [[PRED]], -1
 // CHECK-objc:    call void @llvm.assume(i1 [[IS_DONE]])
 
-func testOnce(_ p: Builtin.RawPointer, f: @convention(thin) () -> ()) {
+func testOnce(_ p: Builtin.RawPointer, f: @escaping @convention(thin) () -> ()) {
   Builtin.once(p, f)
 }
 
@@ -408,7 +408,7 @@ struct S {}
 protocol P {}
 
 // CHECK-LABEL: define hidden void @_TF8builtins10canBeClass
-func canBeClass<T>(_ f: (Builtin.Int8) -> (), _: T) {
+func canBeClass<T>(_ f: @escaping (Builtin.Int8) -> (), _: T) {
   // CHECK: call void {{%.*}}(i8 1
   f(Builtin.canBeClass(O.self))
   // CHECK: call void {{%.*}}(i8 1

--- a/test/Interpreter/FunctionConversion.swift
+++ b/test/Interpreter/FunctionConversion.swift
@@ -229,7 +229,7 @@ func generic1<T>(t: Parent) -> (T, Trivial) {
   return (t as! T, Trivial(n: 0))
 }
 
-func generic2<T : Parent>(f: (Parent) -> (T, Trivial), t: T) -> (Child) -> (Parent, Trivial?) {
+func generic2<T : Parent>(f: @escaping (Parent) -> (T, Trivial), t: T) -> (Child) -> (Parent, Trivial?) {
   return f
 }
 

--- a/test/Interpreter/currying_generics.swift
+++ b/test/Interpreter/currying_generics.swift
@@ -1,11 +1,11 @@
 // RUN: %target-run-simple-swift | FileCheck %s
 // REQUIRES: executable_test
 
-func curry<T, U, V>(_ f: (T, U) -> V) -> (T) -> (U) -> V {
+func curry<T, U, V>(_ f: @escaping (T, U) -> V) -> @escaping (T) -> @escaping (U) -> V {
   return { x in { y in f(x, y) } }
 }
 
-func curry<T1, T2, T3, T4>(_ f: (T1, T2, T3) -> T4) -> (T1) -> (T2) -> (T3) -> T4 {
+func curry<T1, T2, T3, T4>(_ f: @escaping (T1, T2, T3) -> T4) -> @escaping (T1) -> @escaping (T2) -> @escaping (T3) -> T4 {
   return { x in { y in { z in f(x, y, z) } } }
 }
 
@@ -91,7 +91,7 @@ print(test_compose_closure(20)) // CHECK-NEXT: 21
 
 // rdar://problem/18988428
 
-func clamp<T: Comparable>(_ minValue: T, _ maxValue: T) -> (n: T) -> T {
+func clamp<T: Comparable>(_ minValue: T, _ maxValue: T) -> @escaping (n: T) -> T {
     return { n in max(minValue, min(n, maxValue)) }
 }
 
@@ -110,7 +110,7 @@ func pair_<T,U> (_ a: T) -> (b: U) -> (T,U) {
 }
 
 infix operator <+> { }
-func <+><T,U,V> (lhs: T?, rhs: (T) -> (U) -> V) -> (U) -> V? {
+func <+><T,U,V> (lhs: T?, rhs: @escaping (T) -> @escaping (U) -> V) -> @escaping (U) -> V? {
 	if let x = lhs {
 		return { y in .some(rhs(x)(y)) }
 	} else {
@@ -130,11 +130,11 @@ print((b <+> pair_)(a!)) // CHECK-NEXT: (42, 23)
 struct Identity<A> { let value: A }
 struct Const<A, B> { let value: A }
 
-func fmap<A, B>(_ f: (A) -> B) -> (Identity<A>) -> Identity<B> {
+func fmap<A, B>(_ f: @escaping (A) -> B) -> @escaping (Identity<A>) -> Identity<B> {
 	return { identity in Identity(value: f(identity.value)) }
 }
 
-func fmap<A, B>(_ f: (A) -> B) -> (Const<A, B>) -> Const<A, B> {
+func fmap<A, B>(_ f: @escaping (A) -> B) -> @escaping (Const<A, B>) -> Const<A, B> {
 	return { const in const }
 }
 
@@ -160,32 +160,32 @@ func runIdentity<A>(_ i: Identity<A>) -> A {
 }
 
 
-func view<S, A>(_ lens: ((A) -> Const<A, S>) -> (S) -> (((A) -> S) -> (Const<A, S>) -> Const<A, S>) -> Const<A, S>) -> (S) -> A {
+func view<S, A>(_ lens: @escaping (@escaping (A) -> Const<A, S>) -> @escaping (S) -> @escaping (@escaping (@escaping (A) -> S) -> @escaping (Const<A, S>) -> Const<A, S>) -> Const<A, S>) -> @escaping (S) -> A {
 	return { s in getConst(lens(_Const)(s)(fmap)) }
 }
 
-func over<S, A>(_ lens: ((A) -> Identity<A>) -> (S) -> (((A) -> S) -> (Identity<A>) -> Identity<S>) -> Identity<S>) -> ((A) -> A) -> (S) -> S {
+func over<S, A>(_ lens: @escaping (@escaping (A) -> Identity<A>) -> @escaping (S) -> @escaping (@escaping (@escaping (A) -> S) -> @escaping (Identity<A>) -> Identity<S>) -> Identity<S>) -> @escaping (@escaping (A) -> A) -> @escaping (S) -> S {
 	return { f in { s in runIdentity(lens({ _Identity(f($0)) })(s)(fmap)) } }
 }
 
-func set<S, A>(_ lens: ((A) -> Identity<A>) -> (S) -> (((A) -> S) -> (Identity<A>) -> Identity<S>) -> Identity<S>) -> (A) -> (S) -> S {
+func set<S, A>(_ lens: @escaping (@escaping (A) -> Identity<A>) -> @escaping (S) -> @escaping (@escaping (@escaping (A) -> S) -> @escaping (Identity<A>) -> Identity<S>) -> Identity<S>) -> @escaping (A) -> @escaping (S) -> S {
 	return { x in { y in over(lens)(const(x))(y) } }
 }
 
-func _1<A, B, C, D>(_ f: (A) -> C) -> (A, B) -> (((A) -> (A, B)) -> (C) -> D) -> D {
+func _1<A, B, C, D>(_ f: @escaping (A) -> C) -> @escaping (A, B) -> @escaping (@escaping (@escaping (A) -> (A, B)) -> @escaping (C) -> D) -> D {
 	return { (x, y) in { fmap in fmap({ ($0, y) })(f(x)) } }
 }
 
-func _2<A, B, C, D>(_ f: (B) -> C) -> (A, B) -> (((B) -> (A, B)) -> (C) -> D) -> D {
+func _2<A, B, C, D>(_ f: @escaping (B) -> C) -> @escaping (A, B) -> @escaping (@escaping (@escaping (B) -> (A, B)) -> @escaping (C) -> D) -> D {
     return { (x, y) in { fmap in fmap({ (x, $0) })(f(y)) } }
 }
 
 
-public func >>> <T, U, V> (f: (T) -> U, g: (U) -> V) -> (T) -> V {
+public func >>> <T, U, V> (f: @escaping (T) -> U, g: @escaping (U) -> V) -> @escaping (T) -> V {
 	return { g(f($0)) }
 }
 
-public func <<< <T, U, V> (f: (U) -> V, g: (T) -> U) -> (T) -> V {
+public func <<< <T, U, V> (f: @escaping (U) -> V, g: @escaping (T) -> U) -> @escaping (T) -> V {
 	return { f(g($0)) }
 }
 

--- a/test/Interpreter/optional.swift
+++ b/test/Interpreter/optional.swift
@@ -9,7 +9,7 @@ class B : A {
 }
 
 func printA(_ v: A) { v.printA() }
-func printOpt<T>(_ subprint: (T) -> ()) -> (T?) -> () {
+func printOpt<T>(_ subprint: @escaping (T) -> ()) -> (T?) -> () {
   return { x in
     switch (x) {
     case .some(let y): print(".some(", terminator: ""); subprint(y); print(")", terminator: "")

--- a/test/Interpreter/repl.swift
+++ b/test/Interpreter/repl.swift
@@ -197,11 +197,11 @@ var _ : ([Int]).Type = [4].dynamicType
 // CHECK: : ([Int]).Type
 var _ : ((Int) -> Int)? = .none
 // CHECK: : ((Int) -> Int)?
-func chained(f f: (Int) -> ()) -> Int { return 0 }
+func chained(f f: @escaping (Int) -> ()) -> Int { return 0 }
 chained
-// CHECK: : (f: (Int) -> ()) -> Int
+// CHECK: : (f: @escaping (Int) -> ()) -> Int
 [chained]
-// CHECK: : [(f: (Int) -> ()) -> Int]
+// CHECK: : [(f: @escaping (Int) -> ()) -> Int]
 
 ({97210}())
 // CHECK: = 97210

--- a/test/NameBinding/name_lookup.swift
+++ b/test/NameBinding/name_lookup.swift
@@ -457,7 +457,7 @@ protocol MyProto {
 
 // <rdar://problem/14488311>
 struct DefaultArgumentFromExtension {
-  func g(_ x: (DefaultArgumentFromExtension) -> () -> () = f) {
+  func g(_ x: @escaping (DefaultArgumentFromExtension) -> () -> () = f) {
     let f = 42
     var x2 = x
     x2 = f // expected-error{{cannot assign value of type 'Int' to type '(DefaultArgumentFromExtension) -> () -> ()'}}

--- a/test/PrintAsObjC/blocks.swift
+++ b/test/PrintAsObjC/blocks.swift
@@ -45,13 +45,13 @@ typealias MyInt = Int
 // CHECK-NEXT: init
 // CHECK-NEXT: @end
 @objc class Callbacks {
-  func voidBlocks(_ input: () -> ()) -> () -> () {
+  func voidBlocks(_ input: @escaping () -> ()) -> () -> () {
     return input
   }
-  func manyArguments(_ input: (Float, Float, Double, Double) -> ()) {}
+  func manyArguments(_ input: @escaping (Float, Float, Double, Double) -> ()) {}
 
-  func blockTakesBlock(_ input: (() -> ()) -> ()) {}
-  func blockReturnsBlock(_ input: () -> () -> ()) {}
+  func blockTakesBlock(_ input: @escaping (() -> ()) -> ()) {}
+  func blockReturnsBlock(_ input: @escaping () -> () -> ()) {}
   func blockTakesAndReturnsBlock(_ input:
     ((Int16) -> (UInt16)) ->
                 ((Int8) -> (UInt8))) {}
@@ -70,11 +70,11 @@ typealias MyInt = Int
     return nil
   }
 
-  func blockWithTypealias(_ input: (MyTuple) -> MyInt) {}
-  func blockWithSimpleTypealias(_ input: (MyInt) -> MyInt) {}
+  func blockWithTypealias(_ input: @escaping (MyTuple) -> MyInt) {}
+  func blockWithSimpleTypealias(_ input: @escaping (MyInt) -> MyInt) {}
 
-  func namedArguments(_ input: (f1: Float, f2: Float, d1: Double, d2: Double) -> ()) {}
-  func blockTakesNamedBlock(_ input: (block: () -> ()) -> ()) {}
+  func namedArguments(_ input: @escaping (f1: Float, f2: Float, d1: Double, d2: Double) -> ()) {}
+  func blockTakesNamedBlock(_ input: @escaping (block: () -> ()) -> ()) {}
   func returnsBlockWithNamedInput() -> ((object: NSObject) -> ())? {
     return nil
   }
@@ -83,18 +83,18 @@ typealias MyInt = Int
 
   func blockWithKeyword(_ _Nullable: (`class`: Int) -> Int) {}
 
-  func functionPointers(_ input: @convention(c) (Int) -> Int)
+  func functionPointers(_ input: @escaping @convention(c) (Int) -> Int)
       -> @convention(c) (Int) -> Int {
     return input
   }
 
   func functionPointerTakesAndReturnsFunctionPointer(
-    _ input: @convention(c) (Int) -> (Int)
+    _ input: @escaping @convention(c) (Int) -> (Int)
                               -> @convention(c) (Int) -> Int
   ) {
   }
 
-  func functionPointersWithName(_ input: @convention(c) (value: Int) -> Int)
+  func functionPointersWithName(_ input: @escaping @convention(c) (value: Int) -> Int)
       -> @convention(c) (result: Int) -> Int {
     return input
   }

--- a/test/Prototypes/CollectionTransformers.swift
+++ b/test/Prototypes/CollectionTransformers.swift
@@ -390,8 +390,8 @@ final class _ForkJoinWorkDeque<T> {
 
   func tryReplace(
     _ value: T,
-    makeReplacement: () -> T,
-    isEquivalent: (T, T) -> Bool
+    makeReplacement: @escaping () -> T,
+    isEquivalent: @escaping (T, T) -> Bool
   ) -> Bool {
     return _dequeMutex.withLock {
       for i in _deque.indices {
@@ -581,7 +581,7 @@ final public class ForkJoinTask<Result> : ForkJoinTaskBase, _Future {
   internal let _task: () -> Result
   internal var _result: Result? = nil
 
-  public init(_task: () -> Result) {
+  public init(_task: @escaping () -> Result) {
     self._task = _task
   }
 
@@ -689,7 +689,7 @@ final public class ForkJoinPool {
     }
   }
 
-  internal func _compensateForBlockedWorkerThread(_ blockingBody: () -> ()) {
+  internal func _compensateForBlockedWorkerThread(_ blockingBody: @escaping () -> ()) {
     // FIXME: limit the number of compensating threads.
     let submissionQueue = _ForkJoinWorkDeque<ForkJoinTaskBase>()
     let workDeque = _ForkJoinWorkDeque<ForkJoinTaskBase>()
@@ -795,7 +795,7 @@ final public class ForkJoinPool {
   }
 
   // FIXME: return a Future instead?
-  public func forkTask<Result>(task: () -> Result) -> ForkJoinTask<Result> {
+  public func forkTask<Result>(task: @escaping () -> Result) -> ForkJoinTask<Result> {
     let forkJoinTask = ForkJoinTask(_task: task)
     forkTask(forkJoinTask)
     return forkJoinTask
@@ -853,19 +853,19 @@ internal class _CollectionTransformerStep<PipelineInputElement_, OutputElement_>
   typealias PipelineInputElement = PipelineInputElement_
   typealias OutputElement = OutputElement_
 
-  func map<U>(_ transform: (OutputElement) -> U)
+  func map<U>(_ transform: @escaping (OutputElement) -> U)
     -> _CollectionTransformerStep<PipelineInputElement, U> {
 
     fatalError("abstract method")
   }
 
-  func filter(_ isIncluded: (OutputElement) -> Bool)
+  func filter(_ isIncluded: @escaping (OutputElement) -> Bool)
     -> _CollectionTransformerStep<PipelineInputElement, OutputElement> {
 
     fatalError("abstract method")
   }
 
-  func reduce<U>(_ initial: U, _ combine: (U, OutputElement) -> U)
+  func reduce<U>(_ initial: U, _ combine: @escaping (U, OutputElement) -> U)
     -> _CollectionTransformerFinalizer<PipelineInputElement, U> {
 
     fatalError("abstract method")
@@ -903,7 +903,7 @@ final internal class _CollectionTransformerStepCollectionSource<
 
   typealias InputElement = PipelineInputElement
 
-  override func map<U>(_ transform: (InputElement) -> U)
+  override func map<U>(_ transform: @escaping (InputElement) -> U)
     -> _CollectionTransformerStep<PipelineInputElement, U> {
 
     return _CollectionTransformerStepOneToMaybeOne(self) {
@@ -911,7 +911,7 @@ final internal class _CollectionTransformerStepCollectionSource<
     }
   }
 
-  override func filter(_ isIncluded: (InputElement) -> Bool)
+  override func filter(_ isIncluded: @escaping (InputElement) -> Bool)
     -> _CollectionTransformerStep<PipelineInputElement, InputElement> {
 
     return _CollectionTransformerStepOneToMaybeOne(self) {
@@ -919,7 +919,7 @@ final internal class _CollectionTransformerStepCollectionSource<
     }
   }
 
-  override func reduce<U>(_ initial: U, _ combine: (U, InputElement) -> U)
+  override func reduce<U>(_ initial: U, _ combine: @escaping (U, InputElement) -> U)
     -> _CollectionTransformerFinalizer<PipelineInputElement, U> {
 
     return _CollectionTransformerFinalizerReduce(self, initial, combine)
@@ -970,13 +970,13 @@ final internal class _CollectionTransformerStepOneToMaybeOne<
   let _input: InputStep
   let _transform: (InputElement) -> OutputElement?
 
-  init(_ input: InputStep, _ transform: (InputElement) -> OutputElement?) {
+  init(_ input: InputStep, _ transform: @escaping (InputElement) -> OutputElement?) {
     self._input = input
     self._transform = transform
     super.init()
   }
 
-  override func map<U>(_ transform: (OutputElement) -> U)
+  override func map<U>(_ transform: @escaping (OutputElement) -> U)
     -> _CollectionTransformerStep<PipelineInputElement, U> {
 
     // Let the closure below capture only one variable, not the whole `self`.
@@ -990,7 +990,7 @@ final internal class _CollectionTransformerStepOneToMaybeOne<
     }
   }
 
-  override func filter(_ isIncluded: (OutputElement) -> Bool)
+  override func filter(_ isIncluded: @escaping (OutputElement) -> Bool)
     -> _CollectionTransformerStep<PipelineInputElement, OutputElement> {
 
     // Let the closure below capture only one variable, not the whole `self`.
@@ -1004,7 +1004,7 @@ final internal class _CollectionTransformerStepOneToMaybeOne<
     }
   }
 
-  override func reduce<U>(_ initial: U, _ combine: (U, OutputElement) -> U)
+  override func reduce<U>(_ initial: U, _ combine: @escaping (U, OutputElement) -> U)
     -> _CollectionTransformerFinalizer<PipelineInputElement, U> {
 
     return _CollectionTransformerFinalizerReduce(self, initial, combine)
@@ -1050,7 +1050,7 @@ struct _ElementCollectorOneToMaybeOne<
 
   init(
     _ baseCollector: BaseCollector,
-    _ transform: (Element) -> BaseCollector.Element?
+    _ transform: @escaping (Element) -> BaseCollector.Element?
   ) {
     self._baseCollector = baseCollector
     self._transform = transform
@@ -1113,7 +1113,7 @@ final class _CollectionTransformerFinalizerReduce<
   var _initial: U
   var _combine: (U, InputElementTy) -> U
 
-  init(_ input: InputStep, _ initial: U, _ combine: (U, InputElementTy) -> U) {
+  init(_ input: InputStep, _ initial: U, _ combine: @escaping (U, InputElementTy) -> U) {
     self._input = input
     self._initial = initial
     self._combine = combine
@@ -1136,7 +1136,7 @@ struct _ElementCollectorReduce<Element_, Result> : _ElementCollector {
   var _current: Result
   var _combine: (Result, Element) -> Result
 
-  init(_ initial: Result, _ combine: (Result, Element) -> Result) {
+  init(_ initial: Result, _ combine: @escaping (Result, Element) -> Result) {
     self._current = initial
     self._combine = combine
   }
@@ -1256,7 +1256,7 @@ public struct CollectionTransformerPipeline<
   internal var _input: InputCollection
   internal var _step: _CollectionTransformerStep<InputCollection.Iterator.Element, T>
 
-  public func map<U>(_ transform: (T) -> U)
+  public func map<U>(_ transform: @escaping (T) -> U)
     -> CollectionTransformerPipeline<InputCollection, U> {
 
     return CollectionTransformerPipeline<InputCollection, U>(
@@ -1265,7 +1265,7 @@ public struct CollectionTransformerPipeline<
     )
   }
 
-  public func filter(_ isIncluded: (T) -> Bool)
+  public func filter(_ isIncluded: @escaping (T) -> Bool)
     -> CollectionTransformerPipeline<InputCollection, T> {
 
     return CollectionTransformerPipeline<InputCollection, T>(
@@ -1275,7 +1275,7 @@ public struct CollectionTransformerPipeline<
   }
 
   public func reduce<U>(
-    _ initial: U, _ combine: (U, T) -> U
+    _ initial: U, _ combine: @escaping (U, T) -> U
   ) -> U {
     return _runCollectionTransformer(_input, _step.reduce(initial, combine))
   }
@@ -1390,7 +1390,7 @@ t.test("ForkJoinPool.forkTask/Fibonacci") {
   expectEqual(102334155, t.waitAndGetResult())
 }
 
-func _parallelMap(_ input: [Int], transform: (Int) -> Int, range: Range<Int>)
+func _parallelMap(_ input: [Int], transform: @escaping (Int) -> Int, range: Range<Int>)
   -> Array<Int>.Builder {
 
   var builder = Array<Int>.Builder()
@@ -1412,7 +1412,7 @@ func _parallelMap(_ input: [Int], transform: (Int) -> Int, range: Range<Int>)
   return builder
 }
 
-func parallelMap(_ input: [Int], transform: (Int) -> Int) -> [Int] {
+func parallelMap(_ input: [Int], transform: @escaping (Int) -> Int) -> [Int] {
   let t = ForkJoinPool.commonPool.forkTask {
     _parallelMap(
       input,

--- a/test/Reflection/Inputs/ConcreteTypes.swift
+++ b/test/Reflection/Inputs/ConcreteTypes.swift
@@ -14,7 +14,7 @@ public class C {
   public let aMetatype: C.Type
   public let aFunction: (C, S, E, Int) -> (Int)
   public let aFunctionWithVarArgs: (C, S...) -> ()
-  public init(aClass: C, aStruct: S, anEnum: E, aTuple: (C, S, E, Int), aTupleWithLabels: (a: C, s: S, e: E), aMetatype: C.Type, aFunction: (C, S, E, Int) -> Int, aFunctionWithVarArgs: (C, S...) -> ()) {
+  public init(aClass: C, aStruct: S, anEnum: E, aTuple: (C, S, E, Int), aTupleWithLabels: (a: C, s: S, e: E), aMetatype: C.Type, aFunction: @escaping (C, S, E, Int) -> Int, aFunctionWithVarArgs: @escaping (C, S...) -> ()) {
     self.aClass = aClass
     self.aStruct = aStruct
     self.anEnum = anEnum

--- a/test/Runtime/weak-reference-racetests.swift
+++ b/test/Runtime/weak-reference-racetests.swift
@@ -15,7 +15,7 @@ class WBox<T: AnyObject> {
 
 class WeakReferenceRaceData {
   let closure: () -> Void
-  init(_ closure: () -> Void) {
+  init(_ closure: @escaping () -> Void) {
     self.closure = closure
   }
 }

--- a/test/SILGen/c_function_pointers.swift
+++ b/test/SILGen/c_function_pointers.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -emit-silgen -verify %s | FileCheck %s
 
-func values(_ arg: @convention(c) (Int) -> Int) -> @convention(c) (Int) -> Int {
+func values(_ arg: @escaping @convention(c) (Int) -> Int) -> @convention(c) (Int) -> Int {
   return arg
 }
 // CHECK-LABEL: sil hidden @_TF19c_function_pointers6valuesFcSiSicSiSi

--- a/test/SILGen/capture_typed_boxes.swift
+++ b/test/SILGen/capture_typed_boxes.swift
@@ -7,7 +7,7 @@ func foo(_ x: Int) -> () -> Int {
 // CHECK-LABEL: sil shared @_TFF19capture_typed_boxes3fooFSiFT_SiU_FT_Si : $@convention(thin) (@owned @box Int) -> Int {
 // CHECK:       bb0(%0 : $@box Int):
 
-func closure(_ f: (Int) -> Int) -> Int {
+func closure(_ f: @escaping (Int) -> Int) -> Int {
   var f = f
   func bar(_ x: Int) -> Int {
     return f(x)
@@ -18,7 +18,7 @@ func closure(_ f: (Int) -> Int) -> Int {
 // CHECK-LABEL: sil shared @_TFF19capture_typed_boxes7closureFFSiSiSiL_3barfSiSi : $@convention(thin) (Int, @owned @box @callee_owned (Int) -> Int) -> Int {
 // CHECK:       bb0(%0 : $Int, %1 : $@box @callee_owned (Int) -> Int):
 
-func closure_generic<T>(_ f: (T) -> T, x: T) -> T {
+func closure_generic<T>(_ f: @escaping (T) -> T, x: T) -> T {
   var f = f
   func bar(_ x: T) -> T {
     return f(x)

--- a/test/SILGen/dependent_member_lowering.swift
+++ b/test/SILGen/dependent_member_lowering.swift
@@ -15,7 +15,7 @@ struct Foo<T>: P {
 struct Bar<T>: P {
   typealias A = (Int) -> T
 
-  func f(_ t: (Int) -> T) {}
+  func f(_ t: @escaping (Int) -> T) {}
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWurGV25dependent_member_lowering3Barx_S_1PS_FS1_1{{.*}} : $@convention(witness_method) <T> (@in @callee_owned (@in Int) -> @out T, @in_guaranteed Bar<T>) -> ()
   // CHECK:       bb0(%0 : $*@callee_owned (@in Int) -> @out T, %1 : $*Bar<T>):
 }

--- a/test/SILGen/function_conversion.swift
+++ b/test/SILGen/function_conversion.swift
@@ -8,7 +8,7 @@
 // CHECK:         [[THUNK:%.*]] = function_ref @_TTRXFtCc_dSi_dSi_XFo_dSi_dSi_
 // CHECK:         [[FUNC:%.*]] = partial_apply [[THUNK]](%0)
 // CHECK:         return [[FUNC]]
-func cToFunc(_ arg: @convention(c) (Int) -> Int) -> (Int) -> Int {
+func cToFunc(_ arg: @escaping @convention(c) (Int) -> Int) -> (Int) -> Int {
   return arg
 }
 
@@ -17,7 +17,7 @@ func cToFunc(_ arg: @convention(c) (Int) -> Int) -> (Int) -> Int {
 // CHECK:         [[BLOCK:%.*]] = init_block_storage_header [[BLOCK_STORAGE]]
 // CHECK:         [[COPY:%.*]] = copy_block [[BLOCK]] : $@convention(block) (Int) -> Int
 // CHECK:         return [[COPY]]
-func cToBlock(_ arg: @convention(c) (Int) -> Int) -> @convention(block) (Int) -> Int {
+func cToBlock(_ arg: @escaping @convention(c) (Int) -> Int) -> @convention(block) (Int) -> Int {
   return arg
 }
 
@@ -26,14 +26,14 @@ func cToBlock(_ arg: @convention(c) (Int) -> Int) -> @convention(block) (Int) ->
 // CHECK-LABEL: sil hidden @_TF19function_conversion12funcToThrowsFFT_T_FzT_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> @owned @callee_owned () -> @error Error
 // CHECK:         [[FUNC:%.*]] = convert_function %0 : $@callee_owned () -> () to $@callee_owned () -> @error Error
 // CHECK:         return [[FUNC]]
-func funcToThrows(_ x: () -> ()) -> () throws -> () {
+func funcToThrows(_ x: @escaping () -> ()) -> () throws -> () {
   return x
 }
 
 // CHECK-LABEL: sil hidden @_TF19function_conversion12thinToThrowsFXfT_T_XfzT_T_ : $@convention(thin) (@convention(thin) () -> ()) -> @convention(thin) () -> @error Error
 // CHECK:         [[FUNC:%.*]] = convert_function %0 : $@convention(thin) () -> () to $@convention(thin) () -> @error Error
 // CHECK:         return [[FUNC]] : $@convention(thin) () -> @error Error
-func thinToThrows(_ x: @convention(thin) () -> ()) -> @convention(thin) () throws -> () {
+func thinToThrows(_ x: @escaping @convention(thin) () -> ()) -> @convention(thin) () throws -> () {
   return x
 }
 
@@ -54,14 +54,14 @@ class Domesticated : Feral {}
 // CHECK-LABEL: sil hidden @_TF19function_conversion12funcToUpcastFFT_CS_12DomesticatedFT_CS_5Feral : $@convention(thin) (@owned @callee_owned () -> @owned Domesticated) -> @owned @callee_owned () -> @owned Feral
 // CHECK:         [[FUNC:%.*]] = convert_function %0 : $@callee_owned () -> @owned Domesticated to $@callee_owned () -> @owned Feral
 // CHECK:         return [[FUNC]]
-func funcToUpcast(_ x: () -> Domesticated) -> () -> Feral {
+func funcToUpcast(_ x: @escaping () -> Domesticated) -> () -> Feral {
   return x
 }
 
 // CHECK-LABEL: sil hidden @_TF19function_conversion12funcToUpcastFFCS_5FeralT_FCS_12DomesticatedT_ : $@convention(thin) (@owned @callee_owned (@owned Feral) -> ()) -> @owned @callee_owned (@owned Domesticated) -> ()
 // CHECK:         [[FUNC:%.*]] = convert_function %0 : $@callee_owned (@owned Feral) -> () to $@callee_owned (@owned Domesticated) -> (){{.*}} // user: %3
 // CHECK:         return [[FUNC]]
-func funcToUpcast(_ x: (Feral) -> ()) -> (Domesticated) -> () {
+func funcToUpcast(_ x: @escaping (Feral) -> ()) -> (Domesticated) -> () {
   return x
 }
 
@@ -104,7 +104,7 @@ struct AddrOnly {
 }
 
 // CHECK-LABEL: sil hidden @_TF19function_conversion19convOptionalTrivialFFGSqVS_7Trivial_S0_T_
-func convOptionalTrivial(_ t1: (Trivial?) -> Trivial) {
+func convOptionalTrivial(_ t1: @escaping (Trivial?) -> Trivial) {
 // CHECK:         function_ref @_TTRXFo_dGSqV19function_conversion7Trivial__dS0__XFo_dS0__dGSqS0___
 // CHECK:         partial_apply
   let _: (Trivial) -> Trivial? = t1
@@ -127,7 +127,7 @@ func convOptionalTrivial(_ t1: (Trivial?) -> Trivial) {
 // CHECK-NEXT:    return
 
 // CHECK-LABEL: sil hidden @_TF19function_conversion20convOptionalLoadableFFGSqVS_8Loadable_S0_T_
-func convOptionalLoadable(_ l1: (Loadable?) -> Loadable) {
+func convOptionalLoadable(_ l1: @escaping (Loadable?) -> Loadable) {
 // CHECK:         function_ref @_TTRXFo_oGSqV19function_conversion8Loadable__oS0__XFo_oS0__oGSqS0___
 // CHECK:         partial_apply
   let _: (Loadable) -> Loadable? = l1
@@ -144,7 +144,7 @@ func convOptionalLoadable(_ l1: (Loadable?) -> Loadable) {
 // CHECK-NEXT:    return
 
 // CHECK-LABEL: sil hidden @_TF19function_conversion20convOptionalAddrOnlyFFGSqVS_8AddrOnly_S0_T_
-func convOptionalAddrOnly(_ a1: (AddrOnly?) -> AddrOnly) {
+func convOptionalAddrOnly(_ a1: @escaping (AddrOnly?) -> AddrOnly) {
 // CHECK:         function_ref @_TTRXFo_iGSqV19function_conversion8AddrOnly__iS0__XFo_iGSqS0___iGSqS0___
 // CHECK:         partial_apply
   let _: (AddrOnly?) -> AddrOnly? = a1
@@ -191,7 +191,7 @@ extension Loadable : P {}
 extension AddrOnly : P {}
 
 // CHECK-LABEL: sil hidden @_TF19function_conversion22convExistentialTrivialFTFPS_1Q_VS_7Trivial2t3FGSqPS0___S1__T_
-func convExistentialTrivial(_ t2: (Q) -> Trivial, t3: (Q?) -> Trivial) {
+func convExistentialTrivial(_ t2: @escaping (Q) -> Trivial, t3: @escaping (Q?) -> Trivial) {
 // CHECK:         function_ref @_TTRXFo_iP19function_conversion1Q__dVS_7Trivial_XFo_dS1__iPS_1P__
 // CHECK:         partial_apply
   let _: (Trivial) -> P = t2
@@ -245,7 +245,7 @@ func convExistentialTrivial(_ t2: (Q) -> Trivial, t3: (Q?) -> Trivial) {
 // ==== Existential metatypes
 
 // CHECK-LABEL: sil hidden @_TF19function_conversion23convExistentialMetatypeFFGSqPMPS_1Q__MVS_7TrivialT_
-func convExistentialMetatype(_ em: (Q.Type?) -> Trivial.Type) {
+func convExistentialMetatype(_ em: @escaping (Q.Type?) -> Trivial.Type) {
 // CHECK:         function_ref @_TTRXFo_dGSqPMP19function_conversion1Q___dXMtVS_7Trivial_XFo_dXMtS1__dXPMTPS_1P__
 // CHECK:         partial_apply
   let _: (Trivial.Type) -> P.Type = em
@@ -303,8 +303,8 @@ class Child : Parent {}
 // to be generated
 
 // CHECK-LABEL: sil hidden @_TF19function_conversion18convUpcastMetatypeFTFTMCS_6ParentGSqVS_7Trivial__MCS_5Child2c5FTGSqMS0__GSqS1___MS2__T_
-func convUpcastMetatype(_ c4: (Parent.Type, Trivial?) -> Child.Type,
-                        c5: (Parent.Type?, Trivial?) -> Child.Type) {
+func convUpcastMetatype(_ c4: @escaping (Parent.Type, Trivial?) -> Child.Type,
+                        c5: @escaping (Parent.Type?, Trivial?) -> Child.Type) {
 // CHECK:         function_ref @_TTRXFo_dXMTC19function_conversion6ParentdGSqVS_7Trivial__dXMTCS_5Child_XFo_dXMTS2_dS1__dXMTS0__
 // CHECK:         partial_apply
   let _: (Child.Type, Trivial) -> Parent.Type = c4
@@ -341,7 +341,7 @@ func convUpcastMetatype(_ c4: (Parent.Type, Trivial?) -> Child.Type,
 // ==== Function to existential -- make sure we maximally abstract it
 
 // CHECK-LABEL: sil hidden @_TF19function_conversion19convFuncExistentialFFP_FSiSiT_ : $@convention(thin) (@owned @callee_owned (@in Any) -> @owned @callee_owned (Int) -> Int) -> ()
-func convFuncExistential(_ f1: (Any) -> (Int) -> Int) {
+func convFuncExistential(_ f1: @escaping (Any) -> (Int) -> Int) {
 // CHECK:         function_ref @_TTRXFo_iP__oXFo_dSi_dSi__XFo_oXFo_dSi_dSi__iP__
 // CHECK:         partial_apply %3(%0)
   let _: ((Int) -> Int) -> Any = f1
@@ -369,7 +369,7 @@ func convFuncExistential(_ f1: (Any) -> (Int) -> Int) {
 // ==== Class-bound archetype upcast
 
 // CHECK-LABEL: sil hidden @_TF19function_conversion29convClassBoundArchetypeUpcast
-func convClassBoundArchetypeUpcast<T : Parent>(_ f1: (Parent) -> (T, Trivial)) {
+func convClassBoundArchetypeUpcast<T : Parent>(_ f1: @escaping (Parent) -> (T, Trivial)) {
 // CHECK:         function_ref @_TTRGRxC19function_conversion6ParentrXFo_oS0__oxdVS_7Trivial_XFo_ox_oS0_dGSqS1___
 // CHECK:         partial_apply
   let _: (T) -> (Parent, Trivial?) = f1
@@ -386,7 +386,7 @@ func convClassBoundArchetypeUpcast<T : Parent>(_ f1: (Parent) -> (T, Trivial)) {
 // CHECK-NEXT:    return
 
 // CHECK-LABEL: sil hidden @_TF19function_conversion37convClassBoundMetatypeArchetypeUpcast
-func convClassBoundMetatypeArchetypeUpcast<T : Parent>(_ f1: (Parent.Type) -> (T.Type, Trivial)) {
+func convClassBoundMetatypeArchetypeUpcast<T : Parent>(_ f1: @escaping (Parent.Type) -> (T.Type, Trivial)) {
 // CHECK:         function_ref @_TTRGRxC19function_conversion6ParentrXFo_dXMTS0__dXMTxdVS_7Trivial_XFo_dXMTx_dXMTS0_dGSqS1___
 // CHECK:         partial_apply
   let _: (T.Type) -> (Parent.Type, Trivial?) = f1
@@ -413,9 +413,9 @@ func convClassBoundMetatypeArchetypeUpcast<T : Parent>(_ f1: (Parent.Type) -> (T
 
 // CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @_TTRXFo_dGSqTSiSi____XFo_dSidSi__ : $@convention(thin) (Int, Int, @owned @callee_owned (Optional<(Int, Int)>) -> ()) -> ()
 
-func convTupleScalar(_ f1: (Q) -> (),
-                     f2: (parent: Q) -> (),
-                     f3: (tuple: (Int, Int)?) -> ()) {
+func convTupleScalar(_ f1: @escaping (Q) -> (),
+                     f2: @escaping (parent: Q) -> (),
+                     f3: @escaping (tuple: (Int, Int)?) -> ()) {
   let _: (parent: P) -> () = f1
   let _: (P) -> () = f2
   let _: (Int, Int) -> () = f3
@@ -426,6 +426,6 @@ func convTupleScalar(_ f1: (Q) -> (),
 
 // CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @_TTRGrXFo_oGSax___XFo_it4argsGSax___iT__ : $@convention(thin) <T> (@in (args: T...), @owned @callee_owned (@owned Array<T>) -> ()) -> @out ()
 
-func convTupleScalarOpaque<T>(_ f: (args: T...) -> ()) -> ((args: T...) -> ())? {
+func convTupleScalarOpaque<T>(_ f: @escaping (args: T...) -> ()) -> ((args: T...) -> ())? {
   return f
 }

--- a/test/SILGen/function_conversion_objc.swift
+++ b/test/SILGen/function_conversion_objc.swift
@@ -7,7 +7,7 @@ import Foundation
 // ==== Metatype to object conversions
 
 // CHECK-LABEL: sil hidden @_TF24function_conversion_objc20convMetatypeToObjectFFCSo8NSObjectMS0_T_
-func convMetatypeToObject(_ f: (NSObject) -> NSObject.Type) {
+func convMetatypeToObject(_ f: @escaping (NSObject) -> NSObject.Type) {
 // CHECK:         function_ref @_TTRXFo_oCSo8NSObject_dXMTS__XFo_oS__oPs9AnyObject__
 // CHECK:         partial_apply
   let _: (NSObject) -> AnyObject = f
@@ -22,7 +22,7 @@ func convMetatypeToObject(_ f: (NSObject) -> NSObject.Type) {
 @objc protocol NSBurrito {}
 
 // CHECK-LABEL: sil hidden @_TF24function_conversion_objc31convExistentialMetatypeToObjectFFPS_9NSBurrito_PMPS0__T_
-func convExistentialMetatypeToObject(_ f: (NSBurrito) -> NSBurrito.Type) {
+func convExistentialMetatypeToObject(_ f: @escaping (NSBurrito) -> NSBurrito.Type) {
 // CHECK:         function_ref @_TTRXFo_oP24function_conversion_objc9NSBurrito__dXPMTPS0___XFo_oPS0___oPs9AnyObject__
 // CHECK:         partial_apply
   let _: (NSBurrito) -> AnyObject = f
@@ -35,7 +35,7 @@ func convExistentialMetatypeToObject(_ f: (NSBurrito) -> NSBurrito.Type) {
 // CHECK:         return
 
 // CHECK-LABEL: sil hidden @_TF24function_conversion_objc28convProtocolMetatypeToObjectFFT_MPS_9NSBurrito_T_
-func convProtocolMetatypeToObject(_ f: () -> NSBurrito.Protocol) {
+func convProtocolMetatypeToObject(_ f: @escaping () -> NSBurrito.Protocol) {
 // CHECK:         function_ref @_TTRXFo__dXMtP24function_conversion_objc9NSBurrito__XFo__oCSo8Protocol_
 // CHECK:         partial_apply
   let _: () -> Protocol = f
@@ -54,7 +54,7 @@ func convProtocolMetatypeToObject(_ f: () -> NSBurrito.Protocol) {
 // CHECK:         [[BLOCK:%.*]] = init_block_storage_header [[BLOCK_STORAGE]]
 // CHECK:         [[COPY:%.*]] = copy_block [[BLOCK]] : $@convention(block) () -> ()
 // CHECK:         return [[COPY]]
-func funcToBlock(_ x: () -> ()) -> @convention(block) () -> () {
+func funcToBlock(_ x: @escaping () -> ()) -> @convention(block) () -> () {
   return x
 }
 
@@ -63,7 +63,7 @@ func funcToBlock(_ x: () -> ()) -> @convention(block) () -> () {
 // CHECK:         [[THUNK:%.*]] = function_ref @_TTRXFdCb___XFo___
 // CHECK:         [[FUNC:%.*]] = partial_apply [[THUNK]]([[COPIED]])
 // CHECK:         return [[FUNC]]
-func blockToFunc(_ x: @convention(block) () -> ()) -> () -> () {
+func blockToFunc(_ x: @escaping @convention(block) () -> ()) -> () -> () {
   return x
 }
 
@@ -75,7 +75,7 @@ func blockToFunc(_ x: @convention(block) () -> ()) -> () -> () {
 // CHECK:         function_ref @_TTRXFo__dSi_XFo__iP__
 // CHECK:         partial_apply
 // CHECK:         return
-func blockToFuncExistential(_ x: @convention(block) () -> Int) -> () -> Any {
+func blockToFuncExistential(_ x: @escaping @convention(block) () -> Int) -> () -> Any {
   return x
 }
 
@@ -89,7 +89,7 @@ class A : NSObject {}
 class B : A {}
 
 // CHECK-LABEL: sil hidden @_TF24function_conversion_objc18cFuncPtrConversionFcCS_1AT_cCS_1BT_
-func cFuncPtrConversion(_ x: @convention(c) (A) -> ()) -> @convention(c) (B) -> () {
+func cFuncPtrConversion(_ x: @escaping @convention(c) (A) -> ()) -> @convention(c) (B) -> () {
 // CHECK:         convert_function %0 : $@convention(c) (A) -> () to $@convention(c) (B) -> ()
 // CHECK:         return
   return x
@@ -105,7 +105,7 @@ func cFuncDeclConversion() -> @convention(c) (B) -> () {
   return cFuncPtr
 }
 
-func cFuncPtrConversionUnsupported(_ x: @convention(c) (@convention(block) () -> ()) -> ())
+func cFuncPtrConversionUnsupported(_ x: @escaping @convention(c) (@convention(block) () -> ()) -> ())
     -> @convention(c) (@convention(c) () -> ()) -> () {
   return x  // expected-error{{C function pointer signature '@convention(c) (@convention(block) () -> ()) -> ()' is not compatible with expected type '@convention(c) (@convention(c) () -> ()) -> ()'}}
 }

--- a/test/SILGen/functions.swift
+++ b/test/SILGen/functions.swift
@@ -413,7 +413,7 @@ final class r17828355Class {
 
 // <rdar://problem/19981118> Swift 1.2 beta 2: Closures nested in @noescape closures copy, rather than reference, captured vars.
 func noescapefunc(f: @noescape () -> ()) {}
-func escapefunc(_ f : () -> ()) {}
+func escapefunc(_ f : @escaping () -> ()) {}
 
 func testNoescape() {
   // "a" must be captured by-box into noescapefunc because the inner closure

--- a/test/SILGen/generic_closures.swift
+++ b/test/SILGen/generic_closures.swift
@@ -191,7 +191,7 @@ protocol HasClassAssoc { associatedtype Assoc : Class }
 // CHECK: [[GENERIC_FN:%.*]] = function_ref @_TFF16generic_closures34captures_class_constrained_genericuRxS_13HasClassAssocrFTx1fFwx5AssocwxS1__T_U_FT_FQQ_5AssocS2_
 // CHECK: [[CONCRETE_FN:%.*]] = partial_apply [[GENERIC_FN]]<T, T.Assoc>(%1)
 
-func captures_class_constrained_generic<T : HasClassAssoc>(_ x: T, f: (T.Assoc) -> T.Assoc) {
+func captures_class_constrained_generic<T : HasClassAssoc>(_ x: T, f: @escaping (T.Assoc) -> T.Assoc) {
   let _: () -> (T.Assoc) -> T.Assoc = { f }
 }
 

--- a/test/SILGen/generic_signatures.swift
+++ b/test/SILGen/generic_signatures.swift
@@ -77,7 +77,7 @@ func concreteJungle<T where T : Fooable, T.Foo == C>(t: T.Foo) -> C {
   return c
 }
 
-func concreteJungle<T where T : Fooable, T.Foo == C>(f: (T.Foo) -> C) -> T.Foo {
+func concreteJungle<T where T : Fooable, T.Foo == C>(f: @escaping (T.Foo) -> C) -> T.Foo {
   let ff: (C) -> T.Foo = f
   return ff(C())
 }

--- a/test/SILGen/indirect_enum.swift
+++ b/test/SILGen/indirect_enum.swift
@@ -43,7 +43,7 @@ func TreeA_cases<T>(_ t: T, l: TreeA<T>, r: TreeA<T>) {
 }
 
 // CHECK-LABEL: sil hidden @_TF13indirect_enum16TreeA_reabstractFFSiSiT_
-func TreeA_reabstract(_ f: (Int) -> Int) {
+func TreeA_reabstract(_ f: @escaping (Int) -> Int) {
 
 // CHECK:         [[METATYPE:%.*]] = metatype $@thin TreeA<(Int) -> Int>.Type
 // CHECK-NEXT:    [[BOX:%.*]] = alloc_box $@callee_owned (@in Int) -> @out Int

--- a/test/SILGen/let_decls.swift
+++ b/test/SILGen/let_decls.swift
@@ -161,7 +161,7 @@ struct CloseOverAddressOnlyConstant<T> {
 }
 
 // CHECK-LABEL: sil hidden @{{.*}}callThroughLet
-func callThroughLet(_ predicate: (Int, Int) -> Bool) {
+func callThroughLet(_ predicate: @escaping (Int, Int) -> Bool) {
   let p = predicate
   if p(1, 2) {
   }

--- a/test/SILGen/materializeForSet.swift
+++ b/test/SILGen/materializeForSet.swift
@@ -102,7 +102,7 @@ extension Derived : Abstractable {}
 // CHECK-NEXT: function_ref
 // CHECK-NEXT: [[REABSTRACTOR:%.*]] = function_ref @_TTRXFo__iSi_XFo__dSi_ : $@convention(thin) (@owned @callee_owned () -> @out Int) -> Int
 // CHECK-NEXT: [[NEWVALUE:%.*]] = partial_apply [[REABSTRACTOR]]([[VALUE]])
-// CHECK-NEXT: [[FN:%.*]] = class_method [[SELF]] : $Base, #Base.storedFunction!setter.1 : (Base) -> (() -> Int) -> ()
+// CHECK-NEXT: [[FN:%.*]] = class_method [[SELF]] : $Base, #Base.storedFunction!setter.1 : (Base) -> (@escaping () -> Int) -> ()
 // CHECK-NEXT: apply [[FN]]([[NEWVALUE]], [[SELF]])
 // CHECK-NEXT: tuple ()
 // CHECK-NEXT: return

--- a/test/SILGen/metatype_abstraction.swift
+++ b/test/SILGen/metatype_abstraction.swift
@@ -134,6 +134,6 @@ func existential_metatype_of_metatype(_ x: Any) -> Any.Type.Type {
 }
  */
 
-func function_metatype_of_metatype(_ x: () -> ()) -> (() -> ()).Type.Type {
+func function_metatype_of_metatype(_ x: @escaping () -> ()) -> (() -> ()).Type.Type {
   return x.dynamicType.dynamicType
 }

--- a/test/SILGen/objc_blocks_bridging.swift
+++ b/test/SILGen/objc_blocks_bridging.swift
@@ -69,9 +69,9 @@ import Foundation
 
 // CHECK-LABEL: sil hidden @_TF20objc_blocks_bridging10callBlocks
 func callBlocks(_ x: Foo,
-  f: (Int) -> Int,
-  g: (String) -> String,
-  h: (String?) -> String?
+  f: @escaping (Int) -> Int,
+  g: @escaping (String) -> String,
+  h: @escaping (String?) -> String?
 ) -> (Int, String, String?, String?) {
   // CHECK: [[FOO:%.*]] =  class_method [volatile] %0 : $Foo, #Foo.foo!1.foreign
   // CHECK: [[F_BLOCK_STORAGE:%.*]] = alloc_stack $@block_storage

--- a/test/SILGen/optional_lvalue.swift
+++ b/test/SILGen/optional_lvalue.swift
@@ -45,7 +45,7 @@ func assign_iuo_lvalue_implicit(_ s: inout S!, _ y: Int) {
 // CHECK:         [[REABSTRACTED:%.*]] = partial_apply [[REABSTRACT]]
 // CHECK:         assign [[REABSTRACTED]] to {{%.*}} : $*@callee_owned (@in Int) -> @out Int
 func assign_optional_lvalue_reabstracted(_ x: inout ((Int) -> Int)?,
-                                         _ y: (Int) -> Int) {
+                                         _ y: @escaping (Int) -> Int) {
   x! = y
 }
 

--- a/test/SILGen/property_abstraction.swift
+++ b/test/SILGen/property_abstraction.swift
@@ -26,7 +26,7 @@ func getF(_ x: Foo<Int, Int>) -> (Int) -> Int {
 // CHECK:         [[F_ORIG:%.*]] = partial_apply [[REABSTRACT_FN]]({{%.*}})
 // CHECK:         [[F_ADDR:%.*]] = struct_element_addr {{%.*}} : $*Foo<Int, Int>, #Foo.f
 // CHECK:         assign [[F_ORIG]] to [[F_ADDR]]
-func setF(_ x: inout Foo<Int, Int>, f: (Int) -> Int) {
+func setF(_ x: inout Foo<Int, Int>, f: @escaping (Int) -> Int) {
   x.f = f
 }
 
@@ -88,7 +88,7 @@ func getF(_ x: Bar<Int, Int>) -> (Int) -> Int {
   }
 }
 
-func makeF(_ f: (Int) -> Int) -> Bar<Int, Int> {
+func makeF(_ f: @escaping (Int) -> Int) -> Bar<Int, Int> {
   return Bar.F(f)
 }
 

--- a/test/SILGen/vtable_thunks.swift
+++ b/test/SILGen/vtable_thunks.swift
@@ -129,7 +129,7 @@ class Y: X<D> {
 // optional.
 
 class Foo {
-  func foo(x: (Int) -> Int) -> ((Int) -> Int)? {}
+  func foo(x: @escaping (Int) -> Int) -> ((Int) -> Int)? {}
 }
 
 class Bar: Foo {

--- a/test/SILGen/vtable_thunks_reabstraction.swift
+++ b/test/SILGen/vtable_thunks_reabstraction.swift
@@ -11,11 +11,11 @@ class Opaque<T> {
   func inAndOut(x: T) -> T { return x }
   func inAndOutGeneric<U>(x: T, y: U) -> U { return y }
   func inAndOutMetatypes(x: T.Type) -> T.Type { return x }
-  func inAndOutFunctions(x: (T) -> T) -> (T) -> T { return x }
+  func inAndOutFunctions(x: @escaping (T) -> T) -> (T) -> T { return x }
   func inAndOutTuples(x: ObnoxiousTuple) -> ObnoxiousTuple { return x }
   func variantOptionality(x: T) -> T? { return x }
   func variantOptionalityMetatypes(x: T.Type) -> T.Type? { return x }
-  func variantOptionalityFunctions(x: (T) -> T) -> ((T) -> T)? { return x }
+  func variantOptionalityFunctions(x: @escaping (T) -> T) -> ((T) -> T)? { return x }
   func variantOptionalityTuples(x: ObnoxiousTuple) -> ObnoxiousTuple? { return x }
 }
 
@@ -27,22 +27,22 @@ class ConcreteValue<X>: Opaque<S> {
   override func inAndOut(x: S) -> S { return x }
   override func inAndOutGeneric<Z>(x: S, y: Z) -> Z { return y }
   override func inAndOutMetatypes(x: S.Type) -> S.Type { return x }
-  override func inAndOutFunctions(x: (S) -> S) -> (S) -> S { return x }
+  override func inAndOutFunctions(x: @escaping (S) -> S) -> (S) -> S { return x }
   override func inAndOutTuples(x: ObnoxiousTuple) -> ObnoxiousTuple { return x }
   override func variantOptionality(x: S?) -> S { return x! }
   override func variantOptionalityMetatypes(x: S.Type?) -> S.Type { return x! }
-  override func variantOptionalityFunctions(x: ((S) -> S)?) -> (S) -> S { return x! }
+  override func variantOptionalityFunctions(x: (@escaping (S) -> S)?) -> (S) -> S { return x! }
   override func variantOptionalityTuples(x: ObnoxiousTuple?) -> ObnoxiousTuple { return x! }
 }
 
 class ConcreteClass<X>: Opaque<C> {
   override func inAndOut(x: C) -> C { return x }
   override func inAndOutMetatypes(x: C.Type) -> C.Type { return x }
-  override func inAndOutFunctions(x: (C) -> C) -> (C) -> C { return x }
+  override func inAndOutFunctions(x: @escaping (C) -> C) -> (C) -> C { return x }
   override func inAndOutTuples(x: ObnoxiousTuple) -> ObnoxiousTuple { return x }
   override func variantOptionality(x: C?) -> C { return x! }
   override func variantOptionalityMetatypes(x: C.Type?) -> C.Type { return x! }
-  override func variantOptionalityFunctions(x: ((C) -> C)?) -> (C) -> C { return x! }
+  override func variantOptionalityFunctions(x: (@escaping (C) -> C)?) -> (C) -> C { return x! }
   override func variantOptionalityTuples(x: ObnoxiousTuple?) -> ObnoxiousTuple { return x! }
 }
 
@@ -62,12 +62,12 @@ class ConcreteTuple<X>: Opaque<(S, S)> {
 }
 
 class OpaqueFunction<U, V>: Opaque<(U) -> V> {
-  override func inAndOut(x: (U) -> V) -> (U) -> V { return x }
+  override func inAndOut(x: @escaping (U) -> V) -> (U) -> V { return x }
   override func variantOptionality(x: ((U) -> V)?) -> (U) -> V { return x! }
 }
 
 class ConcreteFunction<X>: Opaque<(S) -> S> {
-  override func inAndOut(x: (S) -> S) -> (S) -> S { return x }
+  override func inAndOut(x: @escaping (S) -> S) -> (S) -> S { return x }
   override func variantOptionality(x: ((S) -> S)?) -> (S) -> S { return x! }
 }
 

--- a/test/SILGen/weak.swift
+++ b/test/SILGen/weak.swift
@@ -4,7 +4,7 @@ class C {
   func f() -> Int { return 42 }
 }
 
-func takeClosure(fn: () -> Int) {}
+func takeClosure(fn: @escaping () -> Int) {}
 
 struct A {
   weak var x: C?

--- a/test/SILOptimizer/allocbox_to_stack_not_crash.swift
+++ b/test/SILOptimizer/allocbox_to_stack_not_crash.swift
@@ -5,11 +5,11 @@
 infix operator ~>
 protocol Target {}
 
-func ~> <Target, Arg0, Result>(x: inout Target, f: (_: inout Target, _: Arg0) -> Result) -> (Arg0) -> Result {
+func ~> <Target, Arg0, Result>(x: inout Target, f: @escaping (_: inout Target, _: Arg0) -> Result) -> (Arg0) -> Result {
   return { f(&x, $0) } // expected-error {{escaping closures can only capture inout parameters explicitly by value}}
 }
 
-func ~> (x: inout Int, f: (_: inout Int, _: Target) -> Target) -> (Target) -> Target {
+func ~> (x: inout Int, f: @escaping (_: inout Int, _: Target) -> Target) -> (Target) -> Target {
   return { f(&x, $0) } // expected-error {{escaping closures can only capture inout parameters explicitly by value}}
 }
 

--- a/test/Sema/diag_invalid_inout_captures.swift
+++ b/test/Sema/diag_invalid_inout_captures.swift
@@ -1,7 +1,7 @@
 // RUN: %target-parse-verify-swift
 
 func no_escape(_ you_say_price_of_my_love_is: @noescape () -> ()) {}
-func do_escape(_ not_a_price_you_are_willing_to_pay: () -> ()) {}
+func do_escape(_ not_a_price_you_are_willing_to_pay: @escaping () -> ()) {}
 
 struct you_cry_in_your_tea {
   mutating func which_you_hurl_in_the_sea_when_you_see_me_go_by() {

--- a/test/SourceKit/CursorInfo/cursor_stdlib.swift
+++ b/test/SourceKit/CursorInfo/cursor_stdlib.swift
@@ -37,9 +37,9 @@ func foo3(a: Float, b: Bool) {}
 // CHECK-REPLACEMENT1: <Group>Collection/Array</Group>
 // CHECK-REPLACEMENT1: <Declaration>func sorted() -&gt; [<Type usr="s:Si">Int</Type>]</Declaration>
 // CHECK-REPLACEMENT1: RELATED BEGIN
-// CHECK-REPLACEMENT1: sorted(by: @noescape (Int, Int) -&gt; Bool) -&gt; [Int]</RelatedName>
+// CHECK-REPLACEMENT1: sorted(by: (Int, Int) -&gt; Bool) -&gt; [Int]</RelatedName>
 // CHECK-REPLACEMENT1: sorted() -&gt; [Int]</RelatedName>
-// CHECK-REPLACEMENT1: sorted(by: @noescape (Int, Int) -&gt; Bool) -&gt; [Int]</RelatedName>
+// CHECK-REPLACEMENT1: sorted(by: (Int, Int) -&gt; Bool) -&gt; [Int]</RelatedName>
 // CHECK-REPLACEMENT1: RELATED END
 
 // RUN: %sourcekitd-test -req=cursor -pos=9:8 %s -- %s %mcp_opt %clang-importer-sdk | FileCheck -check-prefix=CHECK-REPLACEMENT2 %s
@@ -48,10 +48,10 @@ func foo3(a: Float, b: Bool) {}
 
 // RUN: %sourcekitd-test -req=cursor -pos=15:10 %s -- %s %mcp_opt %clang-importer-sdk | FileCheck -check-prefix=CHECK-REPLACEMENT3 %s
 // CHECK-REPLACEMENT3: <Group>Collection/Array</Group>
-// CHECK-REPLACEMENT3: func sorted(by areInIncreasingOrder: @noescape (<Type usr="s:V13cursor_stdlib2S1">S1</Type>
+// CHECK-REPLACEMENT3: func sorted(by areInIncreasingOrder: (<Type usr="s:V13cursor_stdlib2S1">S1</Type>
 // CHECK-REPLACEMENT3: sorted() -&gt; [S1]</RelatedName>
 // CHECK-REPLACEMENT3: sorted() -&gt; [S1]</RelatedName>
-// CHECK-REPLACEMENT3: sorted(by: @noescape (S1, S1) -&gt; Bool) -&gt; [S1]</RelatedName>
+// CHECK-REPLACEMENT3: sorted(by: (S1, S1) -&gt; Bool) -&gt; [S1]</RelatedName>
 
 // RUN: %sourcekitd-test -req=cursor -pos=18:8 %s -- %s %mcp_opt %clang-importer-sdk | FileCheck -check-prefix=CHECK-REPLACEMENT4 %s
 // CHECK-REPLACEMENT4: <Group>Collection/Array</Group>

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.response
@@ -158,8 +158,8 @@ var fooIntVar: Int32
 func fooFunc1(_ a: Int32) -> Int32
 func fooFunc1AnonymousParam(_ _: Int32) -> Int32
 func fooFunc3(_ a: Int32, _ b: Float, _ c: Double, _ d: UnsafeMutablePointer<Int32>!) -> Int32
-func fooFuncWithBlock(_ blk: ((Float) -> Int32)!)
-func fooFuncWithFunctionPointer(_ fptr: ((Float) -> Int32)!)
+func fooFuncWithBlock(_ blk: (@escaping (Float) -> Int32)!)
+func fooFuncWithFunctionPointer(_ fptr: (@escaping (Float) -> Int32)!)
 func fooFuncNoreturn1() -> Never
 func fooFuncNoreturn2() -> Never
 func fooFuncWithComment1()
@@ -2840,1842 +2840,1862 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "Float",
-    key.usr: "s:Sf",
+    key.kind: source.lang.swift.syntaxtype.attribute.id,
+    key.offset: 3769,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 3770,
-    key.length: 5
+    key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.name: "Int32",
-    key.usr: "s:Vs5Int32",
+    key.name: "Float",
+    key.usr: "s:Sf",
     key.offset: 3780,
     key.length: 5
   },
   {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Int32",
+    key.usr: "s:Vs5Int32",
+    key.offset: 3790,
+    key.length: 5
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3789,
+    key.offset: 3799,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3794,
+    key.offset: 3804,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3821,
+    key.offset: 3831,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3823,
+    key.offset: 3833,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3823,
+    key.offset: 3833,
     key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.id,
+    key.offset: 3840,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 3841,
+    key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Float",
     key.usr: "s:Sf",
-    key.offset: 3831,
+    key.offset: 3851,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 3841,
+    key.offset: 3861,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3850,
+    key.offset: 3870,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3855,
+    key.offset: 3875,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.ref.enum,
     key.name: "Never",
     key.usr: "s:Os5Never",
-    key.offset: 3877,
+    key.offset: 3897,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3883,
+    key.offset: 3903,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3888,
+    key.offset: 3908,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.ref.enum,
     key.name: "Never",
     key.usr: "s:Os5Never",
-    key.offset: 3910,
+    key.offset: 3930,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3916,
+    key.offset: 3936,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3921,
+    key.offset: 3941,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3943,
+    key.offset: 3963,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3948,
+    key.offset: 3968,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3970,
+    key.offset: 3990,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3975,
+    key.offset: 3995,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3997,
+    key.offset: 4017,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4002,
+    key.offset: 4022,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4024,
+    key.offset: 4044,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4029,
+    key.offset: 4049,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4051,
+    key.offset: 4071,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4056,
+    key.offset: 4076,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 4089,
+    key.offset: 4109,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 4091,
+    key.offset: 4111,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4091,
+    key.offset: 4111,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 4094,
+    key.offset: 4114,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 4104,
+    key.offset: 4124,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4110,
+    key.offset: 4130,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4119,
+    key.offset: 4139,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4142,
+    key.offset: 4162,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4147,
+    key.offset: 4167,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4167,
+    key.offset: 4187,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4172,
+    key.offset: 4192,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4213,
+    key.offset: 4233,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4218,
+    key.offset: 4238,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4259,
+    key.offset: 4279,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4266,
+    key.offset: 4286,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4271,
+    key.offset: 4291,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4296,
+    key.offset: 4316,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4300,
+    key.offset: 4320,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 4314,
+    key.offset: 4334,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4322,
+    key.offset: 4342,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4326,
+    key.offset: 4346,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4337,
+    key.offset: 4357,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4341,
+    key.offset: 4361,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 4355,
+    key.offset: 4375,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4363,
+    key.offset: 4383,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4367,
+    key.offset: 4387,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4378,
+    key.offset: 4398,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4382,
+    key.offset: 4402,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 4396,
+    key.offset: 4416,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4404,
+    key.offset: 4424,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4412,
+    key.offset: 4432,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4421,
+    key.offset: 4441,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "FooProtocolBase",
     key.usr: "c:objc(pl)FooProtocolBase",
-    key.offset: 4442,
+    key.offset: 4462,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4462,
+    key.offset: 4482,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4468,
+    key.offset: 4488,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4488,
+    key.offset: 4508,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4493,
+    key.offset: 4513,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4521,
+    key.offset: 4541,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4526,
+    key.offset: 4546,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 4547,
+    key.offset: 4567,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 4549,
+    key.offset: 4569,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4549,
+    key.offset: 4569,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4559,
+    key.offset: 4579,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 4568,
+    key.offset: 4588,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4587,
+    key.offset: 4607,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4600,
+    key.offset: 4620,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4612,
+    key.offset: 4632,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 4618,
+    key.offset: 4638,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 4624,
+    key.offset: 4644,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4618,
+    key.offset: 4638,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4624,
+    key.offset: 4644,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Float",
     key.usr: "s:Sf",
-    key.offset: 4627,
+    key.offset: 4647,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4639,
+    key.offset: 4659,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4644,
+    key.offset: 4664,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4681,
+    key.offset: 4701,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4687,
+    key.offset: 4707,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4692,
+    key.offset: 4712,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4717,
+    key.offset: 4737,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4722,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 4742,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4752,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4757,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4777,
+    key.offset: 4762,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4787,
+    key.offset: 4772,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4792,
+    key.offset: 4777,
+    key.length: 14
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4797,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4807,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4812,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4813,
+    key.offset: 4833,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4823,
+    key.offset: 4843,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4828,
+    key.offset: 4848,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4848,
+    key.offset: 4868,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4855,
+    key.offset: 4875,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4861,
+    key.offset: 4881,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 4879,
+    key.offset: 4899,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "FooProtocolDerived",
     key.usr: "c:objc(pl)FooProtocolDerived",
-    key.offset: 4893,
+    key.offset: 4913,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4919,
+    key.offset: 4939,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4923,
+    key.offset: 4943,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 4937,
+    key.offset: 4957,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4948,
+    key.offset: 4968,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4952,
+    key.offset: 4972,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 4966,
+    key.offset: 4986,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4977,
+    key.offset: 4997,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4981,
+    key.offset: 5001,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 4995,
+    key.offset: 5015,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5003,
+    key.offset: 5023,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5014,
+    key.offset: 5034,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5019,
+    key.offset: 5039,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5043,
+    key.offset: 5063,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5048,
+    key.offset: 5068,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 5065,
+    key.offset: 5085,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 5067,
+    key.offset: 5087,
     key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5067,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "Int32",
-    key.usr: "s:Vs5Int32",
-    key.offset: 5070,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5082,
-    key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 5087,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Int32",
+    key.usr: "s:Vs5Int32",
+    key.offset: 5090,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5102,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5107,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 5104,
+    key.offset: 5124,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 5106,
+    key.offset: 5126,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5106,
+    key.offset: 5126,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 5109,
+    key.offset: 5129,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 5116,
+    key.offset: 5136,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 5122,
+    key.offset: 5142,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5116,
+    key.offset: 5136,
     key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5122,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "Int32",
-    key.usr: "s:Vs5Int32",
-    key.offset: 5125,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5137,
-    key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 5142,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Int32",
+    key.usr: "s:Vs5Int32",
+    key.offset: 5145,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5157,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5162,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5179,
+    key.offset: 5199,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5185,
+    key.offset: 5205,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5190,
+    key.offset: 5210,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5211,
+    key.offset: 5231,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5216,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 5236,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5246,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5251,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5271,
+    key.offset: 5256,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5281,
+    key.offset: 5266,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5286,
+    key.offset: 5271,
+    key.length: 14
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5291,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5301,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5306,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5307,
+    key.offset: 5327,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5317,
+    key.offset: 5337,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5322,
+    key.offset: 5342,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5342,
+    key.offset: 5362,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5349,
+    key.offset: 5369,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5353,
+    key.offset: 5373,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 5366,
+    key.offset: 5386,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5374,
+    key.offset: 5394,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5380,
+    key.offset: 5400,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5384,
+    key.offset: 5404,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 5397,
+    key.offset: 5417,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5405,
+    key.offset: 5425,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5411,
+    key.offset: 5431,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5415,
+    key.offset: 5435,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 5428,
+    key.offset: 5448,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5436,
+    key.offset: 5456,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5442,
+    key.offset: 5462,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5446,
+    key.offset: 5466,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:Vs6UInt32",
-    key.offset: 5459,
+    key.offset: 5479,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5468,
+    key.offset: 5488,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5474,
+    key.offset: 5494,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5478,
+    key.offset: 5498,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt64",
     key.usr: "s:Vs6UInt64",
-    key.offset: 5491,
+    key.offset: 5511,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5500,
+    key.offset: 5520,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5506,
+    key.offset: 5526,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5510,
+    key.offset: 5530,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 5529,
+    key.offset: 5549,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5537,
+    key.offset: 5557,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5543,
+    key.offset: 5563,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5547,
+    key.offset: 5567,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 5566,
+    key.offset: 5586,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5574,
+    key.offset: 5594,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5580,
+    key.offset: 5600,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5585,
+    key.offset: 5605,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5604,
+    key.offset: 5624,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5609,
+    key.offset: 5629,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5633,
+    key.offset: 5653,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5640,
+    key.offset: 5660,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5663,
+    key.offset: 5683,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5667,
+    key.offset: 5687,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 5670,
+    key.offset: 5690,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5681,
+    key.offset: 5701,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5693,
+    key.offset: 5713,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 5698,
+    key.offset: 5718,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 5700,
+    key.offset: 5720,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5698,
+    key.offset: 5718,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5700,
+    key.offset: 5720,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 5703,
+    key.offset: 5723,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5712,
+    key.offset: 5732,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 5722,
-    key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 5742,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5762,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5747,
+    key.offset: 5767,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5767,
+    key.offset: 5787,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5774,
+    key.offset: 5794,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 5784,
+    key.offset: 5804,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5804,
+    key.offset: 5824,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5809,
+    key.offset: 5829,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5829,
+    key.offset: 5849,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5839,
+    key.offset: 5859,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5844,
+    key.offset: 5864,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5865,
+    key.offset: 5885,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5872,
+    key.offset: 5892,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 5882,
+    key.offset: 5902,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5902,
+    key.offset: 5922,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5907,
+    key.offset: 5927,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5927,
+    key.offset: 5947,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5934,
+    key.offset: 5954,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5943,
+    key.offset: 5963,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5961,
+    key.offset: 5981,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5967,
+    key.offset: 5987,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "_InternalProt",
     key.usr: "c:objc(pl)_InternalProt",
-    key.offset: 5991,
+    key.offset: 6011,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6009,
+    key.offset: 6029,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6015,
+    key.offset: 6035,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 6043,
+    key.offset: 6063,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6063,
+    key.offset: 6083,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6067,
+    key.offset: 6087,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6079,
+    key.offset: 6099,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6089,
+    key.offset: 6109,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6093,
+    key.offset: 6113,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6111,
+    key.offset: 6131,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6121,
+    key.offset: 6141,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6125,
+    key.offset: 6145,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6137,
+    key.offset: 6157,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6147,
+    key.offset: 6167,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6151,
+    key.offset: 6171,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6162,
+    key.offset: 6182,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6172,
+    key.offset: 6192,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6176,
+    key.offset: 6196,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6186,
+    key.offset: 6206,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6196,
+    key.offset: 6216,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6200,
+    key.offset: 6220,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6209,
+    key.offset: 6229,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6219,
+    key.offset: 6239,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6223,
+    key.offset: 6243,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 6231,
+    key.offset: 6251,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6242,
+    key.offset: 6262,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6247,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 6267,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6277,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6282,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6302,
+    key.offset: 6287,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6312,
+    key.offset: 6297,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6317,
+    key.offset: 6302,
+    key.length: 14
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 6322,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 6332,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 6337,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6338,
+    key.offset: 6358,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6348,
+    key.offset: 6368,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6353,
+    key.offset: 6373,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6373,
+    key.offset: 6393,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6380,
+    key.offset: 6400,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6384,
+    key.offset: 6404,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6396,
+    key.offset: 6416,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6402,
+    key.offset: 6422,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 6426,
+    key.offset: 6446,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6446,
+    key.offset: 6466,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6458,
+    key.offset: 6478,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 6464,
+    key.offset: 6484,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 6468,
+    key.offset: 6488,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6464,
+    key.offset: 6484,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6468,
+    key.offset: 6488,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 6471,
+    key.offset: 6491,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6483,
+    key.offset: 6503,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6489,
+    key.offset: 6509,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6494,
+    key.offset: 6514,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 6502,
+    key.offset: 6522,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 6504,
+    key.offset: 6524,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6504,
+    key.offset: 6524,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 6507,
+    key.offset: 6527,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooUnavailableMembers",
     key.usr: "c:objc(cs)FooUnavailableMembers",
-    key.offset: 6517,
+    key.offset: 6537,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6528,
+    key.offset: 6548,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6533,
+    key.offset: 6553,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6552,
+    key.offset: 6572,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6557,
+    key.offset: 6577,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6581,
+    key.offset: 6601,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6586,
+    key.offset: 6606,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6604,
+    key.offset: 6624,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6609,
+    key.offset: 6629,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6639,
+    key.offset: 6659,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6644,
+    key.offset: 6664,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6674,
+    key.offset: 6694,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6679,
+    key.offset: 6699,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6708,
+    key.offset: 6728,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6713,
+    key.offset: 6733,
     key.length: 23
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6744,
+    key.offset: 6764,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6749,
+    key.offset: 6769,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6782,
+    key.offset: 6802,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6787,
+    key.offset: 6807,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6820,
+    key.offset: 6840,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6825,
+    key.offset: 6845,
     key.length: 24
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6857,
+    key.offset: 6877,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6862,
+    key.offset: 6882,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6896,
+    key.offset: 6916,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6901,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 6921,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6931,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6936,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6956,
+    key.offset: 6941,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6966,
+    key.offset: 6951,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6971,
+    key.offset: 6956,
+    key.length: 14
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 6976,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 6986,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 6991,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6992,
+    key.offset: 7012,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7002,
+    key.offset: 7022,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7007,
+    key.offset: 7027,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7027,
+    key.offset: 7047,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7034,
+    key.offset: 7054,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7040,
+    key.offset: 7060,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7054,
+    key.offset: 7074,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7059,
+    key.offset: 7079,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 7076,
+    key.offset: 7096,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 7078,
+    key.offset: 7098,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooCFType",
     key.usr: "c:Foo.h@T@FooCFTypeRef",
-    key.offset: 7081,
+    key.offset: 7101,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7093,
+    key.offset: 7113,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7098,
+    key.offset: 7118,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 7110,
+    key.offset: 7130,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 7112,
+    key.offset: 7132,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7112,
+    key.offset: 7132,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 7115,
+    key.offset: 7135,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 7125,
+    key.offset: 7145,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7131,
+    key.offset: 7151,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7138,
+    key.offset: 7158,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "RawRepresentable",
     key.usr: "s:Ps16RawRepresentable",
-    key.offset: 7152,
+    key.offset: 7172,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Equatable",
     key.usr: "s:Ps9Equatable",
-    key.offset: 7170,
+    key.offset: 7190,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7187,
+    key.offset: 7207,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 7192,
+    key.offset: 7212,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 7194,
+    key.offset: 7214,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7194,
+    key.offset: 7214,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:Vs6UInt32",
-    key.offset: 7204,
+    key.offset: 7224,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7217,
+    key.offset: 7237,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 7222,
+    key.offset: 7242,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 7231,
+    key.offset: 7251,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7222,
+    key.offset: 7242,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7231,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "UInt32",
-    key.usr: "s:Vs6UInt32",
-    key.offset: 7241,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7254,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7258,
+    key.offset: 7251,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:Vs6UInt32",
-    key.offset: 7268,
+    key.offset: 7261,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7277,
+    key.offset: 7274,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7281,
+    key.offset: 7278,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "UInt32",
+    key.usr: "s:Vs6UInt32",
+    key.offset: 7288,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 7297,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 7301,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 7295,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7309,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 7315,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 7329,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 7335,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7319,
+    key.offset: 7339,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 7333,
+    key.offset: 7353,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7347,
+    key.offset: 7367,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7353,
+    key.offset: 7373,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7357,
+    key.offset: 7377,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 7384,
+    key.offset: 7404,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7390,
+    key.offset: 7410,
     key.length: 3
   }
 ]
@@ -6084,15 +6104,15 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "fooFuncWithBlock(_:)",
     key.usr: "c:@F@fooFuncWithBlock",
     key.offset: 3739,
-    key.length: 49,
-    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithBlock</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>blk</decl.var.parameter.name>: <decl.var.parameter.type>((<ref.struct usr=\"s:Sf\">Float</ref.struct>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.function.returntype>)!</decl.var.parameter.type></decl.var.parameter>)</decl.function.free>",
+    key.length: 59,
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithBlock</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>blk</decl.var.parameter.name>: <decl.var.parameter.type>(@escaping (<ref.struct usr=\"s:Sf\">Float</ref.struct>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.function.returntype>)!</decl.var.parameter.type></decl.var.parameter>)</decl.function.free>",
     key.entities: [
       {
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "blk",
         key.offset: 3768,
-        key.length: 19
+        key.length: 29
       }
     ]
   },
@@ -6100,16 +6120,16 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fooFuncWithFunctionPointer(_:)",
     key.usr: "c:@F@fooFuncWithFunctionPointer",
-    key.offset: 3789,
-    key.length: 60,
-    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithFunctionPointer</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>fptr</decl.var.parameter.name>: <decl.var.parameter.type>((<ref.struct usr=\"s:Sf\">Float</ref.struct>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.function.returntype>)!</decl.var.parameter.type></decl.var.parameter>)</decl.function.free>",
+    key.offset: 3799,
+    key.length: 70,
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithFunctionPointer</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>fptr</decl.var.parameter.name>: <decl.var.parameter.type>(@escaping (<ref.struct usr=\"s:Sf\">Float</ref.struct>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.function.returntype>)!</decl.var.parameter.type></decl.var.parameter>)</decl.function.free>",
     key.entities: [
       {
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "fptr",
-        key.offset: 3829,
-        key.length: 19
+        key.offset: 3839,
+        key.length: 29
       }
     ]
   },
@@ -6117,7 +6137,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fooFuncNoreturn1()",
     key.usr: "c:@F@fooFuncNoreturn1",
-    key.offset: 3850,
+    key.offset: 3870,
     key.length: 32,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncNoreturn1</decl.name>() -&gt; <decl.function.returntype><ref.enum usr=\"s:Os5Never\">Never</ref.enum></decl.function.returntype></decl.function.free>"
   },
@@ -6125,7 +6145,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fooFuncNoreturn2()",
     key.usr: "c:@F@fooFuncNoreturn2",
-    key.offset: 3883,
+    key.offset: 3903,
     key.length: 32,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncNoreturn2</decl.name>() -&gt; <decl.function.returntype><ref.enum usr=\"s:Os5Never\">Never</ref.enum></decl.function.returntype></decl.function.free>"
   },
@@ -6134,7 +6154,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "fooFuncWithComment1()",
     key.usr: "c:@F@fooFuncWithComment1",
     key.doc.full_as_xml: "<Function file=Foo.h line=\"88\" column=\"6\"><Name>fooFuncWithComment1</Name><USR>c:@F@fooFuncWithComment1</USR><Declaration>func fooFuncWithComment1()</Declaration><Abstract><Para> Aaa.  fooFuncWithComment1.  Bbb. Ccc.</Para></Abstract><Discussion><Para> Ddd.</Para></Discussion></Function>",
-    key.offset: 3916,
+    key.offset: 3936,
     key.length: 26,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithComment1</decl.name>()</decl.function.free>"
   },
@@ -6143,7 +6163,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "fooFuncWithComment2()",
     key.usr: "c:@F@fooFuncWithComment2",
     key.doc.full_as_xml: "<Function file=Foo.h line=\"93\" column=\"6\"><Name>fooFuncWithComment2</Name><USR>c:@F@fooFuncWithComment2</USR><Declaration>func fooFuncWithComment2()</Declaration><Abstract><Para>  Aaa.  fooFuncWithComment2.  Bbb.</Para></Abstract></Function>",
-    key.offset: 3943,
+    key.offset: 3963,
     key.length: 26,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithComment2</decl.name>()</decl.function.free>"
   },
@@ -6152,7 +6172,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "fooFuncWithComment3()",
     key.usr: "c:@F@fooFuncWithComment3",
     key.doc.full_as_xml: "<Function file=Foo.h line=\"101\" column=\"6\"><Name>fooFuncWithComment3</Name><USR>c:@F@fooFuncWithComment3</USR><Declaration>func fooFuncWithComment3()</Declaration><Abstract><Para> Aaa.  fooFuncWithComment3.  Bbb.</Para></Abstract><Discussion><Para> Ccc.</Para></Discussion></Function>",
-    key.offset: 3970,
+    key.offset: 3990,
     key.length: 26,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithComment3</decl.name>()</decl.function.free>"
   },
@@ -6161,7 +6181,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "fooFuncWithComment4()",
     key.usr: "c:@F@fooFuncWithComment4",
     key.doc.full_as_xml: "<Function file=Foo.h line=\"107\" column=\"6\"><Name>fooFuncWithComment4</Name><USR>c:@F@fooFuncWithComment4</USR><Declaration>func fooFuncWithComment4()</Declaration><Abstract><Para> Aaa.  fooFuncWithComment4.  Bbb.</Para></Abstract><Discussion><Para> Ddd.</Para></Discussion></Function>",
-    key.offset: 3997,
+    key.offset: 4017,
     key.length: 26,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithComment4</decl.name>()</decl.function.free>"
   },
@@ -6170,7 +6190,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "fooFuncWithComment5()",
     key.usr: "c:@F@fooFuncWithComment5",
     key.doc.full_as_xml: "<Function file=Foo.h line=\"113\" column=\"6\"><Name>fooFuncWithComment5</Name><USR>c:@F@fooFuncWithComment5</USR><Declaration>func fooFuncWithComment5()</Declaration><Abstract><Para> Aaa.  fooFuncWithComment5.  Bbb. Ccc.</Para></Abstract><Discussion><Para> Ddd.</Para></Discussion></Function>",
-    key.offset: 4024,
+    key.offset: 4044,
     key.length: 26,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithComment5</decl.name>()</decl.function.free>"
   },
@@ -6179,7 +6199,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "redeclaredInMultipleModulesFunc1(_:)",
     key.usr: "c:@F@redeclaredInMultipleModulesFunc1",
     key.doc.full_as_xml: "<Function file=Foo.h line=\"117\" column=\"5\"><Name>redeclaredInMultipleModulesFunc1</Name><USR>c:@F@redeclaredInMultipleModulesFunc1</USR><Declaration>func redeclaredInMultipleModulesFunc1(_ a: Int32) -> Int32</Declaration><Abstract><Para> Aaa.  redeclaredInMultipleModulesFunc1.  Bbb.</Para></Abstract></Function>",
-    key.offset: 4051,
+    key.offset: 4071,
     key.length: 58,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>redeclaredInMultipleModulesFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
     key.entities: [
@@ -6187,7 +6207,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "a",
-        key.offset: 4094,
+        key.offset: 4114,
         key.length: 5
       }
     ]
@@ -6197,7 +6217,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "FooProtocolBase",
     key.usr: "c:objc(pl)FooProtocolBase",
     key.doc.full_as_xml: "<Other file=Foo.h line=\"120\" column=\"11\"><Name>FooProtocolBase</Name><USR>c:objc(pl)FooProtocolBase</USR><Declaration>protocol FooProtocolBase</Declaration><Abstract><Para> Aaa.  FooProtocolBase.  Bbb.</Para></Abstract></Other>",
-    key.offset: 4110,
+    key.offset: 4130,
     key.length: 301,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>FooProtocolBase</decl.name></decl.protocol>",
     key.entities: [
@@ -6206,7 +6226,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "fooProtoFunc()",
         key.usr: "c:objc(pl)FooProtocolBase(im)fooProtoFunc",
         key.doc.full_as_xml: "<Function isInstanceMethod=\"1\" file=Foo.h line=\"124\" column=\"1\"><Name>fooProtoFunc</Name><USR>c:objc(pl)FooProtocolBase(im)fooProtoFunc</USR><Declaration>func fooProtoFunc()</Declaration><Abstract><Para> Aaa.  fooProtoFunc.  Bbb. Ccc.</Para></Abstract></Function>",
-        key.offset: 4142,
+        key.offset: 4162,
         key.length: 19,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooProtoFunc</decl.name>()</decl.function.method.instance>"
       },
@@ -6215,7 +6235,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "fooProtoFuncWithExtraIndentation1()",
         key.usr: "c:objc(pl)FooProtocolBase(im)fooProtoFuncWithExtraIndentation1",
         key.doc.full_as_xml: "<Function isInstanceMethod=\"1\" file=Foo.h line=\"128\" column=\"3\"><Name>fooProtoFuncWithExtraIndentation1</Name><USR>c:objc(pl)FooProtocolBase(im)fooProtoFuncWithExtraIndentation1</USR><Declaration>func fooProtoFuncWithExtraIndentation1()</Declaration><Abstract><Para> Aaa.  fooProtoFuncWithExtraIndentation1.  Bbb. Ccc.</Para></Abstract></Function>",
-        key.offset: 4167,
+        key.offset: 4187,
         key.length: 40,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooProtoFuncWithExtraIndentation1</decl.name>()</decl.function.method.instance>"
       },
@@ -6224,7 +6244,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "fooProtoFuncWithExtraIndentation2()",
         key.usr: "c:objc(pl)FooProtocolBase(im)fooProtoFuncWithExtraIndentation2",
         key.doc.full_as_xml: "<Function isInstanceMethod=\"1\" file=Foo.h line=\"134\" column=\"3\"><Name>fooProtoFuncWithExtraIndentation2</Name><USR>c:objc(pl)FooProtocolBase(im)fooProtoFuncWithExtraIndentation2</USR><Declaration>func fooProtoFuncWithExtraIndentation2()</Declaration><Abstract><Para> Aaa.  fooProtoFuncWithExtraIndentation2.  Bbb. Ccc.</Para></Abstract></Function>",
-        key.offset: 4213,
+        key.offset: 4233,
         key.length: 40,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooProtoFuncWithExtraIndentation2</decl.name>()</decl.function.method.instance>"
       },
@@ -6232,7 +6252,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.static,
         key.name: "fooProtoClassFunc()",
         key.usr: "c:objc(pl)FooProtocolBase(cm)fooProtoClassFunc",
-        key.offset: 4259,
+        key.offset: 4279,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.method.static><syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooProtoClassFunc</decl.name>()</decl.function.method.static>"
       },
@@ -6240,7 +6260,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "fooProperty1",
         key.usr: "c:objc(pl)FooProtocolBase(py)fooProperty1",
-        key.offset: 4296,
+        key.offset: 4316,
         key.length: 35,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>fooProperty1</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6248,7 +6268,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "fooProperty2",
         key.usr: "c:objc(pl)FooProtocolBase(py)fooProperty2",
-        key.offset: 4337,
+        key.offset: 4357,
         key.length: 35,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>fooProperty2</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6256,7 +6276,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "fooProperty3",
         key.usr: "c:objc(pl)FooProtocolBase(py)fooProperty3",
-        key.offset: 4378,
+        key.offset: 4398,
         key.length: 31,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>fooProperty3</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       }
@@ -6266,7 +6286,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.protocol,
     key.name: "FooProtocolDerived",
     key.usr: "c:objc(pl)FooProtocolDerived",
-    key.offset: 4412,
+    key.offset: 4432,
     key.length: 49,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>FooProtocolDerived</decl.name> : <ref.protocol usr=\"c:objc(pl)FooProtocolBase\">FooProtocolBase</ref.protocol></decl.protocol>",
     key.conforms: [
@@ -6281,7 +6301,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 4462,
+    key.offset: 4482,
     key.length: 392,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>FooClassBase</decl.name></decl.class>",
     key.entities: [
@@ -6289,7 +6309,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooBaseInstanceFunc0()",
         key.usr: "c:objc(cs)FooClassBase(im)fooBaseInstanceFunc0",
-        key.offset: 4488,
+        key.offset: 4508,
         key.length: 27,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooBaseInstanceFunc0</decl.name>()</decl.function.method.instance>"
       },
@@ -6297,7 +6317,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooBaseInstanceFunc1(_:)",
         key.usr: "c:objc(cs)FooClassBase(im)fooBaseInstanceFunc1:",
-        key.offset: 4521,
+        key.offset: 4541,
         key.length: 60,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooBaseInstanceFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>anObject</decl.var.parameter.name>: <decl.var.parameter.type>Any!</decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class>!</decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -6305,7 +6325,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "anObject",
-            key.offset: 4559,
+            key.offset: 4579,
             key.length: 4
           }
         ]
@@ -6314,7 +6334,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
         key.usr: "c:objc(cs)FooClassBase(im)init",
-        key.offset: 4587,
+        key.offset: 4607,
         key.length: 7,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>!()</decl.function.constructor>"
       },
@@ -6322,7 +6342,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(float:)",
         key.usr: "c:objc(cs)FooClassBase(im)initWithFloat:",
-        key.offset: 4600,
+        key.offset: 4620,
         key.length: 33,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>convenience</syntaxtype.keyword> <syntaxtype.keyword>init</syntaxtype.keyword>!(<decl.var.parameter><decl.var.parameter.argument_label>float</decl.var.parameter.argument_label> <decl.var.parameter.name>f</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Sf\">Float</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -6330,7 +6350,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "float",
             key.name: "f",
-            key.offset: 4627,
+            key.offset: 4647,
             key.length: 5
           }
         ]
@@ -6339,7 +6359,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooBaseInstanceFuncOverridden()",
         key.usr: "c:objc(cs)FooClassBase(im)fooBaseInstanceFuncOverridden",
-        key.offset: 4639,
+        key.offset: 4659,
         key.length: 36,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooBaseInstanceFuncOverridden</decl.name>()</decl.function.method.instance>"
       },
@@ -6347,7 +6367,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.class,
         key.name: "fooBaseClassFunc0()",
         key.usr: "c:objc(cs)FooClassBase(cm)fooBaseClassFunc0",
-        key.offset: 4681,
+        key.offset: 4701,
         key.length: 30,
         key.fully_annotated_decl: "<decl.function.method.class><syntaxtype.keyword>class</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooBaseClassFunc0</decl.name>()</decl.function.method.class>"
       },
@@ -6355,7 +6375,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "_internalMeth3()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
-        key.offset: 4717,
+        key.offset: 4737,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -6363,7 +6383,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "_internalMeth2()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth2",
-        key.offset: 4752,
+        key.offset: 4772,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth2</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -6371,7 +6391,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "nonInternalMeth()",
         key.usr: "c:objc(cs)FooClassBase(im)nonInternalMeth",
-        key.offset: 4787,
+        key.offset: 4807,
         key.length: 30,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>nonInternalMeth</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -6379,7 +6399,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "_internalMeth1()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
-        key.offset: 4823,
+        key.offset: 4843,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       }
@@ -6390,7 +6410,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "FooClassDerived",
     key.usr: "c:objc(cs)FooClassDerived",
     key.doc.full_as_xml: "<Other file=Foo.h line=\"157\" column=\"12\"><Name>FooClassDerived</Name><USR>c:objc(cs)FooClassDerived</USR><Declaration>class FooClassDerived : FooClassBase, FooProtocolDerived</Declaration><Abstract><Para> Aaa.  FooClassDerived.  Bbb.</Para></Abstract></Other>",
-    key.offset: 4855,
+    key.offset: 4875,
     key.length: 493,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>FooClassDerived</decl.name> : <ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class>, <ref.protocol usr=\"c:objc(pl)FooProtocolDerived\">FooProtocolDerived</ref.protocol></decl.class>",
     key.inherits: [
@@ -6412,7 +6432,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "fooProperty1",
         key.usr: "c:objc(cs)FooClassDerived(py)fooProperty1",
-        key.offset: 4919,
+        key.offset: 4939,
         key.length: 23,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>fooProperty1</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6420,7 +6440,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "fooProperty2",
         key.usr: "c:objc(cs)FooClassDerived(py)fooProperty2",
-        key.offset: 4948,
+        key.offset: 4968,
         key.length: 23,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>fooProperty2</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6428,7 +6448,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "fooProperty3",
         key.usr: "c:objc(cs)FooClassDerived(py)fooProperty3",
-        key.offset: 4977,
+        key.offset: 4997,
         key.length: 31,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>fooProperty3</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6436,7 +6456,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooInstanceFunc0()",
         key.usr: "c:objc(cs)FooClassDerived(im)fooInstanceFunc0",
-        key.offset: 5014,
+        key.offset: 5034,
         key.length: 23,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooInstanceFunc0</decl.name>()</decl.function.method.instance>"
       },
@@ -6444,7 +6464,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooInstanceFunc1(_:)",
         key.usr: "c:objc(cs)FooClassDerived(im)fooInstanceFunc1:",
-        key.offset: 5043,
+        key.offset: 5063,
         key.length: 33,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooInstanceFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -6452,7 +6472,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "a",
-            key.offset: 5070,
+            key.offset: 5090,
             key.length: 5
           }
         ]
@@ -6461,7 +6481,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooInstanceFunc2(_:withB:)",
         key.usr: "c:objc(cs)FooClassDerived(im)fooInstanceFunc2:withB:",
-        key.offset: 5082,
+        key.offset: 5102,
         key.length: 49,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooInstanceFunc2</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>withB</decl.var.parameter.argument_label> <decl.var.parameter.name>b</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -6469,14 +6489,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "a",
-            key.offset: 5109,
+            key.offset: 5129,
             key.length: 5
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "withB",
             key.name: "b",
-            key.offset: 5125,
+            key.offset: 5145,
             key.length: 5
           }
         ]
@@ -6485,7 +6505,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooBaseInstanceFuncOverridden()",
         key.usr: "c:objc(cs)FooClassDerived(im)fooBaseInstanceFuncOverridden",
-        key.offset: 5137,
+        key.offset: 5157,
         key.length: 36,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooBaseInstanceFuncOverridden</decl.name>()</decl.function.method.instance>",
         key.inherits: [
@@ -6500,7 +6520,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.class,
         key.name: "fooClassFunc0()",
         key.usr: "c:objc(cs)FooClassDerived(cm)fooClassFunc0",
-        key.offset: 5179,
+        key.offset: 5199,
         key.length: 26,
         key.fully_annotated_decl: "<decl.function.method.class><syntaxtype.keyword>class</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooClassFunc0</decl.name>()</decl.function.method.class>"
       },
@@ -6509,7 +6529,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "_internalMeth3()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3::SYNTHESIZED::c:objc(cs)FooClassDerived",
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
-        key.offset: 5211,
+        key.offset: 5231,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -6518,7 +6538,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "_internalMeth2()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth2::SYNTHESIZED::c:objc(cs)FooClassDerived",
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth2",
-        key.offset: 5246,
+        key.offset: 5266,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth2</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -6527,7 +6547,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "nonInternalMeth()",
         key.usr: "c:objc(cs)FooClassBase(im)nonInternalMeth::SYNTHESIZED::c:objc(cs)FooClassDerived",
         key.original_usr: "c:objc(cs)FooClassBase(im)nonInternalMeth",
-        key.offset: 5281,
+        key.offset: 5301,
         key.length: 30,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>nonInternalMeth</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -6536,7 +6556,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "_internalMeth1()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1::SYNTHESIZED::c:objc(cs)FooClassDerived",
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
-        key.offset: 5317,
+        key.offset: 5337,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       }
@@ -6546,7 +6566,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_1",
     key.usr: "c:Foo.h@3647@macro@FOO_MACRO_1",
-    key.offset: 5349,
+    key.offset: 5369,
     key.length: 30,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_1</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6554,7 +6574,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_2",
     key.usr: "c:Foo.h@3669@macro@FOO_MACRO_2",
-    key.offset: 5380,
+    key.offset: 5400,
     key.length: 30,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_2</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6562,7 +6582,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_3",
     key.usr: "c:Foo.h@3691@macro@FOO_MACRO_3",
-    key.offset: 5411,
+    key.offset: 5431,
     key.length: 30,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_3</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6570,7 +6590,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_4",
     key.usr: "c:Foo.h@3755@macro@FOO_MACRO_4",
-    key.offset: 5442,
+    key.offset: 5462,
     key.length: 31,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_4</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs6UInt32\">UInt32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6578,7 +6598,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_5",
     key.usr: "c:Foo.h@3787@macro@FOO_MACRO_5",
-    key.offset: 5474,
+    key.offset: 5494,
     key.length: 31,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_5</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs6UInt64\">UInt64</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6586,7 +6606,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_REDEF_1",
     key.usr: "c:Foo.h@3937@macro@FOO_MACRO_REDEF_1",
-    key.offset: 5506,
+    key.offset: 5526,
     key.length: 36,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_REDEF_1</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6594,7 +6614,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_REDEF_2",
     key.usr: "c:Foo.h@3994@macro@FOO_MACRO_REDEF_2",
-    key.offset: 5543,
+    key.offset: 5563,
     key.length: 36,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_REDEF_2</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6602,7 +6622,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "theLastDeclInFoo()",
     key.usr: "c:@F@theLastDeclInFoo",
-    key.offset: 5580,
+    key.offset: 5600,
     key.length: 23,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>theLastDeclInFoo</decl.name>()</decl.function.free>"
   },
@@ -6610,7 +6630,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "_internalTopLevelFunc()",
     key.usr: "c:@F@_internalTopLevelFunc",
-    key.offset: 5604,
+    key.offset: 5624,
     key.length: 28,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalTopLevelFunc</decl.name>()</decl.function.free>"
   },
@@ -6618,7 +6638,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.struct,
     key.name: "_InternalStruct",
     key.usr: "c:@S@_InternalStruct",
-    key.offset: 5633,
+    key.offset: 5653,
     key.length: 78,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>_InternalStruct</decl.name></decl.struct>",
     key.entities: [
@@ -6626,7 +6646,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "x",
         key.usr: "c:@S@_InternalStruct@FI@x",
-        key.offset: 5663,
+        key.offset: 5683,
         key.length: 12,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>x</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.type></decl.var.instance>"
       },
@@ -6634,7 +6654,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
         key.usr: "s:FVSC15_InternalStructcFT_S_",
-        key.offset: 5681,
+        key.offset: 5701,
         key.length: 6,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
       },
@@ -6642,7 +6662,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(x:)",
         key.usr: "s:FVSC15_InternalStructcFT1xVs5Int32_S_",
-        key.offset: 5693,
+        key.offset: 5713,
         key.length: 16,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -6650,7 +6670,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "x",
             key.name: "x",
-            key.offset: 5703,
+            key.offset: 5723,
             key.length: 5
           }
         ]
@@ -6659,7 +6679,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   },
   {
     key.kind: source.lang.swift.decl.extension.class,
-    key.offset: 5712,
+    key.offset: 5732,
     key.length: 61,
     key.extends: {
       key.kind: source.lang.swift.ref.class,
@@ -6671,7 +6691,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "_internalMeth1()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
-        key.offset: 5742,
+        key.offset: 5762,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       }
@@ -6679,7 +6699,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   },
   {
     key.kind: source.lang.swift.decl.extension.class,
-    key.offset: 5774,
+    key.offset: 5794,
     key.length: 97,
     key.extends: {
       key.kind: source.lang.swift.ref.class,
@@ -6691,7 +6711,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "_internalMeth2()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth2",
-        key.offset: 5804,
+        key.offset: 5824,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth2</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -6699,7 +6719,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "nonInternalMeth()",
         key.usr: "c:objc(cs)FooClassBase(im)nonInternalMeth",
-        key.offset: 5839,
+        key.offset: 5859,
         key.length: 30,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>nonInternalMeth</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       }
@@ -6707,7 +6727,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   },
   {
     key.kind: source.lang.swift.decl.extension.class,
-    key.offset: 5872,
+    key.offset: 5892,
     key.length: 61,
     key.extends: {
       key.kind: source.lang.swift.ref.class,
@@ -6719,7 +6739,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "_internalMeth3()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
-        key.offset: 5902,
+        key.offset: 5922,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       }
@@ -6729,7 +6749,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.protocol,
     key.name: "_InternalProt",
     key.usr: "c:objc(pl)_InternalProt",
-    key.offset: 5934,
+    key.offset: 5954,
     key.length: 26,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>_InternalProt</decl.name></decl.protocol>"
   },
@@ -6737,7 +6757,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.class,
     key.name: "ClassWithInternalProt",
     key.usr: "c:objc(cs)ClassWithInternalProt",
-    key.offset: 5961,
+    key.offset: 5981,
     key.length: 47,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>ClassWithInternalProt</decl.name> : <ref.protocol usr=\"c:objc(pl)_InternalProt\">_InternalProt</ref.protocol></decl.class>",
     key.conforms: [
@@ -6752,7 +6772,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.class,
     key.name: "FooClassPropertyOwnership",
     key.usr: "c:objc(cs)FooClassPropertyOwnership",
-    key.offset: 6009,
+    key.offset: 6029,
     key.length: 370,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>FooClassPropertyOwnership</decl.name> : <ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class></decl.class>",
     key.inherits: [
@@ -6767,7 +6787,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "assignable",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)assignable",
-        key.offset: 6063,
+        key.offset: 6083,
         key.length: 20,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>assignable</decl.name>: <decl.var.type>Any!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6775,7 +6795,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "unsafeAssignable",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)unsafeAssignable",
-        key.offset: 6089,
+        key.offset: 6109,
         key.length: 26,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>unsafeAssignable</decl.name>: <decl.var.type>Any!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6783,7 +6803,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "retainable",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)retainable",
-        key.offset: 6121,
+        key.offset: 6141,
         key.length: 20,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>retainable</decl.name>: <decl.var.type>Any!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6791,7 +6811,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "strongRef",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)strongRef",
-        key.offset: 6147,
+        key.offset: 6167,
         key.length: 19,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>strongRef</decl.name>: <decl.var.type>Any!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6799,7 +6819,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "copyable",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)copyable",
-        key.offset: 6172,
+        key.offset: 6192,
         key.length: 18,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>copyable</decl.name>: <decl.var.type>Any!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6807,7 +6827,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "weakRef",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)weakRef",
-        key.offset: 6196,
+        key.offset: 6216,
         key.length: 17,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>weakRef</decl.name>: <decl.var.type>Any!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6815,7 +6835,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "scalar",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)scalar",
-        key.offset: 6219,
+        key.offset: 6239,
         key.length: 17,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>scalar</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6824,7 +6844,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "_internalMeth3()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3::SYNTHESIZED::c:objc(cs)FooClassPropertyOwnership",
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
-        key.offset: 6242,
+        key.offset: 6262,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -6833,7 +6853,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "_internalMeth2()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth2::SYNTHESIZED::c:objc(cs)FooClassPropertyOwnership",
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth2",
-        key.offset: 6277,
+        key.offset: 6297,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth2</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -6842,7 +6862,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "nonInternalMeth()",
         key.usr: "c:objc(cs)FooClassBase(im)nonInternalMeth::SYNTHESIZED::c:objc(cs)FooClassPropertyOwnership",
         key.original_usr: "c:objc(cs)FooClassBase(im)nonInternalMeth",
-        key.offset: 6312,
+        key.offset: 6332,
         key.length: 30,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>nonInternalMeth</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -6851,7 +6871,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "_internalMeth1()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1::SYNTHESIZED::c:objc(cs)FooClassPropertyOwnership",
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
-        key.offset: 6348,
+        key.offset: 6368,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       }
@@ -6861,7 +6881,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_NIL",
     key.usr: "c:Foo.h@4783@macro@FOO_NIL",
-    key.offset: 6380,
+    key.offset: 6400,
     key.length: 15,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_NIL</decl.name>: <decl.var.type><tuple>()</tuple></decl.var.type></decl.var.global>",
     key.attributes: [
@@ -6877,7 +6897,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.class,
     key.name: "FooUnavailableMembers",
     key.usr: "c:objc(cs)FooUnavailableMembers",
-    key.offset: 6396,
+    key.offset: 6416,
     key.length: 637,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>FooUnavailableMembers</decl.name> : <ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class></decl.class>",
     key.inherits: [
@@ -6892,7 +6912,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(int:)",
         key.usr: "c:objc(cs)FooUnavailableMembers(cm)unavailableMembersWithInt:",
-        key.offset: 6446,
+        key.offset: 6466,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>convenience</syntaxtype.keyword> <syntaxtype.keyword>init</syntaxtype.keyword>!(<decl.var.parameter><decl.var.parameter.argument_label>int</decl.var.parameter.argument_label> <decl.var.parameter.name>i</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -6900,7 +6920,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "int",
             key.name: "i",
-            key.offset: 6471,
+            key.offset: 6491,
             key.length: 5
           }
         ]
@@ -6909,7 +6929,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.class,
         key.name: "withInt(_:)",
         key.usr: "c:objc(cs)FooUnavailableMembers(cm)unavailableMembersWithInt:",
-        key.offset: 6483,
+        key.offset: 6503,
         key.length: 39,
         key.fully_annotated_decl: "<decl.function.method.class><syntaxtype.keyword>class</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>withInt</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>i</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.class usr=\"c:objc(cs)FooUnavailableMembers\">Self</ref.class>!</decl.function.returntype></decl.function.method.class>",
         key.entities: [
@@ -6917,7 +6937,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "i",
-            key.offset: 6507,
+            key.offset: 6527,
             key.length: 5
           }
         ],
@@ -6934,7 +6954,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "unavailable()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)unavailable",
-        key.offset: 6528,
+        key.offset: 6548,
         key.length: 18,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>unavailable</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -6950,7 +6970,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "swiftUnavailable()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)swiftUnavailable",
-        key.offset: 6552,
+        key.offset: 6572,
         key.length: 23,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>swiftUnavailable</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -6965,7 +6985,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "deprecated()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)deprecated",
-        key.offset: 6581,
+        key.offset: 6601,
         key.length: 17,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>deprecated</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -6981,7 +7001,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityIntroduced()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityIntroduced",
-        key.offset: 6604,
+        key.offset: 6624,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityIntroduced</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -6996,7 +7016,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityDeprecated()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityDeprecated",
-        key.offset: 6639,
+        key.offset: 6659,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityDeprecated</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -7015,7 +7035,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityObsoleted()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityObsoleted",
-        key.offset: 6674,
+        key.offset: 6694,
         key.length: 28,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityObsoleted</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -7031,7 +7051,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityUnavailable()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityUnavailable",
-        key.offset: 6708,
+        key.offset: 6728,
         key.length: 30,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityUnavailable</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -7047,7 +7067,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityIntroducedMsg()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityIntroducedMsg",
-        key.offset: 6744,
+        key.offset: 6764,
         key.length: 32,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityIntroducedMsg</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -7063,7 +7083,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityDeprecatedMsg()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityDeprecatedMsg",
-        key.offset: 6782,
+        key.offset: 6802,
         key.length: 32,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityDeprecatedMsg</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -7082,7 +7102,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityObsoletedMsg()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityObsoletedMsg",
-        key.offset: 6820,
+        key.offset: 6840,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityObsoletedMsg</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -7099,7 +7119,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityUnavailableMsg()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityUnavailableMsg",
-        key.offset: 6857,
+        key.offset: 6877,
         key.length: 33,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityUnavailableMsg</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -7117,7 +7137,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "_internalMeth3()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3::SYNTHESIZED::c:objc(cs)FooUnavailableMembers",
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
-        key.offset: 6896,
+        key.offset: 6916,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -7126,7 +7146,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "_internalMeth2()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth2::SYNTHESIZED::c:objc(cs)FooUnavailableMembers",
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth2",
-        key.offset: 6931,
+        key.offset: 6951,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth2</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -7135,7 +7155,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "nonInternalMeth()",
         key.usr: "c:objc(cs)FooClassBase(im)nonInternalMeth::SYNTHESIZED::c:objc(cs)FooUnavailableMembers",
         key.original_usr: "c:objc(cs)FooClassBase(im)nonInternalMeth",
-        key.offset: 6966,
+        key.offset: 6986,
         key.length: 30,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>nonInternalMeth</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -7144,7 +7164,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "_internalMeth1()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1::SYNTHESIZED::c:objc(cs)FooUnavailableMembers",
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
-        key.offset: 7002,
+        key.offset: 7022,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       }
@@ -7154,7 +7174,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.class,
     key.name: "FooCFType",
     key.usr: "c:Foo.h@T@FooCFTypeRef",
-    key.offset: 7034,
+    key.offset: 7054,
     key.length: 19,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>FooCFType</decl.name></decl.class>"
   },
@@ -7162,14 +7182,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "FooCFTypeRelease(_:)",
     key.usr: "c:@F@FooCFTypeRelease",
-    key.offset: 7054,
+    key.offset: 7074,
     key.length: 38,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>FooCFTypeRelease</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.class usr=\"c:Foo.h@T@FooCFTypeRef\">FooCFType</ref.class>!</decl.var.parameter.type></decl.var.parameter>)</decl.function.free>",
     key.entities: [
       {
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
-        key.offset: 7081,
+        key.offset: 7101,
         key.length: 10
       }
     ],
@@ -7186,7 +7206,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fooSubFunc1(_:)",
     key.usr: "c:@F@fooSubFunc1",
-    key.offset: 7093,
+    key.offset: 7113,
     key.length: 37,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooSubFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
     key.entities: [
@@ -7194,7 +7214,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "a",
-        key.offset: 7115,
+        key.offset: 7135,
         key.length: 5
       }
     ]
@@ -7203,7 +7223,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 7131,
+    key.offset: 7151,
     key.length: 145,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>FooSubEnum1</decl.name> : <ref.protocol usr=\"s:Ps16RawRepresentable\">RawRepresentable</ref.protocol>, <ref.protocol usr=\"s:Ps9Equatable\">Equatable</ref.protocol></decl.struct>",
     key.conforms: [
@@ -7223,7 +7243,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(_:)",
         key.usr: "s:FVSC11FooSubEnum1cFVs6UInt32S_",
-        key.offset: 7187,
+        key.offset: 7207,
         key.length: 24,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>rawValue</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs6UInt32\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -7231,7 +7251,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "rawValue",
-            key.offset: 7204,
+            key.offset: 7224,
             key.length: 6
           }
         ]
@@ -7240,7 +7260,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(rawValue:)",
         key.usr: "s:FVSC11FooSubEnum1cFT8rawValueVs6UInt32_S_",
-        key.offset: 7217,
+        key.offset: 7237,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>rawValue</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Vs6UInt32\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.conforms: [
@@ -7255,7 +7275,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "rawValue",
             key.name: "rawValue",
-            key.offset: 7241,
+            key.offset: 7261,
             key.length: 6
           }
         ]
@@ -7264,7 +7284,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "rawValue",
         key.usr: "s:vVSC11FooSubEnum18rawValueVs6UInt32",
-        key.offset: 7254,
+        key.offset: 7274,
         key.length: 20,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>rawValue</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs6UInt32\">UInt32</ref.struct></decl.var.type></decl.var.instance>",
         key.conforms: [
@@ -7281,7 +7301,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FooSubEnum1X",
     key.usr: "c:@E@FooSubEnum1@FooSubEnum1X",
-    key.offset: 7277,
+    key.offset: 7297,
     key.length: 37,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooSubEnum1X</decl.name>: <decl.var.type><ref.struct usr=\"c:@E@FooSubEnum1\">FooSubEnum1</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -7289,7 +7309,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FooSubEnum1Y",
     key.usr: "c:@E@FooSubEnum1@FooSubEnum1Y",
-    key.offset: 7315,
+    key.offset: 7335,
     key.length: 37,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooSubEnum1Y</decl.name>: <decl.var.type><ref.struct usr=\"c:@E@FooSubEnum1\">FooSubEnum1</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -7297,7 +7317,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FooSubUnnamedEnumeratorA1",
     key.usr: "c:@Ea@FooSubUnnamedEnumeratorA1@FooSubUnnamedEnumeratorA1",
-    key.offset: 7353,
+    key.offset: 7373,
     key.length: 42,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooSubUnnamedEnumeratorA1</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   }

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
@@ -119,9 +119,9 @@ public func fooFunc3(_ a: Int32, _ b: Float, _ c: Double, _ d: UnsafeMutablePoin
   Very good
   fooFuncWithBlock function.
 */
-public func fooFuncWithBlock(_ blk: ((Float) -> Int32)!)
+public func fooFuncWithBlock(_ blk: (@escaping (Float) -> Int32)!)
 
-public func fooFuncWithFunctionPointer(_ fptr: (@convention(c) (Float) -> Int32)!)
+public func fooFuncWithFunctionPointer(_ fptr: (@escaping @convention(c) (Float) -> Int32)!)
 
 public func fooFuncNoreturn1() -> Never
 public func fooFuncNoreturn2() -> Never
@@ -1517,9 +1517,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.kind: source.lang.swift.syntaxtype.attribute.id,
+    key.offset: 2301,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 2302,
-    key.length: 5
+    key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
@@ -1527,549 +1532,554 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 5
   },
   {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 2322,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2332,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2329,
+    key.offset: 2339,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2334,
+    key.offset: 2344,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2361,
+    key.offset: 2371,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2363,
+    key.offset: 2373,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.id,
-    key.offset: 2370,
+    key.offset: 2380,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2381,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.id,
+    key.offset: 2390,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2371,
+    key.offset: 2391,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2382,
+    key.offset: 2402,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2386,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2396,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 2406,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2413,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2418,
-    key.length: 16
+    key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2440,
+    key.offset: 2416,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2446,
+    key.offset: 2426,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2453,
+    key.offset: 2433,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2458,
+    key.offset: 2438,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2480,
+    key.offset: 2460,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2466,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2473,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2478,
+    key.length: 16
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2500,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2487,
+    key.offset: 2507,
     key.length: 62
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2550,
+    key.offset: 2570,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2557,
+    key.offset: 2577,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2562,
+    key.offset: 2582,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2585,
+    key.offset: 2605,
     key.length: 42
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2628,
+    key.offset: 2648,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2635,
+    key.offset: 2655,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2640,
+    key.offset: 2660,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2663,
+    key.offset: 2683,
     key.length: 43
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2707,
+    key.offset: 2727,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2723,
+    key.offset: 2743,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2730,
+    key.offset: 2750,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2735,
+    key.offset: 2755,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2758,
+    key.offset: 2778,
     key.length: 43
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2802,
+    key.offset: 2822,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2811,
+    key.offset: 2831,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2818,
+    key.offset: 2838,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2823,
+    key.offset: 2843,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2846,
+    key.offset: 2866,
     key.length: 37
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2883,
+    key.offset: 2903,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2892,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2896,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2905,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 2912,
     key.length: 4
   },
   {
+    key.kind: source.lang.swift.syntaxtype.doccomment,
+    key.offset: 2916,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2925,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2932,
+    key.length: 4
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2917,
+    key.offset: 2937,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2940,
+    key.offset: 2960,
     key.length: 50
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2990,
+    key.offset: 3010,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2997,
+    key.offset: 3017,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3002,
+    key.offset: 3022,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3035,
+    key.offset: 3055,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3037,
+    key.offset: 3057,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3040,
+    key.offset: 3060,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3050,
+    key.offset: 3070,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3057,
+    key.offset: 3077,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3090,
+    key.offset: 3110,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3097,
+    key.offset: 3117,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3106,
+    key.offset: 3126,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3134,
+    key.offset: 3154,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3168,
+    key.offset: 3188,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3181,
+    key.offset: 3201,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3188,
+    key.offset: 3208,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3193,
+    key.offset: 3213,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3218,
+    key.offset: 3238,
     key.length: 51
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3273,
+    key.offset: 3293,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3286,
+    key.offset: 3306,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3293,
+    key.offset: 3313,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3298,
+    key.offset: 3318,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3344,
+    key.offset: 3364,
     key.length: 77
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3426,
+    key.offset: 3446,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3433,
+    key.offset: 3453,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3438,
+    key.offset: 3458,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3484,
+    key.offset: 3504,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3491,
+    key.offset: 3511,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3498,
+    key.offset: 3518,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3503,
+    key.offset: 3523,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3533,
+    key.offset: 3553,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3540,
+    key.offset: 3560,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3544,
+    key.offset: 3564,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3558,
+    key.offset: 3578,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3566,
+    key.offset: 3586,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3570,
+    key.offset: 3590,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3581,
+    key.offset: 3601,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3588,
+    key.offset: 3608,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3592,
+    key.offset: 3612,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3606,
+    key.offset: 3626,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3614,
+    key.offset: 3634,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3618,
+    key.offset: 3638,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3629,
+    key.offset: 3649,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3636,
+    key.offset: 3656,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3640,
+    key.offset: 3660,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3654,
+    key.offset: 3674,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3662,
+    key.offset: 3682,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3671,
+    key.offset: 3691,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3678,
+    key.offset: 3698,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3687,
+    key.offset: 3707,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3708,
+    key.offset: 3728,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3729,
+    key.offset: 3749,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3736,
+    key.offset: 3756,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3742,
+    key.offset: 3762,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3762,
+    key.offset: 3782,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3769,
+    key.offset: 3789,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3774,
+    key.offset: 3794,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3802,
+    key.offset: 3822,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3809,
+    key.offset: 3829,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3814,
+    key.offset: 3834,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3835,
+    key.offset: 3855,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3837,
+    key.offset: 3857,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3847,
+    key.offset: 3867,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3856,
+    key.offset: 3876,
     key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3875,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3882,
-    key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
@@ -2077,1128 +2087,1138 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 6
   },
   {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 3902,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 3915,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 3922,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3914,
+    key.offset: 3934,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3920,
+    key.offset: 3940,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3926,
+    key.offset: 3946,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3929,
+    key.offset: 3949,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3941,
+    key.offset: 3961,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3948,
+    key.offset: 3968,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3953,
+    key.offset: 3973,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3995,
+    key.offset: 4015,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4002,
+    key.offset: 4022,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4008,
+    key.offset: 4028,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4013,
+    key.offset: 4033,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 4036,
+    key.offset: 4056,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4069,
+    key.offset: 4089,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4076,
+    key.offset: 4096,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4082,
+    key.offset: 4102,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4100,
+    key.offset: 4120,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4114,
+    key.offset: 4134,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4145,
+    key.offset: 4165,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4152,
+    key.offset: 4172,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4156,
+    key.offset: 4176,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4170,
+    key.offset: 4190,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4181,
+    key.offset: 4201,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4188,
+    key.offset: 4208,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4192,
+    key.offset: 4212,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4206,
+    key.offset: 4226,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4217,
+    key.offset: 4237,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4224,
+    key.offset: 4244,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4228,
+    key.offset: 4248,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4242,
+    key.offset: 4262,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4250,
+    key.offset: 4270,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 4266,
+    key.offset: 4286,
     key.length: 64
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4335,
+    key.offset: 4355,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4342,
+    key.offset: 4362,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4347,
+    key.offset: 4367,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4371,
+    key.offset: 4391,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4378,
+    key.offset: 4398,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4383,
+    key.offset: 4403,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4400,
+    key.offset: 4420,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4402,
+    key.offset: 4422,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4405,
+    key.offset: 4425,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4417,
+    key.offset: 4437,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4424,
+    key.offset: 4444,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4429,
+    key.offset: 4449,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4446,
+    key.offset: 4466,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4448,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4451,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4458,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4464,
+    key.offset: 4468,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4467,
+    key.offset: 4471,
     key.length: 5
   },
   {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4478,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 4484,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4487,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4504,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4491,
+    key.offset: 4511,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4496,
+    key.offset: 4516,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4538,
+    key.offset: 4558,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4545,
+    key.offset: 4565,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4551,
+    key.offset: 4571,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4556,
+    key.offset: 4576,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 4575,
+    key.offset: 4595,
     key.length: 31
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4607,
+    key.offset: 4627,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4614,
+    key.offset: 4634,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4618,
+    key.offset: 4638,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4631,
+    key.offset: 4651,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4639,
+    key.offset: 4659,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4645,
+    key.offset: 4665,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4652,
+    key.offset: 4672,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4656,
+    key.offset: 4676,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4669,
+    key.offset: 4689,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4677,
+    key.offset: 4697,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4683,
+    key.offset: 4703,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4690,
+    key.offset: 4710,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4694,
+    key.offset: 4714,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4707,
+    key.offset: 4727,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4715,
+    key.offset: 4735,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 4721,
+    key.offset: 4741,
     key.length: 39
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4760,
+    key.offset: 4780,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4767,
+    key.offset: 4787,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4771,
+    key.offset: 4791,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4784,
+    key.offset: 4804,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4793,
+    key.offset: 4813,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4799,
+    key.offset: 4819,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4806,
+    key.offset: 4826,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4810,
+    key.offset: 4830,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4823,
+    key.offset: 4843,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4832,
+    key.offset: 4852,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4839,
+    key.offset: 4859,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4846,
+    key.offset: 4866,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4850,
+    key.offset: 4870,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4869,
+    key.offset: 4889,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4877,
+    key.offset: 4897,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4884,
+    key.offset: 4904,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4891,
+    key.offset: 4911,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4895,
+    key.offset: 4915,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4914,
+    key.offset: 4934,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4922,
+    key.offset: 4942,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4929,
+    key.offset: 4949,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4936,
+    key.offset: 4956,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4941,
+    key.offset: 4961,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4961,
+    key.offset: 4981,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4968,
+    key.offset: 4988,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4973,
+    key.offset: 4993,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4998,
+    key.offset: 5018,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5005,
+    key.offset: 5025,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5012,
+    key.offset: 5032,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5035,
+    key.offset: 5055,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5042,
+    key.offset: 5062,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5046,
+    key.offset: 5066,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5049,
+    key.offset: 5069,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5060,
+    key.offset: 5080,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5067,
+    key.offset: 5087,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5079,
+    key.offset: 5099,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5086,
+    key.offset: 5106,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5091,
+    key.offset: 5111,
     key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5094,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5104,
-    key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 5114,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5124,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 5134,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5134,
+    key.offset: 5154,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5141,
+    key.offset: 5161,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5146,
+    key.offset: 5166,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5166,
+    key.offset: 5186,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 5174,
+    key.offset: 5194,
     key.length: 44
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5219,
+    key.offset: 5239,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5229,
+    key.offset: 5249,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5249,
+    key.offset: 5269,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5256,
+    key.offset: 5276,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5261,
+    key.offset: 5281,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5281,
+    key.offset: 5301,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5291,
+    key.offset: 5311,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5298,
+    key.offset: 5318,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5303,
+    key.offset: 5323,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5324,
+    key.offset: 5344,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5332,
+    key.offset: 5352,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5342,
+    key.offset: 5362,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5362,
+    key.offset: 5382,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5369,
+    key.offset: 5389,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5374,
+    key.offset: 5394,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5394,
+    key.offset: 5414,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5402,
+    key.offset: 5422,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5409,
+    key.offset: 5429,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5418,
+    key.offset: 5438,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5437,
+    key.offset: 5457,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5444,
+    key.offset: 5464,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5450,
+    key.offset: 5470,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5474,
+    key.offset: 5494,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5493,
+    key.offset: 5513,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5500,
+    key.offset: 5520,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5506,
+    key.offset: 5526,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5534,
+    key.offset: 5554,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5554,
+    key.offset: 5574,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5561,
+    key.offset: 5581,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5565,
+    key.offset: 5585,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5577,
+    key.offset: 5597,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5587,
+    key.offset: 5607,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5594,
+    key.offset: 5614,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5598,
+    key.offset: 5618,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5616,
+    key.offset: 5636,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5626,
+    key.offset: 5646,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5633,
+    key.offset: 5653,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5637,
+    key.offset: 5657,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5649,
+    key.offset: 5669,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5659,
+    key.offset: 5679,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5666,
+    key.offset: 5686,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5670,
+    key.offset: 5690,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5681,
+    key.offset: 5701,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5691,
+    key.offset: 5711,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5698,
+    key.offset: 5718,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5702,
+    key.offset: 5722,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5712,
+    key.offset: 5732,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5722,
+    key.offset: 5742,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5729,
+    key.offset: 5749,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5733,
+    key.offset: 5753,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5742,
+    key.offset: 5762,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5752,
+    key.offset: 5772,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5759,
+    key.offset: 5779,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5763,
+    key.offset: 5783,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5771,
+    key.offset: 5791,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5780,
+    key.offset: 5800,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5787,
+    key.offset: 5807,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5793,
+    key.offset: 5813,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5817,
+    key.offset: 5837,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5837,
+    key.offset: 5857,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5844,
+    key.offset: 5864,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5856,
+    key.offset: 5876,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5862,
+    key.offset: 5882,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5866,
+    key.offset: 5886,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5869,
+    key.offset: 5889,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5886,
+    key.offset: 5906,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5900,
+    key.offset: 5920,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5912,
+    key.offset: 5932,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.string,
-    key.offset: 5921,
+    key.offset: 5941,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5930,
+    key.offset: 5950,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5937,
+    key.offset: 5957,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5942,
+    key.offset: 5962,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5965,
+    key.offset: 5985,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5976,
+    key.offset: 5996,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 5980,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5993,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 6000,
     key.length: 4
   },
   {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 6013,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 6020,
+    key.length: 4
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6005,
+    key.offset: 6025,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6040,
+    key.offset: 6060,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6051,
+    key.offset: 6071,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6056,
+    key.offset: 6076,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 6068,
+    key.offset: 6088,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6074,
+    key.offset: 6094,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.string,
-    key.offset: 6083,
+    key.offset: 6103,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6092,
+    key.offset: 6112,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6099,
+    key.offset: 6119,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6104,
+    key.offset: 6124,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6135,
+    key.offset: 6155,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6142,
+    key.offset: 6162,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6148,
+    key.offset: 6168,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6162,
+    key.offset: 6182,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6169,
+    key.offset: 6189,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6175,
+    key.offset: 6195,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6202,
+    key.offset: 6222,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6209,
+    key.offset: 6229,
     key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6214,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6221,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6228,
-    key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 6234,
-    key.length: 22
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6259,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6263,
-    key.length: 19
+    key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6290,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6299,
+    key.offset: 6241,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6306,
+    key.offset: 6248,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 6254,
+    key.length: 22
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 6279,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 6283,
+    key.length: 19
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 6310,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 6319,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 6326,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6311,
+    key.offset: 6331,
     key.length: 1
   }
 ]
@@ -3517,236 +3537,236 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2302,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
     key.offset: 2312,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2386,
+    key.offset: 2322,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2396,
+    key.offset: 2406,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 2416,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.enum,
-    key.offset: 2440,
+    key.offset: 2460,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.enum,
-    key.offset: 2480,
+    key.offset: 2500,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3040,
+    key.offset: 3060,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3050,
+    key.offset: 3070,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3558,
+    key.offset: 3578,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3606,
+    key.offset: 3626,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3654,
+    key.offset: 3674,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 3708,
+    key.offset: 3728,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3856,
+    key.offset: 3876,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3929,
+    key.offset: 3949,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 4100,
+    key.offset: 4120,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 4114,
+    key.offset: 4134,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4170,
+    key.offset: 4190,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4206,
+    key.offset: 4226,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4242,
+    key.offset: 4262,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4405,
+    key.offset: 4425,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4451,
+    key.offset: 4471,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4467,
+    key.offset: 4487,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4631,
+    key.offset: 4651,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4669,
+    key.offset: 4689,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4707,
+    key.offset: 4727,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4784,
+    key.offset: 4804,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4823,
+    key.offset: 4843,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4869,
+    key.offset: 4889,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4914,
+    key.offset: 4934,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5049,
+    key.offset: 5069,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5094,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.class,
     key.offset: 5114,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 5134,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5229,
+    key.offset: 5249,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5342,
+    key.offset: 5362,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 5474,
+    key.offset: 5494,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5534,
+    key.offset: 5554,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5771,
+    key.offset: 5791,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5817,
+    key.offset: 5837,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5869,
+    key.offset: 5889,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.module,
-    key.offset: 6259,
+    key.offset: 6279,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 6263,
+    key.offset: 6283,
     key.length: 19
   }
 ]
@@ -4525,16 +4545,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithBlock(_:)",
     key.offset: 2271,
-    key.length: 49,
+    key.length: 59,
     key.nameoffset: 2276,
-    key.namelength: 44,
+    key.namelength: 54,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "blk",
         key.offset: 2293,
-        key.length: 26,
-        key.typename: "((Float) -> Int32)!",
+        key.length: 36,
+        key.typename: "(@escaping (Float) -> Int32)!",
         key.nameoffset: 0,
         key.namelength: 0
       }
@@ -4544,17 +4564,17 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithFunctionPointer(_:)",
-    key.offset: 2329,
-    key.length: 75,
-    key.nameoffset: 2334,
-    key.namelength: 70,
+    key.offset: 2339,
+    key.length: 85,
+    key.nameoffset: 2344,
+    key.namelength: 80,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "fptr",
-        key.offset: 2361,
-        key.length: 42,
-        key.typename: "(@convention(c) (Float) -> Int32)!",
+        key.offset: 2371,
+        key.length: 52,
+        key.typename: "(@escaping @convention(c) (Float) -> Int32)!",
         key.nameoffset: 0,
         key.namelength: 0
       }
@@ -4564,78 +4584,78 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncNoreturn1()",
-    key.offset: 2413,
+    key.offset: 2433,
     key.length: 32,
-    key.nameoffset: 2418,
+    key.nameoffset: 2438,
     key.namelength: 18
   },
   {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncNoreturn2()",
-    key.offset: 2453,
+    key.offset: 2473,
     key.length: 32,
-    key.nameoffset: 2458,
+    key.nameoffset: 2478,
     key.namelength: 18
   },
   {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment1()",
-    key.offset: 2557,
+    key.offset: 2577,
     key.length: 26,
-    key.nameoffset: 2562,
+    key.nameoffset: 2582,
     key.namelength: 21
   },
   {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment2()",
-    key.offset: 2635,
+    key.offset: 2655,
     key.length: 26,
-    key.nameoffset: 2640,
+    key.nameoffset: 2660,
     key.namelength: 21
   },
   {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment3()",
-    key.offset: 2730,
+    key.offset: 2750,
     key.length: 26,
-    key.nameoffset: 2735,
+    key.nameoffset: 2755,
     key.namelength: 21
   },
   {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment4()",
-    key.offset: 2818,
+    key.offset: 2838,
     key.length: 26,
-    key.nameoffset: 2823,
+    key.nameoffset: 2843,
     key.namelength: 21
   },
   {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment5()",
-    key.offset: 2912,
+    key.offset: 2932,
     key.length: 26,
-    key.nameoffset: 2917,
+    key.nameoffset: 2937,
     key.namelength: 21
   },
   {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "redeclaredInMultipleModulesFunc1(_:)",
-    key.offset: 2997,
+    key.offset: 3017,
     key.length: 58,
-    key.nameoffset: 3002,
+    key.nameoffset: 3022,
     key.namelength: 44,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "a",
-        key.offset: 3035,
+        key.offset: 3055,
         key.length: 10,
         key.typename: "Int32",
         key.nameoffset: 0,
@@ -4647,48 +4667,48 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooProtocolBase",
-    key.offset: 3097,
+    key.offset: 3117,
     key.length: 572,
     key.runtime_name: "_TtP4main15FooProtocolBase_",
-    key.nameoffset: 3106,
+    key.nameoffset: 3126,
     key.namelength: 15,
-    key.bodyoffset: 3123,
+    key.bodyoffset: 3143,
     key.bodylength: 545,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoFunc()",
-        key.offset: 3188,
+        key.offset: 3208,
         key.length: 19,
-        key.nameoffset: 3193,
+        key.nameoffset: 3213,
         key.namelength: 14
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoFuncWithExtraIndentation1()",
-        key.offset: 3293,
+        key.offset: 3313,
         key.length: 40,
-        key.nameoffset: 3298,
+        key.nameoffset: 3318,
         key.namelength: 35
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoFuncWithExtraIndentation2()",
-        key.offset: 3433,
+        key.offset: 3453,
         key.length: 40,
-        key.nameoffset: 3438,
+        key.nameoffset: 3458,
         key.namelength: 35
       },
       {
         key.kind: source.lang.swift.decl.function.method.static,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoClassFunc()",
-        key.offset: 3491,
+        key.offset: 3511,
         key.length: 31,
-        key.nameoffset: 3503,
+        key.nameoffset: 3523,
         key.namelength: 19
       },
       {
@@ -4696,12 +4716,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProperty1",
-        key.offset: 3540,
+        key.offset: 3560,
         key.length: 23,
         key.typename: "Int32",
-        key.nameoffset: 3544,
+        key.nameoffset: 3564,
         key.namelength: 12,
-        key.bodyoffset: 3565,
+        key.bodyoffset: 3585,
         key.bodylength: 9
       },
       {
@@ -4709,24 +4729,24 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProperty2",
-        key.offset: 3588,
+        key.offset: 3608,
         key.length: 23,
         key.typename: "Int32",
-        key.nameoffset: 3592,
+        key.nameoffset: 3612,
         key.namelength: 12,
-        key.bodyoffset: 3613,
+        key.bodyoffset: 3633,
         key.bodylength: 9
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProperty3",
-        key.offset: 3636,
+        key.offset: 3656,
         key.length: 23,
         key.typename: "Int32",
-        key.nameoffset: 3640,
+        key.nameoffset: 3660,
         key.namelength: 12,
-        key.bodyoffset: 3661,
+        key.bodyoffset: 3681,
         key.bodylength: 5
       }
     ]
@@ -4735,12 +4755,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooProtocolDerived",
-    key.offset: 3678,
+    key.offset: 3698,
     key.length: 49,
     key.runtime_name: "_TtP4main18FooProtocolDerived_",
-    key.nameoffset: 3687,
+    key.nameoffset: 3707,
     key.namelength: 18,
-    key.bodyoffset: 3725,
+    key.bodyoffset: 3745,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -4750,7 +4770,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 3708,
+        key.offset: 3728,
         key.length: 15
       }
     ]
@@ -4759,36 +4779,36 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooClassBase",
-    key.offset: 3736,
+    key.offset: 3756,
     key.length: 298,
     key.runtime_name: "_TtC4main12FooClassBase",
-    key.nameoffset: 3742,
+    key.nameoffset: 3762,
     key.namelength: 12,
-    key.bodyoffset: 3756,
+    key.bodyoffset: 3776,
     key.bodylength: 277,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooBaseInstanceFunc0()",
-        key.offset: 3769,
+        key.offset: 3789,
         key.length: 27,
-        key.nameoffset: 3774,
+        key.nameoffset: 3794,
         key.namelength: 22
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooBaseInstanceFunc1(_:)",
-        key.offset: 3809,
+        key.offset: 3829,
         key.length: 60,
-        key.nameoffset: 3814,
+        key.nameoffset: 3834,
         key.namelength: 38,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "anObject",
-            key.offset: 3835,
+            key.offset: 3855,
             key.length: 16,
             key.typename: "Any!",
             key.nameoffset: 0,
@@ -4800,18 +4820,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 3882,
+        key.offset: 3902,
         key.length: 7,
-        key.nameoffset: 3882,
+        key.nameoffset: 3902,
         key.namelength: 7
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(float:)",
-        key.offset: 3914,
+        key.offset: 3934,
         key.length: 21,
-        key.nameoffset: 3914,
+        key.nameoffset: 3934,
         key.namelength: 21,
         key.attributes: [
           {
@@ -4822,10 +4842,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "f",
-            key.offset: 3920,
+            key.offset: 3940,
             key.length: 14,
             key.typename: "Float",
-            key.nameoffset: 3920,
+            key.nameoffset: 3940,
             key.namelength: 5
           }
         ]
@@ -4834,18 +4854,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooBaseInstanceFuncOverridden()",
-        key.offset: 3948,
+        key.offset: 3968,
         key.length: 36,
-        key.nameoffset: 3953,
+        key.nameoffset: 3973,
         key.namelength: 31
       },
       {
         key.kind: source.lang.swift.decl.function.method.class,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooBaseClassFunc0()",
-        key.offset: 4002,
+        key.offset: 4022,
         key.length: 30,
-        key.nameoffset: 4013,
+        key.nameoffset: 4033,
         key.namelength: 19
       }
     ]
@@ -4854,12 +4874,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooClassDerived",
-    key.offset: 4076,
+    key.offset: 4096,
     key.length: 497,
     key.runtime_name: "_TtC4main15FooClassDerived",
-    key.nameoffset: 4082,
+    key.nameoffset: 4102,
     key.namelength: 15,
-    key.bodyoffset: 4134,
+    key.bodyoffset: 4154,
     key.bodylength: 438,
     key.inheritedtypes: [
       {
@@ -4872,12 +4892,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 4100,
+        key.offset: 4120,
         key.length: 12
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 4114,
+        key.offset: 4134,
         key.length: 18
       }
     ],
@@ -4887,10 +4907,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProperty1",
-        key.offset: 4152,
+        key.offset: 4172,
         key.length: 23,
         key.typename: "Int32",
-        key.nameoffset: 4156,
+        key.nameoffset: 4176,
         key.namelength: 12
       },
       {
@@ -4898,10 +4918,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProperty2",
-        key.offset: 4188,
+        key.offset: 4208,
         key.length: 23,
         key.typename: "Int32",
-        key.nameoffset: 4192,
+        key.nameoffset: 4212,
         key.namelength: 12
       },
       {
@@ -4909,34 +4929,34 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProperty3",
-        key.offset: 4224,
+        key.offset: 4244,
         key.length: 23,
         key.typename: "Int32",
-        key.nameoffset: 4228,
+        key.nameoffset: 4248,
         key.namelength: 12
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooInstanceFunc0()",
-        key.offset: 4342,
+        key.offset: 4362,
         key.length: 23,
-        key.nameoffset: 4347,
+        key.nameoffset: 4367,
         key.namelength: 18
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooInstanceFunc1(_:)",
-        key.offset: 4378,
+        key.offset: 4398,
         key.length: 33,
-        key.nameoffset: 4383,
+        key.nameoffset: 4403,
         key.namelength: 28,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "a",
-            key.offset: 4400,
+            key.offset: 4420,
             key.length: 10,
             key.typename: "Int32",
             key.nameoffset: 0,
@@ -4948,15 +4968,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooInstanceFunc2(_:withB:)",
-        key.offset: 4424,
+        key.offset: 4444,
         key.length: 49,
-        key.nameoffset: 4429,
+        key.nameoffset: 4449,
         key.namelength: 44,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "a",
-            key.offset: 4446,
+            key.offset: 4466,
             key.length: 10,
             key.typename: "Int32",
             key.nameoffset: 0,
@@ -4965,10 +4985,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "b",
-            key.offset: 4458,
+            key.offset: 4478,
             key.length: 14,
             key.typename: "Int32",
-            key.nameoffset: 4458,
+            key.nameoffset: 4478,
             key.namelength: 5
           }
         ]
@@ -4977,18 +4997,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooBaseInstanceFuncOverridden()",
-        key.offset: 4491,
+        key.offset: 4511,
         key.length: 36,
-        key.nameoffset: 4496,
+        key.nameoffset: 4516,
         key.namelength: 31
       },
       {
         key.kind: source.lang.swift.decl.function.method.class,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooClassFunc0()",
-        key.offset: 4545,
+        key.offset: 4565,
         key.length: 26,
-        key.nameoffset: 4556,
+        key.nameoffset: 4576,
         key.namelength: 15
       }
     ]
@@ -4998,10 +5018,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.accessibility: source.lang.swift.accessibility.public,
     key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_1",
-    key.offset: 4614,
+    key.offset: 4634,
     key.length: 22,
     key.typename: "Int32",
-    key.nameoffset: 4618,
+    key.nameoffset: 4638,
     key.namelength: 11
   },
   {
@@ -5009,10 +5029,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.accessibility: source.lang.swift.accessibility.public,
     key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_2",
-    key.offset: 4652,
+    key.offset: 4672,
     key.length: 22,
     key.typename: "Int32",
-    key.nameoffset: 4656,
+    key.nameoffset: 4676,
     key.namelength: 11
   },
   {
@@ -5020,10 +5040,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.accessibility: source.lang.swift.accessibility.public,
     key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_3",
-    key.offset: 4690,
+    key.offset: 4710,
     key.length: 22,
     key.typename: "Int32",
-    key.nameoffset: 4694,
+    key.nameoffset: 4714,
     key.namelength: 11
   },
   {
@@ -5031,10 +5051,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.accessibility: source.lang.swift.accessibility.public,
     key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_4",
-    key.offset: 4767,
+    key.offset: 4787,
     key.length: 23,
     key.typename: "UInt32",
-    key.nameoffset: 4771,
+    key.nameoffset: 4791,
     key.namelength: 11
   },
   {
@@ -5042,10 +5062,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.accessibility: source.lang.swift.accessibility.public,
     key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_5",
-    key.offset: 4806,
+    key.offset: 4826,
     key.length: 23,
     key.typename: "UInt64",
-    key.nameoffset: 4810,
+    key.nameoffset: 4830,
     key.namelength: 11
   },
   {
@@ -5053,10 +5073,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.accessibility: source.lang.swift.accessibility.public,
     key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_REDEF_1",
-    key.offset: 4846,
+    key.offset: 4866,
     key.length: 28,
     key.typename: "Int32",
-    key.nameoffset: 4850,
+    key.nameoffset: 4870,
     key.namelength: 17
   },
   {
@@ -5064,39 +5084,39 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.accessibility: source.lang.swift.accessibility.public,
     key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_REDEF_2",
-    key.offset: 4891,
+    key.offset: 4911,
     key.length: 28,
     key.typename: "Int32",
-    key.nameoffset: 4895,
+    key.nameoffset: 4915,
     key.namelength: 17
   },
   {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "theLastDeclInFoo()",
-    key.offset: 4936,
+    key.offset: 4956,
     key.length: 23,
-    key.nameoffset: 4941,
+    key.nameoffset: 4961,
     key.namelength: 18
   },
   {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "_internalTopLevelFunc()",
-    key.offset: 4968,
+    key.offset: 4988,
     key.length: 28,
-    key.nameoffset: 4973,
+    key.nameoffset: 4993,
     key.namelength: 23
   },
   {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "_InternalStruct",
-    key.offset: 5005,
+    key.offset: 5025,
     key.length: 97,
-    key.nameoffset: 5012,
+    key.nameoffset: 5032,
     key.namelength: 15,
-    key.bodyoffset: 5029,
+    key.bodyoffset: 5049,
     key.bodylength: 72,
     key.substructure: [
       {
@@ -5104,37 +5124,37 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "x",
-        key.offset: 5042,
+        key.offset: 5062,
         key.length: 12,
         key.typename: "Int32",
-        key.nameoffset: 5046,
+        key.nameoffset: 5066,
         key.namelength: 1
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 5067,
+        key.offset: 5087,
         key.length: 6,
-        key.nameoffset: 5067,
+        key.nameoffset: 5087,
         key.namelength: 6
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(x:)",
-        key.offset: 5086,
+        key.offset: 5106,
         key.length: 14,
-        key.nameoffset: 5086,
+        key.nameoffset: 5106,
         key.namelength: 14,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "x",
-            key.offset: 5091,
+            key.offset: 5111,
             key.length: 8,
             key.typename: "Int32",
-            key.nameoffset: 5091,
+            key.nameoffset: 5111,
             key.namelength: 1
           }
         ]
@@ -5144,20 +5164,20 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "FooClassBase",
-    key.offset: 5104,
+    key.offset: 5124,
     key.length: 68,
-    key.nameoffset: 5114,
+    key.nameoffset: 5134,
     key.namelength: 12,
-    key.bodyoffset: 5128,
+    key.bodyoffset: 5148,
     key.bodylength: 43,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "_internalMeth1()",
-        key.offset: 5141,
+        key.offset: 5161,
         key.length: 29,
-        key.nameoffset: 5146,
+        key.nameoffset: 5166,
         key.namelength: 16
       }
     ]
@@ -5165,29 +5185,29 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "FooClassBase",
-    key.offset: 5219,
+    key.offset: 5239,
     key.length: 111,
-    key.nameoffset: 5229,
+    key.nameoffset: 5249,
     key.namelength: 12,
-    key.bodyoffset: 5243,
+    key.bodyoffset: 5263,
     key.bodylength: 86,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "_internalMeth2()",
-        key.offset: 5256,
+        key.offset: 5276,
         key.length: 29,
-        key.nameoffset: 5261,
+        key.nameoffset: 5281,
         key.namelength: 16
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "nonInternalMeth()",
-        key.offset: 5298,
+        key.offset: 5318,
         key.length: 30,
-        key.nameoffset: 5303,
+        key.nameoffset: 5323,
         key.namelength: 17
       }
     ]
@@ -5195,20 +5215,20 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "FooClassBase",
-    key.offset: 5332,
+    key.offset: 5352,
     key.length: 68,
-    key.nameoffset: 5342,
+    key.nameoffset: 5362,
     key.namelength: 12,
-    key.bodyoffset: 5356,
+    key.bodyoffset: 5376,
     key.bodylength: 43,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "_internalMeth3()",
-        key.offset: 5369,
+        key.offset: 5389,
         key.length: 29,
-        key.nameoffset: 5374,
+        key.nameoffset: 5394,
         key.namelength: 16
       }
     ]
@@ -5217,24 +5237,24 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "_InternalProt",
-    key.offset: 5409,
+    key.offset: 5429,
     key.length: 26,
     key.runtime_name: "_TtP4main13_InternalProt_",
-    key.nameoffset: 5418,
+    key.nameoffset: 5438,
     key.namelength: 13,
-    key.bodyoffset: 5433,
+    key.bodyoffset: 5453,
     key.bodylength: 1
   },
   {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "ClassWithInternalProt",
-    key.offset: 5444,
+    key.offset: 5464,
     key.length: 47,
     key.runtime_name: "_TtC4main21ClassWithInternalProt",
-    key.nameoffset: 5450,
+    key.nameoffset: 5470,
     key.namelength: 21,
-    key.bodyoffset: 5489,
+    key.bodyoffset: 5509,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -5244,7 +5264,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 5474,
+        key.offset: 5494,
         key.length: 13
       }
     ]
@@ -5253,12 +5273,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooClassPropertyOwnership",
-    key.offset: 5500,
+    key.offset: 5520,
     key.length: 278,
     key.runtime_name: "_TtC4main25FooClassPropertyOwnership",
-    key.nameoffset: 5506,
+    key.nameoffset: 5526,
     key.namelength: 25,
-    key.bodyoffset: 5548,
+    key.bodyoffset: 5568,
     key.bodylength: 229,
     key.inheritedtypes: [
       {
@@ -5268,7 +5288,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 5534,
+        key.offset: 5554,
         key.length: 12
       }
     ],
@@ -5278,10 +5298,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "assignable",
-        key.offset: 5561,
+        key.offset: 5581,
         key.length: 20,
         key.typename: "Any!",
-        key.nameoffset: 5565,
+        key.nameoffset: 5585,
         key.namelength: 10
       },
       {
@@ -5289,10 +5309,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "unsafeAssignable",
-        key.offset: 5594,
+        key.offset: 5614,
         key.length: 26,
         key.typename: "Any!",
-        key.nameoffset: 5598,
+        key.nameoffset: 5618,
         key.namelength: 16
       },
       {
@@ -5300,10 +5320,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "retainable",
-        key.offset: 5633,
+        key.offset: 5653,
         key.length: 20,
         key.typename: "Any!",
-        key.nameoffset: 5637,
+        key.nameoffset: 5657,
         key.namelength: 10
       },
       {
@@ -5311,10 +5331,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "strongRef",
-        key.offset: 5666,
+        key.offset: 5686,
         key.length: 19,
         key.typename: "Any!",
-        key.nameoffset: 5670,
+        key.nameoffset: 5690,
         key.namelength: 9
       },
       {
@@ -5322,10 +5342,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "copyable",
-        key.offset: 5698,
+        key.offset: 5718,
         key.length: 18,
         key.typename: "Any!",
-        key.nameoffset: 5702,
+        key.nameoffset: 5722,
         key.namelength: 8
       },
       {
@@ -5333,10 +5353,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "weakRef",
-        key.offset: 5729,
+        key.offset: 5749,
         key.length: 17,
         key.typename: "Any!",
-        key.nameoffset: 5733,
+        key.nameoffset: 5753,
         key.namelength: 7
       },
       {
@@ -5344,10 +5364,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "scalar",
-        key.offset: 5759,
+        key.offset: 5779,
         key.length: 17,
         key.typename: "Int32",
-        key.nameoffset: 5763,
+        key.nameoffset: 5783,
         key.namelength: 6
       }
     ]
@@ -5356,12 +5376,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooUnavailableMembers",
-    key.offset: 5787,
+    key.offset: 5807,
     key.length: 346,
     key.runtime_name: "_TtC4main21FooUnavailableMembers",
-    key.nameoffset: 5793,
+    key.nameoffset: 5813,
     key.namelength: 21,
-    key.bodyoffset: 5831,
+    key.bodyoffset: 5851,
     key.bodylength: 301,
     key.inheritedtypes: [
       {
@@ -5371,7 +5391,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 5817,
+        key.offset: 5837,
         key.length: 12
       }
     ],
@@ -5380,9 +5400,9 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(int:)",
-        key.offset: 5856,
+        key.offset: 5876,
         key.length: 19,
-        key.nameoffset: 5856,
+        key.nameoffset: 5876,
         key.namelength: 19,
         key.attributes: [
           {
@@ -5393,10 +5413,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "i",
-            key.offset: 5862,
+            key.offset: 5882,
             key.length: 12,
             key.typename: "Int32",
-            key.nameoffset: 5862,
+            key.nameoffset: 5882,
             key.namelength: 3
           }
         ]
@@ -5405,9 +5425,9 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "deprecated()",
-        key.offset: 5937,
+        key.offset: 5957,
         key.length: 17,
-        key.nameoffset: 5942,
+        key.nameoffset: 5962,
         key.namelength: 12,
         key.attributes: [
           {
@@ -5419,9 +5439,9 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "availabilityIntroduced()",
-        key.offset: 6000,
+        key.offset: 6020,
         key.length: 29,
-        key.nameoffset: 6005,
+        key.nameoffset: 6025,
         key.namelength: 24,
         key.attributes: [
           {
@@ -5433,9 +5453,9 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "availabilityIntroducedMsg()",
-        key.offset: 6099,
+        key.offset: 6119,
         key.length: 32,
-        key.nameoffset: 6104,
+        key.nameoffset: 6124,
         key.namelength: 27,
         key.attributes: [
           {
@@ -5449,33 +5469,33 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooCFType",
-    key.offset: 6142,
+    key.offset: 6162,
     key.length: 19,
     key.runtime_name: "_TtC4main9FooCFType",
-    key.nameoffset: 6148,
+    key.nameoffset: 6168,
     key.namelength: 9,
-    key.bodyoffset: 6159,
+    key.bodyoffset: 6179,
     key.bodylength: 1
   },
   {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooOverlayClassBase",
-    key.offset: 6169,
+    key.offset: 6189,
     key.length: 50,
     key.runtime_name: "_TtC4main19FooOverlayClassBase",
-    key.nameoffset: 6175,
+    key.nameoffset: 6195,
     key.namelength: 19,
-    key.bodyoffset: 6196,
+    key.bodyoffset: 6216,
     key.bodylength: 22,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "f()",
-        key.offset: 6209,
+        key.offset: 6229,
         key.length: 8,
-        key.nameoffset: 6214,
+        key.nameoffset: 6234,
         key.namelength: 3
       }
     ]
@@ -5484,12 +5504,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooOverlayClassDerived",
-    key.offset: 6228,
+    key.offset: 6248,
     key.length: 88,
     key.runtime_name: "_TtC4main22FooOverlayClassDerived",
-    key.nameoffset: 6234,
+    key.nameoffset: 6254,
     key.namelength: 22,
-    key.bodyoffset: 6284,
+    key.bodyoffset: 6304,
     key.bodylength: 31,
     key.inheritedtypes: [
       {
@@ -5499,7 +5519,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 6259,
+        key.offset: 6279,
         key.length: 23
       }
     ],
@@ -5508,9 +5528,9 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "f()",
-        key.offset: 6306,
+        key.offset: 6326,
         key.length: 8,
-        key.nameoffset: 6311,
+        key.nameoffset: 6331,
         key.namelength: 3,
         key.attributes: [
           {

--- a/test/TypeCoercion/subtyping.swift
+++ b/test/TypeCoercion/subtyping.swift
@@ -36,9 +36,9 @@ func protocolConformance(ac1: @autoclosure () -> CustomStringConvertible,
   accept_creates_Printable(ac1)
   accept_creates_Printable({ ac2() })
   accept_creates_Printable({ ip1() })
-  accept_creates_FormattedPrintable(ac1) // expected-error{{cannot convert value of type '@autoclosure () -> CustomStringConvertible' to expected argument type '@noescape () -> FormattedPrintable'}}
+  accept_creates_FormattedPrintable(ac1) // expected-error{{cannot convert value of type '@autoclosure () -> CustomStringConvertible' to expected argument type '() -> FormattedPrintable'}}
   accept_creates_FormattedPrintable(ac2)
-  accept_creates_FormattedPrintable(ip1) // expected-error{{cannot convert value of type '@autoclosure () -> IsPrintable1' to expected argument type '@noescape () -> FormattedPrintable'}}
+  accept_creates_FormattedPrintable(ip1) // expected-error{{cannot convert value of type '@autoclosure () -> IsPrintable1' to expected argument type '() -> FormattedPrintable'}}
 }
 
 func p_gen_to_fp(_: () -> CustomStringConvertible) -> FormattedPrintable {}

--- a/test/attr/attr_autoclosure.swift
+++ b/test/attr/attr_autoclosure.swift
@@ -1,7 +1,7 @@
 // RUN: %target-parse-verify-swift
 
 // Simple case.
-var fn : @autoclosure () -> Int = 4  // expected-error {{@autoclosure may only be used on parameters}}  expected-error {{cannot convert value of type 'Int' to specified type '@noescape () -> Int'}}
+var fn : @autoclosure () -> Int = 4  // expected-error {{@autoclosure may only be used on parameters}}  expected-error {{cannot convert value of type 'Int' to specified type '() -> Int'}}
 
 @autoclosure func func1() {}  // expected-error {{@autoclosure may only be used on 'parameter' declarations}}
 
@@ -46,10 +46,10 @@ protocol P2 : P1 {
   associatedtype Element
 }
 
-func overloadedEach<O: P1>(_ source: O, _ closure: () -> ()) {
+func overloadedEach<O: P1>(_ source: O, _ closure: @escaping () -> ()) {
 }
 
-func overloadedEach<P: P2>(_ source: P, _ closure: () -> ()) {
+func overloadedEach<P: P2>(_ source: P, _ closure: @escaping () -> ()) {
 }
 
 struct S : P2 {
@@ -84,7 +84,7 @@ class Sub : Super {
   override func f3(_ x: @autoclosure(escaping) () -> ()) { }  // expected-error{{does not override any method}}
 }
 
-func func12_sink(_ x: () -> Int) { }
+func func12_sink(_ x: @escaping () -> Int) { }
 
 func func12a(_ x: @autoclosure () -> Int) {
   func12_sink(x) // expected-error{{invalid conversion from non-escaping function of type '@autoclosure () -> Int' to potentially escaping function type '() -> Int'}}

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -516,9 +516,10 @@ func trailingClosureArg(_ value: Int, _ other: Int, fn: () -> Void) {} // expect
 func trailingClosureArg2(_ value: Int, _ other: Int, fn: () -> Void) {} // expected-note {{here}}
 
 func testInstanceTrailingClosure() {
-  trailingClosure(0) {} // expected-error {{'trailingClosure(_:fn:)' has been replaced by instance method 'Int.foo(execute:)'}} {{3-18=0.foo}} {{19-20=}}
-  trailingClosureArg(0, 1) {} // expected-error {{'trailingClosureArg(_:_:fn:)' has been replaced by instance method 'Int.foo(bar:execute:)'}} {{3-21=0.foo}} {{22-25=}} {{25-25=bar: }}
-  trailingClosureArg2(0, 1) {} // expected-error {{'trailingClosureArg2(_:_:fn:)' has been replaced by instance method 'Int.foo(bar:execute:)'}} {{3-22=1.foo}} {{23-23=bar: }} {{24-27=}}
+  // FIXME: regression in fixit due to noescape-by-default
+  trailingClosure(0) {} // expected-error {{'trailingClosure(_:fn:)' has been replaced by instance method 'Int.foo(execute:)'}} // FIXME: {{3-18=0.foo}} {{19-20=}}
+  trailingClosureArg(0, 1) {} // expected-error {{'trailingClosureArg(_:_:fn:)' has been replaced by instance method 'Int.foo(bar:execute:)'}} // FIXME: {{3-21=0.foo}} {{22-25=}} {{25-25=bar: }}
+  trailingClosureArg2(0, 1) {} // expected-error {{'trailingClosureArg2(_:_:fn:)' has been replaced by instance method 'Int.foo(bar:execute:)'}} // FIXME: {{3-22=1.foo}} {{23-23=bar: }} {{24-27=}}
 }
 
 @available(*, unavailable, renamed: "+")

--- a/test/attr/attr_noescape.swift
+++ b/test/attr/attr_noescape.swift
@@ -14,17 +14,17 @@ func takesNoEscapeClosure(_ fn : @noescape () -> Int) {
 
   _ = fn()  // ok
 
-  var x = fn  // expected-error {{@noescape parameter 'fn' may only be called}}
+  var x = fn  // expected-error {{non-escaping parameter 'fn' may only be called}}
 
   // This is ok, because the closure itself is noescape.
   takesNoEscapeClosure { fn() }
 
   // This is not ok, because it escapes the 'fn' closure.
-  doesEscape { fn() }   // expected-error {{closure use of @noescape parameter 'fn' may allow it to escape}}
+  doesEscape { fn() }   // expected-error {{closure use of non-escaping parameter 'fn' may allow it to escape}}
 
   // This is not ok, because it escapes the 'fn' closure.
   func nested_function() {
-    _ = fn()   // expected-error {{declaration closing over @noescape parameter 'fn' may allow it to escape}}
+    _ = fn()   // expected-error {{declaration closing over non-escaping parameter 'fn' may allow it to escape}}
   }
 
   takesNoEscapeClosure(fn)  // ok
@@ -165,8 +165,8 @@ func takeNoEscapeTest2(_ fn : @noescape () -> ()) {
 
 // Autoclosure implies noescape, but produce nice diagnostics so people know
 // why noescape problems happen.
-func testAutoclosure(_ a : @autoclosure () -> Int) { // expected-note{{parameter 'a' is implicitly @noescape because it was declared @autoclosure}}
-  doesEscape { a() }  // expected-error {{closure use of @noescape parameter 'a' may allow it to escape}}
+func testAutoclosure(_ a : @autoclosure () -> Int) { // expected-note{{parameter 'a' is implicitly non-escaping because it was declared @autoclosure}}
+  doesEscape { a() }  // expected-error {{closure use of non-escaping parameter 'a' may allow it to escape}}
 }
 
 
@@ -262,15 +262,15 @@ func escapeNoEscapeResult(_ x: [Int]) -> (@noescape (Int) -> Int) -> Int {
 typealias CompletionHandlerNE = @noescape (success: Bool) -> ()
 typealias CompletionHandler = (success: Bool) -> ()
 var escape : CompletionHandlerNE
-func doThing1(_ completion: @noescape (success: Bool) -> ()) {
-  // expected-error @+2 {{@noescape value 'escape' may only be called}}
-  // expected-error @+1 {{@noescape parameter 'completion' may only be called}}
-  escape = completion // expected-error {{declaration closing over @noescape parameter 'escape' may allow it to escape}}
+func doThing1(_ completion: (success: Bool) -> ()) {
+  // expected-error @+2 {{non-escaping value 'escape' may only be called}}
+  // expected-error @+1 {{non-escaping parameter 'completion' may only be called}}
+  escape = completion // expected-error {{declaration closing over non-escaping parameter 'escape' may allow it to escape}}
 }
 func doThing2(_ completion: CompletionHandlerNE) {
-  // expected-error @+2 {{@noescape value 'escape' may only be called}}
-  // expected-error @+1 {{@noescape parameter 'completion' may only be called}}
-  escape = completion // expected-error {{declaration closing over @noescape parameter 'escape' may allow it to escape}}
+  // expected-error @+2 {{non-escaping value 'escape' may only be called}}
+  // expected-error @+1 {{non-escaping parameter 'completion' may only be called}}
+  escape = completion // expected-error {{declaration closing over non-escaping parameter 'escape' may allow it to escape}}
 }
 
 // <rdar://problem/19997680> @noescape doesn't work on parameters of function type

--- a/test/attr/attr_noescape.swift
+++ b/test/attr/attr_noescape.swift
@@ -4,12 +4,15 @@
 
 func conflictingAttrs(_ fn: @noescape @escaping () -> Int) {} // expected-error {{@escaping conflicts with @noescape}}
 
-func doesEscape(_ fn : () -> Int) {}
+func doesEscape(_ fn : @escaping () -> Int) {}
 
 func takesGenericClosure<T>(_ a : Int, _ fn : @noescape () -> T) {}
 
 
-func takesNoEscapeClosure(_ fn : @noescape () -> Int) {
+func takesNoEscapeClosure(_ fn : () -> Int) {
+  // expected-note@-1{{parameter 'fn' is implicitly non-escaping}}
+  // expected-note@-2{{parameter 'fn' is implicitly non-escaping}}
+  // expected-note@-3{{parameter 'fn' is implicitly non-escaping}}
   takesNoEscapeClosure { 4 }  // ok
 
   _ = fn()  // ok
@@ -29,7 +32,7 @@ func takesNoEscapeClosure(_ fn : @noescape () -> Int) {
 
   takesNoEscapeClosure(fn)  // ok
 
-  doesEscape(fn)                   // expected-error {{invalid conversion from non-escaping function of type '@noescape () -> Int' to potentially escaping function type '() -> Int'}}
+  doesEscape(fn)                   // expected-error {{invalid conversion from non-escaping function of type '() -> Int' to potentially escaping function type '() -> Int'}}
   takesGenericClosure(4, fn)       // ok
   takesGenericClosure(4) { fn() }  // ok.
 }
@@ -183,14 +186,14 @@ protocol P2 : P1 {
   associatedtype Element
 }
 
-func overloadedEach<O: P1, T>(_ source: O, _ transform: (O.Element) -> (), _: T) {}
+func overloadedEach<O: P1, T>(_ source: O, _ transform: @escaping (O.Element) -> (), _: T) {}
 
-func overloadedEach<P: P2, T>(_ source: P, _ transform: (P.Element) -> (), _: T) {}
+func overloadedEach<P: P2, T>(_ source: P, _ transform: @escaping (P.Element) -> (), _: T) {}
 
 struct S : P2 {
   typealias Element = Int
   func each(_ transform: @noescape (Int) -> ()) {
-    overloadedEach(self,  // expected-error {{cannot invoke 'overloadedEach' with an argument list of type '(S, @noescape (Int) -> (), Int)'}}
+    overloadedEach(self,  // expected-error {{cannot invoke 'overloadedEach' with an argument list of type '(S, (Int) -> (), Int)'}}
                    transform, 1)
     // expected-note @-2 {{overloads for 'overloadedEach' exist with these partially matching parameter lists: (O, (O.Element) -> (), T), (P, (P.Element) -> (), T)}}
   }
@@ -249,10 +252,10 @@ func curriedFlatMap2<A, B>(_ x: [A]) -> (@noescape (A) -> [B]) -> [B] {
   }
 }
 
-func bad(_ a : (Int)-> Int) -> Int { return 42 }
+func bad(_ a : @escaping (Int)-> Int) -> Int { return 42 }
 func escapeNoEscapeResult(_ x: [Int]) -> (@noescape (Int) -> Int) -> Int {
   return { f in
-    bad(f)  // expected-error {{invalid conversion from non-escaping function of type '@noescape (Int) -> Int' to potentially escaping function type '(Int) -> Int'}}
+    bad(f)  // expected-error {{invalid conversion from non-escaping function of type '(Int) -> Int' to potentially escaping function type '(Int) -> Int'}}
   }
 }
 
@@ -263,11 +266,13 @@ typealias CompletionHandlerNE = @noescape (success: Bool) -> ()
 typealias CompletionHandler = (success: Bool) -> ()
 var escape : CompletionHandlerNE
 func doThing1(_ completion: (success: Bool) -> ()) {
+  // expected-note@-1{{parameter 'completion' is implicitly non-escaping}}
   // expected-error @+2 {{non-escaping value 'escape' may only be called}}
   // expected-error @+1 {{non-escaping parameter 'completion' may only be called}}
   escape = completion // expected-error {{declaration closing over non-escaping parameter 'escape' may allow it to escape}}
 }
 func doThing2(_ completion: CompletionHandlerNE) {
+  // expected-note@-1{{parameter 'completion' is implicitly non-escaping}}
   // expected-error @+2 {{non-escaping value 'escape' may only be called}}
   // expected-error @+1 {{non-escaping parameter 'completion' may only be called}}
   escape = completion // expected-error {{declaration closing over non-escaping parameter 'escape' may allow it to escape}}
@@ -298,7 +303,7 @@ enum r19997577Type {
 }
 
 // type attribute and decl attribute
-func noescapeD(@noescape f: () -> Bool) {} // expected-error {{@noescape is now an attribute on a parameter type, instead of on the parameter itself}} {{16-25=}} {{29-29=@noescape }}
+func noescapeD(@noescape f: @escaping () -> Bool) {} // expected-error {{@noescape is now an attribute on a parameter type, instead of on the parameter itself}} {{16-25=}} {{29-29=@noescape }}
 func noescapeT(f: @noescape () -> Bool) {} // ok
 func autoclosureD(@autoclosure f: () -> Bool) {} // expected-error {{@autoclosure is now an attribute on a parameter type, instead of on the parameter itself}} {{19-31=}} {{35-35=@autoclosure }}
 func autoclosureT(f: @autoclosure () -> Bool) {}  // ok

--- a/test/attr/attr_noescape.swift
+++ b/test/attr/attr_noescape.swift
@@ -303,5 +303,5 @@ func noescapeT(f: @noescape () -> Bool) {} // ok
 func autoclosureD(@autoclosure f: () -> Bool) {} // expected-error {{@autoclosure is now an attribute on a parameter type, instead of on the parameter itself}} {{19-31=}} {{35-35=@autoclosure }}
 func autoclosureT(f: @autoclosure () -> Bool) {}  // ok
 
-func noescapeD_noescapeT(@noescape f: @noescape () -> Bool) {}
+func noescapeD_noescapeT(@noescape f: @noescape () -> Bool) {} // expected-error {{@noescape is now an attribute on a parameter type, instead of on the parameter itself}}
 func autoclosureD_noescapeT(@autoclosure f: @noescape () -> Bool) {} // expected-error {{@autoclosure is now an attribute on a parameter type, instead of on the parameter itself}} {{29-41=}} {{45-45=@autoclosure }}

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -622,20 +622,20 @@ class infer_instanceFunc1 {
 
   @objc func func16_(a: AnyObject) {} // no-error
 
-  func func17(a: () -> ()) {}
-// CHECK-LABEL: {{^}}  @objc func func17(a: () -> ()) {
+  func func17(a: @escaping () -> ()) {}
+// CHECK-LABEL: {{^}}  @objc func func17(a: @escaping () -> ()) {
 
-  @objc func func17_(a: () -> ()) {}
+  @objc func func17_(a: @escaping () -> ()) {}
 
-  func func18(a: (Int) -> (), b: Int) {}
-// CHECK-LABEL: {{^}}  @objc func func18(a: (Int) -> (), b: Int)
+  func func18(a: @escaping (Int) -> (), b: Int) {}
+// CHECK-LABEL: {{^}}  @objc func func18(a: @escaping (Int) -> (), b: Int)
 
-  @objc func func18_(a: (Int) -> (), b: Int) {}
+  @objc func func18_(a: @escaping (Int) -> (), b: Int) {}
 
-  func func19(a: (String) -> (), b: Int) {}
-// CHECK-LABEL: {{^}}  @objc func func19(a: (String) -> (), b: Int) {
+  func func19(a: @escaping (String) -> (), b: Int) {}
+// CHECK-LABEL: {{^}}  @objc func func19(a: @escaping (String) -> (), b: Int) {
 
-  @objc func func19_(a: (String) -> (), b: Int) {}
+  @objc func func19_(a: @escaping (String) -> (), b: Int) {}
 
   func func_FunctionReturn1() -> () -> () {}
 // CHECK-LABEL: {{^}}  @objc func func_FunctionReturn1() -> () -> () {
@@ -1956,9 +1956,9 @@ class ClassThrows1 {
   // CHECK: {{^}} func methodReturnsOptionalObjCClass() throws -> Class_ObjC1?
   func methodReturnsOptionalObjCClass() throws -> Class_ObjC1? { return nil }
 
-  // CHECK: @objc func methodWithTrailingClosures(_ s: String, fn1: ((Int) -> Int), fn2: (Int) -> Int, fn3: (Int) -> Int)
+  // CHECK: @objc func methodWithTrailingClosures(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int, fn3: @escaping (Int) -> Int)
   // CHECK-DUMP: func_decl "methodWithTrailingClosures(_:fn1:fn2:fn3:)"{{.*}}foreign_error=ZeroResult,unowned,param=1,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=Bool
-  func methodWithTrailingClosures(_ s: String, fn1: ((Int) -> Int), fn2: (Int) -> Int, fn3: (Int) -> Int) throws { }
+  func methodWithTrailingClosures(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int, fn3: @escaping (Int) -> Int) throws { }
 
   // CHECK: @objc init(degrees: Double) throws
   // CHECK-DUMP: constructor_decl "init(degrees:)"{{.*}}foreign_error=NilResult,unowned,param=1,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>
@@ -1967,9 +1967,9 @@ class ClassThrows1 {
 
 // CHECK-DUMP-LABEL: class_decl "SubclassImplicitClassThrows1"
 @objc class SubclassImplicitClassThrows1 : ImplicitClassThrows1 {
-  // CHECK: @objc override func methodWithTrailingClosures(_ s: String, fn1: ((Int) -> Int), fn2: ((Int) -> Int), fn3: ((Int) -> Int))
+  // CHECK: @objc override func methodWithTrailingClosures(_ s: String, fn1: (@escaping (Int) -> Int), fn2: (@escaping (Int) -> Int), fn3: (@escaping (Int) -> Int))
   // CHECK-DUMP: func_decl "methodWithTrailingClosures(_:fn1:fn2:fn3:)"{{.*}}foreign_error=ZeroResult,unowned,param=1,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=Bool
-  override func methodWithTrailingClosures(_ s: String, fn1: ((Int) -> Int), fn2: ((Int) -> Int), fn3: ((Int) -> Int)) throws { }
+  override func methodWithTrailingClosures(_ s: String, fn1: (@escaping (Int) -> Int), fn2: (@escaping (Int) -> Int), fn3: (@escaping (Int) -> Int)) throws { }
 }
 
 class ThrowsRedecl1 {
@@ -1979,7 +1979,7 @@ class ThrowsRedecl1 {
   @objc func method2AndReturnError(_ x: Int) { } // expected-note{{declared here}}
   @objc func method2() throws { } // expected-error{{with Objective-C selector 'method2AndReturnError:'}}
 
-  @objc func method3(_ x: Int, error: Int, closure: (Int) -> Int) { }  // expected-note{{declared here}}
+  @objc func method3(_ x: Int, error: Int, closure: @escaping (Int) -> Int) { }  // expected-note{{declared here}}
   @objc func method3(_ x: Int, closure: (Int) -> Int) throws { } // expected-error{{with Objective-C selector 'method3:error:closure:'}}
 
   @objc(initAndReturnError:) func initMethod1(error: Int) { } // expected-note{{declared here}}
@@ -1988,14 +1988,14 @@ class ThrowsRedecl1 {
   @objc(initWithString:error:) func initMethod2(string: String, error: Int) { } // expected-note{{declared here}}
   @objc init(string: String) throws { } // expected-error{{with Objective-C selector 'initWithString:error:'}}
 
-  @objc(initAndReturnError:fn:) func initMethod3(error: Int, fn: (Int) -> Int) { } // expected-note{{declared here}}
+  @objc(initAndReturnError:fn:) func initMethod3(error: Int, fn: @escaping (Int) -> Int) { } // expected-note{{declared here}}
   @objc init(fn: (Int) -> Int) throws { } // expected-error{{with Objective-C selector 'initAndReturnError:fn:'}}
 }
 
 class ThrowsObjCName {
-  @objc(method4:closure:error:) func method4(x: Int, closure: (Int) -> Int) throws { }
+  @objc(method4:closure:error:) func method4(x: Int, closure: @escaping (Int) -> Int) throws { }
 
-  @objc(method5AndReturnError:x:closure:) func method5(x: Int, closure: (Int) -> Int) throws { }
+  @objc(method5AndReturnError:x:closure:) func method5(x: Int, closure: @escaping (Int) -> Int) throws { }
 
   @objc(method6) func method6() throws { } // expected-error{{@objc' method name provides names for 0 arguments, but method has one parameter (the error parameter)}}
 
@@ -2003,19 +2003,19 @@ class ThrowsObjCName {
 
   // CHECK-DUMP: func_decl "method8(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=2,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=Bool
   @objc(method8:fn1:error:fn2:)
-  func method8(_ s: String, fn1: ((Int) -> Int), fn2: (Int) -> Int) throws { }
+  func method8(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 
   // CHECK-DUMP: func_decl "method9(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=0,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=Bool
   @objc(method9AndReturnError:s:fn1:fn2:)
-  func method9(_ s: String, fn1: ((Int) -> Int), fn2: (Int) -> Int) throws { }
+  func method9(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 }
 
 class SubclassThrowsObjCName : ThrowsObjCName {
   // CHECK-DUMP: func_decl "method8(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=2,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=Bool
-  override func method8(_ s: String, fn1: ((Int) -> Int), fn2: (Int) -> Int) throws { }
+  override func method8(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 
   // CHECK-DUMP: func_decl "method9(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=0,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=Bool
-  override func method9(_ s: String, fn1: ((Int) -> Int), fn2: (Int) -> Int) throws { }
+  override func method9(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 }
 
 @objc protocol ProtocolThrowsObjCName {

--- a/test/attr/attr_override.swift
+++ b/test/attr/attr_override.swift
@@ -265,7 +265,7 @@ class MismatchOptionalBase {
 
   func fixSeveralTypes(a: Int?, b: Int!) -> Int { return 0 }
 
-  func functionParam(x: ((Int) -> Int)?) {}
+  func functionParam(x: (@escaping (Int) -> Int)?) {}
   func tupleParam(x: (Int, Int)?) {}
 
   func nameAndTypeMismatch(label: Int?) {}
@@ -316,7 +316,7 @@ class MismatchOptional : MismatchOptionalBase {
   // expected-error@-2 {{cannot override instance method parameter of type 'Int!' with non-optional type 'Int'}} {{47-47=?}}
   // expected-error@-3 {{cannot override instance method result type 'Int' with optional type 'Int!'}} {{55-56=}}
 
-  override func functionParam(x: (Int) -> Int) {} // expected-error {{cannot override instance method parameter of type '((Int) -> Int)?' with non-optional type '(Int) -> Int'}} {{34-34=(}} {{46-46=)?}}
+  override func functionParam(x: @escaping (Int) -> Int) {} // expected-error {{cannot override instance method parameter of type '((Int) -> Int)?' with non-optional type '(Int) -> Int'}} {{34-34=(}} {{56-56=)?}}
   override func tupleParam(x: (Int, Int)) {} // expected-error {{cannot override instance method parameter of type '(Int, Int)?' with non-optional type '(Int, Int)'}} {{41-41=?}}
 
   override func nameAndTypeMismatch(_: Int) {}

--- a/test/decl/func/throwing_functions.swift
+++ b/test/decl/func/throwing_functions.swift
@@ -105,7 +105,7 @@ func testSubtypeArgument1(_ x1: (fn: ((String) -> Int)) -> Int,
 func subtypeArgument2(_ x: (fn: ((String) throws -> Int)) -> Int) { }
 func testSubtypeArgument2(_ x1: (fn: ((String) -> Int)) -> Int,
                           x2: (fn: ((String) throws -> Int)) -> Int) {
-  subtypeArgument2(x1) // expected-error{{cannot convert value of type '(fn: ((String) -> Int)) -> Int' to expected argument type '(fn: ((String) throws -> Int)) -> Int'}}
+  subtypeArgument2(x1) // expected-error{{cannot convert value of type '(fn: (@escaping (String) -> Int)) -> Int' to expected argument type '(fn: (@escaping (String) throws -> Int)) -> Int'}}
   subtypeArgument2(x2)
 }
 

--- a/test/decl/protocol/req/associated_type_inference.swift
+++ b/test/decl/protocol/req/associated_type_inference.swift
@@ -171,7 +171,7 @@ public protocol Thenable {
 }
 
 public class CorePromise<T> : Thenable { // expected-error{{type 'CorePromise<T>' does not conform to protocol 'Thenable'}}
-    public func then(_ success: (t: T, _: CorePromise<T>) -> T) -> Self {
+    public func then(_ success: @escaping (t: T, _: CorePromise<T>) -> T) -> Self {
         return self.then() { (t: T) -> T in
             return success(t: t, self)
         }

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -128,8 +128,8 @@ func anonymousClosureArgsInClosureWithArgs() {
   var a3 = { (z: Int) in $0 } // expected-error {{anonymous closure arguments cannot be used inside a closure that has explicit arguments}}
 }
 
-func doStuff(_ fn : () -> Int) {}
-func doVoidStuff(_ fn : () -> ()) {}
+func doStuff(_ fn : @escaping () -> Int) {}
+func doVoidStuff(_ fn : @escaping () -> ()) {}
 
 // <rdar://problem/16193162> Require specifying self for locations in code where strong reference cycles are likely
 class ExplicitSelfRequiredTest {

--- a/validation-test/stdlib/HashingAvalanche.swift
+++ b/validation-test/stdlib/HashingAvalanche.swift
@@ -8,7 +8,8 @@ import StdlibUnittest
 
 var HashingTestSuite = TestSuite("Hashing")
 
-func avalancheTest(_ bits: Int, _ hashUnderTest: (UInt64) -> UInt64, _ pValue: Double) {
+func avalancheTest(_ bits: Int, _ hashUnderTest: @escaping (UInt64) -> UInt64, 
+                   _ pValue: Double) {
   let testsInBatch = 100000
   let testData = randArray64(testsInBatch)
   let testDataHashed = Array(testData.lazy.map { hashUnderTest($0) })

--- a/validation-test/stdlib/HashingAvalanche.swift
+++ b/validation-test/stdlib/HashingAvalanche.swift
@@ -8,8 +8,11 @@ import StdlibUnittest
 
 var HashingTestSuite = TestSuite("Hashing")
 
-func avalancheTest(_ bits: Int, _ hashUnderTest: @escaping (UInt64) -> UInt64, 
-                   _ pValue: Double) {
+func avalancheTest(
+  _ bits: Int,
+  _ hashUnderTest: @escaping (UInt64) -> UInt64,
+  _ pValue: Double
+) {
   let testsInBatch = 100000
   let testData = randArray64(testsInBatch)
   let testDataHashed = Array(testData.lazy.map { hashUnderTest($0) })

--- a/validation-test/stdlib/NewArray.swift.gyb
+++ b/validation-test/stdlib/NewArray.swift.gyb
@@ -248,7 +248,7 @@ testCocoa()
 #endif // _runtime(_ObjC)
 
 extension ArraySlice {
-  mutating func qsort(_ compare: (Element, Element) -> Bool) {
+  mutating func qsort(_ compare: @escaping (Element, Element) -> Bool) {
     _introSort(&self, subRange: Range(self.indices), by: compare)
   }
 }
@@ -320,14 +320,14 @@ let testWidth = 11
 %arrayTypes = ['ContiguousArray', 'Array', 'ArraySlice']
 %for A in arrayTypes:
 
-func testReplace(_ make: () -> ${A}<LifetimeTracked>) {
+func testReplace(_ make: @escaping () -> ${A}<LifetimeTracked>) {
 
   checkRangeReplaceable(
     make, { LifetimeTracked(100)..<LifetimeTracked(100 + $0) })
 }
 
 func testReplace${A}(
-  makeOne: () -> ${A}<LifetimeTracked> = {
+  makeOne: @escaping () -> ${A}<LifetimeTracked> = {
     var x = ${A}<LifetimeTracked>()
     // make sure some - but not all - replacements will have to grow the buffer
     x.reserveCapacity(testWidth * 3 / 2)


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

```
[noescape by defaul] make noescape the default

This makes @noescape be the default semantics for
function types in argument positions, for everything except property
setters. Property setters are naturally escaping, so they keep their
escaping-by-default behavior.

There is some further (non-source-breaking) work to be done for
SE-0103:

- We need the withoutActuallyEscaping function
- Improve diagnostics and QoI to at least @noescape's standards
- Deprecate / drop @noescape, right now we allow it
- Update internal code completion printing to be contextual
- Add more tests to explore tricky corner cases
- Small regressions in fixits in attr/attr_availability.swift
- Use @autoclosure @escaping instead of @autoclosure(escaping)
```
#### Resolved bug number: ([SR-1952](https://bugs.swift.org/browse/SR-1952))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
