### PR TITLE
[lit] Show test script when '--no-execute -a' is specified to lit.py

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -170,9 +170,23 @@ class SwiftTest(lit.formats.ShTest, object):
 
 
     def execute(self, test, litConfig):
+        if litConfig.noExecute:
+            return self.show_script(test, litConfig)
         self.before_test(test, litConfig)
         result = super(SwiftTest, self).execute(test, litConfig)
         return self.after_test(test, litConfig, result)
+
+    def show_script(self, test, litConfig):
+        script = lit.TestRunner.parseIntegratedTestScript(test, True)
+        if isinstance(script, lit.Test.Result):
+            return script
+        tmpDir, tmpBase = lit.TestRunner.getTempPaths(test)
+        substitutions = lit.TestRunner.getDefaultSubstitutions(
+                test, tmpDir, tmpBase,
+                normalize_slashes=self.execute_external)
+        script = lit.TestRunner.applySubstitutions(script, substitutions)
+        output = "Script:\n--\n%s\n--\n" % ('\n'.join(script))
+        return lit.Test.Result(lit.Test.PASS, output)
 
 # name: The name of this test suite.
 config.name = 'Swift(%s)' % config.variant_suffix[1:]

--- a/utils/run-test
+++ b/utils/run-test
@@ -103,6 +103,8 @@ def main():
                              "--build-dir is specified, none otherwise)")
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="run test with verbose output")
+    parser.add_argument("-n", "--no-execute", action="store_true",
+                        help="print test scripts, but do not execute them ")
     parser.add_argument("--build-dir", type=os.path.realpath, metavar="PATH",
                         help="Swift build directory")
     parser.add_argument("--build",
@@ -231,8 +233,10 @@ def main():
             shutil.rmtree(args.result_dir)
         os.makedirs(args.result_dir)
 
-    if args.verbose:
+    if args.verbose or args.no_execute:
         test_args = ["-a"]
+        if args.no_execute:
+            test_args += ["--no-execute"]
     else:
         test_args = ["-sv"]
 


### PR DESCRIPTION
#### What's in this pull request?

Related: https://github.com/apple/swift/pull/4187#issuecomment-238999040

Show test script  when `--no-execute -a` is specified to `lit.py`
Updated `utils/run-test` to support that.

Note: This is a kind of hack. `lit.py` should implement this functionality.

Example:

```
$ utils/run-test --build-dir ../build/Ninja-ReleaseAssert --build=skip -v -n validation-test/stdlib/Dictionary.swift 
+ /usr/bin/python /home/rintaro/Documents/swift-oss/llvm/utils/lit/lit.py -a --no-execute --param swift_test_mode=optimize_none --param swift_test_subset=primary /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/validation-test-linux-x86_64/stdlib/Dictionary.swift
lit.py: lit.cfg:268: note: using swift: /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift
lit.py: lit.cfg:268: note: using swiftc: /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swiftc
lit.py: lit.cfg:268: note: using sil-opt: /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/sil-opt
lit.py: lit.cfg:268: note: using sil-extract: /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/sil-extract
lit.py: lit.cfg:268: note: using lldb-moduleimport-test: /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/lldb-moduleimport-test
lit.py: lit.cfg:268: note: using swift-ide-test: /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-ide-test
lit.py: lit.cfg:268: note: using swift-reflection-dump: /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-reflection-dump
lit.py: lit.cfg:268: note: using swift-remoteast-test: /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-remoteast-test
lit.py: lit.cfg:268: note: using swift-format: /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-format
lit.py: lit.cfg:268: note: using clang: /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/llvm-linux-x86_64/./bin/clang
lit.py: lit.cfg:268: note: using llvm-link: /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/llvm-linux-x86_64/./bin/llvm-link
lit.py: lit.cfg:268: note: using swift-llvm-opt: /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-llvm-opt
lit.py: lit.cfg:268: note: using llvm-profdata: /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/llvm-linux-x86_64/./bin/llvm-profdata
lit.py: lit.cfg:268: note: using llvm-cov: /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/llvm-linux-x86_64/./bin/llvm-cov
lit.py: lit.cfg:316: note: Using resource dir: /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift
lit.py: lit.cfg:342: note: Using Clang module cache: /tmp/swift-testsuite-clang-module-cache72EMrh
lit.py: lit.cfg:343: note: Using test results dir: /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/./swift-test-results/x86_64-unknown-linux-gnu
lit.py: lit.cfg:347: note: Using code completion cache: /tmp/swift-testsuite-completion-cacheKr7r6U
lit.py: lit.cfg:728: note: Testing Linux x86_64-unknown-linux-gnu
lit.py: lit.cfg:268: note: using swift-autolink-extract: /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift-autolink-extract
lit.py: lit.cfg:994: note: Using platform module dir: /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/%target-sdk-name/x86_64
-- Testing: 1 tests, 1 threads --
PASS: Swift(linux-x86_64) :: stdlib/Dictionary.swift (1 of 1)
Script:
--
rm -rf /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/validation-test-linux-x86_64/stdlib/Output/Dictionary.swift.tmp
mkdir -p /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/validation-test-linux-x86_64/stdlib/Output/Dictionary.swift.tmp
/home/rintaro/Documents/swift-oss/swift/utils/gyb /home/rintaro/Documents/swift-oss/swift/validation-test/stdlib/Dictionary.swift -o /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/validation-test-linux-x86_64/stdlib/Output/Dictionary.swift.tmp/main.swift
if [ native == "objc" ]; then    clang++ -target x86_64-unknown-linux-gnu -fmodules-cache-path='/tmp/swift-testsuite-clang-module-cache72EMrh' -fobjc-arc /home/rintaro/Documents/swift-oss/swift/validation-test/stdlib/Inputs/SlurpFastEnumeration/SlurpFastEnumeration.m -c -o /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/validation-test-linux-x86_64/stdlib/Output/Dictionary.swift.tmp/SlurpFastEnumeration.o;    /home/rintaro/Documents/swift-oss/swift/utils/line-directive /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/validation-test-linux-x86_64/stdlib/Output/Dictionary.swift.tmp/main.swift -- /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swiftc -target x86_64-unknown-linux-gnu  -module-cache-path '/tmp/swift-testsuite-clang-module-cache72EMrh'   /home/rintaro/Documents/swift-oss/swift/validation-test/stdlib/Inputs/DictionaryKeyValueTypes.swift /home/rintaro/Documents/swift-oss/swift/validation-test/stdlib/Inputs/DictionaryKeyValueTypesObjC.swift /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/validation-test-linux-x86_64/stdlib/Output/Dictionary.swift.tmp/main.swift -I /home/rintaro/Documents/swift-oss/swift/validation-test/stdlib/Inputs/SlurpFastEnumeration/ -Xlinker /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/validation-test-linux-x86_64/stdlib/Output/Dictionary.swift.tmp/SlurpFastEnumeration.o -o /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/validation-test-linux-x86_64/stdlib/Output/Dictionary.swift.tmp/Dictionary -Xfrontend -disable-access-control;  else    /home/rintaro/Documents/swift-oss/swift/utils/line-directive /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/validation-test-linux-x86_64/stdlib/Output/Dictionary.swift.tmp/main.swift -- /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swiftc -target x86_64-unknown-linux-gnu  -module-cache-path '/tmp/swift-testsuite-clang-module-cache72EMrh'   /home/rintaro/Documents/swift-oss/swift/validation-test/stdlib/Inputs/DictionaryKeyValueTypes.swift /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/validation-test-linux-x86_64/stdlib/Output/Dictionary.swift.tmp/main.swift -o /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/validation-test-linux-x86_64/stdlib/Output/Dictionary.swift.tmp/Dictionary -Xfrontend -disable-access-control;  fi
/home/rintaro/Documents/swift-oss/swift/utils/line-directive /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/validation-test-linux-x86_64/stdlib/Output/Dictionary.swift.tmp/main.swift --  /home/rintaro/Documents/swift-oss/build/Ninja-ReleaseAssert/swift-linux-x86_64/validation-test-linux-x86_64/stdlib/Output/Dictionary.swift.tmp/Dictionary
--

********************
Testing Time: 0.01s
  Expected Passes    : 1
```

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
