### PR TITLE
[swiftc (56 vs. 5162)] Add crasher in swift::TypeChecker::typeCheckDecl(...)

### DIFF
--- a/validation-test/compiler_crashers/28410-swift-typechecker-typecheckdecl.swift
+++ b/validation-test/compiler_crashers/28410-swift-typechecker-typecheckdecl.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+func g<a{{}associatedtype B<T
+struct A{let f:e
+}
+typealias e:T


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::typeCheckDecl(...)`.

Current number of unresolved compiler crashers: 56 (5162 resolved)

Assertion failure in [`lib/Sema/TypeCheckDecl.cpp (line 4773)`](https://github.com/apple/swift/blob/master/lib/Sema/TypeCheckDecl.cpp#L4773):

```
Assertion `!FD->getType()->hasTypeParameter()' failed.

When executing: void (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl *)
```

Assertion context:

```

    if (FD->isInvalid())
      return;

    // This type check should have created a non-dependent type.
    assert(!FD->getType()->hasTypeParameter());

    validateAttributes(TC, FD);

    // Member functions need some special validation logic.
    if (FD->getDeclContext()->isTypeContext()) {
```

Stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckDecl.cpp:4773: void (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl *): Assertion `!FD->getType()->hasTypeParameter()' failed.
10 swift           0x0000000000edfc26 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
11 swift           0x0000000000f5dc35 swift::addTrivialAccessorsToStorage(swift::AbstractStorageDecl*, swift::TypeChecker&) + 485
12 swift           0x0000000000f64b2d swift::maybeAddAccessorsToVariable(swift::VarDecl*, swift::TypeChecker&) + 2349
13 swift           0x0000000000ed9f4c swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 2732
14 swift           0x0000000000f6519e swift::createImplicitConstructor(swift::TypeChecker&, swift::NominalTypeDecl*, swift::ImplicitConstructorKind) + 398
15 swift           0x0000000000ee5017 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 1639
18 swift           0x0000000000edfc26 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
21 swift           0x0000000000f4a52a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
22 swift           0x0000000000f4a38e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
23 swift           0x0000000000f4af63 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
25 swift           0x0000000000f045c1 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
26 swift           0x0000000000c86e69 swift::CompilerInstance::performSema() + 3289
28 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
29 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28410-swift-typechecker-typecheckdecl.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28410-swift-typechecker-typecheckdecl-96fda3.o
1.  While type-checking 'g' at validation-test/compiler_crashers/28410-swift-typechecker-typecheckdecl.swift:10:1
2.  While type-checking 'A' at validation-test/compiler_crashers/28410-swift-typechecker-typecheckdecl.swift:11:1
3.  While type-checking getter for f at validation-test/compiler_crashers/28410-swift-typechecker-typecheckdecl.swift:11:14
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
