### PR TITLE
[stubs] Remove empty CMake variable

### DIFF
--- a/stdlib/public/stubs/CMakeLists.txt
+++ b/stdlib/public/stubs/CMakeLists.txt
@@ -27,6 +27,5 @@ add_swift_library(swiftStdlibStubs OBJECT_LIBRARY TARGET_LIBRARY
   ${swift_stubs_unicode_normalization_sources}
   C_COMPILE_FLAGS ${SWIFT_RUNTIME_CORE_CXX_FLAGS} -DswiftCore_EXPORTS
   LINK_FLAGS ${SWIFT_RUNTIME_CORE_LINK_FLAGS}
-  LINK_LIBRARIES ${swift_stubs_link_libraries}
   INSTALL_IN_COMPONENT stdlib)
 


### PR DESCRIPTION
<!-- What's in this pull request? -->

`swift_stubs_link_libraries` was removed in d227aeb64d. Remove the `LINK_LIBRARIES` parameter, since its argument will always be empty.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
