### PR TITLE
[Type checker] Don't infer 'dynamic' for 'let' variables or within final classes

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2116,14 +2116,27 @@ static void inferDynamic(ASTContext &ctx, ValueDecl *D) {
     return;
 
   // Only introduce 'dynamic' on declarations...
+  bool isNSManaged = D->getAttrs().hasAttribute<NSManagedAttr>();
   if (!isa<ExtensionDecl>(D->getDeclContext())) {
     // ...and in classes on decls marked @NSManaged.
-    if (!D->getAttrs().hasAttribute<NSManagedAttr>())
+    if (!isNSManaged)
       return;
   }
 
   // The presence of 'dynamic' or 'final' blocks the inference of 'dynamic'.
   if (D->isDynamic() || D->isFinal())
+    return;
+
+  // Variables declared with 'let' cannot be 'dynamic'.
+  if (auto VD = dyn_cast<VarDecl>(D)) {
+    if (VD->isLet() && !isNSManaged) return;
+  }
+
+  // The presence of 'final' on a class prevents 'dynamic'.
+  auto classDecl = D->getDeclContext()->getAsClassOrClassExtensionContext();
+  if (!classDecl) return;
+  if (!isNSManaged && classDecl->isFinal() &&
+      !classDecl->requiresStoredPropertyInits())
     return;
 
   // Add the 'dynamic' attribute.

--- a/test/ClangModules/objc_final_dynamic.swift
+++ b/test/ClangModules/objc_final_dynamic.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -I %S/Inputs/custom-modules %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+// Note: make sure we don't get a bogus error from nowhere,
+//   error: a declaration cannot be both 'final' and 'dynamic'
+extension NSObject {
+  public static let staticIntProperty: Int = 17
+}
+
+final class MyClass : NSObject { }
+
+extension MyClass {
+  public static var otherStaticIntProperty: Int = 17
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->

The 'dynamic' inference would infer 'dynamic' in places where it would
also infer 'final', leading to a diagnostic

  error: a declaration cannot be both 'final' and 'dynamic'

with no source location information. Don't infer 'dynamic' in such
places. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-993](https://bugs.swift.org/browse/SR-993) / rdar://problem/20449627

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
