### PR TITLE
IRGen: fix the address alignment calculation of index_addr and tail_a…

### DIFF
--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -1518,7 +1518,9 @@ Address TypeInfo::indexArray(IRGenFunction &IGF, Address base,
   // do a byte-level GEP with the proper stride.
   const FixedTypeInfo *fixedTI = dyn_cast<FixedTypeInfo>(this);
 
-  Address dest;
+  llvm::Value *destValue = nullptr;
+  Size stride(1);
+  
   // TODO: Arrays currently lower-bound the stride to 1.
   if (!fixedTI
       || std::max(Size(1), fixedTI->getFixedStride()) != fixedTI->getFixedSize()) {
@@ -1528,15 +1530,21 @@ Address TypeInfo::indexArray(IRGenFunction &IGF, Address base,
     if (size->getType() != index->getType())
       size = IGF.Builder.CreateZExtOrTrunc(size, index->getType());
     llvm::Value *distance = IGF.Builder.CreateNSWMul(index, size);
-    llvm::Value *destValue = IGF.Builder.CreateInBoundsGEP(byteAddr, distance);
+    destValue = IGF.Builder.CreateInBoundsGEP(byteAddr, distance);
     destValue = IGF.Builder.CreateBitCast(destValue, base.getType());
-    return Address(destValue, base.getAlignment());
   } else {
     // We don't expose a non-inbounds GEP operation.
-    llvm::Value *destValue = IGF.Builder.CreateInBoundsGEP(base.getAddress(),
-                                                           index);
-    return Address(destValue, base.getAlignment());
+    destValue = IGF.Builder.CreateInBoundsGEP(base.getAddress(), index);
+    stride = fixedTI->getFixedStride();
   }
+  if (auto *IndexConst = dyn_cast<llvm::ConstantInt>(index)) {
+    // If we know the indexing value, we can get a better guess on the
+    // alignment.
+    // This even works if the stride is not known (and assumed to be 1).
+    stride *= IndexConst->getValue().getZExtValue();
+  }
+  Alignment Align = base.getAlignment().alignmentAtOffset(stride);
+  return Address(destValue, Align);
 }
 
 Address TypeInfo::roundUpToTypeAlignment(IRGenFunction &IGF, Address base,

--- a/test/IRGen/tail_alloc.sil
+++ b/test/IRGen/tail_alloc.sil
@@ -160,4 +160,44 @@ bb0(%0 : $Builtin.RawPointer, %1 : $Int32):
   return %r : $()
 }
 
+// sizeof(EmptyClass) = 16 bytes
+class EmptyClass {
+}
+
+sil_vtable EmptyClass {}
+
+// CHECK-LABEL: define{{( protected)?}} i8 @test_align_1_int8
+// CHECK: load i8, i8* %{{.*}}, align 1
+// CHECK: ret
+sil @test_align_1_int8 : $@convention(thin) (EmptyClass) -> Int8 {
+bb0(%0 : $EmptyClass):
+  %a = ref_tail_addr %0 : $EmptyClass, $Int8
+  %w = integer_literal $Builtin.Word, 1
+  %i = index_addr %a : $*Int8, %w : $Builtin.Word
+  %l = load %i : $*Int8
+  return %l : $Int8
+}
+
+// CHECK-LABEL: define{{( protected)?}} i8 @test_align_2_int8
+// CHECK: load i8, i8* %{{.*}}, align 2
+// CHECK: ret
+sil @test_align_2_int8 : $@convention(thin) (EmptyClass) -> Int8 {
+bb0(%0 : $EmptyClass):
+  %a = ref_tail_addr %0 : $EmptyClass, $Int8
+  %w = integer_literal $Builtin.Word, 2
+  %i = index_addr %a : $*Int8, %w : $Builtin.Word
+  %l = load %i : $*Int8
+  return %l : $Int8
+}
+
+// CHECK-LABEL: define{{( protected)?}} i32 @test_align_int32
+// CHECK: load i32, i32* %{{.*}}, align 4
+// CHECK: ret
+sil @test_align_int32 : $@convention(thin) (EmptyClass, Builtin.Word) -> Int32 {
+bb0(%0 : $EmptyClass, %1 : $Builtin.Word):
+  %a = ref_tail_addr %0 : $EmptyClass, $Int32
+  %i = index_addr %a : $*Int32, %1 : $Builtin.Word
+  %l = load %i : $*Int32
+  return %l : $Int32
+}
 


### PR DESCRIPTION
…ddr.

This was wrong if the alignment of the base operand was larger than the alignment of the element type.
rdar://problem/28346274
