### PR TITLE
Provide a fix-it that inserts omitted generic parameters when they can't be inferred

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -852,6 +852,8 @@ ERROR(unbound_generic_parameter_cast,none,
       "generic parameter %0 could not be inferred in cast to %1", (Type, Type))
 NOTE(archetype_declared_in_type,none,
      "%0 declared as parameter to type %1", (Type, Type))
+NOTE(unbound_generic_parameter_explicit_fix,none,
+     "explicitly specify the generic arguments to fix this issue", ())
 
 
 ERROR(string_index_not_integer,none,

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -650,7 +650,8 @@ private:
         Info.ID == diag::deprecated_protocol_composition.ID ||
         Info.ID == diag::deprecated_protocol_composition_single.ID ||
         Info.ID == diag::deprecated_any_composition.ID ||
-        Info.ID == diag::deprecated_operator_body.ID)
+        Info.ID == diag::deprecated_operator_body.ID ||
+        Info.ID == diag::unbound_generic_parameter_explicit_fix.ID)
       return true;
 
     return false;

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -6491,39 +6491,112 @@ void ConstraintSystem::diagnoseFailureForExpr(Expr *expr) {
   diagnosis.diagnoseAmbiguity(expr);
 }
 
+static bool hasArchetype(const GenericTypeDecl *generic,
+                         const ArchetypeType *archetype) {
+  return std::any_of(generic->getInnermostGenericParamTypes().begin(),
+                     generic->getInnermostGenericParamTypes().end(),
+                     [archetype](const GenericTypeParamType *genericParamTy) {
+    return genericParamTy->getDecl()->getArchetype() == archetype;
+  });
+}
+
 static void noteArchetypeSource(const TypeLoc &loc, ArchetypeType *archetype,
-                                TypeChecker &tc) {
-  GenericTypeDecl *FoundDecl = nullptr;
-  
+                                ConstraintSystem &cs) {
+  const GenericTypeDecl *FoundDecl = nullptr;
+  const ComponentIdentTypeRepr *FoundGenericTypeBase = nullptr;
+
   // Walk the TypeRepr to find the type in question.
   if (auto typerepr = loc.getTypeRepr()) {
     struct FindGenericTypeDecl : public ASTWalker {
-      GenericTypeDecl *&FoundDecl;
-      FindGenericTypeDecl(GenericTypeDecl *&FoundDecl) : FoundDecl(FoundDecl) {
-      }
+      const GenericTypeDecl *FoundDecl = nullptr;
+      const ComponentIdentTypeRepr *FoundGenericTypeBase = nullptr;
+      const ArchetypeType *Archetype;
+
+      FindGenericTypeDecl(const ArchetypeType *Archetype)
+          : Archetype(Archetype) {}
       
       bool walkToTypeReprPre(TypeRepr *T) override {
         // If we already emitted the note, we're done.
         if (FoundDecl) return false;
         
-        if (auto ident = dyn_cast<ComponentIdentTypeRepr>(T))
-          FoundDecl = dyn_cast_or_null<GenericTypeDecl>(ident->getBoundDecl());
+        if (auto ident = dyn_cast<ComponentIdentTypeRepr>(T)) {
+          auto *generic =
+              dyn_cast_or_null<GenericTypeDecl>(ident->getBoundDecl());
+          if (hasArchetype(generic, Archetype)) {
+            FoundDecl = generic;
+            FoundGenericTypeBase = ident;
+            return false;
+          }
+        }
         // Keep walking.
         return true;
       }
-    } findGenericTypeDecl(FoundDecl);
-    
+    } findGenericTypeDecl(archetype);
+
     typerepr->walk(findGenericTypeDecl);
+    FoundDecl = findGenericTypeDecl.FoundDecl;
+    FoundGenericTypeBase = findGenericTypeDecl.FoundGenericTypeBase;
   }
-  
+
   // If we didn't find the type in the TypeRepr, fall back to the type in the
   // type checked expression.
