### PR TITLE
[FixCode] Apply coercion fixits on return statement and initialization.

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4040,6 +4040,8 @@ bool FailureDiagnosis::diagnoseContextualConversionError() {
   case CTP_DictionaryKey:
   case CTP_DictionaryValue:
   case CTP_AssignSource:
+  case CTP_Initialization:
+  case CTP_ReturnStmt:
     tryRawRepresentableFixIts(diag, CS, exprType, contextualType,
                               KnownProtocolKind::ExpressibleByIntegerLiteral,
                               expr) ||

--- a/test/FixCode/fixits-apply-objc.swift
+++ b/test/FixCode/fixits-apply-objc.swift
@@ -21,3 +21,11 @@ func foo(an : Any) {
   let a3 : AnyObject!
   a3 = an
 }
+
+func foo1(_ an : Any) {
+  let obj: AnyObject = an
+}
+
+func foo2(_ messageData: Any?) -> AnyObject? {
+  return messageData
+}

--- a/test/FixCode/fixits-apply-objc.swift.result
+++ b/test/FixCode/fixits-apply-objc.swift.result
@@ -21,3 +21,11 @@ func foo(an : Any) {
   let a3 : AnyObject!
   a3 = an as AnyObject!
 }
+
+func foo1(_ an : Any) {
+  let obj: AnyObject = an as AnyObject
+}
+
+func foo2(_ messageData: Any?) -> AnyObject? {
+  return messageData as AnyObject?
+}

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -28,7 +28,7 @@ struct MyMask : OptionSet {
 }
 
 func supported() -> MyMask {
-  return MyMask.Bingo
+  return MyMask(rawValue: UInt(MyMask.Bingo))
 }
 
 struct MyEventMask2 : OptionSet {


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->

   We saw manual migration is necessary on these cases to add 'as Type'. This patch starts
    to issue compiler fixits on return statement and initialization just like in other type-mismatch
    cases.

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…n as well. rdar://27891589 rdar://27891426

We saw manual migration is necessary on these cases to add 'as Type'. This patch starts
to issue compiler fixits on return statement and initialization just like in other type-mismatch
cases.
