### PR TITLE
[SIL] Add test case for crash triggered in swift::constraints::ConstraintSystem::diagnoseFailureForExpr(…)

### DIFF
--- a/validation-test/SIL/crashers/033-swift-constraints-constraintsystem-diagnosefailureforexpr.sil
+++ b/validation-test/SIL/crashers/033-swift-constraints-constraintsystem-diagnosefailureforexpr.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+if(import Swift


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:4: error: expected expression in list of expressions
if(import Swift
   ^
<stdin>:3:4: error: expected ',' separator
if(import Swift
   ^
   ,
<stdin>:3:4: error: expected ')' in expression list
if(import Swift
   ^
<stdin>:3:3: note: to match this opening '('
if(import Swift
  ^
<stdin>:3:4: error: expected '{' after 'if' condition
if(import Swift
   ^
sil-opt: /path/to/swift/lib/Sema/TypeCheckNameLookup.cpp:254: swift::LookupResult swift::TypeChecker::lookupMember(swift::DeclContext *, swift::Type, swift::DeclName, NameLookupOptions): Assertion `!type->is<TupleType>()' failed.
9  sil-opt         0x0000000000bb2386 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 5990
10 sil-opt         0x0000000000bb750e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4078
11 sil-opt         0x0000000000adf6f7 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 471
12 sil-opt         0x0000000000ae2dd5 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 949
13 sil-opt         0x0000000000ae7c74 swift::TypeChecker::typeCheckCondition(swift::Expr*&, swift::DeclContext*) + 180
14 sil-opt         0x0000000000ae7dcb swift::TypeChecker::typeCheckStmtCondition(llvm::MutableArrayRef<swift::StmtConditionElement>&, swift::DeclContext*, swift::Diag<>) + 251
17 sil-opt         0x0000000000b66cd6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
18 sil-opt         0x0000000000b1f3cd swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
19 sil-opt         0x00000000007758a9 swift::CompilerInstance::performSema() + 3289
20 sil-opt         0x000000000075ec65 main + 1813
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  While type-checking expression at [<stdin>:3:3 - line:3:3] RangeText="("
```
