### PR TITLE
[runtime] Update CMake to use TARGET_SDKS (NFC)

### DIFF
--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -21,17 +21,12 @@ endif()
 list(APPEND swift_runtime_compile_flags
      "-D__SWIFT_CURRENT_DYLIB=swiftCore")
 
-set(swift_runtime_objc_sources)
-set(swift_runtime_unicode_normalization_sources)
-if(SWIFT_HOST_VARIANT MATCHES "${SWIFT_DARWIN_VARIANTS}")
-  set(swift_runtime_objc_sources
-      ErrorObject.mm
-      SwiftObject.mm
-      SwiftValue.mm
-      Remangle.cpp
-      Reflection.mm)
-else()
-endif()
+set(swift_runtime_objc_sources
+    ErrorObject.mm
+    SwiftObject.mm
+    SwiftValue.mm
+    Remangle.cpp
+    Reflection.mm)
 
 set(swift_runtime_sources
     AnyHashableSupport.cpp
@@ -68,13 +63,25 @@ set(LLVM_OPTIONAL_SOURCES
     ${swift_runtime_objc_sources}
     ${swift_runtime_leaks_sources})
 
+set(swift_runtime_library_compile_flags ${swift_runtime_compile_flags})
+list(APPEND swift_runtime_library_compile_flags -DswiftCore_EXPORTS)
+
 add_swift_library(swiftRuntime OBJECT_LIBRARY TARGET_LIBRARY
   ${swift_runtime_sources}
   ${swift_runtime_objc_sources}
   ${swift_runtime_leaks_sources}
-  C_COMPILE_FLAGS ${swift_runtime_compile_flags} -DswiftCore_EXPORTS
+  C_COMPILE_FLAGS ${swift_runtime_library_compile_flags}
   LINK_FLAGS ${swift_runtime_linker_flags}
-  INSTALL_IN_COMPONENT never_install)
+  INSTALL_IN_COMPONENT never_install
+  TARGET_SDKS ALL_APPLE_PLATFORMS)
+
+add_swift_library(swiftRuntime OBJECT_LIBRARY TARGET_LIBRARY
+  ${swift_runtime_sources}
+  ${swift_runtime_leaks_sources}
+  C_COMPILE_FLAGS ${swift_runtime_library_compile_flags}
+  LINK_FLAGS ${swift_runtime_linker_flags}
+  INSTALL_IN_COMPONENT never_install
+  TARGET_SDKS ANDROID CYGWIN FREEBSD LINUX)
 
 set(ELFISH_SDKS)
 foreach(sdk ${SWIFT_CONFIGURED_SDKS})


### PR DESCRIPTION
The `add_swift_library` CMake function takes an optional `TARGET_SDKS` parameter. When used, only CMake targets for the specified SDKs are added.

Refactor `stdlib/public/runtime` to use this parameter. This also eliminates logic that determines additional flags or source files to include based on `SWIFT_HOST_VARIANT`, which makes it easier for hosts to add targets for different platforms.

This pull request was split out of https://github.com/apple/swift/pull/4972, which addresses [SR-1362](https://bugs.swift.org/browse/SR-1362).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
