### PR TITLE
Sema: Fix crash when attempting to diagnose a contextual conversion o…

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4114,6 +4114,12 @@ bool FailureDiagnosis::diagnoseContextualConversionError() {
                                                 CS))
     return true;
 
+  // Don't attempt fixits if we have an unsolved type variable, since
+  // the recovery path's recursion into the type checker via typeCheckCast()
+  // will confuse matters.
+  if (exprType->hasTypeVariable())
+    return false;
+
   // When complaining about conversion to a protocol type, complain about
   // conformance instead of "conversion".
   if (contextualType->is<ProtocolType>() ||

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -780,3 +780,18 @@ struct rdar27891805 {
 try rdar27891805(contentsOfURL: nil, usedEncoding: nil)
 // expected-error@-1 {{argument labels '(contentsOfURL:, usedEncoding:)' do not match any available overloads}}
 // expected-note@-2 {{overloads for 'rdar27891805' exist with these partially matching parameter lists: (contentsOf: String, encoding: String), (contentsOf: String, usedEncoding: inout String)}}
+
+// Make sure RawRepresentable fix-its don't crash in the presence of type variables
+class NSCache<K, V> {
+  func object(forKey: K) -> V? {}
+}
+
+class CacheValue {
+  func value(x: Int) -> Int {} // expected-note {{found this candidate}}
+  func value(y: String) -> String {} // expected-note {{found this candidate}}
+}
+
+func valueForKey<K>(_ key: K) -> CacheValue? {
+  let cache = NSCache<K, CacheValue>()
+  return cache.object(forKey: key)?.value // expected-error {{ambiguous reference to member 'value(x:)'}}
+}


### PR DESCRIPTION
- Description: Fixes a crash on invalid code when we should produce a diagnostic.
- Risk: Low, it's just a small change to a diagnostic path. The worst outcome here is a regression in QoI if we bail out too eagerly.
- Tested: New test added, used to produce a bad diagnostic followed by a crash, now produces a diagnostic explaining the actual problem.
- Reviewed by: @jrose-apple 
- JIRA: https://bugs.swift.org/browse/SR-2592, Radar: rdar://problem/28141573
