### PR TITLE
[gardening] Fix incorrect header. PEP-8 fixes. Fix spacing. Fix \t.

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -970,7 +970,7 @@ static void checkRedeclaration(TypeChecker &tc, ValueDecl *current) {
 
       current->setInvalid();
       if (current->hasType())
-	current->overwriteType(ErrorType::get(tc.Context));
+        current->overwriteType(ErrorType::get(tc.Context));
       break;
     }
   }

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -713,7 +713,7 @@ func nilComparison(i: Int, o: AnyObject) {
   _ = o !== nil // expected-warning {{comparing non-optional value of type 'AnyObject' to nil always returns true}}
 }
 
-func secondArgumentNotLabeled(a:Int, _ b: Int) { }
+func secondArgumentNotLabeled(a: Int, _ b: Int) { }
 secondArgumentNotLabeled(10, 20)
 // expected-error@-1 {{missing argument label 'a' in call}}
 

--- a/test/SILOptimizer/cast_folding.swift
+++ b/test/SILOptimizer/cast_folding.swift
@@ -10,16 +10,16 @@ protocol P {}
 
 protocol Q: P {}
 
-class A:P {}
-class AA:A {}
+class A: P {}
+class AA: A {}
 
 class X {}
 
-class B:P {}
+class B: P {}
 
-private struct S:P {}
+private struct S: P {}
 
-struct T:Q {}
+struct T: Q {}
 
 private struct U {}
 
@@ -36,113 +36,113 @@ private final class F: CP1 {}
 // Class E implements both class protocols at once
 class E: CP1, CP2 {}
 
