### PR TITLE
[upstream-update] Link LLVMDebugInfoCodeView into 6 executable tools.

### DIFF
--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -7,6 +7,8 @@ add_swift_executable(swift
   LINK_LIBRARIES
     swiftDriver
     swiftFrontendTool
+  LLVM_COMPONENT_DEPENDS
+    DebugInfoCodeView
 )
 
 target_link_libraries(swift edit)

--- a/tools/lldb-moduleimport-test/CMakeLists.txt
+++ b/tools/lldb-moduleimport-test/CMakeLists.txt
@@ -2,7 +2,9 @@ add_swift_executable(lldb-moduleimport-test
   lldb-moduleimport-test.cpp
   LINK_LIBRARIES
     swiftASTSectionImporter swiftFrontend swiftClangImporter
-    )
+  LLVM_COMPONENT_DEPENDS
+    DebugInfoCodeView
+)
 
 swift_install_in_component(testsuite-tools
     TARGETS lldb-moduleimport-test

--- a/tools/sil-extract/CMakeLists.txt
+++ b/tools/sil-extract/CMakeLists.txt
@@ -6,6 +6,8 @@ add_swift_executable(sil-extract
     swiftSILOptimizer
     swiftSerialization
     swiftClangImporter
+  LLVM_COMPONENT_DEPENDS
+    DebugInfoCodeView
 )
 
 swift_install_in_component(tools

--- a/tools/sil-opt/CMakeLists.txt
+++ b/tools/sil-opt/CMakeLists.txt
@@ -5,6 +5,8 @@ add_swift_executable(sil-opt
     swiftIRGen
     swiftSILGen
     swiftSILOptimizer
+  LLVM_COMPONENT_DEPENDS
+    DebugInfoCodeView
 )
 
 swift_install_in_component(tools

--- a/tools/swift-ide-test/CMakeLists.txt
+++ b/tools/swift-ide-test/CMakeLists.txt
@@ -6,6 +6,8 @@ add_swift_executable(swift-ide-test
     swiftDriver
     swiftFrontend
     swiftIDE
+  LLVM_COMPONENT_DEPENDS
+    DebugInfoCodeView
 )
 
 # If libxml2 is available, make it available for swift-ide-test.

--- a/tools/swift-llvm-opt/CMakeLists.txt
+++ b/tools/swift-llvm-opt/CMakeLists.txt
@@ -10,6 +10,9 @@ add_swift_executable(swift-llvm-opt
   # Clang libraries included to appease the linker on linux.
   clangBasic
   clangCodeGen
+
+  LLVM_COMPONENT_DEPENDS
+    DebugInfoCodeView
 )
 
 swift_install_in_component(tools


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

All of these cases seem to need the symbols from LLVM's new CodeView library to
link.

The specific executables are:
1. Swift Driver.
2. SIL Extract.
3. SIL Opt.
4. Swift IDE Test.
5. Swift LLVM Opt.
6. LLDB Module Import Test
