### PR TITLE
stdlib: String: improvements and refactorings

### DIFF
--- a/stdlib/public/SwiftShims/AssertionReporting.h
+++ b/stdlib/public/SwiftShims/AssertionReporting.h
@@ -16,6 +16,10 @@
 #include "SwiftStdint.h"
 #include "Visibility.h"
 
+#if __has_feature(nullability)
+#pragma clang assume_nonnull begin
+#endif
+
 #ifdef __cplusplus
 namespace swift { extern "C" {
 #endif
@@ -66,6 +70,10 @@ void _swift_stdlib_reportUnimplementedInitializer(
 
 #ifdef __cplusplus
 }} // extern "C", namespace swift
+#endif
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
 #endif
 
 #endif // SWIFT_STDLIB_SHIMS_ASSERTIONREPORTING_H_

--- a/stdlib/public/SwiftShims/AssertionReporting.h
+++ b/stdlib/public/SwiftShims/AssertionReporting.h
@@ -1,0 +1,72 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_STDLIB_SHIMS_ASSERTIONREPORTING_H_
+#define SWIFT_STDLIB_SHIMS_ASSERTIONREPORTING_H_
+
+#include "SwiftStdint.h"
+#include "Visibility.h"
+
+#ifdef __cplusplus
+namespace swift { extern "C" {
+#endif
+
+/// Report a fatal error to system console, stderr, and crash logs.
+///
+///     <prefix>: <message>: file <file>, line <line>\n
+///
+/// The message may be omitted by passing messageLength=0.
+SWIFT_RUNTIME_STDLIB_INTERFACE
+void _swift_stdlib_reportFatalErrorInFile(
+    const unsigned char *prefix, int prefixLength,
+    const unsigned char *message, int messageLength,
+    const unsigned char *file, int fileLength,
+    __swift_uint32_t line,
+    __swift_uint32_t flags);
+
+/// Report a fatal error to system console, stderr, and crash logs.
+///
+///     <prefix>: <message>\n
+SWIFT_RUNTIME_STDLIB_INTERFACE
+void _swift_stdlib_reportFatalError(
+    const unsigned char *prefix, int prefixLength,
+    const unsigned char *message, int messageLength,
+    __swift_uint32_t flags);
+
+/// Report a call to an unimplemented initializer.
+///
+///     <file>: <line>: <column>: fatal error: use of unimplemented
+///     initializer '<initName>' for class '<className>'
+SWIFT_RUNTIME_STDLIB_INTERFACE
+void _swift_stdlib_reportUnimplementedInitializerInFile(
+    const unsigned char *className, int classNameLength,
+    const unsigned char *initName, int initNameLength,
+    const unsigned char *file, int fileLength,
+    __swift_uint32_t line, __swift_uint32_t column,
+    __swift_uint32_t flags);
+
+/// Report a call to an unimplemented initializer.
+///
+///     fatal error: use of unimplemented initializer '<initName>'
+///     for class 'className'
+SWIFT_RUNTIME_STDLIB_INTERFACE
+void _swift_stdlib_reportUnimplementedInitializer(
+    const unsigned char *className, int classNameLength,
+    const unsigned char *initName, int initNameLength,
+    __swift_uint32_t flags);
+
+#ifdef __cplusplus
+}} // extern "C", namespace swift
+#endif
+
+#endif // SWIFT_STDLIB_SHIMS_ASSERTIONREPORTING_H_
+

--- a/stdlib/public/SwiftShims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(sources
+  AssertionReporting.h
   CoreFoundationShims.h
   DispatchShims.h
   FoundationShims.h

--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -23,6 +23,10 @@
 #include "SwiftStddef.h"
 #include "Visibility.h"
 
+#if __has_feature(nullability)
+#pragma clang assume_nonnull begin
+#endif
+
 #ifdef __cplusplus
 namespace swift { extern "C" {
 #endif
@@ -82,14 +86,14 @@ __swift_uint32_t _swift_stdlib_cxx11_mt19937(void);
 SWIFT_RUNTIME_STDLIB_INTERFACE
 __swift_uint32_t
 _swift_stdlib_cxx11_mt19937_uniform(__swift_uint32_t upper_bound);
-  
+
 // Math library functions
 SWIFT_RUNTIME_STDLIB_INTERFACE float _swift_stdlib_remainderf(float, float);
 SWIFT_RUNTIME_STDLIB_INTERFACE float _swift_stdlib_squareRootf(float);
-  
+
 SWIFT_RUNTIME_STDLIB_INTERFACE double _swift_stdlib_remainder(double, double);
 SWIFT_RUNTIME_STDLIB_INTERFACE double _swift_stdlib_squareRoot(double);
-  
+
 // TODO: Remove horrible workaround when importer does Float80 <-> long double.
 #if (defined __i386__ || defined __x86_64__) && !defined _MSC_VER
 SWIFT_RUNTIME_STDLIB_INTERFACE
@@ -100,6 +104,10 @@ void _swift_stdlib_squareRootl(void *_self);
 
 #ifdef __cplusplus
 }} // extern "C", namespace swift
+#endif
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
 #endif
 
 #endif // SWIFT_STDLIB_SHIMS_LIBCSHIMS_H

--- a/stdlib/public/SwiftShims/module.modulemap
+++ b/stdlib/public/SwiftShims/module.modulemap
@@ -1,4 +1,5 @@
 module SwiftShims {
+  header "AssertionReporting.h"
   header "CoreFoundationShims.h"
   header "DispatchShims.h"
   header "FoundationShims.h"

--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftShims
+
 // Implementation Note: this file intentionally uses very LOW-LEVEL
 // CONSTRUCTS, so that assert and fatal may be used liberally in
 // building library abstractions without fear of infinite recursion.
@@ -70,39 +72,6 @@ func _fatalErrorFlags() -> UInt32 {
 #endif
 }
 
-@_silgen_name("_swift_stdlib_reportFatalErrorInFile")
-func _reportFatalErrorInFile(
-  // FIXME(ABI): add argument labels to conform to API guidelines.
-  _ prefix: UnsafePointer<UInt8>, _ prefixLength: UInt,
-  _ message: UnsafePointer<UInt8>, _ messageLength: UInt,
-  _ file: UnsafePointer<UInt8>, _ fileLength: UInt,
-  _ line: UInt, flags: UInt32)
-
-@_silgen_name("_swift_stdlib_reportFatalError")
-func _reportFatalError(
-  // FIXME(ABI): add argument labels to conform to API guidelines.
-  _ prefix: UnsafePointer<UInt8>, _ prefixLength: UInt,
-  _ message: UnsafePointer<UInt8>, _ messageLength: UInt,
-  flags: UInt32)
-
-@_versioned
-@_silgen_name("_swift_stdlib_reportUnimplementedInitializerInFile")
-func _reportUnimplementedInitializerInFile(
-  // FIXME(ABI): add argument labels to conform to API guidelines.
-  _ className: UnsafePointer<UInt8>, _ classNameLength: UInt,
-  _ initName: UnsafePointer<UInt8>, _ initNameLength: UInt,
-  _ file: UnsafePointer<UInt8>, _ fileLength: UInt,
-  _ line: UInt, _ column: UInt,
-  flags: UInt32)
-
-@_versioned
-@_silgen_name("_swift_stdlib_reportUnimplementedInitializer")
-func _reportUnimplementedInitializer(
-  // FIXME(ABI): add argument labels to conform to API guidelines.
-  _ className: UnsafePointer<UInt8>, _ classNameLength: UInt,
-  _ initName: UnsafePointer<UInt8>, _ initNameLength: UInt,
-  flags: UInt32)
-
 /// This function should be used only in the implementation of user-level
 /// assertions.
 ///
@@ -123,11 +92,11 @@ func _assertionFailed(
       (message) -> Void in
       file.withUTF8Buffer {
         (file) -> Void in
-        _reportFatalErrorInFile(
-          prefix.baseAddress!, UInt(prefix.count),
-          message.baseAddress!, UInt(message.count),
-          file.baseAddress!, UInt(file.count), line,
-          flags: flags)
+        _swift_stdlib_reportFatalErrorInFile(
+          prefix.baseAddress!, CInt(prefix.count),
+          message.baseAddress!, CInt(message.count),
+          file.baseAddress!, CInt(file.count), UInt32(line),
+          flags)
         Builtin.int_trap()
       }
     }
@@ -155,11 +124,11 @@ func _assertionFailed(
       (messageUTF8) -> Void in
       file.withUTF8Buffer {
         (file) -> Void in
-        _reportFatalErrorInFile(
-          prefix.baseAddress!, UInt(prefix.count),
-          messageUTF8.baseAddress!, UInt(messageUTF8.count),
-          file.baseAddress!, UInt(file.count), line,
-          flags: flags)
+        _swift_stdlib_reportFatalErrorInFile(
+          prefix.baseAddress!, CInt(prefix.count),
+          messageUTF8.baseAddress!, CInt(messageUTF8.count),
+          file.baseAddress!, CInt(file.count), UInt32(line),
+          flags)
       }
     }
   }
@@ -189,11 +158,11 @@ func _fatalErrorMessage(
       (message) in
       file.withUTF8Buffer {
         (file) in
-        _reportFatalErrorInFile(
-          prefix.baseAddress!, UInt(prefix.count),
-          message.baseAddress!, UInt(message.count),
-          file.baseAddress!, UInt(file.count), line,
-          flags: flags)
+        _swift_stdlib_reportFatalErrorInFile(
+          prefix.baseAddress!, CInt(prefix.count),
+          message.baseAddress!, CInt(message.count),
+          file.baseAddress!, CInt(file.count), UInt32(line),
+          flags)
       }
     }
   }
@@ -202,10 +171,10 @@ func _fatalErrorMessage(
     (prefix) in
     message.withUTF8Buffer {
       (message) in
-      _reportFatalError(
-        prefix.baseAddress!, UInt(prefix.count),
-        message.baseAddress!, UInt(message.count),
-        flags: flags)
+      _swift_stdlib_reportFatalError(
+        prefix.baseAddress!, CInt(prefix.count),
+        message.baseAddress!, CInt(message.count),
+        flags)
     }
   }
 #endif
@@ -235,11 +204,12 @@ func _unimplementedInitializer(className: StaticString,
         (initName) in
         file.withUTF8Buffer {
           (file) in
-          _reportUnimplementedInitializerInFile(
-            className.baseAddress!, UInt(className.count),
-            initName.baseAddress!, UInt(initName.count),
-            file.baseAddress!, UInt(file.count), line, column,
-            flags: 0)
+          _swift_stdlib_reportUnimplementedInitializerInFile(
+            className.baseAddress!, CInt(className.count),
+            initName.baseAddress!, CInt(initName.count),
+            file.baseAddress!, CInt(file.count),
+            UInt32(line), UInt32(column),
+            /*flags:*/ 0)
         }
       }
     }
