### PR TITLE
Swift 3.0 branch measurement

### DIFF
--- a/stdlib/public/SDK/Foundation/Measurement.swift
+++ b/stdlib/public/SDK/Foundation/Measurement.swift
@@ -113,19 +113,6 @@ extension Measurement where UnitType : Dimension {
 
     /// Compare two measurements of the same `Dimension`.
     ///
-    /// If `lhs.unit == rhs.unit`, returns `lhs.value == rhs.value`. Otherwise, converts `rhs` to the same unit as `lhs` and then compares the resulting values.
-    /// - returns: `true` if the measurements are equal.
-    public static func ==(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
-        if lhs.unit == rhs.unit {
-            return lhs.value == rhs.value
-        } else {
-            let rhsInLhs = rhs.converted(to: lhs.unit)
-            return lhs.value == rhsInLhs.value
-        }
-    }
-
-    /// Compare two measurements of the same `Dimension`.
-    ///
     /// If `lhs.unit == rhs.unit`, returns `lhs.value < rhs.value`. Otherwise, converts `rhs` to the same unit as `lhs` and then compares the resulting values.
     /// - returns: `true` if `lhs` is less than `rhs`.
     public static func <(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
@@ -134,45 +121,6 @@ extension Measurement where UnitType : Dimension {
         } else {
             let rhsInLhs = rhs.converted(to: lhs.unit)
             return lhs.value < rhsInLhs.value
-        }
-    }
-
-    /// Compare two measurements of the same `Dimension`.
-    ///
-    /// If `lhs.unit == rhs.unit`, returns `lhs.value > rhs.value`. Otherwise, converts `rhs` to the same unit as `lhs` and then compares the resulting values.
-    /// - returns: `true` if `lhs` is greater than `rhs`.
-    public static func >(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
-        if lhs.unit == rhs.unit {
-            return lhs.value > rhs.value
-        } else {
-            let rhsInLhs = rhs.converted(to: lhs.unit)
-            return lhs.value > rhsInLhs.value
-        }
-    }
-
-    /// Compare two measurements of the same `Dimension`.
-    ///
-    /// If `lhs.unit == rhs.unit`, returns `lhs.value < rhs.value`. Otherwise, converts `rhs` to the same unit as `lhs` and then compares the resulting values.
-    /// - returns: `true` if `lhs` is less than or equal to `rhs`.
-    public static func <=(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
-        if lhs.unit == rhs.unit {
-            return lhs.value <= rhs.value
-        } else {
-            let rhsInLhs = rhs.converted(to: lhs.unit)
-            return lhs.value <= rhsInLhs.value
-        }
-    }
-
-    /// Compare two measurements of the same `Dimension`.
-    ///
-    /// If `lhs.unit == rhs.unit`, returns `lhs.value >= rhs.value`. Otherwise, converts `rhs` to the same unit as `lhs` and then compares the resulting values.
-    /// - returns: `true` if `lhs` is greater or equal to `rhs`.
-    public static func >=(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
-        if lhs.unit == rhs.unit {
-            return lhs.value >= rhs.value
-        } else {
-            let rhsInLhs = rhs.converted(to: lhs.unit)
-            return lhs.value >= rhsInLhs.value
         }
     }
 }
@@ -225,10 +173,21 @@ extension Measurement {
         return Measurement(value: lhs / rhs.value, unit: rhs.unit)
     }
 
