### PR TITLE
[Parse] update a misleading test

### DIFF
--- a/test/Parse/identifiers.swift
+++ b/test/Parse/identifiers.swift
@@ -17,7 +17,7 @@ class 你好 {
 你好.שלום.வணக்கம்.Γειά.привет()
 
 // Identifiers cannot start with combining chars.
-_ = .́duh() // expected-error {{use of unresolved operator '.́'}} // expected-error{{use of unresolved identifier 'duh'}}
+_ = ́duh() // expected-error {{an identifier cannot begin with this character}}
 
 // Combining characters can be used within identifiers.
 func s̈pin̈al_tap̈() {}


### PR DESCRIPTION
@lattner @jckarter

In 0bfacde2, the parsing was changed so that this expression became a valid prefix operator `.́` preceding an identifier. The test was intended to check that identifiers can't start with combining chars, so this diff removes the `.` and leaves only the combining `´` preceding the letters. Before it is whitespace.

(Note: some browsers don't display this properly — you can copy/paste the line into the Character Palette to see the order in which the characters appear in the source.)
