### PR TITLE
[SE-0091] Require member operators to refer to the enclosing nominal type

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -640,6 +640,9 @@ ERROR(nonstatic_operator_in_type,none,
 ERROR(nonfinal_operator_in_class,none,
       "operator %0 declared in non-final class %1 must be 'final'",
       (Identifier, Type))
+ERROR(operator_in_unrelated_type,none,
+      "member operator %2%select{| of protocol %0}1 must have at least one "
+      "argument of type %select{%0|'Self'}1", (Type, bool, DeclName))
 
 // Precedence groups
 ERROR(ambiguous_precedence_groups,none,

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4591,6 +4591,48 @@ public:
     return type->getAs<AnyFunctionType>();
   }
 
+  void checkMemberOperator(FuncDecl *FD) {
+    // Check that member operators reference the type of 'Self'.
+    if (FD->getNumParameterLists() != 2 || FD->isInvalid()) return;
+
+    auto selfNominal =
+      FD->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
+    if (!selfNominal) return;
+
+    // Check the parameters for a reference to 'Self'.
+    bool isProtocol = isa<ProtocolDecl>(selfNominal);
+    for (auto param : *FD->getParameterList(1)) {
+      auto paramType = param->getInterfaceType();
+      if (!paramType) break;
+
+      // Look through 'inout'.
+      paramType = paramType->getInOutObjectType();
+
+      // Look through a metatype reference, if there is one.
+      if (auto metatypeType = paramType->getAs<AnyMetatypeType>())
+        paramType = metatypeType->getInstanceType();
+
+      // Is it the same nominal type?
+      if (paramType->getAnyNominal() == selfNominal) return;
+
+      if (isProtocol) {
+        // For a protocol, is it the 'Self' type parameter?
+        if (auto genericParam = paramType->getAs<GenericTypeParamType>())
+          if (genericParam->getDepth() == 0 && genericParam->getIndex() == 0)
+            return;
+
+        // ... or the 'Self' archetype?
+        if (auto archetype = paramType->getAs<ArchetypeType>())
+          if (archetype->getSelfProtocol() == selfNominal) return;
+      }
+    }
+
+    // We did not find 'Self'. Complain.
+    TC.diagnose(FD, diag::operator_in_unrelated_type,
+                FD->getDeclContext()->getDeclaredTypeInContext(),
+                isProtocol, FD->getFullName());
+  }
+
   void visitFuncDecl(FuncDecl *FD) {
     if (!IsFirstPass) {
       if (FD->hasBody()) {
@@ -4738,6 +4780,9 @@ public:
           }
         }
       }
+
+      if (FD->isOperator())
+        checkMemberOperator(FD);
 
       Optional<ObjCReason> isObjC = shouldMarkAsObjC(TC, FD);
 

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -1092,10 +1092,10 @@ postfix operator <*>
 // PASS_2500-LABEL: {{^}}postfix operator <*>{{$}}
 
 protocol d2600_ProtocolWithOperator1 {
-  static postfix func <*>(_: Int)
+  static postfix func <*>(_: Self)
 }
 // PASS_2500: {{^}}protocol d2600_ProtocolWithOperator1 {{{$}}
-// PASS_2500-NEXT: {{^}}  postfix static func <*>(_: Int){{$}}
+// PASS_2500-NEXT: {{^}}  postfix static func <*>(_: Self){{$}}
 // PASS_2500-NEXT: {{^}}}{{$}}
 
 struct d2601_TestAssignment {}

--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -214,29 +214,125 @@ extension S0 {
 }
 
 struct S1 {
-  func %%%(lhs: S0, rhs: S0) -> S0 { return lhs } // expected-error{{operator '%%%' declared in type 'S1' must be 'static'}}{{3-3=static }}
+  func %%%(lhs: S1, rhs: S1) -> S1 { return lhs } // expected-error{{operator '%%%' declared in type 'S1' must be 'static'}}{{3-3=static }}
 }
 
 extension S1 {
-  func %%%%(lhs: S0, rhs: S0) -> S0 { return lhs } // expected-error{{operator '%%%%' declared in type 'S1' must be 'static'}}{{3-3=static }}
+  func %%%%(lhs: S1, rhs: S1) -> S1 { return lhs } // expected-error{{operator '%%%%' declared in type 'S1' must be 'static'}}{{3-3=static }}
 }
 
 class C0 {
-  static func %%%(lhs: S0, rhs: S0) -> S0 { return lhs }
+  static func %%%(lhs: C0, rhs: C0) -> C0 { return lhs }
 }
 
 class C1 {
-  final func %%%(lhs: S0, rhs: S0) -> S0 { return lhs }
+  final func %%%(lhs: C1, rhs: C1) -> C1 { return lhs }
 }
 
 final class C2 {
-  class func %%%(lhs: S0, rhs: S0) -> S0 { return lhs }
+  class func %%%(lhs: C2, rhs: C2) -> C2 { return lhs }
 }
 
 class C3 {
-  class func %%%(lhs: S0, rhs: S0) -> S0 { return lhs } // expected-error{{operator '%%%' declared in non-final class 'C3' must be 'final'}}{{3-3=final }}
+  class func %%%(lhs: C3, rhs: C3) -> C3 { return lhs } // expected-error{{operator '%%%' declared in non-final class 'C3' must be 'final'}}{{3-3=final }}
 }
 
 class C4 {
-  func %%%(lhs: S0, rhs: S0) -> S0 { return lhs } // expected-error{{operator '%%%' declared in type 'C4' must be 'static'}}{{3-3=static }}
+  func %%%(lhs: C4, rhs: C4) -> C4 { return lhs } // expected-error{{operator '%%%' declared in type 'C4' must be 'static'}}{{3-3=static }}
+}
+
+struct Unrelated { }
+
+struct S2 {
+  static func %%%(lhs: Unrelated, rhs: Unrelated) -> Unrelated { }
+  // expected-error@-1{{member operator '%%%' must have at least one argument of type 'S2'}}
+
+  static func %%%(lhs: Unrelated, rhs: Unrelated) -> S2 { }
+  // expected-error@-1{{member operator '%%%' must have at least one argument of type 'S2'}}
+
+  static func %%%(lhs: Unrelated, rhs: Unrelated) -> S2.Type { }
+  // expected-error@-1{{member operator '%%%' must have at least one argument of type 'S2'}}
+
+  // Okay: refers to S2
+  static func %%%(lhs: S2, rhs: Unrelated) -> Unrelated { }
+  static func %%%(lhs: inout S2, rhs: Unrelated) -> Unrelated { }
+  static func %%%(lhs: S2.Type, rhs: Unrelated) -> Unrelated { }
+  static func %%%(lhs: inout S2.Type, rhs: Unrelated) -> Unrelated { }
+  static func %%%(lhs: Unrelated, rhs: S2) -> Unrelated { }
+  static func %%%(lhs: Unrelated, rhs: inout S2) -> Unrelated { }
+  static func %%%(lhs: Unrelated, rhs: S2.Type) -> Unrelated { }
+  static func %%%(lhs: Unrelated, rhs: inout S2.Type) -> Unrelated { }
+}
+
+extension S2 {
+  static func %%%%(lhs: Unrelated, rhs: Unrelated) -> Unrelated { }
+  // expected-error@-1{{member operator '%%%%' must have at least one argument of type 'S2'}}
+
+  static func %%%%(lhs: Unrelated, rhs: Unrelated) -> S2 { }
+  // expected-error@-1{{member operator '%%%%' must have at least one argument of type 'S2'}}
+
+  static func %%%%(lhs: Unrelated, rhs: Unrelated) -> S2.Type { }
+  // expected-error@-1{{member operator '%%%%' must have at least one argument of type 'S2'}}
+
+  // Okay: refers to S2
+  static func %%%%(lhs: S2, rhs: Unrelated) -> Unrelated { }
+  static func %%%%(lhs: inout S2, rhs: Unrelated) -> Unrelated { }
+  static func %%%%(lhs: S2.Type, rhs: Unrelated) -> Unrelated { }
+  static func %%%%(lhs: inout S2.Type, rhs: Unrelated) -> Unrelated { }
+  static func %%%%(lhs: Unrelated, rhs: S2) -> Unrelated { }
+  static func %%%%(lhs: Unrelated, rhs: inout S2) -> Unrelated { }
+  static func %%%%(lhs: Unrelated, rhs: S2.Type) -> Unrelated { }
+  static func %%%%(lhs: Unrelated, rhs: inout S2.Type) -> Unrelated { }
+}
+
+protocol P2 {
+  static func %%%(lhs: Unrelated, rhs: Unrelated) -> Unrelated
+  // expected-error@-1{{member operator '%%%' of protocol 'P2' must have at least one argument of type 'Self'}}
+
+  static func %%%(lhs: Unrelated, rhs: Unrelated) -> Self
+  // expected-error@-1{{member operator '%%%' of protocol 'P2' must have at least one argument of type 'Self'}}
+
+  static func %%%(lhs: Unrelated, rhs: Unrelated) -> Self.Type
+  // expected-error@-1{{member operator '%%%' of protocol 'P2' must have at least one argument of type 'Self'}}
+
+  // Okay: refers to Self
+  static func %%%(lhs: Self, rhs: Unrelated) -> Unrelated
+  static func %%%(lhs: inout Self, rhs: Unrelated) -> Unrelated
+  static func %%%(lhs: Self.Type, rhs: Unrelated) -> Unrelated
+  static func %%%(lhs: inout Self.Type, rhs: Unrelated) -> Unrelated
+  static func %%%(lhs: Unrelated, rhs: Self) -> Unrelated
+  static func %%%(lhs: Unrelated, rhs: inout Self) -> Unrelated
+  static func %%%(lhs: Unrelated, rhs: Self.Type) -> Unrelated
+  static func %%%(lhs: Unrelated, rhs: inout Self.Type) -> Unrelated
+}
+
+extension P2 {
+  static func %%%%(lhs: Unrelated, rhs: Unrelated) -> Unrelated { }
+  // expected-error@-1{{member operator '%%%%' of protocol 'P2' must have at least one argument of type 'Self'}}
+
+  static func %%%%(lhs: Unrelated, rhs: Unrelated) -> Self { }
+  // expected-error@-1{{member operator '%%%%' of protocol 'P2' must have at least one argument of type 'Self'}}
+
+  static func %%%%(lhs: Unrelated, rhs: Unrelated) -> Self.Type { }
+  // expected-error@-1{{member operator '%%%%' of protocol 'P2' must have at least one argument of type 'Self'}}
+
+  // Okay: refers to Self
+  static func %%%%(lhs: Self, rhs: Unrelated) -> Unrelated { }
+  static func %%%%(lhs: inout Self, rhs: Unrelated) -> Unrelated { }
+  static func %%%%(lhs: Self.Type, rhs: Unrelated) -> Unrelated { }
+  static func %%%%(lhs: inout Self.Type, rhs: Unrelated) -> Unrelated { }
+  static func %%%%(lhs: Unrelated, rhs: Self) -> Unrelated { }
+  static func %%%%(lhs: Unrelated, rhs: inout Self) -> Unrelated { }
+  static func %%%%(lhs: Unrelated, rhs: Self.Type) -> Unrelated { }
+  static func %%%%(lhs: Unrelated, rhs: inout Self.Type) -> Unrelated { }
+}
+
+protocol P3 {
+  // Okay: refers to P3
+  static func %%%(lhs: P3, rhs: Unrelated) -> Unrelated
+}
+
+extension P3 {
+  // Okay: refers to P3
+  static func %%%%(lhs: P3, rhs: Unrelated) -> Unrelated { }
 }


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Member operators should be placed within a nominal type (or extension
thereof) that they operate on. Aside from being good style, enforcing
this in the type checker can help with dependency tracking.
#### Resolved bug number: ([rdar://problem/27536066](rdar://problem/27536066))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…
