### PR TITLE
[swiftc (40 vs. 5156)] Add crasher in swift::TypeBase::gatherAllSubstitutions(...)

### DIFF
--- a/validation-test/compiler_crashers/28387-swift-typebase-gatherallsubstitutions.swift
+++ b/validation-test/compiler_crashers/28387-swift-typebase-gatherallsubstitutions.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+protocol a{typealias B<>:a{}typealias d)class B<T>:a{
+struct B<T>:a
+protocol c{
+}
+func c:d


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::gatherAllSubstitutions(...)`.

Current number of unresolved compiler crashers: 40 (5156 resolved)

Stack trace:

```
6  swift           0x00000000032eac4d llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) + 461
7  swift           0x0000000001130f7e swift::TypeBase::gatherAllSubstitutions(swift::ModuleDecl*, swift::LazyResolver*, swift::DeclContext*) + 4398
8  swift           0x0000000001131647 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) + 1607
9  swift           0x0000000000f1e3ca swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::ProtocolConformance**, swift::SourceLoc) + 106
12 swift           0x0000000000f219be swift::TypeChecker::resolveTypeWitness(swift::NormalProtocolConformance const*, swift::AssociatedTypeDecl*) + 254
13 swift           0x000000000114c126 swift::NormalProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 150
14 swift           0x000000000114c068 swift::ProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 40
15 swift           0x000000000114c356 swift::SpecializedProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 230
16 swift           0x000000000114c052 swift::ProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 18
17 swift           0x000000000114c836 swift::ProtocolConformance::getTypeWitness(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 6
18 swift           0x0000000000f45655 swift::TypeChecker::resolveTypeInContext(swift::TypeDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 2373
22 swift           0x0000000000f4676e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
24 swift           0x0000000000f476b4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
25 swift           0x0000000000f46660 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
27 swift           0x0000000000f10d7e swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 94
30 swift           0x0000000000ed0fd1 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 945
36 swift           0x0000000000ed7186 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
37 swift           0x0000000000efb0c2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
38 swift           0x0000000000c7b5b9 swift::CompilerInstance::performSema() + 3289
40 swift           0x00000000007db4e7 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
41 swift           0x00000000007a72d8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28387-swift-typebase-gatherallsubstitutions.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28387-swift-typebase-gatherallsubstitutions-896572.o
1.  While type-checking 'a' at validation-test/compiler_crashers/28387-swift-typebase-gatherallsubstitutions.swift:9:1
2.  While type-checking 'c' at validation-test/compiler_crashers/28387-swift-typebase-gatherallsubstitutions.swift:13:1
3.  While resolving type d at [validation-test/compiler_crashers/28387-swift-typebase-gatherallsubstitutions.swift:13:8 - line:13:8] RangeText="d"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
