### PR TITLE
Revert "build libdispatch by default in both linux build bot configurations"

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -645,13 +645,11 @@ test
 validation-test
 long-test
 foundation
-libdispatch
 lit-args=-v
 
 dash-dash
 
 install-foundation
-install-libdispatch
 reconfigure
 
 # Ubuntu 16.04 preset for backwards compat and future customizations.
@@ -733,7 +731,6 @@ llbuild
 swiftpm
 xctest
 foundation
-libdispatch
 dash-dash
 
 [preset: buildbot_incremental_linux,long_test]

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2363,8 +2363,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 SWIFTC_BIN="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
                 LLVM_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
 
-                if [[ "${RECONFIGURE}" || ! -f "${LIBDISPATCH_BUILD_DIR}"/config.status ]]; then
-                    echo "Reconfiguring libdispatch"
+                if [[ ! -f "${LIBDISPATCH_BUILD_DIR}"/config.status ]]; then
                     # First time building; need to run autotools and configure
                     if [[ "$LIBDISPATCH_BUILD_TYPE" == "Release" ]] ; then
                         dispatch_build_variant_arg="release"
@@ -2381,8 +2380,7 @@ for host in "${ALL_HOSTS[@]}"; do
                             "${LIBDISPATCH_SOURCE_DIR}"/configure --with-swift-toolchain="${SWIFT_BUILD_PATH}" \
                             --with-build-variant=$dispatch_build_variant_arg \
                             --prefix="$(get_host_install_destdir ${host})$(get_host_install_prefix ${host})"
-                else
-                    echo "Skipping reconfiguration of libdispatch"
+
                 fi
                 with_pushd "${LIBDISPATCH_BUILD_DIR}" \
                     call make


### PR DESCRIPTION
Reverts apple/swift#4203. This broke Linux CI.
https://ci.swift.org/job/oss-swift-incremental-RA-linux-ubuntu-15_10/7448/
