### PR TITLE
[3.0] Runtime: Don't clobber the compiler-emitted layout of empty fields.

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -1764,6 +1764,9 @@ swift::swift_initClassMetadata_UniversalStrategy(ClassMetadata *self,
 
   // Okay, now do layout.
   for (unsigned i = 0; i != numFields; ++i) {
+    // Skip empty fields.
+    if (fieldOffsets[i] == 0 && fieldLayouts[i].Size == 0)
+      continue;
     auto offset = roundUpToAlignMask(size, fieldLayouts[i].AlignMask);
     fieldOffsets[i] = offset;
     size = offset + fieldLayouts[i].Size;

--- a/test/Interpreter/generic_class_empty_field.swift
+++ b/test/Interpreter/generic_class_empty_field.swift
@@ -1,0 +1,47 @@
+// RUN: rm -rf %t  &&  mkdir %t
+// RUN: %target-build-swift %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+// REQUIRES: executable_test
+
+class Outer {
+  class Foo {
+    var zim = Bar()
+    var bas = Outer()
+  }
+  class Boo {
+    var bas = Outer()
+    var zim = Bar()
+  }
+
+  required init() {}
+}
+
+protocol Initable { init() }
+extension Outer: Initable {}
+
+class GFoo<T: Initable> {
+  var zim = Bar()
+  var bas = T()
+}
+class GBoo<T: Initable> {
+  var bas = T()
+  var zim = Bar()
+}
+class GFos<T: Initable> {
+  var bar = T()
+  var zim = Bar()
+  var bas = T()
+}
+
+struct Bar { }
+
+do {
+  let a = Outer.Foo()
+  let b = Outer.Boo()
+  let c = GFoo<Outer>()
+  let d = GBoo<Outer>()
+  let e = GFos<Outer>()
+}
+
+// CHECK: Job's finished
+print("Job's finished")


### PR DESCRIPTION
Otherwise, we try to dirty constant memory for classes emitted as constant-layout by the compiler. Fixes rdar://problem/27951346.
