### PR TITLE
Guard against racy access to NSError.setUserInfoValueProvider.

### DIFF
--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -136,6 +136,9 @@ public extension Error {
   }
 }
 
+internal let _errorDomainUserInfoProviderQueue = DispatchQueue(
+  label: "SwiftFoundation._errorDomainUserInfoProviderQueue")
+
 /// Retrieve the default userInfo dictionary for a given error.
 @_silgen_name("swift_Foundation_getErrorDefaultUserInfo")
 public func _swift_Foundation_getErrorDefaultUserInfo(_ error: Error)
@@ -149,7 +152,8 @@ public func _swift_Foundation_getErrorDefaultUserInfo(_ error: Error)
     // user-info value providers.
     let domain = error._domain
     if domain != NSCocoaErrorDomain {
-      if NSError.userInfoValueProvider(forDomain: domain) == nil {
+      _errorDomainUserInfoProviderQueue.sync {
+        if NSError.userInfoValueProvider(forDomain: domain) != nil { return }
         NSError.setUserInfoValueProvider(forDomain: domain) { (nsError, key) in
           let error = nsError as Error
 

--- a/validation-test/stdlib/ErrorProtocol.swift
+++ b/validation-test/stdlib/ErrorProtocol.swift
@@ -1,6 +1,5 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-// REQUIRES: rdar27541751
 // REQUIRES: objc_interop
 
 import SwiftPrivate


### PR DESCRIPTION
This API is documented in its headers to only allow being called once for a particular domain, so we have to make sure our check for an existing provider is synchronized with the setting.

rdar://problem/27541751

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
