### PR TITLE
Extend `ErrorType` to carry an original type, so we can carry around partial failures

### DIFF
--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -132,7 +132,7 @@ public:
 
 
     auto *CE = TheFunction.get<AbstractClosureExpr *>();
-    if (!CE->getType() || CE->getType()->is<ErrorType>())
+    if (!CE->getType() || CE->getType()->hasError())
       return false;
     return CE->getType()->castTo<FunctionType>()->isNoEscape();
   }

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -54,8 +54,8 @@ typedef llvm::DenseMap<TypeBase *, Type> TypeSubstitutionMap;
 /// Flags that can be passed when substituting into a type.
 enum class SubstFlags {
   /// If a type cannot be produced because some member type is
-  /// missing, return the identity type rather than a null type.
-  IgnoreMissing = 0x01,
+  /// missing, place an 'error' type into the position of the base.
+  UseErrorType = 0x01,
   /// Allow substitutions to recurse into SILFunctionTypes.
   /// Normally, SILType::subst() should be used for lowered
   /// types, however in special cases where the substitution

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -172,7 +172,7 @@ public:
   /// \returns the substituted type, or a null type if an error occurred.
   Type subst(ModuleDecl *module,
              const TypeSubstitutionMap &substitutions,
-             SubstOptions options) const;
+             SubstOptions options = None) const;
 
   /// Replace references to substitutable types with new, concrete types and
   /// return the substituted result.
