### PR TITLE
[swiftc (39 vs. 5155)] Add crasher in swift::Expr::walk(...)

### DIFF
--- a/validation-test/compiler_crashers/28384-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers/28384-swift-expr-walk.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+class A{
+var _=[{return
+class{}}
+(


### PR DESCRIPTION
Add test case for crash triggered in `swift::Expr::walk(...)`.

Current number of unresolved compiler crashers: 39 (5155 resolved)

Assertion failure in [`include/swift/AST/Stmt.h (line 170)`](https://github.com/apple/swift/blob/master/include/swift/AST/Stmt.h#L170):

```
Assertion `Result && "ReturnStmt doesn't have a result"' failed.

When executing: swift::Expr *swift::ReturnStmt::getResult() const
```

Assertion context:

```
  SourceLoc getStartLoc() const;
  SourceLoc getEndLoc() const;

  bool hasResult() const { return Result != 0; }
  Expr *getResult() const {
    assert(Result && "ReturnStmt doesn't have a result");
    return Result;
  }
  void setResult(Expr *e) { Result = e; }

  static bool classof(const Stmt *S) { return S->getKind() == StmtKind::Return;}
```

Stack trace:

```
swift: /path/to/swift/include/swift/AST/Stmt.h:170: swift::Expr *swift::ReturnStmt::getResult() const: Assertion `Result && "ReturnStmt doesn't have a result"' failed.
12 swift           0x0000000001095c6b swift::Expr::walk(swift::ASTWalker&) + 75
13 swift           0x0000000001110418 swift::Expr::forEachChildExpr(std::function<swift::Expr* (swift::Expr*)> const&) + 40
15 swift           0x0000000000f89a5d swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 7021
16 swift           0x0000000000f8e2be swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4078
17 swift           0x0000000000ebbe29 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 857
18 swift           0x0000000000ec2a3d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 621
20 swift           0x0000000000f88a89 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 2969
21 swift           0x0000000000f8e2be swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4078
22 swift           0x0000000000ebbe29 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 857
23 swift           0x0000000000ec2a3d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 621
24 swift           0x0000000000ec3bf0 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 352
25 swift           0x0000000000ec3e0b swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
30 swift           0x0000000000ed5a26 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
31 swift           0x0000000000ef9972 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
32 swift           0x0000000000c7aa69 swift::CompilerInstance::performSema() + 3289
34 swift           0x00000000007db2c7 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
35 swift           0x00000000007a7148 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28384-swift-expr-walk.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28384-swift-expr-walk-c29723.o
1.  While type-checking 'A' at validation-test/compiler_crashers/28384-swift-expr-walk.swift:10:1
2.  While type-checking expression at [validation-test/compiler_crashers/28384-swift-expr-walk.swift:11:7 - line:13:1] RangeText="[{return
3.  While type-checking expression at [validation-test/compiler_crashers/28384-swift-expr-walk.swift:11:7 - line:13:1] RangeText="[{return
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
