### PR TITLE
(WIP) Relax overly conservative "uses generic params" errors in ObjC generic extensions.

### DIFF
--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -477,6 +477,14 @@ public:
       if (E->getType()->isObjCExistentialType()
           || E->getType()->is<AnyMetatypeType>())
         return false;
+      
+      // We also special case Any erasure in pseudogeneric contexts
+      // not to rely on concrete type metadata by erasing from AnyObject
+      // as a waypoint.
+      if (E->getType()->isAny()
+          && erasure->getSubExpr()->getType()->is<ArchetypeType>())
+        return false;
+
       // Erasure to a Swift protocol always captures the type metadata from
       // its subexpression.
       checkType(erasure->getSubExpr()->getType(),
@@ -484,6 +492,7 @@ public:
       return true;
     }
 
+    
     // Converting an @objc metatype to AnyObject doesn't require type
     // metadata.
     if (isa<ClassMetatypeToObjectExpr>(E)

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -397,8 +397,10 @@ public:
     // doesn't require its type metadata.
     if (auto declRef = dyn_cast<DeclRefExpr>(E))
       return (!declRef->getDecl()->isObjC()
-              && !E->getType()->hasRetainablePointerRepresentation()
-              && !E->getType()->is<AnyMetatypeType>());
+              && !E->getType()->getLValueOrInOutObjectType()
+                              ->hasRetainablePointerRepresentation()
+              && !E->getType()->getLValueOrInOutObjectType()
+                              ->is<AnyMetatypeType>());
 
     // Loading classes or metatypes doesn't require their metadata.
     if (isa<LoadExpr>(E))
@@ -487,6 +489,11 @@ public:
     if (isa<ClassMetatypeToObjectExpr>(E)
         || isa<ExistentialMetatypeToObjectExpr>(E))
       return false;
+    
+    // Assigning an object doesn't require type metadata.
+    if (auto assignment = dyn_cast<AssignExpr>(E))
+      return !assignment->getSrc()->getType()
+        ->hasRetainablePointerRepresentation();
 
     return true;
   }

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -75,7 +75,29 @@ public:
 
     // We want to look through type aliases here.
     type = type->getCanonicalType();
-
+    
+    class TypeCaptureWalker : public TypeWalker {
+      AnyFunctionRef AFR;
+      llvm::function_ref<void(Type)> Callback;
+    public:
+      explicit TypeCaptureWalker(AnyFunctionRef AFR,
+                                 llvm::function_ref<void(Type)> callback)
+        : AFR(AFR), Callback(callback) {}
+    
+      Action walkToTypePre(Type ty) override {
+        Callback(ty);
+        // Pseudogeneric classes don't use their generic parameters so we
+        // don't need to visit them.
+        if (AFR.isObjC()) {
+          if (auto clas = dyn_cast_or_null<ClassDecl>(ty->getAnyNominal())) {
+            if (clas->usesObjCGenericsModel()) {
+              return Action::SkipChildren;
+            }
+          }
+        }
+        return Action::Continue;
+      }
+    };
     // If the type contains dynamic 'Self', conservatively assume we will
     // need 'Self' metadata at runtime. We could generalize the analysis
     // used below for usages of generic parameters in Objective-C
@@ -88,14 +110,14 @@ public:
     // retainable pointer. Similarly stored property access does not
     // need it, etc.
     if (type->hasDynamicSelfType()) {
-      type.visit([&](Type t) {
+      type.walk(TypeCaptureWalker(AFR, [&](Type t) {
         if (auto *dynamicSelf = t->getAs<DynamicSelfType>()) {
           if (DynamicSelfCaptureLoc.isInvalid()) {
             DynamicSelfCaptureLoc = loc;
             DynamicSelf = dynamicSelf;
           }
         }
-      });
+      }));
     }
 
     // Similar to dynamic 'Self', IRGen doesn't really need type metadata
@@ -106,13 +128,13 @@ public:
     // instead, but even there we don't really have enough information to
     // perform it accurately.
     if (type->hasArchetype()) {
-      type.visit([&](Type t) {
+      type.walk(TypeCaptureWalker(AFR, [&](Type t) {
         if (t->is<ArchetypeType>() &&
             !t->isOpenedExistential() &&
           GenericParamCaptureLoc.isInvalid()) {
           GenericParamCaptureLoc = loc;
         }
-      });
+      }));
     }
   }
 
@@ -498,6 +520,17 @@ public:
     if (isa<ClassMetatypeToObjectExpr>(E)
         || isa<ExistentialMetatypeToObjectExpr>(E))
       return false;
+    
+    // Casting to an ObjC class doesn't require the metadata of its type
+    // parameters, if any.
+    if (auto cast = dyn_cast<CheckedCastExpr>(E)) {
+      if (auto clas = dyn_cast_or_null<ClassDecl>(
+                         cast->getCastTypeLoc().getType()->getAnyNominal())) {
+        if (clas->usesObjCGenericsModel()) {
+          return false;
+        }
+      }
+    }
     
     // Assigning an object doesn't require type metadata.
     if (auto assignment = dyn_cast<AssignExpr>(E))

