### PR TITLE
[Parse] 'where' to ',' fix-it should remove a preceding space.

### DIFF
--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1179,17 +1179,17 @@ ParserStatus Parser::parseStmtCondition(StmtCondition &Condition,
     if (Tok.isAny(tok::oper_binary_spaced, tok::oper_binary_unspaced) &&
         Tok.getText() == "&&") {
       diagnose(Tok, diag::expected_comma_stmtcondition)
-      .fixItReplace(Tok.getLoc(), ",");
+        .fixItReplaceChars(getEndOfPreviousLoc(), Tok.getRange().getEnd(), ",");
       consumeToken();
       return true;
     }
 
     // Boolean conditions are separated by commas, not the 'where' keyword, as
     // they were in Swift 2 and earlier.
-    SourceLoc whereLoc;
-    if (consumeIf(tok::kw_where, whereLoc)) {
-      diagnose(whereLoc, diag::expected_comma_stmtcondition)
-        .fixItReplace(whereLoc, ",");
+    if (Tok.is(tok::kw_where)) {
+      diagnose(Tok, diag::expected_comma_stmtcondition)
+        .fixItReplaceChars(getEndOfPreviousLoc(), Tok.getRange().getEnd(), ",");
+      consumeToken();
       return true;
     }
     

--- a/test/Parse/availability_query.swift
+++ b/test/Parse/availability_query.swift
@@ -17,7 +17,7 @@ if !#available(OSX 10.52, *) { // expected-error {{#available may only be used a
 if let _ = Optional(5), !#available(OSX 10.52, *) { // expected-error {{#available may only be used as condition}}
 }
 
-if #available(OSX 10.51, *) && #available(OSX 10.52, *) { // expected-error {{expected ',' joining parts of a multi-clause condition}} {{29-31=,}}
+if #available(OSX 10.51, *) && #available(OSX 10.52, *) { // expected-error {{expected ',' joining parts of a multi-clause condition}} {{28-31=,}}
 }
 
 

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -558,7 +558,7 @@ func f1() {
 
 // <rdar://problem/20489838> QoI: Nonsensical error and fixit if "let" is missing between 'if let ... where' clauses
 func testMultiPatternConditionRecovery(x: Int?) {
-  // expected-error@+1 {{expected ',' joining parts of a multi-clause condition}} {{16-21=,}}
+  // expected-error@+1 {{expected ',' joining parts of a multi-clause condition}} {{15-21=,}}
   if let y = x where y == 0, let z = x {
     _ = y
     _ = z

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -427,11 +427,12 @@ func f21080671() {
 // <rdar://problem/24467411> QoI: Using "&& #available" should fixit to comma
 // https://twitter.com/radexp/status/694561060230184960
 func f(_ x : Int, y : Int) {
-  if x == y && #available(iOS 52, *) {}  // expected-error {{expected ',' joining parts of a multi-clause condition}} {{13-15=,}}
-  if #available(iOS 52, *) && x == y {}  // expected-error {{expected ',' joining parts of a multi-clause condition}} {{28-30=,}}
+  if x == y && #available(iOS 52, *) {}  // expected-error {{expected ',' joining parts of a multi-clause condition}} {{12-15=,}}
+  if #available(iOS 52, *) && x == y {}  // expected-error {{expected ',' joining parts of a multi-clause condition}} {{27-30=,}}
 
   // https://twitter.com/radexp/status/694790631881883648
-  if x == y && let _ = Optional(y) {}  // expected-error {{expected ',' joining parts of a multi-clause condition}} {{13-15=,}}
+  if x == y && let _ = Optional(y) {}  // expected-error {{expected ',' joining parts of a multi-clause condition}} {{12-15=,}}
+  if x == y&&let _ = Optional(y) {}  // expected-error {{expected ',' joining parts of a multi-clause condition}} {{12-14=,}}
 }
 
 


### PR DESCRIPTION
- **Explanation:** We have a fix-it for when the user writes `if let … where …` (the Swift 2 way) instead of `if let …, …` (the Swift 3 way). Previously that fix-it just replaced the `where` (or `&&`, another possible mistake) with a comma, which would look out of place with a leading space. This change also removes any preceding whitespace before the `where`. (This is a tiny change but why not take it?)
- **Scope:** Only affects invalid code and this one particular fix-it.
- **Issue:** rdar://problem/27709302
- **Reviewed by:** @jtbandes     
- **Risk:** Very low.
- **Testing:** Updated existing compiler regression tests.
