### PR TITLE
[swiftc (73 vs. 5171)] Add crasher in swift::TypeChecker::validateDecl(…)

### DIFF
--- a/validation-test/compiler_crashers/28432-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers/28432-swift-typechecker-validatedecl.swift
@@ -1,0 +1,15 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+{protocol A
+{func e
+typealias e
+typealias F=(f:A
+typealias F
+typealias e=(


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::validateDecl(...)`.

Current number of unresolved compiler crashers: 73 (5171 resolved)

Assertion failure in [`include/swift/AST/Decl.h (line 4631)`](https://github.com/apple/swift/blob/master/include/swift/AST/Decl.h#L4631):

```
Assertion `!this->GenericEnv && "already have generic context?"' failed.

When executing: void swift::AbstractFunctionDecl::setGenericEnvironment(swift::GenericEnvironment *)
```

Assertion context:

```
  /// Returns true if the function body throws.
  bool hasThrows() const { return AbstractFunctionDeclBits.Throws; }

  // FIXME: Hack that provides names with keyword arguments for accessors.
  DeclName getEffectiveFullName() const;

  /// \brief If this is a method in a type extension for some type,
  /// return that type, otherwise return Type().
  Type getExtensionType() const;

  /// Returns true if the function has a body written in the source file.
```

Stack trace:

```
swift: /path/to/swift/include/swift/AST/Decl.h:4631: void swift::AbstractFunctionDecl::setGenericEnvironment(swift::GenericEnvironment *): Assertion `!this->GenericEnv && "already have generic context?"' failed.
10 swift           0x0000000000ed9851 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 945
12 swift           0x0000000000eda1e2 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3394
13 swift           0x00000000010258c1 swift::ArchetypeBuilder::PotentialArchetype::getNestedType(swift::Identifier, swift::ArchetypeBuilder&) + 705
14 swift           0x00000000010289fc swift::ArchetypeBuilder::addConformanceRequirement(swift::ArchetypeBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::RequirementSource, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 444
15 swift           0x000000000102b0de swift::ArchetypeBuilder::addRequirement(swift::Requirement const&, swift::RequirementSource) + 318
16 swift           0x000000000102cfd0 swift::ArchetypeBuilder::addGenericSignature(swift::GenericSignature*, swift::GenericEnvironment*, bool) + 592
17 swift           0x0000000000f19b26 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::GenericSignature*, swift::GenericEnvironment*, swift::GenericTypeResolver*) + 54
19 swift           0x0000000000f1a18b swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 91
24 swift           0x0000000000edfc26 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
27 swift           0x0000000000f4b744 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
28 swift           0x0000000000f78aec swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
29 swift           0x0000000000ec9506 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 1126
31 swift           0x0000000000f4b886 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
32 swift           0x0000000000f0452d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
33 swift           0x0000000000c86e69 swift::CompilerInstance::performSema() + 3289
35 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
36 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28432-swift-typechecker-validatedecl.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28432-swift-typechecker-validatedecl-787c14.o
1.  While type-checking expression at [validation-test/compiler_crashers/28432-swift-typechecker-validatedecl.swift:10:1 - line:15:13] RangeText="{protocol A
2.  While type-checking 'A' at validation-test/compiler_crashers/28432-swift-typechecker-validatedecl.swift:10:2
3.  While type-checking 'e' at validation-test/compiler_crashers/28432-swift-typechecker-validatedecl.swift:15:1
4.  While type-checking 'e' at validation-test/compiler_crashers/28432-swift-typechecker-validatedecl.swift:11:2
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
