### PR TITLE
Foundation overlay: Fix optionality mismatch in NSMutableDictionary subscript.

### DIFF
--- a/stdlib/public/SDK/Foundation/Foundation.swift
+++ b/stdlib/public/SDK/Foundation/Foundation.swift
@@ -1007,7 +1007,12 @@ extension NSMutableDictionary {
     set {
       // FIXME: Unfortunate that the `NSCopying` check has to be done at
       // runtime.
-      self.setObject(newValue, forKey: key as AnyObject as! NSCopying)
+      let copyingKey = key as AnyObject as! NSCopying
+      if let newValue = newValue {
+        self.setObject(newValue, forKey: copyingKey)
+      } else {
+        self.removeObject(forKey: copyingKey)
+      }
     }
   }
 }

--- a/test/1_stdlib/NSDictionary.swift
+++ b/test/1_stdlib/NSDictionary.swift
@@ -17,5 +17,13 @@ tests.test("copy construction") {
   let y = NSMutableDictionary(dictionary: expected as NSDictionary)
   expectEqual(expected, y as NSDictionary as! Dictionary)
 }
+// rdar://problem/27875914
+tests.test("subscript with Any") {
+  let d = NSMutableDictionary()
+  d["k"] = "@this is how the world ends"
+  expectEqual((d["k"]! as AnyObject).characterAtIndex(0), 0x40)
+  d["k"] = nil
+  expectTrue(d["k"] == nil)
+}
 
 runAllTests()


### PR DESCRIPTION
`setObject:forKey:` takes a nonnull object, causing us to accidentally pass in a boxed Optional-in-an-Any from the Swift subscript's optional newValue. Fixes rdar://problem/27875914.
