### PR TITLE
[SourceKit] Add test case for crash triggered in swift::getTypeOfCompletionContextExpr(…)

### DIFF
--- a/validation-test/IDE/crashers/104-swift-gettypeofcompletioncontextexpr.swift
+++ b/validation-test/IDE/crashers/104-swift-gettypeofcompletioncontextexpr.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+{let:e(var d#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 138
swift-ide-test: /path/to/swift/lib/Sema/TypeCheckConstraints.cpp:1636: Optional<swift::Type> swift::TypeChecker::getTypeOfExpressionWithoutApplying(swift::Expr *&, swift::DeclContext *, swift::ConcreteDeclRef &, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener *): Assertion `exprType && !exprType->hasError() && "erroneous solution?"' failed.
9  swift-ide-test  0x0000000000a4ed43 swift::getTypeOfCompletionContextExpr(swift::ASTContext&, swift::DeclContext*, swift::CompletionTypeCheckKind, swift::Expr*&, swift::ConcreteDeclRef&) + 691
11 swift-ide-test  0x0000000000988f11 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 305
12 swift-ide-test  0x0000000000838cb1 swift::CompilerInstance::performSema() + 3697
13 swift-ide-test  0x00000000007d9494 main + 42580
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking expression at [<INPUT-FILE>:3:12 - line:3:12] RangeText="d"
```
