### PR TITLE
[SR-2209] Add real AccessScope type.

### DIFF
--- a/include/swift/AST/AccessScope.h
+++ b/include/swift/AST/AccessScope.h
@@ -1,0 +1,83 @@
+//===--- AccessScope.h - Swift Access Scope ---------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_ACCESSSCOPE_H
+#define SWIFT_ACCESSSCOPE_H
+
+#include "swift/AST/AttrKind.h"
+#include "swift/AST/DeclContext.h"
+#include "swift/AST/Module.h"
+#include "llvm/ADT/PointerIntPair.h"
+
+namespace swift {
+
+/// The wrapper around the outermost DeclContext from which
+/// a particular declaration can be accessed.
+class AccessScope {
+  /// The declaration context (if not public) along with a bit saying
+  /// whether this scope is private (or not).
+  llvm::PointerIntPair<const DeclContext *, 1, bool> Value;
+public:
+  AccessScope(const DeclContext *DC, bool isPrivate = false)
+    : Value(DC, isPrivate) {
+        if (!DC || isa<ModuleDecl>(DC))
+          assert(!isPrivate && "public or internal scope can't be private");
+      }
+
+  static AccessScope getPublic() { return AccessScope(nullptr); }
+
+  /// Returns nullptr if access scope is public.
+  const DeclContext *getDeclContext() const { return Value.getPointer(); }
+
+  bool operator==(AccessScope RHS) const { return Value == RHS.Value; }
+  bool operator!=(AccessScope RHS) const { return !(*this == RHS); }
+  bool hasEqualDeclContextWith(AccessScope RHS) const {
+    return getDeclContext() == RHS.getDeclContext();
+  }
+
+  bool isPublic() const { return !Value.getPointer(); }
+  bool isPrivate() const { return Value.getInt(); }
+  bool isFileScope() const {
+    auto DC = getDeclContext();
+    return DC && isa<FileUnit>(DC);
+  }
+
+  /// Returns true if this is a child scope of the specified other access scope.
+  ///
+  /// \see DeclContext::isChildContextOf
+  bool isChildOf(AccessScope AS) const {
+    if (!isPublic() && !AS.isPublic())
+      return getDeclContext()->isChildContextOf(AS.getDeclContext());
+    return AS.isPublic();
+  }
+
+  /// Returns the associated access level for diagnostic purposes.
+  Accessibility accessibilityForDiagnostics() const;
+
+  /// Returns the narrowest access scope if this and the specified access scope
+  /// have common intersection, or None if scopes don't intersect.
+  const Optional<AccessScope> intersectWith(AccessScope accessScope) const {
+    if (hasEqualDeclContextWith(accessScope))
+      return *this;
+    if (isChildOf(accessScope))
+      return *this;
+    if (accessScope.isChildOf(*this))
+      return accessScope;
+
+    return None;
+  }
+
+};
+
+} // end namespace swift
+
+#endif

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_DECL_H
 #define SWIFT_DECL_H
 
+#include "swift/AST/AccessScope.h"
 #include "swift/AST/CaptureInfo.h"
 #include "swift/AST/ClangNode.h"
 #include "swift/AST/ConcreteDeclRef.h"
@@ -32,7 +33,6 @@
 #include "llvm/Support/TrailingObjects.h"
 
 namespace swift {
-  class AccessScope;
   enum class AccessSemantics : unsigned char;
   class ApplyExpr;
   class ArchetypeBuilder;

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -32,6 +32,7 @@
 #include "llvm/Support/TrailingObjects.h"
 
 namespace swift {
+  class AccessScope;
   enum class AccessSemantics : unsigned char;
   class ApplyExpr;
   class ArchetypeBuilder;
@@ -2065,7 +2066,7 @@ public:
   ///
   /// \sa getFormalAccess
   /// \sa isAccessibleFrom
-  const DeclContext *
+  AccessScope
   getFormalAccessScope(const DeclContext *useDC = nullptr) const;
 
   /// Returns the access level that actually controls how a declaration should

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1109,32 +1109,34 @@ ERROR(static_requires_initializer,none,
       "expression or getter/setter specifier", (StaticSpellingKind))
 ERROR(pattern_type_access,none,
       "%select{%select{variable|constant}0|property}1 "
-      "%select{must be declared %select{private|fileprivate|internal|PUBLIC}4"
+      "%select{must be declared %select{"
+      "%select{private|fileprivate|internal|PUBLIC}3|private or fileprivate}4"
       "|cannot be declared %select{PRIVATE|fileprivate|internal|public}3}2 "
       "because its type uses "
-      "%select{a private|a fileprivate|an internal|PUBLIC}4 type",
-      (bool, bool, bool, Accessibility, Accessibility))
+      "%select{a private|a fileprivate|an internal|PUBLIC}5 type",
+      (bool, bool, bool, Accessibility, bool, Accessibility))
 WARNING(pattern_type_access_warn,none,
         "%select{%select{variable|constant}0|property}1 "
-        "%select{should be declared %select{private|fileprivate|internal|PUBLIC}4"
+        "%select{should be declared %select{private|fileprivate|internal|PUBLIC}5"
         "|should not be declared %select{in this context|fileprivate|internal|public}3}2 "
         "because its type uses "
-        "%select{a private|a fileprivate|an internal|PUBLIC}4 type",
-        (bool, bool, bool, Accessibility, Accessibility))
+        "%select{a private|a fileprivate|an internal|PUBLIC}5 type",
+        (bool, bool, bool, Accessibility, bool, Accessibility))
 ERROR(pattern_type_access_inferred,none,
       "%select{%select{variable|constant}0|property}1 "
-      "%select{must be declared %select{private|fileprivate|internal|PUBLIC}4"
+      "%select{must be declared %select{"
+      "%select{private|fileprivate|internal|PUBLIC}3|private or fileprivate}4"
       "|cannot be declared %select{PRIVATE|fileprivate|internal|public}3}2 "
-      "because its type %5 uses "
-      "%select{a private|a fileprivate|an internal|PUBLIC}4 type",
-      (bool, bool, bool, Accessibility, Accessibility, Type))
+      "because its type %6 uses "
+      "%select{a private|a fileprivate|an internal|PUBLIC}5 type",
+      (bool, bool, bool, Accessibility, bool, Accessibility, Type))
 WARNING(pattern_type_access_inferred_warn,none,
         "%select{%select{variable|constant}0|property}1 "
-        "%select{should be declared %select{private|fileprivate|internal|PUBLIC}4"
+        "%select{should be declared %select{private|fileprivate|internal|PUBLIC}5"
         "|should not be declared %select{in this context|fileprivate|internal|public}3}2 "
-        "because its type %5 uses "
-        "%select{a private|a fileprivate|an internal|PUBLIC}4 type",
-        (bool, bool, bool, Accessibility, Accessibility, Type))
+        "because its type %6 uses "
+        "%select{a private|a fileprivate|an internal|PUBLIC}5 type",
+        (bool, bool, bool, Accessibility, bool, Accessibility, Type))
 ERROR(pattern_binds_no_variables,none,
       "%select{property|global variable}0 declaration does not bind any "
       "variables",
@@ -1168,24 +1170,24 @@ ERROR(unsupported_nested_protocol,none,
 ERROR(circular_type_alias,none,
       "type alias %0 circularly references itself", (Identifier))
 ERROR(type_alias_underlying_type_access,none,
-      "type alias %select{must be declared "
-      "%select{private|fileprivate|internal|PUBLIC}2"
+      "type alias %select{must be declared %select{"
+      "%select{private|fileprivate|internal|PUBLIC}2|private or fileprivate}3"
       "|cannot be declared %select{PRIVATE|fileprivate|internal|public}1}0 "
       "because its underlying type uses "
       "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
-      (bool, Accessibility, Accessibility))
+      (bool, Accessibility, Accessibility, bool))
 WARNING(type_alias_underlying_type_access_warn,none,
         "type alias %select{should be declared "
         "%select{private|fileprivate|internal|PUBLIC}2"
         "|should not be declared %select{PRIVATE|fileprivate|internal|public}1}0 "
         "because its underlying type uses "
         "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
-        (bool, Accessibility, Accessibility))
+        (bool, Accessibility, Accessibility, bool))
 
 // Subscripts
 ERROR(subscript_type_access,none,
       "subscript %select{must be declared "
-      "%select{private|fileprivate|internal|PUBLIC}2"
+      "%select{private|fileprivate|internal|PUBLIC}1"
       "|cannot be declared %select{PRIVATE|fileprivate|internal|public}1}0 "
       "because its %select{index|element type}3 uses "
       "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
@@ -1200,19 +1202,20 @@ WARNING(subscript_type_access_warn,none,
 
 // Functions
 ERROR(function_type_access,none,
-      "%select{function|method|initializer}3 "
-      "%select{must be declared %select{private|fileprivate|internal|PUBLIC}2"
+      "%select{function|method|initializer}4 "
+      "%select{must be declared %select{"
+      "%select{private|fileprivate|internal|PUBLIC}1|private or fileprivate}2"
       "|cannot be declared %select{PRIVATE|fileprivate|internal|public}1}0 "
-      "because its %select{parameter|result}4 uses "
-      "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
-      (bool, Accessibility, Accessibility, unsigned, bool))
+      "because its %select{parameter|result}5 uses "
+      "%select{a private|a fileprivate|an internal|PUBLIC}3 type",
+      (bool, Accessibility, bool, Accessibility, unsigned, bool))
 WARNING(function_type_access_warn,none,
-        "%select{function|method|initializer}3 "
-        "%select{should be declared %select{private|fileprivate|internal|PUBLIC}2"
+        "%select{function|method|initializer}4 "
+        "%select{should be declared %select{private|fileprivate|internal|PUBLIC}3"
         "|should not be declared %select{in this context|fileprivate|internal|public}1}0 "
-        "because its %select{parameter|result}4 uses "
-        "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
-        (bool, Accessibility, Accessibility, unsigned, bool))
+        "because its %select{parameter|result}5 uses "
+        "%select{a private|a fileprivate|an internal|PUBLIC}3 type",
+        (bool, Accessibility, bool, Accessibility, unsigned, bool))
 WARNING(non_trailing_closure_before_default_args,none,
         "closure parameter prior to parameters with default arguments will "
         "not be treated as a trailing closure", ())
