### PR TITLE
[SIL] Add test case for crash triggered in swift::TypeBase::getDesugaredType()

### DIFF
--- a/validation-test/SIL/crashers/041-swift-typebase-getdesugaredtype.sil
+++ b/validation-test/SIL/crashers/041-swift-typebase-getdesugaredtype.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+class C struct A{weak var e:C


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:9: error: expected '{' in class
class C struct A{weak var e:C
        ^
<stdin>:3:30: error: consecutive declarations on a line must be separated by ';'
class C struct A{weak var e:C
                             ^
                             ;
<stdin>:3:30: error: expected declaration
class C struct A{weak var e:C
                             ^
<stdin>:3:16: note: in declaration of 'A'
class C struct A{weak var e:C
               ^
sil-opt: /path/to/swift/lib/AST/Type.cpp:1368: swift::Type swift::SyntaxSugarType::getImplementationType(): Assertion `implDecl && "Optional type has not been set yet"' failed.
8  sil-opt         0x0000000000eada7f swift::TypeBase::getDesugaredType() + 15
10 sil-opt         0x0000000000e6796c swift::DiagnosticEngine::emitDiagnostic(swift::Diagnostic const&) + 2364
11 sil-opt         0x0000000000e66e11 swift::DiagnosticEngine::flushActiveDiagnostic() + 305
12 sil-opt         0x0000000000cab5b1 swift::TypeChecker::checkOwnershipAttr(swift::VarDecl*, swift::OwnershipAttr*) + 321
13 sil-opt         0x0000000000cab282 swift::TypeChecker::checkTypeModifyingDeclAttributes(swift::VarDecl*) + 82
14 sil-opt         0x0000000000bc0506 swift::TypeChecker::coercePatternToType(swift::Pattern*&, swift::DeclContext*, swift::Type, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeLoc) + 1926
15 sil-opt         0x0000000000bbfcae swift::TypeChecker::typeCheckPattern(swift::Pattern*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) + 1070
17 sil-opt         0x0000000000b762b5 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1973
18 sil-opt         0x0000000000c020f6 swift::createImplicitConstructor(swift::TypeChecker&, swift::NominalTypeDecl*, swift::ImplicitConstructorKind) + 422
19 sil-opt         0x0000000000b81778 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 1384
22 sil-opt         0x0000000000b7c216 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
23 sil-opt         0x0000000000ba29cf swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1055
24 sil-opt         0x0000000000801956 swift::CompilerInstance::performSema() + 3350
25 sil-opt         0x00000000007e84bc main + 1852
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  While type-checking 'A' at <stdin>:3:9
```
