### PR TITLE
[swiftc (56 vs. 5156)] Add crasher in swift::GenericSignature::getSubstitutionMap(...)

### DIFF
--- a/validation-test/compiler_crashers/28403-swift-genericsignature-getsubstitutionmap.swift
+++ b/validation-test/compiler_crashers/28403-swift-genericsignature-getsubstitutionmap.swift
@@ -1,0 +1,17 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+{
+extension{
+protocol A{{
+}
+typealias e struct b{func a{
+enum b{
+let f=F
+class b:A class A:b


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignature::getSubstitutionMap(...)`.

Current number of unresolved compiler crashers: 56 (5156 resolved)

Assertion failure in `llvm/include/llvm/ADT/ArrayRef.h (line 139)`:

```
Assertion `!empty()' failed.

When executing: const T &llvm::ArrayRef<swift::Substitution>::front() const [T = swift::Substitution]
```

Assertion context:

```
    /// size - Get the array size.
    size_t size() const { return Length; }

    /// front - Get the first element.
    const T &front() const {
      assert(!empty());
      return Data[0];
    }

    /// back - Get the last element.
    const T &back() const {
```

Stack trace:

```
swift: /path/to/llvm/include/llvm/ADT/ArrayRef.h:139: const T &llvm::ArrayRef<swift::Substitution>::front() const [T = swift::Substitution]: Assertion `!empty()' failed.
8  swift           0x000000000111d436 swift::GenericSignature::getSubstitutionMap(llvm::ArrayRef<swift::Substitution>) const + 566
9  swift           0x0000000000f5a0d0 swift::createDesignatedInitOverride(swift::TypeChecker&, swift::ClassDecl*, swift::ConstructorDecl*, swift::DesignatedInitKind) + 384
10 swift           0x0000000000edcd44 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 3284
11 swift           0x0000000000ecfcfe swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 5998
12 swift           0x0000000000ed1077 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 375
17 swift           0x0000000001121464 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 1188
18 swift           0x0000000000f16652 swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::Type, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) + 290
19 swift           0x0000000000ebc96a swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 4058
21 swift           0x000000000109a22b swift::Expr::walk(swift::ASTWalker&) + 27
22 swift           0x0000000000ebd1f0 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 224
23 swift           0x0000000000ec443d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 621
24 swift           0x0000000000ec55f0 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 352
25 swift           0x0000000000ec580b swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
30 swift           0x0000000000ed7466 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
33 swift           0x0000000000f3f67a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
34 swift           0x0000000000f3f4de swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
35 swift           0x0000000000f400a3 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
37 swift           0x0000000000efb4a1 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
38 swift           0x0000000000c7b5b9 swift::CompilerInstance::performSema() + 3289
40 swift           0x00000000007db487 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
41 swift           0x00000000007a72b8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28403-swift-genericsignature-getsubstitutionmap.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28403-swift-genericsignature-getsubstitutionmap-72dd2a.o
1.  While type-checking 'a' at validation-test/compiler_crashers/28403-swift-genericsignature-getsubstitutionmap.swift:14:22
2.  While type-checking 'b' at validation-test/compiler_crashers/28403-swift-genericsignature-getsubstitutionmap.swift:15:1
3.  While type-checking expression at [validation-test/compiler_crashers/28403-swift-genericsignature-getsubstitutionmap.swift:16:7 - line:16:7] RangeText="F"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
