### PR TITLE
Don't attempt a value conversion without a valid conversion pair

### DIFF
--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -537,7 +537,10 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     }
 
     if (auto &keyConv = E->getKeyConversion()) {
-      if (Expr *E2 = doIt(keyConv.Conversion)) {
+      auto kConv = keyConv.Conversion;
+      if (!kConv) {
+        return nullptr;
+      } else if (Expr *E2 = doIt(kConv)) {
         E->setKeyConversion({keyConv.OrigValue, E2});
       } else {
         return nullptr;
@@ -545,7 +548,10 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     }
 
     if (auto &valueConv = E->getValueConversion()) {
-      if (Expr *E2 = doIt(valueConv.Conversion)) {
+      auto vConv = valueConv.Conversion;
+      if (!vConv) {
+        return nullptr;
+      } else if (Expr *E2 = doIt(vConv)) {
         E->setValueConversion({valueConv.OrigValue, E2});
       } else {
         return nullptr;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4228,7 +4228,8 @@ Expr *ExprRewriter::coerceTupleToTuple(Expr *expr, TupleType *fromTuple,
     // We need to convert the source element to the destination type.
     if (!fromTupleExpr) {
       // FIXME: Lame! We can't express this in the AST.
-      InFlightDiagnostic diag = tc.diagnose(expr->getLoc(),
+      auto anchorExpr = locator.getBaseLocator()->getAnchor();
+      InFlightDiagnostic diag = tc.diagnose(anchorExpr->getLoc(),
                                         diag::tuple_conversion_not_expressible,
                                             fromTuple, toTuple);
       if (typeFromPattern) {

--- a/test/Sema/diag_express_tuple.swift
+++ b/test/Sema/diag_express_tuple.swift
@@ -5,3 +5,9 @@ func foo(a : [(some: Int, (key: Int, value: String))]) -> String {
     if i == j { return k }
   }
 }
+
+func rdar28207648() -> [(Int, CustomStringConvertible)] {
+  let v : [(Int, Int)] = []
+  return v as [(Int, CustomStringConvertible)] // expected-error {{cannot express tuple conversion '(Int, Int)' to '(Int, CustomStringConvertible)'}}
+}
+


### PR DESCRIPTION
Previously this would crash when invalid tuple conversions were encountered in the middle of collection upcasts because we were trying to convert with NULL `Expr` nodes.

Resolves [SR-2585](https://bugs.swift.org/browse/SR-2585) and rdar://problem/28207648.
