### PR TITLE
[swiftc (74 vs. 5163)] Add crasher in swift::constraints::Solution::convertBooleanTypeToBuiltinI1(…)

### DIFF
--- a/validation-test/compiler_crashers/28425-swift-constraints-solution-convertbooleantypetobuiltini.swift
+++ b/validation-test/compiler_crashers/28425-swift-constraints-solution-convertbooleantypetobuiltini.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+class a{deinit{{if(x:false


### PR DESCRIPTION
Add test case for crash triggered in `swift::constraints::Solution::convertBooleanTypeToBuiltinI1(...)`.

Current number of unresolved compiler crashers: 74 (5163 resolved)

Assertion failure in [`lib/Sema/TypeCheckNameLookup.cpp (line 254)`](https://github.com/apple/swift/blob/master/lib/Sema/TypeCheckNameLookup.cpp#L254):

```
Assertion `!type->is<TupleType>()' failed.

When executing: swift::LookupResult swift::TypeChecker::lookupMember(swift::DeclContext *, swift::Type, swift::DeclName, NameLookupOptions)
```

Assertion context:

```
  // We handle our own overriding/shadowing filtering.
  subOptions &= ~NL_RemoveOverridden;
  subOptions &= ~NL_RemoveNonVisible;

  // We can't have tuple types here; they need to be handled elsewhere.
  assert(!type->is<TupleType>());

  // Local function that performs lookup.
  auto doLookup = [&]() {
    result.clear();

```

Stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckNameLookup.cpp:254: swift::LookupResult swift::TypeChecker::lookupMember(swift::DeclContext *, swift::Type, swift::DeclName, NameLookupOptions): Assertion `!type->is<TupleType>()' failed.
9  swift           0x0000000000f7f779 swift::constraints::Solution::convertBooleanTypeToBuiltinI1(swift::Expr*, swift::constraints::ConstraintLocator*) const + 169
10 swift           0x0000000000ec95ab swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 1291
11 swift           0x0000000000ece2f4 swift::TypeChecker::typeCheckCondition(swift::Expr*&, swift::DeclContext*) + 180
12 swift           0x0000000000ece44b swift::TypeChecker::typeCheckStmtCondition(llvm::MutableArrayRef<swift::StmtConditionElement>&, swift::DeclContext*, swift::Diag<>) + 251
16 swift           0x0000000000f4b744 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
17 swift           0x0000000000f78aec swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
18 swift           0x0000000000ec9506 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 1126
21 swift           0x0000000000f4adf5 swift::TypeChecker::typeCheckDestructorBodyUntil(swift::DestructorDecl*, swift::SourceLoc) + 181
22 swift           0x0000000000f4a37b swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 27
23 swift           0x0000000000f4af63 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
25 swift           0x0000000000f045c1 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
26 swift           0x0000000000c86e69 swift::CompilerInstance::performSema() + 3289
28 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
29 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28425-swift-constraints-solution-convertbooleantypetobuiltini.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28425-swift-constraints-solution-convertbooleantypetobuiltini-0c6692.o
1.  While type-checking 'deinit' at validation-test/compiler_crashers/28425-swift-constraints-solution-convertbooleantypetobuiltini.swift:10:9
2.  While type-checking expression at [validation-test/compiler_crashers/28425-swift-constraints-solution-convertbooleantypetobuiltini.swift:10:16 - line:10:22] RangeText="{if(x:f"
3.  While type-checking expression at [validation-test/compiler_crashers/28425-swift-constraints-solution-convertbooleantypetobuiltini.swift:10:19 - line:10:22] RangeText="(x:f"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
