### PR TITLE
[CMake] NFC. Updates based on post-merge feedback

### DIFF
--- a/cmake/modules/SwiftComponents.cmake
+++ b/cmake/modules/SwiftComponents.cmake
@@ -126,7 +126,10 @@ endfunction()
 function(swift_install_symlink_component component)
   cmake_parse_arguments(
       ARG # prefix
-      "" "LINK_NAME;TARGET;DESTINATION" "" ${ARGN})
+      "" # options
+      "LINK_NAME;TARGET;DESTINATION" # single-value args
+      "" # multi-value args
+      ${ARGN})
   precondition(ARG_LINK_NAME MESSAGE "LINK_NAME is required")
   precondition(ARG_TARGET MESSAGE "TARGET is required")
   precondition(ARG_DESTINATION MESSAGE "DESTINATION is required")
@@ -136,12 +139,9 @@ function(swift_install_symlink_component component)
     return()
   endif()
 
-  foreach(path ${CMAKE_MODULE_PATH})
-    if(EXISTS ${path}/LLVMInstallSymlink.cmake)
-      set(INSTALL_SYMLINK ${path}/LLVMInstallSymlink.cmake)
-      break()
-    endif()
-  endforeach()
+  if(EXISTS ${LLVM_CMAKE_DIR}/LLVMInstallSymlink.cmake)
+    set(INSTALL_SYMLINK ${LLVM_CMAKE_DIR}/LLVMInstallSymlink.cmake)
+  endif()
   precondition(INSTALL_SYMLINK
     MESSAGE "LLVMInstallSymlink script must be available.")
 

--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -230,6 +230,7 @@ macro(swift_common_unified_build_config product)
   set(${product}_NATIVE_CLANG_TOOLS_PATH "${CMAKE_BINARY_DIR}/bin")
   set(LLVM_PACKAGE_VERSION ${PACKAGE_VERSION})
   set(SWIFT_TABLEGEN_EXE llvm-tblgen)
+  set(LLVM_CMAKE_DIR "${CMAKE_SOURCE_DIR}/cmake/modules")
 
   # If cmark was checked out into tools/cmark, expect to build it as
   # part of the unified build.


### PR DESCRIPTION
This patch addresses feedback from @gottesmm in PR5034.
- Ensure LLVM_CMAKE_DIR is always set so it can be used
- Use LLVM_CMAKE_DIR instead of searching the module paths
- Label parameters of cmake_parse_arguments in comments
