### PR TITLE
[Scope map] Local types and functions are visible in the enclosing braces

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -402,11 +402,12 @@ static DeclVisibilityKind getLocalDeclVisibilityKind(const ASTScope *scope) {
   switch (scope->getKind()) {
   case ASTScopeKind::Preexpanded:
   case ASTScopeKind::SourceFile:
+  case ASTScopeKind::TypeDecl:
+  case ASTScopeKind::AbstractFunctionDecl:
   case ASTScopeKind::TypeOrExtensionBody:
   case ASTScopeKind::AbstractFunctionBody:
   case ASTScopeKind::DefaultArgument:
   case ASTScopeKind::PatternBinding:
-  case ASTScopeKind::BraceStmt:
   case ASTScopeKind::IfStmt:
   case ASTScopeKind::GuardStmt:
   case ASTScopeKind::RepeatWhileStmt:
@@ -427,11 +428,10 @@ static DeclVisibilityKind getLocalDeclVisibilityKind(const ASTScope *scope) {
   case ASTScopeKind::PatternInitializer:  // lazy var 'self'
     return DeclVisibilityKind::FunctionParameter;
 
-  case ASTScopeKind::TypeDecl:
-  case ASTScopeKind::AbstractFunctionDecl:
   case ASTScopeKind::AfterPatternBinding:
   case ASTScopeKind::ConditionalClause:
   case ASTScopeKind::ForEachPattern:
+  case ASTScopeKind::BraceStmt:
   case ASTScopeKind::CatchStmt:
   case ASTScopeKind::CaseStmt:
   case ASTScopeKind::ForStmtInitializer:

--- a/test/NameBinding/scope_map.swift
+++ b/test/NameBinding/scope_map.swift
@@ -271,14 +271,14 @@ class LazyProperties {
 // CHECK-EXPANDED-NEXT: {{^}}                |-PatternInitializer {{.*}} entry 0 [54:14 - 54:14] expanded
 // CHECK-EXPANDED-NEXT: {{^}}              `-AfterPatternBinding {{.*}} entry 0 [54:14 - 56:3] expanded
 // CHECK-EXPANDED: {{^}}                `-AfterPatternBinding {{.*}} entry 0 [55:14 - 56:3] expanded
-// CHECK-EXPANDED-NEXT: {{^}}              `-AbstractFunctionDecl {{.*}} f(_:) [57:3 - 100:1] expanded
-// CHECK-EXPANDED-NEXT: {{^}}                |-AbstractFunctionParams {{.*}} f(_:) param 0:0 [57:15 - 57:38] expanded
+// CHECK-EXPANDED-NEXT: {{^}}              |-AbstractFunctionDecl {{.*}} f(_:) [57:3 - 57:38] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                `-AbstractFunctionParams {{.*}} f(_:) param 0:0 [57:15 - 57:38] expanded
 // CHECK-EXPANDED-NEXT:                       `-AbstractFunctionBody {{.*}} f(_:) [57:27 - 57:38] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                  `-BraceStmt {{.*}} [57:27 - 57:38] expanded
 // CHECK-EXPANDED: {{^}}              `-AfterPatternBinding {{.*}} entry 0 [58:16 - 100:1] expanded
-// CHECK-EXPANDED-NEXT: {{^}}                `-TypeDecl {{.*}} S7 [59:3 - 100:1] expanded
-// CHECK-EXPANDED-NEXT: {{^}}                  |-TypeOrExtensionBody {{.*}} 'S7' [59:13 - 59:15] expanded
-// CHECK-EXPANDED-NEXT: {{^}}                  `-TypeDecl {{.*}} S7Alias [60:3 - 100:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                |-TypeDecl {{.*}} S7 [59:3 - 59:15] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                  `-TypeOrExtensionBody {{.*}} 'S7' [59:13 - 59:15] expanded
+// CHECK-EXPANDED-NEXT: {{^}}                  |-TypeDecl {{.*}} S7Alias [60:3 - 60:23] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                    |-IfStmt {{.*}} [62:3 - 66:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                      |-ConditionalClause {{.*}} index 0 [62:18 - 64:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}                        `-ConditionalClause {{.*}} index 1 [62:29 - 64:3] expanded
@@ -376,7 +376,7 @@ class LazyProperties {
 // CHECK-EXPANDED: {{^}}        `-BraceStmt {{.*}} [146:9 - 148:5] expanded
 // CHECK-EXPANDED: {{^}}      `-AfterPatternBinding {{.*}} entry 1 [149:36 - 155:1] expanded
 // CHECK-EXPANDED: {{^}}        `-AfterPatternBinding {{.*}} entry 2 [150:21 - 155:1] expanded
-// CHECK-EXPANDED-NEXT: {{^}}           `-AbstractFunctionDecl {{.*}} _ [150:25 - 155:1] expanded
+// CHECK-EXPANDED-NEXT: {{^}}           |-AbstractFunctionDecl {{.*}} _ [150:25 - 152:3] expanded
 // CHECK-EXPANDED: {{^}}            `-BraceStmt {{.*}} [150:25 - 152:3] expanded
 // CHECK-EXPANDED-NEXT: {{^}}              `-BraceStmt {{.*}} [154:6 - 154:8] expanded
 
@@ -395,7 +395,7 @@ class LazyProperties {
 // CHECK-EXPANDED-NEXT: {{^}}    |-Closure {{.*}} [164:1 - 164:14] expanded
 // CHECK-EXPANDED-NEXT: {{^}}      `-BraceStmt {{.*}} [164:1 - 164:14] expanded
 
-// CHECK-EXPANDED: -AbstractFunctionDecl {{.*}} defaultArguments(i:j:) [166:1 - [[EOF]]] expanded
+// CHECK-EXPANDED: -AbstractFunctionDecl {{.*}} defaultArguments(i:j:) [166:1 - 175:1] expanded
 // CHECK-EXPANDED: {{^}}    |-DefaultArgument {{.*}} [166:32 - 166:32] expanded
 // CHECK-EXPANDED-NEXT: {{^}}    `-AbstractFunctionParams {{.*}} defaultArguments(i:j:) param 0:0 [166:32 - 175:1] expanded
 // CHECK-EXPANDED: {{^}}        |-DefaultArgument {{.*}} [167:32 - 167:48] expanded
@@ -412,7 +412,7 @@ class LazyProperties {
 // CHECK-EXPANDED-NEXT:         `-AbstractFunctionParams {{.*}} _ param 1:0 [183:39 - 183:39] expanded
 // CHECK-EXPANDED-NEXT:           `-AbstractFunctionParams {{.*}} _ param 1:1 [183:39 - 183:39] expanded
 
-// CHECK-EXPANDED: -AbstractFunctionDecl {{.*}} localPatternsWithSharedType() [186:1 - [[EOF]]] expanded
+// CHECK-EXPANDED: -AbstractFunctionDecl {{.*}} localPatternsWithSharedType() [186:1 - 188:1] expanded
 // CHECK-EXPANDED:  `-BraceStmt {{.*}} [186:36 - 188:1] expanded
 // CHECK-EXPANDED-NEXT:    `-PatternBinding {{.*}} entry 0 [187:7 - 188:1] expanded
 // CHECK-EXPANDED-NEXT:      `-AfterPatternBinding {{.*}} entry 0 [187:7 - 188:1] expanded
@@ -478,19 +478,19 @@ class LazyProperties {
 // CHECK-SEARCHES: |-AbstractFunctionDecl {{.*}} functionBodies1(a:b:) [41:1 - 100:1] expanded
 // CHECK-SEARCHES: `-AbstractFunctionParams {{.*}} functionBodies1(a:b:) param 0:0 [41:25 - 100:1] expanded
 // CHECK-SEARCHES: |-AbstractFunctionDecl {{.*}} throwing() [102:1 - 102:26] unexpanded
-// CHECK-SEARCHES: -AbstractFunctionDecl {{.*}} defaultArguments(i:j:) [166:1 - [[EOF]]] expanded
+// CHECK-SEARCHES: -AbstractFunctionDecl {{.*}} defaultArguments(i:j:) [166:1 - 175:1] expanded
 // CHECK-SEARCHES: DefaultArgument {{.*}} [166:32 - 166:32] expanded
 // CHECK-SEARCHES-NOT: {{ expanded}}
-// CHECK-SEARCHES: `-TypeDecl {{.*}} PatternInitializers [177:1 - [[EOF]]] expanded
+// CHECK-SEARCHES: |-TypeDecl {{.*}} PatternInitializers [177:1 - 180:1] expanded
 // CHECK-SEARCHES: -TypeOrExtensionBody {{.*}} 'PatternInitializers' [177:28 - 180:1] expanded
 // CHECK-SEARCHES:    |-PatternBinding {{.*}} entry 0 [178:7 - 178:21] unexpanded
 // CHECK-SEARCHES:    `-PatternBinding {{.*}} entry 1 [179:7 - 179:25] expanded
 // CHECK-SEARCHES:      `-PatternInitializer {{.*}} entry 1 [179:16 - 179:25] expanded
 // CHECK-SEARCHES-NOT: {{ expanded}}
-// CHECK-SEARCHES:    `-TypeDecl {{.*}} ProtoWithSubscript [182:1 - [[EOF]]] expanded
+// CHECK-SEARCHES:    |-TypeDecl {{.*}} ProtoWithSubscript [182:1 - 184:1] unexpanded
 // CHECK-SEARCHES-NOT: {{ expanded}}
-// CHECK-SEARCHES: `-AbstractFunctionDecl {{.*}} localPatternsWithSharedType() [186:1 - [[EOF]]] expanded
-// CHECK-SEARCHES: `-TypeDecl {{.*}} LazyProperties [190:1 - [[EOF]]] expanded
+// CHECK-SEARCHES: |-AbstractFunctionDecl {{.*}} localPatternsWithSharedType() [186:1 - 188:1] unexpanded
+// CHECK-SEARCHES: `-TypeDecl {{.*}} LazyProperties [190:1 - 194:1] expanded
 // CHECK-SEARCHES: -TypeOrExtensionBody {{.*}} 'LazyProperties' [190:22 - 194:1] expanded
 // CHECK-SEARCHES-NEXT:   |-PatternBinding {{.*}} entry 0 [191:7 - 191:20] unexpanded
 // CHECK-SEARCHES-NEXT:   `-PatternBinding {{.*}} entry 0 [193:12 - 193:29] expanded

--- a/test/NameBinding/scope_map_top_level.swift
+++ b/test/NameBinding/scope_map_top_level.swift
@@ -32,6 +32,6 @@ var i: Int = b.my_identity()
 // CHECK-EXPANDED-NEXT:       `-AfterPatternBinding {{.*}} entry 0 [6:15 - [[EOF]]] expanded
 // CHECK-EXPANDED-NEXT:         `-TopLevelCode {{.*}} [8:1 - [[EOF]]] expanded
 // CHECK-EXPANDED: `-ConditionalClause {{.*}} index 0 guard-continuation [9:1 - [[EOF]]] expanded
-// CHECK-EXPANDED-NEXT:                 `-AbstractFunctionDecl {{.*}} foo() [11:1 - [[EOF]]] expanded
+// CHECK-EXPANDED-NEXT:                 |-AbstractFunctionDecl {{.*}} foo() [11:1 - 11:13] expanded
 // CHECK-EXPANDED: `-AfterPatternBinding {{.*}} entry 0 [13:9 - [[EOF]]] expanded
-// CHECK-EXPANDED-NEXT:                           `-TypeDecl {{.*}} T [15:1 - [[EOF]]] expanded
+// CHECK-EXPANDED-NEXT:                           |-TypeDecl {{.*}} T [15:1 - 15:15] expanded

--- a/test/Parse/type_expr.swift
+++ b/test/Parse/type_expr.swift
@@ -1,4 +1,5 @@
 // RUN: %target-parse-verify-swift
+// RUN: %target-parse-verify-swift -enable-astscope-lookup
 
 // Types in expression contexts must be followed by a member access or
 // constructor call.

--- a/test/SILGen/local_recursion.swift
+++ b/test/SILGen/local_recursion.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend  -parse-as-library -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-astscope-lookup  -parse-as-library -emit-silgen %s | %FileCheck %s
 
 // CHECK-LABEL: sil hidden @_TF15local_recursion15local_recursionFTSi1ySi_T_ : $@convention(thin) (Int, Int) -> () {
 // CHECK:       bb0([[X:%0]] : $Int, [[Y:%1]] : $Int):


### PR DESCRIPTION
<!-- What's in this pull request? -->

As in non-local scopes, local types and functions are generally
visible anywhere within enclosing braces, and it is up to capture
analysis to determine whether these entities attempt to capture an
entity that isn't guaranteed to be available.

This brings us down to ~11 failures in the normal test suite when using ASTScope-based unqualified name lookup in lieu of FindLocalVal-based unqualified name lookup. (Plus a pile of crashers in the validation tests)

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
