### PR TITLE
Use std::function to fix unsafe use of llvm::function_ref.

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -302,7 +302,7 @@ static bool shouldHideDeclFromCompletionResults(const ValueDecl *D) {
   return false;
 }
 
-typedef llvm::function_ref<bool(ValueDecl*, DeclVisibilityKind)> DeclFilter;
+typedef std::function<bool(ValueDecl*, DeclVisibilityKind)> DeclFilter;
 DeclFilter DefaultFilter = [] (ValueDecl* VD, DeclVisibilityKind Kind) {return true;};
 DeclFilter KeyPathFilter = [](ValueDecl* decl, DeclVisibilityKind) -> bool {
   return isa<TypeDecl>(decl) ||


### PR DESCRIPTION
This was exposed by building with a recent version of clang. Without this
change, the following tests were failing:

```
Swift(macosx-x86_64) :: IDE/complete_assignment.swift
Swift(macosx-x86_64) :: IDE/complete_enum_elements.swift
Swift(macosx-x86_64) :: IDE/complete_stmt_controlling_expr.swift
Swift(macosx-x86_64) :: SourceKit/CodeComplete/complete_structure.swift
```

I did not narrow it down to which uses of DeclFilter were problematic.
The global variables certainly do not seem like a good place to use a
function_ref. rdar://problem/28699882
