### PR TITLE
[FixCode] Add @escaping when overriding mismatch is because of it.

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1191,8 +1191,8 @@ bool swift::fixItOverrideDeclarationTypes(TypeChecker &TC,
     // Fix-it needs position to apply.
     if (typeRange.isInvalid())
       return false;
-    auto overrideFnTy = overrideTy->getAs<FunctionType>();
-    auto baseFnTy = baseTy->getAs<FunctionType>();
+    auto overrideFnTy = overrideTy->getAs<AnyFunctionType>();
+    auto baseFnTy = baseTy->getAs<AnyFunctionType>();
 
     // Both types should be function.
     if (overrideFnTy && baseFnTy &&

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1191,20 +1191,15 @@ bool swift::fixItOverrideDeclarationTypes(TypeChecker &TC,
     // Fix-it needs position to apply.
     if (typeRange.isInvalid())
       return false;
-    auto overrideFnTy = overrideTy->getCanonicalType()->getAs<FunctionType>();
-    auto baseFnTy = baseTy->getCanonicalType()->getAs<FunctionType>();
+    auto overrideFnTy = overrideTy->getAs<FunctionType>();
+    auto baseFnTy = baseTy->getAs<FunctionType>();
 
     // Both types should be function.
     if (overrideFnTy && baseFnTy &&
-        // Both function types should have same input/result types.
-        overrideFnTy->getInput()->isEqual(baseFnTy->getInput()) &&
-        overrideFnTy->getResult()->isEqual(baseFnTy->getResult()) &&
         // The overriding function type should be no escaping.
         overrideFnTy->getExtInfo().isNoEscape() &&
         // The overriden function type should be escaping.
-        !baseFnTy->getExtInfo().isNoEscape() &&
-        // Being escaping or not should be the only difference.
-        baseFnTy->getExtInfo().withNoEscape() == overrideFnTy->getExtInfo()) {
+        !baseFnTy->getExtInfo().isNoEscape()) {
       diag.fixItInsert(typeRange.Start, "@escaping ");
       return true;
     }

--- a/test/Constraints/override.swift
+++ b/test/Constraints/override.swift
@@ -12,3 +12,13 @@ func removeOverrides<SomeSub: Sub>(concrete: Sub, generic: SomeSub) {
   _ = concrete.foo()
   _ = generic.foo()
 }
+
+class Base1 {
+	func foo1(a : Int, b : @escaping ()->()) {} // expected-note{{potential overridden instance method 'foo1(a:b:)' here}}
+	func foo2(a : @escaping (Int)->(Int), b : @escaping ()->()) {} // expected-note{{potential overridden instance method 'foo2(a:b:)' here}}
+}
+
+class Sub1 : Base1 {
+	override func foo1(a : Int, b : ()->()) {} // expected-error {{method does not override any method from its superclass}} expected-note {{type does not match superclass instance method with type '(Int, @escaping () -> ()) -> ()'}} {{34-34=@escaping }}
+	override func foo2(a : (Int)->(Int), b : ()->()) {} // expected-error {{method does not override any method from its superclass}} expected-note{{type does not match superclass instance method with type '(@escaping (Int) -> (Int), @escaping () -> ()) -> ()'}} {{25-25=@escaping }} {{43-43=@escaping }}
+}

--- a/test/attr/attr_autoclosure.swift
+++ b/test/attr/attr_autoclosure.swift
@@ -88,7 +88,7 @@ class Super {
 class Sub : Super {
   override func f1(_ x: @autoclosure(escaping)() -> ()) { }
     // expected-warning@-1{{@autoclosure(escaping) is deprecated; use @autoclosure @escaping instead}} {{26-47=@autoclosure @escaping }}
-  override func f2(_ x: @autoclosure () -> ()) { } // expected-error{{does not override any method}}
+  override func f2(_ x: @autoclosure () -> ()) { } // expected-error{{does not override any method}} // expected-note{{type does not match superclass instance method with type '(@autoclosure @escaping () -> ()) -> ()'}}
   override func f3(_ x: @autoclosure(escaping) () -> ()) { }  // expected-error{{does not override any method}}
     // expected-warning@-1{{@autoclosure(escaping) is deprecated; use @autoclosure @escaping instead}} {{26-47=@autoclosure @escaping }}
 }


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
- Explanation:  [FixCode] Add @escaping when overriding mismatch is because of it. 
  This fixit is migration-critical. With the change of default escaping behavior, users' existing code overriding objc functions may need to add @escaping to make the overriding match as before. This patch checks if an overriding mismatch is due to the lacking of @escaping and add it as a fixit.
- Scope: This issues new fixit and note about type mismatching in overriding checks. 
- Issue: rdar://problem/27814862
- Reviewed by: Pending
- Risk: Low

Testing: Added a new fix code test to ensure such fixit is not applied when it's dumped to a remap file.

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…4273)
- [FixCode] Add @escaping when overriding mismatch is because of it. rdar://27814862

With the change of default escaping behavior, users' existing code overriding
objc functions may need to add @escaping to make the overriding match as before. This
patch checks if an overriding mismatch is due to the lacking of @escaping and add
it as a fixit.
- [test] Update existing test. NFC
