### PR TITLE
Revert "[CMake] Fix dependency on codesign steps"

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1465,25 +1465,17 @@ function(add_swift_library name)
         endif()
 
         set(lipo_target "${name}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}")
-        
-        if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin" AND SWIFTLIB_SHARED)
-          set(unsigned "-unsigned")
-        endif()
-        
         _add_swift_lipo_target(
             ${sdk}
-            ${lipo_target}${unsigned}
-            "${UNIVERSAL_LIBRARY_NAME}${unsigned}"
+            ${lipo_target}
+            ${UNIVERSAL_LIBRARY_NAME}
             ${THIN_INPUT_TARGETS})
 
         if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin" AND SWIFTLIB_SHARED)
           # Ad-hoc sign stdlib dylibs
-          add_custom_command_target(unused_var
-            COMMAND ${CMAKE_COMMAND} -E copy ${UNIVERSAL_LIBRARY_NAME}${unsigned} ${UNIVERSAL_LIBRARY_NAME}
-            COMMAND "codesign" "-f" "-s" "-" "${UNIVERSAL_LIBRARY_NAME}"
-            OUTPUT ${UNIVERSAL_LIBRARY_NAME}
-            DEPENDS ${lipo_target}${unsigned}
-            CUSTOM_TARGET_NAME ${lipo_target})
+          add_custom_command(TARGET "${name}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}"
+                             POST_BUILD
+                             COMMAND "codesign" "-f" "-s" "-" "${UNIVERSAL_LIBRARY_NAME}")
         endif()
 
         # Cache universal libraries for dependency purposes


### PR DESCRIPTION
This commit introduced a regression where the dylibs that ship with swift are not updated after codesigning.

Just reverting for now, a fix can appear in the future.
