### PR TITLE
Fix crash during type checking when adding members to an extension.

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -898,6 +898,9 @@ void NominalTypeDecl::addedMember(Decl *member) {
 
 void ExtensionDecl::addedMember(Decl *member) {
   if (NextExtension.getInt()) {
+    if (getExtendedType()->is<ErrorType>())
+      return;
+
     auto nominal = getExtendedType()->getAnyNominal();
     if (nominal->LookupTable.getPointer()) {
       // Make sure we have the complete list of extensions.

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -1133,6 +1133,13 @@ extension rdar17391625derived {
   }
 }
 
+// <rdar://problem/27671033> Crash when defining property inside an invalid extension
+public protocol rdar27671033P {}
+struct rdar27671033S<Key, Value> {}
+extension rdar27671033S : rdar27671033P where Key == String { // expected-error {{extension of type 'rdar27671033S' with constraints cannot have an inheritance clause}}
+  // expected-error@-1 {{same-type requirement makes generic parameter 'Key' non-generic}}
+  let d = rdar27671033S<Int, Int>() // expected-error {{extensions may not contain stored properties}}
+}
 
 // <rdar://problem/19874152> struct memberwise initializer violates new sanctity of previously set `let` property
 struct r19874152S1 {


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Cherry-picking a fix from master to the swift-3.0-branch.
#### Resolved bug number: ([rdar://problem/27671033](rdar://problem/27671033))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

If the extension ended up with ErrorType, we could crash while we
continue trying to process its body adding members.

Just bail out in this case.

rdar://problem/27671033

(code cherry picked from commit c9ec7e398b4a2fc5f44b9d40fad4c29fd756b29d)
(test cherry picked from commit 107d602940665903280271905ef9f9c7abf6a9e2)
