### PR TITLE
[SourceKit] Add test case for crash triggered in swift::Decl::print(…)

### DIFF
--- a/validation-test/IDE/crashers/101-swift-decl-print.swift
+++ b/validation-test/IDE/crashers/101-swift-decl-print.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+class A{func b(a c s:]class c:A{#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 158
swift-ide-test: /path/to/llvm/include/llvm/ADT/SmallVector.h:145: reference llvm::SmallVectorTemplateCommon<swift::ParameterTypeFlags, void>::operator[](size_type) [T = swift::ParameterTypeFlags]: Assertion `idx < size()' failed.
11 swift-ide-test  0x0000000000c2e6b1 swift::Decl::print(swift::ASTPrinter&, swift::PrintOptions const&) const + 65
16 swift-ide-test  0x0000000000988451 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 305
17 swift-ide-test  0x0000000000838911 swift::CompilerInstance::performSema() + 3697
18 swift-ide-test  0x00000000007d9161 main + 42417
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
```