-  if (!FoundDecl)
-    FoundDecl = loc.getType()->getAnyGeneric();
-  
-  if (FoundDecl)
-    tc.diagnose(FoundDecl, diag::archetype_declared_in_type, archetype,
-                FoundDecl->getDeclaredType());
+  if (!FoundDecl) {
+    if (const GenericTypeDecl *generic = loc.getType()->getAnyGeneric())
+      if (hasArchetype(generic, archetype))
+        FoundDecl = generic;
+  }
+
+  auto &tc = cs.getTypeChecker();
+  if (FoundDecl) {
+    tc.diagnose(FoundDecl, diag::archetype_declared_in_type,
+                archetype, FoundDecl->getDeclaredType());
+  }
+
+  if (FoundGenericTypeBase && !isa<GenericIdentTypeRepr>(FoundGenericTypeBase)){
+    assert(FoundDecl);
+
+    // If we can, prefer using any types already fixed by the constraint system.
+    // This lets us produce fixes like `Pair<Int, Any>` instead of defaulting to
+    // `Pair<Any, Any>`.
+    // Right now we only handle this when the type that's at fault is the
+    // top-level type passed to this function.
+    ArrayRef<Type> genericArgs;
+    if (auto *boundGenericTy = loc.getType()->getAs<BoundGenericType>()) {
+      if (boundGenericTy->getDecl() == FoundDecl)
+        genericArgs = boundGenericTy->getGenericArgs();
+    }
+
+    auto getPreferredType =
+        [&](const GenericTypeParamDecl *genericParam) -> Type {
+      // If we were able to get the generic arguments (i.e. the types used at
+      // FoundDecl's use site), we can prefer those...
+      if (genericArgs.empty())
+        return Type();
+
+      Type preferred = genericArgs[genericParam->getIndex()];
+      if (!preferred || preferred->is<ErrorType>())
+        return Type();
+
+      // ...but only if they were actually resolved by the constraint system
+      // despite the failure.
+      TypeVariableType *unused;
+      Type maybeFixedType = cs.getFixedTypeRecursive(preferred, unused,
+                                                     /*wantRValue*/true);
+      if (maybeFixedType->hasTypeVariable() ||
+          maybeFixedType->hasUnresolvedType()) {
+        return Type();
+      }
+      return maybeFixedType;
+    };
+
+    SmallString<64> genericParamBuf;
+    if (tc.getDefaultGenericArgumentsString(genericParamBuf, FoundDecl,
+                                            getPreferredType)) {
+      tc.diagnose(FoundGenericTypeBase->getLoc(),
+                  diag::unbound_generic_parameter_explicit_fix)
+        .fixItInsertAfter(FoundGenericTypeBase->getEndLoc(), genericParamBuf);
+    }
+  }
 }
 
 
@@ -6639,11 +6712,7 @@ void FailureDiagnosis::diagnoseUnboundArchetype(ArchetypeType *archetype,
       .highlight(ECE->getCastTypeLoc().getSourceRange());
 
     // Emit a note specifying where this came from, if we can find it.
-    noteArchetypeSource(ECE->getCastTypeLoc(), archetype, tc);
-    if (auto *ND = ECE->getCastTypeLoc().getType()
-          ->getNominalOrBoundGenericNominal())
-      tc.diagnose(ND, diag::archetype_declared_in_type, archetype,
-                  ND->getDeclaredType());
+    noteArchetypeSource(ECE->getCastTypeLoc(), archetype, *CS);
     return;
   }
 
