### PR TITLE
Fix swift tests to work with in-tree LLDB

### DIFF
--- a/test/Driver/options-repl-darwin.swift
+++ b/test/Driver/options-repl-darwin.swift
@@ -4,14 +4,15 @@
 // like the Xcode installation environment. We use hard links to make sure
 // the Swift driver really thinks it's been moved.
 
-// RUN: %swift_driver -repl -### | %FileCheck -check-prefix=INTEGRATED %s
-// RUN: %swift_driver -### | %FileCheck -check-prefix=INTEGRATED %s
-
 // RUN: rm -rf %t
 // RUN: mkdir -p %t/usr/bin/
+// RUN: %hardlink-or-copy(from: %swift_driver_plain, to: %t/usr/bin/swift)
+
+// RUN: %t/usr/bin/swift -repl -### | %FileCheck -check-prefix=INTEGRATED %s
+// RUN: %t/usr/bin/swift -### | %FileCheck -check-prefix=INTEGRATED %s
+
 // RUN: touch %t/usr/bin/lldb
 // RUN: chmod +x %t/usr/bin/lldb
-// RUN: %hardlink-or-copy(from: %swift_driver_plain, to: %t/usr/bin/swift)
 // RUN: %t/usr/bin/swift -repl -### | %FileCheck -check-prefix=LLDB %s
 // RUN: %t/usr/bin/swift -### | %FileCheck -check-prefix=LLDB %s
 

--- a/test/Driver/options-repl.swift
+++ b/test/Driver/options-repl.swift
@@ -5,8 +5,11 @@
 
 // REPL_NO_FILES: REPL mode requires no input files
 
+// RUN: rm -rf %t
+// RUN: mkdir -p %t/usr/bin
+// RUN: %hardlink-or-copy(from: %swift_driver_plain, to: %t/usr/bin/swift)
 
-// RUN: %swift_driver -deprecated-integrated-repl -### | %FileCheck -check-prefix=INTEGRATED %s
+// RUN: %t/usr/bin/swift -deprecated-integrated-repl -### | %FileCheck -check-prefix=INTEGRATED %s
 
 // INTEGRATED: swift -frontend -repl
 // INTEGRATED: -module-name REPL
@@ -38,13 +41,10 @@
 // like the Xcode installation environment. We use hard links to make sure
 // the Swift driver really thinks it's been moved.
 
-// RUN: %swift_driver -repl -### | %FileCheck -check-prefix=INTEGRATED %s
-// RUN: %swift_driver -### | %FileCheck -check-prefix=INTEGRATED %s
+// RUN: %t/usr/bin/swift -repl -### | %FileCheck -check-prefix=INTEGRATED %s
+// RUN: %t/usr/bin/swift -### | %FileCheck -check-prefix=INTEGRATED %s
 
-// RUN: rm -rf %t
-// RUN: mkdir -p %t/usr/bin/
 // RUN: touch %t/usr/bin/lldb
 // RUN: chmod +x %t/usr/bin/lldb
-// RUN: %hardlink-or-copy(from: %swift_driver_plain, to: %t/usr/bin/swift)
 // RUN: %t/usr/bin/swift -repl -### | %FileCheck -check-prefix=LLDB %s
 // RUN: %t/usr/bin/swift -### | %FileCheck -check-prefix=LLDB %s

--- a/test/Driver/subcommands.swift
+++ b/test/Driver/subcommands.swift
@@ -2,9 +2,13 @@
 //
 // REQUIRES: swift_interpreter
 //
-// RUN: %swift_driver_plain -### 2>&1 | %FileCheck -check-prefix=CHECK-SWIFT-INVOKES-REPL %s
-// RUN: %swift_driver_plain run -### 2>&1 | %FileCheck -check-prefix=CHECK-SWIFT-INVOKES-REPL %s
-// RUN: %swift_driver_plain repl -### 2>&1 | %FileCheck -check-prefix=CHECK-SWIFT-INVOKES-REPL %s
+// RUN: rm -rf %t.dir
+// RUN: mkdir -p %t.dir/usr/bin
+// RUN: %hardlink-or-copy(from: %swift_driver_plain, to: %t.dir/usr/bin/swift)
+
+// RUN: %t.dir/usr/bin/swift -### 2>&1 | %FileCheck -check-prefix=CHECK-SWIFT-INVOKES-REPL %s
+// RUN: %t.dir/usr/bin/swift run -### 2>&1 | %FileCheck -check-prefix=CHECK-SWIFT-INVOKES-REPL %s
+// RUN: %t.dir/usr/bin/swift repl -### 2>&1 | %FileCheck -check-prefix=CHECK-SWIFT-INVOKES-REPL %s
 //
 // CHECK-SWIFT-INVOKES-REPL: {{.*}}/swift -frontend -repl
 
@@ -13,7 +17,6 @@
 // (for shebang line use). We have to run these since we can't get the driver to
 // dump what it is doing and test the argv[1] processing.
 //
-// RUN: rm -rf %t.dir
 // RUN: mkdir -p %t.dir/subpath
 // RUN: echo "print(\"exec: \" + #file)" > %t.dir/stdin
 // RUN: echo "print(\"exec: \" + #file)" > %t.dir/t.swift


### PR DESCRIPTION
Several of the swift repl tests assume that lldb does not exist next to the swift driver in the binary directory. This patch updates the tests to remove that assumption. This allows the swift tests to correctly pass if LLDB is built in-tree.
