### PR TITLE
[Import Name] Ruin SwiftNameLookupExtension and Impl's friendship

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -231,9 +231,6 @@ public:
   /// Otherwise, return nullptr.
   Decl *importDeclCached(const clang::NamedDecl *ClangDecl);
 
-  // Returns true if it is expected that the macro is ignored.
-  bool shouldIgnoreMacro(StringRef Name, const clang::MacroInfo *Macro);
-
   /// Returns the name of the given enum element as it would be imported into
   /// Swift.
   ///

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5954,7 +5954,7 @@ void SwiftDeclConverter::importObjCMembers(
 
       // If this declaration shouldn't be visible, don't add it to
       // the list.
-      if (Impl.shouldSuppressDeclImport(objcMethod))
+      if (shouldSuppressDeclImport(objcMethod))
         continue;
     }
 

--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -463,12 +463,12 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
         auto firstMacroInfo = impl.getClangPreprocessor().getMacroInfo(firstID);
         auto secondMacroInfo = impl.getClangPreprocessor().getMacroInfo(
                                                                       secondID);
-        auto firstIdentifier = impl.importMacroName(firstID, firstMacroInfo,
-                                                    impl.getClangASTContext(), 
-                                                    impl.SwiftContext);
-        auto secondIdentifier = impl.importMacroName(secondID, secondMacroInfo,
-                                                    impl.getClangASTContext(),
-                                                    impl.SwiftContext);
+        auto firstIdentifier = importMacroName(firstID, firstMacroInfo,
+                                               impl.getClangASTContext(),
+                                               impl.SwiftContext);
+        auto secondIdentifier = importMacroName(secondID, secondMacroInfo,
+                                               impl.getClangASTContext(),
+                                               impl.SwiftContext);
         impl.importMacro(firstIdentifier, firstMacroInfo);
         impl.importMacro(secondIdentifier, secondMacroInfo);
         auto firstIterator = impl.ImportedMacroConstants.find(firstMacroInfo);

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -132,6 +132,12 @@ struct ImportedName {
 /// in "Notification", or it there would be nothing left.
 StringRef stripNotification(StringRef name);
 
+/// Imports the name of the given Clang macro into Swift.
+Identifier importMacroName(const clang::IdentifierInfo *clangIdentifier,
+                           const clang::MacroInfo *macro,
+                           clang::ASTContext &clangCtx,
+                           ASTContext &SwiftContext);
+
 // TODO: I'd like to remove the following
 /// Flags that control the import of names in importFullName.
 enum class ImportNameFlags {


### PR DESCRIPTION
SwiftNameLookupExtension and ClangImporter::Implementation were
friends, but as time goes on they have drifted apart. As part of the
ImportName refactoring, these are being decoupled to facilitate
multiple-name importing, and fight the existing false encapsulation
present in the Impl.

SwiftNameLookupExtension is now spun off into its own entity, and can
evolve to have and use its own de-coupled NameImporter.
