### PR TITLE
TypeChecker: Fix implicit dynamic inference for extensions methods

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2113,11 +2113,7 @@ static void inferDynamic(ASTContext &ctx, ValueDecl *D) {
     return;
 
   // Only introduce 'dynamic' on declarations...
-  if (isa<ExtensionDecl>(D->getDeclContext())) {
-    // ...in extensions that don't override other declarations.
-    if (D->getOverriddenDecl())
-      return;
-  } else {
+  if (!isa<ExtensionDecl>(D->getDeclContext())) {
     // ...and in classes on decls marked @NSManaged.
     if (!D->getAttrs().hasAttribute<NSManagedAttr>())
       return;

--- a/test/IRGen/Inputs/objc_extension_base.swift
+++ b/test/IRGen/Inputs/objc_extension_base.swift
@@ -1,0 +1,8 @@
+import gizmo
+
+public class SwiftBaseGizmo : Gizmo {
+}
+
+extension SwiftBaseGizmo {
+  public override func frob() {}
+}

--- a/test/IRGen/objc_extensions.swift
+++ b/test/IRGen/objc_extensions.swift
@@ -1,12 +1,14 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -disable-objc-attr-requires-foundation-module -emit-module %S/Inputs/objc_extension_base.swift -o %t
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop
 
 import Foundation
 import gizmo
+import objc_extension_base
 
 // Check that metadata for nested enums added in extensions to imported classes
 // gets emitted concretely.
@@ -156,4 +158,17 @@ class NSDogcow : NSObject {}
 // CHECK: @"_CATEGORY_PROPERTIES__TtC15objc_extensions8NSDogcow_$_objc_extensions" = private constant {{.*}} [[NAME]], {{.*}} [[ATTR]], {{.*}}, section "__DATA, __objc_const", align 8
 extension NSDogcow {
   @NSManaged var woof: Int
+}
+
+class  SwiftSubGizmo : SwiftBaseGizmo {
+
+  // Don't crash on this call. Emit an objC method call to super.
+  //
+  // CHECK-LABEL: define {{.*}} @_TFC15objc_extensions13SwiftSubGizmo4frobfT_T_
+  // CHECK: _TMaC15objc_extensions13SwiftSubGizmo
+  // CHECK: objc_msgSendSuper2
+  // CHECK: ret
+  public override func frob() {
+    super.frob()
+  }
 }

--- a/test/SILGen/Inputs/usr/include/objc_extensions_helper.h
+++ b/test/SILGen/Inputs/usr/include/objc_extensions_helper.h
@@ -1,5 +1,6 @@
 @import Foundation;
 
 @interface Base : NSObject
+- (void)objCBaseMethod;
 @property (nonatomic, strong) NSString *prop;
 @end

--- a/test/SILGen/objc_extensions.swift
+++ b/test/SILGen/objc_extensions.swift
@@ -20,11 +20,13 @@ extension Sub {
 
   func foo() {
   }
+
+  override func objCBaseMethod() {}
 }
 
 // CHECK-LABEL: sil hidden @_TF15objc_extensions20testOverridePropertyFCS_3SubT_
 func testOverrideProperty(_ obj: Sub) {
-  // CHECK: = function_ref @_TFC15objc_extensions3Subs4propGSQSS_
+  // CHECK: = class_method [volatile] %0 : $Sub, #Sub.prop!setter.1.foreign : (Sub) -> (String!) -> ()
   obj.prop = "abc"
 } // CHECK: }
 
@@ -45,7 +47,13 @@ extension Sub {
   }
 }
 
-class SubSub : Sub { }
+class SubSub : Sub {
+// CHECK-LABEL: sil hidden @_TFC15objc_extensions6SubSub14objCBaseMethodfT_T_
+// CHECK:  super_method [volatile] %0 : $SubSub, #Sub.objCBaseMethod!1.foreign : (Sub) -> () -> () , $@convention(objc_method) (Sub) -> ()
+  override func objCBaseMethod() {
+    super.objCBaseMethod()
+  }
+}
 
 extension SubSub {
   // CHECK-LABEL: sil hidden @_TFC15objc_extensions6SubSubs9otherPropSS

--- a/test/attr/attr_dynamic_infer.swift
+++ b/test/attr/attr_dynamic_infer.swift
@@ -1,6 +1,8 @@
 // RUN: %target-swift-ide-test -print-ast-typechecked -source-filename=%s -print-implicit-attrs -disable-objc-attr-requires-foundation-module | FileCheck %s
 
-@objc class Super {}
+@objc class Super {
+  func baseFoo() {}
+}
 
 // CHECK: extension Super {
 extension Super {
@@ -46,5 +48,9 @@ extension Sub {
     get { return sup }
     // CHECK: @objc override dynamic set
     set { }
+  }
+
+  // CHECK: @objc override dynamic func baseFoo
+  override func baseFoo() {
   }
 }


### PR DESCRIPTION
Even if the method is marked override we need to emit an objective C method
call.

There is no v-table guarantee because of the override keyword. The base class
method might be in an objective c class.

rdar://27389992
