### PR TITLE
[FixCode] Make sure to accept the fixit in note about adding '@escapi…

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -601,6 +601,8 @@ private:
         Info.ID == diag::convert_let_to_var.ID ||
         Info.ID == diag::parameter_extraneous_double_up.ID ||
         Info.ID == diag::attr_decl_attr_now_on_type.ID ||
+        Info.ID == diag::noescape_parameter.ID ||
+        Info.ID == diag::noescape_autoclosure.ID ||
         Info.ID == diag::selector_construction_suggest.ID ||
         Info.ID == diag::selector_literal_deprecated_suggest.ID)
       return true;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -603,6 +603,7 @@ private:
         Info.ID == diag::attr_decl_attr_now_on_type.ID ||
         Info.ID == diag::noescape_parameter.ID ||
         Info.ID == diag::noescape_autoclosure.ID ||
+        Info.ID == diag::where_inside_brackets.ID ||
         Info.ID == diag::selector_construction_suggest.ID ||
         Info.ID == diag::selector_literal_deprecated_suggest.ID)
       return true;

--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -214,3 +214,10 @@ func fnWithClosure(c: @escaping ()->()) {}
 func testescape(rec: ()->()) {
   fnWithClosure { rec() }
 }
+
+protocol Prot1 {}
+protocol Prot2 {
+  associatedtype Ty = Prot1
+}
+class Cls1 : Prot1 {}
+func testwhere<T: Prot2 where T.Ty == Cls1>(_: T) {}

--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -209,3 +209,8 @@ class NoSemi {
   enum Bar { case bar }
   var foo: .Bar = .bar
 }
+
+func fnWithClosure(c: @escaping ()->()) {}
+func testescape(rec: ()->()) {
+  fnWithClosure { rec() }
+}

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -217,3 +217,10 @@ func fnWithClosure(c: @escaping ()->()) {}
 func testescape(rec: @escaping ()->()) {
   fnWithClosure { rec() }
 }
+
+protocol Prot1 {}
+protocol Prot2 {
+  associatedtype Ty = Prot1
+}
+class Cls1 : Prot1 {}
+func testwhere<T: Prot2>(_: T) where T.Ty == Cls1 {}

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -212,3 +212,8 @@ class NoSemi {
   enum Bar { case bar }
   var foo: .Bar = .bar
 }
+
+func fnWithClosure(c: @escaping ()->()) {}
+func testescape(rec: @escaping ()->()) {
+  fnWithClosure { rec() }
+}


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Change to accept fixit in diagnostic note about adding '@escaping'.

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…ng'.
