### PR TITLE
Revert "[FixCode] Apply coercion fixit for assignment types' mismatch too."

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4028,7 +4028,6 @@ bool FailureDiagnosis::diagnoseContextualConversionError() {
   case CTP_ArrayElement:
   case CTP_DictionaryKey:
   case CTP_DictionaryValue:
-  case CTP_AssignSource:
     tryRawRepresentableFixIts(diag, CS, exprType, contextualType,
                               KnownProtocolKind::ExpressibleByIntegerLiteral,
                               expr) ||

--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -261,12 +261,3 @@ func disable_unnamed_param_reorder(p: Int, _: String) {}
 disable_unnamed_param_reorder(0, "") // no change.
 
 prefix operator ***** {}
-
-func foo(an : Any) {
-  let a1 : AnyObject
-  a1 = an
-  let a2 : AnyObject?
-  a2 = an
-  let a3 : AnyObject!
-  a3 = an
-}

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -264,12 +264,3 @@ func disable_unnamed_param_reorder(p: Int, _: String) {}
 disable_unnamed_param_reorder(0, "") // no change.
 
 prefix operator *****
-
-func foo(an : Any) {
-  let a1 : AnyObject
-  a1 = an as AnyObject
-  let a2 : AnyObject?
-  a2 = an as AnyObject?
-  let a3 : AnyObject!
-  a3 = an as AnyObject!
-}


### PR DESCRIPTION
Reverts apple/swift#4326. This change failed on Linux: https://ci.swift.org/job/oss-swift-incremental-RA-linux-ubuntu-15_10/7354/
