### PR TITLE
[swiftc (73 vs. 5162)] Add crasher in swift::TypeChecker::validateDecl(…)

### DIFF
--- a/validation-test/compiler_crashers/28423-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers/28423-swift-typechecker-validatedecl.swift
@@ -1,0 +1,17 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+protocol a
+protocol a{
+typealias e:A
+{{
+}
+}
+protocol A{let:A
+var e:e


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::validateDecl(...)`.

Current number of unresolved compiler crashers: 73 (5162 resolved)

Assertion failure in [`lib/AST/GenericEnvironment.cpp (line 58)`](https://github.com/apple/swift/blob/master/lib/AST/GenericEnvironment.cpp#L58):

```
Assertion `!type->hasArchetype() && "not fully substituted"' failed.

When executing: swift::Type swift::GenericEnvironment::mapTypeOutOfContext(swift::ModuleDecl *, swift::Type) const
```

Assertion context:

```
  return ctx.Allocate(bytes, alignof(GenericEnvironment), AllocationArena::Permanent);
}

Type GenericEnvironment::mapTypeOutOfContext(ModuleDecl *M, Type type) const {
  type = type.subst(M, ArchetypeToInterfaceMap, SubstFlags::AllowLoweredTypes);
  assert(!type->hasArchetype() && "not fully substituted");
  return type;
}

Type GenericEnvironment::mapTypeIntoContext(ModuleDecl *M, Type type) const {
  type = type.subst(M, InterfaceToArchetypeMap, SubstFlags::AllowLoweredTypes);
```

Stack trace:

```
swift: /path/to/swift/lib/AST/GenericEnvironment.cpp:58: swift::Type swift::GenericEnvironment::mapTypeOutOfContext(swift::ModuleDecl *, swift::Type) const: Assertion `!type->hasArchetype() && "not fully substituted"' failed.
11 swift           0x0000000000eda3b1 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3857
12 swift           0x0000000001110df7 swift::ProtocolDecl::existentialTypeSupportedSlow(swift::LazyResolver*) + 151
17 swift           0x00000000010aaa04 swift::Decl::walk(swift::ASTWalker&) + 20
18 swift           0x0000000000f5676d swift::TypeChecker::checkUnsupportedProtocolType(swift::Decl*) + 157
24 swift           0x0000000000edfc26 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
25 swift           0x0000000000f044c2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
26 swift           0x0000000000c86e69 swift::CompilerInstance::performSema() + 3289
28 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
29 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28423-swift-typechecker-validatedecl.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28423-swift-typechecker-validatedecl-a62cc0.o
1.  While type-checking 'a' at validation-test/compiler_crashers/28423-swift-typechecker-validatedecl.swift:11:1
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
