### PR TITLE
[QoI] Diagnose initializers written as typed patterns (SR-1461)

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -746,6 +746,9 @@ ERROR(parameter_unnamed,none,
 ERROR(parameter_curry_syntax_removed,none,
       "curried function declaration syntax has been removed; use a single parameter list", ())
 
+ERROR(initializer_as_typed_pattern,none,
+      "unexpected initializer in pattern; did you mean to use '='?", ())
+
 //------------------------------------------------------------------------------
 // Statement parsing diagnostics
 //------------------------------------------------------------------------------

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -786,15 +786,63 @@ ParserResult<Pattern> Parser::parseTypedPattern() {
   auto result = parsePattern();
   
   // Now parse an optional type annotation.
-  if (consumeIf(tok::colon)) {
+  if (Tok.is(tok::colon)) {
+    SourceLoc pastEndOfPrevLoc = getEndOfPreviousLoc();
+    SourceLoc colonLoc = consumeToken(tok::colon);
+    SourceLoc startOfNextLoc = Tok.getLoc();
+    
     if (result.isNull())  // Recover by creating AnyPattern.
       result = makeParserErrorResult(new (Context) AnyPattern(PreviousLoc));
     
     ParserResult<TypeRepr> Ty = parseType();
     if (Ty.hasCodeCompletion())
       return makeParserCodeCompletionResult<Pattern>();
-    if (Ty.isNull())
+    if (!Ty.isNull()) {
+      // Attempt to diagnose initializer calls incorrectly written
+      // as typed patterns, such as "var x: [Int]()".
+      if (Tok.isFollowingLParen()) {
+        BacktrackingScope backtrack(*this);
+        
+        // Create a local context if needed so we can parse trailing closures.
+        LocalContext dummyContext;
+        Optional<ContextChange> contextChange;
+        if (!CurLocalContext) {
+          contextChange.emplace(*this, CurDeclContext, &dummyContext);
+        }
+        
+        SourceLoc lParenLoc, rParenLoc;
+        SmallVector<Expr *, 2> args;
+        SmallVector<Identifier, 2> argLabels;
+        SmallVector<SourceLoc, 2> argLabelLocs;
+        Expr *trailingClosure;
+        ParserStatus status = parseExprList(tok::l_paren, tok::r_paren,
+                                            /*isPostfix=*/true,
+                                            /*isExprBasic=*/false,
+                                            lParenLoc, args, argLabels,
+                                            argLabelLocs, rParenLoc,
+                                            trailingClosure);
+        if (status.isSuccess()) {
+          backtrack.cancelBacktrack();
+          
+          // Suggest replacing ':' with '=' (ensuring proper whitespace).
+          
+          bool needSpaceBefore = (pastEndOfPrevLoc == colonLoc);
+          bool needSpaceAfter =
+            SourceMgr.getByteDistance(colonLoc, startOfNextLoc) <= 1;
+          
+          StringRef replacement = " = ";
+          if (!needSpaceBefore) replacement = replacement.drop_front();
+          if (!needSpaceAfter)  replacement = replacement.drop_back();
+          
+          diagnose(lParenLoc, diag::initializer_as_typed_pattern)
+            .highlight({Ty.get()->getStartLoc(), rParenLoc})
+            .fixItReplace(colonLoc, replacement);
+          result.setIsParseError();
+        }
+      }
+    } else {
       Ty = makeParserResult(new (Context) ErrorTypeRepr(PreviousLoc));
+    }
     
     result = makeParserResult(result,
                             new (Context) TypedPattern(result.get(), Ty.get()));

--- a/test/Parse/diagnose_initializer_as_typed_pattern.swift
+++ b/test/Parse/diagnose_initializer_as_typed_pattern.swift
@@ -1,0 +1,35 @@
+// RUN: %target-parse-verify-swift
+
+// https://bugs.swift.org/browse/SR-1461
+
+class X {}
+func foo() {}
+
+let a:[X]()  // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{6-7= = }}
+let b: [X]()  // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{6-7= =}}
+let c :[X]()  // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{7-8== }}
+let d : [X]()  // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{7-8==}}
+
+let e: X(), ee: Int  // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{6-7= =}}
+
+var _1 = 1, _2 = 2
+
+// paren follows the type, but it's part of a separate (valid) expression
+let ff: X
+(_1, _2) = (_2, _1)
+let fff: X
+ (_1, _2) = (_2, _1)
+
+let g: X(x)  // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{6-7= =}}
+let h: X(x, y)  // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{6-7= =}}
+let i: X() { foo() }  // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{6-7= =}}
+let j: X(x) { foo() }  // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{6-7= =}}
+let k: X(x, y) { foo() }  // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{6-7= =}}
+
+func nonTopLevel() {
+  let a:[X]()   // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{8-9= = }}
+  let i: X() { foo() }  // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{8-9= =}}
+  let j: X(x) { foo() }  // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{8-9= =}}
+  let k: X(x, y) { foo() }  // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{8-9= =}}
+  _ = (a, i, j, k)
+}


### PR DESCRIPTION
#### What's in this pull request?

Diagnose and offer to replace `var x: [Int]()` with `var x = [Int]()`.

```
error: unexpected initializer in pattern; did you mean to use '='?
var x: [Int]()
     ~ ~~~~~^~
      =
```
#### Resolved bug number: [SR-1461](https://bugs.swift.org/browse/SR-1461)

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
