### PR TITLE
[swiftc (60 vs. 5162)] Add crasher in swift::TypeChecker::resolveWitness(...)

### DIFF
--- a/validation-test/compiler_crashers/28414-swift-typechecker-resolvewitness.swift
+++ b/validation-test/compiler_crashers/28414-swift-typechecker-resolvewitness.swift
@@ -1,0 +1,17 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+@objc protocol P{
+func a
+typealias a
+class d{protocol c:P{
+{{
+}
+}
+let a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::resolveWitness(...)`.

Current number of unresolved compiler crashers: 60 (5162 resolved)

Assertion failure in [`lib/Sema/TypeCheckProtocol.cpp (line 1826)`](https://github.com/apple/swift/blob/master/lib/Sema/TypeCheckProtocol.cpp#L1826):

```
Assertion `!resultReplacement->isTypeParameter() && "Can't be dependent"' failed.

When executing: swift::Substitution getArchetypeSubstitution(swift::TypeChecker &, swift::DeclContext *, swift::ArchetypeType *, swift::Type)
```

Assertion context:

```
static Substitution getArchetypeSubstitution(TypeChecker &tc,
                                             DeclContext *dc,
                                             ArchetypeType *archetype,
                                             Type replacement) {
  Type resultReplacement = replacement;
  assert(!resultReplacement->isTypeParameter() && "Can't be dependent");
  SmallVector<ProtocolConformanceRef, 4> conformances;

  bool isError = replacement->is<ErrorType>();
  assert((archetype != nullptr || isError) &&
         "Should have built archetypes already");
```

Stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckProtocol.cpp:1826: swift::Substitution getArchetypeSubstitution(swift::TypeChecker &, swift::DeclContext *, swift::ArchetypeType *, swift::Type): Assertion `!resultReplacement->isTypeParameter() && "Can't be dependent"' failed.
11 swift           0x0000000000f2b7f9 swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) + 569
12 swift           0x000000000115a41b swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const + 171
13 swift           0x0000000000f2ad06 swift::TypeChecker::findWitnessedObjCRequirements(swift::ValueDecl const*, bool) + 582
15 swift           0x0000000000eda049 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 2985
16 swift           0x0000000000f1621f swift::TypeChecker::getTypeOfRValue(swift::ValueDecl*, bool) + 15
18 swift           0x0000000000f5d5f3 swift::convertStoredVarInProtocolToComputed(swift::VarDecl*, swift::TypeChecker&) + 19
19 swift           0x0000000000f64b77 swift::maybeAddAccessorsToVariable(swift::VarDecl*, swift::TypeChecker&) + 2423
20 swift           0x0000000000ed9f4c swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 2732
29 swift           0x0000000000edfc26 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
30 swift           0x0000000000f044c2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
31 swift           0x0000000000c86e69 swift::CompilerInstance::performSema() + 3289
33 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
34 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28414-swift-typechecker-resolvewitness.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28414-swift-typechecker-resolvewitness-a8f5bd.o
1.  While type-checking 'P' at validation-test/compiler_crashers/28414-swift-typechecker-resolvewitness.swift:10:7
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
