### PR TITLE
Don't leak boxes when releasing Mirror owners

### DIFF
--- a/stdlib/public/runtime/Reflection.mm
+++ b/stdlib/public/runtime/Reflection.mm
@@ -428,6 +428,8 @@ static bool loadSpecialReferenceStorage(HeapObject *owner,
   // owner now, we need to release the old owner to maintain the contract.
   if (owner->metadata->isAnyClass())
     swift_unknownRelease(owner);
+  else
+    swift_release(owner);
 
   return true;
 }


### PR DESCRIPTION
Heap boxes don't have a "class" metadata kind, so make
sure to release them when creating a new owner for loading
weak references in the runtime mirrors.

rdar://problem/27348445
