### PR TITLE
[Type system] Infer 'Any' for array elements and dictionary values an…

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2711,6 +2711,14 @@ namespace {
 
       expr->setSemanticExpr(result);
       expr->setType(arrayTy);
+
+      // If the array element type was defaulted, note that in the expression.
+      auto elementTypeVariable = cs.ArrayElementTypeVariables.find(expr);
+      if (elementTypeVariable != cs.ArrayElementTypeVariables.end()) {
+        if (solution.DefaultedTypeVariables.count(elementTypeVariable->second))
+          expr->setIsTypeDefaulted();
+      }
+
       return expr;
     }
 
@@ -2780,6 +2788,18 @@ namespace {
 
       expr->setSemanticExpr(result);
       expr->setType(dictionaryTy);
+
+      // If the dictionary key or value type was defaulted, note that in the
+      // expression.
+      auto elementTypeVariable = cs.DictionaryElementTypeVariables.find(expr);
+      if (elementTypeVariable != cs.DictionaryElementTypeVariables.end()) {
+        if (solution.DefaultedTypeVariables.count(
+              elementTypeVariable->second.first) ||
+            solution.DefaultedTypeVariables.count(
+              elementTypeVariable->second.second))
+          expr->setIsTypeDefaulted();
+      }
+
       return expr;
     }
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -599,6 +599,9 @@ public:
   llvm::SmallDenseMap<ConstraintLocator *, ArchetypeType *>
     OpenedExistentialTypes;
 
+  /// The type variables that were bound via a Defaultable constraint.
+  llvm::SmallPtrSet<TypeVariableType *, 8> DefaultedTypeVariables;
+
   /// \brief Simplify the given type by substituting all occurrences of
   /// type variables for their fixed types.
   Type simplifyType(TypeChecker &tc, Type type) const;
@@ -997,6 +1000,23 @@ private:
   SmallVector<std::pair<ConstraintLocator *, ArchetypeType *>, 4>
     OpenedExistentialTypes;
 
+public:
+  /// The type variables that were bound via a Defaultable constraint.
+  SmallVector<TypeVariableType *, 8> DefaultedTypeVariables;
+
+  /// The type variable used to describe the element type of the given array
+  /// literal.
+  llvm::SmallDenseMap<ArrayExpr *, TypeVariableType *>
+    ArrayElementTypeVariables;
+
+
+  /// The type variables used to describe the key and value types of the given
+  /// dictionary literal.
+  llvm::SmallDenseMap<DictionaryExpr *,
+                      std::pair<TypeVariableType *, TypeVariableType *>>
+    DictionaryElementTypeVariables;
+
+private:
   /// \brief Describes the current solver state.
   struct SolverState {
     SolverState(ConstraintSystem &cs);
@@ -1121,6 +1141,9 @@ public:
 
     /// The length of \c OpenedExistentialTypes.
     unsigned numOpenedExistentialTypes;
+
+    /// The length of \c DefaultedTypeVariables.
+    unsigned numDefaultedTypeVariables;
 
     /// The previous score.
     Score PreviousScore;

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2634,6 +2634,15 @@ void Solution::dump(raw_ostream &out) const {
     }
   }
 
