### PR TITLE
SR-2673: @NSManaged property can't satisfy protocol requirement

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -820,7 +820,10 @@ void TypeChecker::synthesizeAccessorsForStorage(AbstractStorageDecl *storage,
   // If the decl is stored, convert it to StoredWithTrivialAccessors
   // by synthesizing the full set of accessors.
   if (!storage->hasAccessorFunctions()) {
-    addTrivialAccessorsToStorage(storage, *this);
+    if (storage->getAttrs().hasAttribute<NSManagedAttr>())
+      maybeAddAccessorsToVariable(cast<VarDecl>(storage), *this);
+    else
+      addTrivialAccessorsToStorage(storage, *this);
     return;
   }
 

--- a/test/SILGen/objc_attr_NSManaged.swift
+++ b/test/SILGen/objc_attr_NSManaged.swift
@@ -78,6 +78,19 @@ func testFinal(_ obj: FinalGizmo) -> String {
   return obj.y
 }
 
+// SR-2673: @NSManaged property can't satisfy protocol requirement
+@objc protocol ObjCProto {
+  var managedProp: String { get set }
+  var managedExtProp: AnyObject { get }
+}
+
+class ProtoAdopter: Gizmo, ObjCProto {
+  @NSManaged var managedProp: String
+}
+extension ProtoAdopter {
+  @NSManaged var managedExtProp: AnyObject
+}
+
 
 // CHECK-NOT: sil hidden @_TToFC19objc_attr_NSManaged10SwiftGizmog1xCS_1X : $@convention(objc_method) (SwiftGizmo) -> @autoreleased X
 // CHECK-NOT: sil hidden @_TToFC19objc_attr_NSManaged10SwiftGizmos1xCS_1X
@@ -100,3 +113,7 @@ func testFinal(_ obj: FinalGizmo) -> String {
 // CHECK-NEXT:   #SwiftGizmo.init!initializer.1: _TFC19objc_attr_NSManaged10FinalGizmoc
 // CHECK-NEXT:   #FinalGizmo.deinit!deallocator: _TFC19objc_attr_NSManaged10FinalGizmoD
 // CHECK-NEXT: }
+
+// CHECK-LABEL: sil_vtable ProtoAdopter {
+// CHECK-NOT: managed{{.*}}Prop
+// CHECK: {{^}$}}


### PR DESCRIPTION
Targeted fix for [SR-2673](https://bugs.swift.org/browse/SR-2673): if a potential protocol witness is `@NSManaged`, add accessors the NSManaged way, not the stored property way.

There's probably more weirdness around here, so I'll clone the bug to go through maybeAddAccessorsToVariable a lot more often. (Lazy properties could easily be broken in the same way.)
