### PR TITLE
[3.0] [TypeCheckType] Setters are escaping by default only at top level.

### DIFF
--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -1313,6 +1313,22 @@ public func ParamAttrs4(a : @escaping () -> ()) {
   a()
 }
 
+// Setter
+// PASS_PRINT_AST: class FooClassComputed {
+class FooClassComputed {
+
+// PASS_PRINT_AST:   var stored: (((Int) -> Int) -> Int)?
+  var stored : (((Int) -> Int) -> Int)? = nil
+
+// PASS_PRINT_AST:   var computed: ((Int) -> Int) -> Int { get set }
+  var computed : ((Int) -> Int) -> Int {
+    get { return stored! }
+    set { stored = newValue }
+  }
+
+// PASS_PRINT_AST: }
+}
+
 // Protocol extensions
 
 protocol ProtocolToExtend {

--- a/test/attr/attr_escaping.swift
+++ b/test/attr/attr_escaping.swift
@@ -142,3 +142,16 @@ func takesVarargsOfFunctions(fns: () -> ()...) {
 func takesNoEscapeFunction(fn: () -> ()) { // expected-note {{parameter 'fn' is implicitly non-escaping}}
   takesVarargsOfFunctions(fns: fn) // expected-error {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
 }
+
+
+class FooClass {
+  var stored : Optional<(()->Int)->Void> = nil
+  var computed : (()->Int)->Void {
+    get { return stored! }
+    set(newValue) { stored = newValue } // ok
+  }
+  var computedEscaping : (@escaping ()->Int)->Void {
+    get { return stored! }
+    set(newValue) { stored = newValue } // expected-error{{cannot assign value of type '(@escaping () -> Int) -> Void' to type 'Optional<(() -> Int) -> Void>' (aka 'Optional<(() -> Int) -> ()>')}}
+  }
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->

3.0 version of https://github.com/apple/swift/pull/5025

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

We have a special case check for the no-escape-by-default rules for a
computed property setter's newValue argument, which if a closure,
obviously has to be escaping. But, we checked this by checking the
type's overall DeclContext, which unfortunately meant we also made
nested closures escaping implicitly. This fixes that to only tack on
the implicit escaping at the top level for the setter's type.

Conflict fixed for 3.0 version.

• Explanation:  We have a special case check for the no-escape-by-default rules for a computed property setter's newValue argument, which if a closure, obviously has to be escaping. But, we checked this by checking the type's overall DeclContext, which unfortunately meant we also made nested closures escaping implicitly. This fixes that to only tack on the implicit escaping at the top level for the setter's type.
• Scope of Issue:  The bug affects anyone trying to have a computed property of a closure that takes another closure, which is fixed by the PR. But, this PR will affect source compatibility for any code that has a closure computed property that takes another closure as an argument, and relied on it being incorrectly inferred as escaping. However, such code would not compile correctly (crashes SILGen) if used in non-trivial ways.
• Origination: Swift-3, when we added the noescape-by-default rule
• Risk: Low. It’s unlikely that many are exercising this corner case and are relying on the wrong behavior that currently exist. If they are, then they will start crashing the compiler should they use their code in non-trivial ways
• Reviewed By:  Doug and Slava
• Testing: Added lit tests
• Directions for QA: none

rdar://problem/28484375
