### PR TITLE
Fix a compile time performance regression caused by redundant debug info.

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -320,8 +320,7 @@ public:
   /// Keeps track of the mapping of source variables to -O0 shadow copy allocas.
   llvm::SmallDenseMap<StackSlotKey, Address, 8> ShadowStackSlots;
   llvm::SmallDenseMap<Decl *, SmallString<4>, 8> AnonymousVariables;
-  llvm::SmallVector<std::pair<DominancePoint, llvm::Instruction *>, 8>
-      ValueVariables;
+  llvm::SmallDenseMap<llvm::Instruction *, DominancePoint, 8> ValueVariables;
   unsigned NumAnonVars = 0;
   unsigned NumCondFails = 0;
 
@@ -562,9 +561,9 @@ public:
   void emitDebugVariableRangeExtension(const SILBasicBlock *CurBB) {
     if (IGM.IRGen.Opts.Optimize)
       return;
-    for (auto &Variable : reversed(ValueVariables)) {
-      auto VarDominancePoint = Variable.first;
-      llvm::Value *Storage = Variable.second;
+    for (auto &Variable : ValueVariables) {
+      auto VarDominancePoint = Variable.second;
+      llvm::Value *Storage = Variable.first;
       if (getActiveDominancePoint() == VarDominancePoint ||
           isActiveDominancePointDominatedBy(VarDominancePoint)) {
         llvm::Type *ArgTys;
@@ -595,13 +594,14 @@ public:
         // that this shouldn't be necessary. LiveDebugValues should be doing
         // this but can't in general because it currently only tracks register
         // locations.
-        auto It = llvm::BasicBlock::iterator(Variable.second);
-        auto *BB = Variable.second->getParent();
+        llvm::Instruction *Value = Variable.first;
+        auto It = llvm::BasicBlock::iterator(Value);
+        auto *BB = Value->getParent();
         auto *CurBB = Builder.GetInsertBlock();
         if (BB != CurBB)
           for (auto I = std::next(It), E = BB->end(); I != E; ++I) {
             auto *DVI = dyn_cast<llvm::DbgValueInst>(I);
-            if (DVI && DVI->getValue() == Variable.second)
+            if (DVI && DVI->getValue() == Value)
               IGM.DebugInfo->getBuilder().insertDbgValueIntrinsic(
                   DVI->getValue(), 0, DVI->getVariable(), DVI->getExpression(),
                   DVI->getDebugLoc(), &*CurBB->getFirstInsertionPt());
@@ -649,7 +649,7 @@ public:
       if (!needsShadowCopy(Storage)) {
         // Mark for debug value range extension unless this is a constant.
         if (auto *Value = dyn_cast<llvm::Instruction>(Storage))
-          ValueVariables.push_back({getActiveDominancePoint(), Value});
+          ValueVariables.insert({Value, getActiveDominancePoint()});
         return Storage;
       }
 

--- a/test/DebugInfo/liverange-extension.swift
+++ b/test/DebugInfo/liverange-extension.swift
@@ -14,14 +14,14 @@ public func rangeExtension(_ b: Bool) {
     // CHECK: llvm.dbg.value(metadata i32 [[I]], i64 0, metadata
     // CHECK: llvm.dbg.value(metadata i32 [[J:.*]], i64 0, metadata
     use(j)
-    // CHECK: {{(asm sideeffect "", "r".*)|(zext i32)}} [[J]]
-    // CHECK: asm sideeffect "", "r"
+    // CHECK-DAG: {{(asm sideeffect "", "r".*)|(zext i32)}} [[J]]
+    // CHECK-DAG: asm sideeffect "", "r"
   }
   let z = getInt32()
   use(z)
-  // CHECK: llvm.dbg.value(metadata i32 [[I]], i64 0, metadata
   // CHECK-NOT: llvm.dbg.value(metadata i32 [[J]], i64 0, metadata
-  // CHECK: llvm.dbg.value(metadata i32 [[Z:.*]], i64 0, metadata
-  // CHECK: asm sideeffect "", "r"
-  // CHECK: {{(asm sideeffect "", "r".*)|(zext i32)}} [[I]]
+  // CHECK-DAG: llvm.dbg.value(metadata i32 [[I]], i64 0, metadata
+  // CHECK-DAG: llvm.dbg.value(metadata i32 [[Z:.*]], i64 0, metadata
+  // CHECK-DAG: {{(asm sideeffect "", "r".*)|(zext i32)}} [[I]]
+  // CHECK-DAG: asm sideeffect "", "r"
 }

--- a/test/DebugInfo/patternvars.swift
+++ b/test/DebugInfo/patternvars.swift
@@ -1,0 +1,57 @@
+// RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
+
+@_fixed_layout
+public struct UnicodeScalar {
+  var _value: UInt32
+  public var value: UInt32 { return _value }
+}
+
+public func mangle(s: [UnicodeScalar]) -> [UnicodeScalar] {
+  let replacementUnichar = UnicodeScalar(_value: 0)
+  var mangledUnichars: [UnicodeScalar] = s.map {
+    switch $0.value {
+      case
+      // A-Z
+      0x0041...0x005A,
+      // a-z
+      0x0061...0x007A,
+      // 0-9
+      0x0030...0x0039,
+      // _
+      0x005F,
+      // Latin (1)
+      0x00AA...0x00AA:
+      return $0
+    default:
+      return replacementUnichar
+    }
+  }
+  return mangledUnichars
+}
+
+// The patterns in the first case statement each define an anonymous variable,
+// which shares the storage with the expression in the switch statement. Make
+// sure we only emit live range extensions for the storage once per basic block.
+
+// CHECK: define {{.*}}@_TFF11patternvars6mangleFT1sGSaVS_13UnicodeScalar__GSaS0__U_FS0_S0_
+// CHECK: call void asm sideeffect "", "r"
+// CHECK-NOT: call void asm sideeffect "", "r"
+// CHECK: br {{.*}}label
+// CHECK: call void asm sideeffect "", "r"
+// CHECK-NOT: call void asm sideeffect "", "r"
+// CHECK: br {{.*}}label
+// CHECK: call void asm sideeffect "", "r"
+// CHECK-NOT: call void asm sideeffect "", "r"
+// CHECK: br {{.*}}label
+// CHECK: call void asm sideeffect "", "r"
+// CHECK-NOT: call void asm sideeffect "", "r"
+// CHECK: br {{.*}}label
+// CHECK: call void asm sideeffect "", "r"
+// CHECK-NOT: call void asm sideeffect "", "r"
+// CHECK: br {{.*}}label
+// CHECK: call void asm sideeffect "", "r"
+// CHECK-NOT: call void asm sideeffect "", "r"
+// CHECK: br {{.*}}label
+// CHECK: call void asm sideeffect "", "r"
+// CHECK-NOT: call void asm sideeffect "", "r"
+// CHECK: br {{.*}}label


### PR DESCRIPTION
<!-- What's in this pull request? -->

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-2754](https://bugs.swift.org/browse/SR-2754).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

Fix a compile time performance regression caused by redundant debug info.
Even at -Onone one SILValue can back up more than one local source variable.
This commit changes the list of variable values into a set.

rdar://problem/28467349
