### PR TITLE
[SR-2503] Implement subtraction for CharacterSet

### DIFF
--- a/stdlib/public/SDK/Foundation/CharacterSet.swift
+++ b/stdlib/public/SDK/Foundation/CharacterSet.swift
@@ -412,7 +412,17 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
             $0.formIntersection(with: other)
         }
     }
-    
+
+    /// Returns the set of elements in the `CharacterSet` but not in another `CharacterSet`.
+    public func subtracting(_ other: CharacterSet) -> CharacterSet {
+        return intersection(other.inverted)
+    }
+
+    /// Sets the value to the set of elements in the `CharacterSet` but not in another `CharacterSet`.
+    public mutating func subtract(_ other: CharacterSet) {
+        self = subtracting(other)
+    }
+
     /// Returns the exclusive or of the `CharacterSet` with another `CharacterSet`.
     public func symmetricDifference(_ other: CharacterSet) -> CharacterSet {
         return union(other).subtracting(intersection(other))

--- a/stdlib/public/SDK/Foundation/CharacterSet.swift
+++ b/stdlib/public/SDK/Foundation/CharacterSet.swift
@@ -406,29 +406,29 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
         return result
     }
     
-    /// Sets the value to the intersection of the `CharacterSet` with another `CharacterSet`.
+    /// Sets the value to an intersection of the `CharacterSet` with another `CharacterSet`.
     public mutating func formIntersection(_ other: CharacterSet) {
         _applyUnmanagedMutation {
             $0.formIntersection(with: other)
         }
     }
 
-    /// Returns the set of elements in the `CharacterSet` but not in another `CharacterSet`.
+    /// Returns a `CharacterSet` created by removing elements in `other` from `self`.
     public func subtracting(_ other: CharacterSet) -> CharacterSet {
         return intersection(other.inverted)
     }
 
-    /// Sets the value to the set of elements in the `CharacterSet` but not in another `CharacterSet`.
+    /// Sets the value to a `CharacterSet` created by removing elements in `other` from `self`.
     public mutating func subtract(_ other: CharacterSet) {
         self = subtracting(other)
     }
 
-    /// Returns the exclusive or of the `CharacterSet` with another `CharacterSet`.
+    /// Returns an exclusive or of the `CharacterSet` with another `CharacterSet`.
     public func symmetricDifference(_ other: CharacterSet) -> CharacterSet {
         return union(other).subtracting(intersection(other))
     }
     
-    /// Sets the value to the exclusive or of the `CharacterSet` with another `CharacterSet`.
+    /// Sets the value to an exclusive or of the `CharacterSet` with another `CharacterSet`.
     public mutating func formSymmetricDifference(_ other: CharacterSet) {
         self = symmetricDifference(other)
     }

--- a/test/stdlib/TestCharacterSet.swift
+++ b/test/stdlib/TestCharacterSet.swift
@@ -192,6 +192,15 @@ class TestCharacterSet : TestCharacterSetSuper {
         expectEqual(expected, union)
     }
 
