### PR TITLE
send detailed log for failing libdispatch test to stdout

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2604,7 +2604,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 LIBDISPATCH_BUILD_DIR=$(build_directory ${host} ${product})
                 echo "--- Running tests for ${product} ---"
                 with_pushd "${LIBDISPATCH_BUILD_DIR}" \
-                    call make check
+                    call env VERBOSE=1 make check
                 echo "--- Finished tests for ${product} ---"
                 continue
                 ;;


### PR DESCRIPTION
<!-- What's in this pull request? -->

Change to how libdispatch tests are run to enable detailed output of failed test cases to be captured by the Swift CI system.  By setting `VERBOSE` before invoking `make check` we tell the automake test harness that the log file for any failed testcase should be sent to stdout when it summarizes the result of running the testsuite.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
