### PR TITLE
Fix source location on collection cast optional-to-Any warning.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5111,6 +5111,7 @@ maybeDiagnoseUnsupportedFunctionConversion(TypeChecker &tc, Expr *expr,
 
 static CollectionUpcastConversionExpr::ConversionPair
 buildElementConversion(ExprRewriter &rewriter,
+                       SourceLoc srcLoc,
                        Type srcCollectionType,
                        Type destCollectionType,
                        ConstraintLocatorBuilder locator,
@@ -5123,7 +5124,7 @@ buildElementConversion(ExprRewriter &rewriter,
 
   // Build the conversion.
   ASTContext &ctx = rewriter.getConstraintSystem().getASTContext();
-  auto opaque = new (ctx) OpaqueValueExpr(SourceLoc(), srcType);
+  auto opaque = new (ctx) OpaqueValueExpr(srcLoc, srcType);
   auto conversion =
     rewriter.coerceToType(opaque, destType,
            locator.withPathElement(
@@ -5283,8 +5284,8 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       }
 
       // Build the value conversion.
-      auto conv =
-        buildElementConversion(*this, expr->getType(), toType, locator, 0);
+      auto conv = buildElementConversion(*this, expr->getLoc(), expr->getType(),
+                                         toType, locator, 0);
 
       // Form the upcast.
       return new (tc.Context) CollectionUpcastConversionExpr(expr, toType,
@@ -5325,10 +5326,10 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       }
 
       // Build the key and value conversions.
-      auto keyConv =
-        buildElementConversion(*this, expr->getType(), toType, locator, 0);
-      auto valueConv =
-        buildElementConversion(*this, expr->getType(), toType, locator, 1);
+      auto keyConv = buildElementConversion(
+          *this, expr->getLoc(), expr->getType(), toType, locator, 0);
+      auto valueConv = buildElementConversion(
+          *this, expr->getLoc(), expr->getType(), toType, locator, 1);
 
       // If the source key and value types are object types, this is an upcast.
       // Otherwise, it's bridged.
@@ -5348,8 +5349,8 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       }
 
       // Build the value conversion.
-      auto conv =
-        buildElementConversion(*this, expr->getType(), toType, locator, 0);
+      auto conv = buildElementConversion(*this, expr->getLoc(), expr->getType(),
+                                         toType, locator, 0);
 
       return new (tc.Context) CollectionUpcastConversionExpr(expr, toType,
                                                              {}, conv);

--- a/test/Sema/diag_unintended_optional_behavior.swift
+++ b/test/Sema/diag_unintended_optional_behavior.swift
@@ -59,6 +59,31 @@ func warnOptionalToAnyCoercion(value x: Int?) -> Any {
   // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}
 }
 
+func takesCollectionOfAny(_ a: [Any], _ d: [String : Any]) {
+}
+
+func warnCollectionOfAny(_ a: [Int?], _ d: [String : Int?]) {
+  // https://bugs.swift.org/browse/SR-2928 - Collection casts from collections of optionals to collections of Any need custom handling
+  takesCollectionOfAny(a, d) // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}{{25-25= ?? <#default value#>}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}{{25-25=!}}
+  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}{{25-25= as Any}}
+  // expected-warning@-4 {{expression implicitly coerced from 'Int?' to Any}}
+  // expected-note@-5 {{provide a default value to avoid this warning}}{{28-28= ?? <#default value#>}}
+  // expected-note@-6 {{force-unwrap the value to avoid this warning}}{{28-28=!}}
+  // expected-note@-7 {{explicitly cast to Any with 'as Any' to silence this warning}}{{28-28= as Any}}
+
+  // https://bugs.swift.org/browse/SR-2928 - Collection casts from collections of optionals to collections of Any need custom handling
+  takesCollectionOfAny(a as [Any], d as [String : Any]) // expected-warning {{expression implicitly coerced from 'Int?' to Any}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}{{25-25= ?? <#default value#>}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}{{25-25=!}}
+  // expected-note@-3 {{explicitly cast to Any with 'as Any' to silence this warning}}{{25-25= as Any}}
+  // expected-warning@-4 {{expression implicitly coerced from 'Int?' to Any}}
+  // expected-note@-5 {{provide a default value to avoid this warning}}{{37-37= ?? <#default value#>}}
+  // expected-note@-6 {{force-unwrap the value to avoid this warning}}{{37-37=!}}
+  // expected-note@-7 {{explicitly cast to Any with 'as Any' to silence this warning}}{{37-37= as Any}}
+}
+
 func warnOptionalInStringInterpolationSegment(_ o : Int?) {
   print("Always some, Always some, Always some: \(o)")
   // expected-warning@-1 {{string interpolation produces a debug description for an optional value; did you mean to make this explicit?}}
@@ -72,4 +97,3 @@ func warnOptionalInStringInterpolationSegment(_ o : Int?) {
   print("Always some, Always some, Always some: \(o as Int?)") // No warning
   print("Always some, Always some, Always some: \(o.debugDescription)") // No warning.
 }
-


### PR DESCRIPTION
The warnings here are not ideal, nor are the fixits, but having a
correct source location at least helps users determine where the
conversions are happening.

I've filed https://bugs.swift.org/browse/SR-2928 to improve the warnings
and fixits.

This resolves https://bugs.swift.org/browse/SR-2921 and the warning
location portion of rdar://problem/28722908.
