### PR TITLE
[3.0] [CloudKit overlay] Work around an NSError bridging issue specific to CKError

### DIFF
--- a/stdlib/public/SDK/CloudKit/CloudKit.swift
+++ b/stdlib/public/SDK/CloudKit/CloudKit.swift
@@ -4,8 +4,9 @@ import Foundation
 @available(macOS 10.10, iOS 8.0, *)
 extension CKError {
   /// Retrieve partial error results associated by item ID.
-  public var partialErrorsByItemID: [NSObject : Error]? {
-    return userInfo[CKPartialErrorsByItemIDKey] as? [NSObject : Error]
+  public var partialErrorsByItemID: [AnyHashable: Error]? {
+    return userInfo[CKPartialErrorsByItemIDKey] as? [AnyHashable: NSError]
+             as? [AnyHashable: Error]
   }
 
   /// The original CKRecord object that you used as the basis for


### PR DESCRIPTION
<!-- What's in this pull request? -->

While here, fix up the type signature of
`CKError.partialErrorsByItemID`; it doesn't make sense to use `NSObject`
now that we have `AnyHashable`.

This is an awful PR; it narrowly works around an issue with a specific API, and omits a test case because the testing harness isn't set up to handle testing frameworks that require entitlements. I've manually verified that this workaround makes the APIs usable and am looking into the issue of `NSError` subclasses more generally.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [rdar://problem/27936562](rdar://problem/27936562).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

(cherry picked from commit 661df18a884bd7adde6df47b7dc3a368ce981b6e)
