### PR TITLE
build-script: Don't automatically clear the module cache.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2442,10 +2442,6 @@ for host in "${ALL_HOSTS[@]}"; do
                 ;;
         esac
 
-        # Clean the product-local module cache.
-        call rm -rf "${module_cache}"
-        call mkdir -p "${module_cache}"
-
         # Compute the generator output file to check for, to determine if we
         # must reconfigure. We only handle Ninja for now.
         #


### PR DESCRIPTION
**Background**
Since PR4779 LLVM builds with with -DLLVM_ENABLE_MODULES=1. On Darwin, this turns on -gmodules which causes debug info for the types defined by the LLVM modules is stored alongside the modules in the module cache. 
This makes building LLVM several minutes faster and shaves off several gigabytes of redundant debug info from the build directory.
http://llvm.org/devmtg/2015-10/slides/Prantl-ExonSmith-DebugInfoMetadataToModules.pdf

**The Problem**
The swift/utils/build-script has the nasty habit of unconditionally deleting the module cache on every invocation. Deleting the module cache on every invocation of build-script without re-building the LLVM and clang modules will erase the debug info and thus render any LLVM types undebuggable.

**The Solution**
This patch removes this functionality. When a clean build is desired, such as on build bots or after master-next merges, the module cache will still be removed since it is located in the build.

**Risks** 
Incremental buildbots will probably still want to clear the module cache to avoid glitches when clang is advanced. I am not sure what the cleanest way to guarantee this is.

rdar://problem/28655564
