### PR TITLE
Use the existing '.rawValue' fix-it to handle unwrapping objects too.

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3719,7 +3719,7 @@ static bool tryRawRepresentableFixIts(InFlightDiagnostic &diag,
       std::string convWrapBefore;
       std::string convWrapAfter = ".rawValue";
       if (rawTy->getCanonicalType() != toType->getCanonicalType()) {
-        convWrapBefore += rawTy->getString();
+        convWrapBefore += toType->getString();
         convWrapBefore += "(";
         convWrapAfter += ")";
       }

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3582,15 +3582,14 @@ bool FailureDiagnosis::diagnoseCalleeResultContextualConversionError() {
 
 
 /// Return true if the given type conforms to a known protocol type.
-static bool isExpressibleByLiteralType(Type fromType,
-                                     KnownProtocolKind kind,
-                                     ConstraintSystem *CS) {
-  auto integerType =
-    CS->TC.getProtocol(SourceLoc(), kind);
-  if (!integerType)
+static bool conformsToKnownProtocol(Type fromType,
+                                    KnownProtocolKind kind,
+                                    ConstraintSystem *CS) {
+  auto proto = CS->TC.getProtocol(SourceLoc(), kind);
+  if (!proto)
     return false;
 
-  if (CS->TC.conformsToProtocol(fromType, integerType, CS->DC,
+  if (CS->TC.conformsToProtocol(fromType, proto, CS->DC,
                                 ConformanceCheckFlags::InExpression)) {
     return true;
   }
@@ -3599,9 +3598,9 @@ static bool isExpressibleByLiteralType(Type fromType,
 }
 
 static bool isIntegerType(Type fromType, ConstraintSystem *CS) {
-  return isExpressibleByLiteralType(fromType,
-                                  KnownProtocolKind::ExpressibleByIntegerLiteral,
-                                  CS);
+  return conformsToKnownProtocol(fromType,
+                                 KnownProtocolKind::ExpressibleByIntegerLiteral,
+                                 CS);
 }
 
 /// Return true if the given type conforms to RawRepresentable.
@@ -3631,7 +3630,7 @@ static Type isRawRepresentable(Type fromType,
                                KnownProtocolKind kind,
                                ConstraintSystem *CS) {
   Type rawTy = isRawRepresentable(fromType, CS);
-  if (!rawTy || !isExpressibleByLiteralType(rawTy, kind, CS))
+  if (!rawTy || !conformsToKnownProtocol(rawTy, kind, CS))
     return Type();
 
   return rawTy;
@@ -3642,7 +3641,7 @@ static Type isRawRepresentable(Type fromType,
 static bool isIntegerToStringIndexConversion(Type fromType, Type toType,
                                              ConstraintSystem *CS) {
   auto kind = KnownProtocolKind::ExpressibleByIntegerLiteral;
-  return (isExpressibleByLiteralType(fromType, kind, CS) &&
+  return (conformsToKnownProtocol(fromType, kind, CS) &&
           toType->getCanonicalType().getString() == "String.CharacterView.Index");
 }
 
@@ -3697,14 +3696,23 @@ static bool tryRawRepresentableFixIts(InFlightDiagnostic &diag,
     }
   };
 
-  if (isExpressibleByLiteralType(fromType, kind, CS)) {
+  if (conformsToKnownProtocol(fromType, kind, CS)) {
     if (auto rawTy = isRawRepresentable(toType, kind, CS)) {
       // Produce before/after strings like 'Result(rawValue: RawType(<expr>))'
       // or just 'Result(rawValue: <expr>)'.
       std::string convWrapBefore = toType.getString();
       convWrapBefore += "(rawValue: ";
       std::string convWrapAfter = ")";
-      if (rawTy->getCanonicalType() != fromType->getCanonicalType()) {
+      if (!CS->TC.isConvertibleTo(fromType, rawTy, CS->DC)) {
+        // Only try to insert a converting construction if the protocol is a
+        // literal protocol and not some other known protocol.
+        switch (kind) {
+#define EXPRESSIBLE_BY_LITERAL_PROTOCOL_WITH_NAME(name, _) \
+        case KnownProtocolKind::name: break;
+#define PROTOCOL_WITH_NAME(name, _) \
+        case KnownProtocolKind::name: return false;
+#include "swift/AST/KnownProtocols.def"
+        }
         convWrapBefore += rawTy->getString();
         convWrapBefore += "(";
         convWrapAfter += ")";
@@ -3715,10 +3723,19 @@ static bool tryRawRepresentableFixIts(InFlightDiagnostic &diag,
   }
 
   if (auto rawTy = isRawRepresentable(fromType, kind, CS)) {
-    if (isExpressibleByLiteralType(toType, kind, CS)) {
+    if (conformsToKnownProtocol(toType, kind, CS)) {
       std::string convWrapBefore;
       std::string convWrapAfter = ".rawValue";
-      if (rawTy->getCanonicalType() != toType->getCanonicalType()) {
+      if (!CS->TC.isConvertibleTo(rawTy, toType, CS->DC)) {
+        // Only try to insert a converting construction if the protocol is a
+        // literal protocol and not some other known protocol.
+        switch (kind) {
+#define EXPRESSIBLE_BY_LITERAL_PROTOCOL_WITH_NAME(name, _) \
+        case KnownProtocolKind::name: break;
+#define PROTOCOL_WITH_NAME(name, _) \
+        case KnownProtocolKind::name: return false;
+#include "swift/AST/KnownProtocols.def"
+        }
         convWrapBefore += toType->getString();
         convWrapBefore += "(";
         convWrapAfter += ")";
@@ -4179,6 +4196,9 @@ bool FailureDiagnosis::diagnoseContextualConversionError() {
                               expr) ||
     tryRawRepresentableFixIts(diag, CS, exprType, contextualType,
                               KnownProtocolKind::ExpressibleByStringLiteral,
+                              expr) ||
+    tryRawRepresentableFixIts(diag, CS, exprType, contextualType,
+                              KnownProtocolKind::AnyObject,
                               expr) ||
     tryIntegerCastFixIts(diag, CS, exprType, contextualType, expr) ||
     addTypeCoerceFixit(diag, CS, exprType, contextualType, expr);

--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -96,6 +96,29 @@ func testConvertSomeName(s: String) {
   testPassSomeName("\(s)}")
 }
 
+class WrappedClass {}
+class WrappedClassSub: WrappedClass {}
+struct ClassWrapper : RawRepresentable {
+  var rawValue: WrappedClass
+}
+func testPassAnyObject(_: AnyObject) {}
+func testPassAnyObjectOpt(_: AnyObject?) {}
+func testPassWrappedSub(_: WrappedClassSub) {}
+func testConvertClassWrapper(_ x: ClassWrapper, _ sub: WrappedClassSub) {
+  testPassAnyObject(x)
+  testPassAnyObjectOpt(x)
+  testPassWrappedSub(x)
+
+  let iuo: ClassWrapper! = x
+  testPassAnyObject(iuo)
+  testPassAnyObjectOpt(iuo)
+
+  let _: ClassWrapper = sub
+  let _: ClassWrapper = x.rawValue
+  // FIXME: This one inserts 'as!', which is incorrect.
+  let _: ClassWrapper = sub as AnyObject
+}
+
 enum MyEnumType : UInt32 {
   case invalid
 }

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -45,7 +45,7 @@ func testMask2(a: UInt64) {
   sendIt(MyEventMask2(rawValue: a))
 }
 func testMask3(a: MyEventMask2) {
-  testMask1(a: UInt64(a.rawValue))
+  testMask1(a: Int(a.rawValue))
 }
 func testMask4(a: MyEventMask2) {
   testMask2(a: a.rawValue)
@@ -69,7 +69,7 @@ func testMask10(a: Int?) {
   sendIt(a) // no fix, nullability mismatch.
 }
 func testMask11(a: MyEventMask2?) {
-  testMask7(a: a.map { UInt64($0.rawValue) })
+  testMask7(a: a.map { Int($0.rawValue) })
 }
 func testMask12(a: MyEventMask2?) {
   testMask8(a: a.map { $0.rawValue })

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -96,6 +96,29 @@ func testConvertSomeName(s: String) {
   testPassSomeName(SomeName(rawValue: "\(s)}"))
 }
 
+class WrappedClass {}
+class WrappedClassSub: WrappedClass {}
+struct ClassWrapper : RawRepresentable {
+  var rawValue: WrappedClass
+}
+func testPassAnyObject(_: AnyObject) {}
+func testPassAnyObjectOpt(_: AnyObject?) {}
+func testPassWrappedSub(_: WrappedClassSub) {}
+func testConvertClassWrapper(_ x: ClassWrapper, _ sub: WrappedClassSub) {
+  testPassAnyObject(x.rawValue)
+  testPassAnyObjectOpt(x.rawValue)
+  testPassWrappedSub(x)
+
+  let iuo: ClassWrapper! = x
+  testPassAnyObject(iuo)
+  testPassAnyObjectOpt(iuo.map { $0.rawValue })
+
+  let _: ClassWrapper = ClassWrapper(rawValue: sub)
+  let _: ClassWrapper = ClassWrapper(rawValue: x.rawValue)
+  // FIXME: This one inserts 'as!', which is incorrect.
+  let _: ClassWrapper = sub as AnyObject as! ClassWrapper
+}
+
 enum MyEnumType : UInt32 {
   case invalid
 }


### PR DESCRIPTION
We could probably make this even more general, but this specifically avoids trying to insert an "as AnyObject" fix-it, which will now work but probably produce an incorrect result. This comes up when working with `swift_newtype` wrappers of CF types being passed to CFTypeRef parameters.

While here, also fix a copy/paste issue with the existing logic.

rdar://problem/26678862
