### PR TITLE
[3.0] Sema: Make Hashable-to-AnyHashable a Subtype rather than Conversion.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1579,6 +1579,17 @@ ConstraintSystem::matchTypes(Type type1, Type type2, TypeMatchKind kind,
       conversionsOrFixes.push_back(ConversionRestrictionKind::Superclass);
     }
     
+    // T -> AnyHashable.
+    if (isAnyHashableType(desugar2)) {
+      // Don't allow this in operator contexts or we'll end up allowing
+      // 'T() == U()' for unrelated T and U that just happen to be Hashable.
+      // We can remove this special case when we implement operator hiding.
+      if (kind != TypeMatchKind::OperatorArgumentConversion) {
+        conversionsOrFixes.push_back(
+                              ConversionRestrictionKind::HashableToAnyHashable);
+      }
+    }
+
     // Metatype to object conversion.
     //
     // Class and protocol metatypes are interoperable with certain Objective-C
@@ -1649,15 +1660,6 @@ ConstraintSystem::matchTypes(Type type1, Type type2, TypeMatchKind kind,
       } else if (isSetType(desugar1) && isSetType(desugar2)) {
         conversionsOrFixes.push_back(
           ConversionRestrictionKind::SetUpcast);
-      // T -> AnyHashable.
-      } else if (isAnyHashableType(desugar2)) {
-        // Don't allow this in operator contexts or we'll end up allowing
-        // 'T() == U()' for unrelated T and U that just happen to be Hashable.
-        // We can remove this special case when we implement operator hiding.
-        if (kind != TypeMatchKind::OperatorArgumentConversion) {
-          conversionsOrFixes.push_back(
-            ConversionRestrictionKind::HashableToAnyHashable);
-        }
       }
     }
   }

--- a/test/Constraints/anyhashable-collection-cast.swift
+++ b/test/Constraints/anyhashable-collection-cast.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -parse -verify %s
+
+func dict() -> [AnyHashable: Any] {
+   return ["x": "y"]
+}
+func set() -> Set<AnyHashable> {
+   return ["x"]
+}
+
+func test() {
+   if let d = dict() as? [String: String] {
+    print(d)
+   }
+   if let s = set() as? Set<String> {
+    print(s)
+   }
+}


### PR DESCRIPTION
This admits AnyHashable in collection downcasts, though runtime support for the dynamic cast still appears to be incomplete. rdar://problem/27869032
