### PR TITLE
[swiftc (72 vs. 5162)] Add crasher in swift::GenericFunctionType::get(…)

### DIFF
--- a/validation-test/compiler_crashers/28422-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers/28422-swift-genericfunctiontype-get.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+func d<T{
+var d
+var d:[T
+struct S{var _=d.j


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericFunctionType::get(...)`.

Current number of unresolved compiler crashers: 72 (5162 resolved)

Assertion failure in [`lib/AST/ASTContext.cpp (line 3138)`](https://github.com/apple/swift/blob/master/lib/AST/ASTContext.cpp#L3138):

```
Assertion `!input->hasTypeVariable() && !output->hasTypeVariable()' failed.

When executing: static swift::GenericFunctionType *swift::GenericFunctionType::get(swift::GenericSignature *, swift::Type, swift::Type, const swift::AnyFunctionType::ExtInfo &)
```

Assertion context:

```
GenericFunctionType::get(GenericSignature *sig,
                         Type input,
                         Type output,
                         const ExtInfo &info) {
  assert(sig && "no generic signature for generic function type?!");
  assert(!input->hasTypeVariable() && !output->hasTypeVariable());

  llvm::FoldingSetNodeID id;
  GenericFunctionType::Profile(id, sig, input, output, info);

  const ASTContext &ctx = input->getASTContext();
```

Stack trace:

```
swift: /path/to/swift/lib/AST/ASTContext.cpp:3138: static swift::GenericFunctionType *swift::GenericFunctionType::get(swift::GenericSignature *, swift::Type, swift::Type, const swift::AnyFunctionType::ExtInfo &): Assertion `!input->hasTypeVariable() && !output->hasTypeVariable()' failed.
8  swift           0x0000000001040ffb swift::GenericFunctionType::get(swift::GenericSignature*, swift::Type, swift::Type, swift::AnyFunctionType::ExtInfo const&) + 603
9  swift           0x000000000116c7a9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 5129
10 swift           0x0000000001164329 swift::Type::subst(swift::ModuleDecl*, llvm::DenseMap<swift::TypeBase*, swift::Type, llvm::DenseMapInfo<swift::TypeBase*>, llvm::detail::DenseMapPair<swift::TypeBase*, swift::Type> > const&, swift::OptionSet<swift::SubstFlags, unsigned int>) const + 89
15 swift           0x0000000000f1f63b swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::Type, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) + 267
17 swift           0x0000000000f96303 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 2899
18 swift           0x0000000000f9c09e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4078
19 swift           0x0000000000ec5d77 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 471
20 swift           0x0000000000ec9455 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 949
21 swift           0x0000000000ecd7e0 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 352
22 swift           0x0000000000ecd9d5 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 229
27 swift           0x0000000000edfc26 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
30 swift           0x0000000000f4a52a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
31 swift           0x0000000000f4a38e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
32 swift           0x0000000000f4af63 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
34 swift           0x0000000000f045c1 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
35 swift           0x0000000000c86e69 swift::CompilerInstance::performSema() + 3289
37 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
38 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28422-swift-genericfunctiontype-get.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28422-swift-genericfunctiontype-get-8820f1.o
1.  While type-checking 'd' at validation-test/compiler_crashers/28422-swift-genericfunctiontype-get.swift:10:1
2.  While type-checking 'S' at validation-test/compiler_crashers/28422-swift-genericfunctiontype-get.swift:13:1
3.  While type-checking expression at [validation-test/compiler_crashers/28422-swift-genericfunctiontype-get.swift:13:16 - line:13:18] RangeText="d.j"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
