### PR TITLE
Reflection: Fix crash in single-payload enum layout if payload type c…

### DIFF
--- a/include/swift/Reflection/TypeLowering.h
+++ b/include/swift/Reflection/TypeLowering.h
@@ -19,6 +19,7 @@
 #define SWIFT_REFLECTION_TYPELOWERING_H
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/Support/Casting.h"
 
 #include <iostream>
@@ -206,6 +207,7 @@ class TypeConverter {
   TypeRefBuilder &Builder;
   std::vector<std::unique_ptr<const TypeInfo>> Pool;
   llvm::DenseMap<const TypeRef *, const TypeInfo *> Cache;
+  llvm::DenseSet<const TypeRef *> RecursionCheck;
   llvm::DenseMap<std::pair<unsigned, unsigned>,
                  const ReferenceTypeInfo *> ReferenceCache;
 

--- a/test/Reflection/typeref_lowering_missing.swift
+++ b/test/Reflection/typeref_lowering_missing.swift
@@ -1,0 +1,15 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-build-swift %S/Inputs/ConcreteTypes.swift -parse-as-library -emit-module -emit-library -module-name TypeLowering -Xfrontend -disable-reflection-metadata -o %t/libTypesToReflect
+// RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect -binary-filename %platform-module-dir/libswiftCore.dylib -dump-type-lowering < %s | %FileCheck %s
+
+// REQUIRES: objc_interop
+// REQUIRES: CPU=x86_64
+
+V12TypeLowering11BasicStruct
+// CHECK: (struct TypeLowering.BasicStruct)
+// CHECK: Invalid lowering
+
+GSqV12TypeLowering11BasicStruct_
+// CHECK: (bound_generic_enum Swift.Optional
+// CHECK:   (struct TypeLowering.BasicStruct))
+// CHECK: Invalid lowering


### PR DESCRIPTION
This is the same fix as https://github.com/apple/swift/pull/4469, but for master.
