### PR TITLE
Fix for class convenience initializers delegating to factory initializers (3.0)

### DIFF
--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -841,6 +841,12 @@ FUNCTION(GetObjectClass, object_getClass, C_CC,
          ARGS(ObjCPtrTy),
          ATTRS(NoUnwind, ReadOnly))
 
+// id object_dispose(id object);
+FUNCTION(ObjectDispose, object_dispose, C_CC,
+         RETURNS(ObjCPtrTy),
+         ARGS(ObjCPtrTy),
+         ATTRS(NoUnwind))
+
 // Class objc_lookUpClass(const char *name);
 FUNCTION(LookUpClass, objc_lookUpClass, C_CC,
          RETURNS(ObjCClassPtrTy),

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -726,6 +726,22 @@ void irgen::emitPartialClassDeallocation(IRGenFunction &IGF,
                                          llvm::Value *metadataValue) {
   auto *theClass = selfType.getClassOrBoundGenericClass();
 
+  // Foreign classes should not be freed by sending -release.
+  // They should also probably not be freed with object_dispose(),
+  // either.
+  //
+  // However, in practice, the only time we should try to free an
+  // instance of a foreign class here is inside an initializer
+  // delegating to a factory initializer. In this case, the object
+  // was allocated with +allocWithZone:, so calling object_dispose()
+  // should be OK.
+  if (theClass->getForeignClassKind() == ClassDecl::ForeignKind::RuntimeOnly) {
+    selfValue = IGF.Builder.CreateBitCast(selfValue, IGF.IGM.ObjCPtrTy);
+    IGF.Builder.CreateCall(IGF.IGM.getObjectDisposeFn(),
+                           {selfValue});
+    return;
+  }
+
   llvm::Value *size, *alignMask;
   getInstanceSizeAndAlignMask(IGF, selfType, theClass, selfValue,
                               size, alignMask);

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1340,7 +1340,7 @@ static llvm::Value *emitTypeMetadataAccessFunctionBody(IRGenFunction &IGF,
   // Non-native types are just wrapped in various ways.
   if (auto classDecl = dyn_cast<ClassDecl>(typeDecl)) {
     // We emit a completely different pattern for foreign classes.
-    if (classDecl->isForeign()) {
+    if (classDecl->getForeignClassKind() == ClassDecl::ForeignKind::CFType) {
       return emitForeignTypeMetadataRef(IGF, type);
     }
 

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -1107,15 +1107,30 @@ static bool isSelfInitUse(SILInstruction *I) {
  }
 
   // This is a self.init call if structured like this:
+  //
   // (call_expr type='SomeClass'
   //   (dot_syntax_call_expr type='() -> SomeClass' self
   //     (other_constructor_ref_expr implicit decl=SomeClass.init)
   //     (decl_ref_expr type='SomeClass', "self"))
   //   (...some argument...)
-  if (auto AE = dyn_cast<ApplyExpr>(LocExpr)) {
-    if ((AE = dyn_cast<ApplyExpr>(AE->getFn())) &&
-        isa<OtherConstructorDeclRefExpr>(AE->getFn()))
-      return true;
+  //
+  // Or like this:
+  //
+  // (call_expr type='SomeClass'
+  //   (dot_syntax_call_expr type='() -> SomeClass' self
+  //     (decr_ref_expr implicit decl=SomeClass.init)
+  //     (decl_ref_expr type='SomeClass', "self"))
+  //   (...some argument...)
+  //
+  if (auto *AE = dyn_cast<ApplyExpr>(LocExpr)) {
+    if ((AE = dyn_cast<ApplyExpr>(AE->getFn()))) {
+      if (isa<OtherConstructorDeclRefExpr>(AE->getFn()))
+        return true;
+      if (auto *DRE = dyn_cast<DeclRefExpr>(AE->getFn()))
+        if (auto *CD = dyn_cast<ConstructorDecl>(DRE->getDecl()))
+          if (CD->isFactoryInit())
+            return true;
+    }
   }
   return false;
 }
@@ -1128,58 +1143,18 @@ static bool isSelfInitUse(SILArgument *Arg) {
   // of a throwing delegated init.
   auto *BB = Arg->getParent();
   auto *Pred = BB->getSinglePredecessor();
-  if (!Pred || !isa<TryApplyInst>(Pred->getTerminator()))
+
+  // The two interesting cases are where self.init throws, in which case
+  // the argument came from a try_apply, or if self.init is failable,
+  // in which case we have a switch_enum.
+  if (!Pred ||
+      (!isa<TryApplyInst>(Pred->getTerminator()) &&
+       !isa<SwitchEnumInst>(Pred->getTerminator())))
     return false;
+
   return isSelfInitUse(Pred->getTerminator());
 }
 
-
-/// Determine if this value_metatype instruction is part of a call to
-/// self.init when delegating to a factory initializer.
-///
-/// FIXME: This is only necessary due to our broken model for factory
-/// initializers.
-static bool isSelfInitUse(ValueMetatypeInst *Inst) {
-  // "Inst" is a ValueMetatype instruction.  Check to see if it is
-  // used by an apply that came from a call to self.init.
-  for (auto UI : Inst->getUses()) {
-    auto *User = UI->getUser();
-
-    // Check whether we're looking up a factory initializer with
-    // class_method.
-    if (auto *CMI = dyn_cast<ClassMethodInst>(User)) {
-      // Only works for allocating initializers...
-      auto Member = CMI->getMember();
-      if (Member.kind != SILDeclRef::Kind::Allocator)
-        return false;
-
-      // ... of factory initializers.
-      auto ctor = dyn_cast_or_null<ConstructorDecl>(Member.getDecl());
-      return ctor && ctor->isFactoryInit();
-    }
-
-    if (auto apply = ApplySite::isa(User)) {
-      auto *LocExpr = apply.getLoc().getAsASTNode<ApplyExpr>();
-      if (!LocExpr)
-        return false;
-
-      LocExpr = dyn_cast<ApplyExpr>(LocExpr->getFn());
-      if (!LocExpr || !isa<OtherConstructorDeclRefExpr>(LocExpr->getFn()))
-        return false;
-
-      return true;
-    }
-
-    // Ignore the thick_to_objc_metatype instruction.
-    if (isa<ThickToObjCMetatypeInst>(User)) {
-      continue;
-    }
-
-    return false;
-  }
-
-  return false;
-}
 
 void ElementUseCollector::
 collectClassSelfUses(SILValue ClassPointer, SILType MemorySILType,
@@ -1233,18 +1208,12 @@ collectClassSelfUses(SILValue ClassPointer, SILType MemorySILType,
       recordFailableInitCall(User);
     }
 
-    // If this is a ValueMetatypeInst, check to see if it's part of a
-    // self.init call to a factory initializer in a delegating
-    // initializer.
-    if (auto *VMI = dyn_cast<ValueMetatypeInst>(User)) {
-      if (isSelfInitUse(VMI))
-        Kind = DIUseKind::SelfInit;
-      else
-        // Otherwise, this is a simple reference to "type(of:)", which is
-        // always fine, even if self is uninitialized.
-        continue;
-    }
-    
+    // If this is a ValueMetatypeInst, this is a simple reference
+    // to "type(of:)", which is always fine, even if self is
+    // uninitialized.
+    if (isa<ValueMetatypeInst>(User))
+      continue;
+
     // If this is a partial application of self, then this is an escape point
     // for it.
     if (isa<PartialApplyInst>(User))
@@ -1289,12 +1258,13 @@ void ElementUseCollector::collectDelegatingClassInitSelfUses() {
       if (auto apply = dyn_cast<ApplyInst>(cast<AssignInst>(User)->getSrc())) {
         if (auto fn = apply->getCalleeFunction()) {
           if (fn->getRepresentation()
-                == SILFunctionTypeRepresentation::CFunctionPointer)
+                == SILFunctionTypeRepresentation::CFunctionPointer) {
             Uses.push_back(DIMemoryUse(User, DIUseKind::SelfInit, 0, 1));
+            continue;
+          }
         }
       }
 
-      continue;
     }
 
     // Stores *to* the allocation are writes.  If the value being stored is a
@@ -1302,14 +1272,12 @@ void ElementUseCollector::collectDelegatingClassInitSelfUses() {
     if (auto *AI = dyn_cast<AssignInst>(User)) {
       if (auto *AssignSource = dyn_cast<SILInstruction>(AI->getOperand(0)))
         if (isSelfInitUse(AssignSource)) {
-          assert(isa<ArchetypeType>(TheMemory.getType()));
           Uses.push_back(DIMemoryUse(User, DIUseKind::SelfInit, 0, 1));
           continue;
         }
       if (auto *AssignSource = dyn_cast<SILArgument>(AI->getOperand(0)))
         if (AssignSource->getParent() == AI->getParent())
           if (isSelfInitUse(AssignSource)) {
-            assert(isa<ArchetypeType>(TheMemory.getType()));
             Uses.push_back(DIMemoryUse(User, DIUseKind::SelfInit, 0, 1));
             continue;
           }
@@ -1379,16 +1347,10 @@ void ElementUseCollector::collectDelegatingClassInitSelfUses() {
           recordFailableInitCall(User);
         }
 
-        // If this is a ValueMetatypeInst, check to see if it's part of a
-        // self.init call to a factory initializer in a delegating
-        // initializer.
-        if (auto *VMI = dyn_cast<ValueMetatypeInst>(User)) {
-          if (isSelfInitUse(VMI))
-            Kind = DIUseKind::SelfInit;
-          else
-            // Otherwise, this is a simple reference to "type(of:)", which is
-            // always fine, even if self is uninitialized.
-            continue;
+        // A simple reference to "type(of:)" is always fine,
+        // even if self is uninitialized.
+        if (isa<ValueMetatypeInst>(User)) {
+          continue;
         }
 
         Uses.push_back(DIMemoryUse(User, Kind, 0, 1));

--- a/test/1_stdlib/Dispatch.swift
+++ b/test/1_stdlib/Dispatch.swift
@@ -3,9 +3,6 @@
 
 // REQUIRES: objc_interop
 
-// rdar://27226313
-// REQUIRES: optimized_stdlib
-
 import Dispatch
 import Foundation
 import StdlibUnittest

--- a/test/IRGen/objc_protocol_conversion.sil
+++ b/test/IRGen/objc_protocol_conversion.sil
@@ -29,7 +29,8 @@ entry:
 // CHECK-LABEL: define{{( protected)?}} %swift.type* @protocol_metatype()
 sil @protocol_metatype : $@convention(thin) () -> @thick Protocol.Type {
 entry:
-  // CHECK: call %swift.type* @swift_getForeignTypeMetadata
+  // CHECK: call %objc_class* @objc_lookUpClass
+  // CHECK: call %swift.type* @swift_getObjCClassMetadata
   %t = metatype $@thick Protocol.Type
   return %t : $@thick Protocol.Type
 }

--- a/test/IRGen/objc_runtime_visible.sil
+++ b/test/IRGen/objc_runtime_visible.sil
@@ -20,3 +20,17 @@ bb0:
   // CHECK-NEXT:  ret %objc_class*
   return %0 : $@objc_metatype A.Type
 }
+
+// CHECK: define void @deallocA(%CSo1A*) #0 {
+sil @deallocA : $@convention(thin) (@owned A) -> () {
+bb0(%0 : $A):
+  %1 = metatype $@thick A.Type
+
+  // CHECK: call %objc_object* @object_dispose
+  dealloc_partial_ref %0 : $A, %1 : $@thick A.Type
+
+  %2 = tuple ()
+
+  // CHECK-NEXT: ret
+  return %2 : $()
+}

--- a/test/Interpreter/protocol_initializers.swift
+++ b/test/Interpreter/protocol_initializers.swift
@@ -1,0 +1,89 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var ProtocolInitTestSuite = TestSuite("ProtocolInit")
+
+func mustFail<T>(f: () -> T?) {
+  if f() != nil {
+    preconditionFailure("Didn't fail")
+  }
+}
+
+protocol TriviallyConstructible {
+  init(inner: LifetimeTracked)
+}
+
+enum E : Error { case X }
+
+extension TriviallyConstructible {
+  init(middle x: LifetimeTracked) {
+    self.init(inner: x)
+  }
+
+  init?(failingMiddle x: LifetimeTracked, shouldFail: Bool) {
+    if (shouldFail) {
+      return nil
+    }
+    self.init(inner: x)
+  }
+
+  init(throwingMiddle x: LifetimeTracked, shouldThrow: Bool) throws {
+    if (shouldThrow) {
+      throw E.X
+    }
+    self.init(inner: x)
+  }
+}
+
+class TrivialClass : TriviallyConstructible {
+
+  convenience init(outer x: LifetimeTracked) {
+    self.init(middle: x)
+  }
+
+  convenience init?(failingOuter x: LifetimeTracked, shouldFail: Bool) {
+    self.init(failingMiddle: x, shouldFail: shouldFail)
+  }
+
+  convenience init(throwingOuter x: LifetimeTracked, shouldThrow: Bool) throws {
+    try self.init(throwingMiddle: x, shouldThrow: shouldThrow)
+  }
+
+  required init(inner tracker: LifetimeTracked) {
+    self.tracker = tracker
+  }
+
+  let tracker: LifetimeTracked
+}
+
+ProtocolInitTestSuite.test("ProtocolInit_Trivial") {
+  _ = TrivialClass(outer: LifetimeTracked(0))
+}
+
+ProtocolInitTestSuite.test("ProtocolInit_Failable") {
+  do {
+    let result = TrivialClass(failingOuter: LifetimeTracked(1), shouldFail: false)
+    assert(result != nil)
+  }
+  do {
+    let result = TrivialClass(failingOuter: LifetimeTracked(2), shouldFail: true)
+    assert(result == nil)
+  }
+}
+
+ProtocolInitTestSuite.test("ProtocolInit_Throwing") {
+  do {
+    let result = try TrivialClass(throwingOuter: LifetimeTracked(4), shouldThrow: false)
+  } catch {
+    preconditionFailure("Expected no error")
+  }
+
+  do {
+    let result = try TrivialClass(throwingOuter: LifetimeTracked(5), shouldThrow: true)
+    preconditionFailure("Expected error")
+  } catch {}
+}
+
+runAllTests()

--- a/test/Runtime/weak-reference-racetests-dispatch.swift
+++ b/test/Runtime/weak-reference-racetests-dispatch.swift
@@ -1,9 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// Disabled because of a crash with a debug stdlib - rdar://problem/27226313
-// REQUIRES: optimized_stdlib
-
 // REQUIRES: objc_interop
 
 import StdlibUnittest

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -414,7 +414,6 @@ class SomeDerivedClass : SomeClass {
 //  Delegating initializers
 //===----------------------------------------------------------------------===//
 
-
 class DelegatingCtorClass {
   var ivar: EmptyStruct
 
@@ -531,50 +530,15 @@ protocol TriviallyConstructible {
 }
 
 extension TriviallyConstructible {
-  init(up: Int) {
-    self.init()
-    go(up)
-  }
-
   init(down: Int) {
     go(down) // expected-error {{'self' used before self.init call}}
     self.init()
   }
 }
 
-class TrivialClass : TriviallyConstructible {
-  required init() {}
-
-  func go(_ x: Int) {}
-
-  convenience init(y: Int) {
-    self.init(up: y * y)
-  }
-}
-
-struct TrivialStruct : TriviallyConstructible {
-  init() {}
-
-  func go(_ x: Int) {}
-
-  init(y: Int) {
-    self.init(up: y * y)
-  }
-}
-
-enum TrivialEnum : TriviallyConstructible {
-  case NotSoTrivial
-
-  init() {
-    self = .NotSoTrivial
-  }
-
-  func go(_ x: Int) {}
-
-  init(y: Int) {
-    self.init(up: y * y)
-  }
-}
+//===----------------------------------------------------------------------===//
+//  Various bugs
+//===----------------------------------------------------------------------===//
 
 // rdar://16119509 - Dataflow problem where we reject valid code.
 class rdar16119509_Buffer {

--- a/test/SILOptimizer/definite_init_objc_factory_init.swift
+++ b/test/SILOptimizer/definite_init_objc_factory_init.swift
@@ -30,7 +30,8 @@ extension Hive {
     // CHECK: [[OBJC_META:%[0-9]+]] = thick_to_objc_metatype [[META]] : $@thick Hive.Type to $@objc_metatype Hive.Type
     // CHECK: apply [[FACTORY]]([[QUEEN:%[0-9]+]], [[OBJC_META]]) : $@convention(objc_method) (ImplicitlyUnwrappedOptional<Bee>, @objc_metatype Hive.Type) -> @autoreleased ImplicitlyUnwrappedOptional<Hive>
     // CHECK: store [[NEW_SELF:%[0-9]+]] to [[SELF_ADDR]]
-    // CHECK: strong_release [[OLD_SELF]] : $Hive
+    // CHECK: [[METATYPE:%.*]] = value_metatype $@thick Hive.Type, [[OLD_SELF]] : $Hive
+    // CHECK: dealloc_partial_ref [[OLD_SELF]] : $Hive, [[METATYPE]] : $@thick Hive.Type
     // CHECK: dealloc_stack [[SELF_ADDR]]
     // CHECK: return [[NEW_SELF]]
     self.init(queen: other)

--- a/test/SILOptimizer/definite_init_protocol_init.swift
+++ b/test/SILOptimizer/definite_init_protocol_init.swift
@@ -1,0 +1,147 @@
+// RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s
+
+// Ensure that convenience initializers on concrete types can
+// delegate to factory initializers defined in protocol
+// extensions.
+
+protocol TriviallyConstructible {
+  init(lower: Int)
+}
+
+extension TriviallyConstructible {
+  init(middle: Int) {
+    self.init(lower: middle)
+  }
+
+  init?(failingMiddle: Int) {
+    self.init(lower: failingMiddle)
+  }
+
+  init(throwingMiddle: Int) throws {
+    try self.init(lower: throwingMiddle)
+  }
+}
+
+class TrivialClass : TriviallyConstructible {
+  required init(lower: Int) {}
+
+  // CHECK-LABEL: sil hidden @_TFC27definite_init_protocol_init12TrivialClasscfT5upperSi_S0_
+  // CHECK:     bb0(%0 : $Int, %1 : $TrivialClass):
+  // CHECK-NEXT:  [[SELF_BOX:%.*]] = alloc_stack $TrivialClass
+  // CHECK:       store %1 to [[SELF_BOX]]
+  // CHECK-NEXT:  [[METATYPE:%.*]] = value_metatype $@thick TrivialClass.Type, %1
+  // CHECK:       [[FN:%.*]] = function_ref @_TFE27definite_init_protocol_initPS_22TriviallyConstructibleCfT6middleSi_x
+  // CHECK-NEXT:  [[RESULT:%.*]] = alloc_stack $TrivialClass
+  // CHECK-NEXT:  apply [[FN]]<TrivialClass>([[RESULT]], %0, [[METATYPE]])
+  // CHECK-NEXT:  [[NEW_SELF:%.*]] = load [[RESULT]]
+  // CHECK-NEXT:  store [[NEW_SELF]] to [[SELF_BOX]]
+  // CHECK-NEXT:  [[METATYPE:%.*]] = value_metatype $@thick TrivialClass.Type, %1
+  // CHECK-NEXT:  dealloc_partial_ref %1 : $TrivialClass, [[METATYPE]] : $@thick TrivialClass.Type
+  // CHECK-NEXT:  dealloc_stack [[RESULT]]
+  // CHECK-NEXT:  dealloc_stack [[SELF_BOX]]
+  // CHECK-NEXT:  return [[NEW_SELF]]
+  convenience init(upper: Int) {
+    self.init(middle: upper)
+  }
+
+  convenience init?(failingUpper: Int) {
+    self.init(failingMiddle: failingUpper)
+  }
+
+  convenience init(throwingUpper: Int) throws {
+    try self.init(throwingMiddle: throwingUpper)
+  }
+}
+
+struct TrivialStruct : TriviallyConstructible {
+  let x: Int
+
+  init(lower: Int) { self.x = lower }
+
+// CHECK-LABEL: sil hidden @_TFV27definite_init_protocol_init13TrivialStructCfT5upperSi_S0_
+// CHECK:     bb0(%0 : $Int, %1 : $@thin TrivialStruct.Type):
+// CHECK-NEXT: [[SELF:%.*]] = alloc_stack $TrivialStruct
+// CHECK:      [[FN:%.*]] = function_ref @_TFE27definite_init_protocol_initPS_22TriviallyConstructibleCfT6middleSi_x
+// CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thick TrivialStruct.Type
+// CHECK-NEXT: [[SELF_BOX:%.*]] = alloc_stack $TrivialStruct
+// CHECK-NEXT: apply [[FN]]<TrivialStruct>([[SELF_BOX]], %0, [[METATYPE]])
+// CHECK-NEXT: [[NEW_SELF:%.*]] = load [[SELF_BOX]]
+// CHECK-NEXT: store [[NEW_SELF]] to [[SELF]]
+// CHECK-NEXT: dealloc_stack [[SELF_BOX]]
+// CHECK-NEXT: dealloc_stack [[SELF]]
+// CHECK-NEXT: return [[NEW_SELF]]
+  init(upper: Int) {
+    self.init(middle: upper)
+  }
+
+  init?(failingUpper: Int) {
+    self.init(failingMiddle: failingUpper)
+  }
+
+  init(throwingUpper: Int) throws {
+    try self.init(throwingMiddle: throwingUpper)
+  }
+}
+
+struct AddressOnlyStruct : TriviallyConstructible {
+  let x: Any
+
+  init(lower: Int) { self.x = lower }
+
+// CHECK-LABEL: sil hidden @_TFV27definite_init_protocol_init17AddressOnlyStructCfT5upperSi_S0_
+// CHECK:     bb0(%0 : $*AddressOnlyStruct, %1 : $Int, %2 : $@thin AddressOnlyStruct.Type):
+// CHECK-NEXT: [[SELF:%.*]] = alloc_stack $AddressOnlyStruct
+// CHECK:      [[FN:%.*]] = function_ref @_TFE27definite_init_protocol_initPS_22TriviallyConstructibleCfT6middleSi_x
+// CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thick AddressOnlyStruct.Type
+// CHECK-NEXT: [[SELF_BOX:%.*]] = alloc_stack $AddressOnlyStruct
+// CHECK-NEXT: apply [[FN]]<AddressOnlyStruct>([[SELF_BOX]], %1, [[METATYPE]])
+// CHECK-NEXT: copy_addr [take] [[SELF_BOX]] to [initialization] [[SELF]]
+// CHECK-NEXT: dealloc_stack [[SELF_BOX]]
+// CHECK-NEXT: copy_addr [take] [[SELF]] to [initialization] %0
+// CHECK-NEXT: [[RESULT:%.*]] = tuple ()
+// CHECK-NEXT: dealloc_stack [[SELF]]
+// CHECK-NEXT: return [[RESULT]]
+  init(upper: Int) {
+    self.init(middle: upper)
+  }
+
+  init?(failingUpper: Int) {
+    self.init(failingMiddle: failingUpper)
+  }
+
+  init(throwingUpper: Int) throws {
+    try self.init(throwingMiddle: throwingUpper)
+  }
+}
+
+enum TrivialEnum : TriviallyConstructible {
+  case NotSoTrivial
+
+  init(lower: Int) {
+    self = .NotSoTrivial
+  }
+
+// CHECK-LABEL: sil hidden @_TFO27definite_init_protocol_init11TrivialEnumCfT5upperSi_S0_
+// CHECK:     bb0(%0 : $Int, %1 : $@thin TrivialEnum.Type):
+// CHECK-NEXT: [[SELF:%.*]] = alloc_stack $TrivialEnum
+// CHECK:      [[FN:%.*]] = function_ref @_TFE27definite_init_protocol_initPS_22TriviallyConstructibleCfT6middleSi_x
+// CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thick TrivialEnum.Type
+// CHECK-NEXT: [[SELF_BOX:%.*]] = alloc_stack $TrivialEnum
+// CHECK-NEXT: apply [[FN]]<TrivialEnum>([[SELF_BOX]], %0, [[METATYPE]])
+// CHECK-NEXT: [[NEW_SELF:%.*]] = load [[SELF_BOX]]
+// CHECK-NEXT: store [[NEW_SELF]] to [[SELF]]
+// CHECK-NEXT: dealloc_stack [[SELF_BOX]]
+// CHECK-NEXT: dealloc_stack [[SELF]]
+// CHECK-NEXT: return [[NEW_SELF]]
+  init(upper: Int) {
+    self.init(middle: upper)
+  }
+
+  init?(failingUpper: Int) {
+    self.init(failingMiddle: failingUpper)
+  }
+
+  init(throwingUpper: Int) throws {
+    try self.init(throwingMiddle: throwingUpper)
+  }
+}


### PR DESCRIPTION
- Description: This patch fixes runtime crashes with convenience initializer delegation due to issues in definite initialization.
- Scope of the issue: The dispatch overlay adds convenience initializers via an extension on imported classes from libdispatch. These initializers delegate to factory initializers, which are really just top-level C functions imported as constructors via the 'import-as-member' mechanism. Right now this crashes at runtime in debug builds, causing those tests to be disabled. This does not affect users, but it is a problem for compiler developers. The moral equivalent in pure Swift code is to have a convenience initializer of a class delegate to a protocol extension initializer, which is also a desirable feature. This currently crashes in release builds too.
- Risk: Low, the changes have been in master for a while and we have not seen any regressions.
- Tested: There's a new test for the pure Swift case, and the existing XFAILs in the dispatch overlay tests have been removed.
- Reviewed by: Jordan Rose (pending)
- Radar: rdar://problem/27713221, rdar://problem/27226313
