### PR TITLE
[swift-3.0-branch] Make `Sequence.first(where:)` a pure protocol extension

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
@@ -82,7 +82,6 @@ public class SequenceLog {
   public static var map = TypeIndexed(0)
   public static var filter = TypeIndexed(0)
   public static var forEach = TypeIndexed(0)
-  public static var first = TypeIndexed(0)
   public static var dropFirst = TypeIndexed(0)
   public static var dropLast = TypeIndexed(0)
   public static var prefixMaxLength = TypeIndexed(0)
@@ -115,6 +114,7 @@ public class CollectionLog : SequenceLog {
   public static var isEmpty = TypeIndexed(0)
   public static var count = TypeIndexed(0)
   public static var _customIndexOfEquatableElement = TypeIndexed(0)
+  public static var first = TypeIndexed(0)
   public static var advance = TypeIndexed(0)
   public static var advanceLimit = TypeIndexed(0)
   public static var distance = TypeIndexed(0)
@@ -242,13 +242,6 @@ public struct ${Self}<
   ) rethrows {
     Log.forEach[selfType] += 1
     try base.forEach(body)
-  }
-  
-  public func first(
-    where predicate: (Base.Iterator.Element) throws -> Bool
-  ) rethrows -> Base.Iterator.Element? {
-    Log.first[selfType] += 1
-    return try base.first(where: predicate)
   }
 
   public typealias SubSequence = Base.SubSequence

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -566,17 +566,6 @@ public protocol Sequence {
     whereSeparator isSeparator: (Iterator.Element) throws -> Bool
   ) rethrows -> [SubSequence]
 
-  /// Returns the first element of the sequence that satisfies the given
-  /// predicate or nil if no such element is found.
-  ///
-  /// - Parameter predicate: A closure that takes an element of the
-  ///   sequence as its argument and returns a Boolean value indicating
-  ///   whether the element is a match.
-  /// - Returns: The first match or `nil` if there was no match.
-  func first(
-    where predicate: (Iterator.Element) throws -> Bool
-  ) rethrows -> Iterator.Element?
-
   func _customContainsEquatableElement(
     _ element: Iterator.Element
   ) -> Bool?

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -942,16 +942,6 @@ SequenceTypeTests.test("forEach/dispatch") {
 }
 
 //===----------------------------------------------------------------------===//
-// first()
-//===----------------------------------------------------------------------===//
-
-SequenceTypeTests.test("first/dispatch") {
-  let tester = SequenceLog.dispatchTester([OpaqueValue(1)])
-  _ = tester.first { $0.value == 1 }
-  expectCustomizable(tester, tester.log.first)
-}
-
-//===----------------------------------------------------------------------===//
 // dropFirst()
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
- Explanation: Sequence.first(where:) should not be a protocol requirement
- Scope of Issue: The method was first introduced as part of SE-0032 implementation.
- Origination: Incorrect implementation of the original proposal
- Risk: Minimal
- Reviewed By: Dmitri Gribenko
- Testing: Running the test suite
- Directions for QA: N/A

rdar://problem/28266569

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
