### PR TITLE
[gardening] Python tidies in cmpcodesize.main

### DIFF
--- a/utils/cmpcodesize/cmpcodesize/main.py
+++ b/utils/cmpcodesize/cmpcodesize/main.py
@@ -193,11 +193,10 @@ How to specify files:
             if len(old_files) != len(new_files):
                 sys.exit("number of new files must be the same of old files")
 
-            old_files.sort
-            new_files.sort
+            old_files.sort()
+            new_files.sort()
 
-            for idx, old_file in enumerate(old_files):
-                new_file = new_files[idx]
+            for old_file, new_file in zip(old_files, new_files):
                 compare_sizes_of_file([old_file], [new_file],
                                       parsed_arguments.all_sections,
                                       parsed_arguments.list_categories)


### PR DESCRIPTION
#### What's in this pull request?

Some Python tidies:
- Those `.sort`s weren't actually doing anything -- you need to call the methods for them to take effect.
- Use `zip()`, and drop the `idx` variable. We know that `old_files` and `new_files` are the same length -- there's a check on the lines above -- so we don't need to worry about missing elements.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

None.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
- Actually call the `sort()` method.
- Cut out an unnecessary `idx` variable.
