### PR TITLE
[SIL][Swift 3.0] Diagnose improperly-written functions returning uninhabited types

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -179,7 +179,11 @@ ERROR(assignment_to_immutable_value,none,
 ERROR(missing_return,none,
       "missing return in a %select{function|closure}1 expected to return %0",
       (Type, unsigned))
-ERROR(non_exhaustive_switch,none, 
+ERROR(missing_never_call,none,
+      "%select{function|closure}1 with uninhabited return type %0 is missing "
+      "call to another never-returning function on all paths",
+      (Type, unsigned))
+ERROR(non_exhaustive_switch,none,
       "switch must be exhaustive, consider adding a default clause", ())
 ERROR(guard_body_must_not_fallthrough,none,
       "'guard' body may not fall through, consider using 'return' or 'break'"

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -394,7 +394,7 @@ public:
   bool hasReferenceSemantics();
 
   /// Is this an uninhabited type, such as 'Never'?
-  bool isNever();
+  bool isUninhabited();
 
   /// Is this the 'Any' type?
   bool isAny();

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -89,12 +89,11 @@ bool TypeBase::hasReferenceSemantics() {
   return getCanonicalType().hasReferenceSemantics();
 }
 
-bool TypeBase::isNever() {
+bool TypeBase::isUninhabited() {
   if (auto nominalDecl = getAnyNominal())
     if (auto enumDecl = dyn_cast<EnumDecl>(nominalDecl))
       if (enumDecl->getAllElements().empty())
         return true;
-
   return false;
 }
 

--- a/lib/IRGen/GenClangType.cpp
+++ b/lib/IRGen/GenClangType.cpp
@@ -493,7 +493,7 @@ GenClangType::visitBoundGenericType(CanBoundGenericType type) {
 clang::CanQualType GenClangType::visitEnumType(CanEnumType type) {
   // Special case: Uninhabited enums are not @objc, so we don't
   // know what to do below, but we can just convert to 'void'.
-  if (type->isNever())
+  if (type->isUninhabited())
     return Converter.convert(IGM, IGM.Context.TheEmptyTupleType);
 
   assert(type->getDecl()->isObjC() && "not an @objc enum?!");

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -72,7 +72,7 @@ bool SILType::isReferenceCounted(SILModule &M) const {
 
 bool SILType::isNoReturnFunction() const {
   if (auto funcTy = dyn_cast<SILFunctionType>(getSwiftRValueType()))
-    return funcTy->getSILResult().getSwiftRValueType()->isNever();
+    return funcTy->getSILResult().getSwiftRValueType()->isUninhabited();
 
   return false;
 }

--- a/lib/SILOptimizer/Mandatory/DataflowDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/DataflowDiagnostics.cpp
@@ -46,16 +46,13 @@ static void diagnoseMissingReturn(const UnreachableInst *UI,
     llvm_unreachable("unhandled case in MissingReturn");
   }
 
-  // No action required if the function returns 'Void' or that the
-  // function is marked 'noreturn'.
-  if (ResTy->isVoid() || F->isNoReturnFunction())
-    return;
-
   SILLocation L = UI->getLoc();
   assert(L && ResTy);
+  auto diagID = F->isNoReturnFunction() ? diag::missing_never_call
+                                        : diag::missing_return;
   diagnose(Context,
            L.getEndSourceLoc(),
-           diag::missing_return, ResTy,
+           diagID, ResTy,
            FLoc.isASTNode<ClosureExpr>() ? 1 : 0);
 }
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1005,7 +1005,7 @@ bool TypeChecker::typeCheckCatchPattern(CatchStmt *S, DeclContext *DC) {
 
 static bool isDiscardableType(Type type) {
   return (type->is<ErrorType>() ||
-          type->isNever() ||
+          type->isUninhabited() ||
           type->lookThroughAllAnyOptionalTypes()->isVoid());
 }
 

--- a/test/SILOptimizer/return.swift
+++ b/test/SILOptimizer/return.swift
@@ -9,6 +9,32 @@ func singleBlock2() -> Int {
   y += 1
 } // expected-error {{missing return in a function expected to return 'Int'}}
 
+enum NoCasesButNotNever {}
+
+func diagnoseNoCaseEnumMissingReturn() -> NoCasesButNotNever {
+} // expected-error {{function with uninhabited return type 'NoCasesButNotNever' is missing call to another never-returning function on all paths}} 
+
+func diagnoseNeverMissingBody() -> Never {
+} // expected-error {{function with uninhabited return type 'Never' is missing call to another never-returning function on all paths}} 
+
+_ = { () -> Never in
+}() // expected-error {{closure with uninhabited return type 'Never' is missing call to another never-returning function on all paths}}-
+
+func diagnoseNeverWithBody(i : Int) -> Never {
+  if (i == -1) {
+    print("Oh no!")
+  } else {
+    switch i {
+    case 0:
+      exit()
+    case 1:
+      fatalError()
+    default:
+      repeat { } while true 
+    } 
+  }
+} // expected-error {{function with uninhabited return type 'Never' is missing call to another never-returning function on all paths}}
+
 class MyClassWithClosure {
   var f : (_ s: String) -> String = { (_ s: String) -> String in } // expected-error {{missing return in a closure expected to return 'String'}}
 }


### PR DESCRIPTION
- Explanation: This patch fixes an issue where the SIL Optimizer failed to diagnose unreachables in basic blocks as missing returns.  This means any function or closure with a return type that is "uninhabited" gets lowered as an unreachable and as a result was allowed to elide `return`s and calls to other noreturn functions.  It is now an error to do this, and any function relying on this should call another uninhabited function or add cases to their empty enum.
- Scope: Affects closures and functions that return "uninhabited" types that couldn't have been constructed anyway.  This change is potentially source-breaking as a result, though the fix is just to be explicit about wanting to blow up.
- Risk: Low.
- Testing: New tests added.
- Radar: rdar://27897848
