### PR TITLE
Fix Decimal

### DIFF
--- a/stdlib/public/SDK/Foundation/Decimal.swift
+++ b/stdlib/public/SDK/Foundation/Decimal.swift
@@ -31,12 +31,12 @@ extension Decimal {
 
     public var significand: Decimal { 
         get {
-            return Decimal(_exponent: 1, _length: _length, _isNegative: _isNegative, _isCompact: _isCompact, _reserved: 0, _mantissa: _mantissa)
+            return Decimal(_exponent: 0, _length: _length, _isNegative: _isNegative, _isCompact: _isCompact, _reserved: 0, _mantissa: _mantissa)
         }
     }
 
     public init(sign: FloatingPointSign, exponent: Int, significand: Decimal) {
-        self.init(_exponent: Int32(exponent), _length: significand._length, _isNegative: sign == .plus ? 1 : 0, _isCompact: significand._isCompact, _reserved: 0, _mantissa: significand._mantissa)
+        self.init(_exponent: Int32(exponent) + significand._exponent, _length: significand._length, _isNegative: sign == .plus ? 0 : 1, _isCompact: significand._isCompact, _reserved: 0, _mantissa: significand._mantissa)
     }
 
     public init(signOf: Decimal, magnitudeOf magnitude: Decimal) {
@@ -50,7 +50,8 @@ extension Decimal {
     public static var radix: Int { return 10 }
 
     public var ulp: Decimal {
-        return Decimal(_exponent: 1, _length: _length, _isNegative: _isNegative, _isCompact: _isCompact, _reserved: 0, _mantissa: _mantissa)
+        if !self.isFinite { return Decimal.nan }
+        return Decimal(_exponent: _exponent, _length: 8, _isNegative: 0, _isCompact: 1, _reserved: 0, _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000))
     }
 
     @available(*, unavailable, message: "Decimal does not yet fully adopt FloatingPoint.")

--- a/test/Interpreter/SDK/NSDecimal.swift
+++ b/test/Interpreter/SDK/NSDecimal.swift
@@ -117,3 +117,10 @@ twenty = Decimal(20)
 ten = Decimal(10)
 twenty.divide(by: ten)
 print(twenty) // CHECK: 2
+
+twenty = Decimal(20)
+print(twenty.significand) // CHECK: 2
+print(twenty.exponent) // CHECK: 1
+print(twenty.ulp) // CHECK: 10
+
+print(Decimal(sign: .plus, exponent: -2, significand: 100)) // CHECK: 1

--- a/test/Interpreter/SDK/NSDecimal.swift
+++ b/test/Interpreter/SDK/NSDecimal.swift
@@ -118,7 +118,7 @@ ten = Decimal(10)
 twenty.divide(by: ten)
 print(twenty) // CHECK: 2
 
-twenty = Decimal(20)
+twenty = NSDecimalNumber(mantissa: 2, exponent: 1, isNegative: false) as Decimal
 print(twenty.significand) // CHECK: 2
 print(twenty.exponent) // CHECK: 1
 print(twenty.ulp) // CHECK: 10


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

This PR fixes buggy implementations of `FloatingPoint` protocol members in `Decimal`.

**First, it fixes `significand`.**
Previously, `Decimal(1.35).significand == 1350` and `Decimal(1.35).exponent == -2`.
This was obviously incorrect: the expected value for `Decimal(1.35).significand` is `135`.

**Second, it fixes two bugs in `init(sign:exponent:significand:)`.**
Previously, only the mantissa of the `significand` argument was preserved; also, the sign was incorrectly flipped. So, as reported in [SR-2491](https://bugs.swift.org/browse/SR-2491), it was observed that `Decimal(sign: .plus, exponent: -2, significand: 100) == -0.01`.
This was clearly incorrect: the expected value is `1`, in agreement with documentation that the result should be equal to `(sign == .minus ? -1 : 1) * significand * Decimal.radix ** exponent`.

**Third, it aligns `ulp` with the documentation.**
It is unclear what the previous code was trying to do. Now, `x.ulp == Decimal.nan` if `!x.isFinite`; otherwise, the value returned is `10 ** exponent`, the unit of the least significant digit in the significand.
#### Resolved bug number: ([SR-2491](https://bugs.swift.org/browse/SR-2491))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please clean test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please clean test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |
| Linux platform | @swift-ci Please clean test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
