### PR TITLE
tests: replace 'rm -rf ... && mkdir -p ...' with a new substitution %empty-directory

### DIFF
--- a/docs/Testing.rst
+++ b/docs/Testing.rst
@@ -368,6 +368,10 @@ Other substitutions:
 
 * ``%raw-FileCheck``: the LLVM ``FileCheck`` utility.
 
+* ``%empty-directory(`` *directory-name* ``)``: ensures that the given
+  directory exists and is empty.  Equivalent to
+  ``rm -rf directory-name && rm -rf directory-name``.
+
 When writing a test where output (or IR, SIL) depends on the bitness of the
 target CPU, use this pattern::
 

--- a/test/APINotes/irgen-prop-getter-setter.swift
+++ b/test/APINotes/irgen-prop-getter-setter.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-clang-importer-objc-overlays
 
 // RUN: %target-swift-frontend %clang-importer-sdk-nosource -I %t %s -emit-ir

--- a/test/AutolinkExtract/import.swift
+++ b/test/AutolinkExtract/import.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swiftc_driver -emit-library -emit-module -emit-module-path %t/empty.swiftmodule -module-name empty -module-link-name empty %S/empty.swift
 // RUN: %target-swiftc_driver -c %s -I %t -o %t/import_experimental.o
 // RUN: %target-swift-autolink-extract %t/import_experimental.o -o - | %FileCheck --check-prefix CHECK-%target-object-format %s

--- a/test/AutolinkExtract/import_archive.swift
+++ b/test/AutolinkExtract/import_archive.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swiftc_driver -emit-library -emit-module -emit-module-path %t/empty.swiftmodule -module-name empty -module-link-name empty %S/empty.swift
 // RUN: %target-swiftc_driver -c %s -I %t -o %t/import_experimental.o
 // RUN: llvm-ar cr %t/import_experimental.a %t/import_experimental.o

--- a/test/ClangModules/MixedSource/broken-bridging-header.swift
+++ b/test/ClangModules/MixedSource/broken-bridging-header.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: not %target-swift-frontend -parse %S/../../Inputs/empty.swift -import-objc-header %t/fake.h 2>&1 | %FileCheck -check-prefix=MISSING-HEADER %s
 
 // RUN: cp %S/Inputs/error-on-define.h %t

--- a/test/ClangModules/MixedSource/broken-modules.swift
+++ b/test/ClangModules/MixedSource/broken-modules.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: not %target-swift-frontend -parse %s -I %S/Inputs/broken-modules/ -enable-source-import -show-diagnostics-after-fatal 2> %t/err.txt
 // RUN: %FileCheck -check-prefix CHECK -check-prefix CLANG-CHECK %s < %t/err.txt
 

--- a/test/ClangModules/MixedSource/import-mixed-framework.swift
+++ b/test/ClangModules/MixedSource/import-mixed-framework.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/mixed-framework/Mixed.framework %t
 
 // Don't crash if a generated header is present but the swiftmodule is missing.

--- a/test/ClangModules/MixedSource/import-mixed-with-header-twice.swift
+++ b/test/ClangModules/MixedSource/import-mixed-with-header-twice.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp -R %S/Inputs/mixed-target %t
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/../Inputs/custom-modules -import-objc-header %t/mixed-target/header.h -emit-module-path %t/MixedWithHeader.swiftmodule %S/Inputs/mixed-with-header.swift %S/../../Inputs/empty.swift -module-name MixedWithHeader -disable-objc-attr-requires-foundation-module

--- a/test/ClangModules/MixedSource/import-mixed-with-header.swift
+++ b/test/ClangModules/MixedSource/import-mixed-with-header.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp -R %S/Inputs/mixed-target %t
 
 // FIXME: BEGIN -enable-source-import hackaround

--- a/test/ClangModules/MixedSource/resolve-cross-language.swift
+++ b/test/ClangModules/MixedSource/resolve-cross-language.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -emit-module -emit-objc-header -o %t %S/Inputs/resolve-cross-language/Base.swift -disable-objc-attr-requires-foundation-module
 // RUN: cp %S/Inputs/resolve-cross-language/Base-module.map %t/module.map

--- a/test/ClangModules/attr-swift_private.swift
+++ b/test/ClangModules/attr-swift_private.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-clang-importer-objc-overlays
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/Inputs/custom-modules -parse %s -verify

--- a/test/ClangModules/autolinking.swift
+++ b/test/ClangModules/autolinking.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -sdk %S/Inputs -I %S/Inputs/custom-modules -emit-ir -o %t/without-adapter.ll
 // RUN: %FileCheck %s < %t/without-adapter.ll
 

--- a/test/ClangModules/broken-modules.swift
+++ b/test/ClangModules/broken-modules.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: not %target-swift-frontend -parse %s -I %S/Inputs/custom-modules/ -show-diagnostics-after-fatal -D MISSING_FROM_MODULE 2> %t/err.txt
 // RUN: %FileCheck -check-prefix CHECK-MODULE-MAP %s < %t/err.txt

--- a/test/ClangModules/cstring_parse.swift
+++ b/test/ClangModules/cstring_parse.swift
@@ -1,7 +1,6 @@
 // Note: this test intentionally uses a private module cache.
 //
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse -verify -module-cache-path %t/clang-module-cache -I %S/Inputs %s
 // RUN: ls -lR %t/clang-module-cache | %FileCheck %s
 

--- a/test/ClangModules/enum-error-execute.swift
+++ b/test/ClangModules/enum-error-execute.swift
@@ -1,4 +1,4 @@
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-clang %S/Inputs/enum-error.m -c -o %t/enum-error.o
 // RUN: %target-build-swift -import-objc-header %S/Inputs/enum-error.h -Xlinker %t/enum-error.o %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s

--- a/test/ClangModules/mapped-integers.swift.gyb
+++ b/test/ClangModules/mapped-integers.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %gyb %s -o %t/mapped-integers.swift
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse -verify %t/mapped-integers.swift
 

--- a/test/ClangModules/missing-adapter.swift
+++ b/test/ClangModules/missing-adapter.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -emit-module -parse-as-library %S/Inputs/adapter.swift -sdk %S/Inputs -I %S/Inputs/custom-modules -module-name ClangModuleWithAdapter -o %t
 // RUN: %target-swift-frontend %s -sdk %S/Inputs -I %S/Inputs/custom-modules -I %t -parse

--- a/test/ClangModules/non-modular-include.swift
+++ b/test/ClangModules/non-modular-include.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: not %target-swift-frontend -parse %s -I %S/Inputs/non-modular -F %S/Inputs/non-modular 2>&1 | %FileCheck %s
 
 // CHECK: {{.+}}/non-modular/Foo.framework/Headers/Foo.h:1:9: error: include of non-modular header inside framework module 'Foo'

--- a/test/ClangModules/nullability_silgen.swift
+++ b/test/ClangModules/nullability_silgen.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-clang-importer-objc-overlays
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-silgen -I %S/Inputs/custom-modules %s | %FileCheck %s

--- a/test/ClangModules/objc_bridging_custom.swift
+++ b/test/ClangModules/objc_bridging_custom.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -I %S/../Inputs/ObjCBridging %S/../Inputs/ObjCBridging/Appliances.swift -module-name Appliances -o %t
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse -I %S/../Inputs/ObjCBridging -I %t -parse-as-library -verify %s

--- a/test/ClangModules/objc_factory_method.swift
+++ b/test/ClangModules/objc_factory_method.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-clang-importer-objc-overlays
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -target x86_64-apple-macosx10.51 -parse %s -verify

--- a/test/ClangModules/objc_ir.swift
+++ b/test/ClangModules/objc_ir.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-clang-importer-objc-overlays
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/Inputs/custom-modules -emit-ir -o - -primary-file %s | %FileCheck %s
 

--- a/test/ClangModules/objc_subscript.swift
+++ b/test/ClangModules/objc_subscript.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-clang-importer-objc-overlays
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -I %S/Inputs/custom-modules %s -verify

--- a/test/ClangModules/serialization-search-paths.swift
+++ b/test/ClangModules/serialization-search-paths.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module-path %t/SerializationHelper.swiftmodule -I %S/Inputs/custom-modules -F %S/Inputs/frameworks -sdk "" -disable-objc-attr-requires-foundation-module %S/Inputs/SerializationHelper.swift
 // RUN: %target-swift-frontend -parse -I %t %s -sdk "" -verify
 

--- a/test/ClangModules/serialization-sil.swift
+++ b/test/ClangModules/serialization-sil.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module-path %t/Test.swiftmodule -emit-sil -o /dev/null -module-name Test %s -sdk "" -import-objc-header %S/Inputs/serialization-sil.h
 // RUN: %target-sil-extract %t/Test.swiftmodule -func=_TF4Test16testPartialApplyFPSo4Test_T_ -o - | %FileCheck %s
 

--- a/test/ClangModules/serialization.swift
+++ b/test/ClangModules/serialization.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module-path %t/SerializationHelper.swiftmodule -I %S/Inputs/custom-modules %S/Inputs/SerializationHelper.swift -sdk "" -disable-objc-attr-requires-foundation-module
 // RUN: %target-swift-frontend -parse -sdk "" -I %t -I %S/Inputs/custom-modules %s -verify
 

--- a/test/ClangModules/static_inline.swift
+++ b/test/ClangModules/static_inline.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // Check if SIL printing+parsing of a clang imported function works.
 

--- a/test/ClangModules/submodules.swift
+++ b/test/ClangModules/submodules.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse -verify %s -DIMPORT_TOP_LEVEL
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse -verify %s

--- a/test/ClangModules/submodules_indirect.swift
+++ b/test/ClangModules/submodules_indirect.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse -verify -I %S/Inputs/custom-modules/ %s
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -o %t -emit-module -I %S/Inputs/custom-modules/ %s -module-name submodules
 // RUN: echo 'import submodules; let s = "\(x), \(y)"' | %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse - -I %t -I %S/Inputs/custom-modules/

--- a/test/ClangModules/submodules_scoped.swift
+++ b/test/ClangModules/submodules_scoped.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse -verify %s -DCHECK_SCOPING
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s -module-name submodules
 // RUN: echo 'import submodules; let s = "\(x), \(y)"' | %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse - -I %t

--- a/test/Constraints/diag_ambiguities_module.swift
+++ b/test/Constraints/diag_ambiguities_module.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/has_ambiguities.swift
 // RUN: not %target-swift-frontend -parse %s -I %t 2>&1 | %FileCheck %s
 

--- a/test/Constraints/dynamic_lookup.swift
+++ b/test/Constraints/dynamic_lookup.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module %S/Inputs/PrivateObjC.swift -o %t
 // RUN: %target-parse-verify-swift -I %t
 

--- a/test/DebugInfo/ASTSection.swift
+++ b/test/DebugInfo/ASTSection.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift -emit-executable %s -g -o %t/ASTSection -emit-module
 // RUN: %lldb-moduleimport-test %t/ASTSection | %FileCheck %s

--- a/test/DebugInfo/ASTSection_ObjC.swift
+++ b/test/DebugInfo/ASTSection_ObjC.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: cp %S/Inputs/serialized-objc-header.h %t
 // RUN: %target-build-swift -emit-executable %S/ASTSection.swift -g -o %t/ASTSection-with-ObjC -import-objc-header %t/serialized-objc-header.h -DOBJC -module-name ASTSection -emit-module

--- a/test/DebugInfo/ASTSection_linker.swift
+++ b/test/DebugInfo/ASTSection_linker.swift
@@ -1,7 +1,6 @@
 // Run test ASTSection.swift, with separate compile and link steps.
 
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -c -sdk /fake/sdk/path -Xcc -DA -Xcc -DB -emit-module -o %t %S/ASTSection.swift
 // RUN: %swift-ide-test -test-CompilerInvocation-from-module -source-filename=%t/ASTSection.swiftmodule

--- a/test/DebugInfo/ImportClangSubmodule.swift
+++ b/test/DebugInfo/ImportClangSubmodule.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // REQUIRES: OS=macosx
 
 // RUN: %target-swift-frontend -emit-ir %s -g -o - | %FileCheck %s

--- a/test/DebugInfo/Imports.swift
+++ b/test/DebugInfo/Imports.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module-path %t/basic.swiftmodule %S/basic.swift
 
 // RUN: %target-swift-frontend -emit-ir -module-name Foo %s -I %t -g -o - | %FileCheck %s

--- a/test/DebugInfo/external-global.swift
+++ b/test/DebugInfo/external-global.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module-path %t/Globals.swiftmodule %S/Globals.swift
 // RUN: %target-swift-frontend -I %t %s -g -emit-ir -o - | %FileCheck %s
 import Globals

--- a/test/DebugInfo/gsil.swift
+++ b/test/DebugInfo/gsil.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -O -gsil -emit-ir -o %t/out.ir
 // RUN: %FileCheck %s < %t/out.ir
 // RUN: %FileCheck %s --check-prefix=CHECK_OUT_SIL < %t/out.ir.gsil_0.sil

--- a/test/DebugInfo/inlinescopes.swift
+++ b/test/DebugInfo/inlinescopes.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: echo "public var x = Int64()" \
 // RUN:   | %target-swift-frontend -module-name FooBar -emit-module -o %t -
 // RUN: %target-swift-frontend %s -O -I %t -emit-ir -g -o %t.ll

--- a/test/DebugInfo/modulecache.swift
+++ b/test/DebugInfo/modulecache.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // Clang-import a module.
 import ClangModule
 
@@ -13,7 +13,7 @@ import ClangModule
 
 // 2. Test that swift is creating clang modules with debug info.
 
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -c -g -o %t.o -module-cache-path %t -I %S/Inputs
 // RUN: file %t/*/ClangModule-*.pcm | egrep '(Mach-O|ELF)'
 

--- a/test/Demangle/lookup.swift
+++ b/test/Demangle/lookup.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: not %target-swift-ide-test -source-filename=%s -print-ast-typechecked -find-mangled=_notASwiftSymbol
 

--- a/test/Driver/actions.swift
+++ b/test/Driver/actions.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // XFAIL: freebsd, linux
 

--- a/test/Driver/bindings.swift
+++ b/test/Driver/bindings.swift
@@ -1,4 +1,4 @@
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %swiftc_driver -driver-print-bindings -target x86_64-apple-macosx10.9 %s 2>&1 | %FileCheck %s -check-prefix=BASIC
 // BASIC: # "x86_64-apple-macosx10.9" - "swift", inputs: ["{{.*}}bindings.swift"], output: {object: "[[OBJECT:.*\.o]]"}

--- a/test/Driver/driver-compile.swift
+++ b/test/Driver/driver-compile.swift
@@ -37,7 +37,8 @@
 
 // RUN: %swiftc_driver -driver-print-jobs -c -target x86_64-apple-macosx10.9 %s %S/../Inputs/empty.swift -module-name main -driver-use-filelists 2>&1 | %FileCheck -check-prefix=FILELIST %s
 
-// RUN: %empty-directory(%t)/DISTINCTIVE-PATH/usr/bin/
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/DISTINCTIVE-PATH/usr/bin)
 // RUN: ln %swift_driver_plain %t/DISTINCTIVE-PATH/usr/bin/swiftc
 // RUN: ln -s "swiftc" %t/DISTINCTIVE-PATH/usr/bin/swift-update
 // RUN: %t/DISTINCTIVE-PATH/usr/bin/swiftc -driver-print-jobs -update-code -c -target x86_64-apple-macosx10.9 -emit-module -emit-module-path %t.mod %s 2>&1 > %t.upd.txt

--- a/test/Driver/driver-compile.swift
+++ b/test/Driver/driver-compile.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s 2>&1 > %t.simple.txt
 // RUN: %FileCheck %s < %t.simple.txt
@@ -37,7 +37,7 @@
 
 // RUN: %swiftc_driver -driver-print-jobs -c -target x86_64-apple-macosx10.9 %s %S/../Inputs/empty.swift -module-name main -driver-use-filelists 2>&1 | %FileCheck -check-prefix=FILELIST %s
 
-// RUN: rm -rf %t && mkdir -p %t/DISTINCTIVE-PATH/usr/bin/
+// RUN: %empty-directory(%t)/DISTINCTIVE-PATH/usr/bin/
 // RUN: ln %swift_driver_plain %t/DISTINCTIVE-PATH/usr/bin/swiftc
 // RUN: ln -s "swiftc" %t/DISTINCTIVE-PATH/usr/bin/swift-update
 // RUN: %t/DISTINCTIVE-PATH/usr/bin/swiftc -driver-print-jobs -update-code -c -target x86_64-apple-macosx10.9 -emit-module -emit-module-path %t.mod %s 2>&1 > %t.upd.txt

--- a/test/Driver/emit-module-from-sib.swift
+++ b/test/Driver/emit-module-from-sib.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %target-swiftc_driver -emit-module -module-name test %s -o %t/a.swiftmodule
 // RUN: %target-swiftc_driver -emit-sib -module-name test %s -o - | %target-swiftc_driver -emit-module -module-name test -o %t/b.swiftmodule -

--- a/test/Driver/emit-objc-header.swift
+++ b/test/Driver/emit-objc-header.swift
@@ -1,6 +1,5 @@
 // FIXME: BEGIN -enable-source-import hackaround
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
 // FIXME: END -enable-source-import hackaround
 

--- a/test/Driver/filelists.swift
+++ b/test/Driver/filelists.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: touch %t/a.swift %t/b.swift %t/c.swift
 
 // RUN: (cd %t && %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -emit-module ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-use-filelists -output-file-map=%S/Inputs/filelists/output.json 2>&1 | %FileCheck %s)

--- a/test/Driver/filelists.swift
+++ b/test/Driver/filelists.swift
@@ -18,12 +18,12 @@
 // CHECK-WMO-NOT: Handled
 
 
-// RUN: mkdir -p %t/bin
+// RUN: %empty-directory(%t/bin)
 // RUN: ln -s %S/Inputs/filelists/fake-ld.py %t/bin/ld
 
 // RUN: (cd %t && %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -c ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-use-filelists -output-file-map=%S/Inputs/filelists/output.json -force-single-frontend-invocation -num-threads 1 2>&1 | %FileCheck -check-prefix=CHECK-WMO-THREADED %s)
 // RUN: (cd %t && %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -c ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-use-filelists -output-file-map=%S/Inputs/filelists/output.json -force-single-frontend-invocation -num-threads 1 -embed-bitcode 2>&1 | %FileCheck -check-prefix=CHECK-WMO-THREADED %s)
-// RUN: mkdir -p %t/tmp/
+// RUN: %empty-directory(%t/tmp)
 // RUN: (cd %t && env TMPDIR="%t/tmp/" %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -c ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-use-filelists -output-file-map=%S/Inputs/filelists/output.json -force-single-frontend-invocation -num-threads 1 -save-temps 2>&1 | %FileCheck -check-prefix=CHECK-WMO-THREADED %s)
 // RUN: ls %t/tmp/sources-* %t/tmp/outputs-*
 

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -275,7 +275,7 @@
 // the Swift driver really thinks it's been moved.
 
 // RUN: rm -rf %t
-// RUN: mkdir -p %t/DISTINCTIVE-PATH/usr/bin/
+// RUN: %empty-directory(%t/DISTINCTIVE-PATH/usr/bin)
 // RUN: touch %t/DISTINCTIVE-PATH/usr/bin/ld
 // RUN: chmod +x %t/DISTINCTIVE-PATH/usr/bin/ld
 // RUN: ln %swift_driver_plain %t/DISTINCTIVE-PATH/usr/bin/swiftc
@@ -288,8 +288,8 @@
 // Also test arclite detection. This uses xcrun to find arclite when it's not
 // next to Swift.
 
-// RUN: mkdir -p %t/ANOTHER-DISTINCTIVE-PATH/usr/bin
-// RUN: mkdir -p %t/ANOTHER-DISTINCTIVE-PATH/usr/lib/arc
+// RUN: %empty-directory(%t/ANOTHER-DISTINCTIVE-PATH/usr/bin)
+// RUN: %empty-directory(%t/ANOTHER-DISTINCTIVE-PATH/usr/lib/arc)
 // RUN: cp %S/Inputs/xcrun-return-self.sh %t/ANOTHER-DISTINCTIVE-PATH/usr/bin/xcrun
 
 // RUN: env PATH=%t/ANOTHER-DISTINCTIVE-PATH/usr/bin %t/DISTINCTIVE-PATH/usr/bin/swiftc -target x86_64-apple-macosx10.9 %s -### | %FileCheck -check-prefix=XCRUN_ARCLITE %s
@@ -298,7 +298,7 @@
 // XCRUN_ARCLITE: /ANOTHER-DISTINCTIVE-PATH/usr/lib/arc/libarclite_macosx.a
 // XCRUN_ARCLITE: -o {{[^ ]+}}
 
-// RUN: mkdir -p %t/DISTINCTIVE-PATH/usr/lib/arc
+// RUN: %empty-directory(%t/DISTINCTIVE-PATH/usr/lib/arc)
 
 // RUN: env PATH=%t/ANOTHER-DISTINCTIVE-PATH/usr/bin %t/DISTINCTIVE-PATH/usr/bin/swiftc -target x86_64-apple-macosx10.9 %s -### | %FileCheck -check-prefix=RELATIVE_ARCLITE %s
 

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -48,7 +48,7 @@
 // RUN: %swiftc_driver -driver-print-jobs -target arm64-apple-tvos9.0        %s | %FileCheck -check-prefix NO_ARCLITE %s
 // RUN: %swiftc_driver -driver-print-jobs -target armv7k-apple-watchos2.0    %s | %FileCheck -check-prefix NO_ARCLITE %s
 
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: touch %t/a.o
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s %t/a.o -o linker 2>&1 | %FileCheck -check-prefix COMPILE_AND_LINK %s
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s %t/a.o -driver-use-filelists -o linker 2>&1 | %FileCheck -check-prefix FILELIST %s

--- a/test/Driver/multi-threaded.swift
+++ b/test/Driver/multi-threaded.swift
@@ -1,6 +1,6 @@
 // REQUIRES: rdar23493035
 
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swiftc_driver -driver-print-jobs -module-name=ThisModule -wmo -num-threads 4 %S/Inputs/main.swift %s -emit-module -o test.swiftmodule | %FileCheck -check-prefix=MODULE %s
 // RUN: echo "{\"%s\": {\"assembly\": \"/build/multi-threaded.s\"}, \"%S/Inputs/main.swift\": {\"assembly\": \"/build/main.s\"}}" > %t/ofms.json
 // RUN: %target-swiftc_driver -driver-print-jobs -module-name=ThisModule -wmo -num-threads 4 %S/Inputs/main.swift %s -output-file-map %t/ofms.json -S | %FileCheck -check-prefix=ASSEMBLY %s

--- a/test/Driver/options-repl-darwin.swift
+++ b/test/Driver/options-repl-darwin.swift
@@ -7,15 +7,15 @@
 // RUN: %swift_driver -repl -### | %FileCheck -check-prefix=INTEGRATED %s
 // RUN: %swift_driver -### | %FileCheck -check-prefix=INTEGRATED %s
 
-// RUN: rm -rf %t
-// RUN: mkdir -p %t/usr/bin/
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/usr/bin)
 // RUN: touch %t/usr/bin/lldb
 // RUN: chmod +x %t/usr/bin/lldb
 // RUN: ln %swift_driver_plain %t/usr/bin/swift
 // RUN: %t/usr/bin/swift -repl -### | %FileCheck -check-prefix=LLDB %s
 // RUN: %t/usr/bin/swift -### | %FileCheck -check-prefix=LLDB %s
 
-// RUN: mkdir -p %t/Toolchains/Test.xctoolchain/usr/bin/
+// RUN: %empty-directory(%t/Toolchains/Test.xctoolchain/usr/bin)
 // RUN: mv %t/usr/bin/swift %t/Toolchains/Test.xctoolchain/usr/bin/swift
 // RUN: %t/Toolchains/Test.xctoolchain/usr/bin/swift -repl -### | %FileCheck -check-prefix=LLDB %s
 

--- a/test/Driver/options-repl.swift
+++ b/test/Driver/options-repl.swift
@@ -41,8 +41,8 @@
 // RUN: %swift_driver -repl -### | %FileCheck -check-prefix=INTEGRATED %s
 // RUN: %swift_driver -### | %FileCheck -check-prefix=INTEGRATED %s
 
-// RUN: rm -rf %t
-// RUN: mkdir -p %t/usr/bin/
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/usr/bin)
 // RUN: touch %t/usr/bin/lldb
 // RUN: chmod +x %t/usr/bin/lldb
 // RUN: ln %swift_driver_plain %t/usr/bin/swift

--- a/test/Driver/output.swift
+++ b/test/Driver/output.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/sub
 // RUN: cd %t
 

--- a/test/Driver/output.swift
+++ b/test/Driver/output.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: mkdir -p %t/sub
+// RUN: %empty-directory(%t/sub)
 // RUN: cd %t
 
 // RUN: %target-swift-frontend -emit-bc %s

--- a/test/Driver/sdk-apple.swift
+++ b/test/Driver/sdk-apple.swift
@@ -1,7 +1,7 @@
 // XFAIL: freebsd, linux
 
 // Test SDK detection for immediate mode.
-// RUN: rm -rf %t && mkdir -p %t/usr/bin/
+// RUN: %empty-directory(%t)/usr/bin/
 
 // RUN: cp %S/Inputs/xcrun-bad.sh %t/usr/bin/xcrun
 // RUN: env PATH=%t/usr/bin %swift_driver_plain -deprecated-integrated-repl -### | %FileCheck -check-prefix=NOSDK %s
