### PR TITLE
[sil-dead-function-elimination] Don't change the fragility of pre-specialized functions

### DIFF
--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -75,7 +75,6 @@ protected:
     // a pipeline, as it may break some optimizations.
     if (F->isKeepAsPublic()) {
       F->setLinkage(SILLinkage::Public);
-      F->setFragile(IsFragile_t::IsNotFragile);
       DEBUG(llvm::dbgs() << "DFE: Preserve the specialization "
                          << F->getName() << '\n');
       return true;


### PR DESCRIPTION
The old code was changing the fragility of some pre-specialized symbols which made them invisible outside of their own object files, which resulted in linking errors.

Fixes radr://problem/28615847
