### PR TITLE
Emit a warning when optionals are coerced to Any.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2331,11 +2331,11 @@ WARNING(optional_pattern_match_promotion,none,
 WARNING(optional_to_any_coercion,none,
         "expression implicitly coerced from %0 to Any", (Type))
 NOTE(default_optional_to_any,none,
-     "provide a default value to avoid the warning", ())
+     "provide a default value to avoid this warning", ())
 NOTE(force_optional_to_any,none,
-     "force-unwrap the value to avoid the warning", ())
+     "force-unwrap the value to avoid this warning", ())
 NOTE(silence_optional_to_any,none,
-     "explicitly cast to Any with 'as Any' to silence the warning", ())
+     "explicitly cast to Any with 'as Any' to silence this warning", ())
 
 ERROR(invalid_noescape_use,none,
       "non-escaping %select{value|parameter}1 %0 may only be called",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2328,7 +2328,14 @@ WARNING(optional_check_promotion,none,
 WARNING(optional_pattern_match_promotion,none,
         "pattern match introduces an implicit promotion from %0 to %1",
         (Type, Type))
-
+WARNING(optional_to_any_coercion,none,
+        "expression implicitly coerced from %0 to Any", (Type))
+NOTE(default_optional_to_any,none,
+     "provide a default value to avoid the warning", ())
+NOTE(force_optional_to_any,none,
+     "force-unwrap the value to avoid the warning", ())
+NOTE(silence_optional_to_any,none,
+     "explicitly cast to Any with 'as Any' to silence the warning", ())
 
 ERROR(invalid_noescape_use,none,
       "non-escaping %select{value|parameter}1 %0 may only be called",

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3596,7 +3596,7 @@ checkImplicitPromotionsInCondition(const StmtConditionElement &cond,
 
 static void diagnoseOptionalToAnyCoercion(TypeChecker &TC, const Expr *E,
                                           const DeclContext *DC) {
-  if (E == nullptr || isa<ErrorExpr>(E) || !E->getType())
+  if (!E || isa<ErrorExpr>(E) || !E->getType())
     return;
 
   class OptionalToAnyCoercionWalker : public ASTWalker {
@@ -3608,13 +3608,12 @@ static void diagnoseOptionalToAnyCoercion(TypeChecker &TC, const Expr *E,
         return { false, E };
 
       if (auto *coercion = dyn_cast<CoerceExpr>(E)) {
-        if (E->getType()->getDesugaredType()->isAny() &&
-            isa<ErasureExpr>(coercion->getSubExpr()))
+        if (E->getType()->isAny() && isa<ErasureExpr>(coercion->getSubExpr()))
           ErasureCoercedToAny.insert(coercion->getSubExpr());
       } else if (isa<ErasureExpr>(E) && !ErasureCoercedToAny.count(E) &&
-                 E->getType()->getDesugaredType()->isAny()) {
+                 E->getType()->isAny()) {
         auto subExpr = cast<ErasureExpr>(E)->getSubExpr();
-        auto erasedTy = subExpr->getType()->getDesugaredType();
+        auto erasedTy = subExpr->getType();
         if (erasedTy->getOptionalObjectType()) {
           TC.diagnose(subExpr->getStartLoc(), diag::optional_to_any_coercion,
                       erasedTy)

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3593,7 +3593,56 @@ checkImplicitPromotionsInCondition(const StmtConditionElement &cond,
       .highlight(subExpr->getSourceRange());
   }
 }
-        
+
+static void diagnoseOptionalToAnyCoercion(TypeChecker &TC, const Expr *E,
+                                          const DeclContext *DC) {
+  if (E == nullptr || isa<ErrorExpr>(E) || !E->getType())
+    return;
+
+  class OptionalToAnyCoercionWalker : public ASTWalker {
+    TypeChecker &TC;
+    SmallPtrSet<Expr *, 4> ErasureCoercedToAny;
+
+    virtual std::pair<bool, Expr *> walkToExprPre(Expr *E) {
+      if (!E || isa<ErrorExpr>(E) || !E->getType())
+        return { false, E };
+
+      if (auto *coercion = dyn_cast<CoerceExpr>(E)) {
+        if (E->getType()->getDesugaredType()->isAny() &&
+            isa<ErasureExpr>(coercion->getSubExpr()))
+          ErasureCoercedToAny.insert(coercion->getSubExpr());
+      } else if (isa<ErasureExpr>(E) && !ErasureCoercedToAny.count(E) &&
+                 E->getType()->getDesugaredType()->isAny()) {
+        auto subExpr = cast<ErasureExpr>(E)->getSubExpr();
+        auto erasedTy = subExpr->getType()->getDesugaredType();
+        if (erasedTy->getOptionalObjectType()) {
+          TC.diagnose(subExpr->getStartLoc(), diag::optional_to_any_coercion,
+                      erasedTy)
+              .highlight(subExpr->getSourceRange());
+
+          TC.diagnose(subExpr->getLoc(), diag::default_optional_to_any)
+              .highlight(subExpr->getSourceRange())
+              .fixItInsertAfter(subExpr->getEndLoc(), " ?? <#default value#>");
+          TC.diagnose(subExpr->getLoc(), diag::force_optional_to_any)
+              .highlight(subExpr->getSourceRange())
+              .fixItInsertAfter(subExpr->getEndLoc(), "!");
+          TC.diagnose(subExpr->getLoc(), diag::silence_optional_to_any)
+              .highlight(subExpr->getSourceRange())
+              .fixItInsertAfter(subExpr->getEndLoc(), " as Any");
+        }
+      }
+
+      return { true, E };
+    }
+
+  public:
+    OptionalToAnyCoercionWalker(TypeChecker &tc) : TC(tc) { }
+  };
+
+  OptionalToAnyCoercionWalker Walker(TC);
+  const_cast<Expr *>(E)->walk(Walker);
+}
+
 //===----------------------------------------------------------------------===//
 // High-level entry points.
 //===----------------------------------------------------------------------===//
@@ -3606,6 +3655,7 @@ void swift::performSyntacticExprDiagnostics(TypeChecker &TC, const Expr *E,
   diagSyntacticUseRestrictions(TC, E, DC, isExprStmt);
   diagRecursivePropertyAccess(TC, E, DC);
   diagnoseImplicitSelfUseInClosure(TC, E, DC);
+  diagnoseOptionalToAnyCoercion(TC, E, DC);
   if (!TC.getLangOpts().DisableAvailabilityChecking)
     diagAvailability(TC, E, const_cast<DeclContext*>(DC));
   if (TC.Context.LangOpts.EnableObjCInterop)

--- a/test/ClangModules/accessibility_framework.swift
+++ b/test/ClangModules/accessibility_framework.swift
@@ -26,4 +26,4 @@ class AA: NSView {
 }
 
 let a = A()
-print(a.accessibilityLabel(), terminator: "")
+print(a.accessibilityLabel() as Any, terminator: "")

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -171,7 +171,7 @@ func dictionaryToNSDictionary() {
 
   // <rdar://problem/17134986>
   var bcOpt: BridgedClass?
-  nsd = [BridgedStruct() : bcOpt]
+  nsd = [BridgedStruct() : bcOpt as Any]
   bcOpt = nil
   _ = nsd
 }

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -146,8 +146,8 @@ func SR2066(x: Int?) {
 // Test x???? patterns.
 switch (nil as Int???) {
 case let x???: print(x, terminator: "")
-case let x??: print(x, terminator: "")
-case let x?: print(x, terminator: "")
+case let x??: print(x as Any, terminator: "")
+case let x?: print(x as Any, terminator: "")
 case 4???: break
 case nil??: break
 case nil?: break

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -1121,7 +1121,7 @@ func test22436880() {
 
 // sr-184
 let x: String? // expected-note 2 {{constant defined here}}
-print(x?.characters.count) // expected-error {{constant 'x' used before being initialized}}
+print(x?.characters.count as Any) // expected-error {{constant 'x' used before being initialized}}
 print(x!) // expected-error {{constant 'x' used before being initialized}}
 
 

--- a/test/Sema/diag_optional_to_any.swift
+++ b/test/Sema/diag_optional_to_any.swift
@@ -1,0 +1,67 @@
+// RUN: %target-parse-verify-swift
+
+func takeAny(_ left: Any, _ right: Any) -> Int? {
+  return left as? Int
+}
+
+func throwing() throws -> Int? {}
+
+func warnOptionalToAnyCoercion(value x: Int?) -> Any {
+  let a: Any = x // expected-warning {{expression implicitly coerced from 'Optional<Int>' to Any}}
+  // expected-note@-1 {{provide a default value to avoid the warning}}
+  // expected-note@-2 {{force-unwrap the value to avoid the warning}}
+  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence}}
+
+  let b: Any = x as Any
+
+  let c: Any = takeAny(a, b) // expected-warning {{expression implicitly coerced from 'Optional<Int>' to Any}}
+  // expected-note@-1 {{provide a default value to avoid the warning}}
+  // expected-note@-2 {{force-unwrap the value to avoid the warning}}
+  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence}}
+
+  let d: Any = takeAny(c, c) as Any
+
+  let e: Any = (x)  // expected-warning {{expression implicitly coerced from 'Optional<Int>' to Any}}
+  // expected-note@-1 {{provide a default value to avoid the warning}}
+  // expected-note@-2 {{force-unwrap the value to avoid the warning}}
+  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence}}
+
+  _ = takeAny(d, e)
+
+  let f: Any = (x as Any)
+  let g: Any = (x) as (Any)
+
+  _ = takeAny(f as? Int, g) // expected-warning {{expression implicitly coerced from 'Optional<Int>' to Any}}
+  // expected-note@-1 {{provide a default value to avoid the warning}}
+  // expected-note@-2 {{force-unwrap the value to avoid the warning}}
+  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence}}
+
+  let h: Any = takeAny(f as? Int, g) as Any // expected-warning {{expression implicitly coerced from 'Optional<Int>' to Any}}
+  // expected-note@-1 {{provide a default value to avoid the warning}}
+  // expected-note@-2 {{force-unwrap the value to avoid the warning}}
+  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence}}
+
+  let i: Any = takeAny(f as? Int as Any, g) as Any
+
+  _ = takeAny(h, i)
+
+  let j: Any = x! == x! ? 1 : x // expected-warning {{expression implicitly coerced from 'Optional<Int>' to Any}}
+  // expected-note@-1 {{provide a default value to avoid the warning}}
+  // expected-note@-2 {{force-unwrap the value to avoid the warning}}
+  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence}}
+
+  let k: Any
+  do {
+    k = try throwing() // expected-warning {{expression implicitly coerced from 'Optional<Int>' to Any}}
+    // expected-note@-1 {{provide a default value to avoid the warning}}
+    // expected-note@-2 {{force-unwrap the value to avoid the warning}}
+    // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence}}
+  } catch {}
+
+  _ = takeAny(j, k)
+
+  return x // expected-warning {{expression implicitly coerced from 'Optional<Int>' to Any}}
+  // expected-note@-1 {{provide a default value to avoid the warning}}
+  // expected-note@-2 {{force-unwrap the value to avoid the warning}}
+  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence}}
+}

