### PR TITLE
Revert "NSNumber bridging: use BOOL rather than _Bool when bridging Bools."

### DIFF
--- a/stdlib/public/SDK/Foundation/Foundation.swift
+++ b/stdlib/public/SDK/Foundation/Foundation.swift
@@ -160,7 +160,7 @@ internal func _swift_Foundation_TypePreservingNSNumberWithCGFloat(
 
 @_silgen_name("_swift_Foundation_TypePreservingNSNumberWithBool")
 internal func _swift_Foundation_TypePreservingNSNumberWithBool(
-  _ value: ObjCBool
+  _ value: Bool
 ) -> NSNumber
 
 @_silgen_name("_swift_Foundation_TypePreservingNSNumberGetKind")
@@ -207,7 +207,7 @@ internal func _swift_Foundation_TypePreservingNSNumberGetAsCGFloat(
 @_silgen_name("_swift_Foundation_TypePreservingNSNumberGetAsBool")
 internal func _swift_Foundation_TypePreservingNSNumberGetAsBool(
   _ value: NSNumber
-) -> ObjCBool
+) -> Bool
 
 // Conversions between NSNumber and various numeric types. The
 // conversion to NSNumber is automatic (auto-boxing), while conversion
@@ -348,7 +348,7 @@ extension Bool: _ObjectiveCBridgeable {
 
   @_semantics("convertToObjectiveC")
   public func _bridgeToObjectiveC() -> NSNumber {
-    return _swift_Foundation_TypePreservingNSNumberWithBool(ObjCBool(self))
+    return _swift_Foundation_TypePreservingNSNumberWithBool(self)
   }
 
   public static func _forceBridgeFromObjectiveC(
@@ -456,7 +456,7 @@ extension NSNumber : _HasCustomAnyHashableRepresentation {
     case .CoreGraphicsCGFloat:
       return AnyHashable(_swift_Foundation_TypePreservingNSNumberGetAsCGFloat(self))
     case .SwiftBool:
-      return AnyHashable(_swift_Foundation_TypePreservingNSNumberGetAsBool(self).boolValue)
+      return AnyHashable(_swift_Foundation_TypePreservingNSNumberGetAsBool(self))
     }
   }
 }

--- a/stdlib/public/SDK/Foundation/TypePreservingNSNumber.mm
+++ b/stdlib/public/SDK/Foundation/TypePreservingNSNumber.mm
@@ -76,7 +76,7 @@ enum _SwiftTypePreservingNSNumberTag {
   case SwiftCGFloat:
     return @encode(CGFloat);
   case SwiftBool:
-    return @encode(BOOL);
+    return @encode(bool);
   }
   swift::swift_reportError(
       /* flags = */ 0,
@@ -102,7 +102,7 @@ enum _SwiftTypePreservingNSNumberTag {
     memcpy(value, self->storage, sizeof(CGFloat));
     return;
   case SwiftBool:
-    memcpy(value, self->storage, sizeof(BOOL));
+    memcpy(value, self->storage, sizeof(bool));
     return;
   }
   swift::swift_reportError(
@@ -139,7 +139,7 @@ enum _SwiftTypePreservingNSNumberTag {
       return result; \
     } \
     case SwiftBool: { \
-      BOOL result; \
+      bool result; \
       memcpy(&result, self->storage, sizeof(result)); \
       return result; \
     } \
@@ -156,7 +156,6 @@ DEFINE_ACCESSOR(long long, longLongValue)
 DEFINE_ACCESSOR(unsigned long long, unsignedLongLongValue)
 DEFINE_ACCESSOR(float, floatValue)
 DEFINE_ACCESSOR(double, doubleValue)
-DEFINE_ACCESSOR(BOOL, boolValue)
 
 #undef DEFINE_ACCESSOR
 
@@ -179,7 +178,7 @@ DEFINE_INIT(NSUInteger, UInt)
 DEFINE_INIT(float, Float)
 DEFINE_INIT(double, Double)
 DEFINE_INIT(CGFloat, CGFloat)
-DEFINE_INIT(BOOL, Bool)
+DEFINE_INIT(bool, Bool)
 
 #undef DEFINE_INIT
 
@@ -213,7 +212,7 @@ DEFINE_GETTER(NSUInteger, UInt)
 DEFINE_GETTER(float, Float)
 DEFINE_GETTER(double, Double)
 DEFINE_GETTER(CGFloat, CGFloat)
-DEFINE_GETTER(BOOL, Bool)
+DEFINE_GETTER(bool, Bool)
 
 #undef DEFINE_GETTER
 

--- a/validation-test/stdlib/NSNumberBridging.swift.gyb
+++ b/validation-test/stdlib/NSNumberBridging.swift.gyb
@@ -229,11 +229,7 @@ NSNumberTests.test("_SwiftTypePreservingNSNumber(${Self}).getValue(_:), objCType
   _UnknownArchError()
 #endif
 %   elif Self == 'Bool':
-#if ((os(iOS) || os(tvOS)) && (arch(arm64) || arch(x86_64))) || os(watchOS)
   expectedObjCType = "B"
-#else
-  expectedObjCType = "c"
-#endif
 %   else:
   _UnknownTypeError()
 %   end


### PR DESCRIPTION
Reverts apple/swift#4363. #4366 is a more comprehensive solution.
