### PR TITLE
[SourceKit] Add test case for crash triggered in swift::TypeChecker::getTypeOfRValue(…)

### DIFF
--- a/validation-test/IDE/crashers/102-swift-typechecker-gettypeofrvalue.swift
+++ b/validation-test/IDE/crashers/102-swift-typechecker-gettypeofrvalue.swift
@@ -1,0 +1,7 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+protocol B
+let a{
+protocol A{extension{
+func b{func a:B
+extension{var _=a{#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 200
swift-ide-test: /path/to/swift/lib/AST/Decl.cpp:1684: swift::Type swift::ValueDecl::getInterfaceType() const: Assertion `!isa<AbstractFunctionDecl>(this) && "functions should have an interface type"' failed.
8  swift-ide-test  0x0000000000a5d4ac swift::TypeChecker::getTypeOfRValue(swift::ValueDecl*, bool) + 28
9  swift-ide-test  0x0000000000a5d713 swift::TypeChecker::getUnopenedTypeOfReference(swift::ValueDecl*, swift::Type, swift::DeclContext*, swift::DeclRefExpr const*, bool) + 83
10 swift-ide-test  0x0000000000ac40cd swift::constraints::ConstraintSystem::getTypeOfReference(swift::ValueDecl*, bool, bool, swift::FunctionRefKind, swift::constraints::ConstraintLocatorBuilder, swift::DeclRefExpr const*) + 205
11 swift-ide-test  0x0000000000ac695f swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator*, swift::Type, swift::constraints::OverloadChoice) + 671
16 swift-ide-test  0x0000000000c5a9fe swift::Expr::walk(swift::ASTWalker&) + 46
17 swift-ide-test  0x00000000009d3338 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) + 200
18 swift-ide-test  0x00000000009f6b7d swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 77
19 swift-ide-test  0x0000000000a0f96b swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 347
20 swift-ide-test  0x0000000000a124be swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 942
21 swift-ide-test  0x0000000000a15755 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 309
22 swift-ide-test  0x0000000000a1595d swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 237
27 swift-ide-test  0x0000000000a26426 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
30 swift-ide-test  0x0000000000a96b53 swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 355
31 swift-ide-test  0x0000000000a969a7 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 39
32 swift-ide-test  0x0000000000a4e781 swift::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 657
36 swift-ide-test  0x0000000000c5ade4 swift::Decl::walk(swift::ASTWalker&) + 20
37 swift-ide-test  0x0000000000caf36e swift::SourceFile::walk(swift::ASTWalker&) + 174
38 swift-ide-test  0x0000000000cae67f swift::ModuleDecl::walk(swift::ASTWalker&) + 95
39 swift-ide-test  0x0000000000c851f4 swift::DeclContext::walkContext(swift::ASTWalker&) + 180
40 swift-ide-test  0x00000000009884f8 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 136
41 swift-ide-test  0x00000000008388f1 swift::CompilerInstance::performSema() + 3697
42 swift-ide-test  0x00000000007d9111 main + 42417
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl getter for a at <INPUT-FILE>:4:5
2.  While type-checking declaration 0x5aa4dd0 at <INPUT-FILE>:7:1
3.  While type-checking expression at [<INPUT-FILE>:7:17 - line:7:19] RangeText="a{"
```
