### PR TITLE
[3.0] Warn for Optionals in String Interpolation Segments

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2403,6 +2403,12 @@ NOTE(force_optional_to_any,none,
      "force-unwrap the value to avoid this warning", ())
 NOTE(silence_optional_to_any,none,
      "explicitly cast to Any with 'as Any' to silence this warning", ())
+WARNING(optional_in_string_interpolation_segment,none,
+        "string interpolation produces a debug description for an optional "
+        "value; did you mean to make this explicit?",
+        ())
+NOTE(silence_optional_in_interpolation_segment_call,none,
+     "use 'String(describing:)' to silence this warning", ())
 
 ERROR(invalid_noescape_use,none,
       "non-escaping %select{value|parameter}1 %0 may only be called",

--- a/test/Sema/diag_unintended_optional_behavior.swift
+++ b/test/Sema/diag_unintended_optional_behavior.swift
@@ -58,3 +58,18 @@ func warnOptionalToAnyCoercion(value x: Int?) -> Any {
   // expected-note@-2 {{force-unwrap the value to avoid this warning}}
   // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
 }
+
+func warnOptionalInStringInterpolationSegment(_ o : Int?) {
+  print("Always some, Always some, Always some: \(o)")
+  // expected-warning@-1 {{string interpolation produces a debug description for an optional value; did you mean to make this explicit?}}
+  // expected-note@-2 {{use 'String(describing:)' to silence this warning}} {{51-51=String(describing: }} {{52-52=)}} 
+  // expected-note@-3 {{provide a default value to avoid this warning}} {{52-52= ?? <#default value#>}}
+  print("Always some, Always some, Always some: \(o.map { $0 + 1 })")
+  // expected-warning@-1 {{string interpolation produces a debug description for an optional value; did you mean to make this explicit?}}
+  // expected-note@-2 {{use 'String(describing:)' to silence this warning}} {{51-51=String(describing: }} {{67-67=)}} 
+  // expected-note@-3 {{provide a default value to avoid this warning}} {{67-67= ?? <#default value#>}}
+
+  print("Always some, Always some, Always some: \(o as Int?)") // No warning
+  print("Always some, Always some, Always some: \(o.debugDescription)") // No warning.
+}
+


### PR DESCRIPTION
This patch is an extension to optional-as-any warnings introduced to diagnose cases where an optional expression was being upcast to `Any` by mistake.  We now emit a warning in the case that a user writes an optional-typed expression in a string interpolation segment. In addition, we offer fixits to help the user either explicitly request this with `String(describing:)` or offer to insert the start of a default value expression.  As a warning this change is not source-breaking and fairly low risk.

@jrose-apple @rudkx How does it look?