@@ -21,7 +21,7 @@
 
 // ROOT-SDK: -sdk /{{ |$}}
 
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/MacOSX10.8.sdk && not %swift_driver -sdk %t/MacOSX10.8.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
 // RUN: mkdir -p %t/MacOSX10.9.sdk && not %swift_driver -sdk %t/MacOSX10.9.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
 // RUN: mkdir -p %t/MacOSX10.9.Internal.sdk && not %swift_driver -sdk %t/MacOSX10.9.Internal.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s

--- a/test/Driver/sdk-apple.swift
+++ b/test/Driver/sdk-apple.swift
@@ -1,7 +1,8 @@
 // XFAIL: freebsd, linux
 
 // Test SDK detection for immediate mode.
-// RUN: %empty-directory(%t)/usr/bin/
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/usr/bin)
 
 // RUN: cp %S/Inputs/xcrun-bad.sh %t/usr/bin/xcrun
 // RUN: env PATH=%t/usr/bin %swift_driver_plain -deprecated-integrated-repl -### | %FileCheck -check-prefix=NOSDK %s
@@ -22,15 +23,15 @@
 // ROOT-SDK: -sdk /{{ |$}}
 
 // RUN: %empty-directory(%t)
-// RUN: mkdir -p %t/MacOSX10.8.sdk && not %swift_driver -sdk %t/MacOSX10.8.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: mkdir -p %t/MacOSX10.9.sdk && not %swift_driver -sdk %t/MacOSX10.9.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: mkdir -p %t/MacOSX10.9.Internal.sdk && not %swift_driver -sdk %t/MacOSX10.9.Internal.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: mkdir -p %t/MacOSX10.10.sdk && not %swift_driver -sdk %t/MacOSX10.10.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: mkdir -p %t/MacOSX10.10.Internal.sdk && not %swift_driver -sdk %t/MacOSX10.10.Internal.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: mkdir -p %t/MacOSX10.11.sdk && not %swift_driver -sdk %t/MacOSX10.11.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: mkdir -p %t/MacOSX10.11.Internal.sdk && not %swift_driver -sdk %t/MacOSX10.11.Internal.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: mkdir -p %t/MacOSX10.12.sdk && %swift_driver -sdk %t/MacOSX10.12.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
-// RUN: mkdir -p %t/OSX12.sdk && %swift_driver -sdk %t/OSX12.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
+// RUN: %empty-directory(%t/MacOSX10.8.sdk) && not %swift_driver -sdk %t/MacOSX10.8.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
+// RUN: %empty-directory(%t/MacOSX10.9.sdk) && not %swift_driver -sdk %t/MacOSX10.9.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
+// RUN: %empty-directory(%t/MacOSX10.9.Internal.sdk) && not %swift_driver -sdk %t/MacOSX10.9.Internal.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
+// RUN: %empty-directory(%t/MacOSX10.10.sdk) && not %swift_driver -sdk %t/MacOSX10.10.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
+// RUN: %empty-directory(%t/MacOSX10.10.Internal.sdk) && not %swift_driver -sdk %t/MacOSX10.10.Internal.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
+// RUN: %empty-directory(%t/MacOSX10.11.sdk) && not %swift_driver -sdk %t/MacOSX10.11.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
+// RUN: %empty-directory(%t/MacOSX10.11.Internal.sdk) && not %swift_driver -sdk %t/MacOSX10.11.Internal.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
+// RUN: %empty-directory(%t/MacOSX10.12.sdk) && %swift_driver -sdk %t/MacOSX10.12.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
+// RUN: %empty-directory(%t/OSX12.sdk) && %swift_driver -sdk %t/OSX12.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
 
 // RUN: not %swift_driver -sdk %t/MacOSX10.9.sdk/ -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
 // RUN: not %swift_driver -sdk %t/MacOSX10.9.Internal.sdk/ -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
@@ -41,33 +42,33 @@
 // RUN: %swift_driver -sdk %t/MacOSX10.12.sdk/ -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
 // RUN: %swift_driver -sdk %t/MacOSX10.12.Internal.sdk/ -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
 
-// RUN: mkdir -p %t/iPhoneOS7.0.sdk && not %swift_driver -sdk %t/iPhoneOS7.0.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: mkdir -p %t/iPhoneOS7.0.Internal.sdk && not %swift_driver -sdk %t/iPhoneOS7.0.Internal.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: mkdir -p %t/iPhoneOS8.0.sdk && not %swift_driver -sdk %t/iPhoneOS8.0.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: mkdir -p %t/iPhoneOS8.0.Internal.sdk && not %swift_driver -sdk %t/iPhoneOS8.0.Internal.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: mkdir -p %t/iPhoneOS9.0.sdk && not %swift_driver -sdk %t/iPhoneOS9.0.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: mkdir -p %t/iPhoneOS10.0.sdk && %swift_driver -sdk %t/iPhoneOS10.0.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
+// RUN: %empty-directory(%t/iPhoneOS7.0.sdk) && not %swift_driver -sdk %t/iPhoneOS7.0.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
+// RUN: %empty-directory(%t/iPhoneOS7.0.Internal.sdk) && not %swift_driver -sdk %t/iPhoneOS7.0.Internal.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
+// RUN: %empty-directory(%t/iPhoneOS8.0.sdk) && not %swift_driver -sdk %t/iPhoneOS8.0.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
+// RUN: %empty-directory(%t/iPhoneOS8.0.Internal.sdk) && not %swift_driver -sdk %t/iPhoneOS8.0.Internal.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
+// RUN: %empty-directory(%t/iPhoneOS9.0.sdk) && not %swift_driver -sdk %t/iPhoneOS9.0.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
+// RUN: %empty-directory(%t/iPhoneOS10.0.sdk) && %swift_driver -sdk %t/iPhoneOS10.0.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
 
-// RUN: mkdir -p %t/tvOS8.0.sdk && not %swift_driver -sdk %t/tvOS8.0.sdk -target x86_64-apple-tvos9 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: mkdir -p %t/tvOS8.0.Internal.sdk && not %swift_driver -sdk %t/tvOS8.0.Internal.sdk -target x86_64-apple-tvos9 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: mkdir -p %t/tvOS9.0.sdk && not %swift_driver -sdk %t/tvOS9.0.sdk -target x86_64-apple-tvos9 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: mkdir -p %t/tvOS10.0.sdk && %swift_driver -sdk %t/tvOS10.0.sdk -target x86_64-apple-tvos9 -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
+// RUN: %empty-directory(%t/tvOS8.0.sdk) && not %swift_driver -sdk %t/tvOS8.0.sdk -target x86_64-apple-tvos9 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
+// RUN: %empty-directory(%t/tvOS8.0.Internal.sdk) && not %swift_driver -sdk %t/tvOS8.0.Internal.sdk -target x86_64-apple-tvos9 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
+// RUN: %empty-directory(%t/tvOS9.0.sdk) && not %swift_driver -sdk %t/tvOS9.0.sdk -target x86_64-apple-tvos9 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
+// RUN: %empty-directory(%t/tvOS10.0.sdk) && %swift_driver -sdk %t/tvOS10.0.sdk -target x86_64-apple-tvos9 -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
 
-// RUN: mkdir -p %t/watchOS1.0.sdk && not %swift_driver -sdk %t/watchOS1.0.sdk -target x86_64-apple-watchos2 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: mkdir -p %t/watchOS1.0.Internal.sdk && not %swift_driver -sdk %t/watchOS1.0.Internal.sdk -target x86_64-apple-watchos2 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: mkdir -p %t/watchOS2.0.sdk && not %swift_driver -sdk %t/watchOS2.0.sdk -target x86_64-apple-watchos2 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: mkdir -p %t/watchOS3.0.sdk && %swift_driver -sdk %t/watchOS3.0.sdk -target x86_64-apple-watchos2 -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
+// RUN: %empty-directory(%t/watchOS1.0.sdk) && not %swift_driver -sdk %t/watchOS1.0.sdk -target x86_64-apple-watchos2 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
+// RUN: %empty-directory(%t/watchOS1.0.Internal.sdk) && not %swift_driver -sdk %t/watchOS1.0.Internal.sdk -target x86_64-apple-watchos2 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
+// RUN: %empty-directory(%t/watchOS2.0.sdk) && not %swift_driver -sdk %t/watchOS2.0.sdk -target x86_64-apple-watchos2 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
+// RUN: %empty-directory(%t/watchOS3.0.sdk) && %swift_driver -sdk %t/watchOS3.0.sdk -target x86_64-apple-watchos2 -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
 
-// RUN: mkdir -p %t/iPhoneSimulator7.0.sdk && not %swift_driver -sdk %t/iPhoneSimulator7.0.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: mkdir -p %t/iPhoneSimulator8.0.sdk && not %swift_driver -sdk %t/iPhoneSimulator8.0.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: mkdir -p %t/AppleTVSimulator8.0.sdk && not %swift_driver -sdk %t/AppleTVSimulator8.0.sdk -target x86_64-apple-tvos9 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: mkdir -p %t/WatchSimulator1.0.sdk && not %swift_driver -sdk %t/WatchSimulator1.0.sdk -target i386-apple-watchos2 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
+// RUN: %empty-directory(%t/iPhoneSimulator7.0.sdk) && not %swift_driver -sdk %t/iPhoneSimulator7.0.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
+// RUN: %empty-directory(%t/iPhoneSimulator8.0.sdk) && not %swift_driver -sdk %t/iPhoneSimulator8.0.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
+// RUN: %empty-directory(%t/AppleTVSimulator8.0.sdk) && not %swift_driver -sdk %t/AppleTVSimulator8.0.sdk -target x86_64-apple-tvos9 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
+// RUN: %empty-directory(%t/WatchSimulator1.0.sdk) && not %swift_driver -sdk %t/WatchSimulator1.0.sdk -target i386-apple-watchos2 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
 
-// RUN: mkdir -p %t/iPhoneOS.sdk && %swift_driver -sdk %t/iPhoneOS.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
-// RUN: mkdir -p %t/tvOS.sdk && %swift_driver -sdk %t/tvOS.sdk -target x86_64-apple-tvos9 -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
-// RUN: mkdir -p %t/watchOS.sdk && %swift_driver -sdk %t/watchOS.sdk -target x86_64-apple-watchos2 -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
+// RUN: %empty-directory(%t/iPhoneOS.sdk) && %swift_driver -sdk %t/iPhoneOS.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
+// RUN: %empty-directory(%t/tvOS.sdk) && %swift_driver -sdk %t/tvOS.sdk -target x86_64-apple-tvos9 -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
+// RUN: %empty-directory(%t/watchOS.sdk) && %swift_driver -sdk %t/watchOS.sdk -target x86_64-apple-watchos2 -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
 
-// RUN: mkdir -p %t/custom-sdk && %swift_driver -sdk %t/custom-sdk -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
+// RUN: %empty-directory(%t/custom-sdk) && %swift_driver -sdk %t/custom-sdk -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
 
 // SDK-TOO-OLD: error: Swift does not support the SDK '{{.+}}.sdk'{{$}}
 // SDK-OKAY: -sdk {{.*}}/{{[^/ ]+}}sdk

--- a/test/Driver/sdk-link.swift
+++ b/test/Driver/sdk-link.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t/test.swiftmodule %s
 // RUN: %target-build-swift -g -o %t/sdk-link %s
 // RUN: %target-run %t/sdk-link | %FileCheck %s

--- a/test/Driver/static-stdlib-linux.swift
+++ b/test/Driver/static-stdlib-linux.swift
@@ -2,7 +2,7 @@
 // REQUIRES: OS=linux-gnu
 // REQUIRES: static_stdlib
 print("hello world!")
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swiftc_driver -static-stdlib -o %t/static-stdlib %s
 // RUN: %t/static-stdlib | %FileCheck %s
 // RUN: ldd %t/static-stdlib | %FileCheck %s --check-prefix=LDD

--- a/test/Driver/static-stdlib.swift
+++ b/test/Driver/static-stdlib.swift
@@ -2,7 +2,7 @@
 // XFAIL: linux
 // REQUIRES: static_stdlib
 print("hello world!")
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -static-stdlib -o %t/static-stdlib %s
 // RUN: %target-run %t/static-stdlib | %FileCheck %s
 // RUN: otool -L %t/static-stdlib | %FileCheck %s --check-prefix=OTOOL

--- a/test/Driver/subcommands.swift
+++ b/test/Driver/subcommands.swift
@@ -13,8 +13,8 @@
 // (for shebang line use). We have to run these since we can't get the driver to
 // dump what it is doing and test the argv[1] processing.
 //
-// RUN: rm -rf %t.dir
-// RUN: mkdir -p %t.dir/subpath
+// RUN: %empty-directory(%t.dir)
+// RUN: %empty-directory(%t.dir/subpath)
 // RUN: echo "print(\"exec: \" + #file)" > %t.dir/stdin
 // RUN: echo "print(\"exec: \" + #file)" > %t.dir/t.swift
 // RUN: echo "print(\"exec: \" + #file)" > %t.dir/subpath/build
@@ -28,8 +28,7 @@
 
 // Check that 'swift foo' invokes 'swift-foo'.
 //
-// RUN: rm -rf %t.dir
-// RUN: mkdir -p %t.dir
+// RUN: %empty-directory(%t.dir)
 // RUN: echo "#!/bin/sh" > %t.dir/swift-foo
 // RUN: echo "echo \"exec: \$0\"" >> %t.dir/swift-foo
 // RUN: chmod +x %t.dir/swift-foo

--- a/test/Driver/temp-files.swift
+++ b/test/Driver/temp-files.swift
@@ -1,25 +1,25 @@
 // REQUIRES: objc_interop
 // FIXME: actually, this test requires Mach-O.
 
-// RUN: rm -rf %t && mkdir -p %t/tmp/ && touch %t/tmp/dummy
+// RUN: %empty-directory(%t)/tmp/ && touch %t/tmp/dummy
 // RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -emit-executable %s -o %t/main
 // RUN: ls %t/main
 // RUN: ls %t/tmp | %FileCheck -check-prefix=EMPTY %s
 
 // EMPTY-NOT: .{{(o|swiftmodule|swiftdoc)}}
 
-// RUN: rm -rf %t && mkdir -p %t/tmp/ && touch %t/tmp/dummy
+// RUN: %empty-directory(%t)/tmp/ && touch %t/tmp/dummy
 // RUN: env TMPDIR=%t/tmp/ %swiftc_driver -target %target-triple -sdk %sdk -module-cache-path %t -emit-executable %s -o %t/main2 -emit-module-path %t/main2.swiftmodule
 // RUN: ls %t/main2
 // RUN: ls %t/main2.swiftmodule
 // RUN: ls %t/tmp | %FileCheck -check-prefix=EMPTY %s
 
-// RUN: rm -rf %t && mkdir -p %t/tmp/ && touch %t/tmp/dummy
+// RUN: %empty-directory(%t)/tmp/ && touch %t/tmp/dummy
 // RUN: env TMPDIR=%t/tmp/ %swiftc_driver -target %target-triple -sdk %sdk -module-cache-path %t -emit-executable %s -o %t/main3 -g
 // RUN: ls %t/main3
 // RUN: ls %t/tmp | %FileCheck -check-prefix=EMPTY %s
 
-// RUN: rm -rf %t && mkdir -p %t/tmp/ && touch %t/tmp/dummy
+// RUN: %empty-directory(%t)/tmp/ && touch %t/tmp/dummy
 // RUN: env TMPDIR=%t/tmp/ %swiftc_driver -target %target-triple -sdk %sdk -module-cache-path %t -emit-executable %s -o %t/main4 -emit-module-path %t/main4.swiftmodule -g
 // RUN: ls %t/main4
 // RUN: ls %t/main4.swiftmodule
@@ -29,7 +29,7 @@
 // MAIN4-macho: main4.dSYM
 // MAIN4-elf-NOT: .dSYM
 
-// RUN: rm -rf %t && mkdir -p %t/tmp/ && touch %t/tmp/dummy
+// RUN: %empty-directory(%t)/tmp/ && touch %t/tmp/dummy
 // RUN: echo "{\"%s\": {\"object\": \"%t/main5.o\"}}" > %t.json
 // RUN: env TMPDIR=%t/tmp/ %swiftc_driver -target %target-triple -sdk %sdk -module-cache-path %t -emit-executable %s -o %t/main5 -output-file-map %t.json -g
 // RUN: ls %t/main5
@@ -40,7 +40,7 @@
 // MAIN5-macho: main5.dSYM
 // MAIN5-elf-NOT: .dSYM
 
-// RUN: rm -rf %t && mkdir -p %t/tmp/ && touch %t/tmp/dummy
+// RUN: %empty-directory(%t)/tmp/ && touch %t/tmp/dummy
 // RUN: env TMPDIR=%t/tmp/ %swiftc_driver -target %target-triple -sdk %sdk -module-cache-path %t -emit-executable %s -o %t/main6 -g -save-temps
 // RUN: ls %t/main6
 // RUN: ls %t | %FileCheck -check-prefix=MAIN6-%target-object-format %s

--- a/test/Driver/temp-files.swift
+++ b/test/Driver/temp-files.swift
@@ -1,25 +1,27 @@
 // REQUIRES: objc_interop
 // FIXME: actually, this test requires Mach-O.
 
-// RUN: %empty-directory(%t)/tmp/ && touch %t/tmp/dummy
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/tmp)
+// RUN: touch %t/tmp/dummy
 // RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -emit-executable %s -o %t/main
 // RUN: ls %t/main
 // RUN: ls %t/tmp | %FileCheck -check-prefix=EMPTY %s
 
 // EMPTY-NOT: .{{(o|swiftmodule|swiftdoc)}}
 
-// RUN: %empty-directory(%t)/tmp/ && touch %t/tmp/dummy
+// RUN: %empty-directory(%t) && %empty-directory(%t/tmp) && touch %t/tmp/dummy
 // RUN: env TMPDIR=%t/tmp/ %swiftc_driver -target %target-triple -sdk %sdk -module-cache-path %t -emit-executable %s -o %t/main2 -emit-module-path %t/main2.swiftmodule
 // RUN: ls %t/main2
 // RUN: ls %t/main2.swiftmodule
 // RUN: ls %t/tmp | %FileCheck -check-prefix=EMPTY %s
 
-// RUN: %empty-directory(%t)/tmp/ && touch %t/tmp/dummy
+// RUN: %empty-directory(%t) && %empty-directory(%t/tmp) && touch %t/tmp/dummy
 // RUN: env TMPDIR=%t/tmp/ %swiftc_driver -target %target-triple -sdk %sdk -module-cache-path %t -emit-executable %s -o %t/main3 -g
 // RUN: ls %t/main3
 // RUN: ls %t/tmp | %FileCheck -check-prefix=EMPTY %s
 
-// RUN: %empty-directory(%t)/tmp/ && touch %t/tmp/dummy
+// RUN: %empty-directory(%t) && %empty-directory(%t/tmp) && touch %t/tmp/dummy
 // RUN: env TMPDIR=%t/tmp/ %swiftc_driver -target %target-triple -sdk %sdk -module-cache-path %t -emit-executable %s -o %t/main4 -emit-module-path %t/main4.swiftmodule -g
 // RUN: ls %t/main4
 // RUN: ls %t/main4.swiftmodule
@@ -29,7 +31,7 @@
 // MAIN4-macho: main4.dSYM
 // MAIN4-elf-NOT: .dSYM
 
-// RUN: %empty-directory(%t)/tmp/ && touch %t/tmp/dummy
+// RUN: %empty-directory(%t) && %empty-directory(%t/tmp) && touch %t/tmp/dummy
 // RUN: echo "{\"%s\": {\"object\": \"%t/main5.o\"}}" > %t.json
 // RUN: env TMPDIR=%t/tmp/ %swiftc_driver -target %target-triple -sdk %sdk -module-cache-path %t -emit-executable %s -o %t/main5 -output-file-map %t.json -g
 // RUN: ls %t/main5
@@ -40,7 +42,7 @@
 // MAIN5-macho: main5.dSYM
 // MAIN5-elf-NOT: .dSYM
 
-// RUN: %empty-directory(%t)/tmp/ && touch %t/tmp/dummy
+// RUN: %empty-directory(%t) && %empty-directory(%t/tmp) && touch %t/tmp/dummy
 // RUN: env TMPDIR=%t/tmp/ %swiftc_driver -target %target-triple -sdk %sdk -module-cache-path %t -emit-executable %s -o %t/main6 -g -save-temps
 // RUN: ls %t/main6
 // RUN: ls %t | %FileCheck -check-prefix=MAIN6-%target-object-format %s

--- a/test/Driver/unknown-inputs.swift
+++ b/test/Driver/unknown-inputs.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: touch %t/empty
 // RUN: touch %t/empty.swiftmodule
 // RUN: touch %t/empty.o

--- a/test/FixCode/multi-inputs.swift
+++ b/test/FixCode/multi-inputs.swift
@@ -1,4 +1,4 @@
-// RUN: mkdir -p %t.out
+// RUN: %empty-directory(%t.out)
 // RUN: echo "{\"%S/Inputs/t1.swift\": {\"remap\": \"%t.out/t1.remap\"}, \"%S/Inputs/t2.swift\": {\"remap\": \"%t.out/t2.remap\"}}" > %t.json
 // RUN: not %swiftc_driver -target %target-triple -module-name Blah -fixit-code %S/Inputs/t1.swift %S/Inputs/t2.swift -emit-module -emit-module-path %t.mod -emit-objc-header -emit-objc-header-path %t.h -j 1 -output-file-map %t.json 2> %t.err.txt
 // RUN: c-arcmt-test %t.out/t1.remap %t.out/t2.remap | arcmt-test -verify-transformed-files %S/Inputs/t1.swift.result %S/Inputs/t2.swift.result

--- a/test/Frontend/dependencies.swift
+++ b/test/Frontend/dependencies.swift
@@ -1,6 +1,6 @@
 // XFAIL: linux
 
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -emit-dependencies-path - -parse %S/../Inputs/empty\ file.swift | %FileCheck -check-prefix=CHECK-BASIC %s
 // RUN: %target-swift-frontend -emit-reference-dependencies-path - -parse -primary-file %S/../Inputs/empty\ file.swift | %FileCheck -check-prefix=CHECK-BASIC-YAML %s

--- a/test/Frontend/filelist.swift
+++ b/test/Frontend/filelist.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: echo '%S/Inputs/filelist-other.swift' >> %t/input.txt
 // RUN: echo '%s' >> %t/input.txt
 // RUN: echo '%S/../Inputs/empty.swift' >> %t/input.txt

--- a/test/Frontend/sil-primary-file-with-sib.swift
+++ b/test/Frontend/sil-primary-file-with-sib.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift -emit-sib %s -module-name test -o %t/test.sib
 // RUN: %target-build-swift -Xfrontend -disable-llvm-optzns -emit-ir %s -module-name test -o %t/test-orig.ll

--- a/test/IDE/compatibility_alias.swift
+++ b/test/IDE/compatibility_alias.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-clang-importer-objc-overlays
 
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk-nosource) -I %t -I %S/Inputs/custom-modules -print-module -source-filename %s -module-to-print=CompatibilityAlias > %t.printed.CompatibilityAlias.txt

--- a/test/IDE/complete_dynamic_lookup.swift
+++ b/test/IDE/complete_dynamic_lookup.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -disable-objc-attr-requires-foundation-module -o %t %S/Inputs/AnyObject/foo_swift_module.swift
 // RUN: %target-swift-frontend -emit-module -disable-objc-attr-requires-foundation-module -o %t %S/Inputs/AnyObject/bar_swift_module.swift
 // RUN: cp %S/Inputs/AnyObject/baz_clang_module.h %t

--- a/test/IDE/complete_from_reexport.swift
+++ b/test/IDE/complete_from_reexport.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: %target-swift-frontend -emit-module -module-name FooSwiftModule %S/Inputs/foo_swift_module.swift -o %t
 // RUN: %target-swift-frontend -emit-module -module-name FooSwiftModuleOverlay %S/Inputs/foo_swift_module_overlay.swift -I %t -o %t

--- a/test/IDE/complete_from_swift_module.swift
+++ b/test/IDE/complete_from_swift_module.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/foo_swift_module.swift
 //

--- a/test/IDE/complete_testable.swift
+++ b/test/IDE/complete_testable.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -enable-testing -o %t %S/Inputs/complete_testable_helper.swift
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TOP_LEVEL -I %t > %t.txt

--- a/test/IDE/local_types.swift
+++ b/test/IDE/local_types.swift
@@ -1,6 +1,6 @@
 // Tests lookup and mangling of local types
 
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swiftc_driver -v -emit-module -module-name LocalTypes -o %t/LocalTypes.swiftmodule %s
 // RUN: %target-swift-ide-test -print-local-types -I %t -module-to-print LocalTypes -source-filename %s | %FileCheck %s
 

--- a/test/IDE/merge_local_types.swift
+++ b/test/IDE/merge_local_types.swift
@@ -1,6 +1,6 @@
 // Tests merging of modules each with their own local types
 
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // Create separate modules and merge them together
 // RUN: %target-swiftc_driver -v -emit-module -module-name LocalTypesMerged -o %t/LocalTypesMerged.swiftmodule %s %S/local_types.swift

--- a/test/IDE/module_api_smoketest.swift
+++ b/test/IDE/module_api_smoketest.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %swift-ide-test -generate-module-api-description -- -target %target-triple -module-cache-path %t %s | %FileCheck %s
 
 public struct Struct1 {}

