### PR TITLE
[SourceKit] Add test case for crash triggered in swift::getTypeOfCompletionContextExpr(…)

### DIFF
--- a/validation-test/IDE/crashers/108-swift-typechecker-typecheckcompletionsequence.swift
+++ b/validation-test/IDE/crashers/108-swift-typechecker-typecheckcompletionsequence.swift
@@ -1,0 +1,4 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+func c{case
+let a#^A^#}


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 143
swift-ide-test: /path/to/swift/lib/Sema/TypeCheckConstraints.cpp:1636: Optional<swift::Type> swift::TypeChecker::getTypeOfExpressionWithoutApplying(swift::Expr *&, swift::DeclContext *, swift::ConcreteDeclRef &, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener *): Assertion `exprType && !exprType->hasError() && "erroneous solution?"' failed.
9  swift-ide-test  0x0000000000a4fa83 swift::getTypeOfCompletionContextExpr(swift::ASTContext&, swift::DeclContext*, swift::CompletionTypeCheckKind, swift::Expr*&, swift::ConcreteDeclRef&) + 691
13 swift-ide-test  0x0000000000c5d4d4 swift::Decl::walk(swift::ASTWalker&) + 20
14 swift-ide-test  0x0000000000cb22ee swift::SourceFile::walk(swift::ASTWalker&) + 174
15 swift-ide-test  0x0000000000cb15ff swift::ModuleDecl::walk(swift::ASTWalker&) + 95
16 swift-ide-test  0x0000000000c87fc4 swift::DeclContext::walkContext(swift::ASTWalker&) + 180
17 swift-ide-test  0x0000000000989aa8 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 136
18 swift-ide-test  0x0000000000839051 swift::CompilerInstance::performSema() + 3697
19 swift-ide-test  0x00000000007d9854 main + 42916
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl 'c' at <INPUT-FILE>:3:1
2.  While type-checking expression at [<INPUT-FILE>:4:5 - line:4:5] RangeText="a"
```
