### PR TITLE
[swiftc (51 vs. 5156)] Add crasher in swift::ArchetypeBuilder::getGenericSignature(...)

### DIFF
--- a/validation-test/compiler_crashers/28398-swift-archetypebuilder-getgenericsignature.swift
+++ b/validation-test/compiler_crashers/28398-swift-archetypebuilder-getgenericsignature.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+protocol A{class A{var _=c<}protocol A{extension{func<:a


### PR DESCRIPTION
Add test case for crash triggered in `swift::ArchetypeBuilder::getGenericSignature(...)`.

Current number of unresolved compiler crashers: 51 (5156 resolved)

Assertion failure in [`lib/AST/ArchetypeBuilder.cpp (line 2249)`](https://github.com/apple/swift/blob/master/lib/AST/ArchetypeBuilder.cpp#L2249):

```
Assertion `pa && "Missing potential archetype for generic parameter"' failed.

When executing: void collectRequirements(swift::ArchetypeBuilder &, ArrayRef<swift::GenericTypeParamType *>, SmallVectorImpl<swift::Requirement> &)
```

Assertion context:

```
  // of the requirements.
  llvm::SmallPtrSet<PotentialArchetype *, 16> knownPAs;
  llvm::SmallVector<GenericTypeParamType *, 8> primary;
  for (auto param : params) {
    auto pa = builder.resolveArchetype(param);
    assert(pa && "Missing potential archetype for generic parameter");

    // We only care about the representative.
    pa = pa->getRepresentative();

    if (knownPAs.insert(pa).second)
```

Stack trace:

```
swift: /path/to/swift/lib/AST/ArchetypeBuilder.cpp:2249: void collectRequirements(swift::ArchetypeBuilder &, ArrayRef<swift::GenericTypeParamType *>, SmallVectorImpl<swift::Requirement> &): Assertion `pa && "Missing potential archetype for generic parameter"' failed.
8  swift           0x000000000101fae4 swift::ArchetypeBuilder::getGenericSignature(llvm::ArrayRef<swift::GenericTypeParamType*>) + 1604
9  swift           0x0000000000f11128 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 296
12 swift           0x0000000000ed12b1 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 945
15 swift           0x000000000113a4e2 swift::namelookup::lookupInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::DeclName, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >) + 1122
16 swift           0x0000000001141b3f swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 4703
17 swift           0x0000000000f1516b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
18 swift           0x0000000000ebba04 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 116
21 swift           0x000000000109a25b swift::Expr::walk(swift::ASTWalker&) + 75
22 swift           0x0000000000ebd1f0 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 224
23 swift           0x0000000000ec443d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 621
24 swift           0x0000000000ec55f0 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 352
25 swift           0x0000000000ec580b swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
32 swift           0x0000000000ed7466 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
33 swift           0x0000000000efb3a2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
34 swift           0x0000000000c7b5b9 swift::CompilerInstance::performSema() + 3289
36 swift           0x00000000007db487 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
37 swift           0x00000000007a72b8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28398-swift-archetypebuilder-getgenericsignature.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28398-swift-archetypebuilder-getgenericsignature-207c59.o
1.  While type-checking 'A' at validation-test/compiler_crashers/28398-swift-archetypebuilder-getgenericsignature.swift:10:1
2.  While type-checking expression at [validation-test/compiler_crashers/28398-swift-archetypebuilder-getgenericsignature.swift:10:26 - line:10:27] RangeText="c<"
3.  While type-checking '<' at validation-test/compiler_crashers/28398-swift-archetypebuilder-getgenericsignature.swift:10:50
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
