### PR TITLE
SR 716: handle constant structs with padding

### DIFF
--- a/lib/IRGen/CMakeLists.txt
+++ b/lib/IRGen/CMakeLists.txt
@@ -10,6 +10,7 @@ add_swift_library(swiftIRGen STATIC
   GenClangDecl.cpp
   GenClangType.cpp
   GenClass.cpp
+  GenConstant.cpp
   GenControl.cpp
   GenCoverage.cpp
   GenDecl.cpp

--- a/lib/IRGen/GenConstant.cpp
+++ b/lib/IRGen/GenConstant.cpp
@@ -32,16 +32,14 @@ llvm::Constant *irgen::emitConstantInt(IRGenModule &IGM,
     = ILI->getType().castTo<BuiltinIntegerType>()->getWidth();
 
   // The value may need truncation if its type had an abstract size.
-  if (width.isFixedWidth()) {
-    // nothing to do
-  } else if (width.isPointerWidth()) {
+  if (!width.isFixedWidth()) {
+    assert(width.isPointerWidth() && "impossible width value");
+
     unsigned pointerWidth = IGM.getPointerSize().getValueInBits();
     assert(pointerWidth <= value.getBitWidth()
            && "lost precision at AST/SIL level?!");
     if (pointerWidth < value.getBitWidth())
       value = value.trunc(pointerWidth);
-  } else {
-    llvm_unreachable("impossible width value");
   }
 
   return llvm::ConstantInt::get(IGM.LLVMContext, value);

--- a/lib/IRGen/GenConstant.cpp
+++ b/lib/IRGen/GenConstant.cpp
@@ -1,0 +1,142 @@
+//===---- GenConstant.cpp - Swift IR Generation For Constants ---*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements IR generation for constant values.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/IR/Constants.h"
+
+#include "GenConstant.h"
+#include "GenStruct.h"
+#include "GenTuple.h"
+#include "TypeInfo.h"
+#include "swift/Basic/Range.h"
+
+using namespace swift;
+using namespace irgen;
+
+llvm::Constant *irgen::emitConstantInt(IRGenModule &IGM,
+                                       IntegerLiteralInst *ILI) {
+  APInt value = ILI->getValue();
+  BuiltinIntegerWidth width
+    = ILI->getType().castTo<BuiltinIntegerType>()->getWidth();
+
+  // The value may need truncation if its type had an abstract size.
+  if (width.isFixedWidth()) {
+    // nothing to do
+  } else if (width.isPointerWidth()) {
+    unsigned pointerWidth = IGM.getPointerSize().getValueInBits();
+    assert(pointerWidth <= value.getBitWidth()
+           && "lost precision at AST/SIL level?!");
+    if (pointerWidth < value.getBitWidth())
+      value = value.trunc(pointerWidth);
+  } else {
+    llvm_unreachable("impossible width value");
+  }
+
+  return llvm::ConstantInt::get(IGM.LLVMContext, value);
+}
+
+llvm::Constant *irgen::emitConstantFP(IRGenModule &IGM, FloatLiteralInst *FLI) {
+  return llvm::ConstantFP::get(IGM.LLVMContext, FLI->getValue());
+}
+
+llvm::Constant *irgen::emitAddrOfConstantString(IRGenModule &IGM,
+                                                StringLiteralInst *SLI) {
+  switch (SLI->getEncoding()) {
+  case StringLiteralInst::Encoding::UTF8:
+    return IGM.getAddrOfGlobalString(SLI->getValue());
+
+  case StringLiteralInst::Encoding::UTF16: {
+    // This is always a GEP of a GlobalVariable with a nul terminator.
+    auto addr = IGM.getAddrOfGlobalUTF16String(SLI->getValue());
+
+    // Cast to Builtin.RawPointer.
+    return llvm::ConstantExpr::getBitCast(addr, IGM.Int8PtrTy);
+  }
+
+  case StringLiteralInst::Encoding::ObjCSelector:
+    llvm_unreachable("cannot get the address of an Objective-C selector");
+  }
+  llvm_unreachable("bad string encoding");
+}
+
+static llvm::Constant *emitConstantValue(IRGenModule &IGM, SILValue operand) {
+  if (auto *SI = dyn_cast<StructInst>(operand))
+    return emitConstantStruct(IGM, SI);
+  else if (auto *TI = dyn_cast<TupleInst>(operand))
+    return emitConstantTuple(IGM, TI);
+  else if (auto *ILI = dyn_cast<IntegerLiteralInst>(operand))
+    return emitConstantInt(IGM, ILI);
+  else if (auto *FLI = dyn_cast<FloatLiteralInst>(operand))
+    return emitConstantFP(IGM, FLI);
+  else if (auto *SLI = dyn_cast<StringLiteralInst>(operand))
+    return emitAddrOfConstantString(IGM, SLI);
+  else
+    llvm_unreachable("Unsupported SILInstruction in static initializer!");
+}
+
+static template <typename InstTy, typename NextIndexFunc>
+llvm::Constant *emitConstantStructOrTuple(IRGenModule &IGM, InstTy inst,
+                                          NextIndexFunc nextIndex) {
+  auto type = inst->getType();
+  auto *sTy = cast<llvm::StructType>(IGM.getTypeInfo(type).getStorageType());
+
+  SmallVector<llvm::Constant *, 32> elts(sTy->getNumElements(), nullptr);
+
+  // run over the Swift initialisers, putting them into the struct as
+  // appropriate.
+  for (unsigned i = 0, e = inst->getElements().size(); i != e; i++) {
+    auto operand = inst->getOperand(i);
+    unsigned index = nextIndex(IGM, type, i);
+
+    assert(elts[index] == nullptr &&
+           "Unexpected constant struct field overlap");
+
+    elts[index] = emitConstantValue(IGM, operand);
+  }
+
+  // fill in any gaps, which are the explicit padding that swiftc inserts.
+  for (unsigned i = 0, e = elts.size(); i != e; i++) {
+    auto &elt = elts[i];
+    if (elt == nullptr) {
+      auto *eltTy = sTy->getElementType(i);
+      assert(eltTy->isArrayTy() &&
+             eltTy->getArrayElementType()->isIntegerTy(8) &&
+             "Unexpected non-byte-array type for constrant struct padding");
+      elt = llvm::UndefValue::get(eltTy);
+    }
+  }
+
+  return llvm::ConstantStruct::get(sTy, elts);
+}
+
+llvm::Constant *irgen::emitConstantStruct(IRGenModule &IGM, StructInst *SI) {
+  // The only way to get a struct's stored properties (which we need to map to
+  // their physical/LLVM index) is to iterate over the properties
+  // progressively. Fortunately the iteration order matches the order of
+  // operands in a StructInst.
+  auto StoredProperties = SI->getStructDecl()->getStoredProperties();
+  auto Iter = StoredProperties.begin();
+
+  return emitConstantStructOrTuple(
+      IGM, SI, [&Iter](IRGenModule &IGM, SILType Type, unsigned _i) mutable {
+        (void)_i;
+        auto *FD = *Iter++;
+        return irgen::getPhysicalStructFieldIndex(IGM, Type, FD);
+      });
+}
+
+llvm::Constant *irgen::emitConstantTuple(IRGenModule &IGM, TupleInst *TI) {
+  return emitConstantStructOrTuple(IGM, TI, irgen::getTupleElementStructIndex);
+}

--- a/lib/IRGen/GenConstant.h
+++ b/lib/IRGen/GenConstant.h
@@ -1,0 +1,45 @@
+//===---- GenConstant.cpp - Swift IR Generation For Constants ---*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements IR generation for constant values.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_IRGEN_GENCONSTANT_H
+#define SWIFT_IRGEN_GENCONSTANT_H
+
+#include "llvm/IR/Constant.h"
+
+#include "IRGenModule.h"
+
+namespace swift {
+namespace irgen {
+
+/// Construct a ConstantInt from an IntegerLiteralInst.
+llvm::Constant *emitConstantInt(IRGenModule &IGM, IntegerLiteralInst *ILI);
+
+/// Construct a ConstantFP from a FloatLiteralInst.
+llvm::Constant *emitConstantFP(IRGenModule &IGM, FloatLiteralInst *FLI);
+
+/// Construct a pointer to a string from a StringLiteralInst.
+llvm::Constant *emitAddrOfConstantString(IRGenModule &IGM,
+                                         StringLiteralInst *SLI);
+
+/// Construct a struct literal from a StructInst containing constant values.
+llvm::Constant *emitConstantStruct(IRGenModule &IGM, StructInst *SI);
+
+/// Construct a struct literal from a TupleInst containing constant values.
+llvm::Constant *emitConstantTuple(IRGenModule &IGM, TupleInst *TI);
+}
+}
+
+#endif

--- a/lib/IRGen/GenRecord.h
+++ b/lib/IRGen/GenRecord.h
@@ -81,6 +81,8 @@ public:
     return Layout.getByteOffset();
   }
 
+  unsigned getStructIndex() const { return Layout.getStructIndex(); }
+
   unsigned getNonFixedElementIndex() const {
     return Layout.getNonFixedElementIndex();
   }

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -185,6 +185,11 @@ namespace {
       llvm_unreachable("bad field layout kind");
     }
 
+    unsigned getFieldIndex(IRGenModule &IGM, VarDecl *field) const {
+      auto &fieldInfo = getFieldInfo(field);
+      return fieldInfo.getStructIndex();
+    }
+
     // For now, just use extra inhabitants from the first field.
     // FIXME: generalize
     bool mayHaveExtraInhabitants(IRGenModule &IGM) const override {
@@ -824,6 +829,11 @@ MemberAccessStrategy
 irgen::getPhysicalStructMemberAccessStrategy(IRGenModule &IGM,
                                              SILType baseType, VarDecl *field) {
   FOR_STRUCT_IMPL(IGM, baseType, getFieldAccessStrategy, baseType, field);
+}
+
+unsigned irgen::getPhysicalStructFieldIndex(IRGenModule &IGM, SILType baseType,
+                                            VarDecl *field) {
+  FOR_STRUCT_IMPL(IGM, baseType, getFieldIndex, field);
 }
 
 void IRGenModule::emitStructDecl(StructDecl *st) {

--- a/lib/IRGen/GenStruct.h
+++ b/lib/IRGen/GenStruct.h
@@ -56,6 +56,9 @@ namespace irgen {
   getPhysicalStructMemberAccessStrategy(IRGenModule &IGM,
                                         SILType baseType, VarDecl *field);
 
+  unsigned getPhysicalStructFieldIndex(IRGenModule &IGM, SILType baseType,
+                                       VarDecl *field);
+
 } // end namespace irgen
 } // end namespace swift
 

--- a/lib/IRGen/GenTuple.cpp
+++ b/lib/IRGen/GenTuple.cpp
@@ -129,6 +129,11 @@ namespace {
       llvm_unreachable("bad element layout kind");
     }
 
+    unsigned getElementStructIndex(IRGenModule &IGM, unsigned fieldNo) const {
+      const TupleFieldInfo &field = asImpl().getFields()[fieldNo];
+      return field.getStructIndex();
+    }
+
     void initializeFromParams(IRGenFunction &IGF, Explosion &params,
                               Address src, SILType T) const override {
       llvm_unreachable("unexploded tuple as argument?");
@@ -405,4 +410,9 @@ Optional<Size> irgen::getFixedTupleElementOffset(IRGenModule &IGM,
                                                  unsigned fieldNo) {
   // Macro happens to work with IGM, too.
   FOR_TUPLE_IMPL(IGM, tupleType, getFixedElementOffset, fieldNo);
+}
+
+unsigned irgen::getTupleElementStructIndex(IRGenModule &IGM, SILType tupleType,
+                                           unsigned fieldNo) {
+  FOR_TUPLE_IMPL(IGM, tupleType, getElementStructIndex, fieldNo);
 }

--- a/lib/IRGen/GenTuple.h
+++ b/lib/IRGen/GenTuple.h
@@ -48,6 +48,8 @@ namespace irgen {
                                             SILType tupleType,
                                             unsigned fieldNo);
 
+  unsigned getTupleElementStructIndex(IRGenModule &IGM, SILType tupleType,
+                                      unsigned fieldNo);
 } // end namespace irgen
 } // end namespace swift
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -53,6 +53,8 @@
 #include "GenCall.h"
 #include "GenCast.h"
 #include "GenClass.h"
+#include "GenConstant.h"
+#include "GenEnum.h"
 #include "GenExistential.h"
 #include "GenFunc.h"
 #include "GenHeap.h"
@@ -63,11 +65,10 @@
 #include "GenProto.h"
 #include "GenStruct.h"
 #include "GenTuple.h"
-#include "GenEnum.h"
+#include "GenType.h"
 #include "IRGenDebugInfo.h"
 #include "IRGenModule.h"
 #include "ReferenceTypeInfo.h"
-#include "GenType.h"
 #include "WeakTypeInfo.h"
 
 using namespace swift;
@@ -2248,68 +2249,19 @@ void IRGenSILFunction::visitPartialApplyInst(swift::PartialApplyInst *i) {
   setLoweredExplosion(v, function);
 }
 
-/// Construct a ConstantInt from an IntegerLiteralInst.
-static llvm::Constant *getConstantInt(IRGenModule &IGM,
-                                      swift::IntegerLiteralInst *i) {
-  APInt value = i->getValue();
-  BuiltinIntegerWidth width
-    = i->getType().castTo<BuiltinIntegerType>()->getWidth();
-
-  // The value may need truncation if its type had an abstract size.
-  if (width.isFixedWidth()) {
-    // nothing to do
-  } else if (width.isPointerWidth()) {
-    unsigned pointerWidth = IGM.getPointerSize().getValueInBits();
-    assert(pointerWidth <= value.getBitWidth()
-           && "lost precision at AST/SIL level?!");
-    if (pointerWidth < value.getBitWidth())
-      value = value.trunc(pointerWidth);
-  } else {
-    llvm_unreachable("impossible width value");
-  }
-
-  return llvm::ConstantInt::get(IGM.LLVMContext, value);
-}
-
 void IRGenSILFunction::visitIntegerLiteralInst(swift::IntegerLiteralInst *i) {
-  llvm::Value *constant = getConstantInt(IGM, i);
-  
+  llvm::Value *constant = emitConstantInt(IGM, i);
+
   Explosion e;
   e.add(constant);
   setLoweredExplosion(i, e);
-}
-
-/// Construct a ConstantFP from a FloatLiteralInst.
-static llvm::Constant *getConstantFP(IRGenModule &IGM,
-                                     swift::FloatLiteralInst *i) {
-  return llvm::ConstantFP::get(IGM.LLVMContext, i->getValue());
 }
 
 void IRGenSILFunction::visitFloatLiteralInst(swift::FloatLiteralInst *i) {
-  llvm::Value *constant = getConstantFP(IGM, i);
+  llvm::Value *constant = emitConstantFP(IGM, i);
   Explosion e;
   e.add(constant);
   setLoweredExplosion(i, e);
-}
-
-static llvm::Constant *getAddrOfString(IRGenModule &IGM, StringRef string,
-                                       StringLiteralInst::Encoding encoding) {
-  switch (encoding) {
-  case swift::StringLiteralInst::Encoding::UTF8:
-    return IGM.getAddrOfGlobalString(string);
-
-  case swift::StringLiteralInst::Encoding::UTF16: {
-    // This is always a GEP of a GlobalVariable with a nul terminator.
-    auto addr = IGM.getAddrOfGlobalUTF16String(string);
-
-    // Cast to Builtin.RawPointer.
-    return llvm::ConstantExpr::getBitCast(addr, IGM.Int8PtrTy);
-  }
-
-  case swift::StringLiteralInst::Encoding::ObjCSelector:
-    llvm_unreachable("cannot get the address of an Objective-C selector");
-  }
-  llvm_unreachable("bad string encoding");
 }
 
 void IRGenSILFunction::visitStringLiteralInst(swift::StringLiteralInst *i) {
@@ -2319,7 +2271,7 @@ void IRGenSILFunction::visitStringLiteralInst(swift::StringLiteralInst *i) {
   if (i->getEncoding() == swift::StringLiteralInst::Encoding::ObjCSelector)
     addr = emitObjCSelectorRefLoad(i->getValue());
   else
-    addr = getAddrOfString(IGM, i->getValue(), i->getEncoding());
+    addr = emitAddrOfConstantString(IGM, i);
 
   Explosion e;
   e.add(addr);
@@ -2397,7 +2349,7 @@ static llvm::BasicBlock *emitBBMapForSwitchValue(
 static llvm::ConstantInt *
 getSwitchCaseValue(IRGenFunction &IGF, SILValue val) {
   if (auto *IL = dyn_cast<IntegerLiteralInst>(val)) {
-    return dyn_cast<llvm::ConstantInt>(getConstantInt(IGF.IGM, IL));
+    return dyn_cast<llvm::ConstantInt>(emitConstantInt(IGF.IGM, IL));
   }
   else {
     llvm_unreachable("Switch value cases should be integers");
@@ -4737,60 +4689,6 @@ void IRGenSILFunction::visitClassMethodInst(swift::ClassMethodInst *i) {
   setLoweredExplosion(i, e);
 }
 
-static llvm::Constant *getConstantValue(IRGenModule &IGM, llvm::StructType *STy,
-                                        TupleInst *TI);
-
-/// Generate ConstantStruct for StructInst.
-static llvm::Constant *getConstantValue(IRGenModule &IGM, llvm::StructType *STy,
-                                        StructInst *SI) {
-  SmallVector<llvm::Constant*, 32> Elts;
-  assert(SI->getNumOperands() == STy->getNumElements() &&
-         "mismatch StructInst with its lowered StructType!");
-  for (unsigned i = 0, e = STy->getNumElements(); i != e; ++i) {
-    if (auto *Elem = dyn_cast<StructInst>(SI->getOperand(i)))
-      Elts.push_back(getConstantValue(IGM,
-                     cast<llvm::StructType>(STy->getElementType(i)), Elem));
-    else if (auto *Elem = dyn_cast<TupleInst>(SI->getOperand(i)))
-      Elts.push_back(getConstantValue(IGM,
-                     cast<llvm::StructType>(STy->getElementType(i)), Elem));
-    else if (auto *ILI = dyn_cast<IntegerLiteralInst>(SI->getOperand(i)))
-      Elts.push_back(getConstantInt(IGM, ILI));
-    else if (auto *FLI = dyn_cast<FloatLiteralInst>(SI->getOperand(i)))
-      Elts.push_back(getConstantFP(IGM, FLI));
-    else if (auto *SLI = dyn_cast<StringLiteralInst>(SI->getOperand(i)))
-      Elts.push_back(getAddrOfString(IGM, SLI->getValue(), SLI->getEncoding()));
-    else
-      llvm_unreachable("Unexpected SILInstruction in static initializer!");
-  }
-  return llvm::ConstantStruct::get(STy, Elts);
-}
-
-
-/// Generate ConstantStruct for StructInst.
-static llvm::Constant *getConstantValue(IRGenModule &IGM, llvm::StructType *STy,
-                                        TupleInst *TI) {
-  SmallVector<llvm::Constant*, 32> Elts;
-  assert(TI->getNumOperands() == STy->getNumElements() &&
-         "mismatch StructInst with its lowered StructType!");
-  for (unsigned i = 0, e = STy->getNumElements(); i != e; ++i) {
-    if (auto *Elem = dyn_cast<StructInst>(TI->getOperand(i)))
-      Elts.push_back(getConstantValue(IGM,
-                     cast<llvm::StructType>(STy->getElementType(i)), Elem));
-    else if (auto *Elem = dyn_cast<TupleInst>(TI->getOperand(i)))
-      Elts.push_back(getConstantValue(IGM,
-                     cast<llvm::StructType>(STy->getElementType(i)), Elem));
-    else if (auto *ILI = dyn_cast<IntegerLiteralInst>(TI->getOperand(i)))
-      Elts.push_back(getConstantInt(IGM, ILI));
-    else if (auto *FLI = dyn_cast<FloatLiteralInst>(TI->getOperand(i)))
-      Elts.push_back(getConstantFP(IGM, FLI));
-    else if (auto *SLI = dyn_cast<StringLiteralInst>(TI->getOperand(i)))
-      Elts.push_back(getAddrOfString(IGM, SLI->getValue(), SLI->getEncoding()));
-    else
-      llvm_unreachable("Unexpected SILInstruction in static initializer!");
-  }
-  return llvm::ConstantStruct::get(STy, Elts);
-}
-
 void IRGenModule::emitSILStaticInitializers() {
   SmallVector<SILFunction *, 8> StaticInitializers;
   for (SILGlobalVariable &Global : getSILModule().getSILGlobals()) {
@@ -4805,19 +4703,18 @@ void IRGenModule::emitSILStaticInitializers() {
     if (!IRGlobal || !IRGlobal->hasInitializer())
       continue;
 
-    auto *STy = cast<llvm::StructType>(IRGlobal->getInitializer()->getType());
     auto *InitValue = Global.getValueOfStaticInitializer();
 
     // Set the IR global's initializer to the constant for this SIL
     // struct.
     if (auto *SI = dyn_cast<StructInst>(InitValue)) {
-      IRGlobal->setInitializer(getConstantValue(*this, STy, SI));
+      IRGlobal->setInitializer(emitConstantStruct(*this, SI));
       continue;
     }
 
     // Set the IR global's initializer to the constant for this SIL
     // tuple.
     auto *TI = cast<TupleInst>(InitValue);
-    IRGlobal->setInitializer(getConstantValue(*this, STy, TI));
+    IRGlobal->setInitializer(emitConstantTuple(*this, TI));
   }
 }

--- a/test/IRGen/constant_struct_with_padding.sil
+++ b/test/IRGen/constant_struct_with_padding.sil
@@ -1,0 +1,26 @@
+// RUN: %swift -module-name main %s -emit-ir -o - | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+struct T {
+  @sil_stored var a: Builtin.Int1 { get set }
+  @sil_stored var b: Builtin.Int32 { get set }
+}
+
+// CHECK: @global = hidden global %V4main1T <{ i1 false, [3 x i8] undef, i32 0 }>, align 4
+sil_global hidden @global : $T, @globalinit : $@convention(thin) () -> ()
+
+sil private @globalinit : $@convention(thin) () -> () {
+bb0:
+  alloc_global @global
+  %1 = global_addr @global : $*T
+  %2 = integer_literal $Builtin.Int1, 0
+  %3 = integer_literal $Builtin.Int32, 0
+  %6 = struct $T (%2 : $Builtin.Int1, %3 : $Builtin.Int32)
+  store %6 to %1 : $*T
+  %8 = tuple ()
+  return %8 : $()
+}

--- a/test/multifile/constant-struct-with-padding/Other.swift
+++ b/test/multifile/constant-struct-with-padding/Other.swift
@@ -1,0 +1,8 @@
+// RUN: true
+
+struct t {
+	  var a = false	// (or e.g. var a: Int32 = 0)
+	  var b = 0.0	// (or e.g. var b: Int64 = 0)
+}
+
+var g = t()

--- a/test/multifile/constant-struct-with-padding/main.swift
+++ b/test/multifile/constant-struct-with-padding/main.swift
@@ -1,0 +1,5 @@
+// RUN: rm -rf %t && mkdir %t
+
+// RUN: %target-build-swift -O -whole-module-optimization %S/main.swift %S/Other.swift
+
+print( g.a )

--- a/test/multifile/constant-tuple-with-padding/Other.swift
+++ b/test/multifile/constant-tuple-with-padding/Other.swift
@@ -1,0 +1,3 @@
+// RUN: true
+
+var g = (false, 0.0)

--- a/test/multifile/constant-tuple-with-padding/main.swift
+++ b/test/multifile/constant-tuple-with-padding/main.swift
@@ -1,0 +1,5 @@
+// RUN: rm -rf %t && mkdir %t
+
+// RUN: %target-build-swift -O -whole-module-optimization %S/main.swift %S/Other.swift
+
+print( g.0 )


### PR DESCRIPTION
<!-- What's in this pull request? -->

Handle padding in global structs. 

Previously there was a mismatch between SIL's concept of a
struct (padding is implicit) and LLVM's (padding is explicit) in IRGen's
constant evaluator. The explicit padding fields need to be given a value
in the IR.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-716](https://bugs.swift.org/browse/SR-716).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
