### PR TITLE
Sema: Record Hashable conformance as used when emitting AnyHashableErasureExpr (3.0)

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5345,7 +5345,8 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       auto hashable = tc.Context.getProtocol(KnownProtocolKind::Hashable);
       ProtocolConformance *conformance;
       bool conforms = tc.conformsToProtocol(expr->getType(), hashable, cs.DC,
-                                            ConformanceCheckFlags::InExpression,
+                                            ConformanceCheckFlags::InExpression |
+                                            ConformanceCheckFlags::Used,
                                             &conformance);
       assert(conforms && "must conform to Hashable");
       (void)conforms;

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -509,3 +509,19 @@ extension GenericClass {
     return x
   }
 }
+
+// Make sure AnyHashable erasure marks Hashable conformance as used
+class AnyHashableClass : NSObject {
+  // CHECK-LABEL: sil hidden @_TFC17objc_bridging_any16AnyHashableClass18returnsAnyHashablefT_Vs11AnyHashable
+  // CHECK: [[FN:%.*]] = function_ref @_swift_convertToAnyHashable
+  // CHECK: apply [[FN]]<GenericOption>({{.*}})
+  func returnsAnyHashable() -> AnyHashable {
+    return GenericOption.multithreaded
+  }
+}
+
+// CHECK-LABEL: sil_witness_table shared [fragile] GenericOption: Hashable module objc_generics {
+// CHECK-NEXT: base_protocol _Hashable: GenericOption: _Hashable module objc_generics
+// CHECK-NEXT: base_protocol Equatable: GenericOption: Equatable module objc_generics
+// CHECK-NEXT: method #Hashable.hashValue!getter.1: @_TTWVSC13GenericOptions8Hashable13objc_genericsFS0_g9hashValueSi
+// CHECK-NEXT: }


### PR DESCRIPTION
- Explanation: When constructing AST for a coercion to AnyHashable, we neglected to mark the conformance as used, which could lead to a link failure due to a missing symbol.
- Scope of issue: Affects anyone using the new AnyHashable type, or dictionaries containing AnyHashable as keys.
- Risk: Low
- Radar: rdar://problem/27895165
