### PR TITLE
[SourceKit] Add test case for crash triggered in swift::ValueDecl::getFormalAccessScope(…)

### DIFF
--- a/validation-test/IDE/crashers/093-swift-valuedecl-getformalaccessscope.swift
+++ b/validation-test/IDE/crashers/093-swift-valuedecl-getformalaccessscope.swift
@@ -1,0 +1,4 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+func<{#^A^#protocol A{func<struct B
+struct d<T where B:T>:A


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 132
4  swift-ide-test  0x0000000000c2fc3b swift::ValueDecl::getFormalAccessScope(swift::DeclContext const*) const + 11
6  swift-ide-test  0x00000000009dd067 swift::TypeChecker::checkConformance(swift::NormalProtocolConformance*) + 2103
8  swift-ide-test  0x00000000009b9271 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
9  swift-ide-test  0x00000000007abc69 swift::CompilerInstance::performSema() + 3289
10 swift-ide-test  0x000000000074d981 main + 36401
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
```
