### PR TITLE
Fix a bug related to the opened archetypes tracking

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -135,6 +135,11 @@ public:
   void setInsertionPoint(SILBasicBlock *BB, SILBasicBlock::iterator InsertPt) {
     this->BB = BB;
     this->InsertPt = InsertPt;
+    if (InsertPt == BB->end())
+      return;
+    // Set the opened archetype context from the instruction.
+    this->getOpenedArchetypes().addOpenedArchetypeOperands(
+        InsertPt->getTypeDependentOperands());
   }
 
   /// setInsertionPoint - Set the insertion point to insert before the specified
@@ -175,6 +180,14 @@ public:
 
   SmallVectorImpl<SILInstruction *> *getTrackingList() {
     return InsertedInstrs;
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Opened archetypes handling
+  //===--------------------------------------------------------------------===//
+  void addOpenedArchetypeOperands(SILInstruction *I) {
+    getOpenedArchetypes().addOpenedArchetypeOperands(
+        I->getTypeDependentOperands());
   }
 
   //===--------------------------------------------------------------------===//

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -721,6 +721,7 @@ SILCombiner::createApplyWithConcreteType(FullApplySite AI,
 
   FullApplySite NewAI;
   Builder.setCurrentDebugScope(AI.getDebugScope());
+  Builder.addOpenedArchetypeOperands(AI.getInstruction());
 
   if (auto *TAI = dyn_cast<TryApplyInst>(AI))
     NewAI = Builder.createTryApply(AI.getLoc(), AI.getCallee(),
@@ -1156,6 +1157,7 @@ SILInstruction *SILCombiner::visitApplyInst(ApplyInst *AI) {
     // The type of the substitution is the source type of the thin to thick
     // instruction.
     SILType substTy = TTTFI->getOperand()->getType();
+    Builder.addOpenedArchetypeOperands(AI);
     auto *NewAI = Builder.createApply(AI->getLoc(), TTTFI->getOperand(),
                                       substTy, AI->getType(),
                                       AI->getSubstitutions(), Arguments,

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -50,6 +50,7 @@ STATISTIC(NumTargetsPredicted, "Number of monomorphic functions predicted");
 static FullApplySite CloneApply(FullApplySite AI, SILBuilder &Builder) {
   // Clone the Apply.
   Builder.setCurrentDebugScope(AI.getDebugScope());
+  Builder.addOpenedArchetypeOperands(AI.getInstruction());
   auto Args = AI.getArguments();
   SmallVector<SILValue, 8> Ret(Args.size());
   for (unsigned i = 0, e = Args.size(); i != e; ++i)

--- a/test/SILOptimizer/opened_archetype_operands_tracking.sil
+++ b/test/SILOptimizer/opened_archetype_operands_tracking.sil
@@ -1,0 +1,64 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -O | %FileCheck %s
+
+// Check some corner cases related to tracking of opened archetypes.
+// For example, the compiler used to crash compiling the "process" function (rdar://28024272)
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+public protocol P {
+}
+
+extension P {
+  func invokeClosure(_ closure: () throws -> ()) rethrows
+}
+
+public func process(s: P)
+
+sil @invokeClosure : $@convention(method) <Self where Self : P> (@owned @callee_owned () -> @error Error, @in_guaranteed Self) -> @error Error {
+bb0(%0 : $@callee_owned () -> @error Error, %1 : $*Self):
+  strong_release %0 : $@callee_owned () -> @error Error
+  %5 = tuple ()
+  return %5 : $()
+}
+
+sil @closure : $@convention(thin) () -> () {
+bb0:
+  %0 = tuple ()
+  debug_value %0 : $()
+  %2 = tuple ()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil @process
+// CHECK: bb0
+// CHECK-NOT: try_apply
+// CHECK-NOT: unreachable
+// CHECK: apply
+// CHECK-NOT: unreachable
+// CHECK: return
+sil @process : $@convention(thin) (@in P) -> () {
+bb0(%0 : $*P):
+  %2 = open_existential_addr %0 : $*P to $*@opened("4C22C24E-6BAA-11E6-B904-B8E856428C60") P
+  %3 = function_ref @invokeClosure : $@convention(method) <τ_0_0 where τ_0_0 : P> (@owned @callee_owned () -> @error Error, @in_guaranteed τ_0_0) -> @error Error
+  // function_ref (process(s : P) -> ()).(closure #1)
+  %4 = function_ref @closure : $@convention(thin) () -> ()
+  %5 = thin_to_thick_function %4 : $@convention(thin) () -> () to $@callee_owned () -> ()
+  %6 = convert_function %5 : $@callee_owned () -> () to $@callee_owned () -> @error Error
+  try_apply %3<@opened("4C22C24E-6BAA-11E6-B904-B8E856428C60") P>(%6, %2) : $@convention(method) <τ_0_0 where τ_0_0 : P> (@owned @callee_owned () -> @error Error, @in_guaranteed τ_0_0) -> @error Error, normal bb1, error bb2
+
+bb1(%8 : $()):
+  destroy_addr %0 : $*P
+  %10 = tuple ()
+  return %10 : $()
+
+bb2(%12 : $Error):
+  unreachable
+}
+
+sil_default_witness_table P {
+}
+


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please clean test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please clean test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |
| Linux platform | @swift-ci Please clean test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

If a SILBuilder creates a new instruction based on an old instruction and a new instruction is supposed to use some opened archetypes, one needs to set a proper opened archetypes context in the builder based on the opened archetypes used by the old instruction.

This fixes rdar://28024272
