### PR TITLE
SR-2193: Improve diagnostic when member exists but it's not a type

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -547,6 +547,9 @@ ERROR(invalid_member_type,none,
 ERROR(invalid_member_type_suggest,none,
       "%0 does not have a member type named %1; did you mean %2?",
       (Type, Identifier, Identifier))
+ERROR(invalid_member_reference,none,
+      "%0 %1 is not a member type of %2",
+      (DescriptiveDeclKind, Identifier, Type))
 ERROR(invalid_member_type_alias,none,
       "typealias %0 is too complex to be used as a generic constraint; "
       "use an associatedtype instead", (Identifier))

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -580,3 +580,13 @@ enum SomeErrorType {
   }
 }
 
+// SR-2193: QoI: better diagnostic when a decl exists, but is not a type
+
+enum SR_2193_Error: Error {
+  case Boom
+}
+
+do {
+  throw SR_2193_Error.Boom
+} catch let e as SR_2193_Error.Boom { // expected-error {{enum element 'Boom' is not a member type of 'SR_2193_Error'}}
+}

--- a/test/Generics/generic_types.swift
+++ b/test/Generics/generic_types.swift
@@ -237,4 +237,4 @@ struct UnsolvableInheritance2<T : U.A, U : T.A> {}
 // expected-error@-1 {{inheritance from non-protocol, non-class type 'U.A'}}
 // expected-error@-2 {{inheritance from non-protocol, non-class type 'T.A'}}
 
-enum X7<T> where X7.X : G { case X } // expected-error{{'X' is not a member type of 'X7<T>'}}
+enum X7<T> where X7.X : G { case X } // expected-error{{enum element 'X' is not a member type of 'X7<T>'}}

--- a/test/decl/class/circular_inheritance.swift
+++ b/test/decl/class/circular_inheritance.swift
@@ -19,7 +19,7 @@ class Left : Right.Hand {
   class Hand {}
 }
 
-class Right : Left.Hand { // expected-error {{'Hand' is not a member type of 'Left'}}
+class Right : Left.Hand { // expected-error {{class 'Hand' is not a member type of 'Left'}}
   class Hand {}
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->

When trying to resolve type and after member type lookup fails, 
patch attempts to do member lookup to determine if requested entity 
doesn't exist at all or is a regular member of the parent type, such
enables more precise diagnostic.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-2193](https://bugs.swift.org/browse/SR-2193).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
