### PR TITLE
[SourceKit] Add test case for crash triggered in swift::Mangle::Mangler::mangleDeclName(…)

### DIFF
--- a/validation-test/IDE/crashers/100-swift-mangle-mangler-mangledeclname.swift
+++ b/validation-test/IDE/crashers/100-swift-mangle-mangler-mangledeclname.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+{let:{class S(}#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 141
swift-ide-test: /path/to/llvm/include/llvm/ADT/StringRef.h:74: llvm::StringRef::StringRef(const char *): Assertion `Str && "StringRef cannot be built from a NULL argument"' failed.
8  swift-ide-test  0x0000000000ca060c swift::Mangle::Mangler::mangleDeclName(swift::ValueDecl const*) + 716
9  swift-ide-test  0x0000000000ca0283 swift::Mangle::Mangler::mangleEntity(swift::ValueDecl const*, unsigned int) + 499
10 swift-ide-test  0x0000000000c9f546 swift::Mangle::Mangler::mangleContext(swift::DeclContext const*) + 918
11 swift-ide-test  0x0000000000c9fdbd swift::Mangle::Mangler::mangleNominalType(swift::NominalTypeDecl const*) + 157
12 swift-ide-test  0x0000000000ce2ad3 swift::ide::printDeclUSR(swift::ValueDecl const*, llvm::raw_ostream&) + 1107
14 swift-ide-test  0x0000000000840ba4 copyAssociatedUSRs(llvm::BumpPtrAllocatorImpl<llvm::MallocAllocator, 4096ul, 4096ul>&, swift::Decl const*) + 100
15 swift-ide-test  0x000000000084193f swift::ide::CodeCompletionResultBuilder::takeResult() + 1439
19 swift-ide-test  0x0000000000c9a541 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 529
22 swift-ide-test  0x0000000000988451 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 305
23 swift-ide-test  0x0000000000838911 swift::CompilerInstance::performSema() + 3697
24 swift-ide-test  0x00000000007d9161 main + 42417
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
```
