### PR TITLE
[stdlib] Bug in Windows swift_vasprintf()

### DIFF
--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -242,7 +242,7 @@ static int swift_vasprintf(char **strp, const char *fmt, va_list ap) {
   char *buffer = reinterpret_cast<char *>(malloc(len + 1));
   if (!buffer)
     return -1;
-  int result = vsprintf(*strp, fmt, ap);
+  int result = vsprintf(buffer, fmt, ap);
   if (result < 0) {
     free(buffer);
     return -1;


### PR DESCRIPTION
Drive by fix of a bug in the Windows version of swift_vasprintf(). I have no means of testing this.

Resolves [SR-2735](https://bugs.swift.org/browse/SR-2735).
