### PR TITLE
[swiftc (35 vs. 5154)] Add crasher in swift::Type::transform(...)

### DIFF
--- a/validation-test/compiler_crashers/28380-swift-type-transform.swift
+++ b/validation-test/compiler_crashers/28380-swift-type-transform.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+func f<T{{if true as[T.h


### PR DESCRIPTION
New record: 38 crashers fixed during the last 7 days! Thank you @manavgabhawala, @slavapestov, @bitjammer and @DougGregor! 🎈 🎂 

---

Add test case for crash triggered in `swift::Type::transform(...)`.

Current number of unresolved compiler crashers: 35 (5154 resolved)

Stack trace:

```
5  swift           0x0000000001152d13 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 35
6  swift           0x000000000115399f swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 3247
7  swift           0x0000000000f5ebde swift::constraints::ConstraintSystem::openType(swift::Type, swift::constraints::ConstraintLocatorBuilder, llvm::DenseMap<swift::CanType, swift::TypeVariableType*, llvm::DenseMapInfo<swift::CanType>, llvm::detail::DenseMapPair<swift::CanType, swift::TypeVariableType*> >&) + 78
10 swift           0x000000000109170c swift::Expr::walk(swift::ASTWalker&) + 108
11 swift           0x0000000000faa0c8 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) + 200
12 swift           0x0000000000eb8e93 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 371
13 swift           0x0000000000ebfc8d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 621
14 swift           0x0000000000ec1994 swift::TypeChecker::typeCheckCondition(swift::Expr*&, swift::DeclContext*) + 180
15 swift           0x0000000000ec1aeb swift::TypeChecker::typeCheckStmtCondition(llvm::MutableArrayRef<swift::StmtConditionElement>&, swift::DeclContext*, swift::Diag<>) + 251
19 swift           0x0000000000f3cb04 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
20 swift           0x0000000000f690cc swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
21 swift           0x0000000000ebfd2a swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 778
24 swift           0x0000000000f3b7da swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
25 swift           0x0000000000f3b63e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
26 swift           0x0000000000f3c203 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
28 swift           0x0000000000ef6a31 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
29 swift           0x0000000000c77be9 swift::CompilerInstance::performSema() + 3289
31 swift           0x00000000007daf57 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
32 swift           0x00000000007a6e38 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28380-swift-type-transform.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28380-swift-type-transform-07a9ce.o
1.  While type-checking 'f' at validation-test/compiler_crashers/28380-swift-type-transform.swift:9:1
2.  While type-checking expression at [validation-test/compiler_crashers/28380-swift-type-transform.swift:9:10 - line:9:24] RangeText="{if true as[T.h"
3.  While type-checking expression at [validation-test/compiler_crashers/28380-swift-type-transform.swift:9:14 - line:9:24] RangeText="true as[T.h"
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
