### PR TITLE
Remove incorrect early exit from type access checking.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1108,6 +1108,13 @@ ERROR(pattern_type_access,none,
       "because its type uses "
       "%select{a private|a fileprivate|an internal|PUBLIC}4 type",
       (bool, bool, bool, Accessibility, Accessibility))
+WARNING(pattern_type_access_warn,none,
+        "%select{%select{variable|constant}0|property}1 "
+        "%select{should be declared %select{private|fileprivate|internal|PUBLIC}4"
+        "|should not be declared %select{in this context|fileprivate|internal|public}3}2 "
+        "because its type uses "
+        "%select{a private|a fileprivate|an internal|PUBLIC}4 type",
+        (bool, bool, bool, Accessibility, Accessibility))
 ERROR(pattern_type_access_inferred,none,
       "%select{%select{variable|constant}0|property}1 "
       "%select{must be declared %select{private|fileprivate|internal|PUBLIC}4"
@@ -1115,6 +1122,13 @@ ERROR(pattern_type_access_inferred,none,
       "because its type %5 uses "
       "%select{a private|a fileprivate|an internal|PUBLIC}4 type",
       (bool, bool, bool, Accessibility, Accessibility, Type))
+WARNING(pattern_type_access_inferred_warn,none,
+        "%select{%select{variable|constant}0|property}1 "
+        "%select{should be declared %select{private|fileprivate|internal|PUBLIC}4"
+        "|should not be declared %select{in this context|fileprivate|internal|public}3}2 "
+        "because its type %5 uses "
+        "%select{a private|a fileprivate|an internal|PUBLIC}4 type",
+        (bool, bool, bool, Accessibility, Accessibility, Type))
 ERROR(pattern_binds_no_variables,none,
       "%select{property|global variable}0 declaration does not bind any "
       "variables",
@@ -1154,6 +1168,13 @@ ERROR(type_alias_underlying_type_access,none,
       "because its underlying type uses "
       "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
       (bool, Accessibility, Accessibility))
+WARNING(type_alias_underlying_type_access_warn,none,
+        "type alias %select{should be declared "
+        "%select{private|fileprivate|internal|PUBLIC}2"
+        "|should not be declared %select{PRIVATE|fileprivate|internal|public}1}0 "
+        "because its underlying type uses "
+        "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
+        (bool, Accessibility, Accessibility))
 
 // Subscripts
 ERROR(subscript_type_access,none,
@@ -1163,6 +1184,13 @@ ERROR(subscript_type_access,none,
       "because its %select{index|element type}3 uses "
       "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
       (bool, Accessibility, Accessibility, bool))
+WARNING(subscript_type_access_warn,none,
+        "subscript %select{should be declared "
+        "%select{private|fileprivate|internal|PUBLIC}2"
+        "|should not be declared %select{in this context|fileprivate|internal|public}1}0 "
+        "because its %select{index|element type}3 uses "
+        "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
+        (bool, Accessibility, Accessibility, bool))
 
 // Functions
 ERROR(function_type_access,none,
@@ -1172,6 +1200,13 @@ ERROR(function_type_access,none,
       "because its %select{parameter|result}4 uses "
       "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
       (bool, Accessibility, Accessibility, unsigned, bool))
+WARNING(function_type_access_warn,none,
+        "%select{function|method|initializer}3 "
+        "%select{should be declared %select{private|fileprivate|internal|PUBLIC}2"
+        "|should not be declared %select{in this context|fileprivate|internal|public}1}0 "
+        "because its %select{parameter|result}4 uses "
+        "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
+        (bool, Accessibility, Accessibility, unsigned, bool))
 WARNING(non_trailing_closure_before_default_args,none,
         "closure parameter prior to parameters with default arguments will "
         "not be treated as a trailing closure", ())
@@ -1302,6 +1337,12 @@ ERROR(protocol_refine_access,none,
       "|%select{PRIVATE|fileprivate|internal|public}1 protocol cannot "
       "refine}0 %select{a private|a fileprivate|an internal|PUBLIC}2 protocol",
       (bool, Accessibility, Accessibility))
+WARNING(protocol_refine_access_warn,none,
+        "%select{protocol should be declared "
+        "%select{private|fileprivate|internal|PUBLIC}2 because it refines"
+        "|%select{in this context|fileprivate|internal|public}1 protocol should not "
+        "refine}0 %select{a private|a fileprivate|an internal|PUBLIC}2 protocol",
+        (bool, Accessibility, Accessibility))
 ERROR(protocol_property_must_be_computed_var,none,
       "immutable property requirement must be declared as 'var' with a "
       "'{ get }' specifier", ())
@@ -1334,6 +1375,12 @@ ERROR(associated_type_access,none,
       "%select{a private|a fileprivate|an internal|PUBLIC}1 type in its "
       "%select{default definition|requirement}2 ",
       (Accessibility, Accessibility, unsigned))
+WARNING(associated_type_access_warn,none,
+        "associated type in "
+        "%select{a private|a fileprivate|an internal|a public}0 protocol uses "
+        "%select{a private|a fileprivate|an internal|PUBLIC}1 type in its "
+        "%select{default definition|requirement}2 ",
+        (Accessibility, Accessibility, unsigned))
 
 NOTE(bad_associated_type_deduction,none,
      "unable to infer associated type %0 for protocol %1",
@@ -1491,6 +1538,13 @@ ERROR(generic_param_access,none,
       "because its generic %select{parameter|requirement}4 uses "
       "%select{a private|a fileprivate|an internal|PUBLIC}3 type",
       (DescriptiveDeclKind, bool, Accessibility, Accessibility, bool))
+WARNING(generic_param_access_warn,none,
+        "%0 %select{should be declared "
+        "%select{private|fileprivate|internal|PUBLIC}3"
+        "|should not be declared %select{in this context|fileprivate|internal|public}2}1 "
+        "because its generic %select{parameter|requirement}4 uses "
+        "%select{a private|a fileprivate|an internal|PUBLIC}3 type",
+        (DescriptiveDeclKind, bool, Accessibility, Accessibility, bool))
 
 ERROR(override_multiple_decls_base,none,
       "declaration %0 cannot override more than one superclass declaration",
@@ -1683,6 +1737,10 @@ ERROR(enum_case_access,none,
       "enum case in %select{PRIVATE|a fileprivate|an internal|a public}0 enum "
       "uses %select{a private|a fileprivate|an internal|PUBLIC}1 type",
       (Accessibility, Accessibility))
+WARNING(enum_case_access_warn,none,
+        "enum case in %select{a private|a fileprivate|an internal|a public}0 enum "
+        "uses %select{a private|a fileprivate|an internal|PUBLIC}1 type",
+        (Accessibility, Accessibility))
 ERROR(enum_stored_property,none,
       "enums may not contain stored properties", ())
 
@@ -1706,6 +1764,13 @@ ERROR(enum_raw_type_access,none,
       "because its raw type uses "
       "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
       (bool, Accessibility, Accessibility))
+WARNING(enum_raw_type_access_warn,none,
+        "enum %select{should be declared "
+        "%select{private|fileprivate|internal|PUBLIC}2"
+        "|should not be declared %select{in this context|fileprivate|internal|public}1}0 "
+        "because its raw type uses "
+        "%select{a private|a fileprivate|an internal|PUBLIC}2 type",
+        (bool, Accessibility, Accessibility))
 
 NOTE(enum_here,none,
      "enum %0 declared here", (Identifier))
@@ -2639,6 +2704,13 @@ ERROR(class_super_access,none,
       "because its superclass is "
       "%select{private|fileprivate|internal|PUBLIC}2",
       (bool, Accessibility, Accessibility))
+WARNING(class_super_access_warn,none,
+        "class %select{should be declared "
+        "%select{private|fileprivate|internal|PUBLIC}2"
+        "|should not be declared %select{in this context|fileprivate|internal|public}1}0 "
+        "because its superclass is "
+        "%select{private|fileprivate|internal|PUBLIC}2",
+        (bool, Accessibility, Accessibility))
 ERROR(dot_protocol_on_non_existential,none,
       "cannot use 'Protocol' with non-protocol type %0", (Type))
 ERROR(tuple_single_element,none,

--- a/test/Sema/accessibility_private.swift
+++ b/test/Sema/accessibility_private.swift
@@ -160,3 +160,53 @@ extension Container {
     _ = Container.ExtensionConflictingType() // expected-error {{'ExtensionConflictingType' is inaccessible due to 'private' protection level}}
   }
 }
+
+// All of these should be errors, but didn't have the correct behavior in Swift 
+// 3.0GM.
+extension Container {
+  private struct VeryPrivateStruct { // expected-note * {{type declared here}}
+    private typealias VeryPrivateType = Int // expected-note * {{type declared here}}
+    var privateVar: VeryPrivateType { fatalError() } // expected-warning {{property should be declared private because its type uses a private type}}
+    var privateVar2 = VeryPrivateType() // expected-warning {{property should be declared private because its type 'Container.VeryPrivateStruct.VeryPrivateType' (aka 'Int') uses a private type}}
+    typealias PrivateAlias = VeryPrivateType // expected-warning {{type alias should be declared private because its underlying type uses a private type}}
+    subscript(_: VeryPrivateType) -> Void { return () } // expected-warning {{subscript should be declared private because its index uses a private type}}
+    func privateMethod(_: VeryPrivateType) -> Void {} // expected-warning {{method should be declared private because its parameter uses a private type}} {{none}}
+    enum PrivateRawValue: VeryPrivateType { // expected-warning {{enum should be declared private because its raw type uses a private type}} {{none}}
+      case A
+    }
+    enum PrivatePayload {
+      case A(VeryPrivateType) // expected-warning {{enum case in an internal enum uses a private type}} {{none}}
+    }
+
+    private class PrivateInnerClass {} // expected-note * {{declared here}}
+    class PrivateSuper: PrivateInnerClass {} // expected-warning {{class should be declared private because its superclass is private}} {{none}}
+  }
+
+  fileprivate var privateVar: VeryPrivateStruct { fatalError() } // expected-warning {{property should not be declared fileprivate because its type uses a private type}} {{none}}
+  fileprivate typealias PrivateAlias = VeryPrivateStruct // expected-warning {{type alias should not be declared fileprivate because its underlying type uses a private type}} {{none}}
+  fileprivate subscript(_: VeryPrivateStruct) -> Void { return () } // expected-warning {{subscript should not be declared fileprivate because its index uses a private type}} {{none}}
+  fileprivate func privateMethod(_: VeryPrivateStruct) -> Void {} // expected-warning {{method should not be declared fileprivate because its parameter uses a private type}} {{none}}
+  fileprivate enum PrivateRawValue: VeryPrivateStruct {} // expected-warning {{enum should not be declared fileprivate because its raw type uses a private type}} {{none}}
+  // expected-error@-1 {{raw type 'Container.VeryPrivateStruct' is not expressible by any literal}}
+  // expected-error@-2 {{'Container.PrivateRawValue' declares raw type 'Container.VeryPrivateStruct', but does not conform to RawRepresentable and conformance could not be synthesized}}
+  fileprivate enum PrivatePayload {
+    case A(VeryPrivateStruct) // expected-warning {{enum case in an internal enum uses a private type}} {{none}}
+  }
+
+  private class PrivateInnerClass {} // expected-note * {{declared here}}
+  fileprivate class PrivateSuperClass: PrivateInnerClass {} // expected-warning {{class should not be declared fileprivate because its superclass is private}} {{none}}
+  fileprivate class PrivateGenericUser<T> where T: PrivateInnerClass {} // expected-warning {{generic class should not be declared fileprivate because its generic requirement uses a private type}} {{none}}
+  // expected-error@-1 {{type 'PrivateGenericUser' cannot be nested in extension of generic type 'Container'}}
+  // FIXME expected-error@-2 {{cannot conform to class protocol 'AnyObject'}}
+}
+
+fileprivate struct SR2579 {
+  private struct Inner {
+    private struct InnerPrivateType {}
+    var innerProperty = InnerPrivateType() // expected-warning {{property should be declared private because its type 'SR2579.Inner.InnerPrivateType' uses a private type}}
+  }
+  // FIXME: We need better errors when one access violation results in more
+  // downstream.
+  private var outerProperty = Inner().innerProperty // expected-warning {{property should not be declared in this context because its type 'SR2579.Inner.InnerPrivateType' uses a private type}}
+  var outerProperty2 = Inner().innerProperty // expected-warning {{property should be declared private because its type 'SR2579.Inner.InnerPrivateType' uses a private type}}
+}

--- a/test/Sema/accessibility_private.swift
+++ b/test/Sema/accessibility_private.swift
@@ -188,7 +188,7 @@ extension Container {
   fileprivate func privateMethod(_: VeryPrivateStruct) -> Void {} // expected-warning {{method should not be declared fileprivate because its parameter uses a private type}} {{none}}
   fileprivate enum PrivateRawValue: VeryPrivateStruct {} // expected-warning {{enum should not be declared fileprivate because its raw type uses a private type}} {{none}}
   // expected-error@-1 {{raw type 'Container.VeryPrivateStruct' is not expressible by any literal}}
-  // expected-error@-2 {{'Container.PrivateRawValue' declares raw type 'Container.VeryPrivateStruct', but does not conform to RawRepresentable and conformance could not be synthesized}}
+  // expected-error@-2 {{type 'Container.PrivateRawValue' does not conform to protocol 'RawRepresentable'}}
   fileprivate enum PrivatePayload {
     case A(VeryPrivateStruct) // expected-warning {{enum case in an internal enum uses a private type}} {{none}}
   }


### PR DESCRIPTION
- **Explanation:** An early exit from Swift 2's access control checking was causing us not to check access at all for the types of private declarations in Swift 3. Removing the early exit alone could result in breaking code that was valid in Swift 3.0GM, so instead this logic downgrades any check that would have been skipped to a warning. We can remove this downgrading in the future.
- **Scope:** Affects checking for the types of any declarations declared `private` or `fileprivate`, or nested within types declared `private` or `fileprivate`.
- **Issue:** [SR-2579](https://bugs.swift.org/browse/SR-2579)
- **Reviewed by:** @jckarter  
- **Risk:** Low. Should only introduce warnings, not errors, and does no more work than you'd already get for `internal` or `public` checking.
- **Testing:** Added compiler regression tests, verified that the originally reported case now gets a warning.
