### PR TITLE
[API notes] CTFontManagerError is not a valid Error at this time.

### DIFF
--- a/apinotes/CoreText.apinotes
+++ b/apinotes/CoreText.apinotes
@@ -1,8 +1,5 @@
 ---
 Name: CoreText
-Tags:
-- Name: CTFontManagerError
-  NSErrorDomain: kCTFontManagerErrorDomain
 Enumerators:
 - Name: kCTUnderlinePatternSolid
   SwiftName: patternSolid


### PR DESCRIPTION
- **Explanation:** CoreText is below Foundation in the framework stack, so its error enum uses a CFStringRef constant as its domain instead of an NSString. The importer doesn't know how to handle that yet and so we were getting weird errors whenever we tried to resolve CTFontManagerError's automatically-provided conformance to __BridgedNSError. This rarely happened deliberately but showed up fairly reliably during typo correction.
- **Scope:** API notes change, only affects CTFontManagerError itself.
- **Issue:** rdar://problem/27722004
- **Reviewed by:** @slavapestov
- **Risk:** Very low.
- **Testing:** Previously-reproducing test case no longer reproduces; a follow-up commit will add diagnostics in the importer to keep us from making this mistake.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
