### PR TITLE
[tests] Reduce left over files in system temp directory after test execution

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
+++ b/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
@@ -92,6 +92,10 @@ public func createTemporaryFile(
   return fileName
 }
 
+public func removeFile(_ fileName: String) -> Bool {
+  return remove(fileName) == 0
+}
+
 public final class Box<T> {
   public init(_ value: T) { self.value = value }
   public var value: T

--- a/test/FixCode/fixits-apply-all.swift
+++ b/test/FixCode/fixits-apply-all.swift
@@ -1,8 +1,9 @@
 // This tests whether we accept fixits from warnings without filtering.
 // The particular diagnostics used are not important.
 
+// RUN: rm -rf %t.out && mkdir -p %t.out
 // RUN: %swift -parse -target %target-triple %s -fixit-all -emit-fixits-path %t.remap
-// RUN: c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
+// RUN: env TMPDIR=%t.out c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
 
 func ftest1() {
   let myvar = 0

--- a/test/FixCode/fixits-apply-all.swift.result
+++ b/test/FixCode/fixits-apply-all.swift.result
@@ -1,8 +1,9 @@
 // This tests whether we accept fixits from warnings without filtering.
 // The particular diagnostics used are not important.
 
+// RUN: rm -rf %t.out && mkdir -p %t.out
 // RUN: %swift -parse -target %target-triple %s -fixit-all -emit-fixits-path %t.remap
-// RUN: c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
+// RUN: env TMPDIR=%t.out c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
 
 func ftest1() {
   _ = 0

--- a/test/FixCode/fixits-apply-objc.swift
+++ b/test/FixCode/fixits-apply-objc.swift
@@ -1,5 +1,6 @@
+// RUN: rm -rf %t.out && mkdir -p %t.out
 // RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-objc-attr-requires-foundation-module -parse %s -emit-fixits-path %t.remap
-// RUN: c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
+// RUN: env TMPDIR=%t.out c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
 import ObjectiveC
 
 // REQUIRES: objc_interop

--- a/test/FixCode/fixits-apply-objc.swift.result
+++ b/test/FixCode/fixits-apply-objc.swift.result
@@ -1,5 +1,6 @@
+// RUN: rm -rf %t.out && mkdir -p %t.out
 // RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-objc-attr-requires-foundation-module -parse %s -emit-fixits-path %t.remap
-// RUN: c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
+// RUN: env TMPDIR=%t.out c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
 import ObjectiveC
 
 // REQUIRES: objc_interop

--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -1,5 +1,6 @@
+// RUN: rm -rf %t.out && mkdir -p %t.out
 // RUN: not %swift -parse -target %target-triple %s -emit-fixits-path %t.remap -I %S/Inputs
-// RUN: c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
+// RUN: env TMPDIR=%t.out c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
 
 class Base {}
 class Derived : Base {}

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -1,5 +1,6 @@
+// RUN: rm -rf %t.out && mkdir -p %t.out
 // RUN: not %swift -parse -target %target-triple %s -emit-fixits-path %t.remap -I %S/Inputs
-// RUN: c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
+// RUN: env TMPDIR=%t.out c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
 
 class Base {}
 class Derived : Base {}

--- a/test/FixCode/multi-inputs.swift
+++ b/test/FixCode/multi-inputs.swift
@@ -1,7 +1,7 @@
-// RUN: mkdir -p %t.out
+// RUN: rm -rf %t.out && mkdir -p %t.out
 // RUN: echo "{\"%S/Inputs/t1.swift\": {\"remap\": \"%t.out/t1.remap\"}, \"%S/Inputs/t2.swift\": {\"remap\": \"%t.out/t2.remap\"}}" > %t.json
 // RUN: not %swiftc_driver -target %target-triple -module-name Blah -fixit-code %S/Inputs/t1.swift %S/Inputs/t2.swift -emit-module -emit-module-path %t.mod -emit-objc-header -emit-objc-header-path %t.h -j 1 -output-file-map %t.json 2> %t.err.txt
-// RUN: c-arcmt-test %t.out/t1.remap %t.out/t2.remap | arcmt-test -verify-transformed-files %S/Inputs/t1.swift.result %S/Inputs/t2.swift.result
+// RUN: env TMPDIR=%t.out c-arcmt-test %t.out/t1.remap %t.out/t2.remap | arcmt-test -verify-transformed-files %S/Inputs/t1.swift.result %S/Inputs/t2.swift.result
 // RUN: %FileCheck --input-file=%t.err.txt %s
 
 // CHECK: error: use of unresolved identifier 'undeclared_foo1'

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -324,6 +324,10 @@ if test_sdk_overlay_dir is not None:
 test_options = os.environ.get('SWIFT_TEST_OPTIONS')
 config.swift_test_options = ' ' + test_options if test_options else ''
 
+# FIXME: This should not be needed, but unnormalized path will confuse
+# module-cache machinery.
+config.swift_test_results_dir = os.path.normpath(config.swift_test_results_dir)
+
 lit_config.note("Using test results dir: " + config.swift_test_results_dir)
 
 clang_module_cache_path = os.path.join(config.swift_test_results_dir, 'ModuleCache')

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -324,13 +324,14 @@ if test_sdk_overlay_dir is not None:
 test_options = os.environ.get('SWIFT_TEST_OPTIONS')
 config.swift_test_options = ' ' + test_options if test_options else ''
 
-clang_module_cache_path = tempfile.mkdtemp(prefix="swift-testsuite-clang-module-cache")
+lit_config.note("Using test results dir: " + config.swift_test_results_dir)
+
+clang_module_cache_path = os.path.join(config.swift_test_results_dir, 'ModuleCache')
 mcp_opt = "-module-cache-path %r" % clang_module_cache_path
 clang_mcp_opt = "-fmodules-cache-path=%r" % clang_module_cache_path
 lit_config.note("Using Clang module cache: " + clang_module_cache_path)
-lit_config.note("Using test results dir: " + config.swift_test_results_dir)
 
-completion_cache_path = tempfile.mkdtemp(prefix="swift-testsuite-completion-cache")
+completion_cache_path = os.path.join(config.swift_test_results_dir, 'CompletionCache')
 ccp_opt = "-completion-cache-path %r" % completion_cache_path
 lit_config.note("Using code completion cache: " + completion_cache_path)
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -515,6 +515,14 @@ config.target_swiftmodule_name = "unknown.swiftmodule"
 config.target_swiftdoc_name = "unknown.swiftdoc"
 config.target_runtime = "unknown"
 
+target_options = (
+    "-target %s %s %s" %
+    (config.variant_triple, resource_dir_opt, mcp_opt))
+target_options_for_mock_sdk = (
+    "-target %s %s %s" %
+    (config.variant_triple, stdlib_resource_dir_opt, mcp_opt))
+target_options_for_mock_sdk_after = sdk_overlay_dir_opt
+
 if run_vendor == 'apple':
     config.available_features.add('objc_interop')
     config.target_swiftmodule_name = run_cpu + ".swiftmodule"
@@ -528,13 +536,6 @@ if run_vendor == 'apple':
         (config.darwin_xcrun_toolchain, config.variant_sdk))
     extra_frameworks_dir = os.path.join(config.variant_sdk,
         "..", "..", "..", "Developer", "Library", "Frameworks")
-    target_options = (
-        "-target %s %s %s" %
-        (config.variant_triple, resource_dir_opt, mcp_opt))
-    target_options_for_mock_sdk = (
-        "-target %s %s %s" %
-        (config.variant_triple, stdlib_resource_dir_opt, mcp_opt))
-    target_options_for_mock_sdk_after = sdk_overlay_dir_opt
 
     if 'arm' in run_cpu and swift_test_mode != 'only_non_executable':
         raise RuntimeError('Device tests are not currently supported.')
@@ -722,20 +723,19 @@ elif run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'wi
     config.target_runtime = "native"
     config.target_swift_autolink_extract = inferSwiftBinary("swift-autolink-extract")
     config.target_build_swift = (
-        '%s -target %s %s %s %s %s'
-        % (config.swiftc, config.variant_triple, resource_dir_opt, mcp_opt,
+        '%s %s %s %s'
+        % (config.swiftc, target_options,
            config.swift_test_options, swift_execution_tests_extra_flags))
     config.target_swift_frontend = (
-        '%s -frontend -target %s %s'
-        % (config.swift, config.variant_triple, resource_dir_opt))
+        '%s -frontend %s'
+        % (config.swift, target_options))
     subst_target_swift_frontend_mock_sdk = config.target_swift_frontend
     subst_target_swift_frontend_mock_sdk_after = ""
     config.target_run = ''
     if 'interpret' in lit_config.params:
         target_run_base = (
-            '%s -target %s %s %s -module-name main%s %s'
-            % (config.swift, config.variant_triple, resource_dir_opt,
-               mcp_opt, config.swift_test_options,
+            '%s %s -module-name main%s %s'
+            % (config.swift, target_options, config.swift_test_options,
                swift_execution_tests_extra_flags))
         config.target_run_simple_swift = (
             '%s %%s' % (target_run_base))
@@ -749,20 +749,19 @@ elif run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'wi
         config.available_features.add('interpret')
         config.environment['SWIFT_INTERPRETER'] = config.swift
     config.target_sil_opt = (
-        '%s -target %s %s %s' %
-        (config.sil_opt, config.variant_triple, resource_dir_opt, mcp_opt))
+        '%s %s' %
+        (config.sil_opt, target_options))
     config.target_swift_ide_test = (
-        '%s -target %s %s %s %s' %
-        (config.swift_ide_test, config.variant_triple, resource_dir_opt,
-         mcp_opt, ccp_opt))
+        '%s %s %s' %
+        (config.swift_ide_test, target_options, ccp_opt))
     subst_target_swift_ide_test_mock_sdk = config.target_swift_ide_test
     subst_target_swift_ide_test_mock_sdk_after = ""
     config.target_swiftc_driver = (
-        "%s -target %s %s %s" %
-        (config.swiftc, config.variant_triple, resource_dir_opt, mcp_opt))
+        "%s %s" %
+        (config.swiftc, target_options))
     config.target_swift_modulewrap = (
-        '%s -modulewrap -target %s' %
-        (config.swiftc, config.variant_triple))
+        '%s -modulewrap %s' %
+        (config.swiftc, target_options))
     config.target_clang = (
         "clang++ -target %s %s" %
         (config.variant_triple, clang_mcp_opt))