--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-clang-importer-objc-overlays
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk-nosource) -I %t -I %S/Inputs/custom-modules -enable-swift-newtype -print-module -source-filename %s -module-to-print=Newtype > %t.printed.A.txt
 // RUN: %FileCheck %s -check-prefix=PRINT -strict-whitespace < %t.printed.A.txt

--- a/test/IDE/newtype_objc.swift
+++ b/test/IDE/newtype_objc.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-clang-importer-objc-overlays
 
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk-nosource) -I %t -I %S/Inputs/custom-modules -print-module -source-filename %s -module-to-print=NewtypeObjC -enable-swift-newtype > %t.printed.NewtypeObjC.txt

--- a/test/IDE/print_ast_overlay.swift
+++ b/test/IDE/print_ast_overlay.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -emit-module -module-name Foo -o %t -F %S/Inputs/mock-sdk %s
 //
 // RUN: %target-swift-ide-test -print-module -source-filename %s -I %t -F %S/Inputs/mock-sdk -module-to-print=Foo -accessibility-filter-public > %t.printed.txt

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // Build swift modules this test depends on.
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/foo_swift_module.swift

--- a/test/IDE/print_clang_ObjectiveC.swift
+++ b/test/IDE/print_clang_ObjectiveC.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %target-swift-ide-test -print-module -source-filename %s -module-to-print=ObjectiveC.NSObject -function-definitions=false > %t/ObjectiveC.NSObject.printed.txt
 // RUN: %FileCheck -input-file %t/ObjectiveC.NSObject.printed.txt %s

--- a/test/IDE/print_clang_bool_bridging.swift
+++ b/test/IDE/print_clang_bool_bridging.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %target-swift-ide-test -print-module -source-filename %s -module-to-print=BoolBridgingTests -function-definitions=false -print-regular-comments -F %S/Inputs/mock-sdk > %t.txt
 // RUN: diff -u <(tail +9 %s) %t.txt

--- a/test/IDE/print_clang_decls.swift
+++ b/test/IDE/print_clang_decls.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // XFAIL: linux
 

--- a/test/IDE/print_clang_decls_AppKit.swift
+++ b/test/IDE/print_clang_decls_AppKit.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // This file deliberately does not use %clang-importer-sdk for most RUN lines.
 // Instead, it generates custom overlay modules itself, and uses -I %t when it

--- a/test/IDE/print_clang_foundation.swift
+++ b/test/IDE/print_clang_foundation.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %target-swift-ide-test -print-module -source-filename %s -module-to-print=Foundation.NSArray -function-definitions=false > %t/Foundation.NSArray.printed.txt
 // RUN: %FileCheck -input-file %t/Foundation.NSArray.printed.txt -check-prefix=CHECK_NSARRAY %s

--- a/test/IDE/print_clang_framework.swift
+++ b/test/IDE/print_clang_framework.swift
@@ -1,8 +1,7 @@
 // TODO: Properties with unowned or weak ownership should not be bridged.
 // XFAIL: *
 
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %target-swift-ide-test(mock-sdk: -F %S/Inputs/mock-sdk) -print-module -source-filename %s -module-to-print=Foo -function-definitions=false -print-regular-comments > %t/Foo.printed.txt
 // RUN: diff -u %S/Inputs/mock-sdk/Foo.printed.txt %t/Foo.printed.txt

--- a/test/IDE/print_clang_framework_with_overlay.swift
+++ b/test/IDE/print_clang_framework_with_overlay.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend(mock-sdk: -F %S/Inputs/mock-sdk) -I %t -emit-module -o %t/FooOverlay.swiftmodule %S/Inputs/FooOverlay.swift
 // RUN: %target-swift-ide-test(mock-sdk: -F %S/Inputs/mock-sdk) -I %t -print-module -source-filename %s -module-to-print=FooOverlay -function-definitions=false | %FileCheck %s

--- a/test/IDE/print_clang_swift_name.swift
+++ b/test/IDE/print_clang_swift_name.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -source-filename %s -module-to-print=SwiftNameTests -function-definitions=false -print-regular-comments -F %S/Inputs/mock-sdk > %t.txt
 // RUN: diff -u <(tail +9 %s) %t.txt

--- a/test/IDE/print_module_comments.swift
+++ b/test/IDE/print_module_comments.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // Build swift modules this test depends on.
 // RUN: %target-swift-frontend -emit-module %S/Inputs/foo_swift_module.swift -emit-module-path %t/foo_swift_module.swiftmodule -emit-module-doc-path %t/foo_swift_module.swiftdoc

--- a/test/IDE/print_module_without_deinit.swift
+++ b/test/IDE/print_module_without_deinit.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -skip-deinit=true -module-to-print=print_module_without_deinit -I %t -source-filename=%s | %FileCheck -check-prefix=SKIP1 %s
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -skip-deinit=false -module-to-print=print_module_without_deinit -I %t -source-filename=%s | %FileCheck -check-prefix=NOSKIP1 %s

--- a/test/IDE/print_omit_needless_words.swift
+++ b/test/IDE/print_omit_needless_words.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // REQUIRES: objc_interop
 // FIXME: this is failing on simulators

--- a/test/IDE/print_omit_needless_words_appkit.swift
+++ b/test/IDE/print_omit_needless_words_appkit.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx

--- a/test/IDE/print_swift_module.swift
+++ b/test/IDE/print_swift_module.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module-path %t/print_swift_module.swiftmodule -emit-module-doc -emit-module-doc-path %t/print_swift_module.swiftdoc %s
 // RUN: %target-swift-ide-test -print-module -print-interface -no-empty-line-between-members -module-to-print=print_swift_module -I %t -source-filename=%s > %t.syn.txt
 // RUN: %FileCheck %s -check-prefix=CHECK1 < %t.syn.txt

--- a/test/IDE/print_synthesized_extensions.swift
+++ b/test/IDE/print_synthesized_extensions.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module-path %t/print_synthesized_extensions.swiftmodule -emit-module-doc -emit-module-doc-path %t/print_synthesized_extensions.swiftdoc %s
 // RUN: %target-swift-ide-test -print-module -annotate-print -synthesize-extension -print-interface -no-empty-line-between-members -module-to-print=print_synthesized_extensions -I %t -source-filename=%s > %t.syn.txt
 // RUN: %FileCheck %s -check-prefix=CHECK1 < %t.syn.txt

--- a/test/IDE/sdk_sugar.swift
+++ b/test/IDE/sdk_sugar.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-ide-test -print-module -module-print-submodules -module-to-print=Foundation -function-definitions=false -source-filename %s > %t/out 2>&1
 // RUN: %FileCheck -input-file=%t/out %s
 

--- a/test/IRGen/autolink-coff-force-link.swift
+++ b/test/IRGen/autolink-coff-force-link.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %swift -target i686--windows-msvc -parse-as-library -parse-stdlib -module-name autolink -module-link-name autolink -autolink-force-load -emit-ir -o - %s | %FileCheck %s
 // RUN: %swift -target i686--windows-itanium -parse-as-library -parse-stdlib -module-name autolink -module-link-name autolink -autolink-force-load -S -o - %s | %FileCheck %s -check-prefix CHECK-ASM-GNU

--- a/test/IRGen/autolink-coff.swift
+++ b/test/IRGen/autolink-coff.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %swift -target thumbv7--windows-gnu -parse-as-library -parse-stdlib -emit-module-path %t/module.swiftmodule -module-name module -module-link-name module %s
 // RUN: %swift -target thumbv7--windows-gnu -parse-as-library -parse-stdlib -module-name autolink -I %t -D MAIN_MODULE -emit-ir -o - %s | %FileCheck %s -check-prefix CHECK-GNU-IR

--- a/test/IRGen/autolink-psei.swift
+++ b/test/IRGen/autolink-psei.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %swift -target x86_64-scei-ps4 -parse-as-library -parse-stdlib -emit-module-path %t/module.swiftmodule -module-name module -module-link-name module %s
 // RUN: %swift -target x86_64-scei-ps4 -parse-as-library -parse-stdlib -module-name autolink -I %t -D MAIN_MODULE -emit-ir -o - %s | %FileCheck %s -check-prefix CHECK-IR
 

--- a/test/IRGen/autolink_elf.swift
+++ b/test/IRGen/autolink_elf.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %swift -target x86_64-unknown-linux-gnu -emit-module -parse-stdlib -o %t -module-name Empty -module-link-name swiftEmpty %S/../Inputs/empty.swift
 // RUN: %swift -target x86_64-unknown-linux-gnu %s -I %t -parse-stdlib -disable-objc-interop -module-name main -emit-ir -o - | %FileCheck %s
 

--- a/test/IRGen/c_functions.swift
+++ b/test/IRGen/c_functions.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -import-objc-header %S/Inputs/c_functions.h -primary-file %s -emit-ir | %FileCheck %s
 
 // This is deliberately not a SIL test so that we can test SILGen too.

--- a/test/IRGen/clang_inline.swift
+++ b/test/IRGen/clang_inline.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -sdk %S/Inputs -primary-file %s -emit-ir | %FileCheck %s
 
-// RUN: mkdir -p %t/Empty.framework/Modules/Empty.swiftmodule
+// RUN: %empty-directory(%t/Empty.framework/Modules/Empty.swiftmodule)
 // RUN: %target-swift-frontend -emit-module-path %t/Empty.framework/Modules/Empty.swiftmodule/%target-swiftmodule-name %S/../Inputs/empty.swift -module-name Empty
 // RUN: %target-swift-frontend -sdk %S/Inputs -primary-file %s -F %t -DIMPORT_EMPTY -emit-ir > %t.ll
 // RUN: %FileCheck %s < %t.ll

--- a/test/IRGen/clang_inline.swift
+++ b/test/IRGen/clang_inline.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -sdk %S/Inputs -primary-file %s -emit-ir | %FileCheck %s
 
 // RUN: mkdir -p %t/Empty.framework/Modules/Empty.swiftmodule

--- a/test/IRGen/class_isa_pointers.sil
+++ b/test/IRGen/class_isa_pointers.sil
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | %FileCheck %s
 

--- a/test/IRGen/class_isa_pointers_armv7k_watchos.sil
+++ b/test/IRGen/class_isa_pointers_armv7k_watchos.sil
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | %FileCheck %s
 

--- a/test/IRGen/class_with_stub_initializers.swift
+++ b/test/IRGen/class_with_stub_initializers.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | %FileCheck %s
 

--- a/test/IRGen/empty_objc_ivar.swift
+++ b/test/IRGen/empty_objc_ivar.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-ir -verify %s
 

--- a/test/IRGen/enum_derived.swift
+++ b/test/IRGen/enum_derived.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -module-name def_enum -o %t %S/Inputs/def_enum.swift
 // RUN: %target-swift-frontend -I %t -O -primary-file %s -emit-ir | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-NORMAL %s
 // RUN: %target-swift-frontend -I %t -O -primary-file %s -enable-testing -emit-ir | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-TESTABLE %s

--- a/test/IRGen/enum_spare_bits.sil
+++ b/test/IRGen/enum_spare_bits.sil
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize %s
 

--- a/test/IRGen/existentials_objc.sil
+++ b/test/IRGen/existentials_objc.sil
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend -sdk %S/Inputs -I %t %s -emit-ir | %FileCheck %s
 

--- a/test/IRGen/foreign_class_extension.swift
+++ b/test/IRGen/foreign_class_extension.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | %FileCheck %s
 

--- a/test/IRGen/generic_casts.swift
+++ b/test/IRGen/generic_casts.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s
 

--- a/test/IRGen/generic_classes_objc.sil
+++ b/test/IRGen/generic_classes_objc.sil
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | %FileCheck %s
 

--- a/test/IRGen/linker_options_objc.swift
+++ b/test/IRGen/linker_options_objc.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swiftc_driver -emit-module -o %t -module-name Empty -module-link-name swiftEmpty %S/../Inputs/empty.swift
 // RUN: %target-swiftc_driver %s -I %t -emit-ir | %FileCheck %s
 

--- a/test/IRGen/local_types.swift
+++ b/test/IRGen/local_types.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module %S/Inputs/local_types_helper.swift -o %t
 // RUN: %target-swift-frontend -emit-ir -parse-as-library %s -I %t > %t.ll
 // RUN: %FileCheck %s < %t.ll

--- a/test/IRGen/meta_meta_type.swift
+++ b/test/IRGen/meta_meta_type.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck -check-prefix=CHECKIR %s

--- a/test/IRGen/metatype.sil
+++ b/test/IRGen/metatype.sil
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend -sdk %S/Inputs -I %t -emit-ir %s | %FileCheck %s
 

--- a/test/IRGen/module_hash.swift
+++ b/test/IRGen/module_hash.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 
 // Test with a single output file

--- a/test/IRGen/multithread_module.swift
+++ b/test/IRGen/multithread_module.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend %S/Inputs/multithread_module/main.swift -emit-ir -o %t/main.ll %s -o %t/mt_module.ll -num-threads 2 -O -g -module-name test
 // RUN: %FileCheck --check-prefix=CHECK-MAINLL %s <%t/main.ll

--- a/test/IRGen/newtype.swift
+++ b/test/IRGen/newtype.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t -I %S/../IDE/Inputs/custom-modules) %s -emit-ir -enable-swift-newtype | %FileCheck %s
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t -I %S/../IDE/Inputs/custom-modules) %s -emit-ir -enable-swift-newtype -O | %FileCheck %s -check-prefix=OPT

--- a/test/IRGen/objc.swift
+++ b/test/IRGen/objc.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s
 

--- a/test/IRGen/objc_attr_NSManaged.sil
+++ b/test/IRGen/objc_attr_NSManaged.sil
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | %FileCheck %s
 

--- a/test/IRGen/objc_bridge.swift
+++ b/test/IRGen/objc_bridge.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-ir -primary-file %s | %FileCheck %s
 

--- a/test/IRGen/objc_casts.sil
+++ b/test/IRGen/objc_casts.sil
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize %s
 

--- a/test/IRGen/objc_class_export.swift
+++ b/test/IRGen/objc_class_export.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend -sdk %S/Inputs -I %t -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s
 

--- a/test/IRGen/objc_dealloc.sil
+++ b/test/IRGen/objc_dealloc.sil
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | %FileCheck %s
 

--- a/test/IRGen/objc_enum_multi_file.swift
+++ b/test/IRGen/objc_enum_multi_file.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -module-name main -primary-file %s %S/Inputs/objc_enum_multi_file_helper.swift -emit-ir | %FileCheck %s
 
 // RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -emit-module %S/Inputs/objc_enum_multi_file_helper.swift -o %t

--- a/test/IRGen/objc_errors.sil
+++ b/test/IRGen/objc_errors.sil
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | %FileCheck %s
 

--- a/test/IRGen/objc_extensions.swift
+++ b/test/IRGen/objc_extensions.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -disable-objc-attr-requires-foundation-module -emit-module %S/Inputs/objc_extension_base.swift -o %t
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir | %FileCheck %s

--- a/test/IRGen/objc_implicit_with.sil
+++ b/test/IRGen/objc_implicit_with.sil
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | %FileCheck %s
 

--- a/test/IRGen/objc_local.swift
+++ b/test/IRGen/objc_local.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | %FileCheck %s
 

--- a/test/IRGen/objc_methods.swift
+++ b/test/IRGen/objc_methods.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-os %s
 

--- a/test/IRGen/objc_ns_enum.swift
+++ b/test/IRGen/objc_ns_enum.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir | %FileCheck %s
 

--- a/test/IRGen/objc_pointers.swift
+++ b/test/IRGen/objc_pointers.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir | %FileCheck %s
 

--- a/test/IRGen/objc_property_attrs.swift
+++ b/test/IRGen/objc_property_attrs.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | %FileCheck %s
 

--- a/test/IRGen/objc_protocol_conversion.sil
+++ b/test/IRGen/objc_protocol_conversion.sil
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend -sdk %S/Inputs -I %t %s -emit-ir | %FileCheck %s
 

--- a/test/IRGen/objc_protocol_extended_method_types.swift
+++ b/test/IRGen/objc_protocol_extended_method_types.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | %FileCheck %s
 

--- a/test/IRGen/objc_protocols.swift
+++ b/test/IRGen/objc_protocols.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -o %t %S/Inputs/objc_protocols_Bas.swift
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s

--- a/test/IRGen/objc_protocols_jit.swift
+++ b/test/IRGen/objc_protocols_jit.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/objc_protocols_Bas.swift
 // RUN: %target-swift-frontend -sdk %S/Inputs -I %t -primary-file %s -use-jit -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s

--- a/test/IRGen/objc_structs.swift
+++ b/test/IRGen/objc_structs.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir | %FileCheck %s
 

--- a/test/IRGen/objc_subclass.swift
+++ b/test/IRGen/objc_subclass.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize %s
 

--- a/test/IRGen/objc_super.swift
+++ b/test/IRGen/objc_super.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | %FileCheck %s
 

--- a/test/IRGen/objc_type_encoding.swift
+++ b/test/IRGen/objc_type_encoding.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s -check-prefix=CHECK-%target-os
 

--- a/test/IRGen/optional_metatype.sil
+++ b/test/IRGen/optional_metatype.sil
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend -sdk %S/Inputs -I %t -emit-ir %s | %FileCheck %s --check-prefix=%target-cpu
 

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 

--- a/test/IRGen/protocol_conformance_records_objc.swift
+++ b/test/IRGen/protocol_conformance_records_objc.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -o %t %S/Inputs/objc_protocols_Bas.swift
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir | %FileCheck %s

--- a/test/IRGen/rdar15304329.swift
+++ b/test/IRGen/rdar15304329.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | %FileCheck %s
 

--- a/test/IRGen/report_dead_method_call.swift
+++ b/test/IRGen/report_dead_method_call.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // We compile with -O (optimizations) and -disable-access-control (which
 // allows use to "call" methods that are removed by dead code elimination).

--- a/test/IRGen/sil_witness_tables.swift
+++ b/test/IRGen/sil_witness_tables.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/sil_witness_tables_external_conformance.swift
 // RUN: %target-swift-frontend -I %t -primary-file %s -emit-ir | %FileCheck %s
 

--- a/test/IRGen/sil_witness_tables_external_witnesstable.swift
+++ b/test/IRGen/sil_witness_tables_external_witnesstable.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module %S/Inputs/sil_witness_tables_external_input.swift -o %t/Swift.swiftmodule -parse-stdlib -parse-as-library -module-name Swift -sil-serialize-all -module-link-name swiftCore
 // RUN: %target-swift-frontend -I %t -primary-file %s -emit-ir | %FileCheck %s
 

--- a/test/IRGen/super.sil
+++ b/test/IRGen/super.sil
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -enable-resilience -I %t -module-name resilient_struct -o %t %S/../Inputs/resilient_struct.swift
 // RUN: %target-swift-frontend -emit-module -enable-resilience -I %t -module-name resilient_class -o %t %S/../Inputs/resilient_class.swift
 // RUN: %target-swift-frontend -enable-resilience -parse-sil -parse-as-library -emit-ir -I %t %s | %FileCheck %s

--- a/test/IRGen/weak_import.swift
+++ b/test/IRGen/weak_import.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 //
 // Specify explicit target triples for the deployment target to test weak

--- a/test/InterfaceHash/added_function.swift
+++ b/test/InterfaceHash/added_function.swift
@@ -1,4 +1,4 @@
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash

--- a/test/InterfaceHash/added_method.swift
+++ b/test/InterfaceHash/added_method.swift
@@ -1,4 +1,4 @@
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash

--- a/test/InterfaceHash/added_private_class_private_property.swift
+++ b/test/InterfaceHash/added_private_class_private_property.swift
@@ -1,4 +1,4 @@
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash

--- a/test/InterfaceHash/added_private_class_property.swift
+++ b/test/InterfaceHash/added_private_class_property.swift
@@ -1,4 +1,4 @@
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash

--- a/test/InterfaceHash/added_private_enum_private_property.swift
+++ b/test/InterfaceHash/added_private_enum_private_property.swift
@@ -1,4 +1,4 @@
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash

--- a/test/InterfaceHash/added_private_enum_property.swift
+++ b/test/InterfaceHash/added_private_enum_property.swift
@@ -1,4 +1,4 @@
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash

--- a/test/InterfaceHash/added_private_method.swift
+++ b/test/InterfaceHash/added_private_method.swift
@@ -1,4 +1,4 @@
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash

--- a/test/InterfaceHash/added_private_method_value_types.swift
+++ b/test/InterfaceHash/added_private_method_value_types.swift
@@ -1,4 +1,4 @@
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash

--- a/test/InterfaceHash/added_private_protocol_method.swift
+++ b/test/InterfaceHash/added_private_protocol_method.swift
@@ -1,4 +1,4 @@
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash

--- a/test/InterfaceHash/added_private_protocol_property.swift
+++ b/test/InterfaceHash/added_private_protocol_property.swift
@@ -1,4 +1,4 @@
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash

--- a/test/InterfaceHash/added_private_struct_private_property.swift
+++ b/test/InterfaceHash/added_private_struct_private_property.swift
@@ -1,4 +1,4 @@
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash

--- a/test/InterfaceHash/added_private_struct_property.swift
+++ b/test/InterfaceHash/added_private_struct_property.swift
@@ -1,4 +1,4 @@
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash

--- a/test/InterfaceHash/changed_private_var_type.swift
+++ b/test/InterfaceHash/changed_private_var_type.swift
@@ -1,4 +1,4 @@
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash

--- a/test/InterfaceHash/changed_var_name.swift
+++ b/test/InterfaceHash/changed_var_name.swift
@@ -1,4 +1,4 @@
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash

--- a/test/InterfaceHash/changed_var_type.swift
+++ b/test/InterfaceHash/changed_var_type.swift
@@ -1,4 +1,4 @@
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash

--- a/test/InterfaceHash/edited_function_body.swift
+++ b/test/InterfaceHash/edited_function_body.swift
@@ -1,4 +1,4 @@
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash

--- a/test/InterfaceHash/edited_method_body.swift
+++ b/test/InterfaceHash/edited_method_body.swift
@@ -1,4 +1,4 @@
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash

--- a/test/InterfaceHash/edited_property_getter.swift
+++ b/test/InterfaceHash/edited_property_getter.swift
@@ -1,4 +1,4 @@
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash

--- a/test/Interpreter/SDK/Foundation_NSLog.swift
+++ b/test/Interpreter/SDK/Foundation_NSLog.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: echo 'void testNSLog();' > %t/NSLogIsWorking.h
 // RUN: echo '@import Foundation; void testNSLog() { NSLog(@"working"); }' | %target-clang -fobjc-arc -fmodules -x objective-c - -c -o %t/NSLogIsWorking.o

--- a/test/Interpreter/SDK/Foundation_bridge.swift
+++ b/test/Interpreter/SDK/Foundation_bridge.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t  &&  mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -import-objc-header %S/Inputs/Foundation_bridge.h -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test

--- a/test/Interpreter/SDK/OS_objects.swift
+++ b/test/Interpreter/SDK/OS_objects.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift %t/main.swift -I %S/Inputs/custom-modules/ -o %t/OS_objects -Xfrontend -disable-access-control

--- a/test/Interpreter/SDK/UIApplicationMain.swift
+++ b/test/Interpreter/SDK/UIApplicationMain.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/main -parse-as-library
 
 // We aren't yet able to run tests that require a UI context, so just try

--- a/test/Interpreter/SDK/autolinking.swift
+++ b/test/Interpreter/SDK/autolinking.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: echo "int global() { return 42; }" | %clang -dynamiclib -o %t/libLinkMe.dylib -x c -
 // RUN: %target-swift-frontend -emit-module -parse-stdlib -o %t -module-name LinkMe -module-link-name LinkMe %S/../../Inputs/empty.swift
 

--- a/test/Interpreter/SDK/c_pointers.swift
+++ b/test/Interpreter/SDK/c_pointers.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test

--- a/test/Interpreter/SDK/class_as_object.swift
+++ b/test/Interpreter/SDK/class_as_object.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t  &&  mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test

--- a/test/Interpreter/SDK/errors.swift
+++ b/test/Interpreter/SDK/errors.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -import-objc-header %S/Inputs/errors.h -o %t/main
 // RUN: %target-run %t/main
 

--- a/test/Interpreter/SDK/libc.swift
+++ b/test/Interpreter/SDK/libc.swift
@@ -1,7 +1,7 @@
 /* magic */
 // Do not edit the line above.
 
-// RUN: rm -rf %t  &&  mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-run-simple-swift %s %t | %FileCheck %s
 // rdar://26960623
 // REQUIRES: disabled

--- a/test/Interpreter/SDK/missing_imports_repl.swift
+++ b/test/Interpreter/SDK/missing_imports_repl.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: touch %t/Corrupted_Module.swiftmodule
 // RUN: not %target-repl-run-simple-swift -I %t 2> %t/stderr.txt | %FileCheck %s
 // RUN: %FileCheck -check-prefix CHECK-ERROR %s < %t/stderr.txt

--- a/test/Interpreter/SDK/multi-file-imported-enum.swift
+++ b/test/Interpreter/SDK/multi-file-imported-enum.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -module-name test -whole-module-optimization %s %S/Inputs/multi-file-imported-enum/main.swift -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test

--- a/test/Interpreter/SDK/objc_bridge.swift
+++ b/test/Interpreter/SDK/objc_bridge.swift
@@ -1,7 +1,7 @@
 // Test Objective-C bridging for a non-Foundation type that is
 // otherwise unknown to the compiler.
 
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // Build the Appliances module
 // RUN: %target-clang -fobjc-arc -I %S/../../Inputs/ObjCBridging %S/../../Inputs/ObjCBridging/Appliances.m -c -o %t/AppliancesObjC.o

