### PR TITLE
(Almost) Remove AllArchetypes list

### DIFF
--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -216,9 +216,7 @@ private:
 
 public:
   /// \brief Add a new generic parameter for which there may be requirements.
-  ///
-  /// \returns true if an error occurred, false otherwise.
-  bool addGenericParameter(GenericTypeParamDecl *GenericParam);
+  void addGenericParameter(GenericTypeParamDecl *GenericParam);
 
   /// Add the requirements placed on the given abstract type parameter
   /// to the given potential archetype.
@@ -227,9 +225,7 @@ public:
   bool addGenericParameterRequirements(GenericTypeParamDecl *GenericParam);
 
   /// \brief Add a new generic parameter for which there may be requirements.
-  ///
-  /// \returns true if an error occurred, false otherwise.
-  bool addGenericParameter(GenericTypeParamType *GenericParam);
+  void addGenericParameter(GenericTypeParamType *GenericParam);
   
   /// \brief Add a new requirement.
   ///
@@ -248,9 +244,7 @@ public:
   /// FIXME: Requirements from the generic signature are treated as coming from
   /// an outer scope in order to avoid disturbing the AllDependentTypes.
   /// Setting \c treatRequirementsAsExplicit to true disables this behavior.
-  ///
-  /// \returns true if an error occurred, false otherwise.
-  bool addGenericSignature(GenericSignature *sig, bool adoptArchetypes,
+  void addGenericSignature(GenericSignature *sig, bool adoptArchetypes,
                            bool treatRequirementsAsExplicit = false);
 
   /// \brief Get a generic signature based on the provided complete list

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1293,7 +1293,10 @@ public:
   deriveAllArchetypes(ArrayRef<GenericTypeParamDecl*> params,
                       SmallVectorImpl<ArchetypeType*> &archetypes);
 
-  ArrayRef<Substitution> getForwardingSubstitutions(ASTContext &C);
+  void getForwardingSubstitutionMap(TypeSubstitutionMap &result) const;
+
+  ArrayRef<Substitution>
+  getForwardingSubstitutions(GenericSignature *sig) const;
 
   /// Collect the nested archetypes of an archetype into the given
   /// collection.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -29,7 +29,6 @@
 #include "swift/Basic/Range.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
-#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Support/TrailingObjects.h"
 
 namespace swift {
@@ -1049,9 +1048,6 @@ public:
   void printAsWritten(raw_ostream &OS) const;
 };
   
-template<typename T, ArrayRef<T> (GenericParamList::*accessor)() const>
-class NestedGenericParamListIterator;
-  
 /// GenericParamList - A list of generic parameters that is part of a generic
 /// function or type, along with extra requirements placed on those generic
 /// parameters and types derived from them.
@@ -1221,15 +1217,6 @@ public:
     AllArchetypes = AA;
   }
 
-  using NestedArchetypeIterator
-    = NestedGenericParamListIterator<ArchetypeType*,
-                                     &GenericParamList::getAllArchetypes>;
-  
-  /// \brief Retrieves a list containing all archetypes from this generic
-  /// parameter clause and all outer generic parameter clauses in outer-to-
-  /// inner order.
-  iterator_range<NestedArchetypeIterator> getAllNestedArchetypes() const;
-  
   /// \brief Retrieve the outer generic parameter list, which provides the
   /// generic parameters of the context in which this generic parameter list
   /// exists.
@@ -1317,79 +1304,6 @@ public:
   void dump();
 };
   
-/// An iterator template for lazily walking a nested generic parameter list.
-template<typename T, ArrayRef<T> (GenericParamList::*accessor)() const>
-class NestedGenericParamListIterator {
-  SmallVector<const GenericParamList*, 2> stack;
-  ArrayRef<T> elements;
-
-  void refreshElements() {
-    while (elements.empty()) {
-      stack.pop_back();
-      if (stack.empty()) break;
-      elements = (stack.back()->*accessor)();
-    }
-  }
-public:
-  // Create a 'begin' iterator for a generic param list.
-  NestedGenericParamListIterator(const GenericParamList *params) {
-    // Walk up to the outermost list to create a stack of lists to walk.
-    while (params) {
-      stack.push_back(params);
-      params = params->getOuterParameters();
-    }
-    // If the stack is empty, be like the 'end' iterator.
-    if (stack.empty())
-      return;
-
-    elements = (stack.back()->*accessor)();
-    refreshElements();
-  }
-  
-  // Create an 'end' iterator.
-  NestedGenericParamListIterator() {}
-  
-  // Iterator dereference.
-  const T &operator*() const {
-    return elements[0];
-  }
-  const T *operator->() const {
-    return &elements[0];
-  }
-  
-  // Iterator advancement.
-  NestedGenericParamListIterator &operator++() {
-    elements = elements.slice(1);
-    refreshElements();
-    return *this;
-  }
-  NestedGenericParamListIterator operator++(int) {
-    auto copy = *this;
-    ++(*this);
-    return copy;
-  }
-  
-  // Ghetto comparison. Only true if end() == end().
-  bool operator==(const NestedGenericParamListIterator &o) const {
-    return stack.empty() && o.stack.empty();
-  }
-  bool operator!=(const NestedGenericParamListIterator &o) const {
-    return !stack.empty() || !o.stack.empty();
-  }
-  
-  // An empty range of nested archetypes.
-  static iterator_range<NestedGenericParamListIterator> emptyRange() {
-    return {{}, {}};
-  }
-};
-  
-using NestedArchetypeIterator = GenericParamList::NestedArchetypeIterator;
-
-inline iterator_range<NestedArchetypeIterator>
-GenericParamList::getAllNestedArchetypes() const {
-  return {NestedArchetypeIterator(this), NestedArchetypeIterator()};
-}
-
 /// A trailing where clause.
 class alignas(RequirementRepr) TrailingWhereClause final :
     private llvm::TrailingObjects<TrailingWhereClause, RequirementRepr> {

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1283,9 +1283,15 @@ public:
     return depth;
   }
 
