### PR TITLE
[SIL] Add test case for crash triggered in swift::DerivedConformance::deriveRawRepresentable(…)

### DIFF
--- a/validation-test/SIL/crashers/043-swift-derivedconformance-deriverawrepresentable.sil
+++ b/validation-test/SIL/crashers/043-swift-derivedconformance-deriverawrepresentable.sil
@@ -1,0 +1,4 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+import Swift
+func d<T{enum a:T


### PR DESCRIPTION
Stack trace:

```
<stdin>:4:9: error: expected '>' to complete generic parameter list
func d<T{enum a:T
        ^
<stdin>:4:7: note: to match this opening '<'
func d<T{enum a:T
      ^
<stdin>:4:9: error: expected '(' in argument list of function declaration
func d<T{enum a:T
        ^
<stdin>:4:18: error: expected '{' in enum
func d<T{enum a:T
                 ^
<stdin>:4:18: error: expected '}' at end of brace statement
func d<T{enum a:T
                 ^
<stdin>:4:9: note: to match this opening '{'
func d<T{enum a:T
        ^
<stdin>:4:17: error: raw type 'T' is not expressible by any literal
func d<T{enum a:T
                ^
sil-opt: /path/to/swift/lib/AST/ArchetypeBuilder.cpp:1991: static swift::Type swift::ArchetypeBuilder::mapTypeIntoContext(swift::ModuleDecl *, swift::GenericEnvironment *, swift::Type): Assertion `env && "dependent type in non-generic context"' failed.
9  sil-opt         0x0000000000c8d219 swift::DerivedConformance::deriveRawRepresentable(swift::TypeChecker&, swift::Decl*, swift::NominalTypeDecl*, swift::AssociatedTypeDecl*) + 57
12 sil-opt         0x0000000000bc663b swift::TypeChecker::checkConformance(swift::NormalProtocolConformance*) + 1611
13 sil-opt         0x0000000000bc6d35 swift::TypeChecker::checkConformancesInContext(swift::DeclContext*, swift::IterableDeclContext*) + 485
16 sil-opt         0x0000000000b7c216 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
19 sil-opt         0x0000000000be7a53 swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 355
20 sil-opt         0x0000000000be78a7 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 39
21 sil-opt         0x0000000000be84ac swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 188
23 sil-opt         0x0000000000ba2abb swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1291
24 sil-opt         0x0000000000801956 swift::CompilerInstance::performSema() + 3350
25 sil-opt         0x00000000007e84bc main + 1852
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  While type-checking 'd' at <stdin>:4:1
2.  While type-checking 'a' at <stdin>:4:10
```
