### PR TITLE
[omit-needless-words] Fix a bug found by -Wunused-result

### DIFF
--- a/lib/Basic/StringExtras.cpp
+++ b/lib/Basic/StringExtras.cpp
@@ -669,7 +669,7 @@ static StringRef omitNeedlessWords(StringRef name,
                             NameRole::Partial, allPropertyNames, scratch);
       if (shortenedNameWord == newShortenedNameWord &&
           shortenedNameWord.back() == 'e') {
-        shortenedNameWord.drop_back();
+        shortenedNameWord = shortenedNameWord.drop_back();
         newShortenedNameWord =
           omitNeedlessWords(shortenedNameWord, typeName.CollectionElement,
                             NameRole::Partial, allPropertyNames, scratch);

--- a/test/IDE/Inputs/custom-modules/OmitNeedlessWords.h
+++ b/test/IDE/Inputs/custom-modules/OmitNeedlessWords.h
@@ -7,6 +7,9 @@
 @interface SEGreebieArray : NSObject
 @end
 
+@interface Echo : NSObject
+@end
+
 typedef NS_OPTIONS(NSUInteger, OMWWobbleOptions) {
   OMWWobbleSideToSide = 0x01,
   OMWWobbleBackAndForth = 0x02,
@@ -21,6 +24,7 @@ typedef NS_OPTIONS(NSUInteger, OMWWobbleOptions) {
 -(void)jumpToTop:(nonnull id)sender;
 -(void)removeWithNoRemorse:(nonnull id)object;
 -(void)bookmarkWithURLs:(nonnull NSArray<NSURL *> *)urls;
+-(void)listenToEchoes:(nonnull NSArray<Echo *> *)echoes;
 -(void)saveToURL:(nonnull NSURL *)url forSaveOperation:(NSInteger)operation;
 -(void)indexWithItemNamed:(nonnull NSString *)name;
 -(void)methodAndReturnError:(NSError **)error;

--- a/test/IDE/print_omit_needless_words.swift
+++ b/test/IDE/print_omit_needless_words.swift
@@ -209,6 +209,7 @@
 // CHECK-OMIT-NEEDLESS-WORDS: func jumpToTop(_: Any)
 // CHECK-OMIT-NEEDLESS-WORDS: func removeWithNoRemorse(_: Any)
 // CHECK-OMIT-NEEDLESS-WORDS: func bookmark(with: [NSURL])
+// CHECK-OMIT-NEEDLESS-WORDS: func listen(to: [Echo])
 // CHECK-OMIT-NEEDLESS-WORDS: func save(to: NSURL, forSaveOperation: Int)
 // CHECK-OMIT-NEEDLESS-WORDS: func index(withItemNamed: String)
 // CHECK-OMIT-NEEDLESS-WORDS: func methodAndReturnError(_: AutoreleasingUnsafeMutablePointer<NSError?>!)


### PR DESCRIPTION
StringRef::drop_back() returns the new string; it doesn't mutate `this`.
