### PR TITLE
[QoI] Improve fixit for missing parameter clause in initializer decl

### DIFF
--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -736,7 +736,7 @@ Parser::parseConstructorArguments(DeclName &FullName,
     {
       auto diag = diagnose(Tok, diag::expected_lparen_initializer);
       if (Tok.is(tok::l_brace))
-        diag.fixItInsert(Tok.getLoc(), "() ");
+        diag.fixItInsertAfter(PreviousLoc, "()");
     }
 
     // Create an empty parameter list to recover.

--- a/test/Parse/init_deinit.swift
+++ b/test/Parse/init_deinit.swift
@@ -9,7 +9,9 @@ struct FooStructConstructorB {
 }
 
 struct FooStructConstructorC {
-  init {} // expected-error {{expected '('}}{{8-8=() }}
+  init {} // expected-error {{expected '('}}{{7-7=()}}
+  init<T> {} // expected-error {{expected '('}} {{10-10=()}}
+  init? { self.init() } // expected-error {{expected '('}} {{8-8=()}}
 }
 
 
@@ -33,7 +35,7 @@ class FooClassDeinitializerB {
   deinit { }
 }
 
-init {} // expected-error {{initializers may only be declared within a type}} expected-error {{expected '('}} {{6-6=() }}
+init {} // expected-error {{initializers may only be declared within a type}} expected-error {{expected '('}} {{5-5=()}}
 init() // expected-error {{initializers may only be declared within a type}}
 init() {} // expected-error {{initializers may only be declared within a type}}
 


### PR DESCRIPTION
Fix `init {}` to `init() {}` instead of `init () {}`.
