### PR TITLE
Prevent definite initialization from inserting spurious variable debug info.

### DIFF
--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1937,7 +1937,10 @@ SILValue LifetimeChecker::handleConditionalInitAssign() {
   B.setCurrentDebugScope(TheMemory.getFunction().getDebugScope());
   SILType IVType =
     SILType::getBuiltinIntegerType(NumMemoryElements, Module.getASTContext());
-  auto *ControlVariableBox = B.createAllocStack(Loc, IVType);
+  // Use an empty location for the alloc_stack. If Loc is variable declaration
+  // the alloc_stack would look like the storage of that variable.
+  auto *ControlVariableBox =
+      B.createAllocStack(RegularLocation(SourceLoc()), IVType);
   
   // Find all the return blocks in the function, inserting a dealloc_stack
   // before the return.

--- a/test/DebugInfo/conditional-assign.swift
+++ b/test/DebugInfo/conditional-assign.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-frontend %s -emit-sil -g -o - | %FileCheck  %s
+public protocol DelegateA {}
+public protocol DelegateB {}
+public protocol WithDelegate
+{
+    var delegate: DelegateA? { get }
+    func f() throws -> Int
+}
+public enum Err: Swift.Error {
+    case s(Int)
+}
+public class C {}
+public class M {
+    let field: C
+    var value : Int
+  // Verify that definite initialization doesn't create a bogus description of
+  // self pointing to the liveness bitvector.
+  
+  // CHECK: sil @_TFC4main1McfzT4fromPS_12WithDelegate__S0_
+  // CHECK: bb0
+  // CHECK-NEXT: %2 = alloc_stack $Builtin.Int2
+  // CHECK-NOT: let
+  // CHECK-NOT: name
+  // CHECK: scope
+    public init(from d: WithDelegate) throws {
+        guard let delegate = d.delegate as? DelegateB
+        else { throw Err.s(0) }
+        self.field = C()
+        let i: Int = try d.f()
+        value = i
+    }
+}


### PR DESCRIPTION
rdar://problem/28040875
