### PR TITLE
[build-script] Clean submodules where applicable

### DIFF
--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -43,8 +43,16 @@ def update_single_repository(repo_path, branch, reset_to_remote, should_clean):
         if should_clean:
             shell.call(['git', 'clean', '-fdx'],
                        echo=True)
-            shell.call(['git', 'reset', '--hard', 'HEAD'],
+            shell.call(['git', 'submodule', 'foreach', '--recursive', 'git', 'clean', '-fdx'],
                        echo=True)
+            shell.call(['git', 'submodule', 'foreach', '--recursive', 'git', 'reset', '--hard', 'HEAD'],
+                       echo=True)
+            status = shell.call(['git', 'reset', '--hard', 'HEAD'],
+                       echo=True)
+            if status:
+                print("Please, commit your changes.")
+                print(status)
+                exit(1)
 
         if branch:
             status = shell.capture(['git', 'status', '--porcelain', '-uno'],


### PR DESCRIPTION
When updating the project with the clean option, ensure that sub modules are cleaned as well. This issue can be tested by adding a line to swift-corelibs-libdispatch/libkqueue/README.md - if this file is changed then the reset hard on the libdispatch project will fail silently before this fix. As a result the libdispatch project checkout can become out of date. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-2524](https://bugs.swift.org/browse/SR-2524).

When building Swift from a non-clean checkout, the `git reset` that
occurs on subprojects that include submodules may fail if the submodule
is deemed to have been changed (for example, by running the autoconf
scripts).

When cleaning the projects, ensure that `git submodule` is used to clean
submodules and reset them to their original state as well, so that the
project can be reset successfully.

Issue: SR-2524
