### PR TITLE
[FixCode] Using coercion (as) instead of forced-coercion (as!) 

### DIFF
--- a/test/Sema/diag_type_conversion.swift
+++ b/test/Sema/diag_type_conversion.swift
@@ -1,4 +1,8 @@
-// RUN: %target-parse-verify-swift
+// RUN: %target-parse-verify-swift %clang-importer-sdk
+
+// REQUIRES: objc_interop
+
+import Foundation
 
 func foo1(_ a: [Int]) {}
 func foo2(_ a : UnsafePointer<Int>) {}
@@ -33,4 +37,14 @@ struct S1 : P1 {}
 func foo9(s : S1) {}
 func foo10(p : P1) {
   foo9(s : p) // expected-error {{cannot convert value of type 'P1' to expected argument type 'S1'}} {{13-13= as! S1}}
+}
+
+func foo11(a : [AnyHashable]) {}
+func foo12(b : [NSObject]) {
+  foo11(a : b) // expected-error {{cannot convert value of type '[NSObject]' to expected argument type '[AnyHashable]'}} {{14-14= as [AnyHashable]}}
+}
+
+func foo13(a : [AnyHashable : Any]) {}
+func foo14(b : [NSObject : AnyObject]) {
+  foo13(a : b ) // expected-error {{cannot convert value of type '[NSObject : AnyObject]' to expected argument type '[AnyHashable : Any]'}} {{14-14= as [AnyHashable : Any]}}
 }


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->

This is a cherry-picked fixit update to fix rdar://27683732.
The fixit helps users migrate to the id-as-any impacted APIs.

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…he former is applicable. rdar://27683732

This fixit is migration-critical to help users call functions now take 'Any' or 'NSHashble' while used to take
'AnyObject'. We insert coercion to the original call sites.
