### PR TITLE
Fix the cast optimizer to handle CF/NS bridging correctly,

### DIFF
--- a/lib/SIL/DynamicCasts.cpp
+++ b/lib/SIL/DynamicCasts.cpp
@@ -250,6 +250,59 @@ static bool canDynamicallyBeOptionalType(CanType type) {
       && !type.isAnyClassReferenceType();
 }
 
+/// Given two class types, check whether there's a hierarchy relationship
+/// between them.
+static DynamicCastFeasibility
+classifyClassHierarchyCast(CanType source, CanType target) {
+  // Upcast: if the target type statically matches a type in the
+  // source type's hierarchy, this is a static upcast and the cast
+  // will always succeed.
+  if (target->isExactSuperclassOf(source, nullptr))
+    return DynamicCastFeasibility::WillSucceed;
+
+  // Upcast: if the target type might dynamically match a type in the
+  // source type's hierarchy, this might be an upcast, in which
+  // case the cast might succeed.
+  if (target->isBindableToSuperclassOf(source, nullptr))
+    return DynamicCastFeasibility::MaySucceed;
+
+  // Downcast: if the source type might dynamically match a type in the
+  // target type's hierarchy, this might be a downcast, in which case
+  // the cast might succeed.  Note that this also covers the case where
+  // the source type statically matches a type in the target type's
+  // hierarchy; since it's a downcast, the cast still at best might succeed.
+  if (source->isBindableToSuperclassOf(target, nullptr))
+    return DynamicCastFeasibility::MaySucceed;
+
+  // Otherwise, the classes are unrelated and the cast will fail (at least
+  // on these grounds).
+  return DynamicCastFeasibility::WillFail;
+}
+
+static CanType getNSBridgedClassOfCFClass(Module *M, CanType type) {
+  if (auto classDecl = type->getClassOrBoundGenericClass()) {
+    if (classDecl->getForeignClassKind() == ClassDecl::ForeignKind::CFType) {
+      if (auto bridgedAttr =
+            classDecl->getAttrs().getAttribute<ObjCBridgedAttr>()) {
+        auto bridgedClass = bridgedAttr->getObjCClass();
+        // TODO: this should handle generic classes properly.
+        if (!bridgedClass->isGenericContext()) {
+          return bridgedClass->getDeclaredInterfaceType()->getCanonicalType();
+        }
+      }
+    }
+  }
+  return CanType();
+}
+
+static bool isCFBridgingConversion(Module *M, SILType sourceType,
+                                   SILType targetType) {
+  return (sourceType.getSwiftRValueType() ==
+            getNSBridgedClassOfCFClass(M, targetType.getSwiftRValueType()) ||
+          targetType.getSwiftRValueType() ==
+            getNSBridgedClassOfCFClass(M, sourceType.getSwiftRValueType()));
+}
+
 /// Try to classify the dynamic-cast relationship between two types.
 DynamicCastFeasibility
 swift::classifyDynamicCast(Module *M,
@@ -311,6 +364,30 @@ swift::classifyDynamicCast(Module *M,
     return DynamicCastFeasibility::MaySucceed;
   }
 
+  // Casts from AnyHashable.
+  if (auto sourceStruct = dyn_cast<StructType>(source)) {
+    if (sourceStruct->getDecl() == M->getASTContext().getAnyHashableDecl()) {
+      if (auto hashable = getHashableExistentialType(M)) {
+        // Succeeds if Hashable can be cast to the target type.
+        return classifyDynamicCastFromProtocol(M, hashable, target,
+                                               isWholeModuleOpts);
+      }
+    }
+  }
+
+  // Casts to AnyHashable.
+  if (auto targetStruct = dyn_cast<StructType>(target)) {
+    if (targetStruct->getDecl() == M->getASTContext().getAnyHashableDecl()) {
+      // Succeeds if the source type can be dynamically cast to Hashable.
+      // Hashable is not actually a legal existential type right now, but
+      // the check doesn't care about that.
+      if (auto hashable = getHashableExistentialType(M)) {
+        return classifyDynamicCastToProtocol(source, hashable,
+                                             isWholeModuleOpts);
+      }
+    }
+  }
+
   // Metatype casts.
   if (auto sourceMetatype = dyn_cast<AnyMetatypeType>(source)) {
     auto targetMetatype = dyn_cast<AnyMetatypeType>(target);
@@ -369,7 +446,7 @@ swift::classifyDynamicCast(Module *M,
     // cast.
     if (source.getClassOrBoundGenericClass() &&
         target.getClassOrBoundGenericClass())
-      return classifyDynamicCast(M, source, target, false, isWholeModuleOpts);
+      return classifyClassHierarchyCast(source, target);
 
     // Different structs cannot be cast to each other.
     if (source.getStructOrBoundGenericStruct() &&
@@ -386,7 +463,7 @@ swift::classifyDynamicCast(Module *M,
     // If we don't know any better, assume that the cast may succeed.
     return DynamicCastFeasibility::MaySucceed;
   }
-  
+
   // Function casts.
   if (auto sourceFunction = dyn_cast<FunctionType>(source)) {
     if (auto targetFunction = dyn_cast<FunctionType>(target)) {
@@ -457,16 +534,25 @@ swift::classifyDynamicCast(Module *M,
         }
       }
 
+      // Try a hierarchy cast.  If that isn't failure, we can report it.
+      auto hierarchyResult = classifyClassHierarchyCast(source, target);
+      if (hierarchyResult != DynamicCastFeasibility::WillFail)
+        return hierarchyResult;
 
-      if (target->isExactSuperclassOf(source, nullptr))
-        return DynamicCastFeasibility::WillSucceed;
-      if (target->isBindableToSuperclassOf(source, nullptr))
-        return DynamicCastFeasibility::MaySucceed;
-      if (source->isBindableToSuperclassOf(target, nullptr))
-        return DynamicCastFeasibility::MaySucceed;
+      // As a backup, consider whether either type is a CF class type
+      // with an NS bridged equivalent.
+      CanType bridgedSource = getNSBridgedClassOfCFClass(M, source);
+      CanType bridgedTarget = getNSBridgedClassOfCFClass(M, target);
 
-      // FIXME: bridged types, e.g. CF <-> NS (but not for metatypes).
-      return DynamicCastFeasibility::WillFail;
+      // If neither type qualifies, we're done.
+      if (!bridgedSource && !bridgedTarget)
+        return DynamicCastFeasibility::WillFail;
+
+      // Otherwise, map over to the bridged types and try to answer the
+      // question there.
+      if (bridgedSource) source = bridgedSource;
+      if (bridgedTarget) target = bridgedTarget;
+      return classifyDynamicCast(M, source, target, false, isWholeModuleOpts);
     }
 
     // Casts from a class into a non-class can never succeed if the target must
@@ -599,30 +685,6 @@ swift::classifyDynamicCast(Module *M,
     }
   }
 
-  // Casts from AnyHashable.
-  if (auto sourceStruct = dyn_cast<StructType>(source)) {
-    if (sourceStruct->getDecl() == M->getASTContext().getAnyHashableDecl()) {
-      if (auto hashable = getHashableExistentialType(M)) {
-        // Succeeds if Hashable can be cast to the target type.
-        return classifyDynamicCastFromProtocol(M, hashable, target,
-                                               isWholeModuleOpts);
-      }
-    }
-  }
-
-  // Casts to AnyHashable.
-  if (auto targetStruct = dyn_cast<StructType>(target)) {
-    if (targetStruct->getDecl() == M->getASTContext().getAnyHashableDecl()) {
-      // Succeeds if the source type can be dynamically cast to Hashable.
-      // Hashable is not actually a legal existential type right now, but
-      // the check doesn't care about that.
-      if (auto hashable = getHashableExistentialType(M)) {
-        return classifyDynamicCastToProtocol(source, hashable,
-                                             isWholeModuleOpts);
-      }
-    }
-  }
-
   return DynamicCastFeasibility::WillFail;
 }
 
@@ -685,9 +747,11 @@ namespace {
     SILModule &M;
     ASTContext &Ctx;
     SILLocation Loc;
+    Module *SwiftModule;
   public:
     CastEmitter(SILBuilder &B, Module *swiftModule, SILLocation loc)
-      : B(B), M(B.getModule()), Ctx(M.getASTContext()), Loc(loc) {}
+      : B(B), M(B.getModule()), Ctx(M.getASTContext()), Loc(loc),
+        SwiftModule(swiftModule) {}
 
     Source emitTopLevel(Source source, Target target) {
       unsigned sourceOptDepth = getOptionalDepth(source.FormalType);
@@ -768,8 +832,8 @@ namespace {
       }
       assert(!target.FormalType.getAnyOptionalObjectType());
 
-      // The only other thing we return WillSucceed for currently is
-      // an upcast.
+      // The only other things we return WillSucceed for currently is
+      // an upcast or CF/NS toll-free-bridging conversion.
       // FIXME: Upcasts between existential metatypes are not handled yet.
       // We should generate for it:
       // %openedSrcMetatype = open_existential srcMetatype
@@ -781,7 +845,12 @@ namespace {
       } else {
         value = getOwnedScalar(source, srcTL);
       }
-      value = B.createUpcast(Loc, value, target.LoweredType.getObjectType());
+      auto targetTy = target.LoweredType;
+      if (isCFBridgingConversion(SwiftModule, targetTy, value->getType())) {
+        value = B.createUncheckedRefCast(Loc, value, targetTy.getObjectType());
+      } else {
+        value = B.createUpcast(Loc, value, targetTy.getObjectType());
+      }
       return putOwnedScalar(value, target);
     }
 

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -2633,6 +2633,11 @@ bool swift::swift_dynamicCast(OpaqueValue *dest,
     case MetadataKind::Class:
     case MetadataKind::ObjCClassWrapper:
     case MetadataKind::ForeignClass: {
+      // Casts to AnyHashable.
+      if (isAnyHashableType(targetType)) {
+        return _dynamicCastToAnyHashable(dest, src, srcType, targetType, flags);
+      }
+
 #if SWIFT_OBJC_INTEROP
       // If the target type is bridged to Objective-C, try to bridge.
       if (auto targetBridgeWitness = findBridgeWitness(targetType)) {
@@ -2649,10 +2654,6 @@ bool swift::swift_dynamicCast(OpaqueValue *dest,
       }
 #endif
 
-      // Casts to AnyHashable.
-      if (isAnyHashableType(targetType)) {
-        return _dynamicCastToAnyHashable(dest, src, srcType, targetType, flags);
-      }
       break;
     }
 
@@ -2666,10 +2667,16 @@ bool swift::swift_dynamicCast(OpaqueValue *dest,
       }
       break;
 
+    case MetadataKind::Optional:
+    case MetadataKind::Enum:
+      // Casts to AnyHashable.
+      if (isAnyHashableType(targetType)) {
+        return _dynamicCastToAnyHashable(dest, src, srcType, targetType, flags);
+      }
+      break;
+
     case MetadataKind::Existential:
     case MetadataKind::ExistentialMetatype:
-    case MetadataKind::Enum:
-    case MetadataKind::Optional:
     case MetadataKind::Function:
     case MetadataKind::HeapLocalVariable:
     case MetadataKind::HeapGenericLocalVariable:

--- a/test/1_stdlib/AnyHashableCasts.swift.gyb
+++ b/test/1_stdlib/AnyHashableCasts.swift.gyb
@@ -15,6 +15,37 @@ protocol Implemented {}
 protocol Unimplemented {}
 extension Int : Implemented {}
 
+struct HashableStruct : Hashable {
+  var value : Int
+  static func ==(lhs: HashableStruct, rhs: HashableStruct) -> Bool {
+    return lhs.value == rhs.value
+  }
+  var hashValue : Int { return value }
+}
+
+class HashableClass : Hashable {
+  var value : Int
+  init(value v: Int) { self.value = v }
+  static func ==(lhs: HashableClass, rhs: HashableClass) -> Bool {
+    return lhs.value == rhs.value
+  }
+  var hashValue : Int { return value }
+}
+
+enum HashableEnum : Hashable {
+  case value(Int)
+  static func ==(lhs: HashableEnum, rhs: HashableEnum) -> Bool {
+    switch (lhs, rhs) {
+    case (.value(let l), .value(let r)): return l == r
+    }
+  }
+  var hashValue : Int {
+    switch self {
+    case .value(let v): return v
+    }
+  }
+}
+
 func opaqueCast<T, U>(_ lhs: T, _ rhs: U.Type) -> U? {
   return lhs as? U
 }
@@ -39,7 +70,13 @@ testCases = [
   ("5", "AnyHashable", "Unimplemented", False),
   ("5", "Int", "AnyHashable", "5"),
   ("5", "Any", "AnyHashable", "5"),
-  ("AnyHashable(5)", "Any", "Int", "5")
+  ("AnyHashable(5)", "Any", "Int", "5"),
+  ("HashableStruct(value: 5)", "HashableStruct", "AnyHashable",
+   "AnyHashable(HashableStruct(value: 5))"),
+  ("HashableClass(value: 5)", "HashableClass", "AnyHashable",
+   "AnyHashable(HashableClass(value: 5))"),
+  ("HashableEnum.value(5)", "HashableEnum", "AnyHashable",
+   "AnyHashable(HashableEnum.value(5))"),
 ]
 }%
 

--- a/test/SILOptimizer/cast_folding_no_bridging.sil
+++ b/test/SILOptimizer/cast_folding_no_bridging.sil
@@ -59,3 +59,44 @@ bb2(%14 : $NSSet):
 bb3:
   br bb2(%1 : $NSSet)
 }
+
+sil @fail : $@convention(thin) () -> Never
+
+// CHECK-LABEL: sil @testCFToObjC
+// CHECK: bb0(
+// CHECK-NEXT: [[T0:%.*]] = load %1 : $*CFString
+// CHECK-NEXT: [[T1:%.*]] = unchecked_ref_cast [[T0]] : $CFString to $NSString
+// CHECK-NEXT: store [[T1]] to %0 : $*NSString
+sil @testCFToObjC : $@convention(thin) (@in CFString) -> @out NSString {
+bb0(%0 : $*NSString, %1 : $*CFString):
+  checked_cast_addr_br take_always CFString in %1 : $*CFString to NSString in %0 : $*NSString, bb1, bb2
+
+bb1:
+  %ret = tuple ()
+  return %ret : $()
+
+bb2:
+  %fn = function_ref @fail : $@convention(thin) () -> Never
+  apply %fn() : $@convention(thin) () -> Never
+  unreachable
+}
+
+// CHECK-LABEL: sil @testCFToSwift
+// CHECK: bb0(
+// CHECK-NEXT: [[T0:%.*]] = load %1 : $*CFString
+// CHECK-NEXT: [[T1:%.*]] = unchecked_ref_cast [[T0]] : $CFString to $NSString
+// CHECK:      [[FN:%.*]] = function_ref @_TTWSSs21_ObjectiveCBridgeable10FoundationZFS_34_conditionallyBridgeFromObjectiveCfTwx15_ObjectiveCType6resultRGSqx__Sb : $@convention(witness_method) (@owned NSString, @inout Optional<String>, @thick String.Type) -> Bool
+// CHECK: apply [[FN]]([[T1]], {{.*}}, {{.*}})
+sil @testCFToSwift : $@convention(thin) (@in CFString) -> @out String {
+bb0(%0 : $*String, %1 : $*CFString):
+  checked_cast_addr_br take_always CFString in %1 : $*CFString to String in %0 : $*String, bb1, bb2
+
+bb1:
+  %ret = tuple ()
+  return %ret : $()
+
+bb2:
+  %fn = function_ref @fail : $@convention(thin) () -> Never
+  apply %fn() : $@convention(thin) () -> Never
+  unreachable
+}


### PR DESCRIPTION
- Description: There were some bugs in both the specialized cast path and the runtime cast path, leading to differences in behavior between code compiled with -O and without.
- Scope of the issue: Affects anyone working with APIs that accept CFDictionaries, or AnyHashable.
- Risk: Low, it's a small change.
- Testing: New tests were added.
- Reviewed by: Doug Gregor in master branch.
- Radar: rdar://problem/27942352
