### PR TITLE
[stdlib] Simplify StringUTF16's String constructor

### DIFF
--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -282,9 +282,7 @@ extension String {
     }
 
     internal init(_ _core: _StringCore) {
-      self._offset = 0
-      self._length = _core.count
-      self._core = _core
+      self.init(_core, offset: 0, length: _core.count)
     }
 
     internal init(_ _core: _StringCore, offset: Int, length: Int) {


### PR DESCRIPTION
<!-- What's in this pull request? -->

I think it might be cleaner to just directly call the constructor taking `core`, `offset` and `length`: 

``` swift
internal init(_ _core: _StringCore, offset: Int, length: Int)
```

passing the default offset of `0` instead of initializing the `struct` members directly in:

``` swift
internal init(_ _core: _StringCore) 
```

How does it look?

Thanks!

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
