### PR TITLE
Start moving toward a callback model for code-completion type-checking

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -996,6 +996,7 @@ namespace {
 namespace {
   class ConstraintGenerator : public ExprVisitor<ConstraintGenerator, Type> {
     ConstraintSystem &CS;
+    bool forCodeCompletion;
 
     /// \brief Add constraints for a reference to a named member of the given
     /// base type, and return the type of such a reference.
@@ -1136,7 +1137,8 @@ namespace {
     }
 
   public:
-    ConstraintGenerator(ConstraintSystem &CS) : CS(CS) { }
+    ConstraintGenerator(ConstraintSystem &CS, bool forCodeCompletion = false)
+        : CS(CS), forCodeCompletion(forCodeCompletion) {}
     virtual ~ConstraintGenerator() = default;
 
     ConstraintSystem &getConstraintSystem() const { return CS; }
@@ -1147,8 +1149,10 @@ namespace {
     }
 
     virtual Type visitCodeCompletionExpr(CodeCompletionExpr *E) {
-      // If the expression has already been assigned a type; just use that type.
-      return E->getType();
+      return forCodeCompletion
+                 ? CS.createTypeVariable(CS.getConstraintLocator(E),
+                                         TVO_CanBindToLValue)
+                 : E->getType();
     }
 
     Type visitLiteralExpr(LiteralExpr *expr) {
@@ -1618,7 +1622,6 @@ namespace {
     virtual Type visitParenExpr(ParenExpr *expr) {
       auto &ctx = CS.getASTContext();
       expr->setType(ParenType::get(ctx, expr->getSubExpr()->getType()));
-      
       if (auto favoredTy = CS.getFavoredType(expr->getSubExpr())) {
         CS.setFavoredType(expr, favoredTy);
       }
@@ -2811,22 +2814,37 @@ namespace {
 
   class ConstraintWalker : public ASTWalker {
     ConstraintGenerator &CG;
+    bool forCodeCompletion;
+    Expr *interestingExpr = nullptr;
+    bool interestingExprOverrideCSGen = false;
 
   public:
-    ConstraintWalker(ConstraintGenerator &CG) : CG(CG) { }
+    ConstraintWalker(ConstraintGenerator &CG, bool forCodeCompletion)
+        : CG(CG), forCodeCompletion(forCodeCompletion) {}
 
     std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
+      auto &cs = CG.getConstraintSystem();
+
       // Note that the subexpression of a #selector expression is
       // unevaluated.
       if (auto sel = dyn_cast<ObjCSelectorExpr>(expr)) {
-        CG.getConstraintSystem().UnevaluatedRootExprs.insert(sel->getSubExpr());
+        cs.UnevaluatedRootExprs.insert(sel->getSubExpr());
       }
 
       // Check a key-path expression, which fills in its semantic
       // expression as a string literal.
       if (auto keyPath = dyn_cast<ObjCKeyPathExpr>(expr)) {
-        auto &cs = CG.getConstraintSystem();
         (void)cs.getTypeChecker().checkObjCKeyPathExpr(cs.DC, keyPath);
+      }
+
+      if (forCodeCompletion) {
+        auto *callbacks = cs.getTypeChecker().CodeCompletion;
+        assert(callbacks && "CodeCompletion callbacks missing");
+        bool skipCSGen = false;
+        if (callbacks->isInterestingExpr(expr, skipCSGen)) {
+          interestingExpr = expr;
+          interestingExprOverrideCSGen = skipCSGen;
+        }
       }
 
       // For closures containing only a single expression, the body participates
@@ -2876,6 +2894,27 @@ namespace {
                              .getConstraintLocator(
                                expr,
                                ConstraintLocator::ClosureResult));
+          return expr;
+        }
+      }
+
+      if (interestingExpr && interestingExpr == expr) {
+        interestingExpr = nullptr;
+        auto &CS = CG.getConstraintSystem();
+        auto *locator = CS.getConstraintLocator(expr);
+        auto *TV = CS.createTypeVariable(locator, TVO_CanBindToLValue);
+        CS.InterestingExprs[expr] = TV;
+        if (interestingExprOverrideCSGen) {
+          // Override CSGen's normal behaviour, and just assign a type variable.
+          expr->setType(TV);
+          return expr;
+        } else if (auto type = CG.visit(expr)) {
+          auto simple = CG.getConstraintSystem().simplifyType(type);
+          CS.addConstraint(ConstraintKind::Equal, TV, simple, locator);
+          expr->setType(simple);
+          return expr;
+        } else {
+          expr->setType(TV);
           return expr;
         }
       }
@@ -2951,7 +2990,8 @@ namespace {
 
 } // end anonymous namespace
 
-Expr *ConstraintSystem::generateConstraints(Expr *expr) {
+Expr *ConstraintSystem::generateConstraints(Expr *expr,
+                                            bool forCodeCompletion) {
   // Remove implicit conversions from the expression.
   expr = expr->walk(SanitizeExpr(getTypeChecker()));
 
@@ -2959,9 +2999,9 @@ Expr *ConstraintSystem::generateConstraints(Expr *expr) {
   expr->walk(ArgumentLabelWalker(*this, expr));
 
   // Walk the expression, generating constraints.
-  ConstraintGenerator cg(*this);
-  ConstraintWalker cw(cg);
-  
+  ConstraintGenerator cg(*this, forCodeCompletion);
+  ConstraintWalker cw(cg, forCodeCompletion);
+
   Expr* result = expr->walk(cw);
   
   if (result)
@@ -3093,7 +3133,7 @@ bool swift::typeCheckUnresolvedExpr(DeclContext &DC,
   ConstraintSystem CS(*TC, &DC, Options);
   CleanupIllFormedExpressionRAII cleanup(TC->Context, Parent);
   InferUnresolvedMemberConstraintGenerator MCG(E, CS);
-  ConstraintWalker cw(MCG);
+  ConstraintWalker cw(MCG, false);
   Parent->walk(cw);
 
   if (TC->getLangOpts().DebugConstraintSolver) {

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1618,12 +1618,10 @@ void ConstraintSystem::shrink(Expr *expr) {
   }
 }
 
-ConstraintSystem::SolutionKind
-ConstraintSystem::solve(Expr *&expr,
-                        Type convertType,
-                        ExprTypeCheckListener *listener,
-                        SmallVectorImpl<Solution> &solutions,
-                        FreeTypeVariableBinding allowFreeTypeVariables) {
+ConstraintSystem::SolutionKind ConstraintSystem::solve(
+    Expr *&expr, Type convertType, ExprTypeCheckListener *listener,
+    SmallVectorImpl<Solution> &solutions,
+    FreeTypeVariableBinding allowFreeTypeVariables, bool forCodeCompletion) {
   assert(!solverState && "use solveRec for recursive calls");
 
   // Try to shrink the system by reducing disjunction domains. This
@@ -1632,7 +1630,7 @@ ConstraintSystem::solve(Expr *&expr,
   shrink(expr);
 
   // Generate constraints for the main system.
-  if (auto generatedExpr = generateConstraints(expr))
+  if (auto generatedExpr = generateConstraints(expr, forCodeCompletion))
     expr = generatedExpr;
   else {
     return SolutionKind::Error;

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -904,6 +904,8 @@ public:
   /// The original CS if this CS was created as a simplification of another CS
   ConstraintSystem *baseCS = nullptr;
 
+  llvm::SmallDenseMap<Expr *, TypeVariableType *, 4> InterestingExprs;
+
 private:
 
   /// \brief Allocator used for all of the related constraint systems.
@@ -1741,7 +1743,7 @@ public:
   /// \brief Generate constraints for the given (unchecked) expression.
   ///
   /// \returns a possibly-sanitized expression, or null if an error occurred.
-  Expr *generateConstraints(Expr *E);
+  Expr *generateConstraints(Expr *E, bool forCodeCompletion=false);
 
   /// \brief Generate constraints for the given top-level expression,
   /// assuming that its children are already type-checked.
@@ -2057,7 +2059,8 @@ private:
                      ExprTypeCheckListener *listener,
                      SmallVectorImpl<Solution> &solutions,
                      FreeTypeVariableBinding allowFreeTypeVariables
-                       = FreeTypeVariableBinding::Disallow);
+                       = FreeTypeVariableBinding::Disallow,
+                     bool forCodeCompletion = false);
 
   /// \brief Solve the system of constraints.
   ///

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -17,8 +17,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "ConstraintSystem.h"
-#include "TypeChecker.h"
 #include "MiscDiagnostics.h"
+#include "TypeChecker.h"
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/DiagnosticsParse.h"
@@ -27,6 +27,7 @@
 #include "swift/AST/TypeCheckerDebugConsumer.h"
 #include "swift/Basic/Fallthrough.h"
 #include "swift/Parse/Lexer.h"
+#include "swift/Sema/IDETypeChecking.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/FoldingSet.h"
@@ -35,13 +36,13 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Allocator.h"
-#include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/SaveAndRestore.h"
+#include "llvm/Support/raw_ostream.h"
 #include <iterator>
 #include <map>
 #include <memory>
-#include <utility>
 #include <tuple>
+#include <utility>
 
 using namespace swift;
 using namespace constraints;
@@ -1341,6 +1342,78 @@ Expr *ExprTypeCheckListener::appliedSolution(Solution &solution, Expr *expr) {
   return expr;
 }
 
+static ConcreteDeclRef locateReferencedDecl(Expr *expr, Solution &solution) {
+  // Dig the declaration out of the solution.
+  auto &cs = solution.getConstraintSystem();
+  auto semanticExpr = expr->getSemanticsProvidingExpr();
+  auto topLocator = cs.getConstraintLocator(semanticExpr);
+  if (auto referencedDecl = solution.resolveLocatorToDecl(topLocator))
+    return referencedDecl;
+
+  // Do another check in case we have a curried call from binding a function
+  // reference to a variable, for example:
+  //
+  //   class C {
+  //     func instanceFunc(p1: Int, p2: Int) {}
+  //   }
+  //   func t(c: C) {
+  //     C.instanceFunc(c)#^COMPLETE^#
+  //   }
+  //
+  // We need to get the referenced function so we can complete the argument
+  // labels. (Note that the requirement to have labels in the curried call
+  // seems inconsistent with the removal of labels from function types.
+  // If this changes the following code could be removed).
+  if (auto *CE = dyn_cast<CallExpr>(semanticExpr)) {
+    if (auto *UDE = dyn_cast<UnresolvedDotExpr>(CE->getFn())) {
+      if (isa<TypeExpr>(UDE->getBase())) {
+        auto udeLocator = cs.getConstraintLocator(UDE);
+        auto udeRefDecl = solution.resolveLocatorToDecl(udeLocator);
+        if (auto *FD = dyn_cast_or_null<FuncDecl>(udeRefDecl.getDecl())) {
+          if (FD->isInstanceMember())
+            return udeRefDecl;
+        }
+      }
+    }
+  }
+  return ConcreteDeclRef();
+}
+
+static bool
+containsInterestingExpr(Expr *E, bool &overrrideCSGen,
+                        CodeCompletionTypeCheckingCallbacks *codeCompletion) {
+  struct ExprFinder : public ASTWalker {
+    llvm::function_ref<bool(Expr *, bool &)> predicate;
+    bool found = false;
+    bool useFreeTV = false;
+    ExprFinder(llvm::function_ref<bool(Expr *, bool &)> predicate)
+        : predicate(predicate) {}
+    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+      bool b = false;
+      if (predicate(E, b)) {
+        useFreeTV |= b;
+        found = true;
+        return {false, E};
+      }
+      return {true, E};
+    }
+    std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
+      return {false, S};
+    }
+    std::pair<bool, Pattern *> walkToPatternPre(Pattern *P) override {
+      return {false, P};
+    }
+    bool walkToDeclPre(Decl *D) override { return false; }
+  };
+
+  ExprFinder finder([=](Expr *E, bool &freeTV) {
+    return codeCompletion->isInterestingExpr(E, freeTV);
+  });
+  E->walk(finder);
+  overrrideCSGen = finder.useFreeTV;
+  return finder.found;
+}
+
 bool TypeChecker::
 solveForExpression(Expr *&expr, DeclContext *dc, Type convertType,
                    FreeTypeVariableBinding allowFreeTypeVariables,
@@ -1352,12 +1425,21 @@ solveForExpression(Expr *&expr, DeclContext *dc, Type convertType,
   if (preCheckExpression(*this, expr, dc))
     return true;
 
+  bool forCodeCompletion = false;
+  auto origFreeTypeBinding = allowFreeTypeVariables;
+  bool overrideCSGen = false;
+  if (CodeCompletion) {
+    // Does this expression contain an expression for code-completion?
+    forCodeCompletion =
+        containsInterestingExpr(expr, overrideCSGen, CodeCompletion);
+    if (forCodeCompletion &&
+        allowFreeTypeVariables == FreeTypeVariableBinding::Disallow)
+      allowFreeTypeVariables = FreeTypeVariableBinding::UnresolvedType;
+  }
+
   // Attempt to solve the constraint system.
-  auto solution = cs.solve(expr,
-                           convertType,
-                           listener,
-                           viable,
-                           allowFreeTypeVariables);
+  auto solution = cs.solve(expr, convertType, listener, viable,
+                           allowFreeTypeVariables, forCodeCompletion);
 
   // The constraint system has failed
   if (solution == ConstraintSystem::SolutionKind::Error)
@@ -1365,10 +1447,12 @@ solveForExpression(Expr *&expr, DeclContext *dc, Type convertType,
 
   // If the system is unsolved or there are multiple solutions present but
   // type checker options do not allow unresolved types, let's try to salvage
-  if (solution == ConstraintSystem::SolutionKind::Unsolved
-      || (viable.size() != 1 &&
-          !options.contains(TypeCheckExprFlags::AllowUnresolvedTypeVariables))) {
-    if (options.contains(TypeCheckExprFlags::SuppressDiagnostics))
+  if (solution == ConstraintSystem::SolutionKind::Unsolved ||
+      (viable.size() != 1 &&
+       // FIXME: should we allow ambiguous answers for code-completion?
+       !options.contains(TypeCheckExprFlags::AllowUnresolvedTypeVariables))) {
+    if (options.contains(TypeCheckExprFlags::SuppressDiagnostics) ||
+        forCodeCompletion)
       return true;
 
     // Try to provide a decent diagnostic.
@@ -1391,6 +1475,33 @@ solveForExpression(Expr *&expr, DeclContext *dc, Type convertType,
         log << "--- Solution #" << i << " ---\n";
         viable[i].dump(log);
       }
+    }
+  }
+
+  if (forCodeCompletion) {
+    // Report any code-completion expressions resolved along the way.
+    for (auto &solution : viable) {
+      for (auto &pair : cs.InterestingExprs) {
+        Expr *E = pair.getFirst();
+        Type T = solution.simplifyType(*this, pair.getSecond());
+        if (!T->hasUnresolvedType() && !T->hasTypeVariable()) {
+          auto referencedDecl = locateReferencedDecl(E, solution);
+          CodeCompletion->resolvedInterestingExpr(E, T, referencedDecl);
+        }
+      }
+    }
+
+    if (origFreeTypeBinding != FreeTypeVariableBinding::Disallow)
+      return false;
+
+    // Don't apply solutions unless we could have completely solved it outside
+    // of code-completion.
+    if (viable.size() != 1 || overrideCSGen)
+      return true;
+    for (auto *TV : cs.getTypeVariables()) {
+      auto T = viable[0].getFixedType(TV);
+      if (!T || T->hasUnresolvedType())
+        return true;
     }
   }
 
@@ -1625,45 +1736,11 @@ getTypeOfExpressionWithoutApplying(Expr *&expr, DeclContext *dc,
   // Get the expression's simplified type.
   auto &solution = viable[0];
   Type exprType = solution.simplifyType(*this, expr->getType());
-
   assert(exprType && !exprType->is<ErrorType>() && "erroneous solution?");
   assert(!exprType->hasTypeVariable() &&
          "free type variable with FreeTypeVariableBinding::GenericParameters?");
 
-  // Dig the declaration out of the solution.
-  auto semanticExpr = expr->getSemanticsProvidingExpr();
-  auto topLocator = cs.getConstraintLocator(semanticExpr);
-  referencedDecl = solution.resolveLocatorToDecl(topLocator);
-
-  if (!referencedDecl.getDecl()) {
-    // Do another check in case we have a curried call from binding a function
-    // reference to a variable, for example:
-    //
-    //   class C {
-    //     func instanceFunc(p1: Int, p2: Int) {}
-    //   }
-    //   func t(c: C) {
-    //     C.instanceFunc(c)#^COMPLETE^#
-    //   }
-    //
-    // We need to get the referenced function so we can complete the argument
-    // labels. (Note that the requirement to have labels in the curried call
-    // seems inconsistent with the removal of labels from function types.
-    // If this changes the following code could be removed).
-    if (auto *CE = dyn_cast<CallExpr>(semanticExpr)) {
-      if (auto *UDE = dyn_cast<UnresolvedDotExpr>(CE->getFn())) {
-        if (isa<TypeExpr>(UDE->getBase())) {
-          auto udeLocator = cs.getConstraintLocator(UDE);
-          auto udeRefDecl = solution.resolveLocatorToDecl(udeLocator);
-          if (auto *FD = dyn_cast_or_null<FuncDecl>(udeRefDecl.getDecl())) {
-            if (FD->isInstanceMember())
-              referencedDecl = udeRefDecl;
-          }
-        }
-      }
-    }
-  }
-
+  referencedDecl = locateReferencedDecl(expr, solution);
   // Recover the original type if needed.
   recoverOriginalType();
   return exprType;

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -694,8 +694,10 @@ bool swift::performTypeLocChecking(ASTContext &Ctx, TypeLoc &T,
     options |= TR_SILMode;
   if (isSILType)
     options |= TR_SILType;
-
-  if (ProduceDiagnostics) {
+  if (Ctx.getLazyResolver()) {
+    auto *TC = static_cast<TypeChecker *>(Ctx.getLazyResolver());
+    return TC->validateType(T, DC, options);
+  } else if (ProduceDiagnostics) {
     return TypeChecker(Ctx).validateType(T, DC, options);
   } else {
     // Set up a diagnostics engine that swallows diagnostics.
@@ -714,12 +716,15 @@ swift::handleSILGenericParams(ASTContext &Ctx,
 
 bool swift::typeCheckCompletionDecl(Decl *D) {
   auto &Ctx = D->getASTContext();
-
-  // Set up a diagnostics engine that swallows diagnostics.
-  DiagnosticEngine Diags(Ctx.SourceMgr);
-  TypeChecker TC(Ctx, Diags);
-
-  TC.typeCheckDecl(D, true);
+  if (Ctx.getLazyResolver()) {
+    TypeChecker *TC = static_cast<TypeChecker *>(Ctx.getLazyResolver());
+    TC->typeCheckDecl(D, true);
+  } else {
+    // Set up a diagnostics engine that swallows diagnostics.
+    DiagnosticEngine Diags(Ctx.SourceMgr);
+    TypeChecker TC(Ctx, Diags);
+    TC.typeCheckDecl(D, true);
+  }
   return true;
 }
 
@@ -759,22 +764,8 @@ Type swift::lookUpTypeInContext(DeclContext *DC, StringRef Name) {
 static Optional<Type> getTypeOfCompletionContextExpr(
                         TypeChecker &TC,
                         DeclContext *DC,
-                        CompletionTypeCheckKind kind,
                         Expr *&parsedExpr,
                         ConcreteDeclRef &referencedDecl) {
-  switch (kind) {
-  case CompletionTypeCheckKind::Normal:
-    // Handle below.
-    break;
-
-  case CompletionTypeCheckKind::ObjCKeyPath:
-    referencedDecl = nullptr;
-    if (auto keyPath = dyn_cast<ObjCKeyPathExpr>(parsedExpr))
-      return TC.checkObjCKeyPathExpr(DC, keyPath, /*requireResulType=*/true);
-
-    return None;
-  }
-
   CanType originalType = parsedExpr->getType().getCanonicalTypeOrNull();
   if (auto T = TC.getTypeOfExpressionWithoutApplying(parsedExpr, DC,
                  referencedDecl, FreeTypeVariableBinding::GenericParameters))
@@ -790,26 +781,38 @@ static Optional<Type> getTypeOfCompletionContextExpr(
   return None;
 }
 
+Optional<Type> swift::getTypeOfObjCKeyPath(DeclContext *DC,
+                                           ObjCKeyPathExpr *E) {
+  auto &ctx = DC->getASTContext();
+  if (ctx.getLazyResolver()) {
+    TypeChecker *TC = static_cast<TypeChecker *>(ctx.getLazyResolver());
+    return TC->checkObjCKeyPathExpr(DC, E, /*requireResultType=*/true);
+  } else {
+    // Set up a diagnostics engine that swallows diagnostics.
+    DiagnosticEngine diags(ctx.SourceMgr);
+    TypeChecker TC(ctx, diags);
+    return TC.checkObjCKeyPathExpr(DC, E, /*requireResultType=*/true);
+  }
+}
+
 /// \brief Return the type of an expression parsed during code completion, or
 /// a null \c Type on error.
 Optional<Type> swift::getTypeOfCompletionContextExpr(
                         ASTContext &Ctx,
                         DeclContext *DC,
-                        CompletionTypeCheckKind kind,
                         Expr *&parsedExpr,
                         ConcreteDeclRef &referencedDecl) {
 
   if (Ctx.getLazyResolver()) {
     TypeChecker *TC = static_cast<TypeChecker *>(Ctx.getLazyResolver());
-    return ::getTypeOfCompletionContextExpr(*TC, DC, kind, parsedExpr,
+    return ::getTypeOfCompletionContextExpr(*TC, DC, parsedExpr,
                                             referencedDecl);
   } else {
     // Set up a diagnostics engine that swallows diagnostics.
     DiagnosticEngine diags(Ctx.SourceMgr);
     TypeChecker TC(Ctx, diags);
     // Try to solve for the actual type of the expression.
-    return ::getTypeOfCompletionContextExpr(TC, DC, kind, parsedExpr,
-                                            referencedDecl);
+    return ::getTypeOfCompletionContextExpr(TC, DC, parsedExpr, referencedDecl);
   }
 }
 
@@ -841,23 +844,29 @@ bool swift::typeCheckExpression(DeclContext *DC, Expr *&parsedExpr) {
 
 bool swift::typeCheckAbstractFunctionBodyUntil(AbstractFunctionDecl *AFD,
                                                SourceLoc EndTypeCheckLoc) {
-  auto &Ctx = AFD->getASTContext();
-
-  // Set up a diagnostics engine that swallows diagnostics.
-  DiagnosticEngine Diags(Ctx.SourceMgr);
-
-  TypeChecker TC(Ctx, Diags);
-  return !TC.typeCheckAbstractFunctionBodyUntil(AFD, EndTypeCheckLoc);
+  auto &ctx = AFD->getASTContext();
+  if (ctx.getLazyResolver()) {
+    TypeChecker *TC = static_cast<TypeChecker *>(ctx.getLazyResolver());
+    return !TC->typeCheckAbstractFunctionBodyUntil(AFD, EndTypeCheckLoc);
+  } else {
+    // Set up a diagnostics engine that swallows diagnostics.
+    DiagnosticEngine Diags(ctx.SourceMgr);
+    TypeChecker TC(ctx, Diags);
+    return !TC.typeCheckAbstractFunctionBodyUntil(AFD, EndTypeCheckLoc);
+  }
 }
 
 bool swift::typeCheckTopLevelCodeDecl(TopLevelCodeDecl *TLCD) {
-  auto &Ctx = static_cast<Decl *>(TLCD)->getASTContext();
-
-  // Set up a diagnostics engine that swallows diagnostics.
-  DiagnosticEngine Diags(Ctx.SourceMgr);
-
-  TypeChecker TC(Ctx, Diags);
-  TC.typeCheckTopLevelCodeDecl(TLCD);
+  auto &ctx = static_cast<Decl *>(TLCD)->getASTContext();
+  if (ctx.getLazyResolver()) {
+    TypeChecker *TC = static_cast<TypeChecker *>(ctx.getLazyResolver());
+    TC->typeCheckTopLevelCodeDecl(TLCD);
+  } else {
+    // Set up a diagnostics engine that swallows diagnostics.
+    DiagnosticEngine Diags(ctx.SourceMgr);
+    TypeChecker TC(ctx, Diags);
+    TC.typeCheckTopLevelCodeDecl(TLCD);
+  }
   return true;
 }
 
@@ -867,10 +876,13 @@ static void deleteTypeCheckerAndDiags(LazyResolver *resolver) {
   delete &diags;
 }
 
-OwnedResolver swift::createLazyResolver(ASTContext &Ctx) {
+OwnedResolver
+swift::createLazyResolver(ASTContext &Ctx,
+                          CodeCompletionTypeCheckingCallbacks *ccCallbacks) {
   auto diags = new DiagnosticEngine(Ctx.SourceMgr);
-  return OwnedResolver(new TypeChecker(Ctx, *diags),
-                       &deleteTypeCheckerAndDiags);
+  auto *TC = new TypeChecker(Ctx, *diags);
+  TC->CodeCompletion = ccCallbacks;
+  return OwnedResolver(TC, &deleteTypeCheckerAndDiags);
 }
 
 void TypeChecker::diagnoseAmbiguousMemberType(Type baseTy,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -36,6 +36,7 @@
 namespace swift {
 
 class ArchetypeBuilder;
+class CodeCompletionTypeCheckingCallbacks;
 class GenericTypeResolver;
 class NominalTypeDecl;
 class NormalProtocolConformance;
@@ -535,6 +536,10 @@ public:
   /// as C function pointers when the function's captures have not yet been
   /// computed.
   llvm::DenseMap<AnyFunctionRef, std::vector<Expr*>> LocalCFunctionPointers;
+
+  /// Code completion callbacks if we are currently performing code completion;
+  /// otherwise nullptr.
+  CodeCompletionTypeCheckingCallbacks *CodeCompletion = nullptr;
 
 private:
   /// Return statements with functions as return values.

--- a/test/IDE/complete_from_stdlib.swift
+++ b/test/IDE/complete_from_stdlib.swift
@@ -213,7 +213,7 @@ func testArchetypeReplacement6() {
 }
 
 // PRIVATE_NOMINAL_MEMBERS_10: Begin completions
-// PRIVATE_NOMINAL_MEMBERS_10-DAG: Decl[InstanceMethod]/CurrNominal:   foo({#(t): P1 & P2#})[#Void#]{{; name=.+}}
+// PRIVATE_NOMINAL_MEMBERS_10-DAG: Decl[InstanceMethod]/CurrNominal:   foo({#(t): T#})[#Void#]{{; name=.+}}
 
 // rdar://problem/22334700
 struct Test1000 : Sequence {

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -671,8 +671,7 @@ func testInsideFunctionCall2() {
   var a = FooStruct()
   a.instanceFunc1(#^INSIDE_FUNCTION_CALL_2^#
 // INSIDE_FUNCTION_CALL_2: Begin completions
-// FIXME: we should print the non-API param name rdar://20962472
-// INSIDE_FUNCTION_CALL_2-DAG: Pattern/ExprSpecific:       ['(']{#Int#})[#Void#]{{; name=.+$}}
+// INSIDE_FUNCTION_CALL_2-DAG: Pattern/ExprSpecific:       ['(']{#(a): Int#})[#Void#]{{; name=.+$}}
 // INSIDE_FUNCTION_CALL_2-DAG: Decl[GlobalVar]/CurrModule: fooObject[#FooStruct#]{{; name=.+$}}
 // INSIDE_FUNCTION_CALL_2: End completions
 }
@@ -715,8 +714,7 @@ func testInsideFunctionCall7() {
   var a = FooStruct()
   a.instanceFunc8(#^INSIDE_FUNCTION_CALL_7^#
 // INSIDE_FUNCTION_CALL_7: Begin completions
-// FIXME: we should print the non-API param name rdar://20962472
-// INSIDE_FUNCTION_CALL_7: Pattern/ExprSpecific: ['(']{#(Int, Int)#})[#Void#]{{; name=.+$}}
+// INSIDE_FUNCTION_CALL_7: Pattern/ExprSpecific: ['(']{#(a): (Int, Int)#})[#Void#]{{; name=.+$}}
 // INSIDE_FUNCTION_CALL_7: End completions
 }
 
@@ -729,7 +727,7 @@ func testInsideFunctionCall9(_ x: inout FooStruct) {
   x.instanceFunc1(#^INSIDE_FUNCTION_CALL_9^#)
 // Annotated ')'
 // INSIDE_FUNCTION_CALL_9: Begin completions
-// INSIDE_FUNCTION_CALL_9-DAG: Pattern/ExprSpecific: ['(']{#Int#}[')'][#Void#]{{; name=.+$}}
+// INSIDE_FUNCTION_CALL_9-DAG: Pattern/ExprSpecific: ['(']{#(a): Int#}[')'][#Void#]{{; name=.+$}}
 // INSIDE_FUNCTION_CALL_9-DAG: Decl[GlobalVar]/CurrModule: fooObject[#FooStruct#]{{; name=.+$}}
 // INSIDE_FUNCTION_CALL_9: End completions
 }
@@ -754,8 +752,7 @@ func testInsideVarargFunctionCall1() {
   var a = FooStruct()
   a.varargInstanceFunc0(#^INSIDE_VARARG_FUNCTION_CALL_1^#
 // INSIDE_VARARG_FUNCTION_CALL_1: Begin completions
-// FIXME: we should print the non-API param name rdar://20962472
-// INSIDE_VARARG_FUNCTION_CALL_1-DAG: Pattern/ExprSpecific:       ['(']{#Int...#})[#Void#]{{; name=.+$}}
+// INSIDE_VARARG_FUNCTION_CALL_1-DAG: Pattern/ExprSpecific:       ['(']{#(v): Int...#})[#Void#]{{; name=.+$}}
 // INSIDE_VARARG_FUNCTION_CALL_1-DAG: Decl[GlobalVar]/CurrModule: fooObject[#FooStruct#]{{; name=.+$}}
 // INSIDE_VARARG_FUNCTION_CALL_1: End completions
 }
@@ -786,8 +783,7 @@ func testInsideOverloadedFunctionCall1() {
 func testInsideFunctionCallOnClassInstance1(_ a: FooClass) {
   a.fooClassInstanceFunc1(#^INSIDE_FUNCTION_CALL_ON_CLASS_INSTANCE_1^#
 // INSIDE_FUNCTION_CALL_ON_CLASS_INSTANCE_1: Begin completions
-// FIXME: we should print the non-API param name rdar://20962472
-// INSIDE_FUNCTION_CALL_ON_CLASS_INSTANCE_1-DAG: Pattern/ExprSpecific:       ['(']{#Int#})[#Void#]{{; name=.+$}}
+// INSIDE_FUNCTION_CALL_ON_CLASS_INSTANCE_1-DAG: Pattern/ExprSpecific:       ['(']{#(a): Int#})[#Void#]{{; name=.+$}}
 // INSIDE_FUNCTION_CALL_ON_CLASS_INSTANCE_1-DAG: Decl[GlobalVar]/CurrModule: fooObject[#FooStruct#]{{; name=.+$}}
 // INSIDE_FUNCTION_CALL_ON_CLASS_INSTANCE_1: End completions
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->

... to reduce and someday eliminate all the places we do double
typechecking.  The goal is to setup any 'interesting' expressions ahead
of time so that if we type-check them at any point - e.g.  during
checking the context - we don't lose the results and try to check them
again.

For now, this is limited to cases where the original expression is not
replaced by pre-checking or CSGen (i.e. we don't handle
UnresolvedDeclRef through this mechanism yet), and we're only using it
for the "parsed expression", which is either the base of a dot
completion, or the name in a function-call or initializer call
expression.  The intent is to move unresolved member completion to the
same model in the future.

Currently, we use the results from the callbacks for 60% of these
completions, and of the 40% we miss, about 80% are simply
UnresolvedDeclRef or similarly obvious cases.

Progress toward rdar://21466394
Incidentally fixes rdar://20962472

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
