### PR TITLE
[NSError bridging] Use embedded NSError when erasing types to Error e…

### DIFF
--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -129,6 +129,11 @@ public:
   Optional<FuncDecl*> UnconditionallyBridgeFromObjectiveCRequirement;
   Optional<AssociatedTypeDecl*> BridgedObjectiveCType;
 
+  Optional<ProtocolDecl*> BridgedStoredNSError;
+  Optional<VarDecl*> NSErrorRequirement;
+
+  Optional<ProtocolConformance *> NSErrorConformanceToError;
+
 public:
   SILGenModule(SILModule &M, Module *SM, bool makeModuleFragile);
   ~SILGenModule();
@@ -379,6 +384,20 @@ public:
   /// _ObjectiveCBridgeable protocol.
   ProtocolConformance *getConformanceToObjectiveCBridgeable(SILLocation loc,
                                                             Type type);
+
+  /// Retrieve the _BridgedStoredNSError protocol definition.
+  ProtocolDecl *getBridgedStoredNSError(SILLocation loc);
+
+  /// Retrieve the _BridgedStoredNSError._nsError requirement.
+  VarDecl *getNSErrorRequirement(SILLocation loc);
+
+  /// Find the conformance of the given Swift type to the
+  /// _BridgedStoredNSError protocol.
+  ProtocolConformance *getConformanceToBridgedStoredNSError(SILLocation loc,
+                                                            Type type);
+
+  /// Retrieve the conformance of NSError to the Error protocol.
+  ProtocolConformance *getNSErrorConformanceToError();
 
   /// Report a diagnostic.
   template<typename...T, typename...U>

