### PR TITLE
[gardening][ASTPrinter] Eliminate unused PrintOptions.PrintAsInParamType. NFC

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -289,12 +289,6 @@ struct PrintOptions {
   /// Whether we are printing part of SIL body.
   bool PrintInSILBody = false;
 
-  /// Whether to print the types as if they appear as function parameters. This
-  /// governs whether we print a function type with an explicit @escaping. This
-  /// is also set and restored internally when visiting a type in a parameter
-  /// position.
-  bool PrintAsInParamType = false;
-
   /// Whether to use an empty line to separate two members in a single decl.
   bool EmptyLineBetweenMembers = false;
 


### PR DESCRIPTION
The last usage was removed in 8923a12585581324dfbd5e6770866fb3e9e7c5b4.

CC: @milseman 
Any plan to re-use this?
