### PR TITLE
Improvements to casting/metadata of tuple types

### DIFF
--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -2497,6 +2497,51 @@ static bool _dynamicCastStructToStruct(OpaqueValue *destination,
   return result;
 }
 
+static bool _dynamicCastTupleToTuple(OpaqueValue *destination,
+                                     OpaqueValue *source,
+                                     const TupleTypeMetadata *sourceType,
+                                     const TupleTypeMetadata *targetType,
+                                     DynamicCastFlags flags) {
+  assert(sourceType != targetType &&
+         "Caller should handle exact tuple matches");
+
+
+  // Simple case: number of elements mismatches.
+  if (sourceType->NumElements != targetType->NumElements)
+    return _fail(source, sourceType, targetType, flags);
+
+  // Check that the elements line up.
+  const char *sourceLabels = sourceType->Labels;
+  const char *targetLabels = targetType->Labels;
+  for (unsigned i = 0, n = sourceType->NumElements; i != n; ++i) {
+    // Check the label, if there is one.
+    if (sourceLabels && targetLabels && sourceLabels != targetLabels) {
+      const char *sourceSpace = strchr(sourceLabels, ' ');
+      const char *targetSpace = strchr(targetLabels, ' ');
+
+      // If both have labels, and the labels mismatch, we fail.
+      if (sourceSpace && sourceSpace != sourceLabels &&
+          targetSpace && targetSpace != targetLabels) {
+        unsigned sourceLen = sourceSpace - sourceLabels;
+        unsigned targetLen = targetSpace - targetLabels;
+        if (sourceLen != targetLen ||
+            strncmp(sourceLabels, targetLabels, sourceLen) != 0)
+          return _fail(source, sourceType, targetType, flags);
+      }
+
+      sourceLabels = sourceSpace ? sourceSpace + 1 : nullptr;
+      targetLabels = targetSpace ? targetSpace + 1 : nullptr;
+    }
+
+    // Make sure the types match exactly.
+    // FIXME: we should dynamically cast the elements themselves.
+    if (sourceType->getElement(i).Type != targetType->getElement(i).Type)
+      return _fail(source, sourceType, targetType, flags);
+  }
+
+  return _succeed(destination, source, targetType, flags);
+}
+
 /******************************************************************************/
 /****************************** Main Entrypoint *******************************/
 /******************************************************************************/
