### PR TITLE
Disable a check that relies on assertions in test/IDE/complete_pound_decl.swift

### DIFF
--- a/test/IDE/complete_pound_decl.swift
+++ b/test/IDE/complete_pound_decl.swift
@@ -6,7 +6,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_ELSE_MEMATTR | %FileCheck %s -check-prefix=ATTR
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_IF_GBLATTR | %FileCheck %s -check-prefix=ATTR
-// FIXME: RUN: not --crash %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_IF_GBLNAME 
+// FIXME: SR-2364 the following line triggers an assertion
+// RUN_DISABLED: not --crash %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_IF_GBLNAME
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_ELIF_GBLNAME | %FileCheck %s -check-prefix=GLOBAL
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_ELIF_GBLATTR | %FileCheck %s -check-prefix=ATTR
 


### PR DESCRIPTION
he test was expecting a crash (covered by SR-2364), but it only happens
with assertions enabled.  Disable it for now, since it's causing
failures in no-asserts builds.

rdar://problem/28679273
