### PR TITLE
Always ensure that we generate code for referenced transparent functions.

### DIFF
--- a/test/SILOptimizer/no_external_def_to_decl_for_transparent.sil
+++ b/test/SILOptimizer/no_external_def_to_decl_for_transparent.sil
@@ -1,0 +1,39 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -external-func-definition-elim | %FileCheck %s 
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+
+public class X {
+  func testit() -> () -> ()
+  deinit
+  init()
+}
+
+// Check if we keep the body of the externally available transparent function.
+
+// CHECK-LABEL: sil public_external [transparent] [fragile] @imported_transparent_func : $@convention(thin) () -> () {
+sil public_external [transparent] [fragile] @imported_transparent_func : $@convention(thin) () -> () {
+bb0:
+  %r = tuple ()
+  return %r : $()
+}
+
+
+sil private @_TFC4test1X6testitfT_FT_T_  : $@convention(method) (@guaranteed X) -> @owned @callee_owned () -> () {
+bb0(%0 : $X):
+  %6 = function_ref @imported_transparent_func : $@convention(thin) () -> ()
+  %7 = thin_to_thick_function %6 : $@convention(thin) () -> () to $@callee_owned () -> ()
+  return %7 : $@callee_owned () -> ()
+}
+
+sil @_TFC4test1XD : $@convention(method) (@owned X) -> ()
+
+sil_vtable X {
+  #X.testit!1: _TFC4test1X6testitfT_FT_T_
+  #X.deinit!deallocator: _TFC4test1XD
+}
+


### PR DESCRIPTION
We didn't do this if the transparent function was only reachable via a vtable/witness table.

rdar://problem/28294466

• Explanation:  For transparent functions no code is generated in the module which defines such functions (e.g. the stdlib). Instead the module which imports a transparent function - and does not inline it for some reason - has to generate code for it. The problem is that this does not happen if a transparent function is only reachable through a vtable or witness table. The result is a linker error.
• Scope of Issue:  The bug can show up if a transparent function (like any of the basic operators) is not "called" but e.g. passed as a closure. And this is done in function which is only called from a class or witness method, or in a class/witness method itself.
• Origination: Swift-3. 
• Risk: Low. This change explicitly only handles this special case and has no other effects.
• Reviewed By:  Roman and Slava
• Testing: by a swift regression test
• Directions for QA: none
