### PR TITLE
Targeted fix for pulling in Hashable conformance for Set and Dictionary (3.0)

### DIFF
--- a/test/IRGen/objc_generic_class_metadata.sil
+++ b/test/IRGen/objc_generic_class_metadata.sil
@@ -71,6 +71,11 @@ entry(%0: $Subclass):
   unreachable
 }
 
+sil @_TToFC27objc_generic_class_metadata8SubclasscfT7optionsGSqGVs10DictionaryVSC13GenericOptionP____GSQS0__ : $@convention(objc_method) (@owned Subclass, @owned NSDictionary) -> @owned Subclass {
+entry(%0: $Subclass, %1: $NSDictionary):
+  unreachable
+}
+
 // CHECK-LABEL: define linkonce_odr hidden %swift.type* @_TMaCSo12GenericClass()
 // CHECK:         [[T0:%.*]] = load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_GenericClass",
 // CHECK:         call %objc_class* @rt_swift_getInitializedObjCClass(%objc_class* [[T0]])

--- a/test/Inputs/clang-importer-sdk/usr/include/objc_generics.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/objc_generics.h
@@ -1,8 +1,18 @@
 #import <Foundation.h>
 
+#define _CF_TYPED_ENUM __attribute__((swift_wrapper(enum)))
+#define NS_STRING_ENUM _CF_TYPED_ENUM
+#define NS_SWIFT_NAME(Name) __attribute__((swift_name(#Name)))
+
+typedef NSString * GenericOption NS_STRING_ENUM;
+
+GenericOption const GenericOptionMultithreaded NS_SWIFT_NAME(multithreaded);
+
+
 @interface GenericClass<T> : NSObject
 - (id)initWithThing:(T)thing;
 - (id)initWithArrayOfThings:(NSArray<T> *__nonnull)things;
+- (id)initWithOptions:(nullable NSDictionary<GenericOption, id> *)options;
 - (void)dealloc;
 - (__nullable T)thing;
 - (int)count;

--- a/test/SILGen/objc_imported_generic.swift
+++ b/test/SILGen/objc_imported_generic.swift
@@ -103,5 +103,29 @@ func genericFunc<V: AnyObject>(_ v: V.Type) {
   }
 }
 
+// CHECK-LABEL: sil hidden @_TF21objc_imported_generic23configureWithoutOptionsFT_T_ : $@convention(thin) () -> ()
+// CHECK: [[NIL_FN:%.*]] = function_ref @_TFSqCfT10nilLiteralT__GSqx_ : $@convention(method) <τ_0_0> (@thin Optional<τ_0_0>.Type) -> @out Optional<τ_0_0>
+// CHECK: apply [[NIL_FN]]<[GenericOption : Any]>({{.*}})
+// CHECK: return
+func configureWithoutOptions() {
+  _ = GenericClass<NSObject>(options: nil)
+}
+
+// foreign to native thunk for init(options:), uses GenericOption : Hashable
+// conformance
+
+// CHECK-LABEL: sil shared [thunk] @_TTOFCSo12GenericClasscfT7optionsGSqGVs10DictionaryVSC13GenericOptionP____GSQGS_x__ : $@convention(method) <T where T : AnyObject> (@owned Optional<Dictionary<GenericOption, Any>>, @owned GenericClass<T>) -> @owned ImplicitlyUnwrappedOptional<GenericClass<T>>
+// CHECK: [[FN:%.*]] = function_ref @_TFE10FoundationVs10Dictionary19_bridgeToObjectiveCfT_CSo12NSDictionary : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned NSDictionary
+// CHECK: apply [[FN]]<GenericOption, Any>({{.*}}) : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned NSDictionary
+// CHECK: return
+
+// This gets emitted down here for some reason
+
 // CHECK-LABEL: sil shared [thunk] @_TTOFCSo12GenericClasscfT13arrayOfThings
 // CHECK:         class_method [volatile] {{%.*}} : $GenericClass<T>, #GenericClass.init!initializer.1.foreign {{.*}}, $@convention(objc_method) @pseudogeneric <τ_0_0 where τ_0_0 : AnyObject> (NSArray, @owned GenericClass<τ_0_0>) -> @owned ImplicitlyUnwrappedOptional<GenericClass<τ_0_0>>
+
+// Make sure we emitted the witness table for the above conformance
+
+// CHECK-LABEL: sil_witness_table shared [fragile] GenericOption: Hashable module objc_generics {
+// CHECK: method #Hashable.hashValue!getter.1: @_TTWVSC13GenericOptions8Hashable13objc_genericsFS0_g9hashValueSi
+// CHECK: }

--- a/validation-test/stdlib/SceneKit.swift
+++ b/validation-test/stdlib/SceneKit.swift
@@ -346,7 +346,7 @@ if #available(iOS 8.0, *) {
     let sceneData = sceneDescription.data(
       using: .utf8,
       allowLossyConversion: true)!
-    let sceneSource = SCNSceneSource(data: sceneData as Data, options: [:])!
+    let sceneSource = SCNSceneSource(data: sceneData as Data, options: nil)!
 
     do {
       var unarchivedPlaneGeometry =


### PR DESCRIPTION
- Explanation: Recent changes introducing `NS_STRING_ENUM` meant that we are now able to bridge dictionaries whose keys are imported types, namely stringly-typed enums. When bridging a `nil` value, nothing was forcing the conformance of the key type to the Hashable protocol to be emitted. So it was possible to hit a linker error due to an undefined symbol in this case.
- Scope: Affects anyone using frameworks with `NS_STRING_ENUM`s
- Risk: Low
- Testing: New test added, fails without the change and passes with
- Radar: rdar://problem/27470505
