### PR TITLE
Runtime: Handle universal bridging of class metatypes.

### DIFF
--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -2756,7 +2756,16 @@ static id bridgeAnythingNonVerbatimToObjectiveC(OpaqueValue *src,
     return result;
   }
   
-  if (auto srcBridgeWitness = findBridgeWitness(srcType)) {
+  // Handle metatypes. Class metatypes bridge to their class object.
+  if (isa<ExistentialMetatypeMetadata>(srcType)
+      || isa<MetatypeMetadata>(srcType)) {
+    const Metadata *srcMetatypeValue;
+    memcpy(&srcMetatypeValue, src, sizeof(srcMetatypeValue));
+    
+    if (isa<ClassMetadata>(srcMetatypeValue)
+        || isa<ObjCClassWrapperMetadata>(srcMetatypeValue))
+      return (id)srcMetatypeValue->getClassObject();
+  } else if (auto srcBridgeWitness = findBridgeWitness(srcType)) {
     // Bridge the source value to an object.
     auto srcBridgedObject =
       srcBridgeWitness->bridgeToObjectiveC(src, srcType, srcBridgeWitness);

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -2756,15 +2756,27 @@ static id bridgeAnythingNonVerbatimToObjectiveC(OpaqueValue *src,
     return result;
   }
   
-  // Handle metatypes. Class metatypes bridge to their class object.
+  // Handle metatypes.
   if (isa<ExistentialMetatypeMetadata>(srcType)
       || isa<MetatypeMetadata>(srcType)) {
     const Metadata *srcMetatypeValue;
     memcpy(&srcMetatypeValue, src, sizeof(srcMetatypeValue));
     
+    // Class metatypes bridge to their class object.
     if (isa<ClassMetadata>(srcMetatypeValue)
-        || isa<ObjCClassWrapperMetadata>(srcMetatypeValue))
+        || isa<ObjCClassWrapperMetadata>(srcMetatypeValue)) {
       return (id)srcMetatypeValue->getClassObject();
+    
+    // ObjC protocols bridge to their Protocol object.
+    } else if (auto existential
+               = dyn_cast<ExistentialTypeMetadata>(srcMetatypeValue)) {
+      if (existential->isObjC() && existential->Protocols.NumProtocols == 1) {
+        // Though they're statically-allocated globals, Protocol inherits
+        // NSObject's default refcounting behavior so must be retained.
+        auto protocolObj = (id)existential->Protocols[0];
+        return objc_retain(protocolObj);
+      }
+    }
   } else if (auto srcBridgeWitness = findBridgeWitness(srcType)) {
     // Bridge the source value to an object.
     auto srcBridgedObject =

--- a/test/1_stdlib/BridgeIdAsAny.swift.gyb
+++ b/test/1_stdlib/BridgeIdAsAny.swift.gyb
@@ -103,6 +103,17 @@ func metatypeCanBeDynamicallyCast(original: Int.Type,
   expectTrue(original == bridged as! Int.Type)
   expectTrue(original == bridged as! Any.Type)
 }
+func metatypeCanBeDynamicallyCast(original: CFString.Type,
+                                  bridged: AnyObject) {
+  expectTrue(original == bridged as! CFString.Type)
+  expectTrue(original == bridged as! Any.Type)
+}
+func metatypeCanBeDynamicallyCastGenerically<T>(original: T.Type,
+                                                bridged: AnyObject) {
+  expectTrue(original == bridged as! T.Type)
+  expectTrue(original == bridged as! Any.Type)
+}
+
 
 func guineaPigFunction() -> Int {
   return 1738
@@ -114,17 +125,37 @@ func functionCanBeDynamicallyCast(original: () -> Int,
   expectEqual(original(), try! (bridged as! () throws -> Int)())
 }
 
+func classMetatypePreservesIdentity<T: AnyObject>(original: T.Type,
+                                                  bridged: AnyObject) {
+  expectTrue(original as AnyObject === bridged)
+  expectTrue(original as AnyObject.Type as AnyObject === bridged)
+  expectTrue(original as Any.Type as AnyObject === bridged)
+}
+
+func classMetatypePreservesIdentityGenerically<T>(original: T.Type,
+                                                  bridged: AnyObject) {
+  expectTrue(original as AnyObject === bridged)
+  expectTrue(original as Any.Type as AnyObject === bridged)
+}
+
 // We want to exhaustively check all paths through the bridging and dynamic
 // casting infrastructure, so expand out test cases that wrap the different
 // interesting bridging cases in different kinds of existential container.
 %{
 testCases = [
-  ("classes",        "LifetimeTracked(0)", "bridgedObjectPreservesIdentity",           True),
-  ("strings",        '"vitameatavegamin"', "stringBridgesToEqualNSString",             True),
-  ("unbridged type", "KnownUnbridged()",   "boxedTypeRoundTripsThroughDynamicCasting", True),
-  ("tuple",          '(1, "2")',           "tupleCanBeDynamicallyCast",                False),
-  ("metatype",       'Int.self',           "metatypeCanBeDynamicallyCast",             False),
-  ("function",       'guineaPigFunction',  "functionCanBeDynamicallyCast",             False),
+  ("classes",                "LifetimeTracked(0)",   "bridgedObjectPreservesIdentity",            True),
+  ("strings",                '"vitameatavegamin"',   "stringBridgesToEqualNSString",              True),
+  ("unbridged type",         "KnownUnbridged()",     "boxedTypeRoundTripsThroughDynamicCasting",  True),
+  ("tuple",                  '(1, "2")',             "tupleCanBeDynamicallyCast",                 False),
+  ("metatype",               'Int.self',             "metatypeCanBeDynamicallyCast",              False),
+  ("generic metatype",       'Int.self',             "metatypeCanBeDynamicallyCastGenerically",   False),
+  ("CF metatype",            'CFString.self',        "metatypeCanBeDynamicallyCast",              False),
+  ("generic CF metatype",    'CFString.self',        "metatypeCanBeDynamicallyCastGenerically",   False),
+  ("class metatype",         'LifetimeTracked.self', "classMetatypePreservesIdentity",            False),
+  ("objc metatype",          'NSObject.self',        "classMetatypePreservesIdentity",            False),
+  ("generic class metatype", 'LifetimeTracked.self', "classMetatypePreservesIdentityGenerically", False),
+  ("generic objc metatype",  'NSObject.self',        "classMetatypePreservesIdentityGenerically", False),
+  ("function",               'guineaPigFunction',    "functionCanBeDynamicallyCast",              False),
 ]
 }%
 

--- a/test/1_stdlib/BridgeIdAsAny.swift.gyb
+++ b/test/1_stdlib/BridgeIdAsAny.swift.gyb
@@ -138,24 +138,36 @@ func classMetatypePreservesIdentityGenerically<T>(original: T.Type,
   expectTrue(original as Any.Type as AnyObject === bridged)
 }
 
+func protocolObjectPreservesIdentity(original: NSCopying.Protocol,
+                                     bridged: AnyObject) {
+  let proto: Protocol = original
+  expectTrue(proto === bridged)
+}
+
+protocol P {}
+
 // We want to exhaustively check all paths through the bridging and dynamic
 // casting infrastructure, so expand out test cases that wrap the different
 // interesting bridging cases in different kinds of existential container.
 %{
 testCases = [
-  ("classes",                "LifetimeTracked(0)",   "bridgedObjectPreservesIdentity",            True),
-  ("strings",                '"vitameatavegamin"',   "stringBridgesToEqualNSString",              True),
-  ("unbridged type",         "KnownUnbridged()",     "boxedTypeRoundTripsThroughDynamicCasting",  True),
-  ("tuple",                  '(1, "2")',             "tupleCanBeDynamicallyCast",                 False),
-  ("metatype",               'Int.self',             "metatypeCanBeDynamicallyCast",              False),
-  ("generic metatype",       'Int.self',             "metatypeCanBeDynamicallyCastGenerically",   False),
-  ("CF metatype",            'CFString.self',        "metatypeCanBeDynamicallyCast",              False),
-  ("generic CF metatype",    'CFString.self',        "metatypeCanBeDynamicallyCastGenerically",   False),
-  ("class metatype",         'LifetimeTracked.self', "classMetatypePreservesIdentity",            False),
-  ("objc metatype",          'NSObject.self',        "classMetatypePreservesIdentity",            False),
-  ("generic class metatype", 'LifetimeTracked.self', "classMetatypePreservesIdentityGenerically", False),
-  ("generic objc metatype",  'NSObject.self',        "classMetatypePreservesIdentityGenerically", False),
-  ("function",               'guineaPigFunction',    "functionCanBeDynamicallyCast",              False),
+  ("classes",                    "LifetimeTracked(0)",          "bridgedObjectPreservesIdentity",            True),
+  ("strings",                    '"vitameatavegamin"',          "stringBridgesToEqualNSString",              True),
+  ("unbridged type",             "KnownUnbridged()",            "boxedTypeRoundTripsThroughDynamicCasting",  True),
+  ("tuple",                      '(1, "2")',                    "tupleCanBeDynamicallyCast",                 False),
+  ("metatype",                   'Int.self',                    "metatypeCanBeDynamicallyCast",              False),
+  ("generic metatype",           'Int.self',                    "metatypeCanBeDynamicallyCastGenerically",   False),
+  ("CF metatype",                'CFString.self',               "metatypeCanBeDynamicallyCast",              False),
+  ("generic CF metatype",        'CFString.self',               "metatypeCanBeDynamicallyCastGenerically",   False),
+  ("class metatype",             'LifetimeTracked.self',        "classMetatypePreservesIdentity",            False),
+  ("objc metatype",              'NSObject.self',               "classMetatypePreservesIdentity",            False),
+  ("protocol",                   'P.self',                      "metatypeCanBeDynamicallyCastGenerically",   False),
+  ("objc protocol",              'NSCopying.self',              "protocolObjectPreservesIdentity",           False),
+  ("objc protocol composition",  '(NSCopying & NSCoding).self', "metatypeCanBeDynamicallyCastGenerically",   False),
+  ("mixed protocol composition", '(NSCopying & P).self',        "metatypeCanBeDynamicallyCastGenerically",   False),
+  ("generic class metatype",     'LifetimeTracked.self',        "classMetatypePreservesIdentityGenerically", False),
+  ("generic objc metatype",      'NSObject.self',               "classMetatypePreservesIdentityGenerically", False),
+  ("function",                   'guineaPigFunction',           "functionCanBeDynamicallyCast",              False),
 ]
 }%
 


### PR DESCRIPTION
Class metatypes bridge to their `Class` objects in Objective-C.
