### PR TITLE
SE-0138: Add UnsafeRawBufferPointer and UnsafeMutableRawBufferPointer.

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -2111,6 +2111,72 @@ public func != <Element : Equatable>(
 ) -> Bool {
   return !(lhs == rhs)
 }
+
+extension ${Self} {
+  /// Calls a closure with a view of the array's underlying bytes of memory as a
+  /// Collection of `UInt8`.
+  /// ${contiguousCaveat}
+  ///
+  /// - Precondition: `Pointee` is a trivial type.
+  ///
+  /// The following example shows how you copy bytes into an array:
+  ///
+  ///    var numbers = [Int32](repeating: 0, count: 2)
+  ///    var byteValues: [UInt8] = [0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]
+  ///    numbers.withUnsafeMutableBytes { destBytes in
+  ///      byteValues.withUnsafeBytes { srcBytes in
+  ///        destBytes.copyBytes(from: srcBytes)
+  ///      }
+  ///    }
+  ///
+  /// - Parameter body: A closure with an `UnsafeRawBufferPointer` parameter
+  ///   that points to the contiguous storage for the array. If `body` has a
+  ///   return value, it is used as the return value for the
+  ///   `withUnsafeBytes(_:)` method. The argument is valid only for the
+  ///   duration of the closure's execution.
+  /// - Returns: The return value of the `body` closure parameter, if any.
+  ///
+  /// - SeeAlso: `withUnsafeBytes`, `UnsafeMutableRawBufferPointer`
+  public mutating func withUnsafeMutableBytes<R>(
+    _ body: (inout UnsafeMutableRawBufferPointer) throws -> R
+  ) rethrows -> R {
+    return try self.withUnsafeMutableBufferPointer {
+      var bytes = UnsafeMutableRawBufferPointer($0)
+      return try body(&bytes)
+    }
+  }
+
+  /// Calls a closure with a view of the array's underlying bytes of memory
+  /// as a Collection of `UInt8`.
+  /// ${contiguousCaveat}
+  ///
+  /// - Precondition: `Pointee` is a trivial type.
+  ///
+  /// The following example shows how you copy the contents of an array into a
+  /// buffer of `UInt8`:
+  ///
+  ///    let numbers = [1, 2, 3]
+  ///    var byteBuffer = [UInt8]()
+  ///    numbers.withUnsafeBytes {
+  ///        byteBuffer += $0
+  ///    }
+  ///
+  /// - Parameter body: A closure with an `UnsafeRawBufferPointer` parameter
+  ///   that points to the contiguous storage for the array. If `body` has a
+  ///   return value, it is used as the return value for the
+  ///   `withUnsafeBytes(_:)` method. The argument is valid only for the
+  ///   duration of the closure's execution.
+  /// - Returns: The return value of the `body` closure parameter, if any.
+  ///
+  /// - SeeAlso: `withUnsafeBytes`, `UnsafeRawBufferPointer`
+  public mutating func withUnsafeBytes<R>(
+    _ body: (UnsafeRawBufferPointer) throws -> R
+  ) rethrows -> R {
+    return try self.withUnsafeBufferPointer {
+      try body(UnsafeRawBufferPointer($0))
+    }
+  }
+}
 %end
 
 #if _runtime(_ObjC)

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -134,6 +134,7 @@ set(SWIFTLIB_ESSENTIAL
   Unmanaged.swift
   UnsafeBitMap.swift
   UnsafeBufferPointer.swift.gyb
+  UnsafeRawBufferPointer.swift.gyb
   UnsafePointer.swift.gyb
   UnsafeRawPointer.swift.gyb
   WriteBackMutableSlice.swift

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -125,7 +125,8 @@
     "Pointer.swift",
     "UnsafePointer.swift",
     "UnsafeRawPointer.swift",
-    "UnsafeBufferPointer.swift"
+    "UnsafeBufferPointer.swift",
+    "UnsafeRawBufferPointer.swift"
   ],
   "Protocols": [
     "CompilerProtocols.swift",

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1,0 +1,386 @@
+//===--- UnsafeRawBufferPointer.swift.gyb --------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+%import gyb
+
+% for mutable in (True, False):
+%  Self = 'UnsafeMutableRawBufferPointer' if mutable else 'UnsafeRawBufferPointer'
+%  Mutable = 'Mutable' if mutable else ''
+
+/// A non-owning view over a region of memory as a Collection of bytes
+/// independent of the type of values held in that memory. Each 8-bit byte in
+/// memory is viewed as a `UInt8` value.
+///
+/// Reads and writes on memory via `UnsafeRawBufferPointer` are untyped
+/// operations. Accessing this Collection's bytes does not bind the
+/// underlying memory to `UInt8`. The underlying memory must be bound
+/// to some trivial type whenever it is accessed via a typed operation.
+///
+/// - Note: A trivial type can be copied with just a bit-for-bit copy without
+///   any indirection or reference-counting operations.  Generally, native Swift
+///   types that do not contain strong or weak references or other forms of
+///   indirection are trivial, as are imported C structs and enums. Copying
+///   memory that contains values of nontrivial type can only be done safely
+///   with a typed pointer. Copying bytes directly from nontrivial in-memory
+///   values does not produce valid copies and can only be done by calling a C
+///   API such as memmove.
+///
+/// In addition to the `Collection` interface, the following subset of
+/// `Unsafe${Mutable}RawPointer`'s interface to raw memory is
+/// provided with debug mode bounds checks:
+/// - `load(fromByteOffset:as:)`,
+%  if mutable:
+/// - `storeBytes(of:toByteOffset:as:)`
+/// - `copyBytes(from:count:)`
+%  end
+///
+/// This is only a view into memory and does not own the memory. Copying a value
+/// of type `Unsafe${Mutable}Bytes` does not copy the underlying
+/// memory. However, initializing another collection, such as `[UInt8]`, with an
+/// `Unsafe${Mutable}Bytes` into copies bytes out of memory.
+///
+/// Example:
+/// ```swift
+///   // View a slice of memory at someBytes. Nothing is copied.
+///   var destBytes = someBytes[0..<n]
+///
+///   // Copy the slice of memory into a buffer of UInt8.
+///   var byteArray = [UInt8](destBytes)
+///
+///   // Copy another slice of memory into the buffer.
+///   byteArray += someBytes[n..<m]
+/// ```
+///
+%  if mutable:
+/// Assigning into a range of subscripts copies bytes into the memory.
+///
+/// Example (continued):
+/// ```swift
+///   // Copy a another slice of memory back into the original slice.
+///   destBytes[0..<n] = someBytes[m..<(m+n)]
+/// ```
+///
+%  end
+/// TODO: Specialize `index` and `formIndex` and
+/// `_failEarlyRangeCheck` as in `UnsafeBufferPointer`.
+public struct Unsafe${Mutable}RawBufferPointer
+  : ${Mutable}Collection, RandomAccessCollection {
+
+  public typealias Index = Int
+  public typealias IndexDistance = Int
+  public typealias SubSequence = ${Self}
+
+  /// An iterator over the bytes viewed by `${Self}`.
+  public struct Iterator : IteratorProtocol, Sequence {
+
+    /// Advances to the next byte and returns it, or `nil` if no next byte
+    /// exists.
+    ///
+    /// Once `nil` has been returned, all subsequent calls return `nil`.
+    public mutating func next() -> UInt8? {
+      if _position == _end { return nil }
+      
+      let result = _position!.load(as: UInt8.self)
+      _position! += 1
+      return result
+    }
+
+    internal var _position, _end: UnsafeRawPointer?
+  }
+
+%  if mutable:
+  /// Allocate memory for `size` bytes with word alignment.
+  ///
+  /// - Postcondition: The memory is allocated, but not initialized.
+  public static func allocate(count size: Int
+  ) -> UnsafeMutableRawBufferPointer {
+    return UnsafeMutableRawBufferPointer(
+      start: UnsafeMutableRawPointer.allocate(
+        bytes: size, alignedTo: MemoryLayout<UInt>.alignment),
+      count: size)
+  }
+%  end # mutable
+
+  /// Deallocate this memory allocated for `bytes` number of bytes.
+  ///
+  /// - Precondition: The memory is not initialized.
+  ///
+  /// - Postcondition: The memory has been deallocated.
+  public func deallocate() {
+    _position?.deallocate(
+      bytes: count, alignedTo: MemoryLayout<UInt>.alignment)
+  }
+
+  /// Reads raw bytes from memory at `self + offset` and constructs a
+  /// value of type `T`.
+  ///
+  /// - Precondition: `offset + MemoryLayout<T>.size < self.count`
+  ///
+  /// - Precondition: The underlying pointer plus `offset` is properly
+  ///   aligned for accessing `T`.
+  ///
+  /// - Precondition: The memory is initialized to a value of some type `U`
+  ///   such that `T` is layout compatible with `U`.
+  public func load<T>(fromByteOffset offset: Int = 0, as type: T.Type) -> T {
+    _debugPrecondition(offset >= 0, "${Self}.load with negative offset")
+    _debugPrecondition(offset + MemoryLayout<T>.size <= self.count,
+      "${Self}.load out of bounds")
+    return baseAddress!.load(fromByteOffset: offset, as: T.self)
+  }
+
+%  if mutable:
+  /// Stores a value's bytes into raw memory at `self + offset`.
+  ///  
+  /// - Precondition: `offset + MemoryLayout<T>.size < self.count`
+  ///
+  /// - Precondition: The underlying pointer plus `offset` is properly
+  ///   aligned for storing type `T`.
+  ///
+  /// - Precondition: `T` is a trivial type.
+  ///
+  /// - Precondition: The memory is uninitialized, or initialized to
+  ///   some trivial type `U` such that `T` and `U` are mutually layout
+  ///   compatible.
+  /// 
+  /// - Postcondition: The memory is initialized to raw bytes. If the
+  ///   memory is bound to type `U`, then it now contains a value of
+  ///   type `U`.
+  ///
+  /// - Note: A trivial type can be copied with just a bit-for-bit
+  ///   copy without any indirection or reference-counting operations.
+  ///   Generally, native Swift types that do not contain strong or
+  ///   weak references or other forms of indirection are trivial, as
+  ///   are imported C structs and enums.
+  public func storeBytes<T>(
+    of value: T, toByteOffset offset: Int = 0, as: T.Type
+  ) {
+    _debugPrecondition(offset >= 0, "${Self}.storeBytes with negative offset")
+    _debugPrecondition(offset + MemoryLayout<T>.size <= self.count,
+      "${Self}.storeBytes out of bounds")
+
+    baseAddress!.storeBytes(of: value, toByteOffset: offset, as: T.self)
+  }
+
+  /// Copies `count` bytes from `source` into memory at `self`.
+  ///  
+  /// - Precondition: `count` is non-negative.
+  ///
+  /// - Precondition: The memory at `source..<source + count` is
+  ///   initialized to some trivial type `T`.
+  ///
+  /// - Precondition: If the memory at `self..<self+count` is bound to
+  ///   a type `U`, then `U` is a trivial type, the underlying
+  ///   pointers `source` and `self` are properly aligned for type
+  ///   `U`, and `count` is a multiple of `MemoryLayout<U>.stride`.
+  ///
+  /// - Postcondition: The memory at `self..<self+count` is
+  ///   initialized to raw bytes. If the memory is bound to type `U`,
+  ///   then it contains values of type `U`.
+  public func copyBytes(from source: UnsafeRawBufferPointer) {
+    _debugPrecondition(source.count <= self.count,
+      "${Self}.copyBytes source has too many elements")
+    baseAddress?.copyBytes(from: source.baseAddress!, count: source.count)
+  }
+
+  /// Copies from a collection of `UInt8` into memory at `self`.
+  ///
+  /// - Precondition: `source.count <= self.count`.
+  ///
+  /// - Precondition: If the memory at `self..<self+count` is bound to
+  ///   a type `U`, then `U` is a trivial type, the underlying pointer
+  ///   at `self` is properly aligned for type `U`, and `source.count`
+  ///   is a multiple of `MemoryLayout<U>.stride`.
+  ///
+  /// - Postcondition: The memory at `self..<self+count` is
+  ///   initialized to raw bytes. If the memory is bound to type `U`,
+  ///   then it contains values of type `U`.
+  public func copyBytes<C : Collection>(from source: C
+  ) where C.Iterator.Element == UInt8 {
+    _debugPrecondition(numericCast(source.count) <= self.count,
+      "${Self}.copyBytes source has too many elements")
+    guard let position = _position else {
+      return
+    }
+    for (index, byteValue) in source.enumerated() {
+      position.storeBytes(
+        of: byteValue, toByteOffset: index, as: UInt8.self)
+    }
+  }
+%  end # mutable
+
+  /// Creates an `${Self}` over `count` contiguous bytes beginning at `start`.
+  ///
+  /// If `start` is nil, `count` must be 0. However, `count` may be 0 even for
+  /// a nonzero `start`.
+  public init(start: Unsafe${Mutable}RawPointer?, count: Int) {
+    _precondition(count >= 0, "${Self} with negative count")
+    _precondition(count == 0 || start != nil,
+      "${Self} has a nil start and nonzero count")
+    _position = start
+    _end = start.map { $0 + count }
+  }
+
+  /// Converts UnsafeMutableRawBufferPointer to UnsafeRawBufferPointer.
+  public init(_ bytes: UnsafeMutableRawBufferPointer) {
+    self.init(start: bytes.baseAddress, count: bytes.count)
+  }
+
+%  if mutable:
+  /// Converts UnsafeRawBufferPointer to UnsafeMutableRawBufferPointer.
+  public init(mutating bytes: UnsafeRawBufferPointer) {
+    self.init(start: UnsafeMutableRawPointer(mutating: bytes.baseAddress),
+      count: bytes.count)
+  }
+%  else:
+  /// Converts UnsafeRawBufferPointer to UnsafeMutableRawBufferPointer.
+  public init(_ bytes: UnsafeRawBufferPointer) {
+    self.init(start: bytes.baseAddress, count: bytes.count)
+  }
+%  end # !mutable
+
+  /// Creates an `${Self}` over the contiguous bytes in `buffer`.
+  ///
+  /// - Precondition: `T` is a trivial type.
+  public init<T>(_ buffer: UnsafeMutableBufferPointer<T>) {
+    self.init(start: buffer.baseAddress!,
+      count: buffer.count * MemoryLayout<T>.stride)
+  }
+
+%  if not mutable:
+  /// Creates an `${Self}` view over the contiguous memory in `buffer`.
+  ///
+  /// - Precondition: `T` is a trivial type.
+  public init<T>(_ buffer: UnsafeBufferPointer<T>) {
+    self.init(start: buffer.baseAddress!,
+      count: buffer.count * MemoryLayout<T>.stride)
+  }
+%  end # !mutable
+
+  /// Always zero, which is the index of the first byte in a
+  /// non-empty buffer.
+  public var startIndex: Int {
+    return 0
+  }
+
+  /// The "past the end" position---that is, the position one greater than the
+  /// last valid subscript argument.
+  ///
+  /// The `endIndex` property of an `Unsafe${Mutable}RawBufferPointer`
+  /// instance is always identical to `count`.
+  public var endIndex: Int {
+    return count
+  }
+
+  public typealias Indices = CountableRange<Int>
+
+  public var indices: Indices {
+    return startIndex..<endIndex
+  }
+
+  /// Accesses the `i`th byte in the memory region as a `UInt8` value.
+  public subscript(i: Int) -> UInt8 {
+    get {
+      _debugPrecondition(i >= 0)
+      _debugPrecondition(i < endIndex)
+      return _position!.load(fromByteOffset: i, as: UInt8.self)
+    }
+%  if mutable:
+    nonmutating set {
+      _debugPrecondition(i >= 0)
+      _debugPrecondition(i < endIndex)
+      _position!.storeBytes(of: newValue, toByteOffset: i, as: UInt8.self)
+    }
+%  end # mutable
+  }
+
+  /// Accesses the bytes in the memory region within `bounds` as a `UInt8`
+  /// values.
+  public subscript(bounds: Range<Int>) -> Unsafe${Mutable}RawBufferPointer {
+    get {
+      _debugPrecondition(bounds.lowerBound >= startIndex)
+      _debugPrecondition(bounds.upperBound <= endIndex)
+      return Unsafe${Mutable}RawBufferPointer(
+        start: baseAddress.map { $0 + bounds.lowerBound },
+        count: bounds.count)
+    }
+%  if mutable:
+    set {
+      _debugPrecondition(bounds.lowerBound >= startIndex)
+      _debugPrecondition(bounds.upperBound <= endIndex)
+      _debugPrecondition(bounds.count == newValue.count)
+
+      if newValue.count > 0 {
+        (baseAddress! + bounds.lowerBound).copyBytes(
+          from: newValue.baseAddress!,
+          count: newValue.count)
+      }
+    }
+%  end # mutable
+  }
+
+  /// Returns an iterator over the bytes of this sequence.
+  ///
+  /// - Complexity: O(1).
+  public func makeIterator() -> Iterator {
+    return Iterator(_position: _position, _end: _end)
+  }
+
+  /// A pointer to the first byte of the buffer.
+  public var baseAddress: Unsafe${Mutable}RawPointer? {
+    return _position
+  }
+
+  /// The number of bytes in the buffer.
+  public var count: Int {
+    if let pos = _position {
+      return _end! - pos
+    }
+    return 0
+  }
+
+  let _position, _end: Unsafe${Mutable}RawPointer?
+}
+
+extension Unsafe${Mutable}RawBufferPointer : CustomDebugStringConvertible {
+  /// A textual representation of `self`, suitable for debugging.
+  public var debugDescription: String {
+    return "${Self}"
+      + "(start: \(_position.map(String.init(describing:)) ?? "nil"), count: \(count))"
+  }
+}
+
+/// Invokes `body` with an `${Self}` argument and returns the
+/// result.
+%  if mutable:
+public func withUnsafeMutableBytes<T, Result>(
+  of arg: inout T,
+  _ body: (inout UnsafeMutableRawBufferPointer) throws -> Result
+) rethrows -> Result
+{
+  return try withUnsafeMutablePointer(to: &arg) {
+    var bytes = UnsafeMutableRawBufferPointer(start: $0, count: MemoryLayout<T>.size)
+    return try body(&bytes)
+  }
+}
+%  else:
+public func withUnsafeBytes<T, Result>(
+  of arg: inout T,
+  _ body: (UnsafeRawBufferPointer) throws -> Result
+) rethrows -> Result
+{
+  return try withUnsafePointer(to: &arg) {
+    try body(UnsafeRawBufferPointer(start: $0, count: MemoryLayout<T>.size))
+  }
+}
+%  end # mutable
+
+% end # for mutable

--- a/test/stdlib/UnsafePointerDiagnostics.swift
+++ b/test/stdlib/UnsafePointerDiagnostics.swift
@@ -108,3 +108,32 @@ func unsafePointerConversionAvailability(
   _ = UnsafePointer<Int>(oumps) // expected-error {{'init' is unavailable: use 'withMemoryRebound(to:capacity:_)' to temporarily view memory as another layout-compatible type.}}
   _ = UnsafePointer<Int>(oups)  // expected-error {{'init' is unavailable: use 'withMemoryRebound(to:capacity:_)' to temporarily view memory as another layout-compatible type.}}
 }
+
+func unsafeRawBufferPointerConversionAvailability(
+  mrp: UnsafeMutableRawPointer,
+  rp: UnsafeRawPointer,
+  mrbp: UnsafeMutableRawBufferPointer,
+  rbp: UnsafeRawBufferPointer,
+  mbpi: UnsafeMutableBufferPointer<Int>,
+  bpi: UnsafeBufferPointer<Int>) {
+
+  let omrp: UnsafeMutableRawPointer? = mrp
+  let orp: UnsafeRawPointer? = rp
+
+  _ = UnsafeMutableRawBufferPointer(start: mrp, count: 1)
+  _ = UnsafeRawBufferPointer(start: mrp, count: 1)
+  _ = UnsafeMutableRawBufferPointer(start: rp, count: 1) // expected-error {{cannot convert value of type 'UnsafeRawPointer' to expected argument type 'UnsafeMutableRawPointer?'}}
+  _ = UnsafeRawBufferPointer(start: rp, count: 1)
+  _ = UnsafeMutableRawBufferPointer(mrbp)
+  _ = UnsafeRawBufferPointer(mrbp)
+  _ = UnsafeMutableRawBufferPointer(rbp) // expected-error {{cannot invoke initializer for type 'UnsafeMutableRawBufferPointer' with an argument list of type '(UnsafeRawBufferPointer)'}} expected-note {{overloads for 'UnsafeMutableRawBufferPointer' exist with these partially matching parameter lists: (UnsafeMutableRawBufferPointer), (UnsafeMutableBufferPointer<T>)}}
+  _ = UnsafeRawBufferPointer(rbp)
+  _ = UnsafeMutableRawBufferPointer(mbpi)
+  _ = UnsafeRawBufferPointer(mbpi)
+  _ = UnsafeMutableRawBufferPointer(bpi) // expected-error {{cannot invoke initializer for type 'UnsafeMutableRawBufferPointer' with an argument list of type '(UnsafeBufferPointer<Int>)'}} expected-note {{overloads for 'UnsafeMutableRawBufferPointer' exist with these partially matching parameter lists: (UnsafeMutableRawBufferPointer), (UnsafeMutableBufferPointer<T>)}}
+  _ = UnsafeRawBufferPointer(bpi)
+  _ = UnsafeMutableRawBufferPointer(start: omrp, count: 1)
+  _ = UnsafeRawBufferPointer(start: omrp, count: 1)
+  _ = UnsafeMutableRawBufferPointer(start: orp, count: 1) // expected-error {{cannot convert value of type 'UnsafeRawPointer?' to expected argument type 'UnsafeMutableRawPointer?'}}
+  _ = UnsafeRawBufferPointer(start: orp, count: 1)
+}

--- a/test/stdlib/UnsafeRawBufferPointer.swift
+++ b/test/stdlib/UnsafeRawBufferPointer.swift
@@ -1,0 +1,380 @@
+// RUN: %target-run-simple-swiftgyb
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var UnsafeRawBufferPointerTestSuite = TestSuite("UnsafeRawBufferPointer")
+
+// View an in-memory value's bytes.
+// Use copyBytes to overwrite the value's bytes.
+UnsafeRawBufferPointerTestSuite.test("initFromValue") {
+  var value1: Int32 = -1
+  var value2: Int32 = 0
+  // Immutable view of value1's bytes.
+  withUnsafeBytes(of: &value1) { bytes1 in
+    expectEqual(bytes1.count, 4)
+    for b in bytes1 {
+      expectEqual(b, 0xFF)
+    }
+    // Mutable view of value2's bytes.
+    withUnsafeMutableBytes(of: &value2) { bytes2 in
+      expectEqual(bytes1.count, bytes2.count)
+      bytes2[0..<bytes2.count].copyBytes(from: bytes1)
+    }
+  }
+  expectEqual(value2, value1)
+}
+
+// View an array's elements as bytes.
+// Use copyBytes to overwrite the array element's bytes.
+UnsafeRawBufferPointerTestSuite.test("initFromArray") {
+  var array1: [Int32] = [0, 1, 2, 3]
+  var array2 = [Int32](repeating: 0, count: 4)
+  // Immutable view of array1's bytes.
+  array1.withUnsafeBytes { bytes1 in
+    expectEqual(bytes1.count, 16)
+    for (i, b) in bytes1.enumerated() {
+      if i % 4 == 0 {
+        expectEqual(Int(b), i / 4)
+      }
+      else {
+        expectEqual(b, 0)
+      }
+    }
+    // Mutable view of array2's bytes.
+    array2.withUnsafeMutableBytes { bytes2 in
+      expectEqual(bytes1.count, bytes2.count)
+      bytes2[0..<bytes2.count].copyBytes(from: bytes1)
+    }
+  }
+  expectEqual(array2, array1)
+}
+
+// Check Collection conformance and associated types.
+UnsafeRawBufferPointerTestSuite.test("Collection") {
+  expectCollectionType(UnsafeRawBufferPointer.self)
+  expectMutableCollectionType(UnsafeMutableRawBufferPointer.self)
+  expectSliceType(UnsafeRawBufferPointer.self)
+  expectMutableSliceType(UnsafeMutableRawBufferPointer.self)
+
+  expectCollectionAssociatedTypes(
+    collectionType: UnsafeRawBufferPointer.self,
+    iteratorType: UnsafeRawBufferPointer.Iterator.self,
+    subSequenceType: UnsafeRawBufferPointer.self,
+    indexType: Int.self,
+    indexDistanceType: Int.self,
+    indicesType: CountableRange<Int>.self)
+
+  expectCollectionAssociatedTypes(
+    collectionType: UnsafeMutableRawBufferPointer.self,
+    iteratorType: UnsafeMutableRawBufferPointer.Iterator.self,
+    subSequenceType: UnsafeMutableRawBufferPointer.self,
+    indexType: Int.self,
+    indexDistanceType: Int.self,
+    indicesType: CountableRange<Int>.self)
+}
+
+// Verify basic Sequence/Iterator functionality.
+UnsafeRawBufferPointerTestSuite.test("Sequence") {
+  var array1: [Int32] = [0, 1, 2, 3]
+  array1.withUnsafeBytes { bytes1 in
+    // Initialize an array from a sequence of bytes.
+    let byteArray = [UInt8](bytes1)
+    for (b1, b2) in zip(byteArray, bytes1) {
+      expectEqual(b1, b2)
+    }
+  }
+}
+
+// Test the empty buffer.
+UnsafeRawBufferPointerTestSuite.test("empty") {
+  let emptyBytes = UnsafeRawBufferPointer(start: nil, count: 0)
+  for byte in emptyBytes {
+    expectUnreachable()
+  }
+  let emptyMutableBytes = UnsafeMutableRawBufferPointer.allocate(count: 0)
+  for byte in emptyMutableBytes {
+    expectUnreachable()
+  }
+  emptyMutableBytes.deallocate()
+}
+
+// Store a sequence of integers to raw memory, and reload them as structs.
+// Strore structs to raw memory, and reload them as integers.
+UnsafeRawBufferPointerTestSuite.test("reinterpret") {
+  struct Pair {
+    var x: Int32
+    var y: Int32
+  }
+  let numPairs = 2
+  let bytes = UnsafeMutableRawBufferPointer.allocate(
+    count: MemoryLayout<Pair>.stride * numPairs)
+  defer { bytes.deallocate() }  
+
+  for i in 0..<(numPairs * 2) {
+    bytes.storeBytes(of: Int32(i), toByteOffset: i * MemoryLayout<Int32>.stride,
+      as: Int32.self)
+  }
+  let pair1 = bytes.load(as: Pair.self)
+  let pair2 = bytes.load(fromByteOffset: MemoryLayout<Pair>.stride,
+    as: Pair.self)
+  expectEqual(0, pair1.x)
+  expectEqual(1, pair1.y)
+  expectEqual(2, pair2.x)
+  expectEqual(3, pair2.y)
+
+  bytes.storeBytes(of: Pair(x: -1, y: 0), as: Pair.self)
+  for i in 0..<MemoryLayout<Int32>.stride {
+    expectEqual(0xFF, bytes[i])
+  }
+  let bytes2 = bytes[MemoryLayout<Int32>.stride..<bytes.count]
+  for i in 0..<MemoryLayout<Int32>.stride {
+    expectEqual(0, bytes2[i])
+  }
+}
+
+// Store, load, subscript, and slice at all valid byte offsets.
+UnsafeRawBufferPointerTestSuite.test("inBounds") {
+  let numInts = 4
+  let bytes = UnsafeMutableRawBufferPointer.allocate(
+    count: MemoryLayout<Int>.stride * numInts)
+  defer { bytes.deallocate() }
+
+  for i in 0..<numInts {
+    bytes.storeBytes(
+      of: i, toByteOffset: i * MemoryLayout<Int>.stride, as: Int.self)
+  }
+  for i in 0..<numInts {
+    let x = bytes.load(
+      fromByteOffset: i * MemoryLayout<Int>.stride, as: Int.self)
+    expectEqual(x, i)
+  }
+  for i in 0..<numInts {
+    var x = i
+    withUnsafeBytes(of: &x) {
+      for (offset, byte) in $0.enumerated() {
+        expectEqual(bytes[i * MemoryLayout<Int>.stride + offset], byte)
+      }
+    }
+  }
+  let median = (numInts/2 * MemoryLayout<Int>.stride)
+  var firstHalf = bytes[0..<median]
+  var secondHalf = bytes[median..<bytes.count]
+  firstHalf[0..<firstHalf.count] = secondHalf
+  expectEqualSequence(firstHalf, secondHalf)
+}
+
+UnsafeRawBufferPointerTestSuite.test("subscript.get.underflow") {
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  let buffer = UnsafeMutableRawBufferPointer.allocate(count: 2)
+  defer { buffer.deallocate() }
+
+  let bytes = buffer[1..<2]
+  _ = bytes[-1]
+}
+
+UnsafeRawBufferPointerTestSuite.test("subscript.get.overflow") {
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  let buffer = UnsafeMutableRawBufferPointer.allocate(count: 2)
+  defer { buffer.deallocate() }
+
+  let bytes = buffer[0..<1]
+  _ = bytes[1]
+}
+
+UnsafeRawBufferPointerTestSuite.test("subscript.set.underflow") {
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  let buffer = UnsafeMutableRawBufferPointer.allocate(count: 2)
+  defer { buffer.deallocate() }
+
+  let bytes = buffer[1..<2]
+  bytes[-1] = 0
+}
+
+UnsafeRawBufferPointerTestSuite.test("subscript.set.overflow") {
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  let buffer = UnsafeMutableRawBufferPointer.allocate(count: 2)
+  defer { buffer.deallocate() }
+
+  let bytes = buffer[0..<1]
+  bytes[1] = 0
+}
+
+UnsafeRawBufferPointerTestSuite.test("subscript.range.get.underflow") {
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  let buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
+  defer { buffer.deallocate() }
+
+  let bytes = buffer[1..<3]
+  _ = bytes[-1..<1]
+}
+
+UnsafeRawBufferPointerTestSuite.test("subscript.range.get.overflow") {
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  let buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
+  defer { buffer.deallocate() }
+
+  let bytes = buffer[0..<2]
+  _ = bytes[1..<3]
+}
+
+UnsafeRawBufferPointerTestSuite.test("subscript.range.set.underflow") {
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  var buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
+  defer { buffer.deallocate() }
+
+  var bytes = buffer[1..<3]
+  bytes[-1..<1] = bytes[0..<2]
+}
+
+UnsafeRawBufferPointerTestSuite.test("subscript.range.set.overflow") {
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  var buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
+  defer { buffer.deallocate() }
+
+  var bytes = buffer[0..<2]
+  bytes[1..<3] = bytes[0..<2]
+}
+
+UnsafeRawBufferPointerTestSuite.test("subscript.range.narrow") {
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  var buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
+  defer { buffer.deallocate() }
+
+  buffer[0..<3] = buffer[0..<2]
+}
+
+UnsafeRawBufferPointerTestSuite.test("subscript.range.wide") {
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  var buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
+  defer { buffer.deallocate() }
+
+  buffer[0..<2] = buffer[0..<3]
+}
+
+UnsafeRawBufferPointerTestSuite.test("load.before")
+.skip(.custom(
+    { !_isDebugAssertConfiguration() },
+    reason: "This test behaves unpredictably in optimized mode."))
+.code {
+  expectCrashLater()
+  var x: Int32 = 0
+  withUnsafeBytes(of: &x) {
+    _ = $0.load(fromByteOffset: -1, as: UInt8.self)
+  }
+}
+
+UnsafeRawBufferPointerTestSuite.test("load.after")
+.skip(.custom(
+    { !_isDebugAssertConfiguration() },
+    reason: "This test behaves unpredictably in optimized mode."))
+.code {
+  expectCrashLater()
+  var x: Int32 = 0
+  withUnsafeBytes(of: &x) {
+    _ = $0.load(as: UInt64.self)
+  }
+}
+
+UnsafeRawBufferPointerTestSuite.test("store.before")
+.skip(.custom(
+    { !_isDebugAssertConfiguration() },
+    reason: "This test behaves unpredictably in optimized mode."))
+.code {
+  expectCrashLater()
+  var x: Int32 = 0
+  withUnsafeMutableBytes(of: &x) {
+    $0.storeBytes(of: UInt8(0), toByteOffset: -1, as: UInt8.self)
+  }
+}
+UnsafeRawBufferPointerTestSuite.test("store.after")
+.skip(.custom(
+    { !_isDebugAssertConfiguration() },
+    reason: "This test behaves unpredictably in optimized mode."))
+.code {
+  expectCrashLater()
+  var x: Int32 = 0
+  withUnsafeMutableBytes(of: &x) {
+    $0.storeBytes(of: UInt64(0), as: UInt64.self)
+  }
+}
+
+UnsafeRawBufferPointerTestSuite.test("copy.bytes.overflow")
+.skip(.custom(
+    { !_isDebugAssertConfiguration() },
+    reason: "This test behaves unpredictably in optimized mode."))
+.code {
+  expectCrashLater()
+  var x: Int64 = 0
+  var y: Int32 = 0
+  withUnsafeBytes(of: &x) { srcBytes in
+    withUnsafeMutableBytes(of: &y) { destBytes in
+      destBytes.copyBytes(
+        from: UnsafeMutableRawBufferPointer(mutating: srcBytes))
+    }
+  }
+}
+
+UnsafeRawBufferPointerTestSuite.test("copy.sequence.overflow")
+.skip(.custom(
+    { !_isDebugAssertConfiguration() },
+    reason: "This test behaves unpredictably in optimized mode."))
+.code {
+  expectCrashLater()
+  var x: Int64 = 0
+  var y: Int32 = 0
+  withUnsafeBytes(of: &x) { srcBytes in
+    withUnsafeMutableBytes(of: &y) { destBytes in
+      destBytes.copyBytes(from: srcBytes)
+    }
+  }
+}
+
+UnsafeRawBufferPointerTestSuite.test("copy.overlap") {
+  var bytes = UnsafeMutableRawBufferPointer.allocate(count: 4)
+  // Right Overlap
+  bytes[0] = 1
+  bytes[1] = 2
+  bytes[1..<3] = bytes[0..<2]
+  expectEqual(1, bytes[1])
+  expectEqual(2, bytes[2])
+  // Left Overlap
+  bytes[1] = 2
+  bytes[2] = 3
+  bytes[0..<2] = bytes[1..<3]
+  expectEqual(2, bytes[0])
+  expectEqual(3, bytes[1])
+  // Disjoint
+  bytes[2] = 2
+  bytes[3] = 3
+  bytes[0..<2] = bytes[2..<4]
+  expectEqual(2, bytes[0])
+  expectEqual(3, bytes[1])
+  bytes[0] = 0
+  bytes[1] = 1
+  bytes[2..<4] = bytes[0..<2]
+  expectEqual(0, bytes[2])
+  expectEqual(1, bytes[3])
+}
+
+runAllTests()


### PR DESCRIPTION
https://github.com/apple/swift-evolution/blob/master/proposals/0138-unsaferawbufferpointer.md

Unsafe[Mutable]RawBufferPointer is a non-owning view over a region of memory as
a Collection of bytes independent of the type of values held in that
memory. Each 8-bit byte in memory is viewed as a `UInt8` value.

Reads and writes on memory via `Unsafe[Mutable]RawBufferPointer` are untyped
operations. Accessing this Collection's bytes does not bind the
underlying memory to `UInt8`. The underlying memory must be bound
to some trivial type whenever it is accessed via a typed operation.

In addition to the `Collection` interface, the following methods from
`Unsafe[Mutable]RawPointer`'s interface to raw memory are
provided with debug mode bounds checks: `load(fromByteOffset:as:)`,
`storeBytes(of:toByteOffset:as:)`, and `copyBytes(from:count:)`.

This is only a view into memory and does not own the memory. Copying a value of
type `UnsafeMutableRawBufferPointer` does not copy the underlying
memory. Assigning an `Unsafe[Mutable]RawBufferPointer` into a value-based
collection, such as `[UInt8]` copies bytes out of memory. Assigning into a
subscript range of `UnsafeMutableRawBufferPointer` copies into memory.
