### PR TITLE
[sil-arc-code-motion] Properly propagate the atomicity of reference-сounting instructions

### DIFF
--- a/include/swift/SILOptimizer/Utils/Local.h
+++ b/include/swift/SILOptimizer/Utils/Local.h
@@ -45,10 +45,12 @@ inline ValueBaseUserRange makeUserRange(
 using DeadInstructionSet = llvm::SmallSetVector<SILInstruction *, 8>;
 
 /// \brief Create a retain of \p Ptr before the \p InsertPt.
-SILInstruction *createIncrementBefore(SILValue Ptr, SILInstruction *InsertPt);
+SILInstruction *createIncrementBefore(SILValue Ptr, SILInstruction *InsertPt,
+                                      Atomicity InstAtomicity);
 
 /// \brief Create a release of \p Ptr before the \p InsertPt.
-SILInstruction *createDecrementBefore(SILValue Ptr, SILInstruction *InsertPt);
+SILInstruction *createDecrementBefore(SILValue Ptr, SILInstruction *InsertPt,
+                                      Atomicity InstAtomicity);
 
 /// \brief For each of the given instructions, if they are dead delete them
 /// along with their dead operands.

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -701,7 +701,9 @@ void FunctionSignatureTransform::OwnedToGuaranteedTransformFunctionResults() {
       }
       // Create a release to balance it out.
       assert(isa<ApplyInst>(X) && "Unknown epilogue retain");
-      createDecrementBefore(X, dyn_cast<ApplyInst>(X)->getParent()->getTerminator());
+      createDecrementBefore(
+          X, dyn_cast<ApplyInst>(X)->getParent()->getTerminator(),
+          Atomicity::Atomic);
     }
   }
 }

