### PR TITLE
[CMake] Add missing LLVM & Clang tools to check-swift dependencies

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,7 +43,8 @@ function(get_test_dependencies SDK result_var_name)
       swift swift-ide-test sil-opt swift-llvm-opt swift-demangle sil-extract
       lldb-moduleimport-test swift-reflection-dump swift-remoteast-test)
   if(NOT SWIFT_BUILT_STANDALONE)
-    list(APPEND deps_binaries llc)
+    list(APPEND deps_binaries FileCheck arcmt-test c-arcmt-test c-index-test
+         clang llc llvm-cov llvm-dwarfdump llvm-link llvm-profdata not)
   endif()
   if(SWIFT_BUILD_SOURCEKIT)
     list(APPEND deps_binaries sourcekitd-test complete-test)


### PR DESCRIPTION
This only impacts non-standalone builds, and it results in all the tools used during check-swift being built before the lit tests execute.
