### PR TITLE
Don't serialize debug_value/debug_value_addr instructions.

### DIFF
--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1262,8 +1262,6 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
   REFCOUNTING_INSTRUCTION(UnownedRelease)
   UNARY_INSTRUCTION(IsUnique)
   UNARY_INSTRUCTION(IsUniqueOrPinned)
-  UNARY_INSTRUCTION(DebugValue)
-  UNARY_INSTRUCTION(DebugValueAddr)
 #undef UNARY_INSTRUCTION
 #undef REFCOUNTING_INSTRUCTION
 

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -526,6 +526,13 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
   case ValueKind::SILUndef:
     llvm_unreachable("not an instruction");
 
+  case ValueKind::DebugValueInst:
+  case ValueKind::DebugValueAddrInst:
+    // Currently we don't serialize debug variable infos, so it doesn't make
+    // sense to write the instruction at all.
+    // TODO: decide if we want to serialize those instructions.
+    return;
+      
   case ValueKind::UnreachableInst: {
     unsigned abbrCode = SILAbbrCodes[SILInstNoOperandLayout::Code];
     SILInstNoOperandLayout::emitRecord(Out, ScratchRecord, abbrCode,
@@ -1001,9 +1008,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
   case ValueKind::IsUniqueInst:
   case ValueKind::IsUniqueOrPinnedInst:
   case ValueKind::ReturnInst:
-  case ValueKind::ThrowInst:
-  case ValueKind::DebugValueInst:
-  case ValueKind::DebugValueAddrInst: {
+  case ValueKind::ThrowInst: {
     unsigned Attr = 0;
     if (auto *LWI = dyn_cast<LoadWeakInst>(&SI))
       Attr = LWI->isTake();

--- a/test/sil-extract/basic.swift
+++ b/test/sil-extract/basic.swift
@@ -30,7 +30,6 @@
 
 // EXTRACT-TEST-LABEL:  sil hidden @_TFV5basic1X4testfT_T_ : $@convention(method) (X) -> () {
 // EXTRACT-TEST:        bb0(%0 : $X):
-// EXTRACT-TEST-NEXT:     debug_value
 // EXTRACT-TEST-NEXT:     function_ref
 // EXTRACT-TEST-NEXT:     function_ref @_TF5basic3fooFT_Si : $@convention(thin) () -> Int
 // EXTRACT-TEST-NEXT:     apply
@@ -44,8 +43,6 @@
 
 // EXTRACT-INIT-LABEL:   sil hidden @_TFC5basic7VehiclecfT1nSi_S0_ : $@convention(method) (Int, @owned Vehicle) -> @owned Vehicle {
 // EXTRACT-INIT:         bb0
-// EXTRACT-INIT-NEXT:      debug_value
-// EXTRACT-INIT-NEXT:      debug_value
 // EXTRACT-INIT-NEXT:      ref_element_addr
 // EXTRACT-INIT-NEXT:      store
 // EXTRACT-INIT-NEXT:      return
@@ -57,7 +54,6 @@
 
 // EXTRACT-NOW-LABEL:   sil hidden @_TFC5basic7Vehicle3nowfT_Si : $@convention(method) (@guaranteed Vehicle) -> Int {
 // EXTRACT-NOW:         bb0
-// EXTRACT-NOW-NEXT:      debug_value
 // EXTRACT-NOW-NEXT:      ref_element_addr
 // EXTRACT-NOW-NEXT:      load
 // EXTRACT-NOW-NEXT:      return


### PR DESCRIPTION
We didn't serialize the their var-info so after de-serializing they were useless anyway.
By not serializing them we get rid of useless debug_value instructions coming from the stdlib.
In future we might change this and fully serialize them.
