### PR TITLE
[SILGen] Restore old logic for checking (non-)zero error results.

### DIFF
--- a/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
@@ -103,6 +103,28 @@ extension Int : _ObjectiveCBridgeable {
   }
 }
 
+extension Bool: _ObjectiveCBridgeable {
+  public func _bridgeToObjectiveC() -> NSNumber {
+    return NSNumber()
+  }
+  public static func _forceBridgeFromObjectiveC(
+    _ x: NSNumber, 
+    result: inout Bool?
+  ) {
+  }
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ x: NSNumber,
+    result: inout Bool?
+  ) -> Bool {
+    return true
+  }
+  public static func _unconditionallyBridgeFromObjectiveC(
+    _ x: NSNumber?
+  ) -> Bool {
+    return false
+  }
+}
+
 extension Array : _ObjectiveCBridgeable {
   public func _bridgeToObjectiveC() -> NSArray {
     return NSArray()

--- a/test/Inputs/clang-importer-sdk/usr/include/errors.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/errors.h
@@ -45,6 +45,7 @@
 + (float) bounce: (NSError**) err __attribute__((swift_error(nonnull_error)));
 + (void) flounce: (NSError**) err __attribute__((swift_error(nonnull_error)));
 + (int) ounce: (NSError**) err __attribute__((swift_error(zero_result)));
++ (NSInteger) ounceWord: (NSError**) err __attribute__((swift_error(zero_result)));
 + (int) once: (NSError**) err __attribute__((swift_error(nonzero_result)));
 + (BOOL) sconce: (NSError**) err __attribute__((swift_error(zero_result)));
 + (BOOL) scotch: (NSError**) err __attribute__((swift_error(nonzero_result)));


### PR DESCRIPTION
Actually bridging ObjCBool to Bool is overkill for this, but moreover it caused problems for non-boolean types that took this code path. Just go back to the previous logic of unwrapping multiple levels of struct; this way we can also handle wrappers around integer types (if we ever have any).

rdar://problem/27985744
