### PR TITLE
[test] Fix test failure on non-x86_64 targets in failed-clang-module test case.

### DIFF
--- a/test/Serialization/failed-clang-module.swift
+++ b/test/Serialization/failed-clang-module.swift
@@ -9,11 +9,13 @@
 // RUN: mkdir -p %t/MixModA.framework/Modules/MixModA.swiftmodule
 // RUN: cp %S/Inputs/MixModA.modulemap %t/MixModA.framework/Modules/module.modulemap
 
-// RUN: %target-swift-frontend -emit-module %S/Inputs/SwiftModA.swift -module-name MixModA -I %S/Inputs/objcfail -o %t/MixModA.framework/Modules/MixModA.swiftmodule/x86_64.swiftmodule -emit-objc-header -emit-objc-header-path %t/MixModA.framework/Headers/MixModA-Swift.h -module-cache-path %t/mcp
+// RUN: %target-swift-frontend -emit-module %S/Inputs/SwiftModA.swift -module-name MixModA -I %S/Inputs/objcfail -o %t/MixModA.framework/Modules/MixModA.swiftmodule/%target-swiftmodule-name -emit-objc-header -emit-objc-header-path %t/MixModA.framework/Headers/MixModA-Swift.h -module-cache-path %t/mcp
 // RUN: %target-swift-frontend -emit-module %S/Inputs/SwiftModB.swift -module-name SwiftModB -F %t -o %t -module-cache-path %t/mcp
 
 // RUN: %target-swift-frontend -parse %s -I %t -module-cache-path %t/mcp
 // RUN: %target-swift-frontend -parse %s -Xcc -DFAIL -I %t -module-cache-path %t/mcp -show-diagnostics-after-fatal -verify
+
+// XFAIL: linux
 
 import SwiftModB // expected-error {{missing required module}}
 _ = TyB() // expected-error {{use of unresolved identifier 'TyB'}}


### PR DESCRIPTION
#### What's in this pull request?

~~Use `%target-cpu` instead of `x86_64` in lit `RUN:` script~~
Use `%target-swiftmodule-name` instead of `x86_64.swiftmodule` in lit `RUN:` script

Fixes:

```
FAIL: Swift(iphonesimulator-i386) :: Serialization/failed-clang-module.swift (1 of 1)
******************** TEST 'Swift(iphonesimulator-i386) :: Serialization/failed-clang-module.swift' FAILED ********************
...
--
/Users/buildnode/jenkins/workspace/swift-PR-osx/buildbot_incremental/swift-macosx-x86_64/test-iphonesimulator-i386/Serialization/Output/failed-clang-module.swift.tmp/MixModA.framework/Modules/module.modulemap:3:10: error: inferred submodules require a module with an umbrella
  module * { export * }
         ^
/Users/buildnode/jenkins/workspace/swift-PR-osx/buildbot_incremental/swift-macosx-x86_64/test-iphonesimulator-i386/Serialization/Output/failed-clang-module.swift.tmp/MixModA.framework/Modules/module.modulemap:3:10: error: inferred submodules require a module with an umbrella
  module * { export * }
         ^
/Users/buildnode/jenkins/workspace/swift-PR-osx/swift/test/Serialization/Inputs/SwiftModB.swift:1:8: error: could not build Objective-C module 'MixModA'
import MixModA
       ^
```

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