--- a/test/ClangModules/objc_bridging_generics.swift
+++ b/test/ClangModules/objc_bridging_generics.swift
@@ -133,9 +133,8 @@ extension GenericClass {
   func usesGenericParamG(_ x: T) {
     _ = T.self // expected-note{{used here}}
   }
-  // expected-error@+1{{extension of a generic Objective-C class cannot access the class's generic parameters}}
-  func usesGenericParamH(_ x: T) {
-    _ = x as Any // expected-note{{used here}}
+  func doesntUseGenericParamH(_ x: T) {
+    _ = x as Any
   }
   // expected-error@+1{{extension of a generic Objective-C class cannot access the class's generic parameters}}
   func usesGenericParamI(_ y: T.Type) {
@@ -181,14 +180,13 @@ extension AnimalContainer {
     _ = #selector(y.create)
   }
 
-  // TODO: 'Any' bridging should not require reifying generic params.
-  func doesntUseGenericParam2(_ x: T, _ y: T.Type) { // expected-error{{cannot access the class's generic parameters}}
+  func doesntUseGenericParam2(_ x: T, _ y: T.Type) {
     let a = x.another()
     _ = a.another()
     _ = x.another().another()
 
     _ = type(of: x).create().another()
-    _ = type(of: x).init(noise: x).another() // expected-note{{here}}
+    _ = type(of: x).init(noise: x).another()
     _ = y.create().another()
     _ = y.init(noise: x).another()
     _ = y.init(noise: x.another()).another()
@@ -257,9 +255,8 @@ extension AnimalContainer {
 }
 
 extension PettableContainer {
-  // TODO: Any erasure shouldn't use generic parameter metadata.
-  func doesntUseGenericParam(_ x: T, _ y: T.Type) { // expected-error{{cannot access the class's generic parameters}}
-    _ = type(of: x).init(fur: x).other() // expected-note{{here}}
+  func doesntUseGenericParam(_ x: T, _ y: T.Type) {
+    _ = type(of: x).init(fur: x).other()
     _ = type(of: x).adopt().other()
     _ = y.init(fur: x).other()
     _ = y.adopt().other()

--- a/test/ClangModules/objc_bridging_generics.swift
+++ b/test/ClangModules/objc_bridging_generics.swift
@@ -221,6 +221,33 @@ extension AnimalContainer {
     _ = x
   }
 
+  // Doesn't use 'T', since dynamic casting to an ObjC generic class doesn't
+  // check its generic parameters
+  func doesntUseGenericParam7() {
+    _ = (self as AnyObject) as! GenericClass<T>
+    _ = (self as AnyObject) as? GenericClass<T>
+    _ = (self as AnyObject) as! AnimalContainer<T>
+    _ = (self as AnyObject) as? AnimalContainer<T>
+    _ = (self as AnyObject) is AnimalContainer<T>
+    _ = (self as AnyObject) is AnimalContainer<T>
+  }
+
+  // Dynamic casting to the generic parameter would require its generic params,
+  // though
+  // expected-error@+1{{extension of a generic Objective-C class cannot access the class's generic parameters}}
+  func usesGenericParamZ1() {
+    _ = (self as AnyObject) as! T //expected-note{{here}}
+  }
+  // expected-error@+1{{extension of a generic Objective-C class cannot access the class's generic parameters}}
+  func usesGenericParamZ2() {
+    _ = (self as AnyObject) as? T //expected-note{{here}}
+  }
+  // expected-error@+1{{extension of a generic Objective-C class cannot access the class's generic parameters}}
+  func usesGenericParamZ3() {
+    _ = (self as AnyObject) is T //expected-note{{here}}
+  }
+
+
   // expected-error@+1{{extension of a generic Objective-C class cannot access the class's generic parameters}}
   func usesGenericParamA(_ x: T) {
     _ = T(noise: x) // expected-note{{used here}}

--- a/test/ClangModules/objc_bridging_generics.swift
+++ b/test/ClangModules/objc_bridging_generics.swift
@@ -212,6 +212,17 @@ extension AnimalContainer {
     y.apexPredator = x
   }
 
+  func doesntUseGenericParam5(y: T) {
+    var x = y
+    x = y
+    _ = x
+  }
+  func doesntUseGenericParam6(y: T?) {
+    var x = y
+    x = y
+    _ = x
+  }
+
   // expected-error@+1{{extension of a generic Objective-C class cannot access the class's generic parameters}}
   func usesGenericParamA(_ x: T) {
     _ = T(noise: x) // expected-note{{used here}}

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -2,6 +2,7 @@
 // REQUIRES: objc_interop
 
 import Foundation
+import objc_generics
 
 protocol P {}
 protocol CP: class {}
@@ -497,4 +498,14 @@ class IndexForAnySubscript {}
 func dynamicLookup(x: AnyObject) {
   _ = x.anyProperty
   _ = x[IndexForAnySubscript()]
+}
+
+extension GenericClass {
+  // CHECK-LABEL: sil hidden @_TFE17objc_bridging_anyCSo12GenericClass23pseudogenericAnyErasurefT1xx_P_
+  func pseudogenericAnyErasure(x: T) -> Any {
+    // CHECK: [[ANY_BUF:%.*]] = init_existential_addr %0 : $*Any, $AnyObject
+    // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref %1 : $T : $T, $AnyObject
+    // CHECK: store [[ANYOBJECT]] to [[ANY_BUF]]
+    return x
+  }
 }


### PR DESCRIPTION
`id`-as-`Any` regressed some ObjC generic extensions, since going from a generic `T` to `Any` naively would require the type metadata of `T`. Since `T` is always class-constrained currently, we can avoid this by erasing the type to `AnyObject` and building an `Any` around it instead. There are also some cases where we unnecessarily raised the error on assignments and dynamic casts, preventing some workarounds for cases we don't yet support.
