### PR TITLE
[Parser] Preserve empty getter functions for indentation

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3427,8 +3427,7 @@ bool Parser::parseGetSetImpl(ParseDeclOptions Flags, ParameterList *Indices,
                                        AddressorKind::NotAddressor, this,
                                        SourceLoc());
 
-    TheDecl->setBody(BraceStmt::create(Context, LastValidLoc, {},
-                                       Tok.getLoc()));
+    TheDecl->setBody(BraceStmt::create(Context, VarLBLoc, {}, Tok.getLoc()));
     TheDecl->setInvalid();
     Decls.push_back(TheDecl);
     return true;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3417,10 +3417,20 @@ bool Parser::parseGetSetImpl(ParseDeclOptions Flags, ParameterList *Indices,
   // Otherwise, we have a normal var or subscript declaration, parse the full
   // complement of specifiers, along with their bodies.
 
-  // If the body is completely empty, reject it.  This is at best a getter with
+  // If the body is completely empty, preserve it.  This is at best a getter with
   // an implicit fallthrough off the end.
   if (Tok.is(tok::r_brace)) {
     diagnose(Tok, diag::computed_property_no_accessors);
+    auto *TheDecl = createAccessorFunc(VarLBLoc, nullptr, TypeLoc(), nullptr,
+                                       SourceLoc(), Flags,
+                                       AccessorKind::IsGetter,
+                                       AddressorKind::NotAddressor, this,
+                                       SourceLoc());
+
+    TheDecl->setBody(BraceStmt::create(Context, LastValidLoc, {},
+                                       Tok.getLoc()));
+    TheDecl->setInvalid();
+    Decls.push_back(TheDecl);
     return true;
   }
 

--- a/test/SourceKit/CodeFormat/indent-toplevel.swift
+++ b/test/SourceKit/CodeFormat/indent-toplevel.swift
@@ -1,9 +1,14 @@
 for i in 0...5 {
 }
 
+var someProperty: String {
+
+}
 // RUN: %sourcekitd-test -req=format -line=1 -length=1 %s >%t.response
 // RUN: %sourcekitd-test -req=format -line=2 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=5 -length=1 %s >>%t.response
 // RUN: %FileCheck --strict-whitespace %s <%t.response
 
 // CHECK: key.sourcetext: "for i in 0...5 {"
 // CHECK: key.sourcetext: "}"
+// CHECK: key.sourcetext: "    "


### PR DESCRIPTION
<!-- What's in this pull request? -->

[Parser] Preserve empty getter functions to make sure indentation inside its body still works. rdar://28049927

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
