### PR TITLE
[cmake] No depends on intrinsics_gen in standalone

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -851,7 +851,7 @@ function(_add_swift_library_single target name)
         ${SWIFTLIB_SINGLE_DEPENDS}
         ${gyb_dependency_targets}
         "${swift_object_dependency_target}"
-        ${LLVM_COMMON_DEPENDS})
+        ${SWIFT_COMMON_DEPENDS})
 
   # HACK: On some systems or build directory setups, CMake will not find static
   # archives of Clang libraries in the Clang build directory, and it will pass
@@ -1728,7 +1728,7 @@ function(_add_swift_executable_single name)
       TARGETS "${name}"
       DEPENDS
         ${dependency_target}
-        ${LLVM_COMMON_DEPENDS}
+        ${SWIFT_COMMON_DEPENDS}
         ${SWIFTEXE_SINGLE_DEPENDS}
         ${SWIFTEXE_SINGLE_LINK_FAT_LIBRARIES_TARGETS})
   llvm_update_compile_flags("${name}")

--- a/cmake/modules/AddSwiftTableGen.cmake
+++ b/cmake/modules/AddSwiftTableGen.cmake
@@ -9,5 +9,11 @@ endmacro()
 # This needs to be a macro since add_public_tablegen_target (which is a
 # function) needs to set variables in its parent scope.
 macro(swift_add_public_tablegen_target target)
+  # FIXME: LLVM's add_public_tablegen_target should take a DEPENDS argument,
+  #        allowing dependencies to be set without modifying
+  #        LLVM_COMMON_DEPENDS.
+  set(_original_llvm_common_depends ${LLVM_COMMON_DEPENDS})
+  set(LLVM_COMMON_DEPENDS ${SWIFT_COMMON_DEPENDS})
   add_public_tablegen_target(${target})
+  set(LLVM_COMMON_DEPENDS ${_original_llvm_common_depends})
 endmacro()

--- a/cmake/modules/AddSwiftUnittests.cmake
+++ b/cmake/modules/AddSwiftUnittests.cmake
@@ -8,7 +8,13 @@ set_target_properties(SwiftUnitTests PROPERTIES FOLDER "Tests")
 function(add_swift_unittest test_dirname)
   # *NOTE* Even though "add_unittest" does not have llvm in its name, it is a
   # function defined by AddLLVM.cmake.
+  # FIXME: AddLLVM.cmake's add_unittest function should take a DEPENDS
+  #        argument, allowing dependencies to be set without modifying
+  #        LLVM_COMMON_DEPENDS.
+  set(_original_llvm_common_depends ${LLVM_COMMON_DEPENDS})
+  set(LLVM_COMMON_DEPENDS ${SWIFT_COMMON_DEPENDS})
   add_unittest(SwiftUnitTests ${test_dirname} ${ARGN})
+  set(LLVM_COMMON_DEPENDS ${_original_llvm_common_depends})
 
   # TODO: _add_variant_c_compile_link_flags and these tests should share some
   # sort of logic.

--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -91,6 +91,11 @@ macro(swift_common_standalone_build_config_llvm product is_cross_compiling)
   include(AddSwiftTableGen) # This imports TableGen from LLVM.
   include(HandleLLVMOptions)
 
+  # The intrinsics_gen dependency is not available for Swift builds outside of
+  # the LLVM source tree, so remove it.
+  set(SWIFT_COMMON_DEPENDS ${LLVM_COMMON_DEPENDS})
+  list(REMOVE_ITEM SWIFT_COMMON_DEPENDS intrinsics_gen)
+
   # HACK: this ugly tweaking is to prevent the propagation of the flag from LLVM
   # into swift.  The use of this flag pollutes all targets, and we are not able
   # to remove it on a per-target basis which breaks cross-compilation.
@@ -262,6 +267,8 @@ macro(swift_common_unified_build_config product)
   if(CXX_SUPPORTS_NO_NESTED_ANON_TYPES_FLAG)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-nested-anon-types")
   endif()
+
+  set(SWIFT_COMMON_DEPENDS ${LLVM_COMMON_DEPENDS})
 endmacro()
 
 # Common cmake project config for additional warnings.

--- a/tools/SourceKit/CMakeLists.txt
+++ b/tools/SourceKit/CMakeLists.txt
@@ -157,9 +157,9 @@ macro(add_sourcekit_library name)
       BINARY_DIR ${SOURCEKIT_RUNTIME_OUTPUT_INTDIR}
       LIBRARY_DIR ${SOURCEKIT_LIBRARY_OUTPUT_INTDIR})
 
