### PR TITLE
[SourceKit] Avoid adding indentation at the end of a CaptureListExpr.

### DIFF
--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -366,7 +366,8 @@ public:
     Expr *AtExprEnd = End.getAsExpr();
     if (AtExprEnd && (isa<ClosureExpr>(AtExprEnd) ||
                       isa<ParenExpr>(AtExprEnd) ||
-                      isa<TupleExpr>(AtExprEnd))) {
+                      isa<TupleExpr>(AtExprEnd) ||
+                      isa<CaptureListExpr>(AtExprEnd))) {
 
       if (auto *Paren = dyn_cast_or_null<ParenExpr>(Cursor->getAsExpr())) {
         auto *SubExpr = Paren->getSubExpr();

--- a/test/SourceKit/CodeFormat/indent-closure.swift
+++ b/test/SourceKit/CodeFormat/indent-closure.swift
@@ -32,6 +32,16 @@ func foo4() {
     }()
 }
 
+func foo5(input: Int, block: (Int) -> ()) -> Int {
+  return 0
+}
+
+func foo6() {
+  _ = foo5(input: 0, block: { [unowned self] blockInput in
+    foo4()
+  })
+}
+
 // RUN: %sourcekitd-test -req=format -line=3 -length=1 %s >%t.response
 // RUN: %sourcekitd-test -req=format -line=4 -length=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=5 -length=1 %s >>%t.response
@@ -46,6 +56,7 @@ func foo4() {
 // RUN: %sourcekitd-test -req=format -line=30 -length=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=31 -length=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=32 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=42 -length=1 %s >>%t.response
 // RUN: %FileCheck --strict-whitespace %s <%t.response
 
 // CHECK: key.sourcetext: "        var abc = 1"
@@ -68,3 +79,5 @@ func foo4() {
 // CHECK: key.sourcetext: "    let test = {"
 // CHECK: key.sourcetext: "        return 0"
 // CHECK: key.sourcetext: "    }()"
+
+// CHECK: key.sourcetext: "  })"


### PR DESCRIPTION
Explanation: Just like the end of a closure expression, the end of a CapteurListExpr should not be indented further than the start of the statement. This commit blacklists CapureListExpr when deciding whether we should add indentation at the end of it, if it ends on a separate line.

Scope of issue: Indentation of SourceKit only.

Reviewer: @akyrtzi 

Risk: Low

Radar: rdar://28193169
