### PR TITLE
[stdlib] simplify loop logic

### DIFF
--- a/stdlib/public/core/Join.swift
+++ b/stdlib/public/core/Join.swift
@@ -37,7 +37,7 @@ public struct JoinedIterator<Base : IteratorProtocol> : IteratorProtocol
   ///
   /// Once `nil` has been returned, all subsequent calls return `nil`.
   public mutating func next() -> Base.Element.Iterator.Element? {
-    repeat {
+    while true {
       switch _state {
       case .start:
         if let nextSubSequence = _base.next() {
@@ -75,7 +75,6 @@ public struct JoinedIterator<Base : IteratorProtocol> : IteratorProtocol
 
       }
     }
-    while true
   }
 
   internal var _base: Base


### PR DESCRIPTION
<!-- What's in this pull request? -->

The `repeat { ... } while true` in the body of `next()` can be simplified to just a `while true { ... }`.
I think this is better because you can see the loop condition up front, and `while true` behaves the same way with or without a leading `repeat` so might as well simplify this. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
