### PR TITLE
[swiftc (75 vs. 5175)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28438-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28438-swift-typebase-getcanonicaltype.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+protocol A{typealias e}struct B:A{var f=e


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 75 (5175 resolved)

Assertion failure in [`lib/AST/ASTContext.cpp (line 3330)`](https://github.com/apple/swift/blob/master/lib/AST/ASTContext.cpp#L3330):

```
Assertion `!objectTy->hasError() && "cannot have ErrorType wrapped inside LValueType"' failed.

When executing: static swift::LValueType *swift::LValueType::get(swift::Type)
```

Assertion context:

```
  ID.AddPointer(Parent.getPointer());
}

LValueType *LValueType::get(Type objectTy) {
  assert(!objectTy->hasError() &&
         "cannot have ErrorType wrapped inside LValueType");
  assert(!objectTy->is<LValueType>() && !objectTy->is<InOutType>() &&
         "cannot have 'inout' or @lvalue wrapped inside an @lvalue");

  auto properties = objectTy->getRecursiveProperties()
                    | RecursiveTypeProperties::IsLValue;
```

Stack trace:

```
swift: /path/to/swift/lib/AST/ASTContext.cpp:3330: static swift::LValueType *swift::LValueType::get(swift::Type): Assertion `!objectTy->hasError() && "cannot have ErrorType wrapped inside LValueType"' failed.
8  swift           0x00000000011a9c1b swift::TypeBase::getCanonicalType() + 2075
9  swift           0x00000000011aa4a7 swift::TypeBase::isEqual(swift::Type) + 23
10 swift           0x0000000001069e9e swift::constraints::ConstraintSystem::matchTypes(swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 254
11 swift           0x0000000001075d72 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 642
12 swift           0x0000000001008227 swift::constraints::ConstraintSystem::addConstraint(swift::constraints::Constraint*, bool, bool) + 23
13 swift           0x000000000100c27d swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator*, swift::Type, swift::constraints::OverloadChoice) + 2365
14 swift           0x0000000001075e88 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 920
15 swift           0x0000000001008227 swift::constraints::ConstraintSystem::addConstraint(swift::constraints::Constraint*, bool, bool) + 23
20 swift           0x0000000001135d9e swift::Expr::walk(swift::ASTWalker&) + 46
21 swift           0x0000000001053068 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) + 200
22 swift           0x000000000107c2dd swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 77
23 swift           0x0000000000f5e28b swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 347
24 swift           0x0000000000f60d7e swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 942
27 swift           0x0000000000fe5223 swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 355
28 swift           0x0000000000fe5077 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 39
29 swift           0x0000000000fe5c7c swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 188
31 swift           0x0000000000f9a75b swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1291
32 swift           0x0000000000d11fd6 swift::CompilerInstance::performSema() + 3350
33 swift           0x000000000085dd1e swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 3422
34 swift           0x00000000008251de main + 2878
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28438-swift-typebase-getcanonicaltype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28438-swift-typebase-getcanonicaltype-d67508.o
1.  While type-checking setter for f at validation-test/compiler_crashers/28438-swift-typebase-getcanonicaltype.swift:10:39
2.  While type-checking expression at [<invalid loc> - <invalid loc>]
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
