### PR TITLE
[SIL] Add test case for crash triggered in swift::Expr::propagateLValueAccessKind(…)

### DIFF
--- a/validation-test/SIL/crashers/034-swift-expr-propagatelvalueaccesskind.sil
+++ b/validation-test/SIL/crashers/034-swift-expr-propagatelvalueaccesskind.sil
@@ -1,0 +1,4 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+.x.a=Int
+import Swift


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:1: error: expressions are not allowed at the top level
.x.a=Int
^
not an l-value
UNREACHABLE executed at /path/to/swift/include/swift/AST/ExprNodes.def:79!
6  sil-opt         0x000000000309743d llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) + 461
8  sil-opt         0x0000000000e39837 swift::Expr::propagateLValueAccessKind(swift::AccessKind, bool) + 23
12 sil-opt         0x0000000000dc250c swift::Expr::walk(swift::ASTWalker&) + 108
13 sil-opt         0x0000000000b93df2 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 514
14 sil-opt         0x0000000000ae2e86 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 1126
17 sil-opt         0x0000000000bb2a17 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 7671
18 sil-opt         0x0000000000bb750e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4078
19 sil-opt         0x0000000000adf6f7 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 471
20 sil-opt         0x0000000000ae2dd5 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 949
22 sil-opt         0x0000000000b66cd6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
23 sil-opt         0x0000000000b1f3cd swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
24 sil-opt         0x00000000007758a9 swift::CompilerInstance::performSema() + 3289
25 sil-opt         0x000000000075ec65 main + 1813
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  While type-checking expression at [<stdin>:3:1 - line:3:6] RangeText=".x.a=I"
2.  While type-checking expression at [<stdin>:3:1 - line:3:6] RangeText=".x.a=I"
```
