### PR TITLE
[swiftc (43 vs. 5156)] Add crasher in swift::Expr::walk(...)

### DIFF
--- a/validation-test/compiler_crashers/28390-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers/28390-swift-expr-walk.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+.h={return
+class c


### PR DESCRIPTION
Add test case for crash triggered in `swift::Expr::walk(...)`.

Current number of unresolved compiler crashers: 43 (5156 resolved)

Assertion failure in [`include/swift/AST/Stmt.h (line 170)`](https://github.com/apple/swift/blob/master/include/swift/AST/Stmt.h#L170):

```
Assertion `Result && "ReturnStmt doesn't have a result"' failed.

When executing: swift::Expr *swift::ReturnStmt::getResult() const
```

Assertion context:

```
  SourceLoc getStartLoc() const;
  SourceLoc getEndLoc() const;

  bool hasResult() const { return Result != 0; }
  Expr *getResult() const {
    assert(Result && "ReturnStmt doesn't have a result");
    return Result;
  }
  void setResult(Expr *e) { Result = e; }

  static bool classof(const Stmt *S) { return S->getKind() == StmtKind::Return;}
```

Stack trace:

```
swift: /path/to/swift/include/swift/AST/Stmt.h:170: swift::Expr *swift::ReturnStmt::getResult() const: Assertion `Result && "ReturnStmt doesn't have a result"' failed.
12 swift           0x000000000109a52b swift::Expr::walk(swift::ASTWalker&) + 75
13 swift           0x0000000001114d38 swift::Expr::forEachChildExpr(std::function<swift::Expr* (swift::Expr*)> const&) + 40
15 swift           0x0000000000f8c19d swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 7021
16 swift           0x0000000000f90a5e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4078
17 swift           0x0000000000ebd4b9 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 857
18 swift           0x0000000000ec448d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 621
21 swift           0x0000000000f8c19d swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 7021
22 swift           0x0000000000f90a5e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4078
23 swift           0x0000000000ebd4b9 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 857
24 swift           0x0000000000ec448d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 621
26 swift           0x0000000000f40b06 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
27 swift           0x0000000000efb45d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
28 swift           0x0000000000c7b5c9 swift::CompilerInstance::performSema() + 3289
30 swift           0x00000000007db4f7 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
31 swift           0x00000000007a7328 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28390-swift-expr-walk.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28390-swift-expr-walk-405a1f.o
1.  While type-checking expression at [validation-test/compiler_crashers/28390-swift-expr-walk.swift:10:1 - line:11:7] RangeText=".h={return
2.  While type-checking expression at [validation-test/compiler_crashers/28390-swift-expr-walk.swift:10:1 - line:11:7] RangeText=".h={return
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
