### PR TITLE
Reflection: Fix crash in single-payload enum layout if payload type c…

### DIFF
--- a/include/swift/Reflection/TypeLowering.h
+++ b/include/swift/Reflection/TypeLowering.h
@@ -19,6 +19,7 @@
 #define SWIFT_REFLECTION_TYPELOWERING_H
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/Support/Casting.h"
 
 #include <iostream>
@@ -206,6 +207,7 @@ class TypeConverter {
   TypeRefBuilder &Builder;
   std::vector<std::unique_ptr<const TypeInfo>> Pool;
   llvm::DenseMap<const TypeRef *, const TypeInfo *> Cache;
+  llvm::DenseSet<const TypeRef *> RecursionCheck;
   llvm::DenseMap<std::pair<unsigned, unsigned>,
                  const ReferenceTypeInfo *> ReferenceCache;
 

--- a/test/Reflection/typeref_lowering_missing.swift
+++ b/test/Reflection/typeref_lowering_missing.swift
@@ -1,0 +1,15 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-build-swift %S/Inputs/ConcreteTypes.swift -parse-as-library -emit-module -emit-library -module-name TypeLowering -Xfrontend -disable-reflection-metadata -o %t/libTypesToReflect
+// RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect -binary-filename %platform-module-dir/libswiftCore.dylib -dump-type-lowering < %s | %FileCheck %s
+
+// REQUIRES: objc_interop
+// REQUIRES: CPU=x86_64
+
+V12TypeLowering11BasicStruct
+// CHECK: (struct TypeLowering.BasicStruct)
+// CHECK: Invalid lowering
+
+GSqV12TypeLowering11BasicStruct_
+// CHECK: (bound_generic_enum Swift.Optional
+// CHECK:   (struct TypeLowering.BasicStruct))
+// CHECK: Invalid lowering


### PR DESCRIPTION
- Description: The reflection library would dereference a null pointer if it encountered an `Optional` of a type for which we do not have reflection metadata (possibly because we did a release build, or if IRGen neglects to emit the info due to a bug).
- Scope of the issue: Affects anyone doing memory graph debugging in Instruments when the above scenario occurs.
- Risk: Low, the existing logic mostly already handles missing type info, but in this case we forgot to do a null check.
- Tested: Existing tests pass, and there's a new test for the scenario that used to crash.
- Reviewed by: David Farler (pending)
- Radar: rdar://problem/27906876

I will continue investigating the issue (in particular, I'm wondering what the root cause of the missing type info is, since in theory we should always emit everything that we need). But even if we fix the original problem, we need this fix anyway, for general robustness.
