### PR TITLE
[Parse] Fix parsing "protocol<Any>"

### DIFF
--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -468,8 +468,10 @@ ParserResult<TypeRepr> Parser::parseTypeIdentifierOrTypeComposition() {
       StringRef TrailingContent = L->getTokenAt(RAngleLoc).getRange().str().
         substr(1);
       if (!TrailingContent.empty()) {
-        replacement.insert(replacement.begin(), '(');
-        replacement += ")";
+        if (Protocols.size() > 1) {
+          replacement.insert(replacement.begin(), '(');
+          replacement += ")";
+        }
         replacement += TrailingContent;
       }
 

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -308,4 +308,4 @@ func testBoolValue(a : BoolFoo) {
 protocol P1 {}
 protocol P2 {}
 var a : (P1 & P2)?
-var a2 : (P1)= 17 as! P1
+var a2 : P1= 17 as! P1

--- a/test/type/protocol_composition.swift
+++ b/test/type/protocol_composition.swift
@@ -133,3 +133,5 @@ typealias B4 = protocol<P1 , P2> // expected-warning {{'protocol<...>' compositi
 typealias C1 = protocol<Any, P1> // expected-warning {{'protocol<...>' composition syntax is deprecated and not needed here}} {{16-33=P1}}
 typealias C2 = protocol<P1, Any> // expected-warning {{'protocol<...>' composition syntax is deprecated and not needed here}} {{16-33=P1}}
 typealias D = protocol<P1> // expected-warning {{'protocol<...>' composition syntax is deprecated and not needed here}} {{15-27=P1}}
+typealias E = protocol<Any> // expected-warning {{'protocol<...>' composition syntax is deprecated and not needed here}} {{15-28=Any}}
+typealias F = protocol<Any, Any> // expected-warning {{'protocol<...>' composition syntax is deprecated and not needed here}} {{15-33=Any}}

--- a/test/type/protocol_composition.swift
+++ b/test/type/protocol_composition.swift
@@ -123,9 +123,11 @@ func testConversion() {
 }
 
 // Test the parser's splitting of >= into > and =.
-var x : protocol<P5>= 17 // expected-warning {{'protocol<...>' composition syntax is deprecated and not needed here}} {{9-22=(P5)=}}
+var x : protocol<P5>= 17 // expected-warning {{'protocol<...>' composition syntax is deprecated and not needed here}} {{9-22=P5=}}
+var y : protocol<P5, P7>= 17 // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{9-26=(P5 & P7)=}}
 
-typealias A = protocol<> // expected-warning {{'protocol<>' syntax is deprecated; use 'Any' instead}} {{15-25=Any}}
+typealias A1 = protocol<> // expected-warning {{'protocol<>' syntax is deprecated; use 'Any' instead}} {{16-26=Any}}
+typealias A2 = protocol<>? // expected-warning {{'protocol<>' syntax is deprecated; use 'Any' instead}} {{16-27=Any?}}
 typealias B1 = protocol<P1,P2> // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{16-31=P1 & P2}}
 typealias B2 = protocol<P1, P2> // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{16-32=P1 & P2}}
 typealias B3 = protocol<P1 ,P2> // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{16-32=P1 & P2}}


### PR DESCRIPTION
Fix crash while constructing diagnostic fix-it for deprecated syntax.

Also, `protocol<>?` used to be fixed as just `Any`. It should be `Any?` instead.
