### PR TITLE
 [SE-0112] Provide default implementations for CustomNSError…

### DIFF
--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -121,12 +121,55 @@ public protocol CustomNSError : Error {
   var errorUserInfo: [String : Any] { get }
 }
 
+public extension CustomNSError {
+  /// Default domain of the error.
+  static var errorDomain: String {
+    return String(reflecting: type(of: self))
+  }
+
+  /// The error code within the given domain.
+  var errorCode: Int {
+    return _swift_getDefaultErrorCode(self)
+  }
+
+  /// The default user-info dictionary.
+  var errorUserInfo: [String : Any] {
+    return [:]
+  }
+}
+
+extension CustomNSError where Self: RawRepresentable, Self.RawValue: SignedInteger {
+  // The error code of Error with integral raw values is the raw value.
+  public var errorCode: Int {
+    return numericCast(self.rawValue)
+  }
+}
+
+extension CustomNSError where Self: RawRepresentable, Self.RawValue: UnsignedInteger {
+  // The error code of Error with integral raw values is the raw value.
+  public var errorCode: Int {
+    return numericCast(self.rawValue)
+  }
+}
+
 public extension Error where Self : CustomNSError {
   /// Default implementation for customized NSErrors.
   var _domain: String { return Self.errorDomain }
 
   /// Default implementation for customized NSErrors.
   var _code: Int { return self.errorCode }
+}
+
+public extension Error where Self: CustomNSError, Self: RawRepresentable,
+    Self.RawValue: SignedInteger {
+  /// Default implementation for customized NSErrors.
+  var _code: Int { return self.errorCode }  
+}
+
+public extension Error where Self: CustomNSError, Self: RawRepresentable,
+    Self.RawValue: UnsignedInteger {
+  /// Default implementation for customized NSErrors.
+  var _code: Int { return self.errorCode }  
 }
 
 public extension Error {

--- a/stdlib/public/runtime/ErrorObject.mm
+++ b/stdlib/public/runtime/ErrorObject.mm
@@ -394,7 +394,7 @@ extern "C" NSDictionary *swift_stdlib_getErrorUserInfoNSDictionary(
 //public func _stdlib_getErrorDefaultUserInfo<T : Error>(_ x: UnsafePointer<T>) -> AnyObject
 SWIFT_CC(swift) SWIFT_RT_ENTRY_VISIBILITY
 extern "C" NSDictionary *swift_stdlib_getErrorDefaultUserInfo(
-                           const OpaqueValue *error,
+                           OpaqueValue *error,
                            const Metadata *T,
                            const WitnessTable *Error) {
   typedef SWIFT_CC(swift)
@@ -405,7 +405,10 @@ extern "C" NSDictionary *swift_stdlib_getErrorDefaultUserInfo(
   auto foundationGetDefaultUserInfo = SWIFT_LAZY_CONSTANT(
         reinterpret_cast<GetDefaultFn*>
           (dlsym(RTLD_DEFAULT, "swift_Foundation_getErrorDefaultUserInfo")));
-  if (!foundationGetDefaultUserInfo) { return nullptr; }
+  if (!foundationGetDefaultUserInfo) {
+    T->vw_destroy(error);
+    return nullptr;
+  }
 
   return foundationGetDefaultUserInfo(error, T, Error);
 }

--- a/test/stdlib/ErrorBridged.swift
+++ b/test/stdlib/ErrorBridged.swift
@@ -582,6 +582,32 @@ ErrorBridgingTests.test("Customizing localization/recovery laziness") {
   }
 }
 
+enum DefaultCustomizedError1 : CustomNSError {
+  case bad
+  case worse
+}
+
+enum DefaultCustomizedError2 : Int, CustomNSError {
+  case bad = 7
+  case worse = 13
+}
+
+enum DefaultCustomizedError3 : UInt, CustomNSError {
+  case bad = 9
+  case worse = 115
+
+  static var errorDomain: String {
+    return "customized3"
+  }
+}
+
+ErrorBridgingTests.test("Default-customized via CustomNSError") {
+  expectEqual(1, (DefaultCustomizedError1.worse as NSError).code)
+  expectEqual(13, (DefaultCustomizedError2.worse as NSError).code)
+  expectEqual(115, (DefaultCustomizedError3.worse as NSError).code)
+  expectEqual("customized3", (DefaultCustomizedError3.worse as NSError).domain)
+}
+
 class MyNSError : NSError {  }
 
 ErrorBridgingTests.test("NSError subclass identity") {


### PR DESCRIPTION
<!-- Please complete this template before creating the pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

A smoke test on macOS does the following:
1. Builds the compiler incrementally.
2. Builds the standard library only for macOS. Simulator standard libraries and
   device standard libraries are not built.
3. lldb is not built.
4. The test and validation-test targets are run only for macOS. The optimized
   version of these tests are not run.

A smoke test on Linux does the following:
1. Builds the compiler incrementally.
2. Builds the standard library incrementally.
3. lldb is built incrementally.
4. The swift test and validation-test targets are run. The optimized version of these
   tests are not run.
5. lldb is tested.

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please clean test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please clean test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |
| Linux platform | @swift-ci Please clean test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

… requirements.

Provide default implementations for all of the CustomNSError requirements:
- errorDomain: default to the name of the enum type
- errorCode: default to the same thing "_code" gets, e.g., the enum tag or
  raw value
- errorUserInfo: default to empty

This makes it significantly easier to customize just one aspect of the
NSError view of an error type, e.g., just the user-info dictionary,
without having to write boilerplate for the others.
