### PR TITLE
Prefer withVaList over getVaList

### DIFF
--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -124,13 +124,15 @@ public var stderr : UnsafeMutablePointer<FILE> {
 }
 
 public func dprintf(_ fd: Int, _ format: UnsafePointer<Int8>, _ args: CVarArg...) -> Int32 {
-  let va_args = getVaList(args)
-  return vdprintf(Int32(fd), format, va_args)
+  return withVaList(args) { va_args in
+    vdprintf(Int32(fd), format, va_args)
+  }
 }
 
 public func snprintf(ptr: UnsafeMutablePointer<Int8>, _ len: Int, _ format: UnsafePointer<Int8>, _ args: CVarArg...) -> Int32 {
-  let va_args = getVaList(args)
-  return vsnprintf(ptr, len, format, va_args)
+  return withVaList(args) { va_args in
+    return vsnprintf(ptr, len, format, va_args)
+  }
 }
 #endif
 

--- a/stdlib/public/SDK/os/os.swift
+++ b/stdlib/public/SDK/os/os.swift
@@ -27,8 +27,9 @@ public func os_log(
 		// Since dladdr is in libc, it is safe to unsafeBitCast
                 // the cstring argument type.
 		let str = unsafeBitCast(buf.baseAddress!, to: UnsafePointer<Int8>.self)
-		let valist = getVaList(args)
-		_swift_os_log(dso, log, type, str, valist)
+		withVaList(args) { valist in
+		  _swift_os_log(dso, log, type, str, valist)
+    }
 	}
 }
 

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -94,7 +94,7 @@ internal func _withVaList<R>(
 /// - Warning: This function is best avoided in favor of
 ///   `withVaList`, but occasionally (i.e. in a `class` initializer) you
 ///   may find that the language rules don't allow you to use
-/// `withVaList` as intended.
+///   `withVaList` as intended.
 public func getVaList(_ args: [CVarArg]) -> CVaListPointer {
   let builder = _VaListBuilder()
   for a in args {


### PR DESCRIPTION
getVaList introduces needless autorelease, and should go away eventually
