### PR TITLE
[Parser] Fix the fixit for protocol compositions' syntax change (3.0)

### DIFF
--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -450,7 +450,7 @@ ParserResult<TypeRepr> Parser::parseTypeIdentifierOrTypeComposition() {
       // Skip until we hit the '>'.
       RAngleLoc = skipUntilGreaterInTypeList(/*protocolComposition=*/true);
     }
-    
+
     auto composition = ProtocolCompositionTypeRepr::create(
       Context, Protocols, ProtocolLoc, {LAngleLoc, RAngleLoc});
 
@@ -468,6 +468,16 @@ ParserResult<TypeRepr> Parser::parseTypeIdentifierOrTypeComposition() {
       while(++Begin != Protocols.end()) {
         replacement += " & ";
         replacement += extractText(*Begin);
+      }
+
+      // Copy trailing content after '>' to the replacement string.
+      // FIXME: lexer should smartly separate '>' and trailing contents like '?'.
+      StringRef TrailingContent = L->getTokenAt(RAngleLoc).getRange().str().
+        substr(1);
+      if (!TrailingContent.empty()) {
+        replacement.insert(replacement.begin(), '(');
+        replacement += ")";
+        replacement += TrailingContent;
       }
 
       // Replace 'protocol<T1, T2>' with 'T1 & T2'

--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -270,3 +270,8 @@ func testBoolValue(a : BoolFoo) {
   guard a {}
   if a as BoolFoo {}
 }
+
+protocol P1 {}
+protocol P2 {}
+var a : protocol<P1, P2>?
+var a2 : protocol<P1>= 17

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -273,3 +273,8 @@ func testBoolValue(a : BoolFoo) {
   guard a.boolValue {}
   if (a as BoolFoo).boolValue {}
 }
+
+protocol P1 {}
+protocol P2 {}
+var a : (P1 & P2)?
+var a2 : (P1)= 17 as! P1

--- a/test/type/protocol_composition.swift
+++ b/test/type/protocol_composition.swift
@@ -48,7 +48,7 @@ func testEquality() {
   let x4 : (_ : P2) -> ()
   x3 = x4
   _ = x3
-  
+
   // Empty protocol-conformance types are empty.
   let x5 : (_ : Any) -> ()
   let x6 : (_ : Any2) -> ()
@@ -123,7 +123,7 @@ func testConversion() {
 }
 
 // Test the parser's splitting of >= into > and =.
-var x : protocol<P5>= 17 // expected-warning {{'protocol<...>' composition syntax is deprecated and not needed here}} {{9-22=P5}}
+var x : protocol<P5>= 17 // expected-warning {{'protocol<...>' composition syntax is deprecated and not needed here}} {{9-22=(P5)=}}
 
 typealias A = protocol<> // expected-warning {{'protocol<>' syntax is deprecated; use 'Any' instead}} {{15-25=Any}}
 typealias B1 = protocol<P1,P2> // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{16-31=P1 & P2}}


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
- Explanation: When migrating, we found our fixit to replace the old protocol composition syntax, namely `Protocol<A, B>`, to the new syntax, `A & B`, does not preserve the trailing content after `>`. For instance, we replace `Protocol<A, B>?` with `A & B`. This patch fixes the issue by inserting whatever after `>` in the old syntax to the new replacement string.
- Scope: This effects both migrator and users' experience with compiler fixit. Without this patch, we may end up changing users' code incorrectly.
- Risk: Low.
- Reviewed by: Ben Langmuir
- Test: Regression test added; existing test updated.

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
