### PR TITLE
[SIL] Add test case for crash triggered in swift::Parser::parseIdentifier(…)

### DIFF
--- a/validation-test/SIL/crashers/045-swift-parser-parseidentifier.sil
+++ b/validation-test/SIL/crashers/045-swift-parser-parseidentifier.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+class j<rethrows


### PR DESCRIPTION
Stack trace:

```
sil-opt: /path/to/swift/include/swift/Parse/Parser.h:393: swift::SourceLoc swift::Parser::consumeIdentifier(swift::Identifier *): Assertion `Tok.isAny(tok::identifier, tok::kw_self, tok::kw_Self, tok::kw_throws)' failed.
8  sil-opt         0x0000000000ada58e swift::Parser::parseIdentifier(swift::Identifier&, swift::SourceLoc&, swift::Diagnostic const&) + 78
9  sil-opt         0x0000000000b54d5a swift::Parser::parseGenericParameters(swift::SourceLoc) + 570
10 sil-opt         0x0000000000b55bf4 swift::Parser::maybeParseGenericParams() + 132
11 sil-opt         0x0000000000b318ea swift::Parser::parseDeclClass(swift::SourceLoc, swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&) + 954
12 sil-opt         0x0000000000b2f97d swift::Parser::parseDecl(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) + 3901
13 sil-opt         0x0000000000b118a9 swift::Parser::parseBraceItems(llvm::SmallVectorImpl<swift::ASTNode>&, swift::BraceItemListKind, swift::BraceItemListKind) + 889
14 sil-opt         0x0000000000b2543a swift::Parser::parseTopLevel() + 170
15 sil-opt         0x0000000000ad8360 swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) + 208
16 sil-opt         0x0000000000802013 swift::CompilerInstance::performSema() + 3315
17 sil-opt         0x00000000007e8b5c main + 1852
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  With parser at source location: <stdin>:3:9
```
