### PR TITLE
[CMake] Replace APPLE with CMAKE_HOST_APPLE

### DIFF
--- a/tools/SourceKit/tools/sourcekitd/bin/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/bin/CMakeLists.txt
@@ -1,4 +1,4 @@
-  add_subdirectory(InProc)
-if (APPLE)
+add_subdirectory(InProc)
+if (CMAKE_HOST_APPLE)
   add_subdirectory(XPC)
 endif()

--- a/tools/SourceKit/tools/sourcekitd/lib/API/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/CMakeLists.txt
@@ -13,7 +13,7 @@ set(sourcekitdAPI_NonDarwin_InProc_sources
   sourcekitdAPI-InProc.cpp)
 set(LLVM_OPTIONAL_SOURCES ${sourcekitdAPI_Darwin_sources} ${sourcekitdAPI_NonDarwin_InProc_sources})
 
-if(APPLE)
+if(CMAKE_HOST_APPLE)
   list(APPEND sourcekitdAPI_sources ${sourcekitdAPI_Darwin_sources})
 elseif(SWIFT_SOURCEKIT_USE_INPROC_LIBRARY)
   list(APPEND sourcekitdAPI_sources ${sourcekitdAPI_NonDarwin_InProc_sources})


### PR DESCRIPTION
In CMake `APPLE` is defined if you are _targeting_ an Apple platform (or at least if CMake thinks you are). If your host is an Apple platform CMake defines `CMAKE_HOST_APPLE`.

Swift's build system is rolling its own cross-compiling support, so checks such as `APPLE` do not function properly, and instead are true when the _host_ is `APPLE`. To make that fact explicit, change these variables to `CMAKE_HOST_APPLE`.

Addresses a comment by @llvm-beanz on https://github.com/apple/swift/pull/5160#issuecomment-252983869.
