### PR TITLE
[stdlib] fix UnsafePointer.withMemoryRebound(to:capacity:) argument t…

### DIFF
--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -373,13 +373,13 @@ public struct ${Self}<Pointee>
   /// - Precondition: The memory `self..<self + count * MemoryLayout<T>.stride`
   ///   is bound to `Pointee`.
   public func withMemoryRebound<T, Result>(to: T.Type, capacity count: Int,
-    _ body: (UnsafeMutablePointer<T>) throws -> Result
+    _ body: (${Self}<T>) throws -> Result
   ) rethrows -> Result {
     Builtin.bindMemory(_rawValue, count._builtinWordValue, T.self)
     defer {
       Builtin.bindMemory(_rawValue, count._builtinWordValue, Pointee.self)
     }
-    return try body(UnsafeMutablePointer<T>(_rawValue))
+    return try body(${Self}<T>(_rawValue))
   }
 
   /// Accesses the pointee at `self + i`.

--- a/test/stdlib/UnsafePointer.swift.gyb
+++ b/test/stdlib/UnsafePointer.swift.gyb
@@ -457,12 +457,16 @@ ${SelfName}TestSuite.test("Comparable") {
 % for SelfName in ['UnsafePointer', 'UnsafeMutablePointer']:
 
 ${SelfName}TestSuite.test("withMemoryRebound") {
-  let mutablePtr = UnsafeMutablePointer<Int>.allocate(capacity: 4)
-  let ptrI = ${SelfName}<Int>(mutablePtr)
+  let mutablePtrI = UnsafeMutablePointer<Int>.allocate(capacity: 4)
+  defer { mutablePtrI.deallocate(capacity: 4) }
+  let ptrI = ${SelfName}<Int>(mutablePtrI)
   ptrI.withMemoryRebound(to: UInt.self, capacity: 4) {
-    expectType(UInt.self, &$0.pointee)
+    // Make sure the closure argument isa $SelfName
+    var ptrU: ${SelfName}<UInt> = $0
+    // and that the element type is UInt.
+    var mutablePtrU = UnsafeMutablePointer(mutating: ptrU)
+    expectType(UInt.self, &mutablePtrU.pointee)
   }
-  mutablePtr.deallocate(capacity: 4)
 }
 
 % end


### PR DESCRIPTION
SE-0107 states that UnsafePointer.withMemoryRebound(to:capacity:) should produce
a const UnsafePointer, but the implementation that I committed in Whitney
produces an UnsafeMutablePointer.

As a result Swift 3 accepts code, that we would like to reject:

func takesUInt(_: UnsafeMutablePointer<UInt>) {}
func takesConstUInt(_: UnsafePointer<UInt>) {}

func foo(p: UnsafePointer<Int>) {
  p.withMemoryRebound(to: UInt.self, capacity: 1) {
    takesUInt($0) // <========= implicitly converts to a mutable pointer
    takesConstUInt($0)
  }
}

We would like to reject this in favor of:

func takesUInt(_: UnsafeMutablePointer<UInt>) {}
func takesConstUInt(_: UnsafePointer<UInt>) {}

func foo(p: UnsafePointer<Int>) {
  p.withMemoryRebound(to: UInt.self, capacity: 1) {
    takesUInt(UnsafeMutablePointer(mutating: $0))
    takesConstUInt($0)
  }
}

This looks to me like an experimental change accidentally creeped onto my branch
and it was hard to spot in .gyb code. I needed to write the unit test in terms of UnsafeMutablePointer in order to use expectType, so the original test didn't catch this.

rdar://28409842 UnsafePointer.withMemoryRebound(to:capacity:) incorrectly produces a mutable pointer argument
