### PR TITLE
Remove extra closing bracket from build script

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -771,7 +771,7 @@ function configure_default_options() {
         local default_value="${KNOWN_SETTINGS[$((i+1))]}"
 
         # Find the variable name in our lookup table.
-        local varname="${known_setting_varnames[$((i/3))]]}"
+        local varname="${known_setting_varnames[$((i/3))]}"
 
         # Establish the associative array mapping.
         eval "${setting//-/_}_VARNAME=${varname}"


### PR DESCRIPTION
This resulted in a bad substitution for me when running

```
swift/utils/build-script --swiftpm --llbuild
```

Let me know if I'm missing something here since I assume if this had been broken for everyone since it was last changed, it would have been fixed by now.
