### PR TITLE
[swiftc (54 vs. 5162)] Add crasher in swift::TypeChecker::checkInheritanceClause(...)

### DIFF
--- a/validation-test/compiler_crashers/28408-swift-typechecker-checkinheritanceclause.swift
+++ b/validation-test/compiler_crashers/28408-swift-typechecker-checkinheritanceclause.swift
@@ -1,0 +1,19 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+class A{{
+{
+}}
+var _=
+{func<a}class A{
+protocol A{typealias d
+extension{
+protocol a{
+struct g:d{
+func<


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::checkInheritanceClause(...)`.

Current number of unresolved compiler crashers: 54 (5162 resolved)

Assertion failure in [`lib/AST/GenericEnvironment.cpp (line 58)`](https://github.com/apple/swift/blob/master/lib/AST/GenericEnvironment.cpp#L58):

```
Assertion `!type->hasArchetype() && "not fully substituted"' failed.

When executing: swift::Type swift::GenericEnvironment::mapTypeOutOfContext(swift::ModuleDecl *, swift::Type) const
```

Assertion context:

```
  return ctx.Allocate(bytes, alignof(GenericEnvironment), AllocationArena::Permanent);
}

Type GenericEnvironment::mapTypeOutOfContext(ModuleDecl *M, Type type) const {
  type = type.subst(M, ArchetypeToInterfaceMap, SubstFlags::AllowLoweredTypes);
  assert(!type->hasArchetype() && "not fully substituted");
  return type;
}

Type GenericEnvironment::mapTypeIntoContext(ModuleDecl *M, Type type) const {
  type = type.subst(M, InterfaceToArchetypeMap, SubstFlags::AllowLoweredTypes);
```

Stack trace:

```
swift: /path/to/swift/lib/AST/GenericEnvironment.cpp:58: swift::Type swift::GenericEnvironment::mapTypeOutOfContext(swift::ModuleDecl *, swift::Type) const: Assertion `!type->hasArchetype() && "not fully substituted"' failed.
9  swift           0x0000000000ed8032 swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 5442
10 swift           0x0000000000ed9617 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 375
11 swift           0x0000000000ed9570 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 208
14 swift           0x000000000114874d swift::namelookup::lookupVisibleDeclsInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >) + 1101
15 swift           0x000000000112ec12 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 1746
16 swift           0x0000000000f1f652 swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::Type, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) + 290
17 swift           0x0000000000ec53fa swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 4058
19 swift           0x00000000010aa5bb swift::Expr::walk(swift::ASTWalker&) + 27
20 swift           0x0000000000ec5c80 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 224
21 swift           0x0000000000ec9455 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 949
24 swift           0x0000000000f4b744 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
25 swift           0x0000000000f78aec swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
26 swift           0x0000000000ec9506 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 1126
27 swift           0x0000000000ecd7e0 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 352
28 swift           0x0000000000ecd9d5 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 229
33 swift           0x0000000000edfc26 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
34 swift           0x0000000000f044c2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
35 swift           0x0000000000c86e69 swift::CompilerInstance::performSema() + 3289
37 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
38 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28408-swift-typechecker-checkinheritanceclause.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28408-swift-typechecker-checkinheritanceclause-0af88b.o
1.  While type-checking 'A' at validation-test/compiler_crashers/28408-swift-typechecker-checkinheritanceclause.swift:10:1
2.  While type-checking expression at [validation-test/compiler_crashers/28408-swift-typechecker-checkinheritanceclause.swift:14:1 - line:14:8] RangeText="{func<a}"
3.  While type-checking expression at [validation-test/compiler_crashers/28408-swift-typechecker-checkinheritanceclause.swift:14:7 - line:14:7] RangeText="a"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