-  /// Derive a type substitution map for this generic parameter list from a
-  /// matching substitution vector.
-  TypeSubstitutionMap getSubstitutionMap(ArrayRef<Substitution> Subs) const;
+  /// Derive a contextual type substitution map from a substitution array.
+  /// This is just like GenericSignature::getSubstitutionMap(), except
+  /// with contextual types instead of interface types.
+  void
+  getSubstitutionMap(ModuleDecl *mod,
+                     GenericSignature *sig,
+                     ArrayRef<Substitution> subs,
+                     TypeSubstitutionMap &subsMap,
+                     ArchetypeConformanceMap &conformanceMap) const;
 
   /// Derive the all-archetypes list for the given list of generic
   /// parameters.

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -26,6 +26,7 @@
 namespace swift {
 
 class ArchetypeBuilder;
+class ProtocolType;
 
 /// Iterator that walks the generic parameter types declared in a generic
 /// signature and their dependent members.
@@ -163,13 +164,23 @@ public:
     assert(Mem);
     return Mem;
   }
-  
-  /// Build a substitution map from a vector of Substitutions that correspond to
-  /// the generic parameters in this generic signature. The order of primary
-  /// archetypes in the substitution vector must match the order of generic
-  /// parameters in getGenericParams().
+
+  /// Build an interface type substitution map from a vector of Substitutions
+  /// that correspond to the generic parameters in this generic signature.
+  /// The order of primary archetypes in the substitution vector must match
+  /// the order of generic parameters in getGenericParams().
   TypeSubstitutionMap getSubstitutionMap(ArrayRef<Substitution> args) const;
-  
+
+  using LookupConformanceFn =
+      llvm::function_ref<ProtocolConformanceRef(Type, ProtocolType *)>;
+
+  /// Build an array of substitutions from an interface type substitution map,
+  /// using the given function to look up conformances.
+  void getSubstitutions(ModuleDecl &mod,
+                        const TypeSubstitutionMap &subs,
+                        LookupConformanceFn lookupConformance,
+                        SmallVectorImpl<Substitution> &result);
+
   /// Return a range that iterates through first all of the generic parameters
   /// of the signature, followed by all of their recursive member types exposed
   /// through protocol requirements.
@@ -181,7 +192,7 @@ public:
     return GenericSignatureWitnessIterator(getRequirements());
   }
 
-  /// Determines whether this ASTContext is canonical.
+  /// Determines whether this GenericSignature is canonical.
   bool isCanonical() const;
   
   ASTContext &getASTContext() const;

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -37,7 +37,6 @@ class GenericParamList;
 class NormalProtocolConformance;
 class ProtocolConformance;
 class ModuleDecl;
-class SubstitutionIterator;
 enum class AllocationArena;
   
 /// \brief Type substitution mapping from substitutable types to their
@@ -561,8 +560,6 @@ public:
   ArrayRef<Substitution> getGenericSubstitutions() const {
     return GenericSubstitutions;
   }
-
-  SubstitutionIterator getGenericSubstitutionIterator() const;
 
   /// Get the protocol being conformed to.
   ProtocolDecl *getProtocol() const {

--- a/include/swift/AST/Substitution.h
+++ b/include/swift/AST/Substitution.h
@@ -59,12 +59,17 @@ public:
   void dump() const;
   void dump(llvm::raw_ostream &os, unsigned indent = 0) const;
   
-  /// Substitute the replacement and conformance types with the given
-  /// substitution vector.
+  /// Apply a substitution to this substitution's replacement type and
+  /// conformances.
+  ///
+  /// Our replacement type must be written in terms of the context
+  /// archetypes of 'context', which in turn must be derived from the
+  /// generic requirements of 'sig'.
   Substitution subst(ModuleDecl *module,
+                     GenericSignature *sig,
                      GenericParamList *context,
                      ArrayRef<Substitution> subs) const;
-  
+
 private:
   friend class ProtocolConformance;
   

--- a/include/swift/AST/Substitution.h
+++ b/include/swift/AST/Substitution.h
@@ -79,60 +79,6 @@ private:
                      ArchetypeConformanceMap &conformanceMap) const;
 };
 
-/// An iterator over a list of archetypes and the substitutions
-/// applied to them.
-class SubstitutionIterator {
-  // TODO: this should use dependent types when getConformsTo() becomes
-  // efficient there.
-  ArrayRef<ArchetypeType*> Archetypes;
-  ArrayRef<Substitution> Subs;
-
-public:
-  SubstitutionIterator() = default;
-  explicit SubstitutionIterator(GenericParamList *params,
-                                ArrayRef<Substitution> subs);
-
-  struct iterator {
-    ArchetypeType * const *NextArch = nullptr;
-    const Substitution *NextSub = nullptr;
-
-    iterator() = default;
-    iterator(ArchetypeType * const *nextArch, const Substitution *nextSub)
-      : NextArch(nextArch), NextSub(nextSub) {}
-
-    iterator &operator++() {
-      ++NextArch;
-      ++NextSub;
-      return *this;
-    }
-
-    iterator operator++(int) {
-      iterator copy = *this;
-      ++*this;
-      return copy;
-    }
-
-    std::pair<ArchetypeType*,Substitution> operator*() const {
-      return { *NextArch, *NextSub };
-    }
-
-    bool operator==(const iterator &other) const {
-      assert((NextSub == other.NextSub) == (NextArch == other.NextArch));
-      return NextSub == other.NextSub;
-    }
-    bool operator!=(const iterator &other) const {
-      return !(*this == other);
-    }
-  };
-
-  ArrayRef<Substitution> getSubstitutions() const { return Subs; }
-
-  bool empty() const { return Archetypes.empty(); }
-
-  iterator begin() const { return { Archetypes.begin(), Subs.begin() }; }
-  iterator end() const { return { Archetypes.end(), Subs.end() }; }
-};
-
 void dump(const ArrayRef<Substitution> &subs);
 
 } // end namespace swift

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -167,7 +167,8 @@ public:
   /// \param options Options that affect the substitutions.
   ///
   /// \returns the substituted type, or a null type if an error occurred.
