### PR TITLE
[sil-inliner] Introduce a staging flag to enable the inlining of generics

### DIFF
--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -43,6 +43,10 @@ llvm::cl::opt<bool> PrintShortestPathInfo(
     "print-shortest-path-info", llvm::cl::init(false),
     llvm::cl::desc("Print shortest-path information for inlining"));
 
+llvm::cl::opt<bool> EnableSILInliningOfGenerics(
+    "sil-inline-generics", llvm::cl::init(false),
+    llvm::cl::desc("Enable inlining of generics"));
+
 //===----------------------------------------------------------------------===//
 //                               ConstantTracker
 //===----------------------------------------------------------------------===//
@@ -1121,7 +1125,8 @@ SILFunction *SILPerformanceInliner::getEligibleFunction(FullApplySite AI) {
 
   // We don't support this yet.
   if (AI.hasSubstitutions()) {
-    return nullptr;
+    if (!EnableSILInliningOfGenerics)
+      return nullptr;
   }
 
   SILFunction *Caller = AI.getFunction();


### PR DESCRIPTION
Use the following options to enable this flag: -Xllvm -sil-inline-generics

rdar://17768730
