### PR TITLE
[QoI] fix diagnosis of non-Optional enum used in optional pattern

### DIFF
--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -591,45 +591,6 @@ func testRequireOptional2(_ a : String?) -> String {
   return t
 }
 
-enum MyOptional<Wrapped> {
-  case none
-  case some(Wrapped)
-}
-
-// CHECK-LABEL: sil hidden @_TF10statements28testAddressOnlyEnumInRequire
-// CHECK: bb0(%0 : $*T, %1 : $*MyOptional<T>):
-// CHECK-NEXT: debug_value_addr %1 : $*MyOptional<T>, let, name "a"
-// CHECK-NEXT: %3 = alloc_stack $T, let, name "t"
-// CHECK-NEXT: %4 = alloc_stack $MyOptional<T>
-// CHECK-NEXT: copy_addr %1 to [initialization] %4 : $*MyOptional<T>
-// CHECK-NEXT: switch_enum_addr %4 : $*MyOptional<T>, case #MyOptional.some!enumelt.1: bb2, default bb1
-func testAddressOnlyEnumInRequire<T>(_ a: MyOptional<T>) -> T {
-  // CHECK:  bb1:
-  // CHECK-NEXT:   dealloc_stack %4
-  // CHECK-NEXT:   dealloc_stack %3
-  // CHECK-NEXT:   br bb3
-  guard let t = a else { abort() }
-
-  // CHECK:    bb2:
-  // CHECK-NEXT:     %10 = unchecked_take_enum_data_addr %4 : $*MyOptional<T>, #MyOptional.some!enumelt.1
-  // CHECK-NEXT:     copy_addr [take] %10 to [initialization] %3 : $*T
-  // CHECK-NEXT:     dealloc_stack %4
-  // CHECK-NEXT:     copy_addr [take] %3 to [initialization] %0 : $*T
-  // CHECK-NEXT:     dealloc_stack %3
-  // CHECK-NEXT:     destroy_addr %1 : $*MyOptional<T>
-  // CHECK-NEXT:     tuple ()
-  // CHECK-NEXT:     return
-
-  // CHECK:    bb3:
-  // CHECK-NEXT:     // function_ref statements.abort () -> Swift.Never
-  // CHECK-NEXT:     %18 = function_ref @_TF10statements5abortFT_Os5Never
-  // CHECK-NEXT:     %19 = apply %18() : $@convention(thin) () -> Never
-  // CHECK-NEXT:     unreachable
-
-  return t
-}
-
-
 
 // CHECK-LABEL: sil hidden @_TF10statements19testCleanupEmission
 // <rdar://problem/20563234> let-else problem: cleanups for bound patterns shouldn't be run in the else block

--- a/test/stmt/if_while_var.swift
+++ b/test/stmt/if_while_var.swift
@@ -1,7 +1,11 @@
 // RUN: %target-parse-verify-swift
 
+struct NonOptionalStruct {}
+enum NonOptionalEnum { case foo }
+
 func foo() -> Int? { return .none }
-func nonOptional() -> Int { return 0 }
+func nonOptionalStruct() -> NonOptionalStruct { fatalError() }
+func nonOptionalEnum() -> NonOptionalEnum { fatalError() }
 func use(_ x: Int) {}
 func modify(_ x: inout Int) {}
 
@@ -19,7 +23,14 @@ if var x = foo() {
 
 use(x) // expected-error{{unresolved identifier 'x'}}
 
-if let x = nonOptional() { } // expected-error{{initializer for conditional binding must have Optional type, not 'Int'}}
+if let x = nonOptionalStruct() { } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalStruct'}}
+if let x = nonOptionalEnum() { } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalEnum'}}
+
+guard let _ = nonOptionalStruct() else { fatalError() } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalStruct'}}
+guard let _ = nonOptionalEnum() else { fatalError() } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalEnum'}}
+
+if case let x? = nonOptionalStruct() { } // expected-error{{'?' pattern cannot match values of type 'NonOptionalStruct'}}
+if case let x? = nonOptionalEnum() { } // expected-error{{'?' pattern cannot match values of type 'NonOptionalEnum'}}
 
 class B {} // expected-note * {{did you mean 'B'?}}
 class D : B {}// expected-note * {{did you mean 'D'?}}


### PR DESCRIPTION
``` swift
enum Foo { case Bar }
let maybeFoo = Foo.bar
```

Previously:

```
error: enum case 'Some' not found in type 'Foo'
guard let foo = maybeFoo else { fatalError() }
          ^
```

Now:

```
error: initializer for conditional binding must have Optional type, not 'Foo'
guard let foo = maybeFoo else { fatalError() }
          ^
```

Resolves [SR-1456](https://bugs.swift.org/browse/SR-1456).
