### PR TITLE
Deprecate the Indexable protocols

### DIFF
--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -16,7 +16,7 @@
 /// In most cases, it's best to ignore this protocol and use the
 /// `BidirectionalCollection` protocol instead, because it has a more complete
 /// interface.
-@available(*, deprecated, renamed: "BidirectionalCollection")
+@available(*, deprecated, message: "it will be removed in Swift 4.0.  Please use 'BidirectionalCollection' instead")
 public protocol BidirectionalIndexable : Indexable {
   // FIXME(ABI)(compiler limitation): there is no reason for this protocol
   // to exist apart from missing compiler features that we emulate with it.

--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -16,6 +16,7 @@
 /// In most cases, it's best to ignore this protocol and use the
 /// `BidirectionalCollection` protocol instead, because it has a more complete
 /// interface.
+@available(*, deprecated, renamed: "BidirectionalCollection")
 public protocol BidirectionalIndexable : Indexable {
   // FIXME(ABI)(compiler limitation): there is no reason for this protocol
   // to exist apart from missing compiler features that we emulate with it.

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -15,7 +15,7 @@
 ///
 /// In most cases, it's best to ignore this protocol and use the `Collection`
 /// protocol instead, because it has a more complete interface.
-@available(*, deprecated, renamed: "Collection")
+@available(*, deprecated, message: "it will be removed in Swift 4.0.  Please use 'Collection' instead")
 public protocol IndexableBase {
   // FIXME(ABI)(compiler limitation): there is no reason for this protocol
   // to exist apart from missing compiler features that we emulate with it.
@@ -157,7 +157,7 @@ public protocol IndexableBase {
 ///
 /// In most cases, it's best to ignore this protocol and use the `Collection`
 /// protocol instead, because it has a more complete interface.
-@available(*, deprecated, renamed: "Collection")
+@available(*, deprecated, message: "it will be removed in Swift 4.0.  Please use 'Collection' instead")
 public protocol Indexable : IndexableBase {
   /// A type used to represent the number of steps between two indices, where
   /// one value is reachable from the other.

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -15,6 +15,7 @@
 ///
 /// In most cases, it's best to ignore this protocol and use the `Collection`
 /// protocol instead, because it has a more complete interface.
+@available(*, deprecated, renamed: "Collection")
 public protocol IndexableBase {
   // FIXME(ABI)(compiler limitation): there is no reason for this protocol
   // to exist apart from missing compiler features that we emulate with it.
@@ -156,6 +157,7 @@ public protocol IndexableBase {
 ///
 /// In most cases, it's best to ignore this protocol and use the `Collection`
 /// protocol instead, because it has a more complete interface.
+@available(*, deprecated, renamed: "Collection")
 public protocol Indexable : IndexableBase {
   /// A type used to represent the number of steps between two indices, where
   /// one value is reachable from the other.
@@ -1703,3 +1705,4 @@ extension Collection where Iterator.Element : Equatable {
 
 @available(*, unavailable, message: "PermutationGenerator has been removed in Swift 3")
 public struct PermutationGenerator<C : Collection, Indices : Sequence> {}
+

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -15,6 +15,7 @@
 /// In most cases, it's best to ignore this protocol and use the
 /// `MutableCollection` protocol instead, because it has a more complete
 /// interface.
+@available(*, deprecated, renamed: "MutableCollection")
 public protocol MutableIndexable : Indexable {
   // FIXME(ABI)(compiler limitation): there is no reason for this protocol
   // to exist apart from missing compiler features that we emulate with it.

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -15,7 +15,7 @@
 /// In most cases, it's best to ignore this protocol and use the
 /// `MutableCollection` protocol instead, because it has a more complete
 /// interface.
-@available(*, deprecated, renamed: "MutableCollection")
+@available(*, deprecated, message: "it will be removed in Swift 4.0.  Please use 'MutableCollection' instead")
 public protocol MutableIndexable : Indexable {
   // FIXME(ABI)(compiler limitation): there is no reason for this protocol
   // to exist apart from missing compiler features that we emulate with it.

--- a/stdlib/public/core/RandomAccessCollection.swift
+++ b/stdlib/public/core/RandomAccessCollection.swift
@@ -15,7 +15,7 @@
 /// In most cases, it's best to ignore this protocol and use the
 /// `RandomAccessCollection` protocol instead, because it has a more complete
 /// interface.
-@available(*, deprecated, renamed: "RandomAccessCollection")
+@available(*, deprecated, message: "it will be removed in Swift 4.0.  Please use 'RandomAccessCollection' instead")
 public protocol RandomAccessIndexable : BidirectionalIndexable {
   // FIXME(ABI)(compiler limitation): there is no reason for this protocol
   // to exist apart from missing compiler features that we emulate with it.

--- a/stdlib/public/core/RandomAccessCollection.swift
+++ b/stdlib/public/core/RandomAccessCollection.swift
@@ -15,6 +15,7 @@
 /// In most cases, it's best to ignore this protocol and use the
 /// `RandomAccessCollection` protocol instead, because it has a more complete
 /// interface.
+@available(*, deprecated, renamed: "RandomAccessCollection")
 public protocol RandomAccessIndexable : BidirectionalIndexable {
   // FIXME(ABI)(compiler limitation): there is no reason for this protocol
   // to exist apart from missing compiler features that we emulate with it.

--- a/stdlib/public/core/RangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/RangeReplaceableCollection.swift.gyb
@@ -22,6 +22,7 @@
 /// In most cases, it's best to ignore this protocol and use the
 /// `RangeReplaceableCollection` protocol instead, because it has a more
 /// complete interface.
+@available(*, deprecated, renamed: "RangeReplaceableCollection")
 public protocol RangeReplaceableIndexable : Indexable {
   // FIXME(ABI)(compiler limitation): there is no reason for this protocol
   // to exist apart from missing compiler features that we emulate with it.

--- a/stdlib/public/core/RangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/RangeReplaceableCollection.swift.gyb
@@ -22,7 +22,7 @@
 /// In most cases, it's best to ignore this protocol and use the
 /// `RangeReplaceableCollection` protocol instead, because it has a more
 /// complete interface.
-@available(*, deprecated, renamed: "RangeReplaceableCollection")
+@available(*, deprecated, message: "it will be removed in Swift 4.0.  Please use 'RandomAccessCollection' instead")
 public protocol RangeReplaceableIndexable : Indexable {
   // FIXME(ABI)(compiler limitation): there is no reason for this protocol
   // to exist apart from missing compiler features that we emulate with it.

--- a/validation-test/stdlib/CollectionDiagnostics.swift
+++ b/validation-test/stdlib/CollectionDiagnostics.swift
@@ -54,8 +54,7 @@ func sortResultIgnored<
   array.sorted { $0 < $1 } // expected-warning {{result of call to 'sorted(by:)' is unused}}
 }
 
-// expected-warning@+2 {{'Indexable' is deprecated: renamed to 'Collection'}}
-// expected-note@+1 {{use 'Collection' instead}}
+// expected-warning@+1 {{'Indexable' is deprecated: it will be removed in Swift 4.0.  Please use 'Collection' instead}}
 struct GoodIndexable : Indexable { 
   func index(after i: Int) -> Int { return i + 1 }
   var startIndex: Int { return 0 }
@@ -66,8 +65,7 @@ struct GoodIndexable : Indexable {
 }
 
 
-// expected-warning@+3 {{'Indexable' is deprecated: renamed to 'Collection'}}
-// expected-note@+2 {{use 'Collection' instead}}
+// expected-warning@+2 {{'Indexable' is deprecated: it will be removed in Swift 4.0.  Please use 'Collection' instead}}
 // expected-error@+1 {{type 'BadIndexable1' does not conform to protocol 'IndexableBase'}}
 struct BadIndexable1 : Indexable {
   func index(after i: Int) -> Int { return i + 1 }
@@ -79,8 +77,7 @@ struct BadIndexable1 : Indexable {
   // Missing 'subscript(_:) -> SubSequence'.
 }
 
-// expected-warning@+3 {{'Indexable' is deprecated: renamed to 'Collection'}}
-// expected-note@+2 {{use 'Collection' instead}}
+// expected-warning@+2 {{'Indexable' is deprecated: it will be removed in Swift 4.0.  Please use 'Collection' instead}}
 // expected-error@+1 {{type 'BadIndexable2' does not conform to protocol 'IndexableBase'}}
 struct BadIndexable2 : Indexable {
   var startIndex: Int { return 0 }
@@ -91,8 +88,7 @@ struct BadIndexable2 : Indexable {
   // Missing index(after:) -> Int
 }
 
-// expected-warning@+2 {{'BidirectionalIndexable' is deprecated: renamed to 'BidirectionalCollection'}}
-// expected-note@+1 {{use 'BidirectionalCollection' instead}}
+// expected-warning@+1 {{'BidirectionalIndexable' is deprecated: it will be removed in Swift 4.0.  Please use 'BidirectionalCollection' instead}}
 struct GoodBidirectionalIndexable1 : BidirectionalIndexable {
   var startIndex: Int { return 0 }
   var endIndex: Int { return 0 }
@@ -105,8 +101,7 @@ struct GoodBidirectionalIndexable1 : BidirectionalIndexable {
 
 // We'd like to see: {{type 'BadBidirectionalIndexable' does not conform to protocol 'BidirectionalIndexable'}}
 // But the compiler doesn't generate that error.
-// expected-warning@+2 {{'BidirectionalIndexable' is deprecated: renamed to 'BidirectionalCollection'}}
-// expected-note@+1 {{use 'BidirectionalCollection' instead}}
+// expected-warning@+1 {{'BidirectionalIndexable' is deprecated: it will be removed in Swift 4.0.  Please use 'BidirectionalCollection' instead}}
 struct BadBidirectionalIndexable : BidirectionalIndexable {
   var startIndex: Int { return 0 }
   var endIndex: Int { return 0 }

--- a/validation-test/stdlib/CollectionDiagnostics.swift
+++ b/validation-test/stdlib/CollectionDiagnostics.swift
@@ -54,7 +54,9 @@ func sortResultIgnored<
   array.sorted { $0 < $1 } // expected-warning {{result of call to 'sorted(by:)' is unused}}
 }
 
-struct GoodIndexable : Indexable {
+// expected-warning@+2 {{'Indexable' is deprecated: renamed to 'Collection'}}
+// expected-note@+1 {{use 'Collection' instead}}
+struct GoodIndexable : Indexable { 
   func index(after i: Int) -> Int { return i + 1 }
   var startIndex: Int { return 0 }
   var endIndex: Int { return 0 }
@@ -64,6 +66,8 @@ struct GoodIndexable : Indexable {
 }
 
 
+// expected-warning@+3 {{'Indexable' is deprecated: renamed to 'Collection'}}
+// expected-note@+2 {{use 'Collection' instead}}
 // expected-error@+1 {{type 'BadIndexable1' does not conform to protocol 'IndexableBase'}}
 struct BadIndexable1 : Indexable {
   func index(after i: Int) -> Int { return i + 1 }
@@ -75,6 +79,8 @@ struct BadIndexable1 : Indexable {
   // Missing 'subscript(_:) -> SubSequence'.
 }
 
+// expected-warning@+3 {{'Indexable' is deprecated: renamed to 'Collection'}}
+// expected-note@+2 {{use 'Collection' instead}}
 // expected-error@+1 {{type 'BadIndexable2' does not conform to protocol 'IndexableBase'}}
 struct BadIndexable2 : Indexable {
   var startIndex: Int { return 0 }
@@ -85,6 +91,8 @@ struct BadIndexable2 : Indexable {
   // Missing index(after:) -> Int
 }
 
+// expected-warning@+2 {{'BidirectionalIndexable' is deprecated: renamed to 'BidirectionalCollection'}}
+// expected-note@+1 {{use 'BidirectionalCollection' instead}}
 struct GoodBidirectionalIndexable1 : BidirectionalIndexable {
   var startIndex: Int { return 0 }
   var endIndex: Int { return 0 }
@@ -97,6 +105,8 @@ struct GoodBidirectionalIndexable1 : BidirectionalIndexable {
 
 // We'd like to see: {{type 'BadBidirectionalIndexable' does not conform to protocol 'BidirectionalIndexable'}}
 // But the compiler doesn't generate that error.
+// expected-warning@+2 {{'BidirectionalIndexable' is deprecated: renamed to 'BidirectionalCollection'}}
+// expected-note@+1 {{use 'BidirectionalCollection' instead}}
 struct BadBidirectionalIndexable : BidirectionalIndexable {
   var startIndex: Int { return 0 }
   var endIndex: Int { return 0 }


### PR DESCRIPTION
These should really never be used except by the standard library
