### PR TITLE
[Name lookup] Remove NL_VisitSupertypes.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -499,8 +499,12 @@ ERROR(sil_witness_method_not_protocol,none,
       "witness_method is not a protocol method", ())
 ERROR(sil_witness_method_type_does_not_conform,none,
       "witness_method type does not conform to protocol", ())
-ERROR(sil_member_decl_not_found,none,
-      "member not found in method instructions", ())
+ERROR(sil_member_decl_not_found,none, "member not found", ())
+ERROR(sil_named_member_decl_not_found,none,
+      "member %0 not found in type %1", (DeclName, Type))
+ERROR(sil_member_lookup_bad_type,none,
+      "cannot lookup member %0 in non-nominal, non-module type %1",
+      (DeclName, Type))
 ERROR(sil_member_decl_type_mismatch,none,
       "member defined with mismatching type %0 (expected %1)", (Type, Type))
 ERROR(sil_substitution_mismatch,none,

--- a/include/swift/AST/LookupKinds.h
+++ b/include/swift/AST/LookupKinds.h
@@ -28,10 +28,6 @@ enum class NLKind {
 
 /// Constants used to customize name lookup.
 enum NLOptions : unsigned {
-  /// Visit supertypes (such as superclasses or inherited protocols)
-  /// and their extensions as well as the current extension.
-  NL_VisitSupertypes = 0x01,
-
   /// Consider declarations within protocols to which the context type conforms.
   NL_ProtocolMembers = 0x02,
 
@@ -86,12 +82,10 @@ enum NLOptions : unsigned {
   ///
   /// FIXME: Eventually, add NL_ProtocolMembers to this, once all of the
   /// callers can handle it.
-  NL_QualifiedDefault = NL_VisitSupertypes | NL_RemoveNonVisible |
-                        NL_RemoveOverridden,
+  NL_QualifiedDefault = NL_RemoveNonVisible | NL_RemoveOverridden,
 
   /// The default set of options used for unqualified name lookup.
-  NL_UnqualifiedDefault = NL_VisitSupertypes |
-                          NL_RemoveNonVisible | NL_RemoveOverridden
+  NL_UnqualifiedDefault = NL_RemoveNonVisible | NL_RemoveOverridden
 };
 
 static inline NLOptions operator|(NLOptions lhs, NLOptions rhs) {

--- a/lib/AST/DocComment.cpp
+++ b/lib/AST/DocComment.cpp
@@ -423,10 +423,6 @@ getProtocolRequirementDocComment(swift::markup::MarkupContext &MC,
     if (auto Requirement = getSingleRequirementWithNonemptyDoc(ProtoExt, VD))
       RequirementsWithDocs.push_back(Requirement);
 
-    for (auto Proto : ProtoExt->getInheritedProtocols(/*resolver=*/nullptr))
-      if (auto Requirement = getSingleRequirementWithNonemptyDoc(Proto, VD))
-        RequirementsWithDocs.push_back(Requirement);
-
     if (RequirementsWithDocs.size() == 1)
       return getSingleDocComment(MC, RequirementsWithDocs.front());
   }

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1451,16 +1451,14 @@ bool DeclContext::lookupQualified(Type type,
       if (visited.insert(proto).second)
         stack.push_back(proto);
 
-    // If requested, look into the superclasses of this archetype.
-    if (options & NL_VisitSupertypes) {
-      if (auto superclassTy = archetypeTy->getSuperclass()) {
-        if (auto superclassDecl = superclassTy->getAnyNominal()) {
-          if (visited.insert(superclassDecl).second) {
-            stack.push_back(superclassDecl);
+    // Look into the superclasses of this archetype.
+    if (auto superclassTy = archetypeTy->getSuperclass()) {
+      if (auto superclassDecl = superclassTy->getAnyNominal()) {
+        if (visited.insert(superclassDecl).second) {
+          stack.push_back(superclassDecl);
 
-            wantProtocolMembers = (options & NL_ProtocolMembers) &&
-                                  !isa<ProtocolDecl>(superclassDecl);
-          }
+          wantProtocolMembers = (options & NL_ProtocolMembers) &&
+                                !isa<ProtocolDecl>(superclassDecl);
         }
       }
     }
@@ -1563,10 +1561,6 @@ bool DeclContext::lookupQualified(Type type,
       if (isAcceptableDecl(current, decl))
         decls.push_back(decl);
     }
-
-    // If we're not supposed to visit our supertypes, we're done.
-    if ((options & NL_VisitSupertypes) == 0)
-      continue;
 
     // Visit superclass.
     if (auto classDecl = dyn_cast<ClassDecl>(current)) {


### PR DESCRIPTION
<!-- What's in this pull request? -->

As part of cleaning up name lookup, remove the `NL_VisitSupertypes` flag, which shouldn't ever be needed.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
