### PR TITLE
SR-2505: Fix "Call arguments did not match up" assertion

### DIFF
--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -324,3 +324,35 @@ func r20789423() {
 }
 
 let f: (Int, Int) -> Void = { x in }  // expected-error {{contextual closure type specifies '(Int, Int)', but 1 was used in closure body, try adding extra parentheses around the single tuple argument}}
+
+// Make sure that behavior related to allowing trailing closures to match functions
+// with Any as a final parameter is the same after the changes made by SR-2505, namely:
+// that we continue to select function that does _not_ have Any as a final parameter in
+// presence of other posibilities.
+
+protocol SR_2505_Initable { init() }
+struct SR_2505_II : SR_2505_Initable {}
+
+protocol P_SR_2505 {
+  associatedtype T: SR_2505_Initable
+}
+
+extension P_SR_2505 {
+  func test(it o: (T) -> Bool) -> Bool {
+    return o(T.self())
+  }
+}
+
+class C_SR_2505 : P_SR_2505 {
+  typealias T = SR_2505_II
+
+  func test(_ o: Any) -> Bool {
+    return false
+  }
+
+  func call(_ c: C_SR_2505) -> Bool {
+    return c.test { o in test(o) }
+  }
+}
+
+let _ = C_SR_2505().call(C_SR_2505())

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -821,3 +821,29 @@ func foo1255_1() {
 func foo1255_2() -> Int {
   return true || false // expected-error {{cannot convert return expression of type 'Bool' to return type 'Int'}}
 }
+
+// SR-2505: "Call arguments did not match up" assertion
+
+func sr_2505(_ a: Any) {} // expected-note {{}}
+sr_2505()          // expected-error {{missing argument for parameter #1 in call}}
+sr_2505(a: 1)      // expected-error {{extraneous argument label 'a:' in call}}
+sr_2505(1, 2)      // expected-error {{extra argument in call}}
+sr_2505(a: 1, 2)   // expected-error {{extra argument in call}}
+
+struct C_2505 {
+  init(_ arg: Any) {
+  }
+}
+
+protocol P_2505 {
+}
+
+extension C_2505 {
+  init<T>(from: [T]) where T: P_2505 {
+  }
+}
+
+class C2_2505: P_2505 {
+}
+
+let c_2505 = C_2505(arg: [C2_2505()]) // expected-error {{argument labels '(arg:)' do not match any available overloads}} expected-note {{overloads for 'C_2505' exist}}


### PR DESCRIPTION
<!-- What's in this pull request? -->

Always check arguments of the tuple type against corresponding parameters,
otherwise for a single argument functions e.g. foo(_ a: Any) after SE-0046
type checker is going to produce incorrect solution.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-2505](https://bugs.swift.org/browse/SR-2505).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
