### PR TITLE
Optional swift_newtype types are @objc if the raw type would be @objc.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4928,17 +4928,14 @@ Type TypeBase::getSwiftNewtypeUnderlyingType() {
     return {};
 
   // Make sure the clang node has swift_newtype attribute
-  if (!structDecl->getClangNode())
-    return {};
-  auto clangNode = structDecl->getClangNode();
-  if (!clangNode.getAsDecl() ||
-      !clangNode.castAsDecl()->getAttr<clang::SwiftNewtypeAttr>())
+  auto clangNode = structDecl->getClangDecl();
+  if (!clangNode || !clangNode->hasAttr<clang::SwiftNewtypeAttr>())
     return {};
 
   // Underlying type is the type of rawValue
   for (auto member : structDecl->getMembers())
     if (auto varDecl = dyn_cast<VarDecl>(member))
-      if (varDecl->getName().str() == "rawValue")
+      if (varDecl->getName() == getASTContext().Id_rawValue)
         return varDecl->getType();
 
   return {};

--- a/test/ClangModules/Inputs/custom-modules/Newtype.h
+++ b/test/ClangModules/Inputs/custom-modules/Newtype.h
@@ -1,0 +1,4 @@
+@import Foundation;
+
+typedef NSString *__nonnull SNTErrorDomain __attribute((swift_newtype(struct)));
+typedef NSInteger MyInt __attribute((swift_newtype(struct)));

--- a/test/ClangModules/Inputs/custom-modules/module.map
+++ b/test/ClangModules/Inputs/custom-modules/module.map
@@ -69,6 +69,10 @@ module MissingHeader {
   header "this-header-does-not-exist.h"
 }
 
+module Newtype {
+  header "Newtype.h"
+}
+
 module ObjCIRExtras {
   header "ObjCIRExtras.h"
   export *

--- a/test/ClangModules/objc_parse.swift
+++ b/test/ClangModules/objc_parse.swift
@@ -5,6 +5,7 @@
 import AppKit
 import AVFoundation
 
+import Newtype
 import objc_ext
 import TestProtocols
 
@@ -597,5 +598,12 @@ func testNSUInteger(_ obj: NSUIntegerTests, uint: UInt, int: Int) {
   // NSNumber
   let num = NSNumber(value: uint)
   let _: String = num.uintValue // expected-error {{cannot convert value of type 'UInt' to specified type 'String'}}
+}
+
+class NewtypeUser {
+  @objc func stringNewtype(a: SNTErrorDomain) {}
+  @objc func stringNewtypeOptional(a: SNTErrorDomain?) {}
+  @objc func intNewtype(a: MyInt) {}
+  @objc func intNewtypeOptional(a: MyInt?) {} // expected-error {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
 }
 

--- a/test/IRGen/newtype.swift
+++ b/test/IRGen/newtype.swift
@@ -130,3 +130,31 @@ public func compareInits() -> Bool {
 public func anchor() -> Bool {
   return false
 }
+
+class ObjCTest {
+  // CHECK-LABEL: define hidden %0* @_TToFC7newtype8ObjCTest19optionalPassThroughfGSqVSC11ErrorDomain_GSqS1__
+  // CHECK: [[CASTED:%.+]] = ptrtoint %0* %2 to i{{32|64}}
+  // CHECK: [[RESULT:%.+]] = call i{{32|64}} @_TFC7newtype8ObjCTest19optionalPassThroughfGSqVSC11ErrorDomain_GSqS1__(i{{32|64}} [[CASTED]], %C7newtype8ObjCTest* {{%.+}})
+  // CHECK: [[OPAQUE_RESULT:%.+]] = inttoptr i{{32|64}} [[RESULT]] to %0*
+  // CHECK: ret %0* [[OPAQUE_RESULT]]
+  // CHECK: {{^}$}}
+
+  // OPT-LABEL: define hidden %0* @_TToFC7newtype8ObjCTest19optionalPassThroughfGSqVSC11ErrorDomain_GSqS1__
+  // OPT: ret %0* %2
+  // OPT: {{^}$}}
+  @objc func optionalPassThrough(_ ed: ErrorDomain?) -> ErrorDomain? {
+    return ed
+  }
+
+  // CHECK-LABEL: define hidden i32 @_TToFC7newtype8ObjCTest18integerPassThroughfVSC5MyIntS1_
+  // CHECK: [[RESULT:%.+]] = call i32 @_TFC7newtype8ObjCTest18integerPassThroughfVSC5MyIntS1_(i32 %2, %C7newtype8ObjCTest* {{%.+}})
+  // CHECK: ret i32 [[RESULT]]
+  // CHECK: {{^}$}}
+
+  // OPT-LABEL: define hidden i32 @_TToFC7newtype8ObjCTest18integerPassThroughfVSC5MyIntS1_
+  // OPT: ret i32 %2
+  // OPT: {{^}$}}
+  @objc func integerPassThrough(_ num: MyInt) -> MyInt {
+    return num
+  }
+}

--- a/test/PrintAsObjC/newtype.swift
+++ b/test/PrintAsObjC/newtype.swift
@@ -28,6 +28,8 @@ class TestEnumLike : NSObject {
   func takesNewtypeArray(_ a: [EnumLikeStringWrapper]) {}
   // CHECK: - (void)takesNewtypeDictionary:(NSDictionary<EnumLikeStringWrapper, EnumLikeStringWrapper> * _Nonnull)a;
   func takesNewtypeDictionary(_ a: [EnumLikeStringWrapper: EnumLikeStringWrapper]) {}
+  // CHECK: - (void)takesNewtypeOptional:(EnumLikeStringWrapper _Nullable)a;
+  func takesNewtypeOptional(_ a: EnumLikeStringWrapper?) {}
 }
 // CHECK: @end
 
@@ -39,6 +41,8 @@ class TestStructLike : NSObject {
   func takesNewtypeArray(_ a: [StructLikeStringWrapper]) {}
   // CHECK: - (void)takesNewtypeDictionary:(NSDictionary<StructLikeStringWrapper, StructLikeStringWrapper> * _Nonnull)a;
   func takesNewtypeDictionary(_ a: [StructLikeStringWrapper: StructLikeStringWrapper]) {}
+  // CHECK: - (void)takesNewtypeOptional:(StructLikeStringWrapper _Nullable)a;
+  func takesNewtypeOptional(_ a: StructLikeStringWrapper?) {}
 }
 // CHECK: @end
 

--- a/test/SILGen/Inputs/usr/include/newtype.h
+++ b/test/SILGen/Inputs/usr/include/newtype.h
@@ -5,3 +5,5 @@ __attribute((swift_name("ErrorDomain")));
 extern const SNTErrorDomain SNTErrTwo;
 extern const SNTErrorDomain SNTErrorDomainThree;
 extern const SNTErrorDomain SNTFourErrorDomain;
+
+typedef NSInteger MyInt __attribute((swift_newtype(struct)));

--- a/test/SILGen/newtype.swift
+++ b/test/SILGen/newtype.swift
@@ -39,3 +39,17 @@ func getRawValue(ed: ErrorDomain) -> String {
 // CHECK-RAW: [[STRING_RESULT:%[0-9]+]] = load [[STRING_RESULT_ADDR]]
 // CHECK-RAW: return [[STRING_RESULT]]
 
+class ObjCTest {
+  // CHECK-RAW-LABEL: sil hidden @_TFC7newtype8ObjCTest19optionalPassThroughfGSqVSC11ErrorDomain_GSqS1__ : $@convention(method) (@owned Optional<ErrorDomain>, @guaranteed ObjCTest) -> @owned Optional<ErrorDomain> {
+  // CHECK-RAW: sil hidden [thunk] @_TToFC7newtype8ObjCTest19optionalPassThroughfGSqVSC11ErrorDomain_GSqS1__ : $@convention(objc_method) (Optional<ErrorDomain>, ObjCTest) -> Optional<ErrorDomain> {
+  @objc func optionalPassThrough(_ ed: ErrorDomain?) -> ErrorDomain? {
+    return ed
+  }  
+
+  // CHECK-RAW-LABEL: sil hidden @_TFC7newtype8ObjCTest18integerPassThroughfVSC5MyIntS1_ : $@convention(method) (MyInt, @guaranteed ObjCTest) -> MyInt {
+  // CHECK-RAW: sil hidden [thunk] @_TToFC7newtype8ObjCTest18integerPassThroughfVSC5MyIntS1_ : $@convention(objc_method) (MyInt, ObjCTest) -> MyInt {
+  @objc func integerPassThrough(_ ed: MyInt) -> MyInt {
+    return ed
+  }  
+}
+


### PR DESCRIPTION
- **Explanation:** We import certain typedefs as if they were structs wrapping the underlying type; clearly we want to treat these as Objective-C-compatible. However, whether or not the _optional_ version of these types is Objective-C-compatible should be dependent on whether the underlying type can be optional; we were instead rejecting it out of hand. In practice, this was causing issues where the compiler rejected overrides of imported members as being non-ObjC-compatible, even though the type was exactly the same as what the Clang importer was using.
- **Scope:** Affects any (1) imported struct or enum types, that (2) is used in an optional type in (3) a member that may be exposed to Objective-C.
- **Issue:** [SR-2344](https://bugs.swift.org/browse/SR-2344)
- **Reviewed by:** @DougGregor    
- **Risk:** Medium-low. It's mostly existing code paths, but it does expand the _inputs_ to that code. There's no real workaround, though.
- **Testing:** Added new compiler regression tests.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
