### PR TITLE
Revert "[Set/Dictionary] Eliminate "bridging" collection entrypoints."

### DIFF
--- a/stdlib/public/SDK/Foundation/Foundation.swift
+++ b/stdlib/public/SDK/Foundation/Foundation.swift
@@ -638,7 +638,13 @@ extension Dictionary : _ObjectiveCBridgeable {
     result: inout Dictionary?
   ) -> Bool {
     let anyDict = x as [NSObject : AnyObject]
-    result = Swift._dictionaryDownCastConditional(anyDict)
+    if _isBridgedVerbatimToObjectiveC(Key.self) &&
+       _isBridgedVerbatimToObjectiveC(Value.self) {
+      result = Swift._dictionaryDownCastConditional(anyDict)
+      return result != nil
+    }
+
+    result = Swift._dictionaryBridgeFromObjectiveCConditional(anyDict)
     return result != nil
   }
 
@@ -882,7 +888,12 @@ extension Set : _ObjectiveCBridgeable {
     _ x: NSSet, result: inout Set?
   ) -> Bool {
     let anySet = x as Set<NSObject>
-    result = Swift._setDownCastConditional(anySet)
+    if _isBridgedVerbatimToObjectiveC(Element.self) {
+      result = Swift._setDownCastConditional(anySet)
+      return result != nil
+    }
+
+    result = Swift._setBridgeFromObjectiveCConditional(anySet)
     return result != nil
   }
 

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -1291,6 +1291,40 @@ public func _setUpCast<DerivedValue, BaseValue>(_ source: Set<DerivedValue>)
   return builder.take()
 }
 
+#if _runtime(_ObjC)
+
+/// Implements an unconditional upcast that involves bridging.
+///
+/// The cast can fail if bridging fails.
+///
+/// - Precondition: `SwiftValue` is bridged to Objective-C
+///   and requires non-trivial bridging.
+public func _setBridgeToObjectiveC<SwiftValue, ObjCValue>(
+  _ source: Set<SwiftValue>
+) -> Set<ObjCValue> {
+  _sanityCheck(_isClassOrObjCExistential(ObjCValue.self))
+  _sanityCheck(!_isBridgedVerbatimToObjectiveC(SwiftValue.self))
+
+  var result = Set<ObjCValue>(minimumCapacity: source.count)
+  let valueBridgesDirectly =
+    _isBridgedVerbatimToObjectiveC(SwiftValue.self) ==
+    _isBridgedVerbatimToObjectiveC(ObjCValue.self)
+
+  for member in source {
+    var bridgedMember: ObjCValue
+    if valueBridgesDirectly {
+      bridgedMember = unsafeBitCast(member, to: ObjCValue.self)
+    } else {
+      let bridged: AnyObject = _bridgeAnythingToObjectiveC(member)
+      bridgedMember = unsafeBitCast(bridged, to: ObjCValue.self)
+    }
+    result.insert(bridgedMember)
+  }
+  return result
+}
+
+#endif
+
 @_silgen_name("_swift_setDownCastIndirect")
 public func _setDownCastIndirect<SourceValue, TargetValue>(
   _ source: UnsafePointer<Set<SourceValue>>,
@@ -1354,6 +1388,64 @@ public func _setDownCastConditional<BaseValue, DerivedValue>(
       try ($0 as? DerivedValue).unwrappedOrError()
     })
 }
