### PR TITLE
[SR-2624] Refine index out of bounds error messages for ArraySlice and SliceBuffer.

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1756,7 +1756,7 @@ extension ${Self} {
       "${Self} replace: subrange start is negative")
 % else:
     _precondition(subrange.lowerBound >= self._buffer.startIndex,
-      "${Self} replace: subrange start is before the start")
+      "${Self} replace: subrange start is before the startIndex")
 % end
 
     _precondition(subrange.upperBound <= self._buffer.endIndex,

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -839,8 +839,12 @@ public struct ${Self}<Element>
   /// Check that the specified `index` is valid, i.e. `0 ≤ index ≤ count`.
   @_semantics("array.check_index")
   internal func _checkIndex(_ index: Int) {
-    _precondition(index <= endIndex, "${Self} index out of range")
+    _precondition(index <= endIndex, "${Self} index is out of range")
+% if Self in ['Array', 'ContiguousArray']:
     _precondition(index >= startIndex, "Negative ${Self} index is out of range")
+% else:
+    _precondition(index >= startIndex, "${Self} index is out of range (before startIndex)")
+% end
   }
 
   @_semantics("array.get_element")
@@ -1360,7 +1364,7 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
     _precondition(count > 0, "can't removeLast from an empty ${Self}")
     // FIXME(performance): if `self` is uniquely referenced, we should remove
     // the element as shown below (this will deallocate the element and
-    // decrease memory use).  If `self` is not uniquely refeneced, the code
+    // decrease memory use).  If `self` is not uniquely referenced, the code
     // below will make a copy of the storage, which is wasteful.  Instead, we
     // should just shrink the view without allocating new storage.
     let i = endIndex
@@ -1747,8 +1751,13 @@ extension ${Self} {
     _ subrange: Range<Int>,
     with newElements: C
   ) where C : Collection, C.Iterator.Element == _Buffer.Element {
+% if Self in ['Array', 'ContiguousArray']:
     _precondition(subrange.lowerBound >= self._buffer.startIndex,
       "${Self} replace: subrange start is negative")
+% else:
+    _precondition(subrange.lowerBound >= self._buffer.startIndex,
+      "${Self} replace: subrange start is before the start")
+% end
 
     _precondition(subrange.upperBound <= self._buffer.endIndex,
       "${Self} replace: subrange extends past the end")

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -245,8 +245,8 @@ internal struct _SliceBuffer<Element>
 
   @_versioned
   internal func getElement(_ i: Int) -> Element {
-    _sanityCheck(i >= startIndex, "negative slice index is out of range")
-    _sanityCheck(i < endIndex, "slice index out of range")
+    _sanityCheck(i >= startIndex, "slice index is out of range (before startIndex)")
+    _sanityCheck(i < endIndex, "slice index is out of range")
     return subscriptBaseAddress[i]
   }
 
@@ -259,8 +259,8 @@ internal struct _SliceBuffer<Element>
       return getElement(position)
     }
     nonmutating set {
-      _sanityCheck(position >= startIndex, "negative slice index is out of range")
-      _sanityCheck(position < endIndex, "slice index out of range")
+      _sanityCheck(position >= startIndex, "slice index is out of range (before startIndex)")
+      _sanityCheck(position < endIndex, "slice index is out of range")
       subscriptBaseAddress[position] = newValue
     }
   }

--- a/validation-test/stdlib/ArrayTraps.swift.gyb
+++ b/validation-test/stdlib/ArrayTraps.swift.gyb
@@ -29,6 +29,21 @@ def bounds_trap(index, expr_to_write):
 % for ArrayTy in array_types:
 
 var ${ArrayTy}Traps = TestSuite("${ArrayTy}Traps" + testSuiteSuffix)
+var ${ArrayTy}_lower_bound_out_of_range_error_msg = (
+% if ArrayTy in ['Array', 'ContiguousArray']:
+    "Negative ${ArrayTy} index is out of range"
+% else:
+    "${ArrayTy} index is out of range (before startIndex)"
+% end
+)
+
+var ${ArrayTy}_bounds_error_msg = (
+% if ArrayTy in ['Array', 'ContiguousArray']:
+    "Index out of range"
+% else:
+    "Index out of bounds"
+% end
+)
 
 %   for io in ['read', 'write']:
 
