### PR TITLE
IRGen: Bind archetype access paths in emitFieldTypeAccessor

### DIFF
--- a/lib/IRGen/GenArchetype.h
+++ b/lib/IRGen/GenArchetype.h
@@ -18,6 +18,7 @@
 #define SWIFT_IRGEN_GENARCHETYPE_H
 
 #include "swift/AST/Types.h"
+#include "llvm/ADT/STLExtras.h"
 
 namespace llvm {
   class Value;
@@ -30,6 +31,13 @@ namespace swift {
 namespace irgen {
   class Address;
   class IRGenFunction;
+
+  using GetTypeParameterInContextFn =
+    llvm::function_ref<CanType(CanType type)>;
+
+  void bindArchetypeAccessPaths(IRGenFunction &IGF,
+                                GenericSignature *generics,
+                                GetTypeParameterInContextFn getInContext);
 
   /// Emit a type metadata reference for an archetype.
   llvm::Value *emitArchetypeTypeMetadataRef(IRGenFunction &IGF,

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -995,10 +995,6 @@ getWitnessTableLazyAccessFunction(IRGenModule &IGM,
   return accessor;
 }
 
-static void bindArchetypeAccessPaths(IRGenFunction &IGF,
-                                     GenericSignature *Generics,
-                                     GetTypeParameterInContextFn getInContext);
-
 namespace {
 
 /// Conformance info for a witness table that can be directly generated.
@@ -1853,9 +1849,8 @@ void addPotentialArchetypeAccessPath(IRGenFunction &IGF,
                              {srcBaseArchetype, association});
 }
 
-static void bindArchetypeAccessPaths(IRGenFunction &IGF,
-                                     GenericSignature *Generics,
-                                     GetTypeParameterInContextFn getInContext) {
+void irgen::bindArchetypeAccessPaths(IRGenFunction &IGF, GenericSignature *Generics,
+                              GetTypeParameterInContextFn getInContext) {
   // Remember all the extra ways we have of reaching the parameter
   // archetypes due to type equality constraints.
   for (auto reqt : Generics->getRequirements()) {

--- a/test/IRGen/same_type_constraints.swift
+++ b/test/IRGen/same_type_constraints.swift
@@ -23,13 +23,22 @@ public class C2<T: Equatable, U: P where T == U.Foo>: C1<T> {}
 
 // CHECK: define{{( protected)?}} void @_TFC21same_type_constraints2C1D
 
-public protocol DataType {}
+public protocol MyHashable {}
+public protocol DataType : MyHashable {}
 
 public protocol E {
   associatedtype Data: DataType
 }
 
+struct Dict<V : MyHashable, K> {}
+struct Val {}
+
 public class GenericKlazz<T: DataType, R: E> : E where R.Data == T
 {
   public typealias Data = T
+
+  var d: Dict<T, Val>
+  init() {
+     d = Dict()
+  }
 }


### PR DESCRIPTION
Another instance where we did not call bindArchetypeAccessPaths in a potentially generic context.

SR-1951
rdar://27718494
