### PR TITLE
[CodeCompletion] Refactor archetype transform to avoid using recursion.

### DIFF
--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -198,14 +198,12 @@ private:
 } // namespace ide
 
 class ArchetypeTransformer {
-  std::function<Type(Type)> TheFunc = nullptr;
-  DeclContext *DC;
-  Type BaseTy;
-  llvm::DenseMap<TypeBase *, Type> Cache;
-  TypeSubstitutionMap Map;
+  struct Implementation;
+  Implementation &Impl;
 public:
   ArchetypeTransformer(DeclContext *DC, Type Ty);
   llvm::function_ref<Type(Type)> getTransformerFunc();
+  ~ArchetypeTransformer();
 };
 } // namespace swift
 


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->

```
[CodeCompletion] Refactor archetype transform to avoid using recursion. rdar://27615558

We have a radar (rdar://27615558) complaining the exiting recursive calls in type transform
of code completion hangs. This patch refactor the existing code to avoid using
recursion. From existing tests' perspective, this is NFC. I am not able to contrive the
test case that leads to the hang, neither is given by the radar.
```

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…n. rdar://27615558

We have a radar (rdar://27615558) complaining the exiting recursive calls in type transform
of code completion hangs. This patch refactor the existing code to avoid using
recursion. From existing tests' perspective, this is NFC. I am not able to contrive the
test case that leads to the hang, neither is given by the radar.
