### PR TITLE
[swiftc (75 vs. 5165)] Add crasher in swift::TypeBase::gatherAllSubstitutions(...)

### DIFF
--- a/validation-test/compiler_crashers/28428-swift-typebase-gatherallsubstitutions.swift
+++ b/validation-test/compiler_crashers/28428-swift-typebase-gatherallsubstitutions.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+{
+protocol C{class B
+class a{class a{func a{protocol A:d
+struct d<T where B:T>:C


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::gatherAllSubstitutions(...)`.

Current number of unresolved compiler crashers: 75 (5165 resolved)

Assertion failure in [`lib/AST/Module.cpp (line 622)`](https://github.com/apple/swift/blob/master/lib/AST/Module.cpp#L622):

```
Assertion `result.second' failed.

When executing: ArrayRef<swift::Substitution> swift::TypeBase::gatherAllSubstitutions(Module *, swift::LazyResolver *, swift::DeclContext *)
```

Assertion context:

```
  // Add forwarding substitutions from the outer context if we have
  // a type nested inside a generic function.
  if (auto *outerEnv = parentDC->getGenericEnvironmentOfContext())
    for (auto pair : outerEnv->getInterfaceToArchetypeMap()) {
      auto result = substitutions.insert(pair);
      assert(result.second);
    }

  auto lookupConformanceFn =
      [&](CanType original, Type replacement, ProtocolType *protoType)
          -> ProtocolConformanceRef {
```

Stack trace:

```
swift: /path/to/swift/lib/AST/Module.cpp:622: ArrayRef<swift::Substitution> swift::TypeBase::gatherAllSubstitutions(Module *, swift::LazyResolver *, swift::DeclContext *): Assertion `result.second' failed.
8  swift           0x000000000113de40 swift::TypeBase::gatherAllSubstitutions(swift::ModuleDecl*, swift::LazyResolver*, swift::DeclContext*) + 1872
9  swift           0x000000000113e4d3 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) + 1459
10 swift           0x0000000000f27a5e swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::ProtocolConformance**, swift::SourceLoc) + 62
11 swift           0x0000000000f5054d swift::TypeChecker::resolveTypeInContext(swift::TypeDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 1373
15 swift           0x0000000000f51cb2 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 162
17 swift           0x0000000000f52d54 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
18 swift           0x0000000000f514e3 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 195
19 swift           0x0000000000f19d92 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::GenericSignature*, swift::GenericEnvironment*, swift::GenericTypeResolver*) + 674
20 swift           0x0000000000f1b3b6 swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 118
21 swift           0x0000000000f1be6e swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) + 126
22 swift           0x0000000000ed960a swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 362
26 swift           0x0000000000f51cb2 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 162
28 swift           0x0000000000f52d54 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
29 swift           0x0000000000f514e3 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 195
30 swift           0x000000000102279e swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 158
31 swift           0x0000000000ff95dd swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
32 swift           0x0000000000ff9769 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 889
33 swift           0x0000000000ed6a00 swift::TypeChecker::resolveInheritedProtocols(swift::ProtocolDecl*) + 64
34 swift           0x00000000010288f3 swift::ArchetypeBuilder::addConformanceRequirement(swift::ArchetypeBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::RequirementSource, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 179
37 swift           0x000000000102a99f swift::ArchetypeBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>) + 175
38 swift           0x000000000102869a swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 426
39 swift           0x00000000010284c5 swift::ArchetypeBuilder::addGenericParameterRequirements(swift::GenericTypeParamDecl*) + 165
40 swift           0x0000000000f19c48 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::GenericSignature*, swift::GenericEnvironment*, swift::GenericTypeResolver*) + 344
41 swift           0x0000000000f1b3b6 swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 118
42 swift           0x0000000000f1be6e swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) + 126
43 swift           0x0000000000ed9bc6 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1830
46 swift           0x0000000000edfc26 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
49 swift           0x0000000000f4a52a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
50 swift           0x0000000000f4a38e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
51 swift           0x0000000000f4af63 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
53 swift           0x0000000000f045c1 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1281
54 swift           0x0000000000c86e69 swift::CompilerInstance::performSema() + 3289
56 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
57 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28428-swift-typebase-gatherallsubstitutions.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28428-swift-typebase-gatherallsubstitutions-37b7d7.o
1.  While type-checking 'a' at validation-test/compiler_crashers/28428-swift-typebase-gatherallsubstitutions.swift:12:17
2.  While type-checking 'A' at validation-test/compiler_crashers/28428-swift-typebase-gatherallsubstitutions.swift:12:24
3.  While resolving type d at [validation-test/compiler_crashers/28428-swift-typebase-gatherallsubstitutions.swift:12:35 - line:12:35] RangeText="d"
4.  While resolving type B at [validation-test/compiler_crashers/28428-swift-typebase-gatherallsubstitutions.swift:13:18 - line:13:18] RangeText="B"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
