### PR TITLE
[swiftc (55 vs. 5162)] Add crasher in swift::GenericEnvironment::mapTypeIntoContext(...)

### DIFF
--- a/validation-test/compiler_crashers/28409-swift-archetypebuilder-maptypeintocontext.swift
+++ b/validation-test/compiler_crashers/28409-swift-archetypebuilder-maptypeintocontext.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+{
+protocol A{enum S<T where S:t>:T.G.a
+enum S


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericEnvironment::mapTypeIntoContext(...)`.

Current number of unresolved compiler crashers: 55 (5162 resolved)

Stack trace:

```
4  swift           0x000000000112b26b swift::GenericEnvironment::mapTypeIntoContext(swift::ModuleDecl*, swift::Type) const + 27
10 swift           0x0000000000edfc26 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
13 swift           0x0000000000f4b744 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
14 swift           0x0000000000f78aec swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
15 swift           0x0000000000ec9506 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 1126
17 swift           0x0000000000f4b886 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
18 swift           0x0000000000f0452d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
19 swift           0x0000000000c86e69 swift::CompilerInstance::performSema() + 3289
21 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
22 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28409-swift-archetypebuilder-maptypeintocontext.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28409-swift-archetypebuilder-maptypeintocontext-ca7bb4.o
1.  While type-checking expression at [validation-test/compiler_crashers/28409-swift-archetypebuilder-maptypeintocontext.swift:9:1 - line:11:6] RangeText="{
2.  While type-checking 'A' at validation-test/compiler_crashers/28409-swift-archetypebuilder-maptypeintocontext.swift:10:1
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
