### PR TITLE
[swiftc (41 vs. 5156)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28388-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28388-swift-typebase-getcanonicaltype.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+class A{protocol a{struct d:a{{}class B<T>:A{{}}let c=f=1}typealias f)typealias B<>:AnyObject


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 41 (5156 resolved)

Stack trace:

```
4  swift           0x0000000001152aa4 swift::TypeBase::getCanonicalType() + 20
5  swift           0x00000000011314bf swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) + 1215
6  swift           0x0000000000f1e3ca swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::ProtocolConformance**, swift::SourceLoc) + 106
9  swift           0x0000000000f219be swift::TypeChecker::resolveTypeWitness(swift::NormalProtocolConformance const*, swift::AssociatedTypeDecl*) + 254
10 swift           0x000000000114c126 swift::NormalProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 150
11 swift           0x000000000114c068 swift::ProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 40
13 swift           0x0000000000f14f64 swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 404
14 swift           0x0000000000ebb724 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 116
17 swift           0x0000000001099f4b swift::Expr::walk(swift::ASTWalker&) + 75
18 swift           0x0000000000ebcf10 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 224
19 swift           0x0000000000ec415d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 621
20 swift           0x0000000000ec5310 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 352
21 swift           0x0000000000ec552b swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
30 swift           0x0000000000ed7186 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
31 swift           0x0000000000efb0c2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
32 swift           0x0000000000c7b5b9 swift::CompilerInstance::performSema() + 3289
34 swift           0x00000000007db4e7 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
35 swift           0x00000000007a72d8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28388-swift-typebase-getcanonicaltype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28388-swift-typebase-getcanonicaltype-da6437.o
1.  While type-checking 'A' at validation-test/compiler_crashers/28388-swift-typebase-getcanonicaltype.swift:9:1
2.  While type-checking expression at [validation-test/compiler_crashers/28388-swift-typebase-getcanonicaltype.swift:9:55 - line:9:57] RangeText="f=1"
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
