### PR TITLE
[overlay] Declaring MAP_FAILED

### DIFF
--- a/stdlib/public/Platform/Darwin.swift
+++ b/stdlib/public/Platform/Darwin.swift
@@ -11,3 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 @_exported import Darwin // Clang module
+
+public let MAP_FAILED =
+  UnsafeMutableRawPointer(bitPattern: -1)! as UnsafeMutableRawPointer!

--- a/stdlib/public/Platform/Glibc.swift
+++ b/stdlib/public/Platform/Glibc.swift
@@ -11,3 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 @_exported import SwiftGlibc // Clang module
+
+public let MAP_FAILED =
+  UnsafeMutableRawPointer(bitPattern: -1)! as UnsafeMutableRawPointer!

--- a/test/stdlib/mmap.swift
+++ b/test/stdlib/mmap.swift
@@ -1,0 +1,17 @@
+// RUN: %target-run-simple-swift %t
+// REQUIRES: executable_test
+
+import StdlibUnittest
+#if os(Linux)
+  import Glibc
+#else
+  import Darwin
+#endif
+
+var MMapTests = TestSuite("MMaptests")
+
+MMapTests.test("MAP_FAILED") {
+  expectEqual(mmap(nil, 0, 0, 0, 0, 0), MAP_FAILED)
+}
+
+runAllTests()


### PR DESCRIPTION
<!-- What's in this pull request? -->

Clang importer is unable to handle `((void *)-1)`, therefore manually
declaring the said constant in both Darwin and Glibc modules.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves rdar://problem/26689135

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
