### PR TITLE
[sil-devirtualizer] Use a more advanced algorithm to figure out the exact types of instances

### DIFF
--- a/include/swift/SILOptimizer/Utils/Local.h
+++ b/include/swift/SILOptimizer/Utils/Local.h
@@ -16,6 +16,7 @@
 #include "swift/Basic/ArrayRefView.h"
 #include "swift/SILOptimizer/Analysis/ARCAnalysis.h"
 #include "swift/SILOptimizer/Analysis/EpilogueARCAnalysis.h"
+#include "swift/SILOptimizer/Analysis/ClassHierarchyAnalysis.h"
 #include "swift/SILOptimizer/Analysis/SimplifyInstruction.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILBuilder.h"
@@ -693,6 +694,28 @@ void replaceLoadSequence(SILInstruction *I,
 /// Do we have enough information to determine all callees that could
 /// be reached by calling the function represented by Decl?
 bool calleesAreStaticallyKnowable(SILModule &M, SILDeclRef Decl);
+
+// Attempt to get the instance for S, whose static type is the same as
+// its exact dynamic type, returning a null SILValue() if we cannot find it.
+// The information that a static type is the same as the exact dynamic,
+// can be derived e.g.:
+// - from a constructor or
+// - from a successful outcome of a checked_cast_br [exact] instruction.
+SILValue getInstanceWithExactDynamicType(SILValue S, SILModule &M,
+                                         ClassHierarchyAnalysis *CHA);
+
+/// Try to determine the exact dynamic type of an object.
+/// returns the exact dynamic type of the object, or an empty type if the exact
+/// type could not be determined.
+SILType getExactDynamicType(SILValue S, SILModule &M,
+                            ClassHierarchyAnalysis *CHA,
+                            bool ForUnderlyingObject = false);
+
+/// Try to statically determine the exact dynamic type of the underlying object.
+/// returns the exact dynamic type of the underlying object, or an empty SILType
+/// if the exact type could not be determined.
+SILType getExactDynamicTypeOfUnderlyingObject(SILValue S, SILModule &M,
+                                              ClassHierarchyAnalysis *CHA);
 
 /// Hoist the address projection rooted in \p Op to \p InsertBefore.
 /// Requires the projected value to dominate the insertion point.

--- a/test/SILOptimizer/devirtualize2.sil
+++ b/test/SILOptimizer/devirtualize2.sil
@@ -74,6 +74,36 @@ bb6:
   return %7 : $()
 }
 
+// CHECK-LABEL: sil @function_with_cm_with_dynamic_type_known_from_incoming_bb_args
+// CHECK-NOT: class_method
+// CHECK: bb3([[SELF:%.*]] : $Bar):
+// CHECK: [[REF:%.*]] = function_ref @_TFC4main3Bar4pingfS0_FT_T_
+// CHECK: apply [[REF]]([[SELF]])
+// CHECK: return
+sil @function_with_cm_with_dynamic_type_known_from_incoming_bb_args : $@convention(thin) (Builtin.Int1) -> () {
+bb0(%0 : $Builtin.Int1):
+  cond_br %0, bb1, bb2
+
+bb1:
+  %1 = alloc_ref $Bar
+  br bb3(%1 : $Bar)
+
+bb2:
+  %2 = alloc_ref $Bar
+  br bb3(%2 : $Bar)
+
+bb3(%4 : $Bar):
+  // Devirtualizer should be able to figure out that the exact dynamic type of %4 is Bar.
+  %5 = class_method %4 : $Bar, #Bar.ping!1 : (Bar) -> () -> () , $@convention(method) (@guaranteed Bar) -> ()
+  %6 = apply %5(%4) : $@convention(method) (@guaranteed Bar) -> ()
+  br bb4
+
+bb4:
+  strong_release %4 : $Bar
+  %7 = tuple ()
+  return %7 : $()
+}
+
 
 sil @_TFC4main3Bar4pingfS0_FT_T_ : $@convention(method) (@guaranteed Bar) -> ()
 sil @_TFC4main3Foo4pingfS0_FT_T_ : $@convention(method) (@guaranteed Foo) -> ()


### PR DESCRIPTION
<!-- What's in this pull request? -->

Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
- Look through BB arguments with multiple predecessors.
- Provide a new helper function to figure out the exact type of the underlying object. It will be used by subsequent commits to improve the escape analysis.
