### PR TITLE
[build-script] Add clang PGO support

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -810,6 +810,12 @@ class BuildScriptInvocation(object):
         if args.dry_run:
             impl_args += ["--dry-run"]
 
+        if args.clang_profile_instr_use:
+            impl_args += [
+                "--clang-profile-instr-use=%s" %
+                os.path.abspath(args.clang_profile_instr_use)
+            ]
+
         if args.lit_args:
             impl_args += ["--llvm-lit-args=%s" % args.lit_args]
 
@@ -1984,6 +1990,11 @@ details of the setups of other systems or automated environments.""")
         default=None,
         const='full',
         dest='lto_type')
+
+    parser.add_argument(
+        "--clang-profile-instr-use",
+        help="profile file to use for clang PGO",
+        metavar="PATH")
 
     default_max_lto_link_job_counts = host.max_lto_link_job_counts()
     parser.add_argument(

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -237,6 +237,7 @@ KNOWN_SETTINGS=(
     user-config-args            ""               "**Renamed to --extra-cmake-options**: User-supplied arguments to cmake when used to do configuration."
     only-execute                       "all"     "Only execute the named action (see implementation)"
     llvm-lit-args                      ""        "If set, override the lit args passed to LLVM"
+    clang-profile-instr-use            ""        "If set, profile file to use for clang PGO"
     coverage-db                        ""        "If set, coverage database to use when prioritizing testing"
     build-toolchain-only               ""        "If set, only build the necessary tools to build an external toolchain"
 )
@@ -737,6 +738,12 @@ function set_build_options_for_host() {
         )
         swift_cmake_options+=(
             -DLLVM_LIT_ARGS="${LLVM_LIT_ARGS}"
+        )
+    fi
+
+    if [[ "${CLANG_PROFILE_INSTR_USE}" ]]; then
+        llvm_cmake_options+=(
+            -DLLVM_PROFDATA_FILE="${CLANG_PROFILE_INSTR_USE}"
         )
     fi
 


### PR DESCRIPTION
This pull request adds a `--clang-profile-instr-use` parameter to build-script that accepts an llvm profdata file for use in clang profile-guided optimization.
