### PR TITLE
[Type checker] Handle explicit conversion of bridged generic types.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4176,7 +4176,7 @@ ConstraintSystem::simplifyRestrictedConstraint(ConversionRestrictionKind restric
     }
 
     // If the bridged value type is generic, the generic arguments
-    // must match the 
+    // must either match or be bridged.
     // FIXME: This should be an associated type of the protocol.
     if (auto bgt1 = type2->getAs<BoundGenericType>()) {
       if (bgt1->getDecl() == TC.Context.getArrayDecl()) {
@@ -4219,7 +4219,7 @@ ConstraintSystem::simplifyRestrictedConstraint(ConversionRestrictionKind restric
                         locator.withPathElement(
                           LocatorPathElt::getGenericArgument(0))));
       } else {
-        llvm_unreachable("unhandled generic bridged type");
+        // Nothing special to do; matchTypes will match generic arguments.
       }
     }
 

--- a/test/ClangModules/objc_bridging_custom.swift
+++ b/test/ClangModules/objc_bridging_custom.swift
@@ -211,3 +211,18 @@ class TestObjCProtoImpl : NSObject, TestObjCProto {
     return nil
   }
 }
+
+// Check explicit conversions for bridged generic types.
+// rdar://problem/27539951
+func testExplicitConversion(objc: APPManufacturerInfo<NSString>,
+                            swift: ManufacturerInfo<NSString>) {
+  // Bridging to Swift
+  let _ = objc as ManufacturerInfo<NSString>
+  let _ = objc as ManufacturerInfo<NSNumber> // expected-error{{cannot convert value of type 'APPManufacturerInfo<NSString>' to type 'ManufacturerInfo<NSNumber>' in coercion}}
+  let _ = objc as ManufacturerInfo<NSObject> // expected-error{{cannot convert value of type 'APPManufacturerInfo<NSString>' to type 'ManufacturerInfo<NSObject>' in coercion}}
+
+  // Bridging to Objective-C
+  let _ = swift as APPManufacturerInfo<NSString>
+  let _ = swift as APPManufacturerInfo<NSNumber> // expected-error{{cannot convert value of type 'ManufacturerInfo<NSString>' to type 'APPManufacturerInfo<NSNumber>' in coercion}}
+  let _ = swift as APPManufacturerInfo<NSObject> // expected-error{{cannot convert value of type 'ManufacturerInfo<NSString>' to type 'APPManufacturerInfo<NSObject>' in coercion}}
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->

The type checker had some logic for performing specific checking for
explicit bridging casts of generic types based on knowledge of
Array/Dictionary/Set, but pretended no other bridged generic types
existed. That's incorrect now; simply require them to match exactly.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [rdar://problem/27539951](rdar://problem/27539951).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
