### PR TITLE
IRGen: Shuffle self value for witness method partial applications

### DIFF
--- a/test/IRGen/partial_apply_forwarder.sil
+++ b/test/IRGen/partial_apply_forwarder.sil
@@ -6,6 +6,22 @@ public class C : P {}
 public class D<T : P> {}
 class E {}
 
+public protocol Observable {
+  associatedtype Result
+  func subscribe<T: Observer>(o: T) -> ()
+}
+
+public protocol Observer {
+  associatedtype Result
+}
+
+sil hidden @witness_method : $@convention(thin) <S where S : Observable><O where O : Observer, S.Result == O.Result> (@in S) -> @owned @callee_owned (@in O) -> () {
+bb0(%0 : $*S):
+  %1 = witness_method $S, #Observable.subscribe!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
+  %2 = partial_apply %1<S, O, S.Result>(%0) : $@convention(witness_method) <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
+  return %2 : $@callee_owned (@in O) -> ()
+}
+
 // CHECK-LABEL: define internal %GC23partial_apply_forwarder1DCS_1C_* @_TPA_unspecialized_uncurried(%swift.refcounted*
 // CHECK: [[TYPE:%.*]] = call %swift.type* @_TMaC23partial_apply_forwarder1C()
 // CHECK: [[CAST:%.*]] = bitcast %swift.refcounted* %0 to %C23partial_apply_forwarder1E*

--- a/test/IRGen/partial_apply_forwarder.sil
+++ b/test/IRGen/partial_apply_forwarder.sil
@@ -15,10 +15,10 @@ public protocol Observer {
   associatedtype Result
 }
 
-sil hidden @witness_method : $@convention(thin) <S where S : Observable><O where O : Observer, S.Result == O.Result> (@in S) -> @owned @callee_owned (@in O) -> () {
+sil hidden @witness_method : $@convention(thin) <S where S : Observable><O where O : Observer, O.Result == S.Result> (@in S) -> @owned @callee_owned (@in O) -> () {
 bb0(%0 : $*S):
-  %1 = witness_method $S, #Observable.subscribe!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
-  %2 = partial_apply %1<S, O, S.Result>(%0) : $@convention(witness_method) <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
+  %1 = witness_method $S, #Observable.subscribe!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_1_0.Result == τ_0_0.Result> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
+  %2 = partial_apply %1<S, S.Result, O>(%0) : $@convention(witness_method) <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_1_0.Result == τ_0_0.Result> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
   return %2 : $@callee_owned (@in O) -> ()
 }
 


### PR DESCRIPTION
• Explanation: Partial applies of generic witness methods resulted in a compiler crash. We needed to splice self inbetween the polymorphic arguments and the error argument but before the self metadata and witness table arguments.

• Scope of Issue: Partial applications of generic witness calls are affected.

• Origination: This probably never worked.

• Risk: Low. 

• Testing: A regression test was added. The project that reported the issue compiles successfully.

• Directions for QE: Verified by regression test added.

rdar://problem/28302820
