### PR TITLE
[SIL] Fix CMakeLists warning

### DIFF
--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -43,4 +43,4 @@ add_swift_library(swiftSIL STATIC
 if(NOT SWIFT_BUILT_STANDALONE)
   get_property(CLANG_TABLEGEN_TARGETS GLOBAL PROPERTY CLANG_TABLEGEN_TARGETS)
   add_dependencies(swiftSIL intrinsics_gen ${CLANG_TABLEGEN_TARGETS})
-endif(CLANG_TABLEGEN_TARGETS)
+endif()


### PR DESCRIPTION
Fix a CMake warning:

```
CMake Warning (dev) in lib/SIL/CMakeLists.txt:
  A logical block opening on the line

    swift/lib/SIL/CMakeLists.txt:43 (if)

  closes on the line

    swift/lib/SIL/CMakeLists.txt:46 (endif)

  with mis-matching arguments.
This warning is for project developers.  Use -Wno-dev to suppress it.
```
