### PR TITLE
[DO NOT MERGE YET] Cherry-pick commits required for swift-3.0-branch Foundation integration

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -644,11 +644,13 @@ test
 validation-test
 long-test
 foundation
+libdispatch
 lit-args=-v
 
 dash-dash
 
 install-foundation
+install-libdispatch
 reconfigure
 
 # Ubuntu 16.04 preset for backwards compat and future customizations.
@@ -730,6 +732,7 @@ llbuild
 swiftpm
 xctest
 foundation
+libdispatch
 dash-dash
 
 [preset: buildbot_incremental_linux,long_test]

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2391,6 +2391,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 LLVM_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
 
                 if [[ "${RECONFIGURE}" || ! -f "${LIBDISPATCH_BUILD_DIR}"/config.status ]]; then
+                    echo "Reconfiguring libdispatch"
                     # First time building; need to run autotools and configure
                     if [[ "$LIBDISPATCH_BUILD_TYPE" == "Release" ]] ; then
                         dispatch_build_variant_arg="release"
@@ -2400,6 +2401,7 @@ for host in "${ALL_HOSTS[@]}"; do
                         dispatch_build_variant_arg="debug"
                     fi
                     call mkdir -p "${LIBDISPATCH_BUILD_DIR}"
+                    echo `which autoreconf`
                     with_pushd "${LIBDISPATCH_SOURCE_DIR}" \
                         call autoreconf -fvi
                     with_pushd "${LIBDISPATCH_BUILD_DIR}" \
@@ -2407,7 +2409,8 @@ for host in "${ALL_HOSTS[@]}"; do
                             "${LIBDISPATCH_SOURCE_DIR}"/configure --with-swift-toolchain="${SWIFT_BUILD_PATH}" \
                             --with-build-variant=$dispatch_build_variant_arg \
                             --prefix="$(get_host_install_destdir ${host})$(get_host_install_prefix ${host})"
-
+                else
+                    echo "Skipping reconfiguration of libdispatch"
                 fi
                 with_pushd "${LIBDISPATCH_BUILD_DIR}" \
                     call make

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2390,7 +2390,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 SWIFTC_BIN="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
                 LLVM_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
 
-                if [[ ! -f "${LIBDISPATCH_BUILD_DIR}"/config.status ]]; then
+                if [[ "${RECONFIGURE}" || ! -f "${LIBDISPATCH_BUILD_DIR}"/config.status ]]; then
                     # First time building; need to run autotools and configure
                     if [[ "$LIBDISPATCH_BUILD_TYPE" == "Release" ]] ; then
                         dispatch_build_variant_arg="release"

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2401,7 +2401,6 @@ for host in "${ALL_HOSTS[@]}"; do
                         dispatch_build_variant_arg="debug"
                     fi
                     call mkdir -p "${LIBDISPATCH_BUILD_DIR}"
-                    echo `which autoreconf`
                     with_pushd "${LIBDISPATCH_SOURCE_DIR}" \
                         call autoreconf -fvi
                     with_pushd "${LIBDISPATCH_BUILD_DIR}" \


### PR DESCRIPTION
**What's in this pull request?**
Pulls in PR #4203 "build libdispatch by default in both linux build bot configurations". The changes are required for branching swift-corelibs-foundation for Swift 3.

This is not to be merged until [swiftpm #617](https://github.com/apple/swift-package-manager/pull/617), [swift-corelibs-xctest #170](https://github.com/apple/swift-corelibs-xctest/pull/170), and [libdispatch #165](https://github.com/apple/swift-corelibs-libdispatch/pull/165) are ready to merge.