+
+#if _runtime(_ObjC)
+
+/// Implements an unconditional downcast that involves bridging.
+///
+/// - Precondition: At least one of `SwiftValue` is a bridged value
+///   type, and the corresponding `ObjCValue` is a reference type.
+public func _setBridgeFromObjectiveC<ObjCValue, SwiftValue>(
+  _ source: Set<ObjCValue>
+) -> Set<SwiftValue> {
+  let result: Set<SwiftValue>? = _setBridgeFromObjectiveCConditional(source)
+  _precondition(result != nil, "This set cannot be bridged from Objective-C")
+  return result!
+}
+
+/// Implements a conditional downcast that involves bridging.
+///
+/// If the cast fails, the function returns `nil`.  All checks should be
+/// performed eagerly.
+///
+/// - Precondition: At least one of `SwiftValue` is a bridged value
+///   type, and the corresponding `ObjCValue` is a reference type.
+public func _setBridgeFromObjectiveCConditional<
+  ObjCValue, SwiftValue
+>(
+  _ source: Set<ObjCValue>
+) -> Set<SwiftValue>? {
+  _sanityCheck(_isClassOrObjCExistential(ObjCValue.self))
+  _sanityCheck(!_isBridgedVerbatimToObjectiveC(SwiftValue.self))
+
+  let valueBridgesDirectly =
+    _isBridgedVerbatimToObjectiveC(SwiftValue.self) ==
+      _isBridgedVerbatimToObjectiveC(ObjCValue.self)
+
+  var result = Set<SwiftValue>(minimumCapacity: source.count)
+  for value in source {
+    // Downcast the value.
+    var resultValue: SwiftValue
+    if valueBridgesDirectly {
+      if let bridgedValue = value as? SwiftValue {
+        resultValue = bridgedValue
+      } else {
+        return nil
+      }
+    } else {
+      if let bridgedValue = _conditionallyBridgeFromObjectiveC(
+          _reinterpretCastToAnyObject(value), SwiftValue.self) {
+        resultValue = bridgedValue
+      } else {
+        return nil
+      }
+    }
+    result.insert(resultValue)
+  }
+  return result
+}
+
+#endif
 
 //===--- APIs unique to Dictionary<Key, Value> ----------------------------===//
 
@@ -2124,6 +2216,66 @@ public func _dictionaryUpCast<DerivedKey, DerivedValue, BaseKey, BaseValue>(
   return result
 }
 
+#if _runtime(_ObjC)
+
+/// Implements an unconditional upcast that involves bridging.
+///
+/// The cast can fail if bridging fails.
+///
+/// - Precondition: `SwiftKey` and `SwiftValue` are bridged to Objective-C,
+///   and at least one of them requires non-trivial bridging.
+@inline(never)
+@_semantics("stdlib_binary_only")
+public func _dictionaryBridgeToObjectiveC<
+  SwiftKey, SwiftValue, ObjCKey, ObjCValue
+>(
+  _ source: Dictionary<SwiftKey, SwiftValue>
+) -> Dictionary<ObjCKey, ObjCValue> {
+
+  // Note: We force this function to stay in the swift dylib because
+  // it is not performance sensitive and keeping it in the dylib saves
+  // a new kilobytes for each specialization for all users of dictionary.
+
+  _sanityCheck(
+    !_isBridgedVerbatimToObjectiveC(SwiftKey.self) ||
+    !_isBridgedVerbatimToObjectiveC(SwiftValue.self))
+  _sanityCheck(
+    _isClassOrObjCExistential(ObjCKey.self) ||
+    _isClassOrObjCExistential(ObjCValue.self))
+
+  var result = Dictionary<ObjCKey, ObjCValue>(minimumCapacity: source.count)
+  let keyBridgesDirectly =
+    _isBridgedVerbatimToObjectiveC(SwiftKey.self) ==
+      _isBridgedVerbatimToObjectiveC(ObjCKey.self)
+  let valueBridgesDirectly =
+    _isBridgedVerbatimToObjectiveC(SwiftValue.self) ==
+      _isBridgedVerbatimToObjectiveC(ObjCValue.self)
+  for (key, value) in source {
+    // Bridge the key
+    var bridgedKey: ObjCKey
+    if keyBridgesDirectly {
+      bridgedKey = unsafeBitCast(key, to: ObjCKey.self)
+    } else {
+      let bridged: AnyObject = _bridgeAnythingToObjectiveC(key)
+      bridgedKey = unsafeBitCast(bridged, to: ObjCKey.self)
+    }
+
+    // Bridge the value
+    var bridgedValue: ObjCValue
+    if valueBridgesDirectly {
+      bridgedValue = unsafeBitCast(value, to: ObjCValue.self)
+    } else {
+      let bridged: AnyObject? = _bridgeAnythingToObjectiveC(value)
+      bridgedValue = unsafeBitCast(bridged, to: ObjCValue.self)
+    }
+
+    result[bridgedKey] = bridgedValue
+  }
+
+  return result
+}
+#endif
+
 @_silgen_name("_swift_dictionaryDownCastIndirect")
 public func _dictionaryDownCastIndirect<SourceKey, SourceValue,
                                         TargetKey, TargetValue>(
@@ -2212,6 +2364,89 @@ public func _dictionaryDownCastConditional<
   return result
 }
 