@@ -2716,6 +2761,15 @@ bool swift::swift_dynamicCast(OpaqueValue *dest,
     if (auto srcExistentialType = dyn_cast<ExistentialTypeMetadata>(srcType)) {
       return _dynamicCastFromExistential(dest, src, srcExistentialType,
                                          targetType, flags);
+    }
+
+    // If both are tuple types, allow the cast to add/remove labels.
+    if (srcType->getKind() == MetadataKind::Tuple &&
+        targetType->getKind() == MetadataKind::Tuple) {
+      return _dynamicCastTupleToTuple(dest, src,
+                                      cast<TupleTypeMetadata>(srcType),
+                                      cast<TupleTypeMetadata>(targetType),
+                                      flags);
     }
 
     // Otherwise, we have a failure.

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -285,9 +285,26 @@ static void _buildNameForMetadata(const Metadata *type,
     auto tuple = static_cast<const TupleTypeMetadata *>(type);
     result += "(";
     auto elts = tuple->getElements();
+    const char *labels = tuple->Labels;
     for (unsigned i = 0, e = tuple->NumElements; i < e; ++i) {
       if (i > 0)
         result += ", ";
+
+      // If we have any labels, add the label.
+      if (labels) {
+        // Labels are space-separated.
+        if (const char *space = strchr(labels, ' ')) {
+          if (labels != space) {
+            result.append(labels, space - labels);
+            result += ": ";
+          }
+
+          labels = space + 1;
+        } else {
+          labels = nullptr;
+        }
+      }
+
       _buildNameForMetadata(elts[i].Type, TypeSyntaxLevel::Type, qualified,
                             result);
     }

--- a/test/Interpreter/tuple_casts.swift
+++ b/test/Interpreter/tuple_casts.swift
@@ -1,0 +1,30 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// RUN: %target-build-swift -O %s -o %t/a.out.optimized
+// RUN: %target-run %t/a.out.optimized | %FileCheck %s
+// REQUIRES: executable_test
+
+func anyToIntPoint(_ x: Any) -> (x: Int, y: Int) {
+  return x as! (x: Int, y: Int)
+}
+
+func anyToIntPointOpt(_ x: Any) -> (x: Int, y: Int)? {
+  return x as? (x: Int, y: Int)
+}
+
+func anyToInt2(_ x: Any) -> (Int, Int) {
+  return x as! (Int, Int)
+}
+
+// Labels can be added/removed.
+print("Label add/remove")          // CHECK: Label add/remove
+print(anyToIntPoint((x: 1, y: 2))) // CHECK-NEXT: (1, 2)
+print(anyToIntPoint((3, 4)))       // CHECK-NEXT: (3, 4)
+print(anyToIntPoint((x: 5, 6)))    // CHECK-NEXT: (5, 6)
+print(anyToInt2((1, 2)))           // CHECK-NEXT: (1, 2)
+print(anyToInt2((x: 3, y: 4)))     // CHECK-NEXT: (3, 4)
+print(anyToInt2((x: 5, 6)))        // CHECK-NEXT: (5, 6)
+
+// Labels cannot be wrong.
+print("Wrong labels")                 // CHECK: Wrong labels
+print(anyToIntPointOpt((x: 1, z: 2))) // CHECK-NEXT: nil
+print(anyToIntPointOpt((x: 1, y: 2))) // CHECK-NEXT: Optional((1, 2))

--- a/test/Interpreter/typeof.swift
+++ b/test/Interpreter/typeof.swift
@@ -51,6 +51,10 @@ class Meltdown : Error {
 
 class GrilledCheese : Meltdown {}
 
+func labeledTuple() -> (x: Int, y: Int, Double) {
+  return (x: 1, y: 1, 3.14159)
+}
+
 // CHECK: Beads?
 classMetatype(type(of: B()))
 // CHECK: Deeds?
@@ -81,3 +85,5 @@ print(boxedExistentialMetatype(Meltdown()))
 print(boxedExistentialMetatype(GrilledCheese()))
 // CHECK: GrilledCheese
 print(boxedExistentialMetatype(GrilledCheese() as Meltdown))
+// CHECK: (x: Int, y: Int, Double)
+print(type(of: labeledTuple()))

--- a/test/SILOptimizer/cast_folding.swift
+++ b/test/SILOptimizer/cast_folding.swift
@@ -11,6 +11,7 @@ protocol P {}
 protocol Q: P {}
 
 class A:P {}
+class AA:A {}
 
 class X {}
 
@@ -202,6 +203,18 @@ func cast32(_ p: P) -> Bool {
 func cast33(_ p: P) -> Bool {
   // Same as above, but non-existential metatype
   return p is X.Type
+}
+
+func cast38<T>(_ t: T) -> Bool {
+  return t is (Int, Int)
+}
+
+func cast39<T>(_ t: T) -> Bool {
+  return t is (x: Int, y: Int)
+}
+
+func cast40<T>(_ t: T) -> Bool {
+  return t is (x: Int, y: A)
 }
 
 // CHECK-LABEL: sil hidden [noinline] @_TF12cast_folding5test0FT_Sb : $@convention(thin) () -> Bool
@@ -798,6 +811,114 @@ public func test37<T>(ah: T) {
   }
 }
 
+// CHECK-LABEL: sil [noinline] @_TF12cast_folding7test38a
+// CHECK: bb0
+// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: %1 = struct $Bool
+// CHECK-NEXT: return %1
+@inline(never)
+public func test38a() -> Bool {
+  return cast38((1, 2))
+}
+
+// CHECK-LABEL: sil [noinline] @_TF12cast_folding7test38b
+// CHECK: bb0
+// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: %1 = struct $Bool
+// CHECK-NEXT: return %1
+@inline(never)
+public func test38b() -> Bool {
+  return cast38((x: 1, y: 2))
+}
+
+// CHECK-LABEL: sil [noinline] @_TF12cast_folding7test38c
+// CHECK: bb0
+// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: %1 = struct $Bool
+// CHECK-NEXT: return %1
+@inline(never)
+public func test38c() -> Bool {
+  return cast38((z: 1, y: 2))
+}
+
+// CHECK-LABEL: sil [noinline] @_TF12cast_folding7test39a
+// CHECK: bb0
+// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: %1 = struct $Bool
+// CHECK-NEXT: return %1
+@inline(never)
+public func test39a() -> Bool {
+  return cast39((1, 2))
+}
+
+// CHECK-LABEL: sil [noinline] @_TF12cast_folding7test39b
+// CHECK: bb0
+// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: %1 = struct $Bool
+// CHECK-NEXT: return %1
+@inline(never)
+public func test39b() -> Bool {
+  return cast39((x: 1, y: 2))
+}
+
+// CHECK-LABEL: sil [noinline] @_TF12cast_folding7test39c
+// CHECK: bb0
+// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: %1 = struct $Bool
+// CHECK-NEXT: return %1
+@inline(never)
+public func test39c() -> Bool {
+  return cast39((z: 1, y: 2))
+}
+
+// CHECK-LABEL: sil [noinline] @_TF12cast_folding7test39d
+// CHECK: bb0
+// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: %1 = struct $Bool
+// CHECK-NEXT: return %1
+@inline(never)
+public func test39d() -> Bool {
+  return cast39((1, 2, 3))
+}
+
+// CHECK-LABEL: sil [noinline] @_TF12cast_folding7test40a
+// CHECK: bb0
+// FIXME: Would love to fold this to just "true"
+// CHECK-NOT: return:
+// CHECK: unconditional_checked_cast_addr
+@inline(never)
+public func test40a() -> Bool {
+  return cast40((1, A()))
+}
+
+// CHECK-LABEL: sil [noinline] @_TF12cast_folding7test40b
+// CHECK: bb0
+// FIXME: Would love to fold this to just "true"
+// CHECK-NOT: return:
+// CHECK: unconditional_checked_cast_addr
+@inline(never)
+public func test40b() -> Bool {
+  return cast40((1, AA()))
+}
+
+// CHECK-LABEL: sil [noinline] @_TF12cast_folding7test40c
+// CHECK: bb0
+// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: %1 = struct $Bool
+// CHECK-NEXT: return %1
+@inline(never)
+public func test40c() -> Bool {
+  return cast40((1, S()))
+}
+
+// CHECK-LABEL: sil [noinline] @_TF12cast_folding7test40d
+// CHECK: bb0
+// CHECK-NOT: return
+// CHECK: checked_cast_addr_br take_always (Int, Any) in
+@inline(never)
+public func test40d(_ a: Any) -> Bool {
+  return cast40((1, a))
+}
 
 print("test0=\(test0())")
 


### PR DESCRIPTION
<!-- What's in this pull request? -->

Introduce a number of small improvements to our handling of tuple types:
- When forming a type name from tuple metadata, include the labels (e.g., for dynamic casting failure diagnostics)
- Teach the SIL optimizer about casting between tuple types
- Teach the runtime dynamic casting implementation to allow adding/dropping labels

There's still a bit more work to do here: we should perform per-element casting in the runtime, and printing of tuples doesn't include the labels.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [rdar://problem/28121915](rdar://problem/28121915).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
