### PR TITLE
SIL: add the self-parameter to the list of type-dependent operands if…

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -941,8 +941,9 @@ public:
   DynamicMethodInst *createDynamicMethod(SILLocation Loc, SILValue Operand,
                                          SILDeclRef Member, SILType MethodTy,
                                          bool Volatile = false) {
-    return insert(new (F.getModule()) DynamicMethodInst(
-        getSILDebugLocation(Loc), Operand, Member, MethodTy, Volatile));
+    return insert(DynamicMethodInst::create(
+        getSILDebugLocation(Loc), Operand, Member, MethodTy, Volatile,
+        &F, OpenedArchetypes));
   }
 
   OpenExistentialAddrInst *

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -221,9 +221,9 @@ public:
   void doPreProcess(SILInstruction *Orig) {
     // Extend the set of available opened archetypes by the opened archetypes
     // used by the instruction being cloned.
-    auto OpenedArchetypeOperands = Orig->getOpenedArchetypeOperands();
+    auto TypeDependentOperands = Orig->getTypeDependentOperands();
     Builder.getOpenedArchetypes().addOpenedArchetypeOperands(
-        OpenedArchetypeOperands);
+        TypeDependentOperands);
   }
 
   void doPostProcess(SILInstruction *Orig, SILInstruction *Cloned) {

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -270,6 +270,7 @@ public:
     {
       setInsertionPoint(SC.getBuilder().getInsertionBB(),
                         SC.getBuilder().getInsertionPoint());
+      setOpenedArchetypesTracker(SC.getBuilder().getOpenedArchetypesTracker());
     }
 
   ~SILBuilderWithPostProcess() {

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -169,33 +169,52 @@ public:
   /// Return the array of operands for this instruction.
   ArrayRef<Operand> getAllOperands() const;
 
-  /// Return the array of opened archetype operands for this instruction.
-  ArrayRef<Operand> getOpenedArchetypeOperands() const;
+  /// Return the array of type dependent operands for this instruction.
+  ///
+  /// Type dependent operands are hidden operands, i.e. not part of the SIL
+  /// syntax (although they are printed as "type-defs" in comments).
+  /// Their purpose is to establish a def-use relationship between
+  ///   -) an instruction/argument which defines a type, e.g. open_existential
+  /// and
+  ///   -) this instruction, which uses the type, but doesn't use the defining
+  ///      instruction as value-operand, e.g. a type in the substitution list.
+  ///
+  /// Currently there are two kinds of type dependent operands:
+  ///
+  /// 1. for opened archetypes:
+  ///     %o = open_existential_addr %0 : $*P to $*@opened("UUID") P
+  ///     %w = witness_method $@opened("UUID") P, ... // type-defs: %o
+  ///
+  /// 2. for the dynamic self argument:
+  ///     sil @foo : $@convention(method) (@thick X.Type) {
+  ///     bb0(%0 : $@thick X.Type):
+  ///       %a = apply %f<@dynamic_self X>() ... // type-defs: %0
+  ///
+  /// The type dependent operands are just there to let optimizations know that
+  /// there is a dependency between the instruction/argument which defines the
+  /// type and the instruction which uses the type.
+  ArrayRef<Operand> getTypeDependentOperands() const;
 
   /// Return the array of mutable operands for this instruction.
   MutableArrayRef<Operand> getAllOperands();
 
-  /// Return the array of opened archetypes operands for this instruction.
-  MutableArrayRef<Operand> getOpenedArchetypeOperands();
-
-  /// Returns true if a given kind of instruction may have opened archetype
-  /// operands.
-  bool mayHaveOpenedArchetypeOperands() const;
+  /// Return the array of mutable type depedent operands for this instruction.
+  MutableArrayRef<Operand> getTypeDependentOperands();
 
   unsigned getNumOperands() const { return getAllOperands().size(); }
 
-  unsigned getNumOpenedArchetypeOperands() const {
-    return getOpenedArchetypeOperands().size();
+  unsigned getNumTypeDependentOperands() const {
+    return getTypeDependentOperands().size();
   }
 
-  bool isOpenedArchetypeOperand(unsigned i) const {
-    return i >= getNumOperands() - getNumOpenedArchetypeOperands();
+  bool isTypeDependentOperand(unsigned i) const {
+    return i >= getNumOperands() - getNumTypeDependentOperands();
   }
 
-  bool isOpenedArchetypeOperand(Operand &O) const {
+  bool isTypeDependentOperand(Operand &O) const {
     assert(O.getUser() == this &&
            "Operand does not belong to a SILInstruction");
-    return isOpenedArchetypeOperand(O.getOperandNumber());
+    return isTypeDependentOperand(O.getOperandNumber());
   }
 
   SILValue getOperand(unsigned Num) const {
@@ -375,15 +394,11 @@ public:
   ArrayRef<Operand> getAllOperands() const { return Operands.asArray(); }
   MutableArrayRef<Operand> getAllOperands() { return Operands.asArray(); }
 
-  bool hasOpenedArchetypeOperands() const {
-    return false;
-  }
-
-  ArrayRef<Operand> getOpenedArchetypeOperands() const {
+  ArrayRef<Operand> getTypeDependentOperands() const {
     return {};
   }
 
-  MutableArrayRef<Operand> getOpenedArchetypeOperands() {
+  MutableArrayRef<Operand> getTypeDependentOperands() {
     return {};
   }
 
@@ -393,14 +408,14 @@ public:
 };
 
 /// A template base class for instructions that take a single regular SILValue
-/// operand, a set of opened archetypes operands and has no result
+/// operand, a set of type dependent operands and has no result
 /// or a single value result. The operands are tail allocated after the
 /// instruction. Further trailing data can be allocated as well if
 /// TRAILING_TYPES are provided.
 template<ValueKind KIND, typename DERIVED,
          typename BASE, bool HAS_RESULT,
          typename... TRAILING_TYPES>
-class UnaryInstructionWithOpenArchetypesBase :
+class UnaryInstructionWithTypeDependentOperandsBase :
   public BASE,
   protected llvm::TrailingObjects<DERIVED, Operand, TRAILING_TYPES...> {
 
@@ -420,12 +435,12 @@ protected:
   using TrailingBase::totalSizeToAlloc;
 
   // Total number of operands of this instruction.
-  // It is number of opened archetype operands + 1.
+  // It is number of type dependent operands + 1.
   unsigned NumOperands;
 
 public:
   // Destruct tail allocated objects.
-  ~UnaryInstructionWithOpenArchetypesBase() {
+  ~UnaryInstructionWithTypeDependentOperandsBase() {
     Operand *Operands = &getAllOperands()[0];
     for (unsigned i = 0, end = NumOperands; i < end; ++i) {
       Operands[i].~Operand();
@@ -437,40 +452,40 @@ public:
     return NumOperands;
   }
 
-  UnaryInstructionWithOpenArchetypesBase(
+  UnaryInstructionWithTypeDependentOperandsBase(
       SILDebugLocation DebugLoc, SILValue Operand,
-      ArrayRef<SILValue> OpenedArchetypeOperands)
-      : BASE(KIND, DebugLoc), NumOperands(1 + OpenedArchetypeOperands.size()) {
+      ArrayRef<SILValue> TypeDependentOperands)
+      : BASE(KIND, DebugLoc), NumOperands(1 + TypeDependentOperands.size()) {
     TrailingOperandsList::InitOperandsList(getAllOperands().begin(), this,
-                                           Operand, OpenedArchetypeOperands);
+                                           Operand, TypeDependentOperands);
   }
 
   template <typename X = void>
-  UnaryInstructionWithOpenArchetypesBase(
+  UnaryInstructionWithTypeDependentOperandsBase(
       SILDebugLocation DebugLoc, SILValue Operand,
-      ArrayRef<SILValue> OpenedArchetypeOperands,
+      ArrayRef<SILValue> TypeDependentOperands,
       typename std::enable_if<has_result<X>::value, SILType>::type Ty)
       : BASE(KIND, DebugLoc, Ty),
-        NumOperands(1 + OpenedArchetypeOperands.size())
+        NumOperands(1 + TypeDependentOperands.size())
   {
     TrailingOperandsList::InitOperandsList(getAllOperands().begin(), this,
-                                           Operand, OpenedArchetypeOperands);
+                                           Operand, TypeDependentOperands);
   }
 
   template <typename X = void, typename... A>
-  UnaryInstructionWithOpenArchetypesBase(
+  UnaryInstructionWithTypeDependentOperandsBase(
       SILDebugLocation DebugLoc, SILValue Operand,
-      ArrayRef<SILValue> OpenedArchetypeOperands,
+      ArrayRef<SILValue> TypeDependentOperands,
       typename std::enable_if<has_result<X>::value, SILType>::type Ty,
       A &&... args)
       : BASE(KIND, DebugLoc, Ty, std::forward<A>(args)...),
-        NumOperands(1 + OpenedArchetypeOperands.size())
+        NumOperands(1 + TypeDependentOperands.size())
   {
     TrailingOperandsList::InitOperandsList(getAllOperands().begin(), this,
-                                           Operand, OpenedArchetypeOperands);
+                                           Operand, TypeDependentOperands);
   }
 
-  unsigned getNumOpenedArchetypeOperands() const {
+  unsigned getNumTypeDependentOperands() const {
     return NumOperands - 1;
   }
 
@@ -494,15 +509,11 @@ public:
             static_cast<size_t>(NumOperands)};
   }
 
-  bool hasOpenedArchetypeOperands() const {
-    return NumOperands > 1;
-  }
-
-  ArrayRef<Operand> getOpenedArchetypeOperands() const {
+  ArrayRef<Operand> getTypeDependentOperands() const {
     return getAllOperands().slice(1);
   }
 
-  MutableArrayRef<Operand> getOpenedArchetypeOperands() {
+  MutableArrayRef<Operand> getTypeDependentOperands() {
     return getAllOperands().slice(1);
   }
 
@@ -604,7 +615,7 @@ class AllocStackInst final
   TailAllocatedDebugVariable VarInfo;
 
   AllocStackInst(SILDebugLocation Loc, SILType elementType,
-                 ArrayRef<SILValue> OpenedArchetypeOperands,
+                 ArrayRef<SILValue> TypeDependentOperands,
                  SILFunction &F,
                  SILDebugVariable Var);
 
@@ -649,11 +660,11 @@ public:
     return { getTrailingObjects<Operand>(), NumOperands };
   }
 
-  ArrayRef<Operand> getOpenedArchetypeOperands() const {
+  ArrayRef<Operand> getTypeDependentOperands() const {
     return getAllOperands();
   }
 
-  MutableArrayRef<Operand> getOpenedArchetypeOperands() {
+  MutableArrayRef<Operand> getTypeDependentOperands() {
     return getAllOperands();
   }
 
@@ -675,7 +686,7 @@ class AllocRefInst final
   bool ObjC : 1;
 
   AllocRefInst(SILDebugLocation Loc, SILType type, SILFunction &F, bool objc,
-               bool canBeOnStack, ArrayRef<SILValue> OpenedArchetypeOperands);
+               bool canBeOnStack, ArrayRef<SILValue> TypeDependentOperands);
 
   static AllocRefInst *create(SILDebugLocation Loc, SILType type,
                               SILFunction &F, bool objc, bool canBeOnStack,
@@ -697,11 +708,11 @@ public:
     return { getTrailingObjects<Operand>(), NumOperands };
   }
 
-  ArrayRef<Operand> getOpenedArchetypeOperands() const {
+  ArrayRef<Operand> getTypeDependentOperands() const {
     return getAllOperands();
   }
 
-  MutableArrayRef<Operand> getOpenedArchetypeOperands() {
+  MutableArrayRef<Operand> getTypeDependentOperands() {
     return getAllOperands();
   }
 
@@ -718,7 +729,7 @@ public:
 /// the given metatype value. Aside from the reference count, the
 /// instance is returned uninitialized.
 class AllocRefDynamicInst final
-    : public UnaryInstructionWithOpenArchetypesBase<
+    : public UnaryInstructionWithTypeDependentOperandsBase<
                                   ValueKind::AllocRefDynamicInst,
                                   AllocRefDynamicInst,
                                   AllocationInst,
@@ -728,7 +739,7 @@ class AllocRefDynamicInst final
   bool ObjC;
 
   AllocRefDynamicInst(SILDebugLocation DebugLoc, SILValue operand,
-                      ArrayRef<SILValue> OpenedArchetypeOperands, SILType ty,
+                      ArrayRef<SILValue> TypeDependentOperands, SILType ty,
                       bool objc);
 
   static AllocRefDynamicInst *
@@ -742,7 +753,7 @@ public:
 
 /// AllocValueBufferInst - Allocate memory in a value buffer.
 class AllocValueBufferInst final
-    : public UnaryInstructionWithOpenArchetypesBase<
+    : public UnaryInstructionWithTypeDependentOperandsBase<
                                   ValueKind::AllocValueBufferInst,
                                   AllocValueBufferInst,
                                   AllocationInst,
@@ -751,7 +762,7 @@ class AllocValueBufferInst final
 
   AllocValueBufferInst(SILDebugLocation DebugLoc, SILType valueType,
                        SILValue operand,
-                       ArrayRef<SILValue> OpenedArchetypeOperands);
+                       ArrayRef<SILValue> TypeDependentOperands);
 
   static AllocValueBufferInst *
   create(SILDebugLocation DebugLoc, SILType valueType, SILValue operand,
@@ -778,7 +789,7 @@ class AllocBoxInst final
   TailAllocatedDebugVariable VarInfo;
 
   AllocBoxInst(SILDebugLocation DebugLoc, SILType ElementType,
-               ArrayRef<SILValue> OpenedArchetypeOperands, SILFunction &F,
+               ArrayRef<SILValue> TypeDependentOperands, SILFunction &F,
                SILDebugVariable Var);
 
   static AllocBoxInst *create(SILDebugLocation Loc, SILType elementType,
@@ -820,11 +831,11 @@ public:
     return {getTrailingObjects<Operand>(), NumOperands};
   }
 
-  ArrayRef<Operand> getOpenedArchetypeOperands() const {
+  ArrayRef<Operand> getTypeDependentOperands() const {
     return getAllOperands();
   }
 
-  MutableArrayRef<Operand> getOpenedArchetypeOperands() {
+  MutableArrayRef<Operand> getTypeDependentOperands() {
     return getAllOperands();
   }
 
@@ -850,7 +861,7 @@ class AllocExistentialBoxInst final
   AllocExistentialBoxInst(SILDebugLocation DebugLoc, SILType ExistentialType,
                           CanType ConcreteType,
                           ArrayRef<ProtocolConformanceRef> Conformances,
-                          ArrayRef<SILValue> OpenedArchetypeOperands,
+                          ArrayRef<SILValue> TypeDependentOperands,
                           SILFunction *Parent);
 
   static AllocExistentialBoxInst *
@@ -882,11 +893,11 @@ public:
     return {getTrailingObjects<Operand>(), NumOperands};
   }
 
-  ArrayRef<Operand> getOpenedArchetypeOperands() const {
+  ArrayRef<Operand> getTypeDependentOperands() const {
     return getAllOperands();
   }
 
-  MutableArrayRef<Operand> getOpenedArchetypeOperands() {
+  MutableArrayRef<Operand> getTypeDependentOperands() {
     return getAllOperands();
   }
 
@@ -942,12 +953,12 @@ protected:
   ApplyInstBase(ValueKind kind, SILDebugLocation DebugLoc, SILValue callee,
                 SILType substCalleeType, ArrayRef<Substitution> substitutions,
                 ArrayRef<SILValue> args,
-                ArrayRef<SILValue> openedArchetypesOperands,
+                ArrayRef<SILValue> TypeDependentOperands,
                 As... baseArgs)
       : Base(kind, DebugLoc, baseArgs...), SubstCalleeType(substCalleeType),
         NumSubstitutions(substitutions.size()), NonThrowing(false),
         NumCallArguments(args.size()),
-        Operands(this, args, openedArchetypesOperands, callee) {
+        Operands(this, args, TypeDependentOperands, callee) {
     static_assert(sizeof(Impl) == sizeof(*this),
         "subclass has extra storage, cannot use TailAllocatedOperandList");
     memcpy(getSubstitutionsStorage(), substitutions.begin(),
@@ -956,11 +967,11 @@ protected:
 
   static void *allocate(SILFunction &F,
                         ArrayRef<Substitution> substitutions,
-                        ArrayRef<SILValue> openedArchetypesOperands,
+                        ArrayRef<SILValue> TypeDependentOperands,
                         ArrayRef<SILValue> args) {
     return allocateApplyInst(
         F, sizeof(Impl) + decltype(Operands)::getExtraSize(
-                              args.size() + openedArchetypesOperands.size()) +
+                              args.size() + TypeDependentOperands.size()) +
                sizeof(substitutions[0]) * substitutions.size(),
         alignof(Impl));
   }
@@ -1071,15 +1082,11 @@ public:
     return NumCallArguments;
   }
 
-  bool hasOpenedArchetypeOperands() const {
-    return getAllOperands().size() - 1 - getNumCallArguments() != 0;
-  }
-
-  ArrayRef<Operand> getOpenedArchetypeOperands() const {
+  ArrayRef<Operand> getTypeDependentOperands() const {
     return Operands.getDynamicAsArray().slice(NumCallArguments);
   }
 
-  MutableArrayRef<Operand> getOpenedArchetypeOperands() {
+  MutableArrayRef<Operand> getTypeDependentOperands() {
     return Operands.getDynamicAsArray().slice(NumCallArguments);
   }
 };
@@ -1212,7 +1219,7 @@ class ApplyInst : public ApplyInstBase<ApplyInst, SILInstruction> {
             SILType SubstCalleeType, SILType ReturnType,
             ArrayRef<Substitution> Substitutions,
             ArrayRef<SILValue> Args,
-            ArrayRef<SILValue> OpenedArchetypeOperands,
+            ArrayRef<SILValue> TypeDependentOperands,
             bool isNonThrowing);
 
   static ApplyInst *create(SILDebugLocation DebugLoc, SILValue Callee,
@@ -1244,7 +1251,7 @@ class PartialApplyInst
                    SILType SubstCalleeType,
                    ArrayRef<Substitution> Substitutions,
                    ArrayRef<SILValue> Args,
-                   ArrayRef<SILValue> OpenedArchetypeOperands,
+                   ArrayRef<SILValue> TypeDependentOperands,
                    SILType ClosureType);
 
   static PartialApplyInst *create(SILDebugLocation DebugLoc, SILValue Callee,
@@ -2081,7 +2088,7 @@ class BindMemoryInst final :
 
   BindMemoryInst(SILDebugLocation Loc, SILValue Base, SILValue Index,
                  SILType BoundType,
-                 ArrayRef<SILValue> OpenedArchetypeOperands);
+                 ArrayRef<SILValue> TypeDependentOperands);
 
 public:
   // Destruct tail allocated objects.
@@ -2114,11 +2121,11 @@ public:
             static_cast<size_t>(NumOperands)};
   }
 
-  ArrayRef<Operand> getOpenedArchetypeOperands() const {
+  ArrayRef<Operand> getTypeDependentOperands() const {
     return getAllOperands().slice(2);
   }
 
-  MutableArrayRef<Operand> getOpenedArchetypeOperands() {
+  MutableArrayRef<Operand> getTypeDependentOperands() {
     return getAllOperands().slice(2);
   }
 
@@ -2231,7 +2238,7 @@ public:
 /// Convert a heap object reference to a different type without any runtime
 /// checks.
 class UncheckedRefCastInst final
-  : public UnaryInstructionWithOpenArchetypesBase<
+  : public UnaryInstructionWithTypeDependentOperandsBase<
                                 ValueKind::UncheckedRefCastInst,
                                 UncheckedRefCastInst,
                                 ConversionInst,
@@ -2240,9 +2247,9 @@ class UncheckedRefCastInst final
   friend class SILBuilder;
 
   UncheckedRefCastInst(SILDebugLocation DebugLoc, SILValue Operand,
-                       ArrayRef<SILValue> OpenedArchetypeOperands, SILType Ty)
-      : UnaryInstructionWithOpenArchetypesBase(DebugLoc, Operand,
-                                               OpenedArchetypeOperands, Ty) {}
+                       ArrayRef<SILValue> TypeDependentOperands, SILType Ty)
+      : UnaryInstructionWithTypeDependentOperandsBase(DebugLoc, Operand,
+                                               TypeDependentOperands, Ty) {}
   static UncheckedRefCastInst *
   create(SILDebugLocation DebugLoc, SILValue Operand, SILType Ty,
          SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes);
@@ -2291,7 +2298,7 @@ public:
 };
 
 class UncheckedAddrCastInst final
-  : public UnaryInstructionWithOpenArchetypesBase<
+  : public UnaryInstructionWithTypeDependentOperandsBase<
                                 ValueKind::UncheckedAddrCastInst,
                                 UncheckedAddrCastInst,
                                 ConversionInst,
@@ -2300,9 +2307,9 @@ class UncheckedAddrCastInst final
   friend class SILBuilder;
 
   UncheckedAddrCastInst(SILDebugLocation DebugLoc, SILValue Operand,
-                        ArrayRef<SILValue> OpenedArchetypeOperands, SILType Ty)
-      : UnaryInstructionWithOpenArchetypesBase(DebugLoc, Operand,
-                                               OpenedArchetypeOperands, Ty) {}
+                        ArrayRef<SILValue> TypeDependentOperands, SILType Ty)
+      : UnaryInstructionWithTypeDependentOperandsBase(DebugLoc, Operand,
+                                               TypeDependentOperands, Ty) {}
   static UncheckedAddrCastInst *
   create(SILDebugLocation DebugLoc, SILValue Operand, SILType Ty,
          SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes);
@@ -2310,7 +2317,7 @@ class UncheckedAddrCastInst final
 
 /// Convert a value's binary representation to a trivial type of the same size.
 class UncheckedTrivialBitCastInst final
-  : public UnaryInstructionWithOpenArchetypesBase<
+  : public UnaryInstructionWithTypeDependentOperandsBase<
                                 ValueKind::UncheckedTrivialBitCastInst,
                                 UncheckedTrivialBitCastInst,
                                 ConversionInst,
@@ -2319,10 +2326,10 @@ class UncheckedTrivialBitCastInst final
   friend class SILBuilder;
 
   UncheckedTrivialBitCastInst(SILDebugLocation DebugLoc, SILValue Operand,
-                              ArrayRef<SILValue> OpenedArchetypeOperands,
+                              ArrayRef<SILValue> TypeDependentOperands,
                               SILType Ty)
-      : UnaryInstructionWithOpenArchetypesBase(DebugLoc, Operand,
-                                               OpenedArchetypeOperands, Ty) {}
+      : UnaryInstructionWithTypeDependentOperandsBase(DebugLoc, Operand,
+                                               TypeDependentOperands, Ty) {}
 
   static UncheckedTrivialBitCastInst *
   create(SILDebugLocation DebugLoc, SILValue Operand, SILType Ty,
@@ -2331,7 +2338,7 @@ class UncheckedTrivialBitCastInst final
   
 /// Bitwise copy a value into another value of the same size or smaller.
 class UncheckedBitwiseCastInst final
-  : public UnaryInstructionWithOpenArchetypesBase<
+  : public UnaryInstructionWithTypeDependentOperandsBase<
                                 ValueKind::UncheckedBitwiseCastInst,
                                 UncheckedBitwiseCastInst,
                                 ConversionInst,
@@ -2340,10 +2347,10 @@ class UncheckedBitwiseCastInst final
   friend class SILBuilder;
 
   UncheckedBitwiseCastInst(SILDebugLocation DebugLoc, SILValue Operand,
-                           ArrayRef<SILValue> OpenedArchetypeOperands,
+                           ArrayRef<SILValue> TypeDependentOperands,
                            SILType Ty)
-      : UnaryInstructionWithOpenArchetypesBase(DebugLoc, Operand,
-                                               OpenedArchetypeOperands, Ty) {}
+      : UnaryInstructionWithTypeDependentOperandsBase(DebugLoc, Operand,
+                                               TypeDependentOperands, Ty) {}
   static UncheckedBitwiseCastInst *
   create(SILDebugLocation DebugLoc, SILValue Operand, SILType Ty,
          SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes);
@@ -2573,7 +2580,7 @@ class IsNonnullInst : public UnaryInstructionBase<ValueKind::IsNonnullInst> {
 
 /// Perform an unconditional checked cast that aborts if the cast fails.
 class UnconditionalCheckedCastInst final
-  : public UnaryInstructionWithOpenArchetypesBase<
+  : public UnaryInstructionWithTypeDependentOperandsBase<
                                 ValueKind::UnconditionalCheckedCastInst,
                                 UnconditionalCheckedCastInst,
                                 ConversionInst,
@@ -2582,10 +2589,10 @@ class UnconditionalCheckedCastInst final
   friend class SILBuilder;
 
   UnconditionalCheckedCastInst(SILDebugLocation DebugLoc, SILValue Operand,
-                               ArrayRef<SILValue> OpenedArchetypeOperands,
+                               ArrayRef<SILValue> TypeDependentOperands,
                                SILType DestTy)
-      : UnaryInstructionWithOpenArchetypesBase(DebugLoc, Operand,
-                                               OpenedArchetypeOperands,
+      : UnaryInstructionWithTypeDependentOperandsBase(DebugLoc, Operand,
+                                               TypeDependentOperands,
                                                DestTy) {}
 
   static UnconditionalCheckedCastInst *
@@ -3271,7 +3278,7 @@ class MetatypeInst final
 
   /// Constructs a MetatypeInst
   MetatypeInst(SILDebugLocation DebugLoc, SILType Metatype,
-               ArrayRef<SILValue> OpenedArchetypeOperands);
+               ArrayRef<SILValue> TypeDependentOperands);
 
   static MetatypeInst *create(SILDebugLocation DebugLoc, SILType Metatype,
                               SILFunction *F,
@@ -3293,11 +3300,11 @@ public:
     return { getTrailingObjects<Operand>(), NumOperands };
   }
 
-  ArrayRef<Operand> getOpenedArchetypeOperands() const {
+  ArrayRef<Operand> getTypeDependentOperands() const {
     return { getTrailingObjects<Operand>(), NumOperands };
   }
 
-  MutableArrayRef<Operand> getOpenedArchetypeOperands() {
+  MutableArrayRef<Operand> getTypeDependentOperands() {
     return { getTrailingObjects<Operand>(), NumOperands };
   }
 
@@ -3550,14 +3557,14 @@ class WitnessMethodInst final
 
   WitnessMethodInst(SILDebugLocation DebugLoc, CanType LookupType,
                     ProtocolConformanceRef Conformance, SILDeclRef Member,
-                    SILType Ty, ArrayRef<SILValue> OpenedArchetypeOperands,
+                    SILType Ty, ArrayRef<SILValue> TypeDependentOperands,
                     bool Volatile = false)
       : MethodInst(ValueKind::WitnessMethodInst, DebugLoc, Ty, Member,
                    Volatile),
         LookupType(LookupType), Conformance(Conformance),
-        NumOperands(OpenedArchetypeOperands.size()) {
+        NumOperands(TypeDependentOperands.size()) {
     TrailingOperandsList::InitOperandsList(getAllOperands().begin(), this,
-                                           OpenedArchetypeOperands);
+                                           TypeDependentOperands);
   }
 
   static WitnessMethodInst *
@@ -3596,11 +3603,11 @@ public:
     return { getTrailingObjects<Operand>(), NumOperands };
   }
 
-  ArrayRef<Operand> getOpenedArchetypeOperands() const {
+  ArrayRef<Operand> getTypeDependentOperands() const {
     return { getTrailingObjects<Operand>(), NumOperands };
   }
 
-  MutableArrayRef<Operand> getOpenedArchetypeOperands() {
+  MutableArrayRef<Operand> getTypeDependentOperands() {
     return { getTrailingObjects<Operand>(), NumOperands };
   }
 
@@ -3613,14 +3620,25 @@ public:
 /// constant referring to some Objective-C method, performs dynamic method
 /// lookup to extract the implementation of that method. This method lookup
 /// can fail at run-time
-class DynamicMethodInst
-  : public UnaryInstructionBase<ValueKind::DynamicMethodInst, MethodInst>
+class DynamicMethodInst final
+  : public UnaryInstructionWithTypeDependentOperandsBase<
+                                   ValueKind::DynamicMethodInst,
+                                   DynamicMethodInst,
+                                   MethodInst,
+                                   true>
 {
   friend class SILBuilder;
 
   DynamicMethodInst(SILDebugLocation DebugLoc, SILValue Operand,
-                    SILDeclRef Member, SILType Ty, bool Volatile = false)
-      : UnaryInstructionBase(DebugLoc, Operand, Ty, Member, Volatile) {}
+                    ArrayRef<SILValue> TypeDependentOperands,
+                    SILDeclRef Member, SILType Ty, bool Volatile)
+      : UnaryInstructionWithTypeDependentOperandsBase(DebugLoc, Operand,
+                               TypeDependentOperands, Ty, Member, Volatile) {}
+
+  static DynamicMethodInst *
+  create(SILDebugLocation DebugLoc, SILValue Operand,
+         SILDeclRef Member, SILType Ty, bool Volatile, SILFunction *F,
+         SILOpenedArchetypesState &OpenedArchetypes);
 };
 
 /// Given the address of an existential, "opens" the
@@ -3677,7 +3695,7 @@ class OpenExistentialBoxInst
 /// value of the given type, and returns the address of the uninitialized
 /// concrete value inside the existential container.
 class InitExistentialAddrInst final
-  : public UnaryInstructionWithOpenArchetypesBase<
+  : public UnaryInstructionWithTypeDependentOperandsBase<
                                 ValueKind::InitExistentialAddrInst,
                                 InitExistentialAddrInst,
                                 SILInstruction,
@@ -3689,11 +3707,11 @@ class InitExistentialAddrInst final
   ArrayRef<ProtocolConformanceRef> Conformances;
 
   InitExistentialAddrInst(SILDebugLocation DebugLoc, SILValue Existential,
-                          ArrayRef<SILValue> OpenedArchetypeOperands,
+                          ArrayRef<SILValue> TypeDependentOperands,
                           CanType ConcreteType, SILType ConcreteLoweredType,
                           ArrayRef<ProtocolConformanceRef> Conformances)
-      : UnaryInstructionWithOpenArchetypesBase(DebugLoc, Existential,
-                             OpenedArchetypeOperands,
+      : UnaryInstructionWithTypeDependentOperandsBase(DebugLoc, Existential,
+                             TypeDependentOperands,
                              ConcreteLoweredType.getAddressType()),
         ConcreteType(ConcreteType), Conformances(Conformances) {}
 
@@ -3721,7 +3739,7 @@ public:
 /// conformances, creates a class existential value referencing the
 /// class instance.
 class InitExistentialRefInst final
-  : public UnaryInstructionWithOpenArchetypesBase<
+  : public UnaryInstructionWithTypeDependentOperandsBase<
                                 ValueKind::InitExistentialRefInst,
                                 InitExistentialRefInst,
                                 SILInstruction,
@@ -3734,10 +3752,10 @@ class InitExistentialRefInst final
 
   InitExistentialRefInst(SILDebugLocation DebugLoc, SILType ExistentialType,
                          CanType FormalConcreteType, SILValue Instance,
-                         ArrayRef<SILValue> OpenedArchetypeOperands,
+                         ArrayRef<SILValue> TypeDependentOperands,
                          ArrayRef<ProtocolConformanceRef> Conformances)
-      : UnaryInstructionWithOpenArchetypesBase(DebugLoc, Instance,
-                                               OpenedArchetypeOperands,
+      : UnaryInstructionWithTypeDependentOperandsBase(DebugLoc, Instance,
+                                               TypeDependentOperands,
                                                ExistentialType),
         ConcreteType(FormalConcreteType), Conformances(Conformances) {}
 
@@ -3763,7 +3781,7 @@ public:
 /// of conformances, creates an existential metatype value referencing
 /// the metatype.
 class InitExistentialMetatypeInst final
-  : public UnaryInstructionWithOpenArchetypesBase<
+  : public UnaryInstructionWithTypeDependentOperandsBase<
                                   ValueKind::InitExistentialMetatypeInst,
                                   InitExistentialMetatypeInst,
                                   SILInstruction,
@@ -3777,7 +3795,7 @@ class InitExistentialMetatypeInst final
   InitExistentialMetatypeInst(SILDebugLocation DebugLoc,
                               SILType existentialMetatypeType,
                               SILValue metatype,
-                              ArrayRef<SILValue> OpenedArchetypeOperands,
+                              ArrayRef<SILValue> TypeDependentOperands,
                               ArrayRef<ProtocolConformanceRef> conformances);
 
   static InitExistentialMetatypeInst *
@@ -4835,7 +4853,7 @@ public:
 /// The success branch destination block receives the cast result as a BB
 /// argument.
 class CheckedCastBranchInst final:
-  public UnaryInstructionWithOpenArchetypesBase<
+  public UnaryInstructionWithTypeDependentOperandsBase<
                               ValueKind::CheckedCastBranchInst,
                               CheckedCastBranchInst,
                               TermInst,
@@ -4849,11 +4867,11 @@ class CheckedCastBranchInst final:
 
   CheckedCastBranchInst(SILDebugLocation DebugLoc, bool IsExact,
                         SILValue Operand,
-                        ArrayRef<SILValue> OpenedArchetypeOperands,
+                        ArrayRef<SILValue> TypeDependentOperands,
                         SILType DestTy,
                         SILBasicBlock *SuccessBB, SILBasicBlock *FailureBB)
-      : UnaryInstructionWithOpenArchetypesBase(DebugLoc, Operand,
-                                               OpenedArchetypeOperands),
+      : UnaryInstructionWithTypeDependentOperandsBase(DebugLoc, Operand,
+                                               TypeDependentOperands),
         DestTy(DestTy), IsExact(IsExact),
         DestBBs{{this, SuccessBB}, {this, FailureBB}} {}
 
@@ -4982,7 +5000,7 @@ class TryApplyInst
   TryApplyInst(SILDebugLocation DebugLoc, SILValue callee,
                SILType substCalleeType, ArrayRef<Substitution> substitutions,
                ArrayRef<SILValue> args,
-               ArrayRef<SILValue> openedArchetypesOperands,
+               ArrayRef<SILValue> TypeDependentOperands,
                SILBasicBlock *normalBB, SILBasicBlock *errorBB);
 
   static TryApplyInst *create(SILDebugLocation DebugLoc, SILValue callee,

--- a/include/swift/SILOptimizer/Utils/Local.h
+++ b/include/swift/SILOptimizer/Utils/Local.h
@@ -154,7 +154,7 @@ bool hasDynamicSelfTypes(ArrayRef<Substitution> Subs);
 
 /// \brief Return true if any call inside the given function may bind dynamic
 /// 'Self' to a generic argument of the callee.
-bool computeMayBindDynamicSelf(SILFunction *F);
+bool mayBindDynamicSelf(SILFunction *F);
 
 /// \brief Move an ApplyInst's FuncRef so that it dominates the call site.
 void placeFuncRef(ApplyInst *AI, DominanceInfo *DT);

--- a/lib/SIL/SILOpenedArchetypesTracker.cpp
+++ b/lib/SIL/SILOpenedArchetypesTracker.cpp
@@ -87,13 +87,13 @@ void SILOpenedArchetypesTracker::registerUsedOpenedArchetypes(
     const SILInstruction *I) {
   assert((!I->getParent() || I->getFunction() == &F) &&
          "Instruction does not belong to a proper SILFunction");
-  for (auto &Op : I->getOpenedArchetypeOperands()) {
+  for (auto &Op : I->getTypeDependentOperands()) {
     auto OpenedArchetypeDef = Op.get();
-    assert(isa<SILInstruction>(OpenedArchetypeDef) &&
-           "typedef operand should refer to a SILInstruction");
-    addOpenedArchetypeDef(
-        getOpenedArchetypeOf(cast<SILInstruction>(OpenedArchetypeDef)),
-        OpenedArchetypeDef);
+    if (auto *DefInst = dyn_cast<SILInstruction>(OpenedArchetypeDef)) {
+      addOpenedArchetypeDef(
+          getOpenedArchetypeOf(cast<SILInstruction>(OpenedArchetypeDef)),
+          OpenedArchetypeDef);
+    }
   }
 }
 

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -663,7 +663,7 @@ isNonmutatingCapture(SILArgument *BoxArg) {
 static bool
 isNonescapingUse(Operand *O, SmallVectorImpl<SILInstruction*> &Mutations) {
   auto *U = O->getUser();
-  if (U->isOpenedArchetypeOperand(*O))
+  if (U->isTypeDependentOperand(*O))
     return true;
   // Marking the boxed value as escaping is OK. It's just a DI annotation.
   if (isa<MarkFunctionEscapeInst>(U))

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -774,9 +774,9 @@ getConformanceAndConcreteType(FullApplySite AI,
   }
 
   if (ConcreteType->isOpenedExistential()) {
-    assert(!InitExistential->getOpenedArchetypeOperands().empty() &&
+    assert(!InitExistential->getTypeDependentOperands().empty() &&
            "init_existential is supposed to have a typedef operand");
-    ConcreteTypeDef = InitExistential->getOpenedArchetypeOperands()[0].get();
+    ConcreteTypeDef = InitExistential->getTypeDependentOperands()[0].get();
   }
 
   // Find the conformance for the protocol we're interested in.

--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -358,7 +358,7 @@ public:
                               X->getMember().getHashCode(),
                               X->getConformance(),
                               X->getType(),
-                              !X->getOpenedArchetypeOperands().empty(),
+                              !X->getTypeDependentOperands().empty(),
                               llvm::hash_combine_range(
                               Operands.begin(),
                               Operands.end()));
@@ -645,7 +645,7 @@ bool CSE::processOpenExistentialRef(SILInstruction *Inst, ValueBase *V,
   // that need to be replaced.
   for (auto Use : Inst->getUses()) {
     auto User = Use->getUser();
-    if (User->mayHaveOpenedArchetypeOperands()) {
+    if (!User->getTypeDependentOperands().empty()) {
       if (canHandle(User)) {
         auto It = AvailableValues->begin(User);
         if (It != AvailableValues->end()) {
@@ -685,7 +685,7 @@ bool CSE::processOpenExistentialRef(SILInstruction *Inst, ValueBase *V,
   // by a dominating one.
   for (auto Candidate : Candidates) {
     Builder.getOpenedArchetypes().addOpenedArchetypeOperands(
-        Candidate->getOpenedArchetypeOperands());
+        Candidate->getTypeDependentOperands());
     Builder.setInsertionPoint(Candidate);
     auto NewI = Cloner.clone(Candidate);
     Candidate->replaceAllUsesWith(NewI);
@@ -884,7 +884,7 @@ static ApplyWitnessPair getOpenExistentialUsers(OpenExistentialAddrInst *OE) {
   for (auto *UI : getNonDebugUses(OE)) {
     auto *User = UI->getUser();
     if (!isa<WitnessMethodInst>(User) &&
-        User->isOpenedArchetypeOperand(UI->getOperandNumber()))
+        User->isTypeDependentOperand(UI->getOperandNumber()))
       continue;
     // Check that we have a single Apply user.
     if (auto *AA = dyn_cast<ApplyInst>(User)) {

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -123,9 +123,6 @@ class FunctionSignatureTransform {
   /// will use during our optimization.
   llvm::SmallVector<ResultDescriptor, 4> &ResultDescList;
 
-  /// May dynamically bind to self.
-  bool MayDynamicBindSelf;
-
   /// Does this function have a caller inside current module
   bool hasCaller;
 
@@ -134,12 +131,6 @@ class FunctionSignatureTransform {
 
   /// Return a function type based on ArgumentDescList and ResultDescList.
   CanSILFunctionType createOptimizedSILFunctionType();
-
-  // This implicitly asserts that a function binding dynamic self has a 
-  // self metadata argument or object from which self metadata can be obtained.
-  bool isArgumentABIRequired(SILArgument *Arg) {
-    return MayDynamicBindSelf && (F->getSelfMetadataArgument() == Arg);
-  }
 
 private:
   /// ----------------------------------------------------------///
@@ -241,7 +232,7 @@ public:
                              llvm::SmallVector<ResultDescriptor, 4> &RDL)
     : F(F), NewF(nullptr), PM(PM), AA(AA), RCIA(RCIA), FM(FM),
       AIM(AIM), shouldModifySelfArgument(false), ArgumentDescList(ADL),
-      ResultDescList(RDL), MayDynamicBindSelf(computeMayBindDynamicSelf(F)),
+      ResultDescList(RDL),
       hasCaller(hasCaller) {}
 
   /// Return the optimized function.
@@ -526,13 +517,11 @@ bool FunctionSignatureTransform::DeadArgumentAnalyzeParameters() {
     }
 
     // Check whether argument is dead.
-    A.IsEntirelyDead = true;
-    A.IsEntirelyDead &= !isArgumentABIRequired(Args[i]);
-    A.IsEntirelyDead &= !hasNonTrivialNonDebugUse(Args[i]); 
-    SignatureOptimize |= A.IsEntirelyDead;
-
-    if (A.IsEntirelyDead && Args[i]->isSelf()) {
-      shouldModifySelfArgument = true;
+    if (!hasNonTrivialNonDebugUse(Args[i])) {
+      A.IsEntirelyDead = true;
+      SignatureOptimize = true;
+      if (Args[i]->isSelf())
+        shouldModifySelfArgument = true;
     }
   }
   return SignatureOptimize;

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -1128,7 +1128,7 @@ SILFunction *SILPerformanceInliner::getEligibleFunction(FullApplySite AI) {
 
   // We don't support inlining a function that binds dynamic self because we
   // have no mechanism to preserve the original function's local self metadata.
-  if (computeMayBindDynamicSelf(Callee)) {
+  if (mayBindDynamicSelf(Callee)) {
     // Check if passed Self is the same as the Self of the caller.
     // In this case, it is safe to inline because both functions
     // use the same Self.

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -521,7 +521,7 @@ void SILSerializer::writeOneTypeOneOperandLayout(ValueKind valueKind,
 /// Write an instruction that looks exactly like a conversion: all
 /// important information is encoded in the operand and the result type.
 void SILSerializer::writeConversionLikeInstruction(const SILInstruction *I) {
-  assert(I->getNumOperands() - I->getOpenedArchetypeOperands().size() == 1);
+  assert(I->getNumOperands() - I->getTypeDependentOperands().size() == 1);
   writeOneTypeOneOperandLayout(I->getKind(), 0, I->getType(),
                                I->getOperand(0));
 }
@@ -1170,7 +1170,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     break;
   }
   case ValueKind::PointerToAddressInst: {
-    assert(SI.getNumOperands() - SI.getOpenedArchetypeOperands().size() == 1);
+    assert(SI.getNumOperands() - SI.getTypeDependentOperands().size() == 1);
     unsigned attrs = cast<PointerToAddressInst>(SI).isStrict() ? 1 : 0;
     writeOneTypeOneOperandLayout(SI.getKind(), attrs, SI.getType(),
                                  SI.getOperand(0));

--- a/test/SIL/Parser/self.sil
+++ b/test/SIL/Parser/self.sil
@@ -14,7 +14,7 @@ class SelfTest {}
 
 sil_vtable SelfTest {}
 
-sil @test_stuff : $@convention(thin) (@owned SelfTest) -> () {
+sil @test_stuff : $@convention(method) (@owned SelfTest) -> () {
 bb0(%0 : $SelfTest):
   // CHECK: metatype $@thick @dynamic_self SelfTest
   %2 = metatype $@thick @dynamic_self SelfTest.Type

--- a/test/SIL/type_dependent_operands.swift
+++ b/test/SIL/type_dependent_operands.swift
@@ -1,0 +1,60 @@
+// RUN: %target-swift-frontend -O -primary-file %s -emit-sil | %FileCheck %s
+
+
+// Test opened types
+
+protocol P {
+  func foo()
+}
+
+// CHECK-LABEL: sil {{.*}} @{{.*}}test_open_existential
+// CHECK: [[E:%[0-9]+]] = open_existential_addr %0
+// CHECK: [[W:%[0-9]+]] = witness_method $@opened{{.*}} [[E]] {{.*}} // type-defs: [[E]]
+// CHECK: apply [[W]]<@opened{{.*}} // type-defs: [[E]]
+// CHECK: return
+@inline(__always)
+func test_open_existential(p: P) {
+  p.foo()
+}
+
+// Check if after inlining (= cloning) everything is still okay.
+
+// CHECK-LABEL: sil {{.*}} @{{.*}}call_open_existential
+// CHECK: [[E:%[0-9]+]] = open_existential_addr %0
+// CHECK: [[W:%[0-9]+]] = witness_method $@opened{{.*}} [[E]] {{.*}} // type-defs: [[E]]
+// CHECK: apply [[W]]<@opened{{.*}} // type-defs: [[E]]
+// CHECK: return
+func call_open_existential(p: P) {
+  test_open_existential(p: p)
+}
+
+
+// Test dynamic self
+
+func idfunc<T>(_ t: T) -> T {
+  return t
+}
+
+final class X {
+// CHECK-LABEL: sil {{.*}} @{{.*}}test_dynself
+// CHECK: bb0(%0 : $@thick X.Type):
+// CHECK: apply %{{[0-9]+}}<@dynamic_self X>({{.*}} // type-defs: %0
+// CHECK: return
+  @inline(__always)
+  class func test_dynself() -> Self {
+    return idfunc(self.init())
+  }
+
+// Check if after inlining (= cloning) everything is still okay.
+
+// CHECK-LABEL: sil {{.*}} @{{.*}}call_dynself
+// CHECK: bb0(%0 : $@thick X.Type):
+// CHECK: apply %{{[0-9]+}}<@dynamic_self X>({{.*}} // type-defs: %0
+// CHECK: return
+  class func call_dynself() -> Self {
+    return test_dynself()
+  }
+
+  required init() { }
+}
+


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

… an instruction uses the dynamic-self type.

This establishes a real def-use relation from the self-parameter to any instruction which uses the dynamic-self type.
This is an addition to what was already done for opened archetypes.
The biggest part of this commit is to rename "OpenedArchetypeOperands" to "TypeDependentOperands" as this name is now more appropriate.

Other than that the change includes:
*) type-dependent operands are now printed after a SIL instruction in a comment as "type-defs:" (for debugging)
*) FuncationSignatureOpts doesn't need to explicitly check if a function doesn't bind dynamic self to remove a dead self metadata argument
*) the check if a function binds dynamic self (used in the inliner) is much simpler now
*) also collect type-dependent operands for ApplyInstBase::SubstCalleeType and not only in the substitution list
*) with this SILInstruction::mayHaveOpenedArchetypeOperands (used in CSE) is not needed anymore and removed
*) fixed a bug in the cloner: SILBuilderWithPostProcess now inherits the OpenedArchetypesTracker from it's original builder
*) add type dependent operands to dynamic_method instruction

Regarding the generated code it should be a NFC.
