### PR TITLE
Provide a fix-it when overriding 'Any' with 'AnyObject'.

### DIFF
--- a/test/ClangModules/objc_bridging_custom.swift
+++ b/test/ClangModules/objc_bridging_custom.swift
@@ -23,6 +23,7 @@ class Base : NSObject {
   class func testInout(_: inout Refrigerator) {} // expected-note {{potential overridden class method 'testInout' here}}
   func testUnmigrated(a: NSRuncingMode, b: Refrigerator, c: NSCoding) {} // expected-note {{potential overridden instance method 'testUnmigrated(a:b:c:)' here}}
   func testPartialMigrated(a: NSRuncingMode, b: Refrigerator) {} // expected-note {{potential overridden instance method 'testPartialMigrated(a:b:)' here}}
+  func testAny(a: Any, b: Any) -> Any? {} // expected-note {{potential overridden instance method 'testAny(a:b:)' here}}
 
   subscript(a a: Refrigerator, b b: Refrigerator) -> Refrigerator? { // expected-note {{potential overridden subscript 'subscript(a:b:)' here}} {{none}}
     return nil
@@ -57,6 +58,9 @@ class Sub : Base {
 
   // expected-note@+1 {{type does not match superclass instance method with type '(NSRuncingMode, Refrigerator) -> ()'}} {{53-68=Refrigerator}}
   override func testPartialMigrated(a: NSObject, b: APPRefrigerator) {} // expected-error {{method does not override any method from its superclass}} {{none}}
+
+  // expected-note@+1 {{type does not match superclass instance method with type '(Any, Any) -> Any?'}} {{28-37=Any}} {{42-52=Any?}} {{57-66=Any}}
+  override func testAny(a: AnyObject, b: AnyObject?) -> AnyObject {} // expected-error {{method does not override any method from its superclass}}
 
   // expected-note@+1 {{type does not match superclass subscript with type '(Refrigerator, Refrigerator) -> Refrigerator?'}} {{27-42=Refrigerator}} {{49-65=Refrigerator?}} {{70-85=Refrigerator}}
   override subscript(a a: APPRefrigerator, b b: APPRefrigerator?) -> APPRefrigerator { // expected-error {{subscript does not override any subscript from its superclass}} {{none}}


### PR DESCRIPTION
- **Explanation:** id-as-Any results in people accidentally declaring methods as `override func doTheThing(_ sender: AnyObject?)` instead of `sender: Any?`, either because they've copied some Swift 2 code from the internet, or just from muscle memory. We already have a fix-it (on a note) for doing this with specific bridged types (i.e. writing "NSURL" instead of "URL"), so just add a case to that for AnyObject/Any.
- **Scope:** Affects overrides whose types aren't compatible with the declaration they override. This code is only run once an error has already been emitted.
- **Issue:** rdar://problem/27865590
- **Reviewed by:** @DougGregor 
- **Risk:** Very low. 
- **Testing:** Added a compiler regression test, verified that the originally reported case now works.
