### PR TITLE
[swift-3.0-branch] Fix dispatch time comparisons (#5078)

### DIFF
--- a/stdlib/public/SDK/Dispatch/Time.swift
+++ b/stdlib/public/SDK/Dispatch/Time.swift
@@ -45,7 +45,6 @@ public struct DispatchTime : Comparable {
 }
 
 public func <(a: DispatchTime, b: DispatchTime) -> Bool {
-	if a.rawValue == ~0 || b.rawValue == ~0 { return false }
 	return a.rawValue < b.rawValue
 }
 
@@ -73,8 +72,12 @@ public struct DispatchWallTime : Comparable {
 }
 
 public func <(a: DispatchWallTime, b: DispatchWallTime) -> Bool {
-	if a.rawValue == ~0 || b.rawValue == ~0 { return false }
-	return -Int64(a.rawValue) < -Int64(b.rawValue)
+	if b.rawValue == ~0 {
+		return a.rawValue != ~0
+	} else if a.rawValue == ~0 {
+		return false
+	}
+	return -Int64(bitPattern: a.rawValue) < -Int64(bitPattern: b.rawValue)
 }
 
 public func ==(a: DispatchWallTime, b: DispatchWallTime) -> Bool {

--- a/test/1_stdlib/Dispatch.swift
+++ b/test/1_stdlib/Dispatch.swift
@@ -85,3 +85,19 @@ DispatchAPI.test("dispatch_data_t deallocator") {
 		expectEqual(1, t)
 	}
 }
+
+DispatchAPI.test("DispatchTime comparisons") {
+    do {
+        let now = DispatchTime.now()
+        checkComparable([now, now + .milliseconds(1), .distantFuture], oracle: {
+            return $0 < $1 ? .lt : $0 == $1 ? .eq : .gt
+        })
+    }
+
+    do {
+        let now = DispatchWallTime.now()
+        checkComparable([now, now + .milliseconds(1), .distantFuture], oracle: {
+            return $0 < $1 ? .lt : $0 == $1 ? .eq : .gt
+        })
+    }
+}


### PR DESCRIPTION
This is a cherry-pick of #5078.


* Explanation: Correct implementation of DispatchWallTime.< operator.
* Scope of Issue: The existing implementation does not handle the DispatchWallTime.distantFuture values correctly and crashes on some values.
* Origination: Incorrect original implementation.
* Risk: Minimal.
* Reviewed By: Matt Wright
* Testing: Running an updated unit test suite.
* Directions for QA: N/A

<rdar://problem/29028859>
