### PR TITLE
Improve Foundation overlay to handle bridging subscripts and dictionary literals.

### DIFF
--- a/stdlib/public/SDK/XCTest/XCTest.swift
+++ b/stdlib/public/SDK/XCTest/XCTest.swift
@@ -70,13 +70,13 @@ func _XCTRunThrowableBlock(_ block: @noescape () throws -> Void) -> _XCTThrowabl
   if let blockError = blockErrorOptional {
     return .failedWithError(error: blockError)
   } else if d.count > 0 {
-    let t: String = d["type" as NSString] as! String
+    let t: String = d["type"] as! String
     
     if t == "objc" {
       return .failedWithException(
-        className: d["className" as NSString] as! String,
-        name: d["name" as NSString] as! String,
-        reason: d["reason" as NSString] as! String)
+        className: d["className"] as! String,
+        name: d["name"] as! String,
+        reason: d["reason"] as! String)
     } else {
       return .failedWithUnknownException
     }

--- a/test/1_stdlib/NSArrayAPI.swift
+++ b/test/1_stdlib/NSArrayAPI.swift
@@ -12,13 +12,13 @@ var NSArrayAPI = TestSuite("NSArrayAPI")
 
 NSArrayAPI.test("mixed types with AnyObject") {
   do {
-    let result: AnyObject = [1 as NSNumber, "two" as NSString] as NSArray
-    let expect: NSArray = [1 as NSNumber, "two" as NSString]
+    let result: AnyObject = [1, "two"] as NSArray
+    let expect: NSArray = [1, "two"]
     expectEqual(expect, result as! NSArray)
   }
   do {
-    let result: AnyObject = [1 as NSNumber, 2 as NSNumber] as NSArray
-    let expect: NSArray = [1 as NSNumber, 2 as NSNumber]
+    let result: AnyObject = [1, 2] as NSArray
+    let expect: NSArray = [1, 2]
     expectEqual(expect, result as! NSArray)
   }
 }

--- a/test/ClangModules/objc_parse.swift
+++ b/test/ClangModules/objc_parse.swift
@@ -170,8 +170,8 @@ func keyedSubscripting(_ b: B, idx: A, a: A) {
   dict[NSString()] = a
   let value = dict[NSString()]
 
-  dict[nil] = a // expected-error {{nil is not compatible with expected argument type 'NSCopying'}}
-  let q = dict[nil]  // expected-error {{nil is not compatible with expected argument type 'NSCopying'}}
+  dict[nil] = a // expected-error {{ambiguous reference}}
+  let q = dict[nil]  // expected-error {{ambiguous subscript}}
   _ = q
 }
 

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -171,7 +171,7 @@ func dictionaryToNSDictionary() {
 
   // <rdar://problem/17134986>
   var bcOpt: BridgedClass?
-  nsd = [BridgedStruct() : bcOpt] // expected-error{{value of type 'BridgedStruct' does not conform to expected dictionary key type 'NSCopying'}}
+  nsd = [BridgedStruct() : bcOpt]
   bcOpt = nil
   _ = nsd
 }

--- a/test/Constraints/casts_objc.swift
+++ b/test/Constraints/casts_objc.swift
@@ -32,12 +32,12 @@ func nsobject_as_class_cast<T>(_ x: NSObject, _: T) {
 
 // <rdar://problem/20294245> QoI: Error message mentions value rather than key for subscript
 func test(_ a : CFString!, b : CFString) {
-  var dict = NSMutableDictionary()
+  let dict = NSMutableDictionary()
   let object = NSObject()
-  dict[a] = object // expected-error {{argument type 'CFString!' does not conform to expected type 'NSCopying'}}
+  dict[a] = object
 
 
-  dict[b] = object // expected-error {{argument type 'CFString' does not conform to expected type 'NSCopying'}}
+  dict[b] = object
 }
 
 

--- a/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
@@ -327,3 +327,17 @@ public extension _BridgedStoredNSError
     self.init(_nsError: NSError(domain: "", code: 0, userInfo: [:]))
   }
 }
+
+extension NSDictionary {
+  public subscript(_: Any) -> Any? {
+    @objc(_swift_objectForKeyedSubscript:)
+    get { fatalError() }
+  }
+}
+extension NSMutableDictionary {
+  public override subscript(_: Any) -> Any? {
+    get { fatalError() }
+    @objc(_swift_setObject:forKeyedSubscript:)
+    set { }
+  }
+}

