### PR TITLE
suppress unused loop counter warning

### DIFF
--- a/stdlib/private/StdlibUnittest/RaceTest.swift
+++ b/stdlib/private/StdlibUnittest/RaceTest.swift
@@ -589,7 +589,7 @@ public func runRaceTest<RT : RaceTestWithPerTrialData>(
 
   let racingThreadBody = {
     (tid: Int) -> Void in
-    for t in 0..<trials {
+    for _ in 0..<trials {
       let stopNow = _workerThreadOneTrial(tid, sharedState)
       if stopNow { break }
     }


### PR DESCRIPTION
Suppress warning of unused loop counter by replacing with _
