### PR TITLE
Rename 'expectEmpty()' and 'expectNotEmpty()' to 'expectNil()' and 'expectNotNil()'.

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
@@ -890,7 +890,7 @@ extension TestSuite {
         let c = makeWrappedCollection(test.collection)
         let result = c.first
         if test.isEmpty {
-          expectEmpty(result)
+          expectNil(result)
         } else {
           expectOptionalEqual(
             test.collection[0],
@@ -1175,7 +1175,7 @@ extension TestSuite {
     self.test("\(testNamePrefix).popFirst()/slice/empty/semantics") {
       let c = makeWrappedCollection(Array<OpaqueValue<Int>>())
       var slice = c[c.startIndex..<c.startIndex]
-      expectEmpty(slice.popFirst())
+      expectNil(slice.popFirst())
     }
 
     //===------------------------------------------------------------------===//
@@ -1225,7 +1225,7 @@ extension TestSuite {
         let c = makeWrappedCollection(test.collection)
         let result = c.last
         if test.isEmpty {
-          expectEmpty(result)
+          expectNil(result)
         } else {
           expectOptionalEqual(
             test.collection[test.count - 1],
@@ -1382,7 +1382,7 @@ extension TestSuite {
     self.test("\(testNamePrefix).popLast()/slice/empty/semantics") {
       let c = makeWrappedCollection(Array<OpaqueValue<Int>>())
       var slice = c[c.startIndex..<c.startIndex]
-      expectEmpty(slice.popLast())
+      expectNil(slice.popLast())
     }
 
 
@@ -1690,7 +1690,7 @@ extension TestSuite {
           expectEqual(c.nthIndex(expectedOffset), new!,
             stackTrace: SourceLocStack().with(test.loc))
         } else {
-          expectEmpty(new)
+          expectNil(new)
         }
       }
     }
@@ -1731,7 +1731,7 @@ extension TestSuite {
           expectEqual(c.nthIndex(expectedOffset), new!,
             stackTrace: SourceLocStack().with(test.loc))
         } else {
-          expectEmpty(new)
+          expectNil(new)
         }
       } else {
         expectCrashLater()

--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
@@ -455,7 +455,7 @@ self.test("\(testNamePrefix)._withUnsafeMutableBufferPointerIfSupported()/semant
     if withUnsafeMutableBufferPointerIsSupported {
       expectEqualSequence(test.collection, result!.value) { $0.value == $1.value }
     } else {
-      expectEmpty(result)
+      expectNil(result)
     }
   }
 }

--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceInstance.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceInstance.swift.gyb
@@ -45,7 +45,7 @@ public func checkIterator<
   // Having returned `.None` once, a `IteratorProtocol` should not generate
   // more elements.
   for _ in 0..<10 {
-    expectEmpty(mutableGen.next(), ${trace})
+    expectNil(mutableGen.next(), ${trace})
   }
 }
 

--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
@@ -1930,7 +1930,7 @@ self.test("\(testNamePrefix)._preprocessingPass/semantics") {
     if wasInvoked {
       expectOptionalEqual(42, result?.value)
     } else {
-      expectEmpty(result)
+      expectNil(result)
     }
   }
 
@@ -1948,7 +1948,7 @@ self.test("\(testNamePrefix)._preprocessingPass/semantics") {
     } catch {
       caughtError = error
     }
-    expectEmpty(result)
+    expectNil(result)
     if wasInvoked {
       expectOptionalEqual(TestError.error2, caughtError as? TestError)
     }

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -522,17 +522,28 @@ public func expectFalse(_ actual: Bool, ${TRACE}) {
   }
 }
 
+@available(*, deprecated, renamed: "expectNil")
 public func expectEmpty<T>(_ value: T?, ${TRACE}) {
+  expectNil(value, ${trace})
+}
+
+@available(*, deprecated, renamed: "expectNotNil")
+@discardableResult
+public func expectNotEmpty<T>(_ value: T?, ${TRACE}) -> T? {
+  return expectNotNil(value, ${trace})
+}
+
+public func expectNil<T>(_ value: T?, ${TRACE}) {
   if value != nil {
     expectationFailure(
-      "expected optional to be empty\nactual: \"\(value)\"", trace: ${trace})
+      "expected optional to be nil\nactual: \"\(value)\"", trace: ${trace})
   }
 }
 
 @discardableResult
-public func expectNotEmpty<T>(_ value: T?, ${TRACE}) -> T? {
+public func expectNotNil<T>(_ value: T?, ${TRACE}) -> T? {
   if value == nil {
-    expectationFailure("expected optional to be non-empty", trace: ${trace})
+    expectationFailure("expected optional to be non-nil", trace: ${trace})
   }
   return value
 }

--- a/test/Interpreter/SDK/Foundation_test.swift
+++ b/test/Interpreter/SDK/Foundation_test.swift
@@ -274,7 +274,7 @@ FoundationTestSuite.test("NSKeyedUnarchiver/decodeObjectOfClass(_:forKey:)") {
   var KU = NSKeyedUnarchiver(forReadingWith: data as Data)
 
   var missing = KU.decodeObject(of: NSPredicate.self, forKey: "Not there")
-  expectEmpty(missing)
+  expectNil(missing)
   expectType((NSPredicate?).self, &missing)
 
   var decoded = KU.decodeObject(of: NSPredicate.self, forKey: KEY)
@@ -282,7 +282,7 @@ FoundationTestSuite.test("NSKeyedUnarchiver/decodeObjectOfClass(_:forKey:)") {
   expectType((NSPredicate?).self, &decoded)
 
   var wrongType = KU.decodeObject(of: DateFormatter.self, forKey: KEY)
-  expectEmpty(missing)
+  expectNil(missing)
 
   KU.finishDecoding()
 }

--- a/test/Interpreter/SDK/Foundation_test.swift
+++ b/test/Interpreter/SDK/Foundation_test.swift
@@ -278,7 +278,7 @@ FoundationTestSuite.test("NSKeyedUnarchiver/decodeObjectOfClass(_:forKey:)") {
   expectType((NSPredicate?).self, &missing)
 
   var decoded = KU.decodeObject(of: NSPredicate.self, forKey: KEY)
-  expectNotEmpty(decoded)
+  expectNotNil(decoded)
   expectType((NSPredicate?).self, &decoded)
 
   var wrongType = KU.decodeObject(of: DateFormatter.self, forKey: KEY)

--- a/test/Interpreter/SDK/cf_extensions.swift
+++ b/test/Interpreter/SDK/cf_extensions.swift
@@ -70,7 +70,7 @@ CFTestSuite.test("protocols/downcast")
                             components: [1.0, 0.5, 0.25, 1.0])
   let opaquePink: AnyObject = pink
   let downcasted = opaquePink as? SwiftProto
-  expectNotEmpty(downcasted)
+  expectNotNil(downcasted)
   expectTrue(pink === downcasted!.doTheThing())
 }
 

--- a/test/Interpreter/SDK/errors.swift
+++ b/test/Interpreter/SDK/errors.swift
@@ -40,13 +40,13 @@ ErrorHandlingTests.test("succeedIgnoringError") {
 ErrorHandlingTests.test("fail") {
   let obj = ErrorImpl()
   let result = testFail(obj)
-  expectEmpty(result)
+  expectNil(result)
 }
 
 ErrorHandlingTests.test("failIgnoringError") {
   let obj = ErrorImpl()
   let result = testFailIgnoringError(obj)
-  expectEmpty(result)
+  expectNil(result)
 }
 
 runAllTests()

--- a/test/Interpreter/SDK/object_literals.swift
+++ b/test/Interpreter/SDK/object_literals.swift
@@ -15,7 +15,7 @@ LiteralsTestSuite.test("file") {
   // This is what requires the proper bundle folder structure.
   let resource = #fileLiteral(resourceName: "testData.plist")
   let contents = NSDictionary(contentsOf: resource) as! [String: NSObject]?
-  _ = expectNotEmpty(contents)
+  _ = expectNotNil(contents)
   expectEqual(["test": true as NSObject], contents!)
 }
 

--- a/test/Interpreter/objc_class_properties.swift
+++ b/test/Interpreter/objc_class_properties.swift
@@ -155,7 +155,7 @@ ClassProperties.test("inheritance/generic") {
 
 ClassProperties.test("optionalProp") {
   let noProp: ProtoWithClassProperty.Type = ClassWithClassProperty.self
-  expectEmpty(noProp.optionalClassProp)
+  expectNil(noProp.optionalClassProp)
 
   let hasProp: ProtoWithClassProperty.Type = Subclass.self
   expectNotEmpty(hasProp.optionalClassProp)
@@ -178,11 +178,11 @@ class NamingConflictSubclass : PropertyNamingConflict {
 ClassProperties.test("namingConflict") {
   let obj = PropertyNamingConflict()
   expectTrue(obj === obj.prop.map { $0 as AnyObject })
-  expectEmpty(type(of: obj).prop)
-  expectEmpty(PropertyNamingConflict.prop)
+  expectNil(type(of: obj).prop)
+  expectNil(PropertyNamingConflict.prop)
 
   let sub = NamingConflictSubclass()
-  expectEmpty(sub.prop)
+  expectNil(sub.prop)
   expectNotEmpty(type(of: sub).prop)
   expectNotEmpty(NamingConflictSubclass.prop)
 }
@@ -201,10 +201,10 @@ extension NamingConflictSubclass : PropertyNamingConflictProto {
 ClassProperties.test("namingConflict/protocol") {
   let obj: PropertyNamingConflictProto = NamingConflictSubclass()
   expectTrue(obj === obj.protoProp.map { $0 as AnyObject })
-  expectEmpty(type(of: obj).protoProp)
+  expectNil(type(of: obj).protoProp)
 
   let type: PropertyNamingConflictProto.Type = NamingConflictSubclass.self
-  expectEmpty(type.protoProp)
+  expectNil(type.protoProp)
 }
 
 runAllTests()

--- a/test/Interpreter/objc_class_properties.swift
+++ b/test/Interpreter/objc_class_properties.swift
@@ -158,15 +158,15 @@ ClassProperties.test("optionalProp") {
   expectNil(noProp.optionalClassProp)
 
   let hasProp: ProtoWithClassProperty.Type = Subclass.self
-  expectNotEmpty(hasProp.optionalClassProp)
+  expectNotNil(hasProp.optionalClassProp)
   expectEqual(true, hasProp.optionalClassProp!)
 
   let hasOwnProp: ProtoWithClassProperty.Type = SwiftClass.self
-  expectNotEmpty(hasOwnProp.optionalClassProp)
+  expectNotNil(hasOwnProp.optionalClassProp)
   expectEqual(true, hasOwnProp.optionalClassProp!)
 
   let hasPropObjC: ProtoWithClassProperty.Type = ObjCSubclassWithClassProperty.self
-  expectNotEmpty(hasPropObjC.optionalClassProp)
+  expectNotNil(hasPropObjC.optionalClassProp)
   expectEqual(true, hasPropObjC.optionalClassProp!)
 }
 
@@ -183,8 +183,8 @@ ClassProperties.test("namingConflict") {
 
   let sub = NamingConflictSubclass()
   expectNil(sub.prop)
-  expectNotEmpty(type(of: sub).prop)
-  expectNotEmpty(NamingConflictSubclass.prop)
+  expectNotNil(type(of: sub).prop)
+  expectNotNil(NamingConflictSubclass.prop)
 }
 
 extension NamingConflictSubclass : PropertyNamingConflictProto {

--- a/test/Interpreter/objc_class_properties_runtime.swift
+++ b/test/Interpreter/objc_class_properties_runtime.swift
@@ -74,10 +74,10 @@ ClassProperties.test("runtime")
   .code {
   let theClass: AnyObject = SwiftClass.self
   let prop = class_getProperty(object_getClass(theClass), "value")
-  expectNotEmpty(prop)
+  expectNotNil(prop)
 
   let nameAsCString = property_getName(prop)!
-  expectNotEmpty(nameAsCString)
+  expectNotNil(nameAsCString)
   expectEqual("value", String(cString: nameAsCString))
 }
 

--- a/test/Interpreter/objc_runtime_visible.swift
+++ b/test/Interpreter/objc_runtime_visible.swift
@@ -47,7 +47,7 @@ ObjCRuntimeVisibleTestSuite.test("downcast") {
   let obj = HiddenClass.create()
   let opaque: AnyObject = obj
   let downcasted = opaque as? HiddenClass
-  expectNotEmpty(downcasted)
+  expectNotNil(downcasted)
   expectTrue(obj === downcasted)
 }
 
@@ -67,7 +67,7 @@ ObjCRuntimeVisibleTestSuite.test("protocols/downcast")
   let obj = HiddenClass.create()
   let opaque: AnyObject = obj
   let downcasted = opaque as? SwiftProto
-  expectNotEmpty(downcasted)
+  expectNotNil(downcasted)
   expectTrue(obj === downcasted!.doTheThing())
 }
 

--- a/test/stdlib/ArrayBridge.swift.gyb
+++ b/test/stdlib/ArrayBridge.swift.gyb
@@ -259,28 +259,28 @@ tests.test("Another/${Any}") {
   let subclass2 = subclassInBaseBuffer
   
   // Explicit downcast-ability is based on element type, not buffer type
-  expectNotEmpty(subclassInBaseBuffer as? [Subclass])
+  expectNotNil(subclassInBaseBuffer as? [Subclass])
 
   // We can up-cast to array of Any
   let subclassAsAnyArray: [${Any}] = subclassInBaseBuffer
   expectEqual(subclass2, subclassAsAnyArray.map { $0 as! Base })
 
   let downcastBackToBase = subclassAsAnyArray as? [Base]
-  expectNotEmpty(downcastBackToBase)
+  expectNotNil(downcastBackToBase)
 
-  if let downcastBackToSubclass = expectNotEmpty(subclassAsAnyArray as? [Subclass]) {
+  if let downcastBackToSubclass = expectNotNil(subclassAsAnyArray as? [Subclass]) {
     expectEqual(subclass2, downcastBackToSubclass)
   }
 
-  if let downcastToProtocols = expectNotEmpty(subclassAsAnyArray as? [Fooable]) {
+  if let downcastToProtocols = expectNotNil(subclassAsAnyArray as? [Fooable]) {
     expectEqual(subclass2, downcastToProtocols.map { $0 as! Subclass })
   }
 
-  if let downcastToProtocols = expectNotEmpty(subclassAsAnyArray as? [Barable]) {
+  if let downcastToProtocols = expectNotNil(subclassAsAnyArray as? [Barable]) {
     expectEqual(subclass2, downcastToProtocols.map { $0 as! Subclass })
   }
 
-  if let downcastToProtocols = expectNotEmpty(subclassAsAnyArray as? [Barable & Fooable]) {
+  if let downcastToProtocols = expectNotNil(subclassAsAnyArray as? [Barable & Fooable]) {
     expectEqual(subclass2, downcastToProtocols.map { $0 as! Subclass })
   }
 
@@ -364,7 +364,7 @@ tests.test("testExplicitlyBridged/${Any}") {
   }
 
   // Downcasts of up-casted arrays.
-  if let downcasted = expectNotEmpty(
+  if let downcasted = expectNotNil(
     bridgeableValuesAsAnys as? [Subclass]
   ) {
     expectEqualSequence(expectedSubclasses, downcasted)

--- a/test/stdlib/ArrayBridge.swift.gyb
+++ b/test/stdlib/ArrayBridge.swift.gyb
@@ -284,7 +284,7 @@ tests.test("Another/${Any}") {
     expectEqual(subclass2, downcastToProtocols.map { $0 as! Subclass })
   }
 
-  expectEmpty(subclassAsAnyArray as? [Barable & Bazable])
+  expectNil(subclassAsAnyArray as? [Barable & Bazable])
 }
 
 //===--- Explicitly Bridged -----------------------------------------------===//
@@ -393,7 +393,7 @@ tests.test("testExplicitlyBridged/${Any}") {
   }
 
   // Downcast of Cocoa array to an array of strings (which should fail)
-  expectEmpty(wrappedCocoaBridgeableValues as? [String])
+  expectNil(wrappedCocoaBridgeableValues as? [String])
 
   // Downcast from an implicitly unwrapped optional array of Anys.
   var wrappedCocoaBridgeableValuesIUO: [${Any}]! = wrappedCocoaBridgeableValues
@@ -403,7 +403,7 @@ tests.test("testExplicitlyBridged/${Any}") {
 
   // Downcast from a nil implicitly unwrapped optional array of Anys.
   wrappedCocoaBridgeableValuesIUO = nil
-  expectEmpty(wrappedCocoaBridgeableValuesIUO as? [BridgeableValue])
+  expectNil(wrappedCocoaBridgeableValuesIUO as? [BridgeableValue])
 
   // Downcast from an optional array of Anys.
   var wrappedCocoaBridgeableValuesOpt: [${Any}]? = wrappedCocoaBridgeableValues
@@ -413,7 +413,7 @@ tests.test("testExplicitlyBridged/${Any}") {
 
   // Downcast from a nil optional array of Anys.
   wrappedCocoaBridgeableValuesOpt = nil
-  expectEmpty(wrappedCocoaBridgeableValuesOpt as? [BridgeableValue])
+  expectNil(wrappedCocoaBridgeableValuesOpt as? [BridgeableValue])
 }
 % end
 

--- a/test/stdlib/Builtins.swift
+++ b/test/stdlib/Builtins.swift
@@ -164,8 +164,8 @@ class C : B {}
 tests.test("_getSuperclass") {
   expectNil(_getSuperclass(A.self))
   expectNil(_getSuperclass(Classy.self))
-  expectNotEmpty(_getSuperclass(B.self))
-  expectNotEmpty(_getSuperclass(C.self))
+  expectNotNil(_getSuperclass(B.self))
+  expectNotNil(_getSuperclass(C.self))
   expectTrue(_getSuperclass(B.self)! == A.self)
   expectTrue(_getSuperclass(C.self)! == B.self)
 }

--- a/test/stdlib/Builtins.swift
+++ b/test/stdlib/Builtins.swift
@@ -162,8 +162,8 @@ class B : A {}
 class C : B {}
 
 tests.test("_getSuperclass") {
-  expectEmpty(_getSuperclass(A.self))
-  expectEmpty(_getSuperclass(Classy.self))
+  expectNil(_getSuperclass(A.self))
+  expectNil(_getSuperclass(Classy.self))
   expectNotEmpty(_getSuperclass(B.self))
   expectNotEmpty(_getSuperclass(C.self))
   expectTrue(_getSuperclass(B.self)! == A.self)

--- a/test/stdlib/DictionaryTraps.swift
+++ b/test/stdlib/DictionaryTraps.swift
@@ -86,7 +86,7 @@ DictionaryTraps.test("RemoveInvalidIndex4")
   var d = [ 10: 1010 ]
   let index = d.index(forKey: 10)!
   d.remove(at: index)
-  expectEmpty(d[10])
+  expectNil(d[10])
   expectCrashLater()
   d.remove(at: index)
 }

--- a/test/stdlib/Dispatch.swift
+++ b/test/stdlib/Dispatch.swift
@@ -26,12 +26,12 @@ DispatchAPI.test("OS_OBJECT support") {
   expectTrue(mainQueue is DispatchQueue)
 
   // This should not be optimized out, and should succeed.
-  expectNotEmpty(mainQueue as? DispatchQueue)
+  expectNotNil(mainQueue as? DispatchQueue)
 }
 
 DispatchAPI.test("DispatchGroup creation") {
   let group = DispatchGroup()
-  expectNotEmpty(group)
+  expectNotNil(group)
 }
 
 DispatchAPI.test("dispatch_block_t conversions") {

--- a/test/stdlib/Error.swift
+++ b/test/stdlib/Error.swift
@@ -120,7 +120,7 @@ ErrorTests.test("try?") {
   expectType(Optional<Int>.self, &value)
   expectEqual(Optional(1), value)
 
-  expectEmpty(try? { () throws -> Int in throw SillyError.JazzHands }())
+  expectNil(try? { () throws -> Int in throw SillyError.JazzHands }())
 }
 
 enum LifetimeError : Error {

--- a/test/stdlib/ErrorBridged.swift
+++ b/test/stdlib/ErrorBridged.swift
@@ -157,7 +157,7 @@ ErrorBridgingTests.test("NSError-to-enum bridging") {
 
     let urlError = eURL as! URLError
     expectOptionalEqual(testURL, urlError.failingURL)
-    expectEmpty(urlError.failureURLPeerTrust)
+    expectNil(urlError.failureURLPeerTrust)
 
     // CoreLocation error domain
     let nsCL = NSError(domain: kCLErrorDomain,
@@ -467,10 +467,10 @@ class RecoveryDelegate {
 func testCustomizedError(error: Error, nsError: NSError) {
   // LocalizedError
   if #available(OSX 10.11, iOS 9.0, tvOS 9.0, watchOS 2.0, *) {
-    expectEmpty(nsError.userInfo[NSLocalizedDescriptionKey as NSObject])
-    expectEmpty(nsError.userInfo[NSLocalizedFailureReasonErrorKey as NSObject])
-    expectEmpty(nsError.userInfo[NSLocalizedRecoverySuggestionErrorKey as NSObject])
-    expectEmpty(nsError.userInfo[NSHelpAnchorErrorKey as NSObject])
+    expectNil(nsError.userInfo[NSLocalizedDescriptionKey as NSObject])
+    expectNil(nsError.userInfo[NSLocalizedFailureReasonErrorKey as NSObject])
+    expectNil(nsError.userInfo[NSLocalizedRecoverySuggestionErrorKey as NSObject])
+    expectNil(nsError.userInfo[NSHelpAnchorErrorKey as NSObject])
   } else {
     expectOptionalEqual("something went horribly wrong",
       nsError.userInfo[NSLocalizedDescriptionKey as NSObject] as? String)
@@ -489,7 +489,7 @@ func testCustomizedError(error: Error, nsError: NSError) {
 
   // RecoverableError
   if #available(OSX 10.11, iOS 9.0, tvOS 9.0, watchOS 2.0, *) {
-    expectEmpty(nsError.userInfo[NSLocalizedRecoveryOptionsErrorKey as NSObject])
+    expectNil(nsError.userInfo[NSLocalizedRecoveryOptionsErrorKey as NSObject])
   } else {
     expectOptionalEqual(["Delete 'throw'", "Disable the test" ],
       nsError.userInfo[NSLocalizedRecoveryOptionsErrorKey as NSObject] as? [String])
@@ -500,7 +500,7 @@ func testCustomizedError(error: Error, nsError: NSError) {
   // Directly recover.
   let attempter: AnyObject
   if #available(OSX 10.11, iOS 9.0, tvOS 9.0, watchOS 2.0, *) {
-    expectEmpty(nsError.userInfo[NSRecoveryAttempterErrorKey as NSObject])
+    expectNil(nsError.userInfo[NSRecoveryAttempterErrorKey as NSObject])
     attempter = nsError.recoveryAttempter! as AnyObject
   } else {
     attempter = nsError.userInfo[NSRecoveryAttempterErrorKey as NSObject]! as AnyObject
@@ -560,7 +560,7 @@ ErrorBridgingTests.test("Customizing localization/recovery laziness") {
 
   // RecoverableError
   if #available(OSX 10.11, iOS 9.0, tvOS 9.0, watchOS 2.0, *) {
-    expectEmpty(nsError.userInfo[NSLocalizedRecoveryOptionsErrorKey as NSObject])
+    expectNil(nsError.userInfo[NSLocalizedRecoveryOptionsErrorKey as NSObject])
   } else {
     expectOptionalEqual(["Delete 'throw'", "Disable the test" ],
       nsError.userInfo[NSLocalizedRecoveryOptionsErrorKey as NSObject] as? [String])

--- a/test/stdlib/ImplicitlyUnwrappedOptional.swift
+++ b/test/stdlib/ImplicitlyUnwrappedOptional.swift
@@ -50,11 +50,11 @@ ImplicitlyUnwrappedOptionalTests.test("flatMap") {
   //   { if $0 % 2 == 0 { return Int16($0 / 2) } else { return .none } }
 
   // expectOptionalEqual(2 as Int16, half(4))
-  // expectEmpty(half(3))
+  // expectNil(half(3))
 
-  // expectEmpty((.none as Int!).flatMap(half))
+  // expectNil((.none as Int!).flatMap(half))
   // expectOptionalEqual(2 as Int16, (4 as Int!).flatMap(half))
-  // expectEmpty((3 as Int!).flatMap(half))
+  // expectNil((3 as Int!).flatMap(half))
 }
 
 runAllTests()

--- a/test/stdlib/InputStream.swift.gyb
+++ b/test/stdlib/InputStream.swift.gyb
@@ -77,14 +77,14 @@ ReadLineTestSuite.test("Unicode/strippingNewline=${strip_newline}")
 ReadLineTestSuite.test("EOF/1/strippingNewline=${strip_newline}")
   .stdin("", eof: true)
   .code {
-  expectEmpty(readLine(strippingNewline: ${strip_newline}))
+  expectNil(readLine(strippingNewline: ${strip_newline}))
 }
 
 ReadLineTestSuite.test("EOF/2/strippingNewline=${strip_newline}")
   .stdin("abcd 123\n", eof: true)
   .code {
   expectOptionalEqual("abcd 123${newline}", readLine(strippingNewline: ${strip_newline}))
-  expectEmpty(readLine(strippingNewline: ${strip_newline}))
+  expectNil(readLine(strippingNewline: ${strip_newline}))
 }
 
 ReadLineTestSuite.test("MissingNewlineAtEOF/1/strippingNewline=${strip_newline}")

--- a/test/stdlib/Inputs/DictionaryKeyValueTypesObjC.swift
+++ b/test/stdlib/Inputs/DictionaryKeyValueTypesObjC.swift
@@ -526,7 +526,7 @@ import SlurpFastEnumeration
       with: &state, objects: AutoreleasingUnsafeMutablePointer(stackBuf.baseAddress),
       count: stackBufLength)
     expectNotEqual(0, state.state)
-    expectNotEmpty(state.mutationsPtr)
+    expectNotNil(state.mutationsPtr)
     if returnedCount == 0 {
       break
     }
@@ -545,7 +545,7 @@ import SlurpFastEnumeration
       with: &state, objects: AutoreleasingUnsafeMutablePointer(stackBuf.baseAddress),
       count: stackBufLength)
     expectNotEqual(0, state.state)
-    expectNotEmpty(state.mutationsPtr)
+    expectNotNil(state.mutationsPtr)
     expectEqual(0, returnedCount)
   }
 }
@@ -568,7 +568,7 @@ typealias AnyObjectTuple2 = (AnyObject, AnyObject)
       with: &state, objects: AutoreleasingUnsafeMutablePointer(stackBuf.baseAddress),
       count: stackBufLength)
     expectNotEqual(0, state.state)
-    expectNotEmpty(state.mutationsPtr)
+    expectNotNil(state.mutationsPtr)
     if returnedCount == 0 {
       break
     }
@@ -778,7 +778,7 @@ typealias AnyObjectTuple2 = (AnyObject, AnyObject)
       with: &state, objects: AutoreleasingUnsafeMutablePointer(stackBuf.baseAddress),
       count: stackBufLength)
     expectNotEqual(0, state.state)
-    expectNotEmpty(state.mutationsPtr)
+    expectNotNil(state.mutationsPtr)
     if returnedCount == 0 {
       break
     }
@@ -797,7 +797,7 @@ typealias AnyObjectTuple2 = (AnyObject, AnyObject)
       with: &state, objects: AutoreleasingUnsafeMutablePointer(stackBuf.baseAddress),
       count: stackBufLength)
     expectNotEqual(0, state.state)
-    expectNotEmpty(state.mutationsPtr)
+    expectNotNil(state.mutationsPtr)
     expectEqual(0, returnedCount)
   }
 }

--- a/test/stdlib/Mirror.swift
+++ b/test/stdlib/Mirror.swift
@@ -91,7 +91,7 @@ mirrors.test("ForwardStructure") {
   let description = w.testDescription
   for c in letters.characters {
     let expected = "nil: \"\(c)\""
-    expectNotEmpty(find(expected, within: description))
+    expectNotNil(find(expected, within: description))
   }
 }
 
@@ -202,7 +202,7 @@ mirrors.test("Legacy") {
     expectEqual("dx", md.children.first?.label)
     expectEqual(1, md.children.first?.value as? Int)
     
-    expectNotEmpty(md.superclassMirror)
+    expectNotNil(md.superclassMirror)
     if let mb2 = md.superclassMirror { expectBMirror(mb2) }
   }
 
@@ -215,7 +215,7 @@ mirrors.test("Legacy") {
     expectEqual("dx", md.children.first?.label)
     expectEqual(1, md.children.first?.value as? Int)
     
-    expectNotEmpty(md.superclassMirror)
+    expectNotNil(md.superclassMirror)
     if let mb2 = md.superclassMirror { expectBMirror(mb2) }
   }
 }
@@ -275,13 +275,13 @@ mirrors.test("class/Plain/Plain") {
   let b = Mirror(reflecting: B())
   expectTrue(b.subjectType == B.self)
   
-  if let bChild = expectNotEmpty(b.children.first) {
+  if let bChild = expectNotNil(b.children.first) {
     expectEqual("b", bChild.label)
     expectEqual(42, bChild.value as? UInt)
   }
-  if let a = expectNotEmpty(b.superclassMirror) {
+  if let a = expectNotNil(b.superclassMirror) {
     expectTrue(a.subjectType == A.self)
-    if let aChild = expectNotEmpty(a.children.first) {
+    if let aChild = expectNotNil(a.children.first) {
       expectEqual("a", aChild.label)
       expectEqual(1, aChild.value as? Int)
       expectNil(a.superclassMirror)
@@ -301,7 +301,7 @@ mirrors.test("class/UncustomizedSuper/Synthesized/Implicit") {
 
   let b = Mirror(reflecting: B())
   expectTrue(b.subjectType == B.self)
-  if let a = expectNotEmpty(b.superclassMirror) {
+  if let a = expectNotNil(b.superclassMirror) {
     expectTrue(a.subjectType == A.self)
     expectEqual("a", a.children.first?.label)
     expectNil(a.superclassMirror)
@@ -321,7 +321,7 @@ mirrors.test("class/UncustomizedSuper/Synthesized/Explicit") {
 
   let b = Mirror(reflecting: B())
   expectTrue(b.subjectType == B.self)
-  if let a = expectNotEmpty(b.superclassMirror) {
+  if let a = expectNotNil(b.superclassMirror) {
     expectTrue(a.subjectType == A.self)
     expectEqual("a", a.children.first!.label)
     expectNil(a.superclassMirror)
@@ -350,7 +350,7 @@ mirrors.test("class/CustomizedSuper/Synthesized") {
 
   let b = Mirror(reflecting: B())
   expectTrue(b.subjectType == B.self)
-  if let a = expectNotEmpty(b.superclassMirror) {
+  if let a = expectNotNil(b.superclassMirror) {
     expectTrue(a.subjectType == A.self)
     expectEqual("a", a.children.first!.label)
     expectNil(a.superclassMirror)
@@ -369,16 +369,16 @@ mirrors.test("class/ObjCPlain/Plain") {
   let b = Mirror(reflecting: B())
   expectTrue(b.subjectType == B.self)
   
-  if let bChild = expectNotEmpty(b.children.first) {
+  if let bChild = expectNotNil(b.children.first) {
     expectEqual("b", bChild.label)
     expectEqual(42, bChild.value as? UInt)
   }
-  if let a = expectNotEmpty(b.superclassMirror) {
+  if let a = expectNotNil(b.superclassMirror) {
     expectTrue(a.subjectType == A.self)
-    if let aChild = expectNotEmpty(a.children.first) {
+    if let aChild = expectNotNil(a.children.first) {
       expectEqual("a", aChild.label)
       expectEqual(1, aChild.value as? Int)
-      if let o = expectNotEmpty(a.superclassMirror) {
+      if let o = expectNotNil(a.superclassMirror) {
         expectEqual("NSObject", String(reflecting: o.subjectType))
       }
     }
@@ -397,10 +397,10 @@ mirrors.test("class/ObjCUncustomizedSuper/Synthesized/Implicit") {
 
   let b = Mirror(reflecting: B())
   expectTrue(b.subjectType == B.self)
-  if let a = expectNotEmpty(b.superclassMirror) {
+  if let a = expectNotNil(b.superclassMirror) {
     expectTrue(a.subjectType == A.self)
     expectEqual("a", a.children.first?.label)
-    if let o = expectNotEmpty(a.superclassMirror) {
+    if let o = expectNotNil(a.superclassMirror) {
       expectTrue(o.subjectType == NSObject.self)
     }
   }
@@ -419,10 +419,10 @@ mirrors.test("class/ObjCUncustomizedSuper/Synthesized/Explicit") {
 
   let b = Mirror(reflecting: B())
   expectTrue(b.subjectType == B.self)
-  if let a = expectNotEmpty(b.superclassMirror) {
+  if let a = expectNotNil(b.superclassMirror) {
     expectTrue(a.subjectType == A.self)
     expectEqual("a", a.children.first!.label)
-    if let o = expectNotEmpty(a.superclassMirror) {
+    if let o = expectNotNil(a.superclassMirror) {
       expectTrue(o.subjectType == NSObject.self)
     }
   }
@@ -450,14 +450,14 @@ mirrors.test("class/ObjCCustomizedSuper/Synthesized") {
 
   let b = Mirror(reflecting: B())
   expectTrue(b.subjectType == B.self)
-  if let a = expectNotEmpty(b.superclassMirror) {
+  if let a = expectNotNil(b.superclassMirror) {
     expectTrue(a.subjectType == A.self)
     expectEqual("a", a.children.first!.label)
-    if let d = expectNotEmpty(a.superclassMirror) {
+    if let d = expectNotNil(a.superclassMirror) {
       expectTrue(d.subjectType == DateFormatter.self)
-      if let f = expectNotEmpty(d.superclassMirror) {
+      if let f = expectNotNil(d.superclassMirror) {
         expectTrue(f.subjectType == Formatter.self)
-        if let o = expectNotEmpty(f.superclassMirror) {
+        if let o = expectNotNil(f.superclassMirror) {
           expectTrue(o.subjectType == NSObject.self)
           expectNil(o.superclassMirror)
         }
@@ -543,7 +543,7 @@ mirrors.test("class/CustomizedSuper/SuperclassCustomMirror/Direct") {
 
   let b = Mirror(reflecting: B())
   expectTrue(b.subjectType == B.self)
-  if let a = expectNotEmpty(b.superclassMirror) {
+  if let a = expectNotNil(b.superclassMirror) {
     expectTrue(a.subjectType == A.self)
     expectEqual("aye", a.children.first!.label)
     expectNil(a.superclassMirror)
@@ -575,14 +575,14 @@ mirrors.test("class/CustomizedSuper/SuperclassCustomMirror/Indirect") {
 
   let b = Mirror(reflecting: B())
   expectTrue(b.subjectType == B.self)
-  if let y = expectNotEmpty(b.superclassMirror) {
+  if let y = expectNotNil(b.superclassMirror) {
     expectTrue(y.subjectType == Y.self)
-    if let x = expectNotEmpty(y.superclassMirror) {
+    if let x = expectNotNil(y.superclassMirror) {
       expectTrue(x.subjectType == X.self)
       expectEqual(0, x.children.count)
-      if let a = expectNotEmpty(x.superclassMirror) {
+      if let a = expectNotNil(x.superclassMirror) {
         expectTrue(a.subjectType == A.self)
-        if let aye = expectNotEmpty(a.children.first) {
+        if let aye = expectNotNil(a.children.first) {
           expectEqual("aye", aye.label)
         }
       }
@@ -616,9 +616,9 @@ mirrors.test("class/CustomizedSuper/SuperclassCustomMirror/Indirect2") {
 
   let b = Mirror(reflecting: B())
   expectTrue(b.subjectType == B.self)
-  if let a = expectNotEmpty(b.superclassMirror) {
+  if let a = expectNotNil(b.superclassMirror) {
     expectTrue(a.subjectType == A.self)
-    if let aye = expectNotEmpty(a.children.first) {
+    if let aye = expectNotNil(a.children.first) {
       expectEqual("aye", aye.label)
     }
   }
@@ -639,7 +639,7 @@ mirrors.test("class/Cluster") {
 
   let a = Mirror(reflecting: Y())
   expectTrue(a.subjectType == A.self)
-  if let aye = expectNotEmpty(a.children.first) {
+  if let aye = expectNotNil(a.children.first) {
     expectEqual("aye", aye.label)
   }
 }
@@ -655,9 +655,9 @@ mirrors.test("Addressing") {
   
   let m1 = Mirror(reflecting: (a: ["one", "two", "three"], b: 4))
   let ott0 = m1.descendant(0) as? [String]
-  expectNotEmpty(ott0)
+  expectNotNil(ott0)
   let ott1 = m1.descendant(".0") as? [String]
-  expectNotEmpty(ott1)
+  expectNotNil(ott1)
   if ott0 != nil && ott1 != nil {
     expectEqualSequence(ott0!, ott1!)
   }

--- a/test/stdlib/Mirror.swift
+++ b/test/stdlib/Mirror.swift
@@ -125,7 +125,7 @@ mirrors.test("LabeledStructure") {
 
   let z = Zee().customMirror
   expectEqual("[bark: 1, bite: 0]", z.testDescription)
-  expectEmpty(z.displayStyle)
+  expectNil(z.displayStyle)
 
   struct Zee2 : CustomReflectable {
     var customMirror: Mirror {
@@ -173,7 +173,7 @@ mirrors.test("Legacy") {
     expectTrue(mb.subjectType == B.self,
       stackTrace: stackTrace, file: file, line: line)
     
-    expectEmpty(
+    expectNil(
       mb.superclassMirror,
       stackTrace: stackTrace, file: file, line: line)
     
@@ -228,7 +228,7 @@ mirrors.test("Class/Root/Uncustomized") {
 
   let a = Mirror(reflecting: A())
   expectTrue(a.subjectType == A.self)
-  expectEmpty(a.superclassMirror)
+  expectNil(a.superclassMirror)
   expectEqual(1, a.children.count)
   expectEqual("a", a.children.first!.label)
 }
@@ -245,7 +245,7 @@ mirrors.test("Class/Root/superclass:.generated") {
   
   let b = Mirror(reflecting: B())
   expectTrue(b.subjectType == B.self)
-  expectEmpty(b.superclassMirror)
+  expectNil(b.superclassMirror)
   expectEqual(1, b.children.count)
   expectEqual("bee", b.children.first!.label)
   expectEqual("two", b.children.first!.value as? String)
@@ -262,7 +262,7 @@ mirrors.test("class/Root/superclass:<default>") {
   
   let c = Mirror(reflecting: C())
   expectTrue(c.subjectType == C.self)
-  expectEmpty(c.superclassMirror)
+  expectNil(c.superclassMirror)
   expectEqual(1, c.children.count)
   expectEqual("sea", c.children.first!.label)
   expectEqual(4, c.children.first!.value as? UInt)
@@ -284,7 +284,7 @@ mirrors.test("class/Plain/Plain") {
     if let aChild = expectNotEmpty(a.children.first) {
       expectEqual("a", aChild.label)
       expectEqual(1, aChild.value as? Int)
-      expectEmpty(a.superclassMirror)
+      expectNil(a.superclassMirror)
     }
   }
 }
@@ -304,7 +304,7 @@ mirrors.test("class/UncustomizedSuper/Synthesized/Implicit") {
   if let a = expectNotEmpty(b.superclassMirror) {
     expectTrue(a.subjectType == A.self)
     expectEqual("a", a.children.first?.label)
-    expectEmpty(a.superclassMirror)
+    expectNil(a.superclassMirror)
   }
 }
 
@@ -324,7 +324,7 @@ mirrors.test("class/UncustomizedSuper/Synthesized/Explicit") {
   if let a = expectNotEmpty(b.superclassMirror) {
     expectTrue(a.subjectType == A.self)
     expectEqual("a", a.children.first!.label)
-    expectEmpty(a.superclassMirror)
+    expectNil(a.superclassMirror)
   }
 }
 
@@ -353,7 +353,7 @@ mirrors.test("class/CustomizedSuper/Synthesized") {
   if let a = expectNotEmpty(b.superclassMirror) {
     expectTrue(a.subjectType == A.self)
     expectEqual("a", a.children.first!.label)
-    expectEmpty(a.superclassMirror)
+    expectNil(a.superclassMirror)
   }
 }
 
@@ -459,7 +459,7 @@ mirrors.test("class/ObjCCustomizedSuper/Synthesized") {
         expectTrue(f.subjectType == Formatter.self)
         if let o = expectNotEmpty(f.superclassMirror) {
           expectTrue(o.subjectType == NSObject.self)
-          expectEmpty(o.superclassMirror)
+          expectNil(o.superclassMirror)
         }
       }
     }
@@ -479,7 +479,7 @@ mirrors.test("Class/Root/NoSuperclassMirror") {
   
   let b = Mirror(reflecting: B())
   expectTrue(b.subjectType == B.self)
-  expectEmpty(b.superclassMirror)
+  expectNil(b.superclassMirror)
   expectEqual(1, b.children.count)
   expectEqual("bee", b.children.first!.label)
 }
@@ -497,7 +497,7 @@ mirrors.test("class/UncustomizedSuper/NoSuperclassMirror") {
 
   let b = Mirror(reflecting: B())
   expectTrue(b.subjectType == B.self)
-  expectEmpty(b.superclassMirror)
+  expectNil(b.superclassMirror)
 }
 
 mirrors.test("class/CustomizedSuper/NoSuperclassMirror") {
@@ -518,7 +518,7 @@ mirrors.test("class/CustomizedSuper/NoSuperclassMirror") {
 
   let b = Mirror(reflecting: B())
   expectTrue(b.subjectType == B.self)
-  expectEmpty(b.superclassMirror)
+  expectNil(b.superclassMirror)
 }
 
 //===--- Override Superclass Mirrors --------------------------------------===//
@@ -546,7 +546,7 @@ mirrors.test("class/CustomizedSuper/SuperclassCustomMirror/Direct") {
   if let a = expectNotEmpty(b.superclassMirror) {
     expectTrue(a.subjectType == A.self)
     expectEqual("aye", a.children.first!.label)
-    expectEmpty(a.superclassMirror)
+    expectNil(a.superclassMirror)
   }
 }
 
@@ -684,7 +684,7 @@ mirrors.test("Addressing") {
   expectEqual("two", two as? String)
   expectEqual(1, m.descendant(1, 1, "bark") as? Int)
   expectEqual(0, m.descendant(1, 1, "bite") as? Int)
-  expectEmpty(m.descendant(1, 1, "bork"))
+  expectNil(m.descendant(1, 1, "bork"))
 }
 
 mirrors.test("Invalid Path Type")

--- a/test/stdlib/NSSetAPI.swift
+++ b/test/stdlib/NSSetAPI.swift
@@ -85,10 +85,10 @@ NSIndexSetAPI.test("Sequence") {
   // expectEqual(Optional<Int>.some(1), iter.next())
   // expectEqual(Optional<Int>.none, iter.next())
   expectOptionalEqual(1, iter.next())
-  expectEmpty(iter.next())
+  expectNil(iter.next())
   let empty = NSIndexSet(indexesIn: NSMakeRange(1, 0))
   var emptyGen = empty.makeIterator()
-  expectEmpty(emptyGen.next())
+  expectNil(emptyGen.next())
 }
 
 runAllTests()

--- a/test/stdlib/NSStringAPI.swift
+++ b/test/stdlib/NSStringAPI.swift
@@ -461,7 +461,7 @@ NSStringAPIs.test("components(separatedBy:) (String)") {
 }
 
 NSStringAPIs.test("cString(usingEncoding:)") {
-  expectEmpty("абв".cString(using: .ascii))
+  expectNil("абв".cString(using: .ascii))
 
   let expectedBytes: [UInt8] = [ 0xd0, 0xb0, 0xd0, 0xb1, 0xd0, 0xb2, 0 ]
   var expectedStr: [CChar] = expectedBytes.map { CChar(bitPattern: $0) }
@@ -470,7 +470,7 @@ NSStringAPIs.test("cString(usingEncoding:)") {
 }
 
 NSStringAPIs.test("data(usingEncoding:allowLossyConversion:)") {
-  expectEmpty("あいう".data(using: .ascii, allowLossyConversion: false))
+  expectNil("あいう".data(using: .ascii, allowLossyConversion: false))
 
   do {
     let data = "あいう".data(using: .utf8)!
@@ -485,7 +485,7 @@ NSStringAPIs.test("init(data:encoding:)") {
   let bytes: [UInt8] = [0xe3, 0x81, 0x82, 0xe3, 0x81, 0x84, 0xe3, 0x81, 0x86]
   let data = Data(bytes: bytes)
   
-  expectEmpty(String(data: data, encoding: .nonLossyASCII))
+  expectNil(String(data: data, encoding: .nonLossyASCII))
   
   expectEqualSequence(
     "あいう".characters, 
@@ -568,7 +568,7 @@ NSStringAPIs.test("enumerateSubstringsIn(_:options:_:)") {
       (substring_: String?, substringRange: Range<String.Index>,
        enclosingRange: Range<String.Index>, stop: inout Bool)
     in
-      expectEmpty(substring_)
+      expectNil(substring_)
       let substring = s[substringRange]
       substrings.append(substring)
       expectEqual(substring, s[enclosingRange])
@@ -762,7 +762,7 @@ NSStringAPIs.test("init(bytes:encoding:)") {
   FIXME: Test disabled because the NSString documentation is unclear about
   what should actually happen in this case.
 
-  expectEmpty(String(bytes: bytes, length: bytes.count,
+  expectNil(String(bytes: bytes, length: bytes.count,
       encoding: .ascii))
   */
 
@@ -780,7 +780,7 @@ NSStringAPIs.test("init(bytesNoCopy:length:encoding:freeWhenDone:)") {
   FIXME: Test disabled because the NSString documentation is unclear about
   what should actually happen in this case.
 
-  expectEmpty(String(bytesNoCopy: &bytes, length: bytes.count,
+  expectNil(String(bytesNoCopy: &bytes, length: bytes.count,
       encoding: .ascii, freeWhenDone: false))
   */
 
@@ -1073,7 +1073,7 @@ NSStringAPIs.test("rangeOfCharacterFrom(_:options:range:)") {
       expectEqual(s.index(s.startIndex, offsetBy: 5), r.upperBound)
     }
     do {
-      expectEmpty("клмн".rangeOfCharacter(from: charset))
+      expectNil("клмн".rangeOfCharacter(from: charset))
     }
     do {
       let s = "абвклмнабвклмн"
@@ -1093,11 +1093,11 @@ NSStringAPIs.test("rangeOfCharacterFrom(_:options:range:)") {
 
   do {
     let charset = CharacterSet(charactersIn: "\u{305f}\u{3099}")
-    expectEmpty("\u{3060}".rangeOfCharacter(from: charset))
+    expectNil("\u{3060}".rangeOfCharacter(from: charset))
   }
   do {
     let charset = CharacterSet(charactersIn: "\u{3060}")
-    expectEmpty("\u{305f}\u{3099}".rangeOfCharacter(from: charset))
+    expectNil("\u{305f}\u{3099}".rangeOfCharacter(from: charset))
   }
 
   do {
@@ -1108,7 +1108,7 @@ NSStringAPIs.test("rangeOfCharacterFrom(_:options:range:)") {
           s[s.rangeOfCharacter(from: charset)!])
     }
     do {
-      expectEmpty("abc\u{1F601}".rangeOfCharacter(from: charset))
+      expectNil("abc\u{1F601}".rangeOfCharacter(from: charset))
     }
   }
 }
@@ -1147,13 +1147,13 @@ func toIntRange(
 NSStringAPIs.test("range(of:options:range:locale:)") {
   do {
     let s = ""
-    expectEmpty(s.range(of: ""))
-    expectEmpty(s.range(of: "abc"))
+    expectNil(s.range(of: ""))
+    expectNil(s.range(of: "abc"))
   }
   do {
     let s = "abc"
-    expectEmpty(s.range(of: ""))
-    expectEmpty(s.range(of: "def"))
+    expectNil(s.range(of: ""))
+    expectNil(s.range(of: "def"))
     expectOptionalEqual(0..<3, toIntRange(s, s.range(of: "abc")))
   }
   do {
@@ -1161,8 +1161,8 @@ NSStringAPIs.test("range(of:options:range:locale:)") {
     expectOptionalEqual(2..<3, toIntRange(s, s.range(of: "す\u{3099}")))
     expectOptionalEqual(2..<3, toIntRange(s, s.range(of: "\u{305a}")))
 
-    expectEmpty(s.range(of: "\u{3099}す"))
-    expectEmpty(s.range(of: "す"))
+    expectNil(s.range(of: "\u{3099}す"))
+    expectNil(s.range(of: "す"))
 
     // Note: here `rangeOf` API produces indexes that don't point between
     // grapheme cluster boundaries -- these cannot be created with public
@@ -1177,8 +1177,8 @@ NSStringAPIs.test("range(of:options:range:locale:)") {
     expectOptionalEqual(0..<1, toIntRange(s, s.range(of: "а\u{0301}")))
     expectOptionalEqual(1..<2, toIntRange(s, s.range(of: "б\u{0301}")))
 
-    expectEmpty(s.range(of: "б"))
-    expectEmpty(s.range(of: "\u{0301}б"))
+    expectNil(s.range(of: "б"))
+    expectNil(s.range(of: "\u{0301}б"))
 
     // FIXME: Again, indexes that don't correspond to grapheme
     // cluster boundaries.
@@ -1279,10 +1279,10 @@ NSStringAPIs.test("localizedStandardRange(of:)") {
         string, string.localizedStandardRange(of: substring))
     }
     withOverriddenLocaleCurrentLocale("en") { () -> Void in
-      expectEmpty(rangeOf("", ""))
-      expectEmpty(rangeOf("", "a"))
-      expectEmpty(rangeOf("a", ""))
-      expectEmpty(rangeOf("a", "b"))
+      expectNil(rangeOf("", ""))
+      expectNil(rangeOf("", "a"))
+      expectNil(rangeOf("a", ""))
+      expectNil(rangeOf("a", "b"))
       expectEqual(0..<1, rangeOf("a", "a"))
       expectEqual(0..<1, rangeOf("a", "A"))
       expectEqual(0..<1, rangeOf("A", "a"))
@@ -1295,7 +1295,7 @@ NSStringAPIs.test("localizedStandardRange(of:)") {
         expectEqual(
           "\u{0301}", s[s.localizedStandardRange(of: "\u{0301}")!])
       }
-      expectEmpty(rangeOf("a", "\u{0301}"))
+      expectNil(rangeOf("a", "\u{0301}"))
 
       expectEqual(0..<1, rangeOf("i", "I"))
       expectEqual(0..<1, rangeOf("I", "i"))
@@ -1327,7 +1327,7 @@ func getHomeDir() -> String {
 }
 
 NSStringAPIs.test("addingPercentEscapes(using:)") {
-  expectEmpty(
+  expectNil(
     "abcd абвг".addingPercentEscapes(
       using: .ascii))
   expectOptionalEqual("abcd%20%D0%B0%D0%B1%D0%B2%D0%B3",
@@ -1407,7 +1407,7 @@ NSStringAPIs.test("removingPercentEncoding/OSX 10.9")
 }
 
 NSStringAPIs.test("removingPercentEncoding") {
-  expectEmpty("%".removingPercentEncoding)
+  expectNil("%".removingPercentEncoding)
   expectOptionalEqual(
     "abcd абвг",
     "ab%63d %D0%B0%D0%B1%D0%B2%D0%B3".removingPercentEncoding)
@@ -1555,10 +1555,10 @@ NSStringAPIs.test("replacingPercentEscapes(using:)") {
     "%61%62%63%64%20%D0%B0%D0%B1%D0%B2%D0%B3"
       .replacingPercentEscapes(using: .utf8))
 
-  expectEmpty("%ED%B0".replacingPercentEscapes(
+  expectNil("%ED%B0".replacingPercentEscapes(
     using: .utf8))
 
-  expectEmpty("%zz".replacingPercentEscapes(
+  expectNil("%zz".replacingPercentEscapes(
     using: .utf8))
 }
 
@@ -1569,7 +1569,7 @@ NSStringAPIs.test("replacingPercentEscapes(using:)/rdar18029471")
       "replacingPercentEscapesUsingEncoding: does not return nil " +
       "when a byte sequence is not legal in ASCII"))
   .code {
-  expectEmpty(
+  expectNil(
     "abcd%FF".replacingPercentEscapes(
       using: .ascii))
 }

--- a/test/stdlib/NumericParsing.swift.gyb
+++ b/test/stdlib/NumericParsing.swift.gyb
@@ -155,23 +155,23 @@ tests.test("${Self}/Basics") {
   expectEqual(smallText, String(${Self}(smallText)!))
   
   // Cases that should fail to parse
-  expectEmpty(${Self}(""))       // EMPTY
-  expectEmpty(${Self}("0FACE"))  // Hex characters without 0x
-  expectEmpty(${Self}("99x"))
-  expectEmpty(${Self}(" 0"))  // Leading whitespace
-  expectEmpty(${Self}("0 "))  // Trailing whitespace
-  expectEmpty(${Self}("\u{1D7FF}"))  // MATHEMATICAL MONOSPACE DIGIT NINE
+  expectNil(${Self}(""))       // EMPTY
+  expectNil(${Self}("0FACE"))  // Hex characters without 0x
+  expectNil(${Self}("99x"))
+  expectNil(${Self}(" 0"))  // Leading whitespace
+  expectNil(${Self}("0 "))  // Trailing whitespace
+  expectNil(${Self}("\u{1D7FF}"))  // MATHEMATICAL MONOSPACE DIGIT NINE
 
   // Overflow and underflow.  Interleave with other checks to make
   // sure we're not abusing errno
   expectEqual(0.0, ${Self}("0"))
-  expectEmpty(${Self}("2e99999999999999"))  
+  expectNil(${Self}("2e99999999999999"))  
   expectEqual(0.0, ${Self}("0"))
-  expectEmpty(${Self}("2e-99999999999999"))  
+  expectNil(${Self}("2e-99999999999999"))  
   expectEqual(0.0, ${Self}("0"))
-  expectEmpty(${Self}("-2e99999999999999"))  
+  expectNil(${Self}("-2e99999999999999"))  
   expectEqual(0.0, ${Self}("0"))
-  expectEmpty(${Self}("-2e-99999999999999"))  
+  expectNil(${Self}("-2e-99999999999999"))  
   expectEqual(0.0, ${Self}("0"))
 }
 

--- a/test/stdlib/Optional.swift
+++ b/test/stdlib/Optional.swift
@@ -212,11 +212,11 @@ OptionalTests.test("flatMap") {
     { if $0 % 2 == 0 { return Int16($0 / 2) } else { return .none } }
 
   expectOptionalEqual(2 as Int16, half(4))
-  expectEmpty(half(3))
+  expectNil(half(3))
 
-  expectEmpty((.none as Int32?).flatMap(half))
+  expectNil((.none as Int32?).flatMap(half))
   expectOptionalEqual(2 as Int16, (4 as Int32?).flatMap(half))
-  expectEmpty((3 as Int32?).flatMap(half))
+  expectNil((3 as Int32?).flatMap(half))
 }
 
 // FIXME: @inline(never) does not inhibit specialization

--- a/test/stdlib/Runtime.swift.gyb
+++ b/test/stdlib/Runtime.swift.gyb
@@ -239,32 +239,32 @@ Runtime.test("dynamicCasting with as") {
 
   expectTrue(((someP1Ref as AnyObject) as! P1).success)
 
-  expectEmpty((someNotP1Value as? P1))
-  expectEmpty((someNotP1Ref as? P1))
+  expectNil((someNotP1Value as? P1))
+  expectNil((someNotP1Ref as? P1))
 
   expectTrue(((someP1Value as Q1) as? P1)!.success)
   expectTrue(((someP1Value2 as Q1) as? P1)!.success)
-  expectEmpty(((someNotP1Value as Q1) as? P1))
+  expectNil(((someNotP1Value as Q1) as? P1))
   expectEqual("10 20 30 40", ((someP2Value as Q1) as? P2)!.description)
   expectEqual("10 20 30 40 50 60 70 80",
     ((someP2Value2 as Q1) as? P2)!.description)
   expectTrue(((someP1Ref as Q1) as? P1)!.success)
   expectTrue(((someP1Ref2 as Q1) as? P1)!.success)
-  expectEmpty(((someNotP1Ref as Q1) as? P1))
+  expectNil(((someNotP1Ref as Q1) as? P1))
 
   expectTrue(((someP1Value as Any) as? P1)!.success)
   expectTrue(((someP1Value2 as Any) as? P1)!.success)
-  expectEmpty(((someNotP1Value as Any) as? P1))
+  expectNil(((someNotP1Value as Any) as? P1))
   expectEqual("10 20 30 40", ((someP2Value as Any) as? P2)!.description)
   expectEqual("10 20 30 40 50 60 70 80",
     ((someP2Value2 as Any) as? P2)!.description)
   expectTrue(((someP1Ref as Any) as? P1)!.success)
   expectTrue(((someP1Ref2 as Any) as? P1)!.success)
-  expectEmpty(((someNotP1Ref as Any) as? P1))
+  expectNil(((someNotP1Ref as Any) as? P1))
 
   expectTrue(((someP1Ref as AnyObject) as? P1)!.success)
   expectTrue(((someP1Ref2 as AnyObject) as? P1)!.success)
-  expectEmpty(((someNotP1Ref as AnyObject) as? P1))
+  expectNil(((someNotP1Ref as AnyObject) as? P1))
 
   let doesThrow: (Int) throws -> Int = { $0 }
   let doesNotThrow: (String) -> String = { $0 }

--- a/test/stdlib/RuntimeObjC.swift
+++ b/test/stdlib/RuntimeObjC.swift
@@ -253,7 +253,7 @@ Runtime.test("bridgeToObjectiveC/NoLeak") {
 Runtime.test("forceBridgeFromObjectiveC") {
 
   // Bridge back using BridgedValueType.
-  expectEmpty(_conditionallyBridgeFromObjectiveC(
+  expectNil(_conditionallyBridgeFromObjectiveC(
       ClassA(value: 21), BridgedValueType.self))
 
   expectEqual(42, _forceBridgeFromObjectiveC(
@@ -261,11 +261,11 @@ Runtime.test("forceBridgeFromObjectiveC") {
   expectEqual(42, _conditionallyBridgeFromObjectiveC(
       ClassA(value: 42), BridgedValueType.self)!.value)
 
-  expectEmpty(_conditionallyBridgeFromObjectiveC(
+  expectNil(_conditionallyBridgeFromObjectiveC(
       BridgedVerbatimRefType(), BridgedValueType.self))
 
   // Bridge back using BridgedLargeValueType.
-  expectEmpty(_conditionallyBridgeFromObjectiveC(
+  expectNil(_conditionallyBridgeFromObjectiveC(
       ClassA(value: 21), BridgedLargeValueType.self))
 
   expectEqual(42, _forceBridgeFromObjectiveC(
@@ -273,14 +273,14 @@ Runtime.test("forceBridgeFromObjectiveC") {
   expectEqual(42, _conditionallyBridgeFromObjectiveC(
       ClassA(value: 42), BridgedLargeValueType.self)!.value)
 
-  expectEmpty(_conditionallyBridgeFromObjectiveC(
+  expectNil(_conditionallyBridgeFromObjectiveC(
       BridgedVerbatimRefType(), BridgedLargeValueType.self))
 
   // Bridge back using BridgedVerbatimRefType.
-  expectEmpty(_conditionallyBridgeFromObjectiveC(
+  expectNil(_conditionallyBridgeFromObjectiveC(
       ClassA(value: 21), BridgedVerbatimRefType.self))
 
-  expectEmpty(_conditionallyBridgeFromObjectiveC(
+  expectNil(_conditionallyBridgeFromObjectiveC(
       ClassA(value: 42), BridgedVerbatimRefType.self))
 
   var bridgedVerbatimRef = BridgedVerbatimRefType()

--- a/test/stdlib/Strideable.swift
+++ b/test/stdlib/Strideable.swift
@@ -213,7 +213,7 @@ func strideIteratorTest<
 >(_ stride: Stride, nonNilResults: Int) {
   var i = stride.makeIterator()
   for _ in 0..<nonNilResults {
-     expectNotEmpty(i.next())
+     expectNotNil(i.next())
   }
   for _ in 0..<10 {
     expectNil(i.next())

--- a/test/stdlib/Strideable.swift
+++ b/test/stdlib/Strideable.swift
@@ -216,7 +216,7 @@ func strideIteratorTest<
      expectNotEmpty(i.next())
   }
   for _ in 0..<10 {
-    expectEmpty(i.next())
+    expectNil(i.next())
   }
 }
 

--- a/test/stdlib/StringAPI.swift
+++ b/test/stdlib/StringAPI.swift
@@ -465,7 +465,7 @@ CStringTests.test("String.init(validatingUTF8:)") {
   }
   do {
     let (s, dealloc) = getIllFormedUTF8String1()
-    expectEmpty(String(validatingUTF8: bindAsCChar(s)))
+    expectNil(String(validatingUTF8: bindAsCChar(s)))
     dealloc()
   }
 }
@@ -501,7 +501,7 @@ CStringTests.test("String.decodeCString") {
   do {
     let s = getNullUTF8()
     let result = String.decodeCString(s, as: UTF8.self)
-    expectEmpty(result)
+    expectNil(result)
   }
   do { // repairing
     let (s, dealloc) = getIllFormedUTF8String1()
@@ -518,7 +518,7 @@ CStringTests.test("String.decodeCString") {
     let (s, dealloc) = getIllFormedUTF8String1()
     let result = String.decodeCString(
       s, as: UTF8.self, repairingInvalidCodeUnits: false)
-    expectEmpty(result)
+    expectNil(result)
     dealloc()
   }
 }

--- a/test/stdlib/TestData.swift
+++ b/test/stdlib/TestData.swift
@@ -388,17 +388,17 @@ class TestData : TestDataSuper {
 
         do {
             let found = helloWorld.range(of: goodbye)
-            expectEmpty(found)
+            expectNil(found)
         }
 
         do {
             let found = helloWorld.range(of: goodbye, options: .anchored)
-            expectEmpty(found)
+            expectNil(found)
         }
 
         do {
             let found = helloWorld.range(of: hello, in: 7..<helloWorld.count)
-            expectEmpty(found)
+            expectNil(found)
         }
     }
     

--- a/test/stdlib/TestDate.swift
+++ b/test/stdlib/TestDate.swift
@@ -128,11 +128,11 @@ class TestDate : TestDateSuper {
         // Make sure the optional init stuff works
         let dc = DateComponents()
         
-        expectEmpty(dc.year)
+        expectNil(dc.year)
         
         let dc2 = DateComponents(year: 1999)
         
-        expectEmpty(dc2.day)
+        expectNil(dc2.day)
         expectEqual(1999, dc2.year)
     }
 

--- a/test/stdlib/TestDateInterval.swift
+++ b/test/stdlib/TestDateInterval.swift
@@ -106,11 +106,11 @@ class TestDateInterval : TestDateIntervalSuper {
             let testInterval3 = DateInterval(start: start3, end: end3)
             
             let intersection1 = testInterval2.intersection(with: testInterval1)
-            expectNotEmpty(intersection1)
+            expectNotNil(intersection1)
             expectEqual(testInterval3, intersection1)
             
             let intersection2 = testInterval1.intersection(with: testInterval2)
-            expectNotEmpty(intersection2)
+            expectNotNil(intersection2)
             expectEqual(intersection1, intersection2)
         }
     }

--- a/test/stdlib/TestURL.swift
+++ b/test/stdlib/TestURL.swift
@@ -35,7 +35,7 @@ class TestURL : TestURLSuper {
             if let isVolume = resourceValues.isVolume {
                 expectTrue(isVolume)
             }
-            expectNotEmpty(resourceValues.name)
+            expectNotNil(resourceValues.name)
         } catch {
             expectTrue(false, "Should not have thrown")
         }
@@ -56,7 +56,7 @@ class TestURL : TestURLSuper {
         // Modify an existing resource values
         do {
             var resourceValues = try file.resourceValues(forKeys: [.nameKey])
-            expectNotEmpty(resourceValues.name)
+            expectNotNil(resourceValues.name)
             expectEqual(resourceValues.name!, name)
             
             let newName = "goodbye cruel " + UUID().uuidString
@@ -81,7 +81,7 @@ class TestURL : TestURLSuper {
 
         do {
             var resourceValues = try file.resourceValues(forKeys: [.labelNumberKey])
-            expectNotEmpty(resourceValues.labelNumber)
+            expectNotNil(resourceValues.labelNumber)
             
             // set label number
             resourceValues.labelNumber = 1
@@ -89,7 +89,7 @@ class TestURL : TestURLSuper {
             
             // get label number
             let _ = try file.resourceValues(forKeys: [.labelNumberKey])
-            expectNotEmpty(resourceValues.labelNumber)
+            expectNotNil(resourceValues.labelNumber)
             expectEqual(resourceValues.labelNumber!, 1)
         } catch (let e as NSError) {
             expectTrue(false, "Unable to load or set resources \(e)")
@@ -104,7 +104,7 @@ class TestURL : TestURLSuper {
             
             try file.setResourceValues(resourceValues)
             let resourceValues2 = try file.resourceValues(forKeys: [.labelNumberKey])
-            expectNotEmpty(resourceValues2.labelNumber)
+            expectNotNil(resourceValues2.labelNumber)
             expectEqual(resourceValues2.labelNumber!, 2)
         } catch (let e as NSError) {
             expectTrue(false, "Unable to load or set resources \(e)")
@@ -124,27 +124,27 @@ class TestURL : TestURLSuper {
         // Not meant to be a test of all URL components functionality, just some basic bridging stuff
         let s = "http://www.apple.com/us/search/ipad?src=globalnav"
         let components = URLComponents(string: s)!
-        expectNotEmpty(components)
+        expectNotNil(components)
         
-        expectNotEmpty(components.host)
+        expectNotNil(components.host)
         expectEqual("www.apple.com", components.host)
         
         
         if #available(OSX 10.11, iOS 9.0, *) {
             let rangeOfHost = components.rangeOfHost!
-            expectNotEmpty(rangeOfHost)
+            expectNotNil(rangeOfHost)
             expectEqual(s[rangeOfHost], "www.apple.com")
         }
         
         if #available(OSX 10.10, iOS 8.0, *) {
             let qi = components.queryItems!
-            expectNotEmpty(qi)
+            expectNotNil(qi)
             
             expectEqual(1, qi.count)
             let first = qi[0]
             
             expectEqual("src", first.name)
-            expectNotEmpty(first.value)
+            expectNotNil(first.value)
             expectEqual("globalnav", first.value)
         }
     }

--- a/test/stdlib/TestUUID.swift
+++ b/test/stdlib/TestUUID.swift
@@ -80,7 +80,7 @@ class TestUUID : TestUUIDSuper {
         let valFromStr = UUID(uuidString: ref.uuidString)
         expectEqual(ref.uuidString, valFromRef.uuidString)
         expectEqual(ref.uuidString, valFromBytes.uuidString)
-        expectNotEmpty(valFromStr)
+        expectNotNil(valFromStr)
         expectEqual(ref.uuidString, valFromStr!.uuidString)
     }
     

--- a/test/stdlib/TestUUID.swift
+++ b/test/stdlib/TestUUID.swift
@@ -46,12 +46,12 @@ class TestUUID : TestUUIDSuper {
     
     func test_NS_InvalidUUID() {
         let uuid = NSUUID(uuidString: "Invalid UUID")
-        expectEmpty(uuid, "The convenience initializer `init?(uuidString string:)` must return nil for an invalid UUID string.")
+        expectNil(uuid, "The convenience initializer `init?(uuidString string:)` must return nil for an invalid UUID string.")
     }
     
     func test_InvalidUUID() {
         let uuid = UUID(uuidString: "Invalid UUID")
-        expectEmpty(uuid, "The convenience initializer `init?(uuidString string:)` must return nil for an invalid UUID string.")
+        expectNil(uuid, "The convenience initializer `init?(uuidString string:)` must return nil for an invalid UUID string.")
     }
     
     func test_NS_uuidString() {

--- a/test/stdlib/TestUserInfo.swift
+++ b/test/stdlib/TestUserInfo.swift
@@ -63,17 +63,17 @@ class TestUserInfo : TestUserInfoSuper {
             AnyHashable(userInfoKey) : testStructure
         ]
         let note = Notification(name: notifName, userInfo: info)
-        expectNotEmpty(note.userInfo)
+        expectNotNil(note.userInfo)
         let nc = NotificationCenter.default
         nc.addObserver(self, selector: #selector(TestUserInfo.notification(_:)), name: notifName, object: nil)
         nc.post(note)
-        expectNotEmpty(posted)
+        expectNotNil(posted)
         if let notification = posted {
             let postedInfo = notification.userInfo
-            expectNotEmpty(postedInfo)
+            expectNotNil(postedInfo)
             if let userInfo = postedInfo {
                 let postedValue = userInfo[AnyHashable(userInfoKey)] as? SomeStructure
-                expectNotEmpty(postedValue)
+                expectNotNil(postedValue)
                 if let value = postedValue {
                     validate(testStructure, value)
                 }

--- a/test/stdlib/Unmanaged.swift
+++ b/test/stdlib/Unmanaged.swift
@@ -60,7 +60,7 @@ UnmanagedTests.test("Opaque") {
   
   let unknownPtr = Int(bitPattern: opaquePtr)
   let voidPtr = UnsafeRawPointer(bitPattern: unknownPtr)
-  expectNotEmpty(voidPtr, "toOpaque must not return null pointer")
+  expectNotNil(voidPtr, "toOpaque must not return null pointer")
   
   let unmanaged = Unmanaged<Foobar>.fromOpaque(voidPtr!)
   expectEqual(

--- a/test/stdlib/UnsafePointer.swift.gyb
+++ b/test/stdlib/UnsafePointer.swift.gyb
@@ -65,7 +65,7 @@ ${SelfName}TestSuite.test("initFromOpaquePointer") {
 
   let optionalOther: Optional = other
   let optionalPointer = ${SelfType}(optionalOther)
-  expectNotEmpty(optionalPointer)
+  expectNotNil(optionalPointer)
   expectEqual(0x12345678, unsafeBitCast(optionalPointer, to: Int.self))
 
   let nilOther: Optional<OpaquePointer> = nil
@@ -85,7 +85,7 @@ UnsafeMutableRawPointerTestSuite.test("initFromMutating") {
 
   let optionalOther: Optional = other
   let optionalPointer = UnsafeMutableRawPointer(mutating: optionalOther)
-  expectNotEmpty(optionalPointer)
+  expectNotNil(optionalPointer)
   expectEqual(0x12345678, unsafeBitCast(optionalPointer, to: Int.self))
 
   let nilOther: Optional<UnsafeRawPointer> = nil
@@ -110,13 +110,13 @@ ${SelfName}TestSuite.test("initFromInteger") {
   do {
     let word: Int = 0x12345678
     let ptr = ${SelfType}(bitPattern: word)
-    expectNotEmpty(ptr)
+    expectNotNil(ptr)
     expectEqual(word, unsafeBitCast(ptr, to: Int.self))
   }
   do {
     let uword: UInt = 0x12345678
     let ptr = ${SelfType}(bitPattern: uword)
-    expectNotEmpty(ptr)
+    expectNotNil(ptr)
     expectEqual(uword, unsafeBitCast(ptr, to: UInt.self))
   }
 }
@@ -185,7 +185,7 @@ ${SelfName}TestSuite.test("initFromUnsafeMutablePointer") {
 
   let optionalOther: Optional = other
   let optionalPointer = ${SelfType}(optionalOther)
-  expectNotEmpty(optionalPointer)
+  expectNotNil(optionalPointer)
   expectEqual(0x12345678, unsafeBitCast(optionalPointer, to: Int.self))
 
   let nilOther: Optional<UnsafeMutablePointer<Float>> = nil
@@ -206,7 +206,7 @@ ${SelfName}TestSuite.test("initFromUnsafePointer") {
 
   let optionalOther: Optional = other
   let optionalPointer = ${SelfType}(optionalOther)
-  expectNotEmpty(optionalPointer)
+  expectNotNil(optionalPointer)
   expectEqual(0x12345678, unsafeBitCast(optionalPointer, to: Int.self))
 
   let nilOther: Optional<UnsafePointer<Float>> = nil
@@ -223,7 +223,7 @@ UnsafeRawPointerTestSuite.test("initFromUnsafeMutableRawPointer") {
 
   let optionalOther: Optional = other
   let optionalPointer = UnsafeRawPointer(optionalOther)
-  expectNotEmpty(optionalPointer)
+  expectNotNil(optionalPointer)
   expectEqual(0x12345678, unsafeBitCast(optionalPointer, to: Int.self))
 
   let nilOther: Optional<UnsafeMutableRawPointer> = nil

--- a/test/stdlib/UnsafePointer.swift.gyb
+++ b/test/stdlib/UnsafePointer.swift.gyb
@@ -70,7 +70,7 @@ ${SelfName}TestSuite.test("initFromOpaquePointer") {
 
   let nilOther: Optional<OpaquePointer> = nil
   let nilPointer = ${SelfType}(nilOther)
-  expectEmpty(nilPointer)
+  expectNil(nilPointer)
 }
 
 % end
@@ -90,7 +90,7 @@ UnsafeMutableRawPointerTestSuite.test("initFromMutating") {
 
   let nilOther: Optional<UnsafeRawPointer> = nil
   let nilPointer = UnsafeMutableRawPointer(mutating: nilOther)
-  expectEmpty(nilPointer)
+  expectNil(nilPointer)
 }
 % end
 
@@ -125,13 +125,13 @@ ${SelfName}TestSuite.test("initFromNilBitPattern") {
   do {
     let word = unsafeBitCast(nil as ${SelfType}?, to: Int.self)
     let ptr = ${SelfType}(bitPattern: word)
-    expectEmpty(ptr)
+    expectNil(ptr)
     expectEqual(word, unsafeBitCast(ptr, to: Int.self))
   }
   do {
     let uword = unsafeBitCast(nil as ${SelfType}?, to: UInt.self)
     let ptr = ${SelfType}(bitPattern: uword)
-    expectEmpty(ptr)
+    expectNil(ptr)
     expectEqual(uword, unsafeBitCast(ptr, to: UInt.self))
   }
 }
@@ -190,7 +190,7 @@ ${SelfName}TestSuite.test("initFromUnsafeMutablePointer") {
 
   let nilOther: Optional<UnsafeMutablePointer<Float>> = nil
   let nilPointer = ${SelfType}(nilOther)
-  expectEmpty(nilPointer)
+  expectNil(nilPointer)
 }
 
 % end
@@ -211,7 +211,7 @@ ${SelfName}TestSuite.test("initFromUnsafePointer") {
 
   let nilOther: Optional<UnsafePointer<Float>> = nil
   let nilPointer = ${SelfType}(nilOther)
-  expectEmpty(nilPointer)
+  expectNil(nilPointer)
 }
 
 % end
@@ -228,7 +228,7 @@ UnsafeRawPointerTestSuite.test("initFromUnsafeMutableRawPointer") {
 
   let nilOther: Optional<UnsafeMutableRawPointer> = nil
   let nilPointer = UnsafeRawPointer(nilOther)
-  expectEmpty(nilPointer)
+  expectNil(nilPointer)
 }
 
 enum Check {

--- a/validation-test/StdlibUnittest/Assertions.swift.gyb
+++ b/validation-test/StdlibUnittest/Assertions.swift.gyb
@@ -13,6 +13,26 @@ import ObjectiveC
 
 var AssertionsTestSuite = TestSuite("Assertions")
 
+AssertionsTestSuite.test("expectNil(_: T?)") {
+  let none: OpaqueValue<Int>? = nil
+  expectNil(none)
+
+  let some: OpaqueValue<Int>? = OpaqueValue(42)
+  expectFailure {
+    expectNil(some)
+  }
+}
+
+AssertionsTestSuite.test("expectNotNil(_: T?)") {
+  let none: OpaqueValue<Int>? = nil
+  expectFailure {
+    expectNotNil(none)
+  }
+
+  let some: OpaqueValue<Int>? = OpaqueValue(42)
+  expectNotNil(some)
+}
+
 AssertionsTestSuite.test("expectTrapping(_: Bound, in: RangeProtocol)") {
   _setTrappingExpectationFailedCallback() {}
   defer {

--- a/validation-test/stdlib/Arrays.swift.gyb
+++ b/validation-test/stdlib/Arrays.swift.gyb
@@ -359,7 +359,7 @@ ArrayTestSuite.test("${Kind}/popLast") {
   do {
     var a = ${Kind}<Int>()
     let popped = a.popLast()
-    expectEmpty(popped)
+    expectNil(popped)
     expectTrue(a.isEmpty)
   }
 

--- a/validation-test/stdlib/CollectionCasts.swift.gyb
+++ b/validation-test/stdlib/CollectionCasts.swift.gyb
@@ -86,12 +86,12 @@ tests.test("${Collection}/Down/${method}/${Key1}=>${Key0}") {
 
 %             if method == 'Direct':
   
-  guard let downcasted = expectNotEmpty(source as? ${Collection}<${Key0}>)
+  guard let downcasted = expectNotNil(source as? ${Collection}<${Key0}>)
   else { return }
   
 %             else:
   
-  guard let downcasted = expectNotEmpty(cast(source, to: ${Collection}<${Key0}>.self))
+  guard let downcasted = expectNotNil(cast(source, to: ${Collection}<${Key0}>.self))
   else { return }
   
 %             end
@@ -126,18 +126,18 @@ tests.test(
 %   else:
   let upcasted_ = source as Any as? [${Key1}:${Value1}]
   
-  guard let upcasted = expectNotEmpty(upcasted_) else { return }
+  guard let upcasted = expectNotNil(upcasted_) else { return }
 %   end
 
   expectEqual(source.count, upcasted.count)
   
   for (k0, v0) in source {
-    guard let v1 = expectNotEmpty(upcasted[k0]) else { continue }
+    guard let v1 = expectNotNil(upcasted[k0]) else { continue }
     
-    guard let dv0 = expectNotEmpty(
+    guard let dv0 = expectNotNil(
       cast(v0, to: ${DynamicValue}.self)) else { continue }
     
-    guard let dv1 = expectNotEmpty(
+    guard let dv1 = expectNotNil(
       cast(v1, to: ${DynamicValue}.self)) else { continue }
 
     expectEqual(dv0, dv1)
@@ -156,18 +156,18 @@ tests.test(
     ${DynamicKey}(42) as ${Key1} : ${DynamicValue}(42) as ${Value1},
     ${DynamicKey}(17) as ${Key1} : ${DynamicValue}(17) as ${Value1}]
 
-  guard let downcasted = expectNotEmpty(source as? [${Key0}:${Value0}])
+  guard let downcasted = expectNotNil(source as? [${Key0}:${Value0}])
   else { return }
 
   expectEqual(source.count, downcasted.count)
   
   for (k0, v0) in downcasted {
-    guard let v1 = expectNotEmpty(source[k0]) else { continue }
+    guard let v1 = expectNotNil(source[k0]) else { continue }
     
-    guard let dv0 = expectNotEmpty(
+    guard let dv0 = expectNotNil(
       cast(v0, to: ${DynamicValue}.self)) else { continue }
     
-    guard let dv1 = expectNotEmpty(
+    guard let dv1 = expectNotNil(
       cast(v1, to: ${DynamicValue}.self)) else { continue }
 
     expectEqual(dv0, dv1)

--- a/validation-test/stdlib/CoreAudio.swift
+++ b/validation-test/stdlib/CoreAudio.swift
@@ -189,7 +189,7 @@ CoreAudioTestSuite.test(
   do {
     let ablPtrWrapper = UnsafeMutableAudioBufferListPointer(
       UnsafeMutablePointer<AudioBufferList>(bitPattern: 0x1234_5678))
-    expectNotEmpty(ablPtrWrapper)
+    expectNotNil(ablPtrWrapper)
     expectEqual(
       UnsafePointer<AudioBufferList>(bitPattern: 0x1234_5678),
       ablPtrWrapper!.unsafePointer)

--- a/validation-test/stdlib/CoreAudio.swift
+++ b/validation-test/stdlib/CoreAudio.swift
@@ -172,7 +172,7 @@ CoreAudioTestSuite.test(
   "UnsafeMutableAudioBufferListPointer.unsafeMutablePointer") {
   do {
     let ablPtrWrapper = UnsafeMutableAudioBufferListPointer(nil)
-    expectEmpty(ablPtrWrapper)
+    expectNil(ablPtrWrapper)
   }
 
   do {

--- a/validation-test/stdlib/CoreData.swift
+++ b/validation-test/stdlib/CoreData.swift
@@ -22,7 +22,7 @@ CoreDataTests.test("downcasting") {
   expectType([NSFetchRequestResult].self, &dictionaries)
 
   let casted = dictionaries as? [[NSObject: AnyObject]]
-  expectNotEmpty(casted)
+  expectNotNil(casted)
   expectEqual([[:] as NSDictionary, [:] as NSDictionary] as NSArray, casted! as NSArray)
   expectEqual([[:] as NSDictionary, [:] as NSDictionary] as NSArray, dictionaries as! [[NSObject: AnyObject]] as NSArray)
 }
@@ -33,7 +33,7 @@ CoreDataTests.test("bridging") {
   expectEqual([[:], [:]], dictionaries)
 
   let casted = dictionaries as? [[NSObject: AnyObject]]
-  expectNotEmpty(casted)
+  expectNotNil(casted)
   expectEqual([[:] as NSDictionary, [:] as NSDictionary] as NSArray, casted! as NSArray)
   expectEqual([[:] as NSDictionary, [:] as NSDictionary] as NSArray, dictionaries as! [[NSObject: AnyObject]] as NSArray)
 }

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -261,7 +261,7 @@ DictionaryTestSuite.test("COW.Fast.SubscriptWithKeyDoesNotReallocate") {
     var d2: [MinimalHashableValue : OpaqueValue<Int>] = [:]
     MinimalHashableValue.timesEqualEqualWasCalled = 0
     MinimalHashableValue.timesHashValueWasCalled = 0
-    expectEmpty(d2[MinimalHashableValue(42)])
+    expectNil(d2[MinimalHashableValue(42)])
 
     // If the dictionary is empty, we shouldn't be computing the hash value of
     // the provided key.
@@ -316,7 +316,7 @@ DictionaryTestSuite.test("COW.Slow.SubscriptWithKeyDoesNotReallocate") {
     MinimalHashableClass.timesEqualEqualWasCalled = 0
     MinimalHashableClass.timesHashValueWasCalled = 0
 
-    expectEmpty(d2[MinimalHashableClass(42)])
+    expectNil(d2[MinimalHashableClass(42)])
 
     // If the dictionary is empty, we shouldn't be computing the hash value of
     // the provided key.
@@ -507,7 +507,7 @@ DictionaryTestSuite.test("COW.Fast.IndexForKeyDoesNotReallocate") {
     var d2: [MinimalHashableValue : OpaqueValue<Int>] = [:]
     MinimalHashableValue.timesEqualEqualWasCalled = 0
     MinimalHashableValue.timesHashValueWasCalled = 0
-    expectEmpty(d2.index(forKey: MinimalHashableValue(42)))
+    expectNil(d2.index(forKey: MinimalHashableValue(42)))
 
     // If the dictionary is empty, we shouldn't be computing the hash value of
     // the provided key.
@@ -544,7 +544,7 @@ DictionaryTestSuite.test("COW.Slow.IndexForKeyDoesNotReallocate") {
     var d2: [MinimalHashableClass : OpaqueValue<Int>] = [:]
     MinimalHashableClass.timesEqualEqualWasCalled = 0
     MinimalHashableClass.timesHashValueWasCalled = 0
-    expectEmpty(d2.index(forKey: MinimalHashableClass(42)))
+    expectNil(d2.index(forKey: MinimalHashableClass(42)))
 
     // If the dictionary is empty, we shouldn't be computing the hash value of
     // the provided key.
@@ -2586,12 +2586,12 @@ DictionaryTestSuite.test("BridgedToObjC.Verbatim.ObjectForKey") {
   expectEqual(1030, (v as! TestObjCValueTy).value)
   let idValue30 = unsafeBitCast(v, to: UInt.self)
 
-  expectEmpty(d.object(forKey: TestObjCKeyTy(40)))
+  expectNil(d.object(forKey: TestObjCKeyTy(40)))
 
   // NSDictionary can store mixed key types.  Swift's Dictionary is typed, but
   // when bridged to NSDictionary, it should behave like one, and allow queries
   // for mismatched key types.
-  expectEmpty(d.object(forKey: TestObjCInvalidKeyTy()))
+  expectNil(d.object(forKey: TestObjCInvalidKeyTy()))
 
   for i in 0..<3 {
     expectEqual(idValue10, unsafeBitCast(
@@ -3806,14 +3806,14 @@ DictionaryTestSuite.test("misc") {
     expectOptionalEqual(1, dict["Hello"])
     expectOptionalEqual(2, dict["World"])
     expectOptionalEqual(3, dict["Swift"])
-    expectEmpty(dict["Universe"])
+    expectNil(dict["Universe"])
 
     // Overwriting existing value
     dict["Hello"] = 0
     expectOptionalEqual(0, dict["Hello"])
     expectOptionalEqual(2, dict["World"])
     expectOptionalEqual(3, dict["Swift"])
-    expectEmpty(dict["Universe"])
+    expectNil(dict["Universe"])
   }
 
   do {
@@ -3906,7 +3906,7 @@ DictionaryTestSuite.test("popFirst") {
   do {
     var d = [Int: Int]()
     let popped = d.popFirst()
-    expectEmpty(popped)
+    expectNil(popped)
   }
 
   do {
@@ -3940,7 +3940,7 @@ DictionaryTestSuite.test("removeAt") {
     expectEqual(i*10, removed.0)
     expectEqual(i*1010, removed.1)
     expectEqual(2, d.count)
-    expectEmpty(d.index(forKey: i))
+    expectNil(d.index(forKey: i))
     let origKeys: [Int] = [10, 20, 30]
     expectEqual(origKeys.filter { $0 != (i*10) }, d.keys.sorted())
   }

--- a/validation-test/stdlib/DictionaryAnyHashableExtensions.swift
+++ b/validation-test/stdlib/DictionaryAnyHashableExtensions.swift
@@ -16,9 +16,9 @@ DictionaryTests.test("index<Hashable>(forKey:)") {
   expectEqual(2020, d[d.index(forKey: 20)!].value)
   expectEqual(3030, d[d.index(forKey: 30.0)!].value)
 
-  expectEmpty(d.index(forKey: 10.0))
-  expectEmpty(d.index(forKey: 20.0))
-  expectEmpty(d.index(forKey: 30))
+  expectNil(d.index(forKey: 10.0))
+  expectNil(d.index(forKey: 20.0))
+  expectNil(d.index(forKey: 30))
 }
 
 DictionaryTests.test("subscript<Hashable>(_:)") {
@@ -100,7 +100,7 @@ DictionaryTests.test("updateValue<Hashable>(_:forKey:)") {
     expectEqual(expected, d)
   }
 
-  expectEmpty(d.updateValue(4040, forKey: 10.0))
+  expectNil(d.updateValue(4040, forKey: 10.0))
   do {
     let expected: [AnyHashable : Int] = [
       AnyHashable(10) : 101010,
@@ -111,7 +111,7 @@ DictionaryTests.test("updateValue<Hashable>(_:forKey:)") {
     expectEqual(expected, d)
   }
 
-  expectEmpty(d.updateValue(5050, forKey: 20.0))
+  expectNil(d.updateValue(5050, forKey: 20.0))
   do {
     let expected: [AnyHashable : Int] = [
       AnyHashable(10) : 101010,
@@ -123,7 +123,7 @@ DictionaryTests.test("updateValue<Hashable>(_:forKey:)") {
     expectEqual(expected, d)
   }
 
-  expectEmpty(d.updateValue(6060, forKey: 30))
+  expectNil(d.updateValue(6060, forKey: 30))
   do {
     let expected: [AnyHashable : Int] = [
       AnyHashable(10) : 101010,
@@ -144,9 +144,9 @@ DictionaryTests.test("removeValue<Hashable>(forKey:)") {
     AnyHashable(30.0) : 3030,
   ]
 
-  expectEmpty(d.removeValue(forKey: 10.0))
-  expectEmpty(d.removeValue(forKey: 20.0))
-  expectEmpty(d.removeValue(forKey: 30))
+  expectNil(d.removeValue(forKey: 10.0))
+  expectNil(d.removeValue(forKey: 20.0))
+  expectNil(d.removeValue(forKey: 30))
 
   expectEqual(1010, d.removeValue(forKey: 10)!)
   expectEqual(2020, d.removeValue(forKey: 20)!)

--- a/validation-test/stdlib/ExistentialCollection.swift.gyb
+++ b/validation-test/stdlib/ExistentialCollection.swift.gyb
@@ -359,7 +359,7 @@ tests.test("ForwardCollection") {
   expectEqual(a0, a1)
   for e in a0 {
     let i = fc0.index(of: e)
-    expectNotEmpty(i)
+    expectNotNil(i)
     expectEqual(e, fc0[i!])
   }
   for i in fc0.indices {
@@ -373,7 +373,7 @@ tests.test("BidirectionalCollection") {
   let fc0 = AnyCollection(a0.lazy.reversed())
   
   let bc0_ = AnyBidirectionalCollection(fc0)  // upgrade!
-  expectNotEmpty(bc0_)
+  expectNotNil(bc0_)
   let bc0 = bc0_!
   expectTrue(storesSameUnderlyingCollection(fc0, bc0))
 
@@ -387,7 +387,7 @@ tests.test("BidirectionalCollection") {
   expectEqual(a0, a1)
   for e in a0 {
     let i = bc0.index(of: e)
-    expectNotEmpty(i)
+    expectNotNil(i)
     expectEqual(e, bc0[i!])
   }
   for i in bc0.indices {
@@ -408,7 +408,7 @@ tests.test("RandomAccessCollection") {
   let a0: ContiguousArray = [1, 2, 3, 5, 8, 13, 21]
   let fc0 = AnyCollection(a0.lazy.reversed())
   let rc0_ = AnyRandomAccessCollection(fc0)         // upgrade!
-  expectNotEmpty(rc0_)
+  expectNotNil(rc0_)
   let rc0 = rc0_!
   expectTrue(storesSameUnderlyingCollection(rc0, fc0))
 
@@ -422,7 +422,7 @@ tests.test("RandomAccessCollection") {
   expectEqual(a0, a1)
   for e in a0 {
     let i = rc0.index(of: e)
-    expectNotEmpty(i)
+    expectNotNil(i)
     expectEqual(e, rc0[i!])
   }
   for i in rc0.indices {

--- a/validation-test/stdlib/ExistentialCollection.swift.gyb
+++ b/validation-test/stdlib/ExistentialCollection.swift.gyb
@@ -400,8 +400,8 @@ tests.test("BidirectionalCollection") {
   let bc1 = AnyBidirectionalCollection(s0)
   let fc3 = AnyCollection(bc1)
   expectTrue(storesSameUnderlyingCollection(fc3, bc1))
-  expectEmpty(AnyRandomAccessCollection(bc1))
-  expectEmpty(AnyRandomAccessCollection(fc3))
+  expectNil(AnyRandomAccessCollection(bc1))
+  expectNil(AnyRandomAccessCollection(fc3))
 }
 
 tests.test("RandomAccessCollection") {

--- a/validation-test/stdlib/FixedPointConversion.swift.gyb
+++ b/validation-test/stdlib/FixedPointConversion.swift.gyb
@@ -102,7 +102,7 @@ FixedPointConversionTraps.test("${Other}To${Self}Conversion/dest=${testValue}") 
 FixedPointConversionFailure.test("${Other}To${Self}Conversion/dest=${testValue}") {
   // Test that we check if we return nil when an integer would be truncated in conversion.
   let input = get${Other}(${testValue})
-  expectEmpty(${Self}(exactly: input))
+  expectNil(${Self}(exactly: input))
 }
 %       end
 
@@ -134,7 +134,7 @@ FloatingPointConversionTruncations.test("${Other}To${Self}Conversion/dest=${test
 
 FloatingPointConversionFailures.test("${Other}To${Self}FailableConversion/dest=${testValue}") {
   let input = get${Other}(${testValue})
-  expectEmpty(${Self}(exactly: input))
+  expectNil(${Self}(exactly: input))
 }
 
 %       else:
@@ -158,7 +158,7 @@ FloatingPointConversionTruncations.test("${Other}To${Self}Conversion/dest=${test
 
 FloatingPointConversionFailures.test("${Other}To${Self}Conversion/dest=${testValue}") {
   let input = get${Other}(${testValue})
-  expectEmpty(${Self}(exactly: input))
+  expectNil(${Self}(exactly: input))
 }
 %       end
 %     end # for in testValues
@@ -174,7 +174,7 @@ FloatingPointConversionTraps.test("${Self}/${Other}/negative")
 }
 
 FloatingPointConversionFailures.test("${Self}/${Other}/negative") {
-  expectEmpty(${Self}(exactly: get${Other}(-123.0)))
+  expectNil(${Self}(exactly: get${Other}(-123.0)))
 }
 
 %     end
@@ -186,7 +186,7 @@ FloatingPointConversionTraps.test("${Self}/${Other}/+inf")
 }
 
 FloatingPointConversionFailures.test("${Self}/${Other}/+inf") {
-  expectEmpty(${Self}(exactly: get${Other}(${Other}.infinity)))
+  expectNil(${Self}(exactly: get${Other}(${Other}.infinity)))
 }
 
 FloatingPointConversionTraps.test("${Self}/${Other}/-inf")
@@ -196,7 +196,7 @@ FloatingPointConversionTraps.test("${Self}/${Other}/-inf")
 }
 
 FloatingPointConversionFailures.test("${Self}/${Other}/-inf") {
-  expectEmpty(${Self}(exactly: get${Other}(-${Other}.infinity)))
+  expectNil(${Self}(exactly: get${Other}(-${Other}.infinity)))
 }
 
 FloatingPointConversionTraps.test("${Self}/${Other}/NaN")
@@ -206,7 +206,7 @@ FloatingPointConversionTraps.test("${Self}/${Other}/NaN")
 }
 
 FloatingPointConversionFailures.test("${Self}/${Other}/NaN") {
-  expectEmpty(${Self}(exactly: get${Other}(${Other}.nan)))
+  expectNil(${Self}(exactly: get${Other}(${Other}.nan)))
 }
 
 %     if Other == 'Float80':

--- a/validation-test/stdlib/FloatingPointConversion.swift.gyb
+++ b/validation-test/stdlib/FloatingPointConversion.swift.gyb
@@ -93,7 +93,7 @@ FloatingPointConversionFailures.test("${OtherFloat}To${Self}FailableConversion")
     expectEqual(input, ${OtherFloat}(result))
   }
 %   else:
-  expectEmpty(result)
+  expectNil(result)
 %   end
 }
 
@@ -102,7 +102,7 @@ FloatingPointConversionFailures.test("${OtherFloat}To${Self}Conversion/AlwaysSuc
   expectEqual(-1.0 as ${Self},   ${Self}(exactly: -1.0 as ${OtherFloat}))
   expectEqual( ${Self}.infinity, ${Self}(exactly:  ${OtherFloat}.infinity))
   expectEqual(-${Self}.infinity, ${Self}(exactly: -${OtherFloat}.infinity))
-  expectEmpty(${Self}(exactly: ${OtherFloat}.nan))
+  expectNil(${Self}(exactly: ${OtherFloat}.nan))
 }
 
 %   if OtherFloat == 'Float80':

--- a/validation-test/stdlib/FloatingPointConversion.swift.gyb
+++ b/validation-test/stdlib/FloatingPointConversion.swift.gyb
@@ -88,7 +88,7 @@ FloatingPointConversionFailures.test("${OtherFloat}To${Self}FailableConversion")
   input in
   let result = ${Self}(exactly: input)
 %   if OtherSignificandBits <= SelfSignificandBits:
-  if let result = expectNotEmpty(result) {
+  if let result = expectNotNil(result) {
     // FIXME: we should have a stronger postcondition here.
     expectEqual(input, ${OtherFloat}(result))
   }

--- a/validation-test/stdlib/GameplayKit.swift
+++ b/validation-test/stdlib/GameplayKit.swift
@@ -71,7 +71,7 @@ GamePlayKitTests.test("GKEntity.component(ofType)") {
     var componentForOtherTestComponent_nil =
       entity.component(ofType: OtherTestComponent.self)
 
-    expectNotEmpty(componentForTestComponent)
+    expectNotNil(componentForTestComponent)
     expectType(Optional<TestComponent>.self, &componentForTestComponent)
 
     expectNil(componentForOtherTestComponent_nil)
@@ -86,7 +86,7 @@ GamePlayKitTests.test("GKEntity.component(ofType)") {
     var componentForTestComponent_nil =
       entity.component(ofType: TestComponent.self)
 
-    expectNotEmpty(componentForOtherTestComponent)
+    expectNotNil(componentForOtherTestComponent)
     expectType(Optional<OtherTestComponent>.self, &componentForOtherTestComponent)
 
     expectNil(componentForTestComponent_nil)
@@ -104,7 +104,7 @@ GamePlayKitTests.test("GKStateMachine.state(forClass:)") {
     var stateForTestState2_nil =
       stateMachine.state(forClass: TestState2.self)
 
-    expectNotEmpty(stateForTestState1)
+    expectNotNil(stateForTestState1)
     expectType(Optional<TestState1>.self, &stateForTestState1)
 
     expectNil(stateForTestState2_nil)
@@ -120,7 +120,7 @@ GamePlayKitTests.test("GKStateMachine.state(forClass:)") {
     var stateForTestState1_nil =
       stateMachine.state(forClass: TestState1.self)
 
-    expectNotEmpty(stateForTestState2)
+    expectNotNil(stateForTestState2)
     expectType(Optional<TestState2>.self, &stateForTestState2)
 
     expectNil(stateForTestState1_nil)

--- a/validation-test/stdlib/GameplayKit.swift
+++ b/validation-test/stdlib/GameplayKit.swift
@@ -74,7 +74,7 @@ GamePlayKitTests.test("GKEntity.component(ofType)") {
     expectNotEmpty(componentForTestComponent)
     expectType(Optional<TestComponent>.self, &componentForTestComponent)
 
-    expectEmpty(componentForOtherTestComponent_nil)
+    expectNil(componentForOtherTestComponent_nil)
   }
 
   entity.removeComponent(ofType: TestComponent.self)
@@ -89,7 +89,7 @@ GamePlayKitTests.test("GKEntity.component(ofType)") {
     expectNotEmpty(componentForOtherTestComponent)
     expectType(Optional<OtherTestComponent>.self, &componentForOtherTestComponent)
 
-    expectEmpty(componentForTestComponent_nil)
+    expectNil(componentForTestComponent_nil)
   }
 }
 
@@ -107,7 +107,7 @@ GamePlayKitTests.test("GKStateMachine.state(forClass:)") {
     expectNotEmpty(stateForTestState1)
     expectType(Optional<TestState1>.self, &stateForTestState1)
 
-    expectEmpty(stateForTestState2_nil)
+    expectNil(stateForTestState2_nil)
   }
 
   do {
@@ -123,7 +123,7 @@ GamePlayKitTests.test("GKStateMachine.state(forClass:)") {
     expectNotEmpty(stateForTestState2)
     expectType(Optional<TestState2>.self, &stateForTestState2)
 
-    expectEmpty(stateForTestState1_nil)
+    expectNil(stateForTestState1_nil)
   }
 }
 

--- a/validation-test/stdlib/Generator.swift
+++ b/validation-test/stdlib/Generator.swift
@@ -14,7 +14,7 @@ tests.test("Range") {
   var maybe_one = w.next()
   expectType(Optional<Int>.self, &maybe_one)
   expectEqual(1, maybe_one)
-  expectEmpty(w.next())
+  expectNil(w.next())
 }
 
 tests.test("RangeIteratorConformsToSequence") {

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -307,7 +307,7 @@ LazyTestSuite.test("EmptyCollection/index(_:offsetBy:limitedBy:)/NoTrap")
   if offset == 0 {
     expectOptionalEqual(c.startIndex, result)
   } else {
-    expectEmpty(result)
+    expectNil(result)
   }
 }
 
@@ -368,7 +368,7 @@ LazyTestSuite.test("first") {
 }
 
 LazyTestSuite.test("first empty") {
-  expectEmpty((7..<7).lazy.first)
+  expectNil((7..<7).lazy.first)
 }
 
 LazyTestSuite.test("last") {
@@ -376,7 +376,7 @@ LazyTestSuite.test("last") {
 }
 
 LazyTestSuite.test("last empty") {
-  expectEmpty((7..<7).lazy.last)
+  expectNil((7..<7).lazy.last)
 }
 
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/NSNumberBridging.swift.gyb
+++ b/validation-test/stdlib/NSNumberBridging.swift.gyb
@@ -258,7 +258,7 @@ NSNumberTests.test("${Self} bridges to NSNumber (actually _SwiftTypePreservingNS
 %   else:
   expectTrue(isTypePreservingNSNumber(bridgedNSNumber))
 %   end
-  expectNotEmpty(bridgedNSNumber._toCustomAnyHashable())
+  expectNotNil(bridgedNSNumber._toCustomAnyHashable())
 
   // Explicitly constructed NSNumbers don't have a special AnyHashable
   // representation.

--- a/validation-test/stdlib/NSNumberBridging.swift.gyb
+++ b/validation-test/stdlib/NSNumberBridging.swift.gyb
@@ -271,7 +271,7 @@ NSNumberTests.test("${Self} bridges to NSNumber (actually _SwiftTypePreservingNS
   let explicitNSNumber = NSNumber(value: input)
 %   end
   expectFalse(isTypePreservingNSNumber(explicitNSNumber))
-  expectEmpty(explicitNSNumber._toCustomAnyHashable())
+  expectNil(explicitNSNumber._toCustomAnyHashable())
   expectTrue(
     Set(["__NSCFNumber", "__NSCFBoolean"]).contains(
       String(describing: type(of: AnyHashable(explicitNSNumber).base))))

--- a/validation-test/stdlib/NSStringBridging.swift.gyb
+++ b/validation-test/stdlib/NSStringBridging.swift.gyb
@@ -18,7 +18,7 @@ NSStringTests.test("NSString bridges to String with custom AnyHashable")
   .forEach(in: ["", "a", "abc", "a\u{0301}", "\u{e1}"]) {
   input in
   let s = input._bridgeToObjectiveC()
-  expectNotEmpty(s._toCustomAnyHashable())
+  expectNotNil(s._toCustomAnyHashable())
   expectEqual(String.self, type(of: AnyHashable(s).base))
 }
 

--- a/validation-test/stdlib/Prototypes/PersistentVector.swift.gyb
+++ b/validation-test/stdlib/Prototypes/PersistentVector.swift.gyb
@@ -1919,7 +1919,7 @@ func expectContents(
       ${trace})
   }
   for key in unexpectedKeys {
-    expectEmpty(storage.maybeGet(key: key), ${trace})
+    expectNil(storage.maybeGet(key: key), ${trace})
   }
   expectEqual(contents.count, storage.count, ${trace})
 }
@@ -2120,7 +2120,7 @@ func testDictionary(
       let expectedKeys = shadow.keys
       let unexpectedKeys = allKeys.filter { !expectedKeys.contains($0) }
       for key in unexpectedKeys {
-        expectEmpty(dictionary.maybeGet(key: key), ${trace})
+        expectNil(dictionary.maybeGet(key: key), ${trace})
       }
       expectContents(
         shadow._elements,

--- a/validation-test/stdlib/SceneKit.swift
+++ b/validation-test/stdlib/SceneKit.swift
@@ -357,7 +357,7 @@ if #available(iOS 8.0, *) {
       expectNotEmpty(unarchivedPlaneGeometry)
       expectType(Optional<SCNGeometry>.self, &unarchivedPlaneGeometry)
 
-      expectEmpty(unarchivedPlaneNode_nil)
+      expectNil(unarchivedPlaneNode_nil)
     }
 
     do {
@@ -369,7 +369,7 @@ if #available(iOS 8.0, *) {
       expectNotEmpty(unarchivedBoxGeometry)
       expectType(Optional<SCNGeometry>.self, &unarchivedBoxGeometry)
 
-      expectEmpty(unarchivedBoxGeometry_nil)
+      expectNil(unarchivedBoxGeometry_nil)
     }
 
     do {
@@ -381,7 +381,7 @@ if #available(iOS 8.0, *) {
       expectNotEmpty(unarchivedBoxNode)
       expectType(Optional<SCNNode>.self, &unarchivedBoxNode)
 
-      expectEmpty(unarchivedBoxNode_nil)
+      expectNil(unarchivedBoxNode_nil)
     }
   }
 

--- a/validation-test/stdlib/SceneKit.swift
+++ b/validation-test/stdlib/SceneKit.swift
@@ -354,7 +354,7 @@ if #available(iOS 8.0, *) {
       var unarchivedPlaneNode_nil =
         sceneSource.entryWithIdentifier("plane-node", withClass: SCNNode.self)
 
-      expectNotEmpty(unarchivedPlaneGeometry)
+      expectNotNil(unarchivedPlaneGeometry)
       expectType(Optional<SCNGeometry>.self, &unarchivedPlaneGeometry)
 
       expectNil(unarchivedPlaneNode_nil)
@@ -366,7 +366,7 @@ if #available(iOS 8.0, *) {
       var unarchivedBoxGeometry_nil =
         sceneSource.entryWithIdentifier("box-node", withClass: SCNGeometry.self)
 
-      expectNotEmpty(unarchivedBoxGeometry)
+      expectNotNil(unarchivedBoxGeometry)
       expectType(Optional<SCNGeometry>.self, &unarchivedBoxGeometry)
 
       expectNil(unarchivedBoxGeometry_nil)
@@ -378,7 +378,7 @@ if #available(iOS 8.0, *) {
       var unarchivedBoxNode_nil =
         sceneSource.entryWithIdentifier("box", withClass: SCNNode.self)
 
-      expectNotEmpty(unarchivedBoxNode)
+      expectNotNil(unarchivedBoxNode)
       expectType(Optional<SCNNode>.self, &unarchivedBoxNode)
 
       expectNil(unarchivedBoxNode_nil)

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -74,10 +74,10 @@ SequenceTypeTests.test("${algorithmKind}/WhereElementIsComparable") {
         test.expected${AlgorithmKind}Index!, result.identity,
         stackTrace: SourceLocStack().with(test.loc))
     } else {
-      expectEmpty(
+      expectNil(
         test.expected${AlgorithmKind}Value,
         stackTrace: SourceLocStack().with(test.loc))
-      expectEmpty(
+      expectNil(
         test.expected${AlgorithmKind}Index,
         stackTrace: SourceLocStack().with(test.loc))
     }
@@ -106,10 +106,10 @@ SequenceTypeTests.test("${algorithmKind}/Predicate") {
         test.expected${AlgorithmKind}Index!, result.identity,
         stackTrace: SourceLocStack().with(test.loc))
     } else {
-      expectEmpty(
+      expectNil(
         test.expected${AlgorithmKind}Value,
         stackTrace: SourceLocStack().with(test.loc))
-      expectEmpty(
+      expectNil(
         test.expected${AlgorithmKind}Index,
         stackTrace: SourceLocStack().with(test.loc))
     }

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -1005,7 +1005,7 @@ SetTestSuite.test("COW.Fast.FirstDoesNotReallocate") {
   var s = getCOWFastSet()
   var identity1 = s._rawIdentifier()
 
-  expectNotEmpty(s.first)
+  expectNotNil(s.first)
   expectEqual(identity1, s._rawIdentifier())
 }
 
@@ -1021,7 +1021,7 @@ SetTestSuite.test("COW.Slow.FirstDoesNotReallocate") {
   var s = getCOWSlowSet()
   var identity1 = s._rawIdentifier()
 
-  expectNotEmpty(s.first)
+  expectNotNil(s.first)
   expectEqual(identity1, s._rawIdentifier())
 }
 
@@ -1236,7 +1236,7 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.SetIsCopied") {
   expectTrue(isCocoaSet(s))
 
   expectTrue(s.contains(TestObjCKeyTy(1010)))
-  expectNotEmpty(nss.member(TestObjCKeyTy(1010)))
+  expectNotNil(nss.member(TestObjCKeyTy(1010)))
 
   nss.remove(TestObjCKeyTy(1010))
   expectNil(nss.member(TestObjCKeyTy(1010)))
@@ -1249,7 +1249,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.SetIsCopied") {
   expectTrue(isNativeSet(s))
 
   expectTrue(s.contains(TestBridgedKeyTy(1010)))
-  expectNotEmpty(nss.member(TestBridgedKeyTy(1010) as AnyObject))
+  expectNotNil(nss.member(TestBridgedKeyTy(1010) as AnyObject))
 
   nss.remove(TestBridgedKeyTy(1010) as AnyObject)
   expectNil(nss.member(TestBridgedKeyTy(1010) as AnyObject))

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -605,7 +605,7 @@ SetTestSuite.test("COW.Fast.IndexForMemberDoesNotReallocate") {
   // Try to find a key that is not present.
   do {
     var foundIndex1 = s.index(of: 1111)
-    expectEmpty(foundIndex1)
+    expectNil(foundIndex1)
     expectEqual(identity1, s._rawIdentifier())
   }
 
@@ -613,7 +613,7 @@ SetTestSuite.test("COW.Fast.IndexForMemberDoesNotReallocate") {
     var s2: Set<MinimalHashableValue> = []
     MinimalHashableValue.timesEqualEqualWasCalled = 0
     MinimalHashableValue.timesHashValueWasCalled = 0
-    expectEmpty(s2.index(of: MinimalHashableValue(42)))
+    expectNil(s2.index(of: MinimalHashableValue(42)))
 
     // If the set is empty, we shouldn't be computing the hash value of the
     // provided key.
@@ -641,7 +641,7 @@ SetTestSuite.test("COW.Slow.IndexForMemberDoesNotReallocate") {
   // Try to find a key that is not present.
   do {
     var foundIndex1 = s.index(of: TestKeyTy(1111))
-    expectEmpty(foundIndex1)
+    expectNil(foundIndex1)
     expectEqual(identity1, s._rawIdentifier())
   }
 
@@ -649,7 +649,7 @@ SetTestSuite.test("COW.Slow.IndexForMemberDoesNotReallocate") {
     var s2: Set<MinimalHashableClass> = []
     MinimalHashableClass.timesEqualEqualWasCalled = 0
     MinimalHashableClass.timesHashValueWasCalled = 0
-    expectEmpty(s2.index(of: MinimalHashableClass(42)))
+    expectNil(s2.index(of: MinimalHashableClass(42)))
 
     // If the set is empty, we shouldn't be computing the hash value of the
     // provided key.
@@ -672,7 +672,7 @@ SetTestSuite.test("COW.Fast.RemoveAtDoesNotReallocate") {
     expectEqual(1010, removed)
 
     expectEqual(identity1, s._rawIdentifier())
-    expectEmpty(s.index(of: 1010))
+    expectNil(s.index(of: 1010))
   }
 
   do {
@@ -693,7 +693,7 @@ SetTestSuite.test("COW.Fast.RemoveAtDoesNotReallocate") {
 
     expectEqual(identity1, s1._rawIdentifier())
     expectNotEqual(identity1, s2._rawIdentifier())
-    expectEmpty(s2.index(of: 1010))
+    expectNil(s2.index(of: 1010))
   }
 }
 
@@ -711,7 +711,7 @@ SetTestSuite.test("COW.Slow.RemoveAtDoesNotReallocate") {
     expectEqual(TestKeyTy(1010), removed)
 
     expectEqual(identity1, s._rawIdentifier())
-    expectEmpty(s.index(of: TestKeyTy(1010)))
+    expectNil(s.index(of: TestKeyTy(1010)))
   }
 
   do {
@@ -732,7 +732,7 @@ SetTestSuite.test("COW.Slow.RemoveAtDoesNotReallocate") {
 
     expectEqual(identity1, s1._rawIdentifier())
     expectNotEqual(identity1, s2._rawIdentifier())
-    expectEmpty(s2.index(of: TestKeyTy(1010)))
+    expectNil(s2.index(of: TestKeyTy(1010)))
   }
 }
 
@@ -742,7 +742,7 @@ SetTestSuite.test("COW.Fast.RemoveDoesNotReallocate") {
     var identity1 = s1._rawIdentifier()
 
     var deleted = s1.remove(0)
-    expectEmpty(deleted)
+    expectNil(deleted)
     expectEqual(identity1, s1._rawIdentifier())
 
     deleted = s1.remove(1010)
@@ -759,7 +759,7 @@ SetTestSuite.test("COW.Fast.RemoveDoesNotReallocate") {
 
     var s2 = s1
     var deleted = s2.remove(0)
-    expectEmpty(deleted)
+    expectNil(deleted)
     expectEqual(identity1, s1._rawIdentifier())
     expectEqual(identity1, s2._rawIdentifier())
 
@@ -780,7 +780,7 @@ SetTestSuite.test("COW.Slow.RemoveDoesNotReallocate") {
     var identity1 = s1._rawIdentifier()
 
     var deleted = s1.remove(TestKeyTy(0))
-    expectEmpty(deleted)
+    expectNil(deleted)
     expectEqual(identity1, s1._rawIdentifier())
 
     deleted = s1.remove(TestKeyTy(1010))
@@ -797,7 +797,7 @@ SetTestSuite.test("COW.Slow.RemoveDoesNotReallocate") {
 
     var s2 = s1
     var deleted = s2.remove(TestKeyTy(0))
-    expectEmpty(deleted)
+    expectNil(deleted)
     expectEqual(identity1, s1._rawIdentifier())
     expectEqual(identity1, s2._rawIdentifier())
 
@@ -1239,7 +1239,7 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.SetIsCopied") {
   expectNotEmpty(nss.member(TestObjCKeyTy(1010)))
 
   nss.remove(TestObjCKeyTy(1010))
-  expectEmpty(nss.member(TestObjCKeyTy(1010)))
+  expectNil(nss.member(TestObjCKeyTy(1010)))
 
   expectTrue(s.contains(TestObjCKeyTy(1010)))
 }
@@ -1252,7 +1252,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.SetIsCopied") {
   expectNotEmpty(nss.member(TestBridgedKeyTy(1010) as AnyObject))
 
   nss.remove(TestBridgedKeyTy(1010) as AnyObject)
-  expectEmpty(nss.member(TestBridgedKeyTy(1010) as AnyObject))
+  expectNil(nss.member(TestBridgedKeyTy(1010) as AnyObject))
 
   expectTrue(s.contains(TestBridgedKeyTy(1010)))
 }
@@ -1354,7 +1354,7 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.IndexForMember") {
   expectEqual(TestObjCKeyTy(3030), member)
 
   // Try to find a key that does not exist.
-  expectEmpty(s.index(of: TestObjCKeyTy(4040)))
+  expectNil(s.index(of: TestObjCKeyTy(4040)))
   expectEqual(identity1, s._rawIdentifier())
 }
 
@@ -1373,7 +1373,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.IndexForMember") {
     expectEqual(TestBridgedKeyTy(3030), member)
   }
 
-  expectEmpty(s.index(of: TestBridgedKeyTy(4040)))
+  expectNil(s.index(of: TestBridgedKeyTy(4040)))
   expectEqual(identity1, s._rawIdentifier())
 }
 
@@ -1642,7 +1642,7 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.RemoveAt") {
   expectTrue(isNativeSet(s))
   expectEqual(2, s.count)
   expectEqual(TestObjCKeyTy(1010), removedElement)
-  expectEmpty(s.index(of: TestObjCKeyTy(1010)))
+  expectNil(s.index(of: TestObjCKeyTy(1010)))
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAt") {
@@ -1659,7 +1659,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAt") {
   expectTrue(isNativeSet(s))
   expectEqual(1010, removedElement.value)
   expectEqual(2, s.count)
-  expectEmpty(s.index(of: TestBridgedKeyTy(1010)))
+  expectNil(s.index(of: TestBridgedKeyTy(1010)))
 }
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.Remove") {
@@ -1669,7 +1669,7 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.Remove") {
     expectTrue(isCocoaSet(s))
 
     var deleted: AnyObject? = s.remove(TestObjCKeyTy(0))
-    expectEmpty(deleted)
+    expectNil(deleted)
     expectEqual(identity1, s._rawIdentifier())
     expectTrue(isCocoaSet(s))
 
@@ -1695,7 +1695,7 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.Remove") {
     expectTrue(isCocoaSet(s2))
 
     var deleted: AnyObject? = s2.remove(TestObjCKeyTy(0))
-    expectEmpty(deleted)
+    expectNil(deleted)
     expectEqual(identity1, s1._rawIdentifier())
     expectEqual(identity1, s2._rawIdentifier())
     expectTrue(isCocoaSet(s1))
@@ -1731,7 +1731,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Remove") {
     // Trying to remove something not in the set should
     // leave it completely unchanged.
     var deleted = s.remove(TestBridgedKeyTy(0))
-    expectEmpty(deleted)
+    expectNil(deleted)
     expectEqual(identity1, s._rawIdentifier())
     expectTrue(isNativeSet(s))
 
@@ -1764,7 +1764,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Remove") {
     expectTrue(isNativeSet(s2))
 
     var deleted = s2.remove(TestBridgedKeyTy(0))
-    expectEmpty(deleted)
+    expectNil(deleted)
     expectEqual(identity1, s1._rawIdentifier())
     expectEqual(identity1, s2._rawIdentifier())
     expectTrue(isNativeSet(s1))
@@ -1943,9 +1943,9 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.Generate") {
   expectTrue(equalsUnordered(members, [1010, 2020, 3030]))
   // The following is not required by the IteratorProtocol protocol, but
   // it is a nice QoI.
-  expectEmpty(iter.next())
-  expectEmpty(iter.next())
-  expectEmpty(iter.next())
+  expectNil(iter.next())
+  expectNil(iter.next())
+  expectNil(iter.next())
   expectEqual(identity1, s._rawIdentifier())
 }
 
@@ -1962,9 +1962,9 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Generate") {
   expectTrue(equalsUnordered(members, [1010, 2020, 3030]))
   // The following is not required by the IteratorProtocol protocol, but
   // it is a nice QoI.
-  expectEmpty(iter.next())
-  expectEmpty(iter.next())
-  expectEmpty(iter.next())
+  expectNil(iter.next())
+  expectNil(iter.next())
+  expectNil(iter.next())
   expectEqual(identity1, s._rawIdentifier())
 }
 
@@ -1974,12 +1974,12 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.Generate_Empty") {
   expectTrue(isCocoaSet(s))
 
   var iter = s.makeIterator()
-  expectEmpty(iter.next())
+  expectNil(iter.next())
   // The following is not required by the IteratorProtocol protocol, but
   // it is a nice QoI.
-  expectEmpty(iter.next())
-  expectEmpty(iter.next())
-  expectEmpty(iter.next())
+  expectNil(iter.next())
+  expectNil(iter.next())
+  expectNil(iter.next())
   expectEqual(identity1, s._rawIdentifier())
 }
 
@@ -1989,12 +1989,12 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Generate_Empty") {
   expectTrue(isNativeSet(s))
 
   var iter = s.makeIterator()
-  expectEmpty(iter.next())
+  expectNil(iter.next())
   // The following is not required by the IteratorProtocol protocol, but
   // it is a nice QoI.
-  expectEmpty(iter.next())
-  expectEmpty(iter.next())
-  expectEmpty(iter.next())
+  expectNil(iter.next())
+  expectNil(iter.next())
+  expectNil(iter.next())
   expectEqual(identity1, s._rawIdentifier())
 }
 
@@ -2011,9 +2011,9 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.Generate_Huge") {
   expectTrue(equalsUnordered(members, hugeNumberArray))
   // The following is not required by the IteratorProtocol protocol, but
   // it is a nice QoI.
-  expectEmpty(iter.next())
-  expectEmpty(iter.next())
-  expectEmpty(iter.next())
+  expectNil(iter.next())
+  expectNil(iter.next())
+  expectNil(iter.next())
   expectEqual(identity1, s._rawIdentifier())
 }
 
@@ -2030,9 +2030,9 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Generate_Huge") {
   expectTrue(equalsUnordered(members, hugeNumberArray))
   // The following is not required by the IteratorProtocol protocol, but
   // it is a nice QoI.
-  expectEmpty(iter.next())
-  expectEmpty(iter.next())
-  expectEmpty(iter.next())
+  expectNil(iter.next())
+  expectNil(iter.next())
+  expectNil(iter.next())
   expectEqual(identity1, s._rawIdentifier())
 }
 
@@ -2182,12 +2182,12 @@ SetTestSuite.test("BridgedToObjC.Verbatim.Contains") {
   expectEqual(3030, (v as! TestObjCKeyTy).value)
   let idValue30 = unsafeBitCast(v, to: UInt.self)
 
-  expectEmpty(s.member(TestObjCKeyTy(4040)))
+  expectNil(s.member(TestObjCKeyTy(4040)))
 
   // NSSet can store mixed key types.  Swift's Set is typed, but when bridged
   // to NSSet, it should behave like one, and allow queries for mismatched key
   // types.
-  expectEmpty(s.member(TestObjCInvalidKeyTy()))
+  expectNil(s.member(TestObjCInvalidKeyTy()))
 
   for i in 0..<3 {
     expectEqual(idValue10,
@@ -2347,9 +2347,9 @@ SetTestSuite.test("BridgedToObjC.ObjectEnumerator.NextObject") {
   }
   expectTrue(equalsUnordered([1010, 2020, 3030], members))
 
-  expectEmpty(enumerator.nextObject())
-  expectEmpty(enumerator.nextObject())
-  expectEmpty(enumerator.nextObject())
+  expectNil(enumerator.nextObject())
+  expectNil(enumerator.nextObject())
+  expectNil(enumerator.nextObject())
 
   expectAutoreleasedKeysAndValues(unopt: (3, 0))
 }
@@ -2358,9 +2358,9 @@ SetTestSuite.test("BridgedToObjC.ObjectEnumerator.NextObject.Empty") {
   let s = getBridgedEmptyNSSet()
   let enumerator = s.objectEnumerator()
 
-  expectEmpty(enumerator.nextObject())
-  expectEmpty(enumerator.nextObject())
-  expectEmpty(enumerator.nextObject())
+  expectNil(enumerator.nextObject())
+  expectNil(enumerator.nextObject())
+  expectNil(enumerator.nextObject())
 }
 
 //
@@ -3036,7 +3036,7 @@ SetTestSuite.test("replace") {
   do {
     // Replacing an element that isn't present
     let oldMember = s1.update(with: fortyForty)
-    expectEmpty(oldMember)
+    expectNil(oldMember)
   }
   
   do {
@@ -3431,7 +3431,7 @@ SetTestSuite.test("removeFirst") {
   expectTrue(s2.contains(a1))
   expectNotEqual(s1._rawIdentifier(), s2._rawIdentifier())
   expectTrue(s1.isSubset(of: s2))
-  expectEmpty(empty.first)
+  expectNil(empty.first)
 }
 
 SetTestSuite.test("remove(member)") {
@@ -3445,7 +3445,7 @@ SetTestSuite.test("remove(member)") {
   // remove something that's not there.
   let fortyForty = s2.remove(4040)
   expectEqual(s2, s1)
-  expectEmpty(fortyForty)
+  expectNil(fortyForty)
   expectEqual(identity1, s2._rawIdentifier())
 
   // Remove things that are there.
@@ -3492,7 +3492,7 @@ SetTestSuite.test("first") {
   let emptySet = Set<Int>()
 
   expectTrue(s1.contains(s1.first!))
-  expectEmpty(emptySet.first)
+  expectNil(emptySet.first)
 }
 
 SetTestSuite.test("isEmpty") {
@@ -3617,7 +3617,7 @@ SetTestSuite.test("index(of:)") {
   let foundIndex1 = s1.index(of: 1010)!
   expectEqual(1010, s1[foundIndex1])
 
-  expectEmpty(s1.index(of: 999))
+  expectNil(s1.index(of: 999))
 }
 
 SetTestSuite.test("popFirst") {
@@ -3625,7 +3625,7 @@ SetTestSuite.test("popFirst") {
   do {
     var s = Set<Int>()
     let popped = s.popFirst()
-    expectEmpty(popped)
+    expectNil(popped)
     expectTrue(s.isEmpty)
   }
 
@@ -3648,7 +3648,7 @@ SetTestSuite.test("removeAt") {
     let removed = s.remove(at: s.index(of: i*1010)!)
     expectEqual(i*1010, removed)
     expectEqual(2, s.count)
-    expectEmpty(s.index(of: i*1010))
+    expectNil(s.index(of: i*1010))
     let origKeys: [Int] = [1010, 2020, 3030]
     expectEqual(origKeys.filter { $0 != (i*1010) }, [Int](s).sorted())
   }
@@ -3659,7 +3659,7 @@ SetTestSuite.test("_customIndexOfEquatableElement") {
   let foundIndex1 = s1._customIndexOfEquatableElement(1010)!!
   expectEqual(1010, s1[foundIndex1])
 
-  expectEmpty(s1._customIndexOfEquatableElement(999)!)
+  expectNil(s1._customIndexOfEquatableElement(999)!)
 }
 
 SetTestSuite.test("commutative") {

--- a/validation-test/stdlib/SetAnyHashableExtensions.swift
+++ b/validation-test/stdlib/SetAnyHashableExtensions.swift
@@ -47,9 +47,9 @@ SetTests.test("index<Hashable>(of:)") {
   expectEqual(AnyHashable(2020), s[s.index(of: 2020)!])
   expectEqual(AnyHashable(3030.0), s[s.index(of: 3030.0)!])
 
-  expectEmpty(s.index(of: 1010.0))
-  expectEmpty(s.index(of: 2020.0))
-  expectEmpty(s.index(of: 3030))
+  expectNil(s.index(of: 1010.0))
+  expectNil(s.index(of: 2020.0))
+  expectNil(s.index(of: 3030))
 }
 
 SetTests.test("insert<Hashable>(_:)") {
@@ -148,9 +148,9 @@ SetTests.test("update<Hashable>(with:)") {
     expectEqual(1, old.identity)
   }
 
-  expectEmpty(s.update(with: MinimalHashableClass(1010, identity: 2)))
-  expectEmpty(s.update(with: MinimalHashableClass(2020, identity: 2)))
-  expectEmpty(s.update(with: MinimalHashableValue(3030, identity: 2)))
+  expectNil(s.update(with: MinimalHashableClass(1010, identity: 2)))
+  expectNil(s.update(with: MinimalHashableClass(2020, identity: 2)))
+  expectNil(s.update(with: MinimalHashableValue(3030, identity: 2)))
 
   let expected: Set<AnyHashable> = [
     AnyHashable(MinimalHashableValue(1010, identity: 2)),
@@ -188,9 +188,9 @@ SetTests.test("remove<Hashable>(_:)") {
     AnyHashable(MinimalHashableClass(3030, identity: 1)),
   ]
 
-  expectEmpty(s.remove(MinimalHashableClass(1010)))
-  expectEmpty(s.remove(MinimalHashableClass(2020)))
-  expectEmpty(s.remove(MinimalHashableValue(3030)))
+  expectNil(s.remove(MinimalHashableClass(1010)))
+  expectNil(s.remove(MinimalHashableClass(2020)))
+  expectNil(s.remove(MinimalHashableValue(3030)))
 
   expectEqual(3, s.count)
 

--- a/validation-test/stdlib/Sort.swift.gyb
+++ b/validation-test/stdlib/Sort.swift.gyb
@@ -35,7 +35,7 @@ func expectSortedCollection(_ sortedAry: [Int], _ originalAry: [Int]) {
   }
   // Now check if sets of elements are the same in both arrays.
   for (key, value) in sortedVals {
-    expectNotEmpty(originalVals[key])
+    expectNotNil(originalVals[key])
     expectEqual(originalVals[key]!, value)
   }
 

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -874,23 +874,23 @@ StringTests.test("reserveCapacity") {
 }
 
 StringTests.test("toInt") {
-  expectEmpty(Int(""))
-  expectEmpty(Int("+"))
-  expectEmpty(Int("-"))
+  expectNil(Int(""))
+  expectNil(Int("+"))
+  expectNil(Int("-"))
   expectOptionalEqual(20, Int("+20"))
   expectOptionalEqual(0, Int("0"))
   expectOptionalEqual(-20, Int("-20"))
-  expectEmpty(Int("-cc20"))
-  expectEmpty(Int("  -20"))
-  expectEmpty(Int("  \t 20ddd"))
+  expectNil(Int("-cc20"))
+  expectNil(Int("  -20"))
+  expectNil(Int("  \t 20ddd"))
 
   expectOptionalEqual(Int.min, Int("\(Int.min)"))
   expectOptionalEqual(Int.min + 1, Int("\(Int.min + 1)"))
   expectOptionalEqual(Int.max, Int("\(Int.max)"))
   expectOptionalEqual(Int.max - 1, Int("\(Int.max - 1)"))
 
-  expectEmpty(Int("\(Int.min)0"))
-  expectEmpty(Int("\(Int.max)0"))
+  expectNil(Int("\(Int.min)0"))
+  expectNil(Int("\(Int.max)0"))
 
   // Make a String from an Int, mangle the String's characters,
   // then print if the new String is or is not still an Int.
@@ -901,7 +901,7 @@ StringTests.test("toInt") {
     var chars = Array(String(initialValue).utf8)
     modification(&chars)
     let str = String._fromWellFormedCodeUnitSequence(UTF8.self, input: chars)
-    expectEmpty(Int(str))
+    expectNil(Int(str))
   }
 
   testConvertabilityOfStringWithModification(Int.min) {
@@ -918,7 +918,7 @@ StringTests.test("toInt") {
     expectOptionalEqual(Int.min + 1, Int("-\(base)"))
     expectOptionalEqual(Int.min, Int("-\(base + 1)"))
     for i in 2..<20 {
-      expectEmpty(Int("-\(base + UInt(i))"))
+      expectNil(Int("-\(base + UInt(i))"))
     }
   }
 
@@ -935,7 +935,7 @@ StringTests.test("toInt") {
     let base = UInt(Int.max)
     expectOptionalEqual(Int.max, Int("\(base)"))
     for i in 1..<20 {
-      expectEmpty(Int("\(base + UInt(i))"))
+      expectNil(Int("\(base + UInt(i))"))
     }
   }
 

--- a/validation-test/stdlib/StringViews.swift
+++ b/validation-test/stdlib/StringViews.swift
@@ -189,7 +189,7 @@ tests.test("index-mapping/utf16-to-utf8") {
       } ?? []
     }, sameValue: ==)
 
-  expectNotEmpty(winter.utf16.endIndex.samePosition(in: winter.utf8))
+  expectNotNil(winter.utf16.endIndex.samePosition(in: winter.utf8))
   expectEqual(
     winter.utf8.endIndex,
     winter.utf16.endIndex.samePosition(in: winter.utf8)!)
@@ -201,7 +201,7 @@ tests.test("index-mapping/utf16-to-utf8") {
     }
   )
   
-  expectNotEmpty(summer.utf16.endIndex.samePosition(in: summer.utf8))
+  expectNotNil(summer.utf16.endIndex.samePosition(in: summer.utf8))
   expectEqual(
     summer.utf8.endIndex,
     summer.utf16.endIndex.samePosition(in: summer.utf8)!)
@@ -229,7 +229,7 @@ tests.test("index-mapping/utf8-to-unicode-scalar") {
     }, sameValue: ==
   )
 
-  expectNotEmpty(winter.utf8.endIndex.samePosition(in: winter.unicodeScalars))
+  expectNotNil(winter.utf8.endIndex.samePosition(in: winter.unicodeScalars))
   expectEqual(
     winter.unicodeScalars.endIndex,
     winter.utf8.endIndex.samePosition(in: winter.unicodeScalars)!)
@@ -243,7 +243,7 @@ tests.test("index-mapping/utf8-to-unicode-scalar") {
     }, sameValue: ==
   )
 
-  expectNotEmpty(summer.utf8.endIndex.samePosition(in: summer.unicodeScalars))
+  expectNotNil(summer.utf8.endIndex.samePosition(in: summer.unicodeScalars))
   expectEqual(
     summer.unicodeScalars.endIndex,
     summer.utf8.endIndex.samePosition(in: summer.unicodeScalars)!)
@@ -269,7 +269,7 @@ tests.test("index-mapping/utf16-to-unicode-scalar") {
     }, sameValue: ==
   )
 
-  expectNotEmpty(winter.utf16.endIndex.samePosition(in: winter.unicodeScalars))
+  expectNotNil(winter.utf16.endIndex.samePosition(in: winter.unicodeScalars))
   expectEqual(
     winter.unicodeScalars.endIndex,
     winter.utf16.endIndex.samePosition(in: winter.unicodeScalars)!)
@@ -283,7 +283,7 @@ tests.test("index-mapping/utf16-to-unicode-scalar") {
     }, sameValue: ==
   )
 
-  expectNotEmpty(summer.utf16.endIndex.samePosition(in: summer.unicodeScalars))
+  expectNotNil(summer.utf16.endIndex.samePosition(in: summer.unicodeScalars))
   expectEqual(
     summer.unicodeScalars.endIndex,
     summer.utf16.endIndex.samePosition(in: summer.unicodeScalars)!)
@@ -376,7 +376,7 @@ tests.test("index-mapping/utf8-to-utf16") {
       }
     }, sameValue: ==)
 
-  expectNotEmpty(winter.utf8.endIndex.samePosition(in: winter.utf16))
+  expectNotNil(winter.utf8.endIndex.samePosition(in: winter.utf16))
   expectEqual(
     winter.utf16.endIndex,
     winter.utf8.endIndex.samePosition(in: winter.utf16)!)
@@ -386,7 +386,7 @@ tests.test("index-mapping/utf8-to-utf16") {
     summer.utf8.indices.map { summer.utf16[$0.samePosition(in: summer.utf16)!] }
   )
   
-  expectNotEmpty(summer.utf8.endIndex.samePosition(in: summer.utf16))
+  expectNotNil(summer.utf8.endIndex.samePosition(in: summer.utf16))
   expectEqual(
     summer.utf16.endIndex,
     summer.utf8.endIndex.samePosition(in: summer.utf16)!)
@@ -446,7 +446,7 @@ tests.test("index-mapping/utf8-to-unicode-scalar") {
       }
     }, sameValue: ==)
 
-  expectNotEmpty(winter.utf8.endIndex.samePosition(in: winter.unicodeScalars))
+  expectNotNil(winter.utf8.endIndex.samePosition(in: winter.unicodeScalars))
   expectEqual(
     winter.unicodeScalars.endIndex,
     winter.utf8.endIndex.samePosition(in: winter.unicodeScalars)!)
@@ -459,7 +459,7 @@ tests.test("index-mapping/utf8-to-unicode-scalar") {
       }
     }, sameValue: ==)
 
-  expectNotEmpty(summer.utf8.endIndex.samePosition(in: summer.unicodeScalars))
+  expectNotNil(summer.utf8.endIndex.samePosition(in: summer.unicodeScalars))
   expectEqual(
     summer.unicodeScalars.endIndex,
     summer.utf8.endIndex.samePosition(in: summer.unicodeScalars)!)
@@ -485,7 +485,7 @@ tests.test("index-mapping/utf16-to-unicode-scalar") {
       }
     }, sameValue: ==)
 
-  expectNotEmpty(winter.utf16.endIndex.samePosition(in: winter.unicodeScalars))
+  expectNotNil(winter.utf16.endIndex.samePosition(in: winter.unicodeScalars))
   expectEqual(
     winter.unicodeScalars.endIndex,
     winter.utf16.endIndex.samePosition(in: winter.unicodeScalars)!)
@@ -498,7 +498,7 @@ tests.test("index-mapping/utf16-to-unicode-scalar") {
       }
     }, sameValue: ==)
 
-  expectNotEmpty(summer.utf16.endIndex.samePosition(in: summer.unicodeScalars))
+  expectNotNil(summer.utf16.endIndex.samePosition(in: summer.unicodeScalars))
   expectEqual(
     summer.unicodeScalars.endIndex,
     summer.utf16.endIndex.samePosition(in: summer.unicodeScalars)!)
@@ -555,7 +555,7 @@ tests.test("index-mapping/utf8-to-character") {
       }
     }, sameValue: ==)
 
-  expectNotEmpty(winter.utf8.endIndex.samePosition(in: winter))
+  expectNotNil(winter.utf8.endIndex.samePosition(in: winter))
   expectEqual(
     winter.endIndex,
     winter.utf8.endIndex.samePosition(in: winter)!)
@@ -565,7 +565,7 @@ tests.test("index-mapping/utf8-to-character") {
     summer.utf8.indices.map { summer[$0.samePosition(in: summer)!] }
   )
 
-  expectNotEmpty(summer.utf8.endIndex.samePosition(in: summer))
+  expectNotNil(summer.utf8.endIndex.samePosition(in: summer))
   expectEqual(
     summer.endIndex,
     summer.utf8.endIndex.samePosition(in: summer)!)
@@ -585,7 +585,7 @@ tests.test("index-mapping/utf16-to-character") {
       }
     }, sameValue: ==)
 
-  expectNotEmpty(winter.utf16.endIndex.samePosition(in: winter))
+  expectNotNil(winter.utf16.endIndex.samePosition(in: winter))
   expectEqual(
     winter.endIndex,
     winter.utf16.endIndex.samePosition(in: winter)!)
@@ -597,7 +597,7 @@ tests.test("index-mapping/utf16-to-character") {
     }
   )
 
-  expectNotEmpty(summer.utf16.endIndex.samePosition(in: summer))
+  expectNotNil(summer.utf16.endIndex.samePosition(in: summer))
   expectEqual(
     summer.endIndex,
     summer.utf16.endIndex.samePosition(in: summer)!)

--- a/validation-test/stdlib/StringViews.swift
+++ b/validation-test/stdlib/StringViews.swift
@@ -660,13 +660,13 @@ tests.test("UTF8 indexes") {
             // We only have well-formed UTF16 in this string, so the
             // successor points to a trailing surrogate of a pair and
             // thus shouldn't convert to a UTF8 position
-            expectEmpty(u16.index(after: u16i0a).samePosition(in: u8))
+            expectNil(u16.index(after: u16i0a).samePosition(in: u8))
           }
           
           dsa = dsa.advanced(by: 1) // we're moving off the beginning of a new Unicode scalar
         }
         else {
-          expectEmpty(u8i0a.samePosition(in: u16))
+          expectNil(u8i0a.samePosition(in: u16))
         }
         u8i0a = u8.index(u8i0a, offsetBy: 1)
       }
@@ -708,7 +708,7 @@ tests.test("UTF16->String") {
           continue
         }
       }
-      expectEmpty(String(v[i..<j]))
+      expectNil(String(v[i..<j]))
     }
   }
 }
@@ -724,7 +724,7 @@ tests.test("UTF8->String") {
           continue
         }
       }
-      expectEmpty(String(v[i..<j]))
+      expectNil(String(v[i..<j]))
     }
   }
 }

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -288,12 +288,12 @@ ${SelfName}TestSuite.test("AssociatedTypes") {
 
 ${SelfName}TestSuite.test("nilBaseAddress") {
   let emptyBuffer = ${SelfType}(start: nil, count: 0)
-  expectEmpty(emptyBuffer.baseAddress)
+  expectNil(emptyBuffer.baseAddress)
   expectEqual(0, emptyBuffer.count)
   expectTrue(emptyBuffer.startIndex == emptyBuffer.endIndex)
 
   var iter = emptyBuffer.makeIterator()
-  expectEmpty(iter.next())
+  expectNil(iter.next())
 
   expectEqualSequence([], emptyBuffer)
 }
@@ -308,7 +308,7 @@ ${SelfName}TestSuite.test("nonNilButEmpty") {
   expectTrue(emptyBuffer.startIndex == emptyBuffer.endIndex)
 
   var iter = emptyBuffer.makeIterator()
-  expectEmpty(iter.next())
+  expectNil(iter.next())
 
   expectEqualSequence([], emptyBuffer)
 }
@@ -334,7 +334,7 @@ ${SelfName}TestSuite.test("nonNilNonEmpty") {
   expectEqual(1.0, iter.next())
   expectEqual(0.0, iter.next())
   expectEqual(1.0, iter.next())
-  expectEmpty(iter.next())
+  expectNil(iter.next())
 
   expectEqualSequence([1.0, 0.0, 1.0], buffer)
 


### PR DESCRIPTION
The new names are what people generally expect.  The old names made more sense in the old times when the 'Optional.None' case could not be created with the 'nil' keyword.
