### PR TITLE
Introduce a new data structure to explicitly model scopes in the AST

### DIFF
--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -502,6 +502,21 @@ public:
   /// Find the innermost enclosing scope that contains this source location.
   const ASTScope *findInnermostEnclosingScope(SourceLoc loc) const;
 
+  /// Retrieve the declaration context directly associated with this scope, or
+  /// NULL if there is no such declaration context.
+  ///
+  /// \seealso getInnermostEnclosingDeclContext().
+  DeclContext *getDeclContext() const;
+
+  /// Retrieve the innermost enclosing declaration context in which this
+  /// scope
+  ///
+  /// This is semantically equivalent to calling \c getDeclContext() on this
+  /// node and each of its parents until we get a non-null result.
+  ///
+  /// \seealso getDeclContext().
+  DeclContext *getInnermostEnclosingDeclContext() const;
+
   /// Expand the entire scope map.
   ///
   /// Normally, the scope map will be expanded only as needed by its queries,

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -27,6 +27,7 @@
 namespace swift {
 
 class AbstractFunctionDecl;
+class AbstractStorageDecl;
 class ASTContext;
 class BraceStmt;
 class CaseStmt;
@@ -92,6 +93,8 @@ enum class ASTScopeKind : uint8_t {
   /// Describes the scope of variables introduced in the initializer of a
   /// a C-style 'for' statement.
   ForStmtInitializer,
+  /// Scope for the accessors of an abstract storage declaration.
+  Accessors,
 };
 
 class ASTScope {
@@ -206,6 +209,10 @@ class ASTScope {
     /// A for statement, for \c kind == ASTScopeKind::ForStmt or
     /// \c kind == ASTScopeKind::ForStmtInitializer.
     ForStmt *forStmt;
+
+    /// An abstract storage declaration, for
+    /// \c kind == ASTScopeKind::Accessors.
+    AbstractStorageDecl *abstractStorageDecl;
 };
 
   /// Child scopes, sorted by source range.
@@ -311,6 +318,11 @@ class ASTScope {
     this->forStmt = forStmt;
   }
 
+  ASTScope(const ASTScope *parent, AbstractStorageDecl *abstractStorageDecl)
+      : ASTScope(ASTScopeKind::Accessors, parent) {
+    this->abstractStorageDecl = abstractStorageDecl;
+  }
+
   ~ASTScope();
 
   ASTScope(ASTScope &&) = delete;
@@ -392,6 +404,13 @@ public:
   Decl *getLocalDeclaration() const {
     assert(getKind() == ASTScopeKind::LocalDeclaration);
     return localDeclaration;
+  }
+
+  /// Retrieve the abstract storage declaration when
+  /// \c getKind() == ASTScopeKind::Accessors;
+  AbstractStorageDecl *getAbstractStorageDecl() const {
+    assert(getKind() == ASTScopeKind::Accessors);
+    return abstractStorageDecl;
   }
 
   /// Expand the entire scope map.

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -187,6 +187,10 @@ class ASTScope {
 
       /// The index of the conditional clause.
       unsigned index;
+
+      /// Whether this conditional clause is being used for the 'guard'
+      /// continuation.
+      bool isGuardContinuation;
     } conditionalClause;
 
     /// The 'guard' statement, for \c kind == ASTScopeKind::GuardStmt.
@@ -281,10 +285,11 @@ class ASTScope {
   }
 
   ASTScope(const ASTScope *parent, LabeledConditionalStmt *stmt,
-           unsigned index)
+           unsigned index, bool isGuardContinuation)
       : ASTScope(ASTScopeKind::ConditionalClause, parent) {
     this->conditionalClause.stmt = stmt;
     this->conditionalClause.index = index;
+    this->conditionalClause.isGuardContinuation = isGuardContinuation;
   }
 
   ASTScope(const ASTScope *parent, GuardStmt *guard)

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -63,6 +63,8 @@ enum class ASTScopeKind : uint8_t {
   TypeOrExtensionBody,
   /// The generic parameters of a declaration.
   GenericParams,
+  /// A function/initializer/deinitializer.
+  AbstractFunctionDecl,
   /// The parameters of a function/initializer/deinitializer.
   AbstractFunctionParams,
   /// The scope introduced by a particular clause in a pattern binding
@@ -147,7 +149,10 @@ class ASTScope {
       unsigned index;
     } genericParams;
 
-    /// An abstract function (init/func/deinit).
+    /// An abstract function, for \c kind == ASTScopeKind::AbstractFunctionDecl.
+    AbstractFunctionDecl *abstractFunction;
+
+    /// An parameter for an abstract function (init/func/deinit).
     ///
     /// For \c kind == ASTScopeKind::AbstractFunctionParams.
     struct {
@@ -260,6 +265,11 @@ class ASTScope {
     this->genericParams.params = genericParams;
     this->genericParams.decl = decl;
     this->genericParams.index = index;
+  }
+
+  ASTScope(const ASTScope *parent, AbstractFunctionDecl *abstractFunction)
+      : ASTScope(ASTScopeKind::AbstractFunctionDecl, parent) {
+    this->abstractFunction = abstractFunction;
   }
 
   ASTScope(const ASTScope *parent, AbstractFunctionDecl *abstractFunction,
@@ -439,6 +449,13 @@ public:
   Decl *getLocalDeclaration() const {
     assert(getKind() == ASTScopeKind::LocalDeclaration);
     return localDeclaration;
+  }
+
+  /// Retrieve the abstract function declaration when
+  /// \c getKind() == ASTScopeKind::AbstractFunctionDecl;
+  AbstractFunctionDecl *getAbstractFunctionDecl() const {
+    assert(getKind() == ASTScopeKind::AbstractFunctionDecl);
+    return abstractFunction;
   }
 
   /// Retrieve the abstract storage declaration when

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -43,6 +43,7 @@ class GuardStmt;
 class IfStmt;
 class IterableDeclContext;
 class LabeledConditionalStmt;
+class ParamDecl;
 class PatternBindingDecl;
 class RepeatWhileStmt;
 class SourceFile;
@@ -68,6 +69,8 @@ enum class ASTScopeKind : uint8_t {
   AbstractFunctionDecl,
   /// The parameters of a function/initializer/deinitializer.
   AbstractFunctionParams,
+  /// The default argument for a parameter.
+  DefaultArgument,
   /// A specific pattern binding.
   PatternBinding,
   /// The scope introduced for an initializer of a pattern binding.
@@ -172,6 +175,10 @@ class ASTScope {
       /// The parameter index into the current function parameter list.
       unsigned paramIndex;
     } abstractFunctionParams;
+
+    /// The parameter whose default argument is being described, i.e.,
+    /// \c kind == ASTScopeKind::DefaultArgument.
+    ParamDecl *parameter;
 
     /// For \c kind == ASTScopeKind::PatternBinding,
     /// \c kind == ASTScopeKind::AfterPatternBinding, or
@@ -291,6 +298,11 @@ class ASTScope {
     this->abstractFunctionParams.decl = abstractFunction;
     this->abstractFunctionParams.listIndex = listIndex;
     this->abstractFunctionParams.paramIndex = paramIndex;
+  }
+
+  ASTScope(const ASTScope *parent, ParamDecl *param)
+      : ASTScope(ASTScopeKind::DefaultArgument, parent) {
+    this->parameter = param;
   }
 
   ASTScope(ASTScopeKind kind, const ASTScope *parent, PatternBindingDecl *decl,

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -68,6 +68,10 @@ enum class ASTScopeKind : uint8_t {
   AbstractFunctionDecl,
   /// The parameters of a function/initializer/deinitializer.
   AbstractFunctionParams,
+  /// A specific pattern binding.
+  PatternBinding,
+  /// The scope introduced for an initializer of a pattern binding.
+  PatternInitializer,
   /// The scope introduced by a particular clause in a pattern binding
   /// declaration.
   AfterPatternBinding,
@@ -169,7 +173,9 @@ class ASTScope {
       unsigned paramIndex;
     } abstractFunctionParams;
 
-    /// For \c kind == ASTScopeKind::AfterPatternBinding.
+    /// For \c kind == ASTScopeKind::PatternBinding,
+    /// \c kind == ASTScopeKind::AfterPatternBinding, or
+    /// \c kind == ASTScopeKind::PatternInitializer.
     struct {
       PatternBindingDecl *decl;
       unsigned entry;
@@ -287,8 +293,12 @@ class ASTScope {
     this->abstractFunctionParams.paramIndex = paramIndex;
   }
 
-  ASTScope(const ASTScope *parent, PatternBindingDecl *decl, unsigned entry)
-      : ASTScope(ASTScopeKind::AfterPatternBinding, parent) {
+  ASTScope(ASTScopeKind kind, const ASTScope *parent, PatternBindingDecl *decl,
+           unsigned entry)
+      : ASTScope(kind, parent) {
+    assert(kind == ASTScopeKind::PatternBinding ||
+           kind == ASTScopeKind::PatternInitializer ||
+           kind == ASTScopeKind::AfterPatternBinding);
     this->patternBinding.decl = decl;
     this->patternBinding.entry = entry;
   }

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -14,8 +14,8 @@
 // describes the scopes that exist within a Swift AST.
 //
 //===----------------------------------------------------------------------===//
-#ifndef SWIFT_AST_SCOPE_MAP_H
-#define SWIFT_AST_SCOPE_MAP_H
+#ifndef SWIFT_AST_AST_SCOPE_H
+#define SWIFT_AST_AST_SCOPE_H
 
 #include "swift/AST/ASTNode.h"
 #include "swift/Basic/LLVM.h"
@@ -116,6 +116,32 @@ enum class ASTScopeKind : uint8_t {
   TopLevelCode,
 };
 
+/// Describes a lexical scope within a source file.
+///
+/// Each \c ASTScope is a node within a tree that describes all of the lexical
+/// scopes within a particular source range. The root of this scope tree is
+/// always a \c SourceFile node, and the tree covers the entire source file.
+/// The children of a particular node are the lexical scopes immediately
+/// nested within that node, and have source ranges that are enclosed within
+/// the source range of their parent node. At the leaves are lexical scopes
+/// that cannot be subdivided further.
+///
+/// The tree provides source-location-based query operations, allowing one to
+/// find the innermost scope that contains a given source location. Navigation
+/// to parent nodes from that scope allows one to walk the lexically enclosing
+/// scopes outward to the source file. Given a scope, one can also query the
+/// associated \c DeclContext for additional contextual information.
+///
+/// As an implementation detail, the scope tree is lazily constructed as it is
+/// queried, and only the relevant subtrees (i.e., trees whose source ranges
+/// enclose the queried source location or whose children were explicitly
+/// requested by the client) will be constructed. The \c expandAll() operation
+/// can be used to fully-expand the tree, constructing all of its nodes, but
+/// should only be used for testing or debugging purposes, e.g., via the
+/// frontend option
+/// \code
+/// -dump-scope-maps expanded
+/// \endcode
 class ASTScope {
   /// The kind of scope this represents.
   ASTScopeKind kind;
@@ -547,4 +573,4 @@ public:
 
 }
 
-#endif // SWIFT_BASIC_SOURCE_RANGE_MAP_H
+#endif // SWIFT_AST_AST_SCOPE_H

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -1,0 +1,299 @@
+//===--- ASTScope.h - Swift AST Scope ---------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the ASTScope class and related functionality, which
+// describes the scopes that exist within a Swift AST.
+//
+//===----------------------------------------------------------------------===//
+#ifndef SWIFT_AST_SCOPE_MAP_H
+#define SWIFT_AST_SCOPE_MAP_H
+
+#include "swift/AST/ASTNode.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/Basic/SourceManager.h"
+#include "llvm/ADT/PointerIntPair.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace swift {
+
+class AbstractFunctionDecl;
+class ASTContext;
+class BraceStmt;
+class Decl;
+class Expr;
+class GenericParamList;
+class BraceStmt;
+class IfStmt;
+class IterableDeclContext;
+class GenericParamList;
+class GuardStmt;
+class WhileStmt;
+class DoCatchStmt;
+class ForStmt;
+class ForEachStmt;
+class PatternBindingDecl;
+class SourceFile;
+class Stmt;
+class StmtConditionElement;
+
+/// Describes kind of scope that occurs within the AST.
+enum class ASTScopeKind : uint8_t {
+  /// A source file, which is the root of a scope.
+  SourceFile,
+  /// The body of a type or extension thereof.
+  TypeOrExtensionBody,
+  /// The generic parameters of a declaration.
+  GenericParams,
+  /// The parameters of a function/initializer/deinitializer.
+  AbstractFunctionParams,
+  /// The scope introduced by a particular clause in a pattern binding
+  /// declaration.
+  AfterPatternBinding,
+  /// The scope introduced by a brace statement.
+  BraceStmt,
+  /// The scope introduced by an element in a brace statement.
+  BraceStmtElement,
+  /*
+  BraceStmt,
+  IfThenBranch,
+  IfElseBranch,
+  GuardElseBranch,
+  GuardFollowingScope,
+  WhileBody,
+  DoCatchStmt,
+  ForEachBody,
+  FollowingStmtConditionElement,
+   */
+};
+
+class ASTScope {
+  /// The kind of scope this represents.
+  ASTScopeKind kind;
+
+  /// The parent scope of this particular scope along with a bit indicating
+  /// whether the children of this node have already been expanded.
+  mutable llvm::PointerIntPair<const ASTScope *, 1, bool> parentAndExpanded;
+
+  /// Union describing the various kinds of AST nodes that can introduce
+  /// scopes.
+  union {
+    /// For \c kind == ASTScopeKind::SourceFile.
+    struct {
+      // The actual source file.
+      SourceFile *file;
+
+      /// The next element that should be considered in the source file.
+      ///
+      /// This accomodates the expansion of source files.
+      mutable unsigned nextElement;
+    } sourceFile;
+
+    /// An iterable declaration context, which covers nominal type declarations
+    /// and extensions.
+    ///
+    /// For \c kind == ASTScopeKind::TypeOrExtensionBody.
+    IterableDeclContext *iterableDeclContext;
+
+    /// For \c kind == ASTScopeKind::GenericParams.
+    struct {
+      /// The generic parameters themselves.
+      GenericParamList *params;
+
+      /// The declaration that has generic parameters.
+      Decl *decl;
+
+      /// The index of the current parameter.
+      unsigned index;
+    } genericParams;
+
+    /// An abstract function (init/func/deinit).
+    ///
+    /// For \c kind == ASTScopeKind::AbstractFunctionParams.
+    struct {
+      /// The function declaration.
+      AbstractFunctionDecl *decl;
+
+      /// The index into the function parameter lists.
+      unsigned listIndex;
+
+      /// The parameter index into the current function parameter list.
+      unsigned paramIndex;
+    } abstractFunctionParams;
+
+    /// For \c kind == ASTScopeKind::AfterPatternBinding.
+    struct {
+      PatternBindingDecl *decl;
+      unsigned entry;
+    } patternBinding;
+
+    /// For \c kind == ASTScopeKind::BraceStmt.
+    BraceStmt *braceStmt;
+
+    /// For \c kind == ASTScopeKind::BraceStmtElement.
+    struct {
+      BraceStmt *braceStmt;
+      mutable unsigned element;
+    } braceStmtElement;
+};
+
+  /// Child scopes, sorted by source range.
+  mutable SmallVector<ASTScope *, 4> storedChildren;
+
+  ASTScope(SourceFile *sourceFile, unsigned nextElement)
+      : kind(ASTScopeKind::SourceFile), parentAndExpanded(nullptr, false) {
+    this->sourceFile.file = sourceFile;
+    this->sourceFile.nextElement = nextElement;
+  }
+
+  ASTScope(const ASTScope *parent, IterableDeclContext *idc)
+      : kind(ASTScopeKind::TypeOrExtensionBody),
+        parentAndExpanded(parent, false) {
+    this->iterableDeclContext = idc;
+  }
+
+  ASTScope(const ASTScope *parent, GenericParamList *genericParams,
+           Decl *decl, unsigned index)
+      : kind(ASTScopeKind::GenericParams), parentAndExpanded(parent, false) {
+    this->genericParams.params = genericParams;
+    this->genericParams.decl = decl;
+    this->genericParams.index = index;
+  }
+
+  ASTScope(const ASTScope *parent, AbstractFunctionDecl *abstractFunction,
+           unsigned listIndex, unsigned paramIndex)
+      : kind(ASTScopeKind::AbstractFunctionParams),
+        parentAndExpanded(parent, false) {
+    this->abstractFunctionParams.decl = abstractFunction;
+    this->abstractFunctionParams.listIndex = listIndex;
+    this->abstractFunctionParams.paramIndex = paramIndex;
+  }
+
+  ASTScope(const ASTScope *parent, PatternBindingDecl *decl, unsigned entry)
+      : kind(ASTScopeKind::AfterPatternBinding),
+        parentAndExpanded(parent, false) {
+    this->patternBinding.decl = decl;
+    this->patternBinding.entry = entry;
+  }
+  
+  ASTScope(const ASTScope *parent, BraceStmt *braceStmt)
+      : kind(ASTScopeKind::BraceStmt), parentAndExpanded(parent, false) {
+    this->braceStmt = braceStmt;
+  }
+
+  ASTScope(const ASTScope *parent, BraceStmt *braceStmt, unsigned element)
+      : kind(ASTScopeKind::BraceStmtElement), parentAndExpanded(parent, false) {
+    this->braceStmtElement.braceStmt = braceStmt;
+    this->braceStmtElement.element = element;
+  }
+
+  ~ASTScope();
+
+  ASTScope(ASTScope &&) = delete;
+  ASTScope &operator=(ASTScope &&) = delete;
+  ASTScope(const ASTScope &) = delete;
+  ASTScope &operator=(const ASTScope &) = delete;
+
+  /// Expand the children of this AST scope so they can be queried.
+  void expand() const;
+
+  /// Determine whether the given scope has already been expanded.
+  bool isExpanded() const;
+
+  /// Create a new AST scope if one is needed for the given declaration.
+  ///
+  /// \returns the newly-created AST scope, or \c null if there is no scope
+  /// introduced by this declaration.
+  static ASTScope *createIfNeeded(const ASTScope *parent, Decl *decl);
+
+  /// Create a new AST scope if one is needed for the given statement.
+  ///
+  /// \returns the newly-created AST scope, or \c null if there is no scope
+  /// introduced by this statement.
+  static ASTScope *createIfNeeded(const ASTScope *parent, Stmt *stmt);
+
+  /// Create a new AST scope if one is needed for the given expression.
+  ///
+  /// \returns the newly-created AST scope, or \c null if there is no scope
+  /// introduced by this expression.
+  static ASTScope *createIfNeeded(const ASTScope *parent, Expr *Expr);
+
+  /// Create a new AST scope if one is needed for the given AST node.
+  ///
+  /// \returns the newly-created AST scope, or \c null if there is no scope
+  /// introduced by this AST node.
+  static ASTScope *createIfNeeded(const ASTScope *parent, ASTNode node);
+
+  /// Create a new AST scope that describes the continuation within the same
+  /// parent scope.
+  ///
+  /// Statements, such as 'guard' and local declarations, introduce scopes
+  /// that extend to the end of an enclosing brace-stmt. This
+  /// operation finds the "continuation" in the nearest enclosing brace
+  /// statement, which is the next statement following.
+  static ASTScope *createContinuationScope(const ASTScope *parent);
+
+  /// Retrieve the ASTContext in which this scope exists.
+  ASTContext &getASTContext() const;
+
+  /// Retrieve the source file in which this scope exists.
+  SourceFile &getSourceFile() const;
+
+public:
+  /// Create the AST scope for a source file, which is the root of the scope
+  /// tree.
+  static ASTScope *createRoot(SourceFile *sourceFile);
+
+  /// Determine the kind of AST scope we have.
+  ASTScopeKind getKind() const { return kind; }
+
+  /// Retrieve the parent scope that encloses this one.
+  const ASTScope *getParent() const { return parentAndExpanded.getPointer(); }
+
+  /// Retrieve the children of this AST scope, expanding if necessary.
+  ArrayRef<ASTScope *> children() const {
+    if (!isExpanded()) expand();
+    return storedChildren;
+  }
+
+  /// Determine the source range covered by this scope.
+  SourceRange getSourceRange() const;
+
+  /// Expand the entire scope map.
+  ///
+  /// Normally, the scope map will be expanded only as needed by its queries,
+  /// but complete expansion can be useful for debugging.
+  void expandAll() const;
+
+  /// Print out this scope for debugging/reporting purposes.
+  void print(llvm::raw_ostream &out, unsigned level = 0,
+             bool lastChild = false) const;
+
+  LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
+                            "only for use within the debugger");
+
+  // Make vanilla new/delete illegal for Decls.
+  void *operator new(size_t bytes) = delete;
+  void operator delete(void *data) = delete;
+
+  // Only allow allocation of scopes using the allocator of a particular source
+  // file.
+  void *operator new(size_t bytes, const ASTContext &ctx,
+                     unsigned alignment = alignof(ASTScope));
+  void *operator new(size_t Bytes, void *Mem) {
+    assert(Mem);
+    return Mem;
+  }
+};
+
+}
+
+#endif // SWIFT_BASIC_SOURCE_RANGE_MAP_H

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -32,16 +32,15 @@ class BraceStmt;
 class Decl;
 class DoCatchStmt;
 class Expr;
-class GenericParamList;
-class BraceStmt;
+class ForStmt;
+class ForEachStmt;
 class GenericParamList;
 class GuardStmt;
 class IfStmt;
 class IterableDeclContext;
 class LabeledConditionalStmt;
-class ForStmt;
-class ForEachStmt;
 class PatternBindingDecl;
+class RepeatWhileStmt;
 class SourceFile;
 class Stmt;
 class StmtConditionElement;
@@ -71,6 +70,10 @@ enum class ASTScopeKind : uint8_t {
   ConditionalClause,
   /// Node describing a "guard" statement.
   GuardStmt,
+  /// Node describing a repeat...while statement.
+  RepeatWhileStmt,
+  /// Note describing a for-each statement.
+  ForEachStmt,
   /*
   DoCatchStmt,
   ForEachBody,
@@ -162,9 +165,17 @@ class ASTScope {
       unsigned index;
     } conditionalClause;
 
-    /// The 'guard' statement, for \c lind == ASTScopeKind::GuardStmt.
+    /// The 'guard' statement, for \c kind == ASTScopeKind::GuardStmt.
     GuardStmt *guard;
-  };
+
+    /// The repeat...while statement, for
+    /// \c kind == ASTScopeKind::RepeatWhileStmt.
+    RepeatWhileStmt *repeatWhile;
+
+    /// The for-each statement, for
+    /// \c kind == ASTScopeKind::ForEachStmt.
+    ForEachStmt *forEach;
+};
 
   /// Child scopes, sorted by source range.
   mutable SmallVector<ASTScope *, 4> storedChildren;
@@ -228,6 +239,16 @@ class ASTScope {
   ASTScope(const ASTScope *parent, GuardStmt *guard)
       : ASTScope(ASTScopeKind::GuardStmt, parent) {
     this->guard = guard;
+  }
+
+  ASTScope(const ASTScope *parent, RepeatWhileStmt *repeatWhile)
+      : ASTScope(ASTScopeKind::RepeatWhileStmt, parent) {
+    this->repeatWhile = repeatWhile;
+  }
+
+  ASTScope(const ASTScope *parent, ForEachStmt *forEach)
+      : ASTScope(ASTScopeKind::ForEachStmt, parent) {
+    this->forEach = forEach;
   }
 
   ~ASTScope();

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -436,6 +436,9 @@ public:
     return abstractStorageDecl;
   }
 
+  /// Find the innermost enclosing scope that contains this source location.
+  const ASTScope *findInnermostEnclosingScope(SourceLoc loc) const;
+
   /// Expand the entire scope map.
   ///
   /// Normally, the scope map will be expanded only as needed by its queries,
@@ -444,7 +447,8 @@ public:
 
   /// Print out this scope for debugging/reporting purposes.
   void print(llvm::raw_ostream &out, unsigned level = 0,
-             bool lastChild = false) const;
+             bool lastChild = false,
+             bool printChildren = true) const;
 
   LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
                             "only for use within the debugger");

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -29,6 +29,7 @@ namespace swift {
 class AbstractFunctionDecl;
 class ASTContext;
 class BraceStmt;
+class CatchStmt;
 class Decl;
 class DoCatchStmt;
 class Expr;
@@ -76,10 +77,10 @@ enum class ASTScopeKind : uint8_t {
   ForEachStmt,
   /// Describes the scope of the pattern of the for-each statement.
   ForEachPattern,
-  /*
+  /// Describes a do-catch statement.
   DoCatchStmt,
-  ForEachBody,
-   */
+  /// Describes the a catch statement.
+  CatchStmt,
 };
 
 class ASTScope {
@@ -178,6 +179,12 @@ class ASTScope {
     /// \c kind == ASTScopeKind::ForEachStmt or
     /// \c kind == ASTScopeKind::ForEachPattern.
     ForEachStmt *forEach;
+
+    /// A do-catch statement, for \c kind == ASTScopeKind::DoCatchStmt.
+    DoCatchStmt *doCatch;
+
+    /// A catch statement, for \c kind == ASTScopeKind::CatchStmt.
+    CatchStmt *catchStmt;
 };
 
   /// Child scopes, sorted by source range.
@@ -254,6 +261,16 @@ class ASTScope {
     assert(kind == ASTScopeKind::ForEachStmt ||
            kind == ASTScopeKind::ForEachPattern);
     this->forEach = forEach;
+  }
+
+  ASTScope(const ASTScope *parent, DoCatchStmt *doCatch)
+      : ASTScope(ASTScopeKind::DoCatchStmt, parent) {
+    this->doCatch = doCatch;
+  }
+
+  ASTScope(const ASTScope *parent, CatchStmt *catchStmt)
+      : ASTScope(ASTScopeKind::CatchStmt, parent) {
+    this->catchStmt = catchStmt;
   }
 
   ~ASTScope();

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -87,6 +87,11 @@ enum class ASTScopeKind : uint8_t {
   SwitchStmt,
   /// Describes a 'case' statement.
   CaseStmt,
+  /// Describes a C-style 'for' statement.
+  ForStmt,
+  /// Describes the scope of variables introduced in the initializer of a
+  /// a C-style 'for' statement.
+  ForStmtInitializer,
 };
 
 class ASTScope {
@@ -197,6 +202,10 @@ class ASTScope {
 
     /// A case statement, for \c kind == ASTScopeKind::CaseStmt;
     CaseStmt *caseStmt;
+
+    /// A for statement, for \c kind == ASTScopeKind::ForStmt or
+    /// \c kind == ASTScopeKind::ForStmtInitializer.
+    ForStmt *forStmt;
 };
 
   /// Child scopes, sorted by source range.
@@ -293,6 +302,13 @@ class ASTScope {
   ASTScope(const ASTScope *parent, CaseStmt *caseStmt)
       : ASTScope(ASTScopeKind::CaseStmt, parent) {
     this->caseStmt = caseStmt;
+  }
+
+  ASTScope(ASTScopeKind kind, const ASTScope *parent, ForStmt *forStmt)
+      : ASTScope(kind, parent) {
+    assert(kind == ASTScopeKind::ForStmt ||
+           kind == ASTScopeKind::ForStmtInitializer);
+    this->forStmt = forStmt;
   }
 
   ~ASTScope();

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -29,6 +29,7 @@ namespace swift {
 class AbstractFunctionDecl;
 class ASTContext;
 class BraceStmt;
+class CaseStmt;
 class CatchStmt;
 class Decl;
 class DoCatchStmt;
@@ -45,6 +46,7 @@ class RepeatWhileStmt;
 class SourceFile;
 class Stmt;
 class StmtConditionElement;
+class SwitchStmt;
 class WhileStmt;
 
 /// Describes kind of scope that occurs within the AST.
@@ -81,6 +83,10 @@ enum class ASTScopeKind : uint8_t {
   DoCatchStmt,
   /// Describes the a catch statement.
   CatchStmt,
+  /// Describes a switch statement.
+  SwitchStmt,
+  /// Describes a 'case' statement.
+  CaseStmt,
 };
 
 class ASTScope {
@@ -185,6 +191,12 @@ class ASTScope {
 
     /// A catch statement, for \c kind == ASTScopeKind::CatchStmt.
     CatchStmt *catchStmt;
+
+    /// A switch statement, for \c kind == ASTScopeKind::SwitchStmt.
+    SwitchStmt *switchStmt;
+
+    /// A case statement, for \c kind == ASTScopeKind::CaseStmt;
+    CaseStmt *caseStmt;
 };
 
   /// Child scopes, sorted by source range.
@@ -271,6 +283,16 @@ class ASTScope {
   ASTScope(const ASTScope *parent, CatchStmt *catchStmt)
       : ASTScope(ASTScopeKind::CatchStmt, parent) {
     this->catchStmt = catchStmt;
+  }
+
+  ASTScope(const ASTScope *parent, SwitchStmt *switchStmt)
+      : ASTScope(ASTScopeKind::SwitchStmt, parent) {
+    this->switchStmt = switchStmt;
+  }
+
+  ASTScope(const ASTScope *parent, CaseStmt *caseStmt)
+      : ASTScope(ASTScopeKind::CaseStmt, parent) {
+    this->caseStmt = caseStmt;
   }
 
   ~ASTScope();

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -49,6 +49,7 @@ class SourceFile;
 class Stmt;
 class StmtConditionElement;
 class SwitchStmt;
+class TopLevelCodeDecl;
 class WhileStmt;
 
 /// Describes kind of scope that occurs within the AST.
@@ -104,6 +105,8 @@ enum class ASTScopeKind : uint8_t {
   Accessors,
   /// Scope for a closure.
   Closure,
+  /// Scope for top-level code.
+  TopLevelCode,
 };
 
 class ASTScope {
@@ -235,6 +238,10 @@ class ASTScope {
 
     /// The closure, for \c kind == ASTScopeKind::Closure.
     ClosureExpr *closure;
+
+    /// The top-level code declaration for
+    /// \c kind == ASTScopeKind::TopLevelCodeDecl.
+    TopLevelCodeDecl *topLevelCode;
   };
 
   /// Child scopes, sorted by source range.
@@ -357,6 +364,11 @@ class ASTScope {
   ASTScope(const ASTScope *parent, ClosureExpr *closure)
       : ASTScope(ASTScopeKind::Closure, parent) {
     this->closure = closure;
+  }
+
+  ASTScope(const ASTScope *parent, TopLevelCodeDecl *topLevelCode)
+      : ASTScope(ASTScopeKind::TopLevelCode, parent) {
+    this->topLevelCode = topLevelCode;
   }
 
   ~ASTScope();

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -72,8 +72,10 @@ enum class ASTScopeKind : uint8_t {
   GuardStmt,
   /// Node describing a repeat...while statement.
   RepeatWhileStmt,
-  /// Note describing a for-each statement.
+  /// Node describing a for-each statement.
   ForEachStmt,
+  /// Describes the scope of the pattern of the for-each statement.
+  ForEachPattern,
   /*
   DoCatchStmt,
   ForEachBody,
@@ -173,7 +175,8 @@ class ASTScope {
     RepeatWhileStmt *repeatWhile;
 
     /// The for-each statement, for
-    /// \c kind == ASTScopeKind::ForEachStmt.
+    /// \c kind == ASTScopeKind::ForEachStmt or
+    /// \c kind == ASTScopeKind::ForEachPattern.
     ForEachStmt *forEach;
 };
 
@@ -246,8 +249,10 @@ class ASTScope {
     this->repeatWhile = repeatWhile;
   }
 
-  ASTScope(const ASTScope *parent, ForEachStmt *forEach)
-      : ASTScope(ASTScopeKind::ForEachStmt, parent) {
+  ASTScope(ASTScopeKind kind, const ASTScope *parent, ForEachStmt *forEach)
+      : ASTScope(kind, parent) {
+    assert(kind == ASTScopeKind::ForEachStmt ||
+           kind == ASTScopeKind::ForEachPattern);
     this->forEach = forEach;
   }
 

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -91,6 +91,11 @@ ERROR(error_immediate_mode_primary_file,none,
   "immediate mode is incompatible with -primary-file", ())
 ERROR(error_missing_frontend_action,none,
   "no frontend action was selected", ())
+ERROR(error_invalid_source_location_str,none,
+  "invalid source location string '%0'", (StringRef))
+ERROR(error_no_source_location_scope_map,none,
+  "-dump-scope-maps argument must be 'expanded' or a list of source locations",
+  ())
 
 ERROR(error_mode_cannot_emit_dependencies,none,
   "this mode does not support emitting dependency files", ())

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -44,6 +44,7 @@ namespace clang {
 namespace swift {
   enum class ArtificialMainKind : uint8_t;
   class ASTContext;
+  class ASTScope;
   class ASTWalker;
   class BraceStmt;
   class Decl;
@@ -818,6 +819,9 @@ private:
   /// source file.
   llvm::SetVector<NormalProtocolConformance *> UsedConformances;
 
+  /// The scope map that describes this source file.
+  ASTScope *Scope = nullptr;
+
   friend ASTContext;
   friend Impl;
 
@@ -967,6 +971,9 @@ public:
   /// If this buffer corresponds to a file on disk, returns the path.
   /// Otherwise, return an empty string.
   StringRef getFilename() const;
+
+  /// Retrieve the scope that describes this source file.
+  ASTScope &getScope();
 
   void dump() const;
   void dump(raw_ostream &os) const;

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -142,6 +142,9 @@ public:
     DumpAST, ///< Parse, type-check, and dump AST
     PrintAST, ///< Parse, type-check, and pretty-print AST
 
+    /// Parse and dump scope map.
+    DumpScopeMaps,
+
     /// Parse, type-check, and dump type refinement context hierarchy
     DumpTypeRefinementContexts,
 

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -254,6 +254,10 @@ public:
   /// Indicates a debug crash mode for the frontend.
   DebugCrashMode CrashMode = DebugCrashMode::None;
 
+  /// Line and column for each of the locations to be probed by
+  /// -dump-scope-maps.
+  SmallVector<std::pair<unsigned, unsigned>, 2> DumpScopeMapLocations;
+
   /// Indicates whether the RequestedAction has output.
   bool actionHasOutput() const;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -423,6 +423,11 @@ def dump_parse : Flag<["-"], "dump-parse">,
 def dump_ast : Flag<["-"], "dump-ast">,
   HelpText<"Parse and type-check input file(s) and dump AST(s)">, ModeOpt,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
+def dump_scope_maps : Separate<["-"], "dump-scope-maps">,
+  HelpText<"Parse and type-check input file(s) and dump the scope map(s)">,
+  MetaVarName<"<expanded-or-list-of-line:column>">,
+  ModeOpt,
+  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
 def dump_type_refinement_contexts :
   Flag<["-"], "dump-type-refinement-contexts">,
   HelpText<"Type-check input file(s) and dump type refinement contexts(s)">,

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -137,10 +137,22 @@ void ASTScope::expand() const {
         child->print(out);
         out << "***Previous child node***\n";
         prevChild->print(out);
+        out << "***Parent node***\n";
+        this->print(out);
         abort();
       }
 
-      // FIXME: Make sure that the we don't overlap the previous child.
+      // The previous child must not overlap this child.
+      if (sourceMgr.isBeforeInBuffer(childRange.End, prevChildRange.End)) {
+        auto &out = verificationError() << "unexpected child overlap\n";
+        out << "***Child node***\n";
+        child->print(out);
+        out << "***Previous child node***\n";
+        prevChild->print(out);
+        out << "***Parent node***\n";
+        this->print(out);
+        abort();
+      }
     }
 #endif
 

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -1,0 +1,600 @@
+//===--- ASTScope.cpp - Swift AST Scope -----------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the ASTScope class and related functionality, which
+// describes the scopes that exist within a Swift AST.
+//
+//===----------------------------------------------------------------------===//
+#include "swift/AST/ASTScope.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/Module.h"
+#include "swift/AST/ParameterList.h"
+#include "swift/AST/Pattern.h"
+#include "swift/AST/Stmt.h"
+#include "swift/Basic/STLExtras.h"
+using namespace swift;
+
+void ASTScope::expand() const {
+  assert(!isExpanded() && "Already expanded the children of this node");
+  ASTContext &ctx = getASTContext();
+  SourceManager &sourceMgr = ctx.SourceMgr;
+
+#ifndef NDEBUG
+  auto verificationError = [&]() -> llvm::raw_ostream& {
+    return llvm::errs() << "ASTScope verification error in source file '"
+      << getSourceFile().getFilename()
+      << "':";
+  };
+#endif
+
+  // Local function to add a child to the list of children.
+  bool outOfOrder = false;
+  bool previouslyEmpty = storedChildren.empty();
+  auto addChild = [&](ASTScope *child) {
+    assert(child->getParent() == this && "Wrong parent");
+
+    // Check for containment of the child within the parent.
+#ifndef NDEBUG
+    if (!sourceMgr.rangeContains(getSourceRange(), child->getSourceRange())) {
+      auto &out = verificationError() << "child not contained in its parent\n";
+      out << "***Child node***\n";
+      child->print(out);
+      out << "***Parent node***\n";
+      getParent()->print(out);
+      abort();
+    }
+#endif
+
+    // If there was a previous child, check it's source
+    if (!storedChildren.empty()) {
+      auto prevChild = storedChildren.back();
+      SourceRange prevChildRange = prevChild->getSourceRange();
+      SourceRange childRange = child->getSourceRange();
+
+#ifndef NDEBUG
+      // FIXME: Make sure that the we don't overlap the previous child.
+#endif
+
+      // If the previous child does not precede this one, we have an
+      // out-of-order list of children.
+      // FIXME: Decide whether fixing this up at end is a good interim step.
+      if (sourceMgr.isBeforeInBuffer(childRange.Start, prevChildRange.End))
+        outOfOrder = true;
+    }
+
+    // Add the child.
+    storedChildren.push_back(child);
+  };
+
+  // Expand the children in the current scope.
+  switch (kind) {
+  case ASTScopeKind::SourceFile: {
+    /// Add all of the new declarations to the list of children.
+    for (Decl *decl : llvm::makeArrayRef(sourceFile.file->Decls)
+                        .slice(sourceFile.nextElement)) {
+      // Create a child node for this declaration.
+      if (ASTScope *child = createIfNeeded(this, decl))
+        addChild(child);
+    }
+
+    // Make sure we don't visit these children again.
+    sourceFile.nextElement = sourceFile.file->Decls.size();
+    break;
+  }
+
+  case ASTScopeKind::TypeOrExtensionBody:
+    for (auto member : iterableDeclContext->getMembers()) {
+      // Create a child node for this declaration.
+      if (ASTScope *child = createIfNeeded(this, member))
+        addChild(child);
+    }
+    break;
+
+  case ASTScopeKind::GenericParams:
+    // Create a child of the generic parameters, if needed.
+    if (auto child = createIfNeeded(this, genericParams.decl))
+      addChild(child);
+    break;
+
+  case ASTScopeKind::AbstractFunctionParams:
+    // Create a child of the function parameters, which may eventually be
+    // the function body.
+    if (auto child = createIfNeeded(this, abstractFunctionParams.decl))
+      addChild(child);
+    break;
+
+  case ASTScopeKind::AfterPatternBinding: {
+    const auto &patternEntry =
+      patternBinding.decl->getPatternList()[patternBinding.entry];
+
+    /// Create a child for the initializer expression, if present.
+    if (auto child = createIfNeeded(this, patternEntry.getInit()))
+      addChild(child);
+
+    /// Create a child for the next pattern binding.
+    if (auto child = createIfNeeded(this, patternBinding.decl))
+      addChild(child);
+    break;
+  }
+
+  case ASTScopeKind::BraceStmt: {
+    if (braceStmt->getNumElements() > 0) {
+      // Intrduce a scope for the first element.
+      addChild(new (ctx) ASTScope(this, braceStmt, 0));
+    }
+    break;
+  }
+
+  case ASTScopeKind::BraceStmtElement: {
+    // Find the first element that requires a scope. This updates the current
+    // brace statement element in place, rather than creating additional nodes,
+    // because clients cannot see and don't care about the unexpanded scope.
+    auto elements = braceStmtElement.braceStmt->getElements();
+    for (unsigned i : range(braceStmtElement.element, elements.size())) {
+      braceStmtElement.element = i;
+
+      // Try to create the child. If it succeeds, we're done.
+      if (auto child = createIfNeeded(this, elements[i])) {
+        addChild(child);
+        break;
+      }
+    }
+    break;
+  }
+  }
+
+  // If this is the first time we've added children, notify the ASTContext
+  // that there's a SmallVector that needs to be cleaned up.
+  // FIXME: If we had access to SmallVector::isSmall(), we could do better.
+  if (previouslyEmpty && !storedChildren.empty())
+    getASTContext().addDestructorCleanup(storedChildren);
+
+  // Anything but a SourceFile is considered "expanded" at this point; source
+  // files can grow due to the REPL.
+  if (kind != ASTScopeKind::SourceFile)
+    parentAndExpanded.setInt(true);
+}
+
+bool ASTScope::isExpanded() const {
+  // If the 'expanded' bit is set, we've expanded already.
+  if (parentAndExpanded.getInt()) return true;
+
+  // Source files are expanded when there are no new declarations to process.
+  if (kind == ASTScopeKind::SourceFile &&
+      sourceFile.nextElement == sourceFile.file->Decls.size())
+    return true;
+
+  return false;
+}
+
+/// Create the AST scope for a source file, which is the root of the scope
+/// tree.
+ASTScope *ASTScope::createRoot(SourceFile *sourceFile) {
+  ASTContext &ctx = sourceFile->getASTContext();
+
+  // Create the scope.
+  ASTScope *scope = new (ctx) ASTScope(sourceFile, 0);
+  scope->sourceFile.file = sourceFile;
+  scope->sourceFile.nextElement = 0;
+
+  return scope;
+}
+
+/// Find the parameter list and parameter index (into that list) corresponding
+/// to the next parameter.
+static Optional<std::pair<unsigned, unsigned>>
+findNextParameter(AbstractFunctionDecl *func, unsigned listIndex,
+                  unsigned paramIndex) {
+  auto paramLists = func->getParameterLists();
+  unsigned paramOffset = 1;
+  while (listIndex < paramLists.size()) {
+    auto currentList = paramLists[listIndex];
+
+    // If there is a parameter in this list, return it.
+    if (paramIndex + paramOffset < currentList->size()) {
+      return std::make_pair(listIndex, paramIndex + paramOffset);
+    }
+
+    // Move on to the next list.
+    ++listIndex;
+    paramIndex = 0;
+    paramOffset = 0;
+  }
+
+  return None;
+}
+
+ASTScope *ASTScope::createIfNeeded(const ASTScope *parent, Decl *decl) {
+  if (!decl) return nullptr;
+
+  // Implicit declarations don't have source information for name lookup.
+  if (decl->isImplicit()) return nullptr;
+
+  // Local function to handle generic parameters.
+  ASTContext &ctx = decl->getASTContext();
+  auto nextGenericParam =
+      [&](GenericParamList *genericParams, Decl *decl) -> ASTScope * {
+    if (!genericParams) return nullptr;
+
+    unsigned index = parent->getKind() == ASTScopeKind::GenericParams
+                       ? parent->genericParams.index + 1
+                       : 0;
+    if (index < genericParams->size())
+      return new (ctx) ASTScope(parent, genericParams, decl, index);
+
+    return nullptr;
+  };
+
+  // Create the inner scope.
+  bool inLocalContext = decl->getDeclContext()->isLocalContext();
+  switch (decl->getKind()) {
+  case DeclKind::Import:
+  case DeclKind::EnumCase:
+  case DeclKind::PrecedenceGroup:
+  case DeclKind::InfixOperator:
+  case DeclKind::PrefixOperator:
+  case DeclKind::PostfixOperator:
+  case DeclKind::GenericTypeParam:
+  case DeclKind::AssociatedType:
+  case DeclKind::Module:
+  case DeclKind::Param:
+  case DeclKind::EnumElement:
+  case DeclKind::IfConfig:
+    // These declarations do not introduce scopes.
+    return nullptr;
+
+  case DeclKind::Extension:
+    return new (ctx) ASTScope(parent, cast<ExtensionDecl>(decl));
+
+  case DeclKind::Class:
+  case DeclKind::Enum:
+  case DeclKind::Struct: {
+    auto nominal = cast<NominalTypeDecl>(decl);
+
+    // If we have a generic type and our parent isn't describing our generic
+    // parameters, build the generic parameter scope.
+    if (auto scope = nextGenericParam(nominal->getGenericParams(), nominal))
+      return scope;
+
+    return new (ctx) ASTScope(parent, nominal);
+  }
+
+  case DeclKind::Protocol:
+    return new (ctx) ASTScope(parent, cast<ProtocolDecl>(decl));
+
+  case DeclKind::TypeAlias: {
+    // If we have a generic typealias and our parent isn't describing our
+    // generic parameters, build the generic parameter scope.
+    auto typeAlias = cast<TypeAliasDecl>(decl);
+    if (auto scope = nextGenericParam(typeAlias->getGenericParams(), typeAlias))
+      return scope;
+
+    // Typealiases don't introduce any other scopes.
+    return nullptr;
+  }
+
+  case DeclKind::Func:
+  case DeclKind::Constructor:
+  case DeclKind::Destructor: {
+    auto abstractFunction = cast<AbstractFunctionDecl>(decl);
+
+    // If we have a generic function and our parent isn't describing our generic
+    // parameters or function parameters, build the generic parameter scope.
+    if (parent->getKind() != ASTScopeKind::AbstractFunctionParams) {
+      if (auto scope = nextGenericParam(abstractFunction->getGenericParams(),
+                                        abstractFunction))
+        return scope;
+    }
+
+    // Figure out which parameter is next is the next one down.
+    Optional<std::pair<unsigned, unsigned>> nextParameter;
+    if (parent->getKind() == ASTScopeKind::AbstractFunctionParams) {
+      assert(parent->abstractFunctionParams.decl == decl);
+      nextParameter =
+        findNextParameter(parent->abstractFunctionParams.decl,
+                          parent->abstractFunctionParams.listIndex,
+                          parent->abstractFunctionParams.paramIndex);
+    } else if (abstractFunction->getParameterList(0)->size() > 0) {
+      nextParameter = std::make_pair(0, 0);
+    } else {
+      nextParameter = findNextParameter(abstractFunction, 0, 0);
+    }
+
+    // If there is another parameter to visit, do so now.
+    if (nextParameter)
+      return new (ctx) ASTScope(parent, abstractFunction, nextParameter->first,
+                                nextParameter->second);
+
+
+    // Function body, if present.
+    return createIfNeeded(parent, abstractFunction->getBody());
+  }
+
+  case DeclKind::PatternBinding: {
+    // Only pattern bindings in local scope introduce scopes.
+    if (!inLocalContext) return nullptr;
+
+    // If there are no bindings, we're done.
+    auto patternBinding = cast<PatternBindingDecl>(decl);
+
+    // Find the next pattern binding.
+    unsigned entry = parent->getKind() == ASTScopeKind::AfterPatternBinding
+                       ? parent->patternBinding.entry + 1
+                       : 0;
+    if (entry < patternBinding->getPatternList().size())
+      return new (ctx) ASTScope(parent, patternBinding, entry);
+
+    return nullptr;
+  }
+  }
+
+  // FIXME: Handle remaining cases.
+  return nullptr;
+}
+
+ASTScope *ASTScope::createIfNeeded(const ASTScope *parent, Stmt *stmt) {
+  if (!stmt) return nullptr;
+
+  ASTContext &ctx = parent->getASTContext();
+  switch (stmt->getKind()) {
+  case StmtKind::Brace:
+    return new (ctx) ASTScope(parent, cast<BraceStmt>(stmt));
+  }
+
+  // FIXME: Handle remaining cases.
+  return nullptr;
+}
+
+ASTScope *ASTScope::createIfNeeded(const ASTScope *parent, Expr *expr) {
+  // FIXME: Handle expressions.
+  return nullptr;
+}
+
+ASTScope *ASTScope::createIfNeeded(const ASTScope *parent, ASTNode node) {
+  if (auto decl = node.dyn_cast<Decl *>())
+    return createIfNeeded(parent, decl);
+  if (auto stmt = node.dyn_cast<Stmt *>())
+    return createIfNeeded(parent, stmt);
+  return createIfNeeded(parent, node.get<Expr *>());
+}
+
+ASTContext &ASTScope::getASTContext() const {
+  switch (kind) {
+  case ASTScopeKind::SourceFile:
+    return sourceFile.file->getASTContext();
+
+  case ASTScopeKind::TypeOrExtensionBody:
+    return getParent()->getASTContext();
+
+  case ASTScopeKind::GenericParams:
+    return genericParams.decl->getASTContext();
+
+  case ASTScopeKind::AbstractFunctionParams:
+    return abstractFunctionParams.decl->getASTContext();
+
+  case ASTScopeKind::AfterPatternBinding:
+    return patternBinding.decl->getASTContext();
+
+  case ASTScopeKind::BraceStmt:
+  case ASTScopeKind::BraceStmtElement:
+    return getParent()->getASTContext();
+  }
+}
+
+SourceFile &ASTScope::getSourceFile() const {
+  if (kind == ASTScopeKind::SourceFile)
+    return *sourceFile.file;
+
+  return getParent()->getSourceFile();
+}
+
+SourceRange ASTScope::getSourceRange() const {
+  switch (kind) {
+  case ASTScopeKind::SourceFile:
+    if (auto bufferID = sourceFile.file->getBufferID()) {
+      auto charRange = getASTContext().SourceMgr.getRangeForBuffer(*bufferID);
+      return SourceRange(charRange.getStart(), charRange.getEnd());
+    }
+
+    return SourceRange();
+
+  case ASTScopeKind::TypeOrExtensionBody:
+    if (auto ext = dyn_cast<ExtensionDecl>(iterableDeclContext))
+      return ext->getBraces();
+
+    return cast<NominalTypeDecl>(iterableDeclContext)->getBraces();
+
+  case ASTScopeKind::GenericParams:
+    return SourceRange(genericParams.params->getParams()[genericParams.index]
+                         ->getEndLoc(),
+                       genericParams.decl->getEndLoc());
+
+  case ASTScopeKind::AbstractFunctionParams: {
+    SourceLoc endLoc = abstractFunctionParams.decl->getEndLoc();
+
+    // For the 'self' parameter of a member function, use the start of the
+    // first parameter list... or the 'deinit' keyword for deinitializers.
+    // FIXME: Why oh why don't deinitializers have a parameter list?
+    if (abstractFunctionParams.listIndex == 0 &&
+        abstractFunctionParams.decl->getDeclContext()->isTypeContext()) {
+      SourceLoc startLoc;
+      if (isa<DestructorDecl>(abstractFunctionParams.decl)) {
+        startLoc = abstractFunctionParams.decl->getNameLoc();
+      } else {
+        startLoc = abstractFunctionParams.decl->getParameterList(1)
+                     ->getLParenLoc();
+      }
+      return SourceRange(startLoc, endLoc);
+    }
+
+    // Otherwise, find the end of this parameter.
+    auto param = abstractFunctionParams.decl->getParameterList(
+                   abstractFunctionParams.listIndex)
+                     ->get(abstractFunctionParams.paramIndex);
+    // FIXME: getLocForEndOfToken... but I can't use it here.
+    return SourceRange(param->getEndLoc(), endLoc);
+  }
+
+  case ASTScopeKind::AfterPatternBinding: {
+    const auto &patternEntry =
+      patternBinding.decl->getPatternList()[patternBinding.entry];
+    // The scope of the binding begins after the initializer (if there is one);
+    // other, after the pattern itself.
+    SourceLoc startLoc = patternEntry.getOrigInitRange().End;
+    if (startLoc.isInvalid())
+      startLoc = patternEntry.getPattern()->getSourceRange().End;
+
+    // And extends to the end of the parent range.
+    return SourceRange(startLoc, getParent()->getSourceRange().End);
+  }
+
+  case ASTScopeKind::BraceStmt:
+    return braceStmt->getSourceRange();
+
+  case ASTScopeKind::BraceStmtElement: {
+    auto element =
+      braceStmtElement.braceStmt->getElement(braceStmtElement.element);
+    return SourceRange(element.getStartLoc(),
+                       braceStmtElement.braceStmt->getEndLoc());
+  }
+  }
+}
+
+void ASTScope::expandAll() const {
+  if (isExpanded()) return;
+  expand();
+
+  for (auto child : children())
+    child->expandAll();
+}
+
+void ASTScope::print(llvm::raw_ostream &out, unsigned level,
+                     bool lastChild) const {
+  SourceManager &sourceMgr = getASTContext().SourceMgr;
+
+  // Indent for levels 2+.
+  if (level > 1) out.indent((level-1) * 2);
+
+  // Print child marker and leading '-' for levels 1+.
+  if (level > 0) {
+    out << (lastChild ? '`' : '|') << '-';
+  }
+
+  // Local function to print the scope kind
+  auto printScopeKind = [&](StringRef name) {
+    out << name;
+  };
+
+  // Print the address of the node.
+  auto printAddress = [&](const void *address) {
+    out << " " << address;
+  };
+
+  // Print the source location of the node.
+  auto printRange = [&]() {
+    auto range = getSourceRange();
+    auto startLineAndCol = sourceMgr.getLineAndColumn(range.Start);
+    auto endLineAndCol = sourceMgr.getLineAndColumn(range.End);
+
+    out << " [" << startLineAndCol.first << ":" << startLineAndCol.second
+        << " - " << endLineAndCol.first << ":" << endLineAndCol.second << "]";
+  };
+
+  // Print the scope kind and any salient information.
+  switch (kind) {
+  case ASTScopeKind::SourceFile:
+    printScopeKind("SourceFile");
+    printAddress(sourceFile.file);
+    out << " '" << sourceFile.file->getFilename() << "'";
+    printRange();
+    break;
+
+  case ASTScopeKind::TypeOrExtensionBody: {
+    printScopeKind("TypeOrExtensionBody");
+    if (auto ext = dyn_cast<ExtensionDecl>(iterableDeclContext)) {
+      printAddress(ext);
+      out << " extension of '";
+      if (auto typeRepr = ext->getExtendedTypeLoc().getTypeRepr())
+        typeRepr->print(out);
+      else
+        ext->getExtendedType()->print(out);
+      out << "'";
+      printRange();
+    } else {
+      auto nominal = cast<NominalTypeDecl>(iterableDeclContext);
+      printAddress(nominal);
+      out << " '" << nominal->getName() << "'";
+      printRange();
+    }
+    break;
+  }
+
+  case ASTScopeKind::GenericParams:
+    printScopeKind("GenericParams");
+    printAddress(genericParams.params);
+    out << " param " << genericParams.index;
+    printRange();
+    break;
+
+  case ASTScopeKind::AbstractFunctionParams:
+    printScopeKind("AbstractFunctionParams");
+    printAddress(abstractFunctionParams.decl);
+    out << " " << abstractFunctionParams.decl->getFullName()
+        << " param " << abstractFunctionParams.listIndex << ":"
+        << abstractFunctionParams.paramIndex;
+    printRange();
+    break;
+
+  case ASTScopeKind::AfterPatternBinding:
+    printScopeKind("AfterPatternBinding");
+    printAddress(patternBinding.decl);
+    out << " entry " << patternBinding.entry;
+    printRange();
+    break;
+
+  case ASTScopeKind::BraceStmt:
+    printScopeKind("BraceStmt");
+    printAddress(braceStmt);
+    printRange();
+    break;
+
+  case ASTScopeKind::BraceStmtElement:
+    printScopeKind("BraceStmtElement");
+    printAddress(braceStmtElement.braceStmt);
+    out << " element " << braceStmtElement.element;
+    printRange();
+    break;
+  }
+
+  // Was this scope expanded?
+  out << (isExpanded() ? " expanded" : " unexpanded");
+
+  out << "\n";
+
+  // Print the children. In some cases, we can be "unexpanded" but still have
+  // children.
+  for (unsigned i : indices(storedChildren)) {
+    storedChildren[i]->print(out, level + 1,
+                             /*lastChild=*/i == storedChildren.size()-1);
+  }
+}
+
+void ASTScope::dump() const {
+  print(llvm::errs(), 0, false);
+}
+
+void *ASTScope::operator new(size_t bytes, const ASTContext &ctx,
+                             unsigned alignment) {
+  return ctx.Allocate(bytes, alignment);
+}
+

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -1088,7 +1088,7 @@ SourceFile &ASTScope::getSourceFile() const {
   return getParent()->getSourceFile();
 }
 
-SourceRange ASTScope::getSourceRange() const {
+SourceRange ASTScope::getSourceRangeImpl() const {
   switch (kind) {
   case ASTScopeKind::Preexpanded:
     return SourceRange(children().front()->getSourceRange().Start,

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -222,7 +222,8 @@ void ASTScope::expand() const {
       patternBinding.decl->getPatternList()[patternBinding.entry];
 
     // Create a child for the initializer, if present.
-    if (patternEntry.getInit())
+    if (patternEntry.getInit() &&
+        patternEntry.getInit()->getSourceRange().isValid())
       addChild(new (ctx) ASTScope(ASTScopeKind::PatternInitializer, this,
                                   patternBinding.decl, patternBinding.entry));
 
@@ -933,6 +934,7 @@ ASTScope *ASTScope::createIfNeeded(const ASTScope *parent, Stmt *stmt) {
   ASTContext &ctx = parent->getASTContext();
   switch (stmt->getKind()) {
   case StmtKind::Brace:
+    if (stmt->getSourceRange().isInvalid()) return nullptr;
     return new (ctx) ASTScope(parent, cast<BraceStmt>(stmt));
 
   case StmtKind::Return: {

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -4,6 +4,7 @@ add_swift_library(swiftAST STATIC
   ASTDumper.cpp
   ASTNode.cpp
   ASTPrinter.cpp
+  ASTScope.cpp
   ASTVerifier.cpp
   ASTWalker.cpp
   Attr.cpp

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -17,6 +17,7 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/AST.h"
 #include "swift/AST/ASTPrinter.h"
+#include "swift/AST/ASTScope.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/GenericEnvironment.h"
@@ -1484,6 +1485,11 @@ StringRef SourceFile::getFilename() const {
     return "";
   SourceManager &SM = getASTContext().SourceMgr;
   return SM.getIdentifierForBuffer(BufferID);
+}
+
+ASTScope &SourceFile::getScope() {
+  if (!Scope) Scope = ASTScope::createRoot(this);
+  return *Scope;
 }
 
 Identifier

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -952,6 +952,7 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
     case options::OPT_dump_ast:
     case options::OPT_print_ast:
     case options::OPT_dump_type_refinement_contexts:
+    case options::OPT_dump_scope_maps:
     case options::OPT_dump_interface_hash:
       OI.CompilerOutputType = types::TY_Nothing;
       break;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -253,6 +253,8 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
       Action = FrontendOptions::DumpParse;
     } else if (Opt.matches(OPT_dump_ast)) {
       Action = FrontendOptions::DumpAST;
+    } else if (Opt.matches(OPT_dump_scope_maps)) {
+      Action = FrontendOptions::DumpScopeMaps;
     } else if (Opt.matches(OPT_dump_type_refinement_contexts)) {
       Action = FrontendOptions::DumpTypeRefinementContexts;
     } else if (Opt.matches(OPT_dump_interface_hash)) {
@@ -433,6 +435,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::DumpInterfaceHash:
     case FrontendOptions::DumpAST:
     case FrontendOptions::PrintAST:
+    case FrontendOptions::DumpScopeMaps:
     case FrontendOptions::DumpTypeRefinementContexts:
       // Textual modes.
       Opts.setSingleOutputFilename("-");
@@ -622,6 +625,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::DumpInterfaceHash:
     case FrontendOptions::DumpAST:
     case FrontendOptions::PrintAST:
+    case FrontendOptions::DumpScopeMaps:
     case FrontendOptions::DumpTypeRefinementContexts:
     case FrontendOptions::Immediate:
     case FrontendOptions::REPL:
@@ -648,6 +652,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::DumpInterfaceHash:
     case FrontendOptions::DumpAST:
     case FrontendOptions::PrintAST:
+    case FrontendOptions::DumpScopeMaps:
     case FrontendOptions::DumpTypeRefinementContexts:
     case FrontendOptions::Immediate:
     case FrontendOptions::REPL:
@@ -676,6 +681,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::DumpInterfaceHash:
     case FrontendOptions::DumpAST:
     case FrontendOptions::PrintAST:
+    case FrontendOptions::DumpScopeMaps:
     case FrontendOptions::DumpTypeRefinementContexts:
     case FrontendOptions::EmitSILGen:
     case FrontendOptions::Immediate:

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -24,6 +24,7 @@ bool FrontendOptions::actionHasOutput() const {
   case DumpAST:
   case DumpInterfaceHash:
   case PrintAST:
+  case DumpScopeMaps:
   case DumpTypeRefinementContexts:
     return false;
   case EmitSILGen:
@@ -52,6 +53,7 @@ bool FrontendOptions::actionIsImmediate() const {
   case DumpAST:
   case DumpInterfaceHash:
   case PrintAST:
+  case DumpScopeMaps:
   case DumpTypeRefinementContexts:
   case EmitSILGen:
   case EmitSIL:

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -23,6 +23,7 @@
 #include "swift/FrontendTool/FrontendTool.h"
 
 #include "swift/Subsystems.h"
+#include "swift/AST/ASTScope.h"
 #include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/IRGenOptions.h"
@@ -780,6 +781,7 @@ static bool performCompile(CompilerInstance &Instance,
   if (Action == FrontendOptions::DumpParse ||
       Action == FrontendOptions::DumpAST ||
       Action == FrontendOptions::PrintAST ||
+      Action == FrontendOptions::DumpScopeMaps ||
       Action == FrontendOptions::DumpTypeRefinementContexts ||
       Action == FrontendOptions::DumpInterfaceHash) {
     SourceFile *SF = PrimarySourceFile;
@@ -789,7 +791,11 @@ static bool performCompile(CompilerInstance &Instance,
     }
     if (Action == FrontendOptions::PrintAST)
       SF->print(llvm::outs(), PrintOptions::printEverything());
-    else if (Action == FrontendOptions::DumpTypeRefinementContexts)
+    else if (Action == FrontendOptions::DumpScopeMaps) {
+      ASTScope &scope = SF->getScope();
+      scope.expandAll();
+      scope.print(llvm::errs());
+    } else if (Action == FrontendOptions::DumpTypeRefinementContexts)
       SF->getTypeRefinementContext()->dump(llvm::errs(), Context.SourceMgr);
     else if (Action == FrontendOptions::DumpInterfaceHash)
       SF->dumpInterfaceHash(llvm::errs());

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -809,6 +809,11 @@ static bool performCompile(CompilerInstance &Instance,
             << lineColumn.second << "***\n";
           auto locScope = scope.findInnermostEnclosingScope(loc);
           locScope->print(llvm::errs(), 0, false, false);
+
+          // Dump the AST context, too.
+          if (auto dc = locScope->getDeclContext()) {
+            dc->printContext(llvm::errs());
+          }
         }
 
         llvm::errs() << "***Complete scope map***\n";

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -2213,6 +2213,9 @@ ParserResult<Stmt> Parser::parseStmtForCStyle(SourceLoc ForLoc,
 
   // If we're missing a semicolon, try to recover.
   if (Tok.isNot(tok::semi)) {
+    // Provide a reasonable default location for the first semicolon.
+    Semi1Loc = Tok.getLoc();
+
     if (auto *BS = ConvertClosureToBraceStmt(First.getPtrOrNull(), Context)) {
       // We have seen:
       //     for { ... }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1379,7 +1379,8 @@ bool TypeChecker::typeCheckConstructorBodyUntil(ConstructorDecl *ctor,
       !isKnownEndOfConstructor(body->getElements().back())) {
     SmallVector<ASTNode, 8> Elts(body->getElements().begin(),
                                  body->getElements().end());
-    Elts.push_back(new (Context) ReturnStmt(SourceLoc(), /*value*/nullptr,
+    Elts.push_back(new (Context) ReturnStmt(body->getRBraceLoc(),
+                                            /*value*/nullptr,
                                             /*implicit*/true));
     body = BraceStmt::create(Context, body->getLBraceLoc(), Elts,
                              body->getRBraceLoc(), body->isImplicit());

--- a/test/NameBinding/scope_map.swift
+++ b/test/NameBinding/scope_map.swift
@@ -179,6 +179,14 @@ struct PatternInitializers {
       (c, d) = (1.5, 2.5)
 }
 
+protocol ProtoWithSubscript {
+  subscript(native: Int) -> Int { get set }
+}
+
+func localPatternsWithSharedType() {
+  let i, j, k: Int
+}
+
 // RUN: not %target-swift-frontend -dump-scope-maps expanded %s 2> %t.expanded
 // RUN: %FileCheck -check-prefix CHECK-EXPANDED %s < %t.expanded
 
@@ -369,6 +377,24 @@ struct PatternInitializers {
 // CHECK-EXPANDED-NEXT: {{^}}          `-Closure {{.*}} [167:32 - 167:42] expanded
 // CHECK-EXPANDED-NEXT: {{^}}            `-BraceStmt {{.*}} [167:32 - 167:42] expanded
 // CHECK-EXPANDED-NEXT: {{^}}        `-AbstractFunctionParams {{.*}} defaultArguments(i:j:) param 0:1 [167:48 - 175:1] expanded
+
+// CHECK-EXPANDED: -Accessors {{.*}} scope_map.(file).ProtoWithSubscript.subscript@{{.*}}scope_map.swift:183:3 [183:33 - 183:43] expanded
+// CHECK-EXPANDED-NEXT:     |-AbstractFunctionDecl {{.*}} _ [183:35 - 183:35] expanded
+// CHECK-EXPANDED-NEXT:       `-AbstractFunctionParams {{.*}} _ param 0:0 [183:35 - 183:35] expanded
+// CHECK-EXPANDED-NEXT:         `-AbstractFunctionParams {{.*}} _ param 1:0 [183:35 - 183:35] expanded
+// CHECK-EXPANDED-NEXT:     `-AbstractFunctionDecl {{.*}} _ [183:39 - 183:39] expanded
+// CHECK-EXPANDED-NEXT:       `-AbstractFunctionParams {{.*}} _ param 0:0 [183:39 - 183:39] expanded
+// CHECK-EXPANDED-NEXT:         `-AbstractFunctionParams {{.*}} _ param 1:0 [183:39 - 183:39] expanded
+// CHECK-EXPANDED-NEXT:           `-AbstractFunctionParams {{.*}} _ param 1:1 [183:39 - 183:39] expanded
+
+// CHECK-EXPANDED: `-AbstractFunctionDecl {{.*}} localPatternsWithSharedType() [186:1 - 188:1] expanded
+// CHECK-EXPANDED-NEXT:  `-BraceStmt {{.*}} [186:36 - 188:1] expanded
+// CHECK-EXPANDED-NEXT:    `-PatternBinding {{.*}} entry 0 [187:7 - 188:1] expanded
+// CHECK-EXPANDED-NEXT:      `-AfterPatternBinding {{.*}} entry 0 [187:7 - 188:1] expanded
+// CHECK-EXPANDED-NEXT:        `-PatternBinding {{.*}} entry 1 [187:10 - 188:1] expanded
+// CHECK-EXPANDED-NEXT:          `-AfterPatternBinding {{.*}} entry 1 [187:10 - 188:1] expanded
+// CHECK-EXPANDED-NEXT:            `-PatternBinding {{.*}} entry 2 [187:13 - 188:1] expanded
+// CHECK-EXPANDED-NEXT:              `-AfterPatternBinding {{.*}} entry 2 [187:16 - 188:1] expanded
 
 // RUN: not %target-swift-frontend -dump-scope-maps 70:8,26:20,5:18,166:32,179:18 %s 2> %t.searches
 // RUN: %FileCheck -check-prefix CHECK-SEARCHES %s < %t.searches

--- a/test/NameBinding/scope_map.swift
+++ b/test/NameBinding/scope_map.swift
@@ -96,7 +96,7 @@ func functionBodies1(a: Int, b: Int?) {
   default:
     break;
   }
-
+  for (var i = 0; i != 10; i += 1) { }
 }
 
 func throwing() throws { }
@@ -111,7 +111,7 @@ enum MyEnum {
   case third
 }
 
-// RUN: %target-swift-frontend -dump-scope-maps expanded %s 2> %t.expanded
+// RUN: not %target-swift-frontend -dump-scope-maps expanded %s 2> %t.expanded
 // RUN: %FileCheck -check-prefix CHECK-EXPANDED %s < %t.expanded
 
 
@@ -188,12 +188,15 @@ enum MyEnum {
 // CHECK-EXPANDED-NEXT: {{^}}                              `-BraceStmt {{.*}} [85:54 - 86:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                            `-CatchStmt {{.*}} [86:11 - 87:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                              `-BraceStmt {{.*}} [86:11 - 87:3] expanded
-// CHECK-EXPANDED-NEXT: {{^}}                          `-SwitchStmt {{.*}} [89:3 - 98:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                          |-SwitchStmt {{.*}} [89:3 - 98:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                            |-CaseStmt {{.*}} [90:29 - 91:10] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                              `-BraceStmt {{.*}} [91:5 - 91:10] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                            |-CaseStmt {{.*}} [94:5 - 94:10] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                              `-BraceStmt {{.*}} [94:5 - 94:10] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                            `-CaseStmt {{.*}} [97:5 - 97:10] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                              `-BraceStmt {{.*}} [97:5 - 97:10] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                          `-ForStmt {{.*}} [99:3 - 99:38] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                            `-ForStmtInitializer {{.*}} [99:17 - 99:38] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                              `-BraceStmt {{.*}} [99:36 - 99:38] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                      `-BraceStmt {{.*}} [68:37 - 71:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                        `-AfterPatternBinding {{.*}} entry 0 [69:13 - 71:3] expanded

--- a/test/NameBinding/scope_map.swift
+++ b/test/NameBinding/scope_map.swift
@@ -86,16 +86,16 @@ func functionBodies1(a: Int, b: Int?) {
   } catch {
   }
 
+  switch MyEnum.second(1) {
+  case .second(let x) where x == 17:
+    break;
 
+  case .first:
+    break;
 
-
-
-
-
-
-
-
-
+  default:
+    break;
+  }
 
 }
 
@@ -103,6 +103,12 @@ func throwing() throws { }
 
 struct MyError : Error {
   var value: Int
+}
+
+enum MyEnum {
+  case first
+  case second(Int)
+  case third
 }
 
 // RUN: %target-swift-frontend -dump-scope-maps expanded %s 2> %t.expanded
@@ -176,11 +182,18 @@ struct MyError : Error {
 // CHECK-EXPANDED-NEXT: {{^}}                          |-ForEachStmt {{.*}} [79:3 - 81:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                            `-ForEachPattern {{.*}} [79:52 - 81:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                              `-BraceStmt {{.*}} [79:63 - 81:3] expanded
-// CHECK-EXPANDED-NEXT: {{^}}                          `-DoCatchStmt {{.*}} [83:3 - 87:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                          |-DoCatchStmt {{.*}} [83:3 - 87:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                            |-BraceStmt {{.*}} [83:6 - 85:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                            |-CatchStmt {{.*}} [85:31 - 86:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                              `-BraceStmt {{.*}} [85:54 - 86:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                            `-CatchStmt {{.*}} [86:11 - 87:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                              `-BraceStmt {{.*}} [86:11 - 87:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                          `-SwitchStmt {{.*}} [89:3 - 98:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                            |-CaseStmt {{.*}} [90:29 - 91:10] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                              `-BraceStmt {{.*}} [91:5 - 91:10] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                            |-CaseStmt {{.*}} [94:5 - 94:10] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                              `-BraceStmt {{.*}} [94:5 - 94:10] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                            `-CaseStmt {{.*}} [97:5 - 97:10] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                              `-BraceStmt {{.*}} [97:5 - 97:10] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                      `-BraceStmt {{.*}} [68:37 - 71:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                        `-AfterPatternBinding {{.*}} entry 0 [69:13 - 71:3] expanded

--- a/test/NameBinding/scope_map.swift
+++ b/test/NameBinding/scope_map.swift
@@ -324,9 +324,10 @@ func closures() {
 // CHECK-EXPANDED-NEXT: {{^}}    `-Closure {{.*}} [161:10 - 161:19] expanded
 // CHECK-EXPANDED-NEXT: {{^}}      `-BraceStmt {{.*}} [161:10 - 161:19] expanded
 
-// CHECK-EXPANDED: {{^}}`-BraceStmt {{.*}} [164:1 - 164:16] expanded
-// CHECK-EXPANDED-NEXT: {{^}}  `-Closure {{.*}} [164:1 - 164:14] expanded
-// CHECK-EXPANDED-NEXT: {{^}}    `-BraceStmt {{.*}} [164:1 - 164:14] expanded
+// CHECK-EXPANDED: `-TopLevelCode {{.*}} [164:1 - 164:16] expanded
+// CHECK-EXPANDED-NEXT: {{^}}  `-BraceStmt {{.*}} [164:1 - 164:16] expanded
+// CHECK-EXPANDED-NEXT: {{^}}    `-Closure {{.*}} [164:1 - 164:14] expanded
+// CHECK-EXPANDED-NEXT: {{^}}      `-BraceStmt {{.*}} [164:1 - 164:14] expanded
 
 // RUN: not %target-swift-frontend -dump-scope-maps 70:8,26:20 %s 2> %t.searches
 // RUN: %FileCheck -check-prefix CHECK-SEARCHES %s < %t.searches

--- a/test/NameBinding/scope_map.swift
+++ b/test/NameBinding/scope_map.swift
@@ -76,9 +76,9 @@ func functionBodies1(a: Int, b: Int?) {
 
   repeat { } while true;
 
+  for (x, y) in [(1, "hello"), (2, "world")] where x % 2 == 0 {
 
-
-
+  }
 
 
 
@@ -165,7 +165,10 @@ func functionBodies1(a: Int, b: Int?) {
 // CHECK-EXPANDED-NEXT: {{^}}                            `-ConditionalClause {{.*}} index 1 [73:32 - 75:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                              `-BraceStmt {{.*}} [73:32 - 75:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                                `-AfterPatternBinding {{.*}} entry 0 [74:13 - 75:3] expanded
-// CHECK-EXPANDED-NEXT: {{^}}                          `-RepeatWhileStmt {{.*}} [77:3 - 77:20] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                          |-RepeatWhileStmt {{.*}} [77:3 - 77:20] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                            `-BraceStmt {{.*}} [77:10 - 77:12] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                          `-ForEachStmt {{.*}} [79:3 - 81:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                            `-ForEachPattern {{.*}} [79:52 - 81:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                              `-BraceStmt {{.*}} [79:63 - 81:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                      `-BraceStmt {{.*}} [68:37 - 71:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                        `-AfterPatternBinding {{.*}} entry 0 [69:13 - 71:3] expanded

--- a/test/NameBinding/scope_map.swift
+++ b/test/NameBinding/scope_map.swift
@@ -174,6 +174,11 @@ func defaultArguments(i: Int = 1,
   { $0 }(a)
 }
 
+struct PatternInitializers {
+  var (a, b) = (1, 2),
+      (c, d) = (1.5, 2.5)
+}
+
 // RUN: not %target-swift-frontend -dump-scope-maps expanded %s 2> %t.expanded
 // RUN: %FileCheck -check-prefix CHECK-EXPANDED %s < %t.expanded
 
@@ -365,15 +370,40 @@ func defaultArguments(i: Int = 1,
 // CHECK-EXPANDED-NEXT: {{^}}            `-BraceStmt {{.*}} [167:32 - 167:42] expanded
 // CHECK-EXPANDED-NEXT: {{^}}        `-AbstractFunctionParams {{.*}} defaultArguments(i:j:) param 0:1 [167:48 - 175:1] expanded
 
-// RUN: not %target-swift-frontend -dump-scope-maps 70:8,26:20 %s 2> %t.searches
+// RUN: not %target-swift-frontend -dump-scope-maps 70:8,26:20,5:18,166:32,179:18 %s 2> %t.searches
 // RUN: %FileCheck -check-prefix CHECK-SEARCHES %s < %t.searches
 
 // CHECK-SEARCHES-LABEL: ***Scope at 70:8***
 // CHECK-SEARCHES-NEXT: AfterPatternBinding {{.*}} entry 0 [69:13 - 71:3] expanded
+
 // CHECK-SEARCHES-LABEL: ***Scope at 26:20***
 // CHECK-SEARCHES-NEXT: AbstractFunctionParams {{.*}} init(t:u:) param 1:0 [26:17 - 27:3] expanded
+
+// CHECK-SEARCHES-LABEL: ***Scope at 5:18***
+// CHECK-SEARCHES-NEXT: TypeOrExtensionBody {{.*}} 'InnerC0' [5:17 - 5:19] expanded
+// CHECK-SEARCHES-NEXT: Module name=scope_map
+// CHECK-SEARCHES-NEXT:   FileUnit file="{{.*}}scope_map.swift"
+// CHECK-SEARCHES-NEXT:     StructDecl name=S0
+// CHECK-SEARCHES-NEXT:       ClassDecl name=InnerC0
+
+// CHECK-SEARCHES-LABEL: ***Scope at 166:32***
+// CHECK-SEARCHES-NEXT: DefaultArgument {{.*}} [166:32 - 166:32] expanded
+// CHECK-SEARCHES-NEXT: Module name=scope_map
+// CHECK-SEARCHES-NEXT:   FileUnit file="{{.*}}scope_map.swift"
+// CHECK-SEARCHES-NEXT:     AbstractFunctionDecl name=defaultArguments : (Int, Int) -> ()
+// CHECK-SEARCHES-NEXT:       {{.*}} Initializer DefaultArgument index=0
+
+// CHECK-SEARCHES-LABEL: ***Scope at 179:18***
+// CHECK-SEARCHES-NEXT: PatternInitializer {{.*}} entry 1 [179:16 - 179:25] expanded
+// CHECK-SEARCHES-NEXT: {{.*}} Module name=scope_map
+// CHECK-SEARCHES-NEXT:   {{.*}} FileUnit file="{{.*}}scope_map.swift"
+// CHECK-SEARCHES-NEXT:     {{.*}} StructDecl name=PatternInitializers
+// CHECK-SEARCHES-NEXT:       {{.*}} Initializer PatternBinding {{.*}} #1
+
 // CHECK-SEARCHES-LABEL: ***Complete scope map***
 // CHECK-SEARCHES-NEXT: SourceFile {{.*}} '{{.*}}scope_map.swift' [1:1 - {{.*}}:1] expanded
+// CHECK-SEARCHES: TypeOrExtensionBody {{.*}} 'S0' [4:11 - 6:1] expanded
+// CHECK-SEARCHES: -TypeOrExtensionBody {{.*}} 'InnerC0' [5:17 - 5:19] expanded
 // CHECK-SEARCHES-NOT: {{ expanded}}
 // CHECK-SEARCHES: |-TypeOrExtensionBody {{.*}} 'ContainsGenerics0' [25:25 - 31:1] expanded
 // CHECK-SEARCHES-NEXT:   |-AbstractFunctionDecl {{.*}} init(t:u:) [26:3 - 27:3] expanded
@@ -386,4 +416,11 @@ func defaultArguments(i: Int = 1,
 // CHECK-SEARCHES: |-AbstractFunctionDecl {{.*}} functionBodies1(a:b:) [41:1 - 100:1] expanded
 // CHECK-SEARCHES: `-AbstractFunctionParams {{.*}} functionBodies1(a:b:) param 0:0 [41:25 - 100:1] expanded
 // CHECK-SEARCHES: |-AbstractFunctionDecl {{.*}} throwing() [102:1 - 102:26] unexpanded
+// CHECK-SEARCHES: -AbstractFunctionDecl {{.*}} defaultArguments(i:j:) [166:1 - 175:1] expanded
+// CHECK-SEARCHES: DefaultArgument {{.*}} [166:32 - 166:32] expanded
+// CHECK-SEARCHES-NOT: {{ expanded}}
+// CHECK-SEARCHES: -TypeOrExtensionBody {{.*}} 'PatternInitializers' [177:28 - 180:1] expanded
+// CHECK-SEARCHES:    |-PatternBinding {{.*}} entry 0 [178:7 - 178:21] unexpanded
+// CHECK-SEARCHES:    `-PatternBinding {{.*}} entry 1 [179:7 - 179:25] expanded
+// CHECK-SEARCHES:      `-PatternInitializer {{.*}} entry 1 [179:16 - 179:25] expanded
 // CHECK-SEARCHES-NOT: {{ expanded}}

--- a/test/NameBinding/scope_map.swift
+++ b/test/NameBinding/scope_map.swift
@@ -166,7 +166,6 @@ func closures() {
 // RUN: not %target-swift-frontend -dump-scope-maps expanded %s 2> %t.expanded
 // RUN: %FileCheck -check-prefix CHECK-EXPANDED %s < %t.expanded
 
-
 // CHECK-EXPANDED: SourceFile{{.*}}scope_map.swift{{.*}}expanded
 // CHECK-EXPANDED-NEXT: TypeOrExtensionBody {{.*}} 'S0' [4:11 - 6:1] expanded
 // CHECK-EXPANDED-NEXT: `-TypeOrExtensionBody {{.*}} 'InnerC0' [5:17 - 5:19] expanded
@@ -313,3 +312,24 @@ func closures() {
 // CHECK-EXPANDED: {{^}}`-BraceStmt {{.*}} [164:1 - 164:16] expanded
 // CHECK-EXPANDED-NEXT: {{^}}  `-Closure {{.*}} [164:1 - 164:14] expanded
 // CHECK-EXPANDED-NEXT: {{^}}    `-BraceStmt {{.*}} [164:1 - 164:14] expanded
+
+// RUN: not %target-swift-frontend -dump-scope-maps 70:8,26:20 %s 2> %t.searches
+// RUN: %FileCheck -check-prefix CHECK-SEARCHES %s < %t.searches
+
+// CHECK-SEARCHES-LABEL: ***Scope at 70:8***
+// CHECK-SEARCHES-NEXT: AfterPatternBinding {{.*}} entry 0 [69:13 - 71:3] expanded
+// CHECK-SEARCHES-LABEL: ***Scope at 26:20***
+// CHECK-SEARCHES-NEXT: AbstractFunctionParams {{.*}} init(t:u:) param 1:0 [26:17 - 27:3] expanded
+// CHECK-SEARCHES-LABEL: ***Complete scope map***
+// CHECK-SEARCHES-NEXT: SourceFile {{.*}} '{{.*}}scope_map.swift' [1:1 - {{.*}}:1] expanded
+// CHECK-SEARCHES-NOT: {{ expanded}}
+// CHECK-SEARCHES: |-TypeOrExtensionBody {{.*}} 'ContainsGenerics0' [25:25 - 31:1] expanded
+// CHECK-SEARCHES-NEXT:   |-GenericParams {{.*}} param 0 [26:8 - 27:3] expanded
+// CHECK-SEARCHES-NEXT:     `-GenericParams {{.*}} param 1 [26:11 - 27:3] expanded
+// CHECK-SEARCHES-NEXT:       `-AbstractFunctionParams {{.*}} init(t:u:) param 0:0 [26:13 - 27:3] expanded
+// CHECK-SEARCHES-NEXT:         `-AbstractFunctionParams {{.*}} init(t:u:) param 1:0 [26:17 - 27:3] expanded
+// CHECK-SEARCHES-NEXT:           `-AbstractFunctionParams {{.*}} init(t:u:) param 1:1 [26:23 - 27:3] unexpanded
+// CHECK-SEARCHES-NOT: {{ expanded}}
+// CHECK-SEARCHES: |-AbstractFunctionParams {{.*}} functionBodies1(a:b:) param 0:0 [41:25 - 100:1] expanded
+// CHECK-SEARCHES: |-BraceStmt {{.*}} [102:24 - 102:26] unexpanded
+// CHECK-SEARCHES-NOT: {{ expanded}}

--- a/test/NameBinding/scope_map.swift
+++ b/test/NameBinding/scope_map.swift
@@ -80,6 +80,11 @@ func functionBodies1(a: Int, b: Int?) {
 
   }
 
+  do {
+    try throwing()
+  } catch let mine as MyError where mine.value == 17 {
+  } catch {
+  }
 
 
 
@@ -92,11 +97,12 @@ func functionBodies1(a: Int, b: Int?) {
 
 
 
+}
 
+func throwing() throws { }
 
-
-
-
+struct MyError : Error {
+  var value: Int
 }
 
 // RUN: %target-swift-frontend -dump-scope-maps expanded %s 2> %t.expanded
@@ -129,7 +135,7 @@ func functionBodies1(a: Int, b: Int?) {
 // CHECK-EXPANDED-NEXT:     -BraceStmt {{.*}} [29:10 - 30:3] expanded
 // CHECK-EXPANDED-NEXT: -GenericParams {{.*}} param 0 [33:25 - 33:32] expanded
 // CHECK-EXPANDED-NEXT: {{^[|`]}}-TypeOrExtensionBody {{.*}} '{{.*}}ArchStruct' [{{.*}}] expanded
-// CHECK-EXPANDED-NEXT: {{^}}`-AbstractFunctionParams {{.*}} functionBodies1(a:b:) param 0:0 [41:25 - 100:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}|-AbstractFunctionParams {{.*}} functionBodies1(a:b:) param 0:0 [41:25 - 100:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}  `-AbstractFunctionParams {{.*}} functionBodies1(a:b:) param 0:1 [41:36 - 100:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}    `-BraceStmt {{.*}} [41:39 - 100:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}      `-AfterPatternBinding {{.*}} entry 0 [42:23 - 100:1] expanded
@@ -167,8 +173,14 @@ func functionBodies1(a: Int, b: Int?) {
 // CHECK-EXPANDED-NEXT: {{^}}                                `-AfterPatternBinding {{.*}} entry 0 [74:13 - 75:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                          |-RepeatWhileStmt {{.*}} [77:3 - 77:20] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                            `-BraceStmt {{.*}} [77:10 - 77:12] expanded
-// CHECK-EXPANDED-NEXT: {{^}}                          `-ForEachStmt {{.*}} [79:3 - 81:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                          |-ForEachStmt {{.*}} [79:3 - 81:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                            `-ForEachPattern {{.*}} [79:52 - 81:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                              `-BraceStmt {{.*}} [79:63 - 81:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                          `-DoCatchStmt {{.*}} [83:3 - 87:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                            |-BraceStmt {{.*}} [83:6 - 85:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                            |-CatchStmt {{.*}} [85:31 - 86:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                              `-BraceStmt {{.*}} [85:54 - 86:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                            `-CatchStmt {{.*}} [86:11 - 87:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                              `-BraceStmt {{.*}} [86:11 - 87:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                      `-BraceStmt {{.*}} [68:37 - 71:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                        `-AfterPatternBinding {{.*}} entry 0 [69:13 - 71:3] expanded

--- a/test/NameBinding/scope_map.swift
+++ b/test/NameBinding/scope_map.swift
@@ -294,8 +294,6 @@ func closures() {
 // CHECK-EXPANDED-NEXT: {{^}}      |-Accessors {{.*}} scope_map.(file).func decl.computed@{{.*}}scope_map.swift:143:7 [143:21 - 149:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}        |-AbstractFunctionParams {{.*}} _ param 0:0 [144:5 - 145:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}          `-BraceStmt {{.*}} [144:9 - 145:5] expanded
-// CHECK-EXPANDED-NEXT: {{^}}        |-AbstractFunctionParams {{.*}} _ param 0:0 [144:5 - 145:5] expanded
-// CHECK-EXPANDED-NEXT: {{^}}          `-BraceStmt {{.*}} [144:9 - 145:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}        `-BraceStmt {{.*}} [146:9 - 148:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}      `-AfterPatternBinding {{.*}} entry 1 [149:36 - 155:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}        `-AfterPatternBinding {{.*}} entry 2 [150:21 - 155:1] expanded

--- a/test/NameBinding/scope_map.swift
+++ b/test/NameBinding/scope_map.swift
@@ -38,9 +38,65 @@ struct i386ArchStruct { }
 struct OtherArchStruct { }
 #endif
 
-func functionBodies(a: Int, b: Int?) {
-  let (x, y) = (a, b),
-      (z1, z2) = (b, a)
+func functionBodies1(a: Int, b: Int?) {
+  let (x1, x2) = (a, b),
+      (y1, y2) = (b, a)
+  let (z1, z2) = (a, a)
+  do {
+    let a1 = a
+    let a2 = a
+    do {
+      let b1 = b
+      let b2 = b
+    }
+  }
+  do {
+    let b1 = b
+    let b2 = b
+  }
+  func f(_ i: Int) -> Int { return i }
+  let f2 = f(_:)
+  struct S7 { }
+  typealias S7Alias = S7
+  
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 }
 
 // RUN: %target-swift-frontend -dump-scope-maps expanded %s 2> %t.expanded
@@ -69,14 +125,29 @@ func functionBodies(a: Int, b: Int?) {
 // CHECK-EXPANDED-NEXT:       -AbstractFunctionParams {{.*}} init(t:u:) param 1:0 [26:17 - 27:3] expanded
 // CHECK-EXPANDED-NEXT:         -AbstractFunctionParams {{.*}} init(t:u:) param 1:1 [26:23 - 27:3] expanded
 // CHECK-EXPANDED-NEXT:           -BraceStmt {{.*}} [26:26 - 27:3] expanded
-// CHECK-EXPANDED-NEXT:             -BraceStmtElement {{.*}} element 0 [27:3 - 27:3] expanded
 // CHECK-EXPANDED-NEXT:   -AbstractFunctionParams {{.*}} deinit param 0:0 [29:3 - 30:3] expanded
 // CHECK-EXPANDED-NEXT:     -BraceStmt {{.*}} [29:10 - 30:3] expanded
 // CHECK-EXPANDED-NEXT: -GenericParams {{.*}} param 0 [33:25 - 33:32] expanded
 // CHECK-EXPANDED-NEXT: {{^[|`]}}-TypeOrExtensionBody {{.*}} '{{.*}}ArchStruct' [{{.*}}] expanded
-// CHECK-EXPANDED-NEXT: -AbstractFunctionParams {{.*}} functionBodies(a:b:) param 0:0 [41:24 - 44:1] expanded
-// CHECK-EXPANDED-NEXT:   `-AbstractFunctionParams {{.*}} functionBodies(a:b:) param 0:1 [41:35 - 44:1] expanded
-// CHECK-EXPANDED-NEXT:     `-BraceStmt {{.*}} [41:38 - 44:1] expanded
-// CHECK-EXPANDED-NEXT:       `-BraceStmtElement {{.*}} element 0 [42:3 - 44:1] expanded
-// CHECK-EXPANDED-NEXT:         `-AfterPatternBinding {{.*}} entry 0 [42:21 - 44:1] expanded
-// CHECK-EXPANDED-NEXT:           `-AfterPatternBinding {{.*}} entry 1 [43:23 - 44:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}`-AbstractFunctionParams {{.*}} functionBodies1(a:b:) param 0:0 [41:25 - 100:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}  `-AbstractFunctionParams {{.*}} functionBodies1(a:b:) param 0:1 [41:36 - 100:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}    `-BraceStmt {{.*}} [41:39 - 100:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}      `-AfterPatternBinding {{.*}} entry 0 [42:23 - 100:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}        `-AfterPatternBinding {{.*}} entry 1 [43:23 - 100:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}          `-AfterPatternBinding {{.*}} entry 0 [44:23 - 100:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}            |-BraceStmt {{.*}} [45:6 - 52:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}              `-AfterPatternBinding {{.*}} entry 0 [46:14 - 52:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                `-AfterPatternBinding {{.*}} entry 0 [47:14 - 52:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                  `-BraceStmt {{.*}} [48:8 - 51:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                    `-AfterPatternBinding {{.*}} entry 0 [49:16 - 51:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                      `-AfterPatternBinding {{.*}} entry 0 [50:16 - 51:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}            |-BraceStmt {{.*}} [53:6 - 56:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}              `-AfterPatternBinding {{.*}} entry 0 [54:14 - 56:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                `-AfterPatternBinding {{.*}} entry 0 [55:14 - 56:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}            `-LocalDeclaration {{.*}} [57:3 - 100:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}              |-AbstractFunctionParams {{.*}} f(_:) param 0:0 [57:15 - 57:38] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                `-BraceStmt {{.*}} [57:27 - 57:38] expanded
+// CHECK-EXPANDED-NEXT: {{^}}              `-AfterPatternBinding {{.*}} entry 0 [58:16 - 100:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                `-LocalDeclaration {{.*}} [59:3 - 100:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                  |-TypeOrExtensionBody {{.*}} 'S7' [59:13 - 59:15] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                  `-LocalDeclaration {{.*}} [60:3 - 100:1] expanded

--- a/test/NameBinding/scope_map.swift
+++ b/test/NameBinding/scope_map.swift
@@ -163,6 +163,17 @@ func closures() {
 
 { closures() }()
 
+func defaultArguments(i: Int = 1,
+                      j: Int = { $0 + $1 }(1, 2)) {
+
+  func localWithDefaults(i: Int = 1,
+                         j: Int = { $0 + $1 }(1, 2)) {
+  }
+
+  let a = i + j
+  { $0 }(a)
+}
+
 // RUN: not %target-swift-frontend -dump-scope-maps expanded %s 2> %t.expanded
 // RUN: %FileCheck -check-prefix CHECK-EXPANDED %s < %t.expanded
 
@@ -180,7 +191,8 @@ func closures() {
 // CHECK-EXPANDED-NEXT:   -GenericParams {{.*}} param 1 [22:22 - 23:1] expanded
 // CHECK-EXPANDED-NEXT:   -AbstractFunctionParams {{.*}} genericFunc0(t:u:i:) param 0:0 [22:28 - 23:1] expanded
 // CHECK-EXPANDED-NEXT:     -AbstractFunctionParams {{.*}} genericFunc0(t:u:i:) param 0:1 [22:34 - 23:1] expanded
-// CHECK-EXPANDED-NEXT:       -AbstractFunctionParams {{.*}} genericFunc0(t:u:i:) param 0:2 [22:46 - 23:1] expanded
+// CHECK-EXPANDED:            |-DefaultArgument {{.*}} [22:46 - 22:46] expanded
+// CHECK-EXPANDED:            `-AbstractFunctionParams {{.*}} genericFunc0(t:u:i:) param 0:2 [22:46 - 23:1] expanded
 // CHECK-EXPANDED-NEXT:         -BraceStmt {{.*}} [22:50 - 23:1] expanded
 // CHECK-EXPANDED-NEXT: -TypeOrExtensionBody {{.*}} 'ContainsGenerics0' [25:25 - 31:1] expanded
 // CHECK-EXPANDED-NEXT:  -AbstractFunctionDecl {{.*}} init(t:u:) [26:3 - 27:3] expanded
@@ -340,10 +352,18 @@ func closures() {
 // CHECK-EXPANDED-NEXT: {{^}}    `-Closure {{.*}} [161:10 - 161:19] expanded
 // CHECK-EXPANDED-NEXT: {{^}}      `-BraceStmt {{.*}} [161:10 - 161:19] expanded
 
-// CHECK-EXPANDED: `-TopLevelCode {{.*}} [164:1 - 164:16] expanded
+// CHECK-EXPANDED: |-TopLevelCode {{.*}} [164:1 - 164:16] expanded
 // CHECK-EXPANDED-NEXT: {{^}}  `-BraceStmt {{.*}} [164:1 - 164:16] expanded
 // CHECK-EXPANDED-NEXT: {{^}}    `-Closure {{.*}} [164:1 - 164:14] expanded
 // CHECK-EXPANDED-NEXT: {{^}}      `-BraceStmt {{.*}} [164:1 - 164:14] expanded
+
+// CHECK-EXPANDED: -AbstractFunctionDecl {{.*}} defaultArguments(i:j:) [166:1 - 175:1] expanded
+// CHECK-EXPANDED: {{^}}    |-DefaultArgument {{.*}} [166:32 - 166:32] expanded
+// CHECK-EXPANDED-NEXT: {{^}}    `-AbstractFunctionParams {{.*}} defaultArguments(i:j:) param 0:0 [166:32 - 175:1] expanded
+// CHECK-EXPANDED: {{^}}        |-DefaultArgument {{.*}} [167:32 - 167:48] expanded
+// CHECK-EXPANDED-NEXT: {{^}}          `-Closure {{.*}} [167:32 - 167:42] expanded
+// CHECK-EXPANDED-NEXT: {{^}}            `-BraceStmt {{.*}} [167:32 - 167:42] expanded
+// CHECK-EXPANDED-NEXT: {{^}}        `-AbstractFunctionParams {{.*}} defaultArguments(i:j:) param 0:1 [167:48 - 175:1] expanded
 
 // RUN: not %target-swift-frontend -dump-scope-maps 70:8,26:20 %s 2> %t.searches
 // RUN: %FileCheck -check-prefix CHECK-SEARCHES %s < %t.searches

--- a/test/NameBinding/scope_map.swift
+++ b/test/NameBinding/scope_map.swift
@@ -199,23 +199,39 @@ func closures() {
 // CHECK-EXPANDED-NEXT: {{^}}  `-AbstractFunctionParams {{.*}} functionBodies1(a:b:) param 0:0 [41:25 - 100:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}  `-AbstractFunctionParams {{.*}} functionBodies1(a:b:) param 0:1 [41:36 - 100:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}    `-BraceStmt {{.*}} [41:39 - 100:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}      `-PatternBinding {{.*}} entry 0 [42:7 - 100:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}      |-PatternInitializer {{.*}} entry 0 [42:18 - 42:23] expanded
 // CHECK-EXPANDED-NEXT: {{^}}      `-AfterPatternBinding {{.*}} entry 0 [42:23 - 100:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}        `-PatternBinding {{.*}} entry 1 [43:7 - 100:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}              |-PatternInitializer {{.*}} entry 1 [43:18 - 43:23] expanded
 // CHECK-EXPANDED-NEXT: {{^}}        `-AfterPatternBinding {{.*}} entry 1 [43:23 - 100:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}          `-PatternBinding {{.*}} entry 0 [44:7 - 100:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}          |-PatternInitializer {{.*}} entry 0 [44:18 - 44:23] expanded
 // CHECK-EXPANDED-NEXT: {{^}}          `-AfterPatternBinding {{.*}} entry 0 [44:23 - 100:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}            |-BraceStmt {{.*}} [45:6 - 52:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}              `-PatternBinding {{.*}} entry 0 [46:9 - 52:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                |-PatternInitializer {{.*}} entry 0 [46:14 - 46:14] expanded
 // CHECK-EXPANDED-NEXT: {{^}}              `-AfterPatternBinding {{.*}} entry 0 [46:14 - 52:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                `-PatternBinding {{.*}} entry 0 [47:9 - 52:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                  |-PatternInitializer {{.*}} entry 0 [47:14 - 47:14] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                `-AfterPatternBinding {{.*}} entry 0 [47:14 - 52:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                  `-BraceStmt {{.*}} [48:8 - 51:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                    `-PatternBinding {{.*}} entry 0 [49:11 - 51:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                      |-PatternInitializer {{.*}} entry 0 [49:16 - 49:16] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                    `-AfterPatternBinding {{.*}} entry 0 [49:16 - 51:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                      `-PatternBinding {{.*}} entry 0 [50:11 - 51:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                      |-PatternInitializer {{.*}} entry 0 [50:16 - 50:16] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                      `-AfterPatternBinding {{.*}} entry 0 [50:16 - 51:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}            |-BraceStmt {{.*}} [53:6 - 56:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}              `-PatternBinding {{.*}} entry 0 [54:9 - 56:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                |-PatternInitializer {{.*}} entry 0 [54:14 - 54:14] expanded
 // CHECK-EXPANDED-NEXT: {{^}}              `-AfterPatternBinding {{.*}} entry 0 [54:14 - 56:3] expanded
-// CHECK-EXPANDED-NEXT: {{^}}                `-AfterPatternBinding {{.*}} entry 0 [55:14 - 56:3] expanded
+// CHECK-EXPANDED: {{^}}                `-AfterPatternBinding {{.*}} entry 0 [55:14 - 56:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}            `-LocalDeclaration {{.*}} [57:3 - 100:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}              |-AbstractFunctionDecl {{.*}} f(_:) [57:3 - 57:38] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                `-AbstractFunctionParams {{.*}} f(_:) param 0:0 [57:15 - 57:38] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                  `-BraceStmt {{.*}} [57:27 - 57:38] expanded
-// CHECK-EXPANDED-NEXT: {{^}}              `-AfterPatternBinding {{.*}} entry 0 [58:16 - 100:1] expanded
+// CHECK-EXPANDED: {{^}}              `-AfterPatternBinding {{.*}} entry 0 [58:16 - 100:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                `-LocalDeclaration {{.*}} [59:3 - 100:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                  |-TypeOrExtensionBody {{.*}} 'S7' [59:13 - 59:15] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                  `-LocalDeclaration {{.*}} [60:3 - 100:1] expanded
@@ -223,9 +239,9 @@ func closures() {
 // CHECK-EXPANDED-NEXT: {{^}}                      |-ConditionalClause {{.*}} index 0 [62:18 - 64:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                        `-ConditionalClause {{.*}} index 1 [62:29 - 64:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                          `-BraceStmt {{.*}} [62:29 - 64:3] expanded
-// CHECK-EXPANDED-NEXT: {{^}}                            `-AfterPatternBinding {{.*}} entry 0 [63:14 - 64:3] expanded
+// CHECK-EXPANDED: {{^}}                                 `-AfterPatternBinding {{.*}} entry 0 [63:14 - 64:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                      `-BraceStmt {{.*}} [64:10 - 66:3] expanded
-// CHECK-EXPANDED-NEXT: {{^}}                        `-AfterPatternBinding {{.*}} entry 0 [65:14 - 66:3] expanded
+// CHECK-EXPANDED: {{^}}                             `-AfterPatternBinding {{.*}} entry 0 [65:14 - 66:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                    `-GuardStmt {{.*}} [68:3 - 100:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                      |-ConditionalClause {{.*}} index 0 [68:21 - 68:53] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                        `-ConditionalClause {{.*}} index 1 [68:21 - 68:53] expanded
@@ -233,14 +249,14 @@ func closures() {
 // CHECK-EXPANDED-NEXT: {{^}}                            `-BraceStmt {{.*}} [68:21 - 68:30] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                          `-ConditionalClause {{.*}} index 2 [68:53 - 68:53] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                      |-BraceStmt {{.*}} [68:53 - 71:3] expanded
-// CHECK-EXPANDED-NEXT: {{^}}                        `-AfterPatternBinding {{.*}} entry 0 [69:13 - 71:3] expanded
+// CHECK-EXPANDED: {{^}}                        `-AfterPatternBinding {{.*}} entry 0 [69:13 - 71:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                      `-ConditionalClause {{.*}} index 0 guard-continuation [71:3 - 100:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                        `-ConditionalClause {{.*}} index 1 guard-continuation [71:3 - 100:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                          `-ConditionalClause {{.*}} index 2 guard-continuation [71:3 - 100:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                          |-ConditionalClause {{.*}} index 0 [73:21 - 75:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                            `-ConditionalClause {{.*}} index 1 [73:32 - 75:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                              `-BraceStmt {{.*}} [73:32 - 75:3] expanded
-// CHECK-EXPANDED-NEXT: {{^}}                                `-AfterPatternBinding {{.*}} entry 0 [74:13 - 75:3] expanded
+// CHECK-EXPANDED: {{^}}                                `-AfterPatternBinding {{.*}} entry 0 [74:13 - 75:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                          |-RepeatWhileStmt {{.*}} [77:3 - 77:20] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                            `-BraceStmt {{.*}} [77:10 - 77:12] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                          |-ForEachStmt {{.*}} [79:3 - 81:3] expanded
@@ -287,12 +303,12 @@ func closures() {
 // CHECK-EXPANDED-NEXT: {{^}}        `-BraceStmt {{.*}} [127:9 - 128:5] expanded
 
 // CHECK-EXPANDED: {{^}}|-TypeOrExtensionBody {{.*}} 'ClassWithComputedProperties' [132:35 - 140:1] expanded
-// CHECK-EXPANDED-NEXT: {{^}}  |-Accessors {{.*}} scope_map.(file).ClassWithComputedProperties.willSetProperty@{{.*}}scope_map.swift:133:7 [133:32 - 135:3] expanded
+// CHECK-EXPANDED: {{^}}  `-Accessors {{.*}} scope_map.(file).ClassWithComputedProperties.willSetProperty@{{.*}}scope_map.swift:133:7 [133:32 - 135:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}   `-AbstractFunctionDecl {{.*}} _ [134:5 - 134:15] expanded
 // CHECK-EXPANDED-NEXT: {{^}}    `-AbstractFunctionParams {{.*}} _ param 0:0 [134:5 - 134:15] expanded
 // CHECK-EXPANDED-NEXT: {{^}}      `-AbstractFunctionParams {{.*}} _ param 1:0 [134:5 - 134:15] expanded
 // CHECK-EXPANDED-NEXT: {{^}}        `-BraceStmt {{.*}} [134:13 - 134:15] expanded
-// CHECK-EXPANDED-NEXT: {{^}}  `-Accessors {{.*}} scope_map.(file).ClassWithComputedProperties.didSetProperty@{{.*}}scope_map.swift:137:7 [137:31 - 139:3] expanded
+// CHECK-EXPANDED: {{^}}       `-Accessors {{.*}} scope_map.(file).ClassWithComputedProperties.didSetProperty@{{.*}}scope_map.swift:137:7 [137:31 - 139:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}    `-AbstractFunctionDecl {{.*}} _ [138:5 - 138:14] expanded
 // CHECK-EXPANDED-NEXT: {{^}}    `-AbstractFunctionParams {{.*}} _ param 0:0 [138:5 - 138:14] expanded
 // CHECK-EXPANDED-NEXT: {{^}}      `-AbstractFunctionParams {{.*}} _ param 1:0 [138:5 - 138:14] expanded
@@ -300,15 +316,15 @@ func closures() {
 
 // CHECK-EXPANDED: {{^}}  `-AbstractFunctionParams {{.*}} funcWithComputedProperties(i:) param 0:0 [142:36 - 155:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}  `-BraceStmt {{.*}} [142:41 - 155:1] expanded
-// CHECK-EXPANDED-NEXT: {{^}}    `-AfterPatternBinding {{.*}} entry 0 [143:17 - 155:1] expanded
-// CHECK-EXPANDED-NEXT: {{^}}      |-Accessors {{.*}} scope_map.(file).func decl.computed@{{.*}}scope_map.swift:143:7 [143:21 - 149:3] expanded
+// CHECK-EXPANDED: {{^}}      |-Accessors {{.*}} scope_map.(file).func decl.computed@{{.*}}scope_map.swift:143:7 [143:21 - 149:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}       |-AbstractFunctionDecl {{.*}} _ [144:5 - 145:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}        `-AbstractFunctionParams {{.*}} _ param 0:0 [144:5 - 145:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}          `-BraceStmt {{.*}} [144:9 - 145:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}    `-AbstractFunctionDecl {{.*}} _ [146:5 - 148:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}        `-BraceStmt {{.*}} [146:9 - 148:5] expanded
-// CHECK-EXPANDED-NEXT: {{^}}      `-AfterPatternBinding {{.*}} entry 1 [149:36 - 155:1] expanded
-// CHECK-EXPANDED-NEXT: {{^}}        `-AfterPatternBinding {{.*}} entry 2 [150:21 - 155:1] expanded
+// CHECK-EXPANDED: {{^}}    `-AfterPatternBinding {{.*}} entry 0 [149:3 - 155:1] expanded
+// CHECK-EXPANDED: {{^}}      `-AfterPatternBinding {{.*}} entry 1 [149:36 - 155:1] expanded
+// CHECK-EXPANDED: {{^}}        `-AfterPatternBinding {{.*}} entry 2 [150:21 - 155:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}          `-LocalDeclaration {{.*}} [150:25 - 155:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}           |-AbstractFunctionDecl {{.*}} _ [150:25 - 152:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}            `-BraceStmt {{.*}} [150:25 - 152:3] expanded

--- a/test/NameBinding/scope_map.swift
+++ b/test/NameBinding/scope_map.swift
@@ -175,6 +175,7 @@ func closures() {
 // CHECK-EXPANDED-NEXT: -GenericParams {{.*}} param 0 [19:18 - 20:1] expanded
 // CHECK-EXPANDED-NEXT:   -GenericParams {{.*}} param 1 [19:21 - 20:1] expanded
 // CHECK-EXPANDED-NEXT:     -TypeOrExtensionBody {{.*}} 'GenericS0' [19:24 - 20:1] expanded
+// CHECK-EXPANDED-NEXT:-AbstractFunctionDecl {{.*}} genericFunc0(t:u:i:) [22:1 - 23:1] expanded
 // CHECK-EXPANDED-NEXT:  -GenericParams {{.*}} param 0 [22:19 - 23:1] expanded
 // CHECK-EXPANDED-NEXT:   -GenericParams {{.*}} param 1 [22:22 - 23:1] expanded
 // CHECK-EXPANDED-NEXT:   -AbstractFunctionParams {{.*}} genericFunc0(t:u:i:) param 0:0 [22:28 - 23:1] expanded
@@ -182,17 +183,20 @@ func closures() {
 // CHECK-EXPANDED-NEXT:       -AbstractFunctionParams {{.*}} genericFunc0(t:u:i:) param 0:2 [22:46 - 23:1] expanded
 // CHECK-EXPANDED-NEXT:         -BraceStmt {{.*}} [22:50 - 23:1] expanded
 // CHECK-EXPANDED-NEXT: -TypeOrExtensionBody {{.*}} 'ContainsGenerics0' [25:25 - 31:1] expanded
+// CHECK-EXPANDED-NEXT:  -AbstractFunctionDecl {{.*}} init(t:u:) [26:3 - 27:3] expanded
 // CHECK-EXPANDED-NEXT:   -GenericParams {{.*}} param 0 [26:8 - 27:3] expanded
 // CHECK-EXPANDED-NEXT:     -GenericParams {{.*}} param 1 [26:11 - 27:3] expanded
 // CHECK-EXPANDED-NEXT:     -AbstractFunctionParams {{.*}} init(t:u:) param 0:0 [26:13 - 27:3] expanded
 // CHECK-EXPANDED-NEXT:       -AbstractFunctionParams {{.*}} init(t:u:) param 1:0 [26:17 - 27:3] expanded
 // CHECK-EXPANDED-NEXT:         -AbstractFunctionParams {{.*}} init(t:u:) param 1:1 [26:23 - 27:3] expanded
 // CHECK-EXPANDED-NEXT:           -BraceStmt {{.*}} [26:26 - 27:3] expanded
+// CHECK-EXPANDED-NEXT: -AbstractFunctionDecl {{.*}} deinit
 // CHECK-EXPANDED-NEXT:   -AbstractFunctionParams {{.*}} deinit param 0:0 [29:3 - 30:3] expanded
 // CHECK-EXPANDED-NEXT:     -BraceStmt {{.*}} [29:10 - 30:3] expanded
 // CHECK-EXPANDED-NEXT: -GenericParams {{.*}} param 0 [33:25 - 33:32] expanded
 // CHECK-EXPANDED-NEXT: {{^[|`]}}-TypeOrExtensionBody {{.*}} '{{.*}}ArchStruct' [{{.*}}] expanded
-// CHECK-EXPANDED-NEXT: {{^}}|-AbstractFunctionParams {{.*}} functionBodies1(a:b:) param 0:0 [41:25 - 100:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}|-AbstractFunctionDecl {{.*}} functionBodies1(a:b:) [41:1 - 100:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}  `-AbstractFunctionParams {{.*}} functionBodies1(a:b:) param 0:0 [41:25 - 100:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}  `-AbstractFunctionParams {{.*}} functionBodies1(a:b:) param 0:1 [41:36 - 100:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}    `-BraceStmt {{.*}} [41:39 - 100:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}      `-AfterPatternBinding {{.*}} entry 0 [42:23 - 100:1] expanded
@@ -208,8 +212,9 @@ func closures() {
 // CHECK-EXPANDED-NEXT: {{^}}              `-AfterPatternBinding {{.*}} entry 0 [54:14 - 56:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                `-AfterPatternBinding {{.*}} entry 0 [55:14 - 56:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}            `-LocalDeclaration {{.*}} [57:3 - 100:1] expanded
-// CHECK-EXPANDED-NEXT: {{^}}              |-AbstractFunctionParams {{.*}} f(_:) param 0:0 [57:15 - 57:38] expanded
-// CHECK-EXPANDED-NEXT: {{^}}                `-BraceStmt {{.*}} [57:27 - 57:38] expanded
+// CHECK-EXPANDED-NEXT: {{^}}              |-AbstractFunctionDecl {{.*}} f(_:) [57:3 - 57:38] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                `-AbstractFunctionParams {{.*}} f(_:) param 0:0 [57:15 - 57:38] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                  `-BraceStmt {{.*}} [57:27 - 57:38] expanded
 // CHECK-EXPANDED-NEXT: {{^}}              `-AfterPatternBinding {{.*}} entry 0 [58:16 - 100:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                `-LocalDeclaration {{.*}} [59:3 - 100:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                  |-TypeOrExtensionBody {{.*}} 'S7' [59:13 - 59:15] expanded
@@ -260,47 +265,57 @@ func closures() {
 
 // CHECK-EXPANDED: {{^}}|-TypeOrExtensionBody {{.*}} 'StructContainsAbstractStorageDecls' [114:43 - 130:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}  |-Accessors {{.*}} scope_map.(file).StructContainsAbstractStorageDecls.subscript@{{.*}}scope_map.swift:115:3 [115:37 - 121:3] expanded
-// CHECK-EXPANDED-NEXT: {{^}}    |-AbstractFunctionParams {{.*}} _ param 0:0 [116:5 - 117:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}  |-AbstractFunctionDecl {{.*}} _ [116:5 - 117:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}    `-AbstractFunctionParams {{.*}} _ param 0:0 [116:5 - 117:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}      `-AbstractFunctionParams {{.*}} _ param 1:0 [116:5 - 117:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}        `-AbstractFunctionParams {{.*}} _ param 1:1 [116:5 - 117:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}          `-AbstractFunctionParams {{.*}} _ param 1:2 [116:5 - 117:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}            `-BraceStmt {{.*}} [116:9 - 117:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}  `-AbstractFunctionDecl {{.*}} _ [118:5 - 120:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}    `-AbstractFunctionParams {{.*}} _ param 0:0 [118:5 - 120:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}      `-AbstractFunctionParams {{.*}} _ param 1:0 [118:5 - 120:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}        `-AbstractFunctionParams {{.*}} _ param 1:1 [118:5 - 120:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}          `-BraceStmt {{.*}} [118:9 - 120:5] expanded
 
 // CHECK-EXPANDED: {{^}}  `-Accessors {{.*}} scope_map.(file).StructContainsAbstractStorageDecls.computed@{{.*}}scope_map.swift:123:7 [123:21 - 129:3] expanded
-// CHECK-EXPANDED-NEXT: {{^}}    |-AbstractFunctionParams {{.*}} _ param 0:0 [124:5 - 126:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}  |-AbstractFunctionDecl {{.*}} _ [124:5 - 126:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}    `-AbstractFunctionParams {{.*}} _ param 0:0 [124:5 - 126:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}      `-BraceStmt {{.*}} [124:9 - 126:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}    `-AbstractFunctionDecl {{.*}} _ [127:5 - 128:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}    `-AbstractFunctionParams {{.*}} _ param 0:0 [127:5 - 128:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}      `-AbstractFunctionParams {{.*}} _ param 1:0 [127:5 - 128:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}        `-BraceStmt {{.*}} [127:9 - 128:5] expanded
 
 // CHECK-EXPANDED: {{^}}|-TypeOrExtensionBody {{.*}} 'ClassWithComputedProperties' [132:35 - 140:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}  |-Accessors {{.*}} scope_map.(file).ClassWithComputedProperties.willSetProperty@{{.*}}scope_map.swift:133:7 [133:32 - 135:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}   `-AbstractFunctionDecl {{.*}} _ [134:5 - 134:15] expanded
 // CHECK-EXPANDED-NEXT: {{^}}    `-AbstractFunctionParams {{.*}} _ param 0:0 [134:5 - 134:15] expanded
 // CHECK-EXPANDED-NEXT: {{^}}      `-AbstractFunctionParams {{.*}} _ param 1:0 [134:5 - 134:15] expanded
 // CHECK-EXPANDED-NEXT: {{^}}        `-BraceStmt {{.*}} [134:13 - 134:15] expanded
 // CHECK-EXPANDED-NEXT: {{^}}  `-Accessors {{.*}} scope_map.(file).ClassWithComputedProperties.didSetProperty@{{.*}}scope_map.swift:137:7 [137:31 - 139:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}    `-AbstractFunctionDecl {{.*}} _ [138:5 - 138:14] expanded
 // CHECK-EXPANDED-NEXT: {{^}}    `-AbstractFunctionParams {{.*}} _ param 0:0 [138:5 - 138:14] expanded
 // CHECK-EXPANDED-NEXT: {{^}}      `-AbstractFunctionParams {{.*}} _ param 1:0 [138:5 - 138:14] expanded
 // CHECK-EXPANDED-NEXT: {{^}}        `-BraceStmt {{.*}} [138:12 - 138:14] expanded
 
-// CHECK-EXPANDED: {{^}}|-AbstractFunctionParams {{.*}} funcWithComputedProperties(i:) param 0:0 [142:36 - 155:1] expanded
+// CHECK-EXPANDED: {{^}}  `-AbstractFunctionParams {{.*}} funcWithComputedProperties(i:) param 0:0 [142:36 - 155:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}  `-BraceStmt {{.*}} [142:41 - 155:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}    `-AfterPatternBinding {{.*}} entry 0 [143:17 - 155:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}      |-Accessors {{.*}} scope_map.(file).func decl.computed@{{.*}}scope_map.swift:143:7 [143:21 - 149:3] expanded
-// CHECK-EXPANDED-NEXT: {{^}}        |-AbstractFunctionParams {{.*}} _ param 0:0 [144:5 - 145:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}       |-AbstractFunctionDecl {{.*}} _ [144:5 - 145:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}        `-AbstractFunctionParams {{.*}} _ param 0:0 [144:5 - 145:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}          `-BraceStmt {{.*}} [144:9 - 145:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}    `-AbstractFunctionDecl {{.*}} _ [146:5 - 148:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}        `-BraceStmt {{.*}} [146:9 - 148:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}      `-AfterPatternBinding {{.*}} entry 1 [149:36 - 155:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}        `-AfterPatternBinding {{.*}} entry 2 [150:21 - 155:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}          `-LocalDeclaration {{.*}} [150:25 - 155:1] expanded
-// CHECK-EXPANDED-NEXT: {{^}}            |-BraceStmt {{.*}} [150:25 - 152:3] expanded
-// CHECK-EXPANDED-NEXT: {{^}}            `-BraceStmt {{.*}} [154:6 - 154:8] expanded
+// CHECK-EXPANDED-NEXT: {{^}}           |-AbstractFunctionDecl {{.*}} _ [150:25 - 152:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}            `-BraceStmt {{.*}} [150:25 - 152:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}              `-BraceStmt {{.*}} [154:6 - 154:8] expanded
 
-// CHECK-EXPANDED: {{^}}|-BraceStmt {{.*}} [157:17 - 162:1] expanded
+// CHECK-EXPANDED: |-AbstractFunctionDecl {{.*}} closures() [157:1 - 162:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}  `-BraceStmt {{.*}} [157:17 - 162:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}  `-Preexpanded {{.*}} [158:10 - 161:19] expanded
 // CHECK-EXPANDED-NEXT: {{^}}    |-Closure {{.*}} [158:10 - 160:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}      `-BraceStmt {{.*}} [158:10 - 160:3] expanded
@@ -324,12 +339,14 @@ func closures() {
 // CHECK-SEARCHES-NEXT: SourceFile {{.*}} '{{.*}}scope_map.swift' [1:1 - {{.*}}:1] expanded
 // CHECK-SEARCHES-NOT: {{ expanded}}
 // CHECK-SEARCHES: |-TypeOrExtensionBody {{.*}} 'ContainsGenerics0' [25:25 - 31:1] expanded
-// CHECK-SEARCHES-NEXT:   |-GenericParams {{.*}} param 0 [26:8 - 27:3] expanded
+// CHECK-SEARCHES-NEXT:   |-AbstractFunctionDecl {{.*}} init(t:u:) [26:3 - 27:3] expanded
+// CHECK-SEARCHES-NEXT:   `-GenericParams {{.*}} param 0 [26:8 - 27:3] expanded
 // CHECK-SEARCHES-NEXT:     `-GenericParams {{.*}} param 1 [26:11 - 27:3] expanded
 // CHECK-SEARCHES-NEXT:       `-AbstractFunctionParams {{.*}} init(t:u:) param 0:0 [26:13 - 27:3] expanded
 // CHECK-SEARCHES-NEXT:         `-AbstractFunctionParams {{.*}} init(t:u:) param 1:0 [26:17 - 27:3] expanded
 // CHECK-SEARCHES-NEXT:           `-AbstractFunctionParams {{.*}} init(t:u:) param 1:1 [26:23 - 27:3] unexpanded
 // CHECK-SEARCHES-NOT: {{ expanded}}
-// CHECK-SEARCHES: |-AbstractFunctionParams {{.*}} functionBodies1(a:b:) param 0:0 [41:25 - 100:1] expanded
-// CHECK-SEARCHES: |-BraceStmt {{.*}} [102:24 - 102:26] unexpanded
+// CHECK-SEARCHES: |-AbstractFunctionDecl {{.*}} functionBodies1(a:b:) [41:1 - 100:1] expanded
+// CHECK-SEARCHES: `-AbstractFunctionParams {{.*}} functionBodies1(a:b:) param 0:0 [41:25 - 100:1] expanded
+// CHECK-SEARCHES: |-AbstractFunctionDecl {{.*}} throwing() [102:1 - 102:26] unexpanded
 // CHECK-SEARCHES-NOT: {{ expanded}}

--- a/test/NameBinding/scope_map.swift
+++ b/test/NameBinding/scope_map.swift
@@ -74,7 +74,7 @@ func functionBodies1(a: Int, b: Int?) {
     let c = 5
   }
 
-
+  repeat { } while true;
 
 
 
@@ -161,9 +161,11 @@ func functionBodies1(a: Int, b: Int?) {
 // CHECK-EXPANDED-NEXT: {{^}}                    `-GuardStmt {{.*}} [68:3 - 100:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                      |-ConditionalClause {{.*}} index 0 [68:21 - 100:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                        `-ConditionalClause {{.*}} index 1 [71:3 - 100:1] expanded
-// CHECK-EXPANDED-NEXT: {{^}}                          `-ConditionalClause {{.*}} index 0 [73:21 - 75:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                          |-ConditionalClause {{.*}} index 0 [73:21 - 75:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                            `-ConditionalClause {{.*}} index 1 [73:32 - 75:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                              `-BraceStmt {{.*}} [73:32 - 75:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                                `-AfterPatternBinding {{.*}} entry 0 [74:13 - 75:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                          `-RepeatWhileStmt {{.*}} [77:3 - 77:20] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                            `-BraceStmt {{.*}} [77:10 - 77:12] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                      `-BraceStmt {{.*}} [68:37 - 71:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                        `-AfterPatternBinding {{.*}} entry 0 [69:13 - 71:3] expanded

--- a/test/NameBinding/scope_map.swift
+++ b/test/NameBinding/scope_map.swift
@@ -65,7 +65,7 @@ func functionBodies1(a: Int, b: Int?) {
     let c2 = b
   }
 
-  guard let b1 = b, let b2 = b else {
+  guard let b1 = b, { $0 > 5 }(b1), let b2 = b else {
     let c = 5
     return
   }
@@ -223,8 +223,16 @@ func closures() {
 // CHECK-EXPANDED-NEXT: {{^}}                      `-BraceStmt {{.*}} [64:10 - 66:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                        `-AfterPatternBinding {{.*}} entry 0 [65:14 - 66:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                    `-GuardStmt {{.*}} [68:3 - 100:1] expanded
-// CHECK-EXPANDED-NEXT: {{^}}                      |-ConditionalClause {{.*}} index 0 [68:21 - 100:1] expanded
-// CHECK-EXPANDED-NEXT: {{^}}                        `-ConditionalClause {{.*}} index 1 [71:3 - 100:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                      |-ConditionalClause {{.*}} index 0 [68:21 - 68:53] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                        `-ConditionalClause {{.*}} index 1 [68:21 - 68:53] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                          |-Closure {{.*}} [68:21 - 68:30] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                            `-BraceStmt {{.*}} [68:21 - 68:30] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                          `-ConditionalClause {{.*}} index 2 [68:53 - 68:53] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                      |-BraceStmt {{.*}} [68:53 - 71:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                        `-AfterPatternBinding {{.*}} entry 0 [69:13 - 71:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                      `-ConditionalClause {{.*}} index 0 guard-continuation [71:3 - 100:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                        `-ConditionalClause {{.*}} index 1 guard-continuation [71:3 - 100:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                          `-ConditionalClause {{.*}} index 2 guard-continuation [71:3 - 100:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                          |-ConditionalClause {{.*}} index 0 [73:21 - 75:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                            `-ConditionalClause {{.*}} index 1 [73:32 - 75:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                              `-BraceStmt {{.*}} [73:32 - 75:3] expanded
@@ -250,8 +258,6 @@ func closures() {
 // CHECK-EXPANDED-NEXT: {{^}}                          `-ForStmt {{.*}} [99:3 - 99:38] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                            `-ForStmtInitializer {{.*}} [99:17 - 99:38] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                              `-BraceStmt {{.*}} [99:36 - 99:38] expanded
-// CHECK-EXPANDED-NEXT: {{^}}                      `-BraceStmt {{.*}} [68:37 - 71:3] expanded
-// CHECK-EXPANDED-NEXT: {{^}}                        `-AfterPatternBinding {{.*}} entry 0 [69:13 - 71:3] expanded
 
 // CHECK-EXPANDED: {{^}}|-TypeOrExtensionBody {{.*}} 'StructContainsAbstractStorageDecls' [114:43 - 130:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}  |-Accessors {{.*}} scope_map.(file).StructContainsAbstractStorageDecls.subscript@{{.*}}scope_map.swift:115:3 [115:37 - 121:3] expanded

--- a/test/NameBinding/scope_map.swift
+++ b/test/NameBinding/scope_map.swift
@@ -1,0 +1,82 @@
+// Note: test of the scope map. All of these tests are line- and
+// column-sensitive, so any additions should go at the end.
+
+struct S0 {
+  class InnerC0 { }
+}
+
+extension S0 {
+}
+
+class C0 {
+}
+
+enum E0 {
+  case C0
+  case C1(Int, Int)
+}
+
+struct GenericS0<T, U> {
+}
+
+func genericFunc0<T, U>(t: T, u: U, i: Int = 10) {
+}
+
+class ContainsGenerics0 {
+  init<T, U>(t: T, u: U) {
+  }
+
+  deinit {
+  }
+}
+
+typealias GenericAlias0<T> = [T]
+
+#if arch(i386)
+struct i386ArchStruct { }
+#else
+struct OtherArchStruct { }
+#endif
+
+func functionBodies(a: Int, b: Int?) {
+  let (x, y) = (a, b),
+      (z1, z2) = (b, a)
+}
+
+// RUN: %target-swift-frontend -dump-scope-maps expanded %s 2> %t.expanded
+// RUN: %FileCheck -check-prefix CHECK-EXPANDED %s < %t.expanded
+
+
+// CHECK-EXPANDED: SourceFile{{.*}}scope_map.swift{{.*}}expanded
+// CHECK-EXPANDED-NEXT: TypeOrExtensionBody {{.*}} 'S0' [4:11 - 6:1] expanded
+// CHECK-EXPANDED-NEXT: `-TypeOrExtensionBody {{.*}} 'InnerC0' [5:17 - 5:19] expanded
+// CHECK-EXPANDED-NEXT: -TypeOrExtensionBody {{.*}} extension of 'S0' [8:14 - 9:1] expanded
+// CHECK-EXPANDED-NEXT: |-TypeOrExtensionBody {{.*}} 'C0' [11:10 - 12:1] expanded
+// CHECK-EXPANDED-NEXT: -TypeOrExtensionBody {{.*}} 'E0' [14:9 - 17:1] expanded
+// CHECK-EXPANDED-NEXT: -GenericParams {{.*}} param 0 [19:18 - 20:1] expanded
+// CHECK-EXPANDED-NEXT:   -GenericParams {{.*}} param 1 [19:21 - 20:1] expanded
+// CHECK-EXPANDED-NEXT:     -TypeOrExtensionBody {{.*}} 'GenericS0' [19:24 - 20:1] expanded
+// CHECK-EXPANDED-NEXT:  -GenericParams {{.*}} param 0 [22:19 - 23:1] expanded
+// CHECK-EXPANDED-NEXT:   -GenericParams {{.*}} param 1 [22:22 - 23:1] expanded
+// CHECK-EXPANDED-NEXT:   -AbstractFunctionParams {{.*}} genericFunc0(t:u:i:) param 0:0 [22:28 - 23:1] expanded
+// CHECK-EXPANDED-NEXT:     -AbstractFunctionParams {{.*}} genericFunc0(t:u:i:) param 0:1 [22:34 - 23:1] expanded
+// CHECK-EXPANDED-NEXT:       -AbstractFunctionParams {{.*}} genericFunc0(t:u:i:) param 0:2 [22:46 - 23:1] expanded
+// CHECK-EXPANDED-NEXT:         -BraceStmt {{.*}} [22:50 - 23:1] expanded
+// CHECK-EXPANDED-NEXT: -TypeOrExtensionBody {{.*}} 'ContainsGenerics0' [25:25 - 31:1] expanded
+// CHECK-EXPANDED-NEXT:   -GenericParams {{.*}} param 0 [26:8 - 27:3] expanded
+// CHECK-EXPANDED-NEXT:     -GenericParams {{.*}} param 1 [26:11 - 27:3] expanded
+// CHECK-EXPANDED-NEXT:     -AbstractFunctionParams {{.*}} init(t:u:) param 0:0 [26:13 - 27:3] expanded
+// CHECK-EXPANDED-NEXT:       -AbstractFunctionParams {{.*}} init(t:u:) param 1:0 [26:17 - 27:3] expanded
+// CHECK-EXPANDED-NEXT:         -AbstractFunctionParams {{.*}} init(t:u:) param 1:1 [26:23 - 27:3] expanded
+// CHECK-EXPANDED-NEXT:           -BraceStmt {{.*}} [26:26 - 27:3] expanded
+// CHECK-EXPANDED-NEXT:             -BraceStmtElement {{.*}} element 0 [27:3 - 27:3] expanded
+// CHECK-EXPANDED-NEXT:   -AbstractFunctionParams {{.*}} deinit param 0:0 [29:3 - 30:3] expanded
+// CHECK-EXPANDED-NEXT:     -BraceStmt {{.*}} [29:10 - 30:3] expanded
+// CHECK-EXPANDED-NEXT: -GenericParams {{.*}} param 0 [33:25 - 33:32] expanded
+// CHECK-EXPANDED-NEXT: {{^[|`]}}-TypeOrExtensionBody {{.*}} '{{.*}}ArchStruct' [{{.*}}] expanded
+// CHECK-EXPANDED-NEXT: -AbstractFunctionParams {{.*}} functionBodies(a:b:) param 0:0 [41:24 - 44:1] expanded
+// CHECK-EXPANDED-NEXT:   `-AbstractFunctionParams {{.*}} functionBodies(a:b:) param 0:1 [41:35 - 44:1] expanded
+// CHECK-EXPANDED-NEXT:     `-BraceStmt {{.*}} [41:38 - 44:1] expanded
+// CHECK-EXPANDED-NEXT:       `-BraceStmtElement {{.*}} element 0 [42:3 - 44:1] expanded
+// CHECK-EXPANDED-NEXT:         `-AfterPatternBinding {{.*}} entry 0 [42:21 - 44:1] expanded
+// CHECK-EXPANDED-NEXT:           `-AfterPatternBinding {{.*}} entry 1 [43:23 - 44:1] expanded

--- a/test/NameBinding/scope_map.swift
+++ b/test/NameBinding/scope_map.swift
@@ -154,6 +154,14 @@ func funcWithComputedProperties(i: Int) {
   do { }
 }
 
+func closures() {
+  { x, y in 
+    return { $0 + $1 }(x, y)
+  }(1, 2) + 
+  { a, b in a * b }(3, 4)
+}
+
+
 // RUN: not %target-swift-frontend -dump-scope-maps expanded %s 2> %t.expanded
 // RUN: %FileCheck -check-prefix CHECK-EXPANDED %s < %t.expanded
 
@@ -273,7 +281,7 @@ func funcWithComputedProperties(i: Int) {
 // CHECK-EXPANDED-NEXT: {{^}}      `-AbstractFunctionParams {{.*}} _ param 1:0 [138:5 - 138:14] expanded
 // CHECK-EXPANDED-NEXT: {{^}}        `-BraceStmt {{.*}} [138:12 - 138:14] expanded
 
-// CHECK-EXPANDED: {{^}}`-AbstractFunctionParams {{.*}} funcWithComputedProperties(i:) param 0:0 [142:36 - 155:1] expanded
+// CHECK-EXPANDED: {{^}}|-AbstractFunctionParams {{.*}} funcWithComputedProperties(i:) param 0:0 [142:36 - 155:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}  `-BraceStmt {{.*}} [142:41 - 155:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}    `-AfterPatternBinding {{.*}} entry 0 [143:17 - 155:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}      |-Accessors {{.*}} scope_map.(file).func decl.computed@{{.*}}scope_map.swift:143:7 [143:21 - 149:3] expanded
@@ -287,3 +295,12 @@ func funcWithComputedProperties(i: Int) {
 // CHECK-EXPANDED-NEXT: {{^}}          `-LocalDeclaration {{.*}} [150:25 - 155:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}            |-BraceStmt {{.*}} [150:25 - 152:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}            `-BraceStmt {{.*}} [154:6 - 154:8] expanded
+
+// CHECK-EXPANDED: {{^}}`-BraceStmt {{.*}} [157:17 - 162:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}  `-Preexpanded {{.*}} [158:10 - 161:19] expanded
+// CHECK-EXPANDED-NEXT: {{^}}    |-Closure {{.*}} [158:10 - 160:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}      `-BraceStmt {{.*}} [158:10 - 160:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}        `-Closure {{.*}} [159:12 - 159:22] expanded
+// CHECK-EXPANDED-NEXT: {{^}}          `-BraceStmt {{.*}} [159:12 - 159:22] expanded
+// CHECK-EXPANDED-NEXT: {{^}}    `-Closure {{.*}} [161:10 - 161:19] expanded
+// CHECK-EXPANDED-NEXT: {{^}}      `-BraceStmt {{.*}} [161:10 - 161:19] expanded

--- a/test/NameBinding/scope_map.swift
+++ b/test/NameBinding/scope_map.swift
@@ -59,20 +59,20 @@ func functionBodies1(a: Int, b: Int?) {
   struct S7 { }
   typealias S7Alias = S7
   
+  if let b1 = b, let b2 = b {
+    let c1 = b
+  } else {
+    let c2 = b
+  }
 
+  guard let b1 = b, let b2 = b else {
+    let c = 5
+    return
+  }
 
-
-
-
-
-
-
-
-
-
-
-
-
+  while let b3 = b, let b4 = b {
+    let c = 5
+  }
 
 
 
@@ -151,3 +151,19 @@ func functionBodies1(a: Int, b: Int?) {
 // CHECK-EXPANDED-NEXT: {{^}}                `-LocalDeclaration {{.*}} [59:3 - 100:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                  |-TypeOrExtensionBody {{.*}} 'S7' [59:13 - 59:15] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                  `-LocalDeclaration {{.*}} [60:3 - 100:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                    |-IfStmt {{.*}} [62:3 - 66:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                      |-ConditionalClause {{.*}} index 0 [62:18 - 64:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                        `-ConditionalClause {{.*}} index 1 [62:29 - 64:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                          `-BraceStmt {{.*}} [62:29 - 64:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                            `-AfterPatternBinding {{.*}} entry 0 [63:14 - 64:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                      `-BraceStmt {{.*}} [64:10 - 66:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                        `-AfterPatternBinding {{.*}} entry 0 [65:14 - 66:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                    `-GuardStmt {{.*}} [68:3 - 100:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                      |-ConditionalClause {{.*}} index 0 [68:21 - 100:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                        `-ConditionalClause {{.*}} index 1 [71:3 - 100:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                          `-ConditionalClause {{.*}} index 0 [73:21 - 75:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                            `-ConditionalClause {{.*}} index 1 [73:32 - 75:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                              `-BraceStmt {{.*}} [73:32 - 75:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                                `-AfterPatternBinding {{.*}} entry 0 [74:13 - 75:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                      `-BraceStmt {{.*}} [68:37 - 71:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                        `-AfterPatternBinding {{.*}} entry 0 [69:13 - 71:3] expanded

--- a/test/NameBinding/scope_map.swift
+++ b/test/NameBinding/scope_map.swift
@@ -32,8 +32,8 @@ class ContainsGenerics0 {
 
 typealias GenericAlias0<T> = [T]
 
-#if arch(i386)
-struct i386ArchStruct { }
+#if arch(unknown)
+struct UnknownArchStruct { }
 #else
 struct OtherArchStruct { }
 #endif
@@ -161,6 +161,7 @@ func closures() {
   { a, b in a * b }(3, 4)
 }
 
+{ closures() }()
 
 // RUN: not %target-swift-frontend -dump-scope-maps expanded %s 2> %t.expanded
 // RUN: %FileCheck -check-prefix CHECK-EXPANDED %s < %t.expanded
@@ -287,16 +288,16 @@ func closures() {
 // CHECK-EXPANDED-NEXT: {{^}}      |-Accessors {{.*}} scope_map.(file).func decl.computed@{{.*}}scope_map.swift:143:7 [143:21 - 149:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}        |-AbstractFunctionParams {{.*}} _ param 0:0 [144:5 - 145:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}          `-BraceStmt {{.*}} [144:9 - 145:5] expanded
-// CHECK-EXPANDED-NEXT: {{^}}        |-BraceStmt {{.*}} [146:9 - 148:5] expanded
-// CHECK-EXPANDED-NEXT: {{^}}        `-AbstractFunctionParams {{.*}} _ param 0:0 [144:5 - 145:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}        |-AbstractFunctionParams {{.*}} _ param 0:0 [144:5 - 145:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}          `-BraceStmt {{.*}} [144:9 - 145:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}        `-BraceStmt {{.*}} [146:9 - 148:5] expanded
 // CHECK-EXPANDED-NEXT: {{^}}      `-AfterPatternBinding {{.*}} entry 1 [149:36 - 155:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}        `-AfterPatternBinding {{.*}} entry 2 [150:21 - 155:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}          `-LocalDeclaration {{.*}} [150:25 - 155:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}            |-BraceStmt {{.*}} [150:25 - 152:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}            `-BraceStmt {{.*}} [154:6 - 154:8] expanded
 
-// CHECK-EXPANDED: {{^}}`-BraceStmt {{.*}} [157:17 - 162:1] expanded
+// CHECK-EXPANDED: {{^}}|-BraceStmt {{.*}} [157:17 - 162:1] expanded
 // CHECK-EXPANDED-NEXT: {{^}}  `-Preexpanded {{.*}} [158:10 - 161:19] expanded
 // CHECK-EXPANDED-NEXT: {{^}}    |-Closure {{.*}} [158:10 - 160:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}      `-BraceStmt {{.*}} [158:10 - 160:3] expanded
@@ -304,3 +305,7 @@ func closures() {
 // CHECK-EXPANDED-NEXT: {{^}}          `-BraceStmt {{.*}} [159:12 - 159:22] expanded
 // CHECK-EXPANDED-NEXT: {{^}}    `-Closure {{.*}} [161:10 - 161:19] expanded
 // CHECK-EXPANDED-NEXT: {{^}}      `-BraceStmt {{.*}} [161:10 - 161:19] expanded
+
+// CHECK-EXPANDED: {{^}}`-BraceStmt {{.*}} [164:1 - 164:16] expanded
+// CHECK-EXPANDED-NEXT: {{^}}  `-Closure {{.*}} [164:1 - 164:14] expanded
+// CHECK-EXPANDED-NEXT: {{^}}    `-BraceStmt {{.*}} [164:1 - 164:14] expanded

--- a/test/NameBinding/scope_map.swift
+++ b/test/NameBinding/scope_map.swift
@@ -111,6 +111,49 @@ enum MyEnum {
   case third
 }
 
+struct StructContainsAbstractStorageDecls {
+  subscript (i: Int, j: Int) -> Int {
+    set {
+    }
+    get {
+      return i + j
+    }
+  }
+
+  var computed: Int {
+    get {
+      return 0
+    }
+    set {
+    }
+  }
+}
+
+class ClassWithComputedProperties {
+  var willSetProperty: Int = 0 {
+    willSet { }
+  } 
+
+  var didSetProperty: Int = 0 {
+    didSet { }
+  } 
+}
+
+func funcWithComputedProperties(i: Int) {
+  var computed: Int {
+    set {
+    }
+    get {
+      return 0
+    }
+  }, var (stored1, stored2) = (1, 2),
+  var alsoComputed: Int {
+    return 17
+  }
+    
+  do { }
+}
+
 // RUN: not %target-swift-frontend -dump-scope-maps expanded %s 2> %t.expanded
 // RUN: %FileCheck -check-prefix CHECK-EXPANDED %s < %t.expanded
 
@@ -200,3 +243,47 @@ enum MyEnum {
 // CHECK-EXPANDED-NEXT: {{^}}                              `-BraceStmt {{.*}} [99:36 - 99:38] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                      `-BraceStmt {{.*}} [68:37 - 71:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                        `-AfterPatternBinding {{.*}} entry 0 [69:13 - 71:3] expanded
+
+// CHECK-EXPANDED: {{^}}|-TypeOrExtensionBody {{.*}} 'StructContainsAbstractStorageDecls' [114:43 - 130:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}  |-Accessors {{.*}} scope_map.(file).StructContainsAbstractStorageDecls.subscript@{{.*}}scope_map.swift:115:3 [115:37 - 121:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}    |-AbstractFunctionParams {{.*}} _ param 0:0 [116:5 - 117:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}      `-AbstractFunctionParams {{.*}} _ param 1:0 [116:5 - 117:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}        `-AbstractFunctionParams {{.*}} _ param 1:1 [116:5 - 117:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}          `-AbstractFunctionParams {{.*}} _ param 1:2 [116:5 - 117:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}            `-BraceStmt {{.*}} [116:9 - 117:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}    `-AbstractFunctionParams {{.*}} _ param 0:0 [118:5 - 120:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}      `-AbstractFunctionParams {{.*}} _ param 1:0 [118:5 - 120:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}        `-AbstractFunctionParams {{.*}} _ param 1:1 [118:5 - 120:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}          `-BraceStmt {{.*}} [118:9 - 120:5] expanded
+
+// CHECK-EXPANDED: {{^}}  `-Accessors {{.*}} scope_map.(file).StructContainsAbstractStorageDecls.computed@{{.*}}scope_map.swift:123:7 [123:21 - 129:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}    |-AbstractFunctionParams {{.*}} _ param 0:0 [124:5 - 126:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}      `-BraceStmt {{.*}} [124:9 - 126:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}    `-AbstractFunctionParams {{.*}} _ param 0:0 [127:5 - 128:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}      `-AbstractFunctionParams {{.*}} _ param 1:0 [127:5 - 128:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}        `-BraceStmt {{.*}} [127:9 - 128:5] expanded
+
+// CHECK-EXPANDED: {{^}}|-TypeOrExtensionBody {{.*}} 'ClassWithComputedProperties' [132:35 - 140:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}  |-Accessors {{.*}} scope_map.(file).ClassWithComputedProperties.willSetProperty@{{.*}}scope_map.swift:133:7 [133:32 - 135:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}    `-AbstractFunctionParams {{.*}} _ param 0:0 [134:5 - 134:15] expanded
+// CHECK-EXPANDED-NEXT: {{^}}      `-AbstractFunctionParams {{.*}} _ param 1:0 [134:5 - 134:15] expanded
+// CHECK-EXPANDED-NEXT: {{^}}        `-BraceStmt {{.*}} [134:13 - 134:15] expanded
+// CHECK-EXPANDED-NEXT: {{^}}  `-Accessors {{.*}} scope_map.(file).ClassWithComputedProperties.didSetProperty@{{.*}}scope_map.swift:137:7 [137:31 - 139:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}    `-AbstractFunctionParams {{.*}} _ param 0:0 [138:5 - 138:14] expanded
+// CHECK-EXPANDED-NEXT: {{^}}      `-AbstractFunctionParams {{.*}} _ param 1:0 [138:5 - 138:14] expanded
+// CHECK-EXPANDED-NEXT: {{^}}        `-BraceStmt {{.*}} [138:12 - 138:14] expanded
+
+// CHECK-EXPANDED: {{^}}`-AbstractFunctionParams {{.*}} funcWithComputedProperties(i:) param 0:0 [142:36 - 155:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}  `-BraceStmt {{.*}} [142:41 - 155:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}    `-AfterPatternBinding {{.*}} entry 0 [143:17 - 155:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}      |-Accessors {{.*}} scope_map.(file).func decl.computed@{{.*}}scope_map.swift:143:7 [143:21 - 149:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}        |-AbstractFunctionParams {{.*}} _ param 0:0 [144:5 - 145:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}          `-BraceStmt {{.*}} [144:9 - 145:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}        |-BraceStmt {{.*}} [146:9 - 148:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}        `-AbstractFunctionParams {{.*}} _ param 0:0 [144:5 - 145:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}          `-BraceStmt {{.*}} [144:9 - 145:5] expanded
+// CHECK-EXPANDED-NEXT: {{^}}      `-AfterPatternBinding {{.*}} entry 1 [149:36 - 155:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}        `-AfterPatternBinding {{.*}} entry 2 [150:21 - 155:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}          `-LocalDeclaration {{.*}} [150:25 - 155:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}            |-BraceStmt {{.*}} [150:25 - 152:3] expanded
+// CHECK-EXPANDED-NEXT: {{^}}            `-BraceStmt {{.*}} [154:6 - 154:8] expanded


### PR DESCRIPTION
<!-- What's in this pull request? -->

This PR introduces a new data structure that explicitly models scopes in the AST allowing one to query the innermost scope based on a source location and then walk the enclosing scopes. The data structure itself operates on parsed ASTs (which may also be type-checked; it doesn't matter) and is lazily constructed as needed.

At the moment, there are no clients for this data structure. However, it is intended to be used for unqualified name lookup and should also be able to subsume the type refinement context.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
