### PR TITLE
[build-script] Add `--skip-build-sourcekit`

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -329,6 +329,7 @@ class BuildScriptInvocation(object):
             args.skip_build_watchos = True
             args.skip_build_android = True
             args.skip_build_benchmarks = True
+            args.skip_build_sourcekit = True
             args.build_lldb = False
             args.build_llbuild = False
             args.build_swiftpm = False
@@ -652,6 +653,8 @@ class BuildScriptInvocation(object):
                           "--skip-build-swift"]
         if args.skip_build_benchmarks:
             impl_args += ["--skip-build-benchmarks"]
+        if args.skip_build_sourcekit:
+            impl_args += ["--skip-build-sourcekit"]
         if not args.build_foundation:
             impl_args += ["--skip-build-foundation"]
         if not args.build_xctest:
@@ -1669,6 +1672,13 @@ details of the setups of other systems or automated environments.""")
         help="skip building Swift stdlibs for Android",
         action=arguments.action.optional_bool)
 
+    run_build_group.add_argument(
+        "--skip-build-sourcekit",
+        help="skip building SourceKit. %(default)s by default",
+        action=arguments.action.optional_bool,
+        # FIXME: Currently SourceKit only builds on Darwin hosts. See SR-1676
+        #        for details.
+        default=platform.system() != "Darwin")
     run_build_group.add_argument(
         "--skip-build-benchmarks",
         help="skip building Swift Benchmark Suite",

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -117,6 +117,7 @@ KNOWN_SETTINGS=(
     skip-build-foundation       ""               "set to skip building foundation"
     skip-build-libdispatch      ""               "set to skip building libdispatch"
     skip-build-benchmarks       ""               "set to skip building Swift Benchmark Suite"
+    skip-build-sourcekit        ""               "set to skip building SourceKit"
     skip-build-playgroundlogger ""               "set to skip building PlaygroundLogger"
     skip-build-playgroundsupport ""              "set to skip building PlaygroundSupport"
     skip-test-cmark             ""               "set to skip testing CommonMark"
@@ -1985,6 +1986,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY:BOOL=$(true_false "${BUILD_SWIFT_DYNAMIC_SDK_OVERLAY}")
                     -DSWIFT_BUILD_STATIC_SDK_OVERLAY:BOOL=$(true_false "${BUILD_SWIFT_STATIC_SDK_OVERLAY}")
                     -DSWIFT_BUILD_PERF_TESTSUITE:BOOL=$(true_false "${build_perf_testsuite_this_time}")
+                    -DSWIFT_BUILD_SOURCEKIT:BOOL=$(true_false "$(false_true SKIP_BUILD_SOURCEKIT)")
                     -DSWIFT_BUILD_EXAMPLES:BOOL=$(true_false "${BUILD_SWIFT_EXAMPLES}")
                     -DSWIFT_INCLUDE_TESTS:BOOL=$(true_false "${build_tests_this_time}")
                     -DSWIFT_INSTALL_COMPONENTS:STRING="${SWIFT_INSTALL_COMPONENTS}"


### PR DESCRIPTION
<!-- What's in this pull request? -->

Expose the CMake `SWIFT_BUILD_SOURCEKIT` option at the `build-script` and `build-script-impl` layer. This allows SourceKit builds to be enabled/disabled via the command-line:

```
utils/build-script --skip-build-sourcekit
```

Since SourceKit only builds on macOS at the moment, automatically add `--skip-build-sourcekit` to non-macOS host builds.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-2653](https://bugs.swift.org/browse/SR-2653).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
