### PR TITLE
[CMake] Add missing dependency to SIL library

### DIFF
--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -40,5 +40,7 @@ add_swift_library(swiftSIL STATIC
 # This property is only set by calls to clang_tablegen. It will not be set on
 # standalone builds, so it can always be safely passed.
 get_property(CLANG_TABLEGEN_TARGETS GLOBAL PROPERTY CLANG_TABLEGEN_TARGETS)
-add_dependencies(swiftSIL
-                ${CLANG_TABLEGEN_TARGETS})
+if(CLANG_TABLEGEN_TARGETS)
+  add_dependencies(swiftSIL
+                  ${CLANG_TABLEGEN_TARGETS})
+endif(CLANG_TABLEGEN_TARGETS)

--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -37,3 +37,8 @@ add_swift_library(swiftSIL STATIC
     swiftSema
 )
 
+# This property is only set by calls to clang_tablegen. It will not be set on
+# standalone builds, so it can always be safely passed.
+get_property(CLANG_TABLEGEN_TARGETS GLOBAL PROPERTY CLANG_TABLEGEN_TARGETS)
+add_dependencies(swiftSIL
+                ${CLANG_TABLEGEN_TARGETS})


### PR DESCRIPTION
The SIL library needs to depend on the clang tablegen targets because it uses clang headers.
