### PR TITLE
Runtime: Fix breakage when generic subclasses directly inherit NSObject (3.0)

### DIFF
--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -230,16 +230,13 @@ namespace {
         assert(superclass);
 
         if (superclass->hasClangNode()) {
-          // As a special case, assume NSObject has a fixed layout.
-          if (superclass->getName() !=
-                IGM.Context.getSwiftId(KnownFoundationEntity::NSObject)) {
-            // If the superclass was imported from Objective-C, its size is
-            // not known at compile time. However, since the field offset
-            // vector only stores offsets of stored properties defined in
-            // Swift, we don't have to worry about indirect indexing of
-            // the field offset vector.
-            ClassHasFixedSize = false;
-          }
+          // If the superclass was imported from Objective-C, its size is
+          // not known at compile time. However, since the field offset
+          // vector only stores offsets of stored properties defined in
+          // Swift, we don't have to worry about indirect indexing of
+          // the field offset vector.
+          ClassHasFixedSize = false;
+
         } else if (IGM.isResilient(superclass, ResilienceExpansion::Maximal)) {
           ClassMetadataRequiresDynamicInitialization = true;
 

--- a/test/IRGen/class_resilience_objc.swift
+++ b/test/IRGen/class_resilience_objc.swift
@@ -7,13 +7,17 @@
 import Foundation
 
 public class FixedLayoutObjCSubclass : NSObject {
-  // This field uses constant direct access because NSObject has fixed layout.
+  // This field could use constant direct access because NSObject has
+  // fixed layout, but we don't allow that right now.
   public final var field: Int32 = 0
 };
 
 // CHECK-LABEL: define hidden void @_TF21class_resilience_objc29testConstantDirectFieldAccessFCS_23FixedLayoutObjCSubclassT_(%C21class_resilience_objc23FixedLayoutObjCSubclass*)
-// CHECK:      [[FIELD_ADDR:%.*]] = getelementptr inbounds %C21class_resilience_objc23FixedLayoutObjCSubclass, %C21class_resilience_objc23FixedLayoutObjCSubclass* %0, i32 0, i32 1
-// CHECK-NEXT: [[PAYLOAD_ADDR:%.*]] = getelementptr inbounds %Vs5Int32, %Vs5Int32* %1, i32 0, i32 0
+// CHECK:      [[OFFSET:%.*]] = load [[INT]], [[INT]]* @_TWvdvC21class_resilience_objc23FixedLayoutObjCSubclass5fieldVs5Int32
+// CHECK-NEXT: [[OBJECT:%.*]] = bitcast %C21class_resilience_objc23FixedLayoutObjCSubclass* %0 to i8*
+// CHECK-NEXT: [[ADDR:%.*]] = getelementptr inbounds i8, i8* [[OBJECT]], [[INT]] [[OFFSET]]
+// CHECK-NEXT: [[FIELD_ADDR:%.*]] = bitcast i8* [[ADDR]] to %Vs5Int32*
+// CHECK-NEXT: [[PAYLOAD_ADDR:%.*]] = getelementptr inbounds %Vs5Int32, %Vs5Int32* [[FIELD_ADDR]], i32 0, i32 0
 // CHECK-NEXT: store i32 10, i32* [[PAYLOAD_ADDR]]
 
 func testConstantDirectFieldAccess(_ o: FixedLayoutObjCSubclass) {

--- a/test/Interpreter/generic_objc_subclass.swift
+++ b/test/Interpreter/generic_objc_subclass.swift
@@ -233,3 +233,19 @@ fixedB.third = 17
 
 // CHECK: (101, 0, 0, 0, 16, [19, 84], 17)
 print(fixedG())
+
+// Problem with field alignment in direct generic subclass of NSObject -
+// <https://bugs.swift.org/browse/SR-2586>
+public class PandorasBox<T>: NSObject {
+    final public var value: T
+
+    public init(_ value: T) {
+        // Uses ConstantIndirect access pattern
+        self.value = value
+    }
+}
+
+let c = PandorasBox(30)
+// CHECK: 30
+// Uses ConstantDirect access pattern
+print(c.value)


### PR DESCRIPTION
- Description: Pretty bad miscompile when two things happen: a) the user defines a generic class inheriting directly from NSObject b) the class is final, or has a final stored property. In this case we use a more direct access pattern, but it does not match up with what the runtime does, leading to a crash.
- Risk: Low, but I need to see if this impacts remote mirrors in any way before we merge it.
- Reviewed by: @jckarter 
- Tested: New execution test added
- Radar: rdar://problem/28207605, JIRA: https://bugs.swift.org/browse/SR-2586
