### PR TITLE
[swiftc (42 vs. 5156)] Add crasher in swift::lookupVisibleDecls(...)

### DIFF
--- a/validation-test/compiler_crashers/28389-swift-lookupvisibledecls.swift
+++ b/validation-test/compiler_crashers/28389-swift-lookupvisibledecls.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+struct B{let d=A.b}class A:A{let a=V


### PR DESCRIPTION
Add test case for crash triggered in `swift::lookupVisibleDecls(...)`.

Current number of unresolved compiler crashers: 42 (5156 resolved)

Assertion failure in [`lib/AST/LookupVisibleDecls.cpp (line 566)`](https://github.com/apple/swift/blob/master/lib/AST/LookupVisibleDecls.cpp#L566):

```
Assertion `BaseTy.getPointer() != CurClass->getSuperclass().getPointer() && "type is its own superclass"' failed.

When executing: void lookupVisibleMemberDeclsImpl(swift::Type, swift::VisibleDeclConsumer &, const swift::DeclContext *, (anonymous namespace)::LookupState, swift::DeclVisibilityKind, swift::LazyResolver *, VisitedSet &)
```

Assertion context:

```
    // If we have a class type, look into its superclass.
    ClassDecl *CurClass = dyn_cast<ClassDecl>(CurNominal);

    if (CurClass && CurClass->hasSuperclass()) {
      assert(BaseTy.getPointer() != CurClass->getSuperclass().getPointer() &&
             "type is its own superclass");
      BaseTy = CurClass->getSuperclass();
      Reason = getReasonForSuper(Reason);

      bool InheritsSuperclassInitializers =
          CurClass->inheritsSuperclassInitializers(TypeResolver);
```

Stack trace:

```
swift: /path/to/swift/lib/AST/LookupVisibleDecls.cpp:566: void lookupVisibleMemberDeclsImpl(swift::Type, swift::VisibleDeclConsumer &, const swift::DeclContext *, (anonymous namespace)::LookupState, swift::DeclVisibilityKind, swift::LazyResolver *, VisitedSet &): Assertion `BaseTy.getPointer() != CurClass->getSuperclass().getPointer() && "type is its own superclass"' failed.
10 swift           0x0000000001121734 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 1188
11 swift           0x0000000000f16672 swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::Type, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) + 290
12 swift           0x0000000000ebc9ba swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 4058
14 swift           0x000000000109a4fb swift::Expr::walk(swift::ASTWalker&) + 27
15 swift           0x0000000000ebd240 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 224
16 swift           0x0000000000ec448d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 621
17 swift           0x0000000000ec5640 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 352
18 swift           0x0000000000ec585b swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
20 swift           0x0000000000ed1e5b swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3851
25 swift           0x0000000000f1665b swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::Type, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) + 267
27 swift           0x0000000000f8af6c swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 2364
28 swift           0x0000000000f90a5e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4078
29 swift           0x0000000000ebd4b9 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 857
30 swift           0x0000000000ec448d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 621
31 swift           0x0000000000ec5640 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 352
32 swift           0x0000000000ec585b swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
37 swift           0x0000000000ed74b6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
38 swift           0x0000000000efb3f2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
39 swift           0x0000000000c7b5c9 swift::CompilerInstance::performSema() + 3289
41 swift           0x00000000007db4f7 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
42 swift           0x00000000007a7328 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28389-swift-lookupvisibledecls.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28389-swift-lookupvisibledecls-e9a1a8.o
1.  While type-checking 'B' at validation-test/compiler_crashers/28389-swift-lookupvisibledecls.swift:10:1
2.  While type-checking expression at [validation-test/compiler_crashers/28389-swift-lookupvisibledecls.swift:10:16 - line:10:18] RangeText="A.b"
3.  While type-checking expression at [validation-test/compiler_crashers/28389-swift-lookupvisibledecls.swift:10:36 - line:10:36] RangeText="V"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
