### PR TITLE
[swift-3.0-branch] Fix Dispatch API's handling of block parameters

### DIFF
--- a/stdlib/public/SDK/Dispatch/Dispatch.swift
+++ b/stdlib/public/SDK/Dispatch/Dispatch.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 @_exported import Dispatch
+import SwiftShims
 
 /// dispatch_assert
 
@@ -132,15 +133,15 @@ public extension DispatchGroup {
 	public func notify(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], queue: DispatchQueue, execute work: @escaping @convention(block) () -> ()) {
 		if #available(OSX 10.10, iOS 8.0, *), qos != .unspecified || !flags.isEmpty {
 			let item = DispatchWorkItem(qos: qos, flags: flags, block: work)
-			__dispatch_group_notify(self, queue, item._block)
+			_swift_dispatch_group_notify(self, queue, item._block)
 		} else {
-			__dispatch_group_notify(self, queue, work)
+			_swift_dispatch_group_notify(self, queue, work)
 		}
 	}
 
 	@available(OSX 10.10, iOS 8.0, *)
 	public func notify(queue: DispatchQueue, work: DispatchWorkItem) {
-		__dispatch_group_notify(self, queue, work._block)
+		_swift_dispatch_group_notify(self, queue, work._block)
 	}
 
 	public func wait() {

--- a/stdlib/public/SDK/Dispatch/Queue.swift
+++ b/stdlib/public/SDK/Dispatch/Queue.swift
@@ -200,10 +200,10 @@ public extension DispatchQueue {
 		if group == nil && qos == .unspecified {
 			// Fast-path route for the most common API usage
 			if flags.isEmpty {
-				__dispatch_async(self, work)
+				_swift_dispatch_async(self, work)
 				return
 			} else if flags == .barrier {
-				__dispatch_barrier_async(self, work)
+				_swift_dispatch_barrier_async(self, work)
 				return
 			}
 		}
@@ -215,9 +215,9 @@ public extension DispatchQueue {
 		}
 
 		if let g = group {
-			__dispatch_group_async(g, self, block)
+			_swift_dispatch_group_async(g, self, block)
 		} else {
-			__dispatch_async(self, block)
+			_swift_dispatch_async(self, block)
 		}
 	}
 
@@ -292,9 +292,9 @@ public extension DispatchQueue {
 	{
 		if #available(OSX 10.10, iOS 8.0, *), qos != .unspecified || !flags.isEmpty {
 			let item = DispatchWorkItem(qos: qos, flags: flags, block: work)
-			__dispatch_after(deadline.rawValue, self, item._block)
+			_swift_dispatch_after(deadline.rawValue, self, item._block)
 		} else {
-			__dispatch_after(deadline.rawValue, self, work)
+			_swift_dispatch_after(deadline.rawValue, self, work)
 		}
 	}
 
@@ -306,20 +306,20 @@ public extension DispatchQueue {
 	{
 		if #available(OSX 10.10, iOS 8.0, *), qos != .unspecified || !flags.isEmpty {
 			let item = DispatchWorkItem(qos: qos, flags: flags, block: work)
-			__dispatch_after(wallDeadline.rawValue, self, item._block)
+			_swift_dispatch_after(wallDeadline.rawValue, self, item._block)
 		} else {
-			__dispatch_after(wallDeadline.rawValue, self, work)
+			_swift_dispatch_after(wallDeadline.rawValue, self, work)
 		}
 	}
 
 	@available(OSX 10.10, iOS 8.0, *)
 	public func asyncAfter(deadline: DispatchTime, execute: DispatchWorkItem) {
-		__dispatch_after(deadline.rawValue, self, execute._block)
+		_swift_dispatch_after(deadline.rawValue, self, execute._block)
 	}
 
 	@available(OSX 10.10, iOS 8.0, *)
 	public func asyncAfter(wallDeadline: DispatchWallTime, execute: DispatchWorkItem) {
-		__dispatch_after(wallDeadline.rawValue, self, execute._block)
+		_swift_dispatch_after(wallDeadline.rawValue, self, execute._block)
 	}
 
 	@available(OSX 10.10, iOS 8.0, *)

--- a/stdlib/public/SDK/Dispatch/Queue.swift
+++ b/stdlib/public/SDK/Dispatch/Queue.swift
@@ -197,10 +197,15 @@ public extension DispatchQueue {
 		flags: DispatchWorkItemFlags = [], 
 		execute work: @escaping @convention(block) () -> Void) 
 	{
-		if group == nil && qos == .unspecified && flags.isEmpty {
+		if group == nil && qos == .unspecified {
 			// Fast-path route for the most common API usage
-			__dispatch_async(self, work)
-			return
+			if flags.isEmpty {
+				__dispatch_async(self, work)
+				return
+			} else if flags == .barrier {
+				__dispatch_barrier_async(self, work)
+				return
+			}
 		}
 
 		var block: @convention(block) () -> Void = work

--- a/stdlib/public/SDK/Dispatch/Source.swift
+++ b/stdlib/public/SDK/Dispatch/Source.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 // import Foundation
+import SwiftShims
 
 public extension DispatchSourceProtocol {
 	typealias DispatchSourceHandler = @convention(block) () -> Void
@@ -20,15 +21,15 @@ public extension DispatchSourceProtocol {
                    let h = handler,
                    qos != .unspecified || !flags.isEmpty {
 			let item = DispatchWorkItem(qos: qos, flags: flags, block: h)
-			__dispatch_source_set_event_handler(self as! DispatchSource, item._block)
+			_swift_dispatch_source_set_event_handler(self as! DispatchSource, item._block)
 		} else {
-			__dispatch_source_set_event_handler(self as! DispatchSource, handler)
+			_swift_dispatch_source_set_event_handler(self as! DispatchSource, handler)
 		}
 	}
 
 	@available(OSX 10.10, iOS 8.0, *)
 	public func setEventHandler(handler: DispatchWorkItem) {
-		__dispatch_source_set_event_handler(self as! DispatchSource, handler._block)
+		_swift_dispatch_source_set_event_handler(self as! DispatchSource, handler._block)
 	}
 
 	public func setCancelHandler(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], handler: DispatchSourceHandler?) {
@@ -36,15 +37,15 @@ public extension DispatchSourceProtocol {
                    let h = handler,
                    qos != .unspecified || !flags.isEmpty {
 			let item = DispatchWorkItem(qos: qos, flags: flags, block: h)
-			__dispatch_source_set_cancel_handler(self as! DispatchSource, item._block)
+			_swift_dispatch_source_set_cancel_handler(self as! DispatchSource, item._block)
 		} else {
-			__dispatch_source_set_cancel_handler(self as! DispatchSource, handler)
+			_swift_dispatch_source_set_cancel_handler(self as! DispatchSource, handler)
 		}
 	}
 
 	@available(OSX 10.10, iOS 8.0, *)
 	public func setCancelHandler(handler: DispatchWorkItem) {
-		__dispatch_source_set_cancel_handler(self as! DispatchSource, handler._block)
+		_swift_dispatch_source_set_cancel_handler(self as! DispatchSource, handler._block)
 	}
 
 	public func setRegistrationHandler(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], handler: DispatchSourceHandler?) {
@@ -52,15 +53,15 @@ public extension DispatchSourceProtocol {
                    let h = handler,
                    qos != .unspecified || !flags.isEmpty {
 			let item = DispatchWorkItem(qos: qos, flags: flags, block: h)
-			__dispatch_source_set_registration_handler(self as! DispatchSource, item._block)
+			_swift_dispatch_source_set_registration_handler(self as! DispatchSource, item._block)
 		} else {
-			__dispatch_source_set_registration_handler(self as! DispatchSource, handler)
+			_swift_dispatch_source_set_registration_handler(self as! DispatchSource, handler)
 		}
 	}
 
 	@available(OSX 10.10, iOS 8.0, *)
 	public func setRegistrationHandler(handler: DispatchWorkItem) {
-		__dispatch_source_set_registration_handler(self as! DispatchSource, handler._block)
+		_swift_dispatch_source_set_registration_handler(self as! DispatchSource, handler._block)
 	}
 
 	@available(OSX 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)

--- a/stdlib/public/SDK/Dispatch/Time.swift
+++ b/stdlib/public/SDK/Dispatch/Time.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftShims
+
 public struct DispatchTime : Comparable {
 	public let rawValue: dispatch_time_t
 

--- a/stdlib/public/SwiftShims/DispatchShims.h
+++ b/stdlib/public/SwiftShims/DispatchShims.h
@@ -40,10 +40,12 @@ namespace swift { extern "C" {
 
 typedef unsigned long __swift_shims_dispatch_block_flags_t;
 typedef unsigned int __swift_shims_qos_class_t;
+typedef __swift_uint64_t __swift_shims_dispatch_time_t;
 typedef void (^__swift_shims_dispatch_block_t)(void);
 typedef id __swift_shims_dispatch_queue_t;
 typedef id __swift_shims_dispatch_group_t;
 typedef id __swift_shims_dispatch_data_t;
+typedef id __swift_shims_dispatch_source_t;
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
 SWIFT_DISPATCH_RETURNS_RETAINED
@@ -91,8 +93,25 @@ void _swift_dispatch_sync(
 		__swift_shims_dispatch_block_t block);
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
+void _swift_dispatch_barrier_async(
+		__swift_shims_dispatch_queue_t queue,
+		__swift_shims_dispatch_block_t block);
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
 void _swift_dispatch_group_async(
 		__swift_shims_dispatch_group_t group,
+		__swift_shims_dispatch_queue_t queue,
+		__swift_shims_dispatch_block_t block);
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+void _swift_dispatch_group_notify(
+		__swift_shims_dispatch_group_t group,
+		__swift_shims_dispatch_queue_t queue,
+		__swift_shims_dispatch_block_t block);
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+void _swift_dispatch_after(
+		__swift_shims_dispatch_time_t when,
 		__swift_shims_dispatch_queue_t queue,
 		__swift_shims_dispatch_block_t block);
 
@@ -117,6 +136,21 @@ unsigned int
 _swift_dispatch_data_apply(
 		__swift_shims_dispatch_data_t data, 
 		__swift_shims_dispatch_data_applier SWIFT_DISPATCH_NOESCAPE applier);
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+void _swift_dispatch_source_set_event_handler(
+		__swift_shims_dispatch_source_t source,
+		__swift_shims_dispatch_block_t SWIFT_DISPATCH_NULLABLE block);
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+void _swift_dispatch_source_set_cancel_handler(
+		__swift_shims_dispatch_source_t source,
+		__swift_shims_dispatch_block_t SWIFT_DISPATCH_NULLABLE block);
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+void _swift_dispatch_source_set_registration_handler(
+		__swift_shims_dispatch_source_t source,
+		__swift_shims_dispatch_block_t SWIFT_DISPATCH_NULLABLE block);
 
 #ifdef __cplusplus
 }} // extern "C", namespace swift

--- a/stdlib/public/stubs/DispatchShims.mm
+++ b/stdlib/public/stubs/DispatchShims.mm
@@ -95,6 +95,14 @@ swift::_swift_dispatch_async(
 }
 
 void
+swift::_swift_dispatch_barrier_async(
+	      __swift_shims_dispatch_queue_t queue,
+	      __swift_shims_dispatch_block_t block)
+{
+	dispatch_barrier_async(cast(queue), cast(block));
+}
+
+void
 swift::_swift_dispatch_group_async(
 	__swift_shims_dispatch_group_t group,
 	__swift_shims_dispatch_queue_t queue,
@@ -104,11 +112,29 @@ swift::_swift_dispatch_group_async(
 }
 
 void
+swift::_swift_dispatch_group_notify(
+	__swift_shims_dispatch_group_t group,
+	__swift_shims_dispatch_queue_t queue,
+	__swift_shims_dispatch_block_t block)
+{
+	dispatch_group_notify((dispatch_group_t)group, cast(queue), cast(block));
+}
+
+void
 swift::_swift_dispatch_sync(
 	__swift_shims_dispatch_queue_t queue,
 	__swift_shims_dispatch_block_t block)
 {
 	dispatch_sync(cast(queue), cast(block));
+}
+
+void
+swift::_swift_dispatch_after(
+	__swift_shims_dispatch_time_t when,
+	__swift_shims_dispatch_queue_t queue,
+	__swift_shims_dispatch_block_t block)
+{
+	dispatch_after((dispatch_time_t)when, cast(queue), cast(block));
 }
 
 void
@@ -139,4 +165,28 @@ swift::_swift_dispatch_data_apply(
 	return dispatch_data_apply(data, ^bool(dispatch_data_t data, size_t off, const void *loc, size_t size){
 		return applier(data, off, loc, size);
 	});
+}
+
+void
+swift::_swift_dispatch_source_set_event_handler(
+	__swift_shims_dispatch_source_t source,
+	__swift_shims_dispatch_block_t block)
+{
+	dispatch_source_set_event_handler((dispatch_source_t)source, cast(block));
+}
+
+void
+swift::_swift_dispatch_source_set_cancel_handler(
+	__swift_shims_dispatch_source_t source,
+	__swift_shims_dispatch_block_t block)
+{
+	dispatch_source_set_cancel_handler((dispatch_source_t)source, cast(block));
+}
+
+void
+swift::_swift_dispatch_source_set_registration_handler(
+	__swift_shims_dispatch_source_t source,
+	__swift_shims_dispatch_block_t block)
+{
+	dispatch_source_set_registration_handler((dispatch_source_t)source, cast(block));
 }


### PR DESCRIPTION
This is a cherry-pick of #3923.

Reviewed by: @mwwa.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
