### PR TITLE
[irgen] Fix linkage of global aliases in case of using the wholemodule optimization with -num-threads

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -820,9 +820,10 @@ static void performParallelIRGeneration(IRGenOptions &Opts,
   for (auto it = irgen.begin(); it != irgen.end(); ++it) {
     IRGenModule *IGM = it->second;
     llvm::Module *M = IGM->getModule();
-    auto collectReference = [&](llvm::GlobalObject &G) {
+    auto collectReference = [&](llvm::GlobalValue &G) {
       if (G.isDeclaration()
-          && G.getLinkage() == GlobalValue::LinkOnceODRLinkage) {
+          && (G.getLinkage() == GlobalValue::LinkOnceODRLinkage ||
+              G.getLinkage() == GlobalValue::ExternalLinkage)) {
         referencedGlobals.insert(G.getName());
         G.setLinkage(GlobalValue::ExternalLinkage);
       }
@@ -832,6 +833,9 @@ static void performParallelIRGeneration(IRGenOptions &Opts,
     }
     for (llvm::Function &F : M->getFunctionList()) {
       collectReference(F);
+    }
+    for (llvm::GlobalAlias &A : M->getAliasList()) {
+      collectReference(A);
     }
   }
 
@@ -843,7 +847,7 @@ static void performParallelIRGeneration(IRGenOptions &Opts,
     // If a shared function/global is referenced from another file it must have
     // weak instead of linkonce linkage. Otherwise LLVM would remove the
     // definition (if it's not referenced in the same file).
-    auto updateLinkage = [&](llvm::GlobalObject &G) {
+    auto updateLinkage = [&](llvm::GlobalValue &G) {
       if (!G.isDeclaration()
           && G.getLinkage() == GlobalValue::LinkOnceODRLinkage
           && referencedGlobals.count(G.getName()) != 0) {
@@ -855,6 +859,9 @@ static void performParallelIRGeneration(IRGenOptions &Opts,
     }
     for (llvm::Function &F : M->getFunctionList()) {
       updateLinkage(F);
+    }
+    for (llvm::GlobalAlias &A : M->getAliasList()) {
+      updateLinkage(A);
     }
 
     if (!IGM->finalize())

--- a/test/IRGen/Inputs/main.swift
+++ b/test/IRGen/Inputs/main.swift
@@ -1,0 +1,1 @@
+// This file acts as a main file. It is used only for linking purposes.

--- a/test/IRGen/extension_type_metadata_linking.swift
+++ b/test/IRGen/extension_type_metadata_linking.swift
@@ -1,0 +1,28 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-swift-frontend -c  %S/Inputs/simple.swift %s -O  -num-threads 1 -o %t/simple.o -o %t/extension_type_metadata_linking.o
+// RUN: %target-swift-frontend -c  %S/Inputs/main.swift -o %t/main.o
+// RUN: %target-build-swift %t/extension_type_metadata_linking.o %t/simple.o %t/main.o -o %t/main.out
+
+// REQUIRES: objc_interop
+
+// Check that type metadata defined inside extensions of files imported from
+// other modules is emitted properly and there no linking errors.
+// In particular, it shoud be possible to define types inside extensions of
+// types importted from Foundation (rdar://problem/27245620).
+
+import Foundation
+
+extension NSNumber {
+    class Base : CustomStringConvertible {
+        public var description: String {
+            return "Base"
+        }
+    }
+
+    class Derived: Base {
+        override public var description: String {
+            return "Derived"
+        }
+    }
+}
+


### PR DESCRIPTION
<!-- What's in this pull request? -->

Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

The existing code was not handling the linkage of global aliases in LLVM modules. This resulted in linking errors in certain cases, because the LLVM backend would remove some type metadata in scope of a dead code elimination.

Fixes rdar://27245620
