### PR TITLE
Fix quarantineProperty in URLResourceValues

### DIFF
--- a/stdlib/public/SDK/Foundation/URL.swift
+++ b/stdlib/public/SDK/Foundation/URL.swift
@@ -287,8 +287,22 @@ public struct URLResourceValues {
     /// The quarantine properties as defined in LSQuarantine.h. To remove quarantine information from a file, pass `nil` as the value when setting this property.
     @available(OSX 10.10, *)
     public var quarantineProperties: [String : Any]? {
-        get { return _get(.quarantinePropertiesKey) }
-        set { _set(.quarantinePropertiesKey, newValue: newValue as NSObject?) }
+        get {
+            // If a caller has caused us to stash NSNull in the dictionary (via set), make sure to return nil instead of NSNull
+            if let isNull = _values[.quarantinePropertiesKey] as? NSNull {
+                return nil
+            } else {
+                return _values[.quarantinePropertiesKey] as? [String : Any]
+            }
+        }
+        set {
+            if let v = newValue {
+                _set(.quarantinePropertiesKey, newValue: newValue as NSObject?)
+            } else {
+                // Set to NSNull, a special case for deleting quarantine properties
+                _set(.quarantinePropertiesKey, newValue: NSNull())
+            }
+        }
     }
 #endif
     

--- a/test/stdlib/TestURL.swift
+++ b/test/stdlib/TestURL.swift
@@ -53,7 +53,7 @@ class TestURL : TestURLSuper {
             expectTrue(false, "Unable to write data")
         }
         
-        // Modify an existing resource values
+        // Modify an existing resource value
         do {
             var resourceValues = try file.resourceValues(forKeys: [.nameKey])
             expectNotNil(resourceValues.name)
@@ -64,8 +64,64 @@ class TestURL : TestURLSuper {
             try file.setResourceValues(resourceValues)
         } catch {
             expectTrue(false, "Unable to set resources")
-        }        
+        }
     }
+    
+#if os(OSX)
+    func testQuarantineProperties() {
+        // Test the quarantine stuff; it has special logic
+        if #available(OSX 10.11, iOS 9.0, *) {
+            // Create a temporary file
+            var file = URL(fileURLWithPath: NSTemporaryDirectory())
+            let name = "my_great_file" + UUID().uuidString
+            file.appendPathComponent(name)
+            let data = Data(bytes: [1, 2, 3, 4, 5])
+            do {
+                try data.write(to: file)
+            } catch {
+                expectTrue(false, "Unable to write data")
+            }
+
+            // Set the quarantine info on a file
+            do {
+                var resourceValues = URLResourceValues()
+                resourceValues.quarantineProperties = ["LSQuarantineAgentName" : "TestURL"]
+                try file.setResourceValues(resourceValues)
+            } catch {
+                expectTrue(false, "Unable to set quarantine info")
+            }
+            
+            // Get the quarantine info back
+            do {
+                var resourceValues = try file.resourceValues(forKeys: [.quarantinePropertiesKey])
+                expectEqual(resourceValues.quarantineProperties?["LSQuarantineAgentName"] as? String, "TestURL")
+            } catch {
+                expectTrue(false, "Unable to get quarantine info")
+            }
+            
+            // Clear the quarantine info
+            do {
+                var resourceValues = URLResourceValues()
+                resourceValues.quarantineProperties = nil // this effectively sets a flag
+                try file.setResourceValues(resourceValues)
+                
+                // Make sure that the resourceValues property returns nil
+                expectNil(resourceValues.quarantineProperties)
+            } catch {
+                expectTrue(false, "Unable to clear quarantine info")
+            }
+
+            // Get the quarantine info back again
+            do {
+                var resourceValues = try file.resourceValues(forKeys: [.quarantinePropertiesKey])
+                expectNil(resourceValues.quarantineProperties)
+            } catch {
+                expectTrue(false, "Unable to get quarantine info after clearing")
+            }
+
+        }
+    }
+#endif
     
     func testMoreSetProperties() {
         // Create a temporary file
@@ -327,6 +383,9 @@ var URLTests = TestSuite("TestURL")
 URLTests.test("testBasics") { TestURL().testBasics() }
 URLTests.test("testProperties") { TestURL().testProperties() }
 URLTests.test("testSetProperties") { TestURL().testSetProperties() }
+#if os(OSX)
+URLTests.test("testQuarantineProperties") { TestURL().testQuarantineProperties() }
+#endif
 URLTests.test("testMoreSetProperties") { TestURL().testMoreSetProperties() }
 URLTests.test("testURLComponents") { TestURL().testURLComponents() }
 URLTests.test("testURLResourceValues") { TestURL().testURLResourceValues() }


### PR DESCRIPTION
<!-- What's in this pull request? -->

NSURL has an odd behavior around the quarantine dictionary URL resource value - if you want to clear it, you should pass NSNull instead of the NSDictionary. We need to accomodate that in the overlay code with a special case.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves rdar://problem/28575806 Cannot remove Quarantine attribute in Swift 3

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