@@ -36,6 +51,8 @@ ${ArrayTy}Traps.test("bounds1/${io}")
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches(_isDebugAssertConfiguration() ?
+    ${ArrayTy}_bounds_error_msg : "")
   .code {
   var a: ${ArrayTy}<Int> = []
   ${bounds_trap(index='0', expr_to_write='1')}
@@ -45,6 +62,8 @@ ${ArrayTy}Traps.test("bounds2/${io}")
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches(_isDebugAssertConfiguration() ?
+    ${ArrayTy}_bounds_error_msg : "")
   .code {
   var a: ${ArrayTy}<Int> = []
   ${bounds_trap(index='100', expr_to_write='1')}
@@ -54,6 +73,8 @@ ${ArrayTy}Traps.test("bounds3/${io}")
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches(_isDebugAssertConfiguration() ?
+    ${ArrayTy}_bounds_error_msg : "")
   .code {
   var a: ${ArrayTy} = [ 10, 20, 30 ]
   ${bounds_trap(index='3', expr_to_write='1')}
@@ -63,6 +84,8 @@ ${ArrayTy}Traps.test("sliceBounds0/${io}")
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches(_isDebugAssertConfiguration() ?
+    ${ArrayTy}_lower_bound_out_of_range_error_msg : "")
   .code {
   var a: ${ArrayTy}<Int> = []
   ${bounds_trap(index='-1..<1', expr_to_write='ArraySlice()')}
@@ -72,6 +95,8 @@ ${ArrayTy}Traps.test("sliceBounds1/${io}")
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches(_isDebugAssertConfiguration() ?
+    ${ArrayTy}_lower_bound_out_of_range_error_msg : "")
   .code {
   var a: ${ArrayTy} = [ 1 ]
   ${bounds_trap(index='-1..<1', expr_to_write='ArraySlice()')}
@@ -81,6 +106,8 @@ ${ArrayTy}Traps.test("sliceBounds2/${io}")
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches(_isDebugAssertConfiguration() ?
+    "${ArrayTy} index is out of range" : "")
   .code {
   var a: ${ArrayTy} = [ 1 ]
   ${bounds_trap(index='0..<2', expr_to_write='ArraySlice()')}
@@ -90,6 +117,8 @@ ${ArrayTy}Traps.test("sliceBounds3/${io}")
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches(_isDebugAssertConfiguration() ?
+    "${ArrayTy} index is out of range" : "")
   .code {
   var a: ${ArrayTy} = [ 1 ]
   ${bounds_trap(index='1..<2', expr_to_write='ArraySlice()')}
@@ -97,7 +126,10 @@ ${ArrayTy}Traps.test("sliceBounds3/${io}")
 
 %   end
 
-${ArrayTy}Traps.test("PopFromEmpty") {
+${ArrayTy}Traps.test("PopFromEmpty")
+  .crashOutputMatches(_isDebugAssertConfiguration() ?
+    "can't remove last element from an empty collection" : "")
+  .code {
   var a: ${ArrayTy}<Int> = []
   expectCrashLater()
   a.removeLast()
@@ -108,6 +140,13 @@ ${ArrayTy}Traps.test("${'insert(_:at:)/%s' % index}")
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches(_isDebugAssertConfiguration() ?
+% if index < 0:
+    ${ArrayTy}_lower_bound_out_of_range_error_msg
+% else:
+    "${ArrayTy} index is out of range"
+%end
+    : "")
   .code {
   var a: ${ArrayTy}<Int> = [42]
   expectCrashLater()
@@ -120,6 +159,8 @@ ${ArrayTy}Traps.test("${'remove(at:)/%s' % index}")
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches(_isDebugAssertConfiguration() ?
+    ${ArrayTy}_bounds_error_msg : "")
   .code {
   var a: ${ArrayTy}<Int> = [42]
   expectCrashLater()
@@ -132,6 +173,8 @@ ArrayTraps.test("unsafeLength")
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches(_isDebugAssertConfiguration() ?
+    "UnsafeBufferPointer with negative count" : "")
   .code {
   var a = [ 42, 77, 88 ]
 

--- a/validation-test/stdlib/ArrayTraps.swift.gyb
+++ b/validation-test/stdlib/ArrayTraps.swift.gyb
@@ -29,7 +29,7 @@ def bounds_trap(index, expr_to_write):
 % for ArrayTy in array_types:
 
 var ${ArrayTy}Traps = TestSuite("${ArrayTy}Traps" + testSuiteSuffix)
-var ${ArrayTy}_lower_bound_out_of_range_error_msg = (
+var ${ArrayTy}LowerBoundOutOfRangeErrorMsg = (
 % if ArrayTy in ['Array', 'ContiguousArray']:
     "Negative ${ArrayTy} index is out of range"
 % else:
@@ -37,7 +37,7 @@ var ${ArrayTy}_lower_bound_out_of_range_error_msg = (
 % end
 )
 
-var ${ArrayTy}_bounds_error_msg = (
+var ${ArrayTy}BoundsErrorMsg = (
 % if ArrayTy in ['Array', 'ContiguousArray']:
     "Index out of range"
 % else:
@@ -52,7 +52,7 @@ ${ArrayTy}Traps.test("bounds1/${io}")
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
   .crashOutputMatches(_isDebugAssertConfiguration() ?
-    ${ArrayTy}_bounds_error_msg : "")
+    ${ArrayTy}BoundsErrorMsg : "")
   .code {
   var a: ${ArrayTy}<Int> = []
   ${bounds_trap(index='0', expr_to_write='1')}
@@ -63,7 +63,7 @@ ${ArrayTy}Traps.test("bounds2/${io}")
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
   .crashOutputMatches(_isDebugAssertConfiguration() ?
-    ${ArrayTy}_bounds_error_msg : "")
+    ${ArrayTy}BoundsErrorMsg : "")
   .code {
   var a: ${ArrayTy}<Int> = []
   ${bounds_trap(index='100', expr_to_write='1')}
@@ -74,7 +74,7 @@ ${ArrayTy}Traps.test("bounds3/${io}")
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
   .crashOutputMatches(_isDebugAssertConfiguration() ?
-    ${ArrayTy}_bounds_error_msg : "")
+    ${ArrayTy}BoundsErrorMsg : "")
   .code {
   var a: ${ArrayTy} = [ 10, 20, 30 ]
   ${bounds_trap(index='3', expr_to_write='1')}
@@ -85,7 +85,7 @@ ${ArrayTy}Traps.test("sliceBounds0/${io}")
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
   .crashOutputMatches(_isDebugAssertConfiguration() ?
-    ${ArrayTy}_lower_bound_out_of_range_error_msg : "")
+    ${ArrayTy}LowerBoundOutOfRangeErrorMsg : "")
   .code {
   var a: ${ArrayTy}<Int> = []
   ${bounds_trap(index='-1..<1', expr_to_write='ArraySlice()')}
@@ -96,7 +96,7 @@ ${ArrayTy}Traps.test("sliceBounds1/${io}")
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
   .crashOutputMatches(_isDebugAssertConfiguration() ?
-    ${ArrayTy}_lower_bound_out_of_range_error_msg : "")
+    ${ArrayTy}LowerBoundOutOfRangeErrorMsg : "")
   .code {
   var a: ${ArrayTy} = [ 1 ]
   ${bounds_trap(index='-1..<1', expr_to_write='ArraySlice()')}
@@ -142,7 +142,7 @@ ${ArrayTy}Traps.test("${'insert(_:at:)/%s' % index}")
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
   .crashOutputMatches(_isDebugAssertConfiguration() ?
 % if index < 0:
-    ${ArrayTy}_lower_bound_out_of_range_error_msg
+    ${ArrayTy}LowerBoundOutOfRangeErrorMsg
 % else:
     "${ArrayTy} index is out of range"
 %end
@@ -160,7 +160,7 @@ ${ArrayTy}Traps.test("${'remove(at:)/%s' % index}")
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
   .crashOutputMatches(_isDebugAssertConfiguration() ?
-    ${ArrayTy}_bounds_error_msg : "")
+    ${ArrayTy}BoundsErrorMsg : "")
   .code {
   var a: ${ArrayTy}<Int> = [42]
   expectCrashLater()


### PR DESCRIPTION
<!-- What's in this pull request? -->

Updated error messages for ArraySlice and SliceBuffer, so that don't contain word 'negative' due to specific of their indexes. Added message validations for existing tests.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-2624](https://bugs.swift.org/browse/SR-2624).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
