### PR TITLE
Fix var-parameter detection for inferred params

### DIFF
--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -746,21 +746,28 @@ static bool validateParameterType(ParamDecl *decl, DeclContext *DC,
   auto elementOptions = (options |
                          (decl->isVariadic() ? TR_VariadicFunctionInput
                                              : TR_FunctionInput));
-  bool hadError = TC.validateType(decl->getTypeLoc(), DC,
-                                  elementOptions, resolver);
-  
+  bool hadError = false;
+
+  // We might have a null typeLoc if this is a closure parameter list,
+  // where parameters are allowed to elide their types.
+  if (!decl->getTypeLoc().isNull()) {
+    hadError |= TC.validateType(decl->getTypeLoc(), DC,
+                                elementOptions, resolver);
+  }
+
   Type Ty = decl->getTypeLoc().getType();
-  if (decl->isVariadic() && !hadError) {
+  if (decl->isVariadic() && !Ty.isNull() && !hadError) {
     Ty = TC.getArraySliceType(decl->getStartLoc(), Ty);
     if (Ty.isNull()) {
       hadError = true;
     }
     decl->getTypeLoc().setType(Ty);
   }
+
   // If the param is not a 'let' and it is not an 'inout'.
   // It must be a 'var'. Provide helpful diagnostics like a shadow copy
   // in the function body to fix the 'var' attribute.
-  if (!decl->isLet() && !decl->isInOut()) {
+  if (!decl->isLet() && (Ty.isNull() || !Ty->is<InOutType>()) && !hadError) {
     auto func = dyn_cast_or_null<AbstractFunctionDecl>(DC);
     diagnoseAndMigrateVarParameterToBody(decl, func, TC);
     decl->setInvalid();
@@ -769,7 +776,7 @@ static bool validateParameterType(ParamDecl *decl, DeclContext *DC,
 
   if (hadError)
     decl->getTypeLoc().setType(ErrorType::get(TC.Context), /*validated*/true);
-  
+
   return hadError;
 }
 
@@ -780,8 +787,7 @@ bool TypeChecker::typeCheckParameterList(ParameterList *PL, DeclContext *DC,
   bool hadError = false;
   
   for (auto param : *PL) {
-    if (param->getTypeLoc().getTypeRepr())
-      hadError |= validateParameterType(param, DC, options, resolver, *this);
+    hadError |= validateParameterType(param, DC, options, resolver, *this);
     
     auto type = param->getTypeLoc().getType();
     if (!type && param->hasType()) {

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -351,7 +351,9 @@ func invalid_inout(inout var x : Int) { // expected-error {{parameter may not ha
 func invalid_var(var x: Int) { // expected-error {{parameters may not have the 'var' specifier}}{{18-21=}} {{1-1=    var x = x\n}}
   
 }
-
+func takesClosure(_: (Int) -> Int) {
+  takesClosure { (var d) in d } // expected-error {{parameters may not have the 'var' specifier}}
+}
 
 func updateInt(_ x : inout Int) {}
 

--- a/validation-test/IDE/crashers/069-swift-typechecker-typecheckparameterlist.swift
+++ b/validation-test/IDE/crashers/069-swift-typechecker-typecheckparameterlist.swift
@@ -1,3 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
-func b(e:({#^A^#var e){

--- a/validation-test/IDE/crashers_fixed/069-swift-typechecker-typecheckparameterlist.swift
+++ b/validation-test/IDE/crashers_fixed/069-swift-typechecker-typecheckparameterlist.swift
@@ -1,0 +1,3 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+func b(e:({#^A^#var e){


### PR DESCRIPTION
- **Explanation:** We've removed the 'var' modifier from function parameters in Swift 3, but the diagnostic for that is only emitted when we have a valid type loc. With inferred closure parameters, you're allowed to specify a parameter without a type. If you leave 'var' on one of those, it causes an assertion in SILGen. Instead, teach the diagnostic to handle omitted types.
- **Scope:** Only affects function parameters with elided types.
- **Issue:** [SR-2562](https://bugs.swift.org/browse/SR-2562)
- **Reviewed by:** @DougGregor and @CodaFi 
- **Risk:** Low.
- **Testing:** Added a test to cover this diagnostic.
