### PR TITLE
Debug Info: Insert dbg.value intrinsics immediately after the instruction they describe.

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.h
+++ b/lib/IRGen/IRGenDebugInfo.h
@@ -188,7 +188,7 @@ public:
                                ArtificialKind = RealValue);
 
   /// Emit a dbg.declare or dbg.value intrinsic, depending on Storage.
-  void emitDbgIntrinsic(llvm::BasicBlock *BB, llvm::Value *Storage,
+  void emitDbgIntrinsic(IRBuilder &Builder, llvm::Value *Storage,
                         llvm::DILocalVariable *Var, llvm::DIExpression *Expr,
                         unsigned Line, unsigned Col, llvm::DILocalScope *Scope,
                         const SILDebugScope *DS);

--- a/test/DebugInfo/dbgvalue-insertpt.swift
+++ b/test/DebugInfo/dbgvalue-insertpt.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -g -emit-ir %s | %FileCheck %s
+for i in 0 ..< 3 {
+  // CHECK: %[[ALLOCA:[0-9]+]] = alloca %GSqSi_
+  // CHECK: %[[CAST:[0-9]+]] = bitcast %GSqSi_* %[[ALLOCA]] to i{{32|64}}*
+  // CHECK: %[[LD:[0-9]+]] = load i{{32|64}}, i{{32|64}}* %[[CAST]]
+  // CHECK-NEXT: call void @llvm.dbg.value(metadata i{{32|64}} %[[LD]],
+  // CHECK-SAME:                           metadata ![[I:[0-9]+]],
+  // CHECK: ![[I]] = !DILocalVariable(name: "i",
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->

```
Debug Info: Insert dbg.value intrinsics immediately after the instruction
they describe.

This improves the live ranges of local variables during debugging.

<rdar://problem/26627376>
```

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
