### PR TITLE
Allow @testable witnesses to satisfy protocol requirements.

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1239,14 +1239,31 @@ checkWitnessAccessibility(const DeclContext *&requiredAccessScope,
     }
   }
 
-  if (!witness->isAccessibleFrom(requiredAccessScope))
-    return true;
+  const DeclContext *actualScopeToCheck = requiredAccessScope;
+  if (!witness->isAccessibleFrom(actualScopeToCheck)) {
+    // Special case: if we have `@testable import` of the witness's module,
+    // allow the witness to match if it would have matched for just this file.
+    // That is, if '@testable' allows us to see the witness here, it should
+    // allow us to see it anywhere, because any other client could also add
+    // their own `@testable import`.
+    if (auto parentFile = dyn_cast<SourceFile>(DC->getModuleScopeContext())) {
+      const Module *witnessModule = witness->getModuleContext();
+      if (parentFile->getParentModule() != witnessModule &&
+          parentFile->hasTestableImport(witnessModule) &&
+          witness->isAccessibleFrom(parentFile)) {
+        actualScopeToCheck = parentFile;
+      }
+    }
+
+    if (actualScopeToCheck == requiredAccessScope)
+      return true;
+  }
 
   if (requirement->isSettable(DC)) {
     *isSetter = true;
 
     auto ASD = cast<AbstractStorageDecl>(witness);
-    if (!ASD->isSetterAccessibleFrom(requiredAccessScope))
+    if (!ASD->isSetterAccessibleFrom(actualScopeToCheck))
       return true;
   }
 

--- a/test/NameBinding/Inputs/has_accessibility.swift
+++ b/test/NameBinding/Inputs/has_accessibility.swift
@@ -34,3 +34,8 @@ public struct StructWithPrivateSetter {
   public private(set) var x = 0
   public init() {}
 }
+
+public protocol HasDefaultImplementation {}
+extension HasDefaultImplementation {
+  internal func foo() {}
+}

--- a/test/NameBinding/Inputs/has_accessibility.swift
+++ b/test/NameBinding/Inputs/has_accessibility.swift
@@ -39,3 +39,4 @@ public protocol HasDefaultImplementation {}
 extension HasDefaultImplementation {
   internal func foo() {}
 }
+internal class InternalBase {}

--- a/test/NameBinding/accessibility.swift
+++ b/test/NameBinding/accessibility.swift
@@ -1,9 +1,6 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: cp %s %t/main.swift
 
-// RUN: %target-swift-frontend -parse -primary-file %t/main.swift %S/Inputs/accessibility_other.swift -module-name accessibility -enable-source-import -I %S/Inputs -sdk "" -enable-access-control -verify
-// RUN: %target-swift-frontend -parse -primary-file %t/main.swift %S/Inputs/accessibility_other.swift -module-name accessibility -enable-source-import -I %S/Inputs -sdk "" -disable-access-control -D DEFINE_VAR_FOR_SCOPED_IMPORT -D ACCESS_DISABLED
-
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/has_accessibility.swift -D DEFINE_VAR_FOR_SCOPED_IMPORT -enable-testing
 // RUN: %target-swift-frontend -parse -primary-file %t/main.swift %S/Inputs/accessibility_other.swift -module-name accessibility -I %t -sdk "" -enable-access-control -verify
 // RUN: %target-swift-frontend -parse -primary-file %t/main.swift %S/Inputs/accessibility_other.swift -module-name accessibility -I %t -sdk "" -disable-access-control -D ACCESS_DISABLED
@@ -105,9 +102,9 @@ protocol MethodProto {
 }
 
 extension OriginallyEmpty : MethodProto {}
-// TESTABLE-NOT: :[[@LINE-1]]:{{[^:]+}}:
 #if !ACCESS_DISABLED
 extension HiddenMethod : MethodProto {} // expected-error {{type 'HiddenMethod' does not conform to protocol 'MethodProto'}}
