### PR TITLE
[swiftc (73 vs. 5173)] Add crasher in swift::Type::transform(...)

### DIFF
--- a/validation-test/compiler_crashers/28434-swift-type-transform.swift
+++ b/validation-test/compiler_crashers/28434-swift-type-transform.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+e:A
+struct B<T where T=[T>


### PR DESCRIPTION
Add test case for crash triggered in `swift::Type::transform(...)`.

Current number of unresolved compiler crashers: 73 (5173 resolved)

Stack trace:

```
3  swift           0x00000000011a8634 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 20
4  swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
5  swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
6  swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
7  swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
8  swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
9  swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
10 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
11 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
12 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
13 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
14 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
15 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
16 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
17 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
18 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
19 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
20 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
21 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
22 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
23 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
24 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
25 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
26 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
27 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
28 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
29 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
30 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
31 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
32 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
33 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
34 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
35 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
36 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
37 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
38 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
39 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
40 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
41 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
42 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
43 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
44 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
45 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
46 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
47 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
48 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
49 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
50 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
51 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
52 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
53 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
54 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
55 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
56 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
57 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
58 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
59 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
60 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
61 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
62 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
63 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
64 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
65 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
66 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
67 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
68 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
69 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
70 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
71 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
72 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
73 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
74 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
75 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
76 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
77 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
78 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
79 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
80 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
81 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
82 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
83 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
84 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
85 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
86 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
87 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
88 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
89 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
90 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
91 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
92 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
93 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
94 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
95 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
96 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
97 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
98 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
99 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
100 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
101 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
102 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
103 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
104 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
105 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
106 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
107 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
108 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
109 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
110 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
111 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
112 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
113 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
114 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
115 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
116 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
117 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
118 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
119 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
120 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
121 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
122 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
123 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
124 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
125 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
126 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
127 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
128 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
129 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
130 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
131 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
132 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
133 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
134 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
135 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
136 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
137 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
138 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
139 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
140 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
141 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
142 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
143 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
144 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
145 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
146 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
147 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
148 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
149 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
150 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
151 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
152 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
153 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
154 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
155 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
156 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
157 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
158 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
159 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
160 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
161 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
162 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
163 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
164 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
165 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
166 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
167 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
168 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
169 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
170 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
171 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
172 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
173 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
174 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
175 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
176 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
177 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
178 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
179 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
180 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
181 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
182 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
183 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
184 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
185 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
186 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
187 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
188 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
189 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
190 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
191 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
192 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
193 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
194 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
195 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
196 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
197 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
198 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
199 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
200 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
201 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
202 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
203 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
204 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
205 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
206 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
207 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
208 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
209 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
210 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
211 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
212 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
213 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
214 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
215 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
216 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
217 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
218 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
219 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
220 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
221 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
222 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
223 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
224 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
225 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
226 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
227 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
228 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
229 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
230 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
231 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
232 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
233 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
234 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
235 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
236 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
237 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
238 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
239 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
240 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
241 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
242 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
243 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
244 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
245 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
246 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
247 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
248 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
249 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
250 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
251 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
252 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
253 swift           0x00000000011a88e9 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 713
254 swift           0x000000000116acb6 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) + 86
255 swift           0x00000000011a864d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28434-swift-type-transform.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28434-swift-type-transform-8a3623.o
1.  While type-checking 'B' at validation-test/compiler_crashers/28434-swift-type-transform.swift:10:1
2.  While defining default constructor for 'B' at validation-test/compiler_crashers/28434-swift-type-transform.swift:10:1
3.  While type-checking 'init' at validation-test/compiler_crashers/28434-swift-type-transform.swift:10:8
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
