### PR TITLE
Add an `@available` renamed attribute for initializeFrom<C : Collecti…

### DIFF
--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -603,6 +603,11 @@ extension ${Self} {
     Builtin.unreachable()
   }
 
+  @available(*, unavailable, renamed: "initialize(from:)")
+  public func initializeFrom<C : Collection>(_ source: C) {
+    Builtin.unreachable()
+  }
+
   @available(*, unavailable, renamed: "initialize(from:count:)")
   public func initializeFrom(_ source: UnsafePointer<Pointee>, count: Int) {
     Builtin.unreachable()

--- a/test/1_stdlib/Renames.swift
+++ b/test/1_stdlib/Renames.swift
@@ -606,6 +606,10 @@ func _UnsafePointer<T>(x: UnsafeMutablePointer<T>, e: T) {
   ptr2.deallocate(capacity: 1)
 }
 
+func _UnsafePointer<T, C : Collection>(x: UnsafeMutablePointer<T>, c: C) where C.Iterator.Element == T {
+  x.initializeFrom(c) // expected-error {{'initializeFrom' has been renamed to 'initialize(from:)'}}
+}
+
 func _VarArgs() {
   func fn1(_: CVarArgType) {} // expected-error {{'CVarArgType' has been renamed to 'CVarArg'}} {{15-26=CVarArg}}{{none}}
   func fn2(_: VaListBuilder) {} // expected-error {{'VaListBuilder' is unavailable}} {{none}}


### PR DESCRIPTION
…on>(_ : C). (#4444)

rdar:27941024 [3.0 migration] Missing fix-it for UnsafePointer<T>.initializeFrom<C : Collection>(_ C)

@nkcsgexi Please review for CCC.

• Explanation: This is a trivial renaming fix-it ommission.
• Scope of Issue: Developers migrating to 3.0.
• Origination: SE-0107 UnsafeRawPointer, oversight.
• Risk: Near zero.
• Testing: Renames.swift
