### PR TITLE
Escape analysis fix (3.0)

### DIFF
--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -560,8 +560,10 @@ bool EscapeAnalysis::ConnectionGraph::isReachable(CGNode *From, CGNode *To) {
   From->isInWorkList = true;
   for (unsigned Idx = 0; Idx < WorkList.size(); ++Idx) {
     CGNode *Reachable = WorkList[Idx];
-    if (Reachable == To)
+    if (Reachable == To) {
+      clearWorkListFlags(WorkList);
       return true;
+    }
     for (Predecessor Pred : Reachable->Preds) {
       CGNode *PredNode = Pred.getPointer();
       if (!PredNode->isInWorkList) {


### PR DESCRIPTION
- Description: Escape analysis could return inconsistent results when queried multiple times about local allocations which nevertheless escape. Alias analysis in turn relies on escape analysis so a lot of downstream passes were potentially affected, but in particular this came up with ARC code motion.
- Scope of the issue: This could affect anyone, and since it can manifest as a miscompile it is particularly nasty. However, the workaround is simple -- build without optimization.
- Risk: Low, the fix is "obviously correct".
- Tested: I'm still working on a reduced test case. This bug triggers in the form of existing tests failing with some other changes I have for master, but the underlying issue should exist in 3.0 also.
- Radar: rdar://problem/28435907
