### PR TITLE
[SourceKit] Add test case for crash triggered in swift::DeclContext::getParentModule()

### DIFF
--- a/validation-test/IDE/crashers/087-swift-declcontext-getparentmodule.swift
+++ b/validation-test/IDE/crashers/087-swift-declcontext-getparentmodule.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+struct c<c>{class a=var f{let c:a{enum e#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 166
4  swift-ide-test  0x0000000000c3a451 swift::DeclContext::getParentModule() const + 1
5  swift-ide-test  0x0000000000b57613 swift::ArchetypeBuilder::mapTypeOutOfContext(swift::DeclContext const*, swift::Type) + 19
6  swift-ide-test  0x0000000000c5818c swift::Mangle::Mangler::mangleType(swift::Type, unsigned int) + 4188
7  swift-ide-test  0x0000000000c5a6fd swift::Mangle::Mangler::mangleBoundGenericType(swift::Type) + 269
8  swift-ide-test  0x0000000000c59432 swift::Mangle::Mangler::mangleDeclType(swift::ValueDecl const*, unsigned int) + 242
9  swift-ide-test  0x0000000000c565fd swift::Mangle::Mangler::mangleNominalType(swift::NominalTypeDecl const*) + 157
10 swift-ide-test  0x0000000000c990d9 swift::ide::printDeclUSR(swift::ValueDecl const*, llvm::raw_ostream&) + 1113
12 swift-ide-test  0x00000000007b45d8 copyAssociatedUSRs(llvm::BumpPtrAllocatorImpl<llvm::MallocAllocator, 4096ul, 4096ul>&, swift::Decl const*) + 104
13 swift-ide-test  0x00000000007b543e swift::ide::CodeCompletionResultBuilder::takeResult() + 1646
17 swift-ide-test  0x0000000000c50bf2 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 562
24 swift-ide-test  0x0000000000bcce84 swift::Decl::walk(swift::ASTWalker&) + 20
25 swift-ide-test  0x0000000000c65a5e swift::SourceFile::walk(swift::ASTWalker&) + 174
26 swift-ide-test  0x0000000000c64b7f swift::ModuleDecl::walk(swift::ASTWalker&) + 79
27 swift-ide-test  0x0000000000c3b90b swift::DeclContext::walkContext(swift::ASTWalker&) + 187
28 swift-ide-test  0x00000000008f29c8 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 136
29 swift-ide-test  0x00000000007abd9d swift::CompilerInstance::performSema() + 3597
30 swift-ide-test  0x000000000074d981 main + 36401
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl 'c' at <INPUT-FILE>:3:1
```
