### PR TITLE
[SILOpt] Fix an accidental use-of-temporary.

### DIFF
--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -122,7 +122,7 @@ static void addReturnValueImpl(SILBasicBlock *RetBB, SILBasicBlock *NewRetBB,
   Builder.setInsertionPoint(NewRetBB);
   ArrayRef<SILValue> BBArgs;
   if (!NewRetVal->getType().isVoid())
-    BBArgs = {NewRetVal};
+    BBArgs = NewRetVal;
   Builder.createBranch(Loc, MergedBB, BBArgs);
 }
 


### PR DESCRIPTION
Similar to 5356cc37, caught by apple/swift-llvm#26. Keeping this PR open until that one passes cleanly.
