### PR TITLE
[Coverage] Re-enable smoke test post stable-merge

### DIFF
--- a/test/SILGen/coverage_smoke.swift
+++ b/test/SILGen/coverage_smoke.swift
@@ -11,7 +11,6 @@
 
 // REQUIRES: profile_runtime
 // REQUIRES: OS=macosx
-// REQUIRES: rdar28221303
 
 // CHECK-INTERNAL: Functions shown: 1
 // CHECK-COV: {{ *}}[[@LINE+1]]|{{ *}}1{{.*}}func f_internal
@@ -64,10 +63,10 @@ func foo() {
 }
 
 // rdar://problem/27874041 - top level code decls get no coverage
-var g1 : Int32 = 0   // CHECK-COV: |{{.*}}[[@LINE]]
-repeat {             // CHECK-COV: 1|{{.*}}[[@LINE]]
-  g1 += 1            // CHECK-COV: 1|{{.*}}[[@LINE]]
-} while g1 == 0      // CHECK-COV: 1|{{.*}}[[@LINE]]
+var g1 : Int32 = 0   // CHECK-COV: {{ *}}[[@LINE]]|
+repeat {             // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+  g1 += 1            // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+} while g1 == 0      // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
 
-main() // CHECK-COV: 1{{.*}}[[@LINE]]
-foo()  // CHECK-COV: 1{{.*}}[[@LINE]]
+main() // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+foo()  // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1


### PR DESCRIPTION
Tweak the expected output so the line numbers are in the right location.

rdar://problem/28221303 Re-enable SILGen/coverage_smoke after we move to a newer LLVM/Clang
