### PR TITLE
[stdlib] Move empty check for string concatenation to front

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -704,10 +704,10 @@ extension String {
   @effects(readonly)
   @_semantics("string.concat")
   public static func + (lhs: String, rhs: String) -> String {
-    var lhs = lhs
     if lhs.isEmpty {
       return rhs
     }
+    var lhs = lhs
     lhs._core.append(rhs._core)
     return lhs
   }


### PR DESCRIPTION
<!-- What's in this pull request? -->

I think its best to check if the left hand side is empty first before making a mutable copy so I moved the empty check to the front of the function. 

This way a mutable copy of `lhs` is made only when it is actually used. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
