### PR TITLE
[gardening] Replace "a NSFoo" with "an NSFoo".

### DIFF
--- a/benchmark/single-source/NSDictionaryCastToSwift.swift
+++ b/benchmark/single-source/NSDictionaryCastToSwift.swift
@@ -14,7 +14,7 @@
 // rdar://problem/18539730
 //
 // Description:
-//     Create a NSDictionary instance and cast it to [String: NSObject].
+//     Create an NSDictionary instance and cast it to [String: NSObject].
 import Foundation
 import TestsUtils
 

--- a/docs/proposals/TypeState.rst
+++ b/docs/proposals/TypeState.rst
@@ -127,7 +127,7 @@ dimensions without having to manually manage a matrix of states.  This seems
 particularly useful in cases where you have inheritance.  A base class may
 define its own set of states.  A derived class will have those states, plus
 additional dimensions if they wanted.  For example, an NSView could be visible
-or not, while a NSButton derived class could be Normal or Pressed Down, etc.
+or not, while an NSButton derived class could be Normal or Pressed Down, etc.
 
 Generics: "mechanisms like type parameterization need to be duplicated for
 typestate, so that we can talk not only about a list of files, but also about a

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -774,7 +774,7 @@ extension NSData : _HasCustomAnyHashableRepresentation {
     }
 }
 
-/// A NSData subclass that uses Swift reference counting.
+/// An NSData subclass that uses Swift reference counting.
 ///
 /// This subclass implements the API of NSData by holding an instance and forwarding all implementation to that object.
 /// Since it uses Swift reference counting, we can do correct uniqueness checks even if we pass this instance back to Objective-C. In Objective-C, it looks like an instance of NSData.


### PR DESCRIPTION
Replace `a NSFoo` with `an NSFoo`.
