### PR TITLE
Fix a compiler crash due to missing debug locations

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2831,6 +2831,8 @@ llvm::Value *irgen::emitAssociatedTypeMetadataRef(IRGenFunction &IGF,
   witness = IGF.Builder.CreateBitCast(witness, witnessTy->getPointerTo());
 
   // Call the accessor.
+  assert((!IGF.IGM.DebugInfo || IGF.Builder.getCurrentDebugLocation()) &&
+         "creating a function call without a debug location");
   auto call = IGF.Builder.CreateCall(witness, { parentMetadata, wtable });
   call->setDoesNotThrow();
   call->setCallingConv(IGF.IGM.DefaultCC);

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1567,10 +1567,12 @@ void IRGenSILFunction::visitSILBasicBlock(SILBasicBlock *BB) {
         assert(maybeScopeless(I) && "instruction has location, but no scope");
       }
 
-      // Ignore scope-less instructions and have IRBuilder reuse the
-      // previous location and scope.
+      // Set the builder's debug location.
       if (DS && !KeepCurrentLocation)
         IGM.DebugInfo->setCurrentLoc(Builder, DS, ILoc);
+      else
+        // Use an artificial (line 0) location.
+        IGM.DebugInfo->setCurrentLoc(Builder, DS);
 
       // Function argument handling.
       if (InEntryBlock && !ArgsEmitted) {

--- a/test/DebugInfo/cleanupskip.swift
+++ b/test/DebugInfo/cleanupskip.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -emit-ir -g %s -o - -O -disable-llvm-optzns | %FileCheck %s
+// REQUIRES: objc_interop
+import Foundation
+
+public class NSCoder : NSObject {}
+
+public class AClass : NSObject {
+  // Ensure that the call to the type metadata accessor has a line number.
+  // CHECK: call %swift.type* @_TMaC11cleanupskip7NSCoder()
+  // CHECK-SAME:              !dbg ![[LINEZ:[0-9]+]]
+  // CHECK: ![[LINEZ]] = {{.*}}line: 0
+  public required init?(coder aDecoder: NSCoder) {
+        return nil
+    }
+}
+


### PR DESCRIPTION
<!-- What's in this pull request? -->

• Explanation: Fix a compiler crash due to missing debug locations an function calls when optimizations and debug info are enabled.
• Scope of Issue: Functions that invoke a type metadata accessor from a "cleanup" source locationas the first thing after/in the function prologue.
• Risk: The patch more aggressively assigns line number 0 to cleanup locations instead of resusing the previous location. LLDB will safely skip over line 0 locations.
• Testing: swift compiler regression test.
• Directions for QA: Build the example in SR-2745.

Debug info: When skipping over cleanup locations in the middle of a
basic block, revert to line number 0 instead of reusing the last location.
This avoids emitting illegal IR if there was no previous location and the
instruction being emitted is a function call.

SR-2745
rdar://problem/28237133
rdar://problem/26955467
(cherry picked from commit c70d101ab087b8321762228b8705148ae5041f57)
