### PR TITLE
Update more switch statements for recent Clang/LLVM update.

### DIFF
--- a/lib/ClangImporter/ClangAdapter.cpp
+++ b/lib/ClangImporter/ClangAdapter.cpp
@@ -337,6 +337,7 @@ OmissionTypeName importer::getClangTypeNameForOmission(clang::ASTContext &ctx,
     // FIXME: Types that can be mapped, but aren't yet.
     case clang::BuiltinType::Half:
     case clang::BuiltinType::LongDouble:
+    case clang::BuiltinType::Float128:
     case clang::BuiltinType::NullPtr:
       return OmissionTypeName();
 

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -539,6 +539,8 @@ namespace {
         return convertFloatingType(Ctx.getTargetInfo().getDoubleFormat());
       case clang::BuiltinType::LongDouble:
         return convertFloatingType(Ctx.getTargetInfo().getLongDoubleFormat());
+      case clang::BuiltinType::Float128:
+        return convertFloatingType(Ctx.getTargetInfo().getFloat128Format());
 
       // nullptr_t -> void*
       case clang::BuiltinType::NullPtr:


### PR DESCRIPTION
We still don't handle __float128, so no functionality change.
