### PR TITLE
[swiftc (74 vs. 5174)] Add crasher in swift::TypeChecker::typeCheckDecl(…)

### DIFF
--- a/validation-test/compiler_crashers/28436-swift-typechecker-typecheckdecl.swift
+++ b/validation-test/compiler_crashers/28436-swift-typechecker-typecheckdecl.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+@objc protocol a{func^class c:a{func^


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::typeCheckDecl(...)`.

Current number of unresolved compiler crashers: 74 (5174 resolved)

Assertion failure in [`lib/Sema/TypeCheckType.cpp (line 3023)`](https://github.com/apple/swift/blob/master/lib/Sema/TypeCheckType.cpp#L3023):

```
Assertion `isa<ProtocolDecl>(AFD->getDeclContext()) && "all other cases should be caught earlier"' failed.

When executing: bool swift::TypeChecker::isRepresentableInObjC(const swift::AbstractFunctionDecl *, swift::ObjCReason, Optional<swift::ForeignErrorConvention> &)
```

Assertion context:

```
  if (checkObjCInExtensionContext(*this, AFD, Diagnose))
    return false;

  if (AFD->isOperator()) {
    assert(isa<ProtocolDecl>(AFD->getDeclContext()) &&
           "all other cases should be caught earlier");
    diagnose(AFD, diag::objc_operator_proto);
    return false;
  }

  if (auto *FD = dyn_cast<FuncDecl>(AFD)) {
```

Stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckType.cpp:3023: bool swift::TypeChecker::isRepresentableInObjC(const swift::AbstractFunctionDecl *, swift::ObjCReason, Optional<swift::ForeignErrorConvention> &): Assertion `isa<ProtocolDecl>(AFD->getDeclContext()) && "all other cases should be caught earlier"' failed.
14 swift           0x0000000000f74636 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
15 swift           0x0000000000f9975f swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1055
16 swift           0x0000000000d11e86 swift::CompilerInstance::performSema() + 3350
17 swift           0x000000000085da1e swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 3422
18 swift           0x0000000000824ede main + 2878
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28436-swift-typechecker-typecheckdecl.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28436-swift-typechecker-typecheckdecl-3ef15d.o
1.  While type-checking 'a' at validation-test/compiler_crashers/28436-swift-typechecker-typecheckdecl.swift:10:7
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
