### PR TITLE
[Gardening] Normalize the way paren types are stripped in Sema.

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1487,9 +1487,7 @@ struct ASTNodeBase {};
       /// Retrieve the ith element type from the resulting tuple type.
       auto getOuterElementType = [&](unsigned i) -> Type {
         if (!TT) {
-          if (auto parenTy = dyn_cast<ParenType>(E->getType().getPointer()))
-            return parenTy->getUnderlyingType();
-          return E->getType();
+          return E->getType()->getWithoutParens();
         }
 
         return TT->getElementType(i);

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -6388,10 +6388,8 @@ bool FailureDiagnosis::visitIdentityExpr(IdentityExpr *E) {
   
   // If we have a paren expr and our contextual type is a ParenType, remove the
   // paren expr sugar.
-  if (isa<ParenExpr>(E) && contextualType)
-    if (auto *PT = dyn_cast<ParenType>(contextualType.getPointer()))
-      contextualType = PT->getUnderlyingType();
-  
+  if (contextualType)
+    contextualType = contextualType->getWithoutParens();
   if (!typeCheckChildIndependently(E->getSubExpr(), contextualType,
                                    CS->getContextualTypePurpose()))
     return true;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -699,14 +699,6 @@ namespace {
     return NTD->getHasFailableInits();
   }
   
-  Type getInnerParenType(const Type &t) {
-    if (auto parenType = dyn_cast<ParenType>(t.getPointer())) {
-      return getInnerParenType(parenType->getUnderlyingType());
-    }
-    
-    return t;
-  }
-  
   size_t getOperandCount(Type t) {
     size_t nOperands = 0;
     
@@ -874,8 +866,8 @@ namespace {
     auto argTy = expr->getArg()->getType();
     auto argTupleTy = argTy->castTo<TupleType>();
     auto argTupleExpr = dyn_cast<TupleExpr>(expr->getArg());
-    Type firstArgTy = getInnerParenType(argTupleTy->getElement(0).getType());
-    Type secondArgTy = getInnerParenType(argTupleTy->getElement(1).getType());
+    Type firstArgTy = argTupleTy->getElement(0).getType()->getWithoutParens();
+    Type secondArgTy = argTupleTy->getElement(1).getType()->getWithoutParens();
     
     // Determine whether the given declaration is favored.
     auto isFavoredDecl = [&](ValueDecl *value) -> bool {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2839,13 +2839,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
           if (auto fnType =
                   fnTypeWithSelf->getResult()->getAs<FunctionType>()) {
           
-            auto argType = fnType->getInput();
-            
-            if (auto parenType =
-                dyn_cast<ParenType>(argType.getPointer())) {
-              argType = parenType->getUnderlyingType();
-            }
-            
+            auto argType = fnType->getInput()->getWithoutParens();
             if (argType->isEqual(favoredType))
               result.FavoredChoice = result.ViableCandidates.size();
           }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3924,10 +3924,7 @@ static OmissionTypeName getTypeNameForOmission(Type type) {
     }
 
     // Look through parentheses.
-    if (auto parenTy = dyn_cast<ParenType>(type.getPointer())) {
-      type = parenTy->getUnderlyingType();
-      continue;
-    }
+    type = type->getWithoutParens();
 
     // Look through optionals.
     if (auto optObjectTy = type->getAnyOptionalObjectType()) {

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -54,8 +54,7 @@ static void substituteInputSugarArgumentType(Type argTy, CanType resultTy,
 
   // If this type is parenthesized, remove the parens.  We don't want to
   // propagate parens from arguments to the result type.
-  if (auto *PT = dyn_cast<ParenType>(argTy.getPointer()))
-    argTy = PT->getUnderlyingType();
+  argTy = argTy->getWithoutParens();
   
   // If this is the first match against the sugar type we found, use it.
   if (!resultSugarTy) {


### PR DESCRIPTION
Does what it says on the can.  Noticed we were duplicating the definition of `getWithoutParens` in quite a few places while writing #5110.
