### PR TITLE
[CMake] Swift target libraries should depend on clang in non-standalo…

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1199,6 +1199,8 @@ function(add_swift_library name)
 
   if(NOT SWIFTLIB_TARGET_LIBRARY)
     set(SWIFTLIB_INSTALL_IN_COMPONENT dev)
+  elseif(NOT SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER AND NOT SWIFT_BUILT_STANDALONE)
+    list(APPEND SWIFTLIB_DEPENDS clang)
   endif()
 
   # If target SDKs are not specified, build for all known SDKs.


### PR DESCRIPTION
When building non-standalone and using the in-tree clang all TARGET_LIBRARIES should depend on clang. This ensures clang is built before the build tries to use it.

This should be very low risk as it only impacts when NOT SWIFT_BUILTSTANDALONE.
