### PR TITLE
Fix UnsafeRawPointer.load to use Builtin.loadRaw.

### DIFF
--- a/stdlib/public/core/UnsafeRawPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawPointer.swift.gyb
@@ -367,7 +367,7 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
         & (UInt(MemoryLayout<T>.alignment) - 1)),
       "load from misaligned raw pointer")
 
-    return Builtin.load((self + offset)._rawValue)
+    return Builtin.loadRaw((self + offset)._rawValue)
   }
 
 %  if mutable:

--- a/test/SILGen/unsafe_pointer_gen.swift
+++ b/test/SILGen/unsafe_pointer_gen.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend -O -emit-sil -parse-as-library %s | %FileCheck %s
+
+// Test the absence of a 'strict' flag.
+// CHECK-LABEL: _TF18unsafe_pointer_gen13test_raw_loadFT2rpSV_Si
+// CHECK: pointer_to_address {{%.*}} : $Builtin.RawPointer to $*Int
+public func test_raw_load(rp: UnsafeRawPointer) -> Int {
+  return rp.load(as: Int.self)
+}


### PR DESCRIPTION
This API should have been converted to use the
new Builtin before it was introduced here:
commit a41484ea2bf090f4018d32695abbfd6be9a95acd
Author: Andrew Trick atrick@apple.com
Date:   Fri Jul 22 13:32:08 2016
    Add UnsafeRawPointer type and API. (#3677)

But it looks like that was dropped during during some local merge. It's not
likely to be a problem until developers start adopting the new API and the
optimizer starts using TBAA aggressively. The other "raw" API's are binding
memory or using memmove, so those are safe.

rdar:23406272.
