### PR TITLE
SE-0138: Add UnsafeRawBufferPointer and UnsafeMutableRawBufferPointer…

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -2087,6 +2087,72 @@ public func != <Element : Equatable>(
 ) -> Bool {
   return !(lhs == rhs)
 }
+
+extension ${Self} {
+  /// Calls a closure with a view of the array's underlying bytes of memory as a
+  /// Collection of `UInt8`.
+  /// ${contiguousCaveat}
+  ///
+  /// - Precondition: `Pointee` is a trivial type.
+  ///
+  /// The following example shows how you copy bytes into an array:
+  ///
+  ///    var numbers = [Int32](repeating: 0, count: 2)
+  ///    var byteValues: [UInt8] = [0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]
+  ///    numbers.withUnsafeMutableBytes { destBytes in
+  ///      byteValues.withUnsafeBytes { srcBytes in
+  ///        destBytes.copyBytes(from: srcBytes)
+  ///      }
+  ///    }
+  ///
+  /// - Parameter body: A closure with an `UnsafeRawBufferPointer` parameter
+  ///   that points to the contiguous storage for the array. If `body` has a
+  ///   return value, it is used as the return value for the
+  ///   `withUnsafeBytes(_:)` method. The argument is valid only for the
+  ///   duration of the closure's execution.
+  /// - Returns: The return value of the `body` closure parameter, if any.
+  ///
+  /// - SeeAlso: `withUnsafeBytes`, `UnsafeMutableRawBufferPointer`
+  public mutating func withUnsafeMutableBytes<R>(
+    _ body: (inout UnsafeMutableRawBufferPointer) throws -> R
+  ) rethrows -> R {
+    return try self.withUnsafeMutableBufferPointer {
+      var bytes = UnsafeMutableRawBufferPointer($0)
+      return try body(&bytes)
+    }
+  }
+
+  /// Calls a closure with a view of the array's underlying bytes of memory
+  /// as a Collection of `UInt8`.
+  /// ${contiguousCaveat}
+  ///
+  /// - Precondition: `Pointee` is a trivial type.
+  ///
+  /// The following example shows how you copy the contents of an array into a
+  /// buffer of `UInt8`:
+  ///
+  ///    let numbers = [1, 2, 3]
+  ///    var byteBuffer = [UInt8]()
+  ///    numbers.withUnsafeBytes {
+  ///        byteBuffer += $0
+  ///    }
+  ///
+  /// - Parameter body: A closure with an `UnsafeRawBufferPointer` parameter
+  ///   that points to the contiguous storage for the array. If `body` has a
+  ///   return value, it is used as the return value for the
+  ///   `withUnsafeBytes(_:)` method. The argument is valid only for the
+  ///   duration of the closure's execution.
+  /// - Returns: The return value of the `body` closure parameter, if any.
+  ///
+  /// - SeeAlso: `withUnsafeBytes`, `UnsafeRawBufferPointer`
+  public mutating func withUnsafeBytes<R>(
+    _ body: (UnsafeRawBufferPointer) throws -> R
+  ) rethrows -> R {
+    return try self.withUnsafeBufferPointer {
+      try body(UnsafeRawBufferPointer($0))
+    }
+  }
+}
 %end
 
 #if _runtime(_ObjC)

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -2091,6 +2091,7 @@ public func != <Element : Equatable>(
 extension ${Self} {
   /// Calls a closure with a view of the array's underlying bytes of memory as a
   /// Collection of `UInt8`.
+  ///
   /// ${contiguousCaveat}
   ///
   /// - Precondition: `Pointee` is a trivial type.
@@ -2105,25 +2106,25 @@ extension ${Self} {
   ///      }
   ///    }
   ///
-  /// - Parameter body: A closure with an `UnsafeRawBufferPointer` parameter
-  ///   that points to the contiguous storage for the array. If `body` has a
-  ///   return value, it is used as the return value for the
-  ///   `withUnsafeBytes(_:)` method. The argument is valid only for the
+  /// - Parameter body: A closure with an `UnsafeRawBufferPointer`
+  ///   parameter that points to the contiguous storage for the array. If `body`
+  ///   has a return value, it is used as the return value for the
+  ///   `withUnsafeMutableBytes(_:)` method. The argument is valid only for the
   ///   duration of the closure's execution.
   /// - Returns: The return value of the `body` closure parameter, if any.
   ///
   /// - SeeAlso: `withUnsafeBytes`, `UnsafeMutableRawBufferPointer`
   public mutating func withUnsafeMutableBytes<R>(
-    _ body: (inout UnsafeMutableRawBufferPointer) throws -> R
+    _ body: (UnsafeMutableRawBufferPointer) throws -> R
   ) rethrows -> R {
     return try self.withUnsafeMutableBufferPointer {
-      var bytes = UnsafeMutableRawBufferPointer($0)
-      return try body(&bytes)
+      return try body(UnsafeMutableRawBufferPointer($0))
     }
   }
 
   /// Calls a closure with a view of the array's underlying bytes of memory
   /// as a Collection of `UInt8`.
+  ///
   /// ${contiguousCaveat}
   ///
   /// - Precondition: `Pointee` is a trivial type.

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -127,6 +127,7 @@ set(SWIFTLIB_ESSENTIAL
   Unmanaged.swift
   UnsafeBitMap.swift
   UnsafeBufferPointer.swift.gyb
+  UnsafeRawBufferPointer.swift.gyb
   UnsafePointer.swift.gyb
   UnsafeRawPointer.swift.gyb
   WriteBackMutableSlice.swift

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -119,7 +119,8 @@
     "Pointer.swift",
     "UnsafePointer.swift",
     "UnsafeRawPointer.swift",
-    "UnsafeBufferPointer.swift"
+    "UnsafeBufferPointer.swift",
+    "UnsafeRawBufferPointer.swift"
   ],
   "Protocols": [
     "CompilerProtocols.swift",

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -16,9 +16,10 @@
 %  Self = 'UnsafeMutableRawBufferPointer' if mutable else 'UnsafeRawBufferPointer'
 %  Mutable = 'Mutable' if mutable else ''
 
-/// A non-owning view over a region of memory as a Collection of bytes
-/// independent of the type of values held in that memory. Each 8-bit byte in
-/// memory is viewed as a `UInt8` value.
+/// A non-owning view over a region of memory as a Collection of bytes.
+///
+/// Each 8-bit byte in memory is viewed as a `UInt8` value independent of the
+/// type of values held in that memory.
 ///
 /// Reads and writes on memory via `UnsafeRawBufferPointer` are untyped
 /// operations. Accessing this Collection's bytes does not bind the
@@ -313,7 +314,7 @@ public struct Unsafe${Mutable}RawBufferPointer
         count: bounds.count)
     }
 %  if mutable:
-    set {
+    nonmutating set {
       _debugPrecondition(bounds.lowerBound >= startIndex)
       _debugPrecondition(bounds.upperBound <= endIndex)
       _debugPrecondition(bounds.count == newValue.count)
@@ -363,12 +364,12 @@ extension Unsafe${Mutable}RawBufferPointer : CustomDebugStringConvertible {
 %  if mutable:
 public func withUnsafeMutableBytes<T, Result>(
   of arg: inout T,
-  _ body: (inout UnsafeMutableRawBufferPointer) throws -> Result
+  _ body: (UnsafeMutableRawBufferPointer) throws -> Result
 ) rethrows -> Result
 {
   return try withUnsafeMutablePointer(to: &arg) {
-    var bytes = UnsafeMutableRawBufferPointer(start: $0, count: MemoryLayout<T>.size)
-    return try body(&bytes)
+    return try body(UnsafeMutableRawBufferPointer(
+        start: $0, count: MemoryLayout<T>.size))
   }
 }
 %  else:

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1,0 +1,386 @@
+//===--- UnsafeRawBufferPointer.swift.gyb --------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+%import gyb
+
+% for mutable in (True, False):
+%  Self = 'UnsafeMutableRawBufferPointer' if mutable else 'UnsafeRawBufferPointer'
+%  Mutable = 'Mutable' if mutable else ''
+
+/// A non-owning view over a region of memory as a Collection of bytes
+/// independent of the type of values held in that memory. Each 8-bit byte in
+/// memory is viewed as a `UInt8` value.
+///
+/// Reads and writes on memory via `UnsafeRawBufferPointer` are untyped
+/// operations. Accessing this Collection's bytes does not bind the
+/// underlying memory to `UInt8`. The underlying memory must be bound
+/// to some trivial type whenever it is accessed via a typed operation.
+///
+/// - Note: A trivial type can be copied with just a bit-for-bit copy without
+///   any indirection or reference-counting operations.  Generally, native Swift
+///   types that do not contain strong or weak references or other forms of
+///   indirection are trivial, as are imported C structs and enums. Copying
+///   memory that contains values of nontrivial type can only be done safely
+///   with a typed pointer. Copying bytes directly from nontrivial in-memory
+///   values does not produce valid copies and can only be done by calling a C
+///   API such as memmove.
+///
+/// In addition to the `Collection` interface, the following subset of
+/// `Unsafe${Mutable}RawPointer`'s interface to raw memory is
+/// provided with debug mode bounds checks:
+/// - `load(fromByteOffset:as:)`,
+%  if mutable:
+/// - `storeBytes(of:toByteOffset:as:)`
+/// - `copyBytes(from:count:)`
+%  end
+///
+/// This is only a view into memory and does not own the memory. Copying a value
+/// of type `Unsafe${Mutable}Bytes` does not copy the underlying
+/// memory. However, initializing another collection, such as `[UInt8]`, with an
+/// `Unsafe${Mutable}Bytes` into copies bytes out of memory.
+///
+/// Example:
+/// ```swift
+///   // View a slice of memory at someBytes. Nothing is copied.
+///   var destBytes = someBytes[0..<n]
+///
+///   // Copy the slice of memory into a buffer of UInt8.
+///   var byteArray = [UInt8](destBytes)
+///
+///   // Copy another slice of memory into the buffer.
+///   byteArray += someBytes[n..<m]
+/// ```
+///
+%  if mutable:
+/// Assigning into a range of subscripts copies bytes into the memory.
+///
+/// Example (continued):
+/// ```swift
+///   // Copy a another slice of memory back into the original slice.
+///   destBytes[0..<n] = someBytes[m..<(m+n)]
+/// ```
+///
+%  end
+/// TODO: Specialize `index` and `formIndex` and
+/// `_failEarlyRangeCheck` as in `UnsafeBufferPointer`.
+public struct Unsafe${Mutable}RawBufferPointer
+  : ${Mutable}Collection, RandomAccessCollection {
+
+  public typealias Index = Int
+  public typealias IndexDistance = Int
+  public typealias SubSequence = ${Self}
+
+  /// An iterator over the bytes viewed by `${Self}`.
+  public struct Iterator : IteratorProtocol, Sequence {
+
+    /// Advances to the next byte and returns it, or `nil` if no next byte
+    /// exists.
+    ///
+    /// Once `nil` has been returned, all subsequent calls return `nil`.
+    public mutating func next() -> UInt8? {
+      if _position == _end { return nil }
+      
+      let result = _position!.load(as: UInt8.self)
+      _position! += 1
+      return result
+    }
+
+    internal var _position, _end: UnsafeRawPointer?
+  }
+
+%  if mutable:
+  /// Allocate memory for `size` bytes with word alignment.
+  ///
+  /// - Postcondition: The memory is allocated, but not initialized.
+  public static func allocate(count size: Int
+  ) -> UnsafeMutableRawBufferPointer {
+    return UnsafeMutableRawBufferPointer(
+      start: UnsafeMutableRawPointer.allocate(
+        bytes: size, alignedTo: MemoryLayout<UInt>.alignment),
+      count: size)
+  }
+%  end # mutable
+
+  /// Deallocate this memory allocated for `bytes` number of bytes.
+  ///
+  /// - Precondition: The memory is not initialized.
+  ///
+  /// - Postcondition: The memory has been deallocated.
+  public func deallocate() {
+    _position?.deallocate(
+      bytes: count, alignedTo: MemoryLayout<UInt>.alignment)
+  }
+
+  /// Reads raw bytes from memory at `self + offset` and constructs a
+  /// value of type `T`.
+  ///
+  /// - Precondition: `offset + MemoryLayout<T>.size < self.count`
+  ///
+  /// - Precondition: The underlying pointer plus `offset` is properly
+  ///   aligned for accessing `T`.
+  ///
+  /// - Precondition: The memory is initialized to a value of some type `U`
+  ///   such that `T` is layout compatible with `U`.
+  public func load<T>(fromByteOffset offset: Int = 0, as type: T.Type) -> T {
+    _debugPrecondition(offset >= 0, "${Self}.load with negative offset")
+    _debugPrecondition(offset + MemoryLayout<T>.size <= self.count,
+      "${Self}.load out of bounds")
+    return baseAddress!.load(fromByteOffset: offset, as: T.self)
+  }
+
+%  if mutable:
+  /// Stores a value's bytes into raw memory at `self + offset`.
+  ///  
+  /// - Precondition: `offset + MemoryLayout<T>.size < self.count`
+  ///
+  /// - Precondition: The underlying pointer plus `offset` is properly
+  ///   aligned for storing type `T`.
+  ///
+  /// - Precondition: `T` is a trivial type.
+  ///
+  /// - Precondition: The memory is uninitialized, or initialized to
+  ///   some trivial type `U` such that `T` and `U` are mutually layout
+  ///   compatible.
+  /// 
+  /// - Postcondition: The memory is initialized to raw bytes. If the
+  ///   memory is bound to type `U`, then it now contains a value of
+  ///   type `U`.
+  ///
+  /// - Note: A trivial type can be copied with just a bit-for-bit
+  ///   copy without any indirection or reference-counting operations.
+  ///   Generally, native Swift types that do not contain strong or
+  ///   weak references or other forms of indirection are trivial, as
+  ///   are imported C structs and enums.
+  public func storeBytes<T>(
+    of value: T, toByteOffset offset: Int = 0, as: T.Type
+  ) {
+    _debugPrecondition(offset >= 0, "${Self}.storeBytes with negative offset")
+    _debugPrecondition(offset + MemoryLayout<T>.size <= self.count,
+      "${Self}.storeBytes out of bounds")
+
+    baseAddress!.storeBytes(of: value, toByteOffset: offset, as: T.self)
+  }
+
+  /// Copies `count` bytes from `source` into memory at `self`.
+  ///  
+  /// - Precondition: `count` is non-negative.
+  ///
+  /// - Precondition: The memory at `source..<source + count` is
+  ///   initialized to some trivial type `T`.
+  ///
+  /// - Precondition: If the memory at `self..<self+count` is bound to
+  ///   a type `U`, then `U` is a trivial type, the underlying
+  ///   pointers `source` and `self` are properly aligned for type
+  ///   `U`, and `count` is a multiple of `MemoryLayout<U>.stride`.
+  ///
+  /// - Postcondition: The memory at `self..<self+count` is
+  ///   initialized to raw bytes. If the memory is bound to type `U`,
+  ///   then it contains values of type `U`.
+  public func copyBytes(from source: UnsafeRawBufferPointer) {
+    _debugPrecondition(source.count <= self.count,
+      "${Self}.copyBytes source has too many elements")
+    baseAddress?.copyBytes(from: source.baseAddress!, count: source.count)
+  }
+
+  /// Copies from a collection of `UInt8` into memory at `self`.
+  ///
+  /// - Precondition: `source.count <= self.count`.
+  ///
+  /// - Precondition: If the memory at `self..<self+count` is bound to
+  ///   a type `U`, then `U` is a trivial type, the underlying pointer
+  ///   at `self` is properly aligned for type `U`, and `source.count`
+  ///   is a multiple of `MemoryLayout<U>.stride`.
+  ///
+  /// - Postcondition: The memory at `self..<self+count` is
+  ///   initialized to raw bytes. If the memory is bound to type `U`,
+  ///   then it contains values of type `U`.
+  public func copyBytes<C : Collection>(from source: C
+  ) where C.Iterator.Element == UInt8 {
+    _debugPrecondition(numericCast(source.count) <= self.count,
+      "${Self}.copyBytes source has too many elements")
+    guard let position = _position else {
+      return
+    }
+    for (index, byteValue) in source.enumerated() {
+      position.storeBytes(
+        of: byteValue, toByteOffset: index, as: UInt8.self)
+    }
+  }
+%  end # mutable
+
+  /// Creates an `${Self}` over `count` contiguous bytes beginning at `start`.
+  ///
+  /// If `start` is nil, `count` must be 0. However, `count` may be 0 even for
+  /// a nonzero `start`.
+  public init(start: Unsafe${Mutable}RawPointer?, count: Int) {
+    _precondition(count >= 0, "${Self} with negative count")
+    _precondition(count == 0 || start != nil,
+      "${Self} has a nil start and nonzero count")
+    _position = start
+    _end = start.map { $0 + count }
+  }
+
+  /// Converts UnsafeMutableRawBufferPointer to UnsafeRawBufferPointer.
+  public init(_ bytes: UnsafeMutableRawBufferPointer) {
+    self.init(start: bytes.baseAddress, count: bytes.count)
+  }
+
+%  if mutable:
+  /// Converts UnsafeRawBufferPointer to UnsafeMutableRawBufferPointer.
+  public init(mutating bytes: UnsafeRawBufferPointer) {
+    self.init(start: UnsafeMutableRawPointer(mutating: bytes.baseAddress),
+      count: bytes.count)
+  }
+%  else:
+  /// Converts UnsafeRawBufferPointer to UnsafeMutableRawBufferPointer.
+  public init(_ bytes: UnsafeRawBufferPointer) {
+    self.init(start: bytes.baseAddress, count: bytes.count)
+  }
+%  end # !mutable
+
+  /// Creates an `${Self}` over the contiguous bytes in `buffer`.
+  ///
+  /// - Precondition: `T` is a trivial type.
+  public init<T>(_ buffer: UnsafeMutableBufferPointer<T>) {
+    self.init(start: buffer.baseAddress!,
+      count: buffer.count * MemoryLayout<T>.stride)
+  }
+
+%  if not mutable:
+  /// Creates an `${Self}` view over the contiguous memory in `buffer`.
+  ///
+  /// - Precondition: `T` is a trivial type.
+  public init<T>(_ buffer: UnsafeBufferPointer<T>) {
+    self.init(start: buffer.baseAddress!,
+      count: buffer.count * MemoryLayout<T>.stride)
+  }
+%  end # !mutable
+
+  /// Always zero, which is the index of the first byte in a
+  /// non-empty buffer.
+  public var startIndex: Int {
+    return 0
+  }
+
+  /// The "past the end" position---that is, the position one greater than the
+  /// last valid subscript argument.
+  ///
+  /// The `endIndex` property of an `Unsafe${Mutable}RawBufferPointer`
+  /// instance is always identical to `count`.
+  public var endIndex: Int {
+    return count
+  }
+
+  public typealias Indices = CountableRange<Int>
+
+  public var indices: Indices {
+    return startIndex..<endIndex
+  }
+
+  /// Accesses the `i`th byte in the memory region as a `UInt8` value.
+  public subscript(i: Int) -> UInt8 {
+    get {
+      _debugPrecondition(i >= 0)
+      _debugPrecondition(i < endIndex)
+      return _position!.load(fromByteOffset: i, as: UInt8.self)
+    }
+%  if mutable:
+    nonmutating set {
+      _debugPrecondition(i >= 0)
+      _debugPrecondition(i < endIndex)
+      _position!.storeBytes(of: newValue, toByteOffset: i, as: UInt8.self)
+    }
+%  end # mutable
+  }
+
+  /// Accesses the bytes in the memory region within `bounds` as a `UInt8`
+  /// values.
+  public subscript(bounds: Range<Int>) -> Unsafe${Mutable}RawBufferPointer {
+    get {
+      _debugPrecondition(bounds.lowerBound >= startIndex)
+      _debugPrecondition(bounds.upperBound <= endIndex)
+      return Unsafe${Mutable}RawBufferPointer(
+        start: baseAddress.map { $0 + bounds.lowerBound },
+        count: bounds.count)
+    }
+%  if mutable:
+    set {
+      _debugPrecondition(bounds.lowerBound >= startIndex)
+      _debugPrecondition(bounds.upperBound <= endIndex)
+      _debugPrecondition(bounds.count == newValue.count)
+
+      if newValue.count > 0 {
+        (baseAddress! + bounds.lowerBound).copyBytes(
+          from: newValue.baseAddress!,
+          count: newValue.count)
+      }
+    }
+%  end # mutable
+  }
+
+  /// Returns an iterator over the bytes of this sequence.
+  ///
+  /// - Complexity: O(1).
+  public func makeIterator() -> Iterator {
+    return Iterator(_position: _position, _end: _end)
+  }
+
+  /// A pointer to the first byte of the buffer.
+  public var baseAddress: Unsafe${Mutable}RawPointer? {
+    return _position
+  }
+
+  /// The number of bytes in the buffer.
+  public var count: Int {
+    if let pos = _position {
+      return _end! - pos
+    }
+    return 0
+  }
+
+  let _position, _end: Unsafe${Mutable}RawPointer?
+}
+
+extension Unsafe${Mutable}RawBufferPointer : CustomDebugStringConvertible {
+  /// A textual representation of `self`, suitable for debugging.
+  public var debugDescription: String {
+    return "${Self}"
+      + "(start: \(_position.map(String.init(describing:)) ?? "nil"), count: \(count))"
+  }
+}
+
+/// Invokes `body` with an `${Self}` argument and returns the
+/// result.
+%  if mutable:
+public func withUnsafeMutableBytes<T, Result>(
+  of arg: inout T,
+  _ body: (inout UnsafeMutableRawBufferPointer) throws -> Result
+) rethrows -> Result
+{
+  return try withUnsafeMutablePointer(to: &arg) {
+    var bytes = UnsafeMutableRawBufferPointer(start: $0, count: MemoryLayout<T>.size)
+    return try body(&bytes)
+  }
+}
+%  else:
+public func withUnsafeBytes<T, Result>(
+  of arg: inout T,
+  _ body: (UnsafeRawBufferPointer) throws -> Result
+) rethrows -> Result
+{
+  return try withUnsafePointer(to: &arg) {
+    try body(UnsafeRawBufferPointer(start: $0, count: MemoryLayout<T>.size))
+  }
+}
+%  end # mutable
+
+% end # for mutable

--- a/test/1_stdlib/UnsafePointerDiagnostics.swift
+++ b/test/1_stdlib/UnsafePointerDiagnostics.swift
@@ -109,7 +109,7 @@ func unsafePointerConversionAvailability(
   _ = UnsafePointer<Int>(oups)  // expected-error {{'init' is unavailable: use 'withMemoryRebound(to:capacity:_)' to temporarily view memory as another layout-compatible type.}}
 }
 
-func unsafeRawBufferPointerConversionAvailability(
+func unsafeRawBufferPointerConversions(
   mrp: UnsafeMutableRawPointer,
   rp: UnsafeRawPointer,
   mrbp: UnsafeMutableRawBufferPointer,

--- a/test/1_stdlib/UnsafePointerDiagnostics.swift
+++ b/test/1_stdlib/UnsafePointerDiagnostics.swift
@@ -108,3 +108,32 @@ func unsafePointerConversionAvailability(
   _ = UnsafePointer<Int>(oumps) // expected-error {{'init' is unavailable: use 'withMemoryRebound(to:capacity:_)' to temporarily view memory as another layout-compatible type.}}
   _ = UnsafePointer<Int>(oups)  // expected-error {{'init' is unavailable: use 'withMemoryRebound(to:capacity:_)' to temporarily view memory as another layout-compatible type.}}
 }
+
+func unsafeRawBufferPointerConversionAvailability(
+  mrp: UnsafeMutableRawPointer,
+  rp: UnsafeRawPointer,
+  mrbp: UnsafeMutableRawBufferPointer,
+  rbp: UnsafeRawBufferPointer,
+  mbpi: UnsafeMutableBufferPointer<Int>,
+  bpi: UnsafeBufferPointer<Int>) {
+
+  let omrp: UnsafeMutableRawPointer? = mrp
+  let orp: UnsafeRawPointer? = rp
+
+  _ = UnsafeMutableRawBufferPointer(start: mrp, count: 1)
+  _ = UnsafeRawBufferPointer(start: mrp, count: 1)
+  _ = UnsafeMutableRawBufferPointer(start: rp, count: 1) // expected-error {{cannot convert value of type 'UnsafeRawPointer' to expected argument type 'UnsafeMutableRawPointer?'}}
+  _ = UnsafeRawBufferPointer(start: rp, count: 1)
+  _ = UnsafeMutableRawBufferPointer(mrbp)
+  _ = UnsafeRawBufferPointer(mrbp)
+  _ = UnsafeMutableRawBufferPointer(rbp) // expected-error {{cannot invoke initializer for type 'UnsafeMutableRawBufferPointer' with an argument list of type '(UnsafeRawBufferPointer)'}} expected-note {{overloads for 'UnsafeMutableRawBufferPointer' exist with these partially matching parameter lists: (UnsafeMutableRawBufferPointer), (UnsafeMutableBufferPointer<T>)}}
+  _ = UnsafeRawBufferPointer(rbp)
+  _ = UnsafeMutableRawBufferPointer(mbpi)
+  _ = UnsafeRawBufferPointer(mbpi)
+  _ = UnsafeMutableRawBufferPointer(bpi) // expected-error {{cannot invoke initializer for type 'UnsafeMutableRawBufferPointer' with an argument list of type '(UnsafeBufferPointer<Int>)'}} expected-note {{overloads for 'UnsafeMutableRawBufferPointer' exist with these partially matching parameter lists: (UnsafeMutableRawBufferPointer), (UnsafeMutableBufferPointer<T>)}}
+  _ = UnsafeRawBufferPointer(bpi)
+  _ = UnsafeMutableRawBufferPointer(start: omrp, count: 1)
+  _ = UnsafeRawBufferPointer(start: omrp, count: 1)
+  _ = UnsafeMutableRawBufferPointer(start: orp, count: 1) // expected-error {{cannot convert value of type 'UnsafeRawPointer?' to expected argument type 'UnsafeMutableRawPointer?'}}
+  _ = UnsafeRawBufferPointer(start: orp, count: 1)
+}

--- a/test/stdlib/UnsafeRawBufferPointer.swift
+++ b/test/stdlib/UnsafeRawBufferPointer.swift
@@ -1,0 +1,380 @@
+// RUN: %target-run-simple-swiftgyb
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var UnsafeRawBufferPointerTestSuite = TestSuite("UnsafeRawBufferPointer")
+
+// View an in-memory value's bytes.
+// Use copyBytes to overwrite the value's bytes.
+UnsafeRawBufferPointerTestSuite.test("initFromValue") {
+  var value1: Int32 = -1
+  var value2: Int32 = 0
+  // Immutable view of value1's bytes.
+  withUnsafeBytes(of: &value1) { bytes1 in
+    expectEqual(bytes1.count, 4)
+    for b in bytes1 {
+      expectEqual(b, 0xFF)
+    }
+    // Mutable view of value2's bytes.
+    withUnsafeMutableBytes(of: &value2) { bytes2 in
+      expectEqual(bytes1.count, bytes2.count)
+      bytes2[0..<bytes2.count].copyBytes(from: bytes1)
+    }
+  }
+  expectEqual(value2, value1)
+}
+
+// View an array's elements as bytes.
+// Use copyBytes to overwrite the array element's bytes.
+UnsafeRawBufferPointerTestSuite.test("initFromArray") {
+  var array1: [Int32] = [0, 1, 2, 3]
+  var array2 = [Int32](repeating: 0, count: 4)
+  // Immutable view of array1's bytes.
+  array1.withUnsafeBytes { bytes1 in
+    expectEqual(bytes1.count, 16)
+    for (i, b) in bytes1.enumerated() {
+      if i % 4 == 0 {
+        expectEqual(Int(b), i / 4)
+      }
+      else {
+        expectEqual(b, 0)
+      }
+    }
+    // Mutable view of array2's bytes.
+    array2.withUnsafeMutableBytes { bytes2 in
+      expectEqual(bytes1.count, bytes2.count)
+      bytes2[0..<bytes2.count].copyBytes(from: bytes1)
+    }
+  }
+  expectEqual(array2, array1)
+}
+
+// Check Collection conformance and associated types.
+UnsafeRawBufferPointerTestSuite.test("Collection") {
+  expectCollectionType(UnsafeRawBufferPointer.self)
+  expectMutableCollectionType(UnsafeMutableRawBufferPointer.self)
+  expectSliceType(UnsafeRawBufferPointer.self)
+  expectMutableSliceType(UnsafeMutableRawBufferPointer.self)
+
+  expectCollectionAssociatedTypes(
+    collectionType: UnsafeRawBufferPointer.self,
+    iteratorType: UnsafeRawBufferPointer.Iterator.self,
+    subSequenceType: UnsafeRawBufferPointer.self,
+    indexType: Int.self,
+    indexDistanceType: Int.self,
+    indicesType: CountableRange<Int>.self)
+
+  expectCollectionAssociatedTypes(
+    collectionType: UnsafeMutableRawBufferPointer.self,
+    iteratorType: UnsafeMutableRawBufferPointer.Iterator.self,
+    subSequenceType: UnsafeMutableRawBufferPointer.self,
+    indexType: Int.self,
+    indexDistanceType: Int.self,
+    indicesType: CountableRange<Int>.self)
+}
+
+// Verify basic Sequence/Iterator functionality.
+UnsafeRawBufferPointerTestSuite.test("Sequence") {
+  var array1: [Int32] = [0, 1, 2, 3]
+  array1.withUnsafeBytes { bytes1 in
+    // Initialize an array from a sequence of bytes.
+    let byteArray = [UInt8](bytes1)
+    for (b1, b2) in zip(byteArray, bytes1) {
+      expectEqual(b1, b2)
+    }
+  }
+}
+
+// Test the empty buffer.
+UnsafeRawBufferPointerTestSuite.test("empty") {
+  let emptyBytes = UnsafeRawBufferPointer(start: nil, count: 0)
+  for byte in emptyBytes {
+    expectUnreachable()
+  }
+  let emptyMutableBytes = UnsafeMutableRawBufferPointer.allocate(count: 0)
+  for byte in emptyMutableBytes {
+    expectUnreachable()
+  }
+  emptyMutableBytes.deallocate()
+}
+
+// Store a sequence of integers to raw memory, and reload them as structs.
+// Strore structs to raw memory, and reload them as integers.
+UnsafeRawBufferPointerTestSuite.test("reinterpret") {
+  struct Pair {
+    var x: Int32
+    var y: Int32
+  }
+  let numPairs = 2
+  let bytes = UnsafeMutableRawBufferPointer.allocate(
+    count: MemoryLayout<Pair>.stride * numPairs)
+  defer { bytes.deallocate() }  
+
+  for i in 0..<(numPairs * 2) {
+    bytes.storeBytes(of: Int32(i), toByteOffset: i * MemoryLayout<Int32>.stride,
+      as: Int32.self)
+  }
+  let pair1 = bytes.load(as: Pair.self)
+  let pair2 = bytes.load(fromByteOffset: MemoryLayout<Pair>.stride,
+    as: Pair.self)
+  expectEqual(0, pair1.x)
+  expectEqual(1, pair1.y)
+  expectEqual(2, pair2.x)
+  expectEqual(3, pair2.y)
+
+  bytes.storeBytes(of: Pair(x: -1, y: 0), as: Pair.self)
+  for i in 0..<MemoryLayout<Int32>.stride {
+    expectEqual(0xFF, bytes[i])
+  }
+  let bytes2 = bytes[MemoryLayout<Int32>.stride..<bytes.count]
+  for i in 0..<MemoryLayout<Int32>.stride {
+    expectEqual(0, bytes2[i])
+  }
+}
+
+// Store, load, subscript, and slice at all valid byte offsets.
+UnsafeRawBufferPointerTestSuite.test("inBounds") {
+  let numInts = 4
+  let bytes = UnsafeMutableRawBufferPointer.allocate(
+    count: MemoryLayout<Int>.stride * numInts)
+  defer { bytes.deallocate() }
+
+  for i in 0..<numInts {
+    bytes.storeBytes(
+      of: i, toByteOffset: i * MemoryLayout<Int>.stride, as: Int.self)
+  }
+  for i in 0..<numInts {
+    let x = bytes.load(
+      fromByteOffset: i * MemoryLayout<Int>.stride, as: Int.self)
+    expectEqual(x, i)
+  }
+  for i in 0..<numInts {
+    var x = i
+    withUnsafeBytes(of: &x) {
+      for (offset, byte) in $0.enumerated() {
+        expectEqual(bytes[i * MemoryLayout<Int>.stride + offset], byte)
+      }
+    }
+  }
+  let median = (numInts/2 * MemoryLayout<Int>.stride)
+  var firstHalf = bytes[0..<median]
+  var secondHalf = bytes[median..<bytes.count]
+  firstHalf[0..<firstHalf.count] = secondHalf
+  expectEqualSequence(firstHalf, secondHalf)
+}
+
+UnsafeRawBufferPointerTestSuite.test("subscript.get.underflow") {
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  let buffer = UnsafeMutableRawBufferPointer.allocate(count: 2)
+  defer { buffer.deallocate() }
+
+  let bytes = buffer[1..<2]
+  _ = bytes[-1]
+}
+
+UnsafeRawBufferPointerTestSuite.test("subscript.get.overflow") {
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  let buffer = UnsafeMutableRawBufferPointer.allocate(count: 2)
+  defer { buffer.deallocate() }
+
+  let bytes = buffer[0..<1]
+  _ = bytes[1]
+}
+
+UnsafeRawBufferPointerTestSuite.test("subscript.set.underflow") {
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  let buffer = UnsafeMutableRawBufferPointer.allocate(count: 2)
+  defer { buffer.deallocate() }
+
+  let bytes = buffer[1..<2]
+  bytes[-1] = 0
+}
+
+UnsafeRawBufferPointerTestSuite.test("subscript.set.overflow") {
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  let buffer = UnsafeMutableRawBufferPointer.allocate(count: 2)
+  defer { buffer.deallocate() }
+
+  let bytes = buffer[0..<1]
+  bytes[1] = 0
+}
+
+UnsafeRawBufferPointerTestSuite.test("subscript.range.get.underflow") {
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  let buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
+  defer { buffer.deallocate() }
+
+  let bytes = buffer[1..<3]
+  _ = bytes[-1..<1]
+}
+
+UnsafeRawBufferPointerTestSuite.test("subscript.range.get.overflow") {
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  let buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
+  defer { buffer.deallocate() }
+
+  let bytes = buffer[0..<2]
+  _ = bytes[1..<3]
+}
+
+UnsafeRawBufferPointerTestSuite.test("subscript.range.set.underflow") {
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  var buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
+  defer { buffer.deallocate() }
+
+  var bytes = buffer[1..<3]
+  bytes[-1..<1] = bytes[0..<2]
+}
+
+UnsafeRawBufferPointerTestSuite.test("subscript.range.set.overflow") {
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  var buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
+  defer { buffer.deallocate() }
+
+  var bytes = buffer[0..<2]
+  bytes[1..<3] = bytes[0..<2]
+}
+
+UnsafeRawBufferPointerTestSuite.test("subscript.range.narrow") {
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  var buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
+  defer { buffer.deallocate() }
+
+  buffer[0..<3] = buffer[0..<2]
+}
+
+UnsafeRawBufferPointerTestSuite.test("subscript.range.wide") {
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  var buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
+  defer { buffer.deallocate() }
+
+  buffer[0..<2] = buffer[0..<3]
+}
+
+UnsafeRawBufferPointerTestSuite.test("load.before")
+.skip(.custom(
+    { !_isDebugAssertConfiguration() },
+    reason: "This test behaves unpredictably in optimized mode."))
+.code {
+  expectCrashLater()
+  var x: Int32 = 0
+  withUnsafeBytes(of: &x) {
+    _ = $0.load(fromByteOffset: -1, as: UInt8.self)
+  }
+}
+
+UnsafeRawBufferPointerTestSuite.test("load.after")
+.skip(.custom(
+    { !_isDebugAssertConfiguration() },
+    reason: "This test behaves unpredictably in optimized mode."))
+.code {
+  expectCrashLater()
+  var x: Int32 = 0
+  withUnsafeBytes(of: &x) {
+    _ = $0.load(as: UInt64.self)
+  }
+}
+
+UnsafeRawBufferPointerTestSuite.test("store.before")
+.skip(.custom(
+    { !_isDebugAssertConfiguration() },
+    reason: "This test behaves unpredictably in optimized mode."))
+.code {
+  expectCrashLater()
+  var x: Int32 = 0
+  withUnsafeMutableBytes(of: &x) {
+    $0.storeBytes(of: UInt8(0), toByteOffset: -1, as: UInt8.self)
+  }
+}
+UnsafeRawBufferPointerTestSuite.test("store.after")
+.skip(.custom(
+    { !_isDebugAssertConfiguration() },
+    reason: "This test behaves unpredictably in optimized mode."))
+.code {
+  expectCrashLater()
+  var x: Int32 = 0
+  withUnsafeMutableBytes(of: &x) {
+    $0.storeBytes(of: UInt64(0), as: UInt64.self)
+  }
+}
+
+UnsafeRawBufferPointerTestSuite.test("copy.bytes.overflow")
+.skip(.custom(
+    { !_isDebugAssertConfiguration() },
+    reason: "This test behaves unpredictably in optimized mode."))
+.code {
+  expectCrashLater()
+  var x: Int64 = 0
+  var y: Int32 = 0
+  withUnsafeBytes(of: &x) { srcBytes in
+    withUnsafeMutableBytes(of: &y) { destBytes in
+      destBytes.copyBytes(
+        from: UnsafeMutableRawBufferPointer(mutating: srcBytes))
+    }
+  }
+}
+
+UnsafeRawBufferPointerTestSuite.test("copy.sequence.overflow")
+.skip(.custom(
+    { !_isDebugAssertConfiguration() },
+    reason: "This test behaves unpredictably in optimized mode."))
+.code {
+  expectCrashLater()
+  var x: Int64 = 0
+  var y: Int32 = 0
+  withUnsafeBytes(of: &x) { srcBytes in
+    withUnsafeMutableBytes(of: &y) { destBytes in
+      destBytes.copyBytes(from: srcBytes)
+    }
+  }
+}
+
+UnsafeRawBufferPointerTestSuite.test("copy.overlap") {
+  var bytes = UnsafeMutableRawBufferPointer.allocate(count: 4)
+  // Right Overlap
+  bytes[0] = 1
+  bytes[1] = 2
+  bytes[1..<3] = bytes[0..<2]
+  expectEqual(1, bytes[1])
+  expectEqual(2, bytes[2])
+  // Left Overlap
+  bytes[1] = 2
+  bytes[2] = 3
+  bytes[0..<2] = bytes[1..<3]
+  expectEqual(2, bytes[0])
+  expectEqual(3, bytes[1])
+  // Disjoint
+  bytes[2] = 2
+  bytes[3] = 3
+  bytes[0..<2] = bytes[2..<4]
+  expectEqual(2, bytes[0])
+  expectEqual(3, bytes[1])
+  bytes[0] = 0
+  bytes[1] = 1
+  bytes[2..<4] = bytes[0..<2]
+  expectEqual(0, bytes[2])
+  expectEqual(1, bytes[3])
+}
+
+runAllTests()

--- a/test/stdlib/UnsafeRawBufferPointer.swift
+++ b/test/stdlib/UnsafeRawBufferPointer.swift
@@ -1,5 +1,9 @@
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
+//
+// Test corner cases specific to UnsafeRawBufferPointer.
+// General Collection behavior tests are in
+// validation-test/stdlib/UnsafeBufferPointer.swift.
 
 import StdlibUnittest
 
@@ -23,6 +27,27 @@ UnsafeRawBufferPointerTestSuite.test("initFromValue") {
     }
   }
   expectEqual(value2, value1)
+}
+
+// Test mutability and subscript getter/setters.
+UnsafeRawBufferPointerTestSuite.test("nonmutating_subscript_setter") {
+  var value1: Int32 = -1
+  var value2: Int32 = 0
+
+  withUnsafeMutableBytes(of: &value1) { bytes1 in
+    withUnsafeMutableBytes(of: &value2) { bytes2 in
+      bytes2[0..<bytes2.count] = bytes1[0..<bytes1.count]
+    }
+  }
+  expectEqual(value2, value1)
+
+  let buffer = UnsafeMutableRawBufferPointer.allocate(count: 4)
+  defer { buffer.deallocate() }
+  buffer.copyBytes(from: [0, 1, 2, 3] as [UInt8])
+  let leftBytes = buffer[0..<2]
+  let rightBytes = buffer[0..<2]
+  leftBytes[0..<2] = rightBytes
+  expectEqualSequence(leftBytes, rightBytes)
 }
 
 // View an array's elements as bytes.
@@ -50,32 +75,8 @@ UnsafeRawBufferPointerTestSuite.test("initFromArray") {
   expectEqual(array2, array1)
 }
 
-// Check Collection conformance and associated types.
-UnsafeRawBufferPointerTestSuite.test("Collection") {
-  expectCollectionType(UnsafeRawBufferPointer.self)
-  expectMutableCollectionType(UnsafeMutableRawBufferPointer.self)
-  expectSliceType(UnsafeRawBufferPointer.self)
-  expectMutableSliceType(UnsafeMutableRawBufferPointer.self)
-
-  expectCollectionAssociatedTypes(
-    collectionType: UnsafeRawBufferPointer.self,
-    iteratorType: UnsafeRawBufferPointer.Iterator.self,
-    subSequenceType: UnsafeRawBufferPointer.self,
-    indexType: Int.self,
-    indexDistanceType: Int.self,
-    indicesType: CountableRange<Int>.self)
-
-  expectCollectionAssociatedTypes(
-    collectionType: UnsafeMutableRawBufferPointer.self,
-    iteratorType: UnsafeMutableRawBufferPointer.Iterator.self,
-    subSequenceType: UnsafeMutableRawBufferPointer.self,
-    indexType: Int.self,
-    indexDistanceType: Int.self,
-    indicesType: CountableRange<Int>.self)
-}
-
-// Verify basic Sequence/Iterator functionality.
-UnsafeRawBufferPointerTestSuite.test("Sequence") {
+// Directly test the byte Sequence produced by withUnsafeBytes.
+UnsafeRawBufferPointerTestSuite.test("withUnsafeBytes.Sequence") {
   var array1: [Int32] = [0, 1, 2, 3]
   array1.withUnsafeBytes { bytes1 in
     // Initialize an array from a sequence of bytes.
@@ -165,117 +166,161 @@ UnsafeRawBufferPointerTestSuite.test("inBounds") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.get.underflow") {
-  if _isDebugAssertConfiguration() {
-    expectCrashLater()
-  }
   let buffer = UnsafeMutableRawBufferPointer.allocate(count: 2)
   defer { buffer.deallocate() }
 
   let bytes = buffer[1..<2]
+
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  // Accesses a valid buffer location but triggers a debug bounds check.
   _ = bytes[-1]
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.get.overflow") {
-  if _isDebugAssertConfiguration() {
-    expectCrashLater()
-  }
   let buffer = UnsafeMutableRawBufferPointer.allocate(count: 2)
   defer { buffer.deallocate() }
 
   let bytes = buffer[0..<1]
+
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  // Accesses a valid buffer location but triggers a debug bounds check.
   _ = bytes[1]
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.set.underflow") {
-  if _isDebugAssertConfiguration() {
-    expectCrashLater()
-  }
   let buffer = UnsafeMutableRawBufferPointer.allocate(count: 2)
   defer { buffer.deallocate() }
 
   let bytes = buffer[1..<2]
+
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  // Accesses a valid buffer location but triggers a debug bounds check.
   bytes[-1] = 0
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.set.overflow") {
-  if _isDebugAssertConfiguration() {
-    expectCrashLater()
-  }
   let buffer = UnsafeMutableRawBufferPointer.allocate(count: 2)
   defer { buffer.deallocate() }
 
   let bytes = buffer[0..<1]
+
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  // Accesses a valid buffer location but triggers a debug bounds check.
   bytes[1] = 0
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.get.underflow") {
-  if _isDebugAssertConfiguration() {
-    expectCrashLater()
-  }
   let buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
   defer { buffer.deallocate() }
 
   let bytes = buffer[1..<3]
+
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  // Accesses a valid buffer location but triggers a debug bounds check.
   _ = bytes[-1..<1]
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.get.overflow") {
-  if _isDebugAssertConfiguration() {
-    expectCrashLater()
-  }
   let buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
   defer { buffer.deallocate() }
 
   let bytes = buffer[0..<2]
+
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  // Accesses a valid buffer location but triggers a debug bounds check.
   _ = bytes[1..<3]
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.set.underflow") {
-  if _isDebugAssertConfiguration() {
-    expectCrashLater()
-  }
   var buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
   defer { buffer.deallocate() }
 
   var bytes = buffer[1..<3]
+
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  // Accesses a valid buffer location but triggers a debug bounds check.
   bytes[-1..<1] = bytes[0..<2]
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.set.overflow") {
-  if _isDebugAssertConfiguration() {
-    expectCrashLater()
-  }
   var buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
   defer { buffer.deallocate() }
 
   var bytes = buffer[0..<2]
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+
+  // Performs a valid byte-wise copy but triggers a debug bounds check.
   bytes[1..<3] = bytes[0..<2]
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.narrow") {
-  if _isDebugAssertConfiguration() {
-    expectCrashLater()
-  }
   var buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
   defer { buffer.deallocate() }
 
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  // Performs a valid byte-wise copy but triggers a debug bounds check.
   buffer[0..<3] = buffer[0..<2]
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.wide") {
-  if _isDebugAssertConfiguration() {
-    expectCrashLater()
-  }
   var buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
   defer { buffer.deallocate() }
 
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  // Performs a valid byte-wise copy but triggers a debug bounds check.
   buffer[0..<2] = buffer[0..<3]
+}
+
+UnsafeRawBufferPointerTestSuite.test("copyBytes.overflow") {
+  var buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
+  defer { buffer.deallocate() }
+
+  var bytes = buffer[0..<2]
+
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  // Performs a valid byte-wise copy but triggers a debug range size check.
+  bytes.copyBytes(from: buffer)
+}
+
+UnsafeRawBufferPointerTestSuite.test("copyBytes.sequence.overflow") {
+  var buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
+  defer { buffer.deallocate() }
+  
+  var bytes = buffer[0..<2]
+
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  // Performs a valid byte-wise copy but triggers a debug range size check.
+  bytes.copyBytes(from: [0, 1, 2] as [UInt8])
 }
 
 UnsafeRawBufferPointerTestSuite.test("load.before")
 .skip(.custom(
     { !_isDebugAssertConfiguration() },
-    reason: "This test behaves unpredictably in optimized mode."))
+    reason: "This tests a debug precondition."))
 .code {
   expectCrashLater()
   var x: Int32 = 0
@@ -287,7 +332,7 @@ UnsafeRawBufferPointerTestSuite.test("load.before")
 UnsafeRawBufferPointerTestSuite.test("load.after")
 .skip(.custom(
     { !_isDebugAssertConfiguration() },
-    reason: "This test behaves unpredictably in optimized mode."))
+    reason: "This tests a debug precondition.."))
 .code {
   expectCrashLater()
   var x: Int32 = 0
@@ -299,7 +344,7 @@ UnsafeRawBufferPointerTestSuite.test("load.after")
 UnsafeRawBufferPointerTestSuite.test("store.before")
 .skip(.custom(
     { !_isDebugAssertConfiguration() },
-    reason: "This test behaves unpredictably in optimized mode."))
+    reason: "This tests a debug precondition.."))
 .code {
   expectCrashLater()
   var x: Int32 = 0
@@ -310,7 +355,7 @@ UnsafeRawBufferPointerTestSuite.test("store.before")
 UnsafeRawBufferPointerTestSuite.test("store.after")
 .skip(.custom(
     { !_isDebugAssertConfiguration() },
-    reason: "This test behaves unpredictably in optimized mode."))
+    reason: "This tests a debug precondition.."))
 .code {
   expectCrashLater()
   var x: Int32 = 0
@@ -322,7 +367,7 @@ UnsafeRawBufferPointerTestSuite.test("store.after")
 UnsafeRawBufferPointerTestSuite.test("copy.bytes.overflow")
 .skip(.custom(
     { !_isDebugAssertConfiguration() },
-    reason: "This test behaves unpredictably in optimized mode."))
+    reason: "This tests a debug precondition.."))
 .code {
   expectCrashLater()
   var x: Int64 = 0
@@ -338,7 +383,7 @@ UnsafeRawBufferPointerTestSuite.test("copy.bytes.overflow")
 UnsafeRawBufferPointerTestSuite.test("copy.sequence.overflow")
 .skip(.custom(
     { !_isDebugAssertConfiguration() },
-    reason: "This test behaves unpredictably in optimized mode."))
+    reason: "This tests a debug precondition.."))
 .code {
   expectCrashLater()
   var x: Int64 = 0

--- a/validation-test/stdlib/Arrays.swift.gyb
+++ b/validation-test/stdlib/Arrays.swift.gyb
@@ -501,6 +501,21 @@ ArrayTestSuite.test("${array_type}/_withUnsafeMutableBufferPointerIfSupported/Re
   }
 }
 
