### PR TITLE
[Parse] Improve fix-it for @autoclosure(escaping)

### DIFF
--- a/test/attr/attr_autoclosure.swift
+++ b/test/attr/attr_autoclosure.swift
@@ -75,22 +75,22 @@ func func10(@autoclosure(escaping _: () -> ()) { } // expected-error{{expected '
 // expected-note@-1{{to match this opening '('}}
 
 func func11(_: @autoclosure(escaping) @noescape () -> ()) { } // expected-error{{@escaping conflicts with @noescape}}
-  // expected-warning@-1{{@autoclosure(escaping) is deprecated; use @autoclosure @escaping instead}} {{17-38=@autoclosure @escaping }}
+  // expected-warning@-1{{@autoclosure(escaping) is deprecated; use @autoclosure @escaping instead}} {{28-38= @escaping}}
 
 class Super {
   func f1(_ x: @autoclosure(escaping) () -> ()) { }
-    // expected-warning@-1{{@autoclosure(escaping) is deprecated; use @autoclosure @escaping instead}} {{17-38=@autoclosure @escaping }}
+    // expected-warning@-1{{@autoclosure(escaping) is deprecated; use @autoclosure @escaping instead}} {{28-38= @escaping}}
   func f2(_ x: @autoclosure(escaping) () -> ()) { } // expected-note {{potential overridden instance method 'f2' here}}
-    // expected-warning@-1{{@autoclosure(escaping) is deprecated; use @autoclosure @escaping instead}} {{17-38=@autoclosure @escaping }}
+    // expected-warning@-1{{@autoclosure(escaping) is deprecated; use @autoclosure @escaping instead}} {{28-38= @escaping}}
   func f3(x: @autoclosure () -> ()) { }
 }
 
 class Sub : Super {
   override func f1(_ x: @autoclosure(escaping)() -> ()) { }
-    // expected-warning@-1{{@autoclosure(escaping) is deprecated; use @autoclosure @escaping instead}} {{26-47=@autoclosure @escaping }}
+    // expected-warning@-1{{@autoclosure(escaping) is deprecated; use @autoclosure @escaping instead}} {{37-47= @escaping }}
   override func f2(_ x: @autoclosure () -> ()) { } // expected-error{{does not override any method}}
   override func f3(_ x: @autoclosure(escaping) () -> ()) { }  // expected-error{{does not override any method}}
-    // expected-warning@-1{{@autoclosure(escaping) is deprecated; use @autoclosure @escaping instead}} {{26-47=@autoclosure @escaping }}
+    // expected-warning@-1{{@autoclosure(escaping) is deprecated; use @autoclosure @escaping instead}} {{37-47= @escaping}}
 }
 
 func func12_sink(_ x: @escaping () -> Int) { }
@@ -101,7 +101,7 @@ func func12a(_ x: @autoclosure () -> Int) {
   func12_sink(x) // expected-error {{passing non-escaping parameter 'x' to function expecting an @escaping closure}}
 }
 func func12b(_ x: @autoclosure(escaping) () -> Int) {
-  // expected-warning@-1{{@autoclosure(escaping) is deprecated; use @autoclosure @escaping instead}} {{20-41=@autoclosure @escaping }}
+  // expected-warning@-1{{@autoclosure(escaping) is deprecated; use @autoclosure @escaping instead}} {{31-41= @escaping}}
   func12_sink(x) // ok
 }
 func func12c(_ x: @autoclosure @escaping () -> Int) {
@@ -132,7 +132,7 @@ enum AutoclosureFailableOf<T> {
 
 let _ : (@autoclosure () -> ()) -> ()
 let _ : (@autoclosure(escaping) () -> ()) -> ()
-  // expected-warning@-1{{@autoclosure(escaping) is deprecated; use @autoclosure @escaping instead}} {{11-32=@autoclosure @escaping }}
+  // expected-warning@-1{{@autoclosure(escaping) is deprecated; use @autoclosure @escaping instead}} {{22-32= @escaping}}
 
 // escaping is the name of param type
 let _ : (@autoclosure(escaping) -> ()) -> ()  // expected-error {{use of undeclared type 'escaping'}}


### PR DESCRIPTION
- Explanation: This patch nominates @rintaro's fixes for our off-by-one `@autoclosure(escaping)` fixit logic. 
- Scope: Affects a bogus fixit.
- Risk: Very Low.
- Testing: Tests amended with the proper behavior.