--- a/test/Sema/diag_optional_to_any.swift
+++ b/test/Sema/diag_optional_to_any.swift
@@ -7,61 +7,54 @@ func takeAny(_ left: Any, _ right: Any) -> Int? {
 func throwing() throws -> Int? {}
 
 func warnOptionalToAnyCoercion(value x: Int?) -> Any {
-  let a: Any = x // expected-warning {{expression implicitly coerced from 'Optional<Int>' to Any}}
-  // expected-note@-1 {{provide a default value to avoid the warning}}
-  // expected-note@-2 {{force-unwrap the value to avoid the warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence}}
+  let a: Any = x // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}
+  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
 
   let b: Any = x as Any
 
-  let c: Any = takeAny(a, b) // expected-warning {{expression implicitly coerced from 'Optional<Int>' to Any}}
-  // expected-note@-1 {{provide a default value to avoid the warning}}
-  // expected-note@-2 {{force-unwrap the value to avoid the warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence}}
+  let c: Any = takeAny(a, b) // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}
+  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
 
-  let d: Any = takeAny(c, c) as Any
+  let _: Any = takeAny(c, c) as Any
 
-  let e: Any = (x)  // expected-warning {{expression implicitly coerced from 'Optional<Int>' to Any}}
-  // expected-note@-1 {{provide a default value to avoid the warning}}
-  // expected-note@-2 {{force-unwrap the value to avoid the warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence}}
-
-  _ = takeAny(d, e)
+  let _: Any = (x)  // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}
+  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
 
   let f: Any = (x as Any)
   let g: Any = (x) as (Any)
 
-  _ = takeAny(f as? Int, g) // expected-warning {{expression implicitly coerced from 'Optional<Int>' to Any}}
-  // expected-note@-1 {{provide a default value to avoid the warning}}
-  // expected-note@-2 {{force-unwrap the value to avoid the warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence}}
+  _ = takeAny(f as? Int, g) // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}
+  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
 
-  let h: Any = takeAny(f as? Int, g) as Any // expected-warning {{expression implicitly coerced from 'Optional<Int>' to Any}}
-  // expected-note@-1 {{provide a default value to avoid the warning}}
-  // expected-note@-2 {{force-unwrap the value to avoid the warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence}}
+  let _: Any = takeAny(f as? Int, g) as Any // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}
+  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
 
-  let i: Any = takeAny(f as? Int as Any, g) as Any
+  let _: Any = takeAny(f as? Int as Any, g) as Any
 
-  _ = takeAny(h, i)
+  let _: Any = x! == x! ? 1 : x // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}
+  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
 
-  let j: Any = x! == x! ? 1 : x // expected-warning {{expression implicitly coerced from 'Optional<Int>' to Any}}
-  // expected-note@-1 {{provide a default value to avoid the warning}}
-  // expected-note@-2 {{force-unwrap the value to avoid the warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence}}
-
-  let k: Any
   do {
-    k = try throwing() // expected-warning {{expression implicitly coerced from 'Optional<Int>' to Any}}
-    // expected-note@-1 {{provide a default value to avoid the warning}}
-    // expected-note@-2 {{force-unwrap the value to avoid the warning}}
-    // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence}}
+    let _: Any = try throwing() // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+    // expected-note@-1 {{provide a default value to avoid this warning}}
+    // expected-note@-2 {{force-unwrap the value to avoid this warning}}
+    // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
   } catch {}
 
-  _ = takeAny(j, k)
-
-  return x // expected-warning {{expression implicitly coerced from 'Optional<Int>' to Any}}
-  // expected-note@-1 {{provide a default value to avoid the warning}}
-  // expected-note@-2 {{force-unwrap the value to avoid the warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence}}
+  return x // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}
+  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
 }


### PR DESCRIPTION
Pulling this diagnostic change for SE-0140 into swift-3.0-branch.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

Emit a warning for optionals that are implicitly converted to Any, and
add fixits giving options to:
- Add '??' with a default value after
- Force-unwrap the optional with '!'
- Explicitly cast to 'as Any' to silence the warning

This covers diagnostics aspect of SE-0140.

rdar://problem/28196843
