### PR TITLE
Fix crash on typecheck failure in interpolated strings.

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3086,7 +3086,14 @@ namespace {
         
         std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
           TS->ExprTypes[expr] = expr->getType();
-          
+
+          SWIFT_DEFER {
+            assert((!expr->getType() || !expr->getType()->hasTypeVariable()
+                    // FIXME: We shouldn't allow these, either.
+                    || isa<LiteralExpr>(expr)) &&
+                   "Type variable didn't get erased!");
+          };
+
           // Preserve module expr type data to prevent further lookups.
           if (auto *declRef = dyn_cast<DeclRefExpr>(expr))
             if (isa<ModuleDecl>(declRef->getDecl()))
@@ -3097,17 +3104,13 @@ namespace {
           if (isa<OtherConstructorDeclRefExpr>(expr))
             return { false, expr };
           
-          // TypeExpr's are relabeled by CSGen.
-          if (isa<TypeExpr>(expr))
-            return { false, expr };
-          
           // If a literal has a Builtin.Int or Builtin.FP type on it already,
           // then sema has already expanded out a call to
           //   Init.init(<builtinliteral>)
           // and we don't want it to make
           //   Init.init(Init.init(<builtinliteral>))
           // preserve the type info to prevent this from happening.
-          if (isa<LiteralExpr>(expr) &&
+          if (isa<LiteralExpr>(expr) && !isa<InterpolatedStringLiteralExpr>(expr) &&
               !(expr->getType() && expr->getType()->is<ErrorType>()))
             return { false, expr };
 

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar27830834.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar27830834.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-frontend %s -parse -verify
+
+var d = [String:String]()
+_ = "\(d.map{ [$0 : $0] })" // expected-error {{type of expression is ambiguous without more context}}


### PR DESCRIPTION
We were attempting to clean up stray type variables before creating a
new constraint system and moving forward with narrowing down the
typecheck failure, but we were failing to remove type variables for
interpolated strings.

Fix that, as well as removing them from TypeExpr's, and add an assert
that on exit from the pre-order visitor we don't have any type
variables (except for literals that aren't interpolated strings, which
I'm going to dig into further).

Fixes rdar://problem/27830834 and SR-2716.

(cherry picked from commit b44a93ea8438264cbf48bc9f755310322db4f0ed)
