### PR TITLE
More fixes for crashes when building with a recent clang.

### DIFF
--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -117,7 +117,7 @@ namespace {
     llvm::StringMap<SourceLoc> ForwardRefLocalValues;
 
     /// A callback to be invoked every time a type was deserialized.
-    llvm::function_ref<void(Type)> ParsedTypeCallback;
+    std::function<void(Type)> ParsedTypeCallback;
 
 
     bool performTypeLocChecking(TypeLoc &T, bool IsSILType,

--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -120,9 +120,9 @@ static void addReturnValueImpl(SILBasicBlock *RetBB, SILBasicBlock *NewRetBB,
   }
   // Create a CFG edge from NewRetBB to MergedBB.
   Builder.setInsertionPoint(NewRetBB);
-  ArrayRef<SILValue> BBArgs;
+  SmallVector<SILValue, 1> BBArgs;
   if (!NewRetVal->getType().isVoid())
-    BBArgs = NewRetVal;
+    BBArgs.push_back(NewRetVal);
   Builder.createBranch(Loc, MergedBB, BBArgs);
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->

Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

These are more instances of the same problems we've seen elsewhere with
ArrayRef and function_ref capturing references to temporary values.

rdar://problem/28685187