### PR TITLE
[swiftc (74 vs. 5171)] Add crasher in swift::TypeChecker::typeCheckDecl(…)

### DIFF
--- a/validation-test/compiler_crashers/28433-swift-typechecker-typecheckdecl.swift
+++ b/validation-test/compiler_crashers/28433-swift-typechecker-typecheckdecl.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+for in[{protocol a{func e
+typealias e=()
+typealias e


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::typeCheckDecl(...)`.

Current number of unresolved compiler crashers: 74 (5171 resolved)

Assertion failure in [`include/swift/AST/Decl.h (line 4631)`](https://github.com/apple/swift/blob/master/include/swift/AST/Decl.h#L4631):

```
Assertion `!this->GenericEnv && "already have generic context?"' failed.

When executing: void swift::AbstractFunctionDecl::setGenericEnvironment(swift::GenericEnvironment *)
```

Assertion context:

```
  /// Returns true if the function body throws.
  bool hasThrows() const { return AbstractFunctionDeclBits.Throws; }

  // FIXME: Hack that provides names with keyword arguments for accessors.
  DeclName getEffectiveFullName() const;

  /// \brief If this is a method in a type extension for some type,
  /// return that type, otherwise return Type().
  Type getExtensionType() const;

  /// Returns true if the function has a body written in the source file.
```

Stack trace:

```
swift: /path/to/swift/include/swift/AST/Decl.h:4631: void swift::AbstractFunctionDecl::setGenericEnvironment(swift::GenericEnvironment *): Assertion `!this->GenericEnv && "already have generic context?"' failed.
12 swift           0x0000000000edfc26 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
15 swift           0x0000000000f4b744 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
16 swift           0x0000000000f78aec swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
17 swift           0x0000000000ec9506 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 1126
18 swift           0x0000000000ecdb1d swift::TypeChecker::typeCheckForEachBinding(swift::DeclContext*, swift::ForEachStmt*) + 93
21 swift           0x0000000000f4b886 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
22 swift           0x0000000000f0452d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
23 swift           0x0000000000c86e69 swift::CompilerInstance::performSema() + 3289
25 swift           0x00000000007e0947 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2887
26 swift           0x00000000007a8e08 main + 2984
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28433-swift-typechecker-typecheckdecl.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28433-swift-typechecker-typecheckdecl-c97902.o
1.  While type-checking expression at [validation-test/compiler_crashers/28433-swift-typechecker-typecheckdecl.swift:10:7 - line:12:11] RangeText="[{protocol a{func e
2.  While type-checking 'a' at validation-test/compiler_crashers/28433-swift-typechecker-typecheckdecl.swift:10:9
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
