### PR TITLE
Update switch statements for recent LLVM update.

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -235,6 +235,7 @@ namespace {
       // FIXME: Types that can be mapped, but aren't yet.
       case clang::BuiltinType::Half:
       case clang::BuiltinType::LongDouble:
+      case clang::BuiltinType::Float128:
       case clang::BuiltinType::NullPtr:
         return Type();
 

--- a/lib/IRGen/GenClangType.cpp
+++ b/lib/IRGen/GenClangType.cpp
@@ -77,8 +77,11 @@ getClangBuiltinTypeFromKind(const clang::ASTContext &context,
   case clang::BuiltinType::Id:                                                 \
     return context.SingletonId;
 #include "clang/AST/BuiltinTypes.def"
+#define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix)                   \
+  case clang::BuiltinType::Id:                                                 \
+    return context.SingletonId;
+#include "clang/Basic/OpenCLImageTypes.def"
   }
-  llvm_unreachable("Unexpected builtin type!");
 }
 
 static clang::CanQualType getClangSelectorType(


### PR DESCRIPTION
Cleans up the warnings we've been seeing. No intended functionality change.
