### PR TITLE
[Swift 3] print `__attribute__((noescape))` in generated Obj-C headers

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -492,6 +492,7 @@ namespace {
         // FIXME: If we were walking TypeLocs, we could actually get parameter
         // names. The probably doesn't matter outside of a FuncDecl, which
         // we'll have to special-case, but it's an interesting bit of data loss.
+        // We also lose `noescape`. <https://bugs.swift.org/browse/SR-2529>
         params.push_back(swiftParamTy);
       }
 

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -81,6 +81,12 @@ namespace {
     Normal = false,
     CustomNamesOnly = true,
   };
+
+  /// Whether the type being printed is in function param position.
+  enum IsFunctionParam_t : bool {
+    IsFunctionParam = true,
+    IsNotFunctionParam = false,
+  };
 }
 
 static StringRef getNameForObjC(const ValueDecl *VD,
@@ -361,7 +367,7 @@ private:
         (clangParam && isNSUInteger(clangParam->getType()))) {
       os << "NSUInteger";
     } else {
-      print(param->getType(), OTK_None);
+      print(param->getType(), OTK_None, Identifier(), IsFunctionParam);
     }
     os << ")";
 
@@ -542,19 +548,6 @@ private:
 
     os << ";\n";
   }
-  
-  void printSingleFunctionParam(const ParamDecl *param) {
-    // The type name may be multi-part.
-    PrintMultiPartType multiPart(*this);
-    visitPart(param->getType(), OTK_None);
-    auto name = param->getName();
-    if (name.empty())
-      return;
-    
-    os << ' ' << name;
-    if (isClangKeyword(name))
-      os << "_";
-  }
 
   void printAbstractFunctionAsFunction(FuncDecl *FD) {
     printDocumentationComment(FD);
@@ -578,7 +571,8 @@ private:
     auto params = FD->getParameterLists().back();
     interleave(*params,
                [&](const ParamDecl *param) {
-                 printSingleFunctionParam(param);
+                 print(param->getType(), OTK_None, param->getName(),
+                       IsFunctionParam);
                },
                [&]{ os << ", "; });
     
@@ -1437,12 +1431,13 @@ private:
       } else {
         interleave(tupleTy->getElements(),
                    [this](TupleTypeElt elt) {
-                     print(elt.getType(), OTK_None, elt.getName());
+                     print(elt.getType(), OTK_None, elt.getName(),
+                           IsFunctionParam);
                    },
                    [this] { os << ", "; });
       }
     } else {
-      print(paramsTy, OTK_None);
+      print(paramsTy, OTK_None, Identifier(), IsFunctionParam);
     }
     os << ")";
   }
