### PR TITLE
SILGen: Properly calculate substitutions to invoke _bridgeToObjectiveC.

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -17,6 +17,7 @@
 #include "swift/AST/AST.h"
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/ForeignErrorConvention.h"
+#include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/Basic/Fallthrough.h"
 #include "swift/SIL/SILArgument.h"
@@ -61,9 +62,50 @@ emitBridgeNativeToObjectiveC(SILGenFunction &gen,
   auto witnessFnTy = witnessRef->getType();
 
   // Compute the substitutions.
-  ArrayRef<Substitution> substitutions =
-      swiftValueType->gatherAllSubstitutions(
-          gen.SGM.SwiftModule, nullptr);
+  ArrayRef<Substitution> witnessSubstitutions = witness.getSubstitutions();
+  ArrayRef<Substitution> typeSubstitutions =
+      swiftValueType->gatherAllSubstitutions(gen.SGM.SwiftModule, nullptr);
+  
+  // FIXME: Methods of generic types don't have substitutions in their
+  // ConcreteDeclRefs for some reason. Furthermore,
+  // SubsitutedProtocolConformances don't substitute their witness
+  // ConcreteDeclRefs, so we need to do it ourselves.
+  ArrayRef<Substitution> substitutions;
+  SmallVector<Substitution, 4> substitutionsBuf;
+  if (typeSubstitutions.empty()) {
+    substitutions = witnessSubstitutions;
+  } else if (witnessSubstitutions.empty()) {
+    substitutions = typeSubstitutions;
+  } else {
+    // FIXME: The substitutions in a witness ConcreteDeclRef really ought to
+    // be interface types. Instead, we get archetypes from a generic environment
+    // that's either the extension method's generic environment, for a witness
+    // from a nominal extension, or the conforming type's original declaration
+    // generic environment, for a witness from a protocol extension.
+    auto swiftValueTypeDecl = swiftValueType->getAnyNominal();
+    GenericEnvironment *witnessEnv;
+    GenericSignature *witnessSig;
+    
+    if (witness.getDecl()->getDeclContext()->getDeclaredTypeOfContext()
+        ->isExistentialType()) {
+      witnessEnv = swiftValueTypeDecl->getGenericEnvironment();
+      witnessSig = swiftValueTypeDecl->getGenericSignature();
+    } else {
+      witnessEnv = witness.getDecl()->getDeclContext()
+        ->getGenericEnvironmentOfContext();
+      witnessSig = witness.getDecl()->getDeclContext()
+        ->getGenericSignatureOfContext();
+    }
+    
+    SubstitutionMap typeSubMap = witnessEnv
+      ->getSubstitutionMap(gen.SGM.SwiftModule,
+                           witnessSig,
+                           typeSubstitutions);
+    for (auto sub : witnessSubstitutions) {
+      substitutionsBuf.push_back(sub.subst(gen.SGM.SwiftModule, typeSubMap));
+    }
+    substitutions = substitutionsBuf;
+  }
 
   if (!substitutions.empty()) {
     // Substitute into the witness function type.

--- a/test/SILGen/objc_bridged_using_protocol_extension_impl.swift
+++ b/test/SILGen/objc_bridged_using_protocol_extension_impl.swift
@@ -1,0 +1,56 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen %s | %FileCheck %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+protocol Fooable {}
+
+extension Fooable where Self: _ObjectiveCBridgeable {
+  func _bridgeToObjectiveC() -> _ObjectiveCType {
+    fatalError()
+  }
+
+  static func _forceBridgeFromObjectiveC(
+    _ source: _ObjectiveCType,
+    result: inout Self?
+  ) {
+    fatalError()
+  }
+
+  static func _conditionallyBridgeFromObjectiveC(
+    _ source: _ObjectiveCType,
+    result: inout Self?
+  ) -> Bool {
+    fatalError()
+  }
+
+  static func _unconditionallyBridgeFromObjectiveC(_ source: _ObjectiveCType?)
+      -> Self {
+    fatalError()
+  }
+}
+
+struct Foo: Fooable, _ObjectiveCBridgeable {
+  typealias _ObjectiveCType = NSObject
+}
+struct Gen<T, U>: Fooable, _ObjectiveCBridgeable {
+  typealias _ObjectiveCType = NSObject
+}
+
+class Bar: NSObject {
+  dynamic func bar(_: Any) {}
+}
+
+// CHECK-LABEL: sil hidden @_TF42objc_bridged_using_protocol_extension_impl7callBarFT3barCS_3Bar3fooVS_3Foo_T_
+func callBar(bar: Bar, foo: Foo) {
+  // CHECK: [[BRIDGE:%.*]] = function_ref @_TFe42objc_bridged_using_protocol_extension_implRxs21_ObjectiveCBridgeablexS_7FooablerS1_19_bridgeToObjectiveCfT_wxPS0_15_ObjectiveCType
+  // CHECK: apply [[BRIDGE]]<Foo, NSObject>
+  bar.bar(foo)
+}
+
+// CHECK-LABEL:sil hidden @_TF42objc_bridged_using_protocol_extension_impl7callBarFT3barCS_3Bar3genGVS_3GenSiSS__T_ 
+func callBar(bar: Bar, gen: Gen<Int, String>) {
+  // CHECK: [[BRIDGE:%.*]] = function_ref @_TFe42objc_bridged_using_protocol_extension_implRxs21_ObjectiveCBridgeablexS_7FooablerS1_19_bridgeToObjectiveCfT_wxPS0_15_ObjectiveCType
+  // CHECK: apply [[BRIDGE]]<Gen<Int, String>, NSObject>
+  bar.bar(gen)
+}


### PR DESCRIPTION
The existing code assumed that the `_bridgeToObjectiveC` witness would never come from a protocol extension. Generating the correct set of substitutions is a bit harder than it ought to be, due to inconsistencies in how Sema represents generic witnesses. The right thing to do is probably to emit a `witness_method` invocation and let the specializer work out the underlying witness, but for now, get a minimal fix in place for 3.x. Fixes rdar://problem/28279269.
