### PR TITLE
[stdlib] returning false in case where comparison cannot succeed in SwiftValue

### DIFF
--- a/stdlib/public/runtime/SwiftValue.mm
+++ b/stdlib/public/runtime/SwiftValue.mm
@@ -305,7 +305,7 @@ swift::findSwiftValueConformances(const ProtocolDescriptorList &protocols,
   }
 
   if (![other isKindOfClass:getSwiftValueClass()]) {
-    return self == other;
+    return NO;
   }
 
   auto selfHeader = getSwiftValueHeader(self);
@@ -314,12 +314,12 @@ swift::findSwiftValueConformances(const ProtocolDescriptorList &protocols,
   auto hashableBaseType = selfHeader->getHashableBaseType();
   if (!hashableBaseType ||
       otherHeader->getHashableBaseType() != hashableBaseType) {
-    return self == other;
+    return NO;
   }
 
   auto hashableConformance = selfHeader->getHashableConformance();
   if (!hashableConformance) {
-    return self == other;
+    return NO;
   }
 
   return swift_stdlib_Hashable_isEqual_indirect(


### PR DESCRIPTION
<!-- What's in this pull request? -->

In the `SwiftValue.isEqual` there are a few places, where it returns the result of `==` of things that have already been checked for equality. These can be safely replaced by `NO`s.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
