### PR TITLE
[stdlib] Only add Apple reflection test targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -419,6 +419,12 @@ include_directories(BEFORE
 #  endif()
 set(SWIFT_DARWIN_VARIANTS "^(macosx|iphoneos|iphonesimulator|appletvos|appletvsimulator|watchos|watchsimulator)")
 
+# A convenient list to match Darwin SDKs. Example:
+#  if("${SWIFT_HOST_VARIANT_SDK}" IN_LIST SWIFT_APPLE_PLATFORMS)
+#    ...
+#  endif()
+set(SWIFT_APPLE_PLATFORMS "IOS" "IOS_SIMULATOR" "TVOS" "TVOS_SIMULATOR" "WATCHOS" "WATCHOS_SIMULATOR" "OSX")
+
 # Configuration flags passed to all of our invocations of gyb.  Try to
 # avoid making up new variable names here if you can find a CMake
 # variable that will do the job.

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1230,7 +1230,7 @@ function(add_swift_library name)
     set(SWIFTLIB_TARGET_SDKS ${SWIFT_SDKS})
   endif()
   list_replace(SWIFTLIB_TARGET_SDKS ALL_POSIX_PLATFORMS "ALL_APPLE_PLATFORMS;ANDROID;CYGWIN;FREEBSD;LINUX")
-  list_replace(SWIFTLIB_TARGET_SDKS ALL_APPLE_PLATFORMS "IOS;IOS_SIMULATOR;TVOS;TVOS_SIMULATOR;WATCHOS;WATCHOS_SIMULATOR;OSX")
+  list_replace(SWIFTLIB_TARGET_SDKS ALL_APPLE_PLATFORMS "${SWIFT_APPLE_PLATFORMS}")
 
   # All Swift code depends on the standard library, except for the standard
   # library itself.

--- a/stdlib/private/SwiftReflectionTest/CMakeLists.txt
+++ b/stdlib/private/SwiftReflectionTest/CMakeLists.txt
@@ -3,14 +3,17 @@ if (SWIFT_INCLUDE_TESTS)
   add_swift_library(swiftSwiftReflectionTest ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
     SwiftReflectionTest.swift
     SWIFT_MODULE_DEPENDS Darwin
+    TARGET_SDKS ALL_APPLE_PLATFORMS
     INSTALL_IN_COMPONENT stdlib-experimental)
 
   foreach(SDK ${SWIFT_SDKS})
-    foreach(ARCH ${SWIFT_SDK_${SDK}_ARCHITECTURES})
-      set(VARIANT_SUFFIX "-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-${ARCH}")
-      add_dependencies(
-        "swiftSwiftReflectionTest${VARIANT_SUFFIX}"
-        "swift-reflection-test${VARIANT_SUFFIX}")
-    endforeach()
+    if("${SDK}" IN_LIST SWIFT_APPLE_PLATFORMS)
+      foreach(ARCH ${SWIFT_SDK_${SDK}_ARCHITECTURES})
+        set(VARIANT_SUFFIX "-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-${ARCH}")
+        add_dependencies(
+          "swiftSwiftReflectionTest${VARIANT_SUFFIX}"
+          "swift-reflection-test${VARIANT_SUFFIX}")
+      endforeach()
+    endif()
   endforeach()
 endif()


### PR DESCRIPTION
<!-- What's in this pull request? -->

When building on a macOS host, and when `SWIFT_INCLUDE_TESTS` is specified, the `swiftSwiftReflectionTest` target is added to all platforms. However, this target has a dependency upon Foundation, which is not available on non-Apple platforms.

Use `add_swift_library`'s `TARGET_SDKS` parameter and other gating logic to ensure the target is only added for platforms that actually have Darwin available.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

This was pulled out of the larger pull request https://github.com/apple/swift/pull/4972, which addresses [SR-1362](https://bugs.swift.org/browse/SR-1362).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
