### PR TITLE
Re-apply "staging for move to PlaygroundSupport"

### DIFF
--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -944,3 +944,7 @@ extension Mirror : CustomReflectable {
 
 @available(*, unavailable, renamed: "MirrorPath")
 public typealias MirrorPathType = MirrorPath
+
+// Staging so we can move the official declarations into PlaygroundSupport
+public typealias _CustomPlaygroundQuickLookable = CustomPlaygroundQuickLookable
+public typealias _PlaygroundQuickLook = PlaygroundQuickLook


### PR DESCRIPTION
Reverts apple/swift#4196; swift-corelibs-foundation is still depending on it.
