### PR TITLE
[swiftc (39 vs. 5156)] Add crasher in swift::TypeBase::getDesugaredType(...)

### DIFF
--- a/validation-test/compiler_crashers/28386-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers/28386-swift-typebase-getdesugaredtype.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+struct A{init(){let:A
+class B:A
+class A:B{
+init()


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getDesugaredType(...)`.

Current number of unresolved compiler crashers: 39 (5156 resolved)

Stack trace:

```
4  swift           0x0000000001157360 swift::TypeBase::getDesugaredType() + 32
6  swift           0x0000000000edc01e swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 654
7  swift           0x0000000000ecfa1e swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 5998
8  swift           0x0000000000ed0d97 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 375
12 swift           0x0000000000f4676e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
14 swift           0x0000000000f476b4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
15 swift           0x0000000000f46660 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
16 swift           0x0000000000ecf74a swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 5274
17 swift           0x0000000000ed0d97 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 375
21 swift           0x0000000000f4676e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
23 swift           0x0000000000f476b4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
24 swift           0x0000000000f46660 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
25 swift           0x0000000000f18f01 swift::TypeChecker::typeCheckPattern(swift::Pattern*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) + 945
28 swift           0x0000000000ed7186 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
31 swift           0x0000000000f3f7bd swift::TypeChecker::typeCheckConstructorBodyUntil(swift::ConstructorDecl*, swift::SourceLoc) + 845
32 swift           0x0000000000f3f1c2 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 34
33 swift           0x0000000000f3fd93 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
35 swift           0x0000000000efb1c1 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
36 swift           0x0000000000c7b5b9 swift::CompilerInstance::performSema() + 3289
38 swift           0x00000000007db4e7 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
39 swift           0x00000000007a72d8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28386-swift-typebase-getdesugaredtype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28386-swift-typebase-getdesugaredtype-c6011a.o
1.  While type-checking 'init' at validation-test/compiler_crashers/28386-swift-typebase-getdesugaredtype.swift:9:10
2.  While type-checking declaration 0x6733b58 at validation-test/compiler_crashers/28386-swift-typebase-getdesugaredtype.swift:9:17
3.  While resolving type A at [validation-test/compiler_crashers/28386-swift-typebase-getdesugaredtype.swift:9:21 - line:9:21] RangeText="A"
4.  While resolving type B at [validation-test/compiler_crashers/28386-swift-typebase-getdesugaredtype.swift:11:9 - line:11:9] RangeText="B"
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
