### PR TITLE
Improvements to swift-api-dump.py

### DIFF
--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -246,6 +246,9 @@ ImportPaths("I", llvm::cl::desc("add a directory to the import search path"));
 static llvm::cl::list<std::string>
 FrameworkPaths("F", llvm::cl::desc("add a directory to the framework search path"));
 
+static llvm::cl::list<std::string>
+SystemFrameworkPaths("iframework", llvm::cl::desc("add a directory to the system framework search path"));
+
 static llvm::cl::opt<std::string>
 ResourceDir("resource-dir",
             llvm::cl::desc("The directory that holds the compiler resource files"));
@@ -2783,6 +2786,11 @@ int main(int argc, char *argv[]) {
     options::ModuleCachePath;
   InitInvok.setImportSearchPaths(options::ImportPaths);
   InitInvok.setFrameworkSearchPaths(options::FrameworkPaths);
+  for (const auto &systemFrameworkPath : options::SystemFrameworkPaths) {
+    auto &extraArgs = InitInvok.getClangImporterOptions().ExtraArgs;
+    extraArgs.push_back("-iframework");
+    extraArgs.push_back(systemFrameworkPath);
+  }
   InitInvok.getFrontendOptions().EnableSourceImport |=
     options::EnableSourceImport;
   InitInvok.getFrontendOptions().ImplicitObjCHeaderPath =

--- a/utils/swift-api-dump.py
+++ b/utils/swift-api-dump.py
@@ -93,6 +93,8 @@ def create_parser():
                         help='Print extra information.')
     parser.add_argument('-F', '--framework-dir', action='append',
                         help='Add additional framework directories')
+    parser.add_argument('-iframework', '--system-framework-dir', action='append',
+                        help='Add additional system framework directories')
     parser.add_argument('-I', '--include-dir', action='append',
                         help='Add additional include directories')
     parser.add_argument('--enable-infer-import-as-member', action='store_true',
@@ -282,10 +284,13 @@ def main():
         '-skip-overrides'
     ]
 
-    # Add -F / -I arguments.
+    # Add -F / -iframework / -I arguments.
     if args.framework_dir:
         for path in args.framework_dir:
             cmd_common = cmd_common + ['-F', path]
+    if args.system_framework_dir:
+        for path in args.system_framework_dir:
+            cmd_common = cmd_common + ['-iframework', path]
     if args.include_dir:
         for path in args.include_dir:
             cmd_common = cmd_common + ['-I', path]


### PR DESCRIPTION
Add a couple enhancements to `swift-api-dump.py`:
- `-swift-version N` support
- Drop generation of the `-always-argument-labels` flag; we're past Swift 2's weird rules now
- `-iframework <path>` support
