### PR TITLE
Added String.init<T>(_: T) and marked it unavailable

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -1046,6 +1046,11 @@ extension String {
   public var uppercaseString: String {
     Builtin.unreachable()
   }
+
+  @available(*, unavailable, renamed: "init(describing:)")
+  public init<T>(_: T) {
+    Builtin.unreachable()
+  }
 }
 
 extension Sequence where Iterator.Element == String {

--- a/test/1_stdlib/StringDiagnostics_without_Foundation.swift
+++ b/test/1_stdlib/StringDiagnostics_without_Foundation.swift
@@ -23,3 +23,9 @@ func testStringCollectionTypes(s: String) {
   acceptsBidirectionalCollection(s.characters)
   acceptsRandomAccessCollection(s.characters) // expected-error{{argument type 'String.CharacterView' does not conform to expected type 'RandomAccessCollection'}}
 }
+
+struct NotLosslessStringConvertible {}
+
+func testStringInitT() {
+  _ = String(NotLosslessStringConvertible()) // expected-error{{'init' has been renamed to 'init(describing:)}}
+}


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Adds back the `String.init<T>(_: T)` initializer with a hint to either conform to `LosslessStringConvertible` or use `String.init(describing:)`

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-2228](https://bugs.swift.org/browse/SR-2228))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
