### PR TITLE
[stdlib] Remove struct SwiftObject_s.

### DIFF
--- a/stdlib/public/runtime/SwiftObject.h
+++ b/stdlib/public/runtime/SwiftObject.h
@@ -33,6 +33,7 @@
 __attribute__((__objc_root_class__))
 #endif
 SWIFT_RUNTIME_EXPORT @interface SwiftObject<NSObject> {
+  Class isa;
   SWIFT_HEAPOBJECT_NON_OBJC_MEMBERS;
 }
 

--- a/stdlib/public/runtime/SwiftObject.h
+++ b/stdlib/public/runtime/SwiftObject.h
@@ -26,29 +26,14 @@
 #include <objc/NSObject.h>
 #endif
 
-namespace swift {
 
 #if SWIFT_OBJC_INTEROP
-struct SwiftObject_s {
-  void *isa __attribute__((__unavailable__));
-  uint32_t strongRefCount __attribute__((__unavailable__));
-  uint32_t weakRefCount __attribute__((__unavailable__));
-};
-
-static_assert(sizeof(SwiftObject_s) == sizeof(HeapObject),
-              "SwiftObject and HeapObject must have the same header");
-static_assert(std::is_trivially_constructible<SwiftObject_s>::value,
-              "SwiftObject must be trivially constructible");
-static_assert(std::is_trivially_destructible<SwiftObject_s>::value,
-              "SwiftObject must be trivially destructible");
-
-} // namespace swift
 
 #if __has_attribute(objc_root_class)
 __attribute__((__objc_root_class__))
 #endif
 SWIFT_RUNTIME_EXPORT @interface SwiftObject<NSObject> {
-  swift::SwiftObject_s header;
+  SWIFT_HEAPOBJECT_NON_OBJC_MEMBERS;
 }
 
 - (BOOL)isEqual:(id)object;
@@ -92,8 +77,8 @@ void swift_getSummary(String *out, OpaqueValue *value, const Metadata *T);
 // Convert a Swift String to an NSString.
 NSString *convertStringToNSString(String *swiftString);
 
-#endif
-  
 }
+
+#endif
 
 #endif

--- a/stdlib/public/runtime/SwiftValue.mm
+++ b/stdlib/public/runtime/SwiftValue.mm
@@ -125,9 +125,9 @@ static constexpr const size_t SwiftValueMinAlignMask
 /* TODO: If we're able to become a SwiftObject subclass in the future,
  * change to this:
 static constexpr const size_t SwiftValueHeaderOffset
-  = sizeof(SwiftObject_s);
+  = sizeof(HeapObject);
 static constexpr const size_t SwiftValueMinAlignMask
-  = alignof(SwiftObject_s) - 1;
+  = alignof(HeapObject) - 1;
  */
 
 static Class _getSwiftValueClass() {


### PR DESCRIPTION
SWIFT_HEAPOBJECT_NON_OBJC_MEMBERS works just as well with less redundancy.
