### PR TITLE
[SILOptimizer] Fix let constant of non-class protocol type being mutable

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -173,6 +173,9 @@ ERROR(immutable_value_passed_inout,none,
 ERROR(assignment_to_immutable_value,none,
       "immutable value '%0' may not be assigned to",
       (StringRef))
+ERROR(mutating_protocol_witness_method_on_let_constant,none,
+      "cannot perform mutating operation: '%0' is a 'let' constant",
+      (StringRef))
 
 
 // Control flow diagnostics.

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -518,6 +518,7 @@ namespace {
     
 
     void handleStoreUse(unsigned UseID);
+    void handleLoadUse(unsigned UseID);
     void handleInOutUse(const DIMemoryUse &Use);
     void handleEscapeUse(const DIMemoryUse &Use);
 
@@ -807,15 +808,16 @@ void LifetimeChecker::doIt() {
       handleStoreUse(i);
       break;
 
-    case DIUseKind::IndirectIn:
-    case DIUseKind::Load: {
+    case DIUseKind::IndirectIn: {
       bool IsSuperInitComplete, FailedSelfUse;
       // If the value is not definitively initialized, emit an error.
       if (!isInitializedAtUse(Use, &IsSuperInitComplete, &FailedSelfUse))
         handleLoadUseFailure(Use, IsSuperInitComplete, FailedSelfUse);
       break;
     }
-
+    case DIUseKind::Load:
+      handleLoadUse(i);
+      break;
     case DIUseKind::InOutUse:
       handleInOutUse(Use);
       break;
@@ -855,6 +857,55 @@ void LifetimeChecker::doIt() {
     handleConditionalDestroys(ControlVariable);
 }
 
+void LifetimeChecker::handleLoadUse(unsigned UseID) {
+  DIMemoryUse &Use = Uses[UseID];
+  SILInstruction *LoadInst = Use.Inst;
+
+  bool IsSuperInitComplete, FailedSelfUse;
+  // If the value is not definitively initialized, emit an error.
+  if (!isInitializedAtUse(Use, &IsSuperInitComplete, &FailedSelfUse))
+    return handleLoadUseFailure(Use, IsSuperInitComplete, FailedSelfUse);
+
+  // If this is an OpenExistentialAddrInst in preparation for applying
+  // a witness method, analyze its use to make sure, that no mutation of
+  // lvalue let constants occurs.
+  auto* OEAI = dyn_cast<OpenExistentialAddrInst>(LoadInst);
+  if (OEAI != nullptr && TheMemory.isElementLetProperty(Use.FirstElement)) {
+    for (auto OEAUse : OEAI->getUses()) {
+      auto* AI = dyn_cast<ApplyInst>(OEAUse->getUser());
+
+      if (AI == nullptr)
+        // User is not an ApplyInst
+        continue;
+
+      unsigned OperandNumber = OEAUse->getOperandNumber();
+      if (OperandNumber < 1 || OperandNumber > AI->getNumCallArguments())
+        // Not used as a call argument
+        continue;
+
+      unsigned ArgumentNumber = OperandNumber - 1;
+
+      CanSILFunctionType calleeType = AI->getSubstCalleeType();
+      SILParameterInfo parameterInfo = calleeType->getParameters()[ArgumentNumber];
+
+      if (!parameterInfo.isIndirectMutating() ||
+          parameterInfo.getType().isAnyClassReferenceType())
+        continue;
+
+      if (!shouldEmitError(LoadInst))
+        continue;
+
+      std::string PropertyName;
+      auto *VD = TheMemory.getPathStringToElement(Use.FirstElement, PropertyName);
+      diagnose(Module, LoadInst->getLoc(),
+               diag::mutating_protocol_witness_method_on_let_constant, PropertyName);
+
+      if (auto *Var = dyn_cast<VarDecl>(VD)) {
+        Var->emitLetToVarNoteIfSimple(nullptr);
+      }
+    }
+  }
+}
 
 void LifetimeChecker::handleStoreUse(unsigned UseID) {
   DIMemoryUse &InstInfo = Uses[UseID];

--- a/test/SILOptimizer/definite_init_lvalue_let_witness_methods.swift
+++ b/test/SILOptimizer/definite_init_lvalue_let_witness_methods.swift
@@ -1,0 +1,61 @@
+// RUN: %target-swift-frontend -emit-sil -disable-objc-attr-requires-foundation-module -verify %s
+
+// High-level tests that DI rejects passing let constants to
+// mutating witness methods
+
+
+// Mark: General Definitions
+
+protocol TestProtocol {
+    var foo: Int { get set }
+}
+
+struct TestStruct: TestProtocol {
+    var foo: Int
+}
+
+// Mark: - Case1: Illegaly mutating let property of class in initializer
+
+class TestClass {
+    let testObject: TestProtocol // expected-note {{change 'let' to 'var' to make it mutable}}
+    init() {
+        testObject = TestStruct(foo: 42)
+        testObject.foo = 666 // expected-error {{cannot perform mutating operation: 'self.testObject' is a 'let' constant}}
+    }
+}
+
+// Mark: - Case2: Illegaly mutating global let constant
+
+let testObject: TestProtocol  // expected-note {{change 'let' to 'var' to make it mutable}}
+testObject = TestStruct(foo: 42)
+
+testObject.foo = 666 // expected-error {{cannot perform mutating operation: 'testObject' is a 'let' constant}}
+
+extension TestProtocol {
+    mutating func messThingsUp() {
+        foo = 666
+    }
+}
+
+// Mark: - Case3: Illegaly muatating let constant in a function scope
+
+let testObject2: TestProtocol  // expected-note {{change 'let' to 'var' to make it mutable}}
+testObject2 = TestStruct(foo: 42)
+testObject2.messThingsUp() // expected-error {{cannot perform mutating operation: 'testObject2' is a 'let' constant}}
+
+func testFunc() {
+    let testObject: TestProtocol // expected-note {{change 'let' to 'var' to make it mutable}}
+
+    testObject = TestStruct(foo: 42)
+    testObject.foo = 666 // expected-error {{cannot perform mutating operation: 'testObject' is a 'let' constant}}
+}
+
+// Mark: - Case4: Illegaly passing a let constants property as an inout parameter
+
+let testObject3: TestProtocol  // expected-note {{change 'let' to 'var' to make it mutable}}
+testObject3 = TestStruct(foo: 42)
+
+func mutateThis(mutatee: inout Int) {
+    mutatee = 666
+}
+mutateThis(mutatee: &testObject3.foo) // expected-error {{cannot perform mutating operation: 'testObject3' is a 'let' constant}}


### PR DESCRIPTION
In certain cases the Swift compiler currently allows mutating a let constant containing structs and enums.

This pull requests extends the checks in `LifetimeChecker` in `SILOptimizer/Mandatory/DefiniteInitialization.cpp` to catch when the memory object corresponding to a let constant is used as an inout parameter in a protocol witness method.
### Code examples

``` swift
protocol TestProtocol {
    var foo: Int { get set }
}

struct TestStruct: TestProtocol {
    var foo: Int
}

let testObject: TestProtocol
testObject = TestStruct(foo: 42)

testObject.foo = 666       // No compile time error despite mutating
                           // a struct assigned to let constant.

print(testObject)          // Output: TestStruct(foo: 666)
```

The code example above should produce a compile time error in line 12. Instead of failing, the above example behaves as if `testObject` had been defined as a `var`.
### Reproducability
- the constant must be of protocol type  
  _`let testObject: TestStruct` behaves as expected (compile time error)_
- constant declaration and initialization must happen in two different lines / instructions  
  _`let testObject: TestProtocol = TestStruct(foo: 42)` behaves as expected_
- illegal access must occur within either 
  - global scope, if constant was defined in global scope [(Main example)](http://swiftlang.ng.bluemix.net/#/repl/57a3ba35a7e343a94179b85b)  
    _Defining constant in global scope, but attempting mutating action within a function behaves as expected_
  - the function where a local constant is defined [(Example)](http://swiftlang.ng.bluemix.net/#/repl/57a3ba35a7e343a94179b85b)
  - a designated initializer of the class, in which a let property is defined [(Example)](http://swiftlang.ng.bluemix.net/#/repl/57a3c183a7e343a94179b860)  
    _Attempted mutation outside of designated initializer or in subclass initializer behaves as expected_
- mutation can happen through
  - variable setters [(Main example)](http://swiftlang.ng.bluemix.net/#/repl/57a3ba35a7e343a94179b85b)
  - calls to `mutating func`s [(Struct Example)](http://swiftlang.ng.bluemix.net/#/repl/57a3b8bca7e343a94179b859) [(Enum Example)](http://swiftlang.ng.bluemix.net/#/repl/57a3b75ba7e343a94179b858)
  - passing a reference to struct's property as an inout parameter to a function [(Example)](http://swiftlang.ng.bluemix.net/#/repl/57c744d7acbc649256bab974)
### Issue description

Initializing the constant separate from its declaration requires write access. Therefore it is treated as `@lvalue TestProtocol` in the AST for a certain scope.  
Checking that the constant is not written to after being initialized is supposed to happen in the Mandatory SILOptimizer phase instead.

On loads, the Optimizer checks, that a variable is fully initialized, but currently does not validate what happens to it after it is loaded.  
This allows loading the memory object (or the named element of a reference type) through an [`open_existential_addr`](https://github.com/apple/swift/blob/master/docs/SIL.rst#open-existential-addr) instruction and applying the result as an Operand to a mutating witness method.
## 

Note: I currently do not fully understand what an archetype refers to in the Swift compiler internals. The change is written in a way that is not specific to `witness_method`s, but still only checks apply instructions. If you can think of another way the result of an `open_existential_addr` instruction could be used in a mutating fashion, please leave a comment.
