### PR TITLE
[Name lookup] Support lookup of 'self' in lazy property initializers.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1687,6 +1687,10 @@ public:
   }
   SourceRange getOrigInitRange() const;
   void setInit(Expr *E);
+
+  /// Retrieve the initializer as it was written in the source.
+  Expr *getInitAsWritten() const { return InitCheckedAndRemoved.getPointer(); }
+
   bool isInitializerChecked() const {
     return InitCheckedAndRemoved.getInt().contains(Flags::Checked);
   }

--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -34,6 +34,7 @@ class ProtocolDecl;
 class Substitution;
 class TypeDecl;
 class ValueDecl;
+class VarDecl;
 
 /// Abstract interface used to lazily resolve aspects of the AST, such as the
 /// types of declarations or protocol conformance structures.
@@ -91,6 +92,9 @@ public:
 
   /// Bind an extension to its extended type.
   virtual void bindExtension(ExtensionDecl *ext) = 0;
+
+  /// Introduce the accessors for a 'lazy' variable.
+  virtual void introduceLazyVarAccessors(VarDecl *var) = 0;
 
   /// Resolve the type of an extension.
   ///
@@ -161,6 +165,10 @@ public:
 
   void bindExtension(ExtensionDecl *ext) override {
     Principal.bindExtension(ext);
+  }
+
+  void introduceLazyVarAccessors(VarDecl *var) override {
+    Principal.introduceLazyVarAccessors(var);
   }
 
   void resolveExtension(ExtensionDecl *ext) override {

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -407,7 +407,6 @@ static DeclVisibilityKind getLocalDeclVisibilityKind(const ASTScope *scope) {
   case ASTScopeKind::AbstractFunctionBody:
   case ASTScopeKind::DefaultArgument:
   case ASTScopeKind::PatternBinding:
-  case ASTScopeKind::PatternInitializer:
   case ASTScopeKind::BraceStmt:
   case ASTScopeKind::IfStmt:
   case ASTScopeKind::GuardStmt:
@@ -426,6 +425,7 @@ static DeclVisibilityKind getLocalDeclVisibilityKind(const ASTScope *scope) {
 
   case ASTScopeKind::AbstractFunctionParams:
   case ASTScopeKind::Closure:
+  case ASTScopeKind::PatternInitializer:  // lazy var 'self'
     return DeclVisibilityKind::FunctionParameter;
 
   case ASTScopeKind::AfterPatternBinding:
@@ -484,7 +484,8 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
     for (auto currentScope = lookupScope; currentScope;
          currentScope = currentScope->getParent()) {
       // Perform local lookup within this scope.
-      for (auto local : currentScope->getLocalBindings()) {
+      auto localBindings = currentScope->getLocalBindings();
+      for (auto local : localBindings) {
         Consumer.foundDecl(local,
                            getLocalDeclVisibilityKind(currentScope));
       }
@@ -514,10 +515,31 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
         // Pattern binding initializers are only interesting insofar as they
         // affect lookup in an enclosing nominal type or extension thereof.
         if (auto *bindingInit = dyn_cast<PatternBindingInitializer>(dc)) {
-          if (auto binding = bindingInit->getBinding())
+          if (auto binding = bindingInit->getBinding()) {
             lookupInNominalIsStatic = binding->isStatic();
           
-          // FIXME: Look for 'self' for a lazy variable initializer.
+            // Look for 'self' for a lazy variable initializer.
+            if (auto singleVar = binding->getSingleVar())
+              // We only care about lazy variables.
+              if (singleVar->getAttrs().hasAttribute<LazyAttr>()) {
+
+              // 'self' will be listed in the local bindings.
+              for (auto local : localBindings) {
+                auto param = dyn_cast<ParamDecl>(local);
+                if (!param) continue;
+
+
+                // If we have a variable that's the implicit self of its enclosing
+                // context, mark it as 'self'.
+                if (auto func = dyn_cast<FuncDecl>(param->getDeclContext())) {
+                  if (param == func->getImplicitSelfDecl()) {
+                    selfDecl = param;
+                    break;
+                  }
+                }
+              }
+            }
+          }
           continue;
         }
 

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1679,6 +1679,10 @@ void swift::maybeAddMaterializeForSet(AbstractStorageDecl *storage,
   addMaterializeForSet(storage, TC);
 }
 
+void TypeChecker::introduceLazyVarAccessors(VarDecl *var) {
+  maybeAddAccessorsToVariable(var, *this);
+}
+
 void swift::maybeAddAccessorsToVariable(VarDecl *var, TypeChecker &TC) {
   // If we've already synthesized accessors or are currently in the process
   // of doing so, don't proceed.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -991,6 +991,9 @@ public:
     handleExternalDecl(nominal);
   }
 
+  /// Introduce the accessors for a 'lazy' variable.
+  void introduceLazyVarAccessors(VarDecl *var) override;
+
   /// Infer default value witnesses for all requirements in the given protocol.
   void inferDefaultWitnesses(ProtocolDecl *proto);
 

--- a/test/NameBinding/scope_map.swift
+++ b/test/NameBinding/scope_map.swift
@@ -187,6 +187,12 @@ func localPatternsWithSharedType() {
   let i, j, k: Int
 }
 
+class LazyProperties {
+  var value: Int = 17
+
+  lazy var prop: Int = self.value
+}
+
 // RUN: not %target-swift-frontend -dump-scope-maps expanded %s 2> %t.expanded
 // RUN: %FileCheck -check-prefix CHECK-EXPANDED %s < %t.expanded
 
@@ -397,7 +403,7 @@ func localPatternsWithSharedType() {
 // CHECK-EXPANDED-NEXT:         `-AbstractFunctionParams {{.*}} _ param 1:0 [183:39 - 183:39] expanded
 // CHECK-EXPANDED-NEXT:           `-AbstractFunctionParams {{.*}} _ param 1:1 [183:39 - 183:39] expanded
 
-// CHECK-EXPANDED: `-AbstractFunctionDecl {{.*}} localPatternsWithSharedType() [186:1 - 188:1] expanded
+// CHECK-EXPANDED: -AbstractFunctionDecl {{.*}} localPatternsWithSharedType() [186:1 - 188:1] expanded
 // CHECK-EXPANDED:  `-BraceStmt {{.*}} [186:36 - 188:1] expanded
 // CHECK-EXPANDED-NEXT:    `-PatternBinding {{.*}} entry 0 [187:7 - 188:1] expanded
 // CHECK-EXPANDED-NEXT:      `-AfterPatternBinding {{.*}} entry 0 [187:7 - 188:1] expanded
@@ -406,7 +412,7 @@ func localPatternsWithSharedType() {
 // CHECK-EXPANDED-NEXT:            `-PatternBinding {{.*}} entry 2 [187:13 - 188:1] expanded
 // CHECK-EXPANDED-NEXT:              `-AfterPatternBinding {{.*}} entry 2 [187:16 - 188:1] expanded
 
-// RUN: not %target-swift-frontend -dump-scope-maps 70:8,26:20,5:18,166:32,179:18 %s 2> %t.searches
+// RUN: not %target-swift-frontend -dump-scope-maps 70:8,26:20,5:18,166:32,179:18,193:26 %s 2> %t.searches
 // RUN: %FileCheck -check-prefix CHECK-SEARCHES %s < %t.searches
 
 // CHECK-SEARCHES-LABEL: ***Scope at 70:8***
@@ -438,6 +444,14 @@ func localPatternsWithSharedType() {
 // CHECK-SEARCHES-NEXT:     {{.*}} StructDecl name=PatternInitializers
 // CHECK-SEARCHES-NEXT:       {{.*}} Initializer PatternBinding {{.*}} #1
 
+// CHECK-SEARCHES-LABEL: ***Scope at 193:26***
+// CHECK-SEARCHES-NEXT: PatternInitializer {{.*}} entry 0 [193:24 - 193:29] expanded
+// CHECK-SEARCHES-NEXT: name=scope_map
+// CHECK-SEARCHES-NEXT:   FileUnit file="{{.*}}scope_map.swift"
+// CHECK-SEARCHES-NEXT:     ClassDecl name=LazyProperties
+// CHECK-SEARCHES-NEXT:       Initializer PatternBinding {{.*}} #0
+// CHECK-SEARCHES-NEXT: Local bindings: self
+
 // CHECK-SEARCHES-LABEL: ***Complete scope map***
 // CHECK-SEARCHES-NEXT: SourceFile {{.*}} '{{.*}}scope_map.swift' [1:1 - {{.*}}:1] expanded
 // CHECK-SEARCHES: TypeOrExtensionBody {{.*}} 'S0' [4:11 - 6:1] expanded
@@ -461,4 +475,10 @@ func localPatternsWithSharedType() {
 // CHECK-SEARCHES:    |-PatternBinding {{.*}} entry 0 [178:7 - 178:21] unexpanded
 // CHECK-SEARCHES:    `-PatternBinding {{.*}} entry 1 [179:7 - 179:25] expanded
 // CHECK-SEARCHES:      `-PatternInitializer {{.*}} entry 1 [179:16 - 179:25] expanded
+// CHECK-SEARCHES-NOT: {{ expanded}}
+// CHECK-SEARCHES: -TypeOrExtensionBody {{.*}} 'LazyProperties' [190:22 - 194:1] expanded
+// CHECK-SEARCHES-NEXT:   |-PatternBinding {{.*}} entry 0 [191:7 - 191:20] unexpanded
+// CHECK-SEARCHES-NEXT:   `-PatternBinding {{.*}} entry 0 [193:12 - 193:29] expanded
+// CHECK-SEARCHES-NEXT:     |-Accessors {{.*}} scope_map.(file).LazyProperties.prop@{{.*}}scope_map.swift:193:12 [193:12 - 193:12] unexpanded
+// CHECK-SEARCHES-NEXT:     `-PatternInitializer {{.*}} entry 0 [193:24 - 193:29] expanded
 // CHECK-SEARCHES-NOT: {{ expanded}}

--- a/test/NameBinding/scope_map_lookup.swift
+++ b/test/NameBinding/scope_map_lookup.swift
@@ -39,4 +39,16 @@ class LazyProperties {
     localvar += 1
     _ = localvar
   }
+
+  var value: Int = 17
+
+  lazy var prop1: Int = value
+
+  lazy var prop2: Int = { value + 1 }()
+
+  lazy var prop3: Int = { [weak self] in self.value + 1 }()
+
+  lazy var prop4: Int = self.value
+
+  lazy var prop5: Int = { self.value + 1 }()
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->

Lazy property initializers can refer to 'self' either directly or
implicitly (via references to instance members). Model this in
ASTScope-based unqualified name lookup.

Note that the modeling of `self` with the current name lookup
mechanism is broken, so when ASTScope-based unqualified name lookup is
enabled, it fixes SR-2203, rdar://problem/16954496, and the many dupes
of the latter.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
