### PR TITLE
[SceneKit] un-qualify nested type swift_name

### DIFF
--- a/apinotes/SceneKit.apinotes
+++ b/apinotes/SceneKit.apinotes
@@ -64,52 +64,54 @@ Globals:
   SwiftName: SCNHitTestOption.rootNode
 - Name: SCNHitTestIgnoreHiddenNodesKey
   SwiftName: SCNHitTestOption.ignoreHiddenNodes
+# FIXME: All of these are on nested types, which is not supported by swift_name
+# yet. Once it is, make these fully qualified
 - Name: SCNPhysicsShapeTypeKey
-  SwiftName: SCNPhysicsShape.Option.type
+  SwiftName: type
 - Name: SCNPhysicsShapeKeepAsCompoundKey
-  SwiftName: SCNPhysicsShape.Option.keepAsCompound
+  SwiftName: keepAsCompound
 - Name: SCNPhysicsShapeScaleKey
-  SwiftName: SCNPhysicsShape.Option.scale
+  SwiftName: scale
 - Name: SCNPhysicsTestCollisionBitMaskKey
-  SwiftName: SCNPhysicsWorld.TestOption.collisionBitMask
+  SwiftName: collisionBitMask
 - Name: SCNPhysicsTestSearchModeKey
-  SwiftName: SCNPhysicsWorld.TestOption.searchMode
+  SwiftName: searchMode
 - Name: SCNPhysicsTestBackfaceCullingKey
-  SwiftName: SCNPhysicsWorld.TestOption.backfaceCulling
+  SwiftName: backfaceCulling
 - Name: SCNSceneStartTimeAttributeKey
-  SwiftName: SCNScene.Attribute.startTime
+  SwiftName: startTime
 - Name: SCNSceneEndTimeAttributeKey
-  SwiftName: SCNScene.Attribute.endTime
+  SwiftName: endTime
 - Name: SCNSceneFrameRateAttributeKey
-  SwiftName: SCNScene.Attribute.frameRate
+  SwiftName: frameRate
 - Name: SCNSceneUpAxisAttributeKey
-  SwiftName: SCNScene.Attribute.upAxis
+  SwiftName: upAxis
 - Name: SCNSceneSourceCreateNormalsIfAbsentKey
-  SwiftName: SCNSceneSource.LoadingOption.createNormalsIfAbsent
+  SwiftName: createNormalsIfAbsent
 - Name: SCNSceneSourceCheckConsistencyKey
-  SwiftName: SCNSceneSource.LoadingOption.checkConsistency
+  SwiftName: checkConsistency
 - Name: SCNSceneSourceFlattenSceneKey
-  SwiftName: SCNSceneSource.LoadingOption.flattenScene
+  SwiftName: flattenScene
 - Name: SCNSceneSourceUseSafeModeKey
-  SwiftName: SCNSceneSource.LoadingOption.useSafeMode
+  SwiftName: useSafeMode
 - Name: SCNSceneSourceAssetDirectoryURLsKey
-  SwiftName: SCNSceneSource.LoadingOption.assetDirectoryURLs
+  SwiftName: assetDirectoryURLs
 - Name: SCNSceneSourceOverrideAssetURLsKey
-  SwiftName: SCNSceneSource.LoadingOption.overrideAssetURLs
+  SwiftName: overrideAssetURLs
 - Name: SCNSceneSourceStrictConformanceKey
-  SwiftName: SCNSceneSource.LoadingOption.strictConformance
+  SwiftName: strictConformance
 - Name: SCNSceneSourceConvertUnitsToMetersKey
-  SwiftName: SCNSceneSource.LoadingOption.convertUnitsToMeters
+  SwiftName: convertUnitsToMeters
 - Name: SCNSceneSourceConvertToYUpKey
-  SwiftName: SCNSceneSource.LoadingOption.convertToYUp
+  SwiftName: convertToYUp
 - Name: SCNSceneSourceAnimationImportPolicyKey
-  SwiftName: SCNSceneSource.LoadingOption.animationImportPolicy
+  SwiftName: animationImportPolicy
 - Name: SCNPreferredRenderingAPIKey
-  SwiftName: SCNView.Option.preferredRenderingAPI
+  SwiftName: preferredRenderingAPI
 - Name: SCNPreferredDeviceKey
-  SwiftName: SCNView.Option.preferredDevice
+  SwiftName: preferredDevice
 - Name: SCNPreferLowPowerDeviceKey
-  SwiftName: SCNView.Option.preferLowPowerDevice
+  SwiftName: preferLowPowerDevice
 
 #
 # API Renaming


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

```
We don't yet support nested types for the target of swift_name, which
is a very unfortunate omission. Instead, use un-qualified names in the
apinotes, which default to the decl's context, which in this case
fortunately interacts with swift_newtype to end up in the properly
nested struct in Swift proper. Gross.
```
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

We don't yet support nested types for the target of swift_name, which
is a very unfortunate omission. Instead, use un-qualified names in the
apinotes, which default to the decl's context, which in this case
fortunately interacts with swift_newtype to end up in the properly
nested struct in Swift proper. Gross.
