### PR TITLE
[swiftc (70 vs. 5162)] Add crasher in swift::Lowering::emitConditionalCheckedCast(...)

### DIFF
--- a/validation-test/compiler_crashers/28420-swift-lowering-emitconditionalcheckedcast.swift
+++ b/validation-test/compiler_crashers/28420-swift-lowering-emitconditionalcheckedcast.swift
@@ -1,0 +1,17 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+struct A{
+func a()->String{
+}
+}
+func b(){
+guard let c = A.a as?String else{
+}
+}


### PR DESCRIPTION
Add test case for crash triggered in `swift::Lowering::emitConditionalCheckedCast(...)`.

Current number of unresolved compiler crashers: 70 (5162 resolved)

Assertion failure in [`lib/SILGen/SILGenDynamicCast.cpp (line 131)`](https://github.com/apple/swift/blob/master/lib/SILGen/SILGenDynamicCast.cpp#L131):

```
Assertion `operand.getType().isAddress()' failed.

When executing: void (anonymous namespace)::CheckedCastEmitter::emitConditional(swift::Lowering::ManagedValue, swift::CastConsumptionKind, swift::Lowering::SGFContext, const std::function<void (ManagedValue)> &, const std::function<void ()> &)
```

Assertion context:

```

      // Emit the branch.
      SILValue scalarOperandValue;
      SILValue resultBuffer;
      if (Strategy == CastStrategy::Address) {
        assert(operand.getType().isAddress());
        resultBuffer =
          createAbstractResultBuffer(hasAbstraction, origTargetTL, ctx);
        SGF.B.createCheckedCastAddrBranch(Loc, consumption,
                                          operand.forward(SGF), SourceType,
                                          resultBuffer, TargetType,
```

Stack trace:

```
swift: /path/to/swift/lib/SILGen/SILGenDynamicCast.cpp:131: void (anonymous namespace)::CheckedCastEmitter::emitConditional(swift::Lowering::ManagedValue, swift::CastConsumptionKind, swift::Lowering::SGFContext, const std::function<void (ManagedValue)> &, const std::function<void ()> &): Assertion `operand.getType().isAddress()' failed.
9  swift           0x000000000099297c swift::Lowering::emitConditionalCheckedCast(swift::Lowering::SILGenFunction&, swift::SILLocation, swift::Lowering::ManagedValue, swift::Type, swift::Type, swift::CheckedCastKind, swift::Lowering::SGFContext) + 2012
21 swift           0x0000000000944aa2 swift::SILModule::constructSIL(swift::ModuleDecl*, swift::SILOptions&, swift::FileUnit*, llvm::Optional<unsigned int>, bool, bool) + 498
22 swift           0x0000000000945016 swift::performSILGeneration(swift::FileUnit&, swift::SILOptions&, llvm::Optional<unsigned int>, bool) + 118
24 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
25 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28420-swift-lowering-emitconditionalcheckedcast.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28420-swift-lowering-emitconditionalcheckedcast-0c2422.o
1.  While emitting SIL for 'b' at validation-test/compiler_crashers/28420-swift-lowering-emitconditionalcheckedcast.swift:14:1
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
