### PR TITLE
[PlaygroundTransform] Don't log the results of functions that return ().

### DIFF
--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -621,9 +621,9 @@ public:
                   Elements.insert(Elements.begin() + (EI + 1), *Log);
                   ++EI;
                 }
-                Handled = true;
               }
             }
+            Handled = true; // Never log ()
           }
           if (!Handled) {
             // do the same as for all other expressions

--- a/test/PlaygroundTransform/empty-tuple.swift
+++ b/test/PlaygroundTransform/empty-tuple.swift
@@ -1,0 +1,9 @@
+// RUN: rm -rf %t && mkdir %t
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
+// RUN: %target-run %t/main | %FileCheck %s
+// REQUIRES: executable_test
+func foo() { }
+foo()
+1+2
+// CHECK: {{.*}} $builtin_log[='3']


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

The fix for missing logging for `+=` accidentally made us log ALL functions that
return `()`, not just the ones that happen to touch inout parameters.  That's not
really desirable, and resulted from a missing testcase.

This fixes the problem and adds a testcase.
#### Resolved bug number: rdar://problem/27995558

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

The fix for missing logging for += accidentally made us log ALL functions that
return (), not just the ones that happen to touch inout parameters.  That's not
really desirable, and resulted from a missing testcase.

This fixes the problem and adds a testcase.

rdar://problem/27995558
