### PR TITLE
[SILGen] Use the 'Class' existential representation for NSError subcl…

### DIFF
--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -465,8 +465,8 @@ static bool isBridgedErrorClass(SILModule &M,
     t = archetypeType->getSuperclass();
 
   // NSError (TODO: and CFError) can be bridged.
-  auto errorType = M.Types.getNSErrorType();
-  if (t && errorType && t->isEqual(errorType)) {
+  auto nsErrorType = M.Types.getNSErrorType();
+  if (t && nsErrorType && nsErrorType->isExactSuperclassOf(t, nullptr)) {
     return true;
   }
   

--- a/test/1_stdlib/ErrorBridged.swift
+++ b/test/1_stdlib/ErrorBridged.swift
@@ -582,4 +582,12 @@ ErrorBridgingTests.test("Customizing localization/recovery laziness") {
   }
 }
 
+class MyNSError : NSError {  }
+
+ErrorBridgingTests.test("NSError subclass identity") {
+  let myNSError: Error = MyNSError(domain: "MyNSError", code: 0, userInfo: [:])
+  let nsError = myNSError as NSError
+  expectTrue(type(of: nsError) == MyNSError.self)
+}
+
 runAllTests()

--- a/test/SILGen/objc_error.swift
+++ b/test/SILGen/objc_error.swift
@@ -95,3 +95,16 @@ func testProduceOptionalError() -> Error? {
   // CHECK: function_ref @swift_convertNSErrorToError
   return produceOptionalError();
 }
+
+class MyNSError : NSError {
+  override init() {
+    super.init(domain: "MyNSError", code: 0, userInfo: [:])
+  }
+}
+
+// CHECK-LABEL: sil hidden @_TF10objc_error14eraseMyNSError
+// CHECK-NOT: return
+// CHECK: init_existential_ref
+func eraseMyNSError() -> Error {
+  return MyNSError()
+}


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

This avoids wrapping of NSError subclasses in _SwiftNativeNSError within SILGen. The runtime already does some checks for subclasses.
#### Resolved bug number: ([rdar://problem/27658748](rdar://problem/27658748))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…asses.

In addition to using the 'Class' existential representation for
NSError, use it for subclasses of NSError, which can also be toll-free
bridged. Narrowly addresses rdar://problem/27658748.
