### PR TITLE
Fix more ArrayRef problems in ImmutablePointerSetTests unit tests.

### DIFF
--- a/unittests/Basic/ImmutablePointerSetTests.cpp
+++ b/unittests/Basic/ImmutablePointerSetTests.cpp
@@ -49,7 +49,7 @@ TEST(ImmutablePointerSet, MultipleElementSets) {
   unsigned *Ptr3 = (unsigned *)3;
   unsigned *Ptr4 = (unsigned *)5;
   unsigned *Ptr5 = (unsigned *)6;
-  ArrayRef<unsigned *> Data1 = {Ptr1, Ptr2};
+  SmallVector<unsigned *, 2> Data1 = {Ptr1, Ptr2};
 
   auto *TwoEltSet = F.get(Data1);
   EXPECT_FALSE(TwoEltSet->empty());
@@ -71,7 +71,7 @@ TEST(ImmutablePointerSet, MultipleElementSets) {
   EXPECT_FALSE(ThreeEltSet->count(Ptr5));
   EXPECT_EQ(ThreeEltSet, F.merge(TwoEltSet, ThreeEltSet));
 
-  ArrayRef<unsigned *> Data2 = {Ptr3, Ptr4, Ptr5};
+  SmallVector<unsigned *, 3> Data2 = {Ptr3, Ptr4, Ptr5};
   auto *PartialOverlapSet = F.get(Data2);
   EXPECT_FALSE(PartialOverlapSet->empty());
   EXPECT_EQ(PartialOverlapSet->size(), 3u);
@@ -106,10 +106,10 @@ TEST(ImmutablePointerSet, EmptyIntersectionTests) {
   unsigned *Ptr4 = (unsigned *)5;
   unsigned *Ptr5 = (unsigned *)6;
 
-  ArrayRef<unsigned *> Data1 = {Ptr1, Ptr2};
-  ArrayRef<unsigned *> Data2 = {Ptr3, Ptr2};
-  ArrayRef<unsigned *> Data3 = {Ptr4, Ptr5};
-  ArrayRef<unsigned *> Data4 = {Ptr2, Ptr4};
+  SmallVector<unsigned *, 2> Data1 = {Ptr1, Ptr2};
+  SmallVector<unsigned *, 2> Data2 = {Ptr3, Ptr2};
+  SmallVector<unsigned *, 2> Data3 = {Ptr4, Ptr5};
+  SmallVector<unsigned *, 2> Data4 = {Ptr2, Ptr4};
 
   EXPECT_FALSE(F.get(Data1)->hasEmptyIntersection(F.get(Data2)));
   EXPECT_TRUE(F.get(Data1)->hasEmptyIntersection(F.get(Data3)));


### PR DESCRIPTION
<!-- What's in this pull request? -->

Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

These are more instances of the problem with ArrayRef capturing a
reference to a temporary. The problem is exposed when compiling with a
recent version of clang. rdar://problem/28700044
