### PR TITLE
Infer existential element/key/value types for collection literals as a fallback

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2097,7 +2097,11 @@ ERROR(discard_expr_outside_of_assignment,none,
       ())
 ERROR(inout_expr_outside_of_call,none,
       "'&' can only appear immediately in a call argument list", ())
-
+ERROR(collection_literal_heterogenous,none,
+      "heterogenous collection literal could only be inferred to %0; add"
+      " explicit type annotation if this is intentional", (Type))
+ERROR(collection_literal_empty,none,
+      "empty collection literal requires an explicit type", ())
 
 ERROR(unresolved_member_no_inference,none,
       "reference to member %0 cannot be resolved without a contextual type",

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -2162,7 +2162,7 @@ public:
   unsigned getNumElements() const { return Elements.size(); }
 
   bool isTypeDefaulted() const { return IsTypeDefaulted; }
-  void setIsTypeDefaulted(bool value = true) { IsTypeDefaulted = true; }
+  void setIsTypeDefaulted(bool value = true) { IsTypeDefaulted = value; }
 
   SourceLoc getLBracketLoc() const { return LBracketLoc; }
   SourceLoc getRBracketLoc() const { return RBracketLoc; }

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -2140,6 +2140,10 @@ class CollectionExpr : public Expr {
 
   Expr *SemanticExpr = nullptr;
 
+  /// True if the type of this collection expr was inferred by the collection
+  /// fallback type, like [Any].
+  bool IsTypeDefaulted = false;
+
 protected:
   CollectionExpr(ExprKind Kind, SourceLoc LBracketLoc,
                  MutableArrayRef<Expr*> Elements,
@@ -2156,6 +2160,9 @@ public:
   Expr *getElement(unsigned i) const { return Elements[i]; }
   void setElement(unsigned i, Expr *E) { Elements[i] = E; }
   unsigned getNumElements() const { return Elements.size(); }
+
+  bool isTypeDefaulted() const { return IsTypeDefaulted; }
+  void setIsTypeDefaulted(bool value = true) { IsTypeDefaulted = true; }
 
   SourceLoc getLBracketLoc() const { return LBracketLoc; }
   SourceLoc getRBracketLoc() const { return RBracketLoc; }

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -183,7 +183,30 @@ public:
 
   /// Get the canonical type, or return null if the type is null.
   CanType getCanonicalTypeOrNull() const; // in Types.h
-  
+
+  /// Computes the meet between two types.
+  ///
+  /// The meet of two types is the most specific type that is a supertype of
+  /// both \c type1 and \c type2. For example, given a simple class hierarchy as
+  /// follows:
+  ///
+  /// \code
+  /// class A { }
+  /// class B : A { }
+  /// class C : A { }
+  /// class D { }
+  /// \endcode
+  ///
+  /// The meet of B and C is A, the meet of A and B is A. However, there is no
+  /// meet of D and A (or D and B, or D and C) because there is no common
+  /// superclass. One would have to jump to an existential (e.g., \c AnyObject)
+  /// to find a common type.
+  /// 
+  /// \returns the meet of the two types, if there is a concrete type that can
+  /// express the meet, or a null type if the only meet would be a more-general
+  /// existential type (e.g., \c Any).
+  static Type meet(Type type1, Type type2);
+
 private:
   // Direct comparison is disabled for types, because they may not be canonical.
   void operator==(Type T) const = delete;
@@ -432,6 +455,7 @@ public:
     return Signature;
   }
 };
+
 } // end namespace swift
 
 namespace llvm {

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -38,6 +38,7 @@ add_swift_library(swiftAST STATIC
   SourceEntityWalker.cpp
   Substitution.cpp
   Type.cpp
+  TypeJoinMeet.cpp
   TypeRefinementContext.cpp
   TypeRepr.cpp
   TypeWalker.cpp

--- a/lib/AST/TypeJoinMeet.cpp
+++ b/lib/AST/TypeJoinMeet.cpp
@@ -1,0 +1,70 @@
+//===--- TypeJoinMeet.cpp - Swift Type "Join" and "Meet"  -----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements the "meet" operation for types (and, eventually,
+//  "join").
+//
+//===----------------------------------------------------------------------===//
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/Type.h"
+#include "swift/AST/Types.h"
+#include "llvm/ADT/SmallPtrSet.h"
+using namespace swift;
+
+Type Type::meet(Type type1, Type type2) {
+  assert(!type1->hasTypeVariable() && !type2->hasTypeVariable() &&
+         "Cannot compute meet of types involving type variables");
+
+  // FIXME: This algorithm is woefully incomplete, and is only currently used
+  // for optimizing away extra exploratory work in the constraint solver. It
+  // should eventually encompass all of the subtyping rules of the language.
+
+  // If the types are equivalent, the meet is obvious.
+  if (type1->isEqual(type2))
+    return type1;
+
+  // If both are class types or opaque types that potentially have superclasses,
+  // find the common superclass.
+  if (type1->mayHaveSuperclass() && type2->mayHaveSuperclass()) {
+    ASTContext &ctx = type1->getASTContext();
+    LazyResolver *resolver = ctx.getLazyResolver();
+
+    /// Walk the superclasses of type1 looking for type2. Record them for our
+    /// second step.
+    llvm::SmallPtrSet<CanType, 8> superclassesOfType1;
+    CanType canType2 = type2->getCanonicalType();
+    for (Type super1 = type1; super1; super1 = super1->getSuperclass(resolver)){
+      CanType canSuper1 = super1->getCanonicalType();
+
+      // If we have found the second type, we're done.
+      if (canSuper1 == canType2) return super1;
+
+      superclassesOfType1.insert(canSuper1);
+    }
+
+    // Look through the superclasses of type2 to determine if any were also
+    // superclasses of type1.
+    for (Type super2 = type2; super2; super2 = super2->getSuperclass(resolver)){
+      CanType canSuper2 = super2->getCanonicalType();
+
+      // If we found the first type, we're done.
+      if (superclassesOfType1.count(canSuper2)) return super2;
+    }
+
+    // There is no common superclass; we're done.
+    return nullptr;
+  }
+
+  // The meet can only be an existential.
+  return nullptr;
+}
+

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2711,6 +2711,14 @@ namespace {
 
       expr->setSemanticExpr(result);
       expr->setType(arrayTy);
+
+      // If the array element type was defaulted, note that in the expression.
+      auto elementTypeVariable = cs.ArrayElementTypeVariables.find(expr);
+      if (elementTypeVariable != cs.ArrayElementTypeVariables.end()) {
+        if (solution.DefaultedTypeVariables.count(elementTypeVariable->second))
+          expr->setIsTypeDefaulted();
+      }
+
       return expr;
     }
 
@@ -2780,6 +2788,18 @@ namespace {
 
       expr->setSemanticExpr(result);
       expr->setType(dictionaryTy);
+
+      // If the dictionary key or value type was defaulted, note that in the
+      // expression.
+      auto elementTypeVariable = cs.DictionaryElementTypeVariables.find(expr);
+      if (elementTypeVariable != cs.DictionaryElementTypeVariables.end()) {
+        if (solution.DefaultedTypeVariables.count(
+              elementTypeVariable->second.first) ||
+            solution.DefaultedTypeVariables.count(
+              elementTypeVariable->second.second))
+          expr->setIsTypeDefaulted();
+      }
+
       return expr;
     }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1739,8 +1739,7 @@ namespace {
     }
 
     static bool isMergeableValueKind(Expr *expr) {
-      return isa<CollectionExpr>(expr) ||
-             isa<StringLiteralExpr>(expr) || isa<IntegerLiteralExpr>(expr) ||
+      return isa<StringLiteralExpr>(expr) || isa<IntegerLiteralExpr>(expr) ||
              isa<FloatLiteralExpr>(expr);
     }
 
@@ -1818,16 +1817,22 @@ namespace {
               auto keyTyvar2 = tty2->getElementTypes()[0]->
                                 getAs<TypeVariableType>();
 
-              mergedKey = mergeRepresentativeEquivalenceClasses(CS, 
+              auto keyExpr1 = cast<TupleExpr>(element1)->getElements()[0];
+              auto keyExpr2 = cast<TupleExpr>(element2)->getElements()[0];
+
+              if (keyExpr1->getKind() == keyExpr2->getKind() &&
+                  isMergeableValueKind(keyExpr1)) {
+                mergedKey = mergeRepresentativeEquivalenceClasses(CS,
                             keyTyvar1, keyTyvar2);
+              }
 
               auto valueTyvar1 = tty1->getElementTypes()[1]->
                                   getAs<TypeVariableType>();
               auto valueTyvar2 = tty2->getElementTypes()[1]->
                                   getAs<TypeVariableType>();
 
-              auto elemExpr1 = dyn_cast<TupleExpr>(element1)->getElements()[1];
-              auto elemExpr2 = dyn_cast<TupleExpr>(element2)->getElements()[1];
+              auto elemExpr1 = cast<TupleExpr>(element1)->getElements()[1];
+              auto elemExpr2 = cast<TupleExpr>(element2)->getElements()[1];
 
               if (elemExpr1->getKind() == elemExpr2->getKind() &&
                 isMergeableValueKind(elemExpr1)) {

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1011,21 +1011,6 @@ static PotentialBindings getPotentialBindings(ConstraintSystem &cs,
   return result;
 }
 
-void ConstraintSystem::getComputedBindings(TypeVariableType *tvt,
-                                               SmallVectorImpl<Type> &bindings) {
-  // If the type variable is fixed, look no further.
-  if (auto fixedType = tvt->getImpl().getFixedType(nullptr)) {
-    bindings.push_back(fixedType);
-    return;
-  }
-  
-  PotentialBindings potentialBindings = getPotentialBindings(*this, tvt);
-  
-  for (auto binding : potentialBindings.Bindings) {
-    bindings.push_back(binding.BindingType);
-  }
-}
-
 /// \brief Try each of the given type variable bindings to find solutions
 /// to the given constraint system.
 ///

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -692,8 +692,38 @@ static PotentialBindings getPotentialBindings(ConstraintSystem &cs,
   llvm::SmallPtrSet<Constraint *, 4> visitedConstraints;
   cs.getConstraintGraph().gatherConstraints(typeVar, constraints);
 
-  // Consider each of the constraints related to this type variable.
   PotentialBindings result;
+  Optional<unsigned> lastSupertypeIndex;
+
+  // Local function to add a potential binding to the list of bindings,
+  // coalescing supertype bounds when we are able to compute the meet.
+  auto addPotentialBinding = [&](PotentialBinding binding) {
+    // If this is a non-defaulted supertype binding, check whether we can
+    // combine it with another supertype binding by computing the 'meet' of the
+    // types.
+    if (binding.Kind == AllowedBindingKind::Supertypes &&
+        !binding.BindingType->hasTypeVariable() &&
+        !binding.DefaultedProtocol &&
+        !binding.IsDefaultableBinding) {
+      if (lastSupertypeIndex) {
+        // Can we compute a meet?
+        auto &lastBinding = result.Bindings[*lastSupertypeIndex];
+        if (auto meet =
+                Type::meet(lastBinding.BindingType, binding.BindingType)) {
+          // Replace the last supertype binding with the meet. We're done.
+          lastBinding.BindingType = meet;
+          return;
+        }
+      }
+
+      // Record this as the most recent supertype index.
+      lastSupertypeIndex = result.Bindings.size();
+    }
+
+    result.Bindings.push_back(std::move(binding));
+  };
+
+  // Consider each of the constraints related to this type variable.
   llvm::SmallPtrSet<CanType, 4> exactTypes;
   llvm::SmallPtrSet<ProtocolDecl *, 4> literalProtocols;
   SmallVector<Constraint *, 2> defaultableConstraints;
@@ -767,8 +797,8 @@ static PotentialBindings getPotentialBindings(ConstraintSystem &cs,
           continue;
 
         result.foundLiteralBinding(constraint->getProtocol());
-        result.Bindings.push_back({defaultType, AllowedBindingKind::Subtypes,
-                                   constraint->getProtocol()});
+        addPotentialBinding({defaultType, AllowedBindingKind::Subtypes,
+                             constraint->getProtocol()});
         continue;
       }
 
@@ -794,8 +824,8 @@ static PotentialBindings getPotentialBindings(ConstraintSystem &cs,
       if (!matched) {
         result.foundLiteralBinding(constraint->getProtocol());
         exactTypes.insert(defaultType->getCanonicalType());
-        result.Bindings.push_back({defaultType, AllowedBindingKind::Subtypes,
-                                   constraint->getProtocol()});
+        addPotentialBinding({defaultType, AllowedBindingKind::Subtypes,
+                             constraint->getProtocol()});
       }
 
       continue;
@@ -935,10 +965,10 @@ static PotentialBindings getPotentialBindings(ConstraintSystem &cs,
     }
 
     if (exactTypes.insert(type->getCanonicalType()).second)
-      result.Bindings.push_back({type, kind, None});
+      addPotentialBinding({type, kind, None});
     if (alternateType &&
         exactTypes.insert(alternateType->getCanonicalType()).second)
-      result.Bindings.push_back({alternateType, kind, None});
+      addPotentialBinding({alternateType, kind, None});
   }
 
   // If we have any literal constraints, check whether there is already a
@@ -1016,7 +1046,7 @@ static PotentialBindings getPotentialBindings(ConstraintSystem &cs,
       continue;
 
     ++result.NumDefaultableBindings;
-    result.Bindings.push_back({type, AllowedBindingKind::Exact, None, true});
+    addPotentialBinding({type, AllowedBindingKind::Exact, None, true});
   }
 
   // Determine if the bindings only constrain the type variable from above with

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -722,7 +722,7 @@ Type ConstraintSystem::openBindingType(Type type,
   Type result = openType(type, locator);
   
   if (isArrayType(type)) {
-    auto boundStruct = cast<BoundGenericStructType>(type.getPointer());
+    auto boundStruct = type->getAs<BoundGenericStructType>();
     if (auto replacement = getTypeChecker().getArraySliceType(
                              SourceLoc(), boundStruct->getGenericArgs()[0])) {
       return replacement;

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -599,6 +599,9 @@ public:
   llvm::SmallDenseMap<ConstraintLocator *, ArchetypeType *>
     OpenedExistentialTypes;
 
+  /// The type variables that were bound via a Defaultable constraint.
+  llvm::SmallPtrSet<TypeVariableType *, 8> DefaultedTypeVariables;
+
   /// \brief Simplify the given type by substituting all occurrences of
   /// type variables for their fixed types.
   Type simplifyType(TypeChecker &tc, Type type) const;
@@ -997,6 +1000,23 @@ private:
   SmallVector<std::pair<ConstraintLocator *, ArchetypeType *>, 4>
     OpenedExistentialTypes;
 
+public:
+  /// The type variables that were bound via a Defaultable constraint.
+  SmallVector<TypeVariableType *, 8> DefaultedTypeVariables;
+
+  /// The type variable used to describe the element type of the given array
+  /// literal.
+  llvm::SmallDenseMap<ArrayExpr *, TypeVariableType *>
+    ArrayElementTypeVariables;
+
+
+  /// The type variables used to describe the key and value types of the given
+  /// dictionary literal.
+  llvm::SmallDenseMap<DictionaryExpr *,
+                      std::pair<TypeVariableType *, TypeVariableType *>>
+    DictionaryElementTypeVariables;
+
+private:
   /// \brief Describes the current solver state.
   struct SolverState {
     SolverState(ConstraintSystem &cs);
@@ -1121,6 +1141,9 @@ public:
 
     /// The length of \c OpenedExistentialTypes.
     unsigned numOpenedExistentialTypes;
+
+    /// The length of \c DefaultedTypeVariables.
+    unsigned numDefaultedTypeVariables;
 
     /// The previous score.
     Score PreviousScore;

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2070,11 +2070,6 @@ public:
   Expr *applySolutionShallow(const Solution &solution, Expr *expr,
                              bool suppressDiagnostics);
   
-  /// \brief Obtain the specializations computed for a type variable. This is
-  /// useful when emitting diagnostics for computed type variables.
-  void getComputedBindings(TypeVariableType *tvt,
-                           SmallVectorImpl<Type> &bindings);
-  
   /// Extract the base type from an array or slice type.
   /// \param type The array type to inspect.
   /// \returns the base type of the array.

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2634,6 +2634,15 @@ void Solution::dump(raw_ostream &out) const {
     }
   }
 
+  if (!DefaultedTypeVariables.empty()) {
+    out << "\nDefaulted type variables: ";
+    interleave(DefaultedTypeVariables, [&](TypeVariableType *typeVar) {
+      out << "$T" << typeVar->getID();
+    }, [&] {
+      out << ", ";
+    });
+  }
+
   if (!Fixes.empty()) {
     out << "\nFixes:\n";
     for (auto &fix : Fixes) {
@@ -2781,6 +2790,15 @@ void ConstraintSystem::print(raw_ostream &out) {
       out << " opens to " << openedExistential.second->getString();
       out << "\n";
     }
+  }
+
+  if (!DefaultedTypeVariables.empty()) {
+    out << "\nDefaulted type variables: ";
+    interleave(DefaultedTypeVariables, [&](TypeVariableType *typeVar) {
+      out << "$T" << typeVar->getID();
+    }, [&] {
+      out << ", ";
+    });
   }
 
   if (failedConstraint) {

--- a/test/Constraints/array_literal.swift
+++ b/test/Constraints/array_literal.swift
@@ -115,3 +115,31 @@ func rdar25563498_ok<T : ExpressibleByArrayLiteral>(t: T) -> T
   let x: T = [1]
   return x
 }
+
+class A { }
+class B : A { }
+class C : A { }
+
+/// Check for defaulting the element type to 'Any'.
+func defaultToAny(i: Int, s: String) {
+  let a1 = [1, "a", 3.5]
+  // expected-error@-1{{heterogenous collection literal could only be inferred to '[Any]'; add explicit type annotation if this is intentional}}
+  let _: Int = a1  // expected-error{{value of type '[Any]'}}
+
+  let a2: Array = [1, "a", 3.5]
+  // expected-error@-1{{heterogenous collection literal could only be inferred to '[Any]'; add explicit type annotation if this is intentional}}
+
+  let _: Int = a2  // expected-error{{value of type '[Any]'}}
+
+  let a3 = []
+  // expected-error@-1{{empty collection literal requires an explicit type}}
+
+  let _: Int = a3 // expected-error{{value of type '[Any]'}}
+
+  let _: [Any] = [1, "a", 3.5]
+  let _: [Any] = [1, "a", [3.5, 3.7, 3.9]]
+  let _: [Any] = [1, "a", [3.5, "b", 3]]
+
+  let a4 = [B(), C()]
+  let _: Int = a4 // expected-error{{value of type '[A]'}}
+}

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -264,7 +264,7 @@ func rdar19831698() {
 // expected-note@-1{{overloads for '+'}}
   var v72 = true + true // expected-error{{binary operator '+' cannot be applied to two 'Bool' operands}}
   // expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists:}}
-  var v73 = true + [] // expected-error{{binary operator '+' cannot be applied to operands of type 'Bool' and '[_]'}}
+  var v73 = true + [] // expected-error{{binary operator '+' cannot be applied to operands of type 'Bool' and '[Any]'}}
   // expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists:}}
   var v75 = true + "str" // expected-error {{binary operator '+' cannot be applied to operands of type 'Bool' and 'String'}} expected-note {{expected an argument list of type '(String, String)'}}
 }

--- a/test/Constraints/dictionary_literal.swift
+++ b/test/Constraints/dictionary_literal.swift
@@ -85,4 +85,10 @@ func testDefaultExistentials() {
 
   let d3 = ["b" : B(), "c" : C()]
   let _: Int = d3 // expected-error{{value of type 'Dictionary<String, A>'}}
+
+  let _ = ["a" : B(), 17 : "seventeen", 3.14159 : "Pi"]
+  // expected-error@-1{{heterogenous collection literal could only be inferred to 'Dictionary<AnyHashable, Any>'}}
+
+  let _ = ["a" : "hello", 17 : "string"]
+  // expected-error@-1{{heterogenous collection literal could only be inferred to 'Dictionary<AnyHashable, String>'}}
 }

--- a/test/Constraints/dictionary_literal.swift
+++ b/test/Constraints/dictionary_literal.swift
@@ -62,3 +62,27 @@ var _: Dictionary<String, Int>? = ["foo" : 1.0]  // expected-error {{cannot conv
 // <rdar://problem/24058895> QoI: Should handle [] in dictionary contexts better
 var _: [Int: Int] = []  // expected-error {{use [:] to get an empty dictionary literal}} {{22-22=:}}
 
+
+class A { }
+class B : A { }
+class C : A { }
+
+func testDefaultExistentials() {
+  let _ = ["a" : 1, "b" : 2.5, "c" : "hello"]
+  // expected-error@-1{{heterogenous collection literal could only be inferred to 'Dictionary<String, Any>'; add explicit type annotation if this is intentional}}{{46-46= as Dictionary<String, Any>}}
+
+  let _: [String : Any] = ["a" : 1, "b" : 2.5, "c" : "hello"]
+
+  let d2 = [:]
+  // expected-error@-1{{empty collection literal requires an explicit type}}
+
+  let _: Int = d2 // expected-error{{value of type 'Dictionary<AnyHashable, Any>'}}
+
+  let _ = ["a" : 1, 
+            "b" : [ "a", 2, 3.14159 ],
+            "c" : [ "a" : 2, "b" : 3.5] ]
+  // expected-error@-3{{heterogenous collection literal could only be inferred to 'Dictionary<String, Any>'; add explicit type annotation if this is intentional}}
+
+  let d3 = ["b" : B(), "c" : C()]
+  let _: Int = d3 // expected-error{{value of type 'Dictionary<String, A>'}}
+}

--- a/test/Constraints/subscript.swift
+++ b/test/Constraints/subscript.swift
@@ -70,9 +70,7 @@ extension Int {
 
 let _ = 1["1"]  // expected-error {{ambiguous use of 'subscript'}}
 
-
-// rdar://17687826 - QoI: error message when reducing to an untyped dictionary isn't helpful
-let squares = [ 1, 2, 3 ].reduce([:]) { (dict, n) in // expected-error {{unable to infer complex closure return type; add explicit type to disambiguate}} {{51-51=-> [_ : _] }}
+let squares = [ 1, 2, 3 ].reduce([:]) { (dict, n) in
   var dict = dict
   dict[n] = n * n
   return dict

--- a/test/IDE/complete_at_top_level.swift
+++ b/test/IDE/complete_at_top_level.swift
@@ -349,7 +349,7 @@ func resyncParserB6() {}
 for i in [] {
   #^TOP_LEVEL_STMT_6^#
 // TOP_LEVEL_STMT_6: Begin completions
-// TOP_LEVEL_STMT_6: Decl[LocalVar]/Local: i[#<<error type>>#]{{; name=.+$}}
+// TOP_LEVEL_STMT_6: Decl[LocalVar]/Local: i[#Any#]{{; name=.+$}}
 // TOP_LEVEL_STMT_6: End completions
 }
 

--- a/test/Parse/pointer_conversion.swift.gyb
+++ b/test/Parse/pointer_conversion.swift.gyb
@@ -187,9 +187,8 @@ func constVoidPointerArguments(_ p: UnsafeMutablePointer<Int>,
   takesConstVoidPointer(ii)
   takesConstVoidPointer(ff)
 
-  // TODO: These two should be accepted, tracked by rdar://17444930.
-  takesConstVoidPointer([0, 1, 2]) // expected-error {{contextual type 'UnsafeRawPointer' cannot be used with array literal}}
-  takesConstVoidPointer([0.0, 1.0, 2.0])  // expected-error {{contextual type 'UnsafeRawPointer' cannot be used with array literal}}
+  takesConstVoidPointer([0, 1, 2])
+  takesConstVoidPointer([0.0, 1.0, 2.0])
 
   // We don't allow these conversions outside of function arguments.
   var x: UnsafeRawPointer = &i // expected-error{{cannot convert value of type 'inout Int' to specified type 'UnsafeRawPointer'}}
@@ -228,9 +227,8 @@ func constRawPointerArguments(_ p: UnsafeMutablePointer<Int>,
   takesConstRawPointer(ii)
   takesConstRawPointer(ff)
 
-  // TODO: These two should be accepted, tracked by rdar://17444930.
-  takesConstRawPointer([0, 1, 2]) // expected-error {{contextual type 'UnsafeRawPointer' cannot be used with array literal}}
-  takesConstRawPointer([0.0, 1.0, 2.0])  // expected-error {{contextual type 'UnsafeRawPointer' cannot be used with array literal}}
+  takesConstRawPointer([0, 1, 2])
+  takesConstRawPointer([0.0, 1.0, 2.0])
 
   // We don't allow these conversions outside of function arguments.
   var x: UnsafeRawPointer = &i // expected-error{{cannot convert value of type 'inout Int' to specified type 'UnsafeRawPointer'}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -675,15 +675,15 @@ func unusedExpressionResults() {
 //===----------------------------------------------------------------------===//
 
 func arrayLiterals() { 
-  var a = [1,2,3]
-  var b : [Int] = []
-  var c = []  // expected-error {{cannot infer type for empty collection literal without a contextual type}}
+  let _ = [1,2,3]
+  let _ : [Int] = []
+  let _ = []  // expected-error {{empty collection literal requires an explicit type}}
 }
 
 func dictionaryLiterals() {
-  var a = [1 : "foo",2 : "bar",3 : "baz"]
-  var b : Dictionary<Int, String> = [:]
-  var c = [:]  // expected-error {{cannot infer type for empty collection literal without a contextual type}}
+  let _ = [1 : "foo",2 : "bar",3 : "baz"]
+  let _: Dictionary<Int, String> = [:]
+  let _ = [:]  // expected-error {{empty collection literal requires an explicit type}}
 }
 
 func invalidDictionaryLiteral() {


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

The id-as-Any work regressed cases where Swift code could specify
heterogeneous collection literals, e.g.,:

```
var states: [String: Any] = [
  "California": [
    "population": 37_000_000,
    "cities": ["Los Angeles", "San Diego", "San Jose"],
  ],
  "Oregon": [
    "population": 4_000_000,
    "cities": ["Portland", "Salem", "Eugene"],
  ]
]
```

Prior to this, the code worked (when Foundation was imported) because
we'd end up with literals of type `[NSObject : AnyObject]`.

The new defaulting rule says that the element type of an array literal
and the key/value types of a dictionary literal can be defaulted if no
stronger type can be inferred. The default type is:
- `Any`, for the element type of an array literal or the value type of a dictionary literal, or
- `AnyHashable`, for the key type of a dictionary literal.

The latter is intended to compose with implicit conversions to
`AnyHashable`, so the most-general inferred dictionary type is
`[AnyHashable : Any]` and will work for any plausible dictionary
literal.

To prevent this inference from diluting types too greatly, we don't
allow this inference in "top-level" expressions, e.g.,:

  let d = ["a" : 1, "b" : "two"]

will produce an error because it's a heterogeneous dictionary literal
at the top level. One should annotate this with, e.g.,:

  let d = ["a" : 1, "b" : "two"] as [String : Any]

However, we do permit heterogeneous collections in nested positions,
to support cases like the original motivating example.
#### Resolved bug number: ([rdar://problem/27661580](rdar://problem/27661580))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