-func cast0<T>(_ a:T) -> Bool {
+func cast0<T>(_ a: T) -> Bool {
   // Succeeds if T is A
   return type(of: A()) is T.Type
 }
 
 
-func cast1<T>(_ a:T) -> Bool {
+func cast1<T>(_ a: T) -> Bool {
   // Succeeds if T is A
   return type(of: (A() as AnyObject)) is T.Type
 }
 
-func cast2<T>(_ a:T) -> Bool {
+func cast2<T>(_ a: T) -> Bool {
   // Succeeds if T is A
-  let ao:AnyObject = A() as AnyObject
+  let ao: AnyObject = A() as AnyObject
   return type(of: ao) is T.Type
 }
 
 
-func cast3(_ p:AnyObject) -> Bool {
+func cast3(_ p: AnyObject) -> Bool {
   // Always fails
   return type(of: p) is AnyObject.Protocol
 }
 
-func cast4(_ p:AnyObject) -> Bool {
+func cast4(_ p: AnyObject) -> Bool {
   return type(of: p) is A.Type
 }
 
-func cast5(_ t:AnyObject.Type) -> Bool {
+func cast5(_ t: AnyObject.Type) -> Bool {
   // Succeeds if t is B.self
   return t is B.Type
 }
 
-func cast6<T>(_ t:T) -> Bool {
+func cast6<T>(_ t: T) -> Bool {
   // Always fails
   return AnyObject.self is T.Type
 }
 
-func cast7<T>(_ t:T.Type) -> Bool {
+func cast7<T>(_ t: T.Type) -> Bool {
   // Succeeds if t is AnyObject.self
   return t is AnyObject.Protocol
 }
 
 
-func cast8<T>(_ a:T) -> Bool {
+func cast8<T>(_ a: T) -> Bool {
   // Succeeds if T is A
   return type(of: (A() as P)) is T.Type
 }
 
-func cast9<T>(_ a:T) -> Bool {
+func cast9<T>(_ a: T) -> Bool {
   // Succeeds if T is A
-  let ao:P = A() as P
+  let ao: P = A() as P
   return type(of: ao) is T.Type
 }
 
 
-func cast10(_ p:P) -> Bool {
+func cast10(_ p: P) -> Bool {
   return type(of: p) is P.Protocol
 }
 
-func cast11(_ p:P) -> Bool {
+func cast11(_ p: P) -> Bool {
   // Succeeds if p is of type A
   return type(of: p) is A.Type
 }
 
-func cast12(_ t:P.Type) -> Bool {
+func cast12(_ t: P.Type) -> Bool {
   return t is B.Type
 }
 
 
-func cast13<T>(_ t:T) -> Bool {
+func cast13<T>(_ t: T) -> Bool {
   // Succeeds if T is P
   return P.self is T.Type
 }
 
 
-func cast14<T>(_ t:T.Type) -> Bool {
+func cast14<T>(_ t: T.Type) -> Bool {
   // Succeeds if p is P.self
   return t is P.Protocol
 }
 
-func cast15<T>(_ t:T) -> Bool {
+func cast15<T>(_ t: T) -> Bool {
   // Succeeds if T is P
   return P.self is T.Type
 }
 
-func cast16<T>(_ t:T) -> Bool {
+func cast16<T>(_ t: T) -> Bool {
   // Succeeds if T is P
   return T.self is P.Protocol
 }
 
 
-func cast17<T>(_ t:T) -> Bool {
+func cast17<T>(_ t: T) -> Bool {
   // Succeeds if T is AnyObject
   return AnyObject.self is T.Type
 }
 
-func cast18<T>(_ t:T) -> Bool {
+func cast18<T>(_ t: T) -> Bool {
   // Succeeds if T is AnyObject
   return T.self is AnyObject.Protocol
 }
 
-func cast20<T>(_ t:T) -> Bool {
+func cast20<T>(_ t: T) -> Bool {
   // Succeeds if T is P
   return T.self is P.Type
 }
 
-func cast21<T>(_ t:T) -> Bool {
+func cast21<T>(_ t: T) -> Bool {
   // Succeeds if T is P
   return T.self is P.Protocol
 }
@@ -170,7 +170,7 @@ func cast25(_ concrete: P.Protocol) -> Bool {
 }
 
 func cast26(_ existential: Q.Type) -> Bool {
-  // Succeeds always, because Q:P
+  // Succeeds always, because Q: P
   return existential is P.Type
 }
 

--- a/test/stdlib/NSNumberBridging.swift.gyb
+++ b/test/stdlib/NSNumberBridging.swift.gyb
@@ -124,8 +124,8 @@ nsNumberBridging.test("${Type}") {
 % end
 
 %{
-allBridgedTypes = [Type for Type, _, _ in bridgedFixedPointTypes] + \
-                  [Type for Type, _ in bridgedFloatTypes]
+allBridgedTypes = [type_name for type_name, _, _ in bridgedFixedPointTypes] + \
+                  [type_name for type_name, _ in bridgedFloatTypes]
 }%
 
 % for AType in allBridgedTypes:

--- a/test/stdlib/NSValueBridging.swift.gyb
+++ b/test/stdlib/NSValueBridging.swift.gyb
@@ -1,4 +1,4 @@
-//===--- NSValueBridging.swift - Test bridging through NSValue ------------===//
+//===-- NSValueBridging.swift - Test bridging through NSValue -*- swift -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/test/stdlib/Runtime.swift.gyb
+++ b/test/stdlib/Runtime.swift.gyb
@@ -908,7 +908,7 @@ Reflection.test("Enum/IndirectGeneric/DefaultMirror") {
 
   let list = List.Cons(first: 0, rest: .Cons(first: 1, rest: .Nil))
   expectEqual("Cons(first: 0, rest: a.List<Swift.Int>.Cons(first: 1, rest: a.List<Swift.Int>.Nil))",
-	      "\(list)")
+    "\(list)")
 }
 
 class Brilliant : CustomReflectable {

--- a/utils/gyb_foundation_support.py
+++ b/utils/gyb_foundation_support.py
@@ -40,6 +40,7 @@ extension {Type}: _ObjectiveCBridgeable {{
 }}
 """.format(Type=Type)
 
+
 def ObjectiveCBridgeableImplementationForNSValueWithCategoryMethods(
   Type,
   initializer,

--- a/utils/swift_build_support/tests/products/test_swift.py
+++ b/utils/swift_build_support/tests/products/test_swift.py
@@ -264,4 +264,3 @@ class SwiftTestCase(unittest.TestCase):
             ['-DSWIFT_BENCHMARK_NUM_ONONE_ITERATIONS=10',
              '-DSWIFT_BENCHMARK_NUM_O_ITERATIONS=25'],
             swift.cmake_options)
-


### PR DESCRIPTION
Misc gardening:
- Fix incorrect header.
- PEP-8 fixes.
- Fix accidental `\t`.
- Fix incorrect spacing.
