### PR TITLE
[SourceKit] Add test case for crash triggered in swift::TypeChecker::lookupMemberType(…)

### DIFF
--- a/validation-test/IDE/crashers/094-swift-typechecker-lookupmembertype.swift
+++ b/validation-test/IDE/crashers/094-swift-typechecker-lookupmembertype.swift
@@ -1,0 +1,4 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+protocol P{typealias e
+extension{func i(t:e=[{func#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 176
swift-ide-test: /path/to/swift/lib/Sema/TypeCheckNameLookup.cpp:307: swift::LookupTypeResult swift::TypeChecker::lookupMemberType(swift::DeclContext *, swift::Type, swift::Identifier, NameLookupOptions): Assertion `!type->isTypeParameter()' failed.
8  swift-ide-test  0x00000000009d39d4 swift::TypeChecker::lookupMemberType(swift::DeclContext*, swift::Type, swift::Identifier, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 1556
9  swift-ide-test  0x0000000000954c6d swift::constraints::ConstraintSystem::performMemberLookup(swift::constraints::ConstraintKind, swift::DeclName, swift::Type, swift::FunctionRefKind, swift::constraints::ConstraintLocator*, bool) + 2413
10 swift-ide-test  0x0000000000956a5b swift::constraints::ConstraintSystem::simplifyMemberConstraint(swift::constraints::Constraint const&) + 491
11 swift-ide-test  0x0000000000957bc5 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 69
12 swift-ide-test  0x000000000095bc9b swift::constraints::ConstraintSystem::simplify(bool) + 107
13 swift-ide-test  0x000000000095d131 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 49
14 swift-ide-test  0x00000000009648c0 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 18416
15 swift-ide-test  0x000000000095d243 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 323
16 swift-ide-test  0x000000000095d028 swift::constraints::ConstraintSystem::Candidate::solve() + 696
17 swift-ide-test  0x000000000095f838 swift::constraints::ConstraintSystem::shrink(swift::Expr*) + 648
18 swift-ide-test  0x000000000095fa21 swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 65
19 swift-ide-test  0x0000000000979d23 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 403
20 swift-ide-test  0x000000000097d445 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 949
22 swift-ide-test  0x00000000009fe7b1 swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 113
23 swift-ide-test  0x00000000009fe6fe swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
24 swift-ide-test  0x00000000009bb5df swift::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 655
26 swift-ide-test  0x00000000008f2a71 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 305
27 swift-ide-test  0x00000000007abd9d swift::CompilerInstance::performSema() + 3597
28 swift-ide-test  0x000000000074d981 main + 36401
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking expression at [<INPUT-FILE>:4:22 - line:4:28] RangeText="[{func"
```
