### PR TITLE
[Parse] Improve error handling in parseList

### DIFF
--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -325,6 +325,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
         diagnose(Tok, diag::expected_parameter_name);
         param.isInvalid = true;
         param.FirstNameLoc = Tok.getLoc();
+        status.setIsParseError();
       }
     }
                         

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -715,7 +715,10 @@ Parser::parseList(tok RightK, SourceLoc LeftLoc, SourceLoc &RightLoc,
     }
   }
 
-  if (parseMatchingToken(RightK, RightLoc, ErrorDiag, LeftLoc)) {
+  if (Status.isError()) {
+    // If we've already got errors, don't emit missing RightK diagnostics.
+    RightLoc = Tok.is(RightK) ? consumeToken() : PreviousLoc;
+  } else if (parseMatchingToken(RightK, RightLoc, ErrorDiag, LeftLoc)) {
     Status.setIsParseError();
   }
 

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -208,6 +208,8 @@ var Container = OptionTakerContainer1()
 Container.OptionSetTaker1(.#^UNRESOLVED_19^#
 Container.EnumTaker1(.#^UNRESOLVED_20^#
 
+func parserSync() {}
+
 // UNRESOLVED_4: Begin completions
 // UNRESOLVED_4-DAG: Decl[StaticVar]/CurrNominal:        Option1[#SomeOptions1#]; name=Option1
 // UNRESOLVED_4-DAG: Decl[StaticVar]/CurrNominal:        Option2[#SomeOptions1#]; name=Option2

--- a/test/Parse/ConditionalCompilation/decl_parse_errors.swift
+++ b/test/Parse/ConditionalCompilation/decl_parse_errors.swift
@@ -27,7 +27,7 @@ lazy
 var val3: Int = 0;
 #line
 
-class C { // expected-note 3 {{in declaration of 'C'}}
+class C { // expected-note 2 {{in declaration of 'C'}} expected-note {{to match this opening '{'}}
 
 #if os(iOS)
 	func foo() {}
@@ -35,6 +35,6 @@ class C { // expected-note 3 {{in declaration of 'C'}}
 #else
 	func bar() {}
 	func baz() {}
-} // expected-error{{expected #else or #endif at end of conditional compilation block}} expected-error {{expected declaration}}
+} // expected-error{{expected declaration}} expected-error{{expected #else or #endif at end of conditional compilation block}}
 #endif
-// expected-error@+1{{expected declaration}}
+// expected-error@+1{{expected '}' in class}}

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -15,18 +15,18 @@ func test2(inout let x : Int) {}  // expected-error {{parameter may not have mul
 func test3(f : (inout _ x : Int) -> Void) {} // expected-error {{'inout' before a parameter name is not allowed, place it before the parameter type instead}}
 
 func test3() {
-  undeclared_func( // expected-error {{use of unresolved identifier 'undeclared_func'}} expected-note {{to match this opening '('}}
-} // expected-error {{expected expression in list of expressions}} expected-error {{expected ')' in expression list}}
+  undeclared_func( // expected-error {{use of unresolved identifier 'undeclared_func'}}
+} // expected-error {{expected expression in list of expressions}}
 
 func runAction() {} // expected-note {{did you mean 'runAction'?}}
 
 // rdar://16601779
 func foo() {
-  runAction(SKAction.sequence() // expected-error {{use of unresolved identifier 'SKAction'}} expected-note {{to match this opening '('}} expected-error {{expected ',' separator}} {{32-32=,}}
+  runAction(SKAction.sequence() // expected-error {{use of unresolved identifier 'SKAction'}} expected-error {{expected ',' separator}} {{32-32=,}}
     
     skview!
     // expected-error @-1 {{use of unresolved identifier 'skview'}}
-} // expected-error {{expected ')' in expression list}}
+}
 
 super.init() // expected-error {{'super' cannot be used outside of class members}}
 
@@ -38,7 +38,7 @@ switch state { // expected-error {{use of unresolved identifier 'state'}}
 // rdar://18926814
 func test4() {
   let abc = 123
-  _ = " >> \( abc } ) << " // expected-note {{to match this opening '('}}  expected-error {{expected ')' in expression list}} expected-error {{expected ',' separator}} {{18-18=,}}  expected-error {{expected expression in list of expressions}}  expected-error {{extra tokens after interpolated string expression}}
+  _ = " >> \( abc } ) << " // expected-error {{expected ',' separator}} {{18-18=,}}  expected-error {{expected expression in list of expressions}}  expected-error {{extra tokens after interpolated string expression}}
 
 }
 

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -15,20 +15,18 @@ func test2(inout let x : Int) {}  // expected-error {{parameter may not have mul
 func test3(f : (inout _ x : Int) -> Void) {} // expected-error {{'inout' before a parameter name is not allowed, place it before the parameter type instead}}
 
 func test3() {
-  undeclared_func( // expected-error {{use of unresolved identifier 'undeclared_func'}} expected-note {{to match this opening '('}} expected-error {{expected ',' separator}} {{19-19=,}}
+  undeclared_func( // expected-error {{use of unresolved identifier 'undeclared_func'}} expected-note {{to match this opening '('}}
 } // expected-error {{expected expression in list of expressions}} expected-error {{expected ')' in expression list}}
 
 func runAction() {} // expected-note {{did you mean 'runAction'?}}
 
 // rdar://16601779
 func foo() {
-  runAction(SKAction.sequence() // expected-error {{use of unresolved identifier 'SKAction'}}  expected-note {{to match this opening '('}} expected-error {{expected ',' separator}} {{32-32=,}}
+  runAction(SKAction.sequence() // expected-error {{use of unresolved identifier 'SKAction'}} expected-note {{to match this opening '('}} expected-error {{expected ',' separator}} {{32-32=,}}
     
-    // expected-error @+2 {{expected ',' separator}} {{12-12=,}}
-    // expected-error @+1 {{expected ',' separator}} {{12-12=,}}
     skview!
     // expected-error @-1 {{use of unresolved identifier 'skview'}}
-} // expected-error {{expected expression in list of expressions}} expected-error {{expected ')' in expression list}}
+} // expected-error {{expected ')' in expression list}}
 
 super.init() // expected-error {{'super' cannot be used outside of class members}}
 
@@ -40,15 +38,12 @@ switch state { // expected-error {{use of unresolved identifier 'state'}}
 // rdar://18926814
 func test4() {
   let abc = 123
-  _ = " >> \( abc } ) << "   // expected-note {{to match this opening '('}}  expected-error {{expected ')' in expression list}}  expected-error {{expected ',' separator}} {{18-18=,}} expected-error {{expected ',' separator}} {{18-18=,}}  expected-error {{expected expression in list of expressions}}  expected-error {{extra tokens after interpolated string expression}}
+  _ = " >> \( abc } ) << " // expected-note {{to match this opening '('}}  expected-error {{expected ')' in expression list}} expected-error {{expected ',' separator}} {{18-18=,}}  expected-error {{expected expression in list of expressions}}  expected-error {{extra tokens after interpolated string expression}}
 
 }
 
 // rdar://problem/18507467
 func d(_ b: String -> <T>() -> T) {} // expected-error {{expected type for function result}}
-// expected-error @-1 {{expected ',' separator}} {{22-22=,}}
-// expected-error @-2 {{expected parameter name followed by ':'}}
-// expected-error @-3 {{expected ',' separator}}
 
 
 // <rdar://problem/22143680> QoI: terrible diagnostic when trying to form a generic protocol

--- a/test/Parse/matching_patterns.swift
+++ b/test/Parse/matching_patterns.swift
@@ -308,7 +308,7 @@ case (_?)?: break
 
 // <rdar://problem/20365753> Bogus diagnostic "refutable pattern match can fail"
 let (responseObject: Int?) = op1
-// expected-error @-1 2 {{expected ',' separator}} {{25-25=,}} {{25-25=,}}
+// expected-error @-1 {{expected ',' separator}} {{25-25=,}}
 // expected-error @-2 {{expected pattern}}
 
 

--- a/test/Parse/object_literals.swift
+++ b/test/Parse/object_literals.swift
@@ -3,4 +3,4 @@
 let _ = [##] // expected-error{{expected identifier after '#' in object literal expression}} expected-error{{object literal syntax no longer uses '[# ... #]'}} {{9-10=}} {{11-13=}}
 let _ = [#what#] // expected-error{{object literal syntax no longer uses '[# ... #]'}} {{9-10=}} {{15-17=}}
 let _ = [#what()#] // expected-error{{object literal syntax no longer uses '[# ... #]'}} {{9-10=}} {{17-19=}}
-let _ = [#colorLiteral( // expected-error{{expected ',' separator}} expected-error{{expected expression in list of expressions}}
+let _ = [#colorLiteral( // expected-error@+1 {{expected expression in list of expressions}} expected-error @+1 {{expected ')' in expression list}} expected-note {{to match this opening '('}}

--- a/test/Parse/object_literals.swift
+++ b/test/Parse/object_literals.swift
@@ -3,4 +3,4 @@
 let _ = [##] // expected-error{{expected identifier after '#' in object literal expression}} expected-error{{object literal syntax no longer uses '[# ... #]'}} {{9-10=}} {{11-13=}}
 let _ = [#what#] // expected-error{{object literal syntax no longer uses '[# ... #]'}} {{9-10=}} {{15-17=}}
 let _ = [#what()#] // expected-error{{object literal syntax no longer uses '[# ... #]'}} {{9-10=}} {{17-19=}}
-let _ = [#colorLiteral( // expected-error@+1 {{expected expression in list of expressions}} expected-error @+1 {{expected ')' in expression list}} expected-note {{to match this opening '('}}
+let _ = [#colorLiteral( // expected-error@+1 {{expected expression in list of expressions}}

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -523,8 +523,7 @@ case let (jeb):
 // rdar://19605164
 // expected-error@+2{{use of undeclared type 'S'}}
 struct Foo19605164 {
-func a(s: S[{{g) -> Int {} // expected-note {{to match this opening '('}}
-// expected-error@+3 {{expected ')' in parameter}}
+func a(s: S[{{g) -> Int {}
 // expected-error@+2 {{expected parameter name followed by ':'}}
 // expected-error@+1 {{expected ',' separator}}
 }}}

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -481,19 +481,15 @@ Base=1 as Base=1  // expected-error {{cannot assign to immutable expression of t
 
 // <rdar://problem/18634543> Parser hangs at swift::Parser::parseType
 public enum TestA {
-  // expected-error @+2 {{expected ',' separator}}
   // expected-error @+1{{expected '{' in body of function declaration}}
   public static func convertFromExtenndition( // expected-error {{expected parameter name followed by ':'}}
-    // expected-error@+2 {{expected ',' separator}}
     // expected-error@+1{{expected parameter name followed by ':'}}
     s._core.count != 0, "Can't form a Character from an empty String")
 }
 
 public enum TestB {
-  // expected-error@+2 {{expected ',' separator}}
   // expected-error@+1{{expected '{' in body of function declaration}}
   public static func convertFromExtenndition( // expected-error {{expected parameter name followed by ':'}}
-    // expected-error@+2 {{expected ',' separator}}
     // expected-error@+1 {{expected parameter name followed by ':'}}
     s._core.count ?= 0, "Can't form a Character from an empty String")
 }
@@ -527,10 +523,10 @@ case let (jeb):
 // rdar://19605164
 // expected-error@+2{{use of undeclared type 'S'}}
 struct Foo19605164 {
-func a(s: S[{{g) -> Int {}  // expected-note {{to match this opening '('}}
-// expected-error@+3 {{expected parameter name followed by ':'}}
-// expected-error@+2 2 {{expected ',' separator}}
-// expected-error@+1 {{expected ')' in parameter}}
+func a(s: S[{{g) -> Int {} // expected-note {{to match this opening '('}}
+// expected-error@+3 {{expected ')' in parameter}}
+// expected-error@+2 {{expected parameter name followed by ':'}}
+// expected-error@+1 {{expected ',' separator}}
 }}}
 #endif
   
@@ -659,7 +655,7 @@ func r21712891(s : String) -> String {
   let a = s.startIndex..<s.startIndex
   _ = a
   // The specific errors produced don't actually matter, but we need to reject this.
-  return "\(s[a)"  // expected-error 3 {{}}
+  return "\(s[a)"  // expected-error {{expected ']' in expression list}} expected-note {{to match this opening '['}}
 }
 
 

--- a/test/Parse/subscripting.swift
+++ b/test/Parse/subscripting.swift
@@ -81,9 +81,9 @@ _ = y2[0] // expected-error{{cannot use mutating getter on immutable value: 'y2'
 
 // Parsing errors
 // FIXME: Recovery here is horrible
-struct A0 { // expected-note{{in declaration of 'A0'}}
+struct A0 {
   subscript // expected-error{{expected '(' for subscript parameters}}
-    i : Int // expected-error{{expected declaration}}
+    i : Int
      -> Int {
     get {
       return stored
@@ -94,9 +94,9 @@ struct A0 { // expected-note{{in declaration of 'A0'}}
   }
 }
 
-struct A1 { // expected-note{{in declaration of 'A1'}}
+struct A1 {
   subscript (i : Int) // expected-error{{expected '->' for subscript element type}}
-     Int {  // expected-error{{expected declaration}}
+     Int {
     get {
       return stored
     }
@@ -106,9 +106,9 @@ struct A1 { // expected-note{{in declaration of 'A1'}}
   }
 }
 
-struct A2 { // expected-note{{in declaration of 'A2'}}
+struct A2 {
   subscript (i : Int) -> // expected-error{{expected subscripting element type}}
-     {  // expected-error{{expected declaration}}
+     {
     get {
       return stored
     }
@@ -118,17 +118,17 @@ struct A2 { // expected-note{{in declaration of 'A2'}}
   }
 }
 
-struct A3 { // expected-note{{in declaration of 'A3'}}
+struct A3 {
   subscript(i : Int) // expected-error {{expected '->' for subscript element type}}
-  { // expected-error {{expected declaration}}
+  {
     get {
       return i
     }
   }
 }
 
-struct A4 { // expected-note{{in declaration of 'A4'}}
-  subscript(i : Int) { // expected-error {{expected '->' for subscript element type}} expected-error {{consecutive declarations on a line must be separated by ';'}} {{21-21=;}} expected-error {{expected declaration}}
+struct A4 {
+  subscript(i : Int) { // expected-error {{expected '->' for subscript element type}}
     get {
       return i
     }
@@ -139,8 +139,8 @@ struct A5 {
   subscript(i : Int) -> Int // expected-error {{expected '{' in subscript to specify getter and setter implementation}}
 }
 
-struct A6 { // expected-note{{in declaration of 'A6'}}
-  subscript(i: Int)(j: Int) -> Int { // expected-error {{expected '->' for subscript element type}} expected-error {{consecutive declarations on a line must be separated by ';'}} {{20-20=;}} expected-error {{expected declaration}}
+struct A6 {
+  subscript(i: Int)(j: Int) -> Int { // expected-error {{expected '->' for subscript element type}}
     get {
       return i + j
     }
@@ -163,9 +163,9 @@ struct A7b {
   }
 }
 
-struct A8 { // expected-note{{in declaration of 'A8'}}
+struct A8 {
   subscript(i : Int) -> Int // expected-error{{expected '{' in subscript to specify getter and setter implementation}}
-    get { // expected-error{{expected declaration}}
+    get {
       return stored
     }
     set {

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -452,11 +452,11 @@ struct StructWithDelegatingInit {
 }
 
 func test_recovery_missing_name_2(let: Int) {} // expected-error {{'let' as a parameter attribute is not allowed}}{{35-38=}} 
-// expected-error @-1 2{{expected ',' separator}} {{38-38=,}} expected-error @-1 2 {{expected parameter name followed by ':'}}
+// expected-error @-1 {{expected parameter name followed by ':'}}
 
 // <rdar://problem/16792027> compiler infinite loops on a really really mutating function
-struct F { // expected-note 2 {{in declaration of 'F'}}
-  mutating mutating mutating f() { // expected-error 2 {{duplicate modifier}} expected-note 2 {{modifier already specified here}} expected-error {{consecutive declarations on a line must be separated by ';'}} {{29-29=;}} expected-error 2 {{expected declaration}}
+struct F { // expected-note 1 {{in declaration of 'F'}}
+  mutating mutating mutating f() { // expected-error 2 {{duplicate modifier}} expected-note 2 {{modifier already specified here}} expected-error {{expected declaration}}
   }
   
   mutating nonmutating func g() {  // expected-error {{method may not be declared both mutating and nonmutating}} {{12-24=}}

--- a/test/SourceKit/CursorInfo/rdar_18677108-2.swift.response
+++ b/test/SourceKit/CursorInfo/rdar_18677108-2.swift.response
@@ -1,41 +1,20 @@
 [
   {
-    key.line: 6,
-    key.column: 2,
-    key.filepath: rdar_18677108-2-a.swift,
-    key.severity: source.diagnostic.severity.error,
-    key.description: "expected ',' separator",
-    key.diagnostic_stage: source.diagnostic.stage.swift.parse,
-    key.fixits: [
-      {
-        key.offset: 184,
-        key.length: 0,
-        key.sourcetext: ","
-      }
-    ]
-  },
-  {
-    key.line: 6,
-    key.column: 2,
-    key.filepath: rdar_18677108-2-a.swift,
-    key.severity: source.diagnostic.severity.error,
-    key.description: "expected ',' separator",
-    key.diagnostic_stage: source.diagnostic.stage.swift.parse,
-    key.fixits: [
-      {
-        key.offset: 184,
-        key.length: 0,
-        key.sourcetext: ","
-      }
-    ]
-  },
-  {
     key.line: 7,
     key.column: 1,
     key.filepath: rdar_18677108-2-a.swift,
     key.severity: source.diagnostic.severity.error,
-    key.description: "expected expression in list of expressions",
-    key.diagnostic_stage: source.diagnostic.stage.swift.parse
+    key.description: "expected ')' in expression list",
+    key.diagnostic_stage: source.diagnostic.stage.swift.parse,
+    key.diagnostics: [
+      {
+        key.line: 5,
+        key.column: 46,
+        key.filepath: rdar_18677108-2-a.swift,
+        key.severity: source.diagnostic.severity.note,
+        key.description: "to match this opening '('"
+      }
+    ]
   },
   {
     key.line: 7,
@@ -59,15 +38,15 @@
     key.column: 1,
     key.filepath: rdar_18677108-2-a.swift,
     key.severity: source.diagnostic.severity.error,
-    key.description: "expected declaration",
+    key.description: "expected '}' in class",
     key.diagnostic_stage: source.diagnostic.stage.swift.parse,
     key.diagnostics: [
       {
-        key.line: 1,
-        key.column: 7,
+        key.line: 2,
+        key.column: 1,
         key.filepath: rdar_18677108-2-a.swift,
         key.severity: source.diagnostic.severity.note,
-        key.description: "in declaration of 'CameraController'"
+        key.description: "to match this opening '{'"
       }
     ]
   }

--- a/test/decl/func/functions.swift
+++ b/test/decl/func/functions.swift
@@ -82,7 +82,7 @@ func parseError3(_ a: unknown_type, b: ) {} // expected-error {{use of undeclare
 
 func parseError4(_ a: , b: ) {} // expected-error 2{{expected parameter type following ':'}}
 
-func parseError5(_ a: b: ) {} // expected-error {{use of undeclared type 'b'}}  expected-error 2 {{expected ',' separator}} {{24-24=,}} {{24-24=,}} expected-error {{expected parameter name followed by ':'}}
+func parseError5(_ a: b: ) {} // expected-error {{use of undeclared type 'b'}}  expected-error {{expected ',' separator}} {{24-24=,}} expected-error {{expected parameter name followed by ':'}}
 
 func parseError6(_ a: unknown_type, b: ) {} // expected-error {{use of undeclared type 'unknown_type'}}  expected-error {{expected parameter type following ':'}}
 
@@ -90,7 +90,7 @@ func parseError7(_ a: Int, goo b: unknown_type) {} // expected-error {{use of un
 
 public func foo(_ a: Bool = true) -> (b: Bar, c: Bar) {} // expected-error {{use of undeclared type 'Bar'}}
 
-func parenPatternInArg((a): Int) -> Int { // expected-error {{expected parameter name followed by ':'}} expected-error {{expected ',' separator}}
+func parenPatternInArg((a): Int) -> Int { // expected-error {{expected parameter name followed by ':'}}
   return a  // expected-error {{use of unresolved identifier 'a'}}
 }
 parenPatternInArg(0)  // expected-error {{argument passed to call that takes no arguments}}

--- a/test/decl/var/static_var.swift
+++ b/test/decl/var/static_var.swift
@@ -256,11 +256,11 @@ protocol ProtosEvilTwin {
 extension ProtoAdopter : ProtosEvilTwin {}
 
 // rdar://18990358
-public struct Foo { // expected-note {{in declaration of 'Foo'}}
+public struct Foo { // expected-note {{to match this opening '{'}}}
   public static let S { a // expected-error{{computed property must have an explicit type}}
     // expected-error@-1{{type annotation missing in pattern}}
     // expected-error@-2{{'let' declarations cannot be computed properties}}
     // expected-error@-3{{use of unresolved identifier 'a'}}
 }
 
-// expected-error@+1 {{expected declaration}}
+// expected-error@+1 {{expected '}' in struct}}

--- a/test/decl/var/variables.swift
+++ b/test/decl/var/variables.swift
@@ -8,8 +8,8 @@ var t7, t8 : Int
 var t9, t10 = 20 // expected-error {{type annotation missing in pattern}}
 var t11, t12 : Int = 20 // expected-error {{type annotation missing in pattern}}
 var t13 = 2.0, t14 : Int
-var (x = 123, // expected-error 2 {{expected ',' separator}} {{7-7=,}} {{7-7=,}} expected-error {{expected pattern}}
-     y = 456) : (Int,Int) // expected-error 2 {{expected ',' separator}} {{7-7=,}} {{7-7=,}} expected-error {{expected pattern}}
+var (x = 123, // expected-error {{expected ',' separator}} {{7-7=,}} expected-error {{expected pattern}}
+     y = 456) : (Int,Int)
 var bfx : Int, bfy : Int
 
 _ = 10

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -456,10 +456,10 @@ func stringliterals(_ d: [String: Int]) {
     "something else")"
   // expected-error @-2 {{unterminated string literal}} expected-error @-1 {{unterminated string literal}}
 
-  // FIXME: bad diagnostics.
-  // expected-warning @+1 {{initialization of variable 'x2' was never used; consider replacing with assignment to '_' or removing it}}
-  /* expected-error {{unterminated string literal}} expected-error {{expected ',' separator}} expected-error {{expected ',' separator}} expected-note {{to match this opening '('}}  */ var x2 : () = ("hello" + "
-  ; // expected-error {{expected expression in list of expressions}}
+  // expected-warning @+2 {{initialization of variable 'x2' was never used; consider replacing with assignment to '_' or removing it}}
+  // expected-error @+1 {{unterminated string literal}} expected-note @+1 {{to match this opening '('}}
+  var x2 : () = ("hello" + "
+  ;
 } // expected-error {{expected ')' in expression list}}
 
 func testSingleQuoteStringLiterals() {
@@ -689,13 +689,13 @@ func dictionaryLiterals() {
 func invalidDictionaryLiteral() {
   // FIXME: lots of unnecessary diagnostics.
 
-  var a = [1: ; // expected-error {{expected value in dictionary literal}} expected-error 2{{expected ',' separator}} {{14-14=,}} {{14-14=,}} expected-error {{expected key expression in dictionary literal}} expected-error {{expected ']' in container literal expression}} expected-note {{to match this opening '['}}
-  var b = [1: ;] // expected-error {{expected value in dictionary literal}} expected-error 2{{expected ',' separator}} {{14-14=,}} {{14-14=,}} expected-error {{expected key expression in dictionary literal}}
-  var c = [1: "one" ;] // expected-error {{expected key expression in dictionary literal}} expected-error 2{{expected ',' separator}} {{20-20=,}} {{20-20=,}}
-  var d = [1: "one", ;] // expected-error {{expected key expression in dictionary literal}} expected-error {{expected ',' separator}} {{21-21=,}}
+  var a = [1: ; // expected-error {{expected value in dictionary literal}} expected-error {{expected ']' in container literal expression}} expected-note {{to match this opening '['}}
+  var b = [1: ;] // expected-error {{expected value in dictionary literal}}
+  var c = [1: "one" ;] // expected-error {{expected key expression in dictionary literal}} expected-error {{expected ',' separator}} {{20-20=,}}
+  var d = [1: "one", ;] // expected-error {{expected key expression in dictionary literal}}
   var e = [1: "one", 2] // expected-error {{expected ':' in dictionary literal}}
-  var f = [1: "one", 2 ;] // expected-error 2{{expected ',' separator}} {{23-23=,}} {{23-23=,}} expected-error 1{{expected key expression in dictionary literal}} expected-error {{expected ':' in dictionary literal}}
-  var g = [1: "one", 2: ;] // expected-error {{expected value in dictionary literal}} expected-error 2{{expected ',' separator}} {{24-24=,}} {{24-24=,}} expected-error {{expected key expression in dictionary literal}}
+  var f = [1: "one", 2 ;] // expected-error {{expected ':' in dictionary literal}}
+  var g = [1: "one", 2: ;] // expected-error {{expected value in dictionary literal}}
 }
 
     

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -457,10 +457,10 @@ func stringliterals(_ d: [String: Int]) {
   // expected-error @-2 {{unterminated string literal}} expected-error @-1 {{unterminated string literal}}
 
   // expected-warning @+2 {{initialization of variable 'x2' was never used; consider replacing with assignment to '_' or removing it}}
-  // expected-error @+1 {{unterminated string literal}} expected-note @+1 {{to match this opening '('}}
+  // expected-error @+1 {{unterminated string literal}}
   var x2 : () = ("hello" + "
   ;
-} // expected-error {{expected ')' in expression list}}
+}
 
 func testSingleQuoteStringLiterals() {
   _ = 'abc' // expected-error{{single-quoted string literal found, use '"'}}{{7-12="abc"}}
@@ -689,7 +689,7 @@ func dictionaryLiterals() {
 func invalidDictionaryLiteral() {
   // FIXME: lots of unnecessary diagnostics.
 
-  var a = [1: ; // expected-error {{expected value in dictionary literal}} expected-error {{expected ']' in container literal expression}} expected-note {{to match this opening '['}}
+  var a = [1: ; // expected-error {{expected value in dictionary literal}}
   var b = [1: ;] // expected-error {{expected value in dictionary literal}}
   var c = [1: "one" ;] // expected-error {{expected key expression in dictionary literal}} expected-error {{expected ',' separator}} {{20-20=,}}
   var d = [1: "one", ;] // expected-error {{expected key expression in dictionary literal}}

--- a/validation-test/compiler_crashers_fixed/00058-get-self-type-for-container.swift
+++ b/validation-test/compiler_crashers_fixed/00058-get-self-type-for-container.swift
@@ -6,6 +6,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: %target-swift-frontend %s -parse -verify
-protocol c : b { // expected-error {{use of undeclared type 'b'}} expected-note {{in declaration of 'c'}}
+protocol c : b { // expected-error {{use of undeclared type 'b'}} expected-note {{to match this opening '{'}}
 	func b // expected-error {{expected '(' in argument list of function declaration}}
-// expected-error@+1 {{expected declaration}}
+// expected-error@+1 {{expected '}' in protocol}}

--- a/validation-test/compiler_crashers_fixed/00058-get-self-type-for-container.swift
+++ b/validation-test/compiler_crashers_fixed/00058-get-self-type-for-container.swift
@@ -5,7 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: %target-swift-frontend %s -parse -verify
-protocol c : b { // expected-error {{use of undeclared type 'b'}} expected-note {{to match this opening '{'}}
-	func b // expected-error {{expected '(' in argument list of function declaration}}
-// expected-error@+1 {{expected '}' in protocol}}
+// RUN: not %target-swift-frontend %s -parse
+protocol c : b {
+	func b


### PR DESCRIPTION
- Skip ahead if seeing any error while parsing list elements.<br>
  In most cases, we cannot expect that the following tokens could construct a valid element (with missing separator). Skip them, instead of trying to parse them as a next element.
- Bailout if seeing `tok::eof` or token that can never start a element, after parsing an element.<br>
  This silences superfluous `expected ',' separator` error, or misleading `expected declaration` error. What we should emit is `expected ')' in expression list` or `expected '}' in struct`.
- Don't emit missing closing token error if we've already emitted any error while parsing elements.<br>
  **[RFC] about this change**: This might be too silence, but some of other places like this don't emit error for missing closing token.
