### PR TITLE
[swiftc (69 vs. 5162)] Add crasher in swift::SILModule::constructSIL(...)

### DIFF
--- a/validation-test/compiler_crashers/28419-swift-silmodule-constructsil.swift
+++ b/validation-test/compiler_crashers/28419-swift-silmodule-constructsil.swift
@@ -1,0 +1,18 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+class B{
+}
+class A:B{
+override init(){
+defer{
+super.init()
+}
+}
+}


### PR DESCRIPTION
Add test case for crash triggered in `swift::SILModule::constructSIL(...)`.

Current number of unresolved compiler crashers: 69 (5162 resolved)

Assertion failure in [`lib/SILGen/ManagedValue.h (line 112)`](https://github.com/apple/swift/blob/master/lib/SILGen/ManagedValue.h#L112):

```
Assertion `isLValue() && "This isn't an lvalue"' failed.

When executing: swift::SILValue swift::Lowering::ManagedValue::getLValueAddress() const
```

Assertion context:

```
    // either +0 or trivial (in which case +0 vs +1 doesn't matter).
    return !hasCleanup();
  }

  SILValue getLValueAddress() const {
    assert(isLValue() && "This isn't an lvalue");
    return getValue();
  }

  SILValue getUnmanagedValue() const {
    assert(!hasCleanup());
```

Stack trace:

```
swift: /path/to/swift/lib/SILGen/ManagedValue.h:112: swift::SILValue swift::Lowering::ManagedValue::getLValueAddress() const: Assertion `isLValue() && "This isn't an lvalue"' failed.
14 swift           0x0000000000944dba swift::SILModule::constructSIL(swift::ModuleDecl*, swift::SILOptions&, swift::FileUnit*, llvm::Optional<unsigned int>, bool, bool) + 1290
15 swift           0x0000000000945016 swift::performSILGeneration(swift::FileUnit&, swift::SILOptions&, llvm::Optional<unsigned int>, bool) + 118
17 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
18 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28419-swift-silmodule-constructsil.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28419-swift-silmodule-constructsil-a782d2.o
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
