### PR TITLE
[PrintAsObjC] Hack: Assume all option sets have typedefs.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2499,6 +2499,10 @@ namespace {
         if (!result)
           return nullptr;
 
+        // HACK: Make sure PrintAsObjC always omits the 'enum' tag for
+        // option set enums.
+        Impl.DeclsWithSuperfluousTypedefs.insert(decl);
+
         enumeratorContext = result;
         break;
       }

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -97,9 +97,13 @@ static StringRef getNameForObjC(const ValueDecl *VD,
   if (customNamesOnly)
     return StringRef();
 
-  if (auto clangDecl = dyn_cast_or_null<clang::NamedDecl>(VD->getClangDecl()))
+  if (auto clangDecl = dyn_cast_or_null<clang::NamedDecl>(VD->getClangDecl())) {
     if (const clang::IdentifierInfo *II = clangDecl->getIdentifier())
       return II->getName();
+    if (auto *anonDecl = dyn_cast<clang::TagDecl>(clangDecl))
+      if (auto *anonTypedef = anonDecl->getTypedefNameForAnonDecl())
+        return anonTypedef->getIdentifier()->getName();
+  }
 
   return VD->getName().str();
 }

--- a/test/PrintAsObjC/Inputs/enums.h
+++ b/test/PrintAsObjC/Inputs/enums.h
@@ -1,0 +1,23 @@
+// This file is meant to be used with the mock SDK, not the real one.
+#import <Foundation.h>
+
+#define SWIFT_NAME(X) __attribute__((swift_name(#X)))
+
+@interface Wrapper : NSObject
+@end
+
+enum TopLevelRaw { TopLevelRawA };
+enum MemberRaw { MemberRawA } SWIFT_NAME(Wrapper.Raw);
+
+typedef enum { TopLevelAnonA } TopLevelAnon;
+typedef enum { MemberAnonA } MemberAnon SWIFT_NAME(Wrapper.Anon);
+typedef enum SWIFT_NAME(Wrapper.Anon2) { MemberAnon2A } MemberAnon2;
+
+typedef enum TopLevelTypedef { TopLevelTypedefA } TopLevelTypedef;
+typedef enum SWIFT_NAME(Wrapper.Typedef) MemberTypedef { MemberTypedefA } MemberTypedef;
+
+typedef NS_ENUM(long, TopLevelEnum) { TopLevelEnumA };
+typedef NS_ENUM(long, MemberEnum) { MemberEnumA } SWIFT_NAME(Wrapper.Enum);
+
+typedef NS_OPTIONS(long, TopLevelOptions) { TopLevelOptionsA = 1 };
+typedef NS_OPTIONS(long, MemberOptions) { MemberOptionsA = 1} SWIFT_NAME(Wrapper.Options);

--- a/test/PrintAsObjC/enums.swift
+++ b/test/PrintAsObjC/enums.swift
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-source-import -emit-module -emit-module-doc -o %t %s -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/enums.swiftmodule -parse -emit-objc-header-path %t/enums.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-source-import -emit-module -emit-module-doc -o %t %s -import-objc-header %S/Inputs/enums.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/enums.swiftmodule -parse -emit-objc-header-path %t/enums.h -import-objc-header %S/Inputs/enums.h -disable-objc-attr-requires-foundation-module
 // RUN: FileCheck %s < %t/enums.h
 // RUN: FileCheck -check-prefix=NEGATIVE %s < %t/enums.h
 // RUN: %check-in-clang %t/enums.h
@@ -21,6 +21,8 @@ import Foundation
 // CHECK-NEXT: - (enum NegativeValues)takeAndReturnEnum:(enum FooComments)foo;
 // CHECK-NEXT: - (void)acceptPlainEnum:(enum NSMalformedEnumMissingTypedef)_;
 // CHECK-NEXT: - (enum ObjcEnumNamed)takeAndReturnRenamedEnum:(enum ObjcEnumNamed)foo;
+// CHECK-NEXT: - (void)acceptTopLevelImportedWithA:(enum TopLevelRaw)a b:(TopLevelEnum)b c:(TopLevelOptions)c d:(TopLevelTypedef)d e:(TopLevelAnon)e;
+// CHECK-NEXT: - (void)acceptMemberImportedWithA:(enum MemberRaw)a b:(enum MemberEnum)b c:(MemberOptions)c d:(enum MemberTypedef)d e:(MemberAnon)e ee:(MemberAnon2)ee;
 // CHECK: @end
 @objc class AnEnumMethod {
   @objc func takeAndReturnEnum(_ foo: FooComments) -> NegativeValues {
@@ -30,6 +32,9 @@ import Foundation
   @objc func takeAndReturnRenamedEnum(_ foo: EnumNamed) -> EnumNamed {
     return .A
   }
+
+  @objc func acceptTopLevelImported(a: TopLevelRaw, b: TopLevelEnum, c: TopLevelOptions, d: TopLevelTypedef, e: TopLevelAnon) {}
+  @objc func acceptMemberImported(a: Wrapper.Raw, b: Wrapper.Enum, c: Wrapper.Options, d: Wrapper.Typedef, e: Wrapper.Anon, ee: Wrapper.Anon2) {}
 }
 
 // CHECK-LABEL: typedef SWIFT_ENUM_NAMED(NSInteger, ObjcEnumNamed, "EnumNamed") {


### PR DESCRIPTION
- **Explanation:** PrintAsObjC isn't emitting the correct use of NS_OPTIONS enums that are imported as members because it doesn't think they have same-name typedefs. Hack around this for now by assuming all option-set enums have typedefs. This won't be correct in the long term but it is for now.
- **Scope:** Any NS_OPTIONS types that are imported as member types and used then in Swift in `@objc` members that get printed in the generated header. (There's no workaround besides `@nonobjc` or passing the raw value.)
- **Issue:** rdar://problem/27130343
- **Reviewed by:** @milseman
- **Risk:** Low.
- **Testing:** Added a compiler regression test for all sorts of enums imported as members, and retested the original case reported in the Radar (Foundation's `Stream.Event`).

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