@@ -1319,14 +1322,14 @@ ERROR(witness_not_accessible_proto,none,
       "%select{initializer %1|method %1|%select{|setter for }2property %1"
       "|subscript%select{| setter}2}0 must be declared "
       "%select{PRIVATE|fileprivate|internal|public}3 because it matches a "
-      "requirement in %select{PRIVATE|fileprivate|internal|public}3 protocol "
-      "%4",
-      (RequirementKind, DeclName, bool, Accessibility, DeclName))
+      "requirement in %select{private|fileprivate|internal|public}4 protocol "
+      "%5",
+      (RequirementKind, DeclName, bool, Accessibility, Accessibility, DeclName))
 ERROR(witness_not_accessible_type,none,
       "%select{initializer %1|method %1|%select{|setter for }2property %1"
       "|subscript%select{| setter}2}0 must be as accessible as its enclosing "
-      "type because it matches a requirement in protocol %4",
-      (RequirementKind, DeclName, bool, Accessibility, DeclName))
+      "type because it matches a requirement in protocol %5",
+      (RequirementKind, DeclName, bool, Accessibility, Accessibility, DeclName))
 ERROR(type_witness_not_accessible_proto,none,
       "%0 %1 must be declared %select{PRIVATE|fileprivate|internal|public}2 "
       "because it matches a requirement in "
@@ -1338,17 +1341,18 @@ ERROR(type_witness_not_accessible_type,none,
       (DescriptiveDeclKind, DeclName, Accessibility, DeclName))
 
 ERROR(protocol_refine_access,none,
-      "%select{protocol must be declared "
-      "%select{private|fileprivate|internal|PUBLIC}2 because it refines"
+      "%select{protocol must be declared %select{"
+      "%select{private|fileprivate|internal|PUBLIC}2"
+      "|private or fileprivate}3 because it refines"
       "|%select{PRIVATE|fileprivate|internal|public}1 protocol cannot "
       "refine}0 %select{a private|a fileprivate|an internal|PUBLIC}2 protocol",
-      (bool, Accessibility, Accessibility))
+      (bool, Accessibility, Accessibility, bool))
 WARNING(protocol_refine_access_warn,none,
         "%select{protocol should be declared "
         "%select{private|fileprivate|internal|PUBLIC}2 because it refines"
         "|%select{in this context|fileprivate|internal|public}1 protocol should not "
         "refine}0 %select{a private|a fileprivate|an internal|PUBLIC}2 protocol",
-        (bool, Accessibility, Accessibility))
+        (bool, Accessibility, Accessibility, bool))
 ERROR(protocol_property_must_be_computed_var,none,
       "immutable property requirement must be declared as 'var' with a "
       "'{ get }' specifier", ())
