### PR TITLE
Runtime: Call Set/Dictionary casting hooks in the stdlib with the correct calling convention.

### DIFF
--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -2388,14 +2388,18 @@ extern "C"
 void _swift_setDownCastIndirect(OpaqueValue *destination,
                                 OpaqueValue *source,
                                 const Metadata *sourceValueType,
-                                const Metadata *targetValueType);
+                                const Metadata *targetValueType,
+                                const void *sourceValueHashable,
+                                const void *targetValueHashable);
 
 SWIFT_CC(swift)
 extern "C"
 bool _swift_setDownCastConditionalIndirect(OpaqueValue *destination,
-                                           OpaqueValue *source,
-                                           const Metadata *sourceValueType,
-                                           const Metadata *targetValueType);
+                                       OpaqueValue *source,
+                                       const Metadata *sourceValueType,
+                                       const Metadata *targetValueType,
+                                       const void *sourceValueHashable,
+                                       const void *targetValueHashable);
 
 SWIFT_CC(swift)
 extern "C"
@@ -2404,16 +2408,20 @@ void _swift_dictionaryDownCastIndirect(OpaqueValue *destination,
                                        const Metadata *sourceKeyType,
                                        const Metadata *sourceValueType,
                                        const Metadata *targetKeyType,
-                                       const Metadata *targetValueType);
+                                       const Metadata *targetValueType,
+                                       const void *sourceKeyHashable,
+                                       const void *targetKeyHashable);
 
 SWIFT_CC(swift)
 extern "C"
 bool _swift_dictionaryDownCastConditionalIndirect(OpaqueValue *destination,
-                                                  OpaqueValue *source,
-                                            const Metadata *sourceKeyType,
-                                            const Metadata *sourceValueType,
-                                            const Metadata *targetKeyType,
-                                            const Metadata *targetValueType);
+                                        OpaqueValue *source,
+                                        const Metadata *sourceKeyType,
+                                        const Metadata *sourceValueType,
+                                        const Metadata *targetKeyType,
+                                        const Metadata *targetValueType,
+                                        const void *sourceKeyHashable,
+                                        const void *targetKeyHashable);
 
 static bool _dynamicCastStructToStruct(OpaqueValue *destination,
                                        OpaqueValue *source,
@@ -2460,25 +2468,29 @@ static bool _dynamicCastStructToStruct(OpaqueValue *destination,
     if (flags & DynamicCastFlags::Unconditional) {
       _swift_dictionaryDownCastIndirect(source, destination,
                                         sourceArgs[0], sourceArgs[1],
-                                        targetArgs[0], targetArgs[1]);
+                                        targetArgs[0], targetArgs[1],
+                                        sourceArgs[2], targetArgs[2]);
       result = true;
     } else {
       result =
         _swift_dictionaryDownCastConditionalIndirect(source, destination,
                                         sourceArgs[0], sourceArgs[1],
-                                        targetArgs[0], targetArgs[1]);
+                                        targetArgs[0], targetArgs[1],
+                                        sourceArgs[2], targetArgs[2]);
     }
 
   // Sets.
   } else if (descriptor == &_TMnVs3Set) {
     if (flags & DynamicCastFlags::Unconditional) {
       _swift_setDownCastIndirect(source, destination,
-                                 sourceArgs[0], targetArgs[0]);
+                                 sourceArgs[0], targetArgs[0],
+                                 sourceArgs[1], targetArgs[1]);
       result = true;
     } else {
       result =
         _swift_setDownCastConditionalIndirect(source, destination,
-                                              sourceArgs[0], targetArgs[0]);
+                                              sourceArgs[0], targetArgs[0],
+                                              sourceArgs[1], targetArgs[1]);
     }
 
   // Other struct types don't support dynamic covariance for now.

