### PR TITLE
Provide a fix-it when overriding 'Any' with 'AnyObject'.

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1143,7 +1143,14 @@ bool swift::fixItOverrideDeclarationTypes(TypeChecker &TC,
     // ...and just knowing that it's bridged isn't good enough if we don't
     // know what it's bridged /to/. Also, don't do this check for trivial
     // bridging---that doesn't count.
-    Type bridged = TC.Context.getBridgedToObjC(DC, normalizedBaseTy);
+    Type bridged;
+    if (normalizedBaseTy->isAny()) {
+      const ProtocolDecl *anyObjectProto =
+          TC.Context.getProtocol(KnownProtocolKind::AnyObject);
+      bridged = anyObjectProto->getDeclaredType();
+    } else {
+      bridged = TC.Context.getBridgedToObjC(DC, normalizedBaseTy);
+    }
     if (!bridged || bridged->isEqual(normalizedBaseTy))
       return false;
 

--- a/test/ClangModules/objc_bridging_custom.swift
+++ b/test/ClangModules/objc_bridging_custom.swift
@@ -23,6 +23,7 @@ class Base : NSObject {
   class func testInout(_: inout Refrigerator) {} // expected-note {{potential overridden class method 'testInout' here}}
   func testUnmigrated(a: NSRuncingMode, b: Refrigerator, c: NSCoding) {} // expected-note {{potential overridden instance method 'testUnmigrated(a:b:c:)' here}}
   func testPartialMigrated(a: NSRuncingMode, b: Refrigerator) {} // expected-note {{potential overridden instance method 'testPartialMigrated(a:b:)' here}}
+  func testAny(a: Any, b: Any) -> Any? {} // expected-note {{potential overridden instance method 'testAny(a:b:)' here}}
 
   subscript(a a: Refrigerator, b b: Refrigerator) -> Refrigerator? { // expected-note {{potential overridden subscript 'subscript(a:b:)' here}} {{none}}
     return nil
@@ -57,6 +58,9 @@ class Sub : Base {
 
   // expected-note@+1 {{type does not match superclass instance method with type '(NSRuncingMode, Refrigerator) -> ()'}} {{53-68=Refrigerator}}
   override func testPartialMigrated(a: NSObject, b: APPRefrigerator) {} // expected-error {{method does not override any method from its superclass}} {{none}}
+
+  // expected-note@+1 {{type does not match superclass instance method with type '(Any, Any) -> Any?'}} {{28-37=Any}} {{42-52=Any?}} {{57-66=Any}}
+  override func testAny(a: AnyObject, b: AnyObject?) -> AnyObject {} // expected-error {{method does not override any method from its superclass}}
 
   // expected-note@+1 {{type does not match superclass subscript with type '(Refrigerator, Refrigerator) -> Refrigerator?'}} {{27-42=Refrigerator}} {{49-65=Refrigerator?}} {{70-85=Refrigerator}}
   override subscript(a a: APPRefrigerator, b b: APPRefrigerator?) -> APPRefrigerator { // expected-error {{subscript does not override any subscript from its superclass}} {{none}}


### PR DESCRIPTION
This helps when manually migrating Swift 2 code to Swift 3, which includes SE-0116 (id-as-Any). We already did this for specific bridged types (like URL and NSURL); this just adds a special case for Any/AnyObject.

rdar://problem/27865590
