### PR TITLE
[swift-3.0-branch] runtime: rename SwiftValue to _SwiftValue (it is a private class)

### DIFF
--- a/stdlib/public/runtime/AnyHashableSupport.cpp
+++ b/stdlib/public/runtime/AnyHashableSupport.cpp
@@ -139,8 +139,8 @@ extern "C" void _swift_stdlib_makeAnyHashableUpcastingToHashableBaseType(
 #if SWIFT_OBJC_INTEROP
     id srcObject;
     memcpy(&srcObject, value, sizeof(id));
-    // Do we have a SwiftValue?
-    if (SwiftValue *srcSwiftValue = getAsSwiftValue(srcObject)) {
+    // Do we have a _SwiftValue?
+    if (_SwiftValue *srcSwiftValue = getAsSwiftValue(srcObject)) {
       // If so, extract the boxed value and try to cast it.
       const Metadata *unboxedType;
       const OpaqueValue *unboxedValue;

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -2261,11 +2261,11 @@ checkDynamicCastFromOptional(OpaqueValue *dest,
 }
 
 /******************************************************************************/
-/***************************** Bridging SwiftValue ****************************/
+/**************************** Bridging _SwiftValue ****************************/
 /******************************************************************************/
 
 #if SWIFT_OBJC_INTEROP
-/// Try to unbox a SwiftValue box to perform a dynamic cast.
+/// Try to unbox a _SwiftValue box to perform a dynamic cast.
 static bool tryDynamicCastBoxedSwiftValue(OpaqueValue *dest,
                                           OpaqueValue *src,
                                           const Metadata *srcType,
@@ -2283,8 +2283,8 @@ static bool tryDynamicCastBoxedSwiftValue(OpaqueValue *dest,
   id srcObject;
   memcpy(&srcObject, src, sizeof(id));
   
-  // Do we have a SwiftValue?
-  SwiftValue *srcSwiftValue = getAsSwiftValue(srcObject);
+  // Do we have a _SwiftValue?
+  _SwiftValue *srcSwiftValue = getAsSwiftValue(srcObject);
   if (!srcSwiftValue)
     return false;
   
@@ -2483,7 +2483,7 @@ bool swift::swift_dynamicCast(OpaqueValue *dest,
     return unwrapResult.success;
 
 #if SWIFT_OBJC_INTEROP
-  // A class or AnyObject reference may point at a boxed SwiftValue.
+  // A class or AnyObject reference may point at a boxed _SwiftValue.
   if (tryDynamicCastBoxedSwiftValue(dest, src, srcType,
                                     targetType, flags)) {
     return true;

--- a/stdlib/public/runtime/SwiftValue.h
+++ b/stdlib/public/runtime/SwiftValue.h
@@ -24,32 +24,32 @@
 #if SWIFT_OBJC_INTEROP
 #include <objc/runtime.h>
 
-// SwiftValue is an Objective-C class, but we shouldn't interface with it
+// _SwiftValue is an Objective-C class, but we shouldn't interface with it
 // directly as such. Keep the type opaque.
 #if __OBJC__
-@class SwiftValue;
+@class _SwiftValue;
 #else
-typedef struct SwiftValue SwiftValue;
+typedef struct _SwiftValue _SwiftValue;
 #endif
 
 namespace swift {
 
-/// Bridge a Swift value to an Objective-C object by boxing it as a SwiftValue.
-SwiftValue *bridgeAnythingToSwiftValueObject(OpaqueValue *src,
-                                             const Metadata *srcType,
-                                             bool consume);
+/// Bridge a Swift value to an Objective-C object by boxing it as a _SwiftValue.
+_SwiftValue *bridgeAnythingToSwiftValueObject(OpaqueValue *src,
+                                              const Metadata *srcType,
+                                              bool consume);
 
 /// Get the type metadata for a value in a Swift box.
-const Metadata *getSwiftValueTypeMetadata(SwiftValue *v);
+const Metadata *getSwiftValueTypeMetadata(_SwiftValue *v);
 
 /// Get the value out of a Swift box along with its type metadata. The value
 /// inside the box is immutable and must not be modified or taken from the box.
 std::pair<const Metadata *, const OpaqueValue *>
-getValueFromSwiftValue(SwiftValue *v);
+getValueFromSwiftValue(_SwiftValue *v);
 
-/// Return the object reference as a SwiftValue* if it is a SwiftValue instance,
+/// Return the object reference as a _SwiftValue* if it is a _SwiftValue instance,
 /// or nil if it is not.
-SwiftValue *getAsSwiftValue(id object);
+_SwiftValue *getAsSwiftValue(id object);
 
 } // namespace swift
 #endif


### PR DESCRIPTION
This change adds an underscore to a runtime-private class.
