### PR TITLE
[SR-2512] Ignore duplicate conditions when optimizing switch statement

### DIFF
--- a/test/SILOptimizer/simplify_cfg_unique_values.sil
+++ b/test/SILOptimizer/simplify_cfg_unique_values.sil
@@ -1,0 +1,90 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -simplify-cfg | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+enum DupCaseEnum {
+  case firstCase
+  case secondCase
+}
+
+// CHECK-LABEL: sil @performSwitch : $@convention(thin) (Int, @thin DupCaseEnum.Type) -> DupCaseEnum {
+// CHECK: bb0(%0 : $Int, %1 : $@thin DupCaseEnum.Type):
+// CHECK:   select_value
+// CHECK:   br bb1
+// CHECK: bb1:
+// CHECK:   return
+sil @performSwitch : $@convention(thin) (Int, @thin DupCaseEnum.Type) -> DupCaseEnum {
+// %0                                             // users: %9, %5, %3, %2
+bb0(%0 : $Int, %1 : $@thin DupCaseEnum.Type):
+  %4 = integer_literal $Builtin.Int64, 0 // user: %6
+  %5 = struct_extract %0 : $Int, #Int._value // user: %6
+  %6 = builtin "cmp_eq_Int64"(%4 : $Builtin.Int64, %5 : $Builtin.Int64) : $Builtin.Int1 // users: %10, %7
+  cond_br %6, bb6, bb1                   // id: %7
+
+bb1:                                              // Preds: bb0
+  br bb2                                 // id: %8
+
+bb2:                                              // Preds: bb1
+  cond_br %6, bb5, bb3                   // id: %10
+
+bb3:                                              // Preds: bb2
+  br bb4                                 // id: %11
+
+bb4:                                              // Preds: bb3
+  %12 = enum $DupCaseEnum, #DupCaseEnum.secondCase!enumelt // user: %13
+  br bb7(%12 : $DupCaseEnum)                // id: %13
+
+bb5:                                              // Preds: bb2
+  %14 = enum $DupCaseEnum, #DupCaseEnum.firstCase!enumelt // user: %15
+  br bb7(%14 : $DupCaseEnum)                // id: %15
+
+bb6:                                              // Preds: bb0
+  %16 = enum $DupCaseEnum, #DupCaseEnum.firstCase!enumelt // user: %17
+  br bb7(%16 : $DupCaseEnum)                // id: %17
+
+// %18                                            // user: %19
+bb7(%18 : $DupCaseEnum):                             // Preds: bb6 bb5 bb4
+  return %18 : $DupCaseEnum                 // id: %19
+}
+
+// CHECK-LABEL: sil @performSwitch_bail_out : $@convention(thin) (Int, @thin DupCaseEnum.Type) -> DupCaseEnum {
+// CHECK: bb0(%0 : $Int, %1 : $@thin DupCaseEnum.Type):
+// CHECK-NOT:   select_value
+// CHECK-NOT:   br bb1
+// CHECK:   cond_br
+sil @performSwitch_bail_out : $@convention(thin) (Int, @thin DupCaseEnum.Type) -> DupCaseEnum {
+// %0                                             // users: %9, %5, %3, %2
+bb0(%0 : $Int, %1 : $@thin DupCaseEnum.Type):
+  %4 = integer_literal $Builtin.Int64, 0 // user: %6
+  %5 = struct_extract %0 : $Int, #Int._value // user: %6
+  %6 = builtin "cmp_eq_Int64"(%4 : $Builtin.Int64, %5 : $Builtin.Int64) : $Builtin.Int1 // users: %10, %7
+  cond_br %6, bb6, bb1                   // id: %7
+
+bb1:                                              // Preds: bb0
+  br bb2                                 // id: %8
+
+bb2:                                              // Preds: bb1
+  cond_br %6, bb5, bb3                   // id: %10
+
+bb3:                                              // Preds: bb2
+  br bb4                                 // id: %11
+
+bb4:                                              // Preds: bb3
+  %12 = enum $DupCaseEnum, #DupCaseEnum.secondCase!enumelt // user: %13
+  br bb7(%12 : $DupCaseEnum)                // id: %13
+
+bb5:                                              // Preds: bb2
+  %14 = enum $DupCaseEnum, #DupCaseEnum.secondCase!enumelt // user: %15
+  br bb7(%14 : $DupCaseEnum)                // id: %15
+
+bb6:                                              // Preds: bb0
+  %16 = enum $DupCaseEnum, #DupCaseEnum.firstCase!enumelt // user: %17
+  br bb7(%16 : $DupCaseEnum)                // id: %17
+
+// %18                                            // user: %19
+bb7(%18 : $DupCaseEnum):                             // Preds: bb6 bb5 bb4
+  return %18 : $DupCaseEnum                 // id: %19
+}


### PR DESCRIPTION
This PR resolves issue SR-2512 https://bugs.swift.org/browse/SR-2512 , also see radar rdar://problem/28057990

The second ‘case 0’ in the source code is, naturally, unreachable, here’s the relevant SIL parts after applying CSE and DCE on the problematic function:

  %4 = integer_literal $Builtin.Int64, 0, scope 1 // user: %6
  %5 = struct_extract %0 : $Int, #Int._value, scope 1 // user: %6
  %6 = builtin "cmp_eq_Int64"(%4 : $Builtin.Int64, %5 : $Builtin.Int64) : $Builtin.Int1, scope 1 // users: %10, %7
  cond_br %6, bb6, bb1, scope 1                   // id: %7

bb1:                                              // Preds: bb0
  br bb2, scope 1                                 // id: %8

bb2:                                              // Preds: bb1
  debug_value %0 : $Int, scope 1                  // id: %9
  cond_br %6, bb5, bb3, scope 1                   // id: %10

here’s the relevant SIL output of SimplifyCFG:

  %4 = integer_literal $Builtin.Int64, 0, scope 1 // users: %10, %10, %6
  %5 = struct_extract %0 : $Int, #Int._value, scope 1 // users: %10, %6
  %6 = builtin "cmp_eq_Int64"(%4 : $Builtin.Int64, %5 : $Builtin.Int64) : $Builtin.Int1, scope 1
  %7 = enum $DemoEnum, #DemoEnum.firstCase!enumelt, scope 1 // user: %10
  %8 = enum $DemoEnum, #DemoEnum.firstCase!enumelt, scope 1 // user: %10
  %9 = enum $DemoEnum, #DemoEnum.secondCase!enumelt, scope 1 // user: %10
  %10 = select_value %5 : $Builtin.Int64, case %4: %7, case %4: %8, default %9 : $DemoEnum, scope 1 // user: %12

As can be clearly seen, the same case / condition is added twice in select_value, this bug was resolved by adding a check that makes sure we don't add the same case more than once.

relevant output after bugix:
  %6 = builtin "cmp_eq_Int64"(%4 : $Builtin.Int64, %5 : $Builtin.Int64) : $Builtin.Int1, scope 6
  %7 = enum $DemoEnum, #DemoEnum.firstCase!enumelt, scope 6 // user: %9
  %8 = enum $DemoEnum, #DemoEnum.secondCase!enumelt, scope 6 // user: %9
  %9 = select_value %5 : $Builtin.Int64, case %4: %7, default %8 : $DemoEnum, scope 6 // user: %11
