### PR TITLE
[Serialization] Fix deserialization crash occurring when a mixed framework fails to load its ObjC part.

### DIFF
--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1093,7 +1093,7 @@ Status ModuleFile::associateWithFileContext(FileUnit *file,
              "invalid module name (submodules not yet supported)");
     }
     auto module = getModule(modulePath);
-    if (!module) {
+    if (!module || module->failedToLoad()) {
       // If we're missing the module we're shadowing, treat that specially.
       if (modulePath.size() == 1 &&
           modulePath.front() == file->getParentModule()->getName()) {

--- a/test/Serialization/Inputs/MixModA.modulemap
+++ b/test/Serialization/Inputs/MixModA.modulemap
@@ -1,0 +1,8 @@
+framework module MixModA {
+  export *
+  module * { export * }
+}
+
+module MixModA.Swift {
+    header "MixModA-Swift.h"
+}

--- a/test/Serialization/Inputs/SwiftModA.swift
+++ b/test/Serialization/Inputs/SwiftModA.swift
@@ -1,0 +1,5 @@
+import ObjCFail
+
+open class SwiftClsA {
+  public init() {}
+}

--- a/test/Serialization/Inputs/SwiftModB.swift
+++ b/test/Serialization/Inputs/SwiftModB.swift
@@ -1,0 +1,5 @@
+import MixModA
+
+open class TyB : SwiftClsA {
+  public override init() { super.init() }
+}

--- a/test/Serialization/Inputs/objcfail/module.modulemap
+++ b/test/Serialization/Inputs/objcfail/module.modulemap
@@ -1,0 +1,3 @@
+module ObjCFail {
+  header "objcfail.h"
+}

--- a/test/Serialization/Inputs/objcfail/objcfail.h
+++ b/test/Serialization/Inputs/objcfail/objcfail.h
@@ -1,0 +1,3 @@
+#ifdef FAIL
+#error failing clang module
+#endif

--- a/test/Serialization/failed-clang-module.swift
+++ b/test/Serialization/failed-clang-module.swift
@@ -1,0 +1,19 @@
+// Test that there is no crash in such a case:
+// - there is mixed framework A
+// - swift module B depends on A and is built fine
+// - there is a swift invocation that imports B but causes the ObjC part of A to fail to import
+
+
+// RUN: rm -rf %t
+// RUN: mkdir -p %t/MixModA.framework/Headers
+// RUN: mkdir -p %t/MixModA.framework/Modules/MixModA.swiftmodule
+// RUN: cp %S/Inputs/MixModA.modulemap %t/MixModA.framework/Modules/module.modulemap
+
+// RUN: %target-swift-frontend -emit-module %S/Inputs/SwiftModA.swift -module-name MixModA -I %S/Inputs/objcfail -o %t/MixModA.framework/Modules/MixModA.swiftmodule/x86_64.swiftmodule -emit-objc-header -emit-objc-header-path %t/MixModA.framework/Headers/MixModA-Swift.h -module-cache-path %t/mcp
+// RUN: %target-swift-frontend -emit-module %S/Inputs/SwiftModB.swift -module-name SwiftModB -F %t -o %t -module-cache-path %t/mcp
+
+// RUN: %target-swift-frontend -parse %s -I %t -module-cache-path %t/mcp
+// RUN: %target-swift-frontend -parse %s -Xcc -DFAIL -I %t -module-cache-path %t/mcp -show-diagnostics-after-fatal -verify
+
+import SwiftModB // expected-error {{missing required module}}
+_ = TyB() // expected-error {{use of unresolved identifier 'TyB'}}


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->

Fixes crash with a case such as:
- there is mixed framework A
- swift module B depends on A and is built fine
- there is a swift invocation that imports B but causes the ObjC part of A to fail to import
- trying to serialize decls of B that depend on A will crash
  <!-- Description about pull request. -->

rdar://27709042

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
