### PR TITLE
[CodeCompletion] Complete unresolved members that are not enums or Op…

### DIFF
--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -46,6 +46,10 @@
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OTHER_FILE_1 %S/Inputs/EnumFromOtherFile.swift | FileCheck %s -check-prefix=OTHER_FILE_1
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NON_OPT_SET_1 | FileCheck %s -check-prefix=NON_OPT_SET_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NON_OPT_SET_2 | FileCheck %s -check-prefix=NON_OPT_SET_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NON_OPT_SET_3 | FileCheck %s -check-prefix=NON_OPT_SET_1
+
 enum SomeEnum1 {
   case South
   case North
@@ -271,10 +275,11 @@ func testAvail1(x: EnumAvail1) {
 func testAvail2(x: OptionsAvail1) {
   testAvail2(.#^OPTIONS_AVAIL_1^#)
 }
-// OPTIONS_AVAIL_1: Begin completions, 2 items
+// OPTIONS_AVAIL_1: Begin completions, 3 items
 // ENUM_AVAIL_1-NOT: AAA
 // OPTIONS_AVAIL_1-DAG: Decl[StaticVar]/CurrNominal:        aaa[#OptionsAvail1#];
 // OPTIONS_AVAIL_1-DAG: Decl[StaticVar]/CurrNominal/NotRecommended: BBB[#OptionsAvail1#];
+// OPTIONS_AVAIL_1-DAG: Decl[Constructor]/CurrNominal:      init({#rawValue: Int#})[#OptionsAvail1#]
 // ENUM_AVAIL_1-NOT: AAA
 // OPTIONS_AVAIL_1: End completions
 
@@ -329,3 +334,33 @@ func enumFromOtherFile() -> EnumFromOtherFile {
 // OTHER_FILE_1-DAG: Decl[EnumElement]/ExprSpecific:     a({#Int#})[#(Int) -> EnumFromOtherFile#];
 // OTHER_FILE_1-DAG: Decl[EnumElement]/ExprSpecific:     c[#EnumFromOtherFile#];
 // OTHER_FILE_1: End completions
+
+struct NonOptSet {
+  static let a = NonOptSet()
+  static let wrongType = 1
+  let notStatic = NonOptSet()
+  init(x: Int, y: Int) {}
+  init() {}
+  static func b() -> NonOptSet { return NonOptSet() }
+  static func wrongType() -> Int { return 0 }
+  func notStatic() -> NonOptSet { return NonOptSet() }
+}
+
+func testNonOptSet() {
+  let x: NonOptSet
+  x = .#^NON_OPT_SET_1^#
+}
+// NON_OPT_SET_1: Begin completions, 4 items
+// NON_OPT_SET_1-DAG: Decl[StaticVar]/CurrNominal:        a[#NonOptSet#]
+// NON_OPT_SET_1-DAG: Decl[Constructor]/CurrNominal:      init({#x: Int#}, {#y: Int#})[#NonOptSet#]
+// NON_OPT_SET_1-DAG: Decl[Constructor]/CurrNominal:      init()[#NonOptSet#]
+// NON_OPT_SET_1-DAG: Decl[StaticMethod]/CurrNominal:     b()[#NonOptSet#]
+// NON_OPT_SET_1: End completions
+
+func testNonOptSet() {
+  let x: NonOptSet = .#^NON_OPT_SET_2^#
+}
+
+func testNonOptSet() -> NonOptSet {
+  return .#^NON_OPT_SET_3^#
+}


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…tionSets

Replace the enum and OptionSet-specific code with static member lookup
that checks the type against the contextual type.  This lets us complete
static variables, static functions, and initializers.  In particular,
this fixes completion of NS_EXTENSIBLE_STRING_ENUM types from
Objective-C.

rdar://problem/26628652
