### PR TITLE
[Parse] Fix fix-it for old-style 'where' clauses.

### DIFF
--- a/test/Parse/deprecated_where.swift
+++ b/test/Parse/deprecated_where.swift
@@ -64,3 +64,16 @@ struct S23<T where T: Comparable> where T: Equatable {} // expected-warning {{'w
 // 1,2,3
 struct S123<T: Hashable where T: Comparable> where T: Equatable {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{24-44=}} {{46-51=where T: Comparable,}}
 
+
+protocol ProtoA {}
+protocol ProtoB {}
+protocol ProtoC {}
+protocol ProtoD {}
+func testCombinedConstraints<T: ProtoA & ProtoB where T: ProtoC>(x: T) {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{48-64=}} {{71-71= where T: ProtoC}}
+func testCombinedConstraints<T: ProtoA & ProtoB where T: ProtoC>(x: T) where T: ProtoD {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{48-64=}} {{72-77=where T: ProtoC,}}
+
+func testCombinedConstraintsOld<T: protocol<ProtoA, ProtoB> where T: ProtoC>(x: T) {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{60-76=}} {{83-83= where T: ProtoC}}
+// expected-warning@-1 {{'protocol<...>' composition syntax is deprecated}}
+func testCombinedConstraintsOld<T: protocol<ProtoA, ProtoB> where T: ProtoC>(x: T) where T: ProtoD {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{60-76=}} {{84-89=where T: ProtoC,}}
+// expected-warning@-1 {{'protocol<...>' composition syntax is deprecated}}
+


### PR DESCRIPTION
Previously it didn't handle parameters with protocol composition bounds
correctly.

rdar://problem/27648438

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
