### PR TITLE
Improve diagnostics for optionals in string interpolation segments

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2413,11 +2413,8 @@ WARNING(optional_in_string_interpolation_segment,none,
         "string interpolation produces a debug description for an optional "
         "value; did you mean to make this explicit?",
         ())
-NOTE(silence_optional_in_interpolation_segment_cast,none,
-     "use 'as' to explicitly cast to %0 to silence this warning",
-     (Type))
 NOTE(silence_optional_in_interpolation_segment_call,none,
-     "use '.debugDescription' to silence this warning", ())
+     "use 'String(describing:)' to silence this warning", ())
 
 ERROR(invalid_noescape_use,none,
       "non-escaping %select{value|parameter}1 %0 may only be called",

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3723,28 +3723,26 @@ static void diagnoseUnintendedOptionalBehavior(TypeChecker &TC, const Expr *E,
           }
 
           // Bail out if we don't have an optional.
-          auto objectTy = segment->getType()->getOptionalObjectType();
-          if (!objectTy) {
+          if (!segment->getType()->getOptionalObjectType()) {
             continue;
           }
-          auto segmentTy = OptionalType::get(objectTy);
 
           TC.diagnose(segment->getStartLoc(),
                       diag::optional_in_string_interpolation_segment)
               .highlight(segment->getSourceRange());
 
+          // Suggest 'String(describing: <expr>)'.
+          auto segmentStart = segment->getStartLoc().getAdvancedLoc(1);
           TC.diagnose(segment->getLoc(),
                       diag::silence_optional_in_interpolation_segment_call)
             .highlight(segment->getSourceRange())
-            .fixItInsert(segment->getEndLoc(), ".debugDescription");
+            .fixItInsert(segmentStart, "String(describing: ")
+            .fixItInsert(segment->getEndLoc(), ")");
 
-          auto opts = PrintOptions::printForDiagnostics();
-          TC.diagnose(segment->getLoc(),
-                      diag::silence_optional_in_interpolation_segment_cast,
-                      segmentTy)
+          // Suggest a cast to 'Optional'.
+          TC.diagnose(segment->getLoc(), diag::default_optional_to_any)
             .highlight(segment->getSourceRange())
-            .fixItInsert(segment->getEndLoc(),
-                         " as " + segmentTy->getString(opts));
+            .fixItInsert(segment->getEndLoc(), " ?? <#default value#>");
         }
       }
       return { true, E };

--- a/test/Sema/diag_unintended_optional_behavior.swift
+++ b/test/Sema/diag_unintended_optional_behavior.swift
@@ -62,12 +62,12 @@ func warnOptionalToAnyCoercion(value x: Int?) -> Any {
 func warnOptionalInStringInterpolationSegment(_ o : Int?) {
   print("Always some, Always some, Always some: \(o)")
   // expected-warning@-1 {{string interpolation produces a debug description for an optional value; did you mean to make this explicit?}}
-  // expected-note@-2 {{use '.debugDescription' to silence this warning}} {{52-52=.debugDescription}}
-  // expected-note@-3 {{use 'as' to explicitly cast to 'Int?' to silence this warning}} {{52-52= as Int?}}
+  // expected-note@-2 {{use 'String(describing:)' to silence this warning}} {{51-51=String(describing: }} {{52-52=)}} 
+  // expected-note@-3 {{provide a default value to avoid this warning}} {{52-52= ?? <#default value#>}}
   print("Always some, Always some, Always some: \(o.map { $0 + 1 })")
   // expected-warning@-1 {{string interpolation produces a debug description for an optional value; did you mean to make this explicit?}}
-  // expected-note@-2 {{use '.debugDescription' to silence this warning}} {{67-67=.debugDescription}}
-  // expected-note@-3 {{use 'as' to explicitly cast to 'Int?' to silence this warning}} {{67-67= as Int?}}
+  // expected-note@-2 {{use 'String(describing:)' to silence this warning}} {{51-51=String(describing: }} {{67-67=)}} 
+  // expected-note@-3 {{provide a default value to avoid this warning}} {{67-67= ?? <#default value#>}}
 
   print("Always some, Always some, Always some: \(o as Int?)") // No warning
   print("Always some, Always some, Always some: \(o.debugDescription)") // No warning.


### PR DESCRIPTION
Improvements to the diagnostics from #5110 as suggested by @jrose-apple and @jtbandes.
