### PR TITLE
[SR-1788] Add -driver-time-compilation option

### DIFF
--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -128,6 +128,10 @@ private:
   /// True if temporary files should not be deleted.
   bool SaveTemps;
 
+  /// When true, dumps information on how long each compilation task took to
+  /// execute.
+  bool ShowDriverTimeCompilation;
+
   /// When true, dumps information about why files are being scheduled to be
   /// rebuilt.
   bool ShowIncrementalBuildDecisions = false;
@@ -145,7 +149,8 @@ public:
               unsigned NumberOfParallelCommands = 1,
               bool EnableIncrementalBuild = false,
               bool SkipTaskExecution = false,
-              bool SaveTemps = false);
+              bool SaveTemps = false,
+              bool ShowDriverTimeCompilation = false);
   ~Compilation();
 
   ArrayRefView<std::unique_ptr<const Job>, const Job *, Compilation::unwrap>

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -169,6 +169,9 @@ def output_file_map_EQ : Joined<["-"], "output-file-map=">,
 
 def save_temps : Flag<["-"], "save-temps">, Flags<[NoInteractiveOption]>,
   HelpText<"Save intermediate compilation results">;
+def driver_time_compilation : Flag<["-"], "driver-time-compilation">,
+  Flags<[NoInteractiveOption]>,
+  HelpText<"Prints the total time it took to execute all compilation tasks">;
 
 def emit_dependencies : Flag<["-"], "emit-dependencies">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -369,6 +369,8 @@ std::unique_ptr<Compilation> Driver::buildCompilation(
   bool SaveTemps = ArgList->hasArg(options::OPT_save_temps);
   bool ContinueBuildingAfterErrors =
     ArgList->hasArg(options::OPT_continue_building_after_errors);
+  bool ShowDriverTimeCompilation =
+    ArgList->hasArg(options::OPT_driver_time_compilation);
 
   std::unique_ptr<DerivedArgList> TranslatedArgList(
     translateInputArgs(*ArgList));
@@ -503,7 +505,8 @@ std::unique_ptr<Compilation> Driver::buildCompilation(
                                                  NumberOfParallelCommands,
                                                  Incremental,
                                                  DriverSkipExecution,
-                                                 SaveTemps));
+                                                 SaveTemps,
+                                                 ShowDriverTimeCompilation));
 
   buildJobs(Actions, OI, OFM.get(), *TC, *C);
 

--- a/test/Driver/driver-time-compilation.swift
+++ b/test/Driver/driver-time-compilation.swift
@@ -1,0 +1,10 @@
+// RUN: %swiftc_driver -parse -driver-time-compilation %s 2>&1 | %FileCheck %s
+// RUN: %swiftc_driver -parse -driver-time-compilation %s %S/../Inputs/empty.swift 2>&1 | %FileCheck -check-prefix CHECK-MULTIPLE %s
+
+// CHECK: Driver Time Compilation
+// CHECK: Total Execution Time: {{[0-9]+}}.{{[0-9]+}} seconds ({{[0-9]+}}.{{[0-9]+}} wall clock)
+// CHECK: ---Wall Time---
+// CHECK: --- Name ---
+// CHECK: compile {{.*}}driver-time-compilation.swift
+// CHECK-MULTIPLE: compile {{.*}}empty.swift
+// CHECK: {{[0-9]+}}.{{[0-9]+}} (100.0%)  Total


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Add an option to print the time it takes each driver task to complete.

Here's an example of the output:

```
$ swiftc -driver-time-compilation \
         -emit-library -module-name Crispix \
         Crispix/A.swift Crispix/B.swift Crispix/C.swift
===-------------------------------------------------------------------------===
                            Driver Time Compilation
===-------------------------------------------------------------------------===
  Total Execution Time: 0.0000 seconds (0.0892 wall clock)

   ---Wall Time---  --- Name ---
   0.0242 ( 27.1%)  /path/to/bin/swift -frontend -c -primary-file /path/to/Crispix/A.swift /path/to/Crispix/B.swift /path/to/Crispix/C.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -color-diagnostics -parse-as-library -module-name Crispix -o /tmp/A-216874.o

   0.0239 ( 26.7%)  /usr/bin/clang++ -shared -fuse-ld=gold -target x86_64-unknown-linux-gnu -Xlinker -rpath -Xlinker /path/to/lib/swift/linux /path/to/lib/swift/linux/x86_64/swift_begin.o /tmp/A-216874.o /tmp/B-243ab4.o /tmp/C-5af361.o -L /path/to/lib/swift/linux --target=x86_64-unknown-linux-gnu -lswiftCore @/tmp/A-864579.autolink /path/to/lib/swift/linux/x86_64/swift_end.o -o libCrispix.so

   0.0205 ( 23.0%)  /path/to/bin/swift -frontend -c /path/to/Crispix/A.swift -primary-file /path/to/Crispix/B.swift /path/to/Crispix/C.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -color-diagnostics -parse-as-library -module-name Crispix -o /tmp/B-243ab4.o

   0.0174 ( 19.6%)  /path/to/bin/swift -frontend -c /path/to/Crispix/A.swift /path/to/Crispix/B.swift -primary-file /path/to/Crispix/C.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -color-diagnostics -parse-as-library -module-name Crispix -o /tmp/C-5af361.o

   0.0032 (  3.6%)  /path/to/bin/swift-autolink-extract /tmp/A-216874.o /tmp/B-243ab4.o /tmp/C-5af361.o -o /tmp/A-864579.autolink

   0.0892 (100.0%)  Total
```

I don't write C++ very often, and this is probably one of the larger changes I've made to `lib/Driver`, so I wouldn't be surprised if there's some wacky code in here. 😅  Any and all feedback welcome!

/cc @jrose-apple @gottesmm 
#### Resolved bug number: ([SR-1788](https://bugs.swift.org/browse/SR-1788))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
