### PR TITLE
[SourceKit] Add test case for crash triggered in swift::GenericEnvironment::GenericEnvironment(…)

### DIFF
--- a/validation-test/IDE/crashers/092-swift-genericenvironment-genericenvironment.swift
+++ b/validation-test/IDE/crashers/092-swift-genericenvironment-genericenvironment.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+let a{enum S<T>{case={func a<T>{T:#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 160
swift-ide-test: /path/to/swift/lib/AST/GenericEnvironment.cpp:40: swift::GenericEnvironment::GenericEnvironment(TypeSubstitutionMap): Assertion `result.second && "duplicate generic parameters in environment"' failed.
8  swift-ide-test  0x0000000000c4d578 swift::GenericEnvironment::GenericEnvironment(llvm::DenseMap<swift::TypeBase*, swift::Type, llvm::DenseMapInfo<swift::TypeBase*>, llvm::detail::DenseMapPair<swift::TypeBase*, swift::Type> >) + 728
9  swift-ide-test  0x0000000000b6eea9 swift::GenericEnvironment::get(swift::ASTContext&, llvm::DenseMap<swift::TypeBase*, swift::Type, llvm::DenseMapInfo<swift::TypeBase*>, llvm::detail::DenseMapPair<swift::TypeBase*, swift::Type> >) + 57
10 swift-ide-test  0x0000000000b57c16 swift::ArchetypeBuilder::getGenericEnvironment(llvm::ArrayRef<swift::GenericTypeParamType*>) + 326
11 swift-ide-test  0x00000000009cfdf6 swift::TypeChecker::finalizeGenericParamList(swift::ArchetypeBuilder&, swift::GenericParamList*, swift::GenericSignature*, swift::DeclContext*) + 150
14 swift-ide-test  0x000000000098d101 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 945
17 swift-ide-test  0x0000000000c50ac0 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 256
22 swift-ide-test  0x0000000000bcce84 swift::Decl::walk(swift::ASTWalker&) + 20
23 swift-ide-test  0x0000000000c65a5e swift::SourceFile::walk(swift::ASTWalker&) + 174
24 swift-ide-test  0x0000000000c64b7f swift::ModuleDecl::walk(swift::ASTWalker&) + 79
25 swift-ide-test  0x0000000000c3b90b swift::DeclContext::walkContext(swift::ASTWalker&) + 187
26 swift-ide-test  0x00000000008f29c8 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 136
27 swift-ide-test  0x00000000007abd9d swift::CompilerInstance::performSema() + 3597
28 swift-ide-test  0x000000000074d981 main + 36401
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl getter for a at <INPUT-FILE>:3:6
2.  While type-checking 'a' at <INPUT-FILE>:3:23
```
