### PR TITLE
Fix crash on typecheck failure in interpolated strings.

### DIFF
--- a/validation-test/Sema/type_checker_crashers/rdar27830834.swift
+++ b/validation-test/Sema/type_checker_crashers/rdar27830834.swift
@@ -1,4 +1,0 @@
-// RUN: not --crash %target-swift-frontend %s -parse
-
-var d = [String:String]()
-_ = "\(d.map{ [$0 : $0] })"

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar27830834.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar27830834.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-frontend %s -parse -verify
+
+var d = [String:String]()
+_ = "\(d.map{ [$0 : $0] })" // expected-error {{type of expression is ambiguous without more context}}


### PR DESCRIPTION
We were attempting to clean up stray type variables before creating a
new constraint system and moving forward with narrowing down the
typecheck failure, but we were failing to remove type variables for
interpolated strings.

Fix that, as well as removing them from TypeExpr's, and add an assert
that on exit from the pre-order visitor we don't have any type
variables (except for literals that aren't interpolated strings, which
I'm going to dig into further).

Fixes rdar://problem/27830834 and SR-2716.
