### PR TITLE
[SourceKit] Add test case for crash triggered in swift::PersistentParserState::delayTopLevel(…)

### DIFF
--- a/validation-test/IDE/crashers/085-swift-persistentparserstate-delaytoplevel.swift
+++ b/validation-test/IDE/crashers/085-swift-persistentparserstate-delaytoplevel.swift
@@ -1,0 +1,4 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+class A{let:e({var _={"
+}#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 151
swift-ide-test: /path/to/swift/lib/Parse/PersistentParserState.cpp:76: void swift::PersistentParserState::delayDecl(swift::PersistentParserState::DelayedDeclKind, unsigned int, swift::DeclContext *, swift::SourceRange, swift::SourceLoc): Assertion `!CodeCompletionDelayedDeclState.get() && "only one decl can be delayed for code completion"' failed.
9  swift-ide-test  0x0000000000937ec5 swift::PersistentParserState::delayTopLevel(swift::TopLevelCodeDecl*, swift::SourceRange, swift::SourceLoc) + 37
10 swift-ide-test  0x000000000092626f swift::Parser::consumeTopLevelDecl(swift::Parser::ParserPosition, swift::TopLevelCodeDecl*) + 143
11 swift-ide-test  0x0000000000926e21 swift::Parser::parseBraceItems(llvm::SmallVectorImpl<swift::ASTNode>&, swift::BraceItemListKind, swift::BraceItemListKind) + 2929
12 swift-ide-test  0x00000000008bd01c swift::Parser::parseTopLevel() + 156
13 swift-ide-test  0x00000000008f28d0 swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) + 208
14 swift-ide-test  0x00000000007abc46 swift::CompilerInstance::performSema() + 3254
15 swift-ide-test  0x000000000074d981 main + 36401
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  With parser at source location: <INPUT-FILE>:4:3
```
