### PR TITLE
Reflection: Support lookup of associated types in superclasses (3.0)

### DIFF
--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -138,6 +138,10 @@ private:
   /// this TypeRefBuilder and are automatically released.
   std::vector<std::unique_ptr<const TypeRef>> TypeRefPool;
 
+  /// Cache for associated type lookups.
+  std::unordered_map<TypeRefID, const TypeRef *,
+                     TypeRefID::Hash, TypeRefID::Equal> AssociatedTypeCache;
+
   TypeConverter TC;
   MetadataSourceBuilder MSB;
 
@@ -295,14 +299,21 @@ private:
 
   const AssociatedTypeDescriptor *
   lookupAssociatedTypes(const std::string &MangledTypeName,
-                        const DependentMemberTypeRef *DependentMember);
+                        const TypeRef *Protocol);
 
 public:
   TypeConverter &getTypeConverter() { return TC; }
 
   const TypeRef *
-  getDependentMemberTypeRef(const std::string &MangledTypeName,
-                            const DependentMemberTypeRef *DependentMember);
+  lookupTypeWitness(const std::string &MangledTypeName,
+                    const std::string &Member,
+                    const TypeRef *Protocol);
+
+  const TypeRef *
+  lookupSuperclass(const std::string &MangledTypeName);
+
+  const TypeRef *
+  lookupSuperclass(const TypeRef *TR);
 
   /// Load unsubstituted field types for a nominal type.
   const FieldDescriptor *getFieldTypeInfo(const TypeRef *TR);

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -294,12 +294,7 @@ public:
   }
 
 private:
-
   std::vector<ReflectionInfo> ReflectionInfos;
-
-  const AssociatedTypeDescriptor *
-  lookupAssociatedTypes(const std::string &MangledTypeName,
-                        const TypeRef *Protocol);
 
 public:
   TypeConverter &getTypeConverter() { return TC; }

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1148,11 +1148,15 @@ SILLinkage LinkEntity::getLinkage(IRGenModule &IGM,
           == SILLinkage::Shared)
       return SILLinkage::Shared;
     return SILLinkage::Private;
+  case Kind::ReflectionSuperclassDescriptor:
+    if (getDeclLinkage(getDecl()) == FormalLinkage::PublicNonUnique)
+      return SILLinkage::Shared;
+    return SILLinkage::Private;
   }
   llvm_unreachable("bad link entity kind");
 }
 
