### PR TITLE
[Type checker] Don't merge dictionary key type variables with different kinds

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1739,8 +1739,7 @@ namespace {
     }
 
     static bool isMergeableValueKind(Expr *expr) {
-      return isa<CollectionExpr>(expr) ||
-             isa<StringLiteralExpr>(expr) || isa<IntegerLiteralExpr>(expr) ||
+      return isa<StringLiteralExpr>(expr) || isa<IntegerLiteralExpr>(expr) ||
              isa<FloatLiteralExpr>(expr);
     }
 
@@ -1818,16 +1817,22 @@ namespace {
               auto keyTyvar2 = tty2->getElementTypes()[0]->
                                 getAs<TypeVariableType>();
 
-              mergedKey = mergeRepresentativeEquivalenceClasses(CS, 
+              auto keyExpr1 = cast<TupleExpr>(element1)->getElements()[0];
+              auto keyExpr2 = cast<TupleExpr>(element2)->getElements()[0];
+
+              if (keyExpr1->getKind() == keyExpr2->getKind() &&
+                  isMergeableValueKind(keyExpr1)) {
+                mergedKey = mergeRepresentativeEquivalenceClasses(CS,
                             keyTyvar1, keyTyvar2);
+              }
 
               auto valueTyvar1 = tty1->getElementTypes()[1]->
                                   getAs<TypeVariableType>();
               auto valueTyvar2 = tty2->getElementTypes()[1]->
                                   getAs<TypeVariableType>();
 
-              auto elemExpr1 = dyn_cast<TupleExpr>(element1)->getElements()[1];
-              auto elemExpr2 = dyn_cast<TupleExpr>(element2)->getElements()[1];
+              auto elemExpr1 = cast<TupleExpr>(element1)->getElements()[1];
+              auto elemExpr2 = cast<TupleExpr>(element2)->getElements()[1];
 
               if (elemExpr1->getKind() == elemExpr2->getKind() &&
                 isMergeableValueKind(elemExpr1)) {

--- a/test/Constraints/dictionary_literal.swift
+++ b/test/Constraints/dictionary_literal.swift
@@ -85,4 +85,10 @@ func testDefaultExistentials() {
 
   let d3 = ["b" : B(), "c" : C()]
   let _: Int = d3 // expected-error{{value of type 'Dictionary<String, A>'}}
+
+  let _ = ["a" : B(), 17 : "seventeen", 3.14159 : "Pi"]
+  // expected-error@-1{{heterogenous collection literal could only be inferred to 'Dictionary<AnyHashable, Any>'}}
+
+  let _ = ["a" : "hello", 17 : "string"]
+  // expected-error@-1{{heterogenous collection literal could only be inferred to 'Dictionary<AnyHashable, String>'}}
 }


### PR DESCRIPTION
<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…nt expression kinds.

The constraint generator's optimization to eagerly merge type
variables for different keys in a dictionary literal was too eager,
merging the type variables for (e.g.) a string literal and an integer
literal. This prevented us from properly inferring AnyHashable key
types in dictionary literals. Fixes the rest of rdar://problem/27661580.
