### PR TITLE
[Diagnostics] Fix bad diagnostic for failed assignment from Any to a more specific type

### DIFF
--- a/test/Constraints/subscript.swift
+++ b/test/Constraints/subscript.swift
@@ -93,3 +93,16 @@ struct SR718 {
 
 SR718()[a: Int()] // expected-error {{cannot convert value of type 'Int' to expected argument type 'UInt'}}
 
+// rdar://problem/25601561 - Qol: Bad diagnostic for failed assignment from Any to more specific type
+
+struct S_r25601561 {
+  func value() -> Any? { return "hi" }
+}
+
+class C_r25601561 {
+  var a: [S_r25601561?] = []
+  func test(i: Int) -> String {
+    let s: String = a[i]!.value()! // expected-error {{cannot convert value of type 'Any' to specified type 'String'}}
+    return s
+  }
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->

When generating constraints for subscript convert InOutType into LValueType,
because base of the subscript should never be marked as inout, but rather as
@lvalue to denote mutability.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves rdar://problem/25601561.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
