### PR TITLE
Fix small obvious typo.

### DIFF
--- a/include/swift/Basic/BlotSetVector.h
+++ b/include/swift/Basic/BlotSetVector.h
@@ -70,7 +70,7 @@ public:
 
   using const_reverse_iterator = typename VectorT::const_reverse_iterator;
   const_reverse_iterator rbegin() const { return Vector.rbegin(); }
-  const_reverse_iterator rend() const { return Vector.rbegin(); }
+  const_reverse_iterator rend() const { return Vector.rend(); }
   llvm::iterator_range<const_reverse_iterator> getReverseRange() const {
     return {rbegin(), rend()};
   }


### PR DESCRIPTION
This was an obvious typo that Bob found while preparing swift to handle the upstream llvm iplist changes.

This code is actually dead and I just added it for completeness. So I just did a quick obvious drive by fix.