--- a/test/Interpreter/SDK/objc_factory_method.swift
+++ b/test/Interpreter/SDK/objc_factory_method.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t  &&  mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -module-name FactoryTest %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test

--- a/test/Interpreter/SDK/objc_mangling.swift
+++ b/test/Interpreter/SDK/objc_mangling.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t  &&  mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -module-name MangleTest %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test

--- a/test/Interpreter/SDK/object_literals.swift
+++ b/test/Interpreter/SDK/object_literals.swift
@@ -1,4 +1,5 @@
-// RUN: %empty-directory(%t)/Test.app/Contents/MacOS
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/Test.app/Contents/MacOS)
 // RUN: cp -r %S/Inputs/object_literals-Resources %t/Test.app/Contents/Resources
 // RUN: %target-build-swift %s -o %t/Test.app/Contents/MacOS/main
 // RUN: %target-run %t/Test.app/Contents/MacOS/main

--- a/test/Interpreter/SDK/object_literals.swift
+++ b/test/Interpreter/SDK/object_literals.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t/Test.app/Contents/MacOS
+// RUN: %empty-directory(%t)/Test.app/Contents/MacOS
 // RUN: cp -r %S/Inputs/object_literals-Resources %t/Test.app/Contents/Resources
 // RUN: %target-build-swift %s -o %t/Test.app/Contents/MacOS/main
 // RUN: %target-run %t/Test.app/Contents/MacOS/main

--- a/test/Interpreter/SDK/weak_objc_interop.swift
+++ b/test/Interpreter/SDK/weak_objc_interop.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: cp %s %t/main.swift
 // RUN: %target-clang -fobjc-arc %S/Inputs/ObjCWeak/ObjCWeak.m -c -o %t/ObjCWeak.o

--- a/test/Interpreter/availability_weak_linking.swift
+++ b/test/Interpreter/availability_weak_linking.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp -R %S/Inputs/FakeUnavailableObjCFramework.framework %t
 // RUN: %target-clang -dynamiclib %S/Inputs/FakeUnavailableObjCFramework.m -fmodules -F %t -framework Foundation -o %t/FakeUnavailableObjCFramework.framework/FakeUnavailableObjCFramework
 

--- a/test/Interpreter/builtin.swift
+++ b/test/Interpreter/builtin.swift
@@ -1,4 +1,4 @@
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -parse-stdlib -Xfrontend -disable-access-control -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test

--- a/test/Interpreter/builtin_bridge_object.swift
+++ b/test/Interpreter/builtin_bridge_object.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t  &&  mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -parse-stdlib %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test

--- a/test/Interpreter/c_bitfields.swift
+++ b/test/Interpreter/c_bitfields.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t  &&  mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -I %S/../Inputs/clang-importer-sdk/platform/any/usr/include %s -o %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test

--- a/test/Interpreter/c_unions.swift
+++ b/test/Interpreter/c_unions.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t  &&  mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -I %S/../Inputs/clang-importer-sdk/platform/any/usr/include %s -o %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test

--- a/test/Interpreter/class_resilience.swift
+++ b/test/Interpreter/class_resilience.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift -emit-library -Xfrontend -enable-resilience -c %S/../Inputs/resilient_struct.swift -o %t/resilient_struct.o
 // RUN: %target-build-swift -emit-module -Xfrontend -enable-resilience -c %S/../Inputs/resilient_struct.swift -o %t/resilient_struct.o

--- a/test/Interpreter/collection_casts.swift
+++ b/test/Interpreter/collection_casts.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/main
 // RUN: %target-build-swift %s -o %t/main-optimized
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/Interpreter/enum.swift
+++ b/test/Interpreter/enum.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t  &&  mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test

--- a/test/Interpreter/enum_resilience.swift
+++ b/test/Interpreter/enum_resilience.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift -emit-library -Xfrontend -enable-resilience -c %S/../Inputs/resilient_struct.swift -o %t/resilient_struct.o
 // RUN: %target-build-swift -emit-module -Xfrontend -enable-resilience -c %S/../Inputs/resilient_struct.swift -o %t/resilient_struct.o

--- a/test/Interpreter/errors_imported.swift
+++ b/test/Interpreter/errors_imported.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: %target-clang -fobjc-arc %S/Inputs/ObjCClasses/ObjCClasses.m -c -o %t/ObjCClasses.o
 // RUN: %target-build-swift -I %S/Inputs/ObjCClasses/ %t/ObjCClasses.o %s -o %t/a.out

--- a/test/Interpreter/fractal.swift
+++ b/test/Interpreter/fractal.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t  &&  mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-jit-run %s -I %S -enable-source-import | %FileCheck %s
 // REQUIRES: executable_test
 

--- a/test/Interpreter/generic_class.swift
+++ b/test/Interpreter/generic_class.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t  &&  mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test

--- a/test/Interpreter/generic_class_empty_field.swift
+++ b/test/Interpreter/generic_class_empty_field.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t  &&  mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test

--- a/test/Interpreter/generic_objc_subclass.swift
+++ b/test/Interpreter/generic_objc_subclass.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: %target-clang -fobjc-arc %S/Inputs/ObjCClasses/ObjCClasses.m -c -o %t/ObjCClasses.o
 // RUN: %target-build-swift -I %S/Inputs/ObjCClasses/ -Xlinker %t/ObjCClasses.o %s -o %t/a.out

--- a/test/Interpreter/generic_struct.swift
+++ b/test/Interpreter/generic_struct.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t  &&  mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test

--- a/test/Interpreter/global_resilience.swift
+++ b/test/Interpreter/global_resilience.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -emit-library -I %t -Xfrontend -enable-resilience -c %S/../Inputs/resilient_global.swift -o %t/resilient_global.o
 // RUN: %target-build-swift -emit-module -I %t -Xfrontend -enable-resilience -c %S/../Inputs/resilient_global.swift -o %t/resilient_global.o
 // RUN: %target-build-swift -emit-library -I %t -Xfrontend -enable-resilience -c %S/../Inputs/resilient_struct.swift -o %t/resilient_struct.o

--- a/test/Interpreter/import_as_member.swift
+++ b/test/Interpreter/import_as_member.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %clang -isysroot %sdk %S/Inputs/ImportAsMember/IAMVec.c -c -o %t/IAMVec.o
 // RUN: %target-build-swift -I %S/Inputs/ImportAsMember/ -Xlinker %t/IAMVec.o %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s

--- a/test/Interpreter/imported_objc_generics.swift
+++ b/test/Interpreter/imported_objc_generics.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: %target-clang -fobjc-arc %S/Inputs/ObjCClasses/ObjCClasses.m -c -o %t/ObjCClasses.o
 // RUN: %target-build-swift -I %S/Inputs/ObjCClasses/ %t/ObjCClasses.o %s -o %t/a.out

--- a/test/Interpreter/imported_objc_generics_extension.swift
+++ b/test/Interpreter/imported_objc_generics_extension.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: %target-clang -fobjc-arc %S/Inputs/ObjCClasses/ObjCClasses.m -c -o %t/ObjCClasses.o
 // RUN: %target-build-swift -I %S/Inputs/ObjCClasses/ %t/ObjCClasses.o %s -o %t/a.out

--- a/test/Interpreter/interpret_load_framework.swift
+++ b/test/Interpreter/interpret_load_framework.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp -R %S/Inputs/VerySmallObjCFramework.framework %t
 // RUN: %clang -dynamiclib %S/Inputs/VerySmallObjCFramework.m -fmodules -F %t -o %t/VerySmallObjCFramework.framework/VerySmallObjCFramework
 // RUN: %swift_driver -F %t %s | %FileCheck %s

--- a/test/Interpreter/nested_generics.swift
+++ b/test/Interpreter/nested_generics.swift
@@ -1,4 +1,4 @@
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -Xfrontend -enable-experimental-nested-generic-types -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test

--- a/test/Interpreter/objc_bool.swift
+++ b/test/Interpreter/objc_bool.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: %target-clang -fobjc-arc %S/Inputs/ObjCClasses/ObjCClasses.m -c -o %t/ObjCClasses.o
 // RUN: %target-build-swift -I %S/Inputs/ObjCClasses/ -Xlinker %t/ObjCClasses.o %s -o %t/a.out

--- a/test/Interpreter/objc_class_properties.swift
+++ b/test/Interpreter/objc_class_properties.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %clang %target-cc-options -isysroot %sdk -fobjc-arc %S/Inputs/ObjCClasses/ObjCClasses.m -c -o %t/ObjCClasses.o
 // RUN: %target-build-swift -I %S/Inputs/ObjCClasses/ %t/ObjCClasses.o %s -o %t/a.out

--- a/test/Interpreter/objc_class_properties_runtime.swift
+++ b/test/Interpreter/objc_class_properties_runtime.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %clang -arch x86_64 -mmacosx-version-min=10.11 -isysroot %sdk -fobjc-arc %S/Inputs/ObjCClasses/ObjCClasses.m -c -o %t/ObjCClasses.o
 

--- a/test/Interpreter/objc_failable_initializers.swift
+++ b/test/Interpreter/objc_failable_initializers.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: %target-clang -fobjc-arc %S/Inputs/ObjCClasses/ObjCClasses.m -c -o %t/ObjCClasses.o
 // RUN: %target-build-swift -I %S/Inputs/ObjCClasses/ -Xlinker %t/ObjCClasses.o %s -o %t/a.out

--- a/test/Interpreter/objc_runtime_visible.swift
+++ b/test/Interpreter/objc_runtime_visible.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %clang %target-cc-options -isysroot %sdk -fobjc-arc %S/Inputs/objc_runtime_visible.m -fmodules -nodefaultlibs -lc -dynamiclib -o %t/libobjc_runtime_visible.dylib -install_name @executable_path/libobjc_runtime_visible.dylib
 // RUN: codesign -f -s - %t/libobjc_runtime_visible.dylib

--- a/test/Interpreter/objc_throwing_initializers.swift
+++ b/test/Interpreter/objc_throwing_initializers.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: %target-clang -fobjc-arc %S/Inputs/ObjCClasses/ObjCClasses.m -c -o %t/ObjCClasses.o
 // RUN: %target-build-swift -I %S/Inputs/ObjCClasses/ -Xlinker %t/ObjCClasses.o %s -o %t/a.out

--- a/test/Interpreter/pinning.swift
+++ b/test/Interpreter/pinning.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t  &&  mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -parse-stdlib %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test

--- a/test/Interpreter/property_behavior.swift
+++ b/test/Interpreter/property_behavior.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -enable-experimental-property-behaviors %s -o %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test

--- a/test/Interpreter/protocol_resilience.swift
+++ b/test/Interpreter/protocol_resilience.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -emit-library -Xfrontend -enable-resilience -c %S/../Inputs/resilient_protocol.swift -o %t/resilient_protocol.o
 // RUN: %target-build-swift -emit-module -Xfrontend -enable-resilience -c %S/../Inputs/resilient_protocol.swift -o %t/resilient_protocol.o
 // RUN: %target-build-swift %s -Xlinker %t/resilient_protocol.o -I %t -L %t -o %t/main

--- a/test/Interpreter/repl_17597453.swift
+++ b/test/Interpreter/repl_17597453.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp -R %S/Inputs/VerySmallObjCFramework.framework %t
 // RUN: %clang -dynamiclib %S/Inputs/VerySmallObjCFramework.m -fmodules -F %t -o %t/VerySmallObjCFramework.framework/VerySmallObjCFramework
 // RUN: %target-repl-run-simple-swift -F %t | %FileCheck %s

--- a/test/Interpreter/repl_autolinking.swift
+++ b/test/Interpreter/repl_autolinking.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: sed -n -e '/MODULE_A_START$/,/MODULE_A_END$/ p' %s > %t/a.swift
 // RUN: sed -n -e '/MODULE_B_START$/,/MODULE_B_END$/ p' %s > %t/b.swift
 // RUN: sed -n -e '/REPL_START$/,/REPL_END$/ p' %s > %t/repl.swift

--- a/test/Interpreter/struct_resilience.swift
+++ b/test/Interpreter/struct_resilience.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -emit-library -Xfrontend -enable-resilience -c %S/../Inputs/resilient_struct.swift -o %t/resilient_struct.o
 // RUN: %target-build-swift -emit-module -Xfrontend -enable-resilience -c %S/../Inputs/resilient_struct.swift -o %t/resilient_struct.o
 // RUN: %target-build-swift %s -Xlinker %t/resilient_struct.o -I %t -L %t -o %t/main

--- a/test/Interpreter/testability.swift
+++ b/test/Interpreter/testability.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -emit-library -c %S/Inputs/testability_helper.swift -enable-testing -force-single-frontend-invocation -o %t/testability_helper.o -emit-module
 
 // RUN: %target-build-swift %s -I %t -Xlinker %t/testability_helper.o -o %t/main

--- a/test/Interpreter/wildcard_dispatch_on_catch.swift
+++ b/test/Interpreter/wildcard_dispatch_on_catch.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t  &&  mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test

--- a/test/NameBinding/InheritedConformance.swift
+++ b/test/NameBinding/InheritedConformance.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: %target-swift-frontend -parse -primary-file %t/main.swift -emit-reference-dependencies-path - > %t.swiftdeps
 

--- a/test/NameBinding/accessibility.swift
+++ b/test/NameBinding/accessibility.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 
 // RUN: %target-swift-frontend -parse -primary-file %t/main.swift %S/Inputs/accessibility_other.swift -module-name accessibility -enable-source-import -I %S/Inputs -sdk "" -enable-access-control -verify

--- a/test/NameBinding/debug-client-discriminator.swift
+++ b/test/NameBinding/debug-client-discriminator.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -emit-module -o %t -module-name HasPrivateAccess %S/Inputs/HasPrivateAccess1.swift %S/Inputs/HasPrivateAccess2.swift
 // RUN: %target-swift-ide-test -print-ast-typechecked -source-filename %s -I %t -sdk "" -disable-access-control 2>&1 | %FileCheck -check-prefix=CHECK-ERROR %s

--- a/test/NameBinding/import-resolution-2.swift
+++ b/test/NameBinding/import-resolution-2.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/abcde.swift
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/aeiou.swift
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/asdf.swift

--- a/test/NameBinding/import-resolution-overload.swift
+++ b/test/NameBinding/import-resolution-overload.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/overload_intFunctions.swift
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/overload_boolFunctions.swift
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/overload_vars.swift

--- a/test/NameBinding/import-resolution.swift
+++ b/test/NameBinding/import-resolution.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -parse %s -enable-source-import -I %S/Inputs -sdk "" -verify -show-diagnostics-after-fatal
 // RUN: not %target-swift-frontend -parse %s -I %S/Inputs -sdk "" -show-diagnostics-after-fatal 2>&1 | %FileCheck %s -check-prefix=CHECK-NO-SOURCE-IMPORT

--- a/test/NameBinding/import-specific-decl.swift
+++ b/test/NameBinding/import-specific-decl.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/asdf.swift
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/abcde.swift
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/aeiou.swift

--- a/test/NameBinding/import-specific-fixits.swift
+++ b/test/NameBinding/import-specific-fixits.swift
@@ -1,6 +1,5 @@
 // RUN: rm -f %t.*
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/ambiguous_left.swift
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/ambiguous_right.swift
 // RUN: %target-swift-frontend -emit-module -o %t -I %t %S/Inputs/ambiguous.swift

--- a/test/NameBinding/objc_multi_file.swift
+++ b/test/NameBinding/objc_multi_file.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse -parse-as-library -primary-file %S/Inputs/objc_multi_file_2.swift %s -verify
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse -parse-as-library -primary-file %s %S/Inputs/objc_multi_file_2.swift -verify
 
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module %S/Inputs/objc_multi_file_2.swift -DFAKE_UIIMAGE -o %t
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse -module-name main -primary-file %s -I %t -DIMPORT -verify
 

--- a/test/NameBinding/reference-dependencies-dynamic-lookup.swift
+++ b/test/NameBinding/reference-dependencies-dynamic-lookup.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse -primary-file %t/main.swift -emit-reference-dependencies-path - > %t.swiftdeps
 // RUN: %FileCheck %s < %t.swiftdeps

--- a/test/NameBinding/reference-dependencies-errors.swift
+++ b/test/NameBinding/reference-dependencies-errors.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: not %target-swift-frontend -parse -primary-file %t/main.swift -emit-reference-dependencies-path - > %t.swiftdeps
 

--- a/test/NameBinding/reference-dependencies-members.swift
+++ b/test/NameBinding/reference-dependencies-members.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: %target-swift-frontend -parse -primary-file %t/main.swift %S/Inputs/reference-dependencies-members-helper.swift -emit-reference-dependencies-path - > %t.swiftdeps
 

--- a/test/NameBinding/reference-dependencies.swift
+++ b/test/NameBinding/reference-dependencies.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: %target-swift-frontend -parse -primary-file %t/main.swift %S/Inputs/reference-dependencies-helper.swift -emit-reference-dependencies-path - > %t.swiftdeps
 // RUN: %FileCheck %s < %t.swiftdeps

--- a/test/Parse/pointer_conversion.swift.gyb
+++ b/test/Parse/pointer_conversion.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %gyb -DOPT_KIND=None %s -o %t/pointer_conversion.swift
 // RUN: %line-directive %t/pointer_conversion.swift -- %target-swift-frontend -parse -verify %t/pointer_conversion.swift

--- a/test/Parse/pointer_conversion_objc.swift.gyb
+++ b/test/Parse/pointer_conversion_objc.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %gyb -DOPT_KIND=None %s -o %t/pointer_conversion.swift
 // RUN: %line-directive %t/pointer_conversion.swift -- %target-swift-frontend -parse -verify %t/pointer_conversion.swift

--- a/test/PlaygroundTransform/array.swift
+++ b/test/PlaygroundTransform/array.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/array_did_set.swift
+++ b/test/PlaygroundTransform/array_did_set.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/array_in_struct.swift
+++ b/test/PlaygroundTransform/array_in_struct.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/bare_value.swift
+++ b/test/PlaygroundTransform/bare_value.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/control-flow.swift
+++ b/test/PlaygroundTransform/control-flow.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/declarations.swift
+++ b/test/PlaygroundTransform/declarations.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/declarations_error.swift
+++ b/test/PlaygroundTransform/declarations_error.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: not %target-swift-frontend -parse -playground %t/main.swift 2>&1 | %FileCheck %s
 

--- a/test/PlaygroundTransform/disable_transform_only.swift
+++ b/test/PlaygroundTransform/disable_transform_only.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -disable-playground-transform -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s -allow-empty

--- a/test/PlaygroundTransform/do-catch.swift
+++ b/test/PlaygroundTransform/do-catch.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/do.swift
+++ b/test/PlaygroundTransform/do.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/empty-tuple.swift
+++ b/test/PlaygroundTransform/empty-tuple.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/for_crash.swift
+++ b/test/PlaygroundTransform/for_crash.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: not %target-swift-frontend -parse -playground %t/main.swift
 

--- a/test/PlaygroundTransform/high_performance.swift
+++ b/test/PlaygroundTransform/high_performance.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -playground-high-performance -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/import_error.swift
+++ b/test/PlaygroundTransform/import_error.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: %target-swift-frontend -parse -playground %t/main.swift -verify
 

--- a/test/PlaygroundTransform/init.swift
+++ b/test/PlaygroundTransform/init.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/mutation.swift
+++ b/test/PlaygroundTransform/mutation.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/placeholder.swift
+++ b/test/PlaygroundTransform/placeholder.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -disable-playground-transform -o %t/main %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/plus_equals.swift
+++ b/test/PlaygroundTransform/plus_equals.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PlaygroundTransform/print.swift
+++ b/test/PlaygroundTransform/print.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/PrintAsObjC/accessibility.swift
+++ b/test/PrintAsObjC/accessibility.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -parse-as-library %s -parse -emit-objc-header-path %t/accessibility.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck -check-prefix=CHECK -check-prefix=CHECK-PUBLIC %s < %t/accessibility.h
 // RUN: %check-in-clang %t/accessibility.h

--- a/test/PrintAsObjC/any_as_id.swift
+++ b/test/PrintAsObjC/any_as_id.swift
@@ -2,7 +2,7 @@
 
 // REQUIRES: objc_interop
 
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // FIXME: BEGIN -enable-source-import hackaround
 // RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift

--- a/test/PrintAsObjC/arc-conventions.swift
+++ b/test/PrintAsObjC/arc-conventions.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -c %s -parse-as-library -force-single-frontend-invocation -o %t/swift.o -emit-objc-header-path %t/swift.h
 
 // RUN: %target-clang -c -Weverything -Werror -Wno-unused-macros -Wno-incomplete-module -fobjc-arc -fmodules %S/Inputs/arc-conventions.m -o %t/main.o -I %t

--- a/test/PrintAsObjC/blocks.swift
+++ b/test/PrintAsObjC/blocks.swift
@@ -1,7 +1,6 @@
 // Please keep this file in alphabetical order!
 
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s -disable-objc-attr-requires-foundation-module
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/blocks.swiftmodule -parse -emit-objc-header-path %t/blocks.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/blocks.h

--- a/test/PrintAsObjC/cdecl.swift
+++ b/test/PrintAsObjC/cdecl.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-source-import -emit-module -emit-module-doc -o %t %s -disable-objc-attr-requires-foundation-module
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/cdecl.swiftmodule -parse -emit-objc-header-path %t/cdecl.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/cdecl.h

--- a/test/PrintAsObjC/circularity-errors.swift
+++ b/test/PrintAsObjC/circularity-errors.swift
@@ -2,7 +2,7 @@
 
 // REQUIRES: objc_interop
 
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // FIXME: BEGIN -enable-source-import hackaround
 // RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift

--- a/test/PrintAsObjC/circularity.swift
+++ b/test/PrintAsObjC/circularity.swift
@@ -2,7 +2,7 @@
 
 // REQUIRES: objc_interop
 
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // FIXME: BEGIN -enable-source-import hackaround
 // RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -2,8 +2,7 @@
 
 // REQUIRES: objc_interop
 
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // FIXME: BEGIN -enable-source-import hackaround
 // RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift

--- a/test/PrintAsObjC/comments.swift
+++ b/test/PrintAsObjC/comments.swift
@@ -1,7 +1,6 @@
 // Please keep this file in alphabetical order!
 
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-source-import -emit-module -emit-module-path %t/comments.swiftmodule -emit-module-doc -emit-module-doc-path %t/comments.swiftdoc -module-name comments %S/../Inputs/comment_to_something_conversion.swift -disable-objc-attr-requires-foundation-module
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/comments.swiftmodule -parse -emit-objc-header-path %t/comments.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: awk '/A000/,0' %t/comments.h > %t/comments.h-cleaned

--- a/test/PrintAsObjC/depends-on-swift-framework.swift
+++ b/test/PrintAsObjC/depends-on-swift-framework.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // FIXME: BEGIN -enable-source-import hackaround
 // RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift

--- a/test/PrintAsObjC/empty.swift
+++ b/test/PrintAsObjC/empty.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -parse -emit-objc-header-path %t/empty.h
 // RUN: %FileCheck %s < %t/empty.h
 // RUN: %check-in-clang -std=c99 %t/empty.h

--- a/test/PrintAsObjC/enums.swift
+++ b/test/PrintAsObjC/enums.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-source-import -emit-module -emit-module-doc -o %t %s -import-objc-header %S/Inputs/enums.h -disable-objc-attr-requires-foundation-module
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/enums.swiftmodule -parse -emit-objc-header-path %t/enums.h -import-objc-header %S/Inputs/enums.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/enums.h

--- a/test/PrintAsObjC/error-delegate.swift
+++ b/test/PrintAsObjC/error-delegate.swift
@@ -2,7 +2,7 @@
 
 // REQUIRES: objc_interop
 
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // FIXME: BEGIN -enable-source-import hackaround
 // RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift

--- a/test/PrintAsObjC/extensions.swift
+++ b/test/PrintAsObjC/extensions.swift
@@ -1,7 +1,6 @@
 // Please keep this file in alphabetical order!
 
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s -disable-objc-attr-requires-foundation-module
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/extensions.swiftmodule -parse -emit-objc-header-path %t/extensions.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/extensions.h

--- a/test/PrintAsObjC/generic-ancestry.swift
+++ b/test/PrintAsObjC/generic-ancestry.swift
@@ -1,7 +1,6 @@
 // Please keep this file in alphabetical order!
 
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s -module-name generic -disable-objc-attr-requires-foundation-module
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/generic.swiftmodule -parse -emit-objc-header-path %t/generic.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/generic.h

--- a/test/PrintAsObjC/imported-block-typedefs.swift
+++ b/test/PrintAsObjC/imported-block-typedefs.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s -import-objc-header %S/Inputs/imported-block-typedefs.h -disable-objc-attr-requires-foundation-module
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/imported-block-typedefs.swiftmodule -parse -emit-objc-header-path %t/imported-block-typedefs-output.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/imported-block-typedefs-output.h

--- a/test/PrintAsObjC/imports.swift
+++ b/test/PrintAsObjC/imports.swift
@@ -1,7 +1,6 @@
 // Please keep this file in alphabetical order!
 
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules/ -emit-module -o %t %s -disable-objc-attr-requires-foundation-module
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules/ -parse-as-library %t/imports.swiftmodule -parse -emit-objc-header-path %t/imports.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/imports.h

