### PR TITLE
Throwing methods must return an object type in the @objc thunk to be @objc.

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -899,7 +899,7 @@ matchWitness(TypeChecker &tc,
 static RequirementMatch
 matchWitness(TypeChecker &tc,
              ProtocolDecl *proto,
-             NormalProtocolConformance *conformance,
+             ProtocolConformance *conformance,
              DeclContext *dc, ValueDecl *req, ValueDecl *witness) {
   using namespace constraints;
 
@@ -4915,6 +4915,26 @@ TypeChecker::findWitnessedObjCRequirements(const ValueDecl *witness,
       if ((*conformance)->getWitness(req, this).getDecl() == witness) {
         result.push_back(req);
         if (anySingleRequirement) return result;
+        continue;
+      }
+
+      // If we have an inherited conformance, check whether the potential
+      // witness matches the requirement.
+      // FIXME: for now, don't even try this with generics involved. We
+      // should be tracking how subclasses implement optional requirements,
+      // in which case the getWitness() check above would suffice.
+      if (req->getAttrs().hasAttribute<OptionalAttr>() &&
+          isa<InheritedProtocolConformance>(*conformance)) {
+        auto normal = (*conformance)->getRootNormalConformance();
+        if (!(*conformance)->getDeclContext()->getGenericSignatureOfContext() &&
+            !normal->getDeclContext()->getGenericSignatureOfContext() &&
+            matchWitness(*this, proto, *conformance, witness->getDeclContext(),
+                         req, const_cast<ValueDecl *>(witness)).Kind
+              == MatchKind::ExactMatch) {
+          result.push_back(req);
+          if (anySingleRequirement) return result;
+          continue;
+        }
       }
     }
   }

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2164,7 +2164,7 @@ class SuperclassImplementsProtocol : InferFromProtocol { }
 
 // Note: no inference for subclasses
 class SubclassInfersFromProtocol1 : SuperclassImplementsProtocol {
-  // CHECK: {{^}} func method1(value: Int)
+  // CHECK: {{^}} @objc func method1(value: Int)
   func method1(value: Int) { }
 }
 
@@ -2173,7 +2173,7 @@ class SubclassInfersFromProtocol2 : SuperclassImplementsProtocol {
 }
 
 extension SubclassInfersFromProtocol2 {
-  // CHECK: {{^}} func method1(value: Int)
+  // CHECK: {{^}} @objc dynamic func method1(value: Int)
   func method1(value: Int) { }
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->

A throwing method can only be exposed to Objective-C if we can map the
return type convention, either because the return type is `Void` or
because it is something that is bridged to an object type (and can
therefore be `nil` to indicate error). Our predicate for checking
"bridged to an object type" didn't account for value types that are
exposed to (or come from) C, and therefore aren't actually bridged to
object types in the Objective-C thunk, meaning they cannot be
optional. An existing hack dealt with the largest class of
these---types like Int and Bool that can be dynamically bridged
to `NSNumber`---but generalize this by checking exactly how the result
type is going to be represented in Objective-C, rejecting `@objc` for
cases where the result type won't be an object type.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [rdar://problem/28035614](rdar://problem/28035614).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
