### PR TITLE
improve set's conditional downcast performance by over 2X

### DIFF
--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -1390,10 +1390,15 @@ public func _setDownCastConditionalIndirect<SourceValue, TargetValue>(
 public func _setDownCastConditional<BaseValue, DerivedValue>(
   _ source: Set<BaseValue>
 ) -> Set<DerivedValue>? {
-  return try? Set(
-    source.lazy.map {
-      try ($0 as? DerivedValue).unwrappedOrError()
-    })
+  var result = Set<DerivedValue>(minimumCapacity: source.count)
+  for member in source {
+    if let derivedMember = member as? DerivedValue {
+      result.insert(derivedMember)
+      continue
+    }
+    return nil
+  }
+  return result
 }
 
 #if _runtime(_ObjC)


### PR DESCRIPTION
radar rdar://problem/27513079

9a2783f6febec542c6242dcdf5cc6288a1861caf regressed the performance of some benchmarks by over 2X, I traced the problem back to set's conditional downcast implementation.

Using Collection<A>.map<A> -> [A1] to create the Set has a high overhead (see new_run.trace instruments output attached to radar), pre-creation of a Set with a known capacity + iterating over source in a loop vastly improves performance (see fix_run.trace instruments output attached to radar)
