### PR TITLE
[Type checker] Use proper lookup type in substitutions for #keyPath.

### DIFF
--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -33,6 +33,16 @@ class C {
   var nonObjC: String? // expected-note{{add '@objc' to expose this var to Objective-C}}{{3-3=@objc }}
 }
 
+extension NSArray {
+  @objc class Foo : NSObject {
+    @objc var propString: String = ""
+  }
+}
+
+extension Array {
+  typealias Foo = NSArray.Foo
+}
+
 func testKeyPath(a: A, b: B) {
   // Property
   let _: String = #keyPath(A.propB)
@@ -84,6 +94,10 @@ func testKeyPath(a: A, b: B) {
 
   // Property with keyword name.
   let _: String = #keyPath(A.repeat)
+
+  // Nested type of a bridged type (rdar://problem/28061409).
+  typealias IntArray = [Int]
+  let _: String = #keyPath(IntArray.Foo.propString)
 }
 
 func testAsStaticString() {


### PR DESCRIPTION
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves rdar://problem/28061409.](rdar://problem/28061409.).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
