### PR TITLE
rdar://problem/27651717 Make bridged String and collection types conform to CVarArg.

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4073,9 +4073,14 @@ ASTContext::getBridgedToObjC(const DeclContext *dc, Type type,
       *bridgedValueType = type;
 
     // Find the Objective-C class type we bridge to.
-    return ProtocolConformance::getTypeWitnessByName(
-             type, conformance->getConcrete(), Id_ObjectiveCType,
-             resolver);
+    if (conformance->isConcrete()) {
+      return ProtocolConformance::getTypeWitnessByName(
+               type, conformance->getConcrete(), Id_ObjectiveCType,
+               resolver);
+    } else {
+      return type->castTo<ArchetypeType>()->getNestedType(Id_ObjectiveCType)
+        .getValue();
+    }
   }
 
   // Do we conform to Error?

--- a/stdlib/public/SDK/Foundation/Foundation.swift
+++ b/stdlib/public/SDK/Foundation/Foundation.swift
@@ -1550,3 +1550,20 @@ extension AnyHashable : _ObjectiveCBridgeable {
   }
 }
 
+//===----------------------------------------------------------------------===//
+// CVarArg for bridged types
+//===----------------------------------------------------------------------===//
+
+extension CVarArg where Self: _ObjectiveCBridgeable {
+  /// Default implementation for bridgeable types.
+  public var _cVarArgEncoding: [Int] {
+    let object = self._bridgeToObjectiveC()
+    _autorelease(object)
+    return _encodeBitsAsWords(object)
+  }
+}
+
+extension String: CVarArg {}
+extension Array: CVarArg {}
+extension Dictionary: CVarArg {}
+extension Set: CVarArg {}

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -107,7 +107,7 @@ public func getVaList(_ args: [CVarArg]) -> CVaListPointer {
 }
 #endif
 
-public func _encodeBitsAsWords<T : CVarArg>(_ x: T) -> [Int] {
+public func _encodeBitsAsWords<T>(_ x: T) -> [Int] {
   let result = [Int](
     repeating: 0,
     count: (MemoryLayout<T>.size + MemoryLayout<Int>.size - 1) / MemoryLayout<Int>.size)

--- a/test/Interpreter/SDK/Foundation_NSExpression.swift
+++ b/test/Interpreter/SDK/Foundation_NSExpression.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 // Test overlain variadic methods.
-let expression = NSExpression(format: "(3 + 2)**2", "LLLL" as NSString, "BBBB" as NSString)
+let expression = NSExpression(format: "(3 + 2)**2", "LLLL", "BBBB")
 let result = expression.expressionValue(with: expression, context:nil) as! NSNumber
 let number = result.stringValue
 print(number)

--- a/test/Interpreter/SDK/Foundation_NSLog.swift
+++ b/test/Interpreter/SDK/Foundation_NSLog.swift
@@ -19,5 +19,5 @@ testNSLog()
 // CHECK: 1 is the loneliest number that you'll ever do
 NSLog(
   "%@ is the loneliest number that you'll ever %@", 
-  NSNumber(value: 1), "do" as NSString
+  NSNumber(value: 1), "do"
 )

--- a/test/Interpreter/SDK/Foundation_NSPredicate.swift
+++ b/test/Interpreter/SDK/Foundation_NSPredicate.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 // Test overlain variadic methods.
-let s = NSPredicate(format: "(lastName like[cd] %@) AND (birthday > %@)", "LLLL" as NSString, "BBBB" as NSString)
+let s = NSPredicate(format: "(lastName like[cd] %@) AND (birthday > %@)", "LLLL", "BBBB")
 print(s.predicateFormat)
 
 // CHECK: lastName LIKE[cd] "LLLL" AND birthday > "BBBB"

--- a/test/Interpreter/SDK/Foundation_NSString.swift
+++ b/test/Interpreter/SDK/Foundation_NSString.swift
@@ -135,8 +135,16 @@ testComparisons()
 // Test overlain variadic methods.
 // CHECK-LABEL: Variadic methods:
 print("Variadic methods:")
+// Check that it works with bridged Strings.
 // CHECK-NEXT: x y
-print(NSString(format: "%@ %@", "x" as NSString, "y" as NSString))
+print(NSString(format: "%@ %@", "x", "y"))
+// Check that it works with bridged Arrays and Dictionaries.
+// CHECK-NEXT: (
+// CHECK-NEXT:   x
+// CHECK-NEXT: ) {
+// CHECK-NEXT:   y = z;
+// CHECK-NEXT: }
+print(NSString(format: "%@ %@", ["x"], ["y": "z"]))
 // CHECK-NEXT: 1{{.*}}024,25
 print(NSString(
   format: "%g",
@@ -144,13 +152,13 @@ print(NSString(
   1024.25
 ))
 // CHECK-NEXT: x y z
-print(("x " as NSString).appendingFormat("%@ %@", "y" as NSString, "z" as NSString))
+print(("x " as NSString).appendingFormat("%@ %@", "y", "z"))
 // CHECK-NEXT: a b c
 let s = NSMutableString(string: "a ")
-s.appendFormat("%@ %@", "b" as NSString, "c" as NSString)
+s.appendFormat("%@ %@", "b", "c")
 print(s)
 
-let m = NSMutableString.localizedStringWithFormat("<%@ %@>", "q" as NSString, "r" as NSString)
+let m = NSMutableString.localizedStringWithFormat("<%@ %@>", "q", "r")
 // CHECK-NEXT: <q r>
 print(m)
 m.append(" lever")


### PR DESCRIPTION
This allows String, Array, Dictionary, and Set to be passed as variadic arguments to Cocoa APIs like NSLog, NSPredicate, stringWithFormat:, etc. rdar://problem/27651717
