### PR TITLE
[swiftc (51 vs. 5162)] Add crasher in swift::constraints::ConstraintSystem::resolveOverload(...)

### DIFF
--- a/validation-test/compiler_crashers/28405-swift-constraints-constraintsystem-resolveoverload.swift
+++ b/validation-test/compiler_crashers/28405-swift-constraints-constraintsystem-resolveoverload.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+func a<T{class a<T>o{a<T>(


### PR DESCRIPTION
Add test case for crash triggered in `swift::constraints::ConstraintSystem::resolveOverload(...)`.

Current number of unresolved compiler crashers: 51 (5162 resolved)

Assertion failure in [`lib/Sema/ConstraintSystem.cpp (line 1592)`](https://github.com/apple/swift/blob/master/lib/Sema/ConstraintSystem.cpp#L1592):

```
Assertion `!refType->hasTypeParameter() && "Cannot have a dependent type here"' failed.

When executing: void swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator *, swift::Type, swift::constraints::OverloadChoice)
```

Assertion context:

```
          return replaceSelfTypeInArchetype(archetype);
        }
        return type;
      });
  }
  assert(!refType->hasTypeParameter() && "Cannot have a dependent type here");

  // If we're binding to an init member, the 'throws' need to line up between
  // the bound and reference types.
  if (choice.isDecl()) {
    auto decl = choice.getDecl();
```

Stack trace:

```
swift: /path/to/swift/lib/Sema/ConstraintSystem.cpp:1592: void swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator *, swift::Type, swift::constraints::OverloadChoice): Assertion `!refType->hasTypeParameter() && "Cannot have a dependent type here"' failed.
8  swift           0x0000000000f732fc swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator*, swift::Type, swift::constraints::OverloadChoice) + 4492
9  swift           0x0000000000fe0432 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 882
10 swift           0x0000000000f6e957 swift::constraints::ConstraintSystem::addConstraint(swift::constraints::Constraint*, bool, bool) + 23
11 swift           0x0000000000f72109 swift::constraints::ConstraintSystem::addOverloadSet(swift::Type, llvm::ArrayRef<swift::constraints::OverloadChoice>, swift::constraints::ConstraintLocator*, swift::constraints::OverloadChoice*) + 377
12 swift           0x0000000000fdf01f swift::constraints::ConstraintSystem::simplifyMemberConstraint(swift::constraints::Constraint const&) + 623
13 swift           0x0000000000fe0105 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 69
14 swift           0x0000000000f6e957 swift::constraints::ConstraintSystem::addConstraint(swift::constraints::Constraint*, bool, bool) + 23
15 swift           0x0000000000fdb76d swift::constraints::ConstraintSystem::simplifyConstructionConstraint(swift::Type, swift::FunctionType*, unsigned int, swift::FunctionRefKind, swift::constraints::ConstraintLocator*) + 557
16 swift           0x0000000000fdfd7b swift::constraints::ConstraintSystem::simplifyApplicableFnConstraint(swift::constraints::Constraint const&) + 907
17 swift           0x0000000000fe0402 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 834
18 swift           0x0000000000f6e957 swift::constraints::ConstraintSystem::addConstraint(swift::constraints::Constraint*, bool, bool) + 23
22 swift           0x00000000010aa5eb swift::Expr::walk(swift::ASTWalker&) + 75
23 swift           0x0000000000fbb868 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) + 200
24 swift           0x0000000000fe75dd swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 77
25 swift           0x0000000000ec5d33 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 403
26 swift           0x0000000000ec9455 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 949
29 swift           0x0000000000f4a52a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
30 swift           0x0000000000f4a38e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
31 swift           0x0000000000f4af63 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
33 swift           0x0000000000f045c1 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
34 swift           0x0000000000c86e69 swift::CompilerInstance::performSema() + 3289
36 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
37 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28405-swift-constraints-constraintsystem-resolveoverload.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28405-swift-constraints-constraintsystem-resolveoverload-c3526d.o
1.  While type-checking 'a' at validation-test/compiler_crashers/28405-swift-constraints-constraintsystem-resolveoverload.swift:10:1
2.  While type-checking expression at [validation-test/compiler_crashers/28405-swift-constraints-constraintsystem-resolveoverload.swift:10:21 - line:10:26] RangeText="{a<T>("
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
