### PR TITLE
[swift-format] Remove dependency on clang::tooling::Replacement

### DIFF
--- a/test/swift-format/main.swift
+++ b/test/swift-format/main.swift
@@ -7,8 +7,6 @@
 // RUN: %swift-format -line-range 12:18 %s >%t.response
 // RUN: diff -u %s.lines.response %t.response
 
-// REQUIRES: SR-2619
-
 import Foundation
 
 func collatz(n: Int) {


### PR DESCRIPTION
<!-- What's in this pull request? -->

Considering that formatting only affects a single translation unit, and
that code formatting does not support line ranges yet, remove dependency
on clang::tooling::Replacement.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-2619](https://bugs.swift.org/browse/SR-2619).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
