### PR TITLE
[CloudKit overlay] Work around an NSError bridging issue specific to CKError.

### DIFF
--- a/stdlib/public/SDK/CloudKit/CloudKit.swift
+++ b/stdlib/public/SDK/CloudKit/CloudKit.swift
@@ -4,8 +4,9 @@ import Foundation
 @available(macOS 10.10, iOS 8.0, *)
 extension CKError {
   /// Retrieve partial error results associated by item ID.
-  public var partialErrorsByItemID: [NSObject : Error]? {
-    return userInfo[CKPartialErrorsByItemIDKey] as? [NSObject : Error]
+  public var partialErrorsByItemID: [AnyHashable: Error]? {
+    return userInfo[CKPartialErrorsByItemIDKey] as? [AnyHashable: NSError]
+             as? [AnyHashable: Error]
   }
 
   /// The original CKRecord object that you used as the basis for

--- a/validation-test/stdlib/AnyHashable.swift.gyb
+++ b/validation-test/stdlib/AnyHashable.swift.gyb
@@ -773,9 +773,7 @@ AnyHashableTests.test("AnyHashable(Wrappers)/Hashable") {
   checkHashable(values, equalityOracle: equalityOracle,
                 allowBrokenTransitivity: true)
 }
-#endif
 
-#if _runtime(_ObjC)
 AnyHashableTests.test("AnyHashable(_SwiftNativeNSError(MinimalHashablePODSwiftError))/Hashable") {
   let swiftErrors: [MinimalHashablePODSwiftError] = [
     .caseA, .caseA,


### PR DESCRIPTION
<!-- What's in this pull request? -->

Cleans up the signature for `CKError.partialErrorsByItemID` and works around a bridging issue with an `NSError` subclass.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [rdar://problem/27936562](rdar://problem/27936562).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
