### PR TITLE
SR-2280: swiftc -static-stdlib option fails on Linux

### DIFF
--- a/lib/Driver/CMakeLists.txt
+++ b/lib/Driver/CMakeLists.txt
@@ -30,6 +30,9 @@ if(SWIFT_BUILD_STATIC_STDLIB)
         set(ICU_STATICLIB "TRUE")
       else()
         set(ICU_STATICLIB "FALSE")
+        find_package(ICU REQUIRED COMPONENTS uc i18n)
+        get_filename_component(ICU_UC_LIBDIR "${ICU_UC_LIBRARY}" DIRECTORY)
+        get_filename_component(ICU_I18N_LIBDIR "${ICU_I18N_LIBRARY}" DIRECTORY)
       endif()
       set(linkfile "${lowercase_sdk}/static-stdlib-args.lnk")
       add_custom_command_target(swift_static_stdlib_${sdk}_args
@@ -38,6 +41,8 @@ if(SWIFT_BUILD_STATIC_STDLIB)
           "${sdk}"
           "${SWIFTSTATICLIB_DIR}/${linkfile}"
           "${ICU_STATICLIB}"
+          "${ICU_UC_LIBDIR}"
+          "${ICU_I18N_LIBDIR}"
         OUTPUT
           "${SWIFTSTATICLIB_DIR}/${linkfile}")
 

--- a/utils/gen-static-stdlib-link-args
+++ b/utils/gen-static-stdlib-link-args
@@ -2,34 +2,62 @@
 
 #
 # Generate the static-stdlib-args.lnk used by the -static-stdlib option for
-# 'GenericUnix' (eg linux) plaforms. If libicu is built locally then include
-# libicudata
+# 'GenericUnix' (eg linux) plaforms. Tries to find static .a files for libs
+# not normally installed by default (currently libicu)
+# If libicu is built locally then include libicudata
 #
 
 # SDK=$1
 OUTPUTFILE=$2
 ICU_STATIC_LIB=$3
+# libdirs from pkg-config
+ICU_UC_LIBDIR=$4
+ICU_I18N_LIBDIR=$5
 
 
-if [ "${ICU_STATIC_LIB}" == "TRUE" ]; then
-    read -r -d '' ICU_LIBS <<EOF
+# Try and find the libicu .a library files to directly link in using the
+# fullpath to the files otherwise fullback to the default
+function find_static_iculibs {
+    if [ -n "${ICU_I18N_LIBDIR}" ]; then
+        LIBICU_I18N_A=${ICU_I18N_LIBDIR}/libicui18n.a
+    fi
+
+    if [ -n "${ICU_UC_LIBDIR}" ]; then
+        LIBICU_UC_A=${ICU_UC_LIBDIR}/libicuuc.a
+        LIBICU_DATA_A=${ICU_UC_LIBDIR}/libicudata.a
+    fi
+
+    if [ -f "${LIBICU_I18N_A}" ] && [ -f "${LIBICU_UC_A}" ] &&
+       [ -f "${LIBICU_DATA_A}" ]; then
+        read -d '' ICU_LIBS <<EOF
+$LIBICU_I18N_A
+$LIBICU_UC_A
+$LIBICU_DATA_A
+EOF
+    else
+        read -d '' ICU_LIBS <<EOF
+-licui18n
+-licuuc
+EOF
+    fi
+}
+
+
+# If libicu was compiled as part of the swift build then link the libs as normal
+function use_local_iculibs {
+   read -d '' ICU_LIBS <<EOF
 -licui18n
 -licuuc
 -licudata
 EOF
-else
-    read -r -d '' ICU_LIBS <<EOF
--licui18n
--licuuc
-EOF
-fi
+}
 
 
-if [ -z "${OUTPUTFILE}" ]; then
-    echo $0: No outputfile specified
-    exit 1
-fi
-
+function write_linkfile {
+    if [ -z "${OUTPUTFILE}" ]; then
+        echo $0: No outputfile specified
+        exit 1
+    fi
     cat >$OUTPUTFILE <<EOF
 -ldl
 -lpthread
@@ -43,3 +71,12 @@ $ICU_LIBS
 -Xlinker
 ALL
 EOF
+}
+
+
+if [ "${ICU_STATIC_LIB}" == "TRUE" ]; then
+    use_local_iculibs
+else
+    find_static_iculibs
+fi
+write_linkfile


### PR DESCRIPTION
This change makes the -static-stdlib option on linux/ELF platforms link in more static libraries where possible to produce binaries that arent dependant on libraries not installed by default. Currently this is just libicu.a, libicui18n.a and libicudata.a if these can be found

Resolves [SR-2280](https://bugs.swift.org/browse/SR-2280)
- Create a file of linker arguments instead of a hardcoded
  list in ToolChains.cpp for use by -static-stdlib option
- Try and link in more static libs in preference to dynamic
  ones for packages not normally installed by default,
  eg libicu
