### PR TITLE
fix neg count SR-1988

### DIFF
--- a/stdlib/public/SDK/Foundation/ExtraStringAPIs.swift
+++ b/stdlib/public/SDK/Foundation/ExtraStringAPIs.swift
@@ -21,7 +21,7 @@ extension String.UTF16View.Index : Strideable {
   }
 
   public func distance(to other: String.UTF16View.Index) -> Int {
-    return other._offset.distance(to: _offset)
+    return _offset.distance(to: other._offset)
   }
 
   public func advanced(by n: Int) -> String.UTF16View.Index {

--- a/test/1_stdlib/StringAPI.swift
+++ b/test/1_stdlib/StringAPI.swift
@@ -323,6 +323,22 @@ StringTests.test("CompareStringsWithUnpairedSurrogates")
   )
 }
 
+//[SR-1988] Ranges of String.UTF16View.Index have negative count
+StringTests.test("String.UTF16View.Index-count") {
+  let str = "How many elements do I contain?".utf16
+  let indices: Range = str.startIndex ..< str.endIndex
+  expectEqual(indices.count , 31)
+  expectTrue(indices.count >= 0)
+  
+  let blank = "".utf16
+  let blankindices: Range = blank.startIndex ..< blank.endIndex
+  expectEqual(indices.count , 0)
+  
+  let one = "1".utf16
+  let oneindices: Range = one.startIndex ..< one.endIndex
+  expectEqual(indices.count , 1)
+}
+
 var CStringTests = TestSuite("CStringTests")
 
 func getNullUTF8() -> UnsafeMutablePointer<UInt8>? {


### PR DESCRIPTION
#### What's in this pull request?

Ranges of String.UTF16View.Index have negative count 
#### Resolved bug number: 1988 (https://bugs.swift.org/browse/SR-1988))

swift-corelibs-foundation pull https://github.com/apple/swift-corelibs-foundation/pull/505