@@ -248,10 +218,10 @@ func _unimplementedInitializer(className: StaticString,
       (className) in
       initName.withUTF8Buffer {
         (initName) in
-        _reportUnimplementedInitializer(
-          className.baseAddress!, UInt(className.count),
-          initName.baseAddress!, UInt(initName.count),
-          flags: 0)
+        _swift_stdlib_reportUnimplementedInitializer(
+          className.baseAddress!, CInt(className.count),
+          initName.baseAddress!, CInt(initName.count),
+          /*flags:*/ 0)
       }
     }
   }

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -497,11 +497,13 @@ internal struct _Stdout : TextOutputStream {
   mutating func write(_ string: String) {
     if string.isEmpty { return }
 
-    if string._core.isASCII {
+    if let asciiBuffer = string._core.asciiBuffer {
       defer { _fixLifetime(string) }
 
-      _swift_stdlib_fwrite_stdout(UnsafePointer(string._core.startASCII),
-                                  string._core.count, 1)
+      _swift_stdlib_fwrite_stdout(
+        UnsafePointer(asciiBuffer.baseAddress!),
+        asciiBuffer.count,
+        1)
       return
     }
 

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -722,9 +722,9 @@ extension String {
   ///
   /// - Complexity: O(*n*)
   public func lowercased() -> String {
-    if self._core.isASCII {
-      let count = self._core.count
-      let source = self._core.startASCII
+    if let asciiBuffer = self._core.asciiBuffer {
+      let count = asciiBuffer.count
+      let source = asciiBuffer.baseAddress!
       let buffer = _StringBuffer(
         capacity: count, initialSize: count, elementWidth: 1)
       let dest = buffer.start
@@ -772,9 +772,9 @@ extension String {
   ///
   /// - Complexity: O(*n*)
   public func uppercased() -> String {
-    if self._core.isASCII {
-      let count = self._core.count
-      let source = self._core.startASCII
+    if let asciiBuffer = self._core.asciiBuffer {
+      let count = asciiBuffer.count
+      let source = asciiBuffer.baseAddress!
       let buffer = _StringBuffer(
         capacity: count, initialSize: count, elementWidth: 1)
       let dest = buffer.start

--- a/stdlib/public/core/StringCore.swift
+++ b/stdlib/public/core/StringCore.swift
@@ -240,6 +240,13 @@ public struct _StringCore {
     return _baseAddress!.assumingMemoryBound(to: UTF16.CodeUnit.self)
   }
 
+  public var asciiBuffer: UnsafeMutableBufferPointer<UTF8.CodeUnit>? {
+    if elementWidth != 1 {
+      return nil
+    }
+    return UnsafeMutableBufferPointer(start: startASCII, count: count)
+  }
+
   /// the native _StringBuffer, if any, or `nil`.
   public var nativeBuffer: _StringBuffer? {
     if !hasCocoaBuffer {

--- a/stdlib/public/core/StringHashable.swift
+++ b/stdlib/public/core/StringHashable.swift
@@ -48,9 +48,9 @@ extension String : Hashable {
       return hashOffset ^ _stdlib_NSStringHashValue(cocoaString, isASCII)
     }
 #else
-    if self._core.isASCII {
+    if let asciiBuffer = self._core.asciiBuffer {
       return _swift_stdlib_unicode_hash_ascii(
-        _core.startASCII, Int32(_core.count))
+        asciiBuffer.baseAddress!, Int32(asciiBuffer.count))
     } else {
       return _swift_stdlib_unicode_hash(_core.startUTF16, Int32(_core.count))
     }

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -147,15 +147,18 @@ extension String {
     if prefixCount == 0 {
       return true
     }
-    if selfCore.hasContiguousStorage && prefixCore.hasContiguousStorage {
-      if selfCore.isASCII && prefixCore.isASCII {
-        // Prefix longer than self.
-        if prefixCount > selfCore.count {
-          return false
-        }
-        return Int(_swift_stdlib_memcmp(
-          selfCore.startASCII, prefixCore.startASCII, prefixCount)) == 0
+    if let selfASCIIBuffer = selfCore.asciiBuffer,
+       let prefixASCIIBuffer = prefixCore.asciiBuffer {
+      if prefixASCIIBuffer.count > selfASCIIBuffer.count {
+        // Prefix is longer than self.
+        return false
       }
+      return Int(_swift_stdlib_memcmp(
+        selfASCIIBuffer.baseAddress!,
+        prefixASCIIBuffer.baseAddress!,
+        prefixASCIIBuffer.count)) == 0
+    }
+    if selfCore.hasContiguousStorage && prefixCore.hasContiguousStorage {
       let lhsStr = _NSContiguousString(selfCore)
       let rhsStr = _NSContiguousString(prefixCore)
       return lhsStr._unsafeWithNotEscapedSelfPointerPair(rhsStr) {
@@ -202,17 +205,19 @@ extension String {
     if suffixCount == 0 {
       return true
     }
-    if selfCore.hasContiguousStorage && suffixCore.hasContiguousStorage {
-      if selfCore.isASCII && suffixCore.isASCII {
-        // Suffix longer than self.
-        let selfCount = selfCore.count
-        if suffixCount > selfCount {
-          return false
-        }
-        return Int(_swift_stdlib_memcmp(
-                   selfCore.startASCII + (selfCount - suffixCount),
-                   suffixCore.startASCII, suffixCount)) == 0
+    if let selfASCIIBuffer = selfCore.asciiBuffer,
+       let suffixASCIIBuffer = suffixCore.asciiBuffer {
+      if suffixASCIIBuffer.count > selfASCIIBuffer.count {
+        // Suffix is longer than self.
+        return false
       }
+      return Int(_swift_stdlib_memcmp(
+        selfASCIIBuffer.baseAddress!
+          + (selfASCIIBuffer.count - suffixASCIIBuffer.count),
+        suffixASCIIBuffer.baseAddress!,
+        suffixASCIIBuffer.count)) == 0
+    }
+    if selfCore.hasContiguousStorage && suffixCore.hasContiguousStorage {
       let lhsStr = _NSContiguousString(selfCore)
       let rhsStr = _NSContiguousString(suffixCore)
       return lhsStr._unsafeWithNotEscapedSelfPointerPair(rhsStr) {

--- a/stdlib/public/stubs/Assert.cpp
+++ b/stdlib/public/stubs/Assert.cpp
@@ -9,17 +9,15 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-//
-// Implementation of
-//
-//===----------------------------------------------------------------------===//
 
 #include "swift/Runtime/Config.h"
 #include "swift/Runtime/Debug.h"
+#include "../SwiftShims/AssertionReporting.h"
 #include <cstdarg>
 #include <cstdint>
 #include <stdio.h>
 #include <stdlib.h>
+#include <inttypes.h>
 
 using namespace swift;
 
@@ -51,79 +49,74 @@ static int swift_asprintf(char **strp, const char *fmt, ...) {
   return result;
 }
 
-// Report a fatal error to system console, stderr, and crash logs.
-// <prefix>: <message>: file <file>, line <line>\n
-// The message may be omitted by passing messageLength=0.
-SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" void
-_swift_stdlib_reportFatalErrorInFile(const char *prefix, intptr_t prefixLength,
-                                   const char *message, intptr_t messageLength,
-                                   const char *file, intptr_t fileLength,
-                                   uintptr_t line,
-                                     uint32_t flags) {
+void swift::_swift_stdlib_reportFatalErrorInFile(
+    const unsigned char *prefix, int prefixLength,
+    const unsigned char *message, int messageLength,
+    const unsigned char *file, int fileLength,
+    uint32_t line,
+    uint32_t flags
+) {
   char *log;
-  swift_asprintf(&log, "%.*s: %.*s%sfile %.*s, line %zu\n", (int)prefixLength,
-                 prefix, (int)messageLength, message,
-                 (messageLength ? ": " : ""), (int)fileLength, file,
-                 (size_t)line);
+  swift_asprintf(
+      &log, "%.*s: %.*s%sfile %.*s, line %" PRIu32 "\n",
+      prefixLength, prefix,
+      messageLength, message,
+      (messageLength ? ": " : ""),
+      fileLength, file,
+      line);
 
   swift_reportError(flags, log);
   free(log);
 }
 
-// Report a fatal error to system console, stderr, and crash logs.
-// <prefix>: <message>: file <file>, line <line>\n
-// The message may be omitted by passing messageLength=0.
-SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" void
-_swift_stdlib_reportFatalError(const char *prefix,
-                               intptr_t prefixLength,
-                               const char *message,
-                               intptr_t messageLength,
-                               uint32_t flags) {
+void swift::_swift_stdlib_reportFatalError(
+    const unsigned char *prefix, int prefixLength,
+    const unsigned char *message, int messageLength,
+    uint32_t flags
+) {
   char *log;
-  swift_asprintf(&log, "%.*s: %.*s\n", (int)prefixLength, prefix,
-                 (int)messageLength, message);
+  swift_asprintf(
+      &log, "%.*s: %.*s\n",
+      prefixLength, prefix,
+      messageLength, message);
 
   swift_reportError(flags, log);
   free(log);
 }
 
-// Report a call to an unimplemented initializer.
-// <file>: <line>: <column>: fatal error: use of unimplemented
-// initializer '<initName>' for class 'className'
-SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" void
-_swift_stdlib_reportUnimplementedInitializerInFile(
-         const char *className, intptr_t classNameLength, const char *initName,
-         intptr_t initNameLength, const char *file, intptr_t fileLength,
-         uintptr_t line, uintptr_t column, uint32_t flags) {
+void swift::_swift_stdlib_reportUnimplementedInitializerInFile(
+    const unsigned char *className, int classNameLength,
+    const unsigned char *initName, int initNameLength,
+    const unsigned char *file, int fileLength,
+    uint32_t line, uint32_t column,
+    uint32_t flags
+) {
   char *log;
-  swift_asprintf(&log, "%.*s: %zu: %zu: fatal error: use of unimplemented "
-                       "initializer '%.*s' for class '%.*s'\n",
-                 (int)fileLength, file, (size_t)line, (size_t)column,
-                 (int)initNameLength, initName, (int)classNameLength,
-                 className);
+  swift_asprintf(
+      &log,
+      "%.*s: %" PRIu32 ": %" PRIu32 ": fatal error: use of unimplemented "
+      "initializer '%.*s' for class '%.*s'\n",
+      fileLength, file,
+      line, column,
+      initNameLength, initName,
+      classNameLength, className);
 
   swift_reportError(flags, log);
   free(log);
 }
 
-// Report a call to an unimplemented initializer.
-// fatal error: use of unimplemented initializer '<initName>' for class
-// 'className'
-SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" void
-_swift_stdlib_reportUnimplementedInitializer(const char *className,
-                                             intptr_t classNameLength,
-                                             const char *initName,
-                                             intptr_t initNameLength,
-                                             uint32_t flags) {
+void swift::_swift_stdlib_reportUnimplementedInitializer(
+    const unsigned char *className, int classNameLength,
+    const unsigned char *initName, int initNameLength,
+    uint32_t flags
+) {
   char *log;
-  swift_asprintf(&log, "fatal error: use of unimplemented "
-                       "initializer '%.*s' for class '%.*s'\n",
-                 (int)initNameLength, initName, (int)classNameLength,
-                 className);
+  swift_asprintf(
+      &log,
+      "fatal error: use of unimplemented "
+      "initializer '%.*s' for class '%.*s'\n",
+      initNameLength, initName,
+      classNameLength, className);
 
   swift_reportError(flags, log);
   free(log);


### PR DESCRIPTION
- replace error-prone pairs of isASCII/startASCII calls with an API that returns Optional
- annotate `LibcShims.h` with nullability
- declare functions for assertion reporting in SwiftShims instead of using `@_silgen_name`
- stdlib: annotate `AssertionReporting.h` with nullability
