### PR TITLE
Fix for ToolchainTestCase failure on non-FreeBSD systems

### DIFF
--- a/utils/swift_build_support/swift_build_support/toolchain.py
+++ b/utils/swift_build_support/swift_build_support/toolchain.py
@@ -137,10 +137,14 @@ class Linux(GenericUnix):
 
 class FreeBSD(GenericUnix):
     def __init__(self):
+        # For testing toolchain initializer on non-FreeBSD systems
+        sys = platform.system()
+        if sys != 'FreeBSD':
+            suffixes = ['']
         # See: https://github.com/apple/swift/pull/169
         # Building Swift from source requires a recent version of the Clang
         # compiler with C++14 support.
-        if self._release_date and self._release_date >= 1100000:
+        elif self._release_date and self._release_date >= 1100000:
             suffixes = ['']
         else:
             suffixes = ['38', '37', '36', '35']


### PR DESCRIPTION
<!-- What's in this pull request? -->

ToolchainTestCase tried to instantiate every toolchain even when it isn't the current platform.  This failed on SLES 12 where `sysctl -n kern.osreldate` resulted in error.  For the FreeBSD toolchain, we can check whether we are on FreeBSD before we call `_release_date`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-1838](https://bugs.swift.org/browse/SR-1838).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

Tagging @ddunbar for his attention.  Thanks.