@@ -1544,19 +1548,19 @@ ERROR(requires_generic_param_same_type_does_not_conform,none,
       (Type, Identifier))
 
 ERROR(generic_param_access,none,
-      "%0 %select{must be declared "
-      "%select{private|fileprivate|internal|PUBLIC}3"
+      "%0 %select{must be declared %select{"
+      "%select{private|fileprivate|internal|PUBLIC}3|private or fileprivate}4"
       "|cannot be declared %select{PRIVATE|fileprivate|internal|public}2}1 "
-      "because its generic %select{parameter|requirement}4 uses "
+      "because its generic %select{parameter|requirement}5 uses "
       "%select{a private|a fileprivate|an internal|PUBLIC}3 type",
-      (DescriptiveDeclKind, bool, Accessibility, Accessibility, bool))
+      (DescriptiveDeclKind, bool, Accessibility, Accessibility, bool, bool))
 WARNING(generic_param_access_warn,none,
         "%0 %select{should be declared "
         "%select{private|fileprivate|internal|PUBLIC}3"
         "|should not be declared %select{in this context|fileprivate|internal|public}2}1 "
-        "because its generic %select{parameter|requirement}4 uses "
+        "because its generic %select{parameter|requirement}5 uses "
         "%select{a private|a fileprivate|an internal|PUBLIC}3 type",
-        (DescriptiveDeclKind, bool, Accessibility, Accessibility, bool))
+        (DescriptiveDeclKind, bool, Accessibility, Accessibility, bool, bool))
 
 ERROR(override_multiple_decls_base,none,
       "declaration %0 cannot override more than one superclass declaration",
@@ -1775,19 +1779,19 @@ ERROR(enum_raw_type_nonconforming_and_nonsynthable,none,
 NOTE(enum_declares_rawrep_with_raw_type,none,
       "%0 declares raw type %1, which implies RawRepresentable", (Type, Type))
 ERROR(enum_raw_type_access,none,
-      "enum %select{must be declared "
-      "%select{private|fileprivate|internal|PUBLIC}2"
+      "enum %select{must be declared %select{"
+      "%select{private|fileprivate|internal|PUBLIC}2|private or fileprivate}3"
       "|cannot be declared %select{PRIVATE|fileprivate|internal|public}1}0 "
       "because its raw type uses "
       "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
-      (bool, Accessibility, Accessibility))
+      (bool, Accessibility, Accessibility, bool))
 WARNING(enum_raw_type_access_warn,none,
         "enum %select{should be declared "
         "%select{private|fileprivate|internal|PUBLIC}2"
         "|should not be declared %select{in this context|fileprivate|internal|public}1}0 "
         "because its raw type uses "
         "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
-        (bool, Accessibility, Accessibility))
+        (bool, Accessibility, Accessibility, bool))
 
 NOTE(enum_here,none,
      "enum %0 declared here", (Identifier))
