### PR TITLE
[codecomplete] Attempt to workaround ArchetypeBuilder crash in non-as…

### DIFF
--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -1477,6 +1477,10 @@ void ArchetypeBuilder::addRequirement(const Requirement &req,
   case RequirementKind::Conformance: {
     PotentialArchetype *pa = resolveArchetype(req.getFirstType());
     assert(pa && "Re-introducing invalid requirement");
+    // FIXME: defensively return if assertions are disabled until we figure out
+    // how this sitatuaion can occur and fix it properly.
+    if (!pa)
+      return;
 
     SmallVector<ProtocolDecl *, 4> conformsTo;
     bool existential = req.getSecondType()->isExistentialType(conformsTo);


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
- Explanation: There is a common crash happening during code-completion in the archetype builder when adding a conformance requirement with a null potential archetype.  Unfortunately we have not yet found a way to reproduce this or reason out how this situation can occur.  As a workaround, this adds a defensive return-on-null to the caller after the existing `assert()` so that non-asserts users can avoid the crash.
- Scope: This is a common code-completion crash.  It seems to have become an issue in the preview-3/preview-4 timeframe.
- Risk: Very low.  This simply bails out in a place we already have an `assert()`
- Reviewed by: Doug Gregor
- Testing: No new tests because we don't yet know how to reproduce this crash.  If we did, we would fix the underlying issue.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…serts build

Add a defensive return on null if we're building without assertions.
There appears to be a way to trigger this in code-completion, so until
we find a reproducer/figure out what's going wrong, try not to crash.
Only impacts no-asserts builds.

rdar://problem/27615954
