### PR TITLE
[PrintAsObjC] Handle circularities introduced by ObjC generics.

### DIFF
--- a/test/PrintAsObjC/Inputs/circularity.h
+++ b/test/PrintAsObjC/Inputs/circularity.h
@@ -1,0 +1,22 @@
+// This file is meant to be used with the mock SDK, not the real one.
+#import <Foundation.h>
+
+#define SWIFT_NAME(x) __attribute__((swift_name(#x)))
+
+@protocol Proto
+@end
+
+@interface ProtoImpl : NSObject <Proto>
+@end
+
+@interface Parent : NSObject
+@end
+
+@interface Unconstrained<T> : NSObject
+@end
+
+@interface NeedsProto<T: id <Proto>> : NSObject
+@end
+
+@interface NeedsParent<T: Parent *> : NSObject
+@end

--- a/test/PrintAsObjC/circularity-errors.swift
+++ b/test/PrintAsObjC/circularity-errors.swift
@@ -1,0 +1,73 @@
+// Please keep this file in alphabetical order!
+
+// REQUIRES: objc_interop
+
+// RUN: rm -rf %t && mkdir %t
+
+// FIXME: BEGIN -enable-source-import hackaround
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+// FIXME: END -enable-source-import hackaround
+
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/circularity.h -emit-module -o %t %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/circularity.h -parse-as-library %t/circularity-errors.swiftmodule -parse -emit-objc-header-path %t/circularity-errors.h
+
+// RUN: FileCheck %s < %t/circularity-errors.h
+// RUN: not %check-in-clang %t/circularity-errors.h
+
+import Foundation
+
+// CHECK: @protocol A2;
+// CHECK-LABEL: @protocol A1 <Proto>
+@objc protocol A1: Proto {
+  // CHECK: - (void)test:
+  func test(_: NeedsProto<A2>)
+} // CHECK: @end
+// CHECK-LABEL: @protocol A2 <Proto>
+@objc protocol A2: Proto {
+  // CHECK: - (void)test:
+  func test(_: NeedsProto<A1>)
+} // CHECK: @end
+
+// CHECK: @class B2;
+// CHECK-LABEL: @protocol B1 <Proto>
+@objc protocol B1: Proto {
+  // CHECK: - (void)test:
+  @objc optional func test(_: NeedsProto<B2>)
+} // CHECK: @end
+// CHECK-LABEL: @interface B2 : ProtoImpl <B1>
+class B2: ProtoImpl, B1 {
+} // CHECK: @end
+
+// CHECK: @class C1;
+// Moved below.
+class C1: ProtoImpl, C2 {}
+// CHECK-LABEL: @protocol C2 <Proto>
+@objc protocol C2: Proto {
+  // CHECK: - (void)test:
+  @objc optional func test(_: NeedsProto<C1>)
+} // CHECK: @end
+// CHECK-LABEL: @interface C1 : ProtoImpl <C2>
+// CHECK: @end
+
+// CHECK: @protocol D2;
+// CHECK-LABEL: @protocol D1 <Proto>
+@objc protocol D1: Proto {
+  // CHECK: - (void)test:
+  func test(_: NeedsProto<D2>)
+} // CHECK: @end
+// CHECK-LABEL: @protocol D2 <D1>
+@objc protocol D2: D1 {
+} // CHECK: @end
+
+// CHECK: @protocol E1;
+// Moved below.
+@objc protocol E1: E2 {}
+// CHECK-LABEL: @protocol E2 <Proto>
+@objc protocol E2: Proto {
+  // CHECK: - (void)test:
+  func test(_: NeedsProto<E1>)
+} // CHECK: @end
+// CHECK-LABEL: @protocol E1 <E2>
+// CHECK: @end

