### PR TITLE
[escaping] Correct diagnostic for parameter position

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1889,6 +1889,8 @@ ERROR(noescape_conflicts_escaping_autoclosure,none,
 
 ERROR(escaping_function_type,none,
       "@escaping may only be applied to parameters of function type", ())
+ERROR(escaping_non_function_parameter,none,
+      "@escaping attribute may only be used in function parameter position", ())
 
 // NSManaged attribute
 ERROR(attr_NSManaged_not_instance_member,none,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2010,7 +2010,7 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
           loc.getAdvancedLoc(-1),
           Lexer::getLocForEndOfToken(SM, loc));
 
-        TC.diagnose(loc, diag::escaping_function_type)
+        TC.diagnose(loc, diag::escaping_non_function_parameter)
             .fixItRemove(attrRange);
       }
 

--- a/test/attr/attr_escaping.swift
+++ b/test/attr/attr_escaping.swift
@@ -70,6 +70,12 @@ func callEscapingAutoclosureWithNoEscape_3(_ fn: @autoclosure () -> Int) {
   takesEscapingAutoclosure(fn()) // expected-error{{closure use of non-escaping parameter 'fn' may allow it to escape}}
 }
 
+let foo: @escaping (Int) -> Int // expected-error{{@escaping attribute may only be used in function parameter position}} {{10-20=}}
+
+func misuseEscaping(_ a: @escaping Int) {} // expected-error{{@escaping attribute only applies to function types}}
+func misuseEscaping(_ a: (@escaping Int)?) {} // expected-error{{@escaping attribute only applies to function types}}
+func misuseEscaping(_ a: (@escaping (Int) -> Int)?) {} // expected-error{{@escaping attribute may only be used in function parameter position}} {{27-37=}}
+func misuseEscaping(_ a: (@escaping (Int) -> Int, Int)) {} // expected-error{{@escaping attribute may only be used in function parameter position}} {{27-37=}}
 
 func takesEscapingGeneric<T>(_ fn: @escaping () -> T) {}
 func callEscapingGeneric<T>(_ fn: () -> T) { // expected-note {{parameter 'fn' is implicitly non-escaping}} {{35-35=@escaping }}

--- a/test/attr/attr_noescape.swift
+++ b/test/attr/attr_noescape.swift
@@ -271,7 +271,7 @@ func escapeNoEscapeResult(_ x: [Int]) -> (@noescape (Int) -> Int) -> Int { // ex
 typealias CompletionHandlerNE = @noescape (_ success: Bool) -> () // expected-warning{{@noescape is the default and is deprecated}} {{33-43=}}
 
 // Explicit @escaping is not allowed here
-typealias CompletionHandlerE = @escaping (_ success: Bool) -> () // expected-error{{@escaping may only be applied to parameters of function type}}
+typealias CompletionHandlerE = @escaping (_ success: Bool) -> () // expected-error{{@escaping attribute may only be used in function parameter position}} {{32-42=}}
 
 // No @escaping -- it's implicit from context
 typealias CompletionHandler = (_ success: Bool) -> ()


### PR DESCRIPTION
<!-- What's in this pull request? -->

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

In situations where @escaping is used in non-function-parameter
positions, we give an incorrect diagnostic message pertaining to
function types. Instead, we should just state that this is not allowed
in non-function-parameter positions.

This includes the general message fix. Unfortunately, this does not
include more friendly messages for special cases, e.g. closure members
of aggregate and optional closures. That may be possible with more
nested type context information in TypeCheckType.
