### PR TITLE
rdar://problem/26867815 Prevent crashes when accessing ObjC generic members

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -267,8 +267,8 @@ static bool isTypeErasedGenericClassType(CanType type) {
 }
 
 // Get the type that exists at runtime to represent a compile-time type.
-static CanType
-getRuntimeReifiedType(IRGenModule &IGM, CanType type) {
+CanType
+irgen::getRuntimeReifiedType(IRGenModule &IGM, CanType type) {
   return CanType(type.transform([&](Type t) -> Type {
     if (isTypeErasedGenericClassType(CanType(t))) {
       return t->getAnyNominal()->getDeclaredType()->getCanonicalType();

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -85,6 +85,10 @@ namespace irgen {
                                                    CanType type,
                                                    SymbolReferenceKind refKind);
 
+  /// Get the type as it exists in Swift's runtime type system, removing any
+  /// erased generic parameters.
+  CanType getRuntimeReifiedType(IRGenModule &IGM, CanType type);
+
   /// Emit a reference to a compile-time constant piece of heap metadata, or
   /// return a null pointer if the type's heap metadata cannot be represented
   /// by a constant.

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -747,8 +747,10 @@ public:
     // Force all archetypes referenced by the type to be bound by this point.
     // TODO: just make sure that we have a path to them that the debug info
     //       can follow.
-    if (!IGM.IRGen.Opts.Optimize && Ty.getType()->hasArchetype())
-      Ty.getType()->getCanonicalType().visit([&](Type t) {
+    auto runtimeTy = getRuntimeReifiedType(IGM,
+                                           Ty.getType()->getCanonicalType());
+    if (!IGM.IRGen.Opts.Optimize && runtimeTy->hasArchetype())
+      runtimeTy.visit([&](Type t) {
         if (auto archetype = dyn_cast<ArchetypeType>(CanType(t)))
           emitTypeMetadataRef(archetype);
        });

--- a/test/ClangModules/objc_bridging_generics.swift
+++ b/test/ClangModules/objc_bridging_generics.swift
@@ -265,6 +265,14 @@ extension AnimalContainer {
     T.apexPredator = x // expected-note{{used here}}
   }
 
+  // rdar://problem/27796375 -- allocating init entry points for ObjC
+  // initializers are generated as true Swift generics, so reify type
+  // parameters.
+  // expected-error@+1{{extension of a generic Objective-C class cannot access the class's generic parameters}}
+  func usesGenericParamE(_ x: T) {
+    _ = GenericClass(thing: x) // expected-note{{used here}}
+  }
+
   func checkThatMethodsAreObjC() {
     _ = #selector(AnimalContainer.doesntUseGenericParam1)
     _ = #selector(AnimalContainer.doesntUseGenericParam2)
@@ -283,9 +291,11 @@ extension AnimalContainer {
 
 extension PettableContainer {
   func doesntUseGenericParam(_ x: T, _ y: T.Type) {
-    _ = type(of: x).init(fur: x).other()
+    // TODO: rdar://problem/27796375--allocating entry points are emitted as
+    // true generics.
+    // _ = type(of: x).init(fur: x).other()
     _ = type(of: x).adopt().other()
-    _ = y.init(fur: x).other()
+    // _ = y.init(fur: x).other()
     _ = y.adopt().other()
     x.pet()
     x.pet(with: x)

--- a/test/IRGen/objc_generic_class_debug_info.swift
+++ b/test/IRGen/objc_generic_class_debug_info.swift
@@ -1,0 +1,13 @@
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -emit-ir -g -verify
+
+// REQUIRES: objc_interop
+
+import Swift
+import Foundation
+import objc_generics
+
+extension GenericClass {
+  func method() {}
+  class func classMethod() {}
+}


### PR DESCRIPTION
Two problems:
- Emitting debug info for ObjC generic class instances in ObjC extension contexts would attempt to emit debug info for type parameters that don't really exist at runtime.
- We currently emit initializers as true generics, even if they come from Objective-C (rdar://problem/27796375), but would fail to diagnose uses of them from ObjC generic extensions, leading to IRGen crashes when we try to call them with nonexistent metadata. There are some tradeoffs and code that would break if we changed this that are out of scope for Swift 3, so for now diagnose uses of initializers from within ObjC generic extensions.
