### PR TITLE
numbered ABI FIXME #165: _RangeReplaceableIndexable should be RangeReplac…

### DIFF
--- a/stdlib/public/core/RangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/RangeReplaceableCollection.swift.gyb
@@ -244,7 +244,7 @@ public protocol _RangeReplaceableIndexable : _Indexable {
 public protocol RangeReplaceableCollection
   : _RangeReplaceableIndexable, Collection
 {
-  // FIXME(ABI): should require `RangeReplaceableCollection`.
+  // FIXME(ABI)#165 (Recursive Protocol Constraints): should require `RangeReplaceableCollection`.
   associatedtype SubSequence : _RangeReplaceableIndexable /*: RangeReplaceableCollection*/
     = RangeReplaceableSlice<Self>
 


### PR DESCRIPTION
Depends on recursive protocol constrains
