### PR TITLE
Dependency analysis: treat member operators as top-level "provides".

### DIFF
--- a/test/NameBinding/Inputs/reference-dependencies-helper.swift
+++ b/test/NameBinding/Inputs/reference-dependencies-helper.swift
@@ -31,6 +31,22 @@ func getOtherFileIntArray() -> OtherFileIntArray { return OtherFileIntArray() }
 typealias OtherFileAliasForSecret = OtherFileSecretTypeWrapper.SecretType
 
 prefix operator *** {}
+prefix operator ~~~~~ {}
+
+prefix operator ****
+infix operator *****
+infix operator ******
+protocol Starry {
+  static prefix func ****(arg: Self)
+  static func *****(lhs: Self, rhs: Int)
+  static func ******(lhs: Int, rhs: Self)
+}
+// Deliberately does not conform to Starry.
+struct Flyswatter {
+  static prefix func ****(arg: Flyswatter) {}
+  static func *****(lhs: Flyswatter, rhs: Int) {}
+  static func ******(lhs: Int, rhs: Flyswatter) {}
+}
 
 typealias ExpressibleByOtherFileAliasForFloatLiteral = ExpressibleByFloatLiteral
 

--- a/test/NameBinding/reference-dependencies.swift
+++ b/test/NameBinding/reference-dependencies.swift
@@ -18,13 +18,22 @@
 // CHECK-NEXT: "ThreeTilde"
 // CHECK-NEXT: "overloadedOnProto"
 // CHECK-NEXT: "overloadedOnProto"
+// CHECK-NEXT: "~~~~"
+// CHECK-NEXT: "FourTilde"
+// CHECK-NEXT: "FourTildeImpl"
+// CHECK-NEXT: "FiveTildeImpl"
 // CHECK-NEXT: "topLevelComputedProperty"
 // CHECK-NEXT: "lookUpManyTopLevelNames"
+// CHECK-NEXT: "testOperators"
 // CHECK-NEXT: "TopLevelForMemberLookup"
 // CHECK-NEXT: "lookUpMembers"
 // CHECK-NEXT: "publicUseOfMember"
 // CHECK-NEXT: "Outer"
 // CHECK: "eof"
+// CHECK-NEXT: "~~~"
+// CHECK-NEXT: "~~~~"
+// CHECK-NEXT: "~~~~"
+// CHECK-NEXT: "~~~~~"
 
 // CHECK-LABEL: {{^provides-nominal:$}}
 // CHECK-NEXT: "V4main10IntWrapper"
@@ -46,6 +55,8 @@
 // CHECK: - ["Ps25ExpressibleByArrayLiteral", "useless"]
 // CHECK-NEXT: - ["Ps25ExpressibleByArrayLiteral", "useless2"]
 // CHECK-NEXT: - ["Sb", "InnerToBool"]
+// CHECK-NEXT: - ["{{.*[0-9]}}FourTildeImpl", "~~~~"]
+// CHECK-NEXT: - ["{{.*[0-9]}}FiveTildeImpl", "~~~~~"]
 
 // CHECK-LABEL: {{^depends-top-level:$}}
 
@@ -129,6 +140,23 @@ func overloadedOnProto<T: ThreeTilde>(_: T) {}
 // CHECK-DAG: - "~~~"
 private prefix func ~~~(_: ThreeTildeTypeImpl) {}
 
+// CHECK-DAG: - "~~~~"
+prefix operator ~~~~ {}
+protocol FourTilde {
+  prefix static func ~~~~(arg: Self)
+}
+struct FourTildeImpl : FourTilde {}
+extension FourTildeImpl {
+  prefix static func ~~~~(arg: FourTildeImpl) {}
+}
+
+// CHECK-DAG: - "~~~~~"
+// ~~~~~ is declared in the other file.
+struct FiveTildeImpl {}
+extension FiveTildeImpl {
+  prefix static func ~~~~~(arg: FiveTildeImpl) {}
+}
+
 var topLevelComputedProperty: Bool {
   return true
 }
@@ -211,6 +239,19 @@ func lookUpManyTopLevelNames() {
   
   // CHECK-DAG: !private "otherFileGetNonImpl"
   overloadedOnProto(otherFileGetNonImpl())
+}
+
+func testOperators<T: Starry>(generic: T, specific: Flyswatter) {
+  // CHECK-DAG: !private "****"
+  // CHECK-DAG: !private "*****"
+  // CHECK-DAG: !private "******"
+  ****generic
+  generic*****0
+  0******generic
+
+  ****specific
+  specific*****0
+  0******specific
 }
 
 struct TopLevelForMemberLookup {


### PR DESCRIPTION
We still do a global lookup for operators even though they are syntactically declared within types now, so for dependency-tracking purposes continue to treat that as declared at the top level.

This isn't where we actually want to be---ideally we can use the types of the arguments to limit the dependencies to a member lookup (or pair of member lookups)---but since the operator overloads _themselves_ participate in type-checking an expression, I'm not sure that's 100% correct. For now, it's better to be conservative. (This means dependency analysis for operators remains as lousy as it was in Swift 2, but it's not a regression.)

rdar://problem/27659972

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
