### PR TITLE
[stdlib] Deprecate ContiguousArray (do not merge yet)

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -448,6 +448,9 @@ ${SelfDocComment}
 % if Self != 'ArraySlice':
 @_fixed_layout
 %end
+% if Self == 'ContiguousArray':
+@available(*, deprecated, renamed: "Array")
+%end
 public struct ${Self}<Element>
   : RandomAccessCollection,
     MutableCollection,

--- a/test/1_stdlib/Renames.swift
+++ b/test/1_stdlib/Renames.swift
@@ -14,7 +14,7 @@ func _Arrays<T>(e: T) {
   // _ = Array(count: 1, repeatedValue: e) // xpected-error {{Please use init(repeating:count:) instead}} {{none}}
   // The actual error is: {{argument 'repeatedValue' must precede argument 'count'}}
 
-  var a = ContiguousArray<T>()
+  var a = ContiguousArray<T>() // expected-warning {{'ContiguousArray' is deprecated: renamed to 'Array'}} expected-note {{use 'Array' instead}}
   _ = a.removeAtIndex(0) // expected-error {{'removeAtIndex' has been renamed to 'remove(at:)'}} {{9-22=remove}} {{23-23=at: }} {{none}}
   _ = a.replaceRange(0..<1, with: []) // expected-error {{'replaceRange(_:with:)' has been renamed to 'replaceSubrange(_:with:)'}} {{9-21=replaceSubrange}} {{none}}
   _ = a.appendContentsOf([]) // expected-error {{'appendContentsOf' has been renamed to 'append(contentsOf:)'}} {{9-25=append}} {{26-26=contentsOf: }} {{none}}

--- a/test/expr/cast/array_coerce.swift
+++ b/test/expr/cast/array_coerce.swift
@@ -38,8 +38,8 @@ cs = ds // expected-error{{cannot assign value of type 'ArraySlice<D>' to type '
 ds = cs // expected-error{{cannot assign value of type 'ArraySlice<C>' to type 'ArraySlice<D>'}}
 
 // ContiguousArray<T>
-var cna: ContiguousArray<C> = [c1]
-var dna: ContiguousArray<D> = [d1]
+var cna: ContiguousArray<C> = [c1] // expected-warning {{'ContiguousArray' is deprecated: renamed to 'Array'}} expected-note {{use 'Array' instead}}
+var dna: ContiguousArray<D> = [d1] // expected-warning {{'ContiguousArray' is deprecated: renamed to 'Array'}} expected-note {{use 'Array' instead}}
 
 cna = dna // expected-error{{cannot assign value of type 'ContiguousArray<D>' to type 'ContiguousArray<C>'}}
 dna = cna // expected-error{{cannot assign value of type 'ContiguousArray<C>' to type 'ContiguousArray<D>'}}


### PR DESCRIPTION
I want to come back and try to turn it into a typealias, but as that is not API-changing it can wait.
