### PR TITLE
[test] Remove extra -serialize-diagnostics

### DIFF
--- a/test/Misc/serialized-diagnostics.swift
+++ b/test/Misc/serialized-diagnostics.swift
@@ -6,7 +6,7 @@
 // RUN: %FileCheck --input-file=%t.deserialized_diagnostics.txt %s
 
 // Test swift_driver integrated frontend
-// RUN: %target-swift-frontend -parse -serialize-diagnostics -serialize-diagnostics-path %t.integrated_frontend.dia %s -verify
+// RUN: %target-swift-frontend -parse -serialize-diagnostics-path %t.integrated_frontend.dia %s -verify
 // RUN: c-index-test -read-diagnostics %t.integrated_frontend.dia > %t.integrated_frontend.deserialized_diagnostics.txt 2>&1
 // RUN: %FileCheck --input-file=%t.integrated_frontend.deserialized_diagnostics.txt %s
 

--- a/test/SourceKit/Indexing/index.swift
+++ b/test/SourceKit/Indexing/index.swift
@@ -1,4 +1,4 @@
-// RUN: %sourcekitd-test -req=index %s -- -serialize-diagnostics -serialize-diagnostics-path %t.dia %s | %sed_clean > %t.response
+// RUN: %sourcekitd-test -req=index %s -- -serialize-diagnostics-path %t.dia %s | %sed_clean > %t.response
 // RUN: diff -u %s.response %t.response
 
 var globV: Int

--- a/test/SourceKit/Indexing/index_enum_case.swift
+++ b/test/SourceKit/Indexing/index_enum_case.swift
@@ -1,4 +1,4 @@
-// RUN: %sourcekitd-test -req=index %s -- -serialize-diagnostics -serialize-diagnostics-path %t.dia %s | %sed_clean > %t.response
+// RUN: %sourcekitd-test -req=index %s -- -serialize-diagnostics-path %t.dia %s | %sed_clean > %t.response
 // RUN: diff -u %s.response %t.response
 
 public enum E {

--- a/test/SourceKit/Indexing/index_is_test_candidate.swift
+++ b/test/SourceKit/Indexing/index_is_test_candidate.swift
@@ -1,4 +1,4 @@
-// RUN: %sourcekitd-test -req=index %s -- -serialize-diagnostics -serialize-diagnostics-path %t.dia %s | %sed_clean > %t.response
+// RUN: %sourcekitd-test -req=index %s -- -serialize-diagnostics-path %t.dia %s | %sed_clean > %t.response
 // RUN: diff -u %s.response %t.response
 
 // This test verifies that, when Objective-C interop is disabled, private

--- a/test/SourceKit/Indexing/index_is_test_candidate_objc.swift
+++ b/test/SourceKit/Indexing/index_is_test_candidate_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %sourcekitd-test -req=index %s -- -serialize-diagnostics -serialize-diagnostics-path %t.dia %s | %sed_clean > %t.response
+// RUN: %sourcekitd-test -req=index %s -- -serialize-diagnostics-path %t.dia %s | %sed_clean > %t.response
 // RUN: diff -u %s.response %t.response
 
 // This test verifies that, when Objective-C interop is enabled, all "test

--- a/test/SourceKit/Indexing/rdar_21602898.swift
+++ b/test/SourceKit/Indexing/rdar_21602898.swift
@@ -1,4 +1,4 @@
-// RUN: %sourcekitd-test -req=index %s -- -serialize-diagnostics -serialize-diagnostics-path %t.dia %s | %sed_clean > %t.response
+// RUN: %sourcekitd-test -req=index %s -- -serialize-diagnostics-path %t.dia %s | %sed_clean > %t.response
 // RUN: diff -u %s.response %t.response
 
 protocol P {}


### PR DESCRIPTION
<!-- What's in this pull request? -->

The `-serialize-diagnostics-path` option implies `-serialize-diagnostics`; there's no point in specifying both. Remove the extra flags from the tests.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
