### PR TITLE
[swiftc (53 vs. 5156)] Add crasher in swift::constraints::ConstraintSystem::assignFixedType(...)

### DIFF
--- a/validation-test/compiler_crashers/28400-swift-nominaltypedecl-prepareextensions.swift
+++ b/validation-test/compiler_crashers/28400-swift-nominaltypedecl-prepareextensions.swift
@@ -1,0 +1,15 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+// Discovered by https://github.com/airspeedswift (airspeedswift)
+
+let s1: Set<Int>? = []
+let s2: Set<Int>? = []
+let s3: Set<Int>? = []
+let x = s1 ?? s2 ?? s3 ?? []


### PR DESCRIPTION
Add test case for crash triggered in `swift::constraints::ConstraintSystem::assignFixedType(...)`.

Credit goes to @airspeedswift for the discovery of this issue.

Current number of unresolved compiler crashers: 53 (5156 resolved)

Assertion failure in [`lib/Sema/ConstraintGraph.cpp (line 207)`](https://github.com/apple/swift/blob/master/lib/Sema/ConstraintGraph.cpp#L207):

```
Assertion `!adjacency.FixedBinding && "Already marked as a fixed binding?"' failed.

When executing: void swift::constraints::ConstraintGraphNode::addFixedBinding(swift::TypeVariableType *)
```

Assertion context:

```
}

void ConstraintGraphNode::addFixedBinding(TypeVariableType *typeVar) {
  auto &adjacency = getAdjacency(typeVar);

  assert(!adjacency.FixedBinding && "Already marked as a fixed binding?");
  adjacency.FixedBinding = true;
}

void ConstraintGraphNode::removeFixedBinding(TypeVariableType *typeVar) {
  modifyAdjacency(typeVar, [](Adjacency &adj) {
```

Stack trace:

```
swift: /path/to/swift/lib/Sema/ConstraintGraph.cpp:207: void swift::constraints::ConstraintGraphNode::addFixedBinding(swift::TypeVariableType *): Assertion `!adjacency.FixedBinding && "Already marked as a fixed binding?"' failed.
9  swift           0x0000000000f61c3e swift::constraints::ConstraintSystem::assignFixedType(swift::TypeVariableType*, swift::Type, bool) + 366
10 swift           0x0000000000fc8f9e swift::constraints::ConstraintSystem::matchTypes(swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 3262
11 swift           0x0000000000fcd27d swift::constraints::ConstraintSystem::matchDeepEqualityTypes(swift::Type, swift::Type, swift::constraints::ConstraintLocatorBuilder) + 877
12 swift           0x0000000000fcdc15 swift::constraints::ConstraintSystem::simplifyRestrictedConstraint(swift::constraints::ConversionRestrictionKind, swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 1077
13 swift           0x0000000000fd5097 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 439
14 swift           0x0000000000fddc0d swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 11277
15 swift           0x0000000000fd99c3 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 323
16 swift           0x0000000000fddce4 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 11492
17 swift           0x0000000000fd99c3 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 323
18 swift           0x0000000000fddce4 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 11492
19 swift           0x0000000000fd99c3 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 323
20 swift           0x0000000000fdf3c1 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 17345
21 swift           0x0000000000fd99c3 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 323
22 swift           0x0000000000fdf3c1 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 17345
23 swift           0x0000000000fd99c3 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 323
24 swift           0x0000000000fdf3c1 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 17345
25 swift           0x0000000000fd99c3 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 323
26 swift           0x0000000000fddce4 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 11492
27 swift           0x0000000000fd99c3 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 323
28 swift           0x0000000000fddce4 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 11492
29 swift           0x0000000000fd99c3 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 323
30 swift           0x0000000000fddce4 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 11492
31 swift           0x0000000000fd99c3 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 323
32 swift           0x0000000000fddce4 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 11492
33 swift           0x0000000000fd99c3 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 323
34 swift           0x0000000000fddce4 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 11492
35 swift           0x0000000000fd99c3 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 323
36 swift           0x0000000000fddce4 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 11492
37 swift           0x0000000000fd99c3 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 323
38 swift           0x0000000000fddce4 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 11492
39 swift           0x0000000000fd99c3 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 323
40 swift           0x0000000000fddce4 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 11492
41 swift           0x0000000000fd99c3 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 323
42 swift           0x0000000000fd9779 swift::constraints::ConstraintSystem::solve(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 73
43 swift           0x0000000000ebd438 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 808
44 swift           0x0000000000ec443d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 621
45 swift           0x0000000000ec55f0 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 352
46 swift           0x0000000000ec580b swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
49 swift           0x0000000000ed7466 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
51 swift           0x0000000000f40ae6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
52 swift           0x0000000000efb40d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
53 swift           0x0000000000c7b5b9 swift::CompilerInstance::performSema() + 3289
55 swift           0x00000000007db487 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
56 swift           0x00000000007a72b8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28400-swift-nominaltypedecl-prepareextensions.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28400-swift-nominaltypedecl-prepareextensions-72c649.o
1.  While type-checking declaration 0x6578c80 at validation-test/compiler_crashers/28400-swift-nominaltypedecl-prepareextensions.swift:15:1
2.  While type-checking expression at [validation-test/compiler_crashers/28400-swift-nominaltypedecl-prepareextensions.swift:15:9 - line:15:28] RangeText="s1 ?? s2 ?? s3 ?? []"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
