### PR TITLE
NSNumber already preserves whether a value was originally boolean.

### DIFF
--- a/stdlib/public/SDK/Foundation/Foundation.swift
+++ b/stdlib/public/SDK/Foundation/Foundation.swift
@@ -158,11 +158,6 @@ internal func _swift_Foundation_TypePreservingNSNumberWithCGFloat(
   _ value: CGFloat
 ) -> NSNumber
 
-@_silgen_name("_swift_Foundation_TypePreservingNSNumberWithBool")
-internal func _swift_Foundation_TypePreservingNSNumberWithBool(
-  _ value: Bool
-) -> NSNumber
-
 @_silgen_name("_swift_Foundation_TypePreservingNSNumberGetKind")
 internal func _swift_Foundation_TypePreservingNSNumberGetKind(
   _ value: NSNumber
@@ -203,11 +198,6 @@ internal func _swift_Foundation_TypePreservingNSNumberGetAsDouble(
 internal func _swift_Foundation_TypePreservingNSNumberGetAsCGFloat(
   _ value: NSNumber
 ) -> CGFloat
-
-@_silgen_name("_swift_Foundation_TypePreservingNSNumberGetAsBool")
-internal func _swift_Foundation_TypePreservingNSNumberGetAsBool(
-  _ value: NSNumber
-) -> Bool
 
 // Conversions between NSNumber and various numeric types. The
 // conversion to NSNumber is automatic (auto-boxing), while conversion
@@ -348,7 +338,7 @@ extension Bool: _ObjectiveCBridgeable {
 
   @_semantics("convertToObjectiveC")
   public func _bridgeToObjectiveC() -> NSNumber {
-    return _swift_Foundation_TypePreservingNSNumberWithBool(self)
+    return NSNumber(value: self)
   }
 
   public static func _forceBridgeFromObjectiveC(
@@ -456,7 +446,7 @@ extension NSNumber : _HasCustomAnyHashableRepresentation {
     case .CoreGraphicsCGFloat:
       return AnyHashable(_swift_Foundation_TypePreservingNSNumberGetAsCGFloat(self))
     case .SwiftBool:
-      return AnyHashable(_swift_Foundation_TypePreservingNSNumberGetAsBool(self))
+      return AnyHashable(self.boolValue)
     }
   }
 }

--- a/validation-test/stdlib/NSNumberBridging.swift.gyb
+++ b/validation-test/stdlib/NSNumberBridging.swift.gyb
@@ -128,7 +128,7 @@ NSNumberTests.test("_SwiftTypePreservingNSNumber.init(coder:)")
 NSNumberTests.test("_SwiftTypePreservingNSNumber.copy(zone:)") {
   let n: NSNumber = (42 as Int)._bridgeToObjectiveC()
   expectTrue(isTypePreservingNSNumber(n))
-  let copy = n.copy() as! AnyObject
+  let copy = n.copy() as AnyObject
   expectTrue(n === copy)
 }
 
@@ -197,7 +197,11 @@ NSNumberTests.test("_SwiftTypePreservingNSNumber(${Self}).getValue(_:), objCType
   .forEach(in: ${Self}._interestingValues) {
   input in
   let bridgedNSNumber = input._bridgeToObjectiveC()
+%   if Self == 'Bool':
+  expectTrue(CFGetTypeID(bridgedNSNumber) == CFBooleanGetTypeID())
+%   else:
   expectTrue(isTypePreservingNSNumber(bridgedNSNumber))
+%   end
 
   let expectedObjCType: String
 %   if Self == 'Int':
@@ -229,7 +233,9 @@ NSNumberTests.test("_SwiftTypePreservingNSNumber(${Self}).getValue(_:), objCType
   _UnknownArchError()
 #endif
 %   elif Self == 'Bool':
-  expectedObjCType = "B"
+  // NSNumber always encodes booleans as 'signed char', even on platforms where
+  // ObjCBool is a true Bool. This is a very old compatibility concern.
+  expectedObjCType = "c"
 %   else:
   _UnknownTypeError()
 %   end
@@ -247,13 +253,20 @@ NSNumberTests.test("${Self} bridges to NSNumber (actually _SwiftTypePreservingNS
   input in
   // Bridged NSNumbers preserve the Swift type when put into AnyHashable.
   let bridgedNSNumber = input._bridgeToObjectiveC()
+%   if Self == 'Bool':
+  expectTrue(CFGetTypeID(bridgedNSNumber) == CFBooleanGetTypeID())
+%   else:
   expectTrue(isTypePreservingNSNumber(bridgedNSNumber))
+%   end
   expectNotEmpty(bridgedNSNumber._toCustomAnyHashable())
 
   // Explicitly constructed NSNumbers don't have a special AnyHashable
   // representation.
 %   if Self == 'CGFloat':
   let explicitNSNumber = NSNumber(value: input.native)
+%   elif Self == 'Bool':
+  // Bool actually /is/ type-preserving for NSNumber. Use a dummy value instead.
+  let explicitNSNumber = NSNumber(value: (input ? 1 : 0) as Int8)
 %   else:
   let explicitNSNumber = NSNumber(value: input)
 %   end


### PR DESCRIPTION
Use that instead of rolling it up in `_SwiftTypePreservingNSNumber` so that we get the right behavior when we go to write plists.

https://bugs.swift.org/browse/SR-2381

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