@@ -2729,19 +2733,19 @@ ERROR(self_in_nominal,none,
       "'Self' is only available in a protocol or as the result of a "
       "method in a class; did you mean %0?", (Identifier))
 ERROR(class_super_access,none,
-      "class %select{must be declared "
-      "%select{private|fileprivate|internal|PUBLIC}2"
+      "class %select{must be declared %select{"
+      "%select{private|fileprivate|internal|PUBLIC}2|private or fileprivate}3"
       "|cannot be declared %select{PRIVATE|fileprivate|internal|public}1}0 "
       "because its superclass is "
       "%select{private|fileprivate|internal|PUBLIC}2",
-      (bool, Accessibility, Accessibility))
+      (bool, Accessibility, Accessibility, bool))
 WARNING(class_super_access_warn,none,
         "class %select{should be declared "
         "%select{private|fileprivate|internal|PUBLIC}2"
         "|should not be declared %select{in this context|fileprivate|internal|public}1}0 "
         "because its superclass is "
         "%select{private|fileprivate|internal|PUBLIC}2",
-        (bool, Accessibility, Accessibility))
+        (bool, Accessibility, Accessibility, bool))
 ERROR(dot_protocol_on_non_existential,none,
       "cannot use 'Protocol' with non-protocol type %0", (Type))
 ERROR(tuple_single_element,none,

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Subsystems.h"
+#include "swift/AST/AccessScope.h"
 #include "swift/AST/ArchetypeBuilder.h"
 #include "swift/AST/AST.h"
 #include "swift/AST/ASTContext.h"
@@ -639,7 +640,7 @@ struct ASTNodeBase {};
 
       if (D->hasAccessibility()) {
         PrettyStackTraceDecl debugStack("verifying access", D);
-        if (D->getFormalAccessScope() == nullptr &&
+        if (D->getFormalAccessScope().isPublic() &&
             D->getFormalAccess() < Accessibility::Public) {
           Out << "non-public decl has no formal access scope\n";
           D->dump(Out);

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -929,13 +929,24 @@ IterableDeclContext::castDeclToIterableDeclContext(const Decl *D) {
   }
 }
 
+AccessScope::AccessScope(const DeclContext *DC, bool isPrivate)
+    : Value(DC, isPrivate) {
+  if (!DC || isa<ModuleDecl>(DC))
+    assert(!isPrivate && "public or internal scope can't be private");
+}
+
+bool AccessScope::isFileScope() const {
+  auto DC = getDeclContext();
+  return DC && isa<FileUnit>(DC);
+}
+
 Accessibility AccessScope::accessibilityForDiagnostics() const {
   if (isPublic())
     return Accessibility::Public;
   if (isa<ModuleDecl>(getDeclContext()))
     return Accessibility::Internal;
   if (getDeclContext()->isModuleScopeContext()) {
-    return Accessibility::FilePrivate;
+    return isPrivate() ? Accessibility::Private : Accessibility::FilePrivate;
   }
 
   return Accessibility::Private;

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/AST/AST.h"
 #include "swift/AST/DeclContext.h"
+#include "swift/AST/AccessScope.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/SourceManager.h"
@@ -926,4 +927,16 @@ IterableDeclContext::castDeclToIterableDeclContext(const Decl *D) {
         static_cast<const IterableDeclContext*>(cast<ID##Decl>(D)));
 #include "swift/AST/DeclNodes.def"
   }
+}
+
+Accessibility AccessScope::accessibilityForDiagnostics() const {
+  if (isPublic())
+    return Accessibility::Public;
+  if (isa<ModuleDecl>(getDeclContext()))
+    return Accessibility::Internal;
+  if (getDeclContext()->isModuleScopeContext()) {
+    return Accessibility::FilePrivate;
+  }
+
+  return Accessibility::Private;
 }

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/AST/Module.h"
+#include "swift/AST/AccessScope.h"
 #include "swift/AST/AST.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ASTScope.h"
@@ -428,8 +429,8 @@ void Module::lookupMember(SmallVectorImpl<ValueDecl*> &results,
       return VD->getModuleContext() == this;
     });
 
-    const DeclContext *accessScope = nominal->getFormalAccessScope();
-    if (accessScope && !accessScope->isModuleContext())
+    auto AS = nominal->getFormalAccessScope();
+    if (AS.isPrivate() || AS.isFileScope())
       alreadyInPrivateContext = true;
 
     break;

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3800,19 +3800,6 @@ void swift::performStmtDiagnostics(TypeChecker &TC, const Stmt *S) {
 // Utility functions
 //===----------------------------------------------------------------------===//
 
-
-Accessibility
-swift::accessibilityFromScopeForDiagnostics(const DeclContext *accessScope) {
-  if (!accessScope)
-    return Accessibility::Public;
-  if (isa<ModuleDecl>(accessScope))
-    return Accessibility::Internal;
-  if (accessScope->isModuleScopeContext()) {
-    return Accessibility::FilePrivate;
-  }
-  return Accessibility::Private;
-}
-
 void swift::fixItAccessibility(InFlightDiagnostic &diag, ValueDecl *VD,
                                Accessibility desiredAccess, bool isForSetter) {
   StringRef fixItString;

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -32,13 +32,6 @@ namespace swift {
   class TypeChecker;
   class ValueDecl;
 
-/// Returns the access level associated with \p accessScope, for diagnostic
-/// purposes.
-///
-/// \sa ValueDecl::getFormalAccessScope
-Accessibility
-accessibilityFromScopeForDiagnostics(const DeclContext *accessScope);
-
 /// \brief Emit diagnostics for syntactic restrictions on a given expression.
 void performSyntacticExprDiagnostics(TypeChecker &TC, const Expr *E,
                                      const DeclContext *DC,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -18,6 +18,7 @@
 #define TYPECHECKING_H
 
 #include "swift/Sema/TypeCheckRequest.h"
+#include "swift/AST/AccessScope.h"
 #include "swift/AST/AST.h"
 #include "swift/AST/AnyFunctionRef.h"
 #include "swift/AST/Availability.h"
@@ -490,7 +491,7 @@ public:
   /// during type checking.
   llvm::SetVector<NominalTypeDecl *> ValidatedTypes;
 
-  using TypeAccessScopeCacheMap = llvm::DenseMap<Type, const DeclContext *>;
+  using TypeAccessScopeCacheMap = llvm::DenseMap<Type, AccessScope>;
 
   /// Caches the outermost scope where a particular type can be used, relative
   /// to a particular file.

--- a/test/NameBinding/accessibility.swift
+++ b/test/NameBinding/accessibility.swift
@@ -137,8 +137,8 @@ private class PrivateBox<T> { // expected-note 2 {{type declared here}}
   typealias AlwaysFloat = Float
 }
 
-let boxUnboxInt: PrivateBox<Int>.ValueType = 0 // expected-error {{constant must be declared fileprivate because its type uses a fileprivate type}}
-let boxFloat: PrivateBox<Int>.AlwaysFloat = 0 // expected-error {{constant must be declared fileprivate because its type uses a fileprivate type}}
+let boxUnboxInt: PrivateBox<Int>.ValueType = 0 // expected-error {{constant must be declared private or fileprivate because its type uses a private type}}
+let boxFloat: PrivateBox<Int>.AlwaysFloat = 0 // expected-error {{constant must be declared private or fileprivate because its type uses a private type}}
 #endif
 
 

--- a/test/Sema/accessibility.swift
+++ b/test/Sema/accessibility.swift
@@ -22,7 +22,7 @@ public struct PublicStruct: PublicProto, InternalProto, FilePrivateProto, Privat
   private func publicReq() {} // expected-error {{method 'publicReq()' must be declared public because it matches a requirement in public protocol 'PublicProto'}} {{3-10=public}}
   private func internalReq() {} // expected-error {{method 'internalReq()' must be declared internal because it matches a requirement in internal protocol 'InternalProto'}} {{3-10=internal}}
   private func filePrivateReq() {} // expected-error {{method 'filePrivateReq()' must be declared fileprivate because it matches a requirement in fileprivate protocol 'FilePrivateProto'}} {{3-10=fileprivate}}
-  private func privateReq() {} // expected-error {{method 'privateReq()' must be declared fileprivate because it matches a requirement in fileprivate protocol 'PrivateProto'}} {{3-10=fileprivate}}
+  private func privateReq() {} // expected-error {{method 'privateReq()' must be declared fileprivate because it matches a requirement in private protocol 'PrivateProto'}} {{3-10=fileprivate}}
 
   public var publicVar = 0
 }
@@ -32,7 +32,7 @@ internal struct InternalStruct: PublicProto, InternalProto, FilePrivateProto, Pr
   private func publicReq() {} // expected-error {{method 'publicReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'PublicProto'}} {{3-10=internal}}
   private func internalReq() {} // expected-error {{method 'internalReq()' must be declared internal because it matches a requirement in internal protocol 'InternalProto'}} {{3-10=internal}}
   private func filePrivateReq() {} // expected-error {{method 'filePrivateReq()' must be declared fileprivate because it matches a requirement in fileprivate protocol 'FilePrivateProto'}} {{3-10=fileprivate}}
-  private func privateReq() {} // expected-error {{method 'privateReq()' must be declared fileprivate because it matches a requirement in fileprivate protocol 'PrivateProto'}} {{3-10=fileprivate}}
+  private func privateReq() {} // expected-error {{method 'privateReq()' must be declared fileprivate because it matches a requirement in private protocol 'PrivateProto'}} {{3-10=fileprivate}}
 
   public var publicVar = 0
 }
@@ -42,7 +42,7 @@ fileprivate struct FilePrivateStruct: PublicProto, InternalProto, FilePrivatePro
   private func publicReq() {} // expected-error {{method 'publicReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'PublicProto'}} {{3-10=fileprivate}}
   private func internalReq() {} // expected-error {{method 'internalReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'InternalProto'}} {{3-10=fileprivate}}
   private func filePrivateReq() {} // expected-error {{method 'filePrivateReq()' must be declared fileprivate because it matches a requirement in fileprivate protocol 'FilePrivateProto'}} {{3-10=fileprivate}}
-  private func privateReq() {} // expected-error {{method 'privateReq()' must be declared fileprivate because it matches a requirement in fileprivate protocol 'PrivateProto'}} {{3-10=fileprivate}}
+  private func privateReq() {} // expected-error {{method 'privateReq()' must be declared fileprivate because it matches a requirement in private protocol 'PrivateProto'}} {{3-10=fileprivate}}
 
   public var publicVar = 0
 }
@@ -52,7 +52,7 @@ private struct PrivateStruct: PublicProto, InternalProto, FilePrivateProto, Priv
   private func publicReq() {} // expected-error {{method 'publicReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'PublicProto'}} {{3-10=fileprivate}}
   private func internalReq() {} // expected-error {{method 'internalReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'InternalProto'}} {{3-10=fileprivate}}
   private func filePrivateReq() {} // expected-error {{method 'filePrivateReq()' must be declared fileprivate because it matches a requirement in fileprivate protocol 'FilePrivateProto'}} {{3-10=fileprivate}}
-  private func privateReq() {} // expected-error {{method 'privateReq()' must be declared fileprivate because it matches a requirement in fileprivate protocol 'PrivateProto'}} {{3-10=fileprivate}}
+  private func privateReq() {} // expected-error {{method 'privateReq()' must be declared fileprivate because it matches a requirement in private protocol 'PrivateProto'}} {{3-10=fileprivate}}
 
   public var publicVar = 0
 }
@@ -276,28 +276,23 @@ private class PrivateSubPrivateSet: Base {
 public typealias PublicTA1 = PublicStruct
 public typealias PublicTA2 = InternalStruct // expected-error {{type alias cannot be declared public because its underlying type uses an internal type}}
 public typealias PublicTA3 = FilePrivateStruct // expected-error {{type alias cannot be declared public because its underlying type uses a fileprivate type}}
-// FIXME: This type is actually private; it's just being reported as fileprivate because it's top-level.
-public typealias PublicTA4 = PrivateStruct // expected-error {{type alias cannot be declared public because its underlying type uses a fileprivate type}}
+public typealias PublicTA4 = PrivateStruct // expected-error {{type alias cannot be declared public because its underlying type uses a private type}}
 
 // expected-note@+1 {{type declared here}}
 internal typealias InternalTA1 = PublicStruct
 internal typealias InternalTA2 = InternalStruct
 internal typealias InternalTA3 = FilePrivateStruct // expected-error {{type alias cannot be declared internal because its underlying type uses a fileprivate type}}
-// FIXME: This type is actually private; it's just being reported as
-// fileprivate because it's top-level.
-internal typealias InternalTA4 = PrivateStruct // expected-error {{type alias cannot be declared internal because its underlying type uses a fileprivate type}}
+internal typealias InternalTA4 = PrivateStruct // expected-error {{type alias cannot be declared internal because its underlying type uses a private type}}
 
 public typealias PublicFromInternal = InternalTA1 // expected-error {{type alias cannot be declared public because its underlying type uses an internal type}}
 
-// FIXME: These types are actually private; they're just being reported as
-// fileprivate because they're top-level.
-typealias FunctionType1 = (PrivateStruct) -> PublicStruct // expected-error {{type alias must be declared fileprivate because its underlying type uses a fileprivate type}}
-typealias FunctionType2 = (PublicStruct) -> PrivateStruct // expected-error {{type alias must be declared fileprivate because its underlying type uses a fileprivate type}}
-typealias FunctionType3 = (PrivateStruct) -> PrivateStruct // expected-error {{type alias must be declared fileprivate because its underlying type uses a fileprivate type}}
+typealias FunctionType1 = (PrivateStruct) -> PublicStruct // expected-error {{type alias must be declared private or fileprivate because its underlying type uses a private type}}
+typealias FunctionType2 = (PublicStruct) -> PrivateStruct // expected-error {{type alias must be declared private or fileprivate because its underlying type uses a private type}}
+typealias FunctionType3 = (PrivateStruct) -> PrivateStruct // expected-error {{type alias must be declared private or fileprivate because its underlying type uses a private type}}
 
-typealias ArrayType = [PrivateStruct] // expected-error {{type alias must be declared fileprivate because its underlying type uses a fileprivate type}}
-typealias DictType = [String : PrivateStruct] // expected-error {{type alias must be declared fileprivate because its underlying type uses a fileprivate type}}
-typealias GenericArgs = Optional<PrivateStruct> // expected-error {{type alias must be declared fileprivate because its underlying type uses a fileprivate type}}
+typealias ArrayType = [PrivateStruct] // expected-error {{type alias must be declared private or fileprivate because its underlying type uses a private type}}
+typealias DictType = [String : PrivateStruct] // expected-error {{type alias must be declared private or fileprivate because its underlying type uses a private type}}
+typealias GenericArgs = Optional<PrivateStruct> // expected-error {{type alias must be declared private or fileprivate because its underlying type uses a private type}}
 
 
 public protocol HasAssocType {
@@ -311,65 +306,54 @@ public struct AssocTypeImpl: HasAssocType {
 public let _: AssocTypeImpl.Inferred?
 
 
-// FIXME: These types are actually private; they're just being reported as
-// fileprivate because they're top-level.
-public let x: PrivateStruct = PrivateStruct() // expected-error {{constant cannot be declared public because its type uses a fileprivate type}}
-public var a: PrivateStruct?, b: PrivateStruct? // expected-error 2 {{variable cannot be declared public because its type uses a fileprivate type}}
-public var (c, d): (PrivateStruct?, PrivateStruct?) // expected-error {{variable cannot be declared public because its type uses a fileprivate type}}
+public let x: PrivateStruct = PrivateStruct() // expected-error {{constant cannot be declared public because its type uses a private type}}
+public var a: PrivateStruct?, b: PrivateStruct? // expected-error 2 {{variable cannot be declared public because its type uses a private type}}
+public var (c, d): (PrivateStruct?, PrivateStruct?) // expected-error {{variable cannot be declared public because its type uses a private type}}
 
-var internalVar: PrivateStruct? // expected-error {{variable must be declared fileprivate because its type uses a fileprivate type}}
+var internalVar: PrivateStruct? // expected-error {{variable must be declared private or fileprivate because its type uses a private type}}
 
-let internalConstant = PrivateStruct() // expected-error {{constant must be declared fileprivate because its type 'PrivateStruct' uses a fileprivate type}}
+let internalConstant = PrivateStruct() // expected-error {{constant must be declared private or fileprivate because its type 'PrivateStruct' uses a private type}}
 public let publicConstant = [InternalStruct]() // expected-error {{constant cannot be declared public because its type '[InternalStruct]' uses an internal type}}
 
 public struct Properties {
-  // FIXME: These types are actually private; they're just being reported as
-  // fileprivate because they're top-level.
-  public let x: PrivateStruct = PrivateStruct() // expected-error {{property cannot be declared public because its type uses a fileprivate type}}
-  public var a: PrivateStruct?, b: PrivateStruct? // expected-error 2 {{property cannot be declared public because its type uses a fileprivate type}}
-  public var (c, d): (PrivateStruct?, PrivateStruct?) // expected-error {{property cannot be declared public because its type uses a fileprivate type}}
+  public let x: PrivateStruct = PrivateStruct() // expected-error {{property cannot be declared public because its type uses a private type}}
+  public var a: PrivateStruct?, b: PrivateStruct? // expected-error 2 {{property cannot be declared public because its type uses a private type}}
+  public var (c, d): (PrivateStruct?, PrivateStruct?) // expected-error {{property cannot be declared public because its type uses a private type}}
 
-  let y = PrivateStruct() // expected-error {{property must be declared fileprivate because its type 'PrivateStruct' uses a fileprivate type}}
+  let y = PrivateStruct() // expected-error {{property must be declared fileprivate because its type 'PrivateStruct' uses a private type}}
 }
 
 public struct Subscripts {
-  // FIXME: These types are actually private; they're just being reported as
-  // fileprivate because they're top-level.
-  subscript (a: PrivateStruct) -> Int { return 0 } // expected-error {{subscript must be declared fileprivate because its index uses a fileprivate type}}
-  subscript (a: Int) -> PrivateStruct { return PrivateStruct() } // expected-error {{subscript must be declared fileprivate because its element type uses a fileprivate type}}
+  subscript (a: PrivateStruct) -> Int { return 0 } // expected-error {{subscript must be declared fileprivate because its index uses a private type}}
+  subscript (a: Int) -> PrivateStruct { return PrivateStruct() } // expected-error {{subscript must be declared fileprivate because its element type uses a private type}}
 
-  public subscript (a: PrivateStruct, b: Int) -> Int { return 0 } // expected-error {{subscript cannot be declared public because its index uses a fileprivate type}}
-  public subscript (a: Int, b: PrivateStruct) -> Int { return 0 } // expected-error {{subscript cannot be declared public because its index uses a fileprivate type}}
-  public subscript (a: InternalStruct, b: PrivateStruct) -> InternalStruct { return InternalStruct() } // expected-error {{subscript cannot be declared public because its index uses a fileprivate type}}
-  public subscript (a: PrivateStruct, b: InternalStruct) -> PrivateStruct { return PrivateStruct() } // expected-error {{subscript cannot be declared public because its index uses a fileprivate type}}
+  public subscript (a: PrivateStruct, b: Int) -> Int { return 0 } // expected-error {{subscript cannot be declared public because its index uses a private type}}
+  public subscript (a: Int, b: PrivateStruct) -> Int { return 0 } // expected-error {{subscript cannot be declared public because its index uses a private type}}
+  public subscript (a: InternalStruct, b: PrivateStruct) -> InternalStruct { return InternalStruct() } // expected-error {{subscript cannot be declared public because its index uses a private type}}
+  public subscript (a: PrivateStruct, b: InternalStruct) -> PrivateStruct { return PrivateStruct() } // expected-error {{subscript cannot be declared public because its index uses a private type}}
   public subscript (a: Int, b: Int) -> InternalStruct { return InternalStruct() } // expected-error {{subscript cannot be declared public because its element type uses an internal type}}
 }
 
 public struct Methods {
-  // FIXME: These types are actually private; they're just being reported as
-  // fileprivate because they're top-level.
-  func foo(a: PrivateStruct) -> Int { return 0 } // expected-error {{method must be declared fileprivate because its parameter uses a fileprivate type}}
-  func bar(a: Int) -> PrivateStruct { return PrivateStruct() } // expected-error {{method must be declared fileprivate because its result uses a fileprivate type}}
+  func foo(a: PrivateStruct) -> Int { return 0 } // expected-error {{method must be declared fileprivate because its parameter uses a private type}}
+  func bar(a: Int) -> PrivateStruct { return PrivateStruct() } // expected-error {{method must be declared fileprivate because its result uses a private type}}
 
-  public func a(a: PrivateStruct, b: Int) -> Int { return 0 } // expected-error {{method cannot be declared public because its parameter uses a fileprivate type}}
-  public func b(a: Int, b: PrivateStruct) -> Int { return 0 } // expected-error {{method cannot be declared public because its parameter uses a fileprivate type}}
-  public func c(a: InternalStruct, b: PrivateStruct) -> InternalStruct { return InternalStruct() } // expected-error {{method cannot be declared public because its parameter uses a fileprivate type}}
-  public func d(a: PrivateStruct, b: InternalStruct) -> PrivateStruct { return PrivateStruct() } // expected-error {{method cannot be declared public because its parameter uses a fileprivate type}}
+  public func a(a: PrivateStruct, b: Int) -> Int { return 0 } // expected-error {{method cannot be declared public because its parameter uses a private type}}
+  public func b(a: Int, b: PrivateStruct) -> Int { return 0 } // expected-error {{method cannot be declared public because its parameter uses a private type}}
+  public func c(a: InternalStruct, b: PrivateStruct) -> InternalStruct { return InternalStruct() } // expected-error {{method cannot be declared public because its parameter uses a private type}}
+  public func d(a: PrivateStruct, b: InternalStruct) -> PrivateStruct { return PrivateStruct() } // expected-error {{method cannot be declared public because its parameter uses a private type}}
   public func e(a: Int, b: Int) -> InternalStruct { return InternalStruct() } // expected-error {{method cannot be declared public because its result uses an internal type}}
 }
-// FIXME: This type is actually private; it's just being reported as
-// fileprivate because it's top-level.
-func privateParam(a: PrivateStruct) {} // expected-error {{function must be declared fileprivate because its parameter uses a fileprivate type}}
+
+func privateParam(a: PrivateStruct) {} // expected-error {{function must be declared private or fileprivate because its parameter uses a private type}}
 
 public struct Initializers {
-  // FIXME: These types are actually private; they're just being reported as
-  // fileprivate because they're top-level.
-  init(a: PrivateStruct) {} // expected-error {{initializer must be declared fileprivate because its parameter uses a fileprivate type}}
+  init(a: PrivateStruct) {} // expected-error {{initializer must be declared fileprivate because its parameter uses a private type}}
 
-  public init(a: PrivateStruct, b: Int) {} // expected-error {{initializer cannot be declared public because its parameter uses a fileprivate type}}
-  public init(a: Int, b: PrivateStruct) {} // expected-error {{initializer cannot be declared public because its parameter uses a fileprivate type}}
-  public init(a: InternalStruct, b: PrivateStruct) {} // expected-error {{initializer cannot be declared public because its parameter uses a fileprivate type}}
-  public init(a: PrivateStruct, b: InternalStruct) { } // expected-error {{initializer cannot be declared public because its parameter uses a fileprivate type}}
+  public init(a: PrivateStruct, b: Int) {} // expected-error {{initializer cannot be declared public because its parameter uses a private type}}
+  public init(a: Int, b: PrivateStruct) {} // expected-error {{initializer cannot be declared public because its parameter uses a private type}}
+  public init(a: InternalStruct, b: PrivateStruct) {} // expected-error {{initializer cannot be declared public because its parameter uses a private type}}
+  public init(a: PrivateStruct, b: InternalStruct) { } // expected-error {{initializer cannot be declared public because its parameter uses a private type}}
 }
 
 
@@ -384,80 +368,65 @@ public protocol AssocTypes {
 
   associatedtype Internal: InternalClass // expected-error {{associated type in a public protocol uses an internal type in its requirement}}
   associatedtype InternalConformer: InternalProto // expected-error {{associated type in a public protocol uses an internal type in its requirement}}
-  // FIXME: These types are actually private; they're just being reported as
-  // fileprivate because they're top-level.
-  associatedtype PrivateConformer: PrivateProto // expected-error {{associated type in a public protocol uses a fileprivate type in its requirement}}
-  associatedtype PI: PrivateProto, InternalProto // expected-error {{associated type in a public protocol uses a fileprivate type in its requirement}}
-  associatedtype IP: InternalProto, PrivateProto // expected-error {{associated type in a public protocol uses a fileprivate type in its requirement}}
 
-  associatedtype PrivateDefault = PrivateStruct // expected-error {{associated type in a public protocol uses a fileprivate type in its default definition}}
+  associatedtype PrivateConformer: PrivateProto // expected-error {{associated type in a public protocol uses a private type in its requirement}}
+  associatedtype PI: PrivateProto, InternalProto // expected-error {{associated type in a public protocol uses a private type in its requirement}}
+  associatedtype IP: InternalProto, PrivateProto // expected-error {{associated type in a public protocol uses a private type in its requirement}}
+
+  associatedtype PrivateDefault = PrivateStruct // expected-error {{associated type in a public protocol uses a private type in its default definition}}
   associatedtype PublicDefault = PublicStruct
-  associatedtype PrivateDefaultConformer: PublicProto = PrivateStruct // expected-error {{associated type in a public protocol uses a fileprivate type in its default definition}}
-  associatedtype PublicDefaultConformer: PrivateProto = PublicStruct // expected-error {{associated type in a public protocol uses a fileprivate type in its requirement}}
-  associatedtype PrivatePrivateDefaultConformer: PrivateProto = PrivateStruct // expected-error {{associated type in a public protocol uses a fileprivate type in its requirement}}
+  associatedtype PrivateDefaultConformer: PublicProto = PrivateStruct // expected-error {{associated type in a public protocol uses a private type in its default definition}}
+  associatedtype PublicDefaultConformer: PrivateProto = PublicStruct // expected-error {{associated type in a public protocol uses a private type in its requirement}}
+  associatedtype PrivatePrivateDefaultConformer: PrivateProto = PrivateStruct // expected-error {{associated type in a public protocol uses a private type in its requirement}}
   associatedtype PublicPublicDefaultConformer: PublicProto = PublicStruct
 }
 
 public protocol RequirementTypes {
-  // FIXME: These types are actually private; they're just being reported as
-  // fileprivate because they're top-level.
-  var x: PrivateStruct { get } // expected-error {{property cannot be declared public because its type uses a fileprivate type}}
+  var x: PrivateStruct { get } // expected-error {{property cannot be declared public because its type uses a private type}}
   subscript(x: Int) -> InternalStruct { get set } // expected-error {{subscript cannot be declared public because its element type uses an internal type}}
-  func foo() -> PrivateStruct // expected-error {{method cannot be declared public because its result uses a fileprivate type}}
-  init(x: PrivateStruct) // expected-error {{initializer cannot be declared public because its parameter uses a fileprivate type}}
+  func foo() -> PrivateStruct // expected-error {{method cannot be declared public because its result uses a private type}}
+  init(x: PrivateStruct) // expected-error {{initializer cannot be declared public because its parameter uses a private type}}
 }
 
-// FIXME: These types are actually private; they're just being reported as
-// fileprivate because they're top-level.
-protocol DefaultRefinesPrivate : PrivateProto {} // expected-error {{protocol must be declared fileprivate because it refines a fileprivate protocol}}
-public protocol PublicRefinesPrivate : PrivateProto {} // expected-error {{public protocol cannot refine a fileprivate protocol}}
+protocol DefaultRefinesPrivate : PrivateProto {} // expected-error {{protocol must be declared private or fileprivate because it refines a private protocol}}
+public protocol PublicRefinesPrivate : PrivateProto {} // expected-error {{public protocol cannot refine a private protocol}}
 public protocol PublicRefinesInternal : InternalProto {} // expected-error {{public protocol cannot refine an internal protocol}}
-public protocol PublicRefinesPI : PrivateProto, InternalProto {} // expected-error {{public protocol cannot refine a fileprivate protocol}}
-public protocol PublicRefinesIP : InternalProto, PrivateProto {} // expected-error {{public protocol cannot refine a fileprivate protocol}}
+public protocol PublicRefinesPI : PrivateProto, InternalProto {} // expected-error {{public protocol cannot refine a private protocol}}
+public protocol PublicRefinesIP : InternalProto, PrivateProto {} // expected-error {{public protocol cannot refine a private protocol}}
 
 
-// FIXME: These types are actually private; they're just being reported as
-// fileprivate because they're top-level.
 // expected-note@+1 * {{type declared here}}
 private typealias PrivateInt = Int
-enum DefaultRawPrivate : PrivateInt { // expected-error {{enum must be declared fileprivate because its raw type uses a fileprivate type}}
+enum DefaultRawPrivate : PrivateInt { // expected-error {{enum must be declared private or fileprivate because its raw type uses a private type}}
   case A
 }
-public enum PublicRawPrivate : PrivateInt { // expected-error {{enum cannot be declared public because its raw type uses a fileprivate type}}
+public enum PublicRawPrivate : PrivateInt { // expected-error {{enum cannot be declared public because its raw type uses a private type}}
   case A
 }
-public enum MultipleConformance : PrivateProto, PrivateInt { // expected-error {{enum cannot be declared public because its raw type uses a fileprivate type}} expected-error {{must appear first}} {{35-35=PrivateInt, }} {{47-59=}}
+public enum MultipleConformance : PrivateProto, PrivateInt { // expected-error {{enum cannot be declared public because its raw type uses a private type}} expected-error {{must appear first}} {{35-35=PrivateInt, }} {{47-59=}}
   case A
   func privateReq() {}
 }
 
-// FIXME: These types are actually private; they're just being reported as
-// fileprivate because they're top-level.
 public class PublicSubclassPublic : PublicClass {}
 public class PublicSubclassInternal : InternalClass {} // expected-error {{class cannot be declared public because its superclass is internal}}
-public class PublicSubclassPrivate : PrivateClass {} // expected-error {{class cannot be declared public because its superclass is fileprivate}}
+public class PublicSubclassPrivate : PrivateClass {} // expected-error {{class cannot be declared public because its superclass is private}}
 
 class DefaultSubclassPublic : PublicClass {}
 class DefaultSubclassInternal : InternalClass {}
-class DefaultSubclassPrivate : PrivateClass {} // expected-error {{class must be declared fileprivate because its superclass is fileprivate}}
+class DefaultSubclassPrivate : PrivateClass {} // expected-error {{class must be declared private or fileprivate because its superclass is private}}
 
 
 public enum PublicEnumPrivate {
-  // FIXME: These types is actually private; it's just being reported as
-  // fileprivate because it's top-level.
-  case A(PrivateStruct) // expected-error {{enum case in a public enum uses a fileprivate type}}
+  case A(PrivateStruct) // expected-error {{enum case in a public enum uses a private type}}
 }
 enum DefaultEnumPrivate {
-  // FIXME: This types is actually private; it's just being reported as
-  // fileprivate because it's top-level.
-  case A(PrivateStruct) // expected-error {{enum case in an internal enum uses a fileprivate type}}
+  case A(PrivateStruct) // expected-error {{enum case in an internal enum uses a private type}}
 }
 public enum PublicEnumPI {
   case A(InternalStruct) // expected-error {{enum case in a public enum uses an internal type}}
-  // FIXME: These types are actually private; they're just being reported as
-  // fileprivate because they're top-level.
-  case B(PrivateStruct, InternalStruct) // expected-error {{enum case in a public enum uses a fileprivate type}}
-  case C(InternalStruct, PrivateStruct) // expected-error {{enum case in a public enum uses a fileprivate type}}
+  case B(PrivateStruct, InternalStruct) // expected-error {{enum case in a public enum uses a private type}}
+  case C(InternalStruct, PrivateStruct) // expected-error {{enum case in a public enum uses a private type}}
 }
 enum DefaultEnumPublic {
   case A(PublicStruct) // no-warning
@@ -465,28 +434,24 @@ enum DefaultEnumPublic {
 
 
 struct DefaultGeneric<T> {}
-// FIXME: These types are actually private; they're just being reported as
-// fileprivate because they're top-level.
-struct DefaultGenericPrivate<T: PrivateProto> {} // expected-error {{generic struct must be declared fileprivate because its generic parameter uses a fileprivate type}}
-struct DefaultGenericPrivate2<T: PrivateClass> {} // expected-error {{generic struct must be declared fileprivate because its generic parameter uses a fileprivate type}}
+
+struct DefaultGenericPrivate<T: PrivateProto> {} // expected-error {{generic struct must be declared private or fileprivate because its generic parameter uses a private type}}
+struct DefaultGenericPrivate2<T: PrivateClass> {} // expected-error {{generic struct must be declared private or fileprivate because its generic parameter uses a private type}}
 struct DefaultGenericPrivateReq<T> where T == PrivateClass {} // expected-error {{same-type requirement makes generic parameter 'T' non-generic}}
-// expected-error@-1 {{generic struct must be declared fileprivate because its generic requirement uses a fileprivate type}}
-struct DefaultGenericPrivateReq2<T> where T: PrivateProto {} // expected-error {{generic struct must be declared fileprivate because its generic requirement uses a fileprivate type}}
+// expected-error@-1 {{generic struct must be declared private or fileprivate because its generic requirement uses a private type}}
+struct DefaultGenericPrivateReq2<T> where T: PrivateProto {} // expected-error {{generic struct must be declared private or fileprivate because its generic requirement uses a private type}}
 
 public struct PublicGenericInternal<T: InternalProto> {} // expected-error {{generic struct cannot be declared public because its generic parameter uses an internal type}}
-// FIXME: These types are actually private; they're just being reported as
-// fileprivate because they're top-level.
-public struct PublicGenericPI<T: PrivateProto, U: InternalProto> {} // expected-error {{generic struct cannot be declared public because its generic parameter uses a fileprivate type}}
-public struct PublicGenericIP<T: InternalProto, U: PrivateProto> {} // expected-error {{generic struct cannot be declared public because its generic parameter uses a fileprivate type}}
-public struct PublicGenericPIReq<T: PrivateProto> where T: InternalProto {} // expected-error {{generic struct cannot be declared public because its generic parameter uses a fileprivate type}}
-public struct PublicGenericIPReq<T: InternalProto> where T: PrivateProto {} // expected-error {{generic struct cannot be declared public because its generic requirement uses a fileprivate type}}
+
+public struct PublicGenericPI<T: PrivateProto, U: InternalProto> {} // expected-error {{generic struct cannot be declared public because its generic parameter uses a private type}}
+public struct PublicGenericIP<T: InternalProto, U: PrivateProto> {} // expected-error {{generic struct cannot be declared public because its generic parameter uses a private type}}
+public struct PublicGenericPIReq<T: PrivateProto> where T: InternalProto {} // expected-error {{generic struct cannot be declared public because its generic parameter uses a private type}}
+public struct PublicGenericIPReq<T: InternalProto> where T: PrivateProto {} // expected-error {{generic struct cannot be declared public because its generic requirement uses a private type}}
 
 public func genericFunc<T: InternalProto>(_: T) {} // expected-error {{function cannot be declared public because its generic parameter uses an internal type}} {}
 public class GenericClass<T: InternalProto> { // expected-error {{generic class cannot be declared public because its generic parameter uses an internal type}}
-  // FIXME: These types are actually private; they're just being reported as
-  // fileprivate because they're top-level.
-  public init<T: PrivateProto>(_: T) {} // expected-error {{initializer cannot be declared public because its generic parameter uses a fileprivate type}}
-  public func genericMethod<T: PrivateProto>(_: T) {} // expected-error {{instance method cannot be declared public because its generic parameter uses a fileprivate type}}
+  public init<T: PrivateProto>(_: T) {} // expected-error {{initializer cannot be declared public because its generic parameter uses a private type}}
+  public func genericMethod<T: PrivateProto>(_: T) {} // expected-error {{instance method cannot be declared public because its generic parameter uses a private type}}
 }
 public enum GenericEnum<T: InternalProto> { // expected-error {{generic enum cannot be declared public because its generic parameter uses an internal type}}
   case A

--- a/test/attr/accessibility.swift
+++ b/test/attr/accessibility.swift
@@ -163,7 +163,7 @@ protocol InternalProto { // expected-note * {{declared here}}
 public extension InternalProto {} // expected-error {{extension of internal protocol cannot be declared public}} {{1-8=}}
 internal extension InternalProto where Assoc == PublicStruct {}
 internal extension InternalProto where Assoc == InternalStruct {}
-internal extension InternalProto where Assoc == PrivateStruct {} // expected-error {{extension cannot be declared internal because its generic requirement uses a fileprivate type}}
+internal extension InternalProto where Assoc == PrivateStruct {} // expected-error {{extension cannot be declared internal because its generic requirement uses a private type}}
 private extension InternalProto where Assoc == PublicStruct {}
 private extension InternalProto where Assoc == InternalStruct {}
 private extension InternalProto where Assoc == PrivateStruct {}
@@ -174,10 +174,10 @@ public protocol PublicProto {
 public extension PublicProto {}
 public extension PublicProto where Assoc == PublicStruct {}
 public extension PublicProto where Assoc == InternalStruct {} // expected-error {{extension cannot be declared public because its generic requirement uses an internal type}}
-public extension PublicProto where Assoc == PrivateStruct {} // expected-error {{extension cannot be declared public because its generic requirement uses a fileprivate type}}
+public extension PublicProto where Assoc == PrivateStruct {} // expected-error {{extension cannot be declared public because its generic requirement uses a private type}}
 internal extension PublicProto where Assoc == PublicStruct {}
 internal extension PublicProto where Assoc == InternalStruct {}
-internal extension PublicProto where Assoc == PrivateStruct {} // expected-error {{extension cannot be declared internal because its generic requirement uses a fileprivate type}}
+internal extension PublicProto where Assoc == PrivateStruct {} // expected-error {{extension cannot be declared internal because its generic requirement uses a private type}}
 private extension PublicProto where Assoc == PublicStruct {}
 private extension PublicProto where Assoc == InternalStruct {}
 private extension PublicProto where Assoc == PrivateStruct {}


### PR DESCRIPTION
<!-- What's in this pull request? -->

This pull request adds real `AccessScope` type that wraps `DeclContext` along with the bit, saying whether a top-level `DeclContext` should be treated as `private` rather than `fileprivate`. This changes fixes the issue when diagnostics occasionally claims that declaration is `fileprivate` even though the user has written `private`.

Now diagnostics claims correct messages, but there is one moment that I'd like to clarify.

Currently this is a valid code:

``` swift
private protocol PrivateProto {
  func privateReq()
}
public struct PublicStruct: PrivateProto {
  fileprivate func privateReq() {}
}
```

And we have tests for error message and fix-it:

``` swift
private/public/internal/fileprivate struct Struct: PrivateProto {
  private func privateReq() {} // expected-error {{... must be declared fileprivate because ... in fileprivate protocol 'PrivateProto'}} {{3-10=fileprivate}}
}
```

I find this error message a bit confusing, it would be clearer to see this error message next to the protocol declaration:

``` swift
private protocol PrivateProto { // {{ minimum accessibility for the top-level declaration is fileprivate }} {{3-10=fileprivate}}
  func privateReq()
}
```

Is this a valid point and should I start an evolution thread for this change?

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-2209](https://bugs.swift.org/browse/SR-2209).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
