### PR TITLE
Count tail-padding in the size of imported C types.

### DIFF
--- a/test/IRGen/c_layout.sil
+++ b/test/IRGen/c_layout.sil
@@ -7,8 +7,8 @@ import Swift
 
 // TODO: Provide tests for other architectures
 
-// CHECK-x86_64: %VSC11BitfieldOne = type <{ %Vs6UInt32, %VSC6Nested, [1 x i8], [4 x i8], [4 x i8], %Sf, [1 x i8], [7 x i8], %Vs6UInt64, %Vs6UInt32 }>
-// CHECK-x86_64: %VSC6Nested = type <{ %Sf, [3 x i8] }>
+// CHECK-x86_64: %VSC11BitfieldOne = type <{ %Vs6UInt32, %VSC6Nested, [4 x i8], [4 x i8], %Sf, [1 x i8], [7 x i8], %Vs6UInt64, %Vs6UInt32, [4 x i8] }>
+// CHECK-x86_64: %VSC6Nested = type <{ %Sf, [3 x i8], [1 x i8] }>
 
 // CHECK-x86_64: %VSC26BitfieldSeparatorReference = type [[BITFIELD_SEP_TYPE:<{ %Vs5UInt8, \[3 x i8\], %Vs5UInt8 }>]]
 // CHECK-x86_64: %VSC25BitfieldSeparatorSameName = type [[BITFIELD_SEP_TYPE]]
@@ -42,22 +42,22 @@ bb0:
 // CHECK-x86_64:   [[ADDR_B_YZ:%.*]] = getelementptr inbounds %VSC6Nested, %VSC6Nested* [[ADDR_B]], i32 0, i32 1
 // CHECK-x86_64:   [[ADDR_B_YZ_1:%.*]] = bitcast [3 x i8]* [[ADDR_B_YZ]] to i24*
 // CHECK-x86_64:   [[B_YZ:%.*]] = load i24, i24* [[ADDR_B_YZ_1]], align 4
-// CHECK-x86_64:   [[ADDR_CDE:%.*]] = getelementptr inbounds %VSC11BitfieldOne, %VSC11BitfieldOne* [[RESULT]], i32 0, i32 3
+// CHECK-x86_64:   [[ADDR_CDE:%.*]] = getelementptr inbounds %VSC11BitfieldOne, %VSC11BitfieldOne* [[RESULT]], i32 0, i32 2
 // CHECK-x86_64:   [[ADDR_CDE_1:%.*]] = bitcast [4 x i8]* [[ADDR_CDE]] to i32*
 // CHECK-x86_64:   [[CDE:%.*]] = load i32, i32* [[ADDR_CDE_1]], align 4
-// CHECK-x86_64:   [[ADDR_FGH:%.*]] = getelementptr inbounds %VSC11BitfieldOne, %VSC11BitfieldOne* [[RESULT]], i32 0, i32 4
+// CHECK-x86_64:   [[ADDR_FGH:%.*]] = getelementptr inbounds %VSC11BitfieldOne, %VSC11BitfieldOne* [[RESULT]], i32 0, i32 3
 // CHECK-x86_64:   [[ADDR_FGH_1:%.*]] = bitcast [4 x i8]* [[ADDR_FGH]] to i32*
 // CHECK-x86_64:   [[FGH:%.*]] = load i32, i32* [[ADDR_FGH_1]], align 8
-// CHECK-x86_64:   [[ADDR_I:%.*]] = getelementptr inbounds %VSC11BitfieldOne, %VSC11BitfieldOne* [[RESULT]], i32 0, i32 5
+// CHECK-x86_64:   [[ADDR_I:%.*]] = getelementptr inbounds %VSC11BitfieldOne, %VSC11BitfieldOne* [[RESULT]], i32 0, i32 4
 // CHECK-x86_64:   [[ADDR_I_V:%.*]] = getelementptr inbounds %Sf, %Sf* [[ADDR_I]], i32 0, i32 0
 // CHECK-x86_64:   [[I:%.*]] = load float, float* [[ADDR_I_V]], align 4
-// CHECK-x86_64:   [[ADDR_JK:%.*]] = getelementptr inbounds %VSC11BitfieldOne, %VSC11BitfieldOne* [[RESULT]], i32 0, i32 6
+// CHECK-x86_64:   [[ADDR_JK:%.*]] = getelementptr inbounds %VSC11BitfieldOne, %VSC11BitfieldOne* [[RESULT]], i32 0, i32 5
 // CHECK-x86_64:   [[ADDR_JK_1:%.*]] = bitcast [1 x i8]* [[ADDR_JK]] to i8*
 // CHECK-x86_64:   [[JK:%.*]] = load i8, i8* [[ADDR_JK_1]], align 8
