### PR TITLE
[CMake] Don't use hashes in target names

### DIFF
--- a/cmake/modules/SwiftAddCustomCommandTarget.cmake
+++ b/cmake/modules/SwiftAddCustomCommandTarget.cmake
@@ -120,15 +120,9 @@ function(add_custom_command_target dependency_out_var_name)
   set(ACCT_COMMANDS ${ACCT_UNPARSED_ARGUMENTS})
 
   if("${ACCT_CUSTOM_TARGET_NAME}" STREQUAL "")
-    # Construct a unique name for the custom target.
-    # Use a hash so that the file name does not push the OS limits for filename
-    # length.
+    # CMake doesn't allow '/' characters in filenames, so replace them with '-'
     list(GET ACCT_OUTPUT 0 output_filename)
-    string(MD5 target_md5
-        "add_custom_command_target${CMAKE_CURRENT_BINARY_DIR}/${output_filename}")
-    get_filename_component(output_filename_basename "${output_filename}" NAME)
-    set(target_name
-        "add_custom_command_target-${target_md5}-${output_filename_basename}")
+    string(REPLACE "/" "-" target_name "${output_filename}")
   else()
     set(target_name "${ACCT_CUSTOM_TARGET_NAME}")
   endif()


### PR DESCRIPTION
This code was added in the mega-commit 6670bb7 with the commit message "Rewrite the CMake build system", so I'm a little bit light on context here. The comment in the code was:

`# Construct a unique name for the custom target.`
`# Use a hash so that the file name does not push the OS limits for filename`
`# length.`

This seems bunk to me. Since the string being hashed is a filename it seems to me that we don't need a hash to stay under the OS filename size limits. Additionally since output files must be unique using the filename as the unique target name seems like a good idea to me. The only issue here is that custom target names can't contain '/'s. To workaround that we replace the '/' character with '-'.

This patch has the added benefit of having the full filename encoded into the target names, so if you need to debug the build dependency graph you can much more easily walk back from the generated build files to the place in CMake where it was generated.
