### PR TITLE
Dictionary test: fix intermittent failures

### DIFF
--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -3853,8 +3853,8 @@ DictionaryTestSuite.test("misc") {
     expectEqual(3, d.values[d.keys.index(of: "three")!])
     expectEqual(4, d.values[d.keys.index(of: "four")!])
 
-    expectEqual(3, d3.values[d.keys.index(of: "three")!])
-    expectEqual(4, d3.values[d.keys.index(of: "four")!])
+    expectEqual(3, d3.values[d3.keys.index(of: "three")!])
+    expectEqual(4, d3.values[d3.keys.index(of: "four")!])
   }
 }
 


### PR DESCRIPTION
The test was using an index from one dictionary with a different dictionary instance.
