### PR TITLE
[3.0 compat] Don't diagnose @escaping var-arg closures.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -784,6 +784,9 @@ public:
                             clang::ObjCInterfaceDecl *classDecl,
                             bool forInstance);
 
+  /// Whether our effective Swift version is in the Swift 3 family
+  bool isSwiftVersion3() const { return LangOpts.isSwiftVersion3(); }
+
 private:
   friend class Decl;
   Optional<RawComment> getRawComment(const Decl *D);

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -227,6 +227,11 @@ namespace swift {
       return CustomConditionalCompilationFlags;
     }
 
+    /// Whether our effective Swift version is in the Swift 3 family
+    bool isSwiftVersion3() const {
+      return EffectiveLanguageVersion.isVersion3();
+    }
+
     /// Returns true if the 'os' platform condition argument represents
     /// a supported target operating system.
     ///

--- a/include/swift/Basic/Version.h
+++ b/include/swift/Basic/Version.h
@@ -95,6 +95,9 @@ public:
   /// are attempting to maintain backward-compatibility support for.
   bool isValidEffectiveLanguageVersion() const;
 
+  /// Whether this version is in the Swift 3 family
+  bool isVersion3() const { return !empty() && Components[0] == 3; }
+
   /// Parse a version in the form used by the _compiler_version \#if condition.
   static Version parseCompilerVersionString(StringRef VersionString,
                                             SourceLoc Loc,

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -291,8 +291,13 @@ Version::isValidEffectiveLanguageVersion() const
   // Whitelist of backward-compatibility versions that we permit passing as
   // -swift-version <vers>
   char const *whitelist[] = {
+    // Swift 3 family
     "3",
     "3.0",
+
+    // Swift 4 family
+    "4",
+    "4.0",
   };
   for (auto const i : whitelist) {
     auto v = parseVersionString(i, SourceLoc(), nullptr);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2034,10 +2034,8 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
     if (attrs.has(TAK_escaping)) {
       // For compatibility with 3.0, we don't emit an error if it appears on a
       // variadic argument list.
-      //
-      // FIXME: Version-gate on Swift language version 3, as we don't want its
-      // presence to confuse users.
-      bool skipDiagnostic = isVariadicFunctionParam;
+      bool skipDiagnostic =
+          isVariadicFunctionParam && Context.isSwiftVersion3();
 
       // The attribute is meaningless except on parameter types.
       bool shouldDiagnose = !isFunctionParam && !skipDiagnostic;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2032,8 +2032,16 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
   // Handle @escaping
   if (hasFunctionAttr && ty->is<FunctionType>()) {
     if (attrs.has(TAK_escaping)) {
+      // For compatibility with 3.0, we don't emit an error if it appears on a
+      // variadic argument list.
+      //
+      // FIXME: Version-gate on Swift language version 3, as we don't want its
+      // presence to confuse users.
+      bool skipDiagnostic = isVariadicFunctionParam;
+
       // The attribute is meaningless except on parameter types.
-      if (!isFunctionParam) {
+      bool shouldDiagnose = !isFunctionParam && !skipDiagnostic;
+      if (shouldDiagnose) {
         auto &SM = TC.Context.SourceMgr;
         auto loc = attrs.getLoc(TAK_escaping);
         auto attrRange = SourceRange(

--- a/test/Compatibility/attr_escaping.swift
+++ b/test/Compatibility/attr_escaping.swift
@@ -1,0 +1,10 @@
+// RUN: %target-parse-verify-swift
+
+// This is allowed, in order to keep source compat with Swift version 3.0.
+func takesVarargsOfFunctionsExplicitEscaping(_ fns: @escaping () -> ()...) {} 
+
+func takesVarargsOfFunctions(_ fn: () -> (), _ fns: () -> ()...) {
+		// expected-note@-1{{parameter 'fn' is implicitly non-escaping}}
+	takesVarargsOfFunctionsExplicitEscaping(fns[0], fns[1]) // ok
+	takesVarargsOfFunctionsExplicitEscaping(fn) // expected-error{{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
+} 

--- a/test/attr/attr_escaping.swift
+++ b/test/attr/attr_escaping.swift
@@ -1,4 +1,4 @@
-// RUN: %target-parse-verify-swift
+// RUN: %target-parse-verify-swift -swift-version 4
 
 @escaping var fn : () -> Int = { 4 }  // expected-error {{attribute can only be applied to types, not declarations}}
 func paramDeclEscaping(@escaping fn: (Int) -> Void) {} // expected-error {{attribute can only be applied to types, not declarations}}
@@ -140,10 +140,7 @@ func takesVarargsOfFunctions(fns: () -> ()...) {
   }
 }
 
-// This is allowed, in order to keep source compat with Swift version 3.0.
-//
-// FIXME: version-gate on Swift version 3
-func takesVarargsOfFunctionsExplicitEscaping(fns: @escaping () -> ()...) {}
+func takesVarargsOfFunctionsExplicitEscaping(fns: @escaping () -> ()...) {} // expected-error{{@escaping attribute may only be used in function parameter position}}
 
 func takesNoEscapeFunction(fn: () -> ()) { // expected-note {{parameter 'fn' is implicitly non-escaping}}
   takesVarargsOfFunctions(fns: fn) // expected-error {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}

--- a/test/attr/attr_escaping.swift
+++ b/test/attr/attr_escaping.swift
@@ -140,6 +140,11 @@ func takesVarargsOfFunctions(fns: () -> ()...) {
   }
 }
 
+// This is allowed, in order to keep source compat with Swift version 3.0.
+//
+// FIXME: version-gate on Swift version 3
+func takesVarargsOfFunctionsExplicitEscaping(fns: @escaping () -> ()...) {}
+
 func takesNoEscapeFunction(fn: () -> ()) { // expected-note {{parameter 'fn' is implicitly non-escaping}}
   takesVarargsOfFunctions(fns: fn) // expected-error {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->

[3.0 compat] Don't diagnose @escaping var-arg closures.

Var-arg closures are already escaping, so we typically want to issue
an error if @escaping is specified. To not do sure will confuse and
give a false impression on the un-annotated semantics and whether it
is needed. But, 3.0 shipped with a bug where we didn't consistently
apply the no-escape-by-default rule here, and thus it was semantically
meaningful (and needed).

In order to preserve source compatibility, albeit at the expense of
developers on versions 3.0.1 and later in the Swift 3 family, we
suppress the error if we see @escaping. Either way, this is a
relatively uncommon usage, so the confusion won't be too wide spread.

[swift-version] Allow swift-version 4 and tests

The recent @escaping on variadic argument closures back-compat fix is
the first Swift 3.0 compatibility behavior that we don't want to carry
forwards indefinitely into the future. To address this, we
version-gate the diagnostic suppression.

Makes it an official compatibility check. Creates new test directory
for compatibility testing. Allow -swift-version 4 so that we can test
it both ways.

Note: The swift-3 branch PR was already merged at https://github.com/apple/swift/pull/5217

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
