### PR TITLE
Foundation overlay: Remove unnecessary precondition that array elements be ObjectiveCBridgeable.

### DIFF
--- a/stdlib/public/SDK/Foundation/Foundation.swift
+++ b/stdlib/public/SDK/Foundation/Foundation.swift
@@ -498,10 +498,6 @@ extension Array : _ObjectiveCBridgeable {
     _ source: NSArray,
     result: inout Array?
   ) {
-    _precondition(
-      Swift._isBridgedToObjectiveC(Element.self),
-      "array element type is not bridged to Objective-C")
-
     // If we have the appropriate native storage already, just adopt it.
     if let native =
         Array._bridgeFromObjectiveCAdoptingNativeStorageOf(source) {

--- a/test/stdlib/ArrayBridge.swift.gyb
+++ b/test/stdlib/ArrayBridge.swift.gyb
@@ -470,4 +470,16 @@ tests.test("testMutableArray") {
   expectEqualSequence(aCopy, a)
 }
 
+tests.test("rdar://problem/27905230") {
+  let dict = RDar27905230.mutableDictionaryOfMutableLists()!
+  let arr = dict["list"]!
+  expectEqual(arr[0] as! NSNull, NSNull())
+  expectEqual(arr[1] as! String, "")
+  expectEqual(arr[2] as! Int, 1)
+  expectEqual(arr[3] as! Bool, true)
+  expectEqual((arr[4] as! NSValue).rangeValue.location, 0)
+  expectEqual((arr[4] as! NSValue).rangeValue.length, 1)
+  expectEqual(arr[5] as! Date, Date(timeIntervalSince1970: 0))
+}
+
 runAllTests()

--- a/test/stdlib/Inputs/ArrayBridge/ArrayBridge.h
+++ b/test/stdlib/Inputs/ArrayBridge/ArrayBridge.h
@@ -16,3 +16,7 @@ NSArray* idAsArray(id a);
 
 void testSubclass(id thunks);
 void testBridgeableValue(id thunks);
+
+@interface RDar27905230 : NSObject
++ (NSDictionary<NSString *, NSArray<id> *> *)mutableDictionaryOfMutableLists;
+@end

--- a/test/stdlib/Inputs/ArrayBridge/ArrayBridge.m
+++ b/test/stdlib/Inputs/ArrayBridge/ArrayBridge.m
@@ -66,3 +66,18 @@ void testBridgeableValue(id thunks) {
   [toSwiftArr addObject: [thunks createSubclass:14]];
   [thunks acceptBridgeableValueArray: toSwiftArr];
 }
+
+@implementation RDar27905230
+
++ (NSDictionary<NSString *, NSArray<id> *> *)mutableDictionaryOfMutableLists  {
+    NSMutableArray *arr = [NSMutableArray array];
+    [arr addObject:[NSNull null]];
+    [arr addObject:@""];
+    [arr addObject:@1];
+    [arr addObject:@YES];
+    [arr addObject:[NSValue valueWithRange:NSMakeRange(0, 1)]];
+    [arr addObject:[NSDate dateWithTimeIntervalSince1970: 0]];
+    return [NSMutableDictionary dictionaryWithObject:arr forKey:@"list"];
+}
+
+@end


### PR DESCRIPTION
This caused a crash when arrays were bridged from ObjC with `Any` or other non-bridged value type elements. Fixes SR-2490 / rdar://problem/27905230.
