### PR TITLE
[CMake] swiftClangImporter should depend on CLANG_TABLEGEN_TARGETS

### DIFF
--- a/lib/ClangImporter/CMakeLists.txt
+++ b/lib/ClangImporter/CMakeLists.txt
@@ -25,6 +25,8 @@ add_swift_library(swiftClangImporter STATIC
     swiftParse
 )
 
+# This property is only set by calls to clang_tablegen. It will not be set on
+# standalone builds, so it can always be safely passed.
 get_property(CLANG_TABLEGEN_TARGETS GLOBAL PROPERTY CLANG_TABLEGEN_TARGETS)
 add_dependencies(swiftClangImporter
                 "${generated_include_targets}"

--- a/lib/ClangImporter/CMakeLists.txt
+++ b/lib/ClangImporter/CMakeLists.txt
@@ -25,5 +25,7 @@ add_swift_library(swiftClangImporter STATIC
     swiftParse
 )
 
-
-add_dependencies(swiftClangImporter "${generated_include_targets}")
+get_property(CLANG_TABLEGEN_TARGETS GLOBAL PROPERTY CLANG_TABLEGEN_TARGETS)
+add_dependencies(swiftClangImporter
+                "${generated_include_targets}"
+                ${CLANG_TABLEGEN_TARGETS})


### PR DESCRIPTION
Since the swiftClangImporter library uses generated headers from the clang tablegen targets it should have an explicit dependency. This fixes a dependency issue building swift in-tree with LLVM & Clang, and will not impact build-script builds because CLANG_TABLEGEN_TARGETS will be empty.
