### PR TITLE
[Sema] Unify fix-it logic for enclosing trailing closure in argument parens

### DIFF
--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -24,6 +24,7 @@ namespace swift {
   class AbstractFunctionDecl;
   class ApplyExpr;
   class AvailableAttr;
+  class CallExpr;
   class DeclContext;
   class Expr;
   class InFlightDiagnostic;
@@ -85,6 +86,12 @@ bool fixItOverrideDeclarationTypes(TypeChecker &TC,
                                    InFlightDiagnostic &diag,
                                    ValueDecl *decl,
                                    const ValueDecl *base);
+
+/// Emit fix-its to enclose trailing closure in argument parens.
+void fixItEncloseTrailingClosure(TypeChecker &TC,
+                                 InFlightDiagnostic &diag,
+                                 const CallExpr *call,
+                                 Identifier closureLabel);
 } // namespace swift
 
 #endif // SWIFT_SEMA_MISC_DIAGNOSTICS_H


### PR DESCRIPTION
`tryDiagnoseTrailingClosureAmbiguity` and `checkStmtConditionTrailingClosure`
had similar logic.
Added `swift::fixItEncloseTrailingClosure` function.
