### PR TITLE
runtime: rename _TMps8Hashable to HashableProtocolDescriptor

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -231,4 +231,25 @@
 
 #endif
 
+#if !defined(__USER_LABEL_PREFIX__)
+#error __USER_LABEL_PREFIX__ is undefined
+#endif
+
+// Workaround the bug of clang in Cygwin 64bit
+// https://llvm.org/bugs/show_bug.cgi?id=26744
+#if defined(__CYGWIN__) && defined(__x86_64__)
+#undef __USER_LABEL_PREFIX__
+#define __USER_LABEL_PREFIX__
+#endif
+
+#define SWIFT_GLUE_EXPANDED(a, b) a##b
+#define SWIFT_GLUE(a, b) SWIFT_GLUE_EXPANDED(a, b)
+#define SWIFT_SYMBOL_NAME(name) SWIFT_GLUE(__USER_LABEL_PREFIX__, name)
+
+#define SWIFT_QUOTE_EXPANDED(literal) #literal
+#define SWIFT_QUOTE(literal) SWIFT_QUOTE_EXPANDED(literal)
+
+#define SWIFT_QUOTED_SYMBOL_NAME(name)                                   \
+  SWIFT_QUOTE(SWIFT_SYMBOL_NAME(name))
+
 #endif // SWIFT_RUNTIME_CONFIG_H

