### PR TITLE
Do not allow Any to satisfy more specific same-type constraints.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1885,19 +1885,6 @@ ConstraintSystem::matchTypes(Type type1, Type type2, TypeMatchKind kind,
   // we hit commit_to_conversions below, but we have to add a token restriction
   // to ensure we wrap the metatype value in a metatype erasure.
   if (concrete && type2->isExistentialType()) {
-    
-    // If we're binding to an empty existential, we need to make sure that the
-    // conversion is valid.
-    if (kind == TypeMatchKind::BindType &&
-        type2->isEmptyExistentialComposition()) {
-      
-      conversionsOrFixes.push_back(ConversionRestrictionKind::Existential);
-      addConstraint(ConstraintKind::SelfObjectOfProtocol,
-                    type1, type2, getConstraintLocator(locator));
-      
-      return SolutionKind::Solved;
-    }
-    
     if (kind == TypeMatchKind::ConformsTo) {
       conversionsOrFixes.push_back(ConversionRestrictionKind::
                                    MetatypeToExistentialMetatype);

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -236,3 +236,20 @@ Whatever.foo(a: 23) // expected-error {{generic parameter 'A' could not be infer
 // <rdar://problem/21718955> Swift useless error: cannot invoke 'foo' with no arguments
 Whatever.bar()  // expected-error {{generic parameter 'A' could not be inferred}}
 
+// <rdar://problem/27515965> Type checker doesn't enforce same-type constraint if associated type is Any
+protocol P27515965 {
+  associatedtype R
+  func f() -> R
+}
+
+struct S27515965 : P27515965 {
+  func f() -> Any { return self }
+}
+
+struct V27515965 {
+  init<T : P27515965>(_ tp: T) where T.R == Float {}
+}
+
+func test(x: S27515965) -> V27515965 {
+  return V27515965(x) // expected-error {{generic parameter 'T' could not be inferred}}
+}


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Fix an issue where an associated type inferred to be Any is allowed to satisfy all same-type constraints on types.

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

For associated types inferred to be Any, we were allowing the type to
satisfy more specific same-type constraints, e.g. Element ==
Character (where Element is the associated type). This is clearly wrong.

The fix here is very specific to empty protocol compositions, and
removes some code in matchTypes() that doesn't make a lot of
sense. Looking back at the history, this was added in a commit that made
a handful of other changes, and it's not clear this particular change
was important for the issues that commit claimed to fix (and in fact
removing this regresses no tests).

Fixes rdar://problem/27515965.
