### PR TITLE
[test] Add a timeout to runRaceTest(). Use it to limit test AtomicInt.swift.

### DIFF
--- a/stdlib/private/StdlibUnittest/RaceTest.swift
+++ b/stdlib/private/StdlibUnittest/RaceTest.swift
@@ -37,6 +37,7 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftPrivate
+import SwiftPrivateLibcExtras
 import SwiftPrivatePthreadExtras
 #if os(OSX) || os(iOS)
 import Darwin
@@ -391,6 +392,7 @@ class _RaceTestWorkerState<RT : RaceTestWithPerTrialData> {
 
 class _RaceTestSharedState<RT : RaceTestWithPerTrialData> {
   var racingThreadCount: Int
+  var stopNow = false
 
   var trialBarrier: _stdlib_Barrier
   var trialSpinBarrier: _stdlib_AtomicInt = _stdlib_AtomicInt()
@@ -409,6 +411,16 @@ class _RaceTestSharedState<RT : RaceTestWithPerTrialData> {
       self.workerStates.append(_RaceTestWorkerState<RT>())
     }
   }
+}
+
+func _masterThreadStopWorkers<RT : RaceTestWithPerTrialData>(
+    _ sharedState: _RaceTestSharedState<RT>
+) {
+  // Workers are proceeding to the first barrier in _workerThreadOneTrial.
+  sharedState.stopNow = true
+  // Allow workers to proceed past that first barrier. They will then see
+  // stopNow==true and stop.
+  sharedState.trialBarrier.wait()
 }
 
 func _masterThreadOneTrial<RT : RaceTestWithPerTrialData>(
@@ -475,13 +487,16 @@ func _masterThreadOneTrial<RT : RaceTestWithPerTrialData>(
 
 func _workerThreadOneTrial<RT : RaceTestWithPerTrialData>(
   _ tid: Int, _ sharedState: _RaceTestSharedState<RT>
-) {
+) -> Bool {
   sharedState.trialBarrier.wait()
+  if sharedState.stopNow {
+    return true
+  }
   let racingThreadCount = sharedState.racingThreadCount
   let workerState = sharedState.workerStates[tid]
   let rt = RT()
   var threadLocalData = rt.makeThreadLocalData()
-  if true {
+  do {
     let trialSpinBarrier = sharedState.trialSpinBarrier
     _ = trialSpinBarrier.fetchAndAdd(1)
     while trialSpinBarrier.load() < racingThreadCount {}
@@ -493,40 +508,111 @@ func _workerThreadOneTrial<RT : RaceTestWithPerTrialData>(
     workerState.observations.append(rt.thread1(raceData, &threadLocalData))
   }
   sharedState.trialBarrier.wait()
+  return false
+}
+
+/// One-shot sleep in one thread, allowing interrupt by another.
+class _InterruptibleSleep {
+  let writeEnd: CInt
+  let readEnd: CInt
+  var completed = false
+
+  init() {
+    (readEnd: readEnd, writeEnd: writeEnd, _) = _stdlib_pipe()
+  }
+
+  deinit {
+    close(readEnd)
+    close(writeEnd)
+  }
+
+  /// Sleep for durationInSeconds or until another
+  /// thread calls wake(), whichever comes first.
+  func sleep(durationInSeconds duration: Int) {
+    if completed {
+      return
+    }
+
+    var timeout = timeval(tv_sec:duration, tv_usec:0)
+
+    var readFDs = _stdlib_fd_set()
+    var writeFDs = _stdlib_fd_set()
+    var errorFDs = _stdlib_fd_set()
+    readFDs.set(readEnd)
+
+    let ret = _stdlib_select(&readFDs, &writeFDs, &errorFDs, &timeout)
+    precondition(ret >= 0)
+    completed = true
+  }
+
+  /// Wake the thread in sleep().
+  func wake() {
+    if completed { return }
+
+    let buffer: [UInt8] = [1]
+    let ret = write(writeEnd, buffer, 1)
+    precondition(ret >= 0)
+  }
 }
 
 public func runRaceTest<RT : RaceTestWithPerTrialData>(
   _: RT.Type,
   trials: Int,
+  timeoutInSeconds: Int? = nil,
   threads: Int? = nil
 ) {
   let racingThreadCount = threads ?? max(2, _stdlib_getHardwareConcurrency())
   let sharedState = _RaceTestSharedState<RT>(racingThreadCount: racingThreadCount)
 
-  let masterThreadBody: () -> Void = {
+  // Alarm thread sets timeoutReached.
+  // Master thread sees timeoutReached and tells worker threads to stop.
+  let timeoutReached = _stdlib_AtomicInt(0)
+  let alarmTimer = _InterruptibleSleep()
+
+  let masterThreadBody = {
     () -> Void in
-    for _ in 0..<trials {
+    for t in 0..<trials {
+      // Check for timeout.
+      // _masterThreadStopWorkers must run BEFORE the last _masterThreadOneTrial
+      // to make the thread coordination barriers work
+      // but we do want to run at least one trial even if the timeout occurs.
+      if timeoutReached.load() == 1 && t > 0 {
+        _masterThreadStopWorkers(sharedState)
+        break
+      }
+
       autoreleasepool {
         _masterThreadOneTrial(sharedState)
       }
     }
   }
 
-  let racingThreadBody: (Int) -> Void = {
+  let racingThreadBody = {
     (tid: Int) -> Void in
-    for _ in 0..<trials {
-      _workerThreadOneTrial(tid, sharedState)
+    for t in 0..<trials {
+      let stopNow = _workerThreadOneTrial(tid, sharedState)
+      if stopNow { break }
     }
   }
 
-  var allTids = [pthread_t]()
+  let alarmThreadBody = {
+    () -> Void in
+    guard let timeoutInSeconds = timeoutInSeconds
+    else { return }
+
+    alarmTimer.sleep(durationInSeconds: timeoutInSeconds)
+    _ = timeoutReached.fetchAndAdd(1)
+  }
+
+  var testTids = [pthread_t]()
+  var alarmTid: pthread_t
 
   // Create the master thread.
-  if true {
+  do {
     let (ret, tid) = _stdlib_pthread_create_block(
       nil, masterThreadBody, ())
     expectEqual(0, ret)
-    allTids.append(tid!)
+    testTids.append(tid!)
   }
 
   // Create racing threads.
@@ -534,12 +620,27 @@ public func runRaceTest<RT : RaceTestWithPerTrialData>(
     let (ret, tid) = _stdlib_pthread_create_block(
       nil, racingThreadBody, i)
     expectEqual(0, ret)
-    allTids.append(tid!)
+    testTids.append(tid!)
   }
 
-  // Join all threads.
-  for tid in allTids {
+  // Create the alarm thread that enforces the timeout.
+  do {
+    let (ret, tid) = _stdlib_pthread_create_block(
+      nil, alarmThreadBody, ())
+    expectEqual(0, ret)
+    alarmTid = tid!
+  }
+
+  // Join all testing threads.
+  for tid in testTids {
     let (ret, _) = _stdlib_pthread_join(tid, Void.self)
+    expectEqual(0, ret)
+  }
+
+  // Tell the alarm thread to stop if it hasn't already, then join it.
+  do {
+    alarmTimer.wake()
+    let (ret, _) = _stdlib_pthread_join(alarmTid, Void.self)
     expectEqual(0, ret)
   }
 
@@ -555,6 +656,7 @@ internal func _divideRoundUp(_ lhs: Int, _ rhs: Int) -> Int {
 public func runRaceTest<RT : RaceTestWithPerTrialData>(
   _ test: RT.Type,
   operations: Int,
+  timeoutInSeconds: Int? = nil,
   threads: Int? = nil
 ) {
   let racingThreadCount = threads ?? max(2, _stdlib_getHardwareConcurrency())
@@ -562,7 +664,8 @@ public func runRaceTest<RT : RaceTestWithPerTrialData>(
   // Each trial runs threads^2 operations.
   let operationsPerTrial = racingThreadCount * racingThreadCount
   let trials = _divideRoundUp(operations, operationsPerTrial)
-  runRaceTest(test, trials: trials, threads: threads)
+  runRaceTest(test, trials: trials, timeoutInSeconds: timeoutInSeconds,
+    threads: threads)
 }
 
 public func consumeCPU(units amountOfWork: Int) {
@@ -597,9 +700,24 @@ internal struct ClosureBasedRaceTest : RaceTestWithPerTrialData {
 }
 
 public func runRaceTest(
-  trials: Int, threads: Int? = nil, invoking body: @escaping () -> ()
+  trials: Int,
+  timeoutInSeconds: Int? = nil,
+  threads: Int? = nil,
+  invoking body: @escaping () -> ()
 ) {
   ClosureBasedRaceTest.thread = body
-  runRaceTest(ClosureBasedRaceTest.self, trials: trials, threads: threads)
+  runRaceTest(ClosureBasedRaceTest.self, trials: trials,
+    timeoutInSeconds: timeoutInSeconds, threads: threads)
+}
+
+public func runRaceTest(
+  operations: Int,
+  timeoutInSeconds: Int? = nil,
+  threads: Int? = nil,
+  invoking body: @escaping () -> ()
+) {
+  ClosureBasedRaceTest.thread = body
+  runRaceTest(ClosureBasedRaceTest.self, operations: operations,
+    timeoutInSeconds: timeoutInSeconds, threads: threads)
 }
 

--- a/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
@@ -115,6 +115,17 @@ public func _stdlib_select(
 }
 #endif
 
+
+/// Swift-y wrapper around pipe(2)
+public func _stdlib_pipe() -> (readEnd: CInt, writeEnd: CInt, error: CInt) {
+  var fds: [CInt] = [0, 0]
+  let ret = fds.withUnsafeMutableBufferPointer { unsafeFds -> CInt in
+    pipe(unsafeFds.baseAddress)
+  }
+  return (readEnd: fds[0], writeEnd: fds[1], error: ret)
+}
+
+
 //
 // Functions missing in `Darwin` module.
 //

--- a/validation-test/StdlibUnittest/RaceTest.swift
+++ b/validation-test/StdlibUnittest/RaceTest.swift
@@ -2,6 +2,11 @@
 // RUN: %target-run %t.out | %FileCheck %s
 
 import StdlibUnittest
+#if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)
+import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android)
+import Glibc
+#endif
 
 
 _setTestSuiteFailedCallback() { print("abort()") }
@@ -102,7 +107,77 @@ RaceTestSuite.test("closure") {
 }
 // CHECK: [ RUN      ] Race.closure
 // CHECK: [       OK ] Race.closure
-// CHECK: Race: Some tests failed, aborting
+
+RaceTestSuite.test("timeout-zero") {
+  // Zero timeout is still expected to run at least one trial.
+  let count = _stdlib_AtomicInt(0)
+  runRaceTest(trials: 2000000000, timeoutInSeconds: 0) {
+    _ = count.fetchAndAdd(1)
+  }
+  expectGT(count.load(), 0)
+}
+// CHECK: [ RUN      ] Race.timeout-zero
+// CHECK: [       OK ] Race.timeout-zero
+
+
+func -(_ lhs: timeval, _ rhs: timeval) -> timeval {
+  var result = timeval(tv_sec: 0, tv_usec: 0)
+  result.tv_sec = lhs.tv_sec - rhs.tv_sec
+  result.tv_usec = lhs.tv_usec - rhs.tv_usec
+  if result.tv_usec < 0 {
+    result.tv_usec += 1000000
+    result.tv_sec -= 1
+  }
+  return result
+}
+
+func gettimeofday() -> timeval {
+  var result = timeval(tv_sec: 0, tv_usec: 0)
+  gettimeofday(&result, nil)
+  return result
+}
+
+RaceTestSuite.test("timeout-small") {
+  // Verify that the timeout fires after the correct number of seconds.
+  // If the timeout fails to fire then this test will run for a very long time.
+  var startTime: timeval
+  var endTime: timeval
+  let timeout = 5
+  let count = _stdlib_AtomicInt(0)
+  startTime = gettimeofday()
+  runRaceTest(trials: 2000000000, timeoutInSeconds: timeout) {
+    _ = count.fetchAndAdd(1)
+  }
+  endTime = gettimeofday()
+  expectGT(count.load(), 0)
+  // Test should have run to the timeout.
+  // Test should not have run too long after the timeout.
+  let duration = endTime - startTime
+  expectGE(duration.tv_sec, timeout)
+  expectLT(duration.tv_sec, timeout*100)  // large to avoid spurious failures
+}
+// CHECK: [ RUN      ] Race.timeout-small
+// CHECK: [       OK ] Race.timeout-small
+
+RaceTestSuite.test("timeout-big") {
+  // Verify that a short test with a long timeout completes before the timeout.
+  var startTime: timeval
+  var endTime: timeval
+  let timeout = 10000
+  let count = _stdlib_AtomicInt(0)
+  startTime = gettimeofday()
+  runRaceTest(trials: 10, timeoutInSeconds: timeout) {
+    _ = count.fetchAndAdd(1)
+  }
+  endTime = gettimeofday()
+  expectGT(count.load(), 0)
+  // Test should have stopped long before the timeout.
+  let duration = endTime - startTime
+  expectLT(duration.tv_sec, timeout / 2)
+}
+// CHECK: [ RUN      ] Race.timeout-big
+// CHECK: [       OK ] Race.timeout-big
 
 runAllTests()
+// CHECK: Race: Some tests failed, aborting
 

--- a/validation-test/stdlib/AtomicInt.swift
+++ b/validation-test/stdlib/AtomicInt.swift
@@ -14,10 +14,6 @@ import Darwin
 import Glibc
 #endif
 
-func operationCount(_ n: Int) -> Int {
-  return _isDebugAssertConfiguration() ? n/2 : n
-}
-
 final class HeapBool {
   var value: Bool
   init(_ value: Bool) {
@@ -797,39 +793,43 @@ struct AtomicInitializeARCRefRaceTest : RaceTestWithPerTrialData {
 var AtomicIntTestSuite = TestSuite("AtomicInt")
 
 AtomicIntTestSuite.test("fetchAndAdd/1") {
-  runRaceTest(AtomicInt_fetchAndAdd_1_RaceTest.self, operations: operationCount(6400))
+  runRaceTest(AtomicInt_fetchAndAdd_1_RaceTest.self,
+    operations: 6400, timeoutInSeconds: 60)
 }
 
 AtomicIntTestSuite.test("fetchAndAdd/ReleaseAtomicStores/1") {
   runRaceTest(
     AtomicInt_fetchAndAdd_ReleaseAtomicStores_1_RaceTest.self,
-    operations: operationCount(12800))
+    operations: 12800, timeoutInSeconds: 60)
 }
 
 AtomicIntTestSuite.test("fetchAndAdd/ReleaseAtomicStores/2") {
   runRaceTest(
     AtomicInt_fetchAndAdd_ReleaseAtomicStores_2_RaceTest.self,
-    operations: operationCount(12800))
+    operations: 12800, timeoutInSeconds: 60)
 }
 
 AtomicIntTestSuite.test("fetchAndAdd/ReleaseNonAtomicStores/1") {
   runRaceTest(
     AtomicInt_fetchAndAdd_ReleaseNonAtomicStores_RaceTest.self,
-    operations: operationCount(25600))
+    operations: 25600, timeoutInSeconds: 60)
 }
 
 AtomicIntTestSuite.test("fetchAndAnd/1") {
-  runRaceTest(AtomicInt_fetchAndAnd_1_RaceTest.self, operations: operationCount(6400))
+  runRaceTest(AtomicInt_fetchAndAnd_1_RaceTest.self,
+    operations: 6400, timeoutInSeconds: 60)
 }
 // FIXME: add more tests for fetchAndAnd, like we have for fetchAndAdd.
 
 AtomicIntTestSuite.test("fetchAndOr/1") {
-  runRaceTest(AtomicInt_fetchAndOr_1_RaceTest.self, operations: operationCount(6400))
+  runRaceTest(AtomicInt_fetchAndOr_1_RaceTest.self,
+    operations: 6400, timeoutInSeconds: 60)
 }
 // FIXME: add more tests for fetchAndOr, like we have for fetchAndAdd.
 
 AtomicIntTestSuite.test("fetchAndXor/1") {
-  runRaceTest(AtomicInt_fetchAndXor_1_RaceTest.self, operations: operationCount(6400))
+  runRaceTest(AtomicInt_fetchAndXor_1_RaceTest.self,
+    operations: 6400, timeoutInSeconds: 60)
 }
 // FIXME: add more tests for fetchAndXor, like we have for fetchAndAdd.
 
@@ -837,7 +837,8 @@ AtomicIntTestSuite.test("fetchAndXor/1") {
 var AtomicARCRefTestSuite = TestSuite("AtomicARCRef")
 
 AtomicARCRefTestSuite.test("initialize,load") {
-  runRaceTest(AtomicInitializeARCRefRaceTest.self, operations: operationCount(25600))
+  runRaceTest(AtomicInitializeARCRefRaceTest.self,
+    operations: 25600, timeoutInSeconds: 60)
   expectEqual(0, dummyObjectCount.getSum())
 }
 


### PR DESCRIPTION
This cuts AtomicInt.swift's execution time from several hours to
about ten minutes on slow hardware and slow build configurations.
