### PR TITLE
	Reduce boilerplate in the GitHub PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,68 +1,13 @@
-<!-- Please complete this template before creating the pull request. -->
-#### What's in this pull request?
-<!-- Description about pull request. -->
+<!-- What's in this pull request? -->
+Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.
 
-#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))
-<!-- If this pull request resolves any bugs from Swift bug tracker -->
+<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
+Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).
 
-* * * *
+<!--
+Before merging this pull request, you must run the Swift continuous integration tests.
+For information about triggering CI builds via @swift-ci, see:
+https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci
 
-<!-- This selection should only be completed by Swift admin -->
-Before merging this pull request to apple/swift repository:
-- [ ] Test pull request on Swift continuous integration.
-
-<details>
-  <summary>Triggering Swift CI</summary>
-
-The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:
-
-**Smoke Testing**
-
-        Platform     | Comment
-        ------------ | -------------
-        All supported platforms     | @swift-ci Please smoke test
-        All supported platforms     | @swift-ci Please smoke test and merge
-        OS X platform               | @swift-ci Please smoke test OS X platform
-        Linux platform              | @swift-ci Please smoke test Linux platform
-
-A smoke test on macOS does the following:
-
-1. Builds the compiler incrementally.
-2. Builds the standard library only for macOS. Simulator standard libraries and
-   device standard libraries are not built.
-3. lldb is not built.
-4. The test and validation-test targets are run only for macOS. The optimized
-   version of these tests are not run.
-
-A smoke test on Linux does the following:
-
-1. Builds the compiler incrementally.
-2. Builds the standard library incrementally.
-3. lldb is built incrementally.
-4. The swift test and validation-test targets are run. The optimized version of these
-   tests are not run.
-5. lldb is tested.
-
-**Validation Testing**
-
-        Platform     | Comment
-        ------------ | -------------
-        All supported platforms     | @swift-ci Please test
-        All supported platforms     | @swift-ci Please clean test
-        All supported platforms     | @swift-ci Please test and merge
-        OS X platform               | @swift-ci Please test OS X platform
-        OS X platform               | @swift-ci Please clean test OS X platform
-        OS X platform               | @swift-ci Please benchmark
-        Linux platform              | @swift-ci Please test Linux platform
-        Linux platform              | @swift-ci Please clean test Linux platform
-
-
-**Lint Testing**
-
-        Language     | Comment
-        ------------ | -------------
-        Python       | @swift-ci Please Python lint
-
-Note: Only members of the Apple organization can trigger swift-ci.
-</details>
-<!-- Thank you for your contribution to Swift! -->
+Thank you for your contribution to Swift!
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ license](https://swift.org/LICENSE.txt).
 
 ---
 
-Before submitting the pull request, please make sure you have tested your
-changes and that they follow the Swift project [guidelines for contributing
+Before submitting the pull request, please make sure you have [tested your
+changes](https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md)
+and that they follow the Swift project [guidelines for contributing
 code](https://swift.org/contributing/#contributing-code).

--- a/docs/ContinuousIntegration.md
+++ b/docs/ContinuousIntegration.md
@@ -67,9 +67,13 @@ A smoke test on Linux does the following:
         Platform     | Comment
         ------------ | -------------
         All supported platforms     | @swift-ci Please test
+        All supported platforms     | @swift-ci Please clean test
         All supported platforms     | @swift-ci Please test and merge
         OS X platform               | @swift-ci Please test OS X platform
+        OS X platform               | @swift-ci Please clean test OS X platform
+        OS X platform               | @swift-ci Please benchmark
         Linux platform              | @swift-ci Please test Linux platform
+        Linux platform              | @swift-ci Please clean test Linux platform
 
 The core principles of validation testing is that:
 


### PR DESCRIPTION
Following up on some discussion in #4496. IMO, there's no need for all the extra content in the PR template, since the information is in ContinuousIntegration.md. This PR:
- updates ContinuousIntegration.md with the latest triggers from the PR template;
- updates CONTRIBUTING.md to point to ContinuousIntegration.md;
- simplifies the PR template.

cc @gottesmm @jrose-apple @shahmishal 
