### PR TITLE
[SIL] Add test case for crash triggered in swift::Parser::parseTopLevel()

### DIFF
--- a/validation-test/SIL/crashers/042-swift-parser-parsetoplevel.sil
+++ b/validation-test/SIL/crashers/042-swift-parser-parsetoplevel.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+class a 4{sil_vtable a


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:9: error: expected '{' in class
class a 4{sil_vtable a
        ^
<stdin>:3:10: error: statement cannot begin with a closure expression
class a 4{sil_vtable a
         ^
<stdin>:3:10: note: explicitly discard the result of the closure by assigning to '_'
class a 4{sil_vtable a
         ^
         _ =
<stdin>:3:11: error: expected '}' at end of closure
class a 4{sil_vtable a
          ^
<stdin>:3:10: note: to match this opening '{'
class a 4{sil_vtable a
         ^
<stdin>:3:10: error: expressions are not allowed at the top level
class a 4{sil_vtable a
         ^
<stdin>:3:10: error: braced block of statements is an unused closure
class a 4{sil_vtable a
         ^
<stdin>:3:10: error: expression resolves to an unused function
class a 4{sil_vtable a
         ^
sil-opt: /path/to/swift/include/swift/Parse/Parser.h:388: swift::SourceLoc swift::Parser::consumeToken(swift::tok): Assertion `Tok.is(K) && "Consuming wrong token kind"' failed.
8  sil-opt         0x0000000000b23aa3 swift::Parser::parseTopLevel() + 739
9  sil-opt         0x0000000000ad68e0 swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) + 208
10 sil-opt         0x0000000000801933 swift::CompilerInstance::performSema() + 3315
11 sil-opt         0x00000000007e84bc main + 1852
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  With parser at source location: <stdin>:3:23
```
