### PR TITLE
Fix var-parameter detection for inferred params

### DIFF
--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -745,11 +745,17 @@ static bool validateParameterType(ParamDecl *decl, DeclContext *DC,
   auto elementOptions = (options |
                          (decl->isVariadic() ? TR_VariadicFunctionInput
                                              : TR_FunctionInput));
-  bool hadError = TC.validateType(decl->getTypeLoc(), DC,
-                                  elementOptions, resolver);
-  
+  bool hadError = false;
+
+  // We might have a null typeLoc if this is a closure parameter list,
+  // where parameters are allowed to elide their types.
+  if (!decl->getTypeLoc().isNull()) {
+    hadError |= TC.validateType(decl->getTypeLoc(), DC,
+                                elementOptions, resolver);
+  }
+
   Type Ty = decl->getTypeLoc().getType();
-  if (decl->isVariadic() && !hadError) {
+  if (decl->isVariadic() && !Ty.isNull() && !hadError) {
     Ty = TC.getArraySliceType(decl->getStartLoc(), Ty);
     if (Ty.isNull()) {
       hadError = true;
@@ -759,7 +765,7 @@ static bool validateParameterType(ParamDecl *decl, DeclContext *DC,
   // If the param is not a 'let' and it is not an 'inout'.
   // It must be a 'var'. Provide helpful diagnostics like a shadow copy
   // in the function body to fix the 'var' attribute.
-  if (!decl->isLet() && !Ty->is<InOutType>() && !hadError) {
+  if (!decl->isLet() && (Ty.isNull() || !Ty->is<InOutType>()) && !hadError) {
     auto func = dyn_cast_or_null<AbstractFunctionDecl>(DC);
     diagnoseAndMigrateVarParameterToBody(decl, func, TC);
     decl->setInvalid();
@@ -768,7 +774,7 @@ static bool validateParameterType(ParamDecl *decl, DeclContext *DC,
 
   if (hadError)
     decl->getTypeLoc().setType(ErrorType::get(TC.Context), /*validated*/true);
-  
+
   return hadError;
 }
 
@@ -779,8 +785,7 @@ bool TypeChecker::typeCheckParameterList(ParameterList *PL, DeclContext *DC,
   bool hadError = false;
   
   for (auto param : *PL) {
-    if (param->getTypeLoc().getTypeRepr())
-      hadError |= validateParameterType(param, DC, options, resolver, *this);
+    hadError |= validateParameterType(param, DC, options, resolver, *this);
     
     auto type = param->getTypeLoc().getType();
     if (!type && param->hasType()) {

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -351,7 +351,9 @@ func invalid_inout(inout var x : Int) { // expected-error {{parameter may not ha
 func invalid_var(var x: Int) { // expected-error {{parameters may not have the 'var' specifier}}{{18-21=}} {{1-1=    var x = x\n}}
   
 }
-
+func takesClosure(_: (Int) -> Int) {
+  takesClosure { (var d) in d } // expected-error {{parameters may not have the 'var' specifier}}
+}
 
 func updateInt(_ x : inout Int) {}
 


### PR DESCRIPTION
<!-- What's in this pull request? -->

Previously, we would skip validating the type (and checking var/inout) on parameters that didn't have an explicit type, which let them slip through Sema and get caught in a sanity check during SILGen. Instead, teach validateParameterType how to validate an elided type, like those found in closure arguments.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-2562](https://bugs.swift.org/browse/SR-2562).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
