### PR TITLE
[SwiftShims] Improve CMake Clang headers error

### DIFF
--- a/stdlib/public/SwiftShims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/CMakeLists.txt
@@ -66,7 +66,7 @@ if(SWIFT_BUILT_STANDALONE)
     endif()
   endforeach()
   if("${clang_headers_location}" STREQUAL "")
-    message(FATAL_ERROR "Clang headers were not found")
+    message(FATAL_ERROR "Clang headers were not found in any of the following locations: ${clang_headers_locations}")
   endif()
 else() # NOT SWIFT_BUILT_STANDALONE
   set(clang_headers_location "${LLVM_LIBRARY_DIR}/clang/${CLANG_VERSION}")


### PR DESCRIPTION
When Clang headers could not be found, print all the locations that were searched.