@@ -1516,8 +1511,15 @@ private:
   /// visitPart().
 public:
   void print(Type ty, Optional<OptionalTypeKind> optionalKind, 
-             Identifier name = Identifier()) {
+             Identifier name = Identifier(),
+             IsFunctionParam_t isFuncParam = IsNotFunctionParam) {
     PrettyStackTraceType trace(M.getASTContext(), "printing", ty);
+
+    if (isFuncParam)
+      if (auto fnTy = ty->lookThroughAllAnyOptionalTypes()
+                        ->getAs<AnyFunctionType>())
+        if (fnTy->isNoEscape())
+          os << "SWIFT_NOESCAPE ";
 
     PrintMultiPartType multiPart(*this);
     visitPart(ty, optionalKind);
@@ -2079,6 +2081,11 @@ public:
              "__attribute__((objc_method_family(X)))\n"
            "#else\n"
            "# define SWIFT_METHOD_FAMILY(X)\n"
+           "#endif\n"
+           "#if defined(__has_attribute) && __has_attribute(noescape)\n"
+           "# define SWIFT_NOESCAPE __attribute__((noescape))\n"
+           "#else\n"
+           "# define SWIFT_NOESCAPE\n"
            "#endif\n"
            "#if !defined(SWIFT_CLASS_EXTRA)\n"
            "# define SWIFT_CLASS_EXTRA\n"

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1431,6 +1431,7 @@ static Type applyNonEscapingFromContext(DeclContext *DC,
     // FIXME: It would be better to add a new AttributedType sugared type,
     // which would wrap the NameAliasType or ParenType, and apply the
     // isNoEscape bit when de-sugaring.
+    // <https://bugs.swift.org/browse/SR-2520>
     return FunctionType::get(funcTy->getInput(), funcTy->getResult(), extInfo);
   }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1410,9 +1410,9 @@ static bool isDefaultNoEscapeContext(const DeclContext *DC) {
 }
 
 // Hack to apply context-specific @escaping to an AST function type.
-static Type adjustFunctionExtInfo(DeclContext *DC,
-                                  Type ty,
-                                  TypeResolutionOptions options) {
+static Type applyNonEscapingFromContext(DeclContext *DC,
+                                        Type ty,
+                                        TypeResolutionOptions options) {
   // Remember whether this is a function parameter.
   bool isFunctionParam =
     options.contains(TR_FunctionInput) ||
@@ -1426,7 +1426,11 @@ static Type adjustFunctionExtInfo(DeclContext *DC,
   if (defaultNoEscape && !extInfo.isNoEscape()) {
     extInfo = extInfo.withNoEscape();
 
-    // We lost the sugar to flip the isNoEscape bit
+    // We lost the sugar to flip the isNoEscape bit.
+    //
+    // FIXME: It would be better to add a new AttributedType sugared type,
+    // which would wrap the NameAliasType or ParenType, and apply the
+    // isNoEscape bit when de-sugaring.
     return FunctionType::get(funcTy->getInput(), funcTy->getResult(), extInfo);
   }
 
@@ -1467,7 +1471,7 @@ Type TypeChecker::resolveIdentifierType(
   // Hack to apply context-specific @escaping to a typealias with an underlying
   // function type.
   if (result->is<FunctionType>())
-    result = adjustFunctionExtInfo(DC, result, options);
+    result = applyNonEscapingFromContext(DC, result, options);
 
   // We allow a type to conform to a protocol that is less available than
   // the type itself. This enables a type to retroactively model or directly
@@ -1716,7 +1720,7 @@ Type TypeResolver::resolveType(TypeRepr *repr, TypeResolutionOptions options) {
       // Default non-escaping for closure parameters
       auto result = resolveASTFunctionType(cast<FunctionTypeRepr>(repr), options);
       if (result && result->is<FunctionType>())
-        return adjustFunctionExtInfo(DC, result, options);
+        return applyNonEscapingFromContext(DC, result, options);
       return result;
     }
     return resolveSILFunctionType(cast<FunctionTypeRepr>(repr), options);
@@ -1973,10 +1977,6 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
           .fixItReplace(resultRange, "Never");
     }
 
-    if (attrs.has(TAK_noescape)) {
-      // FIXME: diagnostic to tell user this is redundant and drop it
-    }
-
     // Resolve the function type directly with these attributes.
     FunctionType::ExtInfo extInfo(rep,
                                   attrs.has(TAK_autoclosure),
@@ -2016,7 +2016,7 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
       attrs.clearAttribute(TAK_escaping);
     } else {
       // No attribute; set the isNoEscape bit if we're in parameter context.
-      ty = adjustFunctionExtInfo(DC, ty, options);
+      ty = applyNonEscapingFromContext(DC, ty, options);
     }
   }
 
@@ -2034,6 +2034,7 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
       }
     }
   } else if (hasFunctionAttr && fnRepr) {
+    // Remove the function attributes from the set so that we don't diagnose.
     for (auto i : FunctionAttrs)
       attrs.clearAttribute(i);
     attrs.convention = None;
@@ -2484,6 +2485,11 @@ Type TypeResolver::resolveTupleType(TupleTypeRepr *repr,
   
   // If this is the top level of a function input list, peel off the
   // ImmediateFunctionInput marker and install a FunctionInput one instead.
+  //
+  // If we have a single ParenType though, don't clear these bits; we
+  // still want to parse the type contained therein as if it were in
+  // parameter position, meaning function types are not @escaping by
+  // default.
   auto elementOptions = options;
   if (!repr->isParenType()) {
     elementOptions = withoutContext(elementOptions);

--- a/test/ClangModules/blocks_parse.swift
+++ b/test/ClangModules/blocks_parse.swift
@@ -19,6 +19,8 @@ func testNoEscape(f: @convention(block) () -> Void, nsStr: NSString,
                   fStr: (String!) -> Void) {
   accepts_noescape_block(f)
   accepts_noescape_block(f)
+  
+  // Please see related tests in PrintAsObjC/imported-block-typedefs.swift.
 
   // rdar://problem/19818617
   nsStr.enumerateLines(fStr) // okay due to @noescape

--- a/test/Inputs/clang-importer-sdk/usr/include/blocks.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/blocks.h
@@ -19,3 +19,5 @@ my_block_t __nullable blockWithNullable();
 void accepts_block(my_block_t) __attribute__((nonnull));
 void accepts_noescape_block(__attribute__((noescape)) my_block_t) __attribute__((nonnull));
 
+// Please see related tests in PrintAsObjC/imported-block-typedefs.swift.
+

--- a/test/PrintAsObjC/Inputs/comments-expected-output.h
+++ b/test/PrintAsObjC/Inputs/comments-expected-output.h
@@ -127,7 +127,7 @@ SWIFT_CLASS("_TtC8comments16ClosureContainer")
   \a combine error: Nothing.
 
 */
-- (void)closureParameterExplodedExplodedWithA:(NSInteger)a combine:(NSInteger (^ _Nonnull)(NSInteger, NSInteger))combine;
+- (void)closureParameterExplodedExplodedWithA:(NSInteger)a combine:(SWIFT_NOESCAPE NSInteger (^ _Nonnull)(NSInteger, NSInteger))combine;
 /**
   Partially applies a binary operator.
   \param a The left-hand side to partially apply.
@@ -150,7 +150,7 @@ SWIFT_CLASS("_TtC8comments16ClosureContainer")
   \a combine error: Nothing.
 
 */
-- (void)closureParameterOutlineExplodedWithA:(NSInteger)a combine:(NSInteger (^ _Nonnull)(NSInteger, NSInteger))combine;
+- (void)closureParameterOutlineExplodedWithA:(NSInteger)a combine:(SWIFT_NOESCAPE NSInteger (^ _Nonnull)(NSInteger, NSInteger))combine;
 /**
   Partially applies a binary operator.
   \param a The left-hand side to partially apply.
@@ -173,7 +173,7 @@ SWIFT_CLASS("_TtC8comments16ClosureContainer")
   \a combine error: Nothing.
 
 */
-- (void)closureParameterOutlineOutlineWithA:(NSInteger)a combine:(NSInteger (^ _Nonnull)(NSInteger, NSInteger))combine;
+- (void)closureParameterOutlineOutlineWithA:(NSInteger)a combine:(SWIFT_NOESCAPE NSInteger (^ _Nonnull)(NSInteger, NSInteger))combine;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
 

--- a/test/PrintAsObjC/Inputs/imported-block-typedefs.h
+++ b/test/PrintAsObjC/Inputs/imported-block-typedefs.h
@@ -1,0 +1,5 @@
+typedef void (^PlainBlock)(void);
+typedef void (^BlockWithEscapingParam)(PlainBlock);
+typedef void (^BlockWithNoescapeParam)(__attribute__((noescape)) PlainBlock);
+typedef BlockWithEscapingParam (^BlockReturningBlockWithEscapingParam)(void);
+typedef BlockWithNoescapeParam (^BlockReturningBlockWithNoescapeParam)(void);

--- a/test/PrintAsObjC/blocks.swift
+++ b/test/PrintAsObjC/blocks.swift
@@ -14,98 +14,136 @@ import ObjectiveC
 typealias MyTuple = (Int, AnyObject?)
 typealias MyNamedTuple = (a: Int, b: AnyObject?)
 typealias MyInt = Int
+typealias MyBlockWithEscapingParam = (@escaping () -> ()) -> Int
+typealias MyBlockWithNoescapeParam = (() -> ()) -> Int
+
+// Please see related tests in PrintAsObjC/imported-block-typedefs.swift.
 
 // CHECK-LABEL: @interface Callbacks
-// CHECK-NEXT: - (void (^ _Nonnull)(void))voidBlocks:(void (^ _Nonnull)(void))input;
-// CHECK-NEXT: - (void)manyArguments:(void (^ _Nonnull)(float, float, double, double))input;
-// CHECK-NEXT: - (void)blockTakesBlock:(void (^ _Nonnull)(void (^ _Nonnull)(void)))input;
-// CHECK-NEXT: - (void)blockReturnsBlock:(void (^ _Nonnull (^ _Nonnull)(void))(void))input;
-// CHECK-NEXT: - (void)blockTakesAndReturnsBlock:(uint8_t (^ _Nonnull (^ _Nonnull)(uint16_t (^ _Nonnull)(int16_t)))(int8_t))input;
-// CHECK-NEXT: - (void)blockTakesTwoBlocksAndReturnsBlock:(uint8_t (^ _Nonnull (^ _Nonnull)(uint16_t (^ _Nonnull)(int16_t), uint32_t (^ _Nonnull)(int32_t)))(int8_t))input;
-// CHECK-NEXT: - (void (^ _Nullable)(NSObject * _Nonnull))returnsBlockWithInput;
-// CHECK-NEXT: - (void (^ _Nullable)(NSObject * _Nonnull))returnsBlockWithParenthesizedInput;
-// CHECK-NEXT: - (void (^ _Nullable)(NSObject * _Nonnull, NSObject * _Nonnull))returnsBlockWithTwoInputs;
-// CHECK-NEXT: - (void)blockWithTypealias:(NSInteger (^ _Nonnull)(NSInteger, id _Nullable))input;
-// CHECK-NEXT: - (void)blockWithSimpleTypealias:(NSInteger (^ _Nonnull)(NSInteger))input;
-// CHECK-NEXT: - (void)namedArguments:(void (^ _Nonnull)(float, float, double, double))input;
-// CHECK-NEXT: - (void)blockTakesNamedBlock:(void (^ _Nonnull)(void (^ _Nonnull)(void)))input;
-// CHECK-NEXT: - (void (^ _Nullable)(NSObject * _Nonnull))returnsBlockWithNamedInput;
-// CHECK-NEXT: - (void)blockWithTypealiasWithNames:(NSInteger (^ _Nonnull)(NSInteger a, id _Nullable b))input;
-// CHECK-NEXT: - (void)blockWithKeyword:(NSInteger (^ _Nonnull)(NSInteger))_Nullable_;
-// CHECK-NEXT: - (NSInteger (* _Nonnull)(NSInteger))functionPointers:(NSInteger (* _Nonnull)(NSInteger))input;
-// CHECK-NEXT: - (void)functionPointerTakesAndReturnsFunctionPointer:(NSInteger (* _Nonnull (^ _Nonnull (* _Nonnull)(NSInteger))(NSInteger))(NSInteger))input;
-// CHECK-NEXT: - (NSInteger (* _Nonnull)(NSInteger))functionPointersWithName:(NSInteger (* _Nonnull)(NSInteger))input;
-// CHECK-NEXT: @property (nonatomic, copy) NSInteger (^ _Nullable savedBlock)(NSInteger);
-// CHECK-NEXT: @property (nonatomic, copy) NSInteger (^ _Nullable savedBlockWithName)(NSInteger);
-// CHECK-NEXT: @property (nonatomic) NSInteger (* _Nonnull savedFunctionPointer)(NSInteger);
-// CHECK-NEXT: @property (nonatomic) NSInteger (* _Nullable savedFunctionPointer2)(NSInteger);
-// CHECK-NEXT: @property (nonatomic) NSInteger (* _Nonnull savedFunctionPointerWithName)(NSInteger);
-// CHECK-NEXT: @property (nonatomic, copy, getter=this, setter=setThis:) NSInteger (^ _Nonnull this_)(NSInteger);
-// CHECK-NEXT: @property (nonatomic, getter=class, setter=setClass:) NSInteger (* _Nonnull class_)(NSInteger);
-// CHECK-NEXT: init
-// CHECK-NEXT: @end
 @objc class Callbacks {
+  
+  // CHECK-NEXT: - (void (^ _Nonnull)(void))voidBlocks:(void (^ _Nonnull)(void))input;
   func voidBlocks(_ input: @escaping () -> ()) -> () -> () {
     return input
   }
+  
+  // CHECK-NEXT: - (void)manyArguments:(void (^ _Nonnull)(float, float, double, double))input;
   func manyArguments(_ input: @escaping (Float, Float, Double, Double) -> ()) {}
 
+  // CHECK-NEXT: - (void)blockTakesBlock:(void (^ _Nonnull)(SWIFT_NOESCAPE void (^ _Nonnull)(void)))input;
   func blockTakesBlock(_ input: @escaping (() -> ()) -> ()) {}
+  
+  // CHECK-NEXT: - (void)blockReturnsBlock:(void (^ _Nonnull (^ _Nonnull)(void))(void))input;
   func blockReturnsBlock(_ input: @escaping () -> () -> ()) {}
+  
+  // CHECK-NEXT: - (void)blockTakesAndReturnsBlock:(SWIFT_NOESCAPE uint8_t (^ _Nonnull (^ _Nonnull)(SWIFT_NOESCAPE uint16_t (^ _Nonnull)(int16_t)))(int8_t))input;
   func blockTakesAndReturnsBlock(_ input:
     ((Int16) -> (UInt16)) ->
                 ((Int8) -> (UInt8))) {}
+  
+  // CHECK-NEXT: - (void)blockTakesTwoBlocksAndReturnsBlock:(SWIFT_NOESCAPE uint8_t (^ _Nonnull (^ _Nonnull)(SWIFT_NOESCAPE uint16_t (^ _Nonnull)(int16_t), SWIFT_NOESCAPE uint32_t (^ _Nonnull)(int32_t)))(int8_t))input;
   func blockTakesTwoBlocksAndReturnsBlock(_ input:
     ((Int16) -> (UInt16),
                  (Int32) -> (UInt32)) ->
                 ((Int8) -> (UInt8))) {}
 
+  // CHECK-NEXT: - (void (^ _Nullable)(NSObject * _Nonnull))returnsBlockWithInput;
   func returnsBlockWithInput() -> ((NSObject) -> ())? {
     return nil
   }
+  
+  // CHECK-NEXT: - (void (^ _Nullable)(NSObject * _Nonnull))returnsBlockWithParenthesizedInput;
   func returnsBlockWithParenthesizedInput() -> ((NSObject) -> ())? {
     return nil
   }
+  
+  // CHECK-NEXT: - (void (^ _Nullable)(NSObject * _Nonnull, NSObject * _Nonnull))returnsBlockWithTwoInputs;
   func returnsBlockWithTwoInputs() -> ((NSObject, NSObject) -> ())? {
     return nil
   }
 
+  // CHECK-NEXT: - (void)blockWithTypealias:(NSInteger (^ _Nonnull)(NSInteger, id _Nullable))input;
   func blockWithTypealias(_ input: @escaping (MyTuple) -> MyInt) {}
+  
+  // CHECK-NEXT: - (void)blockWithSimpleTypealias:(NSInteger (^ _Nonnull)(NSInteger))input;
   func blockWithSimpleTypealias(_ input: @escaping (MyInt) -> MyInt) {}
 
+  // CHECK-NEXT: - (void)namedArguments:(void (^ _Nonnull)(float, float, double, double))input;
   func namedArguments(_ input: @escaping (_ f1: Float, _ f2: Float, _ d1: Double, _ d2: Double) -> ()) {}
+  
+  // CHECK-NEXT: - (void)blockTakesNamedBlock:(void (^ _Nonnull)(SWIFT_NOESCAPE void (^ _Nonnull)(void)))input;
   func blockTakesNamedBlock(_ input: @escaping (_ block: () -> ()) -> ()) {}
+  
+  // CHECK-NEXT: - (void (^ _Nullable)(NSObject * _Nonnull))returnsBlockWithNamedInput;
   func returnsBlockWithNamedInput() -> ((_ object: NSObject) -> ())? {
     return nil
   }
 
+  // CHECK-NEXT: - (void)blockWithTypealiasWithNames:(SWIFT_NOESCAPE NSInteger (^ _Nonnull)(NSInteger a, id _Nullable b))input;
   func blockWithTypealiasWithNames(_ input: (MyNamedTuple) -> MyInt) {}
 
+  // CHECK-NEXT: - (void)blockWithKeyword:(SWIFT_NOESCAPE NSInteger (^ _Nonnull)(NSInteger))_Nullable_;
   func blockWithKeyword(_ _Nullable: (_ `class`: Int) -> Int) {}
 
+  // CHECK-NEXT: - (NSInteger (* _Nonnull)(NSInteger))functionPointers:(NSInteger (* _Nonnull)(NSInteger))input;
   func functionPointers(_ input: @escaping @convention(c) (Int) -> Int)
       -> @convention(c) (Int) -> Int {
     return input
   }
 
+  // CHECK-NEXT: - (void)blockWithBlockTypealias:(SWIFT_NOESCAPE NSInteger (^ _Nonnull)(void (^ _Nonnull)(void)))block;
+  func blockWithBlockTypealias(_ block: MyBlockWithEscapingParam) {}
+
+  // CHECK-NEXT: - (void)blockWithBlockTypealias2:(NSInteger (^ _Nonnull)(void (^ _Nonnull)(void)))block;
+  func blockWithBlockTypealias2(_ block: @escaping MyBlockWithEscapingParam) {}
+
+  // CHECK-NEXT: - (void)blockWithBlockTypealias3:(SWIFT_NOESCAPE NSInteger (^ _Nonnull)(SWIFT_NOESCAPE void (^ _Nonnull)(void)))block;
+  func blockWithBlockTypealias3(_ block: MyBlockWithNoescapeParam) {}
+
+  // CHECK-NEXT: - (void)blockWithBlockTypealias4:(NSInteger (^ _Nonnull)(SWIFT_NOESCAPE void (^ _Nonnull)(void)))block;
+  func blockWithBlockTypealias4(_ block: @escaping MyBlockWithNoescapeParam) {}
+
+  // CHECK-NEXT: - (void)functionPointerTakesAndReturnsFunctionPointer:(NSInteger (* _Nonnull (^ _Nonnull (* _Nonnull)(NSInteger))(NSInteger))(NSInteger))input;
   func functionPointerTakesAndReturnsFunctionPointer(
     _ input: @escaping @convention(c) (Int) -> (Int)
                               -> @convention(c) (Int) -> Int
   ) {
   }
+  
+  // CHECK-NEXT: - (void (* _Nonnull)(SWIFT_NOESCAPE NSInteger (* _Nonnull)(NSInteger, NSInteger)))returnsFunctionPointerThatTakesFunctionPointer;
+  func returnsFunctionPointerThatTakesFunctionPointer() ->
+    @convention(c) (_ comparator: @convention(c) (_ x: Int, _ y: Int) -> Int) -> Void {
+    fatalError()
+  }
 
+  // CHECK-NEXT: - (NSInteger (* _Nonnull)(NSInteger))functionPointersWithName:(NSInteger (* _Nonnull)(NSInteger))input;
   func functionPointersWithName(_ input: @escaping @convention(c) (_ value: Int) -> Int)
       -> @convention(c) (_ result: Int) -> Int {
     return input
   }
 
+  // CHECK-NEXT: @property (nonatomic, copy) NSInteger (^ _Nullable savedBlock)(NSInteger);
   var savedBlock: ((Int) -> Int)?
+  
+  // CHECK-NEXT: @property (nonatomic, copy) NSInteger (^ _Nullable savedBlockWithName)(NSInteger);
   var savedBlockWithName: ((_ x: Int) -> Int)?
+  
+  // CHECK-NEXT: @property (nonatomic) NSInteger (* _Nonnull savedFunctionPointer)(NSInteger);
   var savedFunctionPointer: @convention(c) (Int) -> Int = { $0 }
+  
+  // CHECK-NEXT: @property (nonatomic) NSInteger (* _Nullable savedFunctionPointer2)(NSInteger);
   var savedFunctionPointer2: (@convention(c) (Int) -> Int)? = { $0 }
+  
+  // CHECK-NEXT: @property (nonatomic) NSInteger (* _Nonnull savedFunctionPointerWithName)(NSInteger);
   var savedFunctionPointerWithName: @convention(c) (_ x: Int) -> Int = { $0 }
 
   // The following uses a clang keyword as the name.
+  
+  // CHECK-NEXT: @property (nonatomic, copy, getter=this, setter=setThis:) NSInteger (^ _Nonnull this_)(NSInteger);
   var this: (_ block: Int) -> Int = { $0 }
+  
+  // CHECK-NEXT: @property (nonatomic, getter=class, setter=setClass:) NSInteger (* _Nonnull class_)(NSInteger);
   var `class`: @convention(c) (_ function: Int) -> Int = { $0 }
 }
+// CHECK-NEXT: init
+// CHECK-NEXT: @end

--- a/test/PrintAsObjC/cdecl.swift
+++ b/test/PrintAsObjC/cdecl.swift
@@ -11,21 +11,35 @@
 // CHECK: /**
 // CHECK-NEXT: What a nightmare!
 // CHECK: */
-// CHECK-LABEL: double (^ _Nonnull block_nightmare(float (^ _Nonnull x)(NSInteger)))(char);
+// CHECK-LABEL: double (^ _Nonnull block_nightmare(SWIFT_NOESCAPE float (^ _Nonnull x)(NSInteger)))(char);
 
 /// What a nightmare!
 @_cdecl("block_nightmare")
 public func block_nightmare(x: @convention(block) (Int) -> Float)
   -> @convention(block) (CChar) -> Double { return { _ in 0 } }
 
+// CHECK-LABEL: double (^ _Nonnull block_recurring_nightmare(float (^ _Nonnull x)(SWIFT_NOESCAPE NSInteger (^ _Nonnull)(double))))(SWIFT_NOESCAPE char (^ _Nonnull)(unsigned char));
+@_cdecl("block_recurring_nightmare")
+public func block_recurring_nightmare(x: @escaping @convention(block) (@convention(block) (Double) -> Int) -> Float)
+  -> @convention(block) (_ asdfasdf: @convention(block) (CUnsignedChar) -> CChar) -> Double {
+  fatalError()
+}
+
 // CHECK-LABEL: void foo_bar(NSInteger x, NSInteger y);
 @_cdecl("foo_bar")
 func foo(x: Int, bar y: Int) {}
 
-// CHECK-LABEL: double (* _Nonnull function_pointer_nightmare(float (* _Nonnull x)(NSInteger)))(char);
+// CHECK-LABEL: double (* _Nonnull function_pointer_nightmare(SWIFT_NOESCAPE float (* _Nonnull x)(NSInteger)))(char);
 @_cdecl("function_pointer_nightmare")
 func function_pointer_nightmare(x: @convention(c) (Int) -> Float)
   -> @convention(c) (CChar) -> Double { return { _ in 0 } }
+
+// CHECK-LABEL: double (* _Nonnull function_pointer_recurring_nightmare(float (* _Nonnull x)(SWIFT_NOESCAPE NSInteger (* _Nonnull)(double))))(SWIFT_NOESCAPE char (* _Nonnull)(unsigned char));
+@_cdecl("function_pointer_recurring_nightmare")
+public func function_pointer_recurring_nightmare(x: @escaping @convention(c) (@convention(c) (Double) -> Int) -> Float)
+  -> @convention(c) (@convention(c) (CUnsignedChar) -> CChar) -> Double {
+  fatalError()
+}
   
 // CHECK-LABEL: void has_keyword_arg_names(NSInteger auto_, NSInteger union_);
 @_cdecl("has_keyword_arg_names")

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -690,7 +690,7 @@ public class NonObjCClass { }
 // CHECK-NEXT: - (nullable instancetype)method4AndReturnError:(NSError * _Nullable * _Nullable)error;
 // CHECK-NEXT: - (nullable instancetype)initAndReturnError:(NSError * _Nullable * _Nullable)error OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: - (nullable instancetype)initWithString:(NSString * _Nonnull)string error:(NSError * _Nullable * _Nullable)error OBJC_DESIGNATED_INITIALIZER;
-// CHECK-NEXT: - (nullable instancetype)initAndReturnError:(NSError * _Nullable * _Nullable)error fn:(NSInteger (^ _Nonnull)(NSInteger))fn OBJC_DESIGNATED_INITIALIZER;
+// CHECK-NEXT: - (nullable instancetype)initAndReturnError:(NSError * _Nullable * _Nullable)error fn:(SWIFT_NOESCAPE NSInteger (^ _Nonnull)(NSInteger))fn OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: @end
 @objc class Throwing1 {
   func method1() throws { }

--- a/test/PrintAsObjC/imported-block-typedefs.swift
+++ b/test/PrintAsObjC/imported-block-typedefs.swift
@@ -1,0 +1,79 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s -import-objc-header %S/Inputs/imported-block-typedefs.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/imported-block-typedefs.swiftmodule -parse -emit-objc-header-path %t/imported-block-typedefs-output.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
+// RUN: %FileCheck %s < %t/imported-block-typedefs-output.h
+// RUN: %check-in-clang %t/imported-block-typedefs-output.h -include %S/Inputs/imported-block-typedefs.h
+
+// REQUIRES: objc_interop
+
+import ObjectiveC
+
+// CHECK-LABEL: @interface Typedefs
+@objc class Typedefs {
+  
+  // FIXME: The imported typedefs should be printed directly as the param types,
+  // but one level of sugar is currently lost when applying @noescape. The importer
+  // also loses __attribute__((noescape)) for params of imported function types.
+  // <https://bugs.swift.org/browse/SR-2520>
+  // <https://bugs.swift.org/browse/SR-2529>
+  
+  // CHECK-NEXT: - (void)noescapeParam1:(SWIFT_NOESCAPE void (^ _Nonnull)(void))input;
+  // CHECK-NEXT: - (void)noescapeParam2:(SWIFT_NOESCAPE void (^ _Nonnull)(PlainBlock _Nullable))input;
+  // CHECK-NEXT: - (void)noescapeParam3:(SWIFT_NOESCAPE void (^ _Nonnull)(PlainBlock _Nullable))input;
+  // CHECK-NEXT: - (void)noescapeParam4:(SWIFT_NOESCAPE BlockWithEscapingParam _Nullable (^ _Nonnull)(void))input;
+  // CHECK-NEXT: - (void)noescapeParam5:(SWIFT_NOESCAPE BlockWithNoescapeParam _Nullable (^ _Nonnull)(void))input;
+  // Ideally should be:
+  // - (void)noescapeParam1:(SWIFT_NOESCAPE PlainBlock _Nonnull)input;
+  // - (void)noescapeParam2:(SWIFT_NOESCAPE BlockWithEscapingParam _Nonnull)input;
+  // - (void)noescapeParam3:(SWIFT_NOESCAPE BlockWithNoescapeParam _Nonnull)input;
+  // - (void)noescapeParam4:(SWIFT_NOESCAPE BlockReturningBlockWithEscapingParam _Nonnull)input;
+  // - (void)noescapeParam5:(SWIFT_NOESCAPE BlockReturningBlockWithNoescapeParam _Nonnull)input;
+  func noescapeParam1(_ input: PlainBlock) {}
+  func noescapeParam2(_ input: BlockWithEscapingParam) {}
+  func noescapeParam3(_ input: BlockWithNoescapeParam) {}
+  func noescapeParam4(_ input: BlockReturningBlockWithEscapingParam) {}
+  func noescapeParam5(_ input: BlockReturningBlockWithNoescapeParam) {}
+  
+  // CHECK-NEXT: - (void)escapingParam1:(PlainBlock _Nonnull)input;
+  // CHECK-NEXT: - (void)escapingParam2:(BlockWithEscapingParam _Nonnull)input;
+  // CHECK-NEXT: - (void)escapingParam3:(BlockWithNoescapeParam _Nonnull)input;
+  // CHECK-NEXT: - (void)escapingParam4:(BlockReturningBlockWithEscapingParam _Nonnull)input;
+  // CHECK-NEXT: - (void)escapingParam5:(BlockReturningBlockWithNoescapeParam _Nonnull)input;
+  func escapingParam1(_ input: @escaping PlainBlock) {}
+  func escapingParam2(_ input: @escaping BlockWithEscapingParam) {}
+  func escapingParam3(_ input: @escaping BlockWithNoescapeParam) {}
+  func escapingParam4(_ input: @escaping BlockReturningBlockWithEscapingParam) {}
+  func escapingParam5(_ input: @escaping BlockReturningBlockWithNoescapeParam) {}
+  
+  // CHECK-NEXT: - (void (^ _Nonnull)(SWIFT_NOESCAPE void (^ _Nonnull)(void)))resultHasNoescapeParam1;
+  // CHECK-NEXT: - (void (^ _Nonnull)(SWIFT_NOESCAPE void (^ _Nonnull)(PlainBlock _Nullable)))resultHasNoescapeParam2;
+  // CHECK-NEXT: - (void (^ _Nonnull)(SWIFT_NOESCAPE void (^ _Nonnull)(PlainBlock _Nullable)))resultHasNoescapeParam3;
+  // CHECK-NEXT: - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockWithEscapingParam _Nullable (^ _Nonnull)(void)))resultHasNoescapeParam4;
+  // CHECK-NEXT: - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockWithNoescapeParam _Nullable (^ _Nonnull)(void)))resultHasNoescapeParam5;
+  // Ideally should be:
+  //  - (void (^ _Nonnull)(SWIFT_NOESCAPE PlainBlock _Nonnull))resultHasNoescapeParam1;
+  //  - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockWithEscapingParam _Nonnull))resultHasNoescapeParam2;
+  //  - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockWithNoescapeParam _Nonnull))resultHasNoescapeParam3;
+  //  - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockReturningBlockWithEscapingParam _Nonnull))resultHasNoescapeParam4;
+  //  - (void (^ _Nonnull)(SWIFT_NOESCAPE BlockReturningBlockWithNoescapeParam _Nonnull))resultHasNoescapeParam5;
+  func resultHasNoescapeParam1() -> (PlainBlock) -> () { fatalError() }
+  func resultHasNoescapeParam2() -> (BlockWithEscapingParam) -> () { fatalError() }
+  func resultHasNoescapeParam3() -> (BlockWithNoescapeParam) -> () { fatalError() }
+  func resultHasNoescapeParam4() -> (BlockReturningBlockWithEscapingParam) -> () { fatalError() }
+  func resultHasNoescapeParam5() -> (BlockReturningBlockWithNoescapeParam) -> () { fatalError() }
+  
+  // CHECK-NEXT: - (void (^ _Nonnull)(PlainBlock _Nonnull))resultHasEscapingParam1;
+  // CHECK-NEXT: - (void (^ _Nonnull)(BlockWithEscapingParam _Nonnull))resultHasEscapingParam2;
+  // CHECK-NEXT: - (void (^ _Nonnull)(BlockWithNoescapeParam _Nonnull))resultHasEscapingParam3;
+  // CHECK-NEXT: - (void (^ _Nonnull)(BlockReturningBlockWithEscapingParam _Nonnull))resultHasEscapingParam4;
+  // CHECK-NEXT: - (void (^ _Nonnull)(BlockReturningBlockWithNoescapeParam _Nonnull))resultHasEscapingParam5;
+  func resultHasEscapingParam1() -> (@escaping PlainBlock) -> () { fatalError() }
+  func resultHasEscapingParam2() -> (@escaping BlockWithEscapingParam) -> () { fatalError() }
+  func resultHasEscapingParam3() -> (@escaping BlockWithNoescapeParam) -> () { fatalError() }
+  func resultHasEscapingParam4() -> (@escaping BlockReturningBlockWithEscapingParam) -> () { fatalError() }
+  func resultHasEscapingParam5() -> (@escaping BlockReturningBlockWithNoescapeParam) -> () { fatalError() }
+
+}
+// CHECK-NEXT: init
+// CHECK-NEXT: @end

--- a/test/PrintAsObjC/local-types.swift
+++ b/test/PrintAsObjC/local-types.swift
@@ -40,7 +40,7 @@ class ANonObjCClass {}
 // CHECK-NEXT: - (void)d:(id <ZForwardProtocol1> _Nonnull)d;
 // CHECK-NEXT: - (void)e:(Class <ZForwardProtocol2> _Nonnull)e;
 // CHECK-NEXT: - (void)e2:(id <ZForwardProtocol2> _Nonnull)e;
-// CHECK-NEXT: - (void)f:(id <ZForwardProtocol5> _Nonnull (^ _Nonnull)(id <ZForwardProtocol3> _Nonnull, id <ZForwardProtocol4> _Nonnull))f;
+// CHECK-NEXT: - (void)f:(SWIFT_NOESCAPE id <ZForwardProtocol5> _Nonnull (^ _Nonnull)(id <ZForwardProtocol3> _Nonnull, id <ZForwardProtocol4> _Nonnull))f;
 // CHECK-NEXT: - (void)g:(id <ZForwardProtocol6, ZForwardProtocol7> _Nonnull)g;
 // CHECK-NEXT: - (void)i:(id <ZForwardProtocol8> _Nonnull)_;
 // CHECK-NEXT: @property (nonatomic, readonly, strong) ZForwardClass3 * _Nonnull j;


### PR DESCRIPTION
### Explanation

Cherry-picks my change to print `__attribute__((noescape))` in generated Obj-C headers from #4438 (reviewed by @jrose-apple).

Specifically, introduces a macro `SWIFT_NOESCAPE` to the generated header which expands to `__attribute__((noescape))` when available.

Also grabbing a NFC commit from @slavapestov that was necessary to make the cherry-picking conflict-free.

**Note:** there are still some remaining issues that make this feature less-than-"perfect"/"complete". I filed follow-up issues for these when I discovered them along the way:

https://bugs.swift.org/browse/SR-2520 "Type alias is lost when applying @escaping-ness"
https://bugs.swift.org/browse/SR-2529 "Keep __attribute__((noescape)) when importing Clang types"

However, I believe there's no harm in including this change in Swift 3: some support for the noescape attribute is better than none.
### Scope

Affects only PrintAsObjC.
### SR issue

https://bugs.swift.org/browse/SR-2406 "Print __attribute__((noescape)) in the generated header"
### Risk

Affects only generated Obj-C headers. 

Possible failure modes would be:
1. Including SWIFT_NOESCAPE in places where it shouldn't be.
2. Not including SWIFT_NOESCAPE in places where it should be.
3. Producing a header that is not valid Obj-C.

Note that 2. was already happening, because SWIFT_NOESCAPE wasn't being printed.

The risk for 1. is low, because to my knowledge clang doesn't actually take this attribute into account when compiling (Obj-)C(++) code.

All 3 are tested by the additional tests that were added.
### Testing

Added tests to `PrintAsObjC/blocks.swift`; added `PrintAsObjC/imported-block-typedefs.swift`; updated other tests as necessary.
