### PR TITLE
[Sema] Implement SE-0110

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2489,7 +2489,10 @@ ERROR(tuple_pattern_in_non_tuple_context,none,
       "tuple pattern cannot match values of the non-tuple type %0", (Type))
 ERROR(closure_argument_list_tuple,none,
       "contextual closure type %0 expects %1 argument%s1, "
-      "but %2 were used in closure body", (Type, unsigned, unsigned))
+      "but %2 %select{were|was}3 used in closure body", (Type, unsigned, unsigned, bool))
+ERROR(closure_argument_list_single_tuple,none,
+      "contextual closure type specifies %0, but %1 %select{was|were}2 used in closure body, "
+      "try adding extra parentheses around the single tuple argument", (Type, unsigned, bool))
 ERROR(closure_argument_list_missing,none,
       "contextual type for closure argument list expects %0 argument%s0, "
       "which cannot be implicitly ignored", (unsigned))

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6464,7 +6464,7 @@ namespace {
         // Coerce the pattern, in case we resolved something.
         auto fnType = closure->getType()->castTo<FunctionType>();
         auto *params = closure->getParameters();
-        if (tc.coerceParameterListToType(params, closure, fnType->getInput()))
+        if (tc.coerceParameterListToType(params, closure, fnType))
           return { false, nullptr };
 
         // If this is a single-expression closure, convert the expression

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -5614,11 +5614,11 @@ bool FailureDiagnosis::visitClosureExpr(ClosureExpr *CE) {
       // don't confuse the issue.
       fnType = FunctionType::get(fnType->getInput(), fnType->getResult());
       diagnose(params->getStartLoc(), diag::closure_argument_list_tuple,
-               fnType, inferredArgCount, actualArgCount);
+               fnType, inferredArgCount, actualArgCount, (actualArgCount == 1));
       return true;
     }
 
-    if (CS->TC.coerceParameterListToType(params, CE, inferredArgType))
+    if (CS->TC.coerceParameterListToType(params, CE, fnType))
       return true;
 
     expectedResultType = fnType->getResult();

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1523,6 +1523,24 @@ bool TypeChecker::typeCheckExpression(Expr *&expr, DeclContext *dc,
          convertType.getType()->hasUnresolvedType())) {
       convertType = TypeLoc();
       convertTypePurpose = CTP_Unused;
+    } else if (auto closure = dyn_cast<ClosureExpr>(expr)) {
+      auto *P = closure->getParameters();
+      
+      if (P->size() == 1 && convertType.getType()->is<FunctionType>()) {
+        auto hintFnType = convertType.getType()->castTo<FunctionType>();
+        auto hintFnInputType = hintFnType->getInput();
+        
+        // Cannot use hintFnInputType->is<TupleType>() since it would desugar ParenType
+        if (isa<TupleType>(hintFnInputType.getPointer())) {
+          TupleType *tupleTy = hintFnInputType->castTo<TupleType>();
+          
+          if (tupleTy->getNumElements() >= 2) {
+            diagnose(P->getStartLoc(), diag::closure_argument_list_single_tuple,
+                     hintFnInputType, P->size(), P->size() > 1);
+            return true;
+          }
+        }
+      }
     }
   }
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1404,7 +1404,7 @@ public:
   /// contextual type.
   ///
   /// \returns true if an error occurred, false otherwise.
-  bool coerceParameterListToType(ParameterList *P, DeclContext *dc, Type type);
+  bool coerceParameterListToType(ParameterList *P, ClosureExpr *CE, AnyFunctionType *FN);
 
   
   /// Type-check an initialized variable pattern declaration.

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -8,7 +8,7 @@ _ = myMap(intArray, { String($0) })
 _ = myMap(intArray, { x -> String in String(x) } )
 
 // Closures with too few parameters.
-func foo(_ x: (Int, Int) -> Int) {}
+func foo(_ x: ((Int, Int)) -> Int) {}
 foo({$0}) // expected-error{{cannot convert value of type '(Int, Int)' to closure result type 'Int'}}
 
 struct X {}
@@ -130,7 +130,7 @@ var _: (Int) -> Int = {a,b in 0}
 // expected-error @+1 {{contextual closure type '(Int) -> Int' expects 1 argument, but 3 were used in closure body}}
 var _: (Int) -> Int = {a,b,c in 0}
 
-var _: (Int, Int) -> Int = {a in 0}
+var _: ((Int, Int)) -> Int = {a in 0}
 
 // expected-error @+1 {{contextual closure type '(Int, Int, Int) -> Int' expects 3 arguments, but 2 were used in closure body}}
 var _: (Int, Int, Int) -> Int = {a, b in a+b}
