### PR TITLE
[Sema] Improve diagnostics for attempt to throw an error *code*

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -283,6 +283,10 @@ ERROR(cannot_convert_to_return_type_nil,none,
 
 ERROR(cannot_convert_thrown_type,none,
       "thrown expression type %0 does not conform to 'Error'", (Type))
+ERROR(cannot_throw_error_code,none,
+      "thrown error code type %0 does not conform to 'Error'; construct an %1 "
+      "instance", (Type, Type))
+
 ERROR(cannot_throw_nil,none,
       "cannot infer concrete Error for thrown 'nil' value", ())
 

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3677,7 +3677,7 @@ bool FailureDiagnosis::diagnoseContextualConversionError() {
     diagIDProtocol = diag::cannot_convert_to_return_type_protocol;
     nilDiag = diag::cannot_convert_to_return_type_nil;
     break;
-  case CTP_ThrowStmt:
+  case CTP_ThrowStmt: {
     if (isa<NilLiteralExpr>(expr->getValueProvidingExpr())) {
       diagnose(expr->getLoc(), diag::cannot_throw_nil);
       return true;
@@ -3686,14 +3686,42 @@ bool FailureDiagnosis::diagnoseContextualConversionError() {
     if (isUnresolvedOrTypeVarType(exprType) ||
         exprType->isEqual(contextualType))
       return false;
-      
+
+    // If we tried to throw the error code of an error type, suggest object
+    // construction.
+    auto &TC = CS->getTypeChecker();
+    if (auto errorCodeProtocol =
+            TC.Context.getProtocol(KnownProtocolKind::ErrorCodeProtocol)) {
+      ProtocolConformance *conformance = nullptr;
+      if (TC.conformsToProtocol(expr->getType(), errorCodeProtocol, CS->DC,
+                                ConformanceCheckFlags::InExpression,
+                                &conformance) &&
+          conformance) {
+        Type errorCodeType = expr->getType();
+        Type errorType =
+          ProtocolConformance::getTypeWitnessByName(errorCodeType, conformance,
+                                                    TC.Context.Id_ErrorType,
+                                                    &TC)->getCanonicalType();
+        if (errorType) {
+          auto diag = diagnose(expr->getLoc(), diag::cannot_throw_error_code,
+                               errorCodeType, errorType);
+          if (auto unresolvedDot = dyn_cast<UnresolvedDotExpr>(expr)) {
+            diag.fixItInsert(unresolvedDot->getDotLoc(), "(");
+            diag.fixItInsertAfter(unresolvedDot->getEndLoc(), ")");
+          }
+          return true;
+        }
+      }
+    }
+
     // The conversion destination of throw is always ErrorType (at the moment)
     // if this ever expands, this should be a specific form like () is for
     // return.
     diagnose(expr->getLoc(), diag::cannot_convert_thrown_type, exprType)
       .highlight(expr->getSourceRange());
     return true;
-      
+  }
+
   case CTP_EnumCaseRawValue:
     diagID = diag::cannot_convert_raw_initializer_value;
     diagIDProtocol = diag::cannot_convert_raw_initializer_value;

--- a/test/Constraints/ErrorBridging.swift
+++ b/test/Constraints/ErrorBridging.swift
@@ -68,3 +68,8 @@ extension Error {
     return self // expected-error{{cannot convert return expression of type 'Self' to return type 'NSError'}}
   }
 }
+
+// rdar://problem/27543121
+func throwErrorCode() throws {
+  throw FictionalServerError.meltedDown // expected-error{{thrown error code type 'FictionalServerError.Code' does not conform to 'Error'; construct an 'FictionalServerError' instance}}{{29-29=(}}{{40-40=)}}
+}

--- a/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
@@ -236,3 +236,76 @@ func _convertNSErrorToError(_ string: NSError?) -> Error
 
 @_silgen_name("swift_convertErrorToNSError")
 func _convertErrorToNSError(_ string: Error) -> NSError
+
+/// An internal protocol to represent Swift error enums that map to standard
+/// Cocoa NSError domains.
+public protocol _ObjectiveCBridgeableError : Error {
+  /// Produce a value of the error type corresponding to the given NSError,
+  /// or return nil if it cannot be bridged.
+  init?(_bridgedNSError: NSError)
+}
+
+/// Describes a bridged error that stores the underlying NSError, so
+/// it can be queried.
+public protocol _BridgedStoredNSError : _ObjectiveCBridgeableError {
+  /// The type of an error code.
+  associatedtype Code: _ErrorCodeProtocol
+
+  /// The error code for the given error.
+  var code: Code { get }
+
+  //// Retrieves the embedded NSError.
+  var _nsError: NSError { get }
+
+  /// Create a new instance of the error type with the given embedded
+  /// NSError.
+  ///
+  /// The \c error must have the appropriate domain for this error
+  /// type.
+  init(_nsError error: NSError)
+}
+
+public protocol _ErrorCodeProtocol {
+  /// The corresponding error code.
+  associatedtype _ErrorType
+}
+
+public extension _BridgedStoredNSError {
+  public init?(_bridgedNSError error: NSError) {
+    self.init(_nsError: error)
+  }
+}
+
+/// Various helper implementations for _BridgedStoredNSError
+public extension _BridgedStoredNSError
+    where Code: RawRepresentable, Code.RawValue: SignedInteger {
+  // FIXME: Generalize to Integer.
+  public var code: Code {
+    return Code(rawValue: numericCast(_nsError.code))!
+  }
+
+  /// Initialize an error within this domain with the given ``code``
+  /// and ``userInfo``.
+  public init(_ code: Code, userInfo: [String : Any] = [:]) {
+    self.init(_nsError: NSError(domain: "", code: 0, userInfo: [:]))
+  }
+
+  /// The user-info dictionary for an error that was bridged from
+  /// NSError.
+  var userInfo: [String : Any] { return [:] }
+}
+
+/// Various helper implementations for _BridgedStoredNSError
+public extension _BridgedStoredNSError
+    where Code: RawRepresentable, Code.RawValue: UnsignedInteger {
+  // FIXME: Generalize to Integer.
+  public var code: Code {
+    return Code(rawValue: numericCast(_nsError.code))!
+  }
+
+  /// Initialize an error within this domain with the given ``code``
+  /// and ``userInfo``.
+  public init(_ code: Code, userInfo: [String : Any] = [:]) {
+    self.init(_nsError: NSError(domain: "", code: 0, userInfo: [:]))
+  }
+}

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -1065,3 +1065,10 @@ static const NSClothingStyle NSClothingStyleOfficeCasual __attribute__((availabi
 void acceptError(NSError * _Nonnull error);
 NSError * _Nonnull produceError(void);
 NSError * _Nullable produceOptionalError(void);
+
+extern NSString * const FictionalServerErrorDomain;
+
+typedef enum __attribute__((ns_error_domain(FictionalServerErrorDomain))) FictionalServerErrorCode : NSInteger {
+  FictionalServerErrorMeltedDown = 1
+} FictionalServerErrorCode;
+


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

As noted in the subject, this improves a diagnostic for pre-NSError-bridging code that attempts to throw an error code without constructing an actual error value. 
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

Fixes rdar://problem/27543121.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Attempting to throw an error code value, e.g.,

  throw CocoaError.fileNoSuchFileError

is now ill-formed, although it was well-formed prior to the
introduction of NSError bridging (SE-0112). Provide a specialized
diagnostic with a Fix-It to add the appropriate parentheses:

  throw CocoaError(.fileNoSuchFileError)

Fixes rdar://problem/27543121.
