### PR TITLE
Remove incorrect early exit from type access checking.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1110,6 +1110,13 @@ ERROR(pattern_type_access,none,
       "because its type uses "
       "%select{a private|a fileprivate|an internal|PUBLIC}4 type",
       (bool, bool, bool, Accessibility, Accessibility))
+WARNING(pattern_type_access_warn,none,
+        "%select{%select{variable|constant}0|property}1 "
+        "%select{should be declared %select{private|fileprivate|internal|PUBLIC}4"
+        "|should not be declared %select{in this context|fileprivate|internal|public}3}2 "
+        "because its type uses "
+        "%select{a private|a fileprivate|an internal|PUBLIC}4 type",
+        (bool, bool, bool, Accessibility, Accessibility))
 ERROR(pattern_type_access_inferred,none,
       "%select{%select{variable|constant}0|property}1 "
       "%select{must be declared %select{private|fileprivate|internal|PUBLIC}4"
@@ -1117,6 +1124,13 @@ ERROR(pattern_type_access_inferred,none,
       "because its type %5 uses "
       "%select{a private|a fileprivate|an internal|PUBLIC}4 type",
       (bool, bool, bool, Accessibility, Accessibility, Type))
+WARNING(pattern_type_access_inferred_warn,none,
+        "%select{%select{variable|constant}0|property}1 "
+        "%select{should be declared %select{private|fileprivate|internal|PUBLIC}4"
+        "|should not be declared %select{in this context|fileprivate|internal|public}3}2 "
+        "because its type %5 uses "
+        "%select{a private|a fileprivate|an internal|PUBLIC}4 type",
+        (bool, bool, bool, Accessibility, Accessibility, Type))
 ERROR(pattern_binds_no_variables,none,
       "%select{property|global variable}0 declaration does not bind any "
       "variables",
@@ -1156,6 +1170,13 @@ ERROR(type_alias_underlying_type_access,none,
       "because its underlying type uses "
       "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
       (bool, Accessibility, Accessibility))
+WARNING(type_alias_underlying_type_access_warn,none,
+        "type alias %select{should be declared "
+        "%select{private|fileprivate|internal|PUBLIC}2"
+        "|should not be declared %select{PRIVATE|fileprivate|internal|public}1}0 "
+        "because its underlying type uses "
+        "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
+        (bool, Accessibility, Accessibility))
 
 // Subscripts
 ERROR(subscript_type_access,none,
@@ -1165,6 +1186,13 @@ ERROR(subscript_type_access,none,
       "because its %select{index|element type}3 uses "
       "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
       (bool, Accessibility, Accessibility, bool))
+WARNING(subscript_type_access_warn,none,
+        "subscript %select{should be declared "
+        "%select{private|fileprivate|internal|PUBLIC}2"
+        "|should not be declared %select{in this context|fileprivate|internal|public}1}0 "
+        "because its %select{index|element type}3 uses "
+        "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
+        (bool, Accessibility, Accessibility, bool))
 
 // Functions
 ERROR(function_type_access,none,
@@ -1174,6 +1202,13 @@ ERROR(function_type_access,none,
       "because its %select{parameter|result}4 uses "
       "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
       (bool, Accessibility, Accessibility, unsigned, bool))
+WARNING(function_type_access_warn,none,
+        "%select{function|method|initializer}3 "
+        "%select{should be declared %select{private|fileprivate|internal|PUBLIC}2"
+        "|should not be declared %select{in this context|fileprivate|internal|public}1}0 "
+        "because its %select{parameter|result}4 uses "
+        "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
+        (bool, Accessibility, Accessibility, unsigned, bool))
 WARNING(non_trailing_closure_before_default_args,none,
         "closure parameter prior to parameters with default arguments will "
         "not be treated as a trailing closure", ())
@@ -1304,6 +1339,12 @@ ERROR(protocol_refine_access,none,
       "|%select{PRIVATE|fileprivate|internal|public}1 protocol cannot "
       "refine}0 %select{a private|a fileprivate|an internal|PUBLIC}2 protocol",
       (bool, Accessibility, Accessibility))
+WARNING(protocol_refine_access_warn,none,
+        "%select{protocol should be declared "
+        "%select{private|fileprivate|internal|PUBLIC}2 because it refines"
+        "|%select{in this context|fileprivate|internal|public}1 protocol should not "
+        "refine}0 %select{a private|a fileprivate|an internal|PUBLIC}2 protocol",
+        (bool, Accessibility, Accessibility))
 ERROR(protocol_property_must_be_computed_var,none,
       "immutable property requirement must be declared as 'var' with a "
       "'{ get }' specifier", ())
@@ -1337,6 +1378,12 @@ ERROR(associated_type_access,none,
       "%select{a private|a fileprivate|an internal|PUBLIC}1 type in its "
       "%select{default definition|requirement}2 ",
       (Accessibility, Accessibility, unsigned))
+WARNING(associated_type_access_warn,none,
+        "associated type in "
+        "%select{a private|a fileprivate|an internal|a public}0 protocol uses "
+        "%select{a private|a fileprivate|an internal|PUBLIC}1 type in its "
+        "%select{default definition|requirement}2 ",
+        (Accessibility, Accessibility, unsigned))
 
 NOTE(bad_associated_type_deduction,none,
      "unable to infer associated type %0 for protocol %1",
@@ -1496,6 +1543,13 @@ ERROR(generic_param_access,none,
       "because its generic %select{parameter|requirement}4 uses "
       "%select{a private|a fileprivate|an internal|PUBLIC}3 type",
       (DescriptiveDeclKind, bool, Accessibility, Accessibility, bool))
+WARNING(generic_param_access_warn,none,
+        "%0 %select{should be declared "
+        "%select{private|fileprivate|internal|PUBLIC}3"
+        "|should not be declared %select{in this context|fileprivate|internal|public}2}1 "
+        "because its generic %select{parameter|requirement}4 uses "
+        "%select{a private|a fileprivate|an internal|PUBLIC}3 type",
+        (DescriptiveDeclKind, bool, Accessibility, Accessibility, bool))
 
 ERROR(override_multiple_decls_base,none,
       "declaration %0 cannot override more than one superclass declaration",
@@ -1688,6 +1742,10 @@ ERROR(enum_case_access,none,
       "enum case in %select{PRIVATE|a fileprivate|an internal|a public}0 enum "
       "uses %select{a private|a fileprivate|an internal|PUBLIC}1 type",
       (Accessibility, Accessibility))
+WARNING(enum_case_access_warn,none,
+        "enum case in %select{a private|a fileprivate|an internal|a public}0 enum "
+        "uses %select{a private|a fileprivate|an internal|PUBLIC}1 type",
+        (Accessibility, Accessibility))
 ERROR(enum_stored_property,none,
       "enums may not contain stored properties", ())
 
@@ -1716,6 +1774,13 @@ ERROR(enum_raw_type_access,none,
       "because its raw type uses "
       "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
       (bool, Accessibility, Accessibility))
+WARNING(enum_raw_type_access_warn,none,
+        "enum %select{should be declared "
+        "%select{private|fileprivate|internal|PUBLIC}2"
+        "|should not be declared %select{in this context|fileprivate|internal|public}1}0 "
+        "because its raw type uses "
+        "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
+        (bool, Accessibility, Accessibility))
 
 NOTE(enum_here,none,
      "enum %0 declared here", (Identifier))
@@ -2650,6 +2715,13 @@ ERROR(class_super_access,none,
       "because its superclass is "
       "%select{private|fileprivate|internal|PUBLIC}2",
       (bool, Accessibility, Accessibility))
+WARNING(class_super_access_warn,none,
+        "class %select{should be declared "
+        "%select{private|fileprivate|internal|PUBLIC}2"
+        "|should not be declared %select{in this context|fileprivate|internal|public}1}0 "
+        "because its superclass is "
+        "%select{private|fileprivate|internal|PUBLIC}2",
+        (bool, Accessibility, Accessibility))
 ERROR(dot_protocol_on_non_existential,none,
       "cannot use 'Protocol' with non-protocol type %0", (Type))
 ERROR(tuple_single_element,none,

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1477,6 +1477,15 @@ public:
     return diagnoser.offendingType;
   }
 };
+
+/// A uniquely-typed boolean to reduce the chances of accidentally inverting
+/// a check.
+///
+/// \see checkTypeAccessibility
+enum class DowngradeToWarning: bool {
+  No,
+  Yes
+};
 } // end anonymous namespace
 
 /// Checks if the access scope of the type described by \p TL contains
@@ -1526,11 +1535,31 @@ static void checkTypeAccessibilityImpl(
   diagnose(*typeAccessScope, complainRepr);
 }
 
+/// Checks if the access scope of the type described by \p TL is valid for the
+/// type to be the type of \p context. If it isn't, calls \p diagnose with a
+/// TypeRepr representing the offending part of \p TL.
+///
+/// The TypeRepr passed to \p diagnose may be null, in which case a particular
+/// part of the type that caused the problem could not be found. The DeclContext
+/// is never null. The DowngradeToWarning parameter is a hack to deal with
+/// early versions of Swift 3 not diagnosing certain access violations.
 static void checkTypeAccessibility(
     TypeChecker &TC, TypeLoc TL, const ValueDecl *context,
-    llvm::function_ref<void(const DeclContext *, const TypeRepr *)> diagnose) {
-  checkTypeAccessibilityImpl(TC, TL, context->getFormalAccessScope(),
-                             context->getDeclContext(), diagnose);
+    llvm::function_ref<void(const DeclContext *, const TypeRepr *,
+                            DowngradeToWarning)> diagnose) {
+  const DeclContext *contextAccessScope = context->getFormalAccessScope();
+  checkTypeAccessibilityImpl(TC, TL, contextAccessScope,
+                             context->getDeclContext(),
+                             [=](const DeclContext *requiredAccessScope,
+                                 const TypeRepr *offendingTR) {
+    auto downgradeToWarning = DowngradeToWarning::No;
+    if (contextAccessScope && !isa<ModuleDecl>(contextAccessScope)) {
+      // Swift 3.0.0 mistakenly didn't diagnose any issues when the context
+      // access scope represented a private or fileprivate level.
+      downgradeToWarning = DowngradeToWarning::Yes;
+    }
+    diagnose(requiredAccessScope, offendingTR, downgradeToWarning);
+  });
 }
 
 /// Highlights the given TypeRepr, and adds a note pointing to the type's
@@ -1568,6 +1597,10 @@ static void checkGenericParamAccessibility(TypeChecker &TC,
   } accessibilityErrorKind;
   const DeclContext *minAccessScope = nullptr;
   const TypeRepr *complainRepr = nullptr;
+
+  // Swift 3.0.0 mistakenly didn't diagnose any issues when the context access
+  // scope represented a private or fileprivate level.
+  bool shouldDowngradeToWarning = accessScope && !isa<ModuleDecl>(accessScope);
 
   for (auto param : *params) {
     if (param->getInherited().empty())
@@ -1624,7 +1657,10 @@ static void checkGenericParamAccessibility(TypeChecker &TC,
     bool isExplicit =
       owner->getAttrs().hasAttribute<AccessibilityAttr>() ||
       owner->getDeclContext()->getAsProtocolOrProtocolExtensionContext();
-    auto diag = TC.diagnose(owner, diag::generic_param_access,
+    auto diagID = diag::generic_param_access;
+    if (shouldDowngradeToWarning)
+      diagID = diag::generic_param_access_warn;
+    auto diag = TC.diagnose(owner, diagID,
                             owner->getDescriptiveKind(), isExplicit,
                             contextAccess, minAccess,
                             accessibilityErrorKind);
@@ -1690,13 +1726,16 @@ static void checkAccessibility(TypeChecker &TC, const Decl *D) {
         checkTypeAccessibility(TC, TypeLoc::withoutLoc(theVar->getType()),
                                theVar,
                                [&](const DeclContext *typeAccessScope,
-                                   const TypeRepr *complainRepr) {
+                                   const TypeRepr *complainRepr,
+                                   DowngradeToWarning downgradeToWarning) {
           auto typeAccess =
               accessibilityFromScopeForDiagnostics(typeAccessScope);
           bool isExplicit =
             theVar->getAttrs().hasAttribute<AccessibilityAttr>();
-          auto diag = TC.diagnose(P->getLoc(),
-                                  diag::pattern_type_access_inferred,
+          auto diagID = diag::pattern_type_access_inferred;
+          if (downgradeToWarning == DowngradeToWarning::Yes)
+            diagID = diag::pattern_type_access_inferred_warn;
+          auto diag = TC.diagnose(P->getLoc(), diagID,
                                   theVar->isLet(),
                                   isTypeContext,
                                   isExplicit,
@@ -1724,12 +1763,16 @@ static void checkAccessibility(TypeChecker &TC, const Decl *D) {
 
       checkTypeAccessibility(TC, TP->getTypeLoc(), anyVar,
                              [&](const DeclContext *typeAccessScope,
-                                 const TypeRepr *complainRepr) {
+                                 const TypeRepr *complainRepr,
+                                 DowngradeToWarning downgradeToWarning) {
         auto typeAccess = accessibilityFromScopeForDiagnostics(typeAccessScope);
         bool isExplicit =
           anyVar->getAttrs().hasAttribute<AccessibilityAttr>() ||
           anyVar->getDeclContext()->getAsProtocolOrProtocolExtensionContext();
-        auto diag = TC.diagnose(P->getLoc(), diag::pattern_type_access,
+        auto diagID = diag::pattern_type_access;
+        if (downgradeToWarning == DowngradeToWarning::Yes)
+          diagID = diag::pattern_type_access_warn;
+        auto diag = TC.diagnose(P->getLoc(), diagID,
                                 anyVar->isLet(),
                                 isTypeContext,
                                 isExplicit,
@@ -1746,10 +1789,14 @@ static void checkAccessibility(TypeChecker &TC, const Decl *D) {
 
     checkTypeAccessibility(TC, TAD->getUnderlyingTypeLoc(), TAD,
                            [&](const DeclContext *typeAccessScope,
-                               const TypeRepr *complainRepr) {
+                               const TypeRepr *complainRepr,
+                               DowngradeToWarning downgradeToWarning) {
       auto typeAccess = accessibilityFromScopeForDiagnostics(typeAccessScope);
       bool isExplicit = TAD->getAttrs().hasAttribute<AccessibilityAttr>();
-      auto diag = TC.diagnose(TAD, diag::type_alias_underlying_type_access,
+      auto diagID = diag::type_alias_underlying_type_access;
+      if (downgradeToWarning == DowngradeToWarning::Yes)
+        diagID = diag::type_alias_underlying_type_access_warn;
+      auto diag = TC.diagnose(TAD, diagID,
                               isExplicit, TAD->getFormalAccess(),
                               typeAccess);
       highlightOffendingType(TC, diag, complainRepr);
@@ -1768,37 +1815,45 @@ static void checkAccessibility(TypeChecker &TC, const Decl *D) {
     } accessibilityErrorKind;
     const DeclContext *minAccessScope = nullptr;
     const TypeRepr *complainRepr = nullptr;
+    auto downgradeToWarning = DowngradeToWarning::No;
 
     std::for_each(assocType->getInherited().begin(),
                   assocType->getInherited().end(),
                   [&](TypeLoc requirement) {
       checkTypeAccessibility(TC, requirement, assocType,
                              [&](const DeclContext *typeAccessScope,
-                                 const TypeRepr *thisComplainRepr) {
+                                 const TypeRepr *thisComplainRepr,
+                                 DowngradeToWarning downgradeDiag) {
         if (!minAccessScope ||
             typeAccessScope->isChildContextOf(minAccessScope) ||
             (!complainRepr && typeAccessScope == minAccessScope)) {
           minAccessScope = typeAccessScope;
           complainRepr = thisComplainRepr;
           accessibilityErrorKind = AEK_Requirement;
+          downgradeToWarning = downgradeDiag;
         }
       });
     });
     checkTypeAccessibility(TC, assocType->getDefaultDefinitionLoc(), assocType,
                            [&](const DeclContext *typeAccessScope,
-                               const TypeRepr *thisComplainRepr) {
+                               const TypeRepr *thisComplainRepr,
+                               DowngradeToWarning downgradeDiag) {
       if (!minAccessScope ||
           typeAccessScope->isChildContextOf(minAccessScope) ||
           (!complainRepr && typeAccessScope == minAccessScope)) {
         minAccessScope = typeAccessScope;
         complainRepr = thisComplainRepr;
         accessibilityErrorKind = AEK_DefaultDefinition;
+        downgradeToWarning = downgradeDiag;
       }
     });
 
     if (minAccessScope) {
       auto minAccess = accessibilityFromScopeForDiagnostics(minAccessScope);
-      auto diag = TC.diagnose(assocType, diag::associated_type_access,
+      auto diagID = diag::associated_type_access;
+      if (downgradeToWarning == DowngradeToWarning::Yes)
+        diagID = diag::associated_type_access_warn;
+      auto diag = TC.diagnose(assocType, diagID,
                               assocType->getFormalAccess(),
                               minAccess, accessibilityErrorKind);
       highlightOffendingType(TC, diag, complainRepr);
@@ -1824,10 +1879,14 @@ static void checkAccessibility(TypeChecker &TC, const Decl *D) {
         return;
       checkTypeAccessibility(TC, *rawTypeLocIter, ED,
                              [&](const DeclContext *typeAccessScope,
-                                 const TypeRepr *complainRepr) {
+                                 const TypeRepr *complainRepr,
+                                 DowngradeToWarning downgradeToWarning) {
         auto typeAccess = accessibilityFromScopeForDiagnostics(typeAccessScope);
         bool isExplicit = ED->getAttrs().hasAttribute<AccessibilityAttr>();
-        auto diag = TC.diagnose(ED, diag::enum_raw_type_access,
+        auto diagID = diag::enum_raw_type_access;
+        if (downgradeToWarning == DowngradeToWarning::Yes)
+          diagID = diag::enum_raw_type_access_warn;
+        auto diag = TC.diagnose(ED, diagID,
                                 isExplicit, ED->getFormalAccess(),
                                 typeAccess);
         highlightOffendingType(TC, diag, complainRepr);
@@ -1861,10 +1920,14 @@ static void checkAccessibility(TypeChecker &TC, const Decl *D) {
         return;
       checkTypeAccessibility(TC, *superclassLocIter, CD,
                              [&](const DeclContext *typeAccessScope,
-                                 const TypeRepr *complainRepr) {
+                                 const TypeRepr *complainRepr,
+                                 DowngradeToWarning downgradeToWarning) {
         auto typeAccess = accessibilityFromScopeForDiagnostics(typeAccessScope);
         bool isExplicit = CD->getAttrs().hasAttribute<AccessibilityAttr>();
-        auto diag = TC.diagnose(CD, diag::class_super_access,
+        auto diagID = diag::class_super_access;
+        if (downgradeToWarning == DowngradeToWarning::Yes)
+          diagID = diag::class_super_access_warn;
+        auto diag = TC.diagnose(CD, diagID,
                                 isExplicit, CD->getFormalAccess(),
                                 typeAccess);
         highlightOffendingType(TC, diag, complainRepr);
@@ -1879,18 +1942,21 @@ static void checkAccessibility(TypeChecker &TC, const Decl *D) {
 
     const DeclContext *minAccessScope = nullptr;
     const TypeRepr *complainRepr = nullptr;
+    auto downgradeToWarning = DowngradeToWarning::No;
 
     std::for_each(proto->getInherited().begin(),
                   proto->getInherited().end(),
                   [&](TypeLoc requirement) {
       checkTypeAccessibility(TC, requirement, proto,
                              [&](const DeclContext *typeAccessScope,
-                                 const TypeRepr *thisComplainRepr) {
+                                 const TypeRepr *thisComplainRepr,
+                                 DowngradeToWarning downgradeDiag) {
         if (!minAccessScope ||
             typeAccessScope->isChildContextOf(minAccessScope) ||
             (!complainRepr && typeAccessScope == minAccessScope)) {
           minAccessScope = typeAccessScope;
           complainRepr = thisComplainRepr;
+          downgradeToWarning = downgradeDiag;
         }
       });
     });
@@ -1898,7 +1964,10 @@ static void checkAccessibility(TypeChecker &TC, const Decl *D) {
     if (minAccessScope) {
       auto minAccess = accessibilityFromScopeForDiagnostics(minAccessScope);
       bool isExplicit = proto->getAttrs().hasAttribute<AccessibilityAttr>();
-      auto diag = TC.diagnose(proto, diag::protocol_refine_access,
+      auto diagID = diag::protocol_refine_access;
+      if (downgradeToWarning == DowngradeToWarning::Yes)
+        diagID = diag::protocol_refine_access_warn;
+      auto diag = TC.diagnose(proto, diagID,
                               isExplicit, proto->getFormalAccess(), minAccess);
       highlightOffendingType(TC, diag, complainRepr);
     }
@@ -1910,28 +1979,34 @@ static void checkAccessibility(TypeChecker &TC, const Decl *D) {
 
     const DeclContext *minAccessScope = nullptr;
     const TypeRepr *complainRepr = nullptr;
+    auto downgradeToWarning = DowngradeToWarning::No;
     bool problemIsElement = false;
+
     for (auto &P : *SD->getIndices()) {
       checkTypeAccessibility(TC, P->getTypeLoc(), SD,
                              [&](const DeclContext *typeAccessScope,
-                                 const TypeRepr *thisComplainRepr) {
+                                 const TypeRepr *thisComplainRepr,
+                                 DowngradeToWarning downgradeDiag) {
         if (!minAccessScope ||
             typeAccessScope->isChildContextOf(minAccessScope) ||
             (!complainRepr && typeAccessScope == minAccessScope)) {
           minAccessScope = typeAccessScope;
           complainRepr = thisComplainRepr;
+          downgradeToWarning = downgradeDiag;
         }
       });
     }
 
     checkTypeAccessibility(TC, SD->getElementTypeLoc(), SD,
                            [&](const DeclContext *typeAccessScope,
-                               const TypeRepr *thisComplainRepr) {
+                               const TypeRepr *thisComplainRepr,
+                               DowngradeToWarning downgradeDiag) {
       if (!minAccessScope ||
           typeAccessScope->isChildContextOf(minAccessScope) ||
           (!complainRepr && typeAccessScope == minAccessScope)) {
         minAccessScope = typeAccessScope;
         complainRepr = thisComplainRepr;
+        downgradeToWarning = downgradeDiag;
         problemIsElement = true;
       }
     });
@@ -1941,7 +2016,10 @@ static void checkAccessibility(TypeChecker &TC, const Decl *D) {
       bool isExplicit =
         SD->getAttrs().hasAttribute<AccessibilityAttr>() ||
         SD->getDeclContext()->getAsProtocolOrProtocolExtensionContext();
-      auto diag = TC.diagnose(SD, diag::subscript_type_access,
+      auto diagID = diag::subscript_type_access;
+      if (downgradeToWarning == DowngradeToWarning::Yes)
+        diagID = diag::subscript_type_access_warn;
+      auto diag = TC.diagnose(SD, diagID,
                               isExplicit,
                               SD->getFormalAccess(),
                               minAccess,
@@ -1961,7 +2039,7 @@ static void checkAccessibility(TypeChecker &TC, const Decl *D) {
 
     checkGenericParamAccessibility(TC, fn->getGenericParams(), fn);
 
-    // This must stay in sync with diag::associated_type_access.
+    // This must stay in sync with diag::function_type_access.
     enum {
       FK_Function = 0,
       FK_Method,
@@ -1970,16 +2048,20 @@ static void checkAccessibility(TypeChecker &TC, const Decl *D) {
 
     const DeclContext *minAccessScope = nullptr;
     const TypeRepr *complainRepr = nullptr;
+    auto downgradeToWarning = DowngradeToWarning::No;
+
     for (auto *PL : fn->getParameterLists().slice(isTypeContext)) {
       for (auto &P : *PL) {
         checkTypeAccessibility(TC, P->getTypeLoc(), fn,
                                [&](const DeclContext *typeAccessScope,
-                                   const TypeRepr *thisComplainRepr) {
+                                   const TypeRepr *thisComplainRepr,
+                                   DowngradeToWarning downgradeDiag) {
           if (!minAccessScope ||
               typeAccessScope->isChildContextOf(minAccessScope) ||
               (!complainRepr && typeAccessScope == minAccessScope)) {
             minAccessScope = typeAccessScope;
             complainRepr = thisComplainRepr;
+            downgradeToWarning = downgradeDiag;
           }
         });
       }
@@ -1989,12 +2071,14 @@ static void checkAccessibility(TypeChecker &TC, const Decl *D) {
     if (auto FD = dyn_cast<FuncDecl>(fn)) {
       checkTypeAccessibility(TC, FD->getBodyResultTypeLoc(), FD,
                              [&](const DeclContext *typeAccessScope,
-                                 const TypeRepr *thisComplainRepr) {
+                                 const TypeRepr *thisComplainRepr,
+                                 DowngradeToWarning downgradeDiag) {
         if (!minAccessScope ||
             typeAccessScope->isChildContextOf(minAccessScope) ||
             (!complainRepr && typeAccessScope == minAccessScope)) {
           minAccessScope = typeAccessScope;
           complainRepr = thisComplainRepr;
+          downgradeToWarning = downgradeDiag;
           problemIsResult = true;
         }
       });
@@ -2005,7 +2089,10 @@ static void checkAccessibility(TypeChecker &TC, const Decl *D) {
       bool isExplicit =
         fn->getAttrs().hasAttribute<AccessibilityAttr>() ||
         D->getDeclContext()->getAsProtocolOrProtocolExtensionContext();
-      auto diag = TC.diagnose(fn, diag::function_type_access,
+      auto diagID = diag::function_type_access;
+      if (downgradeToWarning == DowngradeToWarning::Yes)
+        diagID = diag::function_type_access_warn;
+      auto diag = TC.diagnose(fn, diagID,
                               isExplicit,
                               fn->getFormalAccess(),
                               minAccess,
@@ -2024,9 +2111,13 @@ static void checkAccessibility(TypeChecker &TC, const Decl *D) {
       return;
     checkTypeAccessibility(TC, EED->getArgumentTypeLoc(), EED,
                            [&](const DeclContext *typeAccessScope,
-                               const TypeRepr *complainRepr) {
+                               const TypeRepr *complainRepr,
+                               DowngradeToWarning downgradeToWarning) {
       auto typeAccess = accessibilityFromScopeForDiagnostics(typeAccessScope);
-      auto diag = TC.diagnose(EED, diag::enum_case_access,
+      auto diagID = diag::enum_case_access;
+      if (downgradeToWarning == DowngradeToWarning::Yes)
+        diagID = diag::enum_case_access_warn;
+      auto diag = TC.diagnose(EED, diagID,
                               EED->getFormalAccess(), typeAccess);
       highlightOffendingType(TC, diag, complainRepr);
     });

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1497,9 +1497,9 @@ static void checkTypeAccessibilityImpl(
     return;
   if (!TL.getType())
     return;
-  // Don't spend time checking private access; this is always valid by the time
-  // we get to this point. This includes local declarations.
-  if (contextAccessScope && !isa<ModuleDecl>(contextAccessScope))
+  // Don't spend time checking local declarations; this is always valid by the
+  // time we get to this point.
+  if (contextAccessScope && contextAccessScope->isLocalContext())
     return;
 
   Optional<const DeclContext *> typeAccessScope =
@@ -1512,8 +1512,10 @@ static void checkTypeAccessibilityImpl(
   if (!typeAccessScope.hasValue())
     return;
 
-  if (!*typeAccessScope || *typeAccessScope == contextAccessScope)
+  if (!*typeAccessScope || *typeAccessScope == contextAccessScope ||
+      contextAccessScope->isChildContextOf(*typeAccessScope)) {
     return;
+  }
 
   const TypeRepr *complainRepr = nullptr;
   if (TypeRepr *TR = TL.getTypeRepr()) {

--- a/test/Sema/accessibility_private.swift
+++ b/test/Sema/accessibility_private.swift
@@ -160,3 +160,51 @@ extension Container {
     _ = Container.ExtensionConflictingType() // expected-error {{'ExtensionConflictingType' is inaccessible due to 'private' protection level}}
   }
 }
+
+extension Container {
+  private struct VeryPrivateStruct { // expected-note * {{type declared here}}
+    private typealias VeryPrivateType = Int // expected-note * {{type declared here}}
+    var privateVar: VeryPrivateType { fatalError() } // expected-error {{property must be declared private because its type uses a private type}}
+    var privateVar2 = VeryPrivateType() // expected-error {{property must be declared private because its type 'Container.VeryPrivateStruct.VeryPrivateType' (aka 'Int') uses a private type}}
+    typealias PrivateAlias = VeryPrivateType // expected-error {{type alias must be declared private because its underlying type uses a private type}}
+    subscript(_: VeryPrivateType) -> Void { return () } // expected-error {{subscript must be declared private because its index uses a private type}}
+    func privateMethod(_: VeryPrivateType) -> Void {} // expected-error {{method must be declared private because its parameter uses a private type}} {{none}}
+    enum PrivateRawValue: VeryPrivateType { // expected-error {{enum must be declared private because its raw type uses a private type}} {{none}}
+      case A
+    }
+    enum PrivatePayload {
+      case A(VeryPrivateType) // expected-error {{enum case in an internal enum uses a private type}} {{none}}
+    }
+
+    private class PrivateInnerClass {} // expected-note * {{declared here}}
+    class PrivateSuper: PrivateInnerClass {} // expected-error {{class must be declared private because its superclass is private}} {{none}}
+  }
+
+  fileprivate var privateVar: VeryPrivateStruct { fatalError() } // expected-error {{property cannot be declared fileprivate because its type uses a private type}} {{none}}
+  fileprivate typealias PrivateAlias = VeryPrivateStruct // expected-error {{type alias cannot be declared fileprivate because its underlying type uses a private type}} {{none}}
+  fileprivate subscript(_: VeryPrivateStruct) -> Void { return () } // expected-error {{subscript cannot be declared fileprivate because its index uses a private type}} {{none}}
+  fileprivate func privateMethod(_: VeryPrivateStruct) -> Void {} // expected-error {{method cannot be declared fileprivate because its parameter uses a private type}} {{none}}
+  fileprivate enum PrivateRawValue: VeryPrivateStruct {} // expected-error {{enum cannot be declared fileprivate because its raw type uses a private type}} {{none}}
+  // expected-error@-1 {{raw type 'Container.VeryPrivateStruct' is not expressible by any literal}}
+  // expected-error@-2 {{'Container.PrivateRawValue' declares raw type 'Container.VeryPrivateStruct', but does not conform to RawRepresentable and conformance could not be synthesized}}
+  fileprivate enum PrivatePayload {
+    case A(VeryPrivateStruct) // expected-error {{enum case in an internal enum uses a private type}} {{none}}
+  }
+
+  private class PrivateInnerClass {} // expected-note * {{declared here}}
+  fileprivate class PrivateSuperClass: PrivateInnerClass {} // expected-error {{class cannot be declared fileprivate because its superclass is private}} {{none}}
+  fileprivate class PrivateGenericUser<T> where T: PrivateInnerClass {} // expected-error {{generic class cannot be declared fileprivate because its generic requirement uses a private type}} {{none}}
+  // expected-error@-1 {{type 'PrivateGenericUser' cannot be nested in extension of generic type 'Container'}}
+  // FIXME expected-error@-2 {{cannot conform to class protocol 'AnyObject'}}
+}
+
+fileprivate struct SR2579 {
+  private struct Inner {
+    private struct InnerPrivateType {}
+    var innerProperty = InnerPrivateType() // expected-error {{property must be declared private because its type 'SR2579.Inner.InnerPrivateType' uses a private type}}
+  }
+  // FIXME: We need better errors when one access violation results in more
+  // downstream.
+  private var outerProperty = Inner().innerProperty // expected-error {{property cannot be declared PRIVATE because its type 'SR2579.Inner.InnerPrivateType' uses a private type}}
+  var outerProperty2 = Inner().innerProperty // expected-error {{property must be declared private because its type 'SR2579.Inner.InnerPrivateType' uses a private type}}
+}

--- a/test/Sema/accessibility_private.swift
+++ b/test/Sema/accessibility_private.swift
@@ -161,39 +161,41 @@ extension Container {
   }
 }
 
+// All of these should be errors, but didn't have the correct behavior in Swift 
+// 3.0GM.
 extension Container {
   private struct VeryPrivateStruct { // expected-note * {{type declared here}}
     private typealias VeryPrivateType = Int // expected-note * {{type declared here}}
-    var privateVar: VeryPrivateType { fatalError() } // expected-error {{property must be declared private because its type uses a private type}}
-    var privateVar2 = VeryPrivateType() // expected-error {{property must be declared private because its type 'Container.VeryPrivateStruct.VeryPrivateType' (aka 'Int') uses a private type}}
-    typealias PrivateAlias = VeryPrivateType // expected-error {{type alias must be declared private because its underlying type uses a private type}}
-    subscript(_: VeryPrivateType) -> Void { return () } // expected-error {{subscript must be declared private because its index uses a private type}}
-    func privateMethod(_: VeryPrivateType) -> Void {} // expected-error {{method must be declared private because its parameter uses a private type}} {{none}}
-    enum PrivateRawValue: VeryPrivateType { // expected-error {{enum must be declared private because its raw type uses a private type}} {{none}}
+    var privateVar: VeryPrivateType { fatalError() } // expected-warning {{property should be declared private because its type uses a private type}}
+    var privateVar2 = VeryPrivateType() // expected-warning {{property should be declared private because its type 'Container.VeryPrivateStruct.VeryPrivateType' (aka 'Int') uses a private type}}
+    typealias PrivateAlias = VeryPrivateType // expected-warning {{type alias should be declared private because its underlying type uses a private type}}
+    subscript(_: VeryPrivateType) -> Void { return () } // expected-warning {{subscript should be declared private because its index uses a private type}}
+    func privateMethod(_: VeryPrivateType) -> Void {} // expected-warning {{method should be declared private because its parameter uses a private type}} {{none}}
+    enum PrivateRawValue: VeryPrivateType { // expected-warning {{enum should be declared private because its raw type uses a private type}} {{none}}
       case A
     }
     enum PrivatePayload {
-      case A(VeryPrivateType) // expected-error {{enum case in an internal enum uses a private type}} {{none}}
+      case A(VeryPrivateType) // expected-warning {{enum case in an internal enum uses a private type}} {{none}}
     }
 
     private class PrivateInnerClass {} // expected-note * {{declared here}}
-    class PrivateSuper: PrivateInnerClass {} // expected-error {{class must be declared private because its superclass is private}} {{none}}
+    class PrivateSuper: PrivateInnerClass {} // expected-warning {{class should be declared private because its superclass is private}} {{none}}
   }
 
-  fileprivate var privateVar: VeryPrivateStruct { fatalError() } // expected-error {{property cannot be declared fileprivate because its type uses a private type}} {{none}}
-  fileprivate typealias PrivateAlias = VeryPrivateStruct // expected-error {{type alias cannot be declared fileprivate because its underlying type uses a private type}} {{none}}
-  fileprivate subscript(_: VeryPrivateStruct) -> Void { return () } // expected-error {{subscript cannot be declared fileprivate because its index uses a private type}} {{none}}
-  fileprivate func privateMethod(_: VeryPrivateStruct) -> Void {} // expected-error {{method cannot be declared fileprivate because its parameter uses a private type}} {{none}}
-  fileprivate enum PrivateRawValue: VeryPrivateStruct {} // expected-error {{enum cannot be declared fileprivate because its raw type uses a private type}} {{none}}
+  fileprivate var privateVar: VeryPrivateStruct { fatalError() } // expected-warning {{property should not be declared fileprivate because its type uses a private type}} {{none}}
+  fileprivate typealias PrivateAlias = VeryPrivateStruct // expected-warning {{type alias should not be declared fileprivate because its underlying type uses a private type}} {{none}}
+  fileprivate subscript(_: VeryPrivateStruct) -> Void { return () } // expected-warning {{subscript should not be declared fileprivate because its index uses a private type}} {{none}}
+  fileprivate func privateMethod(_: VeryPrivateStruct) -> Void {} // expected-warning {{method should not be declared fileprivate because its parameter uses a private type}} {{none}}
+  fileprivate enum PrivateRawValue: VeryPrivateStruct {} // expected-warning {{enum should not be declared fileprivate because its raw type uses a private type}} {{none}}
   // expected-error@-1 {{raw type 'Container.VeryPrivateStruct' is not expressible by any literal}}
   // expected-error@-2 {{'Container.PrivateRawValue' declares raw type 'Container.VeryPrivateStruct', but does not conform to RawRepresentable and conformance could not be synthesized}}
   fileprivate enum PrivatePayload {
-    case A(VeryPrivateStruct) // expected-error {{enum case in an internal enum uses a private type}} {{none}}
+    case A(VeryPrivateStruct) // expected-warning {{enum case in an internal enum uses a private type}} {{none}}
   }
 
   private class PrivateInnerClass {} // expected-note * {{declared here}}
-  fileprivate class PrivateSuperClass: PrivateInnerClass {} // expected-error {{class cannot be declared fileprivate because its superclass is private}} {{none}}
-  fileprivate class PrivateGenericUser<T> where T: PrivateInnerClass {} // expected-error {{generic class cannot be declared fileprivate because its generic requirement uses a private type}} {{none}}
+  fileprivate class PrivateSuperClass: PrivateInnerClass {} // expected-warning {{class should not be declared fileprivate because its superclass is private}} {{none}}
+  fileprivate class PrivateGenericUser<T> where T: PrivateInnerClass {} // expected-warning {{generic class should not be declared fileprivate because its generic requirement uses a private type}} {{none}}
   // expected-error@-1 {{type 'PrivateGenericUser' cannot be nested in extension of generic type 'Container'}}
   // FIXME expected-error@-2 {{cannot conform to class protocol 'AnyObject'}}
 }
@@ -201,10 +203,10 @@ extension Container {
 fileprivate struct SR2579 {
   private struct Inner {
     private struct InnerPrivateType {}
-    var innerProperty = InnerPrivateType() // expected-error {{property must be declared private because its type 'SR2579.Inner.InnerPrivateType' uses a private type}}
+    var innerProperty = InnerPrivateType() // expected-warning {{property should be declared private because its type 'SR2579.Inner.InnerPrivateType' uses a private type}}
   }
   // FIXME: We need better errors when one access violation results in more
   // downstream.
-  private var outerProperty = Inner().innerProperty // expected-error {{property cannot be declared PRIVATE because its type 'SR2579.Inner.InnerPrivateType' uses a private type}}
-  var outerProperty2 = Inner().innerProperty // expected-error {{property must be declared private because its type 'SR2579.Inner.InnerPrivateType' uses a private type}}
+  private var outerProperty = Inner().innerProperty // expected-warning {{property should not be declared in this context because its type 'SR2579.Inner.InnerPrivateType' uses a private type}}
+  var outerProperty2 = Inner().innerProperty // expected-warning {{property should be declared private because its type 'SR2579.Inner.InnerPrivateType' uses a private type}}
 }


### PR DESCRIPTION
…then downgrade the resulting errors to warnings to be compatible with Swift 3.0GM.

This was a correct compile-time optimization for Swift 2, but Swift 3 has multiple levels of "private" that need to be taken into account. Fortunately these cases are all safe; they're the cases that would all be `fileprivate` in Swift 2.

Resolves [SR-2579](https://bugs.swift.org/browse/SR-2579).
