### PR TITLE
Don't use construction to convert literals in rawValue fix-it.

### DIFF
--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -77,6 +77,10 @@ func testMask12(a: MyEventMask2?) {
 func testMask13(a: MyEventMask2?) {
   testMask1(a: a) // no fix, nullability mismatch.
 }
+func testMask14() {
+  sendIt(1)
+  sendItOpt(2)
+}
 
 struct Wrapper {
   typealias InnerMask = MyEventMask2

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -77,6 +77,10 @@ func testMask12(a: MyEventMask2?) {
 func testMask13(a: MyEventMask2?) {
   testMask1(a: a) // no fix, nullability mismatch.
 }
+func testMask14() {
+  sendIt(MyEventMask2(rawValue: 1))
+  sendItOpt(MyEventMask2(rawValue: 2))
+}
 
 struct Wrapper {
   typealias InnerMask = MyEventMask2


### PR DESCRIPTION
- **Explanation:** We have a fix-it for when the user tries to pass a bare value to a type that's RawRepresentable with that type, as long as it's a type that's expressible-by-literal. The fix-it is smart enough to insert an extra converting construction if the raw value type doesn't match exactly, but it's _not_ smart enough to omit that if the bare value is itself a literal (and would be inferred to the correct type). Fix that by just checking for a literal expression before inserting the conversion.
- **Scope:** Affects failure diagnosis involving RawRepresentable types.
- **Issue:** rdar://problem/26681232
- **Reviewed by:** @nkcsgexi    
- **Risk:** Very low.
- **Testing:** Added a compiler regression test, verified that the originally reported case now gets useful fix-its.
