### PR TITLE
Provide the '@escaping' fix-it for any call-site escaping mismatch.

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3664,17 +3664,13 @@ static bool tryDiagnoseNonEscapingParameterToEscaping(Expr *expr, Type srcType,
   // Need to be referencing a parameter of function type
   auto declRef = dyn_cast<DeclRefExpr>(expr);
   if (!declRef || !isa<ParamDecl>(declRef->getDecl()) ||
-      !declRef->getType()->is<FunctionType>())
+      !declRef->getType()->is<AnyFunctionType>())
     return false;
 
   // Must be from non-escaping function to escaping function
-  auto srcFT = srcType->getAs<FunctionType>();
-  auto destFT = dstType->getAs<FunctionType>();
+  auto srcFT = srcType->getAs<AnyFunctionType>();
+  auto destFT = dstType->getAs<AnyFunctionType>();
   if (!srcFT || !destFT || !srcFT->isNoEscape() || destFT->isNoEscape())
-    return false;
-
-  // Function types must be equivalent modulo @escaping, @convention, etc.
-  if (!destFT->isEqual(srcFT->withExtInfo(destFT->getExtInfo())))
     return false;
 
   // Pick a specific diagnostic for the specific use

--- a/test/attr/attr_escaping.swift
+++ b/test/attr/attr_escaping.swift
@@ -71,3 +71,24 @@ func callEscapingAutoclosureWithNoEscape_3(_ fn: @autoclosure () -> Int) {
 }
 
 
+func takesEscapingGeneric<T>(_ fn: @escaping () -> T) {}
+func callEscapingGeneric<T>(_ fn: () -> T) { // expected-note {{parameter 'fn' is implicitly non-escaping}} {{35-35=@escaping }}
+  takesEscapingGeneric(fn) // expected-error {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
+}
+
+
+class Super {}
+class Sub: Super {}
+
+func takesEscapingSuper(_ fn: @escaping () -> Super) {}
+func callEscapingSuper(_ fn: () -> Sub) { // expected-note {{parameter 'fn' is implicitly non-escaping}} {{30-30=@escaping }}
+  takesEscapingSuper(fn) // expected-error {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
+}
+
+func takesEscapingSuperGeneric<T: Super>(_ fn: @escaping () -> T) {}
+func callEscapingSuperGeneric(_ fn: () -> Sub) { // expected-note {{parameter 'fn' is implicitly non-escaping}} {{37-37=@escaping }}
+  takesEscapingSuperGeneric(fn) // expected-error {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
+}
+func callEscapingSuperGeneric<T: Sub>(_ fn: () -> T) { // expected-note {{parameter 'fn' is implicitly non-escaping}} {{45-45=@escaping }}
+  takesEscapingSuperGeneric(fn) // expected-error {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
+}


### PR DESCRIPTION
- **Explanation:** Broadens an existing fix-it to apply whenever two function types mismatch on `@escaping`, even if they have nothing else in common.
- **Scope:** Affects diagnostics only, only kicks in when there's a mismatch on `@escaping`.
- **Issue:** rdar://problem/27729540
- **Reviewed by:** @milseman 
- **Risk:** Low.
- **Testing:** Added new compiler regression tests.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
