### PR TITLE
[SIL] Add test case for crash triggered in swift::PrintOptions::setArchetypeAndDynamicSelfTransform(…)

### DIFF
--- a/validation-test/SIL/crashers/040-swift-printoptions-setarchetypeanddynamicselftransform.sil
+++ b/validation-test/SIL/crashers/040-swift-printoptions-setarchetypeanddynamicselftransform.sil
@@ -1,0 +1,4 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+{protocol P{func t
+enum l<τ>:P


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:1: error: statement cannot begin with a closure expression
{protocol P{func t
^
<stdin>:3:1: note: explicitly discard the result of the closure by assigning to '_'
{protocol P{func t
^
_ =
<stdin>:3:19: error: expected '(' in argument list of function declaration
{protocol P{func t
                  ^
<stdin>:4:13: error: expected '{' in enum
enum l<τ>:P
<stdin>:4:13: error: consecutive declarations on a line must be separated by ';'
enum l<τ>:P
<stdin>:4:13: error: expected declaration
enum l<τ>:P
<stdin>:3:11: note: in declaration of 'P'
{protocol P{func t
          ^
<stdin>:4:13: error: expected '}' at end of closure
enum l<τ>:P
<stdin>:3:1: note: to match this opening '{'
{protocol P{func t
^
<stdin>:3:1: error: expressions are not allowed at the top level
{protocol P{func t
^
<stdin>:3:1: error: braced block of statements is an unused closure
{protocol P{func t
^
<stdin>:3:11: error: protocol 'P' cannot be nested inside another declaration
{protocol P{func t
          ^
<stdin>:4:6: error: type 'l' cannot be nested in protocol 'P'
enum l<τ>:P
<stdin>:4:6: error: type 'P.l<τ>' does not conform to protocol 'P'
enum l<τ>:P
sil-opt: /path/to/swift/lib/AST/ASTPrinter.cpp:69: std::unique_ptr<llvm::DenseMap<StringRef, Type> > swift::collectNameTypeMap(swift::Type): Assertion `ParamDecls.size() == Args.size()' failed.
9  sil-opt         0x0000000000d8dd22 swift::PrintOptions::setArchetypeAndDynamicSelfTransform(swift::Type, swift::DeclContext*) + 130
13 sil-opt         0x0000000000b43b47 swift::TypeChecker::checkConformance(swift::NormalProtocolConformance*) + 2103
14 sil-opt         0x0000000000b44057 swift::TypeChecker::checkConformancesInContext(swift::DeclContext*, swift::IterableDeclContext*) + 487
19 sil-opt         0x0000000000af99b6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
22 sil-opt         0x0000000000b66b94 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
23 sil-opt         0x0000000000b93f5c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
24 sil-opt         0x0000000000ae2e86 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 1126
26 sil-opt         0x0000000000b66cd6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
27 sil-opt         0x0000000000b1f3cd swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
28 sil-opt         0x00000000007758a9 swift::CompilerInstance::performSema() + 3289
29 sil-opt         0x000000000075ec65 main + 1813
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  While type-checking expression at [<stdin>:3:1 - line:4:12] RangeText="{protocol P{func t
enum l<τ>:P"
2.  While type-checking 'P' at <stdin>:3:2
```
