### PR TITLE
[stdlib][runtime] fix uninitialized variable savedSize

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2553,7 +2553,7 @@ swift::swift_getForeignTypeMetadata(ForeignTypeMetadata *nonUnique) {
   // saved iterator if it's still valid.  This should only be called
   // while the lock is held.
   decltype(foreignTypes.Types.begin()) savedIterator;
-  size_t savedSize;
+  size_t savedSize = 0;
   auto getCurrentEntry = [&]() -> const ForeignTypeMetadata *& {
     // The iterator may have been invalidated if the size of the map
     // has changed since the last lookup.


### PR DESCRIPTION
On line number 2560 of [Metadata.cpp](https://github.com/apple/swift/blob/master/stdlib/public/runtime/Metadata.cpp#L2560), `savedSize` is accessed without an initialized value. It's always good to initialize variables, because if we try to access a value before it gets assigned any actual (non-garbage) value, then it results in undefined behavior.

Found by https://github.com/bryongloden/cppcheck
