### PR TITLE
[FixCode] Blacklist the fixit for enum case renames to avoid collision.

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -613,6 +613,10 @@ private:
     // invalidating some inits with type errors.
     if (Info.ID == diag::init_not_instance_member.ID)
       return false;
+    // Renaming enum cases interacts poorly with the swift migrator by
+    // reverting changes made by the mgirator.
+    if (Info.ID == diag::could_not_find_enum_case.ID)
+      return false;
 
     if (Kind == DiagnosticKind::Error)
       return true;

--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -221,3 +221,8 @@ protocol Prot2 {
 }
 class Cls1 : Prot1 {}
 func testwhere<T: Prot2 where T.Ty == Cls1>(_: T) {}
+
+enum E {
+  case abc
+}
+func testEnumRename() { _ = E.Abc }

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -224,3 +224,8 @@ protocol Prot2 {
 }
 class Cls1 : Prot1 {}
 func testwhere<T: Prot2>(_: T) where T.Ty == Cls1 {}
+
+enum E {
+  case abc
+}
+func testEnumRename() { _ = E.Abc }


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->

[FixCode] Blacklist the fixit for enum case renames to avoid reverting migrator's change. 

We added the fixit to help users manually migrate enum case references after the declaration has been renamed; however, when interacting with the migrator, the fixit may revert migrator's correct changes, when the migrator updates references before updating the declaration. This patch blacklists the fixit in migrator's pass, so we leave it to users' manually application if necessary.

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…g migrator's change. rdar://27776887

We added the fixit to help users manually migrate enum case references after the declaration
has been renamed; however, when interacting with the migrator, the fixit may revert migrator's
correct changes, when the migrator updates references before updating the declaration. This patch
blacklists the fixit in migrator's pass, so we leave it to users' manually application if necessary.
