### PR TITLE
[Driver] Move some string definitions around (NFC)

### DIFF
--- a/include/swift/Driver/Action.h
+++ b/include/swift/Driver/Action.h
@@ -17,6 +17,8 @@
 #include "swift/Driver/Types.h"
 #include "swift/Driver/Util.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/Optional.h"
+#include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/TimeValue.h"
 
 namespace llvm {

--- a/lib/Driver/CompilationRecord.h
+++ b/lib/Driver/CompilationRecord.h
@@ -1,0 +1,85 @@
+//===--- CompilationRecord.h ------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_DRIVER_COMPILATIONRECORD_H
+#define SWIFT_DRIVER_COMPILATIONRECORD_H
+
+#include "swift/Driver/Action.h"
+
+namespace swift {
+namespace driver {
+namespace compilation_record {
+
+/// Compilation record files (.swiftdeps files) are YAML files composed of these
+/// top-level keys.
+enum class TopLevelKey {
+  /// The key for the Swift compiler version used to produce the compilation
+  /// record.
+  Version,
+  /// The key for the list of arguments passed to the Swift compiler when
+  /// producing the compilation record.
+  Options,
+  /// The key for the time at which the build that produced the compilation
+  /// record started.
+  BuildTime,
+  /// The key for the list of inputs to the compilation that produced the
+  /// compilation record.
+  Inputs,
+};
+
+/// \returns A string representation of the given key.
+inline static StringRef getName(TopLevelKey Key) {
+  switch (Key) {
+  case TopLevelKey::Version: return "version";
+  case TopLevelKey::Options: return "options";
+  case TopLevelKey::BuildTime: return "build_time";
+  case TopLevelKey::Inputs: return "inputs";
+  }
+}
+
+/// \returns The string identifier used to represent the given status in a
+/// compilation record file (.swiftdeps file).
+///
+/// \note Not every InputInfo::Status has a unique identifier. For example,
+/// both NewlyAdded and NeedsCascadingBuild are represented as "!dirty".
+/// Therefore, this will not cleanly round-trip between InputInfo::Status and
+/// string identifiers.
+inline static StringRef
+getIdentifierForInputInfoStatus(CompileJobAction::InputInfo::Status Status) {
+  switch (Status) {
+  case CompileJobAction::InputInfo::UpToDate:
+    return "";
+  case CompileJobAction::InputInfo::NewlyAdded:
+  case CompileJobAction::InputInfo::NeedsCascadingBuild:
+    return "!dirty";
+  case CompileJobAction::InputInfo::NeedsNonCascadingBuild:
+    return "!private";
+  }
+}
+
+/// \returns The status corresponding to the string identifier used in a
+/// compilation record file (.swiftdeps file).
+inline static Optional<CompileJobAction::InputInfo::Status>
+getInfoStatusForIdentifier(StringRef Identifier) {
+  return llvm::StringSwitch<Optional<
+      CompileJobAction::InputInfo::Status>>(Identifier)
+    .Case("", CompileJobAction::InputInfo::UpToDate)
+    .Case("!dirty", CompileJobAction::InputInfo::NeedsCascadingBuild)
+    .Case("!private", CompileJobAction::InputInfo::NeedsNonCascadingBuild)
+    .Default(None);
+}
+
+} // end namespace compilation_record
+} // end namespace driver
+} // end namespace swift
+
+#endif


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

I've been poking around what `.swiftdeps` files are and how they work, and noticed a small amount of duplication, across `Driver.cpp` and `Compilation.cpp`, in some strings used in the files.

I'm not sure how much of an improvement this is, but these two commits "centralize" the duplication. YAML keys like `version` and `inputs` now exist in `CompilationRecord.h`. Input status identifiers like `!dirty` and `!private` are now defined as part of the `CompileJobAction::InputInfo` struct.

Is it worth making the change? I'm not sure. Feel free to close this pull request if you don't think it is. :)
#### Resolved bug number: None

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
