### PR TITLE
[cmake] Bump minimum version to 3.4.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
-
-if(POLICY CMP0051)
-  cmake_policy(SET CMP0051 NEW)
-endif()
-
-if(POLICY CMP0054)
-  cmake_policy(SET CMP0054 NEW)
-endif()
-
-# Enable the IN_LIST operator, as in:
-# `if(<element_variable> IN_LIST <list_variable>)`
-if(POLICY CMP0057)
-  cmake_policy(SET CMP0057 NEW)
-endif()
+cmake_minimum_required(VERSION 3.4.3)
 
 # Add path for custom CMake modules.
 list(APPEND CMAKE_MODULE_PATH

--- a/tools/swift-remoteast-test/CMakeLists.txt
+++ b/tools/swift-remoteast-test/CMakeLists.txt
@@ -6,6 +6,7 @@ add_swift_host_tool(swift-remoteast-test
   SWIFT_COMPONENT tools
 )
 
+set_target_properties(swift-remoteast-test PROPERTIES ENABLE_EXPORTS 1)
 target_link_libraries(swift-remoteast-test edit)
 
 # If building as part of clang, make sure the headers are installed.


### PR DESCRIPTION
<!-- What's in this pull request? -->

**This pull request depends on https://github.com/apple/swift/pull/5112, which fixes warnings that are upgraded to errors in CMake 3.4.3. Please review that pull request before this one.**

The Swift README states that the minimum CMake version required to build the Swift project is the same as LLVM's: 3.4.3. Bump the minimum version used by CMake to correspond to the README.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

This addresses a suggestion left by @gottesmm and @llvm-beanz on https://github.com/apple/swift/pull/4999.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
