### PR TITLE
Add "IgnoreAccessControl" to UnqualifiedLookup, and use it for diagnostics

### DIFF
--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -68,7 +68,8 @@ public:
                     bool IsKnownPrivate = false,
                     SourceLoc Loc = SourceLoc(),
                     bool IsTypeLookup = false,
-                    bool AllowProtocolMembers = false);
+                    bool AllowProtocolMembers = false,
+                    bool IgnoreAccessControl = false);
 
   SmallVector<UnqualifiedLookupResult, 4> Results;
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -399,7 +399,8 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
                                      LazyResolver *TypeResolver,
                                      bool IsKnownNonCascading,
                                      SourceLoc Loc, bool IsTypeLookup,
-                                     bool AllowProtocolMembers) {
+                                     bool AllowProtocolMembers,
+                                     bool IgnoreAccessControl) {
   Module &M = *DC->getParentModule();
   ASTContext &Ctx = M.getASTContext();
   const SourceManager &SM = Ctx.SourceMgr;
@@ -563,6 +564,8 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
           options |= NL_ProtocolMembers;
         if (IsTypeLookup)
           options |= NL_OnlyTypes;
+        if (IgnoreAccessControl)
+          options |= NL_IgnoreAccessibility;
 
         if (!ExtendedType)
           ExtendedType = ErrorType::get(Ctx);

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -199,11 +199,13 @@ LookupResult TypeChecker::lookupUnqualified(DeclContext *dc, DeclName name,
     }
   }
 
-  UnqualifiedLookup lookup(name, dc, this,
-                           options.contains(NameLookupFlags::KnownPrivate),
-                           loc,
-                           options.contains(NameLookupFlags::OnlyTypes),
-                           options.contains(NameLookupFlags::ProtocolMembers));
+  UnqualifiedLookup lookup(
+      name, dc, this,
+      options.contains(NameLookupFlags::KnownPrivate),
+      loc,
+      options.contains(NameLookupFlags::OnlyTypes),
+      options.contains(NameLookupFlags::ProtocolMembers),
+      options.contains(NameLookupFlags::IgnoreAccessibility));
 
   LookupResult result;
   bool considerProtocolMembers

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -745,7 +745,35 @@ static Type diagnoseUnknownType(TypeChecker &tc, DeclContext *dc,
       comp->setValue(nominal);
       return type;
     }
-    
+
+
+    // Try ignoring access control.
+    DeclContext *lookupDC = dc;
+    if (options.contains(TR_GenericSignature))
+      lookupDC = dc->getParent();
+
+    NameLookupOptions relookupOptions = lookupOptions;
+    relookupOptions |= NameLookupFlags::KnownPrivate;
+    relookupOptions |= NameLookupFlags::IgnoreAccessibility;
+    LookupResult inaccessibleResults =
+        tc.lookupUnqualified(lookupDC, comp->getIdentifier(), comp->getIdLoc(),
+                             relookupOptions);
+    if (inaccessibleResults) {
+      // FIXME: What if the unviable candidates have different levels of access?
+      auto first = cast<TypeDecl>(inaccessibleResults.front().Decl);
+      tc.diagnose(comp->getIdLoc(), diag::candidate_inaccessible,
+                  comp->getIdentifier(), first->getFormalAccess());
+
+      // FIXME: If any of the candidates (usually just one) are in the same
+      // module we could offer a fix-it.
+      for (auto lookupResult : inaccessibleResults)
+        tc.diagnose(lookupResult.Decl, diag::type_declared_here);
+
+      // Don't try to recover here; we'll get more access-related diagnostics
+      // downstream if we do.
+      return ErrorType::get(tc.Context);
+    }
+
     // Fallback.
     SourceLoc L = comp->getIdLoc();
     SourceRange R = SourceRange(comp->getIdLoc());

