### PR TITLE
[SIL] Add test case for crash triggered in swift::IterativeTypeChecker::processResolveTypeDecl(…)

### DIFF
--- a/validation-test/SIL/crashers/039-swift-iterativetypechecker-processresolvetypedecl.sil
+++ b/validation-test/SIL/crashers/039-swift-iterativetypechecker-processresolvetypedecl.sil
@@ -1,0 +1,4 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+struct I:b:typealias b:a
+typealias a=f


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:11: error: expected '{' in struct
struct I:b:typealias b:a
          ^
<stdin>:3:23: error: expected '=' in typealias declaration
struct I:b:typealias b:a
                      ^
                       =
sil-opt: /path/to/swift/include/swift/AST/Decl.h:2062: swift::Accessibility swift::ValueDecl::getFormalAccess(const swift::DeclContext *) const: Assertion `hasAccessibility() && "accessibility not computed yet"' failed.
8  sil-opt         0x0000000000c3ea24 swift::IterativeTypeChecker::processResolveTypeDecl(swift::TypeDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 356
9  sil-opt         0x0000000000c14bed swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
10 sil-opt         0x0000000000c14d79 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 889
13 sil-opt         0x0000000000af3d62 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3394
17 sil-opt         0x0000000000b6d122 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 162
19 sil-opt         0x0000000000b6e1c4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
20 sil-opt         0x0000000000b6c953 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 195
21 sil-opt         0x0000000000af1b0a swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 5274
22 sil-opt         0x0000000000af3197 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 375
25 sil-opt         0x0000000000af99b6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
26 sil-opt         0x0000000000b1f362 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
27 sil-opt         0x00000000007758a9 swift::CompilerInstance::performSema() + 3289
28 sil-opt         0x000000000075ec65 main + 1813
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  While type-checking 'I' at <stdin>:3:1
2.  While resolving type b at [<stdin>:3:10 - line:3:10] RangeText="b"
3.  While type-checking 'b' at <stdin>:3:12
```
