### PR TITLE
Revert "Add empty parens to var-to-function renames" (#3947)

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1479,11 +1479,6 @@ void swift::fixItAvailableAttrRename(TypeChecker &TC,
       baseReplace += '.';
     }
     baseReplace += parsed.BaseName;
-    if (parsed.IsFunctionName && parsed.ArgumentLabels.empty() && !call) {
-      // If we're going from a var to a function with no arguments, emit an
-      // empty parameter list.
-      baseReplace += "()";
-    }
     diag.fixItReplace(referenceRange, baseReplace);
   }
 

--- a/test/Sema/availability.swift
+++ b/test/Sema/availability.swift
@@ -130,18 +130,3 @@ func testPlatforms() {
   let _: UnavailableOnOSXAppExt = 0
   let _: UnavailableOnMacOSAppExt = 0
 }
-
-struct VarToFunc {
-  @available(*, unavailable, renamed: "function()")
-  var variable: Int { return 42 } // expected-note{{explicitly marked unavailable here}}
-
-  @available(*, unavailable, renamed: "function()")
-  func oldFunction() -> Int { return 42 } // expected-note{{explicitly marked unavailable here}}
-
-  func function() -> Int {
-    _ = variable // expected-error{{'variable' has been renamed to 'function()'}}{{9-17=function()}}
-    _ = oldFunction() //expected-error{{'oldFunction()' has been renamed to 'function()'}}{{9-20=function}}
-    return 42
-  }
-}
-

--- a/test/stdlib/Renames.swift
+++ b/test/stdlib/Renames.swift
@@ -519,8 +519,8 @@ func _String<S, C>(x: String, s: S, c: C, i: String.Index)
   x.replaceRange(i..<i, with: x) // expected-error {{'replaceRange(_:with:)' has been renamed to 'replaceSubrange'}} {{5-17=replaceSubrange}} {{none}}
   _ = x.removeAtIndex(i) // expected-error {{'removeAtIndex' has been renamed to 'remove(at:)'}} {{9-22=remove}} {{23-23=at: }} {{none}}
   x.removeRange(i..<i) // expected-error {{'removeRange' has been renamed to 'removeSubrange'}} {{5-16=removeSubrange}} {{none}}
-  _ = x.lowercaseString // expected-error {{'lowercaseString' has been renamed to 'lowercased()'}} {{9-24=lowercased()}} {{none}}
-  _ = x.uppercaseString // expected-error {{'uppercaseString' has been renamed to 'uppercased()'}} {{9-24=uppercased()}} {{none}}
+  _ = x.lowercaseString // expected-error {{'lowercaseString' has been renamed to 'lowercased()'}} {{9-24=lowercased}} {{none}}
+  _ = x.uppercaseString // expected-error {{'uppercaseString' has been renamed to 'uppercased()'}} {{9-24=uppercased}} {{none}}
   // FIXME: SR-1649 <rdar://problem/26563343>; We should suggest to add '()'
 }
 func _String<S : Sequence>(s: S, sep: String) where S.Iterator.Element == String {


### PR DESCRIPTION
"!call" doesn't imply "variable", so the fix-it isn't always correct. See discussion in #3947.

This reverts commit a99ca851df88859f05ad6bdcfedff586ef9d2dbc.
