### PR TITLE
runtime: expose the layout of SwiftError to LLDB

### DIFF
--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -39,6 +39,7 @@ set(swift_runtime_sources
     CygwinPort.cpp
     Demangle.cpp
     Enum.cpp
+    ErrorObjectConstants.cpp
     ErrorObjectNative.cpp
     Errors.cpp
     Heap.cpp

--- a/stdlib/public/runtime/ErrorObject.h
+++ b/stdlib/public/runtime/ErrorObject.h
@@ -229,6 +229,14 @@ const Metadata *getNSErrorMetadata();
 
 #endif
 
+SWIFT_RUNTIME_EXPORT
+extern "C"
+const size_t _swift_lldb_offsetof_SwiftError_typeMetadata;
+
+SWIFT_RUNTIME_EXPORT
+extern "C"
+const size_t _swift_lldb_sizeof_SwiftError;
+
 } // namespace swift
 
 #endif

--- a/stdlib/public/runtime/ErrorObject.h
+++ b/stdlib/public/runtime/ErrorObject.h
@@ -78,6 +78,7 @@ struct SwiftError : SwiftErrorHeader {
   /// This member is only available for native Swift errors.
   const WitnessTable *errorConformance;
 
+#if SWIFT_OBJC_INTEROP
   /// The base type that introduces the `Hashable` conformance.
   /// This member is only available for native Swift errors.
   /// This member is lazily-initialized.
@@ -89,6 +90,7 @@ struct SwiftError : SwiftErrorHeader {
   /// This member is lazily-initialized.
   /// Instead of using it directly, call `getHashableConformance()`.
   mutable std::atomic<const hashable_support::HashableWitnessTable *> hashableConformance;
+#endif
 
   /// Get a pointer to the value contained inside the indirectly-referenced
   /// box reference.
@@ -143,6 +145,7 @@ struct SwiftError : SwiftErrorHeader {
   const WitnessTable *getErrorConformance() const { return errorConformance; }
 #endif
 
+#if SWIFT_OBJC_INTEROP
   /// Get the base type that conforms to `Hashable`.
   /// Returns NULL if the type does not conform.
   const Metadata *getHashableBaseType() const;
@@ -150,6 +153,7 @@ struct SwiftError : SwiftErrorHeader {
   /// Get the `Hashable` protocol witness table for the contained type.
   /// Returns NULL if the type does not conform.
   const hashable_support::HashableWitnessTable *getHashableConformance() const;
+#endif
 
   // Don't copy or move, please.
   SwiftError(const SwiftError &) = delete;

--- a/stdlib/public/runtime/ErrorObjectConstants.cpp
+++ b/stdlib/public/runtime/ErrorObjectConstants.cpp
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "ErrorObject.h"
+
+using namespace swift;
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winvalid-offsetof"
+const size_t swift::_swift_lldb_offsetof_SwiftError_typeMetadata =
+    offsetof(SwiftError, type);
+#pragma clang diagnostic pop
+
+const size_t swift::_swift_lldb_sizeof_SwiftError = sizeof(SwiftError);
+

--- a/test/1_stdlib/Runtime.swift.gyb
+++ b/test/1_stdlib/Runtime.swift.gyb
@@ -9,6 +9,11 @@ import Swift
 import StdlibUnittest
 import SwiftShims
 
+#if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)
+import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android)
+import Glibc
+#endif
 
 @_silgen_name("swift_demangle")
 public
@@ -494,6 +499,35 @@ Runtime.test("Struct layout with reference storage types") {
 
   // Make sure malkovich lives long enough.
   print(malkovich)
+}
+
+Runtime.test("SwiftError layout constants for LLDB") {
+#if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)
+  let RTLD_DEFAULT = UnsafeMutableRawPointer(bitPattern: -2)
+#elseif os(Linux)
+  let RTLD_DEFAULT = UnsafeMutableRawPointer(bitPattern: 0)
+#else
+  _UnimplementedError()
+#endif
+
+  let offsetof_SwiftError_typeMetadata =
+    dlsym(RTLD_DEFAULT, "_swift_lldb_offsetof_SwiftError_typeMetadata")!
+  let sizeof_SwiftError =
+    dlsym(RTLD_DEFAULT, "_swift_lldb_sizeof_SwiftError")!
+#if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)
+#if arch(i386) || arch(arm)
+  expectEqual(20, offsetof_SwiftError_typeMetadata.load(as: UInt.self))
+  expectEqual(36, sizeof_SwiftError.load(as: UInt.self))
+#else
+  expectEqual(40, offsetof_SwiftError_typeMetadata.load(as: UInt.self))
+  expectEqual(72, sizeof_SwiftError.load(as: UInt.self))
+#endif
+#elseif os(Linux)
+  expectEqual(16, offsetof_SwiftError_typeMetadata.load(as: UInt.self))
+  expectEqual(32, sizeof_SwiftError.load(as: UInt.self))
+#else
+  _UnimplementedError()
+#endif
 }
 
 var Reflection = TestSuite("Reflection")


### PR DESCRIPTION
Add two global constants that expose the important parts of `SwiftError` layout to LLDB.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
