### PR TITLE
[3.0] Throwing methods must return an object type in the @objc thunk to be @objc

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4853,6 +4853,7 @@ TypeChecker::findWitnessedObjCRequirements(const ValueDecl *witness,
     // We only care about Objective-C protocols.
     if (!proto->isObjC()) continue;
 
+    Optional<ProtocolConformance *> conformance;
     for (auto req : proto->lookupDirect(name, true)) {
       // Skip anything in a protocol extension.
       if (req->getDeclContext() != proto) continue;
@@ -4861,7 +4862,6 @@ TypeChecker::findWitnessedObjCRequirements(const ValueDecl *witness,
       if (isa<TypeDecl>(req)) continue;
       
       // Dig out the conformance.
-      Optional<ProtocolConformance *> conformance;
       if (!conformance.hasValue()) {
         SmallVector<ProtocolConformance *, 2> conformances;
         nominal->lookupConformance(dc->getParentModule(), proto,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2903,31 +2903,18 @@ bool TypeChecker::isCIntegerType(const DeclContext *DC, Type T) {
 
 /// Determines whether the given type is bridged to an Objective-C class type.
 static bool isBridgedToObjectiveCClass(DeclContext *dc, Type type) {
-  // Simple case: bridgeable object types.
-  if (type->isBridgeableObjectType())
-    return true;
-  
-  // Any bridges to AnyObject.
-  if (type->isAny())
-    return true;
-
-  // Determine whether this type is bridged to Objective-C.
-  ASTContext &ctx = type->getASTContext();
-  Optional<Type> bridged = ctx.getBridgedToObjC(dc, type,
-                                                ctx.getLazyResolver());
-  if (!bridged)
+  switch (type->getForeignRepresentableIn(ForeignLanguage::ObjectiveC, dc)
+            .first) {
+  case ForeignRepresentableKind::Trivial:
+  case ForeignRepresentableKind::None:
     return false;
 
-  // Check whether we're bridging to a class.
-  auto classDecl = (*bridged)->getClassOrBoundGenericClass();
-  if (!classDecl)
-    return false;
-
-  // Allow anything that isn't bridged to NSNumber.
-  // FIXME: This feels like a hack, but we don't have the right predicate
-  // anywhere.
-  return classDecl->getName().str()
-            != ctx.getSwiftName(KnownFoundationEntity::NSNumber);
+  case ForeignRepresentableKind::Object:
+  case ForeignRepresentableKind::Bridged:
+  case ForeignRepresentableKind::BridgedError:
+  case ForeignRepresentableKind::StaticBridged:
+    return true;
+  }
 }
 
 bool TypeChecker::isRepresentableInObjC(

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -11,7 +11,9 @@ struct PlainStruct {}
 enum PlainEnum {}
 protocol PlainProtocol {} // expected-note {{protocol 'PlainProtocol' declared here}}
 
-enum ErrorEnum : Error { }
+enum ErrorEnum : Error {
+  case failed
+}
 
 @objc class Class_ObjC1 {}
 
@@ -1978,6 +1980,24 @@ class ClassThrows1 {
   // CHECK: @objc init(degrees: Double) throws
   // CHECK-DUMP: constructor_decl "init(degrees:)"{{.*}}foreign_error=NilResult,unowned,param=1,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>
   init(degrees: Double) throws { }
+
+  // CHECK: {{^}} func methodReturnsBridgedValueType() throws -> NSRange
+  func methodReturnsBridgedValueType() throws -> NSRange { return NSRange() }
+
+  @objc func methodReturnsBridgedValueType2() throws -> NSRange {
+    return NSRange()
+  }
+  // expected-error@-3{{throwing method cannot be marked @objc because it returns a value of type 'NSRange' (aka '_NSRange'); return 'Void' or a type that bridges to an Objective-C class}}
+
+  // CHECK: {{^}} @objc func methodReturnsError() throws -> Error
+  func methodReturnsError() throws -> Error { return ErrorEnum.failed }
+
+  // CHECK: @objc func methodReturnStaticBridged() throws -> ((Int) -> (Int) -> Int)
+  func methodReturnStaticBridged() throws -> ((Int) -> (Int) -> Int) {
+    func add(x: Int) -> (Int) -> Int { 
+      return { x + $0 }
+    }
+  }
 }
 
 // CHECK-DUMP-LABEL: class_decl "SubclassImplicitClassThrows1"

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2147,15 +2147,14 @@ extension ClassInfersFromProtocol3 {
   func method1(value: String) { }
 }
 
+// Inference for subclasses.
 class SuperclassImplementsProtocol : InferFromProtocol { }
 
-// Note: no inference for subclasses
 class SubclassInfersFromProtocol1 : SuperclassImplementsProtocol {
   // CHECK: {{^}} @objc func method1(value: Int)
   func method1(value: Int) { }
 }
 
-// Note: no inference for subclasses
 class SubclassInfersFromProtocol2 : SuperclassImplementsProtocol {
 }
 
@@ -2163,4 +2162,3 @@ extension SubclassInfersFromProtocol2 {
   // CHECK: {{^}} @objc dynamic func method1(value: Int)
   func method1(value: Int) { }
 }
-


### PR DESCRIPTION
<!-- What's in this pull request? -->

A throwing method can only be exposed to Objective-C if we can map the
return type convention, either because the return type is `Void` or
because it is something that is bridged to an object type (and can
therefore be `nil` to indicate error). Our predicate for checking
"bridged to an object type" didn't account for value types that are
exposed to (or come from) C, and therefore aren't actually bridged to
object types in the Objective-C thunk, meaning they cannot be
optional. An existing hack dealt with the largest class of
these---types like Int and Bool that can be dynamically bridged
to `NSNumber`---but generalize this by checking exactly how the result
type is going to be represented in Objective-C, rejecting `@objc` for
cases where the result type won't be an object type.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [rdar://problem/28035614](rdar://problem/28035614).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
