### PR TITLE
Allow demangling of methods in extensions

### DIFF
--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -243,6 +243,10 @@ public:
       }
     } else if (_type == LookupKind::SwiftModule)
       _module->lookupValue(path, name, kind, result);
+    else if (_type == LookupKind::Extension) {
+      auto results = _extension._decl->lookupDirect(DeclName(name));
+      result.append(results.begin(), results.end());
+    }
     return;
   }
 
@@ -1322,6 +1326,7 @@ static void VisitNodeFunction(
     case Demangle::Node::Kind::Module:
     case Demangle::Node::Kind::Structure:
     case Demangle::Node::Kind::Protocol:
+    case Demangle::Node::Kind::Extension:
       nodes.push_back((*pos));
       VisitNode(ast, nodes, decl_scope_result, generic_context);
       break;


### PR DESCRIPTION
```
Add enough logic to TypeReconstruction to allow LLDB to discover the type of methods in protocol extensions, such as e.g.

extension Collection {
  func group<Key: Hashable>(f: Key) -> Key {...}
}

I have a matching test case for this over in LLDB
```
