### PR TITLE
Revert "[ClangImporter] Remove unused variable. NFC."

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5021,6 +5021,7 @@ namespace {
                              const clang::ObjCProtocolList &clangProtocols,
                              SmallVectorImpl<TypeLoc> &inheritedTypes) {
       SmallVector<ProtocolDecl *, 4> protocols;
+      llvm::SmallPtrSet<ProtocolDecl *, 4> knownProtocols;
       if (auto nominal = dyn_cast<NominalTypeDecl>(decl))
         nominal->getImplicitProtocols(protocols);
 


### PR DESCRIPTION
Reverts apple/swift#4426 as a precursor to reverting #4394.
