### PR TITLE
[SourceKit] Add test case for crash triggered in swift::GenericEnvironment::mapTypeIntoContext(…)

### DIFF
--- a/validation-test/IDE/crashers/099-swift-genericenvironment-maptypeintocontext.swift
+++ b/validation-test/IDE/crashers/099-swift-genericenvironment-maptypeintocontext.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+a{
+protocol e{
+typealias e
+extension{
+let b{let a={
+#^A^#func f:e


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 178
3  swift-ide-test  0x0000000000c90cec swift::GenericEnvironment::mapTypeIntoContext(swift::GenericTypeParamType*) const + 12
4  swift-ide-test  0x0000000000a96f5c swift::TypeChecker::resolveTypeInContext(swift::TypeDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 1900
8  swift-ide-test  0x0000000000a9849d swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 157
10 swift-ide-test  0x0000000000a9946f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 159
11 swift-ide-test  0x0000000000a97c45 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 277
14 swift-ide-test  0x0000000000a26166 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
17 swift-ide-test  0x0000000000a91ec6 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 262
18 swift-ide-test  0x0000000000ac6e4c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 812
19 swift-ide-test  0x0000000000a12144 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 1092
20 swift-ide-test  0x0000000000a1538f swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 335
21 swift-ide-test  0x0000000000a155ad swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 237
24 swift-ide-test  0x0000000000a26166 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
27 swift-ide-test  0x0000000000a90c33 swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 355
28 swift-ide-test  0x0000000000a90a87 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 39
29 swift-ide-test  0x0000000000a4e871 swift::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 657
43 swift-ide-test  0x0000000000c54904 swift::Decl::walk(swift::ASTWalker&) + 20
44 swift-ide-test  0x0000000000ca8fae swift::SourceFile::walk(swift::ASTWalker&) + 174
45 swift-ide-test  0x0000000000ca82bf swift::ModuleDecl::walk(swift::ASTWalker&) + 95
46 swift-ide-test  0x0000000000c7ee24 swift::DeclContext::walkContext(swift::ASTWalker&) + 180
47 swift-ide-test  0x0000000000988058 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 136
48 swift-ide-test  0x0000000000838541 swift::CompilerInstance::performSema() + 3697
49 swift-ide-test  0x00000000007d8d91 main + 42417
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl declaration 0x49c7a90 at <INPUT-FILE>:3:1
2.  While type-checking declaration 0x4e22620 at <INPUT-FILE>:7:7
3.  While type-checking expression at [<INPUT-FILE>:7:13 - line:8:9] RangeText="{
func f:e"
4.  While type-checking 'f' at <INPUT-FILE>:8:2
5.  While resolving type e at [<INPUT-FILE>:8:9 - line:8:9] RangeText="e"
```
