### PR TITLE
[stdlib] Rewriting native hashed collection indices (rebased)

### DIFF
--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -1355,15 +1355,9 @@ public func _setDownCast<BaseValue, DerivedValue>(_ source: Set<BaseValue>)
   && _isClassOrObjCExistential(DerivedValue.self) {
     switch source._variantBuffer {
     case _VariantSetBuffer.native(let buffer):
-      let bridged = buffer.bridged()
-      return Set(
-        _immutableCocoaSet:
-        unsafeBitCast(bridged, to: _NSSet.self))
-
+      return Set(_immutableCocoaSet: buffer.bridged())
     case _VariantSetBuffer.cocoa(let cocoaBuffer):
-      return Set(
-        _immutableCocoaSet:
-        unsafeBitCast(cocoaBuffer, to: _NSSet.self))
+      return Set(_immutableCocoaSet: cocoaBuffer.cocoaSet)
     }
   }
 #endif
@@ -2310,15 +2304,9 @@ public func _dictionaryDownCast<BaseKey, BaseValue, DerivedKey, DerivedValue>(
     case .native(let buffer):
       // Note: it is safe to treat the buffer as immutable here because
       // Dictionary will not mutate buffer with reference count greater than 1.
-      let nativeBuffer = buffer.bridged()
-      return Dictionary(
-        _immutableCocoaDictionary:
-        unsafeBitCast(nativeBuffer, to: _NSDictionary.self))
-
+      return Dictionary(_immutableCocoaDictionary: buffer.bridged())
     case .cocoa(let cocoaBuffer):
-      return Dictionary(
-        _immutableCocoaDictionary:
-        unsafeBitCast(cocoaBuffer, to: _NSDictionary.self))
+      return Dictionary(_immutableCocoaDictionary: cocoaBuffer.cocoaDictionary)
     }
   }
 #endif
@@ -3201,15 +3189,25 @@ extension _Native${Self}Buffer
   }
 
 #if _runtime(_ObjC)
-  func bridged() -> _NS${Self}Core {
+  func bridged() -> _NS${Self} {
     // We can zero-cost bridge if our keys are verbatim
     // or if we're the empty singleton.
+
+    // Temporary var for SOME type safety before a cast.
+    let nsSet: _NS${Self}Core
+
     if (_isBridgedVerbatimToObjectiveC(Key.self) &&
         _isBridgedVerbatimToObjectiveC(Value.self)) ||
         self._storage === RawStorage.empty {
-      return self._storage
+      nsSet = self._storage
+    } else {
+      nsSet = _SwiftDeferredNS${Self}(nativeBuffer: self)
     }
-    return _SwiftDeferredNS${Self}(nativeBuffer: self)
+
+    // Cast from "minimal NS${Self}" to "NS${Self}"
+    // Note that if you actually ask Swift for this cast, it will fail.
+    // Never trust a shadow protocol!
+    return unsafeBitCast(nsSet, to: _NS${Self}.self)
   }
 #endif
 

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -92,23 +92,25 @@ import SwiftShims
 //
 // There are three different classes that can provide a native backing storage: 
 // * `_RawNativeDictionaryStorage`
-// * `_TypedNativeDictionaryStorage<K, V>`      (inherits from Raw)
-// * `_NativeDictionaryStorage<K: Hashable, V>` (inherits from Typed)
+// * `_TypedNativeDictionaryStorage<K, V>`                   (extends Raw)
+// * `_HashableTypedNativeDictionaryStorage<K: Hashable, V>` (extends Typed)
 //
-// In a less optimized implementation, the parent classes of NativeStorage could
+// (Hereafter RawStorage, TypedStorage, and HashableStorage, respectively)
+//
+// In a less optimized implementation, the parent classes could
 // be eliminated, as they exist only to provide special-case behaviours. 
-// NativeStorage has everything a full implementation of a Dictionary
+// HashableStorage has everything a full implementation of a Dictionary
 // requires, and is subsequently able to provide a full NSDictionary 
-// implementation. Note that NativeStorage must have the `K: Hashable` constraint
-// because the NSDictionary implementation can't be provided in a constrained 
-// extension.
+// implementation. Note that HashableStorage must have the `K: Hashable` 
+// constraint because the NSDictionary implementation can't be provided in a 
+// constrained extension.
 //
 // In normal usage, you can expect the backing storage of a Dictionary to be a 
 // NativeStorage.
 //
-// TypedStorage is distinguished from NativeStorage to allow us to create a
-// `NativeBuffer<AnyObject, AnyObject>`. Without the Hashable requirement,
-// such a Buffer is restricted to operations which can be performed
+// TypedStorage is distinguished from HashableStorage to allow us to create a
+// `_NativeDictionaryBuffer<AnyObject, AnyObject>`. Without the Hashable 
+// requirement, such a Buffer is restricted to operations which can be performed
 // with only the structure of the Storage: indexing and iteration. This is used
 // in _SwiftDeferredNSDictionary to construct twin "native" and "bridged"
 // storage. Key-based lookups are performed on the native storage, with the
@@ -119,17 +121,18 @@ import SwiftShims
 // inherits an NSDictionary implementation from RawStorage, this implementation 
 // isn't useful and is never used. 
 //
-// RawStorage exists to allow a type-punned empty singleton Storage to be created.
-// Any time an empty Dictionary is created, this Storage is used. If this type
-// didn't exist, then NativeBuffer would have to store a Storage that declared
-// its actual type parameters. Similarly, the empty singleton would have to
-// declare its actual type parameters. If the singleton was, for instance, a
-// `NativeStorage<(), ()>`, then it would be a violation of Swift's strict 
-// aliasing rules to pass it where a `NativeStorage<Int, Int>` was expected.
+// RawStorage exists to allow a type-punned empty singleton Storage to be 
+// created. Any time an empty Dictionary is created, this Storage is used. If 
+// this type didn't exist, then NativeBuffer would have to store a Storage that 
+// declared its actual type parameters. Similarly, the empty singleton would 
+// have to declare its actual type parameters. If the singleton was, for 
+// instance, a `HashableStorage<(), ()>`, then it would be a violation of 
+// Swift's strict  aliasing rules to pass it where a `HashableStorage<Int, Int>`
+// was expected.
 //
 // It's therefore necessary for several types to store a RawStorage, rather than
-// a TypedStorage, to allow for the possibility of the empty singleton. RawStorage
-// also provides an implementation of an always-empty NSDictionary.
+// a TypedStorage, to allow for the possibility of the empty singleton. 
+// RawStorage also provides an implementation of an always-empty NSDictionary.
 //
 //
 // Index Invalidation
@@ -138,7 +141,7 @@ import SwiftShims
 // FIXME: decide if this guarantee is worth making, as it restricts
 // collision resolution to first-come-first-serve. The most obvious alternative
 // would be robin hood hashing. The Rust code base is the best
-// resource on a *practical* implementation of robin hood hashing: 
+// resource on a *practical* implementation of robin hood hashing I know of: 
 // https://github.com/rust-lang/rust/blob/ac919fcd9d4a958baf99b2f2ed5c3d38a2ebf9d0/src/libstd/collections/hash/map.rs#L70-L178
 //
 // Indexing a container, `c[i]`, uses the integral offset stored in the index
@@ -2504,7 +2507,7 @@ internal struct _${Self}BufferHeader {
 /// keys, and values. The data layout starts with the bitmap, followed by the
 /// keys, followed by the values.
 //
-// See the top level docs for more details on this type
+// See the docs at the top of the file for more details on this type
 internal class _RawNative${Self}Storage:
   _SwiftNativeNS${Self}, _NS${Self}Core
 {
@@ -2549,11 +2552,12 @@ internal class _RawNative${Self}Storage:
 
 #if _runtime(_ObjC)
   //
-  // NSSelf implementation, assuming Self is the empty singleton
+  // NS${Self} implementation, assuming Self is the empty singleton
   //
 
-  /// Get the NSEnumator implementation for self. NativeSelfStorage
-  /// overloads this to give NativeSelfNSEnumerator proper type parameters.
+  /// Get the NSEnumator implementation for self. 
+  /// _HashableTypedNative${Self}Storage overloads this to give 
+  /// _NativeSelfNSEnumerator proper type parameters.
   func enumerator() -> _NSEnumerator {
     return _Native${Self}NSEnumerator<${AnyTypeParameters}>(
         _Native${Self}Buffer(_storage: self))
@@ -2574,7 +2578,7 @@ internal class _RawNative${Self}Storage:
     objects: UnsafeMutablePointer<AnyObject>?, count: Int
   ) -> Int {
     // Even though we never do anything in here, we need to update the
-    // state so that people know we actually ran.
+    // state so that callers know we actually ran.
     
     var theState = state.pointee
     if theState.state == 0 {
@@ -2633,7 +2637,7 @@ internal class _RawNative${Self}Storage:
 #endif
 }
 
-// See the top level docs for a description of this type
+// See the docs at the top of this file for a description of this type
 @_versioned
 internal class _TypedNative${Self}Storage<${TypeParameters}> :
   _RawNative${Self}Storage {
@@ -2696,7 +2700,7 @@ internal class _TypedNative${Self}Storage<${TypeParameters}> :
 }
 
 
-// See the top level docs for a description of this type
+// See the docs at the top of this file for a description of this type
 @_versioned
 final internal class _HashableTypedNative${Self}Storage<${TypeParametersDecl}> :
   _TypedNative${Self}Storage<${TypeParameters}> {
@@ -2710,10 +2714,11 @@ final internal class _HashableTypedNative${Self}Storage<${TypeParametersDecl}> :
 
   
 #if _runtime(_ObjC)
-  // NSSelf bridging:
+  // NS${Self} bridging:
 
-  /// All actual functionality comes from Buffer/Dictionary, which are
-  /// just newtype wrappers around a RawNativeSelfStorage.
+  // All actual functionality comes from buffer/full, which are
+  // just wrappers around a RawNative${Self}Storage.
+  
   var buffer: Buffer {
     return Buffer(_storage: self)
   }
@@ -2846,12 +2851,12 @@ final internal class _HashableTypedNative${Self}Storage<${TypeParametersDecl}> :
 }
 
 
-/// This type provides most of the actual functionality for Dictionary,
-/// while just being a wrapper around a RawNativeSelfStorage.
+/// A wrapper around _RawNative${Self}Storage that provides most of the 
+/// implementation of ${Self}.
 ///
 /// This type and most of its functionality doesn't require Hashable at all.
 /// The reason for this is to support storing AnyObject for bridging
-/// with SwiftDeferredNSSelf. What functionality actually relies on
+/// with _SwiftDeferredNS${Self}. What functionality actually relies on
 /// Hashable can be found in an extension.
 internal struct _Native${Self}Buffer<${TypeParameters}> {
 
@@ -2869,7 +2874,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
   internal typealias SequenceElementWithoutLabels = (Key, Value)
 %end
 
-  /// See this comments on RawNativeSelfStorage and its subclasses to
+  /// See this comments on _RawNative${Self}Storage and its subclasses to
   /// understand why we store an untyped storage here.
   internal var _storage: RawStorage
 
@@ -2891,7 +2896,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
   }
 
   /// Given a capacity and uninitialized RawStorage, completes the 
-  /// initialization and produces a properly formed Buffer.  
+  /// initialization and returns a Buffer.  
   internal static func create(capacity: Int, storage: RawStorage) -> Buffer {
     // We can initialize by assignment because _HashedContainerBufferHeader
     // is a trivial type, i.e. contains no references.
@@ -2950,8 +2955,10 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
     return _storage._initializedHashtableEntriesBitMapBuffer
   }
 
-  // just a convenience for _keys and _values
+  // This is just a convenience for computing the offset of the keys array to
+  // avoid _keys and _values duplicating logic.
   internal var _keysRawAddr: Builtin.RawPointer {
+    // Gets the offset for the bitmap, then derives the key offset from that.
     let bitmapAddr = Builtin.projectTailElems(_storage, UInt.self)
     let numWordsForBitmap = _UnsafeBitMap.sizeInWords(forSizeInBits: capacity)
     return Builtin.getTailAddr_Word(bitmapAddr,
@@ -2972,12 +2979,12 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
   }
 %end
 
-  /// Wrap a fully initialized RawStorage
+  /// Constructs a buffer adopting the given storage.
   init(_storage: RawStorage) {
     self._storage = _storage
   }
 
-  /// Construct an instance from the empty singleton
+  /// Constructs an instance from the empty singleton.
   init() {
     self._storage = RawStorage.empty
   }
@@ -2999,14 +3006,16 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
   }
 
 #if _runtime(_ObjC)
-  /// Gets the key at the given Index, and then bridges it.
+  /// Returns the key at the given Index, bridged.
+  ///
   /// Intended for use with verbatim bridgeable keys.
   internal func bridgedKey(at index: Index) -> AnyObject {
     let k = key(at: index.offset)
     return _bridgeAnythingToObjectiveC(k)
   }
 
-  /// Gets the key at the given Index, and then bridges it.
+  /// Returns the value at the given Index, bridged.
+  ///
   /// Intended for use with verbatim bridgeable keys.
   internal func bridgedValue(at index: Index) -> AnyObject {
     let v = value(at: index.offset)
@@ -3421,8 +3430,8 @@ extension _Native${Self}Buffer
 }
 
 #if _runtime(_ObjC)
-/// An NSEnumerator that works with any NativeSelfBuffer of
-/// verbatim bridgeable elements. Used by the various NSSelf impls.
+/// An NSEnumerator that works with any Native${Self}Buffer of
+/// verbatim bridgeable elements. Used by the various NS${Self} impls.
 final internal class _Native${Self}NSEnumerator<${TypeParameters}>
   : _SwiftNativeNSEnumerator, _NSEnumerator {
 
@@ -3492,9 +3501,9 @@ final internal class _Native${Self}NSEnumerator<${TypeParameters}>
 
 #if _runtime(_ObjC)
 /// This class exists for Objective-C bridging. It holds a reference to a
-/// NativeSelfBuffer, and can be upcast to NSSelf when bridging is necessary.
+/// Native${Self}Buffer, and can be upcast to NSSelf when bridging is necessary.
 /// This is the fallback implementation for situations where toll-free bridging
-/// isn't possible. On first access, a NativeSelfBuffer of AnyObject will be
+/// isn't possible. On first access, a Native${Self}Buffer of AnyObject will be
 /// constructed containing all the bridged elements.
 final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
   : _SwiftNativeNS${Self}, _NS${Self}Core {
@@ -3519,10 +3528,10 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
     super.init()
   }
 
-  /// This stored property should be stored at offset zero.  We perform atomic
-  /// operations on it.
-  ///
-  /// Do not access this property directly.
+  // This stored property should be stored at offset zero.  We perform atomic
+  // operations on it.
+  //
+  // Do not access this property directly.
   internal var _heapStorageBridged_DoNotUse: AnyObject?
 
   /// The unbridged elements.
@@ -5132,13 +5141,13 @@ extension ${Self} {
     }
   }
 
-  /// Gets the native Dictionary hidden inside this NSDictionary
-  /// or returns nil.
+  /// Returns the native Dictionary hidden inside this NSDictionary;
+  /// returns nil otherwise.
   public static func _bridgeFromObjectiveCAdoptingNativeStorageOf(
     _ s: AnyObject
   ) -> ${Self}<${TypeParameters}>? {
 
-    // Try all three NSSelf impls that we currently provide.
+    // Try all three NS${Self} impls that we currently provide.
 
     if let deferredBuffer = s as? _SwiftDeferredNS${Self}<${TypeParameters}> {
       return ${Self}(_nativeBuffer: deferredBuffer.nativeBuffer)

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -2487,9 +2487,6 @@ internal class _RawNative${Self}Storage:
   internal final var values: UnsafeMutableRawPointer
 % end
 
-  internal final let maxLoadFactorInverse: Double =
-    _hashContainerDefaultMaxLoadFactorInverse
-
   // This API is unsafe and needs a `_fixLifetime` in the caller.
   internal final
   var _initializedHashtableEntriesBitMapBuffer: UnsafeMutablePointer<UInt> {
@@ -2912,10 +2909,6 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
     get {
       return _assumeNonNegative(_storage.count)
     }
-  }
-
-  internal var _maxLoadFactorInverse: Double {
-    return _storage.maxLoadFactorInverse
   }
 
   internal
@@ -4235,7 +4228,7 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
       ? asNative.capacity
       : NativeBuffer.minimumCapacity(
           minimumCount: asNative.count + 1,
-          maxLoadFactorInverse: asNative._maxLoadFactorInverse)
+          maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
 
     let (_, capacityChanged) = ensureUniqueNativeBuffer(minCapacity)
     if capacityChanged {
@@ -4300,7 +4293,7 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
 
     let minCapacity = NativeBuffer.minimumCapacity(
       minimumCount: asNative.count + 1,
-      maxLoadFactorInverse: asNative._maxLoadFactorInverse)
+      maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
 
     let (_, capacityChanged) = ensureUniqueNativeBuffer(minCapacity)
 

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -46,14 +46,11 @@ import SwiftShims
 //      |
 //      V  _RawNativeDictionaryStorage (a class)  
 //   +-----------------------------------------------------------+
-//   | +-------------------------------------------------------+ |
-//   | |_DictionaryBufferHeader<K,V> (a struct)               | |
-//   | | capacity                                              | |
-//   | | count                                                 | |
-//   | | ptrToBits                                             | |
-//   | | ptrToKeys                                             | |
-//   | | ptrToValues                                           | |
-//   | +-------------------------------------------------------+ |
+//   | capacity                                                  |
+//   | count                                                     |
+//   | ptrToBits                                                 |
+//   | ptrToKeys                                                 |
+//   | ptrToValues                                               |
 //   | [inline array of bits indicating whether bucket is set ]  |
 //   | [inline array of keys                                  ]  |
 //   | [inline array of values                                ]  |
@@ -2470,26 +2467,6 @@ collections = [
 
 % for (Self, a_self, TypeParametersDecl, TypeParameters, AnyTypeParameters, Sequence, AnySequenceType) in collections:
 
-/// Header part of the RawNativeSelfStorage.
-internal struct _${Self}BufferHeader {
-
-  internal init(capacity: Int) {
-    self.capacity = capacity
-  }
-
-  internal let capacity: Int
-  internal var count: Int = 0
-  internal let maxLoadFactorInverse: Double =
-    _hashContainerDefaultMaxLoadFactorInverse
-
-  // Placeholder values until the struct can be initialized.
-  internal var initializedEntries: _UnsafeBitMap! = nil
-  internal var keys: UnsafeMutableRawPointer! = nil
-% if Self == 'Dictionary':
-  internal var values: UnsafeMutableRawPointer! = nil
-% end
-}
-
 /// An instance of this class has all `${Self}` data tail-allocated.
 /// Enough bytes are allocated to hold the bitmap for marking valid entries,
 /// keys, and values. The data layout starts with the bitmap, followed by the
@@ -2499,13 +2476,22 @@ internal struct _${Self}BufferHeader {
 internal class _RawNative${Self}Storage:
   _SwiftNativeNS${Self}, _NS${Self}Core
 {
-  internal typealias BufferHeader = _${Self}BufferHeader
   internal typealias RawStorage = _RawNative${Self}Storage
+  
+  internal final var capacity: Int
+  internal final var count: Int
 
-  internal var _body: BufferHeader
+  internal final var initializedEntries: _UnsafeBitMap
+  internal final var keys: UnsafeMutableRawPointer
+% if Self == 'Dictionary':
+  internal final var values: UnsafeMutableRawPointer
+% end
+
+  internal final let maxLoadFactorInverse: Double =
+    _hashContainerDefaultMaxLoadFactorInverse
 
   // This API is unsafe and needs a `_fixLifetime` in the caller.
-  internal
+  internal final
   var _initializedHashtableEntriesBitMapBuffer: UnsafeMutablePointer<UInt> {
     return UnsafeMutablePointer(Builtin.projectTailElems(self, UInt.self))
   }
@@ -2521,16 +2507,21 @@ internal class _RawNative${Self}Storage:
     // We set the capacity to 1 so that there's an empty hole to search.
     // Any insertion will lead to a real storage being allocated, because 
     // Dictionary guarantees there's always another empty hole after insertion.
-    storage._body = BufferHeader(capacity: 1)
+    storage.capacity = 1
+    storage.count = 0
+
+    // Initialize pointers to garbage; they should never be loaded
+    storage.keys  = UnsafeMutableRawPointer(bitPattern: 1)!
+  % if Self == 'Dictionary':
+    storage.values = UnsafeMutableRawPointer(bitPattern: 1)!
+  % end
 
     let initializedEntries = _UnsafeBitMap(
         storage: storage._initializedHashtableEntriesBitMapBuffer,
         bitCount: 1)
     initializedEntries.initializeToZero()
 
-    // We don't bother to initalize the pointers in the header because
-    // they should never be accessed on the empty singleton.
-    storage._body.initializedEntries = initializedEntries
+    storage.initializedEntries = initializedEntries
     return storage
   }()
 
@@ -2556,10 +2547,6 @@ internal class _RawNative${Self}Storage:
   @objc(copyWithZone:)
   func copy(with zone: _SwiftNSZone?) -> AnyObject {
     return self
-  }
-
-  var count: Int { 
-    return 0 
   }
 
   @objc(countByEnumeratingWithState:objects:count:)
@@ -2638,12 +2625,9 @@ internal class _TypedNative${Self}Storage<${TypeParameters}> :
 %end
 
   deinit {
-    let capacity = _body.capacity
-    let initializedEntries = _UnsafeBitMap(
-        storage: _initializedHashtableEntriesBitMapBuffer, bitCount: capacity)
-    let keys = _body.keys.assumingMemoryBound(to: Key.self)
+    let keys = self.keys.assumingMemoryBound(to: Key.self)
 %if Self == 'Dictionary':
-    let values = _body.values.assumingMemoryBound(to: Value.self)
+    let values = self.values.assumingMemoryBound(to: Value.self)
 %end
 
     if !_isPOD(Key.self) {
@@ -2719,10 +2703,6 @@ final internal class _HashableTypedNative${Self}Storage<${TypeParametersDecl}> :
 
   var full: FullContainer {
     return FullContainer(_nativeBuffer: buffer)
-  }
-
-  override var count: Int { 
-    return full.count 
   }
 
   override func enumerator() -> _NSEnumerator {
@@ -2854,7 +2834,6 @@ final internal class _HashableTypedNative${Self}Storage<${TypeParametersDecl}> :
 /// Hashable can be found in an extension.
 internal struct _Native${Self}Buffer<${TypeParameters}> {
 
-  internal typealias BufferHeader = _${Self}BufferHeader
   internal typealias RawStorage = _RawNative${Self}Storage
   internal typealias TypedStorage = _TypedNative${Self}Storage<${TypeParameters}>
   internal typealias Buffer = _Native${Self}Buffer<${TypeParameters}>
@@ -2892,9 +2871,8 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
   /// Given a capacity and uninitialized RawStorage, completes the 
   /// initialization and returns a Buffer.  
   internal init(capacity: Int, storage: RawStorage) {
-    // We can initialize by assignment because _HashedContainerBufferHeader
-    // is a trivial type, i.e. contains no references.
-    storage._body = BufferHeader(capacity: capacity)
+    storage.capacity = capacity
+    storage.count = 0
     
     self.init(_storage: storage)
 
@@ -2910,44 +2888,34 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
            numWordsForBitmap._builtinWordValue, UInt.self, Key.self)
 
     // Initialize header
-    _body.initializedEntries = initializedEntries
-    _body.keys = UnsafeMutableRawPointer(keysAddr)
+    _storage.initializedEntries = initializedEntries
+    _storage.keys = UnsafeMutableRawPointer(keysAddr)
 %if Self == 'Dictionary':
     let valuesAddr = Builtin.getTailAddr_Word(keysAddr,
         capacity._builtinWordValue, Key.self, Value.self)
-    _body.values = UnsafeMutableRawPointer(valuesAddr)
+    _storage.values = UnsafeMutableRawPointer(valuesAddr)
 %end
-  }
-
-  /// A convenience forwarding the _storage's body
-  internal var _body: BufferHeader { 
-    set {
-      _storage._body = newValue
-    }
-    get {
-      return _storage._body
-    }
   }
 
   // Forwarding the individual fields of the storage in various forms
 
   @_versioned
   internal var capacity: Int {
-    return _assumeNonNegative(_body.capacity)
+    return _assumeNonNegative(_storage.capacity)
   }
 
   @_versioned
   internal var count: Int {
     set {
-      _body.count = newValue
+      _storage.count = newValue
     }
     get {
-      return _assumeNonNegative(_body.count)
+      return _assumeNonNegative(_storage.count)
     }
   }
 
   internal var _maxLoadFactorInverse: Double {
-    return _body.maxLoadFactorInverse
+    return _storage.maxLoadFactorInverse
   }
 
   internal
@@ -2957,13 +2925,13 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
 
   // This API is unsafe and needs a `_fixLifetime` in the caller.
   internal var keys: UnsafeMutablePointer<Key> {
-    return _body.keys.assumingMemoryBound(to: Key.self)
+    return _storage.keys.assumingMemoryBound(to: Key.self)
   }
 
 %if Self == 'Dictionary':
   // This API is unsafe and needs a `_fixLifetime` in the caller.
   internal var values: UnsafeMutablePointer<Value> {
-    return _body.values.assumingMemoryBound(to: Value.self)
+    return _storage.values.assumingMemoryBound(to: Value.self)
   }
 %end
 
@@ -3016,7 +2984,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
     _sanityCheck(i >= 0 && i < capacity)
     defer { _fixLifetime(self) }
 
-    return _body.initializedEntries[i]
+    return _storage.initializedEntries[i]
   }
 
   @_transparent
@@ -3028,7 +2996,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
 %if Self == 'Dictionary':
     (values + i).deinitialize()
 %end
-    _body.initializedEntries[i] = false
+    _storage.initializedEntries[i] = false
   }
 
 %if Self == 'Set':
@@ -3038,7 +3006,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
     defer { _fixLifetime(self) }
 
     (keys + i).initialize(to: k)
-    _body.initializedEntries[i] = true
+    _storage.initializedEntries[i] = true
   }
 
   @_transparent
@@ -3048,8 +3016,8 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
     defer { _fixLifetime(self) }
 
     (keys + toEntryAt).initialize(to: (from.keys + at).move())
-    from._body.initializedEntries[at] = false
-    _body.initializedEntries[toEntryAt] = true
+    from._storage.initializedEntries[at] = false
+    _storage.initializedEntries[toEntryAt] = true
   }
 
   /// Alias for key(at:) in Sets for better code reuse
@@ -3075,7 +3043,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
 
     (keys + i).initialize(to: k)
     (values + i).initialize(to: v)
-    _body.initializedEntries[i] = true
+    _storage.initializedEntries[i] = true
   }
 
   @_transparent
@@ -3085,8 +3053,8 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
 
     (keys + toEntryAt).initialize(to: (from.keys + at).move())
     (values + toEntryAt).initialize(to: (from.values + at).move())
-    from._body.initializedEntries[at] = false
-    _body.initializedEntries[toEntryAt] = true
+    from._storage.initializedEntries[at] = false
+    _storage.initializedEntries[toEntryAt] = true
   }
 
   @_versioned

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -2676,6 +2676,7 @@ internal class _TypedNative${Self}Storage<${TypeParameters}> :
     _sanityCheckFailure("Only create this by calling Buffer.createUnhashable")
   }
 
+#if _runtime(_ObjC)
 %if Self == 'Set':
   @objc
   internal required init(objects: UnsafePointer<AnyObject?>, count: Int) {
@@ -2691,6 +2692,7 @@ internal class _TypedNative${Self}Storage<${TypeParameters}> :
     _sanityCheckFailure("don't call this designated initializer")
   }
 %end
+#endif
 }
 
 
@@ -2996,6 +2998,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
     return res
   }
 
+#if _runtime(_ObjC)
   /// Gets the key at the given Index, and then bridges it.
   /// Intended for use with verbatim bridgeable keys.
   internal func bridgedKey(at index: Index) -> AnyObject {
@@ -3009,6 +3012,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
     let v = value(at: index.offset)
     return _bridgeAnythingToObjectiveC(v)
   }
+#endif
 
   @_versioned
   internal func isInitializedEntry(at i: Int) -> Bool {

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -3789,6 +3789,9 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}> { }
 #endif
 
 #if _runtime(_ObjC)
+
+// FIXME: this should really be a struct but can't because of the lazy allKeys.
+// (but it might be removed with eager bridging, so this is "fine" for now)
 @_versioned
 @_fixed_layout
 internal final class _Cocoa${Self}Buffer : _HashBuffer {

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -36,12 +36,15 @@ import SwiftShims
 // Currently native storage uses a data structure like this::
 //
 //   Dictionary<K,V> (a struct)
-//   +----------------------------------------------+
-//   | [ _VariantDictionaryStorage<K,V> (an enum) ] |
-//   +---|------------------------------------------+
-//      /
-//     |
-//     V  _NativeDictionaryStorage<K,V> (a class)
+//   +------------------------------------------------+
+//   |  _VariantDictionaryStorage<K,V> (an enum)      |
+//   | +--------------------------------------------+ |
+//   | | [_NativeDictionaryStorage<K,V> (a struct)] | |
+//   | +---|----------------------------------------+ |
+//   +----/-------------------------------------------+
+//       /
+//      |
+//      V  _RawNativeDictionaryBuffer (a class)  
 //   +-----------------------------------------------------------+
 //   | +-------------------------------------------------------+ |
 //   | |_DictionaryStorageHeader<K,V> (a struct)               | |
@@ -84,10 +87,55 @@ import SwiftShims
 //   +---------------------------------------+
 //
 //
+// The Native Kinds Buffer
+// -----------------------
+//
+// There are three different classes that can provide native backing storage: 
+// * `_RawNativeDictionaryBuffer`
+// * `_TypedNativeDictionaryBuffer<K, V>`      (inherits from Raw)
+// * `_NativeDictionaryBuffer<K: Hashable, V>` (inherits from Typed)
+//
+// In a less optimized implementation, the parent classes of NativeBuffer could
+// be eliminated, as they exist only to provide special-case behaviours. 
+// NativeBuffer has everything a full implementation of a Dictionary
+// requires, and is subsequently able to provide a full NSDictionary 
+// implementation. Note that NativeBuffer must have the `K: Hashable` constraint
+// because the NSDictionary implementation can't be provided in a constrained 
+// extension.
+//
+// In normal usage, you can expect the backing storage of a Dictionary to be a 
+// NativeBuffer.
+//
+// TypedBuffer is distinguished from NativeBuffer to allow us to create a
+// `NativeStorage<AnyObject, AnyObject>`. Without the Hashable requirement,
+// such a Storage is restricted to operations which can be performed
+// with only the structure of the Buffer: indexing and iteration. This is used
+// in _SwiftDeferredNSDictionary to construct twin "native" and "bridged"
+// storages. Key-based lookups are performed on the native storage, with the
+// resultant index then used on the bridged storage.
+//
+// The only thing that TypedBuffer adds over RawBuffer is an implementation of
+// deinit, to clean up the AnyObjects it stores. Although it nominally 
+// inherits an NSDictionary implementation from RawBuffer, this implementation 
+// isn't useful and is never used. 
+//
+// RawBuffer exists to allow a type-punned empty singleton Buffer to be created.
+// Any time an empty Dictionary is created, this Buffer is used. If this type
+// didn't exist, then NativeStorage would have to store a Buffer that declared
+// its actual type parameters. Similarly, the empty singleton would have to
+// declare its actual type parameters. If the singleton was, for instance, a
+// `NativeBuffer<(), ()>`, then it would be a violation of Swift's strict 
+// aliasing rules to pass it where a `NativeBuffer<Int, Int>` was expected.
+//
+// It's therefore necessary for several types to store a RawBuffer, rather than
+// a TypedBuffer, to allow for the possibility of the empty singleton. RawBuffer
+// also provides an implementation of an always-empty NSDictionary.
+//
+//
 // Index Invalidation
 // ------------------
 //
-// FIXME? not sure if this guarantee is worth making, as it restricts
+// FIXME: decide if this guarantee is worth making, as it restricts
 // collision resolution to first-come-first-serve.
 //
 // Indexing a container, `c[i]`, uses the integral offset stored in the index
@@ -107,11 +155,14 @@ import SwiftShims
 // dictionary buffer are bounds-checked, this scheme never compromises memory
 // safety.
 //
+//
 // Bridging
 // ========
 //
 // Bridging `NSDictionary` to `Dictionary`
 // ---------------------------------------
+//
+// FIXME(eager-bridging): rewrite this based on modern constraints.
 //
 // `NSDictionary` bridges to `Dictionary<NSObject, AnyObject>` in `O(1)`,
 // without memory allocation.
@@ -119,19 +170,27 @@ import SwiftShims
 // Bridging `Dictionary` to `NSDictionary`
 // ---------------------------------------
 //
-// `Dictionary<K, V>` bridges to `NSDictionary` iff both `K` and `V` are
-// bridged.  Otherwise, a runtime error is raised. Because 
-// _NativeDictionaryStorage inherits from ManagedBuffer, it can't also
-// inherit from NSDictionary (_NSDictionaryCore). To have a value that does,
-// we wrap the _NativeDictionaryStorage in another class, 
-// _NativeDictionaryBridgingStorage, which incurs an allocation, but is O(1).
+// `Dictionary<K, V>` bridges to `NSDictionary` in O(1)
+// but may incur an allocation depending on the following conditions:
 //
-// * if both `K` and `V` are bridged verbatim, then access to elements 
-//   does not cause memory allocation.
+// * If the Dictionary is freshly allocated without any elements, then it
+//   contains the empty singleton Buffer which is returned as a toll-free
+//   implementation of `NSDictionary`.
 //
-// * otherwise, `K` and/or `V` are unconditionally or conditionally bridged.
-//   Complete bridging is performed when the first access to elements happens. 
-//   The bridged `NSDictionary` has a cache of pointers it returned, so that:
+// * If both `K` and `V` are bridged verbatim, then `Dictionary<K, V>` is 
+//   still toll-free bridged to `NSDictionary` by returning its Buffer.
+//
+// * If the Dictionary is actually a lazily bridged NSDictionary, then that
+//   NSDictionary is returned. 
+//
+// * Otherwise, bridging the `Dictionary` is done by wrapping its storage in a 
+//   `_SwiftDeferredNSDictionary<K, V>`. This incurs an O(1)-sized allocation.
+//
+//   Complete bridging of the native Buffer's elements to another Buffer 
+//   is performed on first access. This is O(n) work, but is hopefully amortized
+//   by future accesses.
+//
+//   This design ensures that:
 //   - Every time keys or values are accessed on the bridged `NSDictionary`,
 //     new objects are not created.
 //   - Accessing the same element (key or value) multiple times will return
@@ -454,10 +513,6 @@ public struct Set<Element : Hashable> :
     return _variantStorage.endIndex
   }
 
-  /// Returns the index after the given one. 
-  ///
-  /// If this is the last valid index, returns endIndex.
-  /// Aborts on endIndex.
   public func index(after i: Index) -> Index {
     return _variantStorage.index(after: i)
   }
@@ -1665,10 +1720,6 @@ public struct Dictionary<Key : Hashable, Value> :
     return _variantStorage.endIndex
   }
 
-  /// Returns the index after the given one. 
-  ///
-  /// If this is the last valid index, returns endIndex.
-  /// Aborts on endIndex.
   public func index(after i: Index) -> Index {
     return _variantStorage.index(after: i)
   }
@@ -2251,16 +2302,6 @@ public func _dictionaryDownCast<BaseKey, BaseValue, DerivedKey, DerivedValue>(
 
     switch source._variantStorage {
     case .native(let storage):
-      // TODO: rewrite the docs
-      // FIXME(performance): this introduces an indirection through Objective-C
-      // runtime, even though we access native storage.  But we cannot
-      // unsafeBitCast the owner object, because that would change the generic
-      // arguments.
-      //
-      // One way to solve this is to add a third, read-only, representation to
-      // variant storage: like _NativeDictionaryStorageOwner, but it would
-      // perform casts when accessing elements.
-      //
       // Note: it is safe to treat the storage as immutable here because
       // Dictionary will not mutate storage with reference count greater than 1.
       let nativeStorage = storage.bridgingStorage()
@@ -2435,7 +2476,7 @@ collections = [
 
 % for (Self, a_self, TypeParametersDecl, TypeParameters, AnyTypeParameters, Sequence, AnySequenceType) in collections:
 
-/// Header part of the native storage.
+/// Header part of the RawNativeSelfBuffer.
 internal struct _${Self}StorageHeader {
 
   internal init(capacity: Int) {
@@ -2458,9 +2499,9 @@ internal struct _${Self}StorageHeader {
 /// An instance of this class has all `${Self}` data tail-allocated.
 /// Enough bytes are allocated to hold the bitmap for marking valid entries,
 /// keys, and values. The data layout starts with the bitmap, followed by the
-/// keys, followed by the values. This is untyped to allow empty
-/// Buffers to be type-punned. Subclasses add type info to provide deinit and 
-/// more interesting NSSelf impls.
+/// keys, followed by the values.
+//
+// See the top level docs for more details on this type
 internal class _RawNative${Self}Buffer:
   _SwiftNativeNS${Self}, _NS${Self}Core
 {
@@ -2475,13 +2516,17 @@ internal class _RawNative${Self}Buffer:
     return UnsafeMutablePointer(Builtin.projectTailElems(self, UInt.self))
   }
 
+  /// The empty singleton that is used for every single Dictionary that is
+  /// created without any elements. The contents of the buffer should never
+  /// be mutated.
+  // FIXME: this should be set up in rodata like the Array singleton
   internal static let empty: RawBuffer = {
     let buffer = Builtin.allocWithTailElems_1(RawBuffer.self,
         1._builtinWordValue, UInt.self)
     
     // We set the capacity to 1 so that there's an empty hole to search.
-    // Any insertion will reallocate because there always needs to be
-    // an empty hole.
+    // Any insertion will lead to a real buffer being allocated, because 
+    // Dictionary guarantees there's always another empty hole after insertion.
     buffer._body = StorageHeader(capacity: 1)
 
     let initializedEntries = _UnsafeBitMap(
@@ -2489,16 +2534,23 @@ internal class _RawNative${Self}Buffer:
         bitCount: 1)
     initializedEntries.initializeToZero()
 
-    // Initialize header
+    // We don't bother to initalize the pointers in the header because
+    // they should never be accessed on the empty singleton.
     buffer._body.initializedEntries = initializedEntries
     return buffer
   }()
 
   internal init(_doNotCallMe: ()) {
-    _sanityCheckFailure("Only initialize these by calling create")
+    _sanityCheckFailure("Only create this by using the `empty` singleton")
   }
 
 #if _runtime(_ObjC)
+  //
+  // NSSelf implementation, assuming Self is the empty singleton
+  //
+
+  /// Get the NSEnumator implementation for self. NativeSelfBuffer
+  /// overloads this to give NativeSelfNSEnumerator proper type parameters.
   func enumerator() -> _NSEnumerator {
     return _Native${Self}NSEnumerator<${AnyTypeParameters}>(
         _Native${Self}Storage(_buffer: self))
@@ -2518,6 +2570,9 @@ internal class _RawNative${Self}Buffer:
     with state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
     objects: UnsafeMutablePointer<AnyObject>?, count: Int
   ) -> Int {
+    // Even though we never do anything in here, we need to update the
+    // state so that people know we actually ran.
+    
     var theState = state.pointee
     if theState.state == 0 {
       theState.state = 1 // Arbitrary non-zero value.
@@ -2566,8 +2621,6 @@ internal class _RawNative${Self}Buffer:
     return enumerator()
   }
 
-  // We also override the following methods for efficiency.
-
   func getObjects(_ objects: UnsafeMutablePointer<AnyObject>?,
     andKeys keys: UnsafeMutablePointer<AnyObject>?) {
     // Do nothing, we're empty
@@ -2577,9 +2630,7 @@ internal class _RawNative${Self}Buffer:
 #endif
 }
 
-/// Adds types to a RawNativeBuffer, so that deinit can be implemented.
-/// Doesn't requires Hashable so that it can be instantiated with AnyHashable
-/// in _SwiftDeferredNSSelf for the bridged buffer.
+// See the top level docs for a description of this type
 @_versioned
 internal class _TypedNative${Self}Buffer<${TypeParameters}> :
   _RawNative${Self}Buffer {
@@ -2619,7 +2670,7 @@ internal class _TypedNative${Self}Buffer<${TypeParameters}> :
   }
 
   override internal init(_doNotCallMe: ()) {
-    _sanityCheckFailure("Only initialize these by calling create")
+    _sanityCheckFailure("Only create this by calling Storage.createUnhashable")
   }
 
 %if Self == 'Set':
@@ -2639,7 +2690,8 @@ internal class _TypedNative${Self}Buffer<${TypeParameters}> :
 %end
 }
 
-/// Adds the `Key: Hashable` constraint to _NativeTyped
+
+// See the top level docs for a description of this type
 @_versioned
 final internal class _Native${Self}Buffer<${TypeParametersDecl}> :
   _TypedNative${Self}Buffer<${TypeParameters}> {
@@ -2648,12 +2700,15 @@ final internal class _Native${Self}Buffer<${TypeParametersDecl}> :
   internal typealias Storage = _Native${Self}Storage<${TypeParameters}>
 
   override internal init(_doNotCallMe: ()) {
-    _sanityCheckFailure("Only initialize these by calling create")
+    _sanityCheckFailure("Only create this by calling Storage.create")
   }
 
-  // NS bridging support
-
+  
 #if _runtime(_ObjC)
+  // NSSelf bridging:
+
+  /// All actual functionality comes from Storage/Dictionary, which are
+  /// just newtype wrappers around a RawNativeSelfBuffer.
   var storage: Storage {
     return Storage(_buffer: self)
   }
@@ -2665,7 +2720,6 @@ final internal class _Native${Self}Buffer<${TypeParametersDecl}> :
   override var count: Int { 
     return full.count 
   }
-
 
   override func enumerator() -> _NSEnumerator {
     return _Native${Self}NSEnumerator<${TypeParameters}>(
@@ -2786,6 +2840,14 @@ final internal class _Native${Self}Buffer<${TypeParametersDecl}> :
 #endif
 }
 
+
+/// This type provides most of the actual functionality for Dictionary,
+/// while just being a wrapper around a RawNativeSelfBuffer.
+///
+/// This type and most of its functionality doesn't require Hashable at all.
+/// The reason for this is to support storing AnyObject for bridging
+/// with SwiftDeferredNSSelf. What functionality actually relies on
+/// Hashable can be found in an extension.
 internal struct _Native${Self}Storage<${TypeParameters}> {
 
   internal typealias StorageHeader = _${Self}StorageHeader
@@ -2802,7 +2864,8 @@ internal struct _Native${Self}Storage<${TypeParameters}> {
   internal typealias SequenceElementWithoutLabels = (Key, Value)
 %end
 
-  /// We store a RawBuffer so that this can be an empty singleton
+  /// See this comments on RawNativeSelfBuffer and its subclasses to
+  /// understand why we store an untyped buffer here.
   internal var _buffer: RawBuffer
 
   /// Creates a Storage with a buffer that is typed, but doesn't understand
@@ -2823,7 +2886,7 @@ internal struct _Native${Self}Storage<${TypeParameters}> {
   }
 
   /// Given a capacity and uninitialized RawBuffer, completes the 
-  /// initialization and produces a full Storage.  
+  /// initialization and produces a properly formed Storage.  
   internal static func create(capacity: Int, buffer: RawBuffer) -> Storage {
     // We can initialize by assignment because _HashedContainerStorageHeader
     // is a trivial type, i.e. contains no references.
@@ -2846,7 +2909,7 @@ internal struct _Native${Self}Storage<${TypeParameters}> {
     return storage
   }
 
-  /// A convenience forwardhing the _buffer's body
+  /// A convenience forwarding the _buffer's body
   internal var _body: StorageHeader { 
     set {
       _buffer._body = newValue
@@ -2856,9 +2919,8 @@ internal struct _Native${Self}Storage<${TypeParameters}> {
     }
   }
 
-  /// The number of _logical elements_ the ${a_self} can store. Not to be
-  /// confused with `capacity`, the total number of raw `UInt8` bytes stored
-  /// by the `ManagedBuffer`.
+  // Forwarding the individual fields of the buffer in various forms
+
   @_versioned
   internal var _capacity: Int {
     return _assumeNonNegative(_body.capacity)
@@ -2883,6 +2945,7 @@ internal struct _Native${Self}Storage<${TypeParameters}> {
     return _buffer._initializedHashtableEntriesBitMapStorage
   }
 
+  // just a convenience for _keys and _values
   internal var _keysRawAddr: Builtin.RawPointer {
     let bitmapAddr = Builtin.projectTailElems(_buffer, UInt.self)
     let numWordsForBitmap = _UnsafeBitMap.sizeInWords(forSizeInBits: _capacity)
@@ -2904,13 +2967,20 @@ internal struct _Native${Self}Storage<${TypeParameters}> {
   }
 %end
 
+  /// Wrap a fully initialized RawBuffer
   init(_buffer: RawBuffer) {
     self._buffer = _buffer
   }
 
+  /// Construct an instance from the empty singleton
   init() {
     self._buffer = RawBuffer.empty
   }
+
+
+
+  // Most of the implementation of the _HashStorage protocol,
+  // but only the parts that don't actually rely on hashing.
 
   @_versioned
   @inline(__always)
@@ -2923,11 +2993,15 @@ internal struct _Native${Self}Storage<${TypeParameters}> {
     return res
   }
 
+  /// Gets the key at the given Index, and then bridges it.
+  /// Intended for use with verbatim bridgeable keys.
   internal func bridgedKey(at index: Index) -> AnyObject {
     let k = key(at: index.offset)
     return _bridgeAnythingToObjectiveC(k)
   }
 
+  /// Gets the key at the given Index, and then bridges it.
+  /// Intended for use with verbatim bridgeable keys.
   internal func bridgedValue(at index: Index) -> AnyObject {
     let v = value(at: index.offset)
     return _bridgeAnythingToObjectiveC(v)
@@ -3075,8 +3149,6 @@ internal struct _Native${Self}Storage<${TypeParameters}> {
   }
 }
 
-// TODO: conditionally conform to _HashStorage for better compile-time safety.
-// TODO: conditionally conform to CustomStringConvertible.
 extension _Native${Self}Storage 
   where ${'Key' if Self == 'Dictionary' else 'Element'} : Hashable
 {
@@ -3341,6 +3413,8 @@ extension _Native${Self}Storage
 }
 
 #if _runtime(_ObjC)
+/// An NSEnumerator that works with any NativeSelfStorage of
+/// verbatim bridgeable elements. Used by the various NSSelf impls.
 final internal class _Native${Self}NSEnumerator<${TypeParameters}>
   : _SwiftNativeNSEnumerator, _NSEnumerator {
 
@@ -3410,8 +3484,10 @@ final internal class _Native${Self}NSEnumerator<${TypeParameters}>
 
 #if _runtime(_ObjC)
 /// This class exists for Objective-C bridging. It holds a reference to a
-/// `_Native${Self}Storage`, and can be upcast to `NS${Self}` when
-/// bridging is necessary.
+/// NativeSelfStorage, and can be upcast to NSSelf when bridging is necessary.
+/// This is the fallback implementation for situations where toll-free bridging
+/// isn't possible. On first access, a NativeSelfStorage of AnyObject will be
+/// constructed containing all the bridged elements.
 final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
   : _SwiftNativeNS${Self}, _NS${Self}Core {
 
@@ -3435,12 +3511,13 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
     super.init()
   }
 
-  // This stored property should be stored at offset zero.  We perform atomic
-  // operations on it.
-  //
-  // Do not access this property directly.
+  /// This stored property should be stored at offset zero.  We perform atomic
+  /// operations on it.
+  ///
+  /// Do not access this property directly.
   internal var _heapBufferBridged_DoNotUse: AnyObject?
 
+  /// The unbridged elements.
   internal var nativeStorage: NativeStorage
 
   @objc(copyWithZone:)
@@ -3621,10 +3698,6 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
 
 %end
 
-  //
-  // ${Self} -> NS${Self} bridging
-  //
-
   @objc
   internal var count: Int {
     return nativeStorage._count
@@ -3676,6 +3749,7 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
     let endIndex = nativeStorage.endIndex
     var stored = 0
 
+    // Only need to bridge once, so we can hoist it out of the loop.
     if (currIndex != endIndex) {
       bridgeEverything()
     }

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -20,7 +20,7 @@ import SwiftShims
 //
 // `Dictionary` uses two storage schemes: native storage and Cocoa storage.
 //
-// Native storage is a hash table with open addressing and linear probing.  The
+// Native storage is a hash table with open addressing and linear probing. The
 // bucket array forms a logical ring (e.g., a chain can wrap around the end of
 // buckets array to the beginning of it).
 //
@@ -29,7 +29,7 @@ import SwiftShims
 // There is always at least one invalid entry among the buckets. `Dictionary`
 // does not use tombstones.
 //
-// In addition to the native storage `Dictionary` can also wrap an
+// In addition to the native storage, `Dictionary` can also wrap an
 // `NSDictionary` in order to allow bridging `NSDictionary` to `Dictionary` in
 // `O(1)`.
 //
@@ -37,17 +37,17 @@ import SwiftShims
 //
 //   Dictionary<K,V> (a struct)
 //   +------------------------------------------------+
-//   |  _VariantDictionaryStorage<K,V> (an enum)      |
+//   |  _VariantDictionaryBuffer<K,V> (an enum)      |
 //   | +--------------------------------------------+ |
-//   | | [_NativeDictionaryStorage<K,V> (a struct)] | |
+//   | | [_NativeDictionaryBuffer<K,V> (a struct)] | |
 //   | +---|----------------------------------------+ |
 //   +----/-------------------------------------------+
 //       /
 //      |
-//      V  _RawNativeDictionaryBuffer (a class)  
+//      V  _RawNativeDictionaryStorage (a class)  
 //   +-----------------------------------------------------------+
 //   | +-------------------------------------------------------+ |
-//   | |_DictionaryStorageHeader<K,V> (a struct)               | |
+//   | |_DictionaryBufferHeader<K,V> (a struct)               | |
 //   | | capacity                                              | |
 //   | | count                                                 | |
 //   | | ptrToBits                                             | |
@@ -64,9 +64,9 @@ import SwiftShims
 //
 //   Dictionary<K,V> (a struct)
 //   +----------------------------------------------+
-//   | _VariantDictionaryStorage<K,V> (an enum)     |
+//   | _VariantDictionaryBuffer<K,V> (an enum)     |
 //   | +----------------------------------------+   |
-//   | | [ _CocoaDictionaryStorage (a struct) ] |   |
+//   | | [ _CocoaDictionaryBuffer (a struct) ] |   |
 //   | +---|------------------------------------+   |
 //   +-----|----------------------------------------+
 //         |
@@ -87,48 +87,48 @@ import SwiftShims
 //   +---------------------------------------+
 //
 //
-// The Native Kinds Buffer
-// -----------------------
+// The Native Kinds of Storage
+// ---------------------------
 //
-// There are three different classes that can provide native backing storage: 
-// * `_RawNativeDictionaryBuffer`
-// * `_TypedNativeDictionaryBuffer<K, V>`      (inherits from Raw)
-// * `_NativeDictionaryBuffer<K: Hashable, V>` (inherits from Typed)
+// There are three different classes that can provide a native backing storage: 
+// * `_RawNativeDictionaryStorage`
+// * `_TypedNativeDictionaryStorage<K, V>`      (inherits from Raw)
+// * `_NativeDictionaryStorage<K: Hashable, V>` (inherits from Typed)
 //
-// In a less optimized implementation, the parent classes of NativeBuffer could
+// In a less optimized implementation, the parent classes of NativeStorage could
 // be eliminated, as they exist only to provide special-case behaviours. 
-// NativeBuffer has everything a full implementation of a Dictionary
+// NativeStorage has everything a full implementation of a Dictionary
 // requires, and is subsequently able to provide a full NSDictionary 
-// implementation. Note that NativeBuffer must have the `K: Hashable` constraint
+// implementation. Note that NativeStorage must have the `K: Hashable` constraint
 // because the NSDictionary implementation can't be provided in a constrained 
 // extension.
 //
 // In normal usage, you can expect the backing storage of a Dictionary to be a 
-// NativeBuffer.
+// NativeStorage.
 //
-// TypedBuffer is distinguished from NativeBuffer to allow us to create a
-// `NativeStorage<AnyObject, AnyObject>`. Without the Hashable requirement,
-// such a Storage is restricted to operations which can be performed
-// with only the structure of the Buffer: indexing and iteration. This is used
+// TypedStorage is distinguished from NativeStorage to allow us to create a
+// `NativeBuffer<AnyObject, AnyObject>`. Without the Hashable requirement,
+// such a Buffer is restricted to operations which can be performed
+// with only the structure of the Storage: indexing and iteration. This is used
 // in _SwiftDeferredNSDictionary to construct twin "native" and "bridged"
-// storages. Key-based lookups are performed on the native storage, with the
+// storage. Key-based lookups are performed on the native storage, with the
 // resultant index then used on the bridged storage.
 //
-// The only thing that TypedBuffer adds over RawBuffer is an implementation of
+// The only thing that TypedStorage adds over RawStorage is an implementation of
 // deinit, to clean up the AnyObjects it stores. Although it nominally 
-// inherits an NSDictionary implementation from RawBuffer, this implementation 
+// inherits an NSDictionary implementation from RawStorage, this implementation 
 // isn't useful and is never used. 
 //
-// RawBuffer exists to allow a type-punned empty singleton Buffer to be created.
-// Any time an empty Dictionary is created, this Buffer is used. If this type
-// didn't exist, then NativeStorage would have to store a Buffer that declared
+// RawStorage exists to allow a type-punned empty singleton Storage to be created.
+// Any time an empty Dictionary is created, this Storage is used. If this type
+// didn't exist, then NativeBuffer would have to store a Storage that declared
 // its actual type parameters. Similarly, the empty singleton would have to
 // declare its actual type parameters. If the singleton was, for instance, a
-// `NativeBuffer<(), ()>`, then it would be a violation of Swift's strict 
-// aliasing rules to pass it where a `NativeBuffer<Int, Int>` was expected.
+// `NativeStorage<(), ()>`, then it would be a violation of Swift's strict 
+// aliasing rules to pass it where a `NativeStorage<Int, Int>` was expected.
 //
-// It's therefore necessary for several types to store a RawBuffer, rather than
-// a TypedBuffer, to allow for the possibility of the empty singleton. RawBuffer
+// It's therefore necessary for several types to store a RawStorage, rather than
+// a TypedStorage, to allow for the possibility of the empty singleton. RawStorage
 // also provides an implementation of an always-empty NSDictionary.
 //
 //
@@ -143,7 +143,7 @@ import SwiftShims
 // one container has no meaning for another. However copy-on-write currently
 // preserves indices under insertion, as long as reallocation doesn't occur:
 //
-//   var (i, found) = d.find(k) // i is associated with d's buffer
+//   var (i, found) = d.find(k) // i is associated with d's storage
 //   if found {
 //      var e = d            // now d is sharing its data with e
 //      e[newKey] = newValue // e now has a unique copy of the data
@@ -152,7 +152,7 @@ import SwiftShims
 //
 // The result should be a set of iterator invalidation rules familiar to anyone
 // familiar with the C++ standard library.  Note that because all accesses to a
-// dictionary buffer are bounds-checked, this scheme never compromises memory
+// dictionary storage are bounds-checked, this scheme never compromises memory
 // safety.
 //
 //
@@ -174,19 +174,19 @@ import SwiftShims
 // but may incur an allocation depending on the following conditions:
 //
 // * If the Dictionary is freshly allocated without any elements, then it
-//   contains the empty singleton Buffer which is returned as a toll-free
+//   contains the empty singleton Storage which is returned as a toll-free
 //   implementation of `NSDictionary`.
 //
 // * If both `K` and `V` are bridged verbatim, then `Dictionary<K, V>` is 
-//   still toll-free bridged to `NSDictionary` by returning its Buffer.
+//   still toll-free bridged to `NSDictionary` by returning its Storage.
 //
 // * If the Dictionary is actually a lazily bridged NSDictionary, then that
 //   NSDictionary is returned. 
 //
-// * Otherwise, bridging the `Dictionary` is done by wrapping its storage in a 
+// * Otherwise, bridging the `Dictionary` is done by wrapping its buffer in a 
 //   `_SwiftDeferredNSDictionary<K, V>`. This incurs an O(1)-sized allocation.
 //
-//   Complete bridging of the native Buffer's elements to another Buffer 
+//   Complete bridging of the native Storage's elements to another Storage 
 //   is performed on first access. This is O(n) work, but is hopefully amortized
 //   by future accesses.
 //
@@ -204,8 +204,8 @@ import SwiftShims
 //
 
 /// This protocol is only used for compile-time checks that
-/// every storage type implements all required operations.
-internal protocol _HashStorage {
+/// every buffer type implements all required operations.
+internal protocol _HashBuffer {
   associatedtype Key
   associatedtype Value
   associatedtype Index
@@ -437,9 +437,9 @@ internal struct _UnmanagedAnyObjectArray {
 /// then performs additional Swift bookkeeping work that takes O(1) time. For
 /// instances of `NSSet` that are already immutable, `copy(with:)` returns the
 /// same set in constant time; otherwise, the copying performance is
-/// unspecified. The instances of `NSSet` and `Set` share storage using the
+/// unspecified. The instances of `NSSet` and `Set` share buffer using the
 /// same copy-on-write optimization that is used when two instances of `Set`
-/// share storage.
+/// share buffer.
 ///
 /// - SeeAlso: `Hashable`
 @_fixed_layout
@@ -447,38 +447,38 @@ public struct Set<Element : Hashable> :
   SetAlgebra, Hashable, Collection, ExpressibleByArrayLiteral {
 
   internal typealias _Self = Set<Element>
-  internal typealias _VariantStorage = _VariantSetStorage<Element>
-  internal typealias _NativeStorage = _NativeSetStorage<Element>
+  internal typealias _VariantBuffer = _VariantSetBuffer<Element>
+  internal typealias _NativeBuffer = _NativeSetBuffer<Element>
 
   /// The index type for subscripting the set.
   public typealias Index = SetIndex<Element>
 
-  internal var _variantStorage: _VariantStorage
+  internal var _variantBuffer: _VariantBuffer
 
   /// Creates a new, empty set with at least the specified number of elements'
-  /// worth of storage.
+  /// worth of buffer.
   ///
-  /// Use this initializer to avoid repeated reallocations of a set's storage
+  /// Use this initializer to avoid repeated reallocations of a set's buffer
   /// if you know you'll be adding elements to the set after creation. The
   /// actual capacity of the created set will be the smallest power of 2 that
   /// is greater than or equal to `minimumCapacity`.
   ///
   /// - Parameter minimumCapacity: The minimum number of elements that the
   ///   newly created set should be able to store without reallocating its
-  ///   storage.
+  ///   buffer.
   public init(minimumCapacity: Int) {
-    _variantStorage =
-      _VariantStorage.native(
-        _NativeStorage.create(minimumCapacity: minimumCapacity))
+    _variantBuffer =
+      _VariantBuffer.native(
+        _NativeBuffer.create(minimumCapacity: minimumCapacity))
   }
 
   /// Private initializer.
-  internal init(_nativeStorage: _NativeSetStorage<Element>) {
-    _variantStorage = _VariantStorage.native(_nativeStorage)
+  internal init(_nativeBuffer: _NativeSetBuffer<Element>) {
+    _variantBuffer = _VariantBuffer.native(_nativeBuffer)
   }
 
   //
-  // All APIs below should dispatch to `_variantStorage`, without doing any
+  // All APIs below should dispatch to `_variantBuffer`, without doing any
   // additional processing.
   //
 
@@ -492,9 +492,9 @@ public struct Set<Element : Hashable> :
   ///   is a reference type).
   public init(_immutableCocoaSet: _NSSet) {
     _sanityCheck(_isBridgedVerbatimToObjectiveC(Element.self),
-      "Set can be backed by NSSet _variantStorage only when the member type can be bridged verbatim to Objective-C")
-    _variantStorage = _VariantSetStorage.cocoa(
-      _CocoaSetStorage(cocoaSet: _immutableCocoaSet))
+      "Set can be backed by NSSet _variantBuffer only when the member type can be bridged verbatim to Objective-C")
+    _variantBuffer = _VariantSetBuffer.cocoa(
+      _CocoaSetBuffer(cocoaSet: _immutableCocoaSet))
   }
 #endif
 
@@ -502,7 +502,7 @@ public struct Set<Element : Hashable> :
   ///
   /// If the set is empty, `startIndex` is equal to `endIndex`.
   public var startIndex: Index {
-    return _variantStorage.startIndex
+    return _variantBuffer.startIndex
   }
 
   /// The "past the end" position for the set---that is, the position one
@@ -510,11 +510,11 @@ public struct Set<Element : Hashable> :
   ///
   /// If the set is empty, `endIndex` is equal to `startIndex`.
   public var endIndex: Index {
-    return _variantStorage.endIndex
+    return _variantBuffer.endIndex
   }
 
   public func index(after i: Index) -> Index {
-    return _variantStorage.index(after: i)
+    return _variantBuffer.index(after: i)
   }
 
   // APINAMING: complexity docs are broadly missing in this file.
@@ -537,7 +537,7 @@ public struct Set<Element : Hashable> :
   /// - Parameter member: An element to look for in the set.
   /// - Returns: `true` if `member` exists in the set; otherwise, `false`.
   public func contains(_ member: Element) -> Bool {
-    return _variantStorage.maybeGet(member) != nil
+    return _variantBuffer.maybeGet(member) != nil
   }
 
   /// Returns the index of the given element in the set, or `nil` if the
@@ -547,7 +547,7 @@ public struct Set<Element : Hashable> :
   /// - Returns: The index of `member` if it exists in the set; otherwise,
   ///   `nil`.
   public func index(of member: Element) -> Index? {
-    return _variantStorage.index(forKey: member)
+    return _variantBuffer.index(forKey: member)
   }
 
   /// Inserts the given element in the set if it is not already present.
@@ -584,7 +584,7 @@ public struct Set<Element : Hashable> :
   public mutating func insert(
     _ newMember: Element
   ) -> (inserted: Bool, memberAfterInsert: Element) {
-    return _variantStorage.insert(newMember, forKey: newMember)
+    return _variantBuffer.insert(newMember, forKey: newMember)
   }
 
   /// Inserts the given element into the set unconditionally.
@@ -609,7 +609,7 @@ public struct Set<Element : Hashable> :
   ///   other means.
   @discardableResult
   public mutating func update(with newMember: Element) -> Element? {
-    return _variantStorage.updateValue(newMember, forKey: newMember)
+    return _variantBuffer.updateValue(newMember, forKey: newMember)
   }
 
   /// Removes the specified element from the set.
@@ -628,7 +628,7 @@ public struct Set<Element : Hashable> :
   ///   set; otherwise, `nil`.
   @discardableResult
   public mutating func remove(_ member: Element) -> Element? {
-    return _variantStorage.removeValue(forKey: member)
+    return _variantBuffer.removeValue(forKey: member)
   }
 
   /// Removes the element at the given index of the set.
@@ -639,16 +639,16 @@ public struct Set<Element : Hashable> :
   /// - Returns: The element that was removed from the set.
   @discardableResult
   public mutating func remove(at position: Index) -> Element {
-    return _variantStorage.remove(at: position)
+    return _variantBuffer.remove(at: position)
   }
 
   /// Removes all members from the set.
   ///
-  /// - Parameter keepingCapacity: If `true`, the set's storage capacity is
-  ///   preserved; if `false`, the underlying storage is released. The
+  /// - Parameter keepingCapacity: If `true`, the set's buffer capacity is
+  ///   preserved; if `false`, the underlying buffer is released. The
   ///   default is `false`.
   public mutating func removeAll(keepingCapacity keepCapacity: Bool = false) {
-    _variantStorage.removeAll(keepingCapacity: keepCapacity)
+    _variantBuffer.removeAll(keepingCapacity: keepCapacity)
   }
 
   /// Removes the first element of the set.
@@ -669,7 +669,7 @@ public struct Set<Element : Hashable> :
 
   /// The number of elements in the set.
   public var count: Int {
-    return _variantStorage.count
+    return _variantBuffer.count
   }
 
   //
@@ -678,13 +678,13 @@ public struct Set<Element : Hashable> :
 
   /// Accesses the member at the given position.
   public subscript(position: Index) -> Element {
-    return _variantStorage.assertingGet(position)
+    return _variantBuffer.assertingGet(position)
   }
 
   /// Returns an iterator over the members of the set.
   @inline(__always)
   public func makeIterator() -> SetIterator<Element> {
-    return _variantStorage.makeIterator()
+    return _variantBuffer.makeIterator()
   }
 
   //
@@ -709,16 +709,16 @@ public struct Set<Element : Hashable> :
   ///
   /// - Parameter elements: A variadic list of elements of the new set.
   public init(arrayLiteral elements: Element...) {
-    self.init(_nativeStorage: _NativeSetStorage.fromArray(elements))
+    self.init(_nativeBuffer: _NativeSetBuffer.fromArray(elements))
   }
 
   //
   // APIs below this comment should be implemented strictly in terms of
-  // *public* APIs above.  `_variantStorage` should not be accessed directly.
+  // *public* APIs above.  `_variantBuffer` should not be accessed directly.
   //
   // This separates concerns for testing.  Tests for the following APIs need
   // not to concern themselves with testing correctness of behavior of
-  // underlying storage (and different variants of it), only correctness of the
+  // underlying buffer (and different variants of it), only correctness of the
   // API itself.
   //
 
@@ -735,7 +735,7 @@ public struct Set<Element : Hashable> :
   ///     print(emptySet.isEmpty)
   ///     // Prints "true"
   public init() {
-    self = Set<Element>(_nativeStorage: _NativeStorage())
+    self = Set<Element>(_nativeBuffer: _NativeBuffer())
   }
 
   /// Creates a new set from a finite sequence of items.
@@ -763,13 +763,13 @@ public struct Set<Element : Hashable> :
     self.init(minimumCapacity: sequence.underestimatedCount)
     if let s = sequence as? Set<Element> {
       // If this sequence is actually a native `Set`, then we can quickly
-      // adopt its native storage and let COW handle uniquing only
+      // adopt its native buffer and let COW handle uniquing only
       // if necessary.
-      switch s._variantStorage {
-        case .native(let storage):
-          _variantStorage = .native(storage)
+      switch s._variantBuffer {
+        case .native(let buffer):
+          _variantBuffer = .native(buffer)
         case .cocoa(let owner):
-          _variantStorage = .cocoa(owner)
+          _variantBuffer = .cocoa(owner)
       }
     } else {
       for item in sequence {
@@ -1169,10 +1169,10 @@ extension Set {
   /// - Returns: `true` if the `lhs` and `rhs` have the same elements; otherwise,
   ///   `false`.
   public static func == (lhs: Set<Element>, rhs: Set<Element>) -> Bool {
-    switch (lhs._variantStorage, rhs._variantStorage) {
+    switch (lhs._variantBuffer, rhs._variantBuffer) {
     case (.native(let lhsNative), .native(let rhsNative)):
 
-      if lhsNative._buffer === rhsNative._buffer {
+      if lhsNative._storage === rhsNative._storage {
         return true
       }
 
@@ -1189,16 +1189,16 @@ extension Set {
       }
       return true
 
-    case (_VariantSetStorage.cocoa(let lhsCocoa),
-        _VariantSetStorage.cocoa(let rhsCocoa)):
+    case (_VariantSetBuffer.cocoa(let lhsCocoa),
+        _VariantSetBuffer.cocoa(let rhsCocoa)):
   #if _runtime(_ObjC)
       return _stdlib_NSObject_isEqual(lhsCocoa.cocoaSet, rhsCocoa.cocoaSet)
   #else
         _sanityCheckFailure("internal error: unexpected cocoa set")
   #endif
 
-    case (_VariantSetStorage.native(let lhsNative),
-      _VariantSetStorage.cocoa(let rhsCocoa)):
+    case (_VariantSetBuffer.native(let lhsNative),
+      _VariantSetBuffer.cocoa(let rhsCocoa)):
   #if _runtime(_ObjC)
 
       if lhsNative._count != rhsCocoa.count {
@@ -1225,7 +1225,7 @@ extension Set {
         _sanityCheckFailure("internal error: unexpected cocoa set")
   #endif
 
-    case (_VariantSetStorage.cocoa, _VariantSetStorage.native):
+    case (_VariantSetBuffer.cocoa, _VariantSetBuffer.native):
   #if _runtime(_ObjC)
       return rhs == lhs
   #else
@@ -1271,10 +1271,10 @@ func _stdlib_CFSetGetValues(_ nss: _NSSet, _: UnsafeMutablePointer<AnyObject>)
 internal func _stdlib_NSSet_allObjects(_ nss: _NSSet) ->
   _HeapBuffer<Int, AnyObject> {
   let count = nss.count
-  let buffer = _HeapBuffer<Int, AnyObject>(
+  let storage = _HeapBuffer<Int, AnyObject>(
     _HeapBufferStorage<Int, AnyObject>.self, count, count)
-  _stdlib_CFSetGetValues(nss, buffer.baseAddress)
-  return buffer
+  _stdlib_CFSetGetValues(nss, storage.baseAddress)
+  return storage
 }
 #endif
 
@@ -1347,17 +1347,17 @@ public func _setDownCast<BaseValue, DerivedValue>(_ source: Set<BaseValue>)
 #if _runtime(_ObjC)
   if _isClassOrObjCExistential(BaseValue.self)
   && _isClassOrObjCExistential(DerivedValue.self) {
-    switch source._variantStorage {
-    case _VariantSetStorage.native(let storage):
-      let bridged = storage.bridged()
+    switch source._variantBuffer {
+    case _VariantSetBuffer.native(let buffer):
+      let bridged = buffer.bridged()
       return Set(
         _immutableCocoaSet:
         unsafeBitCast(bridged, to: _NSSet.self))
 
-    case _VariantSetStorage.cocoa(let cocoaStorage):
+    case _VariantSetBuffer.cocoa(let cocoaBuffer):
       return Set(
         _immutableCocoaSet:
-        unsafeBitCast(cocoaStorage, to: _NSSet.self))
+        unsafeBitCast(cocoaBuffer, to: _NSSet.self))
     }
   }
 #endif
@@ -1601,12 +1601,12 @@ public func _setBridgeFromObjectiveCConditional<
 ///
 /// A dictionary's indices stay valid across additions to the dictionary as
 /// long as the dictionary has enough capacity to store the added values
-/// without allocating more storage. When a dictionary outgrows its storage,
+/// without allocating more buffer. When a dictionary outgrows its buffer,
 /// existing indices may be invalidated without any notification.
 ///
 /// When you know how many new values you're adding to a dictionary, use the
 /// `init(minimumCapacity:)` initializer to allocate the correct amount of
-/// storage.
+/// buffer.
 ///
 /// Bridging Between Dictionary and NSDictionary
 /// ============================================
@@ -1628,9 +1628,9 @@ public func _setBridgeFromObjectiveCConditional<
 /// takes O(1) time. For instances of `NSDictionary` that are already
 /// immutable, `copy(with:)` usually returns the same dictionary in O(1) time;
 /// otherwise, the copying performance is unspecified. The instances of
-/// `NSDictionary` and `Dictionary` share storage using the same copy-on-write
+/// `NSDictionary` and `Dictionary` share buffer using the same copy-on-write
 /// optimization that is used when two instances of `Dictionary` share
-/// storage.
+/// buffer.
 ///
 /// - SeeAlso: `Hashable`
 @_fixed_layout
@@ -1638,8 +1638,8 @@ public struct Dictionary<Key : Hashable, Value> :
   Collection, ExpressibleByDictionaryLiteral {
 
   internal typealias _Self = Dictionary<Key, Value>
-  internal typealias _VariantStorage = _VariantDictionaryStorage<Key, Value>
-  internal typealias _NativeStorage = _NativeDictionaryStorage<Key, Value>
+  internal typealias _VariantBuffer = _VariantDictionaryBuffer<Key, Value>
+  internal typealias _NativeBuffer = _NativeDictionaryBuffer<Key, Value>
 
   /// The element type of a dictionary: a tuple containing an individual
   /// key-value pair.
@@ -1648,15 +1648,15 @@ public struct Dictionary<Key : Hashable, Value> :
   /// The index type of a dictionary.
   public typealias Index = DictionaryIndex<Key, Value>
 
-  internal var _variantStorage: _VariantStorage
+  internal var _variantBuffer: _VariantBuffer
 
   /// Creates an empty dictionary.
   public init() {
-    self = Dictionary<Key, Value>(_nativeStorage: _NativeStorage())
+    self = Dictionary<Key, Value>(_nativeBuffer: _NativeBuffer())
   }
 
   /// Creates a dictionary with at least the given number of elements worth of
-  /// storage.
+  /// buffer.
   ///
   /// Use this initializer to avoid intermediate reallocations when you know
   /// how many key-value pairs you are adding to a dictionary. The actual
@@ -1664,15 +1664,15 @@ public struct Dictionary<Key : Hashable, Value> :
   /// is greater than or equal to `minimumCapacity`.
   ///
   /// - Parameter minimumCapacity: The minimum number of key-value pairs to
-  ///   allocate storage for in the new dictionary.
+  ///   allocate buffer for in the new dictionary.
   public init(minimumCapacity: Int) {
-    _variantStorage =
-      .native(_NativeStorage.create(minimumCapacity: minimumCapacity))
+    _variantBuffer =
+      .native(_NativeBuffer.create(minimumCapacity: minimumCapacity))
   }
 
-  internal init(_nativeStorage: _NativeDictionaryStorage<Key, Value>) {
-    _variantStorage =
-      .native(_nativeStorage)
+  internal init(_nativeBuffer: _NativeDictionaryBuffer<Key, Value>) {
+    _variantBuffer =
+      .native(_nativeBuffer)
   }
 
 #if _runtime(_ObjC)
@@ -1687,14 +1687,14 @@ public struct Dictionary<Key : Hashable, Value> :
     _sanityCheck(
       _isBridgedVerbatimToObjectiveC(Key.self) &&
       _isBridgedVerbatimToObjectiveC(Value.self),
-      "Dictionary can be backed by NSDictionary storage only when both key and value are bridged verbatim to Objective-C")
-    _variantStorage = .cocoa(
-      _CocoaDictionaryStorage(cocoaDictionary: _immutableCocoaDictionary))
+      "Dictionary can be backed by NSDictionary buffer only when both key and value are bridged verbatim to Objective-C")
+    _variantBuffer = .cocoa(
+      _CocoaDictionaryBuffer(cocoaDictionary: _immutableCocoaDictionary))
   }
 #endif
 
   //
-  // All APIs below should dispatch to `_variantStorage`, without doing any
+  // All APIs below should dispatch to `_variantBuffer`, without doing any
   // additional processing.
   //
 
@@ -1706,7 +1706,7 @@ public struct Dictionary<Key : Hashable, Value> :
   ///   `NSDictionary`. If the dictionary wraps a bridged `NSDictionary`, the
   ///   performance is unspecified.
   public var startIndex: Index {
-    return _variantStorage.startIndex
+    return _variantBuffer.startIndex
   }
 
   /// The dictionary's "past the end" position---that is, the position one
@@ -1717,11 +1717,11 @@ public struct Dictionary<Key : Hashable, Value> :
   /// - Complexity: Amortized O(1) if the dictionary does not wrap a bridged
   ///   `NSDictionary`; otherwise, the performance is unspecified.
   public var endIndex: Index {
-    return _variantStorage.endIndex
+    return _variantBuffer.endIndex
   }
 
   public func index(after i: Index) -> Index {
-    return _variantStorage.index(after: i)
+    return _variantBuffer.index(after: i)
   }
 
   /// Returns the index for the given key.
@@ -1740,9 +1740,9 @@ public struct Dictionary<Key : Hashable, Value> :
   ///   the dictionary; otherwise, `nil`.
   @inline(__always)
   public func index(forKey key: Key) -> Index? {
-    // Complexity: amortized O(1) for native storage, O(*n*) when wrapping an
+    // Complexity: amortized O(1) for native buffer, O(*n*) when wrapping an
     // NSDictionary.
-    return _variantStorage.index(forKey: key)
+    return _variantBuffer.index(forKey: key)
   }
 
   /// Accesses the key-value pair at the specified position.
@@ -1771,7 +1771,7 @@ public struct Dictionary<Key : Hashable, Value> :
   /// - Returns: A two-element tuple with the key and value corresponding to
   ///   `position`.
   public subscript(position: Index) -> Element {
-    return _variantStorage.assertingGet(position)
+    return _variantBuffer.assertingGet(position)
   }
 
   /// Accesses the value associated with the given key for reading and writing.
@@ -1821,12 +1821,12 @@ public struct Dictionary<Key : Hashable, Value> :
   public subscript(key: Key) -> Value? {
     @inline(__always)
     get {
-      return _variantStorage.maybeGet(key)
+      return _variantBuffer.maybeGet(key)
     }
     set(newValue) {
       if let x = newValue {
         // FIXME(performance): this loads and discards the old value.
-        _variantStorage.updateValue(x, forKey: key)
+        _variantBuffer.updateValue(x, forKey: key)
       }
       else {
         // FIXME(performance): this loads and discards the old value.
@@ -1872,7 +1872,7 @@ public struct Dictionary<Key : Hashable, Value> :
   public mutating func updateValue(
     _ value: Value, forKey key: Key
   ) -> Value? {
-    return _variantStorage.updateValue(value, forKey: key)
+    return _variantBuffer.updateValue(value, forKey: key)
   }
 
   /// Removes and returns the key-value pair at the specified index.
@@ -1889,7 +1889,7 @@ public struct Dictionary<Key : Hashable, Value> :
   ///   dictionary.
   @discardableResult
   public mutating func remove(at index: Index) -> Element {
-    return _variantStorage.remove(at: index)
+    return _variantBuffer.remove(at: index)
   }
 
   /// Removes the given key and its associated value from the dictionary.
@@ -1922,7 +1922,7 @@ public struct Dictionary<Key : Hashable, Value> :
   ///   dictionary.
   @discardableResult
   public mutating func removeValue(forKey key: Key) -> Value? {
-    return _variantStorage.removeValue(forKey: key)
+    return _variantBuffer.removeValue(forKey: key)
   }
 
   /// Removes all key-value pairs from the dictionary.
@@ -1931,24 +1931,24 @@ public struct Dictionary<Key : Hashable, Value> :
   /// dictionary.
   ///
   /// - Parameter keepCapacity: Whether the dictionary should keep its
-  ///   underlying storage. If you pass `true`, the operation preserves the
-  ///   storage capacity that the collection has, otherwise the underlying
-  ///   storage is released.  The default is `false`.
+  ///   underlying buffer. If you pass `true`, the operation preserves the
+  ///   buffer capacity that the collection has, otherwise the underlying
+  ///   buffer is released.  The default is `false`.
   ///
   /// - Complexity: O(*n*), where *n* is the number of key-value pairs in the
   ///   dictionary.
   public mutating func removeAll(keepingCapacity keepCapacity: Bool = false) {
     // The 'will not decrease' part in the documentation comment is worded very
-    // carefully.  The capacity can increase if we replace Cocoa storage with
-    // native storage.
-    _variantStorage.removeAll(keepingCapacity: keepCapacity)
+    // carefully.  The capacity can increase if we replace Cocoa buffer with
+    // native buffer.
+    _variantBuffer.removeAll(keepingCapacity: keepCapacity)
   }
 
   /// The number of key-value pairs in the dictionary.
   ///
   /// - Complexity: O(1).
   public var count: Int {
-    return _variantStorage.count
+    return _variantBuffer.count
   }
 
   //
@@ -1974,7 +1974,7 @@ public struct Dictionary<Key : Hashable, Value> :
   ///   `(key: Key, value: Value)`.
   @inline(__always)
   public func makeIterator() -> DictionaryIterator<Key, Value> {
-    return _variantStorage.makeIterator()
+    return _variantBuffer.makeIterator()
   }
 
   //
@@ -2001,16 +2001,16 @@ public struct Dictionary<Key : Hashable, Value> :
   /// - SeeAlso: `ExpressibleByDictionaryLiteral`
   @effects(readonly)
   public init(dictionaryLiteral elements: (Key, Value)...) {
-    self.init(_nativeStorage: _NativeDictionaryStorage.fromArray(elements))
+    self.init(_nativeBuffer: _NativeDictionaryBuffer.fromArray(elements))
   }
 
   //
   // APIs below this comment should be implemented strictly in terms of
-  // *public* APIs above.  `_variantStorage` should not be accessed directly.
+  // *public* APIs above.  `_variantBuffer` should not be accessed directly.
   //
   // This separates concerns for testing.  Tests for the following APIs need
   // not to concern themselves with testing correctness of behavior of
-  // underlying storage (and different variants of it), only correctness of the
+  // underlying buffer (and different variants of it), only correctness of the
   // API itself.
   //
 
@@ -2070,10 +2070,10 @@ public struct Dictionary<Key : Hashable, Value> :
 
 extension Dictionary where Key : Equatable, Value : Equatable {
   public static func == (lhs: [Key : Value], rhs: [Key : Value]) -> Bool {
-    switch (lhs._variantStorage, rhs._variantStorage) {
+    switch (lhs._variantBuffer, rhs._variantBuffer) {
     case (.native(let lhsNative), .native(let rhsNative)):
 
-      if lhsNative._buffer === rhsNative._buffer {
+      if lhsNative._storage === rhsNative._storage {
         return true
       }
 
@@ -2189,11 +2189,11 @@ extension Dictionary : CustomStringConvertible, CustomDebugStringConvertible {
 internal func _stdlib_NSDictionary_allKeys(_ nsd: _NSDictionary)
     -> _HeapBuffer<Int, AnyObject> {
   let count = nsd.count
-  let buffer = _HeapBuffer<Int, AnyObject>(
+  let storage = _HeapBuffer<Int, AnyObject>(
     _HeapBufferStorage<Int, AnyObject>.self, count, count)
 
-  nsd.getObjects(nil, andKeys: buffer.baseAddress)
-  return buffer
+  nsd.getObjects(nil, andKeys: storage.baseAddress)
+  return storage
 }
 #endif
 
@@ -2300,19 +2300,19 @@ public func _dictionaryDownCast<BaseKey, BaseValue, DerivedKey, DerivedValue>(
   && _isClassOrObjCExistential(DerivedKey.self)
   && _isClassOrObjCExistential(DerivedValue.self) {
 
-    switch source._variantStorage {
-    case .native(let storage):
-      // Note: it is safe to treat the storage as immutable here because
-      // Dictionary will not mutate storage with reference count greater than 1.
-      let nativeStorage = storage.bridged()
+    switch source._variantBuffer {
+    case .native(let buffer):
+      // Note: it is safe to treat the buffer as immutable here because
+      // Dictionary will not mutate buffer with reference count greater than 1.
+      let nativeBuffer = buffer.bridged()
       return Dictionary(
         _immutableCocoaDictionary:
-        unsafeBitCast(nativeStorage, to: _NSDictionary.self))
+        unsafeBitCast(nativeBuffer, to: _NSDictionary.self))
 
-    case .cocoa(let cocoaStorage):
+    case .cocoa(let cocoaBuffer):
       return Dictionary(
         _immutableCocoaDictionary:
-        unsafeBitCast(cocoaStorage, to: _NSDictionary.self))
+        unsafeBitCast(cocoaBuffer, to: _NSDictionary.self))
     }
   }
 #endif
@@ -2476,8 +2476,8 @@ collections = [
 
 % for (Self, a_self, TypeParametersDecl, TypeParameters, AnyTypeParameters, Sequence, AnySequenceType) in collections:
 
-/// Header part of the RawNativeSelfBuffer.
-internal struct _${Self}StorageHeader {
+/// Header part of the RawNativeSelfStorage.
+internal struct _${Self}BufferHeader {
 
   internal init(capacity: Int) {
     self.capacity = capacity
@@ -2502,42 +2502,42 @@ internal struct _${Self}StorageHeader {
 /// keys, followed by the values.
 //
 // See the top level docs for more details on this type
-internal class _RawNative${Self}Buffer:
+internal class _RawNative${Self}Storage:
   _SwiftNativeNS${Self}, _NS${Self}Core
 {
-  internal typealias StorageHeader = _${Self}StorageHeader
-  internal typealias RawBuffer = _RawNative${Self}Buffer
+  internal typealias BufferHeader = _${Self}BufferHeader
+  internal typealias RawStorage = _RawNative${Self}Storage
 
-  internal var _body: StorageHeader
+  internal var _body: BufferHeader
 
   // This API is unsafe and needs a `_fixLifetime` in the caller.
   internal
-  var _initializedHashtableEntriesBitMapStorage: UnsafeMutablePointer<UInt> {
+  var _initializedHashtableEntriesBitMapBuffer: UnsafeMutablePointer<UInt> {
     return UnsafeMutablePointer(Builtin.projectTailElems(self, UInt.self))
   }
 
   /// The empty singleton that is used for every single Dictionary that is
-  /// created without any elements. The contents of the buffer should never
+  /// created without any elements. The contents of the storage should never
   /// be mutated.
   // FIXME: this should be set up in rodata like the Array singleton
-  internal static let empty: RawBuffer = {
-    let buffer = Builtin.allocWithTailElems_1(RawBuffer.self,
+  internal static let empty: RawStorage = {
+    let storage = Builtin.allocWithTailElems_1(RawStorage.self,
         1._builtinWordValue, UInt.self)
     
     // We set the capacity to 1 so that there's an empty hole to search.
-    // Any insertion will lead to a real buffer being allocated, because 
+    // Any insertion will lead to a real storage being allocated, because 
     // Dictionary guarantees there's always another empty hole after insertion.
-    buffer._body = StorageHeader(capacity: 1)
+    storage._body = BufferHeader(capacity: 1)
 
     let initializedEntries = _UnsafeBitMap(
-        storage: buffer._initializedHashtableEntriesBitMapStorage,
+        storage: storage._initializedHashtableEntriesBitMapBuffer,
         bitCount: 1)
     initializedEntries.initializeToZero()
 
     // We don't bother to initalize the pointers in the header because
     // they should never be accessed on the empty singleton.
-    buffer._body.initializedEntries = initializedEntries
-    return buffer
+    storage._body.initializedEntries = initializedEntries
+    return storage
   }()
 
   internal init(_doNotCallMe: ()) {
@@ -2549,11 +2549,11 @@ internal class _RawNative${Self}Buffer:
   // NSSelf implementation, assuming Self is the empty singleton
   //
 
-  /// Get the NSEnumator implementation for self. NativeSelfBuffer
+  /// Get the NSEnumator implementation for self. NativeSelfStorage
   /// overloads this to give NativeSelfNSEnumerator proper type parameters.
   func enumerator() -> _NSEnumerator {
     return _Native${Self}NSEnumerator<${AnyTypeParameters}>(
-        _Native${Self}Storage(_buffer: self))
+        _Native${Self}Buffer(_storage: self))
   }
 
   @objc(copyWithZone:)
@@ -2632,8 +2632,8 @@ internal class _RawNative${Self}Buffer:
 
 // See the top level docs for a description of this type
 @_versioned
-internal class _TypedNative${Self}Buffer<${TypeParameters}> :
-  _RawNative${Self}Buffer {
+internal class _TypedNative${Self}Storage<${TypeParameters}> :
+  _RawNative${Self}Storage {
 
 %if Self == 'Set': # Set needs these to keep signatures simple.
   internal typealias Key = ${TypeParameters}
@@ -2643,7 +2643,7 @@ internal class _TypedNative${Self}Buffer<${TypeParameters}> :
   deinit {
     let capacity = _body.capacity
     let initializedEntries = _UnsafeBitMap(
-        storage: _initializedHashtableEntriesBitMapStorage, bitCount: capacity)
+        storage: _initializedHashtableEntriesBitMapBuffer, bitCount: capacity)
     let keys = _body.keys.assumingMemoryBound(to: Key.self)
 %if Self == 'Dictionary':
     let values = _body.values.assumingMemoryBound(to: Value.self)
@@ -2670,7 +2670,7 @@ internal class _TypedNative${Self}Buffer<${TypeParameters}> :
   }
 
   override internal init(_doNotCallMe: ()) {
-    _sanityCheckFailure("Only create this by calling Storage.createUnhashable")
+    _sanityCheckFailure("Only create this by calling Buffer.createUnhashable")
   }
 
 %if Self == 'Set':
@@ -2693,28 +2693,28 @@ internal class _TypedNative${Self}Buffer<${TypeParameters}> :
 
 // See the top level docs for a description of this type
 @_versioned
-final internal class _Native${Self}Buffer<${TypeParametersDecl}> :
-  _TypedNative${Self}Buffer<${TypeParameters}> {
+final internal class _Native${Self}Storage<${TypeParametersDecl}> :
+  _TypedNative${Self}Storage<${TypeParameters}> {
 
   internal typealias FullContainer = ${Self}<${TypeParameters}>
-  internal typealias Storage = _Native${Self}Storage<${TypeParameters}>
+  internal typealias Buffer = _Native${Self}Buffer<${TypeParameters}>
 
   override internal init(_doNotCallMe: ()) {
-    _sanityCheckFailure("Only create this by calling Storage.create")
+    _sanityCheckFailure("Only create this by calling Buffer.create")
   }
 
   
 #if _runtime(_ObjC)
   // NSSelf bridging:
 
-  /// All actual functionality comes from Storage/Dictionary, which are
-  /// just newtype wrappers around a RawNativeSelfBuffer.
-  var storage: Storage {
-    return Storage(_buffer: self)
+  /// All actual functionality comes from Buffer/Dictionary, which are
+  /// just newtype wrappers around a RawNativeSelfStorage.
+  var buffer: Buffer {
+    return Buffer(_storage: self)
   }
 
   var full: FullContainer {
-    return FullContainer(_nativeStorage: storage)
+    return FullContainer(_nativeBuffer: buffer)
   }
 
   override var count: Int { 
@@ -2723,7 +2723,7 @@ final internal class _Native${Self}Buffer<${TypeParametersDecl}> :
 
   override func enumerator() -> _NSEnumerator {
     return _Native${Self}NSEnumerator<${TypeParameters}>(
-        Storage(_buffer: self))
+        Buffer(_storage: self))
   }
 
   @objc(countByEnumeratingWithState:objects:count:)
@@ -2749,17 +2749,17 @@ final internal class _Native${Self}Buffer<${TypeParametersDecl}> :
     let unmanagedObjects = _UnmanagedAnyObjectArray(objects!)
     var currIndex = _Native${Self}Index<${TypeParameters}>(
         offset: Int(theState.extra.0))
-    let endIndex = storage.endIndex
+    let endIndex = buffer.endIndex
     var stored = 0
     for i in 0..<count {
       if (currIndex == endIndex) {
         break
       }
 
-      unmanagedObjects[i] = storage.bridgedKey(at: currIndex)
+      unmanagedObjects[i] = buffer.bridgedKey(at: currIndex)
       
       stored += 1
-      storage.formIndex(after: &currIndex)
+      buffer.formIndex(after: &currIndex)
     }
     theState.extra.0 = CUnsignedLong(currIndex.offset)
     state.pointee = theState
@@ -2770,11 +2770,11 @@ final internal class _Native${Self}Buffer<${TypeParametersDecl}> :
     guard let nativeKey = _conditionallyBridgeFromObjectiveC(aKey, Key.self)
     else { return nil }
 
-    let (i, found) = storage._find(nativeKey, 
-        startBucket: storage._bucket(nativeKey))
+    let (i, found) = buffer._find(nativeKey, 
+        startBucket: buffer._bucket(nativeKey))
 
     if found {
-      return storage.bridgedValue(at: i)
+      return buffer.bridgedValue(at: i)
     }
     return nil
   }
@@ -2811,7 +2811,7 @@ final internal class _Native${Self}Buffer<${TypeParametersDecl}> :
   @objc
   override func getObjects(_ objects: UnsafeMutablePointer<AnyObject>?,
     andKeys keys: UnsafeMutablePointer<AnyObject>?) {
-    // The user is expected to provide a buffer of the correct size
+    // The user is expected to provide a storage of the correct size
     if let unmanagedKeys = _UnmanagedAnyObjectArray(keys) {
       if let unmanagedObjects = _UnmanagedAnyObjectArray(objects) {
         // keys nonnull, objects nonnull
@@ -2842,18 +2842,18 @@ final internal class _Native${Self}Buffer<${TypeParametersDecl}> :
 
 
 /// This type provides most of the actual functionality for Dictionary,
-/// while just being a wrapper around a RawNativeSelfBuffer.
+/// while just being a wrapper around a RawNativeSelfStorage.
 ///
 /// This type and most of its functionality doesn't require Hashable at all.
 /// The reason for this is to support storing AnyObject for bridging
 /// with SwiftDeferredNSSelf. What functionality actually relies on
 /// Hashable can be found in an extension.
-internal struct _Native${Self}Storage<${TypeParameters}> {
+internal struct _Native${Self}Buffer<${TypeParameters}> {
 
-  internal typealias StorageHeader = _${Self}StorageHeader
-  internal typealias RawBuffer = _RawNative${Self}Buffer
-  internal typealias TypedBuffer = _TypedNative${Self}Buffer<${TypeParameters}>
-  internal typealias Storage = _Native${Self}Storage<${TypeParameters}>
+  internal typealias BufferHeader = _${Self}BufferHeader
+  internal typealias RawStorage = _RawNative${Self}Storage
+  internal typealias TypedStorage = _TypedNative${Self}Storage<${TypeParameters}>
+  internal typealias Buffer = _Native${Self}Buffer<${TypeParameters}>
   internal typealias Index = _Native${Self}Index<${TypeParameters}>
 
 %if Self == 'Set': # Set needs these to keep signatures simple.
@@ -2864,62 +2864,62 @@ internal struct _Native${Self}Storage<${TypeParameters}> {
   internal typealias SequenceElementWithoutLabels = (Key, Value)
 %end
 
-  /// See this comments on RawNativeSelfBuffer and its subclasses to
-  /// understand why we store an untyped buffer here.
-  internal var _buffer: RawBuffer
+  /// See this comments on RawNativeSelfStorage and its subclasses to
+  /// understand why we store an untyped storage here.
+  internal var _storage: RawStorage
 
-  /// Creates a Storage with a buffer that is typed, but doesn't understand
+  /// Creates a Buffer with a storage that is typed, but doesn't understand
   /// Hashing. Mostly for bridging; prefer `create(capacity:)`.
-  internal static func createUnhashable(capacity: Int) -> Storage {
+  internal static func createUnhashable(capacity: Int) -> Buffer {
     let numWordsForBitmap = _UnsafeBitMap.sizeInWords(forSizeInBits: capacity)
 %if Self == 'Dictionary':
-    let buffer = Builtin.allocWithTailElems_3(TypedBuffer.self,
+    let storage = Builtin.allocWithTailElems_3(TypedStorage.self,
         numWordsForBitmap._builtinWordValue, UInt.self,
         capacity._builtinWordValue, Key.self,
         capacity._builtinWordValue, Value.self)
 %else:
-    let buffer = Builtin.allocWithTailElems_2(TypedBuffer.self,
+    let storage = Builtin.allocWithTailElems_2(TypedStorage.self,
         numWordsForBitmap._builtinWordValue, UInt.self,
         capacity._builtinWordValue, Key.self)
 %end
-    return create(capacity: capacity, buffer: buffer)
+    return create(capacity: capacity, storage: storage)
   }
 
-  /// Given a capacity and uninitialized RawBuffer, completes the 
-  /// initialization and produces a properly formed Storage.  
-  internal static func create(capacity: Int, buffer: RawBuffer) -> Storage {
-    // We can initialize by assignment because _HashedContainerStorageHeader
+  /// Given a capacity and uninitialized RawStorage, completes the 
+  /// initialization and produces a properly formed Buffer.  
+  internal static func create(capacity: Int, storage: RawStorage) -> Buffer {
+    // We can initialize by assignment because _HashedContainerBufferHeader
     // is a trivial type, i.e. contains no references.
-    buffer._body = StorageHeader(capacity: capacity)
+    storage._body = BufferHeader(capacity: capacity)
     
-    var storage = Storage(_buffer: buffer)
+    var buffer = Buffer(_storage: storage)
 
     let initializedEntries = _UnsafeBitMap(
-        storage: storage._initializedHashtableEntriesBitMapStorage,
+        storage: buffer._initializedHashtableEntriesBitMapBuffer,
         bitCount: capacity)
     initializedEntries.initializeToZero()
 
     // Initialize header
-    storage._body.initializedEntries = initializedEntries
-    storage._body.keys = UnsafeMutableRawPointer(storage._keys)
+    buffer._body.initializedEntries = initializedEntries
+    buffer._body.keys = UnsafeMutableRawPointer(buffer._keys)
 %if Self == 'Dictionary':
-    storage._body.values = UnsafeMutableRawPointer(storage._values)
+    buffer._body.values = UnsafeMutableRawPointer(buffer._values)
 %end
 
-    return storage
+    return buffer
   }
 
-  /// A convenience forwarding the _buffer's body
-  internal var _body: StorageHeader { 
+  /// A convenience forwarding the _storage's body
+  internal var _body: BufferHeader { 
     set {
-      _buffer._body = newValue
+      _storage._body = newValue
     }
     get {
-      return _buffer._body
+      return _storage._body
     }
   }
 
-  // Forwarding the individual fields of the buffer in various forms
+  // Forwarding the individual fields of the storage in various forms
 
   @_versioned
   internal var _capacity: Int {
@@ -2941,13 +2941,13 @@ internal struct _Native${Self}Storage<${TypeParameters}> {
   }
 
   internal
-  var _initializedHashtableEntriesBitMapStorage: UnsafeMutablePointer<UInt> {
-    return _buffer._initializedHashtableEntriesBitMapStorage
+  var _initializedHashtableEntriesBitMapBuffer: UnsafeMutablePointer<UInt> {
+    return _storage._initializedHashtableEntriesBitMapBuffer
   }
 
   // just a convenience for _keys and _values
   internal var _keysRawAddr: Builtin.RawPointer {
-    let bitmapAddr = Builtin.projectTailElems(_buffer, UInt.self)
+    let bitmapAddr = Builtin.projectTailElems(_storage, UInt.self)
     let numWordsForBitmap = _UnsafeBitMap.sizeInWords(forSizeInBits: _capacity)
     return Builtin.getTailAddr_Word(bitmapAddr,
            numWordsForBitmap._builtinWordValue, UInt.self, Key.self)
@@ -2967,19 +2967,19 @@ internal struct _Native${Self}Storage<${TypeParameters}> {
   }
 %end
 
-  /// Wrap a fully initialized RawBuffer
-  init(_buffer: RawBuffer) {
-    self._buffer = _buffer
+  /// Wrap a fully initialized RawStorage
+  init(_storage: RawStorage) {
+    self._storage = _storage
   }
 
   /// Construct an instance from the empty singleton
   init() {
-    self._buffer = RawBuffer.empty
+    self._storage = RawStorage.empty
   }
 
 
 
-  // Most of the implementation of the _HashStorage protocol,
+  // Most of the implementation of the _HashBuffer protocol,
   // but only the parts that don't actually rely on hashing.
 
   @_versioned
@@ -3038,7 +3038,7 @@ internal struct _Native${Self}Storage<${TypeParameters}> {
   }
 
   @_transparent
-  internal func moveInitializeEntry(from: Storage, at: Int, toEntryAt: Int) {
+  internal func moveInitializeEntry(from: Buffer, at: Int, toEntryAt: Int) {
     _sanityCheck(!isInitializedEntry(at: toEntryAt))
 
     defer { _fixLifetime(self) }
@@ -3075,7 +3075,7 @@ internal struct _Native${Self}Storage<${TypeParameters}> {
   }
 
   @_transparent
-  internal func moveInitializeEntry(from: Storage, at: Int, toEntryAt: Int) {
+  internal func moveInitializeEntry(from: Buffer, at: Int, toEntryAt: Int) {
     _sanityCheck(!isInitializedEntry(at: toEntryAt))
     defer { _fixLifetime(self) }
 
@@ -3149,14 +3149,14 @@ internal struct _Native${Self}Storage<${TypeParameters}> {
   }
 }
 
-extension _Native${Self}Storage 
+extension _Native${Self}Buffer 
   where ${'Key' if Self == 'Dictionary' else 'Element'} : Hashable
 {
-  internal typealias HashTypedBuffer = _Native${Self}Buffer<${TypeParameters}>
+  internal typealias HashTypedStorage = _Native${Self}Storage<${TypeParameters}>
   internal typealias SequenceElement = ${Sequence}
 
   @inline(__always)
-  internal static func create(minimumCapacity: Int) -> Storage {
+  internal static func create(minimumCapacity: Int) -> Buffer {
     // Make sure there's a representable power of 2 >= minimumCapacity
     _sanityCheck(minimumCapacity <= (Int.max >> 1) + 1)
     var capacity = 2
@@ -3166,21 +3166,21 @@ extension _Native${Self}Storage
     return create(capacity: capacity)
   }
 
-  /// Create a storage instance with room for at least 'capacity'
+  /// Create a buffer instance with room for at least 'capacity'
   /// entries and all entries marked invalid.
-  internal static func create(capacity: Int) -> Storage {
+  internal static func create(capacity: Int) -> Buffer {
     let numWordsForBitmap = _UnsafeBitMap.sizeInWords(forSizeInBits: capacity)
 %if Self == 'Dictionary':
-    let buffer = Builtin.allocWithTailElems_3(HashTypedBuffer.self,
+    let storage = Builtin.allocWithTailElems_3(HashTypedStorage.self,
         numWordsForBitmap._builtinWordValue, UInt.self,
         capacity._builtinWordValue, Key.self,
         capacity._builtinWordValue, Value.self)
 %else:
-    let buffer = Builtin.allocWithTailElems_2(HashTypedBuffer.self,
+    let storage = Builtin.allocWithTailElems_2(HashTypedStorage.self,
         numWordsForBitmap._builtinWordValue, UInt.self,
         capacity._builtinWordValue, Key.self)
 %end
-    return create(capacity: capacity, buffer: buffer)
+    return create(capacity: capacity, storage: storage)
   }
 
 #if _runtime(_ObjC)
@@ -3189,10 +3189,10 @@ extension _Native${Self}Storage
     // or if we're the empty singleton.
     if (_isBridgedVerbatimToObjectiveC(Key.self) &&
         _isBridgedVerbatimToObjectiveC(Value.self)) ||
-        self._buffer === RawBuffer.empty {
-      return self._buffer
+        self._storage === RawStorage.empty {
+      return self._storage
     }
-    return _SwiftDeferredNS${Self}(nativeStorage: self)
+    return _SwiftDeferredNS${Self}(nativeBuffer: self)
   }
 #endif
 
@@ -3269,7 +3269,7 @@ extension _Native${Self}Storage
                minimumCount + 1)
   }
 
-  /// Storage should be uniquely referenced.
+  /// Buffer should be uniquely referenced.
   /// The `key` should not be present in the ${Self}.
   /// This function does *not* update `count`.
 
@@ -3294,7 +3294,7 @@ extension _Native${Self}Storage
 %end
 
   //
-  // _HashStorage conformance
+  // _HashBuffer conformance
   //
 
   @_versioned
@@ -3341,7 +3341,7 @@ extension _Native${Self}Storage
   @discardableResult
   internal func updateValue(_ value: Value, forKey key: Key) -> Value? {
     _sanityCheckFailure(
-      "don't call mutating methods on _Native${Self}Storage")
+      "don't call mutating methods on _Native${Self}Buffer")
   }
 
   @discardableResult
@@ -3349,89 +3349,89 @@ extension _Native${Self}Storage
     _ value: Value, forKey key: Key
   ) -> (inserted: Bool, memberAfterInsert: Value) {
     _sanityCheckFailure(
-      "don't call mutating methods on _Native${Self}Storage")
+      "don't call mutating methods on _Native${Self}Buffer")
   }
 
   @discardableResult
   internal func remove(at index: Index) -> SequenceElement {
     _sanityCheckFailure(
-      "don't call mutating methods on _Native${Self}Storage")
+      "don't call mutating methods on _Native${Self}Buffer")
   }
 
   @discardableResult
   internal func removeValue(forKey key: Key) -> Value? {
     _sanityCheckFailure(
-      "don't call mutating methods on _Native${Self}Storage")
+      "don't call mutating methods on _Native${Self}Buffer")
   }
 
   internal func removeAll(keepingCapacity keepCapacity: Bool) {
     _sanityCheckFailure(
-      "don't call mutating methods on _Native${Self}Storage")
+      "don't call mutating methods on _Native${Self}Buffer")
   }
 
   internal static func fromArray(_ elements: [SequenceElementWithoutLabels])
-    -> Storage 
+    -> Buffer 
   {
     if elements.isEmpty {
-      return Storage()
+      return Buffer()
     }
 
     let requiredCapacity =
-      Storage.minimumCapacity(
+      Buffer.minimumCapacity(
         minimumCount: elements.count,
         maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
-    var nativeStorage = Storage.create(minimumCapacity: requiredCapacity)
+    var nativeBuffer = Buffer.create(minimumCapacity: requiredCapacity)
 
 %if Self == 'Set':
 
     var count = 0
     for key in elements {
       let (i, found) =
-        nativeStorage._find(key, startBucket: nativeStorage._bucket(key))
+        nativeBuffer._find(key, startBucket: nativeBuffer._bucket(key))
       if found {
         continue
       }
-      nativeStorage.initializeKey(key, at: i.offset)
+      nativeBuffer.initializeKey(key, at: i.offset)
       count += 1
     }
-    nativeStorage._count = count
+    nativeBuffer._count = count
 
 %elif Self == 'Dictionary':
 
     for (key, value) in elements {
       let (i, found) =
-        nativeStorage._find(key, startBucket: nativeStorage._bucket(key))
+        nativeBuffer._find(key, startBucket: nativeBuffer._bucket(key))
       _precondition(!found, "${Self} literal contains duplicate keys")
-      nativeStorage.initializeKey(key, value: value, at: i.offset)
+      nativeBuffer.initializeKey(key, value: value, at: i.offset)
     }
-    nativeStorage._count = elements.count
+    nativeBuffer._count = elements.count
 
 %end
 
-    return nativeStorage
+    return nativeBuffer
   }
 }
 
 #if _runtime(_ObjC)
-/// An NSEnumerator that works with any NativeSelfStorage of
+/// An NSEnumerator that works with any NativeSelfBuffer of
 /// verbatim bridgeable elements. Used by the various NSSelf impls.
 final internal class _Native${Self}NSEnumerator<${TypeParameters}>
   : _SwiftNativeNSEnumerator, _NSEnumerator {
 
-  internal typealias Storage = _Native${Self}Storage<${TypeParameters}>
+  internal typealias Buffer = _Native${Self}Buffer<${TypeParameters}>
   internal typealias Index = _Native${Self}Index<${TypeParameters}>
 
   internal override required init() {
     _sanityCheckFailure("don't call this designated initializer")
   }
 
-  internal init(_ storage: Storage) {
-    self.storage = storage
-    nextIndex = storage.startIndex
-    endIndex = storage.endIndex
+  internal init(_ buffer: Buffer) {
+    self.buffer = buffer
+    nextIndex = buffer.startIndex
+    endIndex = buffer.endIndex
   }
 
-  internal var storage: Storage
+  internal var buffer: Buffer
   internal var nextIndex: Index
   internal var endIndex: Index
 
@@ -3446,8 +3446,8 @@ final internal class _Native${Self}NSEnumerator<${TypeParameters}>
     if nextIndex == endIndex {
       return nil
     }
-    let key = storage.bridgedKey(at: nextIndex)
-    storage.formIndex(after: &nextIndex)
+    let key = buffer.bridgedKey(at: nextIndex)
+    buffer.formIndex(after: &nextIndex)
     return key
   }
 
@@ -3471,8 +3471,8 @@ final internal class _Native${Self}NSEnumerator<${TypeParameters}>
 
     // Return only a single element so that code can start iterating via fast
     // enumeration, terminate it, and continue via NSEnumerator.
-    let key = storage.bridgedKey(at: nextIndex)
-    storage.formIndex(after: &nextIndex)
+    let key = buffer.bridgedKey(at: nextIndex)
+    buffer.formIndex(after: &nextIndex)
 
     let unmanagedObjects = _UnmanagedAnyObjectArray(objects)
     unmanagedObjects[0] = key
@@ -3484,15 +3484,15 @@ final internal class _Native${Self}NSEnumerator<${TypeParameters}>
 
 #if _runtime(_ObjC)
 /// This class exists for Objective-C bridging. It holds a reference to a
-/// NativeSelfStorage, and can be upcast to NSSelf when bridging is necessary.
+/// NativeSelfBuffer, and can be upcast to NSSelf when bridging is necessary.
 /// This is the fallback implementation for situations where toll-free bridging
-/// isn't possible. On first access, a NativeSelfStorage of AnyObject will be
+/// isn't possible. On first access, a NativeSelfBuffer of AnyObject will be
 /// constructed containing all the bridged elements.
 final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
   : _SwiftNativeNS${Self}, _NS${Self}Core {
 
-  internal typealias NativeStorage = _Native${Self}Storage<${TypeParameters}>
-  internal typealias BridgedStorage = _Native${Self}Storage<${AnyTypeParameters}>
+  internal typealias NativeBuffer = _Native${Self}Buffer<${TypeParameters}>
+  internal typealias BridgedBuffer = _Native${Self}Buffer<${AnyTypeParameters}>
   internal typealias NativeIndex = _Native${Self}Index<${TypeParameters}>
   internal typealias BridgedIndex = _Native${Self}Index<${AnyTypeParameters}>
 
@@ -3502,12 +3502,12 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
 %end
 
   internal init(minimumCapacity: Int = 2) {
-    nativeStorage = NativeStorage.create(minimumCapacity: minimumCapacity)
+    nativeBuffer = NativeBuffer.create(minimumCapacity: minimumCapacity)
     super.init()
   }
 
-  internal init(nativeStorage: NativeStorage) {
-    self.nativeStorage = nativeStorage
+  internal init(nativeBuffer: NativeBuffer) {
+    self.nativeBuffer = nativeBuffer
     super.init()
   }
 
@@ -3515,10 +3515,10 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
   /// operations on it.
   ///
   /// Do not access this property directly.
-  internal var _heapBufferBridged_DoNotUse: AnyObject?
+  internal var _heapStorageBridged_DoNotUse: AnyObject?
 
   /// The unbridged elements.
-  internal var nativeStorage: NativeStorage
+  internal var nativeBuffer: NativeBuffer
 
   @objc(copyWithZone:)
   internal func copy(with zone: _SwiftNSZone?) -> AnyObject {
@@ -3533,7 +3533,7 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
   // NSSet implementation.
   //
   // Do not call any of these methods from the standard library!  Use only
-  // `nativeStorage`.
+  // `nativeBuffer`.
   //
 
   @objc
@@ -3556,7 +3556,7 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
   // NSDictionary implementation.
   //
   // Do not call any of these methods from the standard library!  Use only
-  // `nativeStorage`.
+  // `nativeBuffer`.
   //
 
   @objc
@@ -3589,66 +3589,66 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
 
   /// Returns the pointer to the stored property, which contains bridged
   /// ${Self} elements.
-  internal var _heapBufferBridgedPtr: UnsafeMutablePointer<AnyObject?> {
+  internal var _heapStorageBridgedPtr: UnsafeMutablePointer<AnyObject?> {
     return _getUnsafePointerToStoredProperties(self).assumingMemoryBound(
       to: Optional<AnyObject>.self)
   }
 
-  /// The storage for bridged ${Self} elements, if present.
-  internal var _bridgedBuffer:
-    BridgedStorage.RawBuffer? {
+  /// The buffer for bridged ${Self} elements, if present.
+  internal var _bridgedStorage:
+    BridgedBuffer.RawStorage? {
     get {
-      if let ref = _stdlib_atomicLoadARCRef(object: _heapBufferBridgedPtr) {
-        return unsafeDowncast(ref, to: BridgedStorage.RawBuffer.self)
+      if let ref = _stdlib_atomicLoadARCRef(object: _heapStorageBridgedPtr) {
+        return unsafeDowncast(ref, to: BridgedBuffer.RawStorage.self)
       }
       return nil
     }
   }
 
-  /// Attach a storage for bridged ${Self} elements.
-  internal func _initializeHeapBufferBridged(_ newBuffer: AnyObject) {
+  /// Attach a buffer for bridged ${Self} elements.
+  internal func _initializeHeapStorageBridged(_ newStorage: AnyObject) {
     _stdlib_atomicInitializeARCRef(
-      object: _heapBufferBridgedPtr, desired: newBuffer)
+      object: _heapStorageBridgedPtr, desired: newStorage)
   }
 
-  /// Detach the storage of bridged ${Self} elements.
+  /// Detach the buffer of bridged ${Self} elements.
   ///
-  /// Call this before mutating the ${Self} storage owned by this owner.
-  internal func deinitializeHeapBufferBridged() {
-    // Perform a non-atomic store because storage should be
+  /// Call this before mutating the ${Self} buffer owned by this owner.
+  internal func deinitializeHeapStorageBridged() {
+    // Perform a non-atomic store because buffer should be
     // uniquely-referenced.
-    _heapBufferBridgedPtr.pointee = nil
+    _heapStorageBridgedPtr.pointee = nil
   }
 
   /// Returns the bridged ${Self} values.
-  internal var bridgedStorage: BridgedStorage {
-    return BridgedStorage(_buffer: _bridgedBuffer!)
+  internal var bridgedBuffer: BridgedBuffer {
+    return BridgedBuffer(_storage: _bridgedStorage!)
   }
 
   internal func bridgeEverything() {
-    if _fastPath(_bridgedBuffer != nil) {
+    if _fastPath(_bridgedStorage != nil) {
       return
     }
 
-    // Create storage for bridged data.
-    let bridged = BridgedStorage.createUnhashable(
-      capacity: nativeStorage._capacity)
+    // Create buffer for bridged data.
+    let bridged = BridgedBuffer.createUnhashable(
+      capacity: nativeBuffer._capacity)
 
     // Bridge everything.
-    for i in 0..<nativeStorage._capacity {
-      if nativeStorage.isInitializedEntry(at: i) {
-        let key = _bridgeAnythingToObjectiveC(nativeStorage.key(at: i))
+    for i in 0..<nativeBuffer._capacity {
+      if nativeBuffer.isInitializedEntry(at: i) {
+        let key = _bridgeAnythingToObjectiveC(nativeBuffer.key(at: i))
 %if Self == 'Set':
         bridged.initializeKey(key, at: i)
 %elif Self == 'Dictionary':
-        let val = _bridgeAnythingToObjectiveC(nativeStorage.value(at: i))
+        let val = _bridgeAnythingToObjectiveC(nativeBuffer.value(at: i))
         bridged.initializeKey(key, value: val, at: i)
 %end
       }
     }
 
     // Atomically put the bridged elements in place.
-    _initializeHeapBufferBridged(bridged._buffer)
+    _initializeHeapStorageBridged(bridged._storage)
   }
 
 %if Self == 'Dictionary':
@@ -3658,25 +3658,25 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
     _ keys: UnsafeMutablePointer<AnyObject>?
   ) {
     bridgeEverything()
-    // The user is expected to provide a buffer of the correct size
-    var i = 0 // Position in the input buffer
-    let capacity = nativeStorage._capacity
+    // The user is expected to provide a storage of the correct size
+    var i = 0 // Position in the input storage
+    let capacity = nativeBuffer._capacity
 
     if let unmanagedKeys = _UnmanagedAnyObjectArray(keys) {
       if let unmanagedObjects = _UnmanagedAnyObjectArray(objects) {
         // keys nonnull, objects nonnull
         for position in 0..<capacity {
-          if bridgedStorage.isInitializedEntry(at: position) {
-            unmanagedObjects[i] = bridgedStorage.value(at: position)
-            unmanagedKeys[i] = bridgedStorage.key(at: position)
+          if bridgedBuffer.isInitializedEntry(at: position) {
+            unmanagedObjects[i] = bridgedBuffer.value(at: position)
+            unmanagedKeys[i] = bridgedBuffer.key(at: position)
             i += 1
           }
         }
       } else {
         // keys nonnull, objects null
         for position in 0..<capacity {
-          if bridgedStorage.isInitializedEntry(at: position) {
-            unmanagedKeys[i] = bridgedStorage.key(at: position)
+          if bridgedBuffer.isInitializedEntry(at: position) {
+            unmanagedKeys[i] = bridgedBuffer.key(at: position)
             i += 1
           }
         }
@@ -3685,8 +3685,8 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
       if let unmanagedObjects = _UnmanagedAnyObjectArray(objects) {
         // keys null, objects nonnull
         for position in 0..<capacity {
-          if bridgedStorage.isInitializedEntry(at: position) {
-            unmanagedObjects[i] = bridgedStorage.value(at: position)
+          if bridgedBuffer.isInitializedEntry(at: position) {
+            unmanagedObjects[i] = bridgedBuffer.value(at: position)
             i += 1
           }
         }
@@ -3700,7 +3700,7 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
 
   @objc
   internal var count: Int {
-    return nativeStorage._count
+    return nativeBuffer._count
   }
 
   internal func bridgingObjectForKey(_ aKey: AnyObject)
@@ -3708,18 +3708,18 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
     guard let nativeKey = _conditionallyBridgeFromObjectiveC(aKey, Key.self)
     else { return nil }
 
-    let (i, found) = nativeStorage._find(
-      nativeKey, startBucket: nativeStorage._bucket(nativeKey))
+    let (i, found) = nativeBuffer._find(
+      nativeKey, startBucket: nativeBuffer._bucket(nativeKey))
     if found {
       bridgeEverything()
-      return bridgedStorage.value(at: i.offset)
+      return bridgedBuffer.value(at: i.offset)
     }
     return nil
   }
 
   internal func enumerator() -> _NSEnumerator {
     bridgeEverything()
-    return _Native${Self}NSEnumerator<${AnyTypeParameters}>(bridgedStorage)
+    return _Native${Self}NSEnumerator<${AnyTypeParameters}>(bridgedBuffer)
   }
 
   @objc(countByEnumeratingWithState:objects:count:)
@@ -3733,7 +3733,7 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
       theState.state = 1 // Arbitrary non-zero value.
       theState.itemsPtr = AutoreleasingUnsafeMutablePointer(objects)
       theState.mutationsPtr = _fastEnumerationStorageMutationsPtr
-      theState.extra.0 = CUnsignedLong(nativeStorage.startIndex.offset)
+      theState.extra.0 = CUnsignedLong(nativeBuffer.startIndex.offset)
     }
 
     // Test 'objects' rather than 'count' because (a) this is very rare anyway,
@@ -3746,7 +3746,7 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
     let unmanagedObjects = _UnmanagedAnyObjectArray(objects!)
     var currIndex = _Native${Self}Index<${TypeParameters}>(
         offset: Int(theState.extra.0))
-    let endIndex = nativeStorage.endIndex
+    let endIndex = nativeBuffer.endIndex
     var stored = 0
 
     // Only need to bridge once, so we can hoist it out of the loop.
@@ -3759,10 +3759,10 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
         break
       }
 
-      let bridgedKey = bridgedStorage.key(at: currIndex.offset)
+      let bridgedKey = bridgedBuffer.key(at: currIndex.offset)
       unmanagedObjects[i] = bridgedKey
       stored += 1
-      nativeStorage.formIndex(after: &currIndex)
+      nativeBuffer.formIndex(after: &currIndex)
     }
     theState.extra.0 = CUnsignedLong(currIndex.offset)
     state.pointee = theState
@@ -3776,7 +3776,7 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}> { }
 #if _runtime(_ObjC)
 @_versioned
 @_fixed_layout
-internal final class _Cocoa${Self}Storage : _HashStorage {
+internal final class _Cocoa${Self}Buffer : _HashBuffer {
   @_versioned
   internal var cocoa${Self}: _NS${Self}
 
@@ -3907,33 +3907,33 @@ internal final class _Cocoa${Self}Storage : _HashStorage {
   }
 
   internal static func fromArray(_ elements: [SequenceElementWithoutLabels])
-    -> _Cocoa${Self}Storage {
+    -> _Cocoa${Self}Buffer {
 
     _sanityCheckFailure("this function should never be called")
   }
 }
 #else
-internal struct _Cocoa${Self}Storage {}
+internal struct _Cocoa${Self}Buffer {}
 #endif
 
 @_versioned
 @_fixed_layout
-internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
+internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
 
-  internal typealias NativeStorage = _Native${Self}Storage<${TypeParameters}>
+  internal typealias NativeBuffer = _Native${Self}Buffer<${TypeParameters}>
   internal typealias NativeIndex = _Native${Self}Index<${TypeParameters}>
-  internal typealias CocoaStorage = _Cocoa${Self}Storage
+  internal typealias CocoaBuffer = _Cocoa${Self}Buffer
   internal typealias SequenceElement = ${Sequence}
   internal typealias SequenceElementWithoutLabels = ${Sequence}
-  internal typealias SelfType = _Variant${Self}Storage
+  internal typealias SelfType = _Variant${Self}Buffer
 
 %if Self == 'Set':
   internal typealias Key = ${TypeParameters}
   internal typealias Value = ${TypeParameters}
 %end
 
-  case native(NativeStorage)
-  case cocoa(CocoaStorage)
+  case native(NativeBuffer)
+  case cocoa(CocoaBuffer)
 
   @_versioned
   @_transparent
@@ -3942,8 +3942,8 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
   }
 
   internal mutating func isUniquelyReferenced() -> Bool {
-    // Note that &self drills down through .native(NativeStorage) to the first
-    // property in NativeStorage, which is the reference to the buffer.
+    // Note that &self drills down through .native(NativeBuffer) to the first
+    // property in NativeBuffer, which is the reference to the storage.
     if _fastPath(guaranteedNative) {
       return _isUnique_native(&self)
     }
@@ -3952,20 +3952,20 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
     case .native:
       return _isUnique_native(&self)
     case .cocoa:
-      // Don't consider Cocoa storage mutable, even if it is mutable and is
+      // Don't consider Cocoa buffer mutable, even if it is mutable and is
       // uniquely referenced.
       return false
     }
   }
 
   @_versioned
-  internal var asNative: NativeStorage {
+  internal var asNative: NativeBuffer {
     get {
       switch self {
-      case .native(let storage):
-        return storage
+      case .native(let buffer):
+        return buffer
       case .cocoa:
-        _sanityCheckFailure("internal error: not backed by native storage")
+        _sanityCheckFailure("internal error: not backed by native buffer")
       }
     }
     set {
@@ -3974,19 +3974,19 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
   }
 
 #if _runtime(_ObjC)
-  internal var asCocoa: CocoaStorage {
+  internal var asCocoa: CocoaBuffer {
     switch self {
     case .native:
       _sanityCheckFailure("internal error: not backed by NS${Self}")
-    case .cocoa(let cocoaStorage):
-      return cocoaStorage
+    case .cocoa(let cocoaBuffer):
+      return cocoaBuffer
     }
   }
 #endif
 
-  /// Ensure this we hold a unique reference to a native storage
+  /// Ensure this we hold a unique reference to a native buffer
   /// having at least `minimumCapacity` elements.
-  internal mutating func ensureUniqueNativeStorage(_ minimumCapacity: Int)
+  internal mutating func ensureUniqueNativeBuffer(_ minimumCapacity: Int)
     -> (reallocated: Bool, capacityChanged: Bool) {
     switch self {
     case .native:
@@ -3995,60 +3995,60 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
         return (reallocated: false, capacityChanged: false)
       }
 
-      let oldNativeStorage = asNative
-      var newNativeStorage = NativeStorage.create(minimumCapacity: minimumCapacity)
-      let newCapacity = newNativeStorage._capacity
+      let oldNativeBuffer = asNative
+      var newNativeBuffer = NativeBuffer.create(minimumCapacity: minimumCapacity)
+      let newCapacity = newNativeBuffer._capacity
       for i in 0..<oldCapacity {
-        if oldNativeStorage.isInitializedEntry(at: i) {
+        if oldNativeBuffer.isInitializedEntry(at: i) {
           if oldCapacity == newCapacity {
-            let key = oldNativeStorage.key(at: i)
+            let key = oldNativeBuffer.key(at: i)
 %if Self == 'Set':
-            newNativeStorage.initializeKey(key, at: i)
+            newNativeBuffer.initializeKey(key, at: i)
 %elif Self == 'Dictionary':
-            let value = oldNativeStorage.value(at: i)
-            newNativeStorage.initializeKey(key, value: value , at: i)
+            let value = oldNativeBuffer.value(at: i)
+            newNativeBuffer.initializeKey(key, value: value , at: i)
 %end
           } else {
-            let key = oldNativeStorage.key(at: i)
+            let key = oldNativeBuffer.key(at: i)
 %if Self == 'Set':
-            newNativeStorage.unsafeAddNew(key: key)
+            newNativeBuffer.unsafeAddNew(key: key)
 %elif Self == 'Dictionary':
-            newNativeStorage.unsafeAddNew(
+            newNativeBuffer.unsafeAddNew(
               key: key,
-              value: oldNativeStorage.value(at: i))
+              value: oldNativeBuffer.value(at: i))
 %end
           }
         }
       }
-      newNativeStorage._count = oldNativeStorage._count
+      newNativeBuffer._count = oldNativeBuffer._count
 
-      self = .native(newNativeStorage)
+      self = .native(newNativeBuffer)
       return (reallocated: true,
-              capacityChanged: oldCapacity != newNativeStorage._capacity)
+              capacityChanged: oldCapacity != newNativeBuffer._capacity)
 
-    case .cocoa(let cocoaStorage):
+    case .cocoa(let cocoaBuffer):
 #if _runtime(_ObjC)
-      let cocoa${Self} = cocoaStorage.cocoa${Self}
-      var newNativeStorage = NativeStorage.create(minimumCapacity: minimumCapacity)
+      let cocoa${Self} = cocoaBuffer.cocoa${Self}
+      var newNativeBuffer = NativeBuffer.create(minimumCapacity: minimumCapacity)
       let oldCocoaIterator = _Cocoa${Self}Iterator(cocoa${Self})
 %if Self == 'Set':
       while let key = oldCocoaIterator.next() {
-        newNativeStorage.unsafeAddNew(
+        newNativeBuffer.unsafeAddNew(
             key: _forceBridgeFromObjectiveC(key, Value.self))
       }
 
 %elif Self == 'Dictionary':
 
       while let (key, value) = oldCocoaIterator.next() {
-        newNativeStorage.unsafeAddNew(
+        newNativeBuffer.unsafeAddNew(
           key: _forceBridgeFromObjectiveC(key, Key.self),
           value: _forceBridgeFromObjectiveC(value, Value.self))
       }
 
 %end
-      newNativeStorage._count = cocoa${Self}.count
+      newNativeBuffer._count = cocoa${Self}.count
 
-      self = .native(newNativeStorage)
+      self = .native(newNativeBuffer)
       return (reallocated: true, capacityChanged: true)
 #else
       _sanityCheckFailure("internal error: unexpected cocoa ${Self}")
@@ -4058,19 +4058,19 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
 
 #if _runtime(_ObjC)
   @inline(never)
-  internal mutating func migrateDataToNativeStorage(
-    _ cocoaStorage: _Cocoa${Self}Storage
+  internal mutating func migrateDataToNativeBuffer(
+    _ cocoaBuffer: _Cocoa${Self}Buffer
   ) {
-    let minCapacity = NativeStorage.minimumCapacity(
-      minimumCount: cocoaStorage.count,
+    let minCapacity = NativeBuffer.minimumCapacity(
+      minimumCount: cocoaBuffer.count,
       maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
-    let allocated = ensureUniqueNativeStorage(minCapacity).reallocated
-    _sanityCheck(allocated, "failed to allocate native ${Self} storage")
+    let allocated = ensureUniqueNativeBuffer(minCapacity).reallocated
+    _sanityCheck(allocated, "failed to allocate native ${Self} buffer")
   }
 #endif
 
   //
-  // _HashStorage conformance
+  // _HashBuffer conformance
   //
 
   internal typealias Index = ${Self}Index<${TypeParameters}>
@@ -4083,9 +4083,9 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
     switch self {
     case .native:
       return ._native(asNative.startIndex)
-    case .cocoa(let cocoaStorage):
+    case .cocoa(let cocoaBuffer):
 #if _runtime(_ObjC)
-      return ._cocoa(cocoaStorage.startIndex)
+      return ._cocoa(cocoaBuffer.startIndex)
 #else
       _sanityCheckFailure("internal error: unexpected cocoa ${Self}")
 #endif
@@ -4100,9 +4100,9 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
     switch self {
     case .native:
       return ._native(asNative.endIndex)
-    case .cocoa(let cocoaStorage):
+    case .cocoa(let cocoaBuffer):
 #if _runtime(_ObjC)
-      return ._cocoa(cocoaStorage.endIndex)
+      return ._cocoa(cocoaBuffer.endIndex)
 #else
       _sanityCheckFailure("internal error: unexpected cocoa ${Self}")
 #endif
@@ -4118,9 +4118,9 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
     switch self {
     case .native:
       return ._native(asNative.index(after: i._nativeIndex))
-    case .cocoa(let cocoaStorage):
+    case .cocoa(let cocoaBuffer):
 #if _runtime(_ObjC)
-      return ._cocoa(cocoaStorage.index(after: i._cocoaIndex))
+      return ._cocoa(cocoaBuffer.index(after: i._cocoaIndex))
 #else
       _sanityCheckFailure("internal error: unexpected cocoa ${Self}")
 #endif
@@ -4148,10 +4148,10 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
         return ._native(nativeIndex)
       }
       return nil
-    case .cocoa(let cocoaStorage):
+    case .cocoa(let cocoaBuffer):
 #if _runtime(_ObjC)
       let anyObjectKey: AnyObject = _bridgeAnythingToObjectiveC(key)
-      if let cocoaIndex = cocoaStorage.index(forKey: anyObjectKey) {
+      if let cocoaIndex = cocoaBuffer.index(forKey: anyObjectKey) {
         return ._cocoa(cocoaIndex)
       }
       return nil
@@ -4169,15 +4169,15 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
     switch self {
     case .native:
       return asNative.assertingGet(i._nativeIndex)
-    case .cocoa(let cocoaStorage):
+    case .cocoa(let cocoaBuffer):
 #if _runtime(_ObjC)
 %if Self == 'Set':
-      let anyObjectValue: AnyObject = cocoaStorage.assertingGet(i._cocoaIndex)
+      let anyObjectValue: AnyObject = cocoaBuffer.assertingGet(i._cocoaIndex)
       let nativeValue = _forceBridgeFromObjectiveC(anyObjectValue, Value.self)
       return nativeValue
 %elif Self == 'Dictionary':
       let (anyObjectKey, anyObjectValue) =
-          cocoaStorage.assertingGet(i._cocoaIndex)
+          cocoaBuffer.assertingGet(i._cocoaIndex)
       let nativeKey = _forceBridgeFromObjectiveC(anyObjectKey, Key.self)
       let nativeValue = _forceBridgeFromObjectiveC(anyObjectValue, Value.self)
       return (nativeKey, nativeValue)
@@ -4196,11 +4196,11 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
     switch self {
     case .native:
       return asNative.assertingGet(key)
-    case .cocoa(let cocoaStorage):
+    case .cocoa(let cocoaBuffer):
 #if _runtime(_ObjC)
       // FIXME: This assumes that Key and Value are bridged verbatim.
       let anyObjectKey: AnyObject = _bridgeAnythingToObjectiveC(key)
-      let anyObjectValue: AnyObject = cocoaStorage.assertingGet(anyObjectKey)
+      let anyObjectValue: AnyObject = cocoaBuffer.assertingGet(anyObjectKey)
       return _forceBridgeFromObjectiveC(anyObjectValue, Value.self)
 #else
       _sanityCheckFailure("internal error: unexpected cocoa ${Self}")
@@ -4211,11 +4211,11 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
 #if _runtime(_ObjC)
   @_versioned
   @inline(never)
-  internal static func maybeGetFromCocoaStorage(
-    _ cocoaStorage : CocoaStorage, forKey key: Key
+  internal static func maybeGetFromCocoaBuffer(
+    _ cocoaBuffer : CocoaBuffer, forKey key: Key
   ) -> Value? {
     let anyObjectKey: AnyObject = _bridgeAnythingToObjectiveC(key)
-    if let anyObjectValue = cocoaStorage.maybeGet(anyObjectKey) {
+    if let anyObjectValue = cocoaBuffer.maybeGet(anyObjectKey) {
       return _forceBridgeFromObjectiveC(anyObjectValue, Value.self)
     }
     return nil
@@ -4232,9 +4232,9 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
     switch self {
     case .native:
       return asNative.maybeGet(key)
-    case .cocoa(let cocoaStorage):
+    case .cocoa(let cocoaBuffer):
 #if _runtime(_ObjC)
-      return SelfType.maybeGetFromCocoaStorage(cocoaStorage, forKey: key)
+      return SelfType.maybeGetFromCocoaBuffer(cocoaBuffer, forKey: key)
 #else
       _sanityCheckFailure("internal error: unexpected cocoa ${Self}")
 #endif
@@ -4248,11 +4248,11 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
 
     let minCapacity = found
       ? asNative._capacity
-      : NativeStorage.minimumCapacity(
+      : NativeBuffer.minimumCapacity(
           minimumCount: asNative._count + 1,
           maxLoadFactorInverse: asNative._maxLoadFactorInverse)
 
-    let (_, capacityChanged) = ensureUniqueNativeStorage(minCapacity)
+    let (_, capacityChanged) = ensureUniqueNativeBuffer(minCapacity)
     if capacityChanged {
       i = asNative._find(key, startBucket: asNative._bucket(key)).pos
     }
@@ -4290,9 +4290,9 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
     switch self {
     case .native:
       return nativeUpdateValue(value, forKey: key)
-    case .cocoa(let cocoaStorage):
+    case .cocoa(let cocoaBuffer):
 #if _runtime(_ObjC)
-      migrateDataToNativeStorage(cocoaStorage)
+      migrateDataToNativeBuffer(cocoaBuffer)
       return nativeUpdateValue(value, forKey: key)
 #else
       _sanityCheckFailure("internal error: unexpected cocoa ${Self}")
@@ -4313,11 +4313,11 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
 %end
     }
 
-    let minCapacity = NativeStorage.minimumCapacity(
+    let minCapacity = NativeBuffer.minimumCapacity(
       minimumCount: asNative._count + 1,
       maxLoadFactorInverse: asNative._maxLoadFactorInverse)
 
-    let (_, capacityChanged) = ensureUniqueNativeStorage(minCapacity)
+    let (_, capacityChanged) = ensureUniqueNativeBuffer(minCapacity)
 
     if capacityChanged {
       i = asNative._find(key, startBucket: asNative._bucket(key)).pos
@@ -4346,9 +4346,9 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
     switch self {
     case .native:
       return nativeInsert(value, forKey: key)
-    case .cocoa(let cocoaStorage):
+    case .cocoa(let cocoaBuffer):
 #if _runtime(_ObjC)
-      migrateDataToNativeStorage(cocoaStorage)
+      migrateDataToNativeBuffer(cocoaBuffer)
       return nativeInsert(value, forKey: key)
 #else
       _sanityCheckFailure("internal error: unexpected cocoa ${Self}")
@@ -4360,16 +4360,16 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
   /// - parameter offset: The offset of the element that will be deleted.
   /// Precondition: there should be an initialized entry at offset.
   internal mutating func nativeDelete(
-    _ nativeStorage: NativeStorage, idealBucket: Int, offset: Int
+    _ nativeBuffer: NativeBuffer, idealBucket: Int, offset: Int
   ) {
     _sanityCheck(
-        nativeStorage.isInitializedEntry(at: offset), "expected initialized entry")
+        nativeBuffer.isInitializedEntry(at: offset), "expected initialized entry")
 
-    var nativeStorage = nativeStorage
+    var nativeBuffer = nativeBuffer
 
     // remove the element
-    nativeStorage.destroyEntry(at: offset)
-    nativeStorage._count -= 1
+    nativeBuffer.destroyEntry(at: offset)
+    nativeBuffer._count -= 1
 
     // If we've put a hole in a chain of contiguous elements, some
     // element after the hole may belong where the new hole is.
@@ -4377,16 +4377,16 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
 
     // Find the first bucket in the contiguous chain
     var start = idealBucket
-    while nativeStorage.isInitializedEntry(at: nativeStorage._prev(start)) {
-      start = nativeStorage._prev(start)
+    while nativeBuffer.isInitializedEntry(at: nativeBuffer._prev(start)) {
+      start = nativeBuffer._prev(start)
     }
 
     // Find the last bucket in the contiguous chain
     var lastInChain = hole
-    var b = nativeStorage._index(after: lastInChain)
-    while nativeStorage.isInitializedEntry(at: b) {
+    var b = nativeBuffer._index(after: lastInChain)
+    while nativeBuffer.isInitializedEntry(at: b) {
       lastInChain = b
-      b = nativeStorage._index(after: b)
+      b = nativeBuffer._index(after: b)
     }
 
     // Relocate out-of-place elements in the chain, repeating until
@@ -4396,17 +4396,17 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
       // something out-of-place.
       var b = lastInChain
       while b != hole {
-        let idealBucket = nativeStorage._bucket(nativeStorage.key(at: b))
+        let idealBucket = nativeBuffer._bucket(nativeBuffer.key(at: b))
 
         // Does this element belong between start and hole?  We need
         // two separate tests depending on whether [start, hole] wraps
-        // around the end of the buffer
+        // around the end of the storage
         let c0 = idealBucket >= start
         let c1 = idealBucket <= hole
         if start <= hole ? (c0 && c1) : (c0 || c1) {
           break // Found it
         }
-        b = nativeStorage._prev(b)
+        b = nativeBuffer._prev(b)
       }
 
       if b == hole { // No out-of-place elements found; we're done adjusting
@@ -4414,8 +4414,8 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
       }
 
       // Move the found element into the hole
-      nativeStorage.moveInitializeEntry(
-        from: nativeStorage,
+      nativeBuffer.moveInitializeEntry(
+        from: nativeBuffer,
         at: b,
         toEntryAt: hole)
       hole = b
@@ -4427,25 +4427,25 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
     var (index, found) = asNative._find(key, startBucket: idealBucket)
 
     // Fast path: if the key is not present, we will not mutate the set,
-    // so don't force unique storage.
+    // so don't force unique buffer.
     if !found {
       return nil
     }
 
     let (_, capacityChanged) =
-      ensureUniqueNativeStorage(asNative._capacity)
-    let nativeStorage = asNative
+      ensureUniqueNativeBuffer(asNative._capacity)
+    let nativeBuffer = asNative
     if capacityChanged {
-      idealBucket = nativeStorage._bucket(key)
-      (index, found) = nativeStorage._find(key, startBucket: idealBucket)
-      _sanityCheck(found, "key was lost during storage migration")
+      idealBucket = nativeBuffer._bucket(key)
+      (index, found) = nativeBuffer._find(key, startBucket: idealBucket)
+      _sanityCheck(found, "key was lost during buffer migration")
     }
 %if Self == 'Set':
-    let oldValue = nativeStorage.key(at: index.offset)
+    let oldValue = nativeBuffer.key(at: index.offset)
 %elif Self == 'Dictionary':
-    let oldValue = nativeStorage.value(at: index.offset)
+    let oldValue = nativeBuffer.value(at: index.offset)
 %end
-    nativeDelete(nativeStorage, idealBucket: idealBucket,
+    nativeDelete(nativeBuffer, idealBucket: idealBucket,
       offset: index.offset)
     return oldValue
   }
@@ -4455,18 +4455,18 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
   ) -> SequenceElement {
 
     // The provided index should be valid, so we will always mutating the
-    // set storage.  Request unique storage.
-    _ = ensureUniqueNativeStorage(asNative._capacity)
-    let nativeStorage = asNative
+    // set buffer.  Request unique buffer.
+    _ = ensureUniqueNativeBuffer(asNative._capacity)
+    let nativeBuffer = asNative
 
-    let result = nativeStorage.assertingGet(nativeIndex)
+    let result = nativeBuffer.assertingGet(nativeIndex)
 %if Self == 'Set':
     let key = result
 %elif Self == 'Dictionary':
     let key = result.0
 %end
 
-    nativeDelete(nativeStorage, idealBucket: nativeStorage._bucket(key),
+    nativeDelete(nativeBuffer, idealBucket: nativeBuffer._bucket(key),
         offset: nativeIndex.offset)
     return result
   }
@@ -4480,7 +4480,7 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
     switch self {
     case .native:
       return nativeRemove(at: index._nativeIndex)
-    case .cocoa(let cocoaStorage):
+    case .cocoa(let cocoaBuffer):
 #if _runtime(_ObjC)
       // We have to migrate the data first.  But after we do so, the Cocoa
       // index becomes useless, so get the key first.
@@ -4489,8 +4489,8 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
       // operation.
       let cocoaIndex = index._cocoaIndex
       let anyObjectKey: AnyObject =
-        cocoaStorage.allKeys._value[cocoaIndex.currentKeyIndex]
-      migrateDataToNativeStorage(cocoaStorage)
+        cocoaBuffer.allKeys._value[cocoaIndex.currentKeyIndex]
+      migrateDataToNativeBuffer(cocoaBuffer)
       let key = _forceBridgeFromObjectiveC(anyObjectKey, Key.self)
       let value = nativeRemoveObject(forKey: key)
 
@@ -4515,13 +4515,13 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
     switch self {
     case .native:
       return nativeRemoveObject(forKey: key)
-    case .cocoa(let cocoaStorage):
+    case .cocoa(let cocoaBuffer):
 #if _runtime(_ObjC)
       let anyObjectKey: AnyObject = _bridgeAnythingToObjectiveC(key)
-      if cocoaStorage.maybeGet(anyObjectKey) == nil {
+      if cocoaBuffer.maybeGet(anyObjectKey) == nil {
         return nil
       }
-      migrateDataToNativeStorage(cocoaStorage)
+      migrateDataToNativeBuffer(cocoaBuffer)
       return nativeRemoveObject(forKey: key)
 #else
       _sanityCheckFailure("internal error: unexpected cocoa ${Self}")
@@ -4530,22 +4530,22 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
   }
 
   internal mutating func nativeRemoveAll() {
-    // FIXME(performance): if the storage is non-uniquely referenced, we
-    // shouldn't be copying the elements into new storage and then immediately
-    // deleting the elements. We should detect that the storage is not uniquely
-    // referenced and allocate new empty storage of appropriate capacity.
+    // FIXME(performance): if the buffer is non-uniquely referenced, we
+    // shouldn't be copying the elements into new buffer and then immediately
+    // deleting the elements. We should detect that the buffer is not uniquely
+    // referenced and allocate new empty buffer of appropriate capacity.
 
     // We have already checked for the empty dictionary case, so we will always
-    // mutating the dictionary storage.  Request unique storage.
-    _ = ensureUniqueNativeStorage(asNative._capacity)
-    var nativeStorage = asNative
+    // mutating the dictionary buffer.  Request unique buffer.
+    _ = ensureUniqueNativeBuffer(asNative._capacity)
+    var nativeBuffer = asNative
 
-    for b in 0..<nativeStorage._capacity {
-      if nativeStorage.isInitializedEntry(at: b) {
-        nativeStorage.destroyEntry(at: b)
+    for b in 0..<nativeBuffer._capacity {
+      if nativeBuffer.isInitializedEntry(at: b) {
+        nativeBuffer.destroyEntry(at: b)
       }
     }
-    nativeStorage._count = 0
+    nativeBuffer._count = 0
   }
 
   internal mutating func removeAll(keepingCapacity keepCapacity: Bool) {
@@ -4554,7 +4554,7 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
     }
 
     if !keepCapacity {
-      self = .native(NativeStorage.create(minimumCapacity: 2))
+      self = .native(NativeBuffer.create(minimumCapacity: 2))
       return
     }
 
@@ -4566,9 +4566,9 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
     switch self {
     case .native:
       nativeRemoveAll()
-    case .cocoa(let cocoaStorage):
+    case .cocoa(let cocoaBuffer):
 #if _runtime(_ObjC)
-      self = .native(NativeStorage.create(minimumCapacity: cocoaStorage.count))
+      self = .native(NativeBuffer.create(minimumCapacity: cocoaBuffer.count))
 #else
       _sanityCheckFailure("internal error: unexpected cocoa ${Self}")
 #endif
@@ -4583,9 +4583,9 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
     switch self {
     case .native:
       return asNative._count
-    case .cocoa(let cocoaStorage):
+    case .cocoa(let cocoaBuffer):
 #if _runtime(_ObjC)
-      return cocoaStorage.count
+      return cocoaBuffer.count
 #else
       _sanityCheckFailure("internal error: unexpected cocoa ${Self}")
 #endif
@@ -4599,12 +4599,12 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
   @inline(__always)
   internal func makeIterator() -> ${Self}Iterator<${TypeParameters}> {
     switch self {
-    case .native(let storage):
+    case .native(let buffer):
       return ._native(
-        start: asNative.startIndex, end: asNative.endIndex, storage: storage)
-    case .cocoa(let cocoaStorage):
+        start: asNative.startIndex, end: asNative.endIndex, buffer: buffer)
+    case .cocoa(let cocoaBuffer):
 #if _runtime(_ObjC)
-      return ._cocoa(_Cocoa${Self}Iterator(cocoaStorage.cocoa${Self}))
+      return ._cocoa(_Cocoa${Self}Iterator(cocoaBuffer.cocoa${Self}))
 #else
       _sanityCheckFailure("internal error: unexpected cocoa ${Self}")
 #endif
@@ -4612,7 +4612,7 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
   }
 
   internal static func fromArray(_ elements: [SequenceElement])
-    -> _Variant${Self}Storage<${TypeParameters}> {
+    -> _Variant${Self}Buffer<${TypeParameters}> {
 
     _sanityCheckFailure("this function should never be called")
   }
@@ -4710,7 +4710,7 @@ public struct ${Self}Index<${TypeParametersDecl}> :
   // be nested types (Dictionary.Index and Set.Index).
   // rdar://problem/17002096
 
-  // Index for native storage is efficient.  Index for bridged NS${Self} is
+  // Index for native buffer is efficient.  Index for bridged NS${Self} is
   // not, because neither NSEnumerator nor fast enumeration support moving
   // backwards.  Even if they did, there is another issue: NSEnumerator does
   // not support NSCopying, and fast enumeration does not document that it is
@@ -4846,7 +4846,7 @@ final internal class _Cocoa${Self}Iterator : IteratorProtocol {
   }
 
   // These members have to be word-sized integers, they cannot be limited to
-  // Int8 just because our buffer holds 16 elements: fast enumeration is
+  // Int8 just because our storage holds 16 elements: fast enumeration is
   // allowed to return inner pointers to the container, which can be much
   // larger.
   internal var itemIndex: Int = 0
@@ -4866,7 +4866,7 @@ final internal class _Cocoa${Self}Iterator : IteratorProtocol {
     if itemIndex == itemCount {
       let stackBufCount = _fastEnumerationStackBuf.count
       // We can't use `withUnsafeMutablePointer` here to get pointers to
-      // properties, because doing so might introduce a writeback buffer, but
+      // properties, because doing so might introduce a writeback storage, but
       // fast enumeration relies on the pointer identity of the enumeration
       // state struct.
       itemCount = cocoa${Self}.countByEnumerating(
@@ -4901,18 +4901,18 @@ final internal class _Cocoa${Self}Iterator {}
 @_versioned
 internal enum ${Self}IteratorRepresentation<${TypeParametersDecl}> {
   internal typealias _Iterator = ${Self}Iterator<${TypeParameters}>
-  internal typealias _NativeStorage =
-    _Native${Self}Storage<${TypeParameters}>
+  internal typealias _NativeBuffer =
+    _Native${Self}Buffer<${TypeParameters}>
   internal typealias _NativeIndex = _Iterator._NativeIndex
 
-  // For native storage, we keep two indices to keep track of the iteration
-  // progress and the storage owner to make the storage non-uniquely
+  // For native buffer, we keep two indices to keep track of the iteration
+  // progress and the buffer owner to make the buffer non-uniquely
   // referenced.
   //
   // Iterator is iterating over a frozen view of the collection
-  // state, so it should keep its own reference to the storage.
+  // state, so it should keep its own reference to the buffer.
   case _native(
-    start: _NativeIndex, end: _NativeIndex, storage: _NativeStorage)
+    start: _NativeIndex, end: _NativeIndex, buffer: _NativeBuffer)
   case _cocoa(_Cocoa${Self}Iterator)
 }
 
@@ -4921,15 +4921,15 @@ public struct ${Self}Iterator<${TypeParametersDecl}> : IteratorProtocol {
   // ${Self} has a separate IteratorProtocol and Index because of efficiency
   // and implementability reasons.
   //
-  // Index for native storage is efficient.  Index for bridged NS${Self} is
+  // Index for native buffer is efficient.  Index for bridged NS${Self} is
   // not.
   //
   // Even though fast enumeration is not suitable for implementing
   // Index, which is multi-pass, it is suitable for implementing a
   // IteratorProtocol, which is being consumed as iteration proceeds.
 
-  internal typealias _NativeStorage =
-    _Native${Self}Storage<${TypeParameters}>
+  internal typealias _NativeBuffer =
+    _Native${Self}Buffer<${TypeParameters}>
   internal typealias _NativeIndex = _Native${Self}Index<${TypeParameters}>
 
   @_versioned
@@ -4937,10 +4937,10 @@ public struct ${Self}Iterator<${TypeParametersDecl}> : IteratorProtocol {
 
   @_versioned
   internal static func _native(
-    start: _NativeIndex, end: _NativeIndex, storage: _NativeStorage
+    start: _NativeIndex, end: _NativeIndex, buffer: _NativeBuffer
   ) -> ${Self}Iterator {
     return ${Self}Iterator(
-      _state: ._native(start: start, end: end, storage: storage))
+      _state: ._native(start: start, end: end, buffer: buffer))
   }
 #if _runtime(_ObjC)
   @_versioned
@@ -4964,13 +4964,13 @@ public struct ${Self}Iterator<${TypeParametersDecl}> : IteratorProtocol {
   @_versioned
   internal mutating func _nativeNext() -> ${Sequence}? {
     switch _state {
-    case ._native(let startIndex, let endIndex, let storage):
+    case ._native(let startIndex, let endIndex, let buffer):
       if startIndex == endIndex {
         return nil
       }
-      let result = storage.assertingGet(startIndex)
+      let result = buffer.assertingGet(startIndex)
       _state =
-        ._native(start: storage.index(after: startIndex), end: endIndex, storage: storage)
+        ._native(start: buffer.index(after: startIndex), end: endIndex, buffer: buffer)
       return result
     case ._cocoa:
       _sanityCheckFailure("internal error: not backed by NS${Self}")
@@ -5043,29 +5043,29 @@ public struct _${Self}Builder<${TypeParametersDecl}> {
 %end
 
   internal var _result: ${Self}<${TypeParameters}>
-  internal var _nativeStorage: _Native${Self}Storage<${TypeParameters}>
+  internal var _nativeBuffer: _Native${Self}Buffer<${TypeParameters}>
   internal let _requestedCount: Int
   internal var _actualCount: Int
 
   public init(count: Int) {
     let requiredCapacity =
-      _Native${Self}Storage<${TypeParameters}>.minimumCapacity(
+      _Native${Self}Buffer<${TypeParameters}>.minimumCapacity(
         minimumCount: count,
         maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
     _result = ${Self}<${TypeParameters}>(minimumCapacity: requiredCapacity)
-    _nativeStorage = _result._variantStorage.asNative
+    _nativeBuffer = _result._variantBuffer.asNative
     _requestedCount = count
     _actualCount = 0
   }
 
 %if Self == 'Set':
   public mutating func add(member newKey: Key) {
-    _nativeStorage.unsafeAddNew(key: newKey)
+    _nativeBuffer.unsafeAddNew(key: newKey)
     _actualCount += 1
   }
 %elif Self == 'Dictionary':
   public mutating func add(key newKey: Key, value: Value) {
-    _nativeStorage.unsafeAddNew(key: newKey, value: value)
+    _nativeBuffer.unsafeAddNew(key: newKey, value: value)
     _actualCount += 1
   }
 %end
@@ -5077,7 +5077,7 @@ public struct _${Self}Builder<${TypeParametersDecl}> {
       "the number of members added does not match the promised count")
 
     // Finish building the `${Self}`.
-    _nativeStorage._count = _requestedCount
+    _nativeBuffer._count = _requestedCount
 
     // Prevent taking the result twice.
     _actualCount = -1
@@ -5116,11 +5116,11 @@ extension ${Self} {
 #if _runtime(_ObjC)
 extension ${Self} {
   public func _bridgeToObjectiveCImpl() -> _NS${Self}Core {
-    switch _variantStorage {
-    case _Variant${Self}Storage.native(let storage):
-      return storage.bridged()
-    case _Variant${Self}Storage.cocoa(let cocoaStorage):
-      return cocoaStorage.cocoa${Self}
+    switch _variantBuffer {
+    case _Variant${Self}Buffer.native(let buffer):
+      return buffer.bridged()
+    case _Variant${Self}Buffer.cocoa(let cocoaBuffer):
+      return cocoaBuffer.cocoa${Self}
     }
   }
 
@@ -5132,16 +5132,16 @@ extension ${Self} {
 
     // Try all three NSSelf impls that we currently provide.
 
-    if let deferredStorage = s as? _SwiftDeferredNS${Self}<${TypeParameters}> {
-      return ${Self}(_nativeStorage: deferredStorage.nativeStorage)
+    if let deferredBuffer = s as? _SwiftDeferredNS${Self}<${TypeParameters}> {
+      return ${Self}(_nativeBuffer: deferredBuffer.nativeBuffer)
     }
 
-    if let nativeBuffer = s as? _Native${Self}Buffer<${TypeParameters}> {
-      return ${Self}(_nativeStorage: 
-          _Native${Self}Storage(_buffer: nativeBuffer))
+    if let nativeStorage = s as? _Native${Self}Storage<${TypeParameters}> {
+      return ${Self}(_nativeBuffer: 
+          _Native${Self}Buffer(_storage: nativeStorage))
     }
 
-    if s === _RawNative${Self}Buffer.empty {
+    if s === _RawNative${Self}Storage.empty {
       return ${Self}()
     }
     

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -5124,16 +5124,27 @@ extension ${Self} {
     }
   }
 
+  /// Gets the native Dictionary hidden inside this NSDictionary
+  /// or returns nil.
   public static func _bridgeFromObjectiveCAdoptingNativeStorageOf(
     _ s: AnyObject
   ) -> ${Self}<${TypeParameters}>? {
-    if let bridgingStorage =
-        s as AnyObject as? _SwiftDeferredNS${Self}<${TypeParameters}> {
-      // If `NS${Self}` is actually native storage of `${Self}` with key
-      // and value types that the requested ones match exactly, then just
-      // re-wrap the native storage.
-      return ${Self}<${TypeParameters}>(_nativeStorage: bridgingStorage.nativeStorage)
+
+    // Try all three NSSelf impls that we currently provide.
+
+    if let deferredStorage = s as? _SwiftDeferredNS${Self}<${TypeParameters}> {
+      return ${Self}(_nativeStorage: deferredStorage.nativeStorage)
     }
+
+    if let nativeBuffer = s as? _Native${Self}Buffer<${TypeParameters}> {
+      return ${Self}(_nativeStorage: 
+          _Native${Self}Storage(_buffer: nativeBuffer))
+    }
+
+    if s === _RawNative${Self}Buffer.empty {
+      return ${Self}()
+    }
+    
     // FIXME: what if `s` is native storage, but for different key/value type?
     return nil
   }

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -2693,7 +2693,7 @@ internal class _TypedNative${Self}Storage<${TypeParameters}> :
 
 // See the top level docs for a description of this type
 @_versioned
-final internal class _Native${Self}Storage<${TypeParametersDecl}> :
+final internal class _HashableTypedNative${Self}Storage<${TypeParametersDecl}> :
   _TypedNative${Self}Storage<${TypeParameters}> {
 
   internal typealias FullContainer = ${Self}<${TypeParameters}>
@@ -3152,7 +3152,8 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
 extension _Native${Self}Buffer 
   where ${'Key' if Self == 'Dictionary' else 'Element'} : Hashable
 {
-  internal typealias HashTypedStorage = _Native${Self}Storage<${TypeParameters}>
+  internal typealias HashTypedStorage = 
+    _HashableTypedNative${Self}Storage<${TypeParameters}>
   internal typealias SequenceElement = ${Sequence}
 
   @inline(__always)
@@ -5136,7 +5137,7 @@ extension ${Self} {
       return ${Self}(_nativeBuffer: deferredBuffer.nativeBuffer)
     }
 
-    if let nativeStorage = s as? _Native${Self}Storage<${TypeParameters}> {
+    if let nativeStorage = s as? _HashableTypedNative${Self}Storage<${TypeParameters}> {
       return ${Self}(_nativeBuffer: 
           _Native${Self}Buffer(_storage: nativeStorage))
     }

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -136,7 +136,10 @@ import SwiftShims
 // ------------------
 //
 // FIXME: decide if this guarantee is worth making, as it restricts
-// collision resolution to first-come-first-serve.
+// collision resolution to first-come-first-serve. The most obvious alternative
+// would be robin hood hashing. The Rust code base is the best
+// resource on a *practical* implementation of robin hood hashing: 
+// https://github.com/rust-lang/rust/blob/ac919fcd9d4a958baf99b2f2ed5c3d38a2ebf9d0/src/libstd/collections/hash/map.rs#L70-L178
 //
 // Indexing a container, `c[i]`, uses the integral offset stored in the index
 // to access the elements referenced by the container. Generally, an index into

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -680,7 +680,7 @@ public struct Set<Element : Hashable> :
   ///     print(emptySet.isEmpty)
   ///     // Prints "true"
   public init() {
-    self = Set<Element>(minimumCapacity: 0)
+    self = Set<Element>(_nativeStorage: _NativeStorage())
   }
 
   /// Creates a new set from a finite sequence of items.
@@ -1117,7 +1117,7 @@ extension Set {
     switch (lhs._variantStorage, rhs._variantStorage) {
     case (.native(let lhsNative), .native(let rhsNative)):
 
-      if lhsNative === rhsNative {
+      if lhsNative._buffer === rhsNative._buffer {
         return true
       }
 
@@ -1597,7 +1597,7 @@ public struct Dictionary<Key : Hashable, Value> :
 
   /// Creates an empty dictionary.
   public init() {
-    self = Dictionary<Key, Value>(minimumCapacity: 0)
+    self = Dictionary<Key, Value>(_nativeStorage: _NativeStorage())
   }
 
   /// Creates a dictionary with at least the given number of elements worth of
@@ -2022,7 +2022,7 @@ extension Dictionary where Key : Equatable, Value : Equatable {
     switch (lhs._variantStorage, rhs._variantStorage) {
     case (.native(let lhsNative), .native(let rhsNative)):
 
-      if lhsNative === rhsNative {
+      if lhsNative._buffer === rhsNative._buffer {
         return true
       }
 
@@ -2436,12 +2436,7 @@ collections = [
 % for (Self, a_self, TypeParametersDecl, TypeParameters, AnyTypeParameters, Sequence, AnySequenceType) in collections:
 
 /// Header part of the native storage.
-internal struct _${Self}StorageHeader<${TypeParameters}> {
-
-%if Self == 'Set':
-  internal typealias Key = ${TypeParameters}
-  internal typealias Value = ${TypeParameters}
-%end
+internal struct _${Self}StorageHeader {
 
   internal init(capacity: Int) {
     self.capacity = capacity
@@ -2454,26 +2449,57 @@ internal struct _${Self}StorageHeader<${TypeParameters}> {
 
   // Placeholder values until the struct can be initialized.
   internal var initializedEntries: _UnsafeBitMap! = nil
-  internal var keys: UnsafeMutablePointer<Key>! = nil
+  internal var keys: UnsafeMutableRawPointer! = nil
 % if Self == 'Dictionary':
-  internal var values: UnsafeMutablePointer<Value>! = nil
+  internal var values: UnsafeMutableRawPointer! = nil
 % end
 }
 
-/// An instance of this class has all `${Self}` data tail-allocated.
-/// Enough bytes are allocated to hold the bitmap for marking valid entries,
-/// keys, and values. The data layout starts with the bitmap, followed by the
-/// keys, followed by the values.
-@_versioned
-final internal class _Native${Self}Storage<${TypeParameters}> :
-  ManagedBuffer<_${Self}StorageHeader<${TypeParameters}>, UInt8> {
+internal class _RawNative${Self}Buffer : 
+  ManagedBuffer<_${Self}StorageHeader, UInt8> {
+  internal typealias StorageHeader = _${Self}StorageHeader
+  internal typealias RawBuffer = _RawNative${Self}Buffer
+
+  internal var _body: StorageHeader
+
+  // This API is unsafe and needs a `_fixLifetime` in the caller.
+  internal
+  var _initializedHashtableEntriesBitMapStorage: UnsafeMutablePointer<UInt> {
+    return UnsafeMutablePointer(Builtin.projectTailElems(self, UInt.self))
+  }
+
+  internal static let empty: RawBuffer = {
+    let buffer = Builtin.allocWithTailElems_1(RawBuffer.self,
+        1._builtinWordValue, UInt.self)
+    
+    // We set the capacity to 1 so that there's an empty hole to search.
+    // Any insertion will reallocate because there always needs to be
+    // an empty hole.
+    buffer._body = StorageHeader(capacity: 1)
+
+    let initializedEntries = _UnsafeBitMap(
+        storage: buffer._initializedHashtableEntriesBitMapStorage,
+        bitCount: 1)
+    initializedEntries.initializeToZero()
+
+    // Initialize header
+    buffer._body.initializedEntries = initializedEntries
+    return buffer
+  }()
+
+  override internal init(_doNotCallMe: ()) {
+    _sanityCheckFailure("Only initialize these by calling create")
+  }
+}
+
+internal struct _Native${Self}Storage<${TypeParameters}> {
+
   // Note: It is intended that ${TypeParameters}
   // (without : Hashable) is used here - this storage must work
   // with non-Hashable types.
-
-  internal typealias StorageHeader = _${Self}StorageHeader<${TypeParameters}>
-  internal typealias BufferPointer =
-    ManagedBufferPointer<StorageHeader, UInt8>
+  internal typealias StorageHeader = _${Self}StorageHeader
+  internal typealias RawBuffer = _RawNative${Self}Buffer
+  internal typealias TypedBuffer = _Native${Self}Buffer<${TypeParameters}>
   internal typealias Storage = _Native${Self}Storage<${TypeParameters}>
 
 %if Self == 'Set': # Set needs these to keep signatures simple.
@@ -2484,7 +2510,18 @@ final internal class _Native${Self}Storage<${TypeParameters}> :
   internal typealias SequenceElementWithoutLabels = (Key, Value)
 %end
 
-  internal var _body: StorageHeader
+  /// We store a RawBuffer so that this can be an empty singleton
+  internal var _buffer: RawBuffer
+
+  /// A convenience forwardhing the _buffer's body
+  internal var _body: StorageHeader { 
+    set {
+      _buffer._body = newValue
+    }
+    get {
+      return _buffer._body
+    }
+  }
 
   /// The number of _logical elements_ the ${a_self} can store. Not to be
   /// confused with `capacity`, the total number of raw `UInt8` bytes stored
@@ -2508,14 +2545,13 @@ final internal class _Native${Self}Storage<${TypeParameters}> :
     return _body.maxLoadFactorInverse
   }
 
-  // This API is unsafe and needs a `_fixLifetime` in the caller.
   internal
   var _initializedHashtableEntriesBitMapStorage: UnsafeMutablePointer<UInt> {
-    return UnsafeMutablePointer(Builtin.projectTailElems(self, UInt.self))
+    return _buffer._initializedHashtableEntriesBitMapStorage
   }
 
   internal var _keysRawAddr: Builtin.RawPointer {
-    let bitmapAddr = Builtin.projectTailElems(self, UInt.self)
+    let bitmapAddr = Builtin.projectTailElems(_buffer, UInt.self)
     let numWordsForBitmap = _UnsafeBitMap.sizeInWords(forSizeInBits: _capacity)
     return Builtin.getTailAddr_Word(bitmapAddr,
            numWordsForBitmap._builtinWordValue, UInt.self, Key.self)
@@ -2551,19 +2587,21 @@ final internal class _Native${Self}Storage<${TypeParameters}> :
   internal static func create(capacity: Int) -> Storage {
     let numWordsForBitmap = _UnsafeBitMap.sizeInWords(forSizeInBits: capacity)
 %if Self == 'Dictionary':
-    let storage = Builtin.allocWithTailElems_3(Storage.self,
+    let buffer = Builtin.allocWithTailElems_3(TypedBuffer.self,
         numWordsForBitmap._builtinWordValue, UInt.self,
         capacity._builtinWordValue, Key.self,
         capacity._builtinWordValue, Value.self)
 %else:
-    let storage = Builtin.allocWithTailElems_2(Storage.self,
+    let buffer = Builtin.allocWithTailElems_2(TypedBuffer.self,
         numWordsForBitmap._builtinWordValue, UInt.self,
         capacity._builtinWordValue, Key.self)
 %end
 
     // We can initialize by assignment because _HashedContainerStorageHeader
     // is a trivial type, i.e. contains no references.
-    storage._body = StorageHeader(capacity: capacity)
+    buffer._body = StorageHeader(capacity: capacity)
+    
+    var storage = Storage(_buffer: buffer)
 
     let initializedEntries = _UnsafeBitMap(
         storage: storage._initializedHashtableEntriesBitMapStorage,
@@ -2572,21 +2610,44 @@ final internal class _Native${Self}Storage<${TypeParameters}> :
 
     // Initialize header
     storage._body.initializedEntries = initializedEntries
-    storage._body.keys = storage._keys
+    storage._body.keys = UnsafeMutableRawPointer(storage._keys)
 %if Self == 'Dictionary':
-    storage._body.values = storage._values
+    storage._body.values = UnsafeMutableRawPointer(storage._values)
 %end
 
     return storage
   }
 
+  init(_buffer: RawBuffer) {
+    self._buffer = _buffer
+  }
+
+  init() {
+    self._buffer = RawBuffer.empty
+  }
+}
+
+
+/// An instance of this class has all `${Self}` data tail-allocated.
+/// Enough bytes are allocated to hold the bitmap for marking valid entries,
+/// keys, and values. The data layout starts with the bitmap, followed by the
+/// keys, followed by the values.
+@_versioned
+final internal class _Native${Self}Buffer<${TypeParameters}> :
+  _RawNative${Self}Buffer {
+
+%if Self == 'Set': # Set needs these to keep signatures simple.
+  internal typealias Key = ${TypeParameters}
+  internal typealias Value = ${TypeParameters}
+%end
+
   deinit {
-    let capacity = _capacity
+    let capacity = _body.capacity
     let initializedEntries = _UnsafeBitMap(
         storage: _initializedHashtableEntriesBitMapStorage, bitCount: capacity)
-    let keys = _keys
+    let keys = _body.keys.assumingMemoryBound(to: Key.self)
 %if Self == 'Dictionary':
-    let values = _values
+    let values = _body.values.assumingMemoryBound(to: Value.self)
 %end
 
     if !_isPOD(Key.self) {
@@ -2650,7 +2711,7 @@ extension _Native${Self}Storage
     _sanityCheck(isInitializedEntry(at: i))
     defer { _fixLifetime(self) }
 
-    let res = (_body.keys + i).pointee
+    let res = (_keys + i).pointee
     return res
   }
 
@@ -2667,9 +2728,9 @@ extension _Native${Self}Storage
     _sanityCheck(isInitializedEntry(at: i))
     defer { _fixLifetime(self) }
 
-    (_body.keys + i).deinitialize()
+    (_keys + i).deinitialize()
 %if Self == 'Dictionary':
-    (_body.values + i).deinitialize()
+    (_values + i).deinitialize()
 %end
     _body.initializedEntries[i] = false
   }
@@ -2680,7 +2741,7 @@ extension _Native${Self}Storage
     _sanityCheck(!isInitializedEntry(at: i))
     defer { _fixLifetime(self) }
 
-    (_body.keys + i).initialize(to: k)
+    (_keys + i).initialize(to: k)
     _body.initializedEntries[i] = true
   }
 
@@ -2690,7 +2751,7 @@ extension _Native${Self}Storage
 
     defer { _fixLifetime(self) }
 
-    (_body.keys + toEntryAt).initialize(to: (from._body.keys + at).move())
+    (_keys + toEntryAt).initialize(to: (from._keys + at).move())
     from._body.initializedEntries[at] = false
     _body.initializedEntries[toEntryAt] = true
   }
@@ -2700,7 +2761,7 @@ extension _Native${Self}Storage
     _sanityCheck(isInitializedEntry(at: i))
     defer { _fixLifetime(self) }
 
-    (_body.keys + i).pointee = key
+    (_keys + i).pointee = key
   }
 
 %elif Self == 'Dictionary':
@@ -2709,8 +2770,8 @@ extension _Native${Self}Storage
     _sanityCheck(!isInitializedEntry(at: i))
     defer { _fixLifetime(self) }
 
-    (_body.keys + i).initialize(to: k)
-    (_body.values + i).initialize(to: v)
+    (_keys + i).initialize(to: k)
+    (_values + i).initialize(to: v)
     _body.initializedEntries[i] = true
   }
 
@@ -2718,8 +2779,8 @@ extension _Native${Self}Storage
   internal func moveInitializeEntry(from: Storage, at: Int, toEntryAt: Int) {
     _sanityCheck(!isInitializedEntry(at: toEntryAt))
 
-    (_body.keys + toEntryAt).initialize(to: (from._body.keys + at).move())
-    (_body.values + toEntryAt).initialize(to: (from._body.values + at).move())
+    (_keys + toEntryAt).initialize(to: (from._keys + at).move())
+    (_values + toEntryAt).initialize(to: (from._values + at).move())
     from._body.initializedEntries[at] = false
     _body.initializedEntries[toEntryAt] = true
   }
@@ -2730,7 +2791,7 @@ extension _Native${Self}Storage
     _sanityCheck(isInitializedEntry(at: i))
     defer { _fixLifetime(self) }
 
-    let res = (_body.values + i).pointee
+    let res = (_values + i).pointee
     return res
   }
 
@@ -2739,8 +2800,8 @@ extension _Native${Self}Storage
     _sanityCheck(isInitializedEntry(at: i))
     defer { _fixLifetime(self) }
 
-    (_body.keys + i).pointee = key
-    (_body.values + i).pointee = value
+    (_keys + i).pointee = key
+    (_values + i).pointee = value
   }
 
 %end
@@ -2872,7 +2933,7 @@ extension _Native${Self}Storage
   }
 
   internal func assertingGet(_ i: Index) -> SequenceElement {
-    _precondition(i.offset >= 0 && i.offset < capacity)
+    _precondition(i.offset >= 0 && i.offset < _capacity)
     _precondition(
       isInitializedEntry(at: i.offset),
       "attempting to access ${Self} elements using an invalid Index")
@@ -2953,7 +3014,7 @@ extension _Native${Self}Storage
       Storage.minimumCapacity(
         minimumCount: elements.count,
         maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
-    let nativeStorage = Storage.create(minimumCapacity: requiredCapacity)
+    var nativeStorage = Storage.create(minimumCapacity: requiredCapacity)
 
 %if Self == 'Set':
 
@@ -3272,7 +3333,8 @@ final internal class _Native${Self}BridgingStorage<${TypeParametersDecl}>
     BridgedNativeStorage.Storage? {
     get {
       if let ref = _stdlib_atomicLoadARCRef(object: _heapBufferBridgedPtr) {
-        return unsafeDowncast(ref, to: BridgedNativeStorage.Storage.self)
+        return BridgedNativeStorage.Storage(_buffer: unsafeDowncast(ref, 
+            to: BridgedNativeStorage.Storage.RawBuffer.self))
       }
       return nil
     }
@@ -3326,7 +3388,7 @@ final internal class _Native${Self}BridgingStorage<${TypeParametersDecl}>
     }
 
     // Atomically put the bridged elements in place.
-    _initializeHeapBufferBridged(bridged.buffer)
+    _initializeHeapBufferBridged(bridged.buffer._buffer)
   }
 
   //
@@ -3676,11 +3738,16 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
 
   @_versioned
   internal var asNative: NativeStorage {
-    switch self {
-    case .native(let storage):
-      return storage
-    case .cocoa:
-      _sanityCheckFailure("internal error: not backed by native storage")
+    get {
+      switch self {
+      case .native(let storage):
+        return storage
+      case .cocoa:
+        _sanityCheckFailure("internal error: not backed by native storage")
+      }
+    }
+    set {
+      self = .native(newValue)
     }
   }
 
@@ -3707,7 +3774,7 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
       }
 
       let oldNativeStorage = asNative
-      let newNativeStorage = NativeStorage.create(minimumCapacity: minimumCapacity)
+      var newNativeStorage = NativeStorage.create(minimumCapacity: minimumCapacity)
       let newCapacity = newNativeStorage._capacity
       for i in 0..<oldCapacity {
         if oldNativeStorage.isInitializedEntry(at: i) {
@@ -3740,7 +3807,7 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
     case .cocoa(let cocoaStorage):
 #if _runtime(_ObjC)
       let cocoa${Self} = cocoaStorage.cocoa${Self}
-      let newNativeStorage = NativeStorage.create(minimumCapacity: minimumCapacity)
+      var newNativeStorage = NativeStorage.create(minimumCapacity: minimumCapacity)
       let oldCocoaIterator = _Cocoa${Self}Iterator(cocoa${Self})
 %if Self == 'Set':
       while let key = oldCocoaIterator.next() {
@@ -4076,6 +4143,8 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
     _sanityCheck(
         nativeStorage.isInitializedEntry(at: offset), "expected initialized entry")
 
+    var nativeStorage = nativeStorage
+
     // remove the element
     nativeStorage.destroyEntry(at: offset)
     nativeStorage._count -= 1
@@ -4247,7 +4316,7 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
     // We have already checked for the empty dictionary case, so we will always
     // mutating the dictionary storage.  Request unique storage.
     _ = ensureUniqueNativeStorage(asNative._capacity)
-    let nativeStorage = asNative
+    var nativeStorage = asNative
 
     for b in 0..<nativeStorage._capacity {
       if nativeStorage.isInitializedEntry(at: b) {

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -1176,7 +1176,7 @@ extension Set {
         return true
       }
 
-      if lhsNative._count != rhsNative._count {
+      if lhsNative.count != rhsNative.count {
         return false
       }
 
@@ -1201,7 +1201,7 @@ extension Set {
       _VariantSetBuffer.cocoa(let rhsCocoa)):
   #if _runtime(_ObjC)
 
-      if lhsNative._count != rhsCocoa.count {
+      if lhsNative.count != rhsCocoa.count {
         return false
       }
 
@@ -2077,7 +2077,7 @@ extension Dictionary where Key : Equatable, Value : Equatable {
         return true
       }
 
-      if lhsNative._count != rhsNative._count {
+      if lhsNative.count != rhsNative.count {
         return false
       }
 
@@ -2110,7 +2110,7 @@ extension Dictionary where Key : Equatable, Value : Equatable {
     case (.native(let lhsNative), .cocoa(let rhsCocoa)):
   #if _runtime(_ObjC)
 
-      if lhsNative._count != rhsCocoa.count {
+      if lhsNative.count != rhsCocoa.count {
         return false
       }
 
@@ -2922,12 +2922,12 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
   // Forwarding the individual fields of the storage in various forms
 
   @_versioned
-  internal var _capacity: Int {
+  internal var capacity: Int {
     return _assumeNonNegative(_body.capacity)
   }
 
   @_versioned
-  internal var _count: Int {
+  internal var count: Int {
     set {
       _body.count = newValue
     }
@@ -2948,7 +2948,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
   // just a convenience for _keys and _values
   internal var _keysRawAddr: Builtin.RawPointer {
     let bitmapAddr = Builtin.projectTailElems(_storage, UInt.self)
-    let numWordsForBitmap = _UnsafeBitMap.sizeInWords(forSizeInBits: _capacity)
+    let numWordsForBitmap = _UnsafeBitMap.sizeInWords(forSizeInBits: capacity)
     return Builtin.getTailAddr_Word(bitmapAddr,
            numWordsForBitmap._builtinWordValue, UInt.self, Key.self)
   }
@@ -2962,7 +2962,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
   // This API is unsafe and needs a `_fixLifetime` in the caller.
   internal var _values: UnsafeMutablePointer<Value> {
     let valuesAddr = Builtin.getTailAddr_Word(_keysRawAddr,
-        _capacity._builtinWordValue, Key.self, Value.self)
+        capacity._builtinWordValue, Key.self, Value.self)
     return UnsafeMutablePointer(valuesAddr)
   }
 %end
@@ -2985,7 +2985,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
   @_versioned
   @inline(__always)
   internal func key(at i: Int) -> Key {
-    _sanityCheck(i >= 0 && i < _capacity)
+    _sanityCheck(i >= 0 && i < capacity)
     _sanityCheck(isInitializedEntry(at: i))
     defer { _fixLifetime(self) }
 
@@ -3009,7 +3009,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
 
   @_versioned
   internal func isInitializedEntry(at i: Int) -> Bool {
-    _sanityCheck(i >= 0 && i < _capacity)
+    _sanityCheck(i >= 0 && i < capacity)
     defer { _fixLifetime(self) }
 
     return _body.initializedEntries[i]
@@ -3056,7 +3056,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
   }
 
   internal func setKey(_ key: Key, at i: Int) {
-    _sanityCheck(i >= 0 && i < _capacity)
+    _sanityCheck(i >= 0 && i < capacity)
     _sanityCheck(isInitializedEntry(at: i))
     defer { _fixLifetime(self) }
 
@@ -3114,14 +3114,14 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
 
   @_versioned
   internal var endIndex: Index {
-    return Index(offset: _capacity)
+    return Index(offset: capacity)
   }
 
   @_versioned
   internal func index(after i: Index) -> Index {
     _precondition(i != endIndex)
     var idx = i.offset + 1
-    while idx < _capacity && !isInitializedEntry(at: idx) {
+    while idx < capacity && !isInitializedEntry(at: idx) {
       idx += 1
     }
 
@@ -3135,7 +3135,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
 
   
   internal func assertingGet(_ i: Index) -> SequenceElement {
-    _precondition(i.offset >= 0 && i.offset < _capacity)
+    _precondition(i.offset >= 0 && i.offset < capacity)
     _precondition(
       isInitializedEntry(at: i.offset),
       "attempting to access ${Self} elements using an invalid Index")
@@ -3200,7 +3200,7 @@ extension _Native${Self}Buffer
   var description: String {
     var result = ""
 #if INTERNAL_CHECKS_ENABLED
-    for i in 0..<_capacity {
+    for i in 0..<capacity {
       if isInitializedEntry(at: i) {
         let key = self.key(at: i)
         result += "bucket \(i), ideal bucket = \(_bucket(key)), key = \(key)\n"
@@ -3214,18 +3214,18 @@ extension _Native${Self}Buffer
 
   internal var _bucketMask: Int {
     // The capacity is not negative, therefore subtracting 1 will not overflow.
-    return _capacity &- 1
+    return capacity &- 1
   }
 
   @_versioned
   @inline(__always) // For performance reasons.
   internal func _bucket(_ k: Key) -> Int {
-    return _squeezeHashValue(k.hashValue, _capacity)
+    return _squeezeHashValue(k.hashValue, capacity)
   }
 
   @_versioned
   internal func _index(after bucket: Int) -> Int {
-    // Bucket is within 0 and _capacity. Therefore adding 1 does not overflow.
+    // Bucket is within 0 and capacity. Therefore adding 1 does not overflow.
     return (bucket &+ 1) & _bucketMask
   }
 
@@ -3300,7 +3300,7 @@ extension _Native${Self}Buffer
   @_versioned
   @inline(__always)
   internal func index(forKey key: Key) -> Index? {
-    if _count == 0 {
+    if count == 0 {
       // Fast path that avoids computing the hash of the key.
       return nil
     }
@@ -3322,7 +3322,7 @@ extension _Native${Self}Buffer
   @_versioned
   @inline(__always)
   internal func maybeGet(_ key: Key) -> Value? {
-    if _count == 0 {
+    if count == 0 {
       // Fast path that avoids computing the hash of the key.
       return nil
     }
@@ -3394,7 +3394,7 @@ extension _Native${Self}Buffer
       nativeBuffer.initializeKey(key, at: i.offset)
       count += 1
     }
-    nativeBuffer._count = count
+    nativeBuffer.count = count
 
 %elif Self == 'Dictionary':
 
@@ -3404,7 +3404,7 @@ extension _Native${Self}Buffer
       _precondition(!found, "${Self} literal contains duplicate keys")
       nativeBuffer.initializeKey(key, value: value, at: i.offset)
     }
-    nativeBuffer._count = elements.count
+    nativeBuffer.count = elements.count
 
 %end
 
@@ -3632,10 +3632,10 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
 
     // Create buffer for bridged data.
     let bridged = BridgedBuffer.createUnhashable(
-      capacity: nativeBuffer._capacity)
+      capacity: nativeBuffer.capacity)
 
     // Bridge everything.
-    for i in 0..<nativeBuffer._capacity {
+    for i in 0..<nativeBuffer.capacity {
       if nativeBuffer.isInitializedEntry(at: i) {
         let key = _bridgeAnythingToObjectiveC(nativeBuffer.key(at: i))
 %if Self == 'Set':
@@ -3660,7 +3660,7 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
     bridgeEverything()
     // The user is expected to provide a storage of the correct size
     var i = 0 // Position in the input storage
-    let capacity = nativeBuffer._capacity
+    let capacity = nativeBuffer.capacity
 
     if let unmanagedKeys = _UnmanagedAnyObjectArray(keys) {
       if let unmanagedObjects = _UnmanagedAnyObjectArray(objects) {
@@ -3700,7 +3700,7 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
 
   @objc
   internal var count: Int {
-    return nativeBuffer._count
+    return nativeBuffer.count
   }
 
   internal func bridgingObjectForKey(_ aKey: AnyObject)
@@ -3990,14 +3990,14 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
     -> (reallocated: Bool, capacityChanged: Bool) {
     switch self {
     case .native:
-      let oldCapacity = asNative._capacity
+      let oldCapacity = asNative.capacity
       if isUniquelyReferenced() && oldCapacity >= minimumCapacity {
         return (reallocated: false, capacityChanged: false)
       }
 
       let oldNativeBuffer = asNative
       var newNativeBuffer = NativeBuffer.create(minimumCapacity: minimumCapacity)
-      let newCapacity = newNativeBuffer._capacity
+      let newCapacity = newNativeBuffer.capacity
       for i in 0..<oldCapacity {
         if oldNativeBuffer.isInitializedEntry(at: i) {
           if oldCapacity == newCapacity {
@@ -4020,11 +4020,11 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
           }
         }
       }
-      newNativeBuffer._count = oldNativeBuffer._count
+      newNativeBuffer.count = oldNativeBuffer.count
 
       self = .native(newNativeBuffer)
       return (reallocated: true,
-              capacityChanged: oldCapacity != newNativeBuffer._capacity)
+              capacityChanged: oldCapacity != newNativeBuffer.capacity)
 
     case .cocoa(let cocoaBuffer):
 #if _runtime(_ObjC)
@@ -4046,7 +4046,7 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
       }
 
 %end
-      newNativeBuffer._count = cocoa${Self}.count
+      newNativeBuffer.count = cocoa${Self}.count
 
       self = .native(newNativeBuffer)
       return (reallocated: true, capacityChanged: true)
@@ -4247,9 +4247,9 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
     var (i, found) = asNative._find(key, startBucket: asNative._bucket(key))
 
     let minCapacity = found
-      ? asNative._capacity
+      ? asNative.capacity
       : NativeBuffer.minimumCapacity(
-          minimumCount: asNative._count + 1,
+          minimumCount: asNative.count + 1,
           maxLoadFactorInverse: asNative._maxLoadFactorInverse)
 
     let (_, capacityChanged) = ensureUniqueNativeBuffer(minCapacity)
@@ -4263,7 +4263,7 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
       asNative.setKey(key, at: i.offset)
     } else {
       asNative.initializeKey(key, at: i.offset)
-      asNative._count += 1
+      asNative.count += 1
     }
 %elif Self == 'Dictionary':
     let oldValue: Value? = found ? asNative.value(at: i.offset) : nil
@@ -4271,7 +4271,7 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
       asNative.setKey(key, value: value, at: i.offset)
     } else {
       asNative.initializeKey(key, value: value, at: i.offset)
-      asNative._count += 1
+      asNative.count += 1
     }
 %end
 
@@ -4314,7 +4314,7 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
     }
 
     let minCapacity = NativeBuffer.minimumCapacity(
-      minimumCount: asNative._count + 1,
+      minimumCount: asNative.count + 1,
       maxLoadFactorInverse: asNative._maxLoadFactorInverse)
 
     let (_, capacityChanged) = ensureUniqueNativeBuffer(minCapacity)
@@ -4325,10 +4325,10 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
 
 %if Self == 'Set':
     asNative.initializeKey(key, at: i.offset)
-    asNative._count += 1
+    asNative.count += 1
 %elif Self == 'Dictionary':
     asNative.initializeKey(key, value: value, at: i.offset)
-    asNative._count += 1
+    asNative.count += 1
 %end
 
     return (inserted: true, memberAfterInsert: value)
@@ -4369,7 +4369,7 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
 
     // remove the element
     nativeBuffer.destroyEntry(at: offset)
-    nativeBuffer._count -= 1
+    nativeBuffer.count -= 1
 
     // If we've put a hole in a chain of contiguous elements, some
     // element after the hole may belong where the new hole is.
@@ -4433,7 +4433,7 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
     }
 
     let (_, capacityChanged) =
-      ensureUniqueNativeBuffer(asNative._capacity)
+      ensureUniqueNativeBuffer(asNative.capacity)
     let nativeBuffer = asNative
     if capacityChanged {
       idealBucket = nativeBuffer._bucket(key)
@@ -4456,7 +4456,7 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
 
     // The provided index should be valid, so we will always mutating the
     // set buffer.  Request unique buffer.
-    _ = ensureUniqueNativeBuffer(asNative._capacity)
+    _ = ensureUniqueNativeBuffer(asNative.capacity)
     let nativeBuffer = asNative
 
     let result = nativeBuffer.assertingGet(nativeIndex)
@@ -4537,15 +4537,15 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
 
     // We have already checked for the empty dictionary case, so we will always
     // mutating the dictionary buffer.  Request unique buffer.
-    _ = ensureUniqueNativeBuffer(asNative._capacity)
+    _ = ensureUniqueNativeBuffer(asNative.capacity)
     var nativeBuffer = asNative
 
-    for b in 0..<nativeBuffer._capacity {
+    for b in 0..<nativeBuffer.capacity {
       if nativeBuffer.isInitializedEntry(at: b) {
         nativeBuffer.destroyEntry(at: b)
       }
     }
-    nativeBuffer._count = 0
+    nativeBuffer.count = 0
   }
 
   internal mutating func removeAll(keepingCapacity keepCapacity: Bool) {
@@ -4577,12 +4577,12 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
 
   internal var count: Int {
     if _fastPath(guaranteedNative) {
-      return asNative._count
+      return asNative.count
     }
 
     switch self {
     case .native:
-      return asNative._count
+      return asNative.count
     case .cocoa(let cocoaBuffer):
 #if _runtime(_ObjC)
       return cocoaBuffer.count
@@ -4650,7 +4650,7 @@ extension _Native${Self}Index {
 #if _runtime(_ObjC)
 @_versioned
 internal struct _Cocoa${Self}Index : Comparable {
-  /// Index into `allKeys`, a property on the parent collection.
+  /// Index into `allKeys` on the CocoaSelfBuffer
   internal var currentKeyIndex: Int
 
   internal init(value: Int) {
@@ -5077,7 +5077,7 @@ public struct _${Self}Builder<${TypeParametersDecl}> {
       "the number of members added does not match the promised count")
 
     // Finish building the `${Self}`.
-    _nativeBuffer._count = _requestedCount
+    _nativeBuffer.count = _requestedCount
 
     // Prevent taking the result twice.
     _actualCount = -1

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -475,7 +475,7 @@ public struct Set<Element : Hashable> :
   public init(minimumCapacity: Int) {
     _variantBuffer =
       _VariantBuffer.native(
-        _NativeBuffer.create(minimumCapacity: minimumCapacity))
+        _NativeBuffer(minimumCapacity: minimumCapacity))
   }
 
   /// Private initializer.
@@ -1667,7 +1667,7 @@ public struct Dictionary<Key : Hashable, Value> :
   ///   allocate buffer for in the new dictionary.
   public init(minimumCapacity: Int) {
     _variantBuffer =
-      .native(_NativeBuffer.create(minimumCapacity: minimumCapacity))
+      .native(_NativeBuffer(minimumCapacity: minimumCapacity))
   }
 
   internal init(_nativeBuffer: _NativeDictionaryBuffer<Key, Value>) {
@@ -2534,6 +2534,8 @@ internal class _RawNative${Self}Storage:
     return storage
   }()
 
+  // This type is made with allocWithTailElems, so no init is ever called.
+  // But we still need to have an init to satisfy the compiler.
   internal init(_doNotCallMe: ()) {
     _sanityCheckFailure("Only create this by using the `empty` singleton")
   }
@@ -2664,8 +2666,10 @@ internal class _TypedNative${Self}Storage<${TypeParameters}> :
     _fixLifetime(self)
   }
 
+  // This type is made with allocWithTailElems, so no init is ever called.
+  // But we still need to have an init to satisfy the compiler.
   override internal init(_doNotCallMe: ()) {
-    _sanityCheckFailure("Only create this by calling Buffer.createUnhashable")
+    _sanityCheckFailure("Only create this by calling Buffer's inits")
   }
 
 #if _runtime(_ObjC)
@@ -2696,8 +2700,10 @@ final internal class _HashableTypedNative${Self}Storage<${TypeParametersDecl}> :
   internal typealias FullContainer = ${Self}<${TypeParameters}>
   internal typealias Buffer = _Native${Self}Buffer<${TypeParameters}>
 
+  // This type is made with allocWithTailElems, so no init is ever called.
+  // But we still need to have an init to satisfy the compiler.
   override internal init(_doNotCallMe: ()) {
-    _sanityCheckFailure("Only create this by calling Buffer.create")
+    _sanityCheckFailure("Only create this by calling Buffer's inits'")
   }
 
   
@@ -2867,8 +2873,8 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
   internal var _storage: RawStorage
 
   /// Creates a Buffer with a storage that is typed, but doesn't understand
-  /// Hashing. Mostly for bridging; prefer `create(capacity:)`.
-  internal static func createUnhashable(capacity: Int) -> Buffer {
+  /// Hashing. Mostly for bridging; prefer `init(capacity:)`.
+  internal init(capacity: Int, unhashable: ()) {
     let numWordsForBitmap = _UnsafeBitMap.sizeInWords(forSizeInBits: capacity)
 %if Self == 'Dictionary':
     let storage = Builtin.allocWithTailElems_3(TypedStorage.self,
@@ -2880,31 +2886,29 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
         numWordsForBitmap._builtinWordValue, UInt.self,
         capacity._builtinWordValue, Key.self)
 %end
-    return create(capacity: capacity, storage: storage)
+    self.init(capacity: capacity, storage: storage)
   }
 
   /// Given a capacity and uninitialized RawStorage, completes the 
   /// initialization and returns a Buffer.  
-  internal static func create(capacity: Int, storage: RawStorage) -> Buffer {
+  internal init(capacity: Int, storage: RawStorage) {
     // We can initialize by assignment because _HashedContainerBufferHeader
     // is a trivial type, i.e. contains no references.
     storage._body = BufferHeader(capacity: capacity)
     
-    var buffer = Buffer(_storage: storage)
+    self.init(_storage: storage)
 
     let initializedEntries = _UnsafeBitMap(
-        storage: buffer._initializedHashtableEntriesBitMapBuffer,
+        storage: _initializedHashtableEntriesBitMapBuffer,
         bitCount: capacity)
     initializedEntries.initializeToZero()
 
     // Initialize header
-    buffer._body.initializedEntries = initializedEntries
-    buffer._body.keys = UnsafeMutableRawPointer(buffer._keys)
+    _body.initializedEntries = initializedEntries
+    _body.keys = UnsafeMutableRawPointer(_keys)
 %if Self == 'Dictionary':
-    buffer._body.values = UnsafeMutableRawPointer(buffer._values)
+    _body.values = UnsafeMutableRawPointer(_values)
 %end
-
-    return buffer
   }
 
   /// A convenience forwarding the _storage's body
@@ -3161,19 +3165,19 @@ extension _Native${Self}Buffer
   internal typealias SequenceElement = ${Sequence}
 
   @inline(__always)
-  internal static func create(minimumCapacity: Int) -> Buffer {
+  internal init(minimumCapacity: Int) {
     // Make sure there's a representable power of 2 >= minimumCapacity
     _sanityCheck(minimumCapacity <= (Int.max >> 1) + 1)
     var capacity = 2
     while capacity < minimumCapacity {
       capacity <<= 1
     }
-    return create(capacity: capacity)
+    self.init(capacity: capacity)
   }
 
   /// Create a buffer instance with room for at least 'capacity'
   /// entries and all entries marked invalid.
-  internal static func create(capacity: Int) -> Buffer {
+  internal init(capacity: Int) {
     let numWordsForBitmap = _UnsafeBitMap.sizeInWords(forSizeInBits: capacity)
 %if Self == 'Dictionary':
     let storage = Builtin.allocWithTailElems_3(HashTypedStorage.self,
@@ -3185,7 +3189,7 @@ extension _Native${Self}Buffer
         numWordsForBitmap._builtinWordValue, UInt.self,
         capacity._builtinWordValue, Key.self)
 %end
-    return create(capacity: capacity, storage: storage)
+    self.init(capacity: capacity, storage: storage)
   }
 
 #if _runtime(_ObjC)
@@ -3395,7 +3399,7 @@ extension _Native${Self}Buffer
       Buffer.minimumCapacity(
         minimumCount: elements.count,
         maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
-    var nativeBuffer = Buffer.create(minimumCapacity: requiredCapacity)
+    var nativeBuffer = Buffer(minimumCapacity: requiredCapacity)
 
 %if Self == 'Set':
 
@@ -3517,7 +3521,7 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
 %end
 
   internal init(minimumCapacity: Int = 2) {
-    nativeBuffer = NativeBuffer.create(minimumCapacity: minimumCapacity)
+    nativeBuffer = NativeBuffer(minimumCapacity: minimumCapacity)
     super.init()
   }
 
@@ -3646,8 +3650,7 @@ final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
     }
 
     // Create buffer for bridged data.
-    let bridged = BridgedBuffer.createUnhashable(
-      capacity: nativeBuffer.capacity)
+    let bridged = BridgedBuffer(capacity: nativeBuffer.capacity, unhashable: ())
 
     // Bridge everything.
     for i in 0..<nativeBuffer.capacity {
@@ -4014,7 +4017,7 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
       }
 
       let oldNativeBuffer = asNative
-      var newNativeBuffer = NativeBuffer.create(minimumCapacity: minimumCapacity)
+      var newNativeBuffer = NativeBuffer(minimumCapacity: minimumCapacity)
       let newCapacity = newNativeBuffer.capacity
       for i in 0..<oldCapacity {
         if oldNativeBuffer.isInitializedEntry(at: i) {
@@ -4047,7 +4050,7 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
     case .cocoa(let cocoaBuffer):
 #if _runtime(_ObjC)
       let cocoa${Self} = cocoaBuffer.cocoa${Self}
-      var newNativeBuffer = NativeBuffer.create(minimumCapacity: minimumCapacity)
+      var newNativeBuffer = NativeBuffer(minimumCapacity: minimumCapacity)
       let oldCocoaIterator = _Cocoa${Self}Iterator(cocoa${Self})
 %if Self == 'Set':
       while let key = oldCocoaIterator.next() {
@@ -4572,7 +4575,7 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
     }
 
     if !keepCapacity {
-      self = .native(NativeBuffer.create(minimumCapacity: 2))
+      self = .native(NativeBuffer(minimumCapacity: 2))
       return
     }
 
@@ -4586,7 +4589,7 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
       nativeRemoveAll()
     case .cocoa(let cocoaBuffer):
 #if _runtime(_ObjC)
-      self = .native(NativeBuffer.create(minimumCapacity: cocoaBuffer.count))
+      self = .native(NativeBuffer(minimumCapacity: cocoaBuffer.count))
 #else
       _sanityCheckFailure("internal error: unexpected cocoa ${Self}")
 #endif

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -1349,10 +1349,10 @@ public func _setDownCast<BaseValue, DerivedValue>(_ source: Set<BaseValue>)
   && _isClassOrObjCExistential(DerivedValue.self) {
     switch source._variantStorage {
     case _VariantSetStorage.native(let storage):
-      let bridgingStorage = storage.bridgingStorage()
+      let bridged = storage.bridged()
       return Set(
         _immutableCocoaSet:
-        unsafeBitCast(bridgingStorage, to: _NSSet.self))
+        unsafeBitCast(bridged, to: _NSSet.self))
 
     case _VariantSetStorage.cocoa(let cocoaStorage):
       return Set(
@@ -2304,7 +2304,7 @@ public func _dictionaryDownCast<BaseKey, BaseValue, DerivedKey, DerivedValue>(
     case .native(let storage):
       // Note: it is safe to treat the storage as immutable here because
       // Dictionary will not mutate storage with reference count greater than 1.
-      let nativeStorage = storage.bridgingStorage()
+      let nativeStorage = storage.bridged()
       return Dictionary(
         _immutableCocoaDictionary:
         unsafeBitCast(nativeStorage, to: _NSDictionary.self))
@@ -3077,6 +3077,7 @@ internal struct _Native${Self}Storage<${TypeParameters}> {
   @_transparent
   internal func moveInitializeEntry(from: Storage, at: Int, toEntryAt: Int) {
     _sanityCheck(!isInitializedEntry(at: toEntryAt))
+    defer { _fixLifetime(self) }
 
     (_keys + toEntryAt).initialize(to: (from._keys + at).move())
     (_values + toEntryAt).initialize(to: (from._values + at).move())
@@ -3090,8 +3091,7 @@ internal struct _Native${Self}Storage<${TypeParameters}> {
     _sanityCheck(isInitializedEntry(at: i))
     defer { _fixLifetime(self) }
 
-    let res = (_values + i).pointee
-    return res
+    return (_values + i).pointee
   }
 
   @_transparent
@@ -3184,7 +3184,7 @@ extension _Native${Self}Storage
   }
 
 #if _runtime(_ObjC)
-  func bridgingStorage() -> _NS${Self}Core {
+  func bridged() -> _NS${Self}Core {
     // We can zero-cost bridge if our keys are verbatim
     // or if we're the empty singleton.
     if (_isBridgedVerbatimToObjectiveC(Key.self) &&
@@ -5118,7 +5118,7 @@ extension ${Self} {
   public func _bridgeToObjectiveCImpl() -> _NS${Self}Core {
     switch _variantStorage {
     case _Variant${Self}Storage.native(let storage):
-      return storage.bridgingStorage()
+      return storage.bridged()
     case _Variant${Self}Storage.cocoa(let cocoaStorage):
       return cocoaStorage.cocoa${Self}
     }

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -2455,8 +2455,15 @@ internal struct _${Self}StorageHeader {
 % end
 }
 
-internal class _RawNative${Self}Buffer : 
-  ManagedBuffer<_${Self}StorageHeader, UInt8> {
+/// An instance of this class has all `${Self}` data tail-allocated.
+/// Enough bytes are allocated to hold the bitmap for marking valid entries,
+/// keys, and values. The data layout starts with the bitmap, followed by the
+/// keys, followed by the values. This is untyped to allow empty
+/// Buffers to be type-punned. Subclasses add type info to provide deinit and 
+/// more interesting NSSelf impls.
+internal class _RawNative${Self}Buffer:
+  _SwiftNativeNS${Self}, _NS${Self}Core
+{
   internal typealias StorageHeader = _${Self}StorageHeader
   internal typealias RawBuffer = _RawNative${Self}Buffer
 
@@ -2487,20 +2494,305 @@ internal class _RawNative${Self}Buffer :
     return buffer
   }()
 
+  internal init(_doNotCallMe: ()) {
+    _sanityCheckFailure("Only initialize these by calling create")
+  }
+
+#if _runtime(_ObjC)
+  func enumerator() -> _NSEnumerator {
+    return _Native${Self}NSEnumerator<${AnyTypeParameters}>(
+        _Native${Self}Storage(_buffer: self))
+  }
+
+  @objc(copyWithZone:)
+  func copy(with zone: _SwiftNSZone?) -> AnyObject {
+    return self
+  }
+
+  var count: Int { 
+    return 0 
+  }
+
+  @objc(countByEnumeratingWithState:objects:count:)
+  func countByEnumerating(
+    with state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
+    objects: UnsafeMutablePointer<AnyObject>?, count: Int
+  ) -> Int {
+    var theState = state.pointee
+    if theState.state == 0 {
+      theState.state = 1 // Arbitrary non-zero value.
+      theState.itemsPtr = AutoreleasingUnsafeMutablePointer(objects)
+      theState.mutationsPtr = _fastEnumerationStorageMutationsPtr
+    }
+    state.pointee = theState
+    
+    return 0
+  }
+
+%if Self == 'Set':
+
+  @objc
+  internal required init(objects: UnsafePointer<AnyObject?>, count: Int) {
+    _sanityCheckFailure("don't call this designated initializer")
+  }
+
+  @objc
+  internal func member(_ object: AnyObject) -> AnyObject? {
+    return nil
+  }
+
+  @objc
+  internal func objectEnumerator() -> _NSEnumerator {
+    return enumerator()
+  }
+  
+%elif Self == 'Dictionary':
+
+  @objc
+  internal required init(
+    objects: UnsafePointer<AnyObject?>,
+    forKeys: UnsafeRawPointer,
+    count: Int
+  ) {
+    _sanityCheckFailure("don't call this designated initializer")
+  }
+
+  @objc(objectForKey:)
+  func objectFor(_ aKey: AnyObject) -> AnyObject? {
+    return nil
+  }
+
+  func keyEnumerator() -> _NSEnumerator {
+    return enumerator()
+  }
+
+  // We also override the following methods for efficiency.
+
+  func getObjects(_ objects: UnsafeMutablePointer<AnyObject>?,
+    andKeys keys: UnsafeMutablePointer<AnyObject>?) {
+    // Do nothing, we're empty
+  }
+
+%end
+#endif
+}
+
+/// Adds types to a RawNativeBuffer, so that deinit can be implemented.
+/// Doesn't requires Hashable so that it can be instantiated with AnyHashable
+/// in _SwiftDeferredNSSelf for the bridged buffer.
+@_versioned
+internal class _TypedNative${Self}Buffer<${TypeParameters}> :
+  _RawNative${Self}Buffer {
+
+%if Self == 'Set': # Set needs these to keep signatures simple.
+  internal typealias Key = ${TypeParameters}
+  internal typealias Value = ${TypeParameters}
+%end
+
+  deinit {
+    let capacity = _body.capacity
+    let initializedEntries = _UnsafeBitMap(
+        storage: _initializedHashtableEntriesBitMapStorage, bitCount: capacity)
+    let keys = _body.keys.assumingMemoryBound(to: Key.self)
+%if Self == 'Dictionary':
+    let values = _body.values.assumingMemoryBound(to: Value.self)
+%end
+
+    if !_isPOD(Key.self) {
+      for i in 0 ..< capacity {
+        if initializedEntries[i] {
+          (keys+i).deinitialize()
+        }
+      }
+    }
+
+%if Self == 'Dictionary':
+    if !_isPOD(Value.self) {
+      for i in 0 ..< capacity {
+        if initializedEntries[i] {
+          (values+i).deinitialize()
+        }
+      }
+    }
+%end
+    _fixLifetime(self)
+  }
+
   override internal init(_doNotCallMe: ()) {
     _sanityCheckFailure("Only initialize these by calling create")
   }
+
+%if Self == 'Set':
+  @objc
+  internal required init(objects: UnsafePointer<AnyObject?>, count: Int) {
+    _sanityCheckFailure("don't call this designated initializer")
+  }
+%elif Self == 'Dictionary':
+  @objc
+  internal required init(
+    objects: UnsafePointer<AnyObject?>,
+    forKeys: UnsafeRawPointer,
+    count: Int
+  ) {
+    _sanityCheckFailure("don't call this designated initializer")
+  }
+%end
+}
+
+/// Adds the `Key: Hashable` constraint to _NativeTyped
+@_versioned
+final internal class _Native${Self}Buffer<${TypeParametersDecl}> :
+  _TypedNative${Self}Buffer<${TypeParameters}> {
+
+  internal typealias FullContainer = ${Self}<${TypeParameters}>
+  internal typealias Storage = _Native${Self}Storage<${TypeParameters}>
+
+  override internal init(_doNotCallMe: ()) {
+    _sanityCheckFailure("Only initialize these by calling create")
+  }
+
+  // NS bridging support
+
+#if _runtime(_ObjC)
+  var storage: Storage {
+    return Storage(_buffer: self)
+  }
+
+  var full: FullContainer {
+    return FullContainer(_nativeStorage: storage)
+  }
+
+  override var count: Int { 
+    return full.count 
+  }
+
+
+  override func enumerator() -> _NSEnumerator {
+    return _Native${Self}NSEnumerator<${TypeParameters}>(
+        Storage(_buffer: self))
+  }
+
+  @objc(countByEnumeratingWithState:objects:count:)
+  override func countByEnumerating(
+    with state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
+    objects: UnsafeMutablePointer<AnyObject>?, count: Int
+  ) -> Int {
+    var theState = state.pointee
+    if theState.state == 0 {
+      theState.state = 1 // Arbitrary non-zero value.
+      theState.itemsPtr = AutoreleasingUnsafeMutablePointer(objects)
+      theState.mutationsPtr = _fastEnumerationStorageMutationsPtr
+      theState.extra.0 = CUnsignedLong(full.startIndex._nativeIndex.offset)
+    }
+
+    // Test 'objects' rather than 'count' because (a) this is very rare anyway,
+    // and (b) the optimizer should then be able to optimize away the
+    // unwrapping check below.
+    if _slowPath(objects == nil) {
+      return 0
+    }
+
+    let unmanagedObjects = _UnmanagedAnyObjectArray(objects!)
+    var currIndex = _Native${Self}Index<${TypeParameters}>(
+        offset: Int(theState.extra.0))
+    let endIndex = storage.endIndex
+    var stored = 0
+    for i in 0..<count {
+      if (currIndex == endIndex) {
+        break
+      }
+
+      unmanagedObjects[i] = storage.bridgedKey(at: currIndex)
+      
+      stored += 1
+      storage.formIndex(after: &currIndex)
+    }
+    theState.extra.0 = CUnsignedLong(currIndex.offset)
+    state.pointee = theState
+    return stored
+  }
+
+  internal func getObjectFor(_ aKey: AnyObject) -> AnyObject? {
+    guard let nativeKey = _conditionallyBridgeFromObjectiveC(aKey, Key.self)
+    else { return nil }
+
+    let (i, found) = storage._find(nativeKey, 
+        startBucket: storage._bucket(nativeKey))
+
+    if found {
+      return storage.bridgedValue(at: i)
+    }
+    return nil
+  }
+
+%if Self == 'Set':
+
+  @objc
+  internal required init(objects: UnsafePointer<AnyObject?>, count: Int) {
+    _sanityCheckFailure("don't call this designated initializer")
+  }
+
+  @objc
+  override internal func member(_ object: AnyObject) -> AnyObject? {
+    return getObjectFor(object)
+  }
+
+%elif Self == 'Dictionary':
+  
+  @objc
+  internal required init(
+    objects: UnsafePointer<AnyObject?>,
+    forKeys: UnsafeRawPointer,
+    count: Int
+  ) {
+    _sanityCheckFailure("don't call this designated initializer")
+  }
+
+  @objc(objectForKey:)
+  override func objectFor(_ aKey: AnyObject) -> AnyObject? {
+    return getObjectFor(aKey)
+  }
+
+  // We also override the following methods for efficiency.
+  @objc
+  override func getObjects(_ objects: UnsafeMutablePointer<AnyObject>?,
+    andKeys keys: UnsafeMutablePointer<AnyObject>?) {
+    // The user is expected to provide a buffer of the correct size
+    if let unmanagedKeys = _UnmanagedAnyObjectArray(keys) {
+      if let unmanagedObjects = _UnmanagedAnyObjectArray(objects) {
+        // keys nonnull, objects nonnull
+        for (offset: i, element: (key: key, value: val)) in full.enumerated() {
+          unmanagedObjects[i] = _bridgeAnythingToObjectiveC(val)
+          unmanagedKeys[i] = _bridgeAnythingToObjectiveC(key)
+        }
+      } else {
+        // keys nonnull, objects null
+        for (offset: i, element: (key: key, value: _)) in full.enumerated() {
+          unmanagedKeys[i] = _bridgeAnythingToObjectiveC(key)
+        }
+      }
+    } else {
+      if let unmanagedObjects = _UnmanagedAnyObjectArray(objects) {
+        // keys null, objects nonnull
+        for (offset: i, element: (key: _, value: val)) in full.enumerated() {
+          unmanagedObjects[i] = _bridgeAnythingToObjectiveC(val)
+        }
+      } else {
+        // do nothing, both are null
+      }
+    }
+  }
+%end
+#endif
 }
 
 internal struct _Native${Self}Storage<${TypeParameters}> {
 
-  // Note: It is intended that ${TypeParameters}
-  // (without : Hashable) is used here - this storage must work
-  // with non-Hashable types.
   internal typealias StorageHeader = _${Self}StorageHeader
   internal typealias RawBuffer = _RawNative${Self}Buffer
-  internal typealias TypedBuffer = _Native${Self}Buffer<${TypeParameters}>
+  internal typealias TypedBuffer = _TypedNative${Self}Buffer<${TypeParameters}>
   internal typealias Storage = _Native${Self}Storage<${TypeParameters}>
+  internal typealias Index = _Native${Self}Index<${TypeParameters}>
 
 %if Self == 'Set': # Set needs these to keep signatures simple.
   internal typealias Key = ${TypeParameters}
@@ -2512,6 +2804,47 @@ internal struct _Native${Self}Storage<${TypeParameters}> {
 
   /// We store a RawBuffer so that this can be an empty singleton
   internal var _buffer: RawBuffer
+
+  /// Creates a Storage with a buffer that is typed, but doesn't understand
+  /// Hashing. Mostly for bridging; prefer `create(capacity:)`.
+  internal static func createUnhashable(capacity: Int) -> Storage {
+    let numWordsForBitmap = _UnsafeBitMap.sizeInWords(forSizeInBits: capacity)
+%if Self == 'Dictionary':
+    let buffer = Builtin.allocWithTailElems_3(TypedBuffer.self,
+        numWordsForBitmap._builtinWordValue, UInt.self,
+        capacity._builtinWordValue, Key.self,
+        capacity._builtinWordValue, Value.self)
+%else:
+    let buffer = Builtin.allocWithTailElems_2(TypedBuffer.self,
+        numWordsForBitmap._builtinWordValue, UInt.self,
+        capacity._builtinWordValue, Key.self)
+%end
+    return create(capacity: capacity, buffer: buffer)
+  }
+
+  /// Given a capacity and uninitialized RawBuffer, completes the 
+  /// initialization and produces a full Storage.  
+  internal static func create(capacity: Int, buffer: RawBuffer) -> Storage {
+    // We can initialize by assignment because _HashedContainerStorageHeader
+    // is a trivial type, i.e. contains no references.
+    buffer._body = StorageHeader(capacity: capacity)
+    
+    var storage = Storage(_buffer: buffer)
+
+    let initializedEntries = _UnsafeBitMap(
+        storage: storage._initializedHashtableEntriesBitMapStorage,
+        bitCount: capacity)
+    initializedEntries.initializeToZero()
+
+    // Initialize header
+    storage._body.initializedEntries = initializedEntries
+    storage._body.keys = UnsafeMutableRawPointer(storage._keys)
+%if Self == 'Dictionary':
+    storage._body.values = UnsafeMutableRawPointer(storage._values)
+%end
+
+    return storage
+  }
 
   /// A convenience forwardhing the _buffer's body
   internal var _body: StorageHeader { 
@@ -2571,137 +2904,12 @@ internal struct _Native${Self}Storage<${TypeParameters}> {
   }
 %end
 
-  @inline(__always)
-  internal static func create(minimumCapacity: Int) -> Storage {
-    // Make sure there's a representable power of 2 >= minimumCapacity
-    _sanityCheck(minimumCapacity <= (Int.max >> 1) + 1)
-    var capacity = 2
-    while capacity < minimumCapacity {
-      capacity <<= 1
-    }
-    return create(capacity: capacity)
-  }
-
-  /// Create a storage instance with room for at least 'capacity'
-  /// entries and all entries marked invalid.
-  internal static func create(capacity: Int) -> Storage {
-    let numWordsForBitmap = _UnsafeBitMap.sizeInWords(forSizeInBits: capacity)
-%if Self == 'Dictionary':
-    let buffer = Builtin.allocWithTailElems_3(TypedBuffer.self,
-        numWordsForBitmap._builtinWordValue, UInt.self,
-        capacity._builtinWordValue, Key.self,
-        capacity._builtinWordValue, Value.self)
-%else:
-    let buffer = Builtin.allocWithTailElems_2(TypedBuffer.self,
-        numWordsForBitmap._builtinWordValue, UInt.self,
-        capacity._builtinWordValue, Key.self)
-%end
-
-    // We can initialize by assignment because _HashedContainerStorageHeader
-    // is a trivial type, i.e. contains no references.
-    buffer._body = StorageHeader(capacity: capacity)
-    
-    var storage = Storage(_buffer: buffer)
-
-    let initializedEntries = _UnsafeBitMap(
-        storage: storage._initializedHashtableEntriesBitMapStorage,
-        bitCount: capacity)
-    initializedEntries.initializeToZero()
-
-    // Initialize header
-    storage._body.initializedEntries = initializedEntries
-    storage._body.keys = UnsafeMutableRawPointer(storage._keys)
-%if Self == 'Dictionary':
-    storage._body.values = UnsafeMutableRawPointer(storage._values)
-%end
-
-    return storage
-  }
-
   init(_buffer: RawBuffer) {
     self._buffer = _buffer
   }
 
   init() {
     self._buffer = RawBuffer.empty
-  }
-}
-
-
-/// An instance of this class has all `${Self}` data tail-allocated.
-/// Enough bytes are allocated to hold the bitmap for marking valid entries,
-/// keys, and values. The data layout starts with the bitmap, followed by the
-/// keys, followed by the values.
-@_versioned
-final internal class _Native${Self}Buffer<${TypeParameters}> :
-  _RawNative${Self}Buffer {
-
-%if Self == 'Set': # Set needs these to keep signatures simple.
-  internal typealias Key = ${TypeParameters}
-  internal typealias Value = ${TypeParameters}
-%end
-
-  deinit {
-    let capacity = _body.capacity
-    let initializedEntries = _UnsafeBitMap(
-        storage: _initializedHashtableEntriesBitMapStorage, bitCount: capacity)
-    let keys = _body.keys.assumingMemoryBound(to: Key.self)
-%if Self == 'Dictionary':
-    let values = _body.values.assumingMemoryBound(to: Value.self)
-%end
-
-    if !_isPOD(Key.self) {
-      for i in 0 ..< capacity {
-        if initializedEntries[i] {
-          (keys+i).deinitialize()
-        }
-      }
-    }
-
-%if Self == 'Dictionary':
-    if !_isPOD(Value.self) {
-      for i in 0 ..< capacity {
-        if initializedEntries[i] {
-          (values+i).deinitialize()
-        }
-      }
-    }
-%end
-    _fixLifetime(self)
-  }
-
-  override internal init(_doNotCallMe: ()) {
-    _sanityCheckFailure("Only initialize these by calling create")
-  }
-}
-
-// TODO: conditionally conform to _HashStorage for better compile-time safety.
-// TODO: conditionally conform to CustomStringConvertible.
-extension _Native${Self}Storage 
-  where ${'Key' if Self == 'Dictionary' else 'Element'} : Hashable
-{
-  internal typealias SequenceElement = ${Sequence}
-
-#if _runtime(_ObjC)
-  func bridgingStorage() -> _Native${Self}BridgingStorage<${TypeParameters}> {
-    return _Native${Self}BridgingStorage(nativeStorage: self)
-  }
-#endif
-
-  /// A textual representation of `self`.
-  var description: String {
-    var result = ""
-#if INTERNAL_CHECKS_ENABLED
-    for i in 0..<_capacity {
-      if isInitializedEntry(at: i) {
-        let key = self.key(at: i)
-        result += "bucket \(i), ideal bucket = \(_bucket(key)), key = \(key)\n"
-      } else {
-        result += "bucket \(i), empty\n"
-      }
-    }
-#endif
-    return result
   }
 
   @_versioned
@@ -2713,6 +2921,16 @@ extension _Native${Self}Storage
 
     let res = (_keys + i).pointee
     return res
+  }
+
+  internal func bridgedKey(at index: Index) -> AnyObject {
+    let k = key(at: index.offset)
+    return _bridgeAnythingToObjectiveC(k)
+  }
+
+  internal func bridgedValue(at index: Index) -> AnyObject {
+    let v = value(at: index.offset)
+    return _bridgeAnythingToObjectiveC(v)
   }
 
   @_versioned
@@ -2754,6 +2972,13 @@ extension _Native${Self}Storage
     (_keys + toEntryAt).initialize(to: (from._keys + at).move())
     from._body.initializedEntries[at] = false
     _body.initializedEntries[toEntryAt] = true
+  }
+
+  /// Alias for key(at:) in Sets for better code reuse
+  @_versioned
+  @_transparent
+  internal func value(at i: Int) -> Value {
+    return key(at: i)
   }
 
   internal func setKey(_ key: Key, at i: Int) {
@@ -2805,6 +3030,115 @@ extension _Native${Self}Storage
   }
 
 %end
+
+  @_versioned
+  internal var startIndex: Index {
+    // We start at "index after -1" instead of "0" because we need to find the
+    // first occupied slot.
+    return index(after: Index(offset: -1))
+  }
+
+  @_versioned
+  internal var endIndex: Index {
+    return Index(offset: _capacity)
+  }
+
+  @_versioned
+  internal func index(after i: Index) -> Index {
+    _precondition(i != endIndex)
+    var idx = i.offset + 1
+    while idx < _capacity && !isInitializedEntry(at: idx) {
+      idx += 1
+    }
+
+    return Index(offset: idx)
+  }
+
+  @_versioned
+  internal func formIndex(after i: inout Index) {
+    i = index(after: i)
+  }
+
+  
+  internal func assertingGet(_ i: Index) -> SequenceElement {
+    _precondition(i.offset >= 0 && i.offset < _capacity)
+    _precondition(
+      isInitializedEntry(at: i.offset),
+      "attempting to access ${Self} elements using an invalid Index")
+    let key = self.key(at: i.offset)
+%if Self == 'Set':
+    return key
+%elif Self == 'Dictionary':
+    return (key, self.value(at: i.offset))
+%end
+
+  }
+}
+
+// TODO: conditionally conform to _HashStorage for better compile-time safety.
+// TODO: conditionally conform to CustomStringConvertible.
+extension _Native${Self}Storage 
+  where ${'Key' if Self == 'Dictionary' else 'Element'} : Hashable
+{
+  internal typealias HashTypedBuffer = _Native${Self}Buffer<${TypeParameters}>
+  internal typealias SequenceElement = ${Sequence}
+
+  @inline(__always)
+  internal static func create(minimumCapacity: Int) -> Storage {
+    // Make sure there's a representable power of 2 >= minimumCapacity
+    _sanityCheck(minimumCapacity <= (Int.max >> 1) + 1)
+    var capacity = 2
+    while capacity < minimumCapacity {
+      capacity <<= 1
+    }
+    return create(capacity: capacity)
+  }
+
+  /// Create a storage instance with room for at least 'capacity'
+  /// entries and all entries marked invalid.
+  internal static func create(capacity: Int) -> Storage {
+    let numWordsForBitmap = _UnsafeBitMap.sizeInWords(forSizeInBits: capacity)
+%if Self == 'Dictionary':
+    let buffer = Builtin.allocWithTailElems_3(HashTypedBuffer.self,
+        numWordsForBitmap._builtinWordValue, UInt.self,
+        capacity._builtinWordValue, Key.self,
+        capacity._builtinWordValue, Value.self)
+%else:
+    let buffer = Builtin.allocWithTailElems_2(HashTypedBuffer.self,
+        numWordsForBitmap._builtinWordValue, UInt.self,
+        capacity._builtinWordValue, Key.self)
+%end
+    return create(capacity: capacity, buffer: buffer)
+  }
+
+#if _runtime(_ObjC)
+  func bridgingStorage() -> _NS${Self}Core {
+    // We can zero-cost bridge if our keys are verbatim
+    // or if we're the empty singleton.
+    if (_isBridgedVerbatimToObjectiveC(Key.self) &&
+        _isBridgedVerbatimToObjectiveC(Value.self)) ||
+        self._buffer === RawBuffer.empty {
+      return self._buffer
+    }
+    return _SwiftDeferredNS${Self}(nativeStorage: self)
+  }
+#endif
+
+  /// A textual representation of `self`.
+  var description: String {
+    var result = ""
+#if INTERNAL_CHECKS_ENABLED
+    for i in 0..<_capacity {
+      if isInitializedEntry(at: i) {
+        let key = self.key(at: i)
+        result += "bucket \(i), ideal bucket = \(_bucket(key)), key = \(key)\n"
+      } else {
+        result += "bucket \(i), empty\n"
+      }
+    }
+#endif
+    return result
+  }
 
   internal var _bucketMask: Int {
     // The capacity is not negative, therefore subtracting 1 will not overflow.
@@ -2891,36 +3225,6 @@ extension _Native${Self}Storage
   // _HashStorage conformance
   //
 
-  internal typealias Index = _Native${Self}Index<${TypeParameters}>
-
-  @_versioned
-  internal var startIndex: Index {
-    // We start at "index after -1" instead of "0" because we need to find the
-    // first occupied slot.
-    return index(after: Index(offset: -1))
-  }
-
-  @_versioned
-  internal var endIndex: Index {
-    return Index(offset: _capacity)
-  }
-
-  @_versioned
-  internal func index(after i: Index) -> Index {
-    _precondition(i != endIndex)
-    var idx = i.offset + 1
-    while idx < _capacity && !isInitializedEntry(at: idx) {
-      idx += 1
-    }
-
-    return Index(offset: idx)
-  }
-
-  @_versioned
-  internal func formIndex(after i: inout Index) {
-    i = index(after: i)
-  }
-
   @_versioned
   @inline(__always)
   internal func index(forKey key: Key) -> Index? {
@@ -2932,19 +3236,6 @@ extension _Native${Self}Storage
     return found ? i : nil
   }
 
-  internal func assertingGet(_ i: Index) -> SequenceElement {
-    _precondition(i.offset >= 0 && i.offset < _capacity)
-    _precondition(
-      isInitializedEntry(at: i.offset),
-      "attempting to access ${Self} elements using an invalid Index")
-    let key = self.key(at: i.offset)
-%if Self == 'Set':
-    return key
-%elif Self == 'Dictionary':
-    return (key, self.value(at: i.offset))
-%end
-
-  }
 
   internal func assertingGet(_ key: Key) -> Value {
     let (i, found) = _find(key, startBucket: _bucket(key))
@@ -3009,6 +3300,9 @@ extension _Native${Self}Storage
   internal static func fromArray(_ elements: [SequenceElementWithoutLabels])
     -> Storage 
   {
+    if elements.isEmpty {
+      return Storage()
+    }
 
     let requiredCapacity =
       Storage.minimumCapacity(
@@ -3047,123 +3341,23 @@ extension _Native${Self}Storage
 }
 
 #if _runtime(_ObjC)
-/// Storage for bridged `${Self}` elements.  We could have used
-/// `${Self}<${AnyTypeParameters}>`, but `AnyObject` cannot be a Key because
-/// it is not `Hashable`.
-internal struct _BridgedNative${Self}Storage {
-  internal typealias Storage =
-    _Native${Self}Storage<${AnyTypeParameters}>
-  internal typealias SequenceElement = ${AnySequenceType}
-
-  internal let buffer: Storage
-  internal let initializedEntries: _UnsafeBitMap
-  internal let keys: UnsafeMutablePointer<AnyObject>
-%if Self == 'Dictionary':
-  internal let values: UnsafeMutablePointer<AnyObject>
-%end
-
-  internal init(buffer: Storage) {
-    self.buffer = buffer
-    initializedEntries = _UnsafeBitMap(
-      storage: buffer._initializedHashtableEntriesBitMapStorage,
-      bitCount: buffer._capacity)
-    keys = buffer._keys
-%if Self == 'Dictionary':
-    values = buffer._values
-%end
-    _fixLifetime(buffer)
-  }
-
-  @_transparent
-  internal var capacity: Int {
-    return buffer._capacity
-  }
-
-  @_versioned
-  internal func isInitializedEntry(at i: Int) -> Bool {
-    return initializedEntries[i]
-  }
-
-  internal func key(at i: Int) -> AnyObject {
-    _precondition(i >= 0 && i < capacity)
-    _sanityCheck(isInitializedEntry(at: i))
-
-    let res = (keys + i).pointee
-    _fixLifetime(self)
-    return res
-  }
-
-  internal func setKey(_ key: AnyObject, at i: Int) {
-    _precondition(i >= 0 && i < capacity)
-    _sanityCheck(isInitializedEntry(at: i))
-
-    (keys + i).pointee = key
-    _fixLifetime(self)
-  }
-
-%if Self == 'Set':
-  @_transparent
-  internal func initializeKey(_ k: AnyObject, at i: Int) {
-    _sanityCheck(!isInitializedEntry(at: i))
-
-    (keys + i).initialize(to: k)
-    initializedEntries[i] = true
-    _fixLifetime(self)
-  }
-%elif Self == 'Dictionary':
-  @_transparent
-  internal func initializeKey(_ k: AnyObject, value v: AnyObject, at i: Int
-  ) {
-    _sanityCheck(!isInitializedEntry(at: i))
-
-    (keys + i).initialize(to: k)
-    (values + i).initialize(to: v)
-    initializedEntries[i] = true
-    _fixLifetime(self)
-  }
-
-  @_transparent
-  internal func value(at i: Int) -> AnyObject {
-    _sanityCheck(isInitializedEntry(at: i))
-    let res = (values + i).pointee
-    _fixLifetime(self)
-    return res
-  }
-%end
-
-  internal func assertingGet(_ i: Int) -> SequenceElement {
-    _precondition(
-      isInitializedEntry(at: i),
-      "attempting to access ${Self} elements using an invalid Index")
-    let key = self.key(at: i)
-%if Self == 'Set':
-    return key
-%elif Self == 'Dictionary':
-    return (key, self.value(at: i))
-%end
-  }
-}
-
-final internal class _Native${Self}StorageKeyNSEnumerator<
-  ${TypeParametersDecl}
->
+final internal class _Native${Self}NSEnumerator<${TypeParameters}>
   : _SwiftNativeNSEnumerator, _NSEnumerator {
 
-  internal typealias BridgingStorage =
-    _Native${Self}BridgingStorage<${TypeParameters}>
+  internal typealias Storage = _Native${Self}Storage<${TypeParameters}>
   internal typealias Index = _Native${Self}Index<${TypeParameters}>
 
   internal override required init() {
     _sanityCheckFailure("don't call this designated initializer")
   }
 
-  internal init(_ bridgingStorage: BridgingStorage) {
-    self.bridgingStorage = bridgingStorage
-    nextIndex = bridgingStorage.nativeStorage.startIndex
-    endIndex = bridgingStorage.nativeStorage.endIndex
+  internal init(_ storage: Storage) {
+    self.storage = storage
+    nextIndex = storage.startIndex
+    endIndex = storage.endIndex
   }
 
-  internal var bridgingStorage: BridgingStorage
+  internal var storage: Storage
   internal var nextIndex: Index
   internal var endIndex: Index
 
@@ -3178,9 +3372,9 @@ final internal class _Native${Self}StorageKeyNSEnumerator<
     if nextIndex == endIndex {
       return nil
     }
-    let bridgedKey: AnyObject = bridgingStorage._getBridgedKey(nextIndex)
-    bridgingStorage.nativeStorage.formIndex(after: &nextIndex)
-    return bridgedKey
+    let key = storage.bridgedKey(at: nextIndex)
+    storage.formIndex(after: &nextIndex)
+    return key
   }
 
   @objc(countByEnumeratingWithState:objects:count:)
@@ -3203,11 +3397,11 @@ final internal class _Native${Self}StorageKeyNSEnumerator<
 
     // Return only a single element so that code can start iterating via fast
     // enumeration, terminate it, and continue via NSEnumerator.
-    let bridgedKey: AnyObject = bridgingStorage._getBridgedKey(nextIndex)
-    bridgingStorage.nativeStorage.formIndex(after: &nextIndex)
+    let key = storage.bridgedKey(at: nextIndex)
+    storage.formIndex(after: &nextIndex)
 
     let unmanagedObjects = _UnmanagedAnyObjectArray(objects)
-    unmanagedObjects[0] = bridgedKey
+    unmanagedObjects[0] = key
     state.pointee = theState
     return 1
   }
@@ -3218,11 +3412,13 @@ final internal class _Native${Self}StorageKeyNSEnumerator<
 /// This class exists for Objective-C bridging. It holds a reference to a
 /// `_Native${Self}Storage`, and can be upcast to `NS${Self}` when
 /// bridging is necessary.
-final internal class _Native${Self}BridgingStorage<${TypeParametersDecl}>
+final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}>
   : _SwiftNativeNS${Self}, _NS${Self}Core {
 
   internal typealias NativeStorage = _Native${Self}Storage<${TypeParameters}>
-  internal typealias BridgedNativeStorage = _BridgedNative${Self}Storage
+  internal typealias BridgedStorage = _Native${Self}Storage<${AnyTypeParameters}>
+  internal typealias NativeIndex = _Native${Self}Index<${TypeParameters}>
+  internal typealias BridgedIndex = _Native${Self}Index<${AnyTypeParameters}>
 
 %if Self == 'Set':
   internal typealias Key = Element
@@ -3247,6 +3443,13 @@ final internal class _Native${Self}BridgingStorage<${TypeParametersDecl}>
 
   internal var nativeStorage: NativeStorage
 
+  @objc(copyWithZone:)
+  internal func copy(with zone: _SwiftNSZone?) -> AnyObject {
+    // Instances of this class should be visible outside of standard library as
+    // having `NS${Self}` type, which is immutable.
+    return self
+  }
+
 %if Self == 'Set':
 
   //
@@ -3268,14 +3471,7 @@ final internal class _Native${Self}BridgingStorage<${TypeParametersDecl}>
 
   @objc
   internal func objectEnumerator() -> _NSEnumerator {
-    return bridgingKeyEnumerator(())
-  }
-
-  @objc(copyWithZone:)
-  internal func copy(with zone: _SwiftNSZone?) -> AnyObject {
-    // Instances of this class should be visible outside of standard library as
-    // having `NSSet` type, which is immutable.
-    return self
+    return enumerator()
   }
 
 %elif Self == 'Dictionary':
@@ -3302,14 +3498,7 @@ final internal class _Native${Self}BridgingStorage<${TypeParametersDecl}>
 
   @objc
   internal func keyEnumerator() -> _NSEnumerator {
-    return bridgingKeyEnumerator(())
-  }
-
-  @objc(copyWithZone:)
-  internal func copy(with zone: _SwiftNSZone?) -> AnyObject {
-    // Instances of this class should be visible outside of standard library as
-    // having `NSDictionary` type, which is immutable.
-    return self
+    return enumerator()
   }
 
   @objc
@@ -3330,11 +3519,10 @@ final internal class _Native${Self}BridgingStorage<${TypeParametersDecl}>
 
   /// The storage for bridged ${Self} elements, if present.
   internal var _bridgedBuffer:
-    BridgedNativeStorage.Storage? {
+    BridgedStorage.RawBuffer? {
     get {
       if let ref = _stdlib_atomicLoadARCRef(object: _heapBufferBridgedPtr) {
-        return BridgedNativeStorage.Storage(_buffer: unsafeDowncast(ref, 
-            to: BridgedNativeStorage.Storage.RawBuffer.self))
+        return unsafeDowncast(ref, to: BridgedStorage.RawBuffer.self)
       }
       return nil
     }
@@ -3356,14 +3544,8 @@ final internal class _Native${Self}BridgingStorage<${TypeParametersDecl}>
   }
 
   /// Returns the bridged ${Self} values.
-  internal var bridgedNativeStorage: BridgedNativeStorage {
-    return BridgedNativeStorage(buffer: _bridgedBuffer!)
-  }
-
-  internal func _createBridgedNativeStorage(_ capacity: Int) ->
-    BridgedNativeStorage {
-    let buffer = BridgedNativeStorage.Storage.create(capacity: capacity)
-    return BridgedNativeStorage(buffer: buffer)
+  internal var bridgedStorage: BridgedStorage {
+    return BridgedStorage(_buffer: _bridgedBuffer!)
   }
 
   internal func bridgeEverything() {
@@ -3372,7 +3554,8 @@ final internal class _Native${Self}BridgingStorage<${TypeParametersDecl}>
     }
 
     // Create storage for bridged data.
-    let bridged = _createBridgedNativeStorage(nativeStorage._capacity)
+    let bridged = BridgedStorage.createUnhashable(
+      capacity: nativeStorage._capacity)
 
     // Bridge everything.
     for i in 0..<nativeStorage._capacity {
@@ -3388,52 +3571,10 @@ final internal class _Native${Self}BridgingStorage<${TypeParametersDecl}>
     }
 
     // Atomically put the bridged elements in place.
-    _initializeHeapBufferBridged(bridged.buffer._buffer)
+    _initializeHeapBufferBridged(bridged._buffer)
   }
 
-  //
-  // Entry points for bridging ${Self} elements.  In implementations of
-  // Foundation subclasses (NS${Self}, NSEnumerator), don't access any
-  // storage directly, use these functions.
-  //
-  internal func _getBridgedKey(_ i: _Native${Self}Index<${TypeParameters}>) ->
-    AnyObject {
-    if _fastPath(_isClassOrObjCExistential(Key.self)) {
-%if Self == 'Set':
-      return _bridgeAnythingToObjectiveC(nativeStorage.assertingGet(i))
-%elif Self == 'Dictionary':
-      return _bridgeAnythingToObjectiveC(nativeStorage.assertingGet(i).0)
-%end
-    }
-    bridgeEverything()
-%if Self == 'Set':
-    return bridgedNativeStorage.assertingGet(i.offset)
-%elif Self == 'Dictionary':
-    return bridgedNativeStorage.assertingGet(i.offset).0
-%end
-  }
-
-%if Self == 'Set':
-
-  internal func _getBridgedValue(_ i: _Native${Self}Index<${TypeParameters}>) ->
-    AnyObject {
-    if _fastPath(_isClassOrObjCExistential(Value.self)) {
-      return _bridgeAnythingToObjectiveC(nativeStorage.assertingGet(i))
-    }
-    bridgeEverything()
-    return bridgedNativeStorage.assertingGet(i.offset)
-  }
-
-%elif Self == 'Dictionary':
-
-  internal func _getBridgedValue(_ i: _Native${Self}Index<${TypeParameters}>)
-    -> AnyObject {
-    if _fastPath(_isClassOrObjCExistential(Value.self)) {
-      return _bridgeAnythingToObjectiveC(nativeStorage.assertingGet(i).1)
-    }
-    bridgeEverything()
-    return bridgedNativeStorage.assertingGet(i.offset).1
-  }
+%if Self == 'Dictionary':
 
   internal func bridgedAllKeysAndValues(
     _ objects: UnsafeMutablePointer<AnyObject>?,
@@ -3448,17 +3589,17 @@ final internal class _Native${Self}BridgingStorage<${TypeParametersDecl}>
       if let unmanagedObjects = _UnmanagedAnyObjectArray(objects) {
         // keys nonnull, objects nonnull
         for position in 0..<capacity {
-          if bridgedNativeStorage.isInitializedEntry(at: position) {
-            unmanagedObjects[i] = bridgedNativeStorage.value(at: position)
-            unmanagedKeys[i] = bridgedNativeStorage.key(at: position)
+          if bridgedStorage.isInitializedEntry(at: position) {
+            unmanagedObjects[i] = bridgedStorage.value(at: position)
+            unmanagedKeys[i] = bridgedStorage.key(at: position)
             i += 1
           }
         }
       } else {
         // keys nonnull, objects null
         for position in 0..<capacity {
-          if bridgedNativeStorage.isInitializedEntry(at: position) {
-            unmanagedKeys[i] = bridgedNativeStorage.key(at: position)
+          if bridgedStorage.isInitializedEntry(at: position) {
+            unmanagedKeys[i] = bridgedStorage.key(at: position)
             i += 1
           }
         }
@@ -3467,8 +3608,8 @@ final internal class _Native${Self}BridgingStorage<${TypeParametersDecl}>
       if let unmanagedObjects = _UnmanagedAnyObjectArray(objects) {
         // keys null, objects nonnull
         for position in 0..<capacity {
-          if bridgedNativeStorage.isInitializedEntry(at: position) {
-            unmanagedObjects[i] = bridgedNativeStorage.value(at: position)
+          if bridgedStorage.isInitializedEntry(at: position) {
+            unmanagedObjects[i] = bridgedStorage.value(at: position)
             i += 1
           }
         }
@@ -3497,13 +3638,15 @@ final internal class _Native${Self}BridgingStorage<${TypeParametersDecl}>
     let (i, found) = nativeStorage._find(
       nativeKey, startBucket: nativeStorage._bucket(nativeKey))
     if found {
-      return _getBridgedValue(i)
+      bridgeEverything()
+      return bridgedStorage.value(at: i.offset)
     }
     return nil
   }
 
-  internal func bridgingKeyEnumerator() -> _NSEnumerator {
-    return _Native${Self}StorageKeyNSEnumerator<${TypeParameters}>(self)
+  internal func enumerator() -> _NSEnumerator {
+    bridgeEverything()
+    return _Native${Self}NSEnumerator<${AnyTypeParameters}>(bridgedStorage)
   }
 
   @objc(countByEnumeratingWithState:objects:count:)
@@ -3532,12 +3675,17 @@ final internal class _Native${Self}BridgingStorage<${TypeParametersDecl}>
         offset: Int(theState.extra.0))
     let endIndex = nativeStorage.endIndex
     var stored = 0
+
+    if (currIndex != endIndex) {
+      bridgeEverything()
+    }
+    
     for i in 0..<count {
       if (currIndex == endIndex) {
         break
       }
 
-      let bridgedKey: AnyObject = _getBridgedKey(currIndex)
+      let bridgedKey = bridgedStorage.key(at: currIndex.offset)
       unmanagedObjects[i] = bridgedKey
       stored += 1
       nativeStorage.formIndex(after: &currIndex)
@@ -3548,7 +3696,7 @@ final internal class _Native${Self}BridgingStorage<${TypeParametersDecl}>
   }
 }
 #else
-final internal class _Native${Self}BridgingStorage<${TypeParametersDecl}> { }
+final internal class _SwiftDeferredNS${Self}<${TypeParametersDecl}> { }
 #endif
 
 #if _runtime(_ObjC)
@@ -4401,7 +4549,7 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
 }%
 
 @_versioned
-internal struct _Native${Self}Index<${TypeParametersDecl}> : Comparable {
+internal struct _Native${Self}Index<${TypeParameters}> : Comparable {
   @_versioned
   internal var offset: Int
 
@@ -4896,9 +5044,7 @@ extension ${Self} {
   public func _bridgeToObjectiveCImpl() -> _NS${Self}Core {
     switch _variantStorage {
     case _Variant${Self}Storage.native(let storage):
-      let bridgingStorage = storage.bridgingStorage()
-      return bridgingStorage as _Native${Self}BridgingStorage<${TypeParameters}>
-
+      return storage.bridgingStorage()
     case _Variant${Self}Storage.cocoa(let cocoaStorage):
       return cocoaStorage.cocoa${Self}
     }
@@ -4908,7 +5054,7 @@ extension ${Self} {
     _ s: AnyObject
   ) -> ${Self}<${TypeParameters}>? {
     if let bridgingStorage =
-        s as AnyObject as? _Native${Self}BridgingStorage<${TypeParameters}> {
+        s as AnyObject as? _SwiftDeferredNS${Self}<${TypeParameters}> {
       // If `NS${Self}` is actually native storage of `${Self}` with key
       // and value types that the requested ones match exactly, then just
       // re-wrap the native storage.

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -2903,11 +2903,19 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
         bitCount: capacity)
     initializedEntries.initializeToZero()
 
+    // Compute all the array offsets now, so we don't have to later
+    let bitmapAddr = Builtin.projectTailElems(_storage, UInt.self)
+    let numWordsForBitmap = _UnsafeBitMap.sizeInWords(forSizeInBits: capacity)
+    let keysAddr = Builtin.getTailAddr_Word(bitmapAddr,
+           numWordsForBitmap._builtinWordValue, UInt.self, Key.self)
+
     // Initialize header
     _body.initializedEntries = initializedEntries
-    _body.keys = UnsafeMutableRawPointer(_keys)
+    _body.keys = UnsafeMutableRawPointer(keysAddr)
 %if Self == 'Dictionary':
-    _body.values = UnsafeMutableRawPointer(_values)
+    let valuesAddr = Builtin.getTailAddr_Word(keysAddr,
+        capacity._builtinWordValue, Key.self, Value.self)
+    _body.values = UnsafeMutableRawPointer(valuesAddr)
 %end
   }
 
@@ -2947,27 +2955,15 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
     return _storage._initializedHashtableEntriesBitMapBuffer
   }
 
-  // This is just a convenience for computing the offset of the keys array to
-  // avoid _keys and _values duplicating logic.
-  internal var _keysRawAddr: Builtin.RawPointer {
-    // Gets the offset for the bitmap, then derives the key offset from that.
-    let bitmapAddr = Builtin.projectTailElems(_storage, UInt.self)
-    let numWordsForBitmap = _UnsafeBitMap.sizeInWords(forSizeInBits: capacity)
-    return Builtin.getTailAddr_Word(bitmapAddr,
-           numWordsForBitmap._builtinWordValue, UInt.self, Key.self)
-  }
-
   // This API is unsafe and needs a `_fixLifetime` in the caller.
-  internal var _keys: UnsafeMutablePointer<Key> {
-    return UnsafeMutablePointer(_keysRawAddr)
+  internal var keys: UnsafeMutablePointer<Key> {
+    return _body.keys.assumingMemoryBound(to: Key.self)
   }
 
 %if Self == 'Dictionary':
   // This API is unsafe and needs a `_fixLifetime` in the caller.
-  internal var _values: UnsafeMutablePointer<Value> {
-    let valuesAddr = Builtin.getTailAddr_Word(_keysRawAddr,
-        capacity._builtinWordValue, Key.self, Value.self)
-    return UnsafeMutablePointer(valuesAddr)
+  internal var values: UnsafeMutablePointer<Value> {
+    return _body.values.assumingMemoryBound(to: Value.self)
   }
 %end
 
@@ -2993,7 +2989,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
     _sanityCheck(isInitializedEntry(at: i))
     defer { _fixLifetime(self) }
 
-    let res = (_keys + i).pointee
+    let res = (keys + i).pointee
     return res
   }
 
@@ -3028,9 +3024,9 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
     _sanityCheck(isInitializedEntry(at: i))
     defer { _fixLifetime(self) }
 
-    (_keys + i).deinitialize()
+    (keys + i).deinitialize()
 %if Self == 'Dictionary':
-    (_values + i).deinitialize()
+    (values + i).deinitialize()
 %end
     _body.initializedEntries[i] = false
   }
@@ -3041,7 +3037,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
     _sanityCheck(!isInitializedEntry(at: i))
     defer { _fixLifetime(self) }
 
-    (_keys + i).initialize(to: k)
+    (keys + i).initialize(to: k)
     _body.initializedEntries[i] = true
   }
 
@@ -3051,7 +3047,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
 
     defer { _fixLifetime(self) }
 
-    (_keys + toEntryAt).initialize(to: (from._keys + at).move())
+    (keys + toEntryAt).initialize(to: (from.keys + at).move())
     from._body.initializedEntries[at] = false
     _body.initializedEntries[toEntryAt] = true
   }
@@ -3068,7 +3064,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
     _sanityCheck(isInitializedEntry(at: i))
     defer { _fixLifetime(self) }
 
-    (_keys + i).pointee = key
+    (keys + i).pointee = key
   }
 
 %elif Self == 'Dictionary':
@@ -3077,8 +3073,8 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
     _sanityCheck(!isInitializedEntry(at: i))
     defer { _fixLifetime(self) }
 
-    (_keys + i).initialize(to: k)
-    (_values + i).initialize(to: v)
+    (keys + i).initialize(to: k)
+    (values + i).initialize(to: v)
     _body.initializedEntries[i] = true
   }
 
@@ -3087,8 +3083,8 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
     _sanityCheck(!isInitializedEntry(at: toEntryAt))
     defer { _fixLifetime(self) }
 
-    (_keys + toEntryAt).initialize(to: (from._keys + at).move())
-    (_values + toEntryAt).initialize(to: (from._values + at).move())
+    (keys + toEntryAt).initialize(to: (from.keys + at).move())
+    (values + toEntryAt).initialize(to: (from.values + at).move())
     from._body.initializedEntries[at] = false
     _body.initializedEntries[toEntryAt] = true
   }
@@ -3099,7 +3095,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
     _sanityCheck(isInitializedEntry(at: i))
     defer { _fixLifetime(self) }
 
-    return (_values + i).pointee
+    return (values + i).pointee
   }
 
   @_transparent
@@ -3107,8 +3103,8 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
     _sanityCheck(isInitializedEntry(at: i))
     defer { _fixLifetime(self) }
 
-    (_keys + i).pointee = key
-    (_values + i).pointee = value
+    (keys + i).pointee = key
+    (values + i).pointee = value
   }
 
 %end

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -454,7 +454,10 @@ public struct Set<Element : Hashable> :
     return _variantStorage.endIndex
   }
 
-  // TODO: swift-3-indexing-model - add docs
+  /// Returns the index after the given one. 
+  ///
+  /// If this is the last valid index, returns endIndex.
+  /// Aborts on endIndex.
   public func index(after i: Index) -> Index {
     return _variantStorage.index(after: i)
   }
@@ -1662,7 +1665,10 @@ public struct Dictionary<Key : Hashable, Value> :
     return _variantStorage.endIndex
   }
 
-  // TODO: swift-3-indexing-model - add docs
+  /// Returns the index after the given one. 
+  ///
+  /// If this is the last valid index, returns endIndex.
+  /// Aborts on endIndex.
   public func index(after i: Index) -> Index {
     return _variantStorage.index(after: i)
   }
@@ -2063,15 +2069,15 @@ extension Dictionary where Key : Equatable, Value : Equatable {
         let (key, value) = lhsNative.assertingGet(index)
         let optRhsValue: AnyObject? =
           rhsCocoa.maybeGet(_bridgeAnythingToObjectiveC(key))
-        // TODO: swift-3-indexing-model: change 'if' into 'guard'.
-        if let rhsValue = optRhsValue {
-          if value == _forceBridgeFromObjectiveC(rhsValue, Value.self) {
-            lhsNative.formIndex(after: &index)
-            continue
-          }
+
+        guard let rhsValue = optRhsValue,
+          value == _forceBridgeFromObjectiveC(rhsValue, Value.self)
+        else {
+          return false
         }
-        index = lhsNative.index(after: index)
-        return false
+
+        lhsNative.formIndex(after: &index)
+        continue
       }
       return true
   #else
@@ -4321,6 +4327,10 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
   }
 }
 
+%{
+  compareOperators = ["<", "<=", ">", ">=", "=="]
+}%
+
 @_versioned
 internal struct _Native${Self}Index<${TypeParametersDecl}> : Comparable {
   @_versioned
@@ -4333,23 +4343,18 @@ internal struct _Native${Self}Index<${TypeParametersDecl}> : Comparable {
 }
 
 extension _Native${Self}Index {
-  internal static func == (
-    lhs: _Native${Self}Index<${TypeParameters}>,
-    rhs: _Native${Self}Index<${TypeParameters}>
-  ) -> Bool {
-    // FIXME: assert that lhs and rhs are from the same dictionary.
-    return lhs.offset == rhs.offset
-  }
 
-  internal static func < (
+% for op in compareOperators:
+  internal static func ${op} (
     lhs: _Native${Self}Index<${TypeParameters}>,
     rhs: _Native${Self}Index<${TypeParameters}>
   ) -> Bool {
-    // FIXME: assert that lhs and rhs are from the same dictionary.
-    return lhs.offset < rhs.offset
+    return lhs.offset ${op} rhs.offset
   }
-  // TODO: swift-3-indexing-model: forward all Comparable operations.
+% end
+
 }
+
 
 #if _runtime(_ObjC)
 @_versioned
@@ -4363,19 +4368,16 @@ internal struct _Cocoa${Self}Index : Comparable {
 }
 
 extension _Cocoa${Self}Index {
-  internal static func == (
-    lhs: _Cocoa${Self}Index,
-    rhs: _Cocoa${Self}Index
-  ) -> Bool {
-    return lhs.currentKeyIndex == rhs.currentKeyIndex
-  }
 
-  internal static func < (
+% for op in compareOperators:
+  internal static func ${op} (
     lhs: _Cocoa${Self}Index,
     rhs: _Cocoa${Self}Index
   ) -> Bool {
-    return lhs.currentKeyIndex < rhs.currentKeyIndex
+    return lhs.currentKeyIndex ${op} rhs.currentKeyIndex
   }
+% end
+
 }
 #else
 internal struct _Cocoa${Self}Index {}
@@ -4413,9 +4415,8 @@ elif Self == 'Dictionary':
 ${SubscriptingWithIndexDoc}
 public struct ${Self}Index<${TypeParametersDecl}> :
   Comparable {
-  // FIXME(swift-3-indexing-model): rewrite the fixme to reflect the new index model
   // FIXME(ABI)#34 (Nesting types in generics): `DictionaryIndex` and `SetIndex` should
-  // be nested types.
+  // be nested types (Dictionary.Index and Set.Index).
   // rdar://problem/17002096
 
   // Index for native storage is efficient.  Index for bridged NS${Self} is

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -12,6 +12,7 @@
 
 import SwiftShims
 
+// TODO: swift-3-indexing-model: rewrite this description to reflect new indexing model
 // General Mutable, Value-Type Collections
 // =================================================
 //
@@ -464,18 +465,12 @@ public struct Set<Element : Hashable> :
   public init(minimumCapacity: Int) {
     _variantStorage =
       _VariantStorage.native(
-        _NativeStorage.Owner(minimumCapacity: minimumCapacity))
+        _NativeStorage.create(minimumCapacity: minimumCapacity))
   }
 
   /// Private initializer.
   internal init(_nativeStorage: _NativeSetStorage<Element>) {
-    _variantStorage = _VariantStorage.native(
-      _NativeStorage.Owner(nativeStorage: _nativeStorage))
-  }
-
-  /// Private initializer.
-  internal init(_nativeStorageOwner: _NativeSetStorageOwner<Element>) {
-    _variantStorage = .native(_nativeStorageOwner)
+    _variantStorage = _VariantStorage.native(_nativeStorage)
   }
 
   //
@@ -516,7 +511,7 @@ public struct Set<Element : Hashable> :
 
   // TODO: swift-3-indexing-model - add docs
   public func index(after i: Index) -> Index {
-    return i.successor()
+    return _variantStorage.index(after: i)
   }
 
   // APINAMING: complexity docs are broadly missing in this file.
@@ -768,8 +763,8 @@ public struct Set<Element : Hashable> :
       // adopt its native storage and let COW handle uniquing only
       // if necessary.
       switch s._variantStorage {
-        case .native(let owner):
-          _variantStorage = .native(owner)
+        case .native(let storage):
+          _variantStorage = .native(storage)
         case .cocoa(let owner):
           _variantStorage = .cocoa(owner)
       }
@@ -1172,15 +1167,13 @@ extension Set {
   ///   `false`.
   public static func == (lhs: Set<Element>, rhs: Set<Element>) -> Bool {
     switch (lhs._variantStorage, rhs._variantStorage) {
-    case (.native(let lhsNativeOwner), .native(let rhsNativeOwner)):
-      let lhsNative = lhsNativeOwner.nativeStorage
-      let rhsNative = rhsNativeOwner.nativeStorage
+    case (.native(let lhsNative), .native(let rhsNative)):
 
-      if lhsNativeOwner === rhsNativeOwner {
+      if lhsNative === rhsNative {
         return true
       }
 
-      if lhsNative.count != rhsNative.count {
+      if lhsNative._count != rhsNative._count {
         return false
       }
 
@@ -1201,12 +1194,11 @@ extension Set {
         _sanityCheckFailure("internal error: unexpected cocoa set")
   #endif
 
-    case (_VariantSetStorage.native(let lhsNativeOwner),
+    case (_VariantSetStorage.native(let lhsNative),
       _VariantSetStorage.cocoa(let rhsCocoa)):
   #if _runtime(_ObjC)
-      let lhsNative = lhsNativeOwner.nativeStorage
 
-      if lhsNative.count != rhsCocoa.count {
+      if lhsNative._count != rhsCocoa.count {
         return false
       }
 
@@ -1218,11 +1210,11 @@ extension Set {
         let optRhsValue: AnyObject? = rhsCocoa.maybeGet(bridgedKey)
         if let rhsValue = optRhsValue {
           if key == _forceBridgeFromObjectiveC(rhsValue, Element.self) {
-            i = i.successor()
+            i = lhsNative.index(after: i)
             continue
           }
         }
-        i = i.successor()
+        i = lhsNative.index(after: i)
         return false
       }
       return true
@@ -1353,10 +1345,11 @@ public func _setDownCast<BaseValue, DerivedValue>(_ source: Set<BaseValue>)
   if _isClassOrObjCExistential(BaseValue.self)
   && _isClassOrObjCExistential(DerivedValue.self) {
     switch source._variantStorage {
-    case _VariantSetStorage.native(let nativeOwner):
+    case _VariantSetStorage.native(let storage):
+      let bridgingStorage = storage.bridgingStorage()
       return Set(
         _immutableCocoaSet:
-        unsafeBitCast(nativeOwner, to: _NSSet.self))
+        unsafeBitCast(bridgingStorage, to: _NSSet.self))
 
     case _VariantSetStorage.cocoa(let cocoaStorage):
       return Set(
@@ -1671,18 +1664,12 @@ public struct Dictionary<Key : Hashable, Value> :
   ///   allocate storage for in the new dictionary.
   public init(minimumCapacity: Int) {
     _variantStorage =
-      .native(_NativeStorage.Owner(minimumCapacity: minimumCapacity))
+      .native(_NativeStorage.create(minimumCapacity: minimumCapacity))
   }
 
   internal init(_nativeStorage: _NativeDictionaryStorage<Key, Value>) {
     _variantStorage =
-      .native(_NativeStorage.Owner(nativeStorage: _nativeStorage))
-  }
-
-  internal init(
-    _nativeStorageOwner: _NativeDictionaryStorageOwner<Key, Value>
-  ) {
-    _variantStorage = .native(_nativeStorageOwner)
+      .native(_nativeStorage)
   }
 
 #if _runtime(_ObjC)
@@ -1732,7 +1719,7 @@ public struct Dictionary<Key : Hashable, Value> :
 
   // TODO: swift-3-indexing-model - add docs
   public func index(after i: Index) -> Index {
-    return i.successor()
+    return _variantStorage.index(after: i)
   }
 
   /// Returns the index for the given key.
@@ -2082,15 +2069,13 @@ public struct Dictionary<Key : Hashable, Value> :
 extension Dictionary where Key : Equatable, Value : Equatable {
   public static func == (lhs: [Key : Value], rhs: [Key : Value]) -> Bool {
     switch (lhs._variantStorage, rhs._variantStorage) {
-    case (.native(let lhsNativeOwner), .native(let rhsNativeOwner)):
-      let lhsNative = lhsNativeOwner.nativeStorage
-      let rhsNative = rhsNativeOwner.nativeStorage
+    case (.native(let lhsNative), .native(let rhsNative)):
 
-      if lhsNativeOwner === rhsNativeOwner {
+      if lhsNative === rhsNative {
         return true
       }
 
-      if lhsNative.count != rhsNative.count {
+      if lhsNative._count != rhsNative._count {
         return false
       }
 
@@ -2120,11 +2105,10 @@ extension Dictionary where Key : Equatable, Value : Equatable {
       _sanityCheckFailure("internal error: unexpected cocoa dictionary")
   #endif
 
-    case (.native(let lhsNativeOwner), .cocoa(let rhsCocoa)):
+    case (.native(let lhsNative), .cocoa(let rhsCocoa)):
   #if _runtime(_ObjC)
-      let lhsNative = lhsNativeOwner.nativeStorage
 
-      if lhsNative.count != rhsCocoa.count {
+      if lhsNative._count != rhsCocoa.count {
         return false
       }
 
@@ -2141,6 +2125,7 @@ extension Dictionary where Key : Equatable, Value : Equatable {
             continue
           }
         }
+        index = lhsNative.index(after: index)
         return false
       }
       return true
@@ -2314,7 +2299,8 @@ public func _dictionaryDownCast<BaseKey, BaseValue, DerivedKey, DerivedValue>(
   && _isClassOrObjCExistential(DerivedValue.self) {
 
     switch source._variantStorage {
-    case .native(let nativeOwner):
+    case .native(let storage):
+      // TODO: rewrite the docs
       // FIXME(performance): this introduces an indirection through Objective-C
       // runtime, even though we access native storage.  But we cannot
       // unsafeBitCast the owner object, because that would change the generic
@@ -2326,9 +2312,10 @@ public func _dictionaryDownCast<BaseKey, BaseValue, DerivedKey, DerivedValue>(
       //
       // Note: it is safe to treat the storage as immutable here because
       // Dictionary will not mutate storage with reference count greater than 1.
+      let nativeStorage = storage.bridgingStorage()
       return Dictionary(
         _immutableCocoaDictionary:
-        unsafeBitCast(nativeOwner, to: _NSDictionary.self))
+        unsafeBitCast(nativeStorage, to: _NSDictionary.self))
 
     case .cocoa(let cocoaStorage):
       return Dictionary(
@@ -2495,38 +2482,62 @@ collections = [
 ]
 }%
 
+% for (Self, a_self, TypeParametersDecl, TypeParameters, AnyTypeParameters, Sequence, AnySequenceType) in collections:
+
 /// Header part of the native storage.
-internal struct _HashedContainerStorageHeader {
+internal struct _${Self}StorageHeader<${TypeParameters}> {
+
+%if Self == 'Set':
+  internal typealias Key = ${TypeParameters}
+  internal typealias Value = ${TypeParameters}
+%end
+
   internal init(capacity: Int) {
     self.capacity = capacity
   }
 
-  internal var capacity: Int
+  internal let capacity: Int
   internal var count: Int = 0
-  internal var maxLoadFactorInverse: Double =
+  internal let maxLoadFactorInverse: Double =
     _hashContainerDefaultMaxLoadFactorInverse
-}
 
-% for (Self, a_self, TypeParametersDecl, TypeParameters, AnyTypeParameters, Sequence, AnySequenceType) in collections:
+  // Placeholder values until the struct can be initialized.
+  internal var initializedEntries: _UnsafeBitMap! = nil
+  internal var keys: UnsafeMutablePointer<Key>! = nil
+% if Self == 'Dictionary':
+  internal var values: UnsafeMutablePointer<Value>! = nil
+% end
+}
 
 /// An instance of this class has all `${Self}` data tail-allocated.
 /// Enough bytes are allocated to hold the bitmap for marking valid entries,
 /// keys, and values. The data layout starts with the bitmap, followed by the
 /// keys, followed by the values.
 @_versioned
-final internal class _Native${Self}StorageImpl<${TypeParameters}> {
+final internal class _Native${Self}Storage<${TypeParameters}> :
+  ManagedBuffer<_${Self}StorageHeader<${TypeParameters}>, UInt8> {
   // Note: It is intended that ${TypeParameters}
   // (without : Hashable) is used here - this storage must work
   // with non-Hashable types.
 
-  internal typealias StorageImpl = _Native${Self}StorageImpl
+  internal typealias StorageHeader = _${Self}StorageHeader<${TypeParameters}>
+  internal typealias BufferPointer =
+    ManagedBufferPointer<StorageHeader, UInt8>
+  internal typealias Storage = _Native${Self}Storage<${TypeParameters}>
 
 %if Self == 'Set': # Set needs these to keep signatures simple.
   internal typealias Key = ${TypeParameters}
+  internal typealias Value = ${TypeParameters}
+  internal typealias SequenceElementWithoutLabels = Element
+%else:
+  internal typealias SequenceElementWithoutLabels = (Key, Value)
 %end
 
-  internal var _body: _HashedContainerStorageHeader
+  internal var _body: StorageHeader
 
+  /// The number of _logical elements_ the ${a_self} can store. Not to be
+  /// confused with `capacity`, the total number of raw `UInt8` bytes stored
+  /// by the `ManagedBuffer`.
   @_versioned
   internal var _capacity: Int {
     return _assumeNonNegative(_body.capacity)
@@ -2573,29 +2584,48 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> {
   }
 %end
 
-  /// Create a storage instance with room for 'capacity' entries and all entries
-  /// marked invalid.
-  internal class func create(capacity: Int) -> StorageImpl {
+  @inline(__always)
+  internal static func create(minimumCapacity: Int) -> Storage {
+    // Make sure there's a representable power of 2 >= minimumCapacity
+    _sanityCheck(minimumCapacity <= (Int.max >> 1) + 1)
+    var capacity = 2
+    while capacity < minimumCapacity {
+      capacity <<= 1
+    }
+    return create(capacity: capacity)
+  }
+
+  /// Create a storage instance with room for at least 'capacity'
+  /// entries and all entries marked invalid.
+  internal static func create(capacity: Int) -> Storage {
     let numWordsForBitmap = _UnsafeBitMap.sizeInWords(forSizeInBits: capacity)
 %if Self == 'Dictionary':
-    let storage = Builtin.allocWithTailElems_3(StorageImpl.self,
+    let storage = Builtin.allocWithTailElems_3(Storage.self,
         numWordsForBitmap._builtinWordValue, UInt.self,
         capacity._builtinWordValue, Key.self,
         capacity._builtinWordValue, Value.self)
 %else:
-    let storage = Builtin.allocWithTailElems_2(StorageImpl.self,
+    let storage = Builtin.allocWithTailElems_2(Storage.self,
         numWordsForBitmap._builtinWordValue, UInt.self,
         capacity._builtinWordValue, Key.self)
 %end
 
     // We can initialize by assignment because _HashedContainerStorageHeader
     // is a trivial type, i.e. contains no references.
-    storage._body = _HashedContainerStorageHeader(capacity: capacity)
+    storage._body = StorageHeader(capacity: capacity)
 
     let initializedEntries = _UnsafeBitMap(
         storage: storage._initializedHashtableEntriesBitMapStorage,
         bitCount: capacity)
     initializedEntries.initializeToZero()
+
+    // Initialize header
+    storage._body.initializedEntries = initializedEntries
+    storage._body.keys = storage._keys
+%if Self == 'Dictionary':
+    storage._body.values = storage._values
+%end
+
     return storage
   }
 
@@ -2628,196 +2658,156 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> {
     _fixLifetime(self)
   }
 
-  internal init(_doNotCallMe: ()) {
+  override internal init(_doNotCallMe: ()) {
     _sanityCheckFailure("Only initialize these by calling create")
   }
 }
 
-@_fixed_layout
-public // @testable
-struct _Native${Self}Storage<${TypeParametersDecl}> :
-  _HashStorage, CustomStringConvertible {
-  internal typealias Owner = _Native${Self}StorageOwner<${TypeParameters}>
-  internal typealias StorageImpl = _Native${Self}StorageImpl<${TypeParameters}>
+// TODO: conditionally conform to _HashStorage for better compile-time safety.
+// TODO: conditionally conform to CustomStringConvertible.
+extension _Native${Self}Storage 
+  where ${'Key' if Self == 'Dictionary' else 'Element'} : Hashable
+{
   internal typealias SequenceElement = ${Sequence}
-%if Self == 'Set':
-  internal typealias SequenceElementWithoutLabels = Element
-%else:
-  internal typealias SequenceElementWithoutLabels = (Key, Value)
-%end
-  internal typealias Storage = _Native${Self}Storage<${TypeParameters}>
 
-%if Self == 'Set': # Set needs these to keep signatures simple.
-  internal typealias Key = ${TypeParameters}
-  internal typealias Value = ${TypeParameters}
-%end
-
-  internal let buffer: StorageImpl
-
-  internal let initializedEntries: _UnsafeBitMap
-  internal let keys: UnsafeMutablePointer<Key>
-%if Self == 'Dictionary':
-  internal let values: UnsafeMutablePointer<Value>
-%end
-
-  internal init(capacity: Int) {
-    buffer = StorageImpl.create(capacity: capacity)
-    initializedEntries = _UnsafeBitMap(
-      storage: buffer._initializedHashtableEntriesBitMapStorage,
-      bitCount: capacity)
-    keys = buffer._keys
-%if Self == 'Dictionary':
-    values = buffer._values
-%end
-    _fixLifetime(buffer)
+#if _runtime(_ObjC)
+  func bridgingStorage() -> _Native${Self}BridgingStorage<${TypeParameters}> {
+    return _Native${Self}BridgingStorage(nativeStorage: self)
   }
+#endif
 
-  internal init(minimumCapacity: Int = 2) {
-    // Make sure there's a representable power of 2 >= minimumCapacity
-    _sanityCheck(minimumCapacity <= (Int.max >> 1) + 1)
-
-    var capacity = 2
-    while capacity < minimumCapacity {
-      capacity <<= 1
+  /// A textual representation of `self`.
+  var description: String {
+    var result = ""
+#if INTERNAL_CHECKS_ENABLED
+    for i in 0..<_capacity {
+      if isInitializedEntry(at: i) {
+        let key = self.key(at: i)
+        result += "bucket \(i), ideal bucket = \(_bucket(key)), key = \(key)\n"
+      } else {
+        result += "bucket \(i), empty\n"
+      }
     }
-
-    self = _Native${Self}Storage(capacity: capacity)
-  }
-
-  @_transparent
-  public // @testable
-  var capacity: Int {
-    return buffer._capacity
-  }
-
-  @_versioned
-  @_transparent
-  internal var count: Int {
-    get {
-      return buffer._count
-    }
-    nonmutating set(newValue) {
-      buffer._count = newValue
-    }
-  }
-
-  @_transparent
-  internal var maxLoadFactorInverse: Double {
-    return buffer._maxLoadFactorInverse
+#endif
+    return result
   }
 
   @_versioned
   @inline(__always)
   internal func key(at i: Int) -> Key {
-    _sanityCheck(i >= 0 && i < capacity)
+    _sanityCheck(i >= 0 && i < _capacity)
     _sanityCheck(isInitializedEntry(at: i))
+    defer { _fixLifetime(self) }
 
-    let res = (keys + i).pointee
-    _fixLifetime(self)
+    let res = (_body.keys + i).pointee
     return res
   }
 
   @_versioned
   internal func isInitializedEntry(at i: Int) -> Bool {
-    _sanityCheck(i >= 0 && i < capacity)
-    return initializedEntries[i]
+    _sanityCheck(i >= 0 && i < _capacity)
+    defer { _fixLifetime(self) }
+
+    return _body.initializedEntries[i]
   }
 
   @_transparent
   internal func destroyEntry(at i: Int) {
     _sanityCheck(isInitializedEntry(at: i))
-    (keys + i).deinitialize()
+    defer { _fixLifetime(self) }
+
+    (_body.keys + i).deinitialize()
 %if Self == 'Dictionary':
-    (values + i).deinitialize()
+    (_body.values + i).deinitialize()
 %end
-    initializedEntries[i] = false
-    _fixLifetime(self)
+    _body.initializedEntries[i] = false
   }
 
 %if Self == 'Set':
   @_transparent
   internal func initializeKey(_ k: Key, at i: Int) {
     _sanityCheck(!isInitializedEntry(at: i))
+    defer { _fixLifetime(self) }
 
-    (keys + i).initialize(to: k)
-    initializedEntries[i] = true
-    _fixLifetime(self)
+    (_body.keys + i).initialize(to: k)
+    _body.initializedEntries[i] = true
   }
 
   @_transparent
   internal func moveInitializeEntry(from: Storage, at: Int, toEntryAt: Int) {
     _sanityCheck(!isInitializedEntry(at: toEntryAt))
-    (keys + toEntryAt).initialize(to: (from.keys + at).move())
-    from.initializedEntries[at] = false
-    initializedEntries[toEntryAt] = true
+
+    defer { _fixLifetime(self) }
+
+    (_body.keys + toEntryAt).initialize(to: (from._body.keys + at).move())
+    from._body.initializedEntries[at] = false
+    _body.initializedEntries[toEntryAt] = true
   }
 
   internal func setKey(_ key: Key, at i: Int) {
-    _sanityCheck(i >= 0 && i < capacity)
+    _sanityCheck(i >= 0 && i < _capacity)
     _sanityCheck(isInitializedEntry(at: i))
+    defer { _fixLifetime(self) }
 
-    (keys + i).pointee = key
-    _fixLifetime(self)
+    (_body.keys + i).pointee = key
   }
 
 %elif Self == 'Dictionary':
   @_transparent
   internal func initializeKey(_ k: Key, value v: Value, at i: Int) {
     _sanityCheck(!isInitializedEntry(at: i))
+    defer { _fixLifetime(self) }
 
-    (keys + i).initialize(to: k)
-    (values + i).initialize(to: v)
-    initializedEntries[i] = true
-    _fixLifetime(self)
+    (_body.keys + i).initialize(to: k)
+    (_body.values + i).initialize(to: v)
+    _body.initializedEntries[i] = true
   }
 
   @_transparent
   internal func moveInitializeEntry(from: Storage, at: Int, toEntryAt: Int) {
     _sanityCheck(!isInitializedEntry(at: toEntryAt))
-    (keys + toEntryAt).initialize(to: (from.keys + at).move())
-    (values + toEntryAt).initialize(to: (from.values + at).move())
-    from.initializedEntries[at] = false
-    initializedEntries[toEntryAt] = true
+
+    (_body.keys + toEntryAt).initialize(to: (from._body.keys + at).move())
+    (_body.values + toEntryAt).initialize(to: (from._body.values + at).move())
+    from._body.initializedEntries[at] = false
+    _body.initializedEntries[toEntryAt] = true
   }
 
   @_versioned
   @_transparent
   internal func value(at i: Int) -> Value {
     _sanityCheck(isInitializedEntry(at: i))
+    defer { _fixLifetime(self) }
 
-    let res = (values + i).pointee
-    _fixLifetime(self)
+    let res = (_body.values + i).pointee
     return res
   }
 
   @_transparent
   internal func setKey(_ key: Key, value: Value, at i: Int) {
     _sanityCheck(isInitializedEntry(at: i))
-    (keys + i).pointee = key
-    (values + i).pointee = value
-    _fixLifetime(self)
+    defer { _fixLifetime(self) }
+
+    (_body.keys + i).pointee = key
+    (_body.values + i).pointee = value
   }
 
 %end
 
-  //
-  // Implementation details
-  //
-
   internal var _bucketMask: Int {
     // The capacity is not negative, therefore subtracting 1 will not overflow.
-    return capacity &- 1
+    return _capacity &- 1
   }
 
   @_versioned
   @inline(__always) // For performance reasons.
   internal func _bucket(_ k: Key) -> Int {
-    return _squeezeHashValue(k.hashValue, capacity)
+    return _squeezeHashValue(k.hashValue, _capacity)
   }
 
   @_versioned
   internal func _index(after bucket: Int) -> Int {
-    // Bucket is within 0 and capacity. Therefore adding 1 does not overflow.
+    // Bucket is within 0 and _capacity. Therefore adding 1 does not overflow.
     return (bucket &+ 1) & _bucketMask
   }
 
@@ -2842,10 +2832,10 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
     while true {
       let isHole = !isInitializedEntry(at: bucket)
       if isHole {
-        return (Index(nativeStorage: self, offset: bucket), false)
+        return (Index(offset: bucket), false)
       }
       if self.key(at: bucket) == key {
-        return (Index(nativeStorage: self, offset: bucket), true)
+        return (Index(offset: bucket), true)
       }
       bucket = _index(after: bucket)
     }
@@ -2867,7 +2857,7 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
 
 %if Self == 'Set':
 
-  internal mutating func unsafeAddNew(key newKey: Element) {
+  internal func unsafeAddNew(key newKey: Element) {
     let (i, found) = _find(newKey, startBucket: _bucket(newKey))
     _sanityCheck(
       !found, "unsafeAddNew was called, but the key is already present")
@@ -2876,7 +2866,7 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
 
 %elif Self == 'Dictionary':
 
-  internal mutating func unsafeAddNew(key newKey: Key, value: Value) {
+  internal func unsafeAddNew(key newKey: Key, value: Value) {
     let (i, found) = _find(newKey, startBucket: _bucket(newKey))
     _sanityCheck(
       !found, "unsafeAddNew was called, but the key is already present")
@@ -2884,23 +2874,6 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
   }
 
 %end
-
-  /// A textual representation of `self`.
-  public // @testable
-  var description: String {
-    var result = ""
-#if INTERNAL_CHECKS_ENABLED
-    for i in 0..<capacity {
-      if isInitializedEntry(at: i) {
-        let key = self.key(at: i)
-        result += "bucket \(i), ideal bucket = \(_bucket(key)), key = \(key)\n"
-      } else {
-        result += "bucket \(i), empty\n"
-      }
-    }
-#endif
-    return result
-  }
 
   //
   // _HashStorage conformance
@@ -2910,28 +2883,36 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
 
   @_versioned
   internal var startIndex: Index {
-    return Index(nativeStorage: self, offset: -1).successor()
+    // We start at "index after -1" instead of "0" because we need to find the
+    // first occupied slot.
+    return index(after: Index(offset: -1))
   }
 
   @_versioned
   internal var endIndex: Index {
-    return Index(nativeStorage: self, offset: capacity)
+    return Index(offset: _capacity)
   }
 
   @_versioned
   internal func index(after i: Index) -> Index {
-    return i.successor()
+    _precondition(i != endIndex)
+    var idx = i.offset + 1
+    while idx < _capacity && !isInitializedEntry(at: idx) {
+      idx += 1
+    }
+
+    return Index(offset: idx)
   }
 
+  @_versioned
   internal func formIndex(after i: inout Index) {
-    // FIXME: swift-3-indexing-model: optimize if possible.
-    i = i.successor()
+    i = index(after: i)
   }
 
   @_versioned
   @inline(__always)
   internal func index(forKey key: Key) -> Index? {
-    if count == 0 {
+    if _count == 0 {
       // Fast path that avoids computing the hash of the key.
       return nil
     }
@@ -2966,7 +2947,7 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
   @_versioned
   @inline(__always)
   internal func maybeGet(_ key: Key) -> Value? {
-    if count == 0 {
+    if _count == 0 {
       // Fast path that avoids computing the hash of the key.
       return nil
     }
@@ -2983,13 +2964,13 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
   }
 
   @discardableResult
-  internal mutating func updateValue(_ value: Value, forKey key: Key) -> Value? {
+  internal func updateValue(_ value: Value, forKey key: Key) -> Value? {
     _sanityCheckFailure(
       "don't call mutating methods on _Native${Self}Storage")
   }
 
   @discardableResult
-  internal mutating func insert(
+  internal func insert(
     _ value: Value, forKey key: Key
   ) -> (inserted: Bool, memberAfterInsert: Value) {
     _sanityCheckFailure(
@@ -2997,31 +2978,31 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
   }
 
   @discardableResult
-  internal mutating func remove(at index: Index) -> SequenceElement {
+  internal func remove(at index: Index) -> SequenceElement {
     _sanityCheckFailure(
       "don't call mutating methods on _Native${Self}Storage")
   }
 
   @discardableResult
-  internal mutating func removeValue(forKey key: Key) -> Value? {
+  internal func removeValue(forKey key: Key) -> Value? {
     _sanityCheckFailure(
       "don't call mutating methods on _Native${Self}Storage")
   }
 
-  internal mutating func removeAll(keepingCapacity keepCapacity: Bool) {
+  internal func removeAll(keepingCapacity keepCapacity: Bool) {
     _sanityCheckFailure(
       "don't call mutating methods on _Native${Self}Storage")
   }
 
   internal static func fromArray(_ elements: [SequenceElementWithoutLabels])
-    -> _Native${Self}Storage<${TypeParameters}> {
+    -> Storage 
+  {
 
     let requiredCapacity =
-      _Native${Self}Storage<${TypeParameters}>.minimumCapacity(
+      Storage.minimumCapacity(
         minimumCount: elements.count,
         maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
-    let nativeStorage = _Native${Self}Storage<${TypeParameters}>(
-      minimumCapacity: requiredCapacity)
+    let nativeStorage = Storage.create(minimumCapacity: requiredCapacity)
 
 %if Self == 'Set':
 
@@ -3035,7 +3016,7 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
       nativeStorage.initializeKey(key, at: i.offset)
       count += 1
     }
-    nativeStorage.count = count
+    nativeStorage._count = count
 
 %elif Self == 'Dictionary':
 
@@ -3045,7 +3026,7 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
       _precondition(!found, "${Self} literal contains duplicate keys")
       nativeStorage.initializeKey(key, value: value, at: i.offset)
     }
-    nativeStorage.count = elements.count
+    nativeStorage._count = elements.count
 
 %end
 
@@ -3058,18 +3039,18 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
 /// `${Self}<${AnyTypeParameters}>`, but `AnyObject` cannot be a Key because
 /// it is not `Hashable`.
 internal struct _BridgedNative${Self}Storage {
-  internal typealias StorageImpl =
-    _Native${Self}StorageImpl<${AnyTypeParameters}>
+  internal typealias Storage =
+    _Native${Self}Storage<${AnyTypeParameters}>
   internal typealias SequenceElement = ${AnySequenceType}
 
-  internal let buffer: StorageImpl
+  internal let buffer: Storage
   internal let initializedEntries: _UnsafeBitMap
   internal let keys: UnsafeMutablePointer<AnyObject>
 %if Self == 'Dictionary':
   internal let values: UnsafeMutablePointer<AnyObject>
 %end
 
-  internal init(buffer: StorageImpl) {
+  internal init(buffer: Storage) {
     self.buffer = buffer
     initializedEntries = _UnsafeBitMap(
       storage: buffer._initializedHashtableEntriesBitMapStorage,
@@ -3083,9 +3064,7 @@ internal struct _BridgedNative${Self}Storage {
 
   @_transparent
   internal var capacity: Int {
-    let result = buffer._capacity
-    _fixLifetime(buffer)
-    return result
+    return buffer._capacity
   }
 
   @_versioned
@@ -3158,21 +3137,21 @@ final internal class _Native${Self}StorageKeyNSEnumerator<
 >
   : _SwiftNativeNSEnumerator, _NSEnumerator {
 
-  internal typealias NativeStorageOwner =
-    _Native${Self}StorageOwner<${TypeParameters}>
+  internal typealias BridgingStorage =
+    _Native${Self}BridgingStorage<${TypeParameters}>
   internal typealias Index = _Native${Self}Index<${TypeParameters}>
 
   internal override required init() {
     _sanityCheckFailure("don't call this designated initializer")
   }
 
-  internal init(_ nativeStorageOwner: NativeStorageOwner) {
-    self.nativeStorageOwner = nativeStorageOwner
-    nextIndex = nativeStorageOwner.nativeStorage.startIndex
-    endIndex = nativeStorageOwner.nativeStorage.endIndex
+  internal init(_ bridgingStorage: BridgingStorage) {
+    self.bridgingStorage = bridgingStorage
+    nextIndex = bridgingStorage.nativeStorage.startIndex
+    endIndex = bridgingStorage.nativeStorage.endIndex
   }
 
-  internal var nativeStorageOwner: NativeStorageOwner
+  internal var bridgingStorage: BridgingStorage
   internal var nextIndex: Index
   internal var endIndex: Index
 
@@ -3187,8 +3166,8 @@ final internal class _Native${Self}StorageKeyNSEnumerator<
     if nextIndex == endIndex {
       return nil
     }
-    let bridgedKey: AnyObject = nativeStorageOwner._getBridgedKey(nextIndex)
-    nativeStorageOwner.nativeStorage.formIndex(after: &nextIndex)
+    let bridgedKey: AnyObject = bridgingStorage._getBridgedKey(nextIndex)
+    bridgingStorage.nativeStorage.formIndex(after: &nextIndex)
     return bridgedKey
   }
 
@@ -3212,8 +3191,8 @@ final internal class _Native${Self}StorageKeyNSEnumerator<
 
     // Return only a single element so that code can start iterating via fast
     // enumeration, terminate it, and continue via NSEnumerator.
-    let bridgedKey: AnyObject = nativeStorageOwner._getBridgedKey(nextIndex)
-    nativeStorageOwner.nativeStorage.formIndex(after: &nextIndex)
+    let bridgedKey: AnyObject = bridgingStorage._getBridgedKey(nextIndex)
+    bridgingStorage.nativeStorage.formIndex(after: &nextIndex)
 
     let unmanagedObjects = _UnmanagedAnyObjectArray(objects)
     unmanagedObjects[0] = bridgedKey
@@ -3223,26 +3202,15 @@ final internal class _Native${Self}StorageKeyNSEnumerator<
 }
 #endif
 
-/// This class is an artifact of the COW implementation.  This class only
-/// exists to keep separate retain counts separate for:
-/// - `${Self}` and `NS${Self}`,
-/// - `${Self}Index`.
-///
-/// This is important because the uniqueness check for COW only cares about
-/// retain counts of the first kind.
-///
-/// Specifically, `${Self}` points to instances of this class.  This class
-/// is also a proper `NS${Self}` subclass, which is returned to Objective-C
-/// during bridging.  `${Self}Index` points directly to
-/// `_Native${Self}Storage`.
-@_versioned
-final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
+#if _runtime(_ObjC)
+/// This class exists for Objective-C bridging. It holds a reference to a
+/// `_Native${Self}Storage`, and can be upcast to `NS${Self}` when
+/// bridging is necessary.
+final internal class _Native${Self}BridgingStorage<${TypeParametersDecl}>
   : _SwiftNativeNS${Self}, _NS${Self}Core {
 
   internal typealias NativeStorage = _Native${Self}Storage<${TypeParameters}>
-#if _runtime(_ObjC)
   internal typealias BridgedNativeStorage = _BridgedNative${Self}Storage
-#endif
 
 %if Self == 'Set':
   internal typealias Key = Element
@@ -3250,7 +3218,7 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
 %end
 
   internal init(minimumCapacity: Int = 2) {
-    nativeStorage = NativeStorage(minimumCapacity: minimumCapacity)
+    nativeStorage = NativeStorage.create(minimumCapacity: minimumCapacity)
     super.init()
   }
 
@@ -3266,8 +3234,6 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
   internal var _heapBufferBridged_DoNotUse: AnyObject?
 
   internal var nativeStorage: NativeStorage
-
-#if _runtime(_ObjC)
 
 %if Self == 'Set':
 
@@ -3352,10 +3318,10 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
 
   /// The storage for bridged ${Self} elements, if present.
   internal var _bridgedBuffer:
-    BridgedNativeStorage.StorageImpl? {
+    BridgedNativeStorage.Storage? {
     get {
       if let ref = _stdlib_atomicLoadARCRef(object: _heapBufferBridgedPtr) {
-        return unsafeDowncast(ref, to: BridgedNativeStorage.StorageImpl.self)
+        return unsafeDowncast(ref, to: BridgedNativeStorage.Storage.self)
       }
       return nil
     }
@@ -3383,7 +3349,7 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
 
   internal func _createBridgedNativeStorage(_ capacity: Int) ->
     BridgedNativeStorage {
-    let buffer = BridgedNativeStorage.StorageImpl.create(capacity: capacity)
+    let buffer = BridgedNativeStorage.Storage.create(capacity: capacity)
     return BridgedNativeStorage(buffer: buffer)
   }
 
@@ -3393,10 +3359,10 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
     }
 
     // Create storage for bridged data.
-    let bridged = _createBridgedNativeStorage(nativeStorage.capacity)
+    let bridged = _createBridgedNativeStorage(nativeStorage._capacity)
 
     // Bridge everything.
-    for i in 0..<nativeStorage.capacity {
+    for i in 0..<nativeStorage._capacity {
       if nativeStorage.isInitializedEntry(at: i) {
         let key = _bridgeAnythingToObjectiveC(nativeStorage.key(at: i))
 %if Self == 'Set':
@@ -3463,7 +3429,7 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
     bridgeEverything()
     // The user is expected to provide a buffer of the correct size
     var i = 0 // Position in the input buffer
-    let capacity = bridgedNativeStorage.capacity
+    let capacity = nativeStorage._capacity
 
     if let unmanagedKeys = _UnmanagedAnyObjectArray(keys) {
       if let unmanagedObjects = _UnmanagedAnyObjectArray(objects) {
@@ -3507,7 +3473,7 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
 
   @objc
   internal var count: Int {
-    return nativeStorage.count
+    return nativeStorage._count
   }
 
   internal func bridgingObjectForKey(_ aKey: AnyObject)
@@ -3550,7 +3516,7 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
 
     let unmanagedObjects = _UnmanagedAnyObjectArray(objects!)
     var currIndex = _Native${Self}Index<${TypeParameters}>(
-        nativeStorage: nativeStorage, offset: Int(theState.extra.0))
+        offset: Int(theState.extra.0))
     let endIndex = nativeStorage.endIndex
     var stored = 0
     for i in 0..<count {
@@ -3567,13 +3533,15 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
     state.pointee = theState
     return stored
   }
-#endif
 }
+#else
+final internal class _Native${Self}BridgingStorage<${TypeParametersDecl}> { }
+#endif
 
 #if _runtime(_ObjC)
 @_versioned
 @_fixed_layout
-internal struct _Cocoa${Self}Storage : _HashStorage {
+internal final class _Cocoa${Self}Storage : _HashStorage {
   @_versioned
   internal var cocoa${Self}: _NS${Self}
 
@@ -3584,22 +3552,31 @@ internal struct _Cocoa${Self}Storage : _HashStorage {
   internal typealias Key = AnyObject
   internal typealias Value = AnyObject
 
+  internal lazy var allKeys : _Box<_HeapBuffer<Int, AnyObject>> = {
+    return _Box(_stdlib_NS${Self}_all${'Objects' if Self == 'Set' else 'Keys'}(self.cocoa${Self}))
+  }()
+
   internal var startIndex: Index {
-    return Index(cocoa${Self}, startIndex: ())
+    return Index(value: 0)
   }
 
   internal var endIndex: Index {
-    return Index(cocoa${Self}, endIndex: ())
+    return Index(value: allKeys._value.value)
+  }
+
+  // Assumption: we rely on NS${Self}.getObjects when being
+  // repeatedly called on the same NS${Self}, returning items in the same
+  // order every time.
+  @_versioned
+  internal func index(after i: Index) -> Index {
+    _precondition(
+      i.currentKeyIndex < allKeys._value.value, "cannot increment endIndex")
+    return _Cocoa${Self}Index(value: i.currentKeyIndex + 1)
   }
 
   @_versioned
-  internal func index(after i: Index) -> Index {
-    return i.successor()
-  }
-
   internal func formIndex(after i: inout Index) {
-    // FIXME: swift-3-indexing-model: optimize if possible.
-    i = i.successor()
+    i = index(after: i)
   }
 
   @_versioned
@@ -3612,31 +3589,26 @@ internal struct _Cocoa${Self}Storage : _HashStorage {
       return nil
     }
 
-%if Self == 'Set':
-    let allKeys = _stdlib_NSSet_allObjects(cocoaSet)
-%elif Self == 'Dictionary':
-    let allKeys = _stdlib_NSDictionary_allKeys(cocoaDictionary)
-%end
     var keyIndex = -1
-    for i in 0..<allKeys.value {
-      if _stdlib_NSObject_isEqual(key, allKeys[i]) {
+    for i in 0..<allKeys._value.value {
+      if _stdlib_NSObject_isEqual(key, allKeys._value[i]) {
         keyIndex = i
         break
       }
     }
     _sanityCheck(keyIndex >= 0,
         "key was found in fast path, but not found later?")
-    return Index(cocoa${Self}, allKeys, keyIndex)
+    return Index(value: keyIndex)
   }
 
   internal func assertingGet(_ i: Index) -> SequenceElement {
 %if Self == 'Set':
-    let value: Value? = i.allKeys[i.currentKeyIndex]
+    let value: Value? = allKeys._value[i.currentKeyIndex]
     _sanityCheck(value != nil, "item not found in underlying NS${Self}")
     return value!
 %elif Self == 'Dictionary':
-    let key: Key = i.allKeys[i.currentKeyIndex]
-    let value: Value = i.cocoaDictionary.objectFor(key)!
+    let key: Key = allKeys._value[i.currentKeyIndex]
+    let value: Value = cocoaDictionary.objectFor(key)!
     return (key, value)
 %end
 
@@ -3665,29 +3637,33 @@ internal struct _Cocoa${Self}Storage : _HashStorage {
 
   }
 
+  internal init(cocoa${Self}: _NS${Self}) {
+    self.cocoa${Self} = cocoa${Self}
+  }
+
   @discardableResult
-  internal mutating func updateValue(_ value: Value, forKey key: Key) -> Value? {
+  internal func updateValue(_ value: Value, forKey key: Key) -> Value? {
     _sanityCheckFailure("cannot mutate NS${Self}")
   }
 
   @discardableResult
-  internal mutating func insert(
+  internal func insert(
     _ value: Value, forKey key: Key
   ) -> (inserted: Bool, memberAfterInsert: Value) {
     _sanityCheckFailure("cannot mutate NS${Self}")
   }
 
   @discardableResult
-  internal mutating func remove(at index: Index) -> SequenceElement {
+  internal func remove(at index: Index) -> SequenceElement {
     _sanityCheckFailure("cannot mutate NS${Self}")
   }
 
   @discardableResult
-  internal mutating func removeValue(forKey key: Key) -> Value? {
+  internal func removeValue(forKey key: Key) -> Value? {
     _sanityCheckFailure("cannot mutate NS${Self}")
   }
 
-  internal mutating func removeAll(keepingCapacity keepCapacity: Bool) {
+  internal func removeAll(keepingCapacity keepCapacity: Bool) {
     _sanityCheckFailure("cannot mutate NS${Self}")
   }
 
@@ -3710,8 +3686,6 @@ internal struct _Cocoa${Self}Storage {}
 internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
 
   internal typealias NativeStorage = _Native${Self}Storage<${TypeParameters}>
-  internal typealias NativeStorageOwner =
-    _Native${Self}StorageOwner<${TypeParameters}>
   internal typealias NativeIndex = _Native${Self}Index<${TypeParameters}>
   internal typealias CocoaStorage = _Cocoa${Self}Storage
   internal typealias SequenceElement = ${Sequence}
@@ -3723,7 +3697,7 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
   internal typealias Value = ${TypeParameters}
 %end
 
-  case native(NativeStorageOwner)
+  case native(NativeStorage)
   case cocoa(CocoaStorage)
 
   @_versioned
@@ -3733,6 +3707,8 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
   }
 
   internal mutating func isUniquelyReferenced() -> Bool {
+    // Note that &self drills down through .native(NativeStorage) to the first
+    // property in NativeStorage, which is the reference to the buffer.
     if _fastPath(guaranteedNative) {
       return _isUnique_native(&self)
     }
@@ -3750,8 +3726,8 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
   @_versioned
   internal var asNative: NativeStorage {
     switch self {
-    case .native(let owner):
-      return owner.nativeStorage
+    case .native(let storage):
+      return storage
     case .cocoa:
       _sanityCheckFailure("internal error: not backed by native storage")
     }
@@ -3774,24 +3750,14 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
     -> (reallocated: Bool, capacityChanged: Bool) {
     switch self {
     case .native:
-      let oldCapacity = asNative.capacity
+      let oldCapacity = asNative._capacity
       if isUniquelyReferenced() && oldCapacity >= minimumCapacity {
-#if _runtime(_ObjC)
-        // Clear the cache of bridged elements.
-        switch self {
-        case .native(let owner):
-          owner.deinitializeHeapBufferBridged()
-        case .cocoa:
-          _sanityCheckFailure("internal error: not backed by native storage")
-        }
-#endif
         return (reallocated: false, capacityChanged: false)
       }
 
       let oldNativeStorage = asNative
-      let newNativeOwner = NativeStorageOwner(minimumCapacity: minimumCapacity)
-      var newNativeStorage = newNativeOwner.nativeStorage
-      let newCapacity = newNativeStorage.capacity
+      let newNativeStorage = NativeStorage.create(minimumCapacity: minimumCapacity)
+      let newCapacity = newNativeStorage._capacity
       for i in 0..<oldCapacity {
         if oldNativeStorage.isInitializedEntry(at: i) {
           if oldCapacity == newCapacity {
@@ -3814,17 +3780,16 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
           }
         }
       }
-      newNativeStorage.count = oldNativeStorage.count
+      newNativeStorage._count = oldNativeStorage._count
 
-      self = .native(newNativeOwner)
+      self = .native(newNativeStorage)
       return (reallocated: true,
-              capacityChanged: oldCapacity != newNativeStorage.capacity)
+              capacityChanged: oldCapacity != newNativeStorage._capacity)
 
     case .cocoa(let cocoaStorage):
 #if _runtime(_ObjC)
       let cocoa${Self} = cocoaStorage.cocoa${Self}
-      let newNativeOwner = NativeStorageOwner(minimumCapacity: minimumCapacity)
-      var newNativeStorage = newNativeOwner.nativeStorage
+      let newNativeStorage = NativeStorage.create(minimumCapacity: minimumCapacity)
       let oldCocoaIterator = _Cocoa${Self}Iterator(cocoa${Self})
 %if Self == 'Set':
       while let key = oldCocoaIterator.next() {
@@ -3841,9 +3806,9 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
       }
 
 %end
-      newNativeStorage.count = cocoa${Self}.count
+      newNativeStorage._count = cocoa${Self}.count
 
-      self = .native(newNativeOwner)
+      self = .native(newNativeStorage)
       return (reallocated: true, capacityChanged: true)
 #else
       _sanityCheckFailure("internal error: unexpected cocoa ${Self}")
@@ -4042,10 +4007,10 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
     var (i, found) = asNative._find(key, startBucket: asNative._bucket(key))
 
     let minCapacity = found
-      ? asNative.capacity
+      ? asNative._capacity
       : NativeStorage.minimumCapacity(
-          minimumCount: asNative.count + 1,
-          maxLoadFactorInverse: asNative.maxLoadFactorInverse)
+          minimumCount: asNative._count + 1,
+          maxLoadFactorInverse: asNative._maxLoadFactorInverse)
 
     let (_, capacityChanged) = ensureUniqueNativeStorage(minCapacity)
     if capacityChanged {
@@ -4058,7 +4023,7 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
       asNative.setKey(key, at: i.offset)
     } else {
       asNative.initializeKey(key, at: i.offset)
-      asNative.count += 1
+      asNative._count += 1
     }
 %elif Self == 'Dictionary':
     let oldValue: Value? = found ? asNative.value(at: i.offset) : nil
@@ -4066,7 +4031,7 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
       asNative.setKey(key, value: value, at: i.offset)
     } else {
       asNative.initializeKey(key, value: value, at: i.offset)
-      asNative.count += 1
+      asNative._count += 1
     }
 %end
 
@@ -4098,8 +4063,8 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
   internal mutating func nativeInsert(
     _ value: Value, forKey key: Key
   ) -> (inserted: Bool, memberAfterInsert: Value) {
-    var (i, found) = asNative._find(key, startBucket: asNative._bucket(key))
 
+    var (i, found) = asNative._find(key, startBucket: asNative._bucket(key))
     if found {
 %if Self == 'Set':
       return (inserted: false, memberAfterInsert: asNative.key(at: i.offset))
@@ -4109,20 +4074,21 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
     }
 
     let minCapacity = NativeStorage.minimumCapacity(
-      minimumCount: asNative.count + 1,
-      maxLoadFactorInverse: asNative.maxLoadFactorInverse)
+      minimumCount: asNative._count + 1,
+      maxLoadFactorInverse: asNative._maxLoadFactorInverse)
 
     let (_, capacityChanged) = ensureUniqueNativeStorage(minCapacity)
+
     if capacityChanged {
       i = asNative._find(key, startBucket: asNative._bucket(key)).pos
     }
 
 %if Self == 'Set':
     asNative.initializeKey(key, at: i.offset)
-    asNative.count += 1
+    asNative._count += 1
 %elif Self == 'Dictionary':
     asNative.initializeKey(key, value: value, at: i.offset)
-    asNative.count += 1
+    asNative._count += 1
 %end
 
     return (inserted: true, memberAfterInsert: value)
@@ -4153,7 +4119,7 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
   /// - parameter idealBucket: The ideal bucket for the element being deleted.
   /// - parameter offset: The offset of the element that will be deleted.
   /// Precondition: there should be an initialized entry at offset.
-  internal mutating func nativeDeleteImpl(
+  internal mutating func nativeDelete(
     _ nativeStorage: NativeStorage, idealBucket: Int, offset: Int
   ) {
     _sanityCheck(
@@ -4161,7 +4127,7 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
 
     // remove the element
     nativeStorage.destroyEntry(at: offset)
-    nativeStorage.count -= 1
+    nativeStorage._count -= 1
 
     // If we've put a hole in a chain of contiguous elements, some
     // element after the hole may belong where the new hole is.
@@ -4215,9 +4181,8 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
   }
 
   internal mutating func nativeRemoveObject(forKey key: Key) -> Value? {
-    var nativeStorage = asNative
-    var idealBucket = nativeStorage._bucket(key)
-    var (index, found) = nativeStorage._find(key, startBucket: idealBucket)
+    var idealBucket = asNative._bucket(key)
+    var (index, found) = asNative._find(key, startBucket: idealBucket)
 
     // Fast path: if the key is not present, we will not mutate the set,
     // so don't force unique storage.
@@ -4225,11 +4190,9 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
       return nil
     }
 
-    let (reallocated, capacityChanged) =
-      ensureUniqueNativeStorage(nativeStorage.capacity)
-    if reallocated {
-      nativeStorage = asNative
-    }
+    let (_, capacityChanged) =
+      ensureUniqueNativeStorage(asNative._capacity)
+    let nativeStorage = asNative
     if capacityChanged {
       idealBucket = nativeStorage._bucket(key)
       (index, found) = nativeStorage._find(key, startBucket: idealBucket)
@@ -4240,7 +4203,7 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
 %elif Self == 'Dictionary':
     let oldValue = nativeStorage.value(at: index.offset)
 %end
-    nativeDeleteImpl(nativeStorage, idealBucket: idealBucket,
+    nativeDelete(nativeStorage, idealBucket: idealBucket,
       offset: index.offset)
     return oldValue
   }
@@ -4248,14 +4211,11 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
   internal mutating func nativeRemove(
     at nativeIndex: NativeIndex
   ) -> SequenceElement {
-    var nativeStorage = asNative
 
     // The provided index should be valid, so we will always mutating the
     // set storage.  Request unique storage.
-    let (reallocated, _) = ensureUniqueNativeStorage(nativeStorage.capacity)
-    if reallocated {
-      nativeStorage = asNative
-    }
+    _ = ensureUniqueNativeStorage(asNative._capacity)
+    let nativeStorage = asNative
 
     let result = nativeStorage.assertingGet(nativeIndex)
 %if Self == 'Set':
@@ -4264,7 +4224,7 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
     let key = result.0
 %end
 
-    nativeDeleteImpl(nativeStorage, idealBucket: nativeStorage._bucket(key),
+    nativeDelete(nativeStorage, idealBucket: nativeStorage._bucket(key),
         offset: nativeIndex.offset)
     return result
   }
@@ -4287,7 +4247,7 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
       // operation.
       let cocoaIndex = index._cocoaIndex
       let anyObjectKey: AnyObject =
-        cocoaIndex.allKeys[cocoaIndex.currentKeyIndex]
+        cocoaStorage.allKeys._value[cocoaIndex.currentKeyIndex]
       migrateDataToNativeStorage(cocoaStorage)
       let key = _forceBridgeFromObjectiveC(anyObjectKey, Key.self)
       let value = nativeRemoveObject(forKey: key)
@@ -4328,8 +4288,6 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
   }
 
   internal mutating func nativeRemoveAll() {
-    var nativeStorage = asNative
-
     // FIXME(performance): if the storage is non-uniquely referenced, we
     // shouldn't be copying the elements into new storage and then immediately
     // deleting the elements. We should detect that the storage is not uniquely
@@ -4337,17 +4295,15 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
 
     // We have already checked for the empty dictionary case, so we will always
     // mutating the dictionary storage.  Request unique storage.
-    let (reallocated, _) = ensureUniqueNativeStorage(nativeStorage.capacity)
-    if reallocated {
-      nativeStorage = asNative
-    }
+    _ = ensureUniqueNativeStorage(asNative._capacity)
+    let nativeStorage = asNative
 
-    for b in 0..<nativeStorage.capacity {
+    for b in 0..<nativeStorage._capacity {
       if nativeStorage.isInitializedEntry(at: b) {
         nativeStorage.destroyEntry(at: b)
       }
     }
-    nativeStorage.count = 0
+    nativeStorage._count = 0
   }
 
   internal mutating func removeAll(keepingCapacity keepCapacity: Bool) {
@@ -4356,7 +4312,7 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
     }
 
     if !keepCapacity {
-      self = .native(NativeStorage.Owner(minimumCapacity: 2))
+      self = .native(NativeStorage.create(minimumCapacity: 2))
       return
     }
 
@@ -4370,7 +4326,7 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
       nativeRemoveAll()
     case .cocoa(let cocoaStorage):
 #if _runtime(_ObjC)
-      self = .native(NativeStorage.Owner(minimumCapacity: cocoaStorage.count))
+      self = .native(NativeStorage.create(minimumCapacity: cocoaStorage.count))
 #else
       _sanityCheckFailure("internal error: unexpected cocoa ${Self}")
 #endif
@@ -4379,12 +4335,12 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
 
   internal var count: Int {
     if _fastPath(guaranteedNative) {
-      return asNative.count
+      return asNative._count
     }
 
     switch self {
     case .native:
-      return asNative.count
+      return asNative._count
     case .cocoa(let cocoaStorage):
 #if _runtime(_ObjC)
       return cocoaStorage.count
@@ -4401,9 +4357,9 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
   @inline(__always)
   internal func makeIterator() -> ${Self}Iterator<${TypeParameters}> {
     switch self {
-    case .native(let owner):
+    case .native(let storage):
       return ._native(
-        start: asNative.startIndex, end: asNative.endIndex, owner: owner)
+        start: asNative.startIndex, end: asNative.endIndex, storage: storage)
     case .cocoa(let cocoaStorage):
 #if _runtime(_ObjC)
       return ._cocoa(_Cocoa${Self}Iterator(cocoaStorage.cocoa${Self}))
@@ -4421,43 +4377,13 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
 }
 
 @_versioned
-internal struct _Native${Self}Index<${TypeParametersDecl}> :
-  Comparable {
-
-  internal typealias NativeStorage = _Native${Self}Storage<${TypeParameters}>
-  internal typealias NativeIndex = _Native${Self}Index<${TypeParameters}>
-
-  // FIXME: swift-3-indexing-model: remove `nativeStorage`, we don't need it in
-  // the new model.
-  @_versioned
-  internal var nativeStorage: NativeStorage
-
+internal struct _Native${Self}Index<${TypeParametersDecl}> : Comparable {
   @_versioned
   internal var offset: Int
 
   @_versioned
-  internal init(nativeStorage: NativeStorage, offset: Int) {
-    self.nativeStorage = nativeStorage
+  internal init(offset: Int) {
     self.offset = offset
-  }
-
-  /// Returns the next consecutive value after `self`.
-  ///
-  /// - Precondition: The next value is representable.
-  internal func successor() -> NativeIndex {
-    // FIXME: swift-3-indexing-model: remove this method.
-    var i = offset + 1
-    // FIXME: Can't write the simple code pending
-    // <rdar://problem/15484639> Refcounting bug
-    while i < nativeStorage.capacity /*&& !nativeStorage[i]*/ {
-      // FIXME: workaround for <rdar://problem/15484639>
-      if nativeStorage.isInitializedEntry(at: i) {
-        break
-      }
-      // end workaround
-      i += 1
-    }
-    return NativeIndex(nativeStorage: nativeStorage, offset: i)
   }
 }
 
@@ -4483,61 +4409,11 @@ extension _Native${Self}Index {
 #if _runtime(_ObjC)
 @_versioned
 internal struct _Cocoa${Self}Index : Comparable {
-  // Assumption: we rely on NSDictionary.getObjects when being
-  // repeatedly called on the same NSDictionary, returning items in the same
-  // order every time.
-  // Similarly, the same assumption holds for NSSet.allObjects.
-
-  /// A reference to the NS${Self}, which owns members in `allObjects`,
-  /// or `allKeys`, for NSSet and NSDictionary respectively.
-  internal let cocoa${Self}: _NS${Self}
-  // FIXME: swift-3-indexing-model: try to remove the cocoa reference, but make
-  // sure that we have a safety check for accessing `allKeys`.  Maybe move both
-  // into the dictionary/set itself.
-
-  /// An unowned array of keys.
-  internal var allKeys: _HeapBuffer<Int, AnyObject>
-
-  /// Index into `allKeys`
+  /// Index into `allKeys`, a property on the parent collection.
   internal var currentKeyIndex: Int
 
-  internal init(_ cocoa${Self}: _NS${Self}, startIndex: ()) {
-    self.cocoa${Self} = cocoa${Self}
-%if Self == 'Set':
-    self.allKeys = _stdlib_NSSet_allObjects(cocoaSet)
-%elif Self == 'Dictionary':
-    self.allKeys = _stdlib_NSDictionary_allKeys(cocoaDictionary)
-%end
-    self.currentKeyIndex = 0
-  }
-
-  internal init(_ cocoa${Self}: _NS${Self}, endIndex: ()) {
-    self.cocoa${Self} = cocoa${Self}
-%if Self == 'Set':
-    self.allKeys = _stdlib_NS${Self}_allObjects(cocoa${Self})
-%elif Self == 'Dictionary':
-    self.allKeys = _stdlib_NS${Self}_allKeys(cocoa${Self})
-%end
-    self.currentKeyIndex = allKeys.value
-  }
-
-  internal init(_ cocoa${Self}: _NS${Self},
-    _ allKeys: _HeapBuffer<Int, AnyObject>,
-    _ currentKeyIndex: Int
-  ) {
-    self.cocoa${Self} = cocoa${Self}
-    self.allKeys = allKeys
-    self.currentKeyIndex = currentKeyIndex
-  }
-
-  /// Returns the next consecutive value after `self`.
-  ///
-  /// - Precondition: The next value is representable.
-  internal func successor() -> _Cocoa${Self}Index {
-    // FIXME: swift-3-indexing-model: remove this method.
-    _precondition(
-      currentKeyIndex < allKeys.value, "cannot increment endIndex")
-    return _Cocoa${Self}Index(cocoa${Self}, allKeys, currentKeyIndex + 1)
+  internal init(value: Int) {
+    currentKeyIndex = value
   }
 }
 
@@ -4546,11 +4422,6 @@ extension _Cocoa${Self}Index {
     lhs: _Cocoa${Self}Index,
     rhs: _Cocoa${Self}Index
   ) -> Bool {
-    _precondition(lhs.cocoa${Self} === rhs.cocoa${Self},
-      "cannot compare indexes pointing to different ${Self}s")
-    _precondition(lhs.allKeys.value == rhs.allKeys.value,
-      "one or both of the indexes have been invalidated")
-
     return lhs.currentKeyIndex == rhs.currentKeyIndex
   }
 
@@ -4558,11 +4429,6 @@ extension _Cocoa${Self}Index {
     lhs: _Cocoa${Self}Index,
     rhs: _Cocoa${Self}Index
   ) -> Bool {
-    _precondition(lhs.cocoa${Self} === rhs.cocoa${Self},
-      "cannot compare indexes pointing to different ${Self}s")
-    _precondition(lhs.allKeys.value == rhs.allKeys.value,
-      "one or both of the indexes have been invalidated")
-
     return lhs.currentKeyIndex < rhs.currentKeyIndex
   }
 }
@@ -4602,6 +4468,7 @@ elif Self == 'Dictionary':
 ${SubscriptingWithIndexDoc}
 public struct ${Self}Index<${TypeParametersDecl}> :
   Comparable {
+  // FIXME(swift-3-indexing-model): rewrite the fixme to reflect the new index model
   // FIXME(ABI)#34 (Nesting types in generics): `DictionaryIndex` and `SetIndex` should
   // be nested types.
   // rdar://problem/17002096
@@ -4661,26 +4528,6 @@ public struct ${Self}Index<${TypeParametersDecl}> :
     }
   }
 #endif
-
-  /// Returns the next consecutive value after `self`.
-  ///
-  /// - Precondition: The next value is representable.
-  internal func successor() -> ${Self}Index<${TypeParameters}> {
-    if _fastPath(_guaranteedNative) {
-      return ._native(_nativeIndex.successor())
-    }
-
-    switch _value {
-    case ._native(let nativeIndex):
-      return ._native(nativeIndex.successor())
-    case ._cocoa(let cocoaIndex):
-#if _runtime(_ObjC)
-      return ._cocoa(cocoaIndex.successor())
-#else
-      _sanityCheckFailure("internal error: unexpected cocoa ${Self}")
-#endif
-    }
-  }
 }
 
 extension ${Self}Index {
@@ -4817,19 +4664,18 @@ final internal class _Cocoa${Self}Iterator {}
 @_versioned
 internal enum ${Self}IteratorRepresentation<${TypeParametersDecl}> {
   internal typealias _Iterator = ${Self}Iterator<${TypeParameters}>
-  internal typealias _NativeStorageOwner =
-    _Native${Self}StorageOwner<${TypeParameters}>
+  internal typealias _NativeStorage =
+    _Native${Self}Storage<${TypeParameters}>
   internal typealias _NativeIndex = _Iterator._NativeIndex
 
   // For native storage, we keep two indices to keep track of the iteration
   // progress and the storage owner to make the storage non-uniquely
   // referenced.
   //
-  // While indices keep the storage alive, they don't affect reference count of
-  // the storage.  Iterator is iterating over a frozen view of the collection
-  // state, so it should keep its own reference to the storage owner.
+  // Iterator is iterating over a frozen view of the collection
+  // state, so it should keep its own reference to the storage.
   case _native(
-    start: _NativeIndex, end: _NativeIndex, owner: _NativeStorageOwner)
+    start: _NativeIndex, end: _NativeIndex, storage: _NativeStorage)
   case _cocoa(_Cocoa${Self}Iterator)
 }
 
@@ -4845,8 +4691,8 @@ public struct ${Self}Iterator<${TypeParametersDecl}> : IteratorProtocol {
   // Index, which is multi-pass, it is suitable for implementing a
   // IteratorProtocol, which is being consumed as iteration proceeds.
 
-  internal typealias _NativeStorageOwner =
-    _Native${Self}StorageOwner<${TypeParameters}>
+  internal typealias _NativeStorage =
+    _Native${Self}Storage<${TypeParameters}>
   internal typealias _NativeIndex = _Native${Self}Index<${TypeParameters}>
 
   @_versioned
@@ -4854,10 +4700,10 @@ public struct ${Self}Iterator<${TypeParametersDecl}> : IteratorProtocol {
 
   @_versioned
   internal static func _native(
-    start: _NativeIndex, end: _NativeIndex, owner: _NativeStorageOwner
+    start: _NativeIndex, end: _NativeIndex, storage: _NativeStorage
   ) -> ${Self}Iterator {
     return ${Self}Iterator(
-      _state: ._native(start: start, end: end, owner: owner))
+      _state: ._native(start: start, end: end, storage: storage))
   }
 #if _runtime(_ObjC)
   @_versioned
@@ -4881,13 +4727,13 @@ public struct ${Self}Iterator<${TypeParametersDecl}> : IteratorProtocol {
   @_versioned
   internal mutating func _nativeNext() -> ${Sequence}? {
     switch _state {
-    case ._native(let startIndex, let endIndex, let owner):
+    case ._native(let startIndex, let endIndex, let storage):
       if startIndex == endIndex {
         return nil
       }
-      let result = startIndex.nativeStorage.assertingGet(startIndex)
+      let result = storage.assertingGet(startIndex)
       _state =
-        ._native(start: startIndex.successor(), end: endIndex, owner: owner)
+        ._native(start: storage.index(after: startIndex), end: endIndex, storage: storage)
       return result
     case ._cocoa:
       _sanityCheckFailure("internal error: not backed by NS${Self}")
@@ -4994,7 +4840,7 @@ public struct _${Self}Builder<${TypeParametersDecl}> {
       "the number of members added does not match the promised count")
 
     // Finish building the `${Self}`.
-    _nativeStorage.count = _requestedCount
+    _nativeStorage._count = _requestedCount
 
     // Prevent taking the result twice.
     _actualCount = -1
@@ -5034,8 +4880,9 @@ extension ${Self} {
 extension ${Self} {
   public func _bridgeToObjectiveCImpl() -> _NS${Self}Core {
     switch _variantStorage {
-    case _Variant${Self}Storage.native(let nativeOwner):
-      return nativeOwner as _Native${Self}StorageOwner<${TypeParameters}>
+    case _Variant${Self}Storage.native(let storage):
+      let bridgingStorage = storage.bridgingStorage()
+      return bridgingStorage as _Native${Self}BridgingStorage<${TypeParameters}>
 
     case _Variant${Self}Storage.cocoa(let cocoaStorage):
       return cocoaStorage.cocoa${Self}
@@ -5045,12 +4892,12 @@ extension ${Self} {
   public static func _bridgeFromObjectiveCAdoptingNativeStorageOf(
     _ s: AnyObject
   ) -> ${Self}<${TypeParameters}>? {
-    if let nativeOwner =
-        s as AnyObject as? _Native${Self}StorageOwner<${TypeParameters}> {
+    if let bridgingStorage =
+        s as AnyObject as? _Native${Self}BridgingStorage<${TypeParameters}> {
       // If `NS${Self}` is actually native storage of `${Self}` with key
       // and value types that the requested ones match exactly, then just
       // re-wrap the native storage.
-      return ${Self}<${TypeParameters}>(_nativeStorageOwner: nativeOwner)
+      return ${Self}<${TypeParameters}>(_nativeStorage: bridgingStorage.nativeStorage)
     }
     // FIXME: what if `s` is native storage, but for different key/value type?
     return nil

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -12,32 +12,8 @@
 
 import SwiftShims
 
-// TODO: swift-3-indexing-model: rewrite this description to reflect new indexing model
 // General Mutable, Value-Type Collections
 // =================================================
-//
-// Basic copy-on-write (COW) requires a container's data to be copied
-// into new storage before it is modified, to avoid changing the data
-// of other containers that may share the data.  There is one
-// exception: when we know the container has the only reference to the
-// data, we can elide the copy.  This COW optimization is crucial for
-// the performance of mutating algorithms.
-//
-// Some container elements (Characters in a String, key/value pairs in
-// an open-addressing hash table) are not traversable with a fixed
-// size offset, so incrementing/decrementing indices requires looking
-// at the contents of the container.  The current interface for
-// incrementing/decrementing indices of a Collection is the usual ++i,
-// --i. Therefore, for memory safety, the indices need to keep a
-// reference to the container's underlying data so that it can be
-// inspected.  But having multiple outstanding references to the
-// underlying data defeats the COW optimization.
-//
-// The way out is to count containers referencing the data separately
-// from indices that reference the data.  When deciding to elide the
-// copy and modify the data directly---as long as we don't violate
-// memory safety of any outstanding indices---we only need to be
-// sure that no other containers are referencing the data.
 //
 // Implementation notes
 // ====================
@@ -65,50 +41,20 @@ import SwiftShims
 //   +---|------------------------------------------+
 //      /
 //     |
-//     V  _NativeDictionaryStorageOwner<K,V> (a class)
+//     V  _NativeDictionaryStorage<K,V> (a class)
 //   +-----------------------------------------------------------+
-//   | [refcount#1] [ _NativeDictionaryStorage<K,V> (a struct) ] |
-//   +----------------|------------------------------------------+
-//                    |
-//     +--------------+
-//     |
-//     V  _NativeDictionaryStorageImpl<K,V> (a class)
-//   +-----------------------------------------+
-//   | [refcount#2]    [...element storage...] |
-//   +-----------------------------------------+
-//     ^
-//     +---+
-//         |              Dictionary<K,V>.Index (an enum)
-//   +-----|--------------------------------------------+
-//   |     |     _NativeDictionaryIndex<K,V> (a struct) |
-//   | +---|------------------------------------------+ |
-//   | | [ _NativeDictionaryStorage<K,V> (a struct) ] | |
-//   | +----------------------------------------------+ |
-//   +--------------------------------------------------+
-//
-// We would like to optimize by allocating the `_NativeDictionaryStorageOwner`
-// /inside/ the `_NativeDictionaryStorageImpl`, and override the `dealloc`
-// method of `_NativeDictionaryStorageOwner` to do nothing but release its
-// reference.
-//
-//     Dictionary<K,V> (a struct)
-//     +----------------------------------------------+
-//     | [ _VariantDictionaryStorage<K,V> (an enum) ] |
-//     +---|------------------------------------------+
-//        /
-//       |          +---+
-//       |          V   |  _NativeDictionaryStorageImpl<K,V> (a class)
-//   +---|--------------|----------------------------------------------+
-//   |   |              |                                              |
-//   |   | [refcount#2] |                                              |
-//   |   |              |                                              |
-//   |   V              | _NativeDictionaryStorageOwner<K,V> (a class) |
-//   | +----------------|------------------------------------------+   |
-//   | | [refcount#1] [ _NativeDictionaryStorage<K,V> (a struct) ] |   |
-//   | +-----------------------------------------------------------+   |
-//   |                                                                 |
-//   | [...element storage...]                                         |
-//   +-----------------------------------------------------------------+
+//   | +-------------------------------------------------------+ |
+//   | |_DictionaryStorageHeader<K,V> (a struct)               | |
+//   | | capacity                                              | |
+//   | | count                                                 | |
+//   | | ptrToBits                                             | |
+//   | | ptrToKeys                                             | |
+//   | | ptrToValues                                           | |
+//   | +-------------------------------------------------------+ |
+//   | [inline array of bits indicating whether bucket is set ]  |
+//   | [inline array of keys                                  ]  |
+//   | [inline array of values                                ]  |
+//   +-----------------------------------------------------------+
 //
 //
 // Cocoa storage uses a data structure like this::
@@ -137,19 +83,17 @@ import SwiftShims
 //   | +-------------------------------+     |
 //   +---------------------------------------+
 //
-// `_NativeDictionaryStorageOwner` is an `NSDictionary` subclass.  It can
-// be returned to Objective-C during bridging if both `Key` and `Value`
-// bridge verbatim.
 //
 // Index Invalidation
 // ------------------
 //
+// FIXME? not sure if this guarantee is worth making, as it restricts
+// collision resolution to first-come-first-serve.
+//
 // Indexing a container, `c[i]`, uses the integral offset stored in the index
-// to access the elements referenced by the container.  The buffer referenced
-// by the index is only used to increment and decrement the index.  Most of the
-// time, these two buffers will be identical, but they need not always be.  For
-// example, if one ensures that a `Dictionary` has sufficient capacity to avoid
-// reallocation on the next element insertion, the following works ::
+// to access the elements referenced by the container. Generally, an index into
+// one container has no meaning for another. However copy-on-write currently
+// preserves indices under insertion, as long as reallocation doesn't occur:
 //
 //   var (i, found) = d.find(k) // i is associated with d's buffer
 //   if found {
@@ -176,17 +120,18 @@ import SwiftShims
 // ---------------------------------------
 //
 // `Dictionary<K, V>` bridges to `NSDictionary` iff both `K` and `V` are
-// bridged.  Otherwise, a runtime error is raised.
+// bridged.  Otherwise, a runtime error is raised. Because 
+// _NativeDictionaryStorage inherits from ManagedBuffer, it can't also
+// inherit from NSDictionary (_NSDictionaryCore). To have a value that does,
+// we wrap the _NativeDictionaryStorage in another class, 
+// _NativeDictionaryBridgingStorage, which incurs an allocation, but is O(1).
 //
-// * if both `K` and `V` are bridged verbatim, then `Dictionary<K, V>` bridges
-//   to `NSDictionary` in `O(1)`, without memory allocation.  Access to
-//   elements does not cause memory allocation.
+// * if both `K` and `V` are bridged verbatim, then access to elements 
+//   does not cause memory allocation.
 //
 // * otherwise, `K` and/or `V` are unconditionally or conditionally bridged.
-//   In this case, `Dictionary<K, V>` is bridged to `NSDictionary` in `O(1)`,
-//   without memory allocation.  Complete bridging is performed when the first
-//   access to elements happens.  The bridged `NSDictionary` has a cache of
-//   pointers it returned, so that:
+//   Complete bridging is performed when the first access to elements happens. 
+//   The bridged `NSDictionary` has a cache of pointers it returned, so that:
 //   - Every time keys or values are accessed on the bridged `NSDictionary`,
 //     new objects are not created.
 //   - Accessing the same element (key or value) multiple times will return

--- a/test/stdlib/Inputs/DictionaryKeyValueTypesObjC.swift
+++ b/test/stdlib/Inputs/DictionaryKeyValueTypesObjC.swift
@@ -20,7 +20,7 @@ public func convertNSDictionaryToDictionary<
 
 func isNativeDictionary<KeyTy : Hashable, ValueTy>(
   _ d: Dictionary<KeyTy, ValueTy>) -> Bool {
-  switch d._variantStorage {
+  switch d._variantBuffer {
   case .native:
     return true
   case .cocoa:
@@ -35,7 +35,7 @@ func isCocoaDictionary<KeyTy : Hashable, ValueTy>(
 
 func isNativeNSDictionary(_ d: NSDictionary) -> Bool {
   let className: NSString = NSStringFromClass(type(of: d)) as NSString
-  return ["_SwiftDeferredNSDictionary", "NativeDictionaryBuffer"].contains {
+  return ["_SwiftDeferredNSDictionary", "NativeDictionaryStorage"].contains {
     className.range(of: $0).length > 0
   }
 }

--- a/test/stdlib/Inputs/DictionaryKeyValueTypesObjC.swift
+++ b/test/stdlib/Inputs/DictionaryKeyValueTypesObjC.swift
@@ -35,7 +35,9 @@ func isCocoaDictionary<KeyTy : Hashable, ValueTy>(
 
 func isNativeNSDictionary(_ d: NSDictionary) -> Bool {
   let className: NSString = NSStringFromClass(type(of: d)) as NSString
-  return className.range(of: "_NativeDictionaryBridgingStorage").length > 0
+  return ["_SwiftDeferredNSDictionary", "NativeDictionaryBuffer"].contains {
+    className.range(of: $0).length > 0
+  }
 }
 
 func isCocoaNSDictionary(_ d: NSDictionary) -> Bool {

--- a/test/stdlib/Inputs/DictionaryKeyValueTypesObjC.swift
+++ b/test/stdlib/Inputs/DictionaryKeyValueTypesObjC.swift
@@ -35,7 +35,7 @@ func isCocoaDictionary<KeyTy : Hashable, ValueTy>(
 
 func isNativeNSDictionary(_ d: NSDictionary) -> Bool {
   let className: NSString = NSStringFromClass(type(of: d)) as NSString
-  return className.range(of: "_NativeDictionaryStorageOwner").length > 0
+  return className.range(of: "_NativeDictionaryBridgingStorage").length > 0
 }
 
 func isCocoaNSDictionary(_ d: NSDictionary) -> Bool {

--- a/test/stdlib/TestUserInfo.swift
+++ b/test/stdlib/TestUserInfo.swift
@@ -20,15 +20,29 @@ import StdlibUnittest
 class TestUserInfoSuper : NSObject { }
 #endif
 
-struct SubStruct {
+struct SubStruct: Equatable {
     var i: Int
     var str: String
+
+    static func ==(lhs: SubStruct, rhs: SubStruct) -> Bool {
+        return lhs.i == rhs.i && 
+               lhs.str == rhs.str
+    }
 }
 
-struct SomeStructure {
+struct SomeStructure: Hashable {
     var i: Int
     var str: String
     var sub: SubStruct
+
+    static func ==(lhs: SomeStructure, rhs: SomeStructure) -> Bool {
+        return lhs.i == rhs.i && 
+               lhs.str == rhs.str && 
+               lhs.sub == rhs.sub
+    }
+
+    // FIXME: we don't care about this, but Any only finds == on Hashables
+    var hashValue: Int { return i }
 }
 
 /*

--- a/validation-test/Reflection/reflect_Dictionary.swift
+++ b/validation-test/Reflection/reflect_Dictionary.swift
@@ -26,7 +26,7 @@ reflect(object: obj)
 // CHECK-64: (class_instance size=25 alignment=16 stride=32 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (struct size=9 alignment=8 stride=16 num_extra_inhabitants=0
-// CHECK-64:       (field name=_variantStorage offset=0
+// CHECK-64:       (field name=_variantBuffer offset=0
 // CHECK-64:         (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0
 // CHECK-64:           (field name=native offset=0
 // CHECK-64:             (reference kind=strong refcounting=native))
@@ -42,7 +42,7 @@ reflect(object: obj)
 // CHECK-32: (class_instance size=17 alignment=16 stride=32 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=12
 // CHECK-32:     (struct size=5 alignment=4 stride=8 num_extra_inhabitants=0
-// CHECK-32:       (field name=_variantStorage offset=0
+// CHECK-32:       (field name=_variantBuffer offset=0
 // CHECK-32:         (multi_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=0
 // CHECK-32:           (field name=native offset=0
 // CHECK-32:             (reference kind=strong refcounting=native))

--- a/validation-test/Reflection/reflect_Dictionary.swift
+++ b/validation-test/Reflection/reflect_Dictionary.swift
@@ -31,9 +31,7 @@ reflect(object: obj)
 // CHECK-64:           (field name=native offset=0
 // CHECK-64:             (reference kind=strong refcounting=native))
 // CHECK-64:           (field name=cocoa offset=0
-// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647
-// CHECK-64:               (field name=cocoaDictionary offset=0
-// CHECK-64:                 (reference kind=strong refcounting=unknown)))))))))
+// CHECK-64:             (reference kind=strong refcounting=native)))))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -49,9 +47,7 @@ reflect(object: obj)
 // CHECK-32:           (field name=native offset=0
 // CHECK-32:             (reference kind=strong refcounting=native))
 // CHECK-32:           (field name=cocoa offset=0
-// CHECK-32:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096
-// CHECK-32:               (field name=cocoaDictionary offset=0
-// CHECK-32:                 (reference kind=strong refcounting=unknown)))))))))
+// CHECK-32:             (reference kind=strong refcounting=native)))))))
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_Set.swift
+++ b/validation-test/Reflection/reflect_Set.swift
@@ -26,7 +26,7 @@ reflect(object: obj)
 // CHECK-64: (class_instance size=25 alignment=16 stride=32 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
 // CHECK-64:     (struct size=9 alignment=8 stride=16 num_extra_inhabitants=0
-// CHECK-64:       (field name=_variantStorage offset=0
+// CHECK-64:       (field name=_variantBuffer offset=0
 // CHECK-64:         (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0
 // CHECK-64:           (field name=native offset=0
 // CHECK-64:             (reference kind=strong refcounting=native))
@@ -42,7 +42,7 @@ reflect(object: obj)
 // CHECK-32: (class_instance size=17 alignment=16 stride=32 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=12
 // CHECK-32:     (struct size=5 alignment=4 stride=8 num_extra_inhabitants=0
-// CHECK-32:       (field name=_variantStorage offset=0
+// CHECK-32:       (field name=_variantBuffer offset=0
 // CHECK-32:         (multi_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=0
 // CHECK-32:           (field name=native offset=0
 // CHECK-32:             (reference kind=strong refcounting=native))

--- a/validation-test/Reflection/reflect_Set.swift
+++ b/validation-test/Reflection/reflect_Set.swift
@@ -31,9 +31,7 @@ reflect(object: obj)
 // CHECK-64:           (field name=native offset=0
 // CHECK-64:             (reference kind=strong refcounting=native))
 // CHECK-64:           (field name=cocoa offset=0
-// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647
-// CHECK-64:               (field name=cocoaSet offset=0
-// CHECK-64:                 (reference kind=strong refcounting=unknown)))))))))
+// CHECK-64:             (reference kind=strong refcounting=native)))))))
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -49,9 +47,7 @@ reflect(object: obj)
 // CHECK-32:           (field name=native offset=0
 // CHECK-32:             (reference kind=strong refcounting=native))
 // CHECK-32:           (field name=cocoa offset=0
-// CHECK-32:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096
-// CHECK-32:               (field name=cocoaSet offset=0
-// CHECK-32:                 (reference kind=strong refcounting=unknown)))))))))
+// CHECK-32:             (reference kind=strong refcounting=native)))))))
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_multiple_types.swift
+++ b/validation-test/Reflection/reflect_multiple_types.swift
@@ -142,7 +142,7 @@ reflect(object: obj)
 // CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647))))))
 // CHECK-64:   (field name=t03 offset=48
 // CHECK-64:     (struct size=9 alignment=8 stride=16 num_extra_inhabitants=0
-// CHECK-64:       (field name=_variantStorage offset=0
+// CHECK-64:       (field name=_variantBuffer offset=0
 // CHECK-64:         (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0
 // CHECK-64:           (field name=native offset=0
 // CHECK-64:             (reference kind=strong refcounting=native))
@@ -186,7 +186,7 @@ reflect(object: obj)
 // CHECK-64:     (reference kind=strong refcounting=unknown))
 // CHECK-64:   (field name=t15 offset=144
 // CHECK-64:     (struct size=9 alignment=8 stride=16 num_extra_inhabitants=0
-// CHECK-64:       (field name=_variantStorage offset=0
+// CHECK-64:       (field name=_variantBuffer offset=0
 // CHECK-64:         (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0
 // CHECK-64:           (field name=native offset=0
 // CHECK-64:             (reference kind=strong refcounting=native))
@@ -266,7 +266,7 @@ reflect(object: obj)
 // CHECK-32:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647))))))
 // CHECK-32:   (field name=t03 offset=32
 // CHECK-32:     (struct size=5 alignment=4 stride=8 num_extra_inhabitants=0
-// CHECK-32:       (field name=_variantStorage offset=0
+// CHECK-32:       (field name=_variantBuffer offset=0
 // CHECK-32:         (multi_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=0
 // CHECK-32:           (field name=native offset=0
 // CHECK-32:             (reference kind=strong refcounting=native))
@@ -312,7 +312,7 @@ reflect(object: obj)
 // CHECK-32:     (reference kind=strong refcounting=unknown))
 // CHECK-32:   (field name=t15 offset=92
 // CHECK-32:     (struct size=5 alignment=4 stride=8 num_extra_inhabitants=0
-// CHECK-32:       (field name=_variantStorage offset=0
+// CHECK-32:       (field name=_variantBuffer offset=0
 // CHECK-32:         (multi_payload_enum size=5 alignment=4 stride=8 num_extra_inhabitants=0
 // CHECK-32:           (field name=native offset=0
 // CHECK-32:             (reference kind=strong refcounting=native))

--- a/validation-test/Reflection/reflect_multiple_types.swift
+++ b/validation-test/Reflection/reflect_multiple_types.swift
@@ -147,9 +147,7 @@ reflect(object: obj)
 // CHECK-64:           (field name=native offset=0
 // CHECK-64:             (reference kind=strong refcounting=native))
 // CHECK-64:           (field name=cocoa offset=0
-// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647
-// CHECK-64:               (field name=cocoaDictionary offset=0
-// CHECK-64:                 (reference kind=strong refcounting=unknown))))))))
+// CHECK-64:             (reference kind=strong refcounting=native))))))
 // CHECK-64:   (field name=t04 offset=64
 // CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
 // CHECK-64:       (field name=_value offset=0
@@ -193,9 +191,7 @@ reflect(object: obj)
 // CHECK-64:           (field name=native offset=0
 // CHECK-64:             (reference kind=strong refcounting=native))
 // CHECK-64:           (field name=cocoa offset=0
-// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647
-// CHECK-64:               (field name=cocoaSet offset=0
-// CHECK-64:                 (reference kind=strong refcounting=unknown))))))))
+// CHECK-64:             (reference kind=strong refcounting=native))))))
 // CHECK-64:   (field name=t16 offset=160
 // CHECK-64:     (struct size=24 alignment=8 stride=24 num_extra_inhabitants=0
 // CHECK-64:       (field name=_core offset=0

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -719,7 +719,7 @@ DictionaryTestSuite.test("COW.Slow.RemoveValueForKeyDoesNotReallocate") {
 DictionaryTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
   do {
     var d = getCOWFastDictionary()
-    let originalCapacity = d._variantStorage.asNative._capacity
+    let originalCapacity = d._variantBuffer.asNative.capacity
     assert(d.count == 3)
     assert(d[10]! == 1010)
 
@@ -727,7 +727,7 @@ DictionaryTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
     // We cannot assert that identity changed, since the new buffer of smaller
     // size can be allocated at the same address as the old one.
     var identity1 = d._rawIdentifier()
-    assert(d._variantStorage.asNative._capacity < originalCapacity)
+    assert(d._variantBuffer.asNative.capacity < originalCapacity)
     assert(d.count == 0)
     assert(d[10] == nil)
 
@@ -740,19 +740,19 @@ DictionaryTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
   do {
     var d = getCOWFastDictionary()
     var identity1 = d._rawIdentifier()
-    let originalCapacity = d._variantStorage.asNative._capacity
+    let originalCapacity = d._variantBuffer.asNative.capacity
     assert(d.count == 3)
     assert(d[10]! == 1010)
 
     d.removeAll(keepingCapacity: true)
     assert(identity1 == d._rawIdentifier())
-    assert(d._variantStorage.asNative._capacity == originalCapacity)
+    assert(d._variantBuffer.asNative.capacity == originalCapacity)
     assert(d.count == 0)
     assert(d[10] == nil)
 
     d.removeAll(keepingCapacity: true)
     assert(identity1 == d._rawIdentifier())
-    assert(d._variantStorage.asNative._capacity == originalCapacity)
+    assert(d._variantBuffer.asNative.capacity == originalCapacity)
     assert(d.count == 0)
     assert(d[10] == nil)
   }
@@ -781,7 +781,7 @@ DictionaryTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
   do {
     var d1 = getCOWFastDictionary()
     var identity1 = d1._rawIdentifier()
-    let originalCapacity = d1._variantStorage.asNative._capacity
+    let originalCapacity = d1._variantBuffer.asNative.capacity
     assert(d1.count == 3)
     assert(d1[10] == 1010)
 
@@ -792,7 +792,7 @@ DictionaryTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
     assert(identity2 != identity1)
     assert(d1.count == 3)
     assert(d1[10]! == 1010)
-    assert(d2._variantStorage.asNative._capacity == originalCapacity)
+    assert(d2._variantBuffer.asNative.capacity == originalCapacity)
     assert(d2.count == 0)
     assert(d2[10] == nil)
 
@@ -805,7 +805,7 @@ DictionaryTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
 DictionaryTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
   do {
     var d = getCOWSlowDictionary()
-    let originalCapacity = d._variantStorage.asNative._capacity
+    let originalCapacity = d._variantBuffer.asNative.capacity
     assert(d.count == 3)
     assert(d[TestKeyTy(10)]!.value == 1010)
 
@@ -813,7 +813,7 @@ DictionaryTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
     // We cannot assert that identity changed, since the new buffer of smaller
     // size can be allocated at the same address as the old one.
     var identity1 = d._rawIdentifier()
-    assert(d._variantStorage.asNative._capacity < originalCapacity)
+    assert(d._variantBuffer.asNative.capacity < originalCapacity)
     assert(d.count == 0)
     assert(d[TestKeyTy(10)] == nil)
 
@@ -826,19 +826,19 @@ DictionaryTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
   do {
     var d = getCOWSlowDictionary()
     var identity1 = d._rawIdentifier()
-    let originalCapacity = d._variantStorage.asNative._capacity
+    let originalCapacity = d._variantBuffer.asNative.capacity
     assert(d.count == 3)
     assert(d[TestKeyTy(10)]!.value == 1010)
 
     d.removeAll(keepingCapacity: true)
     assert(identity1 == d._rawIdentifier())
-    assert(d._variantStorage.asNative._capacity == originalCapacity)
+    assert(d._variantBuffer.asNative.capacity == originalCapacity)
     assert(d.count == 0)
     assert(d[TestKeyTy(10)] == nil)
 
     d.removeAll(keepingCapacity: true)
     assert(identity1 == d._rawIdentifier())
-    assert(d._variantStorage.asNative._capacity == originalCapacity)
+    assert(d._variantBuffer.asNative.capacity == originalCapacity)
     assert(d.count == 0)
     assert(d[TestKeyTy(10)] == nil)
   }
@@ -867,7 +867,7 @@ DictionaryTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
   do {
     var d1 = getCOWSlowDictionary()
     var identity1 = d1._rawIdentifier()
-    let originalCapacity = d1._variantStorage.asNative._capacity
+    let originalCapacity = d1._variantBuffer.asNative.capacity
     assert(d1.count == 3)
     assert(d1[TestKeyTy(10)]!.value == 1010)
 
@@ -878,7 +878,7 @@ DictionaryTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
     assert(identity2 != identity1)
     assert(d1.count == 3)
     assert(d1[TestKeyTy(10)]!.value == 1010)
-    assert(d2._variantStorage.asNative._capacity == originalCapacity)
+    assert(d2._variantBuffer.asNative.capacity == originalCapacity)
     assert(d2.count == 0)
     assert(d2[TestKeyTy(10)] == nil)
 
@@ -2034,7 +2034,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
 
     d.removeAll()
     assert(identity1 != d._rawIdentifier())
-    assert(d._variantStorage.asNative._capacity < originalCapacity)
+    assert(d._variantBuffer.asNative.capacity < originalCapacity)
     assert(d.count == 0)
     assert(d[TestObjCKeyTy(10)] == nil)
   }
@@ -2049,7 +2049,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
 
     d.removeAll(keepingCapacity: true)
     assert(identity1 != d._rawIdentifier())
-    assert(d._variantStorage.asNative._capacity >= originalCapacity)
+    assert(d._variantBuffer.asNative.capacity >= originalCapacity)
     assert(d.count == 0)
     assert(d[TestObjCKeyTy(10)] == nil)
   }
@@ -2069,7 +2069,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
     assert(identity2 != identity1)
     assert(d1.count == 3)
     assert((d1[TestObjCKeyTy(10)] as! TestObjCValueTy).value == 1010)
-    assert(d2._variantStorage.asNative._capacity < originalCapacity)
+    assert(d2._variantBuffer.asNative.capacity < originalCapacity)
     assert(d2.count == 0)
     assert(d2[TestObjCKeyTy(10)] == nil)
   }
@@ -2089,7 +2089,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
     assert(identity2 != identity1)
     assert(d1.count == 3)
     assert((d1[TestObjCKeyTy(10)] as! TestObjCValueTy).value == 1010)
-    assert(d2._variantStorage.asNative._capacity >= originalCapacity)
+    assert(d2._variantBuffer.asNative.capacity >= originalCapacity)
     assert(d2.count == 0)
     assert(d2[TestObjCKeyTy(10)] == nil)
   }
@@ -2117,7 +2117,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
 
     d.removeAll()
     assert(identity1 != d._rawIdentifier())
-    assert(d._variantStorage.asNative._capacity < originalCapacity)
+    assert(d._variantBuffer.asNative.capacity < originalCapacity)
     assert(d.count == 0)
     assert(d[TestBridgedKeyTy(10)] == nil)
   }
@@ -2132,7 +2132,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
 
     d.removeAll(keepingCapacity: true)
     assert(identity1 == d._rawIdentifier())
-    assert(d._variantStorage.asNative._capacity >= originalCapacity)
+    assert(d._variantBuffer.asNative.capacity >= originalCapacity)
     assert(d.count == 0)
     assert(d[TestBridgedKeyTy(10)] == nil)
   }
@@ -2152,7 +2152,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
     assert(identity2 != identity1)
     assert(d1.count == 3)
     assert(d1[TestBridgedKeyTy(10)]!.value == 1010)
-    assert(d2._variantStorage.asNative._capacity < originalCapacity)
+    assert(d2._variantBuffer.asNative.capacity < originalCapacity)
     assert(d2.count == 0)
     assert(d2[TestBridgedKeyTy(10)] == nil)
   }
@@ -2172,7 +2172,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
     assert(identity2 != identity1)
     assert(d1.count == 3)
     assert(d1[TestBridgedKeyTy(10)]!.value == 1010)
-    assert(d2._variantStorage.asNative._capacity >= originalCapacity)
+    assert(d2._variantBuffer.asNative.capacity >= originalCapacity)
     assert(d2.count == 0)
     assert(d2[TestBridgedKeyTy(10)] == nil)
   }

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -719,7 +719,7 @@ DictionaryTestSuite.test("COW.Slow.RemoveValueForKeyDoesNotReallocate") {
 DictionaryTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
   do {
     var d = getCOWFastDictionary()
-    let originalCapacity = d._variantStorage.asNative.capacity
+    let originalCapacity = d._variantStorage.asNative._capacity
     assert(d.count == 3)
     assert(d[10]! == 1010)
 
@@ -727,7 +727,7 @@ DictionaryTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
     // We cannot assert that identity changed, since the new buffer of smaller
     // size can be allocated at the same address as the old one.
     var identity1 = d._rawIdentifier()
-    assert(d._variantStorage.asNative.capacity < originalCapacity)
+    assert(d._variantStorage.asNative._capacity < originalCapacity)
     assert(d.count == 0)
     assert(d[10] == nil)
 
@@ -740,19 +740,19 @@ DictionaryTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
   do {
     var d = getCOWFastDictionary()
     var identity1 = d._rawIdentifier()
-    let originalCapacity = d._variantStorage.asNative.capacity
+    let originalCapacity = d._variantStorage.asNative._capacity
     assert(d.count == 3)
     assert(d[10]! == 1010)
 
     d.removeAll(keepingCapacity: true)
     assert(identity1 == d._rawIdentifier())
-    assert(d._variantStorage.asNative.capacity == originalCapacity)
+    assert(d._variantStorage.asNative._capacity == originalCapacity)
     assert(d.count == 0)
     assert(d[10] == nil)
 
     d.removeAll(keepingCapacity: true)
     assert(identity1 == d._rawIdentifier())
-    assert(d._variantStorage.asNative.capacity == originalCapacity)
+    assert(d._variantStorage.asNative._capacity == originalCapacity)
     assert(d.count == 0)
     assert(d[10] == nil)
   }
@@ -781,7 +781,7 @@ DictionaryTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
   do {
     var d1 = getCOWFastDictionary()
     var identity1 = d1._rawIdentifier()
-    let originalCapacity = d1._variantStorage.asNative.capacity
+    let originalCapacity = d1._variantStorage.asNative._capacity
     assert(d1.count == 3)
     assert(d1[10] == 1010)
 
@@ -792,7 +792,7 @@ DictionaryTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
     assert(identity2 != identity1)
     assert(d1.count == 3)
     assert(d1[10]! == 1010)
-    assert(d2._variantStorage.asNative.capacity == originalCapacity)
+    assert(d2._variantStorage.asNative._capacity == originalCapacity)
     assert(d2.count == 0)
     assert(d2[10] == nil)
 
@@ -805,7 +805,7 @@ DictionaryTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
 DictionaryTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
   do {
     var d = getCOWSlowDictionary()
-    let originalCapacity = d._variantStorage.asNative.capacity
+    let originalCapacity = d._variantStorage.asNative._capacity
     assert(d.count == 3)
     assert(d[TestKeyTy(10)]!.value == 1010)
 
@@ -813,7 +813,7 @@ DictionaryTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
     // We cannot assert that identity changed, since the new buffer of smaller
     // size can be allocated at the same address as the old one.
     var identity1 = d._rawIdentifier()
-    assert(d._variantStorage.asNative.capacity < originalCapacity)
+    assert(d._variantStorage.asNative._capacity < originalCapacity)
     assert(d.count == 0)
     assert(d[TestKeyTy(10)] == nil)
 
@@ -826,19 +826,19 @@ DictionaryTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
   do {
     var d = getCOWSlowDictionary()
     var identity1 = d._rawIdentifier()
-    let originalCapacity = d._variantStorage.asNative.capacity
+    let originalCapacity = d._variantStorage.asNative._capacity
     assert(d.count == 3)
     assert(d[TestKeyTy(10)]!.value == 1010)
 
     d.removeAll(keepingCapacity: true)
     assert(identity1 == d._rawIdentifier())
-    assert(d._variantStorage.asNative.capacity == originalCapacity)
+    assert(d._variantStorage.asNative._capacity == originalCapacity)
     assert(d.count == 0)
     assert(d[TestKeyTy(10)] == nil)
 
     d.removeAll(keepingCapacity: true)
     assert(identity1 == d._rawIdentifier())
-    assert(d._variantStorage.asNative.capacity == originalCapacity)
+    assert(d._variantStorage.asNative._capacity == originalCapacity)
     assert(d.count == 0)
     assert(d[TestKeyTy(10)] == nil)
   }
@@ -867,7 +867,7 @@ DictionaryTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
   do {
     var d1 = getCOWSlowDictionary()
     var identity1 = d1._rawIdentifier()
-    let originalCapacity = d1._variantStorage.asNative.capacity
+    let originalCapacity = d1._variantStorage.asNative._capacity
     assert(d1.count == 3)
     assert(d1[TestKeyTy(10)]!.value == 1010)
 
@@ -878,7 +878,7 @@ DictionaryTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
     assert(identity2 != identity1)
     assert(d1.count == 3)
     assert(d1[TestKeyTy(10)]!.value == 1010)
-    assert(d2._variantStorage.asNative.capacity == originalCapacity)
+    assert(d2._variantStorage.asNative._capacity == originalCapacity)
     assert(d2.count == 0)
     assert(d2[TestKeyTy(10)] == nil)
 
@@ -2034,7 +2034,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
 
     d.removeAll()
     assert(identity1 != d._rawIdentifier())
-    assert(d._variantStorage.asNative.capacity < originalCapacity)
+    assert(d._variantStorage.asNative._capacity < originalCapacity)
     assert(d.count == 0)
     assert(d[TestObjCKeyTy(10)] == nil)
   }
@@ -2049,7 +2049,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
 
     d.removeAll(keepingCapacity: true)
     assert(identity1 != d._rawIdentifier())
-    assert(d._variantStorage.asNative.capacity >= originalCapacity)
+    assert(d._variantStorage.asNative._capacity >= originalCapacity)
     assert(d.count == 0)
     assert(d[TestObjCKeyTy(10)] == nil)
   }
@@ -2069,7 +2069,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
     assert(identity2 != identity1)
     assert(d1.count == 3)
     assert((d1[TestObjCKeyTy(10)] as! TestObjCValueTy).value == 1010)
-    assert(d2._variantStorage.asNative.capacity < originalCapacity)
+    assert(d2._variantStorage.asNative._capacity < originalCapacity)
     assert(d2.count == 0)
     assert(d2[TestObjCKeyTy(10)] == nil)
   }
@@ -2089,7 +2089,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
     assert(identity2 != identity1)
     assert(d1.count == 3)
     assert((d1[TestObjCKeyTy(10)] as! TestObjCValueTy).value == 1010)
-    assert(d2._variantStorage.asNative.capacity >= originalCapacity)
+    assert(d2._variantStorage.asNative._capacity >= originalCapacity)
     assert(d2.count == 0)
     assert(d2[TestObjCKeyTy(10)] == nil)
   }
@@ -2117,7 +2117,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
 
     d.removeAll()
     assert(identity1 != d._rawIdentifier())
-    assert(d._variantStorage.asNative.capacity < originalCapacity)
+    assert(d._variantStorage.asNative._capacity < originalCapacity)
     assert(d.count == 0)
     assert(d[TestBridgedKeyTy(10)] == nil)
   }
@@ -2132,7 +2132,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
 
     d.removeAll(keepingCapacity: true)
     assert(identity1 == d._rawIdentifier())
-    assert(d._variantStorage.asNative.capacity >= originalCapacity)
+    assert(d._variantStorage.asNative._capacity >= originalCapacity)
     assert(d.count == 0)
     assert(d[TestBridgedKeyTy(10)] == nil)
   }
@@ -2152,7 +2152,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
     assert(identity2 != identity1)
     assert(d1.count == 3)
     assert(d1[TestBridgedKeyTy(10)]!.value == 1010)
-    assert(d2._variantStorage.asNative.capacity < originalCapacity)
+    assert(d2._variantStorage.asNative._capacity < originalCapacity)
     assert(d2.count == 0)
     assert(d2[TestBridgedKeyTy(10)] == nil)
   }
@@ -2172,7 +2172,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
     assert(identity2 != identity1)
     assert(d1.count == 3)
     assert(d1[TestBridgedKeyTy(10)]!.value == 1010)
-    assert(d2._variantStorage.asNative.capacity >= originalCapacity)
+    assert(d2._variantStorage.asNative._capacity >= originalCapacity)
     assert(d2.count == 0)
     assert(d2[TestBridgedKeyTy(10)] == nil)
   }

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -138,7 +138,9 @@ func isNativeSet<T : Hashable>(_ s: Set<T>) -> Bool {
 #if _runtime(_ObjC)
 func isNativeNSSet(_ s: NSSet) -> Bool {
   let className: NSString = NSStringFromClass(type(of: s)) as NSString
-  return className.range(of: "NativeSetBridgingStorage").length > 0
+  return ["_SwiftDeferredNSSet", "NativeSetBuffer"].contains {
+    className.range(of: $0).length > 0
+  }
 }
 
 func isCocoaNSSet(_ s: NSSet) -> Bool {

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -2040,26 +2040,17 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Generate_Huge") {
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.EqualityTest_Empty") {
   var s1 = getBridgedVerbatimSet([])
-  var identity1 = s1._rawIdentifier()
   expectTrue(isCocoaSet(s1))
 
   var s2 = getBridgedVerbatimSet([])
-  var identity2 = s2._rawIdentifier()
   expectTrue(isCocoaSet(s2))
-  expectEqual(identity1, identity2)
 
   expectEqual(s1, s2)
-  expectEqual(identity1, s1._rawIdentifier())
-  expectEqual(identity2, s2._rawIdentifier())
 
   s2.insert(TestObjCKeyTy(4040))
   expectTrue(isNativeSet(s2))
-  expectNotEqual(identity2, s2._rawIdentifier())
-  identity2 = s2._rawIdentifier()
 
   expectNotEqual(s1, s2)
-  expectEqual(identity1, s1._rawIdentifier())
-  expectEqual(identity2, s2._rawIdentifier())
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.EqualityTest_Empty") {

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -127,7 +127,7 @@ func equalsUnordered(_ lhs: Set<Int>, _ rhs: Set<Int>) -> Bool {
 }
 
 func isNativeSet<T : Hashable>(_ s: Set<T>) -> Bool {
-  switch s._variantStorage {
+  switch s._variantBuffer {
   case .native:
     return true
   case .cocoa:
@@ -138,7 +138,7 @@ func isNativeSet<T : Hashable>(_ s: Set<T>) -> Bool {
 #if _runtime(_ObjC)
 func isNativeNSSet(_ s: NSSet) -> Bool {
   let className: NSString = NSStringFromClass(type(of: s)) as NSString
-  return ["_SwiftDeferredNSSet", "NativeSetBuffer"].contains {
+  return ["_SwiftDeferredNSSet", "NativeSetStorage"].contains {
     className.range(of: $0).length > 0
   }
 }
@@ -834,7 +834,7 @@ SetTestSuite.test("COW.Fast.UnionInPlaceSmallSetDoesNotReallocate") {
 SetTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
   do {
     var s = getCOWFastSet()
-    let originalCapacity = s._variantStorage.asNative._capacity
+    let originalCapacity = s._variantBuffer.asNative.capacity
     expectEqual(3, s.count)
     expectTrue(s.contains(1010))
 
@@ -842,7 +842,7 @@ SetTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
     // We cannot expectTrue that identity changed, since the new buffer of
     // smaller size can be allocated at the same address as the old one.
     var identity1 = s._rawIdentifier()
-    expectTrue(s._variantStorage.asNative._capacity < originalCapacity)
+    expectTrue(s._variantBuffer.asNative.capacity < originalCapacity)
     expectEqual(0, s.count)
     expectFalse(s.contains(1010))
 
@@ -855,19 +855,19 @@ SetTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
   do {
     var s = getCOWFastSet()
     var identity1 = s._rawIdentifier()
-    let originalCapacity = s._variantStorage.asNative._capacity
+    let originalCapacity = s._variantBuffer.asNative.capacity
     expectEqual(3, s.count)
     expectTrue(s.contains(1010))
 
     s.removeAll(keepingCapacity: true)
     expectEqual(identity1, s._rawIdentifier())
-    expectEqual(originalCapacity, s._variantStorage.asNative._capacity)
+    expectEqual(originalCapacity, s._variantBuffer.asNative.capacity)
     expectEqual(0, s.count)
     expectFalse(s.contains(1010))
 
     s.removeAll(keepingCapacity: true)
     expectEqual(identity1, s._rawIdentifier())
-    expectEqual(originalCapacity, s._variantStorage.asNative._capacity)
+    expectEqual(originalCapacity, s._variantBuffer.asNative.capacity)
     expectEqual(0, s.count)
     expectFalse(s.contains(1010))
   }
@@ -896,7 +896,7 @@ SetTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
   do {
     var s1 = getCOWFastSet()
     var identity1 = s1._rawIdentifier()
-    let originalCapacity = s1._variantStorage.asNative._capacity
+    let originalCapacity = s1._variantBuffer.asNative.capacity
     expectEqual(3, s1.count)
     expectTrue(s1.contains(1010))
 
@@ -907,7 +907,7 @@ SetTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
     expectNotEqual(identity1, identity2)
     expectEqual(3, s1.count)
     expectTrue(s1.contains(1010))
-    expectEqual(originalCapacity, s2._variantStorage.asNative._capacity)
+    expectEqual(originalCapacity, s2._variantBuffer.asNative.capacity)
     expectEqual(0, s2.count)
     expectFalse(s2.contains(1010))
 
@@ -920,7 +920,7 @@ SetTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
 SetTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
   do {
     var s = getCOWSlowSet()
-    let originalCapacity = s._variantStorage.asNative._capacity
+    let originalCapacity = s._variantBuffer.asNative.capacity
     expectEqual(3, s.count)
     expectTrue(s.contains(TestKeyTy(1010)))
 
@@ -928,7 +928,7 @@ SetTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
     // We cannot expectTrue that identity changed, since the new buffer of
     // smaller size can be allocated at the same address as the old one.
     var identity1 = s._rawIdentifier()
-    expectTrue(s._variantStorage.asNative._capacity < originalCapacity)
+    expectTrue(s._variantBuffer.asNative.capacity < originalCapacity)
     expectEqual(0, s.count)
     expectFalse(s.contains(TestKeyTy(1010)))
 
@@ -941,19 +941,19 @@ SetTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
   do {
     var s = getCOWSlowSet()
     var identity1 = s._rawIdentifier()
-    let originalCapacity = s._variantStorage.asNative._capacity
+    let originalCapacity = s._variantBuffer.asNative.capacity
     expectEqual(3, s.count)
     expectTrue(s.contains(TestKeyTy(1010)))
 
     s.removeAll(keepingCapacity: true)
     expectEqual(identity1, s._rawIdentifier())
-    expectEqual(originalCapacity, s._variantStorage.asNative._capacity)
+    expectEqual(originalCapacity, s._variantBuffer.asNative.capacity)
     expectEqual(0, s.count)
     expectFalse(s.contains(TestKeyTy(1010)))
 
     s.removeAll(keepingCapacity: true)
     expectEqual(identity1, s._rawIdentifier())
-    expectEqual(originalCapacity, s._variantStorage.asNative._capacity)
+    expectEqual(originalCapacity, s._variantBuffer.asNative.capacity)
     expectEqual(0, s.count)
     expectFalse(s.contains(TestKeyTy(1010)))
   }
@@ -982,7 +982,7 @@ SetTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
   do {
     var s1 = getCOWSlowSet()
     var identity1 = s1._rawIdentifier()
-    let originalCapacity = s1._variantStorage.asNative._capacity
+    let originalCapacity = s1._variantBuffer.asNative.capacity
     expectEqual(3, s1.count)
     expectTrue(s1.contains(TestKeyTy(1010)))
 
@@ -993,7 +993,7 @@ SetTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
     expectNotEqual(identity1, identity2)
     expectEqual(3, s1.count)
     expectTrue(s1.contains(TestKeyTy(1010)))
-    expectEqual(originalCapacity, s2._variantStorage.asNative._capacity)
+    expectEqual(originalCapacity, s2._variantBuffer.asNative.capacity)
     expectEqual(0, s2.count)
     expectFalse(s2.contains(TestKeyTy(1010)))
 

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -138,7 +138,7 @@ func isNativeSet<T : Hashable>(_ s: Set<T>) -> Bool {
 #if _runtime(_ObjC)
 func isNativeNSSet(_ s: NSSet) -> Bool {
   let className: NSString = NSStringFromClass(type(of: s)) as NSString
-  return className.range(of: "NativeSetStorage").length > 0
+  return className.range(of: "NativeSetBridgingStorage").length > 0
 }
 
 func isCocoaNSSet(_ s: NSSet) -> Bool {
@@ -832,7 +832,7 @@ SetTestSuite.test("COW.Fast.UnionInPlaceSmallSetDoesNotReallocate") {
 SetTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
   do {
     var s = getCOWFastSet()
-    let originalCapacity = s._variantStorage.asNative.capacity
+    let originalCapacity = s._variantStorage.asNative._capacity
     expectEqual(3, s.count)
     expectTrue(s.contains(1010))
 
@@ -840,7 +840,7 @@ SetTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
     // We cannot expectTrue that identity changed, since the new buffer of
     // smaller size can be allocated at the same address as the old one.
     var identity1 = s._rawIdentifier()
-    expectTrue(s._variantStorage.asNative.capacity < originalCapacity)
+    expectTrue(s._variantStorage.asNative._capacity < originalCapacity)
     expectEqual(0, s.count)
     expectFalse(s.contains(1010))
 
@@ -853,19 +853,19 @@ SetTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
   do {
     var s = getCOWFastSet()
     var identity1 = s._rawIdentifier()
-    let originalCapacity = s._variantStorage.asNative.capacity
+    let originalCapacity = s._variantStorage.asNative._capacity
     expectEqual(3, s.count)
     expectTrue(s.contains(1010))
 
     s.removeAll(keepingCapacity: true)
     expectEqual(identity1, s._rawIdentifier())
-    expectEqual(originalCapacity, s._variantStorage.asNative.capacity)
+    expectEqual(originalCapacity, s._variantStorage.asNative._capacity)
     expectEqual(0, s.count)
     expectFalse(s.contains(1010))
 
     s.removeAll(keepingCapacity: true)
     expectEqual(identity1, s._rawIdentifier())
-    expectEqual(originalCapacity, s._variantStorage.asNative.capacity)
+    expectEqual(originalCapacity, s._variantStorage.asNative._capacity)
     expectEqual(0, s.count)
     expectFalse(s.contains(1010))
   }
@@ -894,7 +894,7 @@ SetTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
   do {
     var s1 = getCOWFastSet()
     var identity1 = s1._rawIdentifier()
-    let originalCapacity = s1._variantStorage.asNative.capacity
+    let originalCapacity = s1._variantStorage.asNative._capacity
     expectEqual(3, s1.count)
     expectTrue(s1.contains(1010))
 
@@ -905,7 +905,7 @@ SetTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
     expectNotEqual(identity1, identity2)
     expectEqual(3, s1.count)
     expectTrue(s1.contains(1010))
-    expectEqual(originalCapacity, s2._variantStorage.asNative.capacity)
+    expectEqual(originalCapacity, s2._variantStorage.asNative._capacity)
     expectEqual(0, s2.count)
     expectFalse(s2.contains(1010))
 
@@ -918,7 +918,7 @@ SetTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
 SetTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
   do {
     var s = getCOWSlowSet()
-    let originalCapacity = s._variantStorage.asNative.capacity
+    let originalCapacity = s._variantStorage.asNative._capacity
     expectEqual(3, s.count)
     expectTrue(s.contains(TestKeyTy(1010)))
 
@@ -926,7 +926,7 @@ SetTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
     // We cannot expectTrue that identity changed, since the new buffer of
     // smaller size can be allocated at the same address as the old one.
     var identity1 = s._rawIdentifier()
-    expectTrue(s._variantStorage.asNative.capacity < originalCapacity)
+    expectTrue(s._variantStorage.asNative._capacity < originalCapacity)
     expectEqual(0, s.count)
     expectFalse(s.contains(TestKeyTy(1010)))
 
@@ -939,19 +939,19 @@ SetTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
   do {
     var s = getCOWSlowSet()
     var identity1 = s._rawIdentifier()
-    let originalCapacity = s._variantStorage.asNative.capacity
+    let originalCapacity = s._variantStorage.asNative._capacity
     expectEqual(3, s.count)
     expectTrue(s.contains(TestKeyTy(1010)))
 
     s.removeAll(keepingCapacity: true)
     expectEqual(identity1, s._rawIdentifier())
-    expectEqual(originalCapacity, s._variantStorage.asNative.capacity)
+    expectEqual(originalCapacity, s._variantStorage.asNative._capacity)
     expectEqual(0, s.count)
     expectFalse(s.contains(TestKeyTy(1010)))
 
     s.removeAll(keepingCapacity: true)
     expectEqual(identity1, s._rawIdentifier())
-    expectEqual(originalCapacity, s._variantStorage.asNative.capacity)
+    expectEqual(originalCapacity, s._variantStorage.asNative._capacity)
     expectEqual(0, s.count)
     expectFalse(s.contains(TestKeyTy(1010)))
   }
@@ -980,7 +980,7 @@ SetTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
   do {
     var s1 = getCOWSlowSet()
     var identity1 = s1._rawIdentifier()
-    let originalCapacity = s1._variantStorage.asNative.capacity
+    let originalCapacity = s1._variantStorage.asNative._capacity
     expectEqual(3, s1.count)
     expectTrue(s1.contains(TestKeyTy(1010)))
 
@@ -991,7 +991,7 @@ SetTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
     expectNotEqual(identity1, identity2)
     expectEqual(3, s1.count)
     expectTrue(s1.contains(TestKeyTy(1010)))
-    expectEqual(originalCapacity, s2._variantStorage.asNative.capacity)
+    expectEqual(originalCapacity, s2._variantStorage.asNative._capacity)
     expectEqual(0, s2.count)
     expectFalse(s2.contains(TestKeyTy(1010)))
 


### PR DESCRIPTION
<!-- What's in this pull request? -->

This is a rebase of #3046. The majority of the work here is @austinzheng's, and can be found in the first commit. However the codebase had changed enough that the patch had to be significantly modified. I'm mostly relying on the test suite to verify that there weren't errors in resolving all the conflicts.

```
Changes:
- Native dictionary and set indices no longer hold references to storage
- Cocoa-based dictionary and set indices no longer hold references to storage
- Removed double indirection trick from hashed collections
- Rewrote storage types to reflect simpler model
- Updated unit tests
```

As a consequence of removing the double indirection, Dictionary -> NSDictionary now always requires an allocation for a wrapper class. This means that if you bridge a Dictionary multiple times, the resultant NSDictionaries will not be referentially identical. I briefly investigated trying to restore the previous behaviour; or at least perform the optimizations that Array does to make the verbatim-bridgeable case free. 

Discussion with @dabrahams lead to the conclusion that restoring the previous behaviour isn't necessary or even strictly desirable. In particular, the old behaviour could lead to the bridged buffer being kept alive much longer than necessary. This design ensures those are cleaned up as soon as possible. 

My own research into adopting Array's optimization appears to be infeasible, as _NativeDictionaryStorage already inherits from ManagedBuffer, and so can't inherit from _NSDictionaryCore as well (right?).

Still, it should be noted that this will almost certainly lead to regressions in bridging performance. At least in micro-benchmarks. 

It should also be noted that this redesign is necessary for soundness, as the double-indirection design is unsound for multi-threading (as discussed in SE-0065: https://github.com/apple/swift-evolution/blob/master/proposals/0065-collections-move-indices.md). 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: 
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN). -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

TODO before merge:
- [x] re-instate empty-collection-singleton
- [x] fix comparison change
- [ ] evaluate benches
- [x] fix documentation
