### PR TITLE
Introduce unqualified name lookup based on ASTScopes

### DIFF
--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -75,8 +75,9 @@ enum class ASTScopeKind : uint8_t {
   PatternBinding,
   /// The scope introduced for an initializer of a pattern binding.
   PatternInitializer,
-  /// The scope introduced by a particular clause in a pattern binding
-  /// declaration.
+  /// The scope following a particular clause in a pattern binding declaration,
+  /// which is the outermost scope in which the variables introduced by that
+  /// clause will be visible.
   AfterPatternBinding,
   /// The scope introduced by a brace statement.
   BraceStmt,
@@ -542,6 +543,18 @@ public:
   ///
   /// \seealso getDeclContext().
   DeclContext *getInnermostEnclosingDeclContext() const;
+
+  /// Retrueve the declarations whose names are directly bound by this scope.
+  ///
+  /// The declarations bound in this scope aren't available in the immediate
+  /// parent of this scope, but will still be visible in child scopes (unless
+  /// shadowed there).
+  ///
+  /// Note that this routine does not produce bindings for anything that can
+  /// be found via qualified name lookup in a \c DeclContext, such as nominal
+  /// type declarations or extensions thereof, or the source file itself. The
+  /// client can perform such lookups using the result of \c getDeclContext().
+  SmallVector<ValueDecl *, 4> getLocalBindings() const;
 
   /// Expand the entire scope map.
   ///

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -141,6 +141,9 @@ namespace swift {
     /// new enough?
     bool EnableTargetOSChecking = true;
 
+    /// Should we use \c ASTScope-based resolution for unqualified name lookup?
+    bool EnableASTScopeLookup = false;
+
     /// Whether to use the import as member inference system
     ///
     /// When importing a global, try to infer whether we can import it as a

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -102,6 +102,9 @@ def disable_target_os_checking :
   Flag<["-"], "disable-target-os-checking">,
   HelpText<"Disable checking the target OS of serialized modules">;
 
+def enable_astscope_lookup : Flag<["-"], "enable-astscope-lookup">,
+  HelpText<"Enable ASTScope-based unqualified name lookup">;
+
 def print_clang_stats : Flag<["-"], "print-clang-stats">,
   HelpText<"Print Clang importer statistics">;
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -541,6 +541,9 @@ public:
   }
 
   ValueDecl *lookupInScope(DeclName Name) {
+    if (Context.LangOpts.EnableASTScopeLookup)
+      return nullptr;
+
     return getScopeInfo().lookupValueName(Name);
   }
 

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -1568,7 +1568,7 @@ DeclContext *ASTScope::getDeclContext() const {
 
   case ASTScopeKind::Accessors:
     // FIXME: Somewhat odd modeling because Subscripts don't have their
-    // own nodes. Maybe that should.
+    // own nodes. Maybe they should.
     if (auto subscript = dyn_cast<SubscriptDecl>(abstractStorageDecl))
       return subscript;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -795,6 +795,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
       = A->getOption().matches(OPT_enable_target_os_checking);
   }
   
+  Opts.EnableASTScopeLookup |= Args.hasArg(OPT_enable_astscope_lookup);
   Opts.DebugConstraintSolver |= Args.hasArg(OPT_debug_constraints);
   Opts.IterativeTypeChecker |= Args.hasArg(OPT_iterative_type_checker);
   Opts.DebugGenericSignatures |= Args.hasArg(OPT_debug_generic_signatures);

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -814,6 +814,20 @@ static bool performCompile(CompilerInstance &Instance,
           if (auto dc = locScope->getDeclContext()) {
             dc->printContext(llvm::errs());
           }
+
+          // Grab the local bindings introduced by this scope.
+          auto localBindings = locScope->getLocalBindings();
+          if (!localBindings.empty()) {
+            llvm::errs() << "Local bindings: ";
+            interleave(localBindings.begin(), localBindings.end(),
+                       [&](ValueDecl *value) {
+                         llvm::errs() << value->getFullName();
+                       },
+                       [&]() {
+                         llvm::errs() << " ";
+                       });
+            llvm::errs() << "\n";
+          }
         }
 
         llvm::errs() << "***Complete scope map***\n";

--- a/test/NameBinding/scope_map.swift
+++ b/test/NameBinding/scope_map.swift
@@ -401,9 +401,11 @@ func localPatternsWithSharedType() {
 
 // CHECK-SEARCHES-LABEL: ***Scope at 70:8***
 // CHECK-SEARCHES-NEXT: AfterPatternBinding {{.*}} entry 0 [69:13 - 71:3] expanded
+// CHECK-SEARCHES-NEXT: Local bindings: c
 
 // CHECK-SEARCHES-LABEL: ***Scope at 26:20***
 // CHECK-SEARCHES-NEXT: AbstractFunctionParams {{.*}} init(t:u:) param 1:0 [26:17 - 27:3] expanded
+// CHECK-SEARCHES-NEXT: Local bindings: t
 
 // CHECK-SEARCHES-LABEL: ***Scope at 5:18***
 // CHECK-SEARCHES-NEXT: TypeOrExtensionBody {{.*}} 'InnerC0' [5:17 - 5:19] expanded

--- a/test/NameBinding/scope_map_lookup.swift
+++ b/test/NameBinding/scope_map_lookup.swift
@@ -1,0 +1,10 @@
+// RUN: %target-parse-verify-swift %s -enable-astscope-lookup
+
+// Name binding in default arguments
+
+// FIXME: Semantic analysis should produce an error here, because 'x'
+// is not actually available.
+func functionParamScopes(x: Int, y: Int = x) -> Int {
+  return x + y
+}
+


### PR DESCRIPTION
<!-- What's in this pull request? -->

This pull request introduces a new, temporary and experimental flag '-enable-astscope-lookup' that reimplements unqualified name lookup in terms of the new `ASTScope` data structure. There are some outright bugs in this new name lookup implementation, as well as a number of places where the implementation needs to perform more semantic analysis because we were relying on (weird, indefensible, but convenient) name lookup behavior to diagnose problems.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
