### PR TITLE
Let the stride of a type be at least one and remove the strideof_nonzero builtin

### DIFF
--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -358,11 +358,6 @@ BUILTIN_MISC_OPERATION(IsPOD, "ispod", "n", Special)
 /// Alignof has type T.Type -> Int
 BUILTIN_MISC_OPERATION(Alignof, "alignof", "n", Special)
 
-/// Strideof has type T.Type -> Int.
-/// Note that this version will never return 0.  It instead always returns
-/// at least 1
-BUILTIN_MISC_OPERATION(StrideofNonZero, "strideof_nonzero", "n", Special)
-
 /// AllocRaw has type (Int, Int) -> Builtin.RawPointer
 BUILTIN_MISC_OPERATION(AllocRaw, "allocRaw", "", Special)
 

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1559,7 +1559,6 @@ ValueDecl *swift::getBuiltinValueDecl(ASTContext &Context, Identifier Id) {
   case BuiltinValueKind::Sizeof:
   case BuiltinValueKind::Strideof:
   case BuiltinValueKind::Alignof:
-  case BuiltinValueKind::StrideofNonZero:
     return getSizeOrAlignOfOperation(Context, Id);
 
   case BuiltinValueKind::IsPOD:

--- a/lib/IRGen/FixedTypeInfo.h
+++ b/lib/IRGen/FixedTypeInfo.h
@@ -120,8 +120,13 @@ public:
   /// object.  The stride is the storage size rounded up to the
   /// alignment; its practical use is that, in an array, it is the
   /// offset from the size of one element to the offset of the next.
+  /// The stride is at least one, even for zero-sized types, like the empty
+  /// tuple.
   Size getFixedStride() const {
-    return StorageSize.roundUpToAlignment(getFixedAlignment());
+    Size s = StorageSize.roundUpToAlignment(getFixedAlignment());
+    if (s.isZero())
+      s = Size(1);
+    return s;
   }
   
   /// Returns the fixed number of "extra inhabitants" (that is, bit

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -171,22 +171,6 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, Identifier FnId,
     return;
   }
 