--- a/stdlib/public/runtime/AnyHashableSupport.cpp
+++ b/stdlib/public/runtime/AnyHashableSupport.cpp
@@ -75,7 +75,7 @@ static const Metadata *findHashableBaseTypeImpl(const Metadata *type) {
     return entry->baseTypeThatConformsToHashable;
   }
   if (!KnownToConformToHashable &&
-      !swift_conformsToProtocol(type, &_TMps8Hashable)) {
+      !swift_conformsToProtocol(type, &HashableProtocolDescriptor)) {
     // Don't cache the negative response because we don't invalidate
     // this cache when a new conformance is loaded dynamically.
     return nullptr;
@@ -88,7 +88,7 @@ static const Metadata *findHashableBaseTypeImpl(const Metadata *type) {
         _swift_class_getSuperclass(baseTypeThatConformsToHashable);
     if (!superclass)
       break;
-    if (!swift_conformsToProtocol(superclass, &_TMps8Hashable))
+    if (!swift_conformsToProtocol(superclass, &HashableProtocolDescriptor))
       break;
     baseTypeThatConformsToHashable = superclass;
   }
@@ -148,7 +148,7 @@ extern "C" void _swift_stdlib_makeAnyHashableUpcastingToHashableBaseType(
           getValueFromSwiftValue(srcSwiftValue);
 
       if (auto unboxedHashableWT =
-              swift_conformsToProtocol(type, &_TMps8Hashable)) {
+              swift_conformsToProtocol(type, &HashableProtocolDescriptor)) {
         ValueBuffer unboxedCopyBuf;
         auto unboxedValueCopy = unboxedType->vw_initializeBufferWithCopy(
             &unboxedCopyBuf, const_cast<OpaqueValue *>(unboxedValue));

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -892,9 +892,6 @@ extern "C" id swift_stdlib_getErrorEmbeddedNSErrorIndirect(
 /// Nominal type descriptor for Swift.AnyHashable.
 extern "C" const NominalTypeDescriptor _TMnVs11AnyHashable;
 
-/// Protocol descriptor for Swift.Hashable.
-extern "C" const ProtocolDescriptor _TMps8Hashable;
-
 static bool isAnyHashableType(const StructMetadata *type) {
   return type->getDescription() == &_TMnVs11AnyHashable;
 }
@@ -914,7 +911,7 @@ static bool _dynamicCastToAnyHashable(OpaqueValue *destination,
                                       DynamicCastFlags flags) {
   // Look for a conformance to Hashable.
   auto hashableConformance = reinterpret_cast<const HashableWitnessTable *>(
-      swift_conformsToProtocol(sourceType, &_TMps8Hashable));
+      swift_conformsToProtocol(sourceType, &HashableProtocolDescriptor));
 
   // If we don't find one, the cast fails.
   if (!hashableConformance) {

--- a/stdlib/public/runtime/ErrorObject.mm
+++ b/stdlib/public/runtime/ErrorObject.mm
@@ -317,7 +317,7 @@ const HashableWitnessTable *SwiftError::getHashableConformance() const {
   const HashableWitnessTable *expectedWT = nullptr;
   const HashableWitnessTable *wt =
       reinterpret_cast<const HashableWitnessTable *>(
-          swift_conformsToProtocol(type, &_TMps8Hashable));
+          swift_conformsToProtocol(type, &HashableProtocolDescriptor));
   hashableConformance.compare_exchange_strong(
       expectedWT, wt ? wt : reinterpret_cast<const HashableWitnessTable *>(1),
       std::memory_order_acq_rel);

--- a/stdlib/public/runtime/Reflection.mm
+++ b/stdlib/public/runtime/Reflection.mm
@@ -12,6 +12,7 @@
 
 #include "swift/Basic/Fallthrough.h"
 #include "swift/Runtime/Reflection.h"
+#include "swift/Runtime/Config.h"
 #include "swift/Runtime/HeapObject.h"
 #include "swift/Runtime/Metadata.h"
 #include "swift/Runtime/Enum.h"
@@ -922,71 +923,51 @@ swift_ClassMirror_quickLookObject(HeapObject *owner, const OpaqueValue *value,
   
 // -- MagicMirror implementation.
 
-#if !defined(__USER_LABEL_PREFIX__)
-#error __USER_LABEL_PREFIX__ is undefined
-#endif
-
-// Workaround the bug of clang in Cygwin 64bit
-// https://llvm.org/bugs/show_bug.cgi?id=26744
-#if defined(__CYGWIN__) && defined(__x86_64__)
-#undef __USER_LABEL_PREFIX__
-#define __USER_LABEL_PREFIX__
-#endif
-
-#define GLUE_EXPANDED(a, b) a##b
-#define GLUE(a, b) GLUE_EXPANDED(a, b)
-#define SYMBOL_NAME(name) GLUE(__USER_LABEL_PREFIX__, name)
-
-#define QUOTE_EXPANDED(literal) #literal
-#define QUOTE(literal) QUOTE_EXPANDED(literal)
-
-#define QUOTED_SYMBOL_NAME(name) QUOTE(SYMBOL_NAME(name))
-
 // Addresses of the type metadata and Mirror witness tables for the primitive
 // mirrors.
 extern "C" const Metadata OpaqueMirrorMetadata
-  __asm__(QUOTED_SYMBOL_NAME(_TMVs13_OpaqueMirror));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TMVs13_OpaqueMirror));
 extern "C" const MirrorWitnessTable OpaqueMirrorWitnessTable
-  __asm__(QUOTED_SYMBOL_NAME(_TWPVs13_OpaqueMirrors7_Mirrors));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TWPVs13_OpaqueMirrors7_Mirrors));
 extern "C" const Metadata TupleMirrorMetadata
-  __asm__(QUOTED_SYMBOL_NAME(_TMVs12_TupleMirror));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TMVs12_TupleMirror));
 extern "C" const MirrorWitnessTable TupleMirrorWitnessTable
-  __asm__(QUOTED_SYMBOL_NAME(_TWPVs12_TupleMirrors7_Mirrors));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TWPVs12_TupleMirrors7_Mirrors));
 
 extern "C" const Metadata StructMirrorMetadata
-  __asm__(QUOTED_SYMBOL_NAME(_TMVs13_StructMirror));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TMVs13_StructMirror));
 extern "C" const MirrorWitnessTable StructMirrorWitnessTable
-  __asm__(QUOTED_SYMBOL_NAME(_TWPVs13_StructMirrors7_Mirrors));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TWPVs13_StructMirrors7_Mirrors));
 
 extern "C" const Metadata EnumMirrorMetadata
-  __asm__(QUOTED_SYMBOL_NAME(_TMVs11_EnumMirror));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TMVs11_EnumMirror));
 extern "C" const MirrorWitnessTable EnumMirrorWitnessTable
-  __asm__(QUOTED_SYMBOL_NAME(_TWPVs11_EnumMirrors7_Mirrors));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TWPVs11_EnumMirrors7_Mirrors));
 
 extern "C" const Metadata ClassMirrorMetadata