--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -496,6 +496,11 @@ extension _ErrorCodeProtocol where Self._ErrorType: _BridgedStoredNSError {
 }
 
 extension _BridgedStoredNSError {
+  /// Retrieve the embedded NSError from a bridged, stored NSError.
+  public func _getEmbeddedNSError() -> AnyObject? {
+    return _nsError
+  }
+
   public static func == (lhs: Self, rhs: Self) -> Bool {
     return lhs._nsError.isEqual(rhs._nsError)
   }

--- a/stdlib/public/core/ErrorType.swift
+++ b/stdlib/public/core/ErrorType.swift
@@ -114,11 +114,22 @@ public protocol Error {
   var _domain: String { get }
   var _code: Int { get }
   var _userInfo: Any? { get }
+
+#if _runtime(_ObjC)
+  func _getEmbeddedNSError() -> AnyObject?
+#endif
 }
 
 #if _runtime(_ObjC)
-// Helper functions for the C++ runtime to have easy access to domain,
-// code, and userInfo as Objective-C values.
+extension Error {
+  /// Default implementation: there is no embedded NSError.
+  public func _getEmbeddedNSError() -> AnyObject? { return nil }
+}
+#endif
+
+#if _runtime(_ObjC)
+// Helper functions for the C++ runtime to have easy access to embedded error,
+// domain, code, and userInfo as Objective-C values.
 @_silgen_name("swift_stdlib_getErrorDomainNSString")
 public func _stdlib_getErrorDomainNSString<T : Error>(_ x: UnsafePointer<T>)
 -> AnyObject {
@@ -136,6 +147,12 @@ public func _stdlib_getErrorCode<T : Error>(_ x: UnsafePointer<T>) -> Int {
 public func _stdlib_getErrorUserInfoNSDictionary<T : Error>(_ x: UnsafePointer<T>)
 -> AnyObject? {
   return x.pointee._userInfo.map { $0 as AnyObject }
+}
+
+@_silgen_name("swift_stdlib_getErrorEmbeddedNSError")
+public func _stdlib_getErrorEmbeddedNSError<T : Error>(_ x: UnsafePointer<T>)
+-> AnyObject? {
+  return x.pointee._getEmbeddedNSError()
 }
 
 @_silgen_name("swift_stdlib_getErrorDefaultUserInfo")

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -2006,14 +2006,32 @@ static bool _dynamicCastToFunction(OpaqueValue *dest,
 }
 
 #if SWIFT_OBJC_INTEROP
+// @_silgen_name("swift_stdlib_getErrorEmbeddedNSError")
+// public func _stdlib_getErrorEmbeddedNSError<T : Error>(_ x: UnsafePointer<T>)
+//   -> AnyObject?
+SWIFT_CC(swift)
+extern "C" id swift_stdlib_getErrorEmbeddedNSError(const OpaqueValue *error,
+                                                   const Metadata *T,
+                                                   const WitnessTable *Error);
+
 static id dynamicCastValueToNSError(OpaqueValue *src,
                                     const Metadata *srcType,
                                     const WitnessTable *srcErrorWitness,
                                     DynamicCastFlags flags) {
+  // Check whether there is an embedded error.
+  if (auto embedded = swift_stdlib_getErrorEmbeddedNSError(src, srcType,
+                                                           srcErrorWitness)) {
+    if (flags & DynamicCastFlags::TakeOnSuccess)
+      srcType->vw_destroy(src);
+
+    return embedded;
+  }
+
   BoxPair errorBox = swift_allocError(srcType, srcErrorWitness, src,
                             /*isTake*/ flags & DynamicCastFlags::TakeOnSuccess);
   return swift_bridgeErrorToNSError((SwiftError*)errorBox.first);
 }
+
 #endif
 
 namespace {

--- a/test/1_stdlib/ErrorBridged.swift
+++ b/test/1_stdlib/ErrorBridged.swift
@@ -590,4 +590,41 @@ ErrorBridgingTests.test("NSError subclass identity") {
   expectTrue(type(of: nsError) == MyNSError.self)
 }
 
+ErrorBridgingTests.test("Wrapped NSError identity") {
+  let nsError = NSError(domain: NSCocoaErrorDomain,
+                   code: NSFileNoSuchFileError,
+                   userInfo: [
+                     AnyHashable(NSFilePathErrorKey) : "/dev/null",
+                     AnyHashable(NSStringEncodingErrorKey): /*ASCII=*/1,
+                   ])
+
+  let error: Error = nsError
+  let nsError2: NSError = error as NSError
+  expectTrue(nsError === nsError2)
+
+  // Extracting the NSError via the runtime.
+  let cocoaErrorAny: Any = error as! CocoaError
+  let nsError3: NSError = cocoaErrorAny as! NSError
+  expectTrue(nsError === nsError3)
+
+  if let cocoaErrorAny2: Any = error as? CocoaError {
+    let nsError4: NSError = cocoaErrorAny2 as! NSError
+    expectTrue(nsError === nsError4)
+  } else {
+    expectUnreachable()
+  }
+
+  // Extracting the NSError via direct call.
+  let cocoaError = error as! CocoaError
+  let nsError5: NSError = cocoaError as NSError
+  expectTrue(nsError === nsError5)
+
+  if let cocoaError2 = error as? CocoaError {
+    let nsError6: NSError = cocoaError as NSError
+    expectTrue(nsError === nsError6)
+  } else {
+    expectUnreachable()
+  }
+}
+
 runAllTests()

--- a/test/SILGen/objc_error.swift
+++ b/test/SILGen/objc_error.swift
@@ -108,3 +108,13 @@ class MyNSError : NSError {
 func eraseMyNSError() -> Error {
   return MyNSError()
 }
+
+// CHECK-LABEL: sil hidden @_TF10objc_error25eraseFictionalServerErrorFT_Ps5Error_
+func eraseFictionalServerError() -> Error {
+  // CHECK-NOT: return
+  // CHECK: [[NSERROR_GETTER:%[0-9]+]] = function_ref @_TFVSC20FictionalServerErrorg8_nsErrorCSo7NSError
+  // CHECK: [[NSERROR:%[0-9]+]] = apply [[NSERROR_GETTER]]
+  // CHECK: [[ERROR:%[0-9]+]] = init_existential_ref [[NSERROR]]
+  // CHECK: return [[ERROR]]
+  return FictionalServerError(.meltedDown)
+}


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Imported Cocoa error types are represented by structs wrapping an NSError. The conversion from these structs to Error would end up boxing the structs in _SwiftNativeNSError, losing identity and leading to a wrapping loop.

Instead, extract the embedded NSError if there is one. In the Swift runtime, do this as part of the dynamic cast to NSError, using a (new, defaulted) requirement in the Error type so we can avoid an extra runtime lookup of the protocol. In SILGEn, do this by looking for the _BridgedStoredNSError protocol conformance when erasing to an Error type.
#### Resolved bug number: ([SR-1562](https://bugs.swift.org/browse/SR-1562))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

AKA: rdar://problem/26370984

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…xistentials.

Imported Cocoa error types are represented by structs wrapping an
NSError. The conversion from these structs to Error would end up
boxing the structs in _SwiftNativeNSError, losing identity and leading
to a wrapping loop.

Instead, extract the embedded NSError if there is one. In the Swift
runtime, do this as part of the dynamic cast to NSError, using a (new,
defaulted) requirement in the Error type so we can avoid an extra
runtime lookup of the protocol. In SILGEn, do this by looking for the
_BridgedStoredNSError protocol conformance when erasing to an Error
type. Fixes SR-1562 / rdar://problem/26370984.
