### PR TITLE
[Foundation] add hints for replacement APIs for Data of some common u…

### DIFF
--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -733,6 +733,13 @@ extension Data : CustomStringConvertible, CustomDebugStringConvertible, CustomRe
     }
 }
 
+extension Data {
+    @available(*, unavailable, renamed: "copyBytes(to:count:)")
+    public func getBytes(_ buffer: UnsafeMutablePointer<Swift.Void>, length: Int) { }
+
+    @available(*, unavailable, renamed: "copyBytes(to:from:)")
+    public func getBytes(_ buffer: UnsafeMutablePointer<Swift.Void>, range: NSRange) { }
+}
 
 /// Provides bridging functionality for struct Data to class NSData and vice-versa.
 extension Data : _ObjectiveCBridgeable {


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

This provides a hint to the proper API to use for struct Data when developers are migrating from NSData.
Purely a fixit addition (no actual functional code)
#### Resolved bug number:

<!-- If this pull request resolves any bugs from Swift bug tracker -->

rdar://problem/26206061 Missing fixit for Data.getBytes
