### PR TITLE
Force LLVM to preserve value names

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -197,6 +197,18 @@ public:
     Hash = (Hash << 1) | DisableLLVMARCOpts;
     return Hash;
   }
+
+  /// Should LLVM IR value names be emitted and preserved?
+  bool shouldProvideValueNames() const {
+    // If the command line contains an explicit request about whether to add
+    // LLVM value names, honor it.  Otherwise, add value names only if the
+    // final result is textual LLVM assembly.
+    if (HasValueNamesSetting) {
+      return ValueNames;
+    } else {
+      return OutputKind == IRGenOutputKind::LLVMAssembly;
+    }
+  }
 };
 
 } // end namespace swift

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -85,6 +85,7 @@ static clang::CodeGenerator *createClangCodeGenerator(ASTContext &Context,
   auto &CGO = Importer->getClangCodeGenOpts();
   CGO.OptimizationLevel = Opts.Optimize ? 3 : 0;
   CGO.DisableFPElim = Opts.DisableFPElim;
+  CGO.DiscardValueNames = !Opts.shouldProvideValueNames();
   switch (Opts.DebugInfoKind) {
   case IRGenDebugInfoKind::None:
     CGO.setDebugInfo(clang::codegenoptions::DebugInfoKind::NoDebugInfo);
@@ -140,14 +141,7 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
 
   auto &opts = irgen.Opts;
 
-  // If the command line contains an explicit request about whether to add
-  // LLVM value names, honor it.  Otherwise, add value names only if the
-  // final result is textual LLVM assembly.
-  if (opts.HasValueNamesSetting) {
-    EnableValueNames = opts.ValueNames;
-  } else {
-    EnableValueNames = (opts.OutputKind == IRGenOutputKind::LLVMAssembly);
-  }
+  EnableValueNames = opts.shouldProvideValueNames();
   
   VoidTy = llvm::Type::getVoidTy(getLLVMContext());
   Int1Ty = llvm::Type::getInt1Ty(getLLVMContext());


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### Resolves rdar://25421818

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Force LLVM to preserve value names in the same situations where
we emit them in the first place.

Fixes IRGen test failures that only arise in non-asserts builds that
we've apparently been working around in less principled ways for
the last few months.
