### PR TITLE
Don't double-emit the source expression when erasing an archetype to Error

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -319,15 +319,13 @@ VarDecl *SILGenModule::getNSErrorRequirement(SILLocation loc) {
   return found;
 }
 
-ProtocolConformance *
+Optional<ProtocolConformanceRef>
 SILGenModule::getConformanceToBridgedStoredNSError(SILLocation loc, Type type) {
   auto proto = getBridgedStoredNSError(loc);
-  if (!proto) return nullptr;
+  if (!proto) return None;
 
   // Find the conformance to _BridgedStoredNSError.
-  auto result = SwiftModule->lookupConformance(type, proto, nullptr);
-  if (result) return result->getConcrete();
-  return nullptr;
+  return SwiftModule->lookupConformance(type, proto, nullptr);
 }
 
 ProtocolConformance *SILGenModule::getNSErrorConformanceToError() {

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -393,8 +393,8 @@ public:
 
   /// Find the conformance of the given Swift type to the
   /// _BridgedStoredNSError protocol.
-  ProtocolConformance *getConformanceToBridgedStoredNSError(SILLocation loc,
-                                                            Type type);
+  Optional<ProtocolConformanceRef>
+  getConformanceToBridgedStoredNSError(SILLocation loc, Type type);
 
   /// Retrieve the conformance of NSError to the Error protocol.
   ProtocolConformance *getNSErrorConformanceToError();

--- a/test/SILGen/objc_error.swift
+++ b/test/SILGen/objc_error.swift
@@ -15,7 +15,8 @@ func NSErrorError_erasure(_ x: NSError) -> Error {
 }
 
 // CHECK-LABEL: sil hidden @_TF10objc_error30NSErrorError_archetype_erasure
-// CHECK:         [[ERROR_TYPE:%.*]] = init_existential_ref %0 : $T : $T, $Error
+// CHECK:         [[T0:%.*]] = upcast %0 : $T to $NSError
+// CHECK:         [[ERROR_TYPE:%.*]] = init_existential_ref [[T0]] : $NSError : $NSError, $Error
 // CHECK:         return [[ERROR_TYPE]]
 func NSErrorError_archetype_erasure<T : NSError>(_ t: T) -> Error {
   return t
@@ -81,18 +82,14 @@ func testAcceptError(error: Error) {
 // CHECK-LABEL: sil hidden @_TF10objc_error16testProduceError
 func testProduceError() -> Error {
   // CHECK: function_ref @produceError : $@convention(c) () -> @autoreleased NSError
-  // CHECK-NOT: return
-  // CHECK: enum $Optional<NSError>, #Optional.some!enumelt.1
-  // CHECK-NOT: return
-  // CHECK: function_ref @swift_convertNSErrorToError
+  // CHECK: init_existential_ref {{.*}} : $NSError : $NSError, $Error
   return produceError()
 }
 
 // CHECK-LABEL: sil hidden @_TF10objc_error24testProduceOptionalError
 func testProduceOptionalError() -> Error? {
   // CHECK: function_ref @produceOptionalError
-  // CHECK-NOT: return
-  // CHECK: function_ref @swift_convertNSErrorToError
+  // CHECK: init_existential_ref {{.*}} : $NSError : $NSError, $Error
   return produceOptionalError();
 }
 
@@ -112,8 +109,7 @@ func eraseMyNSError() -> Error {
 // CHECK-LABEL: sil hidden @_TF10objc_error25eraseFictionalServerErrorFT_Ps5Error_
 func eraseFictionalServerError() -> Error {
   // CHECK-NOT: return
-  // CHECK: [[NSERROR_GETTER:%[0-9]+]] = function_ref @_TFVSC20FictionalServerErrorg8_nsErrorCSo7NSError
-  // CHECK: [[NSERROR:%[0-9]+]] = apply [[NSERROR_GETTER]]
+  // CHECK: [[NSERROR:%[0-9]+]] = struct_extract {{.*}} : $FictionalServerError, #FictionalServerError._nsError
   // CHECK: [[ERROR:%[0-9]+]] = init_existential_ref [[NSERROR]]
   // CHECK: return [[ERROR]]
   return FictionalServerError(.meltedDown)
@@ -124,21 +120,26 @@ extension Error {
   // CHECK-LABEL: sil hidden @_TFE10objc_errorPs5Error16convertToNSErrorfT_CSo7NSError
   // CHECK: bb0([[SELF:%[0-9]+]] : $*Self)
 	func convertToNSError() -> NSError {
+    // CHECK: [[COPY:%.*]] = alloc_stack $Self
+    // CHECK: copy_addr [[SELF]] to [initialization] [[COPY]]
+    // CHECK: [[COPY2:%.*]] = alloc_stack $Self
+    // CHECK: copy_addr [[COPY]] to [initialization] [[COPY2]]
     // CHECK: [[GET_EMBEDDED_FN:%[0-9]+]] = function_ref @swift_stdlib_getErrorEmbeddedNSError
-    // CHECK: [[EMBEDDED_RESULT_OPT:%[0-9]+]] = apply [[GET_EMBEDDED_FN]]
-    // CHECK: [[HAS_EMBEDDED_RESULT:%[0-9]+]] = select_enum [[EMBEDDED_RESULT_OPT]] : $Optional<AnyObject>
-    // CHECK: cond_br [[HAS_EMBEDDED_RESULT]], [[SUCCESS:bb[0-9]+]], [[FAILURE:bb[0-9]+]]
+    // CHECK: [[EMBEDDED_RESULT_OPT:%[0-9]+]] = apply [[GET_EMBEDDED_FN]]<Self>([[COPY2]])
+    // CHECK: switch_enum [[EMBEDDED_RESULT_OPT]] : $Optional<AnyObject>,
+    // CHECK-SAME: case #Optional.some!enumelt.1: [[SUCCESS:bb[0-9]+]],
+    // CHECK-SAME: case #Optional.none!enumelt: [[FAILURE:bb[0-9]+]]
 
-    // CHECK: [[SUCCESS]]:
-    // CHECK: [[EMBEDDED_RESULT:%[0-9]+]] = unchecked_enum_data [[EMBEDDED_RESULT_OPT]] : $Optional<AnyObject>, #Optional.some!enumelt.1
+    // CHECK: [[SUCCESS]]([[EMBEDDED_RESULT:%.*]] : $AnyObject):
     // CHECK: [[EMBEDDED_NSERROR:%[0-9]+]] = unchecked_ref_cast [[EMBEDDED_RESULT]] : $AnyObject to $NSError
     // CHECK: [[ERROR:%[0-9]+]] = init_existential_ref [[EMBEDDED_NSERROR]] : $NSError : $NSError, $Error
+    // CHECK: destroy_addr [[COPY]] : $*Self
     // CHECK: br [[CONTINUATION:bb[0-9]+]]([[ERROR]] : $Error)
 
     // CHECK: [[FAILURE]]:
     // CHECK: [[ERROR_BOX:%[0-9]+]] = alloc_existential_box $Error, $Self
     // CHECK: [[ERROR_PROJECTED:%[0-9]+]] = project_existential_box $Self in [[ERROR_BOX]] : $Error
-    // CHECK: copy_addr [[SELF]] to [initialization] [[ERROR_PROJECTED]] : $*Self
+    // CHECK: copy_addr [take] [[COPY]] to [initialization] [[ERROR_PROJECTED]] : $*Self
     // CHECK: br [[CONTINUATION]]([[ERROR_BOX]] : $Error)
 
     // CHECK: [[CONTINUATION]]([[ERROR_ARG:%[0-9]+]] : $Error):


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Don't double-emit the source expression when erasing an archetype to Error.

This is still a pretty bad code-generation pattern, but the layering
stuff makes it challenging to do the right thing.

Also, bridge non-optional NSErrors to Error using init_existential_ref
instead of going through the runtime function.

rdar://27810321
