### PR TITLE
LLVMPasses: fix DLL storage for merged functions

### DIFF
--- a/lib/LLVMPasses/LLVMMergeFunctions.cpp
+++ b/lib/LLVMPasses/LLVMMergeFunctions.cpp
@@ -1980,6 +1980,9 @@ void SwiftMergeFunctions::mergeWithParams(const FunctionInfos &FInfos,
                                            FirstF->getLinkage(),
                                            FirstF->getName() + "_merged");
   NewFunction->copyAttributesFrom(FirstF);
+  // NOTE: this function is not externally available, do ensure that we reset
+  // the DLL storage
+  NewFunction->setDLLStorageClass(GlobalValue::DefaultStorageClass);
   NewFunction->setLinkage(GlobalValue::InternalLinkage);
 
   // Insert the new function after the last function in the equivalence class.

--- a/test/LLVMPasses/merge_func_coff.ll
+++ b/test/LLVMPasses/merge_func_coff.ll
@@ -1,0 +1,23 @@
+; RUN: %swift-llvm-opt -mtriple i686-windows -swift-merge-functions -swiftmergefunc-threshold=4 %s | %FileCheck %s
+
+@g = external global i32
+
+define dllexport i32 @f(i32 %x, i32 %y) {
+  %sum = add i32 %x, %y
+  %sum2 = add i32 %sum, %y
+  %l = load i32, i32* @g, align 4
+  %sum3 = add i32 %sum2, %y
+  ret i32 %sum3
+}
+
+define dllexport i32 @h(i32 %x, i32 %y) {
+  %sum = add i32 %x, %y
+  %sum2 = add i32 %sum, %y
+  %l = load i32, i32* @g, align 4
+  %sum3 = add i32 %sum2, %y
+  ret i32 %sum3
+}
+
+; CHECK-NOT: define internal dllexport i32 @f_merged(i32, i32)
+; CHECK-LABEL: define internal i32 @f_merged(i32, i32)
+


### PR DESCRIPTION
<!-- What's in this pull request? -->

Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

When constructing the body of the merged function, the internal function is
given internal linkage always.  It is only accessible through the adjusting
thunks which retain the original DLL storage.  Ensure that we reset the DLL
storage which it inherited from the first function.
