### PR TITLE
[APINotes] Fix mis-annotated error code enums.

### DIFF
--- a/apinotes/Metal.apinotes
+++ b/apinotes/Metal.apinotes
@@ -2,11 +2,11 @@
 Name: Metal
 Tags:
 - Name: MTLCommandBufferError
-  SwiftName: MTLCommandBufferErrorDomain
+  NSErrorDomain: MTLCommandBufferErrorDomain
 - Name: MTLLibraryError
-  SwiftName: MTLLibraryErrorDomain
+  NSErrorDomain: MTLLibraryErrorDomain
 - Name: MTLRenderPipelineError
-  SwiftName: MTLRenderPipelineErrorDomain
+  NSErrorDomain: MTLRenderPipelineErrorDomain
 Enumerators:
 - Name: MTLResourceStorageModeShared
   SwiftName: storageModeShared

--- a/apinotes/NetworkExtension.apinotes
+++ b/apinotes/NetworkExtension.apinotes
@@ -2,10 +2,10 @@
 Name: NetworkExtension
 Tags:
 - Name: NEAppProxyFlowError
-  SwiftName: NEAppProxyErrorDomain
+  NSErrorDomain: NEAppProxyErrorDomain
 - Name: NEFilterError
-  SwiftName: NEFilterErrorDomain
+  NSErrorDomain: NEFilterErrorDomain
 - Name: NETunnelProviderError
-  SwiftName: NETunnelProviderErrorDomain
+  NSErrorDomain: NETunnelProviderErrorDomain
 - Name: NEVPNError
-  SwiftName: NEVPNErrorDomain
+  NSErrorDomain: NEVPNErrorDomain

--- a/apinotes/SafariServices.apinotes
+++ b/apinotes/SafariServices.apinotes
@@ -2,6 +2,6 @@
 Name: SafariServices
 Tags:
 - Name: SFErrorCode
-  SwiftName: SFErrorDomain
+  NSErrorDomain: SFErrorDomain
 - Name: SSReadingListErrorCode
-  SwiftName: SSReadingListErrorDomain
+  NSErrorDomain: SSReadingListErrorDomain


### PR DESCRIPTION
- **Explanation:** Our API notes sidecar data has an annotation that can be used to associate an enum representing error codes with an NSError domain string constant. However, in the mechanical process of finding all such error code enums, we messed up and accidentally _renamed_ them to the domain constant instead. This change fixes that.
- **Scope:** Only affects users of these particular errors.
- **Issue:** rdar://problem/28507946
- **Reviewed by:** @DougGregor 
- **Risk:** Medium-low. Someone could have written code using the "wrong" name, but it's clearly incorrect, and since we haven't seen complaints about the unexpected renames, it's possible there isn't any such code.
- **Testing:** Manually verified that the enums import as Swift errors now.