-  if (Builtin.ID == BuiltinValueKind::StrideofNonZero) {
-    // Note this case must never return 0.
-    // It is implemented as max(strideof, 1)
-    args.claimAll();
-    auto valueTy = getLoweredTypeAndTypeInfo(IGF.IGM,
-                                             substitutions[0].getReplacement());
-    // Strideof should never return 0, so return 1 if the type has a 0 stride.
-    llvm::Value *StrideOf = valueTy.second.getStride(IGF, valueTy.first);
-    llvm::IntegerType *IntTy = cast<llvm::IntegerType>(StrideOf->getType());
-    auto *Zero = llvm::ConstantInt::get(IntTy, 0);
-    auto *One = llvm::ConstantInt::get(IntTy, 1);
-    llvm::Value *Cmp = IGF.Builder.CreateICmpEQ(StrideOf, Zero);
-    out.add(IGF.Builder.CreateSelect(Cmp, One, StrideOf));
-    return;
-  }
-
   if (Builtin.ID == BuiltinValueKind::IsPOD) {
     args.claimAll();
     auto valueTy = getLoweredTypeAndTypeInfo(IGF.IGM,

--- a/lib/IRGen/ValueWitness.h
+++ b/lib/IRGen/ValueWitness.h
@@ -228,7 +228,8 @@ enum class ValueWitness : unsigned {
 
   ///   size_t stride;
   ///
-  /// The required size per element of an array of this type.
+  /// The required size per element of an array of this type. It is at least
+  /// one, even for zero-sized types, like the empty tuple.
   Stride,
   
   Last_RequiredValueWitness = Stride,

--- a/lib/SILOptimizer/Analysis/ValueTracking.cpp
+++ b/lib/SILOptimizer/Analysis/ValueTracking.cpp
@@ -141,9 +141,6 @@ Optional<bool> swift::computeSignBit(SILValue V) {
       // Strideof always returns non-negative results.
       case BuiltinValueKind::Strideof:
         return false;
-      // StrideofNonZero always returns positive results.
-      case BuiltinValueKind::StrideofNonZero:
-        return false;
       // Alignof always returns non-negative results.
       case BuiltinValueKind::Alignof:
         return false;

--- a/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
@@ -184,7 +184,7 @@ matchSizeOfMultiplication(SILValue I, MetatypeInst *RequiredType,
                   m_ApplyInst(
                       BuiltinValueKind::SMulOver, m_SILValue(Dist),
                       m_ApplyInst(BuiltinValueKind::ZExtOrBitCast,
-                                  m_ApplyInst(BuiltinValueKind::StrideofNonZero,
+                                  m_ApplyInst(BuiltinValueKind::Strideof,
                                               m_MetatypeInst(StrideType)))),
                   0))) ||
       match(
@@ -195,7 +195,7 @@ matchSizeOfMultiplication(SILValue I, MetatypeInst *RequiredType,
                   m_ApplyInst(
                       BuiltinValueKind::SMulOver,
                       m_ApplyInst(BuiltinValueKind::ZExtOrBitCast,
-                                  m_ApplyInst(BuiltinValueKind::StrideofNonZero,
+                                  m_ApplyInst(BuiltinValueKind::Strideof,
                                               m_MetatypeInst(StrideType))),
                       m_SILValue(Dist)),
                   0)))) {
@@ -464,9 +464,6 @@ SILInstruction *SILCombiner::visitBuiltinInst(BuiltinInst *I) {
 
   if (match(I, m_ApplyInst(BuiltinValueKind::SMulOver,
                             m_ApplyInst(BuiltinValueKind::Strideof),
-                            m_ValueBase(), m_IntegerLiteralInst())) ||
-      match(I, m_ApplyInst(BuiltinValueKind::SMulOver,
-                            m_ApplyInst(BuiltinValueKind::StrideofNonZero),
                             m_ValueBase(), m_IntegerLiteralInst()))) {
     I->swapOperands(0, 1);
     return I;

--- a/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
@@ -90,7 +90,7 @@ visitPointerToAddressInst(PointerToAddressInst *PTAI) {
   // Turn this also into an index_addr. We generate this pattern after switching
   // the Word type to an explicit Int32 or Int64 in the stdlib.
   //
-  // %101 = builtin "strideof_nonzero"<Int>(%84 : $@thick Int.Type) :
+  // %101 = builtin "strideof"<Int>(%84 : $@thick Int.Type) :
   //         $Builtin.Word
   // %102 = builtin "zextOrBitCast_Word_Int64"(%101 : $Builtin.Word) :
   //         $Builtin.Int64
@@ -119,13 +119,13 @@ visitPointerToAddressInst(PointerToAddressInst *PTAI) {
                 m_ApplyInst(
                     BuiltinValueKind::SMulOver, m_SILValue(Distance),
                     m_ApplyInst(BuiltinValueKind::ZExtOrBitCast,
-                                m_ApplyInst(BuiltinValueKind::StrideofNonZero,
+                                m_ApplyInst(BuiltinValueKind::Strideof,
                                             m_MetatypeInst(Metatype))))) ||
           match(StrideMul,
                 m_ApplyInst(
                     BuiltinValueKind::SMulOver,
                     m_ApplyInst(BuiltinValueKind::ZExtOrBitCast,
-                                m_ApplyInst(BuiltinValueKind::StrideofNonZero,
+                                m_ApplyInst(BuiltinValueKind::Strideof,
                                             m_MetatypeInst(Metatype))),
                     m_SILValue(Distance)))) {
         SILType InstanceType =
@@ -166,10 +166,6 @@ visitPointerToAddressInst(PointerToAddressInst *PTAI) {
                                                      0)))) {
     if (match(Bytes, m_ApplyInst(BuiltinValueKind::SMulOver, m_ValueBase(),
                                  m_ApplyInst(BuiltinValueKind::Strideof,
-                                             m_MetatypeInst(Metatype)),
-                                 m_ValueBase())) ||
-        match(Bytes, m_ApplyInst(BuiltinValueKind::SMulOver, m_ValueBase(),
-                                 m_ApplyInst(BuiltinValueKind::StrideofNonZero,
                                              m_MetatypeInst(Metatype)),
                                  m_ValueBase()))) {
       SILType InstanceType =

--- a/stdlib/public/Reflection/TypeLowering.cpp
+++ b/stdlib/public/Reflection/TypeLowering.cpp
@@ -421,6 +421,8 @@ const RecordTypeInfo *RecordTypeInfoBuilder::build() {
 
   // Calculate the stride
   unsigned Stride = ((Size + Alignment - 1) & ~(Alignment - 1));
+  if (Stride == 0)
+    Stride = 1;
 
   return TC.makeTypeInfo<RecordTypeInfo>(
       Size, Alignment, Stride,
@@ -528,7 +530,7 @@ const TypeInfo *TypeConverter::getEmptyTypeInfo() {
   if (EmptyTI != nullptr)
     return EmptyTI;
 
-  EmptyTI = makeTypeInfo<TypeInfo>(TypeInfoKind::Builtin, 0, 1, 0, 0);
+  EmptyTI = makeTypeInfo<TypeInfo>(TypeInfoKind::Builtin, 0, 1, 1, 0);
   return EmptyTI;
 }
 
@@ -962,6 +964,8 @@ public:
 
     // Calculate the stride
     unsigned Stride = ((Size + Alignment - 1) & ~(Alignment - 1));
+    if (Stride == 0)
+      Stride = 1;
 
     return TC.makeTypeInfo<RecordTypeInfo>(
         Size, Alignment, Stride,

--- a/stdlib/public/core/MemoryLayout.swift
+++ b/stdlib/public/core/MemoryLayout.swift
@@ -30,7 +30,7 @@ public enum MemoryLayout<T> {
   /// performance for space efficiency. The result is always positive.
   @_transparent
   public static var stride: Int {
-    return Int(Builtin.strideof_nonzero(T.self))
+    return Int(Builtin.strideof(T.self))
   }
 
   /// The default memory alignment of `T`.

--- a/stdlib/public/runtime/Enum.cpp
+++ b/stdlib/public/runtime/Enum.cpp
@@ -102,7 +102,8 @@ swift::swift_initEnumValueWitnessTableSinglePayload(ValueWitnessTable *vwtable,
     .withExtraInhabitants(unusedExtraInhabitants > 0)
     .withEnumWitnesses(true)
     .withInlineStorage(ValueWitnessTable::isValueInline(size, align));
-  vwtable->stride = llvm::alignTo(size, align);
+  auto rawStride = llvm::alignTo(size, align);
+  vwtable->stride = rawStride == 0 ? 1 : rawStride;
   
   // Substitute in better common value witnesses if we have them.
   // If the payload type is a single-refcounted pointer, and the enum has
@@ -310,7 +311,8 @@ swift::swift_initEnumMetadataMultiPayload(ValueWitnessTable *vwtable,
     .withEnumWitnesses(true)
     .withInlineStorage(ValueWitnessTable::isValueInline(totalSize, alignMask+1))
     ;
-  vwtable->stride = (totalSize + alignMask) & ~alignMask;
+  auto rawStride = (totalSize + alignMask) & ~alignMask;
+  vwtable->stride = rawStride == 0 ? 1 : rawStride;
   
   installCommonValueWitnesses(vwtable);
 }

--- a/stdlib/public/runtime/ExistentialMetadataImpl.h
+++ b/stdlib/public/runtime/ExistentialMetadataImpl.h
@@ -214,8 +214,9 @@ struct LLVM_LIBRARY_VISIBILITY NonFixedOpaqueExistentialBox
       return std::max(alignof(void*), alignof(ValueBuffer));
     }
     static size_t getSize(unsigned numWitnessTables) {
-      return sizeof(OpaqueExistentialContainer)
-           + numWitnessTables * sizeof(void*);
+      constexpr size_t base = sizeof(OpaqueExistentialContainer);
+      static_assert(base > 0, "stride needs base size > 0");
+      return base + numWitnessTables * sizeof(void*);
     }
     static size_t getStride(unsigned numWitnessTables) {
       return getSize(numWitnessTables);
@@ -348,8 +349,9 @@ struct LLVM_LIBRARY_VISIBILITY NonFixedClassExistentialBox
       return alignof(void*);
     }
     static size_t getSize(unsigned numWitnessTables) {
-      return sizeof(ClassExistentialContainer)
-             + numWitnessTables * sizeof(void*);
+      constexpr size_t base = sizeof(ClassExistentialContainer);
+      static_assert(base > 0, "stride needs base size > 0");
+      return base + numWitnessTables * sizeof(void*);
     }
     static size_t getStride(unsigned numWitnessTables) {
       return getSize(numWitnessTables);
@@ -469,8 +471,9 @@ struct LLVM_LIBRARY_VISIBILITY NonFixedExistentialMetatypeBox
       return alignof(void*);
     }
     static size_t getSize(unsigned numWitnessTables) {
-      return sizeof(ExistentialMetatypeContainer)
-             + numWitnessTables * sizeof(void*);
+      constexpr size_t base = sizeof(ExistentialMetatypeContainer);
+      static_assert(base > 0, "stride needs base size > 0");
+      return base + numWitnessTables * sizeof(void*);
     }
     static size_t getStride(unsigned numWitnessTables) {
       return getSize(numWitnessTables);

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -982,7 +982,7 @@ void performBasicLayout(BasicLayout &layout,
                                     .withPOD(isPOD)
                                     .withBitwiseTakable(isBitwiseTakable)
                                     .withInlineStorage(isInline);
-  layout.stride = roundUpToAlignMask(size, alignMask);
+  layout.stride = std::max(size_t(1), roundUpToAlignMask(size, alignMask));
 }
 } // end anonymous namespace
 

--- a/stdlib/public/runtime/MetadataImpl.h
+++ b/stdlib/public/runtime/MetadataImpl.h
@@ -643,7 +643,9 @@ struct AggregateBox {
   using Helper = AggregateBoxHelper<0, EltBoxes...>;
   static constexpr size_t size = Helper::endOffset;
   static constexpr size_t alignment = Helper::alignment;
-  static constexpr size_t stride = roundUpToAlignment(size, alignment);
+  static constexpr size_t rawStride = roundUpToAlignment(size, alignment);
+  static constexpr size_t stride = rawStride == 0 ? 1 : rawStride;
+
   static constexpr bool isPOD = Helper::isPOD;
   static constexpr bool isBitwiseTakable = Helper::isBitwiseTakable;
 

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -245,17 +245,6 @@ func generic_strideof_test<T>(_: T) {
   var s = Builtin.strideof(T.self)
 }
 
-// CHECK: define hidden void @_TF8builtins29generic_strideof_nonzero_testurFxT_(
-func generic_strideof_nonzero_test<T>(_: T) {
-  // CHECK:      [[T0:%.*]] = getelementptr inbounds i8*, i8** [[T:%.*]], i32 19
-  // CHECK-NEXT: [[T1:%.*]] = load i8*, i8** [[T0]]
-  // CHECK-NEXT: [[STRIDE:%.*]] = ptrtoint i8* [[T1]] to i64
-  // CHECK-NEXT: [[CMP:%.*]] = icmp eq i64 [[STRIDE]], 0
-  // CHECK-NEXT: [[SELECT:%.*]] = select i1 [[CMP]], i64 1, i64 [[STRIDE]]
-  // CHECK-NEXT: store i64 [[SELECT]], i64* [[S:%.*]]
-  var s = Builtin.strideof_nonzero(T.self)
-}
-
 class X {}
 
 class Y {}

--- a/test/IRGen/indexing.sil
+++ b/test/IRGen/indexing.sil
@@ -31,6 +31,16 @@ entry(%p : $*DifferentSizeStride, %i: $Builtin.Word):
   return undef : $()
 }
 
+// CHECK:      define{{( protected)?}} void @zero_size(%swift.opaque* noalias nocapture, i64) {{.*}} {
+// CHECK:        %2 = bitcast %swift.opaque* %0 to i8*
+// CHECK-NEXT:   %3 = mul nsw i64 %1, 1
+// CHECK-NEXT:   %4 = getelementptr inbounds i8, i8* %2, i64 %3
+sil @zero_size : $@convention(thin) (@in (), Builtin.Word) -> () {
+entry(%p : $*(), %i: $Builtin.Word):
+  %q = index_addr %p : $*(), %i : $Builtin.Word
+  return undef : $()
+}
+
 // CHECK:      define{{( protected)?}} void @dynamic_size(%swift.opaque* noalias nocapture, i64, %swift.type* %T) {{.*}} {
 // CHECK:        %3 = bitcast %swift.type* %T to i8***
 // CHECK-NEXT:   %4 = getelementptr inbounds i8**, i8*** %3, i64 -1

--- a/test/IRGen/zero_size_types.swift
+++ b/test/IRGen/zero_size_types.swift
@@ -1,0 +1,69 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-build-swift -Xllvm -sil-disable-pass="Generic Specializer" %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+// REQUIRES: executable_test
+
+public struct EmptyStruct {
+}
+
+public enum SingleCaseEnum {
+  case A
+}
+
+public struct GenStruct<T> {
+  var t: T
+}
+
+@inline(never)
+func fail() {
+  fatalError("size/stride mismatch")
+}
+
+@inline(never)
+public func testit<T>(_ t: T) {
+  if MemoryLayout<T>.size != 0 {
+    fail()
+  }
+  if MemoryLayout<T>.stride != 1 {
+    fail()
+  }
+  if MemoryLayout<GenStruct<T>>.size != 0 {
+    fail()
+  }
+  if MemoryLayout<GenStruct<T>>.stride != 1 {
+    fail()
+  }
+}
+
+// Test size and stride which are loaded from the value witness tables.
+
+testit(EmptyStruct())
+testit(())
+testit(SingleCaseEnum.A)
+
+// Test size and stride which are computed as constants in IRGen.
+
+if MemoryLayout<()>.size != 0 {
+  fail()
+}
+if MemoryLayout<()>.stride != 1 {
+  fail()
+}
+
+if MemoryLayout<EmptyStruct>.size != 0 {
+  fail()
+}
+if MemoryLayout<EmptyStruct>.stride != 1 {
+  fail()
+}
+
+if MemoryLayout<SingleCaseEnum>.size != 0 {
+  fail()
+}
+if MemoryLayout<SingleCaseEnum>.stride != 1 {
+  fail()
+}
+
+// CHECK: success
+print("success")
+

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -594,7 +594,7 @@ V12TypeLowering14MetatypeStruct
 // CHECK-64-NEXT:           (field name=wtable offset=16
 // CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))))))
 // CHECK-64-NEXT:   (field name=structMetatype offset=112
-// CHECK-64-NEXT:     (builtin size=0 alignment=1 stride=0 num_extra_inhabitants=0))
+// CHECK-64-NEXT:     (builtin size=0 alignment=1 stride=1 num_extra_inhabitants=0))
 // CHECK-64-NEXT:   (field name=optionalStructMetatype offset=112
 // CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_SUB_1]]
 // CHECK-64-NEXT:       (field name=some offset=0
@@ -667,7 +667,7 @@ V12TypeLowering14MetatypeStruct
 // CHECK-32-NEXT:           (field name=wtable offset=8
 // CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))))))
 // CHECK-32-NEXT:   (field name=structMetatype offset=56
-// CHECK-32-NEXT:     (builtin size=0 alignment=1 stride=0 num_extra_inhabitants=0))
+// CHECK-32-NEXT:     (builtin size=0 alignment=1 stride=1 num_extra_inhabitants=0))
 // CHECK-32-NEXT:   (field name=optionalStructMetatype offset=56
 // CHECK-32-NEXT:     (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095
 // CHECK-32-NEXT:       (field name=some offset=0
@@ -689,11 +689,11 @@ V12TypeLowering10EnumStruct
 // CHECK-64: (struct TypeLowering.EnumStruct)
 // CHECK-64-NEXT: (struct size=81 alignment=8 stride=88 num_extra_inhabitants=0
 // CHECK-64-NEXT:   (field name=empty offset=0
-// CHECK-64-NEXT:     (no_payload_enum size=0 alignment=0 stride=0 num_extra_inhabitants=0))
+// CHECK-64-NEXT:     (no_payload_enum size=0 alignment=0 stride=1 num_extra_inhabitants=0))
 // CHECK-64-NEXT:   (field name=noPayload offset=0
-// CHECK-64-NEXT:     (no_payload_enum size=1 alignment=0 stride=0 num_extra_inhabitants=0))
+// CHECK-64-NEXT:     (no_payload_enum size=1 alignment=0 stride=1 num_extra_inhabitants=0))
 // CHECK-64-NEXT:   (field name=sillyNoPayload offset=0
-// CHECK-64-NEXT:     (no_payload_enum size=1 alignment=0 stride=0 num_extra_inhabitants=0))
+// CHECK-64-NEXT:     (no_payload_enum size=1 alignment=0 stride=1 num_extra_inhabitants=0))
 // CHECK-64-NEXT:   (field name=singleton offset=8
 // CHECK-64-NEXT:     (reference kind=strong refcounting=native))
 // CHECK-64-NEXT:   (field name=singlePayload offset=16

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -1258,16 +1258,16 @@ bb0(%0 : $Builtin.RawPointer, %1 : $Builtin.Word):
   return %11 : $Int8
 }
 
-// CHECK-LABEL: sil @indexrawpointer_to_indexaddr_strideof_nonzero : $@convention(thin) (Builtin.RawPointer, Builtin.Word) -> Int8 {
+// CHECK-LABEL: sil @indexrawpointer_to_indexaddr_strideof : $@convention(thin) (Builtin.RawPointer, Builtin.Word) -> Int8 {
 // CHECK: bb0
 // CHECK-NEXT: pointer_to_address
 // CHECK-NEXT: index_addr
 // CHECK-NEXT: load
 // CHECK-NEXT: return
-sil @indexrawpointer_to_indexaddr_strideof_nonzero : $@convention(thin) (Builtin.RawPointer, Builtin.Word) -> Int8 {
+sil @indexrawpointer_to_indexaddr_strideof : $@convention(thin) (Builtin.RawPointer, Builtin.Word) -> Int8 {
 bb0(%0 : $Builtin.RawPointer, %1 : $Builtin.Word):
   %3 = metatype $@thick Int8.Type
-  %4 = builtin "strideof_nonzero"<Int8>(%3 : $@thick Int8.Type) : $Builtin.Word
+  %4 = builtin "strideof"<Int8>(%3 : $@thick Int8.Type) : $Builtin.Word
   %6 = integer_literal $Builtin.Int1, -1
   %7 = builtin "smul_with_overflow_Word"(%4 : $Builtin.Word, %1 : $Builtin.Word, %6 : $Builtin.Int1) : $(Builtin.Word, Builtin.Int1)
   %8 = tuple_extract %7 : $(Builtin.Word, Builtin.Int1), 0
@@ -1303,7 +1303,7 @@ sil @indexrawpointer_to_indexaddr_with_casts : $@convention(thin) (Builtin.RawPo
 bb0(%0 : $Builtin.RawPointer, %1: $Builtin.Int64):
   %2 = integer_literal $Builtin.Int1, -1
   %3 = metatype $@thick Int32.Type
-  %4 = builtin "strideof_nonzero"<Int32>(%3 : $@thick Int32.Type) : $Builtin.Word
+  %4 = builtin "strideof"<Int32>(%3 : $@thick Int32.Type) : $Builtin.Word
   %5 = builtin "zextOrBitCast_Word_Int64"(%4 : $Builtin.Word) : $Builtin.Int64
   %6 = builtin "smul_with_overflow_Int64"(%1 : $Builtin.Int64, %5 : $Builtin.Int64, %2 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
   %7 = tuple_extract %6 : $(Builtin.Int64, Builtin.Int1), 0
@@ -2143,7 +2143,7 @@ bb0(%0 : $Builtin.Int64, %1 : $Builtin.RawPointer, %2 : $Builtin.RawPointer):
   %4 = metatype $@thick Int32.Type
   %5 = integer_literal $Builtin.Word, 1
   %6 = integer_literal $Builtin.Int1, 0
-  %7 = builtin "strideof_nonzero"<Int32>(%4 : $@thick Int32.Type) : $Builtin.Word
+  %7 = builtin "strideof"<Int32>(%4 : $@thick Int32.Type) : $Builtin.Word
   %14 = builtin "zextOrBitCast_Word_Int64"(%7 : $Builtin.Word) : $Builtin.Int64
   %8 = builtin "smul_with_overflow_Word"(%14 : $Builtin.Int64, %0 : $Builtin.Int64, %6 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
   %9 = tuple_extract %8 : $(Builtin.Int64, Builtin.Int1), 0


### PR DESCRIPTION
<!-- What's in this pull request? -->

Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
