### PR TITLE
[stdlib] Refactor logic for .pastEnd index check.

### DIFF
--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -233,11 +233,11 @@ public struct CountableClosedRange<Bound> : RandomAccessCollection
     case .pastEnd:
       if n == 0 {
         return i
-      } else if n > 0 {
-        _preconditionFailure("Advancing past end index")
-      } else {
+      } 
+      if n < 0 {
         return index(ClosedRangeIndex(upperBound), offsetBy: (n + 1))
       }
+      _preconditionFailure("Advancing past end index")
     }
   }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->

I think that it might be better to rewrite this with the first two `if` statements checking for `n == 0` and `n < 0` then if neither statements are true let execution fall through and run `_preconditionFailure("Advancing past end index")`.

How does it look?

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
