### PR TITLE
[syntax-map] Fix array-of-object-literal syntax map, argument label keywords

### DIFF
--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -94,9 +94,23 @@ SyntaxModelContext::SyntaxModelContext(SourceFile &SrcFile)
       }
 
       switch(Tok.getKind()) {
-#define KEYWORD(X) case tok::kw_##X: Kind = SyntaxNodeKind::Keyword; break;
+#define KEYWORD(X) case tok::kw_##X:
 #include "swift/Parse/Tokens.def"
 #undef KEYWORD
+        if (Tok.getKind() != tok::kw__ &&
+            0 < I && I < Tokens.size() - 1 &&
+            (Tokens[I-1].getKind() == tok::l_paren ||
+             Tokens[I-1].getKind() == tok::comma) &&
+            (Tokens[I+1].getKind() == tok::colon ||
+             Tokens[I+1].getKind() == tok::identifier ||
+             Tokens[I+1].isKeyword())) {
+          // Keywords are allowed as argument labels and should be treated as
+          // identifiers.  The exception is '_' which is not a name.
+          Kind = SyntaxNodeKind::Identifier;
+        } else {
+          Kind = SyntaxNodeKind::Keyword;
+        }
+        break;
 
 #define POUND_OLD_OBJECT_LITERAL(Name, NewName, OldArg, NewArg) \
       case tok::pound_##Name:
@@ -453,9 +467,6 @@ std::pair<bool, Expr *> ModelASTWalker::walkToExprPre(Expr *E) {
                                                                   E->getEndLoc()));
         passTokenNodesUntil(NR.getStart(),
                             PassNodesBehavior::ExcludeNodeAtLocation);
-        if (!TokenNodes.empty())
-          const_cast<SyntaxNode&>(TokenNodes.front()).Kind = SyntaxNodeKind::
-            Identifier;
       }
       else
         SN.Range = SN.BodyRange;
@@ -524,13 +535,8 @@ std::pair<bool, Expr *> ModelASTWalker::walkToExprPre(Expr *E) {
   } else if (auto *Tup = dyn_cast<TupleExpr>(E)) {
     for (unsigned I = 0; I < Tup->getNumElements(); ++ I) {
       SourceLoc NameLoc = Tup->getElementNameLoc(I);
-      if (NameLoc.isValid()) {
+      if (NameLoc.isValid())
         passTokenNodesUntil(NameLoc, PassNodesBehavior::ExcludeNodeAtLocation);
-        if (!TokenNodes.empty()) {
-          const_cast<SyntaxNode&>(TokenNodes.front()).Kind = SyntaxNodeKind::
-            Identifier;
-        }
-      }
     }
   }
 
@@ -860,8 +866,6 @@ bool ModelASTWalker::walkToDeclPre(Decl *D) {
       SourceLoc ArgStart = PD->getSourceRange().Start;
       SN.NameRange = CharSourceRange(ArgStart, PD->getArgumentName().getLength());
       passTokenNodesUntil(ArgStart, PassNodesBehavior::ExcludeNodeAtLocation);
-      const_cast<SyntaxNode&>(TokenNodes.front()).Kind = SyntaxNodeKind::
-        Identifier;
     }
     SN.Range = charSourceRangeFromSourceRange(SM, PD->getSourceRange());
     SN.Attrs = PD->getAttrs();

