### PR TITLE
[stdlib] Simplify implementation of `next()` to not need `defer`

### DIFF
--- a/stdlib/public/core/Algorithm.swift
+++ b/stdlib/public/core/Algorithm.swift
@@ -106,8 +106,9 @@ public struct EnumeratedIterator<
   /// Once `nil` has been returned, all subsequent calls return `nil`.
   public mutating func next() -> Element? {
     guard let b = _base.next() else { return nil }
-    defer { _count += 1 }
-    return (offset: _count, element: b)
+    let result = (offset: _count, element: b)
+    _count += 1 
+    return result
   }
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->

I thought this might be a little more simple and straight forward but how does it look?

Thanks!!

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
