### PR TITLE
Debug Info: Handle vector types when extending variable live ranges.

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -594,11 +594,14 @@ public:
       if (getActiveDominancePoint() == VarDominancePoint ||
           isActiveDominancePointDominatedBy(VarDominancePoint)) {
         llvm::Type *ArgTys;
-        auto *Ty = Storage->getType()->getScalarType();
-        // Pointers and Floats are expected to fit into a register.
-        if (Ty->isPointerTy() || Ty->isFloatingPointTy())
-          ArgTys = { Storage->getType() };
+        auto *Ty = Storage->getType();
+        // Vectors, Pointers and Floats are expected to fit into a register.
+        if (Ty->isPointerTy() || Ty->isFloatingPointTy() || Ty->isVectorTy())
+          ArgTys = { Ty };
         else {
+          // If this is not a scalar or vector type, we can't handle it.
+          if (isa<llvm::CompositeType>(Ty))
+            continue;
           // The storage is guaranteed to be no larger than the register width.
           // Extend the storage so it would fit into a register.
           llvm::Type *IntTy;

--- a/test/DebugInfo/liverange-extension-vector.swift
+++ b/test/DebugInfo/liverange-extension-vector.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend %s -g -emit-ir -o - | %FileCheck %s
+// REQUIRES: objc_interop, CPU=x86_64
+import simd
+
+func use<T>(_ x: T) {}
+
+func getInt32() -> Int32 { return -1 }
+
+public func rangeExtension(x: Int32, y: Int32) {
+  let p = int2(x, y)
+  // CHECK: define {{.*}}rangeExtension
+  // CHECK: llvm.dbg.value(metadata <2 x i32> %[[P:.*]], i64 0, metadata
+  use(p)
+  // CHECK: asm sideeffect "", "r"{{.*}}[[P]]
+}


### PR DESCRIPTION
This cherry-picks 56b7b08 onto swift-3.0-branch.
rdar://problem/27891980
