### PR TITLE
Revert "SILPassManager: After a new function is pushed on the stack don't res…"

### DIFF
--- a/include/swift/SILOptimizer/PassManager/PassManager.h
+++ b/include/swift/SILOptimizer/PassManager/PassManager.h
@@ -42,21 +42,8 @@ class SILPassManager {
   /// A list of registered analysis.
   llvm::SmallVector<SILAnalysis *, 16> Analysis;
 
-  /// An entry in the FunctionWorkList.
-  struct WorklistEntry {
-    WorklistEntry(SILFunction *F) : F(F) { }
-
-    SILFunction *F;
-
-    /// The current position in the transform-list.
-    unsigned PipelineIdx = 0;
-
-    /// How many times the pipeline was restarted for the function.
-    unsigned NumRestarts = 0;
-  };
-
   /// The worklist of functions to be processed by function passes.
-  std::vector<WorklistEntry> FunctionWorklist;
+  std::vector<SILFunction *> FunctionWorklist;
 
   // Name of the current optimization stage for diagnostics.
   std::string StageName;
@@ -224,8 +211,9 @@ private:
   /// the module.
   void runModulePass(SILModuleTransform *SMT);
 
-  /// Run the pass \p SFT on the function \p F.
-  void runPassOnFunction(SILFunctionTransform *SFT, SILFunction *F);
+  /// Run the passes in \p FuncTransforms on the function \p F.
+  void runPassesOnFunction(PassList FuncTransforms, SILFunction *F,
+                           bool runToCompletion);
 
   /// Run the passes in \p FuncTransforms. Return true
   /// if the pass manager requested to stop the execution

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -869,13 +869,6 @@ public:
       // Make sure the PM knows about this function. This will also help us
       // with self-recursion.
       notifyPassManagerOfFunction(FST.getOptimizedFunction());
-
-      // We have to restart the pipeline for this thunk in order to run the
-      // inliner (and other opts) again. This is important if the new
-      // specialized function (which is called from this thunk) is
-      // function-signature-optimized again and also becomes an
-      // always-inline-thunk.
-      restartPassPipeline();
     }
   }
 

--- a/test/SILOptimizer/inline_devirtualize_specialize.sil
+++ b/test/SILOptimizer/inline_devirtualize_specialize.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -devirtualizer -generic-specializer -inline -dce | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -inline -devirtualizer -generic-specializer -dce | %FileCheck %s
 
 sil_stage canonical
 


### PR DESCRIPTION
Reverts apple/swift#4358. This change caused test Interpreter/enum.swift to use 30 GB of heap memory.
