### PR TITLE
Clang Importer: Set the ElementType of synthesized SubscriptDecls to the contextual generic type.

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -726,6 +726,7 @@ namespace {
     void visitSubscriptDecl(SubscriptDecl *SD) {
       printCommon(SD, "subscript_decl");
       OS << " storage_kind=" << getStorageKindName(SD->getStorageKind());
+      OS << " element=" << SD->getElementType()->getCanonicalType();
       printAccessors(SD);
       OS << ')';
     }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4832,6 +4832,9 @@ namespace {
       auto elementTy
         = getter->getInterfaceType()->castTo<AnyFunctionType>()->getResult()
             ->castTo<AnyFunctionType>()->getResult();
+      auto elementContextTy
+        = getter->getType()->castTo<AnyFunctionType>()->getResult()
+          ->castTo<AnyFunctionType>()->getResult();
 
       // Local function to mark the setter unavailable.
       auto makeSetterUnavailable = [&] {
@@ -4934,7 +4937,7 @@ namespace {
                                       getOverridableAccessibility(dc),
                                       name, decl->getLoc(), bodyParams,
                                       decl->getLoc(),
-                                      TypeLoc::withoutLoc(elementTy), dc);
+                                      TypeLoc::withoutLoc(elementContextTy),dc);
 
       /// Record the subscript as an alternative declaration.
       Impl.AlternateDecls[associateWithSetter ? setter : getter] = subscript;

--- a/test/SILGen/Inputs/objc_bridged_generic_nonnull.h
+++ b/test/SILGen/Inputs/objc_bridged_generic_nonnull.h
@@ -1,0 +1,11 @@
+@import Foundation;
+
+@interface NonnullMembers<T> : NSObject
+
+- (T _Nonnull) method;
+
+@property (readonly) T _Nonnull property;
+
+- (T _Nonnull)objectForKeyedSubscript:(id _Nonnull)key;
+
+@end

--- a/test/SILGen/objc_bridged_generic_nonnull.swift
+++ b/test/SILGen/objc_bridged_generic_nonnull.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -emit-silgen -verify -import-objc-header %S/Inputs/objc_bridged_generic_nonnull.h %s
+// REQUIRES: objc_interop
+
+public func test<T: AnyObject>(_ x: NonnullMembers<T>) -> T? {
+  var z: T?
+  z = x.method()
+  z = x.property
+  z = x.property
+  z = x[x]
+  _ = z
+}


### PR DESCRIPTION
This matches what parsed SubscriptDecls do, avoiding a crash later in SILGen. Fixes SR-1576 / rdar://problem/26632701.
