### PR TITLE
[stdlib] Deprecate ExpressibleByStringInterpolation

### DIFF
--- a/stdlib/public/core/CompilerProtocols.swift
+++ b/stdlib/public/core/CompilerProtocols.swift
@@ -613,6 +613,7 @@ public protocol ExpressibleByDictionaryLiteral {
 ///           String(stringInterpolationSegment: " cookies: $"),
 ///           String(stringInterpolationSegment: price * number),
 ///           String(stringInterpolationSegment: "."))
+@available(*, deprecated, message: "it will be replaced or redesigned in Swift 4.0.  Instead of conforming to 'ExpressibleByStringInterpolation', consider adding an 'init(_:String)'")
 public protocol ExpressibleByStringInterpolation {
   /// Creates an instance by concatenating the given values.
   ///

--- a/stdlib/public/core/CompilerProtocols.swift
+++ b/stdlib/public/core/CompilerProtocols.swift
@@ -737,7 +737,7 @@ public typealias ArrayLiteralConvertible
 @available(*, deprecated, renamed: "ExpressibleByDictionaryLiteral")
 public typealias DictionaryLiteralConvertible
   = ExpressibleByDictionaryLiteral
-@available(*, deprecated, renamed: "ExpressibleByStringInterpolation")
+@available(*, deprecated, message: "it will be replaced or redesigned in Swift 4.0.  Instead of conforming to 'StringInterpolationConvertible', consider adding an 'init(_:String)'")
 public typealias StringInterpolationConvertible
   = ExpressibleByStringInterpolation
 @available(*, deprecated, renamed: "_ExpressibleByColorLiteral")

--- a/validation-test/stdlib/BoolDiagnostics_Dataflow.swift
+++ b/validation-test/stdlib/BoolDiagnostics_Dataflow.swift
@@ -55,3 +55,5 @@ func test_constantFoldOr4() -> Int {
   }
 } // expected-error {{missing return in a function expected to return 'Int'}}
 
+// expected-warning@+1 {{'ExpressibleByStringInterpolation' is deprecated: it will be replaced or redesigned in Swift 4.0.  Instead of conforming to 'ExpressibleByStringInterpolation', consider adding an 'init(_:String)'}}
+typealias X = ExpressibleByStringInterpolation


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

We know its API is
inadequate (https://bugs.swift.org/browse/SR-1260?jql=text%20~%20%22StringInterpolationConvertible%22)
and don't want to be constrained to supporting it in future versions.
