### PR TITLE
[Serialization] Ignore filesystem errors when loading modules.

### DIFF
--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -67,7 +67,7 @@ openModuleFiles(StringRef DirName, StringRef ModuleFilename,
   return std::error_code();
 }
 
-static std::error_code
+static bool
 findModule(ASTContext &ctx, AccessPathElem moduleID,
            std::unique_ptr<llvm::MemoryBuffer> &moduleBuffer,
            std::unique_ptr<llvm::MemoryBuffer> &moduleDocBuffer,
@@ -110,8 +110,8 @@ findModule(ASTContext &ctx, AccessPathElem moduleID,
                             moduleBuffer, moduleDocBuffer,
                             scratch);
     }
-    if (!err || err != std::errc::no_such_file_or_directory)
-      return err;
+    if (!err)
+      return true;
   }
 
   {
@@ -127,20 +127,20 @@ findModule(ASTContext &ctx, AccessPathElem moduleID,
                                  archFile.str(), archDocFile.str(),
                                  moduleBuffer, moduleDocBuffer,
                                  scratch);
-      if (!err || err != std::errc::no_such_file_or_directory)
-        return err;
+      if (!err)
+        return true;
     }
   }
 
   // If we're not allowed to look in the runtime library import path, stop.
   if (ctx.SearchPathOpts.SkipRuntimeLibraryImportPath)
-    return std::make_error_code(std::errc::no_such_file_or_directory);
+    return false;
 
   // Search the runtime import path.
   isFramework = false;
-  return openModuleFiles(ctx.SearchPathOpts.RuntimeLibraryImportPath,
-                         moduleFilename.str(), moduleDocFilename.str(),
-                         moduleBuffer, moduleDocBuffer, scratch);
+  return !openModuleFiles(ctx.SearchPathOpts.RuntimeLibraryImportPath,
+                          moduleFilename.str(), moduleDocFilename.str(),
+                          moduleBuffer, moduleDocBuffer, scratch);
 }
 
 FileUnit *SerializedModuleLoader::loadAST(
@@ -378,14 +378,8 @@ Module *SerializedModuleLoader::loadModule(SourceLoc importLoc,
 
   // Otherwise look on disk.
   if (!moduleInputBuffer) {
-    if (std::error_code err = findModule(Ctx, moduleID, moduleInputBuffer,
-                                         moduleDocInputBuffer,
-                                         isFramework)) {
-      if (err != std::errc::no_such_file_or_directory) {
-        Ctx.Diags.diagnose(moduleID.second, diag::sema_opening_import,
-                           moduleID.first, err.message());
-      }
-
+    if (!findModule(Ctx, moduleID, moduleInputBuffer, moduleDocInputBuffer,
+                    isFramework)) {
       return nullptr;
     }
 

--- a/test/Serialization/load-file-permissions.swift
+++ b/test/Serialization/load-file-permissions.swift
@@ -1,0 +1,10 @@
+// RUN: if [[ -d %t ]]; then chmod -R u+rwx %t && rm -rf %t; fi
+// RUN: mkdir -p %t/good
+// RUN: mkdir %t/bad
+// RUN: chmod a-rx %t/bad
+// RUN: %target-swift-frontend -emit-module -o %t/good %S/../Inputs/empty.swift
+// RUN: not %target-swift-frontend %s -parse -I %t/bad -I %t/good -show-diagnostics-after-fatal 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend %s -parse -I %t/good -I %t/bad -show-diagnostics-after-fatal 2>&1 | %FileCheck %s
+
+import empty // CHECK-NOT: empty
+import ThisOneReallyDoesNotExist // CHECK: [[@LINE]]:{{[0-9]+}}: error: no such module 'ThisOneReallyDoesNotExist'


### PR DESCRIPTION
Instead, just go on to the next search path. This prevents a present-but-unreadable directory from leading to a module load failure, which happens when one user builds a module and another user loads it (even if those search paths aren't even being used).

There might still be some other errors that would be useful to treat as "module found but invalid" rather than "module not found", but experience has shown that it's the wrong default.

There is a Radar for this but I can't find it.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
