### PR TITLE
Improvements to optional-to-Any coercion warning.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2341,11 +2341,11 @@ WARNING(optional_pattern_match_promotion,none,
 WARNING(optional_to_any_coercion,none,
         "expression implicitly coerced from %0 to Any", (Type))
 NOTE(default_optional_to_any,none,
-     "provide a default value to avoid the warning", ())
+     "provide a default value to avoid this warning", ())
 NOTE(force_optional_to_any,none,
-     "force-unwrap the value to avoid the warning", ())
+     "force-unwrap the value to avoid this warning", ())
 NOTE(silence_optional_to_any,none,
-     "explicitly cast to Any with 'as Any' to silence the warning", ())
+     "explicitly cast to Any with 'as Any' to silence this warning", ())
 
 ERROR(invalid_noescape_use,none,
       "non-escaping %select{value|parameter}1 %0 may only be called",

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3593,7 +3593,7 @@ checkImplicitPromotionsInCondition(const StmtConditionElement &cond,
 
 static void diagnoseOptionalToAnyCoercion(TypeChecker &TC, const Expr *E,
                                           const DeclContext *DC) {
-  if (E == nullptr || isa<ErrorExpr>(E) || !E->getType())
+  if (!E || isa<ErrorExpr>(E) || !E->getType())
     return;
 
   class OptionalToAnyCoercionWalker : public ASTWalker {
@@ -3605,13 +3605,12 @@ static void diagnoseOptionalToAnyCoercion(TypeChecker &TC, const Expr *E,
         return { false, E };
 
       if (auto *coercion = dyn_cast<CoerceExpr>(E)) {
-        if (E->getType()->getDesugaredType()->isAny() &&
-            isa<ErasureExpr>(coercion->getSubExpr()))
+        if (E->getType()->isAny() && isa<ErasureExpr>(coercion->getSubExpr()))
           ErasureCoercedToAny.insert(coercion->getSubExpr());
       } else if (isa<ErasureExpr>(E) && !ErasureCoercedToAny.count(E) &&
-                 E->getType()->getDesugaredType()->isAny()) {
+                 E->getType()->isAny()) {
         auto subExpr = cast<ErasureExpr>(E)->getSubExpr();
-        auto erasedTy = subExpr->getType()->getDesugaredType();
+        auto erasedTy = subExpr->getType();
         if (erasedTy->getOptionalObjectType()) {
           TC.diagnose(subExpr->getStartLoc(), diag::optional_to_any_coercion,
                       erasedTy)

--- a/test/Sema/diag_optional_to_any.swift
+++ b/test/Sema/diag_optional_to_any.swift
@@ -7,61 +7,54 @@ func takeAny(_ left: Any, _ right: Any) -> Int? {
 func throwing() throws -> Int? {}
 
 func warnOptionalToAnyCoercion(value x: Int?) -> Any {
-  let a: Any = x // expected-warning {{expression implicitly coerced from 'Optional<Int>' to Any}}
-  // expected-note@-1 {{provide a default value to avoid the warning}}
-  // expected-note@-2 {{force-unwrap the value to avoid the warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence}}
+  let a: Any = x // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}
+  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
 
   let b: Any = x as Any
 
-  let c: Any = takeAny(a, b) // expected-warning {{expression implicitly coerced from 'Optional<Int>' to Any}}
-  // expected-note@-1 {{provide a default value to avoid the warning}}
-  // expected-note@-2 {{force-unwrap the value to avoid the warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence}}
+  let c: Any = takeAny(a, b) // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}
+  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
 
-  let d: Any = takeAny(c, c) as Any
+  let _: Any = takeAny(c, c) as Any
 
-  let e: Any = (x)  // expected-warning {{expression implicitly coerced from 'Optional<Int>' to Any}}
-  // expected-note@-1 {{provide a default value to avoid the warning}}
-  // expected-note@-2 {{force-unwrap the value to avoid the warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence}}
-
-  _ = takeAny(d, e)
+  let _: Any = (x)  // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}
+  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
 
   let f: Any = (x as Any)
   let g: Any = (x) as (Any)
 
-  _ = takeAny(f as? Int, g) // expected-warning {{expression implicitly coerced from 'Optional<Int>' to Any}}
-  // expected-note@-1 {{provide a default value to avoid the warning}}
-  // expected-note@-2 {{force-unwrap the value to avoid the warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence}}
+  _ = takeAny(f as? Int, g) // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}
+  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
 
-  let h: Any = takeAny(f as? Int, g) as Any // expected-warning {{expression implicitly coerced from 'Optional<Int>' to Any}}
-  // expected-note@-1 {{provide a default value to avoid the warning}}
-  // expected-note@-2 {{force-unwrap the value to avoid the warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence}}
+  let _: Any = takeAny(f as? Int, g) as Any // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}
+  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
 
-  let i: Any = takeAny(f as? Int as Any, g) as Any
+  let _: Any = takeAny(f as? Int as Any, g) as Any
 
-  _ = takeAny(h, i)
+  let _: Any = x! == x! ? 1 : x // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}
+  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
 
-  let j: Any = x! == x! ? 1 : x // expected-warning {{expression implicitly coerced from 'Optional<Int>' to Any}}
-  // expected-note@-1 {{provide a default value to avoid the warning}}
-  // expected-note@-2 {{force-unwrap the value to avoid the warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence}}
-
-  let k: Any
   do {
-    k = try throwing() // expected-warning {{expression implicitly coerced from 'Optional<Int>' to Any}}
-    // expected-note@-1 {{provide a default value to avoid the warning}}
-    // expected-note@-2 {{force-unwrap the value to avoid the warning}}
-    // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence}}
+    let _: Any = try throwing() // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+    // expected-note@-1 {{provide a default value to avoid this warning}}
+    // expected-note@-2 {{force-unwrap the value to avoid this warning}}
+    // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
   } catch {}
 
-  _ = takeAny(j, k)
-
-  return x // expected-warning {{expression implicitly coerced from 'Optional<Int>' to Any}}
-  // expected-note@-1 {{provide a default value to avoid the warning}}
-  // expected-note@-2 {{force-unwrap the value to avoid the warning}}
-  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence}}
+  return x // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}
+  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
 }


### PR DESCRIPTION
Don't explicitly desguar types when it is not needed and/or results in
worse types displayed in diagnostics.

Tweak the warning messages to use "this warning" rather than "the
warning".

Addresses feedback from Jordan on commit 401ca2453284a990b59bef2e649dcedef05a2b00.
