### PR TITLE
[stdlib] rewrite optional handling using map

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -321,11 +321,7 @@ extension String {
     let (stringBufferOptional, _) =
         _StringBuffer.fromCodeUnits(input, encoding: encoding,
             repairIllFormedSequences: false)
-    if let stringBuffer = stringBufferOptional {
-      return String(_storage: stringBuffer)
-    } else {
-      return nil
-    }
+    return stringBufferOptional.map { String(_storage: $0) }
   }
 
   public // @testable


### PR DESCRIPTION
<!-- What's in this pull request? -->

I thought that rewriting the optional handling using map would make it a little bit
cleaner to read.

Hope its ok!

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
