### PR TITLE
[SIL] Add test case for crash triggered in swift::ArchetypeBuilder::enumerateRequirements(…)

### DIFF
--- a/validation-test/SIL/crashers/038-swift-archetypebuilder-enumeraterequirements.sil
+++ b/validation-test/SIL/crashers/038-swift-archetypebuilder-enumeraterequirements.sil
@@ -1,0 +1,6 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+protocol a
+protocol a{typealias b=a
+typealias b=c
+typealias b


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:11: error: expected '{' in protocol type
protocol a
          ^
<stdin>:6:1: error: typealias is missing an assigned type; use 'associatedtype' to define an associated type requirement
typealias b
^~~~~~~~~
associatedtype
<stdin>:6:12: error: consecutive declarations on a line must be separated by ';'
typealias b
           ^
           ;
<stdin>:6:12: error: expected declaration
typealias b
           ^
<stdin>:4:10: note: in declaration of 'a'
protocol a{typealias b=a
         ^
<stdin>:4:24: error: 'a' is ambiguous for type lookup in this context
protocol a{typealias b=a
                       ^
<stdin>:3:10: note: found this candidate
protocol a
         ^
<stdin>:4:10: note: found this candidate
protocol a{typealias b=a
         ^
<stdin>:5:13: error: use of undeclared type 'c'
typealias b=c
            ^
potential archetype total order failure
UNREACHABLE executed at /path/to/swift/lib/AST/ArchetypeBuilder.cpp:1122!
6  sil-opt         0x000000000309743d llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) + 461
9  libc.so.6       0x00007f30b0e516cc qsort_r + 652
10 sil-opt         0x0000000000d4c2f3 swift::ArchetypeBuilder::enumerateRequirements(llvm::function_ref<void (swift::RequirementKind, swift::ArchetypeBuilder::PotentialArchetype*, llvm::PointerUnion<swift::Type, swift::ArchetypeBuilder::PotentialArchetype*>, swift::RequirementSource)>) + 883
11 sil-opt         0x0000000000d4d248 swift::ArchetypeBuilder::getGenericSignature(llvm::ArrayRef<swift::GenericTypeParamType*>) + 72
12 sil-opt         0x0000000000b3634c swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 300
13 sil-opt         0x0000000000b36d4e swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) + 126
14 sil-opt         0x0000000000af3746 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1830
16 sil-opt         0x0000000000af99b6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
17 sil-opt         0x0000000000b1f362 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
18 sil-opt         0x00000000007758a9 swift::CompilerInstance::performSema() + 3289
19 sil-opt         0x000000000075ec65 main + 1813
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  While type-checking 'a' at <stdin>:3:1
```
