### PR TITLE
[3.0] SILGen: Don't pretend to handle ObjC APIs that "lie" about block return optionality.

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2251,12 +2251,28 @@ RValue RValueEmitter::visitRebindSelfInConstructorExpr(
   return SGF.emitEmptyTupleRValue(E, C);
 }
 
-static bool isNullableTypeInC(SILModule &M, Type ty) {
+static bool isVerbatimNullableTypeInC(SILModule &M, Type ty) {
   ty = ty->getLValueOrInOutObjectType()->getReferenceStorageReferent();
 
-  // Functions, class instances, and @objc existentials are all nullable.
-  if (ty->hasReferenceSemantics())
+  // Class instances, and @objc existentials are all nullable.
+  if (ty->hasReferenceSemantics()) {
+    // So are blocks, but we usually bridge them to Swift closures before we get
+    // a chance to check for optional promotion, so we're already screwed if
+    // an API lies about nullability.
+    if (auto fnTy = ty->getAs<AnyFunctionType>()) {
+      switch (fnTy->getRepresentation()) {
+      // Carried verbatim from C.
+      case FunctionTypeRepresentation::Block:
+      case FunctionTypeRepresentation::CFunctionPointer:
+        return true;
+      // Was already bridged.
+      case FunctionTypeRepresentation::Swift:
+      case FunctionTypeRepresentation::Thin:
+        return false;
+      }
+    }
     return true;
+  }
 
   // Other types like UnsafePointer can also be nullable.
   const DeclContext *DC = M.getAssociatedContext();
@@ -2287,7 +2303,7 @@ static bool mayLieAboutNonOptionalReturn(SILModule &M,
   // Functions that return non-optional reference type and were imported from
   // Objective-C.
   if (auto func = dyn_cast<FuncDecl>(decl)) {
-    assert((isNullableTypeInC(M, func->getResultType())
+    assert((isVerbatimNullableTypeInC(M, func->getResultType())
             || func->getResultType()->hasArchetype())
            && "func's result type is not nullable?!");
     return func->hasClangNode();
@@ -2296,7 +2312,7 @@ static bool mayLieAboutNonOptionalReturn(SILModule &M,
   // Computed properties of non-optional reference type that were imported from
   // Objective-C.
   if (auto var = dyn_cast<VarDecl>(decl)) {
-    assert((isNullableTypeInC(M, var->getType()->getReferenceStorageReferent())
+    assert((isVerbatimNullableTypeInC(M, var->getType()->getReferenceStorageReferent())
             || var->getType()->getReferenceStorageReferent()->hasArchetype())
            && "property's result type is not nullable?!");
     return var->hasClangNode();
@@ -2305,7 +2321,7 @@ static bool mayLieAboutNonOptionalReturn(SILModule &M,
   // Subscripts of non-optional reference type that were imported from
   // Objective-C.
   if (auto subscript = dyn_cast<SubscriptDecl>(decl)) {
-    assert((isNullableTypeInC(M, subscript->getElementType())
+    assert((isVerbatimNullableTypeInC(M, subscript->getElementType())
             || subscript->getElementType()->hasArchetype())
            && "subscript's result type is not nullable?!");
     return subscript->hasClangNode();
@@ -2329,7 +2345,7 @@ static bool mayLieAboutNonOptionalReturn(SILModule &M, Expr *expr) {
   // get the function we're calling.
   if (auto apply = dyn_cast<ApplyExpr>(expr)) {
     // The result has to be a nullable type.
-    if (!isNullableTypeInC(M, apply->getType()))
+    if (!isVerbatimNullableTypeInC(M, apply->getType()))
       return false;
     
     auto getFuncDeclFromDynamicMemberLookup = [&](Expr *expr) -> FuncDecl * {
@@ -2382,25 +2398,25 @@ static bool mayLieAboutNonOptionalReturn(SILModule &M, Expr *expr) {
 
   // A reference to a member property.
   if (auto member = dyn_cast<MemberRefExpr>(expr)) {
-    return isNullableTypeInC(M, member->getType()) &&
+    return isVerbatimNullableTypeInC(M, member->getType()) &&
       mayLieAboutNonOptionalReturn(M, member->getMember().getDecl());
   }
 
   // A reference to a subscript.
   if (auto subscript = dyn_cast<SubscriptExpr>(expr)) {
-    return isNullableTypeInC(M, subscript->getType()) &&
+    return isVerbatimNullableTypeInC(M, subscript->getType()) &&
       mayLieAboutNonOptionalReturn(M, subscript->getDecl().getDecl());
   }
 
   // A reference to a member property found via dynamic lookup.
   if (auto member = dyn_cast<DynamicMemberRefExpr>(expr)) {
-    return isNullableTypeInC(M, member->getType()) &&
+    return isVerbatimNullableTypeInC(M, member->getType()) &&
       mayLieAboutNonOptionalReturn(M, member->getMember().getDecl());
   }
 
   // A reference to a subscript found via dynamic lookup.
   if (auto subscript = dyn_cast<DynamicSubscriptExpr>(expr)) {
-    return isNullableTypeInC(M, subscript->getType()) &&
+    return isVerbatimNullableTypeInC(M, subscript->getType()) &&
       mayLieAboutNonOptionalReturn(M, subscript->getMember().getDecl());
   }
 

--- a/test/SILGen/lying_about_optional_return_objc.swift
+++ b/test/SILGen/lying_about_optional_return_objc.swift
@@ -6,13 +6,13 @@ func optionalChainingForeignFunctionTypeProperties(b: BlockProperty?) {
   // CHECK: enum $Optional<()>, #Optional.some!enumelt.1, {{%.*}} : $()
   b?.readWriteBlock()
 
-  // CHECK: unchecked_bitwise_cast
+  // CHECK: enum $Optional
   _ = b?.readWriteBlock
 
   // CHECK: enum $Optional<()>, #Optional.some!enumelt.1, {{%.*}} : $()
   b?.readOnlyBlock()
 
-  // CHECK: unchecked_bitwise_cast
+  // CHECK: enum $Optional
   _ = b?.readOnlyBlock
 
   // CHECK: unchecked_trivial_bit_cast


### PR DESCRIPTION
If an ObjC API claims to return a nonnull object of a bridged type, such
as blocks, then we're already screwed since we don't take that
possibility into account when bridging to a Swift function. Attempting
to peephole that case only generates broken code attempting to bitcast
() -> () to Optional<() -> ()>, which is invalid due to the abstraction
change between () -> () and Optional<T>. Fixes SR-2331.
