### PR TITLE
[Lex] Reject standalone dollars as identifiers

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -833,7 +833,7 @@ void Lexer::lexDollarIdent() {
   }
 
   // We reserve $nonNumeric for persistent bindings in the debugger.
-  if(!isAllDigits) {
+  if (!isAllDigits) {
     if (!LangOpts.EnableDollarIdentifiers)
       diagnose(tokStart, diag::expected_dollar_numeric);
 

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -829,7 +829,7 @@ void Lexer::lexDollarIdent() {
   // It's always an error to see a standalone $
   if (CurPtr == tokStart + 1) {
     diagnose(tokStart, diag::expected_dollar_numeric);
-    return formToken(tok::unknown, TokStart);
+    return formToken(tok::unknown, tokStart);
   }
 
   // We reserve $nonNumeric for persistent bindings in the debugger.

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -805,7 +805,7 @@ void Lexer::lexOperatorIdentifier() {
   return formToken(leftBound ? tok::oper_postfix : tok::oper_prefix, TokStart);
 }
 
-/// lexDollarIdent - Match $[0-9a-zA-Z_$]*
+/// lexDollarIdent - Match $[0-9a-zA-Z_$]+
 void Lexer::lexDollarIdent() {
   const char *tokStart = CurPtr-1;
   assert(*tokStart == '$');
@@ -826,10 +826,15 @@ void Lexer::lexDollarIdent() {
     }
   }
 
-  // It's always an error to see a standalone $, and we reserve
-  // $nonNumeric for persistent bindings in the debugger.
-  if (CurPtr == tokStart + 1 || !isAllDigits) {
-    if (!isAllDigits && !LangOpts.EnableDollarIdentifiers)
+  // It's always an error to see a standalone $
+  if (CurPtr == tokStart + 1) {
+    diagnose(tokStart, diag::expected_dollar_numeric);
+    return formToken(tok::unknown, TokStart);
+  }
+
+  // We reserve $nonNumeric for persistent bindings in the debugger.
+  if(!isAllDigits) {
+    if (!LangOpts.EnableDollarIdentifiers)
       diagnose(tokStart, diag::expected_dollar_numeric);
 
     // Even if we diagnose, we go ahead and form an identifier token,

--- a/test/Parse/ConditionalCompilation/compiler_version.swift
+++ b/test/Parse/ConditionalCompilation/compiler_version.swift
@@ -31,7 +31,7 @@
 
 #if !_compiler_version("777.*.7")
   // This shouldn't emit any diagnostics.
-  $#%^*&
+  %#^*&
 #endif
 
 #if _compiler_version("700a.*.10") // expected-error {{version component contains non-numeric characters}}

--- a/test/Parse/ConditionalCompilation/language_version.swift
+++ b/test/Parse/ConditionalCompilation/language_version.swift
@@ -31,7 +31,7 @@
 
 #if !swift(>=1.0)
   // This shouldn't emit any diagnostics.
-  $#%^*&
+  %#^*&
 #endif
 
 #if swift(">=7.1") // expected-error {{unexpected platform condition argument: expected a unary comparison, such as '>=2.2'}}
@@ -62,7 +62,7 @@ protocol P {
 
   // There should be no error here.
   adsf asdf asdf
-  $#%^*&
+  %#^*&
   func foo(sdfsdfdsf adsf adsf asdf adsf adsf)
 #endif
 }

--- a/test/Parse/dollar_identifier.swift
+++ b/test/Parse/dollar_identifier.swift
@@ -1,0 +1,13 @@
+// RUN: %target-parse-verify-swift
+
+var $ : Int // expected-error {{expected numeric value following '$'}}
+let $ = 42 // expected-error {{expected numeric value following '$'}}
+class $ : {} // expected-error {{expected numeric value following '$'}}
+enum $ : {} // expected-error {{expected numeric value following '$'}}
+struct $ : {} // expected-error {{expected numeric value following '$'}}
+
+var $a : Int // expected-error {{expected numeric value following '$'}}
+let $b = 42 // expected-error {{expected numeric value following '$'}}
+class $c : {} // expected-error {{expected numeric value following '$'}}
+enum $d : {} // expected-error {{expected numeric value following '$'}}
+struct $e : {} // expected-error {{expected numeric value following '$'}}

--- a/test/Parse/dollar_identifier.swift
+++ b/test/Parse/dollar_identifier.swift
@@ -1,13 +1,29 @@
 // RUN: %target-parse-verify-swift
 
-var $ : Int // expected-error {{expected numeric value following '$'}}
-let $ = 42 // expected-error {{expected numeric value following '$'}}
-class $ : {} // expected-error {{expected numeric value following '$'}}
-enum $ : {} // expected-error {{expected numeric value following '$'}}
-struct $ : {} // expected-error {{expected numeric value following '$'}}
+// SR-1661: Dollar was accidentally allowed as an identifier and identifier head.
 
-var $a : Int // expected-error {{expected numeric value following '$'}}
-let $b = 42 // expected-error {{expected numeric value following '$'}}
-class $c : {} // expected-error {{expected numeric value following '$'}}
-enum $d : {} // expected-error {{expected numeric value following '$'}}
-struct $e : {} // expected-error {{expected numeric value following '$'}}
+func dollarVar() {
+  var $ : Int = 42 // expected-error {{expected numeric value following '$'}} expected-error {{expected pattern}}
+}
+func dollarLet() {
+  let $ = 42 // expected-error {{expected numeric value following '$'}} expected-error {{expected pattern}} 
+}
+func dollarClass() {
+  class $ {} // expected-error {{expected numeric value following '$'}} 
+             // expected-error@-1 {{expression resolves to an unused function}}
+             // expected-error@-2 {{expected identifier in class declaration}}
+             // expected-error@-3 {{braced block of statements is an unused closure}}
+}
+func dollarEnum() {
+  enum $ {} // expected-error {{expected numeric value following '$'}} 
+            // expected-error@-1 {{expected identifier in enum declaration}}
+            // expected-error@-2 {{expression resolves to an unused function}}
+            // expected-error@-3 {{braced block of statements is an unused closure}}
+}
+func dollarStruct() {
+  struct $ {} // expected-error {{expected numeric value following '$'}}
+              // expected-error@-1 {{expected identifier in struct declaration}}
+              // expected-error@-2 {{braced block of statements is an unused closure}}
+              // expected-error@-3 {{expression resolves to an unused function}}
+}
+


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Fixes a case where we accidentally accepted a single dollar as an identifier.  This patch supersedes #3004.
#### Resolved bug number: ([SR-1661](https://bugs.swift.org/browse/SR-1661))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
