### PR TITLE
[swiftc (68 vs. 5162)] Add crasher in swift::TypeChecker::validateDecl(...)

### DIFF
--- a/validation-test/compiler_crashers/28418-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers/28418-swift-typechecker-validatedecl.swift
@@ -1,0 +1,14 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+{protocol P{
+typealias e
+protocol c{{}let t:e
+enum B:c{
+typealias e:e


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::validateDecl(...)`.

Current number of unresolved compiler crashers: 68 (5162 resolved)

Assertion failure in [`include/swift/AST/DiagnosticEngine.h (line 614)`](https://github.com/apple/swift/blob/master/include/swift/AST/DiagnosticEngine.h#L614):

```
Assertion `!ActiveDiagnostic && "Already have an active diagnostic"' failed.

When executing: swift::InFlightDiagnostic swift::DiagnosticEngine::diagnose(swift::SourceLoc, Diag<ArgTypes...>, typename detail::PassArgument<ArgTypes>::type...) [ArgTypes = <swift::Identifier>]
```

Assertion context:

```
    /// the types expected by the diagnostic \p ID.
    template<typename ...ArgTypes>
    InFlightDiagnostic
    diagnose(SourceLoc Loc, Diag<ArgTypes...> ID,
             typename detail::PassArgument<ArgTypes>::type... Args) {
      assert(!ActiveDiagnostic && "Already have an active diagnostic");
      ActiveDiagnostic = Diagnostic(ID, std::move(Args)...);
      ActiveDiagnostic->setLoc(Loc);
      return InFlightDiagnostic(*this);
    }

```

Stack trace:

```
swift: /path/to/swift/include/swift/AST/DiagnosticEngine.h:614: swift::InFlightDiagnostic swift::DiagnosticEngine::diagnose(swift::SourceLoc, Diag<ArgTypes...>, typename detail::PassArgument<ArgTypes>::type...) [ArgTypes = <swift::Identifier>]: Assertion `!ActiveDiagnostic && "Already have an active diagnostic"' failed.
9  swift           0x0000000000eda3e1 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3905
10 swift           0x000000000115029b swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2667
11 swift           0x000000000114eabe swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 4990
12 swift           0x0000000000f1e153 swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 99
15 swift           0x0000000000f51cb2 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 162
17 swift           0x0000000000f52d54 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
18 swift           0x0000000000f514e3 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 195
21 swift           0x0000000000eda1e2 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3394
22 swift           0x000000000115029b swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2667
23 swift           0x0000000000f1eed1 swift::TypeChecker::lookupMemberType(swift::DeclContext*, swift::Type, swift::Identifier, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 289
24 swift           0x0000000000fdd1ad swift::constraints::ConstraintSystem::performMemberLookup(swift::constraints::ConstraintKind, swift::DeclName, swift::Type, swift::FunctionRefKind, swift::constraints::ConstraintLocator*, bool) + 2413
25 swift           0x0000000000fdef9b swift::constraints::ConstraintSystem::simplifyMemberConstraint(swift::constraints::Constraint const&) + 491
26 swift           0x0000000000fe0105 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 69
27 swift           0x0000000000fea7db swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 12235
28 swift           0x0000000000fe4ec3 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 323
29 swift           0x0000000000fe48e9 swift::constraints::ConstraintSystem::solve(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 73
30 swift           0x0000000000fe481b swift::constraints::ConstraintSystem::solveSingle(swift::FreeTypeVariableBinding) + 59
31 swift           0x0000000000fc1c77 swift::checkMemberType(swift::DeclContext&, swift::Type, llvm::ArrayRef<swift::Identifier>) + 487
33 swift           0x000000000116b3c3 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 35
38 swift           0x00000000010715f6 swift::Decl::print(swift::ASTPrinter&, swift::PrintOptions const&) const + 54
42 swift           0x0000000000f28a57 swift::TypeChecker::checkConformance(swift::NormalProtocolConformance*) + 2103
43 swift           0x0000000000f28f67 swift::TypeChecker::checkConformancesInContext(swift::DeclContext*, swift::IterableDeclContext*) + 487
50 swift           0x0000000000edfc26 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
53 swift           0x0000000000f4b744 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
54 swift           0x0000000000f78aec swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
55 swift           0x0000000000ec9506 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 1126
57 swift           0x0000000000f4b886 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
58 swift           0x0000000000f0452d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
59 swift           0x0000000000c86e69 swift::CompilerInstance::performSema() + 3289
61 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
62 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28418-swift-typechecker-validatedecl.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28418-swift-typechecker-validatedecl-77c362.o
1.  While type-checking expression at [validation-test/compiler_crashers/28418-swift-typechecker-validatedecl.swift:10:1 - line:14:13] RangeText="{protocol P{
2.  While type-checking 'P' at validation-test/compiler_crashers/28418-swift-typechecker-validatedecl.swift:10:2
3.  While type-checking 'e' at validation-test/compiler_crashers/28418-swift-typechecker-validatedecl.swift:14:1
4.  While resolving type e at [validation-test/compiler_crashers/28418-swift-typechecker-validatedecl.swift:14:13 - line:14:13] RangeText="e"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
