### PR TITLE
[swiftc (50 vs. 5156)] Add crasher in ?

### DIFF
--- a/validation-test/compiler_crashers/28397-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers/28397-getselftypeforcontainer.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol y{class B:Array<e>typealias e


### PR DESCRIPTION
Add test case for crash triggered in `?`.

Current number of unresolved compiler crashers: 50 (5156 resolved)

Stack trace:

```
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
