### PR TITLE
Debug info:  Fix a crash in LLVM due to missing debug locations

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2837,6 +2837,8 @@ llvm::Value *irgen::emitAssociatedTypeMetadataRef(IRGenFunction &IGF,
   witness = IGF.Builder.CreateBitCast(witness, witnessTy->getPointerTo());
 
   // Call the accessor.
+  assert((!IGF.IGM.DebugInfo || IGF.Builder.getCurrentDebugLocation()) &&
+         "creating a function call without a debug location");
   auto call = IGF.Builder.CreateCall(witness, { parentMetadata, wtable });
   call->setDoesNotThrow();
   call->setCallingConv(IGF.IGM.DefaultCC);

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1569,10 +1569,12 @@ void IRGenSILFunction::visitSILBasicBlock(SILBasicBlock *BB) {
         assert(maybeScopeless(I) && "instruction has location, but no scope");
       }
 
-      // Ignore scope-less instructions and have IRBuilder reuse the
-      // previous location and scope.
+      // Set the builder's debug location.
       if (DS && !KeepCurrentLocation)
         IGM.DebugInfo->setCurrentLoc(Builder, DS, ILoc);
+      else
+        // Use an artificial (line 0) location.
+        IGM.DebugInfo->setCurrentLoc(Builder, DS);
 
       // Function argument handling.
       if (InEntryBlock && !ArgsEmitted) {

--- a/test/DebugInfo/cleanupskip.swift
+++ b/test/DebugInfo/cleanupskip.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -emit-ir -g %s -o - -O -disable-llvm-optzns | %FileCheck %s
+// REQUIRES: objc_interop
+import Foundation
+
+public class NSCoder : NSObject {}
+
+public class AClass : NSObject {
+  // Ensure that the call to the type metadata accessor has a line number.
+  // CHECK: call %swift.type* @_TMaC11cleanupskip7NSCoder()
+  // CHECK-SAME:              !dbg ![[LINEZ:[0-9]+]]
+  // CHECK: ![[LINEZ]] = {{.*}}line: 0
+  public required init?(coder aDecoder: NSCoder) {
+        return nil
+    }
+}
+


### PR DESCRIPTION
<!-- What's in this pull request? -->

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves rdar://problem/28237133

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

Debug info: When skipping over cleanup locations in the middle of a
basic block, revert to line number 0 instead of reusing the last location.
This avoids emitting illegal IR if there was no previous location and the
instruction being emitted is a function call.

rdar://problem/28237133
