### PR TITLE
Fix affinetransform init

### DIFF
--- a/apinotes/Foundation.apinotes
+++ b/apinotes/Foundation.apinotes
@@ -1255,8 +1255,6 @@ Tags:
 - Name: NSURLHandleStatus
   SwiftName: NSURLHandle.Status
 Typedefs:
-- Name: NSAffineTransformStruct
-  SwiftName: AffineTransform
 - Name: NSComparator
   SwiftName: Comparator
 - Name: NSDecimal

--- a/stdlib/public/SDK/Foundation/AffineTransform.swift
+++ b/stdlib/public/SDK/Foundation/AffineTransform.swift
@@ -16,17 +16,46 @@
 
 private let ε: CGFloat = 2.22045e-16
 
-extension AffineTransform : ReferenceConvertible, Hashable, CustomStringConvertible {
+public struct AffineTransform : ReferenceConvertible, Hashable, CustomStringConvertible {
+    public var m11, m12, m21, m22, tX, tY: CGFloat
+    
     public typealias ReferenceType = NSAffineTransform
-
-    private init(reference: NSAffineTransform) {
-        self = reference.transformStruct
+    
+    /**
+     Creates an affine transformation.
+    */
+    public init(m11: CGFloat, m12: CGFloat, m21: CGFloat, m22: CGFloat, tX: CGFloat, tY: CGFloat) {
+        self.m11 = m11
+        self.m12 = m12
+        self.m21 = m21
+        self.m22 = m22
+        self.tX = tX
+        self.tY = tY
     }
     
-    private var reference : NSAffineTransform {
+    fileprivate init(reference: NSAffineTransform) {
+        m11 = reference.transformStruct.m11
+        m12 = reference.transformStruct.m12
+        m21 = reference.transformStruct.m21
+        m22 = reference.transformStruct.m22
+        tX = reference.transformStruct.tX
+        tY = reference.transformStruct.tY
+    }
+    
+    fileprivate var reference : NSAffineTransform {
         let ref = NSAffineTransform()
-        ref.transformStruct = self
+        ref.transformStruct = NSAffineTransformStruct(m11: m11, m12: m12, m21: m21, m22: m22, tX: tX, tY: tY)
         return ref
+    }
+    
+    /**
+     Creates an affine transformation matrix with identity values.
+     - seealso: identity
+    */
+    public init() {
+        self.init(m11: CGFloat(1.0), m12: CGFloat(0.0),
+                  m21: CGFloat(0.0), m22: CGFloat(1.0),
+                  tX: CGFloat(0.0), tY: CGFloat(0.0))
     }
     
     /**
@@ -270,9 +299,7 @@ extension AffineTransform : _ObjectiveCBridgeable {
     
     @_semantics("convertToObjectiveC")
     public func _bridgeToObjectiveC() -> NSAffineTransform {
-        let t = NSAffineTransform()
-        t.transformStruct = self
-        return t
+        return self.reference
     }
     
     public static func _forceBridgeFromObjectiveC(_ x: NSAffineTransform, result: inout AffineTransform?) {
@@ -282,7 +309,7 @@ extension AffineTransform : _ObjectiveCBridgeable {
     }
     
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSAffineTransform, result: inout AffineTransform?) -> Bool {
-        result = x.transformStruct
+        result = AffineTransform(reference: x)
         return true // Can't fail
     }
 

--- a/test/1_stdlib/TestAffineTransform.swift
+++ b/test/1_stdlib/TestAffineTransform.swift
@@ -61,7 +61,10 @@ class TestAffineTransform : TestAffineTransformSuper {
     }
     
     func test_BasicConstruction() {
+        let defaultAffineTransform = AffineTransform()
         let identityTransform = AffineTransform.identity
+
+        expectEqual(defaultAffineTransform, identityTransform)
         
         // The diagonal entries (1,1) and (2,2) of the identity matrix are ones. The other entries are zeros.
         // TODO: These should use DBL_MAX but it's not available as part of Glibc on Linux
@@ -324,8 +327,7 @@ class TestAffineTransform : TestAffineTransformSuper {
             AffineTransform(m11: 0.498, m12: -0.284, m21: -0.742, m22: 0.3248, tX: 12, tY: 44)
         ]
         for val in values {
-            let ref = NSAffineTransform()
-            ref.transformStruct = val
+            let ref = val as NSAffineTransform
             expectEqual(ref.hashValue, val.hashValue)
         }
     }


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

The migrator is changing `NSAffineTransform()` into `AffineTransform()`, but because `AffineTransform` is actually a renamed C struct (previously known as `NSAffineTransformStruct`), its initializer sets everything to zero.

This change removes that renaming and establishes `AffineTransform` as its own struct type, where we can control the behavior of the `init` function. The default initializer now returns an identity `AffineTransform` as expected.
#### Resolved bug number

<!-- If this pull request resolves any bugs from Swift bug tracker -->

rdar://problem/27793851 AffineTransform() and NSAffineTransform() initializers are not semantically equivalent

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