--- a/test/PrintAsObjC/local-types.swift
+++ b/test/PrintAsObjC/local-types.swift
@@ -1,7 +1,6 @@
 // Please keep this file in alphabetical order!
 
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s -module-name local -disable-objc-attr-requires-foundation-module
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/local.swiftmodule -parse -emit-objc-header-path %t/local.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/local.h

--- a/test/PrintAsObjC/mixed-framework-fwd.swift
+++ b/test/PrintAsObjC/mixed-framework-fwd.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -F %S/Inputs/ -module-name Mixed -import-underlying-module %s -parse -emit-objc-header-path %t/mixed.h
 // RUN: %FileCheck -check-prefix=CHECK -check-prefix=NO-IMPORT %s < %t/mixed.h
 // RUN: %check-in-clang -F %S/Inputs/ %t/mixed.h

--- a/test/PrintAsObjC/mixed-framework.swift
+++ b/test/PrintAsObjC/mixed-framework.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -F %S/Inputs/ -module-name Mixed -import-underlying-module -parse-as-library %s -parse -emit-objc-header-path %t/mixed.h
 // RUN: %FileCheck -check-prefix=CHECK -check-prefix=FRAMEWORK %s < %t/mixed.h
 // RUN: %check-in-clang -F %S/Inputs/ %t/mixed.h

--- a/test/PrintAsObjC/newtype.swift
+++ b/test/PrintAsObjC/newtype.swift
@@ -2,7 +2,7 @@
 
 // REQUIRES: objc_interop
 
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // FIXME: BEGIN -enable-source-import hackaround
 // RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift

--- a/test/PrintAsObjC/override.swift
+++ b/test/PrintAsObjC/override.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // FIXME: BEGIN -enable-source-import hackaround
 // RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift

--- a/test/PrintAsObjC/pragma-clang.swift
+++ b/test/PrintAsObjC/pragma-clang.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // FIXME: BEGIN -enable-source-import hackaround
 // RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift

--- a/test/PrintAsObjC/protocols.swift
+++ b/test/PrintAsObjC/protocols.swift
@@ -1,7 +1,6 @@
 // Please keep this file in alphabetical order!
 
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // FIXME: BEGIN -enable-source-import hackaround
 // RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift

--- a/test/PrintAsObjC/simd.swift
+++ b/test/PrintAsObjC/simd.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // FIXME: BEGIN -enable-source-import hackaround
 // RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift

--- a/test/PrintAsObjC/swift_name.m
+++ b/test/PrintAsObjC/swift_name.m
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %S/../Inputs/empty.swift -parse -emit-objc-header-path %t/empty.h
 // RUN: %clang -E -fobjc-arc -fmodules -isysroot %clang-importer-sdk-path -I %t %s | %FileCheck %s
 

--- a/test/PrintAsObjC/swift_name.swift
+++ b/test/PrintAsObjC/swift_name.swift
@@ -2,7 +2,7 @@
 
 // REQUIRES: objc_interop
 
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // FIXME: BEGIN -enable-source-import hackaround
 // RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift

--- a/test/PrintAsObjC/unmodified.swift
+++ b/test/PrintAsObjC/unmodified.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -parse -emit-objc-header-path %t/out.h
 // RUN: touch -t 201401240005 %t/out.h
 // RUN: %S/../Inputs/getmtime.py %t/out.h > %t/orig-mtime.txt

--- a/test/Prototypes/Algorithms.swift.gyb
+++ b/test/Prototypes/Algorithms.swift.gyb
@@ -9,7 +9,8 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-// RUN: rm -rf %t && mkdir -p %t && %gyb -DWORD_BITS=%target-ptrsize %s -o %t/out.swift
+// RUN: %empty-directory(%t)
+// RUN: %gyb -DWORD_BITS=%target-ptrsize %s -o %t/out.swift
 // RUN: %line-directive %t/out.swift -- %target-build-swift -parse-stdlib %t/out.swift -o %t/a.out -Onone
 // RUN: %line-directive %t/out.swift -- %target-run %t/a.out
 

--- a/test/Reflection/box_descriptors.sil
+++ b/test/Reflection/box_descriptors.sil
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -emit-module -emit-library -module-name capture_descriptors -o %t/capture_descriptors.%target-dylib-extension
 // RUN: %target-swift-reflection-dump -binary-filename %t/capture_descriptors.%target-dylib-extension | %FileCheck %s
 

--- a/test/Reflection/capture_descriptors.sil
+++ b/test/Reflection/capture_descriptors.sil
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -emit-module -emit-library -module-name capture_descriptors -o %t/capture_descriptors.%target-dylib-extension
 // RUN: %target-swift-reflection-dump -binary-filename %t/capture_descriptors.%target-dylib-extension | %FileCheck %s
 

--- a/test/Reflection/typeref_decoding.swift
+++ b/test/Reflection/typeref_decoding.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/libTypesToReflect.%target-dylib-extension
 // RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect.%target-dylib-extension | %FileCheck %s
 

--- a/test/Reflection/typeref_decoding_imported.swift
+++ b/test/Reflection/typeref_decoding_imported.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %S/Inputs/ImportedTypes.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/libTypesToReflect.%target-dylib-extension -I %S/Inputs
 // RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect.%target-dylib-extension | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-cpu
 

--- a/test/Reflection/typeref_decoding_objc.swift
+++ b/test/Reflection/typeref_decoding_objc.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %S/Inputs/ObjectiveCTypes.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/libTypesToReflect.%target-dylib-extension
 // RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect.%target-dylib-extension | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK
 // REQUIRES: objc_interop

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %S/Inputs/TypeLowering.swift -parse-as-library -emit-module -emit-library -module-name TypeLowering -o %t/libTypesToReflect.%target-dylib-extension
 // RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect.%target-dylib-extension -binary-filename %platform-module-dir/libswiftCore.%target-dylib-extension -dump-type-lowering < %s | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 

--- a/test/Reflection/typeref_lowering_imported.swift
+++ b/test/Reflection/typeref_lowering_imported.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %S/Inputs/ImportedTypes.swift -parse-as-library -emit-module -emit-library -module-name TypeLowering -I %S/Inputs -o %t/libTypesToReflect
 // RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect -binary-filename %platform-module-dir/libswiftCore.dylib -dump-type-lowering < %s | %FileCheck %s
 

--- a/test/Reflection/typeref_lowering_missing.swift
+++ b/test/Reflection/typeref_lowering_missing.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %S/Inputs/ConcreteTypes.swift -parse-as-library -emit-module -emit-library -module-name TypeLowering -Xfrontend -disable-reflection-metadata -o %t/libTypesToReflect
 // RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect -binary-filename %platform-module-dir/libswiftCore.dylib -dump-type-lowering < %s | %FileCheck %s
 

--- a/test/Reflection/typeref_lowering_objc.swift
+++ b/test/Reflection/typeref_lowering_objc.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %S/Inputs/TypeLoweringObjectiveC.swift -parse-as-library -emit-module -emit-library -module-name TypeLowering -o %t/libTypesToReflect
 // RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect -binary-filename %platform-module-dir/libswiftCore.dylib -dump-type-lowering < %s | %FileCheck %s
 

--- a/test/Runtime/backtrace.swift
+++ b/test/Runtime/backtrace.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out
 // RUN: not --crash %t/a.out 2>&1 | %utils/backtrace-check
 

--- a/test/SIL/Serialization/clang_conformances.swift
+++ b/test/SIL/Serialization/clang_conformances.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/clang_conformances.sil -module-name clang_conformances -import-objc-header %S/Inputs/clang_conformances_helper.h
 // RUN: %target-swift-frontend -emit-sil -o %t -I %t -primary-file %s -module-name main -O
 

--- a/test/SIL/Serialization/clang_sib.swift
+++ b/test/SIL/Serialization/clang_sib.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sib -o %t -primary-file %s -module-name main
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir -o /dev/null -primary-file %t/clang_sib.sib -module-name main
 

--- a/test/SIL/Serialization/deserialize_generic.sil
+++ b/test/SIL/Serialization/deserialize_generic.sil
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -sil-serialize-all -o %t %S/Inputs/def_generic.swift
 // RUN: %target-sil-opt -linker -I %t %s | %FileCheck %s
 

--- a/test/SIL/Serialization/deserialize_generic_marker.sil
+++ b/test/SIL/Serialization/deserialize_generic_marker.sil
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -sil-serialize-all -o %t %S/Inputs/def_generic_marker.swift
 // RUN: %target-sil-opt -linker -I %t %s | %FileCheck %s
 

--- a/test/SIL/Serialization/function_param_convention.sil
+++ b/test/SIL/Serialization/function_param_convention.sil
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -parse-sil -sil-inline-threshold 0 %S/Inputs/function_param_convention_input.sil -o %t/FunctionInput.swiftmodule -emit-module -parse-as-library -parse-stdlib -module-name FunctionInput -sil-serialize-all -O
 // RUN: %target-sil-opt -I %t -linker %s -o - | %FileCheck %s
 

--- a/test/SIL/Serialization/generic_shared_function.swift
+++ b/test/SIL/Serialization/generic_shared_function.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/generic_shared_function_helper.sil -module-name SILSource
 // RUN: %target-swift-frontend -emit-module -o %t -I %t -primary-file %s -module-name main -sil-link-all
 

--- a/test/SIL/Serialization/init_existential_inst_deserializes_witness_tables.swift
+++ b/test/SIL/Serialization/init_existential_inst_deserializes_witness_tables.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -sil-inline-threshold 0 %S/Inputs/init_existential_inst_deserializes_witness_tables_input.swift -o %t/Swift.swiftmodule -emit-module -parse-as-library -parse-stdlib -module-link-name swiftCore -module-name Swift -sil-serialize-all -O
 // RUN: %target-swift-frontend -I %t -O %s -emit-sil -o - | %FileCheck %s
 

--- a/test/SIL/Serialization/perf_inline_without_inline_all.swift
+++ b/test/SIL/Serialization/perf_inline_without_inline_all.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t; mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module %S/Inputs/nontransparent.swift -O -sil-serialize-all -parse-stdlib -parse-as-library -emit-module -o %t/Swift.swiftmodule -module-name=Swift -module-link-name swiftCore
 // RUN: %target-swift-frontend %s -O -I %t -emit-sil -o - | %FileCheck %s
 

--- a/test/SIL/Serialization/semanticsattr.sil
+++ b/test/SIL/Serialization/semanticsattr.sil
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -parse-sil -emit-sib -parse-as-library -parse-stdlib -module-name SemanticsAttr -o %t/SemanticsAttr.sib %s
 // RUN: %target-sil-opt %t/SemanticsAttr.sib -o - -sil-sort-output | %FileCheck %s
 

--- a/test/SIL/Serialization/shared_function_serialization.sil
+++ b/test/SIL/Serialization/shared_function_serialization.sil
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/Inputs/shared_function_serialization_input.swift -o %t/Swift.swiftmodule -emit-module -parse-as-library -parse-stdlib -module-link-name swiftCore -module-name Swift -sil-serialize-all -O
 // RUN: %target-sil-opt -enable-sil-verify-all -I %t -linker -inline %s -o - | %FileCheck %s
 

--- a/test/SIL/Serialization/specializer_can_deserialize.swift
+++ b/test/SIL/Serialization/specializer_can_deserialize.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module %S/Inputs/specializer_input.swift -O -sil-serialize-all -parse-stdlib -parse-as-library -emit-module -o %t/Swift.swiftmodule -module-name=Swift -module-link-name swiftCore 
 // RUN: %target-swift-frontend %s -O -I %t -emit-sil -o - | %FileCheck %s
 

--- a/test/SIL/Serialization/vtable_deserialization.swift
+++ b/test/SIL/Serialization/vtable_deserialization.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/Inputs/vtable_deserialization_input.swift -o %t/Swift.swiftmodule -emit-module -parse-as-library -parse-stdlib -module-link-name swiftCore -module-name Swift -sil-serialize-all
 // RUN: %target-swift-frontend %s -emit-sil -O -I %t -o - | %FileCheck %s
 

--- a/test/SILGen/UIApplicationMain.swift
+++ b/test/SILGen/UIApplicationMain.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-silgen-test-overlays
 
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-silgen -parse-as-library %s | %FileCheck %s

--- a/test/SILGen/accessibility_vtables.swift
+++ b/test/SILGen/accessibility_vtables.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-module -o %t %S/Inputs/accessibility_vtables_helper.swift
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen -primary-file %s %S/Inputs/accessibility_vtables_other.swift -I %t -module-name accessibility_vtables | %FileCheck %s
 

--- a/test/SILGen/coverage_smoke.swift
+++ b/test/SILGen/coverage_smoke.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -profile-generate -profile-coverage-mapping -Xfrontend -disable-incremental-llvm-codegen -o %t/main
 // RUN: env LLVM_PROFILE_FILE=%t/default.profraw %target-run %t/main
 // RUN: %llvm-profdata merge %t/default.profraw -o %t/default.profdata

--- a/test/SILGen/dynamic.swift
+++ b/test/SILGen/dynamic.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-silgen-test-overlays
 
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -Xllvm -sil-full-demangle -primary-file %s %S/Inputs/dynamic_other.swift -emit-silgen | %FileCheck %s

--- a/test/SILGen/expressions.swift
+++ b/test/SILGen/expressions.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: echo "public var x = Int()" | %target-swift-frontend -module-name FooBar -emit-module -o %t -
 // RUN: %target-swift-frontend -parse-stdlib -emit-silgen %s -I%t -disable-access-control | %FileCheck %s
 

--- a/test/SILGen/fragile_globals.swift
+++ b/test/SILGen/fragile_globals.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -parse-as-library -sil-serialize-all -o %t %S/Inputs/ModuleA.swift
 // RUN: %target-swift-frontend -emit-module -parse-as-library -sil-serialize-all -o %t %S/Inputs/ModuleB.swift
 // RUN: %target-swift-frontend -parse-as-library -I%t %s -Xllvm -sil-disable-pass="SIL Global Optimization" -O -emit-sil | %FileCheck %s

--- a/test/SILGen/global_init_attribute.swift
+++ b/test/SILGen/global_init_attribute.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-module -o %t %S/Inputs/def_global.swift
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -parse-as-library -emit-silgen -I %t %s | %FileCheck %s
 //

--- a/test/SILGen/mangling_ext_structA.swift
+++ b/test/SILGen/mangling_ext_structA.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/def_structA.swift
 // RUN: %target-swift-frontend -emit-silgen -module-name ext_structA -I %t %s | %FileCheck %s
 

--- a/test/SILGen/mangling_private.swift
+++ b/test/SILGen/mangling_private.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/mangling_private_helper.swift
 // RUN: %target-swift-frontend -emit-silgen %S/Inputs/mangling_private_helper.swift | %FileCheck %s -check-prefix=CHECK-BASE
 

--- a/test/SILGen/objc_blocks_bridging.swift
+++ b/test/SILGen/objc_blocks_bridging.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-silgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -verify -emit-silgen -I %S/Inputs -disable-objc-attr-requires-foundation-module %s | %FileCheck %s
 

--- a/test/SILGen/objc_bridged_results.swift
+++ b/test/SILGen/objc_bridged_results.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-silgen-test-overlays
 
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-silgen %s -import-objc-header %S/Inputs/objc_bridged_results.h | %FileCheck %s

--- a/test/SILGen/objc_bridging.swift
+++ b/test/SILGen/objc_bridging.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-silgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -o %t -I %S/../Inputs/ObjCBridging %S/../Inputs/ObjCBridging/Appliances.swift
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -I %S/../Inputs/ObjCBridging -Xllvm -sil-full-demangle -emit-silgen %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-cpu --check-prefix=CHECK-%target-os-%target-cpu

--- a/test/SILGen/objc_currying.swift
+++ b/test/SILGen/objc_currying.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-silgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-silgen %s | %FileCheck %s
 

--- a/test/SILGen/objc_dictionary_bridging.swift
+++ b/test/SILGen/objc_dictionary_bridging.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-silgen-test-overlays
 
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-silgen %s | %FileCheck %s

--- a/test/SILGen/objc_disable_brigding.swift
+++ b/test/SILGen/objc_disable_brigding.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-silgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -o %t -I %S/../Inputs/ObjCBridging %S/../Inputs/ObjCBridging/Appliances.swift -I %t
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -I %S/../Inputs/ObjCBridging -disable-swift-bridge-attr -Xllvm -sil-full-demangle -emit-silgen %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-cpu --check-prefix=CHECK-%target-os-%target-cpu

--- a/test/SILGen/objc_error.swift
+++ b/test/SILGen/objc_error.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-clang-importer-objc-overlays
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-silgen %s | %FileCheck %s

--- a/test/SILGen/objc_nonnull_lie_hack.swift
+++ b/test/SILGen/objc_nonnull_lie_hack.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t/APINotes
-// RUN: mkdir -p %t/APINotes
+// RUN: %empty-directory(%t/APINotes)
 // RUN: %clang_apinotes -yaml-to-binary %S/Inputs/gizmo.apinotes -o %t/APINotes/gizmo.apinotesc
 // RUN: %target-swift-frontend -emit-silgen -sdk %S/Inputs -I %S/Inputs -I %t/APINotes -enable-source-import -primary-file %s | %FileCheck -check-prefix=SILGEN %s
 // RUN: %target-swift-frontend -emit-sil -O -sdk %S/Inputs -I %S/Inputs -I %t/APINotes -enable-source-import -primary-file %s | %FileCheck -check-prefix=OPT %s

--- a/test/SILGen/objc_set_bridging.swift
+++ b/test/SILGen/objc_set_bridging.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %build-silgen-test-overlays
 
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-silgen %s | %FileCheck %s

--- a/test/SILGen/partial_apply_super.swift
+++ b/test/SILGen/partial_apply_super.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -I %t -emit-module -emit-module-path=%t/resilient_struct.swiftmodule -module-name resilient_struct %S/../Inputs/resilient_struct.swift
 // RUN: %target-swift-frontend -I %t -emit-module -emit-module-path=%t/resilient_class.swiftmodule -module-name resilient_class %S/../Inputs/resilient_class.swift
 // RUN: %target-swift-frontend -enable-resilience -emit-silgen -parse-as-library -I %t %s | %FileCheck %s

--- a/test/SILGen/super.swift
+++ b/test/SILGen/super.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -I %t -emit-module -emit-module-path=%t/resilient_struct.swiftmodule -module-name resilient_struct %S/../Inputs/resilient_struct.swift
 // RUN: %target-swift-frontend -I %t -emit-module -emit-module-path=%t/resilient_class.swiftmodule -module-name resilient_class %S/../Inputs/resilient_class.swift
 // RUN: %target-swift-frontend -emit-silgen -parse-as-library -I %t %s | %FileCheck %s

--- a/test/SILOptimizer/arcsequenceopts_loops.sil.gyb
+++ b/test/SILOptimizer/arcsequenceopts_loops.sil.gyb
@@ -1,6 +1,5 @@
 %# -*- mode: sil -*-
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %gyb %s > %t/arc-sequence-opts-loops.sil
 // RUN: %target-sil-opt -enable-sil-verify-all -arc-sequence-opts %t/arc-sequence-opts-loops.sil -enable-loop-arc=0 | %FileCheck %t/arc-sequence-opts-loops.sil
 

--- a/test/SILOptimizer/capture_propagation_linkage.swift
+++ b/test/SILOptimizer/capture_propagation_linkage.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t 
+// RUN: %empty-directory(%t) 
 // RUN: %target-build-swift %S/Inputs/capture_propagation_linkage/main.swift %s -O -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test

--- a/test/SILOptimizer/dead_witness_module.swift
+++ b/test/SILOptimizer/dead_witness_module.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -Onone -parse-stdlib -parse-as-library  -module-name TestModule -sil-serialize-all %S/Inputs/TestModule.swift -emit-module-path %t/TestModule.swiftmodule 
 // RUN: %target-swift-frontend -O %s -I %t -emit-sil | %FileCheck %s
 

--- a/test/SILOptimizer/devirt_access.swift
+++ b/test/SILOptimizer/devirt_access.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -Onone -o %t %S/Inputs/devirt_access_other_module.swift
 
 // RUN: %target-swift-frontend -O -primary-file %s %S/Inputs/devirt_access_helper.swift -I %t -emit-sil -sil-inline-threshold 1000 -sil-verify-all | %FileCheck -check-prefix=WHOLE-MODULE %s

--- a/test/SILOptimizer/inline_heuristics.sil
+++ b/test/SILOptimizer/inline_heuristics.sil
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-sil-opt -enable-sil-verify-all %s -inline -debug-only=sil-inliner 2>%t/log | %FileCheck %s
 // RUN: %FileCheck %s --check-prefix=CHECK-LOG <%t/log
 // REQUIRES: asserts

--- a/test/SILOptimizer/inliner_coldblocks.sil
+++ b/test/SILOptimizer/inliner_coldblocks.sil
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-sil-opt -enable-sil-verify-all %s -inline | %FileCheck %s
 
 sil_stage canonical

--- a/test/SILOptimizer/inliner_spa.sil
+++ b/test/SILOptimizer/inliner_spa.sil
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-sil-opt %s -inline -print-shortest-path-info 2>%t/log >/dev/null
 // RUN: %FileCheck %s <%t/log
 // REQUIRES: asserts

--- a/test/SILOptimizer/let_properties_opts_runtime.swift
+++ b/test/SILOptimizer/let_properties_opts_runtime.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -O  %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s -check-prefix=CHECK-OUTPUT
 // RUN: %target-build-swift -O -wmo %s -o %t/a.out

--- a/test/SILOptimizer/linker.swift
+++ b/test/SILOptimizer/linker.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module %S/Inputs/linker_pass_input.swift -o %t/Swift.swiftmodule -parse-stdlib -parse-as-library -module-name Swift -sil-serialize-all -module-link-name swiftCore
 // RUN: %target-swift-frontend %s -O -I %t -sil-debug-serialization -o - -emit-sil | %FileCheck %s
 

--- a/test/SILOptimizer/sil_witness_tables_external_witnesstable.swift
+++ b/test/SILOptimizer/sil_witness_tables_external_witnesstable.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module %S/Inputs/sil_witness_tables_external_input.swift -o %t/Swift.swiftmodule -parse-stdlib -parse-as-library -module-name Swift -sil-serialize-all -module-link-name swiftCore
 // RUN: %target-swift-frontend -O -I %t %s -emit-sil | %FileCheck %s
 

--- a/test/SILOptimizer/specialize_cg_update_crash.sil
+++ b/test/SILOptimizer/specialize_cg_update_crash.sil
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -parse-stdlib -parse-as-library  -module-name TestMod -sil-serialize-all %S/Inputs/TestMod.sil -emit-module-path %t/TestMod.swiftmodule 
 // RUN: %target-sil-opt -enable-sil-verify-all -inline -I %t %s | %FileCheck %s
 

--- a/test/SILOptimizer/specialize_partial_apply.swift
+++ b/test/SILOptimizer/specialize_partial_apply.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend -O -Xllvm -sil-disable-pass="Function Signature Optimization" -module-name=test -emit-sil -primary-file %s | %FileCheck %s
 
 // Also do an end-to-end test to check all components, including IRGen.
-// RUN: rm -rf %t && mkdir -p %t 
+// RUN: %empty-directory(%t) 
 // RUN: %target-build-swift -O -Xllvm -sil-disable-pass="Function Signature Optimization" -module-name=test %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s -check-prefix=CHECK-OUTPUT
 // REQUIRES: executable_test

--- a/test/SILOptimizer/verifier_reject.sil
+++ b/test/SILOptimizer/verifier_reject.sil
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: not --crash %target-sil-opt -enable-sil-verify-all %s 2> %t/err.txt
 // RUN: %FileCheck %s < %t/err.txt
 

--- a/test/Sanitizers/sanitizer_coverage.swift
+++ b/test/Sanitizers/sanitizer_coverage.swift
@@ -1,6 +1,5 @@
 // RUN: %target-build-swift -sanitize=address -sanitize-coverage=edge %s -o %t_binary
-// RUN: rm -rf %t_coverage_dir
-// RUN: mkdir -p %t_coverage_dir
+// RUN: %empty-directory(%t_coverage_dir)
 // RUN: ASAN_OPTIONS=abort_on_error=0,coverage=1,coverage_dir=%t_coverage_dir %t_binary
 // check the coverage file exists
 // RUN: ls %t_coverage_dir/sanitizer_coverage.swift.tmp_binary.*.sancov > /dev/null

--- a/test/Sema/enum_equatable_hashable.swift
+++ b/test/Sema/enum_equatable_hashable.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: %target-swift-frontend -parse -verify -primary-file %t/main.swift %S/Inputs/enum_equatable_hashable_other.swift
 

--- a/test/Serialization/alignment.swift
+++ b/test/Serialization/alignment.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -emit-module -parse-as-library -o %t
 // RUN: %target-sil-opt -enable-sil-verify-all %t/alignment.swiftmodule -o - | %FileCheck %s
 

--- a/test/Serialization/always_inline.swift
+++ b/test/Serialization/always_inline.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -sil-serialize-all -o %t %S/Inputs/def_always_inline.swift
 // RUN: llvm-bcanalyzer %t/def_always_inline.swiftmodule | %FileCheck %s
 // RUN: %target-swift-frontend -emit-silgen -sil-link-all -I %t %s | %FileCheck %s -check-prefix=SIL

--- a/test/Serialization/array.swift
+++ b/test/Serialization/array.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/has_array.swift
 // RUN: llvm-bcanalyzer %t/has_array.swiftmodule | %FileCheck %s
 // RUN: %target-swift-frontend -emit-silgen -I %t %s -o /dev/null

