### PR TITLE
Log debug elapsed time using 2 decimal places

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -155,8 +155,8 @@ namespace {
       ASTContext &ctx = Function.getAsDeclContext()->getASTContext();
 
       if (ShouldDump) {
-        // Round to the nearest 100th of a millisecond
-        llvm::errs() << llvm::format("%0.2f", round(elapsed * 100000) / 100) << "ms\t";
+        // Round up to the nearest 100th of a millisecond.
+        llvm::errs() << llvm::format("%0.2f", ceil(elapsed * 100000) / 100) << "ms\t";
         Function.getLoc().print(llvm::errs(), ctx.SourceMgr);
 
         if (auto *AFD = Function.getAbstractFunctionDecl()) {

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -155,7 +155,7 @@ namespace {
       ASTContext &ctx = Function.getAsDeclContext()->getASTContext();
 
       if (ShouldDump) {
-        llvm::errs() << llvm::format("%0.1f", elapsed * 1000) << "ms\t";
+        llvm::errs() << llvm::format("%0.3f", elapsed * 1000) << "ms\t";
         Function.getLoc().print(llvm::errs(), ctx.SourceMgr);
 
         if (auto *AFD = Function.getAbstractFunctionDecl()) {

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -155,7 +155,8 @@ namespace {
       ASTContext &ctx = Function.getAsDeclContext()->getASTContext();
 
       if (ShouldDump) {
-        llvm::errs() << llvm::format("%0.3f", elapsed * 1000) << "ms\t";
+        // Round to the nearest 100th of a millisecond
+        llvm::errs() << llvm::format("%0.2f", round(elapsed * 100000) / 100) << "ms\t";
         Function.getLoc().print(llvm::errs(), ctx.SourceMgr);
 
         if (auto *AFD = Function.getAbstractFunctionDecl()) {


### PR DESCRIPTION
`-debug-time-function-bodies` is a useful flag for determining compile-time slowness, but it only logs elapsed parse times to 1/10th of a millisecond. While this is useful if a function takes a long time to parse, it doesn't help determine time lost to parsing function bodies that take a short time to parse (less than 0.1ms) but are parsed multiple times over the course of a build and therefore add up to occupying a significant portion of the build time.

Changing this helped me determine the impact of [SR-2901](https://bugs.swift.org/browse/SR-2901).

Resolves [SR-16](https://bugs.swift.org/browse/SR-16)