--- a/test/NameBinding/accessibility.swift
+++ b/test/NameBinding/accessibility.swift
@@ -66,7 +66,7 @@ class Sub : Base {
     // TESTABLE-NOT: :[[@LINE-3]]:{{[^:]+}}:
     // TESTABLE-NOT: :[[@LINE-3]]:{{[^:]+}}:
 
-    method() // expected-error {{use of unresolved identifier 'method'}}
+    method() // expected-error {{'method' is inaccessible due to 'internal' protection level}}
     self.method() // expected-error {{'method' is inaccessible due to 'internal' protection level}}
     super.method() // expected-error {{'method' is inaccessible due to 'internal' protection level}}
     // TESTABLE-NOT: :[[@LINE-3]]:{{[^:]+}}:

--- a/test/Sema/accessibility_private.swift
+++ b/test/Sema/accessibility_private.swift
@@ -15,7 +15,7 @@ class Container {
     _ = self.bar
     self.bar = 5
 
-    privateExtensionMethod() // FIXME expected-error {{use of unresolved identifier 'privateExtensionMethod'}}
+    privateExtensionMethod() // expected-error {{'privateExtensionMethod' is inaccessible due to 'private' protection level}}
     self.privateExtensionMethod() // expected-error {{'privateExtensionMethod' is inaccessible due to 'private' protection level}}
 
     _ = PrivateInner()
@@ -54,23 +54,23 @@ extension Container {
   private func privateExtensionMethod() {} // expected-note * {{declared here}}
 
   func extensionTest() {
-    foo() // FIXME expected-error {{use of unresolved identifier 'foo'}}
+    foo() // expected-error {{'foo' is inaccessible due to 'private' protection level}}
     self.foo() // expected-error {{'foo' is inaccessible due to 'private' protection level}}
 
-    _ = bar // FIXME expected-error {{use of unresolved identifier 'bar'}}
-    bar = 5 // FIXME expected-error {{use of unresolved identifier 'bar'}}
+    _ = bar // expected-error {{'bar' is inaccessible due to 'private' protection level}}
+    bar = 5 // expected-error {{'bar' is inaccessible due to 'private' protection level}}
     _ = self.bar // expected-error {{'bar' is inaccessible due to 'private' protection level}}
     self.bar = 5 // expected-error {{'bar' is inaccessible due to 'private' protection level}}
 
     privateExtensionMethod()
     self.privateExtensionMethod()
 
-    _ = PrivateInner() // FIXME expected-error {{use of unresolved identifier 'PrivateInner'}}
+    _ = PrivateInner() // expected-error {{'PrivateInner' is inaccessible due to 'private' protection level}}
     _ = Container.PrivateInner() // expected-error {{'PrivateInner' is inaccessible due to 'private' protection level}}
   }
 
   // FIXME: Why do these errors happen twice?
-  var extensionInner: PrivateInner? { return nil } // FIXME expected-error 2 {{use of undeclared type 'PrivateInner'}}
+  var extensionInner: PrivateInner? { return nil } // expected-error 2 {{'PrivateInner' is inaccessible due to 'private' protection level}}
   var extensionInnerQualified: Container.PrivateInner? { return nil } // expected-error 2 {{'PrivateInner' is inaccessible due to 'private' protection level}}
 }
 
@@ -81,33 +81,35 @@ extension Container.Inner {
     obj.bar = 5 // expected-error {{'bar' is inaccessible due to 'private' protection level}}
     obj.privateExtensionMethod() // expected-error {{'privateExtensionMethod' is inaccessible due to 'private' protection level}}
 
-    _ = PrivateInner() // FIXME expected-error {{use of unresolved identifier 'PrivateInner'}}
+    // FIXME: Unqualified lookup won't look into Container from here.
+    _ = PrivateInner() // expected-error {{use of unresolved identifier 'PrivateInner'}}
     _ = Container.PrivateInner() // expected-error {{'PrivateInner' is inaccessible due to 'private' protection level}}
   }
 
   // FIXME: Why do these errors happen twice?
-  var inner: PrivateInner? { return nil } // FIXME expected-error 2 {{use of undeclared type 'PrivateInner'}}
+  // FIXME: Unqualified lookup won't look into Container from here.
+  var inner: PrivateInner? { return nil } // expected-error 2 {{use of undeclared type 'PrivateInner'}}
   var innerQualified: Container.PrivateInner? { return nil } // expected-error 2 {{'PrivateInner' is inaccessible due to 'private' protection level}}
 }
 
 class Sub : Container {
   func subTest() {
-    foo() // FIXME expected-error {{use of unresolved identifier 'foo'}}
+    foo() // expected-error {{'foo' is inaccessible due to 'private' protection level}}
     self.foo() // expected-error {{'foo' is inaccessible due to 'private' protection level}}
 
-    _ = bar // FIXME expected-error {{use of unresolved identifier 'bar'}}
-    bar = 5 // FIXME expected-error {{use of unresolved identifier 'bar'}}
+    _ = bar // expected-error {{'bar' is inaccessible due to 'private' protection level}}
+    bar = 5 // expected-error {{'bar' is inaccessible due to 'private' protection level}}
     _ = self.bar // expected-error {{'bar' is inaccessible due to 'private' protection level}}
     self.bar = 5 // expected-error {{'bar' is inaccessible due to 'private' protection level}}
 
-    privateExtensionMethod() // FIXME expected-error {{use of unresolved identifier 'privateExtensionMethod'}}
+    privateExtensionMethod() // expected-error {{'privateExtensionMethod' is inaccessible due to 'private' protection level}}
     self.privateExtensionMethod() // expected-error {{'privateExtensionMethod' is inaccessible due to 'private' protection level}}
 
-    _ = PrivateInner() // FIXME expected-error {{use of unresolved identifier 'PrivateInner'}}
+    _ = PrivateInner() // expected-error {{'PrivateInner' is inaccessible due to 'private' protection level}}
     _ = Container.PrivateInner() // expected-error {{'PrivateInner' is inaccessible due to 'private' protection level}}
   }
 
-  var subInner: PrivateInner? // FIXME expected-error {{use of undeclared type 'PrivateInner'}}
+  var subInner: PrivateInner? // expected-error {{'PrivateInner' is inaccessible due to 'private' protection level}}
   var subInnerQualified: Container.PrivateInner? // expected-error {{'PrivateInner' is inaccessible due to 'private' protection level}}
 }
 
@@ -154,9 +156,9 @@ extension Container {
 }
 extension Container {
   func test() {
-    let a: ExtensionConflictingType? = nil // FIXME expected-error {{use of undeclared type 'ExtensionConflictingType'}}
+    let a: ExtensionConflictingType? = nil // expected-error {{'ExtensionConflictingType' is inaccessible due to 'private' protection level}}
     let b: Container.ExtensionConflictingType? = nil // expected-error {{'ExtensionConflictingType' is inaccessible due to 'private' protection level}}
-    _ = ExtensionConflictingType() // FIXME expected-error {{use of unresolved identifier 'ExtensionConflictingType'}}
+    _ = ExtensionConflictingType() // expected-error {{'ExtensionConflictingType' is inaccessible due to 'private' protection level}}
     _ = Container.ExtensionConflictingType() // expected-error {{'ExtensionConflictingType' is inaccessible due to 'private' protection level}}
   }
 }


### PR DESCRIPTION
- **Explanation:** When qualified lookup finds no results, the compiler tries the search again with access control disabled in order to give better diagnostics ("X is not accessible because it is marked 'fileprivate'"). Unqualified lookup should do the same thing, especially now that the rules for what 'private' means has changed ([SE-0025](https://github.com/apple/swift-evolution/blob/master/proposals/0025-scoped-access-level.md)).
- **Scope:** Only affects unqualified lookups that fail, i.e. when the compiler is already going to emit an error. Most of this uses existing logic, but it could still result in new failures if I got something wrong.
- **Issue:** rdar://problem/27663403
- **Reviewed by:** @DougGregor 
- **Risk:** Medium-low.
- **Testing:** Updated existing compiler regression tests.
