### PR TITLE
SIL ownership staging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,6 +275,10 @@ option(SWIFT_STDLIB_ENABLE_RESILIENCE
     "Build the standard libraries and overlays with resilience enabled; see docs/LibraryEvolution.rst"
     FALSE)
 
+option(SWIFT_STDLIB_ENABLE_SIL_OWNERSHIP
+  "Build the standard libraries and overlays with sil ownership enabled."
+  FALSE)
+
 option(SWIFT_STDLIB_SIL_SERIALIZE_ALL
     "Build the standard libraries and overlays serializing all method bodies"
     TRUE)

--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -225,6 +225,10 @@ function(_compile_swift_files dependency_target_out_var_name)
     list(APPEND swift_flags "-Xfrontend" "-enable-resilience")
   endif()
 
+  if(SWIFT_STDLIB_ENABLE_SIL_OWNERSHIP AND SWIFTFILE_IS_STDLIB)
+    list(APPEND swift_flags "-Xfrontend" "-enable-sil-ownership")
+  endif()
+
   if(SWIFT_EMIT_SORTED_SIL_OUTPUT)
     list(APPEND swift_flags "-Xfrontend" "-emit-sorted-sil")
   endif()

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -113,6 +113,9 @@ public:
 
   /// The name of the SIL outputfile if compiled with SIL debugging (-gsil).
   std::string SILOutputFileNameForDebugging;
+
+  /// If set to true, compile with the SIL Ownership Model enabled.
+  bool EnableSILOwnership = false;
 };
 
 } // end namespace swift

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -227,6 +227,9 @@ def dump_clang_diagnostics : Flag<["-"], "dump-clang-diagnostics">,
 def emit_verbose_sil : Flag<["-"], "emit-verbose-sil">,
   HelpText<"Emit locations during SIL emission">;
 
+def enable_sil_ownership : Flag<["-"], "enable-sil-ownership">,
+  HelpText<"Enable the SIL Ownership Model">;
+
 def enable_experimental_property_behaviors :
   Flag<["-"], "enable-experimental-property-behaviors">,
   HelpText<"Enable experimental property behaviors">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1132,6 +1132,7 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
     Args.hasArg(OPT_enable_guaranteed_closure_contexts);
   Opts.DisableSILPartialApply |=
     Args.hasArg(OPT_disable_sil_partial_apply);
+  Opts.EnableSILOwnership |= Args.hasArg(OPT_enable_sil_ownership);
 
   if (Args.hasArg(OPT_debug_on_sil)) {
     // Derive the name of the SIL file for debugging from

--- a/utils/build-script
+++ b/utils/build-script
@@ -2023,6 +2023,10 @@ iterations with -O",
         metavar="COUNT",
         default=default_max_lto_link_job_counts['swift'])
 
+    parser.add_argument("--enable-sil-ownership",
+                        help="Enable the SIL ownership model",
+                        action='store_true')
+
     parser.add_argument(
         # Explicitly unavailable options here.
         "--build-jobs",

--- a/utils/swift_build_support/swift_build_support/products/swift.py
+++ b/utils/swift_build_support/swift_build_support/products/swift.py
@@ -30,6 +30,9 @@ class Swift(product.Product):
         # Add benchmark specific flags.
         self.cmake_options.extend(self._benchmark_flags)
 
+        # Add any sil ownership flags.
+        self.cmake_options.extend(self._sil_ownership_flags)
+
     @property
     def _runtime_sanitizer_flags(self):
         sanitizer_list = []
@@ -92,3 +95,9 @@ updated without updating swift.py?")
             "-DSWIFT_BENCHMARK_NUM_ONONE_ITERATIONS={}".format(onone_iters),
             "-DSWIFT_BENCHMARK_NUM_O_ITERATIONS={}".format(o_iters)
         ]
+
+    @property
+    def _sil_ownership_flags(self):
+        if not self.args.enable_sil_ownership:
+            return []
+        return ["-DSWIFT_STDLIB_ENABLE_SIL_OWNERSHIP=TRUE"]

--- a/utils/swift_build_support/tests/products/test_swift.py
+++ b/utils/swift_build_support/tests/products/test_swift.py
@@ -54,7 +54,8 @@ class SwiftTestCase(unittest.TestCase):
             darwin_deployment_version_osx="10.9",
             benchmark=False,
             benchmark_num_onone_iterations=3,
-            benchmark_num_o_iterations=3)
+            benchmark_num_o_iterations=3,
+            enable_sil_ownership=False)
 
         # Setup shell
         shell.dry_run = True
@@ -263,4 +264,15 @@ class SwiftTestCase(unittest.TestCase):
         self.assertEqual(
             ['-DSWIFT_BENCHMARK_NUM_ONONE_ITERATIONS=10',
              '-DSWIFT_BENCHMARK_NUM_O_ITERATIONS=25'],
+            swift.cmake_options)
+
+    def test_sil_ownership_flags(self):
+        self.args.enable_sil_ownership = True
+        swift = Swift(
+            args=self.args,
+            toolchain=self.toolchain,
+            source_dir='/path/to/src',
+            build_dir='/path/to/build')
+        self.assertEqual(
+            ['-DSWIFT_STDLIB_ENABLE_SIL_OWNERSHIP=TRUE'],
             swift.cmake_options)


### PR DESCRIPTION
This PR contains the staging necessary for hiding semantic arc changes from affecting other developers in tree.

It is the first part of Semantic ARC that needs to land so we can create bots.

rdar://28685236
