### PR TITLE
Guard against racy access to NSError.setUserInfoValueProvider.

### DIFF
--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -136,6 +136,9 @@ public extension Error {
   }
 }
 
+internal let _errorDomainUserInfoProviderQueue = DispatchQueue(
+  label: "SwiftFoundation._errorDomainUserInfoProviderQueue")
+
 /// Retrieve the default userInfo dictionary for a given error.
 @_silgen_name("swift_Foundation_getErrorDefaultUserInfo")
 public func _swift_Foundation_getErrorDefaultUserInfo(_ error: Error)
@@ -149,7 +152,8 @@ public func _swift_Foundation_getErrorDefaultUserInfo(_ error: Error)
     // user-info value providers.
     let domain = error._domain
     if domain != NSCocoaErrorDomain {
-      if NSError.userInfoValueProvider(forDomain: domain) == nil {
+      _errorDomainUserInfoProviderQueue.sync {
+        if NSError.userInfoValueProvider(forDomain: domain) != nil { return }
         NSError.setUserInfoValueProvider(forDomain: domain) { (nsError, key) in
           let error = nsError as Error
 

--- a/validation-test/stdlib/ErrorProtocol.swift
+++ b/validation-test/stdlib/ErrorProtocol.swift
@@ -1,6 +1,5 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-// REQUIRES: rdar27541751
 // REQUIRES: objc_interop
 
 import SwiftPrivate


### PR DESCRIPTION
- **Explanation:** Our Error/NSError bridging uses a specific API to provide NSError's `userInfo` dictionary without having to actually construct a dictionary in Swift. However, this API can only be called once for a particular domain, so we have to make sure our check for an existing provider is synchronized with the setting. Otherwise, we get a race condition that could lead to an over-release.
- **Scope:** The bug only occurs when the same Swift error type is thrown on two different threads, and no error of that type has been thrown before, _and_ the timing is exactly wrong. The fix affects getting the user info for any Swift error.
- **Issue:** rdar://problem/27541751
- **Reviewed by:** @parkera, @DougGregor   
- **Risk:** Very low.
- **Testing:** Re-enabled the regression test that originally caught this issue. Tests passed locally with several runs under GuardMalloc where they had previously failed every fifth run or so.