--- a/test/Serialization/autolinking.swift
+++ b/test/Serialization/autolinking.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -parse-stdlib -o %t -module-name someModule -module-link-name module %S/../Inputs/empty.swift
 // RUN: %target-swift-frontend -emit-ir -lmagic %s -I %t > %t/out.txt
 // RUN: %FileCheck %s < %t/out.txt

--- a/test/Serialization/autolinking.swift
+++ b/test/Serialization/autolinking.swift
@@ -4,7 +4,7 @@
 // RUN: %FileCheck %s < %t/out.txt
 // RUN: %FileCheck -check-prefix=NO-FORCE-LOAD %s < %t/out.txt
 
-// RUN: mkdir -p %t/someModule.framework/Modules/someModule.swiftmodule/
+// RUN: %empty-directory(%t/someModule.framework/Modules/someModule.swiftmodule)
 // RUN: mv %t/someModule.swiftmodule %t/someModule.framework/Modules/someModule.swiftmodule/%target-swiftmodule-name
 // RUN: %target-swift-frontend -emit-ir -lmagic %s -F %t > %t/framework.txt
 // RUN: %FileCheck -check-prefix=FRAMEWORK %s < %t/framework.txt

--- a/test/Serialization/basic_sil.swift
+++ b/test/Serialization/basic_sil.swift
@@ -1,11 +1,9 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -emit-module -Xfrontend -disable-diagnostic-passes -Xfrontend -sil-serialize-all -force-single-frontend-invocation -o %t/def_basic.swiftmodule %S/Inputs/def_basic.sil
 // RUN: llvm-bcanalyzer %t/def_basic.swiftmodule | %FileCheck %s
 // RUN: %target-build-swift -emit-silgen -Xfrontend -sil-link-all -I %t %s | %FileCheck %S/Inputs/def_basic.sil
 
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -emit-module -Xfrontend -disable-diagnostic-passes -force-single-frontend-invocation -Xfrontend -sil-serialize-all -o %t/def_basic.swiftmodule %S/Inputs/def_basic.sil
 // RUN: %target-build-swift -emit-silgen -Xfrontend -sil-link-all -I %t %s | %FileCheck -check-prefix=CHECK_DECL %S/Inputs/def_basic.sil
 

--- a/test/Serialization/basic_sil_objc.swift
+++ b/test/Serialization/basic_sil_objc.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend %clang-importer-sdk -I %S/../Inputs/clang-importer-sdk/swift-modules -emit-module -Xfrontend -disable-diagnostic-passes -Xfrontend -sil-serialize-all -force-single-frontend-invocation -o %t/def_basic_objc.swiftmodule %S/Inputs/def_basic_objc.sil
 // RUN: llvm-bcanalyzer %t/def_basic_objc.swiftmodule | %FileCheck %s
 // RUN: %target-build-swift -Xfrontend %clang-importer-sdk -emit-silgen -Xfrontend -sil-link-all -I %t %s | %FileCheck %S/Inputs/def_basic_objc.sil

--- a/test/Serialization/builtin.swift
+++ b/test/Serialization/builtin.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -parse-stdlib -o %t %S/Inputs/alias_builtin.swift
 // RUN: llvm-bcanalyzer %t/alias_builtin.swiftmodule | %FileCheck %s
 // RUN: %target-swift-frontend -I %t -parse %s -verify

--- a/test/Serialization/class-determinism.swift
+++ b/test/Serialization/class-determinism.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -module-name def_class -emit-module-path %t/def_class.1.swiftmodule %S/Inputs/def_class.swift -disable-objc-attr-requires-foundation-module
 // RUN: %target-swift-frontend -module-name def_class -emit-module-path %t/def_class.2.swiftmodule %S/Inputs/def_class.swift -disable-objc-attr-requires-foundation-module
 // RUN: diff <(llvm-bcanalyzer -dump %t/def_class.1.swiftmodule | sed -e 's/\.[0-9]\.swiftmodule/\.x\.swiftmodule/g') <(llvm-bcanalyzer -dump %t/def_class.2.swiftmodule | sed -e 's/\.[0-9]\.swiftmodule/\.x\.swiftmodule/g')

--- a/test/Serialization/class-roundtrip-module.swift
+++ b/test/Serialization/class-roundtrip-module.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -module-name def_class -o %t/stage1.swiftmodule %S/Inputs/def_class.swift -disable-objc-attr-requires-foundation-module
 // RUN: %target-swift-frontend -emit-module -parse-as-library -o %t/def_class.swiftmodule %t/stage1.swiftmodule
 // RUN: %target-swift-frontend -emit-sil -Xllvm -sil-disable-pass="External Defs To Decls" -sil-debug-serialization -I %t %S/class.swift | %FileCheck %s -check-prefix=SIL

--- a/test/Serialization/class.swift
+++ b/test/Serialization/class.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-object -emit-module -o %t %S/Inputs/def_class.swift -disable-objc-attr-requires-foundation-module
 // RUN: llvm-bcanalyzer %t/def_class.swiftmodule | %FileCheck %s
 // RUN: %target-swift-frontend -emit-sil -Xllvm -sil-disable-pass="External Defs To Decls" -sil-debug-serialization -I %t %s | %FileCheck %s -check-prefix=SIL

--- a/test/Serialization/comments-framework.swift
+++ b/test/Serialization/comments-framework.swift
@@ -1,5 +1,5 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t/comments.framework/Modules/comments.swiftmodule/
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/comments.framework/Modules/comments.swiftmodule)
 
 // RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/comments.framework/Modules/comments.swiftmodule/%target-swiftmodule-name -emit-module-doc-path %t/comments.framework/Modules/comments.swiftmodule/%target-swiftdoc-name %s
 // RUN: %target-swift-ide-test -print-module-comments -module-to-print=comments -source-filename %s -F %t | %FileCheck %s

--- a/test/Serialization/comments-hidden.swift
+++ b/test/Serialization/comments-hidden.swift
@@ -1,7 +1,6 @@
 // Test the case when we compile normally
 //
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/comments.swiftmodule -emit-module-doc -emit-module-doc-path %t/comments.swiftdoc %s
 // RUN: %target-swift-ide-test -print-module-comments -module-to-print=comments -source-filename %s -I %t > %t.normal.txt
 // RUN: %FileCheck %s -check-prefix=NORMAL < %t.normal.txt
@@ -9,8 +8,7 @@
 
 // Test the case when we compile with -enable-testing
 //
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-testing -module-name comments -emit-module -emit-module-path %t/comments.swiftmodule -emit-module-doc -emit-module-doc-path %t/comments.swiftdoc %s
 // RUN: %target-swift-ide-test -print-module-comments -module-to-print=comments -source-filename %s -I %t > %t.testing.txt
 // RUN: %FileCheck %s -check-prefix=TESTING < %t.testing.txt

--- a/test/Serialization/comments.swift
+++ b/test/Serialization/comments.swift
@@ -1,7 +1,6 @@
 // Test the case when we have a single file in a module.
 //
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/comments.swiftmodule -emit-module-doc -emit-module-doc-path %t/comments.swiftdoc %s
 // RUN: llvm-bcanalyzer %t/comments.swiftmodule | %FileCheck %s -check-prefix=BCANALYZER
 // RUN: llvm-bcanalyzer %t/comments.swiftdoc | %FileCheck %s -check-prefix=BCANALYZER
@@ -9,8 +8,7 @@
 
 // Test the case when we have a multiple files in a module.
 //
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/first.swiftmodule -emit-module-doc -emit-module-doc-path %t/first.swiftdoc -primary-file %s %S/Inputs/def_comments.swift
 // RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/second.swiftmodule -emit-module-doc -emit-module-doc-path %t/second.swiftdoc %s -primary-file %S/Inputs/def_comments.swift
 // RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/comments.swiftmodule -emit-module-doc -emit-module-doc-path %t/comments.swiftdoc %t/first.swiftmodule %t/second.swiftmodule

--- a/test/Serialization/conformance-multi-file.swift
+++ b/test/Serialization/conformance-multi-file.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -module-name Multi -o %t/multi-file-1.swiftmodule -primary-file %s %S/Inputs/conformance-multi-file-other.swift
 // RUN: %target-swift-frontend -emit-module -module-name Multi -o %t/multi-file-2.swiftmodule %s -primary-file %S/Inputs/conformance-multi-file-other.swift
 // RUN: %target-swift-frontend -emit-module -module-name Multi -o %t/Multi.swiftmodule %t/multi-file-*.swiftmodule

--- a/test/Serialization/duplicate_normalprotocolconformance.swift
+++ b/test/Serialization/duplicate_normalprotocolconformance.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/Inputs/duplicate_normalprotocolconformance_input.swift -o %t/Swift.swiftmodule -sil-serialize-all -emit-module -parse-stdlib -parse-as-library -module-link-name swiftCore -module-name Swift
 // RUN: %target-swift-frontend -c %s -I %t -sil-link-all -o %t/out
 

--- a/test/Serialization/empty.swift
+++ b/test/Serialization/empty.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -parse-stdlib -o %t %s
 // RUN: llvm-bcanalyzer -dump %t/empty.swiftmodule > %t/empty.dump.txt
 // RUN: %FileCheck %s < %t/empty.dump.txt

--- a/test/Serialization/enum.swift
+++ b/test/Serialization/enum.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -module-name def_enum -o %t %S/Inputs/def_enum.swift %S/Inputs/def_enum_derived.swift
 // RUN: llvm-bcanalyzer %t/def_enum.swiftmodule | %FileCheck %s
 // RUN: %target-swift-frontend -parse -I %t %s -o /dev/null

--- a/test/Serialization/failed-clang-module.swift
+++ b/test/Serialization/failed-clang-module.swift
@@ -4,9 +4,9 @@
 // - there is a swift invocation that imports B but causes the ObjC part of A to fail to import
 
 
-// RUN: rm -rf %t
-// RUN: mkdir -p %t/MixModA.framework/Headers
-// RUN: mkdir -p %t/MixModA.framework/Modules/MixModA.swiftmodule
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/MixModA.framework/Headers)
+// RUN: %empty-directory(%t/MixModA.framework/Modules/MixModA.swiftmodule)
 // RUN: cp %S/Inputs/MixModA.modulemap %t/MixModA.framework/Modules/module.modulemap
 
 // RUN: %target-swift-frontend -emit-module %S/Inputs/SwiftModA.swift -module-name MixModA -I %S/Inputs/objcfail -o %t/MixModA.framework/Modules/MixModA.swiftmodule/%target-swiftmodule-name -emit-objc-header -emit-objc-header-path %t/MixModA.framework/Headers/MixModA-Swift.h -module-cache-path %t/mcp

--- a/test/Serialization/function.swift
+++ b/test/Serialization/function.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/def_func.swift
 // RUN: llvm-bcanalyzer %t/def_func.swiftmodule | %FileCheck %s
 // RUN: %target-swift-frontend -emit-silgen -I %t %s | %FileCheck %s -check-prefix=SIL

--- a/test/Serialization/generic_extension.swift
+++ b/test/Serialization/generic_extension.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/generic_extension_1.swift
 // RUN: %target-swift-frontend -emit-sil -I %t %s | %FileCheck %s
 

--- a/test/Serialization/generic_witness.swift
+++ b/test/Serialization/generic_witness.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/has_generic_witness.swift
 // RUN: llvm-bcanalyzer %t/has_generic_witness.swiftmodule | %FileCheck %s
 // RUN: %target-swift-frontend -emit-ir -I %t %s -o /dev/null

--- a/test/Serialization/global_init.swift
+++ b/test/Serialization/global_init.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -parse-as-library -sil-serialize-all -o %t %s
 // RUN: llvm-bcanalyzer %t/global_init.swiftmodule | %FileCheck %s -check-prefix=BCANALYZER
 // RUN: %target-sil-opt -enable-sil-verify-all %t/global_init.swiftmodule | %FileCheck %s

--- a/test/Serialization/import.swift
+++ b/test/Serialization/import.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %s -module-name Import
 // RUN: %target-swift-frontend -parse -I %t %s -module-name main -DMAIN -verify
 

--- a/test/Serialization/inherited-conformance.swift
+++ b/test/Serialization/inherited-conformance.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t -module-name Lib %S/Inputs/inherited-conformance-lib.swift
 // RUN: %target-swift-frontend -emit-module -o %t -module-name Base -I %t %S/Inputs/inherited-conformance-base.swift
 // RUN: %target-swift-frontend -emit-module -o %t -module-name User -I %t %S/Inputs/inherited-conformance-user.swift

--- a/test/Serialization/load-file-permissions.swift
+++ b/test/Serialization/load-file-permissions.swift
@@ -1,6 +1,6 @@
 // RUN: if [[ -d %t ]]; then chmod -R u+rwx %t && rm -rf %t; fi
-// RUN: mkdir -p %t/good
-// RUN: mkdir -p %t/bad
+// RUN: %empty-directory(%t/good)
+// RUN: %empty-directory(%t/bad)
 // RUN: chmod a-rx %t/bad
 // RUN: %target-swift-frontend -emit-module -o %t/good %S/../Inputs/empty.swift
 // RUN: not %target-swift-frontend %s -parse -I %t/bad -I %t/good -show-diagnostics-after-fatal 2>&1 | %FileCheck %s

--- a/test/Serialization/load-invalid.swift
+++ b/test/Serialization/load-invalid.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: touch %t/new_module.swiftmodule
 // RUN: %target-swift-frontend %s -parse -I %t -verify -show-diagnostics-after-fatal

--- a/test/Serialization/load-missing-dependencies.swift
+++ b/test/Serialization/load-missing-dependencies.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/../Inputs/empty.swift -module-name new_module
 // RUN: %target-swift-frontend -emit-module -o %t %S/../Inputs/empty.swift -module-name another_new_module
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/depends_on_new_module.swift -I %t

--- a/test/Serialization/load-missing-dependency.swift
+++ b/test/Serialization/load-missing-dependency.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -emit-module -o %t %S/../Inputs/empty.swift -module-name new_module
 // RUN: %target-swift-frontend -emit-module -o %t %S/../Inputs/empty.swift -module-name another_new_module

--- a/test/Serialization/load-wrong-name.swift
+++ b/test/Serialization/load-wrong-name.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/def_func.swift -module-name new_module
 // RUN: not %target-swift-frontend %s -parse -I %t -show-diagnostics-after-fatal 2>&1 | %FileCheck %s
 

--- a/test/Serialization/load.swift
+++ b/test/Serialization/load.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -parse -verify -show-diagnostics-after-fatal
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/def_func.swift -module-name new_module
 // RUN: %target-swift-frontend %s -parse -I %t

--- a/test/Serialization/multi-file.swift
+++ b/test/Serialization/multi-file.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -module-name Multi -o %t/multi-file.swiftmodule -primary-file %s %S/Inputs/multi-file-2.swift
 // RUN: %target-swift-frontend -emit-module -module-name Multi -o %t/multi-file-2.swiftmodule %s -primary-file %S/Inputs/multi-file-2.swift
 

--- a/test/Serialization/noinline.swift
+++ b/test/Serialization/noinline.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -sil-serialize-all -o %t %S/Inputs/def_noinline.swift
 // RUN: llvm-bcanalyzer %t/def_noinline.swiftmodule | %FileCheck %s
 // RUN: %target-swift-frontend -emit-silgen -sil-link-all -I %t %s | %FileCheck %s -check-prefix=SIL

--- a/test/Serialization/objc.swift
+++ b/test/Serialization/objc.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/def_objc.swift -disable-objc-attr-requires-foundation-module
 // RUN: llvm-bcanalyzer %t/def_objc.swiftmodule | %FileCheck %s
 // RUN: %target-swift-frontend -emit-silgen -I %t %s -o - | %FileCheck %s -check-prefix=SIL

--- a/test/Serialization/objc_method_table.swift
+++ b/test/Serialization/objc_method_table.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -disable-objc-attr-requires-foundation-module -o %t %S/Inputs/objc_method_decls.swift
 // RUN: llvm-bcanalyzer %t/objc_method_decls.swiftmodule | %FileCheck %s
 // RUN: %target-swift-frontend -parse -disable-objc-attr-requires-foundation-module -I %t %s -verify

--- a/test/Serialization/objc_xref.swift
+++ b/test/Serialization/objc_xref.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // FIXME: BEGIN -enable-source-import hackaround
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift

--- a/test/Serialization/operator.swift
+++ b/test/Serialization/operator.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/def_operator.swift
 // RUN: llvm-bcanalyzer %t/def_operator.swiftmodule | %FileCheck %s
 // RUN: %target-swift-frontend -parse -I%t %s

--- a/test/Serialization/optimized.swift
+++ b/test/Serialization/optimized.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -O -emit-module -o %t %s
 
 // At one point this triggered deserialization of enough of the stdlib to cause

--- a/test/Serialization/override.swift
+++ b/test/Serialization/override.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/def_class.swift -disable-objc-attr-requires-foundation-module
 // RUN: %target-swift-frontend -emit-module -o %t -I %t %S/Inputs/def_override.swift
 // RUN: llvm-bcanalyzer %t/def_override.swiftmodule | %FileCheck %s

--- a/test/Serialization/print.swift
+++ b/test/Serialization/print.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -skip-deinit=false -module-to-print=print -I %t -source-filename=%s | %FileCheck %s
 

--- a/test/Serialization/resilience.swift
+++ b/test/Serialization/resilience.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // This test checks that we serialize the -enable-resilience and -sil-serialize-all
 // flags correctly.

--- a/test/Serialization/search-paths-relative.swift
+++ b/test/Serialization/search-paths-relative.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t/secret
+// RUN: %empty-directory(%t)/secret
 // RUN: %target-swift-frontend -emit-module -o %t/secret %S/Inputs/struct_with_operators.swift
 // RUN: mkdir -p %t/Frameworks/has_alias.framework/Modules/has_alias.swiftmodule/
 // RUN: %target-swift-frontend -emit-module -o %t/Frameworks/has_alias.framework/Modules/has_alias.swiftmodule/%target-swiftmodule-name %S/Inputs/alias.swift -module-name has_alias

--- a/test/Serialization/search-paths-relative.swift
+++ b/test/Serialization/search-paths-relative.swift
@@ -1,6 +1,7 @@
-// RUN: %empty-directory(%t)/secret
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/secret)
 // RUN: %target-swift-frontend -emit-module -o %t/secret %S/Inputs/struct_with_operators.swift
-// RUN: mkdir -p %t/Frameworks/has_alias.framework/Modules/has_alias.swiftmodule/
+// RUN: %empty-directory(%t/Frameworks/has_alias.framework/Modules/has_alias.swiftmodule)
 // RUN: %target-swift-frontend -emit-module -o %t/Frameworks/has_alias.framework/Modules/has_alias.swiftmodule/%target-swiftmodule-name %S/Inputs/alias.swift -module-name has_alias
 
 // RUN: cd %t/secret && %target-swiftc_driver -emit-module -o %t/has_xref.swiftmodule -I . -F ../Frameworks -parse-as-library %S/Inputs/has_xref.swift %S/../Inputs/empty.swift -Xfrontend -serialize-debugging-options -Xcc -DDUMMY

--- a/test/Serialization/search-paths.swift
+++ b/test/Serialization/search-paths.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t/secret
+// RUN: %empty-directory(%t)/secret
 // RUN: %target-swift-frontend -emit-module -o %t/secret %S/Inputs/struct_with_operators.swift
 // RUN: mkdir -p %t/Frameworks/has_alias.framework/Modules/has_alias.swiftmodule/
 // RUN: %target-swift-frontend -emit-module -o %t/Frameworks/has_alias.framework/Modules/has_alias.swiftmodule/%target-swiftmodule-name %S/Inputs/alias.swift -module-name has_alias

--- a/test/Serialization/search-paths.swift
+++ b/test/Serialization/search-paths.swift
@@ -1,6 +1,7 @@
-// RUN: %empty-directory(%t)/secret
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/secret)
 // RUN: %target-swift-frontend -emit-module -o %t/secret %S/Inputs/struct_with_operators.swift
-// RUN: mkdir -p %t/Frameworks/has_alias.framework/Modules/has_alias.swiftmodule/
+// RUN: %empty-directory(%t/Frameworks/has_alias.framework/Modules/has_alias.swiftmodule)
 // RUN: %target-swift-frontend -emit-module -o %t/Frameworks/has_alias.framework/Modules/has_alias.swiftmodule/%target-swiftmodule-name %S/Inputs/alias.swift -module-name has_alias
 
 // RUN: %target-swift-frontend -emit-module -o %t -I %t/secret -F %t/Frameworks -parse-as-library %S/Inputs/has_xref.swift

--- a/test/Serialization/serialize_attr.swift
+++ b/test/Serialization/serialize_attr.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -parse-as-library -sil-serialize-all -o %t %s
 // RUN: llvm-bcanalyzer %t/serialize_attr.swiftmodule | %FileCheck %s -check-prefix=BCANALYZER
 // RUN: %target-sil-opt -enable-sil-verify-all %t/serialize_attr.swiftmodule | %FileCheck %s

--- a/test/Serialization/sil-serialize-all-with-cross-module-conformance.swift
+++ b/test/Serialization/sil-serialize-all-with-cross-module-conformance.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -parse-as-library -module-name ProtoModule -o %t/ProtoModule.swiftmodule %s -DPROTO
 // RUN: %target-swift-frontend -emit-module -parse-as-library -module-name ModelModule -o %t/ModelModule.swiftmodule %s -DMODEL -I %t -sil-serialize-all
 // RUN: %target-swift-frontend -emit-sil -O -sil-verify-all -o /dev/null %s -DUSE -I %t

--- a/test/Serialization/struct.swift
+++ b/test/Serialization/struct.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/def_struct.swift
 // RUN: llvm-bcanalyzer %t/def_struct.swiftmodule | %FileCheck %s
 // RUN: %target-swift-frontend -emit-silgen -I %t %s -o /dev/null

--- a/test/Serialization/target-incompatible.swift
+++ b/test/Serialization/target-incompatible.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %swift -target x86_64-unknown-darwin14 -o %t/mips-template.swiftmodule -parse-stdlib -emit-module -module-name mips %S/../Inputs/empty.swift
 // RUN: %S/Inputs/binary_sub.py x86_64-unknown-darwin14 mips64-unknown-darwin14 < %t/mips-template.swiftmodule > %t/mips.swiftmodule

--- a/test/Serialization/target-too-new.swift
+++ b/test/Serialization/target-too-new.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -target x86_64-apple-macosx10.50 -emit-module -parse-stdlib %S/../Inputs/empty.swift -o %t
 // RUN: not %target-swift-frontend -I %t -parse %s 2>&1 | %FileCheck %s
 // RUN: %target-swift-frontend -I %t -parse %s -disable-target-os-checking

--- a/test/Serialization/testability.swift
+++ b/test/Serialization/testability.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // This test has two purposes. This first block just tests that we serialize
 // the -enable-testing flag correctly...

--- a/test/Serialization/top-level-code.swift
+++ b/test/Serialization/top-level-code.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %s -module-name Test
 // RUN: llvm-bcanalyzer %t/Test.swiftmodule | %FileCheck %s
 

--- a/test/Serialization/transparent-std.swift
+++ b/test/Serialization/transparent-std.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -parse-stdlib -o %t %S/Inputs/def_transparent_std.swift
 // RUN: llvm-bcanalyzer %t/def_transparent_std.swiftmodule | %FileCheck %s
 // RUN: %target-swift-frontend -emit-sil -Xllvm -sil-disable-pass="External Defs To Decls" -sil-debug-serialization -parse-stdlib -I %t %s | %FileCheck %s -check-prefix=SIL

--- a/test/Serialization/transparent.swift
+++ b/test/Serialization/transparent.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -sil-serialize-all -o %t %S/Inputs/def_transparent.swift
 // RUN: llvm-bcanalyzer %t/def_transparent.swiftmodule | %FileCheck %s
 // RUN: %target-swift-frontend -emit-silgen -sil-link-all -I %t %s | %FileCheck %s -check-prefix=SIL

--- a/test/Serialization/typealias.swift
+++ b/test/Serialization/typealias.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -module-name alias -emit-module -o %t %S/Inputs/alias.swift
 // RUN: llvm-bcanalyzer %t/alias.swiftmodule | %FileCheck %s
 // RUN: %target-build-swift -I %t %s -o %t/a.out

--- a/test/Serialization/vtable-function-deserialization.swift
+++ b/test/Serialization/vtable-function-deserialization.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o Swift.swiftmodule -O -sil-inline-threshold 0 -module-name Swift -module-link-name swiftCore -parse-as-library -parse-stdlib -emit-module -sil-serialize-all %S/Inputs/vtable-function-deserialization-input.swift -o %t/Swift.swiftmodule
 // RUN: %target-swift-frontend -I %t %s -emit-sil -o - -O -sil-link-all
 

--- a/test/Serialization/witnesstable-function-deserialization.swift
+++ b/test/Serialization/witnesstable-function-deserialization.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -O -module-name Swift -module-link-name swiftCore -parse-as-library -parse-stdlib -emit-module -sil-serialize-all %S/Inputs/witnesstable-function-deserialization-input.swift -o %t/Swift.swiftmodule -sil-inline-threshold 10
 // RUN: %target-swift-frontend -I %t %s -emit-sil -o - -O -sil-link-all
 

--- a/test/Serialization/write-to-locked-dir.swift
+++ b/test/Serialization/write-to-locked-dir.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: touch %t/main.swiftmodule %t/main.swiftdoc
 // RUN: chmod -w %t
 

