### PR TITLE
[swiftc (46 vs. 5156)] Add crasher in swift::Type::transform(...)

### DIFF
--- a/validation-test/compiler_crashers/28393-swift-type-transform.swift
+++ b/validation-test/compiler_crashers/28393-swift-type-transform.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+enum S:A{let d=b}protocol A{associatedtype b:A=S


### PR DESCRIPTION
Add test case for crash triggered in `swift::Type::transform(...)`.

Current number of unresolved compiler crashers: 46 (5156 resolved)

Assertion failure in `llvm/include/llvm/Support/Casting.h (line 95)`:

```
Assertion `Val && "isa<> used on a null pointer"' failed.

When executing: static bool llvm::isa_impl_cl<swift::SILFunctionType, const swift::TypeBase *>::doit(const From *) [To = swift::SILFunctionType, From = const swift::TypeBase *]
```

Assertion context:

```
  }
};

template <typename To, typename From> struct isa_impl_cl<To, const From*> {
  static inline bool doit(const From *Val) {
    assert(Val && "isa<> used on a null pointer");
    return isa_impl<To, From>::doit(*Val);
  }
};

template <typename To, typename From> struct isa_impl_cl<To, const From*const> {
```

Stack trace:

```
swift: /path/to/llvm/include/llvm/Support/Casting.h:95: static bool llvm::isa_impl_cl<swift::SILFunctionType, const swift::TypeBase *>::doit(const From *) [To = swift::SILFunctionType, From = const swift::TypeBase *]: Assertion `Val && "isa<> used on a null pointer"' failed.
9  swift           0x000000000115ba63 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 35
10 swift           0x0000000001154db4 swift::Type::subst(swift::ModuleDecl*, llvm::DenseMap<swift::TypeBase*, swift::Type, llvm::DenseMapInfo<swift::TypeBase*>, llvm::detail::DenseMapPair<swift::TypeBase*, swift::Type> >&, swift::OptionSet<swift::SubstFlags, unsigned int>) const + 68
13 swift           0x0000000000f21cce swift::TypeChecker::resolveTypeWitness(swift::NormalProtocolConformance const*, swift::AssociatedTypeDecl*) + 254
14 swift           0x000000000114c436 swift::NormalProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 150
15 swift           0x000000000114c378 swift::ProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 40
17 swift           0x0000000000f15254 swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 420
18 swift           0x0000000000ebba04 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 116
20 swift           0x000000000109a22b swift::Expr::walk(swift::ASTWalker&) + 27
21 swift           0x0000000000ebd1f0 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 224
22 swift           0x0000000000ec443d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 621
23 swift           0x0000000000ec55f0 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 352
24 swift           0x0000000000ec580b swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
29 swift           0x0000000000ed7466 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
30 swift           0x0000000000efb3a2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
31 swift           0x0000000000c7b5b9 swift::CompilerInstance::performSema() + 3289
33 swift           0x00000000007db487 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
34 swift           0x00000000007a72b8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28393-swift-type-transform.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28393-swift-type-transform-10c33b.o
1.  While type-checking 'S' at validation-test/compiler_crashers/28393-swift-type-transform.swift:10:1
2.  While type-checking expression at [validation-test/compiler_crashers/28393-swift-type-transform.swift:10:16 - line:10:16] RangeText="b"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
