### PR TITLE
[swiftc (73 vs. 5163)] Add crasher in swift::ValueDecl::getFormalAccessScope(...)

### DIFF
--- a/validation-test/compiler_crashers/28424-swift-valuedecl-getformalaccessscope.swift
+++ b/validation-test/compiler_crashers/28424-swift-valuedecl-getformalaccessscope.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+func<{{protocol A{func<extension{enum B:A


### PR DESCRIPTION
Add test case for crash triggered in `swift::ValueDecl::getFormalAccessScope(...)`.

Current number of unresolved compiler crashers: 73 (5163 resolved)

Stack trace:

```
4  swift           0x000000000110d7bb swift::ValueDecl::getFormalAccessScope(swift::DeclContext const*) const + 11
6  swift           0x0000000000f28a57 swift::TypeChecker::checkConformance(swift::NormalProtocolConformance*) + 2103
7  swift           0x0000000000f28f67 swift::TypeChecker::checkConformancesInContext(swift::DeclContext*, swift::IterableDeclContext*) + 487
14 swift           0x0000000000edfc26 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
17 swift           0x0000000000f4b744 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
18 swift           0x0000000000f78aec swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
19 swift           0x0000000000ec9506 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 1126
22 swift           0x0000000000f4a52a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
23 swift           0x0000000000f4a38e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
24 swift           0x0000000000f4af63 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
26 swift           0x0000000000f045c1 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
27 swift           0x0000000000c86e69 swift::CompilerInstance::performSema() + 3289
29 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
30 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28424-swift-valuedecl-getformalaccessscope.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28424-swift-valuedecl-getformalaccessscope-60fe38.o
1.  While type-checking '<' at validation-test/compiler_crashers/28424-swift-valuedecl-getformalaccessscope.swift:9:1
2.  While type-checking expression at [validation-test/compiler_crashers/28424-swift-valuedecl-getformalaccessscope.swift:9:7 - line:9:41] RangeText="{protocol A{func<extension{enum B:A"
3.  While type-checking 'A' at validation-test/compiler_crashers/28424-swift-valuedecl-getformalaccessscope.swift:9:8
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
