### PR TITLE
(wip) IRGen: Include witness tables as part of generic metadata patterns' keys.

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -165,8 +165,24 @@ namespace {
     static unsigned getNumGenericArguments(IRGenModule &IGM,
                                            NominalTypeDecl *nominal) {
       GenericTypeRequirements requirements(IGM, nominal);
-      return unsigned(requirements.hasParentType())
-               + requirements.getNumTypeRequirements();
+      unsigned count = requirements.hasParentType() ? 1 : 0;
+
+      for (auto &requirement : requirements.getRequirements()) {
+        if (!requirement.Protocol) {
+          // Type requirement
+          count++;
+          continue;
+        }
+        
+        if (Lowering::TypeConverter
+            ::protocolRequiresWitnessTable(requirement.Protocol)) {
+          // Witness table requirement
+          count++;
+          continue;
+        }
+      }
+      
+      return count;
     }
 
     void collectTypes(IRGenModule &IGM, NominalTypeDecl *nominal) {

--- a/test/IRGen/generic-pattern-key-parameters-objc.swift
+++ b/test/IRGen/generic-pattern-key-parameters-objc.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name main -emit-ir %s | %FileCheck %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+protocol P {
+  associatedtype T
+}
+@objc protocol Q {}
+
+// CHECK: @_TMPC4main1A = {{.*}} i16 2,
+class A<T: P & Q> {}
+// CHECK: @_TMPC4main1B = {{.*}} i16 3,
+class B<T: P & Q> where T.T: P & Q {}

--- a/test/IRGen/generic-pattern-key-parameters.swift
+++ b/test/IRGen/generic-pattern-key-parameters.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-frontend -module-name main -emit-ir %s | %FileCheck %s
+
+protocol P {
+  associatedtype T
+}
+protocol Q {}
+
+// CHECK: @_TMPV4main1A = {{.*}} i16 1,
+struct A<T> {}
+// CHECK: @_TMPV4main1B = {{.*}} i16 1,
+struct B<T: AnyObject> {}
+// CHECK: @_TMPV4main1C = {{.*}} i16 2,
+struct C<T: P> {}
+// CHECK: @_TMPV4main1D = {{.*}} i16 3,
+struct D<T: P & Q> {}
+// CHECK: @_TMPV4main1E = {{.*}} i16 2,
+struct E<T: P & AnyObject> {}
+// CHECK: @_TMPV4main1F = {{.*}} i16 3,
+struct F<T: P & AnyObject & Q> {}
+// CHECK: @_TMPV4main1G = {{.*}} i16 3,
+struct G<T: P> where T.T: P {}
+// CHECK: @_TMPV4main1H = {{.*}} i16 2,
+struct H<T, U> {}
+// CHECK: @_TMPV4main1I = {{.*}} i16 3,
+struct I<T: P, U> {}
+// CHECK: @_TMPV4main1J = {{.*}} i16 3,
+struct J<T, U: P> {}
+// CHECK: @_TMPV4main1K = {{.*}} i16 4,
+struct K<T: P, U: P> {}
+// CHECK: @_TMPV4main1L = {{.*}} i16 5,
+struct L<T: P, U: P & Q>  {}
+// CHECK: @_TMPV4main1M = {{.*}} i16 7,
+struct M<T: P, U: P & Q> where T.T: P, U.T: Q {}
+


### PR DESCRIPTION
The conformance chosen is a significant part of the type, and can differ within a process if multiple modules independently evolve their own conformances of the same type to the same protocol. We used to unique by witness table, but that seems to have been accidentally lost due to other refactorings. The lack of uniquing covered up the problem in rdar://problem/28022201, because we would instantiate some types' metadata with a garbage witness table, then intermingle it with metadata with the correct witness table. Properly uniquing by conformance would make the type mismatch much more apparent at runtime.

(wip) because this exposes a crash in some tests because we fail to unique witness tables emitted for conformances implicitly generated by the Clang importer at runtime, leading to erroneously different Set and Dictionary instantiations on C types at runtime. We need to fix rdar://problem/18884333 before fixing this.
