### PR TITLE
[3.0] [build-script] Add clang PGO support

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -784,6 +784,12 @@ class BuildScriptInvocation(object):
         if args.dry_run:
             impl_args += ["--dry-run"]
 
+        if args.clang_profile_instr_use:
+            impl_args += [
+                "--clang-profile-instr-use=%s" %
+                os.path.abspath(args.clang_profile_instr_use)
+            ]
+
         if args.lit_args:
             impl_args += ["--llvm-lit-args=%s" % args.lit_args]
 
@@ -1921,6 +1927,11 @@ details of the setups of other systems or automated environments.""")
         default=None,
         const='full',
         dest='lto_type')
+
+    parser.add_argument(
+        "--clang-profile-instr-use",
+        help="profile file to use for clang PGO",
+        metavar="PATH")
 
     default_max_lto_link_job_counts = host.max_lto_link_job_counts()
     parser.add_argument(

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -225,6 +225,7 @@ KNOWN_SETTINGS=(
     only-execute                       "all"     "Only execute the named action (see implementation)"
     llvm-lit-args                      ""        "If set, override the lit args passed to LLVM"
     llvm-targets-to-build              "X86;ARM;AArch64;PowerPC;SystemZ" "The code generators that LLVM should build"
+    clang-profile-instr-use            ""        "If set, profile file to use for clang PGO"
     build-toolchain-only               ""        "If set, only build the necessary tools to build an external toolchain"
 )
 
@@ -785,6 +786,12 @@ function set_build_options_for_host() {
         )
         swift_cmake_options+=(
             -DLLVM_LIT_ARGS="${LLVM_LIT_ARGS}"
+        )
+    fi
+
+    if [[ "${CLANG_PROFILE_INSTR_USE}" ]]; then
+        llvm_cmake_options+=(
+            -DLLVM_PROFDATA_FILE="${CLANG_PROFILE_INSTR_USE}"
         )
     fi
 }


### PR DESCRIPTION
- Explanation: This allows build-script to build clang with PGO.
- Scope: Additive build-script change.
- Issue: rdar://problem/28458119
- Reviewed by: None
- Risk: Very low. Only additive.
- Testing: Tested manually.

(cherry picked from commit 0c3c02bdbd2f32ffe5443f60ba495612799c21d8)
