### PR TITLE
[swiftc (49 vs. 5156)] Add crasher in swift::SILModule::constructSIL(...)

### DIFF
--- a/validation-test/compiler_crashers/28396-swift-lowering-silgenfunction-emitclosurevalue.swift
+++ b/validation-test/compiler_crashers/28396-swift-lowering-silgenfunction-emitclosurevalue.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+func a(){var b:()->(){return{b()}}}


### PR DESCRIPTION
Add test case for crash triggered in `swift::SILModule::constructSIL(...)`.

Current number of unresolved compiler crashers: 49 (5156 resolved)

Assertion failure in [`lib/SILGen/SILGenApply.cpp (line 1114)`](https://github.com/apple/swift/blob/master/lib/SILGen/SILGenApply.cpp#L1114):

```
Assertion `vd->isLet() && "Direct reference to vardecl that isn't a let?"' failed.

When executing: void (anonymous namespace)::SILGenApply::visitDeclRefExpr(swift::DeclRefExpr *)
```

Assertion context:

```

    // If this is a direct reference to a vardecl, it must be a let constant
    // (which doesn't need to be loaded).  Just emit its value directly.
    if (auto *vd = dyn_cast<VarDecl>(e->getDecl())) {
      (void)vd;
      assert(vd->isLet() && "Direct reference to vardecl that isn't a let?");
      visitExpr(e);
      return;
    }

    SILDeclRef constant(e->getDecl(),
```

Stack trace:

```
swift: /path/to/swift/lib/SILGen/SILGenApply.cpp:1114: void (anonymous namespace)::SILGenApply::visitDeclRefExpr(swift::DeclRefExpr *): Assertion `vd->isLet() && "Direct reference to vardecl that isn't a let?"' failed.
37 swift           0x000000000093f4c2 swift::SILModule::constructSIL(swift::ModuleDecl*, swift::SILOptions&, swift::FileUnit*, llvm::Optional<unsigned int>, bool, bool) + 498
38 swift           0x000000000093fa36 swift::performSILGeneration(swift::FileUnit&, swift::SILOptions&, llvm::Optional<unsigned int>, bool) + 118
40 swift           0x00000000007db487 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
41 swift           0x00000000007a72b8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28396-swift-lowering-silgenfunction-emitclosurevalue.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28396-swift-lowering-silgenfunction-emitclosurevalue-c63b87.o
1.  While emitting SIL for 'a' at validation-test/compiler_crashers/28396-swift-lowering-silgenfunction-emitclosurevalue.swift:10:1
2.  While emitting SIL for getter for b at validation-test/compiler_crashers/28396-swift-lowering-silgenfunction-emitclosurevalue.swift:10:22
3.  While silgen closureexpr SIL function @_TFFF4main1aFT_T_gL_1bFT_T_U_FT_T_ for expression at [validation-test/compiler_crashers/28396-swift-lowering-silgenfunction-emitclosurevalue.swift:10:29 - line:10:33] RangeText="{b()}"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
