### PR TITLE
[SourceKit] Add test case for crash triggered in swift::TypeChecker::computeDefaultAccessibility(…)

### DIFF
--- a/validation-test/IDE/crashers/091-swift-typechecker-computedefaultaccessibility.swift
+++ b/validation-test/IDE/crashers/091-swift-typechecker-computedefaultaccessibility.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+protocol A{typealias e}extension A{typealias e:e l#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 176
swift-ide-test: /path/to/swift/include/swift/AST/Decl.h:1572: void swift::ExtensionDecl::setDefaultAndMaxAccessibility(swift::Accessibility, swift::Accessibility): Assertion `!hasDefaultAccessibility() && "default accessibility already set"' failed.
9  swift-ide-test  0x000000000098ef3b swift::TypeChecker::computeDefaultAccessibility(swift::ExtensionDecl*) + 843
10 swift-ide-test  0x000000000098f4a0 swift::TypeChecker::computeAccessibility(swift::ValueDecl*) + 688
11 swift-ide-test  0x000000000098f81c swift::TypeChecker::validateAccessibility(swift::ValueDecl*) + 76
12 swift-ide-test  0x000000000098cd92 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 66
16 swift-ide-test  0x00000000009936e6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
17 swift-ide-test  0x00000000009b9172 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
18 swift-ide-test  0x00000000007abc69 swift::CompilerInstance::performSema() + 3289
19 swift-ide-test  0x000000000074d981 main + 36401
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking 'A' at <INPUT-FILE>:3:1
```
