### PR TITLE
[gardening] Avoid "-depth n" which is not findutils compatible

### DIFF
--- a/utils/find-overlay-dependencies-loop.sh
+++ b/utils/find-overlay-dependencies-loop.sh
@@ -28,6 +28,6 @@ case $# in
 esac
 
 # Don't update XCTest
-for overlay in $(find ./stdlib/public/SDK/ -depth 1 -type d ! -name XCTest -exec basename \{\} \;); do
+for overlay in $(find ./stdlib/public/SDK/ -mindepth 1 -maxdepth 1 -type d ! -name XCTest -exec basename \{\} \;); do
   $SCRIPT $overlay $1
 done

--- a/utils/find-overlay-dependencies.sh
+++ b/utils/find-overlay-dependencies.sh
@@ -46,7 +46,7 @@ CUSTOM_NAMED_MODULES[xpc]=XPC
 
 # Exclude XCTest/ and CMakeLists.txt
 ALL_OVERLAYS=()
-for overlay in $(find "$OVERLAYS_PATH" -depth 1 -type d ! -name XCTest -exec basename \{\} \;); do
+for overlay in $(find "$OVERLAYS_PATH" -mindepth 1 -maxdepth 1 -type d ! -name XCTest -exec basename \{\} \;); do
   ALL_OVERLAYS+=${CUSTOM_NAMED_MODULES[$overlay]-$overlay}
 done
 


### PR DESCRIPTION
Avoid `-depth n` which is not `findutils` compatible.

`-mindepth n -maxdepth n` gives the same result, is much faster (!) and works regardless of `find` flavor :-)
