### PR TITLE
[ClangImporter] Predefine __swift__ in imported (Obj)C code.

### DIFF
--- a/include/swift/Basic/Version.h
+++ b/include/swift/Basic/Version.h
@@ -65,13 +65,15 @@ public:
 
   /// Return a string to be used as an internal preprocessor define.
   ///
-  /// Assuming the project version is at most X.Y.Z.a.b, the integral constant
-  /// representing the version is:
+  /// The components of the version are multiplied element-wise by
+  /// \p componentWeights, then added together (a dot product operation).
+  /// If either array is longer than the other, the missing elements are
+  /// treated as zero.
   ///
-  /// X*1000*1000*1000 + Z*1000*1000 + a*1000 + b
-  ///
-  /// The second version component is not used.
-  std::string preprocessorDefinition() const;
+  /// The resulting string will have the form "-DMACRO_NAME=XYYZZ".
+  /// The combined value must fit in a uint64_t.
+  std::string preprocessorDefinition(StringRef macroName,
+                                     ArrayRef<uint64_t> componentWeights) const;
 
   /// Return the ith version component.
   unsigned operator[](size_t i) const {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -315,6 +315,8 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
   const llvm::Triple &triple = ctx.LangOpts.Target;
   SearchPathOptions &searchPathOpts = ctx.SearchPathOpts;
 
+  auto languageVersion = swift::version::Version::getCurrentLanguageVersion();
+
   // Construct the invocation arguments for the current target.
   // Add target-independent options first.
   invocationArgStrs.insert(
@@ -332,8 +334,10 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
           // Don't emit LLVM IR.
           "-fsyntax-only",
 
-          // enable block support
+          // Enable block support.
           "-fblocks",
+
+          languageVersion.preprocessorDefinition("__swift__", {10000, 100, 1}),
 
           "-fretain-comments-from-system-headers",
 
@@ -396,7 +400,8 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
     auto V = version::Version::getCurrentCompilerVersion();
     if (!V.empty()) {
       invocationArgStrs.insert(invocationArgStrs.end(), {
-        V.preprocessorDefinition(),
+        V.preprocessorDefinition("__SWIFT_COMPILER_VERSION",
+                                 {1000000000, /*ignored*/0, 1000000, 1000, 1}),
       });
     }
   } else {

--- a/test/ClangModules/Inputs/custom-modules/PredefinedMacros.h
+++ b/test/ClangModules/Inputs/custom-modules/PredefinedMacros.h
@@ -1,0 +1,9 @@
+#if !defined(__swift__)
+# error "__swift__ not defined"
+#elif __swift__ < 30000
+# error "Why are you using such an old version of Swift?"
+#elif __swift__ >= 810000
+# error "Is Swift 81 out already? If so, please update this test."
+#else
+void swift3ReadyToGo();
+#endif

--- a/test/ClangModules/Inputs/custom-modules/module.map
+++ b/test/ClangModules/Inputs/custom-modules/module.map
@@ -103,6 +103,11 @@ module ObjCSubscripts {
   export *
 }
 
+module PredefinedMacros {
+  header "PredefinedMacros.h"
+  export *
+}
+
 module ProtoWithInitializer {
   header "ProtoWithInitializer.h"
   export *

--- a/test/ClangModules/predefined_macros.swift
+++ b/test/ClangModules/predefined_macros.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse -verify -I %S/Inputs/custom-modules/ %s
+
+import PredefinedMacros
+
+swift3ReadyToGo()


### PR DESCRIPTION
- **Explanation:** Provides a macro allowing imported code to distinguish between Swift versions, particularly between Swift 2 and Swift 3. More explanation and rationale in https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20160822/002754.html. While this is hardly a critical Swift 3 feature, it's _much_ more effective if it goes in now rather than in a point release, and so if there _are_ any further critical fixes we should take this too.
- **Scope:** Pretty much affects no one unless they were defining this macro manually. It does also affect the implementation of `__SWIFT_COMPILER_VERSION`, which is used only for internal processes at Apple, but the intent is that nothing changes there either.
- **Issue:** rdar://problem/26921435
- **Reviewed by:** @DougGregor, @bitjammer  
- **Risk:** Very low.
- **Testing:** Added a compiler regression test.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please clean test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please clean test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |
| Linux platform | @swift-ci Please clean test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
