### PR TITLE
[SourceKit] Add test case for crash triggered in swift::GenericSignature::getArchetypeBuilder(…)

### DIFF
--- a/validation-test/IDE/crashers/096-swift-genericsignature-getarchetypebuilder.swift
+++ b/validation-test/IDE/crashers/096-swift-genericsignature-getarchetypebuilder.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+func b<T{#^A^#let t:T


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 135
3  swift-ide-test  0x0000000000c91863 swift::GenericSignature::getArchetypeBuilder(swift::ModuleDecl&) + 19
4  swift-ide-test  0x0000000000c925a3 swift::GenericSignature::getConformsTo(swift::Type, swift::ModuleDecl&) + 83
6  swift-ide-test  0x0000000000cd092d swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
12 swift-ide-test  0x0000000000c94281 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 529
17 swift-ide-test  0x0000000000c54904 swift::Decl::walk(swift::ASTWalker&) + 20
18 swift-ide-test  0x0000000000ca8fae swift::SourceFile::walk(swift::ASTWalker&) + 174
19 swift-ide-test  0x0000000000ca82bf swift::ModuleDecl::walk(swift::ASTWalker&) + 95
20 swift-ide-test  0x0000000000c7ee24 swift::DeclContext::walkContext(swift::ASTWalker&) + 180
21 swift-ide-test  0x0000000000988058 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 136
22 swift-ide-test  0x0000000000838541 swift::CompilerInstance::performSema() + 3697
23 swift-ide-test  0x00000000007d8d91 main + 42417
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl 'b' at <INPUT-FILE>:3:1
```
