### PR TITLE
[Swift 3.0] Use gold linker on s390x

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1233,6 +1233,7 @@ std::string toolchains::GenericUnix::getDefaultLinker() const {
   case llvm::Triple::x86_64:
   case llvm::Triple::ppc64:
   case llvm::Triple::ppc64le:
+  case llvm::Triple::systemz:
     // BFD linker has issues wrt relocations against protected symbols.
     return "gold";
   default:


### PR DESCRIPTION
<!-- What's in this pull request? -->

Enable gold linker on s390x

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
