### PR TITLE
Fixed an assert caused when a TupleExpr that didn't have a valid SourceRange had a valid SourceLoc for the first element but not for the last

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -2055,8 +2055,7 @@ public:
   SourceLoc getLParenLoc() const { return LParenLoc; }
   SourceLoc getRParenLoc() const { return RParenLoc; }
 
-  SourceLoc getStartLoc() const;
-  SourceLoc getEndLoc() const;
+  SourceRange getSourceRange() const;
 
   /// \brief Whether this expression has a trailing closure as its argument.
   bool hasTrailingClosure() const { return TupleExprBits.HasTrailingClosure; }

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1314,18 +1314,32 @@ SequenceExpr *SequenceExpr::create(ASTContext &ctx, ArrayRef<Expr*> elements) {
   return ::new(Buffer) SequenceExpr(elements);
 }
 
-SourceLoc TupleExpr::getStartLoc() const {
-  if (LParenLoc.isValid()) return LParenLoc;
-  if (getNumElements() == 0) return SourceLoc();
-  return getElement(0)->getStartLoc();
-}
-
-SourceLoc TupleExpr::getEndLoc() const {
-  if (hasTrailingClosure() || RParenLoc.isInvalid()) {
-    if (getNumElements() == 0) return SourceLoc();
-    return getElements().back()->getEndLoc();
+SourceRange TupleExpr::getSourceRange() const {
+  SourceLoc start = SourceLoc();
+  SourceLoc end = SourceLoc();
+  if (LParenLoc.isValid()) {
+    start = LParenLoc;
+  } else if (getNumElements() == 0) {
+    return { SourceLoc(), SourceLoc() };
+  } else {
+    start = getElement(0)->getStartLoc();
   }
-  return RParenLoc;
+  
+  if (hasTrailingClosure() || RParenLoc.isInvalid()) {
+    if (getNumElements() == 0) {
+      return { SourceLoc(), SourceLoc() };
+    } else {
+      end = getElements().back()->getEndLoc();
+    }
+  } else {
+    end = RParenLoc;
+  }
+  
+  if (start.isValid() && end.isValid()) {
+    return { start, end };
+  } else {
+    return { SourceLoc(), SourceLoc() };
+  }
 }
 
 TupleExpr::TupleExpr(SourceLoc LParenLoc, ArrayRef<Expr *> SubExprs,

--- a/unittests/AST/SourceLocTests.cpp
+++ b/unittests/AST/SourceLocTests.cpp
@@ -134,12 +134,21 @@ TEST(SourceLoc, TupleExpr) {
       DeclNameLoc());
   
   // the tuple from the example
-  SmallVector<Expr *, 2> SubExprs({ one, two });
-  SmallVector<Identifier, 2> SubExprNames(2, Identifier());
-  auto exampleTuple = TupleExpr::createImplicit(C.Ctx, SubExprs, SubExprNames);
+  SmallVector<Expr *, 2> subExprsRight({ one, two });
+  SmallVector<Identifier, 2> subExprNamesRight(2, Identifier());
+  auto rightInvalidTuple = TupleExpr::createImplicit(C.Ctx, subExprsRight, subExprNamesRight);
   
   EXPECT_EQ(start, one->getStartLoc());
-  EXPECT_EQ(SourceLoc(), exampleTuple->getStartLoc());
-  EXPECT_EQ(SourceLoc(), exampleTuple->getEndLoc());
-  EXPECT_EQ(SourceRange(), exampleTuple->getSourceRange());
+  EXPECT_EQ(SourceLoc(), rightInvalidTuple->getStartLoc());
+  EXPECT_EQ(SourceLoc(), rightInvalidTuple->getEndLoc());
+  EXPECT_EQ(SourceRange(), rightInvalidTuple->getSourceRange());
+
+  SmallVector<Expr *, 2> subExprsLeft({ two, one });
+  SmallVector<Identifier, 2> subExprNamesLeft(2, Identifier());
+  auto leftInvalidTuple = TupleExpr::createImplicit(C.Ctx, subExprsLeft, subExprNamesLeft);
+  
+  EXPECT_EQ(start, one->getStartLoc());
+  EXPECT_EQ(SourceLoc(), leftInvalidTuple->getStartLoc());
+  EXPECT_EQ(SourceLoc(), leftInvalidTuple->getEndLoc());
+  EXPECT_EQ(SourceRange(), leftInvalidTuple->getSourceRange());
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->

Fixed an assert caused when a TupleExpr that didn't have a valid SourceRange had a valid SourceLoc for the first element but not for the last.

```
In a TupleExpr, if the parens are both invalid, then you can only have a
valid range iff both the first element and last element have valid ranges.
Source ranges also have the property:
  Start.isValid() == End.isValid()
For example, given the buffer "one", of the form:
(tuple_expr
  (declref_expr range=[test.swift:1:0 - line:1:2] ...)
  (declref_expr range=invalid ...))
the range of this TupleExpr is SourceLoc() (invalid).
      v invalid                v invalid
      (     one,         two   )
      valid ^    invalid ^
COL:  xxxxxx012xxxxxxxxxxxxxxxxx
but the SourceRange of 'one' is 1:0 - 1:2.
```
