### PR TITLE
[swiftc (52 vs. 5156)] Add crasher in swift::irgen::emitPolymorphicParameters(...)

### DIFF
--- a/validation-test/compiler_crashers/28399-getpointerelementtype-is-not-storagetype.swift
+++ b/validation-test/compiler_crashers/28399-getpointerelementtype-is-not-storagetype.swift
@@ -1,0 +1,20 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+protocol A{associatedtype B
+}
+struct C<T:A>{
+}
+protocol E{associatedtype F
+func g<T where F==T.B>(_:C<T>)
+}
+struct H:E{
+typealias F = Void
+func g<T where F==T.B>(_:C<T>){}
+}


### PR DESCRIPTION
Add test case for crash triggered in `swift::irgen::emitPolymorphicParameters(...)`.

Current number of unresolved compiler crashers: 52 (5156 resolved)

Assertion failure in [`lib/IRGen/GenProto.cpp (line 1810)`](https://github.com/apple/swift/blob/master/lib/IRGen/GenProto.cpp#L1810):

```
Assertion `targetDepType->isTypeParameter()' failed.

When executing: void addPotentialArchetypeAccessPath(swift::irgen::IRGenFunction &, swift::CanType, swift::CanType, GetTypeParameterInContextFn)
```

Assertion context:

```
  case SILFunctionTypeRepresentation::Thick:
  case SILFunctionTypeRepresentation::Thin:
  case SILFunctionTypeRepresentation::Method:
    return ty->isPolymorphic();

  case SILFunctionTypeRepresentation::CFunctionPointer:
  case SILFunctionTypeRepresentation::ObjCMethod:
    // May be polymorphic at the SIL level, but no type metadata is actually
    // passed.
    return false;

```

Stack trace:

```
swift: /path/to/swift/lib/IRGen/GenProto.cpp:1810: void addPotentialArchetypeAccessPath(swift::irgen::IRGenFunction &, swift::CanType, swift::CanType, GetTypeParameterInContextFn): Assertion `targetDepType->isTypeParameter()' failed.
10 swift           0x000000000087bd49 swift::irgen::emitPolymorphicParameters(swift::irgen::IRGenFunction&, swift::SILFunction&, swift::irgen::Explosion&, swift::irgen::WitnessMetadata*, llvm::function_ref<llvm::Value* (unsigned int)> const&) + 1033
12 swift           0x00000000008b35d4 swift::irgen::IRGenModule::emitSILFunction(swift::SILFunction*) + 1268
13 swift           0x0000000000810c95 swift::irgen::IRGenerator::emitGlobalTopLevel() + 405
15 swift           0x00000000007ea0a4 swift::performIRGeneration(swift::IRGenOptions&, swift::SourceFile&, swift::SILModule*, llvm::StringRef, llvm::LLVMContext&, unsigned int) + 68
17 swift           0x00000000007db487 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
18 swift           0x00000000007a72b8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28399-getpointerelementtype-is-not-storagetype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28399-getpointerelementtype-is-not-storagetype-cd8726.o
1.  While emitting IR SIL function @_TTWV4main1HS_1ES_FS1_1guRd__S_1Awx1Fzwd__1BrfGVS_1Cqd___T_ for 'g' at validation-test/compiler_crashers/28399-getpointerelementtype-is-not-storagetype.swift:19:1
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