--- a/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
@@ -140,7 +140,8 @@ static bool hoistSILArgumentReleaseInst(SILBasicBlock *BB) {
   // Ok, we can get all the incoming values and create releases for them.
   unsigned indices = 0;
   for (auto P : BB->getPreds()) {
-    createDecrementBefore(PredValues[indices++], P->getTerminator());
+    createDecrementBefore(PredValues[indices++], P->getTerminator(),
+                          Atomicity::Atomic);
   }
   // Erase the old instruction.
   Head->eraseFromParent();

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -35,36 +35,48 @@ using namespace swift;
 /// Creates an increment on \p Ptr before insertion point \p InsertPt that
 /// creates a strong_retain if \p Ptr has reference semantics itself or a
 /// retain_value if \p Ptr is a non-trivial value without reference-semantics.
-SILInstruction *
-swift::createIncrementBefore(SILValue Ptr, SILInstruction *InsertPt) {
+SILInstruction *swift::createIncrementBefore(SILValue Ptr,
+                                             SILInstruction *InsertPt,
+                                             Atomicity InstAtomicity) {
   // Set up the builder we use to insert at our insertion point.
   SILBuilder B(InsertPt);
   auto Loc = RegularLocation(SourceLoc());
 
+  if (auto ARI = dyn_cast<AllocRefInst>(Ptr)) {
+    if (ARI->isAllocatingStack())
+      InstAtomicity = Atomicity::NonAtomic;
+  }
+
   // If Ptr is refcounted itself, create the strong_retain and
   // return.
   if (Ptr->getType().isReferenceCounted(B.getModule()))
-    return B.createStrongRetain(Loc, Ptr, Atomicity::Atomic);
+    return B.createStrongRetain(Loc, Ptr, InstAtomicity);
 
   // Otherwise, create the retain_value.
-  return B.createRetainValue(Loc, Ptr, Atomicity::Atomic);
+  return B.createRetainValue(Loc, Ptr, InstAtomicity);
 }
 
 /// Creates a decrement on \p Ptr before insertion point \p InsertPt that
 /// creates a strong_release if \p Ptr has reference semantics itself or
 /// a release_value if \p Ptr is a non-trivial value without reference-semantics.
-SILInstruction *
-swift::createDecrementBefore(SILValue Ptr, SILInstruction *InsertPt) {
+SILInstruction *swift::createDecrementBefore(SILValue Ptr,
+                                             SILInstruction *InsertPt,
+                                             Atomicity InstAtomicity) {
   // Setup the builder we will use to insert at our insertion point.
   SILBuilder B(InsertPt);
   auto Loc = RegularLocation(SourceLoc());
 
+  if (auto ARI = dyn_cast<AllocRefInst>(Ptr)) {
+    if (ARI->isAllocatingStack())
+      InstAtomicity = Atomicity::NonAtomic;
+  }
+
   // If Ptr has reference semantics itself, create a strong_release.
   if (Ptr->getType().isReferenceCounted(B.getModule()))
-    return B.createStrongRelease(Loc, Ptr, Atomicity::Atomic);
+    return B.createStrongRelease(Loc, Ptr, InstAtomicity);
 
   // Otherwise create a release value.
-  return B.createReleaseValue(Loc, Ptr, Atomicity::Atomic);
+  return B.createReleaseValue(Loc, Ptr, InstAtomicity);
 }
 
 /// \brief Perform a fast local check to see if the instruction is dead.

--- a/test/SILOptimizer/retain_release_code_motion.sil
+++ b/test/SILOptimizer/retain_release_code_motion.sil
@@ -443,3 +443,48 @@ bb3:
   %5 = tuple()
   return %5 : $()
 }
+
+sil @c_foo : $@convention(thin) () -> Int32
+
+// Check that all nonatomic RC instructions are preserved as long
+// as all original  RC instructions are non-atomic.
+// CHECK-LABEL: sil @test_retain_release_code_motion_with_nonatomic_rr
+// CHECK: strong_retain [nonatomic]
+// CHECK: strong_release [nonatomic]
+// CHECK: strong_release [nonatomic]
+sil @test_retain_release_code_motion_with_nonatomic_rr : $@convention(thin) () -> Int32 {
+bb0:
+  %0 = alloc_ref [stack] $C
+  %1 = integer_literal $Builtin.Int32, 0
+  %2 = struct $Int32 (%1 : $Builtin.Int32)
+  %3 = function_ref @c_foo : $@convention(thin) () -> Int32
+  strong_retain [nonatomic] %0 : $C
+  %5 = apply %3() : $@convention(thin) () -> Int32
+  strong_release [nonatomic] %0 : $C
+  strong_release [nonatomic] %0 : $C
+  dealloc_ref [stack] %0 : $C
+  return %2 : $Int32
+}
+
+// Check that all nonatomic RC instructions are marked as atomic
+// because one of the original RC instructions is atomic.
+// CHECK-LABEL: sil @test_retain_release_code_motion_with_atomic_and_nonatomic_rr
+// CHECK-NOT: strong_retain [nonatomic]
+// CHECK-NOT: strong_release [nonatomic]
+// CHECK-NOT: strong_release [nonatomic]
+// CHECK: strong_retain
+// CHECK: strong_release
+// CHECK: strong_release
+sil @test_retain_release_code_motion_with_atomic_and_nonatomic_rr : $@convention(thin) () -> Int32 {
+bb0:
+  %0 = alloc_ref $C
+  %1 = integer_literal $Builtin.Int32, 0
+  %2 = struct $Int32 (%1 : $Builtin.Int32)
+  %3 = function_ref @c_foo : $@convention(thin) () -> Int32
+  strong_retain [nonatomic] %0 : $C
+  %5 = apply %3() : $@convention(thin) () -> Int32
+  // This RC instruction is atomic and thus all others should be considered as atomic as well.
+  strong_release %0 : $C
+  strong_release [nonatomic] %0 : $C
+  return %2 : $Int32
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->

Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

ARCCodeMotion was not respecting the atomicity of the reference-counting instructions being moved.
