### PR TITLE
SIL: allow alloc_ref_dynamic to allocate tail elements.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -1868,19 +1868,26 @@ alloc_ref_dynamic
 `````````````````
 ::
 
-  sil-instruction ::= 'alloc_ref_dynamic' ('[' 'objc' ']')? sil-operand ',' sil-type
+  sil-instruction ::= 'alloc_ref_dynamic'
+                        ('[' 'objc' ']')?
+                        ('[' 'tail_elems' sil-type '*' sil-operand ']')*
+                        sil-operand ',' sil-type
 
   %1 = alloc_ref_dynamic %0 : $@thick T.Type, $T
   %1 = alloc_ref_dynamic [objc] %0 : $@objc_metatype T.Type, $T
+  %1 = alloc_ref_dynamic [tail_elems $E * %2 : Builtin.Word] %0 : $@thick T.Type, $T
   // $T must be a class type
   // %1 has type $T
+  // $E is the type of the tail-allocated elements
+  // %2 must be of a builtin integer type
 
 Allocates an object of class type ``T`` or a subclass thereof. The
 dynamic type of the resulting object is specified via the metatype
 value ``%0``. The object will be initialized with retain count 1; its
-state will be otherwise uninitialized. The optional ``objc`` attribute
-indicates that the object should be allocated using Objective-C's
-allocation methods (``+allocWithZone:``).
+state will be otherwise uninitialized.
+
+The optional ``tail_elems`` and ``objc`` attributes have the same effect as
+for ``alloc_ref``. See ``alloc_ref`` for details.
 
 alloc_box
 `````````

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -256,35 +256,30 @@ public:
   }
 
   AllocRefInst *createAllocRef(SILLocation Loc, SILType ObjectType,
-                               bool objc, bool canAllocOnStack) {
-    // AllocRefInsts expand to function calls and can therefore not be
-    // counted towards the function prologue.
-    assert(!Loc.isInPrologue());
-    return insert(AllocRefInst::create(getSILDebugLocation(Loc), F, ObjectType,
-                                       objc, canAllocOnStack,
-                                       {}, {}, OpenedArchetypes));
-  }
-
-  AllocRefInst *createAllocRef(SILLocation Loc, SILType ObjectType,
-                               bool canAllocOnStack,
+                               bool objc, bool canAllocOnStack,
                                ArrayRef<SILType> ElementTypes,
                                ArrayRef<SILValue> ElementCountOperands) {
     // AllocRefInsts expand to function calls and can therefore not be
     // counted towards the function prologue.
     assert(!Loc.isInPrologue());
     return insert(AllocRefInst::create(getSILDebugLocation(Loc),
-                                       F, ObjectType, false, canAllocOnStack,
+                                       F, ObjectType, objc, canAllocOnStack,
                                        ElementTypes, ElementCountOperands,
                                        OpenedArchetypes));
   }
 
   AllocRefDynamicInst *createAllocRefDynamic(SILLocation Loc, SILValue operand,
-                                             SILType type, bool objc) {
+                                             SILType type, bool objc,
+                                    ArrayRef<SILType> ElementTypes,
+                                    ArrayRef<SILValue> ElementCountOperands) {
     // AllocRefDynamicInsts expand to function calls and can therefore
     // not be counted towards the function prologue.
     assert(!Loc.isInPrologue());
-    return insert(AllocRefDynamicInst::create(getSILDebugLocation(Loc), operand,
-                                              type, objc, F, OpenedArchetypes));
+    return insert(AllocRefDynamicInst::create(getSILDebugLocation(Loc), F,
+                                              operand, type, objc,
+                                              ElementTypes,
+                                              ElementCountOperands,
+                                              OpenedArchetypes));
   }
 
   AllocValueBufferInst *

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -473,22 +473,16 @@ template<typename ImplClass>
 void
 SILCloner<ImplClass>::visitAllocRefInst(AllocRefInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
-  SILInstruction *NewInst = nullptr;
-  if (Inst->isObjC()) {
-    NewInst = getBuilder().createAllocRef(getOpLocation(Inst->getLoc()),
-                                          getOpType(Inst->getType()),
-                                          true, Inst->canAllocOnStack());
-  } else {
-    auto CountArgs = getOpValueArray<8>(OperandValueArrayRef(Inst->getTailAllocatedCounts()));
-    SmallVector<SILType, 4> ElemTypes;
-    for (SILType OrigElemType : Inst->getTailAllocatedTypes()) {
-      ElemTypes.push_back(getOpType(OrigElemType));
-    }
-    NewInst = getBuilder().createAllocRef(getOpLocation(Inst->getLoc()),
-                                          getOpType(Inst->getType()),
-                                          Inst->canAllocOnStack(),
-                                          ElemTypes, CountArgs);
+  auto CountArgs = getOpValueArray<8>(OperandValueArrayRef(Inst->
+                                                    getTailAllocatedCounts()));
+  SmallVector<SILType, 4> ElemTypes;
+  for (SILType OrigElemType : Inst->getTailAllocatedTypes()) {
+    ElemTypes.push_back(getOpType(OrigElemType));
   }
+  auto *NewInst = getBuilder().createAllocRef(getOpLocation(Inst->getLoc()),
+                                      getOpType(Inst->getType()),
+                                      Inst->isObjC(), Inst->canAllocOnStack(),
+                                      ElemTypes, CountArgs);
   doPostProcess(Inst, NewInst);
 }
 
@@ -496,11 +490,19 @@ template<typename ImplClass>
 void
 SILCloner<ImplClass>::visitAllocRefDynamicInst(AllocRefDynamicInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
-  doPostProcess(Inst,
-    getBuilder().createAllocRefDynamic(getOpLocation(Inst->getLoc()),
-                                       getOpValue(Inst->getOperand()),
-                                       getOpType(Inst->getType()),
-                                       Inst->isObjC()));
+  auto CountArgs = getOpValueArray<8>(OperandValueArrayRef(Inst->
+                                                  getTailAllocatedCounts()));
+  SmallVector<SILType, 4> ElemTypes;
+  for (SILType OrigElemType : Inst->getTailAllocatedTypes()) {
+    ElemTypes.push_back(getOpType(OrigElemType));
+  }
+  auto *NewInst = getBuilder().createAllocRefDynamic(
+                                      getOpLocation(Inst->getLoc()),
+                                      getOpValue(Inst->getMetatypeOperand()),
+                                      getOpType(Inst->getType()),
+                                      Inst->isObjC(),
+                                      ElemTypes, CountArgs);
+  doPostProcess(Inst, NewInst);
 }
 
 template<typename ImplClass>

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 271; // Stop serializing RequirementReprs
+const uint16_t VERSION_MINOR = 272; // Add tail_elems to alloc_ref_dynamic
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -638,10 +638,34 @@ static llvm::Value *stackPromote(IRGenFunction &IGF,
   return Alloca.getAddress();
 }
 
+llvm::Value *irgen::appendSizeForTailAllocatedArrays(IRGenFunction &IGF,
+                                                     llvm::Value *size,
+                                                     TailArraysRef TailArrays) {
+  for (const auto &TailArray : TailArrays) {
+    SILType ElemTy = TailArray.first;
+    llvm::Value *Count = TailArray.second;
+
+    const TypeInfo &ElemTI = IGF.getTypeInfo(ElemTy);
+
+    // Align up to the tail-allocated array.
+    llvm::Value *ElemStride = ElemTI.getStride(IGF, ElemTy);
+    llvm::Value *AlignMask = ElemTI.getAlignmentMask(IGF, ElemTy);
+    size = IGF.Builder.CreateAdd(size, AlignMask);
+    llvm::Value *InvertedMask = IGF.Builder.CreateNot(AlignMask);
+    size = IGF.Builder.CreateAnd(size, InvertedMask);
+
+    // Add the size of the tail allocated array.
+    llvm::Value *AllocSize = IGF.Builder.CreateMul(ElemStride, Count);
+    size = IGF.Builder.CreateAdd(size, AllocSize);
+  }
+  return size;
+}
+
+
 /// Emit an allocation of a class.
 llvm::Value *irgen::emitClassAllocation(IRGenFunction &IGF, SILType selfType,
-                      bool objc, int &StackAllocSize,
-                      ArrayRef<std::pair<SILType, llvm::Value *>> TailArrays) {
+                                        bool objc, int &StackAllocSize,
+                                        TailArraysRef TailArrays) {
   auto &classTI = IGF.getTypeInfo(selfType).as<ClassTypeInfo>();
   auto classType = selfType.getSwiftRValueType();
 
@@ -675,24 +699,7 @@ llvm::Value *irgen::emitClassAllocation(IRGenFunction &IGF, SILType selfType,
     val = IGF.emitInitStackObjectCall(metadata, val, "reference.new");
   } else {
     // Allocate the object on the heap.
-
-    for (const auto &TailArray : TailArrays) {
-      SILType ElemTy = TailArray.first;
-      llvm::Value *Count = TailArray.second;
-
-      const TypeInfo &ElemTI = IGF.getTypeInfo(ElemTy);
-
-      // Align up to the tail-allocated array.
-      llvm::Value *ElemStride = ElemTI.getStride(IGF, ElemTy);
-      llvm::Value *AlignMask = ElemTI.getAlignmentMask(IGF, ElemTy);
-      size = IGF.Builder.CreateAdd(size, AlignMask);
-      llvm::Value *InvertedMask = IGF.Builder.CreateNot(AlignMask);
-      size = IGF.Builder.CreateAnd(size, InvertedMask);
-
-      // Add the size of the tail allocated array.
-      llvm::Value *AllocSize = IGF.Builder.CreateMul(ElemStride, Count);
-      size = IGF.Builder.CreateAdd(size, AllocSize);
-    }
+    size = appendSizeForTailAllocatedArrays(IGF, size, TailArrays);
     val = IGF.emitAllocObjectCall(metadata, size, alignMask, "reference.new");
     StackAllocSize = -1;
   }
@@ -702,7 +709,8 @@ llvm::Value *irgen::emitClassAllocation(IRGenFunction &IGF, SILType selfType,
 llvm::Value *irgen::emitClassAllocationDynamic(IRGenFunction &IGF, 
                                                llvm::Value *metadata,
                                                SILType selfType,
-                                               bool objc) {
+                                               bool objc,
+                                               TailArraysRef TailArrays) {
   // If we need to use Objective-C allocation, do so.
   if (objc) {
     return emitObjCAllocObjectCall(IGF, metadata, 
@@ -715,7 +723,8 @@ llvm::Value *irgen::emitClassAllocationDynamic(IRGenFunction &IGF,
     = emitClassResilientInstanceSizeAndAlignMask(IGF,
                                    selfType.getClassOrBoundGenericClass(),
                                    metadata);
-  
+  size = appendSizeForTailAllocatedArrays(IGF, size, TailArrays);
+
   llvm::Value *val = IGF.emitAllocObjectCall(metadata, size, alignMask,
                                              "reference.new");
   auto &classTI = IGF.getTypeInfo(selfType).as<ClassTypeInfo>();

--- a/lib/IRGen/GenClass.h
+++ b/lib/IRGen/GenClass.h
@@ -83,6 +83,14 @@ namespace irgen {
   Address emitTailProjection(IRGenFunction &IGF, llvm::Value *Base,
                                   SILType ClassType, SILType TailType);
 
+  typedef llvm::ArrayRef<std::pair<SILType, llvm::Value *>> TailArraysRef;
+
+  /// Adds the size for tail allocated arrays to \p size and returns the new
+  /// size value.
+  llvm::Value *appendSizeForTailAllocatedArrays(IRGenFunction &IGF,
+                                                llvm::Value *size,
+                                                TailArraysRef TailArrays);
+
   /// Emit an allocation of a class.
   /// The \p StackAllocSize is an in- and out-parameter. The passed value
   /// specifies the maximum object size for stack allocation. A negative value
@@ -90,14 +98,13 @@ namespace irgen {
   /// The returned \p StackAllocSize value is the actual size if the object is
   /// allocated on the stack or -1, if the object is allocated on the heap.
   llvm::Value *emitClassAllocation(IRGenFunction &IGF, SILType selfType,
-                  bool objc, int &StackAllocSize,
-                  llvm::ArrayRef<std::pair<SILType, llvm::Value *>> TailArrays);
+                  bool objc, int &StackAllocSize, TailArraysRef TailArrays);
 
   /// Emit an allocation of a class using a metadata value.
   llvm::Value *emitClassAllocationDynamic(IRGenFunction &IGF, 
                                           llvm::Value *metadata,
                                           SILType selfType,
-                                          bool objc);
+                                          bool objc, TailArraysRef TailArrays);
 
   /// Emit class deallocation.
   void emitClassDeallocation(IRGenFunction &IGF, SILType selfType,

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -2547,7 +2547,8 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
     }
     break;
   }
-  case ValueKind::AllocRefInst: {
+  case ValueKind::AllocRefInst:
+  case ValueKind::AllocRefDynamicInst: {
     bool IsObjC = false;
     bool OnStack = false;
     SmallVector<SILType, 2> ElementTypes;
@@ -2580,6 +2581,12 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
       }
       P.parseToken(tok::r_square, diag::expected_in_attribute_list);
     }
+    SILValue Metadata;
+    if (Opcode == ValueKind::AllocRefDynamicInst) {
+      if (parseTypedValueRef(Metadata, B) ||
+          P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ","))
+        return true;
+    }
 
     SILType ObjectType;
     if (parseSILType(ObjectType))
@@ -2588,29 +2595,20 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
     if (parseSILDebugLocation(InstLoc, B))
       return true;
 
-    if (ElementTypes.size() == 0) {
-      ResultVal = B.createAllocRef(InstLoc, ObjectType, IsObjC, OnStack);
-    } else {
-      if (IsObjC) {
-        P.diagnose(P.Tok, diag::sil_objc_with_tail_elements);
+    if (IsObjC && ElementTypes.size() != 0) {
+      P.diagnose(P.Tok, diag::sil_objc_with_tail_elements);
+      return true;
+    }
+    if (Opcode == ValueKind::AllocRefDynamicInst) {
+      if (OnStack)
         return true;
-      }
-      ResultVal = B.createAllocRef(InstLoc, ObjectType, OnStack,
+
+      ResultVal = B.createAllocRefDynamic(InstLoc, Metadata, ObjectType,
+                                          IsObjC, ElementTypes, ElementCounts);
+    } else {
+      ResultVal = B.createAllocRef(InstLoc, ObjectType, IsObjC, OnStack,
                                    ElementTypes, ElementCounts);
     }
-    break;
-  }
-  case ValueKind::AllocRefDynamicInst: {
-    SILType Ty;
-    bool isObjC = false;
-    if (parseSILOptional(isObjC, *this, "objc") ||
-        parseTypedValueRef(Val, B) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseSILType(Ty) ||
-        parseSILDebugLocation(InstLoc, B))
-      return true;
-
-    ResultVal = B.createAllocRefDynamic(InstLoc, Val, Ty, isObjC);
     break;
   }
 

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -838,8 +838,7 @@ public:
     printDebugVar(AVI->getVarInfo());
   }
 
-  void visitAllocRefInst(AllocRefInst *ARI) {
-    *this << "alloc_ref ";
+  void printAllocRefInstBase(AllocRefInstBase *ARI) {
     if (ARI->isObjC())
       *this << "[objc] ";
     if (ARI->canAllocOnStack())
@@ -850,14 +849,18 @@ public:
       *this << "[tail_elems " << Types[Idx] << " * "
             << getIDAndType(Counts[Idx].get()) << "] ";
     }
+  }
+
+  void visitAllocRefInst(AllocRefInst *ARI) {
+    *this << "alloc_ref ";
+    printAllocRefInstBase(ARI);
     *this << ARI->getType();
   }
 
   void visitAllocRefDynamicInst(AllocRefDynamicInst *ARDI) {
     *this << "alloc_ref_dynamic ";
-    if (ARDI->isObjC())
-      *this << "[objc] ";
-    *this << getIDAndType(ARDI->getOperand());
+    printAllocRefInstBase(ARDI);
+    *this << getIDAndType(ARDI->getMetatypeOperand());
     *this << ", " << ARDI->getType();
   }
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -941,7 +941,7 @@ public:
                           loc,
                           selfMetaObjC.getValue(),
                           SGF.SGM.getLoweredType(type),
-                          /*objc=*/true),
+                          /*objc=*/true, {}, {}),
                           selfMetaObjC.getCleanup());
   }
 

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -468,12 +468,12 @@ void SILGenFunction::emitClassConstructorAllocator(ConstructorDecl *ctor) {
     }
 
     selfValue = B.createAllocRefDynamic(Loc, allocArg, selfTy,
-                                        useObjCAllocation);
+                                        useObjCAllocation, {}, {});
   } else {
     // For a designated initializer, we know that the static type being
     // allocated is the type of the class that defines the designated
     // initializer.
-    selfValue = B.createAllocRef(Loc, selfTy, useObjCAllocation, false);
+    selfValue = B.createAllocRef(Loc, selfTy, useObjCAllocation, false, {}, {});
   }
   args.push_back(selfValue);
 

