### PR TITLE
Tests for SR-2289

### DIFF
--- a/test/1_stdlib/Casts.swift
+++ b/test/1_stdlib/Casts.swift
@@ -17,7 +17,9 @@
 // REQUIRES: executable_test
 
 import StdlibUnittest
-
+#if _runtime(_ObjC)
+import Foundation
+#endif
 
 let CastsTests = TestSuite("Casts")
 
@@ -45,5 +47,48 @@ CastsTests.test("No overrelease of existential boxes in failed casts") {
     let err: Error = ErrClass()
     bar(err)
 }
+
+extension Int : P {}
+
+#if _runtime(_ObjC)
+extension CFBitVector : P {
+  static func makeImmutable(from values: Array<UInt8>) -> CFBitVector {
+    return CFBitVectorCreate(/*allocator:*/ nil, values, values.count * 8)
+  }
+}
+
+extension CFMutableBitVector {
+  static func makeMutable(from values: Array<UInt8>) -> CFMutableBitVector {
+    return CFBitVectorCreateMutableCopy(
+      /*allocator:*/ nil,
+      /*capacity:*/ 0,
+      CFBitVector.makeImmutable(from: values))
+  }
+}
+
+func isP<T>(_ t: T) -> Bool {
+  return t is P
+}
+
+CastsTests.test("Dynamic casts of CF types to protocol existentials") {
+  expectTrue(isP(10 as Int))
+
+  // FIXME: SR-2289: dynamic casting of CF types to protocol existentials
+  // should work, but there is a bug in the runtime that prevents them from
+  // working.
+  if !_isDebugAssertConfiguration() {
+    // FIXME: this test should not crash.  It currently crashes in optimized
+    // mode because the optimizer assumes that the type conforms, but then the
+    // runtime disagrees.
+    expectCrashLater()
+  }
+  expectFailure {
+    expectTrue(isP(CFBitVector.makeImmutable(from: [10, 20])))
+  }
+  expectFailure {
+    expectTrue(isP(CFMutableBitVector.makeMutable(from: [10, 20])))
+  }
+}
+#endif
 
 runAllTests()

--- a/test/1_stdlib/Casts.swift
+++ b/test/1_stdlib/Casts.swift
@@ -13,7 +13,7 @@
 /// Contains tests for conversions between types which shouldn't trap.
 ///
 // -----------------------------------------------------------------------------
-// RUN: %target-run-stdlib-swift
+// RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
 import StdlibUnittest


### PR DESCRIPTION
Add XFAIL'ed tests for [SR-2289 Dynamic casts of CoreFoundation types don't work](https://bugs.swift.org/browse/SR-2289).

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
