### PR TITLE
Revert "[Sema] ban multi-arguments to tuple coercion"

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6417,7 +6417,7 @@ namespace {
         // Coerce the pattern, in case we resolved something.
         auto fnType = closure->getType()->castTo<FunctionType>();
         auto *params = closure->getParameters();
-        if (tc.coerceParameterListToType(params, closure, fnType))
+        if (tc.coerceParameterListToType(params, closure, fnType->getInput()))
           return { false, nullptr };
 
         // If this is a single-expression closure, convert the expression

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -5411,7 +5411,7 @@ bool FailureDiagnosis::visitClosureExpr(ClosureExpr *CE) {
       return true;
     }
 
-    if (CS->TC.coerceParameterListToType(params, CE, fnType))
+    if (CS->TC.coerceParameterListToType(params, CE, inferredArgType))
       return true;
 
     expectedResultType = fnType->getResult();

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1386,8 +1386,7 @@ public:
   /// contextual type.
   ///
   /// \returns true if an error occurred, false otherwise.
-  bool coerceParameterListToType(ParameterList *P, ClosureExpr *CE,
-                                 AnyFunctionType *FN);
+  bool coerceParameterListToType(ParameterList *P, DeclContext *dc, Type type);
 
   
   /// Type-check an initialized variable pattern declaration.

--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
@@ -1807,7 +1807,7 @@ self.test("\(testNamePrefix)._preprocessingPass/semantics") {
     let s = makeWrappedSequence(test.sequence.map(OpaqueValue.init))
     var wasInvoked = false
     let result = s._preprocessingPass {
-      () -> OpaqueValue<Int> in
+      (sequence) -> OpaqueValue<Int> in
       wasInvoked = true
 
       expectEqualSequence(
@@ -1830,7 +1830,7 @@ self.test("\(testNamePrefix)._preprocessingPass/semantics") {
     var result: OpaqueValue<Int>? = nil
     do {
       result = try s._preprocessingPass {
-        () -> OpaqueValue<Int> in
+        (sequence) -> OpaqueValue<Int> in
         wasInvoked = true
         throw TestError.error2
       }

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -2387,7 +2387,7 @@ public func expectEqualsUnordered<
   let x: [(T, T)] =
     expected.sorted(by: comparePairLess)
   let y: [(T, T)] =
-    actual.map { ($0, $1) }
+    actual.map { ($0.0, $0.1) }
       .sorted(by: comparePairLess)
 
   func comparePairEquals(_ lhs: (T, T), rhs: (key: T, value: T)) -> Bool {

--- a/stdlib/private/StdlibUnittest/TypeIndexed.swift
+++ b/stdlib/private/StdlibUnittest/TypeIndexed.swift
@@ -105,7 +105,7 @@ public func expectEqual<V: Comparable>(
   file: String = #file, line: UInt = #line
 ) {
   expectEqualsUnordered(
-    expected.map { (key: TypeIdentifier($0), value: $1) },
+    expected.map { (key: TypeIdentifier($0.0), value: $0.1) },
     actual.byType,
     message(), stackTrace: stackTrace) { $0 <=> $1 }
 }

--- a/stdlib/public/SDK/AppKit/AppKit.swift
+++ b/stdlib/public/SDK/AppKit/AppKit.swift
@@ -54,8 +54,8 @@ extension NSView : _DefaultCustomPlaygroundQuickLookable {
 public extension NSGradient {
   convenience init?(colorsAndLocations objects: (NSColor, CGFloat)...) {
     self.init(
-      colors: objects.map { c, _ in c },
-      atLocations: objects.map { _, l in l },
+      colors: objects.map { $0.0 },
+      atLocations: objects.map { $0.1 },
       colorSpace: NSColorSpace.genericRGB())
   }
 }

--- a/stdlib/public/SDK/Foundation/Foundation.swift
+++ b/stdlib/public/SDK/Foundation/Foundation.swift
@@ -570,8 +570,8 @@ extension NSDictionary : ExpressibleByDictionaryLiteral {
     dictionaryLiteral elements: (NSCopying, AnyObject)...
   ) {
     self.init(
-      objects: elements.map { _, v in v },
-      forKeys: elements.map { k, _ in k },
+      objects: elements.map { $0.1 },
+      forKeys: elements.map { $0.0 },
       count: elements.count)
   }
 }

--- a/stdlib/public/SDK/WatchKit/WatchKit.swift
+++ b/stdlib/public/SDK/WatchKit/WatchKit.swift
@@ -29,8 +29,8 @@ extension WKInterfaceController {
     withNamesAndContexts namesAndContexts: [(name: String, context: AnyObject)]
   ) {
     WKInterfaceController.reloadRootControllers(
-      withNames: namesAndContexts.map { name, _ in name },
-      contexts: namesAndContexts.map { _, context in context })
+      withNames: namesAndContexts.map { $0.name },
+      contexts: namesAndContexts.map { $0.context })
   }
 
   @available(*, deprecated,
@@ -47,8 +47,8 @@ extension WKInterfaceController {
     withNamesAndContexts namesAndContexts: [(name: String, context: AnyObject)]
   ) {
     self.presentController(
-      withNames: namesAndContexts.map { name, _ in name },
-      contexts: namesAndContexts.map { _, context in context })
+      withNames: namesAndContexts.map { $0.name },
+      contexts: namesAndContexts.map { $0.context })
   }
 }
 

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -2018,7 +2018,7 @@ public struct Dictionary<Key : Hashable, Value> :
   ///     // Prints "JP"
   ///     // Prints "GH"
   public var keys: LazyMapCollection<Dictionary, Key> {
-    return self.lazy.map { key, _ in key }
+    return self.lazy.map { $0.key }
   }
 
   /// A collection containing just the values of the dictionary.
@@ -2036,7 +2036,7 @@ public struct Dictionary<Key : Hashable, Value> :
   ///     // Prints "Japan"
   ///     // Prints "Ghana"
   public var values: LazyMapCollection<Dictionary, Value> {
-    return self.lazy.map { _, value in value }
+    return self.lazy.map { $0.value }
   }
 
   //

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -81,7 +81,7 @@ open class ManagedBuffer<Header, Element> {
   public final func withUnsafeMutablePointerToElements<R>(
     _ body: @noescape (UnsafeMutablePointer<Element>) throws -> R
   ) rethrows -> R {
-    return try withUnsafeMutablePointers { return try body($1) }
+    return try withUnsafeMutablePointers { return try body($0.1) }
   }
 
   /// Call `body` with `UnsafeMutablePointer`s to the stored `Header`
@@ -267,7 +267,7 @@ public struct ManagedBufferPointer<Header, Element> : Equatable {
   public func withUnsafeMutablePointerToElements<R>(
     _ body: @noescape (UnsafeMutablePointer<Element>) throws -> R
   ) rethrows -> R {
-    return try withUnsafeMutablePointers { return try body($1) }
+    return try withUnsafeMutablePointers { return try body($0.1) }
   }
 
   /// Call `body` with `UnsafeMutablePointer`s to the stored `Header`

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -330,7 +330,7 @@ public struct Mirror {
     self._makeSuperclassMirror = Mirror._superclassIterator(
       subject, ancestorRepresentation)
       
-    let lazyChildren = children.lazy.map { Child(label: $0, value: $1) }
+    let lazyChildren = children.lazy.map { Child(label: $0.0, value: $0.1) }
     self.children = Children(lazyChildren)
 
     self.displayStyle = displayStyle
@@ -440,7 +440,7 @@ extension Mirror {
       let children = Mirror(reflecting: result).children
       let position: Children.Index
       if case let label as String = e {
-        position = children.index { l, _ in l == label } ?? children.endIndex
+        position = children.index { $0.label == label } ?? children.endIndex
       }
       else if let offset = (e as? Int).map({ IntMax($0) }) ?? (e as? IntMax) {
         position = children.index(children.startIndex,

--- a/test/1_stdlib/Mirror.swift
+++ b/test/1_stdlib/Mirror.swift
@@ -32,7 +32,7 @@ extension Mirror {
     let nil_ = "nil"
     return "[" +
       children.lazy
-        .map { "\($0 ?? nil_): \(String(reflecting: $1))" }
+        .map { "\($0.0 ?? nil_): \(String(reflecting: $0.1))" }
         .joined(separator: ", ")
       + "]"
   }
@@ -158,7 +158,7 @@ mirrors.test("Legacy") {
   ]
   expectFalse(
     zip(x0, m.children).contains {
-      $0.value as! Int != $1.value as! Int
+      $0.0.value as! Int != $0.1.value as! Int
     })
 
   class B { let bx: Int = 0 }

--- a/test/1_stdlib/Renames.swift
+++ b/test/1_stdlib/Renames.swift
@@ -407,7 +407,7 @@ func _SequenceAlgorithms<S : Sequence>(x: S) {
   _ = x.minElement { _, _ in true } // expected-error {{'minElement' has been renamed to 'min(by:)'}} {{9-19=min}} {{none}}
   _ = x.maxElement { _, _ in true } // expected-error {{'maxElement' has been renamed to 'max(by:)'}} {{9-19=max}} {{none}}
   _ = x.reverse() // expected-error {{'reverse()' has been renamed to 'reversed()'}} {{9-16=reversed}} {{none}}
-  _ = x.startsWith([]) { _, _ in true } // expected-error {{'startsWith(_:isEquivalent:)' has been renamed to 'starts(with:by:)'}} {{9-19=starts}} {{20-20=with: }} {{none}}
+  _ = x.startsWith([]) { _ in true } // expected-error {{'startsWith(_:isEquivalent:)' has been renamed to 'starts(with:by:)'}} {{9-19=starts}} {{20-20=with: }} {{none}}
   _ = x.lexicographicalCompare([]) { _, _ in true } // expected-error {{'lexicographicalCompare(_:isOrderedBefore:)' has been renamed to 'lexicographicallyPrecedes(_:by:)'}} {{9-31=lexicographicallyPrecedes}}{{none}}
 }
 func _SequenceAlgorithms<S : Sequence>(x: S) where S.Iterator.Element : Comparable {

--- a/test/1_stdlib/UnsafePointer.swift.gyb
+++ b/test/1_stdlib/UnsafePointer.swift.gyb
@@ -455,7 +455,7 @@ ${SelfName}TestSuite.test("Comparable") {
   func comparisonOracle(i: Int, j: Int) -> ExpectedComparisonResult {
     return instances[i].0 <=> instances[j].0
   }
-  checkComparable(instances.map { $1 }, oracle: comparisonOracle)
+  checkComparable(instances.map { $0.1 }, oracle: comparisonOracle)
 }
 
 % end

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -9,7 +9,7 @@ _ = myMap(intArray, { x -> String in String(x) } )
 
 // Closures with too few parameters.
 func foo(_ x: (Int, Int) -> Int) {}
-foo({$0}) // expected-error{{contextual closure type '(Int, Int) -> Int' expects 2 arguments, but 1 were used in closure body}}
+foo({$0}) // expected-error{{cannot convert value of type '(Int, Int)' to closure result type 'Int'}}
 
 struct X {}
 func mySort(_ array: [String], _ predicate: (String, String) -> Bool) -> [String] {}
@@ -121,8 +121,8 @@ var _: (Int,Int) -> Int = {$0+$1+$2}
 // expected-error @+1 {{contextual closure type '(Int, Int, Int) -> Int' expects 3 arguments, but 2 were used in closure body}}
 var _: (Int, Int, Int) -> Int = {$0+$1}
 
-// expected-error @+1 {{contextual closure type '() -> Int' expects 0 arguments, but 1 were used in closure body}}
-var _: () -> Int = {_ in 0}
+
+var _: () -> Int = {a in 0}
 
 // expected-error @+1 {{contextual closure type '(Int) -> Int' expects 1 argument, but 2 were used in closure body}}
 var _: (Int) -> Int = {a,b in 0}
@@ -130,7 +130,6 @@ var _: (Int) -> Int = {a,b in 0}
 // expected-error @+1 {{contextual closure type '(Int) -> Int' expects 1 argument, but 3 were used in closure body}}
 var _: (Int) -> Int = {a,b,c in 0}
 
-// expected-error @+1 {{contextual closure type '(Int, Int) -> Int' expects 2 arguments, but 1 were used in closure body}}
 var _: (Int, Int) -> Int = {a in 0}
 
 // expected-error @+1 {{contextual closure type '(Int, Int, Int) -> Int' expects 3 arguments, but 2 were used in closure body}}
@@ -203,7 +202,7 @@ func acceptNothingToInt (_: @noescape () -> Int) {}
 func testAcceptNothingToInt(ac1: @autoclosure () -> Int) {
   // expected-note@-1{{parameter 'ac1' is implicitly non-escaping because it was declared @autoclosure}}
   acceptNothingToInt({ac1($0)})
-  // expected-error@-1{{contextual closure type '() -> Int' expects 0 arguments, but 1 were used in closure body}}
+  // expected-error@-1{{cannot convert value of type '(_) -> Int' to expected argument type '() -> Int'}}
   // FIXME: expected-error@-2{{closure use of non-escaping parameter 'ac1' may allow it to escape}}
 }
 
@@ -283,6 +282,13 @@ func rdar21078316() {
   var bar : [(String, String)]?
   bar = foo.map { ($0, $1) }  // expected-error {{contextual closure type '([String : String]) -> [(String, String)]' expects 1 argument, but 2 were used in closure body}}
 }
+
+
+// <rdar://problem/20978044> QoI: Poor diagnostic when using an incorrect tuple element in a closure
+var numbers = [1, 2, 3]
+zip(numbers, numbers).filter { $0.2 > 1 }  // expected-error {{value of tuple type '(Int, Int)' has no member '2'}}
+
+
 
 // <rdar://problem/20868864> QoI: Cannot invoke 'function' with an argument list of type 'type'
 func foo20868864(_ callback: ([String]) -> ()) { }

--- a/test/Constraints/tuple.swift
+++ b/test/Constraints/tuple.swift
@@ -192,7 +192,7 @@ extension r25271859 {
 }
 
 func f(a : r25271859<(Float, Int)>) {
-  a.map { f, _ in f }
+  a.map { $0.0 }
     .andThen { _ in   // expected-error {{unable to infer complex closure return type; add explicit type to disambiguate}} {{18-18=-> r25271859<String> }}
       print("hello") // comment this out and it runs, leave any form of print in and it doesn't
       return r25271859<String>()

--- a/test/DebugInfo/WeakCapture.swift
+++ b/test/DebugInfo/WeakCapture.swift
@@ -15,7 +15,7 @@ func function() {
   // CHECK: call void @llvm.dbg.{{.*}}(metadata %swift.weak*
   // CHECK-NOT:                        metadata [[B]]
   // CHECK: call
-    A(handler: { [weak b] in
+    A(handler: { [weak b] _ in
             if b != nil { }
         })
 }

--- a/test/DebugInfo/mangling.swift
+++ b/test/DebugInfo/mangling.swift
@@ -39,5 +39,4 @@ var myTuple3 : (      String,     Int64) = ("C", 3)
 
 markUsed(myTuple1.Id)
 markUsed(myTuple2.Id)
-func f(_ a: (String, Int64)) {}
-markUsed(f(myTuple3))
+markUsed({ $0.1 }(myTuple3))

--- a/test/Interpreter/collection_casts.swift
+++ b/test/Interpreter/collection_casts.swift
@@ -81,7 +81,7 @@ print("Dictionaries.")
 
 let a_dict = ["one" : A(1), "two" : A(2), "three" : A(3)]
 print("begin")
-a_dict.forEach { $1.preen() }
+a_dict.forEach { $0.1.preen() }
 print("end")
 // CHECK-NEXT: begin
 // CHECK-DAG: A1
@@ -91,7 +91,7 @@ print("end")
 
 let preening_dict_1 = a_dict as [String: Preening]
 print("begin")
-preening_dict_1.forEach { $1.preen() }
+preening_dict_1.forEach { $0.1.preen() }
 print("end")
 // CHECK-NEXT: begin
 // CHECK-DAG: A1
@@ -105,7 +105,7 @@ print(any_dict_1.count)
 
 let preening_dict_2 = any_dict_1 as! [String: Preening]
 print("begin")
-preening_dict_2.forEach { $1.preen() }
+preening_dict_2.forEach { $0.1.preen() }
 print("end")
 // CHECK-NEXT: begin
 // CHECK-DAG: A1
@@ -115,7 +115,7 @@ print("end")
 
 let preening_dict_3 = any_dict_1 as? [String: Preening]
 print("begin")
-preening_dict_3?.forEach { $1.preen() }
+preening_dict_3?.forEach { $0.1.preen() }
 print("end")
 // CHECK-NEXT: begin
 // CHECK-DAG: A1
@@ -125,7 +125,7 @@ print("end")
 
 let a_dict_2 = any_dict_1 as! [String: A]
 print("begin")
-a_dict_2.forEach { $1.preen() }
+a_dict_2.forEach { $0.1.preen() }
 print("end")
 // CHECK-NEXT: begin
 // CHECK-DAG: A1
@@ -135,7 +135,7 @@ print("end")
 
 let a_dict_3 = any_dict_1 as? [String: A]
 print("begin")
-a_dict_3?.forEach { $1.preen() }
+a_dict_3?.forEach { $0.1.preen() }
 print("end")
 // CHECK-NEXT: begin
 // CHECK-DAG: A1

--- a/test/Prototypes/Result.swift
+++ b/test/Prototypes/Result.swift
@@ -138,8 +138,8 @@ func mayFail(_ fail: Bool) throws -> Int {
 print(catchResult { try mayFail(true) })
 print(catchResult { try mayFail(false) })
 
-print(catchResult { 1 }.flatMap { _ in Result(success: 4) }.flatMap { _ in Result<String>(error: Icky.Poor) })
-print(catchResult { 1 }.map { _ in three }.flatMap {$0} )
+print(catchResult { _ in 1 }.flatMap { _ in Result(success: 4) }.flatMap { _ in Result<String>(error: Icky.Poor) })
+print(catchResult { _ in 1 }.map { _ in three }.flatMap {$0} )
 
 let results = [three, nasty, four]
 print(results.flatMap { $0.success })

--- a/test/SILGen/apply_abstraction_nested.swift
+++ b/test/SILGen/apply_abstraction_nested.swift
@@ -4,8 +4,8 @@ infix operator ~> { precedence 255 associativity left }
 
 protocol P { }
 
-func bar<T:P>(_: inout T) -> () -> () { return { } }
-func baz<T:P>(_: inout T) -> (Int) -> () { return { _ in } }
+func bar<T:P>(_: inout T) -> () -> () { return {_ in ()} }
+func baz<T:P>(_: inout T) -> (Int) -> () { return {_ in ()} }
 
 func ~> <T: P, Args, Result>(
   x: inout T,

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -590,5 +590,5 @@ class GenericDerived<Ocean> : ConcreteBase {
 // Don't crash on this
 func r25993258_helper(_ fn: (inout Int, Int) -> ()) {}
 func r25993258() {
-  r25993258_helper { _, _ in () }
+  r25993258_helper { _ in () }
 }

--- a/test/expr/capture/generic_params.swift
+++ b/test/expr/capture/generic_params.swift
@@ -29,6 +29,6 @@ func outerGeneric<T>(t: T, x: AnyObject) {
   // CHECK: func_decl "localFunction(tt:)" type='<T> (tt: TT) -> ()' {{.*}} captures=(<generic> )
   func localFunction(tt: TT) {}
 
-  // CHECK: closure_expr type='(T, T) -> ()' {{.*}} captures=(<generic> )
-  let _: (TT) -> () = { _, _ in }
+  // CHECK: closure_expr type='(TT) -> ()' {{.*}} captures=(<generic> )
+  let _: (TT) -> () = { _ in }
 }

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -33,7 +33,7 @@ func funcdecl5(_ a: Int, _ y: Int) {
   
   func6({$0 + $1})       // Closure with two named anonymous arguments
   func6({($0) + $1})    // Closure with sequence expr inferred type
-  func6({($0, $1) + $0})    // // expected-error {{binary operator '+' cannot be applied to operands of type '(Int, Int)' and 'Int'}} expected-note {{expected an argument list of type '(Int, Int)'}}
+  func6({($0) + $0})    // // expected-error {{binary operator '+' cannot be applied to two '(Int, Int)' operands}} expected-note {{expected an argument list of type '(Int, Int)'}}
 
 
   var testfunc : ((), Int) -> Int  // expected-note {{'testfunc' declared here}}
@@ -318,6 +318,9 @@ func r21375863() {
 // <rdar://problem/25993258>
 //   Don't crash if we infer a closure argument to have a tuple type containing inouts.
 func r25993258_helper(_ fn: (inout Int, Int) -> ()) {}
+func r25993258a() {
+  r25993258_helper { x in () } // expected-error {{named parameter has type '(inout Int, Int)' which includes nested inout parameters}}
+}
 func r25993258b() {
-  r25993258_helper { _, _ in () }
+  r25993258_helper { _ in () }
 }

--- a/test/expr/closure/default_args.swift
+++ b/test/expr/closure/default_args.swift
@@ -3,8 +3,8 @@
 func simple_default_args() {
   // <rdar://problem/22753605> QoI: bad diagnostic when closure has default argument
   let _ : (Int) -> Int = {(x : Int = 1) in x+1} // expected-error{{default arguments are not allowed in closures}} {{36-39=}}
-  let _ : () -> Int = {(_ x : Int = 1) in x+1} // expected-error{{contextual closure type '() -> Int' expects 0 arguments, but 1 were used in closure body}} expected-error {{default arguments are not allowed in closures}} {{35-38=}}
-  let _ : () -> Int = {(_ x : Int) in x+1} // expected-error{{contextual closure type '() -> Int' expects 0 arguments, but 1 were used in closure body}}
+  let _ : () -> Int = {(_ x : Int = 1) in x+1} // expected-error{{cannot convert value of type '(Int) -> Int' to specified type '() -> Int'}} expected-error {{default arguments are not allowed in closures}} {{35-38=}}
+  let _ : () -> Int = {(_ x : Int) in x+1} // expected-error{{cannot convert value of type '(Int) -> Int' to specified type '() -> Int'}}
 }
 
 func func_default_args() {

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -115,7 +115,7 @@ func funcdecl7(_ a: Int, b: (c: Int, d: Int), third: (c: Int, d: Int)) -> Int {
 // Error recovery.
 func testfunc2 (_: ((), Int) -> Int) -> Int {}
 func errorRecovery() {
-  testfunc2({ ($0, $1) + 1 }) // expected-error {{binary operator '+' cannot be applied to operands of type '((), Int)' and 'Int'}} expected-note {{expected an argument list of type '(Int, Int)'}}
+  testfunc2({ $0 + 1 }) // expected-error {{binary operator '+' cannot be applied to operands of type '((), Int)' and 'Int'}} expected-note {{expected an argument list of type '(Int, Int)'}}
 
   enum union1 {
     case bar

--- a/validation-test/stdlib/Arrays.swift.gyb
+++ b/validation-test/stdlib/Arrays.swift.gyb
@@ -748,7 +748,7 @@ ArrayTestSuite.test("${array_type}<Void>/map") {
   // stride == 0.
   do {
     let input: ${array_type}<Void> = [ (), (), () ]
-    let result = input.map { () }
+    let result = input.map { (_) -> Void in return () }
     expectEqual(3, result.count)
   }
 

--- a/validation-test/stdlib/CollectionType.swift.gyb
+++ b/validation-test/stdlib/CollectionType.swift.gyb
@@ -794,7 +794,7 @@ CollectionTypeTests.test("partition(by:)/dispatch") {
 
 CollectionTypeTests.test("_withUnsafeMutableBufferPointerIfSupported/dispatch") {
   var tester = MutableCollectionLog.dispatchTester([OpaqueValue(1)])
-  _ = tester._withUnsafeMutableBufferPointerIfSupported { _, _ in () }
+  _ = tester._withUnsafeMutableBufferPointerIfSupported { _ in () }
   expectCustomizable(tester, tester.log._withUnsafeMutableBufferPointerIfSupported)
 }
 

--- a/validation-test/stdlib/CoreMedia.swift
+++ b/validation-test/stdlib/CoreMedia.swift
@@ -43,7 +43,7 @@ CoreMediaTests.test("CMTime/Comparable") {
   func comparisonOracle(i: Int, j: Int) -> ExpectedComparisonResult {
     return instances[i].0 <=> instances[j].0
   }
-  checkComparable(instances.map { $1 }, oracle: comparisonOracle)
+  checkComparable(instances.map { $0.1 }, oracle: comparisonOracle)
 }
 
 CoreMediaTests.test("CMTimeRange(start:duration:)") {
@@ -80,7 +80,7 @@ CoreMediaTests.test("CMTimeRange/Equatable") {
   func comparisonOracle(i: Int, j: Int) -> Bool {
     return instances[i].0 == instances[j].0
   }
-  checkEquatable(instances.map { $1 }, oracle: comparisonOracle)
+  checkEquatable(instances.map { $0.1 }, oracle: comparisonOracle)
 }
 
 runAllTests()

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -3916,7 +3916,7 @@ DictionaryTestSuite.test("popFirst") {
       2020: 2020,
       3030: 3030,
     ]
-    let expected = Array(d.map{($0, $1)})
+    let expected = Array(d.map{($0.0, $0.1)})
     while let element = d.popFirst() {
       popped.append(element)
     }

--- a/validation-test/stdlib/NSNumberBridging.swift.gyb
+++ b/validation-test/stdlib/NSNumberBridging.swift.gyb
@@ -182,7 +182,7 @@ func testNSNumberGetValueAndObjCType(
   n.getValue(&a)
   n.getValue(&b)
   let ab = Array(zip(a, b))
-  let count = ab.index { $0 == 0xaa && $1 == 0xbb }!
+  let count = ab.index { $0.0 == 0xaa && $0.1 == 0xbb }!
   // Check that `getValue` does not overwrite more bytes than needed.
   expectEqual(expectedBytes.count, count)
   expectEqualSequence(expectedBytes, a[0..<count])

--- a/validation-test/stdlib/NSStringBridging.swift.gyb
+++ b/validation-test/stdlib/NSStringBridging.swift.gyb
@@ -31,7 +31,7 @@ NSStringTests.test("AnyHashable(NSString) uses Swift String comparison rules") {
   let ah2 = AnyHashable(nss2)
   expectEqual("String", String(describing: type(of: ah1.base)))
   expectEqual("String", String(describing: type(of: ah2.base)))
-  checkHashable([ah1, ah2], equalityOracle: { _, _ in true })
+  checkHashable([ah1, ah2], equalityOracle: { _ in true })
 }
 
 runAllTests()

--- a/validation-test/stdlib/Prototypes/PersistentVector.swift.gyb
+++ b/validation-test/stdlib/Prototypes/PersistentVector.swift.gyb
@@ -1997,7 +1997,7 @@ struct UnittestDictionary<Key : Equatable, Value> {
   }
 
   var keys: [Key] {
-    return _elements.map { k, _ in k }
+    return _elements.map { $0.0 }
   }
 }
 

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -265,7 +265,7 @@ SequenceTypeTests.test("enumerated()") {
     
     checkSequence(
       test.expected.map {
-        (offset: $0, element: OpaqueValue($1))
+        (offset: $0.0, element: OpaqueValue($0.1))
       } as [Element],
       result,
       resiliencyChecks: .none, sameValue: compareElements)


### PR DESCRIPTION
Reverts apple/swift#3895. It breaks cases where there really is a single unlabeled argument of tuple type, like this:

``` swift
let pairs = [(1, "A"), (2, "B")]
print(pairs.map { $0.0 })
```
