### PR TITLE
stdlib and runtime: a bunch of fixes for AnyHashable and id-as-Any

### DIFF
--- a/stdlib/private/StdlibUnittest/MinimalTypes.swift.gyb
+++ b/stdlib/private/StdlibUnittest/MinimalTypes.swift.gyb
@@ -103,14 +103,14 @@ public func < (
   return MinimalComparableValue.lessImpl.value(lhs.value, rhs.value)
 }
 
-% for kind in [ 'Value', 'Class' ]:
+% for (kind, decl_keyword) in [ ('Value', 'struct'), ('Class', 'class') ]:
 %   Self = 'MinimalHashable%s' % kind
 
 /// A type that conforms only to `Equatable` and `Hashable`.
 ///
 /// This type can be used to check that generic functions don't rely on any
 /// other conformances.
-public struct ${Self} : Equatable, Hashable {
+public ${decl_keyword} ${Self} : Equatable, Hashable {
   public static var timesEqualEqualWasCalled: Int = 0
   public static var timesHashValueWasCalled: Int = 0
 
@@ -148,7 +148,7 @@ public func == (
 
 % end
 
-% for kind in [ 'Value', 'Class' ]:
+% for (kind, decl_keyword) in [ ('Value', 'struct'), ('Class', 'class') ]:
 %   Self = 'GenericMinimalHashable%s' % kind
 
 public var ${Self}_timesEqualEqualWasCalled: Int = 0
@@ -163,7 +163,7 @@ public var ${Self}_hashValueImpl = ResettableValue<(Any) -> Int>(
 ///
 /// This type can be used to check that generic functions don't rely on any
 /// other conformances.
-public struct ${Self}<Wrapped> : Equatable, Hashable {
+public ${decl_keyword} ${Self}<Wrapped> : Equatable, Hashable {
   public var value: Wrapped
   public var identity: Int
 

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -1948,6 +1948,7 @@ public enum TestRunPredicate : CustomStringConvertible {
 public func checkEquatable<Instances : Collection>(
   _ instances: Instances,
   oracle: (Instances.Index, Instances.Index) -> Bool,
+  allowBrokenTransitivity: Bool = false,
   ${TRACE}
 ) where
   Instances.Iterator.Element : Equatable,
@@ -1958,12 +1959,14 @@ public func checkEquatable<Instances : Collection>(
   let indices = Array(instances.indices)
   _checkEquatableImpl(
     Array(instances),
-    oracle: { oracle(indices[$0], indices[$1]) })
+    oracle: { oracle(indices[$0], indices[$1]) },
+    allowBrokenTransitivity: allowBrokenTransitivity)
 }
 
 internal func _checkEquatableImpl<Instance : Equatable>(
   _ instances: [Instance],
   oracle: (Int, Int) -> Bool,
+  allowBrokenTransitivity: Bool = false,
   ${TRACE}
 ) {
   // For each index (which corresponds to an instance being tested) track the
@@ -1996,22 +1999,24 @@ internal func _checkEquatableImpl<Instance : Equatable>(
         "lhs (at index \(i)): \(x)\nrhs (at index \(j)): \(y)",
         stackTrace: ${stackTrace})
 
-      // Check transitivity of the predicate represented by the oracle.
-      // If we are adding the instance `j` into an equivalence set, check that
-      // it is equal to every other instance in the set.
-      if predictedXY && i < j && transitivityScoreboard[i].value.insert(j).inserted {
-        if transitivityScoreboard[i].value.count == 1 {
-          transitivityScoreboard[i].value.insert(i)
+      if !allowBrokenTransitivity {
+        // Check transitivity of the predicate represented by the oracle.
+        // If we are adding the instance `j` into an equivalence set, check that
+        // it is equal to every other instance in the set.
+        if predictedXY && i < j && transitivityScoreboard[i].value.insert(j).inserted {
+          if transitivityScoreboard[i].value.count == 1 {
+            transitivityScoreboard[i].value.insert(i)
+          }
+          for k in transitivityScoreboard[i].value {
+            expectTrue(
+              oracle(j, k),
+              "bad oracle: broken transitivity at indices \(i), \(j), \(k)")
+              // No need to check equality between actual values, we will check
+              // them with the checks above.
+          }
+          precondition(transitivityScoreboard[j].value.isEmpty)
+          transitivityScoreboard[j] = transitivityScoreboard[i]
         }
-        for k in transitivityScoreboard[i].value {
-          expectTrue(
-            oracle(j, k),
-            "bad oracle: broken transitivity at indices \(i), \(j), \(k)")
-            // No need to check equality between actual values, we will check
-            // them with the checks above.
-        }
-        precondition(transitivityScoreboard[j].value.isEmpty)
-        transitivityScoreboard[j] = transitivityScoreboard[i]
       }
     }
   }
@@ -2032,15 +2037,20 @@ public func checkEquatable<T : Equatable>(
 public func checkHashable<Instances : Collection>(
   _ instances: Instances,
   equalityOracle: (Instances.Index, Instances.Index) -> Bool,
+  allowBrokenTransitivity: Bool = false,
   ${TRACE}
 ) where
   Instances.Iterator.Element : Hashable,
   // FIXME(compiler limitation): these constraints should be applied to
   // associated types of Collection.
   Instances.Indices.Iterator.Element == Instances.Index {
-  
-  checkEquatable(instances, oracle: equalityOracle, ${trace})
-  
+
+  checkEquatable(
+    instances,
+    oracle: equalityOracle,
+    allowBrokenTransitivity: allowBrokenTransitivity,
+    ${trace})
+
   for i in instances.indices {
     let x = instances[i]
     for j in instances.indices {

--- a/stdlib/public/core/AnyHashable.swift
+++ b/stdlib/public/core/AnyHashable.swift
@@ -232,9 +232,8 @@ extension Hashable {
 /// Returns a default (non-custom) representation of `self`
 /// as `AnyHashable`.
 ///
-/// Completely ignores the
-/// `_HasCustomAnyHashableRepresentation` conformance, if
-/// any.
+/// Completely ignores the `_HasCustomAnyHashableRepresentation`
+/// conformance, if it exstis.
 @_silgen_name("_swift_stdlib_makeAnyHashableUsingDefaultRepresentation")
 public // COMPILER_INTRINSIC (actually, called from the runtime)
 func _stdlib_makeAnyHashableUsingDefaultRepresentation<H : Hashable>(
@@ -260,7 +259,8 @@ func _convertToAnyHashable<H : Hashable>(_ value: H) -> AnyHashable {
 public // COMPILER_INTRINSIC (actually, called from the runtime)
 func _convertToAnyHashableIndirect<H : Hashable>(
   _ value: H,
-  _ target: UnsafeMutablePointer<AnyHashable>) {
+  _ target: UnsafeMutablePointer<AnyHashable>
+) {
   target.initialize(to: AnyHashable(value))
 }
 
@@ -268,6 +268,7 @@ func _convertToAnyHashableIndirect<H : Hashable>(
 public // COMPILER_INTRINSIC (actually, called from the runtime)
 func _anyHashableDownCastConditionalIndirect<T>(
   _ value: UnsafePointer<AnyHashable>,
-  _ target: UnsafeMutablePointer<T>) -> Bool {
+  _ target: UnsafeMutablePointer<T>
+) -> Bool {
   return value.pointee._downCastConditional(into: target)
 }

--- a/stdlib/public/core/Hashable.swift
+++ b/stdlib/public/core/Hashable.swift
@@ -98,3 +98,22 @@ public protocol Hashable : _Hashable, Equatable {
   var hashValue: Int { get }
 }
 
+public enum _RuntimeHelpers {}
+
+extension _RuntimeHelpers {
+  @_silgen_name("swift_stdlib_Hashable_isEqual_indirect")
+  public static func Hashable_isEqual_indirect<T : Hashable>(
+    _ lhs: UnsafePointer<T>,
+    _ rhs: UnsafePointer<T>
+  ) -> Bool {
+    return lhs.pointee == rhs.pointee
+  }
+
+  @_silgen_name("swift_stdlib_Hashable_hashValue_indirect")
+  public static func Hashable_hashValue_indirect<T : Hashable>(
+    _ value: UnsafePointer<T>
+  ) -> Int {
+    return value.pointee.hashValue
+  }
+}
+

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -34,6 +34,7 @@ else()
 endif()
 
 set(swift_runtime_sources
+    AnyHashableSupport.cpp
     Casting.cpp
     CygwinPort.cpp
     Demangle.cpp

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -1642,11 +1642,6 @@ extern "C" const ProtocolDescriptor _TMps5Error;
 static const WitnessTable *findErrorWitness(const Metadata *srcType) {
   return swift_conformsToProtocol(srcType, &_TMps5Error);
 }
-
-static const Metadata *getNSErrorMetadata() {
-  return SWIFT_LAZY_CONSTANT(
-    swift_getObjCClassMetadata((const ClassMetadata *)getNSErrorClass()));
-}
 #endif
 
 /// Perform a dynamic cast from an existential type to some kind of

--- a/stdlib/public/runtime/ErrorObject.h
+++ b/stdlib/public/runtime/ErrorObject.h
@@ -26,6 +26,7 @@
 
 #include "swift/Runtime/Metadata.h"
 #include "swift/Runtime/HeapObject.h"
+#include "SwiftHashableSupport.h"
 #include <atomic>
 #if SWIFT_OBJC_INTEROP
 # include <CoreFoundation/CoreFoundation.h>
@@ -70,12 +71,25 @@ struct SwiftError : SwiftErrorHeader {
   // Core Foundation's refcounting scheme.
 
   /// The type of Swift error value contained in the box.
-  /// This is only available for native Swift errors.
+  /// This member is only available for native Swift errors.
   const Metadata *type;
-  /// The Error witness table.
-  /// This is only available for native Swift errors.
+
+  /// The witness table for `Error` conformance.
+  /// This member is only available for native Swift errors.
   const WitnessTable *errorConformance;
-  
+
+  /// The base type that introduces the `Hashable` conformance.
+  /// This member is only available for native Swift errors.
+  /// This member is lazily-initialized.
+  /// Instead of using it directly, call `getHashableBaseType()`.
+  mutable std::atomic<const Metadata *> hashableBaseType;
+
+  /// The witness table for `Hashable` conformance.
+  /// This member is only available for native Swift errors.
+  /// This member is lazily-initialized.
+  /// Instead of using it directly, call `getHashableConformance()`.
+  mutable std::atomic<const hashable_support::HashableWitnessTable *> hashableConformance;
+
   /// Get a pointer to the value contained inside the indirectly-referenced
   /// box reference.
   static const OpaqueValue *getIndirectValue(const SwiftError * const *ptr) {
@@ -128,7 +142,15 @@ struct SwiftError : SwiftErrorHeader {
   /// Get the Error protocol witness table for the contained type.
   const WitnessTable *getErrorConformance() const { return errorConformance; }
 #endif
-  
+
+  /// Get the base type that conforms to `Hashable`.
+  /// Returns NULL if the type does not conform.
+  const Metadata *getHashableBaseType() const;
+
+  /// Get the `Hashable` protocol witness table for the contained type.
+  /// Returns NULL if the type does not conform.
+  const hashable_support::HashableWitnessTable *getHashableConformance() const;
+
   // Don't copy or move, please.
   SwiftError(const SwiftError &) = delete;
   SwiftError(SwiftError &&) = delete;
@@ -201,6 +223,9 @@ bool tryDynamicCastNSErrorToValue(OpaqueValue *dest,
 
 /// Get the NSError Objective-C class.
 Class getNSErrorClass();
+
+/// Get the NSError metadata.
+const Metadata *getNSErrorMetadata();
 
 #endif
 

--- a/stdlib/public/runtime/ErrorObject.mm
+++ b/stdlib/public/runtime/ErrorObject.mm
@@ -34,6 +34,7 @@
 #include <Foundation/Foundation.h>
 
 using namespace swift;
+using namespace swift::hashable_support;
 
 /// A subclass of NSError used to represent bridged native Swift errors.
 /// This type cannot be subclassed, and should not ever be instantiated
@@ -97,10 +98,57 @@ using namespace swift;
   return getNSErrorClass();
 }
 
+// Note: We support comparing cases of `@objc` enums defined in Swift to
+// pure `NSError`s.  They should compare equal as long as the domain and
+// code match.  Equal values should have equal hash values.  Thus, we can't
+// use the Swift hash value computation that comes from the `Hashable`
+// conformance if one exists, and we must use the `NSError` hashing
+// algorithm.
+//
+// So we are not overriding the `hash` method, even though we are
+// overriding `isEqual:`.
+
+- (BOOL)isEqual:(id)other {
+  auto self_ = (const SwiftError *)self;
+  auto other_ = (const SwiftError *)other;
+  assert(!self_->isPureNSError());
+
+  if (self == other) {
+    return YES;
+  }
+
+  if (!other) {
+    return NO;
+  }
+
+  if (other_->isPureNSError()) {
+    return [super isEqual:other];
+  }
+
+  auto hashableBaseType = self_->getHashableBaseType();
+  if (!hashableBaseType || other_->getHashableBaseType() != hashableBaseType) {
+    return [super isEqual:other];
+  }
+
+  auto hashableConformance = self_->getHashableConformance();
+  if (!hashableConformance) {
+    return [super isEqual:other];
+  }
+
+  return swift_stdlib_Hashable_isEqual_indirect(
+      self_->getValue(), other_->getValue(), hashableBaseType,
+      hashableConformance);
+}
+
 @end
 
 Class swift::getNSErrorClass() {
   return SWIFT_LAZY_CONSTANT([NSError class]);
+}
+
+const Metadata *swift::getNSErrorMetadata() {
+  return SWIFT_LAZY_CONSTANT(
+    swift_getObjCClassMetadata((const ClassMetadata *)getNSErrorClass()));
 }
 
 static Class getSwiftNativeNSErrorClass() {
@@ -141,7 +189,9 @@ _swift_allocError_(const Metadata *type,
   // Initialize the Swift type metadata.
   instance->type = type;
   instance->errorConformance = errorConformance;
-  
+  instance->hashableBaseType = nullptr;
+  instance->hashableConformance = nullptr;
+
   auto valueBytePtr = reinterpret_cast<char*>(instance) + valueOffset;
   auto valuePtr = reinterpret_cast<OpaqueValue*>(valueBytePtr);
   
@@ -195,10 +245,20 @@ static const WitnessTable *getNSErrorConformanceToError() {
   auto TheWitnessTable = SWIFT_LAZY_CONSTANT(dlsym(RTLD_DEFAULT,
                                    "_TWPCSo7CFErrors5Error10Foundation"));
   assert(TheWitnessTable &&
-         "Foundation overlay not loaded, or CFError: Error conformance "
+         "Foundation overlay not loaded, or 'CFError : Error' conformance "
          "not available");
   
   return reinterpret_cast<const WitnessTable *>(TheWitnessTable);
+}
+
+static const HashableWitnessTable *getNSErrorConformanceToHashable() {
+  auto TheWitnessTable = SWIFT_LAZY_CONSTANT(dlsym(RTLD_DEFAULT,
+                                   "__TWPCSo8NSObjects8Hashable10ObjectiveC"));
+  assert(TheWitnessTable &&
+         "ObjectiveC overlay not loaded, or 'NSObject : Hashable' conformance "
+         "not available");
+
+  return reinterpret_cast<const HashableWitnessTable *>(TheWitnessTable);
 }
 
 bool SwiftError::isPureNSError() const {
@@ -221,6 +281,47 @@ const WitnessTable *SwiftError::getErrorConformance() const {
     return getNSErrorConformanceToError();
   }
   return errorConformance;
+}
+
+const Metadata *SwiftError::getHashableBaseType() const {
+  if (isPureNSError()) {
+    return getNSErrorMetadata();
+  }
+  if (auto type = hashableBaseType.load(std::memory_order_acquire)) {
+    if (reinterpret_cast<uintptr_t>(type) == 1) {
+      return nullptr;
+    }
+    return type;
+  }
+
+  const Metadata *expectedType = nullptr;
+  const Metadata *hashableBaseType = findHashableBaseType(type);
+  this->hashableBaseType.compare_exchange_strong(
+      expectedType, hashableBaseType ? hashableBaseType
+                                     : reinterpret_cast<const Metadata *>(1),
+      std::memory_order_acq_rel);
+  return type;
+}
+
+const HashableWitnessTable *SwiftError::getHashableConformance() const {
+  if (isPureNSError()) {
+    return getNSErrorConformanceToHashable();
+  }
+  if (auto wt = hashableConformance.load(std::memory_order_acquire)) {
+    if (reinterpret_cast<uintptr_t>(wt) == 1) {
+      return nullptr;
+    }
+    return wt;
+  }
+
+  const HashableWitnessTable *expectedWT = nullptr;
+  const HashableWitnessTable *wt =
+      reinterpret_cast<const HashableWitnessTable *>(
+          swift_conformsToProtocol(type, &_TMps8Hashable));
+  hashableConformance.compare_exchange_strong(
+      expectedWT, wt ? wt : reinterpret_cast<const HashableWitnessTable *>(1),
+      std::memory_order_acq_rel);
+  return wt;
 }
 
 /// Extract a pointer to the value, the type metadata, and the Error

--- a/stdlib/public/runtime/ErrorObjectNative.cpp
+++ b/stdlib/public/runtime/ErrorObjectNative.cpp
@@ -17,12 +17,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/Runtime/Config.h"
+
+#if !SWIFT_OBJC_INTEROP
+
 #include <stdio.h>
 #include "swift/Runtime/Debug.h"
 #include "ErrorObject.h"
 #include "Private.h"
-
-#if !SWIFT_OBJC_INTEROP
 
 using namespace swift;
 

--- a/stdlib/public/runtime/SwiftHashableSupport.h
+++ b/stdlib/public/runtime/SwiftHashableSupport.h
@@ -26,13 +26,24 @@ struct HashableWitnessTable;
 
 /// Calls `Equatable.==` through a `Hashable` (not Equatable!) witness
 /// table.
+SWIFT_CC(swift)
 extern "C" bool swift_stdlib_Hashable_isEqual_indirect(
     const void *lhsValue, const void *rhsValue, const Metadata *type,
     const HashableWitnessTable *wt);
 
 /// Calls `Hashable.hashValue.get` through a `Hashable` witness table.
+SWIFT_CC(swift)
 extern "C" intptr_t swift_stdlib_Hashable_hashValue_indirect(
     const void *value, const Metadata *type, const HashableWitnessTable *wt);
+
+SWIFT_CC(swift)
+extern "C" void _swift_convertToAnyHashableIndirect(
+    OpaqueValue *source, OpaqueValue *destination, const Metadata *sourceType,
+    const HashableWitnessTable *sourceConformance);
+
+SWIFT_CC(swift)
+extern "C" bool _swift_anyHashableDownCastConditionalIndirect(
+    OpaqueValue *source, OpaqueValue *destination, const Metadata *targetType);
 
 /// Find the base type that introduces the `Hashable` conformance.
 /// Because the provided type is known to conform to `Hashable`, this

--- a/stdlib/public/runtime/SwiftHashableSupport.h
+++ b/stdlib/public/runtime/SwiftHashableSupport.h
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_RUNTIME_SWIFT_HASHABLE_SUPPORT_H
+#define SWIFT_RUNTIME_SWIFT_HASHABLE_SUPPORT_H
+
+#include "swift/Runtime/Metadata.h"
+#include <stdint.h>
+
+namespace swift {
+namespace hashable_support {
+
+/// The name demangles to "protocol descriptor for Swift.Hashable".
+extern "C" const ProtocolDescriptor _TMps8Hashable;
+
+struct HashableWitnessTable;
+
+/// Calls `Equatable.==` through a `Hashable` (not Equatable!) witness
+/// table.
+extern "C" bool swift_stdlib_Hashable_isEqual_indirect(
+    const void *lhsValue, const void *rhsValue, const Metadata *type,
+    const HashableWitnessTable *wt);
+
+/// Calls `Hashable.hashValue.get` through a `Hashable` witness table.
+extern "C" intptr_t swift_stdlib_Hashable_hashValue_indirect(
+    const void *value, const Metadata *type, const HashableWitnessTable *wt);
+
+/// Find the base type that introduces the `Hashable` conformance.
+/// Because the provided type is known to conform to `Hashable`, this
+/// function always returns non-null.
+///
+/// - Precondition: `type` conforms to `Hashable` (not checked).
+const Metadata *findHashableBaseTypeOfHashableType(
+    const Metadata *type);
+
+/// Find the base type that introduces the `Hashable` conformance.
+/// If `type` does not conform to `Hashable`, `nullptr` is returned.
+const Metadata *findHashableBaseType(const Metadata *type);
+
+} // namespace hashable_support
+} // namespace swift
+
+#endif
+

--- a/stdlib/public/runtime/SwiftValue.h
+++ b/stdlib/public/runtime/SwiftValue.h
@@ -23,7 +23,6 @@
 
 #if SWIFT_OBJC_INTEROP
 #include <objc/runtime.h>
-#endif
 
 // SwiftValue is an Objective-C class, but we shouldn't interface with it
 // directly as such. Keep the type opaque.
@@ -48,12 +47,11 @@ const Metadata *getSwiftValueTypeMetadata(SwiftValue *v);
 std::pair<const Metadata *, const OpaqueValue *>
 getValueFromSwiftValue(SwiftValue *v);
 
-#if SWIFT_OBJC_INTEROP
 /// Return the object reference as a SwiftValue* if it is a SwiftValue instance,
 /// or nil if it is not.
 SwiftValue *getAsSwiftValue(id object);
-#endif
 
-}
+} // namespace swift
+#endif
 
 #endif

--- a/stdlib/public/stubs/CMakeLists.txt
+++ b/stdlib/public/stubs/CMakeLists.txt
@@ -17,7 +17,6 @@ else()
 endif()
 
 add_swift_library(swiftStdlibStubs OBJECT_LIBRARY TARGET_LIBRARY
-  AnyHashableSupport.cpp
   Assert.cpp
   CommandLine.cpp
   GlobalObjects.cpp

--- a/test/1_stdlib/BridgeIdAsAny.swift.gyb
+++ b/test/1_stdlib/BridgeIdAsAny.swift.gyb
@@ -205,8 +205,40 @@ BridgeAnything.test("description of boxed values") {
     expectEqual(summary, _bridgeAnythingToObjectiveC(x).description)
     expectEqual(summary, _bridgeAnythingToObjectiveC(x).debugDescription)
   }
+}
 
-  expectEqual(0, LifetimeTracked.instances)
+BridgeAnything.test("SwiftValue(mixed values)/Hashable") {
+  var boxedXs: [NSObject] = []
+% for wrapped in ['OpaqueValue', 'MinimalHashableValue']:
+  do {
+    let xs = (0..<5).flatMap {
+      [ ${wrapped}($0, identity: 0),
+        ${wrapped}($0, identity: 1) ]
+    }
+    boxedXs.append(
+      contentsOf: xs.map {
+        _bridgeAnythingToObjectiveC($0) as! NSObject
+      })
+  }
+% end
+
+  boxedXs.append(
+    contentsOf: [0, 0, 1, 1, 2, 2, 3, 3, 4, 4].map {
+      _bridgeAnythingToObjectiveC($0) as! NSObject
+    })
+
+  boxedXs.append(
+    contentsOf: ["a", "a", "b", "b", "c", "c", "d", "d", "e", "e"].map {
+      _bridgeAnythingToObjectiveC($0) as! NSObject
+    })
+
+  func equalityOracle(_ lhs: Int, rhs: Int) -> Bool {
+    if (0..<10).contains(lhs) || (0..<10).contains(rhs) {
+      return lhs == rhs
+    }
+    return lhs / 2 == rhs / 2
+  }
+  checkHashable(boxedXs, equalityOracle: equalityOracle)
 }
 
 runAllTests()

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -27,6 +27,7 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     Mutex.cpp
     Enum.cpp
     Refcounting.cpp
+    Stdlib.cpp
     ${PLATFORM_SOURCES}
 
     # The runtime tests link to internal runtime symbols, which aren't exported

--- a/unittests/runtime/Stdlib.cpp
+++ b/unittests/runtime/Stdlib.cpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Runtime/Metadata.h"
+
+using namespace swift;
+
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
+extern "C" void _swift_stdlib_makeAnyHashableUsingDefaultRepresentation(
+  const OpaqueValue *value,
+  const void *anyHashableResultPointer,
+  const Metadata *T,
+  const WitnessTable *hashableWT
+) {
+  abort();
+}
+

--- a/validation-test/StdlibUnittest/CheckEquatable.swift.gyb
+++ b/validation-test/StdlibUnittest/CheckEquatable.swift.gyb
@@ -77,6 +77,10 @@ AssertionsTestSuite.test("checkEquatable/BrokenTransitivity/1") {
     checkEquatable(
       xs, oracle: { MinimalEquatableValue($0) == MinimalEquatableValue($1) })
   }
+  checkEquatable(
+    xs,
+    oracle: { MinimalEquatableValue($0) == MinimalEquatableValue($1) },
+    allowBrokenTransitivity: true)
 }
 // CHECK: stdout>>> bad oracle: broken transitivity at indices 1, 2, 0
 // CHECK: [        OK ] Assertions.checkEquatable/BrokenTransitivity/1
@@ -98,6 +102,10 @@ AssertionsTestSuite.test("checkEquatable/BrokenTransitivity/2") {
     checkEquatable(
       xs, oracle: { MinimalEquatableValue($0) == MinimalEquatableValue($1) })
   }
+  checkEquatable(
+    xs,
+    oracle: { MinimalEquatableValue($0) == MinimalEquatableValue($1) },
+    allowBrokenTransitivity: true)
 }
 // CHECK: stdout>>> bad oracle: broken transitivity at indices 4, 7, 1
 // CHECK: [        OK ] Assertions.checkEquatable/BrokenTransitivity/2
@@ -117,6 +125,10 @@ AssertionsTestSuite.test("checkEquatable/BrokenTransitivity/3") {
     checkEquatable(
       xs, oracle: { MinimalEquatableValue($0) == MinimalEquatableValue($1) })
   }
+  checkEquatable(
+    xs,
+    oracle: { MinimalEquatableValue($0) == MinimalEquatableValue($1) },
+    allowBrokenTransitivity: true)
 }
 // CHECK: stdout>>> bad oracle: broken transitivity at indices 0, 7, 1
 // CHECK: [        OK ] Assertions.checkEquatable/BrokenTransitivity/3

--- a/validation-test/stdlib/AnyHashable.swift.gyb
+++ b/validation-test/stdlib/AnyHashable.swift.gyb
@@ -666,7 +666,7 @@ AnyHashableTests.test("AnyHashable(MinimalHashableRCSwiftError).base") {
 }
 
 #if _runtime(_ObjC)
-AnyHashableTests.test("AnyHashable(_SwiftNativeNSError)/Hashable") {
+AnyHashableTests.test("AnyHashable(_SwiftNativeNSError(MinimalHashablePODSwiftError))/Hashable") {
   let swiftErrors: [MinimalHashablePODSwiftError] = [
     .caseA, .caseA,
     .caseB, .caseB,
@@ -683,8 +683,42 @@ AnyHashableTests.test("AnyHashable(_SwiftNativeNSError)/Hashable") {
     equalityOracle: { $0 / 2 == $1 / 2 })
 }
 
-AnyHashableTests.test("AnyHashable(_SwiftNativeNSError).base") {
+AnyHashableTests.test("AnyHashable(_SwiftNativeNSError(MinimalHashablePODSwiftError)).base") {
   let ah = AnyHashable(MinimalHashablePODSwiftError.caseA as NSError)
+  expectTrue(type(of: ah.base) is NSError.Type)
+}
+
+AnyHashableTests.test("AnyHashable(_SwiftNativeNSError(MinimalHashableRCSwiftError))/Hashable") {
+  let swiftErrors: [MinimalHashableRCSwiftError] = [
+    .caseA(LifetimeTracked(1)), .caseA(LifetimeTracked(1)),
+    .caseA(LifetimeTracked(2)), .caseA(LifetimeTracked(2)),
+    .caseB(LifetimeTracked(1)), .caseB(LifetimeTracked(1)),
+    .caseB(LifetimeTracked(2)), .caseB(LifetimeTracked(2)),
+    .caseC(LifetimeTracked(1)), .caseC(LifetimeTracked(1)),
+    .caseC(LifetimeTracked(2)), .caseC(LifetimeTracked(2)),
+  ]
+  let nsErrors: [NSError] = swiftErrors.map { $0 as NSError }
+  expectEqual(
+    .objCClassWrapper,
+    SwiftRuntime.metadataKind(of: nsErrors.first!))
+  expectEqual("_SwiftNativeNSError", String(describing: type(of: nsErrors[0])))
+  expectFailure {
+    // FIXME(id-as-any): make NSError bridging consistent with Swift's notion
+    // of hashing and equality.
+    checkHashable(nsErrors, equalityOracle: { $0 / 2 == $1 / 2 })
+  }
+  expectFailure {
+    // FIXME(id-as-any): make NSError bridging consistent with Swift's notion
+    // of hashing and equality.
+    checkHashable(
+      nsErrors.map(AnyHashable.init),
+      equalityOracle: { $0 / 2 == $1 / 2 })
+  }
+}
+
+AnyHashableTests.test("AnyHashable(_SwiftNativeNSError(MinimalHashableRCSwiftError)).base") {
+  let ah = AnyHashable(
+    MinimalHashableRCSwiftError.caseA(LifetimeTracked(1)) as NSError)
   expectTrue(type(of: ah.base) is NSError.Type)
 }
 

--- a/validation-test/stdlib/AnyHashable.swift.gyb
+++ b/validation-test/stdlib/AnyHashable.swift.gyb
@@ -79,6 +79,11 @@ AnyHashableTests.test("AnyHashable(${wrapped})/Hashable") {
     xs.map(AnyHashable.init),
     equalityOracle: { $0 / 2 == $1 / 2 })
 }
+
+AnyHashableTests.test("AnyHashable(${wrapped}).base") {
+  let ah = AnyHashable(${wrapped}(42, identity: 0))
+  expectEqual(${wrapped}.self, type(of: ah.base))
+}
 % end
 
 % for wrapped in ['GenericMinimalHashableValue', 'GenericMinimalHashableClass']:
@@ -99,6 +104,11 @@ AnyHashableTests.test("AnyHashable(${wrapped}<OpaqueValue<Int>>)/Hashable") {
   checkHashable(
     xs.map(AnyHashable.init),
     equalityOracle: { $0 / 2 == $1 / 2 })
+}
+
+AnyHashableTests.test("AnyHashable(${wrapped}).base") {
+  let ah = AnyHashable(${wrapped}(${payload}(42), identity: 0))
+  expectEqual(${wrapped}<${payload}>.self, type(of: ah.base))
 }
 %   end
 % end
@@ -192,7 +202,7 @@ ${kw} HasCustomRepresentation_Generic${name}<Wrapped>
 % for name in [ 'Class', 'PODStruct', 'RCStruct' ]:
 %   wrapped = 'HasCustomRepresentation_%s' % name
 %   genericWrapped = 'HasCustomRepresentation_Generic%s' % name
-AnyHashableTests.test("AnyHashable containing ${wrapped}") {
+AnyHashableTests.test("AnyHashable(${wrapped})/Hashable") {
   let xs = (-2...2).flatMap {
     [ ${wrapped}(
         $0, identity: 0,
@@ -208,8 +218,25 @@ AnyHashableTests.test("AnyHashable containing ${wrapped}") {
     equalityOracle: { $0 / 2 == $1 / 2 })
 }
 
+AnyHashableTests.test("AnyHashable(${wrapped}).base") {
+  do {
+    let ah = AnyHashable(
+      ${wrapped}(
+        42, identity: 1,
+        hasDefaultAnyHashableRepresentation: true))
+    expectEqual(${wrapped}.self, type(of: ah.base))
+  }
+  do {
+    let ah = AnyHashable(
+      ${wrapped}(
+        42, identity: 1,
+        hasDefaultAnyHashableRepresentation: false))
+    expectEqual(MinimalHashableValue.self, type(of: ah.base))
+  }
+}
+
 %   for payload in [ 'OpaqueValue<Int>', 'LifetimeTracked' ]:
-AnyHashableTests.test("AnyHashable containing ${genericWrapped} with ${payload}") {
+AnyHashableTests.test("AnyHashable(${genericWrapped}<${payload}>)/Hashable") {
   GenericMinimalHashableValue_equalImpl.value = {
     ($0 as! ${payload}).value == ($1 as! ${payload}).value
   }
@@ -229,6 +256,25 @@ AnyHashableTests.test("AnyHashable containing ${genericWrapped} with ${payload}"
   checkHashable(
     xs.map(AnyHashable.init),
     equalityOracle: { $0 / 2 == $1 / 2 })
+}
+
+AnyHashableTests.test("AnyHashable(${genericWrapped}<${payload}>)/Hashable") {
+  do {
+    let ah = AnyHashable(
+      ${genericWrapped}(
+        ${payload}(42), identity: 0,
+        hasDefaultAnyHashableRepresentation: true))
+    expectEqual(${genericWrapped}<${payload}>.self, type(of: ah.base))
+  }
+  do {
+    let ah = AnyHashable(
+      ${genericWrapped}(
+        ${payload}(42), identity: 0,
+        hasDefaultAnyHashableRepresentation: false))
+    expectEqual(
+      GenericMinimalHashableValue<${payload}>.self,
+      type(of: ah.base))
+  }
 }
 %   end
 % end
@@ -267,8 +313,9 @@ AnyHashableTests.test("AnyHashable containing values with recursive custom repre
   }
   // If the custom representation has its own custom representation,
   // we ignore it.
-  let x = AnyHashable(HasCustomRepresentationRecursively(0))
-  expectPrinted("HasCustomRepresentationRecursively(value: 1)", x)
+  let ah = AnyHashable(HasCustomRepresentationRecursively(0))
+  expectPrinted("HasCustomRepresentationRecursively(value: 1)", ah)
+  expectEqual(HasCustomRepresentationRecursively.self, type(of: ah.base))
 }
 
 class T2_Base {}
@@ -414,9 +461,11 @@ AnyHashableTests.test("AnyHashable containing classes from the ${prefix} hierarc
   }
   checkHashable(xs, equalityOracle: equalityOracle)
 
-  checkHashable(
-    xs.map(AnyHashable.init),
-    equalityOracle: equalityOracle)
+  let anyHashables = xs.map(AnyHashable.init)
+  checkHashable(anyHashables, equalityOracle: equalityOracle)
+  for (x, ah) in zip(xs, anyHashables) {
+    expectEqual(type(of: x), type(of: ah.base))
+  }
 }
 ${'#endif' if 'ObjC' in prefix else ''}
 
@@ -465,7 +514,7 @@ let interestingBitVectorArrays: [[UInt8]] = [
   [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
 ]
 
-AnyHashableTests.test("AnyHashable containing CFBitVector") {
+AnyHashableTests.test("AnyHashable(CFBitVector)/Hashable, .base") {
   let bitVectors: [CFBitVector] =
     interestingBitVectorArrays.map(CFBitVector.makeImmutable)
   let arrays = bitVectors.map { $0.asArray }
@@ -475,24 +524,32 @@ AnyHashableTests.test("AnyHashable containing CFBitVector") {
   expectEqualTest(interestingBitVectorArrays, arrays, sameValue: isEq)
   checkHashable(bitVectors, equalityOracle: { $0 == $1 })
 
-  expectEqual(.foreignClass, SwiftRuntime.metadataKind(of: bitVectors.first!))
+  do {
+    expectEqual(.foreignClass, SwiftRuntime.metadataKind(of: bitVectors.first!))
 
-  checkHashable(
-    bitVectors.map(AnyHashable.init),
-    equalityOracle: { $0 == $1 })
+    let anyHashables = bitVectors.map(AnyHashable.init)
+    checkHashable(anyHashables, equalityOracle: { $0 == $1 })
 
-  let bitVectorsAsAnyObjects: [NSObject] = bitVectors.map {
-    ($0 as AnyObject) as! NSObject
+    let v = anyHashables.first!.base
+    expectTrue(type(of: v) is CFBitVector.Type)
   }
-  expectEqual(
-    .objCClassWrapper,
-    SwiftRuntime.metadataKind(of: bitVectorsAsAnyObjects.first!))
-  checkHashable(
-    bitVectorsAsAnyObjects.map(AnyHashable.init),
-    equalityOracle: { $0 == $1 })
+  do {
+    let bitVectorsAsAnyObjects: [NSObject] = bitVectors.map {
+      ($0 as AnyObject) as! NSObject
+    }
+    expectEqual(
+      .objCClassWrapper,
+      SwiftRuntime.metadataKind(of: bitVectorsAsAnyObjects.first!))
+
+    let anyHashables = bitVectorsAsAnyObjects.map(AnyHashable.init)
+    checkHashable(anyHashables, equalityOracle: { $0 == $1 })
+
+    let v = anyHashables.first!.base
+    expectTrue(type(of: v) is CFBitVector.Type)
+  }
 }
 
-AnyHashableTests.test("AnyHashable containing CFMutableBitVector") {
+AnyHashableTests.test("AnyHashable(CFMutableBitVector)/Hashable, .base") {
   // CFMutableBitVector inherits the Hashable conformance from
   // CFBitVector.
   let bitVectors: [CFMutableBitVector] =
@@ -504,22 +561,33 @@ AnyHashableTests.test("AnyHashable containing CFMutableBitVector") {
   expectEqualTest(interestingBitVectorArrays, arrays, sameValue: isEq)
   checkHashable(bitVectors, equalityOracle: { $0 == $1 })
 
-  expectEqual(.foreignClass, SwiftRuntime.metadataKind(of: bitVectors.first!))
+  do {
+    expectEqual(
+      .foreignClass,
+      SwiftRuntime.metadataKind(of: bitVectors.first!))
 
-  checkHashable(
-    bitVectors.map(AnyHashable.init),
-    equalityOracle: { $0 == $1 })
+    let anyHashables = bitVectors.map(AnyHashable.init)
+    checkHashable(anyHashables, equalityOracle: { $0 == $1 })
 
-  let bitVectorsAsAnyObjects: [NSObject] = bitVectors.map {
-    ($0 as AnyObject) as! NSObject
+    let v = anyHashables.first!.base
+    expectTrue(type(of: v) is CFMutableBitVector.Type)
   }
-  checkHashable(bitVectors, equalityOracle: { $0 == $1 })
-  expectEqual(
-    .objCClassWrapper,
-    SwiftRuntime.metadataKind(of: bitVectorsAsAnyObjects.first!))
-  checkHashable(
-    bitVectorsAsAnyObjects.map(AnyHashable.init),
-    equalityOracle: { $0 == $1 })
+  do {
+    let bitVectorsAsAnyObjects: [NSObject] = bitVectors.map {
+      ($0 as AnyObject) as! NSObject
+    }
+    checkHashable(bitVectorsAsAnyObjects, equalityOracle: { $0 == $1 })
+
+    expectEqual(
+      .objCClassWrapper,
+      SwiftRuntime.metadataKind(of: bitVectorsAsAnyObjects.first!))
+
+    let anyHashables = bitVectorsAsAnyObjects.map(AnyHashable.init)
+    checkHashable(anyHashables, equalityOracle: { $0 == $1 })
+
+    let v = anyHashables.first!.base
+    expectTrue(type(of: v) is CFMutableBitVector.Type)
+  }
 }
 
 #endif
@@ -556,7 +624,7 @@ enum MinimalHashableRCSwiftError : Error, Hashable {
   }
 }
 
-AnyHashableTests.test("AnyHashable containing MinimalHashablePODSwiftError") {
+AnyHashableTests.test("AnyHashable(MinimalHashablePODSwiftError)/Hashable") {
   let xs: [MinimalHashablePODSwiftError] = [
     .caseA, .caseA,
     .caseB, .caseB,
@@ -569,7 +637,12 @@ AnyHashableTests.test("AnyHashable containing MinimalHashablePODSwiftError") {
     equalityOracle: { $0 / 2 == $1 / 2 })
 }
 
-AnyHashableTests.test("AnyHashable containing MinimalHashableRCSwiftError") {
+AnyHashableTests.test("AnyHashable(MinimalHashablePODSwiftError).base") {
+  let ah = AnyHashable(MinimalHashablePODSwiftError.caseA)
+  expectEqual(MinimalHashablePODSwiftError.self, type(of: ah.base))
+}
+
+AnyHashableTests.test("AnyHashable(MinimalHashableRCSwiftError)/Hashable") {
   let xs: [MinimalHashableRCSwiftError] = [
     .caseA(LifetimeTracked(1)), .caseA(LifetimeTracked(1)),
     .caseA(LifetimeTracked(2)), .caseA(LifetimeTracked(2)),
@@ -585,8 +658,13 @@ AnyHashableTests.test("AnyHashable containing MinimalHashableRCSwiftError") {
     equalityOracle: { $0 / 2 == $1 / 2 })
 }
 
+AnyHashableTests.test("AnyHashable(MinimalHashableRCSwiftError).base") {
+  let ah = AnyHashable(MinimalHashableRCSwiftError.caseA(LifetimeTracked(1)))
+  expectEqual(MinimalHashableRCSwiftError.self, type(of: ah.base))
+}
+
 #if _runtime(_ObjC)
-AnyHashableTests.test("AnyHashable containing _SwiftNativeNSError") {
+AnyHashableTests.test("AnyHashable(_SwiftNativeNSError)/Hashable") {
   let swiftErrors: [MinimalHashablePODSwiftError] = [
     .caseA, .caseA,
     .caseB, .caseB,
@@ -603,7 +681,12 @@ AnyHashableTests.test("AnyHashable containing _SwiftNativeNSError") {
     equalityOracle: { $0 / 2 == $1 / 2 })
 }
 
-AnyHashableTests.test("AnyHashable containing NSError") {
+AnyHashableTests.test("AnyHashable(_SwiftNativeNSError).base") {
+  let ah = AnyHashable(MinimalHashablePODSwiftError.caseA as NSError)
+  expectTrue(type(of: ah.base) is NSError.Type)
+}
+
+AnyHashableTests.test("AnyHashable(NSError)/Hashable") {
   let nsErrors: [NSError] = [
     NSError(domain: "Foo", code: 0),
     NSError(domain: "Foo", code: 0),
@@ -619,6 +702,11 @@ AnyHashableTests.test("AnyHashable containing NSError") {
   checkHashable(
     nsErrors.map(AnyHashable.init),
     equalityOracle: { $0 / 2 == $1 / 2 })
+}
+
+AnyHashableTests.test("AnyHashable(NSError).base") {
+  let ah = AnyHashable(NSError(domain: "Foo", code: 0))
+  expectTrue(type(of: ah.base) is NSError.Type)
 }
 #endif
 

--- a/validation-test/stdlib/AnyHashable.swift.gyb
+++ b/validation-test/stdlib/AnyHashable.swift.gyb
@@ -88,6 +88,29 @@ AnyHashableTests.test("AnyHashable(${wrapped}).base") {
 }
 % end
 
+#if _runtime(_ObjC)
+AnyHashableTests.test("AnyHashable(MinimalHashableValue, SwiftValue(MinimalHashableValue))/Hashable") {
+  let xs = (0...5).flatMap {
+    [ MinimalHashableValue($0, identity: 0),
+      MinimalHashableValue($0, identity: 1) ]
+  }
+  checkHashable(xs, equalityOracle: { $0 / 2 == $1 / 2 })
+
+  let boxedXs = xs.flatMap {
+    [ AnyHashable($0),
+      AnyHashable(_bridgeAnythingToObjectiveC($0) as! NSObject) ]
+  }
+  for x in boxedXs {
+    expectEqual(
+      "MinimalHashableValue",
+      String(describing: type(of: x.base)))
+  }
+  checkHashable(
+    boxedXs,
+    equalityOracle: { $0 / 4 == $1 / 4 })
+}
+#endif
+
 % for wrapped in ['GenericMinimalHashableValue', 'GenericMinimalHashableClass']:
 %   for payload in [ 'OpaqueValue<Int>', 'LifetimeTracked' ]:
 AnyHashableTests.test("AnyHashable(${wrapped}<OpaqueValue<Int>>)/Hashable") {

--- a/validation-test/stdlib/AnyHashable.swift.gyb
+++ b/validation-test/stdlib/AnyHashable.swift.gyb
@@ -1,6 +1,8 @@
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 
+// FIXME(id-as-any): make Swift errors boxed in NSError eagerly bridged.
+
 // FIXME(id-as-any): add tests for unboxing.
 
 // FIXME(id-as-any): add tests for the _ObjectiveCBridgeable conformance.

--- a/validation-test/stdlib/AnyHashable.swift.gyb
+++ b/validation-test/stdlib/AnyHashable.swift.gyb
@@ -115,6 +115,46 @@ AnyHashableTests.test("AnyHashable(${wrapped}).base") {
 %   end
 % end
 
+AnyHashableTests.test("AnyHashable(mixed minimal hashables)/Hashable") {
+  var xs: [AnyHashable] = []
+
+% for wrapped in ['MinimalHashableValue', 'MinimalHashableClass']:
+  xs += (0...5).flatMap {
+    [ ${wrapped}($0, identity: 0),
+      ${wrapped}($0, identity: 1) ].map(AnyHashable.init)
+  }
+% end
+
+% for wrapped in ['GenericMinimalHashableValue', 'GenericMinimalHashableClass']:
+  ${wrapped}_equalImpl.value = {
+    (lhs, rhs) in
+    if let lhs = lhs as? OpaqueValue<Int>,
+      let rhs = rhs as? OpaqueValue<Int> {
+      return lhs.value == rhs.value
+    }
+    return (lhs as! LifetimeTracked) == (rhs as! LifetimeTracked)
+  }
+  ${wrapped}_hashValueImpl.value = {
+    payload in
+    if let x = payload as? OpaqueValue<Int> {
+      return x.value
+    }
+    return (payload as! LifetimeTracked).value
+  }
+% end
+
+% for wrapped in ['GenericMinimalHashableValue', 'GenericMinimalHashableClass']:
+%   for payload in [ 'OpaqueValue<Int>', 'LifetimeTracked' ]:
+  xs += (0...5).flatMap {
+    [ ${wrapped}(${payload}($0), identity: 0),
+      ${wrapped}(${payload}($0), identity: 1) ].map(AnyHashable.init)
+  }
+%   end
+% end
+
+  checkHashable(xs, equalityOracle: { $0 / 2 == $1 / 2 })
+}
+
 % for (kw, name) in [
 %   ('class', 'Class'),
 %   ('struct', 'PODStruct'),
@@ -606,7 +646,14 @@ enum MinimalHashableRCSwiftError : Error, Hashable {
   case caseC(LifetimeTracked)
 
   var hashValue: Int {
-    return 0
+    switch self {
+    case .caseA:
+      return 10
+    case .caseB:
+      return 20
+    case .caseC:
+      return 30
+    }
   }
 
   static func == (
@@ -672,15 +719,35 @@ AnyHashableTests.test("AnyHashable(_SwiftNativeNSError(MinimalHashablePODSwiftEr
     .caseB, .caseB,
     .caseC, .caseC,
   ]
-  let nsErrors: [NSError] = swiftErrors.map { $0 as NSError }
+  let nsErrors: [NSError] = swiftErrors.flatMap {
+    swiftError -> [NSError] in
+    let bridgedNSError = swiftError as NSError
+    return [
+      bridgedNSError,
+      NSError(domain: bridgedNSError.domain, code: bridgedNSError.code)
+    ]
+  }
   expectEqual(
     .objCClassWrapper,
-    SwiftRuntime.metadataKind(of: nsErrors.first!))
+    SwiftRuntime.metadataKind(of: nsErrors[0]))
   expectEqual("_SwiftNativeNSError", String(describing: type(of: nsErrors[0])))
-  checkHashable(nsErrors, equalityOracle: { $0 / 2 == $1 / 2 })
+
+  func equalityOracle(_ lhs: Int, _ rhs: Int) -> Bool {
+    // Swift errors compare equal to the `NSError`s that have the same domain
+    // and code.
+    return lhs / 4 == rhs / 4
+  }
+
+  checkHashable(nsErrors, equalityOracle: equalityOracle)
   checkHashable(
     nsErrors.map(AnyHashable.init),
-    equalityOracle: { $0 / 2 == $1 / 2 })
+    equalityOracle: equalityOracle)
+
+  // FIXME(id-as-any): run `checkHashable` on an array of mixed
+  // `AnyHashable(MinimalHashablePODSwiftError)` and
+  // `AnyHashable(_SwiftNativeNSError(MinimalHashablePODSwiftError))`.  For
+  // this to succeed, we need to eagerly bridge Swift errors into the Swift
+  // representation when wrapped in `AnyHashable`.
 }
 
 AnyHashableTests.test("AnyHashable(_SwiftNativeNSError(MinimalHashablePODSwiftError)).base") {
@@ -697,23 +764,59 @@ AnyHashableTests.test("AnyHashable(_SwiftNativeNSError(MinimalHashableRCSwiftErr
     .caseC(LifetimeTracked(1)), .caseC(LifetimeTracked(1)),
     .caseC(LifetimeTracked(2)), .caseC(LifetimeTracked(2)),
   ]
-  let nsErrors: [NSError] = swiftErrors.map { $0 as NSError }
+  let nsErrors: [NSError] = swiftErrors.flatMap {
+    swiftError -> [NSError] in
+    let bridgedNSError = swiftError as NSError
+    return [
+      bridgedNSError,
+      NSError(domain: bridgedNSError.domain, code: bridgedNSError.code)
+    ]
+  }
+
   expectEqual(
     .objCClassWrapper,
-    SwiftRuntime.metadataKind(of: nsErrors.first!))
+    SwiftRuntime.metadataKind(of: nsErrors[0]))
   expectEqual("_SwiftNativeNSError", String(describing: type(of: nsErrors[0])))
-  expectFailure {
-    // FIXME(id-as-any): make NSError bridging consistent with Swift's notion
-    // of hashing and equality.
-    checkHashable(nsErrors, equalityOracle: { $0 / 2 == $1 / 2 })
+
+  expectEqual(
+    .objCClassWrapper,
+    SwiftRuntime.metadataKind(of: nsErrors[1]))
+  expectEqual("NSError", String(describing: type(of: nsErrors[1])))
+
+  func equalityOracle(_ lhs: Int, _ rhs: Int) -> Bool {
+    // Equality of bridged Swift errors takes the payload into account, so for
+    // a fixed X, Y, all `.caseX(LifetimeTracked(Y))` compare equal.
+    // They also compare equal to the `NSError`s that have the same domain
+    // and code.
+    if lhs / 4 == rhs / 4 {
+      return true
+    }
+    // `NSError`s that have the same domain and code as a bridged Swift
+    // error compare equal to all Swift errors with the same domain and code
+    // regardless of the payload.
+    if (lhs % 2 == 1 || rhs % 2 == 1) && (lhs / 8 == rhs / 8) {
+      return true
+    }
+    return false
   }
-  expectFailure {
-    // FIXME(id-as-any): make NSError bridging consistent with Swift's notion
-    // of hashing and equality.
-    checkHashable(
-      nsErrors.map(AnyHashable.init),
-      equalityOracle: { $0 / 2 == $1 / 2 })
-  }
+
+  // FIXME: transitivity is broken because pure `NSError`s can compare equal to
+  // Swift errors with payloads just based on the domain and code, and Swift
+  // errors with payloads don't compare equal when payloads differ.
+  checkHashable(
+    nsErrors,
+    equalityOracle: equalityOracle,
+    allowBrokenTransitivity: true)
+  checkHashable(
+    nsErrors.map(AnyHashable.init),
+    equalityOracle: equalityOracle,
+    allowBrokenTransitivity: true)
+
+  // FIXME(id-as-any): run `checkHashable` on an array of mixed
+  // `AnyHashable(MinimalHashableRCSwiftError)` and
+  // `AnyHashable(_SwiftNativeNSError(MinimalHashableRCSwiftError))`.  For
+  // this to succeed, we need to eagerly bridge Swift errors into the Swift
+  // representation when wrapped in `AnyHashable`.
 }
 
 AnyHashableTests.test("AnyHashable(_SwiftNativeNSError(MinimalHashableRCSwiftError)).base") {


### PR DESCRIPTION
This PR is a set of fixes related to `AnyHashable` and id-as-Any work:
- StdlibUnittest: change `Minimal~Class` types to actually be classes (these types were added for testing `AnyHashable`).
- Added tests for `AnyHashable.base`.
- Changed `_SwiftNativeNSError` to use the `Hashable` conformance, if the boxed value conforms to `Hashable`.  (rdar://problem/27574348)
- Changed `SwiftValue` to use the `Hashable` conformance, if the boxed value conforms to `Hashable`.  (rdar://problem/27574348)
- Changed `AnyHashable` to eagerly unbox `SwiftValue`.  Previously `AnyHashable` would consider `SwiftValue` to be a subclass of `NSObject` (which it is in practice) and return `false` when trying to compare an `AnyHashable` of a `SwiftValue` box to an `AnyHashable` of the unboxed value.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
