### PR TITLE
[PrintAsObjC] Handle typealiases in ObjC generics.

### DIFF
--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -1825,7 +1825,8 @@ public:
         if (TD == container)
           return;
 
-        if (finder.isWithinConstrainedObjCGeneric()) {
+        if (finder.isWithinConstrainedObjCGeneric() &&
+            isa<NominalTypeDecl>(TD)) {
           // We can delay individual members of classes; do so if necessary.
           if (isa<ClassDecl>(container)) {
             if (!tryRequire(TD)) {
@@ -1860,18 +1861,21 @@ public:
           if (!forwardDeclare(CD)) {
             (void)addImport(CD);
           }
-        } else if (auto PD = dyn_cast<ProtocolDecl>(TD))
+        } else if (auto PD = dyn_cast<ProtocolDecl>(TD)) {
           forwardDeclare(PD);
-        else if (addImport(TD))
-          return;
-        else if (auto ED = dyn_cast<EnumDecl>(TD))
-          forwardDeclare(ED);
-        else if (auto TAD = dyn_cast<TypeAliasDecl>(TD))
+        } else if (auto TAD = dyn_cast<TypeAliasDecl>(TD)) {
+          (void)addImport(TD);
+          // Just in case, make sure the underlying type is visible too.
           finder.visit(TAD->getUnderlyingType());
-        else if (isa<AbstractTypeParamDecl>(TD))
+        } else if (addImport(TD)) {
+          return;
+        } else if (auto ED = dyn_cast<EnumDecl>(TD)) {
+          forwardDeclare(ED);
+        } else if (isa<AbstractTypeParamDecl>(TD)) {
           llvm_unreachable("should not see type params here");
-        else
+        } else {
           assert(false && "unknown local type decl");
+        }
       });
 
       if (needsToBeIndividuallyDelayed) {

--- a/test/Inputs/clang-importer-sdk/usr/include/objc_generics.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/objc_generics.h
@@ -86,3 +86,5 @@ void takeGenericClass(__nullable GenericClass<NSString *> *thing);
 - (void)doThing:(__nonnull T<Pettable>)thing;
 @end
 
+typedef id <Fungible> FungibleObject;
+

--- a/test/PrintAsObjC/Inputs/custom-modules/module.map
+++ b/test/PrintAsObjC/Inputs/custom-modules/module.map
@@ -23,3 +23,7 @@ module OverrideBase [system] {
   header "override.h"
   export *
 }
+
+module OtherModule {
+  // Deliberately empty. Used by depends-on-swift-framework.swift.
+}

--- a/test/PrintAsObjC/Inputs/depends-on-swift-framework-helper.swift
+++ b/test/PrintAsObjC/Inputs/depends-on-swift-framework-helper.swift
@@ -1,0 +1,3 @@
+import objc_generics
+
+public typealias AliasForFungible = Fungible

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -711,6 +711,10 @@ public class NonObjCClass { }
   @objc func takeAndReturnGenericClass(_ x: GenericClass<NSString>?) -> GenericClass<AnyObject> { fatalError("") }
   // CHECK: - (FungibleContainer<id <Fungible>> * _Null_unspecified)takeAndReturnFungibleContainer:(FungibleContainer<Spoon *> * _Nonnull)x;
   @objc func takeAndReturnFungibleContainer(_ x: FungibleContainer<Spoon>) -> FungibleContainer<Fungible>! { fatalError("") }
+
+  typealias Dipper = Spoon
+  // CHECK: - (FungibleContainer<FungibleObject> * _Nonnull)fungibleContainerWithAliases:(FungibleContainer<Spoon *> * _Nullable)x;
+  @objc func fungibleContainerWithAliases(_ x: FungibleContainer<Dipper>?) -> FungibleContainer<FungibleObject> { fatalError("") }
 }
 // CHECK: @end
 

--- a/test/PrintAsObjC/depends-on-swift-framework.swift
+++ b/test/PrintAsObjC/depends-on-swift-framework.swift
@@ -1,0 +1,31 @@
+// RUN: rm -rf %t && mkdir %t
+
+// FIXME: BEGIN -enable-source-import hackaround
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+// FIXME: END -enable-source-import hackaround
+
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/Inputs/depends-on-swift-framework-helper.swift -module-name OtherModule
+
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/../Inputs/empty.h -emit-module -o %t %s -module-name main
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/../Inputs/empty.h -parse-as-library %t/main.swiftmodule -parse -emit-objc-header-path %t/main.h
+
+// RUN: %FileCheck %s < %t/main.h
+
+// RUN: %check-in-clang -I %S/Inputs/custom-modules %t/main.h
+// RUN: %check-in-clang -fno-modules -Qunused-arguments %t/main.h -include objc_generics.h
+
+// REQUIRES: objc_interop
+
+import Foundation
+import objc_generics
+import OtherModule
+
+// CHECK-LABEL: @interface Test
+public class Test: NSObject {
+  // CHECK: - (void)testSimpleTypealias:(id <Fungible> _Nonnull)_;
+  func testSimpleTypealias(_: AliasForFungible) {}
+  // CHECK: - (void)testGenericTypealias:(FungibleContainer<id <Fungible>> * _Nonnull)_;
+  func testGenericTypealias(_: FungibleContainer<AliasForFungible>) {}
+} // CHECK: @end


### PR DESCRIPTION
- **Explanation:** The ObjC header generator always tries to make sure a generic argument for an Objective-C class is fully-defined if the corresponding generic parameter has a constraint. However, this logic was mistakenly kicking in for typealiases defined in Swift, which the compiler doesn't actually emit in the generated header (it just uses the underlying type). This led to a crash. The fix just looks through _all_ typealiases to make sure their imports are resolved.
- **Scope:** Affects all typealiases used in `@objc` members. If this causes problems, the workaround of using underlying types should behave as before.
- **Issue:** [SR-2352](https://bugs.swift.org/browse/SR-2352)
- **Reviewed by:** @jckarter    
- **Risk:** Medium-low. While this is certainly a correct thing to do, it does mean more types are being visited than before, which may uncover other existing bugs.
- **Testing:** Added additional compiler regression tests.
