### PR TITLE
[swift-3.0-branch] Foundation: add a custom AnyHashable representation for NSSet

### DIFF
--- a/stdlib/public/SDK/Foundation/Foundation.swift
+++ b/stdlib/public/SDK/Foundation/Foundation.swift
@@ -921,23 +921,13 @@ extension Set : _ObjectiveCBridgeable {
   }
 }
 
-/*
-FIXME(id-as-any): uncomment this when we can cast NSSet to Set<AnyHashable>.
 extension NSSet : _HasCustomAnyHashableRepresentation {
   // Must be @nonobjc to avoid infinite recursion during bridging
   @nonobjc
   public func _toCustomAnyHashable() -> AnyHashable? {
-    var builder = _SetBuilder<Element>(count: s!.count)
-    // FIXME(id-as-any): how to get the Hashable conformance here?
-    s!.enumerateObjects({
-      (anyMember: Any, stop: UnsafeMutablePointer<ObjCBool>) in
-      builder.add(member: Swift._forceBridgeFromObjectiveC(
-        anyMember as AnyObject, Element.self))
-    })
-    return AnyHashable(self as Set<AnyHashable>)
+    return AnyHashable(self as! Set<AnyHashable>)
   }
 }
-*/
 
 extension NSDictionary : Sequence {
   // FIXME: A class because we can't pass a struct with class fields through an

--- a/test/1_stdlib/NSSetAPI.swift
+++ b/test/1_stdlib/NSSetAPI.swift
@@ -43,6 +43,30 @@ NSSetAPI.test("CustomStringConvertible") {
   expectEqual(expect, result)
 }
 
+NSSetAPI.test("AnyHashable containing NSSet") {
+  let values: [NSSet] = [
+    NSSet(),
+    NSSet(objects: 1, 2, 3),
+    NSSet(objects: 1, 2, 3),
+  ]
+  let anyHashables = values.map(AnyHashable.init)
+  expectEqual(Set<AnyHashable>.self, type(of: anyHashables[0].base))
+  expectEqual(Set<AnyHashable>.self, type(of: anyHashables[1].base))
+  expectEqual(Set<AnyHashable>.self, type(of: anyHashables[2].base))
+  expectNotEqual(anyHashables[0], anyHashables[1])
+  expectEqual(anyHashables[1], anyHashables[2])
+}
+
+NSSetAPI.test("AnyHashable containing NSSet that contains an NSSet") {
+  let anyHashable = AnyHashable(NSSet(objects: NSSet(objects: 1,2,3)))
+  expectEqual(Set<AnyHashable>.self, type(of: anyHashable.base))
+
+  if let firstNested
+    = expectNotEmpty((anyHashable.base as! Set<AnyHashable>).first!) {
+    expectEqual(Set<AnyHashable>.self, type(of: firstNested.base))
+  }
+}
+
 var NSOrderedSetAPI = TestSuite("NSOrderedSetAPI")
 
 NSOrderedSetAPI.test("Sequence") {


### PR DESCRIPTION
- Explanation: Add a custom AnyHashable representation for NSSet
- Scope of Issue: Fixes the bridging in case where NSSet is a key in a Dictionary
- Origination:
- Risk: Minimal
- Reviewed By: Doug Gregor
- Testing: Existing test suite.
- Directions for QA: N/A

PR against master: https://github.com/apple/swift/pull/4810
rdar://problem/28330040

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
