### PR TITLE
Fix enum member lookup fixits (3.0)

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -99,7 +99,7 @@ ERROR(could_not_use_type_member_on_instance,none,
 ERROR(could_not_use_enum_element_on_instance,none,
       "enum element %0 cannot be referenced as an instance member",
       (DeclName))
-ERROR(could_not_use_type_member_on_existential,none,
+ERROR(could_not_use_type_member_on_protocol_metatype,none,
       "static member %1 cannot be used on protocol metatype %0",
       (Type, DeclName))
 ERROR(could_not_use_instance_member_on_type,none,

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3388,7 +3388,13 @@ namespace {
     }
     
     Expr *visitUnresolvedPatternExpr(UnresolvedPatternExpr *expr) {
-      llvm_unreachable("should have been eliminated during name binding");
+      // If we end up here, we should have diagnosed somewhere else
+      // already.
+      if (!SuppressDiagnostics) {
+        cs.TC.diagnose(expr->getLoc(), diag::pattern_in_expr,
+                       expr->getSubPattern()->getKind());
+      }
+      return expr;
     }
     
     Expr *visitBindOptionalExpr(BindOptionalExpr *expr) {

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1948,10 +1948,13 @@ private:
   /// the exact expression kind).
   bool diagnoseGeneralMemberFailure(Constraint *constraint);
   
-  /// Diagnose the lookup of an enum element as instance member where only a
-  /// static member is allowed
-  void diagnoseEnumInstanceMemberLookup(EnumElementDecl *enumElementDecl,
-                                        SourceLoc loc);
+  /// Diagnose the lookup of an static member or enum element as instance member.
+  void diagnoseTypeMemberOnInstanceLookup(Type baseObjTy,
+                                          Expr *baseExpr,
+                                          DeclName memberName,
+                                          DeclNameLoc nameLoc,
+                                          ValueDecl *member,
+                                          SourceLoc loc);
 
   /// Given a result of name lookup that had no viable results, diagnose the
   /// unviable ones.
@@ -2338,12 +2341,54 @@ bool FailureDiagnosis::diagnoseGeneralMemberFailure(Constraint *constraint) {
 }
 
 void FailureDiagnosis::
-diagnoseEnumInstanceMemberLookup(EnumElementDecl *enumElementDecl,
-                                 SourceLoc loc) {
-  auto diag = diagnose(loc, diag::could_not_use_enum_element_on_instance,
-                       enumElementDecl->getName());
-  auto parentEnum = enumElementDecl->getParentEnum();
-  auto enumMetatype = parentEnum->getType()->castTo<AnyMetatypeType>();
+diagnoseTypeMemberOnInstanceLookup(Type baseObjTy,
+                                   Expr *baseExpr,
+                                   DeclName memberName,
+                                   DeclNameLoc nameLoc,
+                                   ValueDecl *member,
+                                   SourceLoc loc) {
+  SourceRange baseRange = baseExpr ? baseExpr->getSourceRange() : SourceRange();
+
+  // If the base of the lookup is a protocol metatype, suggest
+  // to replace the metatype with 'Self'
+  // error saying the lookup cannot be on a protocol metatype
+  if (auto metatypeTy = baseObjTy->getAs<MetatypeType>()) {
+    auto Diag = diagnose(loc,
+                         diag::could_not_use_type_member_on_protocol_metatype,
+                         baseObjTy, memberName);
+    Diag.highlight(baseRange).highlight(nameLoc.getSourceRange());
+
+    // See through function decl context
+    if (auto parent = CS->DC->getInnermostTypeContext()) {
+      // If we are in a protocol extension of 'Proto' and we see
+      // 'Proto.static', suggest 'Self.static'
+      if (auto extensionContext = parent->getAsProtocolExtensionContext()) {
+        if (extensionContext->getDeclaredType()->getCanonicalType()
+            == metatypeTy->getInstanceType()->getCanonicalType()) {
+          Diag.fixItReplace(baseRange, "Self");
+        }
+      }
+    }
+
+    return;
+  }
+
+  // Otherwise the static member lookup was invalid because it was
+  // called on an instance
+  Optional<InFlightDiagnostic> Diag;
+
+  if (isa<EnumElementDecl>(member))
+    Diag.emplace(diagnose(loc, diag::could_not_use_enum_element_on_instance,
+                          memberName));
+  else
+    Diag.emplace(diagnose(loc, diag::could_not_use_type_member_on_instance,
+                          baseObjTy, memberName));
+
+  Diag->highlight(nameLoc.getSourceRange());
+
+  // No fix-it if the lookup was qualified
+  if (baseExpr && !baseExpr->isImplicit())
+    return;
 
   // Determine the contextual type of the expression
   Type contextualType;
@@ -2355,8 +2400,8 @@ diagnoseEnumInstanceMemberLookup(EnumElementDecl *enumElementDecl,
 
   // Try to provide a fix-it that only contains a '.'
   if (contextualType) {
-    if (enumMetatype->getInstanceType()->isEqual(contextualType)) {
-      diag.fixItInsert(loc, ".");
+    if (baseObjTy->isEqual(contextualType)) {
+      Diag->fixItInsert(loc, ".");
       return;
     }
   }
@@ -2382,8 +2427,8 @@ diagnoseEnumInstanceMemberLookup(EnumElementDecl *enumElementDecl,
           // If the rhs of '~=' is the enum type, a single dot suffixes
           // since the type can be inferred
           Type secondArgType = binaryExpr->getArg()->getElement(1)->getType();
-          if (secondArgType->isEqual(enumMetatype->getInstanceType())) {
-            diag.fixItInsert(loc, ".");
+          if (secondArgType->isEqual(baseObjTy)) {
+            Diag->fixItInsert(loc, ".");
             return;
           }
         }
@@ -2392,12 +2437,14 @@ diagnoseEnumInstanceMemberLookup(EnumElementDecl *enumElementDecl,
   }
 
   // Fall back to a fix-it with a full type qualifier
-  SmallString<32> enumTypeName;
-  llvm::raw_svector_ostream typeNameStream(enumTypeName);
-  typeNameStream << parentEnum->getName();
-  typeNameStream << ".";
+  auto nominal =
+      member->getDeclContext()
+      ->getAsNominalTypeOrNominalTypeExtensionContext();
+  SmallString<32> typeName;
+  llvm::raw_svector_ostream typeNameStream(typeName);
+  typeNameStream << nominal->getName() << ".";
 
-  diag.fixItInsert(loc, typeNameStream.str());
+  Diag->fixItInsert(loc, typeNameStream.str());
   return;
 }
 
@@ -2495,8 +2542,12 @@ diagnoseUnviableLookupResults(MemberLookupResult &result, Type baseObjTy,
   // because there is exactly one candidate!) diagnose this.
   bool sameProblem = true;
   auto firstProblem = result.UnviableCandidates[0].second;
-  for (auto cand : result.UnviableCandidates)
+  ValueDecl *member = nullptr;
+  for (auto cand : result.UnviableCandidates) {
+    if (member == nullptr)
+      member = cand.first;
     sameProblem &= cand.second == firstProblem;
+  }
   
   auto instanceTy = baseObjTy;
   if (auto *MTT = instanceTy->getAs<AnyMetatypeType>())
@@ -2561,48 +2612,11 @@ diagnoseUnviableLookupResults(MemberLookupResult &result, Type baseObjTy,
                instanceTy, memberName)
         .highlight(baseRange).highlight(nameLoc.getSourceRange());
       return;
-            
+
     case MemberLookupResult::UR_TypeMemberOnInstance:
-      if (instanceTy->isExistentialType() && baseObjTy->is<AnyMetatypeType>()) {
-        // If the base of the lookup is an existential metatype, emit an
-        // error saying the lookup cannot be on a protocol metatype
-        auto Diag = diagnose(loc, diag::could_not_use_type_member_on_existential,
-                             baseObjTy, memberName);
-        Diag.highlight(baseRange).highlight(nameLoc.getSourceRange());
-
-        // See through function decl context
-        if (auto parent = CS->DC->getParent())
-        // If we are in a protocol extension of 'Proto' and we see
-        // 'Proto.static', suggest 'Self.static'
-        if (auto extensionContext = parent->getAsProtocolExtensionContext()) {
-          if (extensionContext->getDeclaredType()->getCanonicalType()
-              == instanceTy->getCanonicalType()) {
-            Diag.fixItReplace(baseRange, "Self");
-          }
-        }
-
-      } else {
-        // Otherwise the static member lookup was invalid because it was
-        // called on an instance
-        
-        // Handle enum element lookup on instance type
-        auto lookThroughBaseObjTy = baseObjTy->lookThroughAllAnyOptionalTypes();
-        if (lookThroughBaseObjTy->is<EnumType>()
-            || lookThroughBaseObjTy->is<BoundGenericEnumType>()) {
-          for (auto cand : result.UnviableCandidates) {
-            ValueDecl *decl = cand.first;
-            if (auto enumElementDecl = dyn_cast<EnumElementDecl>(decl)) {
-              diagnoseEnumInstanceMemberLookup(enumElementDecl, loc);
-              return;
-            }
-          }
-        }
-        
-        // Provide diagnostic other static member lookups on instance type
-        diagnose(loc, diag::could_not_use_type_member_on_instance,
-                 baseObjTy, memberName)
-          .highlight(baseRange).highlight(nameLoc.getSourceRange());
-      }
+      diagnoseTypeMemberOnInstanceLookup(baseObjTy, baseExpr,
+                                         memberName, nameLoc,
+                                         member, loc);
       return;
         
     case MemberLookupResult::UR_MutatingMemberOnRValue:

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2632,9 +2632,7 @@ namespace {
     Type visitUnresolvedPatternExpr(UnresolvedPatternExpr *expr) {
       // If there are UnresolvedPatterns floating around after name binding,
       // they are pattern productions in invalid positions.
-      CS.TC.diagnose(expr->getLoc(), diag::pattern_in_expr,
-                     expr->getSubPattern()->getKind());
-      return Type();
+      return ErrorType::get(CS.getASTContext());
     }
 
     /// Get the type T?

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -120,9 +120,9 @@ var wcurried1 = w.curried
 var wcurried2 = w.curried(0)
 var wcurriedFull : () = w.curried(0)(1)
 
-// Member of enum Type
+// Member of enum type
 func enumMetatypeMember(_ opt: Int?) {
-  opt.none // expected-error{{static member 'none' cannot be used on instance of type 'Int?'}}
+  opt.none // expected-error{{enum element 'none' cannot be referenced as an instance member}}
 }
 
 ////
@@ -310,6 +310,10 @@ protocol StaticP {
 extension StaticP {
   func bar() {
     _ = StaticP.foo(a:) // expected-error{{static member 'foo(a:)' cannot be used on protocol metatype 'StaticP.Protocol'}} {{9-16=Self}}
+
+    func nested() {
+      _ = StaticP.foo(a:) // expected-error{{static member 'foo(a:)' cannot be used on protocol metatype 'StaticP.Protocol'}} {{11-18=Self}}
+    }
   }
 }
 

--- a/test/Parse/enum.swift
+++ b/test/Parse/enum.swift
@@ -453,14 +453,17 @@ struct SE0036_Auxiliary {}
 enum SE0036 {
   case A
   case B(SE0036_Auxiliary)
+  case C(SE0036_Auxiliary)
 
   static func staticReference() {
     _ = A
+    _ = self.A
     _ = SE0036.A
   }
 
   func staticReferenceInInstanceMethod() {
     _ = A // expected-error {{enum element 'A' cannot be referenced as an instance member}} {{9-9=SE0036.}}
+    _ = self.A // expected-error {{enum element 'A' cannot be referenced as an instance member}} {{none}}
     _ = SE0036.A
   }
 
@@ -468,6 +471,7 @@ enum SE0036 {
     switch SE0036.A {
     case A: break
     case B(_): break
+    case C(let x): _ = x; break
     }
   }
 
@@ -475,6 +479,7 @@ enum SE0036 {
     switch self {
     case A: break // expected-error {{enum element 'A' cannot be referenced as an instance member}} {{10-10=.}}
     case B(_): break // expected-error {{enum element 'B' cannot be referenced as an instance member}} {{10-10=.}}
+    case C(let x): _ = x; break // expected-error {{invalid pattern}}
     }
   }
 
@@ -482,6 +487,7 @@ enum SE0036 {
     switch SE0036.A {
     case SE0036.A: break
     case SE0036.B(_): break
+    case SE0036.C(let x): _ = x; break
     }
   }
 
@@ -489,6 +495,7 @@ enum SE0036 {
     switch self {
     case .A: break
     case .B(_): break
+    case .C(let x): _ = x; break
     }
   }
 
@@ -496,6 +503,7 @@ enum SE0036 {
     switch SE0036.A {
     case .A: break
     case .B(_): break
+    case .C(let x): _ = x; break
     }
   }
 
@@ -514,7 +522,11 @@ enum SE0036_Generic<T> {
 
   func foo() {
     switch self {
-    case A(_): break // expected-error {{enum element 'A' cannot be referenced as an instance member}} {{10-10=SE0036_Generic.}}
+    case A(_): break // expected-error {{enum element 'A' cannot be referenced as an instance member}} {{10-10=.}}
+    }
+
+    switch self {
+    case .A(let a): print(a)
     }
 
     switch self {

--- a/test/Parse/enum.swift
+++ b/test/Parse/enum.swift
@@ -479,7 +479,7 @@ enum SE0036 {
     switch self {
     case A: break // expected-error {{enum element 'A' cannot be referenced as an instance member}} {{10-10=.}}
     case B(_): break // expected-error {{enum element 'B' cannot be referenced as an instance member}} {{10-10=.}}
-    case C(let x): _ = x; break // expected-error {{invalid pattern}}
+    case C(let x): _ = x; break // expected-error {{enum element 'C' cannot be referenced as an instance member}} {{10-10=.}}
     }
   }
 

--- a/test/Parse/matching_patterns.swift
+++ b/test/Parse/matching_patterns.swift
@@ -261,9 +261,14 @@ case (1, 2, 3):
   ()
 
 // patterns in expression-only positions are errors.
-case +++(_, var d, 3): // expected-error{{invalid pattern}}
+case +++(_, var d, 3):
+// expected-error@-1{{'+++' is not a prefix unary operator}}
   ()
-case (_, var e, 3) +++ (1, 2, 3): // expected-error{{invalid pattern}}
+case (_, var e, 3) +++ (1, 2, 3):
+// expected-error@-1{{binary operator '+++' cannot be applied to operands of type '(_, <<error type>>, Int)' and '(Int, Int, Int)'}}
+// expected-note@-2{{expected an argument list of type '((Int, Int, Int), (Int, Int, Int))'}}
+// expected-error@-3{{'var' binding pattern cannot appear in an expression}}
+// expected-error@-4{{'var' binding pattern cannot appear in an expression}}
   ()
 }
 

--- a/test/Sema/enum_equatable_hashable.swift
+++ b/test/Sema/enum_equatable_hashable.swift
@@ -96,7 +96,8 @@ private enum Bar<T> {
 
   mutating func value() -> T {
     switch self {
-    case E(let x): // expected-error{{invalid pattern}}
+    // FIXME: Should diagnose here that '.' needs to be inserted, but E has an ErrorType at this point
+    case E(let x):
       return x.value
     }
   }

--- a/test/expr/primary/unqualified_name.swift
+++ b/test/expr/primary/unqualified_name.swift
@@ -3,7 +3,7 @@
 func f0(_ x: Int, y: Int, z: Int) { }
 func f1(_ x: Int, while: Int) { }
 func f2(_ x: Int, `let` _: Int) { }
-func f3(_ x: Int, _ y: Int, z: Int) { }
+func f3(_ x: Int, _ y: Int, z: Int) { } // expected-note{{did you mean 'f3'?}}
 
 func test01() {
   _ = f0(_:y:z:)
@@ -28,6 +28,13 @@ struct S0 {
     _ = self.f0(:y:z:) // expected-error{{an empty argument label is spelled with '_'}}{{17-17=_}}
     _ = self.f1(_:`while`:) // expected-warning{{keyword 'while' does not need to be escaped in argument list}}{{19-20=}}{{25-26=}}
     _ = self.f2(_:`let`:)
+
+    _ = f3(_:y:z:) // expected-error{{use of unresolved identifier 'f3(_:y:z:)'}}
+  }
+
+  static func testStaticS0() {
+    _ = f0(_:y:z:)
+    _ = f3(_:y:z:)
   }
 
   static func f3(_ x: Int, y: Int, z: Int) -> S0 { return S0() }

--- a/validation-test/compiler_crashers_fixed/28376-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
+++ b/validation-test/compiler_crashers_fixed/28376-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
@@ -5,7 +5,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
 class B<enum B{case c
 var:{if c


### PR DESCRIPTION
- Explanation: Backport some fixes from master, enabling the fix-it for SE0036 to be used for patterns such as `case foo(let x)`.
- Scope: Should only impact invalid code that already did not compile, now has a better diagnostic.
- Reviewed by @jrose-apple 
- Risk: Low.
- Testing: New test cases added, and observed to pass on master.
- Radar: rdar://problem/27684266