-  Type subst(ModuleDecl *module, TypeSubstitutionMap &substitutions,
+  Type subst(ModuleDecl *module,
+             const TypeSubstitutionMap &substitutions,
              SubstOptions options) const;
 
   bool isPrivateStdlibType(bool whitelistProtocols=true) const;

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -94,6 +94,9 @@ private:
   /// The context archetypes of the function.
   GenericParamList *ContextGenericParams;
 
+  /// The forwarding substitutions, lazily computed.
+  Optional<ArrayRef<Substitution>> ForwardingSubs;
+
   /// The collection of all BasicBlocks in the SILFunction. Empty for external
   /// function references.
   BlockListType BlockList;

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -128,12 +128,12 @@ public:
 
   ///  Apply a substitution to the type to produce another lowered SIL type.
   static SILType substType(SILModule &silModule, ModuleDecl *astModule,
-                           TypeSubstitutionMap &subs, SILType SrcTy);
+                           const TypeSubstitutionMap &subs, SILType SrcTy);
 
   ///  Apply a substitution to the function type.
   static CanSILFunctionType substFuncType(SILModule &silModule,
                                           ModuleDecl *astModule,
-                                          TypeSubstitutionMap &subs,
+                                          const TypeSubstitutionMap &subs,
                                           CanSILFunctionType SrcTy,
                                           bool dropGenerics);
 
@@ -451,7 +451,7 @@ public:
                            ArrayRef<Substitution> Subs) const;
 
   SILType subst(SILModule &silModule, ModuleDecl *astModule,
-                TypeSubstitutionMap &subs) const;
+                const TypeSubstitutionMap &subs) const;
 
   /// If this is a specialized generic type, return all substitutions used to
   /// generate it.

