### PR TITLE
IRGen: move the iterator dereference out of ctor

### DIFF
--- a/lib/IRGen/Address.h
+++ b/lib/IRGen/Address.h
@@ -37,10 +37,6 @@ public:
   Address(llvm::Value *addr, Alignment align) : Addr(addr), Align(align) {
     assert(addr != nullptr && "building an invalid address");
   }
-  Address(llvm::ilist_iterator<llvm::Argument> addr, Alignment align)
-      : Address(&*addr, align) {}
-  Address(llvm::ilist_iterator<llvm::Instruction> addr, Alignment align)
-      : Address(&*addr, align) {}
 
   llvm::Value *operator->() const {
     assert(isValid());

--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -959,7 +959,7 @@ static llvm::Constant *getDestroyStrongFunction(IRGenModule &IGM) {
   return IGM.getOrCreateHelperFunction("__swift_destroy_strong",
                                        IGM.VoidTy, argTys,
                                        [&](IRGenFunction &IGF) {
-    Address arg(IGF.CurFn->arg_begin(), IGM.getPointerAlignment());
+    Address arg(&*IGF.CurFn->arg_begin(), IGM.getPointerAlignment());
     IGF.emitNativeStrongRelease(IGF.Builder.CreateLoad(arg));
     IGF.Builder.CreateRetVoid();
   });
@@ -992,8 +992,8 @@ static llvm::Constant *getMemCpyFunction(IRGenModule &IGM,
   return IGM.getOrCreateHelperFunction(name, IGM.Int8PtrTy, argTys,
                                        [&](IRGenFunction &IGF) {
     auto it = IGF.CurFn->arg_begin();
-    Address dest(it++, fixedTI->getFixedAlignment());
-    Address src(it++, fixedTI->getFixedAlignment());
+    Address dest(&*it++, fixedTI->getFixedAlignment());
+    Address src(&*it++, fixedTI->getFixedAlignment());
     IGF.emitMemCpy(dest, src, fixedTI->getFixedSize());
     IGF.Builder.CreateRet(dest.getAddress());
   });
@@ -1009,8 +1009,8 @@ static llvm::Constant *getCopyOutOfLinePointerFunction(IRGenModule &IGM) {
                                        IGM.Int8PtrTy, argTys,
                                        [&](IRGenFunction &IGF) {
     auto it = IGF.CurFn->arg_begin();
-    Address dest(it++, IGM.getPointerAlignment());
-    Address src(it++, IGM.getPointerAlignment());
+    Address dest(&*it++, IGM.getPointerAlignment());
+    Address src(&*it++, IGM.getPointerAlignment());
     auto ptr = IGF.Builder.CreateLoad(src);
     IGF.Builder.CreateStore(ptr, dest);
     IGF.Builder.CreateRet(ptr);
@@ -1058,8 +1058,8 @@ static llvm::Constant *getMemOpArrayFunction(IRGenModule &IGM,
   return IGM.getOrCreateHelperFunction(name, IGM.Int8PtrTy, argTys,
                                        [&](IRGenFunction &IGF) {
     auto it = IGF.CurFn->arg_begin();
-    Address dest(it++, fixedTI.getFixedAlignment());
-    Address src(it++, fixedTI.getFixedAlignment());
+    Address dest(&*it++, fixedTI.getFixedAlignment());
+    Address src(&*it++, fixedTI.getFixedAlignment());
     llvm::Value *count = &*(it++);
     llvm::Value *stride
       = llvm::ConstantInt::get(IGM.SizeTy, fixedTI.getFixedStride().getValue());


### PR DESCRIPTION
<!-- What's in this pull request? -->

Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

Rather than have the iterator form of the Address constructor, remove it and
inline the dereference at the sites.  This removes two constructors which used
`ilist_iterator` which is now much more complex.
