### PR TITLE
[SourceKit] Align closures inside function arguments. (3.0)

### DIFF
--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -232,6 +232,10 @@ public:
     return LineAndColumn;
   }
 
+  bool exprEndAtLine(Expr *E, unsigned Line) {
+    return E->getEndLoc().isValid() && SM.getLineNumber(E->getEndLoc()) == Line;
+  };
+
   bool shouldAddIndentForLine(unsigned Line) {
     if (Cursor == Stack.rend())
       return false;
@@ -399,14 +403,27 @@ public:
     //    Character(UnicodeScalar(c))
     //  }) <--- No indentation here.
     auto AtCursorExpr = Cursor->getAsExpr();
-    if (AtCursorExpr && (isa<ParenExpr>(AtCursorExpr) ||
-                         isa<TupleExpr>(AtCursorExpr))) {
-      if (AtExprEnd && isa<CallExpr>(AtExprEnd)) {
-        if (AtExprEnd->getEndLoc().isValid() &&
-            AtCursorExpr->getEndLoc().isValid() &&
-            Line == SM.getLineNumber(AtExprEnd->getEndLoc()) &&
-            Line == SM.getLineNumber(AtCursorExpr->getEndLoc())) {
+    if (AtExprEnd && AtCursorExpr && (isa<ParenExpr>(AtCursorExpr) ||
+                                      isa<TupleExpr>(AtCursorExpr))) {
+      if (isa<CallExpr>(AtExprEnd)) {
+        if (exprEndAtLine(AtExprEnd, Line) &&
+            exprEndAtLine(AtCursorExpr, Line)) {
           return false;
+        }
+      }
+
+      // foo(A: {
+      //  ...
+      // }, B: { <--- No indentation here.
+      //  ...
+      // })
+      if (auto *TE = dyn_cast<TupleExpr>(AtCursorExpr)) {
+        if (isa<ClosureExpr>(AtExprEnd) && exprEndAtLine(AtExprEnd, Line)) {
+          for (auto *ELE : TE->getElements()) {
+            if (exprEndAtLine(ELE, Line)) {
+              return false;
+            }
+          }
         }
       }
     }

--- a/test/SourceKit/CodeFormat/indent-closure.swift
+++ b/test/SourceKit/CodeFormat/indent-closure.swift
@@ -42,6 +42,16 @@ func foo6() {
   })
 }
 
+func foo7(A: ()->(), B: ()->()) {}
+
+func foo8() {
+  foo7(A: { _ in
+    print("hello")
+}, B: {
+    print("world")
+  })
+}
+
 // RUN: %sourcekitd-test -req=format -line=3 -length=1 %s >%t.response
 // RUN: %sourcekitd-test -req=format -line=4 -length=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=5 -length=1 %s >>%t.response
@@ -57,6 +67,7 @@ func foo6() {
 // RUN: %sourcekitd-test -req=format -line=31 -length=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=32 -length=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=42 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=50 -length=1 %s >>%t.response
 // RUN: %FileCheck --strict-whitespace %s <%t.response
 
 // CHECK: key.sourcetext: "        var abc = 1"
@@ -81,3 +92,5 @@ func foo6() {
 // CHECK: key.sourcetext: "    }()"
 
 // CHECK: key.sourcetext: "  })"
+
+// CHECK: key.sourcetext: "  }, B: {"


### PR DESCRIPTION
- Explanation: When indenting a function call taking multiple closures across several lines, the users expect to see these closures align with each other like siblings. This patch adjust our indentation algorithm to incorporate this special case.
- Reviewer: Argyrios
-  Scope of Issue: A special case of Indentation; SourceKit.
- Risk: Very Low.
- Testing: A regression test was added.
