### PR TITLE
[gardening][Parse] Remove 2 unused flags in Parser

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -121,10 +121,6 @@ public:
     IVOLP_InLet
   } InVarOrLetPattern = IVOLP_NotInVarOrLet;
 
-  /// FIXME: Temporary hack to keep the selector-style declaration
-  /// syntax working.
-  bool ArgumentIsParameter = false;
-
   bool InPoundLineEnvironment = false;
 
   LocalContext *CurLocalContext = nullptr;

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -121,8 +121,6 @@ public:
     IVOLP_InLet
   } InVarOrLetPattern = IVOLP_NotInVarOrLet;
 
-  bool GreaterThanIsOperator = true;
-
   /// FIXME: Temporary hack to keep the selector-style declaration
   /// syntax working.
   bool ArgumentIsParameter = false;
@@ -219,24 +217,6 @@ public:
 
     void pop() {
       CC.pop();
-    }
-  };
-
-  /// A RAII object for temporarily changing whether an operator starting with
-  /// '>' is an operator.
-  class GreaterThanIsOperatorRAII {
-    Parser &P;
-    bool OldValue;
-
-  public:
-    GreaterThanIsOperatorRAII(Parser &p, bool newValue)
-      : P(p), OldValue(p.GreaterThanIsOperator)
-    {
-      P.GreaterThanIsOperator = newValue;
-    }
-
-    ~GreaterThanIsOperatorRAII() {
-      P.GreaterThanIsOperator = OldValue;
     }
   };
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -185,10 +185,6 @@ parse_operator:
     switch (Tok.getKind()) {
     case tok::oper_binary_spaced:
     case tok::oper_binary_unspaced: {
-      // If '>' is not an operator and this token starts with a '>', we're done.
-      if (!GreaterThanIsOperator && startsWithGreater(Tok))
-        goto done;
-
       // If this is an "&& #available()" expression (or related things that
       // show up in a stmt-condition production), then don't eat it.
       //
@@ -1589,10 +1585,6 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
 
     // Check for a postfix-operator suffix.
     if (Tok.is(tok::oper_postfix)) {
-      // If '>' is not an operator and this token starts with a '>', we're done.
-      if (!GreaterThanIsOperator && startsWithGreater(Tok))
-        return Result;
-
       Expr *oper = parseExprOperator();
       Result = makeParserResult(
           new (Context) PostfixUnaryExpr(oper, Result.get()));

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -908,14 +908,8 @@ ParserResult<Pattern> Parser::parsePattern() {
 
 Pattern *Parser::createBindingFromPattern(SourceLoc loc, Identifier name,
                                           bool isLet) {
-  VarDecl *var;
-  if (ArgumentIsParameter) {
-    var = new (Context) ParamDecl(isLet, SourceLoc(), loc, name, loc, name,
-                                  Type(), CurDeclContext);
-  } else {
-    var = new (Context) VarDecl(/*static*/ false, /*IsLet*/ isLet,
-                                loc, name, Type(), CurDeclContext);
-  }
+  auto var = new (Context) VarDecl(/*static*/ false, /*IsLet*/ isLet,
+                                   loc, name, Type(), CurDeclContext);
   return new (Context) NamedPattern(var);
 }
 


### PR DESCRIPTION
Remove 2 unused flags in `Parser`

`GreaterThanIsOperator`(`RAII`): The last usage was removed in 68af974.
`ArgumentIsParameter`: The last usage was removed in 4e4173f.
