### PR TITLE
SR-2709: @available(swift, ...)

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -674,7 +674,9 @@ public:
   static AvailableAttr *
   createPlatformAgnostic(ASTContext &C, StringRef Message, StringRef Rename = "",
                       PlatformAgnosticAvailabilityKind Reason
-                        = PlatformAgnosticAvailabilityKind::Unavailable);
+                         = PlatformAgnosticAvailabilityKind::Unavailable,
+                         clang::VersionTuple Obsoleted
+                         = clang::VersionTuple());
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DAK_Available;

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -558,17 +558,17 @@ enum class MinVersionComparison {
   Obsoleted,
 };
 
-/// Describes the unconditional availability of a declaration.
-enum class UnconditionalAvailabilityKind {
-  /// The declaration is not unconditionally unavailable.
+/// Describes the platform-agnostic availability of a declaration.
+enum class PlatformAgnosticAvailabilityKind {
+  /// The associated availability attribute is not platform-agnostic.
   None,
   /// The declaration is deprecated, but can still be used.
   Deprecated,
   /// The declaration is unavailable in Swift, specifically
   UnavailableInSwift,
-  /// The declaration is unavailable in the current version of Swift,
-  /// but was available in previous Swift versions.
-  UnavailableInCurrentSwift,
+  /// The declaration is available in some but not all versions
+  /// of Swift, as specified by the VersionTuple members.
+  SwiftVersionSpecific,
   /// The declaration is unavailable for other reasons.
   Unavailable,
 };
@@ -585,14 +585,14 @@ public:
                    const clang::VersionTuple &Introduced,
                    const clang::VersionTuple &Deprecated,
                    const clang::VersionTuple &Obsoleted,
-                   UnconditionalAvailabilityKind Unconditional,
+                   PlatformAgnosticAvailabilityKind PlatformAgnostic,
                    bool Implicit)
     : DeclAttribute(DAK_Available, AtLoc, Range, Implicit),
       Message(Message), Rename(Rename),
       INIT_VER_TUPLE(Introduced),
       INIT_VER_TUPLE(Deprecated),
       INIT_VER_TUPLE(Obsoleted),
-      Unconditional(Unconditional),
+      PlatformAgnostic(PlatformAgnostic),
       Platform(Platform)
   {}
 
@@ -618,8 +618,8 @@ public:
   /// Indicates when the symbol was obsoleted.
   const Optional<clang::VersionTuple> Obsoleted;
 
-  /// Indicates if the declaration has unconditional availability.
-  const UnconditionalAvailabilityKind Unconditional;
+  /// Indicates if the declaration has platform-agnostic availability.
+  const PlatformAgnosticAvailabilityKind PlatformAgnostic;
 
   /// The platform of the availability.
   const PlatformKind Platform;
@@ -630,9 +630,9 @@ public:
   /// Whether this is an unconditionally deprecated entity.
   bool isUnconditionallyDeprecated() const;
 
-  /// Returns the unconditional unavailability.
-  UnconditionalAvailabilityKind getUnconditionalAvailability() const {
-    return Unconditional;
+  /// Returns the platform-agnostic availability.
+  PlatformAgnosticAvailabilityKind getPlatformAgnosticAvailability() const {
+    return PlatformAgnostic;
   }
 
   /// Determine if a given declaration should be considered unavailable given
@@ -668,9 +668,9 @@ public:
   /// Create an AvailableAttr that indicates specific availability
   /// for all platforms.
   static AvailableAttr *
-  createUnconditional(ASTContext &C, StringRef Message, StringRef Rename = "",
-                      UnconditionalAvailabilityKind Reason
-                        = UnconditionalAvailabilityKind::Unavailable);
+  createPlatformAgnostic(ASTContext &C, StringRef Message, StringRef Rename = "",
+                      PlatformAgnosticAvailabilityKind Reason
+                        = PlatformAgnosticAvailabilityKind::Unavailable);
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DAK_Available;

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -543,16 +543,16 @@ public:
 };
 
 /// Determine the result of comparing an availability attribute to a specific
