### PR TITLE
[lit] Make sure that we use the just built llvm-dwarfdump in lit and …

### DIFF
--- a/test/DebugInfo/Imports.swift
+++ b/test/DebugInfo/Imports.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend -emit-ir -module-name Foo %s -I %t -g -o - | %FileCheck %s
 // RUN: %target-swift-frontend -c -module-name Foo %s -I %t -g -o %t.o
-// RUN: llvm-dwarfdump %t.o | %FileCheck --check-prefix=DWARF %s
+// RUN: %llvm-dwarfdump %t.o | %FileCheck --check-prefix=DWARF %s
 
 // CHECK-DAG: ![[FOOMODULE:[0-9]+]] = !DIModule({{.*}}, name: "Foo", includePath: "{{.*}}test{{.*}}DebugInfo{{.*}}"
 // CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[THISFILE:[0-9]+]], entity: ![[FOOMODULE]]

--- a/test/DebugInfo/iteration.swift
+++ b/test/DebugInfo/iteration.swift
@@ -29,7 +29,7 @@ func count() {
 count()
 
 // End-to-end test:
-// RUN: llc %t.ll -filetype=obj -o - | llvm-dwarfdump - | %FileCheck %s --check-prefix DWARF-CHECK
+// RUN: llc %t.ll -filetype=obj -o - | %llvm-dwarfdump - | %FileCheck %s --check-prefix DWARF-CHECK
 // DWARF-CHECK:  DW_TAG_variable
 // DWARF-CHECK:  DW_AT_name {{.*}} "letter"
 //

--- a/test/DebugInfo/letstring.swift
+++ b/test/DebugInfo/letstring.swift
@@ -25,7 +25,7 @@ class AppDelegate {
 
 // End-to-end test:
 // RUN: llc %t.ll -filetype=obj -o %t.o
-// RUN: llvm-dwarfdump %t.o | %FileCheck %s --check-prefix DWARF-CHECK
+// RUN: %llvm-dwarfdump %t.o | %FileCheck %s --check-prefix DWARF-CHECK
 // DWARF-CHECK: DW_AT_name {{.*}} "f"
 //
 // DWARF-CHECK: DW_TAG_formal_parameter

--- a/test/DebugInfo/local-vars.swift.gyb
+++ b/test/DebugInfo/local-vars.swift.gyb
@@ -5,7 +5,7 @@
 // RUN: %gyb %s -o %t.swift
 // RUN: %target-swift-frontend %t.swift -g -emit-ir -o - | %FileCheck %t.swift
 // RUN: %target-swift-frontend %t.swift -g -c -o %t.o
-// RUN: llvm-dwarfdump --debug-dump=info %t.o \
+// RUN: %llvm-dwarfdump --debug-dump=info %t.o \
 // RUN:   | %FileCheck %t.swift --check-prefix=DWARF
 // RUN: %target-swift-frontend %t.swift -O -g -emit-ir -o - \
 // RUN:   | %FileCheck %t.swift --check-prefix=OPTZNS

--- a/test/DebugInfo/test-foundation.swift
+++ b/test/DebugInfo/test-foundation.swift
@@ -2,7 +2,7 @@
 // RUN: %FileCheck %s --check-prefix IMPORT-CHECK < %t.ll
 // RUN: %FileCheck %s --check-prefix LOC-CHECK < %t.ll
 // RUN: llc %t.ll -filetype=obj -o %t.o
-// RUN: llvm-dwarfdump %t.o | %FileCheck %s --check-prefix DWARF-CHECK
+// RUN: %llvm-dwarfdump %t.o | %FileCheck %s --check-prefix DWARF-CHECK
 // DISABLED <rdar://problem/28232630>: dwarfdump --verify %t.o
 
 // REQUIRES: OS=macosx

--- a/test/DebugInfo/typearg.swift
+++ b/test/DebugInfo/typearg.swift
@@ -35,7 +35,7 @@ class Foo<Bar> {
 
 // Verify that the backend doesn't elide the debug intrinsics.
 // RUN: %target-swift-frontend %s -c -g -o %t.o
-// RUN: llvm-dwarfdump %t.o | %FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: %llvm-dwarfdump %t.o | %FileCheck %s --check-prefix=CHECK-LLVM
 // CHECK-LLVM-DAG:  .debug_str[{{.*}}] = "x"
 // CHECK-LLVM-DAG:  .debug_str[{{.*}}] = "$swift.type.T"
 // CHECK- FIXME -LLVM-DAG:  .debug_str[{{.*}}] = "$swift.type.Bar"

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -286,6 +286,7 @@ config.swift_llvm_opt = inferSwiftBinary('swift-llvm-opt')
 config.llvm_profdata = inferSwiftBinary('llvm-profdata')
 config.llvm_cov = inferSwiftBinary('llvm-cov')
 config.filecheck = inferSwiftBinary('FileCheck')
+config.llvm_dwarfdump = inferSwiftBinary('llvm-dwarfdump')
 
 config.swift_utils = os.path.join(config.swift_src_root, 'utils')
 config.line_directive = os.path.join(config.swift_utils, 'line-directive')
@@ -350,6 +351,7 @@ config.substitutions.append( ('%swift-ide-test', "%r %s %s" % (config.swift_ide_
 config.substitutions.append( ('%swift-format', config.swift_format) )
 config.substitutions.append( ('%llvm-link', config.llvm_link) )
 config.substitutions.append( ('%swift-llvm-opt', config.swift_llvm_opt) )
+config.substitutions.append( ('%llvm-dwarfdump', config.llvm_dwarfdump) )
 
 # This must come after all substitutions containing "%swift".
 config.substitutions.append(
@@ -417,6 +419,7 @@ disallow('lldb-moduleimport-test')
 disallow('swift-ide-test')
 disallow('clang')
 disallow('FileCheck')
+disallow('llvm-dwarfdump')
 
 config.substitutions.insert(0,
     ('%p',


### PR DESCRIPTION
In order to ensure that I have a stable version of dwarfdump to write tests against, this commit ensures that we use the just built llvm-dwarfdump rather than the system dwarfdump when performing lit testing.

rdar://27973141
