### PR TITLE
[Serialization] Add some asserts to catch giant method lists.

### DIFF
--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -433,13 +433,15 @@ public:
 
   static data_type ReadData(internal_key_type key, const uint8_t *data,
                             unsigned length) {
+    const constexpr auto recordSize = sizeof(uint32_t) + 1 + sizeof(uint32_t);
+    assert(length % recordSize == 0 && "invalid length");
     data_type result;
     while (length > 0) {
       TypeID typeID = endian::readNext<uint32_t, little, unaligned>(data);
       bool isInstanceMethod = *data++ != 0;
       DeclID methodID = endian::readNext<uint32_t, little, unaligned>(data);
       result.push_back(std::make_tuple(typeID, isInstanceMethod, methodID));
-      length -= sizeof(uint32_t) + 1 + sizeof(uint32_t);
+      length -= recordSize;
     }
 
     return result;


### PR DESCRIPTION
This would have allowed us to triage rdar://problem/28305755 much sooner. The actual problem is pretty bad: if you have too many methods with the same selector, serialization just falls over.  "Too many" is in the thousands, which seems unlikely, but 'dealloc' can actually get there if there are a lot of little classes, and 'init' might as well, so we really should do better here.
