### PR TITLE
[build-presets] Skip libdispatch tests for XCTest

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -296,6 +296,7 @@ dash-dash
 # being run.
 skip-test-cmark
 skip-test-swift
+skip-test-libdispatch
 skip-test-foundation
 
 # This preset may be used by swift-corelibs-xctest contributors when building


### PR DESCRIPTION
<!-- What's in this pull request? -->

The `corelibs-xctest` preset is one that swift-corelibs-xctest contributors could use locally to quickly ensure that XCTest builds and its tests pass. The libdispatch tests add a significant amount of time to this preset, so remove them.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
