### PR TITLE
stdlib: Add unavailable Zip2Sequence initializer

### DIFF
--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -139,3 +139,10 @@ public struct Zip2Sequence<Sequence1 : Sequence, Sequence2 : Sequence>
   internal let _sequence1: Sequence1
   internal let _sequence2: Sequence2
 }
+
+extension Zip2Sequence {
+  @available(*, unavailable, message: "use zip(_:_:) free function instead")
+  public init(_ sequence1: Sequence1, _ sequence2: Sequence2) {
+    Builtin.unreachable()
+  }
+}

--- a/test/1_stdlib/Renames.swift
+++ b/test/1_stdlib/Renames.swift
@@ -543,6 +543,7 @@ func _VarArgs() {
   func fn2(_: VaListBuilder) {} // expected-error {{'VaListBuilder' is unavailable}} {{none}}
 }
 
-func _Zip<S1 : Sequence, S2: Sequence>(_: S1, _: S2) {
+func _Zip<S1 : Sequence, S2: Sequence>(s1: S1, s2: S2) {
+  _ = Zip2Sequence(s1, s2) // expected-error {{use zip(_:_:) free function instead}} {{none}}
   _ = Zip2Sequence<S1, S2>.Generator.self // expected-error {{'Generator' has been renamed to 'Iterator'}} {{28-37=Iterator}} {{none}}
 }


### PR DESCRIPTION
#### What's in this pull request?

Without this, the compiler suggests to add `_sequence1:_sequnece2:` labels.

Before:

```
testzip2.swift:2:19: error: missing argument labels '_sequence1:_sequence2:' in call
  _ = Zip2Sequence(s1, s2)
                  ^
                   _sequence1:  _sequence2: 
```

After:

```
testzip2.swift:2:7: error: 'init' is unavailable: use zip(_:_:) free function instead
  _ = Zip2Sequence(s1, s2)
      ^~~~~~~~~~~~
Swift.Zip2Sequence<Sequence1, Sequence2>:3:12: note: 'init' has been explicitly marked unavailable here
    public init(_ sequence1: Sequence1, _ sequence2: Sequence2)
           ^
```

**Note:**
Currently, we cannot add fix-it for this, because our compiler doesn't support initializer to free-function fix-it.
i.e.`renamed: "zip(_:_:)"` doesn't work for `Zip2Sequence.init(s1, s2)`

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
