### PR TITLE
[3.0] [AnyHashable] Handle comparisons/casting for wrappers around bridged types

### DIFF
--- a/stdlib/public/core/AnyHashable.swift
+++ b/stdlib/public/core/AnyHashable.swift
@@ -41,7 +41,11 @@ internal protocol _AnyHashableBox {
   var _typeID: ObjectIdentifier { get }
   func _unbox<T : Hashable>() -> T?
 
-  func _isEqual(to: _AnyHashableBox) -> Bool
+  /// Determine whether values in the boxes are equivalent.
+  ///
+  /// - Returns: `nil` to indicate that the boxes store different types, so
+  ///   no comparison is possible. Otherwise, contains the result of `==`.
+  func _isEqual(to: _AnyHashableBox) -> Bool?
   var _hashValue: Int { get }
 
   var _base: Any { get }
@@ -62,11 +66,11 @@ internal struct _ConcreteHashableBox<Base : Hashable> : _AnyHashableBox {
     return (self as _AnyHashableBox as? _ConcreteHashableBox<T>)?._baseHashable
   }
 
-  internal func _isEqual(to rhs: _AnyHashableBox) -> Bool {
+  internal func _isEqual(to rhs: _AnyHashableBox) -> Bool? {
     if let rhs: Base = rhs._unbox() {
       return _baseHashable == rhs
     }
-    return false
+    return nil
   }
 
   internal var _hashValue: Int {
@@ -84,6 +88,18 @@ internal struct _ConcreteHashableBox<Base : Hashable> : _AnyHashableBox {
     return true;
   }
 }
+
+#if _runtime(_ObjC)
+// Retrieve the custom AnyHashable representation of the value after it
+// has been bridged to Objective-C. This mapping to Objective-C and back
+// turns a non-custom representation into a custom one, which is used as
+// the lowest-common-denominator for comparisons.
+func _getBridgedCustomAnyHashable<T>(_ value: T) -> AnyHashable? {
+  let bridgedValue = _bridgeAnythingToObjectiveC(value)
+  return (bridgedValue as?
+    _HasCustomAnyHashableRepresentation)?._toCustomAnyHashable()
+}
+#endif
 
 /// A type-erased hashable value.
 ///
@@ -106,6 +122,7 @@ internal struct _ConcreteHashableBox<Base : Hashable> : _AnyHashableBox {
 ///     print(descriptions[AnyHashable(Set(["a", "b"]))]!) // prints "a set of strings"
 public struct AnyHashable {
   internal var _box: _AnyHashableBox
+  internal var _usedCustomRepresentation: Bool
 
   /// Creates a type-erased hashable value that wraps the given instance.
   ///
@@ -129,10 +146,12 @@ public struct AnyHashable {
     if let customRepresentation =
       (base as? _HasCustomAnyHashableRepresentation)?._toCustomAnyHashable() {
       self = customRepresentation
+      self._usedCustomRepresentation = true
       return
     }
 
     self._box = _ConcreteHashableBox(0 as Int)
+    self._usedCustomRepresentation = false
     _stdlib_makeAnyHashableUpcastingToHashableBaseType(
       base,
       storingResultInto: &self)
@@ -140,6 +159,7 @@ public struct AnyHashable {
 
   internal init<H : Hashable>(_usingDefaultRepresentationOf base: H) {
     self._box = _ConcreteHashableBox(base)
+    self._usedCustomRepresentation = false
   }
 
   /// The value wrapped by this instance.
@@ -162,7 +182,21 @@ public struct AnyHashable {
   /// a downcast on `base`.
   internal
   func _downCastConditional<T>(into result: UnsafeMutablePointer<T>) -> Bool {
-    return _box._downCastConditional(into: result)
+    // Attempt the downcast.
+    if _box._downCastConditional(into: result) { return true }
+
+    #if _runtime(_ObjC)
+    // If we used a custom representation, bridge to Objective-C and then
+    // attempt the cast from there.
+    if _usedCustomRepresentation {
+      if let value = _bridgeAnythingToObjectiveC(_box._base) as? T {
+        result.initialize(to: value)
+        return true
+      }
+    }
+    #endif
+
+    return false
   }
 }
 
@@ -193,7 +227,34 @@ extension AnyHashable : Equatable {
   ///   - lhs: A type-erased hashable value.
   ///   - rhs: Another type-erased hashable value.
   public static func == (lhs: AnyHashable, rhs: AnyHashable) -> Bool {
-    return lhs._box._isEqual(to: rhs._box)
+    // If they're equal, we're done.
+    if let result = lhs._box._isEqual(to: rhs._box) { return result }
+
+    #if _runtime(_ObjC)
+    // If one used a custom representation but the other did not, bridge
+    // the one that did *not* use the custom representation to Objective-C:
+    // if the bridged result has a custom representation, compare those custom
+    // custom representations.
+    if lhs._usedCustomRepresentation != rhs._usedCustomRepresentation {
+      // If the lhs used a custom representation, try comparing against the
+      // custom representation of the bridged rhs (if there is one).
+      if lhs._usedCustomRepresentation {
+        if let customRHS = _getBridgedCustomAnyHashable(rhs._box._base) {
+          return lhs._box._isEqual(to: customRHS._box) ?? false
+        }
+        return false
+      }
+
+      // Otherwise, try comparing the rhs against the custom representation of
+      // the bridged lhs (if there is one).
+      if let customLHS = _getBridgedCustomAnyHashable(lhs._box._base) {
+        return customLHS._box._isEqual(to: rhs._box) ?? false
+      }
+      return false
+    }
+    #endif
+
+    return false
   }
 }
 

--- a/test/1_stdlib/AnyHashableCasts.swift.gyb
+++ b/test/1_stdlib/AnyHashableCasts.swift.gyb
@@ -9,6 +9,10 @@
 
 import StdlibUnittest
 
+#if _runtime(_ObjC)
+import Foundation
+#endif
+
 var AnyHashableCasts = TestSuite("AnyHashableCasts")
 
 protocol Implemented {}
@@ -111,5 +115,42 @@ AnyHashableCasts.test("${valueExpr} as ${coercedType} as? ${castType}") {
   }
 }
 % end
+
+#if _runtime(_ObjC)
+// A wrapper type around a String that bridges to NSString.
+struct StringWrapper1 : _SwiftNewtypeWrapper, Hashable, _ObjectiveCBridgeable {
+  let rawValue: String
+}
+
+// A wrapper type around a String that bridges to NSString.
+struct StringWrapper2 : _SwiftNewtypeWrapper, Hashable, _ObjectiveCBridgeable {
+  let rawValue: String
+}
+
+AnyHashableCasts.test("Wrappers around bridged types") {
+  let wrapper1Hello: AnyHashable = StringWrapper1(rawValue: "hello")
+  let stringHello: AnyHashable = "hello" as String
+  let nsStringHello: AnyHashable = "hello" as NSString
+
+  // Casting from Swift wrapper maintains type identity
+  expectNotEmpty(wrapper1Hello as? StringWrapper1)
+  expectEmpty(wrapper1Hello as? StringWrapper2)
+  expectEmpty(wrapper1Hello as? String)
+  expectNotEmpty(wrapper1Hello as? NSString)
+
+  // Casting from String maintains type identity
+  expectEmpty(stringHello as? StringWrapper1)
+  expectEmpty(stringHello as? StringWrapper2)
+  expectNotEmpty(stringHello as? String)
+  expectNotEmpty(stringHello as? NSString)
+
+  // Casting form NSString works with anything.
+  expectNotEmpty(nsStringHello as? StringWrapper1)
+  expectNotEmpty(nsStringHello as? StringWrapper2)
+  expectNotEmpty(nsStringHello as? String)
+  expectNotEmpty(nsStringHello as? NSString)
+}
+
+#endif
 
 runAllTests()

--- a/validation-test/stdlib/AnyHashable.swift.gyb
+++ b/validation-test/stdlib/AnyHashable.swift.gyb
@@ -736,6 +736,46 @@ AnyHashableTests.test("AnyHashable(MinimalHashableRCSwiftError).base") {
 }
 
 #if _runtime(_ObjC)
+// A wrapper type around a String that bridges to NSString.
+struct StringWrapper1 : _SwiftNewtypeWrapper, Hashable, _ObjectiveCBridgeable {
+  let rawValue: String
+}
+
+// A wrapper type around a String that bridges to NSString.
+struct StringWrapper2 : _SwiftNewtypeWrapper, Hashable, _ObjectiveCBridgeable {
+  let rawValue: String
+}
+
+AnyHashableTests.test("AnyHashable(Wrappers)/Hashable") {
+  let values: [AnyHashable] = [
+    StringWrapper1(rawValue: "hello"),
+    StringWrapper2(rawValue: "hello"),
+    "hello" as String,
+    "hello" as NSString,
+    StringWrapper1(rawValue: "world"),
+    StringWrapper2(rawValue: "world"),
+    "world" as String,
+    "world" as NSString,
+  ]
+
+  func equalityOracle(_ lhs: Int, _ rhs: Int) -> Bool {
+    // Elements in [0, 3] match 3.
+    if lhs == 3 { return rhs >= 0 && rhs <= 3 }
+    if rhs == 3 { return lhs >= 0 && lhs <= 3 }
+
+    // Elements in [4, 7] match 7.
+    if lhs == 7 { return rhs >= 4 && rhs <= 7 }
+    if rhs == 7 { return lhs >= 4 && lhs <= 7 }
+
+    return lhs == rhs
+  }
+
+  checkHashable(values, equalityOracle: equalityOracle,
+                allowBrokenTransitivity: true)
+}
+#endif
+
+#if _runtime(_ObjC)
 AnyHashableTests.test("AnyHashable(_SwiftNativeNSError(MinimalHashablePODSwiftError))/Hashable") {
   let swiftErrors: [MinimalHashablePODSwiftError] = [
     .caseA, .caseA,


### PR DESCRIPTION
<!-- What's in this pull request? -->

Swift value types are their bridged Objective-C classes can have
different hash values. To address this, AnyHashable's responds to the
_HasCustomAnyHashableRepresentation protocol, which bridge objects of
those class types---NSString, NSNumber, etc---into their Swift
counterparts. That way, we get consistent (Swift) hashing behavior
across platforms.

However, there are cases where multiple Swift value types map to the
same Objective-C class type. In such cases, AnyHashable ends up
converting the object of class type back to some canonical type. For
example, an NS_STRING_ENUM (such as (NS)RunLoopMode) is a Swift
wrapper around a String. If an (NS)RunLoopMode is placed into an
AnyHashable, it maintains it's Swift type identity (which is correct
behavior). If it is bridged to Objective-C, it becomes an NSString; if
that NSString is placed into an AnyHashable, it produces a String. The
hash values still line up, but equality of the AnyHashable values
fails, which breaks when (for example) a dictionary with AnyHashable
keys is used from Objective-C. See SR-2648 / rdar://problem/27992351
for a case where this breaks interoperability.

To address this problem, make AnyHashable's casting and equality
sensitive to the origin of the hashed value: if the AnyHashable was
created through a _HasCustomAnyHashableRepresentation conformance,
treat comparisons/casting from it as "fuzzy":
- For equality, if one of the AnyHashable's comes from a custom
  representation (e.g., it originated with an Objective-C type like
  NSString) but the other did not, bridge the value of the _other_
  AnyHashable to Objective-C, re-wrap it in an AnyHashable, and
  compare that. This allows, e.g., an (NS)RunLoopMode created in Swift
  to compare to an NSString constant with the same string value.
- For casting, if the AnyHashable we're casting from came from a
  custom representation and the cast would fail, bridge to Objective-C
  and then initiate the cast again. This allows an NSString to be
  casted to (NS)RunLoopMode.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-2648](https://bugs.swift.org/browse/SR-2648) / rdar://problem/27992351.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

(cherry picked from commit 6f34118cb690ec542077ecaf0c0dfd9997ca2d03)