--- a/test/IRGen/tail_alloc.sil
+++ b/test/IRGen/tail_alloc.sil
@@ -104,6 +104,25 @@ bb0(%0 : $Builtin.Word, %1 : $@thick T.Type):
   return %5 : $TestClass
 }
 
+// CHECK-LABEL: define{{( protected)?}} {{.*}}* @alloc_dynamic
+// CHECK:      [[BYTE_PTR:%[0-9]+]] = bitcast %swift.type* %0 to i8*
+// CHECK-NEXT: [[SIZE_ADDR:%[0-9]+]] = getelementptr inbounds i8, i8* [[BYTE_PTR]], i32 48
+// CHECK-NEXT: [[INT_PTR:%[0-9]+]] = bitcast i8* [[SIZE_ADDR]] to i32*
+// CHECK-NEXT: [[SIZE:%[0-9]+]] = load i32, i32* [[INT_PTR]]
+// CHECK-NEXT: [[SIZE64:%[0-9]+]] = zext i32 [[SIZE]] to i64
+// CHECK:      [[ALIGN_TMP:%[0-9]+]] = add i64 [[SIZE64]], 3
+// CHECK-NEXT: [[ALIGNED:%[0-9]+]] = and i64 [[ALIGN_TMP]], -4
+// CHECK-NEXT: [[TOTAL_SIZE:%[0-9]+]] = add i64 [[ALIGNED]], 12
+// CHECK-NEXT: [[O:%[0-9]+]] = call noalias %swift.refcounted* @rt_swift_allocObject(%swift.type* %0, i64 [[TOTAL_SIZE]], i64 {{.*}})
+// CHECK-NEXT: [[O2:%[0-9]+]] = bitcast %swift.refcounted* [[O]] to %{{.*TestClass}}*
+// CHECK-NEXT:  ret %{{.*TestClass}}* [[O2]]
+sil @alloc_dynamic : $@convention(thin) (@thick TestClass.Type) -> @owned TestClass {
+bb0(%0 : $@thick TestClass.Type):
+  %c = integer_literal $Builtin.Word, 3
+  %o = alloc_ref_dynamic [tail_elems $Int32 * %c : $Builtin.Word] %0 : $@thick TestClass.Type, $TestClass
+  return %o : $TestClass
+}
+
 // CHECK-LABEL: define{{( protected)?}} i8* @project_tail_byte
 // CHECK: getelementptr inbounds i8, i8* %{{[0-9]+}}, i64 17
 // CHECK: ret

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -737,6 +737,17 @@ bb0(%0 : $Builtin.Word, %1 : $Builtin.Word):
   return %3 : $()
 }
 