@@ -202,7 +202,7 @@ func acceptNothingToInt (_: () -> Int) {}
 func testAcceptNothingToInt(ac1: @autoclosure () -> Int) {
   // expected-note@-1{{parameter 'ac1' is implicitly non-escaping because it was declared @autoclosure}}
   acceptNothingToInt({ac1($0)})
-  // expected-error@-1{{cannot convert value of type '(_) -> Int' to expected argument type '() -> Int'}}
+  // expected-error@-1{{contextual closure type '() -> Int' expects 0 arguments, but 1 was used in closure body}}
   // FIXME: expected-error@-2{{closure use of non-escaping parameter 'ac1' may allow it to escape}}
 }
 
@@ -323,4 +323,4 @@ func r20789423() {
   
 }
 
-
+let f: (Int, Int) -> Void = { x in }  // expected-error {{contextual closure type specifies '(Int, Int)', but 1 was used in closure body, try adding extra parentheses around the single tuple argument}}

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -1,6 +1,6 @@
 // RUN: %target-parse-verify-swift
 
-var func6 : (_ fn : (Int,Int) -> Int) -> ()
+var func6 : (_ fn : ((Int, Int)) -> Int) -> ()
 var func6a : ((Int, Int) -> Int) -> ()
 var func6b : (Int, (Int, Int) -> Int) -> ()
 func func6c(_ f: (Int, Int) -> Int, _ n: Int = 0) {} // expected-warning{{prior to parameters}}
@@ -65,7 +65,7 @@ func funcdecl5(_ a: Int, _ y: Int) {
   func6({a,b in 4.0 })  // expected-error {{cannot convert value of type 'Double' to closure result type 'Int'}}
   
   // TODO: This diagnostic can be improved: rdar://22128205
-  func6({(a : Float, b) in 4 }) // expected-error {{cannot convert value of type '(Float, _) -> Int' to expected argument type '(Int, Int) -> Int'}}
+  func6({(a : Float, b) in 4 }) // expected-error {{cannot convert value of type '(Float, _) -> Int' to expected argument type '((Int, Int)) -> Int'}}
 
   
   

--- a/test/expr/closure/default_args.swift
+++ b/test/expr/closure/default_args.swift
@@ -3,8 +3,8 @@
 func simple_default_args() {
   // <rdar://problem/22753605> QoI: bad diagnostic when closure has default argument
   let _ : (Int) -> Int = {(x : Int = 1) in x+1} // expected-error{{default arguments are not allowed in closures}} {{36-39=}}
-  let _ : () -> Int = {(_ x : Int = 1) in x+1} // expected-error{{cannot convert value of type '(Int) -> Int' to specified type '() -> Int'}} expected-error {{default arguments are not allowed in closures}} {{35-38=}}
-  let _ : () -> Int = {(_ x : Int) in x+1} // expected-error{{cannot convert value of type '(Int) -> Int' to specified type '() -> Int'}}
+  let _ : () -> Int = {(_ x : Int = 1) in x+1} // expected-error{{contextual closure type '() -> Int' expects 0 arguments, but 1 was used in closure body}} expected-error {{default arguments are not allowed in closures}} {{35-38=}}
+  let _ : () -> Int = {(_ x : Int) in x+1} // expected-error{{contextual closure type '() -> Int' expects 0 arguments, but 1 was used in closure body}}
 }
 
 func func_default_args() {

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -113,7 +113,7 @@ func funcdecl7(_ a: Int, b: (c: Int, d: Int), third: (c: Int, d: Int)) -> Int {
 }
 
 // Error recovery.
-func testfunc2 (_: ((), Int) -> Int) -> Int {}
+func testfunc2 (_: (((), Int)) -> Int) -> Int {}
 func errorRecovery() {
   testfunc2({ $0 + 1 }) // expected-error {{binary operator '+' cannot be applied to operands of type '((), Int)' and 'Int'}} expected-note {{expected an argument list of type '(Int, Int)'}}
 


### PR DESCRIPTION
#### What's in this pull request?

[Sema] Implement SE-0010

This commit built upon the work of Pull Request 3895 by @dduan. Apart from the work to make the following work

``` swift
let f: (Int, Int) -> Void = { x in  } // this is now an error
```

This patch also implement the part 2 mentioned in the #3895

``` swift
let g: ((Int, Int)) -> Void = { y in  } // y should have type (Int, Int)
```
#### Resolved bug number: ([SR-2008](https://bugs.swift.org/browse/SR-2008))

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

This commit built upon the work of Pull Request 3895. Apart from the
work to make the following work

``` swift
let f: (Int, Int) -> Void = { x in  } // this is now an error
```

This patch also implement the part 2 mentioned in the #3895

``` swift
let g: ((Int, Int)) -> Void = { y in  } // y should have type (Int, Int)
```
