### PR TITLE
[3.0] IRGen: Add missing bitcasts to emitNativeUnowned* operations.

### DIFF
--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -1138,6 +1138,7 @@ void IRGenFunction::emitNativeSetDeallocating(llvm::Value *value) {
 
 void IRGenFunction::emitNativeUnownedInit(llvm::Value *value,
                                           Address dest) {
+  value = Builder.CreateBitCast(value, IGM.RefCountedPtrTy);
   dest = Builder.CreateStructGEP(dest, 0, Size(0));
   Builder.CreateStore(value, dest);
   emitNativeUnownedRetain(value);
@@ -1145,6 +1146,7 @@ void IRGenFunction::emitNativeUnownedInit(llvm::Value *value,
 
 void IRGenFunction::emitNativeUnownedAssign(llvm::Value *value,
                                             Address dest) {
+  value = Builder.CreateBitCast(value, IGM.RefCountedPtrTy);
   dest = Builder.CreateStructGEP(dest, 0, Size(0));
   auto oldValue = Builder.CreateLoad(dest);
   Builder.CreateStore(value, dest);

--- a/test/IRGen/unowned_store.sil
+++ b/test/IRGen/unowned_store.sil
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -emit-ir -verify %s
+
+import Swift
+
+class C {}
+
+sil @foo : $@convention(thin) (@inout @sil_unowned C, @owned C) -> () {
+entry(%0 : $*@sil_unowned C, %1 : $C):
+  store_unowned %1 to [initialization] %0 : $*@sil_unowned C
+  store_unowned %1 to %0 : $*@sil_unowned C
+  return undef : $()
+}
+
+sil_vtable C {}


### PR DESCRIPTION
Fixes rdar://problem/27664203.
