### PR TITLE
[gardening] Fix typo: "doesnt" → "doesn't"

### DIFF
--- a/test/NameBinding/name_lookup.swift
+++ b/test/NameBinding/name_lookup.swift
@@ -518,7 +518,7 @@ class r16954496 {
 
 
 
-// <rdar://problem/27413116> [Swift] Using static constant defined in enum when in switch statement doesnt compile
+// <rdar://problem/27413116> [Swift] Using static constant defined in enum when in switch statement doesn't compile
 enum MyEnum {
   case one
   case two


### PR DESCRIPTION
Fix typo.