-// CHECK-x86_64:   [[ADDR_L:%.*]] = getelementptr inbounds %VSC11BitfieldOne, %VSC11BitfieldOne* [[RESULT]], i32 0, i32 8
+// CHECK-x86_64:   [[ADDR_L:%.*]] = getelementptr inbounds %VSC11BitfieldOne, %VSC11BitfieldOne* [[RESULT]], i32 0, i32 7
 // CHECK-x86_64:   [[ADDR_L_V:%.*]] = getelementptr inbounds %Vs6UInt64, %Vs6UInt64* [[ADDR_L]], i32 0, i32 0
 // CHECK-x86_64:   [[L:%.*]] = load i64, i64* [[ADDR_L_V]], align 8
-// CHECK-x86_64:   [[ADDR_M:%.*]] = getelementptr inbounds %VSC11BitfieldOne, %VSC11BitfieldOne* [[RESULT]], i32 0, i32 9
+// CHECK-x86_64:   [[ADDR_M:%.*]] = getelementptr inbounds %VSC11BitfieldOne, %VSC11BitfieldOne* [[RESULT]], i32 0, i32 8
 // CHECK-x86_64:   [[ADDR_M_V:%.*]] = getelementptr inbounds %Vs6UInt32, %Vs6UInt32* [[ADDR_M]], i32 0, i32 0
 // CHECK-x86_64:   [[M:%.*]] = load i32, i32* [[ADDR_M_V]], align 8
 //   Put all of the values into the indirect argument and make the second call.
@@ -71,22 +71,22 @@ bb0:
 // CHECK-x86_64:   [[ADDR_B_YZ:%.*]] = getelementptr inbounds %VSC6Nested, %VSC6Nested* [[ADDR_B]], i32 0, i32 1
 // CHECK-x86_64:   [[ADDR_B_YZ_1:%.*]] = bitcast [3 x i8]* [[ADDR_B_YZ]] to i24*
 // CHECK-x86_64:   store i24 [[B_YZ]], i24* [[ADDR_B_YZ_1]], align 4
-// CHECK-x86_64:   [[ADDR_CDE:%.*]] = getelementptr inbounds %VSC11BitfieldOne, %VSC11BitfieldOne* [[ARG]], i32 0, i32 3
+// CHECK-x86_64:   [[ADDR_CDE:%.*]] = getelementptr inbounds %VSC11BitfieldOne, %VSC11BitfieldOne* [[ARG]], i32 0, i32 2
 // CHECK-x86_64:   [[ADDR_CDE_1:%.*]] = bitcast [4 x i8]* [[ADDR_CDE]] to i32*
 // CHECK-x86_64:   store i32 [[CDE]], i32* [[ADDR_CDE_1]], align 4
-// CHECK-x86_64:   [[ADDR_FGH:%.*]] = getelementptr inbounds %VSC11BitfieldOne, %VSC11BitfieldOne* [[ARG]], i32 0, i32 4
+// CHECK-x86_64:   [[ADDR_FGH:%.*]] = getelementptr inbounds %VSC11BitfieldOne, %VSC11BitfieldOne* [[ARG]], i32 0, i32 3
 // CHECK-x86_64:   [[ADDR_FGH_1:%.*]] = bitcast [4 x i8]* [[ADDR_FGH]] to i32*
 // CHECK-x86_64:   store i32 [[FGH]], i32* [[ADDR_FGH_1]], align 8
-// CHECK-x86_64:   [[ADDR_I:%.*]] = getelementptr inbounds %VSC11BitfieldOne, %VSC11BitfieldOne* [[ARG]], i32 0, i32 5
+// CHECK-x86_64:   [[ADDR_I:%.*]] = getelementptr inbounds %VSC11BitfieldOne, %VSC11BitfieldOne* [[ARG]], i32 0, i32 4
 // CHECK-x86_64:   [[ADDR_I_V:%.*]] = getelementptr inbounds %Sf, %Sf* [[ADDR_I]], i32 0, i32 0
 // CHECK-x86_64:   store float [[I]], float* [[ADDR_I_V]], align 4
-// CHECK-x86_64:   [[ADDR_JK:%.*]] = getelementptr inbounds %VSC11BitfieldOne, %VSC11BitfieldOne* [[ARG]], i32 0, i32 6
+// CHECK-x86_64:   [[ADDR_JK:%.*]] = getelementptr inbounds %VSC11BitfieldOne, %VSC11BitfieldOne* [[ARG]], i32 0, i32 5
 // CHECK-x86_64:   [[ADDR_JK_1:%.*]] = bitcast [1 x i8]* [[ADDR_JK]] to i8*
 // CHECK-x86_64:   store i8 [[JK]], i8* [[ADDR_JK_1]], align 8
