### PR TITLE
SR-2405 Print IB_DESIGNABLE and IBInspectable in the generated ObjC header

### DIFF
--- a/lib/PrintAsObjC/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsObjC/DeclAndTypePrinter.cpp
@@ -278,6 +278,10 @@ private:
     if (CD->getAttrs().hasAttribute<WeakLinkedAttr>())
       os << "SWIFT_WEAK_IMPORT\n";
 
+    if (CD->getAttrs().hasAttribute<IBDesignableAttr>()) {
+      os << "IB_DESIGNABLE\n";
+    }
+
     bool hasResilientAncestry =
       CD->checkAncestry().contains(AncestryFlags::ResilientOther);
     if (hasResilientAncestry) {
@@ -1189,6 +1193,10 @@ private:
     }
 
     os << ") ";
+    if (VD->getAttrs().hasAttribute<IBInspectableAttr>()) {
+      os << "IBInspectable ";
+    }
+
     if (VD->getAttrs().hasAttribute<IBOutletAttr>()) {
       if (!maybePrintIBOutletCollection(ty))
         os << "IBOutlet ";

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -359,6 +359,14 @@ typealias AliasForNSRect = NSRect
   @objc func testBridgingOptionality(_ a: UnsafePointer<Int>?, b: UnsafeMutablePointer<Int>!, c: AutoreleasingUnsafeMutablePointer<Methods?>?) {}
 }
 
+// CHECK-LABEL: IB_DESIGNABLE
+// CHECK-NEXT: SWIFT_CLASS(
+// CHECK-NEXT: @interface MyDesignableObject : NSObject
+// CHECK-NEXT: init
+// CHECK-NEXT: @end
+// NEGATIVE-NOT: @interface NSObject
+@IBDesignable class MyDesignableObject : NSObject {}
+
 // CHECK-LABEL: @interface MyObject : NSObject
 // CHECK-NEXT: init
 // CHECK-NEXT: @end
@@ -517,6 +525,7 @@ public class NonObjCClass { }
 // CHECK-NEXT: @property (nonatomic) CFAliasForTypeRef _Nullable anyCF2;
 // CHECK-NEXT: @property (nonatomic, weak) IBOutlet id _Null_unspecified outlet;
 // CHECK-NEXT: @property (nonatomic, strong) IBOutlet Properties * _Null_unspecified typedOutlet;
+// CHECK-NEXT: @property (nonatomic) IBInspectable NSInteger inspectable;
 // CHECK-NEXT: @property (nonatomic, copy) NSString * _Nonnull string;
 // CHECK-NEXT: @property (nonatomic, copy) NSArray * _Nonnull array;
 // CHECK-NEXT: @property (nonatomic, copy) NSArray<NSArray<NSNumber *> *> * _Nonnull arrayOfArrays;
@@ -608,6 +617,7 @@ public class NonObjCClass { }
 
   @IBOutlet weak var outlet: AnyObject!
   @IBOutlet var typedOutlet: Properties!
+  @IBInspectable var inspectable: Int = 0
 
   @objc var string = "abc"
   @objc var array: Array<AnyObject> = []


### PR DESCRIPTION
Add support for @IBDesignable and @IBInspectable attribute to the
generated ObjC headers.

It’s my first try to commit to a project like this, and I’m not so sure if I get how the tests works.
I’m doing it right? I have to add some more?