+  if (!DefaultedTypeVariables.empty()) {
+    out << "\nDefaulted type variables: ";
+    interleave(DefaultedTypeVariables, [&](TypeVariableType *typeVar) {
+      out << "$T" << typeVar->getID();
+    }, [&] {
+      out << ", ";
+    });
+  }
+
   if (!Fixes.empty()) {
     out << "\nFixes:\n";
     for (auto &fix : Fixes) {
@@ -2781,6 +2790,15 @@ void ConstraintSystem::print(raw_ostream &out) {
       out << " opens to " << openedExistential.second->getString();
       out << "\n";
     }
+  }
+
+  if (!DefaultedTypeVariables.empty()) {
+    out << "\nDefaulted type variables: ";
+    interleave(DefaultedTypeVariables, [&](TypeVariableType *typeVar) {
+      out << "$T" << typeVar->getID();
+    }, [&] {
+      out << ", ";
+    });
   }
 
   if (failedConstraint) {

--- a/test/Constraints/array_literal.swift
+++ b/test/Constraints/array_literal.swift
@@ -115,3 +115,31 @@ func rdar25563498_ok<T : ExpressibleByArrayLiteral>(t: T) -> T
   let x: T = [1]
   return x
 }
+
+class A { }
+class B : A { }
+class C : A { }
+
+/// Check for defaulting the element type to 'Any'.
+func defaultToAny(i: Int, s: String) {
+  let a1 = [1, "a", 3.5]
+  // expected-error@-1{{heterogenous collection literal could only be inferred to '[Any]'; add explicit type annotation if this is intentional}}
+  let _: Int = a1  // expected-error{{value of type '[Any]'}}
+
+  let a2: Array = [1, "a", 3.5]
+  // expected-error@-1{{heterogenous collection literal could only be inferred to '[Any]'; add explicit type annotation if this is intentional}}
+
+  let _: Int = a2  // expected-error{{value of type '[Any]'}}
+
+  let a3 = []
+  // expected-error@-1{{empty collection literal requires an explicit type}}
+
+  let _: Int = a3 // expected-error{{value of type '[Any]'}}
+
+  let _: [Any] = [1, "a", 3.5]
+  let _: [Any] = [1, "a", [3.5, 3.7, 3.9]]
+  let _: [Any] = [1, "a", [3.5, "b", 3]]
+
+  let a4 = [B(), C()]
+  let _: Int = a4 // expected-error{{value of type '[A]'}}
+}

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -264,7 +264,7 @@ func rdar19831698() {
 // expected-note@-1{{overloads for '+'}}
   var v72 = true + true // expected-error{{binary operator '+' cannot be applied to two 'Bool' operands}}
   // expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists:}}
-  var v73 = true + [] // expected-error{{binary operator '+' cannot be applied to operands of type 'Bool' and '[_]'}}
+  var v73 = true + [] // expected-error{{binary operator '+' cannot be applied to operands of type 'Bool' and '[Any]'}}
   // expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists:}}
   var v75 = true + "str" // expected-error {{binary operator '+' cannot be applied to operands of type 'Bool' and 'String'}} expected-note {{expected an argument list of type '(String, String)'}}
 }

--- a/test/Constraints/dictionary_literal.swift
+++ b/test/Constraints/dictionary_literal.swift
@@ -62,3 +62,27 @@ var _: Dictionary<String, Int>? = ["foo" : 1.0]  // expected-error {{cannot conv
 // <rdar://problem/24058895> QoI: Should handle [] in dictionary contexts better
 var _: [Int: Int] = []  // expected-error {{use [:] to get an empty dictionary literal}} {{22-22=:}}
 
+
+class A { }
+class B : A { }
+class C : A { }
+
+func testDefaultExistentials() {
+  let _ = ["a" : 1, "b" : 2.5, "c" : "hello"]
+  // expected-error@-1{{heterogenous collection literal could only be inferred to 'Dictionary<String, Any>'; add explicit type annotation if this is intentional}}{{46-46= as Dictionary<String, Any>}}
+
+  let _: [String : Any] = ["a" : 1, "b" : 2.5, "c" : "hello"]
+
+  let d2 = [:]
+  // expected-error@-1{{empty collection literal requires an explicit type}}
+
+  let _: Int = d2 // expected-error{{value of type 'Dictionary<AnyHashable, Any>'}}
+
+  let _ = ["a" : 1, 
+            "b" : [ "a", 2, 3.14159 ],
+            "c" : [ "a" : 2, "b" : 3.5] ]
+  // expected-error@-3{{heterogenous collection literal could only be inferred to 'Dictionary<String, Any>'; add explicit type annotation if this is intentional}}
+
+  let d3 = ["b" : B(), "c" : C()]
+  let _: Int = d3 // expected-error{{value of type 'Dictionary<String, A>'}}
+}

--- a/test/Constraints/subscript.swift
+++ b/test/Constraints/subscript.swift
@@ -70,9 +70,7 @@ extension Int {
 
 let _ = 1["1"]  // expected-error {{ambiguous use of 'subscript'}}
 
-
-// rdar://17687826 - QoI: error message when reducing to an untyped dictionary isn't helpful
-let squares = [ 1, 2, 3 ].reduce([:]) { (dict, n) in // expected-error {{unable to infer complex closure return type; add explicit type to disambiguate}} {{51-51=-> [_ : _] }}
+let squares = [ 1, 2, 3 ].reduce([:]) { (dict, n) in
   var dict = dict
   dict[n] = n * n
   return dict

--- a/test/IDE/complete_at_top_level.swift
+++ b/test/IDE/complete_at_top_level.swift
@@ -349,7 +349,7 @@ func resyncParserB6() {}
 for i in [] {
   #^TOP_LEVEL_STMT_6^#
 // TOP_LEVEL_STMT_6: Begin completions
-// TOP_LEVEL_STMT_6: Decl[LocalVar]/Local: i[#<<error type>>#]{{; name=.+$}}
+// TOP_LEVEL_STMT_6: Decl[LocalVar]/Local: i[#Any#]{{; name=.+$}}
 // TOP_LEVEL_STMT_6: End completions
 }
 

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -675,15 +675,15 @@ func unusedExpressionResults() {
 //===----------------------------------------------------------------------===//
 
 func arrayLiterals() { 
-  var a = [1,2,3]
-  var b : [Int] = []
-  var c = []  // expected-error {{cannot infer type for empty collection literal without a contextual type}}
+  let _ = [1,2,3]
+  let _ : [Int] = []
+  let _ = []  // expected-error {{empty collection literal requires an explicit type}}
 }
 
 func dictionaryLiterals() {
-  var a = [1 : "foo",2 : "bar",3 : "baz"]
-  var b : Dictionary<Int, String> = [:]
-  var c = [:]  // expected-error {{cannot infer type for empty collection literal without a contextual type}}
+  let _ = [1 : "foo",2 : "bar",3 : "baz"]
+  let _: Dictionary<Int, String> = [:]
+  let _ = [:]  // expected-error {{empty collection literal requires an explicit type}}
 }
 
 func invalidDictionaryLiteral() {


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

This pull request implements a defaulting rule for the elements of array and dictionary literals.     

The id-as-Any work regressed cases where Swift code could specify heterogeneous collection literals, e.g.,

```
    var states: [String: Any] = [
      "California": [
        "population": 37_000_000,
        "cities": ["Los Angeles", "San Diego", "San Jose"],
      ],
      "Oregon": [
        "population": 4_000_000,
        "cities": ["Portland", "Salem", "Eugene"],
      ]
    ]
```

Prior to this, the code worked (when Foundation was imported) because we'd end up with literals of type `[NSObject : AnyObject]`.

The new defaulting rule says that the element type of an array literal and the key/value types of a dictionary literal can be defaulted if no stronger type can be inferred. The default type is:
- `Any`, for the element type of an array literal or the value type of a dictionary literal, or
- `AnyHashable`, for the key type of a dictionary literal.

The latter is intended to compose with implicit conversions to `AnyHashable`, so the most-general inferred dictionary type is `[AnyHashable : Any]` and will work for any plausible dictionary literal.

To prevent this inference from diluting types too greatly, we don't allow this inference in "top-level" expressions, e.g.,

```
  let d = ["a" : 1, "b" : "two"]
```

will produce an error because it's a heterogeneous dictionary literal at the top level. One should annotate this with, e.g.,

```
  let d = ["a" : 1, "b" : "two"] as [String : Any]
```

However, we do permit heterogeneous collections in nested positions, to support cases like the original motivating example.
#### Resolved bug number: ([rdar://problem/27661580](rdar://problem/27661580))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…d 'AnyHashable' for dictionary keys.

The id-as-Any work regressed cases where Swift code could specify
heterogeneous collection literals, e.g.,

```
var states: [String: Any] = [
  "California": [
    "population": 37_000_000,
    "cities": ["Los Angeles", "San Diego", "San Jose"],
  ],
  "Oregon": [
    "population": 4_000_000,
    "cities": ["Portland", "Salem", "Eugene"],
  ]
]
```

Prior to this, the code worked (when Foundation was imported) because
we'd end up with literals of type [NSObject : AnyObject].

The new defaulting rule says that the element type of an array literal
and the key/value types of a dictionary literal can be defaulted if no
stronger type can be inferred. The default type is:

  Any, for the element type of an array literal or the value type of a
  dictionary literal, or

  AnyHashable, for the key type of a dictionary literal.

The latter is intended to compose with implicit conversions to
AnyHashable, so the most-general inferred dictionary type is
[AnyHashable : Any] and will work for any plausible dictionary
literal.

To prevent this inference from diluting types too greatly, we don't
allow this inference in "top-level" expressions, e.g.,

  let d = ["a" : 1, "b" : "two"]

will produce an error because it's a heterogeneous dictionary literal
at the top level. One should annotate this with, e.g.,

  let d = ["a" : 1, "b" : "two"] as [String : Any]

However, we do permit heterogeneous collections in nested positions,
to support cases like the original motivating example.

Fixes rdar://problem/27661580.
