### PR TITLE
[coverage] Add scripts supporting specific coverage

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,2 +1,2 @@
 [flake8]
-filename = *.py,80+-check,Benchmark_Driver,Benchmark_DTrace.in,Benchmark_GuardMalloc.in,Benchmark_RuntimeLeaksRunner.in,build-script,check-incremental,gyb,line-directive,mock-distcc,ns-html2rst,recursive-lipo,rth,run-test,submit-benchmark-results,update-checkout,viewcfg,backtrace-check
+filename = *.py,80+-check,Benchmark_Driver,Benchmark_DTrace.in,Benchmark_GuardMalloc.in,Benchmark_RuntimeLeaksRunner.in,build-script,check-incremental,gyb,line-directive,mock-distcc,ns-html2rst,recursive-lipo,rth,run-test,submit-benchmark-results,update-checkout,viewcfg,backtrace-check,coverage-build-db,coverage-generate-data,coverage-touch-tests

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -144,6 +144,12 @@ if(PYTHONINTERP_FOUND)
       only_long
   )
 
+  if(NOT "${COVERAGE_DB}" STREQUAL "")
+    add_custom_target("touch-covering-tests"
+        COMMAND "${SWIFT_SOURCE_DIR}/utils/coverage-touch-tests" "--swift-dir" "${SWIFT_SOURCE_DIR}" "--coverage-db" "${COVERAGE_DB}"
+        COMMENT "Touching covering tests")
+  endif()
+
   foreach(SDK ${SWIFT_SDKS})
     foreach(ARCH ${SWIFT_SDK_${SDK}_ARCHITECTURES})
       # Configure variables for this subdirectory.
@@ -186,6 +192,10 @@ if(PYTHONINTERP_FOUND)
       if(SWIFT_BUILD_STDLIB AND SWIFT_INCLUDE_TESTS)
         list(APPEND test_dependencies
             "swift-reflection-test${VARIANT_SUFFIX}")
