### PR TITLE
Fix a bug related to the opened archetypes tracking

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -135,6 +135,11 @@ public:
   void setInsertionPoint(SILBasicBlock *BB, SILBasicBlock::iterator InsertPt) {
     this->BB = BB;
     this->InsertPt = InsertPt;
+    if (InsertPt == BB->end())
+      return;
+    // Set the opened archetype context from the instruction.
+    this->getOpenedArchetypes().addOpenedArchetypeOperands(
+        InsertPt->getOpenedArchetypeOperands());
   }
 
   /// setInsertionPoint - Set the insertion point to insert before the specified
@@ -175,6 +180,14 @@ public:
 
   SmallVectorImpl<SILInstruction *> *getTrackingList() {
     return InsertedInstrs;
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Opened archetypes handling
+  //===--------------------------------------------------------------------===//
+  void addOpenedArchetypeOperands(SILInstruction *I) {
+    getOpenedArchetypes().addOpenedArchetypeOperands(
+        I->getOpenedArchetypeOperands());
   }
 
   //===--------------------------------------------------------------------===//

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -721,6 +721,7 @@ SILCombiner::createApplyWithConcreteType(FullApplySite AI,
 
   FullApplySite NewAI;
   Builder.setCurrentDebugScope(AI.getDebugScope());
+  Builder.addOpenedArchetypeOperands(AI.getInstruction());
 
   if (auto *TAI = dyn_cast<TryApplyInst>(AI))
     NewAI = Builder.createTryApply(AI.getLoc(), AI.getCallee(),
@@ -1169,6 +1170,7 @@ SILInstruction *SILCombiner::visitApplyInst(ApplyInst *AI) {
     // The type of the substitution is the source type of the thin to thick
     // instruction.
     SILType substTy = TTTFI->getOperand()->getType();
+    Builder.addOpenedArchetypeOperands(AI);
     auto *NewAI = Builder.createApply(AI->getLoc(), TTTFI->getOperand(),
                                       substTy, AI->getType(),
                                       AI->getSubstitutions(), Arguments,

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -50,6 +50,7 @@ STATISTIC(NumTargetsPredicted, "Number of monomorphic functions predicted");
 static FullApplySite CloneApply(FullApplySite AI, SILBuilder &Builder) {
   // Clone the Apply.
   Builder.setCurrentDebugScope(AI.getDebugScope());
+  Builder.addOpenedArchetypeOperands(AI.getInstruction());
   auto Args = AI.getArguments();
   SmallVector<SILValue, 8> Ret(Args.size());
   for (unsigned i = 0, e = Args.size(); i != e; ++i)

--- a/test/SILOptimizer/opened_archetype_operands_tracking.sil
+++ b/test/SILOptimizer/opened_archetype_operands_tracking.sil
@@ -1,0 +1,64 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -O | %FileCheck %s
+
+// Check some corner cases related to tracking of opened archetypes.
+// For example, the compiler used to crash compiling the "process" function (rdar://28024272)
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+public protocol P {
+}
+
+extension P {
+  func invokeClosure(_ closure: () throws -> ()) rethrows
+}
+
+public func process(s: P)
+
+sil @invokeClosure : $@convention(method) <Self where Self : P> (@owned @callee_owned () -> @error Error, @in_guaranteed Self) -> @error Error {
+bb0(%0 : $@callee_owned () -> @error Error, %1 : $*Self):
+  strong_release %0 : $@callee_owned () -> @error Error
+  %5 = tuple ()
+  return %5 : $()
+}
+
+sil @closure : $@convention(thin) () -> () {
+bb0:
+  %0 = tuple ()
+  debug_value %0 : $()
+  %2 = tuple ()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil @process
+// CHECK: bb0
+// CHECK-NOT: try_apply
+// CHECK-NOT: unreachable
+// CHECK: apply
+// CHECK-NOT: unreachable
+// CHECK: return
+sil @process : $@convention(thin) (@in P) -> () {
+bb0(%0 : $*P):
+  %2 = open_existential_addr %0 : $*P to $*@opened("4C22C24E-6BAA-11E6-B904-B8E856428C60") P
+  %3 = function_ref @invokeClosure : $@convention(method) <τ_0_0 where τ_0_0 : P> (@owned @callee_owned () -> @error Error, @in_guaranteed τ_0_0) -> @error Error
+  // function_ref (process(s : P) -> ()).(closure #1)
+  %4 = function_ref @closure : $@convention(thin) () -> ()
+  %5 = thin_to_thick_function %4 : $@convention(thin) () -> () to $@callee_owned () -> ()
+  %6 = convert_function %5 : $@callee_owned () -> () to $@callee_owned () -> @error Error
+  try_apply %3<@opened("4C22C24E-6BAA-11E6-B904-B8E856428C60") P>(%6, %2) : $@convention(method) <τ_0_0 where τ_0_0 : P> (@owned @callee_owned () -> @error Error, @in_guaranteed τ_0_0) -> @error Error, normal bb1, error bb2
+
+bb1(%8 : $()):
+  destroy_addr %0 : $*P
+  %10 = tuple ()
+  return %10 : $()
+
+bb2(%12 : $Error):
+  unreachable
+}
+
+sil_default_witness_table P {
+}
+


### PR DESCRIPTION
<!-- What's in this pull request? -->

––– CCC Information –––
• Explanation: It is a correctness fix for opened archetypes tracking.
• Scope of Issue: Compiler crash reported by Dave Abrahams
• Origination: rdar://problem/28024272
• Risk: Pretty low. It fixes some cases which would result in a compiler crash. No new functionality is added.
• Reviewed By: Erik Eckstein
• Testing: Verified locally and using a CI @please test
• Directions for QA: No special directions. The patch includes unit tests.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

Detailed description

If a SILBuilder creates a new instruction based on an old instruction and a new instruction is supposed to use some opened archetypes, one needs to set a proper opened archetypes context in the builder based on the opened archetypes used by the old instruction.

This fixes rdar://28024272
