### PR TITLE
[gardening] Remove three unused diagnostics.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1172,17 +1172,6 @@ ERROR(attr_interpolated_string,none,
 ERROR(attr_only_at_non_local_scope, none,
       "attribute '%0' can only be used in a non-local scope", (StringRef))
 
-ERROR(attr_expected_colon_separator,none,
-      "expected ':' following '%0' argument of '%1'",
-      (StringRef, StringRef))
-
-ERROR(attr_expected_string_literal_arg,none,
-      "expected string literal for '%0' argument of '%1'",
-      (StringRef, StringRef))
-
-ERROR(attr_duplicate_argument,none,
-      "duplicate '%0' argument", (StringRef))
-
 // accessibility
 ERROR(attr_accessibility_expected_set,none,
       "expected 'set' as subject of '%0' modifier", (StringRef))


### PR DESCRIPTION
Remove three unused diagnostics.

Last usage removed in eb3ba78d9411616e30cb9ec92b3881456d1f3059 by @DougGregor 