+// TESTABLE-NOT: :[[@LINE-1]]:{{[^:]+}}:
 
 extension Foo : MethodProto {} // expected-error {{type 'Foo' does not conform to protocol 'MethodProto'}}
 #endif
@@ -163,3 +160,12 @@ private struct PrivateConformerByLocalTypeBad : TypeProto {
 }
 #endif
 
+public protocol Fooable {
+  func foo() // expected-note * {{protocol requires function 'foo()'}}
+}
+
+#if !ACCESS_DISABLED
+internal struct FooImpl: Fooable, HasDefaultImplementation {} // expected-error {{type 'FooImpl' does not conform to protocol 'Fooable'}}
+public struct PublicFooImpl: Fooable, HasDefaultImplementation {} // expected-error {{type 'PublicFooImpl' does not conform to protocol 'Fooable'}}
+#endif
+// TESTABLE-NOT: method 'foo()'

--- a/test/NameBinding/accessibility.swift
+++ b/test/NameBinding/accessibility.swift
@@ -167,5 +167,9 @@ public protocol Fooable {
 #if !ACCESS_DISABLED
 internal struct FooImpl: Fooable, HasDefaultImplementation {} // expected-error {{type 'FooImpl' does not conform to protocol 'Fooable'}}
 public struct PublicFooImpl: Fooable, HasDefaultImplementation {} // expected-error {{type 'PublicFooImpl' does not conform to protocol 'Fooable'}}
-#endif
 // TESTABLE-NOT: method 'foo()'
+
+internal class TestableSub: InternalBase {} // expected-error {{undeclared type 'InternalBase'}}
+public class TestablePublicSub: InternalBase {} // expected-error {{undeclared type 'InternalBase'}}
+// TESTABLE-NOT: undeclared type 'InternalBase'
+#endif

--- a/test/SILGen/Inputs/TestableMultifileHelper.swift
+++ b/test/SILGen/Inputs/TestableMultifileHelper.swift
@@ -2,3 +2,7 @@ public protocol HasDefaultFoo {}
 extension HasDefaultFoo {
   internal func foo() {}
 }
+
+internal class Base {
+  func foo() {}
+}

--- a/test/SILGen/Inputs/TestableMultifileHelper.swift
+++ b/test/SILGen/Inputs/TestableMultifileHelper.swift
@@ -1,0 +1,4 @@
+public protocol HasDefaultFoo {}
+extension HasDefaultFoo {
+  internal func foo() {}
+}

--- a/test/SILGen/testable-multifile-other.swift
+++ b/test/SILGen/testable-multifile-other.swift
@@ -30,3 +30,14 @@ func test(internalFoo: FooImpl, publicFoo: PublicFooImpl) {
 // CHECK: [[IMPL_2:%.+]] = function_ref @_TFE23TestableMultifileHelperPS_13HasDefaultFoo3foofT_T_
 // CHECK: = apply [[IMPL_2]]<PublicFooImpl>({{%.+}}) : $@convention(method) <τ_0_0 where τ_0_0 : HasDefaultFoo> (@in_guaranteed τ_0_0) -> ()
 // CHECK: {{^}$}}
+
+func test(internalSub: Sub, publicSub: PublicSub) {
+  internalSub.foo()
+  publicSub.foo()
+}
+
+// CHECK-LABEL: sil hidden @_TF4main4testFT11internalSubCS_3Sub9publicSubCS_9PublicSub_T_
+// CHECK: = class_method %0 : $Sub, #Sub.foo!1
+// CHECK: = class_method %1 : $PublicSub, #PublicSub.foo!1
+// CHECK: {{^}$}}
+

--- a/test/SILGen/testable-multifile-other.swift
+++ b/test/SILGen/testable-multifile-other.swift
@@ -1,0 +1,32 @@
+// This test is paired with testable-multifile.swift.
+
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-swift-frontend -emit-module %S/Inputs/TestableMultifileHelper.swift -enable-testing -o %t
+
+// RUN: %target-swift-frontend -emit-silgen -I %t %s %S/testable-multifile.swift -module-name main | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -I %t %S/testable-multifile.swift %s -module-name main | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -I %t -primary-file %s %S/testable-multifile.swift -module-name main | %FileCheck %s
+
+// Just make sure we don't crash later on.
+// RUN: %target-swift-frontend -emit-ir -I %t -primary-file %s %S/testable-multifile.swift -module-name main -o /dev/null
+// RUN: %target-swift-frontend -emit-ir -I %t -O -primary-file %s %S/testable-multifile.swift -module-name main -o /dev/null
+
+func use<F: Fooable>(_ f: F) { f.foo() }
+func test(internalFoo: FooImpl, publicFoo: PublicFooImpl) {
+  use(internalFoo)
+  use(publicFoo)
+
+  internalFoo.foo()
+  publicFoo.foo()
+}
+
+// CHECK-LABEL: sil hidden @_TF4main4testFT11internalFooVS_7FooImpl9publicFooVS_13PublicFooImpl_T_
+// CHECK: [[USE_1:%.+]] = function_ref @_TF4main3useuRxS_7FooablerFxT_
+// CHECK: = apply [[USE_1]]<FooImpl>({{%.+}}) : $@convention(thin) <τ_0_0 where τ_0_0 : Fooable> (@in τ_0_0) -> ()
+// CHECK: [[USE_2:%.+]] = function_ref @_TF4main3useuRxS_7FooablerFxT_
+// CHECK: = apply [[USE_2]]<PublicFooImpl>({{%.+}}) : $@convention(thin) <τ_0_0 where τ_0_0 : Fooable> (@in τ_0_0) -> ()
+// CHECK: [[IMPL_1:%.+]] = function_ref @_TFE23TestableMultifileHelperPS_13HasDefaultFoo3foofT_T_
+// CHECK: = apply [[IMPL_1]]<FooImpl>({{%.+}}) : $@convention(method) <τ_0_0 where τ_0_0 : HasDefaultFoo> (@in_guaranteed τ_0_0) -> ()
+// CHECK: [[IMPL_2:%.+]] = function_ref @_TFE23TestableMultifileHelperPS_13HasDefaultFoo3foofT_T_
+// CHECK: = apply [[IMPL_2]]<PublicFooImpl>({{%.+}}) : $@convention(method) <τ_0_0 where τ_0_0 : HasDefaultFoo> (@in_guaranteed τ_0_0) -> ()
+// CHECK: {{^}$}}

--- a/test/SILGen/testable-multifile.swift
+++ b/test/SILGen/testable-multifile.swift
@@ -28,6 +28,36 @@ public struct PublicFooImpl: Fooable, HasDefaultFoo {}
 // CHECK: function_ref @_TFE23TestableMultifileHelperPS_13HasDefaultFoo3foofT_T_
 // CHECK: {{^}$}}
 
+private class PrivateSub: Base {
+  fileprivate override func foo() {}
+}
+class Sub: Base {
+  internal override func foo() {}
+}
+public class PublicSub: Base {
+  public override func foo() {}
+}
+
+// CHECK-LABEL: sil_vtable PrivateSub {
+// CHECK-NEXT:   #Base.foo!1: _TFC4mainP33_F1525133BD493492AD72BF10FBCB1C5210PrivateSub3foofT_T_
+// CHECK-NEXT:   #Base.init!initializer.1: _TFC4mainP33_F1525133BD493492AD72BF10FBCB1C5210PrivateSubcfT_S0_
+// CHECK-NEXT:   #PrivateSub.deinit!deallocator: _TFC4mainP33_F1525133BD493492AD72BF10FBCB1C5210PrivateSubD
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_vtable Sub {
+// CHECK-NEXT:   #Base.foo!1: _TFC4main3Sub3foofT_T_
+// CHECK-NEXT:   #Base.init!initializer.1: _TFC4main3SubcfT_S0_
+// CHECK-NEXT:   #Sub.deinit!deallocator: _TFC4main3SubD
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_vtable PublicSub {
+// CHECK-NEXT:   #Base.foo!1: _TFC4main9PublicSub3foofT_T_
+// CHECK-NEXT:   #Base.init!initializer.1: _TFC4main9PublicSubcfT_S0_
+// CHECK-NEXT:   #PublicSub.deinit!deallocator: _TFC4main9PublicSubD
+// CHECK-NEXT: }
+
+
+
 // CHECK-LABEL: sil_witness_table FooImpl: Fooable module main {
 // CHECK-NEXT:  method #Fooable.foo!1: @_TTWV4main7FooImplS_7FooableS_FS1_3foofT_T_
 // CHECK-NEXT: }

--- a/test/SILGen/testable-multifile.swift
+++ b/test/SILGen/testable-multifile.swift
@@ -1,0 +1,37 @@
+// This test is paired with testable-multifile-other.swift.
+
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-swift-frontend -emit-module %S/Inputs/TestableMultifileHelper.swift -enable-testing -o %t
+
+// RUN: %target-swift-frontend -emit-silgen -I %t %s %S/testable-multifile-other.swift -module-name main | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -I %t %S/testable-multifile-other.swift %s -module-name main | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -I %t -primary-file %s %S/testable-multifile-other.swift -module-name main | %FileCheck %s
+
+// Just make sure we don't crash later on.
+// RUN: %target-swift-frontend -emit-ir -I %t -primary-file %s %S/testable-multifile-other.swift -module-name main -o /dev/null
+// RUN: %target-swift-frontend -emit-ir -I %t -O -primary-file %s %S/testable-multifile-other.swift -module-name main -o /dev/null
+
+@testable import TestableMultifileHelper
+
+public protocol Fooable {
+  func foo()
+}
+
+struct FooImpl: Fooable, HasDefaultFoo {}
+public struct PublicFooImpl: Fooable, HasDefaultFoo {}
+
+// CHECK-LABEL: sil{{.*}} @_TTWV4main7FooImplS_7FooableS_FS1_3foofT_T_ : $@convention(witness_method) (@in_guaranteed FooImpl) -> () {
+// CHECK: function_ref @_TFE23TestableMultifileHelperPS_13HasDefaultFoo3foofT_T_
+// CHECK: {{^}$}}
+
+// CHECK-LABEL: sil{{.*}} @_TTWV4main13PublicFooImplS_7FooableS_FS1_3foofT_T_ : $@convention(witness_method) (@in_guaranteed PublicFooImpl) -> () {
+// CHECK: function_ref @_TFE23TestableMultifileHelperPS_13HasDefaultFoo3foofT_T_
+// CHECK: {{^}$}}
+
+// CHECK-LABEL: sil_witness_table FooImpl: Fooable module main {
+// CHECK-NEXT:  method #Fooable.foo!1: @_TTWV4main7FooImplS_7FooableS_FS1_3foofT_T_
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_witness_table [fragile] PublicFooImpl: Fooable module main {
+// CHECK-NEXT:  method #Fooable.foo!1: @_TTWV4main13PublicFooImplS_7FooableS_FS1_3foofT_T_
+// CHECK-NEXT: }


### PR DESCRIPTION
That is, if a would-be witness to a protocol requirement is only accessible because its module has been imported with `@testable`, consider that "good enough" to satisfy the rule that a witness must be available everywhere the protocol and conforming type are both available (because those other contexts _could_ have done their own testable import, and also shouldn't have to know that this file needed one to conform to the protocol).

This re-enables some patterns that would have been allowed pre-[SE-0025](https://github.com/apple/swift-evolution/blob/master/proposals/0025-scoped-access-level.md).

rdar://problem/28173654
