### PR TITLE
[Scope map] Various improvements in our modeling of the AST

### DIFF
--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -61,6 +61,8 @@ enum class ASTScopeKind : uint8_t {
   Preexpanded,
   /// A source file, which is the root of a scope.
   SourceFile,
+  /// The generic parameters of an extension declaration.
+  ExtensionGenericParams,
   /// The body of a type or extension thereof.
   TypeOrExtensionBody,
   /// The generic parameters of a declaration.
@@ -170,8 +172,12 @@ class ASTScope {
       mutable unsigned nextElement;
     } sourceFile;
 
+    /// An extension declaration, for
+    /// \c kind == ASTScopeKind::ExtensionGenericParams.
+    ExtensionDecl *extension;
+
     /// An iterable declaration context, which covers nominal type declarations
-    /// and extensions.
+    /// and extension bodies.
     ///
     /// For \c kind == ASTScopeKind::TypeOrExtensionBody.
     IterableDeclContext *iterableDeclContext;
@@ -303,6 +309,11 @@ class ASTScope {
 
   /// Constructor that initializes a preexpanded node.
   ASTScope(const ASTScope *parent, ArrayRef<ASTScope *> children);
+
+  ASTScope(const ASTScope *parent, ExtensionDecl *extension)
+      : ASTScope(ASTScopeKind::ExtensionGenericParams, parent) {
+    this->extension = extension;
+  }
 
   ASTScope(const ASTScope *parent, IterableDeclContext *idc)
       : ASTScope(ASTScopeKind::TypeOrExtensionBody, parent) {

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3527,6 +3527,10 @@ public:
   /// FIXME: protocol extensions will introduce a where clause here as well.
   GenericParamList *createGenericParams(DeclContext *dc);
 
+  /// Create the generic parameters of this protocol if the haven't been
+  /// created yet.
+  void createGenericParamsIfMissing();
+
   // Implement isa/cast/dyncast/etc.
   static bool classof(const Decl *D) {
     return D->getKind() == DeclKind::Protocol;

--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -89,6 +89,9 @@ public:
   /// Resolve the inherited protocols of a given protocol.
   virtual void resolveInheritedProtocols(ProtocolDecl *protocol) = 0;
 
+  /// Bind an extension to its extended type.
+  virtual void bindExtension(ExtensionDecl *ext) = 0;
+
   /// Resolve the type of an extension.
   ///
   /// This can be called to ensure that the members of an extension can be
@@ -154,6 +157,10 @@ public:
 
   void resolveInheritedProtocols(ProtocolDecl *protocol) override {
     Principal.resolveInheritedProtocols(protocol);
+  }
+
+  void bindExtension(ExtensionDecl *ext) override {
+    Principal.bindExtension(ext);
   }
 
   void resolveExtension(ExtensionDecl *ext) override {

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -184,6 +184,13 @@ void ASTScope::expand() const {
     break;
   }
 
+  case ASTScopeKind::ExtensionGenericParams: {
+    // Create a child node.
+    if (ASTScope *child = createIfNeeded(this, extension))
+      addChild(child);
+    break;
+  }
+
   case ASTScopeKind::TypeOrExtensionBody:
     for (auto member : iterableDeclContext->getMembers()) {
       // Create a child node for this declaration.
@@ -583,6 +590,7 @@ static bool parentDirectDescendedFromLocalDeclaration(const ASTScope *parent,
     case ASTScopeKind::AbstractFunctionDecl:
     case ASTScopeKind::AbstractFunctionParams:
     case ASTScopeKind::GenericParams:
+    case ASTScopeKind::ExtensionGenericParams:
     case ASTScopeKind::TypeOrExtensionBody:
     case ASTScopeKind::Accessors:
       // Keep looking.
@@ -638,6 +646,7 @@ static bool parentDirectDescendedFromAbstractStorageDecl(
       return (parent->getAbstractStorageDecl() == decl);
 
     case ASTScopeKind::SourceFile:
+    case ASTScopeKind::ExtensionGenericParams:
     case ASTScopeKind::TypeOrExtensionBody:
     case ASTScopeKind::DefaultArgument:
     case ASTScopeKind::AbstractFunctionBody:
@@ -686,6 +695,7 @@ static bool parentDirectDescendedFromAbstractFunctionDecl(
       return (parent->getAbstractFunctionDecl() == decl);
 
     case ASTScopeKind::SourceFile:
+    case ASTScopeKind::ExtensionGenericParams:
     case ASTScopeKind::TypeOrExtensionBody:
     case ASTScopeKind::LocalDeclaration:
     case ASTScopeKind::PatternBinding:
@@ -791,8 +801,17 @@ ASTScope *ASTScope::createIfNeeded(const ASTScope *parent, Decl *decl) {
     // Always handled by a pattern-binding declaration.
     return nullptr;
 
-  case DeclKind::Extension:
-    return new (ctx) ASTScope(parent, cast<ExtensionDecl>(decl));
+  case DeclKind::Extension: {
+    auto ext = cast<ExtensionDecl>(decl);
+
+    // If we already have a scope of the (possible) generic parameters,
+    // add the body.
+    if (parent->getKind() == ASTScopeKind::ExtensionGenericParams)
+      return new (ctx) ASTScope(parent, cast<IterableDeclContext>(ext));
+
+    // Otherwise, form the extension's generic parameters scope.
+    return new (ctx) ASTScope(parent, ext);
+  }
 
   case DeclKind::TopLevelCode: {
     // Drop top-level statements containing just an IfConfigStmt.
@@ -808,6 +827,10 @@ ASTScope *ASTScope::createIfNeeded(const ASTScope *parent, Decl *decl) {
     return new (ctx) ASTScope(parent, topLevelCode);
   }
 
+  case DeclKind::Protocol:
+    cast<ProtocolDecl>(decl)->createGenericParamsIfMissing();
+    SWIFT_FALLTHROUGH;
+
   case DeclKind::Class:
   case DeclKind::Enum:
   case DeclKind::Struct: {
@@ -820,9 +843,6 @@ ASTScope *ASTScope::createIfNeeded(const ASTScope *parent, Decl *decl) {
 
     return new (ctx) ASTScope(parent, nominal);
   }
-
-  case DeclKind::Protocol:
-    return new (ctx) ASTScope(parent, cast<ProtocolDecl>(decl));
 
   case DeclKind::TypeAlias: {
     // If we have a generic typealias and our parent isn't describing our
@@ -1089,6 +1109,7 @@ bool ASTScope::isContinuationScope() const {
   switch (getKind()) {
   case ASTScopeKind::Preexpanded:
   case ASTScopeKind::SourceFile:
+  case ASTScopeKind::ExtensionGenericParams:
   case ASTScopeKind::TypeOrExtensionBody:
   case ASTScopeKind::GenericParams:
   case ASTScopeKind::AbstractFunctionDecl:
@@ -1143,6 +1164,7 @@ void ASTScope::enumerateContinuationScopes(
     switch (continuation->getKind()) {
     case ASTScopeKind::Preexpanded:
     case ASTScopeKind::SourceFile:
+    case ASTScopeKind::ExtensionGenericParams:
     case ASTScopeKind::DefaultArgument:
     case ASTScopeKind::AbstractFunctionBody:
     case ASTScopeKind::PatternInitializer:
@@ -1217,6 +1239,9 @@ ASTContext &ASTScope::getASTContext() const {
   case ASTScopeKind::SourceFile:
     return sourceFile.file->getASTContext();
 
+  case ASTScopeKind::ExtensionGenericParams:
+    return extension->getASTContext();
+
   case ASTScopeKind::TypeOrExtensionBody:
     return getParent()->getASTContext();
 
@@ -1287,6 +1312,18 @@ SourceRange ASTScope::getSourceRangeImpl() const {
 
     return SourceRange();
 
+  case ASTScopeKind::ExtensionGenericParams: {
+    // The generic parameters of an extension are available from the trailing
+    // 'where' (if present) or from the start of the body.
+    SourceLoc startLoc;
+    if (auto trailingWhere = extension->getTrailingWhereClause())
+      startLoc = trailingWhere->getWhereLoc();
+    else
+      startLoc = extension->getBraces().Start;
+
+    return SourceRange(startLoc, extension->getEndLoc());
+  }
+      
   case ASTScopeKind::TypeOrExtensionBody:
     if (auto ext = dyn_cast<ExtensionDecl>(iterableDeclContext))
       return ext->getBraces();
@@ -1294,6 +1331,8 @@ SourceRange ASTScope::getSourceRangeImpl() const {
     return cast<NominalTypeDecl>(iterableDeclContext)->getBraces();
 
   case ASTScopeKind::GenericParams:
+    // Explicitly-written generic parameters are in scope following their
+    // definition.
     return SourceRange(genericParams.params->getParams()[genericParams.index]
                          ->getEndLoc(),
                        genericParams.decl->getEndLoc());
@@ -1595,6 +1634,7 @@ DeclContext *ASTScope::getDeclContext() const {
   case ASTScopeKind::TopLevelCode:
     return topLevelCode;
 
+  case ASTScopeKind::ExtensionGenericParams:
   case ASTScopeKind::GenericParams:
   case ASTScopeKind::AbstractFunctionParams:
   case ASTScopeKind::PatternBinding:
@@ -1656,6 +1696,21 @@ SmallVector<ValueDecl *, 4> ASTScope::getLocalBindings() const {
   case ASTScopeKind::Accessors:
   case ASTScopeKind::TopLevelCode:
     // No local declarations.
+    break;
+
+  case ASTScopeKind::ExtensionGenericParams:
+    // Bind this extension, if we haven't done so already.
+    if (!extension->getExtendedType())
+      if (auto resolver = extension->getASTContext().getLazyResolver())
+        resolver->bindExtension(extension);
+
+    // If there are generic parameters, add them.
+    for (auto genericParams = extension->getGenericParams();
+         genericParams;
+         genericParams = genericParams->getOuterParameters()) {
+      for (auto param : genericParams->getParams())
+        result.push_back(param);
+    }
     break;
 
   case ASTScopeKind::GenericParams:
@@ -1762,6 +1817,18 @@ void ASTScope::print(llvm::raw_ostream &out, unsigned level,
     printScopeKind("SourceFile");
     printAddress(sourceFile.file);
     out << " '" << sourceFile.file->getFilename() << "'";
+    printRange();
+    break;
+
+  case ASTScopeKind::ExtensionGenericParams:
+    printScopeKind("ExtensionGenericParams");
+    printAddress(extension);
+    out << " extension of '";
+    if (auto typeRepr = extension->getExtendedTypeLoc().getTypeRepr())
+      typeRepr->print(out);
+    else
+      extension->getExtendedType()->print(out);
+    out << "'";
     printRange();
     break;
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2028,9 +2028,8 @@ void NominalTypeDecl::computeType() {
   //
   // If this protocol has been deserialized, it already has generic parameters.
   // Don't add them again.
-  if (!getGenericParams())
-    if (auto proto = dyn_cast<ProtocolDecl>(this))
-      setGenericParams(proto->createGenericParams(proto));
+  if (auto proto = dyn_cast<ProtocolDecl>(this))
+    proto->createGenericParamsIfMissing();
 
   // If we still don't have a declared type, don't crash -- there's a weird
   // circular declaration issue in the code.
@@ -2940,6 +2939,11 @@ GenericParamList *ProtocolDecl::createGenericParams(DeclContext *dc) {
                                          SourceLoc());
   result->setOuterParameters(outerGenericParams);
   return result;
+}
+
+void ProtocolDecl::createGenericParamsIfMissing() {
+  if (!getGenericParams())
+    setGenericParams(createGenericParams(this));
 }
 
 /// Returns the default witness for a requirement, or nullptr if there is

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -420,6 +420,7 @@ static DeclVisibilityKind getLocalDeclVisibilityKind(const ASTScope *scope) {
   case ASTScopeKind::TopLevelCode:
     llvm_unreachable("no local declarations?");
 
+  case ASTScopeKind::ExtensionGenericParams:
   case ASTScopeKind::GenericParams:
     return DeclVisibilityKind::GenericParameter;
 

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -389,6 +389,10 @@ static void bindExtensionDecl(ExtensionDecl *ED, TypeChecker &TC) {
   extendedNominal->addExtension(ED);
 }
 
+void TypeChecker::bindExtension(ExtensionDecl *ext) {
+  ::bindExtensionDecl(ext, *this);
+}
+
 static void typeCheckFunctionsAndExternalDecls(TypeChecker &TC) {
   unsigned currentFunctionIdx = 0;
   unsigned currentExternalDef = TC.Context.LastCheckedExternalDefinition;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -975,6 +975,8 @@ public:
     validateDecl(VD, true);
   }
 
+  virtual void bindExtension(ExtensionDecl *ext) override;
+
   virtual void resolveExtension(ExtensionDecl *ext) override {
     validateExtension(ext);
     checkInheritanceClause(ext);

--- a/test/NameBinding/scope_map.swift
+++ b/test/NameBinding/scope_map.swift
@@ -193,6 +193,7 @@ func localPatternsWithSharedType() {
 // CHECK-EXPANDED: SourceFile{{.*}}scope_map.swift{{.*}}expanded
 // CHECK-EXPANDED-NEXT: TypeOrExtensionBody {{.*}} 'S0' [4:11 - 6:1] expanded
 // CHECK-EXPANDED-NEXT: `-TypeOrExtensionBody {{.*}} 'InnerC0' [5:17 - 5:19] expanded
+// CHECK-EXPANDED-NEXT: -ExtensionGenericParams {{.*}} extension of 'S0' [8:14 - 9:1] expanded
 // CHECK-EXPANDED-NEXT: -TypeOrExtensionBody {{.*}} extension of 'S0' [8:14 - 9:1] expanded
 // CHECK-EXPANDED-NEXT: |-TypeOrExtensionBody {{.*}} 'C0' [11:10 - 12:1] expanded
 // CHECK-EXPANDED-NEXT: -TypeOrExtensionBody {{.*}} 'E0' [14:9 - 17:1] expanded

--- a/test/NameBinding/scope_map_lookup.swift
+++ b/test/NameBinding/scope_map_lookup.swift
@@ -16,3 +16,18 @@ class C1 {
     return x
   }
 }
+
+// Protocols involving 'Self'.
+protocol P1 {
+  associatedtype A = Self
+}
+
+// Extensions.
+protocol P2 {
+}
+
+extension P2 {
+  func getSelf() -> Self {
+    return self
+  }
+}

--- a/test/NameBinding/scope_map_lookup.swift
+++ b/test/NameBinding/scope_map_lookup.swift
@@ -31,3 +31,12 @@ extension P2 {
     return self
   }
 }
+
+// Lazy properties
+class LazyProperties {
+  init() {
+    lazy var localvar = 42  // expected-error {{lazy is only valid for members of a struct or class}} {{5-10=}}
+    localvar += 1
+    _ = localvar
+  }
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->

This PR fixes a few issues with the modeling of the AST in the scope map. Specifically, it covers:
- The generic parameters of extensions and protocols, and
- Oddities with accessors and initializers in pattern bindings, particularly for lazy variables

With this change, replacing FindLocalVal-based unqualified name lookup with the ASTScope-based lookup is down to breaking  35 tests in the basic testsuite. Getting there...

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
