### PR TITLE
[Analysis] Adjust inline documentation in ClassHierarchyAnalysis.cpp

### DIFF
--- a/lib/SILOptimizer/Analysis/ClassHierarchyAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ClassHierarchyAnalysis.cpp
@@ -76,9 +76,7 @@ void ClassHierarchyAnalysis::init() {
 }
 
 /// \brief Get all subclasses of a given class.
-/// Does not include any direct subclasses of given base class.
 ///
-/// \p Base class, whose direct subclasses are to be excluded
 /// \p Current class, whose direct and indirect subclasses are
 ///    to be collected.
 /// \p IndirectSubs placeholder for collected results


### PR DESCRIPTION
Updates the inline documentation for `ClassHierarchyAnalysis::getIndirectSubClasses` in `ClassHierarchyAnalysis.cpp` to reflect the `Base` parameter having been removed in [3c792e4](https://github.com/apple/swift/commit/3c792e4648435f61144424e986ee4c2f8432cb9c#diff-ac2c3408c15aefb7be8f231a5b58ee7eL46).

cc @swiftix
