### PR TITLE
[SourceKit] Add test case for crash triggered in swift::PrintOptions::setArchetypeAndDynamicSelfTransform(…)

### DIFF
--- a/validation-test/IDE/crashers/086-swift-printoptions-setarchetypeanddynamicselftransform.swift
+++ b/validation-test/IDE/crashers/086-swift-printoptions-setarchetypeanddynamicselftransform.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+{protocol b{func a#^A^#enum S<T>:b


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 144
swift-ide-test: /path/to/swift/lib/AST/ASTPrinter.cpp:69: std::unique_ptr<llvm::DenseMap<StringRef, Type> > swift::collectNameTypeMap(swift::Type): Assertion `ParamDecls.size() == Args.size()' failed.
9  swift-ide-test  0x0000000000b982b2 swift::PrintOptions::setArchetypeAndDynamicSelfTransform(swift::Type, swift::DeclContext*) + 130
13 swift-ide-test  0x00000000009dd067 swift::TypeChecker::checkConformance(swift::NormalProtocolConformance*) + 2103
14 swift-ide-test  0x00000000009dd577 swift::TypeChecker::checkConformancesInContext(swift::DeclContext*, swift::IterableDeclContext*) + 487
19 swift-ide-test  0x00000000009936e6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
22 swift-ide-test  0x00000000009ffab4 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
23 swift-ide-test  0x0000000000a37d7c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
24 swift-ide-test  0x000000000097d4f6 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 1126
26 swift-ide-test  0x00000000009ffbf6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
27 swift-ide-test  0x00000000009b91dd swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
28 swift-ide-test  0x00000000007abc69 swift::CompilerInstance::performSema() + 3289
29 swift-ide-test  0x000000000074d981 main + 36401
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking expression at [<INPUT-FILE>:3:1 - line:3:30] RangeText="{protocol b{func aenum S<T>:b"
2.  While type-checking 'b' at <INPUT-FILE>:3:2
```
