### PR TITLE
Update embedded bitcode support to work with llvm r269706.

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -517,6 +517,22 @@ static void embedBitcode(llvm::Module *M, const IRGenOptions &Opts)
   if (Opts.EmbedMode == IRGenEmbedMode::None)
     return;
 
+  // Save llvm.compiler.used and remove it.
+  SmallVector<llvm::Constant*, 2> UsedArray;
+  SmallSet<llvm::GlobalValue*, 4> UsedGlobals;
+  auto *UsedElementType =
+    llvm::Type::getInt8Ty(M->getContext())->getPointerTo(0);
+  llvm::GlobalVariable *Used =
+    collectUsedGlobalVariables(*M, UsedGlobals, true);
+  for (auto *GV : UsedGlobals) {
+    if (GV->getName() != "llvm.embedded.module" &&
+        GV->getName() != "llvm.cmdline")
+      UsedArray.push_back(
+          ConstantExpr::getPointerBitCastOrAddrSpaceCast(GV, UsedElementType));
+  }
+  if (Used)
+    Used->eraseFromParent();
+
   // Embed the bitcode for the llvm module.
   std::string Data;
   llvm::raw_string_ostream OS(Data);
@@ -526,14 +542,15 @@ static void embedBitcode(llvm::Module *M, const IRGenOptions &Opts)
   ArrayRef<uint8_t> ModuleData((uint8_t*)OS.str().data(), OS.str().size());
   llvm::Constant *ModuleConstant =
     llvm::ConstantDataArray::get(M->getContext(), ModuleData);
-  // Use Appending linkage so it doesn't get optimized out.
   llvm::GlobalVariable *GV = new llvm::GlobalVariable(*M,
                                        ModuleConstant->getType(), true,
-                                       llvm::GlobalValue::AppendingLinkage,
+                                       llvm::GlobalValue::PrivateLinkage,
                                        ModuleConstant);
+  UsedArray.push_back(
+    llvm::ConstantExpr::getPointerBitCastOrAddrSpaceCast(GV, UsedElementType));
   GV->setSection("__LLVM,__bitcode");
   if (llvm::GlobalVariable *Old =
-      M->getGlobalVariable("llvm.embedded.module")) {
+      M->getGlobalVariable("llvm.embedded.module", true)) {
     GV->takeName(Old);
     Old->replaceAllUsesWith(GV);
     delete Old;
@@ -547,16 +564,28 @@ static void embedBitcode(llvm::Module *M, const IRGenOptions &Opts)
   llvm::Constant *CmdConstant =
     llvm::ConstantDataArray::get(M->getContext(), CmdData);
   GV = new llvm::GlobalVariable(*M, CmdConstant->getType(), true,
-                                llvm::GlobalValue::AppendingLinkage,
+                                llvm::GlobalValue::PrivateLinkage,
                                 CmdConstant);
   GV->setSection("__LLVM,__swift_cmdline");
-  if (llvm::GlobalVariable *Old = M->getGlobalVariable("llvm.cmdline")) {
+  UsedArray.push_back(
+    llvm::ConstantExpr::getPointerBitCastOrAddrSpaceCast(GV, UsedElementType));
+  if (llvm::GlobalVariable *Old = M->getGlobalVariable("llvm.cmdline", true)) {
     GV->takeName(Old);
     Old->replaceAllUsesWith(GV);
     delete Old;
   } else {
     GV->setName("llvm.cmdline");
   }
+
+  if (UsedArray.empty())
+    return;
+
+  // Recreate llvm.compiler.used.
+  auto *ATy = llvm::ArrayType::get(UsedElementType, UsedArray.size());
+  auto *NewUsed = new GlobalVariable(
+           *M, ATy, false, llvm::GlobalValue::AppendingLinkage,
+           llvm::ConstantArray::get(ATy, UsedArray), "llvm.compiler.used");
+  NewUsed->setSection("llvm.metadata");
 }
 
 static void initLLVMModule(const IRGenModule &IGM) {

--- a/test/Driver/multi-threaded.swift
+++ b/test/Driver/multi-threaded.swift
@@ -1,5 +1,3 @@
-// REQUIRES: rdar23493035
-
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %target-swiftc_driver -driver-print-jobs -module-name=ThisModule -wmo -num-threads 4 %S/Inputs/main.swift %s -emit-module -o test.swiftmodule | %FileCheck -check-prefix=MODULE %s
 // RUN: echo "{\"%s\": {\"assembly\": \"/build/multi-threaded.s\"}, \"%S/Inputs/main.swift\": {\"assembly\": \"/build/main.s\"}}" > %t/ofms.json

--- a/test/Frontend/embed-bitcode.ll
+++ b/test/Frontend/embed-bitcode.ll
@@ -1,5 +1,4 @@
 ; REQUIRES: CPU=x86_64
-; REQUIRES: rdar23493035
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: %swift -target x86_64-apple-darwin10 -c -module-name someModule -embed-bitcode -disable-llvm-optzns -o %t2.o %t.bc -dump-clang-diagnostics 2> %t.diags.txt
 ; RUN: llvm-objdump -macho -section="__LLVM,__bitcode" %t2.o | %FileCheck %s

--- a/test/Frontend/embed-bitcode.swift
+++ b/test/Frontend/embed-bitcode.swift
@@ -1,5 +1,4 @@
 // REQUIRES: CPU=x86_64
-// REQUIRES: rdar23493035
 // RUN: %target-swift-frontend -c -module-name someModule -embed-bitcode-marker  -o %t.o %s
 // RUN: llvm-objdump -macho -section="__LLVM,__bitcode" %t.o | %FileCheck -check-prefix=MARKER %s
 // RUN: llvm-objdump -macho -section="__LLVM,__swift_cmdline" %t.o | %FileCheck -check-prefix=MARKER-CMD %s


### PR DESCRIPTION
<!-- What's in this pull request? -->

Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

The original support for embedded bitcode used appending linkage for the
magic internal variables that hold the bitcode and command line options,
but that private linkage is a better fit. The only real reason for
appending linkage was to prevent those variables from being optimized away.
r269706 limits the use of appending linkage so that it cannot be used for
those variables, so this switches to use private linkage and keep the
variables alive with llvm.compiler.used. This is basically copied from
clang r269679. rdar://problem/28685198.

As of the swift-3.1-branch versions of Clang/LLVM, embedded bitcode is now
working well enough that the tests can be reenabled. rdar://problem/26247134
