### PR TITLE
[swiftc (62 vs. 5162)] Add crasher in swift::TypeChecker::resolveIdentifierType(...)

### DIFF
--- a/validation-test/compiler_crashers/28416-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/compiler_crashers/28416-swift-typechecker-resolveidentifiertype.swift
@@ -1,0 +1,17 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+protocol A{
+typealias e protocol P{
+var d:e
+class A{
+let a={enum k:P{
+{
+}
+typealias e:a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::resolveIdentifierType(...)`.

Current number of unresolved compiler crashers: 62 (5162 resolved)

Assertion failure in [`include/swift/AST/DiagnosticEngine.h (line 614)`](https://github.com/apple/swift/blob/master/include/swift/AST/DiagnosticEngine.h#L614):

```
Assertion `!ActiveDiagnostic && "Already have an active diagnostic"' failed.

When executing: swift::InFlightDiagnostic swift::DiagnosticEngine::diagnose(swift::SourceLoc, Diag<ArgTypes...>, typename detail::PassArgument<ArgTypes>::type...) [ArgTypes = <swift::Identifier>]
```

Assertion context:

```
    /// the types expected by the diagnostic \p ID.
    template<typename ...ArgTypes>
    InFlightDiagnostic
    diagnose(SourceLoc Loc, Diag<ArgTypes...> ID,
             typename detail::PassArgument<ArgTypes>::type... Args) {
      assert(!ActiveDiagnostic && "Already have an active diagnostic");
      ActiveDiagnostic = Diagnostic(ID, std::move(Args)...);
      ActiveDiagnostic->setLoc(Loc);
      return InFlightDiagnostic(*this);
    }

```

Stack trace:

```
swift: /path/to/swift/include/swift/AST/DiagnosticEngine.h:614: swift::InFlightDiagnostic swift::DiagnosticEngine::diagnose(swift::SourceLoc, Diag<ArgTypes...>, typename detail::PassArgument<ArgTypes>::type...) [ArgTypes = <swift::Identifier>]: Assertion `!ActiveDiagnostic && "Already have an active diagnostic"' failed.
12 swift           0x0000000000f51cb2 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 162
14 swift           0x0000000000f52d54 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
15 swift           0x0000000000f514e3 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 195
18 swift           0x0000000000eda1e2 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3394
19 swift           0x000000000115029b swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2667
20 swift           0x0000000000f1eed1 swift::TypeChecker::lookupMemberType(swift::DeclContext*, swift::Type, swift::Identifier, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 289
21 swift           0x0000000000fdd1ad swift::constraints::ConstraintSystem::performMemberLookup(swift::constraints::ConstraintKind, swift::DeclName, swift::Type, swift::FunctionRefKind, swift::constraints::ConstraintLocator*, bool) + 2413
22 swift           0x0000000000fdef9b swift::constraints::ConstraintSystem::simplifyMemberConstraint(swift::constraints::Constraint const&) + 491
23 swift           0x0000000000fe0105 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 69
24 swift           0x0000000000fea7db swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 12235
25 swift           0x0000000000fe4ec3 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 323
26 swift           0x0000000000fe48e9 swift::constraints::ConstraintSystem::solve(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 73
27 swift           0x0000000000fe481b swift::constraints::ConstraintSystem::solveSingle(swift::FreeTypeVariableBinding) + 59
28 swift           0x0000000000fc1c77 swift::checkMemberType(swift::DeclContext&, swift::Type, llvm::ArrayRef<swift::Identifier>) + 487
30 swift           0x000000000116b3c3 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 35
35 swift           0x00000000010715f6 swift::Decl::print(swift::ASTPrinter&, swift::PrintOptions const&) const + 54
39 swift           0x0000000000f28a57 swift::TypeChecker::checkConformance(swift::NormalProtocolConformance*) + 2103
40 swift           0x0000000000f28f67 swift::TypeChecker::checkConformancesInContext(swift::DeclContext*, swift::IterableDeclContext*) + 487
43 swift           0x0000000000edfc26 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
46 swift           0x0000000000f4b744 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
47 swift           0x0000000000f78aec swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
48 swift           0x0000000000ec9506 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 1126
49 swift           0x0000000000ecd7e0 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 352
50 swift           0x0000000000ecd9d5 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 229
59 swift           0x0000000000edfc26 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
60 swift           0x0000000000f044c2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
61 swift           0x0000000000c86e69 swift::CompilerInstance::performSema() + 3289
63 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
64 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28416-swift-typechecker-resolveidentifiertype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28416-swift-typechecker-resolveidentifiertype-0f7895.o
1.  While type-checking 'A' at validation-test/compiler_crashers/28416-swift-typechecker-resolveidentifiertype.swift:10:1
2.  While type-checking expression at [validation-test/compiler_crashers/28416-swift-typechecker-resolveidentifiertype.swift:14:7 - line:17:13] RangeText="{enum k:P{
3.  While type-checking 'k' at validation-test/compiler_crashers/28416-swift-typechecker-resolveidentifiertype.swift:14:8
4.  While type-checking 'e' at validation-test/compiler_crashers/28416-swift-typechecker-resolveidentifiertype.swift:17:1
5.  While resolving type a at [validation-test/compiler_crashers/28416-swift-typechecker-resolveidentifiertype.swift:17:13 - line:17:13] RangeText="a"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
