### PR TITLE
[SR-2451] Clarify function_type_argument_label error msg

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -620,7 +620,7 @@ ERROR(expected_type_before_arrow,none,
 ERROR(expected_type_after_arrow,none,
       "expected type after '->'", ())
 ERROR(function_type_argument_label,none,
-      "function types cannot have argument label %0; use '_' instead",
+      "function types cannot have argument labels; use '_' before %0",
       (Identifier))
 
 // Enum Types

--- a/test/type/function/labels.swift
+++ b/test/type/function/labels.swift
@@ -1,27 +1,27 @@
 // RUN: %target-swift-frontend -module-name TestModule -parse -verify %s
 
 // Function type with various forms of argument label.
-typealias Function1 = (a: Int,   // expected-error{{function types cannot have argument label 'a'; use '_' instead}}{{24-24=_ }}
+typealias Function1 = (a: Int,   // expected-error{{function types cannot have argument labels; use '_' before 'a'}}{{24-24=_ }}
                        _ b: Int, // okay
-                       c d: Int, // expected-error{{function types cannot have argument label 'c'; use '_' instead}}{{24-25=_}}
-                       e _: Int, // expected-error{{function types cannot have argument label 'e'; use '_' instead}}{{24-29=}}
+                       c d: Int, // expected-error{{function types cannot have argument labels; use '_' before 'c'}}{{24-25=_}}
+                       e _: Int, // expected-error{{function types cannot have argument labels; use '_' before 'e'}}{{24-29=}}
                        _: Int,   // okay
                        Int)      // okay
     -> Int
 
 // Throwing versions.
-typealias Function2 = (a: Int,   // expected-error{{function types cannot have argument label 'a'; use '_' instead}}{{24-24=_ }}
+typealias Function2 = (a: Int,   // expected-error{{function types cannot have argument labels; use '_' before 'a'}}{{24-24=_ }}
                        _ b: Int, // okay
-                       c d: Int, // expected-error{{function types cannot have argument label 'c'; use '_' instead}}{{24-25=_}}
-                       e _: Int, // expected-error{{function types cannot have argument label 'e'; use '_' instead}}{{24-29=}}
+                       c d: Int, // expected-error{{function types cannot have argument labels; use '_' before 'c'}}{{24-25=_}}
+                       e _: Int, // expected-error{{function types cannot have argument labels; use '_' before 'e'}}{{24-29=}}
                        _: Int,   // okay
                        Int)      // okay
     throws -> Int
 
-typealias Function3 = (a: Int,   // expected-error{{function types cannot have argument label 'a'; use '_' instead}}{{24-24=_ }}
+typealias Function3 = (a: Int,   // expected-error{{function types cannot have argument labels; use '_' before 'a'}}{{24-24=_ }}
                        _ b: Int, // okay
-                       c d: Int, // expected-error{{function types cannot have argument label 'c'; use '_' instead}}{{24-25=_}}
-                       e _: Int, // expected-error{{function types cannot have argument label 'e'; use '_' instead}}{{24-29=}}
+                       c d: Int, // expected-error{{function types cannot have argument labels; use '_' before 'c'}}{{24-25=_}}
+                       e _: Int, // expected-error{{function types cannot have argument labels; use '_' before 'e'}}{{24-29=}}
                        _: Int,   // okay
                        Int)      // okay
     rethrows -> Int              // expected-error{{only function declarations may be marked 'rethrows'}}


### PR DESCRIPTION
<!-- What's in this pull request? -->

This pull request seeks to add clarity to the error message that is displayed when a function type contains argument labels.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-2451](https://bugs.swift.org/browse/SR-2451).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
