### PR TITLE
Use function signatures for SILDeclRefs in witness_tables, vtables and witness_method instructions

### DIFF
--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -293,6 +293,7 @@ namespace {
       SmallVector<ValueDecl *, 4> values;
       return parseSILDeclRef(Result, values);
     }
+    bool parseSILDeclRef(SILDeclRef &Member, bool FnTypeRequired);
     bool parseGlobalName(Identifier &Name);
     bool parseValueName(UnresolvedValueName &Name);
     bool parseValueRef(SILValue &Result, SILType Ty, SILLocation Loc,
@@ -1620,6 +1621,76 @@ static bool parseStoreOwnershipQualifier(StoreOwnershipQualifier &Result,
 
   // Otherwise, assign Result and return false.
   Result = Tmp;
+  return false;
+}
+
+bool SILParser::parseSILDeclRef(SILDeclRef &Member, bool FnTypeRequired) {
+  SourceLoc TyLoc;
+  SmallVector<ValueDecl *, 4> values;
+  if (parseSILDeclRef(Member, values))
+    return true;
+
+  // : ( or : < means that what follows is function type.
+  if (!P.Tok.is(tok::colon))
+    return false;
+
+  if (FnTypeRequired &&
+      !P.peekToken().is(tok::l_paren) &&
+      !P.peekToken().isContextualPunctuator("<"))
+    return false;
+
+  // Type of the SILDeclRef is optional, to be compatible with the old format.
+  if (!P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":")) {
+    // Parse the type for SILDeclRef.
+    Optional<Scope> GenericsScope;
+    GenericsScope.emplace(&P, ScopeKind::Generics);
+    ParserResult<TypeRepr> TyR = P.parseType();
+    GenericsScope.reset();
+    if (TyR.isNull())
+      return true;
+    TypeLoc Ty = TyR.get();
+
+    // The type can be polymorphic.
+    GenericEnvironment *genericEnv = nullptr;
+    if (auto fnType = dyn_cast<FunctionTypeRepr>(TyR.get())) {
+      if (auto generics = fnType->getGenericParams()) {
+        assert(!Ty.wasValidated() && Ty.getType().isNull());
+
+        genericEnv = handleSILGenericParams(P.Context, generics, &P.SF);
+        fnType->setGenericEnvironment(genericEnv);
+      }
+    }
+
+    if (performTypeLocChecking(Ty, /*isSILType=*/ false, genericEnv))
+      return true;
+
+    // Pick the ValueDecl that has the right type.
+    ValueDecl *TheDecl = nullptr;
+    auto declTy = Ty.getType()->getCanonicalType();
+    auto unlabeledDecl =
+        declTy->getUnlabeledType(P.Context)->getCanonicalType();
+    for (unsigned I = 0, E = values.size(); I < E; I++) {
+      auto *VD = values[I];
+      auto lookupTy = values[I]->getInterfaceType();
+      auto unlabeledLookup =
+          lookupTy->getUnlabeledType(P.Context)->getCanonicalType();
+      if (unlabeledDecl == unlabeledLookup) {
+        TheDecl = values[I];
+        // Update SILDeclRef to point to the right Decl.
+        Member.loc = TheDecl;
+        break;
+      }
+      if (values.size() == 1 && !TheDecl) {
+        P.diagnose(TyLoc, diag::sil_member_decl_type_mismatch, declTy,
+                   lookupTy);
+        return true;
+      }
+    }
+    if (!TheDecl) {
+      P.diagnose(TyLoc, diag::sil_member_decl_not_found);
+      return true;
+    }
+  }
   return false;
 }
 
@@ -3044,64 +3115,16 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
     SourceLoc TyLoc;
     SmallVector<ValueDecl *, 4> values;
     if (parseTypedValueRef(Val, B) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseSILDeclRef(Member, values) ||
-        P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":"))
+        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ","))
       return true;
 
-    // Parse the type for SILDeclRef.
-    Optional<Scope> GenericsScope;
-    GenericsScope.emplace(&P, ScopeKind::Generics);
-    ParserResult<TypeRepr> TyR = P.parseType();
-    GenericsScope.reset();
-    if (TyR.isNull())
-      return true;
-    TypeLoc Ty = TyR.get();
-
-    // The type can be polymorphic.
-    GenericEnvironment *genericEnv = nullptr;
-    if (auto fnType = dyn_cast<FunctionTypeRepr>(TyR.get())) {
-      if (auto generics = fnType->getGenericParams()) {
-        assert(!Ty.wasValidated() && Ty.getType().isNull());
-
-        genericEnv = handleSILGenericParams(P.Context, generics, &P.SF);
-        fnType->setGenericEnvironment(genericEnv);
-      }
-    }
-
-    if (performTypeLocChecking(Ty, /*IsSILType=*/ false, genericEnv))
+    if (parseSILDeclRef(Member, true))
       return true;
 
     if (P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
         parseSILType(MethodTy, TyLoc) ||
         parseSILDebugLocation(InstLoc, B))
       return true;
-    
-    // Pick the ValueDecl that has the right type.
-    ValueDecl *TheDecl = nullptr;
-    auto declTy = Ty.getType()->getCanonicalType();
-    auto unlabeledDecl =
-      declTy->getUnlabeledType(P.Context)->getCanonicalType();
-    for (unsigned I = 0, E = values.size(); I < E; I++) {
-      auto lookupTy = values[I]->getInterfaceType();
-      auto unlabeledLookup =
-        lookupTy->getUnlabeledType(P.Context)->getCanonicalType();
-      if (unlabeledDecl == unlabeledLookup) {
-        TheDecl = values[I];
-        // Update SILDeclRef to point to the right Decl.
-        Member.loc = TheDecl;
-        break;
-      }
-      if (values.size() == 1 && !TheDecl) {
-        P.diagnose(TyLoc, diag::sil_member_decl_type_mismatch, declTy,
-                   lookupTy);
-        return true;
-      }
-    }
-    if (!TheDecl) {
-      P.diagnose(TyLoc, diag::sil_member_decl_not_found);
-      return true;
-    }
 
     switch (Opcode) {
     default: llvm_unreachable("Out of sync with parent switch");
@@ -3130,8 +3153,9 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
     SourceLoc TyLoc;
     if (P.parseToken(tok::sil_dollar, diag::expected_tok_in_sil_instr, "$") ||
         parseASTType(LookupTy) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseSILDeclRef(Member))
+        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ","))
+      return true;
+    if (parseSILDeclRef(Member, true))
       return true;
     // Optional operand.
     SILValue Operand;
@@ -4419,7 +4443,7 @@ bool Parser::parseSILVTable() {
       SILDeclRef Ref;
       Identifier FuncName;
       SourceLoc FuncLoc;
-      if (VTableState.parseSILDeclRef(Ref))
+      if (VTableState.parseSILDeclRef(Ref, true))
         return true;
       SILFunction *Func = nullptr;
       Optional<SILLinkage> Linkage = SILLinkage::Private;
@@ -4796,7 +4820,7 @@ bool Parser::parseSILWitnessTable() {
       SILDeclRef Ref;
       Identifier FuncName;
       SourceLoc FuncLoc;
-      if (WitnessState.parseSILDeclRef(Ref) ||
+      if (WitnessState.parseSILDeclRef(Ref, true) ||
           parseToken(tok::colon, diag::expected_sil_witness_colon))
         return true;
       
@@ -4891,7 +4915,7 @@ bool Parser::parseSILDefaultWitnessTable() {
       SILDeclRef Ref;
       Identifier FuncName;
       SourceLoc FuncLoc;
-      if (WitnessState.parseSILDeclRef(Ref) ||
+      if (WitnessState.parseSILDeclRef(Ref, true) ||
           parseToken(tok::colon, diag::expected_sil_witness_colon))
         return true;
       

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1447,19 +1447,20 @@ public:
   void visitClassMethodInst(ClassMethodInst *AMI) {
     printMethodInst(AMI, AMI->getOperand());
     *this << " : " << AMI->getMember().getDecl()->getInterfaceType();
-    *this << " , ";
+    *this << ", ";
     *this << AMI->getType();
   }
   void visitSuperMethodInst(SuperMethodInst *AMI) {
     printMethodInst(AMI, AMI->getOperand());
     *this << " : " << AMI->getMember().getDecl()->getInterfaceType();
-    *this << " , ";
+    *this << ", ";
     *this << AMI->getType();
   }
   void visitWitnessMethodInst(WitnessMethodInst *WMI) {
     if (WMI->isVolatile())
       *this << "[volatile] ";
-    *this << "$" << WMI->getLookupType() << ", " << WMI->getMember();
+    *this << "$" << WMI->getLookupType() << ", " << WMI->getMember() 
+          << " : " << WMI->getMember().getDecl()->getInterfaceType();
     if (!WMI->getTypeDependentOperands().empty()) {
       *this << ", ";
       *this << getIDAndType(WMI->getTypeDependentOperands()[0].get());
@@ -2185,7 +2186,8 @@ void SILVTable::print(llvm::raw_ostream &OS, bool Verbose) const {
   for (auto &entry : getEntries()) {
     OS << "  ";
     entry.Method.print(OS);
-    OS << ": ";
+    OS << ": " << entry.Method.getDecl()->getInterfaceType();
+    OS << " : ";
     if (entry.Linkage !=
         stripExternalFromLinkage(entry.Implementation->getLinkage())) {
       OS << getLinkageString(entry.Linkage);
@@ -2226,7 +2228,8 @@ void SILWitnessTable::print(llvm::raw_ostream &OS, bool Verbose) const {
       auto &methodWitness = witness.getMethodWitness();
       OS << "method ";
       methodWitness.Requirement.print(OS);
-      OS << ": ";
+      OS << ": " << methodWitness.Requirement.getDecl()->getInterfaceType();
+      OS << " : ";
       if (methodWitness.Witness) {
         methodWitness.Witness->printName(OS);
         OS << "\t// "
@@ -2297,7 +2300,8 @@ void SILDefaultWitnessTable::print(llvm::raw_ostream &OS, bool Verbose) const {
     // method #declref: @function
     OS << "  method ";
     witness.getRequirement().print(OS);
-    OS << ": ";
+    OS << ": " << witness.getRequirement().getDecl()->getInterfaceType();
+    OS << " : ";
     witness.getWitness()->printName(OS);
     OS << "\t// "
        << demangleSymbolAsString(witness.getWitness()->getName());

--- a/test/IRGen/dynamic_init.sil
+++ b/test/IRGen/dynamic_init.sil
@@ -24,7 +24,7 @@ bb0(%0 : $@thick C.Type):
   // CHECK:   [[CTOR:%[0-9]+]] = load %C12dynamic_init1C* (%swift.type*)*, %C12dynamic_init1C* (%swift.type*)** [[VTABLE_OFFSET]], align 8
   // CHECK:   [[CTOR_I8:%[0-9]+]] = bitcast %C12dynamic_init1C* (%swift.type*)* [[CTOR]] to i8*
   // CHECK:   [[CTOR_FN:%[0-9]+]] = bitcast i8* [[CTOR_I8]] to %C12dynamic_init1C* (%swift.type*)*
-  %2 = class_method %0 : $@thick C.Type, #C.init!allocator.1 : (C.Type) -> () -> C , $@convention(method) (@thick C.Type) -> @owned C
+  %2 = class_method %0 : $@thick C.Type, #C.init!allocator.1 : (C.Type) -> () -> C, $@convention(method) (@thick C.Type) -> @owned C
   // CHECK:   [[RESULT:%[0-9]+]] = call %C12dynamic_init1C* [[CTOR_FN]](%swift.type* %0)
   %3 = apply %2(%0) : $@convention(method) (@thick C.Type) -> @owned C
   // CHECK:   call void bitcast (void (%swift.refcounted*)* @swift_rt_swift_release to void (%C12dynamic_init1C*)*)(%C12dynamic_init1C* [[RESULT]])

--- a/test/IRGen/exactcast2.sil
+++ b/test/IRGen/exactcast2.sil
@@ -26,7 +26,7 @@ sil @_TFC4main4HashCfMS0_FT_S0_ : $@convention(thin) (@thick Hash.Type) -> @owne
 
 sil @_TFC4main4Hash6updatefS0_FT_T_ : $@convention(method) (@guaranteed Hash) -> () {
 bb0(%0 : $Hash):
-  %1 = class_method %0 : $Hash, #Hash.hash!1 : (Hash) -> () -> () , $@convention(method) (@guaranteed Hash) -> () // user: %9
+  %1 = class_method %0 : $Hash, #Hash.hash!1 : (Hash) -> () -> (), $@convention(method) (@guaranteed Hash) -> () // user: %9
   checked_cast_br [exact] %0 : $Hash to $MD5, bb2, bb3 // id: %2
 
 bb1:                                              // Preds: bb2 bb3

--- a/test/IRGen/objc_factory_method.sil
+++ b/test/IRGen/objc_factory_method.sil
@@ -22,7 +22,7 @@ sil @_TFCSo4HiveCfMS_FT5queenGSQCSo3Bee__S_ : $@convention(thin) (@owned Optiona
 bb0(%0 : $Optional<Bee>, %1 : $@thick Hive.Type):
   %2 = thick_to_objc_metatype %1 : $@thick Hive.Type to $@objc_metatype Hive.Type // users: %3, %4
   // CHECK: load i8*, i8** @"\01L_selector(hiveWithQueen:)"
-  %3 = class_method %2 : $@objc_metatype Hive.Type, #Hive.init!allocator.1.foreign : (Hive.Type) -> (ImplicitlyUnwrappedOptional<Bee>) -> Hive! , $@convention(objc_method) (Optional<Bee>, @objc_metatype Hive.Type) -> @autoreleased Optional<Hive> // user: %4
+  %3 = class_method %2 : $@objc_metatype Hive.Type, #Hive.init!allocator.1.foreign : (Hive.Type) -> (ImplicitlyUnwrappedOptional<Bee>) -> Hive!, $@convention(objc_method) (Optional<Bee>, @objc_metatype Hive.Type) -> @autoreleased Optional<Hive> // user: %4
   // CHECK: call {{.*}} @objc_msgSend
   %4 = apply %3(%0, %2) : $@convention(objc_method) (Optional<Bee>, @objc_metatype Hive.Type) -> @autoreleased Optional<Hive> // users: %5, %6
   // CHECK: call {{.*}} @objc_autorelease

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -108,7 +108,7 @@ entry(%f : $@callee_owned (Builtin.Word) -> (), %x : $Builtin.Word):
 
 sil @objc_partial_apply : $@convention(thin) ObjCClass -> @callee_owned Int -> () {
 entry(%c : $ObjCClass):
-  %m = class_method [volatile] %c : $ObjCClass, #ObjCClass.method!1.foreign : (ObjCClass) -> (Int) -> () , $@convention(objc_method) (Int, ObjCClass) -> ()
+  %m = class_method [volatile] %c : $ObjCClass, #ObjCClass.method!1.foreign : (ObjCClass) -> (Int) -> (), $@convention(objc_method) (Int, ObjCClass) -> ()
   %p = partial_apply %m(%c) : $@convention(objc_method) (Int, ObjCClass) -> ()
   return %p : $@callee_owned Int -> ()
 }
@@ -129,7 +129,7 @@ entry(%c : $ObjCClass):
 // CHECK:  [[VAL:%.*]] = load double, double* [[ORIGINXVAL]]
 sil @objc_partial_apply_indirect_sil_argument : $@convention(thin) ObjCClass -> @callee_owned NSRect -> () {
 entry(%c : $ObjCClass):
-  %m = class_method [volatile] %c : $ObjCClass, #ObjCClass.method2!1.foreign : (ObjCClass) -> (NSRect) -> () , $@convention(objc_method) (NSRect, ObjCClass) -> ()
+  %m = class_method [volatile] %c : $ObjCClass, #ObjCClass.method2!1.foreign : (ObjCClass) -> (NSRect) -> (), $@convention(objc_method) (NSRect, ObjCClass) -> ()
   %p = partial_apply %m(%c) : $@convention(objc_method) (NSRect, ObjCClass) -> ()
   return %p : $@callee_owned NSRect -> ()
 }
@@ -153,7 +153,7 @@ entry(%c : $ObjCClass):
 
 sil @objc_partial_apply_consumes_self : $@convention(thin) ObjCClass -> @callee_owned () -> @owned ObjCClass {
 entry(%c : $ObjCClass):
-  %m = class_method [volatile] %c : $ObjCClass, #ObjCClass.fakeInitFamily!1.foreign : (ObjCClass) -> () -> ObjCClass , $@convention(objc_method) (@owned ObjCClass) -> @owned ObjCClass
+  %m = class_method [volatile] %c : $ObjCClass, #ObjCClass.fakeInitFamily!1.foreign : (ObjCClass) -> () -> ObjCClass, $@convention(objc_method) (@owned ObjCClass) -> @owned ObjCClass
   %p = partial_apply %m(%c) : $@convention(objc_method) (@owned ObjCClass) -> @owned ObjCClass
   return %p : $@callee_owned () -> @owned ObjCClass
 }

--- a/test/IRGen/super.sil
+++ b/test/IRGen/super.sil
@@ -43,7 +43,7 @@ bb0(%0 : $ChildToResilientParent):
   debug_value %0 : $ChildToResilientParent, let, name "self", argno 1
   strong_retain %0 : $ChildToResilientParent
   %3 = upcast %0 : $ChildToResilientParent to $ResilientOutsideParent
-  %4 = super_method %0 : $ChildToResilientParent, #ResilientOutsideParent.method!1 : (ResilientOutsideParent) -> () -> () , $@convention(method) (@guaranteed ResilientOutsideParent) -> ()
+  %4 = super_method %0 : $ChildToResilientParent, #ResilientOutsideParent.method!1 : (ResilientOutsideParent) -> () -> (), $@convention(method) (@guaranteed ResilientOutsideParent) -> ()
   %5 = apply %4(%3) : $@convention(method) (@guaranteed ResilientOutsideParent) -> ()
   strong_release %3 : $ResilientOutsideParent
   %7 = tuple ()
@@ -63,7 +63,7 @@ sil @_T05super22ChildToResilientParentC11classMethodyyFZ : $@convention(method) 
 bb0(%0 : $@thick ChildToResilientParent.Type):
   debug_value %0 : $@thick ChildToResilientParent.Type, let, name "self", argno 1
   %2 = upcast %0 : $@thick ChildToResilientParent.Type to $@thick ResilientOutsideParent.Type
-  %3 = super_method %0 : $@thick ChildToResilientParent.Type, #ResilientOutsideParent.classMethod!1 : (ResilientOutsideParent.Type) -> () -> () , $@convention(method) (@thick ResilientOutsideParent.Type) -> ()
+  %3 = super_method %0 : $@thick ChildToResilientParent.Type, #ResilientOutsideParent.classMethod!1 : (ResilientOutsideParent.Type) -> () -> (), $@convention(method) (@thick ResilientOutsideParent.Type) -> ()
   %4 = apply %3(%2) : $@convention(method) (@thick ResilientOutsideParent.Type) -> ()
   %5 = tuple ()
   return %5 : $()
@@ -90,7 +90,7 @@ bb0(%0 : $ChildToFixedParent):
   debug_value %0 : $ChildToFixedParent, let, name "self", argno 1
   strong_retain %0 : $ChildToFixedParent
   %3 = upcast %0 : $ChildToFixedParent to $OutsideParent
-  %4 = super_method %0 : $ChildToFixedParent, #OutsideParent.method!1 : (OutsideParent) -> () -> () , $@convention(method) (@guaranteed OutsideParent) -> ()
+  %4 = super_method %0 : $ChildToFixedParent, #OutsideParent.method!1 : (OutsideParent) -> () -> (), $@convention(method) (@guaranteed OutsideParent) -> ()
   %5 = apply %4(%3) : $@convention(method) (@guaranteed OutsideParent) -> ()
   strong_release %3 : $OutsideParent
   %7 = tuple ()
@@ -110,7 +110,7 @@ sil @_T05super18ChildToFixedParentC11classMethodyyFZ : $@convention(method) (@th
 bb0(%0 : $@thick ChildToFixedParent.Type):
   debug_value %0 : $@thick ChildToFixedParent.Type, let, name "self", argno 1
   %2 = upcast %0 : $@thick ChildToFixedParent.Type to $@thick OutsideParent.Type
-  %3 = super_method %0 : $@thick ChildToFixedParent.Type, #OutsideParent.classMethod!1 : (OutsideParent.Type) -> () -> () , $@convention(method) (@thick OutsideParent.Type) -> ()
+  %3 = super_method %0 : $@thick ChildToFixedParent.Type, #OutsideParent.classMethod!1 : (OutsideParent.Type) -> () -> (), $@convention(method) (@thick OutsideParent.Type) -> ()
   %4 = apply %3(%2) : $@convention(method) (@thick OutsideParent.Type) -> ()
   %5 = tuple ()
   return %5 : $()
@@ -131,7 +131,7 @@ bb0(%0 : $ResilientOutsideChild):
   debug_value %0 : $ResilientOutsideChild, let, name "self", argno 1
   strong_retain %0 : $ResilientOutsideChild
   %3 = upcast %0 : $ResilientOutsideChild to $ResilientOutsideParent
-  %4 = super_method %0 : $ResilientOutsideChild, #ResilientOutsideParent.method!1 : (ResilientOutsideParent) -> () -> () , $@convention(method) (@guaranteed ResilientOutsideParent) -> ()
+  %4 = super_method %0 : $ResilientOutsideChild, #ResilientOutsideParent.method!1 : (ResilientOutsideParent) -> () -> (), $@convention(method) (@guaranteed ResilientOutsideParent) -> ()
   %5 = apply %4(%3) : $@convention(method) (@guaranteed ResilientOutsideParent) -> ()
   strong_release %3 : $ResilientOutsideParent
   %7 = tuple ()
@@ -155,7 +155,7 @@ sil @_T015resilient_class21ResilientOutsideChildC5superE20callSuperClassMethodyy
 bb0(%0 : $@thick ResilientOutsideChild.Type):
   debug_value %0 : $@thick ResilientOutsideChild.Type, let, name "self", argno 1
   %2 = upcast %0 : $@thick ResilientOutsideChild.Type to $@thick ResilientOutsideParent.Type
-  %3 = super_method %0 : $@thick ResilientOutsideChild.Type, #ResilientOutsideParent.classMethod!1 : (ResilientOutsideParent.Type) -> () -> () , $@convention(method) (@thick ResilientOutsideParent.Type) -> ()
+  %3 = super_method %0 : $@thick ResilientOutsideChild.Type, #ResilientOutsideParent.classMethod!1 : (ResilientOutsideParent.Type) -> () -> (), $@convention(method) (@thick ResilientOutsideParent.Type) -> ()
   %4 = apply %3(%2) : $@convention(method) (@thick ResilientOutsideParent.Type) -> ()
   %5 = tuple ()
   return %5 : $()

--- a/test/SIL/Parser/SILDeclRef.sil
+++ b/test/SIL/Parser/SILDeclRef.sil
@@ -1,0 +1,145 @@
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -module-name="SILDeclRef" %s
+
+// Check that SILDeclRefs with interface types can be parsed properly.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+public protocol P {
+  func foo() -> Int32
+  func foo(n: Int32)
+}
+
+extension P {
+  func boo() -> Int32
+}
+
+public class Base : P {
+  public func foo() -> Int32
+  public func foo(n: Int32)
+  public func foo(f: Float) -> Int32
+  deinit
+  init()
+}
+
+public class Derived1 : Base {
+  override public func foo() -> Int32
+  override public func foo(n: Int32)
+  override public func foo(f: Float) -> Int32
+  deinit
+  override init()
+}
+
+public class Derived2 : Base {
+  override public func foo() -> Int32
+  override public func foo(n: Int32)
+  override public func foo(f: Float) -> Int32
+  deinit
+  override init()
+}
+
+public func testP(p: P) -> Int32
+
+public func testBase(b: Base) -> Int32
+
+// P.boo() -> Int32
+sil @_TFE10SILDeclRefPS_1P3boofT_Vs5Int32 : $@convention(method) <Self where Self : P> (@in_guaranteed Self) -> Int32
+
+// Int32.init(_builtinIntegerLiteral : Builtin.Int2048) -> Int32
+sil public_external [transparent] [fragile] @_TFVs5Int32CfT22_builtinIntegerLiteralBi2048__S_ : $@convention(method) (Builtin.Int2048, @thin Int32.Type) -> Int32
+
+// Base.foo() -> Int32
+sil @_TFC10SILDeclRef4Base3foofT_Vs5Int32 : $@convention(method) (@guaranteed Base) -> Int32
+
+// Base.foo(n : Int32) -> ()
+sil @_TFC10SILDeclRef4Base3foofT1nVs5Int32_T_ : $@convention(method) (Int32, @guaranteed Base) -> ()
+
+// Base.foo(f : Float) -> Int32
+sil @_TFC10SILDeclRef4Base3foofT1fSf_Vs5Int32 : $@convention(method) (Float, @guaranteed Base) -> Int32
+
+// Base.__deallocating_deinit
+sil @_TFC10SILDeclRef4BaseD : $@convention(method) (@owned Base) -> ()
+
+// Base.deinit
+sil @_TFC10SILDeclRef4Based : $@convention(method) (@guaranteed Base) -> @owned Builtin.NativeObject
+
+// Base.init() -> Base
+sil @_TFC10SILDeclRef4BasecfT_S0_ : $@convention(method) (@owned Base) -> @owned Base
+
+// protocol witness for P.foo() -> Int32 in conformance Base
+sil [transparent] [thunk] @_TTWC10SILDeclRef4BaseS_1PS_FS1_3foofT_Vs5Int32 : $@convention(witness_method) (@in_guaranteed Base) -> Int32
+
+// protocol witness for P.foo(n : Int32) -> () in conformance Base
+sil [transparent] [thunk] @_TTWC10SILDeclRef4BaseS_1PS_FS1_3foofT1nVs5Int32_T_ : $@convention(witness_method) (Int32, @in_guaranteed Base) -> ()
+
+// Derived1.foo() -> Int32
+sil @_TFC10SILDeclRef8Derived13foofT_Vs5Int32 : $@convention(method) (@guaranteed Derived1) -> Int32
+
+// Derived1.foo(n : Int32) -> ()
+sil @_TFC10SILDeclRef8Derived13foofT1nVs5Int32_T_ : $@convention(method) (Int32, @guaranteed Derived1) -> ()
+
+// Derived1.foo(f : Float) -> Int32
+sil @_TFC10SILDeclRef8Derived13foofT1fSf_Vs5Int32 : $@convention(method) (Float, @guaranteed Derived1) -> Int32
+
+// Derived1.__deallocating_deinit
+sil @_TFC10SILDeclRef8Derived1D : $@convention(method) (@owned Derived1) -> ()
+
+// Derived1.deinit
+sil @_TFC10SILDeclRef8Derived1d : $@convention(method) (@guaranteed Derived1) -> @owned Builtin.NativeObject
+
+// Derived1.init() -> Derived1
+sil @_TFC10SILDeclRef8Derived1cfT_S0_ : $@convention(method) (@owned Derived1) -> @owned Derived1
+
+// Derived2.foo() -> Int32
+sil @_TFC10SILDeclRef8Derived23foofT_Vs5Int32 : $@convention(method) (@guaranteed Derived2) -> Int32
+
+// Derived2.foo(n : Int32) -> ()
+sil @_TFC10SILDeclRef8Derived23foofT1nVs5Int32_T_ : $@convention(method) (Int32, @guaranteed Derived2) -> ()
+
+// Derived2.foo(f : Float) -> Int32
+sil @_TFC10SILDeclRef8Derived23foofT1fSf_Vs5Int32 : $@convention(method) (Float, @guaranteed Derived2) -> Int32
+
+// Derived2.__deallocating_deinit
+sil @_TFC10SILDeclRef8Derived2D : $@convention(method) (@owned Derived2) -> ()
+
+// Derived2.deinit
+sil @_TFC10SILDeclRef8Derived2d : $@convention(method) (@guaranteed Derived2) -> @owned Builtin.NativeObject
+
+// Derived2.init() -> Derived2
+sil @_TFC10SILDeclRef8Derived2cfT_S0_ : $@convention(method) (@owned Derived2) -> @owned Derived2
+
+// testP(p : P) -> Int32
+sil @_TF10SILDeclRef5testPFT1pPS_1P__Vs5Int32 : $@convention(thin) (@in P) -> Int32
+
+// testBase(b : Base) -> Int32
+sil @_TF10SILDeclRef8testBaseFT1bCS_4Base_Vs5Int32 : $@convention(thin) (@owned Base) -> Int32
+
+sil_vtable Derived1 {
+  #Base.foo!1: (Base) -> () -> Int32 : _TFC10SILDeclRef8Derived13foofT_Vs5Int32	// Derived1.foo() -> Int32
+  #Base.foo!1: (Base) -> (Int32) -> () : _TFC10SILDeclRef8Derived13foofT1nVs5Int32_T_	// Derived1.foo(n : Int32) -> ()
+  #Base.foo!1: (Base) -> (Float) -> Int32 : _TFC10SILDeclRef8Derived13foofT1fSf_Vs5Int32	// Derived1.foo(f : Float) -> Int32
+  #Base.init!initializer.1: (Base.Type) -> () -> Base : _TFC10SILDeclRef8Derived1cfT_S0_	// Derived1.init() -> Derived1
+  #Derived1.deinit!deallocator: (Derived1) -> () -> () : _TFC10SILDeclRef8Derived1D	// Derived1.__deallocating_deinit
+}
+
+sil_vtable Derived2 {
+  #Base.foo!1: (Base) -> () -> Int32 : _TFC10SILDeclRef8Derived23foofT_Vs5Int32	// Derived2.foo() -> Int32
+  #Base.foo!1: (Base) -> (Int32) -> () : _TFC10SILDeclRef8Derived23foofT1nVs5Int32_T_	// Derived2.foo(n : Int32) -> ()
+  #Base.foo!1: (Base) -> (Float) -> Int32 : _TFC10SILDeclRef8Derived23foofT1fSf_Vs5Int32	// Derived2.foo(f : Float) -> Int32
+  #Base.init!initializer.1: (Base.Type) -> () -> Base : _TFC10SILDeclRef8Derived2cfT_S0_	// Derived2.init() -> Derived2
+  #Derived2.deinit!deallocator: (Derived2) -> () -> () : _TFC10SILDeclRef8Derived2D	// Derived2.__deallocating_deinit
+}
+
+sil_witness_table [fragile] Base: P module SILDeclRef {
+  method #P.foo!1: <Self where Self : P> (Self) -> () -> Int32 : @_TTWC10SILDeclRef4BaseS_1PS_FS1_3foofT_Vs5Int32	// protocol witness for P.foo() -> Int32 in conformance Base
+  method #P.foo!1: <Self where Self : P> (Self) -> (Int32) -> () : @_TTWC10SILDeclRef4BaseS_1PS_FS1_3foofT1nVs5Int32_T_	// protocol witness for P.foo(n : Int32) -> () in conformance Base
+}
+
+sil_default_witness_table P {
+  no_default
+  no_default
+}
+

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -220,7 +220,7 @@ bb0:
   %O = unchecked_ref_cast %C : $C to $Builtin.UnknownObject
 
   // CHECK: class_method {{.*}} : $C, #C.doIt!1
-  %2 = class_method %C : $C, #C.doIt!1 : (C) -> () -> () , $@convention(method) (@guaranteed C) -> ()
+  %2 = class_method %C : $C, #C.doIt!1 : (C) -> () -> (), $@convention(method) (@guaranteed C) -> ()
 
   // CHECK: alloc_ref $D
   %D = alloc_ref $D
@@ -1569,8 +1569,8 @@ bb0(%0 : $Builtin.RawPointer, %1 : $Builtin.Word):
 }
 
 // CHECK-LABEL: sil_vtable Foo {
-// CHECK: #Foo.subscript!getter.1: hidden _TFC3tmp3Foog9subscriptFTVs5Int32S1__S1_
-// CHECK: #Foo.subscript!setter.1: _TFC3tmp3Foos9subscriptFTVs5Int32S1__S1_
+// CHECK: #Foo.subscript!getter.1: {{.*}} : hidden _TFC3tmp3Foog9subscriptFTVs5Int32S1__S1_
+// CHECK: #Foo.subscript!setter.1: {{.*}} : _TFC3tmp3Foos9subscriptFTVs5Int32S1__S1_
 // CHECK: }
 sil_vtable Foo {
   // Override the linke to check if it is parsed correctly.

--- a/test/SIL/Parser/default_witness_tables.sil
+++ b/test/SIL/Parser/default_witness_tables.sil
@@ -51,9 +51,9 @@ bb0(%0 : $*Self):
 // CHECK: no_default
 // CHECK: no_default
 // CHECK: no_default
-// CHECK: method #ResilientProtocol.defaultC!1: @defaultC
-// CHECK: method #ResilientProtocol.defaultD!1: @defaultD
-// CHECK: method #ResilientProtocol.defaultE!1: @defaultE
+// CHECK: method #ResilientProtocol.defaultC!1: {{.*}} : @defaultC
+// CHECK: method #ResilientProtocol.defaultD!1: {{.*}} : @defaultD
+// CHECK: method #ResilientProtocol.defaultE!1: {{.*}} : @defaultE
 // CHECK: }
 
 sil_default_witness_table ResilientProtocol {
@@ -68,7 +68,7 @@ sil_default_witness_table ResilientProtocol {
 
 
 // CHECK-LABEL: sil_default_witness_table hidden InternalProtocol {
-// CHECK: method #InternalProtocol.defaultF!1: @defaultF
+// CHECK: method #InternalProtocol.defaultF!1: {{.*}} : @defaultF
 // CHECK: }
 
 sil_default_witness_table hidden InternalProtocol {

--- a/test/SIL/Parser/generic_signature_with_depth.swift
+++ b/test/SIL/Parser/generic_signature_with_depth.swift
@@ -19,7 +19,7 @@ protocol mmExt : mmCollectionType {
 }
 
 // CHECK-LABEL:  @_T028generic_signature_with_depth4testxx_q_tAA5mmExtRzAaCR_9Generator_7ElementQZAD_AERT_r0_lF : $@convention(thin) <EC1, EC2 where EC1 : mmExt, EC2 : mmExt, EC2.Generator.Element == EC1.Generator.Element> (@in EC1, @in EC2) -> @out EC1 {
-// CHECK: witness_method $EC1, #mmExt.extend!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : mmExt><τ_1_0 where τ_1_0 : mmSequenceType, τ_1_0.Generator.Element == τ_0_0.Generator.Element> (@in τ_1_0, @inout τ_0_0) -> ()
+// CHECK: witness_method $EC1, #mmExt.extend!1 : {{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : mmExt><τ_1_0 where τ_1_0 : mmSequenceType, τ_1_0.Generator.Element == τ_0_0.Generator.Element> (@in τ_1_0, @inout τ_0_0) -> ()
 // CHECK: apply {{%[0-9]+}}<EC1, EC2>({{%[0-9]+}}, {{%[0-9]+}}) : $@convention(witness_method) <τ_0_0 where τ_0_0 : mmExt><τ_1_0 where τ_1_0 : mmSequenceType, τ_1_0.Generator.Element == τ_0_0.Generator.Element> (@in τ_1_0, @inout τ_0_0) -> ()
 
 func test<

--- a/test/SIL/Parser/overloaded_member.sil
+++ b/test/SIL/Parser/overloaded_member.sil
@@ -26,8 +26,8 @@ bb0(%0 : $A, %1 : $X):
   %5 = mark_uninitialized [delegatingself] %1 : $X
   store %5 to [init] %2a : $*X
   %7 = load [copy] %2a : $*X
-  // CHECK: class_method [volatile] %{{[0-9]+}} : $X, #X.init!initializer.1.foreign : (X.Type) -> (A, A) -> X , $@convention(objc_method) (A, A, @owned X) -> @owned X
-  %9 = class_method [volatile] %7 : $X, #X.init!initializer.1.foreign : (X.Type) -> (A, A) -> X , $@convention(objc_method) (A, A, @owned X) -> @owned X
+  // CHECK: class_method [volatile] %{{[0-9]+}} : $X, #X.init!initializer.1.foreign : (X.Type) -> (A, A) -> X, $@convention(objc_method) (A, A, @owned X) -> @owned X
+  %9 = class_method [volatile] %7 : $X, #X.init!initializer.1.foreign : (X.Type) -> (A, A) -> X, $@convention(objc_method) (A, A, @owned X) -> @owned X
   %10 = load [trivial] %3a : $*A
   %11 = load [trivial] %3a : $*A
   %12 = apply %9(%10, %11, %7) : $@convention(objc_method) (A, A, @owned X) -> @owned X

--- a/test/SIL/Parser/protocol_getter.sil
+++ b/test/SIL/Parser/protocol_getter.sil
@@ -12,7 +12,7 @@ protocol TestP : class {
 sil @test : $@convention(method) (TestP) -> () {
 bb0(%0 : $TestP):
   %1 = open_existential_ref %0 : $TestP to $@opened("01234567-89ab-cdef-0123-000000000000") TestP
-  // CHECK: witness_method $@opened({{.*}}) TestP, #TestP.count!getter, %{{.*}} : $@opened({{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : TestP> (τ_0_0) -> Int
+  // CHECK: witness_method $@opened({{.*}}) TestP, #TestP.count!getter : {{.*}}, %{{.*}} : $@opened({{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : TestP> (τ_0_0) -> Int
   %2 = witness_method $@opened("01234567-89ab-cdef-0123-000000000000") TestP, #TestP.count!getter, %1 : $@opened("01234567-89ab-cdef-0123-000000000000") TestP : $@convention(witness_method) <T: TestP> (T) -> Int
   %3 = tuple ()
   return %3 : $()

--- a/test/SIL/Parser/undef.sil
+++ b/test/SIL/Parser/undef.sil
@@ -101,10 +101,10 @@ bb0:
 
   // Dynamic dispatch
 
-  // CHECK: class_method undef : $C, #C.fn!1 : (C) -> () -> () , $@convention(method) (@guaranteed C) -> ()
-  class_method undef : $C, #C.fn!1 : (C) -> () -> () , $@convention(method) (@guaranteed C) -> ()
-  // CHECK: super_method undef : $D, #C.fn!1 : (C) -> () -> () , $@convention(method) (@guaranteed C) -> ()
-  super_method undef : $D, #C.fn!1 : (C) -> () -> () , $@convention(method) (@guaranteed C) -> ()
+  // CHECK: class_method undef : $C, #C.fn!1 : (C) -> () -> (), $@convention(method) (@guaranteed C) -> ()
+  class_method undef : $C, #C.fn!1 : (C) -> () -> (), $@convention(method) (@guaranteed C) -> ()
+  // CHECK: super_method undef : $D, #C.fn!1 : (C) -> () -> (), $@convention(method) (@guaranteed C) -> ()
+  super_method undef : $D, #C.fn!1 : (C) -> () -> (), $@convention(method) (@guaranteed C) -> ()
   // CHECK: dynamic_method undef : $C, #C.fn!1 : (C) -> () -> (), $@convention(method) (@guaranteed C) -> ()
   dynamic_method undef : $C, #C.fn!1 : (C) -> () -> (), $@convention(method) (@guaranteed C) -> ()
 

--- a/test/SIL/Parser/witness_protocol_from_import.sil
+++ b/test/SIL/Parser/witness_protocol_from_import.sil
@@ -34,14 +34,14 @@ sil @_TF5test2oi2eeFTOS_1XS0__Sb : $@convention(thin) (X, X) -> Bool
 sil @_TFO5test21Xg9hashValueSi : $@convention(method) (X) -> Int
 
 // CHECK-LABEL: sil_witness_table X: Equatable module
-// CHECK: method #Equatable."=="!1: @_TTWO5test21Xs9EquatableS_FS1_oi2eeUS1___fMQPS1_FT3lhsS2_3rhsS2__Sb
+// CHECK: method #Equatable."=="!1: {{.*}} : @_TTWO5test21Xs9EquatableS_FS1_oi2eeUS1___fMQPS1_FT3lhsS2_3rhsS2__Sb
 sil_witness_table X: Equatable module test2 {
   method #Equatable."=="!1: @_TTWO5test21Xs9EquatableS_FS1_oi2eeUS1___fMQPS1_FT3lhsS2_3rhsS2__Sb
 }
 
 // CHECK-LABEL: sil_witness_table X: Hashable module
 // CHECK: base_protocol Equatable: X: Equatable module
-// CHECK: method #Hashable.hashValue!getter.1: @_TTWO5test21Xs8HashableS_FS1_g9hashValueSi
+// CHECK: method #Hashable.hashValue!getter.1: {{.*}} : @_TTWO5test21Xs8HashableS_FS1_g9hashValueSi
 sil_witness_table X: Hashable module test2 {
   base_protocol Equatable: X: Equatable module test2
   method #Hashable.hashValue!getter.1: @_TTWO5test21Xs8HashableS_FS1_g9hashValueSi

--- a/test/SIL/Parser/witness_tables.sil
+++ b/test/SIL/Parser/witness_tables.sil
@@ -24,7 +24,7 @@ bb0(%0 : $*ConformingAssoc):
 }
 
 // CHECK-LABEL: sil_witness_table ConformingAssoc: AssocReqt module witness_tables {
-// CHECK: #AssocReqt.requiredMethod!1: @_TTWV14witness_tables15ConformingAssocS_9AssocReqtS_FS1_14requiredMethodU_fRQPS1_FT_T_
+// CHECK: #AssocReqt.requiredMethod!1: {{.*}} : @_TTWV14witness_tables15ConformingAssocS_9AssocReqtS_FS1_14requiredMethodU_fRQPS1_FT_T_
 // CHECK: }
 sil_witness_table ConformingAssoc: AssocReqt module witness_tables {
   method #AssocReqt.requiredMethod!1: @_TTWV14witness_tables15ConformingAssocS_9AssocReqtS_FS1_14requiredMethodU_fRQPS1_FT_T_
@@ -90,7 +90,7 @@ class DeadMethodClass : Proto {
 }
 
 // CHECK-LABEL: sil_witness_table DeadMethodClass: Proto module witness_tables
-// CHECK: method #Proto.abc!1: nil
+// CHECK: method #Proto.abc!1: {{.*}} : nil
 // CHECK: }
 sil_witness_table DeadMethodClass: Proto module witness_tables {
   method #Proto.abc!1: nil

--- a/test/SIL/Serialization/witness_tables.sil
+++ b/test/SIL/Serialization/witness_tables.sil
@@ -24,7 +24,7 @@ bb0(%0 : $*ConformingAssoc):
 }
 
 // CHECK-LABEL: sil_witness_table ConformingAssoc: AssocReqt module witness_tables {
-// CHECK: #AssocReqt.requiredMethod!1: @_TTWV14witness_tables15ConformingAssocS_9AssocReqtS_FS1_14requiredMethodU_fRQPS1_FT_T_
+// CHECK: #AssocReqt.requiredMethod!1: {{.*}} : @_TTWV14witness_tables15ConformingAssocS_9AssocReqtS_FS1_14requiredMethodU_fRQPS1_FT_T_
 // CHECK: }
 sil_witness_table ConformingAssoc: AssocReqt module witness_tables {
   method #AssocReqt.requiredMethod!1: @_TTWV14witness_tables15ConformingAssocS_9AssocReqtS_FS1_14requiredMethodU_fRQPS1_FT_T_
@@ -90,7 +90,7 @@ class DeadMethodClass : Proto {
 }
 
 // CHECK-LABEL: sil_witness_table DeadMethodClass: Proto module witness_tables
-// CHECK: method #Proto.abc!1: nil
+// CHECK: method #Proto.abc!1: {{.*}} : nil
 // CHECK: }
 sil_witness_table DeadMethodClass: Proto module witness_tables {
   method #Proto.abc!1: nil

--- a/test/SILGen/SILDeclRef.swift
+++ b/test/SILGen/SILDeclRef.swift
@@ -1,0 +1,70 @@
+// RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil %s | %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -module-name="SILDeclRef"  - | %FileCheck %s
+
+// Check that all SILDeclRefs are represented in the text form with a signature.
+// This allows to avoid ambiguities which sometimes arise e.g. when a
+// vtable or witness table contain multiple entries for a function with the same
+// name but different signatures (like "foo" in the examples below).
+//
+// Check that SILParser can parse the new SIL syntax for SILDeclRefs by first
+// producing the new syntax and then parsing it using sil-opt.
+
+public protocol P {
+  func foo() -> Int32
+  func foo(n: Int32)
+}
+
+extension P {
+  func boo() -> Int32 {
+    return 1
+  }
+}
+
+public class Base : P {
+  public func foo() -> Int32 { return 2 }
+  public func foo(n: Int32) {}
+  public func foo(f: Float) -> Int32 { return 3 }
+}
+
+public class Derived1: Base {
+  override public func foo() -> Int32 { return 4 }
+  override public func foo(n: Int32) {}
+  override public func foo(f: Float) -> Int32 { return 5 }
+}
+
+public class Derived2: Base {
+  override public func foo() -> Int32 { return 6 }
+  override public func foo(n: Int32) {}
+  override public func foo(f: Float) -> Int32 { return 7 }
+}
+
+// CHECK-LABEL: sil @_TF10SILDeclRef5testPFT1pPS_1P__Vs5Int32
+// Check that witness_method contains SILDeclRefs with a signature.
+// CHECK: witness_method $@opened({{.*}}) P, #P.foo!1 : <Self where Self : P> (Self) -> () -> Int32, %{{.*}} : $*@opened({{.*}}) P : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int32
+public func testP(p: P) -> Int32 {
+  return p.foo()
+}
+
+// Check that class_method contains SILDeclRefs with a signature.
+// CHECK-LABEL:sil @_TF10SILDeclRef8testBaseFT1bCS_4Base_Vs5Int32
+// CHECK: class_method %{{.*}} : $Base, #Base.foo!1 : (Base) -> (Float) -> Int32, $@convention(method) (Float, @guaranteed Base) -> Int32
+public func testBase(b: Base) -> Int32 {
+  return b.foo(f: 10)
+}
+
+// Check that vtables and witness tables contain SILDeclRefs with signatures.
+
+// CHECK: sil_vtable Base {
+// CHECK:  #Base.foo!1: (Base) -> () -> Int32 : _TFC10SILDeclRef4Base3foofT_Vs5Int32	// Base.foo() -> Int32
+// CHECK:  #Base.foo!1: (Base) -> (Int32) -> () : _TFC10SILDeclRef4Base3foofT1nVs5Int32_T_	// Base.foo(n : Int32) -> ()
+// CHECK:  #Base.foo!1: (Base) -> (Float) -> Int32 : _TFC10SILDeclRef4Base3foofT1fSf_Vs5Int32	// Base.foo(f : Float) -> Int32
+// CHECK:  #Base.deinit!deallocator: (Base) -> () -> () : _TFC10SILDeclRef4BaseD	// Base.__deallocating_deinit
+// CHECK:  #Base.init!initializer.1: (Base.Type) -> () -> Base : _TFC10SILDeclRef4BasecfT_S0_	// Base.init() -> Base
+// CHECK: }
+
+// CHECK:sil_witness_table [fragile] Base: P module SILDeclRef {
+// CHECK: method #P.foo!1: <Self where Self : P> (Self) -> () -> Int32 : @_TTWC10SILDeclRef4BaseS_1PS_FS1_3foofT_Vs5Int32	// protocol witness for P.foo() -> Int32 in conformance Base
+// CHECK: method #P.foo!1: <Self where Self : P> (Self) -> (Int32) -> () : @_TTWC10SILDeclRef4BaseS_1PS_FS1_3foofT1nVs5Int32_T_	// protocol witness for P.foo(n : Int32) -> () in conformance Base
+// CHECK: }
+
+

--- a/test/SILGen/accessibility_vtables.swift
+++ b/test/SILGen/accessibility_vtables.swift
@@ -17,14 +17,14 @@ class Sub : Base {
 // CHECK:         function_ref @_TFs25_unimplementedInitializerFT9classNameVs12StaticString8initNameS_4fileS_4lineSu6columnSu_Os5Never
 
 // CHECK-LABEL: sil_vtable Sub {
-// CHECK-NEXT:  #Base.internalMethod!1: _TFC28accessibility_vtables_helper4Base14internalMethod
-// CHECK-NEXT:  #Base.prop!getter.1: _TFC21accessibility_vtables3Subg4propSi  // accessibility_vtables.Sub.prop.getter : Swift.Int
-// CHECK-NEXT:  #Base.prop!setter.1: _TFC28accessibility_vtables_helper4Bases4propSi  // accessibility_vtables_helper.Base.prop.setter : Swift.Int
-// CHECK-NEXT:  #Base.prop!materializeForSet.1: _TFC28accessibility_vtables_helper4Basem4propSi  // accessibility_vtables_helper.Base.prop.materializeForSet : Swift.Int
-// CHECK-NEXT:  #Base.init!initializer.1: _TFC21accessibility_vtables3SubcfT_S0_  // accessibility_vtables.Sub.init () -> accessibility_vtables.Sub
-// CHECK-NEXT: #Sub.internalMethod!1: _TFC21accessibility_vtables3Sub14internalMethod
-// CHECK-NEXT: #Sub.prop!setter.1: _TFC21accessibility_vtables3Subs4propSi   // accessibility_vtables.Sub.prop.setter : Swift.Int
-// CHECK-NEXT: #Sub.prop!materializeForSet.1: _TFC21accessibility_vtables3Subm4propSi  // accessibility_vtables.Sub.prop.materializeForSet : Swift.Int
+// CHECK-NEXT:  #Base.internalMethod!1: {{.*}} : _TFC28accessibility_vtables_helper4Base14internalMethod
+// CHECK-NEXT:  #Base.prop!getter.1: {{.*}} : _TFC21accessibility_vtables3Subg4propSi  // accessibility_vtables.Sub.prop.getter : Swift.Int
+// CHECK-NEXT:  #Base.prop!setter.1: {{.*}} : _TFC28accessibility_vtables_helper4Bases4propSi  // accessibility_vtables_helper.Base.prop.setter : Swift.Int
+// CHECK-NEXT:  #Base.prop!materializeForSet.1: {{.*}} : _TFC28accessibility_vtables_helper4Basem4propSi  // accessibility_vtables_helper.Base.prop.materializeForSet : Swift.Int
+// CHECK-NEXT:  #Base.init!initializer.1: {{.*}} : _TFC21accessibility_vtables3SubcfT_S0_  // accessibility_vtables.Sub.init () -> accessibility_vtables.Sub
+// CHECK-NEXT: #Sub.internalMethod!1: {{.*}} : _TFC21accessibility_vtables3Sub14internalMethod
+// CHECK-NEXT: #Sub.prop!setter.1: {{.*}} : _TFC21accessibility_vtables3Subs4propSi   // accessibility_vtables.Sub.prop.setter : Swift.Int
+// CHECK-NEXT: #Sub.prop!materializeForSet.1: {{.*}} : _TFC21accessibility_vtables3Subm4propSi  // accessibility_vtables.Sub.prop.materializeForSet : Swift.Int
 // CHECK-NEXT: #Sub.deinit
 // CHECK-NEXT: }
 
@@ -37,14 +37,14 @@ class InternalSub : InternalBase {
 }
 
 // CHECK-LABEL: sil_vtable InternalSub {
-// CHECK-NEXT:  #InternalBase.method!1: _TFC21accessibility_vtables12InternalBaseP{{[0-9]+}}[[DISCRIMINATOR:_.+]]6method
-// CHECK-NEXT:  #InternalBase.prop!getter.1: _TFC21accessibility_vtables11InternalSubg4propSi // accessibility_vtables.InternalSub.prop.getter : Swift.Int
-// CHECK-NEXT:  #InternalBase.prop!setter.1: _TFC21accessibility_vtables12InternalBases4propSi        // accessibility_vtables.InternalBase.prop.setter : Swift.Int
-// CHECK-NEXT:  #InternalBase.prop!materializeForSet.1: _TFC21accessibility_vtables12InternalBasem4propSi // accessibility_vtables.InternalBase.prop.materializeForSet : Swift.Int
-// CHECK-NEXT:  #InternalBase.init!initializer.1: _TFC21accessibility_vtables11InternalSubc
-// CHECK-NEXT:  #InternalSub.method!1: _TFC21accessibility_vtables11InternalSub6method
-// CHECK-NEXT:  #InternalSub.prop!setter.1: _TFC21accessibility_vtables11InternalSubs4propSi  // accessibility_vtables.InternalSub.prop.setter : Swift.Int
-// CHECK-NEXT:  #InternalSub.prop!materializeForSet.1: _TFC21accessibility_vtables11InternalSubm4propSi // accessibility_vtables.InternalSub.prop.materializeForSet : Swift.Int
+// CHECK-NEXT:  #InternalBase.method!1: {{.*}} : _TFC21accessibility_vtables12InternalBaseP{{[0-9]+}}[[DISCRIMINATOR:_.+]]6method
+// CHECK-NEXT:  #InternalBase.prop!getter.1: {{.*}} : _TFC21accessibility_vtables11InternalSubg4propSi // accessibility_vtables.InternalSub.prop.getter : Swift.Int
+// CHECK-NEXT:  #InternalBase.prop!setter.1: {{.*}} : _TFC21accessibility_vtables12InternalBases4propSi        // accessibility_vtables.InternalBase.prop.setter : Swift.Int
+// CHECK-NEXT:  #InternalBase.prop!materializeForSet.1: {{.*}} : _TFC21accessibility_vtables12InternalBasem4propSi // accessibility_vtables.InternalBase.prop.materializeForSet : Swift.Int
+// CHECK-NEXT:  #InternalBase.init!initializer.1: {{.*}} : _TFC21accessibility_vtables11InternalSubc
+// CHECK-NEXT:  #InternalSub.method!1: {{.*}} : _TFC21accessibility_vtables11InternalSub6method
+// CHECK-NEXT:  #InternalSub.prop!setter.1: {{.*}} : _TFC21accessibility_vtables11InternalSubs4propSi  // accessibility_vtables.InternalSub.prop.setter : Swift.Int
+// CHECK-NEXT:  #InternalSub.prop!materializeForSet.1: {{.*}} : _TFC21accessibility_vtables11InternalSubm4propSi // accessibility_vtables.InternalSub.prop.materializeForSet : Swift.Int
 // CHECK-NEXT:  #InternalSub.deinit
 // CHECK-NEXT: }
 

--- a/test/SILGen/cf.swift
+++ b/test/SILGen/cf.swift
@@ -27,22 +27,22 @@ func useEmAll(_ model: CCMagnetismModel) {
 // CHECK: function_ref @CCRefrigeratorDestroy : $@convention(c) (@owned Optional<CCRefrigerator>) -> ()
   CCRefrigeratorDestroy(clone)
 
-// CHECK: class_method [volatile] %0 : $CCMagnetismModel, #CCMagnetismModel.refrigerator!1.foreign : (CCMagnetismModel) -> () -> Unmanaged<CCRefrigerator>! , $@convention(objc_method) (CCMagnetismModel) -> Optional<Unmanaged<CCRefrigerator>>
+// CHECK: class_method [volatile] %0 : $CCMagnetismModel, #CCMagnetismModel.refrigerator!1.foreign : (CCMagnetismModel) -> () -> Unmanaged<CCRefrigerator>!, $@convention(objc_method) (CCMagnetismModel) -> Optional<Unmanaged<CCRefrigerator>>
   let f0 = model.refrigerator()
 
-// CHECK: class_method [volatile] %0 : $CCMagnetismModel, #CCMagnetismModel.getRefrigerator!1.foreign : (CCMagnetismModel) -> () -> CCRefrigerator! , $@convention(objc_method) (CCMagnetismModel) -> @autoreleased Optional<CCRefrigerator>
+// CHECK: class_method [volatile] %0 : $CCMagnetismModel, #CCMagnetismModel.getRefrigerator!1.foreign : (CCMagnetismModel) -> () -> CCRefrigerator!, $@convention(objc_method) (CCMagnetismModel) -> @autoreleased Optional<CCRefrigerator>
   let f1 = model.getRefrigerator()
 
-// CHECK: class_method [volatile] %0 : $CCMagnetismModel, #CCMagnetismModel.takeRefrigerator!1.foreign : (CCMagnetismModel) -> () -> CCRefrigerator! , $@convention(objc_method) (CCMagnetismModel) -> @owned Optional<CCRefrigerator>
+// CHECK: class_method [volatile] %0 : $CCMagnetismModel, #CCMagnetismModel.takeRefrigerator!1.foreign : (CCMagnetismModel) -> () -> CCRefrigerator!, $@convention(objc_method) (CCMagnetismModel) -> @owned Optional<CCRefrigerator>
   let f2 = model.takeRefrigerator()
 
-// CHECK: class_method [volatile] %0 : $CCMagnetismModel, #CCMagnetismModel.borrowRefrigerator!1.foreign : (CCMagnetismModel) -> () -> CCRefrigerator! , $@convention(objc_method) (CCMagnetismModel) -> @autoreleased Optional<CCRefrigerator>
+// CHECK: class_method [volatile] %0 : $CCMagnetismModel, #CCMagnetismModel.borrowRefrigerator!1.foreign : (CCMagnetismModel) -> () -> CCRefrigerator!, $@convention(objc_method) (CCMagnetismModel) -> @autoreleased Optional<CCRefrigerator>
   let f3 = model.borrowRefrigerator()
 
-// CHECK: class_method [volatile] %0 : $CCMagnetismModel, #CCMagnetismModel.setRefrigerator!1.foreign : (CCMagnetismModel) -> (CCRefrigerator!) -> () , $@convention(objc_method) (Optional<CCRefrigerator>, CCMagnetismModel) -> ()
+// CHECK: class_method [volatile] %0 : $CCMagnetismModel, #CCMagnetismModel.setRefrigerator!1.foreign : (CCMagnetismModel) -> (CCRefrigerator!) -> (), $@convention(objc_method) (Optional<CCRefrigerator>, CCMagnetismModel) -> ()
   model.setRefrigerator(copy)
 
-// CHECK: class_method [volatile] %0 : $CCMagnetismModel, #CCMagnetismModel.giveRefrigerator!1.foreign : (CCMagnetismModel) -> (CCRefrigerator!) -> () , $@convention(objc_method) (@owned Optional<CCRefrigerator>, CCMagnetismModel) -> ()
+// CHECK: class_method [volatile] %0 : $CCMagnetismModel, #CCMagnetismModel.giveRefrigerator!1.foreign : (CCMagnetismModel) -> (CCRefrigerator!) -> (), $@convention(objc_method) (@owned Optional<CCRefrigerator>, CCMagnetismModel) -> ()
   model.giveRefrigerator(copy)
 
   // rdar://16846555

--- a/test/SILGen/complete_object_init.swift
+++ b/test/SILGen/complete_object_init.swift
@@ -10,7 +10,7 @@ class A {
 // CHECK:   [[SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*A
 // CHECK:   store [[SELF_PARAM]] to [init] [[SELF]] : $*A
 // CHECK:   [[SELFP:%[0-9]+]] = load_borrow [[SELF]] : $*A
-// CHECK:   [[INIT:%[0-9]+]] = class_method [[SELFP]] : $A, #A.init!initializer.1 : (A.Type) -> (X) -> A , $@convention(method) (X, @owned A) -> @owned A
+// CHECK:   [[INIT:%[0-9]+]] = class_method [[SELFP]] : $A, #A.init!initializer.1 : (A.Type) -> (X) -> A, $@convention(method) (X, @owned A) -> @owned A
 // CHECK:   [[X_INIT:%[0-9]+]] = function_ref @_T020complete_object_init1XV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@thin X.Type) -> X
 // CHECK:   [[X_META:%[0-9]+]] = metatype $@thin X.Type
 // CHECK:   [[X:%[0-9]+]] = apply [[X_INIT]]([[X_META]]) : $@convention(method) (@thin X.Type) -> X

--- a/test/SILGen/deinit_in_vtable.swift
+++ b/test/SILGen/deinit_in_vtable.swift
@@ -31,9 +31,9 @@ public func testmain() {
 // function elimination
 
 // CHECK-LABEL: sil_vtable A
-// CHECK: A.deinit!deallocator: [[A]]
+// CHECK: A.deinit!deallocator: {{.*}} : [[A]]
 
 // CHECK-LABEL: sil_vtable B
 // CHECK-NOT: A.deinit
-// CHECK: B.deinit!deallocator: [[B]]
+// CHECK: B.deinit!deallocator: {{.*}} : [[B]]
 

--- a/test/SILGen/dynamic.swift
+++ b/test/SILGen/dynamic.swift
@@ -435,7 +435,7 @@ public class Sub : Base {
   // CHECK: bb0([[VALUE:%.*]] : $Sub):
   // CHECK:     [[VALUE_COPY:%.*]] = copy_value [[VALUE]]
   // CHECK:     [[CASTED_VALUE_COPY:%.*]] = upcast [[VALUE_COPY]]
-  // CHECK:     [[SUPER:%.*]] = super_method [volatile] [[VALUE_COPY]] : $Sub, #Base.x!getter.1.foreign : (Base) -> () -> Bool , $@convention(objc_method) (Base) -> ObjCBool
+  // CHECK:     [[SUPER:%.*]] = super_method [volatile] [[VALUE_COPY]] : $Sub, #Base.x!getter.1.foreign : (Base) -> () -> Bool, $@convention(objc_method) (Base) -> ObjCBool
   // CHECK:     = apply [[SUPER]]([[CASTED_VALUE_COPY]])
   // CHECK:     destroy_value [[VALUE_COPY]]
   // CHECK:     destroy_value [[VALUE]]
@@ -446,27 +446,27 @@ public class Sub : Base {
 
 // Vtable contains entries for native and @objc methods, but not dynamic ones
 // CHECK-LABEL: sil_vtable Foo {
-// CHECK-LABEL:   #Foo.init!initializer.1:   _T07dynamic3FooCACSi6native_tcfc
-// CHECK-LABEL:   #Foo.nativeMethod!1:       _T07dynamic3FooC12nativeMethodyyF
-// CHECK-LABEL:   #Foo.subscript!getter.1:   _T07dynamic3FooC9subscriptSiSi6native_tcfg    // dynamic.Foo.subscript.getter : (native : Swift.Int) -> Swift.Int
-// CHECK-LABEL:   #Foo.subscript!setter.1:   _T07dynamic3FooC9subscriptSiSi6native_tcfs    // dynamic.Foo.subscript.setter : (native : Swift.Int) -> Swift.Int
-// CHECK-LABEL:   #Foo.init!initializer.1:   _T07dynamic3FooCACSi4objc_tcfc
-// CHECK-LABEL:   #Foo.objcMethod!1:         _T07dynamic3FooC10objcMethodyyF
-// CHECK-LABEL:   #Foo.subscript!getter.1: _T07dynamic3FooC9subscriptSis9AnyObject_p4objc_tcfg // dynamic.Foo.subscript.getter : (objc : Swift.AnyObject) -> Swift.Int
-// CHECK-LABEL:   #Foo.subscript!setter.1: _T07dynamic3FooC9subscriptSis9AnyObject_p4objc_tcfs // dynamic.Foo.subscript.setter : (objc : Swift.AnyObject) -> Swift.Int
+// CHECK-LABEL:   #Foo.init!initializer.1: {{.*}} :   _T07dynamic3FooCACSi6native_tcfc
+// CHECK-LABEL:   #Foo.nativeMethod!1: {{.*}} :       _T07dynamic3FooC12nativeMethodyyF
+// CHECK-LABEL:   #Foo.subscript!getter.1: {{.*}} :   _T07dynamic3FooC9subscriptSiSi6native_tcfg    // dynamic.Foo.subscript.getter : (native : Swift.Int) -> Swift.Int
+// CHECK-LABEL:   #Foo.subscript!setter.1: {{.*}} :   _T07dynamic3FooC9subscriptSiSi6native_tcfs    // dynamic.Foo.subscript.setter : (native : Swift.Int) -> Swift.Int
+// CHECK-LABEL:   #Foo.init!initializer.1: {{.*}} :   _T07dynamic3FooCACSi4objc_tcfc
+// CHECK-LABEL:   #Foo.objcMethod!1: {{.*}} :         _T07dynamic3FooC10objcMethodyyF
+// CHECK-LABEL:   #Foo.subscript!getter.1: {{.*}} : _T07dynamic3FooC9subscriptSis9AnyObject_p4objc_tcfg // dynamic.Foo.subscript.getter : (objc : Swift.AnyObject) -> Swift.Int
+// CHECK-LABEL:   #Foo.subscript!setter.1: {{.*}} : _T07dynamic3FooC9subscriptSis9AnyObject_p4objc_tcfs // dynamic.Foo.subscript.setter : (objc : Swift.AnyObject) -> Swift.Int
 // CHECK-NOT:     dynamic.Foo.init (dynamic.Foo.Type)(dynamic : Swift.Int) -> dynamic.Foo
 // CHECK-NOT:     dynamic.Foo.dynamicMethod
 // CHECK-NOT:     dynamic.Foo.subscript.getter (dynamic : Swift.Int) -> Swift.Int
 // CHECK-NOT:     dynamic.Foo.subscript.setter (dynamic : Swift.Int) -> Swift.Int
-// CHECK-LABEL:   #Foo.overriddenByDynamic!1: _T07dynamic3FooC19overriddenByDynamic{{[_0-9a-zA-Z]*}}F
-// CHECK-LABEL:   #Foo.nativeProp!getter.1:  _T07dynamic3FooC10nativePropSifg     // dynamic.Foo.nativeProp.getter : Swift.Int
-// CHECK-LABEL:   #Foo.nativeProp!setter.1:  _T07dynamic3FooC10nativePropSifs     // dynamic.Foo.nativeProp.setter : Swift.Int
-// CHECK-LABEL:   #Foo.objcProp!getter.1:    _T07dynamic3FooC8objcPropSifg  // dynamic.Foo.objcProp.getter : Swift.Int
-// CHECK-LABEL:   #Foo.objcProp!setter.1:    _T07dynamic3FooC8objcPropSifs  // dynamic.Foo.objcProp.setter : Swift.Int
+// CHECK-LABEL:   #Foo.overriddenByDynamic!1: {{.*}} : _T07dynamic3FooC19overriddenByDynamic{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL:   #Foo.nativeProp!getter.1: {{.*}} :  _T07dynamic3FooC10nativePropSifg     // dynamic.Foo.nativeProp.getter : Swift.Int
+// CHECK-LABEL:   #Foo.nativeProp!setter.1: {{.*}} :  _T07dynamic3FooC10nativePropSifs     // dynamic.Foo.nativeProp.setter : Swift.Int
+// CHECK-LABEL:   #Foo.objcProp!getter.1: {{.*}} :    _T07dynamic3FooC8objcPropSifg  // dynamic.Foo.objcProp.getter : Swift.Int
+// CHECK-LABEL:   #Foo.objcProp!setter.1: {{.*}} :    _T07dynamic3FooC8objcPropSifs  // dynamic.Foo.objcProp.setter : Swift.Int
 // CHECK-NOT:     dynamic.Foo.dynamicProp.getter
 // CHECK-NOT:     dynamic.Foo.dynamicProp.setter
 
 // Vtable uses a dynamic thunk for dynamic overrides
 // CHECK-LABEL: sil_vtable Subclass {
-// CHECK-LABEL:   #Foo.overriddenByDynamic!1: public _T07dynamic8SubclassC19overriddenByDynamic{{[_0-9a-zA-Z]*}}FTD
+// CHECK-LABEL:   #Foo.overriddenByDynamic!1: {{.*}} : public _T07dynamic8SubclassC19overriddenByDynamic{{[_0-9a-zA-Z]*}}FTD
 

--- a/test/SILGen/dynamic_init.swift
+++ b/test/SILGen/dynamic_init.swift
@@ -7,7 +7,7 @@ class C {
 // CHECK-LABEL: sil hidden @_T012dynamic_init15testDynamicInit{{[_0-9a-zA-Z]*}}F
 func testDynamicInit(cm: C.Type) {
   // CHECK: bb0([[CM:%[0-9]+]] : $@thick C.Type):
-  // CHECK:   [[METHOD:%[0-9]+]] = class_method [[CM]] : $@thick C.Type, #C.init!allocator.1 : (C.Type) -> () -> C , $@convention(method) (@thick C.Type) -> @owned C
+  // CHECK:   [[METHOD:%[0-9]+]] = class_method [[CM]] : $@thick C.Type, #C.init!allocator.1 : (C.Type) -> () -> C, $@convention(method) (@thick C.Type) -> @owned C
   // CHECK:   [[C_OBJ:%[0-9]+]] = apply [[METHOD]]([[CM]]) : $@convention(method) (@thick C.Type) -> @owned C
   // CHECK:   destroy_value [[C_OBJ]] : $C
   // CHECK:   [[RESULT:%[0-9]+]] = tuple ()

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -16,7 +16,7 @@ class X : P, CP {
 
   // CHECK-LABEL: sil hidden @_T012dynamic_self1XC7factory{{[_0-9a-zA-Z]*}}FZ : $@convention(method) (Int, @thick X.Type) -> @owned X
   // CHECK: bb0([[I:%[0-9]+]] : $Int, [[SELF:%[0-9]+]] : $@thick X.Type):
-  // CHECK: [[CTOR:%[0-9]+]] = class_method [[SELF]] : $@thick X.Type, #X.init!allocator.1 : (X.Type) -> (Int) -> X , $@convention(method) (Int, @thick X.Type) -> @owned X
+  // CHECK: [[CTOR:%[0-9]+]] = class_method [[SELF]] : $@thick X.Type, #X.init!allocator.1 : (X.Type) -> (Int) -> X, $@convention(method) (Int, @thick X.Type) -> @owned X
   // CHECK: apply [[CTOR]]([[I]], [[SELF]]) : $@convention(method) (Int, @thick X.Type) -> @owned X
   class func factory(i: Int) -> Self { return self.init(int: i) }
 }
@@ -36,7 +36,7 @@ func testDynamicSelfDispatch(y: Y) {
 // CHECK: bb0([[Y:%[0-9]+]] : $Y):
 // CHECK:   [[Y_COPY:%.*]] = copy_value [[Y]]
 // CHECK:   [[Y_AS_X_COPY:%[0-9]+]] = upcast [[Y_COPY]] : $Y to $X  
-// CHECK:   [[X_F:%[0-9]+]] = class_method [[Y_AS_X_COPY]] : $X, #X.f!1 : (X) -> () -> @dynamic_self X , $@convention(method) (@guaranteed X) -> @owned X
+// CHECK:   [[X_F:%[0-9]+]] = class_method [[Y_AS_X_COPY]] : $X, #X.f!1 : (X) -> () -> @dynamic_self X, $@convention(method) (@guaranteed X) -> @owned X
 // CHECK:   [[X_RESULT:%[0-9]+]] = apply [[X_F]]([[Y_AS_X_COPY]]) : $@convention(method) (@guaranteed X) -> @owned X
 // CHECK:   destroy_value [[Y_AS_X_COPY]]
 // CHECK:   [[Y_RESULT:%[0-9]+]] = unchecked_ref_cast [[X_RESULT]] : $X to $Y
@@ -50,7 +50,7 @@ func testDynamicSelfDispatchGeneric(gy: GY<Int>) {
   // CHECK: bb0([[GY:%[0-9]+]] : $GY<Int>):
   // CHECK:   [[GY_COPY:%.*]] = copy_value [[GY]]
   // CHECK:   [[GY_AS_GX_COPY:%[0-9]+]] = upcast [[GY_COPY]] : $GY<Int> to $GX<Array<Int>>
-  // CHECK:   [[GX_F:%[0-9]+]] = class_method [[GY_AS_GX_COPY]] : $GX<Array<Int>>, #GX.f!1 : <T> (GX<T>) -> () -> @dynamic_self GX<T> , $@convention(method) <τ_0_0> (@guaranteed GX<τ_0_0>) -> @owned GX<τ_0_0>
+  // CHECK:   [[GX_F:%[0-9]+]] = class_method [[GY_AS_GX_COPY]] : $GX<Array<Int>>, #GX.f!1 : <T> (GX<T>) -> () -> @dynamic_self GX<T>, $@convention(method) <τ_0_0> (@guaranteed GX<τ_0_0>) -> @owned GX<τ_0_0>
   // CHECK:   [[GX_RESULT:%[0-9]+]] = apply [[GX_F]]<[Int]>([[GY_AS_GX_COPY]]) : $@convention(method) <τ_0_0> (@guaranteed GX<τ_0_0>) -> @owned GX<τ_0_0>
   // CHECK:   destroy_value [[GY_AS_GX_COPY]]
   // CHECK:   [[GY_RESULT:%[0-9]+]] = unchecked_ref_cast [[GX_RESULT]] : $GX<Array<Int>> to $GY<Int>
@@ -62,7 +62,7 @@ func testDynamicSelfDispatchGeneric(gy: GY<Int>) {
 // CHECK-LABEL: sil hidden @_T012dynamic_self21testArchetypeDispatch{{[_0-9a-zA-Z]*}}F : $@convention(thin) <T where T : P> (@in T) -> ()
 func testArchetypeDispatch<T: P>(t: T) {
   // CHECK: bb0([[T:%[0-9]+]] : $*T):
-  // CHECK:   [[ARCHETYPE_F:%[0-9]+]] = witness_method $T, #P.f!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0
+  // CHECK:   [[ARCHETYPE_F:%[0-9]+]] = witness_method $T, #P.f!1 : {{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0
   // CHECK:   [[T_RESULT:%[0-9]+]] = alloc_stack $T
   // CHECK:   [[SELF_RESULT:%[0-9]+]] = apply [[ARCHETYPE_F]]<T>([[T_RESULT]], [[T]]) : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0
   t.f()
@@ -74,7 +74,7 @@ func testExistentialDispatch(p: P) {
 // CHECK:   [[PCOPY_ADDR:%[0-9]+]] = open_existential_addr [[P]] : $*P to $*@opened([[N:".*"]]) P
 // CHECK:   [[P_RESULT:%[0-9]+]] = alloc_stack $P
 // CHECK:   [[P_RESULT_ADDR:%[0-9]+]] = init_existential_addr [[P_RESULT]] : $*P, $@opened([[N]]) P
-// CHECK:   [[P_F_METHOD:%[0-9]+]] = witness_method $@opened([[N]]) P, #P.f!1, [[PCOPY_ADDR]]{{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0
+// CHECK:   [[P_F_METHOD:%[0-9]+]] = witness_method $@opened([[N]]) P, #P.f!1 : {{.*}}, [[PCOPY_ADDR]]{{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0
 // CHECK:   apply [[P_F_METHOD]]<@opened([[N]]) P>([[P_RESULT_ADDR]], [[PCOPY_ADDR]]) : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0
 // CHECK:   destroy_addr [[P_RESULT]] : $*P
 // CHECK:   dealloc_stack [[P_RESULT]] : $*P
@@ -86,7 +86,7 @@ func testExistentialDispatch(p: P) {
 func testExistentialDispatchClass(cp: CP) {
 // CHECK: bb0([[CP:%[0-9]+]] : $CP):
 // CHECK:   [[CP_ADDR:%[0-9]+]] = open_existential_ref [[CP]] : $CP to $@opened([[N:".*"]]) CP
-// CHECK:   [[CP_F:%[0-9]+]] = witness_method $@opened([[N]]) CP, #CP.f!1, [[CP_ADDR]]{{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : CP> (@guaranteed τ_0_0) -> @owned τ_0_0
+// CHECK:   [[CP_F:%[0-9]+]] = witness_method $@opened([[N]]) CP, #CP.f!1 : {{.*}}, [[CP_ADDR]]{{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : CP> (@guaranteed τ_0_0) -> @owned τ_0_0
 // CHECK:   [[CP_F_RESULT:%[0-9]+]] = apply [[CP_F]]<@opened([[N]]) CP>([[CP_ADDR]]) : $@convention(witness_method) <τ_0_0 where τ_0_0 : CP> (@guaranteed τ_0_0) -> @owned τ_0_0
 // CHECK:   [[RESULT_EXISTENTIAL:%[0-9]+]] = init_existential_ref [[CP_F_RESULT]] : $@opened([[N]]) CP : $@opened([[N]]) CP, $CP
 // CHECK:   destroy_value [[CP_F_RESULT]] : $@opened([[N]]) CP
@@ -121,7 +121,7 @@ func testObjCInit(meta: ObjCInit.Type) {
 // CHECK:   [[PB:%.*]] = project_box [[O]]
 // CHECK:   [[OBJC_META:%[0-9]+]] = thick_to_objc_metatype [[THICK_META]] : $@thick ObjCInit.Type to $@objc_metatype ObjCInit.Type
 // CHECK:   [[OBJ:%[0-9]+]] = alloc_ref_dynamic [objc] [[OBJC_META]] : $@objc_metatype ObjCInit.Type, $ObjCInit
-// CHECK:   [[INIT:%[0-9]+]] = class_method [volatile] [[OBJ]] : $ObjCInit, #ObjCInit.init!initializer.1.foreign : (ObjCInit.Type) -> () -> ObjCInit , $@convention(objc_method) (@owned ObjCInit) -> @owned ObjCInit
+// CHECK:   [[INIT:%[0-9]+]] = class_method [volatile] [[OBJ]] : $ObjCInit, #ObjCInit.init!initializer.1.foreign : (ObjCInit.Type) -> () -> ObjCInit, $@convention(objc_method) (@owned ObjCInit) -> @owned ObjCInit
 // CHECK:   [[RESULT_OBJ:%[0-9]+]] = apply [[INIT]]([[OBJ]]) : $@convention(objc_method) (@owned ObjCInit) -> @owned ObjCInit
 // CHECK:   store [[RESULT_OBJ]] to [init] [[PB]] : $*ObjCInit
 // CHECK:   destroy_value [[O]] : ${ var ObjCInit }
@@ -154,7 +154,7 @@ func testOptionalResult(v : OptionalResultInheritor) {
 // CHECK: bb0([[ARG:%.*]] : $OptionalResultInheritor):
 // CHECK:      [[COPY_ARG:%.*]] = copy_value [[ARG]]
 // CHECK:      [[CAST_COPY_ARG:%.*]] = upcast [[COPY_ARG]]
-// CHECK:      [[T0:%.*]] = class_method [[CAST_COPY_ARG]] : $OptionalResult, #OptionalResult.foo!1 : (OptionalResult) -> () -> @dynamic_self OptionalResult? , $@convention(method) (@guaranteed OptionalResult) -> @owned Optional<OptionalResult>
+// CHECK:      [[T0:%.*]] = class_method [[CAST_COPY_ARG]] : $OptionalResult, #OptionalResult.foo!1 : (OptionalResult) -> () -> @dynamic_self OptionalResult?, $@convention(method) (@guaranteed OptionalResult) -> @owned Optional<OptionalResult>
 // CHECK-NEXT: [[RES:%.*]] = apply [[T0]]([[CAST_COPY_ARG]])
 // CHECK:      select_enum [[RES]]
 // CHECK:      [[T1:%.*]] = unchecked_enum_data [[RES]]
@@ -241,7 +241,7 @@ func partialApplySelfReturn(c: Factory, t: Factory.Type) {
 }
 
 // CHECK-LABEL: sil_witness_table hidden X: P module dynamic_self {
-// CHECK: method #P.f!1: @_T012dynamic_self1XCAA1PAaaDP1f{{[_0-9a-zA-Z]*}}FTW
+// CHECK: method #P.f!1: {{.*}} : @_T012dynamic_self1XCAA1PAaaDP1f{{[_0-9a-zA-Z]*}}FTW
 
 // CHECK-LABEL: sil_witness_table hidden X: CP module dynamic_self {
-// CHECK: method #CP.f!1: @_T012dynamic_self1XCAA2CPAaaDP1f{{[_0-9a-zA-Z]*}}FTW
+// CHECK: method #CP.f!1: {{.*}} : @_T012dynamic_self1XCAA2CPAaaDP1f{{[_0-9a-zA-Z]*}}FTW

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -232,7 +232,7 @@ struct DoomedStruct : Doomed {
 // CHECK:      [[TEMP:%.*]] = alloc_stack $DoomedClass
 // CHECK:      copy_addr %0 to [initialization] [[TEMP]]
 // CHECK:      [[SELF:%.*]] = load [take] [[TEMP]] : $*DoomedClass
-// CHECK:      [[T0:%.*]] = class_method [[SELF]] : $DoomedClass, #DoomedClass.check!1 : (DoomedClass) -> () throws -> () , $@convention(method) (@guaranteed DoomedClass) -> @error Error
+// CHECK:      [[T0:%.*]] = class_method [[SELF]] : $DoomedClass, #DoomedClass.check!1 : (DoomedClass) -> () throws -> (), $@convention(method) (@guaranteed DoomedClass) -> @error Error
 // CHECK-NEXT: try_apply [[T0]]([[SELF]])
 // CHECK:    bb1([[T0:%.*]] : $()):
 // CHECK:      [[T0:%.*]] = tuple ()
@@ -265,7 +265,7 @@ struct HappyStruct : Doomed {
 // CHECK:      [[TEMP:%.*]] = alloc_stack $HappyClass
 // CHECK:      copy_addr %0 to [initialization] [[TEMP]]
 // CHECK:      [[SELF:%.*]] = load [take] [[TEMP]] : $*HappyClass
-// CHECK:      [[T0:%.*]] = class_method [[SELF]] : $HappyClass, #HappyClass.check!1 : (HappyClass) -> () -> () , $@convention(method) (@guaranteed HappyClass) -> ()
+// CHECK:      [[T0:%.*]] = class_method [[SELF]] : $HappyClass, #HappyClass.check!1 : (HappyClass) -> () -> (), $@convention(method) (@guaranteed HappyClass) -> ()
 // CHECK:      [[T1:%.*]] = apply [[T0]]([[SELF]])
 // CHECK:      [[T1:%.*]] = tuple ()
 // CHECK:      destroy_value [[SELF]] : $HappyClass
@@ -894,13 +894,13 @@ func testOptionalTryNeverFailsAddressOnlyVar<T>(_ obj: T) {
 class SomeErrorClass : Error { }
 
 // CHECK-LABEL: sil_vtable SomeErrorClass
-// CHECK-NEXT:   #SomeErrorClass.deinit!deallocator: _TFC6errors14SomeErrorClassD
-// CHECK-NEXT:   #SomeErrorClass.init!initializer.1: _TFC6errors14SomeErrorClasscfT_S0_
+// CHECK-NEXT:   #SomeErrorClass.deinit!deallocator: {{.*}} : _TFC6errors14SomeErrorClassD
+// CHECK-NEXT:   #SomeErrorClass.init!initializer.1: {{.*}} : _TFC6errors14SomeErrorClasscfT_S0_
 // CHECK-NEXT: }
 
 class OtherErrorSub : OtherError { }
 
 // CHECK-LABEL: sil_vtable OtherErrorSub {
-// CHECK-NEXT:  #OtherError.init!initializer.1: _TFC6errors13OtherErrorSubcfT_S0_     // OtherErrorSub.init() -> OtherErrorSub
-// CHECK-NEXT:  #OtherErrorSub.deinit!deallocator: _TFC6errors13OtherErrorSubD        // OtherErrorSub.__deallocating_deinit
+// CHECK-NEXT:  #OtherError.init!initializer.1: {{.*}} : _TFC6errors13OtherErrorSubcfT_S0_     // OtherErrorSub.init() -> OtherErrorSub
+// CHECK-NEXT:  #OtherErrorSub.deinit!deallocator: {{.*}} : _TFC6errors13OtherErrorSubD        // OtherErrorSub.__deallocating_deinit
 // CHECK-NEXT:}

--- a/test/SILGen/existential_erasure.swift
+++ b/test/SILGen/existential_erasure.swift
@@ -44,7 +44,7 @@ func openExistentialToP1(_ p: P) throws {
 // CHECK:   [[OPEN:%.*]] = open_existential_addr %0 : $*P to $*[[OPEN_TYPE:@opened\(.*\) P]]
 // CHECK:   [[RESULT:%.*]] = alloc_stack $P
 // CHECK:   [[RESULT_ADDR:%.*]] = init_existential_addr [[RESULT]] : $*P, $[[OPEN_TYPE]]
-// CHECK:   [[METHOD:%.*]] = witness_method $[[OPEN_TYPE]], #P.downgrade!1, [[OPEN]]
+// CHECK:   [[METHOD:%.*]] = witness_method $[[OPEN_TYPE]], #P.downgrade!1 : {{.*}}, [[OPEN]]
 // CHECK:   [[FUNC:%.*]] = function_ref @_T019existential_erasure12throwingFuncSbyKF
 // CHECK:   try_apply [[FUNC]]()
 //
@@ -69,7 +69,7 @@ func openExistentialToP2(_ p: P) throws {
 // CHECK:   [[OPEN:%.*]] = open_existential_addr %0 : $*P to $*[[OPEN_TYPE:@opened\(.*\) P]]
 // CHECK:   [[RESULT:%.*]] = alloc_stack $P
 // CHECK:   [[RESULT_ADDR:%.*]] = init_existential_addr [[RESULT]] : $*P, $[[OPEN_TYPE]]
-// CHECK:   [[METHOD:%.*]] = witness_method $[[OPEN_TYPE]], #P.upgrade!1, [[OPEN]]
+// CHECK:   [[METHOD:%.*]] = witness_method $[[OPEN_TYPE]], #P.upgrade!1 : {{.*}}, [[OPEN]]
 // CHECK:   try_apply [[METHOD]]<[[OPEN_TYPE]]>([[RESULT_ADDR]], [[OPEN]])
 //
 // CHECK: bb1

--- a/test/SILGen/final.swift
+++ b/test/SILGen/final.swift
@@ -32,14 +32,14 @@ func testDirectDispatch(c : TestClass) -> Int {
 
 // Verify that the non-overriding final methods don't get emitted to the vtable.
 // CHECK-LABEL: sil_vtable TestClass {
-// CHECK-NEXT:  #TestClass.baseMethod!1: _T05final9TestClassC10baseMethod{{[_0-9a-zA-Z]*}}F
+// CHECK-NEXT:  #TestClass.baseMethod!1: {{.*}} : _T05final9TestClassC10baseMethod{{[_0-9a-zA-Z]*}}F
 // CHECK-NEXT:  #TestClass.deinit!
-// CHECK-NEXT:  #TestClass.init!initializer.1: _T05final9TestClassC{{[_0-9a-zA-Z]*}}fc
+// CHECK-NEXT:  #TestClass.init!initializer.1: {{.*}} : _T05final9TestClassC{{[_0-9a-zA-Z]*}}fc
 // CHECK-NEXT: }
 
 // Verify that overriding final methods don't get emitted to the vtable.
 // CHECK-LABEL: sil_vtable TestDerived {
-// CHECK-NEXT:  #TestClass.baseMethod!1: _T05final11TestDerivedC10baseMethod{{[_0-9a-zA-Z]*}}F
-// CHECK-NEXT:  #TestClass.init!initializer.1: _T05final11TestDerivedC{{[_0-9a-zA-Z]*}}fc
+// CHECK-NEXT:  #TestClass.baseMethod!1: {{.*}} : _T05final11TestDerivedC10baseMethod{{[_0-9a-zA-Z]*}}F
+// CHECK-NEXT:  #TestClass.init!initializer.1: {{.*}} : _T05final11TestDerivedC{{[_0-9a-zA-Z]*}}fc
 // CHECK-NEXT:  #TestDerived.deinit!
 // CHECK-NEXT: }

--- a/test/SILGen/force_cast_chained_optional.swift
+++ b/test/SILGen/force_cast_chained_optional.swift
@@ -12,7 +12,7 @@ class C {}
 class D: C {}
 
 // CHECK-LABEL: sil hidden @_T027force_cast_chained_optional4testAA1DCAA3FooCF
-// CHECK:         class_method %0 : $Foo, #Foo.bar!getter.1 : (Foo) -> () -> Bar! , $@convention(method) (@guaranteed Foo) ->
+// CHECK:         class_method %0 : $Foo, #Foo.bar!getter.1 : (Foo) -> () -> Bar!, $@convention(method) (@guaranteed Foo) ->
 // CHECK:         select_enum_addr
 // CHECK:         cond_br {{%.*}}, [[SOME_BAR:bb[0-9]+]], [[NO_BAR:bb[0-9]+]]
 // CHECK:       [[NO_BAR]]:
@@ -20,7 +20,7 @@ class D: C {}
 // CHECK:       [[SOME_BAR]]:
 // CHECK:         [[PAYLOAD_ADDR:%.*]] = unchecked_take_enum_data_addr {{%.*}} : $*Optional<Bar>
 // CHECK:         [[BAR:%.*]] = load [copy] [[PAYLOAD_ADDR]]
-// CHECK:         [[METHOD:%.*]] = class_method [[BAR]] : $Bar, #Bar.bas!getter.1 : (Bar) -> () -> C! , $@convention(method) (@guaranteed Bar) ->
+// CHECK:         [[METHOD:%.*]] = class_method [[BAR]] : $Bar, #Bar.bas!getter.1 : (Bar) -> () -> C!, $@convention(method) (@guaranteed Bar) ->
 // CHECK:         apply [[METHOD]]([[BAR]])
 // CHECK:         destroy_value [[BAR]]
 // CHECK:         unconditional_checked_cast {{%.*}} : $C to $D

--- a/test/SILGen/foreign_errors.swift
+++ b/test/SILGen/foreign_errors.swift
@@ -10,7 +10,7 @@ import errors
 // CHECK: sil hidden @_TF14foreign_errors5test0FzT_T_ : $@convention(thin) () -> @error Error
 func test0() throws {
   // CHECK: [[SELF:%.*]] = metatype $@thick ErrorProne.Type
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $@thick ErrorProne.Type, #ErrorProne.fail!1.foreign : (ErrorProne.Type) -> () throws -> () , $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> ObjCBool
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $@thick ErrorProne.Type, #ErrorProne.fail!1.foreign : (ErrorProne.Type) -> () throws -> (), $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> ObjCBool
   // CHECK: [[OBJC_SELF:%.*]] = thick_to_objc_metatype [[SELF]]
 
   //   Create a strong temporary holding nil.
@@ -139,7 +139,7 @@ let fn = ErrorProne.fail
 
 // CHECK-LABEL: sil shared [thunk] @_TTOZFCSo10ErrorProne4fail{{.*}} : $@convention(method) (@thick ErrorProne.Type) -> @error Error {
 // CHECK:      [[SELF:%.*]] = thick_to_objc_metatype %0 : $@thick ErrorProne.Type to $@objc_metatype ErrorProne.Type
-// CHECK:      [[METHOD:%.*]] = class_method [volatile] [[T0]] : $@objc_metatype ErrorProne.Type, #ErrorProne.fail!1.foreign : (ErrorProne.Type) -> () throws -> () , $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> ObjCBool
+// CHECK:      [[METHOD:%.*]] = class_method [volatile] [[T0]] : $@objc_metatype ErrorProne.Type, #ErrorProne.fail!1.foreign : (ErrorProne.Type) -> () throws -> (), $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> ObjCBool
 // CHECK:      [[TEMP:%.*]] = alloc_stack $Optional<NSError>
 // CHECK:      [[RESULT:%.*]] = apply [[METHOD]]({{%.*}}, [[SELF]])
 // CHECK:      cond_br
@@ -153,14 +153,14 @@ func testArgs() throws {
 }
 // CHECK: sil hidden @_TF14foreign_errors8testArgsFzT_T_ : $@convention(thin) () -> @error Error
 // CHECK:   debug_value undef : $Error, var, name "$error", argno 1
-// CHECK:   class_method [volatile] %1 : $@thick ErrorProne.Type, #ErrorProne.consume!1.foreign : (ErrorProne.Type) -> (Any!) throws -> () , $@convention(objc_method) (Optional<AnyObject>, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> ObjCBool
+// CHECK:   class_method [volatile] %1 : $@thick ErrorProne.Type, #ErrorProne.consume!1.foreign : (ErrorProne.Type) -> (Any!) throws -> (), $@convention(objc_method) (Optional<AnyObject>, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> ObjCBool
 
 func testBridgedResult() throws {
   let array = try ErrorProne.collection(withCount: 0)
 }
 // CHECK-LABEL: sil hidden @_TF14foreign_errors17testBridgedResultFzT_T_ : $@convention(thin) () -> @error Error {
 // CHECK:   debug_value undef : $Error, var, name "$error", argno 1
-// CHECK:   class_method [volatile] %1 : $@thick ErrorProne.Type, #ErrorProne.collection!1.foreign : (ErrorProne.Type) -> (Int) throws -> [Any] , $@convention(objc_method) (Int, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> @autoreleased Optional<NSArray>
+// CHECK:   class_method [volatile] %1 : $@thick ErrorProne.Type, #ErrorProne.collection!1.foreign : (ErrorProne.Type) -> (Int) throws -> [Any], $@convention(objc_method) (Int, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> @autoreleased Optional<NSArray>
 
 // rdar://20861374
 // Clear out the self box before delegating.
@@ -178,7 +178,7 @@ class VeryErrorProne : ErrorProne {
 // CHECK:      store [[ARG2]] to [init] [[MARKED_BOX]]
 // CHECK:      [[T0:%.*]] = load_borrow [[MARKED_BOX]]
 // CHECK-NEXT: [[T1:%.*]] = upcast [[T0]] : $VeryErrorProne to $ErrorProne
-// CHECK-NEXT: [[T2:%.*]] = super_method [volatile] [[T0]] : $VeryErrorProne, #ErrorProne.init!initializer.1.foreign : (ErrorProne.Type) -> (Any?) throws -> ErrorProne , $@convention(objc_method) (Optional<AnyObject>, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @owned ErrorProne) -> @owned Optional<ErrorProne>
+// CHECK-NEXT: [[T2:%.*]] = super_method [volatile] [[T0]] : $VeryErrorProne, #ErrorProne.init!initializer.1.foreign : (ErrorProne.Type) -> (Any?) throws -> ErrorProne, $@convention(objc_method) (Optional<AnyObject>, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @owned ErrorProne) -> @owned Optional<ErrorProne>
 // CHECK:      [[ARG1_COPY:%.*]] = copy_value [[ARG1]]
 // CHECK-NOT:  [[BOX]]{{^[0-9]}}
 // CHECK-NOT:  [[MARKED_BOX]]{{^[0-9]}}
@@ -188,12 +188,12 @@ class VeryErrorProne : ErrorProne {
 // CHECK: sil hidden @_TF14foreign_errors12testProtocolFzPSo18ErrorProneProtocol_T_
 func testProtocol(_ p: ErrorProneProtocol) throws {
   // CHECK:   [[T0:%.*]] = open_existential_ref %0 : $ErrorProneProtocol to $[[OPENED:@opened(.*) ErrorProneProtocol]]
-  // CHECK:   [[T1:%.*]] = witness_method [volatile] $[[OPENED]], #ErrorProneProtocol.obliterate!1.foreign, [[T0]] : $[[OPENED]] :
+  // CHECK:   [[T1:%.*]] = witness_method [volatile] $[[OPENED]], #ErrorProneProtocol.obliterate!1.foreign : {{.*}}, [[T0]] : $[[OPENED]] :
   // CHECK:   apply [[T1]]<[[OPENED]]>({{%.*}}, [[T0]]) : $@convention(objc_method) <τ_0_0 where τ_0_0 : ErrorProneProtocol> (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, τ_0_0) -> ObjCBool
   try p.obliterate()
 
   // CHECK:   [[T0:%.*]] = open_existential_ref %0 : $ErrorProneProtocol to $[[OPENED:@opened(.*) ErrorProneProtocol]]
-  // CHECK:   [[T1:%.*]] = witness_method [volatile] $[[OPENED]], #ErrorProneProtocol.invigorate!1.foreign, [[T0]] : $[[OPENED]] :
+  // CHECK:   [[T1:%.*]] = witness_method [volatile] $[[OPENED]], #ErrorProneProtocol.invigorate!1.foreign : {{.*}}, [[T0]] : $[[OPENED]] :
   // CHECK:   apply [[T1]]<[[OPENED]]>({{%.*}}, {{%.*}}, [[T0]]) : $@convention(objc_method) <τ_0_0 where τ_0_0 : ErrorProneProtocol> (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, Optional<@convention(block) () -> ()>, τ_0_0) -> ObjCBool
   try p.invigorate(callback: {})
 }
@@ -211,7 +211,7 @@ func testNonNilError() throws -> Float {
 }
 // CHECK: sil hidden @_TF14foreign_errors15testNonNilErrorFzT_Sf :
 // CHECK:   [[T0:%.*]] = metatype $@thick ErrorProne.Type
-// CHECK:   [[T1:%.*]] = class_method [volatile] [[T0]] : $@thick ErrorProne.Type, #ErrorProne.bounce!1.foreign : (ErrorProne.Type) -> () throws -> Float , $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> Float
+// CHECK:   [[T1:%.*]] = class_method [volatile] [[T0]] : $@thick ErrorProne.Type, #ErrorProne.bounce!1.foreign : (ErrorProne.Type) -> () throws -> Float, $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> Float
 // CHECK:   [[OPTERR:%.*]] = alloc_stack $Optional<NSError>
 // CHECK:   [[RESULT:%.*]] = apply [[T1]](
 // CHECK:   assign {{%.*}} to [[OPTERR]]
@@ -227,7 +227,7 @@ func testPreservedResult() throws -> CInt {
 }
 // CHECK: sil hidden @_TF14foreign_errors19testPreservedResultFzT_Vs5Int32
 // CHECK:   [[T0:%.*]] = metatype $@thick ErrorProne.Type
-// CHECK:   [[T1:%.*]] = class_method [volatile] [[T0]] : $@thick ErrorProne.Type, #ErrorProne.ounce!1.foreign : (ErrorProne.Type) -> () throws -> Int32 , $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> Int32
+// CHECK:   [[T1:%.*]] = class_method [volatile] [[T0]] : $@thick ErrorProne.Type, #ErrorProne.ounce!1.foreign : (ErrorProne.Type) -> () throws -> Int32, $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> Int32
 // CHECK:   [[OPTERR:%.*]] = alloc_stack $Optional<NSError>
 // CHECK:   [[RESULT:%.*]] = apply [[T1]](
 // CHECK:   [[T0:%.*]] = struct_extract [[RESULT]]
@@ -245,7 +245,7 @@ func testPreservedResultBridged() throws -> Int {
 
 // CHECK-LABEL: sil hidden @_TF14foreign_errors26testPreservedResultBridgedFzT_Si
 // CHECK:   [[T0:%.*]] = metatype $@thick ErrorProne.Type
-// CHECK:   [[T1:%.*]] = class_method [volatile] [[T0]] : $@thick ErrorProne.Type, #ErrorProne.ounceWord!1.foreign : (ErrorProne.Type) -> () throws -> Int , $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> Int
+// CHECK:   [[T1:%.*]] = class_method [volatile] [[T0]] : $@thick ErrorProne.Type, #ErrorProne.ounceWord!1.foreign : (ErrorProne.Type) -> () throws -> Int, $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> Int
 // CHECK:   [[OPTERR:%.*]] = alloc_stack $Optional<NSError>
 // CHECK:   [[RESULT:%.*]] = apply [[T1]](
 // CHECK:   [[T0:%.*]] = struct_extract [[RESULT]]
@@ -263,7 +263,7 @@ func testPreservedResultInverted() throws {
 
 // CHECK-LABEL: sil hidden @_TF14foreign_errors27testPreservedResultInvertedFzT_T_
 // CHECK:   [[T0:%.*]] = metatype $@thick ErrorProne.Type
-// CHECK:   [[T1:%.*]] = class_method [volatile] [[T0]] : $@thick ErrorProne.Type, #ErrorProne.once!1.foreign : (ErrorProne.Type) -> () throws -> () , $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> Int32
+// CHECK:   [[T1:%.*]] = class_method [volatile] [[T0]] : $@thick ErrorProne.Type, #ErrorProne.once!1.foreign : (ErrorProne.Type) -> () throws -> (), $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> Int32
 // CHECK:   [[OPTERR:%.*]] = alloc_stack $Optional<NSError>
 // CHECK:   [[RESULT:%.*]] = apply [[T1]](
 // CHECK:   [[T0:%.*]] = struct_extract [[RESULT]]

--- a/test/SILGen/functions.swift
+++ b/test/SILGen/functions.swift
@@ -191,7 +191,7 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: [[C:%[0-9]+]] = load [copy] [[CADDR]]
   // CHECK: [[J:%[0-9]+]] = load [trivial] [[JADDR]]
   // CHECK: [[K:%[0-9]+]] = load [trivial] [[KADDR]]
-  // CHECK: [[GETTER:%[0-9]+]] = class_method [[C]] : $SomeClass, #SomeClass.subscript!getter.1 : (SomeClass) -> (Builtin.Int64, Builtin.Int64) -> Builtin.Int64 , $@convention(method) (Builtin.Int64, Builtin.Int64, @guaranteed SomeClass) -> Builtin.Int64
+  // CHECK: [[GETTER:%[0-9]+]] = class_method [[C]] : $SomeClass, #SomeClass.subscript!getter.1 : (SomeClass) -> (Builtin.Int64, Builtin.Int64) -> Builtin.Int64, $@convention(method) (Builtin.Int64, Builtin.Int64, @guaranteed SomeClass) -> Builtin.Int64
   // CHECK: apply [[GETTER]]([[J]], [[K]], [[C]])
   // CHECK: destroy_value [[C]]
   i = c[j, k]
@@ -200,7 +200,7 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
   // CHECK: [[J:%[0-9]+]] = load [trivial] [[JADDR]]
   // CHECK: [[K:%[0-9]+]] = load [trivial] [[KADDR]]
-  // CHECK: [[SETTER:%[0-9]+]] = class_method [[C]] : $SomeClass, #SomeClass.subscript!setter.1 : (SomeClass) -> (Builtin.Int64, Builtin.Int64, Builtin.Int64) -> () , $@convention(method) (Builtin.Int64, Builtin.Int64, Builtin.Int64, @guaranteed SomeClass) -> ()
+  // CHECK: [[SETTER:%[0-9]+]] = class_method [[C]] : $SomeClass, #SomeClass.subscript!setter.1 : (SomeClass) -> (Builtin.Int64, Builtin.Int64, Builtin.Int64) -> (), $@convention(method) (Builtin.Int64, Builtin.Int64, Builtin.Int64, @guaranteed SomeClass) -> ()
   // CHECK: apply [[SETTER]]([[K]], [[I]], [[J]], [[C]])
   // CHECK: destroy_value [[C]]
   c[i, j] = k

--- a/test/SILGen/generic_property_base_lifetime.swift
+++ b/test/SILGen/generic_property_base_lifetime.swift
@@ -17,7 +17,7 @@ protocol ProtocolB {
 // CHECK: bb0([[ARG:%.*]] : $ProtocolA):
 // CHECK:   [[PROJECTION:%.*]] = open_existential_ref [[ARG]]
 // CHECK:   [[PROJECTION_COPY:%.*]] = copy_value [[PROJECTION]]
-// CHECK:   [[WITNESS_METHOD:%.*]] = witness_method $@opened({{.*}}) ProtocolA, #ProtocolA.intProp!getter.1, [[PROJECTION]]
+// CHECK:   [[WITNESS_METHOD:%.*]] = witness_method $@opened({{.*}}) ProtocolA, #ProtocolA.intProp!getter.1 : {{.*}}, [[PROJECTION]]
 // CHECK:   [[RESULT:%.*]] = apply [[WITNESS_METHOD]]<@opened{{.*}}>([[PROJECTION_COPY]])
 // CHECK:   destroy_value [[PROJECTION_COPY]]
 // CHECK:   destroy_value [[ARG]]
@@ -31,7 +31,7 @@ func getIntPropExistential(_ a: ProtocolA) -> Int {
 // CHECK: bb0([[ARG:%.*]] : $ProtocolA):
 // CHECK:   [[PROJECTION:%.*]] = open_existential_ref [[ARG]]
 // CHECK:   [[PROJECTION_COPY:%.*]] = copy_value [[PROJECTION]]
-// CHECK:   [[WITNESS_METHOD:%.*]] = witness_method $@opened({{.*}}) ProtocolA, #ProtocolA.intProp!setter.1, [[PROJECTION]]
+// CHECK:   [[WITNESS_METHOD:%.*]] = witness_method $@opened({{.*}}) ProtocolA, #ProtocolA.intProp!setter.1 : {{.*}}, [[PROJECTION]]
 // CHECK:   apply [[WITNESS_METHOD]]<@opened{{.*}}>({{%.*}}, [[PROJECTION_COPY]])
 // CHECK:   destroy_value [[PROJECTION_COPY]]
 // CHECK:   destroy_value [[ARG]]
@@ -83,7 +83,7 @@ func getIntPropGeneric<T: ProtocolB>(_ a: T) -> Int {
 // CHECK: bb0([[ARG:%.*]] : $ProtocolO):
 // CHECK:  [[PROJECTION:%.*]] = open_existential_ref [[ARG]]
 // CHECK:  [[PROJECTION_COPY:%.*]] = copy_value [[PROJECTION]]
-// CHECK:  [[METHOD:%.*]] = witness_method [volatile] $@opened({{.*}}) ProtocolO, #ProtocolO.intProp!getter.1.foreign, [[PROJECTION]]
+// CHECK:  [[METHOD:%.*]] = witness_method [volatile] $@opened({{.*}}) ProtocolO, #ProtocolO.intProp!getter.1.foreign : {{.*}}, [[PROJECTION]]
 // CHECK:  apply [[METHOD]]<@opened{{.*}}>([[PROJECTION_COPY]])
 // CHECK:  destroy_value [[PROJECTION_COPY]]
 // CHECK:  destroy_value [[ARG]]
@@ -96,7 +96,7 @@ func getIntPropExistential(_ a: ProtocolO) -> Int {
 // CHECK: bb0([[ARG:%.*]] : $ProtocolO):
 // CHECK:   [[PROJECTION:%.*]] = open_existential_ref [[ARG]]
 // CHECK:   [[PROJECTION_COPY:%.*]] = copy_value [[PROJECTION]]
-// CHECK:   [[METHOD:%.*]] = witness_method [volatile] $@opened({{.*}}) ProtocolO, #ProtocolO.intProp!setter.1.foreign, [[PROJECTION]]
+// CHECK:   [[METHOD:%.*]] = witness_method [volatile] $@opened({{.*}}) ProtocolO, #ProtocolO.intProp!setter.1.foreign : {{.*}}, [[PROJECTION]]
 // CHECK:   apply [[METHOD]]<@opened{{.*}}>({{.*}}, [[PROJECTION_COPY]])
 // CHECK:   destroy_value [[PROJECTION_COPY]]
 // CHECK:   destroy_value [[ARG]]

--- a/test/SILGen/generic_witness.swift
+++ b/test/SILGen/generic_witness.swift
@@ -8,7 +8,7 @@ protocol Runcible {
 // CHECK-LABEL: sil hidden @_T015generic_witness3foo{{[_0-9a-zA-Z]*}}F : $@convention(thin) <B where B : Runcible> (@in B) -> () {
 
 func foo<B : Runcible>(_ x: B) {
-  // CHECK: [[METHOD:%.*]] = witness_method $B, #Runcible.runce!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : Runcible><τ_1_0> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
+  // CHECK: [[METHOD:%.*]] = witness_method $B, #Runcible.runce!1 : {{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : Runcible><τ_1_0> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
   // CHECK: apply [[METHOD]]<B, Int>
   x.runce(5)
 }

--- a/test/SILGen/guaranteed_self.swift
+++ b/test/SILGen/guaranteed_self.swift
@@ -502,19 +502,19 @@ class LetFieldClass {
 
   // CHECK-LABEL: sil hidden @_T015guaranteed_self13LetFieldClassC10varkMethod{{[_0-9a-zA-Z]*}}F : $@convention(method) (@guaranteed LetFieldClass) -> () {
   // CHECK: bb0([[CLS:%.*]] : $LetFieldClass):
-  // CHECK: [[KRAKEN_GETTER_FUN:%.*]] = class_method [[CLS]] : $LetFieldClass, #LetFieldClass.vark!getter.1 : (LetFieldClass) -> () -> Kraken , $@convention(method) (@guaranteed LetFieldClass) -> @owned Kraken
+  // CHECK: [[KRAKEN_GETTER_FUN:%.*]] = class_method [[CLS]] : $LetFieldClass, #LetFieldClass.vark!getter.1 : (LetFieldClass) -> () -> Kraken, $@convention(method) (@guaranteed LetFieldClass) -> @owned Kraken
   // CHECK-NEXT: [[KRAKEN:%.*]] = apply [[KRAKEN_GETTER_FUN]]([[CLS]])
   // CHECK-NEXT: [[KRAKEN_METH:%.*]] = class_method [[KRAKEN]]
   // CHECK-NEXT: apply [[KRAKEN_METH]]([[KRAKEN]])
   // CHECK-NEXT: destroy_value [[KRAKEN]]
-  // CHECK-NEXT: [[KRAKEN_GETTER_FUN:%.*]] = class_method [[CLS]] : $LetFieldClass, #LetFieldClass.vark!getter.1 : (LetFieldClass) -> () -> Kraken , $@convention(method) (@guaranteed LetFieldClass) -> @owned Kraken
+  // CHECK-NEXT: [[KRAKEN_GETTER_FUN:%.*]] = class_method [[CLS]] : $LetFieldClass, #LetFieldClass.vark!getter.1 : (LetFieldClass) -> () -> Kraken, $@convention(method) (@guaranteed LetFieldClass) -> @owned Kraken
   // CHECK-NEXT: [[KRAKEN:%.*]] = apply [[KRAKEN_GETTER_FUN]]([[CLS]])
   // CHECK: [[DESTROY_SHIP_FUN:%.*]] = function_ref @_T015guaranteed_self11destroyShipyAA6KrakenCF : $@convention(thin) (@owned Kraken) -> ()
   // CHECK-NEXT: [[KRAKEN_COPY:%.*]] = copy_value [[KRAKEN]]
   // CHECK-NEXT: apply [[DESTROY_SHIP_FUN]]([[KRAKEN_COPY]])
   // CHECK-NEXT: [[KRAKEN_BOX:%.*]] = alloc_box ${ var Kraken }
   // CHECK-NEXT: [[PB:%.*]] = project_box [[KRAKEN_BOX]]
-  // CHECK-NEXT: [[KRAKEN_GETTER_FUN:%.*]] = class_method [[CLS]] : $LetFieldClass, #LetFieldClass.vark!getter.1 : (LetFieldClass) -> () -> Kraken , $@convention(method) (@guaranteed LetFieldClass) -> @owned Kraken
+  // CHECK-NEXT: [[KRAKEN_GETTER_FUN:%.*]] = class_method [[CLS]] : $LetFieldClass, #LetFieldClass.vark!getter.1 : (LetFieldClass) -> () -> Kraken, $@convention(method) (@guaranteed LetFieldClass) -> @owned Kraken
   // CHECK-NEXT: [[KRAKEN2:%.*]] = apply [[KRAKEN_GETTER_FUN]]([[CLS]])
   // CHECK-NEXT: store [[KRAKEN2]] to [init] [[PB]]
   // CHECK: [[DESTROY_SHIP_FUN:%.*]] = function_ref @_T015guaranteed_self11destroyShipyAA6KrakenCF : $@convention(thin) (@owned Kraken) -> ()

--- a/test/SILGen/init_ref_delegation.swift
+++ b/test/SILGen/init_ref_delegation.swift
@@ -97,7 +97,7 @@ class C1 {
     // CHECK:   store [[ORIG_SELF]] to [init] [[SELF]] : $*C1
     // CHECK:   [[SELF_FROM_BOX:%[0-9]+]] = load_borrow [[SELF]] : $*C1
 
-    // CHECK:   [[DELEG_INIT:%[0-9]+]] = class_method [[SELF_FROM_BOX]] : $C1, #C1.init!initializer.1 : (C1.Type) -> (X, X) -> C1 , $@convention(method) (X, X, @owned C1) -> @owned C1
+    // CHECK:   [[DELEG_INIT:%[0-9]+]] = class_method [[SELF_FROM_BOX]] : $C1, #C1.init!initializer.1 : (C1.Type) -> (X, X) -> C1, $@convention(method) (X, X, @owned C1) -> @owned C1
     // CHECK:   [[SELFP:%[0-9]+]] = apply [[DELEG_INIT]]([[X]], [[X]], [[SELF_FROM_BOX]]) : $@convention(method) (X, X, @owned C1) -> @owned C1
     // CHECK:   store [[SELFP]] to [init] [[SELF]] : $*C1
     // CHECK:   [[SELFP:%[0-9]+]] = load [copy] [[SELF]] : $*C1
@@ -124,7 +124,7 @@ class C1 {
     // definite-initialization.
     // CHECK:   [[SELF:%[0-9]+]] = load_borrow [[UNINIT_SELF]] : $*C2
 
-    // CHECK:   [[DELEG_INIT:%[0-9]+]] = class_method [[SELF]] : $C2, #C2.init!initializer.1 : (C2.Type) -> (X, X) -> C2 , $@convention(method) (X, X, @owned C2) -> @owned C2
+    // CHECK:   [[DELEG_INIT:%[0-9]+]] = class_method [[SELF]] : $C2, #C2.init!initializer.1 : (C2.Type) -> (X, X) -> C2, $@convention(method) (X, X, @owned C2) -> @owned C2
     // CHECK:   [[REPLACE_SELF:%[0-9]+]] = apply [[DELEG_INIT]]([[X]], [[X]], [[SELF]]) : $@convention(method) (X, X, @owned C2) -> @owned C2
     // CHECK:   store [[REPLACE_SELF]] to [init] [[UNINIT_SELF]] : $*C2
     // CHECK:   [[VAR_15:%[0-9]+]] = load [copy] [[UNINIT_SELF]] : $*C2
@@ -148,7 +148,7 @@ class C3 {
   convenience init() {
     // CHECK: mark_uninitialized [delegatingself]
     // CHECK-NOT: integer_literal
-    // CHECK: class_method [[SELF:%[0-9]+]] : $C3, #C3.init!initializer.1 : (C3.Type) -> (X) -> C3 , $@convention(method) (X, @owned C3) -> @owned C3
+    // CHECK: class_method [[SELF:%[0-9]+]] : $C3, #C3.init!initializer.1 : (C3.Type) -> (X) -> C3, $@convention(method) (X, @owned C3) -> @owned C3
     // CHECK-NOT: integer_literal
     // CHECK: return
     self.init(x: x)

--- a/test/SILGen/lifetime.swift
+++ b/test/SILGen/lifetime.swift
@@ -354,7 +354,7 @@ func logical_lvalue_lifetime(_ r: RefWithProp, _ i: Int, _ v: Val) {
   // -- Reference types need to be copy_valued as property method args.
   r.int_prop = i
   // CHECK: [[R1:%[0-9]+]] = load [copy] [[PR]]
-  // CHECK: [[SETTER_METHOD:%[0-9]+]] = class_method {{.*}} : $RefWithProp, #RefWithProp.int_prop!setter.1 : (RefWithProp) -> (Int) -> () , $@convention(method) (Int, @guaranteed RefWithProp) -> ()
+  // CHECK: [[SETTER_METHOD:%[0-9]+]] = class_method {{.*}} : $RefWithProp, #RefWithProp.int_prop!setter.1 : (RefWithProp) -> (Int) -> (), $@convention(method) (Int, @guaranteed RefWithProp) -> ()
   // CHECK: apply [[SETTER_METHOD]]({{.*}}, [[R1]])
   // CHECK: destroy_value [[R1]]
 

--- a/test/SILGen/mangling_private.swift
+++ b/test/SILGen/mangling_private.swift
@@ -57,10 +57,10 @@ extension PrivateStruct {
 
 // CHECK-LABEL: sil_vtable Sub {
 class Sub : Base {
-  // CHECK-BASE: #Base.privateMethod!1: _T023mangling_private_helper4BaseC0B6Method33_0E108371B0D5773E608A345AC52C7674LLyyF
-  // CHECK-DAG: #Base.privateMethod!1: _T023mangling_private_helper4BaseC0B6Method33_0E108371B0D5773E608A345AC52C7674LLyyF
+  // CHECK-BASE: #Base.privateMethod!1: {{.*}} : _T023mangling_private_helper4BaseC0B6Method33_0E108371B0D5773E608A345AC52C7674LLyyF
+  // CHECK-DAG: #Base.privateMethod!1: {{.*}} : _T023mangling_private_helper4BaseC0B6Method33_0E108371B0D5773E608A345AC52C7674LLyyF
 
-  // CHECK-DAG: #Sub.subMethod!1: _T016mangling_private3SubC9subMethod33_A3CCBB841DB59E79A4AD4EE458655068LLyyF
+  // CHECK-DAG: #Sub.subMethod!1: {{.*}} : _T016mangling_private3SubC9subMethod33_A3CCBB841DB59E79A4AD4EE458655068LLyyF
   private func subMethod() {}
 } // CHECK: {{^[}]$}}
 

--- a/test/SILGen/materializeForSet.swift
+++ b/test/SILGen/materializeForSet.swift
@@ -515,7 +515,7 @@ func testMaterializedSetter() {
 }
 
 // CHECK-LABEL: sil_witness_table hidden Bill: Totalled module materializeForSet {
-// CHECK:   method #Totalled.total!getter.1: @_T017materializeForSet4BillVAA8TotalledAaaDP5totalSifgTW
-// CHECK:   method #Totalled.total!setter.1: @_T017materializeForSet4BillVAA8TotalledAaaDP5totalSifsTW
-// CHECK:   method #Totalled.total!materializeForSet.1: @_T017materializeForSet4BillVAA8TotalledAaaDP5totalSifmTW
+// CHECK:   method #Totalled.total!getter.1: {{.*}} : @_T017materializeForSet4BillVAA8TotalledAaaDP5totalSifgTW
+// CHECK:   method #Totalled.total!setter.1: {{.*}} : @_T017materializeForSet4BillVAA8TotalledAaaDP5totalSifsTW
+// CHECK:   method #Totalled.total!materializeForSet.1: {{.*}} : @_T017materializeForSet4BillVAA8TotalledAaaDP5totalSifmTW
 // CHECK: }

--- a/test/SILGen/multi_file.swift
+++ b/test/SILGen/multi_file.swift
@@ -18,7 +18,7 @@ func lazyPropertiesAreNotStored(_ container: LazyContainer) {
 
 // CHECK-LABEL: sil hidden @_T010multi_file29lazyRefPropertiesAreNotStored{{[_0-9a-zA-Z]*}}F
 func lazyRefPropertiesAreNotStored(_ container: LazyContainerClass) {
-  // CHECK: {{%[0-9]+}} = class_method %0 : $LazyContainerClass, #LazyContainerClass.lazyVar!getter.1 : (LazyContainerClass) -> () -> Int , $@convention(method) (@guaranteed LazyContainerClass) -> Int
+  // CHECK: {{%[0-9]+}} = class_method %0 : $LazyContainerClass, #LazyContainerClass.lazyVar!getter.1 : (LazyContainerClass) -> () -> Int, $@convention(method) (@guaranteed LazyContainerClass) -> Int
   markUsed(container.lazyVar)
 }
 

--- a/test/SILGen/nested_generics.swift
+++ b/test/SILGen/nested_generics.swift
@@ -230,7 +230,7 @@ class SubclassOfInner<T, U> : OuterRing<T>.InnerRing<U> {
 // CHECK:   [[SELF_COPY:%[0-9]+]] = alloc_stack $OuterRing<τ_0_0>.InnerRing<τ_1_0>
 // CHECK:   copy_addr [[SELF]] to [initialization] [[SELF_COPY]] : $*OuterRing<τ_0_0>.InnerRing<τ_1_0>
 // CHECK:   [[SELF_COPY_VAL:%[0-9]+]] = load [take] [[SELF_COPY]] : $*OuterRing<τ_0_0>.InnerRing<τ_1_0>
-// CHECK:   [[METHOD:%[0-9]+]] = class_method [[SELF_COPY_VAL]] : $OuterRing<τ_0_0>.InnerRing<τ_1_0>, #OuterRing.InnerRing.method!1 : <T><U><V> (OuterRing<T>.InnerRing<U>) -> (T, U, V) -> (T, U, V) , $@convention(method) <τ_0_0><τ_1_0><τ_2_0> (@in τ_0_0, @in τ_1_0, @in τ_2_0, @guaranteed OuterRing<τ_0_0>.InnerRing<τ_1_0>) -> (@out τ_0_0, @out τ_1_0, @out τ_2_0)
+// CHECK:   [[METHOD:%[0-9]+]] = class_method [[SELF_COPY_VAL]] : $OuterRing<τ_0_0>.InnerRing<τ_1_0>, #OuterRing.InnerRing.method!1 : <T><U><V> (OuterRing<T>.InnerRing<U>) -> (T, U, V) -> (T, U, V), $@convention(method) <τ_0_0><τ_1_0><τ_2_0> (@in τ_0_0, @in τ_1_0, @in τ_2_0, @guaranteed OuterRing<τ_0_0>.InnerRing<τ_1_0>) -> (@out τ_0_0, @out τ_1_0, @out τ_2_0)
 // CHECK:   apply [[METHOD]]<τ_0_0, τ_1_0, τ_2_0>([[T]], [[U]], [[V]], [[TOut]], [[UOut]], [[VOut]], [[SELF_COPY_VAL]]) : $@convention(method) <τ_0_0><τ_1_0><τ_2_0> (@in τ_0_0, @in τ_1_0, @in τ_2_0, @guaranteed OuterRing<τ_0_0>.InnerRing<τ_1_0>) -> (@out τ_0_0, @out τ_1_0, @out τ_2_0)
 // CHECK:   [[RESULT:%[0-9]+]] = tuple ()
 // CHECK:   destroy_value [[SELF_COPY_VAL]] : $OuterRing<τ_0_0>.InnerRing<τ_1_0>

--- a/test/SILGen/objc_attr_NSManaged.swift
+++ b/test/SILGen/objc_attr_NSManaged.swift
@@ -23,10 +23,10 @@ class SwiftGizmo : Gizmo {
   // Make sure that we're calling through the @objc entry points.
   // CHECK-LABEL: sil hidden @_T019objc_attr_NSManaged10SwiftGizmoC7modifyX{{[_0-9a-zA-Z]*}}F : $@convention(method) (@guaranteed SwiftGizmo) -> () {
   func modifyX() {
-    // CHECK:   [[GETTER:%[0-9]+]] = class_method [volatile] [[SELF:%.*]] : $SwiftGizmo, #SwiftGizmo.x!getter.1.foreign : (SwiftGizmo) -> () -> X , $@convention(objc_method) (SwiftGizmo) -> @autoreleased X
+    // CHECK:   [[GETTER:%[0-9]+]] = class_method [volatile] [[SELF:%.*]] : $SwiftGizmo, #SwiftGizmo.x!getter.1.foreign : (SwiftGizmo) -> () -> X, $@convention(objc_method) (SwiftGizmo) -> @autoreleased X
     // CHECK-NEXT: apply [[GETTER]]([[SELF]]) : $@convention(objc_method) (SwiftGizmo) -> @autoreleased X
     // CHECK-NOT: return
-    // CHECK:   [[SETTER:%[0-9]+]] = class_method [volatile] [[SELF]] : $SwiftGizmo, #SwiftGizmo.x!setter.1.foreign : (SwiftGizmo) -> (X) -> () , $@convention(objc_method) (X, SwiftGizmo) -> ()
+    // CHECK:   [[SETTER:%[0-9]+]] = class_method [volatile] [[SELF]] : $SwiftGizmo, #SwiftGizmo.x!setter.1.foreign : (SwiftGizmo) -> (X) -> (), $@convention(objc_method) (X, SwiftGizmo) -> ()
     // CHECK:  apply [[SETTER]]([[XMOD:%.*]], [[SELF]]) : $@convention(objc_method) (X, SwiftGizmo) -> ()
     x = x.foo()
     // CHECK: return
@@ -34,7 +34,7 @@ class SwiftGizmo : Gizmo {
 
   // CHECK-LABEL: sil hidden @_T019objc_attr_NSManaged10SwiftGizmoC8testFunc{{[_0-9a-zA-Z]*}}F
   func testFunc() {
-    // CHECK: = class_method [volatile] %0 : $SwiftGizmo, #SwiftGizmo.kvc!1.foreign : (SwiftGizmo) -> () -> () , $@convention(objc_method) (SwiftGizmo) -> ()
+    // CHECK: = class_method [volatile] %0 : $SwiftGizmo, #SwiftGizmo.kvc!1.foreign : (SwiftGizmo) -> () -> (), $@convention(objc_method) (SwiftGizmo) -> ()
     // CHECK: return
     kvc()
   }
@@ -45,7 +45,7 @@ extension SwiftGizmo {
 
   // CHECK-LABEL: _T019objc_attr_NSManaged10SwiftGizmoC7testExt{{[_0-9a-zA-Z]*}}F
   func testExt() {
-    // CHECK: = class_method [volatile] %0 : $SwiftGizmo, #SwiftGizmo.extKVC!1.foreign : (SwiftGizmo) -> () -> () , $@convention(objc_method) (SwiftGizmo) -> ()
+    // CHECK: = class_method [volatile] %0 : $SwiftGizmo, #SwiftGizmo.extKVC!1.foreign : (SwiftGizmo) -> () -> (), $@convention(objc_method) (SwiftGizmo) -> ()
     // CHECK: return
     extKVC()
   }
@@ -62,7 +62,7 @@ extension FinalGizmo {
 
   // CHECK-LABEL: _T019objc_attr_NSManaged10FinalGizmoC8testExt2{{[_0-9a-zA-Z]*}}F
   func testExt2() {
-    // CHECK: = class_method [volatile] %0 : $FinalGizmo, #FinalGizmo.extKVC2!1.foreign : (FinalGizmo) -> () -> () , $@convention(objc_method) (FinalGizmo) -> ()
+    // CHECK: = class_method [volatile] %0 : $FinalGizmo, #FinalGizmo.extKVC2!1.foreign : (FinalGizmo) -> () -> (), $@convention(objc_method) (FinalGizmo) -> ()
     // CHECK: return
     extKVC2()
   }
@@ -70,9 +70,9 @@ extension FinalGizmo {
 
 // CHECK-LABEL: sil hidden @_T019objc_attr_NSManaged9testFinalSSAA0E5GizmoCF : $@convention(thin) (@owned FinalGizmo) -> @owned String {
 func testFinal(_ obj: FinalGizmo) -> String {
-  // CHECK: class_method [volatile] %0 : $FinalGizmo, #FinalGizmo.kvc2!1.foreign : (FinalGizmo) -> () -> () , $@convention(objc_method) (FinalGizmo) -> ()
+  // CHECK: class_method [volatile] %0 : $FinalGizmo, #FinalGizmo.kvc2!1.foreign : (FinalGizmo) -> () -> (), $@convention(objc_method) (FinalGizmo) -> ()
   // CHECK-NOT: return
-  // CHECK: class_method [volatile] %0 : $FinalGizmo, #FinalGizmo.y!getter.1.foreign : (FinalGizmo) -> () -> String , $@convention(objc_method) (FinalGizmo) -> @autoreleased NSString
+  // CHECK: class_method [volatile] %0 : $FinalGizmo, #FinalGizmo.y!getter.1.foreign : (FinalGizmo) -> () -> String, $@convention(objc_method) (FinalGizmo) -> @autoreleased NSString
   // CHECK: return
   obj.kvc2()
   return obj.y
@@ -99,19 +99,19 @@ extension ProtoAdopter {
 
 // The vtable should not contain any entry points for getters and setters.
 // CHECK-LABEL: sil_vtable SwiftGizmo {
-// CHECK-NEXT:   #SwiftGizmo.modifyX!1: _T019objc_attr_NSManaged10SwiftGizmoC7modifyXyyF
-// CHECK-NEXT:   #SwiftGizmo.testFunc!1: _T019objc_attr_NSManaged10SwiftGizmoC8testFuncyyF
-// CHECK-NEXT:   #SwiftGizmo.deinit!deallocator:
-// CHECK-NEXT:   #SwiftGizmo.init!initializer.1: _T019objc_attr_NSManaged10SwiftGizmoCSQyACGycfc
-// CHECK-NEXT:   #SwiftGizmo.init!initializer.1: _T019objc_attr_NSManaged10SwiftGizmoCSQyACGSi7bellsOn_tcfc
+// CHECK-NEXT:   #SwiftGizmo.modifyX!1: {{.*}} : _T019objc_attr_NSManaged10SwiftGizmoC7modifyXyyF
+// CHECK-NEXT:   #SwiftGizmo.testFunc!1: {{.*}} : _T019objc_attr_NSManaged10SwiftGizmoC8testFuncyyF
+// CHECK-NEXT:   #SwiftGizmo.deinit!deallocator: {{.*}} : _T019objc_attr_NSManaged10SwiftGizmoCfD
+// CHECK-NEXT:   #SwiftGizmo.init!initializer.1: {{.*}} : _T019objc_attr_NSManaged10SwiftGizmoCSQyACGycfc
+// CHECK-NEXT:   #SwiftGizmo.init!initializer.1: {{.*}} : _T019objc_attr_NSManaged10SwiftGizmoCSQyACGSi7bellsOn_tcfc
 // CHECK-NEXT: }
 
 // CHECK-LABEL: sil_vtable FinalGizmo {
-// CHECK-NEXT:   #SwiftGizmo.modifyX!1: _T019objc_attr_NSManaged10SwiftGizmoC7modifyX{{[_0-9a-zA-Z]*}}F
-// CHECK-NEXT: #SwiftGizmo.testFunc!1: _T019objc_attr_NSManaged10SwiftGizmoC8testFunc{{[_0-9a-zA-Z]*}}F
-// CHECK-NEXT:   #SwiftGizmo.init!initializer.1: _T019objc_attr_NSManaged10FinalGizmoC{{[_0-9a-zA-Z]*}}fc
-// CHECK-NEXT:   #SwiftGizmo.init!initializer.1: _T019objc_attr_NSManaged10FinalGizmoC{{[_0-9a-zA-Z]*}}fc
-// CHECK-NEXT:   #FinalGizmo.deinit!deallocator: _T019objc_attr_NSManaged10FinalGizmoCfD
+// CHECK-NEXT:   #SwiftGizmo.modifyX!1: {{.*}} : _T019objc_attr_NSManaged10SwiftGizmoC7modifyX{{[_0-9a-zA-Z]*}}F
+// CHECK-NEXT: #SwiftGizmo.testFunc!1: {{.*}} : _T019objc_attr_NSManaged10SwiftGizmoC8testFunc{{[_0-9a-zA-Z]*}}F
+// CHECK-NEXT:   #SwiftGizmo.init!initializer.1: {{.*}} : _T019objc_attr_NSManaged10FinalGizmoC{{[_0-9a-zA-Z]*}}fc
+// CHECK-NEXT:   #SwiftGizmo.init!initializer.1: {{.*}} : _T019objc_attr_NSManaged10FinalGizmoC{{[_0-9a-zA-Z]*}}fc
+// CHECK-NEXT:   #FinalGizmo.deinit!deallocator: {{.*}} : _T019objc_attr_NSManaged10FinalGizmoCfD
 // CHECK-NEXT: }
 
 // CHECK-LABEL: sil_vtable ProtoAdopter {

--- a/test/SILGen/objc_attr_NSManaged_multi.swift
+++ b/test/SILGen/objc_attr_NSManaged_multi.swift
@@ -6,11 +6,11 @@ import Foundation
 
 // CHECK-LABEL: sil hidden @_T025objc_attr_NSManaged_multi9testMultis9AnyObject_pAA10SwiftGizmoCF : $@convention(thin) (@owned SwiftGizmo) -> @owned AnyObject {
 func testMulti(_ obj: SwiftGizmo) -> AnyObject {
-  // CHECK: = class_method [volatile] %0 : $SwiftGizmo, #SwiftGizmo.kvc!1.foreign : (SwiftGizmo) -> () -> () , $@convention(objc_method) (SwiftGizmo) -> ()
+  // CHECK: = class_method [volatile] %0 : $SwiftGizmo, #SwiftGizmo.kvc!1.foreign : (SwiftGizmo) -> () -> (), $@convention(objc_method) (SwiftGizmo) -> ()
   // CHECK-NOT: return
-  // CHECK: = class_method [volatile] %0 : $SwiftGizmo, #SwiftGizmo.extKVC!1.foreign : (SwiftGizmo) -> () -> () , $@convention(objc_method) (SwiftGizmo) -> ()
+  // CHECK: = class_method [volatile] %0 : $SwiftGizmo, #SwiftGizmo.extKVC!1.foreign : (SwiftGizmo) -> () -> (), $@convention(objc_method) (SwiftGizmo) -> ()
   // CHECK-NOT: return
-  // CHECK: class_method [volatile] %0 : $SwiftGizmo, #SwiftGizmo.x!getter.1.foreign : (SwiftGizmo) -> () -> X , $@convention(objc_method) (SwiftGizmo) -> @autoreleased X
+  // CHECK: class_method [volatile] %0 : $SwiftGizmo, #SwiftGizmo.x!getter.1.foreign : (SwiftGizmo) -> () -> X, $@convention(objc_method) (SwiftGizmo) -> @autoreleased X
   // CHECK: return
   obj.kvc()
   obj.extKVC()
@@ -19,11 +19,11 @@ func testMulti(_ obj: SwiftGizmo) -> AnyObject {
 
 // CHECK-LABEL: sil hidden @_T025objc_attr_NSManaged_multi14testFinalMultiSSAA0F5GizmoCF : $@convention(thin) (@owned FinalGizmo) -> @owned String {
 func testFinalMulti(_ obj: FinalGizmo) -> String {
-  // CHECK: class_method [volatile] %0 : $FinalGizmo, #FinalGizmo.kvc2!1.foreign : (FinalGizmo) -> () -> () , $@convention(objc_method) (FinalGizmo) -> ()
+  // CHECK: class_method [volatile] %0 : $FinalGizmo, #FinalGizmo.kvc2!1.foreign : (FinalGizmo) -> () -> (), $@convention(objc_method) (FinalGizmo) -> ()
   // CHECK-NOT: return
-  // CHECK: class_method [volatile] %0 : $FinalGizmo, #FinalGizmo.extKVC2!1.foreign : (FinalGizmo) -> () -> () , $@convention(objc_method) (FinalGizmo) -> ()
+  // CHECK: class_method [volatile] %0 : $FinalGizmo, #FinalGizmo.extKVC2!1.foreign : (FinalGizmo) -> () -> (), $@convention(objc_method) (FinalGizmo) -> ()
   // CHECK-NOT: return
-  // CHECK: class_method [volatile] %0 : $FinalGizmo, #FinalGizmo.y!getter.1.foreign : (FinalGizmo) -> () -> String , $@convention(objc_method) (FinalGizmo) -> @autoreleased NSString
+  // CHECK: class_method [volatile] %0 : $FinalGizmo, #FinalGizmo.y!getter.1.foreign : (FinalGizmo) -> () -> String, $@convention(objc_method) (FinalGizmo) -> @autoreleased NSString
   // CHECK: return
   obj.kvc2()
   obj.extKVC2()

--- a/test/SILGen/objc_bridged_results.swift
+++ b/test/SILGen/objc_bridged_results.swift
@@ -9,7 +9,7 @@ import Foundation
 
 // CHECK-LABEL: sil hidden @_T020objc_bridged_results11testNonnullSayypGSo4TestCF
 func testNonnull(_ obj: Test) -> [Any] {
-  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] %0 : $Test, #Test.nonnullArray!getter.1.foreign : (Test) -> () -> [Any] , $@convention(objc_method) (Test) -> @autoreleased Optional<NSArray>
+  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] %0 : $Test, #Test.nonnullArray!getter.1.foreign : (Test) -> () -> [Any], $@convention(objc_method) (Test) -> @autoreleased Optional<NSArray>
   // CHECK: [[COCOA_VAL:%[0-9]+]] = apply [[METHOD]](%0) : $@convention(objc_method) (Test) -> @autoreleased Optional<NSArray>
   // CHECK: [[CONVERT:%[0-9]+]] = function_ref @_T0Sa10FoundationE36_unconditionallyBridgeFromObjectiveCSayxGSo7NSArrayCSgFZ
   // CHECK: [[ARRAY_META:%[0-9]+]] = metatype $@thin Array<Any>.Type
@@ -21,7 +21,7 @@ func testNonnull(_ obj: Test) -> [Any] {
 
 // CHECK-LABEL: sil hidden @_T020objc_bridged_results12testNullableSayypGSgSo4TestCF
 func testNullable(_ obj: Test) -> [Any]? {
-  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] %0 : $Test, #Test.nullableArray!getter.1.foreign : (Test) -> () -> [Any]? , $@convention(objc_method) (Test) -> @autoreleased Optional<NSArray>
+  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] %0 : $Test, #Test.nullableArray!getter.1.foreign : (Test) -> () -> [Any]?, $@convention(objc_method) (Test) -> @autoreleased Optional<NSArray>
   // CHECK: [[COCOA_VAL:%[0-9]+]] = apply [[METHOD]](%0) : $@convention(objc_method) (Test) -> @autoreleased Optional<NSArray>
   
   // CHECK: [[IS_NON_NIL:%[0-9]+]] = select_enum [[COCOA_VAL]] : $Optional<NSArray>
@@ -48,7 +48,7 @@ func testNullable(_ obj: Test) -> [Any]? {
 
 // CHECK-LABEL: sil hidden @_T020objc_bridged_results19testNullUnspecifiedSQySayypGGSo4TestCF
 func testNullUnspecified(_ obj: Test) -> [Any]! {
-  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] %0 : $Test, #Test.nullUnspecifiedArray!getter.1.foreign : (Test) -> () -> [Any]! , $@convention(objc_method) (Test) -> @autoreleased Optional<NSArray>
+  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] %0 : $Test, #Test.nullUnspecifiedArray!getter.1.foreign : (Test) -> () -> [Any]!, $@convention(objc_method) (Test) -> @autoreleased Optional<NSArray>
   // CHECK: [[COCOA_VAL:%[0-9]+]] = apply [[METHOD]](%0) : $@convention(objc_method) (Test) -> @autoreleased Optional<NSArray>
   // CHECK: [[IS_NON_NIL:%[0-9]+]] = select_enum [[COCOA_VAL]] : $Optional<NSArray>
   // CHECK: cond_br [[IS_NON_NIL]], [[CASE_NON_NIL:[^, ]+]], [[CASE_NIL:[^, ]+]]
@@ -75,7 +75,7 @@ func testNullUnspecified(_ obj: Test) -> [Any]! {
 
 // CHECK-LABEL: sil hidden @_T020objc_bridged_results21testNonnullDictionarys0F0Vys11AnyHashableVypGSo4TestCF
 func testNonnullDictionary(_ obj: Test) -> [AnyHashable: Any] {
-  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] %0 : $Test, #Test.nonnullDictionary!getter.1.foreign : (Test) -> () -> [AnyHashable : Any] , $@convention(objc_method) (Test) -> @autoreleased Optional<NSDictionary>
+  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] %0 : $Test, #Test.nonnullDictionary!getter.1.foreign : (Test) -> () -> [AnyHashable : Any], $@convention(objc_method) (Test) -> @autoreleased Optional<NSDictionary>
   // CHECK: [[COCOA_VAL:%[0-9]+]] = apply [[METHOD]](%0) : $@convention(objc_method) (Test) -> @autoreleased Optional<NSDictionary>
   // CHECK: [[CONVERT:%[0-9]+]] = function_ref @_T0s10DictionaryV10FoundationE36_unconditionallyBridgeFromObjectiveCAByxq_GSo12NSDictionaryCSgFZ
   // CHECK: [[DICT_META:%[0-9]+]] = metatype $@thin Dictionary<AnyHashable, Any>.Type
@@ -87,7 +87,7 @@ func testNonnullDictionary(_ obj: Test) -> [AnyHashable: Any] {
 
 // CHECK-LABEL: sil hidden @_T020objc_bridged_results14testNonnullSets0F0Vys11AnyHashableVGSo4TestCF
 func testNonnullSet(_ obj: Test) -> Set<AnyHashable> {
-  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] %0 : $Test, #Test.nonnullSet!getter.1.foreign : (Test) -> () -> Set<AnyHashable> , $@convention(objc_method) (Test) -> @autoreleased Optional<NSSet>
+  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] %0 : $Test, #Test.nonnullSet!getter.1.foreign : (Test) -> () -> Set<AnyHashable>, $@convention(objc_method) (Test) -> @autoreleased Optional<NSSet>
   // CHECK: [[COCOA_VAL:%[0-9]+]] = apply [[METHOD]](%0) : $@convention(objc_method) (Test) -> @autoreleased Optional<NSSet>
   // CHECK: [[CONVERT:%[0-9]+]] = function_ref @_T0s3SetV10FoundationE36_unconditionallyBridgeFromObjectiveCAByxGSo5NSSetCSgFZ
   // CHECK: [[SET_META:%[0-9]+]] = metatype $@thin Set<AnyHashable>.Type
@@ -99,7 +99,7 @@ func testNonnullSet(_ obj: Test) -> Set<AnyHashable> {
 
 // CHECK-LABEL: sil hidden @_T020objc_bridged_results17testNonnullStringSSSo4TestCF
 func testNonnullString(_ obj: Test) -> String {
-  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] %0 : $Test, #Test.nonnullString!getter.1.foreign : (Test) -> () -> String , $@convention(objc_method) (Test) -> @autoreleased Optional<NSString>
+  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] %0 : $Test, #Test.nonnullString!getter.1.foreign : (Test) -> () -> String, $@convention(objc_method) (Test) -> @autoreleased Optional<NSString>
   // CHECK: [[COCOA_VAL:%[0-9]+]] = apply [[METHOD]](%0) : $@convention(objc_method) (Test) -> @autoreleased Optional<NSString>
   // CHECK: [[CONVERT:%[0-9]+]] = function_ref @_T0SS10FoundationE36_unconditionallyBridgeFromObjectiveCSSSo8NSStringCSgFZ
   // CHECK: [[STRING_META:%[0-9]+]] = metatype $@thin String.Type
@@ -112,7 +112,7 @@ func testNonnullString(_ obj: Test) -> String {
 // CHECK-LABEL: sil hidden @_T020objc_bridged_results13testClassPropSSyF
 func testClassProp() -> String {
   // CHECK: [[CLASS:%.+]] = metatype $@thick Test.Type
-  // CHECK: [[METHOD:%.+]] = class_method [volatile] [[CLASS]] : $@thick Test.Type, #Test.nonnullSharedString!getter.1.foreign : (Test.Type) -> () -> String , $@convention(objc_method) (@objc_metatype Test.Type) -> @autoreleased Optional<NSString>
+  // CHECK: [[METHOD:%.+]] = class_method [volatile] [[CLASS]] : $@thick Test.Type, #Test.nonnullSharedString!getter.1.foreign : (Test.Type) -> () -> String, $@convention(objc_method) (@objc_metatype Test.Type) -> @autoreleased Optional<NSString>
   // CHECK: [[OBJC_CLASS:%.+]] = thick_to_objc_metatype [[CLASS]] : $@thick Test.Type to $@objc_metatype Test.Type
   // CHECK: [[COCOA_VAL:%[0-9]+]] = apply [[METHOD]]([[OBJC_CLASS]]) : $@convention(objc_method) (@objc_metatype Test.Type) -> @autoreleased Optional<NSString>
   // CHECK: [[CONVERT:%[0-9]+]] = function_ref @_T0SS10FoundationE36_unconditionallyBridgeFromObjectiveCSSSo8NSStringCSgFZ
@@ -128,7 +128,7 @@ func testClassProp() -> String {
 // not to crash trying to generate the thunk.
 // CHECK-LABEL: sil hidden @_T020objc_bridged_results20testNonnullSubscriptSayypGSo4TestCF
 func testNonnullSubscript(_ obj: Test) -> [Any] {
-  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] %0 : $Test, #Test.subscript!getter.1.foreign : (Test) -> (Int) -> [Any] , $@convention(objc_method) (Int, Test) -> @autoreleased Optional<NSArray>
+  // CHECK: [[METHOD:%[0-9]+]] = class_method [volatile] %0 : $Test, #Test.subscript!getter.1.foreign : (Test) -> (Int) -> [Any], $@convention(objc_method) (Int, Test) -> @autoreleased Optional<NSArray>
   // CHECK: [[COCOA_VAL:%[0-9]+]] = apply [[METHOD]]({{%[0-9]+}}, %0) : $@convention(objc_method) (Int, Test) -> @autoreleased Optional<NSArray>
   // CHECK: [[CONVERT:%[0-9]+]] = function_ref @_T0Sa10FoundationE36_unconditionallyBridgeFromObjectiveCSayxGSo7NSArrayCSgFZ
   // CHECK: [[ARRAY_META:%[0-9]+]] = metatype $@thin Array<Any>.Type,

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -610,5 +610,5 @@ class AnyHashableClass : NSObject {
 // CHECK-LABEL: sil_witness_table shared [fragile] GenericOption: Hashable module objc_generics {
 // CHECK-NEXT: base_protocol _Hashable: GenericOption: _Hashable module objc_generics
 // CHECK-NEXT: base_protocol Equatable: GenericOption: Equatable module objc_generics
-// CHECK-NEXT: method #Hashable.hashValue!getter.1: @_TTWVSC13GenericOptions8Hashable13objc_genericsFS0_g9hashValueSi
+// CHECK-NEXT: method #Hashable.hashValue!getter.1: {{.*}} : @_TTWVSC13GenericOptions8Hashable13objc_genericsFS0_g9hashValueSi
 // CHECK-NEXT: }

--- a/test/SILGen/objc_dealloc.swift
+++ b/test/SILGen/objc_dealloc.swift
@@ -40,7 +40,7 @@ class SwiftGizmo : Gizmo {
     // CHECK-NOT: ref_element_addr
 
     // Call super -dealloc.
-    // CHECK:   [[SUPER_DEALLOC:%[0-9]+]] = super_method [[SELF]] : $SwiftGizmo, #Gizmo.deinit!deallocator.foreign : (Gizmo) -> () -> () , $@convention(objc_method) (Gizmo) -> ()
+    // CHECK:   [[SUPER_DEALLOC:%[0-9]+]] = super_method [[SELF]] : $SwiftGizmo, #Gizmo.deinit!deallocator.foreign : (Gizmo) -> () -> (), $@convention(objc_method) (Gizmo) -> ()
     // CHECK:   [[SUPER:%[0-9]+]] = upcast [[SELF]] : $SwiftGizmo to $Gizmo
     // CHECK:   [[SUPER_DEALLOC_RESULT:%[0-9]+]] = apply [[SUPER_DEALLOC]]([[SUPER]]) : $@convention(objc_method) (Gizmo) -> ()
     // CHECK:   [[RESULT:%[0-9]+]] = tuple ()

--- a/test/SILGen/objc_extensions.swift
+++ b/test/SILGen/objc_extensions.swift
@@ -58,7 +58,7 @@ extension Sub {
     // CHECK: bb0([[NEW_VALUE:%.*]] : $Optional<String>, [[SELF:%.*]] : $Sub):
     // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
     // CHECK:   [[UPCAST_SELF_COPY:%.*]] = upcast [[SELF_COPY]] : $Sub to $Base
-    // CHECK:   [[GET_SUPER_METHOD:%.*]] = super_method [volatile] [[SELF_COPY]] : $Sub, #Base.prop!getter.1.foreign : (Base) -> () -> String! , $@convention(objc_method) (Base) -> @autoreleased Optional<NSString>
+    // CHECK:   [[GET_SUPER_METHOD:%.*]] = super_method [volatile] [[SELF_COPY]] : $Sub, #Base.prop!getter.1.foreign : (Base) -> () -> String!, $@convention(objc_method) (Base) -> @autoreleased Optional<NSString>
     // CHECK:   [[OLD_NSSTRING:%.*]] = apply [[GET_SUPER_METHOD]]([[UPCAST_SELF_COPY]])
 
     // CHECK: bb3([[OLD_NSSTRING_BRIDGED:%.*]] : $Optional<String>):
@@ -66,7 +66,7 @@ extension Sub {
     // CHECK:   destroy_value [[SELF_COPY]]
     // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
     // CHECK:   [[UPCAST_SELF_COPY:%.*]] = upcast [[SELF_COPY]] : $Sub to $Base
-    // CHECK:   [[SET_SUPER_METHOD:%.*]] = super_method [volatile] [[SELF_COPY]] : $Sub, #Base.prop!setter.1.foreign : (Base) -> (String!) -> () , $@convention(objc_method) (Optional<NSString>, Base) -> ()
+    // CHECK:   [[SET_SUPER_METHOD:%.*]] = super_method [volatile] [[SELF_COPY]] : $Sub, #Base.prop!setter.1.foreign : (Base) -> (String!) -> (), $@convention(objc_method) (Optional<NSString>, Base) -> ()
     // CHECK: bb4:
     // CHECK: bb6([[BRIDGED_NEW_STRING:%.*]] : $Optional<NSString>):
     // CHECK:    apply [[SET_SUPER_METHOD]]([[BRIDGED_NEW_STRING]], [[UPCAST_SELF_COPY]])
@@ -119,7 +119,7 @@ class SubSub : Sub {
   // CHECK-LABEL: sil hidden @_T015objc_extensions03SubC0C14objCBaseMethodyyF
   // CHECK: bb0([[SELF:%.*]] : $SubSub):
   // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
-  // CHECK:   super_method [volatile] [[SELF_COPY]] : $SubSub, #Sub.objCBaseMethod!1.foreign : (Sub) -> () -> () , $@convention(objc_method) (Sub) -> ()
+  // CHECK:   super_method [volatile] [[SELF_COPY]] : $SubSub, #Sub.objCBaseMethod!1.foreign : (Sub) -> () -> (), $@convention(objc_method) (Sub) -> ()
   // CHECK: } // end sil function '_T015objc_extensions03SubC0C14objCBaseMethodyyF'
   override func objCBaseMethod() {
     super.objCBaseMethod()

--- a/test/SILGen/objc_generic_class.swift
+++ b/test/SILGen/objc_generic_class.swift
@@ -33,7 +33,7 @@ class Generic<T>: NSObject {
 
 // CHECK-LABEL: sil hidden @_T018objc_generic_class11SubGeneric1CfD : $@convention(method) <U, V> (@owned SubGeneric1<U, V>) -> () {
 // CHECK:       bb0([[SELF:%.*]] : $SubGeneric1<U, V>):
-// CHECK:         [[SUPER_DEALLOC:%.*]] = super_method [[SELF]] : $SubGeneric1<U, V>, #Generic.deinit!deallocator.foreign : <T> (Generic<T>) -> () -> () , $@convention(objc_method) <τ_0_0> (Generic<τ_0_0>) -> ()
+// CHECK:         [[SUPER_DEALLOC:%.*]] = super_method [[SELF]] : $SubGeneric1<U, V>, #Generic.deinit!deallocator.foreign : <T> (Generic<T>) -> () -> (), $@convention(objc_method) <τ_0_0> (Generic<τ_0_0>) -> ()
 // CHECK:         [[SUPER:%.*]] = upcast [[SELF:%.*]] : $SubGeneric1<U, V> to $Generic<Int>
 // CHECK:         apply [[SUPER_DEALLOC]]<Int>([[SUPER]])
 class SubGeneric1<U, V>: Generic<Int> {

--- a/test/SILGen/objc_imported_generic.swift
+++ b/test/SILGen/objc_imported_generic.swift
@@ -139,5 +139,5 @@ func configureWithoutOptions() {
 // Make sure we emitted the witness table for the above conformance
 
 // CHECK-LABEL: sil_witness_table shared [fragile] GenericOption: Hashable module objc_generics {
-// CHECK: method #Hashable.hashValue!getter.1: @_TTWVSC13GenericOptions8Hashable13objc_genericsFS0_g9hashValueSi
+// CHECK: method #Hashable.hashValue!getter.1: {{.*}} : @_TTWVSC13GenericOptions8Hashable13objc_genericsFS0_g9hashValueSi
 // CHECK: }

--- a/test/SILGen/objc_init_ref_delegation.swift
+++ b/test/SILGen/objc_init_ref_delegation.swift
@@ -14,7 +14,7 @@ extension Gizmo {
     // CHECK:   store [[ORIG_SELF]] to [init] [[SELFMUI]] : $*Gizmo
     // SEMANTIC ARC TODO: Another case of needing a mutable borrow load.
     // CHECK:   [[SELF:%[0-9]+]] = load_borrow [[SELFMUI]] : $*Gizmo
-    // CHECK:   [[INIT_DELEG:%[0-9]+]] = class_method [volatile] [[SELF]] : $Gizmo, #Gizmo.init!initializer.1.foreign : (Gizmo.Type) -> (Int) -> Gizmo! , $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
+    // CHECK:   [[INIT_DELEG:%[0-9]+]] = class_method [volatile] [[SELF]] : $Gizmo, #Gizmo.init!initializer.1.foreign : (Gizmo.Type) -> (Int) -> Gizmo!, $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
     // CHECK:   [[SELF_RET:%[0-9]+]] = apply [[INIT_DELEG]]([[I]], [[SELF]]) : $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
     // CHECK:   [[SELF4:%.*]] = load [copy] [[SELFMUI]]
     // CHECK:   destroy_value [[SELF_BOX:%[0-9]+]] : ${ var Gizmo }

--- a/test/SILGen/objc_nonnull_lie_hack.swift
+++ b/test/SILGen/objc_nonnull_lie_hack.swift
@@ -28,7 +28,7 @@ func makeObject() -> NSObject? {
 
 // OPT-LABEL: sil hidden @_TF21objc_nonnull_lie_hack15callClassMethod
 // OPT: [[METATYPE:%[0-9]+]] = metatype $@thick Gizmo.Type
-// OPT: [[METHOD:%[0-9]+]] = class_method [volatile] [[METATYPE]] : $@thick Gizmo.Type, #Gizmo.nonNilGizmo!1.foreign : (Gizmo.Type) -> () -> Gizmo , $@convention(objc_method) (@objc_metatype Gizmo.Type) -> @autoreleased Gizmo
+// OPT: [[METHOD:%[0-9]+]] = class_method [volatile] [[METATYPE]] : $@thick Gizmo.Type, #Gizmo.nonNilGizmo!1.foreign : (Gizmo.Type) -> () -> Gizmo, $@convention(objc_method) (@objc_metatype Gizmo.Type) -> @autoreleased Gizmo
 // OPT: [[OBJC_METATYPE:%[0-9]+]] = metatype $@objc_metatype Gizmo.Type
 // OPT: [[NONOPTIONAL:%[0-9]+]] = apply [[METHOD]]([[OBJC_METATYPE]]) : $@convention(objc_method) (@objc_metatype Gizmo.Type) -> @autoreleased Gizmo
 // OPT: [[OPTIONAL:%[0-9]+]] = unchecked_ref_cast [[NONOPTIONAL]] : $Gizmo to $Optional<Gizmo>
@@ -42,7 +42,7 @@ func callClassMethod() -> Gizmo? {
 }
 
 // OPT-LABEL: sil hidden @_TTSf4g___TF21objc_nonnull_lie_hack18callInstanceMetho
-// OPT: [[METHOD:%[0-9]+]] = class_method [volatile] [[OBJ:%[0-9]+]] : $Gizmo, #Gizmo.nonNilGizmo!1.foreign : (Gizmo) -> () -> Gizmo , $@convention(objc_method) (Gizmo) -> @autoreleased Gizmo
+// OPT: [[METHOD:%[0-9]+]] = class_method [volatile] [[OBJ:%[0-9]+]] : $Gizmo, #Gizmo.nonNilGizmo!1.foreign : (Gizmo) -> () -> Gizmo, $@convention(objc_method) (Gizmo) -> @autoreleased Gizmo
 // OPT: [[NONOPTIONAL:%[0-9]+]] = apply [[METHOD]]([[OBJ]]) : $@convention(objc_method) (Gizmo) -> @autoreleased Gizmo
 // OPT: [[OPTIONAL:%[0-9]+]] = unchecked_ref_cast [[NONOPTIONAL]]
 // OPT: switch_enum [[OPTIONAL]] : $Optional<Gizmo>
@@ -56,7 +56,7 @@ func callInstanceMethod(gizmo: Gizmo) -> Gizmo? {
 }
 
 // OPT-LABEL: sil hidden @_TTSf4g___TF21objc_nonnull_lie_hack12loadPropertyFT5gizmoCSo5Gizmo_GSqS0__
-// OPT: [[GETTER:%[0-9]+]] = class_method [volatile] [[OBJ:%[0-9]+]] : $Gizmo, #Gizmo.nonNilGizmoProperty!getter.1.foreign : (Gizmo) -> () -> Gizmo , $@convention(objc_method) (Gizmo) -> @autoreleased Gizmo
+// OPT: [[GETTER:%[0-9]+]] = class_method [volatile] [[OBJ:%[0-9]+]] : $Gizmo, #Gizmo.nonNilGizmoProperty!getter.1.foreign : (Gizmo) -> () -> Gizmo, $@convention(objc_method) (Gizmo) -> @autoreleased Gizmo
 // OPT: [[NONOPTIONAL:%[0-9]+]] = apply [[GETTER]]([[OBJ]]) : $@convention(objc_method) (Gizmo) -> @autoreleased Gizmo
 // OPT: [[OPTIONAL:%[0-9]+]] = unchecked_ref_cast [[NONOPTIONAL]] : $Gizmo to $Optional<Gizmo>
 // OPT: switch_enum [[OPTIONAL]] : $Optional<Gizmo>,
@@ -69,7 +69,7 @@ func loadProperty(gizmo: Gizmo) -> Gizmo? {
 }
 
 // OPT-LABEL: sil hidden @_TTSf4g___TF21objc_nonnull_lie_hack19loadUnownedPropertyFT5gizmoCSo5Gizmo_GSqS0__
-// OPT: [[GETTER:%[0-9]+]] = class_method [volatile] [[OBJ:%[0-9]+]] : $Gizmo, #Gizmo.unownedNonNilGizmoProperty!getter.1.foreign : (Gizmo) -> () -> Gizmo , $@convention(objc_method) (Gizmo) -> @autoreleased Gizmo
+// OPT: [[GETTER:%[0-9]+]] = class_method [volatile] [[OBJ:%[0-9]+]] : $Gizmo, #Gizmo.unownedNonNilGizmoProperty!getter.1.foreign : (Gizmo) -> () -> Gizmo, $@convention(objc_method) (Gizmo) -> @autoreleased Gizmo
 // OPT: [[NONOPTIONAL:%[0-9]+]] = apply [[GETTER]]([[OBJ]]) : $@convention(objc_method) (Gizmo) -> @autoreleased Gizmo
 // OPT: [[OPTIONAL:%[0-9]+]] = unchecked_ref_cast [[NONOPTIONAL]] : $Gizmo to $Optional<Gizmo>
 // OPT: switch_enum [[OPTIONAL]] : $Optional<Gizmo>

--- a/test/SILGen/objc_ownership_conventions.swift
+++ b/test/SILGen/objc_ownership_conventions.swift
@@ -126,7 +126,7 @@ func test10(_ g: Gizmo) -> AnyClass {
   // CHECK: bb0([[G:%[0-9]+]] : $Gizmo):
   // CHECK:      [[G_COPY:%.*]] = copy_value [[G]]
   // CHECK-NEXT: [[NS_G_COPY:%[0-9]+]] = upcast [[G_COPY]] : $Gizmo to $NSObject
-  // CHECK-NEXT: [[GETTER:%[0-9]+]] = class_method [volatile] [[NS_G_COPY]] : $NSObject, #NSObject.classProp!getter.1.foreign : (NSObject) -> () -> AnyObject.Type! , $@convention(objc_method) (NSObject) -> Optional<@objc_metatype AnyObject.Type>
+  // CHECK-NEXT: [[GETTER:%[0-9]+]] = class_method [volatile] [[NS_G_COPY]] : $NSObject, #NSObject.classProp!getter.1.foreign : (NSObject) -> () -> AnyObject.Type!, $@convention(objc_method) (NSObject) -> Optional<@objc_metatype AnyObject.Type>
   // CHECK-NEXT: [[OPT_OBJC:%.*]] = apply [[GETTER]]([[NS_G_COPY]]) : $@convention(objc_method) (NSObject) -> Optional<@objc_metatype AnyObject.Type>
   // CHECK:      select_enum [[OPT_OBJC]]
   // CHECK:      [[OBJC:%.*]] = unchecked_enum_data [[OPT_OBJC]]
@@ -144,7 +144,7 @@ func test11(_ g: Gizmo) -> AnyClass {
   // CHECK: bb0([[G:%[0-9]+]] : $Gizmo):
   // CHECK: [[G_COPY:%.*]] = copy_value [[G]]
   // CHECK: [[NS_G_COPY:%[0-9]+]] = upcast [[G_COPY:%[0-9]+]] : $Gizmo to $NSObject
-  // CHECK: [[GETTER:%[0-9]+]] = class_method [volatile] [[NS_G_COPY]] : $NSObject, #NSObject.qualifiedClassProp!getter.1.foreign : (NSObject) -> () -> NSAnsing.Type! , $@convention(objc_method) (NSObject) -> Optional<@objc_metatype NSAnsing.Type>
+  // CHECK: [[GETTER:%[0-9]+]] = class_method [volatile] [[NS_G_COPY]] : $NSObject, #NSObject.qualifiedClassProp!getter.1.foreign : (NSObject) -> () -> NSAnsing.Type!, $@convention(objc_method) (NSObject) -> Optional<@objc_metatype NSAnsing.Type>
   // CHECK-NEXT: [[OPT_OBJC:%.*]] = apply [[GETTER]]([[NS_G_COPY]]) : $@convention(objc_method) (NSObject) -> Optional<@objc_metatype NSAnsing.Type>
   // CHECK:      select_enum [[OPT_OBJC]]
   // CHECK:      [[OBJC:%.*]] = unchecked_enum_data [[OPT_OBJC]]
@@ -188,7 +188,7 @@ func useInnerPointer(_ p: UnsafeMutableRawPointer) {}
 // CHECK-LABEL: sil hidden @_T026objc_ownership_conventions18innerPointerMethodySo5GizmoCF : $@convention(thin) (@owned Gizmo) -> () {
 // CHECK: bb0([[ARG:%.*]] : $Gizmo):
 // CHECK:         [[USE:%.*]] = function_ref @_T026objc_ownership_conventions15useInnerPointer{{[_0-9a-zA-Z]*}}F
-// CHECK:         [[METHOD:%.*]] = class_method [volatile] [[ARG]] : $Gizmo, #Gizmo.getBytes!1.foreign : (Gizmo) -> () -> UnsafeMutableRawPointer , $@convention(objc_method) (Gizmo) -> @unowned_inner_pointer UnsafeMutableRawPointer
+// CHECK:         [[METHOD:%.*]] = class_method [volatile] [[ARG]] : $Gizmo, #Gizmo.getBytes!1.foreign : (Gizmo) -> () -> UnsafeMutableRawPointer, $@convention(objc_method) (Gizmo) -> @unowned_inner_pointer UnsafeMutableRawPointer
 // CHECK:         [[ARG_COPY:%.*]] = copy_value [[ARG]]
 // SEMANTIC ARC TODO: The apply below /should/ be on ARG_COPY
 // CHECK:         [[PTR:%.*]] = apply [[METHOD]]([[ARG]])
@@ -202,7 +202,7 @@ func innerPointerMethod(_ g: Gizmo) {
 // CHECK-LABEL: sil hidden @_T026objc_ownership_conventions20innerPointerPropertyySo5GizmoCF : $@convention(thin) (@owned Gizmo) -> () {
 // CHECK:       bb0([[ARG:%.*]] : $Gizmo):
 // CHECK:         [[USE:%.*]] = function_ref @_T026objc_ownership_conventions15useInnerPointer{{[_0-9a-zA-Z]*}}F
-// CHECK:         [[METHOD:%.*]] = class_method [volatile] [[ARG]] : $Gizmo, #Gizmo.innerProperty!getter.1.foreign : (Gizmo) -> () -> UnsafeMutableRawPointer , $@convention(objc_method) (Gizmo) -> @unowned_inner_pointer UnsafeMutableRawPointer
+// CHECK:         [[METHOD:%.*]] = class_method [volatile] [[ARG]] : $Gizmo, #Gizmo.innerProperty!getter.1.foreign : (Gizmo) -> () -> UnsafeMutableRawPointer, $@convention(objc_method) (Gizmo) -> @unowned_inner_pointer UnsafeMutableRawPointer
 // CHECK:         [[ARG_COPY:%.*]] = copy_value [[ARG]]
 // SEMANTIC ARC TODO: The apply below should be on ARG_COPY
 // CHECK:         [[PTR:%.*]] = apply [[METHOD]]([[ARG]])

--- a/test/SILGen/objc_properties.swift
+++ b/test/SILGen/objc_properties.swift
@@ -59,25 +59,25 @@ class A {
 
 // CHECK-LABEL: sil hidden @_T015objc_properties11testPropGet{{[_0-9a-zA-Z]*}}F
 func testPropGet(_ a: A) -> Int {
-  // CHECK: class_method [volatile] [[OBJ:%[0-9]+]] : $A, #A.prop!getter.1.foreign : (A) -> () -> Int , $@convention(objc_method) (A) -> Int
+  // CHECK: class_method [volatile] [[OBJ:%[0-9]+]] : $A, #A.prop!getter.1.foreign : (A) -> () -> Int, $@convention(objc_method) (A) -> Int
   return a.prop
 }
 
 // CHECK-LABEL: sil hidden @_T015objc_properties11testPropSet{{[_0-9a-zA-Z]*}}F
 func testPropSet(_ a: A, i: Int) {
-  // CHECK: class_method [volatile] [[OBJ:%[0-9]+]] : $A, #A.prop!setter.1.foreign : (A) -> (Int) -> () , $@convention(objc_method) (Int, A) -> ()
+  // CHECK: class_method [volatile] [[OBJ:%[0-9]+]] : $A, #A.prop!setter.1.foreign : (A) -> (Int) -> (), $@convention(objc_method) (Int, A) -> ()
   a.prop = i
 }
 
 // CHECK-LABEL: sil hidden @_T015objc_properties19testComputedPropGet{{[_0-9a-zA-Z]*}}F
 func testComputedPropGet(_ a: A) -> Int {
-  // CHECK: class_method [volatile] [[OBJ:%[0-9]+]] : $A, #A.computedProp!getter.1.foreign : (A) -> () -> Int , $@convention(objc_method) (A) -> Int
+  // CHECK: class_method [volatile] [[OBJ:%[0-9]+]] : $A, #A.computedProp!getter.1.foreign : (A) -> () -> Int, $@convention(objc_method) (A) -> Int
   return a.computedProp
 }
 
 // CHECK-LABEL: sil hidden @_T015objc_properties19testComputedPropSet{{[_0-9a-zA-Z]*}}F
 func testComputedPropSet(_ a: A, i: Int) {
-  // CHECK: class_method [volatile] [[OBJ:%[0-9]+]] : $A, #A.computedProp!setter.1.foreign : (A) -> (Int) -> () , $@convention(objc_method) (Int, A) -> ()
+  // CHECK: class_method [volatile] [[OBJ:%[0-9]+]] : $A, #A.computedProp!setter.1.foreign : (A) -> (Int) -> (), $@convention(objc_method) (Int, A) -> ()
   a.computedProp = i
 }
 
@@ -86,12 +86,12 @@ class B : A {
   @objc override var computedProp: Int {
     // CHECK-LABEL: sil hidden @_T015objc_properties1BC12computedPropSifg : $@convention(method) (@guaranteed B) -> Int
     get {
-      // CHECK: super_method [volatile] [[SELF:%[0-9]+]] : $B, #A.computedProp!getter.1.foreign : (A) -> () -> Int , $@convention(objc_method) (A) -> Int
+      // CHECK: super_method [volatile] [[SELF:%[0-9]+]] : $B, #A.computedProp!getter.1.foreign : (A) -> () -> Int, $@convention(objc_method) (A) -> Int
       return super.computedProp
     }
     // CHECK-LABEL: sil hidden @_T015objc_properties1BC12computedPropSifs : $@convention(method) (Int, @guaranteed B) -> ()
     set(value) {
-      // CHECK: super_method [volatile] [[SELF:%[0-9]+]] : $B, #A.computedProp!setter.1.foreign : (A) -> (Int) -> () , $@convention(objc_method) (Int, A) -> ()
+      // CHECK: super_method [volatile] [[SELF:%[0-9]+]] : $B, #A.computedProp!setter.1.foreign : (A) -> (Int) -> (), $@convention(objc_method) (Int, A) -> ()
       super.computedProp = value
     }
   }

--- a/test/SILGen/objc_protocols.swift
+++ b/test/SILGen/objc_protocols.swift
@@ -252,7 +252,7 @@ func testInitializableExistential(_ im: Initializable.Type, i: Int) -> Initializ
   // CHECK:   [[ARCHETYPE_META:%[0-9]+]] = open_existential_metatype [[META]] : $@thick Initializable.Type to $@thick (@opened([[N:".*"]]) Initializable).Type
   // CHECK:   [[ARCHETYPE_META_OBJC:%[0-9]+]] = thick_to_objc_metatype [[ARCHETYPE_META]] : $@thick (@opened([[N]]) Initializable).Type to $@objc_metatype (@opened([[N]]) Initializable).Type
   // CHECK:   [[I2_ALLOC:%[0-9]+]] = alloc_ref_dynamic [objc] [[ARCHETYPE_META_OBJC]] : $@objc_metatype (@opened([[N]]) Initializable).Type, $@opened([[N]]) Initializable
-  // CHECK:   [[INIT_WITNESS:%[0-9]+]] = witness_method [volatile] $@opened([[N]]) Initializable, #Initializable.init!initializer.1.foreign, [[ARCHETYPE_META]]{{.*}} : $@convention(objc_method) <τ_0_0 where τ_0_0 : Initializable> (Int, @owned τ_0_0) -> @owned τ_0_0
+  // CHECK:   [[INIT_WITNESS:%[0-9]+]] = witness_method [volatile] $@opened([[N]]) Initializable, #Initializable.init!initializer.1.foreign : {{.*}}, [[ARCHETYPE_META]]{{.*}} : $@convention(objc_method) <τ_0_0 where τ_0_0 : Initializable> (Int, @owned τ_0_0) -> @owned τ_0_0
   // CHECK:   [[I2_COPY:%.*]] = copy_value [[I2_ALLOC]]
   // CHECK:   [[I2:%[0-9]+]] = apply [[INIT_WITNESS]]<@opened([[N]]) Initializable>([[I]], [[I2_COPY]]) : $@convention(objc_method) <τ_0_0 where τ_0_0 : Initializable> (Int, @owned τ_0_0) -> @owned τ_0_0
   // CHECK:   [[I2_EXIST_CONTAINER:%[0-9]+]] = init_existential_ref [[I2]] : $@opened([[N]]) Initializable : $@opened([[N]]) Initializable, $Initializable

--- a/test/SILGen/objc_subscript.swift
+++ b/test/SILGen/objc_subscript.swift
@@ -15,13 +15,13 @@ class A {
 
 // CHECK-LABEL: sil hidden @_T014objc_subscript16testSubscriptGet{{[_0-9a-zA-Z]*}}F
 func testSubscriptGet(a: A, i: Int) -> ObjCClass {
-  // CHECK: class_method [volatile] [[OBJ:%[0-9]+]] : $A, #A.subscript!getter.1.foreign : (A) -> (Int) -> ObjCClass , $@convention(objc_method) (Int, A) -> @autoreleased ObjCClass
+  // CHECK: class_method [volatile] [[OBJ:%[0-9]+]] : $A, #A.subscript!getter.1.foreign : (A) -> (Int) -> ObjCClass, $@convention(objc_method) (Int, A) -> @autoreleased ObjCClass
   return a[i]
 }
 
 // CHECK-LABEL: sil hidden @_T014objc_subscript16testSubscriptSet{{[_0-9a-zA-Z]*}}F
 func testSubscriptSet(a: A, i: Int, v: ObjCClass) {
-  // CHECK: class_method [volatile] [[OBJ:%[0-9]+]] : $A, #A.subscript!setter.1.foreign : (A) -> (ObjCClass, Int) -> () , $@convention(objc_method) (ObjCClass, Int, A) -> ()
+  // CHECK: class_method [volatile] [[OBJ:%[0-9]+]] : $A, #A.subscript!setter.1.foreign : (A) -> (ObjCClass, Int) -> (), $@convention(objc_method) (ObjCClass, Int, A) -> ()
   a[i] = v
 }
 
@@ -30,12 +30,12 @@ class B : A {
   @objc override subscript (i: Int) -> ObjCClass {
     // CHECK-LABEL: sil hidden @_T014objc_subscript1BC0B0AA9ObjCClassCSicfg : $@convention(method) (Int, @guaranteed B) -> @owned ObjCClass
     get {
-      // CHECK: super_method [volatile] [[SELF:%[0-9]+]] : $B, #A.subscript!getter.1.foreign : (A) -> (Int) -> ObjCClass , $@convention(objc_method) (Int, A) -> @autoreleased ObjCClass
+      // CHECK: super_method [volatile] [[SELF:%[0-9]+]] : $B, #A.subscript!getter.1.foreign : (A) -> (Int) -> ObjCClass, $@convention(objc_method) (Int, A) -> @autoreleased ObjCClass
       return super[i]
     }
     // CHECK-LABEL: sil hidden @_T014objc_subscript1BC0B0AA9ObjCClassCSicfs : $@convention(method) (@owned ObjCClass, Int, @guaranteed B) -> ()
     set(value) {
-      // CHECK: super_method [volatile] [[SELF:%[0-9]+]] : $B, #A.subscript!setter.1.foreign : (A) -> (ObjCClass, Int) -> () , $@convention(objc_method) (ObjCClass, Int, A) -> ()
+      // CHECK: super_method [volatile] [[SELF:%[0-9]+]] : $B, #A.subscript!setter.1.foreign : (A) -> (ObjCClass, Int) -> (), $@convention(objc_method) (ObjCClass, Int, A) -> ()
       super[i] = value
     }
   }

--- a/test/SILGen/objc_thunks.swift
+++ b/test/SILGen/objc_thunks.swift
@@ -268,7 +268,7 @@ class Hoozit : Gizmo {
   // CHECK: [[PB:%.*]] = project_box [[SELF_BOX]]
   // CHECK: [[SELFMUI:%[0-9]+]] = mark_uninitialized [derivedself] [[PB]]
   // CHECK: [[GIZMO:%[0-9]+]] = upcast [[SELF:%[0-9]+]] : $Hoozit to $Gizmo
-  // CHECK: [[SUPERMETHOD:%[0-9]+]] = super_method [volatile] [[SELF]] : $Hoozit, #Gizmo.init!initializer.1.foreign : (Gizmo.Type) -> (Int) -> Gizmo! , $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
+  // CHECK: [[SUPERMETHOD:%[0-9]+]] = super_method [volatile] [[SELF]] : $Hoozit, #Gizmo.init!initializer.1.foreign : (Gizmo.Type) -> (Int) -> Gizmo!, $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
   // CHECK-NEXT: [[SELF_REPLACED:%[0-9]+]] = apply [[SUPERMETHOD]](%0, [[X:%[0-9]+]]) : $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
   // CHECK-NOT: unconditional_checked_cast downcast [[SELF_REPLACED]] : $Gizmo to $Hoozit
   // CHECK: unchecked_ref_cast
@@ -366,7 +366,7 @@ extension Hoozit {
     // CHECK: [[SELFMUI:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]]
     // CHECK: [[X_BOX:%[0-9]+]] = alloc_box ${ var X }
     var x = X()
-    // CHECK: [[CTOR:%[0-9]+]] = class_method [volatile] [[SELF:%[0-9]+]] : $Hoozit, #Hoozit.init!initializer.1.foreign : (Hoozit.Type) -> (Int) -> Hoozit , $@convention(objc_method) (Int, @owned Hoozit) -> @owned Hoozit
+    // CHECK: [[CTOR:%[0-9]+]] = class_method [volatile] [[SELF:%[0-9]+]] : $Hoozit, #Hoozit.init!initializer.1.foreign : (Hoozit.Type) -> (Int) -> Hoozit, $@convention(objc_method) (Int, @owned Hoozit) -> @owned Hoozit
     // CHECK: [[NEW_SELF:%[0-9]+]] = apply [[CTOR]]
     // CHECK: store [[NEW_SELF]] to [init] [[SELFMUI]] : $*Hoozit
     // CHECK: [[NONNULL:%[0-9]+]] = is_nonnull [[NEW_SELF]] : $Hoozit
@@ -458,12 +458,12 @@ class DesignatedOverrides : Gizmo {
   // CHECK-LABEL: sil hidden @_TFC11objc_thunks19DesignatedOverridesc{{.*}}
   // CHECK-NOT: return
   // CHECK: function_ref @_TIvC11objc_thunks19DesignatedOverrides1iSii : $@convention(thin) () -> Int
-  // CHECK: super_method [volatile] [[SELF:%[0-9]+]] : $DesignatedOverrides, #Gizmo.init!initializer.1.foreign : (Gizmo.Type) -> () -> Gizmo! , $@convention(objc_method) (@owned Gizmo) -> @owned Optional<Gizmo>
+  // CHECK: super_method [volatile] [[SELF:%[0-9]+]] : $DesignatedOverrides, #Gizmo.init!initializer.1.foreign : (Gizmo.Type) -> () -> Gizmo!, $@convention(objc_method) (@owned Gizmo) -> @owned Optional<Gizmo>
   // CHECK: return
 
   // CHECK-LABEL: sil hidden @_TFC11objc_thunks19DesignatedOverridesc{{.*}}
   // CHECK: function_ref @_TIvC11objc_thunks19DesignatedOverrides1iSii : $@convention(thin) () -> Int
-  // CHECK: super_method [volatile] [[SELF:%[0-9]+]] : $DesignatedOverrides, #Gizmo.init!initializer.1.foreign : (Gizmo.Type) -> (Int) -> Gizmo! , $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
+  // CHECK: super_method [volatile] [[SELF:%[0-9]+]] : $DesignatedOverrides, #Gizmo.init!initializer.1.foreign : (Gizmo.Type) -> (Int) -> Gizmo!, $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
   // CHECK: return
 }
 

--- a/test/SILGen/partial_apply_protocol.swift
+++ b/test/SILGen/partial_apply_protocol.swift
@@ -28,7 +28,7 @@ func testClonable(c: Clonable) {
   // CHECK: [[THUNK:%.*]] = partial_apply [[THUNK_FN]]<@opened("{{.*}}") Clonable>({{.*}}) : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @thick τ_0_0.Type) -> @thick Clonable.Type
   let _: () -> Clonable.Type = c.cloneMetatype
 
-  // CHECK: [[METHOD_FN:%.*]] = witness_method $@opened("{{.*}}") Clonable, #Clonable.getCloneFn!1, {{.*}} : $*@opened("{{.*}}") Clonable : $@convention(witness_method) <τ_0_0 where τ_0_0 : Clonable> (@in_guaranteed τ_0_0) -> @owned @callee_owned () -> @out τ_0_0
+  // CHECK: [[METHOD_FN:%.*]] = witness_method $@opened("{{.*}}") Clonable, #Clonable.getCloneFn!1 : {{.*}}, {{.*}} : $*@opened("{{.*}}") Clonable : $@convention(witness_method) <τ_0_0 where τ_0_0 : Clonable> (@in_guaranteed τ_0_0) -> @owned @callee_owned () -> @out τ_0_0
   // CHECK: [[RESULT:%.*]] = apply [[METHOD_FN]]<@opened("{{.*}}") Clonable>({{.*}}) : $@convention(witness_method) <τ_0_0 where τ_0_0 : Clonable> (@in_guaranteed τ_0_0) -> @owned @callee_owned () -> @out τ_0_0
   // CHECK: [[THUNK_FN:%.*]] = function_ref @_T0xIxr_22partial_apply_protocol8Clonable_pIxr_AaBRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @out τ_0_0) -> @out Clonable
   // CHECK: [[THUNK:%.*]] = partial_apply [[THUNK_FN]]<@opened("{{.*}}") Clonable>([[RESULT]]) : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @out τ_0_0) -> @out Clonable
@@ -111,7 +111,7 @@ func testClonableInGenericContext<T>(c: Clonable, t: T) {
   // CHECK: [[THUNK:%.*]] = partial_apply [[THUNK_FN]]<@opened("{{.*}}") Clonable>({{.*}}) : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @thick τ_0_0.Type) -> @thick Clonable.Type
   let _: () -> Clonable.Type = c.cloneMetatype
 
-  // CHECK: [[METHOD_FN:%.*]] = witness_method $@opened("{{.*}}") Clonable, #Clonable.getCloneFn!1, {{.*}} : $*@opened("{{.*}}") Clonable : $@convention(witness_method) <τ_0_0 where τ_0_0 : Clonable> (@in_guaranteed τ_0_0) -> @owned @callee_owned () -> @out τ_0_0
+  // CHECK: [[METHOD_FN:%.*]] = witness_method $@opened("{{.*}}") Clonable, #Clonable.getCloneFn!1 : {{.*}}, {{.*}} : $*@opened("{{.*}}") Clonable : $@convention(witness_method) <τ_0_0 where τ_0_0 : Clonable> (@in_guaranteed τ_0_0) -> @owned @callee_owned () -> @out τ_0_0
   // CHECK: [[RESULT:%.*]] = apply [[METHOD_FN]]<@opened("{{.*}}") Clonable>({{.*}}) : $@convention(witness_method) <τ_0_0 where τ_0_0 : Clonable> (@in_guaranteed τ_0_0) -> @owned @callee_owned () -> @out τ_0_0
   // CHECK: [[THUNK_FN:%.*]] = function_ref @_T0xIxr_22partial_apply_protocol8Clonable_pIxr_AaBRzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @out τ_0_0) -> @out Clonable
   // CHECK: [[THUNK:%.*]] = partial_apply [[THUNK_FN]]<@opened("{{.*}}") Clonable>([[RESULT]]) : $@convention(thin) <τ_0_0 where τ_0_0 : Clonable> (@owned @callee_owned () -> @out τ_0_0) -> @out Clonable

--- a/test/SILGen/partial_apply_super.swift
+++ b/test/SILGen/partial_apply_super.swift
@@ -111,7 +111,7 @@ class ChildToFixedOutsideParent : OutsideParent {
   // CHECK:   [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:   [[CASTED_SELF_COPY:%[0-9]+]] = upcast [[SELF_COPY]] : $ChildToFixedOutsideParent to $OutsideParent
-  // CHECK:   [[SUPER_METHOD:%[0-9]+]] = super_method [[SELF_COPY]] : $ChildToFixedOutsideParent, #OutsideParent.method!1 : (OutsideParent) -> () -> () , $@convention(method) (@guaranteed OutsideParent) -> ()
+  // CHECK:   [[SUPER_METHOD:%[0-9]+]] = super_method [[SELF_COPY]] : $ChildToFixedOutsideParent, #OutsideParent.method!1 : (OutsideParent) -> () -> (), $@convention(method) (@guaranteed OutsideParent) -> ()
   // CHECK:   [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF_COPY]]) : $@convention(method) (@guaranteed OutsideParent) -> ()
   // CHECK:   apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   // CHECK: } // end sil function '_T019partial_apply_super25ChildToFixedOutsideParentC6methodyyF'
@@ -122,7 +122,7 @@ class ChildToFixedOutsideParent : OutsideParent {
   // CHECK-LABEL: sil hidden @_T019partial_apply_super25ChildToFixedOutsideParentC11classMethodyyFZ
   // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $@thick ChildToFixedOutsideParent.Type to $@thick OutsideParent.Type
-  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick ChildToFixedOutsideParent.Type, #OutsideParent.classMethod!1 : (OutsideParent.Type) -> () -> () , $@convention(method) (@thick OutsideParent.Type) -> (){{.*}} // user: %5
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick ChildToFixedOutsideParent.Type, #OutsideParent.classMethod!1 : (OutsideParent.Type) -> () -> (), $@convention(method) (@thick OutsideParent.Type) -> (){{.*}} // user: %5
   // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(method) (@thick OutsideParent.Type) -> ()
   // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   override class func classMethod() {
@@ -136,7 +136,7 @@ class ChildToResilientOutsideParent : ResilientOutsideParent {
   // CHECK:   [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:   [[CASTED_SELF_COPY:%[0-9]+]] = upcast [[SELF_COPY]] : $ChildToResilientOutsideParent to $ResilientOutsideParent
-  // CHECK:   [[SUPER_METHOD:%[0-9]+]] = super_method [[SELF_COPY]] : $ChildToResilientOutsideParent, #ResilientOutsideParent.method!1 : (ResilientOutsideParent) -> () -> () , $@convention(method) (@guaranteed ResilientOutsideParent) -> ()
+  // CHECK:   [[SUPER_METHOD:%[0-9]+]] = super_method [[SELF_COPY]] : $ChildToResilientOutsideParent, #ResilientOutsideParent.method!1 : (ResilientOutsideParent) -> () -> (), $@convention(method) (@guaranteed ResilientOutsideParent) -> ()
   // CHECK:   [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF_COPY]]) : $@convention(method) (@guaranteed ResilientOutsideParent) -> ()
   // CHECK:   apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   // CHECK: } // end sil function '_T019partial_apply_super29ChildToResilientOutsideParentC6methodyyF'
@@ -147,7 +147,7 @@ class ChildToResilientOutsideParent : ResilientOutsideParent {
   // CHECK-LABEL: sil hidden @_T019partial_apply_super29ChildToResilientOutsideParentC11classMethodyyFZ
   // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $@thick ChildToResilientOutsideParent.Type to $@thick ResilientOutsideParent.Type
-  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick ChildToResilientOutsideParent.Type, #ResilientOutsideParent.classMethod!1 : (ResilientOutsideParent.Type) -> () -> () , $@convention(method) (@thick ResilientOutsideParent.Type) -> ()
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick ChildToResilientOutsideParent.Type, #ResilientOutsideParent.classMethod!1 : (ResilientOutsideParent.Type) -> () -> (), $@convention(method) (@thick ResilientOutsideParent.Type) -> ()
   // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(method) (@thick ResilientOutsideParent.Type) -> ()
   // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   override class func classMethod() {
@@ -161,7 +161,7 @@ class GrandchildToFixedOutsideChild : OutsideChild {
   // CHECK:     [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   // CHECK:     [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:     [[CASTED_SELF_COPY:%[0-9]+]] = upcast [[SELF_COPY]] : $GrandchildToFixedOutsideChild to $OutsideChild
-  // CHECK:     [[SUPER_METHOD:%[0-9]+]] = super_method [[SELF_COPY]] : $GrandchildToFixedOutsideChild, #OutsideChild.method!1 : (OutsideChild) -> () -> () , $@convention(method) (@guaranteed OutsideChild) -> ()
+  // CHECK:     [[SUPER_METHOD:%[0-9]+]] = super_method [[SELF_COPY]] : $GrandchildToFixedOutsideChild, #OutsideChild.method!1 : (OutsideChild) -> () -> (), $@convention(method) (@guaranteed OutsideChild) -> ()
   // CHECK:     [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF_COPY]]) : $@convention(method) (@guaranteed OutsideChild) -> ()
   // CHECK:     apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   // CHECK: } // end sil function '_T019partial_apply_super29GrandchildToFixedOutsideChildC6methodyyF'
@@ -172,7 +172,7 @@ class GrandchildToFixedOutsideChild : OutsideChild {
   // CHECK-LABEL: sil hidden @_T019partial_apply_super29GrandchildToFixedOutsideChildC11classMethodyyFZ
   // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $@thick GrandchildToFixedOutsideChild.Type to $@thick OutsideChild.Type
-  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick GrandchildToFixedOutsideChild.Type, #OutsideChild.classMethod!1 : (OutsideChild.Type) -> () -> () , $@convention(method) (@thick OutsideChild.Type) -> ()
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick GrandchildToFixedOutsideChild.Type, #OutsideChild.classMethod!1 : (OutsideChild.Type) -> () -> (), $@convention(method) (@thick OutsideChild.Type) -> ()
   // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply %4(%3) : $@convention(method) (@thick OutsideChild.Type) -> ()
   // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   override class func classMethod() {
@@ -186,7 +186,7 @@ class GrandchildToResilientOutsideChild : ResilientOutsideChild {
   // CHECK:     [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   // CHECK:     [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:     [[CASTED_SELF_COPY:%[0-9]+]] = upcast [[SELF_COPY]] : $GrandchildToResilientOutsideChild to $ResilientOutsideChild
-  // CHECK:     [[SUPER_METHOD:%[0-9]+]] = super_method [[SELF_COPY]] : $GrandchildToResilientOutsideChild, #ResilientOutsideChild.method!1 : (ResilientOutsideChild) -> () -> () , $@convention(method) (@guaranteed ResilientOutsideChild) -> ()
+  // CHECK:     [[SUPER_METHOD:%[0-9]+]] = super_method [[SELF_COPY]] : $GrandchildToResilientOutsideChild, #ResilientOutsideChild.method!1 : (ResilientOutsideChild) -> () -> (), $@convention(method) (@guaranteed ResilientOutsideChild) -> ()
   // CHECK:     [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF_COPY]]) : $@convention(method) (@guaranteed ResilientOutsideChild) -> ()
   // CHECK:     apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   // CHECK: } // end sil function '_T019partial_apply_super33GrandchildToResilientOutsideChildC6methodyyF'
@@ -197,7 +197,7 @@ class GrandchildToResilientOutsideChild : ResilientOutsideChild {
   // CHECK-LABEL: sil hidden @_T019partial_apply_super33GrandchildToResilientOutsideChildC11classMethodyyFZ
   // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $@thick GrandchildToResilientOutsideChild.Type to $@thick ResilientOutsideChild.Type
-  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick GrandchildToResilientOutsideChild.Type, #ResilientOutsideChild.classMethod!1 : (ResilientOutsideChild.Type) -> () -> () , $@convention(method) (@thick ResilientOutsideChild.Type) -> ()
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick GrandchildToResilientOutsideChild.Type, #ResilientOutsideChild.classMethod!1 : (ResilientOutsideChild.Type) -> () -> (), $@convention(method) (@thick ResilientOutsideChild.Type) -> ()
   // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(method) (@thick ResilientOutsideChild.Type) -> ()
   // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   override class func classMethod() {
@@ -211,7 +211,7 @@ class GenericChildToFixedGenericOutsideParent<A> : GenericOutsideParent<A> {
   // CHECK:     [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   // CHECK:     [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:     [[CASTED_SELF_COPY:%[0-9]+]] = upcast [[SELF_COPY]] : $GenericChildToFixedGenericOutsideParent<A> to $GenericOutsideParent<A>
-  // CHECK:     [[SUPER_METHOD:%[0-9]+]] = super_method [[SELF_COPY]] : $GenericChildToFixedGenericOutsideParent<A>, #GenericOutsideParent.method!1 : <A> (GenericOutsideParent<A>) -> () -> () , $@convention(method) <τ_0_0> (@guaranteed GenericOutsideParent<τ_0_0>) -> ()
+  // CHECK:     [[SUPER_METHOD:%[0-9]+]] = super_method [[SELF_COPY]] : $GenericChildToFixedGenericOutsideParent<A>, #GenericOutsideParent.method!1 : <A> (GenericOutsideParent<A>) -> () -> (), $@convention(method) <τ_0_0> (@guaranteed GenericOutsideParent<τ_0_0>) -> ()
   // CHECK:     [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]<A>([[CASTED_SELF_COPY]]) : $@convention(method) <τ_0_0> (@guaranteed GenericOutsideParent<τ_0_0>) -> ()
   // CHECK:     apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   // CHECK: } // end sil function '_T019partial_apply_super019GenericChildToFixedD13OutsideParentC6methodyyF'
@@ -222,7 +222,7 @@ class GenericChildToFixedGenericOutsideParent<A> : GenericOutsideParent<A> {
   // CHECK-LABEL: sil hidden @_T019partial_apply_super019GenericChildToFixedD13OutsideParentC11classMethodyyFZ
   // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $@thick GenericChildToFixedGenericOutsideParent<A>.Type to $@thick GenericOutsideParent<A>.Type
-  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick GenericChildToFixedGenericOutsideParent<A>.Type, #GenericOutsideParent.classMethod!1 : <A> (GenericOutsideParent<A>.Type) -> () -> () , $@convention(method) <τ_0_0> (@thick GenericOutsideParent<τ_0_0>.Type) -> ()
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick GenericChildToFixedGenericOutsideParent<A>.Type, #GenericOutsideParent.classMethod!1 : <A> (GenericOutsideParent<A>.Type) -> () -> (), $@convention(method) <τ_0_0> (@thick GenericOutsideParent<τ_0_0>.Type) -> ()
   // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]<A>([[CASTED_SELF]]) : $@convention(method) <τ_0_0> (@thick GenericOutsideParent<τ_0_0>.Type) -> ()
   // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   override class func classMethod() {
@@ -236,7 +236,7 @@ class GenericChildToResilientGenericOutsideParent<A> : ResilientGenericOutsidePa
   // CHECK:     [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   // CHECK:     [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:     [[CASTED_SELF_COPY:%[0-9]+]] = upcast [[SELF_COPY]] : $GenericChildToResilientGenericOutsideParent<A> to $ResilientGenericOutsideParent<A>
-  // CHECK:     [[SUPER_METHOD:%[0-9]+]] = super_method [[SELF_COPY]] : $GenericChildToResilientGenericOutsideParent<A>, #ResilientGenericOutsideParent.method!1 : <A> (ResilientGenericOutsideParent<A>) -> () -> () , $@convention(method) <τ_0_0> (@guaranteed ResilientGenericOutsideParent<τ_0_0>) -> ()
+  // CHECK:     [[SUPER_METHOD:%[0-9]+]] = super_method [[SELF_COPY]] : $GenericChildToResilientGenericOutsideParent<A>, #ResilientGenericOutsideParent.method!1 : <A> (ResilientGenericOutsideParent<A>) -> () -> (), $@convention(method) <τ_0_0> (@guaranteed ResilientGenericOutsideParent<τ_0_0>) -> ()
   // CHECK:     [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]<A>([[CASTED_SELF_COPY]]) : $@convention(method) <τ_0_0> (@guaranteed ResilientGenericOutsideParent<τ_0_0>) -> ()
   // CHECK:     apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   // CHECK: } // end sil function '_T019partial_apply_super023GenericChildToResilientD13OutsideParentC6methodyyF'
@@ -247,7 +247,7 @@ class GenericChildToResilientGenericOutsideParent<A> : ResilientGenericOutsidePa
   // CHECK-LABEL: sil hidden @_T019partial_apply_super023GenericChildToResilientD13OutsideParentC11classMethodyyFZ
   // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_T019partial_apply_super5doFooyyycF : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $@thick GenericChildToResilientGenericOutsideParent<A>.Type to $@thick ResilientGenericOutsideParent<A>.Type
-  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick GenericChildToResilientGenericOutsideParent<A>.Type, #ResilientGenericOutsideParent.classMethod!1 : <A> (ResilientGenericOutsideParent<A>.Type) -> () -> () , $@convention(method) <τ_0_0> (@thick ResilientGenericOutsideParent<τ_0_0>.Type) -> ()
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick GenericChildToResilientGenericOutsideParent<A>.Type, #ResilientGenericOutsideParent.classMethod!1 : <A> (ResilientGenericOutsideParent<A>.Type) -> () -> (), $@convention(method) <τ_0_0> (@thick ResilientGenericOutsideParent<τ_0_0>.Type) -> ()
   // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]<A>([[CASTED_SELF]]) : $@convention(method) <τ_0_0> (@thick ResilientGenericOutsideParent<τ_0_0>.Type) -> ()
   // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   override class func classMethod() {

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -111,7 +111,7 @@ func physical_subclass_lvalue(_ r: RefSubclass, a: Int) {
   r.y = a
   // CHECK: [[ARG1_COPY:%.*]] = copy_value [[ARG1]] : $RefSubclass
   // CHECK: [[R_SUP:%[0-9]+]] = upcast [[ARG1_COPY]] : $RefSubclass to $Ref
-  // CHECK: [[FN:%[0-9]+]] = class_method [[R_SUP]] : $Ref, #Ref.y!setter.1 : (Ref) -> (Int) -> () , $@convention(method) (Int, @guaranteed Ref) -> ()
+  // CHECK: [[FN:%[0-9]+]] = class_method [[R_SUP]] : $Ref, #Ref.y!setter.1 : (Ref) -> (Int) -> (), $@convention(method) (Int, @guaranteed Ref) -> ()
   // CHECK: apply [[FN]]([[ARG2]], [[R_SUP]]) :
   // CHECK: destroy_value [[R_SUP]]
   r.w = a

--- a/test/SILGen/protocol_extensions.swift
+++ b/test/SILGen/protocol_extensions.swift
@@ -13,7 +13,7 @@ extension P1 {
   // CHECK-LABEL: sil hidden @_T019protocol_extensions2P1PAAE6extP1a{{[_0-9a-zA-Z]*}}F : $@convention(method) <Self where Self : P1> (@in_guaranteed Self) -> () {
   // CHECK: bb0([[SELF:%[0-9]+]] : $*Self):
   final func extP1a() {
-    // CHECK: [[WITNESS:%[0-9]+]] = witness_method $Self, #P1.reqP1a!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : P1> (@in_guaranteed τ_0_0) -> ()
+    // CHECK: [[WITNESS:%[0-9]+]] = witness_method $Self, #P1.reqP1a!1 : {{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : P1> (@in_guaranteed τ_0_0) -> ()
     // CHECK-NEXT: apply [[WITNESS]]<Self>([[SELF]]) : $@convention(witness_method) <τ_0_0 where τ_0_0 : P1> (@in_guaranteed τ_0_0) -> ()
     reqP1a()
     // CHECK: return
@@ -686,7 +686,7 @@ extension InitRequirement {
   // CHECK-LABEL: sil hidden @_T019protocol_extensions15InitRequirementPAAE{{[_0-9a-zA-Z]*}}fC : $@convention(method) <Self where Self : InitRequirement> (@owned D, @thick Self.Type) -> @out Self
   // CHECK:       bb0([[OUT:%.*]] : $*Self, [[ARG:%.*]] : $D, [[SELF_TYPE:%.*]] : $@thick Self.Type):
   init(d: D) {
-  // CHECK:         [[DELEGATEE:%.*]] = witness_method $Self, #InitRequirement.init!allocator.1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : InitRequirement> (@owned C, @thick τ_0_0.Type) -> @out τ_0_0
+    // CHECK:         [[DELEGATEE:%.*]] = witness_method $Self, #InitRequirement.init!allocator.1 : {{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : InitRequirement> (@owned C, @thick τ_0_0.Type) -> @out τ_0_0
   // CHECK:         [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK:         [[ARG_COPY_CAST:%.*]] = upcast [[ARG_COPY]]
   // CHECK:         apply [[DELEGATEE]]<Self>({{%.*}}, [[ARG_COPY_CAST]], [[SELF_TYPE]])
@@ -709,7 +709,7 @@ protocol ClassInitRequirement: class {
 extension ClassInitRequirement {
   // CHECK-LABEL: sil hidden @_T019protocol_extensions20ClassInitRequirementPAAE{{[_0-9a-zA-Z]*}}fC : $@convention(method) <Self where Self : ClassInitRequirement> (@owned D, @thick Self.Type) -> @owned Self
   // CHECK:       bb0([[ARG:%.*]] : $D, [[SELF_TYPE:%.*]] : $@thick Self.Type):
-  // CHECK:         [[DELEGATEE:%.*]] = witness_method $Self, #ClassInitRequirement.init!allocator.1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : ClassInitRequirement> (@owned C, @thick τ_0_0.Type) -> @owned τ_0_0
+  // CHECK:         [[DELEGATEE:%.*]] = witness_method $Self, #ClassInitRequirement.init!allocator.1 : {{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : ClassInitRequirement> (@owned C, @thick τ_0_0.Type) -> @owned τ_0_0
   // CHECK:         [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK:         [[ARG_COPY_CAST:%.*]] = upcast [[ARG_COPY]]
   // CHECK:         apply [[DELEGATEE]]<Self>([[ARG_COPY_CAST]], [[SELF_TYPE]])
@@ -735,7 +735,7 @@ extension ObjCInitRequirement {
   // CHECK:       bb0([[ARG:%.*]] : $OD, [[SELF_TYPE:%.*]] : $@thick Self.Type):
   // CHECK:         [[OBJC_SELF_TYPE:%.*]] = thick_to_objc_metatype [[SELF_TYPE]]
   // CHECK:         [[SELF:%.*]] = alloc_ref_dynamic [objc] [[OBJC_SELF_TYPE]] : $@objc_metatype Self.Type, $Self
-  // CHECK:         [[WITNESS:%.*]] = witness_method [volatile] $Self, #ObjCInitRequirement.init!initializer.1.foreign : $@convention(objc_method) <τ_0_0 where τ_0_0 : ObjCInitRequirement> (OC, OC, @owned τ_0_0) -> @owned τ_0_0
+  // CHECK:         [[WITNESS:%.*]] = witness_method [volatile] $Self, #ObjCInitRequirement.init!initializer.1.foreign : {{.*}} : $@convention(objc_method) <τ_0_0 where τ_0_0 : ObjCInitRequirement> (OC, OC, @owned τ_0_0) -> @owned τ_0_0
   // CHECK:         [[ARG_COPY_1:%.*]] = copy_value [[ARG]]
   // CHECK:         [[ARG_COPY_1_UPCAST:%.*]] = upcast [[ARG_COPY_1]]
   // CHECK:         [[ARG_COPY_2:%.*]] = copy_value [[ARG]]
@@ -765,7 +765,7 @@ extension ProtoDelegatesToObjC where Self : ObjCInitClass {
     // CHECK:   [[SELF_META_OBJC:%[0-9]+]] = thick_to_objc_metatype [[SELF_META]] : $@thick Self.Type to $@objc_metatype Self.Type
     // CHECK:   [[SELF_ALLOC:%[0-9]+]] = alloc_ref_dynamic [objc] [[SELF_META_OBJC]] : $@objc_metatype Self.Type, $Self
     // CHECK:   [[SELF_ALLOC_C:%[0-9]+]] = upcast [[SELF_ALLOC]] : $Self to $ObjCInitClass
-    // CHECK:   [[OBJC_INIT:%[0-9]+]] = class_method [[SELF_ALLOC_C]] : $ObjCInitClass, #ObjCInitClass.init!initializer.1 : (ObjCInitClass.Type) -> () -> ObjCInitClass , $@convention(method) (@owned ObjCInitClass) -> @owned ObjCInitClass
+    // CHECK:   [[OBJC_INIT:%[0-9]+]] = class_method [[SELF_ALLOC_C]] : $ObjCInitClass, #ObjCInitClass.init!initializer.1 : (ObjCInitClass.Type) -> () -> ObjCInitClass, $@convention(method) (@owned ObjCInitClass) -> @owned ObjCInitClass
     // CHECK:   [[SELF_RESULT:%[0-9]+]] = apply [[OBJC_INIT]]([[SELF_ALLOC_C]]) : $@convention(method) (@owned ObjCInitClass) -> @owned ObjCInitClass
     // CHECK:   [[SELF_RESULT_AS_SELF:%[0-9]+]] = unchecked_ref_cast [[SELF_RESULT]] : $ObjCInitClass to $Self
     // CHECK:   assign [[SELF_RESULT_AS_SELF]] to [[SELF]] : $*Self
@@ -789,7 +789,7 @@ extension ProtoDelegatesToRequired where Self : RequiredInitClass {
   // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
   // CHECK:   [[SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*Self
   // CHECK:   [[SELF_META_AS_CLASS_META:%[0-9]+]] = upcast [[SELF_META]] : $@thick Self.Type to $@thick RequiredInitClass.Type
-  // CHECK:   [[INIT:%[0-9]+]] = class_method [[SELF_META_AS_CLASS_META]] : $@thick RequiredInitClass.Type, #RequiredInitClass.init!allocator.1 : (RequiredInitClass.Type) -> () -> RequiredInitClass , $@convention(method) (@thick RequiredInitClass.Type) -> @owned RequiredInitClass
+  // CHECK:   [[INIT:%[0-9]+]] = class_method [[SELF_META_AS_CLASS_META]] : $@thick RequiredInitClass.Type, #RequiredInitClass.init!allocator.1 : (RequiredInitClass.Type) -> () -> RequiredInitClass, $@convention(method) (@thick RequiredInitClass.Type) -> @owned RequiredInitClass
   // CHECK:   [[SELF_RESULT:%[0-9]+]] = apply [[INIT]]([[SELF_META_AS_CLASS_META]]) : $@convention(method) (@thick RequiredInitClass.Type) -> @owned RequiredInitClass
   // CHECK:   [[SELF_RESULT_AS_SELF:%[0-9]+]] = unchecked_ref_cast [[SELF_RESULT]] : $RequiredInitClass to $Self
   // CHECK:   assign [[SELF_RESULT_AS_SELF]] to [[SELF]] : $*Self

--- a/test/SILGen/protocol_resilience.swift
+++ b/test/SILGen/protocol_resilience.swift
@@ -261,20 +261,20 @@ extension InternalProtocol {
 // CHECK-LABEL: sil_default_witness_table ResilientMethods {
 // CHECK-NEXT:    no_default
 // CHECK-NEXT:    no_default
-// CHECK-NEXT:    method #ResilientMethods.defaultWitness!1: @_T019protocol_resilience16ResilientMethodsP14defaultWitnessyyF
-// CHECK-NEXT:    method #ResilientMethods.anotherDefaultWitness!1: @_T019protocol_resilience16ResilientMethodsP21anotherDefaultWitnessxSiF
-// CHECK-NEXT:    method #ResilientMethods.defaultWitnessWithAssociatedType!1: @_T019protocol_resilience16ResilientMethodsP32defaultWitnessWithAssociatedTypey05AssocI0QzF
-// CHECK-NEXT:    method #ResilientMethods.defaultWitnessMoreAbstractThanRequirement!1: @_T019protocol_resilience16ResilientMethodsP41defaultWitnessMoreAbstractThanRequirementy9AssocTypeQz_Si1btF
-// CHECK-NEXT:    method #ResilientMethods.defaultWitnessMoreAbstractThanGenericRequirement!1: @_T019protocol_resilience16ResilientMethodsP48defaultWitnessMoreAbstractThanGenericRequirementy9AssocTypeQz_qd__1ttlF
+// CHECK-NEXT:    method #ResilientMethods.defaultWitness!1: {{.*}} : @_T019protocol_resilience16ResilientMethodsP14defaultWitnessyyF
+// CHECK-NEXT:    method #ResilientMethods.anotherDefaultWitness!1: {{.*}} : @_T019protocol_resilience16ResilientMethodsP21anotherDefaultWitnessxSiF
+// CHECK-NEXT:    method #ResilientMethods.defaultWitnessWithAssociatedType!1: {{.*}} : @_T019protocol_resilience16ResilientMethodsP32defaultWitnessWithAssociatedTypey05AssocI0QzF
+// CHECK-NEXT:    method #ResilientMethods.defaultWitnessMoreAbstractThanRequirement!1: {{.*}} : @_T019protocol_resilience16ResilientMethodsP41defaultWitnessMoreAbstractThanRequirementy9AssocTypeQz_Si1btF
+// CHECK-NEXT:    method #ResilientMethods.defaultWitnessMoreAbstractThanGenericRequirement!1: {{.*}} : @_T019protocol_resilience16ResilientMethodsP48defaultWitnessMoreAbstractThanGenericRequirementy9AssocTypeQz_qd__1ttlF
 // CHECK-NEXT:    no_default
 // CHECK-NEXT:    no_default
-// CHECK-NEXT:    method #ResilientMethods.staticDefaultWitness!1: @_T019protocol_resilience16ResilientMethodsP20staticDefaultWitnessxSiFZ
+// CHECK-NEXT:    method #ResilientMethods.staticDefaultWitness!1: {{.*}} : @_T019protocol_resilience16ResilientMethodsP20staticDefaultWitnessxSiFZ
 // CHECK-NEXT: }
 
 // CHECK-LABEL: sil_default_witness_table ResilientConstructors {
 // CHECK-NEXT:    no_default
-// CHECK-NEXT:    method #ResilientConstructors.init!allocator.1: @_T019protocol_resilience21ResilientConstructorsPxyt7default_tcfC
-// CHECK-NEXT:    method #ResilientConstructors.init!allocator.1: @_T019protocol_resilience21ResilientConstructorsPxSgyt17defaultIsOptional_tcfC
+// CHECK-NEXT:    method #ResilientConstructors.init!allocator.1: {{.*}} : @_T019protocol_resilience21ResilientConstructorsPxyt7default_tcfC
+// CHECK-NEXT:    method #ResilientConstructors.init!allocator.1: {{.*}} : @_T019protocol_resilience21ResilientConstructorsPxSgyt17defaultIsOptional_tcfC
 // CHECK-NEXT:    no_default
 // CHECK-NEXT:    no_default
 // CHECK-NEXT: }
@@ -282,42 +282,42 @@ extension InternalProtocol {
 // CHECK-LABEL: sil_default_witness_table ResilientStorage {
 // CHECK-NEXT:   no_default
 // CHECK-NEXT:   no_default
-// CHECK-NEXT:   method #ResilientStorage.propertyWithDefault!getter.1: @_T019protocol_resilience16ResilientStorageP19propertyWithDefaultSifg
+// CHECK-NEXT:   method #ResilientStorage.propertyWithDefault!getter.1: {{.*}} : @_T019protocol_resilience16ResilientStorageP19propertyWithDefaultSifg
 // CHECK-NEXT:   no_default
-// CHECK-NEXT:   method #ResilientStorage.mutablePropertyWithDefault!getter.1: @_T019protocol_resilience16ResilientStorageP26mutablePropertyWithDefaultSifg
-// CHECK-NEXT:   method #ResilientStorage.mutablePropertyWithDefault!setter.1: @_T019protocol_resilience16ResilientStorageP26mutablePropertyWithDefaultSifs
-// CHECK-NEXT:   method #ResilientStorage.mutablePropertyWithDefault!materializeForSet.1: @_T019protocol_resilience16ResilientStorageP26mutablePropertyWithDefaultSifm
+// CHECK-NEXT:   method #ResilientStorage.mutablePropertyWithDefault!getter.1: {{.*}} : @_T019protocol_resilience16ResilientStorageP26mutablePropertyWithDefaultSifg
+// CHECK-NEXT:   method #ResilientStorage.mutablePropertyWithDefault!setter.1: {{.*}} : @_T019protocol_resilience16ResilientStorageP26mutablePropertyWithDefaultSifs
+// CHECK-NEXT:   method #ResilientStorage.mutablePropertyWithDefault!materializeForSet.1: {{.*}} : @_T019protocol_resilience16ResilientStorageP26mutablePropertyWithDefaultSifm
 // CHECK-NEXT:   no_default
 // CHECK-NEXT:   no_default
 // CHECK-NEXT:   no_default
-// CHECK-NEXT:   method #ResilientStorage.mutableGenericPropertyWithDefault!getter.1: @_T019protocol_resilience16ResilientStorageP33mutableGenericPropertyWithDefault1TQzfg
-// CHECK-NEXT:   method #ResilientStorage.mutableGenericPropertyWithDefault!setter.1: @_T019protocol_resilience16ResilientStorageP33mutableGenericPropertyWithDefault1TQzfs
-// CHECK-NEXT:   method #ResilientStorage.mutableGenericPropertyWithDefault!materializeForSet.1: @_T019protocol_resilience16ResilientStorageP33mutableGenericPropertyWithDefault1TQzfm
-// CHECK-NEXT:   method #ResilientStorage.subscript!getter.1: @_T019protocol_resilience16ResilientStorageP9subscript1TQzAFcfg
-// CHECK-NEXT:   method #ResilientStorage.subscript!setter.1: @_T019protocol_resilience16ResilientStorageP9subscript1TQzAFcfs
-// CHECK-NEXT:   method #ResilientStorage.subscript!materializeForSet.1: @_T019protocol_resilience16ResilientStorageP9subscript1TQzAFcfm
-// CHECK-NEXT:   method #ResilientStorage.mutatingGetterWithNonMutatingDefault!getter.1: @_T019protocol_resilience16ResilientStorageP36mutatingGetterWithNonMutatingDefaultSifg
-// CHECK-NEXT:   method #ResilientStorage.mutatingGetterWithNonMutatingDefault!setter.1: @_T019protocol_resilience16ResilientStorageP36mutatingGetterWithNonMutatingDefaultSifs
-// CHECK-NEXT:   method #ResilientStorage.mutatingGetterWithNonMutatingDefault!materializeForSet.1: @_T019protocol_resilience16ResilientStorageP36mutatingGetterWithNonMutatingDefaultSifm
+// CHECK-NEXT:   method #ResilientStorage.mutableGenericPropertyWithDefault!getter.1: {{.*}} : @_T019protocol_resilience16ResilientStorageP33mutableGenericPropertyWithDefault1TQzfg
+// CHECK-NEXT:   method #ResilientStorage.mutableGenericPropertyWithDefault!setter.1: {{.*}} : @_T019protocol_resilience16ResilientStorageP33mutableGenericPropertyWithDefault1TQzfs
+// CHECK-NEXT:   method #ResilientStorage.mutableGenericPropertyWithDefault!materializeForSet.1: {{.*}} : @_T019protocol_resilience16ResilientStorageP33mutableGenericPropertyWithDefault1TQzfm
+// CHECK-NEXT:   method #ResilientStorage.subscript!getter.1: {{.*}} : @_T019protocol_resilience16ResilientStorageP9subscript1TQzAFcfg
+// CHECK-NEXT:   method #ResilientStorage.subscript!setter.1: {{.*}} : @_T019protocol_resilience16ResilientStorageP9subscript1TQzAFcfs
+// CHECK-NEXT:   method #ResilientStorage.subscript!materializeForSet.1: {{.*}} : @_T019protocol_resilience16ResilientStorageP9subscript1TQzAFcfm
+// CHECK-NEXT:   method #ResilientStorage.mutatingGetterWithNonMutatingDefault!getter.1: {{.*}} : @_T019protocol_resilience16ResilientStorageP36mutatingGetterWithNonMutatingDefaultSifg
+// CHECK-NEXT:   method #ResilientStorage.mutatingGetterWithNonMutatingDefault!setter.1: {{.*}} : @_T019protocol_resilience16ResilientStorageP36mutatingGetterWithNonMutatingDefaultSifs
+// CHECK-NEXT:   method #ResilientStorage.mutatingGetterWithNonMutatingDefault!materializeForSet.1: {{.*}} : @_T019protocol_resilience16ResilientStorageP36mutatingGetterWithNonMutatingDefaultSifm
 // CHECK-NEXT: }
 
 // CHECK-LABEL: sil_default_witness_table ResilientOperators {
 // CHECK-NEXT:    no_default
 // CHECK-NEXT:    no_default
-// CHECK-NEXT:    method #ResilientOperators."~~~"!1: @_T019protocol_resilience18ResilientOperatorsP3tttopyxFZ
-// CHECK-NEXT:    method #ResilientOperators."<*>"!1: @_T019protocol_resilience18ResilientOperatorsP3lmgoiyx_qd__tlFZ
-// CHECK-NEXT:    method #ResilientOperators."<**>"!1: @_T019protocol_resilience18ResilientOperatorsP4lmmgoi9AssocTypeQzqd___xtlFZ
-// CHECK-NEXT:    method #ResilientOperators."<===>"!1: @_T019protocol_resilience18ResilientOperatorsP5leeegoi9AssocTypeQyd__qd___xtAaBRd__lFZ
+// CHECK-NEXT:    method #ResilientOperators."~~~"!1: {{.*}} : @_T019protocol_resilience18ResilientOperatorsP3tttopyxFZ
+// CHECK-NEXT:    method #ResilientOperators."<*>"!1: {{.*}} : @_T019protocol_resilience18ResilientOperatorsP3lmgoiyx_qd__tlFZ
+// CHECK-NEXT:    method #ResilientOperators."<**>"!1: {{.*}} : @_T019protocol_resilience18ResilientOperatorsP4lmmgoi9AssocTypeQzqd___xtlFZ
+// CHECK-NEXT:    method #ResilientOperators."<===>"!1: {{.*}} : @_T019protocol_resilience18ResilientOperatorsP5leeegoi9AssocTypeQyd__qd___xtAaBRd__lFZ
 // CHECK-NEXT: }
 
 // CHECK-LABEL: sil_default_witness_table ReabstractSelfRefined {
 // CHECK-NEXT:   no_default
-// CHECK-NEXT:   method #ReabstractSelfRefined.callback!getter.1: @_T019protocol_resilience21ReabstractSelfRefinedP8callbackxxcfg
-// CHECK-NEXT:   method #ReabstractSelfRefined.callback!setter.1: @_T019protocol_resilience21ReabstractSelfRefinedP8callbackxxcfs
-// CHECK-NEXT:   method #ReabstractSelfRefined.callback!materializeForSet.1: @_T019protocol_resilience21ReabstractSelfRefinedP8callbackxxcfm
+// CHECK-NEXT:   method #ReabstractSelfRefined.callback!getter.1: {{.*}} : @_T019protocol_resilience21ReabstractSelfRefinedP8callbackxxcfg
+// CHECK-NEXT:   method #ReabstractSelfRefined.callback!setter.1: {{.*}} : @_T019protocol_resilience21ReabstractSelfRefinedP8callbackxxcfs
+// CHECK-NEXT:   method #ReabstractSelfRefined.callback!materializeForSet.1: {{.*}} : @_T019protocol_resilience21ReabstractSelfRefinedP8callbackxxcfm
 // CHECK-NEXT: }
 
 // CHECK-LABEL: sil_default_witness_table hidden InternalProtocol {
 // CHECK-NEXT:   no_default
-// CHECK-NEXT:   method #InternalProtocol.defaultG!1: @_T019protocol_resilience16InternalProtocolP8defaultGyyF
+// CHECK-NEXT:   method #InternalProtocol.defaultG!1: {{.*}} : @_T019protocol_resilience16InternalProtocolP8defaultGyyF
 // CHECK-NEXT: }

--- a/test/SILGen/protocols.swift
+++ b/test/SILGen/protocols.swift
@@ -200,7 +200,7 @@ protocol Initializable {
 
 // CHECK-LABEL: sil hidden @_T09protocols27use_initializable_archetype{{[_0-9a-zA-Z]*}}F
 func use_initializable_archetype<T: Initializable>(_ t: T, i: Int) {
-  // CHECK:   [[T_INIT:%[0-9]+]] = witness_method $T, #Initializable.init!allocator.1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : Initializable> (Int, @thick τ_0_0.Type) -> @out τ_0_0
+  // CHECK:   [[T_INIT:%[0-9]+]] = witness_method $T, #Initializable.init!allocator.1 : {{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : Initializable> (Int, @thick τ_0_0.Type) -> @out τ_0_0
   // CHECK:   [[T_META:%[0-9]+]] = metatype $@thick T.Type
   // CHECK:   [[T_RESULT:%[0-9]+]] = alloc_stack $T
   // CHECK:   [[T_RESULT_ADDR:%[0-9]+]] = apply [[T_INIT]]<T>([[T_RESULT]], %1, [[T_META]]) : $@convention(witness_method) <τ_0_0 where τ_0_0 : Initializable> (Int, @thick τ_0_0.Type) -> @out τ_0_0
@@ -218,7 +218,7 @@ func use_initializable_existential(_ im: Initializable.Type, i: Int) {
 // CHECK:   [[ARCHETYPE_META:%[0-9]+]] = open_existential_metatype [[IM]] : $@thick Initializable.Type to $@thick (@opened([[N:".*"]]) Initializable).Type
 // CHECK:   [[TEMP_VALUE:%[0-9]+]] = alloc_stack $Initializable
 // CHECK:   [[TEMP_ADDR:%[0-9]+]] = init_existential_addr [[TEMP_VALUE]] : $*Initializable, $@opened([[N]]) Initializable
-// CHECK:   [[INIT_WITNESS:%[0-9]+]] = witness_method $@opened([[N]]) Initializable, #Initializable.init!allocator.1, [[ARCHETYPE_META]]{{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : Initializable> (Int, @thick τ_0_0.Type) -> @out τ_0_0
+// CHECK:   [[INIT_WITNESS:%[0-9]+]] = witness_method $@opened([[N]]) Initializable, #Initializable.init!allocator.1 : {{.*}}, [[ARCHETYPE_META]]{{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : Initializable> (Int, @thick τ_0_0.Type) -> @out τ_0_0
 // CHECK:   [[INIT_RESULT:%[0-9]+]] = apply [[INIT_WITNESS]]<@opened([[N]]) Initializable>([[TEMP_ADDR]], [[I]], [[ARCHETYPE_META]]) : $@convention(witness_method) <τ_0_0 where τ_0_0 : Initializable> (Int, @thick τ_0_0.Type) -> @out τ_0_0
 // CHECK:   destroy_addr [[TEMP_VALUE]] : $*Initializable
 // CHECK:   dealloc_stack [[TEMP_VALUE]] : $*Initializable
@@ -246,7 +246,7 @@ class ClassWithGetter : PropertyWithGetter {
 // CHECK-NEXT: [[CCOPY:%.*]] = alloc_stack $ClassWithGetter
 // CHECK-NEXT: copy_addr [[C]] to [initialization] [[CCOPY]]
 // CHECK-NEXT: [[CCOPY_LOADED:%.*]] = load [take] [[CCOPY]]
-// CHECK-NEXT: [[FUN:%.*]] = class_method [[CCOPY_LOADED]] : $ClassWithGetter, #ClassWithGetter.a!getter.1 : (ClassWithGetter) -> () -> Int , $@convention(method) (@guaranteed ClassWithGetter) -> Int
+// CHECK-NEXT: [[FUN:%.*]] = class_method [[CCOPY_LOADED]] : $ClassWithGetter, #ClassWithGetter.a!getter.1 : (ClassWithGetter) -> () -> Int, $@convention(method) (@guaranteed ClassWithGetter) -> Int
 // CHECK-NEXT: apply [[FUN]]([[CCOPY_LOADED]])
 // CHECK-NEXT: destroy_value [[CCOPY_LOADED]]
 // CHECK-NEXT: dealloc_stack [[CCOPY]]
@@ -272,7 +272,7 @@ class ClassWithGetterSetter : PropertyWithGetterSetter, PropertyWithGetter {
 // CHECK-NEXT: [[CCOPY:%.*]] = alloc_stack $ClassWithGetterSetter
 // CHECK-NEXT: copy_addr [[C]] to [initialization] [[CCOPY]]
 // CHECK-NEXT: [[CCOPY_LOADED:%.*]] = load [take] [[CCOPY]]
-// CHECK-NEXT: [[FUN:%.*]] = class_method [[CCOPY_LOADED]] : $ClassWithGetterSetter, #ClassWithGetterSetter.b!getter.1 : (ClassWithGetterSetter) -> () -> Int , $@convention(method) (@guaranteed ClassWithGetterSetter) -> Int
+// CHECK-NEXT: [[FUN:%.*]] = class_method [[CCOPY_LOADED]] : $ClassWithGetterSetter, #ClassWithGetterSetter.b!getter.1 : (ClassWithGetterSetter) -> () -> Int, $@convention(method) (@guaranteed ClassWithGetterSetter) -> Int
 // CHECK-NEXT: apply [[FUN]]([[CCOPY_LOADED]])
 // CHECK-NEXT: destroy_value [[CCOPY_LOADED]]
 // CHECK-NEXT: dealloc_stack [[CCOPY]]
@@ -291,7 +291,7 @@ class ClassWithStoredProperty : PropertyWithGetter {
   // CHECK: bb0([[ARG:%.*]] : $ClassWithStoredProperty):
   // CHECK-NEXT: debug_value [[ARG]]
   // CHECK-NOT: copy_value
-  // CHECK-NEXT: [[FUN:%.*]] = class_method [[ARG]] : $ClassWithStoredProperty, #ClassWithStoredProperty.a!getter.1 : (ClassWithStoredProperty) -> () -> Int , $@convention(method) (@guaranteed ClassWithStoredProperty) -> Int
+  // CHECK-NEXT: [[FUN:%.*]] = class_method [[ARG]] : $ClassWithStoredProperty, #ClassWithStoredProperty.a!getter.1 : (ClassWithStoredProperty) -> () -> Int, $@convention(method) (@guaranteed ClassWithStoredProperty) -> Int
   // CHECK-NEXT: [[RESULT:%.*]] = apply [[FUN]]([[ARG]])
   // CHECK-NOT: destroy_value
   // CHECK-NEXT: return [[RESULT]] : $Int
@@ -413,23 +413,23 @@ func modifyProperty<T : PropertyWithGetterSetter>(_ x: inout T) {
 // CHECK:      apply [[CALLBACK]]<T>
 
 // CHECK-LABEL: sil_witness_table hidden ClassWithGetter: PropertyWithGetter module protocols {
-// CHECK-NEXT:  method #PropertyWithGetter.a!getter.1: @_T09protocols15ClassWithGetterCAA08PropertycD0AaaDP1aSifgTW
+// CHECK-NEXT:  method #PropertyWithGetter.a!getter.1: {{.*}} : @_T09protocols15ClassWithGetterCAA08PropertycD0AaaDP1aSifgTW
 // CHECK-NEXT: }
 
 // CHECK-LABEL: sil_witness_table hidden ClassWithGetterSetter: PropertyWithGetterSetter module protocols {
-// CHECK-NEXT:  method #PropertyWithGetterSetter.b!getter.1: @_T09protocols21ClassWithGetterSetterCAA08PropertycdE0AaaDP1bSifgTW
-// CHECK-NEXT:  method #PropertyWithGetterSetter.b!setter.1: @_T09protocols21ClassWithGetterSetterCAA08PropertycdE0AaaDP1bSifsTW
-// CHECK-NEXT:  method #PropertyWithGetterSetter.b!materializeForSet.1: @_T09protocols21ClassWithGetterSetterCAA08PropertycdE0AaaDP1bSifmTW
+// CHECK-NEXT:  method #PropertyWithGetterSetter.b!getter.1: {{.*}} : @_T09protocols21ClassWithGetterSetterCAA08PropertycdE0AaaDP1bSifgTW
+// CHECK-NEXT:  method #PropertyWithGetterSetter.b!setter.1: {{.*}} : @_T09protocols21ClassWithGetterSetterCAA08PropertycdE0AaaDP1bSifsTW
+// CHECK-NEXT:  method #PropertyWithGetterSetter.b!materializeForSet.1: {{.*}} : @_T09protocols21ClassWithGetterSetterCAA08PropertycdE0AaaDP1bSifmTW
 // CHECK-NEXT: }
 
 // CHECK-LABEL: sil_witness_table hidden ClassWithGetterSetter: PropertyWithGetter module protocols {
-// CHECK-NEXT:  method #PropertyWithGetter.a!getter.1: @_T09protocols21ClassWithGetterSetterCAA08PropertycD0AaaDP1aSifgTW
+// CHECK-NEXT:  method #PropertyWithGetter.a!getter.1: {{.*}} : @_T09protocols21ClassWithGetterSetterCAA08PropertycD0AaaDP1aSifgTW
 // CHECK-NEXT: }
 
 // CHECK-LABEL: sil_witness_table hidden StructWithStoredProperty: PropertyWithGetter module protocols {
-// CHECK-NEXT:  method #PropertyWithGetter.a!getter.1: @_T09protocols24StructWithStoredPropertyVAA0eC6GetterAaaDP1aSifgTW
+// CHECK-NEXT:  method #PropertyWithGetter.a!getter.1: {{.*}} : @_T09protocols24StructWithStoredPropertyVAA0eC6GetterAaaDP1aSifgTW
 // CHECK-NEXT: }
 
 // CHECK-LABEL: sil_witness_table hidden StructWithStoredClassProperty: PropertyWithGetter module protocols {
-// CHECK-NEXT:  method #PropertyWithGetter.a!getter.1: @_T09protocols29StructWithStoredClassPropertyVAA0fC6GetterAaaDP1aSifgTW
+// CHECK-NEXT:  method #PropertyWithGetter.a!getter.1: {{.*}} : @_T09protocols29StructWithStoredClassPropertyVAA0fC6GetterAaaDP1aSifgTW
 // CHECK-NEXT: }

--- a/test/SILGen/required_init.swift
+++ b/test/SILGen/required_init.swift
@@ -18,9 +18,9 @@ class Bar: Foo {
 }
 
 // CHECK-LABEL: sil_vtable Foo {
-// CHECK:         #Foo.init!allocator.1: _T013required_init3FooC{{[_0-9a-zA-Z]*}}fC
-// CHECK:         #Foo.init!initializer.1: _T013required_init3FooC{{[_0-9a-zA-Z]*}}fc
+// CHECK:         #Foo.init!allocator.1: {{.*}} : _T013required_init3FooC{{[_0-9a-zA-Z]*}}fC
+// CHECK:         #Foo.init!initializer.1: {{.*}} : _T013required_init3FooC{{[_0-9a-zA-Z]*}}fc
 
 // CHECK-LABEL: sil_vtable Bar {
-// CHECK:         #Foo.init!allocator.1: _T013required_init3BarC{{[_0-9a-zA-Z]*}}fC
-// CHECK:         #Foo.init!initializer.1: _T013required_init3BarC{{[_0-9a-zA-Z]*}}fc
+// CHECK:         #Foo.init!allocator.1: {{.*}} : _T013required_init3BarC{{[_0-9a-zA-Z]*}}fC
+// CHECK:         #Foo.init!initializer.1: {{.*}} : _T013required_init3BarC{{[_0-9a-zA-Z]*}}fc

--- a/test/SILGen/testable-multifile.swift
+++ b/test/SILGen/testable-multifile.swift
@@ -39,29 +39,29 @@ public class PublicSub: Base {
 }
 
 // CHECK-LABEL: sil_vtable PrivateSub {
-// CHECK-NEXT:   #Base.foo!1: _T04main10PrivateSub33_F1525133BD493492AD72BF10FBCB1C52LLC3fooyyF
-// CHECK-NEXT:   #Base.init!initializer.1: _T04main10PrivateSub33_F1525133BD493492AD72BF10FBCB1C52LLCADycfc
-// CHECK-NEXT:   #PrivateSub.deinit!deallocator: _T04main10PrivateSub33_F1525133BD493492AD72BF10FBCB1C52LLCfD
+// CHECK-NEXT:   #Base.foo!1: {{.*}} : _T04main10PrivateSub33_F1525133BD493492AD72BF10FBCB1C52LLC3fooyyF
+// CHECK-NEXT:   #Base.init!initializer.1: {{.*}} : _T04main10PrivateSub33_F1525133BD493492AD72BF10FBCB1C52LLCADycfc
+// CHECK-NEXT:   #PrivateSub.deinit!deallocator: {{.*}} : _T04main10PrivateSub33_F1525133BD493492AD72BF10FBCB1C52LLCfD
 // CHECK-NEXT: }
 
 // CHECK-LABEL: sil_vtable Sub {
-// CHECK-NEXT:   #Base.foo!1: _T04main3SubC3fooyyF
-// CHECK-NEXT:   #Base.init!initializer.1: _T04main3SubCACycfc
-// CHECK-NEXT:   #Sub.deinit!deallocator: _T04main3SubCfD
+// CHECK-NEXT:   #Base.foo!1: {{.*}} : _T04main3SubC3fooyyF
+// CHECK-NEXT:   #Base.init!initializer.1: {{.*}} : _T04main3SubCACycfc
+// CHECK-NEXT:   #Sub.deinit!deallocator: {{.*}} : _T04main3SubCfD
 // CHECK-NEXT: }
 
 // CHECK-LABEL: sil_vtable PublicSub {
-// CHECK-NEXT:   #Base.foo!1: _T04main9PublicSubC3fooyyF
-// CHECK-NEXT:   #Base.init!initializer.1: _T04main9PublicSubCACycfc
-// CHECK-NEXT:   #PublicSub.deinit!deallocator: _T04main9PublicSubCfD
+// CHECK-NEXT:   #Base.foo!1: {{.*}} : _T04main9PublicSubC3fooyyF
+// CHECK-NEXT:   #Base.init!initializer.1: {{.*}} : _T04main9PublicSubCACycfc
+// CHECK-NEXT:   #PublicSub.deinit!deallocator: {{.*}} : _T04main9PublicSubCfD
 // CHECK-NEXT: }
 
 
 
 // CHECK-LABEL: sil_witness_table hidden FooImpl: Fooable module main {
-// CHECK-NEXT:  method #Fooable.foo!1: @_T04main7FooImplVAA7FooableAaaDP3fooyyFTW
+// CHECK-NEXT:  method #Fooable.foo!1: {{.*}} : @_T04main7FooImplVAA7FooableAaaDP3fooyyFTW
 // CHECK-NEXT: }
 
 // CHECK-LABEL: sil_witness_table [fragile] PublicFooImpl: Fooable module main {
-// CHECK-NEXT:  method #Fooable.foo!1: @_T04main13PublicFooImplVAA7FooableAaaDP3fooyyFTW
+// CHECK-NEXT:  method #Fooable.foo!1: {{.*}} : @_T04main13PublicFooImplVAA7FooableAaaDP3fooyyFTW
 // CHECK-NEXT: }

--- a/test/SILGen/unowned.swift
+++ b/test/SILGen/unowned.swift
@@ -112,7 +112,7 @@ func test_unowned_let_capture(_ aC : C) {
 // CHECK-NEXT:   debug_value %0 : $@sil_unowned C, let, name "bC", argno 1
 // CHECK-NEXT:   strong_retain_unowned [[ARG]] : $@sil_unowned C
 // CHECK-NEXT:   [[UNOWNED_ARG:%.*]] = unowned_to_ref [[ARG]] : $@sil_unowned C to $C
-// CHECK-NEXT:   [[FUN:%.*]] = class_method [[UNOWNED_ARG]] : $C, #C.f!1 : (C) -> () -> Int , $@convention(method) (@guaranteed C) -> Int
+// CHECK-NEXT:   [[FUN:%.*]] = class_method [[UNOWNED_ARG]] : $C, #C.f!1 : (C) -> () -> Int, $@convention(method) (@guaranteed C) -> Int
 // CHECK-NEXT:   [[RESULT:%.*]] = apply [[FUN]]([[UNOWNED_ARG]]) : $@convention(method) (@guaranteed C) -> Int
 // CHECK-NEXT:   destroy_value [[UNOWNED_ARG]]
 // CHECK-NEXT:   destroy_value [[ARG]] : $@sil_unowned C

--- a/test/SILGen/vtable_thunks.swift
+++ b/test/SILGen/vtable_thunks.swift
@@ -193,62 +193,62 @@ class Noot : Aap {
 // CHECK:         [[OUTER:%.*]] = convert_function [[INNER]] : $@callee_owned () -> @owned Noot to $@callee_owned () -> @owned Optional<Aap>
 // CHECK:         return [[OUTER]]
 // CHECK-LABEL: sil_vtable D {
-// CHECK:         #B.iuo!1: hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.f!1: _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
-// CHECK:         #B.f2!1: _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
-// CHECK:         #B.f3!1: _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
-// CHECK:         #B.f4!1: _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
-// CHECK:         #B.g!1: hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.g2!1: hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.g3!1: hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.g4!1: _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
-// CHECK:         #B.h!1: hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.h2!1: hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.h3!1: hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.h4!1: _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
-// CHECK:         #B.i!1: hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.i2!1: hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.i3!1: hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.i4!1: _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
+// CHECK:         #B.iuo!1: {{.*}} : hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.f!1: {{.*}} : _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
+// CHECK:         #B.f2!1: {{.*}} : _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
+// CHECK:         #B.f3!1: {{.*}} : _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
+// CHECK:         #B.f4!1: {{.*}} : _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
+// CHECK:         #B.g!1: {{.*}} : hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.g2!1: {{.*}} : hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.g3!1: {{.*}} : hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.g4!1: {{.*}} : _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
+// CHECK:         #B.h!1: {{.*}} : hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.h2!1: {{.*}} : hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.h3!1: {{.*}} : hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.h4!1: {{.*}} : _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
+// CHECK:         #B.i!1: {{.*}} : hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.i2!1: {{.*}} : hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.i3!1: {{.*}} : hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.i4!1: {{.*}} : _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
 
 // CHECK-LABEL: sil_vtable E {
-// CHECK:         #B.iuo!1: hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.f!1: _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
-// CHECK:         #B.f2!1: _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
-// CHECK:         #B.f3!1: _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
-// CHECK:         #B.f4!1: _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
-// CHECK:         #B.g!1: hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.g2!1: hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.g3!1: hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.g4!1: _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
-// CHECK:         #B.h!1: hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.h2!1: hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.h3!1: hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.h4!1: _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
-// CHECK:         #B.i!1: hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.i2!1: hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.i3!1: hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.i4!1: _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
+// CHECK:         #B.iuo!1: {{.*}} : hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.f!1: {{.*}} : _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
+// CHECK:         #B.f2!1: {{.*}} : _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
+// CHECK:         #B.f3!1: {{.*}} : _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
+// CHECK:         #B.f4!1: {{.*}} : _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
+// CHECK:         #B.g!1: {{.*}} : hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.g2!1: {{.*}} : hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.g3!1: {{.*}} : hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.g4!1: {{.*}} : _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
+// CHECK:         #B.h!1: {{.*}} : hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.h2!1: {{.*}} : hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.h3!1: {{.*}} : hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.h4!1: {{.*}} : _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
+// CHECK:         #B.i!1: {{.*}} : hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.i2!1: {{.*}} : hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.i3!1: {{.*}} : hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.i4!1: {{.*}} : _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}F
 
 // CHECK-LABEL: sil_vtable F {
-// CHECK:         #B.iuo!1: hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.f!1: _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}F
-// CHECK:         #B.f2!1: _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}F
-// CHECK:         #B.f3!1: _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}F
-// CHECK:         #B.f4!1: _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}F
-// CHECK:         #B.g!1: hidden _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.g2!1: hidden _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.g3!1: hidden _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.g4!1: _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}F
-// CHECK:         #B.h!1: hidden _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.h2!1: hidden _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.h3!1: hidden _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.h4!1: _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}F
-// CHECK:         #B.i!1: hidden _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.i2!1: hidden _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.i3!1: hidden _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}FTV
-// CHECK:         #B.i4!1: _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}F
+// CHECK:         #B.iuo!1: {{.*}} : hidden _T013vtable_thunks1D{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.f!1: {{.*}} : _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}F
+// CHECK:         #B.f2!1: {{.*}} : _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}F
+// CHECK:         #B.f3!1: {{.*}} : _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}F
+// CHECK:         #B.f4!1: {{.*}} : _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}F
+// CHECK:         #B.g!1: {{.*}} : hidden _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.g2!1: {{.*}} : hidden _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.g3!1: {{.*}} : hidden _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.g4!1: {{.*}} : _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}F
+// CHECK:         #B.h!1: {{.*}} : hidden _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.h2!1: {{.*}} : hidden _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.h3!1: {{.*}} : hidden _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.h4!1: {{.*}} : _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}F
+// CHECK:         #B.i!1: {{.*}} : hidden _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.i2!1: {{.*}} : hidden _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.i3!1: {{.*}} : hidden _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}FTV
+// CHECK:         #B.i4!1: {{.*}} : _T013vtable_thunks1F{{[A-Z0-9a-z_]*}}F
 
 // CHECK-LABEL: sil_vtable NoThrowVariance {
-// CHECK:         #ThrowVariance.mightThrow!1: _T013vtable_thunks{{[A-Z0-9a-z_]*}}F
+// CHECK:         #ThrowVariance.mightThrow!1: {{.*}} : _T013vtable_thunks{{[A-Z0-9a-z_]*}}F
 

--- a/test/SILGen/vtables.swift
+++ b/test/SILGen/vtables.swift
@@ -23,16 +23,16 @@ class C : B {
   func mopsy() {}
 }
 // CHECK: sil_vtable C {
-// CHECK:   #A.foo!1: _T07vtables1BC3foo{{[_0-9a-zA-Z]*}}F
-// CHECK:   #A.bar!1: _T07vtables1CC3bar{{[_0-9a-zA-Z]*}}F
-// CHECK:   #A.bas!1: _T07vtables1AC3bas{{[_0-9a-zA-Z]*}}F
-// CHECK:   #A.qux!1: _T07vtables1CC3qux{{[_0-9a-zA-Z]*}}F
-// CHECK:   #B.init!allocator.1: _T07vtables1CC{{[_0-9a-zA-Z]*}}fC
-// CHECK:   #B.init!initializer.1: _T07vtables1CC{{[_0-9a-zA-Z]*}}fc
-// CHECK:   #B.zim!1: _T07vtables1BC3zim{{[_0-9a-zA-Z]*}}F
-// CHECK:   #B.zang!1: _T07vtables1CC4zang{{[_0-9a-zA-Z]*}}F
-// CHECK:   #C.flopsy!1: _T07vtables1CC6flopsy{{[_0-9a-zA-Z]*}}F
-// CHECK:   #C.mopsy!1: _T07vtables1CC5mopsy{{[_0-9a-zA-Z]*}}F
+// CHECK:   #A.foo!1: {{.*}} : _T07vtables1BC3foo{{[_0-9a-zA-Z]*}}F
+// CHECK:   #A.bar!1: {{.*}} : _T07vtables1CC3bar{{[_0-9a-zA-Z]*}}F
+// CHECK:   #A.bas!1: {{.*}} : _T07vtables1AC3bas{{[_0-9a-zA-Z]*}}F
+// CHECK:   #A.qux!1: {{.*}} : _T07vtables1CC3qux{{[_0-9a-zA-Z]*}}F
+// CHECK:   #B.init!allocator.1: {{.*}} : _T07vtables1CC{{[_0-9a-zA-Z]*}}fC
+// CHECK:   #B.init!initializer.1: {{.*}} : _T07vtables1CC{{[_0-9a-zA-Z]*}}fc
+// CHECK:   #B.zim!1: {{.*}} : _T07vtables1BC3zim{{[_0-9a-zA-Z]*}}F
+// CHECK:   #B.zang!1: {{.*}} : _T07vtables1CC4zang{{[_0-9a-zA-Z]*}}F
+// CHECK:   #C.flopsy!1: {{.*}} : _T07vtables1CC6flopsy{{[_0-9a-zA-Z]*}}F
+// CHECK:   #C.mopsy!1: {{.*}} : _T07vtables1CC5mopsy{{[_0-9a-zA-Z]*}}F
 // CHECK: }
 
 class A {
@@ -43,11 +43,11 @@ class A {
 }
 
 // CHECK: sil_vtable A {
-// CHECK:   #A.foo!1: _T07vtables1AC3foo{{[_0-9a-zA-Z]*}}F
-// CHECK:   #A.bar!1: _T07vtables1AC3bar{{[_0-9a-zA-Z]*}}F
-// CHECK:   #A.bas!1: _T07vtables1AC3bas{{[_0-9a-zA-Z]*}}F
-// CHECK:   #A.qux!1: _T07vtables1AC3qux{{[_0-9a-zA-Z]*}}F
-// CHECK:   #A.init!initializer.1: _T07vtables1AC{{[_0-9a-zA-Z]*}}fc
+// CHECK:   #A.foo!1: {{.*}} : _T07vtables1AC3foo{{[_0-9a-zA-Z]*}}F
+// CHECK:   #A.bar!1: {{.*}} : _T07vtables1AC3bar{{[_0-9a-zA-Z]*}}F
+// CHECK:   #A.bas!1: {{.*}} : _T07vtables1AC3bas{{[_0-9a-zA-Z]*}}F
+// CHECK:   #A.qux!1: {{.*}} : _T07vtables1AC3qux{{[_0-9a-zA-Z]*}}F
+// CHECK:   #A.init!initializer.1: {{.*}} : _T07vtables1AC{{[_0-9a-zA-Z]*}}fc
 // CHECK: }
 
 class B : A {
@@ -63,14 +63,14 @@ class B : A {
 }
 
 // CHECK: sil_vtable B {
-// CHECK:   #A.foo!1: _T07vtables1BC3foo{{[_0-9a-zA-Z]*}}F
-// CHECK:   #A.bar!1: _T07vtables1AC3bar{{[_0-9a-zA-Z]*}}F
-// CHECK:   #A.bas!1: _T07vtables1AC3bas{{[_0-9a-zA-Z]*}}F
-// CHECK:   #A.qux!1: _T07vtables1BC3qux{{[_0-9a-zA-Z]*}}F
-// CHECK:   #B.init!allocator.1: _T07vtables1BC{{[_0-9a-zA-Z]*}}fC
-// CHECK:   #B.init!initializer.1: _T07vtables1BC{{[_0-9a-zA-Z]*}}fc
-// CHECK:   #B.zim!1: _T07vtables1BC3zim{{[_0-9a-zA-Z]*}}F
-// CHECK:   #B.zang!1: _T07vtables1BC4zang{{[_0-9a-zA-Z]*}}F
+// CHECK:   #A.foo!1: {{.*}} : _T07vtables1BC3foo{{[_0-9a-zA-Z]*}}F
+// CHECK:   #A.bar!1: {{.*}} : _T07vtables1AC3bar{{[_0-9a-zA-Z]*}}F
+// CHECK:   #A.bas!1: {{.*}} : _T07vtables1AC3bas{{[_0-9a-zA-Z]*}}F
+// CHECK:   #A.qux!1: {{.*}} : _T07vtables1BC3qux{{[_0-9a-zA-Z]*}}F
+// CHECK:   #B.init!allocator.1: {{.*}} : _T07vtables1BC{{[_0-9a-zA-Z]*}}fC
+// CHECK:   #B.init!initializer.1: {{.*}} : _T07vtables1BC{{[_0-9a-zA-Z]*}}fc
+// CHECK:   #B.zim!1: {{.*}} : _T07vtables1BC3zim{{[_0-9a-zA-Z]*}}F
+// CHECK:   #B.zang!1: {{.*}} : _T07vtables1BC4zang{{[_0-9a-zA-Z]*}}F
 // CHECK: }
 
 // Test ObjC base class
@@ -88,10 +88,10 @@ class Hoozit : Gizmo {
 // Entries only exist for native Swift methods
 
 // CHECK: sil_vtable Hoozit {
-// CHECK:   #Hoozit.frob!1: _T07vtables6HoozitC4frob{{[_0-9a-zA-Z]*}}F
-// CHECK:   #Hoozit.funge!1: _T07vtables6HoozitC5funge{{[_0-9a-zA-Z]*}}F
-// CHECK:   #Hoozit.anse!1: _T07vtables6HoozitC4anse{{[_0-9a-zA-Z]*}}F
-// CHECK:   #Hoozit.incorrige!1: _T07vtables6HoozitC9incorrige{{[_0-9a-zA-Z]*}}F
+// CHECK:   #Hoozit.frob!1: {{.*}} : _T07vtables6HoozitC4frob{{[_0-9a-zA-Z]*}}F
+// CHECK:   #Hoozit.funge!1: {{.*}} : _T07vtables6HoozitC5funge{{[_0-9a-zA-Z]*}}F
+// CHECK:   #Hoozit.anse!1: {{.*}} : _T07vtables6HoozitC4anse{{[_0-9a-zA-Z]*}}F
+// CHECK:   #Hoozit.incorrige!1: {{.*}} : _T07vtables6HoozitC9incorrige{{[_0-9a-zA-Z]*}}F
 // CHECK: }
 
 class Wotsit : Hoozit {
@@ -100,18 +100,18 @@ class Wotsit : Hoozit {
 }
 
 // CHECK: sil_vtable Wotsit {
-// CHECK:   #Hoozit.frob!1: _T07vtables6HoozitC4frob{{[_0-9a-zA-Z]*}}F
-// CHECK:   #Hoozit.funge!1: _T07vtables6WotsitC5funge{{[_0-9a-zA-Z]*}}F
-// CHECK:   #Hoozit.anse!1: _T07vtables6HoozitC4anse{{[_0-9a-zA-Z]*}}F
-// CHECK:   #Hoozit.incorrige!1: _T07vtables6WotsitC9incorrige{{[_0-9a-zA-Z]*}}F
+// CHECK:   #Hoozit.frob!1: {{.*}} : _T07vtables6HoozitC4frob{{[_0-9a-zA-Z]*}}F
+// CHECK:   #Hoozit.funge!1: {{.*}} : _T07vtables6WotsitC5funge{{[_0-9a-zA-Z]*}}F
+// CHECK:   #Hoozit.anse!1: {{.*}} : _T07vtables6HoozitC4anse{{[_0-9a-zA-Z]*}}F
+// CHECK:   #Hoozit.incorrige!1: {{.*}} : _T07vtables6WotsitC9incorrige{{[_0-9a-zA-Z]*}}F
 // CHECK: }
 
 // <rdar://problem/15282548>
 // CHECK: sil_vtable Base {
-// CHECK:   #Base.init!initializer.1: _T07vtables4BaseC{{[_0-9a-zA-Z]*}}fc
+// CHECK:   #Base.init!initializer.1: {{.*}} : _T07vtables4BaseC{{[_0-9a-zA-Z]*}}fc
 // CHECK: }
 // CHECK: sil_vtable Derived {
-// CHECK:   #Base.init!initializer.1: _T07vtables7DerivedC{{[_0-9a-zA-Z]*}}fc
+// CHECK:   #Base.init!initializer.1: {{.*}} : _T07vtables7DerivedC{{[_0-9a-zA-Z]*}}fc
 // CHECK: }
 @objc class Base {}
 
@@ -130,8 +130,8 @@ class Derived : Base {
 
 
 // CHECK: sil_vtable RequiredInitDerived {
-// CHECK-NEXT: #SimpleInitBase.init!initializer.1: _T07vtables19RequiredInitDerivedC{{[_0-9a-zA-Z]*}}fc
-// CHECK-NEXT  #RequiredInitDerived.init!allocator.1: _TFC7vtables19RequiredInitDerivedC
+// CHECK-NEXT: #SimpleInitBase.init!initializer.1: {{.*}} : _T07vtables19RequiredInitDerivedC{{[_0-9a-zA-Z]*}}fc
+// CHECK-NEXT  #RequiredInitDerived.init!allocator.1: {{.*}} : _TFC7vtables19RequiredInitDerivedC
 // CHECK-NEXT}
 
 class SimpleInitBase { }
@@ -168,4 +168,4 @@ class DerivedWithoutDefaults : BaseWithDefaults {
 // CHECK:         #Observed.x!setter
 
 // CHECK-LABEL: sil_vtable DerivedWithoutDefaults {
-// CHECK:         #BaseWithDefaults.a!1: _T07vtables22DerivedWithoutDefaultsC1a{{[_0-9a-zA-Z]*}}F
+// CHECK:         #BaseWithDefaults.a!1: {{.*}} : _T07vtables22DerivedWithoutDefaultsC1a{{[_0-9a-zA-Z]*}}F

--- a/test/SILGen/witness_tables.swift
+++ b/test/SILGen/witness_tables.swift
@@ -62,7 +62,7 @@ struct ConformingAssoc : AssocReqt {
 }
 // TABLE-LABEL: sil_witness_table hidden ConformingAssoc: AssocReqt module witness_tables {
 // TABLE-TESTABLE-LABEL: sil_witness_table [fragile] ConformingAssoc: AssocReqt module witness_tables {
-// TABLE-ALL-NEXT:    method #AssocReqt.requiredMethod!1: @_T014witness_tables15ConformingAssocVAA0D4ReqtAaaDP14requiredMethod{{[_0-9a-zA-Z]*}}FTW
+// TABLE-ALL-NEXT:    method #AssocReqt.requiredMethod!1: {{.*}} : @_T014witness_tables15ConformingAssocVAA0D4ReqtAaaDP14requiredMethod{{[_0-9a-zA-Z]*}}FTW
 // TABLE-ALL-NEXT:  }
 // SYMBOL:      sil hidden [transparent] [thunk] @_T014witness_tables15ConformingAssocVAA0D4ReqtAaaDP14requiredMethod{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method) (@in_guaranteed ConformingAssoc) -> ()
 // SYMBOL-TESTABLE:      sil [transparent] [thunk] @_T014witness_tables15ConformingAssocVAA0D4ReqtAaaDP14requiredMethod{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method) (@in_guaranteed ConformingAssoc) -> ()
@@ -83,11 +83,11 @@ func <~>(x: ConformingStruct, y: ConformingStruct) {}
 // TABLE-NEXT:    associated_type AssocType: SomeAssoc
 // TABLE-NEXT:    associated_type AssocWithReqt: ConformingAssoc
 // TABLE-NEXT:    associated_type_protocol (AssocWithReqt: AssocReqt): ConformingAssoc: AssocReqt module witness_tables
-// TABLE-NEXT:    method #AnyProtocol.method!1: @_T014witness_tables16ConformingStructVAA11AnyProtocolAaaDP6method{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.generic!1: @_T014witness_tables16ConformingStructVAA11AnyProtocolAaaDP7generic{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.assocTypesMethod!1: @_T014witness_tables16ConformingStructVAA11AnyProtocolAaaDP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.staticMethod!1: @_T014witness_tables16ConformingStructVAA11AnyProtocolAaaDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW
-// TABLE-NEXT:    method #AnyProtocol."<~>"!1: @_T014witness_tables16ConformingStructVAA11AnyProtocolAaaDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW
+// TABLE-NEXT:    method #AnyProtocol.method!1: {{.*}} : @_T014witness_tables16ConformingStructVAA11AnyProtocolAaaDP6method{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.generic!1: {{.*}} : @_T014witness_tables16ConformingStructVAA11AnyProtocolAaaDP7generic{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.assocTypesMethod!1: {{.*}} : @_T014witness_tables16ConformingStructVAA11AnyProtocolAaaDP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.staticMethod!1: {{.*}} : @_T014witness_tables16ConformingStructVAA11AnyProtocolAaaDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW
+// TABLE-NEXT:    method #AnyProtocol."<~>"!1: {{.*}} : @_T014witness_tables16ConformingStructVAA11AnyProtocolAaaDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW
 // TABLE-NEXT:  }
 // SYMBOL:      sil hidden [transparent] [thunk] @_T014witness_tables16ConformingStructVAA11AnyProtocolAaaDP6method{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method) (Arg, @in ConformingStruct, @in_guaranteed ConformingStruct) -> ()
 // SYMBOL:      sil hidden [transparent] [thunk] @_T014witness_tables16ConformingStructVAA11AnyProtocolAaaDP7generic{{[_0-9a-zA-Z]*}}FTW {{.*}}: ArchetypeReqt> (@in τ_0_0, @in ConformingStruct, @in_guaranteed ConformingStruct) -> ()
@@ -120,11 +120,11 @@ func <~>(x: ConformingAddressOnlyStruct, y: ConformingAddressOnlyStruct) {}
 // TABLE-NEXT:    associated_type AssocType: SomeAssoc
 // TABLE-NEXT:    associated_type AssocWithReqt: ConformingAssoc
 // TABLE-NEXT:    associated_type_protocol (AssocWithReqt: AssocReqt): ConformingAssoc: AssocReqt module witness_tables
-// TABLE-NEXT:    method #AnyProtocol.method!1: @_T014witness_tables27ConformingAddressOnlyStructVAA11AnyProtocolAaaDP6method{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.generic!1: @_T014witness_tables27ConformingAddressOnlyStructVAA11AnyProtocolAaaDP7generic{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.assocTypesMethod!1: @_T014witness_tables27ConformingAddressOnlyStructVAA11AnyProtocolAaaDP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.staticMethod!1: @_T014witness_tables27ConformingAddressOnlyStructVAA11AnyProtocolAaaDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW
-// TABLE-NEXT:    method #AnyProtocol."<~>"!1: @_T014witness_tables27ConformingAddressOnlyStructVAA11AnyProtocolAaaDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW
+// TABLE-NEXT:    method #AnyProtocol.method!1: {{.*}} : @_T014witness_tables27ConformingAddressOnlyStructVAA11AnyProtocolAaaDP6method{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.generic!1: {{.*}} : @_T014witness_tables27ConformingAddressOnlyStructVAA11AnyProtocolAaaDP7generic{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.assocTypesMethod!1: {{.*}} : @_T014witness_tables27ConformingAddressOnlyStructVAA11AnyProtocolAaaDP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.staticMethod!1: {{.*}} : @_T014witness_tables27ConformingAddressOnlyStructVAA11AnyProtocolAaaDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW
+// TABLE-NEXT:    method #AnyProtocol."<~>"!1: {{.*}} : @_T014witness_tables27ConformingAddressOnlyStructVAA11AnyProtocolAaaDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW
 // TABLE-NEXT:  }
 // SYMBOL:      sil hidden [transparent] [thunk] @_T014witness_tables27ConformingAddressOnlyStructVAA11AnyProtocolAaaDP6method{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method) (Arg, @in ConformingAddressOnlyStruct, @in_guaranteed ConformingAddressOnlyStruct) -> ()
 // SYMBOL:      sil hidden [transparent] [thunk] @_T014witness_tables27ConformingAddressOnlyStructVAA11AnyProtocolAaaDP7generic{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method) <τ_0_0 where τ_0_0 : ArchetypeReqt> (@in τ_0_0, @in ConformingAddressOnlyStruct, @in_guaranteed ConformingAddressOnlyStruct) -> ()
@@ -148,11 +148,11 @@ func <~>(x: ConformingClass, y: ConformingClass) {}
 // TABLE-NEXT:    associated_type AssocType: SomeAssoc
 // TABLE-NEXT:    associated_type AssocWithReqt: ConformingAssoc
 // TABLE-NEXT:    associated_type_protocol (AssocWithReqt: AssocReqt): ConformingAssoc: AssocReqt module witness_tables
-// TABLE-NEXT:    method #AnyProtocol.method!1: @_T014witness_tables15ConformingClassCAA11AnyProtocolAaaDP6method{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.generic!1: @_T014witness_tables15ConformingClassCAA11AnyProtocolAaaDP7generic{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.assocTypesMethod!1: @_T014witness_tables15ConformingClassCAA11AnyProtocolAaaDP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.staticMethod!1: @_T014witness_tables15ConformingClassCAA11AnyProtocolAaaDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW
-// TABLE-NEXT:    method #AnyProtocol."<~>"!1: @_T014witness_tables15ConformingClassCAA11AnyProtocolAaaDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW
+// TABLE-NEXT:    method #AnyProtocol.method!1: {{.*}} : @_T014witness_tables15ConformingClassCAA11AnyProtocolAaaDP6method{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.generic!1: {{.*}} : @_T014witness_tables15ConformingClassCAA11AnyProtocolAaaDP7generic{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.assocTypesMethod!1: {{.*}} : @_T014witness_tables15ConformingClassCAA11AnyProtocolAaaDP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.staticMethod!1: {{.*}} : @_T014witness_tables15ConformingClassCAA11AnyProtocolAaaDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW
+// TABLE-NEXT:    method #AnyProtocol."<~>"!1: {{.*}} : @_T014witness_tables15ConformingClassCAA11AnyProtocolAaaDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW
 // TABLE-NEXT:  }
 // SYMBOL:      sil hidden [transparent] [thunk] @_T014witness_tables15ConformingClassCAA11AnyProtocolAaaDP6method{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method) (Arg, @in ConformingClass, @in_guaranteed ConformingClass) -> ()
 // SYMBOL:      sil hidden [transparent] [thunk] @_T014witness_tables15ConformingClassCAA11AnyProtocolAaaDP7generic{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method) <τ_0_0 where τ_0_0 : ArchetypeReqt> (@in τ_0_0, @in ConformingClass, @in_guaranteed ConformingClass) -> ()
@@ -177,11 +177,11 @@ func <~>(x: ConformsByExtension, y: ConformsByExtension) {}
 // TABLE-NEXT:    associated_type AssocType: SomeAssoc
 // TABLE-NEXT:    associated_type AssocWithReqt: ConformingAssoc
 // TABLE-NEXT:    associated_type_protocol (AssocWithReqt: AssocReqt): ConformingAssoc: AssocReqt module witness_tables
-// TABLE-NEXT:    method #AnyProtocol.method!1: @_T014witness_tables19ConformsByExtensionVAA11AnyProtocolAaaDP6method{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.generic!1: @_T014witness_tables19ConformsByExtensionVAA11AnyProtocolAaaDP7generic{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.assocTypesMethod!1: @_T014witness_tables19ConformsByExtensionVAA11AnyProtocolAaaDP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.staticMethod!1: @_T014witness_tables19ConformsByExtensionVAA11AnyProtocolAaaDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW
-// TABLE-NEXT:    method #AnyProtocol."<~>"!1: @_T014witness_tables19ConformsByExtensionVAA11AnyProtocolAaaDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW
+// TABLE-NEXT:    method #AnyProtocol.method!1: {{.*}} : @_T014witness_tables19ConformsByExtensionVAA11AnyProtocolAaaDP6method{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.generic!1: {{.*}} : @_T014witness_tables19ConformsByExtensionVAA11AnyProtocolAaaDP7generic{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.assocTypesMethod!1: {{.*}} : @_T014witness_tables19ConformsByExtensionVAA11AnyProtocolAaaDP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.staticMethod!1: {{.*}} : @_T014witness_tables19ConformsByExtensionVAA11AnyProtocolAaaDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW
+// TABLE-NEXT:    method #AnyProtocol."<~>"!1: {{.*}} : @_T014witness_tables19ConformsByExtensionVAA11AnyProtocolAaaDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW
 // TABLE-NEXT:  }
 // SYMBOL:      sil hidden [transparent] [thunk] @_T014witness_tables19ConformsByExtensionVAA11AnyProtocolAaaDP6method{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method) (Arg, @in ConformsByExtension, @in_guaranteed ConformsByExtension) -> ()
 // SYMBOL:      sil hidden [transparent] [thunk] @_T014witness_tables19ConformsByExtensionVAA11AnyProtocolAaaDP7generic{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method) <τ_0_0 where τ_0_0 : ArchetypeReqt> (@in τ_0_0, @in ConformsByExtension, @in_guaranteed ConformsByExtension) -> ()
@@ -205,11 +205,11 @@ func <~>(x: OtherModuleStruct, y: OtherModuleStruct) {}
 // TABLE-NEXT:    associated_type AssocType: SomeAssoc
 // TABLE-NEXT:    associated_type AssocWithReqt: ConformingAssoc
 // TABLE-NEXT:    associated_type_protocol (AssocWithReqt: AssocReqt): ConformingAssoc: AssocReqt module witness_tables
-// TABLE-NEXT:    method #AnyProtocol.method!1: @_T016witness_tables_b17OtherModuleStructV0a1_B011AnyProtocolAddEP6method{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.generic!1: @_T016witness_tables_b17OtherModuleStructV0a1_B011AnyProtocolAddEP7generic{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.assocTypesMethod!1: @_T016witness_tables_b17OtherModuleStructV0a1_B011AnyProtocolAddEP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.staticMethod!1: @_T016witness_tables_b17OtherModuleStructV0a1_B011AnyProtocolAddEP12staticMethod{{[_0-9a-zA-Z]*}}FZTW
-// TABLE-NEXT:    method #AnyProtocol."<~>"!1: @_T016witness_tables_b17OtherModuleStructV0a1_B011AnyProtocolAddEP3ltgoi{{[_0-9a-zA-Z]*}}FZTW
+// TABLE-NEXT:    method #AnyProtocol.method!1: {{.*}} : @_T016witness_tables_b17OtherModuleStructV0a1_B011AnyProtocolAddEP6method{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.generic!1: {{.*}} : @_T016witness_tables_b17OtherModuleStructV0a1_B011AnyProtocolAddEP7generic{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.assocTypesMethod!1: {{.*}} : @_T016witness_tables_b17OtherModuleStructV0a1_B011AnyProtocolAddEP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.staticMethod!1: {{.*}} : @_T016witness_tables_b17OtherModuleStructV0a1_B011AnyProtocolAddEP12staticMethod{{[_0-9a-zA-Z]*}}FZTW
+// TABLE-NEXT:    method #AnyProtocol."<~>"!1: {{.*}} : @_T016witness_tables_b17OtherModuleStructV0a1_B011AnyProtocolAddEP3ltgoi{{[_0-9a-zA-Z]*}}FZTW
 // TABLE-NEXT:  }
 // SYMBOL:      sil hidden [transparent] [thunk] @_T016witness_tables_b17OtherModuleStructV0a1_B011AnyProtocolAddEP6method{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method) (Arg, @in OtherModuleStruct, @in_guaranteed OtherModuleStruct) -> ()
 // SYMBOL:      sil hidden [transparent] [thunk] @_T016witness_tables_b17OtherModuleStructV0a1_B011AnyProtocolAddEP7generic{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method) <τ_0_0 where τ_0_0 : ArchetypeReqt> (@in τ_0_0, @in OtherModuleStruct, @in_guaranteed OtherModuleStruct) -> ()
@@ -235,11 +235,11 @@ func <~> <P: OtherProtocol>(x: P, y: P) {}
 // TABLE-NEXT:    associated_type AssocType: SomeAssoc
 // TABLE-NEXT:    associated_type AssocWithReqt: ConformingAssoc
 // TABLE-NEXT:    associated_type_protocol (AssocWithReqt: AssocReqt): ConformingAssoc: AssocReqt module witness_tables
-// TABLE-NEXT:    method #AnyProtocol.method!1: @_T014witness_tables32ConformsWithMoreGenericWitnessesVAA11AnyProtocolAaaDP6method{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.generic!1: @_T014witness_tables32ConformsWithMoreGenericWitnessesVAA11AnyProtocolAaaDP7generic{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.assocTypesMethod!1: @_T014witness_tables32ConformsWithMoreGenericWitnessesVAA11AnyProtocolAaaDP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.staticMethod!1: @_T014witness_tables32ConformsWithMoreGenericWitnessesVAA11AnyProtocolAaaDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW
-// TABLE-NEXT:    method #AnyProtocol."<~>"!1: @_T014witness_tables32ConformsWithMoreGenericWitnessesVAA11AnyProtocolAaaDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW
+// TABLE-NEXT:    method #AnyProtocol.method!1: {{.*}} : @_T014witness_tables32ConformsWithMoreGenericWitnessesVAA11AnyProtocolAaaDP6method{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.generic!1: {{.*}} : @_T014witness_tables32ConformsWithMoreGenericWitnessesVAA11AnyProtocolAaaDP7generic{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.assocTypesMethod!1: {{.*}} : @_T014witness_tables32ConformsWithMoreGenericWitnessesVAA11AnyProtocolAaaDP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.staticMethod!1: {{.*}} : @_T014witness_tables32ConformsWithMoreGenericWitnessesVAA11AnyProtocolAaaDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW
+// TABLE-NEXT:    method #AnyProtocol."<~>"!1: {{.*}} : @_T014witness_tables32ConformsWithMoreGenericWitnessesVAA11AnyProtocolAaaDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW
 // TABLE-NEXT:  }
 // SYMBOL:      sil hidden [transparent] [thunk] @_T014witness_tables32ConformsWithMoreGenericWitnessesVAA11AnyProtocolAaaDP6method{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method) (Arg, @in ConformsWithMoreGenericWitnesses, @in_guaranteed ConformsWithMoreGenericWitnesses) -> ()
 // SYMBOL:      sil hidden [transparent] [thunk] @_T014witness_tables32ConformsWithMoreGenericWitnessesVAA11AnyProtocolAaaDP7generic{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method) <τ_0_0 where τ_0_0 : ArchetypeReqt> (@in τ_0_0, @in ConformsWithMoreGenericWitnesses, @in_guaranteed ConformsWithMoreGenericWitnesses) -> ()
@@ -264,11 +264,11 @@ func <~>(x: ConformingClassToClassProtocol,
 // TABLE-NEXT:    associated_type AssocType: SomeAssoc
 // TABLE-NEXT:    associated_type AssocWithReqt: ConformingAssoc
 // TABLE-NEXT:    associated_type_protocol (AssocWithReqt: AssocReqt): ConformingAssoc: AssocReqt module witness_tables
-// TABLE-NEXT:    method #ClassProtocol.method!1: @_T014witness_tables017ConformingClassToD8ProtocolCAA0dF0AaaDP6method{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #ClassProtocol.generic!1: @_T014witness_tables017ConformingClassToD8ProtocolCAA0dF0AaaDP7generic{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #ClassProtocol.assocTypesMethod!1: @_T014witness_tables017ConformingClassToD8ProtocolCAA0dF0AaaDP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #ClassProtocol.staticMethod!1: @_T014witness_tables017ConformingClassToD8ProtocolCAA0dF0AaaDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW
-// TABLE-NEXT:    method #ClassProtocol."<~>"!1: @_T014witness_tables017ConformingClassToD8ProtocolCAA0dF0AaaDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW
+// TABLE-NEXT:    method #ClassProtocol.method!1: {{.*}} : @_T014witness_tables017ConformingClassToD8ProtocolCAA0dF0AaaDP6method{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #ClassProtocol.generic!1: {{.*}} : @_T014witness_tables017ConformingClassToD8ProtocolCAA0dF0AaaDP7generic{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #ClassProtocol.assocTypesMethod!1: {{.*}} : @_T014witness_tables017ConformingClassToD8ProtocolCAA0dF0AaaDP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #ClassProtocol.staticMethod!1: {{.*}} : @_T014witness_tables017ConformingClassToD8ProtocolCAA0dF0AaaDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW
+// TABLE-NEXT:    method #ClassProtocol."<~>"!1: {{.*}} : @_T014witness_tables017ConformingClassToD8ProtocolCAA0dF0AaaDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW
 // TABLE-NEXT:  }
 // SYMBOL:  sil hidden [transparent] [thunk] @_T014witness_tables017ConformingClassToD8ProtocolCAA0dF0AaaDP6method{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method) (Arg, @owned ConformingClassToClassProtocol, @guaranteed ConformingClassToClassProtocol) -> ()
 // SYMBOL:  sil hidden [transparent] [thunk] @_T014witness_tables017ConformingClassToD8ProtocolCAA0dF0AaaDP7generic{{[_0-9a-zA-Z]*}}FTW : $@convention(witness_method) <τ_0_0 where τ_0_0 : ArchetypeReqt> (@in τ_0_0, @owned ConformingClassToClassProtocol, @guaranteed ConformingClassToClassProtocol) -> ()
@@ -298,11 +298,11 @@ func <~> <R: AssocReqt>(x: ConformingGeneric<R>, y: ConformingGeneric<R>) {}
 // TABLE-NEXT:    associated_type AssocType: SomeAssoc
 // TABLE-NEXT:    associated_type AssocWithReqt: R
 // TABLE-NEXT:    associated_type_protocol (AssocWithReqt: AssocReqt): dependent
-// TABLE-NEXT:    method #AnyProtocol.method!1: @_T014witness_tables17ConformingGenericVyxGAA11AnyProtocolAaA9AssocReqtRzlAaDP6method{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.generic!1: @_T014witness_tables17ConformingGenericVyxGAA11AnyProtocolAaA9AssocReqtRzlAaDP7generic{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.assocTypesMethod!1: @_T014witness_tables17ConformingGenericVyxGAA11AnyProtocolAaA9AssocReqtRzlAaDP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.staticMethod!1: @_T014witness_tables17ConformingGenericVyxGAA11AnyProtocolAaA9AssocReqtRzlAaDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW
-// TABLE-NEXT:    method #AnyProtocol."<~>"!1: @_T014witness_tables17ConformingGenericVyxGAA11AnyProtocolAaA9AssocReqtRzlAaDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW
+// TABLE-NEXT:    method #AnyProtocol.method!1: {{.*}} : @_T014witness_tables17ConformingGenericVyxGAA11AnyProtocolAaA9AssocReqtRzlAaDP6method{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.generic!1: {{.*}} : @_T014witness_tables17ConformingGenericVyxGAA11AnyProtocolAaA9AssocReqtRzlAaDP7generic{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.assocTypesMethod!1: {{.*}} : @_T014witness_tables17ConformingGenericVyxGAA11AnyProtocolAaA9AssocReqtRzlAaDP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.staticMethod!1: {{.*}} : @_T014witness_tables17ConformingGenericVyxGAA11AnyProtocolAaA9AssocReqtRzlAaDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW
+// TABLE-NEXT:    method #AnyProtocol."<~>"!1: {{.*}} : @_T014witness_tables17ConformingGenericVyxGAA11AnyProtocolAaA9AssocReqtRzlAaDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW
 // TABLE-NEXT:  }
 
 protocol AnotherProtocol {}
@@ -325,11 +325,11 @@ func <~> <AA: AnotherProtocol, BB: AnotherProtocol>(x: AA, y: BB) {}
 // TABLE-NEXT:    associated_type AssocType: SomeAssoc
 // TABLE-NEXT:    associated_type AssocWithReqt: S
 // TABLE-NEXT:    associated_type_protocol (AssocWithReqt: AssocReqt): dependent
-// TABLE-NEXT:    method #AnyProtocol.method!1: @_T014witness_tables025ConformingGenericWithMoreD9WitnessesVyxGAA11AnyProtocolAaA9AssocReqtRzlAaDP6method{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.generic!1: @_T014witness_tables025ConformingGenericWithMoreD9WitnessesVyxGAA11AnyProtocolAaA9AssocReqtRzlAaDP7generic{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.assocTypesMethod!1: @_T014witness_tables025ConformingGenericWithMoreD9WitnessesVyxGAA11AnyProtocolAaA9AssocReqtRzlAaDP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.staticMethod!1: @_T014witness_tables025ConformingGenericWithMoreD9WitnessesVyxGAA11AnyProtocolAaA9AssocReqtRzlAaDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW
-// TABLE-NEXT:    method #AnyProtocol."<~>"!1: @_T014witness_tables025ConformingGenericWithMoreD9WitnessesVyxGAA11AnyProtocolAaA9AssocReqtRzlAaDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW
+// TABLE-NEXT:    method #AnyProtocol.method!1: {{.*}} : @_T014witness_tables025ConformingGenericWithMoreD9WitnessesVyxGAA11AnyProtocolAaA9AssocReqtRzlAaDP6method{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.generic!1: {{.*}} : @_T014witness_tables025ConformingGenericWithMoreD9WitnessesVyxGAA11AnyProtocolAaA9AssocReqtRzlAaDP7generic{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.assocTypesMethod!1: {{.*}} : @_T014witness_tables025ConformingGenericWithMoreD9WitnessesVyxGAA11AnyProtocolAaA9AssocReqtRzlAaDP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.staticMethod!1: {{.*}} : @_T014witness_tables025ConformingGenericWithMoreD9WitnessesVyxGAA11AnyProtocolAaA9AssocReqtRzlAaDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW
+// TABLE-NEXT:    method #AnyProtocol."<~>"!1: {{.*}} : @_T014witness_tables025ConformingGenericWithMoreD9WitnessesVyxGAA11AnyProtocolAaA9AssocReqtRzlAaDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW
 // TABLE-NEXT:  }
 
 protocol InheritedProtocol1 : AnyProtocol {
@@ -360,17 +360,17 @@ struct InheritedConformance : InheritedProtocol1 {
 func <~>(x: InheritedConformance, y: InheritedConformance) {}
 // TABLE-LABEL: sil_witness_table hidden InheritedConformance: InheritedProtocol1 module witness_tables {
 // TABLE-NEXT:    base_protocol AnyProtocol: InheritedConformance: AnyProtocol module witness_tables
-// TABLE-NEXT:    method #InheritedProtocol1.inheritedMethod!1: @_T014witness_tables20InheritedConformanceVAA0C9Protocol1AaaDP15inheritedMethod{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #InheritedProtocol1.inheritedMethod!1: {{.*}} : @_T014witness_tables20InheritedConformanceVAA0C9Protocol1AaaDP15inheritedMethod{{[_0-9a-zA-Z]*}}FTW
 // TABLE-NEXT:  }
 // TABLE-LABEL: sil_witness_table hidden InheritedConformance: AnyProtocol module witness_tables {
 // TABLE-NEXT:    associated_type AssocType: SomeAssoc
 // TABLE-NEXT:    associated_type AssocWithReqt: ConformingAssoc
 // TABLE-NEXT:    associated_type_protocol (AssocWithReqt: AssocReqt): ConformingAssoc: AssocReqt module witness_tables
-// TABLE-NEXT:    method #AnyProtocol.method!1: @_T014witness_tables20InheritedConformanceVAA11AnyProtocolAaaDP6method{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.generic!1: @_T014witness_tables20InheritedConformanceVAA11AnyProtocolAaaDP7generic{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.assocTypesMethod!1: @_T014witness_tables20InheritedConformanceVAA11AnyProtocolAaaDP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.staticMethod!1: @_T014witness_tables20InheritedConformanceVAA11AnyProtocolAaaDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW
-// TABLE-NEXT:    method #AnyProtocol."<~>"!1: @_T014witness_tables20InheritedConformanceVAA11AnyProtocolAaaDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW
+// TABLE-NEXT:    method #AnyProtocol.method!1: {{.*}} : @_T014witness_tables20InheritedConformanceVAA11AnyProtocolAaaDP6method{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.generic!1: {{.*}} : @_T014witness_tables20InheritedConformanceVAA11AnyProtocolAaaDP7generic{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.assocTypesMethod!1: {{.*}} : @_T014witness_tables20InheritedConformanceVAA11AnyProtocolAaaDP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.staticMethod!1: {{.*}} : @_T014witness_tables20InheritedConformanceVAA11AnyProtocolAaaDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW
+// TABLE-NEXT:    method #AnyProtocol."<~>"!1: {{.*}} : @_T014witness_tables20InheritedConformanceVAA11AnyProtocolAaaDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW
 // TABLE-NEXT:  }
 
 struct RedundantInheritedConformance : InheritedProtocol1, AnyProtocol {
@@ -389,17 +389,17 @@ struct RedundantInheritedConformance : InheritedProtocol1, AnyProtocol {
 func <~>(x: RedundantInheritedConformance, y: RedundantInheritedConformance) {}
 // TABLE-LABEL: sil_witness_table hidden RedundantInheritedConformance: InheritedProtocol1 module witness_tables {
 // TABLE-NEXT:    base_protocol AnyProtocol: RedundantInheritedConformance: AnyProtocol module witness_tables
-// TABLE-NEXT:    method #InheritedProtocol1.inheritedMethod!1: @_T014witness_tables29RedundantInheritedConformanceVAA0D9Protocol1AaaDP15inheritedMethod{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #InheritedProtocol1.inheritedMethod!1: {{.*}} : @_T014witness_tables29RedundantInheritedConformanceVAA0D9Protocol1AaaDP15inheritedMethod{{[_0-9a-zA-Z]*}}FTW
 // TABLE-NEXT:  }
 // TABLE-LABEL: sil_witness_table hidden RedundantInheritedConformance: AnyProtocol module witness_tables {
 // TABLE-NEXT:    associated_type AssocType: SomeAssoc
 // TABLE-NEXT:    associated_type AssocWithReqt: ConformingAssoc
 // TABLE-NEXT:    associated_type_protocol (AssocWithReqt: AssocReqt): ConformingAssoc: AssocReqt module witness_tables
-// TABLE-NEXT:    method #AnyProtocol.method!1: @_T014witness_tables29RedundantInheritedConformanceVAA11AnyProtocolAaaDP6method{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.generic!1: @_T014witness_tables29RedundantInheritedConformanceVAA11AnyProtocolAaaDP7generic{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.assocTypesMethod!1: @_T014witness_tables29RedundantInheritedConformanceVAA11AnyProtocolAaaDP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.staticMethod!1: @_T014witness_tables29RedundantInheritedConformanceVAA11AnyProtocolAaaDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW
-// TABLE-NEXT:    method #AnyProtocol."<~>"!1: @_T014witness_tables29RedundantInheritedConformanceVAA11AnyProtocolAaaDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW
+// TABLE-NEXT:    method #AnyProtocol.method!1: {{.*}} : @_T014witness_tables29RedundantInheritedConformanceVAA11AnyProtocolAaaDP6method{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.generic!1: {{.*}} : @_T014witness_tables29RedundantInheritedConformanceVAA11AnyProtocolAaaDP7generic{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.assocTypesMethod!1: {{.*}} : @_T014witness_tables29RedundantInheritedConformanceVAA11AnyProtocolAaaDP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.staticMethod!1: {{.*}} : @_T014witness_tables29RedundantInheritedConformanceVAA11AnyProtocolAaaDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW
+// TABLE-NEXT:    method #AnyProtocol."<~>"!1: {{.*}} : @_T014witness_tables29RedundantInheritedConformanceVAA11AnyProtocolAaaDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW
 // TABLE-NEXT:  }
 
 struct DiamondInheritedConformance : InheritedProtocol1, InheritedProtocol2 {
@@ -418,21 +418,21 @@ struct DiamondInheritedConformance : InheritedProtocol1, InheritedProtocol2 {
 func <~>(x: DiamondInheritedConformance, y: DiamondInheritedConformance) {}
 // TABLE-LABEL: sil_witness_table hidden DiamondInheritedConformance: InheritedProtocol1 module witness_tables {
 // TABLE-NEXT:    base_protocol AnyProtocol: DiamondInheritedConformance: AnyProtocol module witness_tables
-// TABLE-NEXT:    method #InheritedProtocol1.inheritedMethod!1: @_T014witness_tables27DiamondInheritedConformanceVAA0D9Protocol1AaaDP15inheritedMethod{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #InheritedProtocol1.inheritedMethod!1: {{.*}} : @_T014witness_tables27DiamondInheritedConformanceVAA0D9Protocol1AaaDP15inheritedMethod{{[_0-9a-zA-Z]*}}FTW
 // TABLE-NEXT:  }
 // TABLE-LABEL: sil_witness_table hidden DiamondInheritedConformance: InheritedProtocol2 module witness_tables {
 // TABLE-NEXT:    base_protocol AnyProtocol: DiamondInheritedConformance: AnyProtocol module witness_tables
-// TABLE-NEXT:    method #InheritedProtocol2.inheritedMethod!1: @_T014witness_tables27DiamondInheritedConformanceVAA0D9Protocol2AaaDP15inheritedMethod{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #InheritedProtocol2.inheritedMethod!1: {{.*}} : @_T014witness_tables27DiamondInheritedConformanceVAA0D9Protocol2AaaDP15inheritedMethod{{[_0-9a-zA-Z]*}}FTW
 // TABLE-NEXT:  }
 // TABLE-LABEL: sil_witness_table hidden DiamondInheritedConformance: AnyProtocol module witness_tables {
 // TABLE-NEXT:    associated_type AssocType: SomeAssoc
 // TABLE-NEXT:    associated_type AssocWithReqt: ConformingAssoc
 // TABLE-NEXT:    associated_type_protocol (AssocWithReqt: AssocReqt): ConformingAssoc: AssocReqt module witness_tables
-// TABLE-NEXT:    method #AnyProtocol.method!1: @_T014witness_tables27DiamondInheritedConformanceVAA11AnyProtocolAaaDP6method{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.generic!1: @_T014witness_tables27DiamondInheritedConformanceVAA11AnyProtocolAaaDP7generic{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.assocTypesMethod!1: @_T014witness_tables27DiamondInheritedConformanceVAA11AnyProtocolAaaDP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.staticMethod!1: @_T014witness_tables27DiamondInheritedConformanceVAA11AnyProtocolAaaDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW
-// TABLE-NEXT:    method #AnyProtocol."<~>"!1: @_T014witness_tables27DiamondInheritedConformanceVAA11AnyProtocolAaaDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW
+// TABLE-NEXT:    method #AnyProtocol.method!1: {{.*}} : @_T014witness_tables27DiamondInheritedConformanceVAA11AnyProtocolAaaDP6method{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.generic!1: {{.*}} : @_T014witness_tables27DiamondInheritedConformanceVAA11AnyProtocolAaaDP7generic{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.assocTypesMethod!1: {{.*}} : @_T014witness_tables27DiamondInheritedConformanceVAA11AnyProtocolAaaDP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.staticMethod!1: {{.*}} : @_T014witness_tables27DiamondInheritedConformanceVAA11AnyProtocolAaaDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW
+// TABLE-NEXT:    method #AnyProtocol."<~>"!1: {{.*}} : @_T014witness_tables27DiamondInheritedConformanceVAA11AnyProtocolAaaDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW
 // TABLE-NEXT:  }
 
 class ClassInheritedConformance : InheritedClassProtocol {
@@ -451,17 +451,17 @@ class ClassInheritedConformance : InheritedClassProtocol {
 func <~>(x: ClassInheritedConformance, y: ClassInheritedConformance) {}
 // TABLE-LABEL: sil_witness_table hidden ClassInheritedConformance: InheritedClassProtocol module witness_tables {
 // TABLE-NEXT:    base_protocol AnyProtocol: ClassInheritedConformance: AnyProtocol module witness_tables
-// TABLE-NEXT:    method #InheritedClassProtocol.inheritedMethod!1: @_T014witness_tables25ClassInheritedConformanceCAA0dC8ProtocolAaaDP15inheritedMethod{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #InheritedClassProtocol.inheritedMethod!1: {{.*}} : @_T014witness_tables25ClassInheritedConformanceCAA0dC8ProtocolAaaDP15inheritedMethod{{[_0-9a-zA-Z]*}}FTW
 // TABLE-NEXT:  }
 // TABLE-LABEL: sil_witness_table hidden ClassInheritedConformance: AnyProtocol module witness_tables {
 // TABLE-NEXT:    associated_type AssocType: SomeAssoc
 // TABLE-NEXT:    associated_type AssocWithReqt: ConformingAssoc
 // TABLE-NEXT:    associated_type_protocol (AssocWithReqt: AssocReqt): ConformingAssoc: AssocReqt module witness_tables
-// TABLE-NEXT:    method #AnyProtocol.method!1: @_T014witness_tables25ClassInheritedConformanceCAA11AnyProtocolAaaDP6method{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.generic!1: @_T014witness_tables25ClassInheritedConformanceCAA11AnyProtocolAaaDP7generic{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.assocTypesMethod!1: @_T014witness_tables25ClassInheritedConformanceCAA11AnyProtocolAaaDP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW
-// TABLE-NEXT:    method #AnyProtocol.staticMethod!1: @_T014witness_tables25ClassInheritedConformanceCAA11AnyProtocolAaaDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW
-// TABLE-NEXT:    method #AnyProtocol."<~>"!1: @_T014witness_tables25ClassInheritedConformanceCAA11AnyProtocolAaaDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW
+// TABLE-NEXT:    method #AnyProtocol.method!1: {{.*}} : @_T014witness_tables25ClassInheritedConformanceCAA11AnyProtocolAaaDP6method{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.generic!1: {{.*}} : @_T014witness_tables25ClassInheritedConformanceCAA11AnyProtocolAaaDP7generic{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.assocTypesMethod!1: {{.*}} : @_T014witness_tables25ClassInheritedConformanceCAA11AnyProtocolAaaDP16assocTypesMethod{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #AnyProtocol.staticMethod!1: {{.*}} : @_T014witness_tables25ClassInheritedConformanceCAA11AnyProtocolAaaDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW
+// TABLE-NEXT:    method #AnyProtocol."<~>"!1: {{.*}} : @_T014witness_tables25ClassInheritedConformanceCAA11AnyProtocolAaaDP3ltgoi{{[_0-9a-zA-Z]*}}FZTW
 // TABLE-NEXT:  }
 // -- Witnesses have the 'self' abstraction level of their protocol.
 //    AnyProtocol has no class bound, so its witnesses treat Self as opaque.
@@ -504,7 +504,7 @@ class ConformsInheritedFromObjC : InheritedFromObjC {
   func inheritedMethod() {}
 }
 // TABLE-LABEL: sil_witness_table hidden ConformsInheritedFromObjC: InheritedFromObjC module witness_tables {
-// TABLE-NEXT:    method #InheritedFromObjC.inheritedMethod!1: @_T014witness_tables25ConformsInheritedFromObjCCAA0deF1CAaaDP15inheritedMethod{{[_0-9a-zA-Z]*}}FTW
+// TABLE-NEXT:    method #InheritedFromObjC.inheritedMethod!1: {{.*}} : @_T014witness_tables25ConformsInheritedFromObjCCAA0deF1CAaaDP15inheritedMethod{{[_0-9a-zA-Z]*}}FTW
 // TABLE-NEXT:  }
 
 protocol ObjCAssoc {
@@ -523,7 +523,7 @@ protocol Initializer {
 }
 
 // TABLE-LABEL: sil_witness_table hidden HasInitializerStruct: Initializer module witness_tables {
-// TABLE-NEXT:  method #Initializer.init!allocator.1: @_T014witness_tables20HasInitializerStructVAA0D0AaaDP{{[_0-9a-zA-Z]*}}fCTW
+// TABLE-NEXT:  method #Initializer.init!allocator.1: {{.*}} : @_T014witness_tables20HasInitializerStructVAA0D0AaaDP{{[_0-9a-zA-Z]*}}fCTW
 // TABLE-NEXT: }
 // SYMBOL: sil hidden [transparent] [thunk] @_T014witness_tables20HasInitializerStructVAA0D0AaaDP{{[_0-9a-zA-Z]*}}fCTW : $@convention(witness_method) (Arg, @thick HasInitializerStruct.Type) -> @out HasInitializerStruct
 struct HasInitializerStruct : Initializer { 
@@ -531,7 +531,7 @@ struct HasInitializerStruct : Initializer {
 }
 
 // TABLE-LABEL: sil_witness_table hidden HasInitializerClass: Initializer module witness_tables {
-// TABLE-NEXT:  method #Initializer.init!allocator.1: @_T014witness_tables19HasInitializerClassCAA0D0AaaDP{{[_0-9a-zA-Z]*}}fCTW
+// TABLE-NEXT:  method #Initializer.init!allocator.1: {{.*}} : @_T014witness_tables19HasInitializerClassCAA0D0AaaDP{{[_0-9a-zA-Z]*}}fCTW
 // TABLE-NEXT: }
 // SYMBOL: sil hidden [transparent] [thunk] @_T014witness_tables19HasInitializerClassCAA0D0AaaDP{{[_0-9a-zA-Z]*}}fCTW : $@convention(witness_method) (Arg, @thick HasInitializerClass.Type) -> @out HasInitializerClass
 class HasInitializerClass : Initializer {
@@ -539,7 +539,7 @@ class HasInitializerClass : Initializer {
 }
 
 // TABLE-LABEL: sil_witness_table hidden HasInitializerEnum: Initializer module witness_tables {
-// TABLE-NEXT:  method #Initializer.init!allocator.1: @_T014witness_tables18HasInitializerEnumOAA0D0AaaDP{{[_0-9a-zA-Z]*}}fCTW
+// TABLE-NEXT:  method #Initializer.init!allocator.1: {{.*}} : @_T014witness_tables18HasInitializerEnumOAA0D0AaaDP{{[_0-9a-zA-Z]*}}fCTW
 // TABLE-NEXT: }
 // SYMBOL: sil hidden [transparent] [thunk] @_T014witness_tables18HasInitializerEnumOAA0D0AaaDP{{[_0-9a-zA-Z]*}}fCTW : $@convention(witness_method) (Arg, @thick HasInitializerEnum.Type) -> @out HasInitializerEnum
 enum HasInitializerEnum : Initializer {

--- a/test/SILGen/witnesses.swift
+++ b/test/SILGen/witnesses.swift
@@ -7,8 +7,8 @@ func archetype_method<T: X>(x: T, y: T) -> T {
   var y = y
   return x.selfTypes(x: y)
 }
-// CHECK-LABEL: sil hidden @_T09witnesses16archetype_method{{[_0-9a-zA-Z]*}}F : $@convention(thin) <T where T : X> (@in T, @in T) -> @out T {
-// CHECK:         [[METHOD:%.*]] = witness_method $T, #X.selfTypes!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : X> (@in τ_0_0, @inout τ_0_0) -> @out τ_0_0
+// CHECK-LABEL: sil hidden @_T09witnesses16archetype_method{{[_0-9a-zA-Z]*}}F{{.*}} : $@convention(thin) <T where T : X> (@in T, @in T) -> @out T {
+// CHECK:         [[METHOD:%.*]] = witness_method $T, #X.selfTypes!1 : {{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : X> (@in τ_0_0, @inout τ_0_0) -> @out τ_0_0
 // CHECK:         apply [[METHOD]]<T>({{%.*}}, {{%.*}}, {{%.*}}) : $@convention(witness_method) <τ_0_0 where τ_0_0 : X> (@in τ_0_0, @inout τ_0_0) -> @out τ_0_0
 // CHECK:       }
 
@@ -16,8 +16,8 @@ func archetype_generic_method<T: X>(x: T, y: Loadable) -> Loadable {
   var x = x
   return x.generic(x: y)
 }
-// CHECK-LABEL: sil hidden @_T09witnesses24archetype_generic_method{{[_0-9a-zA-Z]*}}F : $@convention(thin) <T where T : X> (@in T, Loadable) -> Loadable {
-// CHECK:         [[METHOD:%.*]] = witness_method $T, #X.generic!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : X><τ_1_0> (@in τ_1_0, @inout τ_0_0) -> @out τ_1_0
+// CHECK-LABEL: sil hidden @_T09witnesses24archetype_generic_method{{[_0-9a-zA-Z]*}}F{{.*}} : $@convention(thin) <T where T : X> (@in T, Loadable) -> Loadable {
+// CHECK:         [[METHOD:%.*]] = witness_method $T, #X.generic!1 : {{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : X><τ_1_0> (@in τ_1_0, @inout τ_0_0) -> @out τ_1_0
 // CHECK:         apply [[METHOD]]<T, Loadable>({{%.*}}, {{%.*}}, {{%.*}}) : $@convention(witness_method) <τ_0_0 where τ_0_0 : X><τ_1_0> (@in τ_1_0, @inout τ_0_0) -> @out τ_1_0
 // CHECK:       }
 
@@ -31,7 +31,7 @@ protocol StaticMethod { static func staticMethod() }
 
 // CHECK-LABEL: sil hidden @_T09witnesses23archetype_static_method{{[_0-9a-zA-Z]*}}F : $@convention(thin) <T where T : StaticMethod> (@in T) -> ()
 func archetype_static_method<T: StaticMethod>(x: T) {
-  // CHECK: [[METHOD:%.*]] = witness_method $T, #StaticMethod.staticMethod!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : StaticMethod> (@thick τ_0_0.Type) -> ()
+  // CHECK: [[METHOD:%.*]] = witness_method $T, #StaticMethod.staticMethod!1 : {{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : StaticMethod> (@thick τ_0_0.Type) -> ()
   // CHECK: apply [[METHOD]]<T>
   T.staticMethod()
 }
@@ -492,7 +492,7 @@ class CrashableBase {
 // CHECK-NEXT: copy_addr %0 to [initialization] [[BOX]] : $*GenericCrashable<τ_0_0>
 // CHECK-NEXT: [[SELF:%.*]] = load [take] [[BOX]] : $*GenericCrashable<τ_0_0>
 // CHECK-NEXT: [[BASE:%.*]] = upcast [[SELF]] : $GenericCrashable<τ_0_0> to $CrashableBase
-// CHECK-NEXT: [[FN:%.*]] = class_method [[BASE]] : $CrashableBase, #CrashableBase.crash!1 : (CrashableBase) -> () -> () , $@convention(method) (@guaranteed CrashableBase) -> ()
+// CHECK-NEXT: [[FN:%.*]] = class_method [[BASE]] : $CrashableBase, #CrashableBase.crash!1 : (CrashableBase) -> () -> (), $@convention(method) (@guaranteed CrashableBase) -> ()
 // CHECK-NEXT: apply [[FN]]([[BASE]]) : $@convention(method) (@guaranteed CrashableBase) -> ()
 // CHECK-NEXT: [[RESULT:%.*]] = tuple ()
 // CHECK-NEXT: destroy_value [[SELF]] : $GenericCrashable<τ_0_0>

--- a/test/SILOptimizer/alive_method_with_thunk.swift
+++ b/test/SILOptimizer/alive_method_with_thunk.swift
@@ -15,10 +15,10 @@ public class DerivedClass: BaseClass<Double> {
 }
 
 // CHECK: sil_vtable BaseClass {
-// CHECK:  #BaseClass.doSomething!1: _{{.*}}// BaseClass.doSomething(A) -> Int
+// CHECK:  #BaseClass.doSomething!1: {{.*}} : _{{.*}}// BaseClass.doSomething(A) -> Int
 // CHECK: }
 
 // CHECK: sil_vtable DerivedClass {
-// CHECK:  #BaseClass.doSomething!1: public _{{.*}}// override DerivedClass.doSomething(Double) -> Int
+// CHECK:  #BaseClass.doSomething!1: {{.*}} : public _{{.*}}// override DerivedClass.doSomething(Double) -> Int
 // CHECK: }
 

--- a/test/SILOptimizer/basic-callee-printer.sil
+++ b/test/SILOptimizer/basic-callee-printer.sil
@@ -171,7 +171,7 @@ bb0(%0 : $private_derived):
 
 
 // CHECK: Function call site:
-// CHECK:   %2 = class_method %0 : $private_base, #private_base.foo!1 : (private_base) -> () -> () , $@convention(method) (@guaranteed private_base) -> (),{{.*}} // user: %3
+// CHECK:   %2 = class_method %0 : $private_base, #private_base.foo!1 : (private_base) -> () -> (), $@convention(method) (@guaranteed private_base) -> (),{{.*}} // user: %3
 // CHECK:   %3 = apply %2(%0) : $@convention(method) (@guaranteed private_base) -> ()
 // CHECK: Incomplete callee list? : No
 // CHECK: Known callees:
@@ -180,7 +180,7 @@ bb0(%0 : $private_derived):
 sil private [noinline] @call_private : $@convention(thin) (@owned private_base) -> () {
 bb0(%0 : $private_base):
   debug_value %0 : $private_base
-  %2 = class_method %0 : $private_base, #private_base.foo!1 : (private_base) -> () -> () , $@convention(method) (@guaranteed private_base) -> ()
+  %2 = class_method %0 : $private_base, #private_base.foo!1 : (private_base) -> () -> (), $@convention(method) (@guaranteed private_base) -> ()
   %3 = apply %2(%0) : $@convention(method) (@guaranteed private_base) -> ()
   strong_release %0 : $private_base
   %5 = tuple ()
@@ -221,7 +221,7 @@ bb0(%0 : $internal_derived):
 
 
 // CHECK: Function call site:
-// CHECK:   %4 = class_method %0 : $internal_base, #internal_base.bar!1 : (internal_base) -> () -> () , $@convention(method) (@guaranteed internal_base) -> (){{.*}} // user: %5
+// CHECK:   %4 = class_method %0 : $internal_base, #internal_base.bar!1 : (internal_base) -> () -> (), $@convention(method) (@guaranteed internal_base) -> (){{.*}} // user: %5
 // CHECK:   %5 = apply %4(%0) : $@convention(method) (@guaranteed internal_base) -> ()
 // CHECK-NOWMO: Incomplete callee list? : Yes
 // CHECK-WMO: Incomplete callee list? : No
@@ -231,9 +231,9 @@ bb0(%0 : $internal_derived):
 sil hidden [noinline] @call_internal : $@convention(thin) (@owned internal_base) -> () {
 bb0(%0 : $internal_base):
   debug_value %0 : $internal_base
-  %2 = class_method %0 : $internal_base, #internal_base.foo!1 : (internal_base) -> () -> () , $@convention(method) (@guaranteed internal_base) -> ()
+  %2 = class_method %0 : $internal_base, #internal_base.foo!1 : (internal_base) -> () -> (), $@convention(method) (@guaranteed internal_base) -> ()
   %3 = apply %2(%0) : $@convention(method) (@guaranteed internal_base) -> ()
-  %4 = class_method %0 : $internal_base, #internal_base.bar!1 : (internal_base) -> () -> () , $@convention(method) (@guaranteed internal_base) -> ()
+  %4 = class_method %0 : $internal_base, #internal_base.bar!1 : (internal_base) -> () -> (), $@convention(method) (@guaranteed internal_base) -> ()
   %5 = apply %4(%0) : $@convention(method) (@guaranteed internal_base) -> ()
   strong_release %0 : $internal_base
   %7 = tuple ()
@@ -290,7 +290,7 @@ bb0(%0 : $public_derived):
 
 
 // CHECK: Function call site:
-// CHECK:   %2 = class_method %0 : $public_base, #public_base.foo!1 : (public_base) -> () -> () , $@convention(method) (@guaranteed public_base) -> (){{.*}} // user: %3
+// CHECK:   %2 = class_method %0 : $public_base, #public_base.foo!1 : (public_base) -> () -> (), $@convention(method) (@guaranteed public_base) -> (){{.*}} // user: %3
 // CHECK:   %3 = apply %2(%0) : $@convention(method) (@guaranteed public_base) -> ()
 // CHECK-NOWMO: Incomplete callee list? : Yes
 // CHECK-WMO: Incomplete callee list? : No
@@ -299,7 +299,7 @@ bb0(%0 : $public_derived):
 // CHECK: public_derived_foo
 //
 // CHECK: Function call site:
-// CHECK:   %4 = class_method %0 : $public_base, #public_base.bar!1 : (public_base) -> () -> () , $@convention(method) (@guaranteed public_base) -> (){{.*}} // user: %5
+// CHECK:   %4 = class_method %0 : $public_base, #public_base.bar!1 : (public_base) -> () -> (), $@convention(method) (@guaranteed public_base) -> (){{.*}} // user: %5
 // CHECK:   %5 = apply %4(%0) : $@convention(method) (@guaranteed public_base) -> ()
 // CHECK: Incomplete callee list? : Yes
 // CHECK: Known callees:
@@ -307,7 +307,7 @@ bb0(%0 : $public_derived):
 // CHECK: public_derived_bar
 //
 // CHECK: Function call site:
-// CHECK:   %6 = class_method %0 : $public_base, #public_base.baz!1 : (public_base) -> () -> () , $@convention(method) (@guaranteed public_base) -> (){{.*}} // user: %7
+// CHECK:   %6 = class_method %0 : $public_base, #public_base.baz!1 : (public_base) -> () -> (), $@convention(method) (@guaranteed public_base) -> (){{.*}} // user: %7
 // CHECK:   %7 = apply %6(%0) : $@convention(method) (@guaranteed public_base) -> ()
 // CHECK: Incomplete callee list? : Yes
 // CHECK: Known callees:
@@ -316,11 +316,11 @@ bb0(%0 : $public_derived):
 sil hidden [noinline] @call_public : $@convention(thin) (@owned public_base) -> () {
 bb0(%0 : $public_base):
   debug_value %0 : $public_base
-  %2 = class_method %0 : $public_base, #public_base.foo!1 : (public_base) -> () -> () , $@convention(method) (@guaranteed public_base) -> ()
+  %2 = class_method %0 : $public_base, #public_base.foo!1 : (public_base) -> () -> (), $@convention(method) (@guaranteed public_base) -> ()
   %3 = apply %2(%0) : $@convention(method) (@guaranteed public_base) -> ()
-  %4 = class_method %0 : $public_base, #public_base.bar!1 : (public_base) -> () -> () , $@convention(method) (@guaranteed public_base) -> ()
+  %4 = class_method %0 : $public_base, #public_base.bar!1 : (public_base) -> () -> (), $@convention(method) (@guaranteed public_base) -> ()
   %5 = apply %4(%0) : $@convention(method) (@guaranteed public_base) -> ()
-  %6 = class_method %0 : $public_base, #public_base.baz!1 : (public_base) -> () -> () , $@convention(method) (@guaranteed public_base) -> ()
+  %6 = class_method %0 : $public_base, #public_base.baz!1 : (public_base) -> () -> (), $@convention(method) (@guaranteed public_base) -> ()
   %7 = apply %6(%0) : $@convention(method) (@guaranteed public_base) -> ()
   strong_release %0 : $public_base
   %9 = tuple ()
@@ -406,7 +406,7 @@ bb0(%0 : $private_proto_private_class):
 
 
 // CHECK: Function call site:
-// CHECK:   %3 = class_method %1 : $private_proto_private_class, #private_proto_private_class.theMethod!1 : (private_proto_private_class) -> () -> () , $@convention(method) (@guaranteed private_proto_private_class) -> (){{.*}} // user: %4
+// CHECK:   %3 = class_method %1 : $private_proto_private_class, #private_proto_private_class.theMethod!1 : (private_proto_private_class) -> () -> (), $@convention(method) (@guaranteed private_proto_private_class) -> (){{.*}} // user: %4
 // CHECK:   %4 = apply %3(%1) : $@convention(method) (@guaranteed private_proto_private_class) -> (){{.*}} // user: %6
 // CHECK: Incomplete callee list? : No
 // CHECK: Known callees:
@@ -415,7 +415,7 @@ sil private [transparent] [thunk] @private_proto_1_private_class_witness : $@con
 bb0(%0 : $*private_proto_private_class):
   %1 = load %0 : $*private_proto_private_class
   strong_retain %1 : $private_proto_private_class
-  %3 = class_method %1 : $private_proto_private_class, #private_proto_private_class.theMethod!1 : (private_proto_private_class) -> () -> () , $@convention(method) (@guaranteed private_proto_private_class) -> ()
+  %3 = class_method %1 : $private_proto_private_class, #private_proto_private_class.theMethod!1 : (private_proto_private_class) -> () -> (), $@convention(method) (@guaranteed private_proto_private_class) -> ()
   %4 = apply %3(%1) : $@convention(method) (@guaranteed private_proto_private_class) -> ()
   strong_release %1 : $private_proto_private_class
   return %4 : $()
@@ -423,7 +423,7 @@ bb0(%0 : $*private_proto_private_class):
 
 
 // CHECK: Function call site:
-// CHECK:   %2 = witness_method $T, #private_proto_1.theMethod!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : private_proto_1> (@in_guaranteed τ_0_0) -> (){{.*}} // user: %3
+// CHECK:   %2 = witness_method $T, #private_proto_1.theMethod!1 : {{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : private_proto_1> (@in_guaranteed τ_0_0) -> (){{.*}} // user: %3
 // CHECK:   %3 = apply %2<T>(%0) : $@convention(witness_method) <τ_0_0 where τ_0_0 : private_proto_1> (@in_guaranteed τ_0_0) -> ()
 // CHECK: Incomplete callee list? : Yes
 // CHECK: Known callees:
@@ -448,7 +448,7 @@ bb0(%0 : $private_proto_internal_class):
 
 
 // CHECK: Function call site:
-// CHECK:   %3 = class_method %1 : $private_proto_internal_class, #private_proto_internal_class.theMethod!1 : (private_proto_internal_class) -> () -> () , $@convention(method) (@guaranteed private_proto_internal_class) -> (){{.*}} // user: %4
+// CHECK:   %3 = class_method %1 : $private_proto_internal_class, #private_proto_internal_class.theMethod!1 : (private_proto_internal_class) -> () -> (), $@convention(method) (@guaranteed private_proto_internal_class) -> (){{.*}} // user: %4
 // CHECK:   %4 = apply %3(%1) : $@convention(method) (@guaranteed private_proto_internal_class) -> (){{.*}} // user: %6
 // CHECK-NOWMO: Incomplete callee list? : Yes
 // CHECK-WMO: Incomplete callee list? : No
@@ -458,7 +458,7 @@ sil private [transparent] [thunk] @private_proto_2_internal_class_witness : $@co
 bb0(%0 : $*private_proto_internal_class):
   %1 = load %0 : $*private_proto_internal_class
   strong_retain %1 : $private_proto_internal_class
-  %3 = class_method %1 : $private_proto_internal_class, #private_proto_internal_class.theMethod!1 : (private_proto_internal_class) -> () -> () , $@convention(method) (@guaranteed private_proto_internal_class) -> ()
+  %3 = class_method %1 : $private_proto_internal_class, #private_proto_internal_class.theMethod!1 : (private_proto_internal_class) -> () -> (), $@convention(method) (@guaranteed private_proto_internal_class) -> ()
   %4 = apply %3(%1) : $@convention(method) (@guaranteed private_proto_internal_class) -> ()
   strong_release %1 : $private_proto_internal_class
   return %4 : $()
@@ -466,7 +466,7 @@ bb0(%0 : $*private_proto_internal_class):
 
 
 // CHECK: Function call site:
-// CHECK:   %2 = witness_method $T, #private_proto_2.theMethod!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : private_proto_2> (@in_guaranteed τ_0_0) -> (){{.*}} // user: %3
+// CHECK:   %2 = witness_method $T, #private_proto_2.theMethod!1 : {{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : private_proto_2> (@in_guaranteed τ_0_0) -> (){{.*}} // user: %3
 // CHECK:   %3 = apply %2<T>(%0) : $@convention(witness_method) <τ_0_0 where τ_0_0 : private_proto_2> (@in_guaranteed τ_0_0) -> ()
 // CHECK: Incomplete callee list? : Yes
 // CHECK: Known callees:
@@ -491,7 +491,7 @@ bb0(%0 : $private_proto_public_class):
 
 
 // CHECK: Function call site:
-// CHECK:   %3 = class_method %1 : $private_proto_public_class, #private_proto_public_class.theMethod!1 : (private_proto_public_class) -> () -> () , $@convention(method) (@guaranteed private_proto_public_class) -> (){{.*}} // user: %4
+// CHECK:   %3 = class_method %1 : $private_proto_public_class, #private_proto_public_class.theMethod!1 : (private_proto_public_class) -> () -> (), $@convention(method) (@guaranteed private_proto_public_class) -> (){{.*}} // user: %4
 // CHECK:   %4 = apply %3(%1) : $@convention(method) (@guaranteed private_proto_public_class) -> (){{.*}} // user: %6
 // CHECK: Incomplete callee list? : Yes
 // CHECK: Known callees:
@@ -500,7 +500,7 @@ sil private [transparent] [thunk] @private_proto_3_public_class_witness : $@conv
 bb0(%0 : $*private_proto_public_class):
   %1 = load %0 : $*private_proto_public_class
   strong_retain %1 : $private_proto_public_class
-  %3 = class_method %1 : $private_proto_public_class, #private_proto_public_class.theMethod!1 : (private_proto_public_class) -> () -> () , $@convention(method) (@guaranteed private_proto_public_class) -> ()
+  %3 = class_method %1 : $private_proto_public_class, #private_proto_public_class.theMethod!1 : (private_proto_public_class) -> () -> (), $@convention(method) (@guaranteed private_proto_public_class) -> ()
   %4 = apply %3(%1) : $@convention(method) (@guaranteed private_proto_public_class) -> ()
   strong_release %1 : $private_proto_public_class
   return %4 : $()
@@ -508,7 +508,7 @@ bb0(%0 : $*private_proto_public_class):
 
 
 // CHECK: Function call site:
-// CHECK:   %2 = witness_method $T, #private_proto_3.theMethod!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : private_proto_3> (@in_guaranteed τ_0_0) -> (){{.*}} // user: %3
+// CHECK:   %2 = witness_method $T, #private_proto_3.theMethod!1 : {{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : private_proto_3> (@in_guaranteed τ_0_0) -> (){{.*}} // user: %3
 // CHECK:   %3 = apply %2<T>(%0) : $@convention(witness_method) <τ_0_0 where τ_0_0 : private_proto_3> (@in_guaranteed τ_0_0) -> ()
 // CHECK: Incomplete callee list? : Yes
 // CHECK: Known callees:
@@ -533,7 +533,7 @@ bb0(%0 : $private_proto_public_class_private_method):
 
 
 // CHECK: Function call site:
-// CHECK:   %3 = class_method %1 : $private_proto_public_class_private_method, #private_proto_public_class_private_method.theMethod!1 : (private_proto_public_class_private_method) -> () -> () , $@convention(method) (@guaranteed private_proto_public_class_private_method) -> (){{.*}} // user: %4
+// CHECK:   %3 = class_method %1 : $private_proto_public_class_private_method, #private_proto_public_class_private_method.theMethod!1 : (private_proto_public_class_private_method) -> () -> (), $@convention(method) (@guaranteed private_proto_public_class_private_method) -> (){{.*}} // user: %4
 // CHECK:   %4 = apply %3(%1) : $@convention(method) (@guaranteed private_proto_public_class_private_method) -> (){{.*}} // user: %6
 // CHECK: Incomplete callee list? : No
 // CHECK: Known callees:
@@ -542,7 +542,7 @@ sil private [transparent] [thunk] @private_proto_4_public_class_private_method_w
 bb0(%0 : $*private_proto_public_class_private_method):
   %1 = load %0 : $*private_proto_public_class_private_method
   strong_retain %1 : $private_proto_public_class_private_method
-  %3 = class_method %1 : $private_proto_public_class_private_method, #private_proto_public_class_private_method.theMethod!1 : (private_proto_public_class_private_method) -> () -> () , $@convention(method) (@guaranteed private_proto_public_class_private_method) -> ()
+  %3 = class_method %1 : $private_proto_public_class_private_method, #private_proto_public_class_private_method.theMethod!1 : (private_proto_public_class_private_method) -> () -> (), $@convention(method) (@guaranteed private_proto_public_class_private_method) -> ()
   %4 = apply %3(%1) : $@convention(method) (@guaranteed private_proto_public_class_private_method) -> ()
   strong_release %1 : $private_proto_public_class_private_method
   return %4 : $()
@@ -550,7 +550,7 @@ bb0(%0 : $*private_proto_public_class_private_method):
 
 
 // CHECK: Function call site:
-// CHECK:   %2 = witness_method $T, #private_proto_4.theMethod!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : private_proto_4> (@in_guaranteed τ_0_0) -> (){{.*}} // user: %3
+// CHECK:   %2 = witness_method $T, #private_proto_4.theMethod!1 : {{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : private_proto_4> (@in_guaranteed τ_0_0) -> (){{.*}} // user: %3
 // CHECK:   %3 = apply %2<T>(%0) : $@convention(witness_method) <τ_0_0 where τ_0_0 : private_proto_4> (@in_guaranteed τ_0_0) -> ()
 // CHECK: Incomplete callee list? : Yes
 // CHECK: Known callees:
@@ -617,7 +617,7 @@ sil @test_call_of_allocator_and_initializer : $@convention(thin) (@thick SomeIte
 bb0(%0 : $@thick SomeItem.Type, %1: $InitVal):
 
 // CHECK: Function call site:
-// CHECK:   %2 = class_method %0 : $@thick SomeItem.Type, #SomeItem.init!allocator.1 : (SomeItem.Type) -> (InitVal) -> SomeItem , $@convention(method) (InitVal, @thick SomeItem.Type) -> @owned SomeItem
+// CHECK:   %2 = class_method %0 : $@thick SomeItem.Type, #SomeItem.init!allocator.1 : (SomeItem.Type) -> (InitVal) -> SomeItem, $@convention(method) (InitVal, @thick SomeItem.Type) -> @owned SomeItem
 // CHECK:   %3 = apply %2(%1, %0) : $@convention(method) (InitVal, @thick SomeItem.Type) -> @owned SomeItem
 // CHECK-NOWMO: Incomplete callee list? : Yes
 // CHECK-WMO: Incomplete callee list? : No
@@ -625,11 +625,11 @@ bb0(%0 : $@thick SomeItem.Type, %1: $InitVal):
 // CHECK: SomeChildItem_allocator
 // CHECK: SomeItem_allocator
 
-  %2 = class_method %0 : $@thick SomeItem.Type, #SomeItem.init!allocator.1 : (SomeItem.Type) -> (InitVal) -> SomeItem , $@convention(method) (InitVal, @thick SomeItem.Type) -> @owned SomeItem
+  %2 = class_method %0 : $@thick SomeItem.Type, #SomeItem.init!allocator.1 : (SomeItem.Type) -> (InitVal) -> SomeItem, $@convention(method) (InitVal, @thick SomeItem.Type) -> @owned SomeItem
   %3 = apply %2(%1, %0) : $@convention(method) (InitVal, @thick SomeItem.Type) -> @owned SomeItem
 
 // CHECK: Function call site:
-// CHECK:   %4 = class_method %3 : $SomeItem, #SomeItem.init!initializer.1 : (SomeItem.Type) -> (InitVal) -> SomeItem , $@convention(method) (InitVal, @owned SomeItem) -> @owned SomeItem
+// CHECK:   %4 = class_method %3 : $SomeItem, #SomeItem.init!initializer.1 : (SomeItem.Type) -> (InitVal) -> SomeItem, $@convention(method) (InitVal, @owned SomeItem) -> @owned SomeItem
 // CHECK:   %5 = apply %4(%1, %3) : $@convention(method) (InitVal, @owned SomeItem) -> @owned SomeItem
 // CHECK-NOWMO: Incomplete callee list? : Yes
 // CHECK-WMO: Incomplete callee list? : No
@@ -637,7 +637,7 @@ bb0(%0 : $@thick SomeItem.Type, %1: $InitVal):
 // CHECK: SomeChildItem_initializer
 // CHECK: SomeItem_initializer
 
-  %4 = class_method %3 : $SomeItem, #SomeItem.init!initializer.1 : (SomeItem.Type) -> (InitVal) -> SomeItem , $@convention(method) (InitVal, @owned SomeItem) -> @owned SomeItem
+  %4 = class_method %3 : $SomeItem, #SomeItem.init!initializer.1 : (SomeItem.Type) -> (InitVal) -> SomeItem, $@convention(method) (InitVal, @owned SomeItem) -> @owned SomeItem
   %5 = apply %4(%1, %3) : $@convention(method) (InitVal, @owned SomeItem) -> @owned SomeItem
   return %5 : $SomeItem
 }

--- a/test/SILOptimizer/capture_promotion.sil
+++ b/test/SILOptimizer/capture_promotion.sil
@@ -154,7 +154,7 @@ bb0:
 
 // The load of %1 is removed, and its uses replaced with the Foo argument
 // CHECK-NEXT: strong_retain {{.*}} : $Foo
-// CHECK-NEXT: [[METHOD_FOO:%.*]] = class_method {{.*}} : $Foo, #Foo.foo!1 : (Foo) -> () -> Int , $@convention(method) (@guaranteed Foo) -> Int
+// CHECK-NEXT: [[METHOD_FOO:%.*]] = class_method {{.*}} : $Foo, #Foo.foo!1 : (Foo) -> () -> Int, $@convention(method) (@guaranteed Foo) -> Int
 // CHECK-NEXT: [[APPLY_FOO:%.*]] = apply [[METHOD_FOO]]({{.*}}) : $@convention(method) (@guaranteed Foo) -> Int
 
 // The struct_element_addr of %3 followed by a load is replaced by a struct_extract of the Baz argument

--- a/test/SILOptimizer/constant_propagation_castopt_analysis_invalidation.sil
+++ b/test/SILOptimizer/constant_propagation_castopt_analysis_invalidation.sil
@@ -202,7 +202,7 @@ bb4(%12 : $Foo2):                                 // Preds: bb3
   br bb6                                          // id: %17
 
 bb5:                                              // Preds: bb3
-  %18 = class_method %0 : $Foo, #Foo.speak!1 : Foo -> () -> () , $@convention(method) (@guaranteed Foo) -> () // user: %19
+  %18 = class_method %0 : $Foo, #Foo.speak!1 : Foo -> () -> (), $@convention(method) (@guaranteed Foo) -> () // user: %19
   %19 = apply %18(%0) : $@convention(method) (@guaranteed Foo) -> ()
   br bb6                                          // id: %20
 

--- a/test/SILOptimizer/cse.sil
+++ b/test/SILOptimizer/cse.sil
@@ -1059,11 +1059,11 @@ sil  @_TFC4main4PingcfMS0_FT_S0_ : $@convention(method) (@owned Ping) -> @owned 
 // CHECK-NEXT:      return
 sil @_TF4main4ringFCS_4PingT_ : $@convention(thin) (@owned Ping) -> () {
 bb0(%0 : $Ping):
-  %1 = class_method %0 : $Ping, #Ping.ping!1 : (Ping) -> () -> Ping , $@convention(method) (@guaranteed Ping) -> @owned Ping
-  %2 = class_method %0 : $Ping, #Ping.ping!1 : (Ping) -> () -> Ping , $@convention(method) (@guaranteed Ping) -> @owned Ping
-  %3 = class_method %0 : $Ping, #Ping.ping!1 : (Ping) -> () -> Ping , $@convention(method) (@guaranteed Ping) -> @owned Ping
-  %4 = class_method %0 : $Ping, #Ping.ping!1 : (Ping) -> () -> Ping , $@convention(method) (@guaranteed Ping) -> @owned Ping
-  %5 = class_method %0 : $Ping, #Ping.ping!1 : (Ping) -> () -> Ping , $@convention(method) (@guaranteed Ping) -> @owned Ping
+  %1 = class_method %0 : $Ping, #Ping.ping!1 : (Ping) -> () -> Ping, $@convention(method) (@guaranteed Ping) -> @owned Ping
+  %2 = class_method %0 : $Ping, #Ping.ping!1 : (Ping) -> () -> Ping, $@convention(method) (@guaranteed Ping) -> @owned Ping
+  %3 = class_method %0 : $Ping, #Ping.ping!1 : (Ping) -> () -> Ping, $@convention(method) (@guaranteed Ping) -> @owned Ping
+  %4 = class_method %0 : $Ping, #Ping.ping!1 : (Ping) -> () -> Ping, $@convention(method) (@guaranteed Ping) -> @owned Ping
+  %5 = class_method %0 : $Ping, #Ping.ping!1 : (Ping) -> () -> Ping, $@convention(method) (@guaranteed Ping) -> @owned Ping
   %6 = apply %1(%0) : $@convention(method) (@guaranteed Ping) -> @owned Ping
   %7 = apply %2(%0) : $@convention(method) (@guaranteed Ping) -> @owned Ping
   %8 = apply %3(%0) : $@convention(method) (@guaranteed Ping) -> @owned Ping
@@ -1126,7 +1126,7 @@ sil hidden [transparent] [thunk] @_TTWC1p1TS_9ReachableS_FS1_5reachuRq_S1__fq_FT
 bb0(%0 : $*T):
   %1 = load %0 : $*T                              // users: %2, %3, %4, %5
   strong_retain %1 : $T                           // id: %2
-  %3 = class_method %1 : $T, #T.reach!1 : (T) -> () -> () , $@convention(method) (@guaranteed T) -> () // user: %4
+  %3 = class_method %1 : $T, #T.reach!1 : (T) -> () -> (), $@convention(method) (@guaranteed T) -> () // user: %4
   %4 = apply %3(%1) : $@convention(method) (@guaranteed T) -> () // user: %6
   strong_release %1 : $T                          // id: %5
   return %4 : $()                                 // id: %6
@@ -1249,7 +1249,7 @@ protocol Pingable { func ping() }
 
 // CHECK-LABEL: CSE_Existential_Simple
 // CHECK: open_existential_addr %0 : $*Pingable to $*@opened("1E467EB8-D5C5-11E5-8C0E-A82066121073")
-// CHECK: witness_method $@opened("1E467EB8-D5C5-11E5-8C0E-A82066121073") Pingable, #Pingable.ping!1, %2
+// CHECK: witness_method $@opened("1E467EB8-D5C5-11E5-8C0E-A82066121073") Pingable, #Pingable.ping!1 : {{.*}}, %2
 // CHECK: apply %3<@opened("1E467EB8-D5C5-11E5-8C0E-A82066121073") Pingable>(%2)
 // CHECK: open_existential_addr
 // CHECK: witness_method

--- a/test/SILOptimizer/cse_objc.sil
+++ b/test/SILOptimizer/cse_objc.sil
@@ -39,7 +39,7 @@ bb0(%0 : $Bar):
   %1 = alloc_stack $Bar, let, name "sf"              // users: %2, %6, %9, %10
   store %0 to %1 : $*Bar                        // id: %2
   %3 = upcast %0 : $Bar to $NSObject              // user: %7
-  %4 = super_method [volatile] %0 : $Bar, #NSObject.init!initializer.1.foreign : (NSObject.Type) -> () -> NSObject , $@convention(objc_method) (@owned NSObject) -> @owned NSObject // user: %7
+  %4 = super_method [volatile] %0 : $Bar, #NSObject.init!initializer.1.foreign : (NSObject.Type) -> () -> NSObject, $@convention(objc_method) (@owned NSObject) -> @owned NSObject // user: %7
   %7 = apply %4(%3) : $@convention(objc_method) (@owned NSObject) -> @owned NSObject // user: %8
   %8 = unchecked_ref_cast %7 : $NSObject to $Bar  // users: %9, %11
   store %8 to %1 : $*Bar                        // id: %9
@@ -89,7 +89,7 @@ bb0(%0 : $Bar):
 sil hidden @_TFC4test3BarD : $@convention(method) (@owned Bar) -> () {
 bb0(%0 : $Bar):
   debug_value %0 : $Bar, let, name "self" // id: %1
-  %2 = super_method %0 : $Bar, #NSObject.deinit!deallocator.foreign : (NSObject) -> () -> () , $@convention(objc_method) (NSObject) -> ()  // user: %4
+  %2 = super_method %0 : $Bar, #NSObject.deinit!deallocator.foreign : (NSObject) -> () -> (), $@convention(objc_method) (NSObject) -> ()  // user: %4
   %3 = upcast %0 : $Bar to $NSObject              // user: %4
   %4 = apply %2(%3) : $@convention(objc_method) (NSObject) -> ()
   %5 = tuple ()                                   // user: %6

--- a/test/SILOptimizer/dead_func_init_method.sil
+++ b/test/SILOptimizer/dead_func_init_method.sil
@@ -27,7 +27,7 @@ bb0(%4 : $Derived):
 
 sil @testit : $@convention(method) (@owned Derived) -> @owned Derived {
 bb0(%1 : $Derived):
-  %157 = class_method %1 : $Derived, #Derived.init!initializer.1 : (Derived.Type) -> () -> Derived , $@convention(method) (@owned Derived) -> @owned Derived
+  %157 = class_method %1 : $Derived, #Derived.init!initializer.1 : (Derived.Type) -> () -> Derived, $@convention(method) (@owned Derived) -> @owned Derived
   return %1 : $Derived
 }
 

--- a/test/SILOptimizer/dead_function_elimination.swift
+++ b/test/SILOptimizer/dead_function_elimination.swift
@@ -192,8 +192,8 @@ internal func donotEliminate() {
 // CHECK: notInOther
 
 // CHECK-LABEL: sil_witness_table hidden Adopt: Prot
-// CHECK: aliveWitness!1: @{{.*}}aliveWitness
-// CHECK: DeadWitness!1: nil
+// CHECK: aliveWitness!1: {{.*}} : @{{.*}}aliveWitness
+// CHECK: DeadWitness!1: {{.*}} : nil
 
 // CHECK-TESTING-LABEL: sil_witness_table [fragile] Adopt: Prot
 // CHECK-TESTING: DeadWitness{{.*}}: @{{.*}}DeadWitness

--- a/test/SILOptimizer/dead_witness_module.swift
+++ b/test/SILOptimizer/dead_witness_module.swift
@@ -10,4 +10,4 @@ import TestModule
 testit(MyStruct())
 
 // CHECK: sil_witness_table public_external [fragile] MyStruct: Proto module TestModule
-// CHECK-NEXT: method #Proto.confx!1: @_T0{{.*}}confx{{.*}}FTW
+// CHECK-NEXT: method #Proto.confx!1: {{.*}} : @_T0{{.*}}confx{{.*}}FTW

--- a/test/SILOptimizer/definite_init_objc_factory_init.swift
+++ b/test/SILOptimizer/definite_init_objc_factory_init.swift
@@ -9,7 +9,7 @@ import ImportAsMember.Class
 func testInstanceTypeFactoryMethod(queen: Bee) {
   // CHECK: bb0([[QUEEN:%[0-9]+]] : $Optional<Bee>, [[HIVE_META:%[0-9]+]] : $@thick Hive.Type):
   // CHECK-NEXT:   [[HIVE_META_OBJC:%[0-9]+]] = thick_to_objc_metatype [[HIVE_META]] : $@thick Hive.Type to $@objc_metatype Hive.Type
-  // CHECK-NEXT:   [[FACTORY:%[0-9]+]] = class_method [volatile] [[HIVE_META_OBJC]] : $@objc_metatype Hive.Type, #Hive.init!allocator.1.foreign : (Hive.Type) -> (Bee!) -> Hive! , $@convention(objc_method) (Optional<Bee>, @objc_metatype Hive.Type) -> @autoreleased Optional<Hive>
+  // CHECK-NEXT:   [[FACTORY:%[0-9]+]] = class_method [volatile] [[HIVE_META_OBJC]] : $@objc_metatype Hive.Type, #Hive.init!allocator.1.foreign : (Hive.Type) -> (Bee!) -> Hive!, $@convention(objc_method) (Optional<Bee>, @objc_metatype Hive.Type) -> @autoreleased Optional<Hive>
   // CHECK-NEXT:   [[HIVE:%[0-9]+]] = apply [[FACTORY]]([[QUEEN]], [[HIVE_META_OBJC]]) : $@convention(objc_method) (Optional<Bee>, @objc_metatype Hive.Type) -> @autoreleased Optional<Hive>
   // CHECK-NEXT:   release_value [[QUEEN]]
   // CHECK-NEXT:   return [[HIVE]] : $Optional<Hive>
@@ -26,7 +26,7 @@ extension Hive {
     // CHECK: [[SELF_ADDR:%[0-9]+]] = alloc_stack $Hive
     // CHECK: store [[OLD_SELF:%[0-9]+]] to [[SELF_ADDR]]
     // CHECK: [[META:%[0-9]+]] = value_metatype $@thick Hive.Type, [[OLD_SELF]] : $Hive
-    // CHECK: [[FACTORY:%[0-9]+]] = class_method [volatile] [[META]] : $@thick Hive.Type, #Hive.init!allocator.1.foreign : (Hive.Type) -> (Bee!) -> Hive! , $@convention(objc_method) (Optional<Bee>, @objc_metatype Hive.Type) -> @autoreleased Optional<Hive>
+    // CHECK: [[FACTORY:%[0-9]+]] = class_method [volatile] [[META]] : $@thick Hive.Type, #Hive.init!allocator.1.foreign : (Hive.Type) -> (Bee!) -> Hive!, $@convention(objc_method) (Optional<Bee>, @objc_metatype Hive.Type) -> @autoreleased Optional<Hive>
     // CHECK: [[OBJC_META:%[0-9]+]] = thick_to_objc_metatype [[META]] : $@thick Hive.Type to $@objc_metatype Hive.Type
     // CHECK: apply [[FACTORY]]([[QUEEN:%[0-9]+]], [[OBJC_META]]) : $@convention(objc_method) (Optional<Bee>, @objc_metatype Hive.Type) -> @autoreleased Optional<Hive>
     // CHECK: store [[NEW_SELF:%[0-9]+]] to [[SELF_ADDR]]

--- a/test/SILOptimizer/devirt_access.sil
+++ b/test/SILOptimizer/devirt_access.sil
@@ -19,7 +19,7 @@ class K {
 //CHECK-NEXT: return
 sil @_TFC4test1K4pingfS0_FT_Si : $@convention(method) (@guaranteed K) -> Int {
 bb0(%0 : $K):
-  %1 = class_method %0 : $K, #K.pong!1 : (K) -> () -> Int , $@convention(method) (@guaranteed K) -> Int // user: %2
+  %1 = class_method %0 : $K, #K.pong!1 : (K) -> () -> Int, $@convention(method) (@guaranteed K) -> Int // user: %2
   %2 = apply %1(%0) : $@convention(method) (@guaranteed K) -> Int // user: %3
   return %2 : $Int                                // id: %3
 }
@@ -94,7 +94,7 @@ sil @Case1 : $@convention(thin) (@owned X) -> Int {
 bb0(%0 : $X):
   debug_value %0 : $X, let, name "a" // id: %1
   strong_retain %0 : $X                           // id: %2
-  %3 = class_method %0 : $X, #X.ping!1 : (X) -> () -> Int , $@convention(method) (@guaranteed X) -> Int // user: %4
+  %3 = class_method %0 : $X, #X.ping!1 : (X) -> () -> Int, $@convention(method) (@guaranteed X) -> Int // user: %4
   %4 = apply %3(%0) : $@convention(method) (@guaranteed X) -> Int // user: %6
   strong_release %0 : $X                          // id: %5
   return %4 : $Int                                // id: %6
@@ -113,7 +113,7 @@ bb0(%0 : $Y):
   debug_value %0 : $Y, let, name "a" // id: %1
   strong_retain %0 : $Y                           // id: %2
   %3 = upcast %0 : $Y to $X                       // users: %4, %5
-  %4 = class_method %3 : $X, #X.ping!1 : (X) -> () -> Int , $@convention(method) (@guaranteed X) -> Int // user: %5
+  %4 = class_method %3 : $X, #X.ping!1 : (X) -> () -> Int, $@convention(method) (@guaranteed X) -> Int // user: %5
   %5 = apply %4(%3) : $@convention(method) (@guaranteed X) -> Int // user: %7
   strong_release %0 : $Y                          // id: %6
   return %5 : $Int                                // id: %7
@@ -126,7 +126,7 @@ sil @Case3 : $@convention(thin) (@owned A) -> Int {
 bb0(%0 : $A):
   debug_value %0 : $A, let, name "a" // id: %1
   strong_retain %0 : $A                           // id: %2
-  %3 = class_method %0 : $A, #A.ping!1 : (A) -> () -> Int , $@convention(method) (@guaranteed A) -> Int // user: %4
+  %3 = class_method %0 : $A, #A.ping!1 : (A) -> () -> Int, $@convention(method) (@guaranteed A) -> Int // user: %4
   %4 = apply %3(%0) : $@convention(method) (@guaranteed A) -> Int // user: %6
   strong_release %0 : $A                          // id: %5
   return %4 : $Int                                // id: %6
@@ -139,7 +139,7 @@ sil @Case4 : $@convention(thin) (@owned B) -> Int {
 bb0(%0 : $B):
   debug_value %0 : $B, let, name "a" // id: %1
   strong_retain %0 : $B                           // id: %2
-  %3 = class_method %0 : $B, #B.ping!1 : (B) -> () -> Int , $@convention(method) (@guaranteed B) -> Int // user: %4
+  %3 = class_method %0 : $B, #B.ping!1 : (B) -> () -> Int, $@convention(method) (@guaranteed B) -> Int // user: %4
   %4 = apply %3(%0) : $@convention(method) (@guaranteed B) -> Int // user: %6
   strong_release %0 : $B                          // id: %5
   return %4 : $Int                                // id: %6

--- a/test/SILOptimizer/devirt_alloc_ref_dynamic.sil
+++ b/test/SILOptimizer/devirt_alloc_ref_dynamic.sil
@@ -33,7 +33,7 @@ bb0:
   %1 = metatype $@thick A.Type
   %2 = alloc_ref_dynamic %1 : $@thick A.Type, $A
   strong_retain %2 : $A
-  %8 = class_method %2 : $A, #A.foo!1 : (A) -> () -> Int32 , $@convention(method) (@guaranteed A) -> Int32
+  %8 = class_method %2 : $A, #A.foo!1 : (A) -> () -> Int32, $@convention(method) (@guaranteed A) -> Int32
   %9 = apply %8(%2) : $@convention(method) (@guaranteed A) -> Int32
   strong_release %2 : $A
   return %9 : $Int32

--- a/test/SILOptimizer/devirt_ctors.sil
+++ b/test/SILOptimizer/devirt_ctors.sil
@@ -34,9 +34,9 @@ bb0:
   // function_ref main.ABC.init (main.ABC.Type)(y : Swift.Int64) -> main.ABC
   %3 = function_ref @_TFC4main3ABCcfMS0_FT1ySi_S0_ : $@convention(method) (Int64, @owned ABC) -> @owned ABC // user: %4
   %4 = apply %3(%1, %2) : $@convention(method) (Int64, @owned ABC) -> @owned ABC // users: %7, %6, %5, %10, %9, %8, %11
-  %6 = class_method %4 : $ABC, #ABC.member!1 : (ABC) -> () -> () , $@convention(method) (@guaranteed ABC) -> () // user: %7
+  %6 = class_method %4 : $ABC, #ABC.member!1 : (ABC) -> () -> (), $@convention(method) (@guaranteed ABC) -> () // user: %7
   %7 = apply %6(%4) : $@convention(method) (@guaranteed ABC) -> ()
-  %9 = class_method %4 : $ABC, #ABC.member2!1 : (ABC) -> () -> () , $@convention(method) (@guaranteed ABC) -> () // user: %10
+  %9 = class_method %4 : $ABC, #ABC.member2!1 : (ABC) -> () -> (), $@convention(method) (@guaranteed ABC) -> () // user: %10
   %10 = apply %9(%4) : $@convention(method) (@guaranteed ABC) -> ()
   strong_release %4 : $ABC                        // id: %11
   %12 = tuple ()                                  // user: %13

--- a/test/SILOptimizer/devirt_jump_thread.sil
+++ b/test/SILOptimizer/devirt_jump_thread.sil
@@ -117,7 +117,7 @@ bb5(%34 : $FooClass):                             // Preds: bb0
   br bb1(%37 : $Int32)                              // id: %40
 
 bb6:                                              // Preds: bb0
-  %41 = class_method %0 : $FooClass, #FooClass.foo!1 : (FooClass) -> (Int32) -> Int32 , $@convention(method) (Int32, @guaranteed FooClass) -> Int32 // user: %43
+  %41 = class_method %0 : $FooClass, #FooClass.foo!1 : (FooClass) -> (Int32) -> Int32, $@convention(method) (Int32, @guaranteed FooClass) -> Int32 // user: %43
   strong_retain %0 : $FooClass                    // id: %42
   %43 = apply %41(%2, %0) : $@convention(method) (Int32, @guaranteed FooClass) -> Int32 // user: %44
   br bb1(%43 : $Int32)                              // id: %44
@@ -132,7 +132,7 @@ bb7(%45 : $FooClass):                             // Preds: bb1
   br bb2(%48 : $Int32)                              // id: %51
 
 bb8:                                              // Preds: bb1
-  %52 = class_method %0 : $FooClass, #FooClass.foo!1 : (FooClass) -> (Int32) -> Int32 , $@convention(method) (Int32, @guaranteed FooClass) -> Int32 // user: %54
+  %52 = class_method %0 : $FooClass, #FooClass.foo!1 : (FooClass) -> (Int32) -> Int32, $@convention(method) (Int32, @guaranteed FooClass) -> Int32 // user: %54
   strong_retain %0 : $FooClass                    // id: %53
   %54 = apply %52(%2, %0) : $@convention(method) (Int32, @guaranteed FooClass) -> Int32 // user: %55
   br bb2(%54 : $Int32)                              // id: %55
@@ -147,7 +147,7 @@ bb9(%56 : $FooClass):                             // Preds: bb2
   br bb3(%59 : $Int32)                              // id: %62
 
 bb10:                                             // Preds: bb2
-  %63 = class_method %0 : $FooClass, #FooClass.foo!1 : (FooClass) -> (Int32) -> Int32 , $@convention(method) (Int32, @guaranteed FooClass) -> Int32 // user: %65
+  %63 = class_method %0 : $FooClass, #FooClass.foo!1 : (FooClass) -> (Int32) -> Int32, $@convention(method) (Int32, @guaranteed FooClass) -> Int32 // user: %65
   strong_retain %0 : $FooClass                    // id: %64
   %65 = apply %63(%15, %0) : $@convention(method) (Int32, @guaranteed FooClass) -> Int32 // user: %66
   br bb3(%65 : $Int32)                              // id: %66
@@ -161,7 +161,7 @@ bb11(%67 : $FooClass):                            // Preds: bb3
   br bb4(%69 : $Int32)                              // id: %72
 
 bb12:                                             // Preds: bb3
-  %73 = class_method %0 : $FooClass, #FooClass.foo!1 : (FooClass) -> (Int32) -> Int32 , $@convention(method) (Int32, @guaranteed FooClass) -> Int32 // user: %74
+  %73 = class_method %0 : $FooClass, #FooClass.foo!1 : (FooClass) -> (Int32) -> Int32, $@convention(method) (Int32, @guaranteed FooClass) -> Int32 // user: %74
   %74 = apply %73(%24, %0) : $@convention(method) (Int32, @guaranteed FooClass) -> Int32 // user: %75
   br bb4(%74 : $Int32)                              // id: %75
 }
@@ -202,7 +202,7 @@ bb3(%14 : $FooClass):                             // Preds: bb0
   br bb1(%16 : $Int32)                              // id: %17
 
 bb4:                                              // Preds: bb0
-  %18 = class_method %0 : $FooClass, #FooClass.value!getter.1 : (FooClass) -> () -> Int32 , $@convention(method) (@guaranteed FooClass) -> Int32 // user: %20
+  %18 = class_method %0 : $FooClass, #FooClass.value!getter.1 : (FooClass) -> () -> Int32, $@convention(method) (@guaranteed FooClass) -> Int32 // user: %20
   strong_retain %0 : $FooClass                    // id: %19
   %20 = apply %18(%0) : $@convention(method) (@guaranteed FooClass) -> Int32 // user: %21
   br bb1(%20 : $Int32)                              // id: %21
@@ -214,7 +214,7 @@ bb5(%22 : $FooClass):                             // Preds: bb1
   br bb2(%24 : $Int32)                              // id: %26
 
 bb6:                                              // Preds: bb1
-  %27 = class_method %0 : $FooClass, #FooClass.value!getter.1 : (FooClass) -> () -> Int32 , $@convention(method) (@guaranteed FooClass) -> Int32 // user: %28
+  %27 = class_method %0 : $FooClass, #FooClass.value!getter.1 : (FooClass) -> () -> Int32, $@convention(method) (@guaranteed FooClass) -> Int32 // user: %28
   %28 = apply %27(%0) : $@convention(method) (@guaranteed FooClass) -> Int32 // user: %29
   br bb2(%28 : $Int32)                              // id: %29
 }
@@ -257,7 +257,7 @@ bb3(%14 : $FooClass):                             // Preds: bb0
   br bb1(%16 : $Int32)                              // id: %17
 
 bb4:                                              // Preds: bb0
-  %18 = class_method %0 : $FooClass, #FooClass.value!getter.1 : (FooClass) -> () -> Int32 , $@convention(method) (@guaranteed FooClass) -> Int32 // user: %20
+  %18 = class_method %0 : $FooClass, #FooClass.value!getter.1 : (FooClass) -> () -> Int32, $@convention(method) (@guaranteed FooClass) -> Int32 // user: %20
   %20 = apply %18(%0) : $@convention(method) (@guaranteed FooClass) -> Int32 // user: %21
   br bb1(%20 : $Int32)                              // id: %21
 
@@ -267,7 +267,7 @@ bb5(%22 : $FooClass):                             // Preds: bb1
   br bb2(%24 : $Int32)                              // id: %26
 
 bb6:                                              // Preds: bb1
-  %27 = class_method %0 : $FooClass, #FooClass.value!getter.1 : (FooClass) -> () -> Int32 , $@convention(method) (@guaranteed FooClass) -> Int32 // user: %28
+  %27 = class_method %0 : $FooClass, #FooClass.value!getter.1 : (FooClass) -> () -> Int32, $@convention(method) (@guaranteed FooClass) -> Int32 // user: %28
   %28 = apply %27(%0) : $@convention(method) (@guaranteed FooClass) -> Int32 // user: %29
   br bb2(%28 : $Int32)                              // id: %29
 }
@@ -291,7 +291,7 @@ bb0(%0 : $FooClass):
   checked_cast_br [exact] %0 : $FooClass to $FooClass, bb3, bb4 // id: %1
 
 bb1(%2 : $Int32):                                   // Preds: bb3 bb4
-  %101 = class_method [volatile] %100 : $Bar, #Bar.foo!1.foreign : (Bar) -> () -> () , $@convention(objc_method) (Bar) -> ()
+  %101 = class_method [volatile] %100 : $Bar, #Bar.foo!1.foreign : (Bar) -> () -> (), $@convention(objc_method) (Bar) -> ()
   checked_cast_br [exact] %0 : $FooClass to $FooClass, bb5, bb6 // id: %3
 
 bb2(%4 : $Int32):                                   // Preds: bb5 bb6
@@ -311,7 +311,7 @@ bb3(%14 : $FooClass):                             // Preds: bb0
   br bb1(%16 : $Int32)                              // id: %17
 
 bb4:                                              // Preds: bb0
-  %18 = class_method %0 : $FooClass, #FooClass.value!getter.1 : (FooClass) -> () -> Int32 , $@convention(method) (@guaranteed FooClass) -> Int32 // user: %20
+  %18 = class_method %0 : $FooClass, #FooClass.value!getter.1 : (FooClass) -> () -> Int32, $@convention(method) (@guaranteed FooClass) -> Int32 // user: %20
   strong_retain %0 : $FooClass                    // id: %19
   %20 = apply %18(%0) : $@convention(method) (@guaranteed FooClass) -> Int32 // user: %21
   br bb1(%20 : $Int32)                              // id: %21
@@ -323,7 +323,7 @@ bb5(%22 : $FooClass):                             // Preds: bb1
   br bb2(%24 : $Int32)                              // id: %26
 
 bb6:                                              // Preds: bb1
-  %27 = class_method %0 : $FooClass, #FooClass.value!getter.1 : (FooClass) -> () -> Int32 , $@convention(method) (@guaranteed FooClass) -> Int32 // user: %28
+  %27 = class_method %0 : $FooClass, #FooClass.value!getter.1 : (FooClass) -> () -> Int32, $@convention(method) (@guaranteed FooClass) -> Int32 // user: %28
   %28 = apply %27(%0) : $@convention(method) (@guaranteed FooClass) -> Int32 // user: %29
   br bb2(%28 : $Int32)                              // id: %29
 }

--- a/test/SILOptimizer/devirt_override.sil
+++ b/test/SILOptimizer/devirt_override.sil
@@ -38,7 +38,7 @@ bb0:
   strong_retain %69 : $Hash
   // CHECK: function_ref @_TFC4test3MD54hashfS0_FT3MsgVs5UInt8_T_ : $@convention(method) (@guaranteed MD5) -> ()
   // CHECK: apply {{%[0-9]+}}({{%[0-9]+}}) : $@convention(method) (@guaranteed MD5) -> ()
-  %134 = class_method %69 : $Hash, #Hash.hash!1 : (Hash) -> () -> () , $@convention(method) (@guaranteed Hash) -> ()
+  %134 = class_method %69 : $Hash, #Hash.hash!1 : (Hash) -> () -> (), $@convention(method) (@guaranteed Hash) -> ()
   %135 = apply %134(%69) : $@convention(method) (@guaranteed Hash) -> ()
   strong_release %2 : $MD5
   %17 = tuple ()
@@ -54,7 +54,7 @@ bb0:
   %61 = upcast %21 : $MD5 to $Hash
   // CHECK: function_ref @_TFC9hash2_new4Hash6updatefS0_FT3MsgVs5UInt83CntSi_T_ : $@convention(method) (@guaranteed Hash) -> ()
   // CHECK: apply {{%[0-9]+}}({{%[0-9]+}}) : $@convention(method) (@guaranteed Hash) -> ()
-  %62 = class_method %61 : $Hash, #Hash.update!1 : (Hash) -> () -> () , $@convention(method) (@guaranteed Hash) -> ()
+  %62 = class_method %61 : $Hash, #Hash.update!1 : (Hash) -> () -> (), $@convention(method) (@guaranteed Hash) -> ()
   %135 = apply %62(%61) : $@convention(method) (@guaranteed Hash) -> ()
   %17 = tuple ()
   // CHECK: return
@@ -115,7 +115,7 @@ bb0:
   %0 = alloc_ref $E
   %1 = upcast %0 : $E to $C
   %2 = unconditional_checked_cast %1 : $C to $D
-  %3 = class_method %2 : $D, #D.doIt!1 : (D) -> () -> () , $@convention(method) (@guaranteed D) -> ()
+  %3 = class_method %2 : $D, #D.doIt!1 : (D) -> () -> (), $@convention(method) (@guaranteed D) -> ()
   %4 = apply %3(%2) : $@convention(method) (@guaranteed D) -> ()
   %5 = tuple ()
 // CHECK: return

--- a/test/SILOptimizer/devirt_single_module_in_multiple_files.swift
+++ b/test/SILOptimizer/devirt_single_module_in_multiple_files.swift
@@ -7,11 +7,11 @@ public func test() {
 }
 
 // CHECK-LABEL: sil shared @_T038devirt_single_module_in_multiple_files9EvaluatorCACycfcSiycfU_
-// CHECK: %{{.*}} = class_method %{{.*}} : $Problem1, #Problem1.run!1 : (Problem1) -> () -> Int , $@convention(method) (@guaranteed Problem1) -> Int
+// CHECK: %{{.*}} = class_method %{{.*}} : $Problem1, #Problem1.run!1 : (Problem1) -> () -> Int, $@convention(method) (@guaranteed Problem1) -> Int
 // CHECK-NEXT: apply
 // CHECK: return
 
 // CHECK-LABEL: sil shared @_T038devirt_single_module_in_multiple_files9EvaluatorCACycfcSiycfU0_
-// CHECK: %{{.*}} = class_method %{{.*}} : $Problem2, #Problem2.run!1 : (Problem2) -> () -> Int , $@convention(method) (@guaranteed Problem2) -> Int
+// CHECK: %{{.*}} = class_method %{{.*}} : $Problem2, #Problem2.run!1 : (Problem2) -> () -> Int, $@convention(method) (@guaranteed Problem2) -> Int
 // CHECK-NEXT: apply
 // CHECK: return

--- a/test/SILOptimizer/devirt_speculate.swift
+++ b/test/SILOptimizer/devirt_speculate.swift
@@ -38,7 +38,7 @@ class Sub7 : Base {
 // CHECK: checked_cast_br [exact] %0 : $Base to $Sub5
 // CHECK: checked_cast_br [exact] %0 : $Base to $Sub6
 // CHECK-NOT: checked_cast_br
-// CHECK: %[[CM:[0-9]+]] = class_method %0 : $Base, #Base.foo!1 : (Base) -> () -> () , $@convention(method) (@guaranteed Base) -> ()
+// CHECK: %[[CM:[0-9]+]] = class_method %0 : $Base, #Base.foo!1 : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
 // CHECK: apply %[[CM]](%0) : $@convention(method) (@guaranteed Base) -> ()
 public func testMaxNumSpeculativeTargets(_ b: Base) {
   b.foo()

--- a/test/SILOptimizer/devirt_speculative.sil
+++ b/test/SILOptimizer/devirt_speculative.sil
@@ -35,7 +35,7 @@ sil_vtable Sub {
 
 sil @test_objc_ancestry : $@convention(thin) (@guaranteed Base) -> () {
 bb0(%0: $Base):
-  %1 = class_method %0 : $Base, #Base.foo!1 : (Base) -> () -> () , $@convention(method) (@guaranteed Base) -> ()
+  %1 = class_method %0 : $Base, #Base.foo!1 : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
   %2 = apply %1(%0) : $@convention(method) (@guaranteed Base) -> ()
   %3 = tuple()
   return %3 : $()
@@ -45,7 +45,7 @@ bb0(%0: $Base):
 
 // CHECK-LABEL: sil @test_objc_ancestry
 // CHECK: bb0
-// CHECK:  [[METH:%.*]] = class_method %0 : $Base, #Base.foo!1 : (Base) -> () -> () , $@convention(method) (@guaranteed Base) -> ()
+// CHECK:  [[METH:%.*]] = class_method %0 : $Base, #Base.foo!1 : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
 // CHECK:  checked_cast_br [exact] %0 : $Base to $Base, bb{{.*}}, bb[[CHECK2:[0-9]+]]
 // CHECK: bb[[CHECK2]]{{.*}}:
 // CHECK:  checked_cast_br [exact] %0 : $Base to $Sub, bb{{.*}}, bb[[GENCALL:[0-9]+]]
@@ -90,7 +90,7 @@ sil_vtable Sub2 {
 
 sil @test_objc_ancestry2 : $@convention(thin) (@guaranteed Base2) -> () {
 bb0(%0: $Base2):
-  %1 = class_method %0 : $Base2, #Base2.foo!1 : (Base2) -> () -> () , $@convention(method) (@guaranteed Base2) -> ()
+  %1 = class_method %0 : $Base2, #Base2.foo!1 : (Base2) -> () -> (), $@convention(method) (@guaranteed Base2) -> ()
   %2 = apply %1(%0) : $@convention(method) (@guaranteed Base2) -> ()
   %3 = tuple()
   return %3 : $()
@@ -98,7 +98,7 @@ bb0(%0: $Base2):
 
 // CHECK-LABEL: sil @test_objc_ancestry2
 // CHECK: bb0
-// CHECK:  [[METH:%.*]] = class_method %0 : $Base2, #Base2.foo!1 : (Base2) -> () -> () , $@convention(method) (@guaranteed Base2) -> ()
+// CHECK:  [[METH:%.*]] = class_method %0 : $Base2, #Base2.foo!1 : (Base2) -> () -> (), $@convention(method) (@guaranteed Base2) -> ()
 // CHECK:  checked_cast_br [exact] %0 : $Base2 to $Base2, bb{{.*}}, bb[[CHECK2:[0-9]+]]
 // CHECK: bb[[CHECK2]]{{.*}}:
 // CHECK:  checked_cast_br [exact] %0 : $Base2 to $Sub2, bb{{.*}}, bb[[GENCALL:[0-9]+]]

--- a/test/SILOptimizer/devirt_try_apply.sil
+++ b/test/SILOptimizer/devirt_try_apply.sil
@@ -372,7 +372,7 @@ sil [transparent] [thunk] @_TTWC16devirt_try_apply3CP1S_1PS_FS1_3foouRq_S1__fq_F
 bb0(%0 : $*CP1):
   %1 = load %0 : $*CP1
   strong_retain %1 : $CP1
-  %3 = class_method %1 : $CP1, #CP1.foo!1 : (CP1) -> () throws -> Int32 , $@convention(method) (@guaranteed CP1) -> (Int32, @error Error)
+  %3 = class_method %1 : $CP1, #CP1.foo!1 : (CP1) -> () throws -> Int32, $@convention(method) (@guaranteed CP1) -> (Int32, @error Error)
   try_apply %3(%1) : $@convention(method) (@guaranteed CP1) -> (Int32, @error Error), normal bb1, error bb2
 
 bb1(%5 : $Int32):
@@ -459,7 +459,7 @@ bb0(%0 : $Base):
   %6 = load %3 : $*Optional<Int32>
   store %6 to %1 : $*Optional<Int32>
   dealloc_stack %3 : $*Optional<Int32>
-  %9 = class_method %0 : $Base, #Base.foo!1 : (Base) -> () throws -> Int32? , $@convention(method) (@guaranteed Base) -> (Optional<Int32>, @error Error)
+  %9 = class_method %0 : $Base, #Base.foo!1 : (Base) -> () throws -> Int32?, $@convention(method) (@guaranteed Base) -> (Optional<Int32>, @error Error)
   try_apply %9(%0) : $@convention(method) (@guaranteed Base) -> (Optional<Int32>, @error Error), normal bb1, error bb4
 
 bb1(%11 : $Optional<Int32>):
@@ -499,7 +499,7 @@ bb0(%0 : $Base):
   %6 = load %3 : $*Optional<Base>
   store %6 to %1 : $*Optional<Base>
   dealloc_stack %3 : $*Optional<Base>
-  %9 = class_method %0 : $Base, #Base.boo1!1 : (Base) -> () throws -> Base , $@convention(method) (@guaranteed Base) -> (@owned Base, @error Error)
+  %9 = class_method %0 : $Base, #Base.boo1!1 : (Base) -> () throws -> Base, $@convention(method) (@guaranteed Base) -> (@owned Base, @error Error)
   try_apply %9(%0) : $@convention(method) (@guaranteed Base) -> (@owned Base, @error Error), normal bb1, error bb4
 
 bb1(%11 : $Base):
@@ -540,7 +540,7 @@ bb0(%0 : $Base):
   %6 = load %3 : $*Optional<Base>
   store %6 to %1 : $*Optional<Base>
   dealloc_stack %3 : $*Optional<Base>
-  %9 = class_method %0 : $Base, #Base.boo2!1 : (Base) -> () throws -> Base? , $@convention(method) (@guaranteed Base) -> (@owned Optional<Base>, @error Error)
+  %9 = class_method %0 : $Base, #Base.boo2!1 : (Base) -> () throws -> Base?, $@convention(method) (@guaranteed Base) -> (@owned Optional<Base>, @error Error)
   try_apply %9(%0) : $@convention(method) (@guaranteed Base) -> (@owned Optional<Base>, @error Error), normal bb1, error bb4
 
 bb1(%11 : $Optional<Base>):
@@ -629,7 +629,7 @@ bb0:
   %5 = integer_literal $Builtin.Int32, 0
   %6 = struct $Int32 (%5 : $Builtin.Int32)
   store %6 to %0 : $*Int32
-  %8 = class_method %3 : $CP2, #CP2.foo!1 : (CP2) -> () throws -> Int32 , $@convention(method) (@guaranteed CP2) -> (Int32, @error Error)
+  %8 = class_method %3 : $CP2, #CP2.foo!1 : (CP2) -> () throws -> Int32, $@convention(method) (@guaranteed CP2) -> (Int32, @error Error)
   try_apply %8(%3) : $@convention(method) (@guaranteed CP2) -> (Int32, @error Error), normal bb1, error bb4
 
 bb1(%10 : $Int32):
@@ -715,7 +715,7 @@ bb0:
   %6 = struct $Int32 (%5 : $Builtin.Int32)
   %7 = enum $Optional<Int32>, #Optional.some!enumelt.1, %6 : $Int32
   store %7 to %0 : $*Optional<Int32>
-  %9 = class_method %3 : $Derived1, #Derived1.foo!1 : (Derived1) -> () throws -> Int32? , $@convention(method) (@guaranteed Derived1) -> (Optional<Int32>, @error Error)
+  %9 = class_method %3 : $Derived1, #Derived1.foo!1 : (Derived1) -> () throws -> Int32?, $@convention(method) (@guaranteed Derived1) -> (Optional<Int32>, @error Error)
   try_apply %9(%3) : $@convention(method) (@guaranteed Derived1) -> (Optional<Int32>, @error Error), normal bb1, error bb4
 
 bb1(%11 : $Optional<Int32>):
@@ -758,7 +758,7 @@ bb0:
   %5 = integer_literal $Builtin.Int32, 0
   %6 = struct $Int32 (%5 : $Builtin.Int32)
   store %6 to %0 : $*Int32
-  %8 = class_method %1 : $CP2, #CP2.foo!1 : (CP2) -> () throws -> Int32 , $@convention(method) (@guaranteed CP2) -> (Int32, @error Error)
+  %8 = class_method %1 : $CP2, #CP2.foo!1 : (CP2) -> () throws -> Int32, $@convention(method) (@guaranteed CP2) -> (Int32, @error Error)
   try_apply %8(%1) : $@convention(method) (@guaranteed CP2) -> (Int32, @error Error), normal bb1, error bb4
 
 bb1(%10 : $Int32):
@@ -827,7 +827,7 @@ sil @test_devirt_try_apply_at_Onone : $@convention(thin) () -> (@owned Optional<
 bb0:
   %2 = alloc_ref $D3
   %3 = upcast %2 : $D3 to $D1
-  %4 = class_method %3 : $D1, #D1.f1!1 : (D1) -> () throws -> Optional<A> , $@convention(method) (@guaranteed D1) -> (@owned Optional<A>, @error Error)
+  %4 = class_method %3 : $D1, #D1.f1!1 : (D1) -> () throws -> Optional<A>, $@convention(method) (@guaranteed D1) -> (@owned Optional<A>, @error Error)
   try_apply %4(%3) : $@convention(method) (@guaranteed D1) -> (@owned Optional<A>, @error Error), normal bb1, error bb2
 
 bb1(%6 : $Optional<A>):

--- a/test/SILOptimizer/devirtualize.sil
+++ b/test/SILOptimizer/devirtualize.sil
@@ -24,7 +24,7 @@ bb0:
   %1 = alloc_ref $Bar                             // user: %2
   store %1 to %0 : $*Bar                          // id: %2
   %3 = load %0 : $*Bar                            // users: %6, %5, %4
-  %5 = class_method %1 : $Bar, #Bar.foo!1 : (Bar) -> () -> () , $@convention(method) (@guaranteed Bar) -> () // user: %6
+  %5 = class_method %1 : $Bar, #Bar.foo!1 : (Bar) -> () -> (), $@convention(method) (@guaranteed Bar) -> () // user: %6
   %6 = apply %5(%1) : $@convention(method) (@guaranteed Bar) -> ()
   release_value %1 : $Bar
   %7 = tuple ()                                   // user: %8
@@ -50,7 +50,7 @@ bb0(%0 : $Node):
   strong_retain %0 : $Node
   // CHECK-NOT: class_method %0
   // CHECK: [[FUNC:%.*]] = function_ref @transparent_target
-  %3 = class_method %0 : $Node, #Node.index!getter.1 : (Node) -> () -> Int , $@convention(method) (@guaranteed Node) -> Int
+  %3 = class_method %0 : $Node, #Node.index!getter.1 : (Node) -> () -> Int, $@convention(method) (@guaranteed Node) -> Int
   // CHECK: [[RESULT:%.*]] = apply [[FUNC]](%0)
   %4 = apply %3(%0) : $@convention(method) (@guaranteed Node) -> Int
   // CHECK: strong_release %0
@@ -86,7 +86,7 @@ bb0(%0 : $@thick C.Type):
   %2 = upcast %0 : $@thick C.Type to $@thick B.Type
   // CHECK-NOT: class_method
   // CHECK: function_ref @_TZFC4metaP33_7026FC13D35FB9700BACF693F51A99011B3foofMS0_FT_Si
-  %3 = class_method %2 : $@thick B.Type, #B.foo!1 : (B.Type) -> () -> Int , $@convention(method) (@thick B.Type) -> Int
+  %3 = class_method %2 : $@thick B.Type, #B.foo!1 : (B.Type) -> () -> Int, $@convention(method) (@thick B.Type) -> Int
   %4 = apply %3(%2) : $@convention(method) (@thick B.Type) -> Int
   %5 = tuple ()
   // CHECK: return

--- a/test/SILOptimizer/devirtualize2.sil
+++ b/test/SILOptimizer/devirtualize2.sil
@@ -35,7 +35,7 @@ bb0:
   store %6 to %0 : $*Bar                          // id: %7
   %8 = load %0 : $*Bar                            // users: %11, %10, %9
   strong_retain %6 : $Bar                         // id: %9
-  %10 = class_method %6 : $Bar, #Bar.ping!1 : (Bar) -> () -> () , $@convention(method) (@guaranteed Bar) -> () // user: %11
+  %10 = class_method %6 : $Bar, #Bar.ping!1 : (Bar) -> () -> (), $@convention(method) (@guaranteed Bar) -> () // user: %11
   %11 = apply %10(%8) : $@convention(method) (@guaranteed Bar) -> ()
   %12 = tuple ()                                  // user: %13
   return %12 : $()                                // id: %13
@@ -62,7 +62,7 @@ bb3(%3 : $Bar):
 
 bb4(%4 : $Bar):
   // Devirtualizer should be able to figure out that the exact dynamic type of %1 is Bar.
-  %5 = class_method %4 : $Bar, #Bar.ping!1 : (Bar) -> () -> () , $@convention(method) (@guaranteed Bar) -> ()
+  %5 = class_method %4 : $Bar, #Bar.ping!1 : (Bar) -> () -> (), $@convention(method) (@guaranteed Bar) -> ()
   %6 = apply %5(%4) : $@convention(method) (@guaranteed Bar) -> ()
   br bb6
 
@@ -94,7 +94,7 @@ bb2:
 
 bb3(%4 : $Bar):
   // Devirtualizer should be able to figure out that the exact dynamic type of %4 is Bar.
-  %5 = class_method %4 : $Bar, #Bar.ping!1 : (Bar) -> () -> () , $@convention(method) (@guaranteed Bar) -> ()
+  %5 = class_method %4 : $Bar, #Bar.ping!1 : (Bar) -> () -> (), $@convention(method) (@guaranteed Bar) -> ()
   %6 = apply %5(%4) : $@convention(method) (@guaranteed Bar) -> ()
   br bb4
 

--- a/test/SILOptimizer/eager_specialize.sil
+++ b/test/SILOptimizer/eager_specialize.sil
@@ -225,7 +225,7 @@ bb2:                                              // Preds: bb0
 // CHECK:   throw %{{.*}} : $Error
 
 // CHECK: bb4:                                              // Preds: bb1
-// CHECK:   %{{.*}} = witness_method $T, #IntegerArithmetic."/"!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : IntegerArithmetic> (@in τ_0_0, @in τ_0_0, @thick τ_0_0.Type) -> @out τ_0_0
+// CHECK:   %{{.*}} = witness_method $T, #IntegerArithmetic."/"!1 : {{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : IntegerArithmetic> (@in τ_0_0, @in τ_0_0, @thick τ_0_0.Type) -> @out τ_0_0
 // CHECK:   apply %{{.*}}<T>({{.*}}) : $@convention(witness_method) <τ_0_0 where τ_0_0 : IntegerArithmetic> (@in τ_0_0, @in τ_0_0, @thick τ_0_0.Type) -> @out τ_0_0
 // CHECK:   br bb5
 

--- a/test/SILOptimizer/earlycodemotion.sil
+++ b/test/SILOptimizer/earlycodemotion.sil
@@ -635,7 +635,7 @@ bb1:
 // CHECK-NOT: strong_retain
   %17 = load %0 : $*Test
   strong_retain %17 : $Test
-  %19 = class_method %17 : $Test, #Test.testing!1 : (Test) -> () -> UInt64 , $@convention(method) (@guaranteed Test) -> UInt64
+  %19 = class_method %17 : $Test, #Test.testing!1 : (Test) -> () -> UInt64, $@convention(method) (@guaranteed Test) -> UInt64
   %20 = load %7 : $*UInt64
   checked_cast_br [exact] %17 : $Test to $Test, bb3, bb4
 bb2:
@@ -1358,7 +1358,7 @@ bb4(%10 : $X):                                    // Preds: bb1
   br bb2                                          // id: %12
 
 bb5:                                              // Preds: bb1
-  %13 = class_method %3 : $X, #X.ping!1 : (X) -> () -> () , $@convention(method) (@guaranteed X) -> () // user: %14
+  %13 = class_method %3 : $X, #X.ping!1 : (X) -> () -> (), $@convention(method) (@guaranteed X) -> () // user: %14
   %14 = apply %13(%3) : $@convention(method) (@guaranteed X) -> ()
   strong_release %3 : $X                          // id: %15
   br bb2                                          // id: %16
@@ -1384,7 +1384,7 @@ bb0(%0 : $X):
 bb1(%3 : $Y):                                     // Preds: bb0
   debug_value %3 : $Y, let, name "z" // id: %4
   %5 = upcast %3 : $Y to $X                       // users: %6, %7, %21, %23
-  %6 = class_method %5 : $X, #X.ping!1 : (X) -> () -> () , $@convention(method) (@guaranteed X) -> () // users: %21, %23
+  %6 = class_method %5 : $X, #X.ping!1 : (X) -> () -> (), $@convention(method) (@guaranteed X) -> () // users: %21, %23
   checked_cast_br [exact] %5 : $X to $Y, bb5, bb6 // id: %7
 
 bb2:                                              // Preds: bb5 bb6

--- a/test/SILOptimizer/function_order.sil
+++ b/test/SILOptimizer/function_order.sil
@@ -149,7 +149,7 @@ public class public_derived : public_base {
 sil private [noinline] @call_private : $@convention(thin) (@owned private_base) -> () {
 bb0(%0 : $private_base):
   debug_value %0 : $private_base
-  %2 = class_method %0 : $private_base, #private_base.foo!1 : (private_base) -> () -> () , $@convention(method) (@guaranteed private_base) -> ()
+  %2 = class_method %0 : $private_base, #private_base.foo!1 : (private_base) -> () -> (), $@convention(method) (@guaranteed private_base) -> ()
   %3 = apply %2(%0) : $@convention(method) (@guaranteed private_base) -> ()
   strong_release %0 : $private_base
   %5 = tuple ()
@@ -175,9 +175,9 @@ bb0(%0 : $private_base):
 sil hidden [noinline] @call_internal : $@convention(thin) (@owned internal_base) -> () {
 bb0(%0 : $internal_base):
   debug_value %0 : $internal_base
-  %2 = class_method %0 : $internal_base, #internal_base.foo!1 : (internal_base) -> () -> () , $@convention(method) (@guaranteed internal_base) -> ()
+  %2 = class_method %0 : $internal_base, #internal_base.foo!1 : (internal_base) -> () -> (), $@convention(method) (@guaranteed internal_base) -> ()
   %3 = apply %2(%0) : $@convention(method) (@guaranteed internal_base) -> ()
-  %4 = class_method %0 : $internal_base, #internal_base.bar!1 : (internal_base) -> () -> () , $@convention(method) (@guaranteed internal_base) -> ()
+  %4 = class_method %0 : $internal_base, #internal_base.bar!1 : (internal_base) -> () -> (), $@convention(method) (@guaranteed internal_base) -> ()
   %5 = apply %4(%0) : $@convention(method) (@guaranteed internal_base) -> ()
   strong_release %0 : $internal_base
   %7 = tuple ()
@@ -216,11 +216,11 @@ bb0(%0 : $internal_derived):
 sil hidden [noinline] @call_public : $@convention(thin) (@owned public_base) -> () {
 bb0(%0 : $public_base):
   debug_value %0 : $public_base
-  %2 = class_method %0 : $public_base, #public_base.foo!1 : (public_base) -> () -> () , $@convention(method) (@guaranteed public_base) -> ()
+  %2 = class_method %0 : $public_base, #public_base.foo!1 : (public_base) -> () -> (), $@convention(method) (@guaranteed public_base) -> ()
   %3 = apply %2(%0) : $@convention(method) (@guaranteed public_base) -> ()
-  %4 = class_method %0 : $public_base, #public_base.bar!1 : (public_base) -> () -> () , $@convention(method) (@guaranteed public_base) -> ()
+  %4 = class_method %0 : $public_base, #public_base.bar!1 : (public_base) -> () -> (), $@convention(method) (@guaranteed public_base) -> ()
   %5 = apply %4(%0) : $@convention(method) (@guaranteed public_base) -> ()
-  %6 = class_method %0 : $public_base, #public_base.baz!1 : (public_base) -> () -> () , $@convention(method) (@guaranteed public_base) -> ()
+  %6 = class_method %0 : $public_base, #public_base.baz!1 : (public_base) -> () -> (), $@convention(method) (@guaranteed public_base) -> ()
   %7 = apply %6(%0) : $@convention(method) (@guaranteed public_base) -> ()
   strong_release %0 : $public_base
   %9 = tuple ()
@@ -357,7 +357,7 @@ sil private [transparent] [thunk] @private_proto_1_private_class_witness : $@con
 bb0(%0 : $*private_proto_private_class):
   %1 = load %0 : $*private_proto_private_class
   strong_retain %1 : $private_proto_private_class
-  %3 = class_method %1 : $private_proto_private_class, #private_proto_private_class.theMethod!1 : (private_proto_private_class) -> () -> () , $@convention(method) (@guaranteed private_proto_private_class) -> ()
+  %3 = class_method %1 : $private_proto_private_class, #private_proto_private_class.theMethod!1 : (private_proto_private_class) -> () -> (), $@convention(method) (@guaranteed private_proto_private_class) -> ()
   %4 = apply %3(%1) : $@convention(method) (@guaranteed private_proto_private_class) -> ()
   strong_release %1 : $private_proto_private_class
   return %4 : $()
@@ -384,7 +384,7 @@ sil private [transparent] [thunk] @private_proto_2_internal_class_witness : $@co
 bb0(%0 : $*private_proto_internal_class):
   %1 = load %0 : $*private_proto_internal_class
   strong_retain %1 : $private_proto_internal_class
-  %3 = class_method %1 : $private_proto_internal_class, #private_proto_internal_class.theMethod!1 : (private_proto_internal_class) -> () -> () , $@convention(method) (@guaranteed private_proto_internal_class) -> ()
+  %3 = class_method %1 : $private_proto_internal_class, #private_proto_internal_class.theMethod!1 : (private_proto_internal_class) -> () -> (), $@convention(method) (@guaranteed private_proto_internal_class) -> ()
   %4 = apply %3(%1) : $@convention(method) (@guaranteed private_proto_internal_class) -> ()
   strong_release %1 : $private_proto_internal_class
   return %4 : $()
@@ -414,7 +414,7 @@ sil private [transparent] [thunk] @private_proto_3_public_class_witness : $@conv
 bb0(%0 : $*private_proto_public_class):
   %1 = load %0 : $*private_proto_public_class
   strong_retain %1 : $private_proto_public_class
-  %3 = class_method %1 : $private_proto_public_class, #private_proto_public_class.theMethod!1 : (private_proto_public_class) -> () -> () , $@convention(method) (@guaranteed private_proto_public_class) -> ()
+  %3 = class_method %1 : $private_proto_public_class, #private_proto_public_class.theMethod!1 : (private_proto_public_class) -> () -> (), $@convention(method) (@guaranteed private_proto_public_class) -> ()
   %4 = apply %3(%1) : $@convention(method) (@guaranteed private_proto_public_class) -> ()
   strong_release %1 : $private_proto_public_class
   return %4 : $()
@@ -442,7 +442,7 @@ sil private [transparent] [thunk] @private_proto_4_public_class_private_method_w
 bb0(%0 : $*private_proto_public_class_private_method):
   %1 = load %0 : $*private_proto_public_class_private_method
   strong_retain %1 : $private_proto_public_class_private_method
-  %3 = class_method %1 : $private_proto_public_class_private_method, #private_proto_public_class_private_method.theMethod!1 : (private_proto_public_class_private_method) -> () -> () , $@convention(method) (@guaranteed private_proto_public_class_private_method) -> ()
+  %3 = class_method %1 : $private_proto_public_class_private_method, #private_proto_public_class_private_method.theMethod!1 : (private_proto_public_class_private_method) -> () -> (), $@convention(method) (@guaranteed private_proto_public_class_private_method) -> ()
   %4 = apply %3(%1) : $@convention(method) (@guaranteed private_proto_public_class_private_method) -> ()
   strong_release %1 : $private_proto_public_class_private_method
   return %4 : $()

--- a/test/SILOptimizer/generic_inline_self.swift
+++ b/test/SILOptimizer/generic_inline_self.swift
@@ -39,7 +39,7 @@ class C : P {
 // CHECK:       bb0(%0 : $C):
 // CHECK:         [[METATYPE:%.*]] = metatype $@thick @dynamic_self C.Type
 // CHECK-NEXT:    [[STATIC_METATYPE:%.*]] = upcast [[METATYPE]] : $@thick @dynamic_self C.Type to $@thick C.Type
-// CHECK-NEXT:    [[FN:%.*]] = class_method [[STATIC_METATYPE]] : $@thick C.Type, #C.init!allocator.1 : (C.Type) -> () -> C , $@convention(method) (@thick C.Type) -> @owned C
+// CHECK-NEXT:    [[FN:%.*]] = class_method [[STATIC_METATYPE]] : $@thick C.Type, #C.init!allocator.1 : (C.Type) -> () -> C, $@convention(method) (@thick C.Type) -> @owned C
 // CHECK-NEXT:    [[RESULT2:%.*]] = apply [[FN]]([[STATIC_METATYPE]]) : $@convention(method) (@thick C.Type) -> @owned C
 // CHECK-NEXT:    [[RESULT:%.*]] = unchecked_ref_cast [[RESULT2]] : $C to $C
 // CHECK-NEXT:    return [[RESULT]] : $C
@@ -51,7 +51,7 @@ class C : P {
 // CHECK:       bb0(%0 : $C):
 // CHECK:         [[METATYPE:%.*]] = metatype $@thick @dynamic_self C.Type
 // CHECK-NEXT:    [[STATIC_METATYPE:%.*]] = upcast [[METATYPE]] : $@thick @dynamic_self C.Type to $@thick C.Type
-// CHECK-NEXT:    [[FN:%.*]] = class_method [[STATIC_METATYPE]] : $@thick C.Type, #C.init!allocator.1 : (C.Type) -> () -> C , $@convention(method) (@thick C.Type) -> @owned C
+// CHECK-NEXT:    [[FN:%.*]] = class_method [[STATIC_METATYPE]] : $@thick C.Type, #C.init!allocator.1 : (C.Type) -> () -> C, $@convention(method) (@thick C.Type) -> @owned C
 // CHECK-NEXT:    [[RESULT2:%.*]] = apply [[FN]]([[STATIC_METATYPE]]) : $@convention(method) (@thick C.Type) -> @owned C
 // CHECK-NEXT:    tuple ()
 // CHECK-NEXT:    tuple ()

--- a/test/SILOptimizer/inline_caches.sil
+++ b/test/SILOptimizer/inline_caches.sil
@@ -24,7 +24,7 @@ bb0(%0 : $Foo):
 
 //CHECK: class_method
 //CHECK-NEXT: apply
-  %1 = class_method %0 : $Foo, #Foo.ping!1 : (Foo) -> () -> () , $@convention(method) (@guaranteed Foo) -> () // user: %2
+  %1 = class_method %0 : $Foo, #Foo.ping!1 : (Foo) -> () -> (), $@convention(method) (@guaranteed Foo) -> () // user: %2
   %2 = apply %1(%0) : $@convention(method) (@guaranteed Foo) -> ()
   %3 = tuple ()                                   // user: %4
   return %3 : $()                                 // id: %4
@@ -60,9 +60,9 @@ bb0(%0 : $@thick C.Type):
   // CHECK: apply [[REF]]
   // CHECK: br bb1
   // CHECK: bb3
-  // CHECK: [[METHOD:%.*]] = class_method %0 : $@thick C.Type, #C.foo!1 : (C.Type) -> () -> () , $@convention(method) (@thick C.Type) -> ()
+  // CHECK: [[METHOD:%.*]] = class_method %0 : $@thick C.Type, #C.foo!1 : (C.Type) -> () -> (), $@convention(method) (@thick C.Type) -> ()
   // CHECK: apply [[METHOD]]
-  %2 = class_method %0 : $@thick C.Type, #C.foo!1 : (C.Type) -> () -> () , $@convention(method) (@thick C.Type) -> ()
+  %2 = class_method %0 : $@thick C.Type, #C.foo!1 : (C.Type) -> () -> (), $@convention(method) (@thick C.Type) -> ()
   %3 = apply %2(%0) : $@convention(method) (@thick C.Type) -> ()
   %4 = tuple ()
   return %4 : $()

--- a/test/SILOptimizer/inline_devirtualize_specialize.sil
+++ b/test/SILOptimizer/inline_devirtualize_specialize.sil
@@ -67,7 +67,7 @@ bb0(%0 : $*C):
   // CHECK-NOT: load
   %1 = load %0 : $*C
   // CHECK-NOT: class_method
-  %3 = class_method %1 : $C, #C.foo!1 : (C) -> () -> Builtin.Int1 , $@convention(method) (@guaranteed C) -> Builtin.Int1
+  %3 = class_method %1 : $C, #C.foo!1 : (C) -> () -> Builtin.Int1, $@convention(method) (@guaranteed C) -> Builtin.Int1
   // CHECK-NOT: apply
   %4 = apply %3(%1) : $@convention(method) (@guaranteed C) -> Builtin.Int1
   // CHECK: [[ONE:%.*]] = integer_literal $Builtin.Int1, -1

--- a/test/SILOptimizer/inlinecaches_arc.sil
+++ b/test/SILOptimizer/inlinecaches_arc.sil
@@ -32,7 +32,7 @@ sil @_TFC4main3FoocfMS0_FT_S0_ : $@convention(method) (@owned Foo) -> @owned Foo
 sil @_TF4main7my_mainFCS_3FooSi : $@convention(thin) (@owned Foo) -> Int {
 bb0(%0 : $Foo):
   debug_value %0 : $Foo, let, name "x" // id: %1
-  %3 = class_method %0 : $Foo, #Foo.ping!1 : (Foo) -> () -> Int , $@convention(method) (@guaranteed Foo) -> Int // user: %4
+  %3 = class_method %0 : $Foo, #Foo.ping!1 : (Foo) -> () -> Int, $@convention(method) (@guaranteed Foo) -> Int // user: %4
   %4 = apply %3(%0) : $@convention(method) (@guaranteed Foo) -> Int // user: %6
   strong_release %0 : $Foo                        // id: %5
   return %4 : $Int                                // id: %6

--- a/test/SILOptimizer/inlinecaches_invalidate_failure.sil
+++ b/test/SILOptimizer/inlinecaches_invalidate_failure.sil
@@ -95,7 +95,7 @@ bb0(%0 : $@thick Foo2.Type):
 sil hidden @_TF4test4mainFCS_3FooS0_ : $@convention(thin) (@owned Foo) -> @owned Foo {
 bb0(%0 : $Foo):
   debug_value %0 : $Foo                           // id: %1
-  %2 = class_method %0 : $Foo, #Foo.doSomething!1 : (Foo) -> () -> Foo , $@convention(method) (@guaranteed Foo) -> @owned Foo // user: %3
+  %2 = class_method %0 : $Foo, #Foo.doSomething!1 : (Foo) -> () -> Foo, $@convention(method) (@guaranteed Foo) -> @owned Foo // user: %3
   %3 = apply %2(%0) : $@convention(method) (@guaranteed Foo) -> @owned Foo // user: %5
   strong_release %0 : $Foo                        // id: %4
   return %3 : $Foo                                // id: %5

--- a/test/SILOptimizer/latecodemotion.sil
+++ b/test/SILOptimizer/latecodemotion.sil
@@ -812,7 +812,7 @@ bb1:
 // CHECK-NOT: strong_retain
   %17 = load %0 : $*Test
   strong_retain %17 : $Test
-  %19 = class_method %17 : $Test, #Test.testing!1 : (Test) -> () -> UInt64 , $@convention(method) (@guaranteed Test) -> UInt64
+  %19 = class_method %17 : $Test, #Test.testing!1 : (Test) -> () -> UInt64, $@convention(method) (@guaranteed Test) -> UInt64
   %20 = load %7 : $*UInt64
   checked_cast_br [exact] %17 : $Test to $Test, bb3, bb4
 bb2:

--- a/test/SILOptimizer/looprotate.sil
+++ b/test/SILOptimizer/looprotate.sil
@@ -50,7 +50,7 @@ bb0(%0 : $Int32, %25: $Bar):
   br bb1(%1 : $Builtin.Int32, %2 : $Builtin.Int32, %25: $Bar, %30 : $<τ_0_0> { var τ_0_0 } <Bool>, %30a : $*Bool)
 
 bb1(%4 : $Builtin.Int32, %5 : $Builtin.Int32, %26: $Bar, %31 : $<τ_0_0> { var τ_0_0 } <Bool>, %32 : $*Bool):
-  %24 = class_method %26 : $Bar, #Bar.foo!1 : (Bar) -> () -> () , $@convention(method) (@guaranteed Bar) -> () // user: %6
+  %24 = class_method %26 : $Bar, #Bar.foo!1 : (Bar) -> () -> (), $@convention(method) (@guaranteed Bar) -> () // user: %6
   %27 = apply %24(%25) : $@convention(method) (@guaranteed Bar) -> ()
   %6 = struct $Int32 (%5 : $Builtin.Int32)
   %8 = builtin "cmp_eq_Word"(%5 : $Builtin.Int32, %1 : $Builtin.Int32) : $Builtin.Int1
@@ -224,7 +224,7 @@ bb0(%0 : $Int32, %25: $Bar):
   br bb1(%1 : $Builtin.Int32, %2 : $Builtin.Int32, %25: $Bar)
 
 bb1(%4 : $Builtin.Int32, %5 : $Builtin.Int32, %26: $Bar):
-  %101 = class_method [volatile] %100 : $Bar, #Bar.foo!1.foreign : (Bar) -> () -> () , $@convention(objc_method) (Bar) -> ()
+  %101 = class_method [volatile] %100 : $Bar, #Bar.foo!1.foreign : (Bar) -> () -> (), $@convention(objc_method) (Bar) -> ()
   %6 = struct $Int32 (%5 : $Builtin.Int32)
   %8 = builtin "cmp_eq_Word"(%5 : $Builtin.Int32, %1 : $Builtin.Int32) : $Builtin.Int1
   cond_br %8, bb3, bb2

--- a/test/SILOptimizer/mandatory_inlining.sil
+++ b/test/SILOptimizer/mandatory_inlining.sil
@@ -738,7 +738,7 @@ bb0(%0 : $Foo):
   %2 = function_ref @protocolConstrained : $@convention(thin) <τ_0_0 where τ_0_0 : Foo> (@owned τ_0_0) -> ()
   strong_retain %0 : $Foo
   // CHECK-NOT: apply
-  // CHECK: [[METHOD:%[a-zA-Z0-9]+]] = witness_method [volatile] $Foo, #Foo.foo!1.foreign : $@convention(objc_method) <τ_0_0 where τ_0_0 : Foo> (τ_0_0) -> ()
+  // CHECK: [[METHOD:%[a-zA-Z0-9]+]] = witness_method [volatile] $Foo, #Foo.foo!1.foreign : {{.*}} : $@convention(objc_method) <τ_0_0 where τ_0_0 : Foo> (τ_0_0) -> ()
   // CHECK: apply [[METHOD]]<Foo>(%0) : $@convention(objc_method) <τ_0_0 where τ_0_0 : Foo> (τ_0_0) -> ()
   %4 = apply %2<Foo>(%0) : $@convention(thin) <τ_0_0 where τ_0_0 : Foo> (@owned τ_0_0) -> ()
   strong_release %0 : $Foo
@@ -891,7 +891,7 @@ bb0(%0 : $*Self):
 // uses the opened archetype from the caller.
 // CHECK-LABEL: sil hidden @L_start
 // CHECK: open_existential_addr{{.*}}$*@[[OPENED_ARCHETYPE:opened\("[A-Z0-9-]+"\) P2]]
-// CHECK: witness_method $@[[OPENED_ARCHETYPE]], #P2.c!getter.1, %{{[0-9]+}} : $*@[[OPENED_ARCHETYPE]]
+// CHECK: witness_method $@[[OPENED_ARCHETYPE]], #P2.c!getter.1 : {{.*}}, %{{[0-9]+}} : $*@[[OPENED_ARCHETYPE]]
 // CHECK: return
 sil hidden @L_start : $@convention(method) (@in_guaranteed L) -> Int32 {
 bb0(%0 : $*L):

--- a/test/SILOptimizer/optimize_never.sil
+++ b/test/SILOptimizer/optimize_never.sil
@@ -176,7 +176,7 @@ bb0(%0 : $*T):
 // CHECK: function_ref @_TF14optimize_never10transform1urFxVs5Int32
 // CHECK: apply
 // CHECK-NOT: checked_cast_br
-// CHECK: class_method {{%.*}} : $C, #C.foo!1 : (C) -> () -> Int32 , $@convention(method) (@guaranteed C) -> Int32
+// CHECK: class_method {{%.*}} : $C, #C.foo!1 : (C) -> () -> Int32, $@convention(method) (@guaranteed C) -> Int32
 // CHECK: apply
 // CHECK: return
 sil [_semantics "optimize.sil.never"] @_TF14optimize_never4foo1urFTxCS_1C_Vs5Int32 : $@convention(thin) <T> (@in T, @owned C) -> Int32 {
@@ -185,7 +185,7 @@ bb0(%0 : $*T, %1 : $C):
   %5 = alloc_stack $T
   copy_addr %0 to [initialization] %5 : $*T
   %7 = apply %4<T>(%5) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int32
-  %8 = class_method %1 : $C, #C.foo!1 : (C) -> () -> Int32 , $@convention(method) (@guaranteed C) -> Int32
+  %8 = class_method %1 : $C, #C.foo!1 : (C) -> () -> Int32, $@convention(method) (@guaranteed C) -> Int32
   %9 = apply %8(%1) : $@convention(method) (@guaranteed C) -> Int32
   %10 = struct_extract %7 : $Int32, #Int32._value
   %11 = struct_extract %9 : $Int32, #Int32._value
@@ -241,14 +241,14 @@ bb0(%0 : $Int32):
 // CHECK: function_ref @_TF14optimize_never10transform2FVs5Int32S0_
 // CHECK: apply
 // CHECK-NOT: checked_cast_br
-// CHECK: class_method {{%.*}} : $C, #C.foo!1 : (C) -> () -> Int32 , $@convention(method) (@guaranteed C) -> Int32
+// CHECK: class_method {{%.*}} : $C, #C.foo!1 : (C) -> () -> Int32, $@convention(method) (@guaranteed C) -> Int32
 // CHECK: apply
 // CHECK: return
 sil [_semantics "optimize.sil.never"] @_TF14optimize_never4foo2FTVs5Int32CS_1C_S0_ : $@convention(thin) (Int32, @owned C) -> Int32 {
 bb0(%0 : $Int32, %1 : $C):
   %4 = function_ref @_TF14optimize_never10transform2FVs5Int32S0_ : $@convention(thin) (Int32) -> Int32
   %5 = apply %4(%0) : $@convention(thin) (Int32) -> Int32
-  %6 = class_method %1 : $C, #C.foo!1 : (C) -> () -> Int32 , $@convention(method) (@guaranteed C) -> Int32
+  %6 = class_method %1 : $C, #C.foo!1 : (C) -> () -> Int32, $@convention(method) (@guaranteed C) -> Int32
   %7 = apply %6(%1) : $@convention(method) (@guaranteed C) -> Int32
   %8 = struct_extract %5 : $Int32, #Int32._value
   %9 = struct_extract %7 : $Int32, #Int32._value
@@ -301,7 +301,7 @@ bb0(%0 : $*T, %1 : $C):
   %5 = alloc_stack $T
   copy_addr %0 to [initialization] %5 : $*T
   %7 = apply %4<T>(%5) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int32
-  %8 = class_method %1 : $C, #C.foo!1 : (C) -> () -> Int32 , $@convention(method) (@guaranteed C) -> Int32
+  %8 = class_method %1 : $C, #C.foo!1 : (C) -> () -> Int32, $@convention(method) (@guaranteed C) -> Int32
   %9 = apply %8(%1) : $@convention(method) (@guaranteed C) -> Int32
   %10 = struct_extract %7 : $Int32, #Int32._value
   %11 = struct_extract %9 : $Int32, #Int32._value
@@ -353,7 +353,7 @@ sil @_TF14optimize_never4foo4FTVs5Int32CS_1C_S0_ : $@convention(thin) (Int32, @o
 bb0(%0 : $Int32, %1 : $C):
   %4 = function_ref @_TF14optimize_never10transform4FVs5Int32S0_ : $@convention(thin) (Int32) -> Int32
   %5 = apply %4(%0) : $@convention(thin) (Int32) -> Int32
-  %6 = class_method %1 : $C, #C.foo!1 : (C) -> () -> Int32 , $@convention(method) (@guaranteed C) -> Int32
+  %6 = class_method %1 : $C, #C.foo!1 : (C) -> () -> Int32, $@convention(method) (@guaranteed C) -> Int32
   %7 = apply %6(%1) : $@convention(method) (@guaranteed C) -> Int32
   %8 = struct_extract %5 : $Int32, #Int32._value
   %9 = struct_extract %7 : $Int32, #Int32._value
@@ -461,7 +461,7 @@ bb0(%0 : $Base):
 // CHECK: }
 sil @_TF14optimize_never23testDoNotDevirtDerived1FT1oCS_4Base_Vs5Int32 : $@convention(thin) (@owned Base) -> Int32 {
 bb0(%0 : $Base):
-  %2 = class_method %0 : $Base, #Base.boo!1 : (Base) -> () -> Int32 , $@convention(method) (@guaranteed Base) -> Int32
+  %2 = class_method %0 : $Base, #Base.boo!1 : (Base) -> () -> Int32, $@convention(method) (@guaranteed Base) -> Int32
   %3 = apply %2(%0) : $@convention(method) (@guaranteed Base) -> Int32
   strong_release %0 : $Base
   return %3 : $Int32

--- a/test/SILOptimizer/polymorphic_inline_caches.sil
+++ b/test/SILOptimizer/polymorphic_inline_caches.sil
@@ -35,7 +35,7 @@ bb0(%0 : $A, %1 : $Builtin.Int32):
 // CHECK-NOT: strong_retain %0
   strong_retain %0 : $A
 // CHECK-NOT: class_method
-  %5 = class_method %0 : $A, #A.ping!1 : (A) -> (Builtin.Int32) -> Builtin.Int32 , $@convention(method) (Builtin.Int32, @guaranteed A) -> Builtin.Int32
+  %5 = class_method %0 : $A, #A.ping!1 : (A) -> (Builtin.Int32) -> Builtin.Int32, $@convention(method) (Builtin.Int32, @guaranteed A) -> Builtin.Int32
   // CHECK-NOT: apply
   %6 = apply %5(%1, %0) : $@convention(method) (Builtin.Int32, @guaranteed A) -> Builtin.Int32
   // CHECK: checked_cast_br [exact] %0 : $A to $A, bb2, bb3
@@ -71,7 +71,7 @@ sil @polymorphic_inline_caches_dont_sink_retain : $@convention(thin) (@owned A, 
 bb0(%0 : $A, %1 : $Builtin.Int32):
 // CHECK: strong_retain %0
   %4 = function_ref @external_func : $@convention(thin) (A) -> Builtin.Int32
-  %5 = class_method %0 : $A, #A.ping!1 : (A) -> (Builtin.Int32) -> Builtin.Int32 , $@convention(method) (Builtin.Int32, @guaranteed A) -> Builtin.Int32
+  %5 = class_method %0 : $A, #A.ping!1 : (A) -> (Builtin.Int32) -> Builtin.Int32, $@convention(method) (Builtin.Int32, @guaranteed A) -> Builtin.Int32
 
   // Don't sink this retain, because its argument is used by %6 (apply of @external_func)
   strong_retain %0 : $A
@@ -157,7 +157,7 @@ bb0(%0 : $Builtin.NativeObject):
   // CHECK: [[CAST:%.*]] = unchecked_ref_cast %0 : $Builtin.NativeObject to $E
   %3 = unchecked_ref_cast %0 : $Builtin.NativeObject to $E
   // CHECK-NOT: class_method
-  %4 = class_method %3 : $E, #E.foo!1 : (E) -> () -> () , $@convention(method) (@guaranteed E) -> ()
+  %4 = class_method %3 : $E, #E.foo!1 : (E) -> () -> (), $@convention(method) (@guaranteed E) -> ()
   %5 = apply %4(%3) : $@convention(method) (@guaranteed E) -> ()
   strong_release %0 : $Builtin.NativeObject
   %7 = tuple ()
@@ -199,7 +199,7 @@ bb0(%0 : $E):
   // CHECK: [[CAST:%.*]] = unchecked_ref_cast %0 : $E to $F
   %3 = unchecked_ref_cast %0 : $E to $F
   // CHECK-NOT: class_method
-  %4 = class_method %3 : $F, #F.foo!1 : (F) -> () -> () , $@convention(method) (@guaranteed F) -> ()
+  %4 = class_method %3 : $F, #F.foo!1 : (F) -> () -> (), $@convention(method) (@guaranteed F) -> ()
   %5 = apply %4(%3) : $@convention(method) (@guaranteed F) -> ()
   strong_release %0 : $E
   %7 = tuple ()

--- a/test/SILOptimizer/recursive_func.sil
+++ b/test/SILOptimizer/recursive_func.sil
@@ -48,7 +48,7 @@ bb0(%0 : $Int, %1 : $REC):
 
 bb1:                                              // Preds: bb0
   strong_retain %1 : $REC                         // id: %13
-  %14 = class_method %1 : $REC, #REC.recursive!1 : (REC) -> (Int) -> () , $@convention(method) (Int, @guaranteed REC) -> () // user: %21
+  %14 = class_method %1 : $REC, #REC.recursive!1 : (REC) -> (Int) -> (), $@convention(method) (Int, @guaranteed REC) -> () // user: %21
   // function_ref Swift.- @infix (Swift.Int, Swift.Int) -> Swift.Int
   %15 = function_ref @_TFsoi1sFTSiSi_Si : $@convention(thin) (Int, Int) -> Int // user: %20
   // function_ref Swift.Int._convertFromBuiltinIntegerLiteral (Swift.Int.Type)(Builtin.Int2048) -> Swift.Int
@@ -59,7 +59,7 @@ bb1:                                              // Preds: bb0
   %20 = apply %15(%0, %19) : $@convention(thin) (Int, Int) -> Int // user: %21
   %21 = apply %14(%20, %1) : $@convention(method) (Int, @guaranteed REC) -> ()
   strong_retain %1 : $REC                         // id: %22
-  %23 = class_method %1 : $REC, #REC.recursive!1 : (REC) -> (Int) -> () , $@convention(method) (Int, @guaranteed REC) -> () // user: %30
+  %23 = class_method %1 : $REC, #REC.recursive!1 : (REC) -> (Int) -> (), $@convention(method) (Int, @guaranteed REC) -> () // user: %30
   // function_ref Swift.- @infix (Swift.Int, Swift.Int) -> Swift.Int
   %24 = function_ref @_TFsoi1sFTSiSi_Si : $@convention(thin) (Int, Int) -> Int // user: %29
   // function_ref Swift.Int._convertFromBuiltinIntegerLiteral (Swift.Int.Type)(Builtin.Int2048) -> Swift.Int
@@ -138,7 +138,7 @@ bb0(%0 : $Int):
   %4 = apply %2(%3) : $@convention(thin) (@thick REC.Type) -> @owned REC // users: %5, %6, %7, %8, %9
   debug_value %4 : $REC, let, name "rec" // id: %5
   strong_retain %4 : $REC                         // id: %6
-  %7 = class_method %4 : $REC, #REC.recursive!1 : (REC) -> (Int) -> () , $@convention(method) (Int, @guaranteed REC) -> () // user: %8
+  %7 = class_method %4 : $REC, #REC.recursive!1 : (REC) -> (Int) -> (), $@convention(method) (Int, @guaranteed REC) -> () // user: %8
   %8 = apply %7(%0, %4) : $@convention(method) (Int, @guaranteed REC) -> ()
   strong_release %4 : $REC                        // id: %9
   %10 = tuple ()                                  // user: %11

--- a/test/SILOptimizer/recursive_single.sil
+++ b/test/SILOptimizer/recursive_single.sil
@@ -50,7 +50,7 @@ bb0(%0 : $Int, %1 : $REC):
 
 bb1:                                              // Preds: bb0
   strong_retain %1 : $REC                         // id: %13
-  %14 = class_method %1 : $REC, #REC.recursive!1 : (REC) -> (Int) -> () , $@convention(method) (Int, @guaranteed REC) -> () // user: %21
+  %14 = class_method %1 : $REC, #REC.recursive!1 : (REC) -> (Int) -> (), $@convention(method) (Int, @guaranteed REC) -> () // user: %21
   // function_ref Swift.- @infix (Swift.Int, Swift.Int) -> Swift.Int
   %15 = function_ref @_TFsoi1sFTSiSi_Si : $@convention(thin) (Int, Int) -> Int // user: %20
   // function_ref Swift.Int._convertFromBuiltinIntegerLiteral (Swift.Int.Type)(Builtin.Int2048) -> Swift.Int
@@ -129,7 +129,7 @@ bb0(%0 : $Int):
   %4 = apply %2(%3) : $@convention(thin) (@thick REC.Type) -> @owned REC // users: %5, %6, %7, %8, %9
   debug_value %4 : $REC, let, name "rec" // id: %5
   strong_retain %4 : $REC                         // id: %6
-  %7 = class_method %4 : $REC, #REC.recursive!1 : (REC) -> (Int) -> () , $@convention(method) (Int, @guaranteed REC) -> () // user: %8
+  %7 = class_method %4 : $REC, #REC.recursive!1 : (REC) -> (Int) -> (), $@convention(method) (Int, @guaranteed REC) -> () // user: %8
   %8 = apply %7(%0, %4) : $@convention(method) (Int, @guaranteed REC) -> ()
   strong_release %4 : $REC                        // id: %9
   %10 = tuple ()                                  // user: %11

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -3155,7 +3155,7 @@ final class XXX : BBB {
 // upcast.
 // CHECK-LABEL: sil @silcombine_dont_generate_wrong_upcasts_during_devirt
 // CHECK-NOT: upcast
-// CHECK: witness_method $XXX, #PPP.foo!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : PPP> (@guaranteed τ_0_0) -> ()
+// CHECK: witness_method $XXX, #PPP.foo!1 : {{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : PPP> (@guaranteed τ_0_0) -> ()
 // CHECK-NOT: upcast
 // CHECK: return
 sil @silcombine_dont_generate_wrong_upcasts_during_devirt: $@convention(thin) (@owned BBB) -> () {

--- a/test/SILOptimizer/sil_combine_devirt.sil
+++ b/test/SILOptimizer/sil_combine_devirt.sil
@@ -32,7 +32,7 @@ bb0:
   %3 = alloc_ref $Foo                             // users: %6, %7, %4
   %4 = ref_element_addr %3 : $Foo, #Foo.m_val     // user: %5
   store %2 to %4 : $*Int32                        // id: %5
-  %6 = class_method %3 : $Foo, #Foo.get!1 : (Foo) -> () -> Int32 , $@convention(method) (@guaranteed Foo) -> Int32 // user: %7
+  %6 = class_method %3 : $Foo, #Foo.get!1 : (Foo) -> () -> Int32, $@convention(method) (@guaranteed Foo) -> Int32 // user: %7
   %7 = apply %6(%3) : $@convention(method) (@guaranteed Foo) -> Int32 // user: %8
   %8 = apply %0(%7) : $@convention(thin) (Int32) -> ()
   %9 = tuple ()                                   // user: %10

--- a/test/SILOptimizer/sil_combine_enums.sil
+++ b/test/SILOptimizer/sil_combine_enums.sil
@@ -41,7 +41,7 @@ bb1:                                              // Preds: bb0
   %12 = load %11 : $*SomeClass                    // users: %15, %16
   dealloc_stack %7 : $*Optional<SomeClass> // id: %13
   release_value %5 : $Optional<SomeClass>         // id: %14
-  %15 = class_method %12 : $SomeClass, #SomeClass.hash!1 : (SomeClass) -> () -> Int , $@convention(method) (@guaranteed SomeClass) -> Int // user: %16
+  %15 = class_method %12 : $SomeClass, #SomeClass.hash!1 : (SomeClass) -> () -> Int, $@convention(method) (@guaranteed SomeClass) -> Int // user: %16
   %16 = apply %15(%12) : $@convention(method) (@guaranteed SomeClass) -> Int // user: %20
   %17 = load %0 : $*Optional<SomeClass>         // user: %18
   release_value %17 : $Optional<SomeClass>        // id: %18
@@ -79,7 +79,7 @@ bb1:
   %12 = load %11 : $*SomeClass                    // users: %15, %16
   dealloc_stack %7 : $*Optional<SomeClass>
   release_value %5 : $Optional<SomeClass>
-  %15 = class_method %12 : $SomeClass, #SomeClass.hash!1 : (SomeClass) -> () -> Int , $@convention(method) (@guaranteed SomeClass) -> Int
+  %15 = class_method %12 : $SomeClass, #SomeClass.hash!1 : (SomeClass) -> () -> Int, $@convention(method) (@guaranteed SomeClass) -> Int
   %16 = apply %15(%12) : $@convention(method) (@guaranteed SomeClass) -> Int
   %17 = load %0 : $*Optional<SomeClass>
   release_value %17 : $Optional<SomeClass>
@@ -260,7 +260,7 @@ bb0(%0 : $Optional<SomeClass>):
 
 bb1:
   %5 = unchecked_enum_data %0 : $Optional<SomeClass>, #Optional.some!enumelt.1
-  %6 = class_method %5 : $SomeClass, #SomeClass.hash!1 : (SomeClass) -> () -> Int , $@convention(method) (@guaranteed SomeClass) -> Int
+  %6 = class_method %5 : $SomeClass, #SomeClass.hash!1 : (SomeClass) -> () -> Int, $@convention(method) (@guaranteed SomeClass) -> Int
   %7 = apply %6(%5) : $@convention(method) (@guaranteed SomeClass) -> Int
   fix_lifetime %5 : $SomeClass
   strong_release %5 : $SomeClass
@@ -350,7 +350,7 @@ bb0(%0 : $Optional<SomeClass>):
 
 bb1:
   %5 = unchecked_enum_data %0 : $Optional<SomeClass>, #Optional.some!enumelt.1
-  %6 = class_method %5 : $SomeClass, #SomeClass.hash!1 : (SomeClass) -> () -> Int , $@convention(method) (@guaranteed SomeClass) -> Int
+  %6 = class_method %5 : $SomeClass, #SomeClass.hash!1 : (SomeClass) -> () -> Int, $@convention(method) (@guaranteed SomeClass) -> Int
   %7 = apply %6(%5) : $@convention(method) (@guaranteed SomeClass) -> Int
   fix_lifetime %5 : $SomeClass
   strong_release %5 : $SomeClass

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -1110,8 +1110,8 @@ sil @_TFC3ccb4Base6middlefS0_FT_T_ : $@convention(method) (@guaranteed Base) -> 
 // CHECK-LABEL: sil @redundant_checked_cast_br
 sil @redundant_checked_cast_br : $@convention(method) (@guaranteed Base) -> () {
 bb0(%0 : $Base):
-// CHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle!1 : (Base) -> () -> () , $@convention(method) (@guaranteed Base) -> ()
-  %1 = class_method %0 : $Base, #Base.middle!1 : (Base) -> () -> () , $@convention(method) (@guaranteed Base) -> ()
+// CHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle!1 : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+  %1 = class_method %0 : $Base, #Base.middle!1 : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
 // CHECK: checked_cast_br [exact] %0 : $Base to $Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
   checked_cast_br [exact] %0 : $Base to $Base, bb2, bb7
 
@@ -1122,7 +1122,7 @@ bb1:
 
 bb2(%5 : $Base):
 // CHECK: [[SUCCESS]]
-  %7 = class_method %0 : $Base, #Base.inner!1 : (Base) -> () -> () , $@convention(method) (@guaranteed Base) -> ()
+  %7 = class_method %0 : $Base, #Base.inner!1 : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
 // CHECK-NOT: checked_cast_br
   checked_cast_br [exact] %0 : $Base to $Base, bb3, bb5
 // CHECK: [[INNER:%.*]] = function_ref @_TFC3ccb4Base5innerfS0_FT_T_ : $@convention(method) (@guaranteed Base) -> ()
@@ -1158,8 +1158,8 @@ bb7:
 // CHECK-LABEL: sil @not_redundant_checked_cast_br : $@convention(method) (@guaranteed Base) -> () {
 sil @not_redundant_checked_cast_br : $@convention(method) (@guaranteed Base) -> () {
 bb0(%0 : $Base):
-// CHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle!1 : (Base) -> () -> () , $@convention(method) (@guaranteed Base) -> ()
-  %1 = class_method %0 : $Base, #Base.middle!1 : (Base) -> () -> () , $@convention(method) (@guaranteed Base) -> ()
+// CHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle!1 : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+  %1 = class_method %0 : $Base, #Base.middle!1 : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
 // CHECK: checked_cast_br [exact] %0 : $Base to $Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
   checked_cast_br [exact] %0 : $Base to $Base, bb2, bb7
 
@@ -1169,8 +1169,8 @@ bb1:
 
 bb2(%5 : $Base):
 // CHECK: [[SUCCESS]]
-// CHECK: [[METHOD2:%.*]] = class_method %0 : $Base, #Base.inner!1 : (Base) -> () -> () , $@convention(method) (@guaranteed Base) -> ()
-  %7 = class_method %0 : $Base, #Base.inner!1 : (Base) -> () -> () , $@convention(method) (@guaranteed Base) -> ()
+// CHECK: [[METHOD2:%.*]] = class_method %0 : $Base, #Base.inner!1 : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+  %7 = class_method %0 : $Base, #Base.inner!1 : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
   %8 = apply %7(%0) : $@convention(method) (@guaranteed Base) -> ()
   br bb4
 
@@ -1184,7 +1184,7 @@ bb4:
   br bb6(%13 : $())
 
 bb5:
-  %14 = class_method %0 : $Base, #Base.inner!1 : (Base) -> () -> () , $@convention(method) (@guaranteed Base) -> ()
+  %14 = class_method %0 : $Base, #Base.inner!1 : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
   %15 = apply %14(%0) : $@convention(method) (@guaranteed Base) -> ()
   br bb4
 
@@ -1203,8 +1203,8 @@ bb7:
 // CHECK-LABEL: sil @failing_checked_cast_br
 sil @failing_checked_cast_br : $@convention(method) (@guaranteed Base) -> () {
 bb0(%0 : $Base):
-// CHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle!1 : (Base) -> () -> () , $@convention(method) (@guaranteed Base) -> ()
-  %1 = class_method %0 : $Base, #Base.middle!1 : (Base) -> () -> () , $@convention(method) (@guaranteed Base) -> ()
+// CHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle!1 : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+  %1 = class_method %0 : $Base, #Base.middle!1 : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
 // CHECK: checked_cast_br [exact] %0 : $Base to $Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
   checked_cast_br [exact] %0 : $Base to $Base, bb2, bb7
 
@@ -1215,8 +1215,8 @@ bb1:
 
 bb2(%5 : $Base):
 // CHECK: [[SUCCESS]]
-// CHECK: [[METHOD2:%.*]] = class_method %0 : $Base, #Base.inner!1 : (Base) -> () -> () , $@convention(method) (@guaranteed Base) -> ()
-  %7 = class_method %0 : $Base, #Base.inner!1 : (Base) -> () -> () , $@convention(method) (@guaranteed Base) -> ()
+// CHECK: [[METHOD2:%.*]] = class_method %0 : $Base, #Base.inner!1 : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+  %7 = class_method %0 : $Base, #Base.inner!1 : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
 // CHECK-NOT: checked_cast_br [exact] %0 : $Base to $Derived
 // CHECK: apply [[METHOD2]]
 // Check that checked_cast_br [exact] was replaced by a branch to the failure BB of the checked_cast_br.
@@ -1449,7 +1449,7 @@ bb2:
   br bb3(%1 : $Builtin.Int32, %14 : $Builtin.Int32, %16 : $Optional<Int32>)
 
 bb3(%18 : $Builtin.Int32, %19 : $Builtin.Int32, %20 : $Optional<Int32>):
-  %101 = class_method [volatile] %100 : $Bar, #Bar.foo!1.foreign : (Bar) -> () -> () , $@convention(objc_method) (Bar) -> ()
+  %101 = class_method [volatile] %100 : $Bar, #Bar.foo!1.foreign : (Bar) -> () -> (), $@convention(objc_method) (Bar) -> ()
   switch_enum %20 : $Optional<Int32>, case #Optional.some!enumelt.1: bb4, case #Optional.none!enumelt: bb5
 
 bb4:

--- a/test/SILOptimizer/sink.sil
+++ b/test/SILOptimizer/sink.sil
@@ -38,7 +38,7 @@ bb0(%0 : $Y):
   debug_value %0 : $Y
   strong_retain %0 : $Y
   %3 = upcast %0 : $Y to $X
-  %4 = class_method %3 : $X, #X.ping!1 : (X) -> () -> Int , $@convention(method) (@guaranteed X) -> Int
+  %4 = class_method %3 : $X, #X.ping!1 : (X) -> () -> Int, $@convention(method) (@guaranteed X) -> Int
   br bb1
 
 bb1:
@@ -57,7 +57,7 @@ bb0(%0 : $Y):
   debug_value %0 : $Y
   strong_retain %0 : $Y
   %3 = upcast %0 : $Y to $X
-  %4 = class_method %3 : $X, #X.ping!1 : (X) -> () -> Int , $@convention(method) (@guaranteed X) -> Int
+  %4 = class_method %3 : $X, #X.ping!1 : (X) -> () -> Int, $@convention(method) (@guaranteed X) -> Int
   cond_br undef, bb1, bb2
 
 bb1:
@@ -86,7 +86,7 @@ bb0(%0 : $Y):
   debug_value %0 : $Y
   strong_retain %0 : $Y
   %3 = upcast %0 : $Y to $X
-  %4 = class_method %3 : $X, #X.ping!1 : (X) -> () -> Int , $@convention(method) (@guaranteed X) -> Int
+  %4 = class_method %3 : $X, #X.ping!1 : (X) -> () -> Int, $@convention(method) (@guaranteed X) -> Int
   cond_br undef, bb1, bb2
 
 bb1:
@@ -115,7 +115,7 @@ bb0(%0 : $Y):
   debug_value %0 : $Y
   strong_retain %0 : $Y
   %3 = upcast %0 : $Y to $X
-  %4 = class_method %3 : $X, #X.ping!1 : (X) -> () -> Int , $@convention(method) (@guaranteed X) -> Int
+  %4 = class_method %3 : $X, #X.ping!1 : (X) -> () -> Int, $@convention(method) (@guaranteed X) -> Int
   br bb1
 
 bb1:
@@ -144,7 +144,7 @@ bb0(%0 : $Y):
   debug_value %0 : $Y
   strong_retain %0 : $Y
   %3 = upcast %0 : $Y to $X
-  %4 = class_method %3 : $X, #X.ping!1 : (X) -> () -> Int , $@convention(method) (@guaranteed X) -> Int
+  %4 = class_method %3 : $X, #X.ping!1 : (X) -> () -> Int, $@convention(method) (@guaranteed X) -> Int
   br bb1
 
 // This is a loop!
@@ -167,7 +167,7 @@ bb2:
 sil @sink_nested_loop : $@convention(thin) (@owned Y) -> Int {
 bb0(%0 : $Y):
   %3 = upcast %0 : $Y to $X
-  %4 = class_method %3 : $X, #X.ping!1 : (X) -> () -> Int , $@convention(method) (@guaranteed X) -> Int
+  %4 = class_method %3 : $X, #X.ping!1 : (X) -> () -> Int, $@convention(method) (@guaranteed X) -> Int
   br bb1
 
 bb1:

--- a/test/SILOptimizer/super_class_method.swift
+++ b/test/SILOptimizer/super_class_method.swift
@@ -14,7 +14,7 @@ class Child : Parent {}
 class Grandchild : Child {
   class func onlyInGrandchild() {
     // CHECK-LABEL: sil hidden @_T018super_class_method10GrandchildC06onlyInD0yyFZ
-    // CHECK-NOT: super_method %0 : $@thick Grandchild.Type, #Parent.onlyInParent!1 : Parent.Type -> () -> () , $@convention(method) (@thick Parent.Type) -> (){{.*}} // user: %5
+    // CHECK-NOT: super_method %0 : $@thick Grandchild.Type, #Parent.onlyInParent!1 : Parent.Type -> () -> (), $@convention(method) (@thick Parent.Type) -> (){{.*}} // user: %5
     // CHECK: function_ref @_T018super_class_method6ParentC06onlyInD0yyFZ
     super.onlyInParent()
     // CHECK: function_ref @_T018super_class_method6ParentC011finalOnlyInD0yyFZ
@@ -23,7 +23,7 @@ class Grandchild : Child {
 
   override class func foo() {
     // CHECK: sil hidden @_T018super_class_method10GrandchildC3fooyyFZ : $@convention(method) (@thick Grandchild.Type) -> () {
-    // CHECK-NOT: super_method %0 : $@thick Grandchild.Type, #Parent.foo!1 : Parent.Type -> () -> () , $@convention(method) (@thick Parent.Type) -> ()
+    // CHECK-NOT: super_method %0 : $@thick Grandchild.Type, #Parent.foo!1 : Parent.Type -> () -> (), $@convention(method) (@thick Parent.Type) -> ()
     // CHECK: function_ref @_T018super_class_method6ParentC3fooyyFZ 
     super.foo()
   }

--- a/test/SILOptimizer/unsafe_guaranteed_peephole.sil
+++ b/test/SILOptimizer/unsafe_guaranteed_peephole.sil
@@ -33,7 +33,7 @@ bb0(%0 : $Foo):
   %4 = builtin "unsafeGuaranteed"<Foo>(%0 : $Foo) : $(Foo, Builtin.Int8)
   %5 = tuple_extract %4 : $(Foo, Builtin.Int8), 0
   %6 = tuple_extract %4 : $(Foo, Builtin.Int8), 1
-  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> () , $@convention(method) (@guaranteed Foo) -> ()
+  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> (), $@convention(method) (@guaranteed Foo) -> ()
   %20 = apply %19(%5) : $@convention(method) (@guaranteed Foo) -> ()
   strong_release %5 : $Foo
   %16 = builtin "unsafeGuaranteedEnd"(%6 : $Builtin.Int8) : $()
@@ -59,7 +59,7 @@ bb0(%0 : $Foo):
   %4 = builtin "unsafeGuaranteed"<Foo>(%0 : $Foo) : $(Foo, Builtin.Int8)
   %5 = tuple_extract %4 : $(Foo, Builtin.Int8), 0
   %6 = tuple_extract %4 : $(Foo, Builtin.Int8), 1
-  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> () , $@convention(method) (@guaranteed Foo) -> ()
+  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> (), $@convention(method) (@guaranteed Foo) -> ()
   %20 = apply %19(%5) : $@convention(method) (@guaranteed Foo) -> ()
   %16 = builtin "unsafeGuaranteedEnd"(%6 : $Builtin.Int8) : $()
   strong_release %5 : $Foo
@@ -85,7 +85,7 @@ bb0(%0 : $Foo):
   %4 = builtin "unsafeGuaranteed"<Foo>(%0 : $Foo) : $(Foo, Builtin.Int8)
   %5 = tuple_extract %4 : $(Foo, Builtin.Int8), 0
   %6 = tuple_extract %4 : $(Foo, Builtin.Int8), 1
-  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> () , $@convention(method) (@guaranteed Foo) -> ()
+  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> (), $@convention(method) (@guaranteed Foo) -> ()
   %20 = apply %19(%5) : $@convention(method) (@guaranteed Foo) -> ()
   %16 = builtin "unsafeGuaranteedEnd"(%6 : $Builtin.Int8) : $()
   release_value %4 : $(Foo, Builtin.Int8)
@@ -111,7 +111,7 @@ bb0(%0 : $Foo):
   %4 = builtin "unsafeGuaranteed"<Foo>(%0 : $Foo) : $(Foo, Builtin.Int8)
   %5 = tuple_extract %4 : $(Foo, Builtin.Int8), 0
   %6 = tuple_extract %4 : $(Foo, Builtin.Int8), 1
-  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> () , $@convention(method) (@guaranteed Foo) -> ()
+  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> (), $@convention(method) (@guaranteed Foo) -> ()
   %20 = apply %19(%5) : $@convention(method) (@guaranteed Foo) -> ()
   %16 = builtin "unsafeGuaranteedEnd"(%6 : $Builtin.Int8) : $()
   release_value %0 : $Foo
@@ -135,7 +135,7 @@ bb0(%0 : $Foo):
   %4 = builtin "unsafeGuaranteed"<Foo>(%0 : $Foo) : $(Foo, Builtin.Int8)
   %5 = tuple_extract %4 : $(Foo, Builtin.Int8), 0
   %6 = tuple_extract %4 : $(Foo, Builtin.Int8), 1
-  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> () , $@convention(method) (@guaranteed Foo) -> ()
+  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> (), $@convention(method) (@guaranteed Foo) -> ()
   %20 = apply %19(%5) : $@convention(method) (@guaranteed Foo) -> ()
   strong_release %5 : $Foo
   %16 = builtin "unsafeGuaranteedEnd"(%6 : $Builtin.Int8) : $()
@@ -160,7 +160,7 @@ bb0(%0 : $Foo):
   %4 = builtin "unsafeGuaranteed"<Foo>(%0 : $Foo) : $(Foo, Builtin.Int8)
   %5 = tuple_extract %4 : $(Foo, Builtin.Int8), 0
   %6 = tuple_extract %4 : $(Foo, Builtin.Int8), 1
-  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> () , $@convention(method) (@guaranteed Foo) -> ()
+  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> (), $@convention(method) (@guaranteed Foo) -> ()
   %20 = apply %19(%5) : $@convention(method) (@guaranteed Foo) -> ()
   %16 = builtin "unsafeGuaranteedEnd"(%6 : $Builtin.Int8) : $()
   %17 = tuple ()
@@ -187,7 +187,7 @@ bb0(%0 : $Foo, %1: $Foo):
   %4 = builtin "unsafeGuaranteed"<Foo>(%0 : $Foo) : $(Foo, Builtin.Int8)
   %5 = tuple_extract %4 : $(Foo, Builtin.Int8), 0
   %6 = tuple_extract %4 : $(Foo, Builtin.Int8), 1
-  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> () , $@convention(method) (@guaranteed Foo) -> ()
+  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> (), $@convention(method) (@guaranteed Foo) -> ()
   %20 = apply %19(%5) : $@convention(method) (@guaranteed Foo) -> ()
   strong_release %5 : $Foo
   strong_release %1 : $Foo
@@ -213,7 +213,7 @@ bb0(%0 : $Foo, %1 : $Builtin.Int1):
   %4 = builtin "unsafeGuaranteed"<Foo>(%0 : $Foo) : $(Foo, Builtin.Int8)
   %5 = tuple_extract %4 : $(Foo, Builtin.Int8), 0
   %6 = tuple_extract %4 : $(Foo, Builtin.Int8), 1
-  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> () , $@convention(method) (@guaranteed Foo) -> ()
+  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> (), $@convention(method) (@guaranteed Foo) -> ()
   %20 = apply %19(%5) : $@convention(method) (@guaranteed Foo) -> ()
   strong_release %5 : $Foo
   %16 = builtin "unsafeGuaranteedEnd"(%6 : $Builtin.Int8) : $()
@@ -237,7 +237,7 @@ bb0(%0 : $Foo, %1 : $Builtin.Int1):
   %4 = builtin "unsafeGuaranteed"<Foo>(%0 : $Foo) : $(Foo, Builtin.Int8)
   %5 = tuple_extract %4 : $(Foo, Builtin.Int8), 0
   %6 = tuple_extract %4 : $(Foo, Builtin.Int8), 1
-  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> () , $@convention(method) (@guaranteed Foo) -> ()
+  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> (), $@convention(method) (@guaranteed Foo) -> ()
   %20 = apply %19(%5) : $@convention(method) (@guaranteed Foo) -> ()
   strong_release %5 : $Foo
   cond_fail %1 : $Builtin.Int1
@@ -285,7 +285,7 @@ bb2:
   return %17 : $()
 
 bb3:
-  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> () , $@convention(method) (@guaranteed Foo) -> ()
+  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> (), $@convention(method) (@guaranteed Foo) -> ()
   %20 = apply %19(%5) : $@convention(method) (@guaranteed Foo) -> ()
   br bb2
 }
@@ -315,7 +315,7 @@ bb2:
   return %17 : $()
 
 bb3:
-  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> () , $@convention(method) (@guaranteed Foo) -> ()
+  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> (), $@convention(method) (@guaranteed Foo) -> ()
   %20 = apply %19(%5) : $@convention(method) (@guaranteed Foo) -> ()
   br bb2
 }
@@ -338,7 +338,7 @@ bb0(%0 : $Foo):
   %4 = builtin "unsafeGuaranteed"<Foo>(%0 : $Foo) : $(Foo, Builtin.Int8)
   %5 = tuple_extract %4 : $(Foo, Builtin.Int8), 0
   %6 = tuple_extract %4 : $(Foo, Builtin.Int8), 1
-  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> () , $@convention(method) (@guaranteed Foo) -> ()
+  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> (), $@convention(method) (@guaranteed Foo) -> ()
   %20 = apply %19(%5) : $@convention(method) (@guaranteed Foo) -> ()
   strong_release %5 : $Foo
   debug_value %5 : $Foo
@@ -397,7 +397,7 @@ bb0(%0 : $Foo, %1: $Builtin.Int32):
   %4 = builtin "unsafeGuaranteed"<Foo>(%0 : $Foo) : $(Foo, Builtin.Int8)
   %5 = tuple_extract %4 : $(Foo, Builtin.Int8), 0
   %6 = tuple_extract %4 : $(Foo, Builtin.Int8), 1
-  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> () , $@convention(method) (@guaranteed Foo) -> ()
+  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> (), $@convention(method) (@guaranteed Foo) -> ()
   %20 = apply %19(%5) : $@convention(method) (@guaranteed Foo) -> ()
   strong_release %5 : $Foo
   %21 = struct $MyInt(%1 : $Builtin.Int32)
@@ -421,7 +421,7 @@ bb0(%0 : $Foo, %1: $*Builtin.Int32, %2: $Builtin.Int32):
   %4 = builtin "unsafeGuaranteed"<Foo>(%0 : $Foo) : $(Foo, Builtin.Int8)
   %5 = tuple_extract %4 : $(Foo, Builtin.Int8), 0
   %6 = tuple_extract %4 : $(Foo, Builtin.Int8), 1
-  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> () , $@convention(method) (@guaranteed Foo) -> ()
+  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> (), $@convention(method) (@guaranteed Foo) -> ()
   %20 = apply %19(%5) : $@convention(method) (@guaranteed Foo) -> ()
   strong_release %5 : $Foo
   %16 = builtin "unsafeGuaranteedEnd"(%6 : $Builtin.Int8) : $()
@@ -442,7 +442,7 @@ bb0(%0 : $Foo, %1: $*Builtin.Int32, %2: $Builtin.Int32):
   %4 = builtin "unsafeGuaranteed"<Foo>(%0 : $Foo) : $(Foo, Builtin.Int8)
   %5 = tuple_extract %4 : $(Foo, Builtin.Int8), 0
   %6 = tuple_extract %4 : $(Foo, Builtin.Int8), 1
-  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> () , $@convention(method) (@guaranteed Foo) -> ()
+  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> (), $@convention(method) (@guaranteed Foo) -> ()
   %20 = apply %19(%5) : $@convention(method) (@guaranteed Foo) -> ()
   strong_release %5 : $Foo
   store %2 to %1 : $*Builtin.Int32
@@ -472,7 +472,7 @@ bb0(%0 : $Foo, %1: $Builtin.Int32):
   %5 = tuple_extract %4 : $(Foo, Builtin.Int8), 0
   %6 = tuple_extract %4 : $(Foo, Builtin.Int8), 1
   %7 = upcast %5 : $Foo to $Base
-  %19 = class_method %7 : $Base, #Base.beep!1 : (Base) -> () -> () , $@convention(method) (@guaranteed Base) -> ()
+  %19 = class_method %7 : $Base, #Base.beep!1 : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
   %20 = apply %19(%7) : $@convention(method) (@guaranteed Base) -> ()
   strong_release %7 : $Base
   %21 = struct $MyInt(%1 : $Builtin.Int32)
@@ -505,7 +505,7 @@ bb0(%0 : $AnyObject, %1: $Builtin.Int32):
   %5 = tuple_extract %4 : $(Foo, Builtin.Int8), 0
   %6 = tuple_extract %4 : $(Foo, Builtin.Int8), 1
   %7 = upcast %5 : $Foo to $Base
-  %19 = class_method %7 : $Base, #Base.beep!1 : (Base) -> () -> () , $@convention(method) (@guaranteed Base) -> ()
+  %19 = class_method %7 : $Base, #Base.beep!1 : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
   %20 = apply %19(%7) : $@convention(method) (@guaranteed Base) -> ()
   strong_release %7 : $Base
   %21 = struct $MyInt(%1 : $Builtin.Int32)

--- a/test/Serialization/Inputs/def_basic.sil
+++ b/test/Serialization/Inputs/def_basic.sil
@@ -1266,12 +1266,12 @@ bb0(%0 : $Int32, %1 : $Int, %2 : $Int, %3 : $Foo):
 
 
 // CHECK-LABEL: sil_vtable Foo {
-// CHECK: #Foo.subscript!getter.1: _T03tmp3FooC9subscriptSiSi1x_Si1ytcfg
-// CHECK: #Foo.subscript!setter.1: _T03tmp3FooC9subscriptSiSi1x_Si1ytcfs
+// CHECK: #Foo.subscript!getter.1: {{.*}} : _T03tmp3FooC9subscriptSiSi1x_Si1ytcfg
+// CHECK: #Foo.subscript!setter.1: {{.*}} : _T03tmp3FooC9subscriptSiSi1x_Si1ytcfs
 // CHECK: }
 // CHECK_DECL-LABEL: sil_vtable Foo {
-// CHECK_DECL: #Foo.subscript!getter.1: _T03tmp3FooC9subscriptSiSi1x_Si1ytcfg
-// CHECK_DECL: #Foo.subscript!setter.1: _T03tmp3FooC9subscriptSiSi1x_Si1ytcfs
+// CHECK_DECL: #Foo.subscript!getter.1: {{.*}} : _T03tmp3FooC9subscriptSiSi1x_Si1ytcfg
+// CHECK_DECL: #Foo.subscript!setter.1: {{.*}} : _T03tmp3FooC9subscriptSiSi1x_Si1ytcfs
 // CHECK_DECL: }
 sil_vtable Foo {
   #Foo.subscript!getter.1: _T03tmp3FooC9subscriptSiSi1x_Si1ytcfg
@@ -1303,7 +1303,7 @@ bb0(%0 : $*ConformingAssoc):
 
 
 // CHECK-LABEL: sil_witness_table public_external ConformingAssoc: AssocReqt module
-// CHECK: #AssocReqt.requiredMethod!1: @_TTWV14witness_tables15ConformingAssocS_9AssocReqtS_FS1_14requiredMethodU_fRQPS1_FT_T_
+// CHECK: #AssocReqt.requiredMethod!1: {{.*}} : @_TTWV14witness_tables15ConformingAssocS_9AssocReqtS_FS1_14requiredMethodU_fRQPS1_FT_T_
 // CHECK: }
 sil_witness_table ConformingAssoc: AssocReqt module def_basic {
   method #AssocReqt.requiredMethod!1: @_TTWV14witness_tables15ConformingAssocS_9AssocReqtS_FS1_14requiredMethodU_fRQPS1_FT_T_


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Textual SIL was sometimes ambiguous when SILDeclRefs were used, because the textual representation of SILDeclRefs was the same for functions that have the same name, but different signatures.

This patch fixes this problem.
