### PR TITLE
[swiftc (74 vs. 5165)] Add crasher in swift::Lexer::lexStringLiteral(…)

### DIFF
--- a/validation-test/compiler_crashers/28427-swift-lexer-lexstringliteral.swift
+++ b/validation-test/compiler_crashers/28427-swift-lexer-lexstringliteral.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+struct c:protocol<{"


### PR DESCRIPTION
Add test case for crash triggered in `swift::Lexer::lexStringLiteral(...)`.

Current number of unresolved compiler crashers: 74 (5165 resolved)

Assertion failure in [`include/swift/AST/DiagnosticEngine.h (line 595)`](https://github.com/apple/swift/blob/master/include/swift/AST/DiagnosticEngine.h#L595):

```
Assertion `!ActiveDiagnostic && "Already have an active diagnostic"' failed.

When executing: swift::InFlightDiagnostic swift::DiagnosticEngine::diagnose(swift::SourceLoc, const swift::Diagnostic &)
```

Assertion context:

```
    /// \param D The diagnostic.
    ///
    /// \returns An in-flight diagnostic, to which additional information can
    /// be attached.
    InFlightDiagnostic diagnose(SourceLoc Loc, const Diagnostic &D) {
      assert(!ActiveDiagnostic && "Already have an active diagnostic");
      ActiveDiagnostic = D;
      ActiveDiagnostic->setLoc(Loc);
      return InFlightDiagnostic(*this);
    }

```

Stack trace:

```
swift: /path/to/swift/include/swift/AST/DiagnosticEngine.h:595: swift::InFlightDiagnostic swift::DiagnosticEngine::diagnose(swift::SourceLoc, const swift::Diagnostic &): Assertion `!ActiveDiagnostic && "Already have an active diagnostic"' failed.
9  swift           0x0000000000e3c946 swift::Lexer::lexStringLiteral() + 278
10 swift           0x0000000000e37924 swift::Lexer::lexImpl() + 1524
11 swift           0x0000000000e380c6 swift::Lexer::getTokenAt(swift::SourceLoc) + 230
12 swift           0x0000000000e57b93 swift::Parser::parseInheritance(llvm::SmallVectorImpl<swift::TypeLoc>&, swift::SourceLoc*) + 915
13 swift           0x0000000000e51cd6 swift::Parser::parseDeclStruct(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&) + 1190
14 swift           0x0000000000e4a340 swift::Parser::parseDecl(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) + 2896
15 swift           0x0000000000ea7319 swift::Parser::parseBraceItems(llvm::SmallVectorImpl<swift::ASTNode>&, swift::BraceItemListKind, swift::BraceItemListKind) + 841
16 swift           0x0000000000e3eb5c swift::Parser::parseTopLevel() + 156
17 swift           0x0000000000e742d0 swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) + 208
18 swift           0x0000000000c86e46 swift::CompilerInstance::performSema() + 3254
20 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
21 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28427-swift-lexer-lexstringliteral.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28427-swift-lexer-lexstringliteral-00820d.o
1.  With parser at source location: validation-test/compiler_crashers/28427-swift-lexer-lexstringliteral.swift:10:19
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
