### PR TITLE
[Parse] Several improvement for attribute parsing.

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -262,8 +262,6 @@ SIMPLE_DECL_ATTR(discardableResult, DiscardableResult,
 
 SIMPLE_DECL_ATTR(GKInspectable, GKInspectable, OnVar, 66)
 
-SIMPLE_DECL_ATTR(escaping, Escaping, OnParam, 67)
-
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef SIMPLE_DECL_ATTR

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1048,7 +1048,6 @@ public:
   /// followed by one of the above tokens, then this function returns false,
   /// and the expression will parse with the '<' as an operator.
   bool canParseAsGenericArgumentList();
-  bool canParseAttributes();
 
   bool canParseType();
   bool canParseTypeIdentifier();

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -689,9 +689,7 @@ public:
 
   /// Parse the optional attributes before a declaration.
   bool parseDeclAttributeList(DeclAttributes &Attributes,
-                              bool &FoundCodeCompletionToken,
-                              bool StopAtTypeAttributes = false,
-                              bool InParam = false);
+                              bool &FoundCodeCompletionToken);
 
   /// Parse a specific attribute.
   bool parseDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1249,8 +1249,11 @@ bool Parser::parseDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc) {
     diagnose(Tok, diag::type_attribute_applied_to_decl);
   else
     diagnose(Tok, diag::unknown_attribute, Tok.getText());
-  // Recover by eating @foo when foo is not known.
+
+  // Recover by eating @foo(...) when foo is not known.
   consumeToken();
+  if (Tok.is(tok::l_paren))
+    skipSingle();
 
   return true;
 }
@@ -1312,15 +1315,16 @@ bool Parser::parseTypeAttribute(TypeAttributes &Attributes, bool justChecking) {
       }
     }
     
-    // Recover by eating @foo when foo is not known.
+    // Recover by eating @foo(...) when foo is not known.
     consumeToken();