--- a/test/PrintAsObjC/circularity.swift
+++ b/test/PrintAsObjC/circularity.swift
@@ -1,0 +1,283 @@
+// Please keep this file in alphabetical order!
+
+// REQUIRES: objc_interop
+
+// RUN: rm -rf %t && mkdir %t
+
+// FIXME: BEGIN -enable-source-import hackaround
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+// FIXME: END -enable-source-import hackaround
+
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/circularity.h -emit-module -o %t %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/circularity.h -parse-as-library %t/circularity.swiftmodule -parse -emit-objc-header-path %t/circularity.h
+
+// RUN: FileCheck %s < %t/circularity.h
+
+// RUN: %check-in-clang %t/circularity.h
+// RUN: %check-in-clang -fno-modules -Qunused-arguments %t/circularity.h
+
+import Foundation
+
+// CHECK-LABEL: @interface A1 : ProtoImpl
+class A1: ProtoImpl {
+  // CHECK: // 'test(_:)' below
+  func test(_: NeedsProto<A2>) {}
+} // CHECK: @end
+// CHECK-LABEL: @interface A2 : ProtoImpl
+class A2: ProtoImpl {
+  // CHECK: - (void)test:
+  func test(_: NeedsProto<A1>) {}
+} // CHECK: @end
+
+// CHECK-LABEL: @interface B1 : ProtoImpl
+class B1: ProtoImpl {
+  // CHECK: // 'test(_:)' below
+  func test(_: NeedsProto<B2>) {}
+} // CHECK: @end
+// CHECK-LABEL: @interface B2 : ProtoImpl
+class B2: ProtoImpl {
+} // CHECK: @end
+
+// CHECK-LABEL: @interface C1 : ProtoImpl
+class C1: ProtoImpl {
+  // CHECK: // 'test(_:)' below
+  func test(_: NeedsProto<C2>) {}
+} // CHECK: @end
+// CHECK-LABEL: @protocol C2 <Proto>
+@objc protocol C2: Proto {
+} // CHECK: @end
+
+// CHECK-LABEL: @interface D1 : ProtoImpl
+class D1: ProtoImpl {
+  // CHECK: // 'test(_:)' below
+  func test(_: NeedsProto<D2>) {}
+} // CHECK: @end
+// CHECK-LABEL: @protocol D2 <Proto>
+@objc protocol D2: Proto {
+  // CHECK: - (void)test:
+  func test(_: NeedsProto<D1>)
+} // CHECK: @end
+
+// CHECK-LABEL: @interface D4 : ProtoImpl
+// CHECK: // 'test(_:)' below
+// CHECK: @end
+// CHECK-LABEL: @protocol D3 <Proto>
+@objc protocol D3: Proto {
+  // CHECK: - (void)test:
+  func test(_: NeedsProto<D4>)
+} // CHECK: @end
+// Moved ahead.
+class D4: ProtoImpl {
+  func test(_: NeedsProto<D3>) {}
+}
+
+// CHECK-LABEL: @interface E2 : ProtoImpl
+// CHECK: @end
+// CHECK-LABEL: @protocol E1 <Proto>
+@objc protocol E1: Proto {
+  // CHECK: - (void)test:
+  func test(_: NeedsProto<E2>)
+} // CHECK: @end
+// Moved ahead.
+class E2: ProtoImpl {}
+
+// CHECK-LABEL: @interface F1 : ProtoImpl
+class F1: ProtoImpl {
+} // CHECK: @end
+// CHECK-LABEL @interface F2 : ProtoImpl
+// CHECK: @end
+// CHECK-LABEL @interface F1 (SWIFT_EXTENSION(circularity))
+extension F1 {
+  // CHECK: - (void)test:
+  func test(_: NeedsProto<F2>) {}
+} // CHECK: @end
+// Moved ahead.
+class F2: ProtoImpl {}
+
+// CHECK-LABEL: @interface G1 : ProtoImpl
+class G1: ProtoImpl {
+} // CHECK: @end
+// CHECK-LABEL @protocol G2 <Proto>
+// CHECK: @end
+// CHECK-LABEL @interface G1 (SWIFT_EXTENSION(circularity))
+extension G1 {
+  // CHECK: - (void)test:
+  func test(_: NeedsProto<G2>) {}
+} // CHECK: @end
+// Moved ahead.
+@objc protocol G2: Proto {}
+
+// CHECK-LABEL: @interface H1 : ProtoImpl
+class H1: ProtoImpl {
+  // CHECK: 'test(_:)' below
+  func test(_: NeedsProto<H2>) {}
+  // CHECK: 'anotherTest(_:)' below
+  func anotherTest(_: NeedsProto<H3>) {}
+} // CHECK: @end
+// CHECK-LABEL: @interface H2 : ProtoImpl
+class H2: ProtoImpl {
+  // CHECK: // 'test(_:)' below
+  func test(_: NeedsProto<H3>) {}
+  // CHECK: - (void)anotherTest:
+  func anotherTest(_: NeedsProto<H1>) {}
+} // CHECK: @end
+// CHECK-LABEL: @interface H3 : ProtoImpl
+class H3: ProtoImpl {
+  // CHECK: - (void)test:
+  func test(_: NeedsProto<H1>) {}
+  // CHECK: - (void)anotherTest:
+  func anotherTest(_: NeedsProto<H2>) {}
+} // CHECK: @end
+
+// CHECK-LABEL: @interface I1 : Parent
+class I1 : Parent {
+  // CHECK: // 'test(_:)' below
+  func test(_: NeedsParent<I2>) {}
+} // CHECK: @end
+// CHECK-LABEL: @interface I2 : Parent
+class I2 : Parent {
+  // CHECK: - (void)test:
+  func test(_: NeedsParent<I1>) {}
+} // CHECK: @end
+
+// CHECK-LABEL: @interface J1 : Parent
+class J1 : Parent {
+  // CHECK: - (void)test:
+  func test(_: Unconstrained<J2>) {}
+} // CHECK: @end
+// CHECK-LABEL: @interface J2 : Parent
+class J2 : Parent {
+  // CHECK: - (void)test:
+  func test(_: Unconstrained<J1>) {}
+} // CHECK: @end
+
+// CHECK-LABEL: @protocol K1 <Proto>
+@objc protocol K1 : Proto {
+  // CHECK: - (void)test:
+  func test(_: Unconstrained<K2>)
+} // CHECK: @end
+// CHECK-LABEL: @protocol K2 <Proto>
+@objc protocol K2 : Proto {
+  // CHECK: - (void)test:
+  func test(_: Unconstrained<K1>)
+} // CHECK: @end
+
+
+// CHECK-LABEL: @interface NA2 : ProtoImpl
+// CHECK: @end
+// CHECK-LABEL: @protocol NA1
+// CHECK: - (void)test:
+// CHECK: @end
+// CHECK-LABEL: @interface NA3 : NSObject <NA1>
+// CHECK: @end
+@objc protocol NA1 {
+  @objc optional func test(_: NeedsProto<NA2>)
+}
+class NA2: ProtoImpl {}
+class NA3: NSObject, NA1 {}
+
+// CHECK-LABEL: @interface NB1 : ProtoImpl
+// CHECK: @end
+// CHECK-LABEL: @protocol NB2
+// CHECK: - (void)test:
+// CHECK: @end
+// CHECK-LABEL: @interface NB3 : NSObject <NB2>
+// CHECK: @end
+class NB1: ProtoImpl {}
+@objc protocol NB2 {
+  @objc optional func test(_: NeedsProto<NB1>)
+}
+class NB3: NSObject, NB2 {}
+
+// CHECK-LABEL: @interface NC2 : ProtoImpl
+// CHECK: @end
+// CHECK-LABEL: @protocol NC3
+// CHECK: - (void)test:
+// CHECK: @end
+// CHECK-LABEL: @interface NC1 : NSObject <NC3>
+// CHECK: @end
+class NC1: NSObject, NC3 {}
+class NC2: ProtoImpl {}
+@objc protocol NC3 {
+  @objc optional func test(_: NeedsProto<NC2>)
+}
+
+// CHECK-LABEL: @interface ND3 : ProtoImpl
+// CHECK: @end
+// CHECK-LABEL: @protocol ND2
+// CHECK: - (void)test:
+// CHECK: @end
+// CHECK-LABEL: @interface ND1 : NSObject <ND2>
+// CHECK: @end
+class ND1: NSObject, ND2 {}
+@objc protocol ND2 {
+  @objc optional func test(_: NeedsProto<ND3>)
+}
+class ND3: ProtoImpl {}
+
+// CHECK-LABEL: @interface NE3 : ProtoImpl
+// CHECK: @end
+// CHECK-LABEL: @protocol NE1
+// CHECK: - (void)test:
+// CHECK: @end
+// CHECK-LABEL: @interface NE2 : NSObject <NE1>
+// CHECK: @end
+@objc protocol NE1 {
+  @objc optional func test(_: NeedsProto<NE3>)
+}
+class NE2: NSObject, NE1 {}
+class NE3: ProtoImpl {}
+
+// CHECK-LABEL: @interface NF2 : ProtoImpl
+// CHECK: @end
+// CHECK-LABEL: @protocol NF1
+// CHECK: - (void)test:
+// CHECK: @end
+// CHECK-LABEL: @interface NF3 : NSObject <NF1>
+// CHECK: @end
+@objc protocol NF1 {
+  @objc optional func test(_: NeedsProto<NF2>)
+}
+class NF2: ProtoImpl {}
+class NF3: NSObject, NF1 {}
+
+// CHECK-LABEL: @interface ZZZ_EOF : NSObject
+class ZZZ_EOF : NSObject {
+} // CHECK: @end
+
+// CHECK-LABEL: @interface A1 (SWIFT_EXTENSION(circularity))
+// CHECK: - (void)test:
+// CHECK: @end
+
+// CHECK-LABEL: @interface B1 (SWIFT_EXTENSION(circularity))
+// CHECK: - (void)test:
+// CHECK: @end
+
+// CHECK-LABEL: @interface C1 (SWIFT_EXTENSION(circularity))
+// CHECK: - (void)test:
+// CHECK: @end
+
+// CHECK-LABEL: @interface D1 (SWIFT_EXTENSION(circularity))
+// CHECK: - (void)test:
+// CHECK: @end
+
+// CHECK-LABEL: @interface D4 (SWIFT_EXTENSION(circularity))
+// CHECK: - (void)test:
+// CHECK: @end
+
+// CHECK-LABEL: @interface H1 (SWIFT_EXTENSION(circularity))
+// CHECK: - (void)test:
+// CHECK-NOT: @end
+// CHECK: - (void)anotherTest:
+// CHECK: @end
+
+// CHECK-LABEL: @interface H2 (SWIFT_EXTENSION(circularity))
+// CHECK: - (void)test:
+// CHECK: @end
+
+// CHECK-LABEL: @interface I1 (SWIFT_EXTENSION(circularity))
+// CHECK: - (void)test:
+// CHECK: @end
+


