### PR TITLE
[NSError bridging] Extract embedded NSError from an Error consistently.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -364,7 +364,7 @@ public:
                                         PrecedenceGroupDecl *right) const;
 
   /// Retrieve the declaration of Swift.Error.
-  NominalTypeDecl *getErrorDecl() const;
+  ProtocolDecl *getErrorDecl() const;
   CanType getExceptionType() const;
   
   /// Retrieve the declaration of Swift.Bool.

--- a/include/swift/AST/KnownDecls.def
+++ b/include/swift/AST/KnownDecls.def
@@ -71,4 +71,6 @@ FUNC_DECL(BridgeAnythingToObjectiveC,
 FUNC_DECL(DidEnterMain, "_stdlib_didEnterMain")
 FUNC_DECL(DiagnoseUnexpectedNilOptional, "_diagnoseUnexpectedNilOptional")
 
+FUNC_DECL(GetErrorEmbeddedNSErrorValue, "_stdlib_getErrorEmbeddedNSErrorValue")
+
 #undef FUNC_DECL

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -612,7 +612,7 @@ CanType ASTContext::getExceptionType() const {
   }
 }
 
-NominalTypeDecl *ASTContext::getErrorDecl() const {
+ProtocolDecl *ASTContext::getErrorDecl() const {
   return getProtocol(KnownProtocolKind::Error);
 }
 

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -946,7 +946,8 @@ public:
                             const TypeLowering &existentialTL,
                             ArrayRef<ProtocolConformanceRef> conformances,
                             SGFContext C,
-                            llvm::function_ref<ManagedValue (SGFContext)> F);
+                            llvm::function_ref<ManagedValue (SGFContext)> F,
+                            bool allowEmbeddedNSError = true);
 
   //===--------------------------------------------------------------------===//
   // Recursive entry points

--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -241,6 +241,11 @@ extension NSError : Error {
   public var _domain: String { return domain }
   public var _code: Int { return code }
   public var _userInfo: Any? { return userInfo }
+
+  /// The "embedded" NSError is itself.
+  public func _getEmbeddedNSError() -> AnyObject? {
+    return self
+  }
 }
 
 extension CFError : Error {
@@ -254,6 +259,11 @@ extension CFError : Error {
 
   public var _userInfo: Any? {
     return CFErrorCopyUserInfo(self) as Any
+  }
+
+  /// The "embedded" NSError is itself.
+  public func _getEmbeddedNSError() -> AnyObject? {
+    return self
   }
 }
 

--- a/stdlib/public/core/ErrorType.swift
+++ b/stdlib/public/core/ErrorType.swift
@@ -155,6 +155,13 @@ public func _stdlib_getErrorEmbeddedNSError<T : Error>(_ x: UnsafePointer<T>)
   return x.pointee._getEmbeddedNSError()
 }
 
+/// FIXME: Quite unfortunate to have both of these.
+@_silgen_name("swift_stdlib_getErrorEmbeddedNSErrorValue")
+public func _stdlib_getErrorEmbeddedNSErrorValue<T : Error>(_ x: T)
+-> AnyObject? {
+  return x._getEmbeddedNSError()
+}
+
 @_silgen_name("swift_stdlib_getErrorDefaultUserInfo")
 public func _stdlib_getErrorDefaultUserInfo(_ error: Error) -> AnyObject?
 

--- a/test/1_stdlib/ErrorBridged.swift
+++ b/test/1_stdlib/ErrorBridged.swift
@@ -627,4 +627,17 @@ ErrorBridgingTests.test("Wrapped NSError identity") {
   }
 }
 
+extension Error {
+	func asNSError() -> NSError {
+		return self as NSError
+	}
+}
+
+// SR-1562
+ErrorBridgingTests.test("Error archetype identity") {
+  let myError = NSError(domain: "myErrorDomain", code: 0,
+                        userInfo: [ AnyHashable("one") : 1 ])
+  expectTrue(myError === myError.asNSError())
+}
+
 runAllTests()

--- a/test/SILGen/objc_error.swift
+++ b/test/SILGen/objc_error.swift
@@ -118,3 +118,30 @@ func eraseFictionalServerError() -> Error {
   // CHECK: return [[ERROR]]
   return FictionalServerError(.meltedDown)
 }
+
+// SR-1562
+extension Error {
+  // CHECK-LABEL: sil hidden @_TFE10objc_errorPs5Error16convertToNSErrorfT_CSo7NSError
+  // CHECK: bb0([[SELF:%[0-9]+]] : $*Self)
+	func convertToNSError() -> NSError {
+    // CHECK: [[GET_EMBEDDED_FN:%[0-9]+]] = function_ref @swift_stdlib_getErrorEmbeddedNSErrorValue 
+    // CHECK: [[EMBEDDED_RESULT_OPT:%[0-9]+]] = apply [[GET_EMBEDDED_FN]]
+    // CHECK: [[HAS_EMBEDDED_RESULT:%[0-9]+]] = select_enum [[EMBEDDED_RESULT_OPT]] : $Optional<AnyObject>
+    // CHECK: cond_br [[HAS_EMBEDDED_RESULT]], [[SUCCESS:bb[0-9]+]], [[FAILURE:bb[0-9]+]]
+
+    // CHECK: [[SUCCESS]]:
+    // CHECK: [[EMBEDDED_RESULT:%[0-9]+]] = unchecked_enum_data [[EMBEDDED_RESULT_OPT]] : $Optional<AnyObject>, #Optional.some!enumelt.1
+    // CHECK: [[EMBEDDED_NSERROR:%[0-9]+]] = unchecked_ref_cast [[EMBEDDED_RESULT]] : $AnyObject to $NSError
+    // CHECK: [[ERROR:%[0-9]+]] = init_existential_ref [[EMBEDDED_NSERROR]] : $NSError : $NSError, $Error
+    // CHECK: br [[CONTINUATION:bb[0-9]+]]([[ERROR]] : $Error)
+
+    // CHECK: [[FAILURE]]:
+    // CHECK: [[ERROR_BOX:%[0-9]+]] = alloc_existential_box $Error, $Self
+    // CHECK: [[ERROR_PROJECTED:%[0-9]+]] = project_existential_box $Self in [[ERROR_BOX]] : $Error
+    // CHECK: copy_addr [[SELF]] to [initialization] [[ERROR_PROJECTED]] : $*Self
+    // CHECK: br [[CONTINUATION]]([[ERROR_BOX]] : $Error)
+
+    // CHECK: [[CONTINUATION]]([[ERROR_ARG:%[0-9]+]] : $Error):
+		return self as NSError
+	}
+}


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Fix SR-1562 by consistently extracting an embedded NSError from an Error type or existential.
#### Resolved bug number: ([SR-1562](https://bugs.swift.org/browse/SR-1562))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

When emitting an existential erasure to Error from an archetype, use
the _getEmbeddedNSError() witness. If it produces an NSError, erase
that; otherwise, go through the normal erasure path.

Of course, make NSError and CFError implement _getEmbeddedNSError() so
this kicks in for the obvious cases as well as the more obscure ones.

Fixes the rest of SR-1562 / rdar://problem/26370984.
