### PR TITLE
[swift-ide-test] Add -debug-constraints option; add logging to typeCh…

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -19,9 +19,10 @@
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/ParameterList.h"
+#include "swift/AST/PrettyStackTrace.h"
 #include "swift/Sema/IDETypeChecking.h"
-#include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/APInt.h"
+#include "llvm/ADT/StringExtras.h"
 
 using namespace swift;
 using namespace swift::constraints;
@@ -3010,20 +3011,25 @@ public:
     return Expr->getType();
   }
 
-  void collectResolvedType(Solution &S, SmallVectorImpl<Type> &PossibleTypes) {
+  bool collectResolvedType(Solution &S, SmallVectorImpl<Type> &PossibleTypes) {
     if (auto Bind = S.typeBindings[VT]) {
       // We allow type variables in the overall solution, but must skip any
       // type variables in the binding for VT; these types must outlive the
       // constraint solver memory arena.
-      if (!Bind->hasTypeVariable())
+      if (!Bind->hasTypeVariable()) {
         PossibleTypes.push_back(Bind);
+        return true;
+      }
     }
+    return false;
   }
 };
 
 bool swift::typeCheckUnresolvedExpr(DeclContext &DC,
                                     Expr *E, Expr *Parent,
                                     SmallVectorImpl<Type> &PossibleTypes) {
+  PrettyStackTraceExpr stackTrace(DC.getASTContext(),
+                                  "type-checking unresolved member", Parent);
   ConstraintSystemOptions Options = ConstraintSystemFlags::AllowFixes;
   auto *TC = static_cast<TypeChecker*>(DC.getASTContext().getLazyResolver());
   ConstraintSystem CS(*TC, &DC, Options);
@@ -3032,12 +3038,29 @@ bool swift::typeCheckUnresolvedExpr(DeclContext &DC,
   ConstraintWalker cw(MCG);
   Parent->walk(cw);
 
+  if (TC->getLangOpts().DebugConstraintSolver) {
+    auto &log = DC.getASTContext().TypeCheckerDebug->getStream();
+    log << "---Initial constraints for the given expression---\n";
+    Parent->print(log);
+    log << "\n";
+    CS.print(log);
+  }
+
   SmallVector<Solution, 3> solutions;
   if (CS.solve(solutions, FreeTypeVariableBinding::Allow)) {
     return false;
   }
+
   for (auto &S : solutions) {
-    MCG.collectResolvedType(S, PossibleTypes);
+    bool resolved = MCG.collectResolvedType(S, PossibleTypes);
+
+    if (TC->getLangOpts().DebugConstraintSolver) {
+      auto &log = DC.getASTContext().TypeCheckerDebug->getStream();
+      log << "--- Solution ---\n";
+      S.dump(log);
+      if (resolved)
+        log << "--- Resolved target type ---\n" << PossibleTypes.back() << "\n";
+    }
   }
   return !PossibleTypes.empty();
 }

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -543,6 +543,9 @@ static llvm::cl::opt<bool>
 NoEmptyLineBetweenMembers("no-empty-line-between-members",
                           llvm::cl::desc("Print no empty line between members."),
                           llvm::cl::init(false));
+
+static llvm::cl::opt<bool> DebugConstraintSolver("debug-constraints",
+    llvm::cl::desc("Enable verbose debugging from the constraint solver."));
 } // namespace options
 
 static std::unique_ptr<llvm::MemoryBuffer>
@@ -2799,6 +2802,9 @@ int main(int argc, char *argv[]) {
     options::DebugForbidTypecheckPrefix;
   InitInvok.getLangOptions().EnableObjCAttrRequiresFoundation =
     !options::DisableObjCAttrRequiresFoundationModule;
+
+  InitInvok.getLangOptions().DebugConstraintSolver =
+      options::DebugConstraintSolver;
 
   for (auto ConfigName : options::BuildConfigs)
     InitInvok.getLangOptions().addCustomConditionalCompilationFlag(ConfigName);


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…eckUnresolvedExpr

I keep wanting to debug type-checking of unresolved members, so add the
logic so I can enable it from swift-ide-test rather than having to
modify the source.
