### PR TITLE
Tighten up and document the type of Error._userInfo somewhat.

### DIFF
--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -287,7 +287,7 @@ public func _swift_Foundation_getErrorDefaultUserInfo(_ error: Error)
 extension NSError : Error {
   public var _domain: String { return domain }
   public var _code: Int { return code }
-  public var _userInfo: Any? { return userInfo }
+  public var _userInfo: AnyObject? { return userInfo as NSDictionary }
 
   /// The "embedded" NSError is itself.
   public func _getEmbeddedNSError() -> AnyObject? {
@@ -304,8 +304,8 @@ extension CFError : Error {
     return CFErrorGetCode(self)
   }
 
-  public var _userInfo: Any? {
-    return CFErrorCopyUserInfo(self) as Any
+  public var _userInfo: AnyObject? {
+    return CFErrorCopyUserInfo(self) as AnyObject
   }
 
   /// The "embedded" NSError is itself.

--- a/stdlib/public/core/ErrorType.swift
+++ b/stdlib/public/core/ErrorType.swift
@@ -113,7 +113,11 @@ import SwiftShims
 public protocol Error {
   var _domain: String { get }
   var _code: Int { get }
-  var _userInfo: Any? { get }
+
+  // Note: _userInfo is always an NSDictionary, but we cannot use that type here
+  // because the standard library cannot depend on Foundation. However, the
+  // underscore implies that we control all implementations of this requirement.
+  var _userInfo: AnyObject? { get }
 
 #if _runtime(_ObjC)
   func _getEmbeddedNSError() -> AnyObject?
@@ -203,7 +207,7 @@ extension Error {
     return String(reflecting: type(of: self))
   }
 
-  public var _userInfo: Any? {
+  public var _userInfo: AnyObject? {
 #if _runtime(_ObjC)
     return _stdlib_getErrorDefaultUserInfo(self)
 #else


### PR DESCRIPTION
<!-- What's in this pull request? -->

The implementation-detail requirement Error._userInfo is always an
NSDictionary?. However, because this requirement is declared within
the standard library, it cannot be typed as such. So, use
'AnyObject?', comment that this is always 'NSDictionary?' in practice,
and fix up the uses.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [rdar://problem/27824194](rdar://problem/27824194).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
