### PR TITLE
[swiftc (77 vs. 5165)] Add crasher in swift::Lexer::lexOperatorIdentifier(...)

### DIFF
--- a/validation-test/compiler_crashers/28430-swift-lexer-lexoperatoridentifier.swift
+++ b/validation-test/compiler_crashers/28430-swift-lexer-lexoperatoridentifier.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+let i{
+class d{
+protocol A:protocol<
+case=


### PR DESCRIPTION
Add test case for crash triggered in `swift::Lexer::lexOperatorIdentifier(...)`.

Current number of unresolved compiler crashers: 77 (5165 resolved)

Assertion failure in [`include/swift/AST/DiagnosticEngine.h (line 595)`](https://github.com/apple/swift/blob/master/include/swift/AST/DiagnosticEngine.h#L595):

```
Assertion `!ActiveDiagnostic && "Already have an active diagnostic"' failed.

When executing: swift::InFlightDiagnostic swift::DiagnosticEngine::diagnose(swift::SourceLoc, const swift::Diagnostic &)
```

Assertion context:

```
    /// \param D The diagnostic.
    ///
    /// \returns An in-flight diagnostic, to which additional information can
    /// be attached.
    InFlightDiagnostic diagnose(SourceLoc Loc, const Diagnostic &D) {
      assert(!ActiveDiagnostic && "Already have an active diagnostic");
      ActiveDiagnostic = D;
      ActiveDiagnostic->setLoc(Loc);
      return InFlightDiagnostic(*this);
    }

```

Stack trace:

```
swift: /path/to/swift/include/swift/AST/DiagnosticEngine.h:595: swift::InFlightDiagnostic swift::DiagnosticEngine::diagnose(swift::SourceLoc, const swift::Diagnostic &): Assertion `!ActiveDiagnostic && "Already have an active diagnostic"' failed.
9  swift           0x0000000000e3b5e3 swift::Lexer::lexOperatorIdentifier() + 1555
10 swift           0x0000000000e37829 swift::Lexer::lexImpl() + 1273
11 swift           0x0000000000e380c6 swift::Lexer::getTokenAt(swift::SourceLoc) + 230
12 swift           0x0000000000e57b93 swift::Parser::parseInheritance(llvm::SmallVectorImpl<swift::TypeLoc>&, swift::SourceLoc*) + 915
13 swift           0x0000000000e5498d swift::Parser::parseDeclProtocol(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&) + 1085
14 swift           0x0000000000e4a30a swift::Parser::parseDecl(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) + 2842
16 swift           0x0000000000e77799 swift::Parser::parseList(swift::tok, swift::SourceLoc, swift::SourceLoc&, swift::tok, bool, bool, swift::Diag<>, std::function<swift::ParserStatus ()>) + 393
17 swift           0x0000000000e4c7ae swift::Parser::parseDeclClass(swift::SourceLoc, swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&) + 1598
18 swift           0x0000000000e4a630 swift::Parser::parseDecl(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) + 3648
19 swift           0x0000000000ea7319 swift::Parser::parseBraceItems(llvm::SmallVectorImpl<swift::ASTNode>&, swift::BraceItemListKind, swift::BraceItemListKind) + 841
20 swift           0x0000000000e5955c swift::Parser::parseGetSetImpl(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::ParameterList*, swift::TypeLoc, swift::Parser::ParsedAccessors&, swift::SourceLoc&, swift::SourceLoc, swift::SourceLoc, llvm::SmallVectorImpl<swift::Decl*>&) + 3468
21 swift           0x0000000000e5ab25 swift::Parser::parseGetSet(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::ParameterList*, swift::TypeLoc, swift::Parser::ParsedAccessors&, swift::SourceLoc, llvm::SmallVectorImpl<swift::Decl*>&) + 117
22 swift           0x0000000000e5b1f4 swift::Parser::parseDeclVarGetSet(swift::Pattern*, swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::SourceLoc, bool, swift::DeclAttributes const&, llvm::SmallVectorImpl<swift::Decl*>&) + 372
23 swift           0x0000000000e4e79a swift::Parser::parseDeclVar(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&, llvm::SmallVectorImpl<swift::Decl*>&, swift::SourceLoc, swift::StaticSpellingKind, swift::SourceLoc) + 3130
24 swift           0x0000000000e4a15c swift::Parser::parseDecl(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) + 2412
25 swift           0x0000000000ea7319 swift::Parser::parseBraceItems(llvm::SmallVectorImpl<swift::ASTNode>&, swift::BraceItemListKind, swift::BraceItemListKind) + 841
26 swift           0x0000000000e3eb5c swift::Parser::parseTopLevel() + 156
27 swift           0x0000000000e742d0 swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) + 208
28 swift           0x0000000000c86e46 swift::CompilerInstance::performSema() + 3254
30 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
31 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28430-swift-lexer-lexoperatoridentifier.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28430-swift-lexer-lexoperatoridentifier-10569e.o
1.  With parser at source location: validation-test/compiler_crashers/28430-swift-lexer-lexoperatoridentifier.swift:13:1
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
