### PR TITLE
[FixCode] Disable a migrating fixit that interacts badly with the migrator.

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -598,6 +598,13 @@ private:
     if (Info.ID == diag::objc_witness_selector_mismatch.ID ||
         Info.ID == diag::witness_non_objc.ID)
       return false;
+    // This interacts badly with the migrator. For such code:
+    //   func test(p: Int, _: String) {}
+    //   test(0, "")
+    // the compiler bizarrely suggests to change order of arguments in the call
+    // site.
+    if (Info.ID == diag::argument_out_of_order_unnamed_unnamed.ID)
+      return false;
     // The following interact badly with the swift migrator by removing @IB*
     // attributes when there is some unrelated type issue.
     if (Info.ID == diag::invalid_iboutlet.ID ||

--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -256,3 +256,6 @@ func testProtocolCompositionSyntax() {
   var _: protocol<Prot1>
   var _: protocol<Prot1, Prot2>
 }
+
+func disable_unnamed_param_reorder(p: Int, _: String) {}
+disable_unnamed_param_reorder(0, "") // no change.

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -259,3 +259,6 @@ func testProtocolCompositionSyntax() {
   var _: Prot1
   var _: Prot1 & Prot2
 }
+
+func disable_unnamed_param_reorder(p: Int, _: String) {}
+disable_unnamed_param_reorder(0, "") // no change.


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

For such code:

```
      func test(p: Int, _: String) {}
      test(0, "")
```

the compiler bizarrely suggests to change order of arguments in the call site.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

rdar://27709722

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