-// CHECK-x86_64:   [[ADDR_L:%.*]] = getelementptr inbounds %VSC11BitfieldOne, %VSC11BitfieldOne* [[ARG]], i32 0, i32 8
+// CHECK-x86_64:   [[ADDR_L:%.*]] = getelementptr inbounds %VSC11BitfieldOne, %VSC11BitfieldOne* [[ARG]], i32 0, i32 7
 // CHECK-x86_64:   [[ADDR_L_V:%.*]] = getelementptr inbounds %Vs6UInt64, %Vs6UInt64* [[ADDR_L]], i32 0, i32 0
 // CHECK-x86_64:   store i64 [[L]], i64* [[ADDR_L_V]], align 8
-// CHECK-x86_64:   [[ADDR_M:%.*]] = getelementptr inbounds %VSC11BitfieldOne, %VSC11BitfieldOne* [[ARG]], i32 0, i32 9
+// CHECK-x86_64:   [[ADDR_M:%.*]] = getelementptr inbounds %VSC11BitfieldOne, %VSC11BitfieldOne* [[ARG]], i32 0, i32 8
 // CHECK-x86_64:   [[ADDR_M_V:%.*]] = getelementptr inbounds %Vs6UInt32, %Vs6UInt32* [[ADDR_M]], i32 0, i32 0
 // CHECK-x86_64:   store i32 [[M]], i32* [[ADDR_M_V]], align 8
 // CHECK-x86_64:   call void @consumeBitfieldOne(%VSC11BitfieldOne* byval align 8 [[ARG]])

--- a/test/Reflection/typeref_decoding_imported.swift
+++ b/test/Reflection/typeref_decoding_imported.swift
@@ -25,7 +25,7 @@
 // CHECK-32: ==============
 
 // CHECK-32: - __C.MyCStruct:
-// CHECK-32: Size: 9
+// CHECK-32: Size: 12
 // CHECK-32: Alignment: 4
 // CHECK-32: Stride: 12
 // CHECK-32: NumExtraInhabitants: 0
@@ -43,7 +43,7 @@
 // CHECK-32: NumExtraInhabitants: 0
 
 // CHECK-i386: - __C.MyCStructWithBitfields:
-// CHECK-i386: Size: 2
+// CHECK-i386: Size: 4
 // CHECK-i386: Alignment: 4
 // CHECK-i386: Stride: 4
 // CHECK-i386: NumExtraInhabitants: 0

--- a/test/Reflection/typeref_decoding_imported.swift
+++ b/test/Reflection/typeref_decoding_imported.swift
@@ -81,7 +81,7 @@
 // CHECK-64: ==============
 
 // CHECK-64: - __C.MyCStruct:
-// CHECK-64: Size: 17
+// CHECK-64: Size: 24
 // CHECK-64: Alignment: 8
 // CHECK-64: Stride: 24
 // CHECK-64: NumExtraInhabitants: 0
@@ -99,7 +99,7 @@
 // CHECK-64: NumExtraInhabitants: 0
 
 // CHECK-64: - __C.MyCStructWithBitfields:
-// CHECK-64: Size: 2
+// CHECK-64: Size: 4
 // CHECK-64: Alignment: 4
 // CHECK-64: Stride: 4
 // CHECK-64: NumExtraInhabitants: 0

--- a/test/Reflection/typeref_lowering_imported.swift
+++ b/test/Reflection/typeref_lowering_imported.swift
@@ -7,13 +7,13 @@
 
 V12TypeLowering9HasCTypes
 // CHECK:     (struct TypeLowering.HasCTypes)
-// CHECK-NEXT: (struct size=34 alignment=8 stride=40 num_extra_inhabitants=0
+// CHECK-NEXT: (struct size=44 alignment=8 stride=48 num_extra_inhabitants=0
 // CHECK-NEXT:   (field name=mcs offset=0
-// CHECK-NEXT:     (builtin size=17 alignment=8 stride=24 num_extra_inhabitants=0))
-// CHECK-NEXT:   (field name=mce offset=20
+// CHECK-NEXT:     (builtin size=24 alignment=8 stride=24 num_extra_inhabitants=0))
+// CHECK-NEXT:   (field name=mce offset=24
 // CHECK-NEXT:     (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))
-// CHECK-NEXT:   (field name=mcu offset=24
+// CHECK-NEXT:   (field name=mcu offset=32
 // CHECK-NEXT:     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))
-// CHECK-NEXT:   (field name=mcsbf offset=32
-// CHECK-NEXT:     (builtin size=2 alignment=4 stride=4 num_extra_inhabitants=0)))
+// CHECK-NEXT:   (field name=mcsbf offset=40
+// CHECK-NEXT:     (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0)))
 


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

Resolves rdar://26828018.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

This allows us to freely pass the address of a variable of such
types to a C function without worrying about it overwriting other
things if e.g. it memcpy's sizeof(T) bytes and thus clobbers the
otherwise-non-existent tail padding.

There are ways to get this optimization back, but they require
things like materializing to a temporary instead of passing the
address directly.  We haven't done that work yet, so we don't
get to take advantage of it.

rdar://26828018
