### PR TITLE
[FixCode] Add necessary constructor call to bridge a String to AnyHashable

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3399,6 +3399,12 @@ static bool isIntegerType(Type fromType, ConstraintSystem *CS) {
                                   CS);
 }
 
+static bool isStringType(Type fromType, ConstraintSystem *CS) {
+  return isExpressibleByLiteralType(fromType,
+                                  KnownProtocolKind::ExpressibleByStringLiteral,
+                                    CS);
+}
+
 /// Return true if the given type conforms to RawRepresentable.
 static Type isRawRepresentable(Type fromType,
                                ConstraintSystem *CS) {
@@ -3594,6 +3600,23 @@ addTypeCoerceFixit(InFlightDiagnostic &diag, ConstraintSystem *CS,
                      (llvm::Twine(Kind == CheckedCastKind::Coercion ? " as " :
                                                                       " as! ") +
                       OS.str()).str());
+    return true;
+  }
+  return false;
+}
+
+
+/// Attempts to add fix-its for the mistake when fromType is String:
+/// - Passing a string to a parameter expecting AnyHashable. The fixit inserts
+///   'AnyHashable(' and ')' to initialize an AnyHashable from the string.
+static bool
+tryStringCastFixIts(InFlightDiagnostic &diag, ConstraintSystem *CS,
+                    Type fromType, Type toType, Expr *expr) {
+  if (!isStringType(fromType, CS))
+    return false;
+  if (CS->isAnyHashableType(toType)) {
+    diag.fixItInsert(expr->getStartLoc(), "AnyHashable(").
+      fixItInsertAfter(expr->getEndLoc(), ")");
     return true;
   }
   return false;
@@ -3967,7 +3990,8 @@ bool FailureDiagnosis::diagnoseContextualConversionError() {
                               KnownProtocolKind::ExpressibleByStringLiteral,
                               expr) ||
     tryIntegerCastFixIts(diag, CS, exprType, contextualType, expr) ||
-    addTypeCoerceFixit(diag, CS, exprType, contextualType, expr);
+    addTypeCoerceFixit(diag, CS, exprType, contextualType, expr) ||
+    tryStringCastFixIts(diag, CS, exprType, contextualType, expr);
     break;
 
   default:

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -709,6 +709,14 @@ bool ConstraintSystem::isSetType(Type type) {
   return false;
 }
 
+bool ConstraintSystem::isAnyHashableType(Type type) {
+  if (auto sType = type->getAs<StructType>()) {
+    return sType->getDecl() == TC.Context.getAnyHashableDecl();
+  }
+
+  return false;
+}
+
 Type ConstraintSystem::openBindingType(Type type, 
                                        ConstraintLocatorBuilder locator) {
   Type result = openType(type, locator);

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1499,6 +1499,9 @@ public:
   /// \brief Determine if the type in question is a Set<T>.
   bool isSetType(Type t);
 
+  /// \brief Determine if the type in question is a AnyHashable.
+  bool isAnyHashableType(Type t);
+
 private:
   /// Introduce the constraints associated with the given type variable
   /// into the worklist.

--- a/test/Sema/diag_type_conversion.swift
+++ b/test/Sema/diag_type_conversion.swift
@@ -48,3 +48,12 @@ func foo13(a : [AnyHashable : Any]) {}
 func foo14(b : [NSObject : AnyObject]) {
   foo13(a : b ) // expected-error {{cannot convert value of type '[NSObject : AnyObject]' to expected argument type '[AnyHashable : Any]'}} {{14-14= as [AnyHashable : Any]}}
 }
+
+func foo15(a : AnyHashable) {}
+func foo16(a : String) {
+  foo15(a : a) // expected-error {{cannot convert value of type 'String' to expected argument type 'AnyHashable'}} {{13-13=AnyHashable(}} {{14-14=)}}
+}
+
+func foo17() {
+  var dict : [AnyHashable: String] = ["": ""] // expected-error {{cannot convert value of type 'String' to expected dictionary key type 'AnyHashable'}} {{39-39=AnyHashable(}} {{41-41=)}}
+}


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->

 [FixCode] Add necessary constructor call to bridge a String to AnyHashable. rdar://27685458

```
This is migration-critical fixit. After id-as-any, imported dictionary may require key as AnyHashable.
This fixit helps construct AnyHashable from a string if an unable-to-convert error is encountered.
```

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…hable. rdar://27685458

This is migration-critical fixit. After id-as-any, imported dictionary may require key as AnyHashable.
This fixit helps construct AnyHashable from a string if an unable-to-convert error is encountered.