-static bool isAvailableExternally(IRGenModule &IGM, DeclContext *dc) {
+static bool isAvailableExternally(IRGenModule &IGM, const DeclContext *dc) {
   dc = dc->getModuleScopeContext();
   if (isa<ClangModuleUnit>(dc) ||
       dc == IGM.getSILModule().getAssociatedContext())
@@ -1160,7 +1164,7 @@ static bool isAvailableExternally(IRGenModule &IGM, DeclContext *dc) {
   return true;
 }
 
-static bool isAvailableExternally(IRGenModule &IGM, Decl *decl) {
+static bool isAvailableExternally(IRGenModule &IGM, const Decl *decl) {
   return isAvailableExternally(IGM, decl->getDeclContext());
 }
 
@@ -1214,6 +1218,7 @@ bool LinkEntity::isAvailableExternally(IRGenModule &IGM) const {
   case Kind::ReflectionBuiltinDescriptor:
   case Kind::ReflectionFieldDescriptor:
   case Kind::ReflectionAssociatedTypeDescriptor:
+  case Kind::ReflectionSuperclassDescriptor:
     llvm_unreachable("Relative reference to unsupported link entity");
   }
   llvm_unreachable("bad link entity kind");

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -221,9 +221,57 @@ protected:
     addRelativeAddress(mangledName);
   }
 
+  llvm::GlobalVariable *emit(Optional<LinkEntity> entity,
+                             const char *section) {
+    auto tempBase = std::unique_ptr<llvm::GlobalVariable>(
+        new llvm::GlobalVariable(IGM.Int8Ty, /*isConstant*/ true,
+                                 llvm::GlobalValue::PrivateLinkage));
+    setRelativeAddressBase(tempBase.get());
+
+    layout();
+
+    auto init = getInit();
+    if (!init)
+      return nullptr;
+
+    llvm::GlobalVariable *var;
+
+    // Some reflection records have a mangled symbol name, for uniquing
+    // imported type metadata.
+    if (entity) {
+      auto info = LinkInfo::get(IGM, *entity, ForDefinition);
+
+      var = info.createVariable(IGM, init->getType(), Alignment(4));
+      var->setConstant(true);
+      var->setInitializer(init);
+
+    // Others, such as capture descriptors, do not have a name.
+    } else {
+      var = new llvm::GlobalVariable(*IGM.getModule(), init->getType(),
+                                     /*isConstant*/ true,
+                                     llvm::GlobalValue::PrivateLinkage,
+                                     init,
+                                     "\x01l__swift3_reflection_descriptor");
+      var->setAlignment(4);
+    }
+
+    var->setSection(section);
+
+    auto replacer = llvm::ConstantExpr::getBitCast(var, IGM.Int8PtrTy);
+    tempBase->replaceAllUsesWith(replacer);
+
+    IGM.addUsedGlobal(var);
+
+    return var;
+  }
+
+  virtual void layout() = 0;
+
 public:
   ReflectionMetadataBuilder(IRGenModule &IGM)
     : ConstantBuilder(IGM) {}
+
+  virtual ~ReflectionMetadataBuilder() {}
 };
 
 class AssociatedTypeMetadataBuilder : public ReflectionMetadataBuilder {
@@ -232,7 +280,7 @@ class AssociatedTypeMetadataBuilder : public ReflectionMetadataBuilder {
   const ProtocolConformance *Conformance;
   ArrayRef<std::pair<StringRef, CanType>> AssociatedTypes;
 
-  void layout() {
+  void layout() override {
     // If the conforming type is generic, we just want to emit the
     // unbound generic type here.
     auto *Nominal = Conformance->getInterfaceType()->getAnyNominal();
@@ -267,28 +315,9 @@ public:
       AssociatedTypes(AssociatedTypes) {}
 
   llvm::GlobalVariable *emit() {
-    auto tempBase = std::unique_ptr<llvm::GlobalVariable>(
-        new llvm::GlobalVariable(IGM.Int8Ty, /*isConstant*/ true,
-                                 llvm::GlobalValue::PrivateLinkage));
-    setRelativeAddressBase(tempBase.get());
-
-    layout();
-    auto init = getInit();
-    if (!init)
-      return nullptr;
-
     auto entity = LinkEntity::forReflectionAssociatedTypeDescriptor(Conformance);
-    auto info = LinkInfo::get(IGM, entity, ForDefinition);
-
-    auto var = info.createVariable(IGM, init->getType(), Alignment(4));
-    var->setConstant(true);
-    var->setInitializer(init);
-    var->setSection(IGM.getAssociatedTypeMetadataSectionName());
-
-    auto replacer = llvm::ConstantExpr::getBitCast(var, IGM.Int8PtrTy);
-    tempBase->replaceAllUsesWith(replacer);
-    
-    return var;
+    auto section = IGM.getAssociatedTypeMetadataSectionName();
+    return ReflectionMetadataBuilder::emit(entity, section);
   }
 };
 
@@ -433,31 +462,10 @@ public:
     : ReflectionMetadataBuilder(IGM), NTD(NTD) {}
 
   llvm::GlobalVariable *emit() {
-
-    auto tempBase = std::unique_ptr<llvm::GlobalVariable>(
-        new llvm::GlobalVariable(IGM.Int8Ty, /*isConstant*/ true,
-                                 llvm::GlobalValue::PrivateLinkage));
-    setRelativeAddressBase(tempBase.get());
-
-    layout();
-    auto init = getInit();
-
-    if (!init)
-      return nullptr;
-
     auto entity = LinkEntity::forReflectionFieldDescriptor(
         NTD->getDeclaredType()->getCanonicalType());
-    auto info = LinkInfo::get(IGM, entity, ForDefinition);
-
-    auto var = info.createVariable(IGM, init->getType(), Alignment(4));
-    var->setConstant(true);
-    var->setInitializer(init);
-    var->setSection(IGM.getFieldTypeMetadataSectionName());
-
-    auto replacer = llvm::ConstantExpr::getBitCast(var, IGM.Int8PtrTy);
-    tempBase->replaceAllUsesWith(replacer);
-
-    return var;
+    auto section = IGM.getFieldTypeMetadataSectionName();
+    return ReflectionMetadataBuilder::emit(entity, section);
   }
 };
 
@@ -494,45 +502,20 @@ public:
   }
 
   llvm::GlobalVariable *emit() {
-    auto tempBase = std::unique_ptr<llvm::GlobalVariable>(
-        new llvm::GlobalVariable(IGM.Int8Ty, /*isConstant*/ true,
-                                 llvm::GlobalValue::PrivateLinkage));
-    setRelativeAddressBase(tempBase.get());
-
-    layout();
-
-    auto init = getInit();
-
-    if (!init)
-      return nullptr;
-
     auto entity = LinkEntity::forReflectionBuiltinDescriptor(type);
-    auto info = LinkInfo::get(IGM, entity, ForDefinition);
-
-    auto var = info.createVariable(IGM, init->getType(), Alignment(4));
-    var->setConstant(true);
-    var->setInitializer(init);
-    var->setSection(IGM.getBuiltinTypeMetadataSectionName());
-
-    auto replacer = llvm::ConstantExpr::getBitCast(var, IGM.Int8PtrTy);
-    tempBase->replaceAllUsesWith(replacer);
-
-    return var;
+    auto section = IGM.getBuiltinTypeMetadataSectionName();
+    return ReflectionMetadataBuilder::emit(entity, section);
   }
 };
 
 void IRGenModule::emitBuiltinTypeMetadataRecord(CanType builtinType) {
   FixedTypeMetadataBuilder builder(*this, builtinType);
-  auto var = builder.emit();
-  if (var)
-    addUsedGlobal(var);
+  builder.emit();
 }
 
 void IRGenModule::emitOpaqueTypeMetadataRecord(const NominalTypeDecl *nominalDecl) {
   FixedTypeMetadataBuilder builder(*this, nominalDecl);
-  auto var = builder.emit();
-  if (var)
-    addUsedGlobal(var);
+  builder.emit();
 }
 
 /// Builds a constant LLVM struct describing the layout of a fixed-size
@@ -554,29 +537,8 @@ public:
   }
 
   llvm::GlobalVariable *emit() {
-    auto tempBase = std::unique_ptr<llvm::GlobalVariable>(
-      new llvm::GlobalVariable(IGM.Int8Ty, /*isConstant*/ true,
-                               llvm::GlobalValue::PrivateLinkage));
-    setRelativeAddressBase(tempBase.get());
-
-    layout();
-    auto init = getInit();
-
-    if (!init)
-      return nullptr;
-
-    auto var = new llvm::GlobalVariable(*IGM.getModule(), init->getType(),
-                                        /*isConstant*/ true,
-                                        llvm::GlobalValue::PrivateLinkage,
-                                        init,
-                                        "\x01l__swift3_box_descriptor");
-    var->setSection(IGM.getCaptureDescriptorMetadataSectionName());
-    var->setAlignment(4);
-
-    auto replacer = llvm::ConstantExpr::getBitCast(var, IGM.Int8PtrTy);
-    tempBase->replaceAllUsesWith(replacer);
-
-    return var;
+    auto section = IGM.getCaptureDescriptorMetadataSectionName();
+    return ReflectionMetadataBuilder::emit(None, section);
   }
 };
 
