### PR TITLE
In CSDiag, diagnose callee inaccessibility before digging into args.

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -5278,6 +5278,10 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
                               argLabels))
     return true;
 
+  // Diagnose some simple and common errors.
+  if (calleeInfo.diagnoseSimpleErrors(callExpr))
+    return true;
+
   // Force recheck of the arg expression because we allowed unresolved types
   // before, and that turned out not to help, and now we want any diagnoses
   // from disallowing them.
@@ -5285,10 +5289,6 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
                                                 calleeInfo, TCC_ForceRecheck);
   if (!argExpr)
     return true; // already diagnosed.
-  
-  // Diagnose some simple and common errors.
-  if (calleeInfo.diagnoseSimpleErrors(callExpr))
-    return true;
   
   // A common error is to apply an operator that only has inout forms (e.g. +=)
   // to non-lvalues (e.g. a local let).  Produce a nice diagnostic for this

--- a/test/NameBinding/accessibility.swift
+++ b/test/NameBinding/accessibility.swift
@@ -54,10 +54,10 @@ _ = Foo() // expected-error {{'Foo' initializer is inaccessible due to 'internal
 // <rdar://problem/27982012> QoI: Poor diagnostic for inaccessible initializer
 struct rdar27982012 {
   var x: Int
-  private init(_ x: Int) { self.x = x }
+  private init(_ x: Int) { self.x = x } // expected-note {{'init' declared here}}
 }
 
-_ = { rdar27982012($0.0) }((1, 2)) // expected-error {{type of expression is ambiguous without more context}}
+_ = { rdar27982012($0.0) }((1, 2)) // expected-error {{initializer is inaccessible due to 'private' protection level}}
 
 // TESTABLE-NOT: :[[@LINE-1]]:{{[^:]+}}:
 _ = PrivateInit() // expected-error {{'PrivateInit' initializer is inaccessible due to 'private' protection level}}


### PR DESCRIPTION
A small fix in diagnostic ordering to prefer noting when a callee is inaccessible before digging into the args (and failing to resolve them against the callee anyways). Replaces an "ambiguous type" error with the true cause.

Noted in QoI rdar://problem/27982012 , test already exists, this just fixes it.