@@ -968,9 +967,11 @@ config.substitutions.append(('%target-swift-reflection-test', lit.util.which('sw
 config.substitutions.append(('%target-swift-reflection-dump', '{} {} {}'.format(config.swift_reflection_dump, '-arch', run_cpu)))
 config.substitutions.append(('%target-swiftc_driver', config.target_swiftc_driver))
 config.substitutions.append(('%target-swift-remoteast-test-with-sdk',
-                             '%s -sdk %s' %
-                               (config.swift_remoteast_test, config.variant_sdk)))
-config.substitutions.append(('%target-swift-remoteast-test', config.swift_remoteast_test))
+                             '%s -sdk %s %s' %
+                               (config.swift_remoteast_test, config.variant_sdk, mcp_opt)))
+config.substitutions.append(('%target-swift-remoteast-test',
+                             '%s %s' %
+                               (config.swift_remoteast_test, mcp_opt)))
 
 if hasattr(config, 'target_swift_autolink_extract'):
     config.available_features.add('autolink-extract')

--- a/test/stdlib/NSStringAPI.swift
+++ b/test/stdlib/NSStringAPI.swift
@@ -52,15 +52,26 @@ let temporaryFileContents =
   "sed do eiusmod tempor incididunt ut labore et dolore magna\n" +
   "aliqua.\n"
 
+var temporaryFileNames: [String] = []
+
 func createNSStringTemporaryFile()
   -> (existingPath: String, nonExistentPath: String) {
   let existingPath =
     createTemporaryFile("NSStringAPIs.", ".txt", temporaryFileContents)
   let nonExistentPath = existingPath + "-NoNeXiStEnT"
+  temporaryFileNames.append(existingPath)
+  temporaryFileNames.append(nonExistentPath)
   return (existingPath, nonExistentPath)
 }
 
 var NSStringAPIs = TestSuite("NSStringAPIs")
+
+NSStringAPIs.tearDown {
+  for fileName in temporaryFileNames {
+    _ = removeFile(fileName)
+  }
+  temporaryFileNames = []
+}
 
 NSStringAPIs.test("Encodings") {
   let availableEncodings: [String.Encoding] = String.availableStringEncodings

--- a/utils/swift_build_support/tests/test_tar.py
+++ b/utils/swift_build_support/tests/test_tar.py
@@ -23,6 +23,7 @@ from swift_build_support.tar import tar
 
 class TarTestCase(unittest.TestCase):
     def setUp(self):
+        _, self.tmppath = tempfile.mkstemp()
         self._orig_stdout = sys.stdout
         self._orig_stderr = sys.stderr
         self.stdout = StringIO()
@@ -33,12 +34,12 @@ class TarTestCase(unittest.TestCase):
     def tearDown(self):
         sys.stdout = self._orig_stdout
         sys.stderr = self._orig_stderr
+        os.remove(self.tmppath)
 
     def test_tar_this_file_succeeds(self):
         # `tar` complains about absolute paths, so use a relative path here.
         source = os.path.relpath(__file__)
-        _, destination = tempfile.mkstemp()
-        tar(source=source, destination=destination)
+        tar(source=source, destination=self.tmppath)
 
         if platform.system() == "Darwin":
             expect = "+ tar -c -z -f {dest} {source}\n"
@@ -47,7 +48,7 @@ class TarTestCase(unittest.TestCase):
 
         self.assertEqual(self.stdout.getvalue(), "")
         self.assertEqual(self.stderr.getvalue(),
-                         expect.format(dest=destination, source=source))
+                         expect.format(dest=self.tmppath, source=source))
 
     def test_tar_nonexistent_file_raises(self):
         with self.assertRaises(SystemExit):


### PR DESCRIPTION
- Create `module_cache_path` and `completion_cache_path` in the test results directory.
- Use `-module-cache-path` option as much as possible. Especially in Linux, that was used only for very limited `lit` substitutions.
- `swift_build_support` tests: Remove temporary file after test execution.
- FixCode: Set `TMPDIR` environment variable as `%t.out`. So that `c-arcmt-test` doesn't leave output files in the system temporary directory.
- `NSStringAPI` test: clean temporary files.
