### PR TITLE
[FixCode] Add @escaping when overriding mismatch is because of it.

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1130,8 +1130,8 @@ bool swift::fixItOverrideDeclarationTypes(TypeChecker &TC,
   // override uses a reference type, and the value type is bridged to the
   // reference type. This is a way to migrate code that makes use of types
   // that previously were not bridged to value types.
-  auto checkType = [&](Type overrideTy, Type baseTy,
-                       SourceRange typeRange) -> bool {
+  auto checkValueReferenceType = [&](Type overrideTy, Type baseTy,
+                                     SourceRange typeRange) -> bool {
     if (typeRange.isInvalid())
       return false;
 
@@ -1182,6 +1182,34 @@ bool swift::fixItOverrideDeclarationTypes(TypeChecker &TC,
     newOverrideTy->print(baseTypeStr, options);
     diag.fixItReplace(typeRange, baseTypeStr.str());
     return true;
+  };
+
+  // Check if overriding fails because we lack @escaping attribute on the function
+  // type repr.
+  auto checkTypeMissingEscaping = [&](Type overrideTy, Type baseTy,
+                                      SourceRange typeRange) -> bool {
+    // Fix-it needs position to apply.
+    if (typeRange.isInvalid())
+      return false;
+    auto overrideFnTy = overrideTy->getAs<AnyFunctionType>();
+    auto baseFnTy = baseTy->getAs<AnyFunctionType>();
+
+    // Both types should be function.
+    if (overrideFnTy && baseFnTy &&
+        // The overriding function type should be no escaping.
+        overrideFnTy->getExtInfo().isNoEscape() &&
+        // The overriden function type should be escaping.
+        !baseFnTy->getExtInfo().isNoEscape()) {
+      diag.fixItInsert(typeRange.Start, "@escaping ");
+      return true;
+    }
+    return false;
+  };
+
+  auto checkType = [&](Type overrideTy, Type baseTy,
+                       SourceRange typeRange) -> bool {
+    return checkValueReferenceType(overrideTy, baseTy, typeRange) ||
+      checkTypeMissingEscaping(overrideTy, baseTy, typeRange);
   };
 
   if (auto *var = dyn_cast<VarDecl>(decl)) {

--- a/test/Constraints/override.swift
+++ b/test/Constraints/override.swift
@@ -12,3 +12,21 @@ func removeOverrides<SomeSub: Sub>(concrete: Sub, generic: SomeSub) {
   _ = concrete.foo()
   _ = generic.foo()
 }
+
+class Base1 {
+	func foo1(a : Int, b : @escaping ()->()) {} // expected-note{{potential overridden instance method 'foo1(a:b:)' here}}
+	func foo2(a : @escaping (Int)->(Int), b : @escaping ()->()) {} // expected-note{{potential overridden instance method 'foo2(a:b:)' here}}
+}
+
+class Sub1 : Base1 {
+	override func foo1(a : Int, b : ()->()) {} // expected-error {{method does not override any method from its superclass}} expected-note {{type does not match superclass instance method with type '(Int, @escaping () -> ()) -> ()'}} {{34-34=@escaping }}
+	override func foo2(a : (Int)->(Int), b : ()->()) {} // expected-error {{method does not override any method from its superclass}} expected-note{{type does not match superclass instance method with type '(@escaping (Int) -> (Int), @escaping () -> ()) -> ()'}} {{25-25=@escaping }} {{43-43=@escaping }}
+}
+
+class Base2 {
+  func foo<T>(a : @escaping (T) ->()) {} // expected-note{{potential overridden instance method 'foo(a:)' here}}
+}
+
+class Sub2 : Base2 {
+  override func foo<T>(a : (T) ->()) {} // expected-error {{method does not override any method from its superclass}} expected-note{{type does not match superclass instance method with type '<T> (a: (T) -> ()) -> ()'}}{{28-28=@escaping }}
+}

--- a/test/attr/attr_autoclosure.swift
+++ b/test/attr/attr_autoclosure.swift
@@ -88,7 +88,7 @@ class Super {
 class Sub : Super {
   override func f1(_ x: @autoclosure(escaping)() -> ()) { }
     // expected-warning@-1{{@autoclosure(escaping) is deprecated; use @autoclosure @escaping instead}} {{37-47= @escaping }}
-  override func f2(_ x: @autoclosure () -> ()) { } // expected-error{{does not override any method}}
+  override func f2(_ x: @autoclosure () -> ()) { } // expected-error{{does not override any method}} // expected-note{{type does not match superclass instance method with type '(@autoclosure @escaping () -> ()) -> ()'}}
   override func f3(_ x: @autoclosure(escaping) () -> ()) { }  // expected-error{{does not override any method}}
     // expected-warning@-1{{@autoclosure(escaping) is deprecated; use @autoclosure @escaping instead}} {{37-47= @escaping}}
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->

[FixCode] Add @escaping when overriding mismatch is because of it. rdar://27814862
- Explanation: With the change of default escaping behavior, users' existing code overriding
  objc functions may need to add @escaping to make the overriding match as before. This
  patch checks if an overriding mismatch is due to the lacking of @escaping and add
  it as a fixit.
- Scope of issue: One fixit in overriding.
- Reviewer: @jrose-apple 
- Risk: Low
- Radar: rdar://27814862

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
