### PR TITLE
[Type checker] Infer @objc for witnesses of protocol conformances from superclasses

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -899,7 +899,7 @@ matchWitness(TypeChecker &tc,
 static RequirementMatch
 matchWitness(TypeChecker &tc,
              ProtocolDecl *proto,
-             NormalProtocolConformance *conformance,
+             ProtocolConformance *conformance,
              DeclContext *dc, ValueDecl *req, ValueDecl *witness) {
   using namespace constraints;
 
@@ -4915,6 +4915,26 @@ TypeChecker::findWitnessedObjCRequirements(const ValueDecl *witness,
       if ((*conformance)->getWitness(req, this).getDecl() == witness) {
         result.push_back(req);
         if (anySingleRequirement) return result;
+        continue;
+      }
+
+      // If we have an inherited conformance, check whether the potential
+      // witness matches the requirement.
+      // FIXME: for now, don't even try this with generics involved. We
+      // should be tracking how subclasses implement optional requirements,
+      // in which case the getWitness() check above would suffice.
+      if (req->getAttrs().hasAttribute<OptionalAttr>() &&
+          isa<InheritedProtocolConformance>(*conformance)) {
+        auto normal = (*conformance)->getRootNormalConformance();
+        if (!(*conformance)->getDeclContext()->getGenericSignatureOfContext() &&
+            !normal->getDeclContext()->getGenericSignatureOfContext() &&
+            matchWitness(*this, proto, *conformance, witness->getDeclContext(),
+                         req, const_cast<ValueDecl *>(witness)).Kind
+              == MatchKind::ExactMatch) {
+          result.push_back(req);
+          if (anySingleRequirement) return result;
+          continue;
+        }
       }
     }
   }

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2164,7 +2164,7 @@ class SuperclassImplementsProtocol : InferFromProtocol { }
 
 // Note: no inference for subclasses
 class SubclassInfersFromProtocol1 : SuperclassImplementsProtocol {
-  // CHECK: {{^}} func method1(value: Int)
+  // CHECK: {{^}} @objc func method1(value: Int)
   func method1(value: Int) { }
 }
 
@@ -2173,7 +2173,7 @@ class SubclassInfersFromProtocol2 : SuperclassImplementsProtocol {
 }
 
 extension SubclassInfersFromProtocol2 {
-  // CHECK: {{^}} func method1(value: Int)
+  // CHECK: {{^}} @objc dynamic func method1(value: Int)
   func method1(value: Int) { }
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->

Extend `@objc` inference for witnesses to also consider optional
protocols whose conformances come from superclasses. Because we don't
do real binding of witnesses for inherited conformances, this is a bit
of an heuristic, looking at whether the witness is a potential match
(vs. the known exact match), so it can infer `@objc` somewhat more
liberally than a complete solution.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [rdar://problem/27348369](rdar://problem/27348369).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
