### PR TITLE
[Parse] Add fix-its for empty Swift 2 operator decl braces.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -381,6 +381,9 @@ ERROR(identifier_when_expecting_operator,PointsToFirstBadToken,
 
 WARNING(deprecated_operator_body,PointsToFirstBadToken,
         "operator should no longer be declared with body", ())
+WARNING(deprecated_operator_body_use_group,PointsToFirstBadToken,
+        "operator should no longer be declared with body; "
+        "use a precedence group instead", ())
 ERROR(operator_decl_no_fixity,none,
       "operator must be declared as 'prefix', 'postfix', or 'infix'", ())
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -647,7 +647,8 @@ private:
         Info.ID == diag::any_as_anyobject_fixit.ID ||
         Info.ID == diag::deprecated_protocol_composition.ID ||
         Info.ID == diag::deprecated_protocol_composition_single.ID ||
-        Info.ID == diag::deprecated_any_composition.ID)
+        Info.ID == diag::deprecated_any_composition.ID ||
+        Info.ID == diag::deprecated_operator_body.ID)
       return true;
 
     return false;

--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -259,3 +259,5 @@ func testProtocolCompositionSyntax() {
 
 func disable_unnamed_param_reorder(p: Int, _: String) {}
 disable_unnamed_param_reorder(0, "") // no change.
+
+prefix operator ***** {}

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -262,3 +262,5 @@ func testProtocolCompositionSyntax() {
 
 func disable_unnamed_param_reorder(p: Int, _: String) {}
 disable_unnamed_param_reorder(0, "") // no change.
+
+prefix operator *****

--- a/test/Parse/operator_decl.swift
+++ b/test/Parse/operator_decl.swift
@@ -1,8 +1,12 @@
 // RUN: %target-parse-verify-swift
 
-prefix operator +++ {} // expected-warning {{operator should no longer be declared with body}}
-postfix operator +++ {} // expected-warning {{operator should no longer be declared with body}}
-infix operator +++ {} // expected-warning {{operator should no longer be declared with body}}
+prefix operator +++ {} // expected-warning {{operator should no longer be declared with body}} {{20-23=}}
+postfix operator +++ {} // expected-warning {{operator should no longer be declared with body}} {{21-24=}}
+infix operator +++ {} // expected-warning {{operator should no longer be declared with body}} {{19-22=}}
+infix operator +++* { // expected-warning {{operator should no longer be declared with body; use a precedence group instead}} {{none}}
+  associativity right
+}
+infix operator +++** : A { } // expected-warning {{operator should no longer be declared with body}} {{25-29=}}
 
 prefix operator // expected-error {{expected operator name in operator declaration}}
 


### PR DESCRIPTION
- **Explanation:** In simple cases, Swift 2's operator declaration syntax can be trivially migrated to Swift 3. This adds a fix-it to do that and enables it for use by the migrator.
- **Scope:** Affects diagnostics for Swift-2-style operator declarations. Does not affect code that has already switched to Swift 3 style.
- **Issue:** rdar://problem/27576922
- **Reviewed by:** @rjmccall, @nkcsgexi  
- **Risk:** Very low.
- **Testing:** Added new compiler regression tests.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
