### PR TITLE
[SourceKit] Add test case for crash triggered in swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(…)

### DIFF
--- a/validation-test/IDE/crashers/107-swift-typechecker-typecheckabstractfunctionbodyuntil.swift
+++ b/validation-test/IDE/crashers/107-swift-typechecker-typecheckabstractfunctionbodyuntil.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+let a{func i(={#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 141
swift-ide-test: /path/to/swift/lib/Sema/TypeCheckStmt.cpp:1277: bool swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl *, swift::SourceLoc): Assertion `BS && "Should have a body"' failed.
8  swift-ide-test  0x0000000000a98477 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 39
9  swift-ide-test  0x0000000000a50491 swift::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 657
13 swift-ide-test  0x0000000000c5d4d4 swift::Decl::walk(swift::ASTWalker&) + 20
14 swift-ide-test  0x0000000000cb22ee swift::SourceFile::walk(swift::ASTWalker&) + 174
15 swift-ide-test  0x0000000000cb15ff swift::ModuleDecl::walk(swift::ASTWalker&) + 95
16 swift-ide-test  0x0000000000c87fc4 swift::DeclContext::walkContext(swift::ASTWalker&) + 180
17 swift-ide-test  0x0000000000989aa8 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 136
18 swift-ide-test  0x0000000000839051 swift::CompilerInstance::performSema() + 3697
19 swift-ide-test  0x00000000007d9854 main + 42916
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl getter for a at <INPUT-FILE>:3:5
```
