### PR TITLE
[Type Checker] SR-2505: Fix "Call arguments did not match up" assertion

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -614,24 +614,6 @@ static ConstraintSystem::SolutionKind
 matchCallArguments(ConstraintSystem &cs, TypeMatchKind kind,
                    Type argType, Type paramType,
                    ConstraintLocatorBuilder locator) {
-  
-  // In the empty existential parameter case, we don't need to decompose the
-  // arguments.
-  if (paramType->isEmptyExistentialComposition()) {
-    if (argType->is<InOutType>())
-      return ConstraintSystem::SolutionKind::Error;
-
-    // If the param type is an empty existential composition, the function can
-    // only have one argument. Check if exactly one argument was passed to this
-    // function, otherwise we obviously have a mismatch
-    if (auto tupleArgType = dyn_cast<TupleType>(argType.getPointer())) {
-      if (tupleArgType->getNumElements() != 1) {
-        return ConstraintSystem::SolutionKind::Error;
-      }
-    }
-    return ConstraintSystem::SolutionKind::Solved;
-  }
-
   // Extract the parameters.
   ValueDecl *callee;
   unsigned calleeLevel;

--- a/test/ClangModules/objc_parse.swift
+++ b/test/ClangModules/objc_parse.swift
@@ -171,7 +171,7 @@ func keyedSubscripting(_ b: B, idx: A, a: A) {
   dict[NSString()] = a
   let value = dict[NSString()]
 
-  dict[nil] = a // expected-error {{ambiguous reference}}
+  dict[nil] = a // expected-error {{ambiguous subscript}}
   let q = dict[nil]  // expected-error {{ambiguous subscript}}
   _ = q
 }

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -815,3 +815,29 @@ r27212391(a: 1, 3, y: 5)    // expected-error {{missing argument label 'x' in ca
 r27212391(1, x: 3, y: 5)    // expected-error {{missing argument label 'a' in call}}
 r27212391(a: 1, y: 3, x: 5) // expected-error {{argument 'x' must precede argument 'y'}}
 r27212391(a: 1, 3, x: 5)    // expected-error {{argument 'x' must precede unnamed argument #2}}
+
+// SR-2505: "Call arguments did not match up" assertion
+
+func sr_2505(_ a: Any) {} // expected-note {{}}
+sr_2505()          // expected-error {{missing argument for parameter #1 in call}}
+sr_2505(a: 1)      // expected-error {{extraneous argument label 'a:' in call}}
+sr_2505(1, 2)      // expected-error {{extra argument in call}}
+sr_2505(a: 1, 2)   // expected-error {{extra argument in call}}
+
+struct C_2505 {
+  init(_ arg: Any) {
+  }
+}
+
+protocol P_2505 {
+}
+
+extension C_2505 {
+  init<T>(from: [T]) where T: P_2505 {
+  }
+}
+
+class C2_2505: P_2505 {
+}
+
+let c_2505 = C_2505(arg: [C2_2505()]) // expected-error {{argument labels '(arg:)' do not match any available overloads}} expected-note {{overloads for 'C_2505' exist}}


### PR DESCRIPTION
<!-- What's in this pull request? -->

Always check arguments of the tuple type against corresponding parameters,
otherwise for a single argument functions e.g. foo(_ a: Any) after SE-0046
type checker is going to produce incorrect solution.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-2505](https://bugs.swift.org/browse/SR-2505).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