--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -89,14 +89,15 @@ protected:
   }
 
   Substitution remapSubstitution(Substitution sub) {
-    auto newSub = sub.subst(SwiftMod,
-                            Original.getContextGenericParams(),
-                            ApplySubs);
+    if (!ApplySubs.empty()) {
+      auto *params = Original.getContextGenericParams();
+      auto sig = Original.getLoweredFunctionType()->getGenericSignature();
+      sub = sub.subst(SwiftMod, sig, params, ApplySubs);
+    }
     // Remap opened archetypes into the cloned context.
-    newSub = Substitution(getASTTypeInClonedContext(newSub.getReplacement()
-                                                      ->getCanonicalType()),
-                          newSub.getConformances());
-    return newSub;
+    return Substitution(getASTTypeInClonedContext(sub.getReplacement()
+                                                    ->getCanonicalType()),
+                        sub.getConformances());
   }
 
   ProtocolConformanceRef remapConformance(CanType type,
@@ -205,13 +206,13 @@ protected:
 
   void visitWitnessMethodInst(WitnessMethodInst *Inst) {
     // Specialize the Self substitution of the witness_method.
-    //
-    // FIXME: This needs to not only handle Self but all Self derived types so
-    // we handle type aliases correctly.
-    auto sub =
-      Inst->getSelfSubstitution().subst(Inst->getModule().getSwiftModule(),
-                                        Original.getContextGenericParams(),
-                                        ApplySubs);
+    auto sub = Inst->getSelfSubstitution();
+    if (!ApplySubs.empty()) {
+      auto sig = Original.getLoweredFunctionType()->getGenericSignature();
+      auto *params = Original.getContextGenericParams();
+      sub = sub.subst(Inst->getModule().getSwiftModule(),
+                      sig, params, ApplySubs);
+    }
 
     assert(sub.getConformances().size() == 1 &&
            "didn't get conformance from substitution?!");

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -53,7 +53,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 260; // Last change: open
+const uint16_t VERSION_MINOR = 261; // Last change: remove AllArchetypes indexing
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -536,29 +536,38 @@ void GenericParamList::addTrailingWhereClause(
   Requirements = newRequirements;
 }
 
-ArrayRef<Substitution>
-GenericParamList::getForwardingSubstitutions(ASTContext &C) {
-  SmallVector<Substitution, 4> subs;
-
-  // TODO: IRGen wants substitutions for secondary archetypes.
-  // for (auto &param : params->getNestedGenericParams()) {
-  //  ArchetypeType *archetype = param.getAsTypeParam()->getArchetype();
-
-  for (auto archetype : getAllNestedArchetypes()) {
-    // "Check conformance" on each declared protocol to build a
-    // conformance map.
-    SmallVector<ProtocolConformanceRef, 2> conformances;
-
-    for (ProtocolDecl *proto : archetype->getConformsTo()) {
-      conformances.push_back(ProtocolConformanceRef(proto));
-    }
-
-    // Build an identity mapping with the derived conformances.
-    auto replacement = SubstitutedType::get(archetype, archetype, C);
-    subs.push_back({replacement, C.AllocateCopy(conformances)});
+void GenericParamList::
+getForwardingSubstitutionMap(TypeSubstitutionMap &result) const {
+  // Add forwarding substitutions from the outer context if we have
+  // a type nested inside a generic function.
+  for (auto *params = this;
+       params != nullptr;
+       params = params->getOuterParameters()) {
+    for (auto *param : params->getParams())
+      result[param->getDeclaredType()->getCanonicalType().getPointer()]
+          = param->getArchetype();
   }
+}
 
-  return C.AllocateCopy(subs);
+ArrayRef<Substitution>
+GenericParamList::getForwardingSubstitutions(GenericSignature *sig) const {
+  // This is stupid. We don't really need a module, because we
+  // should not be looking up concrete conformances when we
+  // substitute types here.
+  auto *mod = getParams()[0]->getDeclContext()->getParentModule();
+
+  TypeSubstitutionMap subs;
+  getForwardingSubstitutionMap(subs);
+
+  auto lookupConformanceFn =
+      [&](Type replacement, ProtocolType *protoType)
+          -> ProtocolConformanceRef {
+    return ProtocolConformanceRef(protoType->getDecl());
+  };
+
+  SmallVector<Substitution, 4> result;
+  sig->getSubstitutions(*mod, subs, lookupConformanceFn, result);
+  return sig->getASTContext().AllocateCopy(result);
 }
 
 /// \brief Add the nested archetypes of the given archetype to the set

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -414,6 +414,63 @@ GenericSignature::getSubstitutionMap(ArrayRef<Substitution> args) const {
   return subs;
 }
 
+void GenericSignature::
+getSubstitutions(ModuleDecl &mod,
+                 const TypeSubstitutionMap &subs,
+                 GenericSignature::LookupConformanceFn lookupConformance,
+                 SmallVectorImpl<Substitution> &result) {
+  auto &ctx = getASTContext();
+
+  Type currentReplacement;
+  SmallVector<ProtocolConformanceRef, 4> currentConformances;
+
+  for (const auto &req : getRequirements()) {
+    switch (req.getKind()) {
+    case RequirementKind::Conformance: {
+      // Get the conformance and record it.
+      auto protoType = req.getSecondType()->castTo<ProtocolType>();
+      currentConformances.push_back(
+          lookupConformance(currentReplacement, protoType));
+      break;
+    }
+
+    case RequirementKind::Superclass:
+      // Superclass requirements aren't recorded in substitutions.
+      break;
+
+    case RequirementKind::SameType:
+      // Same-type requirements aren't recorded in substitutions.
+      break;
+
+    case RequirementKind::WitnessMarker:
+      // Flush the current conformances.
+      if (currentReplacement) {
+        result.push_back({
+          currentReplacement,
+          ctx.AllocateCopy(currentConformances)
+        });
+        currentConformances.clear();
+      }
+
+      // Each witness marker starts a new substitution.
+      currentReplacement = req.getFirstType().subst(&mod, subs, SubstOptions());
+      if (!currentReplacement)
+        currentReplacement = ErrorType::get(ctx);
+
+      break;
+    }
+  }
+
+  // Flush the final conformances.
+  if (currentReplacement) {
+    result.push_back({
+      currentReplacement,
+      ctx.AllocateCopy(currentConformances),
+    });
+    currentConformances.clear();
+  }
+}
+
 bool GenericSignature::requiresClass(Type type, ModuleDecl &mod) {
   if (!type->isTypeParameter()) return false;
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -558,9 +558,8 @@ TypeBase::gatherAllSubstitutions(Module *module,
   // don't have access to the module. It will have to go away once we're
   // properly differentiating bound generic types based on the protocol
   // conformances visible from a given module.
-  if (!module) {
+  if (!module)
     module = getAnyNominal()->getParentModule();
-  }
 
   // Check the context, introducing the default if needed.
   if (!gpContext)
@@ -569,8 +568,8 @@ TypeBase::gatherAllSubstitutions(Module *module,
   assert(gpContext->getAsNominalTypeOrNominalTypeExtensionContext()
          == getAnyNominal() && "not a valid context");
 
-  auto *genericParams = gpContext->getGenericParamsOfContext();
-  if (!genericParams)
+  auto *genericSig = gpContext->getGenericSignatureOfContext();
+  if (genericSig == nullptr)
     return { };
 
   // If we already have a cached copy of the substitutions, return them.
@@ -596,8 +595,8 @@ TypeBase::gatherAllSubstitutions(Module *module,
 
       for (Type arg : boundGeneric->getGenericArgs()) {
         auto gp = genericParams->getParams()[index++];
-        auto archetype = gp->getArchetype();
-        substitutions[archetype] = arg;
+        substitutions[gp->getDeclaredType()->getCanonicalType()
+                        .getPointer()] = arg;
       }
 
       parent = CanType(boundGeneric->getParent());
@@ -616,61 +615,33 @@ TypeBase::gatherAllSubstitutions(Module *module,
 
   // Add forwarding substitutions from the outer context if we have
   // a type nested inside a generic function.
-  if (auto *outerGenericParams = parentDC->getGenericParamsOfContext()) {
-    for (auto archetype : outerGenericParams->getAllNestedArchetypes())
-      substitutions[archetype] = archetype;
-  }
+  if (auto *outerParams = parentDC->getGenericParamsOfContext())
+    outerParams->getForwardingSubstitutionMap(substitutions);
 
-  // Collect all of the archetypes.
-  SmallVector<ArchetypeType *, 2> allArchetypesList;
-  ArrayRef<ArchetypeType *> allArchetypes = genericParams->getAllArchetypes();
-  if (genericParams->getOuterParameters()) {
-    SmallVector<const GenericParamList *, 2> allGenericParams;
-    unsigned numArchetypes = 0;
-    for (; genericParams; genericParams = genericParams->getOuterParameters()) {
-      allGenericParams.push_back(genericParams);
-      numArchetypes += genericParams->getAllArchetypes().size();
-    }
-    allArchetypesList.reserve(numArchetypes);
-    for (auto gp = allGenericParams.rbegin(), gpEnd = allGenericParams.rend();
-         gp != gpEnd; ++gp) {
-      allArchetypesList.append((*gp)->getAllArchetypes().begin(),
-                               (*gp)->getAllArchetypes().end());
-    }
-    allArchetypes = allArchetypesList;
-  }
+  auto lookupConformanceFn =
+      [&](Type replacement, ProtocolType *protoType)
+          -> ProtocolConformanceRef {
 
-  // For each of the archetypes, compute the substitution.
-  bool hasTypeVariables = canon->hasTypeVariable();
-  SmallVector<Substitution, 4> resultSubstitutions;
-  resultSubstitutions.resize(allArchetypes.size());
-  unsigned index = 0;
-  for (auto archetype : allArchetypes) {
-    // Substitute into the type.
-    auto type = Type(archetype).subst(module, substitutions, SubstOptions());
-    if (!type)
-      type = ErrorType::get(module->getASTContext());
+    auto *proto = protoType->getDecl();
 
-    SmallVector<ProtocolConformanceRef, 4> conformances;
-    for (auto proto : archetype->getConformsTo()) {
-      // If the type is a type variable or is dependent, just fill in empty
-      // conformances.
-      if (type->is<TypeVariableType>() || type->isTypeParameter()) {
-        conformances.push_back(ProtocolConformanceRef(proto));
+    // If the type is a type variable or is dependent, just fill in empty
+    // conformances.
+    if (replacement->is<TypeVariableType>() || replacement->isTypeParameter())
+      return ProtocolConformanceRef(proto);
 
-      // Otherwise, find the conformances.
-      } else {
-        if (auto conforms = module->lookupConformance(type, proto, resolver))
-          conformances.push_back(*conforms);
-        else
-          conformances.push_back(ProtocolConformanceRef(proto));
-      }
-    }
+    // Otherwise, find the conformance.
+    auto conforms = module->lookupConformance(replacement, proto, resolver);
+    if (conforms)
+      return *conforms;
 
-    // Record this substitution.
-    resultSubstitutions[index] = {type, ctx.AllocateCopy(conformances)};
-    ++index;
-  }
+    // FIXME: Should we ever end up here?
+    return ProtocolConformanceRef(proto);
+  };
+
+  SmallVector<Substitution, 4> result;
+  genericSig->getSubstitutions(*module, substitutions,
+                               lookupConformanceFn,
+                               result);
 
   // Before recording substitutions, make sure we didn't end up doing it
   // recursively.
@@ -678,7 +649,8 @@ TypeBase::gatherAllSubstitutions(Module *module,
     return *known;
 
   // Copy and record the substitutions.
-  auto permanentSubs = ctx.AllocateCopy(resultSubstitutions,
+  bool hasTypeVariables = canon->hasTypeVariable();
+  auto permanentSubs = ctx.AllocateCopy(result,
                                         hasTypeVariables
                                           ? AllocationArena::ConstraintSolver
                                           : AllocationArena::Permanent);

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -647,10 +647,7 @@ TypeBase::gatherAllSubstitutions(Module *module,
   unsigned index = 0;
   for (auto archetype : allArchetypes) {
     // Substitute into the type.
-    SubstOptions options;
-    if (hasTypeVariables)
-      options |= SubstFlags::IgnoreMissing;
-    auto type = Type(archetype).subst(module, substitutions, options);
+    auto type = Type(archetype).subst(module, substitutions, SubstOptions());
     if (!type)
       type = ErrorType::get(module->getASTContext());
 

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -333,13 +333,6 @@ SpecializedProtocolConformance::SpecializedProtocolConformance(
   assert(genericConformance->getKind() != ProtocolConformanceKind::Specialized);
 }
 
-SubstitutionIterator
-SpecializedProtocolConformance::getGenericSubstitutionIterator() const {
-  return SubstitutionIterator(
-          GenericConformance->getDeclContext()->getGenericParamsOfContext(),
-                              GenericSubstitutions);
-}
-
 bool SpecializedProtocolConformance::hasTypeWitness(
                       AssociatedTypeDecl *assocType, 
                       LazyResolver *resolver) const {

--- a/lib/AST/Substitution.cpp
+++ b/lib/AST/Substitution.cpp
@@ -142,8 +142,3 @@ Substitution Substitution::subst(Module *module,
 
   return Substitution{substReplacement, substConfs};
 }
-
-SubstitutionIterator::SubstitutionIterator(GenericParamList *params,
-                                           ArrayRef<Substitution> subs)
-  : Archetypes(params->getAllArchetypes()), Subs(subs) {
-}

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2996,8 +2996,7 @@ TypeSubstitutionMap TypeBase::getMemberSubstitutions(const DeclContext *dc) {
     // FIXME: This feels painfully inefficient. We're creating a dense map
     // for a single substitution.
     substitutions[dc->getSelfInterfaceType()
-                    ->getCanonicalType()
-                    ->castTo<GenericTypeParamType>()]
+                    ->getCanonicalType().getPointer()]
       = baseTy;
     return substitutions;
   }
@@ -3028,8 +3027,7 @@ TypeSubstitutionMap TypeBase::getMemberSubstitutions(const DeclContext *dc) {
       auto args = boundGeneric->getGenericArgs();
       for (unsigned i = 0, n = args.size(); i != n; ++i) {
         substitutions[params[i]->getDeclaredType()->getCanonicalType()
-                        ->castTo<GenericTypeParamType>()]
-          = args[i];
+                        .getPointer()] = args[i];
       }
 
       // Continue looking into the parent.

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2895,7 +2895,8 @@ Type DependentMemberType::substBaseType(Module *module,
                               None);
 }
 
-Type Type::subst(Module *module, TypeSubstitutionMap &substitutions,
+Type Type::subst(Module *module,
+                 const TypeSubstitutionMap &substitutions,
                  SubstOptions options) const {
   /// Return the original type or a null type, depending on the 'ignoreMissing'
   /// flag.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5148,11 +5148,8 @@ namespace {
     GenericSignature *calculateGenericSignature(GenericParamList *genericParams,
                                                 DeclContext *dc) {
       ArchetypeBuilder builder(*dc->getParentModule(), Impl.SwiftContext.Diags);
-      for (auto param : *genericParams) {
-        if (builder.addGenericParameter(param)) {
-          return nullptr;
-        }
-      }
+      for (auto param : *genericParams)
+        builder.addGenericParameter(param);
       for (auto param : *genericParams) {
         if (builder.addGenericParameterRequirements(param)) {
           return nullptr;

--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -101,35 +101,6 @@ static TypeBase *GetTemplateArgument(TypeBase *type, size_t arg_idx) {
   return nullptr;
 }
 
-enum class MemberType : uint32_t { Invalid, BaseClass, Field };
-
-struct MemberInfo {
-  Type clang_type;
-  const std::string name;
-  uint64_t byte_size;
-  uint32_t byte_offset;
-  MemberType member_type;
-  bool is_fragile;
-
-  MemberInfo(MemberType member_type)
-      : clang_type(), name(), byte_size(0), byte_offset(0),
-        member_type(member_type), is_fragile(false) {}
-};
-
-struct EnumElementInfo {
-  Type clang_type;
-  ConstString name;
-  uint64_t byte_size;
-  uint32_t value;       // The value for this enumeration element
-  uint32_t extra_value; // If not UINT32_MAX, then this value is an extra value
-  // that appears at offset 0 to tell one or more empty
-  // enums apart. This value will only be filled in if there
-  // are one or more enum elements that have a non-zero byte size
-
-  EnumElementInfo()
-      : clang_type(), name(), byte_size(0), extra_value(UINT32_MAX) {}
-};
-
 class DeclsLookupSource {
 public:
   typedef SmallVectorImpl<ValueDecl *> ValueDecls;

--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/IDE/Utils.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/Mangle.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/Basic/Demangle.h"
@@ -61,14 +62,22 @@ static TypeBase *GetTemplateArgument(TypeBase *type, size_t arg_idx) {
       auto *nominal_type_decl = unbound_generic_type->getDecl();
       if (!nominal_type_decl)
         break;
-      GenericParamList *generic_param_list =
-          nominal_type_decl->getGenericParams();
-      if (!generic_param_list)
+      GenericSignature *generic_sig =
+          nominal_type_decl->getGenericSignature();
+      if (!generic_sig)
         break;
-      if (arg_idx >= generic_param_list->getAllArchetypes().size())
-        break;
-      return generic_param_list->getAllArchetypes()[arg_idx];
-    } break;
+      for (auto depTy : generic_sig->getAllDependentTypes()) {
+        if (arg_idx == 0) {
+          return ArchetypeBuilder::mapTypeIntoContext(
+              nominal_type_decl, depTy)->castTo<ArchetypeType>();
+        }
+
+        arg_idx--;
+      }
+
+      // Index was out of bounds...
+      break;
+    }
     case TypeKind::BoundGenericClass:
     case TypeKind::BoundGenericStruct:
     case TypeKind::BoundGenericEnum: {

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -555,8 +555,15 @@ void SILFunction::convertToDeclaration() {
 }
 
 ArrayRef<Substitution> SILFunction::getForwardingSubstitutions() {
+  if (ForwardingSubs)
+    return *ForwardingSubs;
+
   auto *params = getContextGenericParams();
   if (!params)
     return {};
-  return params->getForwardingSubstitutions(getASTContext());
+
+  auto sig = getLoweredFunctionType()->getGenericSignature();
+  ForwardingSubs = params->getForwardingSubstitutions(sig);
+
+  return *ForwardingSubs;
 }

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -2105,13 +2105,13 @@ namespace {
       public CanTypeVisitor<SILTypeSubstituter, CanType> {
     SILModule &TheSILModule;
     Module *TheASTModule;
-    TypeSubstitutionMap &Subs;
+    const TypeSubstitutionMap &Subs;
 
     ASTContext &getASTContext() { return TheSILModule.getASTContext(); }
 
   public:
     SILTypeSubstituter(SILModule &silModule, Module *astModule,
-                       TypeSubstitutionMap &subs)
+                       const TypeSubstitutionMap &subs)
       : TheSILModule(silModule), TheASTModule(astModule), Subs(subs)
     {}
 
@@ -2219,19 +2219,19 @@ namespace {
 }
 
 SILType SILType::substType(SILModule &silModule, Module *astModule,
-                           TypeSubstitutionMap &subs, SILType SrcTy) {
+                           const TypeSubstitutionMap &subs, SILType SrcTy) {
   return SrcTy.subst(silModule, astModule, subs);
 }
 
 SILType SILType::subst(SILModule &silModule, Module *astModule,
-                       TypeSubstitutionMap &subs) const {
+                       const TypeSubstitutionMap &subs) const {
   SILTypeSubstituter STST(silModule, astModule, subs);
   return STST.subst(*this);
 }
 
 CanSILFunctionType SILType::substFuncType(SILModule &silModule,
                                           Module *astModule,
-                                          TypeSubstitutionMap &subs,
+                                          const TypeSubstitutionMap &subs,
                                           CanSILFunctionType SrcTy,
                                           bool dropGenerics) {
   SILTypeSubstituter STST(silModule, astModule, subs);

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1757,9 +1757,11 @@ public:
     auto methodTy = constantInfo.SILFnType;
 
     // Map interface types to archetypes.
-    if (auto *params = constantInfo.ContextGenericParams)
-      methodTy = methodTy->substGenericArgs(F.getModule(), M,
-                                            params->getForwardingSubstitutions(C));
+    if (auto *params = constantInfo.ContextGenericParams) {
+      auto sig = constantInfo.SILFnType->getGenericSignature();
+      auto subs = params->getForwardingSubstitutions(sig);
+      methodTy = methodTy->substGenericArgs(F.getModule(), M, subs);
+    }
     assert(!methodTy->isPolymorphic());
 
     // Replace Self parameter with type of 'self' at the call site.

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -66,7 +66,7 @@ emitBridgeNativeToObjectiveC(SILGenFunction &gen,
           gen.SGM.SwiftModule, nullptr);
 
   if (!substitutions.empty()) {
-    // Substitute into the witness function tye.
+    // Substitute into the witness function type.
     witnessFnTy = witnessFnTy.substGenericArgs(gen.SGM.M, substitutions);
   }
 

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -491,9 +491,10 @@ void SILGenFunction::emitClassConstructorAllocator(ConstructorDecl *ctor) {
   ArrayRef<Substitution> subs;
   // Call the initializer.
   ArrayRef<Substitution> forwardingSubs;
-  if (auto *genericParamList = ctor->getGenericParamsOfContext())
-    forwardingSubs =
-        genericParamList->getForwardingSubstitutions(getASTContext());
+  if (auto *genericParamList = ctor->getGenericParamsOfContext()) {
+    auto *genericSig = ctor->getGenericSignatureOfContext();
+    forwardingSubs = genericParamList->getForwardingSubstitutions(genericSig);
+  }
   std::tie(initVal, initTy, subs)
     = emitSiblingMethodRef(Loc, selfValue, initConstant, forwardingSubs);
 
@@ -871,8 +872,10 @@ void SILGenFunction::emitMemberInitializers(DeclContext *dc,
         // Get the substitutions for the constructor context.
         ArrayRef<Substitution> subs;
         auto *genericParams = dc->getGenericParamsOfContext();
-        if (genericParams)
-          subs = genericParams->getForwardingSubstitutions(getASTContext());
+        if (genericParams) {
+          auto *genericSig = dc->getGenericSignatureOfContext();
+          subs = genericParams->getForwardingSubstitutions(genericSig);
+        }
 
         // Get the type of the initialization result, in terms
         // of the constructor context's archetypes.

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -815,8 +815,10 @@ void SILGenFunction::emitCurryThunk(ValueDecl *vd,
 
   // Forward substitutions.
   ArrayRef<Substitution> subs;
-  if (auto gp = getConstantInfo(to).ContextGenericParams) {
-    subs = gp->getForwardingSubstitutions(getASTContext());
+  auto constantInfo = getConstantInfo(to);
+  if (auto gp = constantInfo.ContextGenericParams) {
+    auto sig = constantInfo.SILFnType->getGenericSignature();
+    subs = gp->getForwardingSubstitutions(sig);
   }
 
   SILValue toFn = getNextUncurryLevelRef(*this, vd, to, from.isDirectReference,

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1584,10 +1584,11 @@ LValue SILGenLValue::visitExpr(Expr *e, AccessKind accessKind) {
 static ArrayRef<Substitution>
 getNonMemberVarDeclSubstitutions(SILGenModule &SGM, VarDecl *var) {
   ArrayRef<Substitution> substitutions;
-  if (auto genericParams
-      = var->getDeclContext()->getGenericParamsOfContext())
-    substitutions =
-        genericParams->getForwardingSubstitutions(SGM.getASTContext());
+  auto *dc = var->getDeclContext();
+  if (auto genericParams = dc->getGenericParamsOfContext()) {
+    auto *genericSig = dc->getGenericSignatureOfContext();
+    substitutions = genericParams->getForwardingSubstitutions(genericSig);
+  }
   return substitutions;
 }
 

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -862,6 +862,7 @@ constructClonedFunction(PartialApplyInst *PAI, FunctionRefInst *FRI,
   // Create the substitution maps.
   TypeSubstitutionMap InterfaceSubs;
   TypeSubstitutionMap ContextSubs;
+  ArchetypeConformanceMap ConformanceMap;
 
   ArrayRef<Substitution> ApplySubs = PAI->getSubstitutions();
   auto genericSig = F->getLoweredFunctionType()->getGenericSignature();
@@ -869,7 +870,9 @@ constructClonedFunction(PartialApplyInst *PAI, FunctionRefInst *FRI,
 
   if (!ApplySubs.empty()) {
     InterfaceSubs = genericSig->getSubstitutionMap(ApplySubs);
-    ContextSubs = genericParams->getSubstitutionMap(ApplySubs);
+    genericParams->getSubstitutionMap(F->getModule().getSwiftModule(),
+                                      genericSig, ApplySubs,
+                                      ContextSubs, ConformanceMap);
   } else {
     assert(!genericSig && "Function type has Unexpected generic signature!");
     assert(!genericParams &&

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -187,9 +187,14 @@ GenericFuncSpecializer::GenericFuncSpecializer(SILFunction *GenericFunc,
 
   assert(GenericFunc->isDefinition() && "Expected definition to specialize!");
 
-  if (GenericFunc->getContextGenericParams())
-    ContextSubs = GenericFunc->getContextGenericParams()
-      ->getSubstitutionMap(ParamSubs);
+  if (auto *params = GenericFunc->getContextGenericParams()) {
+    auto sig = GenericFunc->getLoweredFunctionType()->getGenericSignature();
+
+    ArchetypeConformanceMap conformanceMap;
+    params->getSubstitutionMap(M.getSwiftModule(), sig,
+                               ParamSubs, ContextSubs,
+                               conformanceMap);
+  }
 
   Mangle::Mangler Mangler;
   GenericSpecializationMangler GenericMangler(Mangler, GenericFunc,

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1271,9 +1271,9 @@ void TypeChecker::completePropertyBehaviorStorage(VarDecl *VD,
   
   // Add the witnesses to the conformance.
   ArrayRef<Substitution> MemberSubs;
-  if (DC->isGenericContext()) {
+  if (auto *sig = DC->getGenericSignatureOfContext()) {
     MemberSubs = DC->getGenericParamsOfContext()
-                   ->getForwardingSubstitutions(Context);
+                   ->getForwardingSubstitutions(sig);
   }
   
   BehaviorConformance->setWitness(BehaviorStorage,
@@ -1440,9 +1440,9 @@ void TypeChecker::completePropertyBehaviorParameter(VarDecl *VD,
 
   // Add the witnesses to the conformance.
   ArrayRef<Substitution> MemberSubs;
-  if (DC->isGenericContext()) {
+  if (auto *sig = DC->getGenericSignatureOfContext()) {
     MemberSubs = DC->getGenericParamsOfContext()
-    ->getForwardingSubstitutions(Context);
+    ->getForwardingSubstitutions(sig);
   }
 
   BehaviorConformance->setWitness(BehaviorParameter,

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -271,10 +271,8 @@ bool TypeChecker::checkGenericParamList(ArchetypeBuilder *builder,
   for (auto param : *genericParams) {
     param->setDepth(depth);
 
-    if (builder) {
-      if (builder->addGenericParameter(param))
-        invalid = true;
-    }
+    if (builder)
+      builder->addGenericParameter(param);
   }
 
   // Now, check the inheritance clauses of each parameter.

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3816,19 +3816,9 @@ Type ModuleFile::getType(TypeID TID) {
     auto nominal = cast<NominalTypeDecl>(getDecl(declID));
     auto parentTy = getType(parentID);
 
-    // Check the first ID to decide if we are using indices to the Decl's
-    // Archetypes. 
     SmallVector<Type, 8> genericArgs;
-    if (rawArgumentIDs.size() > 1 && rawArgumentIDs[0] == INT32_MAX) {
-      for (unsigned i = 1; i < rawArgumentIDs.size(); i++) {
-        auto index = rawArgumentIDs[i];
-        genericArgs.push_back(nominal->getGenericParams()
-                                     ->getAllArchetypes()[index]);
-      }
-    } else {
-      for (TypeID type : rawArgumentIDs)
-        genericArgs.push_back(getType(type));
-    }
+    for (TypeID type : rawArgumentIDs)
+      genericArgs.push_back(getType(type));
 
     auto boundTy = BoundGenericType::get(nominal, parentTy, genericArgs);
     typeOrOffset = boundTy;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3151,58 +3151,10 @@ void Serializer::writeType(Type ty) {
   case TypeKind::BoundGenericEnum:
   case TypeKind::BoundGenericStruct: {
     auto generic = cast<BoundGenericType>(ty.getPointer());
-
-    // We don't want two copies of Archetype being serialized, one by
-    // serializing genericArgs, the other by serializing the Decl. The reason
-    // is that it is likely the Decl's Archetype can be serialized in
-    // a different module, causing two copies being constructed at
-    // deserialization, one in the other module, one in this module as
-    // genericArgs. The fix is to check if genericArgs exist in the Decl's
-    // Archetypes, if they all exist, we use indices to the Decl's
-    // Archetypes..
-    bool allGenericArgsInDecl = true;
-#ifndef NDEBUG
-    bool someGenericArgsInDecl = false;
-#endif
     SmallVector<TypeID, 8> genericArgIDs;
-    // Push in a special number to say that IDs are indices to the Archetypes.
-    if (!generic->getGenericArgs().empty())
-      genericArgIDs.push_back(INT32_MAX);
-    for (auto next : generic->getGenericArgs()) {
-      bool found = false;
-      if (auto arche = dyn_cast<ArchetypeType>(next.getPointer())) {
-        auto genericParams = generic->getDecl()->getGenericParams();
-        unsigned idx = 0;
-        // Check if next exists in the Decl.
-        for (auto archetype : genericParams->getAllArchetypes()) {
-          if (archetype == arche) {
-            found = true;
-            genericArgIDs.push_back(idx);
-#ifndef NDEBUG
-            someGenericArgsInDecl = true;
-#endif
-            break;
-          }
-          idx++;
-        }
-      }
 
-      if (!found) {
-        allGenericArgsInDecl = false;
-        break;
-      }
-    }
-
-    if (!allGenericArgsInDecl) {
-#ifndef NDEBUG
-      if (someGenericArgsInDecl && isDeclXRef(generic->getDecl()))
-        // Emit warning message. 
-        llvm::errs() << "Serialization: we may have two copied of Archetype\n";
-#endif
-      genericArgIDs.clear();
-      for (auto next : generic->getGenericArgs())
-        genericArgIDs.push_back(addTypeRef(next));
-    }
+    for (auto next : generic->getGenericArgs())
+      genericArgIDs.push_back(addTypeRef(next));
 
     unsigned abbrCode = DeclTypeAbbrCodes[BoundGenericTypeLayout::Code];
     BoundGenericTypeLayout::emitRecord(Out, ScratchRecord, abbrCode,


### PR DESCRIPTION
This PR nukes most usages of AllArchetypes, except some stuff in serialization which breaks some obscure .sib tests if I remove them.

I wanted to get the rest checked in before I untangle serialization, to avoid bitrot.
