### PR TITLE
Make the llvm-include-tests flag actually do something

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1973,6 +1973,13 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DCLANG_TOOL_CLANG_FORMAT_BUILD=NO
                     )
                 fi
+                
+                if [[ $(true_false "${LLVM_INCLUDE_TESTS}") == "FALSE" ]]; then
+                    cmake_options+=(
+                        -DLLVM_INCLUDE_TESTS=NO
+                        -DCLANG_INCLUDE_TESTS=NO
+                    )
+                fi
 
                 if [[ $(is_cross_tools_host ${host}) ]] ; then
                     cmake_options=(


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

The only way to set "LLVM_INCLUDE_TESTS=NO" and "CLANG_INCLUDE_TESTS=NO" in CMake currently is with the build-toolchain-only flag, but that has lots of other stuff it disables. This allows a configuration where the clang and llvm tests aren't built but everything else is (tools,etc).

The function "compute_cmake_llvm_tool_disable_flags()" never gets called, so unless you use build-toolchain-only, there is no way to not build these tests, but that flag also disables the tools.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Before this patch, it would not actually do anything unless
compute_cmake_llvm_tool_disable_flags()
was called, which is currently dead code, in the state of
build-script-impl currently.
