### PR TITLE
[Parser] Fix right angle location in erroneous parameter list

### DIFF
--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -121,22 +121,17 @@ Parser::parseGenericParameters(SourceLoc LAngleLoc) {
   
   // Parse the closing '>'.
   SourceLoc RAngleLoc;
-  if (!startsWithGreater(Tok)) {
+  if (startsWithGreater(Tok)) {
+    RAngleLoc = consumeStartingGreater();
+  } else {
     if (!Invalid) {
       diagnose(Tok, diag::expected_rangle_generics_param);
       diagnose(LAngleLoc, diag::opening_angle);
-      
       Invalid = true;
     }
-    
+
     // Skip until we hit the '>'.
-    skipUntilGreaterInTypeList();
-    if (startsWithGreater(Tok))
-      RAngleLoc = consumeStartingGreater();
-    else
-      Invalid = true;
-  } else {
-    RAngleLoc = consumeStartingGreater();
+    RAngleLoc = skipUntilGreaterInTypeList();
   }
 
   if (GenericParams.empty() || Invalid) {

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -438,7 +438,7 @@ void Parser::skipUntilAnyOperator() {
 /// of generic parameters, generic arguments, or list of types in a protocol
 /// composition.
 SourceLoc Parser::skipUntilGreaterInTypeList(bool protocolComposition) {
-  SourceLoc lastLoc = Tok.getLoc();
+  SourceLoc lastLoc = PreviousLoc;
   while (true) {
     switch (Tok.getKind()) {
     case tok::eof:
@@ -473,8 +473,8 @@ SourceLoc Parser::skipUntilGreaterInTypeList(bool protocolComposition) {
       
       break;
     }
-    lastLoc = Tok.getLoc();
     skipSingle();
+    lastLoc = PreviousLoc;
   }
 }
 

--- a/validation-test/compiler_crashers_fixed/28429-swift-decl-print.swift
+++ b/validation-test/compiler_crashers_fixed/28429-swift-decl-print.swift
@@ -5,7 +5,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
 {class
 func g:protocol<


### PR DESCRIPTION
If `>` could not be found, the `skipUntilGreaterInTypeList` should return the location of the
last token consumed, instead of the current token.
Previously, it may cause ASTVerifier error `"child source range not contained within its parent"` in some cases. Or highlight overrun in diagnostics:

```
error: protocol composition is neither allowed nor needed here
    associatedtype A: protocol<P1 }
                      ^~~~~~~~~~~~~
```

Resolves [`compiler_crashers/28429-swift-decl-print.swift
`](https://github.com/apple/swift/commit/5ca0d6ee06436aa85af0702ade99d0920aaedc55).
