### PR TITLE
[CMake] Tentative fix for extra intrinsic_gen dependencies

### DIFF
--- a/lib/ClangImporter/CMakeLists.txt
+++ b/lib/ClangImporter/CMakeLists.txt
@@ -25,9 +25,10 @@ add_swift_library(swiftClangImporter STATIC
     swiftParse
 )
 
-# This property is only set by calls to clang_tablegen. It will not be set on
-# standalone builds, so it can always be safely passed.
-get_property(CLANG_TABLEGEN_TARGETS GLOBAL PROPERTY CLANG_TABLEGEN_TARGETS)
+if(NOT SWIFT_BUILT_STANDALONE)
+  get_property(CLANG_TABLEGEN_TARGETS GLOBAL PROPERTY CLANG_TABLEGEN_TARGETS)
+endif()
+
 add_dependencies(swiftClangImporter
                 "${generated_include_targets}"
                 ${CLANG_TABLEGEN_TARGETS})


### PR DESCRIPTION
Recent swift builds have been complaining about extra dependencies on intrnsics_gen. Hopefully this will resolve the issue.