-  if(LLVM_COMMON_DEPENDS)
-    add_dependencies(${name} ${LLVM_COMMON_DEPENDS})
-  endif(LLVM_COMMON_DEPENDS)
+  if(SWIFT_COMMON_DEPENDS)
+    add_dependencies(${name} ${SWIFT_COMMON_DEPENDS})
+  endif()
 
   set(prefixed_link_libraries)
   foreach(dep ${SOURCEKITLIB_DEPENDS})
@@ -236,8 +236,8 @@ macro(add_sourcekit_executable name)
       LIBRARY_DIR ${SOURCEKIT_LIBRARY_OUTPUT_INTDIR})
 
   # Add appropriate dependencies
-  if(LLVM_COMMON_DEPENDS)
-    add_dependencies(${name} ${LLVM_COMMON_DEPENDS})
+  if(SWIFT_COMMON_DEPENDS)
+    add_dependencies(${name} ${SWIFT_COMMON_DEPENDS})
   endif()
 
   target_link_libraries(${name} ${SOURCEKITEXE_DEPENDS})
@@ -308,9 +308,9 @@ macro(add_sourcekit_framework name)
     set_source_files_properties(${headers} PROPERTIES HEADER_FILE_ONLY ON)
   endif(MSVC_IDE OR XCODE)
 
-  if(LLVM_COMMON_DEPENDS)
-    add_dependencies(${name} ${LLVM_COMMON_DEPENDS})
-  endif(LLVM_COMMON_DEPENDS)
+  if(SWIFT_COMMON_DEPENDS)
+    add_dependencies(${name} ${SWIFT_COMMON_DEPENDS})
+  endif()
 
   target_link_libraries(${name} PRIVATE ${SOURCEKITFW_DEPENDS})
   swift_common_llvm_config(${name} ${SOURCEKITFW_LLVM_COMPONENT_DEPENDS})
@@ -411,7 +411,13 @@ macro(add_sourcekit_xpc_service name framework_target)
       "${CMAKE_CURRENT_BINARY_DIR}/${name}.Info.plist" "${xpc_contents_dir}/Info.plist")
   list(APPEND srcs "${xpc_contents_dir}/Info.plist")
 
+  # FIXME: LLVM's add_llvm_executable should take a DEPENDS argument, allowing
+  #        dependencies to be set without modifying LLVM_COMMON_DEPENDS.
+  set(_original_llvm_common_depends ${LLVM_COMMON_DEPENDS})
+  set(LLVM_COMMON_DEPENDS ${SWIFT_COMMON_DEPENDS})
   add_llvm_executable(${name} ${srcs})
+  set(LLVM_COMMON_DEPENDS ${_original_llvm_common_depends})
+
   set_target_properties(${name} PROPERTIES FOLDER "XPC Services")
   set_target_properties(${name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${xpc_bin_dir}")
 
@@ -420,9 +426,9 @@ macro(add_sourcekit_xpc_service name framework_target)
     LIBRARY_DIR "${xpc_bin_dir}")
 
   # Add appropriate dependencies
-  if(LLVM_COMMON_DEPENDS)
-    add_dependencies(${name} ${LLVM_COMMON_DEPENDS})
-  endif(LLVM_COMMON_DEPENDS)
+  if(SWIFT_COMMON_DEPENDS)
+    add_dependencies(${name} ${SWIFT_COMMON_DEPENDS})
+  endif(SWIFT_COMMON_DEPENDS)
 
   target_link_libraries(${name} ${SOURCEKITXPC_DEPENDS})
   swift_common_llvm_config(${name} ${SOURCEKITXPC_LLVM_COMPONENT_DEPENDS})


### PR DESCRIPTION
<!-- What's in this pull request? -->

The `intrinsics_gen` target exists only when building Swift "in tree" -- that is, when building Swift within the LLVM source tree. Adding a non-existent `intrinsics_gen` target in "out of tree" builds results in CMake warning (which are upgraded to hard errors in later versions of CMake, such as 3.4.3).

Prevent the non-existent `intrinsics_gen` target from being added in out of tree builds by defining a separate list of common dependencies, `SWIFT_COMMON_DEPENDS`, and using this in place of `LLVM_COMMON_DEPENDS`. I've added FIXMEs where LLVM functions use `LLVM_COMMON_DEPENDS` internally, without allowing dependencies to be specified by callers.

Alternatively, it may be possible to simply remove the `intrinsics_gen` target from the `LLVM_COMMON_DEPENDS` list when building out of tree. I opted to not pursue this option, since it would involve mutating a global list that may be repercussions elsewhere.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

This addresses a suggestion left by @gottesmm and @llvm-beanz on https://github.com/apple/swift/pull/4999.
