### PR TITLE
IRGen: Avoid generating LLVM switches when brs will do.

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -239,6 +239,190 @@ irgen::EnumImplStrategy::getResilientTagIndex(EnumElementDecl *Case) const {
 }
 
 namespace {
+  /// A builder that produces an LLVM branch or switch instruction for a set
+  /// of destinations.
+  class SwitchBuilder {
+  private:
+#ifndef NDEBUG
+    /// Track whether we added as many cases as we expected to.
+    unsigned CasesToAdd;
+#endif
+
+  protected:
+    IRBuilder Builder;
+    llvm::Value *Subject;
+    
+    /// Protected initializer. Clients should use the `create` factory method.
+    SwitchBuilder(IRGenFunction &IGF, llvm::Value *Subject, unsigned NumCases)
+      :
+#ifndef NDEBUG
+        CasesToAdd(NumCases),
+#endif
+        // Create our own IRBuilder, so that the SwitchBuilder is always able to
+        // generate the branch instruction at the right point, even if it needs
+        // to collect multiple cases before building an instruction.
+        Builder(IGF.IGM.getLLVMContext(), /*DebugInfo*/ false), Subject(Subject)
+    {
+      // Start our builder off at IGF's current insertion point.
+      Builder.SetInsertPoint(IGF.Builder.GetInsertBlock(),
+                             IGF.Builder.GetInsertPoint());
+    }
+    
+  public:
+#ifndef NDEBUG
+    virtual ~SwitchBuilder() {
+      assert(CasesToAdd == 0 && "Did not add enough cases");
+    }
+#endif
+
+    // Create a SwitchBuilder instance for a switch that will have the given
+    // number of cases.
+    static std::unique_ptr<SwitchBuilder>
+    create(IRGenFunction &IGF, llvm::Value *Subject,
+           SwitchDefaultDest Default,
+           unsigned NumCases);
+    
+    /// Add a case to the switch.
+    virtual void addCase(llvm::ConstantInt *value, llvm::BasicBlock *dest) {
+#ifndef NDEBUG
+      assert(CasesToAdd > 0 && "Added too many cases");
+      --CasesToAdd;
+#endif
+    }
+  };
+  
+  /// A builder that emits an unconditional branch for a "switch" with only
+  /// one destination.
+  class BrSwitchBuilder final : public SwitchBuilder {
+  private:
+    friend class SwitchBuilder;
+
+    BrSwitchBuilder(IRGenFunction &IGF, llvm::Value *Subject, unsigned NumCases)
+      : SwitchBuilder(IGF, Subject, NumCases)
+    {
+      assert(NumCases == 1 && "should have only one branch");
+    }
+    
+  public:
+    void addCase(llvm::ConstantInt *value, llvm::BasicBlock *dest) override {
+      SwitchBuilder::addCase(value, dest);
+      Builder.CreateBr(dest);
+    }
+  };
+  
+  /// A builder that produces a conditional branch for a "switch" with two
+  /// defined destinations.
+  class CondBrSwitchBuilder final : public SwitchBuilder {
+  private:
+    friend class SwitchBuilder;
+    llvm::BasicBlock *FirstDest;
+
+    CondBrSwitchBuilder(IRGenFunction &IGF, llvm::Value *Subject,
+                        SwitchDefaultDest Default,
+                        unsigned NumCases)
+      : SwitchBuilder(IGF, Subject, NumCases),
+        FirstDest(Default.getInt() == IsUnreachable
+                    ? nullptr : Default.getPointer())
+    {
+      assert(NumCases + (Default.getInt() == IsNotUnreachable) == 2
+             && "should have two branches total");
+    }
+    
+  public:
+    void addCase(llvm::ConstantInt *value, llvm::BasicBlock *dest) override {
+      SwitchBuilder::addCase(value, dest);
+      
+      // If we don't have a first destination yet, save it.
+      // We don't need to save the value in this case since we assume that the
+      // subject must be one of the case values. We only have to test one or
+      // the other.
+      //
+      // TODO: It may make sense to save both case values, and pick which one
+      // to compare based on which value is more likely to be efficiently
+      // representable in the target machine language. For example, zero
+      // or a small immediate is usually cheaper to materialize than a larger
+      // value that may require multiple instructions or a bigger encoding.
+      if (!FirstDest) {
+        FirstDest = dest;
+        return;
+      }
+      
+      // Otherwise, we have both destinations for the branch and a value to
+      // test against. We can make the instruction now.
+      if (cast<llvm::IntegerType>(Subject->getType())->getBitWidth() == 1) {
+        // If the subject is already i1, we can use it directly as the branch
+        // condition.
+        if (value->isZero())
+          Builder.CreateCondBr(Subject, FirstDest, dest);
+        else
+          Builder.CreateCondBr(Subject, dest, FirstDest);
+        return;
+      }
+      // Otherwise, compare against the case value we have.
+      auto test = Builder.CreateICmpNE(Subject, value);
+      Builder.CreateCondBr(test, FirstDest, dest);
+    }
+  };
+  
+  /// A builder that produces a switch instruction for a switch with many
+  /// destinations.
+  class SwitchSwitchBuilder final : public SwitchBuilder {
+  private:
+    friend class SwitchBuilder;
+    llvm::SwitchInst *TheSwitch;
+    
+    SwitchSwitchBuilder(IRGenFunction &IGF, llvm::Value *Subject,
+                        SwitchDefaultDest Default,
+                        unsigned NumCases)
+      : SwitchBuilder(IGF, Subject, NumCases)
+    {
+      TheSwitch = IGF.Builder.CreateSwitch(Subject, Default.getPointer(),
+                                           NumCases);
+    }
+    
+  public:
+    void addCase(llvm::ConstantInt *value, llvm::BasicBlock *dest) override {
+      SwitchBuilder::addCase(value, dest);
+      TheSwitch->addCase(value, dest);
+    }
+  };
+  
+  std::unique_ptr<SwitchBuilder>
+  SwitchBuilder::create(IRGenFunction &IGF, llvm::Value *Subject,
+                        SwitchDefaultDest Default, unsigned NumCases) {
+    // Pick a builder based on how many total reachable destinations we intend
+    // to have.
+    switch (NumCases + (Default.getInt() == IsNotUnreachable)) {
+    case 0:
+      // No reachable destinations. We can emit an unreachable and go about
+      // our business.
+      IGF.Builder.CreateUnreachable();
+      return nullptr;
+    case 1:
+      // One reachable destination. We can emit an unconditional branch.
+      // If that one branch is the default, we're done.
+      if (Default.getInt() == IsNotUnreachable) {
+        IGF.Builder.CreateBr(Default.getPointer());
+        return nullptr;
+      }
+      
+      // Otherwise, use a builder to emit the one case.
+      return std::unique_ptr<SwitchBuilder>(
+        new BrSwitchBuilder(IGF, Subject, NumCases));
+    case 2:
+      // Two reachable destinations. We can emit a single conditional branch.
+      return std::unique_ptr<SwitchBuilder>(
+        new CondBrSwitchBuilder(IGF, Subject, Default, NumCases));
+    default:
+      // Anything more, fall over into a switch.
+      // TODO: Since fast isel doesn't support switch insns, we may want to
+      // also support a "pre-lowered-switch" builder that builds a jump tree
+      // for unoptimized builds.
+      return std::unique_ptr<SwitchBuilder>(
+        new SwitchSwitchBuilder(IGF, Subject, Default, NumCases));
+    }
+  }
+
   /// Implementation strategy for singleton enums, with zero or one cases.
   class SingletonEnumImplStrategy final : public EnumImplStrategy {
     bool needsPayloadSizeInMetadata() const override { return false; }
@@ -755,9 +939,12 @@ namespace {
         unreachableDefault = true;
         defaultDest = llvm::BasicBlock::Create(IGF.IGM.getLLVMContext());
       }
-
-      auto *i = IGF.Builder.CreateSwitch(discriminator, defaultDest,
-                                         dests.size());
+      
+      auto i = SwitchBuilder::create(IGF, discriminator,
+                         SwitchDefaultDest(defaultDest,
+                                     unreachableDefault ? IsUnreachable
+                                                        : IsNotUnreachable),
+                         dests.size());
       for (auto &dest : dests)
         i->addCase(getDiscriminatorIdxConst(dest.first), dest.second);
 
@@ -1725,8 +1912,9 @@ namespace {
           }
           IGF.Builder.CreateCondBr(tagBits, oneDest, zeroDest);
         } else {
-          auto *swi = IGF.Builder.CreateSwitch(tagBits, unreachableBB,
-                                               NumExtraTagValues);
+          auto swi = SwitchBuilder::create(IGF, tagBits,
+                           SwitchDefaultDest(unreachableBB, IsUnreachable),
+                           NumExtraTagValues);
 
           // If we have extra inhabitants, we need to check for them in the
           // zero-tag case. Otherwise, we switch directly to the payload case.
@@ -1840,7 +2028,11 @@ namespace {
       auto caseIndex = emitGetEnumTag(IGF, T, addr);
 
       // Switch on the index.
-      auto *swi = IGF.Builder.CreateSwitch(caseIndex, defaultDest);
+      auto swi = SwitchBuilder::create(IGF, caseIndex,
+                         SwitchDefaultDest(defaultDest,
+                                           unreachableBB ? IsUnreachable
+                                                         : IsNotUnreachable),
+                         dests.size());
 
       auto emitCase = [&](Element elt) {
         auto tagVal =
@@ -3270,36 +3462,58 @@ namespace {
       // the default.
       if (!defaultDest)
         defaultDest = unreachableBB;
-
-      auto blockForCase = [&](EnumElementDecl *theCase) -> llvm::BasicBlock* {
-        auto found = destMap.find(theCase);
-        if (found == destMap.end())
-          return defaultDest;
-        else
-          return found->second;
-      };
+      
+      auto isUnreachable =
+        defaultDest == unreachableBB ? IsUnreachable : IsNotUnreachable;
 
       auto parts = destructureAndTagLoadableEnum(IGF, value);
+
+      // Figure out how many branches we have for the tag switch.
+      // We have one for each payload case we're switching to.
+      unsigned numPayloadBranches = std::count_if(ElementsWithPayload.begin(),
+                                                  ElementsWithPayload.end(),
+        [&](const Element &e) -> bool {
+          return destMap.find(e.decl) != destMap.end();
+        });
+      // We have one for each group of empty tags corresponding to a tag value
+      // for which we have a case corresponding to at least one member of the
+      // group.
+      unsigned numEmptyBranches = 0;
+      unsigned noPayloadI = 0;
+      unsigned casesPerTag = getNumCasesPerTag();
+      while (noPayloadI < ElementsWithNoPayload.size()) {
+        for (unsigned i = 0;
+             i < casesPerTag && noPayloadI < ElementsWithNoPayload.size();
+             ++i, ++noPayloadI) {
+          if (destMap.find(ElementsWithNoPayload[noPayloadI].decl)
+              != destMap.end()) {
+            ++numEmptyBranches;
+            noPayloadI += casesPerTag - i;
+            goto nextTag;
+          }
+        }
+      nextTag:;
+      }
 
       // Extract and switch on the tag bits.
       unsigned numTagBits
         = cast<llvm::IntegerType>(parts.tag->getType())->getBitWidth();
-      
-      auto *tagSwitch = IGF.Builder.CreateSwitch(parts.tag, unreachableBB,
-                             ElementsWithPayload.size() + NumEmptyElementTags);
+      auto tagSwitch = SwitchBuilder::create(IGF, parts.tag,
+                                 SwitchDefaultDest(defaultDest, isUnreachable),
+                                 numPayloadBranches + numEmptyBranches);
 
       // Switch over the tag bits for payload cases.
       unsigned tagIndex = 0;
       for (auto &payloadCasePair : ElementsWithPayload) {
         EnumElementDecl *payloadCase = payloadCasePair.decl;
-        tagSwitch->addCase(llvm::ConstantInt::get(C,APInt(numTagBits,tagIndex)),
-                           blockForCase(payloadCase));
+        auto found = destMap.find(payloadCase);
+        if (found != destMap.end())
+          tagSwitch->addCase(llvm::ConstantInt::get(C,APInt(numTagBits,tagIndex)),
+                             found->second);
         ++tagIndex;
       }
 
       // Switch over the no-payload cases.
-      unsigned casesPerTag = getNumCasesPerTag();
-
       auto elti = ElementsWithNoPayload.begin(),
            eltEnd = ElementsWithNoPayload.end();
 
@@ -3311,29 +3525,37 @@ namespace {
         
         // If the payload is empty, there's only one case per tag.
         if (CommonSpareBits.size() == 0) {
-          tagSwitch->addCase(tagVal, blockForCase(elti->decl));
+          auto found = destMap.find(elti->decl);
+          if (found != destMap.end())
+            tagSwitch->addCase(tagVal, found->second);
         
           ++elti;
           ++tagIndex;
           continue;
         }
         
-        auto *tagBB = llvm::BasicBlock::Create(C);
-        tagSwitch->addCase(tagVal, tagBB);
-
-        // Switch over the cases for this tag.
-        IGF.Builder.emitBlock(tagBB);
         SmallVector<std::pair<APInt, llvm::BasicBlock *>, 4> cases;
         
+        // Switch over the cases for this tag.
         for (unsigned idx = 0; idx < casesPerTag && elti != eltEnd; ++idx) {
           auto val = getEmptyCasePayload(IGF.IGM, tagIndex, idx);
-          cases.push_back({val, blockForCase(elti->decl)});
+          auto found = destMap.find(elti->decl);
+          if (found != destMap.end())
+            cases.push_back({val, found->second});
           ++elti;
         }
+        
+        if (!cases.empty()) {
+          auto *tagBB = llvm::BasicBlock::Create(C);
+          tagSwitch->addCase(tagVal, tagBB);
+          
+          IGF.Builder.emitBlock(tagBB);
 
-        parts.payload.emitSwitch(IGF, APInt::getAllOnesValue(PayloadBitCount),
-                               cases,
-                               SwitchDefaultDest(unreachableBB, IsUnreachable));
+          parts.payload.emitSwitch(IGF, APInt::getAllOnesValue(PayloadBitCount),
+                                 cases,
+                                 SwitchDefaultDest(defaultDest, isUnreachable));
+        }
+
         ++tagIndex;
       }
 
@@ -3372,18 +3594,18 @@ namespace {
       if (!defaultDest)
         defaultDest = unreachableBB;
 
-      auto *tagSwitch = IGF.Builder.CreateSwitch(tag, unreachableBB,
-                                                 NumElements);
+      auto tagSwitch = SwitchBuilder::create(IGF, tag,
+         SwitchDefaultDest(defaultDest,
+               defaultDest == unreachableBB ? IsUnreachable : IsNotUnreachable),
+         dests.size());
 
       auto emitCase = [&](Element elt) {
         auto tagVal =
             llvm::ConstantInt::get(IGF.IGM.Int32Ty,
                                    getTagIndex(elt.decl));
         auto found = destMap.find(elt.decl);
-        tagSwitch->addCase(tagVal,
-                           (found == destMap.end()
-                            ? defaultDest
-                            : found->second));
+        if (found != destMap.end())
+          tagSwitch->addCase(tagVal, found->second);
       };
 
       for (auto &elt : ElementsWithPayload)
@@ -3635,7 +3857,18 @@ namespace {
     const {
       auto *endBB = llvm::BasicBlock::Create(IGF.IGM.getLLVMContext());
 
-      auto *swi = IGF.Builder.CreateSwitch(tag, endBB);
+      unsigned numNontrivialPayloads
+        = std::count_if(ElementsWithPayload.begin(), ElementsWithPayload.end(),
+                     [](Element e) -> bool {
+                       return !e.ti->isPOD(ResilienceExpansion::Maximal);
+                     });
+
+      bool anyTrivial = !ElementsWithNoPayload.empty()
+        || numNontrivialPayloads != ElementsWithPayload.size();
+      
+      auto swi = SwitchBuilder::create(IGF, tag,
+        SwitchDefaultDest(endBB, anyTrivial ? IsNotUnreachable : IsUnreachable),
+        numNontrivialPayloads);
       auto *tagTy = cast<llvm::IntegerType>(tag->getType());
 
       // Handle nontrivial tags.
@@ -3911,13 +4144,32 @@ namespace {
         assert(PayloadTagBits.none() &&
                "address-only multi-payload enum layout cannot use spare bits");
 
+        /// True if the type is trivially copyable or takable by this operation.
+        auto isTrivial = [&](const TypeInfo &ti) -> bool {
+          return ti.isPOD(ResilienceExpansion::Maximal)
+              || (isTake && ti.isBitwiseTakable(ResilienceExpansion::Maximal));
+        };
+        
         llvm::Value *tag = loadPayloadTag(IGF, src, T);
 
         auto *endBB = llvm::BasicBlock::Create(C);
 
         /// Switch out nontrivial payloads.
         auto *trivialBB = llvm::BasicBlock::Create(C);
-        auto *swi = IGF.Builder.CreateSwitch(tag, trivialBB);
+        
+        unsigned numNontrivialPayloads
+          = std::count_if(ElementsWithPayload.begin(),
+                          ElementsWithPayload.end(),
+                          [&](Element e) -> bool {
+                            return !isTrivial(*e.ti);
+                          });
+        bool anyTrivial = !ElementsWithNoPayload.empty()
+          || numNontrivialPayloads != ElementsWithPayload.size();
+        
+        auto swi = SwitchBuilder::create(IGF, tag,
+          SwitchDefaultDest(trivialBB, anyTrivial ? IsNotUnreachable
+                                                  : IsUnreachable),
+          numNontrivialPayloads);
         auto *tagTy = cast<llvm::IntegerType>(tag->getType());
 
         unsigned tagIndex = 0;
@@ -3927,8 +4179,7 @@ namespace {
           auto &payloadTI = *payloadCasePair.ti;
           // Trivial and, in the case of a take, bitwise-takable payloads,
           // can all share the default path.
-          if (payloadTI.isPOD(ResilienceExpansion::Maximal)
-              || (isTake && payloadTI.isBitwiseTakable(ResilienceExpansion::Maximal))) {
+          if (isTrivial(payloadTI)) {
             ++tagIndex;
             continue;
           }
@@ -3966,10 +4217,20 @@ namespace {
 
         // For trivial payloads (including no-payload cases), we can just
         // primitive-copy to the destination.
-        IGF.Builder.emitBlock(trivialBB);
-        ConditionalDominanceScope condition(IGF);
-        emitPrimitiveCopy(IGF, dest, src, T);
-        IGF.Builder.CreateBr(endBB);
+        if (anyTrivial) {
+          IGF.Builder.emitBlock(trivialBB);
+          ConditionalDominanceScope condition(IGF);
+          emitPrimitiveCopy(IGF, dest, src, T);
+          IGF.Builder.CreateBr(endBB);
+        } else {
+          // If there are no trivial cases to handle, this is unreachable.
+          if (trivialBB->use_empty()) {
+            delete trivialBB;
+          } else {
+            IGF.Builder.emitBlock(trivialBB);
+            IGF.Builder.CreateUnreachable();
+          }
+        }
 
         IGF.Builder.emitBlock(endBB);
       }
@@ -4463,7 +4724,12 @@ namespace {
       if (!defaultDest)
         defaultDest = unreachableBB;
 
-      auto *tagSwitch = IGF.Builder.CreateSwitch(tag, defaultDest, NumElements);
+      auto tagSwitch = SwitchBuilder::create(IGF, tag,
+                                             SwitchDefaultDest(defaultDest,
+                                               defaultDest == unreachableBB
+                                                 ? IsUnreachable
+                                                 : IsNotUnreachable),
+                                             dests.size());
 
       auto emitCase = [&](Element elt) {
         auto tagVal =

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -408,9 +408,8 @@ enum NoPayloads2 {
 sil @no_payload_switch_2 : $@convention(thin) (NoPayloads2) -> () {
 // CHECK: entry:
 entry(%u : $NoPayloads2):
-// CHECK:   switch i8 %0, label %[[DEFAULT_DEST:[0-9]+]] [
-// CHECK:     i8 4, label %[[U_DEST:[0-9]+]]
-// CHECK:   ]
+// CHECK:   [[COND:%.*]] = icmp ne i8 %0, 4
+// CHECK:   br i1 [[COND]], label %[[DEFAULT_DEST:[0-9]+]], label %[[U_DEST:[0-9]+]]
   switch_enum %u : $NoPayloads2, case #NoPayloads2.u!enumelt: u_dest, default default_dest
 
 // CHECK: ; <label>:[[U_DEST]]
@@ -2238,10 +2237,7 @@ enum MultiPayloadNested {
 // CHECK:   %5 = load i8, i8* %4
 // CHECK:   %6 = lshr i8 %5, 7
 // CHECK:   %7 = trunc i8 %6 to i1
-// CHECK:   switch i1 %7, label {{%.*}} [
-// CHECK:     i1 false, label {{%.*}}
-// CHECK:     i1 true, label {{%.*}}
-// CHECK:   ]
+// CHECK:   br i1 %7
 sil @multi_payload_nested_switch : $(@in MultiPayloadNested) -> () {
 entry(%c : $*MultiPayloadNested):
   switch_enum_addr %c : $*MultiPayloadNested, case #MultiPayloadNested.A!enumelt.1: a_dest, case #MultiPayloadNested.B!enumelt.1: b_dest
@@ -2274,10 +2270,7 @@ enum MultiPayloadNestedSpareBits {
 // CHECK-64:   %2 = load [[WORD]], [[WORD]]* %1
 // CHECK-64:   %3 = lshr [[WORD]] %2, 61
 // CHECK-64:   %4 = trunc [[WORD]] %3 to i1
-// CHECK-64:   switch i1 %4, label {{%.*}} [
-// CHECK-64:     i1 false, label {{%.*}}
-// CHECK-64:     i1 true, label {{%.*}}
-// CHECK-64:   ]
+// CHECK-64:   br i1 %4
 sil @multi_payload_nested_spare_bits_switch : $(@in MultiPayloadNestedSpareBits) -> () {
 entry(%c : $*MultiPayloadNestedSpareBits):
   switch_enum_addr %c : $*MultiPayloadNestedSpareBits, case #MultiPayloadNestedSpareBits.A!enumelt.1: a_dest, case #MultiPayloadNestedSpareBits.B!enumelt.1: b_dest

--- a/test/IRGen/enum_dynamic_multi_payload.sil
+++ b/test/IRGen/enum_dynamic_multi_payload.sil
@@ -58,13 +58,11 @@ entry(%e : $Either<(), ()>):
   %a = unchecked_enum_data %l : $Either<(), ()>, #Either.Left!enumelt.1
   %b = unchecked_enum_data %r : $Either<(), ()>, #Either.Right!enumelt.1
 
-  // CHECK-NEXT: switch 
-  // CHECK-NEXT:   i1 false, label %6
-  // CHECK-NEXT:   i1 true, label %7
+  // CHECK-NEXT: br i1 {{%.*}}, label %6, label %5
+  // CHECK:      <label>:5
+  // CHECK:        br label %7
   // CHECK:      <label>:6
   // CHECK:        br label %8
-  // CHECK:      <label>:7
-  // CHECK:        br label %9
   switch_enum %e : $Either<(), ()>,
     case #Either.Left!enumelt.1: left,
     case #Either.Right!enumelt.1: right
@@ -77,7 +75,7 @@ right(%y : $()):
   %1 = integer_literal $Builtin.Int8, 1
   br next(%1 : $Builtin.Int8)
 
-  // CHECK:        phi i8 [ 1, %9 ], [ 0, %8 ]
+  // CHECK:        phi i8 [ 1, %8 ], [ 0, %7 ]
 next(%z : $Builtin.Int8):
   dealloc_stack %s : $*Either<(), ()>
   return undef : $()
@@ -340,10 +338,9 @@ next(%x : $Builtin.Int8):
 sil @dynamic_value_semantics : $@convention(thin) <T> (@in EitherOr<T, Builtin.Int64>) -> @out EitherOr<T, Builtin.Int64> {
 entry(%a : $*EitherOr<T, Builtin.Int64>, %b : $*EitherOr<T, Builtin.Int64>):
   // CHECK:        [[TAG:%.*]] = call i32 @swift_getEnumCaseMultiPayload
-  // CHECK:        switch i32 [[TAG]], label %[[NOOP:[0-9]+]] [
   // -- only the Left branch of this instance needs cleanup
-  // CHECK-NEXT:     i32 0, label %[[LEFT:[0-9]+]]
-  // CHECK-NEXT:   ]
+  // CHECK:        [[COND:%.*]] = icmp ne i32 [[TAG]], 0
+  // CHECK-NEXT:   br i1 [[COND]], label %[[NOOP:[0-9]+]], label %[[LEFT:[0-9]+]]
   // CHECK:      <label>:[[LEFT]]
   // CHECK:        call void %destroy(%swift.opaque* {{%.*}}, %swift.type* %T)
   // CHECK:        br label %[[NOOP]]
@@ -351,10 +348,9 @@ entry(%a : $*EitherOr<T, Builtin.Int64>, %b : $*EitherOr<T, Builtin.Int64>):
   destroy_addr %a : $*EitherOr<T, Builtin.Int64>
 
   // CHECK:        [[TAG:%.*]] = call i32 @swift_getEnumCaseMultiPayload
-  // CHECK:        switch i32 [[TAG]], label %[[TRIVIAL:[0-9]+]] [
   // -- only the Left branch of this instance needs nontrivial take
-  // CHECK-NEXT:     i32 0, label %[[LEFT:[0-9]+]]
-  // CHECK-NEXT:   ]
+  // CHECK:        [[COND:%.*]] = icmp ne i32 [[TAG]], 0
+  // CHECK-NEXT:   br i1 [[COND]], label %[[TRIVIAL:[0-9]+]], label %[[LEFT:[0-9]+]]
   // CHECK:      <label>:[[LEFT]]
   // CHECK:        call %swift.opaque* %initializeWithTake(%swift.opaque* {{%.*}}, %swift.type* %T)
   // CHECK:        br label %[[DONE:[0-9]+]]
@@ -389,10 +385,9 @@ entry(%a : $*EitherOr<T, C>, %b : $*EitherOr<T, C>):
   destroy_addr %a : $*EitherOr<T, C>
 
   // CHECK:        [[TAG:%.*]] = call i32 @swift_getEnumCaseMultiPayload
-  // CHECK:        switch i32 [[TAG]], label %[[TRIVIAL:[0-9]+]] [
-  // -- only the Left branch of this instance needs nontrivial take
-  // CHECK-NEXT:     i32 0, label %[[LEFT:[0-9]+]]
-  // CHECK-NEXT:   ]
+  // -- only the Left branch of this instance needs cleanup
+  // CHECK:        [[COND:%.*]] = icmp ne i32 [[TAG]], 0
+  // CHECK-NEXT:   br i1 [[COND]], label %[[TRIVIAL:[0-9]+]], label %[[LEFT:[0-9]+]]
   // CHECK:      <label>:[[LEFT]]
   // CHECK:        call %swift.opaque* %initializeWithTake(%swift.opaque* {{%.*}}, %swift.type* %T)
   // CHECK:        br label %[[DONE:[0-9]+]]

--- a/test/IRGen/two_tag_enums.swift.gyb
+++ b/test/IRGen/two_tag_enums.swift.gyb
@@ -1,0 +1,63 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: %gyb %s > %t/main.swift
+// RUN: %target-swift-frontend -emit-ir %t/main.swift | %FileCheck %s
+
+// CHECK-NOT: switch i{{[0-9]}}
+class C {}
+
+enum TwoTags {
+  case A, B
+}
+
+enum OneFullPayloadOneTag {
+  case A(Int), B
+}
+
+enum OneXIPayloadOneTag {
+  case A(C), B
+}
+
+enum OneGenericPayloadOneTag<T> {
+  case A(T), B
+}
+
+enum TwoFullPayloads {
+  case A(Int), B(Int)
+}
+
+enum TwoSpareBitPayloads {
+  case A(C), B(C)
+}
+
+enum TwoGenericPayloads<T,U> {
+  case A(T), B(U)
+}
+
+func a() {}
+func b() {}
+
+%{
+Types = [
+  'TwoTags',
+  'OneFullPayloadOneTag',
+  'OneXIPayloadOneTag',
+  'OneGenericPayloadOneTag<T>',
+  'TwoFullPayloads',
+  'TwoSpareBitPayloads',
+  'TwoGenericPayloads<T, U>',
+]
+}%
+
+% for Type in Types:
+
+func switch${Type}(_ x: ${Type}) {
+  switch x {
+  case .A:
+    a()
+  case .B:
+    b()
+  }
+}
+
+% end


### PR DESCRIPTION
FastISel doesn't like switch, and it's generally more compact code gen to build conditionals for two-target branches instead of switching all the time. There are many popular two-tag enums (Optional, someday Bool, Either) and this should greatly improve the potential for FastISel to kick in at -Onone.
rdar://problem/27476935