### PR TITLE
Sil verify all verify functions when added to worklist

### DIFF
--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -247,7 +247,7 @@ bool SILPassManager::continueTransforming() {
 }
 
 bool SILPassManager::analysesUnlocked() {
-  for (auto A : Analysis)
+  for (auto *A : Analysis)
     if (A->isLocked())
       return false;
 
@@ -542,11 +542,11 @@ void SILPassManager::run() {
 /// D'tor.
 SILPassManager::~SILPassManager() {
   // Free all transformations.
-  for (auto T : Transformations)
+  for (auto *T : Transformations)
     delete T;
 
   // delete the analysis.
-  for (auto A : Analysis) {
+  for (auto *A : Analysis) {
     Mod->removeDeleteNotificationHandler(A);
     assert(!A->isLocked() &&
            "Deleting a locked analysis. Did we forget to unlock ?");
@@ -590,7 +590,7 @@ void SILPassManager::restartWithCurrentFunction(SILTransform *T) {
 /// \brief Reset the state of the pass manager and remove all transformation
 /// owned by the pass manager. Analysis passes will be kept.
 void SILPassManager::resetAndRemoveTransformations() {
-  for (auto T : Transformations)
+  for (auto *T : Transformations)
     delete T;
 
   Transformations.clear();

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -481,7 +481,7 @@ void SILPassManager::runOneIteration() {
   }
   NumOptzIterations++;
   NumOptimizationIterations++;
-  SmallVector<SILFunctionTransform*, 16> PendingFuncTransforms;
+  SmallVector<SILFunctionTransform *, 16> PendingFuncTransforms;
 
   // Run the transforms by alternating between function transforms and
   // module transforms. We'll queue up all the function transforms

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -559,7 +559,7 @@ void SILPassManager::addFunctionToWorklist(SILFunction *F,
   assert(F && F->isDefinition() && F->shouldOptimize() &&
          "Expected optimizable function definition!");
 
-  const int MaxDeriveLevels = 10;
+  constexpr int MaxDeriveLevels = 10;
 
   int NewLevel = 1;
   if (DerivedFrom) {


### PR DESCRIPTION
When SILVerifyAll is enabled, individual functions are verified after
function passes are run upon them. This means that any functions created
by a function pass will not be verified after the pass runs. Thus
specialization errors that cause the verifier to trip will be
misattributed to the first pass that makes a change to the specialized
function. This is very misleading and increases triage time.

As a result, when SILVerifyAll is enabled, we always verify newly
specialized functions as they are added to the worklist.
