### PR TITLE
[serialization] Yet Another Misuse of ArrayRef

### DIFF
--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1117,8 +1117,9 @@ Status ModuleFile::associateWithFileContext(FileUnit *file,
       auto scopeID = ctx.getIdentifier(scopePath);
       assert(!scopeID.empty() &&
              "invalid decl name (non-top-level decls not supported)");
-      auto path = Module::AccessPathTy({scopeID, SourceLoc()});
-      dependency.Import = { ctx.AllocateCopy(path), module };
+      std::pair<Identifier, SourceLoc> accessPathElem(scopeID, SourceLoc());
+      dependency.Import = {ctx.AllocateCopy(llvm::makeArrayRef(accessPathElem)),
+                           module};
     }
   }
 


### PR DESCRIPTION
I found this one by guessing which file was the problem, compiling it with -O0, and seeing if things got better, then marking the [problematic ArrayRef constructors](https://reviews.llvm.org/D25446) as `deprecated` and seeing if we were using any in that file (which we were). This is not a good workflow.

rdar://problem/28699599
