### PR TITLE
[SourceKit] Add test case for crash triggered in swift::TypeChecker::performTypoCorrection(…)

### DIFF
--- a/validation-test/IDE/crashers/088-swift-typechecker-performtypocorrection.swift
+++ b/validation-test/IDE/crashers/088-swift-typechecker-performtypocorrection.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+let a{enum S{var f=A.a class A:A#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 158
swift-ide-test: /path/to/swift/lib/AST/LookupVisibleDecls.cpp:566: void lookupVisibleMemberDeclsImpl(swift::Type, swift::VisibleDeclConsumer &, const swift::DeclContext *, (anonymous namespace)::LookupState, swift::DeclVisibilityKind, swift::LazyResolver *, VisitedSet &): Assertion `BaseTy.getPointer() != CurClass->getSuperclass().getPointer() && "type is its own superclass"' failed.
10 swift-ide-test  0x00000000009d3c4b swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::Type, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) + 267
12 swift-ide-test  0x0000000000a54d43 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 2899
13 swift-ide-test  0x0000000000a5aade swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4078
14 swift-ide-test  0x0000000000979d67 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 471
15 swift-ide-test  0x000000000097d445 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 949
16 swift-ide-test  0x00000000009817d0 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 352
17 swift-ide-test  0x00000000009819c5 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 229
22 swift-ide-test  0x00000000009936e6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
25 swift-ide-test  0x00000000009fe89a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
26 swift-ide-test  0x00000000009fe6fe swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
27 swift-ide-test  0x00000000009bb5df swift::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 655
33 swift-ide-test  0x0000000000bcce84 swift::Decl::walk(swift::ASTWalker&) + 20
34 swift-ide-test  0x0000000000c65a5e swift::SourceFile::walk(swift::ASTWalker&) + 174
35 swift-ide-test  0x0000000000c64b7f swift::ModuleDecl::walk(swift::ASTWalker&) + 79
36 swift-ide-test  0x0000000000c3b90b swift::DeclContext::walkContext(swift::ASTWalker&) + 187
37 swift-ide-test  0x00000000008f29c8 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 136
38 swift-ide-test  0x00000000007abd9d swift::CompilerInstance::performSema() + 3597
39 swift-ide-test  0x000000000074d981 main + 36401
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl getter for a at <INPUT-FILE>:3:6
2.  While type-checking 'S' at <INPUT-FILE>:3:7
3.  While type-checking expression at [<INPUT-FILE>:3:20 - line:3:22] RangeText="A.a"
```
