### PR TITLE
[SourceKit] Add test case for crash triggered in swift::IterativeTypeChecker::satisfy(…)

### DIFF
--- a/validation-test/IDE/crashers/090-swift-iterativetypechecker-satisfy.swift
+++ b/validation-test/IDE/crashers/090-swift-iterativetypechecker-satisfy.swift
@@ -1,0 +1,4 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+#^A^#}"
+typealias B<T T>:T


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 126
swift-ide-test: /path/to/swift/lib/Sema/IterativeTypeChecker.cpp:103: void swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest): Assertion `isSatisfied(request)' failed.
9  swift-ide-test  0x0000000000a859d9 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 889
12 swift-ide-test  0x000000000098da92 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3394
15 swift-ide-test  0x00000000009936e6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
16 swift-ide-test  0x00000000009b9172 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
17 swift-ide-test  0x00000000007abc69 swift::CompilerInstance::performSema() + 3289
18 swift-ide-test  0x000000000074d981 main + 36401
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking 'B' at <INPUT-FILE>:4:1
2.  While type-checking 'B' at <INPUT-FILE>:4:1
```
