### PR TITLE
[Type checker] Eliminate generation of useless constraints NFC.

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -3313,6 +3313,12 @@ public:
         }
       }
 
+      // If the right-hand side and result type are both type parameters, we're
+      // not providing a useful completion.
+      if (expr->getType()->isTypeParameter() &&
+          CCE.getType()->isTypeParameter())
+        return;
+
       addInfixOperatorCompletion(op, expr->getType(), CCE.getType());
     }
   }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -468,25 +468,6 @@ namespace {
                                             FunctionRefKind::Compound,
                                             locator));
 
-        if (!archetype) {
-          // If the nested type is not an archetype (because it was constrained
-          // to a concrete type by a requirement), return the fresh type
-          // variable now, and let binding occur during overload resolution.
-          return memberTypeVar;
-        }
-                                
-        // FIXME: Would be better to walk the requirements of the protocol
-        // of which the associated type is a member.
-        if (auto superclass = member->getSuperclass()) {
-          CS.addConstraint(ConstraintKind::Subtype, memberTypeVar,
-                           superclass, locator);
-        }
-
-        for (auto proto : member->getConformingProtocols()) {
-          CS.addConstraint(ConstraintKind::ConformsTo, memberTypeVar,
-                           proto->getDeclaredType(), locator);
-        }
-
         return memberTypeVar;
       });
     }


### PR DESCRIPTION
<!-- What's in this pull request? -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

There's no point in adding the constraints known on an associated type
to the constraint system, because they're implied by the protocol
constraint itself.
