### PR TITLE
[gardening] fix enum value spacing

### DIFF
--- a/stdlib/public/Platform/MachError.swift
+++ b/stdlib/public/Platform/MachError.swift
@@ -1,7 +1,7 @@
 #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS)
 /// Enumeration describing Mach error codes.
 @objc public enum MachErrorCode : Int32 {
-  case success                   = 0
+  case success                  = 0
 
   /// Specified address is not currently valid.
   case invalidAddress           = 1
@@ -19,7 +19,7 @@
   case invalidArgument          = 4
 
   /// The function could not be performed.  A catch-all.
-  case failure                   = 5
+  case failure                  = 5
 
   /// A system resource could not be allocated to fulfill this
   /// request.  This failure may not be permanent.
@@ -68,7 +68,7 @@
   case invalidValue             = 18
 
   /// Operation would overflow limit on user-references.
-  case userReferencesOverflow            = 19
+  case userReferencesOverflow   = 19
 
   /// The supplied (port) capability is improper.
   case invalidCapability        = 20


### PR DESCRIPTION
<!-- What's in this pull request? -->

The spacing was not uniform in `MachError.swift` when I was reading through it, so
I thought it might be worth fixing up! 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
