### PR TITLE
[FixCode] Accept the fixit for the warning that @warn_unused_result is the default now.

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -636,6 +636,7 @@ private:
         Info.ID == diag::selector_literal_deprecated_suggest.ID ||
         Info.ID == diag::attr_noescape_deprecated.ID ||
         Info.ID == diag::attr_autoclosure_escaping_deprecated.ID ||
+        Info.ID == diag::attr_warn_unused_result_removed.ID ||
         Info.ID == diag::any_as_anyobject_fixit.ID ||
         Info.ID == diag::deprecated_protocol_composition.ID ||
         Info.ID == diag::deprecated_protocol_composition_single.ID ||

--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -233,6 +233,8 @@ func testescape(rec: ()->()) {
   fnWithClosure { rec() }
 }
 
+@warn_unused_result func testDeprecatedAttr() -> Int { return 0 }
+
 protocol Prot1 {}
 protocol Prot2 {
   associatedtype Ty = Prot1

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -236,6 +236,8 @@ func testescape(rec: @escaping ()->()) {
   fnWithClosure { rec() }
 }
 
+func testDeprecatedAttr() -> Int { return 0 }
+
 protocol Prot1 {}
 protocol Prot2 {
   associatedtype Ty = Prot1


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

Accept the fixit for the warning that @warn_unused_result is the default now. Useful for migration.
Very safe change, only affects fixit mode used when migrating.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

rdar://27516354

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
