### PR TITLE
Always ensure that we generate code for referenced transparent functi…

### DIFF
--- a/test/SILOptimizer/no_external_def_to_decl_for_transparent.sil
+++ b/test/SILOptimizer/no_external_def_to_decl_for_transparent.sil
@@ -1,0 +1,39 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -external-func-definition-elim | %FileCheck %s 
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+
+public class X {
+  func testit() -> () -> ()
+  deinit
+  init()
+}
+
+// Check if we keep the body of the externally available transparent function.
+
+// CHECK-LABEL: sil public_external [transparent] [fragile] @imported_transparent_func : $@convention(thin) () -> () {
+sil public_external [transparent] [fragile] @imported_transparent_func : $@convention(thin) () -> () {
+bb0:
+  %r = tuple ()
+  return %r : $()
+}
+
+
+sil private @_TFC4test1X6testitfT_FT_T_  : $@convention(method) (@guaranteed X) -> @owned @callee_owned () -> () {
+bb0(%0 : $X):
+  %6 = function_ref @imported_transparent_func : $@convention(thin) () -> ()
+  %7 = thin_to_thick_function %6 : $@convention(thin) () -> () to $@callee_owned () -> ()
+  return %7 : $@callee_owned () -> ()
+}
+
+sil @_TFC4test1XD : $@convention(method) (@owned X) -> ()
+
+sil_vtable X {
+  #X.testit!1: _TFC4test1X6testitfT_FT_T_
+  #X.deinit!deallocator: _TFC4test1XD
+}
+


### PR DESCRIPTION
…ons.

We didn't do this if the transparent function was only reachable via a vtable/witness table.

rdar://problem/28294466