-    /// Compare two measurements of the same `Unit`.
-    /// - returns: `true` if `lhs.value == rhs.value && lhs.unit == rhs.unit`.
-    public static func ==(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
-        return lhs.value == rhs.value && lhs.unit == rhs.unit
+    /// Compare two measurements of the same `Dimension`.
+    ///
+    /// If `lhs.unit == rhs.unit`, returns `lhs.value == rhs.value`. Otherwise, converts `rhs` to the same unit as `lhs` and then compares the resulting values.
+    /// - returns: `true` if the measurements are equal.
+    public static func ==(_ lhs: Measurement<UnitType>, _ rhs: Measurement<UnitType>) -> Bool {
+        if lhs.unit == rhs.unit {
+            return lhs.value == rhs.value
+        } else {
+            let rhsM = rhs as NSMeasurement
+            if rhsM.canBeConverted(to: lhs.unit) {
+                return lhs.value == rhsM.converting(to: lhs.unit).value
+            } else {
+                return false
+            }
+        }
     }
 
     /// Compare two measurements of the same `Unit`.
@@ -236,27 +195,6 @@ extension Measurement {
     /// - returns: `lhs.value < rhs.value`
     public static func <(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
         return lhs.value < rhs.value
-    }
-
-    /// Compare two measurements of the same `Unit`.
-    /// - note: This function does not check `==` for the `unit` property of `lhs` and `rhs`.
-    /// - returns: `lhs.value > rhs.value`
-    public static func >(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
-        return lhs.value > rhs.value
-    }
-
-    /// Compare two measurements of the same `Unit`.
-    /// - note: This function does not check `==` for the `unit` property of `lhs` and `rhs`.
-    /// - returns: `lhs.value <= rhs.value`
-    public static func <=(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
-        return lhs.value <= rhs.value
-    }
-
-    /// Compare two measurements of the same `Unit`.
-    /// - note: This function does not check `==` for the `unit` property of `lhs` and `rhs`.
-    /// - returns: `lhs.value >= rhs.value`
-    public static func >=(lhs: Measurement<UnitType>, rhs: Measurement<UnitType>) -> Bool {
-        return lhs.value >= rhs.value
     }
 }
 

--- a/test/1_stdlib/TestMeasurement.swift
+++ b/test/1_stdlib/TestMeasurement.swift
@@ -126,6 +126,27 @@ class TestMeasurement : TestMeasurementSuper {
         // Just make sure we get a result at all here
         expectFalse(result.isEmpty)
     }
+
+    func testEquality() {
+        let fiveKM = Measurement(value: 5, unit: UnitLength.kilometers)
+        let fiveSeconds = Measurement(value: 5, unit: UnitDuration.seconds)
+        let fiveThousandM = Measurement(value: 5000, unit: UnitLength.meters)
+
+        expectTrue(fiveKM == fiveThousandM)
+        expectEqual(fiveKM, fiveThousandM)
+        expectFalse(fiveKM == fiveSeconds)
+    }
+
+    func testComparison() {
+        let fiveKM = Measurement(value: 5, unit: UnitLength.kilometers)
+        let fiveThousandM = Measurement(value: 5000, unit: UnitLength.meters)
+        let sixKM = Measurement(value: 6, unit: UnitLength.kilometers)
+        let sevenThousandM = Measurement(value: 7000, unit: UnitLength.meters)
+
+        expectTrue(fiveKM < sixKM)
+        expectTrue(fiveKM < sevenThousandM)
+        expectTrue(fiveKM <= fiveThousandM)
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -136,6 +157,8 @@ if #available(OSX 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *) {
     MeasurementTests.test("testOperators") { TestMeasurement().testOperators() }
     MeasurementTests.test("testUnits") { TestMeasurement().testUnits() }
     MeasurementTests.test("testMeasurementFormatter") { TestMeasurement().testMeasurementFormatter() }
+    MeasurementTests.test("testEquality") { TestMeasurement().testEquality() }
+    MeasurementTests.test("testComparison") { TestMeasurement().testComparison() }
     runAllTests()
 }
 #endif


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

 The default implementation for comparable automatically adds >, >= etc by having == and < defined. Also the dynamic check for comparison of measurements that are convertible should traverse through the same runtime equality check instead of a static dispatch call out.

Additional conformance changes for Measurement and unit tests to verify comparison and equality. 

After speaking with the current owner of Measurement, the most sensible path is to at runtime verifty the conformance of Units to a specific dimension since we cannot directly check at compile time. If at a future point in time a more specific comparitor can be added that can restrict the comparison to measurements in a specific dimension without causing equatable failures we may want to revisit this. However as it stands this preserves the most reasonable implementation of comparison of disperate measurement unit types while preserving the expected logic of conversions within that dimension.
#### Resolved bug number:

<!-- If this pull request resolves any bugs from Swift bug tracker -->

rdar://problem/27556581 Measurement type defines two '==' functions

---
