### PR TITLE
Runtime: Add a convenient `-[_SwiftValue _swiftTypeName]` method for debugging.

### DIFF
--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -1155,6 +1155,11 @@ static inline void swift_unknownUnownedTakeAssign(UnownedReference *dest,
 
 #endif /* SWIFT_OBJC_INTEROP */
 
+/// Return the name of a Swift type represented by a metadata object.
+SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT
+extern "C"
+TwoWordPair<const char *, uintptr_t>::Return
+swift_getTypeName(const Metadata *type, bool qualified);  
 
 } // end namespace swift
 

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -316,9 +316,8 @@ std::string swift::nameForMetadata(const Metadata *type,
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT
-extern "C"
 TwoWordPair<const char *, uintptr_t>::Return
-swift_getTypeName(const Metadata *type, bool qualified) {
+swift::swift_getTypeName(const Metadata *type, bool qualified) {
   using Pair = TwoWordPair<const char *, uintptr_t>;
   using Key = llvm::PointerIntPair<const Metadata *, 1, bool>;
 

--- a/stdlib/public/runtime/SwiftValue.mm
+++ b/stdlib/public/runtime/SwiftValue.mm
@@ -326,6 +326,12 @@ static NSString *getValueDescription(_SwiftValue *self) {
 - (const Metadata *)_swiftTypeMetadata {
   return getSwiftValueTypeMetadata(self);
 }
+- (NSString *)_swiftTypeName {
+  TwoWordPair<const char *, uintptr_t> typeName
+    = swift_getTypeName(getSwiftValueTypeMetadata(self), true);
+  
+  return [NSString stringWithUTF8String: typeName.first];
+}
 - (const OpaqueValue *)_swiftValue {
   return getValueFromSwiftValue(self).second;
 }


### PR DESCRIPTION
This makes it a bit easier to diagnose unexpected boxing problems in the debugger, by allowing `po [value _swiftTypeName]` to work, instead of forcing users to know how to call `swift_getTypeName` from lldb themselves.
