### PR TITLE
[Preview 5] Fix crash due to bad @objc inference for on Error-conforming Swift enums

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2686,6 +2686,8 @@ NOTE(not_objc_empty_protocol_composition,none,
      "'Any' is not considered '@objc'; use 'AnyObject' instead", ())
 NOTE(not_objc_protocol,none,
      "protocol %0 is not '@objc'", (Type))
+NOTE(not_objc_error_protocol_composition,none,
+     "protocol composition involving 'Error' is not '@objc'", ())
 NOTE(not_objc_empty_tuple,none,
       "empty tuple type cannot be represented in Objective-C", ())
 NOTE(not_objc_tuple,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2687,7 +2687,8 @@ NOTE(not_objc_empty_protocol_composition,none,
 NOTE(not_objc_protocol,none,
      "protocol %0 is not '@objc'", (Type))
 NOTE(not_objc_error_protocol_composition,none,
-     "protocol composition involving 'Error' is not '@objc'", ())
+     "protocol composition involving 'Error' cannot be represented "
+     "in Objective-C", ())
 NOTE(not_objc_empty_tuple,none,
       "empty tuple type cannot be represented in Objective-C", ())
 NOTE(not_objc_tuple,none,

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2148,33 +2148,8 @@ getForeignRepresentable(Type type, ForeignLanguage language,
   if (type->isTypeParameter() && language == ForeignLanguage::ObjectiveC)
     return { ForeignRepresentableKind::Object, nullptr };
 
-  // In Objective-C, existentials involving Error are bridged
-  // to NSError.
-  if (language == ForeignLanguage::ObjectiveC &&
-      type->isExistentialWithError()) {
-    return { ForeignRepresentableKind::BridgedError, nullptr };
-  }
-
-  /// Determine whether the given type is a type that is bridged to NSError
-  /// because it conforms to the Error protocol.
-  auto isBridgedErrorViaConformance = [dc](Type type) -> bool {
-    ASTContext &ctx = type->getASTContext();
-    auto errorProto = ctx.getProtocol(KnownProtocolKind::Error);
-    if (!errorProto) return false;
-
-    return dc->getParentModule()->lookupConformance(type, errorProto,
-                                                    ctx.getLazyResolver())
-             .hasValue();
-  };
-
   auto nominal = type->getAnyNominal();
-  if (!nominal) {
-    /// It might still be a bridged Error via conformance to Error.
-    if (isBridgedErrorViaConformance(type))
-      return { ForeignRepresentableKind::BridgedError, nullptr };
-
-    return failure();
-  }
+  if (!nominal) return failure();
 
   ASTContext &ctx = nominal->getASTContext();
 
@@ -2257,13 +2232,7 @@ getForeignRepresentable(Type type, ForeignLanguage language,
   // Determine whether this nominal type is known to be representable
   // in this foreign language.
   auto result = ctx.getForeignRepresentationInfo(nominal, language, dc);
-  if (result.getKind() == ForeignRepresentableKind::None) {
-    /// It might still be a bridged Error via conformance to Error.
-    if (isBridgedErrorViaConformance(type))
-      return { ForeignRepresentableKind::BridgedError, nullptr };
-
-    return failure();
-  }
+  if (result.getKind() == ForeignRepresentableKind::None) return failure();
 
   if (wasOptional && !result.isRepresentableAsOptional())
     return failure();

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -1274,25 +1274,14 @@ private:
     PCT = cast<ProtocolCompositionType>(canonicalComposition);
 
     // Dig out the protocols. If we see 'Error', record that we saw it.
-    bool hasError = false;
     SmallVector<ProtocolDecl *, 4> protos;
     for (auto protoTy : PCT->getProtocols()) {
       auto proto = protoTy->castTo<ProtocolType>()->getDecl();
-      if (proto->isSpecificProtocol(KnownProtocolKind::Error)) {
-        hasError = true;
-        continue;
-      }
-
       protos.push_back(proto);
     }
 
-    os << (isMetatype ? "Class"
-           : hasError ? "NSError"
-           : "id");
+    os << (isMetatype ? "Class" : "id");
     printProtocols(protos);
-
-    if (hasError && !isMetatype)
-      os << " *";
 
     printNullability(optionalKind);
   }
@@ -1808,10 +1797,9 @@ public:
 
     ASTContext &ctx = M.getASTContext();
 
-    auto protos = ED->getAllProtocols();
+    SmallVector<ProtocolConformance *, 1> conformances;
     auto errorTypeProto = ctx.getProtocol(KnownProtocolKind::Error);
-    if (std::find(protos.begin(), protos.end(), errorTypeProto) !=
-        protos.end()) {
+    if (ED->lookupConformance(&M, errorTypeProto, conformances)) {
       bool hasDomainCase = std::any_of(ED->getAllElements().begin(),
                                        ED->getAllElements().end(),
                                        [](const EnumElementDecl *elem) {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3187,13 +3187,25 @@ void TypeChecker::diagnoseTypeNotRepresentableInObjC(const DeclContext *DC,
       return;
     }
     // Find a protocol that is not @objc.
+    bool sawErrorProtocol = false;
     for (auto PD : Protocols) {
+      if (PD->isSpecificProtocol(KnownProtocolKind::Error)) {
+        sawErrorProtocol = true;
+        break;
+      }
+
       if (!PD->isObjC()) {
         diagnose(TypeRange.Start, diag::not_objc_protocol,
                  PD->getDeclaredType());
         return;
       }
     }
+
+    if (sawErrorProtocol) {
+      diagnose(TypeRange.Start, diag::not_objc_error_protocol_composition);
+      return;
+    }
+
     return;
   }
 

--- a/test/PrintAsObjC/error-delegate.swift
+++ b/test/PrintAsObjC/error-delegate.swift
@@ -18,20 +18,12 @@
 
 import Foundation
 
-@objc protocol MySwiftProtocol { }
-
 // CHECK-LABEL: @interface Test : NSObject <ABCErrorProtocol>
 // CHECK-NEXT: - (void)didFail:(NSError * _Nonnull)error;
 // CHECK-NEXT: - (void)didFailOptional:(NSError * _Nullable)error;
-// CHECK-NEXT-FIXME: - (void)composition:(NSError<MySwiftProtocol> * _Nonnull)error;
-// CHECK-NEXT-FIXME: - (void)compositionOptional:(NSError<MySwiftProtocol> * _Nullable)error;
 // CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: @end
 class Test : NSObject, ABCErrorProtocol {
   func didFail(_ error: Swift.Error) {}
   func didFailOptional(_ error: Swift.Error?) {}
-
-  // FIXME: SILGenc crashes on this.
-  //  func composition(_ error: MySwiftProtocol & Error) { }
-  //  func compositionOptional(_ error: (MySwiftProtocol & Error)?) { }
 }

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -1949,7 +1949,7 @@ class ClassThrows1 {
 
   @objc func fooWithErrorProtocolComposition1(x: Error & Protocol_ObjC1) { }
   // expected-error@-1{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
-  // expected-note@-2{{protocol composition involving 'Error' is not '@objc'}}
+  // expected-note@-2{{protocol composition involving 'Error' cannot be represented in Objective-C}}
 
   // CHECK: {{^}} func fooWithErrorProtocolComposition2(x: Error & Protocol_ObjC1)
   func fooWithErrorProtocolComposition2(x: Error & Protocol_ObjC1) { }

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -11,6 +11,7 @@ struct PlainStruct {}
 enum PlainEnum {}
 protocol PlainProtocol {} // expected-note {{protocol 'PlainProtocol' declared here}}
 
+enum ErrorEnum : Error { }
 
 @objc class Class_ObjC1 {}
 
@@ -1938,6 +1939,20 @@ class ClassThrows1 {
   @objc init?(radians: Double) throws { } // expected-error{{a failable and throwing initializer cannot be marked @objc because 'nil' indicates failure to Objective-C}}
 
   @objc init!(string: String) throws { } // expected-error{{a failable and throwing initializer cannot be marked @objc because 'nil' indicates failure to Objective-C}}
+
+  @objc func fooWithErrorEnum1(x: ErrorEnum) {}
+  // expected-error@-1{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // expected-note@-2{{non-'@objc' enums cannot be represented in Objective-C}}
+
+  // CHECK: {{^}} func fooWithErrorEnum2(x: ErrorEnum)
+  func fooWithErrorEnum2(x: ErrorEnum) {}
+
+  @objc func fooWithErrorProtocolComposition1(x: Error & Protocol_ObjC1) { }
+  // expected-error@-1{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // expected-note@-2{{protocol composition involving 'Error' is not '@objc'}}
+
+  // CHECK: {{^}} func fooWithErrorProtocolComposition2(x: Error & Protocol_ObjC1)
+  func fooWithErrorProtocolComposition2(x: Error & Protocol_ObjC1) { }
 }
 
 


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

This pull request fixes a problem with '@objc' inference that considers Swift-defined enum types that conform to the Error protocol to be representable in Objective-C. They are not, causing SILGen and PrintAsObjC changes.
#### Resolved bug number: ([SR-2249](https://bugs.swift.org/browse/SR-2249))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

Also tracked as rdar://problem/27658940.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
