### PR TITLE
[Swift 3.0] Eliminate double-wrapping of NSErrors in _SwiftNativeNSError

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -364,7 +364,7 @@ public:
                                         PrecedenceGroupDecl *right) const;
 
   /// Retrieve the declaration of Swift.Error.
-  NominalTypeDecl *getErrorDecl() const;
+  ProtocolDecl *getErrorDecl() const;
   CanType getExceptionType() const;
   
   /// Retrieve the declaration of Swift.Bool.

--- a/include/swift/AST/KnownDecls.def
+++ b/include/swift/AST/KnownDecls.def
@@ -71,6 +71,6 @@ FUNC_DECL(BridgeAnythingToObjectiveC,
 FUNC_DECL(DidEnterMain, "_stdlib_didEnterMain")
 FUNC_DECL(DiagnoseUnexpectedNilOptional, "_diagnoseUnexpectedNilOptional")
 
-FUNC_DECL(GetErrorEmbeddedNSErrorValue, "_stdlib_getErrorEmbeddedNSErrorValue")
+FUNC_DECL(GetErrorEmbeddedNSError, "_stdlib_getErrorEmbeddedNSError")
 
 #undef FUNC_DECL

--- a/include/swift/AST/KnownDecls.def
+++ b/include/swift/AST/KnownDecls.def
@@ -71,4 +71,6 @@ FUNC_DECL(BridgeAnythingToObjectiveC,
 FUNC_DECL(DidEnterMain, "_stdlib_didEnterMain")
 FUNC_DECL(DiagnoseUnexpectedNilOptional, "_diagnoseUnexpectedNilOptional")
 
+FUNC_DECL(GetErrorEmbeddedNSErrorValue, "_stdlib_getErrorEmbeddedNSErrorValue")
+
 #undef FUNC_DECL

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -612,7 +612,7 @@ CanType ASTContext::getExceptionType() const {
   }
 }
 
-NominalTypeDecl *ASTContext::getErrorDecl() const {
+ProtocolDecl *ASTContext::getErrorDecl() const {
   return getProtocol(KnownProtocolKind::Error);
 }
 

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -465,8 +465,8 @@ static bool isBridgedErrorClass(SILModule &M,
     t = archetypeType->getSuperclass();
 
   // NSError (TODO: and CFError) can be bridged.
-  auto errorType = M.Types.getNSErrorType();
-  if (t && errorType && t->isEqual(errorType)) {
+  auto nsErrorType = M.Types.getNSErrorType();
+  if (t && nsErrorType && nsErrorType->isExactSuperclassOf(t, nullptr)) {
     return true;
   }
   

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -129,6 +129,11 @@ public:
   Optional<FuncDecl*> UnconditionallyBridgeFromObjectiveCRequirement;
   Optional<AssociatedTypeDecl*> BridgedObjectiveCType;
 
+  Optional<ProtocolDecl*> BridgedStoredNSError;
+  Optional<VarDecl*> NSErrorRequirement;
+
+  Optional<ProtocolConformance *> NSErrorConformanceToError;
+
 public:
   SILGenModule(SILModule &M, Module *SM, bool makeModuleFragile);
   ~SILGenModule();
@@ -376,6 +381,20 @@ public:
   /// _ObjectiveCBridgeable protocol.
   ProtocolConformance *getConformanceToObjectiveCBridgeable(SILLocation loc,
                                                             Type type);
+
+  /// Retrieve the _BridgedStoredNSError protocol definition.
+  ProtocolDecl *getBridgedStoredNSError(SILLocation loc);
+
+  /// Retrieve the _BridgedStoredNSError._nsError requirement.
+  VarDecl *getNSErrorRequirement(SILLocation loc);
+
+  /// Find the conformance of the given Swift type to the
+  /// _BridgedStoredNSError protocol.
+  ProtocolConformance *getConformanceToBridgedStoredNSError(SILLocation loc,
+                                                            Type type);
+
+  /// Retrieve the conformance of NSError to the Error protocol.
+  ProtocolConformance *getNSErrorConformanceToError();
 
   /// Report a diagnostic.
   template<typename...T, typename...U>

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -539,7 +539,7 @@ ManagedValue SILGenFunction::emitExistentialErasure(
         ManagedValue concreteValue = F(SGFContext());
         ManagedValue potentialNSError =
           emitApplyOfLibraryIntrinsic(loc,
-                                      SGM.getGetErrorEmbeddedNSErrorValue(loc),
+                                      SGM.getGetErrorEmbeddedNSError(loc),
                                       ctx.AllocateCopy(substitutions),
                                       { concreteValue },
                                       SGFContext())

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -944,7 +944,8 @@ public:
                             const TypeLowering &existentialTL,
                             ArrayRef<ProtocolConformanceRef> conformances,
                             SGFContext C,
-                            llvm::function_ref<ManagedValue (SGFContext)> F);
+                            llvm::function_ref<ManagedValue (SGFContext)> F,
+                            bool allowEmbeddedNSError = true);
 
   //===--------------------------------------------------------------------===//
   // Recursive entry points

--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -241,6 +241,11 @@ extension NSError : Error {
   public var _domain: String { return domain }
   public var _code: Int { return code }
   public var _userInfo: Any? { return userInfo }
+
+  /// The "embedded" NSError is itself.
+  public func _getEmbeddedNSError() -> AnyObject? {
+    return self
+  }
 }
 
 extension CFError : Error {
@@ -254,6 +259,11 @@ extension CFError : Error {
 
   public var _userInfo: Any? {
     return CFErrorCopyUserInfo(self) as Any
+  }
+
+  /// The "embedded" NSError is itself.
+  public func _getEmbeddedNSError() -> AnyObject? {
+    return self
   }
 }
 

--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -496,6 +496,11 @@ extension _ErrorCodeProtocol where Self._ErrorType: _BridgedStoredNSError {
 }
 
 extension _BridgedStoredNSError {
+  /// Retrieve the embedded NSError from a bridged, stored NSError.
+  public func _getEmbeddedNSError() -> AnyObject? {
+    return _nsError
+  }
+
   public static func == (lhs: Self, rhs: Self) -> Bool {
     return lhs._nsError.isEqual(rhs._nsError)
   }

--- a/stdlib/public/core/ErrorType.swift
+++ b/stdlib/public/core/ErrorType.swift
@@ -149,15 +149,15 @@ public func _stdlib_getErrorUserInfoNSDictionary<T : Error>(_ x: UnsafePointer<T
   return x.pointee._userInfo.map { $0 as AnyObject }
 }
 
-@_silgen_name("swift_stdlib_getErrorEmbeddedNSError")
-public func _stdlib_getErrorEmbeddedNSError<T : Error>(_ x: UnsafePointer<T>)
--> AnyObject? {
+@_silgen_name("swift_stdlib_getErrorEmbeddedNSErrorIndirect")
+public func _stdlib_getErrorEmbeddedNSErrorIndirect<T : Error>(
+    _ x: UnsafePointer<T>) -> AnyObject? {
   return x.pointee._getEmbeddedNSError()
 }
 
 /// FIXME: Quite unfortunate to have both of these.
-@_silgen_name("swift_stdlib_getErrorEmbeddedNSErrorValue")
-public func _stdlib_getErrorEmbeddedNSErrorValue<T : Error>(_ x: T)
+@_silgen_name("swift_stdlib_getErrorEmbeddedNSError")
+public func _stdlib_getErrorEmbeddedNSError<T : Error>(_ x: T)
 -> AnyObject? {
   return x._getEmbeddedNSError()
 }

--- a/stdlib/public/core/ErrorType.swift
+++ b/stdlib/public/core/ErrorType.swift
@@ -155,6 +155,13 @@ public func _stdlib_getErrorEmbeddedNSError<T : Error>(_ x: UnsafePointer<T>)
   return x.pointee._getEmbeddedNSError()
 }
 
+/// FIXME: Quite unfortunate to have both of these.
+@_silgen_name("swift_stdlib_getErrorEmbeddedNSErrorValue")
+public func _stdlib_getErrorEmbeddedNSErrorValue<T : Error>(_ x: T)
+-> AnyObject? {
+  return x._getEmbeddedNSError()
+}
+
 @_silgen_name("swift_stdlib_getErrorDefaultUserInfo")
 public func _stdlib_getErrorDefaultUserInfo(_ error: Error) -> AnyObject?
 

--- a/stdlib/public/core/ErrorType.swift
+++ b/stdlib/public/core/ErrorType.swift
@@ -114,11 +114,22 @@ public protocol Error {
   var _domain: String { get }
   var _code: Int { get }
   var _userInfo: Any? { get }
+
+#if _runtime(_ObjC)
+  func _getEmbeddedNSError() -> AnyObject?
+#endif
 }
 
 #if _runtime(_ObjC)
-// Helper functions for the C++ runtime to have easy access to domain,
-// code, and userInfo as Objective-C values.
+extension Error {
+  /// Default implementation: there is no embedded NSError.
+  public func _getEmbeddedNSError() -> AnyObject? { return nil }
+}
+#endif
+
+#if _runtime(_ObjC)
+// Helper functions for the C++ runtime to have easy access to embedded error,
+// domain, code, and userInfo as Objective-C values.
 @_silgen_name("swift_stdlib_getErrorDomainNSString")
 public func _stdlib_getErrorDomainNSString<T : Error>(_ x: UnsafePointer<T>)
 -> AnyObject {
@@ -136,6 +147,12 @@ public func _stdlib_getErrorCode<T : Error>(_ x: UnsafePointer<T>) -> Int {
 public func _stdlib_getErrorUserInfoNSDictionary<T : Error>(_ x: UnsafePointer<T>)
 -> AnyObject? {
   return x.pointee._userInfo.map { $0 as AnyObject }
+}
+
+@_silgen_name("swift_stdlib_getErrorEmbeddedNSError")
+public func _stdlib_getErrorEmbeddedNSError<T : Error>(_ x: UnsafePointer<T>)
+-> AnyObject? {
+  return x.pointee._getEmbeddedNSError()
 }
 
 @_silgen_name("swift_stdlib_getErrorDefaultUserInfo")

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -2006,21 +2006,23 @@ static bool _dynamicCastToFunction(OpaqueValue *dest,
 }
 
 #if SWIFT_OBJC_INTEROP
-// @_silgen_name("swift_stdlib_getErrorEmbeddedNSError")
-// public func _stdlib_getErrorEmbeddedNSError<T : Error>(_ x: UnsafePointer<T>)
-//   -> AnyObject?
+// @_silgen_name("swift_stdlib_getErrorEmbeddedNSErrorIndirect")
+// public func _stdlib_getErrorEmbeddedNSErrorIndirect<T : Error>(
+///    _ x: UnsafePointer<T>) -> AnyObject?
 SWIFT_CC(swift)
-extern "C" id swift_stdlib_getErrorEmbeddedNSError(const OpaqueValue *error,
-                                                   const Metadata *T,
-                                                   const WitnessTable *Error);
+extern "C" id swift_stdlib_getErrorEmbeddedNSErrorIndirect(
+                const OpaqueValue *error,
+                const Metadata *T,
+                const WitnessTable *Error);
 
 static id dynamicCastValueToNSError(OpaqueValue *src,
                                     const Metadata *srcType,
                                     const WitnessTable *srcErrorWitness,
                                     DynamicCastFlags flags) {
   // Check whether there is an embedded error.
-  if (auto embedded = swift_stdlib_getErrorEmbeddedNSError(src, srcType,
-                                                           srcErrorWitness)) {
+  if (auto embedded =
+          swift_stdlib_getErrorEmbeddedNSErrorIndirect(src, srcType,
+                                                       srcErrorWitness)) {
     if (flags & DynamicCastFlags::TakeOnSuccess)
       srcType->vw_destroy(src);
 

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -872,6 +872,16 @@ swift_dynamicCastMetatypeToObjectUnconditional(const Metadata *metatype) {
   }
   }
 }
+
+// @_silgen_name("swift_stdlib_getErrorEmbeddedNSErrorIndirect")
+// public func _stdlib_getErrorEmbeddedNSErrorIndirect<T : Error>(
+///    _ x: UnsafePointer<T>) -> AnyObject?
+SWIFT_CC(swift)
+extern "C" id swift_stdlib_getErrorEmbeddedNSErrorIndirect(
+                const OpaqueValue *error,
+                const Metadata *T,
+                const WitnessTable *Error);
+
 #endif
 
 /// Perform a dynamic cast to an existential type.
@@ -1040,7 +1050,20 @@ static bool _dynamicCastToExistential(OpaqueValue *dest,
                               targetType->Protocols,
                               &errorWitness))
       return _fail(src, srcType, targetType, flags, srcDynamicType);
-    
+
+#if SWIFT_OBJC_INTEROP
+    // Check whether there is an embedded NSError. If so, use that for our Error
+    // representation.
+    if (auto embedded =
+          swift_stdlib_getErrorEmbeddedNSErrorIndirect(srcDynamicValue,
+                                                       srcDynamicType,
+                                                       errorWitness)) {
+      *destBoxAddr = reinterpret_cast<SwiftError*>(embedded);
+      maybeDeallocateSourceAfterSuccess();
+      return true;
+    }
+#endif
+
     BoxPair destBox = swift_allocError(srcDynamicType, errorWitness,
                                        srcDynamicValue,
                /*isTake*/ canTake && (flags & DynamicCastFlags::TakeOnSuccess));
@@ -2006,20 +2029,11 @@ static bool _dynamicCastToFunction(OpaqueValue *dest,
 }
 
 #if SWIFT_OBJC_INTEROP
-// @_silgen_name("swift_stdlib_getErrorEmbeddedNSErrorIndirect")
-// public func _stdlib_getErrorEmbeddedNSErrorIndirect<T : Error>(
-///    _ x: UnsafePointer<T>) -> AnyObject?
-SWIFT_CC(swift)
-extern "C" id swift_stdlib_getErrorEmbeddedNSErrorIndirect(
-                const OpaqueValue *error,
-                const Metadata *T,
-                const WitnessTable *Error);
-
 static id dynamicCastValueToNSError(OpaqueValue *src,
                                     const Metadata *srcType,
                                     const WitnessTable *srcErrorWitness,
                                     DynamicCastFlags flags) {
-  // Check whether there is an embedded error.
+  // Check whether there is an embedded NSError.
   if (auto embedded =
           swift_stdlib_getErrorEmbeddedNSErrorIndirect(src, srcType,
                                                        srcErrorWitness)) {

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -2006,14 +2006,32 @@ static bool _dynamicCastToFunction(OpaqueValue *dest,
 }
 
 #if SWIFT_OBJC_INTEROP
+// @_silgen_name("swift_stdlib_getErrorEmbeddedNSError")
+// public func _stdlib_getErrorEmbeddedNSError<T : Error>(_ x: UnsafePointer<T>)
+//   -> AnyObject?
+SWIFT_CC(swift)
+extern "C" id swift_stdlib_getErrorEmbeddedNSError(const OpaqueValue *error,
+                                                   const Metadata *T,
+                                                   const WitnessTable *Error);
+
 static id dynamicCastValueToNSError(OpaqueValue *src,
                                     const Metadata *srcType,
                                     const WitnessTable *srcErrorWitness,
                                     DynamicCastFlags flags) {
+  // Check whether there is an embedded error.
+  if (auto embedded = swift_stdlib_getErrorEmbeddedNSError(src, srcType,
+                                                           srcErrorWitness)) {
+    if (flags & DynamicCastFlags::TakeOnSuccess)
+      srcType->vw_destroy(src);
+
+    return embedded;
+  }
+
   BoxPair errorBox = swift_allocError(srcType, srcErrorWitness, src,
                             /*isTake*/ flags & DynamicCastFlags::TakeOnSuccess);
   return swift_bridgeErrorToNSError((SwiftError*)errorBox.first);
 }
+
 #endif
 
 namespace {

--- a/test/1_stdlib/ErrorBridged.swift
+++ b/test/1_stdlib/ErrorBridged.swift
@@ -627,4 +627,17 @@ ErrorBridgingTests.test("Wrapped NSError identity") {
   }
 }
 
+extension Error {
+	func asNSError() -> NSError {
+		return self as NSError
+	}
+}
+
+// SR-1562
+ErrorBridgingTests.test("Error archetype identity") {
+  let myError = NSError(domain: "myErrorDomain", code: 0,
+                        userInfo: [ AnyHashable("one") : 1 ])
+  expectTrue(myError === myError.asNSError())
+}
+
 runAllTests()

--- a/test/1_stdlib/ErrorBridged.swift
+++ b/test/1_stdlib/ErrorBridged.swift
@@ -582,4 +582,12 @@ ErrorBridgingTests.test("Customizing localization/recovery laziness") {
   }
 }
 
+class MyNSError : NSError {  }
+
+ErrorBridgingTests.test("NSError subclass identity") {
+  let myNSError: Error = MyNSError(domain: "MyNSError", code: 0, userInfo: [:])
+  let nsError = myNSError as NSError
+  expectTrue(type(of: nsError) == MyNSError.self)
+}
+
 runAllTests()

--- a/test/1_stdlib/ErrorBridged.swift
+++ b/test/1_stdlib/ErrorBridged.swift
@@ -590,4 +590,41 @@ ErrorBridgingTests.test("NSError subclass identity") {
   expectTrue(type(of: nsError) == MyNSError.self)
 }
 
+ErrorBridgingTests.test("Wrapped NSError identity") {
+  let nsError = NSError(domain: NSCocoaErrorDomain,
+                   code: NSFileNoSuchFileError,
+                   userInfo: [
+                     AnyHashable(NSFilePathErrorKey) : "/dev/null",
+                     AnyHashable(NSStringEncodingErrorKey): /*ASCII=*/1,
+                   ])
+
+  let error: Error = nsError
+  let nsError2: NSError = error as NSError
+  expectTrue(nsError === nsError2)
+
+  // Extracting the NSError via the runtime.
+  let cocoaErrorAny: Any = error as! CocoaError
+  let nsError3: NSError = cocoaErrorAny as! NSError
+  expectTrue(nsError === nsError3)
+
+  if let cocoaErrorAny2: Any = error as? CocoaError {
+    let nsError4: NSError = cocoaErrorAny2 as! NSError
+    expectTrue(nsError === nsError4)
+  } else {
+    expectUnreachable()
+  }
+
+  // Extracting the NSError via direct call.
+  let cocoaError = error as! CocoaError
+  let nsError5: NSError = cocoaError as NSError
+  expectTrue(nsError === nsError5)
+
+  if let cocoaError2 = error as? CocoaError {
+    let nsError6: NSError = cocoaError as NSError
+    expectTrue(nsError === nsError6)
+  } else {
+    expectUnreachable()
+  }
+}
+
 runAllTests()

--- a/test/1_stdlib/ErrorBridged.swift
+++ b/test/1_stdlib/ErrorBridged.swift
@@ -633,11 +633,24 @@ extension Error {
 	}
 }
 
+func unconditionalCast<T>(_ x: Any, to: T.Type) -> T {
+  return x as! T
+}
+
+func conditionalCast<T>(_ x: Any, to: T.Type) -> T? {
+  return x as? T
+}
+
 // SR-1562
 ErrorBridgingTests.test("Error archetype identity") {
   let myError = NSError(domain: "myErrorDomain", code: 0,
                         userInfo: [ AnyHashable("one") : 1 ])
   expectTrue(myError === myError.asNSError())
+
+  expectTrue(unconditionalCast(myError, to: Error.self) as NSError
+     === myError)
+  expectTrue(conditionalCast(myError, to: Error.self)! as NSError
+     === myError)
 }
 
 runAllTests()

--- a/test/SILGen/objc_error.swift
+++ b/test/SILGen/objc_error.swift
@@ -108,3 +108,13 @@ class MyNSError : NSError {
 func eraseMyNSError() -> Error {
   return MyNSError()
 }
+
+// CHECK-LABEL: sil hidden @_TF10objc_error25eraseFictionalServerErrorFT_Ps5Error_
+func eraseFictionalServerError() -> Error {
+  // CHECK-NOT: return
+  // CHECK: [[NSERROR_GETTER:%[0-9]+]] = function_ref @_TFVSC20FictionalServerErrorg8_nsErrorCSo7NSError
+  // CHECK: [[NSERROR:%[0-9]+]] = apply [[NSERROR_GETTER]]
+  // CHECK: [[ERROR:%[0-9]+]] = init_existential_ref [[NSERROR]]
+  // CHECK: return [[ERROR]]
+  return FictionalServerError(.meltedDown)
+}

--- a/test/SILGen/objc_error.swift
+++ b/test/SILGen/objc_error.swift
@@ -124,7 +124,7 @@ extension Error {
   // CHECK-LABEL: sil hidden @_TFE10objc_errorPs5Error16convertToNSErrorfT_CSo7NSError
   // CHECK: bb0([[SELF:%[0-9]+]] : $*Self)
 	func convertToNSError() -> NSError {
-    // CHECK: [[GET_EMBEDDED_FN:%[0-9]+]] = function_ref @swift_stdlib_getErrorEmbeddedNSErrorValue 
+    // CHECK: [[GET_EMBEDDED_FN:%[0-9]+]] = function_ref @swift_stdlib_getErrorEmbeddedNSError
     // CHECK: [[EMBEDDED_RESULT_OPT:%[0-9]+]] = apply [[GET_EMBEDDED_FN]]
     // CHECK: [[HAS_EMBEDDED_RESULT:%[0-9]+]] = select_enum [[EMBEDDED_RESULT_OPT]] : $Optional<AnyObject>
     // CHECK: cond_br [[HAS_EMBEDDED_RESULT]], [[SUCCESS:bb[0-9]+]], [[FAILURE:bb[0-9]+]]

--- a/test/SILGen/objc_error.swift
+++ b/test/SILGen/objc_error.swift
@@ -118,3 +118,30 @@ func eraseFictionalServerError() -> Error {
   // CHECK: return [[ERROR]]
   return FictionalServerError(.meltedDown)
 }
+
+// SR-1562
+extension Error {
+  // CHECK-LABEL: sil hidden @_TFE10objc_errorPs5Error16convertToNSErrorfT_CSo7NSError
+  // CHECK: bb0([[SELF:%[0-9]+]] : $*Self)
+	func convertToNSError() -> NSError {
+    // CHECK: [[GET_EMBEDDED_FN:%[0-9]+]] = function_ref @swift_stdlib_getErrorEmbeddedNSErrorValue 
+    // CHECK: [[EMBEDDED_RESULT_OPT:%[0-9]+]] = apply [[GET_EMBEDDED_FN]]
+    // CHECK: [[HAS_EMBEDDED_RESULT:%[0-9]+]] = select_enum [[EMBEDDED_RESULT_OPT]] : $Optional<AnyObject>
+    // CHECK: cond_br [[HAS_EMBEDDED_RESULT]], [[SUCCESS:bb[0-9]+]], [[FAILURE:bb[0-9]+]]
+
+    // CHECK: [[SUCCESS]]:
+    // CHECK: [[EMBEDDED_RESULT:%[0-9]+]] = unchecked_enum_data [[EMBEDDED_RESULT_OPT]] : $Optional<AnyObject>, #Optional.some!enumelt.1
+    // CHECK: [[EMBEDDED_NSERROR:%[0-9]+]] = unchecked_ref_cast [[EMBEDDED_RESULT]] : $AnyObject to $NSError
+    // CHECK: [[ERROR:%[0-9]+]] = init_existential_ref [[EMBEDDED_NSERROR]] : $NSError : $NSError, $Error
+    // CHECK: br [[CONTINUATION:bb[0-9]+]]([[ERROR]] : $Error)
+
+    // CHECK: [[FAILURE]]:
+    // CHECK: [[ERROR_BOX:%[0-9]+]] = alloc_existential_box $Error, $Self
+    // CHECK: [[ERROR_PROJECTED:%[0-9]+]] = project_existential_box $Self in [[ERROR_BOX]] : $Error
+    // CHECK: copy_addr [[SELF]] to [initialization] [[ERROR_PROJECTED]] : $*Self
+    // CHECK: br [[CONTINUATION]]([[ERROR_BOX]] : $Error)
+
+    // CHECK: [[CONTINUATION]]([[ERROR_ARG:%[0-9]+]] : $Error):
+		return self as NSError
+	}
+}

--- a/test/SILGen/objc_error.swift
+++ b/test/SILGen/objc_error.swift
@@ -95,3 +95,16 @@ func testProduceOptionalError() -> Error? {
   // CHECK: function_ref @swift_convertNSErrorToError
   return produceOptionalError();
 }
+
+class MyNSError : NSError {
+  override init() {
+    super.init(domain: "MyNSError", code: 0, userInfo: [:])
+  }
+}
+
+// CHECK-LABEL: sil hidden @_TF10objc_error14eraseMyNSError
+// CHECK-NOT: return
+// CHECK: init_existential_ref
+func eraseMyNSError() -> Error {
+  return MyNSError()
+}


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

This PR eliminates the double-wrapping of NSErrors in _SwiftNativeNSError, e.g., when an Error type that is an NSError (or subclasses NSError) or is a synthesized struct that wraps an NSError (for imported Cocoa errors) gets placed into an Error existential. Previously, these would end up getting boxed up against in a _SwiftNativeNSError, losing NSError identity and potentially causing a wrapping loop. Make sure that neither SILGen nor the runtime perform this double-wrapping.
#### Resolved bug number: ([SR-1562](https://bugs.swift.org/browse/SR-1562))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

This also resolves rdar://problem/27658748 and rdar://problem/26370984

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