@@ -751,29 +713,8 @@ public:
   }
 
   llvm::GlobalVariable *emit() {
-    auto tempBase = std::unique_ptr<llvm::GlobalVariable>(
-      new llvm::GlobalVariable(IGM.Int8Ty, /*isConstant*/ true,
-                               llvm::GlobalValue::PrivateLinkage));
-    setRelativeAddressBase(tempBase.get());
-
-    layout();
-    auto init = getInit();
-
-    if (!init)
-      return nullptr;
-
-    auto var = new llvm::GlobalVariable(*IGM.getModule(), init->getType(),
-                                        /*isConstant*/ true,
-                                        llvm::GlobalValue::PrivateLinkage,
-                                        init,
-                                        "\x01l__swift3_capture_descriptor");
-    var->setSection(IGM.getCaptureDescriptorMetadataSectionName());
-    var->setAlignment(4);
-
-    auto replacer = llvm::ConstantExpr::getBitCast(var, IGM.Int8PtrTy);
-    tempBase->replaceAllUsesWith(replacer);
-
-    return var;
+    auto section = IGM.getCaptureDescriptorMetadataSectionName();
+    return ReflectionMetadataBuilder::emit(None, section);
   }
 };
 
@@ -802,28 +743,40 @@ static std::string getReflectionSectionName(IRGenModule &IGM,
   return OS.str();
 }
 
