### PR TITLE
[swiftc (55 vs. 5156)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28402-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28402-swift-typebase-getcanonicaltype.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+let c{{
+return.E == .i
+c


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 55 (5156 resolved)

Assertion failure in [`include/swift/AST/Type.h (line 241)`](https://github.com/apple/swift/blob/master/include/swift/AST/Type.h#L241):

```
Assertion `isActuallyCanonicalOrNull() && "Forming a CanType out of a non-canonical type!"' failed.

When executing: swift::CanType::CanType(swift::TypeBase *)
```

Assertion context:

```
  static CanType getLValueOrInOutObjectTypeImpl(CanType type);
  static ClassDecl *getClassBoundImpl(CanType type);

public:
  explicit CanType(TypeBase *P = 0) : Type(P) {
    assert(isActuallyCanonicalOrNull() &&
           "Forming a CanType out of a non-canonical type!");
  }
  explicit CanType(Type T) : Type(T) {
    assert(isActuallyCanonicalOrNull() &&
           "Forming a CanType out of a non-canonical type!");
```

Stack trace:

```
swift: /path/to/swift/include/swift/AST/Type.h:241: swift::CanType::CanType(swift::TypeBase *): Assertion `isActuallyCanonicalOrNull() && "Forming a CanType out of a non-canonical type!"' failed.
8  swift           0x00000000011536e2 swift::TypeBase::getCanonicalType() + 2370
14 swift           0x000000000109a2de swift::Stmt::walk(swift::ASTWalker&) + 78
15 swift           0x0000000000f03b35 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) + 549
19 swift           0x000000000109a2de swift::Stmt::walk(swift::ASTWalker&) + 78
20 swift           0x0000000000f03b35 swift::TypeChecker::computeCaptures(swift::AnyFunctionRef) + 549
22 swift           0x0000000000efb4a1 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
23 swift           0x0000000000c7b5b9 swift::CompilerInstance::performSema() + 3289
25 swift           0x00000000007db487 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
26 swift           0x00000000007a72b8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28402-swift-typebase-getcanonicaltype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28402-swift-typebase-getcanonicaltype-e8cf35.o
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
