### PR TITLE
[Diag] Remove following white space when removing tokens after l-paren

### DIFF
--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -167,10 +167,11 @@ InFlightDiagnostic &InFlightDiagnostic::fixItRemove(SourceRange R) {
   // space around its hole.  Specifically, check to see there is whitespace
   // before and after the end of range.  If so, nuke the space afterward to keep
   // things consistent.
-  if (extractCharAfter(SM, charRange.getEnd()) == ' ' &&
-      isspace(extractCharBefore(SM, charRange.getStart()))) {
-    charRange = CharSourceRange(charRange.getStart(),
-                                charRange.getByteLength()+1);
+  if (extractCharAfter(SM, charRange.getEnd()) == ' ') {
+    auto beforeChar = extractCharBefore(SM, charRange.getStart());
+    if (isspace(beforeChar) || beforeChar == '(')
+      charRange = CharSourceRange(charRange.getStart(),
+                                  charRange.getByteLength() + 1);
   }
   Engine->getActiveDiagnostic().addFixIt(Diagnostic::FixIt(charRange, {}));
   return *this;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4257,7 +4257,7 @@ ParserStatus Parser::parseDeclVar(ParseDeclOptions Flags,
     if (PBDEntries.size() == 1 && PBDEntries.front().getInit() &&
         !isa<ErrorExpr>(PBDEntries.front().getInit())) {
       auto *init = PBDEntries.front().getInit();
-      inFlightDiag.fixItRemoveChars(TryLoc, VarLoc);
+      inFlightDiag.fixItRemove(TryLoc);
       inFlightDiag.fixItInsert(init->getStartLoc(), "try ");
 
       // Note: We can't use TryLoc here because it's outside the PBD source

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -229,7 +229,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
           param.SecondNameLoc.isValid()) {
         diagnose(param.FirstNameLoc, diag::parameter_operator_keyword_argument,
                  isClosure)
-          .fixItRemoveChars(param.FirstNameLoc, param.SecondNameLoc);
+          .fixItRemove(param.FirstNameLoc);
         param.FirstName = param.SecondName;
         param.FirstNameLoc = param.SecondNameLoc;
         param.SecondName = Identifier();
@@ -460,7 +460,7 @@ mapParsedParameters(Parser &parser,
         parser.diagnose(param.FirstNameLoc,
                         diag::parameter_extraneous_double_up,
                         param.FirstName)
-          .fixItRemoveChars(param.FirstNameLoc, param.SecondNameLoc);
+          .fixItRemove(param.FirstNameLoc);
       }
     } else {
       if (isKeywordArgumentByDefault)

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -713,7 +713,7 @@ ParserResult<Stmt> Parser::parseStmtReturn(SourceLoc tryLoc) {
     if (tryLoc.isValid()) {
       diagnose(tryLoc, diag::try_on_return_throw, /*isThrow=*/false)
         .fixItInsert(ExprLoc, "try ")
-        .fixItRemoveChars(tryLoc, ReturnLoc);
+        .fixItRemove(tryLoc);
 
       // Note: We can't use tryLoc here because that's outside the ReturnStmt's
       // source range.
@@ -753,7 +753,7 @@ ParserResult<Stmt> Parser::parseStmtThrow(SourceLoc tryLoc) {
   if (tryLoc.isValid() && exprLoc.isValid()) {
     diagnose(tryLoc, diag::try_on_return_throw, /*isThrow=*/true)
       .fixItInsert(exprLoc, "try ")
-      .fixItRemoveChars(tryLoc, throwLoc);
+      .fixItRemove(tryLoc);
 
     // Note: We can't use tryLoc here because that's outside the ThrowStmt's
     // source range.

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -9,9 +9,9 @@ func foo(_ a: Int) {
 
 // rdar://15946844
 func test1(inout var x : Int) {}  // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{18-22=}}
-// expected-error @-1 {{'inout' before a parameter name is not allowed, place it before the parameter type instead}} {{12-17=}} {{26-26=inout }}
+// expected-error @-1 {{'inout' before a parameter name is not allowed, place it before the parameter type instead}} {{12-18=}} {{26-26=inout }}
 func test2(inout let x : Int) {}  // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{18-22=}}
-// expected-error @-1 {{'inout' before a parameter name is not allowed, place it before the parameter type instead}} {{12-17=}} {{26-26=inout }}
+// expected-error @-1 {{'inout' before a parameter name is not allowed, place it before the parameter type instead}} {{12-18=}} {{26-26=inout }}
 func test3(f : (inout _ x : Int) -> Void) {} // expected-error {{'inout' before a parameter name is not allowed, place it before the parameter type instead}}
 
 func test3() {
@@ -70,24 +70,24 @@ SR698(1, b: 2,) // expected-error {{unexpected ',' separator}}
 
 // SR-979 - Two inout crash compiler
 func SR979a(a : inout inout Int) {}  // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{17-23=}}
-func SR979b(inout inout b: Int) {} // expected-error {{inout' before a parameter name is not allowed, place it before the parameter type instead}} {{13-18=}} {{28-28=inout }} 
+func SR979b(inout inout b: Int) {} // expected-error {{inout' before a parameter name is not allowed, place it before the parameter type instead}} {{13-19=}} {{28-28=inout }} 
 // expected-error@-1 {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{19-25=}}
-func SR979c(let a: inout Int) {}	 // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{13-16=}} 
-// expected-error @-1 {{'let' as a parameter attribute is not allowed}} {{13-16=}}
-func SR979d(let let a: Int) {}  // expected-error {{'let' as a parameter attribute is not allowed}} {{13-16=}} 
+func SR979c(let a: inout Int) {}	 // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{13-17=}} 
+// expected-error @-1 {{'let' as a parameter attribute is not allowed}} {{13-17=}}
+func SR979d(let let a: Int) {}  // expected-error {{'let' as a parameter attribute is not allowed}} {{13-17=}} 
 // expected-error @-1 {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{17-21=}}
-func SR979e(inout x: inout String) {} // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{13-18=}}
+func SR979e(inout x: inout String) {} // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{13-19=}}
 func SR979f(var inout x : Int) { // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{17-23=}}
-// expected-error @-1 {{parameters may not have the 'var' specifier}} {{13-16=}}{{3-3=var x = x\n  }} 
+// expected-error @-1 {{parameters may not have the 'var' specifier}} {{13-17=}}{{3-3=var x = x\n  }} 
   x += 10
 }
-func SR979g(inout i: inout Int) {} // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{13-18=}}
+func SR979g(inout i: inout Int) {} // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{13-19=}}
 func SR979h(let inout x : Int) {}  // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{17-23=}}
 // expected-error @-1 {{'let' as a parameter attribute is not allowed}}
 class VarTester {
-  init(var a: Int, var b: Int) {} // expected-error {{parameters may not have the 'var' specifier}} {{8-11=}} {{33-33= var a = a }}
+  init(var a: Int, var b: Int) {} // expected-error {{parameters may not have the 'var' specifier}} {{8-12=}} {{33-33= var a = a }}
   // expected-error @-1 {{parameters may not have the 'var' specifier}} {{20-24=}} {{33-33= var b = b }}
-    func x(var b: Int) { //expected-error {{parameters may not have the 'var' specifier}} {{12-15=}} {{9-9=var b = b\n        }}
+    func x(var b: Int) { //expected-error {{parameters may not have the 'var' specifier}} {{12-16=}} {{9-9=var b = b\n        }}
         b += 10
     }
 }

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -322,7 +322,7 @@ protocol SubscriptNoGetter {
   subscript (i: Int) -> Int { get }
 }
 
-func testSubscriptNoGetter(let iis: SubscriptNoGetter) { // expected-error {{'let' as a parameter attribute is not allowed}}{{28-31=}}
+func testSubscriptNoGetter(let iis: SubscriptNoGetter) { // expected-error {{'let' as a parameter attribute is not allowed}}{{28-32=}}
   var _: Int = iis[17]
 }
 
@@ -335,7 +335,7 @@ func testSelectorStyleArguments1(_ x: Int, bar y: Int) {
   _ = y
 }
 
-func testSelectorStyleArguments2(let x: Int, // expected-error {{'let' as a parameter attribute is not allowed}}{{34-37=}}
+func testSelectorStyleArguments2(let x: Int, // expected-error {{'let' as a parameter attribute is not allowed}}{{34-38=}}
                                  let bar y: Int) { // expected-error {{'let' as a parameter attribute is not allowed}}{{34-38=}}
                                  
   
@@ -346,9 +346,9 @@ func testSelectorStyleArguments3(_ x: Int, bar y: Int) {
 }
 
 func invalid_inout(inout var x : Int) { // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{26-30=}}
-// expected-error @-1 {{'inout' before a parameter name is not allowed, place it before the parameter type instead}}{{20-25=}}{{34-34=inout }}
+// expected-error @-1 {{'inout' before a parameter name is not allowed, place it before the parameter type instead}}{{20-26=}}{{34-34=inout }}
 }
-func invalid_var(var x: Int) { // expected-error {{parameters may not have the 'var' specifier}}{{18-21=}} {{1-1=    var x = x\n}}
+func invalid_var(var x: Int) { // expected-error {{parameters may not have the 'var' specifier}}{{18-22=}} {{1-1=    var x = x\n}}
   
 }
 func takesClosure(_: (Int) -> Int) {

--- a/test/attr/attr_autoclosure.swift
+++ b/test/attr/attr_autoclosure.swift
@@ -70,7 +70,7 @@ struct AutoclosureEscapeTest {
 }
 
 // @autoclosure(escaping)
-// expected-error @+1 {{@autoclosure is now an attribute on a parameter type, instead of on the parameter itself}} {{13-34=}} {{38-38=@autoclosure @escaping }}
+// expected-error @+1 {{@autoclosure is now an attribute on a parameter type, instead of on the parameter itself}} {{13-35=}} {{38-38=@autoclosure @escaping }}
 func func10(@autoclosure(escaping _: () -> ()) { } // expected-error{{expected ')' in @autoclosure}}
 // expected-note@-1{{to match this opening '('}}
 
@@ -138,10 +138,10 @@ let _ : (@autoclosure(escaping) () -> ()) -> ()
 let _ : (@autoclosure(escaping) -> ()) -> ()  // expected-error {{use of undeclared type 'escaping'}}
 
 // Migration
-// expected-error @+1 {{@autoclosure is now an attribute on a parameter type, instead of on the parameter itself}} {{16-28=}} {{32-32=@autoclosure }}
+// expected-error @+1 {{@autoclosure is now an attribute on a parameter type, instead of on the parameter itself}} {{16-29=}} {{32-32=@autoclosure }}
 func migrateAC(@autoclosure _: () -> ()) { }
 
-// expected-error @+1 {{@autoclosure is now an attribute on a parameter type, instead of on the parameter itself}} {{17-39=}} {{43-43=@autoclosure @escaping }}
+// expected-error @+1 {{@autoclosure is now an attribute on a parameter type, instead of on the parameter itself}} {{17-40=}} {{43-43=@autoclosure @escaping }}
 func migrateACE(@autoclosure(escaping) _: () -> ()) { }
 
 func takesAutoclosure(_ fn: @autoclosure () -> Int) {}

--- a/test/attr/attr_noescape.swift
+++ b/test/attr/attr_noescape.swift
@@ -244,20 +244,20 @@ public func XCTAssert(_ expression: @autoclosure () -> Bool, _ message: String =
 
 
 /// SR-770 - Currying and `noescape`/`rethrows` don't work together anymore
-func curriedFlatMap<A, B>(_ x: [A]) -> (@noescape (A) -> [B]) -> [B] { // expected-warning{{@noescape is the default and is deprecated}} {{41-50=}}
+func curriedFlatMap<A, B>(_ x: [A]) -> (@noescape (A) -> [B]) -> [B] { // expected-warning{{@noescape is the default and is deprecated}} {{41-51=}}
   return { f in
     x.flatMap(f)
   }
 }
 
-func curriedFlatMap2<A, B>(_ x: [A]) -> (@noescape (A) -> [B]) -> [B] { // expected-warning{{@noescape is the default and is deprecated}} {{42-51=}}
+func curriedFlatMap2<A, B>(_ x: [A]) -> (@noescape (A) -> [B]) -> [B] { // expected-warning{{@noescape is the default and is deprecated}} {{42-52=}}
   return { (f : @noescape (A) -> [B]) in // expected-warning{{@noescape is the default and is deprecated}} {{17-27=}}
     x.flatMap(f)
   }
 }
 
 func bad(_ a : @escaping (Int)-> Int) -> Int { return 42 }
-func escapeNoEscapeResult(_ x: [Int]) -> (@noescape (Int) -> Int) -> Int { // expected-warning{{@noescape is the default and is deprecated}} {{43-52=}}
+func escapeNoEscapeResult(_ x: [Int]) -> (@noescape (Int) -> Int) -> Int { // expected-warning{{@noescape is the default and is deprecated}} {{43-53=}}
   return { f in // expected-note{{parameter 'f' is implicitly non-escaping}}
     bad(f)  // expected-error {{passing non-escaping parameter 'f' to function expecting an @escaping closure}}
   }
@@ -304,7 +304,7 @@ func doThing4(_ completion: @escaping CompletionHandler) {
 func apply<T, U>(_ f: @noescape (T) -> U, g: @noescape (@noescape (T) -> U) -> U) -> U { 
   // expected-warning@-1{{@noescape is the default and is deprecated}} {{23-33=}}
   // expected-warning@-2{{@noescape is the default and is deprecated}} {{46-56=}}
-  // expected-warning@-3{{@noescape is the default and is deprecated}} {{57-66=}}
+  // expected-warning@-3{{@noescape is the default and is deprecated}} {{57-67=}}
   return g(f)
 }
 
@@ -328,14 +328,14 @@ enum r19997577Type {
 }
 
 // type attribute and decl attribute
-func noescapeD(@noescape f: @escaping () -> Bool) {} // expected-error {{@noescape is now an attribute on a parameter type, instead of on the parameter itself}} {{16-25=}} {{29-29=@noescape }}
+func noescapeD(@noescape f: @escaping () -> Bool) {} // expected-error {{@noescape is now an attribute on a parameter type, instead of on the parameter itself}} {{16-26=}} {{29-29=@noescape }}
 func noescapeT(f: @noescape () -> Bool) {} // expected-warning{{@noescape is the default and is deprecated}} {{19-29=}}
-func autoclosureD(@autoclosure f: () -> Bool) {} // expected-error {{@autoclosure is now an attribute on a parameter type, instead of on the parameter itself}} {{19-31=}} {{35-35=@autoclosure }}
+func autoclosureD(@autoclosure f: () -> Bool) {} // expected-error {{@autoclosure is now an attribute on a parameter type, instead of on the parameter itself}} {{19-32=}} {{35-35=@autoclosure }}
 func autoclosureT(f: @autoclosure () -> Bool) {}  // ok
 
 func noescapeD_noescapeT(@noescape f: @noescape () -> Bool) {} // expected-error {{@noescape is now an attribute on a parameter type, instead of on the parameter itself}}
  // expected-warning@-1{{@noescape is the default and is deprecated}} {{39-49=}}
 
-func autoclosureD_noescapeT(@autoclosure f: @noescape () -> Bool) {} // expected-error {{@autoclosure is now an attribute on a parameter type, instead of on the parameter itself}} {{29-41=}} {{45-45=@autoclosure }}
+func autoclosureD_noescapeT(@autoclosure f: @noescape () -> Bool) {} // expected-error {{@autoclosure is now an attribute on a parameter type, instead of on the parameter itself}} {{29-42=}} {{45-45=@autoclosure }}
  // expected-warning@-1{{@noescape is the default and is deprecated}} {{45-55=}}
 

--- a/test/decl/class/override.swift
+++ b/test/decl/class/override.swift
@@ -169,7 +169,7 @@ class H : G {
 
   func manyA(_: AnyObject, _: AnyObject) {}
   func manyB(_ a: AnyObject, b: AnyObject) {}
-  func manyC(var a: AnyObject,  // expected-error {{parameters may not have the 'var' specifier}} {{14-17=}}
+  func manyC(var a: AnyObject,  // expected-error {{parameters may not have the 'var' specifier}} {{14-18=}}
              var b: AnyObject) {} // expected-error {{parameters may not have the 'var' specifier}} {{14-18=}}
 
   func result() -> AnyObject? { return nil }

--- a/test/decl/func/functions.swift
+++ b/test/decl/func/functions.swift
@@ -124,7 +124,7 @@ func testObjCMethodCurry(_ a : ClassWithObjCMethod) -> (Int) -> () {
 
 // We used to crash on this.
 func rdar16786220(inout let c: Int) -> () { // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{25-29=}}
-// expected-error @-1 {{'inout' before a parameter name is not allowed, place it before the parameter type instead}}{{19-24=}}{{32-32=inout }}
+// expected-error @-1 {{'inout' before a parameter name is not allowed, place it before the parameter type instead}}{{19-25=}}{{32-32=inout }}
 
   c = 42
 }
@@ -140,7 +140,7 @@ _ = [1] !!! [1]   // unambiguously picking the array overload.
 
 // <rdar://problem/16786168> Functions currently permit 'var inout' parameters
 func var_inout_error(inout var x : Int) {} // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{28-32=}}
-// expected-error @-1 {{'inout' before a parameter name is not allowed, place it before the parameter type instead}} {{22-27=}}{{36-36=inout }}
+// expected-error @-1 {{'inout' before a parameter name is not allowed, place it before the parameter type instead}} {{22-28=}}{{36-36=inout }}
 
 // Unnamed parameters require the name "_":
 func unnamed(Int) { } // expected-error{{unnamed parameters must be written with the empty name '_'}}{{14-14=_: }}


### PR DESCRIPTION
It's common to emit fix-it to remove the first token after l-paren.
For example, in this case

``` swift
func f(inout x: Int, inout y: Int) {}
```

`fixItRemove` used to remove the space after the second `inout`, but not for the first `inout`:

``` swift
func f( x: Int, y: Int) {}
       ~
```

Extend "extra work" in `fixItRemove` to remove these whitespace.
## 

Also, replaced `fixItRemoveChars` with `fixItReplace` where we can.
We prefer token range based fix-it, to minimally alter the source code.

Consider fixing:

``` swift
func foo(name /* comment */ name: Arg) {
```

Previously:

``` swift
  func foo(name: Arg) {
```

Now:

``` swift
  func foo(/* comment */ name: Arg) {
```
