### PR TITLE
stdlib: add a couple of ABI FIXMEs to String implementation

### DIFF
--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -236,6 +236,9 @@ extension String.CharacterView : BidirectionalCollection {
     )
   }
 
+  // FIXME(ABI): don't make this function inlineable.  Grapheme cluster
+  // segmentation uses a completely different algorithm in Unicode 9.0.
+  //
   /// Returns the length of the first extended grapheme cluster in UTF-16
   /// code units.
   @inline(never)
@@ -275,7 +278,10 @@ extension String.CharacterView : BidirectionalCollection {
     
     return start._position - startIndexUTF16
   }
-  
+
+  // FIXME(ABI): don't make this function inlineable.  Grapheme cluster
+  // segmentation uses a completely different algorithm in Unicode 9.0.
+  //
   /// Returns the length of the previous extended grapheme cluster in UTF-16
   /// code units.
   @inline(never)

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -577,6 +577,8 @@ extension String.UnicodeScalarIndex {
 }
 
 extension String.UnicodeScalarView {
+  // FIXME(ABI): don't make this function inlineable.  Grapheme cluster
+  // segmentation uses a completely different algorithm in Unicode 9.0.
   internal func _isOnGraphemeClusterBoundary(_ i: Index) -> Bool {
     if i == startIndex || i == endIndex {
       return true

--- a/stdlib/public/core/UnicodeTrie.swift.gyb
+++ b/stdlib/public/core/UnicodeTrie.swift.gyb
@@ -206,6 +206,9 @@ struct _UnicodeGraphemeClusterBreakPropertyTrie {
   }
 }
 
+// FIXME(ABI): don't mark this type versioned, or any of its APIs inlineable.
+// Grapheme cluster segmentation uses a completely different algorithm in
+// Unicode 9.0.
 internal struct _UnicodeExtendedGraphemeClusterSegmenter {
   let _noBoundaryRulesMatrix: UnsafePointer<UInt16>
 


### PR DESCRIPTION
We should not make grapheme segmentation algorithm inlineable now (and
possibly ever).  The immediate reason is that Unicode 8.0 grapheme
segmentation algorithm has been changed significantly in Unicode 9.0.
Unicode 9.0 requires a stateful algorithm.  Current indices and
iterators just don't have the storage for that state, so we can't mark
them as fragile.
