### PR TITLE
SR-0140: Bridge Optionals to nonnull ObjC objects by bridging their payload, or using a sentinel.

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3877,18 +3877,22 @@ ASTContext::getForeignRepresentationInfo(NominalTypeDecl *nominal,
        known->second.getGeneration() < CurrentGeneration)) {
     Optional<ForeignRepresentationInfo> result;
 
-    // Look for a conformance to _ObjectiveCBridgeable.
+    // Look for a conformance to _ObjectiveCBridgeable (other than Optional's--
+    // we don't want to allow exposing APIs with double-optional types like
+    // NSObject??, even though Optional is bridged to its underlying type).
     //
     // FIXME: We're implicitly depending on the fact that lookupConformance
     // is global, ignoring the module we provide for it.
-    if (auto objcBridgeable
-          = getProtocol(KnownProtocolKind::ObjectiveCBridgeable)) {
-      if (auto conformance
-            = dc->getParentModule()->lookupConformance(
-                nominal->getDeclaredType(), objcBridgeable,
-                getLazyResolver())) {
-        result =
-            ForeignRepresentationInfo::forBridged(conformance->getConcrete());
+    if (nominal != dc->getASTContext().getOptionalDecl()) {
+      if (auto objcBridgeable
+            = getProtocol(KnownProtocolKind::ObjectiveCBridgeable)) {
+        if (auto conformance
+              = dc->getParentModule()->lookupConformance(
+                  nominal->getDeclaredType(), objcBridgeable,
+                  getLazyResolver())) {
+          result =
+              ForeignRepresentationInfo::forBridged(conformance->getConcrete());
+        }
       }
     }
 
@@ -3984,6 +3988,11 @@ Type ASTContext::getBridgedToObjC(const DeclContext *dc, Type type,
   // Try to find a conformance that will enable bridging.
   auto findConformance =
     [&](KnownProtocolKind known) -> Optional<ProtocolConformanceRef> {
+      // Don't ascribe any behavior to Optional other than what we explicitly
+      // give it. We don't want things like AnyObject?? to work.
+      if (type->getAnyNominal() == getOptionalDecl())
+        return None;
+      
       // Find the protocol.
       auto proto = getProtocol(known);
       if (!proto) return None;

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -701,6 +701,7 @@ static ValueDecl *getIsOptionalOperation(ASTContext &Context, Identifier Id) {
   return builder.build(Id);
 }
 
+
 static ValueDecl *getAllocOperation(ASTContext &Context, Identifier Id) {
   Type PtrSizeTy = BuiltinIntegerType::getWordType(Context);
   Type ResultTy = Context.TheRawPointerType;

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1664,6 +1664,11 @@ optimizeBridgedSwiftToObjCCast(SILInstruction *Inst,
 
   auto SILFnTy = SILType::getPrimitiveObjectType(
       M.Types.getConstantFunctionType(BridgeFuncDeclRef));
+  
+  // TODO: Handle indirect argument to or return from witness function.
+  if (ParamTypes[0].isIndirect()
+      || BridgedFunc->getLoweredFunctionType()->getSingleResult().isIndirect())
+    return nullptr;
 
   // Get substitutions, if source is a bound generic type.
   ArrayRef<Substitution> Subs =
@@ -1730,9 +1735,9 @@ optimizeBridgedSwiftToObjCCast(SILInstruction *Inst,
     case ParameterConvention::Direct_Unowned:
       break;
     case ParameterConvention::Indirect_In:
+    case ParameterConvention::Indirect_In_Guaranteed:
     case ParameterConvention::Indirect_Inout:
     case ParameterConvention::Indirect_InoutAliasable:
-    case ParameterConvention::Indirect_In_Guaranteed:
     case ParameterConvention::Direct_Deallocating:
       llvm_unreachable("unsupported convention for bridging conversion");
   }

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -487,3 +487,78 @@ extension Optional {
   }
 
 }
+
+//===----------------------------------------------------------------------===//
+// Bridging
+//===----------------------------------------------------------------------===//
+
+#if _runtime(_ObjC)
+extension Optional : _ObjectiveCBridgeable {
+  // The object that represents `none` for an Optional of this type.
+  internal static var _nilSentinel : AnyObject {
+    @_silgen_name("_swift_Foundation_getOptionalNilSentinelObject")
+    get
+  }
+
+  public func _bridgeToObjectiveC() -> AnyObject {
+    // Bridge a wrapped value by unwrapping.
+    if let value = self {
+      return _bridgeAnythingToObjectiveC(value)
+    }
+    // Bridge nil using a sentinel.
+    return type(of: self)._nilSentinel
+  }
+
+  public static func _forceBridgeFromObjectiveC(_ source: AnyObject,
+                                         result: inout Optional<Wrapped>?) {
+    // Map the nil sentinel back to .none.
+    // NB that the signature of _forceBridgeFromObjectiveC adds another level
+    // of optionality, so we need to wrap the immediate result of the conversion
+    // in `.some`.
+    if source === _nilSentinel {
+      result = .some(.none)
+      return
+    }
+    // Otherwise, force-bridge the underlying value.
+    let unwrappedResult = source as! Wrapped
+    result = .some(.some(unwrappedResult))
+  }
+
+  public static func _conditionallyBridgeFromObjectiveC(_ source: AnyObject,
+                                             result: inout Optional<Wrapped>?)
+      -> Bool {
+    // Map the nil sentinel back to .none.
+    // NB that the signature of _forceBridgeFromObjectiveC adds another level
+    // of optionality, so we need to wrap the immediate result of the conversion
+    // in `.some` to indicate success of the bridging operation, with a nil
+    // result.
+    if source === _nilSentinel {
+      result = .some(.none)
+      return true
+    }
+    // Otherwise, try to bridge the underlying value.
+    if let unwrappedResult = source as? Wrapped {
+      result = .some(.some(unwrappedResult))
+      return true
+    } else {
+      result = .none
+      return false
+    }
+  }
+
+  public static func _unconditionallyBridgeFromObjectiveC(_ source: AnyObject?)
+      -> Optional<Wrapped> {
+    if let nonnullSource = source {
+      // Map the nil sentinel back to none.
+      if nonnullSource === _nilSentinel {
+        return .none
+      } else {
+        return .some(nonnullSource as! Wrapped)
+      }
+    } else {
+      // If we unexpectedly got nil, just map it to `none` too.
+      return .none
+    }
+  }
+}
+#endif

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -2513,6 +2513,18 @@ bool swift::swift_dynamicCast(OpaqueValue *dest,
     // unwrapping the target. This handles an optional source wrapped within an
     // existential that Optional conforms to (Any).
     if (auto srcExistentialType = dyn_cast<ExistentialTypeMetadata>(srcType)) {
+#if SWIFT_OBJC_INTEROP
+      // If coming from AnyObject, we may want to bridge.
+      if (srcExistentialType->Flags.getSpecialProtocol()
+            == SpecialProtocol::AnyObject) {
+        if (auto targetBridgeWitness = findBridgeWitness(targetType)) {
+          return _dynamicCastClassToValueViaObjCBridgeable(dest, src, srcType,
+                                                           targetType,
+                                                           targetBridgeWitness,
+                                                           flags);
+        }
+      }
+#endif
       return _dynamicCastFromExistential(dest, src, srcExistentialType,
                                          targetType, flags);
     }

--- a/stdlib/public/stubs/CMakeLists.txt
+++ b/stdlib/public/stubs/CMakeLists.txt
@@ -6,6 +6,7 @@ if(SWIFT_HOST_VARIANT MATCHES "${SWIFT_DARWIN_VARIANTS}")
       Availability.mm
       DispatchShims.mm
       FoundationHelpers.mm
+      OptionalBridgingHelper.mm
       Reflection.mm
       SwiftNativeNSXXXBase.mm.gyb)
   set(LLVM_OPTIONAL_SOURCES

--- a/stdlib/public/stubs/OptionalBridgingHelper.mm
+++ b/stdlib/public/stubs/OptionalBridgingHelper.mm
@@ -1,0 +1,100 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include <Foundation/Foundation.h>
+#include "swift/Basic/Lazy.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/Runtime/Metadata.h"
+#include "swift/Runtime/Mutex.h"
+#include "swift/Runtime/ObjCBridge.h"
+#include <vector>
+
+using namespace swift;
+
+/// Class of sentinel objects used to represent the `nil` value of nested
+/// optionals.
+@interface _SwiftNull : NSObject {
+@public
+  unsigned depth;
+}
+@end
+
+@implementation _SwiftNull : NSObject
+
+- (NSString*)description {
+  return [NSString stringWithFormat:@"<_SwiftNull %u>", self->depth];
+}
+
+- (void)dealloc {
+  [super dealloc];
+}
+
+@end
+
+namespace {
+
+struct SwiftNullSentinelCache {
+  std::vector<id> Cache;
+  StaticReadWriteLock Lock;
+};
+
+static Lazy<SwiftNullSentinelCache> Sentinels;
+
+static id getSentinelForDepth(unsigned depth) {
+  // For unnested optionals, use NSNull.
+  if (depth == 1)
+    return SWIFT_LAZY_CONSTANT([NSNull null]);
+  // Otherwise, make up our own sentinel.
+  // See if we created one for this depth.
+  auto &theSentinels = Sentinels.get();
+  unsigned depthIndex = depth - 2;
+  {
+    StaticScopedReadLock lock(theSentinels.Lock);
+    const auto &cache = theSentinels.Cache;
+    if (depthIndex < cache.size()) {
+      id cached = cache[depthIndex];
+      if (cached)
+        return cached;
+    }
+  }
+  // Make one if we need to.
+  {
+    StaticScopedWriteLock lock(theSentinels.Lock);
+    if (depthIndex >= theSentinels.Cache.size())
+      theSentinels.Cache.resize(depthIndex + 1);
+    auto &cached = theSentinels.Cache[depthIndex];
+    // Make sure another writer didn't sneak in.
+    if (!cached) {
+      auto sentinel = [[_SwiftNull alloc] init];
+      sentinel->depth = depth;
+      cached = sentinel;
+    }
+    return cached;
+  }
+}
+
+}
+
+/// Return the sentinel object to use to represent `nil` for a given Optional
+/// type.
+SWIFT_RUNTIME_STDLIB_INTERFACE SWIFT_CC(swift)
+extern "C"
+id _swift_Foundation_getOptionalNilSentinelObject(const Metadata *Wrapped) {
+  // Figure out the depth of optionality we're working with.
+  unsigned depth = 1;
+  while (Wrapped->getKind() == MetadataKind::Optional) {
+    ++depth;
+    Wrapped = cast<EnumMetadata>(Wrapped)->getGenericArgs()[0];
+  }
+  
+  return objc_retain(getSentinelForDepth(depth));
+}

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -126,27 +126,29 @@ func passingToId<T: CP, U>(receiver: NSIdLover,
   // CHECK: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
   receiver.takesId(knownUnbridged)
 
+  // These cases bridge using Optional's _ObjectiveCBridgeable conformance.
+
   // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
+  // CHECK: [[BRIDGE_OPTIONAL:%.*]] = function_ref @_TFSq19_bridgeToObjectiveCfT_Ps9AnyObject_
   // CHECK: [[TMP:%.*]] = alloc_stack $Optional<String>
   // CHECK: store [[OPT_STRING]] to [[TMP]]
-  // CHECK: [[BRIDGE_ANYTHING:%.*]] = function_ref @_TFs27_bridgeAnythingToObjectiveC
-  // CHECK: [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<Optional<String>>([[TMP]])
+  // CHECK: [[ANYOBJECT:%.*]] = apply [[BRIDGE_OPTIONAL]]<String>([[TMP]])
   // CHECK: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
   receiver.takesId(optionalA)
 
   // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
+  // CHECK: [[BRIDGE_OPTIONAL:%.*]] = function_ref @_TFSq19_bridgeToObjectiveCfT_Ps9AnyObject_
   // CHECK: [[TMP:%.*]] = alloc_stack $Optional<NSString>
   // CHECK: store [[OPT_NSSTRING]] to [[TMP]]
-  // CHECK: [[BRIDGE_ANYTHING:%.*]] = function_ref @_TFs27_bridgeAnythingToObjectiveC
-  // CHECK: [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<Optional<NSString>>([[TMP]])
+  // CHECK: [[ANYOBJECT:%.*]] = apply [[BRIDGE_OPTIONAL]]<NSString>([[TMP]])
   // CHECK: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
   receiver.takesId(optionalB)
 
   // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
   // CHECK: [[TMP:%.*]] = alloc_stack $Optional<Any>
   // CHECK: copy_addr [[OPT_ANY]] to [initialization] [[TMP]]
-  // CHECK: [[BRIDGE_ANYTHING:%.*]] = function_ref @_TFs27_bridgeAnythingToObjectiveC
-  // CHECK: [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<Optional<Any>>([[TMP]])
+  // CHECK: [[BRIDGE_OPTIONAL:%.*]] = function_ref @_TFSq19_bridgeToObjectiveCfT_Ps9AnyObject_
+  // CHECK: [[ANYOBJECT:%.*]] = apply [[BRIDGE_OPTIONAL]]<Any>([[TMP]])
   // CHECK: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
   receiver.takesId(optionalC)
 

--- a/test/stdlib/OptionalBridge.swift
+++ b/test/stdlib/OptionalBridge.swift
@@ -1,0 +1,135 @@
+//===--- OptionalBridge.swift - Tests of Optional bridging ----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+import StdlibUnittest
+
+let tests = TestSuite("OptionalBridge")
+
+// Work around bugs in the type checker preventing casts back to optional.
+func cast<T>(_ value: AnyObject, to: T.Type) -> T {
+  return value as! T
+}
+
+// expectEqual() helpers for deeper-nested nullability than StdlibUnittest
+// provides.
+func expectEqual<T: Equatable>(_ x: T??, _ y: T??) {
+  switch (x, y) {
+  case (.some(let xx), .some(let yy)):
+    expectEqual(xx, yy)
+  case (.none, .none):
+    return
+  default:
+    expectUnreachable("\(T.self)?? values don't match: \(x) vs. \(y)")
+  }
+}
+func expectEqual<T: Equatable>(_ x: T???, _ y: T???) {
+  switch (x, y) {
+  case (.some(let xx), .some(let yy)):
+    expectEqual(xx, yy)
+  case (.none, .none):
+    return
+  default:
+    expectUnreachable("\(T.self)??? values don't match: \(x) vs. \(y)")
+  }
+}
+
+tests.test("wrapped value") {
+  let unwrapped = "foo"
+  let wrapped = Optional(unwrapped)
+  let doubleWrapped = Optional(wrapped)
+
+  let unwrappedBridged = unwrapped as AnyObject
+  let wrappedBridged = wrapped as AnyObject
+  let doubleWrappedBridged = doubleWrapped as AnyObject
+  expectTrue(unwrappedBridged.isEqual(to: wrappedBridged)
+             && wrappedBridged.isEqual(to: doubleWrappedBridged))
+
+  let unwrappedCastBack = cast(unwrappedBridged, to: String.self)
+  let wrappedCastBack = cast(wrappedBridged, to: Optional<String>.self)
+  let doubleWrappedCastBack = cast(doubleWrappedBridged, to: Optional<String?>.self)
+
+  expectEqual(unwrapped, unwrappedCastBack)
+  expectEqual(wrapped, wrappedCastBack)
+  expectEqual(doubleWrapped, doubleWrappedCastBack)
+}
+
+tests.test("wrapped class instance") {
+  let unwrapped = LifetimeTracked(0)
+  let wrapped = Optional(unwrapped)
+
+  expectTrue(wrapped as AnyObject === unwrapped as AnyObject)
+}
+
+tests.test("nil") {
+  let null: String? = nil
+  let wrappedNull = Optional(null)
+  let doubleWrappedNull = Optional(wrappedNull)
+
+  let nullBridged = null as AnyObject
+  let wrappedNullBridged = wrappedNull as AnyObject
+  let doubleWrappedNullBridged = doubleWrappedNull as AnyObject
+
+  expectTrue(nullBridged === NSNull())
+  expectTrue(wrappedNullBridged === NSNull())
+  expectTrue(doubleWrappedNullBridged === NSNull())
+
+  let nullCastBack = cast(nullBridged, to: Optional<String>.self)
+  let wrappedNullCastBack = cast(nullBridged, to: Optional<String?>.self)
+  let doubleWrappedNullCastBack = cast(nullBridged, to: Optional<String??>.self)
+
+  expectEqual(nullCastBack, null)
+  expectEqual(wrappedNullCastBack, wrappedNull)
+  expectEqual(doubleWrappedNullCastBack, doubleWrappedNull)
+}
+
+tests.test("nil in nested optional") {
+  let doubleNull: String?? = nil
+  let wrappedDoubleNull = Optional(doubleNull)
+
+  let doubleNullBridged = doubleNull as AnyObject
+  let wrappedDoubleNullBridged = wrappedDoubleNull as AnyObject
+
+  expectTrue(doubleNullBridged === wrappedDoubleNullBridged)
+  expectTrue(doubleNullBridged !== NSNull())
+
+  let doubleNullCastBack = cast(doubleNullBridged, to: Optional<String?>.self)
+  let wrappedDoubleNullCastBack = cast(doubleNullBridged, to: Optional<String??>.self)
+
+  expectEqual(doubleNullCastBack, doubleNull)
+  expectEqual(wrappedDoubleNullCastBack, wrappedDoubleNull)
+
+  let tripleNull: String??? = nil
+  let tripleNullBridged = tripleNull as AnyObject
+
+  expectTrue(doubleNullBridged !== tripleNullBridged)
+
+  let tripleNullCastBack = cast(tripleNullBridged, to: Optional<String??>.self)
+  expectEqual(tripleNullCastBack, tripleNull)
+}
+
+tests.test("collection of Optional") {
+  let holeyArray: [LifetimeTracked?] = [LifetimeTracked(0), nil, LifetimeTracked(1)]
+  let nsArray = holeyArray as NSArray
+
+  autoreleasepool {
+    expectTrue((nsArray[0] as AnyObject) === holeyArray[0]!)
+    expectTrue((nsArray[1] as AnyObject) === NSNull())
+    expectTrue((nsArray[2] as AnyObject) === holeyArray[2]!)
+  }
+}
+
+runAllTests()


### PR DESCRIPTION
id-as-Any lets you pass Optional to an ObjC API that takes `nonnull id`, and also lets you bridge containers of `Optional` to `NSArray` etc. When this occurs, we can unwrap the value and bridge it so that inhabited optionals still pass into ObjC in the expected way, but we need something to represent `none` other than the `nil` pointer. Cocoa provides `NSNull` as the canonical "null for containers" object, which is the least bad of many possible answers. If we happen to have the rare nested optional `T??`, there is no precedented analog for these in Cocoa, so just generate a unique sentinel object to preserve the `nil`-ness depth so we at least don't lose information round-tripping across the ObjC-Swift bridge.

Making Optional conform to _ObjectiveCBridgeable is more or less enough to make this all work, though there are a few additional edge case things that need to be fixed up. We don't want to accept `AnyObject??` as an @objc-compatible type, so special-case Optional in `getForeignRepresentable`.

Implements SR-0140 (rdar://problem/27905315).
