### PR TITLE
IRGen: emitObjCMetadataRef needs to handle weakly linked Objective C …

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -286,6 +286,11 @@ static SimpleGlobalCache<ObjCClassCacheEntry> ObjCClassWrappers;
 
 const Metadata *
 swift::swift_getObjCClassMetadata(const ClassMetadata *theClass) {
+  // Make calls resilient against receiving a null Objective-C class. This can
+  // happen when classes are weakly linked and not available.
+  if (theClass == nullptr)
+    return nullptr;
+
   // If the class pointer is valid as metadata, no translation is required.
   if (theClass->isTypeMetadata()) {
     return theClass;


### PR DESCRIPTION
…classes which maybe null

WIP, test case to follow ...

rdar://28203571
