### PR TITLE
[FixCode] Help users construct mutable pointer from a pointer

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -204,6 +204,8 @@ ERROR(cannot_call_with_params, none,
       "cannot invoke %select{|initializer for type }2'%0' with an argument list"
       " of type '%1'", (StringRef, StringRef, bool))
 
+NOTE(pointer_init_add_mutating,none,
+     "do you want to add 'mutating'", ())
 ERROR(expected_do_in_statement,none,
       "expected 'do' keyword to designate a block of statements", ())
 

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4824,6 +4824,25 @@ bool FailureDiagnosis::diagnoseNilLiteralComparison(
   return true;
 }
 
+static bool shouldAddMutating(ASTContext &Ctx, const Expr *Fn,
+                              const Expr* Arg) {
+  auto *TypeExp = dyn_cast<TypeExpr>(Fn);
+  auto *ParenExp = dyn_cast<ParenExpr>(Arg);
+  if (!TypeExp || !ParenExp)
+    return false;
+  auto InitType = TypeExp->getInstanceType();
+  auto ArgType = ParenExp->getSubExpr()->getType();
+  if (InitType.isNull() || ArgType.isNull())
+    return false;
+  if (auto *InitNom = InitType->getAnyNominal()) {
+    if (auto *ArgNom = ArgType->getAnyNominal()) {
+      return InitNom == Ctx.getUnsafeMutablePointerDecl() &&
+        ArgNom == Ctx.getUnsafePointerDecl();
+    }
+  }
+  return false;
+}
+
 bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
   // Type check the function subexpression to resolve a type for it if possible.
   auto fnExpr = typeCheckChildIndependently(callExpr->getFn());
@@ -5137,6 +5156,12 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
   } else {
     diagnose(fnExpr->getLoc(), diag::cannot_call_with_params,
              overloadName, argString, isInitializer);
+  }
+
+
+  if (shouldAddMutating(CS->DC->getASTContext(), fnExpr, argExpr)) {
+    diagnose(fnExpr->getLoc(), diag::pointer_init_add_mutating).fixItInsert(
+      dyn_cast<ParenExpr>(argExpr)->getSubExpr()->getStartLoc(), "mutating: ");
   }
   
   // Did the user intend on invoking a different overload?

--- a/test/Sema/diag_init.swift
+++ b/test/Sema/diag_init.swift
@@ -1,0 +1,5 @@
+// RUN: %target-parse-verify-swift
+
+func foo(a :  UnsafePointer<Void>)->UnsafeMutablePointer<Void> {
+  return UnsafeMutablePointer(a) // expected-error {{cannot invoke initializer for type 'UnsafeMutablePointer<_>' with an argument list of type '(UnsafePointer<Void>)'}} // expected-note {{do you want to add 'mutating'}}{{31-31=mutating: }} // expected-note {{overloads for 'UnsafeMutablePointer<_>' exist with these partially matching parameter lists: (RawPointer), (OpaquePointer), (OpaquePointer?), (UnsafeMutablePointer<Pointee>), (UnsafeMutablePointer<Pointee>?)}}
+}


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->

This is a migration-critical fixit that helps users to construct UnsafeMutablePointer from UnsafePointer.

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…rting 'mutating'. rdar://27500578
