### PR TITLE
[swiftc (53 vs. 5162)] Add crasher in swift::GenericSignature::getSubstitutionMap(...)

### DIFF
--- a/validation-test/compiler_crashers/28407-swift-genericsignature-getsubstitutionmap.swift
+++ b/validation-test/compiler_crashers/28407-swift-genericsignature-getsubstitutionmap.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+class A{class S<T>func b<T{class A:S<T>


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignature::getSubstitutionMap(...)`.

Current number of unresolved compiler crashers: 53 (5162 resolved)

Stack trace:

```
4  swift           0x000000000112c2eb swift::GenericSignature::getSubstitutionMap(llvm::ArrayRef<swift::Substitution>, swift::SubstitutionMap&) const + 27
5  swift           0x000000000112c2bf swift::GenericSignature::getSubstitutionMap(llvm::ArrayRef<swift::Substitution>) const + 47
6  swift           0x0000000001167a6c swift::TypeBase::getSuperclass(swift::LazyResolver*) + 220
7  swift           0x000000000117b431 swift::ConformanceLookupTable::getConformance(swift::NominalTypeDecl*, swift::LazyResolver*, swift::ConformanceLookupTable::ConformanceEntry*) + 289
9  swift           0x000000000117bb54 swift::ConformanceLookupTable::lookupConformances(swift::NominalTypeDecl*, swift::DeclContext*, swift::LazyResolver*, swift::ConformanceLookupKind, llvm::SmallVectorImpl<swift::ProtocolDecl*>*, llvm::SmallVectorImpl<swift::ProtocolConformance*>*, llvm::SmallVectorImpl<swift::ConformanceDiagnostic>*) + 692
10 swift           0x000000000115bcb4 swift::DeclContext::getLocalConformances(swift::ConformanceLookupKind, llvm::SmallVectorImpl<swift::ConformanceDiagnostic>*, bool) const + 212
11 swift           0x0000000000f28ed2 swift::TypeChecker::checkConformancesInContext(swift::DeclContext*, swift::IterableDeclContext*) + 338
14 swift           0x0000000000edfc26 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
17 swift           0x0000000000f4a52a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
18 swift           0x0000000000f4a38e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
19 swift           0x0000000000f4af63 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
21 swift           0x0000000000f045c1 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
22 swift           0x0000000000c86e69 swift::CompilerInstance::performSema() + 3289
24 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
25 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28407-swift-genericsignature-getsubstitutionmap.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28407-swift-genericsignature-getsubstitutionmap-4752b5.o
1.  While type-checking 'b' at validation-test/compiler_crashers/28407-swift-genericsignature-getsubstitutionmap.swift:9:19
2.  While type-checking 'A' at validation-test/compiler_crashers/28407-swift-genericsignature-getsubstitutionmap.swift:9:28
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
