### PR TITLE
[ClangImporter] Preserve macros from all implicit submodules.

### DIFF
--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -19,6 +19,7 @@
 #include "swift/Basic/Version.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/Lex/MacroInfo.h"
+#include "clang/Lex/Preprocessor.h"
 #include "clang/Serialization/ASTBitCodes.h"
 #include "clang/Serialization/ASTReader.h"
 #include "clang/Serialization/ASTWriter.h"
@@ -41,6 +42,76 @@ static bool matchesExistingDecl(clang::Decl *decl, clang::Decl *existingDecl) {
   }
 
   return false;
+}
+
+namespace {
+enum class MacroConflictAction {
+  Discard,
+  Replace,
+  AddAsAlternative
+};
+}
+
+/// Based on the Clang module structure, decides what to do when a new
+/// definition of an existing macro is seen: discard it, have it replace the
+/// old one, or add it as an alternative.
+///
+/// Specifically, if the innermost explicit submodule containing \p newMacro
+/// contains the innermost explicit submodule containing \p existingMacro,
+/// \p newMacro should replace \p existingMacro; if they're the same module,
+/// \p existingMacro should stay in place. Otherwise, they don't share an
+/// explicit module, and should be considered alternatives.
+///
+/// Note that the above assumes that macro definitions are processed in reverse
+/// order, i.e. the first definition seen is the last in a translation unit.
+///
+/// If we're not currently building a module, then the "latest" macro wins,
+/// which (by the same assumption) should be the existing macro.
+static MacroConflictAction
+considerReplacingExistingMacro(const clang::MacroInfo *newMacro,
+                               const clang::MacroInfo *existingMacro,
+                               const clang::Preprocessor *PP) {
+  assert(PP);
+  assert(newMacro);
+  assert(existingMacro);
+  assert(newMacro->getOwningModuleID() == 0);
+  assert(existingMacro->getOwningModuleID() == 0);
+
+  if (PP->getLangOpts().CurrentModule.empty())
+    return MacroConflictAction::Discard;
+
+  clang::ModuleMap &moduleInfo = PP->getHeaderSearchInfo().getModuleMap();
+  const clang::SourceManager &sourceMgr = PP->getSourceManager();
+
+  auto findContainingExplicitModule =
+      [&moduleInfo, &sourceMgr](const clang::MacroInfo *macro)
+        -> const clang::Module * {
+
+    clang::SourceLocation definitionLoc = macro->getDefinitionLoc();
+    assert(definitionLoc.isValid() &&
+           "implicitly-defined macros shouldn't show up in a module's lookup");
+    clang::FullSourceLoc fullLoc(definitionLoc, sourceMgr);
+
+    const clang::Module *module = moduleInfo.inferModuleFromLocation(fullLoc);
+    assert(module && "we are building a module; everything should be modular");
+
+    while (module->isSubModule()) {
+      if (module->IsExplicit)
+        break;
+      module = module->Parent;
+    }
+    return module;
+  };
+
+  const clang::Module *newModule = findContainingExplicitModule(newMacro);
+  const clang::Module *existingModule =
+      findContainingExplicitModule(existingMacro);
+
+  if (existingModule == newModule)
+    return MacroConflictAction::Discard;
+  if (existingModule->isSubModuleOf(newModule))
+    return MacroConflictAction::Replace;
+  return MacroConflictAction::AddAsAlternative;
 }
 
 bool SwiftLookupTable::contextRequiresName(ContextKind kind) {
@@ -262,7 +333,8 @@ static bool isGlobalAsMember(SwiftLookupTable::SingleEntry entry,
 }
 
 bool SwiftLookupTable::addLocalEntry(SingleEntry newEntry,
-                                     SmallVectorImpl<uintptr_t> &entries) {
+                                     SmallVectorImpl<uintptr_t> &entries,
+                                     const clang::Preprocessor *PP) {
   // Check whether this entry matches any existing entry.
   auto decl = newEntry.dyn_cast<clang::NamedDecl *>();
   auto macro = newEntry.dyn_cast<clang::MacroInfo *>();
@@ -272,10 +344,21 @@ bool SwiftLookupTable::addLocalEntry(SingleEntry newEntry,
         matchesExistingDecl(decl, mapStoredDecl(existingEntry)))
       return false;
 
-    // If it matches an existing macro, overwrite the existing entry.
+    // If it matches an existing macro, decide on the best course of action.
     if (macro && isMacroEntry(existingEntry)) {
-      existingEntry = encodeEntry(macro);
-      return false;
+      MacroConflictAction action =
+         considerReplacingExistingMacro(macro,
+                                        mapStoredMacro(existingEntry),
+                                        PP);
+      switch (action) {
+      case MacroConflictAction::Discard:
+        return false;
+      case MacroConflictAction::Replace:
+        existingEntry = encodeEntry(macro);
+        return false;
+      case MacroConflictAction::AddAsAlternative:
+        break;
+      }
     }
   }
 
@@ -288,7 +371,8 @@ bool SwiftLookupTable::addLocalEntry(SingleEntry newEntry,
 }
 
 void SwiftLookupTable::addEntry(DeclName name, SingleEntry newEntry,
-                                EffectiveClangContext effectiveContext) {
+                                EffectiveClangContext effectiveContext,
+                                const clang::Preprocessor *PP) {
   assert(!Reader && "Cannot modify a lookup table stored on disk");
 
   // Translate the context.
@@ -311,7 +395,7 @@ void SwiftLookupTable::addEntry(DeclName name, SingleEntry newEntry,
   // If this is a global imported as a member, record is as such.
   if (isGlobalAsMember(newEntry, context)) {
     auto &entries = GlobalsAsMembers[context];
-    (void)addLocalEntry(newEntry, entries);
+    (void)addLocalEntry(newEntry, entries, PP);
   }
 
   // Find the list of entries for this base name.
@@ -321,7 +405,7 @@ void SwiftLookupTable::addEntry(DeclName name, SingleEntry newEntry,
   for (auto &entry : entries) {
     if (entry.Context == context) {
       // We have entries for this context.
-      (void)addLocalEntry(newEntry, entry.DeclsOrMacros);
+      (void)addLocalEntry(newEntry, entry.DeclsOrMacros, PP);
       return;
     }
   }

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -297,7 +297,8 @@ private:
   /// present.
   ///
   /// \returns true if the entry was added, false otherwise.
-  bool addLocalEntry(SingleEntry newEntry, SmallVectorImpl<uintptr_t> &entries);
+  bool addLocalEntry(SingleEntry newEntry, SmallVectorImpl<uintptr_t> &entries,
+                     const clang::Preprocessor *PP);
 
 public:
   explicit SwiftLookupTable(SwiftLookupTableReader *reader) : Reader(reader) { }
@@ -324,7 +325,8 @@ public:
   /// \param newEntry The Clang declaration or macro.
   /// \param effectiveContext The effective context in which name lookup occurs.
   void addEntry(DeclName name, SingleEntry newEntry,
-                EffectiveClangContext effectiveContext);
+                EffectiveClangContext effectiveContext,
+                const clang::Preprocessor *PP = nullptr);
 
   /// Add an Objective-C category or extension to the table.
   void addCategory(clang::ObjCCategoryDecl *category);

--- a/test/ClangModules/Inputs/custom-modules/MacrosRedefWithParallelSubmodules/A.h
+++ b/test/ClangModules/Inputs/custom-modules/MacrosRedefWithParallelSubmodules/A.h
@@ -1,0 +1,2 @@
+#define MRWPS_REDEF_1 "hello"
+#define MRWPS_REDEF_2 "swift"

--- a/test/ClangModules/Inputs/custom-modules/MacrosRedefWithParallelSubmodules/B.h
+++ b/test/ClangModules/Inputs/custom-modules/MacrosRedefWithParallelSubmodules/B.h
@@ -1,0 +1,2 @@
+#define MRWPS_REDEF_1 "hello"
+#define MRWPS_REDEF_2 "world"

--- a/test/ClangModules/Inputs/custom-modules/MacrosRedefWithParallelSubmodules/module.modulemap
+++ b/test/ClangModules/Inputs/custom-modules/MacrosRedefWithParallelSubmodules/module.modulemap
@@ -1,0 +1,8 @@
+module MacrosRedefWithParallelSubmodules {
+  explicit module A {
+    header "A.h"
+  }
+  explicit module B {
+    header "B.h"
+  }
+}

--- a/test/ClangModules/Inputs/custom-modules/MacrosRedefWithSubmodules/Inner.h
+++ b/test/ClangModules/Inputs/custom-modules/MacrosRedefWithSubmodules/Inner.h
@@ -1,0 +1,2 @@
+#define MRWS_REDEF_1 "hello"
+#define MRWS_REDEF_2 "swift"

--- a/test/ClangModules/Inputs/custom-modules/MacrosRedefWithSubmodules/Outer.h
+++ b/test/ClangModules/Inputs/custom-modules/MacrosRedefWithSubmodules/Outer.h
@@ -1,0 +1,2 @@
+#define MRWS_REDEF_1 "hello"
+#define MRWS_REDEF_2 "world"

--- a/test/ClangModules/Inputs/custom-modules/MacrosRedefWithSubmodules/module.modulemap
+++ b/test/ClangModules/Inputs/custom-modules/MacrosRedefWithSubmodules/module.modulemap
@@ -1,0 +1,6 @@
+module MacrosRedefWithSubmodules {
+  header "Outer.h"
+  explicit module TheSubmodule {
+    header "Inner.h"
+  }
+}

--- a/test/ClangModules/Inputs/macros_redef.h
+++ b/test/ClangModules/Inputs/macros_redef.h
@@ -1,0 +1,7 @@
+#define BRIDGING_HEADER_1 1
+#undef BRIDGING_HEADER_1
+#define BRIDGING_HEADER_1 "1"
+
+#define BRIDGING_HEADER_2 2
+#define BRIDGING_HEADER_2 "2"
+

--- a/test/ClangModules/macros_redef.swift
+++ b/test/ClangModules/macros_redef.swift
@@ -1,11 +1,46 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -parse -verify %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -import-objc-header %S/Inputs/macros_redef.h -parse %s
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -import-objc-header %S/Inputs/macros_redef.h -DCONFLICT -parse -verify %s
 
 import MacrosRedefA
 import MacrosRedefB
 
-func testMacroRedef() {
+#if CONFLICT
+import MacrosRedefWithSubmodules
+import MacrosRedefWithSubmodules.TheSubmodule
+import MacrosRedefWithParallelSubmodules.A
+import MacrosRedefWithParallelSubmodules.B
+#else
+import MacrosRedefWithSubmodules.TheSubmodule
+import MacrosRedefWithParallelSubmodules.A
+#endif
+
+func testFrameworkRedef() {
   var s: String
   s = REDEF_1
+#if CONFLICT
   s = REDEF_2 // expected-error{{ambiguous use of 'REDEF_2'}}
+#endif
+}
+
+func testBridgingHeaderRedef() {
+  var s: String
+  s = BRIDGING_HEADER_1
+  s = BRIDGING_HEADER_2
+  _ = s
+}
+
+func testSubmodules() {
+  var s: String
+  s = MRWS_REDEF_1
+  s = MRWS_REDEF_2
+  _ = s
+}
+
+func testParallelSubmodules() {
+  var s: String
+  s = MRWPS_REDEF_1
+  s = MRWPS_REDEF_2 // expected-error{{ambiguous use of 'MRWPS_REDEF_2'}}
+  _ = s
 }
 

--- a/test/Interpreter/SDK/submodules_smoke_test.swift
+++ b/test/Interpreter/SDK/submodules_smoke_test.swift
@@ -8,6 +8,8 @@
 import OpenGL.GL3
 _ = glGetString
 _ = OpenGL.glGetString
+_ = GL_COLOR_BUFFER_BIT
+_ = OpenGL.GL_COLOR_BUFFER_BIT
 
 import AppKit.NSPanGestureRecognizer
 


### PR DESCRIPTION
- **Explanation:** When there are multiple definitions of a macro in the same top-level module but different explicit submodules, the compiler has been arbitrarily picking one and leaving it out of the other, leading to "use of undeclared value". The new model tries to decide if it's possible for two modules to be imported separately, and keeps both macro entries if possible, only deduplicating equivalent definitions at the last minute (when importing into Swift).
- **Scope:** This doesn't happen very often, but it does include the OpenGL modules on macOS, and it's a regression from Swift 2. The fix affects the code path for importing any macro, but should preserve the same behavior in the common cases.
- **Issue:** [SR-1718](https://bugs.swift.org/browse/SR-1718) / rdar://problem/26731529
- **Reviewed by:** @DougGregor
- **Risk:** Medium-low.
- **Testing:** Added compiler regression tests for individual cases, as well as the originally-reported test case involving OpenGL.GL3.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
