### PR TITLE
Error for declaring postfix operators that begin with '?' or '!'

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5523,6 +5523,11 @@ Parser::parseDeclOperator(ParseDeclOptions Flags, DeclAttributes &Attributes) {
   
   Identifier Name = Context.getIdentifier(Tok.getText());
   SourceLoc NameLoc = consumeToken();
+    
+  if (Attributes.hasAttribute<PostfixAttr>()) {
+    if (!Name.empty() && (Name.get()[0] == '?' || Name.get()[0] == '!'))
+      diagnose(NameLoc, diag::expected_operator_name_after_operator);      
+  }
   
   auto Result = parseDeclOperatorImpl(OperatorLoc, Name, NameLoc, Attributes);
 

--- a/test/Parse/operator_decl.swift
+++ b/test/Parse/operator_decl.swift
@@ -39,6 +39,11 @@ prefix operator // expected-error {{expected operator name in operator declarati
 ;
 prefix operator %%+
 
+prefix operator ??
+postfix operator ?? // expected-error {{expected operator name in operator declaration}}
+prefix operator !!
+postfix operator !! // expected-error {{expected operator name in operator declaration}}
+
 infix operator +++=
 infix operator *** : A
 infix operator --- : ;

--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -148,8 +148,8 @@ postfix prefix infix func ++(x: Double) {} // expected-error {{'prefix' contradi
 infix prefix func +-+(x: Int, y: Int) {} // expected-error {{'infix' modifier is not required or allowed on func declarations}} {{1-7=}} expected-error{{'prefix' contradicts previous modifier 'infix'}} {{7-14=}}
 
 // Don't allow one to define a postfix '!'; it's built into the
-// language.
-postfix operator!  // expected-error {{cannot declare a custom postfix '!' operator}}
+// language. Also illegal to have any postfix operator starting with '!'.
+postfix operator !  // expected-error {{cannot declare a custom postfix '!' operator}} expected-error {{expected operator name in operator declaration}}
 prefix operator &  // expected-error {{cannot declare a custom prefix '&' operator}}
 
 // <rdar://problem/14607026> Restrict use of '<' and '>' as prefix/postfix operator names


### PR DESCRIPTION
<!-- What's in this pull request? -->

The existing limitation that postfix operators can't begin with '?' or '!' wasn't being detected while parsing operator decls, and so declarations of invalid operators would be accepted without error and then later couldn't be used.

Now errors correctly and new tests added.

This is just https://github.com/apple/swift/pull/4515 done over again, since that ran into conflicts.
