### PR TITLE
Do not recurse infinitely when type checking constructor parameters.

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6425,17 +6425,22 @@ public:
       }
     }
 
-    // Type check the constructor parameters.
-    if (CD->isInvalid() || semaFuncParamPatterns(CD)) {
-      CD->overwriteType(ErrorType::get(TC.Context));
-      CD->setInterfaceType(ErrorType::get(TC.Context));
-      CD->setInvalid();
-    } else {
-      configureConstructorType(CD, SelfTy,
-                               CD->getParameterList(1)->getType(TC.Context));
+    {
+      CD->setIsBeingTypeChecked(true);
+      SWIFT_DEFER { CD->setIsBeingTypeChecked(false); };
 
-      if (!CD->isGenericContext())
-        TC.configureInterfaceType(CD);
+      // Type check the constructor parameters.
+      if (CD->isInvalid() || semaFuncParamPatterns(CD)) {
+        CD->overwriteType(ErrorType::get(TC.Context));
+        CD->setInterfaceType(ErrorType::get(TC.Context));
+        CD->setInvalid();
+      } else {
+        configureConstructorType(CD, SelfTy,
+                                 CD->getParameterList(1)->getType(TC.Context));
+
+        if (!CD->isGenericContext())
+          TC.configureInterfaceType(CD);
+      }
     }
 
     validateAttributes(TC, CD);

--- a/test/Sema/circular_decl_checking.swift
+++ b/test/Sema/circular_decl_checking.swift
@@ -66,3 +66,13 @@ struct SomeStruct<A> {
   typealias A = A // expected-error {{type alias 'A' circularly references itself}}
 }
 
+// <rdar://problem/27680407> Infinite recursion when using fully-qualified associatedtype name that has not been defined with typealias
+protocol rdar27680407Proto {
+  associatedtype T // expected-note {{protocol requires nested type 'T'; do you want to add it?}}
+
+  init(value: T)
+}
+
+struct rdar27680407Struct : rdar27680407Proto { // expected-error {{type 'rdar27680407Struct' does not conform to protocol 'rdar27680407Proto'}}
+  init(value: rdar27680407Struct.T) {}
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->

Avoid infinite recursion when type checking constructor parameters where a referenced type is a fully-qualified associated type that does not yet have a defined typealias.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [rdar://problem/27680407](rdar://problem/27680407).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

Fully-qualified references to associated types in parameter lists of
constructors could result in infinite recursion and crash the compiler
when the typealias for the associated type is not defined.

Use the same approach used in normal function parameter lists of setting
IsBeingTypeChecked on the enclosing type to avoid going into an infinite
recursion here.

Resolves rdar://problem/27680407.

(cherry picked from commit 126b9fcb2a8d22ea9313172bff150a39939df1ff)