### PR DESCRIPTION
Like Swift generics, Objective-C generics may have constraints; unlike Swift generics, Objective-C doesn't do separate parsing and type-checking passes. This means that any generic arguments for constrained generic parameters must be fully-defined, in order to check that they satisfy the constraints.

This commit addresses this problem with three different mechanisms, one for each kind of declaration that might run into this issue:
- For classes, if a member references a type with constrained generic parameter, and the corresponding argument type hasn't been printed yet, that member is "delayed", which means it is put into a category at the end of the file.
- Protocols cannot have categories, so for protocols we instead see if we can print the definition of the other type first. To break circular dependencies, the printer will not attempt this if both the type and the protocol are already being depended on. This isn't perfect (see below).
- Rather than delaying members of extensions, we just delay them wholesale. This keeps related members together, but also has problems (see below).

These approaches solve the most common cases while still not crashing in the uncommon ones. However, there are still a number of problems:
- The protocol heuristic is overly negative, which means we may generate an invalid header even when there's a reasonable ordering. For example, a single class might inherit from a class A and conform to protocol P, and protocol P depends on class A as a generic argument. In this case, defining class A first is the right thing to do, but it's possible for the printer to decide that there's circularity here and just forward-declare A instead.
- Protocols really can be circular. This can be fixed by printing a forward-declared protocol alongside the generic constraints, i.e. `id <MoreThanNSCopying, NSCopying>` instead of just `id <MoreThanNSCopying>`.
- Extensions can introduce protocols as well. This is not modeled at all; if a member depends on a protocol conformance, it's assumed that simply printing the class would be sufficient. This could be fixed by checking how a generic argument satisfies its constraints, possibly delaying individual members from extensions in order to print them sooner.
- More cases I haven't thought about.

Test cases for some of these problems are in the new circularity-errors.swift file, mostly to make sure the ObjC printer doesn't crash when it encounters them. I intend to file bugs for these issues.

rdar://problem/27109377

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