-std::string IRGenModule::getFieldTypeMetadataSectionName() {
-  return getReflectionSectionName(*this, "fieldmd", "flmd");
+const char *IRGenModule::getFieldTypeMetadataSectionName() {
+  if (FieldTypeSection.empty())
+    FieldTypeSection = getReflectionSectionName(*this, "fieldmd", "flmd");
+  return FieldTypeSection.c_str();
 }
 
-std::string IRGenModule::getBuiltinTypeMetadataSectionName() {
-  return getReflectionSectionName(*this, "builtin", "bltn");
+const char *IRGenModule::getBuiltinTypeMetadataSectionName() {
+  if (BuiltinTypeSection.empty())
+    BuiltinTypeSection = getReflectionSectionName(*this, "builtin", "bltn");
+  return BuiltinTypeSection.c_str();
 }
 
-std::string IRGenModule::getAssociatedTypeMetadataSectionName() {
-  return getReflectionSectionName(*this, "assocty", "asty");
+const char *IRGenModule::getAssociatedTypeMetadataSectionName() {
+  if (AssociatedTypeSection.empty())
+    AssociatedTypeSection = getReflectionSectionName(*this, "assocty", "asty");
+  return AssociatedTypeSection.c_str();
 }
 
-std::string IRGenModule::getCaptureDescriptorMetadataSectionName() {
-  return getReflectionSectionName(*this, "capture", "cptr");
+const char *IRGenModule::getCaptureDescriptorMetadataSectionName() {
+  if (CaptureDescriptorSection.empty())
+    CaptureDescriptorSection = getReflectionSectionName(*this, "capture", "cptr");
+  return CaptureDescriptorSection.c_str();
 }
 
-std::string IRGenModule::getReflectionStringsSectionName() {
-  return getReflectionSectionName(*this, "reflstr", "rfst");
+const char *IRGenModule::getReflectionStringsSectionName() {
+  if (ReflectionStringsSection.empty())
+    ReflectionStringsSection = getReflectionSectionName(*this, "reflstr", "rfst");
+  return ReflectionStringsSection.c_str();
 }
 
-std::string IRGenModule::getReflectionTypeRefSectionName() {
-  return getReflectionSectionName(*this, "typeref", "tyrf");
+const char *IRGenModule::getReflectionTypeRefSectionName() {
+  if (ReflectionTypeRefSection.empty())
+    ReflectionTypeRefSection = getReflectionSectionName(*this, "typeref", "tyrf");
+  return ReflectionTypeRefSection.c_str();
 }
 
 llvm::Constant *IRGenModule::getAddrOfFieldName(StringRef Name) {
@@ -852,10 +805,7 @@ IRGenModule::getAddrOfBoxDescriptor(CanType BoxedType) {
     return llvm::Constant::getNullValue(CaptureDescriptorPtrTy);
 
   BoxDescriptorBuilder builder(*this, BoxedType);
-
   auto var = builder.emit();
-  if (var)
-    addUsedGlobal(var);
 
   return llvm::ConstantExpr::getBitCast(var, CaptureDescriptorPtrTy);
 }
@@ -872,10 +822,7 @@ IRGenModule::getAddrOfCaptureDescriptor(SILFunction &Caller,
   CaptureDescriptorBuilder builder(*this, Caller,
                                    OrigCalleeType, SubstCalleeType, Subs,
                                    Layout);
-
   auto var = builder.emit();
-  if (var)
-    addUsedGlobal(var);
 
   return llvm::ConstantExpr::getBitCast(var, CaptureDescriptorPtrTy);
 }
@@ -909,9 +856,7 @@ emitAssociatedTypeMetadataRecord(const ProtocolConformance *Conformance) {
     return;
 
   AssociatedTypeMetadataBuilder builder(*this, Conformance, AssociatedTypes);
-  auto var = builder.emit();
-  if (var)
-    addUsedGlobal(var);
+  builder.emit();
 }
 
 void IRGenModule::emitBuiltinReflectionMetadata() {
@@ -961,9 +906,7 @@ void IRGenModule::emitFieldMetadataRecord(const NominalTypeDecl *Decl) {
     return;
 
   FieldTypeMetadataBuilder builder(*this, Decl);
-  auto var = builder.emit();
-  if (var)
-    addUsedGlobal(var);
+  builder.emit();
 }
 
 void IRGenModule::emitReflectionMetadataVersion() {

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -728,6 +728,14 @@ private:
 
 //--- Remote reflection metadata --------------------------------------------
 public:
+  /// Section names.
+  std::string FieldTypeSection;
+  std::string BuiltinTypeSection;
+  std::string AssociatedTypeSection;
+  std::string CaptureDescriptorSection;
+  std::string ReflectionStringsSection;
+  std::string ReflectionTypeRefSection;
+
   /// Builtin types referenced by types in this module when emitting
   /// reflection metadata.
   llvm::SetVector<CanType> BuiltinTypes;
@@ -770,12 +778,12 @@ public:
   /// Emit a symbol identifying the reflection metadata version.
   void emitReflectionMetadataVersion();
 
-  std::string getBuiltinTypeMetadataSectionName();
-  std::string getFieldTypeMetadataSectionName();
-  std::string getAssociatedTypeMetadataSectionName();
-  std::string getCaptureDescriptorMetadataSectionName();
-  std::string getReflectionStringsSectionName();
-  std::string getReflectionTypeRefSectionName();
+  const char *getBuiltinTypeMetadataSectionName();
+  const char *getFieldTypeMetadataSectionName();
+  const char *getAssociatedTypeMetadataSectionName();
+  const char *getCaptureDescriptorMetadataSectionName();
+  const char *getReflectionStringsSectionName();
+  const char *getReflectionTypeRefSectionName();
 
 //--- Runtime ---------------------------------------------------------------
 public:

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -328,6 +328,10 @@ void LinkEntity::mangle(raw_ostream &buffer) const {
     mangler.append("_TMRa");
     mangler.mangleProtocolConformance(getProtocolConformance());
     return mangler.finalize(buffer);
+  case Kind::ReflectionSuperclassDescriptor:
+    mangler.append("_TMRs");
+    mangler.mangleNominalType(cast<ClassDecl>(getDecl()));
+    return mangler.finalize(buffer);
   }
   llvm_unreachable("bad entity kind!");
 }

--- a/lib/IRGen/Linking.h
+++ b/lib/IRGen/Linking.h
@@ -125,6 +125,9 @@ class LinkEntity {
     /// The pointer is a Decl*.
     Other,
 
+    /// A reflection metadata descriptor for the superclass of a class.
+    ReflectionSuperclassDescriptor,
+
     /// A SIL function. The pointer is a SILFunction*.
     SILFunction,
     
@@ -228,7 +231,7 @@ class LinkEntity {
   }
 
   static bool isDeclKind(Kind k) {
-    return k <= Kind::Other;
+    return k <= Kind::ReflectionSuperclassDescriptor;
   }
   static bool isTypeKind(Kind k) {
     return k >= Kind::ProtocolWitnessTableLazyAccessFunction;
@@ -239,9 +242,9 @@ class LinkEntity {
             k <= Kind::ProtocolWitnessTableLazyCacheVariable);
   }
 
-  void setForDecl(Kind kind, ValueDecl *decl, unsigned uncurryLevel) {
+  void setForDecl(Kind kind, const ValueDecl *decl, unsigned uncurryLevel) {
     assert(isDeclKind(kind));
-    Pointer = decl;
+    Pointer = const_cast<void*>(static_cast<const void*>(decl));
     SecondaryPointer = nullptr;
     Data = LINKENTITY_SET_FIELD(Kind, unsigned(kind))
          | LINKENTITY_SET_FIELD(UncurryLevel, uncurryLevel);
@@ -525,6 +528,13 @@ public:
     return entity;
   }
 
+  static LinkEntity
+  forReflectionSuperclassDescriptor(const ClassDecl *decl) {
+    LinkEntity entity;
+    entity.setForDecl(Kind::ReflectionSuperclassDescriptor, decl, 0);
+    return entity;
+  }
+
 
   void mangle(llvm::raw_ostream &out) const;
   void mangle(SmallVectorImpl<char> &buffer) const;
@@ -541,7 +551,7 @@ public:
   ///
   bool isFragile(IRGenModule &IGM) const;
 
-  ValueDecl *getDecl() const {
+  const ValueDecl *getDecl() const {
     assert(isDeclKind(getKind()));
     return reinterpret_cast<ValueDecl*>(Pointer);
   }

--- a/stdlib/public/Reflection/TypeLowering.cpp
+++ b/stdlib/public/Reflection/TypeLowering.cpp
@@ -776,13 +776,13 @@ public:
 
   MetatypeRepresentation
   visitGenericTypeParameterTypeRef(const GenericTypeParameterTypeRef *GTP) {
-    unreachable("Must have concrete TypeRef");
+    DEBUG(std::cerr << "Unresolved generic TypeRef: "; GTP->dump());
     return MetatypeRepresentation::Unknown;
   }
 
   MetatypeRepresentation
   visitDependentMemberTypeRef(const DependentMemberTypeRef *DM) {
-    unreachable("Must have concrete TypeRef");
+    DEBUG(std::cerr << "Unresolved generic TypeRef: "; DM->dump());
     return MetatypeRepresentation::Unknown;
   }
 
@@ -1118,13 +1118,13 @@ public:
 
   const TypeInfo *
   visitGenericTypeParameterTypeRef(const GenericTypeParameterTypeRef *GTP) {
-    unreachable("Must have concrete TypeRef");
+    DEBUG(std::cerr << "Unresolved generic TypeRef: "; GTP->dump());
     return nullptr;
   }
 
   const TypeInfo *
   visitDependentMemberTypeRef(const DependentMemberTypeRef *DM) {
-    unreachable("Must have concrete TypeRef");
+    DEBUG(std::cerr << "Unresolved generic TypeRef: "; DM->dump());
     return nullptr;
   }
 

--- a/stdlib/public/Reflection/TypeRefBuilder.cpp
+++ b/stdlib/public/Reflection/TypeRefBuilder.cpp
@@ -28,9 +28,18 @@ using namespace reflection;
 
 TypeRefBuilder::TypeRefBuilder() : TC(*this) {}
 
-const AssociatedTypeDescriptor * TypeRefBuilder::
-lookupAssociatedTypes(const std::string &MangledTypeName,
-                      const DependentMemberTypeRef *DependentMember) {
+const TypeRef * TypeRefBuilder::
+lookupTypeWitness(const std::string &MangledTypeName,
+                  const std::string &Member,
+                  const TypeRef *Protocol) {
+  TypeRefID key;
+  key.addString(MangledTypeName);
+  key.addString(Member);
+  key.addPointer(Protocol);
+  auto found = AssociatedTypeCache.find(key);
+  if (found != AssociatedTypeCache.end())
+    return found->second;
+
   // Cache missed - we need to look through all of the assocty sections
   // for all images that we've been notified about.
   for (auto &Info : ReflectionInfos) {
@@ -38,15 +47,24 @@ lookupAssociatedTypes(const std::string &MangledTypeName,
       std::string ConformingTypeName(AssocTyDescriptor.ConformingTypeName);
       if (ConformingTypeName.compare(MangledTypeName) != 0)
         continue;
+
       std::string ProtocolMangledName(AssocTyDescriptor.ProtocolTypeName);
       auto DemangledProto = Demangle::demangleTypeAsNode(ProtocolMangledName);
       auto TR = swift::remote::decodeMangledType(*this, DemangledProto);
 
-      auto &Conformance = *DependentMember->getProtocol();
-      if (auto Protocol = dyn_cast<ProtocolTypeRef>(TR)) {
-        if (*Protocol != Conformance)
+      if (Protocol != TR)
+        continue;
+
+      for (auto &AssocTy : AssocTyDescriptor) {
+        if (Member.compare(AssocTy.getName()) != 0)
           continue;
-        return &AssocTyDescriptor;
+
+        auto SubstitutedTypeName = AssocTy.getMangledSubstitutedTypeName();
+        auto Demangled = Demangle::demangleTypeAsNode(SubstitutedTypeName);
+        auto *TypeWitness = swift::remote::decodeMangledType(*this, Demangled);
+
+        AssociatedTypeCache.insert(std::make_pair(key, TypeWitness));
+        return TypeWitness;
       }
     }
   }
@@ -54,20 +72,28 @@ lookupAssociatedTypes(const std::string &MangledTypeName,
 }
 
 const TypeRef * TypeRefBuilder::
-getDependentMemberTypeRef(const std::string &MangledTypeName,
-                          const DependentMemberTypeRef *DependentMember) {
+lookupSuperclass(const std::string &MangledTypeName) {
+  // Superclasses are recorded as a special associated type named 'super'
+  // on the 'AnyObject' protocol.
+  return lookupTypeWitness(MangledTypeName, "super",
+                           ProtocolTypeRef::create(*this, "Ps9AnyObject_"));
+}
 
-  if (auto AssocTys = lookupAssociatedTypes(MangledTypeName, DependentMember)) {
-    for (auto &AssocTy : *AssocTys) {
-      if (DependentMember->getMember().compare(AssocTy.getName()) != 0)
-        continue;
+const TypeRef * TypeRefBuilder::
+lookupSuperclass(const TypeRef *TR) {
+  const TypeRef *Superclass = nullptr;
 
-      auto SubstitutedTypeName = AssocTy.getMangledSubstitutedTypeName();
-      auto Demangled = Demangle::demangleTypeAsNode(SubstitutedTypeName);
-      return swift::remote::decodeMangledType(*this, Demangled);
-    }
+  if (auto *Nominal = dyn_cast<NominalTypeRef>(TR)) {
+    Superclass = lookupSuperclass(Nominal->getMangledName());
+  } else {
+    auto BG = cast<BoundGenericTypeRef>(TR);
+    Superclass = lookupSuperclass(BG->getMangledName());
   }
-  return nullptr;
+
+  if (Superclass == nullptr)
+    return nullptr;
+
+  return Superclass->subst(*this, TR->getSubstMap());
 }
 
 const FieldDescriptor *

--- a/test/IRGen/closure.swift
+++ b/test/IRGen/closure.swift
@@ -4,7 +4,7 @@
 
 // -- partial_apply context metadata
 
-// CHECK: [[METADATA:@.*]] = private constant %swift.full_boxmetadata { void (%swift.refcounted*)* @objectdestroy, i8** null, %swift.type { i64 64 }, i32 16, i8* bitcast (<{ i32, i32, i32, i32 }>* @"\01l__swift3_capture_descriptor" to i8*) }
+// CHECK: [[METADATA:@.*]] = private constant %swift.full_boxmetadata { void (%swift.refcounted*)* @objectdestroy, i8** null, %swift.type { i64 64 }, i32 16, i8* bitcast (<{ i32, i32, i32, i32 }>* @"\01l__swift3_reflection_descriptor" to i8*) }
 
 func a(i i: Int) -> (Int) -> Int {
   return { x in i }

--- a/test/IRGen/reflection_metadata.swift
+++ b/test/IRGen/reflection_metadata.swift
@@ -37,7 +37,7 @@
 // CHECK-DAG: private constant [3 x i8] c"GS\00", section "{{[^"]*}}swift3_reflstr{{[^"]*}}"
 // CHECK-DAG: private constant [3 x i8] c"GE\00", section "{{[^"]*}}swift3_reflstr{{[^"]*}}"
 
-// CHECK-DAG: @"\01l__swift3_capture_descriptor" = private constant <{ {{.*}} }> <{ i32 1, i32 1, i32 2, {{.*}} }>
+// CHECK-DAG: @"\01l__swift3_reflection_descriptor" = private constant <{ {{.*}} }> <{ i32 1, i32 1, i32 2, {{.*}} }>
 
 // CHECK-DAG: @_TMRfP19reflection_metadata10MyProtocol_ = internal constant {{.*}}swift3_fieldmd
 // CHECK-DAG: @_TMRfC19reflection_metadata7MyClass = internal constant {{.*}}swift3_fieldmd

--- a/test/IRGen/swift3-metadata-coff.swift
+++ b/test/IRGen/swift3-metadata-coff.swift
@@ -23,7 +23,7 @@ public func f(s : S) -> (() -> ()) {
   return { _ = s }
 }
 
-// CHECK-DAG: @"\01l__swift3_capture_descriptor" = private constant {{.*}}, section ".sw3cptr"
+// CHECK-DAG: @"\01l__swift3_reflection_descriptor" = private constant {{.*}}, section ".sw3cptr"
 // CHECK-DAG: @{{[0-9]+}} = private constant [3 x i8] c"Sq\00", section ".sw3tyrf"
 // CHECK-DAG: @{{[0-9]+}} = private constant [5 x i8] c"none\00", section ".sw3rfst"
 // CHECK-DAG: @{{[0-9]+}} = private constant [5 x i8] c"some\00", section ".sw3rfst"

--- a/test/Reflection/Inputs/Missing.swift
+++ b/test/Reflection/Inputs/Missing.swift
@@ -1,0 +1,14 @@
+public struct Box<T> {
+  public let value: T
+}
+
+public protocol P {
+  associatedtype A
+  associatedtype B
+}
+
+public struct Bar<T : P> {
+  public let a: T.A
+  public let b: T.B
+  public let c: (T.A, T.B)
+}

--- a/test/Reflection/Inputs/TypeLowering.swift
+++ b/test/Reflection/Inputs/TypeLowering.swift
@@ -17,10 +17,26 @@ public protocol P {
   associatedtype B
 }
 
-public struct Foo<T, U> : P {
+public protocol Q : P {}
+
+public struct ConformsP<T, U> : P {
   public typealias A = Box<U>
   public typealias B = Box<T>
 }
+
+public struct ConformsQ<T, U> : Q {
+  public typealias A = Box<U>
+  public typealias B = Box<T>
+}
+
+public class Base<T, U> : P {
+  public typealias A = Box<T>
+  public typealias B = Box<U>
+}
+
+public class Derived : Base<Int8, Int16> {}
+
+public class GenericDerived<T> : Base<T, T> {}
 
 public struct Bar<T : P> {
   public let a: T.A
@@ -29,7 +45,11 @@ public struct Bar<T : P> {
 }
 
 public struct AssocTypeStruct {
-  public let t: Bar<Foo<Int8, Int16>>
+  public let t1: Bar<ConformsP<Int8, Int16>>
+  public let t2: Bar<ConformsQ<Int8, Int16>>
+  public let t3: Bar<Base<Int8, Int16>>
+  public let t4: Bar<Derived>
+  public let t5: Bar<GenericDerived<Int8>>
 }
 
 public class C {}

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -37,7 +37,7 @@ V12TypeLowering11BasicStruct
 // CHECK-64-NEXT:           (field name=_value offset=0
 // CHECK-64-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0)))))))
 
-// CHECK-32: (struct TypeLowering.BasicStruct)
+// CHECK-32:      (struct TypeLowering.BasicStruct)
 // CHECK-32-NEXT: (struct size=16 alignment=4 stride=16 num_extra_inhabitants=0
 // CHECK-32-NEXT:   (field name=i1 offset=0
 // CHECK-32-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
@@ -72,8 +72,8 @@ V12TypeLowering11BasicStruct
 
 V12TypeLowering15AssocTypeStruct
 // CHECK-64:      (struct TypeLowering.AssocTypeStruct)
-// CHECK-64-NEXT: (struct size=7 alignment=2 stride=8 num_extra_inhabitants=0
-// CHECK-64-NEXT:   (field name=t offset=0
+// CHECK-64-NEXT: (struct size=36 alignment=2 stride=36 num_extra_inhabitants=0
+// CHECK-64-NEXT:   (field name=t1 offset=0
 // CHECK-64-NEXT:     (struct size=7 alignment=2 stride=8 num_extra_inhabitants=0
 // CHECK-64-NEXT:       (field name=a offset=0
 // CHECK-64-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
@@ -100,11 +100,123 @@ V12TypeLowering15AssocTypeStruct
 // CHECK-64-NEXT:               (field name=value offset=0
 // CHECK-64-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
 // CHECK-64-NEXT:                   (field name=_value offset=0
+// CHECK-64-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0))))))))))
+// CHECK-64-NEXT:   (field name=t2 offset=8
+// CHECK-64-NEXT:     (struct size=7 alignment=2 stride=8 num_extra_inhabitants=0
+// CHECK-64-NEXT:       (field name=a offset=0
+// CHECK-64-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
+// CHECK-64-NEXT:           (field name=value offset=0
+// CHECK-64-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
+// CHECK-64-NEXT:               (field name=_value offset=0
+// CHECK-64-NEXT:                 (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0))))))
+// CHECK-64-NEXT:       (field name=b offset=2
+// CHECK-64-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-64-NEXT:           (field name=value offset=0
+// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-64-NEXT:               (field name=_value offset=0
+// CHECK-64-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0))))))
+// CHECK-64-NEXT:       (field name=c offset=4
+// CHECK-64-NEXT:         (tuple size=3 alignment=2 stride=4 num_extra_inhabitants=0
+// CHECK-64-NEXT:           (field offset=0
+// CHECK-64-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
+// CHECK-64-NEXT:               (field name=value offset=0
+// CHECK-64-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
+// CHECK-64-NEXT:                   (field name=_value offset=0
+// CHECK-64-NEXT:                     (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0))))))
+// CHECK-64-NEXT:           (field offset=2
+// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-64-NEXT:               (field name=value offset=0
+// CHECK-64-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-64-NEXT:                   (field name=_value offset=0
+// CHECK-64-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0))))))))))
+// CHECK-64-NEXT:   (field name=t3 offset=16
+// CHECK-64-NEXT:     (struct size=8 alignment=2 stride=8 num_extra_inhabitants=0
+// CHECK-64-NEXT:       (field name=a offset=0
+// CHECK-64-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-64-NEXT:           (field name=value offset=0
+// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-64-NEXT:               (field name=_value offset=0
+// CHECK-64-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0))))))
+// CHECK-64-NEXT:       (field name=b offset=2
+// CHECK-64-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
+// CHECK-64-NEXT:           (field name=value offset=0
+// CHECK-64-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
+// CHECK-64-NEXT:               (field name=_value offset=0
+// CHECK-64-NEXT:                 (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0))))))
+// CHECK-64-NEXT:       (field name=c offset=4
+// CHECK-64-NEXT:         (tuple size=4 alignment=2 stride=4 num_extra_inhabitants=0
+// CHECK-64-NEXT:           (field offset=0
+// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-64-NEXT:               (field name=value offset=0
+// CHECK-64-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-64-NEXT:                   (field name=_value offset=0
+// CHECK-64-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0))))))
+// CHECK-64-NEXT:           (field offset=2
+// CHECK-64-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
+// CHECK-64-NEXT:               (field name=value offset=0
+// CHECK-64-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
+// CHECK-64-NEXT:                   (field name=_value offset=0
+// CHECK-64-NEXT:                     (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0))))))))))
+// CHECK-64-NEXT:   (field name=t4 offset=24
+// CHECK-64-NEXT:     (struct size=8 alignment=2 stride=8 num_extra_inhabitants=0
+// CHECK-64-NEXT:       (field name=a offset=0
+// CHECK-64-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-64-NEXT:           (field name=value offset=0
+// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-64-NEXT:               (field name=_value offset=0
+// CHECK-64-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0))))))
+// CHECK-64-NEXT:       (field name=b offset=2
+// CHECK-64-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
+// CHECK-64-NEXT:           (field name=value offset=0
+// CHECK-64-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
+// CHECK-64-NEXT:               (field name=_value offset=0
+// CHECK-64-NEXT:                 (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0))))))
+// CHECK-64-NEXT:       (field name=c offset=4
+// CHECK-64-NEXT:         (tuple size=4 alignment=2 stride=4 num_extra_inhabitants=0
+// CHECK-64-NEXT:           (field offset=0
+// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-64-NEXT:               (field name=value offset=0
+// CHECK-64-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-64-NEXT:                   (field name=_value offset=0
+// CHECK-64-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0))))))
+// CHECK-64-NEXT:           (field offset=2
+// CHECK-64-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
+// CHECK-64-NEXT:               (field name=value offset=0
+// CHECK-64-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
+// CHECK-64-NEXT:                   (field name=_value offset=0
+// CHECK-64-NEXT:                     (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0))))))))))
+// CHECK-64-NEXT:   (field name=t5 offset=32
+// CHECK-64-NEXT:     (struct size=4 alignment=1 stride=4 num_extra_inhabitants=0
+// CHECK-64-NEXT:       (field name=a offset=0
+// CHECK-64-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-64-NEXT:           (field name=value offset=0
+// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-64-NEXT:               (field name=_value offset=0
+// CHECK-64-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0))))))
+// CHECK-64-NEXT:       (field name=b offset=1
+// CHECK-64-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-64-NEXT:           (field name=value offset=0
+// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-64-NEXT:               (field name=_value offset=0
+// CHECK-64-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0))))))
+// CHECK-64-NEXT:       (field name=c offset=2
+// CHECK-64-NEXT:         (tuple size=2 alignment=1 stride=2 num_extra_inhabitants=0
+// CHECK-64-NEXT:           (field offset=0
+// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-64-NEXT:               (field name=value offset=0
+// CHECK-64-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-64-NEXT:                   (field name=_value offset=0
+// CHECK-64-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0))))))
+// CHECK-64-NEXT:           (field offset=1
+// CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-64-NEXT:               (field name=value offset=0
+// CHECK-64-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-64-NEXT:                   (field name=_value offset=0
 // CHECK-64-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0)))))))))))
 
-// CHECK-32:     (struct TypeLowering.AssocTypeStruct)
-// CHECK-32-NEXT: (struct size=7 alignment=2 stride=8 num_extra_inhabitants=0
-// CHECK-32-NEXT:   (field name=t offset=0
+// CHECK-32:      (struct TypeLowering.AssocTypeStruct)
+// CHECK-32-NEXT: (struct size=36 alignment=2 stride=36 num_extra_inhabitants=0
+// CHECK-32-NEXT:   (field name=t1 offset=0
 // CHECK-32-NEXT:     (struct size=7 alignment=2 stride=8 num_extra_inhabitants=0
 // CHECK-32-NEXT:       (field name=a offset=0
 // CHECK-32-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
@@ -127,6 +239,118 @@ V12TypeLowering15AssocTypeStruct
 // CHECK-32-NEXT:                   (field name=_value offset=0
 // CHECK-32-NEXT:                     (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0))))))
 // CHECK-32-NEXT:           (field offset=2
+// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-32-NEXT:               (field name=value offset=0
+// CHECK-32-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-32-NEXT:                   (field name=_value offset=0
+// CHECK-32-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0))))))))))
+// CHECK-32-NEXT:   (field name=t2 offset=8
+// CHECK-32-NEXT:     (struct size=7 alignment=2 stride=8 num_extra_inhabitants=0
+// CHECK-32-NEXT:       (field name=a offset=0
+// CHECK-32-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
+// CHECK-32-NEXT:           (field name=value offset=0
+// CHECK-32-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
+// CHECK-32-NEXT:               (field name=_value offset=0
+// CHECK-32-NEXT:                 (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0))))))
+// CHECK-32-NEXT:       (field name=b offset=2
+// CHECK-32-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-32-NEXT:           (field name=value offset=0
+// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-32-NEXT:               (field name=_value offset=0
+// CHECK-32-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0))))))
+// CHECK-32-NEXT:       (field name=c offset=4
+// CHECK-32-NEXT:         (tuple size=3 alignment=2 stride=4 num_extra_inhabitants=0
+// CHECK-32-NEXT:           (field offset=0
+// CHECK-32-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
+// CHECK-32-NEXT:               (field name=value offset=0
+// CHECK-32-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
+// CHECK-32-NEXT:                   (field name=_value offset=0
+// CHECK-32-NEXT:                     (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0))))))
+// CHECK-32-NEXT:           (field offset=2
+// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-32-NEXT:               (field name=value offset=0
+// CHECK-32-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-32-NEXT:                   (field name=_value offset=0
+// CHECK-32-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0))))))))))
+// CHECK-32-NEXT:   (field name=t3 offset=16
+// CHECK-32-NEXT:     (struct size=8 alignment=2 stride=8 num_extra_inhabitants=0
+// CHECK-32-NEXT:       (field name=a offset=0
+// CHECK-32-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-32-NEXT:           (field name=value offset=0
+// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-32-NEXT:               (field name=_value offset=0
+// CHECK-32-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0))))))
+// CHECK-32-NEXT:       (field name=b offset=2
+// CHECK-32-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
+// CHECK-32-NEXT:           (field name=value offset=0
+// CHECK-32-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
+// CHECK-32-NEXT:               (field name=_value offset=0
+// CHECK-32-NEXT:                 (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0))))))
+// CHECK-32-NEXT:       (field name=c offset=4
+// CHECK-32-NEXT:         (tuple size=4 alignment=2 stride=4 num_extra_inhabitants=0
+// CHECK-32-NEXT:           (field offset=0
+// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-32-NEXT:               (field name=value offset=0
+// CHECK-32-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-32-NEXT:                   (field name=_value offset=0
+// CHECK-32-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0))))))
+// CHECK-32-NEXT:           (field offset=2
+// CHECK-32-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
+// CHECK-32-NEXT:               (field name=value offset=0
+// CHECK-32-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
+// CHECK-32-NEXT:                   (field name=_value offset=0
+// CHECK-32-NEXT:                     (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0))))))))))
+// CHECK-32-NEXT:   (field name=t4 offset=24
+// CHECK-32-NEXT:     (struct size=8 alignment=2 stride=8 num_extra_inhabitants=0
+// CHECK-32-NEXT:       (field name=a offset=0
+// CHECK-32-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-32-NEXT:           (field name=value offset=0
+// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-32-NEXT:               (field name=_value offset=0
+// CHECK-32-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0))))))
+// CHECK-32-NEXT:       (field name=b offset=2
+// CHECK-32-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
+// CHECK-32-NEXT:           (field name=value offset=0
+// CHECK-32-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
+// CHECK-32-NEXT:               (field name=_value offset=0
+// CHECK-32-NEXT:                 (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0))))))
+// CHECK-32-NEXT:       (field name=c offset=4
+// CHECK-32-NEXT:         (tuple size=4 alignment=2 stride=4 num_extra_inhabitants=0
+// CHECK-32-NEXT:           (field offset=0
+// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-32-NEXT:               (field name=value offset=0
+// CHECK-32-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-32-NEXT:                   (field name=_value offset=0
+// CHECK-32-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0))))))
+// CHECK-32-NEXT:           (field offset=2
+// CHECK-32-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
+// CHECK-32-NEXT:               (field name=value offset=0
+// CHECK-32-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
+// CHECK-32-NEXT:                   (field name=_value offset=0
+// CHECK-32-NEXT:                     (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0))))))))))
+// CHECK-32-NEXT:   (field name=t5 offset=32
+// CHECK-32-NEXT:     (struct size=4 alignment=1 stride=4 num_extra_inhabitants=0
+// CHECK-32-NEXT:       (field name=a offset=0
+// CHECK-32-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-32-NEXT:           (field name=value offset=0
+// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-32-NEXT:               (field name=_value offset=0
+// CHECK-32-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0))))))
+// CHECK-32-NEXT:       (field name=b offset=1
+// CHECK-32-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-32-NEXT:           (field name=value offset=0
+// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-32-NEXT:               (field name=_value offset=0
+// CHECK-32-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0))))))
+// CHECK-32-NEXT:       (field name=c offset=2
+// CHECK-32-NEXT:         (tuple size=2 alignment=1 stride=2 num_extra_inhabitants=0
+// CHECK-32-NEXT:           (field offset=0
+// CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-32-NEXT:               (field name=value offset=0
+// CHECK-32-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
+// CHECK-32-NEXT:                   (field name=_value offset=0
+// CHECK-32-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0))))))
+// CHECK-32-NEXT:           (field offset=1
 // CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
 // CHECK-32-NEXT:               (field name=value offset=0
 // CHECK-32-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0

--- a/test/Reflection/typeref_lowering_missing.swift
+++ b/test/Reflection/typeref_lowering_missing.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-build-swift %S/Inputs/ConcreteTypes.swift -parse-as-library -emit-module -emit-library -module-name TypeLowering -Xfrontend -disable-reflection-metadata -o %t/libTypesToReflect
+// RUN: %target-build-swift %S/Inputs/Missing.swift -parse-as-library -emit-module -emit-library -module-name TypeLowering -o %t/libTypesToReflect
 // RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect -binary-filename %platform-module-dir/libswiftCore.dylib -dump-type-lowering < %s | %FileCheck %s
 
 // REQUIRES: objc_interop
@@ -11,5 +11,10 @@ V12TypeLowering11BasicStruct
 
 GSqV12TypeLowering11BasicStruct_
 // CHECK: (bound_generic_enum Swift.Optional
+// CHECK:   (struct TypeLowering.BasicStruct))
+// CHECK: Invalid lowering
+
+GV12TypeLowering3BarV12TypeLowering11BasicStruct_
+// CHECK: (bound_generic_struct TypeLowering.Bar
 // CHECK:   (struct TypeLowering.BasicStruct))
 // CHECK: Invalid lowering


### PR DESCRIPTION
- Description: The reflection library did not walk up the superclass chain when looking up associated types. Furthermore, a missing associated type would cause a crash rather than fail gracefully.
- Scope of the issue: Affects anyone trying to use the memory debugger with more advanced generics code. Known to affect ReactiveCocoa in the wild at the very least.
- Risk: Medium, there are lots of changes here but the existing test coverage was so abysmal it's hard to see how this can make things worse.
- Tested: New test added, existing tests pass.
- Radar: rdar://problem/28331935
