### PR TITLE
[swiftc (51 vs. 5162)] Add crasher in swift::GenericSignature::getSubstitutionMap(...)

### DIFF
--- a/validation-test/compiler_crashers/28404-swift-genericsignature-getsubstitutionmap.swift
+++ b/validation-test/compiler_crashers/28404-swift-genericsignature-getsubstitutionmap.swift
@@ -1,0 +1,15 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+{class a{
+class A
+protocol A{{
+}typealias e:A
+{
+}protocol A{{}class a<A{let f{class B:A{}class A:a{init()


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignature::getSubstitutionMap(...)`.

Current number of unresolved compiler crashers: 51 (5162 resolved)

Assertion failure in [`lib/AST/GenericSignature.cpp (line 413)`](https://github.com/apple/swift/blob/master/lib/AST/GenericSignature.cpp#L413):

```
Assertion `args.empty() && "did not use all substitutions?!"' failed.

When executing: TypeSubstitutionMap swift::GenericSignature::getSubstitutionMap(ArrayRef<swift::Substitution>) const
```

Assertion context:

```
  if (pa == rep) {
    assert(rep->getDependentType(builder, /*allowUnresolved*/ false)
              ->getCanonicalType() == type->getCanonicalType());
    return type;
  }
  return rep->getDependentType(builder, /*allowUnresolved*/ false);
}

bool GenericSignature::areSameTypeParameterInContext(Type type1, Type type2,
                                                     ModuleDecl &mod) {
  assert(type1->isTypeParameter());
```

Stack trace:

```
swift: /path/to/swift/lib/AST/GenericSignature.cpp:413: TypeSubstitutionMap swift::GenericSignature::getSubstitutionMap(ArrayRef<swift::Substitution>) const: Assertion `args.empty() && "did not use all substitutions?!"' failed.
8  swift           0x000000000111d493 swift::GenericSignature::getSubstitutionMap(llvm::ArrayRef<swift::Substitution>) const + 659
9  swift           0x0000000000f5a0d0 swift::createDesignatedInitOverride(swift::TypeChecker&, swift::ClassDecl*, swift::ConstructorDecl*, swift::DesignatedInitKind) + 384
10 swift           0x0000000000edcd44 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 3284
13 swift           0x0000000000ed7466 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
16 swift           0x0000000000f3f67a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
17 swift           0x0000000000f3f4de swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
18 swift           0x0000000000f400a3 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
20 swift           0x0000000000efb4a1 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
21 swift           0x0000000000c7b5b9 swift::CompilerInstance::performSema() + 3289
23 swift           0x00000000007db487 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
24 swift           0x00000000007a72b8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28404-swift-genericsignature-getsubstitutionmap.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28404-swift-genericsignature-getsubstitutionmap-d11cec.o
1.  While type-checking getter for f at validation-test/compiler_crashers/28404-swift-genericsignature-getsubstitutionmap.swift:15:30
2.  While type-checking 'B' at validation-test/compiler_crashers/28404-swift-genericsignature-getsubstitutionmap.swift:15:31
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
