### PR TITLE
rephrase diagnostic

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -44,7 +44,7 @@ NOTE(note_from_clang,none,
   "%0", (StringRef))
 
 ERROR(clang_cannot_build_module,Fatal,
-  "could not build Objective-C module '%0'", (StringRef))
+  "could not build module '%0'", (StringRef))
 
 ERROR(bridging_header_missing,Fatal,
   "bridging header '%0' does not exist", (StringRef))

--- a/test/ClangModules/MixedSource/broken-modules.swift
+++ b/test/ClangModules/MixedSource/broken-modules.swift
@@ -22,7 +22,7 @@ import MissingDependencyFromSwift
 
 import MissingDependencyFromClang
 // CHECK: {{.+}}/Inputs/broken-modules/MissingDependencyFromClang.h:1:9: error: module 'Dependency' not found
-// CHECK: broken-modules.swift:[[@LINE-2]]:8: error: could not build Objective-C module 'MissingDependencyFromClang'
+// CHECK: broken-modules.swift:[[@LINE-2]]:8: error: could not build module 'MissingDependencyFromClang'
 // CHECK: error: no such module 'MissingDependencyFromClang'
 
 import BrokenClangModule
@@ -34,7 +34,7 @@ import BrokenClangModule
 // CLANG-CHECK: a-fake-file.h:45:11: note: expanded from macro 'I'
 // CLANG-CHECK: {{.+}}/Inputs/broken-modules/BrokenClangModule.h:11:35: error: expected ';' after top level declarator
 
-// CHECK: broken-modules.swift:[[@LINE-9]]:8: error: could not build Objective-C module 'BrokenClangModule'
+// CHECK: broken-modules.swift:[[@LINE-9]]:8: error: could not build module 'BrokenClangModule'
 // CHECK: error: no such module 'BrokenClangModule'
 // CHECK-BRIDGING-HEADER: error: failed to import bridging header '{{.*}}/BrokenClangModule.h'
 

--- a/test/ClangModules/broken-modules.swift
+++ b/test/ClangModules/broken-modules.swift
@@ -17,7 +17,7 @@
 #if MISSING_FROM_MODULE
 import MissingHeader
 // CHECK-MODULE-MAP: {{.*}}/Inputs/custom-modules/module.map:{{[0-9]+:[0-9]+}}: error: header 'this-header-does-not-exist.h' not found
-// CHECK-MODULE-MAP: broken-modules.swift:[[@LINE-2]]:8: error: could not build Objective-C module 'MissingHeader'
+// CHECK-MODULE-MAP: broken-modules.swift:[[@LINE-2]]:8: error: could not build module 'MissingHeader'
 
 #else
 
@@ -42,8 +42,8 @@ import ImportsMissingHeader
 // CHECK-INDIRECT-NEXT: @import ImportsMissingHeader;
 
 
-// CHECK-DIRECT: broken-modules.swift:{{[0-9]+}}:8: error: could not build Objective-C module 'ImportsMissingHeader'
-// CHECK-INDIRECT: broken-modules.swift:{{[0-9]+}}:8: error: could not build Objective-C module 'ImportsMissingHeaderIndirect'
+// CHECK-DIRECT: broken-modules.swift:{{[0-9]+}}:8: error: could not build module 'ImportsMissingHeader'
+// CHECK-INDIRECT: broken-modules.swift:{{[0-9]+}}:8: error: could not build module 'ImportsMissingHeaderIndirect'
 
 #endif
 

--- a/test/ClangModules/diags_from_module.swift
+++ b/test/ClangModules/diags_from_module.swift
@@ -7,7 +7,7 @@ import Module
 
 // CHECK: Another.h:2:4: error: Module should have been built without -DFOO
 // CHECK: Sub2.h:2:9: error: could not build module 'Another'
-// CHECK: diags_from_module.swift:[[@LINE-4]]:8: error: could not build Objective-C module 'Module'
+// CHECK: diags_from_module.swift:[[@LINE-4]]:8: error: could not build module 'Module'
 
 // RUN: %target-swift-frontend -parse %s -F %S/Inputs/frameworks 2> %tw.err.txt
 // RUN: %FileCheck -input-file=%tw.err.txt %s -check-prefix=CHECK-WARN

--- a/test/ClangModules/non-modular-include.swift
+++ b/test/ClangModules/non-modular-include.swift
@@ -2,7 +2,7 @@
 // RUN: not %target-swift-frontend -parse %s -I %S/Inputs/non-modular -F %S/Inputs/non-modular 2>&1 | %FileCheck %s
 
 // CHECK: {{.+}}/non-modular/Foo.framework/Headers/Foo.h:1:9: error: include of non-modular header inside framework module 'Foo'
-// CHECK: error: could not build Objective-C module 'Foo'
+// CHECK: error: could not build module 'Foo'
 // CHECK-NOT: error
 
 import Foo

--- a/test/ClangModules/submodules_indirect.swift
+++ b/test/ClangModules/submodules_indirect.swift
@@ -8,7 +8,7 @@
 // XFAIL: linux
 
 import ctypes_bits_exported
-// MISSING: could not build Objective-C module 'ctypes_bits_exported'
+// MISSING: could not build module 'ctypes_bits_exported'
 
 // From bits submodule
 public var x : DWORD = MY_INT


### PR DESCRIPTION
Removed Objective-C from diagnostic message to so that it is generic.
Resolves [SR-2409](https://bugs.swift.org/browse/SR-2409).
