### PR TITLE
stdlib: make 'Sequence.first(where:)' a pure protocol extension (no dynamic dispatch)

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
@@ -82,7 +82,6 @@ public class SequenceLog {
   public static var map = TypeIndexed(0)
   public static var filter = TypeIndexed(0)
   public static var forEach = TypeIndexed(0)
-  public static var first = TypeIndexed(0)
   public static var dropFirst = TypeIndexed(0)
   public static var dropLast = TypeIndexed(0)
   public static var dropWhile = TypeIndexed(0)
@@ -117,6 +116,7 @@ public class CollectionLog : SequenceLog {
   public static var isEmpty = TypeIndexed(0)
   public static var count = TypeIndexed(0)
   public static var _customIndexOfEquatableElement = TypeIndexed(0)
+  public static var first = TypeIndexed(0)
   public static var advance = TypeIndexed(0)
   public static var advanceLimit = TypeIndexed(0)
   public static var distance = TypeIndexed(0)
@@ -244,13 +244,6 @@ public struct ${Self}<
   ) rethrows {
     Log.forEach[selfType] += 1
     try base.forEach(body)
-  }
-  
-  public func first(
-    where predicate: (Base.Iterator.Element) throws -> Bool
-  ) rethrows -> Base.Iterator.Element? {
-    Log.first[selfType] += 1
-    return try base.first(where: predicate)
   }
 
   public typealias SubSequence = Base.SubSequence

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -590,17 +590,6 @@ public protocol Sequence {
     whereSeparator isSeparator: (Iterator.Element) throws -> Bool
   ) rethrows -> [SubSequence]
 
-  /// Returns the first element of the sequence that satisfies the given
-  /// predicate or nil if no such element is found.
-  ///
-  /// - Parameter predicate: A closure that takes an element of the
-  ///   sequence as its argument and returns a Boolean value indicating
-  ///   whether the element is a match.
-  /// - Returns: The first match or `nil` if there was no match.
-  func first(
-    where predicate: (Iterator.Element) throws -> Bool
-  ) rethrows -> Iterator.Element?
-
   func _customContainsEquatableElement(
     _ element: Iterator.Element
   ) -> Bool?

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -942,16 +942,6 @@ SequenceTypeTests.test("forEach/dispatch") {
 }
 
 //===----------------------------------------------------------------------===//
-// first()
-//===----------------------------------------------------------------------===//
-
-SequenceTypeTests.test("first/dispatch") {
-  let tester = SequenceLog.dispatchTester([OpaqueValue(1)])
-  _ = tester.first { $0.value == 1 }
-  expectCustomizable(tester, tester.log.first)
-}
-
-//===----------------------------------------------------------------------===//
 // dropFirst()
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
SE-0032 did not propose a protocol entry point, only a protocol extension.

Using a pure protocol extension is the right choice here because a concrete sequence can't provide a more efficient implementation of this method than the default one.

SE-0032 was implemented by https://github.com/apple/swift/pull/2529.
