### PR TITLE
[swiftc (76 vs. 5165)] Add crasher in swift::Decl::print(...)

### DIFF
--- a/validation-test/compiler_crashers/28429-swift-decl-print.swift
+++ b/validation-test/compiler_crashers/28429-swift-decl-print.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+{class
+func g:protocol<


### PR DESCRIPTION
Add test case for crash triggered in `swift::Decl::print(...)`.

Current number of unresolved compiler crashers: 76 (5165 resolved)

Stack trace:

```
11 swift           0x00000000010715f6 swift::Decl::print(swift::ASTPrinter&, swift::PrintOptions const&) const + 54
12 swift           0x00000000010714bd swift::Decl::print(llvm::raw_ostream&) const + 477
21 swift           0x00000000010aaa04 swift::Decl::walk(swift::ASTWalker&) + 20
22 swift           0x000000000114349e swift::SourceFile::walk(swift::ASTWalker&) + 174
23 swift           0x0000000001090d24 swift::verify(swift::SourceFile&) + 52
24 swift           0x0000000000e3ecf3 swift::Parser::parseTopLevel() + 563
25 swift           0x0000000000e742d0 swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) + 208
26 swift           0x0000000000c86e46 swift::CompilerInstance::performSema() + 3254
28 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
29 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28429-swift-decl-print.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28429-swift-decl-print-7c6e69.o
1.  With parser at source location: validation-test/compiler_crashers/28429-swift-decl-print.swift:12:1
2.  While walking into decl declaration 0x6838ca0 at validation-test/compiler_crashers/28429-swift-decl-print.swift:10:1
3.  While verifying ranges 'g' at validation-test/compiler_crashers/28429-swift-decl-print.swift:11:1
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
