### PR TITLE
[swiftc (73 vs. 5174)] Add crasher in swift::GenericEnvironment::mapTypeIntoContext(...)

### DIFF
--- a/validation-test/compiler_crashers/28435-swift-genericenvironment-maptypeintocontext.swift
+++ b/validation-test/compiler_crashers/28435-swift-genericenvironment-maptypeintocontext.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+enum ST:d
+protocol a{typealias d:A.B{
+{
+}}struct A:a{}func d:d typealias B}typealias d:a


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericEnvironment::mapTypeIntoContext(...)`.

Current number of unresolved compiler crashers: 73 (5174 resolved)

Stack trace:

```
3  swift           0x0000000001168cac swift::GenericEnvironment::mapTypeIntoContext(swift::GenericTypeParamType*) const + 12
4  swift           0x0000000000fe29bc swift::TypeChecker::resolveTypeInContext(swift::TypeDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 1900
8  swift           0x0000000000fe3efd swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 157
10 swift           0x0000000000fe4ecf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 159
11 swift           0x0000000000fe36a5 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 277
14 swift           0x0000000000f6c4e7 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1511
17 swift           0x0000000000fbde1a swift::TypeChecker::resolveTypeWitness(swift::NormalProtocolConformance const*, swift::AssociatedTypeDecl*) + 218
18 swift           0x0000000001196b93 swift::NormalProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 147
19 swift           0x0000000001196ad8 swift::ProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 40
20 swift           0x0000000000fb1bff swift::TypeChecker::lookupMemberType(swift::DeclContext*, swift::Type, swift::Identifier, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 1119
22 swift           0x0000000000fe3efd swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 157
24 swift           0x0000000000fe4ecf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 159
25 swift           0x0000000000fe36a5 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 277
26 swift           0x0000000000f6ab8a swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 4042
28 swift           0x0000000000f6c404 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1284
32 swift           0x0000000000fe3efd swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 157
34 swift           0x0000000000fe4ecf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 159
35 swift           0x0000000000fe36a5 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 277
38 swift           0x0000000000f6c4e7 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1511
41 swift           0x0000000000fbde1a swift::TypeChecker::resolveTypeWitness(swift::NormalProtocolConformance const*, swift::AssociatedTypeDecl*) + 218
42 swift           0x0000000001196b93 swift::NormalProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 147
43 swift           0x0000000001196ad8 swift::ProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 40
44 swift           0x0000000000fb1bff swift::TypeChecker::lookupMemberType(swift::DeclContext*, swift::Type, swift::Identifier, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 1119
46 swift           0x0000000000fe3efd swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 157
48 swift           0x0000000000fe4ecf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 159
49 swift           0x0000000000fe36a5 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 277
50 swift           0x00000000010ac937 swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 151
51 swift           0x0000000001083cf7 swift::IterativeTypeChecker::process(swift::TypeCheckRequest, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 135
52 swift           0x0000000001084452 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 498
53 swift           0x0000000000f69b69 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) + 137
54 swift           0x0000000000f6c5b3 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1715
55 swift           0x00000000010ad4d8 swift::IterativeTypeChecker::processResolveTypeDecl(swift::TypeDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 264
56 swift           0x0000000001083d95 swift::IterativeTypeChecker::process(swift::TypeCheckRequest, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 293
57 swift           0x0000000001084452 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 498
58 swift           0x00000000010845f8 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 920
61 swift           0x0000000000f6c4e7 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1511
65 swift           0x0000000000fe3efd swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 157
67 swift           0x0000000000fe4ecf swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 159
68 swift           0x0000000000fe36a5 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 277
69 swift           0x00000000010ac937 swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 151
70 swift           0x0000000001083cf7 swift::IterativeTypeChecker::process(swift::TypeCheckRequest, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 135
71 swift           0x0000000001084452 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 498
72 swift           0x00000000010845f8 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 920
73 swift           0x0000000000f69a60 swift::TypeChecker::resolveRawType(swift::EnumDecl*) + 64
74 swift           0x000000000119867b swift::NominalTypeDecl::prepareConformanceTable() const + 315
75 swift           0x00000000011989bf swift::NominalTypeDecl::getImplicitProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) + 15
76 swift           0x0000000000f69f98 swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 984
77 swift           0x0000000000f6c069 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 361
80 swift           0x0000000000f72616 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
81 swift           0x0000000000f97a8f swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1055
82 swift           0x0000000000d0fec6 swift::CompilerInstance::performSema() + 3350
83 swift           0x000000000085d20e swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 3422
84 swift           0x00000000008246ce main + 2878
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28435-swift-genericenvironment-maptypeintocontext.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28435-swift-genericenvironment-maptypeintocontext-94e705.o
1.  While type-checking 'ST' at validation-test/compiler_crashers/28435-swift-genericenvironment-maptypeintocontext.swift:9:1
2.  While resolving type d at [validation-test/compiler_crashers/28435-swift-genericenvironment-maptypeintocontext.swift:9:9 - line:9:9] RangeText="d"
3.  While type-checking 'd' at validation-test/compiler_crashers/28435-swift-genericenvironment-maptypeintocontext.swift:12:36
4.  While resolving type A.B at [validation-test/compiler_crashers/28435-swift-genericenvironment-maptypeintocontext.swift:10:24 - line:10:26] RangeText="A.B"
5.  While type-checking 'd' at validation-test/compiler_crashers/28435-swift-genericenvironment-maptypeintocontext.swift:12:15
6.  While resolving type d at [validation-test/compiler_crashers/28435-swift-genericenvironment-maptypeintocontext.swift:12:22 - line:12:22] RangeText="d"
7.  While resolving type A.B at [validation-test/compiler_crashers/28435-swift-genericenvironment-maptypeintocontext.swift:10:24 - line:10:26] RangeText="A.B"
8.  While type-checking 'd' at validation-test/compiler_crashers/28435-swift-genericenvironment-maptypeintocontext.swift:12:15
9.  While resolving type d at [validation-test/compiler_crashers/28435-swift-genericenvironment-maptypeintocontext.swift:12:22 - line:12:22] RangeText="d"
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
