### PR TITLE
Sema: Fix bogus 'parameters may not have the 'var' specifier' diagnostic

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -288,6 +288,11 @@ class alignas(1 << DeclAlignInBits) Decl {
     /// once (either in its declaration, or once later), making it immutable.
     unsigned IsLet : 1;
 
+    /// \brief Whether this is an 'inout' parameter; this is preferable
+    /// to checking if the parameter type is an InOutType, because invalid
+    /// inout parameters have an error type.
+    unsigned IsInOut : 1;
+
     /// \brief Whether this vardecl has an initial value bound to it in a way
     /// that isn't represented in the AST with an initializer in the pattern
     /// binding.  This happens in cases like "for i in ...", switch cases, etc.
@@ -301,7 +306,7 @@ class alignas(1 << DeclAlignInBits) Decl {
     /// a.storage for lazy var a is a decl that cannot be accessed.
     unsigned IsUserAccessible : 1;
   };
-  enum { NumVarDeclBits = NumAbstractStorageDeclBits + 5 };
+  enum { NumVarDeclBits = NumAbstractStorageDeclBits + 6 };
   static_assert(NumVarDeclBits <= 32, "fits in an unsigned");
   
   class EnumElementDeclBitfields {
@@ -4234,6 +4239,7 @@ protected:
     VarDeclBits.IsUserAccessible = true;
     VarDeclBits.IsStatic = IsStatic;
     VarDeclBits.IsLet = IsLet;
+    VarDeclBits.IsInOut = false;
     VarDeclBits.IsDebuggerVar = false;
     VarDeclBits.HasNonPatternBindingInit = false;
     setType(Ty);
@@ -4330,6 +4336,10 @@ public:
   /// Is this an immutable 'let' property?
   bool isLet() const { return VarDeclBits.IsLet; }
   void setLet(bool IsLet) { VarDeclBits.IsLet = IsLet; }
+
+  /// Is this an 'inout' parameter?
+  bool isInOut() const { return VarDeclBits.IsInOut; }
+  void setInOut(bool InOut) { VarDeclBits.IsInOut = InOut; }
 
   /// Return true if this vardecl has an initial value bound to it in a way
   /// that isn't represented in the AST with an initializer in the pattern
@@ -4439,6 +4449,7 @@ public:
   ExprHandle *getDefaultValue() const {
     return DefaultValueAndIsVariadic.getPointer();
   }
+
   /// Whether or not this parameter is varargs.
   bool isVariadic() const { return DefaultValueAndIsVariadic.getInt(); }
   void setVariadic(bool value = true) {DefaultValueAndIsVariadic.setInt(value);}

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -387,8 +387,10 @@ mapParsedParameters(Parser &parser,
     // If a type was provided, create the type for the parameter.
     if (auto type = paramInfo.Type) {
       // If 'inout' was specified, turn the type into an in-out type.
-      if (specifierKind == Parser::ParsedParameter::InOut)
+      if (specifierKind == Parser::ParsedParameter::InOut) {
         type = new (ctx) InOutTypeRepr(type, paramInfo.LetVarInOutLoc);
+        param->setInOut(true);
+      }
 
       param->getTypeLoc() = TypeLoc(type);
     } else if (paramContext != Parser::ParameterContextKind::Closure) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1121,6 +1121,7 @@ Type swift::configureImplicitSelf(TypeChecker &tc,
   // 'self' is 'let' for reference types (i.e., classes) or when 'self' is
   // neither inout.
   selfDecl->setLet(!selfTy->is<InOutType>());
+  selfDecl->setInOut(selfTy->is<InOutType>());
   selfDecl->overwriteType(selfTy);
   
   // Install the self type on the Parameter that contains it.  This ensures that

--- a/test/Constraints/same_types.swift
+++ b/test/Constraints/same_types.swift
@@ -139,6 +139,6 @@ struct BadFooable : Fooable {
   var foo: Foo { while true {} }
 }
 
-func bogusInOutError(d: inout Brunch<BadFooable>) {} // expected-error{{parameters may not have the 'var' specifier}}
+func bogusInOutError(d: inout Brunch<BadFooable>) {}
 // expected-error@-1{{'Brunch' requires the types '<<error type>>' and 'X' be equivalent}}
 

--- a/test/decl/func/functions.swift
+++ b/test/decl/func/functions.swift
@@ -155,3 +155,7 @@ func testCurryFixits() {
   func f5(_ x: Int)()(y: Int) {} // expected-error{{curried function declaration syntax has been removed; use a single parameter list}} {{19-21=}} {{21-23=, }}
   func f5a(_ x: Int, y: Int) {}
 }
+
+// Bogus diagnostic talking about a 'var' where there is none
+func invalidInOutParam(x: inout XYZ) {}
+// expected-error@-1{{use of undeclared type 'XYZ'}}


### PR DESCRIPTION
Small regression with Swift 3 language changes.
