### PR TITLE
[gardening] "an unary" → "a unary", "an parameter" → "a parameter", "an struct" → "a struct"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,7 @@ Swift 3.0
 
   The collection methods `partition()` and `partition(isOrderedBefore:)` have
   been removed from Swift. They were replaced by the method `partition(by:)`
-  which takes an unary predicate.
+  which takes a unary predicate.
 
   Calls to the `partition()` method can be replaced by the following code.
 

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -221,7 +221,7 @@ class ASTScope {
     /// or \c kind == ASTScopeKind::AbstractFunctionBody.
     AbstractFunctionDecl *abstractFunction;
 
-    /// An parameter for an abstract function (init/func/deinit).
+    /// A parameter for an abstract function (init/func/deinit).
     ///
     /// For \c kind == ASTScopeKind::AbstractFunctionParams.
     struct {

--- a/lib/IRGen/Linking.h
+++ b/lib/IRGen/Linking.h
@@ -209,7 +209,7 @@ class LinkEntity {
     /// A reflection metadata descriptor for a builtin or imported type.
     ReflectionBuiltinDescriptor,
 
-    /// A reflection metadata descriptor for an struct, enum, class or protocol.
+    /// A reflection metadata descriptor for a struct, enum, class or protocol.
     ReflectionFieldDescriptor,
   };
   friend struct llvm::DenseMapInfo<LinkEntity>;


### PR DESCRIPTION
- "an unary" → "a unary"
- "an parameter" → "a parameter"
- "an struct" → "a struct"
