### PR TITLE
[Parse/ASTPrinter] Print default argument for nil, [], and [:]

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2631,6 +2631,7 @@ void PrintAST::printOneParameter(const ParamDecl *param, bool Curried,
       case DefaultArgumentKind::Column:
       case DefaultArgumentKind::Function:
       case DefaultArgumentKind::DSOHandle:
+      case DefaultArgumentKind::Nil:
         Printer.printKeyword(defaultArgStr);
         break;
       default:

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -135,6 +135,12 @@ struct d0100_FooStruct {
   func instanceFuncWithDefaultArg2(a: Int = 0, b: Double = 0) {}
 // PASS_COMMON-NEXT: {{^}}  func instanceFuncWithDefaultArg2(a: Int = default, b: Double = default){{$}}
 
+  func instanceFuncWithDefaultArg3(a: [Int] = [], b: Double? = nil, c: [String:String] = [:]) {}
+// PASS_COMMON-NEXT: {{^}}  func instanceFuncWithDefaultArg3(a: [Int] = [], b: Double? = nil, c: [String : String] = [:]){{$}}
+
+  func instanceFuncWithDefaultArg4(a: [Int] = [1], b: Double? = 2.0, c: [String:String] = ["foo":"bar"]) {}
+// PASS_COMMON-NEXT: {{^}}  func instanceFuncWithDefaultArg4(a: [Int] = default, b: Double? = default, c: [String : String] = default){{$}}
+
   func varargInstanceFunc0(v: Int...) {}
 // PASS_COMMON-NEXT: {{^}}  func varargInstanceFunc0(v: Int...){{$}}
 

--- a/test/SourceKit/CursorInfo/cursor_info.swift
+++ b/test/SourceKit/CursorInfo/cursor_info.swift
@@ -631,12 +631,9 @@ func convention7(_: @convention(witness_method) ()->()) {}
 // CHECK73-SAME: = <syntaxtype.keyword>#file</syntaxtype.keyword>
 // CHECK73-SAME: = <syntaxtype.keyword>#line</syntaxtype.keyword>
 // CHECK73-SAME: = <syntaxtype.keyword>#column</syntaxtype.keyword>
-// FIXME: []
-// CHECK73-SAME: = <syntaxtype.keyword>default</syntaxtype.keyword>
-// FIXME: [:]
-// CHECK73-SAME: = <syntaxtype.keyword>default</syntaxtype.keyword>
-// FIXME: keyword nil
-// CHECK73-SAME: = <syntaxtype.keyword>default</syntaxtype.keyword>
+// CHECK73-SAME: = []
+// CHECK73-SAME: = [:]
+// CHECK73-SAME: = <syntaxtype.keyword>nil</syntaxtype.keyword>
 // CHECK73-SAME: = <syntaxtype.keyword>default</syntaxtype.keyword>
 
 // RUN: %sourcekitd-test -req=cursor -pos=162:8 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck %s -check-prefix=CHECK74


### PR DESCRIPTION
`DefaultArgumentKind` is extended in 5aa40dd0aa057591398339c77df91a976ae35c72, but never applied to the Swift parser.

CC: @DougGregor 
Any reason _not_ to do this?
