### PR TITLE
[swiftc (75 vs. 5174)] Add crasher in swift::TypeChecker::validateDecl(…)

### DIFF
--- a/validation-test/compiler_crashers/28437-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers/28437-swift-typechecker-validatedecl.swift
@@ -1,0 +1,16 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+func a
+protocol a{
+typealias e:d
+typealias B
+typealias B<T>:P
+protocol P
+protocol d:a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::validateDecl(...)`.

Current number of unresolved compiler crashers: 75 (5174 resolved)

Assertion failure in [`lib/Sema/TypeCheckDecl.cpp (line 7389)`](https://github.com/apple/swift/blob/master/lib/Sema/TypeCheckDecl.cpp#L7389):

```
Assertion `D->hasType()' failed.

When executing: void swift::TypeChecker::validateDecl(swift::ValueDecl *, bool)
```

Assertion context:

```
    typeCheckDecl(D, true);
    break;
  }
  }

  assert(D->hasType());
}

void TypeChecker::validateAccessibility(ValueDecl *D) {
  if (D->hasAccessibility())
```

Stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckDecl.cpp:7389: void swift::TypeChecker::validateDecl(swift::ValueDecl *, bool): Assertion `D->hasType()' failed.
7  swift           0x0000000000f6f608 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 5800
9  swift           0x0000000000f6e547 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1511
10 swift           0x00000000010b6f8f swift::ArchetypeBuilder::PotentialArchetype::getNestedType(swift::Identifier, swift::ArchetypeBuilder&) + 623
11 swift           0x00000000010b9541 swift::ArchetypeBuilder::addConformanceRequirement(swift::ArchetypeBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::RequirementSource, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 465
14 swift           0x00000000010bb09f swift::ArchetypeBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>) + 175
15 swift           0x00000000010b9200 swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 560
16 swift           0x00000000010b8fad swift::ArchetypeBuilder::addGenericParameterRequirements(swift::GenericTypeParamDecl*) + 93
17 swift           0x0000000000fae536 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::GenericSignature*, swift::GenericEnvironment*, swift::GenericTypeResolver*) + 342
18 swift           0x0000000000fafad6 swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, bool, std::function<void (swift::ArchetypeBuilder&)>) + 118
19 swift           0x0000000000fb0570 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) + 128
20 swift           0x0000000000f6ea10 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 2736
22 swift           0x0000000000f74636 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
23 swift           0x0000000000f9975f swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1055
24 swift           0x0000000000d11e86 swift::CompilerInstance::performSema() + 3350
25 swift           0x000000000085da1e swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 3422
26 swift           0x0000000000824ede main + 2878
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28437-swift-typechecker-validatedecl.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28437-swift-typechecker-validatedecl-a3dd03.o
1.  While type-checking 'a' at validation-test/compiler_crashers/28437-swift-typechecker-validatedecl.swift:10:1
2.  While type-checking 'B' at validation-test/compiler_crashers/28437-swift-typechecker-validatedecl.swift:14:1
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
