### PR TITLE
[QoI] improve diagnostics for operator declarations; unify parsing code

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -388,6 +388,8 @@ ERROR(operator_decl_no_fixity,none,
       "operator must be declared as 'prefix', 'postfix', or 'infix'", ())
 
 // PrecedenceGroup
+ERROR(precedencegroup_not_infix,none,
+      "only infix operators may declare a precedence", ())
 ERROR(expected_precedencegroup_name,none,
       "expected identifier after 'precedencegroup'", ())
 ERROR(expected_precedencegroup_lbrace,none,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -825,18 +825,10 @@ public:
 
   ParserResult<OperatorDecl> parseDeclOperator(ParseDeclOptions Flags,
                                                DeclAttributes &Attributes);
-  ParserResult<OperatorDecl> parseDeclPrefixOperator(SourceLoc OperatorLoc,
-                                                     Identifier Name,
-                                                     SourceLoc NameLoc,
-                                                     DeclAttributes &Attrs);
-  ParserResult<OperatorDecl> parseDeclPostfixOperator(SourceLoc OperatorLoc,
-                                                      Identifier Name,
-                                                      SourceLoc NameLoc,
-                                                      DeclAttributes &Attrs);
-  ParserResult<OperatorDecl> parseDeclInfixOperator(SourceLoc OperatorLoc,
-                                                    Identifier Name,
-                                                    SourceLoc NameLoc,
-                                                    DeclAttributes &Attrs);
+  ParserResult<OperatorDecl> parseDeclOperatorImpl(SourceLoc OperatorLoc,
+                                                   Identifier Name,
+                                                   SourceLoc NameLoc,
+                                                   DeclAttributes &Attrs);
 
   ParserResult<PrecedenceGroupDecl>
   parseDeclPrecedenceGroup(ParseDeclOptions flags, DeclAttributes &attributes);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5466,17 +5466,8 @@ Parser::parseDeclOperator(ParseDeclOptions Flags, DeclAttributes &Attributes) {
   
   Identifier Name = Context.getIdentifier(Tok.getText());
   SourceLoc NameLoc = consumeToken();
-
-  ParserResult<OperatorDecl> Result;
-  if (Attributes.hasAttribute<PrefixAttr>())
-    Result = parseDeclPrefixOperator(OperatorLoc, Name, NameLoc, Attributes);
-  else if (Attributes.hasAttribute<PostfixAttr>())
-    Result = parseDeclPostfixOperator(OperatorLoc, Name, NameLoc, Attributes);
-  else {
-    if (!Attributes.hasAttribute<InfixAttr>())
-      diagnose(OperatorLoc, diag::operator_decl_no_fixity);
-    Result = parseDeclInfixOperator(OperatorLoc, Name, NameLoc, Attributes);
-  }
+  
+  auto Result = parseDeclOperatorImpl(OperatorLoc, Name, NameLoc, Attributes);
 
   if (!DCC.movedToTopLevel() && !AllowTopLevel) {
     diagnose(OperatorLoc, diag::operator_decl_inner_scope);
@@ -5487,55 +5478,13 @@ Parser::parseDeclOperator(ParseDeclOptions Flags, DeclAttributes &Attributes) {
 }
 
 ParserResult<OperatorDecl>
-Parser::parseDeclPrefixOperator(SourceLoc OperatorLoc, Identifier Name,
+Parser::parseDeclOperatorImpl(SourceLoc OperatorLoc, Identifier Name,
                                 SourceLoc NameLoc, DeclAttributes &Attributes) {
-  SourceLoc lBraceLoc;
-  if (consumeIf(tok::l_brace, lBraceLoc)) {
-    auto Diag = diagnose(lBraceLoc, diag::deprecated_operator_body);
-    if (Tok.is(tok::r_brace)) {
-      SourceLoc lastGoodLocEnd = Lexer::getLocForEndOfToken(SourceMgr,
-                                                            NameLoc);
-      SourceLoc rBraceEnd = Lexer::getLocForEndOfToken(SourceMgr, Tok.getLoc());
-      Diag.fixItRemoveChars(lastGoodLocEnd, rBraceEnd);
-    }
-
-    skipUntilDeclRBrace();
-    (void) consumeIf(tok::r_brace);
-  }
+  bool isPrefix = Attributes.hasAttribute<PrefixAttr>();
+  bool isInfix = Attributes.hasAttribute<InfixAttr>();
+  bool isPostfix = Attributes.hasAttribute<PostfixAttr>();
   
-  auto *Res = new (Context) PrefixOperatorDecl(CurDeclContext, OperatorLoc,
-                                               Name, NameLoc);
-  Res->getAttrs() = Attributes;
-  return makeParserResult(Res);
-}
-
-ParserResult<OperatorDecl>
-Parser::parseDeclPostfixOperator(SourceLoc OperatorLoc,
-                                 Identifier Name, SourceLoc NameLoc,
-                                 DeclAttributes &Attributes) {
-  SourceLoc lBraceLoc;
-  if (consumeIf(tok::l_brace, lBraceLoc)) {
-    auto Diag = diagnose(lBraceLoc, diag::deprecated_operator_body);
-    if (Tok.is(tok::r_brace)) {
-      SourceLoc lastGoodLocEnd = Lexer::getLocForEndOfToken(SourceMgr,
-                                                            NameLoc);
-      SourceLoc rBraceEnd = Lexer::getLocForEndOfToken(SourceMgr, Tok.getLoc());
-      Diag.fixItRemoveChars(lastGoodLocEnd, rBraceEnd);
-    }
-
-    skipUntilDeclRBrace();
-    (void) consumeIf(tok::r_brace);
-  }
-
-  auto Res = new (Context) PostfixOperatorDecl(CurDeclContext, OperatorLoc,
-                                               Name, NameLoc);
-  Res->getAttrs() = Attributes;
-  return makeParserResult(Res);
-}
-
-ParserResult<OperatorDecl>
-Parser::parseDeclInfixOperator(SourceLoc operatorLoc, Identifier name,
-                               SourceLoc nameLoc, DeclAttributes &attributes) {
+  // Parse (or diagnose) a specified precedence group.
   SourceLoc colonLoc;
   Identifier precedenceGroupName;
   SourceLoc precedenceGroupNameLoc;
@@ -5543,33 +5492,54 @@ Parser::parseDeclInfixOperator(SourceLoc operatorLoc, Identifier name,
     if (Tok.is(tok::identifier)) {
       precedenceGroupName = Context.getIdentifier(Tok.getText());
       precedenceGroupNameLoc = consumeToken(tok::identifier);
+      
+      if (isPrefix || isPostfix)
+        diagnose(colonLoc, diag::precedencegroup_not_infix)
+          .fixItRemove({colonLoc, precedenceGroupNameLoc});
     }
   }
-
+  
+  // Diagnose deprecated operator body syntax `operator + { ... }`.
   SourceLoc lBraceLoc;
   if (consumeIf(tok::l_brace, lBraceLoc)) {
-    if (Tok.is(tok::r_brace)) {
-      SourceLoc lastGoodLoc = precedenceGroupNameLoc;
-      if (lastGoodLoc.isInvalid())
-        lastGoodLoc = nameLoc;
-      SourceLoc lastGoodLocEnd = Lexer::getLocForEndOfToken(SourceMgr,
-                                                            lastGoodLoc);
-      SourceLoc rBraceEnd = Lexer::getLocForEndOfToken(SourceMgr, Tok.getLoc());
-      diagnose(lBraceLoc, diag::deprecated_operator_body)
-        .fixItRemoveChars(lastGoodLocEnd, rBraceEnd);
-    } else {
+    if (isInfix && !Tok.is(tok::r_brace)) {
       diagnose(lBraceLoc, diag::deprecated_operator_body_use_group);
+    } else {
+      auto Diag = diagnose(lBraceLoc, diag::deprecated_operator_body);
+      if (Tok.is(tok::r_brace)) {
+        SourceLoc lastGoodLoc = precedenceGroupNameLoc;
+        if (lastGoodLoc.isInvalid())
+          lastGoodLoc = NameLoc;
+        SourceLoc lastGoodLocEnd = Lexer::getLocForEndOfToken(SourceMgr,
+                                                              lastGoodLoc);
+        SourceLoc rBraceEnd = Lexer::getLocForEndOfToken(SourceMgr, Tok.getLoc());
+        Diag.fixItRemoveChars(lastGoodLocEnd, rBraceEnd);
+      }
     }
 
     skipUntilDeclRBrace();
     (void) consumeIf(tok::r_brace);
   }
-
-  auto res = new (Context) InfixOperatorDecl(CurDeclContext, operatorLoc,
-                                             name, nameLoc, colonLoc,
-                                             precedenceGroupName,
-                                             precedenceGroupNameLoc);
-  res->getAttrs() = attributes;
+  
+  
+  OperatorDecl *res;
+  if (Attributes.hasAttribute<PrefixAttr>())
+    res = new (Context) PrefixOperatorDecl(CurDeclContext, OperatorLoc,
+                                           Name, NameLoc);
+  else if (Attributes.hasAttribute<PostfixAttr>())
+    res = new (Context) PostfixOperatorDecl(CurDeclContext, OperatorLoc,
+                                            Name, NameLoc);
+  else {
+    if (!Attributes.hasAttribute<InfixAttr>())
+      diagnose(OperatorLoc, diag::operator_decl_no_fixity);
+    
+    res = new (Context) InfixOperatorDecl(CurDeclContext, OperatorLoc,
+                                          Name, NameLoc, colonLoc,
+                                          precedenceGroupName,
+                                          precedenceGroupNameLoc);
+  }
+  
+  res->getAttrs() = Attributes;
   return makeParserResult(res);
 }
 

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -860,7 +860,7 @@ namespace {
     Expr *Guard = nullptr;
   };
   
-  /// Contexts in which a guarded pattern can appears.
+  /// Contexts in which a guarded pattern can appear.
   enum class GuardedPatternContext {
     Case,
     Catch,

--- a/test/Parse/operator_decl.swift
+++ b/test/Parse/operator_decl.swift
@@ -6,7 +6,33 @@ infix operator +++ {} // expected-warning {{operator should no longer be declare
 infix operator +++* { // expected-warning {{operator should no longer be declared with body; use a precedence group instead}} {{none}}
   associativity right
 }
-infix operator +++** : A { } // expected-warning {{operator should no longer be declared with body}} {{25-29=}}
+infix operator +++*+ : A { } // expected-warning {{operator should no longer be declared with body}} {{25-29=}}
+
+
+prefix operator +++** : A { }
+// expected-error@-1 {{only infix operators may declare a precedence}} {{23-27=}}
+// expected-warning@-2 {{operator should no longer be declared with body}} {{26-30=}}
+
+prefix operator ++*++ : A
+// expected-error@-1 {{only infix operators may declare a precedence}} {{23-26=}}
+
+postfix operator ++*+* : A { }
+// expected-error@-1 {{only infix operators may declare a precedence}} {{24-28=}}
+// expected-warning@-2 {{operator should no longer be declared with body}} {{27-31=}}
+
+postfix operator ++**+ : A
+// expected-error@-1 {{only infix operators may declare a precedence}} {{24-27=}}
+
+operator ++*** : A
+// expected-error@-1 {{operator must be declared as 'prefix', 'postfix', or 'infix'}}
+
+operator +*+++ { }
+// expected-error@-1 {{operator must be declared as 'prefix', 'postfix', or 'infix'}}
+// expected-warning@-2 {{operator should no longer be declared with body}} {{15-19=}}
+
+operator +*++* : A { }
+// expected-error@-1 {{operator must be declared as 'prefix', 'postfix', or 'infix'}}
+// expected-warning@-2 {{operator should no longer be declared with body}} {{19-23=}}
 
 prefix operator // expected-error {{expected operator name in operator declaration}}
 


### PR DESCRIPTION
Improves diagnostics for invalid operator declarations, particularly when specifying precedence for a non-infix operator.  (Prompted by @erica's [post about operators](http://ericasadun.com/2016/09/04/optionals-optionals-optionals-introducing-precedence/)!)

Along the way, cleans up code that was nearly identical between `parseDeclOperator{Infix,Prefix,Postfix}()`, replacing them with a single function named `parseDeclOperatorImpl()`.
### Before:

<pre>
<b>error: consecutive statements on a line must be separated by ';'</b>
postfix operator +? : DefaultPrecedence
                   ^
                   ;
<b>error: expected expression</b>
postfix operator +? : DefaultPrecedence
                    ^
</pre>

### After:

<pre>
<b>error: only infix operators may declare a precedence</b>
postfix operator +? : DefaultPrecedence
                    ^~~~~~~~~~~~~~~~~~~
</pre>
