### PR TITLE
SILGen: Don't pretend to handle ObjC APIs that "lie" about block return optionality.

### DIFF
--- a/test/SILGen/lying_about_optional_return_objc.swift
+++ b/test/SILGen/lying_about_optional_return_objc.swift
@@ -6,13 +6,13 @@ func optionalChainingForeignFunctionTypeProperties(b: BlockProperty?) {
   // CHECK: enum $Optional<()>, #Optional.some!enumelt.1, {{%.*}} : $()
   b?.readWriteBlock()
 
-  // CHECK: unchecked_bitwise_cast
+  // CHECK: enum $Optional
   _ = b?.readWriteBlock
 
   // CHECK: enum $Optional<()>, #Optional.some!enumelt.1, {{%.*}} : $()
   b?.readOnlyBlock()
 
-  // CHECK: unchecked_bitwise_cast
+  // CHECK: enum $Optional
   _ = b?.readOnlyBlock
 
   // CHECK: unchecked_trivial_bit_cast


### PR DESCRIPTION
If an ObjC API claims to return a nonnull object of a bridged type, such as blocks, then we're already screwed since we don't take that possibility into account when bridging to a Swift function. Attempting to peephole that case only generates broken code attempting to bitcast () -> () to Optional<() -> ()>, which is invalid due to the abstraction change between () -> () and Optional<T>. Fixes SR-2331.
