### PR TITLE
[GlibcModuleMap] Add sys/file.h to glibc modulemap

### DIFF
--- a/stdlib/public/Platform/glibc.modulemap.gyb
+++ b/stdlib/public/Platform/glibc.modulemap.gyb
@@ -317,6 +317,10 @@ module SwiftGlibc [system] {
       export *
 
 % if CMAKE_SDK in ["LINUX", "FREEBSD", "CYGWIN"]:
+      module file {
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/file.h"
+        export *
+      }
       module sem {
         header "${GLIBC_ARCH_INCLUDE_PATH}/sys/sem.h"
         export *


### PR DESCRIPTION
<!-- What's in this pull request? -->

Add `sys/file.h` in glibc modulemap to export `flock()` on Linux platforms
Ref: https://github.com/apple/swift-package-manager/pull/720

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
