### PR TITLE
[SIL] Add test case for crash triggered in swift::Parser::parseSILCoverageMap()

### DIFF
--- a/validation-test/SIL/crashers/044-swift-parser-parsesilcoveragemap.sil
+++ b/validation-test/SIL/crashers/044-swift-parser-parsesilcoveragemap.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+sil_default_witness_table


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:26: error: expected SIL value name
sil_default_witness_table
                         ^
sil-opt: /path/to/swift/include/swift/Parse/Parser.h:388: swift::SourceLoc swift::Parser::consumeToken(swift::tok): Assertion `Tok.is(K) && "Consuming wrong token kind"' failed.
7  sil-opt         0x0000000000ae77a0 swift::Parser::parseSILCoverageMap() + 0
8  sil-opt         0x0000000000b257cb swift::Parser::parseTopLevel() + 811
9  sil-opt         0x0000000000ad8550 swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) + 208
10 sil-opt         0x0000000000801cd3 swift::CompilerInstance::performSema() + 3315
11 sil-opt         0x00000000007e883c main + 1852
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  With parser at source location: <stdin>:3:26
```
