### PR TITLE
IRGen: import external vtable symbols always as _public_ undefined sy…

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -355,6 +355,8 @@ public:
       case PublicClass:
         if (L == SILLinkage::Private || L == SILLinkage::Hidden)
           return SILLinkage::Public;
+        if (L == SILLinkage::PrivateExternal || L == SILLinkage::HiddenExternal)
+          return SILLinkage::PublicExternal;
         break;
     }
     return L;

--- a/test/IRGen/Inputs/vtable_symbol_linkage_base.swift
+++ b/test/IRGen/Inputs/vtable_symbol_linkage_base.swift
@@ -1,0 +1,12 @@
+
+open class Base {
+  private func privateFunc() -> Int {
+    return 27
+  }
+  internal func internalFunc() -> Int {
+    return 28
+  }
+
+  private var privateVar: Int = 29
+  internal var internalVar: Int = 30
+}

--- a/test/IRGen/vtable_symbol_linkage.swift
+++ b/test/IRGen/vtable_symbol_linkage.swift
@@ -1,0 +1,12 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-build-swift %S/Inputs/vtable_symbol_linkage_base.swift -emit-module -emit-module-path=%t/BaseModule.swiftmodule -emit-library -module-name BaseModule -o %t/BaseModule.%target-dylib-extension
+// RUN: %target-build-swift -I %t %s %t/BaseModule.%target-dylib-extension -o %t/a.out
+
+// Check if the program can be linked without undefined symbol errors.
+
+import BaseModule
+
+public class Derived : Base {
+}
+
+

--- a/test/Interpreter/use_public_var_private_setter.swift
+++ b/test/Interpreter/use_public_var_private_setter.swift
@@ -1,10 +1,6 @@
 // RUN: %target-build-swift -emit-module -emit-library %S/Inputs/public_var_private_setter.swift
 // RUN: %target-build-swift -I . -L . -lpublic_var_private_setter %s -o use_public_var_private_setter
 
-// On Linux, the linker step of this test fails with "Bad value", specifically:
-// "hidden symbol `_TFC25public_var_private_setter9BaseClasscfT_S0_' isn't defined".
-// XFAIL: linux
-
 import public_var_private_setter
 
 class Class: BaseClass {}


### PR DESCRIPTION
…mbols and not as _local_ undefined symbols.

This doesn't make a difference on Darwin, but on Linux it causes linker errors if a class inherits from a public class in another module which has private/internal members.

fixes SR-1901
