### PR TITLE
SR-2747: Recommend type(of:) instead of .dynamicType

### DIFF
--- a/apinotes/ObjectiveC.apinotes
+++ b/apinotes/ObjectiveC.apinotes
@@ -101,7 +101,7 @@ Protocols:
   - Selector: class
     MethodKind: Instance
     Availability: nonswift
-    AvailabilityMsg: use 'dynamicType' instead
+    AvailabilityMsg: use 'type(of:)' instead
   - Selector: 'conformsToProtocol:'
     MethodKind: Instance
     Nullability:

--- a/test/ClangModules/availability.swift
+++ b/test/ClangModules/availability.swift
@@ -34,9 +34,9 @@ func test_NSInvocation(_ x: NSInvocation,         // expected-error {{'NSInvocat
                        z: NSMethodSignature) {} // expected-error {{'NSMethodSignature' is unavailable}}
 
 func test_class_avail(_ x:NSObject, obj: AnyObject) {
-  x.`class`() // expected-error {{'class()' is unavailable in Swift: use 'dynamicType' instead}} expected-warning {{result of call to 'class()' is unused}}
+  x.`class`() // expected-error {{'class()' is unavailable in Swift: use 'type(of:)' instead}} expected-warning {{result of call to 'class()' is unused}}
   _ = NSObject.`class`() // expected-error {{'class()' is unavailable in Swift: use 'self' instead}}
-  _ = obj.`class`!() // expected-error {{'class()' is unavailable in Swift: use 'dynamicType' instead}}
+  _ = obj.`class`!() // expected-error {{'class()' is unavailable in Swift: use 'type(of:)' instead}}
 }
 
 func test_unavailable_app_extension() {


### PR DESCRIPTION
<!-- What's in this pull request? -->

When trying to use `.class()` from Objective-C, the compiler recommended using `.dynamicType` instead, which has been deprecated in favor of `type(of:)`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-2747](https://bugs.swift.org/browse/SR-2747).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
