### PR TITLE
[Driver] Begin testing -driver-show-incremental

### DIFF
--- a/test/Driver/Dependencies/driver-show-incremental-mutual.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-mutual.swift
@@ -1,0 +1,17 @@
+/// main <==> other
+
+// RUN: rm -rf %t && cp -r %S/Inputs/mutual/ %t
+// RUN: touch -t 201401240005 %t/*
+
+// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v -driver-show-incremental 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// CHECK-FIRST: Queuing main.swift (initial)
+
+// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v -driver-show-incremental 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// CHECK-SECOND-NOT: Queuing
+
+// RUN: touch -t 201401240006 %t/other.swift
+// RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v -driver-show-incremental 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
+// CHECK-THIRD: Queuing other.swift (initial)
+// CHECK-THIRD: Queuing main.swift because of the initial set:
+// CHECK-THIRD-NEXT: other.swift provides top-level name 'a'
+


### PR DESCRIPTION
<!-- What's in this pull request? -->

[SR-2855](https://bugs.swift.org/browse/SR-2855) describes additional functionality to be added to `-driver-show-incremental`. That option is not currently tested anywhere. Using the option does not interfere with existing incremental compilation tests, so begin adding it to tests, starting with mutual dependencies tests.

I considered adding new, isolated tests for this option, but adding it to existing tests results in less setup code and test boilerplate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

A first step in addressing [SR-2855](https://bugs.swift.org/browse/SR-2855).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

---

@jrose-apple I thought adding some tests for `-driver-show-incremental` would be a good start. What do you think of adding it to the existing tests? If that sounds good, I'll add it to more tests, then update the `CHECK`s once I've implemented [SR-2855](https://bugs.swift.org/browse/SR-2855).
