### PR TITLE
Assert that the main source file name is non-empty.

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -95,7 +95,7 @@ IRGenDebugInfo::IRGenDebugInfo(const IRGenOptions &Opts,
                                ClangImporter &CI,
                                IRGenModule &IGM,
                                llvm::Module &M,
-                               SourceFile *SF)
+                               StringRef MainSourceFileName)
   : Opts(Opts),
     CI(CI),
     SM(IGM.Context.SourceMgr),
@@ -107,18 +107,8 @@ IRGenDebugInfo::IRGenDebugInfo(const IRGenOptions &Opts,
     LastDebugLoc({}),
     LastScope(nullptr)
 {
-  assert(Opts.DebugInfoKind > IRGenDebugInfoKind::None
-         && "no debug info should be generated");
-  StringRef SourceFileName = SF ? SF->getFilename() :
-                                  StringRef(Opts.MainInputFilename);
-  StringRef Dir;
-  llvm::SmallString<256> AbsMainFile;
-  if (SourceFileName.empty())
-    AbsMainFile = "<unknown>";
-  else {
-    AbsMainFile = SourceFileName;
-    llvm::sys::fs::make_absolute(AbsMainFile);
-  }
+  assert(Opts.DebugInfoKind > IRGenDebugInfoKind::None &&
+         "no debug info should be generated");
 
   unsigned Lang = llvm::dwarf::DW_LANG_Swift;
   std::string Producer = version::getSwiftFullVersion(
@@ -131,6 +121,14 @@ IRGenDebugInfo::IRGenDebugInfo(const IRGenOptions &Opts,
 
   // No split DWARF on Darwin.
   StringRef SplitName = StringRef();
+
+  // The Darwin linker ld64 depends on DW_AT_comp_dir to determine
+  // whether an object file has debug info.
+  assert(!MainSourceFileName.empty() && "main source file name is empty");
+  llvm::SmallString<256> AbsMainFile;
+  AbsMainFile = MainSourceFileName;
+  llvm::sys::fs::make_absolute(AbsMainFile);
+
   // Note that File + Dir need not result in a valid path.
   // Clang is doing the same thing here.
   TheCU = DBuilder.createCompileUnit(

--- a/lib/IRGen/IRGenDebugInfo.h
+++ b/lib/IRGen/IRGenDebugInfo.h
@@ -97,7 +97,7 @@ class IRGenDebugInfo {
 
 public:
   IRGenDebugInfo(const IRGenOptions &Opts, ClangImporter &CI, IRGenModule &IGM,
-                 llvm::Module &M, SourceFile *SF);
+                 llvm::Module &M, StringRef MainSourceFileName);
 
   /// Finalize the llvm::DIBuilder owned by this object.
   void finalize();

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -384,8 +384,11 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
   else
     RegisterPreservingCC = DefaultCC;
 
-  if (IRGen.Opts.DebugInfoKind > IRGenDebugInfoKind::None)
-    DebugInfo = new IRGenDebugInfo(IRGen.Opts, *CI, *this, Module, SF);
+  if (IRGen.Opts.DebugInfoKind > IRGenDebugInfoKind::None) {
+    StringRef MainFile(SF ? SF->getFilename()
+                          : StringRef(IRGen.Opts.MainInputFilename));
+    DebugInfo = new IRGenDebugInfo(IRGen.Opts, *CI, *this, Module, MainFile);
+  }
 
   initClangTypeConverter();
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

The Darwin linker won't process the debug info if the source file name
is invalid so there is no point in having a fallback implemented there.

rdar://problem/25130236
