### PR TITLE
[swiftc (38 vs. 5154)] Add crasher in swift::ArchetypeBuilder::mapTypeOutOfContext(...)

### DIFF
--- a/validation-test/compiler_crashers/28382-swift-archetypebuilder-maptypeoutofcontext.swift
+++ b/validation-test/compiler_crashers/28382-swift-archetypebuilder-maptypeoutofcontext.swift
@@ -1,0 +1,15 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+var b{{
+}
+typealias e:A
+protocol A{
+typealias e:e:typealias F
+typealias e=F


### PR DESCRIPTION
Add test case for crash triggered in `swift::ArchetypeBuilder::mapTypeOutOfContext(...)`.

Current number of unresolved compiler crashers: 38 (5154 resolved)

Assertion failure in [`lib/AST/ArchetypeBuilder.cpp (line 2086)`](https://github.com/apple/swift/blob/master/lib/AST/ArchetypeBuilder.cpp#L2086):

```
Assertion `!canType->hasTypeParameter() && "already have an interface type"' failed.

When executing: static swift::Type swift::ArchetypeBuilder::mapTypeOutOfContext(swift::ModuleDecl *, swift::GenericParamList *, swift::Type)
```

Assertion context:

```

Type ArchetypeBuilder::mapTypeOutOfContext(ModuleDecl *M,
                                           GenericParamList *genericParams,
                                           Type type) {
  auto canType = type->getCanonicalType();
  assert(!canType->hasTypeParameter() && "already have an interface type");
  if (!canType->hasArchetype())
    return type;

  assert(genericParams && "dependent type in non-generic context");

```

Stack trace:

```
swift: /path/to/swift/lib/AST/ArchetypeBuilder.cpp:2086: static swift::Type swift::ArchetypeBuilder::mapTypeOutOfContext(swift::ModuleDecl *, swift::GenericParamList *, swift::Type): Assertion `!canType->hasTypeParameter() && "already have an interface type"' failed.
8  swift           0x00000000010169b5 swift::ArchetypeBuilder::mapTypeOutOfContext(swift::ModuleDecl*, swift::GenericParamList*, swift::Type) + 293
11 swift           0x0000000000ecc972 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3394
12 swift           0x000000000113982b swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2667
13 swift           0x00000000011380b1 swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2833
14 swift           0x0000000000f0fc4b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
17 swift           0x0000000000f4190e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
19 swift           0x0000000000f42864 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
20 swift           0x0000000000f41800 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
21 swift           0x000000000100c83e swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 158
22 swift           0x0000000000fe2a0d swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
23 swift           0x0000000000ec9279 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) + 137
24 swift           0x0000000000ecc0cd swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1181
28 swift           0x0000000000f4190e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
30 swift           0x0000000000f42864 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
31 swift           0x0000000000f41800 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
34 swift           0x0000000000ecc972 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3394
37 swift           0x0000000000ed2096 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
40 swift           0x0000000000f3a50a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
41 swift           0x0000000000f3a36e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
42 swift           0x0000000000f3af33 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
44 swift           0x0000000000ef5f71 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
45 swift           0x0000000000c76f49 swift::CompilerInstance::performSema() + 3289
47 swift           0x00000000007dadd7 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
48 swift           0x00000000007a6ca8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28382-swift-archetypebuilder-maptypeoutofcontext.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28382-swift-archetypebuilder-maptypeoutofcontext-e6d0cd.o
1.  While type-checking getter for b at validation-test/compiler_crashers/28382-swift-archetypebuilder-maptypeoutofcontext.swift:10:6
2.  While type-checking 'e' at validation-test/compiler_crashers/28382-swift-archetypebuilder-maptypeoutofcontext.swift:12:1
3.  While type-checking 'e' at validation-test/compiler_crashers/28382-swift-archetypebuilder-maptypeoutofcontext.swift:12:1
4.  While resolving type A at [validation-test/compiler_crashers/28382-swift-archetypebuilder-maptypeoutofcontext.swift:12:13 - line:12:13] RangeText="A"
5.  While resolving type e at [validation-test/compiler_crashers/28382-swift-archetypebuilder-maptypeoutofcontext.swift:14:13 - line:14:13] RangeText="e"
6.  While type-checking 'e' at validation-test/compiler_crashers/28382-swift-archetypebuilder-maptypeoutofcontext.swift:15:1
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
