### PR TITLE
[swiftc (47 vs. 5156)] Add crasher in swift::TypeChecker::checkConformance(...)

### DIFF
--- a/validation-test/compiler_crashers/28394-swift-typechecker-checkconformance.swift
+++ b/validation-test/compiler_crashers/28394-swift-typechecker-checkconformance.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+class d:a{let c=A}protocol a{struct A{}class S<T{}typealias e:a typealias d:a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::checkConformance(...)`.

Current number of unresolved compiler crashers: 47 (5156 resolved)

Assertion failure in [`lib/Sema/TypeCheckProtocol.cpp (line 1598)`](https://github.com/apple/swift/blob/master/lib/Sema/TypeCheckProtocol.cpp#L1598):

```
Assertion `isa<SubscriptDecl>(VD) && "Unhandled requirement kind"' failed.

When executing: diag::RequirementKind getRequirementKind(swift::ValueDecl *)
```

Assertion context:

```
  if (isa<ConstructorDecl>(VD))
    return diag::RequirementKind::Constructor;

  if (isa<FuncDecl>(VD))
    return diag::RequirementKind::Func;

  if (isa<VarDecl>(VD))
    return diag::RequirementKind::Var;

  assert(isa<SubscriptDecl>(VD) && "Unhandled requirement kind");
  return diag::RequirementKind::Subscript;
```

Stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckProtocol.cpp:1598: diag::RequirementKind getRequirementKind(swift::ValueDecl *): Assertion `isa<SubscriptDecl>(VD) && "Unhandled requirement kind"' failed.
11 swift           0x0000000000f1f666 swift::TypeChecker::checkConformance(swift::NormalProtocolConformance*) + 1686
12 swift           0x0000000000f1fda7 swift::TypeChecker::checkConformancesInContext(swift::DeclContext*, swift::IterableDeclContext*) + 471
15 swift           0x0000000000ed7466 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
16 swift           0x0000000000efb42a swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1162
17 swift           0x0000000000c7b5b9 swift::CompilerInstance::performSema() + 3289
19 swift           0x00000000007db487 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
20 swift           0x00000000007a72b8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28394-swift-typechecker-checkconformance.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28394-swift-typechecker-checkconformance-09c483.o
1.  While type-checking 'd' at validation-test/compiler_crashers/28394-swift-typechecker-checkconformance.swift:10:1
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