-  __asm__(QUOTED_SYMBOL_NAME(_TMVs12_ClassMirror));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TMVs12_ClassMirror));
 extern "C" const MirrorWitnessTable ClassMirrorWitnessTable
-  __asm__(QUOTED_SYMBOL_NAME(_TWPVs12_ClassMirrors7_Mirrors));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TWPVs12_ClassMirrors7_Mirrors));
 
 extern "C" const Metadata ClassSuperMirrorMetadata
-  __asm__(QUOTED_SYMBOL_NAME(_TMVs17_ClassSuperMirror));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TMVs17_ClassSuperMirror));
 extern "C" const MirrorWitnessTable ClassSuperMirrorWitnessTable
-  __asm__(QUOTED_SYMBOL_NAME(_TWPVs17_ClassSuperMirrors7_Mirrors));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TWPVs17_ClassSuperMirrors7_Mirrors));
 
 extern "C" const Metadata MetatypeMirrorMetadata
-  __asm__(QUOTED_SYMBOL_NAME(_TMVs15_MetatypeMirror));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TMVs15_MetatypeMirror));
 extern "C" const MirrorWitnessTable MetatypeMirrorWitnessTable
-  __asm__(QUOTED_SYMBOL_NAME(_TWPVs15_MetatypeMirrors7_Mirrors));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TWPVs15_MetatypeMirrors7_Mirrors));
 
 #if SWIFT_OBJC_INTEROP
 extern "C" const Metadata ObjCMirrorMetadata
-  __asm__(QUOTED_SYMBOL_NAME(_TMVs11_ObjCMirror));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TMVs11_ObjCMirror));
 extern "C" const MirrorWitnessTable ObjCMirrorWitnessTable
-  __asm__(QUOTED_SYMBOL_NAME(_TWPVs11_ObjCMirrors7_Mirrors));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TWPVs11_ObjCMirrors7_Mirrors));
 extern "C" const Metadata ObjCSuperMirrorMetadata
-  __asm__(QUOTED_SYMBOL_NAME(_TMVs16_ObjCSuperMirror));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TMVs16_ObjCSuperMirror));
 extern "C" const MirrorWitnessTable ObjCSuperMirrorWitnessTable
-  __asm__(QUOTED_SYMBOL_NAME(_TWPVs16_ObjCSuperMirrors7_Mirrors));
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TWPVs16_ObjCSuperMirrors7_Mirrors));
 #endif
 
 /// \param owner passed at +1, consumed.

--- a/stdlib/public/runtime/SwiftHashableSupport.h
+++ b/stdlib/public/runtime/SwiftHashableSupport.h
@@ -13,14 +13,15 @@
 #ifndef SWIFT_RUNTIME_SWIFT_HASHABLE_SUPPORT_H
 #define SWIFT_RUNTIME_SWIFT_HASHABLE_SUPPORT_H
 
+#include "swift/Runtime/Config.h"
 #include "swift/Runtime/Metadata.h"
 #include <stdint.h>
 
 namespace swift {
 namespace hashable_support {
 
-/// The name demangles to "protocol descriptor for Swift.Hashable".
-extern "C" const ProtocolDescriptor _TMps8Hashable;
+extern "C" const ProtocolDescriptor HashableProtocolDescriptor
+  __asm__(SWIFT_QUOTED_SYMBOL_NAME(_TMps8Hashable));
 
 struct HashableWitnessTable;
 

--- a/stdlib/public/runtime/SwiftValue.mm
+++ b/stdlib/public/runtime/SwiftValue.mm
@@ -111,7 +111,7 @@ SwiftValueHeader::getHashableConformance() const {
   const HashableWitnessTable *expectedWT = nullptr;
   const HashableWitnessTable *wt =
       reinterpret_cast<const HashableWitnessTable *>(
-          swift_conformsToProtocol(type, &_TMps8Hashable));
+          swift_conformsToProtocol(type, &HashableProtocolDescriptor));
   hashableConformance.compare_exchange_strong(
       expectedWT, wt ? wt : reinterpret_cast<const HashableWitnessTable *>(1),
       std::memory_order_acq_rel);


### PR DESCRIPTION
Use `__asm__` to give `_TMps8Hashable` a better name in C++ sources.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
