### PR TITLE
[swiftc (63 vs. 5162)] Add crasher in swift::GenericSignature::getSubstitutions(...)

### DIFF
--- a/validation-test/compiler_crashers/28417-swift-genericsignature-getsubstitutions.swift
+++ b/validation-test/compiler_crashers/28417-swift-genericsignature-getsubstitutions.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+protocol A::{struct Q<T where T:A>{protocol A{enum S<f>{case


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignature::getSubstitutions(...)`.

Current number of unresolved compiler crashers: 63 (5162 resolved)

Assertion failure in [`lib/Sema/CSApply.cpp (line 133)`](https://github.com/apple/swift/blob/master/lib/Sema/CSApply.cpp#L133):

```
Assertion `(conforms || replacement->is<ErrorType>() || isOpenedAnyObject(replacement) || replacement->is<GenericTypeParamType>()) && "Constraint system missed a conformance?"' failed.

When executing: auto swift::constraints::Solution::computeSubstitutions(swift::Type, swift::DeclContext *, swift::Type, swift::constraints::ConstraintLocator *, SmallVectorImpl<swift::Substitution> &)::(anonymous class)::operator()(swift::CanType, swift::Type, swift::ProtocolType *) const
```

Assertion context:

```
    (void)isOpenedAnyObject;
    assert((conforms ||
            replacement->is<ErrorType>() ||
            isOpenedAnyObject(replacement) ||
            replacement->is<GenericTypeParamType>()) &&
           "Constraint system missed a conformance?");
    (void)conforms;

    assert(conformance ||
           replacement->is<ErrorType>() ||
           replacement->hasDependentProtocolConformances());
```

Stack trace:

```
swift: /path/to/swift/lib/Sema/CSApply.cpp:133: auto swift::constraints::Solution::computeSubstitutions(swift::Type, swift::DeclContext *, swift::Type, swift::constraints::ConstraintLocator *, SmallVectorImpl<swift::Substitution> &)::(anonymous class)::operator()(swift::CanType, swift::Type, swift::ProtocolType *) const: Assertion `(conforms || replacement->is<ErrorType>() || isOpenedAnyObject(replacement) || replacement->is<GenericTypeParamType>()) && "Constraint system missed a conformance?"' failed.
9  swift           0x000000000112c701 swift::GenericSignature::getSubstitutions(swift::ModuleDecl&, llvm::DenseMap<swift::TypeBase*, swift::Type, llvm::DenseMapInfo<swift::TypeBase*>, llvm::detail::DenseMapPair<swift::TypeBase*, swift::Type> > const&, llvm::function_ref<swift::ProtocolConformanceRef (swift::CanType, swift::Type, swift::ProtocolType*)>, llvm::SmallVectorImpl<swift::Substitution>&) const + 481
10 swift           0x0000000000f76713 swift::constraints::Solution::computeSubstitutions(swift::Type, swift::DeclContext*, swift::Type, swift::constraints::ConstraintLocator*, llvm::SmallVectorImpl<swift::Substitution>&) const + 563
15 swift           0x0000000000f28a74 swift::TypeChecker::checkConformance(swift::NormalProtocolConformance*) + 2132
16 swift           0x0000000000f28f67 swift::TypeChecker::checkConformancesInContext(swift::DeclContext*, swift::IterableDeclContext*) + 487
23 swift           0x0000000000edfc26 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
26 swift           0x0000000000f4b744 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
27 swift           0x0000000000f78aec swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
28 swift           0x0000000000ec9506 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 1126
30 swift           0x0000000000f4b886 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
31 swift           0x0000000000f0452d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
32 swift           0x0000000000c86e69 swift::CompilerInstance::performSema() + 3289
34 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
35 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28417-swift-genericsignature-getsubstitutions.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28417-swift-genericsignature-getsubstitutions-1c018d.o
1.  While type-checking expression at [validation-test/compiler_crashers/28417-swift-genericsignature-getsubstitutions.swift:10:13 - line:10:57] RangeText="{struct Q<T where T:A>{protocol A{enum S<f>{c"
2.  While type-checking 'Q' at validation-test/compiler_crashers/28417-swift-genericsignature-getsubstitutions.swift:10:14
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
