### PR TITLE
[FixCode] Add a fixit to help users migrate to Swift 3 name convention.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -72,6 +72,9 @@ ERROR(could_not_find_value_member,none,
 ERROR(could_not_find_type_member,none,
       "type %0 has no member %1", (Type, DeclName))
 
+ERROR(could_not_find_enum_case,none,
+      "enum type %0 has no case %1; do you mean %2", (Type, DeclName, DeclName))
+
 NOTE(did_you_mean_raw_type,none,
      "did you mean to specify a raw type on the enum declaration?", ())
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -73,7 +73,7 @@ ERROR(could_not_find_type_member,none,
       "type %0 has no member %1", (Type, DeclName))
 
 ERROR(could_not_find_enum_case,none,
-      "enum type %0 has no case %1; do you mean %2", (Type, DeclName, DeclName))
+      "enum type %0 has no case %1; did you mean %2", (Type, DeclName, DeclName))
 
 NOTE(did_you_mean_raw_type,none,
      "did you mean to specify a raw type on the enum declaration?", ())

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2410,20 +2410,20 @@ findCorrectEnumCaseName(MetatypeType *MetaTy, LookupResult &Result,
                         DeclName memberName) {
   if (!memberName.isSimpleName())
     return DeclName();
-  if (MetaTy->getInstanceType()->getKind() != TypeKind::Enum)
+  if (!MetaTy->getInstanceType()->is<EnumType>())
     return DeclName();
   std::vector<DeclName> candidates;
   for (auto &correction : Result) {
     DeclName correctName = correction.Decl->getFullName();
     if (!correctName.isSimpleName())
       continue;
-    if (correction.Decl->getKind() != DeclKind::EnumElement)
+    if (!isa<EnumElementDecl>(correction.Decl))
       continue;
-    if (0 == correctName.getBaseName().str().
-          compare_lower(memberName.getBaseName().str()))
+    if (correctName.getBaseName().str().
+          compare_lower(memberName.getBaseName().str()) == 0)
       candidates.push_back(correctName);
   }
-  if (1 == candidates.size())
+  if (candidates.size() == 1)
     return candidates.front();
   return DeclName();
 }

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -446,8 +446,8 @@ let _: Color = .frob(1, i)  // expected-error {{passing value of type 'Int' to a
 let _: Color = .frob(1, b: i)  // expected-error {{passing value of type 'Int' to an inout parameter requires explicit '&'}}
 let _: Color = .frob(1, &d) // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
 let _: Color = .frob(1, b: &d) // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
-var someColor : Color = .red // expected-error {{enum type 'Color' has no case 'red'; do you mean 'Red'}}
-someColor = .red  // expected-error {{enum type 'Color' has no case 'red'; do you mean 'Red'}}
+var someColor : Color = .red // expected-error {{enum type 'Color' has no case 'red'; did you mean 'Red'}}
+someColor = .red  // expected-error {{enum type 'Color' has no case 'red'; did you mean 'Red'}}
 
 func testTypeSugar(_ a : Int) {
   typealias Stride = Int

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -412,7 +412,7 @@ CurriedClass.m2(12)  // expected-error {{use of instance member 'm2' on type 'Cu
 
 // <rdar://problem/20491794> Error message does not tell me what the problem is
 enum Color {
-  case Red // expected-note 2 {{did you mean 'Red'?}}
+  case Red
   case Unknown(description: String)
 
   static func rainbow() -> Color {}
@@ -446,8 +446,8 @@ let _: Color = .frob(1, i)  // expected-error {{passing value of type 'Int' to a
 let _: Color = .frob(1, b: i)  // expected-error {{passing value of type 'Int' to an inout parameter requires explicit '&'}}
 let _: Color = .frob(1, &d) // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
 let _: Color = .frob(1, b: &d) // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
-var someColor : Color = .red // expected-error {{type 'Color' has no member 'red'}}
-someColor = .red  // expected-error {{type 'Color' has no member 'red'}}
+var someColor : Color = .red // expected-error {{enum type 'Color' has no case 'red'; do you mean 'Red'}}
+someColor = .red  // expected-error {{enum type 'Color' has no case 'red'; do you mean 'Red'}}
 
 func testTypeSugar(_ a : Int) {
   typealias Stride = Int

--- a/test/NameBinding/name_lookup.swift
+++ b/test/NameBinding/name_lookup.swift
@@ -522,7 +522,8 @@ class r16954496 {
 enum MyEnum {
   case one
   case two
-  
+  case oneTwoThree
+
   static let kMyConstant = "myConstant"
 }
 
@@ -535,3 +536,8 @@ default:
   break
 }
 
+func foo() {
+  _ = MyEnum.One // expected-error {{enum type 'MyEnum' has no case 'One'; do you mean 'one'}}{{14-17=one}}
+  _ = MyEnum.Two // expected-error {{enum type 'MyEnum' has no case 'Two'; do you mean 'two'}}{{14-17=two}}
+  _ = MyEnum.OneTwoThree // expected-error {{enum type 'MyEnum' has no case 'OneTwoThree'; do you mean 'oneTwoThree'}}{{14-25=oneTwoThree}}
+}

--- a/test/NameBinding/name_lookup.swift
+++ b/test/NameBinding/name_lookup.swift
@@ -537,7 +537,7 @@ default:
 }
 
 func foo() {
-  _ = MyEnum.One // expected-error {{enum type 'MyEnum' has no case 'One'; do you mean 'one'}}{{14-17=one}}
-  _ = MyEnum.Two // expected-error {{enum type 'MyEnum' has no case 'Two'; do you mean 'two'}}{{14-17=two}}
-  _ = MyEnum.OneTwoThree // expected-error {{enum type 'MyEnum' has no case 'OneTwoThree'; do you mean 'oneTwoThree'}}{{14-25=oneTwoThree}}
+  _ = MyEnum.One // expected-error {{enum type 'MyEnum' has no case 'One'; did you mean 'one'}}{{14-17=one}}
+  _ = MyEnum.Two // expected-error {{enum type 'MyEnum' has no case 'Two'; did you mean 'two'}}{{14-17=two}}
+  _ = MyEnum.OneTwoThree // expected-error {{enum type 'MyEnum' has no case 'OneTwoThree'; did you mean 'oneTwoThree'}}{{14-25=oneTwoThree}}
 }


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->

[FixCode] Add a fixit to help users migrate to Swift 3 name convention of enum cases. rdar://26887735

```
When users' referring to a enum case with a wrong name and we can find a correct enum case whose name differs from the wrong name only in capitalization, we replace the wrong name with the correct one.
```

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…n of enum cases. rdar://26887735

When users' referring to a enum case with a wrong name and we can find a correct enum case whose name
differs from the wrong name only in capitalization, we replace the wrong name with the correct one.