-/// minimum platform version.
-enum class MinVersionComparison {
+/// platform or language version.
+enum class AvailableVersionComparison {
   /// The entity is guaranteed to be available.
   Available,
 
   /// The entity is never available.
   Unavailable,
 
-  /// The entity might be unavailable, because it was introduced after
-  /// the minimum version.
+  /// The entity might be unavailable at runtime, because it was introduced
+  /// after the requested minimum platform version.
   PotentiallyUnavailable,
 
   /// The entity has been obsoleted.
@@ -664,10 +664,10 @@ public:
   /// Returns true if this attribute is active given the current platform.
   bool isActivePlatform(const ASTContext &ctx) const;
 
-  /// Compare this attribute's version information against the minimum platform
-  /// version (assuming the this attribute pertains to the active platform).
-  MinVersionComparison getMinVersionAvailability(
-                         clang::VersionTuple minVersion) const;
+  /// Compare this attribute's version information against the platform or
+  /// language version (assuming the this attribute pertains to the active
+  /// platform).
+  AvailableVersionComparison getVersionAvailability(const ASTContext &ctx) const;
 
   /// Create an AvailableAttr that indicates specific availability
   /// for all platforms.

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -625,6 +625,9 @@ public:
   /// The platform of the availability.
   const PlatformKind Platform;
 
+  /// Whether this is a language-version-specific entity.
+  bool isLanguageVersionSpecific() const;
+
   /// Whether this is an unconditionally unavailable entity.
   bool isUnconditionallyUnavailable() const;
 

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -21,6 +21,7 @@
 #include "swift/Basic/UUID.h"
 #include "swift/Basic/STLExtras.h"
 #include "swift/Basic/Range.h"
+#include "swift/Basic/Version.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/AttrKind.h"
 #include "swift/AST/ConcreteDeclRef.h"
@@ -1081,9 +1082,11 @@ public:
     return getUnavailable(ctx) != nullptr;
   }
 
-  /// Determine whether there is an "unavailable in current Swift"
-  /// attribute.
-  bool isUnavailableInCurrentSwift() const;
+  /// Determine whether there is a swiftVersionSpecific attribute that's
+  /// unavailable relative to the provided language version (defaulting to
+  /// current language version).
+  bool isUnavailableInSwiftVersion(const version::Version &effectiveVersion =
+           version::Version::getCurrentLanguageVersion()) const;
 
   /// Returns the first @available attribute that indicates
   /// a declaration is unavailable, or null otherwise.

--- a/include/swift/AST/AvailabilitySpec.h
+++ b/include/swift/AST/AvailabilitySpec.h
@@ -28,12 +28,15 @@ class ASTContext;
 enum class VersionComparison { GreaterThanEqual };
 
 enum class AvailabilitySpecKind {
-    /// A version constraint of the form PlatformName X.Y.Z
-    VersionConstraint,
+    /// A platform-version constraint of the form "PlatformName X.Y.Z"
+    PlatformVersionConstraint,
 
     /// A wildcard constraint, spelled '*', that is be equivalent
     /// to CurrentPlatformName >= MinimumDeploymentTargetVersion
-    OtherPlatform
+    OtherPlatform,
+
+    /// A language-version constraint of the form "swift X.Y.Z"
+    LanguageVersionConstraint,
 };
 
 /// The root class for specifications of API availability in availability
@@ -57,7 +60,7 @@ public:
 
 /// \brief An availability specification that guards execution based on the
 /// run-time platform and version, e.g., OS X >= 10.10.
-class VersionConstraintAvailabilitySpec : public AvailabilitySpec {
+class PlatformVersionConstraintAvailabilitySpec : public AvailabilitySpec {
   PlatformKind Platform;
   SourceLoc PlatformLoc;
 
@@ -65,14 +68,14 @@ class VersionConstraintAvailabilitySpec : public AvailabilitySpec {
   SourceRange VersionSrcRange;
 
 public:
-  VersionConstraintAvailabilitySpec(PlatformKind Platform,
-                                    SourceLoc PlatformLoc,
-                                    clang::VersionTuple Version,
-                                    SourceRange VersionSrcRange)
-      : AvailabilitySpec(AvailabilitySpecKind::VersionConstraint),
-        Platform(Platform),
-        PlatformLoc(PlatformLoc), Version(Version),
-        VersionSrcRange(VersionSrcRange) {}
+  PlatformVersionConstraintAvailabilitySpec(PlatformKind Platform,
+                                            SourceLoc PlatformLoc,
+                                            clang::VersionTuple Version,
+                                            SourceRange VersionSrcRange)
+    : AvailabilitySpec(AvailabilitySpecKind::PlatformVersionConstraint),
+      Platform(Platform),
+      PlatformLoc(PlatformLoc), Version(Version),
+      VersionSrcRange(VersionSrcRange) {}
 
   /// The required platform.
   PlatformKind getPlatform() const { return Platform; }
@@ -87,12 +90,49 @@ public:
   void print(raw_ostream &OS, unsigned Indent) const;
   
   static bool classof(const AvailabilitySpec *Spec) {
-    return Spec->getKind() == AvailabilitySpecKind::VersionConstraint;
+    return Spec->getKind() == AvailabilitySpecKind::PlatformVersionConstraint;
   }
 
   void *
   operator new(size_t Bytes, ASTContext &C,
-               unsigned Alignment = alignof(VersionConstraintAvailabilitySpec)){
+               unsigned Alignment = alignof(PlatformVersionConstraintAvailabilitySpec)){
+    return AvailabilitySpec::operator new(Bytes, C, Alignment);
+  }
+};
+
+/// \brief An availability specification that guards execution based on the
+/// compile-time language version, e.g., swift >= 3.0.1.
+class LanguageVersionConstraintAvailabilitySpec : public AvailabilitySpec {
+  SourceLoc SwiftLoc;
+
+  clang::VersionTuple Version;
+  SourceRange VersionSrcRange;
+
+public:
+  LanguageVersionConstraintAvailabilitySpec(SourceLoc SwiftLoc,
+                                            clang::VersionTuple Version,
+                                            SourceRange VersionSrcRange)
+    : AvailabilitySpec(AvailabilitySpecKind::LanguageVersionConstraint),
+      SwiftLoc(SwiftLoc), Version(Version),
+      VersionSrcRange(VersionSrcRange) {}
+
+  SourceLoc getSwiftLoc() const { return SwiftLoc; }
+
+  // The platform version to compare against.
+  clang::VersionTuple getVersion() const { return Version; }
+  SourceRange getVersionSrcRange() const { return VersionSrcRange; }
+
+  SourceRange getSourceRange() const;
+
+  void print(raw_ostream &OS, unsigned Indent) const;
+
+  static bool classof(const AvailabilitySpec *Spec) {
+    return Spec->getKind() == AvailabilitySpecKind::LanguageVersionConstraint;
+  }
+
+  void *
+  operator new(size_t Bytes, ASTContext &C,
+               unsigned Alignment = alignof(LanguageVersionConstraintAvailabilitySpec)){
     return AvailabilitySpec::operator new(Bytes, C, Alignment);
   }
 };

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1380,6 +1380,12 @@ ERROR(avail_query_version_comparison_not_needed,
 ERROR(availability_query_wildcard_required, none,
       "must handle potential future platforms with '*'", ())
 
+ERROR(availability_swift_must_occur_alone, none,
+      "'swift' version-availability must be specified alone", ())
+
+ERROR(pound_available_swift_not_allowed, none,
+      "Swift language version checks not allowed in #available(...)", ())
+
 ERROR(availability_query_repeated_platform, none,
       "version for '%0' already specified", (StringRef))
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3108,6 +3108,10 @@ ERROR(availability_decl_unavailable_in_swift_msg, none,
 NOTE(availability_marked_unavailable, none,
   "%0 has been explicitly marked unavailable here", (DeclName))
 
+NOTE(availability_introduced_in_swift, none,
+     "%0 was introduced in Swift %1",
+    (DeclName, clang::VersionTuple))
+
 NOTE(availability_obsoleted, none,
      "%0 was obsoleted in %1 %2",
     (DeclName, StringRef, clang::VersionTuple))

--- a/include/swift/Basic/Version.h
+++ b/include/swift/Basic/Version.h
@@ -24,6 +24,7 @@
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "clang/Basic/VersionTuple.h"
 #include <string>
 
 namespace swift {
@@ -88,6 +89,10 @@ public:
   bool empty() const {
     return Components.empty();
   }
+
+  /// Convert to a (maximum-4-element) clang::VersionTuple, truncating
+  /// away any 5th component that might be in this version.
+  operator clang::VersionTuple() const;
 
   /// Return whether this version is a valid Swift language version number
   /// to set the compiler to using -swift-version; this is not the same as

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1245,7 +1245,10 @@ public:
   parseAvailabilitySpecList(SmallVectorImpl<AvailabilitySpec *> &Specs);
 
   ParserResult<AvailabilitySpec> parseAvailabilitySpec();
-  ParserResult<PlatformVersionConstraintAvailabilitySpec> parseVersionConstraintSpec();
+  ParserResult<PlatformVersionConstraintAvailabilitySpec>
+  parsePlatformVersionConstraintSpec();
+  ParserResult<LanguageVersionConstraintAvailabilitySpec>
+  parseLanguageVersionConstraintSpec();
 };
 
 /// Describes a parsed declaration name.

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1245,7 +1245,7 @@ public:
   parseAvailabilitySpecList(SmallVectorImpl<AvailabilitySpec *> &Specs);
 
   ParserResult<AvailabilitySpec> parseAvailabilitySpec();
-  ParserResult<VersionConstraintAvailabilitySpec> parseVersionConstraintSpec();
+  ParserResult<PlatformVersionConstraintAvailabilitySpec> parseVersionConstraintSpec();
 };
 
 /// Describes a parsed declaration name.

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1215,8 +1215,11 @@ public:
       for (auto *Query : C.getAvailability()->getQueries()) {
         OS << '\n';
         switch (Query->getKind()) {
-        case AvailabilitySpecKind::VersionConstraint:
-          cast<VersionConstraintAvailabilitySpec>(Query)->print(OS, Indent + 2);
+        case AvailabilitySpecKind::PlatformVersionConstraint:
+          cast<PlatformVersionConstraintAvailabilitySpec>(Query)->print(OS, Indent + 2);
+          break;
+        case AvailabilitySpecKind::LanguageVersionConstraint:
+          cast<LanguageVersionConstraintAvailabilitySpec>(Query)->print(OS, Indent + 2);
           break;
         case AvailabilitySpecKind::OtherPlatform:
           cast<OtherPlatformAvailabilitySpec>(Query)->print(OS, Indent + 2);

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1448,7 +1448,7 @@ bool swift::shouldPrint(const Decl *D, PrintOptions &Options) {
       D->getAttrs().isUnavailable(D->getASTContext()))
     return false;
 
-  // Skip stub declarations used for prior variants of Swift.
+  // Skip stub declarations used for prior or later variants of Swift.
   if (D->getAttrs().isUnavailableInCurrentSwift())
     return false;
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1449,7 +1449,7 @@ bool swift::shouldPrint(const Decl *D, PrintOptions &Options) {
     return false;
 
   // Skip stub declarations used for prior or later variants of Swift.
-  if (D->getAttrs().isUnavailableInCurrentSwift())
+  if (D->getAttrs().isUnavailableInSwiftVersion())
     return false;
 
   if (Options.ExplodeEnumCaseDecls) {

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -91,8 +91,8 @@ bool DeclAttributes::isUnavailableInCurrentSwift() const {
       if (available->isInvalid())
         continue;
 
-      if (available->getUnconditionalAvailability() ==
-            UnconditionalAvailabilityKind::UnavailableInCurrentSwift)
+      if (available->getPlatformAgnosticAvailability() ==
+            PlatformAgnosticAvailabilityKind::SwiftVersionSpecific)
         return true;
     }
   }
@@ -197,7 +197,7 @@ static bool isShortAvailable(const DeclAttribute *DA) {
   if (!AvailAttr->Rename.empty())
     return false;
 
-  if (AvailAttr->Unconditional != UnconditionalAvailabilityKind::None)
+  if (AvailAttr->PlatformAgnostic != PlatformAgnosticAvailabilityKind::None)
     return false;
 
   return true;
@@ -379,8 +379,8 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options) 
     // the generated interface.
     if (!Attr->Message.empty())
       Printer << ", message: \"" << Attr->Message << "\"";
-    else if (Attr->getUnconditionalAvailability()
-               == UnconditionalAvailabilityKind::UnavailableInSwift)
+    else if (Attr->getPlatformAgnosticAvailability()
+               == PlatformAgnosticAvailabilityKind::UnavailableInSwift)
       Printer << ", message: \"Not available in Swift\"";
 
     Printer << ")";
@@ -643,11 +643,11 @@ ObjCAttr *ObjCAttr::clone(ASTContext &context) const {
 }
 
 AvailableAttr *
-AvailableAttr::createUnconditional(ASTContext &C,
+AvailableAttr::createPlatformAgnostic(ASTContext &C,
                                    StringRef Message,
                                    StringRef Rename,
-                                   UnconditionalAvailabilityKind Reason) {
-  assert(Reason != UnconditionalAvailabilityKind::None);
+                                   PlatformAgnosticAvailabilityKind Reason) {
+  assert(Reason != PlatformAgnosticAvailabilityKind::None);
   clang::VersionTuple NoVersion;
   return new (C) AvailableAttr(
     SourceLoc(), SourceRange(), PlatformKind::none, Message, Rename,
@@ -659,27 +659,27 @@ bool AvailableAttr::isActivePlatform(const ASTContext &ctx) const {
 }
 
 bool AvailableAttr::isUnconditionallyUnavailable() const {
-  switch (Unconditional) {
-  case UnconditionalAvailabilityKind::None:
-  case UnconditionalAvailabilityKind::Deprecated:
+  switch (PlatformAgnostic) {
+  case PlatformAgnosticAvailabilityKind::None:
+  case PlatformAgnosticAvailabilityKind::Deprecated:
+  case PlatformAgnosticAvailabilityKind::SwiftVersionSpecific:
     return false;
 
-  case UnconditionalAvailabilityKind::Unavailable:
-  case UnconditionalAvailabilityKind::UnavailableInSwift:
-  case UnconditionalAvailabilityKind::UnavailableInCurrentSwift:
+  case PlatformAgnosticAvailabilityKind::Unavailable:
+  case PlatformAgnosticAvailabilityKind::UnavailableInSwift:
     return true;
   }
 }
 
 bool AvailableAttr::isUnconditionallyDeprecated() const {
-  switch (Unconditional) {
-  case UnconditionalAvailabilityKind::None:
-  case UnconditionalAvailabilityKind::Unavailable:
-  case UnconditionalAvailabilityKind::UnavailableInSwift:
-  case UnconditionalAvailabilityKind::UnavailableInCurrentSwift:
+  switch (PlatformAgnostic) {
+  case PlatformAgnosticAvailabilityKind::None:
+  case PlatformAgnosticAvailabilityKind::Unavailable:
+  case PlatformAgnosticAvailabilityKind::UnavailableInSwift:
+  case PlatformAgnosticAvailabilityKind::SwiftVersionSpecific:
     return false;
 
-  case UnconditionalAvailabilityKind::Deprecated:
+  case PlatformAgnosticAvailabilityKind::Deprecated:
     return true;
   }
 }

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -655,12 +655,16 @@ AvailableAttr *
 AvailableAttr::createPlatformAgnostic(ASTContext &C,
                                    StringRef Message,
                                    StringRef Rename,
-                                   PlatformAgnosticAvailabilityKind Reason) {
-  assert(Reason != PlatformAgnosticAvailabilityKind::None);
+                                   PlatformAgnosticAvailabilityKind Kind,
+                                   clang::VersionTuple Obsoleted) {
+  assert(Kind != PlatformAgnosticAvailabilityKind::None);
   clang::VersionTuple NoVersion;
+  if (Kind == PlatformAgnosticAvailabilityKind::SwiftVersionSpecific) {
+    assert(!Obsoleted.empty());
+  }
   return new (C) AvailableAttr(
     SourceLoc(), SourceRange(), PlatformKind::none, Message, Rename,
-    NoVersion, NoVersion, NoVersion, Reason, /* isImplicit */ false);
+    NoVersion, NoVersion, Obsoleted, Kind, /* isImplicit */ false);
 }
 
 bool AvailableAttr::isActivePlatform(const ASTContext &ctx) const {

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -667,6 +667,19 @@ bool AvailableAttr::isActivePlatform(const ASTContext &ctx) const {
   return isPlatformActive(Platform, ctx.LangOpts);
 }
 
+bool AvailableAttr::isLanguageVersionSpecific() const {
+  if (PlatformAgnostic ==
+      PlatformAgnosticAvailabilityKind::SwiftVersionSpecific)
+    {
+      assert(Platform == PlatformKind::none &&
+             (Introduced.hasValue() ||
+              Deprecated.hasValue() ||
+              Obsoleted.hasValue()));
+      return true;
+    }
+  return false;
+}
+
 bool AvailableAttr::isUnconditionallyUnavailable() const {
   switch (PlatformAgnostic) {
   case PlatformAgnosticAvailabilityKind::None:

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -27,8 +27,8 @@ namespace {
 /// The inferred availability required to access a group of declarations
 /// on a single platform.
 struct InferredAvailability {
-  UnconditionalAvailabilityKind Unconditional
-    = UnconditionalAvailabilityKind::None;
+  PlatformAgnosticAvailabilityKind PlatformAgnostic
+    = PlatformAgnosticAvailabilityKind::None;
   
   Optional<clang::VersionTuple> Introduced;
   Optional<clang::VersionTuple> Deprecated;
@@ -61,10 +61,10 @@ mergeIntoInferredVersion(const Optional<clang::VersionTuple> &Version,
 /// the attribute requires.
 static void mergeWithInferredAvailability(const AvailableAttr *Attr,
                                           InferredAvailability &Inferred) {
-  Inferred.Unconditional
-    = static_cast<UnconditionalAvailabilityKind>(
-      std::max(static_cast<unsigned>(Inferred.Unconditional),
-               static_cast<unsigned>(Attr->getUnconditionalAvailability())));
+  Inferred.PlatformAgnostic
+    = static_cast<PlatformAgnosticAvailabilityKind>(
+      std::max(static_cast<unsigned>(Inferred.PlatformAgnostic),
+               static_cast<unsigned>(Attr->getPlatformAgnosticAvailability())));
 
   // The merge of two introduction versions is the maximum of the two versions.
   mergeIntoInferredVersion(Attr->Introduced, Inferred.Introduced, std::max);
@@ -92,7 +92,7 @@ createAvailableAttr(PlatformKind Platform,
       SourceLoc(), SourceRange(), Platform,
       /*Message=*/StringRef(),
       /*Rename=*/StringRef(), Introduced, Deprecated, Obsoleted,
-      Inferred.Unconditional, /*Implicit=*/true);
+      Inferred.PlatformAgnostic, /*Implicit=*/true);
 }
 
 void AvailabilityInference::applyInferredAvailableAttrs(

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -128,7 +128,8 @@ AvailabilityInference::annotatedAvailableRange(const Decl *D, ASTContext &Ctx) {
   for (auto Attr : D->getAttrs()) {
     auto *AvailAttr = dyn_cast<AvailableAttr>(Attr);
     if (AvailAttr == nullptr || !AvailAttr->Introduced.hasValue() ||
-        !AvailAttr->isActivePlatform(Ctx)) {
+        !AvailAttr->isActivePlatform(Ctx) ||
+        AvailAttr->isLanguageVersionSpecific()) {
       continue;
     }
 

--- a/lib/AST/AvailabilitySpec.cpp
+++ b/lib/AST/AvailabilitySpec.cpp
@@ -22,8 +22,11 @@ using namespace swift;
 
 SourceRange AvailabilitySpec::getSourceRange() const {
   switch (getKind()) {
-  case AvailabilitySpecKind::VersionConstraint:
-    return cast<VersionConstraintAvailabilitySpec>(this)->getSourceRange();
+  case AvailabilitySpecKind::PlatformVersionConstraint:
+    return cast<PlatformVersionConstraintAvailabilitySpec>(this)->getSourceRange();
+
+ case AvailabilitySpecKind::LanguageVersionConstraint:
+   return cast<LanguageVersionConstraintAvailabilitySpec>(this)->getSourceRange();
 
   case AvailabilitySpecKind::OtherPlatform:
     return cast<OtherPlatformAvailabilitySpec>(this)->getSourceRange();
@@ -39,20 +42,31 @@ void *AvailabilitySpec::operator new(size_t Bytes, ASTContext &C,
 }
 
 
-SourceRange VersionConstraintAvailabilitySpec::getSourceRange() const {
+SourceRange PlatformVersionConstraintAvailabilitySpec::getSourceRange() const {
   return SourceRange(PlatformLoc, VersionSrcRange.End);
 }
 
-void VersionConstraintAvailabilitySpec::print(raw_ostream &OS,
+void PlatformVersionConstraintAvailabilitySpec::print(raw_ostream &OS,
                                               unsigned Indent) const {
-  OS.indent(Indent) << '(' << "version_constraint_availability_spec"
+  OS.indent(Indent) << '(' << "platform_version_constraint_availability_spec"
                     << " platform='" << platformString(getPlatform()) << "'"
                     << " version='" << getVersion() << "'"
                     << ')';
 }
 
+SourceRange LanguageVersionConstraintAvailabilitySpec::getSourceRange() const {
+  return SourceRange(SwiftLoc, VersionSrcRange.End);
+}
+
+void LanguageVersionConstraintAvailabilitySpec::print(raw_ostream &OS,
+                                                      unsigned Indent) const {
+  OS.indent(Indent) << '(' << "language_version_constraint_availability_spec"
+                    << " version='" << getVersion() << "'"
+                    << ')';
+}
+
 void OtherPlatformAvailabilitySpec::print(raw_ostream &OS, unsigned Indent) const {
-  OS.indent(Indent) << '(' << "version_constraint_availability_spec"
+  OS.indent(Indent) << '(' << "other_constraint_availability_spec"
                     << " "
                     << ')';
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -471,7 +471,7 @@ bool Decl::isWeakImported(Module *fromModule) const {
     return clangDecl->isWeakImported();
   }
 
-  // FIXME: Implement using AvailableAttr::getMinVersionAvailability().
+  // FIXME: Implement using AvailableAttr::getVersionAvailability().
   return false;
 }
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -648,7 +648,7 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
           auto unavailableLookupResult =
             [&](const UnqualifiedLookupResult &result) {
             return result.getValueDecl()->getAttrs()
-                     .isUnavailableInCurrentSwift();
+                     .isUnavailableInSwiftVersion();
           };
 
           // If all of the results we found are unavailable, keep looking.
@@ -849,7 +849,7 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
             auto unavailableLookupResult =
               [&](const UnqualifiedLookupResult &result) {
               return result.getValueDecl()->getAttrs()
-                       .isUnavailableInCurrentSwift();
+                       .isUnavailableInSwiftVersion();
             };
 
             // If all of the results we found are unavailable, keep looking.

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -287,7 +287,7 @@ void PoundAvailableInfo::
 getPlatformKeywordLocs(SmallVectorImpl<SourceLoc> &PlatformLocs) {
   for (unsigned i = 0; i < NumQueries; i++) {
     auto *VersionSpec =
-      dyn_cast<VersionConstraintAvailabilitySpec>(getQueries()[i]);
+      dyn_cast<PlatformVersionConstraintAvailabilitySpec>(getQueries()[i]);
     if (!VersionSpec)
       continue;
     

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -285,6 +285,31 @@ Version::preprocessorDefinition(StringRef macroName,
   return define;
 }
 
+Version::operator clang::VersionTuple() const
+{
+  switch (Components.size()) {
+ case 0:
+   return clang::VersionTuple();
+ case 1:
+   return clang::VersionTuple((unsigned)Components[0]);
+ case 2:
+   return clang::VersionTuple((unsigned)Components[0],
+                              (unsigned)Components[1]);
+ case 3:
+   return clang::VersionTuple((unsigned)Components[0],
+                              (unsigned)Components[1],
+                              (unsigned)Components[2]);
+ case 4:
+ case 5:
+   return clang::VersionTuple((unsigned)Components[0],
+                              (unsigned)Components[1],
+                              (unsigned)Components[2],
+                              (unsigned)Components[3]);
+ default:
+   llvm_unreachable("swift::version::Version with 6 or more components");
+  }
+}
+
 bool
 Version::isValidEffectiveLanguageVersion() const
 {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3595,7 +3595,7 @@ namespace {
             typeResolver->resolveDeclSignature(singleResult);
 
           // Skip Swift 2 variants.
-          if (singleResult->getAttrs().isUnavailableInCurrentSwift())
+          if (singleResult->getAttrs().isUnavailableInSwiftVersion())
             continue;
 
           if (found)
@@ -6000,7 +6000,7 @@ void SwiftDeclConverter::importMirroredProtocolMembers(
 
     for (auto member : proto->getMembers()) {
       // Skip Swift 2 stubs; there's no reason to mirror them.
-      if (member->getAttrs().isUnavailableInCurrentSwift())
+      if (member->getAttrs().isUnavailableInSwiftVersion())
         continue;
 
       if (auto prop = dyn_cast<VarDecl>(member)) {
@@ -6097,7 +6097,7 @@ void SwiftDeclConverter::importInheritedConstructors(
         continue;
 
       // Don't inherit Swift 2 stubs.
-      if (ctor->getAttrs().isUnavailableInCurrentSwift())
+      if (ctor->getAttrs().isUnavailableInSwiftVersion())
         continue;
 
       // Don't inherit (non-convenience) factory initializers.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1840,7 +1840,8 @@ namespace {
 
       auto attr = AvailableAttr::createPlatformAgnostic(
                     ctx, StringRef(), ctx.AllocateCopy(renamed.str()),
-                    PlatformAgnosticAvailabilityKind::SwiftVersionSpecific);
+                    PlatformAgnosticAvailabilityKind::SwiftVersionSpecific,
+                    clang::VersionTuple(3));
       decl->getAttrs().add(attr);
       decl->setImplicit();
     }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -752,7 +752,7 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
                                      /*Introduced=*/VersionSpec->getVersion(),
                                      /*Deprecated=*/clang::VersionTuple(),
                                      /*Obsoleted=*/clang::VersionTuple(),
-                                     UnconditionalAvailabilityKind::None,
+                                     PlatformAgnosticAvailabilityKind::None,
                                      /*Implicit=*/true));
       }
 
@@ -769,7 +769,7 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
 
     StringRef Message, Renamed;
     clang::VersionTuple Introduced, Deprecated, Obsoleted;
-    auto Unconditional = UnconditionalAvailabilityKind::None;
+    auto PlatformAgnostic = PlatformAgnosticAvailabilityKind::None;
     bool AnyAnnotations = false;
     int ParamIndex = 0;
 
@@ -860,12 +860,12 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
 
       case IsDeprecated:
         if (!findAttrValueDelimiter()) {
-          if (Unconditional != UnconditionalAvailabilityKind::None) {
+          if (PlatformAgnostic != PlatformAgnosticAvailabilityKind::None) {
             diagnose(Tok, diag::attr_availability_unavailable_deprecated,
                      AttrName);
           }
 
-          Unconditional = UnconditionalAvailabilityKind::Deprecated;
+          PlatformAgnostic = PlatformAgnosticAvailabilityKind::Deprecated;
           break;
         }
         SWIFT_FALLTHROUGH;
@@ -903,12 +903,12 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
       }
 
       case IsUnavailable:
-        if (Unconditional != UnconditionalAvailabilityKind::None) {
+        if (PlatformAgnostic != PlatformAgnosticAvailabilityKind::None) {
           diagnose(Tok, diag::attr_availability_unavailable_deprecated,
                    AttrName);
         }
 
-        Unconditional = UnconditionalAvailabilityKind::Unavailable;
+        PlatformAgnostic = PlatformAgnosticAvailabilityKind::Unavailable;
         break;
 
       case IsInvalid:
@@ -942,7 +942,7 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
                                         Introduced,
                                         Deprecated,
                                         Obsoleted,
-                                        Unconditional,
+                                        PlatformAgnostic,
                                         /*Implicit=*/false));
       } else {
         // Not a known platform. Just drop the attribute.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -740,7 +740,7 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
       //  @available(iOS, introduced: 8.0)
       //  @available(OSX, introduced: 10.10)
       for (auto *Spec : Specs) {
-        auto *VersionSpec = dyn_cast<VersionConstraintAvailabilitySpec>(Spec);
+        auto *VersionSpec = dyn_cast<PlatformVersionConstraintAvailabilitySpec>(Spec);
         if (!VersionSpec)
           continue;
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -739,20 +739,45 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
       // we will synthesize:
       //  @available(iOS, introduced: 8.0)
       //  @available(OSX, introduced: 10.10)
+      //
+      // Similarly if we have a language version spec in the spec
+      // list, create an implicit AvailableAttr with the specified
+      // version as the introduced argument. For example, if we have
+      //   @available(swift 3.1)
+      // we will synthesize
+      //   @available(swift, introduced: 3.1)
+
       for (auto *Spec : Specs) {
-        auto *VersionSpec = dyn_cast<PlatformVersionConstraintAvailabilitySpec>(Spec);
-        if (!VersionSpec)
+        PlatformKind Platform;
+        clang::VersionTuple Version;
+        PlatformAgnosticAvailabilityKind PlatformAgnostic;
+
+        if (auto *PlatformVersionSpec =
+            dyn_cast<PlatformVersionConstraintAvailabilitySpec>(Spec)) {
+          Platform = PlatformVersionSpec->getPlatform();
+          Version = PlatformVersionSpec->getVersion();
+          PlatformAgnostic = PlatformAgnosticAvailabilityKind::None;
+
+        } else if (auto *LanguageVersionSpec =
+                   dyn_cast<LanguageVersionConstraintAvailabilitySpec>(Spec)) {
+          Platform = PlatformKind::none;
+          Version = LanguageVersionSpec->getVersion();
+          PlatformAgnostic =
+            PlatformAgnosticAvailabilityKind::SwiftVersionSpecific;
+
+        } else {
           continue;
+        }
 
         Attributes.add(new (Context)
                        AvailableAttr(AtLoc, AttrRange,
-                                     VersionSpec->getPlatform(),
+                                     Platform,
                                      /*Message=*/StringRef(),
                                      /*Renamed=*/StringRef(),
-                                     /*Introduced=*/VersionSpec->getVersion(),
+                                     /*Introduced=*/Version,
                                      /*Deprecated=*/clang::VersionTuple(),
                                      /*Obsoleted=*/clang::VersionTuple(),
-                                     PlatformAgnosticAvailabilityKind::None,
+                                     PlatformAgnostic,
                                      /*Implicit=*/true));
       }
 
@@ -934,6 +959,22 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
 
     if (!DiscardAttribute) {
       auto PlatformKind = platformFromString(Platform);
+
+      // Treat 'swift' as a valid version-qualifying token, when
+      // at least some versions were mentioned and no other
+      // platform-agnostic availability spec has been provided.
+      bool SomeVersion = (!Introduced.empty() ||
+                          !Deprecated.empty() ||
+                          !Obsoleted.empty());
+      if (!PlatformKind.hasValue() &&
+          Platform == "swift" &&
+          SomeVersion &&
+          PlatformAgnostic == PlatformAgnosticAvailabilityKind::None) {
+        PlatformKind = PlatformKind::none;
+        PlatformAgnostic =
+          PlatformAgnosticAvailabilityKind::SwiftVersionSpecific;
+      }
+
       if (PlatformKind.hasValue()) {
         Attributes.add(new (Context)
                        AvailableAttr(AtLoc, AttrRange,

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2984,7 +2984,7 @@ ParserResult<AvailabilitySpec> Parser::parseAvailabilitySpec() {
 ///
 ///  version-constraint-spec:
 ///     identifier version-comparison version-tuple
-ParserResult<VersionConstraintAvailabilitySpec>
+ParserResult<PlatformVersionConstraintAvailabilitySpec>
 Parser::parseVersionConstraintSpec() {
   Identifier PlatformIdentifier;
   SourceLoc PlatformLoc;
@@ -3024,7 +3024,7 @@ Parser::parseVersionConstraintSpec() {
     return nullptr;
   }
 
-  return makeParserResult(new (Context) VersionConstraintAvailabilitySpec(
+  return makeParserResult(new (Context) PlatformVersionConstraintAvailabilitySpec(
       Platform.getValue(), PlatformLoc, Version, VersionRange));
 }
 

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1047,7 +1047,7 @@ static void validateAvailabilitySpecList(Parser &P,
       continue;
     }
 
-    auto *VersionSpec = cast<VersionConstraintAvailabilitySpec>(Spec);
+    auto *VersionSpec = cast<PlatformVersionConstraintAvailabilitySpec>(Spec);
     bool Inserted = Platforms.insert(VersionSpec->getPlatform()).second;
     if (!Inserted) {
       // Rule out multiple version specs referring to the same platform.

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1041,9 +1041,24 @@ static void validateAvailabilitySpecList(Parser &P,
                                          ArrayRef<AvailabilitySpec *> Specs) {
   llvm::SmallSet<PlatformKind, 4> Platforms;
   bool HasOtherPlatformSpec = false;
+
+  if (Specs.size() == 1 &&
+      isa<LanguageVersionConstraintAvailabilitySpec>(Specs[0])) {
+    // @avalable(swift N) is allowed only in isolation; it cannot
+    // be combined with other availability specs in a single list.
+    return;
+  }
+
   for (auto *Spec : Specs) {
     if (isa<OtherPlatformAvailabilitySpec>(Spec)) {
       HasOtherPlatformSpec = true;
+      continue;
+    }
+
+    if (auto *LangSpec =
+        dyn_cast<LanguageVersionConstraintAvailabilitySpec>(Spec)) {
+      P.diagnose(LangSpec->getSwiftLoc(),
+                 diag::availability_swift_must_occur_alone);
       continue;
     }
 
@@ -1081,6 +1096,15 @@ ParserResult<PoundAvailableInfo> Parser::parseStmtConditionPoundAvailable() {
 
   SmallVector<AvailabilitySpec *, 5> Specs;
   ParserStatus Status = parseAvailabilitySpecList(Specs);
+
+  for (auto *Spec : Specs) {
+    if (auto *Lang =
+        dyn_cast<LanguageVersionConstraintAvailabilitySpec>(Spec)) {
+      diagnose(Lang->getSwiftLoc(),
+               diag::pound_available_swift_not_allowed);
+      Status.setIsParseError();
+    }
+  }
 
   SourceLoc RParenLoc;
   if (parseMatchingToken(tok::r_paren, RParenLoc,

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1867,9 +1867,10 @@ bool TypeChecker::diagnoseExplicitUnavailability(
                              newName);
         attachRenameFixIts(diag);
       } else {
+        EncodedDiagnosticMessage EncodedMessage(Attr->Message);
         auto diag = diagnose(Loc, diag::availability_decl_unavailable_rename_msg,
                              Name, replaceKind.hasValue(), rawReplaceKind,
-                             newName, Attr->Message);
+                             newName, EncodedMessage.Message);
         attachRenameFixIts(diag);
       }
     } else if (Attr->Message.empty()) {
@@ -2131,7 +2132,6 @@ private:
   }
 };
 }
-
 
 /// Diagnose uses of unavailable declarations. Returns true if a diagnostic
 /// was emitted.

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1842,16 +1842,16 @@ bool TypeChecker::diagnoseExplicitUnavailability(
   SourceLoc Loc = R.Start;
   auto Name = D->getFullName();
 
-  switch (Attr->getUnconditionalAvailability()) {
-  case UnconditionalAvailabilityKind::Deprecated:
+  switch (Attr->getPlatformAgnosticAvailability()) {
+  case PlatformAgnosticAvailabilityKind::Deprecated:
     break;
 
-  case UnconditionalAvailabilityKind::None:
-  case UnconditionalAvailabilityKind::Unavailable:
-  case UnconditionalAvailabilityKind::UnavailableInCurrentSwift:
-  case UnconditionalAvailabilityKind::UnavailableInSwift: {
-    bool inSwift = (Attr->getUnconditionalAvailability() ==
-                    UnconditionalAvailabilityKind::UnavailableInSwift);
+  case PlatformAgnosticAvailabilityKind::None:
+  case PlatformAgnosticAvailabilityKind::Unavailable:
+  case PlatformAgnosticAvailabilityKind::SwiftVersionSpecific:
+  case PlatformAgnosticAvailabilityKind::UnavailableInSwift: {
+    bool inSwift = (Attr->getPlatformAgnosticAvailability() ==
+                    PlatformAgnosticAvailabilityKind::UnavailableInSwift);
 
     if (!Attr->Rename.empty()) {
       SmallString<32> newNameBuf;

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -93,6 +93,17 @@ void fixItEncloseTrailingClosure(TypeChecker &TC,
                                  InFlightDiagnostic &diag,
                                  const CallExpr *call,
                                  Identifier closureLabel);
+
+/// Run the Availability-diagnostics algorithm otherwise used in an expr
+/// context, but for non-expr contexts such as TypeDecls referenced from
+/// TypeReprs.
+bool diagnoseDeclAvailability(const ValueDecl *Decl,
+                              TypeChecker &TC,
+                              DeclContext *DC,
+                              SourceRange R,
+                              bool AllowPotentiallyUnavailableProtocol,
+                              bool SignalOnPotentialUnavailability);
+
 } // namespace swift
 
 #endif // SWIFT_SEMA_MISC_DIAGNOSTICS_H

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1297,16 +1297,16 @@ static bool checkTypeDeclAvailability(const TypeDecl *TypeDecl,
 
   if (auto CI = dyn_cast<ComponentIdentTypeRepr>(IdType)) {
     if (auto Attr = AvailableAttr::isUnavailable(TypeDecl)) {
-      switch (Attr->getUnconditionalAvailability()) {
-      case UnconditionalAvailabilityKind::None:
-      case UnconditionalAvailabilityKind::Deprecated:
+      switch (Attr->getPlatformAgnosticAvailability()) {
+      case PlatformAgnosticAvailabilityKind::None:
+      case PlatformAgnosticAvailabilityKind::Deprecated:
         break;
 
-      case UnconditionalAvailabilityKind::Unavailable:
-      case UnconditionalAvailabilityKind::UnavailableInCurrentSwift:
-      case UnconditionalAvailabilityKind::UnavailableInSwift: {
-        bool inSwift = (Attr->getUnconditionalAvailability() ==
-                        UnconditionalAvailabilityKind::UnavailableInSwift);
+      case PlatformAgnosticAvailabilityKind::Unavailable:
+      case PlatformAgnosticAvailabilityKind::SwiftVersionSpecific:
+      case PlatformAgnosticAvailabilityKind::UnavailableInSwift: {
+        bool inSwift = (Attr->getPlatformAgnosticAvailability() ==
+                        PlatformAgnosticAvailabilityKind::UnavailableInSwift);
 
         if (!Attr->Rename.empty()) {
           auto diag = TC.diagnose(Loc,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1288,75 +1288,15 @@ static Type resolveIdentTypeComponent(
                                          unsatisfiedDependency);
 }
 
-// FIXME: Merge this with diagAvailability in MiscDiagnostics.cpp.
 static bool checkTypeDeclAvailability(const TypeDecl *TypeDecl,
                                       IdentTypeRepr *IdType,
                                       SourceLoc Loc, DeclContext *DC,
                                       TypeChecker &TC,
                                       bool AllowPotentiallyUnavailableProtocol){
-
-  if (auto CI = dyn_cast<ComponentIdentTypeRepr>(IdType)) {
-    if (auto Attr = AvailableAttr::isUnavailable(TypeDecl)) {
-      switch (Attr->getPlatformAgnosticAvailability()) {
-      case PlatformAgnosticAvailabilityKind::None:
-      case PlatformAgnosticAvailabilityKind::Deprecated:
-        break;
-
-      case PlatformAgnosticAvailabilityKind::Unavailable:
-      case PlatformAgnosticAvailabilityKind::SwiftVersionSpecific:
-      case PlatformAgnosticAvailabilityKind::UnavailableInSwift: {
-        bool inSwift = (Attr->getPlatformAgnosticAvailability() ==
-                        PlatformAgnosticAvailabilityKind::UnavailableInSwift);
-
-        if (!Attr->Rename.empty()) {
-          auto diag = TC.diagnose(Loc,
-                                  diag::availability_decl_unavailable_rename,
-                                  CI->getIdentifier(), /*"replaced"*/false,
-                                  /*special kind*/0, Attr->Rename);
-          fixItAvailableAttrRename(TC, diag, Loc, TypeDecl, Attr,
-                                   /*call*/nullptr);
-        } else if (Attr->Message.empty()) {
-          TC.diagnose(Loc,
-                      inSwift ? diag::availability_decl_unavailable_in_swift
-                              : diag::availability_decl_unavailable,
-                      CI->getIdentifier())
-            .highlight(Loc);
-        } else {
-          EncodedDiagnosticMessage EncodedMessage(Attr->Message);
-          TC.diagnose(Loc,
-                      inSwift ? diag::availability_decl_unavailable_in_swift_msg
-                              : diag::availability_decl_unavailable_msg,
-                      CI->getIdentifier(), EncodedMessage.Message)
-            .highlight(Loc);
-        }
-        break;
-      }
-      }
-
-      auto DLoc = TypeDecl->getLoc();
-      if (DLoc.isValid())
-        TC.diagnose(DLoc, diag::availability_marked_unavailable,
-                    CI->getIdentifier()).highlight(Attr->getRange());
-      return true;
-    }
-
-    TC.diagnoseIfDeprecated(CI->getSourceRange(), DC, TypeDecl,
-                            /*call, N/A*/nullptr);
-    
-    if (AllowPotentiallyUnavailableProtocol && isa<ProtocolDecl>(TypeDecl))
-      return false;
-
-    // Check for potential unavailability because of the minimum
-    // deployment version.
-    // We should probably unify this checking for deployment-version API
-    // unavailability with checking for explicitly annotated unavailability.
-    Optional<UnavailabilityReason> Unavail =
-        TC.checkDeclarationAvailability(TypeDecl, Loc, DC);
-    if (Unavail.hasValue()) {
-      TC.diagnosePotentialUnavailability(TypeDecl, CI->getIdentifier(),
-                                         CI->getSourceRange(), DC,
-                                         Unavail.getValue());
-    }
+  if (isa<ComponentIdentTypeRepr>(IdType)) {
+    return diagnoseDeclAvailability(TypeDecl, TC, DC, Loc,
+                                    AllowPotentiallyUnavailableProtocol,
+                                    false);
   }
 
   return false;

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -1383,7 +1383,7 @@ private:
         continue;
       }
 
-      auto *VersionSpec = dyn_cast<VersionConstraintAvailabilitySpec>(Spec);
+      auto *VersionSpec = dyn_cast<PlatformVersionConstraintAvailabilitySpec>(Spec);
       if (!VersionSpec)
         continue;
 
@@ -1407,7 +1407,7 @@ private:
       return AvailabilityContext::alwaysAvailable();
     }
 
-    auto *VersionSpec = cast<VersionConstraintAvailabilitySpec>(Spec);
+    auto *VersionSpec = cast<PlatformVersionConstraintAvailabilitySpec>(Spec);
     return AvailabilityContext(VersionRange::allGTE(VersionSpec->getVersion()));
   }
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2034,19 +2034,25 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
         DECODE_VER_TUPLE(Deprecated)
         DECODE_VER_TUPLE(Obsoleted)
 
-        UnconditionalAvailabilityKind unconditional;
+        PlatformAgnosticAvailabilityKind platformAgnostic;
         if (isUnavailable)
-          unconditional = UnconditionalAvailabilityKind::Unavailable;
+          platformAgnostic = PlatformAgnosticAvailabilityKind::Unavailable;
         else if (isDeprecated)
-          unconditional = UnconditionalAvailabilityKind::Deprecated;
+          platformAgnostic = PlatformAgnosticAvailabilityKind::Deprecated;
+        else if (((PlatformKind)platform) == PlatformKind::none &&
+                 (!Introduced.empty() ||
+                  !Deprecated.empty() ||
+                  !Obsoleted.empty()))
+          platformAgnostic =
+            PlatformAgnosticAvailabilityKind::SwiftVersionSpecific;
         else
-          unconditional = UnconditionalAvailabilityKind::None;
+          platformAgnostic = PlatformAgnosticAvailabilityKind::None;
 
         Attr = new (ctx) AvailableAttr(
           SourceLoc(), SourceRange(),
           (PlatformKind)platform, message, rename,
           Introduced, Deprecated, Obsoleted,
-          unconditional, isImplicit);
+          platformAgnostic, isImplicit);
         break;
 
 #undef DEF_VER_TUPLE_PIECES

--- a/test/Parse/ConditionalCompilation/language_version_explicit.swift
+++ b/test/Parse/ConditionalCompilation/language_version_explicit.swift
@@ -1,6 +1,6 @@
-// RUN: %target-parse-verify-swift -swift-version 3
+// RUN: %target-parse-verify-swift -swift-version 4
 
-#if swift(>=3)
+#if swift(>=4)
   let w = 1
 #else
   // This shouldn't emit any diagnostics.

--- a/test/attr/Inputs/OldAndNew.swift
+++ b/test/attr/Inputs/OldAndNew.swift
@@ -1,0 +1,9 @@
+@available(swift, introduced: 3.0, obsoleted: 4.0)
+public func threeOnly() -> Int {
+  return 3
+}
+
+@available(swift, introduced: 4.0)
+public func fourOnly() -> Int {
+  return 4
+}

--- a/test/attr/attr_availability_swift.swift
+++ b/test/attr/attr_availability_swift.swift
@@ -1,0 +1,22 @@
+// RUN: %target-parse-verify-swift
+
+@available(swift 3.0)
+func foo() {
+}
+
+@available(swift 3.0, iOS 10, *) // expected-error {{version-availability must be specified alone}}
+func bar() {
+}
+
+func baz() {
+  if #available(swift 4) { // expected-error {{Swift language version checks not allowed in #available}}
+                           // expected-error @-1 {{condition required for target platform}}
+    print("yes")
+  } else {
+    print("no")
+  }
+}
+
+@available(swift, introduced: 3.0.1, obsoleted: 3.0.2, message: "tiny bug")
+func bug() {
+}

--- a/test/attr/attr_availability_swift_deserialize.swift
+++ b/test/attr/attr_availability_swift_deserialize.swift
@@ -1,0 +1,14 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/OldAndNew.swiftmodule -module-name OldAndNew %S/Inputs/OldAndNew.swift 
+// RUN: not %target-swift-frontend -parse -I %t -swift-version 3.0 %s 2>&1 | %FileCheck -check-prefix THREE %s
+// RUN: not %target-swift-frontend -parse -I %t -swift-version 4.0 %s 2>&1 | %FileCheck -check-prefix FOUR %s
+
+import OldAndNew
+
+// THREE: 'fourOnly()' is unavailable
+// THREE: 'fourOnly()' was introduced in Swift 4.0
+let _ = fourOnly()
+
+// FOUR: 'threeOnly()' is unavailable
+// FOUR: 'threeOnly()' was obsoleted in Swift 4.0
+let _ = threeOnly()

--- a/test/attr/attr_availability_swift_v3.swift
+++ b/test/attr/attr_availability_swift_v3.swift
@@ -1,0 +1,61 @@
+// RUN: %target-parse-verify-swift -swift-version 3 %s
+
+@available(swift 3)
+func swiftShortThree() {}
+
+@available(swift 3.0)
+func swiftShortThreePointOh() {}
+
+@available(swift, introduced: 3.0)
+func swiftThreePointOh() {}
+
+@available(swift, introduced: 3.0, obsoleted: 4.0)
+func swiftThreePointOhOnly() {}
+
+@available(swift, deprecated: 3.0)
+func swiftDeprecatedThreePointOh() {}
+
+@available(swift, obsoleted: 3.0)
+func swiftObsoletedThreePointOh() {} // expected-note {{was obsoleted in Swift 3.0}}
+
+@available(swift, introduced: 3, obsoleted: 4.0)
+class SwiftThreeOnly {}
+
+@available(swift 4)
+func swiftShortFour() {} // expected-note {{was introduced in Swift 4}}
+
+@available(swift 4.0)
+func swiftShortFourPointOh() {} // expected-note {{was introduced in Swift 4.0}}
+
+@available(swift, introduced: 4)
+func swiftFour() {} // expected-note {{was introduced in Swift 4}}
+
+@available(swift, introduced: 4.0)
+func swiftFourPointOh() {} // expected-note {{was introduced in Swift 4.0}}
+
+@available(swift, introduced: 4.0, message: "uses abc")
+func swiftFourPointOhWithMessage() {} // expected-note {{was introduced in Swift 4.0}}
+
+@available(swift 4)
+class SwiftShortFour {} // expected-note {{was introduced in Swift 4}}
+
+@available(swift, introduced: 4, message: "uses pqr")
+class SwiftFourWithMessage {} // expected-note {{was introduced in Swift 4}}
+
+
+swiftShortThree()
+swiftShortThreePointOh()
+swiftThreePointOh()
+swiftThreePointOhOnly()
+swiftDeprecatedThreePointOh() // expected-warning {{is deprecated}}
+swiftObsoletedThreePointOh() // expected-error {{is unavailable}}
+let a : SwiftThreeOnly
+
+
+swiftShortFour() // expected-error {{is unavailable}}
+swiftShortFourPointOh() // expected-error {{is unavailable}}
+swiftFour() // expected-error {{is unavailable}}
+swiftFourPointOh() // expected-error {{is unavailable}}
+swiftFourPointOhWithMessage() // expected-error {{is unavailable: uses abc}}
+let aa : SwiftShortFour // expected-error {{is unavailable}}
+let bb : SwiftFourWithMessage // expected-error {{is unavailable: uses pqr}}

--- a/test/attr/attr_availability_swift_v4.swift
+++ b/test/attr/attr_availability_swift_v4.swift
@@ -1,0 +1,58 @@
+// RUN: %target-parse-verify-swift -swift-version 4 %s
+
+@available(swift 3)
+func swiftShortThree() {}
+
+@available(swift 3.0)
+func swiftShortThreePointOh() {}
+
+@available(swift, introduced: 3.0)
+func swiftThreePointOh() {}
+
+@available(swift, introduced: 3.0, obsoleted: 4.0)
+func swiftThreePointOhOnly() {} // expected-note {{was obsoleted in Swift 4.0}}
+
+@available(swift, deprecated: 3.0)
+func swiftDeprecatedThreePointOh() {}
+
+@available(swift, obsoleted: 3.0)
+func swiftObsoletedThreePointOh() {} // expected-note {{was obsoleted in Swift 3.0}}
+
+@available(swift, introduced: 3.0, obsoleted: 4.0)
+class SwiftThreePointOhOnly {} // expected-note {{was obsoleted in Swift 4.0}}
+
+@available(swift, introduced: 3, obsoleted: 4, message: "uses abc")
+class SwiftThreeOnlyWithMessage {} // expected-note {{was obsoleted in Swift 4}}
+
+
+@available(swift 4)
+func swiftShortFour() {}
+
+@available(swift 4.0)
+func swiftShortFourPointOh() {}
+
+@available(swift, introduced: 4)
+func swiftFour() {}
+
+@available(swift, introduced: 4.0)
+func swiftFourPointOh() {}
+
+@available(swift 4)
+class SwiftShortFour {}
+
+
+swiftShortThree()
+swiftShortThreePointOh()
+swiftThreePointOh()
+swiftThreePointOhOnly() // expected-error {{is unavailable}}
+swiftDeprecatedThreePointOh() // expected-warning {{is deprecated}}
+swiftObsoletedThreePointOh() // expected-error {{is unavailable}}
+let a : SwiftThreePointOhOnly // expected-error {{is unavailable}}
+let b : SwiftThreeOnlyWithMessage // expected-error {{is unavailable: uses abc}}
+
+
+swiftShortFour()
+swiftShortFourPointOh()
+swiftFour()
+swiftFourPointOh()
+let aa : SwiftShortFour


### PR DESCRIPTION
This PR addresses SR-2709, and corresponds to the proposal currently under review in
https://lists.swift.org/pipermail/swift-evolution-announce/2016-September/000286.html

It's a relatively minor extension to the `@available(...)` system to permit availability testing
by swift language version. A companion to the previous PR #4826 that enables command-line
backwards compatibility adjustment of the compiler's effective language version.

I'm posting here for implementation review; it should not be merged until the evolution proposal
has been reviewed and approved by the community. I'll amend here to track any changes that
come up during that discussion.

Resolves [SR-2709](https://bugs.swift.org/browse/SR-2709).
