### PR TITLE
[Android] Enable building static stdlib on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -566,23 +566,6 @@ if("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "LINUX")
     set(SWIFT_PRIMARY_VARIANT_ARCH_default "${SWIFT_HOST_VARIANT_ARCH}")
   endif()
 
-  # Compatible cross-compile SDKS for LINUX: ANDROID (arch always armv7)
-  is_sdk_requested(ANDROID swift_build_android)
-  if("${SWIFT_ANDROID_NDK_PATH}" STREQUAL "")
-    set(swift_can_crosscompile_stdlib_android FALSE)
-  else()
-    set(swift_can_crosscompile_stdlib_android TRUE)
-  endif()
-
-  if(swift_build_android AND ${swift_can_crosscompile_stdlib_android})
-    configure_sdk_unix(ANDROID "Android" "android" "android" "armv7" "armv7-none-linux-androideabi" "${SWIFT_ANDROID_SDK_PATH}")
-    # If we're not building for the host, the cross-compiled target should be the 'primary variant'.
-    if("${swift_build_linux}" STREQUAL "FALSE")
-      set(SWIFT_PRIMARY_VARIANT_SDK_default "ANDROID")
-      set(SWIFT_PRIMARY_VARIANT_ARCH_default "armv7")
-    endif()
-  endif()
-
 elseif("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "FREEBSD")
   
   set(CMAKE_EXECUTABLE_FORMAT "ELF")
@@ -725,6 +708,28 @@ if("${SWIFT_PRIMARY_VARIANT_SDK}" STREQUAL "")
 endif()
 if("${SWIFT_PRIMARY_VARIANT_ARCH}" STREQUAL "")
   set(SWIFT_PRIMARY_VARIANT_ARCH "${SWIFT_PRIMARY_VARIANT_ARCH_default}")
+endif()
+
+# Should we cross-compile the standard library for Android?
+is_sdk_requested(ANDROID swift_build_android)
+if(swift_build_android AND NOT "${SWIFT_ANDROID_NDK_PATH}" STREQUAL "")
+  configure_sdk_unix(ANDROID "Android" "android" "android" "armv7" "armv7-none-linux-androideabi" "${SWIFT_ANDROID_SDK_PATH}")
+
+  if (NOT ("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin" OR "${CMAKE_SYSTEM_NAME}" STREQUAL "Linux"))
+    message(FATAL_ERROR "A Darwin or Linux host is required to build the Swift runtime for Android")
+  elseif(("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin" AND NOT swift_build_osx) OR
+         ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux" AND NOT swift_build_linux))
+    set(SWIFT_PRIMARY_VARIANT_SDK_default "ANDROID")
+    set(SWIFT_PRIMARY_VARIANT_ARCH_default "armv7")
+  endif()
+
+  if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+    set(_swift_android_prebuilt_suffix "darwin-x86_64")
+  elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+    set(_swift_android_prebuilt_suffix "linux-x86_64")
+  endif()
+  set(SWIFT_ANDROID_PREBUILT_PATH
+      "${SWIFT_ANDROID_NDK_PATH}/toolchains/arm-linux-androideabi-${SWIFT_ANDROID_NDK_GCC_VERSION}/prebuilt/${_swift_android_prebuilt_suffix}")
 endif()
 
 # Should we cross-compile the standard library for Windows?

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -122,7 +122,7 @@ function(_add_variant_c_compile_link_flags)
     list(APPEND result
       "--sysroot=${SWIFT_ANDROID_SDK_PATH}"
       # Use the linker included in the Android NDK.
-      "-B" "${SWIFT_ANDROID_NDK_PATH}/toolchains/arm-linux-androideabi-${SWIFT_ANDROID_NDK_GCC_VERSION}/prebuilt/linux-x86_64/arm-linux-androideabi/bin/")
+      "-B" "${SWIFT_ANDROID_PREBUILT_PATH}/arm-linux-androideabi/bin/")
   endif()
 
   if("${CFLAGS_SDK}" STREQUAL "WINDOWS")
@@ -315,7 +315,7 @@ function(_add_variant_link_flags)
   elseif("${LFLAGS_SDK}" STREQUAL "ANDROID")
     list(APPEND result
         "-ldl"
-        "-L${SWIFT_ANDROID_NDK_PATH}/toolchains/arm-linux-androideabi-${SWIFT_ANDROID_NDK_GCC_VERSION}/prebuilt/linux-x86_64/lib/gcc/arm-linux-androideabi/${SWIFT_ANDROID_NDK_GCC_VERSION}.x"
+        "-L${SWIFT_ANDROID_PREBUILT_PATH}/lib/gcc/arm-linux-androideabi/${SWIFT_ANDROID_NDK_GCC_VERSION}.x"
         "${SWIFT_ANDROID_NDK_PATH}/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a/libc++_shared.so")
   else()
     list(APPEND result "-lobjc")


### PR DESCRIPTION
<!-- What's in this pull request? -->

The Swift runtime can be built for Android on Linux host machines using the instructions in `docs/Android.md`. This commit allows it to be built on macOS host machines as well.

This work is inspired by @compnerd's work in enabling Windows builds from macOS hosts. It assumes host tools are already built for macOS. It also does not support building the stdlib and SDK overlays yet. I intend to support these in a future commit.

For now, the Android runtime may be built by using the following bash script, which simply calls CMake:

``` sh

set -e
set -x

HOME_DIR="/Users/bgesiak"

APPLE_DIR="${HOME_DIR}/GitHub/apple"
BUILD_DIR="${APPLE_DIR}/build/Ninja-Release"
CMARK_SRC_DIR="${APPLE_DIR}/cmark"
CMARK_BUILD_DIR="${BUILD_DIR}/cmark-macosx-x86_64"
LLVM_SRC_DIR="${APPLE_DIR}/llvm"
LLVM_BUILD_DIR="${BUILD_DIR}/llvm-macosx-x86_64"
SWIFT_BUILD_DIR="${BUILD_DIR}/swift-macosx-x86_64"

ANDROID_NDK_DIR="${HOME_DIR}/android-ndk-r12b"
LIBICU_SRC_DIR="${APPLE_DIR}/libiconv-libicu-android"
LIBICU_BUILD_DIR="${LIBICU_SRC_DIR}/armeabi-v7a"

SWIFT_ANDROID_BUILD_DIR="${APPLE_DIR}/build/SwiftAndroid"

mkdir -p "${SWIFT_ANDROID_BUILD_DIR}"

cmake \
  -G "Ninja" \
  \
  -DCMAKE_C_COMPILER:PATH="${LLVM_BUILD_DIR}/bin/clang" \
  -DCMAKE_CXX_COMPILER:PATH="${LLVM_BUILD_DIR}/bin/clang++" \
  \
  -DSWIFT_PATH_TO_CMARK_SOURCE:PATH="${CMARK_SRC_DIR}" \
  -DSWIFT_PATH_TO_CMARK_BUILD:PATH="${CMARK_BUILD_DIR}" \
  -DSWIFT_CMARK_LIBRARY_DIR:PATH="${CMARK_BUILD_DIR}/src" \
  -DSWIFT_PATH_TO_LLVM_SOURCE:PATH="${LLVM_SRC_DIR}" \
  -DSWIFT_PATH_TO_LLVM_BUILD:PATH="${LLVM_BUILD_DIR}" \
  -DSWIFT_PATH_TO_CLANG_SOURCE:PATH="${LLVM_SRC_DIR}/tools/clang" \
  -DSWIFT_PATH_TO_CLANG_BUILD:PATH="${LLVM_BUILD_DIR}" \
  -DSWIFT_NATIVE_LLVM_TOOLS_PATH:STRING="${LLVM_BUILD_DIR}/bin" \
  -DSWIFT_NATIVE_SWIFT_TOOLS_PATH:STRING="${SWIFT_BUILD_DIR}/bin" \
  \
  -DSWIFT_ANALYZE_CODE_COVERAGE:STRING=FALSE \
  -DSWIFT_SERIALIZE_STDLIB_UNITTEST:BOOL=FALSE \
  -DSWIFT_STDLIB_SIL_DEBUGGING:BOOL=FALSE \
  -DSWIFT_CHECK_INCREMENTAL_COMPILATION:BOOL=FALSE \
  -DSWIFT_STDLIB_ENABLE_RESILIENCE:BOOL=FALSE \
  -DSWIFT_STDLIB_SIL_SERIALIZE_ALL:BOOL=TRUE \
  -DSWIFT_BUILD_PERF_TESTSUITE:BOOL=FALSE \
  -DSWIFT_BUILD_EXAMPLES:BOOL=FALSE \
  -DSWIFT_INCLUDE_TESTS:BOOL=FALSE \
  -DSWIFT_EMBED_BITCODE_SECTION:BOOL=FALSE \
  -DSWIFT_TOOLS_ENABLE_LTO:STRING= \
  -DSWIFT_AST_VERIFIER:BOOL=TRUE \
  -DSWIFT_SIL_VERIFY_ALL:BOOL=FALSE \
  -DSWIFT_RUNTIME_ENABLE_LEAK_CHECKER:BOOL=FALSE \
  \
  -DCMAKE_BUILD_TYPE:STRING=Release \
  -DLLVM_ENABLE_ASSERTIONS:BOOL=TRUE \
  -DSWIFT_STDLIB_BUILD_TYPE:STRING=Release \
  -DSWIFT_STDLIB_ASSERTIONS:BOOL=TRUE \
  -DSWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER:BOOL=TRUE \
  -DSWIFT_HOST_VARIANT=macosx \
  -DSWIFT_HOST_VARIANT_SDK=OSX \
  -DSWIFT_HOST_VARIANT_ARCH=x86_64 \
  -DSWIFT_BUILD_TOOLS:BOOL=FALSE \
  -DSWIFT_INCLUDE_TOOLS:BOOL=FALSE \
  -DSWIFT_BUILD_REMOTE_MIRROR:BOOL=FALSE \
  -DSWIFT_BUILD_DYNAMIC_STDLIB:BOOL=FALSE \
  -DSWIFT_BUILD_STATIC_STDLIB:BOOL=TRUE \
  -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY:BOOL=FALSE \
  -DSWIFT_BUILD_STATIC_SDK_OVERLAY:BOOL=FALSE \
  -DSWIFT_EXEC:STRING="${SWIFT_BUILD_DIR}/bin/swiftc" \
  \
  -DSWIFT_ENABLE_GOLD_LINKER:BOOL=TRUE \
  -DSWIFT_SDKS:STRING=ANDROID \
  -DSWIFT_ANDROID_NDK_PATH:STRING="${ANDROID_NDK_DIR}" \
  -DSWIFT_ANDROID_NDK_GCC_VERSION:STRING=4.9 \
  -DSWIFT_ANDROID_SDK_PATH:STRING="${ANDROID_NDK_DIR}/platforms/android-21/arch-arm" \
  -DSWIFT_ANDROID_ICU_UC:STRING="${LIBICU_BUILD_DIR}" \
  -DSWIFT_ANDROID_ICU_UC_INCLUDE:STRING="${LIBICU_BUILD_DIR}/icu/source/common" \
  -DSWIFT_ANDROID_ICU_I18N:STRING="${LIBICU_BUILD_DIR}" \
  -DSWIFT_ANDROID_ICU_I18N_INCLUDE:STRING="${LIBICU_BUILD_DIR}/icu/source/i18n" \
  \
  "${APPLE_DIR}/swift"

cmake --build "${APPLE_DIR}/swift" -- -j8 swift-stdlib-android-armv7
```

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Addresses part of [SR-1362](https://bugs.swift.org/browse/SR-1362), with stdlib and SDK overlay support coming in a future pull request.