+//===----------------------------------------------------------------------===//
+// withUnsafeMutableBytes
+//===----------------------------------------------------------------------===//
+
+// Test the uniqueness of the raw buffer.
+ArrayTestSuite.test("${array_type}/withUnsafeMutableBytes") {
+  var a = getFresh${array_type}([UInt8](repeating: 10, count: 1))
+  let b = a
+  a.withUnsafeMutableBytes { bytes in
+    bytes[0] = 42
+  }
+  expectEqual(42, a[0])
+  expectEqual(10, b[0])
+}
+
 //===---
 // Check that iterators traverse a snapshot of the collection.
 //===---

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -35,7 +35,7 @@ extension SubscriptTest {
   /// Create and populate an `${SelfType}` for use with unit tests.
   /// PRECONDITION: `memory` must be allocated with space for
   /// `SubscriptGetTest.elementCount` bytes. 
-  func create${SelfType}(from memory: UnsafeMutableRawPointer) 
+  static func create${SelfType}(from memory: UnsafeMutableRawPointer) 
     -> ${SelfType}
   {
     for i in Self.start..<Self.end {
@@ -49,7 +49,7 @@ extension SubscriptTest {
   /// Create and populate an `${SelfType}` for use with unit tests.
   /// PRECONDITION: `memory` must be allocated with space for
   /// `SubscriptGetTest.elementCount` elements. 
-  func create${SelfType}(from memory: UnsafeMutablePointer<OpaqueValue<Int>>) 
+  static func create${SelfType}(from memory: UnsafeMutablePointer<OpaqueValue<Int>>) 
     -> ${SelfType}<OpaqueValue<Int>> 
   {
     for i in Self.start..<Self.end {
@@ -464,6 +464,30 @@ ${SelfName}TestSuite.test("badNilCount")
   _ = buffer
 }
 
+${SelfName}TestSuite.test("RandomAccessCollection") {
+  let elementCount = SubscriptGetTest.elementCount
+  var memory = SubscriptGetTest.allocateFor${'Raw' if IsRaw else ''}Buffer(
+    count: elementCount)
+  defer { SubscriptGetTest.deallocateFor${'Raw' if IsRaw else ''}Buffer(
+      memory, count: elementCount) }
+  var memoryCopy = SubscriptGetTest.allocateFor${'Raw' if IsRaw else ''}Buffer(
+    count: elementCount)
+  defer { SubscriptGetTest.deallocateFor${'Raw' if IsRaw else ''}Buffer(
+      memoryCopy, count: elementCount) }
+
+  var buffer = SubscriptGetTest.create${SelfName}(from: memory)
+  var expected = UnsafeMutable${'Raw' if IsRaw else ''}BufferPointer(
+    start: memoryCopy, count: buffer.count)
+
+%   if IsRaw:
+  expected.copyBytes(from: buffer)
+  checkRandomAccessCollection(expected, buffer) { $0 == $1 }
+%   else:
+  expected.baseAddress!.initialize(from: buffer)
+  checkRandomAccessCollection(expected, buffer) { $0.value == $1.value }
+%   end
+}
+
 %   for RangeName in ['range', 'countableRange', 'closedRange', 'countableClosedRange']:
 ${SelfName}TestSuite.test("subscript/${RangeName}/get").forEach(in: subscriptGetTests) { 
   (test) in
@@ -491,7 +515,7 @@ ${SelfName}TestSuite.test("subscript/${RangeName}/get").forEach(in: subscriptGet
   defer { SubscriptGetTest.deallocateFor${'Raw' if IsRaw else ''}Buffer(
       memory, count: elementCount) }
 
-  let buffer = test.create${SelfName}(from: memory)
+  let buffer = SubscriptGetTest.create${SelfName}(from: memory)
 
 %     if IsRaw:
   // A raw buffer pointer has debug bounds checks on indices.
@@ -559,7 +583,7 @@ UnsafeMutable${'Raw' if IsRaw else ''}BufferPointerTestSuite.test("subscript/${R
   defer { SubscriptSetTest.deallocateFor${'Raw' if IsRaw else ''}Buffer(
       sliceMemory, count: replacementValues.count) }
 
-  var buffer = test.create${SelfName}(from: memory)
+  var buffer = SubscriptSetTest.create${SelfName}(from: memory)
 
 %     if IsRaw:
   // A raw buffer pointer has debug bounds checks on indices.

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -6,20 +6,44 @@ import StdlibCollectionUnittest
 
 // Tests
 
-struct SubscriptGetTest {
-  // SubscriptGetTest operates on a `(end - start)` sized buffer containing
-  // monotonically increasing integers from `start` to `end - 1`.
-  static let start = 0
-  static let end = 20
-  let rangeSelection: RangeSelection
-  /// The values that should be expected by slicing the UBP, or `nil` if the
-  /// test is expected to crash.
-  let expectedValues: [Int]?
-  /// Same as `expectedValues`, but for closed ranges. `nil` if no difference.
-  let expectedClosedValues: [Int]?
-  let loc: SourceLoc
+protocol SubscriptTest {
+  static var start: Int { get }
+  static var end: Int { get }
+  static var elementCount: Int { get }
+}
 
-  static var elementCount = (end - start)
+extension SubscriptTest {
+  static var elementCount: Int { get { return end - start } }
+
+  static func allocateForRawBuffer(count: Int) -> UnsafeMutableRawPointer {
+    return UnsafeMutableRawPointer.allocate(bytes: count, alignedTo: 1)
+  }
+  static func allocateForBuffer(count: Int
+  ) -> UnsafeMutablePointer<OpaqueValue<Int>> {
+    return UnsafeMutablePointer<OpaqueValue<Int>>.allocate(capacity: count)
+  }
+  static func deallocateForRawBuffer(
+    _ memory: UnsafeMutableRawPointer, count: Int) {
+    memory.deallocate(bytes: count, alignedTo: 1)
+  }
+  static func deallocateForBuffer(
+    _ memory: UnsafeMutablePointer<OpaqueValue<Int>>, count: Int) {
+    memory.deallocate(capacity: count)
+  }
+
+% for SelfType in ['UnsafeRawBufferPointer', 'UnsafeMutableRawBufferPointer']:
+  /// Create and populate an `${SelfType}` for use with unit tests.
+  /// PRECONDITION: `memory` must be allocated with space for
+  /// `SubscriptGetTest.elementCount` bytes. 
+  func create${SelfType}(from memory: UnsafeMutableRawPointer) 
+    -> ${SelfType}
+  {
+    for i in Self.start..<Self.end {
+      memory.initializeMemory(as: UInt8.self, at: i, to: numericCast(i))
+    }
+    return ${SelfType}(start: memory, count: Self.elementCount)
+  }
+% end
 
 % for SelfType in ['UnsafeBufferPointer', 'UnsafeMutableBufferPointer']:
   /// Create and populate an `${SelfType}` for use with unit tests.
@@ -28,12 +52,29 @@ struct SubscriptGetTest {
   func create${SelfType}(from memory: UnsafeMutablePointer<OpaqueValue<Int>>) 
     -> ${SelfType}<OpaqueValue<Int>> 
   {
-    for i in SubscriptGetTest.start..<SubscriptGetTest.end {
+    for i in Self.start..<Self.end {
       memory[i] = OpaqueValue(i)  
     }
-    return ${SelfType}(start: memory, count: SubscriptGetTest.elementCount)
+    return ${SelfType}(start: memory, count: Self.elementCount)
   }
 % end
+}
+
+struct SubscriptGetTest : SubscriptTest {
+  // SubscriptGetTest operates on a `(end - start)` sized buffer containing
+  // monotonically increasing integers from `start` to `end - 1`.
+  static var start = 0
+  static var end = 20
+
+  let rangeSelection: RangeSelection
+  /// The values that should be expected by slicing the UBP, or `nil` if the
+  /// test is expected to crash.
+  let expectedValues: [Int]?
+  /// Same as `expectedValues`, but for closed ranges. `nil` if no difference,
+  /// and empty if the test is expected to crash.
+  let expectedClosedValues: [Int]?
+
+  let loc: SourceLoc
 
   init(
     rangeSelection: RangeSelection, expectedValues: [Int]? = nil,
@@ -81,8 +122,12 @@ let subscriptGetTests : [SubscriptGetTest] = [
   SubscriptGetTest(rangeSelection: .offsets(-100, 5)),
 
   // Invalid, top out of bounds.
-  SubscriptGetTest(rangeSelection: .offsets(20, 20)),
-  SubscriptGetTest(rangeSelection: .offsets(19, 20)),
+  SubscriptGetTest(rangeSelection: .offsets(20, 20),
+    expectedValues: []), // Only crash on a closed range.
+  SubscriptGetTest(rangeSelection: .offsets(19, 20),
+    expectedValues: [19],
+    expectedClosedValues: []), // Only crash on a closed range
+  SubscriptGetTest(rangeSelection: .offsets(21, 21)),
   SubscriptGetTest(rangeSelection: .offsets(5, 100)),
 
   // Invalid, both out of bounds.
@@ -90,43 +135,66 @@ let subscriptGetTests : [SubscriptGetTest] = [
   SubscriptGetTest(rangeSelection: .offsets(-100, 100)),
 ]
 
-struct SubscriptSetTest {
+struct SubscriptSetTest : SubscriptTest {
   // SubscriptSetTest operates on a `(end - start)` sized buffer containing
   // monotonically increasing integers from `start` to `end - 1`.
-  static let start = 0
-  static let end = 10
+  static var start = 0
+  static var end = 10
 
   let rangeSelection: RangeSelection
 
   let replacementValues: [OpaqueValue<Int>]
-  let replacementValuesClosed: [OpaqueValue<Int>]
+  let replacementClosedValues: [OpaqueValue<Int>]
 
   /// The values that should be expected by slicing the UBP, or `nil` if the
   /// test is expected to crash.
   let expectedValues: [Int]?
-  let expectedValuesClosed: [Int]?
+  /// Same as `expectedValues`, but for closed ranges. `nil` if no difference.
+  let expectedClosedValues: [Int]?
 
   let loc: SourceLoc
 
-  static var elementCount = (end - start)
+  init(
+    rangeSelection: RangeSelection, 
+    replacementValues: [Int],
+    replacementClosedValues: [Int]? = nil,
+    expectedValues: [Int]? = nil,
+    expectedClosedValues: [Int]? = nil,
+    file: String = #file, line: UInt = #line
+  ) {
+    self.rangeSelection = rangeSelection
+    self.expectedValues = expectedValues
+    self.expectedClosedValues = expectedClosedValues ?? expectedValues
 
-  /// Create and populate an `UnsafeMutableBufferPointer` for use with unit
-  /// tests.
-  /// PRECONDITION: `memory` must be allocated with space for
-  /// `SubscriptSetTest.elementCount` elements. 
-  func createUnsafeMutableBufferPointer(
-    from memory: UnsafeMutablePointer<OpaqueValue<Int>>
-  ) -> UnsafeMutableBufferPointer<OpaqueValue<Int>> 
-  {
-    for i in SubscriptSetTest.start..<SubscriptSetTest.end {
-      memory[i] = OpaqueValue(i)  
+    self.replacementValues = replacementValues.map { OpaqueValue($0) }
+    if let replacements = replacementClosedValues {
+      self.replacementClosedValues = replacements.map { OpaqueValue($0) }
+    } else {
+      self.replacementClosedValues = self.replacementValues
     }
-    return UnsafeMutableBufferPointer(
-      start: memory, 
-      count: SubscriptSetTest.elementCount)
+    self.loc = SourceLoc(file, line, comment: "test data")
   }
 
-  /// Create and populate a mutable buffer pointer slice for use with unit
+  /// Create and populate an UnsafeMutableRawBufferPointer slice for use with
+  /// unit tests.
+  /// PRECONDITION: `memory` must be allocated with space for
+  /// `replacementValues.count` bytes.
+  func replacementValuesSlice(
+    from memory: UnsafeMutableRawPointer,
+    replacementValues: [OpaqueValue<Int>]
+  ) -> UnsafeMutableRawBufferPointer
+  {
+    for (i, value) in replacementValues.enumerated() {
+      memory.initializeMemory(
+        as: UInt8.self, at: i, to: numericCast(value.value))
+    }
+    let buffer = UnsafeMutableRawBufferPointer(
+      start: memory, count: replacementValues.count)
+    let fullRange = RangeSelection.full.range(in: buffer)
+    return buffer[fullRange]
+  }
+
+  /// Create and populate an UnsafeMutableBufferPointer slice for use with unit
   /// tests.
   /// PRECONDITION: `memory` must be allocated with space for
   /// `replacementValues.count` elements.
@@ -139,30 +207,9 @@ struct SubscriptSetTest {
       memory[i] = value
     }
     let buffer = UnsafeMutableBufferPointer(
-      start: memory, 
-      count: replacementValues.count)
+      start: memory, count: replacementValues.count)
     let fullRange = RangeSelection.full.range(in: buffer)
     return buffer[fullRange]
-  }
-
-  init(
-    rangeSelection: RangeSelection, 
-    replacementValues: [Int],
-    replacementValuesClosed: [Int]? = nil,
-    expectedValues: [Int]? = nil,
-    expectedValuesClosed: [Int]? = nil,
-    file: String = #file, line: UInt = #line
-  ) {
-    self.rangeSelection = rangeSelection
-    self.replacementValues = replacementValues.map { OpaqueValue($0) }
-    if let replacements = replacementValuesClosed {
-      self.replacementValuesClosed = replacements.map { OpaqueValue($0) }
-    } else {
-      self.replacementValuesClosed = self.replacementValues
-    }
-    self.expectedValues = expectedValues
-    self.expectedValuesClosed = expectedValuesClosed ?? expectedValues
-    self.loc = SourceLoc(file, line, comment: "test data")
   }
 }
 
@@ -177,15 +224,15 @@ let subscriptSetTests : [SubscriptSetTest] = [
   SubscriptSetTest(
     rangeSelection: .leftEdge,
     replacementValues: [],
-    replacementValuesClosed: [9001],
+    replacementClosedValues: [91],
     expectedValues: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-    expectedValuesClosed: [9001, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+    expectedClosedValues: [91, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
   SubscriptSetTest(
     rangeSelection: .rightEdge,
     replacementValues: [],
-    replacementValuesClosed: [9001],
+    replacementClosedValues: [91],
     expectedValues: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-    expectedValuesClosed: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9001]),
+    expectedClosedValues: [0, 1, 2, 3, 4, 5, 6, 7, 8, 91]),
 
   // Valid, internal.
   SubscriptSetTest(
@@ -208,28 +255,24 @@ let subscriptSetTests : [SubscriptSetTest] = [
   // Invalid, range and replacement count mismatch.
   SubscriptSetTest(
     rangeSelection: .leftEdge,
-    replacementValues: [],
-    replacementValuesClosed: [9]),
-  SubscriptSetTest(
-    rangeSelection: .leftEdge,
     replacementValues: [9, 9],
-    replacementValuesClosed: [9, 9, 9]),
+    replacementClosedValues: [9, 9, 9]),
   SubscriptSetTest(
     rangeSelection: .offsets(1, 2),
     replacementValues: [],
-    replacementValuesClosed: [9]),
+    replacementClosedValues: [9]),
   SubscriptSetTest(
     rangeSelection: .offsets(1, 2),
     replacementValues: [9, 9],
-    replacementValuesClosed: [9, 9, 9]),
+    replacementClosedValues: [9, 9, 9]),
   SubscriptSetTest(
     rangeSelection: .offsets(2, 5),
     replacementValues: [9, 9],
-    replacementValuesClosed: [9, 9, 9]),
+    replacementClosedValues: [9, 9, 9]),
   SubscriptSetTest(
     rangeSelection: .offsets(2, 5),
     replacementValues: [9, 9, 9, 9],
-    replacementValuesClosed: [9, 9, 9, 9, 9]),
+    replacementClosedValues: [9, 9, 9, 9, 9]),
 
   // Invalid, bottom out of bounds.
   SubscriptSetTest(
@@ -245,10 +288,17 @@ let subscriptSetTests : [SubscriptSetTest] = [
   // Invalid, top out of bounds.
   SubscriptSetTest(
     rangeSelection: .offsets(10, 10),
-    replacementValues: []),
+    replacementValues: [],
+    expectedValues: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+    expectedClosedValues: []), // Only crash on a closed range.
   SubscriptSetTest(
     rangeSelection: .offsets(9, 10),
-    replacementValues: [9]),
+    replacementValues: [91],
+    expectedValues: [0, 1, 2, 3, 4, 5, 6, 7, 8, 91],
+    expectedClosedValues: []), // Only crash on a closed range.
+  SubscriptSetTest(
+    rangeSelection: .offsets(11, 11),
+    replacementValues: []),
   SubscriptSetTest(
     rangeSelection: .offsets(8, 15),
     replacementValues: [9, 9, 9, 9, 9, 9, 9]),
@@ -267,12 +317,29 @@ let subscriptSetTests : [SubscriptSetTest] = [
 
 var UnsafeBufferPointerTestSuite = TestSuite("UnsafeBufferPointer")
 var UnsafeMutableBufferPointerTestSuite = TestSuite("UnsafeMutableBufferPointer")
+var UnsafeRawBufferPointerTestSuite = TestSuite("UnsafeRawBufferPointer")
+var UnsafeMutableRawBufferPointerTestSuite = TestSuite("UnsafeMutableRawBufferPointer")
 
-% for (SelfName, IsMutable, SelfType, PointerType) in [
-%   ('UnsafeBufferPointer', False, 'UnsafeBufferPointer<Float>', 'UnsafePointer<Float>'),
-%   ('UnsafeMutableBufferPointer', True, 'UnsafeMutableBufferPointer<Float>', 'UnsafeMutablePointer<Float>')
+% for (SelfName, IsMutable, IsRaw, SelfType, PointerType) in [
+%   ('UnsafeBufferPointer', False, False, 'UnsafeBufferPointer<Float>', 'UnsafePointer<Float>'),
+%   ('UnsafeMutableBufferPointer', True, False, 'UnsafeMutableBufferPointer<Float>', 'UnsafeMutablePointer<Float>'),
+%   ('UnsafeRawBufferPointer', False, True, 'UnsafeRawBufferPointer', 'UnsafeRawPointer'),
+%   ('UnsafeMutableRawBufferPointer', True, True, 'UnsafeMutableRawBufferPointer', 'UnsafeMutableRawPointer')
 % ]:
 
+%   if IsRaw:
+${SelfName}TestSuite.test("AssociatedTypes") {
+  expectRandomAccessCollectionAssociatedTypes(
+    collectionType: ${SelfType}.self,
+    iteratorType: ${SelfType}.Iterator.self,
+    subSequenceType: ${SelfType}.self,
+    indexType: Int.self,
+    indexDistanceType: Int.self,
+    indicesType: CountableRange<Int>.self)
+
+  expect${'Mutable' if IsMutable else ''}CollectionType(${SelfType}.self)
+}
+%   else: # !IsRaw
 ${SelfName}TestSuite.test("AssociatedTypes") {
   typealias Subject = ${SelfName}<OpaqueValue<Int>>
   expectRandomAccessCollectionAssociatedTypes(
@@ -285,6 +352,7 @@ ${SelfName}TestSuite.test("AssociatedTypes") {
 
   expect${'Mutable' if IsMutable else ''}CollectionType(Subject.self)
 }
+%   end # !IsRaw
 
 ${SelfName}TestSuite.test("nilBaseAddress") {
   let emptyBuffer = ${SelfType}(start: nil, count: 0)
@@ -313,6 +381,35 @@ ${SelfName}TestSuite.test("nonNilButEmpty") {
   expectEqualSequence([], emptyBuffer)
 }
 
+%   if IsRaw:
+${SelfName}TestSuite.test("nonNilNonEmpty") {
+  let count = 4
+  let allocated = UnsafeMutableRawPointer.allocate(bytes: count, alignedTo: 1)
+  defer { allocated.deallocate(bytes: count, alignedTo: 1) }
+  let uint8Ptr = allocated.initializeMemory(as: UInt8.self, count: count, to: 1)
+  uint8Ptr[count - 1] = 2
+
+  let buffer = ${SelfType}(start: ${PointerType}(allocated), count: count - 1)
+  expectEqual(allocated, buffer.baseAddress)
+  expectEqual(count - 1, buffer.count)
+  expectEqual(count - 1, buffer.endIndex - buffer.startIndex)
+
+  uint8Ptr[1] = 0
+  expectEqual(1, buffer[0])
+  expectEqual(0, buffer[1])
+  expectEqual(1, buffer[2])
+
+  var iter = buffer.makeIterator()
+  expectEqual(1, iter.next())
+  expectEqual(0, iter.next())
+  expectEqual(1, iter.next())
+  expectNil(iter.next())
+
+  expectEqualSequence([1, 0, 1], buffer.map { Int($0) })
+
+  expectEqual(2, uint8Ptr[count-1])
+}
+%   else: # !IsRaw
 ${SelfName}TestSuite.test("nonNilNonEmpty") {
   let count = 4
   let allocated = UnsafeMutablePointer<Float>.allocate(capacity: count)
@@ -340,6 +437,7 @@ ${SelfName}TestSuite.test("nonNilNonEmpty") {
 
   expectEqual(2.0, allocated[count-1])
 }
+%   end # !IsRaw
 
 ${SelfName}TestSuite.test("badCount")
   .skip(.custom(
@@ -371,37 +469,64 @@ ${SelfName}TestSuite.test("subscript/${RangeName}/get").forEach(in: subscriptGet
   (test) in
 
   let expectedValues: [Int]?
-%      if 'closed' in RangeName.lower():
+%     if 'closed' in RangeName.lower():
   if test.rangeSelection.isEmpty {
     return
   }
-  expectedValues = test.expectedClosedValues
-%      else:
+  // Treat an empty set as nil for closed ranges.
+  if test.expectedClosedValues?.isEmpty ?? true {
+    expectedValues = nil
+  }
+  else {
+    expectedValues = test.expectedClosedValues
+  }
+%     else:
   expectedValues = test.expectedValues
-%      end
+%     end
 
   let elementCount = SubscriptGetTest.elementCount
 
-  var memory = UnsafeMutablePointer<OpaqueValue<Int>>.allocate(capacity: elementCount)
-  let buffer = test.create${SelfName}(from: memory)
-  defer { memory.deallocate(capacity: elementCount) }
+  var memory = SubscriptGetTest.allocateFor${'Raw' if IsRaw else ''}Buffer(
+    count: elementCount)
+  defer { SubscriptGetTest.deallocateFor${'Raw' if IsRaw else ''}Buffer(
+      memory, count: elementCount) }
 
+  let buffer = test.create${SelfName}(from: memory)
+
+%     if IsRaw:
+  // A raw buffer pointer has debug bounds checks on indices.
+  if _isDebugAssertConfiguration() {
+    if expectedValues == nil { expectCrashLater() }
+  }
+%     end
   let range = test.rangeSelection.${RangeName}(in: buffer)
 
   if expectedValues == nil { expectCrashLater() }
   let slice = buffer[range]
-  expectEqual(
-    expectedValues!,
-    slice.map { $0.value },
-    stackTrace: SourceLocStack().with(test.loc)
-  )
+  // If expectedValues is nil, we should have crashed above. Allowing the
+  // following code to crash leads to false positives.
+  if let expectedValues = expectedValues {
+    expectEqual(
+      expectedValues,
+%     if IsRaw:
+      slice.map { Int($0) },
+% else:
+      slice.map { $0.value },
+%     end
+      stackTrace: SourceLocStack().with(test.loc)
+    )
+  }
 }
 %    end
 
 % end
 
+% for (SelfName, IsRaw) in [
+%   ('UnsafeMutableBufferPointer', False),
+%   ('UnsafeMutableRawBufferPointer', True)
+% ]:
 %   for RangeName in ['range', 'countableRange', 'closedRange', 'countableClosedRange']:
-UnsafeMutableBufferPointerTestSuite.test("subscript/${RangeName}/set")
+UnsafeMutable${'Raw' if IsRaw else ''}BufferPointerTestSuite.test("subscript/${RangeName}/set")
   .forEach(in: subscriptSetTests) { (test) in
 
   let expectedValues: [Int]?
@@ -410,8 +535,14 @@ UnsafeMutableBufferPointerTestSuite.test("subscript/${RangeName}/set")
   if test.rangeSelection.isEmpty {
     return
   }
-  expectedValues = test.expectedValuesClosed
-  replacementValues = test.replacementValuesClosed
+  // Treat an empty set as nil for closed ranges.
+  if test.expectedClosedValues?.isEmpty ?? true {
+    expectedValues = nil
+  }
+  else {
+    expectedValues = test.expectedClosedValues
+  }
+  replacementValues = test.replacementClosedValues
 %      else:
   expectedValues = test.expectedValues
   replacementValues = test.replacementValues
@@ -419,30 +550,77 @@ UnsafeMutableBufferPointerTestSuite.test("subscript/${RangeName}/set")
 
   let elementCount = SubscriptSetTest.elementCount
 
-  var memory = UnsafeMutablePointer<OpaqueValue<Int>>.allocate(
-    capacity: elementCount)
-  var sliceMemory = UnsafeMutablePointer<OpaqueValue<Int>>.allocate(
-    capacity: replacementValues.count)
-  var buffer = test.createUnsafeMutableBufferPointer(from: memory)
-  defer { 
-    memory.deallocate(capacity: elementCount) 
-    sliceMemory.deallocate(capacity: replacementValues.count)
-  }
+  var memory = SubscriptSetTest.allocateFor${'Raw' if IsRaw else ''}Buffer(
+    count: elementCount)
+  defer { SubscriptSetTest.deallocateFor${'Raw' if IsRaw else ''}Buffer(
+      memory, count: elementCount) }
+  var sliceMemory = SubscriptSetTest.allocateFor${'Raw' if IsRaw else ''}Buffer(
+    count: replacementValues.count)
+  defer { SubscriptSetTest.deallocateFor${'Raw' if IsRaw else ''}Buffer(
+      sliceMemory, count: replacementValues.count) }
 
+  var buffer = test.create${SelfName}(from: memory)
+
+%     if IsRaw:
+  // A raw buffer pointer has debug bounds checks on indices.
+  if _isDebugAssertConfiguration() {
+    if expectedValues == nil { expectCrashLater() }
+  }
+%     end
   let range = test.rangeSelection.${RangeName}(in: buffer)
+
   let replacementSlice = test.replacementValuesSlice(
     from: sliceMemory,
     replacementValues: replacementValues)
 
   if expectedValues == nil { expectCrashLater() }
   buffer[range] = replacementSlice
-  expectEqual(
-    expectedValues!,
-    buffer.map { $0.value },
-    stackTrace: SourceLocStack().with(test.loc)
-  )
+  // If expectedValues is nil, we should have crashed above. Allowing the
+  // following code to crash leads to false positives.
+  if let expectedValues = expectedValues {
+    expectEqual(
+      expectedValues,
+%     if IsRaw:
+      buffer.map { Int($0) },
+% else:
+      buffer.map { $0.value },
+%     end
+      stackTrace: SourceLocStack().with(test.loc)
+    )
+  }
 }
-% end
+%   end # RangeName
+% end # SelfName
+
+UnsafeMutableRawBufferPointerTestSuite.test("changeElementViaBuffer") {
+  let count = 4
+  let allocated = UnsafeMutableRawPointer.allocate(bytes: count, alignedTo: 1)
+  defer { allocated.deallocate(bytes: count, alignedTo: 1) }
+  let uint8Ptr = allocated.initializeMemory(as: UInt8.self, count: count, to: 1)
+  uint8Ptr[count-1] = UInt8.max
+
+  var buffer = UnsafeMutableRawBufferPointer(start: allocated, count: count - 1)
+
+  buffer[1] = 0
+  expectEqual(1, buffer[0])
+  expectEqual(0, buffer[1])
+  expectEqual(1, buffer[2])
+
+  expectEqual(1, uint8Ptr[0])
+  expectEqual(0, uint8Ptr[1])
+  expectEqual(1, uint8Ptr[2])
+  expectEqual(UInt8.max, uint8Ptr[count-1])
+
+  buffer.sort()
+  expectEqual(0, buffer[0])
+  expectEqual(1, buffer[1])
+  expectEqual(1, buffer[2])
+
+  expectEqual(0, uint8Ptr[0])
+  expectEqual(1, uint8Ptr[1])
+  expectEqual(1, uint8Ptr[2])
+  expectEqual(UInt8.max, uint8Ptr[count-1])
+}
 
 UnsafeMutableBufferPointerTestSuite.test("changeElementViaBuffer") {
   let count = 4

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -403,7 +403,7 @@ ${SelfName}TestSuite.test("nonNilNonEmpty") {
   expectEqual(1, iter.next())
   expectEqual(0, iter.next())
   expectEqual(1, iter.next())
-  expectNil(iter.next())
+  expectEqual(iter.next(), nil)
 
   expectEqualSequence([1, 0, 1], buffer.map { Int($0) })
 

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -518,14 +518,15 @@ ${SelfName}TestSuite.test("subscript/${RangeName}/get").forEach(in: subscriptGet
   let buffer = SubscriptGetTest.create${SelfName}(from: memory)
 
 %     if IsRaw:
-  // A raw buffer pointer has debug bounds checks on indices.
-  if _isDebugAssertConfiguration() {
-    if expectedValues == nil { expectCrashLater() }
-  }
+  // A raw buffer pointer has debug bounds checks on indices, and
+  // (currently) invokes Collection._failEarlyRangeCheck in nondebug mode.
+  if expectedValues == nil { expectCrashLater() }
 %     end
   let range = test.rangeSelection.${RangeName}(in: buffer)
 
-  if expectedValues == nil { expectCrashLater() }
+  if _isDebugAssertConfiguration() {
+    if expectedValues == nil { expectCrashLater() }
+  }
   let slice = buffer[range]
   // If expectedValues is nil, we should have crashed above. Allowing the
   // following code to crash leads to false positives.
@@ -551,10 +552,19 @@ ${SelfName}TestSuite.test("subscript/${RangeName}/get").forEach(in: subscriptGet
 % ]:
 %   for RangeName in ['range', 'countableRange', 'closedRange', 'countableClosedRange']:
 UnsafeMutable${'Raw' if IsRaw else ''}BufferPointerTestSuite.test("subscript/${RangeName}/set")
-  .forEach(in: subscriptSetTests) { (test) in
+%     if not IsRaw:
+  // UnsafeRawBuffer (currently) invokes Collection._failEarlyRangeCheck
+  // in nondebug mode.
+  .skip(.custom(
+    { !_isDebugAssertConfiguration() },
+    reason: "This tests a debug precondition."))
+%     end
+.forEach(in: subscriptSetTests) { (test) in
 
   let expectedValues: [Int]?
   let replacementValues: [OpaqueValue<Int>]
+  let elementCount = SubscriptSetTest.elementCount
+
 %      if 'closed' in RangeName.lower():
   if test.rangeSelection.isEmpty {
     return
@@ -567,12 +577,26 @@ UnsafeMutable${'Raw' if IsRaw else ''}BufferPointerTestSuite.test("subscript/${R
     expectedValues = test.expectedClosedValues
   }
   replacementValues = test.replacementClosedValues
+  let isOutOfBounds: () -> Bool = {
+    switch test.rangeSelection {
+    case let .offsets(lowerBound, upperBound):
+      return lowerBound < 0 || upperBound >= elementCount
+    default:
+      return false
+    }
+  }
 %      else:
   expectedValues = test.expectedValues
   replacementValues = test.replacementValues
+  let isOutOfBounds: () -> Bool = {
+    switch test.rangeSelection {
+    case let .offsets(lowerBound, upperBound):
+      return lowerBound < 0 || upperBound > elementCount
+    default:
+      return false
+    }
+  }
 %      end
-
-  let elementCount = SubscriptSetTest.elementCount
 
   var memory = SubscriptSetTest.allocateFor${'Raw' if IsRaw else ''}Buffer(
     count: elementCount)
@@ -586,8 +610,9 @@ UnsafeMutable${'Raw' if IsRaw else ''}BufferPointerTestSuite.test("subscript/${R
   var buffer = SubscriptSetTest.create${SelfName}(from: memory)
 
 %     if IsRaw:
-  // A raw buffer pointer has debug bounds checks on indices.
-  if _isDebugAssertConfiguration() {
+  // A raw buffer pointer has debug bounds checks on indices, and
+  // (currently) invokes Collection._failEarlyRangeCheck in nondebug mode.
+  if _isDebugAssertConfiguration() || isOutOfBounds() {
     if expectedValues == nil { expectCrashLater() }
   }
 %     end
@@ -597,7 +622,9 @@ UnsafeMutable${'Raw' if IsRaw else ''}BufferPointerTestSuite.test("subscript/${R
     from: sliceMemory,
     replacementValues: replacementValues)
 
-  if expectedValues == nil { expectCrashLater() }
+  if _isDebugAssertConfiguration() {
+    if expectedValues == nil { expectCrashLater() }
+  }
   buffer[range] = replacementSlice
   // If expectedValues is nil, we should have crashed above. Allowing the
   // following code to crash leads to false positives.


### PR DESCRIPTION
…. (#4954)

https://github.com/apple/swift-evolution/blob/master/proposals/0138-unsaferawbufferpointer.md

Unsafe[Mutable]RawBufferPointer is a non-owning view over a region of memory as
a Collection of bytes independent of the type of values held in that
memory. Each 8-bit byte in memory is viewed as a `UInt8` value.

Reads and writes on memory via `Unsafe[Mutable]RawBufferPointer` are untyped
operations. Accessing this Collection's bytes does not bind the
underlying memory to `UInt8`. The underlying memory must be bound
to some trivial type whenever it is accessed via a typed operation.

In addition to the `Collection` interface, the following methods from
`Unsafe[Mutable]RawPointer`'s interface to raw memory are
provided with debug mode bounds checks: `load(fromByteOffset:as:)`,
`storeBytes(of:toByteOffset:as:)`, and `copyBytes(from:count:)`.

This is only a view into memory and does not own the memory. Copying a value of
type `UnsafeMutableRawBufferPointer` does not copy the underlying
memory. Assigning an `Unsafe[Mutable]RawBufferPointer` into a value-based
collection, such as `[UInt8]` copies bytes out of memory. Assigning into a
subscript range of UnsafeMutableRawBufferPointer copies into memory.
