### PR TITLE
[swiftc (61 vs. 5162)] Add crasher in swift::IterativeTypeChecker::processTypeCheckSuperclass(...)

### DIFF
--- a/validation-test/compiler_crashers/28415-swift-iterativetypechecker-processtypechecksuperclass.swift
+++ b/validation-test/compiler_crashers/28415-swift-iterativetypechecker-processtypechecksuperclass.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+class B<a>{
+protocol c:a
+class a:A
+class A:a


### PR DESCRIPTION
Add test case for crash triggered in `swift::IterativeTypeChecker::processTypeCheckSuperclass(...)`.

Current number of unresolved compiler crashers: 61 (5162 resolved)

Assertion failure in [`lib/AST/Decl.cpp (line 4974)`](https://github.com/apple/swift/blob/master/lib/AST/Decl.cpp#L4974):

```
Assertion `(!superclass || !superclass->hasArchetype()) && "superclass must be interface type"' failed.

When executing: void swift::ClassDecl::setSuperclass(swift::Type)
```

Assertion context:

```
  return nullptr;
}

void ClassDecl::setSuperclass(Type superclass) {
  assert((!superclass || !superclass->hasArchetype())
         && "superclass must be interface type");
  LazySemanticInfo.Superclass.setPointerAndInt(superclass, true);
}
```

Stack trace:

```
swift: /path/to/swift/lib/AST/Decl.cpp:4974: void swift::ClassDecl::setSuperclass(swift::Type): Assertion `(!superclass || !superclass->hasArchetype()) && "superclass must be interface type"' failed.
9  swift           0x000000000102294d swift::IterativeTypeChecker::processTypeCheckSuperclass(swift::ClassDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 269
10 swift           0x0000000000ff95dd swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
11 swift           0x0000000000ed6940 swift::TypeChecker::resolveSuperclass(swift::ClassDecl*) + 64
12 swift           0x0000000001177da9 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) + 217
13 swift           0x0000000001178302 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) + 1586
14 swift           0x000000000117bfae swift::ConformanceLookupTable::getAllProtocols(swift::NominalTypeDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolDecl*>&) + 30
15 swift           0x000000000115b8bf swift::NominalTypeDecl::getAllProtocols() const + 95
16 swift           0x0000000000f2ab4d swift::TypeChecker::findWitnessedObjCRequirements(swift::ValueDecl const*, bool) + 141
20 swift           0x0000000000edfc26 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
21 swift           0x0000000000f65556 swift::createImplicitConstructor(swift::TypeChecker&, swift::NominalTypeDecl*, swift::ImplicitConstructorKind) + 1350
22 swift           0x0000000000ee6082 swift::TypeChecker::defineDefaultConstructor(swift::NominalTypeDecl*) + 338
23 swift           0x0000000000ee5074 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 1732
24 swift           0x0000000000ed8267 swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 6007
25 swift           0x0000000000ed9617 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 375
26 swift           0x000000000115029b swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2667
27 swift           0x000000000114eabe swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 4990
28 swift           0x0000000000f1e153 swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 99
31 swift           0x0000000000f51cb2 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 162
33 swift           0x0000000000f52d54 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
34 swift           0x0000000000f514e3 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 195
35 swift           0x0000000000ed7f8a swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 5274
36 swift           0x0000000000ed9617 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 375
37 swift           0x000000000115029b swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2667
38 swift           0x000000000114eabe swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 4990
39 swift           0x0000000000f1e153 swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 99
42 swift           0x0000000000f51cb2 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 162
44 swift           0x0000000000f52d54 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
45 swift           0x0000000000f514e3 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 195
46 swift           0x000000000102279e swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 158
47 swift           0x0000000000ff95dd swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
48 swift           0x0000000000ff9769 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 889
49 swift           0x0000000000ed6a00 swift::TypeChecker::resolveInheritedProtocols(swift::ProtocolDecl*) + 64
50 swift           0x00000000010288f3 swift::ArchetypeBuilder::addConformanceRequirement(swift::ArchetypeBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::RequirementSource, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 179
53 swift           0x000000000102a99f swift::ArchetypeBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>) + 175
54 swift           0x000000000102869a swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 426
55 swift           0x00000000010284c5 swift::ArchetypeBuilder::addGenericParameterRequirements(swift::GenericTypeParamDecl*) + 165
56 swift           0x0000000000f19c48 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::GenericSignature*, swift::GenericEnvironment*, swift::GenericTypeResolver*) + 344
57 swift           0x0000000000f1b3b6 swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 118
58 swift           0x0000000000f1be6e swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) + 126
59 swift           0x0000000000ed9bc6 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1830
64 swift           0x0000000000edfc26 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
65 swift           0x0000000000f044c2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
66 swift           0x0000000000c86e69 swift::CompilerInstance::performSema() + 3289
68 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
69 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28415-swift-iterativetypechecker-processtypechecksuperclass.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28415-swift-iterativetypechecker-processtypechecksuperclass-5fcc84.o
1.  While type-checking 'B' at validation-test/compiler_crashers/28415-swift-iterativetypechecker-processtypechecksuperclass.swift:10:1
2.  While resolving type a at [validation-test/compiler_crashers/28415-swift-iterativetypechecker-processtypechecksuperclass.swift:11:12 - line:11:12] RangeText="a"
3.  While resolving type A at [validation-test/compiler_crashers/28415-swift-iterativetypechecker-processtypechecksuperclass.swift:12:9 - line:12:9] RangeText="A"
4.  While defining default constructor for 'a' at validation-test/compiler_crashers/28415-swift-iterativetypechecker-processtypechecksuperclass.swift:12:1
5.  While type-checking 'init' at validation-test/compiler_crashers/28415-swift-iterativetypechecker-processtypechecksuperclass.swift:12:7
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
