### PR TITLE
Remove an assert and instead return nullptr.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3148,9 +3148,8 @@ namespace {
         return nullptr;
 
       // Convert the subexpression.
-      bool failed = tc.convertToType(sub, toType, cs.DC);
-      (void)failed;
-      assert(!failed && "Not convertible?");
+      if (tc.convertToType(sub, toType, cs.DC))
+        return nullptr;
 
       expr->setSubExpr(sub);
       expr->setType(toType);

--- a/test/Sema/diag_express_tuple.swift
+++ b/test/Sema/diag_express_tuple.swift
@@ -11,3 +11,9 @@ func rdar28207648() -> [(Int, CustomStringConvertible)] {
   return v as [(Int, CustomStringConvertible)] // expected-error {{cannot express tuple conversion '(Int, Int)' to '(Int, CustomStringConvertible)'}}
 }
 
+class rdar28207648Base {}
+class rdar28207648Derived : rdar28207648Base {}
+
+func rdar28207648(x: (Int, rdar28207648Derived)) -> (Int, rdar28207648Base) {
+  return x as (Int, rdar28207648Base) // expected-error {{cannot express tuple conversion '(Int, rdar28207648Derived)' to '(Int, rdar28207648Base)'}}
+}


### PR DESCRIPTION
We were asserting in ExprRewriter::visitCoerceExpr() that the conversion
we attempt is successfully. However, we have known cases where we will
emit a diagnostic and fail attempting to convert, so we should really
just bail out at this point rather than asserting.

Resovles the last part of rdar://problem/28207648.
