### PR TITLE
[gardening] Remove unused code: UnwrappedGenericParams + isOptionSetDecl(...)

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3358,7 +3358,6 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
 
   ASTPrinter &Printer;
   const PrintOptions &Options;
-  Optional<std::vector<GenericParamList *>> UnwrappedGenericParams;
 
   /// Whether we are printing something in a function parameter position, and
   /// thus want to print @escaping if it escapes.

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -3066,16 +3066,6 @@ public:
     return false;
   }
 
-  bool isOptionSetDecl(NominalTypeDecl *D) {
-    auto optionSetType = dyn_cast<ProtocolDecl>(Ctx.getOptionSetDecl());
-    if (!optionSetType)
-      return false;
-
-    SmallVector<ProtocolConformance *, 1> conformances;
-    return D->lookupConformance(CurrDeclContext->getParentModule(),
-                                optionSetType, conformances);
-  }
-
   void getTupleExprCompletions(TupleType *ExprType) {
     unsigned Index = 0;
     for (auto TupleElt : ExprType->getElements()) {


### PR DESCRIPTION
Remove unused code:
- `UnwrappedGenericParams` (last usage removed in ca0b548 by @slavapestov)
- `isOptionSetDecl(...)` (last usage removed in 31f583f by your truly)
