### PR TITLE
SIL: Add the ability for partial_apply instructions to control the ownership of the produced closure.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -2956,10 +2956,11 @@ partial_apply
 `````````````
 ::
 
-  sil-instruction ::= 'partial_apply' sil-value
+  sil-instruction ::= 'partial_apply' callee-ownership-attr? sil-value
                         sil-apply-substitution-list?
                         '(' (sil-value (',' sil-value)*)? ')'
                         ':' sil-type
+  callee-ownership-attr ::= '[callee_guaranteed]'
 
   %c = partial_apply %0(%1, %2, ...) : $(Z..., A, B, ...) -> R
   // Note that the type of the callee '%0' is specified *after* the arguments
@@ -2995,6 +2996,11 @@ TODO: The instruction, when applied to a generic function,
 currently implicitly performs abstraction difference transformations enabled
 by the given substitutions, such as promoting address-only arguments and returns
 to register arguments. This should be fixed.
+
+By default, ``partial_apply`` creates a closure whose invocation takes ownership
+of the context, meaning that a call implicitly releases the closure. The
+``[callee_guaranteed]`` change this to a caller-guaranteed model, where the
+caller promises not to release the closure while the function is being called.
 
 This instruction is used to implement both curry thunks and closures. A
 curried function in Swift::

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -164,7 +164,7 @@ def enable_guaranteed_closure_contexts : Flag<["-"], "enable-guaranteed-closure-
   HelpText<"Use @guaranteed convention for closure context">;
 
 def remove_runtime_asserts : Flag<["-"], "remove-runtime-asserts">,
-HelpText<"Remove runtime asserts.">;
+  HelpText<"Remove runtime asserts.">;
 
 def disable_access_control : Flag<["-"], "disable-access-control">,
   HelpText<"Don't respect access control restrictions">;

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -195,8 +195,9 @@ public:
   //===--------------------------------------------------------------------===//
 
   static SILType getPartialApplyResultType(SILType Ty, unsigned ArgCount,
-                                           SILModule &M,
-                                           ArrayRef<Substitution> subs);
+                                         SILModule &M,
+                                         ArrayRef<Substitution> subs,
+                                         ParameterConvention calleeConvention);
 
   //===--------------------------------------------------------------------===//
   // CFG Manipulation

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1329,7 +1329,7 @@ class PartialApplyInst
                                   SILOpenedArchetypesState &OpenedArchetypes);
 
 public:
-  /// Return the ast level function type of this partial apply.
+  /// Return the result function type of this partial apply.
   CanSILFunctionType getFunctionType() const {
     return getType().castTo<SILFunctionType>();
   }

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 272; // Add tail_elems to alloc_ref_dynamic
+const uint16_t VERSION_MINOR = 273; // Last change: partial_apply ownership control
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -3737,9 +3737,18 @@ bool SILParser::parseCallInstruction(SILLocation InstLoc,
   UnresolvedValueName FnName;
   SmallVector<UnresolvedValueName, 4> ArgNames;
 
+  auto PartialApplyConvention = ParameterConvention::Direct_Owned;
   bool IsNonThrowingApply = false;
-  if (parseSILOptional(IsNonThrowingApply, *this, "nothrow"))
-    return true;
+  StringRef AttrName;
+  
+  if (parseSILOptional(AttrName, *this)) {
+    if (AttrName.equals("nothrow"))
+      IsNonThrowingApply = true;
+    else if (AttrName.equals("callee_guaranteed"))
+      PartialApplyConvention = ParameterConvention::Direct_Guaranteed;
+    else
+      return true;
+  }
   
   if (parseValueName(FnName))
     return true;
@@ -3838,7 +3847,8 @@ bool SILParser::parseCallInstruction(SILLocation InstLoc,
     }
 
     SILType closureTy =
-      SILBuilder::getPartialApplyResultType(Ty, ArgNames.size(), SILMod, subs);
+      SILBuilder::getPartialApplyResultType(Ty, ArgNames.size(), SILMod, subs,
+                                            PartialApplyConvention);
     // FIXME: Why the arbitrary order difference in IRBuilder type argument?
     ResultVal = B.createPartialApply(InstLoc, FnVal, FnTy,
                                      subs, Args, closureTy);

--- a/lib/SIL/SILBuilder.cpp
+++ b/lib/SIL/SILBuilder.cpp
@@ -29,8 +29,9 @@ TupleInst *SILBuilder::createTuple(SILLocation loc, ArrayRef<SILValue> elts) {
 }
 
 SILType SILBuilder::getPartialApplyResultType(SILType origTy, unsigned argCount,
-                                              SILModule &M,
-                                              ArrayRef<Substitution> subs) {
+                                        SILModule &M,
+                                        ArrayRef<Substitution> subs,
+                                        ParameterConvention calleeConvention) {
   CanSILFunctionType FTI = origTy.castTo<SILFunctionType>();
   if (!subs.empty())
     FTI = FTI->substGenericArgs(M, M.getSwiftModule(), subs);
@@ -59,7 +60,7 @@ SILType SILBuilder::getPartialApplyResultType(SILType origTy, unsigned argCount,
   }
 
   auto appliedFnType = SILFunctionType::get(nullptr, extInfo,
-                                            ParameterConvention::Direct_Owned,
+                                            calleeConvention,
                                             newParams,
                                             results,
                                             FTI->getOptionalErrorResult(),

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -910,10 +910,26 @@ public:
     *this << ", normal " << getID(AI->getNormalBB());
     *this << ", error " << getID(AI->getErrorBB());
   }
-  
-  
+
   void visitPartialApplyInst(PartialApplyInst *CI) {
     *this << "partial_apply ";
+    switch (CI->getFunctionType()->getCalleeConvention()) {
+    case ParameterConvention::Direct_Owned:
+      // Default; do nothing.
+      break;
+    case ParameterConvention::Direct_Guaranteed:
+      *this << "[callee_guaranteed] ";
+      break;
+    
+    // Should not apply to callees.
+    case ParameterConvention::Direct_Unowned:
+    case ParameterConvention::Direct_Deallocating:
+    case ParameterConvention::Indirect_In:
+    case ParameterConvention::Indirect_Inout:
+    case ParameterConvention::Indirect_In_Guaranteed:
+    case ParameterConvention::Indirect_InoutAliasable:
+      llvm_unreachable("unexpected callee convention!");
+    }
     *this << getID(CI->getCallee());
     printSubstitutions(CI->getSubstitutions());
     *this << '(';

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4405,7 +4405,8 @@ namespace {
             constantInfo.getSILType(),
             1,
             gen.B.getModule(),
-            subs);
+            subs,
+            ParameterConvention::Direct_Owned);
 
           auto &module = gen.getFunction().getModule();
 
@@ -5417,9 +5418,10 @@ static SILValue emitDynamicPartialApply(SILGenFunction &gen,
                                         SILValue self,
                                         CanFunctionType methodTy) {
   auto partialApplyTy = SILBuilder::getPartialApplyResultType(method->getType(),
-                                                              /*argCount*/1,
-                                                              gen.SGM.M,
-                                                              /*subs*/{});
+                                            /*argCount*/1,
+                                            gen.SGM.M,
+                                            /*subs*/{},
+                                            ParameterConvention::Direct_Owned);
 
   // Retain 'self' because the partial apply will take ownership.
   // We can't simply forward 'self' because the partial apply is conditional.

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -428,7 +428,8 @@ SILGenFunction::emitClosureValue(SILLocation loc, SILDeclRef constant,
   SILType closureTy =
     SILGenBuilder::getPartialApplyResultType(functionRef->getType(),
                                              capturedArgs.size(), SGM.M,
-                                             subs);
+                                             subs,
+                                             ParameterConvention::Direct_Owned);
   auto toClosure =
     B.createPartialApply(loc, functionRef, functionTy,
                          subs, forwardedArgs, closureTy);
@@ -840,7 +841,8 @@ void SILGenFunction::emitCurryThunk(ValueDecl *vd,
   // Partially apply the next uncurry level and return the result closure.
   auto closureTy =
     SILGenBuilder::getPartialApplyResultType(toFn->getType(), curriedArgs.size(),
-                                             SGM.M, subs);
+                                             SGM.M, subs,
+                                             ParameterConvention::Direct_Owned);
   SILInstruction *toClosure =
     B.createPartialApply(vd, toFn, toTy, subs, curriedArgs, closureTy);
   if (resultTy != closureTy)

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -792,7 +792,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
         SILAbbrCodes[SILInstApplyLayout::Code], SIL_PARTIAL_APPLY,
         PAI->getSubstitutions().size(),
         S.addTypeRef(PAI->getCallee()->getType().getSwiftRValueType()),
-        S.addTypeRef(PAI->getSubstCalleeType()),
+        S.addTypeRef(PAI->getType().getSwiftRValueType()),
         addValueRef(PAI->getCallee()),
         Args);
     S.writeSubstitutions(PAI->getSubstitutions(), SILAbbrCodes);

--- a/test/SIL/Parser/partial_apply_ownership.sil
+++ b/test/SIL/Parser/partial_apply_ownership.sil
@@ -1,0 +1,29 @@
+// RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s
+
+import Builtin
+
+sil_stage canonical
+
+sil @subject : $@convention(thin) (Builtin.Int64) -> ()
+
+// CHECK-LABEL: sil @partial_apply_callee_owned_by_default : $@convention(thin) () -> @callee_owned () -> () {
+sil @partial_apply_callee_owned_by_default : $@convention(thin) () -> @callee_owned () -> () {
+entry:
+  %f = function_ref @subject : $@convention(thin) (Builtin.Int64) -> ()
+  %z = integer_literal $Builtin.Int64, 0
+  // CHECK: [[PA:%.*]] = partial_apply {{.*}} $@convention(thin) (Builtin.Int64) -> ()
+  %g = partial_apply %f(%z) : $@convention(thin) (Builtin.Int64) -> ()
+  // CHECK: return [[PA]] : $@callee_owned () -> ()
+  return %g : $@callee_owned () -> ()
+}
+
+// CHECK-LABEL: sil @partial_apply_callee_guaranteed_by_attr : $@convention(thin) () -> @callee_guaranteed () -> () {
+sil @partial_apply_callee_guaranteed_by_attr : $@convention(thin) () -> @callee_guaranteed () -> () {
+entry:
+  %f = function_ref @subject : $@convention(thin) (Builtin.Int64) -> ()
+  %z = integer_literal $Builtin.Int64, 0
+  // CHECK: [[PA:%.*]] = partial_apply [callee_guaranteed] {{.*}} $@convention(thin) (Builtin.Int64) -> ()
+  %g = partial_apply [callee_guaranteed] %f(%z) : $@convention(thin) (Builtin.Int64) -> ()
+  // CHECK: return [[PA]] : $@callee_guaranteed () -> ()
+  return %g : $@callee_guaranteed () -> ()
+}

--- a/test/Serialization/sil_partial_apply_ownership.sil
+++ b/test/Serialization/sil_partial_apply_ownership.sil
@@ -1,0 +1,45 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: %target-build-swift -emit-module -Xfrontend -disable-diagnostic-passes -Xfrontend -sil-serialize-all -force-single-frontend-invocation -o %t/sil_partial_apply_ownership.swiftmodule %s
+// RUN: %target-build-swift -emit-sil -Xfrontend -sil-link-all -I %t %s | %FileCheck %s
+
+import Builtin
+
+sil_stage canonical
+
+sil @subject : $@convention(thin) (Builtin.Int64) -> ()
+sil @generic_subject : $@convention(thin) <T> (@in T, @in T) -> ()
+
+// CHECK-LABEL: sil @partial_apply_callee_owned_by_default : $@convention(thin) () -> @callee_owned () -> () {
+sil @partial_apply_callee_owned_by_default : $@convention(thin) () -> @callee_owned () -> () {
+entry:
+  %f = function_ref @subject : $@convention(thin) (Builtin.Int64) -> ()
+  %z = integer_literal $Builtin.Int64, 0
+  // CHECK: [[PA:%.*]] = partial_apply {{.*}} $@convention(thin) (Builtin.Int64) -> ()
+  %g = partial_apply %f(%z) : $@convention(thin) (Builtin.Int64) -> ()
+  // CHECK: return [[PA]] : $@callee_owned () -> ()
+  return %g : $@callee_owned () -> ()
+}
+
+// CHECK-LABEL: sil @partial_apply_callee_guaranteed_by_attr : $@convention(thin) () -> @callee_guaranteed () -> () {
+sil @partial_apply_callee_guaranteed_by_attr : $@convention(thin) () -> @callee_guaranteed () -> () {
+entry:
+  %f = function_ref @subject : $@convention(thin) (Builtin.Int64) -> ()
+  %z = integer_literal $Builtin.Int64, 0
+  // CHECK: [[PA:%.*]] = partial_apply [callee_guaranteed] {{.*}} $@convention(thin) (Builtin.Int64) -> ()
+  %g = partial_apply [callee_guaranteed] %f(%z) : $@convention(thin) (Builtin.Int64) -> ()
+  // CHECK: return [[PA]] : $@callee_guaranteed () -> ()
+  return %g : $@callee_guaranteed () -> ()
+}
+
+sil @partial_apply_generic : $@convention(thin) () -> @callee_owned (@in Builtin.Int64) -> () {
+entry:
+  %f = function_ref @generic_subject : $@convention(thin) <T> (@in T, @in T) -> ()
+  %z = integer_literal $Builtin.Int64, 0
+  %s = alloc_stack $Builtin.Int64
+  store %z to %s : $*Builtin.Int64
+  // CHECK: [[PA:%.*]] = partial_apply {{.*}}<Builtin.Int64>({{.*}}) : $@convention(thin)
+  %g = partial_apply %f<Builtin.Int64>(%s) : $@convention(thin) <T> (@in T, @in T) -> ()
+  dealloc_stack %s : $*Builtin.Int64
+  return %g : $@callee_owned (@in Builtin.Int64) -> ()
+}


### PR DESCRIPTION
This lets us get to the goal of +0 guaranteed closure contexts. NFC yet, just add the under-the-hood ability for partial_apply instructions producing callee-guaranteed closures to be parsed, printed, and serialized.