--- a/test/Serialization/xref-multi-file.swift
+++ b/test/Serialization/xref-multi-file.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/struct_with_operators.swift
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/alias.swift -module-name has_alias
 // RUN: %target-swift-frontend -emit-module -o %t -I %t %S/Inputs/has_xref.swift

--- a/test/Serialization/xref.swift
+++ b/test/Serialization/xref.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/struct_with_operators.swift
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/alias.swift -module-name has_alias
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/xref_distraction.swift

--- a/test/SourceKit/CodeComplete/complete_import_module_flag.swift
+++ b/test/SourceKit/CodeComplete/complete_import_module_flag.swift
@@ -1,5 +1,5 @@
 // XFAIL: broken_std_regex
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %swift -Xcc -I%S/Inputs -emit-module -o %t/auxiliary_file.swiftmodule %S/Inputs/auxiliary_file.swift
 // RUN: %complete-test -group=none -hide-none -raw -tok=TOP_LEVEL_0 %s -- -import-module auxiliary_file  -I %t -I %S/Inputs | %FileCheck %s
 // RUN: %complete-test -group=none -tok=TOP_LEVEL_0 %s -- -import-module auxiliary_file  -I %t -I %S/Inputs | %FileCheck %s -check-prefix=WITH_HIDING

--- a/test/SourceKit/CodeComplete/complete_playground_symlink.swift
+++ b/test/SourceKit/CodeComplete/complete_playground_symlink.swift
@@ -1,5 +1,5 @@
-// RUN: rm -rf %t.dir
-// RUN: mkdir -p %t.dir/test.playground
+// RUN: %empty-directory(%t.dir)
+// RUN: %empty-directory(%t.dir/test.playground)
 // RUN: echo "let foo_blah = 0" > %t.dir/input.swift
 // RUN: echo "" >> %t.dir/input.swift
 // RUN: ln -s %t.dir/test.playground %t.dir/linked.playground

--- a/test/SourceKit/CursorInfo/cursor_info.swift
+++ b/test/SourceKit/CursorInfo/cursor_info.swift
@@ -206,8 +206,7 @@ func convention5(_: @convention(method) ()->()) {}
 func convention6(_: @convention(objc_method) ()->()) {}
 func convention7(_: @convention(witness_method) ()->()) {}
 
-// RUN: rm -rf %t.tmp
-// RUN: mkdir -p %t.tmp
+// RUN: %empty-directory(%t.tmp)
 // RUN: %swiftc_driver -emit-module -o %t.tmp/FooSwiftModule.swiftmodule %S/Inputs/FooSwiftModule.swift
 // RUN: %sourcekitd-test -req=cursor -pos=9:8 %s -- -F %S/../Inputs/libIDE-mock-sdk %mcp_opt %s | %FileCheck -check-prefix=CHECK1 %s
 // CHECK1:      source.lang.swift.ref.var.global (4:5-4:9)

--- a/test/SourceKit/CursorInfo/cursor_symlink.swift
+++ b/test/SourceKit/CursorInfo/cursor_symlink.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t.dir
-// RUN: mkdir -p %t.dir
+// RUN: %empty-directory(%t.dir)
 // RUN: echo "let foo = 0" > %t.dir/real.swift
 // RUN: ln -s %t.dir/real.swift %t.dir/linked.swift
 // RUN: %sourcekitd-test -req=cursor -pos=1:5 %t.dir/linked.swift -- %t.dir/real.swift | %FileCheck %s

--- a/test/SourceKit/CursorInfo/cursor_usr.swift
+++ b/test/SourceKit/CursorInfo/cursor_usr.swift
@@ -8,8 +8,7 @@ struct S1 {}
 
 func foo(x: FooStruct1) -> S1 {}
 
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %swiftc_driver -emit-module -o %t/FooSwiftModule.swiftmodule %S/Inputs/FooSwiftModule.swift
 
 // Sanity check that we have identical responses when things work.

--- a/test/SourceKit/DocSupport/doc_swift_module.swift
+++ b/test/SourceKit/DocSupport/doc_swift_module.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t.mod
-// RUN: mkdir -p %t.mod
+// RUN: %empty-directory(%t.mod)
 // RUN: %swift -emit-module -o %t.mod/cake.swiftmodule %S/Inputs/cake.swift -parse-as-library
 // RUN: %sourcekitd-test -req=doc-info -module cake -- -I %t.mod > %t.response
 // RUN: diff -u %s.response %t.response

--- a/test/SourceKit/Indexing/index_module_cycle.swift
+++ b/test/SourceKit/Indexing/index_module_cycle.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %swift -emit-module -o %t %S/Inputs/cycle-depend/A.swift -I %S/Inputs/cycle-depend -enable-source-import
 // RUN: %swift -emit-module -o %t %S/Inputs/cycle-depend/B.swift -I %S/Inputs/cycle-depend -enable-source-import
 

--- a/test/SourceKit/Indexing/index_module_missing_depend.swift
+++ b/test/SourceKit/Indexing/index_module_missing_depend.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %swift -emit-module -o %t %S/Inputs/cycle-depend/A.swift -I %S/Inputs/cycle-depend -enable-source-import
 
 // RUN: not %sourcekitd-test -req=index %t/A.swiftmodule -- %t/A.swiftmodule 2>&1 | %FileCheck %s

--- a/test/SourceKit/Indexing/index_with_swift_module.swift
+++ b/test/SourceKit/Indexing/index_with_swift_module.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %swift -emit-module -o %t/test_module.swiftmodule %S/Inputs/test_module.swift
 
 // RUN: %sourcekitd-test -req=index %s -- %s -I %t | %FileCheck %s

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift
@@ -4,8 +4,7 @@ var x: FooClassBase
 
 // REQUIRES: objc_interop
 
-// RUN: rm -rf %t.overlays
-// RUN: mkdir -p %t.overlays
+// RUN: %empty-directory(%t.overlays)
 //
 // RUN: %swift -emit-module -o %t.overlays -F %S/../Inputs/libIDE-mock-sdk %S/Inputs/Foo.swift
 //

--- a/test/SourceKit/InterfaceGen/gen_mixed_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_mixed_module.swift
@@ -1,8 +1,7 @@
 var x = 10
 
 // REQUIRES: objc_interop
-// RUN: rm -rf %t.overlays
-// RUN: mkdir -p %t.overlays
+// RUN: %empty-directory(%t.overlays)
 
 // RUN: %swift -emit-module -o %t.overlays -F %S/../Inputs/libIDE-mock-sdk %S/../Inputs/libIDE-mock-sdk/Mixed.swift -import-underlying-module -module-name Mixed -disable-objc-attr-requires-foundation-module
 // RUN: %sourcekitd-test -req=interface-gen -module Mixed -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk %mcp_opt %clang-importer-sdk | %FileCheck -check-prefix=CHECK1 %s

--- a/test/SourceKit/InterfaceGen/gen_swift_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_swift_module.swift
@@ -4,8 +4,7 @@ func f(s : inout [Int]) {
   s.sort()
 }
 
-// RUN: rm -rf %t.mod
-// RUN: mkdir -p %t.mod
+// RUN: %empty-directory(%t.mod)
 // RUN: %swift -emit-module -o %t.mod/swift_mod.swiftmodule %S/Inputs/swift_mod.swift -parse-as-library
 // RUN: %sourcekitd-test -req=interface-gen -module swift_mod -- -I %t.mod > %t.response
 // RUN: diff -u %s.response %t.response

--- a/test/SourceKit/Sema/sema_symlink.swift
+++ b/test/SourceKit/Sema/sema_symlink.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t.dir
-// RUN: mkdir -p %t.dir
+// RUN: %empty-directory(%t.dir)
 // RUN: echo "let foo: Int = goo" > %t.dir/real.swift
 // RUN: ln -s %t.dir/real.swift %t.dir/linked.swift
 // RUN: %sourcekitd-test -req=sema %t.dir/linked.swift -- %t.dir/real.swift | %sed_clean > %t.link.response

--- a/test/attr/accessibility_multifile.swift
+++ b/test/attr/accessibility_multifile.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -parse %t/file1.swift -primary-file %t/file2.swift -verify
 

--- a/test/attr/accessibility_print.swift
+++ b/test/attr/accessibility_print.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-ide-test -skip-deinit=false -print-ast-typechecked -print-accessibility -source-filename=%s | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-SRC
 // RUN: %target-swift-frontend -emit-module-path %t/accessibility_print.swiftmodule %s
 // RUN: %target-swift-ide-test -skip-deinit=false -print-module -print-accessibility -module-to-print=accessibility_print -I %t -source-filename=%s | %FileCheck %s

--- a/test/attr/open.swift
+++ b/test/attr/open.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -emit-module -c %S/Inputs/OpenHelpers.swift -o %t/OpenHelpers.swiftmodule
 // RUN: %target-parse-verify-swift -I %t
 

--- a/test/attr/testable.swift
+++ b/test/attr/testable.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -enable-testing -o %t %S/../Inputs/empty.swift
 // RUN: %target-swift-frontend -parse -I %t -I %S/Inputs/custom-modules %s -verify
 // RUN: %target-swift-frontend -parse -I %t -I %S/Inputs/custom-modules %s -disable-testable-attr-requires-testable-module -DIMPORTS_ONLY

--- a/test/attr/warn_unqualified_access.swift
+++ b/test/attr/warn_unqualified_access.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module-path %t/Other1.swiftmodule -module-name Other1 %S/Inputs/warn_unqualified_access_other.swift
 // RUN: %target-swift-frontend -emit-module-path %t/Other2.swiftmodule -module-name Other2 %S/Inputs/warn_unqualified_access_other.swift
 // RUN: %target-swift-frontend -I %t -parse %s -verify

--- a/test/decl/class/inheritance_protocol_multi_module.swift
+++ b/test/decl/class/inheritance_protocol_multi_module.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module-path %t/Mod.swiftmodule -module-name Mod %s
 // RUN: %target-swift-frontend -parse -verify -I %t %S/Inputs/inheritance_protocol_multi_module_2.swift
 

--- a/test/decl/import/import.swift
+++ b/test/decl/import/import.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: echo "public struct X {}; public var x = X()" | %target-swift-frontend -module-name import_builtin -parse-stdlib -emit-module -o %t -
 // RUN: echo "public func foo() -> Int { return false }" > %t/import_text.swift
 // RUN: echo "public func pho$(printf '\xC3\xBB')x() -> Int { return false }" > %t/fran$(printf '\xC3\xA7')ais.swift

--- a/test/decl/precedencegroup/circularity.swift
+++ b/test/decl/precedencegroup/circularity.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/ExternPrecedences.swift
 
 // RUN: %target-parse-verify-swift -I%t

--- a/test/decl/protocol/conforms/placement.swift
+++ b/test/decl/protocol/conforms/placement.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/Inputs/placement_module_A.swift -emit-module -parse-as-library -o %t
 // RUN: %target-swift-frontend -I %t %S/Inputs/placement_module_B.swift -emit-module -parse-as-library -o %t
 

--- a/test/decl/protocol/special/Error.swift
+++ b/test/decl/protocol/special/Error.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: %target-swift-frontend -parse -verify -primary-file %t/main.swift %S/Inputs/Error_other.swift
 

--- a/test/decl/var/lazy_properties_multi_file.swift
+++ b/test/decl/var/lazy_properties_multi_file.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -verify -O -primary-file %s %S/Inputs/lazy_properties_multi_file_2.swift -c -o %t/lazy_properties_multi_file.o
 
 class MyClass {

--- a/test/expr/cast/array_downcast_Foundation.swift
+++ b/test/expr/cast/array_downcast_Foundation.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // FIXME: BEGIN -enable-source-import hackaround
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift

--- a/test/expr/unary/selector/fixits.swift
+++ b/test/expr/unary/selector/fixits.swift
@@ -1,9 +1,7 @@
 // REQUIRES: objc_interop
 
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
-// RUN: rm -rf %t.overlays
-// RUN: mkdir -p %t.overlays
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t.overlays)
 
 // FIXME: BEGIN -enable-source-import hackaround
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t.overlays %clang-importer-sdk-path/swift-modules/ObjectiveC.swift
@@ -16,8 +14,8 @@
 
 // Copy the source, apply the Fix-Its, and compile it again, making
 // sure that we've cleaned up all of the deprecation warnings.
-// RUN: mkdir -p %t.sources
-// RUN: mkdir -p %t.remapping
+// RUN: %empty-directory(%t.sources)
+// RUN: %empty-directory(%t.remapping)
 // RUN: cp %s %t.sources/fixits.swift
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t.overlays) -parse %t.sources/fixits.swift -fixit-all -emit-fixits-path %t.remapping/fixits.remap
 // RUN: %utils/apply-fixit-edits.py %t.remapping

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -954,6 +954,8 @@ config.substitutions.append(('%utils', config.swift_utils))
 config.substitutions.append(('%line-directive', config.line_directive))
 config.substitutions.append(('%gyb', config.gyb))
 config.substitutions.append(('%rth', config.rth))
+config.substitutions.append(
+    ('%empty-directory\(([^)]+)\)', 'rm -rf \\1 && mkdir -p \\1'))
 
 config.substitutions.append(('%target-sil-opt', config.target_sil_opt))
 config.substitutions.append(('%target-sil-extract', config.target_sil_extract))

--- a/test/multifile/error-type/two-modules/main.swift
+++ b/test/multifile/error-type/two-modules/main.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: mkdir -p %t/linker
 // RUN: %target-build-swift -emit-module -c %S/library.swift -o %t/linker/library.o

--- a/test/multifile/error-type/two-modules/main.swift
+++ b/test/multifile/error-type/two-modules/main.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: mkdir -p %t/linker
+// RUN: %empty-directory(%t/linker)
 // RUN: %target-build-swift -emit-module -c %S/library.swift -o %t/linker/library.o
 // RUN: %target-build-swift -emit-library -c %S/library.swift -o %t/linker/library.o
 // RUN: %target-build-swift %S/main.swift %t/linker/library.o -I %t/linker/ -L %t/linker/ -o %t/linker/main

--- a/test/multifile/protocol-conformance-member.swift
+++ b/test/multifile/protocol-conformance-member.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -emit-library %s %S/Inputs/protocol-conformance-member-helper.swift -o %t/libTest.dylib -module-name Test
 // RUN: llvm-nm %t/libTest.dylib | %FileCheck %s
 

--- a/test/multifile/synthesized-accessors/two-modules/main.swift
+++ b/test/multifile/synthesized-accessors/two-modules/main.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: mkdir -p %t/linker
 // RUN: %target-build-swift -emit-module -c %S/library.swift -o %t/linker/library.o

--- a/test/multifile/synthesized-accessors/two-modules/main.swift
+++ b/test/multifile/synthesized-accessors/two-modules/main.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: mkdir -p %t/linker
+// RUN: %empty-directory(%t/linker)
 // RUN: %target-build-swift -emit-module -c %S/library.swift -o %t/linker/library.o
 // RUN: %target-build-swift -emit-library -c %S/library.swift -o %t/linker/library.o
 // RUN: %target-build-swift %S/main.swift %t/linker/library.o -I %t/linker/ -L %t/linker/ -o %t/linker/main

--- a/test/multifile/typealias/one-module/main.swift
+++ b/test/multifile/typealias/one-module/main.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift %S/main.swift %S/library.swift
 // RUN: %target-build-swift -g %S/main.swift %S/library.swift

--- a/test/multifile/typealias/two-modules/main.swift
+++ b/test/multifile/typealias/two-modules/main.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: mkdir -p %t/linker
 // RUN: %target-build-swift -emit-module -c %S/library.swift -o %t/linker/library.o

--- a/test/multifile/typealias/two-modules/main.swift
+++ b/test/multifile/typealias/two-modules/main.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: mkdir -p %t/linker
+// RUN: %empty-directory(%t/linker)
 // RUN: %target-build-swift -emit-module -c %S/library.swift -o %t/linker/library.o
 // RUN: %target-build-swift -emit-library -c %S/library.swift -o %t/linker/library.o
 // RUN: %target-build-swift %S/main.swift %t/linker/library.o -I %t/linker/ -L %t/linker/ -o %t/linker/main

--- a/test/sil-opt/emit-sib.swift
+++ b/test/sil-opt/emit-sib.swift
@@ -1,6 +1,6 @@
 // <rdar://problem/27394237> IR generation CFG order isn't deterministic (XFAIL: test/sil-opt/emit-sib.swift)
 
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %target-swiftc_driver -emit-sib %s -module-name test -assert-config Release -O -o %t/a-opt.sib
 // RUN: %target-swiftc_driver -emit-ir %t/a-opt.sib -module-name test -assert-config Release -o %t/test.ll

--- a/test/stdlib/AnyHashableCasts.swift.gyb
+++ b/test/stdlib/AnyHashableCasts.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t  &&  mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: %gyb %s -o %t/AnyHashableCasts.swift
 // RUN: %target-build-swift -g -module-name a %t/AnyHashableCasts.swift -o %t.out

--- a/test/stdlib/ArrayBridge.swift.gyb
+++ b/test/stdlib/ArrayBridge.swift.gyb
@@ -10,8 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: %gyb %s -o %t/ArrayBridge.swift
 // RUN: %target-clang %S/Inputs/ArrayBridge/ArrayBridge.m -c -o %t/ArrayBridgeObjC.o -g

--- a/test/stdlib/BridgeIdAsAny.swift.gyb
+++ b/test/stdlib/BridgeIdAsAny.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t  &&  mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: %gyb %s -o %t/BridgeIdAsAny.swift
 // RUN: %target-build-swift -g -module-name a %t/BridgeIdAsAny.swift -o %t.out

--- a/test/stdlib/Builtins.swift
+++ b/test/stdlib/Builtins.swift
@@ -9,7 +9,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 //   note: building with -Onone to test debug-mode-only safety checks
 // RUN: %target-build-swift %s -parse-stdlib -Xfrontend -disable-access-control -Onone -o %t/Builtins
 // RUN: %target-run %t/Builtins

--- a/test/stdlib/CharacterTraps.swift
+++ b/test/stdlib/CharacterTraps.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out_Debug
 // RUN: %target-build-swift %s -o %t/a.out_Release -O
 //

--- a/test/stdlib/CommandLine.swift
+++ b/test/stdlib/CommandLine.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 //
 // RUN: %target-build-swift %S/Inputs/CommandLineStressTest/CommandLineStressTest.swift -parse-as-library -force-single-frontend-invocation -module-name CommandLineStressTestSwift -emit-object -o %t/CommandLineStressTestSwift.o

--- a/test/stdlib/DictionaryTraps.swift
+++ b/test/stdlib/DictionaryTraps.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out_Debug
 // RUN: %target-build-swift %s -o %t/a.out_Release -O
 //

--- a/test/stdlib/DictionaryUnchecked.swift
+++ b/test/stdlib/DictionaryUnchecked.swift
@@ -1,4 +1,4 @@
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out -Ounchecked
 //
 // RUN: %target-run %t/a.out

--- a/test/stdlib/Float.swift
+++ b/test/stdlib/Float.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 
 // RUN: echo "typealias TestFloat = Float" > %t/float_type.swift

--- a/test/stdlib/FloatingPoint.swift.gyb
+++ b/test/stdlib/FloatingPoint.swift.gyb
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t && %gyb %s -o %t/FloatingPoint.swift
+// RUN: %empty-directory(%t)
+// RUN: %gyb %s -o %t/FloatingPoint.swift
 // RUN: %line-directive %t/FloatingPoint.swift -- %target-build-swift -parse-stdlib %t/FloatingPoint.swift -o %t/a.out
 // RUN: %line-directive %t/FloatingPoint.swift -- %target-run %t/a.out
 // REQUIRES: executable_test

--- a/test/stdlib/IntervalTraps.swift
+++ b/test/stdlib/IntervalTraps.swift
@@ -9,8 +9,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out_Debug
 // RUN: %target-build-swift %s -o %t/a.out_Release -O
 //

--- a/test/stdlib/Mirror.swift
+++ b/test/stdlib/Mirror.swift
@@ -9,8 +9,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: if [ %target-runtime == "objc" ]; \
 // RUN: then \

--- a/test/stdlib/NumericParsing.swift.gyb
+++ b/test/stdlib/NumericParsing.swift.gyb
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 // -*- swift -*-
-// RUN: rm -rf %t ; mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %gyb -DCMAKE_SIZEOF_VOID_P=%target-ptrsize %s -o %t/NumericParsing.swift
 // RUN: %line-directive %t/NumericParsing.swift -- %target-build-swift %t/NumericParsing.swift -o %t/a.out
 // RUN: %line-directive %t/NumericParsing.swift -- %target-run %t/a.out

--- a/test/stdlib/OptionalTraps.swift
+++ b/test/stdlib/OptionalTraps.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/Assert_Debug -Onone
 // RUN: %target-build-swift %s -Xfrontend -disable-access-control -o %t/Assert_Release -O
 // RUN: %target-build-swift %s -Xfrontend -disable-access-control -o %t/Assert_Unchecked -Ounchecked

--- a/test/stdlib/Print.swift
+++ b/test/stdlib/Print.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -c -force-single-frontend-invocation -parse-as-library -emit-module -emit-module-path %t/PrintTestTypes.swiftmodule -o %t/PrintTestTypes.o %S/Inputs/PrintTestTypes.swift
 // RUN: %target-build-swift %s -Xlinker %t/PrintTestTypes.o -I %t -L %t -o %t/main
 // RUN: %target-run %t/main

--- a/test/stdlib/PrintArray.swift
+++ b/test/stdlib/PrintArray.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -c -force-single-frontend-invocation -parse-as-library -emit-module -emit-module-path %t/PrintTestTypes.swiftmodule -o %t/PrintTestTypes.o %S/Inputs/PrintTestTypes.swift
 // RUN: %target-build-swift %s -Xlinker %t/PrintTestTypes.o -I %t -L %t -o %t/main
 // RUN: %target-run %t/main

--- a/test/stdlib/PrintClass.swift
+++ b/test/stdlib/PrintClass.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -c -force-single-frontend-invocation -parse-as-library -emit-module -emit-module-path %t/PrintTestTypes.swiftmodule -o %t/PrintTestTypes.o %S/Inputs/PrintTestTypes.swift
 // RUN: %target-build-swift %s -Xlinker %t/PrintTestTypes.o -I %t -L %t -o %t/main
 // RUN: %target-run %t/main

--- a/test/stdlib/PrintFloat.swift
+++ b/test/stdlib/PrintFloat.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -c -force-single-frontend-invocation -parse-as-library -emit-module -emit-module-path %t/PrintTestTypes.swiftmodule -o %t/PrintTestTypes.o %S/Inputs/PrintTestTypes.swift
 // RUN: %target-build-swift %s -Xlinker %t/PrintTestTypes.o -I %t -L %t -o %t/main.out
 // RUN: %target-run %t/main.out

--- a/test/stdlib/PrintString.swift
+++ b/test/stdlib/PrintString.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -c -force-single-frontend-invocation -parse-as-library -emit-module -emit-module-path %t/PrintTestTypes.swiftmodule -o %t/PrintTestTypes.o %S/Inputs/PrintTestTypes.swift
 // RUN: %target-build-swift %s -Xlinker %t/PrintTestTypes.o -I %t -L %t -o %t/main
 // RUN: %target-run %t/main

--- a/test/stdlib/PrintStruct.swift
+++ b/test/stdlib/PrintStruct.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -c -force-single-frontend-invocation -parse-as-library -emit-module -emit-module-path %t/PrintTestTypes.swiftmodule -o %t/PrintTestTypes.o %S/Inputs/PrintTestTypes.swift
 // RUN: %target-build-swift %s -Xlinker %t/PrintTestTypes.o -I %t -L %t -o %t/main
 // RUN: %target-run %t/main

--- a/test/stdlib/PrintTuple.swift
+++ b/test/stdlib/PrintTuple.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -c -force-single-frontend-invocation -parse-as-library -emit-module -emit-module-path %t/PrintTestTypes.swiftmodule -o %t/PrintTestTypes.o %S/Inputs/PrintTestTypes.swift
 // RUN: %target-build-swift %s -Xlinker %t/PrintTestTypes.o -I %t -L %t -o %t/main
 // RUN: %target-run %t/main

--- a/test/stdlib/RangeTraps.swift
+++ b/test/stdlib/RangeTraps.swift
@@ -9,8 +9,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out_Debug
 // RUN: %target-build-swift %s -o %t/a.out_Release -O
 //

--- a/test/stdlib/Reflection.swift
+++ b/test/stdlib/Reflection.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t  &&  mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -parse-stdlib %s -module-name Reflection -o %t/a.out
 // RUN: %S/timeout.sh 360 %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test

--- a/test/stdlib/Reflection_objc.swift
+++ b/test/stdlib/Reflection_objc.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t  &&  mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: %target-clang %S/Inputs/Mirror/Mirror.mm -c -o %t/Mirror.mm.o -g
 // RUN: %target-build-swift -parse-stdlib %s -module-name Reflection -I %S/Inputs/Mirror/ -Xlinker %t/Mirror.mm.o -o %t/a.out

--- a/test/stdlib/Runtime.swift.gyb
+++ b/test/stdlib/Runtime.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t  &&  mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: %gyb %s -o %t/Runtime.swift
 // RUN: %target-build-swift -parse-stdlib -module-name a %t/Runtime.swift -o %t.out

