### PR TITLE
[swift-3.0-branch] Declaring MAP_FAILED

### DIFF
--- a/stdlib/public/Platform/Darwin.swift
+++ b/stdlib/public/Platform/Darwin.swift
@@ -11,3 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 @_exported import Darwin // Clang module
+
+public let MAP_FAILED =
+  UnsafeMutableRawPointer(bitPattern: -1)! as UnsafeMutableRawPointer!

--- a/stdlib/public/Platform/Glibc.swift
+++ b/stdlib/public/Platform/Glibc.swift
@@ -11,3 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 @_exported import SwiftGlibc // Clang module
+
+public let MAP_FAILED =
+  UnsafeMutableRawPointer(bitPattern: -1)! as UnsafeMutableRawPointer!

--- a/test/stdlib/mmap.swift
+++ b/test/stdlib/mmap.swift
@@ -1,0 +1,17 @@
+// RUN: %target-run-simple-swift %t
+// REQUIRES: executable_test
+
+import StdlibUnittest
+#if os(Linux)
+  import Glibc
+#else
+  import Darwin
+#endif
+
+var MMapTests = TestSuite("MMaptests")
+
+MMapTests.test("MAP_FAILED") {
+  expectEqual(mmap(nil, 0, 0, 0, 0, 0), MAP_FAILED)
+}
+
+runAllTests()


### PR DESCRIPTION
- Explanation: Export MAP_FAILED constant
- Scope of Issue: Purely additive change, that will simplify using mmap() library function
- Origination: Clang importer is unable to handle ((void *)-1)
- Risk: Minimal
- Reviewed By: Doug Gregor
- Testing: Ran the existing test suite.
- Directions for QA: N/A

rdar://problem/28454321
