### PR TITLE
[test] Remove "RUN: true" lit commands

### DIFF
--- a/test/DebugInfo/Globals.swift
+++ b/test/DebugInfo/Globals.swift
@@ -1,3 +1,2 @@
 // This module is imported by external-global.swift
-// RUN: true
 public var global : Int64 = 0

--- a/test/multifile/error-type/imported/library.swift
+++ b/test/multifile/error-type/imported/library.swift
@@ -1,5 +1,3 @@
-// RUN: true
-
 public func go() throws {
   throw AXError(0)
 }

--- a/test/multifile/error-type/one-module/library.swift
+++ b/test/multifile/error-type/one-module/library.swift
@@ -1,5 +1,3 @@
-// RUN: true
-
 enum NuclearMeltdown {
   case Critical
   case Mild

--- a/test/multifile/error-type/two-modules/library.swift
+++ b/test/multifile/error-type/two-modules/library.swift
@@ -1,5 +1,3 @@
-// RUN: true
-
 public enum NuclearMeltdown {
   case Critical
   case Mild

--- a/test/multifile/synthesized-accessors/one-module-imported/library.swift
+++ b/test/multifile/synthesized-accessors/one-module-imported/library.swift
@@ -1,5 +1,3 @@
-// RUN: true
-
 import CoreGraphics
 
 protocol OtherPoint {

--- a/test/multifile/synthesized-accessors/one-module-internal/library.swift
+++ b/test/multifile/synthesized-accessors/one-module-internal/library.swift
@@ -1,5 +1,3 @@
-// RUN: true
-
 struct FishAndChips {
   var costPounds: Float
   var costEuros: Float {

--- a/test/multifile/synthesized-accessors/one-module-public/library.swift
+++ b/test/multifile/synthesized-accessors/one-module-public/library.swift
@@ -1,5 +1,3 @@
-// RUN: true
-
 public struct FishAndChips {
   public var costPounds: Float
   public var costEuros: Float {

--- a/test/multifile/synthesized-accessors/two-modules-imported/library.swift
+++ b/test/multifile/synthesized-accessors/two-modules-imported/library.swift
@@ -1,5 +1,3 @@
-// RUN: true
-
 import CoreGraphics
 
 public protocol OtherPoint {

--- a/test/multifile/synthesized-accessors/two-modules/library.swift
+++ b/test/multifile/synthesized-accessors/two-modules/library.swift
@@ -1,5 +1,3 @@
-// RUN: true
-
 public struct FishAndChips {
   public var costPounds: Float
   public var costEuros: Float {

--- a/test/multifile/typealias/one-module/library.swift
+++ b/test/multifile/typealias/one-module/library.swift
@@ -1,5 +1,3 @@
-// RUN: true
-
 public enum Result<T, U>
 {
     case success(T)

--- a/test/multifile/typealias/two-modules/library.swift
+++ b/test/multifile/typealias/two-modules/library.swift
@@ -1,5 +1,3 @@
-// RUN: true
-
 public enum Result<T, U>
 {
     case success(T)


### PR DESCRIPTION
<!-- What's in this pull request? -->

The lit test runner runs all `RUN:` commands in test files, and fails the test if the commands exit with a non-zero status. In this sense, including `RUN: false` in a lit test is an easy way to cause a test to fail, perhaps as a means of debugging its output at some intermediate step. On the other hand, there's no purpose in including `RUN: true`. That command will always pass.

Remove the unneeded lit commands.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
