### PR TITLE
[Coverage] Do not map function decls with no body

### DIFF
--- a/lib/SILGen/SILGenProfiling.cpp
+++ b/lib/SILGen/SILGenProfiling.cpp
@@ -30,6 +30,10 @@ using namespace swift;
 using namespace Lowering;
 
 static bool isUnmappedDecl(Decl *D) {
+  if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D))
+    if (!AFD->getBody())
+      return true;
+
   if (isa<ConstructorDecl>(D) || isa<DestructorDecl>(D))
     return false;
 

--- a/test/SILGen/coverage_closures.swift
+++ b/test/SILGen/coverage_closures.swift
@@ -27,5 +27,11 @@ func foo() {
   f1 { left, right in left == 0 || right == 1 }
 }
 
+// SR-2615: Implicit constructor decl has no body, and shouldn't be mapped
+struct C1 {
+// CHECK-NOT: sil_coverage_map{{.*}}errors
+  private var errors = [String]()
+}
+
 bar(arr: [{ x in x }])
 foo()


### PR DESCRIPTION
Resolves [SR-2615](https://bugs.swift.org/browse/SR-2615).

We can't place counters on function decls with no bodies. The old
behavior was to map a fresh counter to a null AST node, which is highly
suspicious at best.
rdar://problem/28283331