### PR TITLE
Add a sidetable cache in the module for VTable entries, replacing linear lookup

### DIFF
--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -132,6 +132,10 @@ private:
   /// The list of SILVTables in the module.
   VTableListType vtables;
 
+  /// This is a cache of vtable entries for quick look-up
+  llvm::DenseMap<std::pair<const SILVTable *, SILDeclRef>, SILFunction *>
+      VTableEntryCache;
+
   /// Lookup table for SIL witness tables from conformances.
   llvm::DenseMap<const NormalProtocolConformance *, SILWitnessTable *>
   WitnessTableMap;

--- a/include/swift/SIL/SILVTable.h
+++ b/include/swift/SIL/SILVTable.h
@@ -86,6 +86,7 @@ public:
                                [&](Pair &entry) -> bool {
       if (predicate(entry)) {
         entry.second->decrementRefCount();
+        removeFromVTableCache(entry);
         return true;
       }
       return false;
@@ -99,6 +100,9 @@ public:
   /// Print the vtable.
   void print(llvm::raw_ostream &OS, bool Verbose = false) const;
   void dump() const;
+
+private:
+  void removeFromVTableCache(Pair &entry);
 };
 
 } // end swift namespace


### PR DESCRIPTION
radar rdar://problem/28311199

This commits resolves a FIXME in SILVTable::getImplementation: Building a sidetable cache in the module for function lookup.

That, in turn, drastically reduces Swift's compilation time in programs with large VTables.
