### PR TITLE
[SILOptimizer] simplify enum frontend pattern, add support for cross-basic block enums - rdar://problem/27640524

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -12,21 +12,22 @@
 
 #define DEBUG_TYPE "sil-combine"
 #include "SILCombiner.h"
+#include "swift/Basic/STLExtras.h"
+#include "swift/SIL/DebugUtils.h"
 #include "swift/SIL/DynamicCasts.h"
 #include "swift/SIL/PatternMatch.h"
 #include "swift/SIL/Projection.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILVisitor.h"
-#include "swift/SIL/DebugUtils.h"
-#include "swift/SILOptimizer/Analysis/AliasAnalysis.h"
 #include "swift/SILOptimizer/Analysis/ARCAnalysis.h"
+#include "swift/SILOptimizer/Analysis/AliasAnalysis.h"
 #include "swift/SILOptimizer/Analysis/CFG.h"
 #include "swift/SILOptimizer/Analysis/ValueTracking.h"
-#include "swift/SILOptimizer/Utils/Local.h"
 #include "swift/SILOptimizer/Utils/Devirtualize.h"
+#include "swift/SILOptimizer/Utils/Local.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/DenseMap.h"
 
 using namespace swift;
 using namespace swift::PatternMatch;
@@ -781,67 +782,116 @@ SILCombiner::visitInjectEnumAddrInst(InjectEnumAddrInst *IEAI) {
 
   // Ok, we have a payload enum, make sure that we have a store previous to
   // us...
-  SILBasicBlock::iterator II = IEAI->getIterator();
-  StoreInst *SI = nullptr;
-  InitEnumDataAddrInst *DataAddrInst = nullptr;
-  ApplyInst *AI = nullptr;
-  Operand *EnumInitOperand = nullptr;
-  for (;;) {
-    if (II == IEAI->getParent()->begin())
-      return nullptr;
-    --II;
-    SI = dyn_cast<StoreInst>(&*II);
-    if (SI) {
-      // Find a Store whose destination is taken from an init_enum_data_addr
-      // whose address is same allocation as our inject_enum_addr.
-      DataAddrInst = dyn_cast<InitEnumDataAddrInst>(SI->getDest());
-      if (DataAddrInst && DataAddrInst->getOperand() == IEAI->getOperand())
-        break;
-      SI = nullptr;
-    }
-    // Check whether we have an apply initializing the enum.
-    //  %iedai = init_enum_data_addr %enum_addr
-    //         = apply(%iedai,...)
-    //  inject_enum_addr %enum_addr
-    //
-    // We can localize the store to an alloc_stack.
-    // Allowing us to perform the same optimization as for the store.
-    //
-    //  %alloca = alloc_stack
-    //            apply(%alloca,...)
-    //  %load = load %alloca
-    //  %1 = enum $EnumType, $EnumType.case, %load
-    //  store %1 to %nopayload_addr
-    //
-    if ((AI = dyn_cast<ApplyInst>(&*II))) {
-      unsigned ArgIdx = 0;
-      for (auto &Opd : AI->getArgumentOperands()) {
-        // Found an apply that initializes the enum. We can optimize this by
-        // localizing the initialization to an alloc_stack and loading from it.
-        DataAddrInst = dyn_cast<InitEnumDataAddrInst>(Opd.get());
-        if (DataAddrInst && DataAddrInst->getOperand() == IEAI->getOperand() &&
-            ArgIdx < AI->getSubstCalleeType()->getNumIndirectResults()) {
-          EnumInitOperand = &Opd;
-          break;
-        }
-        ++ArgIdx;
-      }
-      // We found an enum initialization.
-      if (EnumInitOperand)
-        break;
-      AI = nullptr;
-    }
+  SILValue ASO = IEAI->getOperand();
+  if (!isa<AllocStackInst>(ASO)) {
+    return nullptr;
   }
-  // Found the store to this enum payload. Check if the store is the only use.
-  if (!DataAddrInst->hasOneUse())
+  InitEnumDataAddrInst *DataAddrInst = nullptr;
+  InjectEnumAddrInst *EnumAddrIns = nullptr;
+  llvm::SmallPtrSet<SILInstruction *, 32> WriteSet;
+  for (auto UsersIt : ASO->getUses()) {
+    SILInstruction *CurrUser = UsersIt->getUser();
+    if (CurrUser->isDeallocatingStack()) {
+      // we don't care about the dealloc stack instructions
+      continue;
+    }
+    if (isDebugInst(CurrUser) || isa<LoadInst>(CurrUser)) {
+      // These Instructions are a non-risky use we can ignore
+      continue;
+    }
+    if (auto *CurrInst = dyn_cast<InitEnumDataAddrInst>(CurrUser)) {
+      if (DataAddrInst) {
+        return nullptr;
+      }
+      DataAddrInst = CurrInst;
+      continue;
+    }
+    if (auto *CurrInst = dyn_cast<InjectEnumAddrInst>(CurrUser)) {
+      if (EnumAddrIns) {
+        return nullptr;
+      }
+      EnumAddrIns = CurrInst;
+      continue;
+    }
+    if (isa<StoreInst>(CurrUser)) {
+      // The only MayWrite Instruction we can safely handle
+      WriteSet.insert(CurrUser);
+      continue;
+    }
+    // It is too risky to continue if it is any other instruction.
+    return nullptr;
+  }
+
+  if (!DataAddrInst || !EnumAddrIns) {
+    return nullptr;
+  }
+  assert((EnumAddrIns == IEAI) &&
+         "Found InitEnumDataAddrInst differs from IEAI");
+  // Found the DataAddrInst to this enum payload. Check if it has only use.
+  if (!hasOneNonDebugUse(DataAddrInst))
     return nullptr;
 
+  StoreInst *SI = dyn_cast<StoreInst>(getSingleNonDebugUser(DataAddrInst));
+  ApplyInst *AI = dyn_cast<ApplyInst>(getSingleNonDebugUser(DataAddrInst));
+  if (!SI && !AI) {
+    return nullptr;
+  }
+
+  // Make sure the enum pattern instructions are the only ones which write to
+  // this location
+  if (!WriteSet.empty()) {
+    // Analyze the instructions (implicit dominator analysis)
+    // If we find any of MayWriteSet, return nullptr
+    SILBasicBlock *InitEnumBB = DataAddrInst->getParent();
+    assert(InitEnumBB && "DataAddrInst is not in a valid Basic Block");
+    llvm::SmallVector<SILInstruction *, 64> Worklist;
+    Worklist.push_back(IEAI);
+    llvm::SmallPtrSet<SILBasicBlock *, 16> Preds;
+    Preds.insert(IEAI->getParent());
+    while (!Worklist.empty()) {
+      SILInstruction *CurrIns = Worklist.pop_back_val();
+      SILBasicBlock *CurrBB = CurrIns->getParent();
+
+      if (CurrBB->isEntry() && CurrBB != InitEnumBB) {
+        // reached prologue without encountering the init bb
+        return nullptr;
+      }
+
+      for (llvm::iplist<SILInstruction>::reverse_iterator InsIt(
+               CurrIns->getIterator());
+           InsIt != CurrBB->rend(); ++InsIt) {
+        SILInstruction *Ins = &*InsIt;
+        if (Ins == DataAddrInst) {
+          // don't care about what comes before init enum in the basic block
+          break;
+        }
+        if (WriteSet.count(Ins) != 0) {
+          return nullptr;
+        }
+      }
+
+      if (CurrBB == InitEnumBB) {
+        continue;
+      }
+
+      // Go to predecessors and do all that again
+      for (SILBasicBlock *Pred : CurrBB->getPreds()) {
+        // If it's already in the set, then we've already queued and/or
+        // processed the predecessors.
+        if (Preds.insert(Pred).second) {
+          Worklist.push_back(&*Pred->rbegin());
+        }
+      }
+    }
+  }
+
   if (SI) {
+    assert((SI->getDest() == DataAddrInst) &&
+           "Can't find StoreInst with DataAddrInst as its destination");
     // In that case, create the payload enum/store.
-    EnumInst *E =
-      Builder.createEnum(DataAddrInst->getLoc(), SI->getSrc(),
-                         DataAddrInst->getElement(),
-                         DataAddrInst->getOperand()->getType().getObjectType());
+    EnumInst *E = Builder.createEnum(
+        DataAddrInst->getLoc(), SI->getSrc(), DataAddrInst->getElement(),
+        DataAddrInst->getOperand()->getType().getObjectType());
     Builder.createStore(DataAddrInst->getLoc(), E, DataAddrInst->getOperand());
     // Cleanup.
     eraseInstFromFunction(*SI);
@@ -849,7 +899,39 @@ SILCombiner::visitInjectEnumAddrInst(InjectEnumAddrInst *IEAI) {
     return eraseInstFromFunction(*IEAI);
   }
 
+  // Check whether we have an apply initializing the enum.
+  //  %iedai = init_enum_data_addr %enum_addr
+  //         = apply(%iedai,...)
+  //  inject_enum_addr %enum_addr
+  //
+  // We can localize the store to an alloc_stack.
+  // Allowing us to perform the same optimization as for the store.
+  //
+  //  %alloca = alloc_stack
+  //            apply(%alloca,...)
+  //  %load = load %alloca
+  //  %1 = enum $EnumType, $EnumType.case, %load
+  //  store %1 to %nopayload_addr
+  //
   assert(AI && "Must have an apply");
+  unsigned ArgIdx = 0;
+  Operand *EnumInitOperand = nullptr;
+  for (auto &Opd : AI->getArgumentOperands()) {
+    // Found an apply that initializes the enum. We can optimize this by
+    // localizing the initialization to an alloc_stack and loading from it.
+    DataAddrInst = dyn_cast<InitEnumDataAddrInst>(Opd.get());
+    if (DataAddrInst && DataAddrInst->getOperand() == IEAI->getOperand() &&
+        ArgIdx < AI->getSubstCalleeType()->getNumIndirectResults()) {
+      EnumInitOperand = &Opd;
+      break;
+    }
+    ++ArgIdx;
+  }
+
+  if (!EnumInitOperand) {
+    return nullptr;
+  }
+
   // Localize the address access.
   Builder.setInsertionPoint(AI);
   auto *AllocStack = Builder.createAllocStack(DataAddrInst->getLoc(),

--- a/test/SILOptimizer/sil_combine_enums.sil
+++ b/test/SILOptimizer/sil_combine_enums.sil
@@ -157,6 +157,93 @@ bb0(%0 : $*Int32, %1 : $Builtin.Int32):
   return %i : $Int32
 }
 
+// CHECK-LABEL: sil @canonicalize_init_enum_data_addr_diff_basic_blocks
+// CHECK-NOT: init_enum_data_addr
+// CHECK-NOT: inject_enum_addr
+// CHECK: enum $Optional<Int32>, #Optional.some!enumelt.1
+// CHECK-NOT: inject_enum_addr
+// CHECK: return
+sil @canonicalize_init_enum_data_addr_diff_basic_blocks : $@convention(thin) (@inout Int32, Builtin.Int32) -> Int32 {
+bb0(%0 : $*Int32, %1 : $Builtin.Int32):
+  %s1 = alloc_stack $Optional<Int32>
+  %e1 = init_enum_data_addr %s1 : $*Optional<Int32>, #Optional.some!enumelt.1
+  %v = load %0 : $*Int32
+  store %v to %e1 : $*Int32
+  %i1 = integer_literal $Builtin.Int32, 1
+  %i0 = integer_literal $Builtin.Int1, 0
+  %a = builtin "sadd_with_overflow_Int32"(%1 : $Builtin.Int32, %i1 : $Builtin.Int32, %i0 : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1)
+  %w = tuple_extract %a : $(Builtin.Int32, Builtin.Int1), 0
+  %i = struct $Int32 (%w : $Builtin.Int32)
+  br bb1
+
+bb1:                                              // Preds: bb0
+  store %i to %0 : $*Int32
+  inject_enum_addr %s1 : $*Optional<Int32>, #Optional.some!enumelt.1
+  dealloc_stack %s1 : $*Optional<Int32>
+  return %i : $Int32
+}
+
+// CHECK-LABEL: sil @fail_to_canonicalize_init_enum_data_addr_reach_entry
+// CHECK: init_enum_data_addr
+// CHECK: inject_enum_addr
+// CHECK-NOT: enum $Optional<Int32>, #Optional.some!enumelt.1
+// CHECK: return
+sil @fail_to_canonicalize_init_enum_data_addr_reach_entry : $@convention(thin) (@inout Int32, Builtin.Int32, Builtin.Int1) -> Int32 {
+bb0(%0 : $*Int32, %1 : $Builtin.Int32, %2 : $Builtin.Int1):
+  %s1 = alloc_stack $Optional<Int32>
+  %i2 = load %0 : $*Int32
+  %en = enum $Optional<Int32>, #Optional.none!enumelt
+  store %en to %s1 : $*Optional<Int32>
+  cond_br %2, bb1, bb2
+
+bb1:
+  %e1 = init_enum_data_addr %s1 : $*Optional<Int32>, #Optional.some!enumelt.1
+  %v = load %0 : $*Int32
+  store %v to %e1 : $*Int32
+  %i1 = integer_literal $Builtin.Int32, 1
+  %i0 = integer_literal $Builtin.Int1, 0
+  %a = builtin "sadd_with_overflow_Int32"(%1 : $Builtin.Int32, %i1 : $Builtin.Int32, %i0 : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1)
+  %w = tuple_extract %a : $(Builtin.Int32, Builtin.Int1), 0
+  %i = struct $Int32 (%w : $Builtin.Int32)
+  store %i to %0 : $*Int32
+  br bb2
+
+bb2:                                              // Preds: bb0 bb1
+  inject_enum_addr %s1 : $*Optional<Int32>, #Optional.some!enumelt.1
+  dealloc_stack %s1 : $*Optional<Int32>
+  return %i2 : $Int32
+}
+
+// CHECK-LABEL: sil @fail_to_canonicalize_init_enum_data_addr
+// CHECK: init_enum_data_addr
+// CHECK: inject_enum_addr
+// CHECK-NOT: enum $Optional<Int32>, #Optional.some!enumelt.1
+// CHECK: return
+sil @fail_to_canonicalize_init_enum_data_addr : $@convention(thin) (@inout Int32, Builtin.Int32) -> Int32 {
+bb0(%0 : $*Int32, %1 : $Builtin.Int32):
+  %s1 = alloc_stack $Optional<Int32>
+  %e1 = init_enum_data_addr %s1 : $*Optional<Int32>, #Optional.some!enumelt.1
+  %v = load %0 : $*Int32
+  store %v to %e1 : $*Int32
+  %i1 = integer_literal $Builtin.Int32, 1
+  %i0 = integer_literal $Builtin.Int1, 0
+  %a = builtin "sadd_with_overflow_Int32"(%1 : $Builtin.Int32, %i1 : $Builtin.Int32, %i0 : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1)
+  %w = tuple_extract %a : $(Builtin.Int32, Builtin.Int1), 0
+  %i = struct $Int32 (%w : $Builtin.Int32)
+  br bb1
+  
+bb1:
+  %o = enum $Optional<Int32>, #Optional.none!enumelt
+  store %o to %s1 : $*Optional<Int32>
+  br bb2
+
+bb2:
+  store %i to %0 : $*Int32
+  inject_enum_addr %s1 : $*Optional<Int32>, #Optional.some!enumelt.1
+  dealloc_stack %s1 : $*Optional<Int32>
+  return %i : $Int32
+}
+
 // Check the cond_br(select_enum) -> switch_enum conversion.
 //
 // CHECK-LABEL: sil @convert_select_enum_cond_br_to_switch_enum


### PR DESCRIPTION
Adds support for cross-basic block enums - simplifies the following frontend pattern:

%payload_addr = init_enum_data_addr %payload_allocation
store %payload to %payload_addr
inject_enum_addr %payload_allocation, $EnumType.case

for a concrete enum type $EnumType.case to:
 %1 = enum $EnumType, $EnumType.case, %payload
store %1 to %payload_addr
