### PR TITLE
[sil-ownership] Add a new preset buildbot,tools=RA,stdlib=RDA,sil-own…

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -258,6 +258,12 @@ skip-test-ios-host
 skip-test-tvos-host
 skip-test-watchos-host
 
+[preset: buildbot,tools=RA,stdlib=RDA,sil-ownership]
+mixin-preset=
+    buildbot,tools=RA,stdlib=RDA
+build-subdir=Ninja-ReleaseAssert+stdlib-RelWithDebInfo+sil-ownership
+enable-sil-ownership
+dash-dash
 
 #===------------------------------------------------------------------------===#
 # Incremental buildbots for Darwin OSes


### PR DESCRIPTION
This commit just adds a new preset for building swift with sil-ownership enabled. It will be used on the bots.

rdar://28685236
