### PR TITLE
[swiftc] Sync with swift-compiler-crashes (add regressions + missing cases)

### DIFF
--- a/validation-test/compiler_crashers/00046-swift-archetypebuilder-potentialarchetype-getnestedtype.timeout.swift
+++ b/validation-test/compiler_crashers/00046-swift-archetypebuilder-potentialarchetype-getnestedtype.timeout.swift
@@ -1,0 +1,14 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+protocol P{
+protocol A
+typealias e=b
+typealias e
+typealias e=A
+typealias b

--- a/validation-test/compiler_crashers/23919-swift-astvisitor.swift
+++ b/validation-test/compiler_crashers/23919-swift-astvisitor.swift
@@ -1,0 +1,7 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+func b<T{enum a:T

--- a/validation-test/compiler_crashers/28209-swift-protocoldecl-requiresclassslow.swift
+++ b/validation-test/compiler_crashers/28209-swift-protocoldecl-requiresclassslow.swift
@@ -1,0 +1,9 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+protocol a:b
+protocol b:Range<b>

--- a/validation-test/compiler_crashers/28356-swift-typechecker-resolvetypewitness.swift
+++ b/validation-test/compiler_crashers/28356-swift-typechecker-resolvetypewitness.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+var d={protocol a{typealias d:a{}class B<associatedtype b{{}}class B:a{func d:d enum b


### PR DESCRIPTION
Sync with `swift-compiler-crashes` (add regressions + missing cases).
