### PR TITLE
Fix a globalvariable initializer bug in LLVMSwiftARC

### DIFF
--- a/lib/LLVMPasses/LLVMARCOpts.cpp
+++ b/lib/LLVMPasses/LLVMARCOpts.cpp
@@ -545,8 +545,10 @@ static DtorKind analyzeDestructor(Value *P) {
 
   // We have to have a known heap metadata value, reject dynamically computed
   // ones, or places
+  // Also, make sure we have a definitive initializer for the global.
   GlobalVariable *GV = dyn_cast<GlobalVariable>(P->stripPointerCasts());
-  if (GV == 0 || GV->mayBeOverridden()) return DtorKind::Unknown;
+  if (GV == 0 || !GV->hasDefinitiveInitializer())
+    return DtorKind::Unknown;
 
   ConstantStruct *CS = dyn_cast_or_null<ConstantStruct>(GV->getInitializer());
   if (CS == 0 || CS->getNumOperands() == 0) return DtorKind::Unknown;

--- a/test/LLVMPasses/allocation-deletion.ll
+++ b/test/LLVMPasses/allocation-deletion.ll
@@ -81,4 +81,19 @@ entry:
 ; CHECK-NEXT: ret void
 
 
+; external_dtor_alloc_eliminate -  Make sure we can not eliminate the allocation
+; because we know nothing about the type of the allocation.
+@external_dtor_metadata = external global %swift.heapmetadata, align 8
+define void @external_dtor_alloc_eliminate() nounwind {
+entry:
+  %0 = tail call noalias %swift.refcounted* @swift_allocObject(%swift.heapmetadata* nonnull @external_dtor_metadata, i64 24, i64 8) nounwind
+  tail call void @swift_release(%swift.refcounted* %0) nounwind
+  ret void
+}
+
+; CHECK: @external_dtor_alloc_eliminate
+; CHECK-NEXT: entry:
+; CHECK-NEXT: swift_allocObject
+; CHECK-NEXT: swift_release
+; CHECK-NEXT: ret void
 


### PR DESCRIPTION
––– CCC Information –––
• Explanation: It is a possible compiler crash fix when LLVM ARC tries to get initializer for globals that are external.
• Scope of Issue: It can happen when we call getInitializer() for globals that are external in LLVM ARC pass.
• Origination:  Long standing bug for multiple years. rdar://problem/27941015
• Risk: very low. 
• Reviewed By: Erik Eckstein
• Testing: Verified locally and using a CI @please smoke test
• Directions for QA: No special directions. The patch includes unit tests.

Detailed description:

We tried to call getInitializer() for globals that are external. we are missing a check. Using the hasDefinitiveInitializer() is the right way to do this check, it guarantees that we have an initializer for the metatype information and its definitive and unique. With this information, we can analyze the destructor and reason about whether its safe to delete an allocation.

Fixes rdar://problem/27941015
