### PR TITLE
Fix @available renaming for renamed initializers

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1367,10 +1367,7 @@ void swift::fixItAvailableAttrRename(TypeChecker &TC,
     if (parsed.isMember()) {
       diag.fixItReplace(call->getFn()->getSourceRange(), parsed.ContextName);
 
-    } else {
-      auto *dotCall = dyn_cast<DotSyntaxCallExpr>(call->getFn());
-      if (!dotCall)
-        return;
+    } else if (auto *dotCall = dyn_cast<DotSyntaxCallExpr>(call->getFn())) {
 
       SourceLoc removeLoc = dotCall->getDotLoc();
       if (removeLoc.isInvalid())

--- a/test/1_stdlib/StringDiagnostics_without_Foundation.swift
+++ b/test/1_stdlib/StringDiagnostics_without_Foundation.swift
@@ -27,5 +27,5 @@ func testStringCollectionTypes(s: String) {
 struct NotLosslessStringConvertible {}
 
 func testStringInitT() {
-  _ = String(NotLosslessStringConvertible()) // expected-error{{'init' has been renamed to 'init(describing:)}}
+  _ = String(NotLosslessStringConvertible()) // expected-error{{'init' has been renamed to 'init(describing:)}}{{14-14=describing: }}
 }


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Right now, renaming an initializer doesn't create a fixit with the correct argument labels.
This patch fixes that, and fixes the test case from #3938.

<!-- Description about pull request. -->
#### Resolved bug number: (N/A)

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
