### PR TITLE
[APINotes] Fix mis-annotated error code enums.

### DIFF
--- a/apinotes/CMakeLists.txt
+++ b/apinotes/CMakeLists.txt
@@ -35,7 +35,6 @@ set(SWIFT_API_NOTES_INPUTS
   ObjectiveC
   PassKit
   Photos
-  QuartzCore
   QuickLook
   SafariServices
   SceneKit

--- a/apinotes/Metal.apinotes
+++ b/apinotes/Metal.apinotes
@@ -2,11 +2,11 @@
 Name: Metal
 Tags:
 - Name: MTLCommandBufferError
-  SwiftName: MTLCommandBufferErrorDomain
+  NSErrorDomain: MTLCommandBufferErrorDomain
 - Name: MTLLibraryError
-  SwiftName: MTLLibraryErrorDomain
+  NSErrorDomain: MTLLibraryErrorDomain
 - Name: MTLRenderPipelineError
-  SwiftName: MTLRenderPipelineErrorDomain
+  NSErrorDomain: MTLRenderPipelineErrorDomain
 Enumerators:
 - Name: MTLResourceStorageModeShared
   SwiftName: storageModeShared

--- a/apinotes/NetworkExtension.apinotes
+++ b/apinotes/NetworkExtension.apinotes
@@ -2,10 +2,10 @@
 Name: NetworkExtension
 Tags:
 - Name: NEAppProxyFlowError
-  SwiftName: NEAppProxyErrorDomain
+  NSErrorDomain: NEAppProxyErrorDomain
 - Name: NEFilterError
-  SwiftName: NEFilterErrorDomain
+  NSErrorDomain: NEFilterErrorDomain
 - Name: NETunnelProviderError
-  SwiftName: NETunnelProviderErrorDomain
+  NSErrorDomain: NETunnelProviderErrorDomain
 - Name: NEVPNError
-  SwiftName: NEVPNErrorDomain
+  NSErrorDomain: NEVPNErrorDomain

--- a/apinotes/QuartzCore.apinotes
+++ b/apinotes/QuartzCore.apinotes
@@ -1,5 +1,0 @@
----
-Name: QuartzCore
-Classes:
-- Name: NSEnumerator
-  SwiftName: NSEnumerator

--- a/apinotes/SafariServices.apinotes
+++ b/apinotes/SafariServices.apinotes
@@ -2,6 +2,6 @@
 Name: SafariServices
 Tags:
 - Name: SFErrorCode
-  SwiftName: SFErrorDomain
+  NSErrorDomain: SFErrorDomain
 - Name: SSReadingListErrorCode
-  SwiftName: SSReadingListErrorDomain
+  NSErrorDomain: SSReadingListErrorDomain


### PR DESCRIPTION
Some files accidentally _renamed_ the enums using `SwiftName` rather than associating them with an error domain constant using `NSErrorDomain`. Amazingly, we've gotten no complaints about this.