--- a/test/Interpreter/SDK/Foundation_test.swift
+++ b/test/Interpreter/SDK/Foundation_test.swift
@@ -122,13 +122,13 @@ FoundationTestSuite.test("arrayConversions") {
 //===----------------------------------------------------------------------===//
 
 FoundationTestSuite.test("NSDictionary") {
-  var nsDict : NSDictionary = [1 as NSNumber : "Hello" as NSString, 2 as NSNumber : "World" as NSString]
-  assert((nsDict[1 as NSNumber]! as! NSString).isEqual("Hello"))
-  assert((nsDict[2 as NSNumber]! as! NSString).isEqual("World"))
+  var nsDict : NSDictionary = [1 : "Hello", 2 : "World"]
+  assert((nsDict[1]! as! NSString).isEqual("Hello"))
+  assert((nsDict[2]! as! NSString).isEqual("World"))
 
-  let nsMutableDict: NSMutableDictionary = ["Hello" as NSString : 1 as NSNumber, "World" as NSString : 2 as NSNumber]
-  assert((nsMutableDict["Hello" as NSString]! as AnyObject).isEqual(1))
-  assert((nsMutableDict["World" as NSString]! as AnyObject).isEqual(2))
+  let nsMutableDict: NSMutableDictionary = ["Hello" : 1, "World" : 2 as NSNumber]
+  assert((nsMutableDict["Hello"]! as AnyObject).isEqual(1))
+  assert((nsMutableDict["World"]! as AnyObject).isEqual(2))
 }
 
 //===----------------------------------------------------------------------===//
@@ -189,8 +189,8 @@ class ClassWithDtor : NSObject {
 FoundationTestSuite.test("rdar://17584531") {
   // <rdar://problem/17584531>
   // Type checker used to be confused by this.
-  var dict: NSDictionary = ["status" as NSString: 200 as NSNumber, "people" as NSString: [["id" as NSString: 255 as NSNumber, "name" as NSString: ["first" as NSString: "John" as NSString, "last" as NSString: "Appleseed" as NSString] as NSDictionary] as NSDictionary] as NSArray] as NSDictionary
-  var dict2 = dict["people" as NSString].map { $0 as AnyObject }?[0] as! NSDictionary
+  var dict: NSDictionary = ["status": 200, "people": [["id": 255, "name": ["first": "John", "last": "Appleseed"] as NSDictionary] as NSDictionary] as NSArray]
+  var dict2 = dict["people"].flatMap { $0 as? NSArray }?[0] as! NSDictionary
   expectEqual("Optional(255)", String(describing: dict2["id" as NSString]))
 }
 

--- a/test/Interpreter/SDK/objc_dynamic_lookup.swift
+++ b/test/Interpreter/SDK/objc_dynamic_lookup.swift
@@ -7,7 +7,7 @@ import Foundation
 
 // Dynamic subscripting of NSArray, dynamic method dispatch
 // CHECK: {{^3$}}
-var array : AnyObject = [1 as NSNumber, 2 as NSNumber, 3 as NSNumber, 4 as NSNumber, 5 as NSNumber] as NSArray
+var array : AnyObject = [1, 2, 3, 4, 5] as NSArray
 print((array[2] as AnyObject).description)
 
 // Dynamic subscripting on an array using an object (fails)
@@ -21,7 +21,7 @@ if optVal1 != nil {
 
 // Dynamic subscripting of NSDictionary, dynamic method dispatch
 // CHECK: {{^2$}}
-var nsdict : NSDictionary = ["Hello" as NSString : 1 as NSNumber, "World" as NSString : 2 as NSNumber]
+var nsdict : NSDictionary = ["Hello" : 1, "World" : 2]
 var dict : AnyObject = nsdict
 print(((dict["World" as NSString]!)! as AnyObject).description)
 

--- a/test/Interpreter/SDK/objc_fast_enumeration.swift
+++ b/test/Interpreter/SDK/objc_fast_enumeration.swift
@@ -60,8 +60,8 @@ autoreleasepool {
 // CHECK: exited
 print("exited")
 
-var d : NSDictionary = [415 as NSNumber : "Giants" as NSString, 510 as NSNumber : "A's" as NSString]
-var d_m : NSMutableDictionary = [1415 as NSNumber : "Big Giants" as NSString, 11510 as NSNumber : "B's" as NSString]
+var d : NSDictionary = [415 : "Giants" , 510 : "A's"]
+var d_m : NSMutableDictionary = [1415 : "Big Giants", 11510 : "B's"]
 
 // CHECK: 510 => A's
 for (key, value) in d {

--- a/test/Interpreter/SDK/objc_switch.swift
+++ b/test/Interpreter/SDK/objc_switch.swift
@@ -3,9 +3,6 @@
 
 // REQUIRES: objc_interop
 
-// rdar://problem/27616753
-// XFAIL: *
-
 import Foundation
 
 func testAnyObjectIsa(_ obj: AnyObject) {
@@ -33,19 +30,19 @@ print("testing...")
 
 
 // CHECK-NEXT: (String)
-testAnyObjectIsa("hello")
+testAnyObjectIsa("hello" as NSString)
 
 // CHECK-NEXT: (Int)
-testAnyObjectIsa(5)
+testAnyObjectIsa(5 as NSNumber)
 
 // CHECK-NEXT: ([NSString])
-testAnyObjectIsa(["hello", "swift", "world"])
+testAnyObjectIsa(["hello", "swift", "world"] as NSArray)
 
 // CHECK-NEXT: ([Int])
-testAnyObjectIsa([1, 2, 3, 4, 5])
+testAnyObjectIsa([1, 2, 3, 4, 5] as NSArray)
 
 // CHECK-NEXT: (Dictionary<String, Int>)
-testAnyObjectIsa(["hello" : 1, "world" : 2])
+testAnyObjectIsa(["hello" : 1, "world" : 2] as NSDictionary)
 
 func testNSArrayIsa(_ nsArr: NSArray) {
   print("(", terminator: "")
@@ -67,7 +64,7 @@ testNSArrayIsa([1, 2, 3])
 // CHECK-NEXT: ()
 testNSArrayIsa([[1, 2], [3, 4], [5, 6]])
 
-func testArrayIsa(_ arr: Array<AnyObject>) {
+func testArrayIsa(_ arr: Array<Any>) {
   print("(", terminator: "")
   if arr is [NSString] {
     print("[NSString]", terminator: "")
@@ -87,7 +84,7 @@ testArrayIsa([1, 2, 3])
 // CHECK-NEXT: ()
 testArrayIsa([[1, 2], [3, 4], [5, 6]])
 
-func testArrayIsaBridged(_ arr: Array<AnyObject>) {
+func testArrayIsaBridged(_ arr: Array<Any>) {
   print("(", terminator: "")
   if arr is [String] {
     print("[String]", terminator: "")
@@ -145,22 +142,22 @@ func testAnyObjectDowncast(_ obj: AnyObject!) {
 }
 
 // CHECK-NEXT: String: hello
-testAnyObjectDowncast("hello")
+testAnyObjectDowncast("hello" as NSString)
 
 // CHECK-NEXT: Int: 5
-testAnyObjectDowncast(5)
+testAnyObjectDowncast(5 as NSNumber)
 
 // CHECK-NEXT: NSString array: [hello, swift, world]
 testAnyObjectDowncast(["hello", "swift", "world"] as NSArray)
 
 // CHECK-NEXT: Int array: [1, 2, 3, 4, 5]
-testAnyObjectDowncast([1, 2, 3, 4, 5])
+testAnyObjectDowncast([1, 2, 3, 4, 5] as NSArray)
 
 // CHECK: Dictionary<String, Int>: [
 // CHECK-DAG: "hello": 1
 // CHECK-DAG: "world": 2
 // CHECK: ]
-testAnyObjectDowncast(["hello" : 1, "world" : 2])
+testAnyObjectDowncast(["hello" : 1, "world" : 2] as NSDictionary)
 
 // CHECK-NEXT: Did not match
 testAnyObjectDowncast(nil)

--- a/test/SILOptimizer/bridged_casts_folding.swift
+++ b/test/SILOptimizer/bridged_casts_folding.swift
@@ -188,9 +188,9 @@ public func testCondCastNStoSwiftArrayString() -> [String]? {
 
 // Check optimization of casts from NSDictionary to Swift Dictionary
 
-var nsDictInt: NSDictionary = [1 as NSNumber:1 as NSNumber, 2 as NSNumber:2 as NSNumber, 3 as NSNumber:3 as NSNumber, 4 as NSNumber:4 as NSNumber]
-var nsDictDouble: NSDictionary = [1.1 as NSNumber : 1.1 as NSNumber, 2.2 as NSNumber : 2.2 as NSNumber, 3.3 as NSNumber : 3.3 as NSNumber, 4.4 as NSNumber : 4.4 as NSNumber]
-var nsDictString: NSDictionary = ["One" as NSString:"One" as NSString, "Two" as NSString:"Two" as NSString, "Three" as NSString:"Three" as NSString, "Four" as NSString:"Four" as NSString]
+var nsDictInt: NSDictionary = [1:1, 2:2, 3:3, 4:4]
+var nsDictDouble: NSDictionary = [1.1 : 1.1, 2.2 : 2.2, 3.3 : 3.3, 4.4 : 4.4]
+var nsDictString: NSDictionary = ["One":"One", "Two":"Two", "Three":"Three", "Four":"Four"]
 
 // CHECK-LABEL: sil [noinline] @_TF21bridged_casts_folding30testForcedCastNStoSwiftDictIntFT_GVs10DictionarySiSi_
 // CHECK-NOT: unconditional_checked

--- a/validation-test/stdlib/XCTest.swift
+++ b/validation-test/stdlib/XCTest.swift
@@ -161,8 +161,8 @@ XCTestTestSuite.test("XCTAssertEqual/Dictionary<T, U>") {
     }
 
     dynamic func test_whenDictionariesAreNotEqual_fails() {
-      XCTAssertEqual(["foo": ["bar": "baz"] as Dictionary as NSDictionary],
-                     ["foo": ["bar": "flim"] as Dictionary as NSDictionary])
+      XCTAssertEqual(["foo": ["bar": "baz"] as NSDictionary],
+                     ["foo": ["bar": "flim"] as NSDictionary])
     }
   }
 


### PR DESCRIPTION
SE-0072 took implicit bridging conversions away, which regressed the ability to express NSDictionaries as dictionary literals and index them using literal keys. Address this by changing the signature of init(dictionaryLiteral:) to use Hashable and Any, and by replacing the subscript from Objective-C with one using _Hashable that does the bridging on the user's behalf. This largely restores the QoI of working with NS collections.
