### PR TITLE
[build] Fix incorrect path quoting in build-script

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -979,7 +979,7 @@ function make_relative_symlink() {
     local SOURCE=$1
     local TARGET=$2
     local TARGET_DIR=$(dirname $2)
-    local RELATIVE_SOURCE=$(python -c "import os.path; print(os.path.relpath(\""${SOURCE}"\", \""${TARGET_DIR}"\"))")
+    local RELATIVE_SOURCE=$(python -c "import os.path; print(os.path.relpath(\"${SOURCE}\", \"${TARGET_DIR}\"))")
     call ln -sf "${RELATIVE_SOURCE}" "${TARGET}"
 }
 


### PR DESCRIPTION
**Problem**:

Building Swift currently fails for spaces in path names. Example:

```
# Setup Swift as described in README, then:
cd /Volumes/Seagate HD/swift-source/swift
utils/build-script -r -t
```

This fails with error:

```
File "<string>", line 1
    import os.path; print(os.path.relpath("/Volumes/Seagate
                                                          ^
SyntaxError: EOL while scanning string literal
```

**Fix**:

This pull request fixes the underlying error: A wrong path quoting in `build-script-impl`. This makes the build process more robust against spaces in paths. 

(Note, this does not protect against other "special" symbols such as single or double quotes in path names.)