--- a/test/stdlib/RuntimeObjC.swift
+++ b/test/stdlib/RuntimeObjC.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t  &&  mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: %target-clang %S/Inputs/Mirror/Mirror.mm -c -o %t/Mirror.mm.o -g
 // RUN: %target-build-swift -parse-stdlib -Xfrontend -disable-access-control -module-name a -I %S/Inputs/Mirror/ -Xlinker %t/Mirror.mm.o %s -o %t.out

--- a/test/stdlib/SegmentAlignment.c
+++ b/test/stdlib/SegmentAlignment.c
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t  &&  mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: xcrun -sdk %target-sdk-name %clang -c -arch %target-cpu %s -o %t/SegmentAlignment.o
 // RUN: %target-build-swift %S/Inputs/SegmentAlignment.swift -Xlinker %t/SegmentAlignment.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s

--- a/test/stdlib/SetTraps.swift
+++ b/test/stdlib/SetTraps.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out_Debug
 // RUN: %target-build-swift %s -o %t/a.out_Release -O
 //

--- a/test/stdlib/SetTrapsObjC.swift
+++ b/test/stdlib/SetTrapsObjC.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out_Debug
 // RUN: %target-build-swift %s -o %t/a.out_Release -O
 //

--- a/test/stdlib/StringTraps.swift
+++ b/test/stdlib/StringTraps.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out_Debug
 // RUN: %target-build-swift %s -o %t/a.out_Release -O
 //

--- a/test/stdlib/SwiftObjectNSObject.swift
+++ b/test/stdlib/SwiftObjectNSObject.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: rm -rf %t  &&  mkdir -p %t
+// RUN: %empty-directory(%t)
 // 
 // RUN: %target-clang %S/Inputs/SwiftObjectNSObject/SwiftObjectNSObject.m -c -o %t/SwiftObjectNSObject.o -g
 // RUN: %target-build-swift %s -I %S/Inputs/SwiftObjectNSObject/ -Xlinker %t/SwiftObjectNSObject.o -o %t/SwiftObjectNSObject

--- a/test/stdlib/TestCalendar.swift
+++ b/test/stdlib/TestCalendar.swift
@@ -6,8 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: %target-clang %S/Inputs/FoundationBridge/FoundationBridge.m -c -o %t/FoundationBridgeObjC.o -g
 // RUN: %target-build-swift %s -I %S/Inputs/FoundationBridge/ -Xlinker %t/FoundationBridgeObjC.o -o %t/TestCalendar

--- a/test/stdlib/TestData.swift
+++ b/test/stdlib/TestData.swift
@@ -6,8 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: %target-clang %S/Inputs/FoundationBridge/FoundationBridge.m -c -o %t/FoundationBridgeObjC.o -g
 // RUN: %target-build-swift %s -I %S/Inputs/FoundationBridge/ -Xlinker %t/FoundationBridgeObjC.o -o %t/TestData

--- a/test/stdlib/TestLocale.swift
+++ b/test/stdlib/TestLocale.swift
@@ -6,8 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: %target-clang %S/Inputs/FoundationBridge/FoundationBridge.m -c -o %t/FoundationBridgeObjC.o -g
 // RUN: %target-build-swift %s -I %S/Inputs/FoundationBridge/ -Xlinker %t/FoundationBridgeObjC.o -o %t/TestLocale

--- a/test/stdlib/TestTimeZone.swift
+++ b/test/stdlib/TestTimeZone.swift
@@ -6,8 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: %target-clang %S/Inputs/FoundationBridge/FoundationBridge.m -c -o %t/FoundationBridgeObjC.o -g
 // RUN: %target-build-swift %s -I %S/Inputs/FoundationBridge/ -Xlinker %t/FoundationBridgeObjC.o -o %t/TestTimeZone

--- a/test/stdlib/UnavailableStringAPIs.swift.gyb
+++ b/test/stdlib/UnavailableStringAPIs.swift.gyb
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %gyb -D_runtime=%target-runtime %s -o %t/main.swift
 // RUN: %line-directive %t/main.swift -- %target-swift-frontend -parse -verify %t/main.swift
 

--- a/test/stdlib/WeakMirror.swift
+++ b/test/stdlib/WeakMirror.swift
@@ -9,8 +9,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: if [ %target-runtime == "objc" ]; \
 // RUN: then \

--- a/test/stdlib/tgmath_optimized.swift
+++ b/test/stdlib/tgmath_optimized.swift
@@ -1,4 +1,4 @@
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out -Ounchecked
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test

--- a/validation-test/Driver/Dependencies/rdar25405605.swift
+++ b/validation-test/Driver/Dependencies/rdar25405605.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: cp %s %t/main.swift
 // RUN: cp %S/Inputs/rdar25405605/helper-1.swift %t/helper.swift

--- a/validation-test/Driver/many-inputs.swift
+++ b/validation-test/Driver/many-inputs.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // This limit was chosen because multi-threaded compilation broke here on OS X
 // at one point.

--- a/validation-test/Reflection/existentials.swift
+++ b/validation-test/Reflection/existentials.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/existentials
 // RUN: %target-run %target-swift-reflection-test %t/existentials | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop

--- a/validation-test/Reflection/functions.swift
+++ b/validation-test/Reflection/functions.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/functions
 // RUN: %target-run %target-swift-reflection-test %t/functions | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 

--- a/validation-test/Reflection/functions_objc.swift
+++ b/validation-test/Reflection/functions_objc.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/functions
 // RUN: %target-run %target-swift-reflection-test %t/functions | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop

--- a/validation-test/Reflection/inherits_NSObject.swift
+++ b/validation-test/Reflection/inherits_NSObject.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/inherits_NSObject
 // RUN: %target-run %target-swift-reflection-test %t/inherits_NSObject | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 

--- a/validation-test/Reflection/reflect_Array.swift
+++ b/validation-test/Reflection/reflect_Array.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Array
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Array 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop

--- a/validation-test/Reflection/reflect_Bool.swift
+++ b/validation-test/Reflection/reflect_Bool.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Bool
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Bool 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop

--- a/validation-test/Reflection/reflect_Character.swift
+++ b/validation-test/Reflection/reflect_Character.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Character
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Character 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop

--- a/validation-test/Reflection/reflect_Dictionary.swift
+++ b/validation-test/Reflection/reflect_Dictionary.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Dictionary
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Dictionary 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop

--- a/validation-test/Reflection/reflect_Double.swift
+++ b/validation-test/Reflection/reflect_Double.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Double
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Double 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop

--- a/validation-test/Reflection/reflect_Float.swift
+++ b/validation-test/Reflection/reflect_Float.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Float
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Float 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop

--- a/validation-test/Reflection/reflect_Int.swift
+++ b/validation-test/Reflection/reflect_Int.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Int
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Int 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop

--- a/validation-test/Reflection/reflect_Int16.swift
+++ b/validation-test/Reflection/reflect_Int16.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Int16
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Int16 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop

--- a/validation-test/Reflection/reflect_Int32.swift
+++ b/validation-test/Reflection/reflect_Int32.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Int32
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Int32 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop

--- a/validation-test/Reflection/reflect_Int64.swift
+++ b/validation-test/Reflection/reflect_Int64.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Int64
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Int64 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop

--- a/validation-test/Reflection/reflect_Int8.swift
+++ b/validation-test/Reflection/reflect_Int8.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Int8
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Int8 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop

--- a/validation-test/Reflection/reflect_NSArray.swift
+++ b/validation-test/Reflection/reflect_NSArray.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_NSArray
 // RUN: %target-run %target-swift-reflection-test %t/reflect_NSArray 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop

--- a/validation-test/Reflection/reflect_NSNumber.swift
+++ b/validation-test/Reflection/reflect_NSNumber.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_NSNumber
 // RUN: %target-run %target-swift-reflection-test %t/reflect_NSNumber 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop

--- a/validation-test/Reflection/reflect_NSSet.swift
+++ b/validation-test/Reflection/reflect_NSSet.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_NSSet
 // RUN: %target-run %target-swift-reflection-test %t/reflect_NSSet 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop

--- a/validation-test/Reflection/reflect_NSString.swift
+++ b/validation-test/Reflection/reflect_NSString.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_NSString
 // RUN: %target-run %target-swift-reflection-test %t/reflect_NSString 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop

--- a/validation-test/Reflection/reflect_Set.swift
+++ b/validation-test/Reflection/reflect_Set.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Set
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Set 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop

--- a/validation-test/Reflection/reflect_String.swift
+++ b/validation-test/Reflection/reflect_String.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_String
 // RUN: %target-run %target-swift-reflection-test %t/reflect_String 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop

--- a/validation-test/Reflection/reflect_UInt.swift
+++ b/validation-test/Reflection/reflect_UInt.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_UInt
 // RUN: %target-run %target-swift-reflection-test %t/reflect_UInt 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop

--- a/validation-test/Reflection/reflect_UInt16.swift
+++ b/validation-test/Reflection/reflect_UInt16.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_UInt16
 // RUN: %target-run %target-swift-reflection-test %t/reflect_UInt16 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop

--- a/validation-test/Reflection/reflect_UInt32.swift
+++ b/validation-test/Reflection/reflect_UInt32.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_UInt32
 // RUN: %target-run %target-swift-reflection-test %t/reflect_UInt32 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop

--- a/validation-test/Reflection/reflect_UInt64.swift
+++ b/validation-test/Reflection/reflect_UInt64.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_UInt64
 // RUN: %target-run %target-swift-reflection-test %t/reflect_UInt64 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop

--- a/validation-test/Reflection/reflect_UInt8.swift
+++ b/validation-test/Reflection/reflect_UInt8.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_UInt8
 // RUN: %target-run %target-swift-reflection-test %t/reflect_UInt8 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop

--- a/validation-test/Reflection/reflect_empty_class.swift
+++ b/validation-test/Reflection/reflect_empty_class.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_empty_class
 // RUN: %target-run %target-swift-reflection-test %t/reflect_empty_class 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop

--- a/validation-test/Reflection/reflect_multiple_types.swift
+++ b/validation-test/Reflection/reflect_multiple_types.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_multiple_types
 // RUN: %target-run %target-swift-reflection-test %t/reflect_multiple_types 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop

--- a/validation-test/Serialization/serialization_loops.swift
+++ b/validation-test/Serialization/serialization_loops.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -import-objc-header %S/Inputs/serialization_loops.h -o %t %S/Inputs/serialization_loops_helper.swift
 // RUN: %target-swift-frontend -emit-module -import-objc-header %S/Inputs/serialization_loops.h -I %t -o %t %S/Inputs/serialization_loops_helper2.swift
 // RUN: %target-swift-frontend -emit-sil -import-objc-header %S/Inputs/serialization_loops.h -I %t -o /dev/null %s

--- a/validation-test/StdlibUnittest/CommandLine.swift
+++ b/validation-test/StdlibUnittest/CommandLine.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/main.out
 // RUN: %target-run %t/main.out | %FileCheck -check-prefix=CHECK-EMPTY %s
 // RUN: %target-run %t/main.out --abc | %FileCheck -check-prefix=CHECK-1 %s

--- a/validation-test/execution/dsohandle-multi-module.swift
+++ b/validation-test/execution/dsohandle-multi-module.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: (cd %t && %target-build-swift %S/Inputs/dsohandle-first.swift -emit-library -emit-module -module-name first)
 // RUN: (cd %t && %target-build-swift %S/Inputs/dsohandle-second.swift -emit-library -emit-module -module-name second)

--- a/validation-test/execution/interpret-with-dependencies-linux.swift
+++ b/validation-test/execution/interpret-with-dependencies-linux.swift
@@ -8,11 +8,11 @@
 // CHECK: {{okay}}
 
 // Now test a dependency on a library in the compiler's resource directory.
-// RUN: mkdir -p %t/rsrc/%target-sdk-name/
+// RUN: %empty-directory(%t/rsrc/%target-sdk-name)
 // RUN: ln -s %t/libabc.so %t/rsrc/%target-sdk-name/
 // RUN: ln -s %platform-module-dir/../* %t/rsrc/%target-sdk-name/
 // RUN: ln -s %platform-module-dir/../../shims %t/rsrc/
-// RUN: mkdir -p %t/other
+// RUN: %empty-directory(%t/other)
 // RUN: ln -s %t/libfoo.so %t/other
 
 // RUN: %swift_driver -I %S/Inputs/custom-modules -L%t/other -resource-dir %t/rsrc/ %s | %FileCheck %s

--- a/validation-test/execution/interpret-with-dependencies-linux.swift
+++ b/validation-test/execution/interpret-with-dependencies-linux.swift
@@ -1,5 +1,5 @@
 // REQUIRES: OS=linux-gnu
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: echo 'int abc = 42;' | %clang -x c - -shared -fPIC -o %t/libabc.so
 // RUN: echo 'int test() { extern int abc; return abc; }' | %clang -x c - -L%t -shared -fPIC -labc -o %t/libfoo.so

--- a/validation-test/execution/interpret-with-dependencies.swift
+++ b/validation-test/execution/interpret-with-dependencies.swift
@@ -1,5 +1,5 @@
 // REQUIRES: OS=macosx
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: echo 'int abc = 42;' | %clang -x c - -dynamiclib -Xlinker -install_name -Xlinker libabc.dylib -o %t/libabc.dylib
 // RUN: echo 'int test() { extern int abc; return abc; }' | %clang -x c - -L%t -dynamiclib -labc -o %t/libfoo.dylib

--- a/validation-test/execution/interpret-with-dependencies.swift
+++ b/validation-test/execution/interpret-with-dependencies.swift
@@ -8,11 +8,11 @@
 // CHECK: {{okay}}
 
 // Now test a dependency on a library in the compiler's resource directory.
-// RUN: mkdir -p %t/rsrc/%target-sdk-name/
+// RUN: %empty-directory(%t/rsrc/%target-sdk-name)
 // RUN: ln -s %t/libabc.dylib %t/rsrc/%target-sdk-name/
 // RUN: ln -s %platform-module-dir/../* %t/rsrc/%target-sdk-name/
 // RUN: ln -s %platform-module-dir/../../shims %t/rsrc/
-// RUN: mkdir -p %t/other
+// RUN: %empty-directory(%t/other)
 // RUN: ln -s %t/libfoo.dylib %t/other
 
 // RUN: %swift_driver -I %S/Inputs/custom-modules -L%t/other -resource-dir %t/rsrc/ %s | %FileCheck %s

--- a/validation-test/execution/testability.swift
+++ b/validation-test/execution/testability.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // This file is intended to match the run lines in
 // test/Interpreter/testability.swift, but with -O added to all compilations.

--- a/validation-test/stdlib/ArrayBridging.swift
+++ b/validation-test/stdlib/ArrayBridging.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: %target-clang -fobjc-arc %S/Inputs/SlurpFastEnumeration/SlurpFastEnumeration.m -c -o %t/SlurpFastEnumeration.o
 // RUN: echo '#sourceLocation(file: "%s", line: 1)' > "%t/main.swift" && cat "%s" >> "%t/main.swift" && chmod -w "%t/main.swift"

--- a/validation-test/stdlib/ArrayNew.swift.gyb
+++ b/validation-test/stdlib/ArrayNew.swift.gyb
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: %gyb %s -o %t/main.swift
 // RUN: if [ %target-runtime == "objc" ]; then \

--- a/validation-test/stdlib/ArrayTraps.swift.gyb
+++ b/validation-test/stdlib/ArrayTraps.swift.gyb
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %gyb %s -o %t/ArrayTraps.swift
 // RUN: %line-directive %t/ArrayTraps.swift -- %target-build-swift %t/ArrayTraps.swift -o %t/a.out_Debug
 // RUN: %line-directive %t/ArrayTraps.swift -- %target-build-swift %t/ArrayTraps.swift -o %t/a.out_Release -O

--- a/validation-test/stdlib/ArrayTrapsObjC.swift.gyb
+++ b/validation-test/stdlib/ArrayTrapsObjC.swift.gyb
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %gyb %s -o %t/ArrayTraps.swift
 // RUN: %line-directive %t/ArrayTraps.swift -- %target-build-swift %t/ArrayTraps.swift -o %t/a.out_Debug
 // RUN: %line-directive %t/ArrayTraps.swift -- %target-build-swift %t/ArrayTraps.swift -o %t/a.out_Release -O

--- a/validation-test/stdlib/Assert.swift
+++ b/validation-test/stdlib/Assert.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -Xfrontend -disable-access-control -o %t/Assert_Debug
 // RUN: %target-build-swift %s -Xfrontend -disable-access-control -o %t/Assert_Release -O
 // RUN: %target-build-swift %s -Xfrontend -disable-access-control -o %t/Assert_Unchecked -Ounchecked

--- a/validation-test/stdlib/AtomicInt.swift
+++ b/validation-test/stdlib/AtomicInt.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: %target-build-swift -module-name a %s -o %t.out -O
 // RUN: %target-run %t.out

--- a/validation-test/stdlib/CollectionCasts.swift.gyb
+++ b/validation-test/stdlib/CollectionCasts.swift.gyb
@@ -9,8 +9,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %gyb %s -o %t/CollectionCasts.swift
 // RUN: %line-directive %t/CollectionCasts.swift -- %target-build-swift %t/CollectionCasts.swift -o %t/a.out
 // RUN: %line-directive %t/CollectionCasts.swift -- %target-run %t/a.out 2>&1

--- a/validation-test/stdlib/CoreData.swift
+++ b/validation-test/stdlib/CoreData.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
 
 // RUN: %target-clang %S/Inputs/CoreDataHelper/CoreDataHelper.m -c -o %t/CoreDataHelper.o -g -fmodules
 // RUN: %target-build-swift %s -import-objc-header %S/Inputs/CoreDataHelper/CoreDataHelper.h -Xlinker %t/CoreDataHelper.o -o %t/main

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: %gyb %s -o %t/main.swift
 // RUN: if [ %target-runtime == "objc" ]; then \

--- a/validation-test/stdlib/DictionaryBridging.swift
+++ b/validation-test/stdlib/DictionaryBridging.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: %target-clang -fobjc-arc %S/Inputs/SlurpFastEnumeration/SlurpFastEnumeration.m -c -o %t/SlurpFastEnumeration.o
 // RUN: echo '#sourceLocation(file: "%s", line: 1)' > "%t/main.swift" && cat "%s" >> "%t/main.swift" && chmod -w "%t/main.swift"

--- a/validation-test/stdlib/DictionaryTrapsObjC.swift
+++ b/validation-test/stdlib/DictionaryTrapsObjC.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out_Debug
 // RUN: %target-build-swift %s -o %t/a.out_Release -O
 //

--- a/validation-test/stdlib/FixedPointArithmeticTraps.swift.gyb
+++ b/validation-test/stdlib/FixedPointArithmeticTraps.swift.gyb
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %gyb %s -o %t/FixedPointArithmeticTraps.swift
 // RUN: %line-directive %t/FixedPointArithmeticTraps.swift -- %target-build-swift %t/FixedPointArithmeticTraps.swift -o %t/a.out_Debug
 // RUN: %line-directive %t/FixedPointArithmeticTraps.swift -- %target-build-swift %t/FixedPointArithmeticTraps.swift -o %t/a.out_Release -O

--- a/validation-test/stdlib/FixedPointConversion.swift.gyb
+++ b/validation-test/stdlib/FixedPointConversion.swift.gyb
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %S/../../utils/gyb %s -o %t/FixedPointConversion.swift
 // RUN: %S/../../utils/line-directive %t/FixedPointConversion.swift -- %target-build-swift %t/FixedPointConversion.swift -o %t/a.out_Debug
 // RUN: %S/../../utils/line-directive %t/FixedPointConversion.swift -- %target-build-swift %t/FixedPointConversion.swift -o %t/a.out_Release -O

--- a/validation-test/stdlib/FixedPointDiagnostics.swift.gyb
+++ b/validation-test/stdlib/FixedPointDiagnostics.swift.gyb
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t && %gyb %s -o %t/main.swift
+// RUN: %empty-directory(%t)
+// RUN: %gyb %s -o %t/main.swift
 // RUN: %line-directive %t/main.swift -- %target-swift-frontend -parse -verify %t/main.swift
 
 func testUnaryMinusInUnsigned() {

--- a/validation-test/stdlib/FloatingPointConversion.swift.gyb
+++ b/validation-test/stdlib/FloatingPointConversion.swift.gyb
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %gyb %s -o %t/FloatingPointConversion.swift
 // RUN: %line-directive %t/FloatingPointConversion.swift -- %target-build-swift %t/FloatingPointConversion.swift -Xfrontend -disable-access-control -o %t/a.out_Debug
 // RUN: %line-directive %t/FloatingPointConversion.swift -- %target-build-swift %t/FloatingPointConversion.swift -Xfrontend -disable-access-control -o %t/a.out_Release -O

--- a/validation-test/stdlib/MicroStdlib/MicroStdlib.swift
+++ b/validation-test/stdlib/MicroStdlib/MicroStdlib.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -c -force-single-frontend-invocation -parse-as-library -parse-stdlib -module-name Swift -emit-module -emit-module-path %t/Swift.swiftmodule -o %t/Swift.o %S/Inputs/Swift.swift
 // RUN: ls %t/Swift.swiftmodule
 // RUN: ls %t/Swift.swiftdoc

--- a/validation-test/stdlib/NewArray.swift.gyb
+++ b/validation-test/stdlib/NewArray.swift.gyb
@@ -11,7 +11,8 @@
 //
 //===----------------------------------------------------------------------===//
 // RUN-DISABLED: %target-run-simple-swift | %FileCheck %s
-// RUN: rm -rf %t && mkdir -p %t && %gyb %s -o %t/NewArray.swift
+// RUN: %empty-directory(%t)
+// RUN: %gyb %s -o %t/NewArray.swift
 // RUN: %line-directive %t/NewArray.swift -- %target-build-swift %t/NewArray.swift -o %t/a.out -Xfrontend -disable-access-control
 // RUN: %target-run %t/a.out 2>&1 | %line-directive %t/NewArray.swift -- %FileCheck %t/NewArray.swift --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
 // REQUIRES: executable_test

--- a/validation-test/stdlib/NumericDiagnostics.swift.gyb
+++ b/validation-test/stdlib/NumericDiagnostics.swift.gyb
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t && %gyb %s -o %t/main.swift
+// RUN: %empty-directory(%t)
+// RUN: %gyb %s -o %t/main.swift
 // RUN: %line-directive %t/main.swift -- %target-build-swift -parse -Xfrontend -verify %t/main.swift
 // REQUIRES: executable_test
 

--- a/validation-test/stdlib/Prototypes/PersistentVector.swift.gyb
+++ b/validation-test/stdlib/Prototypes/PersistentVector.swift.gyb
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t && %gyb %s -o %t/PersistentVector.swift
+// RUN: %empty-directory(%t)
+// RUN: %gyb %s -o %t/PersistentVector.swift
 // RUN: %line-directive %t/PersistentVector.swift -- %target-build-swift -parse-stdlib %t/PersistentVector.swift -o %t/a.out
 // RUN: %line-directive %t/PersistentVector.swift -- %target-run %t/a.out
 // REQUIRES: executable_test

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: %gyb %s -o %t/main.swift
 // RUN: if [ %target-runtime == "objc" ]; then \

--- a/validation-test/stdlib/SwiftNativeNSBase.swift
+++ b/validation-test/stdlib/SwiftNativeNSBase.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: rm -rf %t  &&  mkdir -p %t
+// RUN: %empty-directory(%t)
 // 
 // RUN: %target-clang %S/Inputs/SwiftNativeNSBase/SwiftNativeNSBase.m -c -o %t/SwiftNativeNSBase.o -g
 // RUN: %target-build-swift %s -I %S/Inputs/SwiftNativeNSBase/ -Xlinker %t/SwiftNativeNSBase.o -o %t/SwiftNativeNSBase

--- a/validation-test/stdlib/UnicodeTrie.swift.gyb
+++ b/validation-test/stdlib/UnicodeTrie.swift.gyb
@@ -10,7 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: rm -rf %t && mkdir -p %t && %gyb -DunicodeGraphemeBreakPropertyFile=%utils/UnicodeData/GraphemeBreakProperty.txt -DunicodeGraphemeBreakTestFile=%utils/UnicodeData/GraphemeBreakTest.txt %s -o %t/UnicodeTrie.swift
+// RUN: %empty-directory(%t)
+// RUN: %gyb -DunicodeGraphemeBreakPropertyFile=%utils/UnicodeData/GraphemeBreakProperty.txt -DunicodeGraphemeBreakTestFile=%utils/UnicodeData/GraphemeBreakTest.txt %s -o %t/UnicodeTrie.swift
 // RUN: %line-directive %t/UnicodeTrie.swift -- %target-build-swift %t/UnicodeTrie.swift -o %t/a.out -g -Xfrontend -disable-access-control
 // RUN: %line-directive %t/UnicodeTrie.swift -- %target-run %t/a.out
 // REQUIRES: executable_test

--- a/validation-test/stdlib/UnicodeTrieGenerator.gyb
+++ b/validation-test/stdlib/UnicodeTrieGenerator.gyb
@@ -1,6 +1,6 @@
 %{
 
-# RUN: rm -rf %t && mkdir -p %t && %gyb %s | %FileCheck %s
+# RUN: %gyb %s | %FileCheck %s
 
 from __future__ import print_function
 

--- a/validation-test/stdlib/UnicodeUTFEncoders.swift
+++ b/validation-test/stdlib/UnicodeUTFEncoders.swift
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out -O
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test


### PR DESCRIPTION
Replace various `rm -rf && mkdir` patterns we have in our tests with a new substitution `%empty-directory(directory-name)`.
