### PR TITLE
[SourceKit] Add test case for crash triggered in swift::NameAliasType::getSinglyDesugaredType()

### DIFF
--- a/validation-test/IDE/crashers/089-swift-namealiastype-getsinglydesugaredtype.swift
+++ b/validation-test/IDE/crashers/089-swift-namealiastype-getsinglydesugaredtype.swift
@@ -1,0 +1,10 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+#^A^#
+func"
+struct c
+class A{
+protocol e
+var f=F
+typealias e:f{}
+typealias f=c


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 126
swift-ide-test: /path/to/swift/include/swift/AST/Decl.h:2387: swift::Type swift::TypeAliasDecl::getUnderlyingType() const: Assertion `!UnderlyingTy.getType().isNull() && "getting invalid underlying type"' failed.
8  swift-ide-test  0x0000000000c890f2 swift::NameAliasType::getSinglyDesugaredType() + 146
9  swift-ide-test  0x0000000000c84baa swift::TypeBase::getCanonicalType() + 474
10 swift-ide-test  0x0000000000c84ca5 swift::TypeBase::getCanonicalType() + 725
11 swift-ide-test  0x0000000000c6e8a4 swift::removeShadowedDecls(llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::ModuleDecl const*, swift::LazyResolver*) + 324
16 swift-ide-test  0x0000000000c50e64 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 1188
17 swift-ide-test  0x00000000009d3c62 swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::Type, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) + 290
18 swift-ide-test  0x00000000009793ea swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 4058
20 swift-ide-test  0x0000000000bcca3b swift::Expr::walk(swift::ASTWalker&) + 27
21 swift-ide-test  0x0000000000979c70 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 224
22 swift-ide-test  0x000000000097d445 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 949
23 swift-ide-test  0x00000000009817d0 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 352
24 swift-ide-test  0x00000000009819c5 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 229
26 swift-ide-test  0x000000000098dc61 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3857
28 swift-ide-test  0x000000000098da92 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3394
29 swift-ide-test  0x0000000000c72a0b swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2667
30 swift-ide-test  0x0000000000c7122e swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 4990
31 swift-ide-test  0x00000000009d2763 swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 99
34 swift-ide-test  0x0000000000a06042 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 162
36 swift-ide-test  0x0000000000a070e4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
37 swift-ide-test  0x0000000000a05873 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 195
40 swift-ide-test  0x000000000098da92 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3394
44 swift-ide-test  0x00000000009936e6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
45 swift-ide-test  0x00000000009b9172 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
46 swift-ide-test  0x00000000007abc69 swift::CompilerInstance::performSema() + 3289
47 swift-ide-test  0x000000000074d981 main + 36401
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking 'A' at <INPUT-FILE>:6:1
2.  While type-checking 'e' at <INPUT-FILE>:9:1
3.  While resolving type f at [<INPUT-FILE>:9:13 - line:9:13] RangeText="f"
4.  While type-checking 'f' at <INPUT-FILE>:10:1
5.  While type-checking expression at [<INPUT-FILE>:8:7 - line:8:7] RangeText="F"
```
