### PR TITLE
stdlib: Add unavailable declaration for 'withUnsafePointers' and 'readLine'

### DIFF
--- a/stdlib/public/core/InputStream.swift
+++ b/stdlib/public/core/InputStream.swift
@@ -71,3 +71,8 @@ public func readLine(strippingNewline: Bool = true) -> String? {
   _swift_stdlib_free(linePtr)
   return result
 }
+
+@available(*, unavailable, renamed: "readLine(strippingNewline:)")
+public func readLine(stripNewline: Bool = true) -> String? {
+  Builtin.unreachable()
+}

--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -95,3 +95,50 @@ public func withUnsafePointer<T, Result>(
 {
   Builtin.unreachable()
 }
+
+@available(*, unavailable, message:"use nested withUnsafeMutablePointer(to:_:) instead")
+public func withUnsafeMutablePointers<A0, A1, Result>(
+  _ arg0: inout A0,
+  _ arg1: inout A1,
+  _ body: @noescape (
+    UnsafeMutablePointer<A0>, UnsafeMutablePointer<A1>) throws -> Result
+) rethrows -> Result {
+  Builtin.unreachable()
+}
+
+@available(*, unavailable, message:"use nested withUnsafeMutablePointer(to:_:) instead")
+public func withUnsafeMutablePointers<A0, A1, A2, Result>(
+  _ arg0: inout A0,
+  _ arg1: inout A1,
+  _ arg2: inout A2,
+  _ body: @noescape (
+    UnsafeMutablePointer<A0>,
+    UnsafeMutablePointer<A1>,
+    UnsafeMutablePointer<A2>
+  ) throws -> Result
+) rethrows -> Result {
+  Builtin.unreachable()
+}
+
+@available(*, unavailable, message:"use nested withUnsafePointer(to:_:) instead")
+public func withUnsafePointers<A0, A1, Result>(
+  _ arg0: inout A0,
+  _ arg1: inout A1,
+  _ body: (UnsafePointer<A0>, UnsafePointer<A1>) throws -> Result
+) rethrows -> Result {
+  Builtin.unreachable()
+}
+
+@available(*, unavailable, message:"use nested withUnsafePointer(to:_:) instead")
+public func withUnsafePointers<A0, A1, A2, Result>(
+  _ arg0: inout A0,
+  _ arg1: inout A1,
+  _ arg2: inout A2,
+  _ body: (
+    UnsafePointer<A0>,
+    UnsafePointer<A1>,
+    UnsafePointer<A2>
+  ) throws -> Result
+) rethrows -> Result {
+  Builtin.unreachable()
+}

--- a/test/1_stdlib/Renames.swift
+++ b/test/1_stdlib/Renames.swift
@@ -240,6 +240,11 @@ func _Index() {
   func fn3<T : RandomAccessIndexType>(_: T) {} // expected-error {{'RandomAccessIndexType' has been renamed to 'Strideable'}} {{16-37=Strideable}} {{none}}
 }
 
+func _InputStream() {
+  _ = readLine(stripNewline: true) // expected-error {{'readLine(stripNewline:)' has been renamed to 'readLine(strippingNewline:)'}} {{7-15=readLine}} {{16-28=strippingNewline}} {{none}}
+  _ = readLine() // ok
+}
+
 func _IntegerArithmetic() {
   func fn1<T : IntegerArithmeticType>(_: T) {} // expected-error {{'IntegerArithmeticType' has been renamed to 'IntegerArithmetic'}} {{16-37=IntegerArithmetic}} {{none}}
   func fn2<T : SignedNumberType>(_: T) {} // expected-error {{'SignedNumberType' has been renamed to 'SignedNumber'}} {{16-32=SignedNumber}} {{none}}

--- a/test/1_stdlib/Renames.swift
+++ b/test/1_stdlib/Renames.swift
@@ -266,6 +266,16 @@ func _LazySequence<S : LazySequenceProtocol>(s: S) {
   _ = s.array // expected-error {{'array' is unavailable: Please use Array initializer instead.}} {{none}}
 }
 
+func _LifetimeManager<T>(x: T) {
+  var x = x
+  _ = withUnsafeMutablePointer(&x) { _ in } // expected-error {{'withUnsafeMutablePointer' has been renamed to 'withUnsafeMutablePointer(to:_:)'}} {{7-31=withUnsafeMutablePointer}} {{32-32=to: }} {{none}}
+  _ = withUnsafeMutablePointers(&x, &x) { _, _ in } // expected-error {{'withUnsafeMutablePointers' is unavailable: use nested withUnsafeMutablePointer(to:_:) instead}} {{none}}
+  _ = withUnsafeMutablePointers(&x, &x, &x) { _, _, _ in } // expected-error {{'withUnsafeMutablePointers' is unavailable: use nested withUnsafeMutablePointer(to:_:) instead}} {{none}}
+  _ = withUnsafePointer(&x) { _ in } // expected-error {{'withUnsafePointer' has been renamed to 'withUnsafePointer(to:_:)'}} {7-24=withUnsafePointer}} {{25-25=to: }} {{none}}
+  _ = withUnsafePointers(&x, &x) { _, _ in } // expected-error {{'withUnsafePointers' is unavailable: use nested withUnsafePointer(to:_:) instead}} {{none}}
+  _ = withUnsafePointers(&x, &x, &x) { _, _, _ in } // expected-error {{'withUnsafePointers' is unavailable: use nested withUnsafePointer(to:_:) instead}} {{none}}
+}
+
 func _ManagedBuffer<V, E>(x: ManagedBufferPointer<V, E>) {
   _ = x.allocatedElementCount // expected-error {{'allocatedElementCount' has been renamed to 'capacity'}} {{9-30=capacity}} {{none}}
 }


### PR DESCRIPTION
#### What's in this pull request?
- `withUnsafePointers` and `withUnsafeMutablePointers` were removed in 112451c44afa951a7e6447e8b2dc7c52d756dd16
- `readLine(stripNewline:)` was renamed to `readLine(strippingNewline:)`

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
