### PR TITLE
[Type checker] Infer @objc for protocol conformances in other extensions

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2069,7 +2069,7 @@ static Optional<ObjCReason> shouldMarkAsObjC(TypeChecker &TC,
   // A witness to an @objc protocol requirement is implicitly @objc.
   else if (!TC.findWitnessedObjCRequirements(
              VD,
-             /*onlyFirstRequirement=*/true).empty())
+             /*anySingleRequirement=*/true).empty())
     return ObjCReason::WitnessToObjC;
   else if (VD->isInvalid())
     return None;
@@ -2280,8 +2280,7 @@ static void inferObjCName(TypeChecker &tc, ValueDecl *decl) {
   // requirements for which this declaration is a witness.
   Optional<ObjCSelector> requirementObjCName;
   ValueDecl *firstReq = nullptr;
-  for (auto req : tc.findWitnessedObjCRequirements(decl,
-                                                   /*onlyFirst=*/false)) {
+  for (auto req : tc.findWitnessedObjCRequirements(decl)) {
     // If this is the first requirement, take its name.
     if (!requirementObjCName) {
       requirementObjCName = req->getObjCRuntimeName();

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4875,7 +4875,7 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
 
 llvm::TinyPtrVector<ValueDecl *>
 TypeChecker::findWitnessedObjCRequirements(const ValueDecl *witness,
-                                           bool onlyFirstRequirement) {
+                                           bool anySingleRequirement) {
   llvm::TinyPtrVector<ValueDecl *> result;
 
   // Types don't infer @objc this way.
@@ -4883,10 +4883,11 @@ TypeChecker::findWitnessedObjCRequirements(const ValueDecl *witness,
 
   auto dc = witness->getDeclContext();
   auto name = witness->getFullName();
-  for (auto conformance : dc->getLocalConformances(ConformanceLookupKind::All,
-                                                   nullptr, /*sorted=*/true)) {
+  auto nominal = dc->getAsNominalTypeOrNominalTypeExtensionContext();
+  if (!nominal) return result;
+
+  for (auto proto : nominal->getAllProtocols()) {
     // We only care about Objective-C protocols.
-    auto proto = conformance->getProtocol();
     if (!proto->isObjC()) continue;
 
     for (auto req : proto->lookupDirect(name, true)) {
@@ -4895,16 +4896,41 @@ TypeChecker::findWitnessedObjCRequirements(const ValueDecl *witness,
 
       // Skip types.
       if (isa<TypeDecl>(req)) continue;
+      
+      // Dig out the conformance.
+      Optional<ProtocolConformance *> conformance;
+      if (!conformance.hasValue()) {
+        SmallVector<ProtocolConformance *, 2> conformances;
+        nominal->lookupConformance(dc->getParentModule(), proto,
+                                   conformances);
+        if (conformances.size() == 1)
+          conformance = conformances.front();
+        else
+          conformance = nullptr;
+      }
+      if (!*conformance) continue;
 
       // Determine whether the witness for this conformance is in fact
       // our witness.
-      if (conformance->getWitness(req, this).getDecl() == witness) {
+      if ((*conformance)->getWitness(req, this).getDecl() == witness) {
         result.push_back(req);
-        if (onlyFirstRequirement) return result;
+        if (anySingleRequirement) return result;
       }
     }
   }
 
+  // Sort the results.
+  if (result.size() > 2) {
+    std::stable_sort(result.begin(), result.end(),
+                     [&](ValueDecl *lhs, ValueDecl *rhs) {
+                       ProtocolDecl *lhsProto
+                         = cast<ProtocolDecl>(lhs->getDeclContext());
+                       ProtocolDecl *rhsProto
+                         = cast<ProtocolDecl>(rhs->getDeclContext());
+                       return ProtocolType::compareProtocols(&lhsProto,
+                                                             &rhsProto) < 0;
+                     });
+  }
   return result;
 }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2712,8 +2712,7 @@ static void describeObjCReason(TypeChecker &TC, const ValueDecl *VD,
     TC.diagnose(overridden, diag::objc_overriding_objc_decl,
                 kind, VD->getOverriddenDecl()->getFullName());
   } else if (Reason == ObjCReason::WitnessToObjC) {
-    auto requirement =
-      TC.findWitnessedObjCRequirements(VD, /*onlyFirst=*/true).front();
+    auto requirement = TC.findWitnessedObjCRequirements(VD).front();
     TC.diagnose(requirement, diag::objc_witness_objc_requirement,
                 VD->getDescriptiveKind(), requirement->getFullName(),
                 cast<ProtocolDecl>(requirement->getDeclContext())

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1592,14 +1592,14 @@ public:
   /// Find the @objc requirement that are witnessed by the given
   /// declaration.
   ///
-  /// \param onlyFirstRequirement If true, only returns the first such
-  /// requirement, rather than all of them.
+  /// \param anySingleRequirement If true, returns at most a single requirement,
+  /// which might be any of the requirements that match.
   ///
   /// \returns the set of requirements to which the given witness is a
   /// witness.
   llvm::TinyPtrVector<ValueDecl *> findWitnessedObjCRequirements(
                                      const ValueDecl *witness,
-                                     bool onlyFirstRequirement);
+                                     bool anySingleRequirement = false);
 
   /// Mark any _ObjectiveCBridgeable conformances in the given type as "used".
   void useObjectiveCBridgeableConformances(DeclContext *dc, Type type);

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.response
@@ -5076,6 +5076,11 @@ var FooSubUnnamedEnumeratorA1: Int { get }
           {
             key.kind: source.lang.swift.ref.function.constructor,
             key.name: "init(rawValue:)",
+            key.usr: "s:FPs9OptionSetcFT8rawValuewx8RawValue_x"
+          },
+          {
+            key.kind: source.lang.swift.ref.function.constructor,
+            key.name: "init(rawValue:)",
             key.usr: "s:FPs16RawRepresentablecFT8rawValuewx8RawValue_GSqx_"
           }
         ],

--- a/test/decl/protocol/req/optional.swift
+++ b/test/decl/protocol/req/optional.swift
@@ -6,11 +6,11 @@
 @objc class ObjCClass { }
 
 @objc protocol P1 {
-  @objc optional func method(_ x: Int) // expected-note 2{{requirement 'method' declared here}}
+  @objc optional func method(_ x: Int) // expected-note {{requirement 'method' declared here}}
 
-  @objc optional var prop: Int { get } // expected-note{{requirement 'prop' declared here}}
+  @objc optional var prop: Int { get }
 
-  @objc optional subscript (i: Int) -> ObjCClass? { get } // expected-note{{requirement 'subscript' declared here}}
+  @objc optional subscript (i: Int) -> ObjCClass? { get }
 }
 
 @objc protocol P2 {
@@ -38,10 +38,6 @@ class C2 : P1 {
     set {}
   }
 }
-
-// -----------------------------------------------------------------------
-// "Near" matches.
-// -----------------------------------------------------------------------
 
 class C3 : P1 {
   func method(_ x: Int) { } 
@@ -71,20 +67,18 @@ extension C4 : P1 {
   }
 }
 
+// -----------------------------------------------------------------------
+// Okay to match via extensions.
+// -----------------------------------------------------------------------
+
 class C5 : P1 { }
 
 extension C5 {
   func method(_ x: Int) { } 
-  // expected-warning@-1{{non-'@objc' method 'method' does not satisfy optional requirement of '@objc' protocol 'P1'}}{{3-3=@objc }}
-  // expected-note@-2{{add '@nonobjc' to silence this warning}}{{3-3=@nonobjc }}
 
   var prop: Int { return 5 }
-  // expected-warning@-1{{non-'@objc' property 'prop' does not satisfy optional requirement of '@objc' protocol 'P1'}}{{3-3=@objc }}
-  // expected-note@-2{{add '@nonobjc' to silence this warning}}{{3-3=@nonobjc }}
 
   subscript (i: Int) -> ObjCClass? {
-    // expected-warning@-1{{non-'@objc' subscript does not satisfy optional requirement of '@objc' protocol 'P1'}}{{3-3=@objc }}
-    // expected-note@-2{{add '@nonobjc' to silence this warning}}{{3-3=@nonobjc }}
     get {
       return nil
     }
@@ -92,7 +86,7 @@ extension C5 {
   }
 }
 
-// Note: @nonobjc suppresses warnings
+// Note: @nonobjc suppresses witness match.
 class C6 { }
 
 extension C6 : P1 {
@@ -107,6 +101,10 @@ extension C6 : P1 {
     set {}
   }
 }
+
+// -----------------------------------------------------------------------
+// "Near" matches.
+// -----------------------------------------------------------------------
 
 // Note: warn about selector matches where the Swift names didn't match.
 @objc class C7 : P1 { // expected-note{{class 'C7' declares conformance to protocol 'P1' here}}


### PR DESCRIPTION
<!-- What's in this pull request? -->

Expand the scope of @objc inference for witnesses to encompass
witnesses that are in a different extension from that of the
conformance, including cases where one or the other is in the nominal
type declaration itself.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [rdar://problem/26892526](rdar://problem/26892526).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
