### PR TITLE
Don't use construction to convert literals in rawValue fix-it.

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3584,7 +3584,7 @@ bool FailureDiagnosis::diagnoseCalleeResultContextualConversionError() {
 /// Return true if the given type conforms to a known protocol type.
 static bool conformsToKnownProtocol(Type fromType,
                                     KnownProtocolKind kind,
-                                    ConstraintSystem *CS) {
+                                    const ConstraintSystem *CS) {
   auto proto = CS->TC.getProtocol(SourceLoc(), kind);
   if (!proto)
     return false;
@@ -3597,7 +3597,7 @@ static bool conformsToKnownProtocol(Type fromType,
   return false;
 }
 
-static bool isIntegerType(Type fromType, ConstraintSystem *CS) {
+static bool isIntegerType(Type fromType, const ConstraintSystem *CS) {
   return conformsToKnownProtocol(fromType,
                                  KnownProtocolKind::ExpressibleByIntegerLiteral,
                                  CS);
@@ -3605,7 +3605,7 @@ static bool isIntegerType(Type fromType, ConstraintSystem *CS) {
 
 /// Return true if the given type conforms to RawRepresentable.
 static Type isRawRepresentable(Type fromType,
-                               ConstraintSystem *CS) {
+                               const ConstraintSystem *CS) {
   auto rawReprType =
     CS->TC.getProtocol(SourceLoc(), KnownProtocolKind::RawRepresentable);
   if (!rawReprType)
@@ -3628,7 +3628,7 @@ static Type isRawRepresentable(Type fromType,
 /// underlying type conforming to the given known protocol.
 static Type isRawRepresentable(Type fromType,
                                KnownProtocolKind kind,
-                               ConstraintSystem *CS) {
+                               const ConstraintSystem *CS) {
   Type rawTy = isRawRepresentable(fromType, CS);
   if (!rawTy || !conformsToKnownProtocol(rawTy, kind, CS))
     return Type();
@@ -3659,11 +3659,11 @@ static bool isIntegerToStringIndexConversion(Type fromType, Type toType,
 ///
 /// This helps migration with SDK changes.
 static bool tryRawRepresentableFixIts(InFlightDiagnostic &diag,
-                                      ConstraintSystem *CS,
+                                      const ConstraintSystem *CS,
                                       Type fromType,
                                       Type toType,
                                       KnownProtocolKind kind,
-                                      Expr *expr) {
+                                      const Expr *expr) {
   // The following fixes apply for optional destination types as well.
   bool toTypeIsOptional = !toType->getAnyOptionalObjectType().isNull();
   toType = toType->lookThroughAllAnyOptionalTypes();
@@ -3703,7 +3703,8 @@ static bool tryRawRepresentableFixIts(InFlightDiagnostic &diag,
       std::string convWrapBefore = toType.getString();
       convWrapBefore += "(rawValue: ";
       std::string convWrapAfter = ")";
-      if (!CS->TC.isConvertibleTo(fromType, rawTy, CS->DC)) {
+      if (!isa<LiteralExpr>(expr) &&
+          !CS->TC.isConvertibleTo(fromType, rawTy, CS->DC)) {
         // Only try to insert a converting construction if the protocol is a
         // literal protocol and not some other known protocol.
         switch (kind) {

--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -77,6 +77,10 @@ func testMask12(a: MyEventMask2?) {
 func testMask13(a: MyEventMask2?) {
   testMask1(a: a) // no fix, nullability mismatch.
 }
+func testMask14() {
+  sendIt(1)
+  sendItOpt(2)
+}
 
 struct Wrapper {
   typealias InnerMask = MyEventMask2

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -77,6 +77,10 @@ func testMask12(a: MyEventMask2?) {
 func testMask13(a: MyEventMask2?) {
   testMask1(a: a) // no fix, nullability mismatch.
 }
+func testMask14() {
+  sendIt(MyEventMask2(rawValue: 1))
+  sendItOpt(MyEventMask2(rawValue: 2))
+}
 
 struct Wrapper {
   typealias InnerMask = MyEventMask2


### PR DESCRIPTION
```
     Input:  panel.styleMask = 8345
Old output:  panel.styleMask = NSWindowStyleMask(rawValue: UInt(8345))
New output:  panel.styleMask = NSWindowStyleMask(rawValue: 8345)
```

rdar://problem/26681232
