### PR TITLE
Merge swift_configure_install_components and swift_configure_components.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,10 +126,6 @@ set(SWIFT_ENABLE_LLD_LINKER FALSE CACHE BOOL
 set(SWIFT_ENABLE_GOLD_LINKER FALSE CACHE BOOL
     "Enable using the gold linker when available")
 
-# Configure and initialize swift components.
-include(SwiftComponents)
-swift_configure_components()
-
 set(SWIFT_SDKS "" CACHE STRING
     "If non-empty, limits building target binaries only to specified SDKs (despite other SDKs being available)")
 
@@ -331,6 +327,7 @@ set(CMAKE_CXX_ARCHIVE_FINISH "")
 
 include(CheckCXXSourceRuns)
 include(CMakeParseArguments)
+include(SwiftComponents)
 include(SwiftHandleGybSources)
 include(SwiftSetIfArchBitness)
 include(SwiftSource)
@@ -339,7 +336,8 @@ include(SwiftConfigureSDK)
 include(SwiftComponents)
 include(SwiftList)
 
-swift_configure_install_components("${SWIFT_INSTALL_COMPONENTS}")
+# Configure swift include, install, build components.
+swift_configure_components()
 
 if("${CMAKE_VERSION}" VERSION_LESS "3.0")
   set(SWIFT_CMAKE_HAS_GENERATOR_EXPRESSIONS FALSE)

--- a/cmake/modules/SwiftComponents.cmake
+++ b/cmake/modules/SwiftComponents.cmake
@@ -71,6 +71,23 @@ macro(swift_configure_components)
   # Set the SWIFT_INSTALL_COMPONENTS variable to the default value if it is not passed in via -D
   set(SWIFT_INSTALL_COMPONENTS "${_SWIFT_DEFINED_COMPONENTS}" CACHE STRING
     "A semicolon-separated list of components to install ${_SWIFT_DEFINED_COMPONENTS}")
+
+  foreach(component ${_SWIFT_DEFINED_COMPONENTS})
+    string(TOUPPER "${component}" var_name_piece)
+    string(REPLACE "-" "_" var_name_piece "${var_name_piece}")
+    set(SWIFT_INSTALL_${var_name_piece} FALSE)
+  endforeach()
+
+  foreach(component ${SWIFT_INSTALL_COMPONENTS})
+    list(FIND _SWIFT_DEFINED_COMPONENTS "${component}" index)
+    if(${index} EQUAL -1)
+      message(FATAL_ERROR "unknown install component: ${component}")
+    endif()
+
+    string(TOUPPER "${component}" var_name_piece)
+    string(REPLACE "-" "_" var_name_piece "${var_name_piece}")
+    set(SWIFT_INSTALL_${var_name_piece} TRUE)
+  endforeach()
 endmacro()
 
 function(swift_is_installing_component component result_var_name)
@@ -105,22 +122,3 @@ function(swift_install_in_component component)
     install(${ARGN})
   endif()
 endfunction()
-
-macro(swift_configure_install_components install_components)
-  foreach(component ${_SWIFT_DEFINED_COMPONENTS})
-    string(TOUPPER "${component}" var_name_piece)
-    string(REPLACE "-" "_" var_name_piece "${var_name_piece}")
-    set(SWIFT_INSTALL_${var_name_piece} FALSE)
-  endforeach()
-
-  foreach(component ${install_components})
-    list(FIND _SWIFT_DEFINED_COMPONENTS "${component}" index)
-    if(${index} EQUAL -1)
-      message(FATAL_ERROR "unknown install component: ${component}")
-    endif()
-
-    string(TOUPPER "${component}" var_name_piece)
-    string(REPLACE "-" "_" var_name_piece "${var_name_piece}")
-    set(SWIFT_INSTALL_${var_name_piece} TRUE)
-  endforeach()
-endmacro()


### PR DESCRIPTION
This is the last NFC commit for swift components. It does two things:
1. It introduces SWIFT_INCLUDE,BUILD_COMPONENTS. These are not wired up to anything.
2. It merges swift_configure_install_components and swift_configure_components. This ensures that component configuration happens in one place in the main cmake file. There is no reason to keep them separate so lets make the code easier to understand.
