### PR TITLE
Swift 3: pull in fixes from master branch

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -746,6 +746,9 @@ ERROR(parameter_unnamed,none,
 ERROR(parameter_curry_syntax_removed,none,
       "curried function declaration syntax has been removed; use a single parameter list", ())
 
+ERROR(initializer_as_typed_pattern,none,
+      "unexpected initializer in pattern; did you mean to use '='?", ())
+
 //------------------------------------------------------------------------------
 // Statement parsing diagnostics
 //------------------------------------------------------------------------------

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -788,15 +788,63 @@ ParserResult<Pattern> Parser::parseTypedPattern() {
   auto result = parsePattern();
   
   // Now parse an optional type annotation.
-  if (consumeIf(tok::colon)) {
+  if (Tok.is(tok::colon)) {
+    SourceLoc pastEndOfPrevLoc = getEndOfPreviousLoc();
+    SourceLoc colonLoc = consumeToken(tok::colon);
+    SourceLoc startOfNextLoc = Tok.getLoc();
+    
     if (result.isNull())  // Recover by creating AnyPattern.
       result = makeParserErrorResult(new (Context) AnyPattern(PreviousLoc));
     
     ParserResult<TypeRepr> Ty = parseType();
     if (Ty.hasCodeCompletion())
       return makeParserCodeCompletionResult<Pattern>();
-    if (Ty.isNull())
+    if (!Ty.isNull()) {
+      // Attempt to diagnose initializer calls incorrectly written
+      // as typed patterns, such as "var x: [Int]()".
+      if (Tok.isFollowingLParen()) {
+        BacktrackingScope backtrack(*this);
+        
+        // Create a local context if needed so we can parse trailing closures.
+        LocalContext dummyContext;
+        Optional<ContextChange> contextChange;
+        if (!CurLocalContext) {
+          contextChange.emplace(*this, CurDeclContext, &dummyContext);
+        }
+        
+        SourceLoc lParenLoc, rParenLoc;
+        SmallVector<Expr *, 2> args;
+        SmallVector<Identifier, 2> argLabels;
+        SmallVector<SourceLoc, 2> argLabelLocs;
+        Expr *trailingClosure;
+        ParserStatus status = parseExprList(tok::l_paren, tok::r_paren,
+                                            /*isPostfix=*/true,
+                                            /*isExprBasic=*/false,
+                                            lParenLoc, args, argLabels,
+                                            argLabelLocs, rParenLoc,
+                                            trailingClosure);
+        if (status.isSuccess()) {
+          backtrack.cancelBacktrack();
+          
+          // Suggest replacing ':' with '=' (ensuring proper whitespace).
+          
+          bool needSpaceBefore = (pastEndOfPrevLoc == colonLoc);
+          bool needSpaceAfter =
+            SourceMgr.getByteDistance(colonLoc, startOfNextLoc) <= 1;
+          
+          StringRef replacement = " = ";
+          if (!needSpaceBefore) replacement = replacement.drop_front();
+          if (!needSpaceAfter)  replacement = replacement.drop_back();
+          
+          diagnose(lParenLoc, diag::initializer_as_typed_pattern)
+            .highlight({Ty.get()->getStartLoc(), rParenLoc})
+            .fixItReplace(colonLoc, replacement);
+          result.setIsParseError();
+        }
+      }
+    } else {
       Ty = makeParserResult(new (Context) ErrorTypeRepr(PreviousLoc));
+    }
     
     result = makeParserResult(result,
                             new (Context) TypedPattern(result.get(), Ty.get()));

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1459,8 +1459,10 @@ bool TypeChecker::coercePatternToType(Pattern *&P, DeclContext *dc, Type type,
 
   case PatternKind::OptionalSome: {
     auto *OP = cast<OptionalSomePattern>(P);
-    auto *enumDecl = type->getEnumOrBoundGenericEnum();
-    if (!enumDecl) {
+    OptionalTypeKind optionalKind;
+    Type elementType = type->getAnyOptionalObjectType(optionalKind);
+
+    if (elementType.isNull()) {
       auto diagID = diag::optional_element_pattern_not_valid_type;
       SourceLoc loc = OP->getQuestionLoc();
       // Produce tailored diagnostic for if/let and other conditions.
@@ -1473,35 +1475,10 @@ bool TypeChecker::coercePatternToType(Pattern *&P, DeclContext *dc, Type type,
       return true;
     }
 
-    // If the element decl was not resolved (because it was spelled without a
-    // type as `.Foo`), resolve it now that we have a type.
-    if (!OP->getElementDecl()) {
-      auto *element = lookupEnumMemberElement(*this, dc, type, Context.Id_some,
-                                              OP->getLoc());
-      if (!element) {
-        diagnose(OP->getLoc(), diag::enum_element_pattern_member_not_found,
-                 "Some", type);
-        return true;
-      }
-      OP->setElementDecl(element);
-    }
+    EnumElementDecl *elementDecl = Context.getOptionalSomeDecl(optionalKind);
+    assert(elementDecl && "missing optional some decl?!");
+    OP->setElementDecl(elementDecl);
 
-    EnumElementDecl *elt = OP->getElementDecl();
-    // Is the enum element actually part of the enum type we're matching?
-    if (elt->getParentEnum() != enumDecl) {
-      diagnose(OP->getLoc(), diag::enum_element_pattern_not_member_of_enum,
-               "Some", type);
-      return true;
-    }
-
-    // Check the subpattern & push the enum element type down onto it.
-    Type elementType;
-    if (elt->hasArgumentType())
-      elementType = type->getTypeOfMember(elt->getModuleContext(),
-                                          elt, this,
-                                          elt->getArgumentInterfaceType());
-    else
-      elementType = TupleType::getEmpty(Context);
     Pattern *sub = OP->getSubPattern();
     if (coercePatternToType(sub, dc, elementType,
                             subOptions|TR_FromNonInferredPattern|TR_EnumPatternPayload,

--- a/test/Parse/diagnose_initializer_as_typed_pattern.swift
+++ b/test/Parse/diagnose_initializer_as_typed_pattern.swift
@@ -1,0 +1,35 @@
+// RUN: %target-parse-verify-swift
+
+// https://bugs.swift.org/browse/SR-1461
+
+class X {}
+func foo() {}
+
+let a:[X]()  // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{6-7= = }}
+let b: [X]()  // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{6-7= =}}
+let c :[X]()  // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{7-8== }}
+let d : [X]()  // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{7-8==}}
+
+let e: X(), ee: Int  // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{6-7= =}}
+
+var _1 = 1, _2 = 2
+
+// paren follows the type, but it's part of a separate (valid) expression
+let ff: X
+(_1, _2) = (_2, _1)
+let fff: X
+ (_1, _2) = (_2, _1)
+
+let g: X(x)  // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{6-7= =}}
+let h: X(x, y)  // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{6-7= =}}
+let i: X() { foo() }  // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{6-7= =}}
+let j: X(x) { foo() }  // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{6-7= =}}
+let k: X(x, y) { foo() }  // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{6-7= =}}
+
+func nonTopLevel() {
+  let a:[X]()   // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{8-9= = }}
+  let i: X() { foo() }  // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{8-9= =}}
+  let j: X(x) { foo() }  // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{8-9= =}}
+  let k: X(x, y) { foo() }  // expected-error{{unexpected initializer in pattern; did you mean to use '='?}} {{8-9= =}}
+  _ = (a, i, j, k)
+}

--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -591,45 +591,6 @@ func testRequireOptional2(_ a : String?) -> String {
   return t
 }
 
-enum MyOptional<Wrapped> {
-  case none
-  case some(Wrapped)
-}
-
-// CHECK-LABEL: sil hidden @_TF10statements28testAddressOnlyEnumInRequire
-// CHECK: bb0(%0 : $*T, %1 : $*MyOptional<T>):
-// CHECK-NEXT: debug_value_addr %1 : $*MyOptional<T>, let, name "a"
-// CHECK-NEXT: %3 = alloc_stack $T, let, name "t"
-// CHECK-NEXT: %4 = alloc_stack $MyOptional<T>
-// CHECK-NEXT: copy_addr %1 to [initialization] %4 : $*MyOptional<T>
-// CHECK-NEXT: switch_enum_addr %4 : $*MyOptional<T>, case #MyOptional.some!enumelt.1: bb2, default bb1
-func testAddressOnlyEnumInRequire<T>(_ a: MyOptional<T>) -> T {
-  // CHECK:  bb1:
-  // CHECK-NEXT:   dealloc_stack %4
-  // CHECK-NEXT:   dealloc_stack %3
-  // CHECK-NEXT:   br bb3
-  guard let t = a else { abort() }
-
-  // CHECK:    bb2:
-  // CHECK-NEXT:     %10 = unchecked_take_enum_data_addr %4 : $*MyOptional<T>, #MyOptional.some!enumelt.1
-  // CHECK-NEXT:     copy_addr [take] %10 to [initialization] %3 : $*T
-  // CHECK-NEXT:     dealloc_stack %4
-  // CHECK-NEXT:     copy_addr [take] %3 to [initialization] %0 : $*T
-  // CHECK-NEXT:     dealloc_stack %3
-  // CHECK-NEXT:     destroy_addr %1 : $*MyOptional<T>
-  // CHECK-NEXT:     tuple ()
-  // CHECK-NEXT:     return
-
-  // CHECK:    bb3:
-  // CHECK-NEXT:     // function_ref statements.abort () -> Swift.Never
-  // CHECK-NEXT:     %18 = function_ref @_TF10statements5abortFT_Os5Never
-  // CHECK-NEXT:     %19 = apply %18() : $@convention(thin) () -> Never
-  // CHECK-NEXT:     unreachable
-
-  return t
-}
-
-
 
 // CHECK-LABEL: sil hidden @_TF10statements19testCleanupEmission
 // <rdar://problem/20563234> let-else problem: cleanups for bound patterns shouldn't be run in the else block

--- a/test/stmt/if_while_var.swift
+++ b/test/stmt/if_while_var.swift
@@ -1,7 +1,11 @@
 // RUN: %target-parse-verify-swift
 
+struct NonOptionalStruct {}
+enum NonOptionalEnum { case foo }
+
 func foo() -> Int? { return .none }
-func nonOptional() -> Int { return 0 }
+func nonOptionalStruct() -> NonOptionalStruct { fatalError() }
+func nonOptionalEnum() -> NonOptionalEnum { fatalError() }
 func use(_ x: Int) {}
 func modify(_ x: inout Int) {}
 
@@ -19,7 +23,14 @@ if var x = foo() {
 
 use(x) // expected-error{{unresolved identifier 'x'}}
 
-if let x = nonOptional() { } // expected-error{{initializer for conditional binding must have Optional type, not 'Int'}}
+if let x = nonOptionalStruct() { } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalStruct'}}
+if let x = nonOptionalEnum() { } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalEnum'}}
+
+guard let _ = nonOptionalStruct() else { fatalError() } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalStruct'}}
+guard let _ = nonOptionalEnum() else { fatalError() } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalEnum'}}
+
+if case let x? = nonOptionalStruct() { } // expected-error{{'?' pattern cannot match values of type 'NonOptionalStruct'}}
+if case let x? = nonOptionalEnum() { } // expected-error{{'?' pattern cannot match values of type 'NonOptionalEnum'}}
 
 class B {} // expected-note * {{did you mean 'B'?}}
 class D : B {}// expected-note * {{did you mean 'D'?}}


### PR DESCRIPTION
This PR pulls changes from two recent PRs into the swift-3.0-branch.
- #4371: better diagnostics for `var x: T()`
- #4445: better diagnostics for `guard let x = (non-optional enum) ...`
