### PR TITLE
Allow 'Any' as an IBAction's sender and an IBOutlet's type. (#4320)

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -343,7 +343,7 @@ void AttributeEarlyChecker::visitSILStoredAttr(SILStoredAttr *attr) {
 
 static Optional<Diag<bool,Type>>
 isAcceptableOutletType(Type type, bool &isArray, TypeChecker &TC) {
-  if (type->isObjCExistentialType())
+  if (type->isObjCExistentialType() || type->isAny())
     return None; // @objc existential types are okay
 
   auto nominal = type->getAnyNominal();
@@ -800,8 +800,8 @@ static bool checkObjectOrOptionalObjectType(TypeChecker &TC, Decl *D,
         .highlight(param->getSourceRange());
       return true;
     }
-  } else if (ty->isObjCExistentialType()) {
-    // @objc existential types are okay
+  } else if (ty->isObjCExistentialType() || ty->isAny()) {
+    // @objc existential types are okay, as is Any.
     // Nothing to do.
   } else {
     // No other types are permitted.

--- a/test/attr/attr_ibaction.swift
+++ b/test/attr/attr_ibaction.swift
@@ -63,6 +63,11 @@ protocol CP2 : class { }
   @IBAction func action5(_: AnyObject?) {}
   @IBAction func action6(_: AnyObject!) {}
 
+  // Any
+  @IBAction func action4a(_: Any) {}
+  @IBAction func action5a(_: Any?) {}
+  @IBAction func action6a(_: Any!) {}
+
   // Protocol types
   @IBAction func action7(_: P1) {} // expected-error{{argument to @IBAction method cannot have non-object type 'P1'}}
   // expected-error@-1{{method cannot be marked @IBAction because the type of the parameter cannot be represented in Objective-C}}

--- a/test/attr/attr_iboutlet.swift
+++ b/test/attr/attr_iboutlet.swift
@@ -64,6 +64,10 @@ class NonObjC {}
   @IBOutlet var outlet5: AnyObject?
   @IBOutlet var outlet6: AnyObject!
 
+  // Any
+  @IBOutlet var outlet5a: Any?
+  @IBOutlet var outlet6a: Any!
+
   // Protocol types
   @IBOutlet var outlet7: P1 // expected-error{{@IBOutlet property cannot have non-'@objc' protocol type 'P1'}} {{3-13=}}
   @IBOutlet var outlet8: CP1 // expected-error{{@IBOutlet property cannot have non-'@objc' protocol type 'CP1'}} {{3-13=}}


### PR DESCRIPTION
- **Explanation:** The `IBAction` and `IBOutlet` attributes are used to identify members made available to Interface Builder. The compiler does some basic sanity checking on the types of these members to keep people from making obvious mistakes; unfortunately those checks were never updated for id-as-Any ([SE-0116](https://github.com/apple/swift-evolution/blob/master/proposals/0116-id-as-any.md)). This is mostly okay (you can still use `AnyObject`), but not when the method you want to mark as an action is also an override.
- **Scope:** Pure-additive change that prevents an error from being emitted when a type is `Any` or `Any?`. Uses existing code paths for everything else.
- **Issue:** rdar://problem/27853737
- **Reviewed by:** @jckarter   
- **Risk:** Very low.
- **Testing:** Added new compiler regression tests.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