@@ -6673,7 +6742,7 @@ void FailureDiagnosis::diagnoseUnboundArchetype(ArchetypeType *archetype,
 
   if (auto TE = dyn_cast<TypeExpr>(anchor)) {
     // Emit a note specifying where this came from, if we can find it.
-    noteArchetypeSource(TE->getTypeLoc(), archetype, tc);
+    noteArchetypeSource(TE->getTypeLoc(), archetype, *CS);
     return;
   }
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -932,6 +932,69 @@ static void diagnoseImplicitSelfUseInClosure(TypeChecker &TC, const Expr *E,
   const_cast<Expr *>(E)->walk(DiagnoseWalker(TC, isAlreadyInClosure));
 }
 
+bool TypeChecker::getDefaultGenericArgumentsString(
+    SmallVectorImpl<char> &buf,
+    const swift::GenericTypeDecl *typeDecl,
+    llvm::function_ref<Type(const GenericTypeParamDecl *)> getPreferredType) {
+  llvm::raw_svector_ostream genericParamText{buf};
+  genericParamText << "<";
+
+  auto printGenericParamSummary =
+      [&](const GenericTypeParamType *genericParamTy) {
+    const GenericTypeParamDecl *genericParam = genericParamTy->getDecl();
+    if (Type result = getPreferredType(genericParam)) {
+      result.print(genericParamText);
+      return;
+    }
+
+    ArrayRef<ProtocolDecl *> protocols =
+        genericParam->getConformingProtocols(this);
+
+    if (Type superclass = genericParam->getSuperclass()) {
+      if (protocols.empty()) {
+        superclass.print(genericParamText);
+        return;
+      }
+
+      genericParamText << "<#" << genericParam->getName() << ": ";
+      superclass.print(genericParamText);
+      for (const ProtocolDecl *proto : protocols) {
+        if (proto->isSpecificProtocol(KnownProtocolKind::AnyObject))
+          continue;
+        genericParamText << " & " << proto->getName();
+      }
+      genericParamText << "#>";
+      return;
+    }
+
+    if (protocols.empty()) {
+      genericParamText << Context.Id_Any;
+      return;
+    }
+
+    if (protocols.size() == 1 &&
+        (protocols.front()->isObjC() ||
+         protocols.front()->isSpecificProtocol(KnownProtocolKind::AnyObject))) {
+      genericParamText << protocols.front()->getName();
+      return;
+    }
+
+    genericParamText << "<#" << genericParam->getName() << ": ";
+    interleave(protocols,
+               [&](const ProtocolDecl *proto) {
+                 genericParamText << proto->getName();
+               },
+               [&] { genericParamText << " & "; });
+    genericParamText << "#>";
+  };
+
+  interleave(typeDecl->getInnermostGenericParamTypes(),
+             printGenericParamSummary, [&]{ genericParamText << ", "; });
+
+  genericParamText << ">";
+  return true;
+}
+
 /// Diagnose an argument labeling issue, returning true if we successfully
 /// diagnosed the issue.
 bool swift::diagnoseArgumentLabelError(TypeChecker &TC, const Expr *expr,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1980,6 +1980,23 @@ public:
                                               ConstructorDecl *ctorDecl,
                                               bool SuppressDiagnostics);
 
+  /// Builds a string representing a "default" generic argument list for
+  /// \p typeDecl. In general, this means taking the bound of each generic
+  /// parameter. The \p getPreferredType callback can be used to provide a
+  /// different type from the bound.
+  ///
+  /// It may not always be possible to find a single appropriate type for a
+  /// particular parameter (say, if it has two bounds). In this case, an
+  /// Xcode-style placeholder will be used instead.
+  ///
+  /// Returns true if the arguments list could be constructed, false if for
+  /// some reason it could not.
+  bool getDefaultGenericArgumentsString(
+      SmallVectorImpl<char> &buf,
+      const GenericTypeDecl *typeDecl,
+      llvm::function_ref<Type(const GenericTypeParamDecl *)> getPreferredType =
+          [](const GenericTypeParamDecl *) { return Type(); });
+
   /// Attempt to omit needless words from the name of the given declaration.
   Optional<DeclName> omitNeedlessWords(AbstractFunctionDecl *afd);
 

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -298,7 +298,7 @@ func rdar20029786(_ ns: NSString?) {
 
 // <rdar://problem/19813772> QoI: Using as! instead of as in this case produces really bad diagnostic
 func rdar19813772(_ nsma: NSMutableArray) {
-  var a1 = nsma as! Array // expected-error{{generic parameter 'Element' could not be inferred in cast to 'Array<_>'}}
+  var a1 = nsma as! Array // expected-error{{generic parameter 'Element' could not be inferred in cast to 'Array<_>'}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{26-26=<Any>}}
   // FIXME: The following diagnostic is misleading and should not happen: expected-warning@-1{{cast from 'NSMutableArray' to unrelated type 'Array<_>' always fails}}
   var a2 = nsma as! Array<AnyObject> // expected-warning{{forced cast from 'NSMutableArray' to 'Array<AnyObject>' always succeeds; did you mean to use 'as'?}} {{17-20=as}}
   var a3 = nsma as Array<AnyObject>

--- a/test/Constraints/construction.swift
+++ b/test/Constraints/construction.swift
@@ -57,7 +57,7 @@ acceptString("\(hello), \(world) #\(i)!")
 Optional<Int>(1) // expected-warning{{unused}}
 Optional(1) // expected-warning{{unused}}
 _ = .none as Optional<Int>
-Optional(.none) // expected-error{{generic parameter 'T' could not be inferred}}
+Optional(.none) // expected-error{{generic parameter 'T' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{9-9=<Any>}}
 
 // Interpolation
 _ = "\(hello), \(world) #\(i)!"

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -52,7 +52,7 @@ func generic_metatypes<T : SomeProtocol>(_ x: T)
 }
 
 // Inferring a variable's type from a call to a generic.
-struct Pair<T, U> { }
+struct Pair<T, U> { } // expected-note 5 {{'T' declared as parameter to type 'Pair'}}
 
 func pair<T, U>(_ x: T, _ y: U) -> Pair<T, U> { }
 
@@ -188,7 +188,7 @@ func r22459135() {
 
 // <rdar://problem/19710848> QoI: Friendlier error message for "[] as Set"
 // <rdar://problem/22326930> QoI: "argument for generic parameter 'Element' could not be inferred" lacks context
-_ = [] as Set  // expected-error {{generic parameter 'Element' could not be inferred in cast to 'Set<_>}}
+_ = [] as Set  // expected-error {{generic parameter 'Element' could not be inferred in cast to 'Set<_>}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{14-14=<<#Element: Hashable#>>}}
 
 
 //<rdar://problem/22509125> QoI: Error when unable to infer generic archetype lacks greatness
@@ -201,7 +201,7 @@ func r22509125<T>(_ a : T?) { // expected-note {{in call to function 'r22509125'
 struct R24267414<T> {  // expected-note {{'T' declared as parameter to type 'R24267414'}}
   static func foo() -> Int {}
 }
-var _ : Int = R24267414.foo() // expected-error {{generic parameter 'T' could not be inferred}}
+var _ : Int = R24267414.foo() // expected-error {{generic parameter 'T' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{24-24=<Any>}}
 
 
 // https://bugs.swift.org/browse/SR-599
@@ -231,10 +231,10 @@ class Whatever<A: IntegerArithmetic, B: IntegerArithmetic> {  // expected-note 2
   static func bar() {}
 
 }
-Whatever.foo(a: 23) // expected-error {{generic parameter 'A' could not be inferred}}
+Whatever.foo(a: 23) // expected-error {{generic parameter 'A' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{9-9=<<#A: IntegerArithmetic#>, <#B: IntegerArithmetic#>>}}
 
 // <rdar://problem/21718955> Swift useless error: cannot invoke 'foo' with no arguments
-Whatever.bar()  // expected-error {{generic parameter 'A' could not be inferred}}
+Whatever.bar()  // expected-error {{generic parameter 'A' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{9-9=<<#A: IntegerArithmetic#>, <#B: IntegerArithmetic#>>}}
 
 // <rdar://problem/27515965> Type checker doesn't enforce same-type constraint if associated type is Any
 protocol P27515965 {
@@ -252,4 +252,111 @@ struct V27515965 {
 
 func test(x: S27515965) -> V27515965 {
   return V27515965(x) // expected-error {{generic parameter 'T' could not be inferred}}
+}
+
+protocol BaseProto {}
+protocol SubProto: BaseProto {}
+@objc protocol NSCopyish {
+  func copy() -> Any
+}
+
+struct FullyGeneric<Foo> {} // expected-note 2 {{'Foo' declared as parameter to type 'FullyGeneric'}}
+
+struct AnyClassBound<Foo: AnyObject> {} // expected-note {{'Foo' declared as parameter to type 'AnyClassBound'}}
+struct AnyClassBound2<Foo> where Foo: AnyObject {} // expected-note {{'Foo' declared as parameter to type 'AnyClassBound2'}}
+
+struct ProtoBound<Foo: SubProto> {} // expected-note {{'Foo' declared as parameter to type 'ProtoBound'}}
+struct ProtoBound2<Foo> where Foo: SubProto {} // expected-note {{'Foo' declared as parameter to type 'ProtoBound2'}}
+
+struct ObjCProtoBound<Foo: NSCopyish> {} // expected-note {{'Foo' declared as parameter to type 'ObjCProtoBound'}}
+struct ObjCProtoBound2<Foo> where Foo: NSCopyish {} // expected-note {{'Foo' declared as parameter to type 'ObjCProtoBound2'}}
+
+struct ClassBound<Foo: X> {} // expected-note {{generic type 'ClassBound' declared here}}
+struct ClassBound2<Foo> where Foo: X {} // expected-note {{generic type 'ClassBound2' declared here}}
+
+struct ProtosBound<Foo> where Foo: SubProto & NSCopyish {} // expected-note {{'Foo' declared as parameter to type 'ProtosBound'}}
+struct ProtosBound2<Foo: SubProto & NSCopyish> {} // expected-note {{'Foo' declared as parameter to type 'ProtosBound2'}}
+struct ProtosBound3<Foo: SubProto> where Foo: NSCopyish {} // expected-note {{'Foo' declared as parameter to type 'ProtosBound3'}}
+
+struct AnyClassAndProtoBound<Foo> where Foo: AnyObject, Foo: SubProto {} // expected-note {{'Foo' declared as parameter to type 'AnyClassAndProtoBound'}}
+struct AnyClassAndProtoBound2<Foo> where Foo: SubProto, Foo: AnyObject {} // expected-note {{'Foo' declared as parameter to type 'AnyClassAndProtoBound2'}}
+
+struct ClassAndProtoBound<Foo> where Foo: X, Foo: SubProto {} // expected-note {{'Foo' declared as parameter to type 'ClassAndProtoBound'}}
+
+struct ClassAndProtosBound<Foo> where Foo: X, Foo: SubProto, Foo: NSCopyish {} // expected-note {{'Foo' declared as parameter to type 'ClassAndProtosBound'}}
+struct ClassAndProtosBound2<Foo> where Foo: X, Foo: SubProto & NSCopyish {} // expected-note {{'Foo' declared as parameter to type 'ClassAndProtosBound2'}}
+
+extension Pair {
+  init(first: T) {}
+  init(second: U) {}
+
+  var first: T { fatalError() }
+  var second: U { fatalError() }
+}
+
+func testFixIts() {
+  _ = FullyGeneric() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{19-19=<Any>}}
+  _ = FullyGeneric<Any>()
+
+  _ = AnyClassBound() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{20-20=<AnyObject>}}
+  _ = AnyClassBound<Any>() // expected-error {{type 'Any' does not conform to protocol 'AnyObject'}}
+  _ = AnyClassBound<AnyObject>()
+
+  _ = AnyClassBound2() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{21-21=<AnyObject>}}
+  _ = AnyClassBound2<Any>() // expected-error {{type 'Any' does not conform to protocol 'AnyObject'}}
+  _ = AnyClassBound2<AnyObject>()
+
+  _ = ProtoBound() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{17-17=<<#Foo: SubProto#>>}}
+  _ = ProtoBound<Any>() // expected-error {{type 'Any' does not conform to protocol 'SubProto'}}
+
+  _ = ProtoBound2() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{18-18=<<#Foo: SubProto#>>}}
+  _ = ProtoBound2<Any>() // expected-error {{type 'Any' does not conform to protocol 'SubProto'}}
+
+  _ = ObjCProtoBound() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{21-21=<NSCopyish>}}
+  _ = ObjCProtoBound<AnyObject>() // expected-error {{type 'AnyObject' does not conform to protocol 'NSCopyish'}}
+  _ = ObjCProtoBound<NSCopyish>()
+
+  _ = ObjCProtoBound2() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{22-22=<NSCopyish>}}
+  _ = ObjCProtoBound2<AnyObject>() // expected-error {{type 'AnyObject' does not conform to protocol 'NSCopyish'}}
+  _ = ObjCProtoBound2<NSCopyish>()
+
+  _ = ProtosBound() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{18-18=<<#Foo: NSCopyish & SubProto#>>}}
+  _ = ProtosBound2() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{19-19=<<#Foo: NSCopyish & SubProto#>>}}
+  _ = ProtosBound3() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{19-19=<<#Foo: NSCopyish & SubProto#>>}}
+
+  _ = AnyClassAndProtoBound() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{28-28=<<#Foo: AnyObject & SubProto#>>}}
+  _ = AnyClassAndProtoBound2() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{29-29=<<#Foo: AnyObject & SubProto#>>}}
+
+  _ = ClassAndProtoBound() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{25-25=<<#Foo: X & SubProto#>>}}
+
+  _ = ClassAndProtosBound() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{26-26=<<#Foo: X & NSCopyish & SubProto#>>}}
+  _ = ClassAndProtosBound2() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{27-27=<<#Foo: X & NSCopyish & SubProto#>>}}
+
+  _ = Pair() // expected-error {{generic parameter 'T' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{11-11=<Any, Any>}}
+  // FIXME: This should say "generic parameter 'U'".
+  _ = Pair(first: S()) // expected-error {{generic parameter 'T' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{11-11=<S, Any>}}
+  _ = Pair(second: S()) // expected-error {{generic parameter 'T' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{11-11=<Any, S>}}
+}
+
+func testFixItClassBound() {
+  // We infer a single class bound for simple cases in expressions...
+  let x = ClassBound()
+  let x1: String = x // expected-error {{cannot convert value of type 'ClassBound<X>' to specified type 'String'}}
+
+  let y = ClassBound2()
+  let y1: String = y // expected-error {{cannot convert value of type 'ClassBound2<X>' to specified type 'String'}}
+
+  // ...but not in types.
+  let z1: ClassBound // expected-error {{reference to generic type 'ClassBound' requires arguments in <...>}} {{21-21=<X>}}
+  let z2: ClassBound2 // expected-error {{reference to generic type 'ClassBound2' requires arguments in <...>}} {{22-22=<X>}}
+}
+
+func testFixItCasting(x: Any) {
+  _ = x as! FullyGeneric // expected-error {{generic parameter 'Foo' could not be inferred in cast to 'FullyGeneric<_>'}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{25-25=<Any>}}
+}
+
+func testFixItContextualKnowledge() {
+  // FIXME: These could propagate backwards.
+  let _: Int = Pair().first // expected-error {{generic parameter 'T' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{20-20=<Any, Any>}}
+  let _: Int = Pair().second // expected-error {{generic parameter 'T' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{20-20=<Any, Any>}}
 }

--- a/test/Constraints/incomplete_function_ref.swift
+++ b/test/Constraints/incomplete_function_ref.swift
@@ -6,7 +6,7 @@ struct MyCollection<Element> {  // expected-note {{'Element' declared as paramet
   }
 }
 
-MyCollection.map // expected-error{{generic parameter 'Element' could not be inferred}}
+MyCollection.map // expected-error{{generic parameter 'Element' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{13-13=<Any>}}
 
 let a = MyCollection<Int>()
 a.map // expected-error{{generic parameter 'T' could not be inferred}}

--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -189,6 +189,7 @@ var graph: Graph3
 
 class Graph4<NodeType : SomeProt> {}
 var graph: Graph4
+var graphAgain = Graph4()
 
 class GraphCombo<NodeType : SomeProt & ObjCProt> {}
 var graph: GraphCombo

--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -187,8 +187,11 @@ var graph: Graph2
 class Graph3<NodeType : ObjCProt> {}
 var graph: Graph3
 
-class GraphNoFix<NodeType : SomeProt> {}
-var graph: GraphNoFix
+class Graph4<NodeType : SomeProt> {}
+var graph: Graph4
+
+class GraphCombo<NodeType : SomeProt & ObjCProt> {}
+var graph: GraphCombo
 
 func evilCommas(s: String) {
   _ = s[s.startIndex..<<#editorplaceholder#>]

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -188,10 +188,13 @@ var graph: Graph2<Node, Node2>
 
 @objc protocol ObjCProt { }
 class Graph3<NodeType : ObjCProt> {}
-var graph: Graph3<AnyObject>
+var graph: Graph3<ObjCProt>
 
-class GraphNoFix<NodeType : SomeProt> {}
-var graph: GraphNoFix
+class Graph4<NodeType : SomeProt> {}
+var graph: Graph4<<#NodeType: SomeProt#>>
+
+class GraphCombo<NodeType : SomeProt & ObjCProt> {}
+var graph: GraphCombo<<#NodeType: ObjCProt & SomeProt#>>
 
 func evilCommas(s: String) {
   _ = s[s.startIndex..<<#editorplaceholder#>]

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -192,6 +192,7 @@ var graph: Graph3<ObjCProt>
 
 class Graph4<NodeType : SomeProt> {}
 var graph: Graph4<<#NodeType: SomeProt#>>
+var graphAgain = Graph4<<#NodeType: SomeProt#>>()
 
 class GraphCombo<NodeType : SomeProt & ObjCProt> {}
 var graph: GraphCombo<<#NodeType: ObjCProt & SomeProt#>>

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -76,11 +76,13 @@ let _ : D = D(a: 1, b: 2)  // expected-error {{cannot convert value of type 'MyT
 
 let _ : D<Int, Int, Float> = D<Int, Int, Float>(a: 1, b: 2)
 
+// FIXME: This is not a great error.
 // expected-error @+1 {{cannot convert value of type 'MyType<Int, Int>' to specified type 'D'}}
 let _ : D = D<Int, Int, Float>(a: 1, b: 2)
 
 
-// expected-error @+1 {{generic parameter 'T3' could not be inferred}}
+// expected-error @+2 {{generic parameter 'T3' could not be inferred}}
+// expected-note @+1 {{explicitly specify the generic arguments to fix this issue}} {{31-31=<Any, Any, Any>}}
 let _ : D<Int, Int, Float> = D(a: 1, b: 2)
 
 let _ : F = { (a : Int) -> Int in a }  // Infer the types of F
@@ -95,7 +97,7 @@ _ = A<String, Int>(a: "foo", // expected-error {{'String' is not convertible to 
   b: 42)
 _ = B(a: 12, b: 42)
 _ = B(a: 12, b: 42 as Float)
-_ = B(a: "foo", b: 42)     // expected-error {{generic parameter 'T1' could not be inferred}}
+_ = B(a: "foo", b: 42)     // expected-error {{generic parameter 'T1' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{6-6=<Any>}}
 _ = C(a: "foo", b: 42)
 _ = C(a: 42,        // expected-error {{'Int' is not convertible to 'String'}}
   b: 42)


### PR DESCRIPTION
This will help when migrating to Swift 3 and Objective-C classes with newly-added generic parameters.

Still to do:
- More tests
- See if there's a way to handle conflicting context

rdar://problem/27087345
