### PR TITLE
[update-checkout] Add an option '--dump-hashes' for dumping the check…

### DIFF
--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -171,6 +171,20 @@ def obtain_additional_swift_sources(
                    echo=False)
 
 
+def dump_repo_hashes(config):
+    max_len = reduce(lambda acc, x: max(acc, len(x)),
+                     config['repos'].keys(), 0)
+    fmt = "{:<%r}{}" % (max_len+5)
+    for repo_name, repo_info in sorted(config['repos'].items(),
+                                       key=lambda x: x[0]):
+        with shell.pushd(os.path.join(SWIFT_SOURCE_ROOT, repo_name),
+                         dry_run=False,
+                         echo=False):
+            h = shell.capture(["git", "log", "--oneline", "-n", "1"],
+                              echo=False).strip()
+            print(fmt.format(repo_name, h))
+
+
 def validate_config(config):
     # Make sure that our branch-names are unique.
     scheme_names = config['branch-schemes'].keys()
@@ -241,7 +255,11 @@ By default, updates your checkouts of Swift, SourceKit, LLDB, and SwiftPM.""")
         help="""Check out related pull requests referenced in the given
         free-form GitHub-style comment.""",
         metavar='GITHUB-COMMENT',
-        dest='github_comment')
+        dest='github_comment'),
+    parser.add_argument(
+        '--dump-hashes',
+        action='store_true',
+        help='Dump the git hashes of all repositories being tracked')
     args = parser.parse_args()
 
     clone = args.clone
@@ -253,6 +271,10 @@ By default, updates your checkouts of Swift, SourceKit, LLDB, and SwiftPM.""")
     with open(args.config) as f:
         config = json.load(f)
     validate_config(config)
+
+    if args.dump_hashes:
+        dump_repo_hashes(config)
+        return 0
 
     cross_repos_pr = {}
     if github_comment:


### PR DESCRIPTION
This is a small addition to update-checkout to make it easy to dump out the git hashes associated with each repo checked out by update-checkout. We should consider renaming update-checkout to repo-tool at this point as it gets more complicated.

The output looks as follows:

```
clang                              973bd1a Merge remote-tracking branch 'origin/swift-3.1-branch' into stable
cmark                              5af77f3 Merge pull request #95 from kainjow/master
compiler-rt                        1f24bd0 Merge remote-tracking branch 'origin/swift-3.1-branch' into stable
llbuild                            c324ee3 Merge pull request #35 from tinysun212/pr-cygwin-1
lldb                               f6a5830 Adjust LLDB for changes to the layout of _SwiftTypePreservingNSNumber
llvm                               52482d0 Merge remote-tracking branch 'origin/swift-3.1-branch' into stable
swift                              45f3d2a [update-checkout] Add a small tool to dump hashes for all of the checkout repos.
swift-corelibs-foundation          cc5985e Loopback tests for URLSession (#613)
swift-corelibs-libdispatch         ba7802e Merge pull request #178 from dgrove-oss/depend-on-swiftc
swift-corelibs-xctest              51b419d Merge pull request #174 from modocache/sr-1901-remove-workarounds
swift-integration-tests            c95c832 Merge pull request #12 from abertelrud/fix-swift-package-init-lib-test
swift-xcode-playground-support     4b40c34 Merge pull request #10 from apple/stdlib-unittest-expect-nil
swiftpm                            65403f5 [ConventionTests] Collect all the diagnostics from PackageBuilder
```
