### PR TITLE
[irgen] Fix linkage of global aliases in case of using the wholemodule optimization with -num-threads

### DIFF
--- a/test/IRGen/Inputs/main.swift
+++ b/test/IRGen/Inputs/main.swift
@@ -1,0 +1,1 @@
+// This file acts as a main file. It is used only for linking purposes.

--- a/test/IRGen/extension_type_metadata_linking.swift
+++ b/test/IRGen/extension_type_metadata_linking.swift
@@ -1,0 +1,28 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-swift-frontend -c  %S/Inputs/simple.swift %s -O  -num-threads 1 -o %t/simple.o -o %t/extension_type_metadata_linking.o
+// RUN: %target-swift-frontend -c  %S/Inputs/main.swift -o %t/main.o
+// RUN: %target-build-swift %t/extension_type_metadata_linking.o %t/simple.o %t/main.o -o %t/main.out
+
+// REQUIRES: objc_interop
+
+// Check that type metadata defined inside extensions of files imported from
+// other modules is emitted properly and there no linking errors.
+// In particular, it shoud be possible to define types inside extensions of
+// types importted from Foundation (rdar://problem/27245620).
+
+import Foundation
+
+extension NSNumber {
+    class Base : CustomStringConvertible {
+        public var description: String {
+            return "Base"
+        }
+    }
+
+    class Derived: Base {
+        override public var description: String {
+            return "Derived"
+        }
+    }
+}
+


### PR DESCRIPTION
––– CCC Information –––
• Explanation: Fix for a linking error related to missing type metadata symbols.
• Scope of Issue: It can happen if the current module defines an extension of a type from a different module and defines new types inside this extension. The error happens only if the wholemodule optimization with -num-threads option is used, which is a default setting in Xcode.
• Origination: It is a long standing bug.  rdar://problem/27245620
• Risk: low. 
• Reviewed By: Erik Eckstein
• Testing: Verified locally and using a CI @please smoke test
• Directions for QA: No special directions. The patch includes unit tests.

Detailed description:

The existing code was not handling the linkage of global aliases in LLVM modules. This resulted in linking errors in certain cases, because the LLVM backend would remove some type metadata in scope of a dead code elimination.

Fixes rdar://27245620
