### PR TITLE
[swiftc (45 vs. 5156)] Add crasher in swift::DependentGenericTypeResolver::resolveSelfAssociatedType(...)

### DIFF
--- a/validation-test/compiler_crashers/28392-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
+++ b/validation-test/compiler_crashers/28392-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
@@ -1,0 +1,21 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+{
+class A{
+let f=a{
+}
+protocol c{typealias e:A
+protocol A{
+struct A{
+let f={
+struct h{
+func a
+func a:e
+a


### PR DESCRIPTION
Add test case for crash triggered in `swift::DependentGenericTypeResolver::resolveSelfAssociatedType(...)`.

Current number of unresolved compiler crashers: 45 (5156 resolved)

Assertion failure in [`lib/Sema/TypeCheckGeneric.cpp (line 47)`](https://github.com/apple/swift/blob/master/lib/Sema/TypeCheckGeneric.cpp#L47):

```
Assertion `archetype && "Bad generic context nesting?"' failed.

When executing: virtual swift::Type swift::DependentGenericTypeResolver::resolveSelfAssociatedType(swift::Type, swift::DeclContext *, swift::AssociatedTypeDecl *)
```

Assertion context:

```
Type DependentGenericTypeResolver::resolveSelfAssociatedType(
       Type selfTy,
       DeclContext *DC,
       AssociatedTypeDecl *assocType) {
  auto archetype = Builder.resolveArchetype(selfTy);
  assert(archetype && "Bad generic context nesting?");

  return archetype->getRepresentative()
           ->getNestedType(assocType->getName(), Builder)
           ->getDependentType(Builder, true);
}
```

Stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckGeneric.cpp:47: virtual swift::Type swift::DependentGenericTypeResolver::resolveSelfAssociatedType(swift::Type, swift::DeclContext *, swift::AssociatedTypeDecl *): Assertion `archetype && "Bad generic context nesting?"' failed.
8  swift           0x0000000000f102ad swift::DependentGenericTypeResolver::resolveSelfAssociatedType(swift::Type, swift::DeclContext*, swift::AssociatedTypeDecl*) + 125
9  swift           0x0000000000f457c4 swift::TypeChecker::resolveTypeInContext(swift::TypeDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 1956
13 swift           0x0000000000f46a7e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
15 swift           0x0000000000f479c4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
16 swift           0x0000000000f46970 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
18 swift           0x0000000000f1105e swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 94
21 swift           0x0000000000ed12b1 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 945
25 swift           0x0000000000ed7466 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
28 swift           0x0000000000f409a4 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
29 swift           0x0000000000f6d57c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
30 swift           0x0000000000ec44da swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 778
31 swift           0x0000000000ec55f0 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 352
32 swift           0x0000000000ec580b swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
43 swift           0x0000000000ed7466 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
46 swift           0x0000000000f409a4 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
47 swift           0x0000000000f6d57c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
48 swift           0x0000000000ec44da swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 778
50 swift           0x0000000000f40ae6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
51 swift           0x0000000000efb40d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
52 swift           0x0000000000c7b5b9 swift::CompilerInstance::performSema() + 3289
54 swift           0x00000000007db487 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
55 swift           0x00000000007a72b8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28392-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28392-swift-dependentgenerictyperesolver-resolveselfassociatedtype-0402cf.o
1.  While type-checking expression at [validation-test/compiler_crashers/28392-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift:10:1 - line:21:1] RangeText="{
2.  While type-checking 'A' at validation-test/compiler_crashers/28392-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift:11:1
3.  While type-checking expression at [validation-test/compiler_crashers/28392-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift:17:7 - line:21:1] RangeText="{
4.  While type-checking 'h' at validation-test/compiler_crashers/28392-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift:18:1
5.  While type-checking 'a' at validation-test/compiler_crashers/28392-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift:20:1
6.  While resolving type e at [validation-test/compiler_crashers/28392-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift:20:8 - line:20:8] RangeText="e"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
