### PR TITLE
[Foundation overlay] Enable custom AnyHashable representation for NSMeasurement

### DIFF
--- a/stdlib/public/SDK/Foundation/Measurement.swift
+++ b/stdlib/public/SDK/Foundation/Measurement.swift
@@ -227,10 +227,6 @@ extension Measurement : _ObjectiveCBridgeable {
     }
 }
 
-/*
-FIXME(id-as-any): can't write this code because of:
-<rdar://problem/27539951> "unhandled generic bridged type" when bridging NSMeasurement
-
 @available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
 extension NSMeasurement : _HasCustomAnyHashableRepresentation {
     // Must be @nonobjc to avoid infinite recursion during bridging.
@@ -239,7 +235,6 @@ extension NSMeasurement : _HasCustomAnyHashableRepresentation {
         return AnyHashable(self as Measurement)
     }
 }
-*/
 
 // This workaround is required for the time being, because Swift doesn't support covariance for Measurement (26607639)
 @available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)

--- a/test/stdlib/TestMeasurement.swift
+++ b/test/stdlib/TestMeasurement.swift
@@ -163,19 +163,17 @@ class TestMeasurement : TestMeasurementSuper {
     }
 
     func test_AnyHashableCreatedFromNSMeasurement() {
-        if #available(iOS 8.0, *) {
-            let values: [NSMeasurement] = [
-                NSMeasurement(doubleValue: 100, unit: UnitLength.meters),
-                NSMeasurement(doubleValue: 100, unit: UnitLength.kilometers),
-                NSMeasurement(doubleValue: 100, unit: UnitLength.kilometers),
-            ]
-            let anyHashables = values.map(AnyHashable.init)
-            expectEqual(Measurement.self, type(of: anyHashables[0].base))
-            expectEqual(Measurement.self, type(of: anyHashables[1].base))
-            expectEqual(Measurement.self, type(of: anyHashables[2].base))
-            expectNotEqual(anyHashables[0], anyHashables[1])
-            expectEqual(anyHashables[1], anyHashables[2])
-        }
+        let values: [NSMeasurement] = [
+            NSMeasurement(doubleValue: 100, unit: UnitLength.meters),
+            NSMeasurement(doubleValue: 100, unit: UnitLength.kilometers),
+            NSMeasurement(doubleValue: 100, unit: UnitLength.kilometers),
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(Measurement<Unit>.self, type(of: anyHashables[0].base))
+        expectEqual(Measurement<Unit>.self, type(of: anyHashables[1].base))
+        expectEqual(Measurement<Unit>.self, type(of: anyHashables[2].base))
+        expectNotEqual(anyHashables[0], anyHashables[1])
+        expectEqual(anyHashables[1], anyHashables[2])
     }
 }
 

--- a/test/stdlib/TestMeasurement.swift
+++ b/test/stdlib/TestMeasurement.swift
@@ -147,6 +147,36 @@ class TestMeasurement : TestMeasurementSuper {
         expectTrue(fiveKM < sevenThousandM)
         expectTrue(fiveKM <= fiveThousandM)
     }
+
+    func test_AnyHashableContainingMeasurement() {
+        let values: [Measurement<UnitLength>] = [
+          Measurement(value: 100, unit: UnitLength.meters),
+          Measurement(value: 100, unit: UnitLength.kilometers),
+          Measurement(value: 100, unit: UnitLength.kilometers),
+        ]
+        let anyHashables = values.map(AnyHashable.init)
+        expectEqual(Measurement<UnitLength>.self, type(of: anyHashables[0].base))
+        expectEqual(Measurement<UnitLength>.self, type(of: anyHashables[1].base))
+        expectEqual(Measurement<UnitLength>.self, type(of: anyHashables[2].base))
+        expectNotEqual(anyHashables[0], anyHashables[1])
+        expectEqual(anyHashables[1], anyHashables[2])
+    }
+
+    func test_AnyHashableCreatedFromNSMeasurement() {
+        if #available(iOS 8.0, *) {
+            let values: [NSMeasurement] = [
+                NSMeasurement(doubleValue: 100, unit: UnitLength.meters),
+                NSMeasurement(doubleValue: 100, unit: UnitLength.kilometers),
+                NSMeasurement(doubleValue: 100, unit: UnitLength.kilometers),
+            ]
+            let anyHashables = values.map(AnyHashable.init)
+            expectEqual(Measurement.self, type(of: anyHashables[0].base))
+            expectEqual(Measurement.self, type(of: anyHashables[1].base))
+            expectEqual(Measurement.self, type(of: anyHashables[2].base))
+            expectNotEqual(anyHashables[0], anyHashables[1])
+            expectEqual(anyHashables[1], anyHashables[2])
+        }
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -159,6 +189,8 @@ if #available(OSX 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *) {
     MeasurementTests.test("testMeasurementFormatter") { TestMeasurement().testMeasurementFormatter() }
     MeasurementTests.test("testEquality") { TestMeasurement().testEquality() }
     MeasurementTests.test("testComparison") { TestMeasurement().testComparison() }
+    MeasurementTests.test("test_AnyHashableContainingMeasurement") { TestMeasurement().test_AnyHashableContainingMeasurement() }
+  MeasurementTests.test("test_AnyHashableCreatedFromNSMeasurement") { TestMeasurement().test_AnyHashableCreatedFromNSMeasurement() }
     runAllTests()
 }
 #endif


### PR DESCRIPTION
<!-- What's in this pull request? -->

Enable custom AnyHashable representation for NSMeasurement

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [rdar://problem/27539951](rdar://problem/27539951).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
