### PR TITLE
[swiftc (73 vs. 5165)] Add crasher in swift::Expr::walk(...)

### DIFF
--- a/validation-test/compiler_crashers/28426-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers/28426-swift-expr-walk.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+func a<T{if let a<T:T.h{


### PR DESCRIPTION
Add test case for crash triggered in `swift::Expr::walk(...)`.

Current number of unresolved compiler crashers: 73 (5165 resolved)

Assertion failure in [`include/swift/AST/Pattern.h (line 111)`](https://github.com/apple/swift/blob/master/include/swift/AST/Pattern.h#L111):

```
Assertion `hasType()' failed.

When executing: swift::Type swift::Pattern::getType() const
```

Assertion context:

```
  /// Returns whether this pattern has been type-checked yet.
  bool hasType() const { return !Ty.isNull(); }

  /// If this pattern has been type-checked, return the type it
  /// matches.
  Type getType() const { assert(hasType()); return Ty; }

  /// Set the type of this pattern, given that it was previously not
  /// type-checked.
  void setType(Type ty) { Ty = ty; }

```

Stack trace:

```
swift: /path/to/swift/include/swift/AST/Pattern.h:111: swift::Type swift::Pattern::getType() const: Assertion `hasType()' failed.
14 swift           0x00000000010aa5eb swift::Expr::walk(swift::ASTWalker&) + 75
15 swift           0x0000000000fe4b34 swift::constraints::ConstraintSystem::Candidate::solve() + 324
16 swift           0x0000000000fe73e8 swift::constraints::ConstraintSystem::shrink(swift::Expr*) + 648
17 swift           0x0000000000fe75d1 swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 65
18 swift           0x0000000000ec5d33 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 403
19 swift           0x0000000000ec9455 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 949
20 swift           0x0000000000ece2f4 swift::TypeChecker::typeCheckCondition(swift::Expr*&, swift::DeclContext*) + 180
21 swift           0x0000000000eceb3e swift::TypeChecker::typeCheckExprPattern(swift::ExprPattern*, swift::DeclContext*, swift::Type) + 894
22 swift           0x0000000000f22ebf swift::TypeChecker::coercePatternToType(swift::Pattern*&, swift::DeclContext*, swift::Type, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeLoc) + 2879
23 swift           0x0000000000f226ca swift::TypeChecker::coercePatternToType(swift::Pattern*&, swift::DeclContext*, swift::Type, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeLoc) + 842
24 swift           0x0000000000f222a1 swift::TypeChecker::typeCheckPattern(swift::Pattern*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) + 1041
25 swift           0x0000000000ece40d swift::TypeChecker::typeCheckStmtCondition(llvm::MutableArrayRef<swift::StmtConditionElement>&, swift::DeclContext*, swift::Diag<>) + 189
29 swift           0x0000000000f4a52a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
30 swift           0x0000000000f4a38e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
31 swift           0x0000000000f4af63 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
33 swift           0x0000000000f045c1 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
34 swift           0x0000000000c86e69 swift::CompilerInstance::performSema() + 3289
36 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
37 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28426-swift-expr-walk.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28426-swift-expr-walk-c7d0ab.o
1.  While type-checking 'a' at validation-test/compiler_crashers/28426-swift-expr-walk.swift:10:1
2.  While type-checking pattern at [validation-test/compiler_crashers/28426-swift-expr-walk.swift:10:17 - line:10:19] RangeText="a<T"
3.  While type-checking expression at [validation-test/compiler_crashers/28426-swift-expr-walk.swift:10:17 - line:10:19] RangeText="a<T"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
