### PR TITLE
[SyntaxColor] Respect keywords' syntax kind when they appear in conditions

### DIFF
--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -545,6 +545,13 @@ func foo1() {
 // CHECK: <kw>_</kw> = (<kw>_</kw>: <int>0</int>, <kw>_</kw>: <int>2</int>)
 }
 
+func foo2(O1 : Int?, O2: Int?, O3: Int?) {
+  guard let _ = O1, var _ = O2, let _ = O3 else { }
+// CHECK:  <kw>guard</kw> <kw>let</kw> <kw>_</kw> = O1, <kw>var</kw> <kw>_</kw> = O2, <kw>let</kw> <kw>_</kw> = O3 <kw>else</kw> { }
+  if let _ = O1, var _ = O2, let _ = O3 {}
+// CHECK: <kw>if</kw> <kw>let</kw> <kw>_</kw> = O1, <kw>var</kw> <kw>_</kw> = O2, <kw>let</kw> <kw>_</kw> = O3 {}
+}
+
 // Keep this as the last test
 /**
   Trailing off ...


### PR DESCRIPTION
Keywords like 'let' can serve as argument labels. When they do so, we should
highlight them as identifiers instead of keywords. However, the check for this
situation seems overly lenient so that when 'let', 'var' appear in conditions
of IfStmt or GuardStmt, they are wrongly highlighted as identifiers too. This
commit strengthens the checking to preserve keywords' identity in these statements.
rdar://28297337
