### PR TITLE
Fix no asserts build

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1934,8 +1934,8 @@ for host in "${ALL_HOSTS[@]}"; do
                     "${cmake_options[@]}"
                     -DCMAKE_C_FLAGS="$(llvm_c_flags ${host})"
                     -DCMAKE_CXX_FLAGS="$(llvm_c_flags ${host})"
-                    -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2"
-                    -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2"
+                    -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2 -DNDEBUG"
+                    -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -DNDEBUG"
                     -DCMAKE_BUILD_TYPE:STRING="${LLVM_BUILD_TYPE}"
                     -DLLVM_TOOL_SWIFT_BUILD:BOOL=NO
                     -DLLVM_INCLUDE_DOCS:BOOL=TRUE
@@ -2049,8 +2049,8 @@ for host in "${ALL_HOSTS[@]}"; do
                     "${cmake_options[@]}"
                     -DCMAKE_C_FLAGS="$(swift_c_flags ${host})"
                     -DCMAKE_CXX_FLAGS="$(swift_c_flags ${host})"
-                    -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2"
-                    -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2"
+                    -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2 -DNDEBUG"
+                    -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -DNDEBUG"
                     -DCMAKE_BUILD_TYPE:STRING="${SWIFT_BUILD_TYPE}"
                     -DLLVM_ENABLE_ASSERTIONS:BOOL=$(true_false "${SWIFT_ENABLE_ASSERTIONS}")
                     -DSWIFT_ANALYZE_CODE_COVERAGE:STRING=$(toupper "${SWIFT_ANALYZE_CODE_COVERAGE}")

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1934,14 +1934,8 @@ for host in "${ALL_HOSTS[@]}"; do
                     "${cmake_options[@]}"
                     -DCMAKE_C_FLAGS="$(llvm_c_flags ${host})"
                     -DCMAKE_CXX_FLAGS="$(llvm_c_flags ${host})"
-                    -DCMAKE_C_FLAGS_DEBUG=""
-                    -DCMAKE_CXX_FLAGS_DEBUG=""
-                    -DCMAKE_C_FLAGS_RELEASE="-O3"
-                    -DCMAKE_CXX_FLAGS_RELEASE="-O3"
                     -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2"
                     -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2"
-                    -DCMAKE_C_FLAGS_MINSIZEREL="-Os"
-                    -DCMAKE_CXX_FLAGS_MINSIZEREL="-Os"
                     -DCMAKE_BUILD_TYPE:STRING="${LLVM_BUILD_TYPE}"
                     -DLLVM_TOOL_SWIFT_BUILD:BOOL=NO
                     -DLLVM_INCLUDE_DOCS:BOOL=TRUE
@@ -2055,14 +2049,8 @@ for host in "${ALL_HOSTS[@]}"; do
                     "${cmake_options[@]}"
                     -DCMAKE_C_FLAGS="$(swift_c_flags ${host})"
                     -DCMAKE_CXX_FLAGS="$(swift_c_flags ${host})"
-                    -DCMAKE_C_FLAGS_DEBUG=""
-                    -DCMAKE_CXX_FLAGS_DEBUG=""
-                    -DCMAKE_C_FLAGS_RELEASE="-O3"
-                    -DCMAKE_CXX_FLAGS_RELEASE="-O3"
                     -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2"
                     -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2"
-                    -DCMAKE_C_FLAGS_MINSIZEREL="-Os"
-                    -DCMAKE_CXX_FLAGS_MINSIZEREL="-Os"
                     -DCMAKE_BUILD_TYPE:STRING="${SWIFT_BUILD_TYPE}"
                     -DLLVM_ENABLE_ASSERTIONS:BOOL=$(true_false "${SWIFT_ENABLE_ASSERTIONS}")
                     -DSWIFT_ANALYZE_CODE_COVERAGE:STRING=$(toupper "${SWIFT_ANALYZE_CODE_COVERAGE}")


### PR DESCRIPTION
This group of commits does two things:
1. It responds to some post commit review from @llvm-beanz on e4d8cc7. Specifically, we only need to stop -g from being put on the command line by cmake when we compile with LTO+RelWithDebInfo.
2. In a separate commit, it adds -DNDEBUG to the overridden flags line for RelWithDebInfo to ensure that asserts are properly enabled given how LLVM implements LLVM_ENABLE_ASSERTIONS (it just rewrites the cflags flag to change the -D in -DNDEBUG to -U).

I am going to file a radar for a separate piece of work to fix LLVM to do something sane, namely, adding -DNDEBUG or -UNDEBUG to the end of command lines and perhaps create some sort of verification on the swift side that we are getting asserts where we think they are supposed to be.
