### PR TITLE
[swiftc (38 vs. 5156)] Add crasher in swift::constraints::ConstraintGraph::addConstraint(...)

### DIFF
--- a/validation-test/compiler_crashers/28385-swift-constraints-constraintgraph-addconstraint.swift
+++ b/validation-test/compiler_crashers/28385-swift-constraints-constraintgraph-addconstraint.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+assert((n:String{


### PR DESCRIPTION
Add test case for crash triggered in `swift::constraints::ConstraintGraph::addConstraint(...)`.

Current number of unresolved compiler crashers: 38 (5156 resolved)

Assertion failure in [`lib/Sema/ConstraintGraph.cpp (line 50)`](https://github.com/apple/swift/blob/master/lib/Sema/ConstraintGraph.cpp#L50):

```
Assertion `impl.getGraphIndex() < TypeVariables.size() && "Out-of-bounds index"' failed.

When executing: std::pair<ConstraintGraphNode &, unsigned int> swift::constraints::ConstraintGraph::lookupNode(swift::TypeVariableType *)
```

Assertion context:

```
std::pair<ConstraintGraphNode &, unsigned>
ConstraintGraph::lookupNode(TypeVariableType *typeVar) {
  // Check whether we've already created a node for this type variable.
  auto &impl = typeVar->getImpl();
  if (auto nodePtr = impl.getGraphNode()) {
    assert(impl.getGraphIndex() < TypeVariables.size() && "Out-of-bounds index");
    assert(TypeVariables[impl.getGraphIndex()] == typeVar &&
           "Type variable mismatch");
    return { *nodePtr, impl.getGraphIndex() };
  }

```

Stack trace:

```
swift: /path/to/swift/lib/Sema/ConstraintGraph.cpp:50: std::pair<ConstraintGraphNode &, unsigned int> swift::constraints::ConstraintGraph::lookupNode(swift::TypeVariableType *): Assertion `impl.getGraphIndex() < TypeVariables.size() && "Out-of-bounds index"' failed.
9  swift           0x000000000100b20f swift::constraints::ConstraintGraph::addConstraint(swift::constraints::Constraint*) + 127
10 swift           0x0000000000f62b62 swift::constraints::ConstraintSystem::addConstraint(swift::constraints::Constraint*, bool, bool) + 258
11 swift           0x0000000000fc8085 swift::constraints::ConstraintSystem::matchTypes(swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 1685
12 swift           0x0000000000fcc186 swift::constraints::ConstraintSystem::matchTupleToScalarTypes(swift::TupleType*, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 182
13 swift           0x0000000000fcd2c2 swift::constraints::ConstraintSystem::simplifyRestrictedConstraint(swift::constraints::ConversionRestrictionKind, swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 978
14 swift           0x0000000000fca954 swift::constraints::ConstraintSystem::matchTypes(swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 12132
15 swift           0x0000000000fd4866 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 630
16 swift           0x0000000000f62a77 swift::constraints::ConstraintSystem::addConstraint(swift::constraints::Constraint*, bool, bool) + 23
17 swift           0x0000000000ec690a swift::TypeChecker::typesSatisfyConstraint(swift::Type, swift::Type, swift::constraints::ConstraintKind, swift::DeclContext*) + 138
18 swift           0x0000000000ec6a5f swift::TypeChecker::typeCheckCheckedCast(swift::Type, swift::Type, swift::DeclContext*, swift::SourceLoc, swift::SourceRange, swift::SourceRange, std::function<bool (swift::Type)>, bool) + 79
20 swift           0x0000000000f8a352 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 114
21 swift           0x0000000000f9070e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4078
22 swift           0x0000000000ebd169 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 857
23 swift           0x0000000000ec413d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 621
26 swift           0x0000000000f8a340 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 96
27 swift           0x0000000000f9070e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4078
28 swift           0x0000000000ebd169 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 857
29 swift           0x0000000000ec413d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 621
33 swift           0x0000000000f8a340 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 96
34 swift           0x0000000000f9070e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4078
35 swift           0x0000000000ebd169 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 857
36 swift           0x0000000000ec413d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 621
38 swift           0x0000000000f407b6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
39 swift           0x0000000000efb10d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
40 swift           0x0000000000c7b599 swift::CompilerInstance::performSema() + 3289
42 swift           0x00000000007db4c7 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
43 swift           0x00000000007a72b8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28385-swift-constraints-constraintgraph-addconstraint.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28385-swift-constraints-constraintgraph-addconstraint-8d8da3.o
1.  While type-checking expression at [validation-test/compiler_crashers/28385-swift-constraints-constraintgraph-addconstraint.swift:10:1 - line:10:17] RangeText="assert((n:String{"
2.  While type-checking expression at [validation-test/compiler_crashers/28385-swift-constraints-constraintgraph-addconstraint.swift:10:7 - line:10:17] RangeText="((n:String{"
3.  While type-checking expression at [validation-test/compiler_crashers/28385-swift-constraints-constraintgraph-addconstraint.swift:10:8 - line:10:17] RangeText="(n:String{"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