+#if _runtime(_ObjC)
+/// Implements an unconditional downcast that involves bridging.
+///
+/// - Precondition: At least one of `SwiftKey` or `SwiftValue` is a bridged value
+///   type, and the corresponding `ObjCKey` or `ObjCValue` is a reference type.
+public func _dictionaryBridgeFromObjectiveC<
+  ObjCKey, ObjCValue, SwiftKey, SwiftValue
+>(
+  _ source: Dictionary<ObjCKey, ObjCValue>
+) -> Dictionary<SwiftKey, SwiftValue> {
+  let result: Dictionary<SwiftKey, SwiftValue>? =
+    _dictionaryBridgeFromObjectiveCConditional(source)
+  _precondition(result != nil, "dictionary cannot be bridged from Objective-C")
+  return result!
+}
+
+/// Implements a conditional downcast that involves bridging.
+///
+/// If the cast fails, the function returns `nil`.  All checks should be
+/// performed eagerly.
+///
+/// - Precondition: At least one of `SwiftKey` or `SwiftValue` is a bridged value
+///   type, and the corresponding `ObjCKey` or `ObjCValue` is a reference type.
+public func _dictionaryBridgeFromObjectiveCConditional<
+  ObjCKey, ObjCValue, SwiftKey, SwiftValue
+>(
+  _ source: Dictionary<ObjCKey, ObjCValue>
+) -> Dictionary<SwiftKey, SwiftValue>? {
+  _sanityCheck(
+    _isClassOrObjCExistential(ObjCKey.self) ||
+    _isClassOrObjCExistential(ObjCValue.self))
+  _sanityCheck(
+    !_isBridgedVerbatimToObjectiveC(SwiftKey.self) ||
+    !_isBridgedVerbatimToObjectiveC(SwiftValue.self))
+
+  let keyBridgesDirectly =
+    _isBridgedVerbatimToObjectiveC(SwiftKey.self) ==
+      _isBridgedVerbatimToObjectiveC(ObjCKey.self)
+  let valueBridgesDirectly =
+    _isBridgedVerbatimToObjectiveC(SwiftValue.self) ==
+      _isBridgedVerbatimToObjectiveC(ObjCValue.self)
+
+  var result = Dictionary<SwiftKey, SwiftValue>(minimumCapacity: source.count)
+  for (key, value) in source {
+    // Downcast the key.
+    var resultKey: SwiftKey
+    if keyBridgesDirectly {
+      if let bridgedKey = key as? SwiftKey {
+        resultKey = bridgedKey
+      } else {
+        return nil
+      }
+    } else {
+      if let bridgedKey = _conditionallyBridgeFromObjectiveC(
+        _reinterpretCastToAnyObject(key), SwiftKey.self) {
+          resultKey = bridgedKey
+      } else {
+        return nil
+      }
+    }
+
+    // Downcast the value.
+    var resultValue: SwiftValue
+    if valueBridgesDirectly {
+      if let bridgedValue = value as? SwiftValue {
+        resultValue = bridgedValue
+      } else {
+        return nil
+      }
+    } else {
+      if let bridgedValue = _conditionallyBridgeFromObjectiveC(
+        _reinterpretCastToAnyObject(value), SwiftValue.self) {
+          resultValue = bridgedValue
+      } else {
+        return nil
+      }
+    }
+
+    result[resultKey] = resultValue
+  }
+  return result
+}
+#endif
 //===--- APIs templated for Dictionary and Set ----------------------------===//
 
 %{

--- a/test/1_stdlib/DictionaryTrapsObjC.swift
+++ b/test/1_stdlib/DictionaryTrapsObjC.swift
@@ -144,7 +144,7 @@ DictionaryTraps.test("BridgedKeyIsNotNSCopyable2")
 DictionaryTraps.test("Downcast1") {
   let d: Dictionary<NSObject, NSObject> = [ TestObjCKeyTy(10): NSObject(),
                                             NSObject() : NSObject() ]
-  let d2: Dictionary<TestObjCKeyTy, NSObject> = d as! Dictionary<TestObjCKeyTy, NSObject>
+  let d2: Dictionary<TestObjCKeyTy, NSObject> = _dictionaryDownCast(d)
   expectCrashLater()
   let v1 = d2[TestObjCKeyTy(10)]
   let v2 = d2[TestObjCKeyTy(20)]
@@ -163,7 +163,7 @@ DictionaryTraps.test("Downcast2")
 
   expectCrashLater()
   let d2: Dictionary<TestBridgedKeyTy, NSObject>
-    = d as! Dictionary<TestBridgedKeyTy, NSObject>
+    = _dictionaryBridgeFromObjectiveC(d)
   let v1 = d2[TestBridgedKeyTy(10)]
 }
 

--- a/test/1_stdlib/SetTrapsObjC.swift
+++ b/test/1_stdlib/SetTrapsObjC.swift
@@ -134,7 +134,7 @@ SetTraps.test("Downcast1")
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
   .code {
   let s: Set<NSObject> = [ NSObject(), NSObject() ]
-  let s2: Set<TestObjCKeyTy> = s as! Set<TestObjCKeyTy>
+  let s2: Set<TestObjCKeyTy> = _setDownCast(s)
   expectCrashLater()
   let v1 = s2.contains(TestObjCKeyTy(10))
   let v2 = s2.contains(TestObjCKeyTy(20))
@@ -150,7 +150,7 @@ SetTraps.test("Downcast2")
   .code {
   let s: Set<NSObject> = [ TestObjCKeyTy(10), NSObject() ]
   expectCrashLater()
-  let s2: Set<TestBridgedKeyTy> = s as! Set<TestBridgedKeyTy>
+  let s2: Set<TestBridgedKeyTy> = _setBridgeFromObjectiveC(s)
   let v1 = s2.contains(TestBridgedKeyTy(10))
 }
 

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -2970,7 +2970,7 @@ DictionaryTestSuite.test("DictionaryUpcastEntryPoint") {
   d[TestObjCKeyTy(20)] = TestObjCValueTy(1020)
   d[TestObjCKeyTy(30)] = TestObjCValueTy(1030)
 
-  var dAsAnyObject: Dictionary<NSObject, AnyObject> = d as Dictionary<AnyHashable, Any> as! Dictionary<NSObject, AnyObject>
+  var dAsAnyObject: Dictionary<NSObject, AnyObject> = _dictionaryUpCast(d)
 
   assert(dAsAnyObject.count == 3)
   var v: AnyObject? = dAsAnyObject[TestObjCKeyTy(10)]
@@ -3009,7 +3009,7 @@ DictionaryTestSuite.test("DictionaryUpcastBridgedEntryPoint") {
   d[TestBridgedKeyTy(30)] = TestBridgedValueTy(1030)
 
   do {
-    var dOO: Dictionary<NSObject, AnyObject> = d as Dictionary<AnyHashable, Any> as! Dictionary<NSObject, AnyObject>
+    var dOO: Dictionary<NSObject, AnyObject> = _dictionaryBridgeToObjectiveC(d)
 
     assert(dOO.count == 3)
     var v: AnyObject? = dOO[TestObjCKeyTy(10)]
@@ -3024,7 +3024,7 @@ DictionaryTestSuite.test("DictionaryUpcastBridgedEntryPoint") {
 
   do {
     var dOV: Dictionary<NSObject, TestBridgedValueTy>
-      = d as Dictionary<AnyHashable, Any> as! Dictionary<NSObject, TestBridgedValueTy>
+      = _dictionaryBridgeToObjectiveC(d)
 
     assert(dOV.count == 3)
     var v = dOV[TestObjCKeyTy(10)]
@@ -3039,7 +3039,7 @@ DictionaryTestSuite.test("DictionaryUpcastBridgedEntryPoint") {
 
   do {
     var dVO: Dictionary<TestBridgedKeyTy, AnyObject>
-      = d as Dictionary<AnyHashable, Any> as! Dictionary<TestBridgedKeyTy, AnyObject>
+      = _dictionaryBridgeToObjectiveC(d)
 
     assert(dVO.count == 3)
     var v: AnyObject? = dVO[TestBridgedKeyTy(10)]
@@ -3113,8 +3113,7 @@ DictionaryTestSuite.test("DictionaryDowncastEntryPoint") {
   d[TestObjCKeyTy(30)] = TestObjCValueTy(1030)
 
   // Successful downcast.
-  let dCC: Dictionary<TestObjCKeyTy, TestObjCValueTy> =
-    d as! Dictionary<TestObjCKeyTy, TestObjCValueTy>
+  let dCC: Dictionary<TestObjCKeyTy, TestObjCValueTy> = _dictionaryDownCast(d)
   assert(dCC.count == 3)
   var v = dCC[TestObjCKeyTy(10)]
   assert(v!.value == 1010)
@@ -3156,7 +3155,8 @@ DictionaryTestSuite.test("DictionaryDowncastConditionalEntryPoint") {
   d[TestObjCKeyTy(30)] = TestObjCValueTy(1030)
 
   // Successful downcast.
-  if let dCC = d as? Dictionary<TestObjCKeyTy, TestObjCValueTy> {
+  if let dCC
+       = _dictionaryDownCastConditional(d) as Dictionary<TestObjCKeyTy, TestObjCValueTy>? {
     assert(dCC.count == 3)
     var v = dCC[TestObjCKeyTy(10)]
     assert(v!.value == 1010)
@@ -3172,7 +3172,8 @@ DictionaryTestSuite.test("DictionaryDowncastConditionalEntryPoint") {
 
   // Unsuccessful downcast
   d["hello" as NSString] = 17 as NSNumber
-  if let dCC = d as? Dictionary<TestObjCKeyTy, TestObjCValueTy> {
+  if let dCC
+       = _dictionaryDownCastConditional(d) as Dictionary<TestObjCKeyTy, TestObjCValueTy>? {
     assert(false)
   }
 }
@@ -3213,7 +3214,7 @@ DictionaryTestSuite.test("DictionaryBridgeFromObjectiveCEntryPoint") {
 
   // Successful downcast.
   let dCV: Dictionary<TestObjCKeyTy, TestBridgedValueTy>
-    = d as! Dictionary<TestObjCKeyTy, TestBridgedValueTy>
+    = _dictionaryBridgeFromObjectiveC(d)
   do {
     assert(dCV.count == 3)
     var v = dCV[TestObjCKeyTy(10)]
@@ -3228,7 +3229,7 @@ DictionaryTestSuite.test("DictionaryBridgeFromObjectiveCEntryPoint") {
 
   // Successful downcast.
   let dVC: Dictionary<TestBridgedKeyTy, TestObjCValueTy>
-    = d as! Dictionary<TestBridgedKeyTy, TestObjCValueTy>
+    = _dictionaryBridgeFromObjectiveC(d)
   do {
     assert(dVC.count == 3)
     var v = dVC[TestBridgedKeyTy(10)]
@@ -3243,7 +3244,7 @@ DictionaryTestSuite.test("DictionaryBridgeFromObjectiveCEntryPoint") {
 
   // Successful downcast.
   let dVV: Dictionary<TestBridgedKeyTy, TestBridgedValueTy>
-        = d as! Dictionary<TestBridgedKeyTy, TestBridgedValueTy>
+        = _dictionaryBridgeFromObjectiveC(d)
   do {
     assert(dVV.count == 3)
     var v = dVV[TestBridgedKeyTy(10)]
@@ -3313,7 +3314,9 @@ DictionaryTestSuite.test("DictionaryBridgeFromObjectiveCConditionalEntryPoint") 
   d[TestObjCKeyTy(30)] = TestObjCValueTy(1030)
 
   // Successful downcast.
-  if let dCV = d as? Dictionary<TestObjCKeyTy, TestBridgedValueTy> {
+  if let dCV
+       = _dictionaryBridgeFromObjectiveCConditional(d) as
+         Dictionary<TestObjCKeyTy, TestBridgedValueTy>? {
     assert(dCV.count == 3)
     var v = dCV[TestObjCKeyTy(10)]
     assert(v!.value == 1010)
@@ -3328,7 +3331,8 @@ DictionaryTestSuite.test("DictionaryBridgeFromObjectiveCConditionalEntryPoint") 
   }
 
   // Successful downcast.
-  if let dVC = d as? Dictionary<TestBridgedKeyTy, TestObjCValueTy> {
+  if let dVC
+       = _dictionaryBridgeFromObjectiveCConditional(d) as Dictionary<TestBridgedKeyTy, TestObjCValueTy>? {
     assert(dVC.count == 3)
     var v = dVC[TestBridgedKeyTy(10)]
     assert(v!.value == 1010)
@@ -3343,7 +3347,8 @@ DictionaryTestSuite.test("DictionaryBridgeFromObjectiveCConditionalEntryPoint") 
   }
 
   // Successful downcast.
-  if let dVV = d as? Dictionary<TestBridgedKeyTy, TestBridgedValueTy> {
+  if let dVV
+       = _dictionaryBridgeFromObjectiveCConditional(d) as Dictionary<TestBridgedKeyTy, TestBridgedValueTy>? {
     assert(dVV.count == 3)
     var v = dVV[TestBridgedKeyTy(10)]
     assert(v!.value == 1010)
@@ -3359,13 +3364,16 @@ DictionaryTestSuite.test("DictionaryBridgeFromObjectiveCConditionalEntryPoint") 
 
   // Unsuccessful downcasts
   d["hello" as NSString] = 17 as NSNumber
-  if let dCV = d as? Dictionary<TestObjCKeyTy, TestBridgedValueTy> {
+  if let dCV
+       = _dictionaryBridgeFromObjectiveCConditional(d) as Dictionary<TestObjCKeyTy, TestBridgedValueTy>?{
     assert(false)
   }
-  if let dVC = d as? Dictionary<TestBridgedKeyTy, TestObjCValueTy> {
+  if let dVC
+       = _dictionaryBridgeFromObjectiveCConditional(d) as Dictionary<TestBridgedKeyTy, TestObjCValueTy>?{
     assert(false)
   }
-  if let dVV = d as? Dictionary<TestBridgedKeyTy, TestBridgedValueTy> {
+  if let dVV
+       = _dictionaryBridgeFromObjectiveCConditional(d) as Dictionary<TestBridgedKeyTy, TestBridgedValueTy>?{
     assert(false)
   }
 }

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -2436,7 +2436,7 @@ SetTestSuite.test("SetUpcastEntryPoint") {
       s.insert(TestObjCKeyTy(i))
   }
 
-  var sAsAnyObject: Set<NSObject> = s
+  var sAsAnyObject: Set<NSObject> = _setUpCast(s)
 
   expectEqual(3, sAsAnyObject.count)
   expectTrue(sAsAnyObject.contains(TestObjCKeyTy(1010)))
@@ -2465,7 +2465,7 @@ SetTestSuite.test("SetUpcastBridgedEntryPoint") {
   }
 
   do {
-    var s: Set<NSObject> = s as Set<AnyHashable> as! Set<NSObject>
+    var s: Set<NSObject> = _setBridgeToObjectiveC(s)
 
     expectTrue(s.contains(TestBridgedKeyTy(1010) as NSObject))
     expectTrue(s.contains(TestBridgedKeyTy(2020) as NSObject))
@@ -2473,7 +2473,7 @@ SetTestSuite.test("SetUpcastBridgedEntryPoint") {
   }
 
   do {
-    var s: Set<TestObjCKeyTy> = s as Set<AnyHashable> as! Set<TestObjCKeyTy>
+    var s: Set<TestObjCKeyTy> = _setBridgeToObjectiveC(s)
 
     expectEqual(3, s.count)
     expectTrue(s.contains(TestBridgedKeyTy(1010) as TestObjCKeyTy))
@@ -2518,7 +2518,7 @@ SetTestSuite.test("SetDowncastEntryPoint") {
   }
 
   // Successful downcast.
-  let sCC: Set<TestObjCKeyTy> = s as! Set<TestObjCKeyTy>
+  let sCC: Set<TestObjCKeyTy> = _setDownCast(s)
   expectEqual(3, sCC.count)
   expectTrue(sCC.contains(TestObjCKeyTy(1010)))
   expectTrue(sCC.contains(TestObjCKeyTy(2020)))
@@ -2550,7 +2550,7 @@ SetTestSuite.test("SetDowncastConditionalEntryPoint") {
   }
 
   // Successful downcast.
-  if let sCC  = s as? Set<TestObjCKeyTy> {
+  if let sCC  = _setDownCastConditional(s) as Set<TestObjCKeyTy>? {
     expectEqual(3, sCC.count)
     expectTrue(sCC.contains(TestObjCKeyTy(1010)))
     expectTrue(sCC.contains(TestObjCKeyTy(2020)))
@@ -2561,7 +2561,7 @@ SetTestSuite.test("SetDowncastConditionalEntryPoint") {
 
   // Unsuccessful downcast
   s.insert("Hello, world" as NSString)
-  if let sCC = s as? Set<TestObjCKeyTy> {
+  if let sCC = _setDownCastConditional(s) as Set<TestObjCKeyTy>? {
     expectTrue(false)
   }
 }
@@ -2596,7 +2596,7 @@ SetTestSuite.test("SetBridgeFromObjectiveCEntryPoint") {
   }
 
   // Successful downcast.
-  let sCV: Set<TestBridgedKeyTy> = s as! Set<TestBridgedKeyTy>
+  let sCV: Set<TestBridgedKeyTy> = _setBridgeFromObjectiveC(s)
   do {
     expectEqual(3, sCV.count)
     expectTrue(sCV.contains(TestBridgedKeyTy(1010)))
@@ -2639,7 +2639,7 @@ SetTestSuite.test("SetBridgeFromObjectiveCConditionalEntryPoint") {
   }
 
   // Successful downcast.
-  if let sVC = s as? Set<TestBridgedKeyTy> {
+  if let sVC = _setBridgeFromObjectiveCConditional(s) as Set<TestBridgedKeyTy>? {
     expectEqual(3, sVC.count)
     expectTrue(sVC.contains(TestBridgedKeyTy(1010)))
     expectTrue(sVC.contains(TestBridgedKeyTy(2020)))
@@ -2650,7 +2650,7 @@ SetTestSuite.test("SetBridgeFromObjectiveCConditionalEntryPoint") {
 
   // Unsuccessful downcasts
   s.insert("Hello, world, I'm your wild girl. I'm your ch-ch-ch-ch-ch-ch cherry bomb" as NSString)
-  if let sVC = s as? Set<TestBridgedKeyTy> {
+  if let sVC = _setBridgeFromObjectiveCConditional(s) as Set<TestBridgedKeyTy>? {
     expectTrue(false)
   }
 }


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

This reverts commit dc0ae675bc6af4b6a0819561fc2e5ec665187053. The
change here (presumably the change to Foundation) caused a regression
in several of the bridging-related benchmarks, e.g.,
ObjectiveCBridgeFromNSSetAnyObjectToString, DictionaryBridge,
ObjectiveCBridgeFromNSDictionaryAnyObjectToString.
