### PR TITLE
[Swift 3.0] Endian fix for Strings in s390x

### DIFF
--- a/stdlib/public/core/StaticString.swift
+++ b/stdlib/public/core/StaticString.swift
@@ -132,7 +132,11 @@ public struct StaticString
       var buffer: UInt64 = 0
       var i = 0
       let sink: (UInt8) -> Void = {
+#if _endian(little)
         buffer = buffer | (UInt64($0) << (UInt64(i) * 8))
+#else
+        buffer = buffer | (UInt64($0) << (UInt64(7-i) * 8))
+#endif
         i += 1
       }
       UTF8.encode(unicodeScalar, into: sink)

--- a/stdlib/public/core/StringCore.swift
+++ b/stdlib/public/core/StringCore.swift
@@ -299,8 +299,12 @@ public struct _StringCore {
     // Always dereference two bytes, but when elements are 8 bits we
     // multiply the high byte by 0.
     // FIXME(performance): use masking instead of multiplication.
+#if _endian(little)
     return UTF16.CodeUnit(p.pointee)
       + UTF16.CodeUnit((p + 1).pointee) * _highByteMultiplier
+#else
+    return _highByteMultiplier == 0 ? UTF16.CodeUnit(p.pointee) : UTF16.CodeUnit((p + 1).pointee) + UTF16.CodeUnit(p.pointee) * _highByteMultiplier
+#endif
   }
 
   /// Get the Nth UTF-16 Code Unit stored.


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

This is the same fix from https://github.com/apple/swift/pull/4194. We'd like to include this in Swift 3.0. Thanks.

@garyliu1 FYI
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
1. The change in StaticString's withUTF8Buffer is to store the UTF-8 code unit properly in the buffer.
2. The change in StringCore's _nthContiguous is to represent the UTF-16 data correctly when it contains the high byte.

We ran validation tests and foundation tests with the change on x86-64 and s390x. No new regression is observed.
