### PR TITLE
[CMake] Use precondition in _add_swift_lipo_target

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -363,13 +363,8 @@ endfunction()
 #                         # lipo'd into the output.
 #   )
 function(_add_swift_lipo_target target output)
-  if("${target}" STREQUAL "")
-    message(FATAL_ERROR "target is required")
-  endif()
-
-  if("${output}" STREQUAL "")
-    message(FATAL_ERROR "output is required")
-  endif()
+  precondition(target MESSAGE "target is required")
+  precondition(output MESSAGE "output is required")
 
   set(source_targets ${ARGN})
 


### PR DESCRIPTION
<!-- What's in this pull request? -->

Use the `precondition` CMake function added in e12fff76fd, rather than custom logic, to check if arguments to `_add_swift_lipo_target` are not set.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

This ties into similar changes made to this function in https://github.com/apple/swift/pull/4972, which addresses [SR-1362](https://bugs.swift.org/browse/SR-1362).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
