### PR TITLE
[SIL] Add test case for crash triggered in swift::TypeBase::getCanonicalType()

### DIFF
--- a/validation-test/SIL/crashers/035-swift-typebase-getcanonicaltype.sil
+++ b/validation-test/SIL/crashers/035-swift-typebase-getcanonicaltype.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+protocol f{func<extension{func<


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:16: warning: operator '<' declared in protocol must be 'static'
protocol f{func<extension{func<
               ^
           static
<stdin>:3:17: error: expected '(' in argument list of function declaration
protocol f{func<extension{func<
                ^
<stdin>:3:17: error: consecutive declarations on a line must be separated by ';'
protocol f{func<extension{func<
                ^
                ;
<stdin>:3:26: error: expected type name in extension declaration
protocol f{func<extension{func<
                         ^
<stdin>:3:32: error: expected '(' in argument list of function declaration
protocol f{func<extension{func<
                               ^
<stdin>:3:32: error: expected declaration
protocol f{func<extension{func<
                               ^
<stdin>:3:17: error: declaration is only valid at file scope
protocol f{func<extension{func<
                ^
<stdin>:3:32: error: consecutive declarations on a line must be separated by ';'
protocol f{func<extension{func<
                               ^
                               ;
<stdin>:3:32: error: expected declaration
protocol f{func<extension{func<
                               ^
<stdin>:3:10: note: in declaration of 'f'
protocol f{func<extension{func<
         ^
<stdin>:3:16: error: operators must have one or two arguments
protocol f{func<extension{func<
               ^
<stdin>:3:16: error: member operator '<()' of protocol 'f' must have at least one argument of type 'Self'
protocol f{func<extension{func<
               ^
<stdin>:3:31: error: operator '<' declared in type '<<error type>>' must be 'static'
protocol f{func<extension{func<
                              ^
                          static
<stdin>:3:31: error: operators must have one or two arguments
protocol f{func<extension{func<
                              ^
4  sil-opt         0x0000000000e76f54 swift::TypeBase::getCanonicalType() + 20
5  sil-opt         0x0000000000e21744 swift::ExtensionDecl::isConstrainedExtension() const + 20
7  sil-opt         0x0000000000b46e40 swift::TypeChecker::inferDefaultWitnesses(swift::ProtocolDecl*) + 288
8  sil-opt         0x0000000000b1fa68 swift::finishTypeChecking(swift::SourceFile&) + 536
9  sil-opt         0x0000000000775a5a swift::CompilerInstance::performSema() + 3722
10 sil-opt         0x000000000075ec65 main + 1813
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
```
