### PR TITLE
[swiftc (71 vs. 5162)] Add crasher in swift::constraints::ConstraintSystem::diagnoseFailureForExpr(...)

### DIFF
--- a/validation-test/compiler_crashers/28421-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
+++ b/validation-test/compiler_crashers/28421-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
@@ -1,0 +1,14 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+{
+extension{{
+}init(){a{}{
+for b
+(


### PR DESCRIPTION
Add test case for crash triggered in `swift::constraints::ConstraintSystem::diagnoseFailureForExpr(...)`.

Current number of unresolved compiler crashers: 71 (5162 resolved)

Assertion failure in [`lib/Sema/TypeCheckNameLookup.cpp (line 254)`](https://github.com/apple/swift/blob/master/lib/Sema/TypeCheckNameLookup.cpp#L254):

```
Assertion `!type->is<TupleType>()' failed.

When executing: swift::LookupResult swift::TypeChecker::lookupMember(swift::DeclContext *, swift::Type, swift::DeclName, NameLookupOptions)
```

Assertion context:

```
  // We handle our own overriding/shadowing filtering.
  subOptions &= ~NL_RemoveOverridden;
  subOptions &= ~NL_RemoveNonVisible;

  // We can't have tuple types here; they need to be handled elsewhere.
  assert(!type->is<TupleType>());

  // Local function that performs lookup.
  auto doLookup = [&]() {
    result.clear();

```

Stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckNameLookup.cpp:254: swift::LookupResult swift::TypeChecker::lookupMember(swift::DeclContext *, swift::Type, swift::DeclName, NameLookupOptions): Assertion `!type->is<TupleType>()' failed.
9  swift           0x0000000000f96f16 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 5990
10 swift           0x0000000000f9c09e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4078
11 swift           0x0000000000ec5d77 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 471
12 swift           0x0000000000ec9455 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 949
13 swift           0x0000000000ece2f4 swift::TypeChecker::typeCheckCondition(swift::Expr*&, swift::DeclContext*) + 180
17 swift           0x0000000000f4b744 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
18 swift           0x0000000000f78aec swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
19 swift           0x0000000000ec9506 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 1126
22 swift           0x0000000000f4a986 swift::TypeChecker::typeCheckConstructorBodyUntil(swift::ConstructorDecl*, swift::SourceLoc) + 854
23 swift           0x0000000000f4a382 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 34
24 swift           0x0000000000f4af63 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
26 swift           0x0000000000f045c1 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
27 swift           0x0000000000c86e69 swift::CompilerInstance::performSema() + 3289
29 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
30 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28421-swift-constraints-constraintsystem-diagnosefailureforexpr.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28421-swift-constraints-constraintsystem-diagnosefailureforexpr-aed2bd.o
1.  While type-checking 'init' at validation-test/compiler_crashers/28421-swift-constraints-constraintsystem-diagnosefailureforexpr.swift:12:2
2.  While type-checking expression at [validation-test/compiler_crashers/28421-swift-constraints-constraintsystem-diagnosefailureforexpr.swift:12:12 - line:14:1] RangeText="{
3.  While type-checking expression at [validation-test/compiler_crashers/28421-swift-constraints-constraintsystem-diagnosefailureforexpr.swift:14:1 - line:14:1] RangeText="("
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