+// CHECK-LABEL: sil @test_tail_elems_dynamic
+sil @test_tail_elems_dynamic : $@convention(thin) (Builtin.Word, Builtin.Word, @thick Class1.Type) -> () {
+bb0(%0 : $Builtin.Word, %1 : $Builtin.Word, %2 : $@thick Class1.Type):
+  // CHECK: alloc_ref_dynamic  [tail_elems $Val * %0 : $Builtin.Word] [tail_elems $Aleph * %1 : $Builtin.Word] %2 : $@thick Class1
+  %3 = alloc_ref_dynamic [tail_elems $Val * %0 : $Builtin.Word] [tail_elems $Aleph * %1 : $Builtin.Word] %2 : $@thick Class1.Type, $Class1
+  // CHECK: dealloc_ref %3 : $Class1
+  dealloc_ref %3 : $Class1
+  %4 = tuple ()
+  return %4 : $()
+}
+
 // CHECK-LABEL: sil @test_tail_addr
 sil @test_tail_addr : $@convention(thin) (@owned Class1, Builtin.Word) -> @owned Class1 {
 bb0(%0 : $Class1, %1 : $Builtin.Word):

--- a/test/Serialization/Inputs/def_basic.sil
+++ b/test/Serialization/Inputs/def_basic.sil
@@ -679,6 +679,17 @@ bb0(%0 : $Builtin.Word, %1 : $Builtin.Word):
   return %3 : $()
 }
 