@@ -184,7 +184,7 @@ public:
   ///
   /// \returns the substituted type, or a null type if an error occurred.
   Type subst(const SubstitutionMap &substitutions,
-             SubstOptions options) const;
+             SubstOptions options = None) const;
 
   bool isPrivateStdlibType(bool whitelistProtocols=true) const;
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4585,7 +4585,7 @@ inline TupleTypeElt::TupleTypeElt(Type ty, Identifier name, bool isVariadic,
     : Name(name), ElementType(ty),
       Flags(isVariadic, isAutoClosure, isEscaping) {
   assert(!isVariadic ||
-         isa<ErrorType>(ty.getPointer()) ||
+         ty->hasError() ||
          isa<ArraySliceType>(ty.getPointer()) ||
          (isa<BoundGenericType>(ty.getPointer()) &&
           ty->castTo<BoundGenericType>()->getGenericArgs().size() == 1));
@@ -4603,7 +4603,7 @@ inline Type TupleTypeElt::getVarargBaseTy(Type VarArgT) {
     // It's the stdlib Array<T>.
     return BGT->getGenericArgs()[0];
   }
-  assert(isa<ErrorType>(T));
+  assert(T->hasError());
   return T;
 }
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3365,13 +3365,13 @@ SubstitutedType *SubstitutedType::get(Type Original, Type Replacement,
   return Known;
 }
 
-DependentMemberType *DependentMemberType::get(Type base, Identifier name,
-                                              const ASTContext &ctx) {
+DependentMemberType *DependentMemberType::get(Type base, Identifier name) {
   auto properties = base->getRecursiveProperties();
   properties |= RecursiveTypeProperties::HasTypeParameter;
   auto arena = getArena(properties);
 
   llvm::PointerUnion<Identifier, AssociatedTypeDecl *> stored(name);
+  const ASTContext &ctx = base->getASTContext();
   auto *&known = ctx.Impl.getArena(arena).DependentMemberTypes[
                                             {base, stored.getOpaqueValue()}];
   if (!known) {
@@ -3383,13 +3383,13 @@ DependentMemberType *DependentMemberType::get(Type base, Identifier name,
 }
 
 DependentMemberType *DependentMemberType::get(Type base,
-                                              AssociatedTypeDecl *assocType,
-                                              const ASTContext &ctx) {
+                                              AssociatedTypeDecl *assocType) {
   auto properties = base->getRecursiveProperties();
   properties |= RecursiveTypeProperties::HasTypeParameter;
   auto arena = getArena(properties);
 
   llvm::PointerUnion<Identifier, AssociatedTypeDecl *> stored(assocType);
+  const ASTContext &ctx = base->getASTContext();
   auto *&known = ctx.Impl.getArena(arena).DependentMemberTypes[
                                             {base, stored.getOpaqueValue()}];
   if (!known) {

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3326,7 +3326,7 @@ void ProtocolType::Profile(llvm::FoldingSetNodeID &ID, ProtocolDecl *D,
 }
 
 LValueType *LValueType::get(Type objectTy) {
-  assert(!objectTy->is<ErrorType>() &&
+  assert(!objectTy->hasError() &&
          "cannot have ErrorType wrapped inside LValueType");
   assert(!objectTy->is<LValueType>() && !objectTy->is<InOutType>() &&
          "cannot have 'inout' or @lvalue wrapped inside an @lvalue");
@@ -3346,8 +3346,6 @@ LValueType *LValueType::get(Type objectTy) {
 }
 
 InOutType *InOutType::get(Type objectTy) {
-  assert(!objectTy->is<ErrorType>() &&
-         "cannot have ErrorType wrapped inside InOutType");
   assert(!objectTy->is<LValueType>() && !objectTy->is<InOutType>() &&
          "cannot have 'inout' or @lvalue wrapped inside an 'inout'");
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2637,7 +2637,13 @@ namespace {
       printCommon(T, label, #Name "_type") << ")";              \
     }
 
-    TRIVIAL_TYPE_PRINTER(Error, error)
+    void visitErrorType(ErrorType *T, StringRef label) {
+      printCommon(T, label, "error_type");
+      if (auto originalType = T->getOriginalType())
+        printRec("original_type", originalType);
+      OS << ")";
+    }
+
     TRIVIAL_TYPE_PRINTER(Unresolved, unresolved)
 
     void visitBuiltinIntegerType(BuiltinIntegerType *T, StringRef label) {

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1317,8 +1317,10 @@ void PrintAST::printSingleDepthOfGenericSignature(
         Printer << ", ";
 
       if (!subMap.empty()) {
-        auto argTy = Type(param).subst(M, subMap, SubstFlags::IgnoreMissing);
-        printType(argTy);
+        if (auto argTy = Type(param).subst(M, subMap))
+          printType(argTy);
+        else
+          printType(param);
       } else if (auto *GP = param->getDecl()) {
         Printer.callPrintStructurePre(PrintStructureKind::GenericParameter, GP);
         Printer.printName(GP->getName(), PrintNameContext::GenericParameter);
@@ -1347,8 +1349,10 @@ void PrintAST::printSingleDepthOfGenericSignature(
       }
 
       if (!subMap.empty()) {
-        first = first.subst(M, subMap, SubstFlags::IgnoreMissing);
-        second = second.subst(M, subMap, SubstFlags::IgnoreMissing);
+        if (Type subFirst = first.subst(M, subMap))
+          first = subFirst;
+        if (Type subSecond = second.subst(M, subMap))
+          second = subSecond;
         if (!(first->is<ArchetypeType>() || first->isTypeParameter()) &&
             !(second->is<ArchetypeType>() || second->isTypeParameter()))
           continue;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3430,7 +3430,10 @@ public:
   }
 
   void visitErrorType(ErrorType *T) {
-    Printer << "<<error type>>";
+    if (auto originalType = T->getOriginalType())
+      visit(originalType);
+    else
+      Printer << "<<error type>>";
   }
 
   void visitUnresolvedType(UnresolvedType *T) {

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -863,7 +863,7 @@ struct ASTNodeBase {};
       Type Ty = E->getType();
       if (!Ty)
         return;
-      if (Ty->is<ErrorType>())
+      if (Ty->hasError())
         return;
       if (!Ty->is<FunctionType>()) {
         PrettyStackTraceExpr debugStack(Ctx, "verifying closure", E);
@@ -2750,7 +2750,7 @@ struct ASTNodeBase {};
 
       if (!D->hasType())
         return;
-      if (D->getType()->is<ErrorType>() && !D->isInvalid()) {
+      if (D->getType()->hasError() && !D->isInvalid()) {
         Out << "Valid decl has error type!\n";
         D->dump(Out);
         abort();

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -641,7 +641,7 @@ ArchetypeBuilder::PotentialArchetype::getType(ArchetypeBuilder &builder) {
 
       // Resolve the member type.
       auto type = getDependentType(builder, false);
-      if (type->is<ErrorType>())
+      if (type->hasError())
         return NestedType::forConcreteType(type);
 
       auto depMemberType = type->castTo<DependentMemberType>();
@@ -742,7 +742,7 @@ Type ArchetypeBuilder::PotentialArchetype::getDependentType(
        bool allowUnresolved) {
   if (auto parent = getParent()) {
     Type parentType = parent->getDependentType(builder, allowUnresolved);
-    if (parentType->is<ErrorType>())
+    if (parentType->hasError())
       return parentType;
 
     // If we've resolved to an associated type, use it.
@@ -2071,7 +2071,7 @@ static void collectRequirements(ArchetypeBuilder &builder,
 
     auto depTy = archetype->getDependentType(builder, false);
 
-    if (depTy->is<ErrorType>())
+    if (depTy->hasError())
       return;
 
     if (kind == RequirementKind::WitnessMarker) {
@@ -2089,7 +2089,7 @@ static void collectRequirements(ArchetypeBuilder &builder,
           ->getDependentType(builder, false);
     }
 
-    if (repTy->is<ErrorType>())
+    if (repTy->hasError())
       return;
 
     requirements.push_back(Requirement(kind, depTy, repTy));

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -1580,8 +1580,7 @@ public:
       case RequirementKind::SameType: {
         auto firstType = req.getFirstType().subst(
                            &Builder.getModule(),
-                           substitutions,
-                           SubstFlags::IgnoreMissing);
+                           substitutions);
         if (!firstType)
           break;
 
@@ -1592,8 +1591,7 @@ public:
 
         auto secondType = req.getSecondType().subst(
                             &Builder.getModule(), 
-                            substitutions,
-                            SubstFlags::IgnoreMissing);
+                            substitutions);
         if (!secondType)
           break;
         auto secondPA = Builder.resolveArchetype(secondType);
@@ -1617,8 +1615,7 @@ public:
       case RequirementKind::Conformance: {
         auto subjectType = req.getFirstType().subst(
                              &Builder.getModule(),
-                             substitutions,
-                             SubstFlags::IgnoreMissing);
+                             substitutions);
         if (!subjectType)
           break;
 

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -747,7 +747,7 @@ Type ArchetypeBuilder::PotentialArchetype::getDependentType(
 
     // If we've resolved to an associated type, use it.
     if (auto assocType = getResolvedAssociatedType())
-      return DependentMemberType::get(parentType, assocType, builder.Context);
+      return DependentMemberType::get(parentType, assocType);
 
     // If typo correction renamed this type, get the renamed type.
     if (wasRenamed())
@@ -758,7 +758,7 @@ Type ArchetypeBuilder::PotentialArchetype::getDependentType(
     if (!allowUnresolved)
       return ErrorType::get(builder.Context);
 
-    return DependentMemberType::get(parentType, getName(), builder.Context);
+    return DependentMemberType::get(parentType, getName());
   }
   
   assert(getGenericParam() && "Not a generic parameter?");

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1672,8 +1672,7 @@ Type ValueDecl::getInterfaceType() const {
     auto &ctx = getASTContext();
     InterfaceTy = DependentMemberType::get(
                     selfTy,
-                    const_cast<AssociatedTypeDecl *>(assocType),
-                    ctx);
+                    const_cast<AssociatedTypeDecl *>(assocType));
     InterfaceTy = MetatypeType::get(InterfaceTy, ctx);
     return InterfaceTy;
   }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1209,7 +1209,7 @@ bool AbstractStorageDecl::hasFixedLayout() const {
 
   if (dc->isTypeContext()) {
     auto declaredType = dc->getDeclaredTypeOfContext();
-    if (declaredType->is<ErrorType>())
+    if (declaredType->hasError())
       return true;
     return declaredType->getAnyNominal()->hasFixedLayout();
   }
@@ -1653,7 +1653,7 @@ void ValueDecl::setType(Type T) {
 
 void ValueDecl::overwriteType(Type T) {
   TypeAndAccess.setPointer(T);
-  if (!T.isNull() && T->is<ErrorType>())
+  if (!T.isNull() && T->hasError())
     setInvalid();
 }
 
@@ -1926,14 +1926,14 @@ ValueDecl::getFormalAccessScope(const DeclContext *useDC) const {
 
 Type TypeDecl::getDeclaredType() const {
   if (auto TAD = dyn_cast<TypeAliasDecl>(this)) {
-    if (TAD->hasType() && TAD->getType()->is<ErrorType>())
+    if (TAD->hasType() && TAD->getType()->hasError())
       return TAD->getType();
 
     return TAD->getAliasType();
   }
   if (auto typeParam = dyn_cast<AbstractTypeParamDecl>(this)) {
     auto type = typeParam->getType();
-    if (type->is<ErrorType>())
+    if (type->hasError())
       return type;
 
     return type->castTo<MetatypeType>()->getInstanceType();
@@ -1946,7 +1946,7 @@ Type TypeDecl::getDeclaredType() const {
 
 Type TypeDecl::getDeclaredInterfaceType() const {
   Type interfaceType = getInterfaceType();
-  if (interfaceType.isNull() || interfaceType->is<ErrorType>())
+  if (interfaceType.isNull() || interfaceType->hasError())
     return interfaceType;
 
   return interfaceType->castTo<MetatypeType>()->getInstanceType();
@@ -2039,7 +2039,7 @@ void NominalTypeDecl::computeType() {
   // If we still don't have a declared type, don't crash -- there's a weird
   // circular declaration issue in the code.
   Type declaredTy = getDeclaredType();
-  if (!declaredTy || declaredTy->is<ErrorType>()) {
+  if (!declaredTy || declaredTy->hasError()) {
     setType(ErrorType::get(ctx));
     return;
   }
@@ -2071,7 +2071,7 @@ static Type computeNominalType(NominalTypeDecl *decl, DeclTypeKind kind) {
       Ty = dc->getDeclaredInterfaceType();
       break;
     }
-    if (!Ty || Ty->is<ErrorType>())
+    if (!Ty || Ty->hasError())
       return Ty;
   }
 
@@ -2812,7 +2812,7 @@ ProtocolDecl::findProtocolSelfReferences(const ValueDecl *value,
     return SelfReferenceKind::None();
 
   // Skip invalid declarations.
-  if (type->is<ErrorType>())
+  if (type->hasError())
     return SelfReferenceKind::None();
 
   if (isa<AbstractFunctionDecl>(value)) {
@@ -3783,7 +3783,7 @@ ParamDecl *ParamDecl::createUnboundSelf(SourceLoc loc, DeclContext *DC,
   // If we have a valid selfType (i.e. we're not in the parser before we
   // know such things, or we're nested inside an invalid extension),
   // configure it.
-  if (selfType && !selfType->is<ErrorType>()) {
+  if (selfType && !selfType->hasError()) {
     if (isStaticMethod)
       selfType = MetatypeType::get(selfType);
     
@@ -3882,7 +3882,7 @@ Type ParamDecl::getVarargBaseTy(Type VarArgT) {
     // It's the stdlib Array<T>.
     return BGT->getGenericArgs()[0];
   }
-  assert(isa<ErrorType>(T));
+  assert(T->hasError());
   return T;
 }
 
@@ -3957,7 +3957,7 @@ void SubscriptDecl::setIndices(ParameterList *p) {
 
 Type SubscriptDecl::getIndicesType() const {
   const auto type = getType();
-  if (type->is<ErrorType>())
+  if (type->hasError())
     return type;
   return type->castTo<AnyFunctionType>()->getInput();
 }
@@ -4052,7 +4052,7 @@ static Type getSelfTypeForContainer(AbstractFunctionDecl *theMethod,
 
   // If the self type couldn't be computed, or is the result of an
   // upstream error, return an error type.
-  if (!selfTy || selfTy->is<ErrorType>())
+  if (!selfTy || selfTy->hasError())
     return ErrorType::get(dc->getASTContext());
 
   // 'static' functions have 'self' of type metatype<T>.
@@ -4473,7 +4473,7 @@ Type FuncDecl::getResultType() const {
     return nullptr;
 
   Type resultTy = getType();
-  if (resultTy->is<ErrorType>())
+  if (resultTy->hasError())
     return resultTy;
 
   for (unsigned i = 0, e = getNumParameterLists(); i != e; ++i)
@@ -4628,7 +4628,7 @@ bool EnumElementDecl::computeType() {
   EnumDecl *ED = getParentEnum();
   Type resultTy = ED->getDeclaredTypeInContext();
 
-  if (resultTy->is<ErrorType>()) {
+  if (resultTy->hasError()) {
     setType(resultTy);
     return false;
   }
@@ -4654,7 +4654,7 @@ Type EnumElementDecl::getArgumentInterfaceType() const {
     return nullptr;
 
   auto interfaceType = getInterfaceType();
-  if (interfaceType->is<ErrorType>()) {
+  if (interfaceType->hasError()) {
     return interfaceType;
   }
 

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -55,7 +55,7 @@ DeclContext::getAsGenericTypeOrGenericTypeExtensionContext() const {
     auto ED = cast<ExtensionDecl>(this);
     auto type = ED->getExtendedType();
 
-    if (type.isNull() || type->is<ErrorType>())
+    if (type.isNull() || type->hasError())
       return nullptr;
 
     if (auto ND = type->getNominalOrBoundGenericNominal())
@@ -147,7 +147,7 @@ static Type computeExtensionType(const ExtensionDecl *ED, DeclTypeKind kind) {
     type = ED->getExtendedType();
   }
 
-  if (type->is<ErrorType>())
+  if (type->hasError())
     return type;
 
   switch (kind) {

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -61,7 +61,8 @@ Type GenericEnvironment::mapTypeOutOfContext(ModuleDecl *M, Type type) const {
 
 Type GenericEnvironment::mapTypeIntoContext(ModuleDecl *M, Type type) const {
   type = type.subst(M, InterfaceToArchetypeMap, SubstFlags::AllowLoweredTypes);
-  assert(!type->hasTypeParameter() && "not fully substituted");
+  assert((!type->hasTypeParameter() || type->hasError()) &&
+         "not fully substituted");
   return type;
 }
 

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -214,9 +214,9 @@ getSubstitutions(ModuleDecl &mod,
       }
 
       // Each witness marker starts a new substitution.
-      currentReplacement = req.getFirstType().subst(&mod, subs, SubstOptions());
+      currentReplacement = req.getFirstType().subst(&mod, subs);
       if (!currentReplacement)
-        currentReplacement = ErrorType::get(ctx);
+        currentReplacement = ErrorType::get(req.getFirstType());
 
       break;
     }

--- a/lib/AST/Mangle.cpp
+++ b/lib/AST/Mangle.cpp
@@ -250,7 +250,7 @@ void Mangler::mangleContext(const DeclContext *ctx) {
     auto ExtD = cast<ExtensionDecl>(ctx);
     auto ExtTy = ExtD->getExtendedType();
     // Recover from erroneous extension.
-    if (ExtTy.isNull() || ExtTy->is<ErrorType>())
+    if (ExtTy.isNull() || ExtTy->hasError())
       return mangleContext(ExtD->getDeclContext());
 
     auto decl = ExtTy->getAnyNominal();
@@ -388,7 +388,7 @@ static bool isInPrivateOrLocalContext(const ValueDecl *D) {
   }
 
   auto declaredType = DC->getDeclaredTypeOfContext();
-  if (!declaredType || declaredType->is<ErrorType>())
+  if (!declaredType || declaredType->hasError())
     return false;
 
   auto *nominal = declaredType->getAnyNominal();
@@ -507,7 +507,7 @@ Type Mangler::getDeclTypeForMangling(const ValueDecl *decl,
   }
 
   // Shed the 'self' type and generic requirements from method manglings.
-  if (isMethodDecl(decl) && type && !type->is<ErrorType>()) {
+  if (isMethodDecl(decl) && type && !type->hasError()) {
     // Drop the Self argument clause from the type.
     type = type->castTo<AnyFunctionType>()->getResult();
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -807,7 +807,7 @@ Module::lookupConformance(Type type, ProtocolDecl *protocol,
                                                         explicitConformanceDC);
       
       for (auto sub : substitutions) {
-        if (sub.getReplacement()->is<ErrorType>())
+        if (sub.getReplacement()->hasError())
           return None;
       }
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -609,7 +609,7 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
             lookupType = proto->getDeclaredType();
         }
 
-        if (!lookupType || lookupType->is<ErrorType>()) continue;
+        if (!lookupType || lookupType->hasError()) continue;
 
         // If we're performing a static lookup, use the metatype.
         // FIXME: This is awful. The client should filter, not us.
@@ -1156,7 +1156,7 @@ void NominalTypeDecl::addedMember(Decl *member) {
 
 void ExtensionDecl::addedMember(Decl *member) {
   if (NextExtension.getInt()) {
-    if (getExtendedType()->is<ErrorType>())
+    if (getExtendedType()->hasError())
       return;
 
     auto nominal = getExtendedType()->getAnyNominal();
@@ -1341,7 +1341,7 @@ bool DeclContext::lookupQualified(Type type,
   using namespace namelookup;
   assert(decls.empty() && "additive lookup not supported");
 
-  if (type->is<ErrorType>())
+  if (type->hasError())
     return false;
 
   auto checkLookupCascading = [this, options]() -> Optional<bool> {

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -390,7 +390,8 @@ SpecializedProtocolConformance::getTypeWitnessSubstAndDecl(
     assert((conforms ||
             specializedType->is<TypeVariableType>() ||
             specializedType->isTypeParameter() ||
-            specializedType->is<ErrorType>()) &&
+            specializedType->hasError() ||
+            specializedType->getCanonicalType()->hasError()) &&
            "Improperly checked substitution");
     conformances.push_back(conforms ? *conforms 
                                     : ProtocolConformanceRef(proto));

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1163,11 +1163,10 @@ CanType TypeBase::getCanonicalType() {
   case TypeKind::DependentMember: {
     auto dependent = cast<DependentMemberType>(this);
     auto base = dependent->getBase()->getCanonicalType();
-    const ASTContext &ctx = base->getASTContext();
     if (auto assocType = dependent->getAssocType())
-      Result = DependentMemberType::get(base, assocType, ctx);
+      Result = DependentMemberType::get(base, assocType);
     else
-      Result = DependentMemberType::get(base, dependent->getName(), ctx);
+      Result = DependentMemberType::get(base, dependent->getName());
     break;
   }
 
@@ -2776,11 +2775,9 @@ static Type getMemberForBaseType(ConformanceSource conformances,
   // If the parent is dependent, create a dependent member type.
   if (substBase->isTypeParameter()) {
     if (assocType)
-      return DependentMemberType::get(substBase, assocType,
-                                      substBase->getASTContext());
+      return DependentMemberType::get(substBase, assocType);
     else
-      return DependentMemberType::get(substBase, name,
-                                      substBase->getASTContext());
+      return DependentMemberType::get(substBase, name);
   }
 
   // If we know the associated type, look in the witness table.
@@ -3366,11 +3363,9 @@ case TypeKind::Id:
       return *this;
 
     if (auto assocType = dependent->getAssocType())
-      return DependentMemberType::get(dependentBase, assocType,
-                                      Ptr->getASTContext());
+      return DependentMemberType::get(dependentBase, assocType);
 
-    return DependentMemberType::get(dependentBase, dependent->getName(),
-                                    Ptr->getASTContext());
+    return DependentMemberType::get(dependentBase, dependent->getName());
   }
 
   case TypeKind::Substituted: {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -37,7 +37,7 @@ using namespace swift;
 
 bool TypeLoc::isError() const {
   assert(wasValidated() && "Type not yet validated");
-  return getType()->is<ErrorType>();
+  return getType()->hasError() || getType()->getCanonicalType()->hasError();
 }
 
 SourceRange TypeLoc::getSourceRange() const {
@@ -2834,6 +2834,9 @@ static Type getMemberForBaseType(ConformanceSource conformances,
         if (!aliasType->is<ErrorType>())
           witness = aliasType->getSinglyDesugaredType();
 
+    if (witness->is<ErrorType>())
+      return failed();
+
     return witness;
   }
 
@@ -3542,7 +3545,7 @@ case TypeKind::Id:
   case TypeKind::LValue: {
     auto lvalue = cast<LValueType>(base);
     auto objectTy = lvalue->getObjectType().transform(fn);
-    if (!objectTy || objectTy->is<ErrorType>())
+    if (!objectTy || objectTy->hasError())
       return objectTy;
 
     return objectTy.getPointer() == lvalue->getObjectType().getPointer() ?
@@ -3552,7 +3555,7 @@ case TypeKind::Id:
   case TypeKind::InOut: {
     auto inout = cast<InOutType>(base);
     auto objectTy = inout->getObjectType().transform(fn);
-    if (!objectTy || objectTy->is<ErrorType>())
+    if (!objectTy || objectTy->hasError())
       return objectTy;
     
     return objectTy.getPointer() == inout->getObjectType().getPointer() ?

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2727,8 +2727,8 @@ GenericFunctionType::substGenericArgs(ArrayRef<Substitution> args) {
   
   auto subs = getGenericSignature()->getSubstitutionMap(args);
 
-  Type input = getInput().subst(subs, SubstFlags::IgnoreMissing);
-  Type result = getResult().subst(subs, SubstFlags::IgnoreMissing);
+  Type input = getInput().subst(subs);
+  Type result = getResult().subst(subs);
   return FunctionType::get(input, result, getExtInfo());
 }
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1982,7 +1982,7 @@ public:
         auto Subs = MaybeNominalType->getMemberSubstitutions(
             VD->getDeclContext());
         T = T.subst(M, Subs, (SubstFlags::DesugarMemberTypes |
-                              SubstFlags::IgnoreMissing));
+                              SubstFlags::UseErrorType));
       }
     }
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -393,18 +393,18 @@ static void eraseErrorTypes(Expr *E) {
   assert(E);
   struct Eraser : public ASTWalker {
     std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
-      if (expr && expr->getType() && expr->getType()->is<ErrorType>())
+      if (expr && expr->getType() && expr->getType()->hasError())
         expr->setType(Type());
       return { true, expr };
     }
     bool walkToTypeLocPre(TypeLoc &TL) override {
-      if (TL.getType() && TL.getType()->is<ErrorType>())
+      if (TL.getType() && TL.getType()->hasError())
         TL.setType(Type(), /*was validated*/false);
       return true;
     }
 
     std::pair<bool, Pattern*> walkToPatternPre(Pattern *P) override {
-      if (P && P->hasType() && P->getType()->is<ErrorType>()) {
+      if (P && P->hasType() && P->getType()->hasError()) {
         P->setType(Type());
       }
       return { true, P };
@@ -2380,11 +2380,12 @@ public:
       FirstIndex = 1;
     Type FunctionType = getTypeOfMember(FD);
     assert(FunctionType);
-    if (FirstIndex != 0 && !FunctionType->is<ErrorType>())
+    if (FirstIndex != 0 && FunctionType->is<AnyFunctionType>())
       FunctionType = FunctionType->castTo<AnyFunctionType>()->getResult();
 
     bool trivialTrailingClosure = false;
-    if (!IsImplicitlyCurriedInstanceMethod && !FunctionType->is<ErrorType>()) {
+    if (!IsImplicitlyCurriedInstanceMethod &&
+        FunctionType->is<AnyFunctionType>()) {
       trivialTrailingClosure = hasTrivialTrailingClosure(
           FD, FunctionType->castTo<AnyFunctionType>());
     }
@@ -2407,7 +2408,7 @@ public:
 
       llvm::SmallString<32> TypeStr;
 
-      if (FunctionType->is<ErrorType>()) {
+      if (!FunctionType->is<AnyFunctionType>()) {
         llvm::raw_svector_ostream OS(TypeStr);
         FunctionType.print(OS);
         Builder.addTypeAnnotation(OS.str());
@@ -2454,7 +2455,7 @@ public:
       Builder.addTypeAnnotation(TypeStr);
     };
 
-    if (!FunctionType->is<ErrorType>() &&
+    if (FunctionType->is<AnyFunctionType>() &&
         hasInterestingDefaultValues(FD)) {
       addMethodImpl(/*includeDefaultArgs*/ false);
     }
@@ -2472,10 +2473,9 @@ public:
     foundFunction(CD);
     Type MemberType = getTypeOfMember(CD, BaseType);
     AnyFunctionType *ConstructorType = nullptr;
-    if (!MemberType->is<ErrorType>())
-      ConstructorType = MemberType->castTo<AnyFunctionType>()
-                            ->getResult()
-                            ->castTo<AnyFunctionType>();
+    if (auto MemberFuncType = MemberType->getAs<AnyFunctionType>())
+      ConstructorType = MemberFuncType->getResult()
+                                      ->castTo<AnyFunctionType>();
 
     bool needInit = false;
     if (!IsOnMetatype) {
@@ -2508,10 +2508,10 @@ public:
       } else if (!addName.empty()) {
         Builder.addTextChunk(addName.str());
       } else {
-        assert(!MemberType->is<ErrorType>() && "will insert empty result");
+        assert(!MemberType->hasError() && "will insert empty result");
       }
 
-      if (MemberType->is<ErrorType>()) {
+      if (!ConstructorType) {
         addTypeAnnotation(Builder, MemberType);
         return;
       }

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -342,7 +342,7 @@ public:
     if (!base->isTypeParameter())
       return Type();
     // TODO: look up protocol?
-    return DependentMemberType::get(base, Ctx.getIdentifier(member), Ctx);
+    return DependentMemberType::get(base, Ctx.getIdentifier(member));
   }
 
   Type createUnownedStorageType(Type base) {

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1755,10 +1755,8 @@ substSelfTypeIntoProtocolRequirementType(SILModule &M,
         continue;
 
       // Substitute the constrained types.
-      auto first = reqt.getFirstType().subst(subs, SubstFlags::IgnoreMissing)
-          ->getCanonicalType();
-      auto second = reqt.getSecondType().subst(subs, SubstFlags::IgnoreMissing)
-          ->getCanonicalType();
+      auto first = reqt.getFirstType().subst(subs)->getCanonicalType();
+      auto second = reqt.getSecondType().subst(subs)->getCanonicalType();
 
       if (!first->isTypeParameter()) {
         assert(second->isTypeParameter());
@@ -1773,10 +1771,8 @@ substSelfTypeIntoProtocolRequirementType(SILModule &M,
   }
 
   // Substitute away `Self` in parameter and result types.
-  auto input = reqtTy->getInput().subst(subs, SubstFlags::IgnoreMissing)
-    ->getCanonicalType();
-  auto result = reqtTy->getResult().subst(subs, SubstFlags::IgnoreMissing)
-    ->getCanonicalType();
+  auto input = reqtTy->getInput().subst(subs)->getCanonicalType();
+  auto result = reqtTy->getResult().subst(subs)->getCanonicalType();
 
   // The result might be fully concrete, if the witness had no generic
   // signature, and the requirement had no additional generic parameters

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -127,14 +127,14 @@ Type Solution::computeSubstitutions(
                       &conformance);
     (void)isOpenedAnyObject;
     assert((conforms ||
-            replacement->is<ErrorType>() ||
+            replacement->hasError() ||
             isOpenedAnyObject(replacement) ||
             replacement->is<GenericTypeParamType>()) &&
            "Constraint system missed a conformance?");
     (void)conforms;
 
     assert(conformance ||
-           replacement->is<ErrorType>() ||
+           replacement->hasError() ||
            replacement->hasDependentProtocolConformances());
 
     return ProtocolConformanceRef(protoType->getDecl(), conformance);
@@ -5840,7 +5840,7 @@ Expr *ExprRewriter::convertLiteral(Expr *literal,
       return nullptr;
 
     // If the argument type is in error, we're done.
-    if (argType->is<ErrorType>())
+    if (argType->hasError() || argType->getCanonicalType()->hasError())
       return nullptr;
 
     // Convert the literal to the non-builtin argument type via the

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2896,7 +2896,7 @@ namespace {
         = solution.convertBooleanTypeToBuiltinI1(expr->getCondExpr(),
                                                  cs.getConstraintLocator(expr));
       if (!cond) {
-        expr->getCondExpr()->setType(ErrorType::get(cs.getASTContext()));
+        expr->getCondExpr()->setType(ErrorType::get(resultTy));
       } else {
         expr->setCondExpr(cond);
       }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3141,8 +3141,7 @@ bool swift::isExtensionApplied(DeclContext &DC, Type BaseTy,
   // Prepare type substitution map.
   TypeSubstitutionMap Substitutions = BaseTy->getMemberSubstitutions(ED);
   auto resolveType = [&](Type Ty) {
-    return Ty.subst(DC.getParentModule(), Substitutions,
-                    SubstFlags::IgnoreMissing);
+    return Ty.subst(DC.getParentModule(), Substitutions);
   };
 
   auto createMemberConstraint = [&](Requirement &Req, ConstraintKind Kind) {

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3193,9 +3193,7 @@ static bool canSatisfy(Type T1, Type T2, DeclContext &DC, ConstraintKind Kind,
   ConstraintSystem CS(*TC, &DC, None);
   if (ReplaceArchetypeWithVariables) {
     std::function<Type(Type)> Trans = [&](Type Base) {
-      if (isa<GenericTypeParamType>(Base.getPointer()) ||
-          isa<DependentMemberType>(Base.getPointer()) ||
-          isa<ArchetypeType>(Base.getPointer())) {
+      if (Base->isTypeParameter() || isa<ArchetypeType>(Base.getPointer())) {
         return Type(CS.createTypeVariable(CS.getConstraintLocator(nullptr),
                                     TypeVariableOptions::TVO_CanBindToLValue));
       }

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1562,13 +1562,13 @@ void ConstraintSystem::shrink(Expr *expr) {
     /// \returns ErrorType on failure, properly constructed type otherwise.
     Type extractElementType(Type collection) {
       auto &ctx = CS.getASTContext();
-      if (collection.isNull() || collection->is<ErrorType>())
+      if (collection.isNull() || collection->hasError())
         return ErrorType::get(ctx);
 
       auto base = collection.getPointer();
       auto isInvalidType = [](Type type) -> bool {
         return type.isNull() || type->hasUnresolvedType() ||
-               type->is<ErrorType>();
+               type->hasError();
       };
 
       // Array type.

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1246,7 +1246,7 @@ static bool tryTypeVariableBindings(
     // Enumerate the supertypes of each of the types we tried.
     for (auto binding : bindings) {
       const auto type = binding.BindingType;
-      if (type->is<ErrorType>())
+      if (type->hasError())
         continue;
 
       // After our first pass, note that we've explored these
@@ -1651,7 +1651,7 @@ void ConstraintSystem::shrink(Expr *expr) {
                                                   TypeResolutionOptions());
 
             // Looks like coercion type is invalid, let's skip this sub-tree.
-            if (coercionType->is<ErrorType>())
+            if (coercionType->hasError())
               return nullptr;
 
             // Visit collection expression inline.
@@ -1680,7 +1680,7 @@ void ConstraintSystem::shrink(Expr *expr) {
         auto elementType = extractElementType(contextualType);
         // If we couldn't deduce element type for the collection, let's
         // not attempt to solve it.
-        if (elementType->is<ErrorType>())
+        if (elementType->hasError())
           return;
 
         contextualType = elementType;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -562,7 +562,7 @@ namespace {
         // dependency that isn't being diagnosed properly.
         if (!unboundDecl->getGenericSignature()) {
           cs.TC.diagnose(unboundDecl, diag::circular_reference);
-          return ErrorType::get(cs.getASTContext());
+          return ErrorType::get(type);
         }
         
         

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1326,7 +1326,7 @@ ConstraintSystem::getTypeOfMemberReference(
       if (!isClassBoundExistential &&
           !selfTy->hasReferenceSemantics() &&
           baseTy->is<LValueType>() &&
-          !selfTy->is<ErrorType>())
+          !selfTy->hasError())
         selfTy = InOutType::get(selfTy);
 
       openedType = FunctionType::get(selfTy, openedType);

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -346,14 +346,14 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
       /// Diagnose a '_' that isn't on the immediate LHS of an assignment.
       if (auto *DAE = dyn_cast<DiscardAssignmentExpr>(E)) {
         if (!CorrectDiscardAssignmentExprs.count(DAE) &&
-            !DAE->getType()->is<ErrorType>())
+            !DAE->getType()->hasError())
           TC.diagnose(DAE->getLoc(), diag::discard_expr_outside_of_assignment);
       }
 
       // Diagnose an '&' that isn't in an argument lists.
       if (auto *IOE = dyn_cast<InOutExpr>(E)) {
         if (!IOE->isImplicit() && !AcceptableInOutExprs.count(IOE) &&
-            !IOE->getType()->is<ErrorType>())
+            !IOE->getType()->hasError())
           TC.diagnose(IOE->getLoc(), diag::inout_expr_outside_of_call)
             .highlight(IOE->getSubExpr()->getSourceRange());
       }
@@ -2272,7 +2272,7 @@ bool AvailabilityWalker::diagnoseMemoryLayoutMigration(const ValueDecl *D,
   StringRef Suffix = ">.";
   if (isValue) {
     auto valueType = subject->getType()->getRValueType();
-    if (!valueType || valueType->is<ErrorType>()) {
+    if (!valueType || valueType->hasError()) {
       // If we don't have a suitable argument, we cannot emit a fix-it.
       return true;
     }
@@ -2698,7 +2698,7 @@ markBaseOfAbstractStorageDeclStore(Expr *base, ConcreteDeclRef decl) {
 void VarDeclUsageChecker::markStoredOrInOutExpr(Expr *E, unsigned Flags) {
   // Sema leaves some subexpressions null, which seems really unfortunate.  It
   // should replace them with ErrorExpr.
-  if (E == nullptr || !E->getType() || E->getType()->is<ErrorType>()) {
+  if (E == nullptr || !E->getType() || E->getType()->hasError()) {
     sawError = true;
     return;
   }
@@ -2766,7 +2766,7 @@ void VarDeclUsageChecker::markStoredOrInOutExpr(Expr *E, unsigned Flags) {
 std::pair<bool, Expr *> VarDeclUsageChecker::walkToExprPre(Expr *E) {
   // Sema leaves some subexpressions null, which seems really unfortunate.  It
   // should replace them with ErrorExpr.
-  if (E == nullptr || !E->getType() || E->getType()->is<ErrorType>()) {
+  if (E == nullptr || !E->getType() || E->getType()->hasError()) {
     sawError = true;
     return { false, E };
   }
@@ -3167,7 +3167,7 @@ static void checkStmtConditionTrailingClosure(TypeChecker &TC, const Expr *E) {
       auto argsExpr = E->getArg();
       auto argsTy = argsExpr->getType();
       // Ignore invalid argument type. Some diagnostics are already emitted.
-      if (!argsTy || argsTy->is<ErrorType>()) return;
+      if (!argsTy || argsTy->hasError()) return;
 
       if (auto TSE = dyn_cast<TupleShuffleExpr>(argsExpr))
         argsExpr = TSE->getSubExpr();

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -454,7 +454,7 @@ public:
   public:
     ErrorFinder () { }
     virtual std::pair<bool, Expr*> walkToExprPre(Expr *E) {
-      if (isa<ErrorExpr>(E) || !E->getType() || E->getType()->is<ErrorType>()) {
+      if (isa<ErrorExpr>(E) || !E->getType() || E->getType()->hasError()) {
         error = true;
         return { false, E };
       }
@@ -462,7 +462,7 @@ public:
     }
     virtual bool walkToDeclPre(Decl *D) {
       if (ValueDecl *VD = dyn_cast<ValueDecl>(D)) {
-        if (!VD->getType() || VD->getType()->is<ErrorType>()) {
+        if (!VD->getType() || VD->getType()->hasError()) {
           error = true;
           return false;
         }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1287,7 +1287,7 @@ void AttributeChecker::visitRequiredAttr(RequiredAttr *attr) {
       return;
     }
   } else {
-    if (!parentTy->is<ErrorType>()) {
+    if (!parentTy->hasError()) {
       TC.diagnose(ctor, diag::required_initializer_nonclass, parentTy)
         .highlight(attr->getLocation());
     }
@@ -1312,7 +1312,7 @@ static bool hasThrowingFunctionParameter(CanType type) {
   }
 
   // Suppress diagnostics in the presence of errors.
-  if (isa<ErrorType>(type)) {
+  if (type->hasError()) {
     return true;
   }
 
@@ -1441,7 +1441,7 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
     auto &tl = attr->getTypeLocs()[paramIdx];
 
     auto ty = TC.resolveType(tl.getTypeRepr(), DC, None);
-    if (ty && !ty->is<ErrorType>()) {
+    if (ty && !ty->hasError()) {
       if (ty->getCanonicalType()->hasArchetype()) {
         TC.diagnose(attr->getLocation(),
                     diag::cannot_partially_specialize_generic_function);

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -413,7 +413,7 @@ public:
     if (!AFR.isObjC())
       return true;
 
-    if (!E->getType() || E->getType()->is<ErrorType>())
+    if (!E->getType() || E->getType()->hasError())
       return false;
 
     // We can use Objective-C generics in limited ways without reifying

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2991,8 +2991,7 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
           FunctionType::get(TC.Context.TheEmptyTupleType, storageTy);
         Type valueTy = DependentMemberType::get(
                                           behaviorProto->getSelfInterfaceType(),
-                                          valueReqt,
-                                          TC.Context);
+                                          valueReqt);
         
         auto expectedParameterizedInitStorageTy =
           FunctionType::get(valueTy, storageTy);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -374,7 +374,7 @@ void TypeChecker::checkInheritanceClause(Decl *decl,
     auto inheritedTy = inherited.getType();
 
     // If this is an error type, ignore it.
-    if (inheritedTy->is<ErrorType>())
+    if (inheritedTy->hasError())
       continue;
 
     // Retrieve the interface type for this inherited type.
@@ -693,7 +693,7 @@ static void setBoundVarsTypeError(Pattern *pattern, ASTContext &ctx) {
   pattern->forEachVariable([&](VarDecl *var) {
     // Don't change the type of a variable that we've been able to
     // compute a type for.
-    if (var->hasType() && !var->getType()->is<ErrorType>())
+    if (var->hasType() && !var->getType()->hasError())
       return;
 
     var->overwriteType(ErrorType::get(ctx));
@@ -1276,7 +1276,7 @@ void TypeChecker::computeDefaultAccessibility(ExtensionDecl *ED) {
   Accessibility maxAccess = Accessibility::Public;
 
   if (!ED->getExtendedType().isNull() &&
-      !ED->getExtendedType()->is<ErrorType>()) {
+      !ED->getExtendedType()->hasError()) {
     if (NominalTypeDecl *nominal = ED->getExtendedType()->getAnyNominal()) {
       validateDecl(nominal);
       maxAccess = std::max(nominal->getFormalAccess(),
@@ -2617,7 +2617,7 @@ static void checkEnumRawValues(TypeChecker &TC, EnumDecl *ED) {
 
   if (ED->getGenericEnvironmentOfContext() != nullptr)
     rawTy = ArchetypeBuilder::mapTypeIntoContext(ED, rawTy);
-  if (rawTy->is<ErrorType>())
+  if (rawTy->hasError())
     return;
 
   AutomaticEnumValueKind valueKind;
@@ -2809,7 +2809,7 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
     return;
   
   // Don't try to check the behavior if we already encountered an error.
-  if (decl->getType()->is<ErrorType>())
+  if (decl->getType()->hasError())
     return;
   
   auto behavior = decl->getMutableBehavior() ;
@@ -3650,7 +3650,7 @@ public:
         if (PBD->getPattern(i)->hasType() &&
             !PBD->getInit(i) &&
             PBD->getPattern(i)->hasStorage() &&
-            !PBD->getPattern(i)->getType()->is<ErrorType>()) {
+            !PBD->getPattern(i)->getType()->hasError()) {
 
           // If we have a type-adjusting attribute (like ownership), apply it now.
           if (auto var = PBD->getSingleVar())
@@ -4654,7 +4654,7 @@ public:
     // 'Self' is only a dynamic self on class methods and
     // protocol requirements.
     auto declaredType = dc->getDeclaredTypeOfContext();
-    if (declaredType->is<ErrorType>())
+    if (declaredType->hasError())
       return false;
 
     auto nominal = declaredType->getAnyNominal();
@@ -5290,7 +5290,7 @@ public:
 
     {
       Type baseTy = base->getInterfaceType();
-      if (baseTy->is<ErrorType>())
+      if (baseTy->hasError())
         return false;
 
       Optional<InFlightDiagnostic> activeDiag;
@@ -6368,7 +6368,7 @@ public:
       if (auto extendedTy = ED->getExtendedType()) {
         if (!extendedTy->is<NominalType>() &&
             !extendedTy->is<BoundGenericType>() &&
-            !extendedTy->is<ErrorType>()) {
+            !extendedTy->hasError()) {
           // FIXME: Redundant diagnostic test here?
           TC.diagnose(ED->getStartLoc(), diag::non_nominal_extension,
                       extendedTy);
@@ -6477,7 +6477,7 @@ public:
           TC.diagnose(CD->getLoc(), diag::cfclass_convenience_init);
         }
 
-        if (!extClass && !extType->is<ErrorType>()) {
+        if (!extClass && !extType->hasError()) {
           auto ConvenienceLoc =
             CD->getAttrs().getAttribute<ConvenienceAttr>()->getLocation();
 
@@ -7589,7 +7589,7 @@ void TypeChecker::validateExtension(ExtensionDecl *ext) {
   // within a generic type.
   auto extendedType = ext->getExtendedType();
 
-  if (extendedType.isNull() || extendedType->is<ErrorType>())
+  if (extendedType.isNull() || extendedType->hasError())
     return;
 
   if (auto unbound = extendedType->getAs<UnboundGenericType>()) {

--- a/lib/Sema/TypeCheckError.cpp
+++ b/lib/Sema/TypeCheckError.cpp
@@ -392,7 +392,7 @@ public:
   Classification classifyApply(ApplyExpr *E) {
     // An apply expression is a potential throw site if the function throws.
     // But if the expression didn't type-check, suppress diagnostics.
-    if (!E->getType() || E->getType()->is<ErrorType>())
+    if (!E->getType() || E->getType()->hasError())
       return Classification::forInvalidCode();
     auto type = E->getFn()->getType();
     if (!type) return Classification::forInvalidCode();
@@ -408,7 +408,7 @@ public:
 
     // If any of the arguments didn't type check, fail.
     for (auto arg : args) {
-      if (!arg->getType() || arg->getType()->is<ErrorType>())
+      if (!arg->getType() || arg->getType()->hasError())
         return Classification::forInvalidCode();
     }
 
@@ -790,7 +790,7 @@ private:
   /// 'rethrows' function to throw.
   static Classification classifyArgumentByType(Type paramType,
                                                PotentialReason reason) {
-    if (!paramType || paramType->is<ErrorType>())
+    if (!paramType || paramType->hasError())
       return Classification::forInvalidCode();
     if (auto fnType = paramType->getAs<AnyFunctionType>()) {
       if (fnType->throws()) {

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -74,7 +74,7 @@ static void substituteInputSugarArgumentType(Type argTy, CanType resultTy,
 /// an apply, do so.
 ///
 Expr *TypeChecker::substituteInputSugarTypeForResult(ApplyExpr *E) {
-  if (!E->getType() || E->getType()->is<ErrorType>())
+  if (!E->getType() || E->getType()->hasError())
     return E;
   
   Type resultTy = E->getFn()->getType()->castTo<FunctionType>()->getResult();

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -128,7 +128,7 @@ Type PartialGenericTypeToArchetypeResolver::resolveDependentMemberType(
                                               ComponentIdentTypeRepr *ref) {
   // We don't have enough information to find the associated type.
   // FIXME: Nonsense, but we shouldn't need this code anyway.
-  return DependentMemberType::get(baseTy, ref->getIdentifier(), DC->getASTContext());
+  return DependentMemberType::get(baseTy, ref->getIdentifier());
 }
 
 Type PartialGenericTypeToArchetypeResolver::resolveSelfAssociatedType(
@@ -137,7 +137,7 @@ Type PartialGenericTypeToArchetypeResolver::resolveSelfAssociatedType(
        AssociatedTypeDecl *assocType) {
   // We don't have enough information to find the associated type.
   // FIXME: Nonsense, but we shouldn't need this code anyway.
-  return DependentMemberType::get(selfTy, assocType, DC->getASTContext());
+  return DependentMemberType::get(selfTy, assocType);
 }
 
 Type
@@ -199,7 +199,7 @@ Type CompleteGenericTypeResolver::resolveDependentMemberType(
 
   // If the nested type has been resolved to an associated type, use it.
   if (auto assocType = nestedPA->getResolvedAssociatedType()) {
-    return DependentMemberType::get(baseTy, assocType, TC.Context);
+    return DependentMemberType::get(baseTy, assocType);
   }
 
   // If the nested type comes from a type alias, use either the alias's

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -979,8 +979,7 @@ bool TypeChecker::checkGenericArguments(DeclContext *dc, SourceLoc loc,
   // Check each of the requirements.
   Module *module = dc->getParentModule();
   for (const auto &req : genericSig->getRequirements()) {
-    Type firstType = req.getFirstType().subst(module, substitutions,
-                                              SubstFlags::IgnoreMissing);
+    Type firstType = req.getFirstType().subst(module, substitutions);
     if (firstType.isNull()) {
       // Another requirement will fail later; just continue.
       continue;
@@ -988,8 +987,7 @@ bool TypeChecker::checkGenericArguments(DeclContext *dc, SourceLoc loc,
 
     Type secondType = req.getSecondType();
     if (secondType) {
-      secondType = secondType.subst(module, substitutions,
-                                    SubstFlags::IgnoreMissing);
+      secondType = secondType.subst(module, substitutions);
       if (secondType.isNull()) {
         // Another requirement will fail later; just continue.
         continue;

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -652,7 +652,7 @@ static bool validateTypedPattern(TypeChecker &TC, DeclContext *DC,
                                  TypeResolutionOptions options,
                                  GenericTypeResolver *resolver) {
   if (TP->hasType())
-    return TP->getType()->is<ErrorType>();
+    return TP->getType()->hasError();
 
   TypeLoc &TL = TP->getTypeLoc();
   bool hadError = TC.validateType(TL, DC, options, resolver);
@@ -737,7 +737,7 @@ static bool validateParameterType(ParamDecl *decl, DeclContext *DC,
                                   GenericTypeResolver *resolver,
                                   TypeChecker &TC) {
   if (auto ty = decl->getTypeLoc().getType())
-    return ty->is<ErrorType>();
+    return ty->hasError();
 
   // If the element is a variadic parameter, resolve the parameter type as if
   // it were in non-parameter position, since we want functions to be
@@ -1057,7 +1057,7 @@ bool TypeChecker::coercePatternToType(Pattern *&P, DeclContext *dc, Type type,
     TypedPattern *TP = cast<TypedPattern>(P);
     bool hadError = validateTypedPattern(*this, dc, TP, options, resolver);
     if (!hadError) {
-      if (!type->isEqual(TP->getType()) && !type->is<ErrorType>()) {
+      if (!type->isEqual(TP->getType()) && !type->hasError()) {
         if (options & TR_OverrideType) {
           TP->overwriteType(type);
         } else {
@@ -1140,7 +1140,7 @@ bool TypeChecker::coercePatternToType(Pattern *&P, DeclContext *dc, Type type,
   // TODO: permit implicit conversions?
   case PatternKind::Tuple: {
     TuplePattern *TP = cast<TuplePattern>(P);
-    bool hadError = type->is<ErrorType>();
+    bool hadError = type->hasError();
     
     // Sometimes a paren is just a paren. If the tuple pattern has a single
     // element, we can reduce it to a paren pattern.
@@ -1289,7 +1289,7 @@ bool TypeChecker::coercePatternToType(Pattern *&P, DeclContext *dc, Type type,
                              IP->getLoc(),
                              IP->getLoc(),IP->getCastTypeLoc().getSourceRange(),
                              [](Type) { return false; },
-                             /*suppressDiagnostics=*/ type->is<ErrorType>());
+                             /*suppressDiagnostics=*/ type->hasError());
     switch (castKind) {
     case CheckedCastKind::Unresolved:
       return false;
@@ -1348,7 +1348,7 @@ bool TypeChecker::coercePatternToType(Pattern *&P, DeclContext *dc, Type type,
                                       EEP->getLoc());
       }
       if (!elt) {
-        if (!type->is<ErrorType>()) {
+        if (!type->hasError()) {
           // Lowercasing of Swift.Optional's cases is handled in the
           // standard library itself, not through the clang importer,
           // so we have to do this check here. Additionally, .Some
@@ -1508,7 +1508,7 @@ bool TypeChecker::coercePatternToType(Pattern *&P, DeclContext *dc, Type type,
 bool TypeChecker::coerceParameterListToType(ParameterList *P, ClosureExpr *CE,
                                             AnyFunctionType *FN) {
   Type paramListType = FN->getInput();
-  bool hadError = paramListType->is<ErrorType>();
+  bool hadError = paramListType->hasError();
 
   // Sometimes a scalar type gets applied to a single-argument parameter list.
   auto handleParameter = [&](ParamDecl *param, Type ty) -> bool {
@@ -1522,7 +1522,7 @@ bool TypeChecker::coerceParameterListToType(ParameterList *P, ClosureExpr *CE,
       // Now that we've type checked the explicit argument type, see if it
       // agrees with the contextual type.
       if (!hadError && !ty->isEqual(param->getTypeLoc().getType()) &&
-          !ty->is<ErrorType>())
+          !ty->hasError())
         param->overwriteType(ty);
     }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3042,8 +3042,7 @@ void ConformanceChecker::resolveTypeWitnesses() {
     TC.validateDecl(assocType);
     Type defaultType = assocType->getDefaultDefinitionLoc().getType().subst(
                          DC->getParentModule(),
-                         substitutions,
-                         SubstFlags::IgnoreMissing);
+                         substitutions);
     if (!defaultType)
       return Type();
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1826,7 +1826,8 @@ static Substitution getArchetypeSubstitution(TypeChecker &tc,
   assert(!resultReplacement->isTypeParameter() && "Can't be dependent");
   SmallVector<ProtocolConformanceRef, 4> conformances;
 
-  bool isError = replacement->is<ErrorType>();
+  bool isError =
+    replacement->hasError() || replacement->getCanonicalType()->hasError();
   assert((archetype != nullptr || isError) &&
          "Should have built archetypes already");
 
@@ -1954,7 +1955,7 @@ void ConformanceChecker::recordTypeWitness(AssociatedTypeDecl *assocType,
     // happen when type-checking a different conformance deduces a
     // different type witness with the same name. For non-error cases,
     // the caller handles this.
-    if (performRedeclarationCheck && type->is<ErrorType>()) {
+    if (performRedeclarationCheck && type->hasError()) {
       switch (resolveTypeWitnessViaLookup(assocType)) {
       case ResolveWitnessResult::Success:
       case ResolveWitnessResult::ExplicitFailed:
@@ -1976,7 +1977,7 @@ void ConformanceChecker::recordTypeWitness(AssociatedTypeDecl *assocType,
                                                     DC);
     aliasDecl->computeType();
     aliasDecl->setImplicit();
-    if (type->is<ErrorType>()) {
+    if (type->hasError()) {
       aliasDecl->setInvalid();
 
       // If we're recording a failed type witness, keep the sugar around for
@@ -2133,7 +2134,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
   // this value witness: it will fail.
   for (auto assocType : getReferencedAssociatedTypes(requirement)) {
     if (Conformance->getTypeWitness(assocType, nullptr).getReplacement()
-          ->is<ErrorType>()) {
+          ->hasError()) {
       return ResolveWitnessResult::ExplicitFailed;
     }
   }
@@ -2608,7 +2609,7 @@ ResolveWitnessResult ConformanceChecker::resolveTypeWitnessViaLookup(
       tc.diagnose(assocType, diag::no_witnesses_type, assocType->getName());
 
       for (auto candidate : nonViable) {
-        if (candidate.first->getDeclaredType()->is<ErrorType>())
+        if (candidate.first->getDeclaredType()->hasError())
           continue;
 
         tc.diagnose(candidate.first,
@@ -2638,7 +2639,7 @@ ConformanceChecker::inferTypeWitnessesViaValueWitnesses(ValueDecl *req) {
                      witnessResult.Inferred.end(),
                      [&](const std::pair<AssociatedTypeDecl *, Type> &result) {
                        // Filter out errors.
-                       if (result.second->is<ErrorType>())
+                       if (result.second->hasError())
                          return true;
 
                        // Filter out duplicates.
@@ -3085,7 +3086,7 @@ void ConformanceChecker::resolveTypeWitnesses() {
   // Local function to compute the derived type of an associated type,
   // for protocols known to the compiler.
   auto computeDerivedTypeWitness = [&](AssociatedTypeDecl *assocType) -> Type {
-    if (Adoptee->is<ErrorType>())
+    if (Adoptee->hasError())
       return Type();
 
     // UnresolvedTypes propagated their unresolvedness to any witnesses.
@@ -3213,7 +3214,7 @@ void ConformanceChecker::resolveTypeWitnesses() {
         auto typeWitness = typeWitnesses.begin(assocType);
         if (typeWitness != typeWitnesses.end()) {
           // The solution contains an error.
-          if (typeWitness->first->is<ErrorType>()) {
+          if (typeWitness->first->hasError()) {
             recordMissing();
             return;
           }
@@ -3225,7 +3226,7 @@ void ConformanceChecker::resolveTypeWitnesses() {
 
         // If we can form a default type, do so.
         if (Type defaultType = computeDefaultTypeWitness(assocType)) {
-          if (defaultType->is<ErrorType>()) {
+          if (defaultType->hasError()) {
             recordMissing();
             return;
           }
@@ -3236,7 +3237,7 @@ void ConformanceChecker::resolveTypeWitnesses() {
 
         // If we can derive a type witness, do so.
         if (Type derivedType = computeDerivedTypeWitness(assocType)) {
-          if (derivedType->is<ErrorType>()) {
+          if (derivedType->hasError()) {
             recordMissing();
             return;
           }
@@ -3712,7 +3713,7 @@ void ConformanceChecker::resolveSingleWitness(ValueDecl *requirement) {
   // this value witness: it will fail.
   for (auto assocType : getReferencedAssociatedTypes(requirement)) {
     if (Conformance->getTypeWitness(assocType, nullptr).getReplacement()
-          ->is<ErrorType>()) {
+          ->hasError()) {
       Conformance->setInvalid();
       return;
     }
@@ -4027,7 +4028,7 @@ static void diagnoseConformanceFailure(TypeChecker &TC, Type T,
                                        ProtocolDecl *Proto,
                                        DeclContext *DC,
                                        SourceLoc ComplainLoc) {
-  if (T->is<ErrorType>())
+  if (T->hasError() || T->getCanonicalType()->hasError())
     return;
 
   // If we're checking conformance of an existential type to a protocol,

--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -289,7 +289,7 @@ void REPLChecker::processREPLTopLevelExpr(Expr *E) {
   CanType T = E->getType()->getCanonicalType();
 
   // Don't try to print invalid expressions, module exprs, or void expressions.
-  if (isa<ErrorType>(T) || isa<ModuleType>(T) || T->isVoid())
+  if (T->hasError() || isa<ModuleType>(T) || T->isVoid())
     return;
 
   // Okay, we need to print this expression.  We generally do this by creating a

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -390,7 +390,7 @@ public:
     }
 
     Type ResultTy = TheFunc->getBodyResultType();
-    if (!ResultTy || ResultTy->is<ErrorType>())
+    if (!ResultTy || ResultTy->hasError())
       return nullptr;
 
     if (!RS->hasResult()) {
@@ -1003,7 +1003,7 @@ bool TypeChecker::typeCheckCatchPattern(CatchStmt *S, DeclContext *DC) {
 }
 
 static bool isDiscardableType(Type type) {
-  return (type->is<ErrorType>() ||
+  return (type->hasError() ||
           type->isUninhabited() ||
           type->lookThroughAllAnyOptionalTypes()->isVoid());
 }
@@ -1211,7 +1211,7 @@ static void checkDefaultArguments(TypeChecker &tc, ParameterList *params,
   for (auto &param : *params) {
     ++nextArgIndex;
     if (!param->getDefaultValue() || !param->hasType() ||
-        param->getType()->is<ErrorType>())
+        param->getType()->hasError())
       continue;
     
     Expr *e = param->getDefaultValue();

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -280,7 +280,7 @@ Type TypeChecker::resolveTypeInContext(
 
     // Start with the type of the current context.
     auto fromType = resolver->resolveTypeOfContext(parentDC);
-    if (!fromType || fromType->is<ErrorType>())
+    if (!fromType || fromType->hasError())
       incomplete = true;
     else
       stack.push_back(fromType);
@@ -419,7 +419,7 @@ Type TypeChecker::applyGenericArguments(Type type, TypeDecl *decl,
                                         TypeResolutionOptions options,
                                         GenericTypeResolver *resolver) {
 
-  if (type->is<ErrorType>()) {
+  if (type->hasError()) {
     generic->setInvalid();
     return type;
   }
@@ -737,7 +737,7 @@ static Type diagnoseUnknownType(TypeChecker &tc, DeclContext *dc,
       assert(!isa<ProtocolDecl>(nominal) && "Cannot be a protocol");
       auto type = resolveTypeDecl(tc, nominal, comp->getIdLoc(), dc, nullptr,
                                   options, resolver, unsatisfiedDependency);
-      if (type->is<ErrorType>())
+      if (type->hasError())
         return type;
 
       // Produce a Fix-It replacing 'Self' with the nominal type name.
@@ -997,7 +997,7 @@ resolveTopLevelIdentTypeComponent(TypeChecker &TC, DeclContext *DC,
                                 dyn_cast<GenericIdentTypeRepr>(comp), options,
                                 resolver, unsatisfiedDependency);
 
-    if (!type || type->is<ErrorType>())
+    if (!type || type->hasError())
       return type;
 
     // If this is the first result we found, record it.
@@ -1114,7 +1114,7 @@ static Type resolveNestedIdentTypeComponent(
                                             /*isTypeReference=*/true);
 
     // Propagate failure.
-    if (!memberType || memberType->is<ErrorType>()) return memberType;
+    if (!memberType || memberType->hasError()) return memberType;
 
     // If there are generic arguments, apply them now.
     if (auto genComp = dyn_cast<GenericIdentTypeRepr>(comp)) {
@@ -1123,7 +1123,7 @@ static Type resolveNestedIdentTypeComponent(
           options, resolver);
 
       // Propagate failure.
-      if (!memberType || memberType->is<ErrorType>()) return memberType;
+      if (!memberType || memberType->hasError()) return memberType;
     }
 
     // We're done.
@@ -1207,7 +1207,7 @@ static Type resolveNestedIdentTypeComponent(
     Type ty = diagnoseUnknownType(TC, DC, parentTy, parentRange, comp, options,
                                   lookupOptions, resolver,
                                   unsatisfiedDependency);
-    if (!ty || ty->is<ErrorType>()) {
+    if (!ty || ty->hasError()) {
       return ErrorType::get(TC.Context);
     }
 
@@ -1275,7 +1275,7 @@ static Type resolveIdentTypeComponent(
   Type parentTy = resolveIdentTypeComponent(TC, DC, parentComps, options,
                                             diagnoseErrors, resolver,
                                             unsatisfiedDependency);
-  if (!parentTy || parentTy->is<ErrorType>()) return parentTy;
+  if (!parentTy || parentTy->hasError()) return parentTy;
   
   SourceRange parentRange(parentComps.front()->getIdLoc(),
                           parentComps.back()->getSourceRange().End);
@@ -1682,7 +1682,7 @@ Type TypeChecker::resolveType(TypeRepr *TyR, DeclContext *DC,
   
   // If we resolved down to an error, make sure to mark the typeRepr as invalid
   // so we don't produce a redundant diagnostic.
-  if (result && result->is<ErrorType>())
+  if (result && result->hasError())
     TyR->setInvalid();
   return result;
 }
@@ -1836,7 +1836,7 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
           instanceOptions -= TR_FunctionInput;
 
           auto instanceTy = resolveType(base, instanceOptions);
-          if (!instanceTy || instanceTy->is<ErrorType>())
+          if (!instanceTy || instanceTy->hasError())
             return instanceTy;
 
           // Check for @thin.
@@ -1865,7 +1865,7 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
             attrs.clearAttribute(TAK_objc_metatype);
           }
 
-          if (instanceTy->is<ErrorType>()) {
+          if (instanceTy->hasError()) {
             ty = instanceTy;
           } else if (auto metatype = dyn_cast<MetatypeTypeRepr>(repr)) {
             ty = buildMetatypeType(metatype, instanceTy, storedRepr);
@@ -1962,7 +1962,7 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
     SILFunctionType::ExtInfo extInfo(rep, attrs.has(TAK_pseudogeneric));
 
     ty = resolveSILFunctionType(fnRepr, options, extInfo, calleeConvention);
-    if (!ty || ty->is<ErrorType>()) return ty;
+    if (!ty || ty->hasError()) return ty;
   } else if (hasFunctionAttr && fnRepr) {
 
     FunctionType::Representation rep = FunctionType::Representation::Swift;
@@ -2015,7 +2015,7 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
                                   fnRepr->throws());
 
     ty = resolveASTFunctionType(fnRepr, options, extInfo);
-    if (!ty || ty->is<ErrorType>()) return ty;
+    if (!ty || ty->hasError()) return ty;
   }
 
   auto instanceOptions = options;
@@ -2027,7 +2027,7 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
   // attribute. Resolve the type as if it were in non-parameter
   // context, and then set isNoEscape if @escaping is not present.
   if (!ty) ty = resolveType(repr, instanceOptions);
-  if (!ty || ty->is<ErrorType>()) return ty;
+  if (!ty || ty->hasError()) return ty;
 
   // Handle @escaping
   if (hasFunctionAttr && ty->is<FunctionType>()) {
@@ -2134,10 +2134,10 @@ Type TypeResolver::resolveASTFunctionType(FunctionTypeRepr *repr,
 
   Type inputTy = resolveType(repr->getArgsTypeRepr(),
                              options | TR_ImmediateFunctionInput);
-  if (!inputTy || inputTy->is<ErrorType>()) return inputTy;
+  if (!inputTy || inputTy->hasError()) return inputTy;
 
   Type outputTy = resolveType(repr->getResultTypeRepr(), options);
-  if (!outputTy || outputTy->is<ErrorType>()) return outputTy;
+  if (!outputTy || outputTy->hasError()) return outputTy;
 
   extInfo = extInfo.withThrows(repr->throws());
 
@@ -2218,7 +2218,7 @@ Type TypeResolver::resolveSILFunctionType(FunctionTypeRepr *repr,
       params.push_back(param);
       if (!param.getType()) return nullptr;
 
-      if (param.getType()->is<ErrorType>())
+      if (param.getType()->hasError())
         hasError = true;
     }
   } else {
@@ -2227,7 +2227,7 @@ Type TypeResolver::resolveSILFunctionType(FunctionTypeRepr *repr,
     params.push_back(param);
     if (!param.getType()) return nullptr;
 
-    if (param.getType()->is<ErrorType>())
+    if (param.getType()->hasError())
       hasError = true;
   }
 
@@ -2323,7 +2323,7 @@ SILParameterInfo TypeResolver::resolveSILParameter(
     type = resolveType(repr, options);
   }
 
-  if (!type || type->is<ErrorType>()) {
+  if (!type || type->hasError()) {
     hadError = true;
 
   // Diagnose types that are illegal in SIL.
@@ -2382,7 +2382,7 @@ bool TypeResolver::resolveSingleSILResult(TypeRepr *repr,
   }
 
   // Propagate type-resolution errors out.
-  if (!type || type->is<ErrorType>()) return true;
+  if (!type || type->hasError()) return true;
 
   // Diagnose types that are illegal in SIL.
   if (!type->isLegalSILType()) {
@@ -2454,7 +2454,7 @@ Type TypeResolver::resolveInOutType(InOutTypeRepr *repr,
   options -= TR_FunctionInput;
 
   Type ty = resolveType(cast<InOutTypeRepr>(repr)->getBase(), options);
-  if (!ty || ty->is<ErrorType>()) return ty;
+  if (!ty || ty->hasError()) return ty;
   return InOutType::get(ty);
 }
 
@@ -2463,7 +2463,7 @@ Type TypeResolver::resolveArrayType(ArrayTypeRepr *repr,
                                     TypeResolutionOptions options) {
   // FIXME: diagnose non-materializability of element type!
   Type baseTy = resolveType(repr->getBase(), withoutContext(options));
-  if (!baseTy || baseTy->is<ErrorType>()) return baseTy;
+  if (!baseTy || baseTy->hasError()) return baseTy;
 
   auto sliceTy = TC.getArraySliceType(repr->getBrackets().Start, baseTy);
   if (!sliceTy)
@@ -2479,10 +2479,10 @@ Type TypeResolver::resolveDictionaryType(DictionaryTypeRepr *repr,
                                          TypeResolutionOptions options) {
   // FIXME: diagnose non-materializability of key/value type?
   Type keyTy = resolveType(repr->getKey(), withoutContext(options));
-  if (!keyTy || keyTy->is<ErrorType>()) return keyTy;
+  if (!keyTy || keyTy->hasError()) return keyTy;
 
   Type valueTy = resolveType(repr->getValue(), withoutContext(options));
-  if (!valueTy || valueTy->is<ErrorType>()) return valueTy;
+  if (!valueTy || valueTy->hasError()) return valueTy;
 
   auto dictDecl = TC.Context.getDictionaryDecl();
 
@@ -2519,7 +2519,7 @@ Type TypeResolver::resolveOptionalType(OptionalTypeRepr *repr,
   // The T in T? is a generic type argument and therefore always an AST type.
   // FIXME: diagnose non-materializability of element type!
   Type baseTy = resolveType(repr->getBase(), elementOptions);
-  if (!baseTy || baseTy->is<ErrorType>()) return baseTy;
+  if (!baseTy || baseTy->hasError()) return baseTy;
 
   auto optionalTy = TC.getOptionalType(repr->getQuestionLoc(), baseTy);
   if (!optionalTy) return ErrorType::get(Context);
@@ -2536,7 +2536,7 @@ Type TypeResolver::resolveImplicitlyUnwrappedOptionalType(
   // The T in T! is a generic type argument and therefore always an AST type.
   // FIXME: diagnose non-materializability of element type!
   Type baseTy = resolveType(repr->getBase(), elementOptions);
-  if (!baseTy || baseTy->is<ErrorType>()) return baseTy;
+  if (!baseTy || baseTy->hasError()) return baseTy;
 
   auto uncheckedOptionalTy =
     TC.getImplicitlyUnwrappedOptionalType(repr->getExclamationLoc(), baseTy);
@@ -2604,7 +2604,7 @@ Type TypeResolver::resolveTupleType(TupleTypeRepr *repr,
     }
 
     ty = resolveType(tyR, thisElementOptions);
-    if (!ty || ty->is<ErrorType>()) return ty;
+    if (!ty || ty->hasError()) return ty;
 
     // If the element is a variadic parameter, the underlying type is actually
     // an ArraySlice of the element type.
@@ -2644,7 +2644,7 @@ Type TypeResolver::resolveProtocolCompositionType(
   SmallVector<Type, 4> ProtocolTypes;
   for (auto tyR : repr->getProtocols()) {
     Type ty = TC.resolveType(tyR, DC, withoutContext(options), Resolver);
-    if (!ty || ty->is<ErrorType>()) return ty;
+    if (!ty || ty->hasError()) return ty;
 
     if (!ty->isExistentialType()) {
       TC.diagnose(tyR->getStartLoc(), diag::protocol_composition_not_protocol,
@@ -2661,7 +2661,7 @@ Type TypeResolver::resolveMetatypeType(MetatypeTypeRepr *repr,
                                        TypeResolutionOptions options) {
   // The instance type of a metatype is always abstract, not SIL-lowered.
   Type ty = resolveType(repr->getBase(), withoutContext(options));
-  if (!ty || ty->is<ErrorType>()) return ty;
+  if (!ty || ty->hasError()) return ty;
 
   Optional<MetatypeRepresentation> storedRepr;
   
@@ -2692,7 +2692,7 @@ Type TypeResolver::resolveProtocolType(ProtocolTypeRepr *repr,
                                        TypeResolutionOptions options) {
   // The instance type of a metatype is always abstract, not SIL-lowered.
   Type ty = resolveType(repr->getBase(), withoutContext(options));
-  if (!ty || ty->is<ErrorType>()) return ty;
+  if (!ty || ty->hasError()) return ty;
 
   Optional<MetatypeRepresentation> storedRepr;
   
@@ -3363,7 +3363,7 @@ bool TypeChecker::isRepresentableInObjC(const SubscriptDecl *SD,
       IndicesType = TupleTy->getElementType(0);
   }
   
-  if (IndicesType->is<ErrorType>())
+  if (IndicesType->hasError())
     return false;
 
   bool IndicesResult =

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -764,7 +764,7 @@ static Optional<Type> getTypeOfCompletionContextExpr(
 
   // Try to recover if we've made any progress.
   if (parsedExpr && !isa<ErrorExpr>(parsedExpr) && parsedExpr->getType() &&
-      !parsedExpr->getType()->is<ErrorType>() &&
+      !parsedExpr->getType()->hasError() &&
       parsedExpr->getType().getCanonicalTypeOrNull() != originalType) {
     return parsedExpr->getType();
   }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3797,8 +3797,7 @@ Type ModuleFile::getType(TypeID TID) {
                                                        assocTypeID);
     typeOrOffset = DependentMemberType::get(
                      getType(baseID),
-                     cast<AssociatedTypeDecl>(getDecl(assocTypeID)),
-                     ctx);
+                     cast<AssociatedTypeDecl>(getDecl(assocTypeID)));
     break;
   }
 

--- a/test/Constraints/same_types.swift
+++ b/test/Constraints/same_types.swift
@@ -130,9 +130,7 @@ func rdar19137463<T>(_ t: T) where T.a == T {} // expected-error{{'a' is not a m
 rdar19137463(1)
 
 
-// FIXME: Terrible diagnostic
-
-struct Brunch<U : Fooable> where U.Foo == X {} // expected-note{{requirement specified as 'U.Foo' == 'X' [with U = BadFooable]}}
+struct Brunch<U : Fooable> where U.Foo == X {}
 
 struct BadFooable : Fooable {
   typealias Foo = DoesNotExist // expected-error{{use of undeclared type 'DoesNotExist'}}
@@ -140,7 +138,6 @@ struct BadFooable : Fooable {
 }
 
 func bogusInOutError(d: inout Brunch<BadFooable>) {}
-// expected-error@-1{{'Brunch' requires the types '<<error type>>' and 'X' be equivalent}}
 
 // Some interesting invalid cases that used to crash
 protocol P {

--- a/test/decl/protocol/conforms/failure.swift
+++ b/test/decl/protocol/conforms/failure.swift
@@ -75,9 +75,9 @@ struct P5Conformer : P5 { // expected-error {{does not conform}}
 
 
 protocol P6Base {
-  associatedtype Foo
+  associatedtype Foo // expected-note {{protocol requires nested type 'Foo'; do you want to add it?}}
   func foo()
-  func bar() -> Foo // expected-note{{protocol requires function 'bar()' }}
+  func bar() -> Foo
 }
 extension P6Base {
 }
@@ -85,7 +85,7 @@ protocol P6 : P6Base {
   associatedtype Bar // expected-note {{protocol requires nested type 'Bar'}}
 }
 extension P6 {
-  func bar() -> Bar? { return nil } // expected-note{{candidate has non-matching type}}
+  func bar() -> Bar? { return nil }
 }
 
 struct P6Conformer : P6 { // expected-error 2 {{does not conform}}

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -419,7 +419,7 @@ protocol P2 {
 struct X3<T : P1> where T.Assoc : P2 {}
 
 struct X4 : P1 { // expected-error{{type 'X4' does not conform to protocol 'P1'}}
-  func getX1() -> X3<X4> { return X3() }
+  func getX1() -> X3<X4> { return X3() } // expected-error{{cannot convert return expression of type 'X3<_>' to return type 'X3<X4>'}}
 }
 
 protocol ShouldntCrash {

--- a/validation-test/compiler_crashers_fixed/28434-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/28434-swift-type-transform.swift
@@ -5,6 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 e:A
 struct B<T where T=[T>


### PR DESCRIPTION
This PR extends the reach of `ErrorType` in the type system a bit, in an effort to maintain more information from failed substitutions and start making type substitution more robust. There are a few steps here:
- Introduce an "original type" to `ErrorType` to maintain some information about what went wrong. This captures the type that was at that particular position when something broke. When printing such error types, we print the "original type" instead
- Allow error types to be embedded in other structural types, instead of always having it be a top-level type. This means we should use `TypeBase::hasError()` rather than `TypeBase::is<ErrorType>()` when we just want to determine "did an error occur?" Specific clients---associated type inference, code completion, and expression type checker diagnostics---use more fine-grained information about where errors occur.
- Start cleaning up uses of `DependentMemberType`, which was my actual goal ;)
