### PR TITLE
[Parse] Don't propagate static spelling to AST while parsing top level decls

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3972,6 +3972,7 @@ ParserStatus Parser::parseDeclVar(ParseDeclOptions Flags,
       diagnose(Tok, diag::static_var_decl_global_scope, StaticSpelling)
           .fixItRemove(StaticLoc);
       StaticLoc = SourceLoc();
+      StaticSpelling = StaticSpellingKind::None;
     } else if (Flags.contains(PD_InStruct) || Flags.contains(PD_InEnum) ||
                Flags.contains(PD_InProtocol)) {
       if (StaticSpelling == StaticSpellingKind::KeywordClass)
@@ -4346,6 +4347,7 @@ Parser::parseDeclFunc(SourceLoc StaticLoc, StaticSpellingKind StaticSpelling,
       diagnose(Tok, diag::static_func_decl_global_scope, StaticSpelling)
           .fixItRemove(StaticLoc);
       StaticLoc = SourceLoc();
+      StaticSpelling = StaticSpellingKind::None;
     } else if (Flags.contains(PD_InStruct) || Flags.contains(PD_InEnum) ||
                Flags.contains(PD_InProtocol)) {
       if (StaticSpelling == StaticSpellingKind::KeywordClass) {

--- a/test/IDE/print_ast_tc_decls_errors.swift
+++ b/test/IDE/print_ast_tc_decls_errors.swift
@@ -218,3 +218,10 @@ class OuterContext {
 // CHECK:   func protocolFunc()
   }
 }
+
+static func topLevelStaticFunc() {} // expected-error {{static methods may only be declared on a type}}
+// NO-TYPEPR: {{^}}func topLevelStaticFunc() -> <<error type>>{{$}}
+// TYPEPR: {{^}}func topLevelStaticFunc() {{$}}
+
+static var topLevelStaticVar = 42 // expected-error {{static properties may only be declared on a type}}
+// CHECK: {{^}}var topLevelStaticVar: Int{{$}}


### PR DESCRIPTION
`FuncDecl` of `static func foo() {}` in top level was accidentally `isStatic()`.
That causes assertion failure in `ASTPrinter`.

This was the immediate cause of [`compiler_crashers/28429-swift-decl-print.swift
`](https://github.com/apple/swift/commit/5ca0d6ee06436aa85af0702ade99d0920aaedc55).
