### PR TITLE
[PlaygroundTransform] Instrument mutations of inout vars by class methods.

### DIFF
--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -611,15 +611,19 @@ public:
                   Elements.insert(Elements.begin() + (EI + 1), *Log);
                   ++EI;
                 }
-              }
-            } else if (DeclRefExpr *DRE = digForInoutDeclRef(AE->getArg())) {
-              Added<Stmt *> Log = logDeclOrMemberRef(DRE);
-              if (*Log) {
-                Elements.insert(Elements.begin() + (EI + 1), *Log);
-                ++EI;
+                Handled = true;
               }
             }
-            Handled = true;
+            if (!Handled) {
+              if (DeclRefExpr *DRE = digForInoutDeclRef(AE->getArg())) {
+                Added<Stmt *> Log = logDeclOrMemberRef(DRE);
+                if (*Log) {
+                  Elements.insert(Elements.begin() + (EI + 1), *Log);
+                  ++EI;
+                }
+                Handled = true;
+              }
+            }
           }
           if (!Handled) {
             // do the same as for all other expressions

--- a/test/PlaygroundTransform/plus_equals.swift
+++ b/test/PlaygroundTransform/plus_equals.swift
@@ -10,4 +10,4 @@ var b = "b"
 a += b 
 // CHECK: [{{.*}}] $builtin_log[a='a']
 // CHECK-NEXT: [{{.*}}] $builtin_log[b='b']
-// CHECK-NEXT: [{{.*}}] $builtin_log[='ab']
+// CHECK-NEXT: [{{.*}}] $builtin_log[a='ab']

--- a/test/PlaygroundTransform/plus_equals.swift
+++ b/test/PlaygroundTransform/plus_equals.swift
@@ -1,0 +1,13 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// REQUIRES: executable_test
+
+var a = "a"
+var b = "b" 
+a += b 
+// CHECK: [{{.*}}] $builtin_log[a='a']
+// CHECK-NEXT: [{{.*}}] $builtin_log[b='b']
+// CHECK-NEXT: [{{.*}}] $builtin_log[='ab']


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

[PlaygroundTransform] Instrument mutations of inout vars by class methods.

+= is now a class method, which means the playground transform ignores it. This
is undesirable, and we have ways to instrument methods that mutate inout
parameters the way += does. I have just made it so that if we see a method call
and we can't instrument the mutation of the base of the method call, we still
instrument the inout argument if there is one.

Also added a test case.
#### Resolved bug number: rdar://problem/27876479 Tests failed because += did not produce result when updating a variable

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
