### PR TITLE
[gardening] Remove redundant nil-initialization of optional variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3663,7 +3663,7 @@ Swift 1.0
   accepts inouts or `nil`:
 
     ```swift
-    var error: NSError? = nil
+    var error: NSError?
     let words = NSString.stringWithContentsOfFile("/usr/share/dict/words",
       encoding: .UTF8StringEncoding,
       error: &error)

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -96,7 +96,7 @@ struct TestConfig {
 
   /// After we run the tests, should the harness sleep to allow for utilities
   /// like leaks that require a PID to run on the test harness.
-  var afterRunSleep: Int? = nil
+  var afterRunSleep: Int?
 
   /// The list of tests to run.
   var tests = [Test]()

--- a/docs/SequencesAndCollections.rst
+++ b/docs/SequencesAndCollections.rst
@@ -142,7 +142,7 @@ implement a generic `for`\ …\ `in` loop.
         latest = _baseIterator.next() ?? latest
         return latest 
       }
-      public private(set) var latest: I.Element? = nil
+      public private(set) var latest: I.Element?
       private var _baseIterator: I
     }
 

--- a/docs/proposals/CPointerInteropLanguageModel.rst
+++ b/docs/proposals/CPointerInteropLanguageModel.rst
@@ -116,7 +116,7 @@ So if you have a function declared::
 
 You can call it as any of::
 
-  var x: NSBas? = nil
+  var x: NSBas?
   var p: AutoreleasingUnsafeMutablePointer<NSBas?> = nil
   bas(nil)
   bas(p)

--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
@@ -1937,8 +1937,8 @@ self.test("\(testNamePrefix)._preprocessingPass/semantics") {
   for test in forEachTests {
     let s = makeWrappedSequence(test.sequence.map(OpaqueValue.init))
     var wasInvoked = false
-    var caughtError: Error? = nil
-    var result: OpaqueValue<Int>? = nil
+    var caughtError: Error?
+    var result: OpaqueValue<Int>?
     do {
       result = try s._preprocessingPass {
         (sequence) -> OpaqueValue<Int> in

--- a/stdlib/private/StdlibUnicodeUnittest/Collation.swift
+++ b/stdlib/private/StdlibUnicodeUnittest/Collation.swift
@@ -247,7 +247,7 @@ public struct StringComparisonTest {
   public let collationElements: [UInt64]
   public let loc: SourceLoc
 
-  public var order: Int? = nil
+  public var order: Int?
 
   public init(
     _ string: String,

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -681,7 +681,7 @@ func _childProcess() {
 }
 
 struct _ParentProcess {
-  internal var _pid: pid_t? = nil
+  internal var _pid: pid_t?
   internal var _childStdin: _FDOutputStream = _FDOutputStream(fd: -1)
   internal var _childStdout: _FDInputStream = _FDInputStream(fd: -1)
   internal var _childStderr: _FDInputStream = _FDInputStream(fd: -1)
@@ -849,7 +849,7 @@ struct _ParentProcess {
 
     // Check if the child has sent us "end" markers for the current test.
     if stdoutEnd && stderrEnd {
-      var status: ProcessTerminationStatus? = nil
+      var status: ProcessTerminationStatus?
       if !testSuite._testByName(testName).canReuseChildProcessAfterTest {
         status = _waitForChild()
         switch status! {
@@ -937,7 +937,7 @@ struct _ParentProcess {
     print("[ RUN      ] \(fullTestName)\(activeXFailsText)")
 
     var expectCrash = false
-    var childTerminationStatus: ProcessTerminationStatus? = nil
+    var childTerminationStatus: ProcessTerminationStatus?
     var crashStdout: [String] = []
     var crashStderr: [String] = []
     if _runTestsInProcess {
@@ -1145,7 +1145,7 @@ public func runAllTests() {
     _childProcess()
   } else {
     var runTestsInProcess: Bool = false
-    var filter: String? = nil
+    var filter: String?
     var args = [String]()
     var i = 0
     i += 1 // Skip the name of the executable.
@@ -1331,10 +1331,10 @@ public final class TestSuite {
     internal final class _Data {
       var _xfail: [TestRunPredicate] = []
       var _skip: [TestRunPredicate] = []
-      var _stdinText: String? = nil
+      var _stdinText: String?
       var _stdinEndsWithEOF: Bool = false
       var _crashOutputMatches: [String] = []
-      var _testLoc: SourceLoc? = nil
+      var _testLoc: SourceLoc?
     }
 
     init(testSuite: TestSuite, name: String, loc: SourceLoc) {
@@ -1507,7 +1507,7 @@ func _getOSVersion() -> OSVersion {
 }
 
 var _runningOSVersion: OSVersion = _getOSVersion()
-var _overrideOSVersion: OSVersion? = nil
+var _overrideOSVersion: OSVersion?
 
 /// Override the OS version for testing.
 public func _setOverrideOSVersion(_ v: OSVersion) {

--- a/stdlib/private/StdlibUnittestFoundationExtras/StdlibUnittestFoundationExtras.swift
+++ b/stdlib/private/StdlibUnittestFoundationExtras/StdlibUnittestFoundationExtras.swift
@@ -13,7 +13,7 @@
 import ObjectiveC
 import Foundation
 
-internal var _temporaryLocaleCurrentLocale: NSLocale? = nil
+internal var _temporaryLocaleCurrentLocale: NSLocale?
 
 extension NSLocale {
   @objc

--- a/stdlib/private/SwiftPrivatePthreadExtras/PthreadBarriers.swift
+++ b/stdlib/private/SwiftPrivatePthreadExtras/PthreadBarriers.swift
@@ -43,8 +43,8 @@ public var _stdlib_PTHREAD_BARRIER_SERIAL_THREAD: CInt {
 }
 
 public struct _stdlib_pthread_barrier_t {
-  var mutex: UnsafeMutablePointer<pthread_mutex_t>? = nil
-  var cond: UnsafeMutablePointer<pthread_cond_t>? = nil
+  var mutex: UnsafeMutablePointer<pthread_mutex_t>?
+  var cond: UnsafeMutablePointer<pthread_cond_t>?
 
   /// The number of threads to synchronize.
   var count: CUnsignedInt = 0

--- a/stdlib/private/SwiftPrivatePthreadExtras/SwiftPrivatePthreadExtras.swift
+++ b/stdlib/private/SwiftPrivatePthreadExtras/SwiftPrivatePthreadExtras.swift
@@ -95,7 +95,7 @@ public func _stdlib_pthread_join<Result>(
   _ thread: pthread_t,
   _ resultType: Result.Type
 ) -> (CInt, Result?) {
-  var threadResultRawPtr: UnsafeMutableRawPointer? = nil
+  var threadResultRawPtr: UnsafeMutableRawPointer?
   let result = pthread_join(thread, &threadResultRawPtr)
   if result == 0 {
     let threadResultPtr = threadResultRawPtr!.assumingMemoryBound(

--- a/stdlib/public/SDK/CryptoTokenKit/CryptoTokenKit.swift
+++ b/stdlib/public/SDK/CryptoTokenKit/CryptoTokenKit.swift
@@ -35,7 +35,7 @@ extension TKSmartCard {
 
   @available(OSX 10.12, *)
   public func withSession<T>(_ body: @escaping () throws -> T) throws -> T {
-    var result: T? = nil
+    var result: T?
     try self.__inSession(executeBlock: {
       (errorPointer: NSErrorPointer) -> Bool in
       do {

--- a/stdlib/public/SDK/Dispatch/Data.swift
+++ b/stdlib/public/SDK/Dispatch/Data.swift
@@ -72,7 +72,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	public func withUnsafeBytes<Result, ContentType>(
 		body: (UnsafePointer<ContentType>) throws -> Result) rethrows -> Result
 	{
-		var ptr: UnsafeRawPointer? = nil
+		var ptr: UnsafeRawPointer?
 		var size = 0
 		let data = __dispatch_data_create_map(__wrapped, &ptr, &size)
         let contentPtr = ptr!.bindMemory(
@@ -183,7 +183,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 		var offset = 0
 		let subdata = __dispatch_data_copy_region(__wrapped, index, &offset)
 
-		var ptr: UnsafeRawPointer? = nil
+		var ptr: UnsafeRawPointer?
 		var size = 0
 		let map = __dispatch_data_create_map(subdata, &ptr, &size)
 		defer { _fixLifetime(map) }
@@ -280,7 +280,7 @@ extension DispatchData {
 	}
 
 	public static func _unconditionallyBridgeFromObjectiveC(_ source: __DispatchData?) -> DispatchData {
-		var result: DispatchData? = nil
+		var result: DispatchData?
 		_forceBridgeFromObjectiveC(source!, result: &result)
 		return result!
 	}

--- a/stdlib/public/SDK/Dispatch/Queue.swift
+++ b/stdlib/public/SDK/Dispatch/Queue.swift
@@ -34,7 +34,7 @@ public extension DispatchQueue {
 		public static let initiallyInactive = Attributes(rawValue: 1<<2)
 
 		fileprivate func _attr() -> __OS_dispatch_queue_attr? {
-			var attr: __OS_dispatch_queue_attr? = nil
+			var attr: __OS_dispatch_queue_attr?
 
 			if self.contains(.concurrent) {
 				attr = _swift_dispatch_queue_concurrent()

--- a/stdlib/public/SDK/Foundation/Calendar.swift
+++ b/stdlib/public/SDK/Foundation/Calendar.swift
@@ -410,7 +410,7 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
     /// - parameter date: The specified date.
     /// - returns: `true` if the starting time and duration of a component could be calculated, otherwise `false`.
     public func dateInterval(of component: Component, start: inout Date, interval: inout TimeInterval, for date: Date) -> Bool {
-        var nsDate : NSDate? = nil
+        var nsDate : NSDate?
         var ti : TimeInterval = 0
         if _handle.map({ $0.range(of: Calendar._toCalendarUnit([component]), start: &nsDate, interval: &ti, for: date) }) {
             start = nsDate as! Date
@@ -688,7 +688,7 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
     /// - returns: `true` if a date range could be found, and `false` if the date is not in a weekend.
     @available(iOS 8.0, *)
     public func dateIntervalOfWeekend(containing date: Date, start: inout Date, interval: inout TimeInterval) -> Bool {
-        var nsDate : NSDate? = nil
+        var nsDate : NSDate?
         var ti : TimeInterval = 0
         if _handle.map({ $0.range(ofWeekendStart: &nsDate, interval: &ti, containing: date) }) {
             start = nsDate as! Date
@@ -705,7 +705,7 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
     /// - returns: A `DateInterval`, or nil if the date is not in a weekend.
     @available(OSX 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
     public func dateIntervalOfWeekend(containing date: Date) -> DateInterval? {
-        var nsDate : NSDate? = nil
+        var nsDate : NSDate?
         var ti : TimeInterval = 0
         if _handle.map({ $0.range(ofWeekendStart: &nsDate, interval: &ti, containing: date) }) {
             return DateInterval(start: nsDate as! Date, duration: ti)
@@ -729,7 +729,7 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
     @available(iOS 8.0, *)
     public func nextWeekend(startingAfter date: Date, start: inout Date, interval: inout TimeInterval, direction: SearchDirection = .forward) -> Bool {
         // The implementation actually overrides previousKeepSmaller and nextKeepSmaller with matchNext, always - but strict still trumps all.
-        var nsDate : NSDate? = nil
+        var nsDate : NSDate?
         var ti : TimeInterval = 0
         if _handle.map({ $0.nextWeekendStart(&nsDate, interval: &ti, options: direction == .backward ? [.searchBackwards] : [], after: date) }) {
             start = nsDate as! Date
@@ -751,7 +751,7 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
     @available(OSX 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
     public func nextWeekend(startingAfter date: Date, direction: SearchDirection = .forward) -> DateInterval? {
         // The implementation actually overrides previousKeepSmaller and nextKeepSmaller with matchNext, always - but strict still trumps all.
-        var nsDate : NSDate? = nil
+        var nsDate : NSDate?
         var ti : TimeInterval = 0
         if _handle.map({ $0.nextWeekendStart(&nsDate, interval: &ti, options: direction == .backward ? [.searchBackwards] : [], after: date) }) {
             /// WARNING: searching backwards is totally broken! 26643365
@@ -1122,7 +1122,7 @@ extension Calendar : _ObjectiveCBridgeable {
     }
     
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSCalendar?) -> Calendar {
-        var result: Calendar? = nil
+        var result: Calendar?
         _forceBridgeFromObjectiveC(source!, result: &result)
         return result!
     }

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -760,7 +760,7 @@ extension Data : _ObjectiveCBridgeable {
     }
     
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSData?) -> Data {
-        var result: Data? = nil
+        var result: Data?
         _forceBridgeFromObjectiveC(source!, result: &result)
         return result!
     }

--- a/stdlib/public/SDK/Foundation/Date.swift
+++ b/stdlib/public/SDK/Foundation/Date.swift
@@ -256,7 +256,7 @@ extension Date : _ObjectiveCBridgeable {
     }
 
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSDate?) -> Date {
-        var result: Date? = nil
+        var result: Date?
         _forceBridgeFromObjectiveC(source!, result: &result)
         return result!
     }

--- a/stdlib/public/SDK/Foundation/DateComponents.swift
+++ b/stdlib/public/SDK/Foundation/DateComponents.swift
@@ -339,7 +339,7 @@ extension DateComponents : _ObjectiveCBridgeable {
     }
 
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSDateComponents?) -> DateComponents {
-        var result: DateComponents? = nil
+        var result: DateComponents?
         _forceBridgeFromObjectiveC(source!, result: &result)
         return result!
     }

--- a/stdlib/public/SDK/Foundation/DateInterval.swift
+++ b/stdlib/public/SDK/Foundation/DateInterval.swift
@@ -214,7 +214,7 @@ extension DateInterval : _ObjectiveCBridgeable {
     }
 
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSDateInterval?) -> DateInterval {
-        var result: DateInterval? = nil
+        var result: DateInterval?
         _forceBridgeFromObjectiveC(source!, result: &result)
         return result!
     }

--- a/stdlib/public/SDK/Foundation/Decimal.swift
+++ b/stdlib/public/SDK/Foundation/Decimal.swift
@@ -454,7 +454,7 @@ extension Decimal : _ObjectiveCBridgeable {
     }
 
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSDecimalNumber?) -> Decimal {
-        var result: Decimal? = nil
+        var result: Decimal?
         _forceBridgeFromObjectiveC(source!, result: &result)
         return result!
     }

--- a/stdlib/public/SDK/Foundation/FileManager.swift
+++ b/stdlib/public/SDK/Foundation/FileManager.swift
@@ -30,7 +30,7 @@ extension FileManager {
     
     @available(*, deprecated, renamed:"replaceItemAt(_:withItemAt:backupItemName:options:)")
     public func replaceItemAtURL(originalItemURL: NSURL, withItemAtURL newItemURL: NSURL, backupItemName: String? = nil, options: FileManager.ItemReplacementOptions = []) throws -> NSURL? {
-        var error: NSError? = nil
+        var error: NSError?
         if let result = NS_Swift_NSFileManager_replaceItemAtURL_withItemAtURL_backupItemName_options(self, originalItemURL, newItemURL, backupItemName, options, &error) {
             return result
         }
@@ -39,7 +39,7 @@ extension FileManager {
 
     @available(OSX 10.6, iOS 4.0, *)
     public func replaceItemAt(_ originalItemURL: URL, withItemAt newItemURL: URL, backupItemName: String? = nil, options: FileManager.ItemReplacementOptions = []) throws -> NSURL? {
-        var error: NSError? = nil
+        var error: NSError?
         if let result = NS_Swift_NSFileManager_replaceItemAtURL_withItemAtURL_backupItemName_options(self, originalItemURL as NSURL, newItemURL as NSURL, backupItemName, options, &error) {
             return result
         }

--- a/stdlib/public/SDK/Foundation/Foundation.swift
+++ b/stdlib/public/SDK/Foundation/Foundation.swift
@@ -1416,7 +1416,7 @@ extension NSCoder {
 
   @nonobjc
   public func decodeObject(of classes: [AnyClass]?, forKey key: String) -> Any? {
-    var classesAsNSObjects: NSSet? = nil
+    var classesAsNSObjects: NSSet?
     if let theClasses = classes {
       classesAsNSObjects = NSSet(array: theClasses.map { $0 as AnyObject })
     }
@@ -1474,8 +1474,8 @@ extension NSCoder {
   @nonobjc
   @available(OSX 10.11, iOS 9.0, *)
   public func decodeTopLevelObject(of classes: [AnyClass]?, forKey key: String) throws -> Any? {
-    var error: NSError? = nil
-    var classesAsNSObjects: NSSet? = nil
+    var error: NSError?
+    var classesAsNSObjects: NSSet?
     if let theClasses = classes {
       classesAsNSObjects = NSSet(array: theClasses.map { $0 as AnyObject })
     }

--- a/stdlib/public/SDK/Foundation/IndexSet.swift
+++ b/stdlib/public/SDK/Foundation/IndexSet.swift
@@ -683,7 +683,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     public func filteredIndexSet(in range : Range<Element>, includeInteger: (Element) throws -> Bool) rethrows -> IndexSet {
         let r : NSRange = _toNSRange(range)
         return try _handle.map {
-            var error : Error? = nil
+            var error : Error?
             let result = $0.indexes(in: r, options: [], passingTest: { (i, stop) -> Bool in
                 do {
                     let include = try includeInteger(i)

--- a/stdlib/public/SDK/Foundation/Locale.swift
+++ b/stdlib/public/SDK/Foundation/Locale.swift
@@ -476,7 +476,7 @@ extension Locale : _ObjectiveCBridgeable {
     }
     
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSLocale?) -> Locale {
-        var result: Locale? = nil
+        var result: Locale?
         _forceBridgeFromObjectiveC(source!, result: &result)
         return result!
     }

--- a/stdlib/public/SDK/Foundation/Notification.swift
+++ b/stdlib/public/SDK/Foundation/Notification.swift
@@ -121,7 +121,7 @@ extension Notification : _ObjectiveCBridgeable {
     }
 
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNotification?) -> Notification {
-        var result: Notification? = nil
+        var result: Notification?
         _forceBridgeFromObjectiveC(source!, result: &result)
         return result!
     }

--- a/stdlib/public/SDK/Foundation/PersonNameComponents.swift
+++ b/stdlib/public/SDK/Foundation/PersonNameComponents.swift
@@ -130,7 +130,7 @@ extension PersonNameComponents : _ObjectiveCBridgeable {
     }
 
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSPersonNameComponents?) -> PersonNameComponents {
-        var result: PersonNameComponents? = nil
+        var result: PersonNameComponents?
         _forceBridgeFromObjectiveC(source!, result: &result)
         return result!
     }

--- a/stdlib/public/SDK/Foundation/TimeZone.swift
+++ b/stdlib/public/SDK/Foundation/TimeZone.swift
@@ -270,7 +270,7 @@ extension TimeZone : _ObjectiveCBridgeable {
     }
     
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSTimeZone?) -> TimeZone {
-        var result: TimeZone? = nil
+        var result: TimeZone?
         _forceBridgeFromObjectiveC(source!, result: &result)
         return result!
     }

--- a/stdlib/public/SDK/Foundation/URL.swift
+++ b/stdlib/public/SDK/Foundation/URL.swift
@@ -965,7 +965,7 @@ public struct URL : ReferenceConvertible, Equatable {
     ///
     /// This method synchronously checks if the resource's backing store is reachable. Checking reachability is appropriate when making decisions that do not require other immediate operations on the resource, e.g. periodic maintenance of UI state that depends on the existence of a specific document. When performing operations such as opening a file or copying resource properties, it is more efficient to simply try the operation and handle failures. This method is currently applicable only to URLs for file system resources. For other URL types, `false` is returned.
     public func checkResourceIsReachable() throws -> Bool {
-        var error : NSError? = nil
+        var error : NSError?
         let result = _url.checkResourceIsReachableAndReturnError(&error)
         if let e = error {
             throw e
@@ -979,7 +979,7 @@ public struct URL : ReferenceConvertible, Equatable {
     /// This method synchronously checks if the resource's backing store is reachable. Checking reachability is appropriate when making decisions that do not require other immediate operations on the resource, e.g. periodic maintenance of UI state that depends on the existence of a specific document. When performing operations such as opening a file or copying resource properties, it is more efficient to simply try the operation and handle failures. This method is currently applicable only to URLs for file system resources. For other URL types, `false` is returned.
     @available(OSX 10.10, iOS 8.0, *)
     public func checkPromisedItemIsReachable() throws -> Bool {
-        var error : NSError? = nil
+        var error : NSError?
         let result = _url.checkPromisedItemIsReachableAndReturnError(&error)
         if let e = error {
             throw e
@@ -1151,7 +1151,7 @@ extension URL : _ObjectiveCBridgeable {
     }
 
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSURL?) -> URL {
-        var result: URL? = nil
+        var result: URL?
         _forceBridgeFromObjectiveC(source!, result: &result)
         return result!
     }

--- a/stdlib/public/SDK/Foundation/URLComponents.swift
+++ b/stdlib/public/SDK/Foundation/URLComponents.swift
@@ -364,7 +364,7 @@ extension URLComponents : _ObjectiveCBridgeable {
     }
 
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSURLComponents?) -> URLComponents {
-        var result: URLComponents? = nil
+        var result: URLComponents?
         _forceBridgeFromObjectiveC(source!, result: &result)
         return result!
     }
@@ -457,7 +457,7 @@ extension URLQueryItem : _ObjectiveCBridgeable {
     }
 
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSURLQueryItem?) -> URLQueryItem {
-        var result: URLQueryItem? = nil
+        var result: URLQueryItem?
         _forceBridgeFromObjectiveC(source!, result: &result)
         return result!
     }

--- a/stdlib/public/SDK/Foundation/URLRequest.swift
+++ b/stdlib/public/SDK/Foundation/URLRequest.swift
@@ -290,7 +290,7 @@ extension URLRequest : _ObjectiveCBridgeable {
     }
     
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSURLRequest?) -> URLRequest {
-        var result: URLRequest? = nil
+        var result: URLRequest?
         _forceBridgeFromObjectiveC(source!, result: &result)
         return result!
     }

--- a/stdlib/public/SDK/Foundation/UUID.swift
+++ b/stdlib/public/SDK/Foundation/UUID.swift
@@ -134,7 +134,7 @@ extension UUID : _ObjectiveCBridgeable {
     }
 
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSUUID?) -> UUID {
-        var result: UUID? = nil
+        var result: UUID?
         _forceBridgeFromObjectiveC(source!, result: &result)
         return result!
     }

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -76,7 +76,7 @@ class _ContiguousArrayStorage1 : _ContiguousArrayStorageBase {
   final override func _withVerbatimBridgedUnsafeBuffer<R>(
     _ body: (UnsafeBufferPointer<AnyObject>) throws -> R
   ) rethrows -> R? {
-    var result: R? = nil
+    var result: R?
     try self._withVerbatimBridgedUnsafeBufferImpl {
       result = try body($0)
     }

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -3250,7 +3250,7 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
   // operations on it.
   //
   // Do not access this property directly.
-  internal var _heapBufferBridged_DoNotUse: AnyObject? = nil
+  internal var _heapBufferBridged_DoNotUse: AnyObject?
 
   internal var nativeStorage: NativeStorage
 

--- a/stdlib/public/core/InputStream.swift
+++ b/stdlib/public/core/InputStream.swift
@@ -27,7 +27,7 @@ import SwiftShims
 /// - Returns: The string of characters read from standard input. If EOF has
 ///   already been reached when `readLine()` is called, the result is `nil`.
 public func readLine(strippingNewline: Bool = true) -> String? {
-  var linePtrVar: UnsafeMutablePointer<UInt8>? = nil
+  var linePtrVar: UnsafeMutablePointer<UInt8>?
   var readBytes = swift_stdlib_readLine_stdin(&linePtrVar)
   if readBytes == -1 {
     return nil

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -1057,7 +1057,7 @@ extension Sequence {
   public func first(
     where predicate: (Iterator.Element) throws -> Bool
   ) rethrows -> Iterator.Element? {
-    var foundElement: Iterator.Element? = nil
+    var foundElement: Iterator.Element?
     do {
       try self.forEach {
         if try predicate($0) {

--- a/stdlib/public/core/SipHash.swift.gyb
+++ b/stdlib/public/core/SipHash.swift.gyb
@@ -97,7 +97,7 @@ struct ${Self} {
   internal var dataTail: UInt64 = 0
   internal var dataTailByteCount: Int = 0
 
-  internal var finalizedHash: UInt64? = nil
+  internal var finalizedHash: UInt64?
 
   public init(key: (UInt64, UInt64)) {
     v3 ^= key.1

--- a/stdlib/public/core/SwiftNativeNSArray.swift
+++ b/stdlib/public/core/SwiftNativeNSArray.swift
@@ -131,7 +131,7 @@ extension _SwiftNativeNSArrayWithContiguousStorage : _NSArrayCore {
   // operations on it.
   //
   // Do not access this property directly.
-  internal var _heapBufferBridged_DoNotUse: AnyObject? = nil
+  internal var _heapBufferBridged_DoNotUse: AnyObject?
 
   // When this class is allocated inline, this property can become a
   // computed one.

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -377,7 +377,7 @@ final internal class _VaListBuilder {
   let requiredAlignmentInBytes = MemoryLayout<Double>.alignment
   var count = 0
   var allocated = 0
-  var storage: UnsafeMutablePointer<Int>? = nil
+  var storage: UnsafeMutablePointer<Int>?
 
   static var alignedStorageForEmptyVaLists: Double = 0
 }
@@ -391,8 +391,8 @@ final internal class _VaListBuilder {
   struct Header {
     var gp_offset = CUnsignedInt(0)
     var fp_offset = CUnsignedInt(_x86_64CountGPRegisters * MemoryLayout<Int>.stride)
-    var overflow_arg_area: UnsafeMutablePointer<Int>? = nil
-    var reg_save_area: UnsafeMutablePointer<Int>? = nil
+    var overflow_arg_area: UnsafeMutablePointer<Int>?
+    var reg_save_area: UnsafeMutablePointer<Int>?
   }
 
   init() {

--- a/test/ClangModules/CoreServices_test.swift
+++ b/test/ClangModules/CoreServices_test.swift
@@ -12,7 +12,7 @@ func test(_ url: CFURL, ident: CSIdentity) {
 
   _ = kCollectionNoAttributes // expected-error{{use of unresolved identifier 'kCollectionNoAttributes'}}
 
-  var name: Unmanaged<CFString>? = nil
+  var name: Unmanaged<CFString>?
   _ = LSCopyDisplayNameForURL(url, &name) as OSStatus // okay
 
   let unicharArray: [UniChar] = [ 0x61, 0x62, 0x63, 0x2E, 0x64 ]

--- a/test/ClangModules/MixedSource/mixed-nsuinteger.swift
+++ b/test/ClangModules/MixedSource/mixed-nsuinteger.swift
@@ -9,8 +9,8 @@ import user
 
 var ui: UInt = 5
 var i: Int = 56
-var p: UnsafeMutablePointer<NSFastEnumerationState>? = nil
-var pp: AutoreleasingUnsafeMutablePointer<AnyObject?>? = nil
+var p: UnsafeMutablePointer<NSFastEnumerationState>?
+var pp: AutoreleasingUnsafeMutablePointer<AnyObject?>?
 
 var userTypedObj = NSUIntTest()
 
@@ -40,8 +40,8 @@ var rr: UInt = userTypedObj.countByEnumerating(with: p!, objects: pp!, count: ui
 // Check exercising protocol conformance.
 func gen<T:NSFastEnumeration>(_ t:T) {
   let i: Int = 56
-  let p: UnsafeMutablePointer<NSFastEnumerationState>? = nil
-  let pp: AutoreleasingUnsafeMutablePointer<AnyObject?>? = nil
+  let p: UnsafeMutablePointer<NSFastEnumerationState>?
+  let pp: AutoreleasingUnsafeMutablePointer<AnyObject?>?
   t.countByEnumerating(with: p!, objects: pp!, count: i)
 }
 

--- a/test/ClangModules/MixedSource/mixed-target-using-header.swift
+++ b/test/ClangModules/MixedSource/mixed-target-using-header.swift
@@ -59,12 +59,12 @@ func testFoundationOverlay() {
 }
 
 func testProtocolNamingConflict() {
-  let a: ConflictingName1? = nil
+  let a: ConflictingName1?
   var b: ConflictingName1Protocol?
   b = a // expected-error {{cannot assign value of type 'ConflictingName1?' to type 'ConflictingName1Protocol?'}}
   _ = b
 
-  let c: ConflictingName2? = nil
+  let c: ConflictingName2?
   var d: ConflictingName2Protocol?
   d = c // expected-error {{cannot assign value of type 'ConflictingName2?' to type 'ConflictingName2Protocol?'}}
   _ = d

--- a/test/ClangModules/Security_test.swift
+++ b/test/ClangModules/Security_test.swift
@@ -12,7 +12,7 @@ func testIntegration() {
   // Based on code in <rdar://problem/17162475>.
   let query = [kSecClass as NSString: kSecClassGenericPassword] as NSDictionary as CFDictionary
 
-  var dataTypeRef: Unmanaged<AnyObject>? = nil
+  var dataTypeRef: Unmanaged<AnyObject>?
   let status = SecItemCopyMatching(query, &dataTypeRef)
   
   if status == errSecSuccess {
@@ -24,7 +24,7 @@ func testIntegration() {
 }
 
 func testAuthorizationIsNotCF() {
-  var auth: AuthorizationRef? = nil
+  var auth: AuthorizationRef?
   _ = AuthorizationCreate(&auth)
   _ = AuthorizationFree(auth)
 }

--- a/test/ClangModules/cfuncs_parse.swift
+++ b/test/ClangModules/cfuncs_parse.swift
@@ -104,7 +104,7 @@ func test_pointer() {
   param_const_void_pointer(fa)
   // FIXME: param_const_void_pointer([1.0, 2.0, 3.0])
 
-  let op: OpaquePointer? = nil
+  let op: OpaquePointer?
   opaque_pointer_param(op)
 }
 

--- a/test/ClangModules/ctypes_parse_objc.swift
+++ b/test/ClangModules/ctypes_parse_objc.swift
@@ -29,7 +29,7 @@ func testArrays() {
 // FIXME: Import pointers to opaque types as unique types.
 
 func testPointers() {
-  let cfstr: CFString? = nil
+  let cfstr: CFString?
   _ = cfstr as CFTypeRef?
 }
 

--- a/test/ClangModules/submodules.swift
+++ b/test/ClangModules/submodules.swift
@@ -22,7 +22,7 @@ public var x : DWORD = MY_INT
 public var y : CInt = x
 
 let _: ctypes.DWORD = ctypes.MY_INT
-let _: ctypes.Color? = nil
+let _: ctypes.Color?
 
 // Error: "bits" should not be a valid name in this scope.
 #if !NO_ERRORS

--- a/test/Constraints/associated_types.swift
+++ b/test/Constraints/associated_types.swift
@@ -35,5 +35,5 @@ func owl3() {
 // "Can't access associated types through class-constrained generic parameters"
 // (https://bugs.swift.org/browse/SR-726)
 func spoon<S: Spoon>(_ s: S) {
-  let _: S.Runcee? = nil
+  let _: S.Runcee?
 }

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -62,7 +62,7 @@ struct BridgedStruct : Hashable, _ObjectiveCBridgeable {
 
   static func _unconditionallyBridgeFromObjectiveC(_ source: BridgedClass?)
       -> BridgedStruct {
-    var result: BridgedStruct? = nil
+    var result: BridgedStruct?
     _forceBridgeFromObjectiveC(source!, result: &result)
     return result!
   }

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -238,7 +238,7 @@ func ident<T>(_ t: T) -> T {}
 var c = ident({1.DOESNT_EXIST}) // error: expected-error {{value of type 'Int' has no member 'DOESNT_EXIST'}}
 
 // <rdar://problem/20712541> QoI: Int/UInt mismatch produces useless error inside a block
-var afterMessageCount : Int? = nil
+var afterMessageCount : Int?
 
 func uintFunc() -> UInt {}
 func takeVoidVoidFn(_ a : () -> ()) {}

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -766,7 +766,7 @@ struct SR1752 {
   func foo() {}
 }
 
-let sr1752: SR1752? = nil
+let sr1752: SR1752?
 
 true ? nil : sr1752?.foo() // don't generate a warning about unused result since foo returns Void
 

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -162,7 +162,7 @@ default: break
 
 
 // Test some value patterns.
-let x : Int? = nil
+let x : Int?
 
 extension Int {
   func method() -> Int { return 42 }
@@ -245,6 +245,6 @@ enum SR2057 {
   case foo
 }
 
-let sr2057: SR2057? = nil
+let sr2057: SR2057?
 if case .foo = sr2057 { } // expected-error{{enum case 'foo' not found in type 'SR2057?'}}
 

--- a/test/Generics/associated_self_constraints.swift
+++ b/test/Generics/associated_self_constraints.swift
@@ -19,9 +19,9 @@ class Subject<T>: Observer, Observable {
     
     // Observer implementation
     
-    var onNextFunc: ((T) -> Void)? = nil
-    var onCompletedFunc: (() -> Void)? = nil
-    var onErrorFunc: ((String) -> Void)? = nil
+    var onNextFunc: ((T) -> Void)?
+    var onCompletedFunc: (() -> Void)?
+    var onErrorFunc: ((String) -> Void)?
     
     func onNext(_ item: T) -> Void {
         onNextFunc?(item)

--- a/test/IRGen/field_type_vectors.sil
+++ b/test/IRGen/field_type_vectors.sil
@@ -38,9 +38,9 @@ struct Bas<T, U> {
 //    vector slot, with type %swift.type**
 // CHECK:         i64, %swift.type*, %swift.opaque*, %swift.opaque*, i64, i32, i32, i32, i16, i16, i32, i32, i64, i8*, %swift.type*, %swift.type*, i8*, i64, i64, i64, %swift.type**
 class Zim<T, U> {
-  var foo: Foo? = nil
-  var bar: Bar<T>? = nil
-  var bas: Bas<T, U>? = nil
+  var foo: Foo?
+  var bar: Bar<T>?
+  var bas: Bas<T, U>?
 }
 sil_vtable Zim {}
 

--- a/test/Interpreter/SDK/archiving_generic_swift_class.swift
+++ b/test/Interpreter/SDK/archiving_generic_swift_class.swift
@@ -55,7 +55,7 @@ func driver() {
 
   do {
     // Set up the archiver's stdout to feed into our pipe.
-    var archiverActions: posix_spawn_file_actions_t? = nil
+    var archiverActions: posix_spawn_file_actions_t?
     guard posix_spawn_file_actions_init(&archiverActions) == 0 else {
       fatalError("posix_spawn_file_actions_init failed")
     }
@@ -85,7 +85,7 @@ func driver() {
 
   do {
     // Set up the unarchiver's stdin to read from our pipe.
-    var unarchiverActions: posix_spawn_file_actions_t? = nil
+    var unarchiverActions: posix_spawn_file_actions_t?
     guard posix_spawn_file_actions_init(&unarchiverActions) == 0 else {
       fatalError("posix_spawn_file_actions_init failed")
     }

--- a/test/Interpreter/SDK/objc_nil.swift
+++ b/test/Interpreter/SDK/objc_nil.swift
@@ -5,8 +5,8 @@
 
 import Foundation
 
-var str : NSString? = nil
-var url : NSURL? = nil
+var str : NSString?
+var url : NSURL?
 
 print("\(str == nil) \(nil == url) \(str == url)")
 // CHECK: true true true

--- a/test/Interpreter/builtin_bridge_object.swift
+++ b/test/Interpreter/builtin_bridge_object.swift
@@ -182,7 +182,7 @@ if true {
   print(MemoryLayout<Optional<Builtin.BridgeObject>>.size
             == MemoryLayout<Builtin.BridgeObject>.size)
 
-  var bo: Builtin.BridgeObject? = nil
+  var bo: Builtin.BridgeObject?
 
   // CHECK-NEXT: none
   hitOptionalSpecifically(bo)

--- a/test/Interpreter/enum.swift
+++ b/test/Interpreter/enum.swift
@@ -467,13 +467,13 @@ print((NoPayload.x as NoPayload?) == NoPayload.y)
 class Foo {}
 
 struct Oof {
-  weak var foo: Foo? = nil
+  weak var foo: Foo?
 }
 
 protocol Boo {}
 
 struct Goof {
-  var boo: Boo? = nil
+  var boo: Boo?
 }
 
 let oofs = [Oof()]

--- a/test/Interpreter/generic_objc_subclass.swift
+++ b/test/Interpreter/generic_objc_subclass.swift
@@ -25,7 +25,7 @@ protocol PP {
 
 class A<T> : HasHiddenIvars, P {
   var first: Int = 16
-  var second: T? = nil
+  var second: T?
   var third: Int = 61
 
   override var description: String {

--- a/test/Interpreter/pinning.swift
+++ b/test/Interpreter/pinning.swift
@@ -9,7 +9,7 @@ import SwiftShims
 typealias _HeapObject = SwiftShims.HeapObject
 
 class C {
-  var value: AnyObject? = nil
+  var value: AnyObject?
   deinit { print("deallocated") }
 }
 

--- a/test/Misc/misc_diagnostics.swift
+++ b/test/Misc/misc_diagnostics.swift
@@ -5,7 +5,7 @@
 import Foundation
 import CoreGraphics
 
-var roomName : String? = nil
+var roomName : String?
 
 if let realRoomName = roomName as! NSString { // expected-error {{initializer for conditional binding must have Optional type, not 'NSString'}} expected-warning {{cast from 'String?' to unrelated type 'NSString' always fails}}
 			

--- a/test/Parse/matching_patterns.swift
+++ b/test/Parse/matching_patterns.swift
@@ -288,8 +288,8 @@ default:
 
 
 // Optional patterns.
-let op1 : Int? = nil
-let op2 : Int?? = nil
+let op1 : Int?
+let op2 : Int??
 
 switch op1 {
 case nil: break

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -291,7 +291,7 @@ typealias AliasForNSRect = NSRect
   func cf(_ x: CFTree, str: CFString, str2: CFMutableString, obj: CFAliasForType) -> CFTypeRef? { return nil }
 
   func appKitInImplementation() {
-    let _ : NSResponder? = nil
+    let _ : NSResponder?
   }
 
   func returnsURL() -> NSURL? { return nil }
@@ -379,18 +379,18 @@ class MyObject : NSObject {}
   // CHECK-NEXT: init
   // CHECK-NEXT: @end
   @objc class Inner2 {
-    var ref: NestedMembers? = nil
+    var ref: NestedMembers?
   }
 
-  var ref2: Inner2? = nil
-  var ref3: Inner3? = nil
+  var ref2: Inner2?
+  var ref3: Inner3?
 
   // CHECK-LABEL: @interface Inner3
   // CHECK-NEXT: @property (nonatomic, strong) NestedMembers * _Nullable ref;
   // CHECK-NEXT: init
   // CHECK-NEXT: @end
   @objc class Inner3 {
-    var ref: NestedMembers? = nil
+    var ref: NestedMembers?
   }
 }
 

--- a/test/Prototypes/CollectionTransformers.swift
+++ b/test/Prototypes/CollectionTransformers.swift
@@ -426,7 +426,7 @@ final class _ForkJoinWorkerThread {
   }
 
   internal func startAsync() {
-    var queue: DispatchQueue? = nil
+    var queue: DispatchQueue?
     if #available(OSX 10.10, iOS 8.0, *) {
       queue = DispatchQueue.global(qos: .background)
     } else {
@@ -539,7 +539,7 @@ internal protocol _Future {
 }
 
 public class ForkJoinTaskBase {
-  final internal var _pool: ForkJoinPool? = nil
+  final internal var _pool: ForkJoinPool?
 
   // FIXME(performance): there is no need to create heavy-weight
   // synchronization primitives every time.  We could start with a lightweight
@@ -582,7 +582,7 @@ public class ForkJoinTaskBase {
 
 final public class ForkJoinTask<Result> : ForkJoinTaskBase, _Future {
   internal let _task: () -> Result
-  internal var _result: Result? = nil
+  internal var _result: Result?
 
   public init(_task: @escaping () -> Result) {
     self._task = _task

--- a/test/SILGen/collection_downcast.swift
+++ b/test/SILGen/collection_downcast.swift
@@ -8,7 +8,7 @@ import Foundation
 public extension _ObjectiveCBridgeable {
   static func _unconditionallyBridgeFromObjectiveC(_ source: _ObjectiveCType?)
       -> Self {
-    var result: Self? = nil
+    var result: Self?
     _forceBridgeFromObjectiveC(source!, result: &result)
     return result!
   }

--- a/test/SILGen/collection_upcast.swift
+++ b/test/SILGen/collection_upcast.swift
@@ -9,7 +9,7 @@ import Foundation
 public extension _ObjectiveCBridgeable {
   static func _unconditionallyBridgeFromObjectiveC(_ source: _ObjectiveCType?)
       -> Self {
-    var result: Self? = nil
+    var result: Self?
     _forceBridgeFromObjectiveC(source!, result: &result)
     return result!
   }

--- a/test/SILGen/let_decls.swift
+++ b/test/SILGen/let_decls.swift
@@ -154,7 +154,7 @@ extension Optional {
 }
 struct CloseOverAddressOnlyConstant<T> {
   func isError() {
-    let AOV: T? = nil
+    let AOV: T?
     takeClosure({ AOV.getLV() })
   }
   

--- a/test/SILGen/materializeForSet.swift
+++ b/test/SILGen/materializeForSet.swift
@@ -273,7 +273,7 @@ class HasStoredDidSet {
 // CHECK: }
 
 class HasWeak {
-  weak var weakvar: HasWeak? = nil
+  weak var weakvar: HasWeak?
 }
 // CHECK-LABEL: sil hidden [transparent] @_TFC17materializeForSet7HasWeakm7weakvarXwGSqS0__ : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @guaranteed HasWeak) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>) {
 // CHECK: bb0([[BUFFER:%.*]] : $Builtin.RawPointer, [[STORAGE:%.*]] : $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : $HasWeak):

--- a/test/SILOptimizer/cast_folding_objc.swift
+++ b/test/SILOptimizer/cast_folding_objc.swift
@@ -25,7 +25,7 @@ struct CX: _ObjectiveCBridgeable {
 
   static func _unconditionallyBridgeFromObjectiveC(_ source: ObjCX?)
       -> CX {
-    var result: CX? = nil
+    var result: CX?
     _forceBridgeFromObjectiveC(source!, result: &result)
     return result!
   }

--- a/test/Sanitizers/tsan.swift
+++ b/test/Sanitizers/tsan.swift
@@ -9,8 +9,8 @@
 // Test ThreadSanitizer execution end-to-end.
 
 import Darwin
-var user_interactive_thread: pthread_t? = nil
-var user_interactive_thread2: pthread_t? = nil
+var user_interactive_thread: pthread_t?
+var user_interactive_thread2: pthread_t?
 var racey_x: Int;
 
 pthread_create(&user_interactive_thread, nil, { _ in

--- a/test/Sema/deprecation_osx.swift
+++ b/test/Sema/deprecation_osx.swift
@@ -123,7 +123,7 @@ func annotatedHasReturnDeprecatedIn10_51() -> ClassDeprecatedIn10_51 {
 var globalWithDeprecatedType : ClassDeprecatedIn10_51? = nil // expected-warning {{ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
 
 @available(OSX, introduced: 10.8, deprecated: 10.51)
-var annotatedGlobalWithDeprecatedType : ClassDeprecatedIn10_51? = nil
+var annotatedGlobalWithDeprecatedType : ClassDeprecatedIn10_51?
 
 
 enum EnumWithDeprecatedCasePayload {

--- a/test/Serialization/testability.swift
+++ b/test/Serialization/testability.swift
@@ -49,7 +49,7 @@
   #endif
 
   #if TESTABLE || DEBUG
-    let x: Sub? = nil
+    let x: Sub?
   #endif
 
   unrelated()

--- a/test/SourceKit/Indexing/index_bad_modulename.swift
+++ b/test/SourceKit/Indexing/index_bad_modulename.swift
@@ -4,6 +4,6 @@
 // RUN: diff -u %s.response %t.response2
 
 import ObjectiveC
-let v: NSObject? = nil
+let v: NSObject?
 
 // REQUIRES: objc_interop

--- a/test/expr/cast/array_bridge.swift
+++ b/test/expr/cast/array_bridge.swift
@@ -6,7 +6,7 @@
 public extension _ObjectiveCBridgeable {
   static func _unconditionallyBridgeFromObjectiveC(_ source: _ObjectiveCType?)
       -> Self {
-    var result: Self? = nil
+    var result: Self?
     _forceBridgeFromObjectiveC(source!, result: &result)
     return result!
   }

--- a/test/expr/cast/array_downcast.swift
+++ b/test/expr/cast/array_downcast.swift
@@ -6,7 +6,7 @@
 public extension _ObjectiveCBridgeable {
   static func _unconditionallyBridgeFromObjectiveC(_ source: _ObjectiveCType?)
       -> Self {
-    var result: Self? = nil
+    var result: Self?
     _forceBridgeFromObjectiveC(source!, result: &result)
     return result!
   }

--- a/test/expr/cast/bridged.swift
+++ b/test/expr/cast/bridged.swift
@@ -8,7 +8,7 @@
 public extension _ObjectiveCBridgeable {
   static func _unconditionallyBridgeFromObjectiveC(_ source: _ObjectiveCType?)
       -> Self {
-    var result: Self? = nil
+    var result: Self?
     _forceBridgeFromObjectiveC(source!, result: &result)
     return result!
   }

--- a/test/expr/cast/dictionary_bridge.swift
+++ b/test/expr/cast/dictionary_bridge.swift
@@ -6,7 +6,7 @@
 public extension _ObjectiveCBridgeable {
   static func _unconditionallyBridgeFromObjectiveC(_ source: _ObjectiveCType?)
       -> Self {
-    var result: Self? = nil
+    var result: Self?
     _forceBridgeFromObjectiveC(source!, result: &result)
     return result!
   }

--- a/test/expr/cast/set_bridge.swift
+++ b/test/expr/cast/set_bridge.swift
@@ -6,7 +6,7 @@
 public extension _ObjectiveCBridgeable {
   static func _unconditionallyBridgeFromObjectiveC(_ source: _ObjectiveCType?)
       -> Self {
-    var result: Self? = nil
+    var result: Self?
     _forceBridgeFromObjectiveC(source!, result: &result)
     return result!
   }

--- a/test/stdlib/ArrayBridge.swift.gyb
+++ b/test/stdlib/ArrayBridge.swift.gyb
@@ -104,7 +104,7 @@ struct BridgeableValue : _ObjectiveCBridgeable, Equatable {
 
   static func _unconditionallyBridgeFromObjectiveC(_ source: Subclass?)
       -> BridgeableValue {
-    var result: BridgeableValue? = nil
+    var result: BridgeableValue?
     _forceBridgeFromObjectiveC(source!, result: &result)
     return result!
   }

--- a/test/stdlib/BridgeNonVerbatim.swift
+++ b/test/stdlib/BridgeNonVerbatim.swift
@@ -53,7 +53,7 @@ struct X : _ObjectiveCBridgeable {
 
   static func _unconditionallyBridgeFromObjectiveC(_ source: LifetimeTracked?)
       -> X {
-    var result: X? = nil
+    var result: X?
     _forceBridgeFromObjectiveC(source!, result: &result)
     return result!
   }

--- a/test/stdlib/Bridgeable.swift
+++ b/test/stdlib/Bridgeable.swift
@@ -7,7 +7,7 @@
 public extension _ObjectiveCBridgeable {
   static func _unconditionallyBridgeFromObjectiveC(_ source: _ObjectiveCType?)
       -> Self {
-    var result: Self? = nil
+    var result: Self?
     _forceBridgeFromObjectiveC(source!, result: &result)
     return result!
   }

--- a/test/stdlib/Error.swift
+++ b/test/stdlib/Error.swift
@@ -130,7 +130,7 @@ enum LifetimeError : Error {
 ErrorTests.test("existential in lvalue") {
   expectEqual(0, LifetimeTracked.instances)
   do {
-    var e: Error? = nil
+    var e: Error?
     do {
       throw LifetimeError.MistakeOfALifetime(LifetimeTracked(0),
                                              yearsIncarcerated: 25)

--- a/test/stdlib/PrintStruct.swift
+++ b/test/stdlib/PrintStruct.swift
@@ -33,7 +33,7 @@ PrintTests.test("Printable") {
 
 PrintTests.test("custom string convertible structs") {
   struct Wrapper : CustomStringConvertible {
-    var x: CustomStringConvertible? = nil
+    var x: CustomStringConvertible?
     
     var description: String {
       return "Wrapper(\(x.debugDescription))"

--- a/test/stdlib/Reflection.swift
+++ b/test/stdlib/Reflection.swift
@@ -171,7 +171,7 @@ dump(String.self)
 dump(stride(from: 1.0, through: 12.15, by: 3.14))
 
 // CHECK-NEXT: nil
-var nilUnsafeMutablePointerString: UnsafeMutablePointer<String>? = nil
+var nilUnsafeMutablePointerString: UnsafeMutablePointer<String>?
 dump(nilUnsafeMutablePointerString)
 
 // CHECK-NEXT: 123456

--- a/test/stdlib/RuntimeObjC.swift
+++ b/test/stdlib/RuntimeObjC.swift
@@ -83,7 +83,7 @@ struct BridgedValueType : _ObjectiveCBridgeable {
 
   static func _unconditionallyBridgeFromObjectiveC(_ source: ClassA?)
       -> BridgedValueType {
-    var result: BridgedValueType? = nil
+    var result: BridgedValueType?
     _forceBridgeFromObjectiveC(source!, result: &result)
     return result!
   }
@@ -132,7 +132,7 @@ struct BridgedLargeValueType : _ObjectiveCBridgeable {
 
   static func _unconditionallyBridgeFromObjectiveC(_ source: ClassA?)
       -> BridgedLargeValueType {
-    var result: BridgedLargeValueType? = nil
+    var result: BridgedLargeValueType?
     _forceBridgeFromObjectiveC(source!, result: &result)
     return result!
   }
@@ -736,7 +736,7 @@ Reflection.test("CGRect") {
 
 Reflection.test("Unmanaged/nil") {
   var output = ""
-  var optionalURL: Unmanaged<CFURL>? = nil
+  var optionalURL: Unmanaged<CFURL>?
   dump(optionalURL, to: &output)
 
   let expected = "- nil\n"

--- a/test/stdlib/SetTrapsObjC.swift
+++ b/test/stdlib/SetTrapsObjC.swift
@@ -105,7 +105,7 @@ struct TestBridgedKeyTy : Hashable, _ObjectiveCBridgeable {
 
   static func _unconditionallyBridgeFromObjectiveC(_ source: TestObjCKeyTy?)
       -> TestBridgedKeyTy {
-    var result: TestBridgedKeyTy? = nil
+    var result: TestBridgedKeyTy?
     _forceBridgeFromObjectiveC(source!, result: &result)
     return result!
   }

--- a/test/stdlib/WeakMirror.swift
+++ b/test/stdlib/WeakMirror.swift
@@ -149,7 +149,7 @@ class ObjCClassHasObjCClassBoundExistential : NSObject {
 }
 
 struct StructHasObjCWeakReference {
-  weak var weakProperty: ObjCClass? = nil
+  weak var weakProperty: ObjCClass?
   let x: Int
   init(x: Int) {
     self.x = x
@@ -157,7 +157,7 @@ struct StructHasObjCWeakReference {
 }
 
 struct StructHasObjCClassBoundExistential {
-  weak var weakProperty: ObjCClassExistential? = nil
+  weak var weakProperty: ObjCClassExistential?
   let x: Int
   init(x: Int) {
     self.x = x

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -167,7 +167,7 @@ func testMatchingPatterns() {
 
 // <rdar://problem/21662365> QoI: diagnostic for for-each over an optional sequence isn't great
 func testOptionalSequence() {
-  let array : [Int]? = nil
+  let array : [Int]?
   for x in array {  // expected-error {{value of optional type '[Int]?' not unwrapped; did you mean to use '!' or '?'?}} {{17-17=!}}
   }
 }

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -3885,7 +3885,7 @@ DictionaryTestSuite.test("getObjects:andKeys:") {
     start: UnsafeMutablePointer<NSString>.allocate(capacity: 2), count: 2)
   var kp = AutoreleasingUnsafeMutablePointer<AnyObject?>(keys.baseAddress!)
   var vp = AutoreleasingUnsafeMutablePointer<AnyObject?>(values.baseAddress!)
-  var null: AutoreleasingUnsafeMutablePointer<AnyObject?>? = nil
+  var null: AutoreleasingUnsafeMutablePointer<AnyObject?>?
 
   d.available_getObjects(null, andKeys: null) // don't segfault
 

--- a/validation-test/stdlib/DictionaryTrapsObjC.swift
+++ b/validation-test/stdlib/DictionaryTrapsObjC.swift
@@ -105,7 +105,7 @@ struct TestBridgedKeyTy : Hashable, _ObjectiveCBridgeable {
 
   static func _unconditionallyBridgeFromObjectiveC(_ source: TestObjCKeyTy?)
       -> TestBridgedKeyTy {
-    var result: TestBridgedKeyTy? = nil
+    var result: TestBridgedKeyTy?
     _forceBridgeFromObjectiveC(source!, result: &result)
     return result!
   }

--- a/validation-test/stdlib/Range.swift.gyb
+++ b/validation-test/stdlib/Range.swift.gyb
@@ -555,7 +555,7 @@ ${TestSuite}.test("index(after:)/semantics").forEach(in: [3, 5, 10, 12, 86]) {
   let end = ${Bound}(endValue)
   let range: ${Self}<${Bound}> = start${op}end
   var idx = range.startIndex
-  var previousValue: Int? = nil
+  var previousValue: Int?
 
   for _ in 0${op}(endValue - 1) {
     // Advance the index to the last in-range position.
@@ -592,7 +592,7 @@ ${TestSuite}.test("index(before:)/semantics").forEach(in: [3, 5, 10, 12, 86]) {
   let end = ${Bound}(endValue)
   let range: ${Self}<${Bound}> = start${op}end
   var idx = range.endIndex
-  var previousValue: Int? = nil
+  var previousValue: Int?
 
   for _ in 0${op}(endValue) {
     // Advance the index backwards until we reach `startIndex`.

--- a/validation-test/stdlib/StringSlicesConcurrentAppend.swift
+++ b/validation-test/stdlib/StringSlicesConcurrentAppend.swift
@@ -30,7 +30,7 @@ enum ThreadID {
   case Secondary
 }
 
-var barrierVar: UnsafeMutablePointer<_stdlib_pthread_barrier_t>? = nil
+var barrierVar: UnsafeMutablePointer<_stdlib_pthread_barrier_t>?
 var sharedString: String = ""
 var secondaryString: String = ""
 


### PR DESCRIPTION
Remove redundant `nil`-initialization of optional variables.

From the Swift documentation:

> If you define an optional variable without providing a default value, the variable is automatically set to `nil` for you.
