### PR TITLE
Fix a few documentation errors in struct Locale

### DIFF
--- a/stdlib/public/SDK/Foundation/Locale.swift
+++ b/stdlib/public/SDK/Foundation/Locale.swift
@@ -80,7 +80,7 @@ public struct Locale : Hashable, Equatable, ReferenceConvertible {
     
     /// Returns a localized string for a specified identifier.
     ///
-    /// For example, in the "en" locale, the result for `"en"` is `"Spanish"`.
+    /// For example, in the "en" locale, the result for `"es"` is `"Spanish"`.
     public func localizedString(forIdentifier identifier: String) -> String? {
         return _wrapped.displayName(forKey: .identifier, value: identifier)
     }
@@ -94,7 +94,7 @@ public struct Locale : Hashable, Equatable, ReferenceConvertible {
 
     /// Returns a localized string for a specified region code.
     ///
-    /// For example, in the "en" locale, the result for `"fr"` is `"French"`.
+    /// For example, in the "en" locale, the result for `"fr"` is `"France"`.
     public func localizedString(forRegionCode regionCode: String) -> String? {
         return _wrapped.displayName(forKey: .countryCode, value: regionCode)
     }


### PR DESCRIPTION
<!-- What's in this pull request? -->

Fixes a couple of small documentation errors in `Locale`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves rdar://27912457.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
