### PR TITLE
[gardening] Remove unused diagnostic: escaping_function_type. Fix inconsistent header.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1950,8 +1950,6 @@ ERROR(noescape_implied_by_autoclosure,none,
 ERROR(noescape_conflicts_escaping_autoclosure,none,
       "@noescape conflicts with @autoclosure(escaping)", ())
 
-ERROR(escaping_function_type,none,
-      "@escaping may only be applied to parameters of function type", ())
 ERROR(escaping_non_function_parameter,none,
       "@escaping attribute may only be used in function parameter position", ())
 

--- a/lib/IRGen/GenConstant.cpp
+++ b/lib/IRGen/GenConstant.cpp
@@ -1,4 +1,4 @@
-//===--- GenConstant.cpp - Swift IR Generation For Constants ----*- C++ -*-===//
+//===--- GenConstant.cpp - Swift IR Generation For Constants --------------===//
 //
 // This source file is part of the Swift.org open source project
 //


### PR DESCRIPTION
- Remove unused diagnostic `escaping_function_type`. Last usage removed by @rintaro in 430a0d8.
- Fix inconsistent header.
