### PR TITLE
Initialize CachedVFile with nullptr

### DIFF
--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -40,7 +40,7 @@ class SourceManager {
     int LineOffset;
   };
   std::map<const char *, VirtualFile> VirtualFiles;
-  mutable std::pair<const char *, const VirtualFile*> CachedVFile = {};
+  mutable std::pair<const char *, const VirtualFile*> CachedVFile = {nullptr, nullptr};
 
 public:
   llvm::SourceMgr &getLLVMSourceMgr() {

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -82,7 +82,7 @@ bool SourceManager::openVirtualFile(SourceLoc loc, StringRef name,
 
   CharSourceRange range = CharSourceRange(*this, loc, end);
   VirtualFiles[end.Value.getPointer()] = { range, name, lineOffset };
-  CachedVFile = {};
+  CachedVFile = {nullptr, nullptr};
   return true;
 }
 
@@ -99,7 +99,7 @@ void SourceManager::closeVirtualFile(SourceLoc end) {
 #endif
     return;
   }
-  CachedVFile = {};
+  CachedVFile = {nullptr, nullptr};
 
   CharSourceRange oldRange = virtualFile->Range;
   virtualFile->Range = CharSourceRange(*this, virtualFile->Range.getStart(),


### PR DESCRIPTION
Building on Ubuntu 16.10 with Clang 3.8 caused build failure with error below, to resolve this issue @bitjammer suggested `CachedVFile = {nullptr, nullptr};`

```
/home/buildnode/disk1/workspace/oss-swift-incremental-RA-linux-ubuntu-16_10/swift/lib/Basic/SourceLoc.cpp:85:15: error: use of overloaded operator '=' is ambiguous (with operand types 'std::pair<const char *, const VirtualFile *>' and 'void')
  CachedVFile = {};
  ~~~~~~~~~~~ ^ ~~
```
