### PR TITLE
[utils] Minor Python tidies in utils/swift-bench.py

### DIFF
--- a/utils/swift-bench.py
+++ b/utils/swift-bench.py
@@ -42,6 +42,25 @@ import subprocess
 import sys
 
 
+# This regular expression is looking for Swift functions named `bench_*`
+# that take no arguments and return an Int.  The Swift code for such a function is:
+#
+#     func bench_myname() {
+#         // function body goes here
+#     }
+BENCH_RE = re.compile(
+    r"^\s*"             # whitespace at the start of the line
+    r"func\s+"          # 'func' keyword, which must be followed by
+                        # at least one space
+    r"bench_([a-zA-Z0-9_]+)\s*"
+                        # name of the function
+    r"\s*\(\s*\)"       # argument list
+    r"\s*->\s*Int\s*"   # return type
+    r"({)?"             # opening brace of the function body
+    r"\s*$"             # whitespace ot the end of the line
+)
+
+
 def pstdev(sample):
     """Given a list of numbers, return the population standard deviation.
 
@@ -85,7 +104,9 @@ class SwiftBenchHarness(object):
             "-v", "--verbosity",
             help="increase output verbosity", type=int)
         parser.add_argument("files", help="input files", nargs='+')
-        parser.add_argument('-c', '--compiler', help="compiler to use")
+        parser.add_argument(
+            '-c', '--compiler',
+            help="compiler to use", default="swiftc")
         parser.add_argument(
             '-t', '--timelimit',
             help="Time limit for every test", type=int)
@@ -98,12 +119,9 @@ class SwiftBenchHarness(object):
         if args.verbosity:
             self.verbose_level = args.verbosity
         self.sources = args.files
+        self.compiler = args.compiler
         if args.flags:
             self.opt_flags = args.flags
-        if args.compiler:
-            self.compiler = args.compiler
-        else:
-            self.compiler = 'swiftc'
         if args.timelimit and args.timelimit > 0:
             self.time_limit = args.timelimit
         if args.sampletime and args.sampletime > 0:
@@ -171,15 +189,12 @@ func main() {
 main()
 """
 
-        bench_re = re.compile(
-            "^\s*func\s\s*bench_([a-zA-Z0-9_]+)" +
-            "\s*\(\s*\)\s*->\s*Int\s*({)?\s*$")
         with open(name) as f:
             lines = list(f)
         output = header
         looking_for_curly_brace = False
         test_names = []
-        for l in lines:
+        for lineno, l in enumerate(lines, start=1):
             if looking_for_curly_brace:
                 output += l
                 if "{" not in l:
@@ -188,13 +203,13 @@ main()
                 output += into_bench
                 continue
 
-            m = bench_re.match(l)
+            m = BENCH_RE.match(l)
             if m:
                 output += before_bench
                 output += l
                 bench_name = m.group(1)
-                # TODO: Keep track of the line number as well
-                self.log("Benchmark found: %s" % bench_name, 3)
+                self.log("Benchmark found: %s (line %d)" %
+                         (bench_name, lineno), 3)
                 self.tests[
                     name + ":" +
                     bench_name] = Test(bench_name, name, "", "")

--- a/utils/swift-bench.py
+++ b/utils/swift-bench.py
@@ -43,7 +43,8 @@ import sys
 
 
 # This regular expression is looking for Swift functions named `bench_*`
-# that take no arguments and return an Int.  The Swift code for such a function is:
+# that take no arguments and return an Int.  The Swift code for such
+# a function is:
 #
 #     func bench_myname() {
 #         // function body goes here


### PR DESCRIPTION
<!-- What's in this pull request? -->
- Track the line number where benchmarks are found
- Tidy up the argument parsing code for the default `--compiler` value
- Pull the regex for finding benchmarks out into a top-level constant,
  and add comments for improved readability

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
