### PR TITLE
Add standard "end anonymous namespace" comment. NFC.

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -270,7 +270,7 @@ public:
     Hash.final(Result);
   }
 };
-}
+} // end anonymous namespace
 
 /// Computes the MD5 hash of the llvm \p Module including the compiler version
 /// and options which influence the compilation.


### PR DESCRIPTION
Fixup for #5086. Thanks, @gottesmm.
