### PR TITLE
Fix dispatch time comparisons

### DIFF
--- a/stdlib/public/SDK/Dispatch/Time.swift
+++ b/stdlib/public/SDK/Dispatch/Time.swift
@@ -74,7 +74,7 @@ public struct DispatchWallTime : Comparable {
 
 public func <(a: DispatchWallTime, b: DispatchWallTime) -> Bool {
 	if a.rawValue == ~0 || b.rawValue == ~0 { return false }
-	return -Int64(a.rawValue) < -Int64(b.rawValue)
+	return -Int64(bitPattern: a.rawValue) < -Int64(bitPattern: b.rawValue)
 }
 
 public func ==(a: DispatchWallTime, b: DispatchWallTime) -> Bool {

--- a/stdlib/public/SDK/Dispatch/Time.swift
+++ b/stdlib/public/SDK/Dispatch/Time.swift
@@ -45,7 +45,6 @@ public struct DispatchTime : Comparable {
 }
 
 public func <(a: DispatchTime, b: DispatchTime) -> Bool {
-	if a.rawValue == ~0 || b.rawValue == ~0 { return false }
 	return a.rawValue < b.rawValue
 }
 
@@ -73,7 +72,11 @@ public struct DispatchWallTime : Comparable {
 }
 
 public func <(a: DispatchWallTime, b: DispatchWallTime) -> Bool {
-	if a.rawValue == ~0 || b.rawValue == ~0 { return false }
+	if b.rawValue == ~0 {
+		return a.rawValue != ~0
+	} else if a.rawValue == ~0 {
+		return false
+	}
 	return -Int64(bitPattern: a.rawValue) < -Int64(bitPattern: b.rawValue)
 }
 

--- a/test/stdlib/Dispatch.swift
+++ b/test/stdlib/Dispatch.swift
@@ -89,14 +89,14 @@ DispatchAPI.test("dispatch_data_t deallocator") {
 DispatchAPI.test("DispatchTime comparisons") {
     do {
         let now = DispatchTime.now()
-        checkComparable([now, now + .milliseconds(1)], oracle: {
+        checkComparable([now, now + .milliseconds(1), .distantFuture], oracle: {
             return $0 < $1 ? .lt : $0 == $1 ? .eq : .gt
         })
     }
 
     do {
         let now = DispatchWallTime.now()
-        checkComparable([now, now + .milliseconds(1)], oracle: {
+        checkComparable([now, now + .milliseconds(1), .distantFuture], oracle: {
             return $0 < $1 ? .lt : $0 == $1 ? .eq : .gt
         })
     }

--- a/test/stdlib/Dispatch.swift
+++ b/test/stdlib/Dispatch.swift
@@ -85,3 +85,19 @@ DispatchAPI.test("dispatch_data_t deallocator") {
 		expectEqual(1, t)
 	}
 }
+
+DispatchAPI.test("DispatchTime comparisons") {
+    do {
+        let now = DispatchTime.now()
+        checkComparable([now, now + .milliseconds(1)], oracle: {
+            return $0 < $1 ? .lt : $0 == $1 ? .eq : .gt
+        })
+    }
+
+    do {
+        let now = DispatchWallTime.now()
+        checkComparable([now, now + .milliseconds(1)], oracle: {
+            return $0 < $1 ? .lt : $0 == $1 ? .eq : .gt
+        })
+    }
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->

This PR does two things:
1. It makes `<` comparisons on `DispatchWallTime` not crash.
2. It makes `<` comparisons against `DispatchTime.distantFuture` and `DispatchWallTime.distantFuture` behave as expected.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Fixes half of [SR-2807](https://bugs.swift.org/browse/SR-2807).