+    func test_subtractAndFormSymmetricDifference() {
+        var set1 = CharacterSet(charactersIn: "abc")
+        let set2 = CharacterSet(charactersIn: "b")
+        set1.subtract(set2)
+        expectFalse(set1.contains("b"))
+        set1.formSymmetricDifference(set2)
+        expectTrue(set1.contains("b"))
+    }
+
     func test_hasMember() {
         let contains = CharacterSet.letters.hasMember(inPlane: 1)
         expectTrue(contains)
@@ -219,6 +228,7 @@ CharacterSetTests.test("test_AnyHashableContainingCharacterSet") { TestCharacter
 CharacterSetTests.test("test_AnyHashableCreatedFromNSCharacterSet") { TestCharacterSet().test_AnyHashableCreatedFromNSCharacterSet() }
 CharacterSetTests.test("test_superSet") { TestCharacterSet().test_superSet() }
 CharacterSetTests.test("test_union") { TestCharacterSet().test_union() }
+CharacterSetTests.test("test_subtractAndFormSymmetricDifference") { TestCharacterSet().test_subtractAndFormSymmetricDifference() }
 CharacterSetTests.test("test_hasMember") { TestCharacterSet().test_hasMember() }
 CharacterSetTests.test("test_bitmap") { TestCharacterSet().test_bitmap() }
 runAllTests()

--- a/test/stdlib/TestCharacterSet.swift
+++ b/test/stdlib/TestCharacterSet.swift
@@ -192,20 +192,31 @@ class TestCharacterSet : TestCharacterSetSuper {
         expectEqual(expected, union)
     }
 
-    func test_subtractAndFormSymmetricDifference() {
-        var set1 = CharacterSet(charactersIn: "abc")
-        let set2 = CharacterSet(charactersIn: "b")
-        set1.subtract(set2)
-        expectFalse(set1.contains("b"))
-        set1.formSymmetricDifference(set2)
-        expectTrue(set1.contains("b"))
+    func test_subtracting() {
+        let difference = CharacterSet(charactersIn: "abc").subtracting(CharacterSet(charactersIn: "b"))
+        let expected = CharacterSet(charactersIn: "ac")
+        expectEqual(expected, difference)
+    }
 
-        let expected = set1
-        var set3 = CharacterSet()
-        set1.subtract(set3)
-        expectEqual(expected, set1)
-        set3.subtract(set1)
-        expectTrue(set3.isEmpty)
+    func test_subtractEmptySet() {
+        var mutableSet = CharacterSet(charactersIn: "abc")
+        let emptySet = CharacterSet()
+        mutableSet.subtract(emptySet)
+        let expected = CharacterSet(charactersIn: "abc")
+        expectEqual(expected, mutableSet)
+    }
+
+    func test_subtractNonEmptySet() {
+        var mutableSet = CharacterSet()
+        let nonEmptySet = CharacterSet(charactersIn: "abc")
+        mutableSet.subtract(nonEmptySet)
+        expectTrue(mutableSet.isEmpty)
+    }
+
+    func test_symmetricDifference() {
+        let symmetricDifference = CharacterSet(charactersIn: "ac").symmetricDifference(CharacterSet(charactersIn: "b"))
+        let expected = CharacterSet(charactersIn: "abc")
+        expectEqual(expected, symmetricDifference)
     }
 
     func test_hasMember() {
@@ -235,7 +246,10 @@ CharacterSetTests.test("test_AnyHashableContainingCharacterSet") { TestCharacter
 CharacterSetTests.test("test_AnyHashableCreatedFromNSCharacterSet") { TestCharacterSet().test_AnyHashableCreatedFromNSCharacterSet() }
 CharacterSetTests.test("test_superSet") { TestCharacterSet().test_superSet() }
 CharacterSetTests.test("test_union") { TestCharacterSet().test_union() }
-CharacterSetTests.test("test_subtractAndFormSymmetricDifference") { TestCharacterSet().test_subtractAndFormSymmetricDifference() }
+CharacterSetTests.test("test_subtracting") { TestCharacterSet().test_subtracting() }
+CharacterSetTests.test("test_subtractEmptySet") { TestCharacterSet().test_subtractEmptySet() }
+CharacterSetTests.test("test_subtractNonEmptySet") { TestCharacterSet().test_subtractNonEmptySet() }
+CharacterSetTests.test("test_symmetricDifference") { TestCharacterSet().test_symmetricDifference() }
 CharacterSetTests.test("test_hasMember") { TestCharacterSet().test_hasMember() }
 CharacterSetTests.test("test_bitmap") { TestCharacterSet().test_bitmap() }
 runAllTests()

--- a/test/stdlib/TestCharacterSet.swift
+++ b/test/stdlib/TestCharacterSet.swift
@@ -199,6 +199,13 @@ class TestCharacterSet : TestCharacterSetSuper {
         expectFalse(set1.contains("b"))
         set1.formSymmetricDifference(set2)
         expectTrue(set1.contains("b"))
+
+        let expected = set1
+        var set3 = CharacterSet()
+        set1.subtract(set3)
+        expectEqual(expected, set1)
+        set3.subtract(set1)
+        expectTrue(set3.isEmpty)
     }
 
     func test_hasMember() {


### PR DESCRIPTION
Execution is interrupted when `CharacterSet.subtracting(_:)` is invoked. The underlying reason is that `subtracting(_:)` is a default implementation that calls `symmetricDifference(_:)`, but `CharacterSet.symmetricDifference(_:)` invokes `subtracting(_:)`.

This PR implements `CharacterSet.subtracting(_:)` and `CharacterSet.subtract(_:)`. As a side benefit, `CharacterSet.symmetricDifference(_:)` and `CharacterSet.formSymmetricDifference(_:)` are now usable as well, where previously their invocation would also halt execution.

A new test has been added for this code.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-2503](https://bugs.swift.org/browse/SR-2503).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
