### PR TITLE
build libdispatch by default in both linux build bot configurations

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -646,11 +646,13 @@ test
 validation-test
 long-test
 foundation
+libdispatch
 lit-args=-v
 
 dash-dash
 
 install-foundation
+install-libdispatch
 reconfigure
 
 # Ubuntu 16.04 preset for backwards compat and future customizations.
@@ -722,6 +724,7 @@ llbuild
 swiftpm
 xctest
 foundation
+libdispatch
 dash-dash
 
 [preset: buildbot_incremental_linux,long_test]

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2419,7 +2419,6 @@ for host in "${ALL_HOSTS[@]}"; do
                         dispatch_build_variant_arg="debug"
                     fi
                     call mkdir -p "${LIBDISPATCH_BUILD_DIR}"
-                    echo `which autoreconf`
                     with_pushd "${LIBDISPATCH_SOURCE_DIR}" \
                         call autoreconf -fvi
                     with_pushd "${LIBDISPATCH_BUILD_DIR}" \

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2409,6 +2409,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 LLVM_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
 
                 if [[ "${RECONFIGURE}" || ! -f "${LIBDISPATCH_BUILD_DIR}"/config.status ]]; then
+                    echo "Reconfiguring libdispatch"
                     # First time building; need to run autotools and configure
                     if [[ "$LIBDISPATCH_BUILD_TYPE" == "Release" ]] ; then
                         dispatch_build_variant_arg="release"
@@ -2418,6 +2419,7 @@ for host in "${ALL_HOSTS[@]}"; do
                         dispatch_build_variant_arg="debug"
                     fi
                     call mkdir -p "${LIBDISPATCH_BUILD_DIR}"
+                    echo `which autoreconf`
                     with_pushd "${LIBDISPATCH_SOURCE_DIR}" \
                         call autoreconf -fvi
                     with_pushd "${LIBDISPATCH_BUILD_DIR}" \
@@ -2425,7 +2427,8 @@ for host in "${ALL_HOSTS[@]}"; do
                             "${LIBDISPATCH_SOURCE_DIR}"/configure --with-swift-toolchain="${SWIFT_BUILD_PATH}" \
                             --with-build-variant=$dispatch_build_variant_arg \
                             --prefix="$(get_host_install_destdir ${host})$(get_host_install_prefix ${host})"
-
+                else
+                    echo "Skipping reconfiguration of libdispatch"
                 fi
                 with_pushd "${LIBDISPATCH_BUILD_DIR}" \
                     call make

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2408,7 +2408,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 SWIFTC_BIN="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
                 LLVM_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
 
-                if [[ ! -f "${LIBDISPATCH_BUILD_DIR}"/config.status ]]; then
+                if [[ "${RECONFIGURE}" || ! -f "${LIBDISPATCH_BUILD_DIR}"/config.status ]]; then
                     # First time building; need to run autotools and configure
                     if [[ "$LIBDISPATCH_BUILD_TYPE" == "Release" ]] ; then
                         dispatch_build_variant_arg="release"


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Foundation is prepared to handle building libdispatch by default for Linux targets. This should add libdispatch as a default argument to the build script for the build bots.

---
