### PR TITLE
[Constraint solver] Introduce a *trivial* 'meet' operation for types.

### DIFF
--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -183,7 +183,30 @@ public:
 
   /// Get the canonical type, or return null if the type is null.
   CanType getCanonicalTypeOrNull() const; // in Types.h
-  
+
+  /// Computes the meet between two types.
+  ///
+  /// The meet of two types is the most specific type that is a supertype of
+  /// both \c type1 and \c type2. For example, given a simple class hierarchy as
+  /// follows:
+  ///
+  /// \code
+  /// class A { }
+  /// class B : A { }
+  /// class C : A { }
+  /// class D { }
+  /// \endcode
+  ///
+  /// The meet of B and C is A, the meet of A and B is A. However, there is no
+  /// meet of D and A (or D and B, or D and C) because there is no common
+  /// superclass. One would have to jump to an existential (e.g., \c AnyObject)
+  /// to find a common type.
+  /// 
+  /// \returns the meet of the two types, if there is a concrete type that can
+  /// express the meet, or \c None of the only meet would be a more-general
+  /// existential type (e.g., \c Any).
+  static Optional<Type> meet(Type type1, Type type2);
+
 private:
   // Direct comparison is disabled for types, because they may not be canonical.
   void operator==(Type T) const = delete;
@@ -432,6 +455,7 @@ public:
     return Signature;
   }
 };
+
 } // end namespace swift
 
 namespace llvm {

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -38,6 +38,7 @@ add_swift_library(swiftAST STATIC
   SourceEntityWalker.cpp
   Substitution.cpp
   Type.cpp
+  TypeJoinMeet.cpp
   TypeRefinementContext.cpp
   TypeRepr.cpp
   TypeWalker.cpp

--- a/lib/AST/TypeJoinMeet.cpp
+++ b/lib/AST/TypeJoinMeet.cpp
@@ -1,0 +1,70 @@
+//===--- TypeJoinMeet.cpp - Swift Type "Join" and "Meet"  -----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements the "meet" operation for types (and, eventually,
+//  "join").
+//
+//===----------------------------------------------------------------------===//
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/Type.h"
+#include "swift/AST/Types.h"
+#include "llvm/ADT/SmallPtrSet.h"
+using namespace swift;
+
+Optional<Type> Type::meet(Type type1, Type type2) {
+  assert(!type1->hasTypeVariable() && !type2->hasTypeVariable() &&
+         "Cannot compute meet of types involving type variables");
+
+  // FIXME: This algorithm is woefully incomplete, and is only currently used
+  // for optimizing away extra exploratory work in the constraint solver. It
+  // should eventually encompass all of the subtyping rules of the language.
+
+  // If the types are equivalent, the meet is obvious.
+  if (type1->isEqual(type2))
+    return type1;
+
+  // If both are class types or opaque types that potentially have superclasses,
+  // find the common superclass.
+  if (type1->mayHaveSuperclass() && type2->mayHaveSuperclass()) {
+    ASTContext &ctx = type1->getASTContext();
+    LazyResolver *resolver = ctx.getLazyResolver();
+
+    /// Walk the superclasses of type1 looking for type2. Record them for our
+    /// second step.
+    llvm::SmallPtrSet<CanType, 8> superclassesOfType1;
+    CanType canType2 = type2->getCanonicalType();
+    for (Type super1 = type1; super1; super1 = super1->getSuperclass(resolver)){
+      CanType canSuper1 = super1->getCanonicalType();
+
+      // If we have found the second type, we're done.
+      if (canSuper1 == canType2) return super1;
+
+      superclassesOfType1.insert(canSuper1);
+    }
+
+    // Look through the superclasses of type2 to determine if any were also
+    // superclasses of type1.
+    for (Type super2 = type2; super2; super2 = super2->getSuperclass(resolver)){
+      CanType canSuper2 = super2->getCanonicalType();
+
+      // If we found the first type, we're done.
+      if (superclassesOfType1.count(canSuper2)) return super2;
+    }
+
+    // There is no common superclass; we're done.
+    return None;
+  }
+
+  // The meet can only be an existential.
+  return None;
+}
+


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

This introduces a trivial meet operation for types that can be used to reduce the number of type variable bindings we consider in simple cases. See the commit to get an understanding of just how trivial and simplistic this is :)
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Stub out a simplistic 'meet' operation for types that currently only
handles finding the meet of two class types. Use it to optimize the
constraint solver ever so slightly: when we see a type variable whose
constraints state that it is a supertype of two different concrete
types, we attempt to compute their meet and, if we find it, only
produce one potential binding that is the meet itself.

Note that this is an extremely poor implementation of this concept
that is meant to address a specific regression being introduced by the
defaulting of collection literal element types. A real implementation
would, at the very least:
- Implement a proper 'meet' that covers all subtyping in the language.
- Distinguish between "I don't know if there is a meet" and "I am
  absolutely certain that there is no meet".
- Collapse the constraints themselves to reduce the number of
  constraints in the system, rather than just the number of type
  variable bindings we attempt.
