### PR TITLE
[swiftc] COFF does not support PrivateLinkage

### DIFF
--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -186,7 +186,7 @@ static llvm::Function *createDtorFn(IRGenModule &IGM,
                                     const HeapLayout &layout) {
   llvm::Function *fn =
     llvm::Function::Create(IGM.DeallocatingDtorTy,
-                           llvm::Function::PrivateLinkage,
+                           llvm::Function::InternalLinkage,
                            "objectdestroy", &IGM.Module);
   fn->setAttributes(IGM.constructInitialAttributes());
 
@@ -230,7 +230,7 @@ static llvm::Function *createDtorFn(IRGenModule &IGM,
 llvm::Constant *HeapLayout::createSizeFn(IRGenModule &IGM) const {
   llvm::Function *fn =
     llvm::Function::Create(IGM.DeallocatingDtorTy,
-                           llvm::Function::PrivateLinkage,
+                           llvm::Function::InternalLinkage,
                            "objectsize", &IGM.Module);
   fn->setAttributes(IGM.constructInitialAttributes());
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1222,7 +1222,7 @@ createInPlaceMetadataInitializationFunction(IRGenModule &IGM,
   auto fnTy = llvm::FunctionType::get(IGM.VoidTy, {IGM.Int8PtrTy},
                                       /*variadic*/ false);
   llvm::Function *fn = llvm::Function::Create(fnTy,
-                                       llvm::GlobalValue::PrivateLinkage,
+                                       llvm::GlobalValue::InternalLinkage,
                                        Twine("initialize_metadata_")
                                            + type->getDecl()->getName().str(),
                                        &IGM.Module);
@@ -2392,7 +2392,7 @@ namespace {
     auto fnTy = llvm::FunctionType::get(metadataArrayPtrTy,
                                         IGM.TypeMetadataPtrTy,
                                         /*vararg*/ false);
-    auto fn = llvm::Function::Create(fnTy, llvm::GlobalValue::PrivateLinkage,
+    auto fn = llvm::Function::Create(fnTy, llvm::GlobalValue::InternalLinkage,
                                      llvm::Twine("get_field_types_")
                                        + type->getName().str(),
                                      IGM.getModule());
@@ -2925,7 +2925,7 @@ namespace {
       auto ty = llvm::FunctionType::get(IGM.TypeMetadataPtrTy,
                                         argTys, /*isVarArg*/ false);
       llvm::Function *f = llvm::Function::Create(ty,
-                                           llvm::GlobalValue::PrivateLinkage,
+                                           llvm::GlobalValue::InternalLinkage,
                                            llvm::Twine("create_generic_metadata_")
                                                + Target->getName().str(),
                                            &IGM.Module);
@@ -5295,7 +5295,7 @@ namespace {
       auto fnTy = llvm::FunctionType::get(IGM.VoidTy, {IGM.TypeMetadataPtrTy},
                                           /*variadic*/ false);
       llvm::Function *fn = llvm::Function::Create(fnTy,
-                                           llvm::GlobalValue::PrivateLinkage,
+                                           llvm::GlobalValue::InternalLinkage,
                                            Twine("initialize_metadata_")
                                              + type->getDecl()->getName().str(),
                                            &IGM.Module);


### PR DESCRIPTION
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

Changing to `InternalLinkage` works under `Cygwin`, but I think some conditional modification 
to this PR is needed for other platforms. (or this PR should be moved to `LLVM` ?)

I tested under `Cygwin/MinGW`.

The variable and function symbols in object files, generated with `PrivateLinkage` by LLVM,
are show up in symbol table and not internal. One of the symbol name is `Lobjectdestroy`.

I don't know why the letter 'L' is prefixed to the symbol name.

Anyway, it generates duplicate error when linking with other object having same named symbol.

Because the 'objectdestroy' code is not same to all object, ignoring duplicate cann't be the
solution.
