### PR TITLE
[CMake] Fix bad dependency in symlink_clang_headers

### DIFF
--- a/cmake/modules/SwiftComponents.cmake
+++ b/cmake/modules/SwiftComponents.cmake
@@ -122,3 +122,29 @@ function(swift_install_in_component component)
     install(${ARGN})
   endif()
 endfunction()
+
+function(swift_install_symlink_component component)
+  cmake_parse_arguments(
+      ARG # prefix
+      "" "LINK_NAME;TARGET;DESTINATION" "" ${ARGN})
+  precondition(ARG_LINK_NAME MESSAGE "LINK_NAME is required")
+  precondition(ARG_TARGET MESSAGE "TARGET is required")
+  precondition(ARG_DESTINATION MESSAGE "DESTINATION is required")
+
+  swift_is_installing_component("${component}" is_installing)
+  if (NOT is_installing)
+    return()
+  endif()
+
+  foreach(path ${CMAKE_MODULE_PATH})
+    if(EXISTS ${path}/LLVMInstallSymlink.cmake)
+      set(INSTALL_SYMLINK ${path}/LLVMInstallSymlink.cmake)
+      break()
+    endif()
+  endforeach()
+  precondition(INSTALL_SYMLINK
+    MESSAGE "LLVMInstallSymlink script must be available.")
+
+  install(SCRIPT ${INSTALL_SYMLINK}
+          CODE "install_symlink(${ARG_LINK_NAME} ${ARG_TARGET} ${ARG_DESTINATION})")
+endfunction()

--- a/stdlib/public/SwiftShims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/CMakeLists.txt
@@ -80,22 +80,8 @@ add_custom_command_target(unused_var
       "${clang_headers_location}"
       "${SWIFTLIB_DIR}/clang"
 
-    # Create a broken symlink that points to '../clang/$VERSION'.  It is not
-    # used when running Swift tools from the build tree directly, but we will
-    # install it in such a way that it points to Clang installation.  If the 
-    # link can be resolved, CMake would try to follow it when installing the
-    # project under certain conditions.
-    COMMAND
-      "${CMAKE_COMMAND}" "-E" "make_directory" "${SWIFTLIB_DIR}/install-tmp/install-tmp"
-    COMMAND
-      "${CMAKE_COMMAND}" "-E" "remove"
-      "${SWIFTLIB_DIR}/install-tmp/install-tmp/clang"
-    COMMAND
-      "${CMAKE_COMMAND}" "-E" "create_symlink"
-      "../clang/${CLANG_VERSION}"
-      "${SWIFTLIB_DIR}/install-tmp/install-tmp/clang"
     CUSTOM_TARGET_NAME "symlink_clang_headers"
-    OUTPUT "${SWIFTLIB_DIR}/clang" "${SWIFTLIB_DIR}/install-tmp/install-tmp/clang"
+    OUTPUT "${SWIFTLIB_DIR}/clang"
     COMMENT "Symlinking Clang resource headers into ${SWIFTLIB_DIR}/clang")
 add_dependencies(copy_shim_headers symlink_clang_headers)
 
@@ -110,10 +96,10 @@ swift_install_in_component(clang-builtin-headers
     DESTINATION "lib/swift/clang"
     PATTERN "*.h")
 
-# Alternatively, install a symbolic link to the Clang resource directory.
-swift_install_in_component(clang-resource-dir-symlink
-    DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib/swift/install-tmp/install-tmp/clang"
-    DESTINATION "lib/swift")
+swift_install_symlink_component(clang-resource-dir-symlink
+  LINK_NAME clang
+  TARGET ../clang/${CLANG_VERSION}
+  DESTINATION "lib/swift")
 
 # Possibly install Clang headers under Clang's resource directory in case we
 # need to use a different version of the headers than the installed Clang. This


### PR DESCRIPTION
The problem here is a bit complicated. The symlink_clang_headers target creates two symlinks to clang's headers, one under the build directory at lib/swift/clang, and the other under a temporary path.

The one under the temporary path is a bad symlink, and it is only created during the build so that it can be installed. It isn't actually used by the build. Ninja treats the bad symlink as a non-existing file, and since the build rule that creates it has the restat property on it this results in the commands to symlink the clang headers directory running over and over and over again during the build.

This patch prevents that by not generating the bad symlink during the build. Instead we generate it at install time using the LLVMInstallSymlink script that is vended as part of LLVM's distribution.
