### PR TITLE
PrintAsObjC: Handle new upper bounds of Array/Dictionary/Set correctly.

### DIFF
--- a/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
@@ -45,6 +45,24 @@ internal func _convertNSSetToSet<T : Hashable>(_ s: NSSet?) -> Set<T> {
   return Set<T>()
 }
 
+extension AnyHashable : _ObjectiveCBridgeable {
+  public func _bridgeToObjectiveC() -> NSObject {
+    return NSObject()
+  }
+  public static func _forceBridgeFromObjectiveC(_ x: NSObject,
+                                                result: inout AnyHashable?) {
+  }
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ x: NSObject,
+    result: inout AnyHashable?
+  ) -> Bool {
+    return true
+  }
+  public static func _unconditionallyBridgeFromObjectiveC(_ x: NSObject?) -> AnyHashable {
+    return AnyHashable("")
+ }
+}
+
 extension String : _ObjectiveCBridgeable {
   public func _bridgeToObjectiveC() -> NSString {
     return NSString()

--- a/test/PrintAsObjC/any_as_id.swift
+++ b/test/PrintAsObjC/any_as_id.swift
@@ -16,7 +16,6 @@
 // RUN: FileCheck %s < %t/any_as_id.h
 
 // RUN: %check-in-clang %t/any_as_id.h
-// RUN: %check-in-clang -fno-modules -Qunused-arguments %t/any_as_id.h
 
 import Foundation
 
@@ -25,33 +24,51 @@ import Foundation
 // CHECK-NEXT:  @interface AnyAsIdTest : NSObject
 class AnyAsIdTest : NSObject {
 
-// CHECK-NEXT:  - (void)takesId:(id _Nonnull)x;
-	func takesId(_ x: Any) {}
+// CHECK-NEXT:  - (NSArray * _Nonnull)arrayOfAny:(NSArray * _Nonnull)x;
+  func arrayOfAny(_ x: [Any]) -> [Any] { return x }
+// CHECK-NEXT:  - (NSArray * _Nullable)arrayOfAnyPerhaps:(NSArray * _Nonnull)x;
+  func arrayOfAnyPerhaps(_ x: [Any]) -> [Any]? { return x }
+
+// CHECK-NEXT:  - (NSDictionary * _Nonnull)dictionaryOfAny:(NSDictionary * _Nonnull)x;
+  func dictionaryOfAny(_ x: [AnyHashable: Any]) -> [AnyHashable: Any] { return x }
+// CHECK-NEXT:  - (void)dictionaryOfAnyKeys:(NSDictionary<id <NSCopying>, NSString *> * _Nonnull)x;
+  func dictionaryOfAnyKeys(_ x: [AnyHashable: String]) {}
+// CHECK-NEXT:  - (NSDictionary * _Nullable)dictionaryOfAnyMayhap:(NSDictionary * _Nonnull)x;
+  func dictionaryOfAnyMayhap(_ x: [AnyHashable: Any]) -> [AnyHashable: Any]? { return x }
+// CHECK-NEXT:  - (void)dictionaryOfAnyValues:(NSDictionary<NSString *, id> * _Nonnull)x;
+  func dictionaryOfAnyValues(_ x: [String: Any]) {}
 
 // CHECK-NEXT:  - (id _Nonnull)getAny;
   func getAny() -> Any { return 1 as Any }
-
-// CHECK-NEXT:  - (id _Nonnull)passThroughAny:(id _Nonnull)x;
-  func passThroughAny(_ x: Any) -> Any { return x }
-
-// CHECK-NEXT: - (id _Nonnull)unwrapAny:(id _Nullable)x;
-  func unwrapAny(_ x : Any?) -> Any { return x! }
-
+// CHECK-NEXT: - (id _Nullable)getAnyConstructively;
+  func getAnyConstructively() -> Any? { return Optional<Any>(1 as Any) }
 // CHECK-NEXT: - (id _Nullable)getAnyMaybe;
   func getAnyMaybe() -> Any? { return nil }
 // CHECK-NEXT: - (id _Nullable)getAnyProbably;
   func getAnyProbably() -> Any? { return 1 as Any }
+
+// CHECK-NEXT:  - (id _Nonnull)passThroughAny:(id _Nonnull)x;
+  func passThroughAny(_ x: Any) -> Any { return x }
 // CHECK-NEXT: - (id _Nullable)passThroughAnyMaybe:(id _Nullable)x;
   func passThroughAnyMaybe(_ x: Any?) -> Any? { return x }
-// CHECK-NEXT: - (id _Nullable)getAnyConstructively;
-  func getAnyConstructively() -> Any? { return Optional<Any>(1 as Any) }
+
+// CHECK-NEXT: - (void)setOfAny:(NSSet * _Nonnull)x;
+  func setOfAny(_ x: Set<AnyHashable>) {}
+
+// CHECK-NEXT:  - (void)takesId:(id _Nonnull)x;
+  func takesId(_ x: Any) {}
+
+// CHECK-NEXT: - (id _Nonnull)unwrapAny:(id _Nullable)x;
+  func unwrapAny(_ x : Any?) -> Any { return x! }
+
 // CHECK-NEXT: - (id _Nullable)wrapAny:(id _Nonnull)x;
   func wrapAny(_ x : Any) -> Any? { return x }
 
 // CHECK-NEXT:  - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
-	/* implicit inherited init() */
+  /* implicit inherited init() */
+
 }
 // CHECK-NEXT:  @end
 
-
+extension NSArray { func forceToExist() {} }
 


### PR DESCRIPTION
We would crash because 'Any' doesn't have a corresponding bridged type through the normal bridging mechanism. Handle this correctly, and correctly recognize 'AnyHashable' and 'Any' as the upper bounds of Dictionary, Set, and Array so we present the unqualified NS types in the generated header.
