### PR TITLE
[Type Checker] Directional Path Consistency algorithm

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -1415,7 +1415,11 @@ protected:
 
 public:
   ArrayRef<ValueDecl*> getDecls() const { return Decls; }
-  
+
+  void setDecls(ArrayRef<ValueDecl *> domain) {
+    Decls = domain;
+  }
+
   /// getBaseType - Determine the type of the base object provided for the
   /// given overload set, which is only non-null when dealing with an overloaded
   /// member reference.

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -20,6 +20,8 @@
 #include "llvm/Support/SaveAndRestore.h"
 #include <memory>
 #include <tuple>
+#include <stack>
+#include <queue>
 using namespace swift;
 using namespace constraints;
 
@@ -1333,6 +1335,321 @@ ConstraintSystem::solveSingle(FreeTypeVariableBinding allowFreeTypeVariables) {
   return std::move(solutions[0]);
 }
 
+bool ConstraintSystem::Candidate::solve() {
+  // Cleanup after constraint system generation/solving,
+  // because it would assign types to expressions, which
+  // might interfere with solving higher-level expressions.
+  ExprCleaner cleaner(E);
+
+  // Allocate new constraint system for sub-expression.
+  ConstraintSystem cs(TC, DC, None);
+
+  // Set contextual type if present. This is done before constraint generation
+  // to give a "hint" to that operation about possible optimizations.
+  if (!CT.isNull())
+    cs.setContextualType(E, CT, CTP);
+
+  // Generate constraints for the new system.
+  if (auto generatedExpr = cs.generateConstraints(E)) {
+    E = generatedExpr;
+  } else {
+    // Failure to generate constraint system for sub-expression means we can't
+    // continue solving sub-expressions.
+    return true;
+  }
+
+  // If there is contextual type present, add an explicit "conversion"
+  // constraint to the system.
+  if (!CT.isNull()) {
+    auto constraintKind = ConstraintKind::Conversion;
+    if (CTP == CTP_CallArgument)
+      constraintKind = ConstraintKind::ArgumentConversion;
+
+    cs.addConstraint(constraintKind, E->getType(), CT.getType(),
+                     cs.getConstraintLocator(E), /*isFavored=*/true);
+  }
+
+  // Try to solve the system and record all available solutions.
+  llvm::SmallVector<Solution, 2> solutions;
+  {
+    SolverState state(cs);
+    cs.solverState = &state;
+
+    // Use solveRec() instead of solve() in here, because solve()
+    // would try to deduce the best solution, which we don't
+    // really want. Instead, we want the reduced set of domain choices.
+    cs.solveRec(solutions, FreeTypeVariableBinding::Allow);
+
+    cs.solverState = nullptr;
+  }
+
+  // No solutions for the sub-expression means that either main expression
+  // needs salvaging or it's inconsistent (read: doesn't have solutions).
+  if (solutions.empty())
+    return true;
+
+  // Record found solutions as suggestions.
+  this->applySolutions(solutions);
+  return false;
+}
+
+void ConstraintSystem::Candidate::applySolutions(
+                            llvm::SmallVectorImpl<Solution> &solutions) const {
+  // A collection of OSRs with their newly reduced domains,
+  // it's domains are sets because multiple solutions can have the same
+  // choice for one of the type variables, and we want no duplication.
+  llvm::SmallDenseMap<OverloadSetRefExpr *, llvm::SmallSet<ValueDecl *, 2>>
+    domains;
+  for (auto &solution : solutions) {
+    for (auto choice : solution.overloadChoices) {
+      // Some of the choices might not have locators.
+      if (!choice.getFirst())
+        continue;
+
+      auto anchor = choice.getFirst()->getAnchor();
+      // Anchor is not available or expression is not an overload set.
+      if (!anchor || !isa<OverloadSetRefExpr>(anchor))
+        continue;
+
+      auto OSR = cast<OverloadSetRefExpr>(anchor);
+      auto overload = choice.getSecond().choice;
+      auto type = overload.getDecl()->getInterfaceType();
+
+      // One of the solutions has polymorphic type assigned with one of it's
+      // type variables. Such functions can only be properly resolved
+      // via complete expression, so we'll have to forget solutions
+      // we have already recorded. They might not include all viable overload
+      // choices.
+      if (type->is<GenericFunctionType>()) {
+        return;
+      }
+
+      domains[OSR].insert(overload.getDecl());
+    }
+  }
+
+  // Reduce the domains.
+  for (auto &domain : domains) {
+    auto OSR = domain.getFirst();
+    auto &choices = domain.getSecond();
+
+    // If the domain wasn't reduced, skip it.
+    if (OSR->getDecls().size() == choices.size()) continue;
+
+    // Update the expression with the reduced domain.
+    MutableArrayRef<ValueDecl *> decls
+      = TC.Context.AllocateUninitialized<ValueDecl *>(choices.size());
+    std::uninitialized_copy(choices.begin(), choices.end(), decls.begin());
+    OSR->setDecls(decls);
+  }
+}
+
+void ConstraintSystem::shrink(Expr *expr) {
+  typedef llvm::SmallDenseMap<Expr *, ArrayRef<ValueDecl *>> DomainMap;
+
+  // A collection of original domains of all of the expressions,
+  // so they can be restored in case of failure.
+  DomainMap domains;
+
+  struct ExprCollector : public ASTWalker {
+    // The primary constraint system.
+    ConstraintSystem &CS;
+
+    // All of the sub-expressions of certain type (binary/unary/calls) in
+    // depth-first order.
+    std::queue<Candidate> &SubExprs;
+
+    // Counts the number of overload sets present in the tree so far.
+    // Note that the traversal is depth-first.
+    std::stack<std::pair<ApplyExpr *, unsigned>,
+               llvm::SmallVector<std::pair<ApplyExpr *, unsigned>, 4>>
+      ApplyExprs;
+
+    // A collection of original domains of all of the expressions,
+    // so they can be restored in case of failure.
+    DomainMap &Domains;
+
+    ExprCollector(ConstraintSystem &cs,
+                  std::queue<Candidate> &container,
+                  DomainMap &domains)
+      : CS(cs), SubExprs(container), Domains(domains) { }
+
+    std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
+      // A dictionary expression is just a set of tuples; try to solve ones
+      // that have overload sets.
+      if (auto dictionaryExpr = dyn_cast<DictionaryExpr>(expr)) {
+        for (auto element : dictionaryExpr->getElements()) {
+          unsigned numOverlaods = 0;
+          element->walk(OverloadSetCounter(numOverlaods));
+
+          // There are no overload sets in the element; skip it.
+          if (numOverlaods == 0)
+            continue;
+
+          // FIXME: Could we avoid creating a separate dictionary expression
+          // here by introducing a contextual type on the element?
+          auto dict = DictionaryExpr::create(CS.getASTContext(),
+                                             dictionaryExpr->getLBracketLoc(),
+                                             { element },
+                                             dictionaryExpr->getRBracketLoc(),
+                                             dictionaryExpr->getType());
+
+          // Make each of the dictionary elements an independent dictionary,
+          // such makes it easy to type-check everything separately.
+          SubExprs.push(Candidate(CS, dict));
+        }
+
+        // Don't try to walk into the dictionary.
+        return { false, expr };
+      }
+
+      // Let's not attempt to type-check closures or default values,
+      // which has already been type checked anyway.
+      if (isa<ClosureExpr>(expr) || isa<DefaultValueExpr>(expr)) {
+        return { false, expr };
+      }
+
+      // Coerce to type expressions are only viable if they have
+      // a single child expression.
+      if (auto coerceExpr = dyn_cast<CoerceExpr>(expr)) {
+        if (!coerceExpr->getSubExpr()) {
+          return { false, expr };
+        }
+      }
+
+      if (auto OSR = dyn_cast<OverloadSetRefExpr>(expr)) {
+        Domains[OSR] = OSR->getDecls();
+      }
+
+      if (auto applyExpr = dyn_cast<ApplyExpr>(expr)) {
+        auto func = applyExpr->getFn();
+        // Let's record this function application for post-processing
+        // as well as if it contains overload set, see walkToExprPost.
+        ApplyExprs.push({ applyExpr, isa<OverloadSetRefExpr>(func) });
+      }
+
+      return { true, expr };
+    }
+
+    Expr *walkToExprPost(Expr *expr) override {
+      if (!isa<ApplyExpr>(expr))
+        return expr;
+
+      unsigned numOverloadSets = 0;
+      // Let's count how many overload sets do we have.
+      while (!ApplyExprs.empty()) {
+        auto application = ApplyExprs.top();
+        auto applyExpr = application.first;
+
+        // Add overload sets tracked by current expression.
+        numOverloadSets += application.second;
+        ApplyExprs.pop();
+
+        // We've found the current expression, so record the number of
+        // overloads.
+        if (expr == applyExpr) {
+          ApplyExprs.push({ applyExpr, numOverloadSets });
+          break;
+        }
+      }
+
+      // If there are fewer than two overloads in the chain
+      // there is no point of solving this expression,
+      // because we won't be able to reduce it's domain.
+      if (numOverloadSets > 1)
+        SubExprs.push(Candidate(CS, expr));
+
+      return expr;
+    }
+  };
+
+  std::queue<Candidate> expressions;
+  ExprCollector collector(*this, expressions, domains);
+
+  // Collect all of the binary/unary and call sub-expressions
+  // so we can start solving them separately.
+  expr->walk(collector);
+
+  while (!expressions.empty()) {
+    auto &candidate = expressions.front();
+
+    // If there are no results, let's forget everything we know about the
+    // system so far. This actually is ok, because some of the expressions
+    // might require manual salvaging.
+    if (candidate.solve()) {
+      // Let's restore all of the original OSR domains.
+      for (auto &domain : domains) {
+        if (auto OSR = dyn_cast<OverloadSetRefExpr>(domain.getFirst())) {
+          OSR->setDecls(domain.getSecond());
+        }
+      }
+      break;
+    }
+
+    expressions.pop();
+  }
+}
+
+ConstraintSystem::SolutionKind
+ConstraintSystem::solve(Expr *&expr,
+                        Type convertType,
+                        ExprTypeCheckListener *listener,
+                        SmallVectorImpl<Solution> &solutions,
+                        FreeTypeVariableBinding allowFreeTypeVariables) {
+  assert(!solverState && "use solveRec for recursive calls");
+
+  // Try to shrink the system by reducing disjunction domains. This
+  // goes through every sub-expression and generate it's own sub-system, to
+  // try to reduce the domains of those subexpressions.
+  shrink(expr);
+
+  // Generate constraints for the main system.
+  if (auto generatedExpr = generateConstraints(expr))
+    expr = generatedExpr;
+  else {
+    return SolutionKind::Error;
+  }
+
+  // If there is a type that we're expected to convert to, add the conversion
+  // constraint.
+  if (convertType) {
+    auto constraintKind = ConstraintKind::Conversion;
+    if (getContextualTypePurpose() == CTP_CallArgument)
+      constraintKind = ConstraintKind::ArgumentConversion;
+
+    if (allowFreeTypeVariables == FreeTypeVariableBinding::UnresolvedType) {
+      convertType = convertType.transform([&](Type type) -> Type {
+        if (type->is<UnresolvedType>())
+          return createTypeVariable(getConstraintLocator(expr), 0);
+        return type;
+      });
+    }
+
+    addConstraint(constraintKind, expr->getType(), convertType,
+                  getConstraintLocator(expr), /*isFavored*/ true);
+  }
+
+  // Notify the listener that we've built the constraint system.
+  if (listener && listener->builtConstraints(*this, expr)) {
+    return SolutionKind::Error;
+  }
+
+  if (TC.getLangOpts().DebugConstraintSolver) {
+    auto &log = getASTContext().TypeCheckerDebug->getStream();
+    log << "---Initial constraints for the given expression---\n";
+    expr->print(log);
+    log << "\n";
+    print(log);
+  }
+
+  // Try to solve the constraint system using computed suggestions.
+  solve(solutions, allowFreeTypeVariables);
+
+  // If there are no solutions let's mark system as unsolved,
+  // and solved otherwise even if there are multiple solutions still present.
+  return solutions.empty() ? SolutionKind::Unsolved : SolutionKind::Solved;
+}
+
 bool ConstraintSystem::solve(SmallVectorImpl<Solution> &solutions,
                              FreeTypeVariableBinding allowFreeTypeVariables) {
   assert(!solverState && "use solveRec for recursive calls");
@@ -1356,7 +1673,7 @@ bool ConstraintSystem::solve(SmallVectorImpl<Solution> &solutions,
 
   // Remove the solver state.
   this->solverState = nullptr;
-  
+
   // We fail if there is no solution.
   return solutions.empty();
 }

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -27,6 +27,7 @@
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/OptionSet.h"
 #include "swift/AST/ASTVisitor.h"
+#include "swift/AST/ASTWalker.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/Types.h"
 #include "swift/AST/TypeCheckerDebugConsumer.h"
@@ -1015,6 +1016,40 @@ public:
     DictionaryElementTypeVariables;
 
 private:
+  /// \brief Describe the candidate expression for partial solving.
+  /// This class used used by shrink & solve methods which apply
+  /// variation of directional path consistency algorithm in attempt
+  /// to reduce scopes of the overload sets (disjunctions) in the system.
+  class Candidate {
+    Expr *E;
+    TypeChecker &TC;
+    DeclContext *DC;
+    TypeLoc CT;
+    ContextualTypePurpose CTP;
+
+  public:
+    Candidate(ConstraintSystem &cs, Expr *expr)
+    : E(expr),
+      TC(cs.TC),
+      DC(cs.DC),
+      CT(cs.getContextualTypeLoc()),
+      CTP(cs.getContextualTypePurpose())
+    {}
+
+    /// \brief Try to solve this candidate sub-expression
+    /// and re-write it's OSR domains afterwards.
+    ///
+    /// \returs true on solver failure, false otherwise.
+    bool solve();
+
+    /// \brief Apply solutions found by solver as reduced OSR sets for
+    /// for current and all of it's sub-expressions.
+    ///
+    /// \param solutions The solutions found by running solver on the
+    /// this candidate expression.
+    void applySolutions(llvm::SmallVectorImpl<Solution> &solutions) const;
+  };
+
   /// \brief Describes the current solver state.
   struct SolverState {
     SolverState(ConstraintSystem &cs);
@@ -1995,7 +2030,36 @@ private:
   /// \returns true if an error occurred, false otherwise.
   bool solveSimplified(SmallVectorImpl<Solution> &solutions,
                        FreeTypeVariableBinding allowFreeTypeVariables);
+
+  /// \brief Find reduced domains of disjunction constraints for given
+  /// expression, this is achived to solving individual sub-expressions
+  /// and combining resolving types. Such algorithm is called directional
+  /// path consistency because it goes from children to parents for all
+  /// related sub-expressions taking union of their domains.
+  ///
+  /// \param expr The expression to find reductions for.
+  void shrink(Expr *expr);
+
  public:
+
+  /// \brief Solve the system of constraints generated from provided expression.
+  ///
+  /// \param expr The expression to generate constraints from.
+  /// \param convertType The expected type of the expression.
+  /// \param listener The callback to check solving progress.
+  /// \param solutions The set of solutions to the system of constraints.
+  /// \param allowFreeTypeVariables How to bind free type variables in
+  /// the solution.
+  ///
+  /// \returns Error is an error occured, Solved is system is consistent
+  /// and solutions were found, Unsolved otherwise.
+  SolutionKind solve(Expr *&expr,
+                     Type convertType,
+                     ExprTypeCheckListener *listener,
+                     SmallVectorImpl<Solution> &solutions,
+                     FreeTypeVariableBinding allowFreeTypeVariables
+                       = FreeTypeVariableBinding::Disallow);
+
   /// \brief Solve the system of constraints.
   ///
   /// \param solutions The set of solutions to this system of constraints.
@@ -2272,6 +2336,90 @@ TypeVariableType *TypeVariableType::getNew(const ASTContext &C, unsigned ID,
 /// underlying forced downcast expression.
 ForcedCheckedCastExpr *findForcedDowncast(ASTContext &ctx, Expr *expr);
 
+/// ExprCleaner - This class is used by shrink to ensure that in
+/// no situation will an expr node be left with a dangling type variable stuck
+/// to it.  Often type checking will create new AST nodes and replace old ones
+/// (e.g. by turning an UnresolvedDotExpr into a MemberRefExpr).  These nodes
+/// might be left with pointers into the temporary constraint system through
+/// their type variables, and we don't want pointers into the original AST to
+/// dereference these now-dangling types.
+class ExprCleaner {
+  llvm::SmallDenseMap<Expr *, Type> Exprs;
+  llvm::SmallDenseMap<TypeLoc *, Type> TypeLocs;
+  llvm::SmallDenseMap<Pattern *, Type> Patterns;
+public:
+
+  ExprCleaner(Expr *E) {
+    struct ExprCleanserImpl : public ASTWalker {
+      ExprCleaner *TS;
+      ExprCleanserImpl(ExprCleaner *TS) : TS(TS) {}
+
+      std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
+        TS->Exprs.insert({ expr, expr->getType() });
+        return { true, expr };
+      }
+
+      bool walkToTypeLocPre(TypeLoc &TL) override {
+        TS->TypeLocs.insert({ &TL, TL.getType() });
+        return true;
+      }
+
+      std::pair<bool, Pattern*> walkToPatternPre(Pattern *P) override {
+        TS->Patterns.insert({ P, P->getType() });
+        return { true, P };
+      }
+
+      // Don't walk into statements.  This handles the BraceStmt in
+      // non-single-expr closures, so we don't walk into their body.
+      std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
+        return { false, S };
+      }
+    };
+
+    E->walk(ExprCleanserImpl(this));
+  }
+
+  ~ExprCleaner() {
+    // Check each of the expression nodes to verify that there are no type
+    // variables hanging out.  If so, just nuke the type.
+    for (auto E : Exprs) {
+      E.getFirst()->setType(E.getSecond());
+    }
+
+    for (auto TL : TypeLocs) {
+      TL.getFirst()->setType(TL.getSecond(), false);
+    }
+
+    for (auto P : Patterns) {
+      P.getFirst()->setType(P.getSecond());
+    }
+  }
+};
+
+/**
+ * Count the number of overload sets present
+ * in the expression and all of the children.
+ */
+class OverloadSetCounter : public ASTWalker {
+  unsigned &NumOverloads;
+
+public:
+  OverloadSetCounter(unsigned &overloads)
+  : NumOverloads(overloads)
+  {}
+
+  std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
+    if (auto applyExpr = dyn_cast<ApplyExpr>(expr)) {
+      // If we've found function application and it's
+      // function is an overload set, count it.
+      if (isa<OverloadSetRefExpr>(applyExpr->getFn()))
+        ++NumOverloads;
+    }
+
+    // Always recur into the children.
+    return { true, expr };
+  }
+};
 } // end namespace swift
 
 #endif // LLVM_SWIFT_SEMA_CONSTRAINT_SYSTEM_H

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1347,54 +1347,27 @@ solveForExpression(Expr *&expr, DeclContext *dc, Type convertType,
                    ExprTypeCheckListener *listener, ConstraintSystem &cs,
                    SmallVectorImpl<Solution> &viable,
                    TypeCheckExprOptions options) {
-
   // First, pre-check the expression, validating any types that occur in the
   // expression and folding sequence expressions.
   if (preCheckExpression(*this, expr, dc))
     return true;
 
-  if (auto generatedExpr = cs.generateConstraints(expr))
-    expr = generatedExpr;
-  else {
-    return true;
-  }
-
-  // If there is a type that we're expected to convert to, add the conversion
-  // constraint.
-  if (convertType) {
-    auto constraintKind = ConstraintKind::Conversion;
-    if (cs.getContextualTypePurpose() == CTP_CallArgument)
-      constraintKind = ConstraintKind::ArgumentConversion;
-      
-    if (allowFreeTypeVariables == FreeTypeVariableBinding::UnresolvedType) {
-      convertType = convertType.transform([&](Type type) -> Type {
-        if (type->is<UnresolvedType>())
-          return cs.createTypeVariable(cs.getConstraintLocator(expr), 0);
-        return type;
-      });
-    }
-    
-    cs.addConstraint(constraintKind, expr->getType(), convertType,
-                     cs.getConstraintLocator(expr), /*isFavored*/ true);
-  }
-
-  // Notify the listener that we've built the constraint system.
-  if (listener && listener->builtConstraints(cs, expr)) {
-    return true;
-  }
-
-  if (getLangOpts().DebugConstraintSolver) {
-    auto &log = Context.TypeCheckerDebug->getStream();
-    log << "---Initial constraints for the given expression---\n";
-    expr->print(log);
-    log << "\n";
-    cs.print(log);
-  }
-
   // Attempt to solve the constraint system.
-  if (cs.solve(viable, allowFreeTypeVariables) ||
-      (viable.size() != 1 &&
-       !options.contains(TypeCheckExprFlags::AllowUnresolvedTypeVariables))) {
+  auto solution = cs.solve(expr,
+                           convertType,
+                           listener,
+                           viable,
+                           allowFreeTypeVariables);
+
+  // The constraint system has failed
+  if (solution == ConstraintSystem::SolutionKind::Error)
+    return true;
+
+  // If the system is unsolved or there are multiple solutions present but
+  // type checker options do not allow unresolved types, let's try to salvage
+  if (solution == ConstraintSystem::SolutionKind::Unsolved
+      || (viable.size() != 1 &&
+          !options.contains(TypeCheckExprFlags::AllowUnresolvedTypeVariables))) {
     if (options.contains(TypeCheckExprFlags::SuppressDiagnostics))
       return true;
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -44,6 +44,7 @@ class TypeChecker;
 
 namespace constraints {
   enum class ConstraintKind : char;
+  enum class SolutionKind : char;
   class ConstraintSystem;
   class Solution;
 }

--- a/test/Sema/complex_expressions.swift
+++ b/test/Sema/complex_expressions.swift
@@ -1,0 +1,79 @@
+// RUN: %target-parse-verify-swift
+
+// SR-139:
+// Infinite recursion parsing bitwise operators
+let x = UInt32(0x1FF)&0xFF << 24 | UInt32(0x1FF)&0xFF << 16 | UInt32(0x1FF)&0xFF << 8 | (UInt32(0x1FF)&0xFF);
+
+// SR-838:
+// expression test_seconds() was too complex to be solved in reasonable time
+struct Nano : CustomStringConvertible {
+  var value: Int64 = 0
+  init(_ x: Int64) { self.value = x }
+  var description: String { return "\(self.value)" }
+}
+
+func *(lhs: Nano, rhs: Int) -> Nano { return Nano(lhs.value * Int64(rhs)); }
+func *(lhs: Int, rhs: Nano) -> Nano { return Nano(Int64(lhs) * rhs.value); }
+func +(lhs: Nano, rhs: String) -> String { return lhs.description + rhs; }
+func +(lhs: String, rhs: Nano) -> String { return lhs + rhs.description; }
+func +(lhs: Nano, rhs: Nano) -> Nano { return Nano(lhs.value + rhs.value); }
+
+let u_nano = Nano(1)
+let u_second = Nano(1_000_000_00)
+let u_minute = u_second * 60
+
+extension Int {
+  var ns: Nano { return Nano(Int64(self)) }
+  var s: Nano { return self * u_second }
+  var i: Nano { return self * u_minute }
+}
+
+func test_seconds() {
+  print("Testing second operations:\n")
+  print(u_minute + u_second + Nano(500) + " = " + 1.i + 1.s + 500.ns)
+  print((u_minute + u_second + Nano(500)) + " = " + (1.i + 1.s + 500.ns))
+}
+
+// SR-2102:
+// DictionaryExpr was too complex to be solved in resonable time
+
+let M_PI: Double = 3.1415926535897931
+let M_E : Double = 2.7182818284590451
+
+func sqrt(degrees: Int) -> Double {
+  return 0
+}
+
+func sqrt(degrees: Float) -> Double {
+  return 0
+}
+
+func sqrt(degrees: Double) -> Double {
+  return 0
+}
+
+enum Operation {
+  case constant(Double)
+  case unaryOperation((Double) -> Double)
+  case binaryOperation((Double, Double) -> Double)
+  case equals
+}
+
+var operations: Dictionary<String, Operation> = [
+  "π": .constant(M_PI),
+  "e": .constant(M_E),
+  "√": .unaryOperation(sqrt),
+  "×": .binaryOperation({ (op1: Double, op2: Double) in
+    return op1 * op2
+  }),
+  "÷": .binaryOperation({ (op1, op2) in
+    return op1 / op2
+  }),
+  "+": .binaryOperation({ (op1: Double, op2: Double) in
+    return op1 + op2
+  }),
+  "−": .binaryOperation({ (op1, op2) in
+    return op1 - op2
+  }),
+  "=": .equals,
+]


### PR DESCRIPTION
#### What's in this pull request?

Improvements to the TypeChecker, namely DPC
(directional path consistency) algoritm which tries to 
solve individual sub-expressions and combine
resolved types as a way to reduce pre-existing OSR domains. Solving
is done bottom-up so each consecutive sub-expression tightens
possible solution domain even further.

_Note_: Original PR (https://github.com/apple/swift/pull/4485); Changes: updated test for SR-2102 to avoid importing Foundation and clang-format'ed sources and tests.
#### Resolved bug number: ([SR-139](https://bugs.swift.org/browse/SR-139))
#### Resolved bug number: ([SR-838](https://bugs.swift.org/browse/SR-838))
#### Resolved bug number: ([SR-2102](https://bugs.swift.org/browse/SR-2102))

And most likely at least couple of others related to "expression is too complex" I haven't seen yet.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

DPC algoritm tries to solve individual sub-expressions and combine
resolved types as a way to reduce pre-existing OSR domains. Solving
is done bottom-up so each consecutive sub-expression tightens
possible solution domain even further.
