### PR TITLE
[build-script-impl] Always add debug info flags from build-script for…

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -671,7 +671,12 @@ function set_build_options_for_host() {
                     )
                 fi
 
+                llvm_cmake_options+=(
+                    -DLLVM_ENABLE_MODULE_DEBUGGING:BOOL=NO
+                )
+
                 swift_cmake_options+=(
+                    -DLLVM_ENABLE_MODULE_DEBUGGING:BOOL=NO
                     "-DSWIFT_PARALLEL_LINK_JOBS=${SWIFT_TOOLS_NUM_PARALLEL_LTO_LINK_JOBS}"
                 )
             fi
@@ -1556,6 +1561,12 @@ function is_cmake_release_build_type() {
     fi
 }
 
+function is_cmake_debuginfo_build_type() {
+    if [[ "$1" == "Debug" || "$1" == "RelWithDebInfo" ]] ; then
+        echo 1
+    fi
+}
+
 function common_cross_c_flags() {
     echo -n "${COMMON_C_FLAGS}"
 
@@ -1598,8 +1609,12 @@ function llvm_c_flags() {
     if [[ $(is_cmake_release_build_type "${LLVM_BUILD_TYPE}") ]] ; then
         echo -n " -fno-stack-protector"
     fi
-    if [[ $(is_llvm_lto_enabled) == "TRUE" ]] ; then
-        echo -n " -gline-tables-only"
+    if [[ $(is_cmake_debuginfo_build_type "${LLVM_BUILD_TYPE}") ]] ; then
+        if [[ $(is_llvm_lto_enabled) == "TRUE" ]] ; then
+            echo -n " -gline-tables-only"
+        else
+            echo -n " -g"
+        fi
     fi
 }
 
@@ -1919,6 +1934,14 @@ for host in "${ALL_HOSTS[@]}"; do
                     "${cmake_options[@]}"
                     -DCMAKE_C_FLAGS="$(llvm_c_flags ${host})"
                     -DCMAKE_CXX_FLAGS="$(llvm_c_flags ${host})"
+                    -DCMAKE_C_FLAGS_DEBUG=""
+                    -DCMAKE_CXX_FLAGS_DEBUG=""
+                    -DCMAKE_C_FLAGS_RELEASE="-O3"
+                    -DCMAKE_CXX_FLAGS_RELEASE="-O3"
+                    -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2"
+                    -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2"
+                    -DCMAKE_C_FLAGS_MINSIZEREL="-Os"
+                    -DCMAKE_CXX_FLAGS_MINSIZEREL="-Os"
                     -DCMAKE_BUILD_TYPE:STRING="${LLVM_BUILD_TYPE}"
                     -DLLVM_TOOL_SWIFT_BUILD:BOOL=NO
                     -DLLVM_INCLUDE_DOCS:BOOL=TRUE
@@ -2032,6 +2055,14 @@ for host in "${ALL_HOSTS[@]}"; do
                     "${cmake_options[@]}"
                     -DCMAKE_C_FLAGS="$(swift_c_flags ${host})"
                     -DCMAKE_CXX_FLAGS="$(swift_c_flags ${host})"
+                    -DCMAKE_C_FLAGS_DEBUG=""
+                    -DCMAKE_CXX_FLAGS_DEBUG=""
+                    -DCMAKE_C_FLAGS_RELEASE="-O3"
+                    -DCMAKE_CXX_FLAGS_RELEASE="-O3"
+                    -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2"
+                    -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2"
+                    -DCMAKE_C_FLAGS_MINSIZEREL="-Os"
+                    -DCMAKE_CXX_FLAGS_MINSIZEREL="-Os"
                     -DCMAKE_BUILD_TYPE:STRING="${SWIFT_BUILD_TYPE}"
                     -DLLVM_ENABLE_ASSERTIONS:BOOL=$(true_false "${SWIFT_ENABLE_ASSERTIONS}")
                     -DSWIFT_ANALYZE_CODE_COVERAGE:STRING=$(toupper "${SWIFT_ANALYZE_CODE_COVERAGE}")

--- a/validation-test/LTO/lto-object-files-only-have-line-tables.test-sh
+++ b/validation-test/LTO/lto-object-files-only-have-line-tables.test-sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# This test makes sure that if lto is enabled:
+#
+# 1. We have lto object files for swift in our build tree. We swift and libswiftdemangle.
+# 2. These lto output files all have line tables in the swift include directory,
+#    but do not have full debug info. To check for the latter case, we look for
+#    SmallVector a commonly used data type.
+# 3. We use swift-demangle since it is a much smaller executable than all of
+#    swift.
+
+set -e
+set -u
+
+# REQUIRES: lto
+# REQUIRES: OS=macosx
+# REQUIRES: tools-debuginfo
+# RUN: rm -rf %t
+# RUN: mkdir -p %t
+# RUN: %s %swift_obj_root %t %llvm-dwarfdump
+
+OBJECT_ROOT=$1
+TEMP_DIR=$2
+DWARFDUMP=$3
+
+SWIFT_DEMANGLE_LTO_OBJECT_FILE=$(find ${OBJECT_ROOT} -path '*/swift-demangle/swift-demangle*-lto.o' | head -1)
+
+# Check that we have a temporary lto file for swift.
+if [[ -z "${SWIFT_DEMANGLE_LTO_OBJECT_FILE}" ]]; then
+   echo "Failed to find a temporary debug file for swift-demangle?!"
+   exit 1
+else
+    echo "Found swift-demangle LTO object!"
+fi
+
+${DWARFDUMP} -debug-dump=line ${SWIFT_DEMANGLE_LTO_OBJECT_FILE} > ${TEMP_DIR}/line.info
+
+# Make sure that we found a line table.
+if [[ -z "$(sed -n "/include_directories.*=.*include\/swift/{p;q;}" ${TEMP_DIR}/line.info)" ]] ; then
+  echo "Failed to find line table information for swift-demangle?!"
+  exit 1
+else
+  echo "Found line table information for swift-demangle in swift LTO object"
+fi
+
+${DWARFDUMP} -debug-dump=apple_types ${SWIFT_DEMANGLE_LTO_OBJECT_FILE} > ${TEMP_DIR}/types.info
+
+# And that it does not have full debug info
+if [[ -n "$(sed -n '/Name:.*SmallVector<..*>/{p;q;}' ${TEMP_DIR}/types.info)" ]] ; then
+  echo "Found full debug info in the swift-demangle lto object?!"
+  exit 1
+else
+  echo "Did not find full debug info for swift-demangle lto object!"
+fi
+
+echo "The swift-demangle binary only has line table debug info!"
+
+set +u
+set +e

--- a/validation-test/lit.site.cfg.in
+++ b/validation-test/lit.site.cfg.in
@@ -48,6 +48,10 @@ if "@LLVM_ENABLE_ASSERTIONS@" == "TRUE":
 else:
     config.available_features.add('no_asserts')
 
+# If tools have debug info, set the tools-debuginfo flag.
+if "@CMAKE_BUILD_TYPE@" in ["Debug", "RelWithDebInfo"]:
+    config.available_features.add('tools-debuginfo')
+
 if "@SWIFT_STDLIB_ASSERTIONS@" == "TRUE":
     config.available_features.add('swift_stdlib_asserts')
 else:


### PR DESCRIPTION
This patch ensures that -g flags do not sneak into any command lines via CMAKE_C_FLAGS_${BUILD_TYPE}. We will always control such debug flags via CMAKE_C_FLAGS itself.

This ensures that multiple debug info command line arguments will not be placed on the command line (causing the last one to win).

The reason why we care about this is that we found that when compiling with lto we were having a slow build since we were using the full debug info by mistake since -g and -gline-tables-only were both being passed in when compiling.
