### PR TITLE
[build-script] Add in an buildbot,tools=RDA-flto,stdlib=RDA preset.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -98,6 +98,24 @@ swift-stdlib-enable-assertions=true
 # This is a release non-incremental build. Run sil-verify-all.
 sil-verify-all
 
+[preset: mixin_buildbot_tools_RDA_stdlib_RDA]
+mixin-preset=
+    mixin_buildbot_trunk_base
+    mixin_buildbot_install_components
+
+# Build Release without debug info, because it is faster to build.
+release-debuginfo
+assertions
+# Also run tests in optimized modes.
+test-optimized
+
+dash-dash
+
+swift-stdlib-build-type=RelWithDebInfo
+swift-stdlib-enable-assertions=true
+
+# This is a release non-incremental build. Run sil-verify-all.
+sil-verify-all
 
 [preset: mixin_buildbot_tools_RA_stdlib_RD]
 mixin-preset=
@@ -195,6 +213,24 @@ build-swift-static-sdk-overlay
 skip-test-ios-host
 skip-test-tvos-host
 skip-test-watchos-host
+
+[preset: buildbot,tools=RDA-flto,stdlib=RDA]
+mixin-preset=
+    mixin_buildbot_tools_RDA_stdlib_RDA
+
+lto
+
+dash-dash
+
+build-swift-static-stdlib
+build-swift-static-sdk-overlay
+
+# Don't run host tests for iOS, tvOS and watchOS platforms to make the build
+# faster.
+skip-test-ios-host
+skip-test-tvos-host
+skip-test-watchos-host
+
 
 #===------------------------------------------------------------------------===#
 # Incremental buildbots for Darwin OSes


### PR DESCRIPTION
This is a NFC change that just adds a release-debuginfo preset for flto. I am going to use it to bring up a tool RDA buildbot internally to double check that we are properly compiling LTO + debug info.
