### PR TITLE
[stubs] Update CMake to use TARGET_SDKS (NFC)

### DIFF
--- a/stdlib/public/stubs/CMakeLists.txt
+++ b/stdlib/public/stubs/CMakeLists.txt
@@ -1,32 +1,40 @@
-set(swift_stubs_objc_sources)
-set(swift_stubs_unicode_normalization_sources)
+set(swift_stubs_sources
+    Assert.cpp
+    CommandLine.cpp
+    GlobalObjects.cpp
+    LibcShims.cpp
+    Stubs.cpp
+    UnicodeExtendedGraphemeClusters.cpp.gyb)
+set(swift_stubs_objc_sources
+    Availability.mm
+    DispatchShims.mm
+    FoundationHelpers.mm
+    OptionalBridgingHelper.mm
+    Reflection.mm
+    SwiftNativeNSXXXBase.mm.gyb)
+set(swift_stubs_unicode_normalization_sources
+    UnicodeNormalization.cpp)
+set(LLVM_OPTIONAL_SOURCES
+    ${swift_stubs_objc_sources}
+    ${swift_stubs_unicode_normalization_sources})
 
-if(SWIFT_HOST_VARIANT MATCHES "${SWIFT_DARWIN_VARIANTS}")
-  set(swift_stubs_objc_sources
-      Availability.mm
-      DispatchShims.mm
-      FoundationHelpers.mm
-      OptionalBridgingHelper.mm
-      Reflection.mm
-      SwiftNativeNSXXXBase.mm.gyb)
-  set(LLVM_OPTIONAL_SOURCES
-      UnicodeNormalization.cpp)
-else()
-  find_package(ICU REQUIRED COMPONENTS uc i18n)
-  set(swift_stubs_unicode_normalization_sources
-      UnicodeNormalization.cpp)
-endif()
+set(swift_stubs_c_compile_flags ${SWIFT_RUNTIME_CORE_CXX_FLAGS})
+list(APPEND swift_stubs_c_compile_flags -DswiftCore_EXPORTS)
 
 add_swift_library(swiftStdlibStubs OBJECT_LIBRARY TARGET_LIBRARY
-  Assert.cpp
-  CommandLine.cpp
-  GlobalObjects.cpp
-  LibcShims.cpp
-  Stubs.cpp
-  UnicodeExtendedGraphemeClusters.cpp.gyb
+  ${swift_stubs_sources}
   ${swift_stubs_objc_sources}
-  ${swift_stubs_unicode_normalization_sources}
-  C_COMPILE_FLAGS ${SWIFT_RUNTIME_CORE_CXX_FLAGS} -DswiftCore_EXPORTS
+  C_COMPILE_FLAGS ${swift_stubs_c_compile_flags}
   LINK_FLAGS ${SWIFT_RUNTIME_CORE_LINK_FLAGS}
+  TARGET_SDKS ALL_APPLE_PLATFORMS
+  INSTALL_IN_COMPONENT stdlib)
+
+add_swift_library(swiftStdlibStubs OBJECT_LIBRARY TARGET_LIBRARY
+  ${swift_stubs_sources}
+  ${swift_stubs_unicode_normalization_sources}
+  C_COMPILE_FLAGS ${swift_stubs_c_compile_flags}
+  LINK_FLAGS ${SWIFT_RUNTIME_CORE_LINK_FLAGS}
+  LINK_LIBRARIES ${ICU_UC_LIBRARY} ${ICU_I18N_LIBRARY}
+  TARGET_SDKS ANDROID CYGWIN FREEBSD LINUX
   INSTALL_IN_COMPONENT stdlib)
 


### PR DESCRIPTION
The `add_swift_library` CMake function takes an optional `TARGET_SDKS` parameter. When used, only CMake targets for the specified SDKs are added.

Refactor `stdlib/public/stubs` to use this parameter. This also eliminates logic that determines additional flags or source files to include based on `SWIFT_HOST_VARIANT`, which makes it easier for hosts to add targets for different platforms.

This pull request was split out of https://github.com/apple/swift/pull/4972, which addresses [SR-1362](https://bugs.swift.org/browse/SR-1362).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
