### PR TITLE
Propagate dbg.value intrinsics into basic blocks with a range extension intrinsic.

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -19,6 +19,7 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/InlineAsm.h"
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/ADT/MapVector.h"
@@ -587,7 +588,7 @@ public:
   void emitDebugVariableRangeExtension(const SILBasicBlock *CurBB) {
     if (IGM.IRGen.Opts.Optimize)
       return;
-    for (auto &Variable : ValueVariables) {
+    for (auto &Variable : reversed(ValueVariables)) {
       auto VarDominancePoint = Variable.first;
       llvm::Value *Storage = Variable.second;
       if (getActiveDominancePoint() == VarDominancePoint ||
@@ -613,6 +614,24 @@ public:
         auto *AsmFnTy = llvm::FunctionType::get(IGM.VoidTy, ArgTys, false);
         auto *InlineAsm = llvm::InlineAsm::get(AsmFnTy, "", "r", true);
         Builder.CreateCall(InlineAsm, Storage);
+        // Propagate the dbg.value intrinsics into the later basic blocks.  Note
+        // that this shouldn't be necessary. LiveDebugValues should be doing
+        // this but can't in general because it currently only tracks register
+        // locations.
+        auto It = llvm::BasicBlock::iterator(Variable.second);
+        auto *BB = Variable.second->getParent();
+        auto *CurBB = Builder.GetInsertBlock();
+        if (BB != CurBB)
+          for (auto I = std::next(It), E = BB->end(); I != E; ++I) {
+            auto *DVI = dyn_cast<llvm::DbgValueInst>(I);
+            if (DVI && DVI->getValue() == Variable.second)
+              IGM.DebugInfo->getBuilder().insertDbgValueIntrinsic(
+                  DVI->getValue(), 0, DVI->getVariable(), DVI->getExpression(),
+                  DVI->getDebugLoc(), &*CurBB->getFirstInsertionPt());
+            else
+              // Found all dbg.value instrinsics describing this location.
+              break;
+        }
       }
     }
   }
@@ -1589,9 +1608,9 @@ void IRGenSILFunction::visitSILBasicBlock(SILBasicBlock *BB) {
           ArgsEmitted = true;
         }
       }
+      if (isa<TermInst>(&I))
+        emitDebugVariableRangeExtension(BB);
     }
-    if (isa<TermInst>(&I))
-      emitDebugVariableRangeExtension(BB);
     visit(&I);
 
     assert(!EmissionNotes.count(&I) &&

--- a/test/DebugInfo/liverange-extension.swift
+++ b/test/DebugInfo/liverange-extension.swift
@@ -11,14 +11,17 @@ public func rangeExtension(_ b: Bool) {
   use(i)
   if b {
     let j = getInt32()
+    // CHECK: llvm.dbg.value(metadata i32 [[I]], i64 0, metadata
     // CHECK: llvm.dbg.value(metadata i32 [[J:.*]], i64 0, metadata
     use(j)
-    // CHECK: asm sideeffect "", "r"
     // CHECK: {{(asm sideeffect "", "r".*)|(zext i32)}} [[J]]
+    // CHECK: asm sideeffect "", "r"
   }
   let z = getInt32()
   use(z)
+  // CHECK: llvm.dbg.value(metadata i32 [[I]], i64 0, metadata
+  // CHECK-NOT: llvm.dbg.value(metadata i32 [[J]], i64 0, metadata
   // CHECK: llvm.dbg.value(metadata i32 [[Z:.*]], i64 0, metadata
-  // CHECK: {{(asm sideeffect "", "r".*)|(zext i32)}} [[I]]
   // CHECK: asm sideeffect "", "r"
+  // CHECK: {{(asm sideeffect "", "r".*)|(zext i32)}} [[I]]
 }


### PR DESCRIPTION
This is working around a bug in LLVM.
LiveDebugValues should be doing this but can't in general because it
currently only tracks register locations.

rdar://problem/27348117
