### PR TITLE
[swiftc (59 vs. 5162)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28413-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28413-swift-typebase-getcanonicaltype.swift
@@ -1,0 +1,15 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+t c
+let : {{
+return $0
+== Int
+struct B
+}
+g:


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 59 (5162 resolved)

Stack trace:

```
15 swift           0x00000000010aaa04 swift::Decl::walk(swift::ASTWalker&) + 20
16 swift           0x000000000114349e swift::SourceFile::walk(swift::ASTWalker&) + 174
17 swift           0x0000000001090d24 swift::verify(swift::SourceFile&) + 52
18 swift           0x0000000000f04683 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1475
19 swift           0x0000000000c86e69 swift::CompilerInstance::performSema() + 3289
21 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
22 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28413-swift-typebase-getcanonicaltype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28413-swift-typebase-getcanonicaltype-3df5c6.o
1.  While walking into decl declaration 0x5d2b2d0 at validation-test/compiler_crashers/28413-swift-typebase-getcanonicaltype.swift:10:7
2.  While walking into body of declaration 0x5d2b2d0 at validation-test/compiler_crashers/28413-swift-typebase-getcanonicaltype.swift:10:7
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
