### PR TITLE
[swiftc (36 vs. 5154)] Add crasher in swift::ArchetypeBuilder::addRequirement(...)

### DIFF
--- a/validation-test/compiler_crashers/28381-swift-archetypebuilder-addrequirement.swift
+++ b/validation-test/compiler_crashers/28381-swift-archetypebuilder-addrequirement.swift
@@ -1,0 +1,14 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+{{
+class A:a}protocol a{typealias f:a
+let t:A
+protocol A
+typealias e:a


### PR DESCRIPTION
Add test case for crash triggered in `swift::ArchetypeBuilder::addRequirement(...)`.

Current number of unresolved compiler crashers: 36 (5154 resolved)

Assertion failure in [`lib/AST/ArchetypeBuilder.cpp (line 1489)`](https://github.com/apple/swift/blob/master/lib/AST/ArchetypeBuilder.cpp#L1489):

```
Assertion `!invalid && "Re-introducing invalid requirement"' failed.

When executing: void swift::ArchetypeBuilder::addRequirement(const swift::Requirement &, swift::RequirementSource)
```

Assertion context:

```
    (void)existential;

    // Add each of the protocols.
    for (auto proto : conformsTo) {
      bool invalid = addConformanceRequirement(pa, proto, source);
      assert(!invalid && "Re-introducing invalid requirement");
      (void)invalid;
    }

    return;
  }
```

Stack trace:

```
swift: /path/to/swift/lib/AST/ArchetypeBuilder.cpp:1489: void swift::ArchetypeBuilder::addRequirement(const swift::Requirement &, swift::RequirementSource): Assertion `!invalid && "Re-introducing invalid requirement"' failed.
8  swift           0x00000000010168bd swift::ArchetypeBuilder::addRequirement(swift::Requirement const&, swift::RequirementSource) + 605
9  swift           0x0000000001018553 swift::ArchetypeBuilder::addGenericSignature(swift::GenericSignature*, bool, bool) + 515
10 swift           0x0000000000f0c52f swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::GenericSignature*, bool, swift::GenericTypeResolver*) + 63
11 swift           0x0000000000f0df47 swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 135
12 swift           0x0000000000f0ea9f swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) + 111
13 swift           0x0000000000ecd466 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1830
14 swift           0x000000000113b66b swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2667
15 swift           0x0000000001139efb swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2491
16 swift           0x0000000000f10d5b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
19 swift           0x0000000000f4322e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
21 swift           0x0000000000f44184 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
22 swift           0x0000000000f43120 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
23 swift           0x0000000000f14df9 swift::TypeChecker::typeCheckPattern(swift::Pattern*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) + 937
25 swift           0x0000000000ecdc4b swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3851
28 swift           0x0000000000f1be0e swift::TypeChecker::checkConformance(swift::NormalProtocolConformance*) + 1694
29 swift           0x0000000000f1c547 swift::TypeChecker::checkConformancesInContext(swift::DeclContext*, swift::IterableDeclContext*) + 471
32 swift           0x0000000000ed31a6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
35 swift           0x0000000000f3d154 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
36 swift           0x0000000000f696ac swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
37 swift           0x0000000000ec037a swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 778
40 swift           0x0000000000f3d154 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
41 swift           0x0000000000f696ac swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
42 swift           0x0000000000ec037a swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 778
44 swift           0x0000000000f3d296 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
45 swift           0x0000000000ef6fed swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
46 swift           0x0000000000c77d69 swift::CompilerInstance::performSema() + 3289
48 swift           0x00000000007db0d7 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
49 swift           0x00000000007a6fb8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28381-swift-archetypebuilder-addrequirement.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28381-swift-archetypebuilder-addrequirement-cb9111.o
1.  While type-checking expression at [validation-test/compiler_crashers/28381-swift-archetypebuilder-addrequirement.swift:10:1 - line:14:13] RangeText="{{
2.  While type-checking expression at [validation-test/compiler_crashers/28381-swift-archetypebuilder-addrequirement.swift:10:2 - line:11:10] RangeText="{
3.  While type-checking 'A' at validation-test/compiler_crashers/28381-swift-archetypebuilder-addrequirement.swift:11:1
4.  While resolving type A at [validation-test/compiler_crashers/28381-swift-archetypebuilder-addrequirement.swift:12:7 - line:12:7] RangeText="A"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
