### PR TITLE
[QoI] diagnose operator fixity attrs together; improve messages

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1139,9 +1139,12 @@ ERROR(duplicate_attribute,none,
       "duplicate %select{attribute|modifier}0", (bool))
 NOTE(previous_attribute,none,
      "%select{attribute|modifier}0 already specified here", (bool))
+ERROR(mutually_exclusive_attrs,none,
+      "'%0' contradicts previous %select{attribute|modifier}2 '%1'", (StringRef, StringRef, bool))
 
-ERROR(cannot_combine_attribute,none,
-      "attribute '%0' cannot be combined with this attribute", (StringRef))
+ERROR(invalid_infix_on_func,none,
+      "'infix' modifier is not required or allowed on func declarations", ())
+
 ERROR(expected_in_attribute_list,none,
       "expected ']' or ',' in attribute list", ())
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -901,8 +901,6 @@ ERROR(operator_not_func,none,
       "operators must be declared with 'func'", ())
 ERROR(redefining_builtin_operator,none,
       "cannot declare a custom %0 '%1' operator", (StringRef, StringRef))
-ERROR(invalid_infix_on_func,none,
-      "'infix' modifier is not required or allowed on func declarations", ())
 ERROR(attribute_requires_operator_identifier,none,
       "'%0' requires a function with an operator identifier", (StringRef))
 ERROR(attribute_requires_single_argument,none,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1085,14 +1085,6 @@ void AttributeChecker::checkOperatorAttribute(DeclAttribute *attr) {
     return;
   }
 
-  // Infix operator is only allowed on operator declarations, not on func.
-  if (isa<InfixAttr>(attr)) {
-    TC.diagnose(attr->getLocation(), diag::invalid_infix_on_func)
-      .fixItRemove(attr->getLocation());
-    attr->setInvalid();
-    return;
-  }
-
   // Otherwise, must be unary.
   if (!FD->isUnaryOperator()) {
     TC.diagnose(attr->getLocation(), diag::attribute_requires_single_argument,

--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -19,7 +19,7 @@ precedencegroup ReallyHighPrecedence {
   associativity: left
 }
 
-infix func fn_binary(_ lhs: Int, rhs: Int) {}  // expected-error {{'infix' requires a function with an operator identifier}}
+infix func fn_binary(_ lhs: Int, rhs: Int) {}  // expected-error {{'infix' modifier is not required or allowed on func declarations}}
 
 
 func ++++(lhs: X, rhs: X) -> X {}
@@ -142,8 +142,10 @@ func test_14705150() {
 
 }
 
-prefix postfix func ++(x: Int) {} // expected-error {{attribute 'prefix' cannot be combined with this attribute}}
-postfix prefix func ++(x: Int) {} // expected-error {{attribute 'postfix' cannot be combined with this attribute}}
+prefix postfix func ++(x: Int) {} // expected-error {{'postfix' contradicts previous modifier 'prefix'}} {{8-16=}}
+postfix prefix func ++(x: Float) {} // expected-error {{'prefix' contradicts previous modifier 'postfix'}} {{9-16=}}
+postfix prefix infix func ++(x: Double) {} // expected-error {{'prefix' contradicts previous modifier 'postfix'}} {{9-16=}} expected-error {{'infix' contradicts previous modifier 'postfix'}} {{16-22=}}
+infix prefix func +-+(x: Int, y: Int) {} // expected-error {{'infix' modifier is not required or allowed on func declarations}} {{1-7=}} expected-error{{'prefix' contradicts previous modifier 'infix'}} {{7-14=}}
 
 // Don't allow one to define a postfix '!'; it's built into the
 // language.


### PR DESCRIPTION
Addresses an issue raised by @rintaro in #4628.

Previously, `infix` was not recognized as conflicting with `prefix` and `postfix`. We now offer to remove all but the first fixity attribute.
### RFC:

I'm not sure `ParseDecl.cpp` is really the right place to check these attrs. I like the idea of having `TypeCheckAttr.cpp` contain most of the attribute-verifying logic, but it's structured as a simple visitor which doesn't have the power to handle a few related attributes at the same time (without architectural changes). Maybe I'm missing something, but to me the current distinction between things in `DiagnosticsSema.def` and things in `DiagnosticsParse.def` seems somewhat arbitrary.

Perhaps @DougGregor or someone else can provide a better alternative.
### Before:

<pre><b>no error 😱</b>
infix prefix operator ++

<b>attribute 'postfix' cannot be combined with this attribute</b>
postfix prefix operator --
        ^
</pre>

### After:

<pre><b>error: 'prefix' contradicts previous modifier 'infix'</b>
infix prefix operator ++
      ^~~~~~~

<b>error: 'prefix' contradicts previous modifier 'postfix'</b>
postfix prefix operator --
        ^~~~~~~</pre>
