### PR TITLE
[Import as Member] Error on convenience inits in extensions of CFTypes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2040,6 +2040,9 @@ ERROR(enumstruct_convenience_init,none,
 ERROR(nonclass_convenience_init,none,
       "convenience initializer not allowed in non-class type %0",
       (Type))
+ERROR(cfclass_convenience_init,none,
+      "convenience initializers are not supported in extensions of CF types",
+      ())
 
 ERROR(dynamic_construct_class,none,
       "constructing an object of class type %0 with a metatype value must use "

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6313,8 +6313,16 @@ public:
     // extensions thereof.
     if (CD->isConvenienceInit()) {
       if (auto extType = CD->getExtensionType()) {
-        if (!extType->getClassOrBoundGenericClass() &&
-            !extType->is<ErrorType>()) {
+        auto extClass = extType->getClassOrBoundGenericClass();
+
+        // Forbid convenience inits on Foreign CF types, as Swift does not yet
+        // support user-defined factory inits.
+        if (extClass &&
+            extClass->getForeignClassKind() == ClassDecl::ForeignKind::CFType) {
+          TC.diagnose(CD->getLoc(), diag::cfclass_convenience_init);
+        }
+
+        if (!extClass && !extType->is<ErrorType>()) {
           auto ConvenienceLoc =
             CD->getAttrs().getAttribute<ConvenienceAttr>()->getLocation();
 

--- a/test/ClangModules/CoreGraphics_test.swift
+++ b/test/ClangModules/CoreGraphics_test.swift
@@ -87,15 +87,6 @@ public func testColorRenames(color: CGColor,
 // CHECK:   ret void
 }
 
-// Test factory-ness of inferred imports
-extension CGMutablePath {
-  // CHECK-LABEL: define %{{.*}}CGMutablePath* {{.*}}CGMutablePath{{.*}}(i1{{.*}})
-  public convenience init(p: Bool) {
-    self.init()
-    // CHECK: tail call %struct.CGPath* @CGPathCreateMutable()
-  }
-}
-
 // CHECK-LABEL: define void {{.*}}testRenames{{.*}} {
 public func testRenames(transform: CGAffineTransform, context: CGContext,
                         point: CGPoint, size: CGSize, rect: CGRect,

--- a/test/decl/init/cf-types.swift
+++ b/test/decl/init/cf-types.swift
@@ -1,0 +1,23 @@
+// RUN: %target-parse-verify-swift
+// REQUIRES: OS=macosx
+
+import CoreGraphics
+
+extension CGMutablePath {
+  public convenience init(p: Bool) { // expected-error{{convenience initializers are not supported in extensions of CF types}}
+    self.init()
+  }
+  public convenience init?(maybe: Bool) { // expected-error{{convenience initializers are not supported in extensions of CF types}}
+    self.init()
+  }
+
+  public convenience init(toss: Bool) throws { // expected-error{{convenience initializers are not supported in extensions of CF types}}
+    self.init()
+  }
+}
+
+public func useInit() {
+  let _ = CGMutablePath(p: true)
+  let _ = CGMutablePath(maybe: true)
+  let _ = try! CGMutablePath(toss: true)
+}


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

```
Swift does not currently support user-defined factory inits. With
import as member, we're seeing many C functions now imported as
initializers, which gives users the false hope that they can define
their own factory inits as conveinence inits in extensions of CF
types. We issue an explicit error now, rather than crashing later.
```
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Swift does not currently support user-defined factory inits. With
import as member, we're seeing many C functions now imported as
initializers, which gives users the false hope that they can define
their own factory inits as conveinence inits in extensions of CF
types. We issue an explicit error now, rather than crashing later.
