### PR TITLE
LTO Debug Info Fixes

### DIFF
--- a/test/DebugInfo/Imports.swift
+++ b/test/DebugInfo/Imports.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend -emit-ir -module-name Foo %s -I %t -g -o - | %FileCheck %s
 // RUN: %target-swift-frontend -c -module-name Foo %s -I %t -g -o %t.o
-// RUN: llvm-dwarfdump %t.o | %FileCheck --check-prefix=DWARF %s
+// RUN: %llvm-dwarfdump %t.o | %FileCheck --check-prefix=DWARF %s
 
 // CHECK-DAG: ![[FOOMODULE:[0-9]+]] = !DIModule({{.*}}, name: "Foo", includePath: "{{.*}}test{{.*}}DebugInfo{{.*}}"
 // CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[THISFILE:[0-9]+]], entity: ![[FOOMODULE]]

--- a/test/DebugInfo/iteration.swift
+++ b/test/DebugInfo/iteration.swift
@@ -29,7 +29,7 @@ func count() {
 count()
 
 // End-to-end test:
-// RUN: llc %t.ll -filetype=obj -o - | llvm-dwarfdump - | %FileCheck %s --check-prefix DWARF-CHECK
+// RUN: llc %t.ll -filetype=obj -o - | %llvm-dwarfdump - | %FileCheck %s --check-prefix DWARF-CHECK
 // DWARF-CHECK:  DW_TAG_variable
 // DWARF-CHECK:  DW_AT_name {{.*}} "letter"
 //

--- a/test/DebugInfo/letstring.swift
+++ b/test/DebugInfo/letstring.swift
@@ -25,7 +25,7 @@ class AppDelegate {
 
 // End-to-end test:
 // RUN: llc %t.ll -filetype=obj -o %t.o
-// RUN: llvm-dwarfdump %t.o | %FileCheck %s --check-prefix DWARF-CHECK
+// RUN: %llvm-dwarfdump %t.o | %FileCheck %s --check-prefix DWARF-CHECK
 // DWARF-CHECK: DW_AT_name {{.*}} "f"
 //
 // DWARF-CHECK: DW_TAG_formal_parameter

--- a/test/DebugInfo/local-vars.swift.gyb
+++ b/test/DebugInfo/local-vars.swift.gyb
@@ -5,7 +5,7 @@
 // RUN: %gyb %s -o %t.swift
 // RUN: %target-swift-frontend %t.swift -g -emit-ir -o - | %FileCheck %t.swift
 // RUN: %target-swift-frontend %t.swift -g -c -o %t.o
-// RUN: llvm-dwarfdump --debug-dump=info %t.o \
+// RUN: %llvm-dwarfdump --debug-dump=info %t.o \
 // RUN:   | %FileCheck %t.swift --check-prefix=DWARF
 // RUN: %target-swift-frontend %t.swift -O -g -emit-ir -o - \
 // RUN:   | %FileCheck %t.swift --check-prefix=OPTZNS

--- a/test/DebugInfo/test-foundation.swift
+++ b/test/DebugInfo/test-foundation.swift
@@ -2,7 +2,7 @@
 // RUN: %FileCheck %s --check-prefix IMPORT-CHECK < %t.ll
 // RUN: %FileCheck %s --check-prefix LOC-CHECK < %t.ll
 // RUN: llc %t.ll -filetype=obj -o %t.o
-// RUN: llvm-dwarfdump %t.o | %FileCheck %s --check-prefix DWARF-CHECK
+// RUN: %llvm-dwarfdump %t.o | %FileCheck %s --check-prefix DWARF-CHECK
 // RUN: dwarfdump --verify %t.o
 
 // REQUIRES: OS=macosx

--- a/test/DebugInfo/typearg.swift
+++ b/test/DebugInfo/typearg.swift
@@ -35,7 +35,7 @@ class Foo<Bar> {
 
 // Verify that the backend doesn't elide the debug intrinsics.
 // RUN: %target-swift-frontend %s -c -g -o %t.o
-// RUN: llvm-dwarfdump %t.o | %FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: %llvm-dwarfdump %t.o | %FileCheck %s --check-prefix=CHECK-LLVM
 // CHECK-LLVM-DAG:  .debug_str[{{.*}}] = "x"
 // CHECK-LLVM-DAG:  .debug_str[{{.*}}] = "$swift.type.T"
 // CHECK- FIXME -LLVM-DAG:  .debug_str[{{.*}}] = "$swift.type.Bar"

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -284,6 +284,7 @@ config.llvm_link = inferSwiftBinary('llvm-link')
 config.swift_llvm_opt = inferSwiftBinary('swift-llvm-opt')
 config.llvm_profdata = inferSwiftBinary('llvm-profdata')
 config.llvm_cov = inferSwiftBinary('llvm-cov')
+config.llvm_dwarfdump = inferSwiftBinary('llvm-dwarfdump')
 
 config.swift_utils = os.path.join(config.swift_src_root, 'utils')
 config.line_directive = os.path.join(config.swift_utils, 'line-directive')
@@ -347,6 +348,7 @@ config.substitutions.append( ('%swift-ide-test_plain', config.swift_ide_test) )
 config.substitutions.append( ('%swift-ide-test', "%r %s %s" % (config.swift_ide_test, mcp_opt, ccp_opt)) )
 config.substitutions.append( ('%llvm-link', config.llvm_link) )
 config.substitutions.append( ('%swift-llvm-opt', config.swift_llvm_opt) )
+config.substitutions.append( ('%llvm-dwarfdump', config.llvm_dwarfdump) )
 
 # This must come after all substitutions containing "%swift".
 config.substitutions.append(
@@ -414,6 +416,7 @@ disallow('lldb-moduleimport-test')
 disallow('swift-ide-test')
 disallow('clang')
 disallow('FileCheck')
+disallow('llvm-dwarfdump')
 
 config.substitutions.insert(0,
     ('%p',

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -722,7 +722,12 @@ function set_build_options_for_host() {
                     )
                 fi
 
+                llvm_cmake_options+=(
+                    -DLLVM_ENABLE_MODULE_DEBUGGING:BOOL=NO
+                )
+
                 swift_cmake_options+=(
+                    -DLLVM_ENABLE_MODULE_DEBUGGING:BOOL=NO
                     "-DSWIFT_PARALLEL_LINK_JOBS=${SWIFT_TOOLS_NUM_PARALLEL_LTO_LINK_JOBS}"
                 )
             fi
@@ -1588,6 +1593,12 @@ function is_cmake_release_build_type() {
     fi
 }
 
+function is_cmake_debuginfo_build_type() {
+    if [[ "$1" == "Debug" || "$1" == "RelWithDebInfo" ]] ; then
+        echo 1
+    fi
+}
+
 function common_cross_c_flags() {
     echo -n "${COMMON_C_FLAGS}"
 
@@ -1630,8 +1641,12 @@ function llvm_c_flags() {
     if [[ $(is_cmake_release_build_type "${LLVM_BUILD_TYPE}") ]] ; then
         echo -n " -fno-stack-protector"
     fi
-    if [[ $(is_llvm_lto_enabled) == "TRUE" ]] ; then
-        echo -n " -gline-tables-only"
+    if [[ $(is_cmake_debuginfo_build_type "${LLVM_BUILD_TYPE}") ]] ; then
+        if [[ $(is_llvm_lto_enabled) == "TRUE" ]] ; then
+            echo -n " -gline-tables-only"
+        else
+            echo -n " -g"
+        fi
     fi
 }
 
@@ -1950,6 +1965,14 @@ for host in "${ALL_HOSTS[@]}"; do
                     "${cmake_options[@]}"
                     -DCMAKE_C_FLAGS="$(llvm_c_flags ${host})"
                     -DCMAKE_CXX_FLAGS="$(llvm_c_flags ${host})"
+                    -DCMAKE_C_FLAGS_DEBUG=""
+                    -DCMAKE_CXX_FLAGS_DEBUG=""
+                    -DCMAKE_C_FLAGS_RELEASE="-O3"
+                    -DCMAKE_CXX_FLAGS_RELEASE="-O3"
+                    -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2"
+                    -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2"
+                    -DCMAKE_C_FLAGS_MINSIZEREL="-Os"
+                    -DCMAKE_CXX_FLAGS_MINSIZEREL="-Os"
                     -DCMAKE_BUILD_TYPE:STRING="${LLVM_BUILD_TYPE}"
                     -DLLVM_ENABLE_ASSERTIONS:BOOL=$(true_false "${LLVM_ENABLE_ASSERTIONS}")
                     -DLLVM_TOOL_SWIFT_BUILD:BOOL=NO
@@ -2065,6 +2088,14 @@ for host in "${ALL_HOSTS[@]}"; do
                     "${cmake_options[@]}"
                     -DCMAKE_C_FLAGS="$(swift_c_flags ${host})"
                     -DCMAKE_CXX_FLAGS="$(swift_c_flags ${host})"
+                    -DCMAKE_C_FLAGS_DEBUG=""
+                    -DCMAKE_CXX_FLAGS_DEBUG=""
+                    -DCMAKE_C_FLAGS_RELEASE="-O3"
+                    -DCMAKE_CXX_FLAGS_RELEASE="-O3"
+                    -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2"
+                    -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2"
+                    -DCMAKE_C_FLAGS_MINSIZEREL="-Os"
+                    -DCMAKE_CXX_FLAGS_MINSIZEREL="-Os"
                     -DCMAKE_BUILD_TYPE:STRING="${SWIFT_BUILD_TYPE}"
                     -DLLVM_ENABLE_ASSERTIONS:BOOL=$(true_false "${SWIFT_ENABLE_ASSERTIONS}")
                     -DSWIFT_ANALYZE_CODE_COVERAGE:STRING=$(toupper "${SWIFT_ANALYZE_CODE_COVERAGE}")

--- a/validation-test/LTO/lto-object-files-only-have-line-tables.test-sh
+++ b/validation-test/LTO/lto-object-files-only-have-line-tables.test-sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# This test makes sure that if lto is enabled:
+#
+# 1. We have lto object files for swift in our build tree. We swift and libswiftdemangle.
+# 2. These lto output files all have line tables in the swift include directory,
+#    but do not have full debug info. To check for the latter case, we look for
+#    SmallVector a commonly used data type.
+# 3. We use swift-demangle since it is a much smaller executable than all of
+#    swift.
+
+set -e
+set -u
+
+# REQUIRES: lto
+# REQUIRES: OS=macosx
+# REQUIRES: tools-debuginfo
+# RUN: rm -rf %t
+# RUN: mkdir -p %t
+# RUN: %s %swift_obj_root %t %llvm-dwarfdump
+
+OBJECT_ROOT=$1
+TEMP_DIR=$2
+DWARFDUMP=$3
+
+SWIFT_DEMANGLE_LTO_OBJECT_FILE=$(find ${OBJECT_ROOT} -path '*/swift-demangle/swift-demangle*-lto.o' | head -1)
+
+# Check that we have a temporary lto file for swift.
+if [[ -z "${SWIFT_DEMANGLE_LTO_OBJECT_FILE}" ]]; then
+   echo "Failed to find a temporary debug file for swift-demangle?!"
+   exit 1
+else
+    echo "Found swift-demangle LTO object!"
+fi
+
+${DWARFDUMP} -debug-dump=line ${SWIFT_DEMANGLE_LTO_OBJECT_FILE} > ${TEMP_DIR}/line.info
+
+# Make sure that we found a line table.
+if [[ -z "$(sed -n "/include_directories.*=.*include\/swift/{p;q;}" ${TEMP_DIR}/line.info)" ]] ; then
+  echo "Failed to find line table information for swift-demangle?!"
+  exit 1
+else
+  echo "Found line table information for swift-demangle in swift LTO object"
+fi
+
+${DWARFDUMP} -debug-dump=apple_types ${SWIFT_DEMANGLE_LTO_OBJECT_FILE} > ${TEMP_DIR}/types.info
+
+# And that it does not have full debug info
+if [[ -n "$(sed -n '/Name:.*SmallVector<..*>/{p;q;}' ${TEMP_DIR}/types.info)" ]] ; then
+  echo "Found full debug info in the swift-demangle lto object?!"
+  exit 1
+else
+  echo "Did not find full debug info for swift-demangle lto object!"
+fi
+
+echo "The swift-demangle binary only has line table debug info!"
+
+set +u
+set +e

--- a/validation-test/lit.site.cfg.in
+++ b/validation-test/lit.site.cfg.in
@@ -50,6 +50,10 @@ if "@LLVM_ENABLE_ASSERTIONS@" == "TRUE":
 else:
     config.available_features.add('no_asserts')
 
+# If tools have debug info, set the tools-debuginfo flag.
+if "@CMAKE_BUILD_TYPE@" in ["Debug", "RelWithDebInfo"]:
+    config.available_features.add('tools-debuginfo')
+
 if "@SWIFT_STDLIB_ASSERTIONS@" == "TRUE":
     config.available_features.add('swift_stdlib_asserts')
 else:


### PR DESCRIPTION
• Explanation: We were passing in debug info flags twice on the command line, once with -gline-tables-only and later with -g. This then caused us to use full debug info and have a slower build.
• Scope of Issue: The full debug info caused the swift LTO build to be slower than it needed to be.
• Origination: The issue was introduced when the LTO build was brought up.
• Risk: There is no risk here since we are only changing debug info. Compiler codegen will not change and the end users compile time will not change. The only change will be that we will get better compile time when building swift with LTO.
• Nominated Reviewers: @llvm-beanz already reviewed this.
• Testing: I added a lit test to the compiler test-suite that validates that: 1. we are generating the intermediate lto files not in /tmp, but in tree and also that verifies that these intermediate files contain line tables and not full debug info. My test was written using dwarfdump. So to verify this, one just needs to run a RelWithDebInfo build with LTO.
• Bug: rdar://28484159
