### PR TITLE
[stdlib] Remove incorrect format specifier checks

### DIFF
--- a/stdlib/public/SDK/Foundation/NSStringAPI.swift
+++ b/stdlib/public/SDK/Foundation/NSStringAPI.swift
@@ -34,33 +34,6 @@ func _toNSRange(_ r: Range<String.Index>) -> NSRange {
     length: r.upperBound._utf16Index - r.lowerBound._utf16Index)
 }
 
-func _countFormatSpecifiers(_ a: String) -> Int {
-  // The implementation takes advantage of the fact that internal
-  // representation of String is UTF-16.  Because we only care about the ASCII
-  // percent character, we don't need to decode UTF-16.
-
-  let percentUTF16  = UTF16.CodeUnit(("%" as UnicodeScalar).value)
-  let notPercentUTF16: UTF16.CodeUnit = 0
-  var lastChar = notPercentUTF16 // anything other than % would work here
-  var count = 0
-
-  for c in a.utf16 {
-    if lastChar == percentUTF16 {
-      if c == percentUTF16 {
-        // a "%" following this one should not be taken as literal
-        lastChar = notPercentUTF16
-      }
-      else {
-        count += 1
-        lastChar = c
-      }
-    } else {
-      lastChar = c
-    }
-  }
-  return count
-}
-
 // We only need this for UnsafeMutablePointer, but there's not currently a way
 // to write that constraint.
 extension Optional {
@@ -978,10 +951,6 @@ extension String {
   /// format string as a template into which the remaining argument
   /// values are substituted according to given locale information.
   public init(format: String, locale: Locale?, arguments: [CVarArg]) {
-    _precondition(
-      _countFormatSpecifiers(format) <= arguments.count,
-      "Too many format specifiers (%<letter>) provided for the argument list"
-    )
     self = withVaList(arguments) {
       NSString(format: format, locale: locale, arguments: $0) as String
     }


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->

Removes incorrect format specifier checks from `String`.

<!-- Description about pull request. -->

String.init(format:locale:arguments:) contained a check to make sure that the format string didn't try to format more arguments than were actually passed.  However, the check didn't guarantee safety (since the format specifiers didn't have to match the _type_ of the passed argument) and contained bugs.  Since the check was not a guarantor of safety and was wrong, it is hereby removed.

If checks are to be reintroduced, they should both be correct and guarantee complete safety.  Doing this check correctly is a nontrivial job (the code in Clang to parse such specifiers is well over 500 lines), and should be taken on as a distinct project.
#### Resolved bug number: ([SR-1378](https://bugs.swift.org/browse/SR-1378))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

String.init(format:locale:arguments:) contained a check to make sure
that the format string didn't try to format more arguments than were
actually passed.  However, the check didn't guarantee safety (since the
format specifiers didn't have to match the _type_ of the passed
argument) and contained bugs such as
https://bugs.swift.org/browse/SR-1378.  Since the check was not a
guarantor of safety and was wrong, it is hereby removed.

If checks are to be reintroduced, they should both be correct and
guarantee complete safety.  Doing this check correctly is a nontrivial
job (the code in Clang to parse such specifiers is well over 500 lines),
and should be taken on as a distinct project.
