### PR TITLE
[SourceKit] Add test case for crash triggered in swift::ModuleDecl::lookupConformance(…)

### DIFF
--- a/validation-test/IDE/crashers/106-swift-moduledecl-lookupconformance.swift
+++ b/validation-test/IDE/crashers/106-swift-moduledecl-lookupconformance.swift
@@ -1,0 +1,4 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+protocol c{#^A^#class B<d,g:T>:c
+class T


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 137
swift-ide-test: /path/to/swift/lib/AST/Module.cpp:596: ArrayRef<swift::Substitution> swift::TypeBase::gatherAllSubstitutions(Module *, swift::LazyResolver *, swift::DeclContext *): Assertion `boundGeneric->getGenericArgs().size() == genericSig->getInnermostGenericParams().size()' failed.
8  swift-ide-test  0x0000000000cad47d swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) + 1677
9  swift-ide-test  0x0000000000a706ce swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::ProtocolConformance**, swift::SourceLoc) + 62
10 swift-ide-test  0x0000000000a9e689 swift::TypeChecker::resolveTypeInContext(swift::TypeDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 1273
14 swift-ide-test  0x0000000000a9fdfd swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 157
16 swift-ide-test  0x0000000000aa0e0f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 159
17 swift-ide-test  0x0000000000a9f5a5 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 277
18 swift-ide-test  0x0000000000a1ff62 swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 2178
19 swift-ide-test  0x0000000000a62cd6 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::GenericSignature*, swift::GenericEnvironment*, swift::GenericTypeResolver*) + 326
20 swift-ide-test  0x0000000000a640c4 swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, bool, std::function<void (swift::ArchetypeBuilder&)>) + 116
21 swift-ide-test  0x0000000000a64b10 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) + 128
22 swift-ide-test  0x0000000000a21bac swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 348
27 swift-ide-test  0x0000000000a28126 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
28 swift-ide-test  0x0000000000a4e64f swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1055
29 swift-ide-test  0x0000000000838ef6 swift::CompilerInstance::performSema() + 3350
30 swift-ide-test  0x00000000007d9854 main + 42916
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking 'c' at <INPUT-FILE>:3:1
2.  While resolving type T at [<INPUT-FILE>:3:25 - line:3:25] RangeText="T"
```
