### PR TITLE
[CMake] Check target, not host, for Info.plist

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -972,7 +972,7 @@ function(_add_swift_library_single target name)
 
   # Configure plist creation for OS X.
   set(PLIST_INFO_PLIST "Info.plist" CACHE STRING "Plist name")
-  if(APPLE AND SWIFTLIB_SINGLE_IS_STDLIB)
+  if("${SWIFTLIB_SINGLE_SDK}" IN_LIST SWIFT_APPLE_PLATFORMS AND SWIFTLIB_SINGLE_IS_STDLIB)
     set(PLIST_INFO_NAME ${name})
     set(PLIST_INFO_UTI "com.apple.dt.runtime.${name}")
     set(PLIST_INFO_VERSION "${SWIFT_VERSION}")


### PR DESCRIPTION
The CMake variable `APPLE` is set to true when building on a macOS host, which means that logic to include linker flags for application extensions, etc., will be enabled on a macOS host. That is, they will be enabled even when cross-compiling the standard library to a non-Apple platform, such as Android.

Instead of using `APPLE` to check the host OS, check whether the target is an Apple platform.

This was pulled out of the larger pull request https://github.com/apple/swift/pull/4972, which addresses [SR-1362](https://bugs.swift.org/browse/SR-1362).
