### PR TITLE
[swiftc (57 vs. 5162)] Add crasher in swift::TypeChecker::resolveIdentifierType(...)

### DIFF
--- a/validation-test/compiler_crashers/28411-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/compiler_crashers/28411-swift-typechecker-resolveidentifiertype.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+func b<f{typealias f:f.a{func x(n:f.d


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::resolveIdentifierType(...)`.

Current number of unresolved compiler crashers: 57 (5162 resolved)

Stack trace:

```
6  swift           0x00000000033a62bd llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) + 461
9  swift           0x0000000000f51cb2 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 162
11 swift           0x0000000000f52d54 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
12 swift           0x0000000000f514e3 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 195
14 swift           0x0000000000f21302 swift::TypeChecker::typeCheckParameterList(swift::ParameterList*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) + 114
17 swift           0x0000000000edfc26 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
20 swift           0x0000000000f4b744 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
21 swift           0x0000000000f78aec swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
22 swift           0x0000000000ec9506 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 1126
25 swift           0x0000000000f4a52a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
26 swift           0x0000000000f4a38e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
27 swift           0x0000000000f4af63 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
29 swift           0x0000000000f045c1 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
30 swift           0x0000000000c86e69 swift::CompilerInstance::performSema() + 3289
32 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
33 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28411-swift-typechecker-resolveidentifiertype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28411-swift-typechecker-resolveidentifiertype-b907a1.o
1.  While type-checking 'b' at validation-test/compiler_crashers/28411-swift-typechecker-resolveidentifiertype.swift:9:1
2.  While type-checking expression at [validation-test/compiler_crashers/28411-swift-typechecker-resolveidentifiertype.swift:9:25 - line:9:37] RangeText="{func x(n:f.d"
3.  While type-checking 'x' at validation-test/compiler_crashers/28411-swift-typechecker-resolveidentifiertype.swift:9:26
4.  While resolving type f.d at [validation-test/compiler_crashers/28411-swift-typechecker-resolveidentifiertype.swift:9:35 - line:9:37] RangeText="f.d"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
