### PR TITLE
[python] Enable PEP-8 checking of fake-toolchain/clang++

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,2 +1,2 @@
 [flake8]
-filename = *.py,80+-check,backtrace-check,Benchmark_Driver,Benchmark_DTrace.in,Benchmark_GuardMalloc.in,Benchmark_RuntimeLeaksRunner.in,build-script,check-incremental,coverage-build-db,coverage-generate-data,coverage-touch-tests,gyb,ld,line-directive,mock-distcc,ns-html2rst,PathSanitizingFileCheck,recursive-lipo,rth,run-test,submit-benchmark-results,update-checkout,viewcfg
+filename = *.py,80+-check,backtrace-check,Benchmark_Driver,Benchmark_DTrace.in,Benchmark_GuardMalloc.in,Benchmark_RuntimeLeaksRunner.in,build-script,check-incremental,clang++,coverage-build-db,coverage-generate-data,coverage-touch-tests,gyb,ld,line-directive,mock-distcc,ns-html2rst,PathSanitizingFileCheck,recursive-lipo,rth,run-test,submit-benchmark-results,update-checkout,viewcfg


### PR DESCRIPTION
Enable PEP-8 checking of `fake-toolchain/clang++`.
