### PR TITLE
SE-0138: Minor update. Array.withUnsafeBytes is nonmutating.

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -2170,7 +2170,7 @@ extension ${Self} {
   /// - Returns: The return value of the `body` closure parameter, if any.
   ///
   /// - SeeAlso: `withUnsafeBytes`, `UnsafeRawBufferPointer`
-  public mutating func withUnsafeBytes<R>(
+  public func withUnsafeBytes<R>(
     _ body: (UnsafeRawBufferPointer) throws -> R
   ) rethrows -> R {
     return try self.withUnsafeBufferPointer {

--- a/test/stdlib/UnsafeRawBufferPointer.swift
+++ b/test/stdlib/UnsafeRawBufferPointer.swift
@@ -53,7 +53,7 @@ UnsafeRawBufferPointerTestSuite.test("nonmutating_subscript_setter") {
 // View an array's elements as bytes.
 // Use copyBytes to overwrite the array element's bytes.
 UnsafeRawBufferPointerTestSuite.test("initFromArray") {
-  var array1: [Int32] = [0, 1, 2, 3]
+  let array1: [Int32] = [0, 1, 2, 3]
   var array2 = [Int32](repeating: 0, count: 4)
   // Immutable view of array1's bytes.
   array1.withUnsafeBytes { bytes1 in
@@ -77,7 +77,7 @@ UnsafeRawBufferPointerTestSuite.test("initFromArray") {
 
 // Directly test the byte Sequence produced by withUnsafeBytes.
 UnsafeRawBufferPointerTestSuite.test("withUnsafeBytes.Sequence") {
-  var array1: [Int32] = [0, 1, 2, 3]
+  let array1: [Int32] = [0, 1, 2, 3]
   array1.withUnsafeBytes { bytes1 in
     // Initialize an array from a sequence of bytes.
     let byteArray = [UInt8](bytes1)


### PR DESCRIPTION
The "mutating" keyword should not have been on this API. The example
code in SE-0138 uses it as a nonmutating API.

(The mutating keyword was a temporary workaround for a bug that has now been fixed on master.)
