### PR TITLE
[swiftc (44 vs. 5156)] Add crasher in swift::TypeChecker::validateDecl(...)

### DIFF
--- a/validation-test/compiler_crashers/28391-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers/28391-swift-typechecker-validatedecl.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+protocol c{typealias B)class a{func f(f)typealias f=B


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::validateDecl(...)`.

Current number of unresolved compiler crashers: 44 (5156 resolved)

Assertion failure in [`lib/Sema/TypeCheckDecl.cpp (line 4724)`](https://github.com/apple/swift/blob/master/lib/Sema/TypeCheckDecl.cpp#L4724):

```
Assertion `!FD->getType()->hasTypeParameter()' failed.

When executing: void (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl *)
```

Assertion context:

```

    if (FD->isInvalid())
      return;

    // This type check should have created a non-dependent type.
    assert(!FD->getType()->hasTypeParameter());

    validateAttributes(TC, FD);

    // Member functions need some special validation logic.
    if (FD->getDeclContext()->isTypeContext()) {
```

Stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckDecl.cpp:4724: void (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl *): Assertion `!FD->getType()->hasTypeParameter()' failed.
10 swift           0x0000000000ed1301 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 945
12 swift           0x0000000000ed1c92 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3394
13 swift           0x0000000001142d7b swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2667
14 swift           0x00000000011416e0 swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2864
15 swift           0x0000000000f151bb swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
18 swift           0x0000000000f46a9e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
20 swift           0x0000000000f479e4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
21 swift           0x0000000000f46990 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
23 swift           0x0000000000f18305 swift::TypeChecker::typeCheckParameterList(swift::ParameterList*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) + 117
25 swift           0x0000000000f110ae swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 94
32 swift           0x0000000000ed74b6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
33 swift           0x0000000000efb3f2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
34 swift           0x0000000000c7b5c9 swift::CompilerInstance::performSema() + 3289
36 swift           0x00000000007db4f7 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
37 swift           0x00000000007a7328 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28391-swift-typechecker-validatedecl.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28391-swift-typechecker-validatedecl-1d567d.o
1.  While type-checking 'c' at validation-test/compiler_crashers/28391-swift-typechecker-validatedecl.swift:10:1
2.  While resolving type f at [validation-test/compiler_crashers/28391-swift-typechecker-validatedecl.swift:10:39 - line:10:39] RangeText="f"
3.  While type-checking 'f' at validation-test/compiler_crashers/28391-swift-typechecker-validatedecl.swift:10:41
4.  While type-checking 'f' at validation-test/compiler_crashers/28391-swift-typechecker-validatedecl.swift:10:32
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
