### PR TITLE
[stubs] Prevent CMake from linking with object lib

### DIFF
--- a/stdlib/public/stubs/CMakeLists.txt
+++ b/stdlib/public/stubs/CMakeLists.txt
@@ -34,7 +34,6 @@ add_swift_library(swiftStdlibStubs OBJECT_LIBRARY TARGET_LIBRARY
   ${swift_stubs_unicode_normalization_sources}
   C_COMPILE_FLAGS ${swift_stubs_c_compile_flags}
   LINK_FLAGS ${SWIFT_RUNTIME_CORE_LINK_FLAGS}
-  LINK_LIBRARIES ${ICU_UC_LIBRARY} ${ICU_I18N_LIBRARY}
   TARGET_SDKS ANDROID CYGWIN FREEBSD LINUX
   INSTALL_IN_COMPONENT stdlib)
 


### PR DESCRIPTION
Attempting to link against an object library results in a CMake error. Prevent such an error by removing a line I mistakenly added in b86125ac.
