### PR TITLE
[swiftc (48 vs. 5156)] Add crasher in swift::Expr::propagateLValueAccessKind(...)

### DIFF
--- a/validation-test/compiler_crashers/28395-swift-expr-propagatelvalueaccesskind.swift
+++ b/validation-test/compiler_crashers/28395-swift-expr-propagatelvalueaccesskind.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+{guard let b=.h.h=.n?(){


### PR DESCRIPTION
Add test case for crash triggered in `swift::Expr::propagateLValueAccessKind(...)`.

Current number of unresolved compiler crashers: 48 (5156 resolved)

Stack trace:

```
6  swift           0x00000000032eaf5d llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) + 461
8  swift           0x0000000001113fc7 swift::Expr::propagateLValueAccessKind(swift::AccessKind, bool) + 23
12 swift           0x000000000109a27c swift::Expr::walk(swift::ASTWalker&) + 108
13 swift           0x0000000000f6d412 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 514
14 swift           0x0000000000ec44da swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 778
17 swift           0x0000000000f8c17d swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 7021
18 swift           0x0000000000f90a3e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4078
19 swift           0x0000000000ebd469 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 857
20 swift           0x0000000000ec443d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 621
21 swift           0x0000000000ec55f0 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 352
22 swift           0x0000000000ec6335 swift::TypeChecker::typeCheckStmtCondition(llvm::MutableArrayRef<swift::StmtConditionElement>&, swift::DeclContext*, swift::Diag<>) + 373
26 swift           0x0000000000f409a4 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
27 swift           0x0000000000f6d57c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
28 swift           0x0000000000ec44da swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 778
30 swift           0x0000000000f40ae6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
31 swift           0x0000000000efb40d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
32 swift           0x0000000000c7b5b9 swift::CompilerInstance::performSema() + 3289
34 swift           0x00000000007db487 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
35 swift           0x00000000007a72b8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28395-swift-expr-propagatelvalueaccesskind.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28395-swift-expr-propagatelvalueaccesskind-943db0.o
1.  While type-checking expression at [validation-test/compiler_crashers/28395-swift-expr-propagatelvalueaccesskind.swift:9:1 - line:9:24] RangeText="{guard let b=.h.h=.n?(){"
2.  While type-checking expression at [validation-test/compiler_crashers/28395-swift-expr-propagatelvalueaccesskind.swift:9:14 - line:9:23] RangeText=".h.h=.n?()"
3.  While type-checking expression at [validation-test/compiler_crashers/28395-swift-expr-propagatelvalueaccesskind.swift:9:14 - line:9:23] RangeText=".h.h=.n?()"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
