### PR TITLE
[swiftc (38 vs. 5155)] Add crasher in swift::constraints::ConstraintGraphNode::getMemberType(...)

### DIFF
--- a/validation-test/compiler_crashers/28383-swift-constraints-constraintgraphnode-getmembertype.swift
+++ b/validation-test/compiler_crashers/28383-swift-constraints-constraintgraphnode-getmembertype.swift
@@ -1,0 +1,14 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+protocol A{associatedtype f:A
+typealias e:a
+protocol a
+}extension A
+protocol c:A{
+struct A{let c=g


### PR DESCRIPTION
Add test case for crash triggered in `swift::constraints::ConstraintGraphNode::getMemberType(...)`.

Current number of unresolved compiler crashers: 38 (5155 resolved)

Stack trace:

```
6  swift           0x00000000010073e6 swift::constraints::ConstraintGraphNode::getMemberType(swift::Identifier, std::function<swift::TypeVariableType* ()>) + 182
7  swift           0x0000000001007fca swift::constraints::ConstraintGraph::getMemberType(swift::TypeVariableType*, swift::Identifier, std::function<swift::TypeVariableType* ()>) + 154
9  swift           0x0000000001157493 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 35
10 swift           0x0000000000f62f4b swift::constraints::ConstraintSystem::openGeneric(swift::DeclContext*, swift::DeclContext*, llvm::ArrayRef<swift::GenericTypeParamType*>, llvm::ArrayRef<swift::Requirement>, bool, swift::constraints::ConstraintLocatorBuilder, llvm::DenseMap<swift::CanType, swift::TypeVariableType*, llvm::DenseMapInfo<swift::CanType>, llvm::detail::DenseMapPair<swift::CanType, swift::TypeVariableType*> >&) + 1659
11 swift           0x0000000000f210a4 swift::TypeChecker::isProtocolExtensionUsable(swift::DeclContext*, swift::Type, swift::ExtensionDecl*) + 356
17 swift           0x000000000111ce14 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 1188
18 swift           0x0000000000f14bf2 swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::Type, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) + 290
19 swift           0x0000000000ebb32a swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 4058
21 swift           0x0000000001095c3b swift::Expr::walk(swift::ASTWalker&) + 27
22 swift           0x0000000000ebbbb0 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 224
23 swift           0x0000000000ec2a3d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 621
24 swift           0x0000000000ec3bf0 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 352
25 swift           0x0000000000ec3e0b swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
32 swift           0x0000000000ed5a26 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
33 swift           0x0000000000ef9972 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
34 swift           0x0000000000c7aa69 swift::CompilerInstance::performSema() + 3289
36 swift           0x00000000007db2c7 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
37 swift           0x00000000007a7148 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28383-swift-constraints-constraintgraphnode-getmembertype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28383-swift-constraints-constraintgraphnode-getmembertype-b45c8b.o
1.  While type-checking 'c' at validation-test/compiler_crashers/28383-swift-constraints-constraintgraphnode-getmembertype.swift:13:1
2.  While type-checking expression at [validation-test/compiler_crashers/28383-swift-constraints-constraintgraphnode-getmembertype.swift:14:16 - line:14:16] RangeText="g"
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
