### PR TITLE
[SIL] Add test case for crash triggered in swift::SourceFile::LookupCache::lookupClassMembers(…)

### DIFF
--- a/validation-test/SIL/crashers/037-swift-sourcefile-lookupcache-lookupclassmembers.sil
+++ b/validation-test/SIL/crashers/037-swift-sourcefile-lookupcache-lookupclassmembers.sil
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+{
+()AnyObject
+.n
+}
+import Swift
+class b{@objc func a(c)


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:1: error: statement cannot begin with a closure expression
{
^
<stdin>:3:1: note: explicitly discard the result of the closure by assigning to '_'
{
^
_ =
<stdin>:4:3: error: consecutive statements on a line must be separated by ';'
()AnyObject
  ^
  ;
<stdin>:3:1: error: expressions are not allowed at the top level
{
^
<stdin>:3:1: error: braced block of statements is an unused closure
{
^
<stdin>:8:22: error: unnamed parameters must be written with the empty name '_'
class b{@objc func a(c)
                     ^
                     _:
<stdin>:8:24: error: consecutive declarations on a line must be separated by ';'
class b{@objc func a(c)
                       ^
                       ;
<stdin>:8:24: error: expected declaration
class b{@objc func a(c)
                       ^
<stdin>:8:7: note: in declaration of 'b'
class b{@objc func a(c)
      ^
<stdin>:8:22: error: use of undeclared type 'c'
class b{@objc func a(c)
                     ^
sil-opt: /path/to/llvm/include/llvm/Support/Casting.h:237: typename cast_retty<X, Y *>::ret_type llvm::cast(Y *) [X = swift::AnyFunctionType, Y = swift::TypeBase]: Assertion `isa<X>(Val) && "cast<Ty>() argument of incompatible type!"' failed.
9  sil-opt         0x0000000000e51dd3 swift::SourceFile::LookupCache::lookupClassMembers(llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::VisibleDeclConsumer&, swift::SourceFile const&) + 787
10 sil-opt         0x0000000000e532a2 swift::ModuleDecl::lookupClassMembers(llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::VisibleDeclConsumer&) const + 50
12 sil-opt         0x0000000000e582ed swift::ModuleDecl::forAllVisibleModules(llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, bool, llvm::function_ref<bool (std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>)>) + 477
13 sil-opt         0x0000000000e58461 swift::FileUnit::forAllVisibleModules(llvm::function_ref<bool (std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>)>) + 81
17 sil-opt         0x0000000000b3a51b swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::Type, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) + 267
19 sil-opt         0x0000000000bb1773 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 2899
20 sil-opt         0x0000000000bb750e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4078
21 sil-opt         0x0000000000adf6f7 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 471
22 sil-opt         0x0000000000ae2dd5 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 949
25 sil-opt         0x0000000000b66b94 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
26 sil-opt         0x0000000000b93f5c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
27 sil-opt         0x0000000000ae2e86 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 1126
29 sil-opt         0x0000000000b66cd6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
30 sil-opt         0x0000000000b1f3cd swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
31 sil-opt         0x00000000007758a9 swift::CompilerInstance::performSema() + 3289
32 sil-opt         0x000000000075ec65 main + 1813
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  While type-checking expression at [<stdin>:3:1 - line:6:1] RangeText="{
()AnyObject
.n
}"
2.  While type-checking expression at [<stdin>:4:3 - line:5:2] RangeText="AnyObject
.n"
```