--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -278,6 +278,10 @@ func test4(inout a: Int) {
   // CHECK: <kw>if</kw> <kw>#available</kw> (<kw>OSX</kw> >= <float>10.10</float>, <kw>iOS</kw> >= <float>8.01</float>) {<kw>let</kw> OSX = <str>"iOS"</str>}}{{$}}
   if #available (OSX >= 10.10, iOS >= 8.01) {let OSX = "iOS"}}
 
+// CHECK: <kw>func</kw> test4b(a: <kw>inout</kw> <type>Int</type>) {{{$}}
+func test4b(a: inout Int) {
+}
+
 // CHECK: <kw>class</kw> MySubClass : <type>MyCls</type> {
 class MySubClass : MyCls {
     // CHECK: <attr-builtin>override</attr-builtin> <kw>func</kw> foo(x: <type>Int</type>) {}

--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -273,7 +273,7 @@ func test3(o: AnyObject) {
   let x = o as! MyCls
 }
 
-// CHECK: <kw>func</kw> test4(<kw>inout</kw> a: <type>Int</type>) {{{$}}
+// CHECK: <kw>func</kw> test4(inout a: <type>Int</type>) {{{$}}
 func test4(inout a: Int) {
   // CHECK: <kw>if</kw> <kw>#available</kw> (<kw>OSX</kw> >= <float>10.10</float>, <kw>iOS</kw> >= <float>8.01</float>) {<kw>let</kw> OSX = <str>"iOS"</str>}}{{$}}
   if #available (OSX >= 10.10, iOS >= 8.01) {let OSX = "iOS"}}
@@ -501,6 +501,13 @@ let file = #fileLiteral(resourceName: "cloud.png")
 let black = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)
 // CHECK: <kw>let</kw> black = <object-literal>#colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)</object-literal>
 
+let rgb = [#colorLiteral(red: 1, green: 0, blue: 0, alpha: 1),
+           #colorLiteral(red: 0, green: 1, blue: 0, alpha: 1),
+           #colorLiteral(red: 0, green: 0, blue: 1, alpha: 1)]
+// CHECK: <kw>let</kw> rgb = [<object-literal>#colorLiteral(red: 1, green: 0, blue: 0, alpha: 1)</object-literal>,
+// CHECK:                     <object-literal>#colorLiteral(red: 0, green: 1, blue: 0, alpha: 1)</object-literal>,
+// CHECK:                     <object-literal>#colorLiteral(red: 0, green: 0, blue: 1, alpha: 1)</object-literal>]
+
 "--\"\(x) --"
 // CHECK: <str>"--\"</str>\<anchor>(</anchor>x<anchor>)</anchor><str> --"</str>
 
@@ -508,6 +515,14 @@ func keywordAsLabel1(in: Int) {}
 // CHECK: <kw>func</kw> keywordAsLabel1(in: <type>Int</type>) {}
 func keywordAsLabel2(for: Int) {}
 // CHECK: <kw>func</kw> keywordAsLabel2(for: <type>Int</type>) {}
+func keywordAsLabel3(if: Int, for: Int) {}
+// CHECK: <kw>func</kw> keywordAsLabel3(if: <type>Int</type>, for: <type>Int</type>) {}
+func keywordAsLabel4(_: Int) {}
+// CHECK: <kw>func</kw> keywordAsLabel4(<kw>_</kw>: <type>Int</type>) {}
+func keywordAsLabel5(_: Int, for: Int) {}
+// CHECK: <kw>func</kw> keywordAsLabel5(<kw>_</kw>: <type>Int</type>, for: <type>Int</type>) {}
+func keywordAsLabel6(if let: Int) {}
+// CHECK: <kw>func</kw> keywordAsLabel6(if <kw>let</kw>: <type>Int</type>) {}
 
 func foo1() {
 // CHECK: <kw>func</kw> foo1() {
@@ -515,6 +530,15 @@ func foo1() {
 // CHECK: keywordAsLabel1(in: <int>1</int>)
   keywordAsLabel2(for: 1)
 // CHECK: keywordAsLabel2(for: <int>1</int>)
+  keywordAsLabel3(if: 1, for: 2)
+// CHECK: keywordAsLabel3(if: <int>1</int>, for: <int>2</int>)
+  keywordAsLabel5(1, for: 2)
+// CHECK: keywordAsLabel5(<int>1</int>, for: <int>2</int>)
+
+  _ = (if: 0, for: 2)
+// CHECK: <kw>_</kw> = (if: <int>0</int>, for: <int>2</int>)
+  _ = (_: 0, _: 2)
+// CHECK: <kw>_</kw> = (<kw>_</kw>: <int>0</int>, <kw>_</kw>: <int>2</int>)
 }
 
 // Keep this as the last test

--- a/test/SourceKit/SyntaxMapData/syntaxmap-object-literals.swift.response
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-object-literals.swift.response
@@ -29,7 +29,7 @@
       key.length: 40
     },
     {
-      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.kind: source.lang.swift.syntaxtype.keyword,
       key.offset: 165,
       key.length: 3
     },
@@ -44,7 +44,7 @@
       key.length: 50
     },
     {
-      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.kind: source.lang.swift.syntaxtype.keyword,
       key.offset: 228,
       key.length: 3
     },


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
- Explanation: The syntax-map incorrectly classifies the second and later object literals inside an array expression as "identifier" instead of "object-literal".  There are also several ways to get keywords or other syntax entities misclassified as identifiers in other corner cases.  These are all caused by some logic that is attempting to handle keywords used as argument labels running amok.
- Scope: This is a regression in preview 3.  It affects editors that rely on the syntax map for syntax highlighting, and generally results in mis-coloring.  If an editor uses the syntax map to identify object literals for special UI, then they will not recognize object literals in array expressions correctly.  Note: editors that use the document structure instead of the syntax map for this purpose were not affected.
- Risk: Low; this only affects the syntax map and in the worst case could only result in mis-categorizing a keyword as an identifier.
- Reviewed by: _pending_
- Testing: Regression tests added.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

rdar://problem/27726422

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…
