### PR TITLE
[SIL] Add test case for crash triggered in swift::CanType::isReferenceTypeImpl(…)

### DIFF
--- a/validation-test/SIL/crashers/036-swift-cantype-isreferencetypeimpl.sil
+++ b/validation-test/SIL/crashers/036-swift-cantype-isreferencetypeimpl.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+func l<X{weak var c:X


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:9: error: expected '>' to complete generic parameter list
func l<X{weak var c:X
        ^
<stdin>:3:7: note: to match this opening '<'
func l<X{weak var c:X
      ^
<stdin>:3:9: error: expected '(' in argument list of function declaration
func l<X{weak var c:X
        ^
<stdin>:3:22: error: expected '}' at end of brace statement
func l<X{weak var c:X
                     ^
<stdin>:3:9: note: to match this opening '{'
func l<X{weak var c:X
        ^
Dependent types can't answer reference-semantics query
UNREACHABLE executed at /path/to/swift/lib/AST/Type.cpp:174!
6  sil-opt         0x000000000309743d llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) + 461
7  sil-opt         0x0000000000e77e13 swift::CanType::isReferenceTypeImpl(swift::CanType, bool) + 419
8  sil-opt         0x0000000000c2f52e swift::TypeChecker::checkOwnershipAttr(swift::VarDecl*, swift::OwnershipAttr*) + 190
9  sil-opt         0x0000000000c2f27c swift::TypeChecker::checkTypeModifyingDeclAttributes(swift::VarDecl*) + 76
10 sil-opt         0x0000000000b3dc8c swift::TypeChecker::coercePatternToType(swift::Pattern*&, swift::DeclContext*, swift::Type, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeLoc) + 2076
11 sil-opt         0x0000000000b3d391 swift::TypeChecker::typeCheckPattern(swift::Pattern*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) + 1041
14 sil-opt         0x0000000000af99b6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
17 sil-opt         0x0000000000b6597a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
18 sil-opt         0x0000000000b657de swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
19 sil-opt         0x0000000000b663b3 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
21 sil-opt         0x0000000000b1f461 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
22 sil-opt         0x00000000007758a9 swift::CompilerInstance::performSema() + 3289
23 sil-opt         0x000000000075ec65 main + 1813
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  While type-checking 'l' at <stdin>:3:1
2.  While type-checking declaration 0x5752658 at <stdin>:3:15
```
