### PR TITLE
[IRGen] Handle 'super' method sends in ObjC partial application forwarders

### DIFF
--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -786,7 +786,7 @@ llvm::Value *irgen::emitObjCAllocObjectCall(IRGenFunction &IGF,
 }
 
 static llvm::Function *emitObjCPartialApplicationForwarder(IRGenModule &IGM,
-                                            SILDeclRef method,
+                                                           ObjCMethod method,
                                             CanSILFunctionType origMethodType,
                                             CanSILFunctionType resultType,
                                             const HeapLayout &layout,
@@ -884,10 +884,12 @@ static llvm::Function *emitObjCPartialApplicationForwarder(IRGenModule &IGM,
   }
 
   // Prepare the call to the underlying method.
+  
   CallEmission emission
-    = prepareObjCMethodRootCall(subIGF, method, origMethodType, origMethodType,
+    = prepareObjCMethodRootCall(subIGF, method.getMethod(),
+                                origMethodType, origMethodType,
                                 ArrayRef<Substitution>{},
-                                ObjCMessageKind::Normal);
+                                method.getMessageKind());
   
   Explosion args;
 
@@ -895,7 +897,8 @@ static llvm::Function *emitObjCPartialApplicationForwarder(IRGenModule &IGM,
   if (formalIndirectResult)
     args.add(formalIndirectResult);
 
-  addObjCMethodCallImplicitArguments(subIGF, args, method, self, SILType());
+  addObjCMethodCallImplicitArguments(subIGF, args, method.getMethod(), self,
+                                     method.getSearchType());
   args.add(params.claimAll());
   emission.setArgs(args);
   
@@ -930,7 +933,7 @@ static llvm::Function *emitObjCPartialApplicationForwarder(IRGenModule &IGM,
 }
 
 void irgen::emitObjCPartialApplication(IRGenFunction &IGF,
-                                       SILDeclRef method,
+                                       ObjCMethod method,
                                        CanSILFunctionType origMethodType,
                                        CanSILFunctionType resultType,
                                        llvm::Value *self,

--- a/lib/IRGen/GenObjC.h
+++ b/lib/IRGen/GenObjC.h
@@ -46,6 +46,42 @@ namespace irgen {
     Peer
   };
 
+  /// Represents an ObjC method reference that will be invoked by a form of
+  /// objc_msgSend.
+  class ObjCMethod {
+    /// The SILDeclRef declaring the method.
+    SILDeclRef method;
+    /// For a bounded call, the static type that provides the lower bound for
+    /// the search. Null for unbounded calls that will look for the method in
+    /// the dynamic type of the object.
+    llvm::PointerIntPair<SILType, 1, bool> searchTypeAndSuper;
+
+  public:
+    ObjCMethod(SILDeclRef method, SILType searchType, bool startAtSuper)
+      : method(method), searchTypeAndSuper(searchType, startAtSuper)
+    {}
+    
+    SILDeclRef getMethod() const { return method; }
+    SILType getSearchType() const { return searchTypeAndSuper.getPointer(); }
+    bool shouldStartAtSuper() const { return searchTypeAndSuper.getInt(); }
+    
+    /// FIXME: Thunk down to a Swift function value?
+    llvm::Value *getExplosionValue(IRGenFunction &IGF) const {
+      llvm_unreachable("thunking unapplied objc method to swift function "
+                       "not yet implemented");
+    }
+    
+    /// Determine the kind of message that should be sent to this
+    /// method.
+    ObjCMessageKind getMessageKind() const {
+      // Determine the kind of message send to perform.
+      if (!getSearchType()) return ObjCMessageKind::Normal;
+
+      return shouldStartAtSuper()? ObjCMessageKind::Super
+                                 : ObjCMessageKind::Peer;
+    }
+  };
+
   CallEmission prepareObjCMethodRootCall(IRGenFunction &IGF,
                                          SILDeclRef method,
                                          CanSILFunctionType origFnType,
@@ -62,7 +98,7 @@ namespace irgen {
   /// Emit a partial application of an Objective-C method to its 'self'
   /// argument.
   void emitObjCPartialApplication(IRGenFunction &IGF,
-                                  SILDeclRef method,
+                                  ObjCMethod method,
                                   CanSILFunctionType origType,
                                   CanSILFunctionType partialAppliedType,
                                   llvm::Value *self,

--- a/test/IRGen/objc_super.swift
+++ b/test/IRGen/objc_super.swift
@@ -11,6 +11,7 @@ import gizmo
 // CHECK: [[TYPE:%swift.type]] = type
 // CHECK: [[HOOZIT:%C10objc_super6Hoozit]] = type
 // CHECK: [[NSRECT:%VSC6NSRect]] = type
+// CHECK: [[PARTIAL_APPLY_CLASS:%C10objc_super12PartialApply]] = type
 // CHECK: [[SUPER:%objc_super]] = type
 // CHECK: [[OBJC:%objc_object]] = type
 // CHECK: [[GIZMO:%CSo5Gizmo]] = type
@@ -65,5 +66,22 @@ class Hoozit : Gizmo {
     // CHECK: ret
     super.init(bellsOn:y)
   }
+  // CHECK: }
+}
+
+func acceptFn(_ fn: () -> Void) { }
+
+class PartialApply : Gizmo {
+  // CHECK: define hidden void @_TFC10objc_super12PartialApply4frobfT_T_([[PARTIAL_APPLY_CLASS]]*) {{.*}} {
+  override func frob() {
+    // CHECK: call void @_TF10objc_super8acceptFnFFT_T_T_(i8* bitcast (void (%swift.refcounted*)* [[PARTIAL_FORWARDING_THUNK:@[A-Za-z0-9_]+]] to i8*), %swift.refcounted* %3)
+    acceptFn( super.frob )
+  }
+  // CHECK: }
+
+  // CHECK: define internal void [[PARTIAL_FORWARDING_THUNK]](%swift.refcounted*) #0 {
+  // CHECK: call %swift.type* @_TMaC10objc_super12PartialApply()
+  // CHECK: @"\01L_selector(frob)"
+  // CHECK: call void bitcast (void ()* @objc_msgSendSuper2
   // CHECK: }
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->

The Objective-C partial application forwarder that one gets when
using, e.g., "super.foo" as a function value was doing a normal
objc_msgSend. Fix the miscompile by threading all of the information
about the Objective-C message send through the forwarder.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [rdar://problem/28140758](rdar://problem/28140758).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
