### PR TITLE
stdlib: make RangeReplaceableCollection.SubSequence a RangeReplaceableCollection

### DIFF
--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -613,9 +613,9 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         }
     }
     
-    public subscript(bounds: Range<Index>) -> MutableRandomAccessSlice<Data> {
+    public subscript(bounds: Range<Index>) -> MutableRangeReplaceableRandomAccessSlice<Data> {
         get {
-            return MutableRandomAccessSlice(base: self, bounds: bounds)
+            return MutableRangeReplaceableRandomAccessSlice(base: self, bounds: bounds)
         }
         set {
             replaceSubrange(bounds, with: newValue.base)

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -81,7 +81,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     public typealias Base64DecodingOptions = NSData.Base64DecodingOptions
     
     public typealias Index = Int
-    public typealias Indices = DefaultRandomAccessIndices<Data>
+    public typealias Indices = CountableRange<Int>
     
     internal var _wrapped : _SwiftNSData
     
@@ -640,6 +640,10 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
 
     public func index(after i: Index) -> Index {
         return i + 1
+    }
+
+    public var indices: CountableRange<Int> {
+        return startIndex..<endIndex
     }
 
     /// An iterator over the contents of the data.

--- a/stdlib/public/core/RangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/RangeReplaceableCollection.swift.gyb
@@ -244,6 +244,10 @@ public protocol _RangeReplaceableIndexable : _Indexable {
 public protocol RangeReplaceableCollection
   : _RangeReplaceableIndexable, Collection
 {
+  // FIXME(ABI): should require `RangeReplaceableCollection`.
+  associatedtype SubSequence : _RangeReplaceableIndexable /*: RangeReplaceableCollection*/
+    = RangeReplaceableSlice<Self>
+
   //===--- Fundamental Requirements ---------------------------------------===//
 
   /// Creates a new, empty collection.
@@ -540,6 +544,9 @@ public protocol RangeReplaceableCollection
 //===----------------------------------------------------------------------===//
 
 extension RangeReplaceableCollection {
+  public subscript(bounds: Range<Index>) -> RangeReplaceableSlice<Self> {
+    return RangeReplaceableSlice(base: self, bounds: bounds)
+  }
 
   /// Creates a new collection containing the specified number of a single,
   /// repeated value.

--- a/validation-test/stdlib/CollectionDiagnostics.swift
+++ b/validation-test/stdlib/CollectionDiagnostics.swift
@@ -116,3 +116,27 @@ struct BadBidirectionalIndexable : BidirectionalIndexable {
   // expected-error@+1 {{'index(after:)' has different argument names from those required by protocol '_BidirectionalIndexable' ('index(before:)'}}
   func index(after i: Int) -> Int { return 0 }
 }
+
+//
+// Check that RangeReplaceableCollection.SubSequence is defaulted.
+//
+
+struct RangeReplaceableCollection_SubSequence_IsDefaulted : RangeReplaceableCollection {
+  var startIndex: Int { fatalError() }
+  var endIndex: Int { fatalError() }
+
+  subscript(pos: Int) -> Int { return 0 }
+
+  func index(after: Int) -> Int { fatalError() }
+  func index(before: Int) -> Int { fatalError() }
+  func index(_: Int, offsetBy: Int) -> Int { fatalError() }
+  func distance(from: Int, to: Int) -> Int { fatalError() }
+
+  mutating func replaceSubrange<C>(
+    _ subrange: Range<Int>,
+    with newElements: C
+  ) where C : Collection, C.Iterator.Element == Int {
+    fatalError()
+  }
+}
+

--- a/validation-test/stdlib/Data.swift
+++ b/validation-test/stdlib/Data.swift
@@ -29,4 +29,17 @@ DataTestSuite.test("Data.Iterator semantics") {
   }
   checkSequence((0..<65535).lazy.map({ UInt8($0 % 23) }), data)
 }
+
+DataTestSuite.test("associated types") {
+  typealias Subject = Data
+  expectRandomAccessCollectionAssociatedTypes(
+    collectionType: Subject.self,
+    iteratorType: Data.Iterator.self,
+    subSequenceType: MutableRangeReplaceableRandomAccessSlice<Subject>.self,
+    indexType: Int.self,
+    indexDistanceType: Int.self,
+    indicesType: CountableRange<Int>.self)
+}
+
+
 runAllTests()


### PR DESCRIPTION
This change makes RangeReplaceableCollection.SubSequence a RangeReplaceableCollection, and fixes Foundation.Data that did not conform to this requirement.

Fixes:
rdar://problem/28330668
rdar://problem/28330713