+      endif()
+
+      if(NOT "${COVERAGE_DB}" STREQUAL "")
+        list(APPEND test_dependencies "touch-covering-tests")
       endif()
 
       set(validation_test_dependencies

--- a/utils/build-script
+++ b/utils/build-script
@@ -811,6 +811,9 @@ class BuildScriptInvocation(object):
         if args.lit_args:
             impl_args += ["--llvm-lit-args=%s" % args.lit_args]
 
+        if args.coverage_db:
+            impl_args += ["--coverage-db=%s" % args.coverage_db]
+
         # Compute the set of host-specific variables, which we pass through to
         # the build script via environment variables.
         host_specific_variables = self.compute_host_specific_variables()
@@ -2008,6 +2011,11 @@ details of the setups of other systems or automated environments.""")
         help="lit args to use when testing",
         metavar="LITARGS",
         default="-sv")
+
+    parser.add_argument(
+        "--coverage-db",
+        help="coverage database to use when prioritizing testing",
+        metavar="PATH")
 
     args = migration.parse_args(parser, sys.argv[1:])
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -237,6 +237,7 @@ KNOWN_SETTINGS=(
     user-config-args            ""               "**Renamed to --extra-cmake-options**: User-supplied arguments to cmake when used to do configuration."
     only-execute                       "all"     "Only execute the named action (see implementation)"
     llvm-lit-args                      ""        "If set, override the lit args passed to LLVM"
+    coverage-db                        ""        "If set, coverage database to use when prioritizing testing"
     build-toolchain-only               ""        "If set, only build the necessary tools to build an external toolchain"
 )
 
@@ -727,6 +728,10 @@ function set_build_options_for_host() {
             -DLLVM_LIT_ARGS="${LLVM_LIT_ARGS}"
         )
     fi
+
+    swift_cmake_options+=(
+        -DCOVERAGE_DB="${COVERAGE_DB}"
+    )
 }
 
 function configure_default_options() {

--- a/utils/coverage-build-db
+++ b/utils/coverage-build-db
@@ -1,0 +1,204 @@
+#!/usr/bin/env python
+# utils/coverage-build-db - Build sqlite3 database from profdata
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import Queue
+import argparse
+import logging
+import multiprocessing
+import os
+import re
+import sqlite3
+import sys
+
+logging_format = '%(asctime)s %(levelname)s %(message)s'
+logging.basicConfig(level=logging.DEBUG,
+                    format=logging_format,
+                    filename='/tmp/%s.log' % os.path.basename(__file__),
+                    filemode='w')
+console = logging.StreamHandler()
+console.setLevel(logging.INFO)
+formatter = logging.Formatter(logging_format)
+console.setFormatter(formatter)
+logging.getLogger().addHandler(console)
+
+
+def parse_coverage_log(filepath):
+    """Return parsed coverage intervals from `llvm-profdata show` output at
+    `filepath`"""
+    logging.info('Parsing: %s', filepath)
+    test = os.path.basename(os.path.dirname(filepath)).rsplit('.', 1)[0]
+    with open(filepath) as f:
+        # Initial parse
+        parsed = []
+        for section in [section.split("\n")
+                        for section in f.read().split("\n\n")]:
+            if ".cpp:" in section[0] or ".h:" in section[0]:
+                parsed_section = [section[0].split(":", 1) + [test]]
+                for line in section[1:]:
+                    linedata = linedata_re.match(line).group(1, 2)
+                    parsed_section.append(linedata)
+                parsed.append(parsed_section)
+        # Build intervals
+        parsed_interval = []
+        for section in parsed:
+            new_section = [section[0]]
+            i = 1
+            if len(section) > 2:
+                while i < len(section)-1:
+                    while i < len(section)-1 and section[i][0] in ['0', None]:
+                        i += 1
+                    if i == len(section)-1:
+                        if section[i][0] not in ['0', None]:
+                            istart = int(section[i][1])
+                            iend = istart
+                            new_section.append((istart, iend))
+                        break
+                    istart = int(section[i][1])
+                    iend = istart  # single line interval starting
+                    while i < len(section)-1 and \
+                            int(section[i+1][1]) == iend + 1 and \
+                            section[i+1][0] not in ['0', None]:
+                        iend += 1
+                        i += 1
+                    new_section.append((istart, iend))
+                    i += 1
+            else:
+                if section[i][0] not in ['0', None]:
+                    istart = int(section[i][1])
+                    iend = istart
+                    new_section.append((istart, iend))
+            parsed_interval.append(new_section)
+        return parsed_interval
+
+
+def worker(args):
+    """Parse coverage log at path `args[0]` and place in queue `args[1]`"""
+    args[1].put(parse_coverage_log(args[0]))
+
+manager = multiprocessing.Manager()
+result_queue = manager.Queue()
+worker_queue = []
+
+linedata_re = re.compile(r"^\s*([^\s]+?)?\|\s*(\d+)\|")
+strings = dict()
+
+pool = multiprocessing.Pool(3)
+
+
+def insert_coverage_section_into_db(db_cursor, section):
+    """Insert parsed intervals in `section` into database at `db_cursor`"""
+    filename = section[0][0]
+    function = section[0][1]
+    test = section[0][2]
+    logging.debug('Inserting section into database for file: %s', filename)
+    if filename not in strings:
+        db_cursor.execute("INSERT INTO strings (string) VALUES (?)",
+                          (filename,))
+        strings[filename] = db_cursor.lastrowid
+    if test not in strings:
+        db_cursor.execute("INSERT INTO strings (string) VALUES (?)", (test,))
+        strings[test] = db_cursor.lastrowid
+    if function not in strings:
+        db_cursor.execute("INSERT INTO strings (string) VALUES (?)",
+                          (function,))
+        strings[function] = db_cursor.lastrowid
+    for istart, iend in section[1:]:
+        logging.debug('%s, %s, %s, %s, %s', function, filename, test, istart,
+                      iend)
+        db_cursor.execute("INSERT INTO coverage VALUES (?,?,?,?,?)",
+                          (strings[function], strings[filename],
+                           strings[test], istart, iend))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Build sqlite3 database from profdata')
+    parser.add_argument('root_directory',
+                        metavar='root-directory',
+                        help='a root directory to recursively search for '
+                             'coverage logs')
+    parser.add_argument('--coverage-filename',
+                        help='a coverage log file name to search for '
+                             '(default: coverage.log.demangled)',
+                        metavar='NAME',
+                        default='coverage.log.demangled')
+    parser.add_argument('--db-filepath',
+                        help='the filepath of the coverage db to build '
+                             '(default: coverage.db)',
+                        metavar='PATH',
+                        default='coverage.db')
+    parser.add_argument('--log',
+                        help='the level of information to log (default: info)',
+                        metavar='LEVEL',
+                        default='info',
+                        choices=['info', 'debug', 'warning', 'error',
+                                 'critical'])
+    args = parser.parse_args()
+
+    console.setLevel(level=args.log.upper())
+    logging.debug(args)
+
+    if not os.path.exists(args.root_directory):
+        logging.critical('Directory not found: %s', args.root_directory)
+        return 1
+
+    if os.path.exists(args.db_filepath):
+        logging.info('Deleting existing database: %s', args.db_filepath)
+        os.unlink(args.db_filepath)
+
+    logging.info('Creating database: %s', args.db_filepath)
+    conn = sqlite3.connect(args.db_filepath)
+
+    try:
+        logging.debug('Creating coverage table')
+        c = conn.cursor()
+        c.execute('''CREATE TABLE strings
+                     (id integer primary key autoincrement, string text)''')
+        c.execute('''CREATE TABLE coverage
+                     (function references strings(id),
+                      src references strings(id),
+                      test references strings(id),
+                      istart integer, iend integer)''')
+        conn.commit()
+
+        for root, folders, files in os.walk(args.root_directory):
+            for f in files:
+                if f == args.coverage_filename:
+                    filepath = os.path.join(root, f)
+                    logging.debug('Adding file to queue: %s', filepath)
+                    worker_queue.append((filepath, result_queue))
+
+        logging.info('Finished adding %s paths to queue', len(worker_queue))
+        pool.map_async(worker, worker_queue)
+
+        while True:
+            parsed = result_queue.get(timeout=60)
+            logging.info('Inserting coverage data into db for %s function(s)',
+                         len(parsed))
+            for section in parsed:
+                insert_coverage_section_into_db(c, section)
+            conn.commit()
+            result_queue.task_done()
+    except Queue.Empty:
+        logging.info('Queue exhausted. Shutting down...')
+    except KeyboardInterrupt:
+        logging.debug('Caught KeyboardInterrupt. Shutting down...')
+    finally:
+        logging.debug('Closing database')
+        conn.commit()
+        conn.close()
+        logging.debug('Terminating pool')
+        pool.terminate()
+
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/utils/coverage-generate-data
+++ b/utils/coverage-generate-data
@@ -1,0 +1,265 @@
+#!/usr/bin/env python
+# utils/coverage-generate-data - Generate, parse test run profdata
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+from multiprocessing import Pool
+import argparse
+import logging
+import multiprocessing
+import os
+import pipes
+import subprocess
+import sys
+import timeit
+
+NUM_CORES = multiprocessing.cpu_count()
+
+logging_format = '%(asctime)s %(levelname)s %(message)s'
+logging.basicConfig(level=logging.DEBUG,
+                    format=logging_format,
+                    filename='/tmp/%s.log' % os.path.basename(__file__),
+                    filemode='w')
+console = logging.StreamHandler()
+console.setLevel(logging.INFO)
+formatter = logging.Formatter(logging_format)
+console.setFormatter(formatter)
+logging.getLogger().addHandler(console)
+
+global_build_subdir = ''
+
+
+def quote_shell_cmd(cmd):
+    """Return `cmd` as a properly quoted shell string"""
+    return ' '.join([pipes.quote(a) for a in cmd])
+
+
+def call(cmd, verbose=True, show_cmd=True):
+    """Call `cmd` and optionally log debug info"""
+    formatted_cmd = quote_shell_cmd(cmd) if isinstance(cmd, list) else cmd
+    if show_cmd:
+        logging.info('$ ' + formatted_cmd)
+    start_time = timeit.default_timer()
+    process = subprocess.Popen(
+        cmd,
+        shell=(not isinstance(cmd, list)),
+        bufsize=1,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT
+    )
+    for line in iter(process.stdout.readline, b''):
+        if verbose:
+            logging.info('STDOUT: ' + line.rstrip())
+    end_time = timeit.default_timer()
+    logging.debug('END $ ' + formatted_cmd)
+    logging.debug('Return code: %s', process.returncode)
+    logging.debug('Elapsed time: %s', end_time - start_time)
+    return process.returncode
+
+
+def check_output(cmd, verbose=True, show_cmd=True):
+    """Return output of calling `cmd` and optionally log debug info"""
+    output = []
+    formatted_cmd = quote_shell_cmd(cmd) if isinstance(cmd, list) else cmd
+    if show_cmd:
+        logging.info('$ ' + formatted_cmd)
+    start_time = timeit.default_timer()
+    process = subprocess.Popen(
+        cmd,
+        shell=(not isinstance(cmd, list)),
+        bufsize=1,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT
+    )
+    for line in iter(process.stdout.readline, b''):
+        if verbose:
+            logging.info('STDOUT: ' + line.rstrip())
+        output.append(line)
+    end_time = timeit.default_timer()
+    logging.debug('Return code: %s', process.returncode)
+    logging.debug('Elapsed time: %s', end_time - start_time)
+    return (process.returncode, ''.join(output))
+
+
+def xcrun_find(cmd):
+    """Return path of `cmd` using xcrun -f"""
+    return check_output(['xcrun', '-f', cmd])[1].strip()
+
+
+llvm_cov = xcrun_find('llvm-cov')
+llvm_profdata = xcrun_find('llvm-profdata')
+
+
+def dump_coverage_data(merged_file):
+    """Dump coverage data of file at path `merged_file` using llvm-cov"""
+    try:
+        swift = os.path.join(global_build_subdir,
+                             'swift-macosx-x86_64/bin/swift')
+        coverage_log = os.path.join(os.path.dirname(merged_file),
+                                    'coverage.log')
+        testname = os.path.basename(os.path.dirname(merged_file))
+        logging.info('Searching for covered files: %s', testname)
+        (returncode, output) = check_output(
+                [llvm_cov, 'report', '-instr-profile=%s' % merged_file, swift],
+                verbose=False,
+                show_cmd=False
+        )
+        output = [line.split()[0]
+                  for line in output.split()
+                  if '0.00' not in line and '/swift' in line]
+        with open(coverage_log, 'w') as f:
+            logging.info('Dumping coverage data: %s', testname)
+            (returncode2, dumped) = check_output(
+                quote_shell_cmd(
+                    [llvm_cov, 'show', '-line-coverage-gt=0',
+                     '-instr-profile=%s' % merged_file, swift] +
+                    output
+                ),
+                verbose=False,
+                show_cmd=False
+            )
+            f.write(dumped)
+    except Exception as e:
+        logging.debug(str(e))
+
+
+def find_folders(root_path, suffix):
+    """Return a list of folder paths ending in `suffix` rooted at
+    `root_path`"""
+    found_folders = []
+    for root, folders, files in os.walk(root_path):
+        for folder in folders:
+            if folder.endswith(suffix):
+                folderpath = os.path.join(root, folder)
+                logging.debug('Found %s', folderpath)
+                found_folders.append(folderpath)
+    logging.info('Found %s "%s" folders', len(found_folders), suffix)
+    return found_folders
+
+
+def find_files(root_path, suffix):
+    """Return a list of file paths ending in `suffix` rooted at
+    `root_path`"""
+    found_files = []
+    for root, folders, files in os.walk(root_path):
+        for f in files:
+            if f.endswith(suffix):
+                fpath = os.path.join(root, f)
+                logging.debug('Found %s', fpath)
+                found_files.append(fpath)
+    logging.info('Found %s "%s" files', len(found_files), suffix)
+    return found_files
+
+
+def merge_profdir(profdir_path):
+    """Merge swift-*.profraw files contained in `profdir_path` into
+    merged.profraw"""
+    logging.info('Merging %s', profdir_path)
+    if not os.path.exists(os.path.join(profdir_path, 'merged.profraw')):
+        call('set -x; '
+             'cd %s; '
+             '%s merge -output merged.profraw swift-*.profraw && '
+             'rm swift-*.profraw' % (profdir_path, llvm_profdata))
+
+
+def demangle_coverage_data(coverage_log_path):
+    """Demangle coverage dump at `coverage_log_path` using c++filt"""
+    logging.info('Demangling %s', coverage_log_path)
+    cppfilt = '/usr/bin/c++filt'
+    demangled_log_path = coverage_log_path + '.demangled'
+    returncode = 1
+    with open(coverage_log_path) as cf, open(demangled_log_path, 'w') as df:
+        process = subprocess.Popen(
+            [cppfilt, '-n'],
+            stdin=subprocess.PIPE,
+            stdout=df,
+            stderr=subprocess.PIPE
+        )
+        for line in cf:
+            process.stdin.write(line)
+        process.stdin.close()
+        returncode = process.wait()
+    return returncode
+
+
+def main():
+    global global_build_subdir
+
+    parser = argparse.ArgumentParser(
+        description='Generate, parse test run profdata')
+    parser.add_argument('swift_dir', metavar='swift-dir')
+    parser.add_argument('--build-dir')
+    parser.add_argument('--build-subdir', default='coverage')
+    parser.add_argument('--log',
+                        help='the level of information to log (default: info)',
+                        metavar='LEVEL',
+                        default='info',
+                        choices=['info', 'debug', 'warning', 'error',
+                                 'critical'])
+    args = parser.parse_args()
+
+    console.setLevel(level=args.log.upper())
+    logging.debug(args)
+
+    swift_dir = os.path.realpath(os.path.abspath(args.swift_dir))
+    if args.build_dir:
+        build_dir = os.path.realpath(os.path.abspath(args.build_dir))
+    else:
+        build_dir = os.path.realpath(os.path.join(os.path.dirname(swift_dir),
+                                                  'build'))
+    build_subdir = os.path.join(build_dir, args.build_subdir)
+
+    global_build_subdir = build_subdir
+
+    build_script_cmd = [
+        os.path.join(swift_dir, 'utils/build-script'),
+        '--release',
+        '--no-assertions',
+        '--swift-analyze-code-coverage', 'not-merged',
+        '--test',
+        '--validation-test',
+        '--skip-test-ios',
+        '--skip-test-tvos',
+        '--skip-test-watchos',
+        '--skip-build-benchmark',
+        '--verbose-build',
+        '--lit-args=-v',
+        '--reconfigure',
+        '--build-ninja',
+        '--build-subdir', build_subdir
+    ]
+
+    if args.build_dir:
+        build_script_cmd += ['--build-dir', build_dir]
+
+    call(build_script_cmd)
+
+    assert global_build_subdir
+
+    pool = Pool(NUM_CORES)
+
+    logging.info('Starting merge on %s', build_dir)
+    folders = find_folders(build_dir, '.profdir')
+    pool.map_async(merge_profdir, folders).get(9999999)
+
+    logging.info('Starting coverage data dump...')
+    merged_profraw_files = find_files(build_dir, 'merged.profraw')
+    pool.map_async(dump_coverage_data, merged_profraw_files).get(9999999)
+
+    logging.info('Starting coverage data dump demangling...')
+    coverage_log_files = find_files(build_dir, 'coverage.log')
+    pool.map_async(demangle_coverage_data, coverage_log_files).get(9999999)
+    return 0
+
+if __name__ == '__main__':
+    try:
+        sys.exit(main())
+    except Exception as e:
+        logging.debug(str(e))
+        sys.exit(1)

--- a/utils/coverage-touch-tests
+++ b/utils/coverage-touch-tests
@@ -1,0 +1,165 @@
+#!/usr/bin/env python
+# utils/coverage-touch-tests - Touch tests covering git changes
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import argparse
+import logging
+import multiprocessing
+import os
+import re
+import subprocess
+import sys
+
+logging_format = '%(asctime)s %(levelname)s %(message)s'
+logging.basicConfig(level=logging.DEBUG,
+                    format=logging_format,
+                    filename='/tmp/%s.log' % os.path.basename(__file__),
+                    filemode='w')
+console = logging.StreamHandler()
+console.setLevel(logging.INFO)
+formatter = logging.Formatter(logging_format)
+console.setFormatter(formatter)
+logging.getLogger().addHandler(console)
+
+script_path = os.path.realpath(__file__)
+sql_query_covering = '''SELECT DISTINCT test_string.string
+FROM strings as src_string, coverage, strings as test_string
+WHERE src_string.string = '{0}'
+  AND ((istart <= {1} AND {1} <= iend) OR
+       (istart <= {2} AND {2} <= iend) OR
+       ({1} <= istart AND istart <= {2}))
+  AND src_string.id = coverage.src
+  AND test_string.id = coverage.test;'''
+
+
+def worker(args):
+    i, (coverage_db, (filename, (rstart, rend))) = args
+    logging.info('[%s] Finding covering tests for: %s %s',
+                 i+1, filename, (rstart, rend))
+    tmp_covering_tests = subprocess.check_output(
+        ['sqlite3',
+         coverage_db,
+         sql_query_covering.format(filename, rstart, rend)]
+    ).splitlines()
+    for covering_test in tmp_covering_tests:
+        logging.debug('  %s', covering_test)
+    logging.info('Found %s covering tests', len(tmp_covering_tests))
+    return set(tmp_covering_tests)
+
+
+NUM_CORES = multiprocessing.cpu_count()
+pool = multiprocessing.Pool(NUM_CORES)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Touch tests covering git changes')
+    parser.add_argument('--swift-dir',
+                        metavar='PATH',
+                        help='the path to a swift source directory containing '
+                             'changes',
+                        required=True)
+    parser.add_argument('--coverage-db',
+                        metavar='PATH',
+                        help='the path to a swift coverage database',
+                        required=True)
+    parser.add_argument('--log',
+                        help='the level of information to log (default: info)',
+                        metavar='LEVEL',
+                        default='info',
+                        choices=['info', 'debug', 'warning', 'error',
+                                 'critical'])
+    args = parser.parse_args()
+
+    for path in [args.swift_dir, args.coverage_db]:
+        assert os.path.exists(path), "Unable to find %s. Try absolute paths." \
+                                      % path
+
+    console.setLevel(level=args.log.upper())
+    logging.debug(args)
+    environment = os.environ.copy()
+    environment['GIT_EXTERNAL_DIFF'] = script_path
+    logging.info('Getting diff of swift dir: %s', args.swift_dir)
+    output = subprocess.check_output(['git', '-C', args.swift_dir, 'diff'],
+                                     env=environment)
+    changed_ranges = []
+    for line in output.splitlines():
+        logging.debug(line)
+        if line.startswith('FILENAME'):
+            filename = line.split()[1]
+        elif line.startswith('@'):
+            start_line, num_lines = re.match(
+                r'\@\@ \-(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? \@\@',
+                line
+            ).group(1, 2)
+            if num_lines:
+                start_line, num_lines = int(start_line), int(num_lines)
+                changed_range = (start_line, start_line + num_lines - 1)
+                logging.debug('Found changed range: %s %s',
+                              filename, changed_range)
+                changed_ranges.append(
+                    (args.coverage_db, (filename, changed_range)))
+            else:
+                start_line = int(start_line)
+                logging.debug('Found changed line: %s %s',
+                              filename, start_line)
+                changed_ranges.append(
+                    (args.coverage_db, (filename, (start_line, start_line))))
+
+    logging.info('Found %s changed ranges/lines', len(changed_ranges))
+    relevant_changes = [
+         cr for cr in changed_ranges
+         if cr[1][0].endswith('.cpp') or cr[1][0].endswith('.h')
+    ]
+    relevant_changes_count = len(relevant_changes)
+    logging.info('Finding covering tests for %s relevant ranges/lines...',
+                 relevant_changes_count)
+    covering_tests = set().union(*pool.map_async(
+        worker,
+        enumerate(relevant_changes)
+    ).get(9999999))
+
+    logging.info('Combined covering tests:')
+    for covering_test in covering_tests:
+        logging.debug('  %s', covering_test)
+    logging.info('Found %s combined covering tests',
+                 len(covering_tests))
+
+    logging.info('Touching covering tests:')
+    for root, folders, files in os.walk(args.swift_dir):
+        for filename in files:
+            if filename in covering_tests:
+                filepath = os.path.join(root, filename)
+                logging.info('  %s', filepath)
+                os.utime(filepath, None)
+
+    return 0
+
+
+def diff():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('path')
+    parser.add_argument('old_file')
+    parser.add_argument('old_hex')
+    parser.add_argument('old_mode')
+    parser.add_argument('new_file')
+    parser.add_argument('new_hex')
+    parser.add_argument('new_mode')
+    args = parser.parse_args()
+    print 'FILENAME', os.path.basename(args.new_file)
+    sys.stdout.flush()
+    subprocess.call(['diff', '-U0', args.old_file, args.new_file])
+    return 0
+
+if __name__ == '__main__':
+    if 'GIT_EXTERNAL_DIFF' in os.environ:
+        sys.exit(diff())
+    else:
+        sys.exit(main())


### PR DESCRIPTION
The three included Python scripts work together to generate a sqlite3
database containing mappings of all covered Swift source code regions to
the specific tests that cover them.

Additionally, build-script support is included for utilizing the
coverage database to prioritize tests covering changes in the Swift
repository.
