### PR TITLE
SIL: Avoid dereferencing sentinel nodes in ilist_iterators

### DIFF
--- a/include/swift/Basic/STLExtras.h
+++ b/include/swift/Basic/STLExtras.h
@@ -180,6 +180,14 @@ inline void set_union_for_each(const Container1 &C1, const Container2 &C2,
   set_union_for_each(C1.begin(), C1.end(), C2.begin(), C2.end(), f);
 }
 
+/// Takes an iterator and an iterator pointing to the end of the iterator range.
+/// If the iterator already points to the end of its range, simply return it,
+/// otherwise return the the next element.
+template <typename Iterator>
+inline Iterator next_or_end(Iterator it, Iterator end) {
+  return (it == end) ? end : std::next(it);
+}
+
 /// @}
 
 /// A range of iterators.

--- a/lib/SILGen/SILGenEpilog.cpp
+++ b/lib/SILGen/SILGenEpilog.cpp
@@ -130,8 +130,7 @@ SILGenFunction::emitEpilogBB(SILLocation TopLevel) {
     B.setInsertionPoint(pred);
   } else {
     // Move the epilog block to the end of the ordinary section.
-    auto endOfOrdinarySection =
-      (StartOfPostmatter ? SILFunction::iterator(StartOfPostmatter) : F.end());
+    auto endOfOrdinarySection = StartOfPostmatter;
     B.moveBlockTo(epilogBB, endOfOrdinarySection);
 
     // Emit the epilog into the epilog bb. Its arguments are the

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -34,12 +34,9 @@ using namespace Lowering;
 //===----------------------------------------------------------------------===//
 
 SILGenFunction::SILGenFunction(SILGenModule &SGM, SILFunction &F)
-  : SGM(SGM), F(F),
-    B(*this, createBasicBlock()),
-    OpenedArchetypesTracker(F),
-    CurrentSILLoc(F.getLocation()),
-    Cleanups(*this)
-{
+    : SGM(SGM), F(F), StartOfPostmatter(F.end()), B(*this, createBasicBlock()),
+      OpenedArchetypesTracker(F), CurrentSILLoc(F.getLocation()),
+      Cleanups(*this) {
   B.setCurrentDebugScope(F.getDebugScope());
   B.setOpenedArchetypesTracker(&OpenedArchetypesTracker);
 }
@@ -875,8 +872,8 @@ SILGenBuilder::SILGenBuilder(SILGenFunction &gen, SILBasicBlock *insertBB,
                              SmallVectorImpl<SILInstruction *> *insertedInsts)
   : SILBuilder(insertBB, insertedInsts), SGM(gen.SGM) {}
 SILGenBuilder::SILGenBuilder(SILGenFunction &gen, SILBasicBlock *insertBB,
-                             SILInstruction *insertInst)
-    : SILBuilder(insertBB, insertInst->getIterator()), SGM(gen.SGM) {}
+                             SILBasicBlock::iterator insertInst)
+    : SILBuilder(insertBB, insertInst), SGM(gen.SGM) {}
 
 MetatypeInst *SILGenBuilder::createMetatype(SILLocation loc, SILType metatype) {
   auto theMetatype = metatype.castTo<MetatypeType>();

--- a/lib/SILGen/SILGenGlobalVariable.cpp
+++ b/lib/SILGen/SILGenGlobalVariable.cpp
@@ -110,7 +110,7 @@ SILGenFunction::emitGlobalVariableRef(SILLocation loc, VarDecl *var) {
   // Global variables can be accessed directly with global_addr.  Emit this
   // instruction into the prolog of the function so we can memoize/CSE it in
   // VarLocs.
-  auto entryBB = getFunction().getBlocks().begin();
+  auto entryBB = getFunction().begin();
   SILGenBuilder prologueB(*this, entryBB, entryBB->begin());
   prologueB.setTrackingList(B.getTrackingList());
 

--- a/lib/SILOptimizer/Transforms/StackPromotion.cpp
+++ b/lib/SILOptimizer/Transforms/StackPromotion.cpp
@@ -319,7 +319,7 @@ template <> struct GraphTraits<StackPromoter *>
     return nodes_iterator(SP->getFunction()->end(), SP->getFunction()->end());
   }
   static unsigned size(GraphType SP) {
-    return std::distance(nodes_begin(SP), nodes_end(SP));
+    return std::distance(SP->getFunction()->begin(), SP->getFunction()->end());
   }
 };
 


### PR DESCRIPTION
<!-- What's in this pull request? -->

Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

The behaviour of ilist has changed in LLVM.  It is no longer permissible to
dereference the `end()` value.  Add a check to ensure that we do not
accidentally dereference the iterator.
