### PR TITLE
[sil-verifier] Verify correctly that lowered SIL optional types are lowered types of formal optional types.

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2753,22 +2753,25 @@ namespace {
       OS << ")";
     }
 
+    void printMetatypeRepresentation(MetatypeRepresentation representation) {
+      OS << " ";
+      switch (representation) {
+      case MetatypeRepresentation::Thin:
+        OS << "@thin";
+        break;
+      case MetatypeRepresentation::Thick:
+        OS << "@thick";
+        break;
+      case MetatypeRepresentation::ObjC:
+        OS << "@objc";
+        break;
+      }
+    }
+
     void visitMetatypeType(MetatypeType *T, StringRef label) {
       printCommon(T, label, "metatype_type");
-      if (T->hasRepresentation()) {
-        OS << " ";
-        switch (T->getRepresentation()) {
-        case MetatypeRepresentation::Thin:
-          OS << "@thin";
-          break;
-        case MetatypeRepresentation::Thick:
-          OS << "@thick";
-          break;
-        case MetatypeRepresentation::ObjC:
-          OS << "@objc";
-          break;
-        }
-      }
+      if (T->hasRepresentation())
+        printMetatypeRepresentation(T->getRepresentation());
       printRec(T->getInstanceType());
       OS << ")";
     }
@@ -2776,6 +2779,8 @@ namespace {
     void visitExistentialMetatypeType(ExistentialMetatypeType *T,
                                       StringRef label) {
       printCommon(T, label, "existential_metatype_type");
+      if (T->hasRepresentation())
+        printMetatypeRepresentation(T->getRepresentation());
       printRec(T->getInstanceType());
       OS << ")";
     }

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1491,8 +1491,9 @@ public:
       if (auto dynamicSelf = dyn_cast<DynamicSelfType>(formalObjectType)) {
         formalObjectType = dynamicSelf->getSelfType()->getCanonicalType();
       }
-      return ((loweredOptionalKind == formalOptionalKind) &&
-              loweredObjectType == formalObjectType);
+      return loweredOptionalKind == formalOptionalKind &&
+             isLoweringOf(SILType::getPrimitiveAddressType(loweredObjectType),
+                          formalObjectType);
     }
 
     // Metatypes preserve their instance type through lowering.

--- a/test/SIL/verifier-value-metatype-lowering.sil
+++ b/test/SIL/verifier-value-metatype-lowering.sil
@@ -1,0 +1,22 @@
+// RUN: %target-sil-opt -module-name Swift %s
+// REQUIRES: asserts
+//
+// Make sure that we properly verify the lowering of optional value
+// metatypes. This shouldn't crash.
+//
+// rdar://28536812
+
+enum Optional<T> {
+case none
+case some(T)
+}
+
+sil @foo : $@convention(thin) () -> () {
+  %0 = enum $Optional<@thick Any.Type>, #Optional.none!enumelt
+  %1 = alloc_stack $Optional<@thick Any.Type>
+  store %0 to %1 : $*Optional<@thick Any.Type>
+  %2 = value_metatype $@thick Optional<Any.Type>.Type, %1 : $*Optional<@thick Any.Type>
+  dealloc_stack %1 : $*Optional<@thick Any.Type>
+  %3 = tuple()
+  return %3 : $()
+}


### PR DESCRIPTION
Recently, the lowering of Optional<T> was changed to be more like the lowering
    of tuples. Specifically this means that we recursively propagate types into the
    optional's component type rather than treating the component type as a
    standalone formal type ala other nominal types.

This patch updates the function isLoweringOf in the SILVerifier that was missed
    as apart of the aforementioned updates. Specifically, previously isLoweringOf
    assumed that the optional's component type was always a formal type implying
    that it could just compare the lowered SIL types corresponding formal type and
    the passed in formal type. Now since we are propagating types down into the
    optional's component types, we need to recurse performing isLoweringOf on the
    maximally abstracted version of the optional SIL type (i.e. the primitive
    address form).

I would like to thank John for his patience in explaining the big picture here.

rdar://28536812