-      
-    // Recovery by eating "@foo=bar" if present.
-    if (consumeIf(tok::equal)) {
-      if (Tok.is(tok::identifier) ||
-          Tok.is(tok::integer_literal) ||
-          Tok.is(tok::floating_literal))
-        consumeToken();
+    if (Tok.is(tok::l_paren) && getEndOfPreviousLoc() == Tok.getLoc()) {
+      ParserPosition LParenPosition = getParserPosition();
+      skipSingle();
+      // If we found '->', or 'throws' after paren, it's likely a parameter
+      // of function type.
+      if (Tok.isAny(tok::arrow, tok::kw_throws, tok::kw_rethrows,
+                    tok::kw_throw))
+        backtrackToPosition(LParenPosition);
     }
     return true;
   }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1570,7 +1570,7 @@ bool Parser::parseDeclAttributeList(DeclAttributes &Attributes,
 ///     attribute-list-clause attribute-list
 ///   attribute-list-clause:
 ///     '@' attribute
-///     '@' attribute ','? attribute-list-clause
+///     '@' attribute attribute-list-clause
 /// \endverbatim
 bool Parser::parseTypeAttributeListPresent(TypeAttributes &Attributes) {
   Attributes.AtLoc = Tok.getLoc();

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1528,9 +1528,7 @@ bool Parser::parseTypeAttribute(TypeAttributes &Attributes, bool justChecking) {
 ///     '@' attribute
 /// \endverbatim
 bool Parser::parseDeclAttributeList(DeclAttributes &Attributes,
-                                    bool &FoundCCToken,
-                                    bool StopAtTypeAttributes,
-                                    bool InParam) {
+                                    bool &FoundCCToken) {
   FoundCCToken = false;
   while (Tok.is(tok::at_sign)) {
     if (peekToken().is(tok::code_complete)) {
@@ -1539,25 +1537,7 @@ bool Parser::parseDeclAttributeList(DeclAttributes &Attributes,
       FoundCCToken = true;
       continue;
     }
-    SourceLoc AtLoc = Tok.getLoc();
-
-    // If StopAtTypeAttributes is true, then we sniff to see if the following
-    // attribute is a type attribute.  If so, we stop here, instead of producing
-    // an error on it.
-    if (StopAtTypeAttributes) {
-      Token next = peekToken();
-      auto Kind = TypeAttributes::getAttrKindFromString(next.getText());
-
-      // noescape/autoclosure are valid as a decl attribute and type attribute
-      // (in parameter lists) but we disambiguate them as a decl attribute.
-      if (Kind == TAK_noescape || Kind == TAK_autoclosure)
-        Kind = TAK_Count;
-
-      if (Kind != TAK_Count)
-        return false;
-    }
-
-    consumeToken();
+    SourceLoc AtLoc = consumeToken();
     if (parseDeclAttribute(Attributes, AtLoc))
       return true;
   }

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -858,8 +858,11 @@ static bool isStartOfGetSetAccessor(Parser &P) {
   P.consumeToken(tok::l_brace);
 
   // Eat attributes, if present.
-  if (!P.canParseAttributes())
-    return false;
+  while (P.consumeIf(tok::at_sign)) {
+    if (!P.consumeIf(tok::identifier)) return false;
+    // Eat paren after attribute name; e.g. @foo(x)
+    if (P.Tok.is(tok::l_paren)) P.skipSingle();
+  }
 
   // Check if we have 'didSet'/'willSet' after attributes.
   return P.Tok.isContextualKeyword("didSet") ||

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -171,8 +171,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
 
     // Attributes.
     bool FoundCCToken;
-    parseDeclAttributeList(param.Attrs, FoundCCToken,
-                          /*stop at type attributes*/true, true);
+    parseDeclAttributeList(param.Attrs, FoundCCToken);
     if (FoundCCToken) {
       if (CodeCompletion) {
         CodeCompletion->completeDeclAttrKeyword(nullptr, isInSILMode(), true);

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -1105,26 +1105,6 @@ bool Parser::canParseOldStyleProtocolComposition() {
   return true;
 }
 
-bool Parser::canParseAttributes() {
-  while (consumeIf(tok::at_sign)) {
-    if (!consumeIf(tok::identifier)) return false;
-    
-    if (consumeIf(tok::equal)) {
-      if (Tok.isNot(tok::identifier) &&
-          Tok.isNot(tok::integer_literal) &&
-          Tok.isNot(tok::floating_literal))
-        return false;
-      consumeToken();
-    } else if (Tok.is(tok::l_paren)) {
-      // Attributes like cc(x,y,z)
-      skipSingle();
-    }
-    
-    consumeIf(tok::comma);
-  }
-  return true;
-}
-
 bool Parser::canParseTypeTupleBody() {
   if (Tok.isNot(tok::r_paren) && Tok.isNot(tok::r_brace) &&
       Tok.isNotEllipsis() && !isStartOfDecl()) {
@@ -1143,9 +1123,8 @@ bool Parser::canParseTypeTupleBody() {
         }
         consumeToken(tok::colon);
 
-        // Parse attributes then a type.
-        if (!canParseAttributes() ||
-            !canParseType())
+        // Parse a type.
+        if (!canParseType())
           return false;
 
         // Parse default values. This aren't actually allowed, but we recover
@@ -1163,11 +1142,6 @@ bool Parser::canParseTypeTupleBody() {
       }
       
       // Otherwise, this has to be a type.
-
-      // Parse attributes.
-      if (!canParseAttributes())
-        return false;
- 
       if (!canParseType())
         return false;
 
@@ -1179,6 +1153,3 @@ bool Parser::canParseTypeTupleBody() {
   
   return consumeIf(tok::r_paren);
 }
-
-
-

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -155,15 +155,6 @@ public:
     TC.checkNoEscapeAttr(cast<ParamDecl>(D), attr);
   }
 
-  void visitEscapingAttr(EscapingAttr *attr) {
-    auto *PD = cast<ParamDecl>(D);
-    auto *FTy = PD->getType()->getAs<FunctionType>();
-    if (FTy == 0) {
-      TC.diagnose(attr->getLocation(), diag::escaping_function_type);
-      attr->setInvalid();
-    }
-  }
-
   void visitTransparentAttr(TransparentAttr *attr);
   void visitMutationAttr(DeclAttribute *attr);
   void visitMutatingAttr(MutatingAttr *attr) { visitMutationAttr(attr); }
@@ -742,7 +733,6 @@ public:
     IGNORED_ATTR(WarnUnqualifiedAccess)
     IGNORED_ATTR(ShowInInterface)
     IGNORED_ATTR(DiscardableResult)
-    IGNORED_ATTR(Escaping)
 
     // FIXME: We actually do have things to enforce for versioned API.
     IGNORED_ATTR(Versioned)

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5920,7 +5920,6 @@ public:
     // These can't appear on overridable declarations.
     UNINTERESTING_ATTR(AutoClosure)
     UNINTERESTING_ATTR(NoEscape)
-    UNINTERESTING_ATTR(Escaping)
 
     UNINTERESTING_ATTR(Prefix)
     UNINTERESTING_ATTR(Postfix)

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -35,10 +35,9 @@
 
 func method(@#^KEYWORD1^#) {}
 
-// KEYWORD1:                  Begin completions, 3 items
+// KEYWORD1:                  Begin completions, 2 items
 // KEYWORD1-NEXT:             Keyword/None:                       autoclosure[#Param Attribute#]; name=autoclosure{{$}}
 // KEYWORD1-NEXT:             Keyword/None:                       noescape[#Param Attribute#]; name=noescape{{$}}
-// KEYWORD1-NEXT:             Keyword/None:                       escaping[#Param Attribute#]; name=escaping{{$}}
 // KEYWORD1-NEXT:             End completions
 
 @#^KEYWORD2^#
@@ -86,7 +85,7 @@ struct S{}
 
 @#^KEYWORD_LAST^#
 
-// KEYWORD_LAST:                  Begin completions, 21 items
+// KEYWORD_LAST:                  Begin completions, 20 items
 // KEYWORD_LAST-NEXT:             Keyword/None:                       available[#Declaration Attribute#]; name=available{{$}}
 // KEYWORD_LAST-NEXT:             Keyword/None:                       objc[#Declaration Attribute#]; name=objc{{$}}
 // KEYWORD_LAST-NEXT:             Keyword/None:                       noreturn[#Declaration Attribute#]; name=noreturn{{$}}
@@ -107,5 +106,4 @@ struct S{}
 // KEYWORD_LAST-NEXT:             Keyword/None:                       warn_unqualified_access[#Declaration Attribute#]; name=warn_unqualified_access
 // KEYWORD_LAST-NEXT:             Keyword/None:                       discardableResult[#Declaration Attribute#]; name=discardableResult
 // KEYWORD_LAST-NEXT:             Keyword/None:                       GKInspectable[#Declaration Attribute#]; name=GKInspectable{{$}}
-// KEYWORD_LAST-NEXT:             Keyword/None:                       escaping[#Declaration Attribute#]; name=escaping{{$}}
 // KEYWORD_LAST-NEXT:             End completions

--- a/test/attr/attr_escaping.swift
+++ b/test/attr/attr_escaping.swift
@@ -1,6 +1,7 @@
 // RUN: %target-parse-verify-swift
 
-@escaping var fn : () -> Int = { 4 }  // expected-error {{@escaping may only be used on 'parameter' declarations}} {{1-11=}}
+@escaping var fn : () -> Int = { 4 }  // expected-error {{attribute can only be applied to types, not declarations}}
+func paramDeclEscaping(@escaping fn: (Int) -> Void) {} // expected-error {{attribute can only be applied to types, not declarations}}
 
 func wrongParamType(a: @escaping Int) {} // expected-error {{@escaping attribute only applies to function types}}
 

--- a/test/attr/attributes.swift
+++ b/test/attr/attributes.swift
@@ -1,6 +1,7 @@
 // RUN: %target-parse-verify-swift
 
 @unknown func f0() {} // expected-error{{unknown attribute 'unknown'}}
+@unknown(x,y) func f1() {} // expected-error{{unknown attribute 'unknown'}}
 
 enum binary { 
   case Zero
@@ -190,6 +191,16 @@ var func_result_type_attr : () -> @xyz Int  // expected-error {{unknown attribut
 func func_result_attr() -> @xyz Int {       // expected-error {{unknown attribute 'xyz'}}
   return 4
 }
+
+func func_with_unknown_attr1(@unknown(*) x: Int) {} // expected-error {{unknown attribute 'unknown'}}
+func func_with_unknown_attr2(x: @unknown(_) Int) {} // expected-error {{unknown attribute 'unknown'}}
+func func_with_unknown_attr3(x: @unknown(Int) -> Int) {} // expected-error {{unknown attribute 'unknown'}}
+func func_with_unknown_attr4(x: @unknown(Int) throws -> Int) {} // expected-error {{unknown attribute 'unknown'}}
+func func_with_unknown_attr5(x: @unknown (x: Int, y: Int)) {} // expected-error {{unknown attribute 'unknown'}}
+func func_with_unknown_attr6(x: @unknown(x: Int, y: Int)) {} // expected-error {{unknown attribute 'unknown'}} expected-error {{expected parameter type following ':'}}
+func func_with_unknown_attr7(x: @unknown (Int) () -> Int) {} // expected-error {{unknown attribute 'unknown'}} expected-error {{expected ',' separator}} {{47-47=,}} expected-error {{unnamed parameters must be written with the empty name '_'}} {{48-48=_: }}
+
+func func_type_attribute_with_space(x: @convention (c) () -> Int) {} // OK. Known attributes can have space before its paren.
 
 // @thin is not supported except in SIL.
 var thinFunc : @thin () -> () // expected-error {{attribute is not supported}}

--- a/test/decl/func/functions.swift
+++ b/test/decl/func/functions.swift
@@ -145,6 +145,12 @@ func var_inout_error(inout var x : Int) {} // expected-error {{parameter may not
 // Unnamed parameters require the name "_":
 func unnamed(Int) { } // expected-error{{unnamed parameters must be written with the empty name '_'}}{{14-14=_: }}
 
+func typeAttrBeforeParamDecl(@convention(c) _: () -> Void) {} // expected-error{{attribute can only be applied to types, not declarations}}
+
+// FIXME: Bad diagnostics
+func bareTypeWithAttr(@convention(c) () -> Void) {} // expected-error{{attribute can only be applied to types, not declarations}}
+// expected-error @-1 {{unnamed parameters must be written with the empty name '_'}} {{38-38=_: }}
+
 // Test fixits on curried functions.
 func testCurryFixits() {
   func f1(_ x: Int)(y: Int) {} // expected-error{{curried function declaration syntax has been removed; use a single parameter list}} {{19-21=, }}


### PR DESCRIPTION
### [Parse] Eliminate Parser::canParseAttributes()

`@foo=bar` style attributes are no longer supported anyway.
So as `,` separated attribute list.

In `canParseTypeTupleBody()`, `canParseType()` can more accurately consume
type attributes.

In `isStartOfGetSetAccessor()`, we can trivially inline the functionality.
### [QoI][Parse] Improve recovering from unknown attribute

By consuming parens.
As for type attributes, handle `@unknownAttribute(Arg) -> Ret` case.

Improves diagnostic QoI. For example, on:
`func foo(x: @unknown(x) Int) {}`

Before:

```
test.swift:1:14: error: unknown attribute 'unknown'
test.swift:1:25: error: expected ',' separator
test.swift:1:25: error: unnamed parameters must be written with the empty name '_'
test.swift:1:22: error: use of undeclared type 'x'
```

Now, we just emit the first one:

```
test.swift:1:14: error: unknown attribute 'unknown'
func foo(x: @unknown(x) Int) {}
             ^
```
### [Parse] Remove unnecessary parameters from `parseDeclAttributeList` function.

`InParam` was not used at all.

`StopAtTypeAttributes`
As far as I understand, this option _was_ merely for improving diagnostic QoI
for declarations like:
  `func foo(@typeattr Arg) {}`
to fix-it to:
  `func foo(_: @typeattr Arg) {}`

But, this causes the very loudly diagnostics for misplaced type attributes.
For example, on:
`func foo(@convention(block) x: () -> CInt) {}`

```
test.swift:1:10: error: expected parameter name followed by ':'
test.swift:1:10: error: expected ',' separator
test.swift:1:10: error: expected ')' in parameter
test.swift:1:9: note: to match this opening '('
test.swift:1:10: error: consecutive statements on a line must be separated by ';'
test.swift:1:11: error: attribute can only be applied to types, not declarations
test.swift:1:21: error: expected declaration
test.swift:1:44: error: statement cannot begin with a closure expression
test.swift:1:44: note: explicitly discard the result of the closure by assigning to '_'
test.swift:1:44: error: braced block of statements is an unused closure
test.swift:1:6: error: expected '{' in body of function declaration
test.swift:1:44: error: expression resolves to an unused function
```

Now, we emit more accurate diagnostic:

```
test.swift:1:11: error: attribute can only be applied to types, not declarations
func foo(@convention(block) x: () -> CInt) {}
          ^
```

Note that This causes small regression in diagnostics for bare type parameter
like `func foo(@convention(c) () -> CInt) {}`:

Before:

```
test.swift:1:10: error: unnamed parameters must be written with the empty name '_'
func foo(@convention(block) () -> CInt) {}
         ^
         _:
```

Now:

```
test.swift:1:11: error: attribute can only be applied to types, not declarations
func foo(@convention(block) () -> CInt) {}
          ^
test.swift:1:29: error: unnamed parameters must be written with the empty name '_'
func foo(@convention(block) () -> CInt) {}
                            ^
                            _:
```
### [AST] Remove @escaping from decl attributes.

`@escaping` is not really a decl attribute, ever since it was introduced.
