### PR TITLE
Import name

### DIFF
--- a/lib/ClangImporter/ClangAdapter.cpp
+++ b/lib/ClangImporter/ClangAdapter.cpp
@@ -666,9 +666,9 @@ bool importer::isObjCId(const clang::Decl *decl) {
   return typedefDecl->getName() == "id";
 }
 
-bool importer::isUnavailableInSwift(const clang::Decl *decl,
-                                    PlatformAvailability &platformAvailability,
-                                    bool enableObjCInterop) {
+bool importer::isUnavailableInSwift(
+    const clang::Decl *decl, const PlatformAvailability &platformAvailability,
+    bool enableObjCInterop) {
   // 'id' is always unavailable in Swift.
   if (enableObjCInterop && isObjCId(decl))
     return true;

--- a/lib/ClangImporter/ClangAdapter.h
+++ b/lib/ClangImporter/ClangAdapter.h
@@ -136,7 +136,7 @@ bool isObjCId(const clang::Decl *decl);
 
 /// Determine whether the given declaration is considered
 /// 'unavailable' in Swift.
-bool isUnavailableInSwift(const clang::Decl *decl, PlatformAvailability &,
+bool isUnavailableInSwift(const clang::Decl *decl, const PlatformAvailability &,
                           bool enableObjCInterop);
 
 /// Determine the optionality of the given Clang parameter.

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1332,7 +1332,9 @@ ClangImporter::Implementation::Implementation(ASTContext &ctx,
       ImportForwardDeclarations(opts.ImportForwardDeclarations),
       InferImportAsMember(opts.InferImportAsMember),
       DisableSwiftBridgeAttr(opts.DisableSwiftBridgeAttr),
-      BridgingHeaderLookupTable(nullptr), platformAvailability(ctx.LangOpts) {}
+      BridgingHeaderLookupTable(nullptr), platformAvailability(ctx.LangOpts),
+      nameImporter(SwiftContext, platformAvailability, enumInfoCache,
+                   InferImportAsMember) {}
 
 ClangImporter::Implementation::~Implementation() {
   assert(NumCurrentImportingEntities == 0);

--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -464,9 +464,11 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
         auto secondMacroInfo = impl.getClangPreprocessor().getMacroInfo(
                                                                       secondID);
         auto firstIdentifier = impl.importMacroName(firstID, firstMacroInfo,
-                                                    impl.getClangASTContext());
+                                                    impl.getClangASTContext(), 
+                                                    impl.SwiftContext);
         auto secondIdentifier = impl.importMacroName(secondID, secondMacroInfo,
-                                                    impl.getClangASTContext());
+                                                    impl.getClangASTContext(),
+                                                    impl.SwiftContext);
         impl.importMacro(firstIdentifier, firstMacroInfo);
         impl.importMacro(secondIdentifier, secondMacroInfo);
         auto firstIterator = impl.ImportedMacroConstants.find(firstMacroInfo);

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1121,7 +1121,8 @@ ImportedName NameImporter::importFullName(const clang::NamedDecl *D,
     SmallVector<const clang::ObjCMethodDecl *, 4> overriddenMethods;
     method->getOverriddenMethods(overriddenMethods);
     for (auto overridden : overriddenMethods) {
-      const auto overriddenName = importFullName(overridden, clangSema);
+      const auto overriddenName =
+          importFullName(overridden, clangSema, options);
       if (overriddenName.Imported)
         overriddenNames.push_back({overridden, overriddenName});
     }
@@ -1154,7 +1155,7 @@ ImportedName NameImporter::importFullName(const clang::NamedDecl *D,
           continue;
 
         const auto overriddenName =
-            importFullName(overriddenProperty, clangSema);
+            importFullName(overriddenProperty, clangSema, options);
         if (overriddenName.Imported)
           overriddenNames.push_back({overriddenProperty, overriddenName});
       }

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -166,12 +166,16 @@ public:
       : swiftCtx(ctx), availability(avail), enumInfoCache(enumCache),
         inferImportAsMember(inferIAM) {}
 
-  /// Describe me
+  /// Determine the Swift name for a clang decl
   ImportedName importFullName(const clang::NamedDecl *,
                               clang::Sema &clangSema, // :-(
                               ImportNameOptions options = None);
 
   ASTContext &getContext() { return swiftCtx; }
+
+  const LangOptions &getLangOpts() const { return swiftCtx.LangOpts; }
+
+  bool isInferImportAsMember() const { return inferImportAsMember; }
 
 private:
   bool enableObjCInterop() const { return swiftCtx.LangOpts.EnableObjCInterop; }

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -169,7 +169,7 @@ public:
   /// Determine the Swift name for a clang decl
   ImportedName importFullName(const clang::NamedDecl *,
                               clang::Sema &clangSema, // :-(
-                              ImportNameOptions options = None);
+                              ImportNameOptions options);
 
   ASTContext &getContext() { return swiftCtx; }
 

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_IMPORT_NAME_H
 #define SWIFT_IMPORT_NAME_H
 
+#include "ImportEnumInfo.h"
 #include "SwiftLookupTable.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
@@ -24,7 +25,7 @@
 
 namespace swift {
 namespace importer {
-class EnumInfoCache;
+struct PlatformAvailability;
 
 /// Information about imported error parameters.
 struct ImportedErrorInfo {
@@ -50,6 +51,8 @@ enum class ImportedAccessorKind {
 
 /// Describes a name that was imported from Clang.
 struct ImportedName {
+  // TODO: pare down in conjunction with ImportName refactoring
+
   /// The imported name.
   DeclName Imported;
 
@@ -129,6 +132,7 @@ struct ImportedName {
 /// in "Notification", or it there would be nothing left.
 StringRef stripNotification(StringRef name);
 
+// TODO: I'd like to remove the following
 /// Flags that control the import of names in importFullName.
 enum class ImportNameFlags {
   /// Suppress the factory-method-as-initializer transformation.
@@ -140,15 +144,69 @@ enum class ImportNameFlags {
 /// Options that control the import of names in importFullName.
 typedef OptionSet<ImportNameFlags> ImportNameOptions;
 
-/// The below is a work in progress to make import naming less stateful and tied
-/// to the Impl. In it's current form, it is rather unwieldy.
-// TODO: refactor into convenience class, multi-versioned, etc.
-ImportedName importFullName(const clang::NamedDecl *, ASTContext &SwiftContext,
-                            clang::Sema &clangSema,
-                            EnumInfoCache &enumInfoCache,
-                            PlatformAvailability &platformAvailability,
-                            ImportNameOptions options,
-                            bool inferImportAsMember);
+/// Class to determine the Swift name of foreign entities. Currently fairly
+/// stateless and borrows from the ClangImporter::Implementation, but in the
+/// future will be more self-contained and encapsulated.
+class NameImporter {
+  ASTContext &swiftCtx;
+  const PlatformAvailability &availability;
+
+  // FIXME: host an enumInfo ourselves, rather than a reference to the Impl's.
+  EnumInfoCache &enumInfoCache;
+
+  StringScratchSpace scratch;
+
+  const bool inferImportAsMember;
+
+  // TODO: cache values
+
+public:
+  NameImporter(ASTContext &ctx, const PlatformAvailability &avail,
+               EnumInfoCache &enumCache, bool inferIAM)
+      : swiftCtx(ctx), availability(avail), enumInfoCache(enumCache),
+        inferImportAsMember(inferIAM) {}
+
+  /// Describe me
+  ImportedName importFullName(const clang::NamedDecl *,
+                              clang::Sema &clangSema, // :-(
+                              ImportNameOptions options = None);
+
+private:
+  bool enableObjCInterop() const { return swiftCtx.LangOpts.EnableObjCInterop; }
+
+  bool useSwift2Name(ImportNameOptions options) const {
+    return options.contains(ImportNameFlags::Swift2Name);
+  }
+
+  /// Look for a method that will import to have the same name as the
+  /// given method after importing the Nth parameter as an elided error
+  /// parameter.
+  bool hasErrorMethodNameCollision(const clang::ObjCMethodDecl *method,
+                                   unsigned paramIndex,
+                                   StringRef suffixToStrip);
+
+  /// Test to see if there is a value with the same name as 'proposedName' in
+  /// the same module as the decl
+  bool hasNamingConflict(const clang::NamedDecl *decl,
+                         const clang::IdentifierInfo *proposedName,
+                         const clang::TypedefNameDecl *cfTypedef,
+                         clang::Sema &clangSema);
+
+  Optional<ImportedErrorInfo>
+  considerErrorImport(const clang::ObjCMethodDecl *clangDecl,
+                      StringRef &baseName,
+                      SmallVectorImpl<StringRef> &paramNames,
+                      ArrayRef<const clang::ParmVarDecl *> params,
+                      bool isInitializer, bool hasCustomName);
+
+  /// Whether we should import this as Swift Private
+  bool shouldBeSwiftPrivate(const clang::NamedDecl *, clang::Sema &clangSema);
+
+  EffectiveClangContext determineEffectiveContext(const clang::NamedDecl *,
+                                                  const clang::DeclContext *,
+                                                  ImportNameOptions options,
+                                                  clang::Sema &clangSema);
+};
 }
 }
 

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -171,6 +171,8 @@ public:
                               clang::Sema &clangSema, // :-(
                               ImportNameOptions options = None);
 
+  ASTContext &getContext() { return swiftCtx; }
+
 private:
   bool enableObjCInterop() const { return swiftCtx.LangOpts.EnableObjCInterop; }
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -583,13 +583,17 @@ public:
 
   /// Add the macros from the given Clang preprocessor to the given
   /// Swift name lookup table.
-  void addMacrosToLookupTable(clang::ASTContext &clangCtx,
-                              clang::Preprocessor &pp, SwiftLookupTable &table);
+  static void addMacrosToLookupTable(clang::ASTContext &clangCtx,
+                                     clang::Preprocessor &pp,
+                                     SwiftLookupTable &table,
+       ASTContext &SwiftContext);
 
   /// Finalize a lookup table, handling any as-yet-unresolved entries
   /// and emitting diagnostics if necessary.
-  void finalizeLookupTable(clang::ASTContext &clangCtx,
-                           clang::Preprocessor &pp, SwiftLookupTable &table);
+  static void finalizeLookupTable(clang::ASTContext &clangCtx,
+                                  clang::Preprocessor &pp,
+                                  SwiftLookupTable &table,
+                                  ASTContext &SwiftContext);
 
 public:
   void registerExternalDecl(Decl *D) {
@@ -662,9 +666,10 @@ public:
   }
 
   /// Imports the name of the given Clang macro into Swift.
-  Identifier importMacroName(const clang::IdentifierInfo *clangIdentifier,
-                             const clang::MacroInfo *macro,
-                             clang::ASTContext &clangCtx);
+  static Identifier
+  importMacroName(const clang::IdentifierInfo *clangIdentifier,
+                  const clang::MacroInfo *macro, clang::ASTContext &clangCtx,
+                  ASTContext &SwiftContext);
 
   /// Print an imported name as a string suitable for the swift_name attribute,
   /// or the 'Rename' field of AvailableAttr.

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -260,7 +260,7 @@ class LLVM_LIBRARY_VISIBILITY ClangImporter::Implementation
   friend class ClangImporter;
 
   class SwiftNameLookupExtension : public clang::ModuleFileExtension {
-    Implementation &Impl;
+    Implementation &Impl; // FIXME: remove, instead have a NameImporter...
 
   public:
     SwiftNameLookupExtension(Implementation &impl) : Impl(impl) { }
@@ -555,6 +555,7 @@ private:
 
 public:
   importer::PlatformAvailability platformAvailability;
+  importer::NameImporter nameImporter;
 
   /// Tracks top level decls from the bridging header.
   std::vector<clang::Decl *> BridgeHeaderTopLevelDecls;
@@ -649,7 +650,10 @@ public:
   importer::ImportedName
   importFullName(const clang::NamedDecl *D,
                  importer::ImportNameOptions options = None,
-                 clang::Sema *clangSemaOverride = nullptr);
+                 clang::Sema *clangSemaOverride = nullptr) {
+    return nameImporter.importFullName(
+        D, clangSemaOverride ? *clangSemaOverride : getClangSema(), options);
+  }
 
   /// Imports the name of the given Clang macro into Swift.
   Identifier importMacroName(const clang::IdentifierInfo *clangIdentifier,

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -572,8 +572,14 @@ public:
 
   /// Add the given named declaration as an entry to the given Swift name
   /// lookup table, including any of its child entries.
+  static void addEntryToLookupTable(clang::Sema &clangSema,
+                                    SwiftLookupTable &table,
+                                    clang::NamedDecl *named,
+                                    importer::NameImporter &);
   void addEntryToLookupTable(clang::Sema &clangSema, SwiftLookupTable &table,
-                             clang::NamedDecl *named);
+                             clang::NamedDecl *named) {
+    return addEntryToLookupTable(clangSema, table, named, nameImporter);
+  }
 
   /// Add the macros from the given Clang preprocessor to the given
   /// Swift name lookup table.

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1400,13 +1400,6 @@ static bool diagnoseAvailability(Type ty, IdentTypeRepr *IdType, SourceLoc Loc,
   return false;
 }
 
-/// Whether the given DC is a noescape-by-default context, i.e. not a property
-/// setter
-static bool isDefaultNoEscapeContext(const DeclContext *DC) {
-  auto funcDecl = dyn_cast<FuncDecl>(DC);
-  return !funcDecl || !funcDecl->isSetter();
-}
-
 // Hack to apply context-specific @escaping to an AST function type.
 static Type applyNonEscapingFromContext(DeclContext *DC,
                                         Type ty,
@@ -1416,7 +1409,7 @@ static Type applyNonEscapingFromContext(DeclContext *DC,
     options.contains(TR_FunctionInput) ||
     options.contains(TR_ImmediateFunctionInput);
 
-  bool defaultNoEscape = isFunctionParam && isDefaultNoEscapeContext(DC);
+  bool defaultNoEscape = isFunctionParam;
 
   // Desugar here
   auto *funcTy = ty->castTo<FunctionType>();
@@ -1580,6 +1573,12 @@ bool TypeChecker::validateType(TypeLoc &Loc, DeclContext *DC,
       Loc.setType(ErrorType::get(Context), true);
       return true;
     }
+
+    // Special case: in computed property setter, newValue closure is escaping
+    if (auto funcDecl = dyn_cast<FuncDecl>(DC))
+      if (funcDecl->isSetter())
+        if (auto funTy = type->getAs<AnyFunctionType>())
+          type = funTy->withExtInfo(funTy->getExtInfo().withNoEscape(false));
 
     Loc.setType(type, true);
     return Loc.isError();

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -1313,6 +1313,22 @@ public func ParamAttrs4(a : @escaping () -> ()) {
   a()
 }
 
+// Setter
+// PASS_PRINT_AST: class FooClassComputed {
+class FooClassComputed {
+
+// PASS_PRINT_AST:   var stored: (((Int) -> Int) -> Int)?
+  var stored : (((Int) -> Int) -> Int)? = nil
+
+// PASS_PRINT_AST:   var computed: ((Int) -> Int) -> Int { get set }
+  var computed : ((Int) -> Int) -> Int {
+    get { return stored! }
+    set { stored = newValue }
+  }
+
+// PASS_PRINT_AST: }
+}
+
 // Protocol extensions
 
 protocol ProtocolToExtend {

--- a/test/attr/attr_escaping.swift
+++ b/test/attr/attr_escaping.swift
@@ -142,3 +142,16 @@ func takesVarargsOfFunctions(fns: () -> ()...) {
 func takesNoEscapeFunction(fn: () -> ()) { // expected-note {{parameter 'fn' is implicitly non-escaping}}
   takesVarargsOfFunctions(fns: fn) // expected-error {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
 }
+
+
+class FooClass {
+  var stored : Optional<(()->Int)->Void> = nil
+  var computed : (()->Int)->Void {
+    get { return stored! }
+    set(newValue) { stored = newValue } // ok
+  }
+  var computedEscaping : (@escaping ()->Int)->Void {
+    get { return stored! }
+    set(newValue) { stored = newValue } // expected-error{{cannot assign value of type '(@escaping () -> Int) -> Void' to type 'Optional<(() -> Int) -> Void>' (aka 'Optional<(() -> Int) -> ()>')}}
+  }
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->

```
[Import Name] Introduce contextual class Name Importer

Name Importer wraps references to the Swift context and other needed
encapsulation. The eventual goal is to allow name lookup tables to
live separately from the Impl, and do better Clang-instance-based
caching in the future, as well as general separation of concerns.

NFC

[ImportName] Static-ize addEntryToLookupTable

addEntryToLookupTable is one of the laggards holding back the
Impl-free Clang lookup table effort. Make a static variant, now that
we have the convenient NameImporter.

NFC
[ImportName] Static-ize many more methods

Change more methods on the Impl to be static, passing down an
ASTContext if necessary. While this does ugly up the functions
slightly with the extra parameter, it decouples them from the Impl,
which has been a false abstraction when building the lookup
tables. These can all be moved to a more appropriate place in the
future.

NFC

[ImportName] Wean SwiftNameLookupExtension off of Impl

Finally, SwiftNameLookupExtension no longer stors a reference to
ClangImporter::Implementation, a false encapsulation. Instead, it uses
a NameImporter of its own, and merely keeps a reference to the lookup
table map.

Future directions include making the NameImporter specific to a Clang
instance, meaning that we can effectively cache Clang entities better
(and not resort to EnumInfoCache's stringly keyed caches). We can also
then drop all notions of a "ClangOverride" and other messy phase
entanglement.

NFC
```

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
