### PR TITLE
Add descriptive doc comments to withMemoryRebound(to:capacity:_:) and…

### DIFF
--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -362,12 +362,25 @@ public struct ${Self}<Pointee>
 %  end
 
   /// Rebinds memory at `self` to type `T` with capacity to hold `count`
-  /// adjacent `T` values while executing the `body` closure. After executing
-  /// the closure, rebinds memory back to `Pointee`.
+  /// adjacent `T` values while executing the `body` closure.
+  ///
+  /// After executing the closure, rebinds memory back to `Pointee`.
   ///
   /// - Precondition: Type 'T' is layout compatible with type 'Pointee'.
   /// - Precondition: The memory `self..<self + count * MemoryLayout<T>.stride`
   ///   is bound to `Pointee`.
+  ///
+  /// Accessing ${Self}<T>.pointee requires that the memory be "bound" to
+  /// type `T`.  A memory location may only be bound to one type at a time, so
+  /// accessing the same memory as an unrelated type without first rebinding the
+  /// memory is undefined. `self` may not be accessed within the `body` closure
+  /// because memory is no longer bound to `Pointee` while it executes. The
+  /// closure's ${Self}<T> argument must not escape the closure because memory
+  /// is only temporarily bound to `T`.
+  ///
+  /// To persistently bind this memory to a different type, first obtain a
+  /// raw pointer to the memory, then invoke the `bindMemory` API:
+  /// `UnsafeRawPointer(typedPointer).bindMemory(to:capacity:)`.
   public func withMemoryRebound<T, Result>(to: T.Type, capacity count: Int,
     _ body: (${Self}<T>) throws -> Result
   ) rethrows -> Result {

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -370,12 +370,12 @@ public struct ${Self}<Pointee>
   /// - Precondition: The memory `self..<self + count * MemoryLayout<T>.stride`
   ///   is bound to `Pointee`.
   ///
-  /// Accessing ${Self}<T>.pointee requires that the memory be "bound" to
+  /// Accessing `${Self}<T>.pointee` requires that the memory be "bound" to
   /// type `T`.  A memory location may only be bound to one type at a time, so
   /// accessing the same memory as an unrelated type without first rebinding the
   /// memory is undefined. `self` may not be accessed within the `body` closure
   /// because memory is no longer bound to `Pointee` while it executes. The
-  /// closure's ${Self}<T> argument must not escape the closure because memory
+  /// closure's `${Self}<T>` argument must not escape the closure because memory
   /// is only temporarily bound to `T`.
   ///
   /// To persistently bind this memory to a different type, first obtain a

--- a/stdlib/public/core/UnsafeRawPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawPointer.swift.gyb
@@ -171,8 +171,9 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
   /// - Precondition: The memory is uninitialized.
   /// - Postcondition: The memory is bound to 'T' starting at `self` continuing
   ///   through `self` + `count` * `MemoryLayout<T>.stride`
-  /// - Warning: Binding memory to a type is potentially undefined if the
-  ///   memory is ever accessed as an unrelated type.
+  /// - Warning: A memory location may only be bound to one type at a time.
+  ///   The behavior of accessing memory as type `U` while it is bound to an
+  ///   unrelated type `T` is undefined.
   @_transparent
   @discardableResult
   public func bindMemory<T>(to type: T.Type, capacity count: Int)


### PR DESCRIPTION
… bindMemory(to:capacity:).

SR-2480: Improve documentation for withMemoryRebound(to:capacity:_:)
rdar://problem/28440528
