### PR TITLE
[SIL] Fix Diagnosing Never-returning functions that don't call other Never-returning functions

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -179,7 +179,11 @@ ERROR(assignment_to_immutable_value,none,
 ERROR(missing_return,none,
       "missing return in a %select{function|closure}1 expected to return %0",
       (Type, unsigned))
-ERROR(non_exhaustive_switch,none, 
+ERROR(missing_never_call,none,
+      "%select{function|closure}1 with uninhabited return type %0 is missing "
+      "call to another never-returning function on all paths",
+      (Type, unsigned))
+ERROR(non_exhaustive_switch,none,
       "switch must be exhaustive, consider adding a default clause", ())
 ERROR(guard_body_must_not_fallthrough,none,
       "'guard' body may not fall through, consider using 'return' or 'break'"

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -393,7 +393,7 @@ public:
   /// semantics?
   bool hasReferenceSemantics();
 
-  /// Is this an uninhabited type, such as 'Never'?
+  /// Is this 'Never'?
   bool isNever();
 
   /// Is this the 'Any' type?

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -393,8 +393,8 @@ public:
   /// semantics?
   bool hasReferenceSemantics();
 
-  /// Is this 'Never'?
-  bool isNever();
+  /// Is this an uninhabited type, such as 'Never'?
+  bool isUninhabited();
 
   /// Is this the 'Any' type?
   bool isAny();

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -89,10 +89,11 @@ bool TypeBase::hasReferenceSemantics() {
   return getCanonicalType().hasReferenceSemantics();
 }
 
-bool TypeBase::isNever() {
+bool TypeBase::isUninhabited() {
   if (auto nominalDecl = getAnyNominal())
     if (auto enumDecl = dyn_cast<EnumDecl>(nominalDecl))
-      return enumDecl == getASTContext().getNeverDecl();
+      if (enumDecl->getAllElements().empty())
+        return true;
   return false;
 }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -92,9 +92,7 @@ bool TypeBase::hasReferenceSemantics() {
 bool TypeBase::isNever() {
   if (auto nominalDecl = getAnyNominal())
     if (auto enumDecl = dyn_cast<EnumDecl>(nominalDecl))
-      if (enumDecl->getAllElements().empty())
-        return true;
-
+      return enumDecl == getASTContext().getNeverDecl();
   return false;
 }
 

--- a/lib/IRGen/GenClangType.cpp
+++ b/lib/IRGen/GenClangType.cpp
@@ -493,7 +493,7 @@ GenClangType::visitBoundGenericType(CanBoundGenericType type) {
 clang::CanQualType GenClangType::visitEnumType(CanEnumType type) {
   // Special case: Uninhabited enums are not @objc, so we don't
   // know what to do below, but we can just convert to 'void'.
-  if (type->getDecl()->getAllElements().empty())
+  if (type->isUninhabited())
     return Converter.convert(IGM, IGM.Context.TheEmptyTupleType);
 
   assert(type->getDecl()->isObjC() && "not an @objc enum?!");

--- a/lib/IRGen/GenClangType.cpp
+++ b/lib/IRGen/GenClangType.cpp
@@ -493,7 +493,7 @@ GenClangType::visitBoundGenericType(CanBoundGenericType type) {
 clang::CanQualType GenClangType::visitEnumType(CanEnumType type) {
   // Special case: Uninhabited enums are not @objc, so we don't
   // know what to do below, but we can just convert to 'void'.
-  if (type->isNever())
+  if (type->getDecl()->getAllElements().empty())
     return Converter.convert(IGM, IGM.Context.TheEmptyTupleType);
 
   assert(type->getDecl()->isObjC() && "not an @objc enum?!");

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -72,7 +72,7 @@ bool SILType::isReferenceCounted(SILModule &M) const {
 
 bool SILType::isNoReturnFunction() const {
   if (auto funcTy = dyn_cast<SILFunctionType>(getSwiftRValueType()))
-    return funcTy->getSILResult().getSwiftRValueType()->isNever();
+    return funcTy->getSILResult().getSwiftRValueType()->isUninhabited();
 
   return false;
 }

--- a/lib/SILOptimizer/Mandatory/DataflowDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/DataflowDiagnostics.cpp
@@ -46,16 +46,13 @@ static void diagnoseMissingReturn(const UnreachableInst *UI,
     llvm_unreachable("unhandled case in MissingReturn");
   }
 
-  // No action required if the function returns 'Void' or that the
-  // function is marked 'noreturn'.
-  if (ResTy->isVoid() || F->isNoReturnFunction())
-    return;
-
   SILLocation L = UI->getLoc();
   assert(L && ResTy);
+  auto diagID = F->isNoReturnFunction() ? diag::missing_never_call
+                                        : diag::missing_return;
   diagnose(Context,
            L.getEndSourceLoc(),
-           diag::missing_return, ResTy,
+           diagID, ResTy,
            FLoc.isASTNode<ClosureExpr>() ? 1 : 0);
 }
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1005,7 +1005,7 @@ bool TypeChecker::typeCheckCatchPattern(CatchStmt *S, DeclContext *DC) {
 
 static bool isDiscardableType(Type type) {
   return (type->is<ErrorType>() ||
-          type->isNever() ||
+          type->isUninhabited() ||
           type->lookThroughAllAnyOptionalTypes()->isVoid());
 }
 

--- a/test/IRGen/dllexport.swift
+++ b/test/IRGen/dllexport.swift
@@ -20,7 +20,7 @@ public var ci : c = c()
 
 open class d {
   private func m() -> Never {
-    return fatalError()
+    fatalError()
   }
 }
 

--- a/test/IRGen/dllexport.swift
+++ b/test/IRGen/dllexport.swift
@@ -20,7 +20,7 @@ public var ci : c = c()
 
 open class d {
   private func m() -> Never {
-    fatalError()
+    return fatalError()
   }
 }
 

--- a/test/SILOptimizer/return.swift
+++ b/test/SILOptimizer/return.swift
@@ -12,7 +12,28 @@ func singleBlock2() -> Int {
 enum NoCasesButNotNever {}
 
 func diagnoseNoCaseEnumMissingReturn() -> NoCasesButNotNever {
-} // expected-error {{missing return in a function expected to return 'NoCasesButNotNever'}}
+} // expected-error {{function with uninhabited return type 'NoCasesButNotNever' is missing call to another never-returning function on all paths}} 
+
+func diagnoseNeverMissingBody() -> Never {
+} // expected-error {{function with uninhabited return type 'Never' is missing call to another never-returning function on all paths}} 
+
+_ = { () -> Never in
+}() // expected-error {{closure with uninhabited return type 'Never' is missing call to another never-returning function on all paths}}-
+
+func diagnoseNeverWithBody(i : Int) -> Never {
+  if (i == -1) {
+    print("Oh no!")
+  } else {
+    switch i {
+    case 0:
+      exit()
+    case 1:
+      fatalError()
+    default:
+      repeat { } while true 
+    } 
+  }
+} // expected-error {{function with uninhabited return type 'Never' is missing call to another never-returning function on all paths}}
 
 class MyClassWithClosure {
   var f : (_ s: String) -> String = { (_ s: String) -> String in } // expected-error {{missing return in a closure expected to return 'String'}}

--- a/test/SILOptimizer/return.swift
+++ b/test/SILOptimizer/return.swift
@@ -9,6 +9,11 @@ func singleBlock2() -> Int {
   y += 1
 } // expected-error {{missing return in a function expected to return 'Int'}}
 
+enum NoCasesButNotNever {}
+
+func diagnoseNoCaseEnumMissingReturn() -> NoCasesButNotNever {
+} // expected-error {{missing return in a function expected to return 'NoCasesButNotNever'}}
+
 class MyClassWithClosure {
   var f : (_ s: String) -> String = { (_ s: String) -> String in } // expected-error {{missing return in a closure expected to return 'String'}}
 }


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

A more principled fix than #4365.  It turns out we have never handled this kind of thing correctly in the SIL Optimizer.  Previous versions of Swift even allowed this to work before the uninhabited changes went through.

``` swift
enum X {}
@noreturn func foo() -> X {}
```

The SIL Optimizer now understands that `Void` is the only case where a missing return is acceptable and correctly diagnoses failing to call other `Never`-returning functions from all paths in `Never`-returning functions.

@slavapestov can you review?

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
