### PR TITLE
Fix relwithdebuginfo in 3.0-branch

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1965,14 +1965,8 @@ for host in "${ALL_HOSTS[@]}"; do
                     "${cmake_options[@]}"
                     -DCMAKE_C_FLAGS="$(llvm_c_flags ${host})"
                     -DCMAKE_CXX_FLAGS="$(llvm_c_flags ${host})"
-                    -DCMAKE_C_FLAGS_DEBUG=""
-                    -DCMAKE_CXX_FLAGS_DEBUG=""
-                    -DCMAKE_C_FLAGS_RELEASE="-O3"
-                    -DCMAKE_CXX_FLAGS_RELEASE="-O3"
-                    -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2"
-                    -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2"
-                    -DCMAKE_C_FLAGS_MINSIZEREL="-Os"
-                    -DCMAKE_CXX_FLAGS_MINSIZEREL="-Os"
+                    -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2 -DNDEBUG"
+                    -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -DNDEBUG"
                     -DCMAKE_BUILD_TYPE:STRING="${LLVM_BUILD_TYPE}"
                     -DLLVM_ENABLE_ASSERTIONS:BOOL=$(true_false "${LLVM_ENABLE_ASSERTIONS}")
                     -DLLVM_TOOL_SWIFT_BUILD:BOOL=NO
@@ -2088,14 +2082,8 @@ for host in "${ALL_HOSTS[@]}"; do
                     "${cmake_options[@]}"
                     -DCMAKE_C_FLAGS="$(swift_c_flags ${host})"
                     -DCMAKE_CXX_FLAGS="$(swift_c_flags ${host})"
-                    -DCMAKE_C_FLAGS_DEBUG=""
-                    -DCMAKE_CXX_FLAGS_DEBUG=""
-                    -DCMAKE_C_FLAGS_RELEASE="-O3"
-                    -DCMAKE_CXX_FLAGS_RELEASE="-O3"
-                    -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2"
-                    -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2"
-                    -DCMAKE_C_FLAGS_MINSIZEREL="-Os"
-                    -DCMAKE_CXX_FLAGS_MINSIZEREL="-Os"
+                    -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2 -DNDEBUG"
+                    -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -DNDEBUG"
                     -DCMAKE_BUILD_TYPE:STRING="${SWIFT_BUILD_TYPE}"
                     -DLLVM_ENABLE_ASSERTIONS:BOOL=$(true_false "${SWIFT_ENABLE_ASSERTIONS}")
                     -DSWIFT_ANALYZE_CODE_COVERAGE:STRING=$(toupper "${SWIFT_ANALYZE_CODE_COVERAGE}")


### PR DESCRIPTION
<!-- What's in this pull request? -->

This fixes relwithdebuginfo in the swift-3.0-branch

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
