### PR TITLE
IRGen: Don't represent enums with weird-sized LLVM integer types.

### DIFF
--- a/lib/IRGen/EnumPayload.cpp
+++ b/lib/IRGen/EnumPayload.cpp
@@ -672,6 +672,69 @@ EnumPayload::emitApplyOrMask(IRGenFunction &IGF,
   }
 }
 
+/// Gather spare bits into the low bits of a smaller integer value.
+llvm::Value *irgen::emitGatherSpareBits(IRGenFunction &IGF,
+                                        const SpareBitVector &spareBitMask,
+                                        llvm::Value *spareBits,
+                                        unsigned resultLowBit,
+                                        unsigned resultBitWidth) {
+  auto destTy
+    = llvm::IntegerType::get(IGF.IGM.getLLVMContext(), resultBitWidth);
+  unsigned usedBits = resultLowBit;
+  llvm::Value *result = nullptr;
+
+  auto spareBitEnumeration = spareBitMask.enumerateSetBits();
+  for (auto optSpareBit = spareBitEnumeration.findNext();
+       optSpareBit.hasValue() && usedBits < resultBitWidth;
+       optSpareBit = spareBitEnumeration.findNext()) {
+    unsigned u = optSpareBit.getValue();
+    assert(u >= (usedBits - resultLowBit) &&
+           "used more bits than we've processed?!");
+
+    // Shift the bits into place.
+    llvm::Value *newBits;
+    if (u > usedBits)
+      newBits = IGF.Builder.CreateLShr(spareBits, u - usedBits);
+    else if (u < usedBits)
+      newBits = IGF.Builder.CreateShl(spareBits, usedBits - u);
+    else
+      newBits = spareBits;
+    newBits = IGF.Builder.CreateZExtOrTrunc(newBits, destTy);
+
+    // See how many consecutive bits we have.
+    unsigned numBits = 1;
+    ++u;
+    // We don't need more bits than the size of the result.
+    unsigned maxBits = resultBitWidth - usedBits;
+    for (unsigned e = spareBitMask.size();
+         u < e && numBits < maxBits && spareBitMask[u];
+         ++u) {
+      ++numBits;
+      (void) spareBitEnumeration.findNext();
+    }
+
+    // Mask out the selected bits.
+    auto val = APInt::getAllOnesValue(numBits);
+    if (numBits < resultBitWidth)
+      val = val.zext(resultBitWidth);
+    val = val.shl(usedBits);
+    auto *mask = llvm::ConstantInt::get(IGF.IGM.getLLVMContext(), val);
+    newBits = IGF.Builder.CreateAnd(newBits, mask);
+
+    // Accumulate the result.
+    if (result)
+      result = IGF.Builder.CreateOr(result, newBits);
+    else
+      result = newBits;
+
+    usedBits += numBits;
+  }
+
+  return result;
+}
+
+
+
 llvm::Value *
 EnumPayload::emitGatherSpareBits(IRGenFunction &IGF,
                                  const SpareBitVector &spareBits,

--- a/lib/IRGen/IRGen.h
+++ b/lib/IRGen/IRGen.h
@@ -262,6 +262,10 @@ public:
 
   constexpr Size() : Value(0) {}
   explicit constexpr Size(int_type Value) : Value(Value) {}
+  
+  static constexpr Size forBits(int_type bitSize) {
+    return Size((bitSize + 7U) / 8U);
+  }
 
   /// An "invalid" size, equal to the maximum possible size.
   static constexpr Size invalid() { return Size(~int_type(0)); }

--- a/test/IRGen/alignment.sil
+++ b/test/IRGen/alignment.sil
@@ -49,9 +49,9 @@ entry:
   %x = load %c : $*Empty
   store %x to %c : $*Empty
 
-  // CHECK: load i2{{.*}}, align 16
+  // CHECK: load i8{{.*}}, align 16
   %w = load %d : $*NoPayload
-  // CHECK: store i2{{.*}}, align 16
+  // CHECK: store i8{{.*}}, align 16
   store %w to %d : $*NoPayload
 
   // CHECK: load i32{{.*}}, align 16
@@ -62,10 +62,10 @@ entry:
   store %v to %e : $*SinglePayload
 
   // CHECK: load i32{{.*}}, align 16
-  // CHECK: load i2{{.*}}, align 4
+  // CHECK: load i8{{.*}}, align 4
   %u = load %f : $*MultiPayload
   // CHECK: store i32{{.*}}, align 16
-  // CHECK: store i2{{.*}}, align 4
+  // CHECK: store i8{{.*}}, align 4
   store %u to %f : $*MultiPayload
 
   dealloc_stack %f : $*MultiPayload

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -16,8 +16,8 @@ import Swift
 // CHECK: %O4enum12SingletonRef = type <{ %swift.refcounted* }>
 
 // -- No-payload enums. The representation is just an enum tag.
-// CHECK: %O4enum10NoPayloads = type <{ i2 }>
-// CHECK: %O4enum11NoPayloads2 = type <{ i3 }>
+// CHECK: %O4enum10NoPayloads = type <{ i8 }>
+// CHECK: %O4enum11NoPayloads2 = type <{ i8 }>
 
 // -- Single-payload enum, no extra inhabitants in the payload type. The
 //    representation adds a tag bit to distinguish payload from enum tag:
@@ -290,14 +290,14 @@ sil @e : $@convention(thin) () -> ()
 sil @f : $@convention(thin) () -> ()
 
 
-// CHECK: define{{( protected)?}} void @no_payload_switch(i2) {{.*}} {
+// CHECK: define{{( protected)?}} void @no_payload_switch(i8) {{.*}} {
 sil @no_payload_switch : $@convention(thin) (NoPayloads) -> () {
 // CHECK: entry:
 entry(%u : $NoPayloads):
-// CHECK:   switch i2 %0, label %[[DFLT:[0-9]+]] [
-// CHECK:     i2 0, label %[[X_DEST:[0-9]+]]
-// CHECK:     i2 1, label %[[Y_DEST:[0-9]+]]
-// CHECK:     i2 -2, label %[[Z_DEST:[0-9]+]]
+// CHECK:   switch i8 %0, label %[[DFLT:[0-9]+]] [
+// CHECK:     i8 0, label %[[X_DEST:[0-9]+]]
+// CHECK:     i8 1, label %[[Y_DEST:[0-9]+]]
+// CHECK:     i8 2, label %[[Z_DEST:[0-9]+]]
 // CHECK:   ]
 // CHECK: ; <label>:[[DFLT]]
 // CHECK:   unreachable
@@ -336,8 +336,8 @@ end:
 sil @no_payload_switch_indirect : $@convention(thin) (@inout NoPayloads) -> () {
 entry(%u : $*NoPayloads):
 // CHECK:   [[TAG_ADDR:%.*]] = getelementptr inbounds %O4enum10NoPayloads, %O4enum10NoPayloads* %0, i32 0, i32 0
-// CHECK:   [[TAG:%.*]] = load i2, i2* [[TAG_ADDR]]
-// CHECK:   switch i2 [[TAG]]
+// CHECK:   [[TAG:%.*]] = load i8, i8* [[TAG_ADDR]]
+// CHECK:   switch i8 [[TAG]]
   switch_enum_addr %u : $*NoPayloads, case #NoPayloads.x!enumelt: x_dest, case #NoPayloads.y!enumelt: y_dest, case #NoPayloads.z!enumelt: z_dest
 
 x_dest:
@@ -351,9 +351,9 @@ end:
   return %x : $()
 }
 
-// CHECK: define{{( protected)?}} i2 @no_payload_inject_x() {{.*}} {
+// CHECK: define{{( protected)?}} i8 @no_payload_inject_x() {{.*}} {
 // CHECK: entry:
-// CHECK:   ret i2 0
+// CHECK:   ret i8 0
 // CHECK: }
 sil @no_payload_inject_x : $() -> NoPayloads {
 entry:
@@ -361,9 +361,9 @@ entry:
   return %u : $NoPayloads
 }
 
-// CHECK: define{{( protected)?}} i2 @no_payload_inject_y() {{.*}} {
+// CHECK: define{{( protected)?}} i8 @no_payload_inject_y() {{.*}} {
 // CHECK: entry:
-// CHECK:   ret i2 1
+// CHECK:   ret i8 1
 // CHECK: }
 sil @no_payload_inject_y : $() -> NoPayloads {
 entry:
@@ -371,9 +371,9 @@ entry:
   return %u : $NoPayloads
 }
 
-// CHECK: define{{( protected)?}} i2 @no_payload_inject_z() {{.*}} {
+// CHECK: define{{( protected)?}} i8 @no_payload_inject_z() {{.*}} {
 // CHECK: entry:
-// CHECK:   ret i2 -2
+// CHECK:   ret i8 2
 // CHECK: }
 sil @no_payload_inject_z : $() -> NoPayloads {
 entry:
@@ -384,7 +384,7 @@ entry:
 // CHECK: define{{( protected)?}} void @no_payload_inject_z_indirect(%O4enum10NoPayloads* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[TAG_ADDR:%.*]] = getelementptr inbounds %O4enum10NoPayloads, %O4enum10NoPayloads* %0, i32 0, i32 0
-// CHECK:   store i2 -2, i2* [[TAG_ADDR]]
+// CHECK:   store i8 2, i8* [[TAG_ADDR]]
 // CHECK:   ret void
 // CHECK: }
 sil @no_payload_inject_z_indirect : $(@inout NoPayloads) -> () {
@@ -404,12 +404,12 @@ enum NoPayloads2 {
   case y
 }
 
-// CHECK: define{{( protected)?}} void @no_payload_switch_2(i3) {{.*}} {
+// CHECK: define{{( protected)?}} void @no_payload_switch_2(i8) {{.*}} {
 sil @no_payload_switch_2 : $@convention(thin) (NoPayloads2) -> () {
 // CHECK: entry:
 entry(%u : $NoPayloads2):
-// CHECK:   switch i3 %0, label %[[DEFAULT_DEST:[0-9]+]] [
-// CHECK:     i3 -4, label %[[U_DEST:[0-9]+]]
+// CHECK:   switch i8 %0, label %[[DEFAULT_DEST:[0-9]+]] [
+// CHECK:     i8 4, label %[[U_DEST:[0-9]+]]
 // CHECK:   ]
   switch_enum %u : $NoPayloads2, case #NoPayloads2.u!enumelt: u_dest, default default_dest
 
@@ -1040,10 +1040,10 @@ h_dest:
   br end
 
 a_dest(%w : $NoPayloads):
-// CHECK:   switch i2 {{%.*}}, label {{%.*}} [
-// CHECK:     i2 0, label {{%.*}}
-// CHECK:     i2 1, label {{%.*}}
-// CHECK:     i2 -2, label {{%.*}}
+// CHECK:   switch i8 {{%.*}}, label {{%.*}} [
+// CHECK:     i8 0, label {{%.*}}
+// CHECK:     i8 1, label {{%.*}}
+// CHECK:     i8 2, label {{%.*}}
 // CHECK:   ]
   switch_enum %w : $NoPayloads, case #NoPayloads.x!enumelt: x_dest, case #NoPayloads.y!enumelt: y_dest, case #NoPayloads.z!enumelt: z_dest
 b_dest:
@@ -1264,12 +1264,12 @@ entry(%r : $*DynamicSinglePayload<T>):
 // -- Ensure instantiations of single-payload types with empty payloads work.
 //    Bug discovered by Greg Parker.
 
-// CHECK: define{{( protected)?}} void @dynamic_single_payload_empty_payload_switch(i2) {{.*}} {
-// CHECK:   switch i2 {{%.*}}, label {{.*}} [
-// CHECK:     i2 0, label {{.*}}
-// CHECK:     i2 1, label {{.*}}
-// CHECK:     i2 -2, label {{.*}}
-// CHECK:     i2 -1, label {{.*}}
+// CHECK: define{{( protected)?}} void @dynamic_single_payload_empty_payload_switch(i8) {{.*}} {
+// CHECK:   switch i8 {{%.*}}, label {{.*}} [
+// CHECK:     i8 0, label {{.*}}
+// CHECK:     i8 1, label {{.*}}
+// CHECK:     i8 2, label {{.*}}
+// CHECK:     i8 3, label {{.*}}
 // CHECK:   ]
 sil @dynamic_single_payload_empty_payload_switch : $DynamicSinglePayload<()> -> () {
 entry(%x : $DynamicSinglePayload<()>):
@@ -1294,11 +1294,11 @@ end(%z : $()):
   return %z : $()
 }
 
-// CHECK: define{{( protected)?}} i2 @dynamic_single_payload_empty_payload_load([[DYNAMIC_SINGLE_EMPTY_PAYLOAD]]* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK: define{{( protected)?}} i8 @dynamic_single_payload_empty_payload_load([[DYNAMIC_SINGLE_EMPTY_PAYLOAD]]* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK: entry:
-// CHECK:   %1 = bitcast [[DYNAMIC_SINGLE_EMPTY_PAYLOAD]]* %0 to i2*
-// CHECK:   %2 = load i2, i2* %1
-// CHECK:   ret i2 %2
+// CHECK:   %1 = bitcast [[DYNAMIC_SINGLE_EMPTY_PAYLOAD]]* %0 to i8*
+// CHECK:   %2 = load i8, i8* %1
+// CHECK:   ret i8 %2
 // CHECK: }
 sil @dynamic_single_payload_empty_payload_load : $(@inout DynamicSinglePayload<()>) -> DynamicSinglePayload<()> {
 entry(%p : $*DynamicSinglePayload<()>):
@@ -1306,10 +1306,10 @@ entry(%p : $*DynamicSinglePayload<()>):
   return %x : $DynamicSinglePayload<()>
 }
 
-// CHECK: define{{( protected)?}} void @dynamic_single_payload_empty_payload_store([[DYNAMIC_SINGLE_EMPTY_PAYLOAD]]* nocapture dereferenceable({{.*}}), i2) {{.*}} {
+// CHECK: define{{( protected)?}} void @dynamic_single_payload_empty_payload_store([[DYNAMIC_SINGLE_EMPTY_PAYLOAD]]* nocapture dereferenceable({{.*}}), i8) {{.*}} {
 // CHECK: entry:
-// CHECK:   %2 = bitcast [[DYNAMIC_SINGLE_EMPTY_PAYLOAD]]* %0 to i2*
-// CHECK:   store i2 %1, i2* %2
+// CHECK:   %2 = bitcast [[DYNAMIC_SINGLE_EMPTY_PAYLOAD]]* %0 to i8*
+// CHECK:   store i8 %1, i8* %2
 // CHECK:   ret void
 // CHECK: }
 sil @dynamic_single_payload_empty_payload_store : $(@inout DynamicSinglePayload<()>, DynamicSinglePayload<()>) -> () {
@@ -1319,9 +1319,9 @@ entry(%p : $*DynamicSinglePayload<()>, %x : $DynamicSinglePayload<()>):
   return %v : $()
 }
 
-// CHECK: define{{( protected)?}} i2 @dynamic_single_payload_empty_payload_inject_payload() {{.*}} {
+// CHECK: define{{( protected)?}} i8 @dynamic_single_payload_empty_payload_inject_payload() {{.*}} {
 // CHECK: entry:
-// CHECK:   ret i2 0
+// CHECK:   ret i8 0
 // CHECK: }
 sil @dynamic_single_payload_empty_payload_inject_payload : $() -> DynamicSinglePayload<()> {
   %v = tuple ()
@@ -1329,9 +1329,9 @@ sil @dynamic_single_payload_empty_payload_inject_payload : $() -> DynamicSingleP
   return %u : $DynamicSinglePayload<()>
 }
 
-// CHECK: define{{( protected)?}} i2 @dynamic_single_payload_empty_payload_inject_no_payload() {{.*}} {
+// CHECK: define{{( protected)?}} i8 @dynamic_single_payload_empty_payload_inject_no_payload() {{.*}} {
 // CHECK: entry:
-// CHECK:   ret i2 1
+// CHECK:   ret i8 1
 // CHECK: }
 sil @dynamic_single_payload_empty_payload_inject_no_payload : $() -> DynamicSinglePayload<()> {
   %u = enum $DynamicSinglePayload<()>, #DynamicSinglePayload.y!enumelt
@@ -1360,14 +1360,14 @@ enum MultiPayloadNoSpareBits {
   case c
 }
 
-// CHECK-64: define{{( protected)?}} void @multi_payload_no_spare_bits_switch(i64, i2) {{.*}} {
+// CHECK-64: define{{( protected)?}} void @multi_payload_no_spare_bits_switch(i64, i8) {{.*}} {
 sil @multi_payload_no_spare_bits_switch : $(MultiPayloadNoSpareBits) -> () {
 entry(%u : $MultiPayloadNoSpareBits):
-// CHECK-64:   switch i2 %1, label %[[UNREACHABLE:[0-9]+]] [
-// CHECK-64:     i2 0, label %[[X_PREDEST:[0-9]+]]
-// CHECK-64:     i2 1, label %[[Y_PREDEST:[0-9]+]]
-// CHECK-64:     i2 -2, label %[[Z_PREDEST:[0-9]+]]
-// CHECK-64:     i2 -1, label %[[EMPTY:[0-9]+]]
+// CHECK-64:   switch i8 %1, label %[[UNREACHABLE:[0-9]+]] [
+// CHECK-64:     i8 0, label %[[X_PREDEST:[0-9]+]]
+// CHECK-64:     i8 1, label %[[Y_PREDEST:[0-9]+]]
+// CHECK-64:     i8 2, label %[[Z_PREDEST:[0-9]+]]
+// CHECK-64:     i8 3, label %[[EMPTY:[0-9]+]]
 // CHECK-64:   ]
 // CHECK-64: ; <label>:[[EMPTY]]
 // CHECK-64:   switch i64 %0, label %[[UNREACHABLE]] [
@@ -1438,9 +1438,9 @@ entry(%u : $*MultiPayloadNoSpareBits):
 // CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %O4enum23MultiPayloadNoSpareBits* %0 to i64*
 // CHECK-64:   [[PAYLOAD:%.*]] = load i64, i64* [[PAYLOAD_ADDR]]
 // CHECK-64:   [[T0:%.*]] = getelementptr inbounds %O4enum23MultiPayloadNoSpareBits, %O4enum23MultiPayloadNoSpareBits* %0, i32 0, i32 1
-// CHECK-64:   [[TAG_ADDR:%.*]] = bitcast [1 x i8]* [[T0]] to i2*
-// CHECK-64:   [[TAG:%.*]] = load i2, i2* [[TAG_ADDR]]
-// CHECK-64:   switch i2 [[TAG]]
+// CHECK-64:   [[TAG_ADDR:%.*]] = bitcast [1 x i8]* [[T0]] to i8*
+// CHECK-64:   [[TAG:%.*]] = load i8, i8* [[TAG_ADDR]]
+// CHECK-64:   switch i8 [[TAG]]
 // CHECK-64:   switch i64 [[PAYLOAD]]
 // CHECK-64: ; <label>:
 // CHECK-64:   unreachable
@@ -1479,11 +1479,11 @@ end:
   return %v : $()
 }
 
-// CHECK-64: define{{( protected)?}} { i64, i2 } @multi_payload_no_spare_bit_inject_x(i64) {{.*}} {
+// CHECK-64: define{{( protected)?}} { i64, i8 } @multi_payload_no_spare_bit_inject_x(i64) {{.*}} {
 // CHECK-64: entry:
-// CHECK-64:   [[RES_0:%.*]] = insertvalue { i64, i2 } undef, i64 %0, 0
-// CHECK-64:   [[RES:%.*]] = insertvalue { i64, i2 } [[RES_0]], i2 0, 1
-// CHECK-64:   ret { i64, i2 } [[RES]]
+// CHECK-64:   [[RES_0:%.*]] = insertvalue { i64, i8 } undef, i64 %0, 0
+// CHECK-64:   [[RES:%.*]] = insertvalue { i64, i8 } [[RES_0]], i8 0, 1
+// CHECK-64:   ret { i64, i8 } [[RES]]
 // CHECK-64: }
 sil @multi_payload_no_spare_bit_inject_x : $(Builtin.Int64) -> MultiPayloadNoSpareBits {
 entry(%0 : $Builtin.Int64):
@@ -1496,8 +1496,8 @@ entry(%0 : $Builtin.Int64):
 // CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %O4enum23MultiPayloadNoSpareBits* %1 to i64*
 // CHECK-64:   store i64 %0, i64* [[DATA_ADDR]]
 // CHECK-64:   [[T0:%.*]] = getelementptr inbounds %O4enum23MultiPayloadNoSpareBits, %O4enum23MultiPayloadNoSpareBits* %1, i32 0, i32 1
-// CHECK-64:   [[TAG_ADDR:%.*]] = bitcast [1 x i8]* [[T0]] to i2*
-// CHECK-64:   store i2 0, i2* [[TAG_ADDR]]
+// CHECK-64:   [[TAG_ADDR:%.*]] = bitcast [1 x i8]* [[T0]] to i8*
+// CHECK-64:   store i8 0, i8* [[TAG_ADDR]]
 // CHECK-64:   ret void
 // CHECK-64: }
 sil @multi_payload_no_spare_bit_inject_x_indirect : $(Builtin.Int64, @inout MultiPayloadNoSpareBits) -> () {
@@ -1509,12 +1509,12 @@ entry(%0 : $Builtin.Int64, %1 : $*MultiPayloadNoSpareBits):
   return %v : $()
 }
 
-// CHECK-64: define{{( protected)?}} { i64, i2 } @multi_payload_no_spare_bit_inject_y(i32) {{.*}} {
+// CHECK-64: define{{( protected)?}} { i64, i8 } @multi_payload_no_spare_bit_inject_y(i32) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[ZEXT:%.*]] = zext i32 %0 to i64
-// CHECK-64:   [[RES_0:%.*]] = insertvalue { i64, i2 } undef, i64 [[ZEXT]], 0
-// CHECK-64:   [[RES:%.*]] = insertvalue { i64, i2 } [[RES_0]], i2 1, 1
-// CHECK-64:   ret { i64, i2 } [[RES]]
+// CHECK-64:   [[RES_0:%.*]] = insertvalue { i64, i8 } undef, i64 [[ZEXT]], 0
+// CHECK-64:   [[RES:%.*]] = insertvalue { i64, i8 } [[RES_0]], i8 1, 1
+// CHECK-64:   ret { i64, i8 } [[RES]]
 // CHECK-64: }
 sil @multi_payload_no_spare_bit_inject_y : $(Builtin.Int32) -> MultiPayloadNoSpareBits {
 entry(%0 : $Builtin.Int32):
@@ -1522,12 +1522,12 @@ entry(%0 : $Builtin.Int32):
   return %u : $MultiPayloadNoSpareBits
 }
 
-// CHECK-64: define{{( protected)?}} { i64, i2 } @multi_payload_no_spare_bit_inject_z(i63) {{.*}} {
+// CHECK-64: define{{( protected)?}} { i64, i8 } @multi_payload_no_spare_bit_inject_z(i63) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[ZEXT:%.*]] = zext i63 %0 to i64
-// CHECK-64:   [[RES_0:%.*]] = insertvalue { i64, i2 } undef, i64 [[ZEXT]], 0
-// CHECK-64:   [[RES:%.*]] = insertvalue { i64, i2 } [[RES_0]], i2 -2, 1
-// CHECK-64:   ret { i64, i2 } [[RES]]
+// CHECK-64:   [[RES_0:%.*]] = insertvalue { i64, i8 } undef, i64 [[ZEXT]], 0
+// CHECK-64:   [[RES:%.*]] = insertvalue { i64, i8 } [[RES_0]], i8 2, 1
+// CHECK-64:   ret { i64, i8 } [[RES]]
 // CHECK-64: }
 sil @multi_payload_no_spare_bit_inject_z : $(Builtin.Int63) -> MultiPayloadNoSpareBits {
 entry(%0 : $Builtin.Int63):
@@ -1535,9 +1535,9 @@ entry(%0 : $Builtin.Int63):
   return %u : $MultiPayloadNoSpareBits
 }
 
-// CHECK-64: define{{( protected)?}} { i64, i2 } @multi_payload_no_spare_bit_inject_a() {{.*}} {
+// CHECK-64: define{{( protected)?}} { i64, i8 } @multi_payload_no_spare_bit_inject_a() {{.*}} {
 // CHECK-64: entry:
-// CHECK-64:   ret { i64, i2 } { i64 0, i2 -1 }
+// CHECK-64:   ret { i64, i8 } { i64 0, i8 3 }
 // CHECK-64: }
 sil @multi_payload_no_spare_bit_inject_a : $() -> MultiPayloadNoSpareBits {
 entry:
@@ -1550,8 +1550,8 @@ entry:
 // CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %O4enum23MultiPayloadNoSpareBits* %0 to i64*
 // CHECK-64:   store i64 0, i64* [[PAYLOAD_ADDR]]
 // CHECK-64:   [[T0:%.*]] = getelementptr inbounds %O4enum23MultiPayloadNoSpareBits, %O4enum23MultiPayloadNoSpareBits* %0, i32 0, i32 1
-// CHECK-64:   [[TAG_ADDR:%.*]] = bitcast [1 x i8]* [[T0]] to i2*
-// CHECK-64:   store i2 -1, i2* [[TAG_ADDR]]
+// CHECK-64:   [[TAG_ADDR:%.*]] = bitcast [1 x i8]* [[T0]] to i8*
+// CHECK-64:   store i8 3, i8* [[TAG_ADDR]]
 // CHECK-64:   ret void
 // CHECK-64: }
 sil @multi_payload_no_spare_bit_inject_a_indirect : $(@inout MultiPayloadNoSpareBits) -> () {
@@ -1561,9 +1561,9 @@ entry(%0 : $*MultiPayloadNoSpareBits):
   return %v : $()
 }
 
-// CHECK-64: define{{( protected)?}} { i64, i2 } @multi_payload_no_spare_bit_inject_b() {{.*}} {
+// CHECK-64: define{{( protected)?}} { i64, i8 } @multi_payload_no_spare_bit_inject_b() {{.*}} {
 // CHECK-64: entry:
-// CHECK-64:   ret { i64, i2 } { i64 1, i2 -1 }
+// CHECK-64:   ret { i64, i8 } { i64 1, i8 3 }
 // CHECK-64: }
 sil @multi_payload_no_spare_bit_inject_b : $() -> MultiPayloadNoSpareBits {
 entry:
@@ -1571,9 +1571,9 @@ entry:
   return %u : $MultiPayloadNoSpareBits
 }
 
-// CHECK-64: define{{( protected)?}} { i64, i2 } @multi_payload_no_spare_bit_inject_c() {{.*}} {
+// CHECK-64: define{{( protected)?}} { i64, i8 } @multi_payload_no_spare_bit_inject_c() {{.*}} {
 // CHECK-64: entry:
-// CHECK-64:   ret { i64, i2 } { i64 2, i2 -1 }
+// CHECK-64:   ret { i64, i8 } { i64 2, i8 3 }
 // CHECK-64: }
 sil @multi_payload_no_spare_bit_inject_c : $() -> MultiPayloadNoSpareBits {
 entry:
@@ -1594,16 +1594,16 @@ enum MultiPayloadOneSpareBit {
 sil @multi_payload_one_spare_bit_switch : $(MultiPayloadOneSpareBit) -> () {
 entry(%u : $MultiPayloadOneSpareBit):
 // CHECK-64:   [[SPARE_TAG_LSHR:%.*]] = lshr i64 %0, 63
-// CHECK-64:   [[SPARE_TAG_TRUNC:%.*]] = trunc i64 [[SPARE_TAG_LSHR]] to i2
-// CHECK-64:   [[SPARE_TAG:%.*]] = and i2 [[SPARE_TAG_TRUNC]], 1
-// CHECK-64:   [[EXTRA_TAG_ZEXT:%.*]] = zext i1 %1 to i2
-// CHECK-64:   [[EXTRA_TAG:%.*]] = shl i2 [[EXTRA_TAG_ZEXT]], 1
-// CHECK-64:   [[TAG:%.*]] = or i2 [[SPARE_TAG]], [[EXTRA_TAG]]
-// CHECK-64:   switch i2 [[TAG]], label %[[UNREACHABLE:[0-9]+]] [
-// CHECK-64:     i2 0, label %[[X_PREDEST:[0-9]+]]
-// CHECK-64:     i2 1, label %[[Y_PREDEST:[0-9]+]]
-// CHECK-64:     i2 -2, label %[[Z_PREDEST:[0-9]+]]
-// CHECK-64:     i2 -1, label %[[EMPTY_DEST:[0-9]+]]
+// CHECK-64:   [[SPARE_TAG_TRUNC:%.*]] = trunc i64 [[SPARE_TAG_LSHR]] to i8
+// CHECK-64:   [[SPARE_TAG:%.*]] = and i8 [[SPARE_TAG_TRUNC]], 1
+// CHECK-64:   [[EXTRA_TAG_ZEXT:%.*]] = zext i1 %1 to i8
+// CHECK-64:   [[EXTRA_TAG:%.*]] = shl i8 [[EXTRA_TAG_ZEXT]], 1
+// CHECK-64:   [[TAG:%.*]] = or i8 [[SPARE_TAG]], [[EXTRA_TAG]]
+// CHECK-64:   switch i8 [[TAG]], label %[[UNREACHABLE:[0-9]+]] [
+// CHECK-64:     i8 0, label %[[X_PREDEST:[0-9]+]]
+// CHECK-64:     i8 1, label %[[Y_PREDEST:[0-9]+]]
+// CHECK-64:     i8 2, label %[[Z_PREDEST:[0-9]+]]
+// CHECK-64:     i8 3, label %[[EMPTY_DEST:[0-9]+]]
 // CHECK-64:   ]
 
 // CHECK-64: ; <label>:[[EMPTY_DEST]]
@@ -1683,7 +1683,7 @@ entry(%u : $*MultiPayloadOneSpareBit):
 // CHECK-64:   [[T0:%.*]] = getelementptr inbounds %O4enum23MultiPayloadOneSpareBit, %O4enum23MultiPayloadOneSpareBit* %0, i32 0, i32 1
 // CHECK-64:   [[TAG_ADDR:%.*]] = bitcast [1 x i8]* [[T0]] to i1*
 // CHECK-64:   [[TAG:%.*]] = load i1, i1* [[TAG_ADDR]]
-// CHECK-64:   switch i2 {{%.*}}
+// CHECK-64:   switch i8 {{%.*}}
 // CHECK-64:   switch i64 [[PAYLOAD]]
 // CHECK-64: ; <label>:
 // CHECK-64:   unreachable
@@ -1886,12 +1886,13 @@ enum MultiPayloadTwoSpareBits {
 sil @multi_payload_two_spare_bits_switch : $(MultiPayloadTwoSpareBits) -> () {
 entry(%u : $MultiPayloadTwoSpareBits):
 // CHECK-64:   [[TAG_LSHR:%.*]] = lshr i64 %0, 62
-// CHECK-64:   [[TAG:%.*]] = trunc i64 [[TAG_LSHR]] to i2
-// CHECK-64:   switch i2 [[TAG]], label %[[UNREACHABLE:[0-9]+]] [
-// CHECK-64:     i2 0, label %[[X_PREDEST:[0-9]+]]
-// CHECK-64:     i2 1, label %[[Y_PREDEST:[0-9]+]]
-// CHECK-64:     i2 -2, label %[[Z_PREDEST:[0-9]+]]
-// CHECK-64:     i2 -1, label %[[EMPTY_DEST:[0-9]+]]
+// CHECK-64:   [[TAG_BYTE:%.*]] = trunc i64 [[TAG_LSHR]] to i8
+// CHECK-64:   [[TAG:%.*]] = and i8 [[TAG_BYTE]], 3
+// CHECK-64:   switch i8 [[TAG]], label %[[UNREACHABLE:[0-9]+]] [
+// CHECK-64:     i8 0, label %[[X_PREDEST:[0-9]+]]
+// CHECK-64:     i8 1, label %[[Y_PREDEST:[0-9]+]]
+// CHECK-64:     i8 2, label %[[Z_PREDEST:[0-9]+]]
+// CHECK-64:     i8 3, label %[[EMPTY_DEST:[0-9]+]]
 // CHECK-64:   ]
 // CHECK-64: ; <label>:[[EMPTY_DEST]]
 // CHECK-64:   switch i64 %0, label %[[UNREACHABLE]] [
@@ -2108,11 +2109,12 @@ enum MultiPayloadClasses {
 
 // CHECK-64-LABEL: define{{( protected)?}} void @multi_payload_classes_switch(i64) {{.*}} {
 // CHECK-64:   %1 = lshr i64 %0, 62
-// CHECK-64:   %2 = trunc i64 %1 to i2
-// CHECK-64:   switch i2 %2, label {{%.*}} [
-// CHECK-64:     i2 0, label {{%.*}}
-// CHECK-64:     i2 1, label {{%.*}}
-// CHECK-64:     i2 -2, label {{%.*}}
+// CHECK-64:   %2 = trunc i64 %1 to i8
+// CHECK-64:   %3 = and i8 %2, 3
+// CHECK-64:   switch i8 %3, label {{%.*}} [
+// CHECK-64:     i8 0, label {{%.*}}
+// CHECK-64:     i8 1, label {{%.*}}
+// CHECK-64:     i8 2, label {{%.*}}
 // CHECK-64:   ]
 // CHECK-64:   switch i64 %0, label {{%.*}} [
 // --             0x8000000000000000
@@ -2128,11 +2130,12 @@ enum MultiPayloadClasses {
 // CHECK-64:   inttoptr i64 [[MASKED]] to %C4enum1D*
 
 // CHECK-32-LABEL: define{{( protected)?}} void @multi_payload_classes_switch(i32) {{.*}} {
-// CHECK-32:   %1 = trunc i32 %0 to i2
-// CHECK-32:   switch i2 %1, label {{%.*}} [
-// CHECK-32:     i2 0, label {{%.*}}
-// CHECK-32:     i2 1, label {{%.*}}
-// CHECK-32:     i2 -2, label {{%.*}}
+// CHECK-32:   %1 = trunc i32 %0 to i8
+// CHECK-32:   %2 = and i8 %1, 3
+// CHECK-32:   switch i8 %2, label {{%.*}} [
+// CHECK-32:     i8 0, label {{%.*}}
+// CHECK-32:     i8 1, label {{%.*}}
+// CHECK-32:     i8 2, label {{%.*}}
 // CHECK-32:   ]
 // CHECK-32:   switch i32 %0, label {{%.*}} [
 // CHECK-32:     i32 2, label {{%.*}}
@@ -2180,11 +2183,12 @@ enum MultiPayloadSpareBitAggregates {
 
 // CHECK-64-LABEL: define{{( protected)?}} void @multi_payload_spare_bit_aggregate_switch(i64, i64) {{.*}} {
 // CHECK-64:   [[T0:%.*]] = lshr i64 %0, 62
-// CHECK-64:   [[TAG:%.*]] = trunc i64 [[T0]] to i2
-// CHECK-64:   switch i2 [[TAG]], label {{%.*}} [
-// CHECK-64:     i2 0, label %[[X_DEST:[0-9]+]]
-// CHECK-64:     i2 1, label %[[Y_DEST:[0-9]+]]
-// CHECK-64:     i2 -2, label %[[Z_DEST:[0-9]+]]
+// CHECK-64:   [[TAG_BYTE:%.*]] = trunc i64 [[T0]] to i8
+// CHECK-64:   [[TAG:%.*]] = and i8 [[TAG_BYTE]], 3
+// CHECK-64:   switch i8 [[TAG]], label {{%.*}} [
+// CHECK-64:     i8 0, label %[[X_DEST:[0-9]+]]
+// CHECK-64:     i8 1, label %[[Y_DEST:[0-9]+]]
+// CHECK-64:     i8 2, label %[[Z_DEST:[0-9]+]]
 // CHECK-64:   ]
 // CHECK-64: ; <label>:[[X_DEST]]
 // CHECK-64:   [[X_0:%.*]] = trunc i64 %0 to i32
@@ -2411,7 +2415,7 @@ entry(%0 : $DynamicSingleton<()>):
   %v = tuple ()
   return %v : $()
 }
-// CHECK: define{{( protected)?}} void @dynamic_singleton_instance_arg_2(i2)
+// CHECK: define{{( protected)?}} void @dynamic_singleton_instance_arg_2(i8)
 sil @dynamic_singleton_instance_arg_2 : $(DynamicSingleton<NoPayloads>) -> () {
 entry(%0 : $DynamicSingleton<NoPayloads>):
   %v = tuple ()
@@ -2636,9 +2640,9 @@ bb4:
 // CHECK:  [[VAL01:%.*]] = bitcast %O4enum40MultiPayloadLessThan32BitsWithEmptyCases* [[VAL00]] to i8*
 // CHECK:  [[VAL02:%.*]] = load {{.*}} [[VAL01]]
 // CHECK:  [[VAL03:%.*]] = getelementptr inbounds {{.*}} [[VAL00]], i32 0, i32 1
-// CHECK:  [[VAL04:%.*]] = bitcast {{.*}} [[VAL03]] to i2*
+// CHECK:  [[VAL04:%.*]] = bitcast {{.*}} [[VAL03]] to i8*
 // CHECK:  [[VAL05:%.*]] = load {{.*}} [[VAL04]]
-// CHECK:  [[VAL06:%.*]] = zext i2 [[VAL05]] to i32
+// CHECK:  [[VAL06:%.*]] = zext i8 [[VAL05]] to i32
 // CHECK:  [[VAL07:%.*]] = sub i32 [[VAL06]], 2
 // CHECK:  [[VAL08:%.*]] = zext i8 [[VAL02]] to i32
 // CHECK:  [[VAL09:%.*]] = and i32 [[VAL08]], 255
@@ -2657,16 +2661,16 @@ bb4:
 // CHECK:  [[VAL04:%.*]] = bitcast %O4enum40MultiPayloadLessThan32BitsWithEmptyCases* [[VAL00]] to i8*
 // CHECK:  store i8 [[VAL03]], i8* [[VAL04]]
 // CHECK:  [[VAL05:%.*]] = getelementptr inbounds {{.*}} [[VAL00]], i32 0, i32 1
-// CHECK:  [[VAL06:%.*]] = bitcast [1 x i8]* [[VAL05]] to i2*
-// CHECK:  store i2 -2, i2* [[VAL06]]
+// CHECK:  [[VAL06:%.*]] = bitcast [1 x i8]* [[VAL05]] to i8*
+// CHECK:  store i8 2, i8* [[VAL06]]
 // CHECK:  br label %[[RLABEL:.*]]
 
 // CHECK: <label>:[[FLABEL]]
 // CHECK:  [[VAL08:%.*]] = add i32 %tag, 2
-// CHECK:  [[VAL09:%.*]] = trunc i32 [[VAL08]] to i2
+// CHECK:  [[VAL09:%.*]] = trunc i32 [[VAL08]] to i8
 // CHECK:  [[VAL10:%.*]] = getelementptr inbounds {{.*}} [[VAL00]], i32 0, i32 1
-// CHECK:  [[VAL11:%.*]] = bitcast [1 x i8]* [[VAL10]] to i2*
-// CHECK:  store i2 [[VAL09]], i2* [[VAL11]]
+// CHECK:  [[VAL11:%.*]] = bitcast [1 x i8]* [[VAL10]] to i8*
+// CHECK:  store i8 [[VAL09]], i8* [[VAL11]]
 // CHECK:  br label %[[RLABEL]]
 
 // CHECK: <label>:[[RLABEL]]

--- a/test/IRGen/enum_derived.swift
+++ b/test/IRGen/enum_derived.swift
@@ -18,16 +18,16 @@ enum E {
 
 // Check if the == comparison can be compiled to a simple icmp instruction.
 
-// CHECK-NORMAL-LABEL:define hidden i1 @_TZFO12enum_derived1Eoi2eefTS0_S0__Sb(i2, i2)
-// CHECK-TESTABLE-LABEL:define{{( protected)?}} i1 @_TZFO12enum_derived1Eoi2eefTS0_S0__Sb(i2, i2)
-// CHECK: %2 = icmp eq i2 %0, %1
+// CHECK-NORMAL-LABEL:define hidden i1 @_TZFO12enum_derived1Eoi2eefTS0_S0__Sb(i8, i8)
+// CHECK-TESTABLE-LABEL:define{{( protected)?}} i1 @_TZFO12enum_derived1Eoi2eefTS0_S0__Sb(i8, i8)
+// CHECK: %2 = icmp eq i8 %0, %1
 // CHECK: ret i1 %2
 
 // Check if the hashValue getter can be compiled to a simple zext instruction.
 
-// CHECK-NORMAL-LABEL:define hidden i{{.*}} @_TFO12enum_derived1Eg9hashValueSi(i2)
-// CHECK-TESTABLE-LABEL:define{{( protected)?}} i{{.*}} @_TFO12enum_derived1Eg9hashValueSi(i2)
-// CHECK: %1 = zext i2 %0 to i{{.*}}
+// CHECK-NORMAL-LABEL:define hidden i{{.*}} @_TFO12enum_derived1Eg9hashValueSi(i8)
+// CHECK-TESTABLE-LABEL:define{{( protected)?}} i{{.*}} @_TFO12enum_derived1Eg9hashValueSi(i8)
+// CHECK: %1 = zext i8 %0 to i{{.*}}
 // CHECK: ret i{{.*}} %1
 
 // Derived conformances from extensions

--- a/test/IRGen/enum_dynamic_multi_payload.sil
+++ b/test/IRGen/enum_dynamic_multi_payload.sil
@@ -83,7 +83,7 @@ next(%z : $Builtin.Int8):
   return undef : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} void @empty_instance2(i2) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} void @empty_instance2(i8) {{.*}} {
 sil @empty_instance2 : $@convention(thin) (EitherOr<(), ()>) -> () {
 // CHECK-NEXT: entry:
 entry(%e : $EitherOr<(), ()>):
@@ -97,20 +97,20 @@ entry(%e : $EitherOr<(), ()>):
   // CHECK-NEXT: llvm.lifetime.start
   %s = alloc_stack $EitherOr<(), ()>
 
-  // CHECK-NEXT: bitcast {{.*}} to i2*
-  // CHECK-NEXT: store i2 0
+  // CHECK-NEXT: bitcast {{.*}} to i8*
+  // CHECK-NEXT: store i8 0
   %l = enum $EitherOr<(), ()>, #EitherOr.Left!enumelt.1, undef : $()
   store %l to %s : $*EitherOr<(), ()>
-  // CHECK-NEXT: bitcast {{.*}} to i2*
-  // CHECK-NEXT: store i2 1
+  // CHECK-NEXT: bitcast {{.*}} to i8*
+  // CHECK-NEXT: store i8 1
   %r = enum $EitherOr<(), ()>, #EitherOr.Right!enumelt.1, undef : $()
   store %r to %s : $*EitherOr<(), ()>
-  // CHECK-NEXT: bitcast {{.*}} to i2*
-  // CHECK-NEXT: store i2 -2
+  // CHECK-NEXT: bitcast {{.*}} to i8*
+  // CHECK-NEXT: store i8 2
   %m = enum $EitherOr<(), ()>, #EitherOr.Middle!enumelt
   store %m to %s : $*EitherOr<(), ()>
-  // CHECK-NEXT: bitcast {{.*}} to i2*
-  // CHECK-NEXT: store i2 -1
+  // CHECK-NEXT: bitcast {{.*}} to i8*
+  // CHECK-NEXT: store i8 3
   %k = enum $EitherOr<(), ()>, #EitherOr.Center!enumelt
   store %k to %s : $*EitherOr<(), ()>
 
@@ -118,10 +118,10 @@ entry(%e : $EitherOr<(), ()>):
   %b = unchecked_enum_data %r : $EitherOr<(), ()>, #EitherOr.Right!enumelt.1
 
   // CHECK-NEXT: switch
-  // CHECK-NEXT:   i2  0, label %[[LEFT_PRE:[0-9]+]]
-  // CHECK-NEXT:   i2  1, label %[[RIGHT_PRE:[0-9]+]]
-  // CHECK-NEXT:   i2 -2, label [[MIDDLE:%[0-9]+]]
-  // CHECK-NEXT:   i2 -1, label [[CENTER:%[0-9]+]]
+  // CHECK-NEXT:   i8 0, label %[[LEFT_PRE:[0-9]+]]
+  // CHECK-NEXT:   i8 1, label %[[RIGHT_PRE:[0-9]+]]
+  // CHECK-NEXT:   i8 2, label [[MIDDLE:%[0-9]+]]
+  // CHECK-NEXT:   i8 3, label [[CENTER:%[0-9]+]]
   switch_enum %e : $EitherOr<(), ()>,
     case #EitherOr.Left!enumelt.1: left,
     case #EitherOr.Middle!enumelt: middle,

--- a/test/IRGen/enum_value_semantics.sil
+++ b/test/IRGen/enum_value_semantics.sil
@@ -231,8 +231,8 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-LABEL: define linkonce_odr hidden i32 @_TwugO20enum_value_semantics9NoPayload
 // CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %O20enum_value_semantics9NoPayload*
 // CHECK-NEXT: [[TAG_ADDR:%.*]] = getelementptr inbounds %O20enum_value_semantics9NoPayload, %O20enum_value_semantics9NoPayload* [[SELF]], i32 0, i32 0
-// CHECK-NEXT: [[TAG:%.*]] = load i2, i2* [[TAG_ADDR]], align 1
-// CHECK-NEXT: [[RESULT:%.*]] = zext i2 %2 to i32
+// CHECK-NEXT: [[TAG:%.*]] = load i8, i8* [[TAG_ADDR]], align 1
+// CHECK-NEXT: [[RESULT:%.*]] = zext i8 %2 to i32
 // CHECK-NEXT: ret i32 [[RESULT]]
 
 
@@ -244,9 +244,9 @@ bb0(%0 : $SinglePayloadNontrivial):
 // -- NoPayload destructiveInjectEnumTag
 // CHECK-LABEL: define linkonce_odr hidden void @_TwuiO20enum_value_semantics9NoPayload
 // CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %O20enum_value_semantics9NoPayload*
-// CHECK-NEXT: [[TAG:%.*]] = trunc i32 %tag to i2
+// CHECK-NEXT: [[TAG:%.*]] = trunc i32 %tag to i8
 // CHECK-NEXT: [[TAG_ADDR:%.*]] = getelementptr inbounds %O20enum_value_semantics9NoPayload, %O20enum_value_semantics9NoPayload* [[SELF]], i32 0, i32 0
-// CHECK-NEXT: store i2 [[TAG]], i2* [[TAG_ADDR]], align 1
+// CHECK-NEXT: store i8 [[TAG]], i8* [[TAG_ADDR]], align 1
 // CHECK-NEXT: ret void
 
 
@@ -335,9 +335,9 @@ bb0(%0 : $SinglePayloadNontrivial):
 
 //   -- Load the high bits of the tag from the extra tag area
 // CHECK-NEXT: [[EXTRA_TAG_ADDR_TMP:%.*]] = getelementptr inbounds %O20enum_value_semantics19MultiPayloadTrivial, %O20enum_value_semantics19MultiPayloadTrivial* [[SELF]], i32 0, i32 1
-// CHECK-NEXT: [[EXTRA_TAG_ADDR:%.*]] = bitcast [1 x i8]* [[EXTRA_TAG_ADDR_TMP]] to i2*
-// CHECK-NEXT: [[EXTRA_TAG_TMP:%.*]] = load i2, i2* [[EXTRA_TAG_ADDR]], align 8
-// CHECK-NEXT: [[EXTRA_TAG:%.*]] = zext i2 [[EXTRA_TAG_TMP]] to i32
+// CHECK-NEXT: [[EXTRA_TAG_ADDR:%.*]] = bitcast [1 x i8]* [[EXTRA_TAG_ADDR_TMP]] to i8*
+// CHECK-NEXT: [[EXTRA_TAG_TMP:%.*]] = load i8, i8* [[EXTRA_TAG_ADDR]], align 8
+// CHECK-NEXT: [[EXTRA_TAG:%.*]] = zext i8 [[EXTRA_TAG_TMP]] to i32
 
 //   -- Form tag for the payload case, or the high bits of no-payload case
 // CHECK-NEXT: [[PAYLOAD_TAG:%.*]] = sub i32 [[EXTRA_TAG]], 2
@@ -374,18 +374,18 @@ bb0(%0 : $SinglePayloadNontrivial):
 
 //   -- Store the high bits of the tag in the extra tag area
 // CHECK-NEXT: [[EXTRA_TAG_ADDR_TMP:%.*]] = getelementptr inbounds %O20enum_value_semantics19MultiPayloadTrivial, %O20enum_value_semantics19MultiPayloadTrivial* [[SELF]], i32 0, i32 1
-// CHECK-NEXT: [[EXTRA_TAG_ADDR:%.*]] = bitcast [1 x i8]* [[EXTRA_TAG_ADDR_TMP]] to i2*
-// CHECK-NEXT: store i2 -2, i2* [[EXTRA_TAG_ADDR]], align 8
+// CHECK-NEXT: [[EXTRA_TAG_ADDR:%.*]] = bitcast [1 x i8]* [[EXTRA_TAG_ADDR_TMP]] to i8*
+// CHECK-NEXT: store i8 2, i8* [[EXTRA_TAG_ADDR]], align 8
 // CHECK-NEXT: br label %[[DONE:.*]]
 
 // CHECK:      ; <label>:[[HAS_PAYLOAD]]
 
 //   -- Store the tag in the extra tag area
 // CHECK-NEXT: [[PAYLOAD_TAG:%.*]] = add i32 %tag, 2
-// CHECK-NEXT: [[TAG:%.*]] = trunc i32 [[PAYLOAD_TAG]] to i2
+// CHECK-NEXT: [[TAG:%.*]] = trunc i32 [[PAYLOAD_TAG]] to i8
 // CHECK-NEXT: [[EXTRA_TAG_ADDR_TMP:%.*]] = getelementptr inbounds %O20enum_value_semantics19MultiPayloadTrivial, %O20enum_value_semantics19MultiPayloadTrivial* [[SELF]], i32 0, i32 1
-// CHECK-NEXT: [[EXTRA_TAG_ADDR:%.*]] = bitcast [1 x i8]* [[EXTRA_TAG_ADDR_TMP]] to i2*
-// CHECK-NEXT: store i2 [[TAG]], i2* [[EXTRA_TAG_ADDR]], align 8
+// CHECK-NEXT: [[EXTRA_TAG_ADDR:%.*]] = bitcast [1 x i8]* [[EXTRA_TAG_ADDR_TMP]] to i8*
+// CHECK-NEXT: store i8 [[TAG]], i8* [[EXTRA_TAG_ADDR]], align 8
 // CHECK-NEXT: br label %[[DONE]]
 
 // CHECK:      ; <label>:[[DONE]]
@@ -441,8 +441,8 @@ bb0(%0 : $SinglePayloadNontrivial):
 
 //   -- Load the tag from the extra tag area
 // CHECK-NEXT: [[EXTRA_TAG_ADDR:%.*]] = getelementptr inbounds %O20enum_value_semantics24MultiPayloadEmptyPayload, %O20enum_value_semantics24MultiPayloadEmptyPayload* [[SELF]], i32 0, i32 0
-// CHECK-NEXT: [[EXTRA_TAG_TMP:%.*]] = load i3, i3* [[EXTRA_TAG_ADDR]], align 1
-// CHECK-NEXT: [[EXTRA_TAG:%.*]] = zext i3 [[EXTRA_TAG_TMP]] to i32
+// CHECK-NEXT: [[EXTRA_TAG_TMP:%.*]] = load i8, i8* [[EXTRA_TAG_ADDR]], align 1
+// CHECK-NEXT: [[EXTRA_TAG:%.*]] = zext i8 [[EXTRA_TAG_TMP]] to i32
 // CHECK-NEXT: ret i32 [[EXTRA_TAG]]
 
 
@@ -456,9 +456,9 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %O20enum_value_semantics24MultiPayloadEmptyPayload*
 
 //   -- Store the tag in the extra tag area
-// CHECK-NEXT: [[TAG:%.*]] = trunc i32 %tag to i3
+// CHECK-NEXT: [[TAG:%.*]] = trunc i32 %tag to i8
 // CHECK-NEXT: [[EXTRA_TAG_ADDR:%.*]] = getelementptr inbounds %O20enum_value_semantics24MultiPayloadEmptyPayload, %O20enum_value_semantics24MultiPayloadEmptyPayload* [[SELF]], i32 0, i32 0
-// CHECK-NEXT: store i3 [[TAG]], i3* [[EXTRA_TAG_ADDR]], align 1
+// CHECK-NEXT: store i8 [[TAG]], i8* [[EXTRA_TAG_ADDR]], align 1
 // CHECK-NEXT: ret void
 
 
@@ -476,11 +476,11 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT: [[PAYLOAD_1_ADDR:%.*]] = getelementptr
 // CHECK-NEXT: [[PAYLOAD_1:%.*]] = load i64, i64* [[PAYLOAD_1_ADDR]], align 8
 // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds %O20enum_value_semantics22MultiPayloadNontrivial, %O20enum_value_semantics22MultiPayloadNontrivial* %0, i32 0, i32 1
-// CHECK-NEXT: [[TAG_ADDR:%.*]] = bitcast [1 x i8]* [[T0]] to i3*
-// CHECK-NEXT: [[TAG:%.*]] = load i3, i3* [[TAG_ADDR]], align 8
-// CHECK-NEXT: switch i3 [[TAG]], label %[[END:[0-9]+]] [
-// CHECK:        i3 0, label %[[PAYLOAD1_DESTROY:[0-9]+]]
-// CHECK:        i3 2, label %[[PAYLOAD3_DESTROY:[0-9]+]]
+// CHECK-NEXT: [[TAG_ADDR:%.*]] = bitcast [1 x i8]* [[T0]] to i8*
+// CHECK-NEXT: [[TAG:%.*]] = load i8, i8* [[TAG_ADDR]], align 8
+// CHECK-NEXT: switch i8 [[TAG]], label %[[END:[0-9]+]] [
+// CHECK:        i8 0, label %[[PAYLOAD1_DESTROY:[0-9]+]]
+// CHECK:        i8 2, label %[[PAYLOAD3_DESTROY:[0-9]+]]
 // CHECK:      ]
 // CHECK:      ; <label>:[[PAYLOAD1_DESTROY]]
 // CHECK-NEXT: [[PAYLOAD1_VAL:%.*]] = inttoptr i64 [[PAYLOAD_0]] to %swift.refcounted*
@@ -533,9 +533,9 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT: [[PAYLOAD_0:%.*]] = load i64, i64* [[PAYLOAD_0_ADDR]], align 8
 // CHECK-NEXT: [[PAYLOAD_1_ADDR:%.*]] = getelementptr
 // CHECK-NEXT: [[PAYLOAD_1:%.*]] = load i64, i64* [[PAYLOAD_1_ADDR]], align 8
-// CHECK:      switch i2 [[SPARE_BITS:%.*]], label %[[END:[0-9]+]] [
-// CHECK:        i2 0, label %[[PAYLOAD1_DESTROY:[0-9]+]]
-// CHECK:        i2 -2, label %[[PAYLOAD3_DESTROY:[0-9]+]]
+// CHECK:      switch i8 [[SPARE_BITS:%.*]], label %[[END:[0-9]+]] [
+// CHECK:        i8 0, label %[[PAYLOAD1_DESTROY:[0-9]+]]
+// CHECK:        i8 2, label %[[PAYLOAD3_DESTROY:[0-9]+]]
 // CHECK:      ]
 // CHECK:      ; <label>:[[PAYLOAD1_DESTROY]]
 // CHECK-NEXT: [[PAYLOAD1_VAL:%.*]] = inttoptr i64 [[PAYLOAD_0]] to %swift.refcounted*
@@ -561,9 +561,10 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT: [[SECOND:%.*]] = load i64, i64* [[SECOND_ADDR]], align 8
 
 //   -- Get the high bits of the tag from the spare bits
-// CHECK-NEXT: [[SPARE_TAG_TMP2:%.*]] = lshr i64 [[SECOND]], 62
-// CHECK-NEXT: [[SPARE_TAG_TMP:%.*]] = trunc i64 [[SPARE_TAG_TMP2]] to i2
-// CHECK-NEXT: [[SPARE_TAG:%.*]] = zext i2 [[SPARE_TAG_TMP]] to i32
+// CHECK-NEXT: [[SPARE_TAG_TMP:%.*]] = lshr i64 [[SECOND]], 62
+// CHECK-NEXT: [[SPARE_TAG_TMP2:%.*]] = trunc i64 [[SPARE_TAG_TMP]] to i8
+// CHECK-NEXT: [[SPARE_TAG_TMP3:%.*]] = and i8 [[SPARE_TAG_TMP2]], 3
+// CHECK-NEXT: [[SPARE_TAG:%.*]] = zext i8 [[SPARE_TAG_TMP3]] to i32
 // CHECK-NEXT: [[PAYLOAD_TAG:%.*]] = sub i32 [[SPARE_TAG]], 3
 
 //   -- Get the low bits of the tag from the payload area
@@ -671,14 +672,14 @@ bb0(%0 : $SinglePayloadNontrivial):
 
 //   -- Load the high bits of the tag from the spare bits area
 // CHECK-NEXT: [[SPARE_BITS_TMP2:%.*]] = lshr i64 [[PAYLOAD]], 63
-// CHECK-NEXT: [[SPARE_BITS_TMP:%.*]] = trunc i64 [[SPARE_BITS_TMP2]] to i2
-// CHECK-NEXT: [[SPARE_BITS:%.*]] = and i2 [[SPARE_BITS_TMP]], 1
-// CHECK-NEXT: [[EXTRA_TAG:%.*]] = zext i1 [[EXTRA_TAG_TMP]] to i2
+// CHECK-NEXT: [[SPARE_BITS_TMP:%.*]] = trunc i64 [[SPARE_BITS_TMP2]] to i8
+// CHECK-NEXT: [[SPARE_BITS:%.*]] = and i8 [[SPARE_BITS_TMP]], 1
+// CHECK-NEXT: [[EXTRA_TAG:%.*]] = zext i1 [[EXTRA_TAG_TMP]] to i8
 
 //   -- Combine high bits and low bits to form tag
-// CHECK-NEXT: [[TAG_TMP:%.*]] = shl i2 [[EXTRA_TAG]], 1
-// CHECK-NEXT: [[TAG:%.*]] = or i2 [[SPARE_BITS]], [[TAG_TMP]] 
-// CHECK-NEXT: [[RESULT:%.*]] = zext i2 [[TAG]] to i32
+// CHECK-NEXT: [[TAG_TMP:%.*]] = shl i8 [[EXTRA_TAG]], 1
+// CHECK-NEXT: [[TAG:%.*]] = or i8 [[SPARE_BITS]], [[TAG_TMP]] 
+// CHECK-NEXT: [[RESULT:%.*]] = zext i8 [[TAG]] to i32
 // CHECK-NEXT: [[PAYLOAD_TAG:%.*]] = sub i32 [[RESULT]],
 // CHECK-NEXT: ret i32 [[PAYLOAD_TAG]]
 

--- a/test/IRGen/select_enum_optimized.swift
+++ b/test/IRGen/select_enum_optimized.swift
@@ -10,7 +10,7 @@ enum NoPayload {
 // Check if the code of a select_num is a simple int cast and not a switch.
 
 // CHECK-LABEL: define {{.*}}selectDirect
-// CHECK: %1 = zext i2 %0 to i32
+// CHECK: %1 = zext i8 %0 to i32
 // CHECK: ret i32 %1
 
 @inline(never)
@@ -28,7 +28,7 @@ func selectDirect(e: NoPayload) -> Int32 {
 }
 
 // CHECK-LABEL: define {{.*}}selectNegOffset
-// CHECK: %1 = zext i2 %0 to i32
+// CHECK: %1 = zext i8 %0 to i32
 // CHECK: %2 = add i32 %1, -6
 // CHECK: ret i32 %2
 
@@ -47,7 +47,7 @@ func selectNegOffset(e: NoPayload) -> Int32 {
 }
 
 // CHECK-LABEL: define {{.*}}selectPosOffset
-// CHECK: %1 = zext i2 %0 to i32
+// CHECK: %1 = zext i8 %0 to i32
 // CHECK: %2 = add i32 %1, 3
 // CHECK: ret i32 %2
 
@@ -69,7 +69,7 @@ func selectPosOffset(e: NoPayload) -> Int32 {
 // simple conversion.
 
 // CHECK-LABEL: define {{.*}}selectWithDefault
-// CHECK: switch i2
+// CHECK: switch i8
 // CHECK: ret
 
 @inline(never)
@@ -85,7 +85,7 @@ func selectWithDefault(e: NoPayload) -> Int32 {
 }
 
 // CHECK-LABEL: define {{.*}}selectNonContiguous
-// CHECK: switch i2
+// CHECK: switch i8
 // CHECK: ret
 
 @inline(never)
@@ -105,7 +105,7 @@ func selectNonContiguous(e: NoPayload) -> Int32 {
 var gg : Int32 = 10
 
 // CHECK-LABEL: define {{.*}}selectNonConstant
-// CHECK: switch i2
+// CHECK: switch i8
 // CHECK: ret
 
 @inline(never)
@@ -123,7 +123,7 @@ func selectNonConstant(e: NoPayload) -> Int32 {
 }
 
 // CHECK-LABEL: define {{.*}}selectTuple
-// CHECK: switch i2
+// CHECK: switch i8
 // CHECK: ret
 
 @inline(never)
@@ -141,7 +141,7 @@ func selectTuple(e: NoPayload) -> (Int32, Int32) {
 }
 
 // CHECK-LABEL: define {{.*}}selectNonInt
-// CHECK: switch i2
+// CHECK: switch i8
 // CHECK: ret
 
 @inline(never)


### PR DESCRIPTION
In practice, this interferes with FastISel and has exposed lots of latent LLVM backend bugs. Using "normal" power-of-two-bytes sized integers is easier to work with and improves code gen performance for nonoptimizing clients like Swift Playgrounds.

rdar://problem/27592463