### PR TITLE
[SILGen] Restore old logic for checking (non-)zero error results.

### DIFF
--- a/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
@@ -103,6 +103,28 @@ extension Int : _ObjectiveCBridgeable {
   }
 }
 
+extension Bool: _ObjectiveCBridgeable {
+  public func _bridgeToObjectiveC() -> NSNumber {
+    return NSNumber()
+  }
+  public static func _forceBridgeFromObjectiveC(
+    _ x: NSNumber, 
+    result: inout Bool?
+  ) {
+  }
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ x: NSNumber,
+    result: inout Bool?
+  ) -> Bool {
+    return true
+  }
+  public static func _unconditionallyBridgeFromObjectiveC(
+    _ x: NSNumber?
+  ) -> Bool {
+    return false
+  }
+}
+
 extension Array : _ObjectiveCBridgeable {
   public func _bridgeToObjectiveC() -> NSArray {
     return NSArray()

--- a/test/Inputs/clang-importer-sdk/usr/include/errors.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/errors.h
@@ -45,6 +45,7 @@
 + (float) bounce: (NSError**) err __attribute__((swift_error(nonnull_error)));
 + (void) flounce: (NSError**) err __attribute__((swift_error(nonnull_error)));
 + (int) ounce: (NSError**) err __attribute__((swift_error(zero_result)));
++ (NSInteger) ounceWord: (NSError**) err __attribute__((swift_error(zero_result)));
 + (int) once: (NSError**) err __attribute__((swift_error(nonzero_result)));
 + (BOOL) sconce: (NSError**) err __attribute__((swift_error(zero_result)));
 + (BOOL) scotch: (NSError**) err __attribute__((swift_error(nonzero_result)));


### PR DESCRIPTION
- **Explanation:** We broke `__attribute__((swift_error(zero_result)))` by making a part of its implementation assume it would only be used with boolean values (it also supports integers); this resulted in assertion failures in debug builds of the compiler and incorrect run-time behavior (failing to identify errors) in release builds. The breakage was part of a general change to better handle boolean values in SIL, but _this_ part of it wasn't fully correct and turned out to not be necessary. Revert back to the older way of doing things when dealing with imported throwing functions.
- **Scope:** Affects imported throwing functions that use integer or boolean results to specify whether they succeeded or failed.
- **Issue:** rdar://problem/27985744
- **Reviewed by:** @slavapestov 
- **Risk:** Low; the "new" code is from previous betas, where this feature was working correctly.
- **Testing:** Added compiler regression tests, verified that the originally reported case now works.
