### PR TITLE
SR-2164: Fix erroneous diagnostic when unable to infer generic parameter

### DIFF
--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -868,3 +868,35 @@ func test2208() {
   foo.bar(value: result) // expected-error {{cannot convert value of type 'Int' to expected argument type 'UInt'}}
   foo.bar(value: UInt(result)) // Ok
 }
+
+// SR-2164: Erroneous diagnostic when unable to infer generic type
+
+struct SR_2164<A, B> { // expected-note 3 {{'B' declared as parameter to type 'SR_2164'}} expected-note 2 {{'A' declared as parameter to type 'SR_2164'}} expected-note * {{generic type 'SR_2164' declared here}}
+  init(a: A) {}
+  init(b: B) {}
+  init(c: Int) {}
+  init(_ d: A) {}
+  init(e: A?) {}
+}
+
+struct SR_2164_Array<A, B> { // expected-note {{'B' declared as parameter to type 'SR_2164_Array'}} expected-note * {{generic type 'SR_2164_Array' declared here}}
+  init(_ a: [A]) {}
+}
+
+struct SR_2164_Dict<A: Hashable, B> { // expected-note {{'B' declared as parameter to type 'SR_2164_Dict'}} expected-note * {{generic type 'SR_2164_Dict' declared here}}
+  init(a: [A: Double]) {}
+}
+
+SR_2164(a: 0) // expected-error {{generic parameter 'B' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}}
+SR_2164(b: 1) // expected-error {{generic parameter 'A' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}}
+SR_2164(c: 2) // expected-error {{generic parameter 'A' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}}
+SR_2164(3) // expected-error {{generic parameter 'B' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}}
+SR_2164_Array([4]) // expected-error {{generic parameter 'B' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}}
+SR_2164(e: 5) // expected-error {{generic parameter 'B' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}}
+SR_2164_Dict(a: ["pi": 3.14]) // expected-error {{generic parameter 'B' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}}
+SR_2164<Int>(a: 0) // expected-error {{generic type 'SR_2164' specialized with too few type parameters (got 1, but expected 2)}}
+SR_2164<Int>(b: 1) // expected-error {{generic type 'SR_2164' specialized with too few type parameters (got 1, but expected 2)}}
+let _ = SR_2164<Int, Bool>(a: 0)    // Ok
+let _ = SR_2164<Int, Bool>(b: true) // Ok
+SR_2164<Int, Bool, Float>(a: 0) // expected-error {{generic type 'SR_2164' specialized with too many type parameters (got 3, but expected 2)}}
+SR_2164<Int, Bool, Float>(b: 0) // expected-error {{generic type 'SR_2164' specialized with too many type parameters (got 3, but expected 2)}}

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -52,9 +52,9 @@ func generic_metatypes<T : SomeProtocol>(_ x: T)
 }
 
 // Inferring a variable's type from a call to a generic.
-struct Pair<T, U> { } // expected-note 5 {{'T' declared as parameter to type 'Pair'}}
+struct Pair<T, U> { } // expected-note 4 {{'T' declared as parameter to type 'Pair'}} expected-note {{'U' declared as parameter to type 'Pair'}}
 
-func pair<T, U>(_ x: T, _ y: U) -> Pair<T, U> { } // expected-note 3 {{in call to function 'pair'}}
+func pair<T, U>(_ x: T, _ y: U) -> Pair<T, U> { }
 
 var i : Int, f : Float
 var p = pair(i, f)
@@ -260,7 +260,7 @@ protocol SubProto: BaseProto {}
   func copy() -> Any
 }
 
-struct FullyGeneric<Foo> {} // expected-note 3 {{'Foo' declared as parameter to type 'FullyGeneric'}} expected-note 6 {{generic type 'FullyGeneric' declared here}}
+struct FullyGeneric<Foo> {} // expected-note 6 {{'Foo' declared as parameter to type 'FullyGeneric'}} expected-note 6 {{generic type 'FullyGeneric' declared here}}
 
 struct AnyClassBound<Foo: AnyObject> {} // expected-note {{'Foo' declared as parameter to type 'AnyClassBound'}} expected-note {{generic type 'AnyClassBound' declared here}}
 struct AnyClassBound2<Foo> where Foo: AnyObject {} // expected-note {{'Foo' declared as parameter to type 'AnyClassBound2'}}
@@ -333,8 +333,7 @@ func testFixIts() {
   _ = ClassAndProtosBound2() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{27-27=<<#Foo: X & NSCopyish & SubProto#>>}}
 
   _ = Pair() // expected-error {{generic parameter 'T' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{11-11=<Any, Any>}}
-  // FIXME: This should say "generic parameter 'U'".
-  _ = Pair(first: S()) // expected-error {{generic parameter 'T' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{11-11=<S, Any>}}
+  _ = Pair(first: S()) // expected-error {{generic parameter 'U' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{11-11=<S, Any>}}
   _ = Pair(second: S()) // expected-error {{generic parameter 'T' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{11-11=<Any, S>}}
 }
 
@@ -388,17 +387,16 @@ func testFixItNested() {
     FullyGeneric<Any>
   >()
 
-  // FIXME: These errors could be improved.
-  _ = pair( // expected-error {{generic parameter 'T' could not be inferred}} {{none}}
-    FullyGeneric(),
+  _ = pair( // expected-error {{generic parameter 'Foo' could not be inferred}} {{none}}
+    FullyGeneric(), // expected-note {{explicitly specify the generic arguments to fix this issue}}
     FullyGeneric()
   )
-  _ = pair( // expected-error {{generic parameter 'T' could not be inferred}} {{none}}
+  _ = pair( // expected-error {{generic parameter 'Foo' could not be inferred}} {{none}}
     FullyGeneric<Any>(),
-    FullyGeneric()
+    FullyGeneric() // expected-note {{explicitly specify the generic arguments to fix this issue}}
   )
-  _ = pair( // expected-error {{generic parameter 'T' could not be inferred}} {{none}}
-    FullyGeneric(),
+  _ = pair( // expected-error {{generic parameter 'Foo' could not be inferred}} {{none}}
+    FullyGeneric(), // expected-note {{explicitly specify the generic arguments to fix this issue}}
     FullyGeneric<Any>()
   )
 }

--- a/test/Generics/deduction.swift
+++ b/test/Generics/deduction.swift
@@ -81,7 +81,7 @@ func passFunction(_ f: (Int) -> Float, x: Int, y: Float) {
 func returnTuple<T, U>(_: T) -> (T, U) { } // expected-note {{in call to function 'returnTuple'}}
 
 func testReturnTuple(_ x: Int, y: Float) {
-  returnTuple(x) // expected-error{{generic parameter 'T' could not be inferred}}
+  returnTuple(x) // expected-error{{generic parameter 'U' could not be inferred}}
   
   var _ : (Int, Float) = returnTuple(x)
   var _ : (Float, Float) = returnTuple(y)


### PR DESCRIPTION
<!-- What's in this pull request? -->

This patch attempts to improve diagnostics related to generic type construction when
some of the generic parameters are not provided by constructor and, as a result, are unbound.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-2164](https://bugs.swift.org/browse/SR-2164).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
