### PR TITLE
[swiftc (78 vs. 5165)] Add crasher in swift::Lexer::lexOperatorIdentifier(...)

### DIFF
--- a/validation-test/compiler_crashers/28431-swift-lexer-lexoperatoridentifier.swift
+++ b/validation-test/compiler_crashers/28431-swift-lexer-lexoperatoridentifier.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+class a{struct b{{}
+protocol a{typealias e:protocol<
+case.


### PR DESCRIPTION
Add test case for crash triggered in `swift::Lexer::lexOperatorIdentifier(...)`.

Current number of unresolved compiler crashers: 78 (5165 resolved)

Assertion failure in [`include/swift/AST/DiagnosticEngine.h (line 595)`](https://github.com/apple/swift/blob/master/include/swift/AST/DiagnosticEngine.h#L595):

```
Assertion `!ActiveDiagnostic && "Already have an active diagnostic"' failed.

When executing: swift::InFlightDiagnostic swift::DiagnosticEngine::diagnose(swift::SourceLoc, const swift::Diagnostic &)
```

Assertion context:

```
    /// \param D The diagnostic.
    ///
    /// \returns An in-flight diagnostic, to which additional information can
    /// be attached.
    InFlightDiagnostic diagnose(SourceLoc Loc, const Diagnostic &D) {
      assert(!ActiveDiagnostic && "Already have an active diagnostic");
      ActiveDiagnostic = D;
      ActiveDiagnostic->setLoc(Loc);
      return InFlightDiagnostic(*this);
    }

```

Stack trace:

```
swift: /path/to/swift/include/swift/AST/DiagnosticEngine.h:595: swift::InFlightDiagnostic swift::DiagnosticEngine::diagnose(swift::SourceLoc, const swift::Diagnostic &): Assertion `!ActiveDiagnostic && "Already have an active diagnostic"' failed.
9  swift           0x0000000000e3b7b7 swift::Lexer::lexOperatorIdentifier() + 2023
10 swift           0x0000000000e37829 swift::Lexer::lexImpl() + 1273
11 swift           0x0000000000e380c6 swift::Lexer::getTokenAt(swift::SourceLoc) + 230
12 swift           0x0000000000e57b93 swift::Parser::parseInheritance(llvm::SmallVectorImpl<swift::TypeLoc>&, swift::SourceLoc*) + 915
13 swift           0x0000000000e50101 swift::Parser::parseDeclAssociatedType(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&) + 1121
14 swift           0x0000000000e4f8c3 swift::Parser::parseDeclTypeAlias(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&) + 1267
15 swift           0x0000000000e4a4e4 swift::Parser::parseDecl(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) + 3316
17 swift           0x0000000000e77799 swift::Parser::parseList(swift::tok, swift::SourceLoc, swift::SourceLoc&, swift::tok, bool, bool, swift::Diag<>, std::function<swift::ParserStatus ()>) + 393
18 swift           0x0000000000e54c2f swift::Parser::parseDeclProtocol(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&) + 1759
19 swift           0x0000000000e4a30a swift::Parser::parseDecl(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) + 2842
21 swift           0x0000000000e77799 swift::Parser::parseList(swift::tok, swift::SourceLoc, swift::SourceLoc&, swift::tok, bool, bool, swift::Diag<>, std::function<swift::ParserStatus ()>) + 393
22 swift           0x0000000000e51f3a swift::Parser::parseDeclStruct(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&) + 1802
23 swift           0x0000000000e4a340 swift::Parser::parseDecl(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) + 2896
25 swift           0x0000000000e77799 swift::Parser::parseList(swift::tok, swift::SourceLoc, swift::SourceLoc&, swift::tok, bool, bool, swift::Diag<>, std::function<swift::ParserStatus ()>) + 393
26 swift           0x0000000000e4c7ae swift::Parser::parseDeclClass(swift::SourceLoc, swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&) + 1598
27 swift           0x0000000000e4a630 swift::Parser::parseDecl(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) + 3648
28 swift           0x0000000000ea7319 swift::Parser::parseBraceItems(llvm::SmallVectorImpl<swift::ASTNode>&, swift::BraceItemListKind, swift::BraceItemListKind) + 841
29 swift           0x0000000000e3eb5c swift::Parser::parseTopLevel() + 156
30 swift           0x0000000000e742d0 swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) + 208
31 swift           0x0000000000c86e46 swift::CompilerInstance::performSema() + 3254
33 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
34 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28431-swift-lexer-lexoperatoridentifier.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28431-swift-lexer-lexoperatoridentifier-91641f.o
1.  With parser at source location: validation-test/compiler_crashers/28431-swift-lexer-lexoperatoridentifier.swift:12:1
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
