### PR TITLE
[Foundation] Ensure _SwiftNSCharacterSet overrides all abstract metho…

### DIFF
--- a/stdlib/public/SDK/Foundation/CharacterSet.swift
+++ b/stdlib/public/SDK/Foundation/CharacterSet.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 @_exported import Foundation // Clang module
+import CoreFoundation
 
 private func _utfRangeToNSRange(_ inRange : Range<UnicodeScalar>) -> NSRange {
     return NSMakeRange(Int(inRange.lowerBound.value), Int(inRange.upperBound.value - inRange.lowerBound.value))
@@ -483,28 +484,37 @@ extension _SwiftNSCharacterSet {
     
     // Immutable
     
+    @objc(bitmapRepresentation)
     var bitmapRepresentation: Data {
         return _mapUnmanaged { $0.bitmapRepresentation }
     }
     
+    @objc(invertedSet)
     var inverted : CharacterSet {
         return _mapUnmanaged { $0.inverted }
     }
     
+    @objc(hasMemberInPlane:)
     func hasMember(inPlane plane: UInt8) -> Bool {
         return _mapUnmanaged {$0.hasMemberInPlane(plane) }
     }
     
+    @objc(characterIsMember:)
     func characterIsMember(_ member: unichar) -> Bool {
         return _mapUnmanaged { $0.characterIsMember(member) }
     }
     
+    @objc(longCharacterIsMember:)
     func longCharacterIsMember(_ member: UTF32Char) -> Bool {
         return _mapUnmanaged { $0.longCharacterIsMember(member) }
     }
     
+    @objc(isSupersetOfSet:)
     func isSuperset(of other: CharacterSet) -> Bool {
-        return _mapUnmanaged { $0.isSuperset(of: other) }
+        return _mapUnmanaged {
+            // this is a work around for <rdar://problem/27768939>
+            return CFCharacterSetIsSupersetOfSet($0 as CFCharacterSet, (other as NSCharacterSet).copy() as! CFCharacterSet)
+        }
     }
     
 }

--- a/test/1_stdlib/TestCharacterSet.swift
+++ b/test/1_stdlib/TestCharacterSet.swift
@@ -180,6 +180,28 @@ class TestCharacterSet : TestCharacterSetSuper {
         expectNotEqual(anyHashables[0], anyHashables[1])
         expectEqual(anyHashables[1], anyHashables[2])
     }
+
+    func test_superSet() {
+        let a = CharacterSet.letters.isSuperset(of: CharacterSet(charactersIn: "ab"))
+        expectTrue(a)
+    }
+
+    func test_union() {
+        let union = CharacterSet(charactersIn: "ab").union(CharacterSet(charactersIn: "cd"))
+        let expected = CharacterSet(charactersIn: "abcd")
+        expectEqual(expected, union)
+    }
+
+    func test_hasMember() {
+        let contains = CharacterSet.letters.hasMember(inPlane: 1)
+        expectTrue(contains)
+    }
+
+    func test_bitmap() {
+        let bitmap = CharacterSet(charactersIn: "ab").bitmapRepresentation
+        expectEqual(0x6, bitmap[12])
+        expectEqual(8192, bitmap.count)
+    }
 }
 
 
@@ -195,6 +217,10 @@ CharacterSetTests.test("testBasics") { TestCharacterSet().testBasics() }
 CharacterSetTests.test("test_classForCoder") { TestCharacterSet().test_classForCoder() }
 CharacterSetTests.test("test_AnyHashableContainingCharacterSet") { TestCharacterSet().test_AnyHashableContainingCharacterSet() }
 CharacterSetTests.test("test_AnyHashableCreatedFromNSCharacterSet") { TestCharacterSet().test_AnyHashableCreatedFromNSCharacterSet() }
+CharacterSetTests.test("test_superSet") { TestCharacterSet().test_superSet() }
+CharacterSetTests.test("test_union") { TestCharacterSet().test_union() }
+CharacterSetTests.test("test_hasMember") { TestCharacterSet().test_hasMember() }
+CharacterSetTests.test("test_bitmap") { TestCharacterSet().test_bitmap() }
 runAllTests()
 #endif
 


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

The override methods were not marked with @objc which incorrectly funneled to the abstract base class methods. In the method isSuperset(of:) it would incorrectly hit a requirement of a subclass implementation. This exposed a flaw with NSCharacterSet in which that method cannot recieve subclasses to the other CharacterSet being passed. This is being tracked via rdar://problem/27768939 which will need to be accounted for by CoreFoundation. Until such a time that can be addressed the workaround by using CFCharacterSetIsSupersetOfSet must be used with a copy passed as the other set.

This is a cherry pick of the fix applied to the swift 3.0 branch in https://github.com/apple/swift/pull/4162
#### Resolved bug number: ([SR-2307](https://bugs.swift.org/browse/SR-2307))

---
