### PR TITLE
ARC: fix epilog-release-matcher. It has to handle dealloc_ref instruc…

### DIFF
--- a/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
@@ -790,6 +790,11 @@ collectMatchingReleases(SILBasicBlock *BB) {
   for (auto II = std::next(BB->rbegin()), IE = BB->rend(); II != IE; ++II) {
     // If we do not have a release_value or strong_release. We can continue
     if (!isa<ReleaseValueInst>(*II) && !isa<StrongReleaseInst>(*II)) {
+
+      // We cannot match a final release if it is followed by a dealloc_ref.
+      if (isa<DeallocRefInst>(*II))
+        break;
+
       // We do not know what this instruction is, do a simple check to make sure
       // that it does not decrement the reference count of any of its operand. 
       //

--- a/test/SILOptimizer/epilogue_release_dumper.sil
+++ b/test/SILOptimizer/epilogue_release_dumper.sil
@@ -94,6 +94,19 @@ bb0(%0 : $foo, %1 : $*foo):
   return %3 : $()
 }
 
+// CHECK-LABEL: START: sil @dealloc_ref_after_last_release
+// CHECK: [[IN1:%.*]] = argument of bb0 : $foo
+// CHECK-NOT: strong_release [[IN1]] : $foo
+// CHECK: END: sil @dealloc_ref_after_last_release
+sil @dealloc_ref_after_last_release : $@convention(thin) (@owned foo) -> () {
+bb0(%0 : $foo):
+  strong_retain %0 : $foo
+  strong_release %0 : $foo
+  dealloc_ref %0 : $foo
+  %3 = tuple ()
+  return %3 : $()
+}
+
 // CHECK-LABEL: START: sil @single_release_bar
 // CHECK: [[IN1:%.*]] = argument of bb0 : $bar
 // CHECK: strong_release [[IN1]] : $bar


### PR DESCRIPTION
<!-- What's in this pull request? -->

Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

…tions.

This fixes a problem which might result in converting the owned self argument of a deallocating deinitializer into a guaranteed argument.

rdar://problem/28096460
