### PR TITLE
Runtime: Make swift_getObjCClassMetadata resilient against weakly linked classes

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -357,6 +357,11 @@ static Lazy<MetadataCache<ObjCClassCacheEntry>> ObjCClassWrappers;
 
 const Metadata *
 swift::swift_getObjCClassMetadata(const ClassMetadata *theClass) {
+  // Make calls resilient against receiving a null Objective-C class. This can
+  // happen when classes are weakly linked and not available.
+  if (theClass == nullptr)
+    return nullptr;
+
   // If the class pointer is valid as metadata, no translation is required.
   if (theClass->isTypeMetadata()) {
     return theClass;


### PR DESCRIPTION
Description: Whenever we would link against a swift overlay (like CallKit) that has weakly linked Objective-C classes we run the risk of crashing in runtime functions that access type metadata.
The type metadata is initiatialized with swift_getObjCClassMetadata. If the class is weakly linked and not present this function is called with a null (the weakly linked) class.
For example, we crash on iOS9 on a simple “print(“foo”)” call when this application links against CallKit.

Scope: At least three bug reports so far.

Risk: Very low, the fix is to return null if the class passed is null.

Tested: Verified that the reported crashers work after this change

Radar: rdar://problem/28203571 (also rdar://problem/28340074)

Reviewed by: Joe Groff

rdar://28203571