+// CHECK-LABEL: sil public_external [fragile] @test_tail_elems_dynamic
+sil [fragile] @test_tail_elems_dynamic : $@convention(thin) (Builtin.Word, Builtin.Word, @thick Class1.Type) -> () {
+bb0(%0 : $Builtin.Word, %1 : $Builtin.Word, %2 : $@thick Class1.Type):
+  // CHECK: alloc_ref_dynamic  [tail_elems $Val * %0 : $Builtin.Word] [tail_elems $Aleph * %1 : $Builtin.Word] %2 : $@thick Class1
+  %3 = alloc_ref_dynamic [tail_elems $Val * %0 : $Builtin.Word] [tail_elems $Aleph * %1 : $Builtin.Word] %2 : $@thick Class1.Type, $Class1
+  // CHECK: dealloc_ref %3 : $Class1
+  dealloc_ref %3 : $Class1
+  %4 = tuple ()
+  return %4 : $()
+}
+
 // CHECK-LABEL: sil public_external [fragile] @test_tail_addr
 sil [fragile] @test_tail_addr : $@convention(thin) (@owned Class1, Builtin.Word) -> @owned Class1 {
 bb0(%0 : $Class1, %1 : $Builtin.Word):
@@ -1376,8 +1387,9 @@ bb0:
   %85 = function_ref @test_dealloc_box : $@convention(thin) () -> ()
   %86 = function_ref @test_stack_flag : $@convention(thin) () -> ()
   %87 = function_ref @test_tail_elems : $@convention(thin) (Builtin.Word, Builtin.Word) -> ()
-  %88 = function_ref @test_tail_addr : $@convention(thin) (@owned Class1, Builtin.Word) -> @owned Class1
-  %89 = function_ref @closure_test : $@convention(thin) () -> ()
+  %88 = function_ref @test_tail_elems_dynamic : $@convention(thin) (Builtin.Word, Builtin.Word, @thick Class1.Type) -> ()
+  %89 = function_ref @test_tail_addr : $@convention(thin) (@owned Class1, Builtin.Word) -> @owned Class1
+  %90 = function_ref @closure_test : $@convention(thin) () -> ()
   %97 = function_ref @test_switch_union : $@convention(thin) (MaybePair) -> ()
   %99 = function_ref @test_switch_union_addr : $@convention(thin) (@in MaybeAddressOnlyPair) -> ()
   %101 = function_ref @test_switch_value : $@convention(thin) (Builtin.Word) -> ()


### PR DESCRIPTION
It's the same thing as for alloc_ref: the optional [tail_elems ...] attribute specify the tail elements to allocate.
For details see docs/SIL.rst

This feature is needed so that we can allocate a MangedBuffer with alloc_ref_dynamic.
The ManagedBuffer.create() function uses the dynamic self type to create the buffer instance.

So far it's a NFC, because it's not used yet.
