### PR TITLE
Debug Info: Use the main module as scope for top-level closures.

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -536,10 +536,8 @@ llvm::DIScope *IRGenDebugInfo::getOrCreateContext(DeclContext *DC) {
   case DeclContextKind::Initializer:
   case DeclContextKind::ExtensionDecl:
   case DeclContextKind::SubscriptDecl:
-    return getOrCreateContext(DC->getParent());
-
   case DeclContextKind::TopLevelCodeDecl:
-    return getEntryPointFn();
+    return getOrCreateContext(DC->getParent());
 
   case DeclContextKind::Module:
     return getOrCreateModule({Module::AccessPathTy(), cast<ModuleDecl>(DC)});

--- a/test/DebugInfo/scope-closure.swift
+++ b/test/DebugInfo/scope-closure.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -emit-ir -g %s -o - | %FileCheck %s
+//
+// A top-level closure is expected to have the main module as scope and not the
+// top_level_code function.
+//
+// CHECK: define {{.*}}@_TF4mainU_FT_Si() {{.*}} !dbg ![[CLOSURE:[0-9]+]] {
+// CHECK: ![[MOD:[0-9]+]] = !DIModule(scope: null, name: "main"
+// CHECK: ![[CLOSURE]] = distinct !DISubprogram({{.*}}scope: ![[MOD]],
+let closure = { 42 }
+closure()


### PR DESCRIPTION
This works around a compiler crash when a top-level closure is inlined
into a different compile unit. The top-level-code function is only
generated once so the parent cannot be resolved in any other CU.
This change is NFC as far as the generated DWARF is concerned.

Fixes SR-2725.

rdar://problem/28565158