### PR TITLE
[swiftc (58 vs. 5162)] Add crasher in swift::SourceFile::LookupCache::lookupClassMembers(...)

### DIFF
--- a/validation-test/compiler_crashers/28412-swift-sourcefile-lookupcache-lookupclassmembers.swift
+++ b/validation-test/compiler_crashers/28412-swift-sourcefile-lookupcache-lookupclassmembers.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+protocol c:AnyObject{@objc protocol A{func b{}func b=enum A{let c=o


### PR DESCRIPTION
Add test case for crash triggered in `swift::SourceFile::LookupCache::lookupClassMembers(...)`.

Current number of unresolved compiler crashers: 58 (5162 resolved)

Assertion failure in `llvm/include/llvm/Support/Casting.h (line 237)`:

```
Assertion `isa<X>(Val) && "cast<Ty>() argument of incompatible type!"' failed.

When executing: typename cast_retty<X, Y *>::ret_type llvm::cast(Y *) [X = swift::AnyFunctionType, Y = swift::TypeBase]
```

Assertion context:

```
                          typename simplify_type<Y>::SimpleType>::doit(Val);
}

template <class X, class Y>
inline typename cast_retty<X, Y *>::ret_type cast(Y *Val) {
  assert(isa<X>(Val) && "cast<Ty>() argument of incompatible type!");
  return cast_convert_val<X, Y*,
                          typename simplify_type<Y*>::SimpleType>::doit(Val);
}

// cast_or_null<X> - Functionally identical to cast, except that a null value is
```

Stack trace:

```
swift: /path/to/llvm/include/llvm/Support/Casting.h:237: typename cast_retty<X, Y *>::ret_type llvm::cast(Y *) [X = swift::AnyFunctionType, Y = swift::TypeBase]: Assertion `isa<X>(Val) && "cast<Ty>() argument of incompatible type!"' failed.
9  swift           0x000000000113bd83 swift::SourceFile::LookupCache::lookupClassMembers(llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::VisibleDeclConsumer&, swift::SourceFile const&) + 787
10 swift           0x000000000113d252 swift::ModuleDecl::lookupClassMembers(llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::VisibleDeclConsumer&) const + 50
12 swift           0x000000000114215d swift::ModuleDecl::forAllVisibleModules(llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, bool, llvm::function_ref<bool (std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>)>) + 477
13 swift           0x00000000011422d1 swift::FileUnit::forAllVisibleModules(llvm::function_ref<bool (std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>)>) + 81
18 swift           0x000000000112e9e4 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 1188
19 swift           0x0000000000f1f652 swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::Type, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) + 290
20 swift           0x0000000000ec53fa swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 4058
22 swift           0x00000000010aa5bb swift::Expr::walk(swift::ASTWalker&) + 27
23 swift           0x0000000000ec5c80 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 224
24 swift           0x0000000000ec9455 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 949
25 swift           0x0000000000ecd7e0 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 352
26 swift           0x0000000000ecd9d5 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 229
35 swift           0x0000000000edfc26 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
36 swift           0x0000000000f044c2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
37 swift           0x0000000000c86e69 swift::CompilerInstance::performSema() + 3289
39 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
40 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28412-swift-sourcefile-lookupcache-lookupclassmembers.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28412-swift-sourcefile-lookupcache-lookupclassmembers-91d26f.o
1.  While type-checking 'c' at validation-test/compiler_crashers/28412-swift-sourcefile-lookupcache-lookupclassmembers.swift:10:1
2.  While type-checking expression at [validation-test/compiler_crashers/28412-swift-sourcefile-lookupcache-lookupclassmembers.swift:10:67 - line:10:67] RangeText="o"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
