### PR TITLE
[SE-0112] Provide default implementations for CustomNSError requirements

### DIFF
--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -121,12 +121,55 @@ public protocol CustomNSError : Error {
   var errorUserInfo: [String : Any] { get }
 }
 
+public extension CustomNSError {
+  /// Default domain of the error.
+  static var errorDomain: String {
+    return String(reflecting: type(of: self))
+  }
+
+  /// The error code within the given domain.
+  var errorCode: Int {
+    return _swift_getDefaultErrorCode(self)
+  }
+
+  /// The default user-info dictionary.
+  var errorUserInfo: [String : Any] {
+    return [:]
+  }
+}
+
+extension CustomNSError where Self: RawRepresentable, Self.RawValue: SignedInteger {
+  // The error code of Error with integral raw values is the raw value.
+  public var errorCode: Int {
+    return numericCast(self.rawValue)
+  }
+}
+
+extension CustomNSError where Self: RawRepresentable, Self.RawValue: UnsignedInteger {
+  // The error code of Error with integral raw values is the raw value.
+  public var errorCode: Int {
+    return numericCast(self.rawValue)
+  }
+}
+
 public extension Error where Self : CustomNSError {
   /// Default implementation for customized NSErrors.
   var _domain: String { return Self.errorDomain }
 
   /// Default implementation for customized NSErrors.
   var _code: Int { return self.errorCode }
+}
+
+public extension Error where Self: CustomNSError, Self: RawRepresentable,
+    Self.RawValue: SignedInteger {
+  /// Default implementation for customized NSErrors.
+  var _code: Int { return self.errorCode }  
+}
+
+public extension Error where Self: CustomNSError, Self: RawRepresentable,
+    Self.RawValue: UnsignedInteger {
+  /// Default implementation for customized NSErrors.
+  var _code: Int { return self.errorCode }  
 }
 
 public extension Error {

--- a/stdlib/public/runtime/ErrorObject.mm
+++ b/stdlib/public/runtime/ErrorObject.mm
@@ -394,7 +394,7 @@ extern "C" NSDictionary *swift_stdlib_getErrorUserInfoNSDictionary(
 //public func _stdlib_getErrorDefaultUserInfo<T : Error>(_ x: UnsafePointer<T>) -> AnyObject
 SWIFT_CC(swift) SWIFT_RT_ENTRY_VISIBILITY
 extern "C" NSDictionary *swift_stdlib_getErrorDefaultUserInfo(
-                           const OpaqueValue *error,
+                           OpaqueValue *error,
                            const Metadata *T,
                            const WitnessTable *Error) {
   typedef SWIFT_CC(swift)
@@ -405,7 +405,10 @@ extern "C" NSDictionary *swift_stdlib_getErrorDefaultUserInfo(
   auto foundationGetDefaultUserInfo = SWIFT_LAZY_CONSTANT(
         reinterpret_cast<GetDefaultFn*>
           (dlsym(RTLD_DEFAULT, "swift_Foundation_getErrorDefaultUserInfo")));
-  if (!foundationGetDefaultUserInfo) { return nullptr; }
+  if (!foundationGetDefaultUserInfo) {
+    T->vw_destroy(error);
+    return nullptr;
+  }
 
   return foundationGetDefaultUserInfo(error, T, Error);
 }

--- a/test/stdlib/ErrorBridged.swift
+++ b/test/stdlib/ErrorBridged.swift
@@ -582,6 +582,32 @@ ErrorBridgingTests.test("Customizing localization/recovery laziness") {
   }
 }
 
+enum DefaultCustomizedError1 : CustomNSError {
+  case bad
+  case worse
+}
+
+enum DefaultCustomizedError2 : Int, CustomNSError {
+  case bad = 7
+  case worse = 13
+}
+
+enum DefaultCustomizedError3 : UInt, CustomNSError {
+  case bad = 9
+  case worse = 115
+
+  static var errorDomain: String {
+    return "customized3"
+  }
+}
+
+ErrorBridgingTests.test("Default-customized via CustomNSError") {
+  expectEqual(1, (DefaultCustomizedError1.worse as NSError).code)
+  expectEqual(13, (DefaultCustomizedError2.worse as NSError).code)
+  expectEqual(115, (DefaultCustomizedError3.worse as NSError).code)
+  expectEqual("customized3", (DefaultCustomizedError3.worse as NSError).domain)
+}
+
 class MyNSError : NSError {  }
 
 ErrorBridgingTests.test("NSError subclass identity") {


### PR DESCRIPTION
<!-- What's in this pull request? -->

Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [rdar://problem/23511842](rdar://problem/23511842).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

Provide default implementations for all of the CustomNSError requirements:
- errorDomain: default to the name of the enum type
- errorCode: default to the same thing "_code" gets, e.g., the enum tag or
  raw value
- errorUserInfo: default to empty

This makes it significantly easier to customize just one aspect of the
NSError view of an error type, e.g., just the user-info dictionary,
without having to write boilerplate for the others. This was actually
part of SE-0112, but I missed it in the original implementation and we
thought it was an amendment.

Fixes rdar://problem/23511842.
