### PR TITLE
This test is known to fail on a debug stdlib

### DIFF
--- a/test/1_stdlib/Dispatch.swift
+++ b/test/1_stdlib/Dispatch.swift
@@ -3,6 +3,9 @@
 
 // REQUIRES: objc_interop
 
+// rdar://27226313
+// REQUIRES: optimized_stdlib
+
 import Dispatch
 import Foundation
 import StdlibUnittest


### PR DESCRIPTION
rdar://27226313
(cherry picked from commit b5a8805b495e1f5004c9baa7b28fe837bbeb26dd)
