### PR TITLE
[swiftc (52 vs. 5162)] Add crasher in swift::decomposeParamType(...)

### DIFF
--- a/validation-test/compiler_crashers/28406-swift-decomposeparamtype.swift
+++ b/validation-test/compiler_crashers/28406-swift-decomposeparamtype.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+func b<T>
+func b(t:AnyObject
+var f=b()?


### PR DESCRIPTION
Add test case for crash triggered in `swift::decomposeParamType(...)`.

Current number of unresolved compiler crashers: 52 (5162 resolved)

Assertion failure in `llvm/include/llvm/ADT/ArrayRef.h (line 186)`:

```
Assertion `Index < Length && "Invalid index!"' failed.

When executing: const T &llvm::ArrayRef<swift::ParamDecl *>::operator[](size_t) const [T = swift::ParamDecl *]
```

Assertion context:

```

    /// @}
    /// @name Operator Overloads
    /// @{
    const T &operator[](size_t Index) const {
      assert(Index < Length && "Invalid index!");
      return Data[Index];
    }

    /// @}
    /// @name Expensive Operations
```

Stack trace:

```
swift: /path/to/llvm/include/llvm/ADT/ArrayRef.h:186: const T &llvm::ArrayRef<swift::ParamDecl *>::operator[](size_t) const [T = swift::ParamDecl *]: Assertion `Index < Length && "Invalid index!"' failed.
8  swift           0x0000000001165954 swift::decomposeParamType(swift::Type, swift::ValueDecl const*, unsigned int) + 708
12 swift           0x0000000000f95819 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 105
13 swift           0x0000000000f9c09e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4078
14 swift           0x0000000000ec5d77 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 471
15 swift           0x0000000000ec9455 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 949
18 swift           0x0000000000f95819 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 105
19 swift           0x0000000000f9c09e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4078
20 swift           0x0000000000ec5d77 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 471
21 swift           0x0000000000ec9455 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 949
26 swift           0x00000000010aa5eb swift::Expr::walk(swift::ASTWalker&) + 75
27 swift           0x000000000112425b swift::Expr::forEachImmediateChildExpr(std::function<swift::Expr* (swift::Expr*)> const&) + 43
29 swift           0x0000000000f95819 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 105
30 swift           0x0000000000f9c09e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4078
31 swift           0x0000000000ec5d77 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 471
32 swift           0x0000000000ec9455 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 949
33 swift           0x0000000000ecd7e0 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 352
34 swift           0x0000000000ecd9d5 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 229
37 swift           0x0000000000edfc26 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
39 swift           0x0000000000f4b886 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
40 swift           0x0000000000f0452d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
41 swift           0x0000000000c86e69 swift::CompilerInstance::performSema() + 3289
43 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
44 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28406-swift-decomposeparamtype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28406-swift-decomposeparamtype-072c9e.o
1.  While type-checking declaration 0x65c9410 at validation-test/compiler_crashers/28406-swift-decomposeparamtype.swift:12:1
2.  While type-checking expression at [validation-test/compiler_crashers/28406-swift-decomposeparamtype.swift:12:7 - line:12:10] RangeText="b()?"
3.  While type-checking expression at [validation-test/compiler_crashers/28406-swift-decomposeparamtype.swift:12:7 - line:12:10] RangeText="b()?"
4.  While type-checking expression at [validation-test/compiler_crashers/28406-swift-decomposeparamtype.swift:12:7 - line:12:9] RangeText="b()"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
