### PR TITLE
SILGen: Test the trustworthiness of ObjC subscript nullability based on the element's contextual type.

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2328,8 +2328,13 @@ static bool mayLieAboutNonOptionalReturn(SILModule &M,
   // Subscripts of non-optional reference type that were imported from
   // Objective-C.
   if (auto subscript = dyn_cast<SubscriptDecl>(decl)) {
-    assert((isNullableTypeInC(M, subscript->getElementType())
-            || subscript->getElementType()->hasArchetype())
+    // The subscript element type is an interface type. Map it into context
+    // so we can properly gauge reference-ness.
+    auto elementType =
+      ArchetypeBuilder::mapTypeIntoContext(subscript,
+                                           subscript->getElementType());
+    assert((isNullableTypeInC(M, elementType)
+            || elementType->hasArchetype())
            && "subscript's result type is not nullable?!");
     return subscript->hasClangNode();
   }

--- a/test/SILGen/Inputs/objc_bridged_generic_nonnull.h
+++ b/test/SILGen/Inputs/objc_bridged_generic_nonnull.h
@@ -1,0 +1,11 @@
+@import Foundation;
+
+@interface NonnullMembers<T> : NSObject
+
+- (T _Nonnull) method;
+
+@property (readonly) T _Nonnull property;
+
+- (T _Nonnull)objectForKeyedSubscript:(id _Nonnull)key;
+
+@end

--- a/test/SILGen/objc_bridged_generic_nonnull.swift
+++ b/test/SILGen/objc_bridged_generic_nonnull.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -emit-silgen -verify -import-objc-header %S/Inputs/objc_bridged_generic_nonnull.h %s
+// REQUIRES: objc_interop
+
+public func test<T: AnyObject>(_ x: NonnullMembers<T>) -> T? {
+  var z: T?
+  z = x.method()
+  z = x.property
+  z = x.property
+  z = x[x]
+  _ = z
+}


### PR DESCRIPTION
We would crash in this test because an abstract generic parameter doesn't know whether it's class-constrained absent context. Fixes rdar://problem/26632701.