--- a/test/Interpreter/dynamic_cast_dict_conditional_type_metadata.swift
+++ b/test/Interpreter/dynamic_cast_dict_conditional_type_metadata.swift
@@ -1,0 +1,25 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+// rdar://problem/28022201 exposed an ABI mismatch bug between the C++ code
+// in the runtime and standard library hook functions written in Swift, which
+// led to dynamic cast operations on sets and dictionaries generating corrupt
+// type metadata. Exercising this bug requires that the first instantiation of
+// a specific dictionary type in the process be through a dynamic cast. We
+// then bridge to ObjC, so that the resulting NSDictionary subclass is forced
+// to recover the underlying Dictionary's generic environment from the
+// corrupted class metadata instead of getting it passed in from the compiler.
+
+import Foundation
+
+let a: [String: Int] = ["foo": 1]
+let b: Any = a
+let c = b as? [String: Any]
+
+let d = (c as AnyObject) as! NSDictionary
+
+_ = d.object(forKey: "foo" as NSString)
+
+// CHECK: ok
+print("ok")

--- a/test/Interpreter/dynamic_cast_dict_unconditional_type_metadata.swift
+++ b/test/Interpreter/dynamic_cast_dict_unconditional_type_metadata.swift
@@ -1,0 +1,25 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+// rdar://problem/28022201 exposed an ABI mismatch bug between the C++ code
+// in the runtime and standard library hook functions written in Swift, which
+// led to dynamic cast operations on sets and dictionaries generating corrupt
+// type metadata. Exercising this bug requires that the first instantiation of
+// a specific dictionary type in the process be through a dynamic cast. We
+// then bridge to ObjC, so that the resulting NSDictionary subclass is forced
+// to recover the underlying Dictionary's generic environment from the
+// corrupted class metadata instead of getting it passed in from the compiler.
+
+import Foundation
+
+let a: [String: Int] = ["foo": 1]
+let b: Any = a
+let c = b as! [String: Any]
+
+let d = (c as AnyObject) as! NSDictionary
+
+_ = d.object(forKey: "foo" as NSString)
+
+// CHECK: ok
+print("ok")

--- a/test/Interpreter/dynamic_cast_set_conditional_type_metadata.swift
+++ b/test/Interpreter/dynamic_cast_set_conditional_type_metadata.swift
@@ -1,0 +1,25 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+// rdar://problem/28022201 exposed an ABI mismatch bug between the C++ code
+// in the runtime and standard library hook functions written in Swift, which
+// led to dynamic cast operations on sets and dictionaries generating corrupt
+// type metadata. Exercising this bug requires that the first instantiation of
+// a specific dictionary type in the process be through a dynamic cast. We
+// then bridge to ObjC, so that the resulting NSDictionary subclass is forced
+// to recover the underlying Dictionary's generic environment from the
+// corrupted class metadata instead of getting it passed in from the compiler.
+
+import Foundation
+
+let a: Set<String> = ["foo"]
+let b: Any = a
+let c = b as? Set<AnyHashable>
+
+let d = (c as AnyObject) as! NSSet
+
+_ = d.member("foo")
+
+// CHECK: ok
+print("ok")

--- a/test/Interpreter/dynamic_cast_set_unconditional_type_metadata.swift
+++ b/test/Interpreter/dynamic_cast_set_unconditional_type_metadata.swift
@@ -1,0 +1,25 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+// rdar://problem/28022201 exposed an ABI mismatch bug between the C++ code
+// in the runtime and standard library hook functions written in Swift, which
+// led to dynamic cast operations on sets and dictionaries generating corrupt
+// type metadata. Exercising this bug requires that the first instantiation of
+// a specific dictionary type in the process be through a dynamic cast. We
+// then bridge to ObjC, so that the resulting NSDictionary subclass is forced
+// to recover the underlying Dictionary's generic environment from the
+// corrupted class metadata instead of getting it passed in from the compiler.
+
+import Foundation
+
+let a: Set<String> = ["foo"]
+let b: Any = a
+let c = b as! Set<AnyHashable>
+
+let d = (c as AnyObject) as! NSSet
+
+_ = d.member("foo")
+
+// CHECK: ok
+print("ok")


### PR DESCRIPTION
We neglected to pass down the Hashable witness table parameters, leading to Heisenbugs because we would call into invalid witness pointers occasionally when loading the Hashable conformance from corrupted metadata. Fixes rdar://problem/28022201.
