### PR TITLE
[Sema] Fix SR-1681 spurious "unused result" warning

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1080,9 +1080,12 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
   // If we have an OptionalEvaluationExpr at the top level, then someone is
   // "optional chaining" and ignoring the result.  Produce a diagnostic if it
   // doesn't make sense to ignore it.
-  if (auto *OEE = dyn_cast<OptionalEvaluationExpr>(valueE))
+  if (auto *OEE = dyn_cast<OptionalEvaluationExpr>(valueE)) {
     if (auto *IIO = dyn_cast<InjectIntoOptionalExpr>(OEE->getSubExpr()))
       return checkIgnoredExpr(IIO->getSubExpr());
+    if (auto *C = dyn_cast<CallExpr>(OEE->getSubExpr()))
+      return checkIgnoredExpr(C);
+  }
 
   // Check if we have a call to a function not marked with
   // '@discardableResult'.

--- a/test/attr/attr_discardableResult.swift
+++ b/test/attr/attr_discardableResult.swift
@@ -43,6 +43,11 @@ class C1 {
   func f2() -> Int { }
 
   @discardableResult
+  func f1Optional() -> Int? { }
+
+  func f2Optional() -> Int? { }
+
+  @discardableResult
   func me() -> Self { return self }
 
   func reallyMe() -> Self { return self }
@@ -68,6 +73,10 @@ func testFunctionsInClass(c1 : C1, c2: C2) {
   c1.f2()           // expected-warning {{result of call to 'f2()' is unused}}
   _ = c1.f2()       // okay
 
+  c1.f1Optional()   // okay
+  c1.f2Optional()   // expected-warning {{result of call to 'f2Optional()' is unused}}
+  _ = c1.f2Optional() // okay
+
   c1.me()           // okay
   c2.me()           // okay
 
@@ -91,6 +100,11 @@ struct S1 {
   func f1() -> Int { }
 
   func f2() -> Int { }
+
+  @discardableResult
+  func f1Optional() -> Int? { }
+
+  func f2Optional() -> Int? { }
 }
 
 func testFunctionsInStruct(s1 : S1) {
@@ -106,6 +120,10 @@ func testFunctionsInStruct(s1 : S1) {
   s1.f1()           // okay
   s1.f2()           // expected-warning {{result of call to 'f2()' is unused}}
   _ = s1.f2()       // okay
+
+  s1.f1Optional()   // okay
+  s1.f2Optional()   // expected-warning {{result of call to 'f2Optional()' is unused}}
+  _ = s1.f2Optional() // okay
 }
 
 protocol P1 {
@@ -137,4 +155,24 @@ class X {
   @warn_unused_result // expected-warning {{'warn_unused_result' attribute behavior is now the default}} {{3-23=}}
   @objc
   func h() -> Int { }
+}
+
+func testOptionalChaining(c1: C1?, s1: S1?) {
+  c1?.f1()         // okay
+  c1!.f1()         // okay
+  c1?.f1Optional() // okay
+  c1!.f1Optional() // okay
+  c1?.f2()         // expected-warning {{result of call to 'f2()' is unused}}
+  c1!.f2()         // expected-warning {{result of call to 'f2()' is unused}}
+  c1?.f2Optional() // expected-warning {{result of call to 'f2Optional()' is unused}}
+  c1!.f2Optional() // expected-warning {{result of call to 'f2Optional()' is unused}}
+
+  s1?.f1()         // okay
+  s1!.f1()         // okay
+  s1?.f1Optional() // okay
+  s1!.f1Optional() // okay
+  s1?.f2()         // expected-warning {{result of call to 'f2()' is unused}}
+  s1!.f2()         // expected-warning {{result of call to 'f2()' is unused}}
+  s1?.f2Optional() // expected-warning {{result of call to 'f2Optional()' is unused}}
+  s1!.f2Optional() // expected-warning {{result of call to 'f2Optional()' is unused}}
 }


### PR DESCRIPTION
Extends https://github.com/apple/swift/commit/ea52d4fbc7093582eef84c57b3906e9d7e274fe8 to support methods returning optional types.

When an optionally chained method already has an optional return type, the corresponding CallExpr is not wrapped in an `InjectIntoOptionalExpr`. Instead an `OptionalEvaluationExpr` can have a `CallExpr` directly as its SubExpr in this case.

I'm not sure if the cast to `CallExpr` is even needed, but put it in for safety reasons. If someone can confirm whether or not it makes sense to keep it in there, and if there are other types that could be relevant as a SubExpr, please let me know.

Resolves [SR-1681](https://bugs.swift.org/browse/SR-1681).
