### PR TITLE
[swift-runtime] Rename rt_swift_* to swift_rt_*. NFC

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -219,7 +219,7 @@
 #define SWIFT_RT_ENTRY_IMPL_VISIBILITY LLVM_LIBRARY_VISIBILITY
 
 // Prefix of wrappers generated for runtime functions.
-#define SWIFT_WRAPPER_PREFIX "rt_"
+#define SWIFT_WRAPPER_PREFIX "swift_rt_"
 
 #else
 

--- a/test/ClangModules/objc_ir.swift
+++ b/test/ClangModules/objc_ir.swift
@@ -83,7 +83,7 @@ func propertyAccess(b b: B) {
 // CHECK: define hidden [[B]]* @_TF7objc_ir8downcastFT1aCSo1A_CSo1B(
 func downcast(a a: A) -> B {
   // CHECK: [[CLASS:%.*]] = load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_B"
-  // CHECK: [[T0:%.*]] = call %objc_class* @rt_swift_getInitializedObjCClass(%objc_class* [[CLASS]])
+  // CHECK: [[T0:%.*]] = call %objc_class* @swift_rt_swift_getInitializedObjCClass(%objc_class* [[CLASS]])
   // CHECK: [[T1:%.*]] = bitcast %objc_class* [[T0]] to i8*
   // CHECK: call i8* @swift_dynamicCastObjCClassUnconditional(i8* [[A:%.*]], i8* [[T1]]) [[NOUNWIND:#[0-9]+]]
   return a as! B
@@ -134,7 +134,7 @@ func protocolCompositionMetatype(p: Impl) -> (FooProto & AnotherProto).Type {
   // CHECK: [[RAW_RESULT:%.+]] = call i8* @processComboType(i8* {{%.+}})
   // CHECK: [[CASTED_RESULT:%.+]] = bitcast i8* [[RAW_RESULT]] to %objc_class*
   // CHECK: [[SWIFT_RESULT:%.+]] = call %swift.type* @swift_getObjCClassMetadata(%objc_class* [[CASTED_RESULT]])
-  // CHECK: call void bitcast (void (%swift.refcounted*)* @rt_swift_release to void (%C7objc_ir4Impl*)*)(%C7objc_ir4Impl* %0)
+  // CHECK: call void bitcast (void (%swift.refcounted*)* @swift_rt_swift_release to void (%C7objc_ir4Impl*)*)(%C7objc_ir4Impl* %0)
   // CHECK: ret %swift.type* [[SWIFT_RESULT]]
   let type = processComboType(type(of: p))
   return type
@@ -147,7 +147,7 @@ func protocolCompositionMetatype2(p: Impl) -> (FooProto & AnotherProto).Type {
   // CHECK: [[RAW_RESULT:%.+]] = call i8* @processComboType2(i8* {{%.+}})
   // CHECK: [[CASTED_RESULT:%.+]] = bitcast i8* [[RAW_RESULT]] to %objc_class*
   // CHECK: [[SWIFT_RESULT:%.+]] = call %swift.type* @swift_getObjCClassMetadata(%objc_class* [[CASTED_RESULT]])
-  // CHECK: call void bitcast (void (%swift.refcounted*)* @rt_swift_release to void (%C7objc_ir4Impl*)*)(%C7objc_ir4Impl* %0)
+  // CHECK: call void bitcast (void (%swift.refcounted*)* @swift_rt_swift_release to void (%C7objc_ir4Impl*)*)(%C7objc_ir4Impl* %0)
   // CHECK: ret %swift.type* [[SWIFT_RESULT]]
   let type = processComboType2(type(of: p))
   return type

--- a/test/DebugInfo/linetable.swift
+++ b/test/DebugInfo/linetable.swift
@@ -33,8 +33,8 @@ func main(_ x: Int64) -> Void
         {
             var result = my_class.do_something(x)
             markUsed(result)
-// CHECK: call {{.*}} @rt_swift_release {{.*}}
-// CHECK: call {{.*}} @rt_swift_release {{.*}}, !dbg ![[CLOSURE_END:.*]]
+// CHECK: call {{.*}} @swift_rt_swift_release {{.*}}
+// CHECK: call {{.*}} @swift_rt_swift_release {{.*}}, !dbg ![[CLOSURE_END:.*]]
 // CHECK-NEXT: bitcast
 // CHECK-NEXT: llvm.lifetime.end
 // CHECK-NEXT: ret void, !dbg ![[CLOSURE_END]]

--- a/test/DebugInfo/return.swift
+++ b/test/DebugInfo/return.swift
@@ -11,14 +11,14 @@ public func ifelseexpr() -> Int64 {
   // CHECK: [[META:%.*]] = call %swift.type* @_TMaC6return1X()
   // CHECK: [[X:%.*]] = call %C6return1X* @_TFC6return1XCfT1iVs5Int64_S0_(
   // CHECK-SAME:                                  i64 0, %swift.type* [[META]])
-  // CHECK:  @rt_swift_release to void (%C6return1X*)*)(%C6return1X* [[X]])
+  // CHECK:  @swift_rt_swift_release to void (%C6return1X*)*)(%C6return1X* [[X]])
   if true {
     x.x += 1
   } else {
     x.x -= 1
   }
-  // CHECK:  @rt_swift_release to void (%C6return1X*)*)(%C6return1X* [[X]])
-  // CHECK:  @rt_swift_release to void (%C6return1X*)*)(%C6return1X* [[X]])
+  // CHECK:  @swift_rt_swift_release to void (%C6return1X*)*)(%C6return1X* [[X]])
+  // CHECK:  @swift_rt_swift_release to void (%C6return1X*)*)(%C6return1X* [[X]])
   // CHECK-SAME:                    , !dbg ![[RELEASE:.*]]
 
   // The ret instruction should be in the same scope as the return expression.

--- a/test/IRGen/alloc.sil
+++ b/test/IRGen/alloc.sil
@@ -20,15 +20,15 @@ struct Huge {
 }
 
 // CHECK: @_swift_slowAlloc = external global i8* ([[SIZE_T:i(32|64)]],
-// CHECK: define linkonce_odr hidden i8* @rt_swift_slowAlloc([[SIZE_T:i(32|64)]],
+// CHECK: define linkonce_odr hidden i8* @swift_rt_swift_slowAlloc([[SIZE_T:i(32|64)]],
 
 // CHECK:    define linkonce_odr hidden void @_TwdeV4main4Huge(
 // CHECK:      [[T0:%.*]] = bitcast [[BUFFER:.[0-9]+ x i8.]]* {{%.*}} to i8**
 // CHECK-NEXT: [[T1:%.*]] = load i8*, i8** [[T0]]
-// CHECK-NEXT: call void @rt_swift_slowDealloc(i8* [[T1]], [[SIZE_T]] 4097, [[SIZE_T]] 7)
+// CHECK-NEXT: call void @swift_rt_swift_slowDealloc(i8* [[T1]], [[SIZE_T]] 4097, [[SIZE_T]] 7)
 // CHECK-NEXT: ret void
 
 // CHECK:    define linkonce_odr hidden [[OPAQUE:%swift.opaque]]* @_TwalV4main4Huge(
-// CHECK:      [[T0:%.*]] = call noalias i8* @rt_swift_slowAlloc([[SIZE_T]] 4097, [[SIZE_T]] 7)
+// CHECK:      [[T0:%.*]] = call noalias i8* @swift_rt_swift_slowAlloc([[SIZE_T]] 4097, [[SIZE_T]] 7)
 // CHECK-NEXT: [[T1:%.*]] = bitcast [[BUFFER]]* {{%.*}} to i8**
 // CHECK-NEXT: store i8* [[T0]], i8** [[T1]]

--- a/test/IRGen/associated_type_witness.swift
+++ b/test/IRGen/associated_type_witness.swift
@@ -118,7 +118,7 @@ struct Computed<T, U> : Assocked {
 //   Witness table instantiation function for Computed : Assocked.
 // CHECK-LABEL: define hidden i8** @_TWauRx23associated_type_witness1PrGVS_15GenericComputedx_S_22DerivedFromSimpleAssocS_(%swift.type*)
 // CHECK:         entry:
-// CHECK-NEXT:     [[WTABLE:%.*]] = call i8** @rt_swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @_TWGuRx23associated_type_witness1PrGVS_15GenericComputedx_S_22DerivedFromSimpleAssocS_, %swift.type* %0, i8** null)
+// CHECK-NEXT:     [[WTABLE:%.*]] = call i8** @swift_rt_swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @_TWGuRx23associated_type_witness1PrGVS_15GenericComputedx_S_22DerivedFromSimpleAssocS_, %swift.type* %0, i8** null)
 // CHECK-NEXT:     ret i8** [[WTABLE]]
 
 
@@ -158,7 +158,7 @@ struct GenericComputed<T: P> : DerivedFromSimpleAssoc {
 //   Witness table instantiation function for GenericComputed : HasSimpleAssoc..
 // CHECK-LABEL: define hidden i8** @_TWauRx23associated_type_witness1PrGVS_15GenericComputedx_S_14HasSimpleAssocS_(%swift.type*)
 // CHECK-NEXT:   entry:
-// CHECK-NEXT:    [[WTABLE:%.*]] = call i8** @rt_swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @_TWGuRx23associated_type_witness1PrGVS_15GenericComputedx_S_14HasSimpleAssocS_, %swift.type* %0, i8** null)
+// CHECK-NEXT:    [[WTABLE:%.*]] = call i8** @swift_rt_swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @_TWGuRx23associated_type_witness1PrGVS_15GenericComputedx_S_14HasSimpleAssocS_, %swift.type* %0, i8** null)
 // CHECK-NEXT:    ret i8** %1
 
 

--- a/test/IRGen/bitcast.sil
+++ b/test/IRGen/bitcast.sil
@@ -115,8 +115,8 @@ bb0(%0 : $Int, %1 : $Int):
 }
 
 // CHECK-LABEL: define{{( protected)?}} void @unchecked_ref_cast_addr
-// CHECK-i386: call i1 @rt_swift_dynamicCast(%swift.opaque* %0, %swift.opaque* %{{.*}}, %swift.type* %T, %swift.type* %U, i32 7)
-// CHECK-x86_64: call i1 @rt_swift_dynamicCast(%swift.opaque* %0, %swift.opaque* %{{.*}}, %swift.type* %T, %swift.type* %U, i64 7)
+// CHECK-i386: call i1 @swift_rt_swift_dynamicCast(%swift.opaque* %0, %swift.opaque* %{{.*}}, %swift.type* %T, %swift.type* %U, i32 7)
+// CHECK-x86_64: call i1 @swift_rt_swift_dynamicCast(%swift.opaque* %0, %swift.opaque* %{{.*}}, %swift.type* %T, %swift.type* %U, i64 7)
 sil @unchecked_ref_cast_addr : $@convention(thin) <T, U> (@in T) -> @out U {
 bb0(%0 : $*U, %1 : $*T):
   %a = alloc_stack $T

--- a/test/IRGen/boxed_existential.sil
+++ b/test/IRGen/boxed_existential.sil
@@ -6,10 +6,10 @@ import Swift
 sil @retain_release_boxed_existential : $@convention(thin) (Error) -> () {
 entry(%e : $Error):
   // CHECK-objc: @swift_errorRetain
-  // CHECK-native: @rt_swift_retain
+  // CHECK-native: @swift_rt_swift_retain
   strong_retain %e : $Error
   // CHECK-objc: @swift_errorRelease
-  // CHECK-native: @rt_swift_release
+  // CHECK-native: @swift_rt_swift_release
   strong_release %e : $Error
   return undef : $()
 }
@@ -109,7 +109,7 @@ entry(%b : $Error):
   %m = existential_metatype $@thick Error.Type, %b : $Error
 
   // CHECK-objc:   call void @swift_errorRelease(%swift.error* %0)
-  // CHECK-native: call void bitcast (void (%swift.refcounted*)* @rt_swift_release to void (%swift.error*)*)(%swift.error* %0)
+  // CHECK-native: call void bitcast (void (%swift.refcounted*)* @swift_rt_swift_release to void (%swift.error*)*)(%swift.error* %0)
   strong_release %b : $Error
 
   // CHECK: [[RET:%.*]] = insertvalue { %swift.type*, i8** } undef, %swift.type* [[DYNAMIC_TYPE]], 0

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -151,7 +151,7 @@ func assign_test(_ value: Builtin.Int64, ptr: Builtin.RawPointer) {
 // CHECK: define hidden %swift.refcounted* @_TF8builtins16load_object_test
 func load_object_test(_ ptr: Builtin.RawPointer) -> Builtin.NativeObject {
   // CHECK: [[T0:%.*]] = load [[REFCOUNT]]*, [[REFCOUNT]]**
-  // CHECK: call void @rt_swift_retain([[REFCOUNT]]* [[T0]])
+  // CHECK: call void @swift_rt_swift_retain([[REFCOUNT]]* [[T0]])
   // CHECK: ret [[REFCOUNT]]* [[T0]]
   return Builtin.load(ptr)
 }
@@ -159,7 +159,7 @@ func load_object_test(_ ptr: Builtin.RawPointer) -> Builtin.NativeObject {
 // CHECK: define hidden %swift.refcounted* @_TF8builtins20load_raw_object_test
 func load_raw_object_test(_ ptr: Builtin.RawPointer) -> Builtin.NativeObject {
   // CHECK: [[T0:%.*]] = load [[REFCOUNT]]*, [[REFCOUNT]]**
-  // CHECK: call void @rt_swift_retain([[REFCOUNT]]* [[T0]])
+  // CHECK: call void @swift_rt_swift_retain([[REFCOUNT]]* [[T0]])
   // CHECK: ret [[REFCOUNT]]* [[T0]]
   return Builtin.loadRaw(ptr)
 }
@@ -430,7 +430,7 @@ func destroyPODArray(_ array: Builtin.RawPointer, count: Builtin.Word) {
 // CHECK-LABEL: define hidden void @_TF8builtins18destroyNonPODArray{{.*}}(i8*, i64) {{.*}} {
 // CHECK:       iter:
 // CHECK:       loop:
-// CHECK:         call {{.*}} @rt_swift_release
+// CHECK:         call {{.*}} @swift_rt_swift_release
 // CHECK:         br label %iter
 func destroyNonPODArray(_ array: Builtin.RawPointer, count: Builtin.Word) {
   Builtin.destroyArray(C.self, array, count)
@@ -461,7 +461,7 @@ func copyPODArray(_ dest: Builtin.RawPointer, src: Builtin.RawPointer, count: Bu
 // CHECK-LABEL: define hidden void @_TF8builtins11copyBTArray{{.*}}(i8*, i8*, i64) {{.*}} {
 // CHECK:       iter:
 // CHECK:       loop:
-// CHECK:         call {{.*}} @rt_swift_retain
+// CHECK:         call {{.*}} @swift_rt_swift_retain
 // CHECK:         br label %iter
 // CHECK:         mul nuw i64 8, %2
 // CHECK:         call void @llvm.memmove.p0i8.p0i8.i64(i8* {{.*}}, i8* {{.*}}, i64 {{.*}}, i32 8, i1 false)
@@ -575,7 +575,7 @@ func isUnique(_ ref: inout Builtin.NativeObject?) -> Bool {
 // CHECK-LABEL: define hidden i1 @_TF8builtins8isUniqueFRBoBi1_(%swift.refcounted** nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK-NEXT: load %swift.refcounted*, %swift.refcounted** %0
-// CHECK-NEXT: call i1 @rt_swift_isUniquelyReferenced_nonNull_native(%swift.refcounted* %1)
+// CHECK-NEXT: call i1 @swift_rt_swift_isUniquelyReferenced_nonNull_native(%swift.refcounted* %1)
 // CHECK-NEXT: ret i1 %2
 func isUnique(_ ref: inout Builtin.NativeObject) -> Bool {
   return Builtin.isUnique(&ref)
@@ -586,7 +586,7 @@ func isUnique(_ ref: inout Builtin.NativeObject) -> Bool {
 // CHECK-NEXT: entry:
 // CHECK-NEXT: bitcast [[BUILTIN_NATIVE_OBJECT_TY]]* %0 to %swift.refcounted**
 // CHECK-NEXT: load %swift.refcounted*, %swift.refcounted** %1
-// CHECK-NEXT: call i1 @rt_swift_isUniquelyReferencedOrPinned_native(%swift.refcounted* %2)
+// CHECK-NEXT: call i1 @swift_rt_swift_isUniquelyReferencedOrPinned_native(%swift.refcounted* %2)
 // CHECK-NEXT: ret i1 %3
 func isUniqueOrPinned(_ ref: inout Builtin.NativeObject?) -> Bool {
   return Builtin.isUniqueOrPinned(&ref)
@@ -596,7 +596,7 @@ func isUniqueOrPinned(_ ref: inout Builtin.NativeObject?) -> Bool {
 // CHECK-LABEL: define hidden i1 @_TF8builtins16isUniqueOrPinnedFRBoBi1_(%swift.refcounted** nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK-NEXT: load %swift.refcounted*, %swift.refcounted** %0
-// CHECK-NEXT: call i1 @rt_swift_isUniquelyReferencedOrPinned_nonNull_native(%swift.refcounted* %1)
+// CHECK-NEXT: call i1 @swift_rt_swift_isUniquelyReferencedOrPinned_nonNull_native(%swift.refcounted* %1)
 // CHECK-NEXT: ret i1 %2
 func isUniqueOrPinned(_ ref: inout Builtin.NativeObject) -> Bool {
   return Builtin.isUniqueOrPinned(&ref)
@@ -661,7 +661,7 @@ func isUniqueOrPinned(_ ref: inout Builtin.BridgeObject) -> Bool {
 // CHECK-NEXT: entry:
 // CHECK-NEXT: bitcast %swift.bridge** %0 to %swift.refcounted**
 // CHECK-NEXT: load %swift.refcounted*, %swift.refcounted** %1
-// CHECK-NEXT: call i1 @rt_swift_isUniquelyReferenced_nonNull_native(%swift.refcounted* %2)
+// CHECK-NEXT: call i1 @swift_rt_swift_isUniquelyReferenced_nonNull_native(%swift.refcounted* %2)
 // CHECK-NEXT: ret i1 %3
 func isUnique_native(_ ref: inout Builtin.BridgeObject) -> Bool {
   return Builtin.isUnique_native(&ref)
@@ -672,7 +672,7 @@ func isUnique_native(_ ref: inout Builtin.BridgeObject) -> Bool {
 // CHECK-NEXT: entry:
 // CHECK-NEXT: bitcast %swift.bridge** %0 to %swift.refcounted**
 // CHECK-NEXT: load %swift.refcounted*, %swift.refcounted** %1
-// CHECK-NEXT: call i1 @rt_swift_isUniquelyReferencedOrPinned_nonNull_native(%swift.refcounted* %2)
+// CHECK-NEXT: call i1 @swift_rt_swift_isUniquelyReferencedOrPinned_nonNull_native(%swift.refcounted* %2)
 // CHECK-NEXT: ret i1 %3
 func isUniqueOrPinned_native(_ ref: inout Builtin.BridgeObject) -> Bool {
   return Builtin.isUniqueOrPinned_native(&ref)
@@ -718,9 +718,9 @@ func generic_unsafeGuaranteed_test<T: AnyObject>(_ t : T) -> T {
 
 // CHECK-LABEL: define {{.*}} @{{.*}}unsafeGuaranteed_test
 // CHECK:  [[LOCAL:%.*]] = alloca %swift.refcounted*
-// CHECK:  call void @rt_swift_retain(%swift.refcounted* %0)
+// CHECK:  call void @swift_rt_swift_retain(%swift.refcounted* %0)
 // CHECK:  store %swift.refcounted* %0, %swift.refcounted** [[LOCAL]]
-// CHECK:  call void @rt_swift_release(%swift.refcounted* %0)
+// CHECK:  call void @swift_rt_swift_release(%swift.refcounted* %0)
 // CHECK:  ret %swift.refcounted* %0
 func unsafeGuaranteed_test(_ x: Builtin.NativeObject) -> Builtin.NativeObject {
   var (g,t) = Builtin.unsafeGuaranteed(x)

--- a/test/IRGen/casts.sil
+++ b/test/IRGen/casts.sil
@@ -225,7 +225,7 @@ nay:
 // CHECK:         [[OBJ_PTR:%.*]] = bitcast %C5casts1A* [[T0]] to i8*
 // CHECK:         [[METADATA:%.*]] = call %swift.type* @_TMaC5casts1A()
 // CHECK:         [[METADATA_PTR:%.*]] = bitcast %swift.type* [[METADATA]] to i8*
-// CHECK:         [[RESULT_PTR:%.*]] = call i8* @rt_swift_dynamicCastClass(i8* [[OBJ_PTR]], i8* [[METADATA_PTR]])
+// CHECK:         [[RESULT_PTR:%.*]] = call i8* @swift_rt_swift_dynamicCastClass(i8* [[OBJ_PTR]], i8* [[METADATA_PTR]])
 // CHECK:         [[RESULT:%.*]] = bitcast i8* [[RESULT_PTR]] to %C5casts1A*
 // CHECK:         [[COND:%.*]] = icmp ne %C5casts1A* [[RESULT]], null
 // CHECK:         br i1 [[COND]]

--- a/test/IRGen/class.sil
+++ b/test/IRGen/class.sil
@@ -100,7 +100,7 @@ bb0(%0 : $@thick C.Type):
   // CHECK:   [[T1:%.*]] = bitcast i8* [[T0]] to i16*
   // CHECK:   [[ALIGN16:%.*]] = load i16, i16* [[T1]], align 4
   // CHECK:   [[ALIGN:%.*]] = zext i16 [[ALIGN16]] to i64
-  // CHECK:   [[RESULT:%[0-9]+]] = call noalias %swift.refcounted* @rt_swift_allocObject(%swift.type* %0, i64 [[SIZE]], i64 [[ALIGN]])
+  // CHECK:   [[RESULT:%[0-9]+]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* %0, i64 [[SIZE]], i64 [[ALIGN]])
   %1 = alloc_ref_dynamic %0 : $@thick C.Type, $C
   return %1 : $C
 }

--- a/test/IRGen/class_stack_alloc.sil
+++ b/test/IRGen/class_stack_alloc.sil
@@ -34,7 +34,7 @@ sil_vtable BigClass {}
 // CHECK-NEXT: [[O:%[0-9]+]] = bitcast %[[C]]* %reference.raw to %swift.refcounted*
 // CHECK-NEXT: %reference.new = call %swift.refcounted* @swift_initStackObject(%swift.type* [[M]], %swift.refcounted* [[O]])
 // CHECK-NEXT: [[R:%[0-9]+]] = bitcast %swift.refcounted* %reference.new to %[[C]]*
-// CHECK-NEXT: call {{.*}} @rt_swift_release {{.*}} [[R]])
+// CHECK-NEXT: call {{.*}} @swift_rt_swift_release {{.*}} [[R]])
 // CHECK-NEXT: [[O2:%[0-9]+]] = bitcast %[[C]]* [[R]] to i8*
 // CHECK-NEXT: call void @llvm.lifetime.end(i64 -1, i8* [[O2]])
 // CHECK-NEXT: ret void
@@ -56,7 +56,7 @@ bb0:
 // CHECK: alloca {{.*}}TestStruct
 // CHECK-NOT: alloca
 // CHECK: call %swift.refcounted* @swift_initStackObject
-// CHECK: call noalias %swift.refcounted* @rt_swift_allocObject
+// CHECK: call noalias %swift.refcounted* @swift_rt_swift_allocObject
 // CHECK: ret void
 sil @exceed_limit : $@convention(thin) () -> () {
 bb0:
@@ -124,7 +124,7 @@ bb0:
 }
 
 // CHECK-LABEL: define{{( protected)?}} void @not_promoted_with_inlined_devirtualized_release
-// CHECK: [[O:%[0-9]+]] = call {{.*}} @rt_swift_allocObject
+// CHECK: [[O:%[0-9]+]] = call {{.*}} @swift_rt_swift_allocObject
 // CHECK-NEXT: [[BC:%[0-9]+]] = bitcast %swift.refcounted* [[O]] to
 // CHECK-NEXT: call {{.*}} @swift_setDeallocating {{.*}}({{.*}} [[BC]])
 // CHECK-NEXT: [[BC2:%[0-9]+]] = bitcast {{.*}} [[BC]] to %swift.refcounted*

--- a/test/IRGen/closure.swift
+++ b/test/IRGen/closure.swift
@@ -40,8 +40,8 @@ func b<T : Ordinable>(seq seq: T) -> (Int) -> Int {
 // CHECK:   [[WITNESS:%.*]] = load i8**, i8*** [[WITNESSADDR]], align 8
 // CHECK:   [[BOXADDR:%.*]] = getelementptr inbounds <{ %swift.refcounted, [16 x i8], %swift.refcounted* }>, <{ %swift.refcounted, [16 x i8], %swift.refcounted* }>* [[CONTEXT]], i32 0, i32 2
 // CHECK:   [[BOX:%.*]] = load %swift.refcounted*, %swift.refcounted** [[BOXADDR]], align 8
-// CHECK:   call void @rt_swift_retain(%swift.refcounted* [[BOX]])
-// CHECK:   call void @rt_swift_release(%swift.refcounted* %1)
+// CHECK:   call void @swift_rt_swift_retain(%swift.refcounted* [[BOX]])
+// CHECK:   call void @swift_rt_swift_release(%swift.refcounted* %1)
 // CHECK:   [[RES:%.*]] = tail call i64 @[[CLOSURE2]](i64 %0, %swift.refcounted* [[BOX]], %swift.type* [[TYPE]], i8** [[WITNESS]])
 // CHECK:   ret i64 [[RES]]
 // CHECK: }

--- a/test/IRGen/dllimport.swift
+++ b/test/IRGen/dllimport.swift
@@ -50,10 +50,10 @@ public func g() {
 // CHECK-NO-OPT-DAG: declare dllimport %swift.refcounted* @_TFC9dllexport1cd(%C9dllexport1c*)
 // CHECK-NO-OPT-DAG: declare dllimport %swift.type* @_TMaC9dllexport1c()
 // CHECK-NO-OPT-DAG: declare dllimport void @swift_deallocClassInstance(%swift.refcounted*, i32, i32)
-// CHECK-NO-OPT-DAG: define linkonce_odr hidden i8* @rt_swift_slowAlloc(i32, i32)
-// CHECK-NO-OPT-DAG: define linkonce_odr hidden void @rt_swift_release(%swift.refcounted*)
-// CHECK-NO-OPT-DAG: define linkonce_odr hidden void @rt_swift_retain(%swift.refcounted*)
-// CHECK-NO-OPT-DAG: define linkonce_odr hidden void @rt_swift_slowDealloc(i8*, i32, i32)
+// CHECK-NO-OPT-DAG: define linkonce_odr hidden i8* @swift_rt_swift_slowAlloc(i32, i32)
+// CHECK-NO-OPT-DAG: define linkonce_odr hidden void @swift_rt_swift_release(%swift.refcounted*)
+// CHECK-NO-OPT-DAG: define linkonce_odr hidden void @swift_rt_swift_retain(%swift.refcounted*)
+// CHECK-NO-OPT-DAG: define linkonce_odr hidden void @swift_rt_swift_slowDealloc(i8*, i32, i32)
 
 // CHECK-OPT-DAG: @_swift_retain = external dllimport local_unnamed_addr global void (%swift.refcounted*)
 // CHECK-OPT-DAG: @_TWVBo = external dllimport global i8*
@@ -66,6 +66,6 @@ public func g() {
 // CHECK-OPT-DAG: declare dllimport void @swift_deallocClassInstance(%swift.refcounted*, i32, i32)
 // CHECK-OPT-DAG: declare dllimport %swift.refcounted* @_TFC9dllexport1cd(%C9dllexport1c*)
 // CHECK-OPT-DAG: declare dllimport void @swift_deletedMethodError()
-// CHECK-OPT-DAG: define linkonce_odr hidden i8* @rt_swift_slowAlloc(i32, i32)
-// CHECK-OPT-DAG: define linkonce_odr hidden void @rt_swift_slowDealloc(i8*, i32, i32)
+// CHECK-OPT-DAG: define linkonce_odr hidden i8* @swift_rt_swift_slowAlloc(i32, i32)
+// CHECK-OPT-DAG: define linkonce_odr hidden void @swift_rt_swift_slowDealloc(i8*, i32, i32)
 

--- a/test/IRGen/dynamic_cast.sil
+++ b/test/IRGen/dynamic_cast.sil
@@ -26,7 +26,7 @@ bb0(%0 : $*P):
   // CHECK: [[T1:%.*]] = bitcast [[S]]* [[T0]] to [[OPAQUE:%swift.opaque]]*
   // CHECK: [[T2:%.*]] = bitcast [[P:%.*]]* {{%.*}} to [[OPAQUE]]*
   // CHECK: [[T3:%.*]] = call [[TYPE:%.*]]* @_TMaP12dynamic_cast1P_()
-  // CHECK: call i1 @rt_swift_dynamicCast([[OPAQUE]]* [[T1]], [[OPAQUE]]* [[T2]], [[TYPE]]* [[T3]], [[TYPE]]* {{.*}}, [[LLVM_PTRSIZE_INT]] 7)
+  // CHECK: call i1 @swift_rt_swift_dynamicCast([[OPAQUE]]* [[T1]], [[OPAQUE]]* [[T2]], [[TYPE]]* [[T3]], [[TYPE]]* {{.*}}, [[LLVM_PTRSIZE_INT]] 7)
   %1 = alloc_stack $S
   unconditional_checked_cast_addr take_always P in %0 : $*P to S in %1 : $*S
   destroy_addr %1 : $*S
@@ -36,7 +36,7 @@ bb0(%0 : $*P):
 }
 
 // CHECK-LABEL: define linkonce_odr hidden %swift.type* @_TMaP12dynamic_cast1P_()
-// CHECK:       call %swift.type* @rt_swift_getExistentialTypeMetadata(
+// CHECK:       call %swift.type* @swift_rt_swift_getExistentialTypeMetadata(
 
 // CHECK-LABEL: define{{( protected)?}} void @testUnconditional1(
 sil @testUnconditional1 : $@convention(thin) (@in P) -> () {
@@ -45,7 +45,7 @@ bb0(%0 : $*P):
   // CHECK: [[T1:%.*]] = bitcast [[S]]* [[T0]] to [[OPAQUE:%swift.opaque]]*
   // CHECK: [[T2:%.*]] = bitcast [[P:%.*]]* {{%.*}} to [[OPAQUE]]*
   // CHECK: [[T3:%.*]] = call [[TYPE:%.*]]* @_TMaP12dynamic_cast1P_()
-  // CHECK: call i1 @rt_swift_dynamicCast([[OPAQUE]]* [[T1]], [[OPAQUE]]* [[T2]], [[TYPE]]* [[T3]], [[TYPE]]* {{.*}}, [[LLVM_PTRSIZE_INT]] 3)
+  // CHECK: call i1 @swift_rt_swift_dynamicCast([[OPAQUE]]* [[T1]], [[OPAQUE]]* [[T2]], [[TYPE]]* [[T3]], [[TYPE]]* {{.*}}, [[LLVM_PTRSIZE_INT]] 3)
   %1 = alloc_stack $S
   unconditional_checked_cast_addr take_on_success P in %0 : $*P to S in %1 : $*S
   destroy_addr %1 : $*S
@@ -61,7 +61,7 @@ bb0(%0 : $*P):
   // CHECK: [[T1:%.*]] = bitcast [[S]]* [[T0]] to [[OPAQUE:%swift.opaque]]*
   // CHECK: [[T2:%.*]] = bitcast [[P:%.*]]* {{%.*}} to [[OPAQUE]]*
   // CHECK: [[T3:%.*]] = call [[TYPE:%.*]]* @_TMaP12dynamic_cast1P_()
-  // CHECK: call i1 @rt_swift_dynamicCast([[OPAQUE]]* [[T1]], [[OPAQUE]]* [[T2]], [[TYPE]]* [[T3]], [[TYPE]]* {{.*}}, [[LLVM_PTRSIZE_INT]] 1)
+  // CHECK: call i1 @swift_rt_swift_dynamicCast([[OPAQUE]]* [[T1]], [[OPAQUE]]* [[T2]], [[TYPE]]* [[T3]], [[TYPE]]* {{.*}}, [[LLVM_PTRSIZE_INT]] 1)
   %1 = alloc_stack $S
   unconditional_checked_cast_addr copy_on_success P in %0 : $*P to S in %1 : $*S
   destroy_addr %1 : $*S
@@ -77,7 +77,7 @@ bb0(%0 : $*P):
   // CHECK: [[T1:%.*]] = bitcast [[S]]* [[T0]] to [[OPAQUE:%swift.opaque]]*
   // CHECK: [[T2:%.*]] = bitcast [[P:%.*]]* {{%.*}} to [[OPAQUE]]*
   // CHECK: [[T3:%.*]] = call [[TYPE:%.*]]* @_TMaP12dynamic_cast1P_()
-  // CHECK: [[T4:%.*]] = call i1 @rt_swift_dynamicCast([[OPAQUE]]* [[T1]], [[OPAQUE]]* [[T2]], [[TYPE]]* [[T3]], [[TYPE]]* {{.*}}, [[LLVM_PTRSIZE_INT]] 6)
+  // CHECK: [[T4:%.*]] = call i1 @swift_rt_swift_dynamicCast([[OPAQUE]]* [[T1]], [[OPAQUE]]* [[T2]], [[TYPE]]* [[T3]], [[TYPE]]* {{.*}}, [[LLVM_PTRSIZE_INT]] 6)
   // CHECK: br i1 [[T4]], 
   %1 = alloc_stack $S
   checked_cast_addr_br take_always P in %0 : $*P to S in %1 : $*S, bb1, bb2
@@ -97,7 +97,7 @@ bb0(%0 : $*P):
   // CHECK: [[T1:%.*]] = bitcast [[S]]* [[T0]] to [[OPAQUE:%swift.opaque]]*
   // CHECK: [[T2:%.*]] = bitcast [[P:%.*]]* {{%.*}} to [[OPAQUE]]*
   // CHECK: [[T3:%.*]] = call [[TYPE:%.*]]* @_TMaP12dynamic_cast1P_()
-  // CHECK: [[T4:%.*]] = call i1 @rt_swift_dynamicCast([[OPAQUE]]* [[T1]], [[OPAQUE]]* [[T2]], [[TYPE]]* [[T3]], [[TYPE]]* {{.*}}, [[LLVM_PTRSIZE_INT]] 2)
+  // CHECK: [[T4:%.*]] = call i1 @swift_rt_swift_dynamicCast([[OPAQUE]]* [[T1]], [[OPAQUE]]* [[T2]], [[TYPE]]* [[T3]], [[TYPE]]* {{.*}}, [[LLVM_PTRSIZE_INT]] 2)
   // CHECK: br i1 [[T4]], 
   %1 = alloc_stack $S
   checked_cast_addr_br take_on_success P in %0 : $*P to S in %1 : $*S, bb1, bb2
@@ -117,7 +117,7 @@ bb0(%0 : $*P):
   // CHECK: [[T1:%.*]] = bitcast [[S]]* [[T0]] to [[OPAQUE:%swift.opaque]]*
   // CHECK: [[T2:%.*]] = bitcast [[P:%.*]]* {{%.*}} to [[OPAQUE]]*
   // CHECK: [[T3:%.*]] = call [[TYPE:%.*]]* @_TMaP12dynamic_cast1P_()
-  // CHECK: [[T4:%.*]] = call i1 @rt_swift_dynamicCast([[OPAQUE]]* [[T1]], [[OPAQUE]]* [[T2]], [[TYPE]]* [[T3]], [[TYPE]]* {{.*}}, [[LLVM_PTRSIZE_INT]] 0)
+  // CHECK: [[T4:%.*]] = call i1 @swift_rt_swift_dynamicCast([[OPAQUE]]* [[T1]], [[OPAQUE]]* [[T2]], [[TYPE]]* [[T3]], [[TYPE]]* {{.*}}, [[LLVM_PTRSIZE_INT]] 0)
   // CHECK: br i1 [[T4]], 
   %1 = alloc_stack $S
   checked_cast_addr_br copy_on_success P in %0 : $*P to S in %1 : $*S, bb1, bb2

--- a/test/IRGen/dynamic_init.sil
+++ b/test/IRGen/dynamic_init.sil
@@ -27,7 +27,7 @@ bb0(%0 : $@thick C.Type):
   %2 = class_method %0 : $@thick C.Type, #C.init!allocator.1 : (C.Type) -> () -> C , $@convention(method) (@thick C.Type) -> @owned C
   // CHECK:   [[RESULT:%[0-9]+]] = call %C12dynamic_init1C* [[CTOR_FN]](%swift.type* %0)
   %3 = apply %2(%0) : $@convention(method) (@thick C.Type) -> @owned C
-  // CHECK:   call void bitcast (void (%swift.refcounted*)* @rt_swift_release to void (%C12dynamic_init1C*)*)(%C12dynamic_init1C* [[RESULT]])
+  // CHECK:   call void bitcast (void (%swift.refcounted*)* @swift_rt_swift_release to void (%C12dynamic_init1C*)*)(%C12dynamic_init1C* [[RESULT]])
   strong_release %3 : $C
   // CHECK: ret void
   %5 = tuple ()

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -1217,7 +1217,7 @@ enum DynamicSinglePayload<T> {
 
 // CHECK: define{{( protected)?}} void @dynamic_single_payload_switch(%O4enum20DynamicSinglePayload* noalias nocapture, %swift.type* %T) {{.*}} {
 // CHECK:   [[OPAQUE_ENUM:%.*]] = bitcast %O4enum20DynamicSinglePayload* %0 to %swift.opaque*
-// CHECK:   [[CASE_INDEX:%.*]] = call i32 @rt_swift_getEnumCaseSinglePayload(%swift.opaque* [[OPAQUE_ENUM]], %swift.type* %T, i32 3)
+// CHECK:   [[CASE_INDEX:%.*]] = call i32 @swift_rt_swift_getEnumCaseSinglePayload(%swift.opaque* [[OPAQUE_ENUM]], %swift.type* %T, i32 3)
 // CHECK:   switch i32 [[CASE_INDEX]], label {{%.*}} [
 // CHECK:     i32 -1, label {{%.*}}
 // CHECK:     i32 2, label {{%.*}}
@@ -1242,7 +1242,7 @@ end:
 
 // CHECK: define{{( protected)?}} void @dynamic_single_payload_inject_x(%O4enum20DynamicSinglePayload* noalias nocapture sret, %swift.opaque* noalias nocapture, %swift.type* %T) {{.*}} {
 // CHECK:   [[ADDR:%.*]] = bitcast %O4enum20DynamicSinglePayload* %0 to %swift.opaque*
-// CHECK:   call void @rt_swift_storeEnumTagSinglePayload(%swift.opaque* [[ADDR]], %swift.type* %T, i32 -1, i32 3)
+// CHECK:   call void @swift_rt_swift_storeEnumTagSinglePayload(%swift.opaque* [[ADDR]], %swift.type* %T, i32 -1, i32 3)
 sil @dynamic_single_payload_inject_x : $<T> (@in T) -> @out DynamicSinglePayload<T> {
 entry(%r : $*DynamicSinglePayload<T>, %t : $*T):
   inject_enum_addr %r : $*DynamicSinglePayload<T>, #DynamicSinglePayload.x!enumelt.1
@@ -1252,7 +1252,7 @@ entry(%r : $*DynamicSinglePayload<T>, %t : $*T):
 
 // CHECK: define{{( protected)?}} void @dynamic_single_payload_inject_y(%O4enum20DynamicSinglePayload* noalias nocapture sret, %swift.type* %T) {{.*}} {
 // CHECK:   [[ADDR:%.*]] = bitcast %O4enum20DynamicSinglePayload* %0 to %swift.opaque*
-// CHECK:   call void @rt_swift_storeEnumTagSinglePayload(%swift.opaque* [[ADDR]], %swift.type* %T, i32 0, i32 3)
+// CHECK:   call void @swift_rt_swift_storeEnumTagSinglePayload(%swift.opaque* [[ADDR]], %swift.type* %T, i32 0, i32 3)
 sil @dynamic_single_payload_inject_y : $<T> () -> @out DynamicSinglePayload<T> {
 entry(%r : $*DynamicSinglePayload<T>):
   inject_enum_addr %r : $*DynamicSinglePayload<T>, #DynamicSinglePayload.y!enumelt

--- a/test/IRGen/enum_dynamic_multi_payload.sil
+++ b/test/IRGen/enum_dynamic_multi_payload.sil
@@ -380,7 +380,7 @@ entry(%a : $*EitherOr<T, C>, %b : $*EitherOr<T, C>):
   // CHECK:        call void %destroy(%swift.opaque* {{%.*}}, %swift.type* %T)
   // CHECK:        br label %[[NOOP]]
   // CHECK:      <label>:[[RIGHT]]
-  // CHECK:        call void {{.*}} @rt_swift_release
+  // CHECK:        call void {{.*}} @swift_rt_swift_release
   // CHECK:      <label>:[[NOOP]]
   destroy_addr %a : $*EitherOr<T, C>
 
@@ -407,7 +407,7 @@ entry(%a : $*EitherOr<T, C>, %b : $*EitherOr<T, C>):
   // CHECK:        call %swift.opaque* %initializeWithCopy(%swift.opaque* {{%.*}}, %swift.type* %T)
   // CHECK:        br label %[[DONE:[0-9]+]]
   // CHECK:      <label>:[[RIGHT]]
-  // CHECK:        call void @rt_swift_retain
+  // CHECK:        call void @swift_rt_swift_retain
   // CHECK:        br label %[[DONE:[0-9]+]]
   // CHECK:      <label>:[[TRIVIAL]]
   // CHECK:        call void @llvm.memcpy

--- a/test/IRGen/enum_function.sil
+++ b/test/IRGen/enum_function.sil
@@ -20,7 +20,7 @@ bb0(%0 : $Optional<() -> ()>):
   // CHECK: br i1 [[T0]], label
   // CHECK: [[FNPTR:%.*]] = inttoptr [[WORD]] %0 to i8*
   // CHECK: [[CTX:%.*]] = inttoptr [[WORD]] %1 to %swift.refcounted*
-  // CHECK: call void @rt_swift_retain(%swift.refcounted* [[CTX]])
+  // CHECK: call void @swift_rt_swift_retain(%swift.refcounted* [[CTX]])
   // CHECK: br label
   retain_value %0 : $Optional<() -> ()>
   

--- a/test/IRGen/enum_resilience.swift
+++ b/test/IRGen/enum_resilience.swift
@@ -195,7 +195,7 @@ public func reabstraction<T>(_ f: (Medium) -> T) {}
 // CHECK-LABEL: define{{( protected)?}} void @_TF15enum_resilience25resilientEnumPartialApplyFFO14resilient_enum6MediumSiT_(i8*, %swift.refcounted*)
 public func resilientEnumPartialApply(_ f: (Medium) -> Int) {
 
-// CHECK:     [[CONTEXT:%.*]] = call noalias %swift.refcounted* @rt_swift_allocObject
+// CHECK:     [[CONTEXT:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject
 // CHECK:     call void @_TF15enum_resilience13reabstractionurFFO14resilient_enum6MediumxT_(i8* bitcast (void (%Si*, %swift.opaque*, %swift.refcounted*)* @_TPA__TTRXFo_iO14resilient_enum6Medium_dSi_XFo_iS0__iSi_ to i8*), %swift.refcounted* [[CONTEXT:%.*]], %swift.type* @_TMSi)
   reabstraction(f)
 

--- a/test/IRGen/enum_value_semantics.sil
+++ b/test/IRGen/enum_value_semantics.sil
@@ -200,7 +200,7 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT:   i64 4, label [[NOT_PRESENT]]
 // CHECK-NEXT: ]
 // CHECK:      [[T0:%.*]] = inttoptr i64 [[V:%.*]] to %swift.refcounted*
-// CHECK-NEXT: call void @rt_swift_retain(%swift.refcounted* [[T0]])
+// CHECK-NEXT: call void @swift_rt_swift_retain(%swift.refcounted* [[T0]])
 // CHECK-NEXT: br label [[NOT_PRESENT]]
 // CHECK:      switch i64 %0, label [[PRESENT:%.*]] [
 // CHECK-NEXT:   i64 0, label [[NOT_PRESENT:%.*]]
@@ -208,7 +208,7 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT:   i64 4, label [[NOT_PRESENT]]
 // CHECK-NEXT: ]
 // CHECK:      [[T0:%.*]] = inttoptr i64 [[V:%.*]] to %swift.refcounted*
-// CHECK-NEXT: call void @rt_swift_release(%swift.refcounted* [[T0]])
+// CHECK-NEXT: call void @swift_rt_swift_release(%swift.refcounted* [[T0]])
 // CHECK-NEXT: br label [[NOT_PRESENT]]
 // CHECK:      ret void
 
@@ -276,7 +276,7 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-LABEL: define linkonce_odr hidden i32 @_TwugO20enum_value_semantics20SinglePayloadTrivial
 // CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %O20enum_value_semantics20SinglePayloadTrivial*
 // CHECK-NEXT: [[OPAQUE:%.*]] = bitcast %O20enum_value_semantics20SinglePayloadTrivial* [[SELF]] to %swift.opaque*
-// CHECK-NEXT: [[TAG:%.*]] = call i32 @rt_swift_getEnumCaseSinglePayload(%swift.opaque* [[OPAQUE]], %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_TMBi64_, i32 0, i32 1), i32 3)
+// CHECK-NEXT: [[TAG:%.*]] = call i32 @swift_rt_swift_getEnumCaseSinglePayload(%swift.opaque* [[OPAQUE]], %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_TMBi64_, i32 0, i32 1), i32 3)
 // CHECK-NEXT: ret i32 [[TAG]]
 
 
@@ -294,7 +294,7 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-LABEL: define linkonce_odr hidden void @_TwuiO20enum_value_semantics20SinglePayloadTrivial
 // CHECK:      [[SELF:%.*]] = bitcast %swift.opaque* %value to %O20enum_value_semantics20SinglePayloadTrivial*
 // CHECK-NEXT: [[OPAQUE:%.*]] = bitcast %O20enum_value_semantics20SinglePayloadTrivial* [[SELF]] to %swift.opaque*
-// CHECK-NEXT: call void @rt_swift_storeEnumTagSinglePayload(%swift.opaque* [[OPAQUE]], %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_TMBi64_, i32 0, i32 1), i32 %tag, i32 3)
+// CHECK-NEXT: call void @swift_rt_swift_storeEnumTagSinglePayload(%swift.opaque* [[OPAQUE]], %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @_TMBi64_, i32 0, i32 1), i32 %tag, i32 3)
 // CHECK-NEXT: ret void
 
 
@@ -312,7 +312,7 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK:      ; <label>:[[RELEASE_PAYLOAD]]
 // CHECK-NEXT: [[DATA_ADDR:%.*]] = bitcast %O20enum_value_semantics23SinglePayloadNontrivial* [[ADDR]] to %swift.refcounted**
 // CHECK-NEXT: [[DATA:%.*]] = load %swift.refcounted*, %swift.refcounted** [[DATA_ADDR]], align 8
-// CHECK-NEXT: call void @rt_swift_release(%swift.refcounted* [[DATA]])
+// CHECK-NEXT: call void @swift_rt_swift_release(%swift.refcounted* [[DATA]])
 // CHECK-NEXT: br label %[[DONE]]
 
 // CHECK:      ; <label>:[[DONE]]
@@ -484,7 +484,7 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK:      ]
 // CHECK:      ; <label>:[[PAYLOAD1_DESTROY]]
 // CHECK-NEXT: [[PAYLOAD1_VAL:%.*]] = inttoptr i64 [[PAYLOAD_0]] to %swift.refcounted*
-// CHECK-NEXT: call void @rt_swift_release(%swift.refcounted* [[PAYLOAD1_VAL]])
+// CHECK-NEXT: call void @swift_rt_swift_release(%swift.refcounted* [[PAYLOAD1_VAL]])
 // CHECK-NEXT: br label %[[END]]
 // CHECK:      ; <label>:[[PAYLOAD3_DESTROY]]
 // CHECK-NEXT: [[PAYLOAD3_1_VAL:%.*]] = inttoptr i64 [[PAYLOAD_1]] to %objc_object*
@@ -539,7 +539,7 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK:      ]
 // CHECK:      ; <label>:[[PAYLOAD1_DESTROY]]
 // CHECK-NEXT: [[PAYLOAD1_VAL:%.*]] = inttoptr i64 [[PAYLOAD_0]] to %swift.refcounted*
-// CHECK-NEXT: call void @rt_swift_release(%swift.refcounted* [[PAYLOAD1_VAL]])
+// CHECK-NEXT: call void @swift_rt_swift_release(%swift.refcounted* [[PAYLOAD1_VAL]])
 // CHECK-NEXT: br label %[[END]]
 // CHECK:      ; <label>:[[PAYLOAD3_DESTROY]]
 // CHECK-NEXT: [[MASKED:%.*]] = and i64 [[PAYLOAD_1]]

--- a/test/IRGen/enum_value_semantics_special_cases.sil
+++ b/test/IRGen/enum_value_semantics_special_cases.sil
@@ -16,7 +16,7 @@ enum NullableRefcounted {
 // CHECK:   %0 = bitcast %swift.opaque* %object to %O34enum_value_semantics_special_cases18NullableRefcounted*
 // CHECK:   %1 = bitcast %O34enum_value_semantics_special_cases18NullableRefcounted* %0 to %swift.refcounted**
 // CHECK:   %2 = load %swift.refcounted*, %swift.refcounted** %1, align 8
-// CHECK:   call void @rt_swift_release(%swift.refcounted* %2) {{#[0-9]+}}
+// CHECK:   call void @swift_rt_swift_release(%swift.refcounted* %2) {{#[0-9]+}}
 // CHECK:   ret void
 // CHECK: }
 
@@ -27,7 +27,7 @@ enum NullableRefcounted {
 // CHECK:   %2 = bitcast %O34enum_value_semantics_special_cases18NullableRefcounted* %0 to %swift.refcounted**
 // CHECK:   %3 = bitcast %O34enum_value_semantics_special_cases18NullableRefcounted* %1 to %swift.refcounted**
 // CHECK:   %4 = load %swift.refcounted*, %swift.refcounted** %3, align 8
-// CHECK:   call void @rt_swift_retain(%swift.refcounted* %4) {{#[0-9]+}}
+// CHECK:   call void @swift_rt_swift_retain(%swift.refcounted* %4) {{#[0-9]+}}
 // CHECK:   store %swift.refcounted* %4, %swift.refcounted** %2, align 8
 // CHECK:   %5 = bitcast %O34enum_value_semantics_special_cases18NullableRefcounted* %0 to %swift.opaque*
 // CHECK:   ret %swift.opaque* %5
@@ -41,9 +41,9 @@ enum NullableRefcounted {
 // CHECK:   %3 = bitcast %O34enum_value_semantics_special_cases18NullableRefcounted* %1 to %swift.refcounted**
 // CHECK:   %4 = load %swift.refcounted*, %swift.refcounted** %2, align 8
 // CHECK:   %5 = load %swift.refcounted*, %swift.refcounted** %3, align 8
-// CHECK:   call void @rt_swift_retain(%swift.refcounted* %5) {{#[0-9]+}}
+// CHECK:   call void @swift_rt_swift_retain(%swift.refcounted* %5) {{#[0-9]+}}
 // CHECK:   store %swift.refcounted* %5, %swift.refcounted** %2, align 8
-// CHECK:   call void @rt_swift_release(%swift.refcounted* %4) {{#[0-9]+}}
+// CHECK:   call void @swift_rt_swift_release(%swift.refcounted* %4) {{#[0-9]+}}
 // CHECK:   %6 = bitcast %O34enum_value_semantics_special_cases18NullableRefcounted* %0 to %swift.opaque*
 // CHECK:   ret %swift.opaque* %6
 // CHECK: }
@@ -57,7 +57,7 @@ enum NullableRefcounted {
 // CHECK:   %4 = load %swift.refcounted*, %swift.refcounted** %2, align 8
 // CHECK:   %5 = load %swift.refcounted*, %swift.refcounted** %3, align 8
 // CHECK:   store %swift.refcounted* %5, %swift.refcounted** %2, align 8
-// CHECK:   call void @rt_swift_release(%swift.refcounted* %4) {{#[0-9]+}}
+// CHECK:   call void @swift_rt_swift_release(%swift.refcounted* %4) {{#[0-9]+}}
 // CHECK:   %6 = bitcast %O34enum_value_semantics_special_cases18NullableRefcounted* %0 to %swift.opaque*
 // CHECK:   ret %swift.opaque* %6
 // CHECK: }
@@ -139,7 +139,7 @@ enum MultipleEmptyRefcounted {
 // CHECK: ; <label>:3:                                      ; preds = %entry
 // CHECK:   %4 = bitcast %O34enum_value_semantics_special_cases23MultipleEmptyRefcounted* %0 to %swift.refcounted**
 // CHECK:   %toDestroy = load %swift.refcounted*, %swift.refcounted** %4, align 8
-// CHECK:   call void @rt_swift_release(%swift.refcounted* %toDestroy) {{#[0-9]+}}
+// CHECK:   call void @swift_rt_swift_release(%swift.refcounted* %toDestroy) {{#[0-9]+}}
 // CHECK:   br label %5
 // CHECK: ; <label>:5:                                      ; preds = %3, %entry, %entry
 // CHECK:   ret void
@@ -172,7 +172,7 @@ enum AllRefcounted {
 // --                        0x3fffffffffffffff
 // CHECK:   %3 = and i64 %2, 4611686018427387903
 // CHECK:   %4 = inttoptr i64 %3 to %swift.refcounted*
-// CHECK:   call void @rt_swift_release(%swift.refcounted* %4) {{#[0-9]+}}
+// CHECK:   call void @swift_rt_swift_release(%swift.refcounted* %4) {{#[0-9]+}}
 // CHECK:   ret void
 // CHECK: }
 
@@ -181,7 +181,7 @@ enum AllRefcounted {
 // --                              0x3fffffffffffffff
 // CHECK:         %4 = and i64 %3, 4611686018427387903
 // CHECK:         %5 = inttoptr i64 %4 to %swift.refcounted*
-// CHECK:         call void @rt_swift_retain(%swift.refcounted* %5)
+// CHECK:         call void @swift_rt_swift_retain(%swift.refcounted* %5)
 // CHECK:         %6 = bitcast %O34enum_value_semantics_special_cases13AllRefcounted* %0 to i64*
 // -- NB: The original loaded value is stored, not the masked one.
 // CHECK:         store i64 %3, i64* %6, align 8

--- a/test/IRGen/errors.sil
+++ b/test/IRGen/errors.sil
@@ -58,7 +58,7 @@ entry(%0 : $AnyObject):
 // CHECK-objc:        [[T0:%.*]] = phi %objc_object* [ [[RESULT]],
 // CHECK-objc-NEXT:   call void @swift_unknownRelease(%objc_object* [[T0]])
 // CHECK-native:      [[T0:%.*]] = phi %swift.refcounted* [ [[RESULT]],
-// CHECK-native-NEXT: call void @rt_swift_release(%swift.refcounted* [[T0]])
+// CHECK-native-NEXT: call void @swift_rt_swift_release(%swift.refcounted* [[T0]])
 // CHECK-NEXT:        br label [[CONT:%[0-9]+]]
 bb1(%2 : $AnyObject):
   strong_release %2 : $AnyObject
@@ -67,7 +67,7 @@ bb1(%2 : $AnyObject):
 // CHECK:             [[T0:%.*]] = phi %swift.error* [ [[ERR]],
 // CHECK-NEXT:        store %swift.error* null, %swift.error** [[ERRORSLOT]], align
 // CHECK-objc-NEXT:   call void @swift_errorRelease(%swift.error* [[T0]])
-// CHECK-native-NEXT: call void bitcast (void (%swift.refcounted*)* @rt_swift_release to void (%swift.error*)*)(%swift.error* [[T0]])
+// CHECK-native-NEXT: call void bitcast (void (%swift.refcounted*)* @swift_rt_swift_release to void (%swift.error*)*)(%swift.error* [[T0]])
 // CHECK-NEXT:        br label [[CONT]]
 bb2(%3 : $Error):
   release_value %3 : $Error

--- a/test/IRGen/existentials.sil
+++ b/test/IRGen/existentials.sil
@@ -12,15 +12,15 @@ protocol CP: class {}
 sil @class_existential_unowned : $@convention(thin) (@owned CP) -> @owned CP {
 entry(%s : $CP):
   %u = ref_to_unowned %s : $CP to $@sil_unowned CP
-  // CHECK: call void @rt_swift_unownedRetain(%swift.refcounted* %0)
+  // CHECK: call void @swift_rt_swift_unownedRetain(%swift.refcounted* %0)
   unowned_retain %u : $@sil_unowned CP
-  // CHECK: call void @rt_swift_unownedRelease(%swift.refcounted* %0)
+  // CHECK: call void @swift_rt_swift_unownedRelease(%swift.refcounted* %0)
   unowned_release %u : $@sil_unowned CP
 
-  // CHECK: call void @rt_swift_unownedRetainStrong(%swift.refcounted* %0)
+  // CHECK: call void @swift_rt_swift_unownedRetainStrong(%swift.refcounted* %0)
   strong_retain_unowned %u : $@sil_unowned CP
   %t = unowned_to_ref %u : $@sil_unowned CP to $CP
-  // CHECK: call void @rt_swift_release(%swift.refcounted* %0)
+  // CHECK: call void @swift_rt_swift_release(%swift.refcounted* %0)
   strong_release %t : $CP
 
   %v = ref_to_unmanaged %s : $CP to $@sil_unmanaged CP

--- a/test/IRGen/function_types.sil
+++ b/test/IRGen/function_types.sil
@@ -23,8 +23,8 @@ entry(%x : $@convention(thin) () -> ()):
 
 // CHECK-LABEL: define{{( protected)?}} { i8*, %swift.refcounted* } @thick_func_value(i8*, %swift.refcounted*) {{.*}} {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    call void @rt_swift_retain(%swift.refcounted* %1) {{#[0-9]+}}
-// CHECK-NEXT:    call void @rt_swift_release(%swift.refcounted* %1) {{#[0-9]+}}
+// CHECK-NEXT:    call void @swift_rt_swift_retain(%swift.refcounted* %1) {{#[0-9]+}}
+// CHECK-NEXT:    call void @swift_rt_swift_release(%swift.refcounted* %1) {{#[0-9]+}}
 // CHECK-NEXT:    %2 = insertvalue { i8*, %swift.refcounted* } undef, i8* %0, 0
 // CHECK-NEXT:    %3 = insertvalue { i8*, %swift.refcounted* } %2, %swift.refcounted* %1, 1
 // CHECK-NEXT:    ret { i8*, %swift.refcounted* } %3

--- a/test/IRGen/generic_casts.swift
+++ b/test/IRGen/generic_casts.swift
@@ -38,7 +38,7 @@ func allToInt<T>(_ x: T) -> Int {
   // CHECK: [[INT_TEMP:%.*]] = alloca %Si,
   // CHECK: [[TEMP:%.*]] = call %swift.opaque* {{.*}}([[BUFFER]]* [[BUF]], %swift.opaque* %0, %swift.type* %T)
   // CHECK: [[T0:%.*]] = bitcast %Si* [[INT_TEMP]] to %swift.opaque*
-  // CHECK: call i1 @rt_swift_dynamicCast(%swift.opaque* [[T0]], %swift.opaque* [[TEMP]], %swift.type* %T, %swift.type* @_TMSi, i64 7)
+  // CHECK: call i1 @swift_rt_swift_dynamicCast(%swift.opaque* [[T0]], %swift.opaque* [[TEMP]], %swift.type* %T, %swift.type* @_TMSi, i64 7)
   // CHECK: [[T0:%.*]] = getelementptr inbounds %Si, %Si* [[INT_TEMP]], i32 0, i32 0
   // CHECK: [[INT_RESULT:%.*]] = load i64, i64* [[T0]],
   // CHECK: ret i64 [[INT_RESULT]]
@@ -50,7 +50,7 @@ func intToAll<T>(_ x: Int) -> T {
   // CHECK: [[T0:%.*]] = getelementptr inbounds %Si, %Si* [[INT_TEMP]], i32 0, i32 0
   // CHECK: store i64 %1, i64* [[T0]],
   // CHECK: [[T0:%.*]] = bitcast %Si* [[INT_TEMP]] to %swift.opaque*
-  // CHECK: call i1 @rt_swift_dynamicCast(%swift.opaque* %0, %swift.opaque* [[T0]], %swift.type* @_TMSi, %swift.type* %T, i64 7)
+  // CHECK: call i1 @swift_rt_swift_dynamicCast(%swift.opaque* %0, %swift.opaque* [[T0]], %swift.type* @_TMSi, %swift.type* %T, i64 7)
   return x as! T
 }
 
@@ -94,7 +94,7 @@ func classExistentialToOpaqueArchetype<T>(_ x: ObjCProto1) -> T {
   // CHECK: [[LOCAL:%.*]] = alloca %P13generic_casts10ObjCProto1_
   // CHECK: [[LOCAL_OPAQUE:%.*]] = bitcast %P13generic_casts10ObjCProto1_* [[LOCAL]] to %swift.opaque*
   // CHECK: [[PROTO_TYPE:%.*]] = call %swift.type* @_TMaP13generic_casts10ObjCProto1_()
-  // CHECK: call i1 @rt_swift_dynamicCast(%swift.opaque* %0, %swift.opaque* [[LOCAL_OPAQUE]], %swift.type* [[PROTO_TYPE]], %swift.type* %T, i64 7)
+  // CHECK: call i1 @swift_rt_swift_dynamicCast(%swift.opaque* %0, %swift.opaque* [[LOCAL_OPAQUE]], %swift.type* [[PROTO_TYPE]], %swift.type* %T, i64 7)
   return x as! T
 }
 

--- a/test/IRGen/generic_classes.sil
+++ b/test/IRGen/generic_classes.sil
@@ -214,7 +214,7 @@ sil @_TFC15generic_classes31RecursiveGenericInheritsGenericD : $@convention(meth
 // CHECK:   [[T1:%.*]] = bitcast i8* [[T0]] to i16*
 // CHECK:   [[ALIGN16:%.*]] = load i16, i16* [[T1]], align 4
 // CHECK:   [[ALIGN:%.*]] = zext i16 [[ALIGN16]] to i64
-// CHECK:   call noalias %swift.refcounted* @rt_swift_allocObject(%swift.type* [[METADATA]], i64 [[SIZE]], i64 [[ALIGN]])
+// CHECK:   call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* [[METADATA]], i64 [[SIZE]], i64 [[ALIGN]])
 sil @RootGeneric_fragile_dependent_alloc : $<G> () -> RootGeneric<G> {
 entry:
   %x = alloc_ref $RootGeneric<G>

--- a/test/IRGen/generic_metatypes.swift
+++ b/test/IRGen/generic_metatypes.swift
@@ -125,7 +125,7 @@ func makeGenericMetatypes() {
 // CHECK:   [[BUFFER_ELT:%.*]] = getelementptr inbounds { %swift.type* }, { %swift.type* }* [[BUFFER]], i32 0, i32 0
 // CHECK:   store %swift.type* %0, %swift.type** [[BUFFER_ELT]]
 // CHECK:   [[BUFFER_PTR:%.*]] = bitcast { %swift.type* }* [[BUFFER]] to i8*
-// CHECK:   [[METADATA:%.*]] = call %swift.type* @rt_swift_getGenericMetadata(%swift.type_pattern* {{.*}} @_TMPV17generic_metatypes6OneArg {{.*}}, i8* [[BUFFER_PTR]])
+// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_rt_swift_getGenericMetadata(%swift.type_pattern* {{.*}} @_TMPV17generic_metatypes6OneArg {{.*}}, i8* [[BUFFER_PTR]])
 // CHECK:   [[BUFFER_PTR:%.*]] = bitcast { %swift.type* }* [[BUFFER]] to i8*
 // CHECK:   call void @llvm.lifetime.end
 // CHECK:   ret %swift.type* [[METADATA]]
@@ -143,7 +143,7 @@ func makeGenericMetatypes() {
 // CHECK:   [[BUFFER_ELT:%.*]] = getelementptr inbounds { %swift.type*, %swift.type* }, { %swift.type*, %swift.type* }* [[BUFFER]], i32 0, i32 1
 // CHECK:   store %swift.type* %1, %swift.type** [[BUFFER_ELT]]
 // CHECK:   [[BUFFER_PTR:%.*]] = bitcast { %swift.type*, %swift.type* }* [[BUFFER]] to i8*
-// CHECK:   [[METADATA:%.*]] = call %swift.type* @rt_swift_getGenericMetadata(%swift.type_pattern* {{.*}} @_TMPV17generic_metatypes7TwoArgs {{.*}}, i8* [[BUFFER_PTR]])
+// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_rt_swift_getGenericMetadata(%swift.type_pattern* {{.*}} @_TMPV17generic_metatypes7TwoArgs {{.*}}, i8* [[BUFFER_PTR]])
 // CHECK:   [[BUFFER_PTR:%.*]] = bitcast { %swift.type*, %swift.type* }* [[BUFFER]] to i8*
 // CHECK:   call void @llvm.lifetime.end
 // CHECK:   ret %swift.type* [[METADATA]]
@@ -163,7 +163,7 @@ func makeGenericMetatypes() {
 // CHECK:   [[BUFFER_ELT:%.*]] = getelementptr inbounds { %swift.type*, %swift.type*, %swift.type* }, { %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]], i32 0, i32 2
 // CHECK:   store %swift.type* %2, %swift.type** [[BUFFER_ELT]]
 // CHECK:   [[BUFFER_PTR:%.*]] = bitcast { %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]] to i8*
-// CHECK:   [[METADATA:%.*]] = call %swift.type* @rt_swift_getGenericMetadata(%swift.type_pattern* {{.*}} @_TMPV17generic_metatypes9ThreeArgs {{.*}}, i8* [[BUFFER_PTR]])
+// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_rt_swift_getGenericMetadata(%swift.type_pattern* {{.*}} @_TMPV17generic_metatypes9ThreeArgs {{.*}}, i8* [[BUFFER_PTR]])
 // CHECK:   [[BUFFER_PTR:%.*]] = bitcast { %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]] to i8*
 // CHECK:   call void @llvm.lifetime.end
 // CHECK:   ret %swift.type* [[METADATA]]
@@ -185,7 +185,7 @@ func makeGenericMetatypes() {
 // CHECK:   [[BUFFER_ELT:%.*]] = getelementptr inbounds { %swift.type*, %swift.type*, %swift.type*, %swift.type* }, { %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]], i32 0, i32 3
 // CHECK:   store %swift.type* %3, %swift.type** [[BUFFER_ELT]]
 // CHECK:   [[BUFFER_PTR:%.*]] = bitcast { %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]] to i8*
-// CHECK:   [[METADATA:%.*]] = call %swift.type* @rt_swift_getGenericMetadata(%swift.type_pattern* {{.*}} @_TMPV17generic_metatypes8FourArgs {{.*}}, i8* [[BUFFER_PTR]])
+// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_rt_swift_getGenericMetadata(%swift.type_pattern* {{.*}} @_TMPV17generic_metatypes8FourArgs {{.*}}, i8* [[BUFFER_PTR]])
 // CHECK:   [[BUFFER_PTR:%.*]] = bitcast { %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]] to i8*
 // CHECK:   call void @llvm.lifetime.end
 // CHECK:   ret %swift.type* [[METADATA]]
@@ -207,7 +207,7 @@ func makeGenericMetatypes() {
 // CHECK:   [[BUFFER_ELT:%.*]] = getelementptr inbounds { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }, { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]], i32 0, i32 3
 // CHECK:   store %swift.type* %3, %swift.type** [[BUFFER_ELT]]
 // CHECK:   [[BUFFER_PTR:%.*]] = bitcast { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]] to i8*
-// CHECK:   [[METADATA:%.*]] = call %swift.type* @rt_swift_getGenericMetadata(%swift.type_pattern* {{.*}} @_TMPV17generic_metatypes8FiveArgs {{.*}}, i8* [[BUFFER_PTR]])
+// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_rt_swift_getGenericMetadata(%swift.type_pattern* {{.*}} @_TMPV17generic_metatypes8FiveArgs {{.*}}, i8* [[BUFFER_PTR]])
 // CHECK:   [[BUFFER_PTR:%.*]] = bitcast { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]] to i8*
 // CHECK:   call void @llvm.lifetime.end
 // CHECK:   ret %swift.type* [[METADATA]]

--- a/test/IRGen/generic_tuples.swift
+++ b/test/IRGen/generic_tuples.swift
@@ -50,7 +50,7 @@ func dupC<T : C>(_ x: T) -> (T, T) { return (x, x) }
 // CHECK-LABEL: define hidden { %C14generic_tuples1C*, %C14generic_tuples1C* } @_TF14generic_tuples4dupCuRxCS_1CrFxTxx_(%C14generic_tuples1C*, %swift.type* %T)
 // CHECK-NEXT: entry:
 // CHECK:      [[REF:%.*]] = bitcast %C14generic_tuples1C* %0 to %swift.refcounted*
-// CHECK-NEXT: call void @rt_swift_retain(%swift.refcounted* [[REF]])
+// CHECK-NEXT: call void @swift_rt_swift_retain(%swift.refcounted* [[REF]])
 // CHECK-NEXT: [[TUP1:%.*]] = insertvalue { %C14generic_tuples1C*, %C14generic_tuples1C* } undef, %C14generic_tuples1C* %0, 0
 // CHECK-NEXT: [[TUP2:%.*]] = insertvalue { %C14generic_tuples1C*, %C14generic_tuples1C* } [[TUP1:%.*]], %C14generic_tuples1C* %0, 1
 // CHECK-NEXT: ret { %C14generic_tuples1C*, %C14generic_tuples1C* } [[TUP2]]
@@ -59,14 +59,14 @@ func callDupC(_ c: C) { _ = dupC(c) }
 // CHECK-LABEL: define hidden void @_TF14generic_tuples8callDupCFCS_1CT_(%C14generic_tuples1C*)
 // CHECK-NEXT: entry:
 // CHECK-NEXT: [[REF:%.*]] = bitcast %C14generic_tuples1C* %0 to %swift.refcounted*
-// CHECK-NEXT: call void @rt_swift_retain(%swift.refcounted* [[REF]])
+// CHECK-NEXT: call void @swift_rt_swift_retain(%swift.refcounted* [[REF]])
 // CHECK-NEXT: [[METATYPE:%.*]] = call %swift.type* @_TMaC14generic_tuples1C()
 // CHECK-NEXT: [[TUPLE:%.*]] = call { %C14generic_tuples1C*, %C14generic_tuples1C* } @_TF14generic_tuples4dupCuRxCS_1CrFxTxx_(%C14generic_tuples1C* %0, %swift.type* [[METATYPE]])
 // CHECK-NEXT: [[LEFT:%.*]] = extractvalue { %C14generic_tuples1C*, %C14generic_tuples1C* } [[TUPLE]], 0
 // CHECK-NEXT: [[RIGHT:%.*]] = extractvalue { %C14generic_tuples1C*, %C14generic_tuples1C* } [[TUPLE]], 1
-// CHECK-NEXT: call void bitcast (void (%swift.refcounted*)* @rt_swift_release to void (%C14generic_tuples1C*)*)(%C14generic_tuples1C* [[RIGHT]])
-// CHECK-NEXT: call void bitcast (void (%swift.refcounted*)* @rt_swift_release to void (%C14generic_tuples1C*)*)(%C14generic_tuples1C* [[LEFT]])
-// CHECK-NEXT: call void bitcast (void (%swift.refcounted*)* @rt_swift_release to void (%C14generic_tuples1C*)*)(%C14generic_tuples1C* %0)
+// CHECK-NEXT: call void bitcast (void (%swift.refcounted*)* @swift_rt_swift_release to void (%C14generic_tuples1C*)*)(%C14generic_tuples1C* [[RIGHT]])
+// CHECK-NEXT: call void bitcast (void (%swift.refcounted*)* @swift_rt_swift_release to void (%C14generic_tuples1C*)*)(%C14generic_tuples1C* [[LEFT]])
+// CHECK-NEXT: call void bitcast (void (%swift.refcounted*)* @swift_rt_swift_release to void (%C14generic_tuples1C*)*)(%C14generic_tuples1C* %0)
 // CHECK-NEXT: ret void
 
 // CHECK: define hidden i64 @_TF14generic_tuples4lump{{.*}}(%swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T)

--- a/test/IRGen/generic_types.swift
+++ b/test/IRGen/generic_types.swift
@@ -88,7 +88,7 @@ import Swift
 // CHECK:   %T = load %swift.type*, %swift.type** [[T0]],
 // CHECK-native: [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericClassMetadata(%swift.type_pattern* %0, i8** %1, %objc_class* null)
 // CHECK-objc:   [[T0:%.*]] = load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_SwiftObject"
-// CHECK-objc:   [[SUPER:%.*]] = call %objc_class* @rt_swift_getInitializedObjCClass(%objc_class* [[T0]])
+// CHECK-objc:   [[SUPER:%.*]] = call %objc_class* @swift_rt_swift_getInitializedObjCClass(%objc_class* [[T0]])
 // CHECK-objc:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericClassMetadata(%swift.type_pattern* %0, i8** %1, %objc_class* [[SUPER]])
 // CHECK:   [[SELF_ARRAY:%.*]] = bitcast %swift.type* [[METADATA]] to i8**
 // CHECK:   [[T1:%.*]] = getelementptr inbounds i8*, i8** [[SELF_ARRAY]], i32 10
@@ -102,7 +102,7 @@ import Swift
 // CHECK:   %T = load %swift.type*, %swift.type** [[T0]],
 // CHECK-native: [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericClassMetadata(%swift.type_pattern* %0, i8** %1, %objc_class* null)
 // CHECK-objc:   [[T0:%.*]] = load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_SwiftObject"
-// CHECK-objc:   [[SUPER:%.*]] = call %objc_class* @rt_swift_getInitializedObjCClass(%objc_class* [[T0]])
+// CHECK-objc:   [[SUPER:%.*]] = call %objc_class* @swift_rt_swift_getInitializedObjCClass(%objc_class* [[T0]])
 // CHECK-objc:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericClassMetadata(%swift.type_pattern* %0, i8** %1, %objc_class* [[SUPER]])
 // CHECK:   [[SELF_ARRAY:%.*]] = bitcast %swift.type* [[METADATA]] to i8**
 // CHECK:   [[T1:%.*]] = getelementptr inbounds i8*, i8** [[SELF_ARRAY]], i32 10

--- a/test/IRGen/global_resilience.sil
+++ b/test/IRGen/global_resilience.sil
@@ -73,7 +73,7 @@ bb0:
 // CHECK-LABEL: define{{( protected)?}} void @testLargeGlobal()
 sil @testLargeGlobal : $@convention(thin) () -> () {
 bb0:
-  // CHECK: [[ALLOC:%.*]] = call noalias i8* @rt_swift_slowAlloc([[INT]] 32, [[INT]] 7)
+  // CHECK: [[ALLOC:%.*]] = call noalias i8* @swift_rt_swift_slowAlloc([[INT]] 32, [[INT]] 7)
   // CHECK: store i8* [[ALLOC]], i8** bitcast ([[BUFFER]]* @largeGlobal to i8**), align 1
   alloc_global @largeGlobal
 

--- a/test/IRGen/indirect_argument.sil
+++ b/test/IRGen/indirect_argument.sil
@@ -65,7 +65,7 @@ entry(%o : $*Huge, %x : $Huge):
 
 // CHECK-LABEL: define{{( protected)?}} void @huge_partial_application(%V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}), %V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}))
 // CHECK:         [[TMP_ARG:%.*]] = alloca
-// CHECK:         [[CLOSURE:%.*]] = call noalias %swift.refcounted* @rt_swift_allocObject
+// CHECK:         [[CLOSURE:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject
 // CHECK:         bitcast %swift.refcounted* [[CLOSURE]] to <{ %swift.refcounted, %V17indirect_argument4Huge }>*
 // CHECK:         call void @_TPA_huge_partial_application(%V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}) [[TMP_ARG]], %swift.refcounted* [[CLOSURE]])
 // CHECK:       define internal void @_TPA_huge_partial_application(%V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}), %swift.refcounted*)
@@ -83,7 +83,7 @@ entry(%x : $Huge, %y : $Huge):
 // CHECK-LABEL: define{{( protected)?}} void @huge_partial_application_stret(%V17indirect_argument4Huge* noalias nocapture sret, %V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}), %V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}))
 // CHECK:         [[TMP_ARG:%.*]] = alloca
 // CHECK:         [[TMP_RET:%.*]] = alloca
-// CHECK:         [[CLOSURE:%.*]] = call noalias %swift.refcounted* @rt_swift_allocObject
+// CHECK:         [[CLOSURE:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject
 // CHECK:         bitcast %swift.refcounted* [[CLOSURE]] to <{ %swift.refcounted, %V17indirect_argument4Huge }>*
 // CHECK:         call void @_TPA_huge_partial_application_stret(%V17indirect_argument4Huge* noalias nocapture sret [[TMP_RET]], %V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}) [[TMP_ARG]], %swift.refcounted* [[CLOSURE]])
 // CHECK:       define internal void @_TPA_huge_partial_application_stret(%V17indirect_argument4Huge* noalias nocapture sret, %V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}), %swift.refcounted*)

--- a/test/IRGen/metadata_dominance.swift
+++ b/test/IRGen/metadata_dominance.swift
@@ -80,5 +80,5 @@ func testMakeFoo(_ p: P) -> Foo.Type {
 // conformance metadata_dominance.Foo : metadata_dominance.P should not use the Self type
 // as the type of the object to be created. It should dynamically obtain the type.
 // CHECK-OPT-LABEL: define hidden %C18metadata_dominance3Foo* @_TTWC18metadata_dominance3FooS_1PS_FS1_7makeFoofT_S0_
-// CHECK-OPT-NOT: tail call noalias %swift.refcounted* @rt_swift_allocObject(%swift.type* %Self
+// CHECK-OPT-NOT: tail call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* %Self
 

--- a/test/IRGen/nonatomic_reference_counting.sil
+++ b/test/IRGen/nonatomic_reference_counting.sil
@@ -33,8 +33,8 @@ bb0(%0 : $C):
 sil @doSomething : $@convention(thin) () -> ()
 
 // CHECK-LABEL: define {{.*}}@test_strong_nonatomic_rr
-// CHECK: call {{.*}}@rt_swift_nonatomic_retain
-// CHECK: call {{.*}}@rt_swift_nonatomic_release
+// CHECK: call {{.*}}@swift_rt_swift_nonatomic_retain
+// CHECK: call {{.*}}@swift_rt_swift_nonatomic_release
 // CHECK: ret
 sil @test_strong_nonatomic_rr: $@convention(thin) () -> @owned C {
 bb0:
@@ -47,8 +47,8 @@ bb0:
 }
 
 // CHECK-LABEL: define {{.*}}@test_unknown_nonatomic_rr
-// CHECK: call {{.*}}@{{(swift_nonatomic_unknownRetain|rt_swift_nonatomic_retain)}}
-// CHECK: call {{.*}}@{{(swift_nonatomic_unknownRelease|rt_swift_nonatomic_release)}}
+// CHECK: call {{.*}}@{{(swift_nonatomic_unknownRetain|swift_rt_swift_nonatomic_retain)}}
+// CHECK: call {{.*}}@{{(swift_nonatomic_unknownRelease|swift_rt_swift_nonatomic_release)}}
 // CHECK: ret
 sil @test_unknown_nonatomic_rr: $@convention(thin) <T where T : P> (@owned T) -> () {
 bb0(%0 : $T):
@@ -61,8 +61,8 @@ bb0(%0 : $T):
 }
 
 // CHECK-LABEL: define {{.*}}@test_strong_nonatomic_rr_n
-// CHECK: call {{.*}}@rt_swift_nonatomic_retain_n
-// CHECK: call {{.*}}@rt_swift_nonatomic_release_n
+// CHECK: call {{.*}}@swift_rt_swift_nonatomic_retain_n
+// CHECK: call {{.*}}@swift_rt_swift_nonatomic_release_n
 // CHECK: ret
 sil @test_strong_nonatomic_rr_n: $@convention(thin) () -> @owned C {
 bb0:
@@ -77,8 +77,8 @@ bb0:
 }
 
 // CHECK-LABEL: define {{.*}}@test_strong_mixed_rr_n
-// CHECK: call {{.*}}@rt_swift_retain_n
-// CHECK: call {{.*}}@rt_swift_release_n
+// CHECK: call {{.*}}@swift_rt_swift_retain_n
+// CHECK: call {{.*}}@swift_rt_swift_release_n
 // CHECK: ret
 sil @test_strong_mixed_rr_n: $@convention(thin) () -> @owned C {
 bb0:
@@ -93,8 +93,8 @@ bb0:
 }
 
 // CHECK-LABEL: define {{.*}}@test_unknown_nonatomic_rr_n
-// CHECK: call {{.*}}@{{(swift_nonatomic_unknownRetain_n|rt_swift_nonatomic_retain_n)}}
-// CHECK: call {{.*}}@{{(swift_nonatomic_unknownRelease_n|rt_swift_nonatomic_release_n)}}
+// CHECK: call {{.*}}@{{(swift_nonatomic_unknownRetain_n|swift_rt_swift_nonatomic_retain_n)}}
+// CHECK: call {{.*}}@{{(swift_nonatomic_unknownRelease_n|swift_rt_swift_nonatomic_release_n)}}
 // CHECK: ret
 sil @test_unknown_nonatomic_rr_n: $@convention(thin) <T where T : P> (@owned T) -> () {
 bb0(%0 : $T):
@@ -109,8 +109,8 @@ bb0(%0 : $T):
 }
 
 // CHECK-LABEL: define {{.*}}@test_unknown_mixed_rr_n
-// CHECK: call {{.*}}@{{(swift_unknownRetain_n|rt_swift_retain_n)}}
-// CHECK: call {{.*}}@{{(swift_unknownRelease_n|rt_swift_release_n)}}
+// CHECK: call {{.*}}@{{(swift_unknownRetain_n|swift_rt_swift_retain_n)}}
+// CHECK: call {{.*}}@{{(swift_unknownRelease_n|swift_rt_swift_release_n)}}
 // CHECK: ret
 sil @test_unknown_mixed_rr_n: $@convention(thin) <T where T : P> (@owned T) -> () {
 bb0(%0 : $T):
@@ -196,8 +196,8 @@ bb0:
 }
 
 // CHECK-LABEL: define {{.*}}@test_nonatomic_pin_unpin
-// CHECK: call {{.*}}@rt_swift_nonatomic_tryPin
-// CHECK: call {{.*}}@rt_swift_nonatomic_unpin
+// CHECK: call {{.*}}@swift_rt_swift_nonatomic_tryPin
+// CHECK: call {{.*}}@swift_rt_swift_nonatomic_unpin
 // CHECK: ret
 sil @test_nonatomic_pin_unpin: $@convention(thin) () -> () {
 bb0:

--- a/test/IRGen/objc.swift
+++ b/test/IRGen/objc.swift
@@ -39,7 +39,7 @@ struct id {
 class MyBlammo : Blammo {
   func foo() {}
 // CHECK:  define hidden void @_TFC4objc8MyBlammo3foofT_T_([[MYBLAMMO]]*) {{.*}} {
-// CHECK:    call {{.*}} @rt_swift_release
+// CHECK:    call {{.*}} @swift_rt_swift_release
 // CHECK:    ret void
 }
 
@@ -83,7 +83,7 @@ func test0(_ arg: id) -> id {
 
 func test1(_ cell: Blammo) {}
 // CHECK:  define hidden void @_TF4objc5test1{{.*}}([[BLAMMO]]*) {{.*}} {
-// CHECK:    call {{.*}} @rt_swift_release
+// CHECK:    call {{.*}} @swift_rt_swift_release
 // CHECK:    ret void
 
 

--- a/test/IRGen/objc_block_storage.sil
+++ b/test/IRGen/objc_block_storage.sil
@@ -127,7 +127,7 @@ entry(%0 : $*@block_storage Builtin.NativeObject):
 // CHECK-NEXT:    %2 = getelementptr inbounds { %objc_block, %swift.refcounted* }, { %objc_block, %swift.refcounted* }* %0, i32 0, i32 1
 // CHECK-NEXT:    %3 = getelementptr inbounds { %objc_block, %swift.refcounted* }, { %objc_block, %swift.refcounted* }* %1, i32 0, i32 1
 // CHECK-NEXT:    %4 = load %swift.refcounted*, %swift.refcounted** %3, align 8
-// CHECK-NEXT:    call void @rt_swift_retain(%swift.refcounted* %4) {{#[0-9]+}}
+// CHECK-NEXT:    call void @swift_rt_swift_retain(%swift.refcounted* %4) {{#[0-9]+}}
 // CHECK-NEXT:    store %swift.refcounted* %4, %swift.refcounted** %2, align 8
 // CHECK-NEXT:    ret void
 
@@ -135,7 +135,7 @@ entry(%0 : $*@block_storage Builtin.NativeObject):
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    %1 = getelementptr inbounds { %objc_block, %swift.refcounted* }, { %objc_block, %swift.refcounted* }* %0, i32 0, i32 1
 // CHECK-NEXT:    %toDestroy = load %swift.refcounted*, %swift.refcounted** %1, align 8
-// CHECK-NEXT:    call void @rt_swift_release(%swift.refcounted* %toDestroy) {{#[0-9]+}}
+// CHECK-NEXT:    call void @swift_rt_swift_release(%swift.refcounted* %toDestroy) {{#[0-9]+}}
 // CHECK-NEXT:    ret void
 
 sil public_external @invoke_nontrivial : $@convention(c) (@inout_aliasable @block_storage Builtin.NativeObject) -> ()

--- a/test/IRGen/objc_casts.sil
+++ b/test/IRGen/objc_casts.sil
@@ -29,7 +29,7 @@ bb0(%unused : $@thick T.Type, %obj : $NSObject):
 //   TODO: is this really necessary? also, this really shouldn't use a direct reference
 // CHECK-NEXT:  [[T1:%.*]] = bitcast %objc_object* [[T0]] to i8*
 // CHECK-NEXT:  [[T2a:%.*]] = load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_Foo"
-// CHECK-NEXT:  [[T2:%.*]] = call %objc_class* @rt_swift_getInitializedObjCClass(%objc_class* [[T2a]])
+// CHECK-NEXT:  [[T2:%.*]] = call %objc_class* @swift_rt_swift_getInitializedObjCClass(%objc_class* [[T2a]])
 // CHECK-NEXT:  [[T3:%.*]] = bitcast %objc_class* [[T2]] to i8*
 // CHECK-NEXT:  call i8* @swift_dynamicCastObjCClassUnconditional(i8* [[T1]], i8* [[T3]])
 sil hidden @metatype_to_objc_class : $@convention(thin) <T> (@thick T.Type) -> () {
@@ -45,7 +45,7 @@ bb0(%metatype : $@thick T.Type):
 //   TODO: is this really necessary? also, this really shouldn't use a direct reference
 // CHECK-NEXT:  [[T1:%.*]] = bitcast %objc_object* [[T0]] to i8*
 // CHECK-NEXT:  [[T2a:%.*]] = load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_Foo"
-// CHECK-NEXT:  [[T2:%.*]] = call %objc_class* @rt_swift_getInitializedObjCClass(%objc_class* [[T2a]])
+// CHECK-NEXT:  [[T2:%.*]] = call %objc_class* @swift_rt_swift_getInitializedObjCClass(%objc_class* [[T2a]])
 // CHECK-NEXT:  [[T3:%.*]] = bitcast %objc_class* [[T2]] to i8*
 // CHECK-NEXT:  call i8* @swift_dynamicCastObjCClassUnconditional(i8* [[T1]], i8* [[T3]])
 sil hidden @opt_metatype_to_objc_class : $@convention(thin) <T> (Optional<@thick T.Type>) -> () {

--- a/test/IRGen/objc_dealloc.sil
+++ b/test/IRGen/objc_dealloc.sil
@@ -86,7 +86,7 @@ bb0(%0 : $SwiftGizmo):
   // CHECK-NEXT: [[IVAR_ADDR:%[a-zA-Z0-9]+]] = getelementptr inbounds i8, i8* {{.*}}, i64 [[XOFFSET]]
   // CHECK-NEXT: [[XADDR:%[.a-zA-Z0-9]+]] = bitcast i8* [[IVAR_ADDR]] to %C12objc_dealloc1X**
   // CHECK-NEXT: [[X:%[a-zA-Z0-9]+]] = load %C12objc_dealloc1X*, %C12objc_dealloc1X** [[XADDR]], align 8
-  // CHECK-NEXT: call void bitcast (void (%swift.refcounted*)* @rt_swift_release to void (%C12objc_dealloc1X*)*)(%C12objc_dealloc1X* [[X]])
+  // CHECK-NEXT: call void bitcast (void (%swift.refcounted*)* @swift_rt_swift_release to void (%C12objc_dealloc1X*)*)(%C12objc_dealloc1X* [[X]])
   %3 = ref_element_addr %0 : $SwiftGizmo, #SwiftGizmo.x      // user: %4
   destroy_addr %3 : $*X                           // id: %4
 

--- a/test/IRGen/objc_generic_class_metadata.sil
+++ b/test/IRGen/objc_generic_class_metadata.sil
@@ -39,7 +39,7 @@ entry:
   apply %z<GenericClass<NSObject>>(%b) : $@convention(thin) <T> (@thick T.Type) -> ()
 
   // CHECK: [[T0:%.*]] = load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_GenericClass",
-  // CHECK: [[OBJC_CLASS:%.*]] = call %objc_class* @rt_swift_getInitializedObjCClass(%objc_class* [[T0]])
+  // CHECK: [[OBJC_CLASS:%.*]] = call %objc_class* @swift_rt_swift_getInitializedObjCClass(%objc_class* [[T0]])
   // CHECK: call void @objc_class_sink(%objc_class* [[OBJC_CLASS]], %swift.type* [[METADATA]])
   %c = metatype $@objc_metatype GenericClass<NSString>.Type
   apply %y<GenericClass<NSString>>(%c) : $@convention(thin) <T: AnyObject> (@objc_metatype T.Type) -> ()
@@ -78,7 +78,7 @@ entry(%0: $Subclass, %1: $NSDictionary):
 
 // CHECK-LABEL: define linkonce_odr hidden %swift.type* @_TMaCSo12GenericClass()
 // CHECK:         [[T0:%.*]] = load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_GenericClass",
-// CHECK:         call %objc_class* @rt_swift_getInitializedObjCClass(%objc_class* [[T0]])
+// CHECK:         call %objc_class* @swift_rt_swift_getInitializedObjCClass(%objc_class* [[T0]])
 
 // CHECK-LABEL: define linkonce_odr hidden %swift.type* @_TMaGSaTCSo12GenericClassSi__()
 // CHECK:         [[TUPLE:%.*]] = call %swift.type* @_TMaTCSo12GenericClassSi_()

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -50,7 +50,7 @@ bb0(%0 : $ObjCClass):
 
 // CHECK-LABEL: define{{( protected)?}} { i8*, %swift.refcounted* } @indirect_partial_apply(i8*, %swift.refcounted*, i64) {{.*}} {
 // CHECK: entry:
-// CHECK:   [[OBJ:%.*]] = call noalias %swift.refcounted* @rt_swift_allocObject(%swift.type* getelementptr inbounds (%swift.full_boxmetadata, %swift.full_boxmetadata* @metadata, i32 0, i32 2), i64 40, i64 7)
+// CHECK:   [[OBJ:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* getelementptr inbounds (%swift.full_boxmetadata, %swift.full_boxmetadata* @metadata, i32 0, i32 2), i64 40, i64 7)
 // CHECK:   [[DATA_ADDR:%.*]] = bitcast %swift.refcounted* [[OBJ]] to [[DATA_TYPE:<{ %swift.refcounted, i64, %swift.refcounted\*, i8\* }>]]*
 // CHECK:   [[X_ADDR:%.*]] = getelementptr inbounds [[DATA_TYPE]], [[DATA_TYPE]]* [[DATA_ADDR]], i32 0, i32 1
 // CHECK:   store i64 %2, i64* [[X_ADDR]], align 8
@@ -83,7 +83,7 @@ entry(%f : $@callee_owned (Builtin.Word) -> (), %x : $Builtin.Word):
 
 // CHECK-LABEL: define{{( protected)?}} { i8*, %swift.refcounted* } @objc_partial_apply(%C13partial_apply9ObjCClass*) {{.*}} {
 // CHECK: entry:
-// CHECK:   [[OBJ:%.*]] = call noalias %swift.refcounted* @rt_swift_allocObject(%swift.type* getelementptr inbounds (%swift.full_boxmetadata, %swift.full_boxmetadata* @metadata.2, i32 0, i32 2), i64 24, i64 7)
+// CHECK:   [[OBJ:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* getelementptr inbounds (%swift.full_boxmetadata, %swift.full_boxmetadata* @metadata.2, i32 0, i32 2), i64 24, i64 7)
 // CHECK:   [[DATA_ADDR:%.*]] = bitcast %swift.refcounted* [[OBJ]] to [[DATA_TYPE:<{ %swift.refcounted, %C13partial_apply9ObjCClass\* }>]]*
 // CHECK:   [[X_ADDR:%.*]] = getelementptr inbounds [[DATA_TYPE]], [[DATA_TYPE]]* [[DATA_ADDR]], i32 0, i32 1
 // CHECK:   store %C13partial_apply9ObjCClass* %0, %C13partial_apply9ObjCClass** [[X_ADDR]], align 8
@@ -114,7 +114,7 @@ entry(%c : $ObjCClass):
 }
 
 // CHECK-LABEL: define{{.*}} { i8*, %swift.refcounted* } @objc_partial_apply_indirect_sil_argument(%C13partial_apply9ObjCClass*) {{.*}}
-// CHECK:  [[CTX:%.*]] = call noalias %swift.refcounted* @rt_swift_allocObject
+// CHECK:  [[CTX:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject
 // CHECK:  [[CTX_ADDR:%.*]] = bitcast %swift.refcounted* [[CTX]] to [[CTXTYPE:<{ %swift.refcounted, %C13partial_apply9ObjCClass\* }>]]*
 // CHECK:  [[SELF_ADDR:%.*]] = getelementptr inbounds [[CTXTYPE]], [[CTXTYPE]]* [[CTX_ADDR]], i32 0, i32 1
 // CHECK:  store %C13partial_apply9ObjCClass* %0, %C13partial_apply9ObjCClass** [[SELF_ADDR]]
@@ -146,7 +146,7 @@ entry(%c : $ObjCClass):
 // CHECK:   [[I8PTRSELF:%.*]] = bitcast %C13partial_apply9ObjCClass* [[SELF]] to [[OPAQUE4:%.*]]*
 // CHECK:   call [[OPAQUE3:%.*]]* bitcast (void ()* @objc_msgSend to [[OPAQUE3]]* ([[OPAQUE4:%.*]]*, i8*)*)([[OPAQUE4]]* [[I8PTRSELF]], i8* [[CMD]])
 // CHECK-NOT: release
-// CHECK:   call void @rt_swift_release(%swift.refcounted* %0)
+// CHECK:   call void @swift_rt_swift_release(%swift.refcounted* %0)
 // CHECK-NOT: release
 // CHECK:   ret void
 // CHECK: }
@@ -208,7 +208,7 @@ entry(%c : $SwiftClass):
 sil @partially_applyable_to_pure_objc : $@convention(thin) Gizmo -> ()
 
 // CHECK: define{{( protected)?}} { i8*, %swift.refcounted* } @partial_apply_pure_objc
-// CHECK:   @rt_swift_allocObject
+// CHECK:   @swift_rt_swift_allocObject
 sil @partial_apply_pure_objc : $@convention(thin) Gizmo -> @callee_owned () -> () {
 entry(%c : $Gizmo):
   %f = function_ref @partially_applyable_to_pure_objc : $@convention(thin) Gizmo -> ()
@@ -296,7 +296,7 @@ sil public_external @indirect_guaranteed_captured_class_param : $@convention(thi
 // CHECK-NOT:     release
 // CHECK:         [[RESULT:%.*]] = call i64 @indirect_guaranteed_captured_class_param(i64 %0, %C13partial_apply10SwiftClass** noalias nocapture dereferenceable({{.*}}) [[X_CAST]]
 // CHECK-NOT:     retain
-// CHECK:         call void @rt_swift_release(%swift.refcounted* %1)
+// CHECK:         call void @swift_rt_swift_release(%swift.refcounted* %1)
 // CHECK:         ret i64 [[RESULT]]
 
 sil @partial_apply_indirect_guaranteed_class_param : $@convention(thin) (@in SwiftClass) -> @callee_owned (Int) -> Int {
@@ -345,7 +345,7 @@ struct SwiftClassPair { var x: SwiftClass, y: SwiftClass }
 sil public_external @guaranteed_captured_class_pair_param : $@convention(thin) (Int, @guaranteed SwiftClassPair) -> Int
 
 // CHECK-LABEL: define{{( protected)?}} { i8*, %swift.refcounted* } @partial_apply_guaranteed_class_pair_param(%C13partial_apply10SwiftClass*, %C13partial_apply10SwiftClass*)
-// CHECK:         [[CONTEXT_OBJ:%.*]] = call noalias %swift.refcounted* @rt_swift_allocObject
+// CHECK:         [[CONTEXT_OBJ:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject
 // CHECK:         [[PAIR_ADDR:%.*]] = getelementptr
 // CHECK-NEXT:    [[X_ADDR:%.*]] = getelementptr inbounds %V13partial_apply14SwiftClassPair, %V13partial_apply14SwiftClassPair* [[PAIR_ADDR]], i32 0, i32 0
 // CHECK-NEXT:    store %C13partial_apply10SwiftClass* %0, %C13partial_apply10SwiftClass** [[X_ADDR]], align
@@ -376,7 +376,7 @@ bb0(%x : $SwiftClassPair):
 sil public_external @indirect_guaranteed_captured_class_pair_param : $@convention(thin) (Int, @in_guaranteed SwiftClassPair) -> Int
 
 // CHECK-LABEL: define{{( protected)?}} { i8*, %swift.refcounted* } @partial_apply_indirect_guaranteed_class_pair_param(%V13partial_apply14SwiftClassPair* noalias nocapture dereferenceable({{.*}}))
-// CHECK:         [[CONTEXT_OBJ:%.*]] = call noalias %swift.refcounted* @rt_swift_allocObject
+// CHECK:         [[CONTEXT_OBJ:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject
 // CHECK-NOT:     {{retain|release}}
 // CHECK:         [[T0:%.*]] = insertvalue {{.*}} [[PARTIAL_APPLY_FORWARDER:@_TPA_[A-Za-z0-9_]+]] {{.*}} [[CONTEXT_OBJ]]
 // CHECK:         ret {{.*}} [[T0]]
@@ -399,7 +399,7 @@ bb0(%x : $*SwiftClassPair):
 sil public_external @indirect_consumed_captured_class_pair_param : $@convention(thin) (Int, @in SwiftClassPair) -> Int
 
 // CHECK-LABEL: define{{( protected)?}} { i8*, %swift.refcounted* } @partial_apply_indirect_consumed_class_pair_param(%V13partial_apply14SwiftClassPair* noalias nocapture dereferenceable({{.*}}))
-// CHECK:         [[CONTEXT_OBJ:%.*]] = call noalias %swift.refcounted* @rt_swift_allocObject
+// CHECK:         [[CONTEXT_OBJ:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject
 // CHECK-NOT:     {{retain|release}}
 // CHECK:         [[T0:%.*]] = insertvalue {{.*}} [[PARTIAL_APPLY_FORWARDER:@_TPA_[A-Za-z0-9_]+]] {{.*}} [[CONTEXT_OBJ]]
 // CHECK:         ret {{.*}} [[T0]]
@@ -461,7 +461,7 @@ sil public_external @captured_fixed_and_dependent_params : $@convention(thin) <A
 // CHECK-32:      [[TOTAL_ALIGN:%.*]] = or [[WORD]] [[TOTAL_ALIGN_1]], 3
 
 // -- Allocate using the total size and alignment.
-// CHECK:         [[BOX:%.*]] = call noalias %swift.refcounted* @rt_swift_allocObject(%swift.type* {{.*}}, [[WORD]] [[TOTAL_SIZE]], [[WORD]] [[TOTAL_ALIGN]])
+// CHECK:         [[BOX:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* {{.*}}, [[WORD]] [[TOTAL_SIZE]], [[WORD]] [[TOTAL_ALIGN]])
 // CHECK:         [[BOX_DATA:%.*]] = bitcast %swift.refcounted* [[BOX]]
 // -- metadata
 // CHECK:         getelementptr inbounds {{.*}} [[BOX_DATA]], i32 0, i32 1
@@ -580,7 +580,7 @@ bb0(%0 : $Int):
   return %result : $()
 }
 // CHECK-LABEL: define void @partial_apply_complex_generic_function(i64, %swift.type* %T, i8** %T.P2, i8** %T.Y.P2)
-// CHECK:      [[T0:%.*]] = call noalias %swift.refcounted* @rt_swift_allocObject(%swift.type* {{.*}}, i64 48, i64 7)
+// CHECK:      [[T0:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* {{.*}}, i64 48, i64 7)
 // CHECK-NEXT: [[T1:%.*]] = bitcast %swift.refcounted* [[T0]] to <{ %swift.refcounted, [24 x i8], %Si }>*
 // CHECK-NEXT: [[T2:%.*]] = getelementptr inbounds <{ %swift.refcounted, [24 x i8], %Si }>, <{ %swift.refcounted, [24 x i8], %Si }>* [[T1]], i32 0, i32 1
 // CHECK-NEXT: [[BUFFER:%.*]] = bitcast [24 x i8]* [[T2]] to %swift.type**

--- a/test/IRGen/protocol_metadata.swift
+++ b/test/IRGen/protocol_metadata.swift
@@ -82,12 +82,12 @@ func protocol_types(_ a: A,
                     abc: A & B & C,
                     abco: A & B & C & O) {
   // CHECK: store %swift.protocol* @_TMp17protocol_metadata1A
-  // CHECK: call %swift.type* @rt_swift_getExistentialTypeMetadata(i64 1, %swift.protocol** {{%.*}})
+  // CHECK: call %swift.type* @swift_rt_swift_getExistentialTypeMetadata(i64 1, %swift.protocol** {{%.*}})
   reify_metadata(a)
   // CHECK: store %swift.protocol* @_TMp17protocol_metadata1A
   // CHECK: store %swift.protocol* @_TMp17protocol_metadata1B
   // CHECK: store %swift.protocol* @_TMp17protocol_metadata1C
-  // CHECK: call %swift.type* @rt_swift_getExistentialTypeMetadata(i64 3, %swift.protocol** {{%.*}})
+  // CHECK: call %swift.type* @swift_rt_swift_getExistentialTypeMetadata(i64 3, %swift.protocol** {{%.*}})
   reify_metadata(abc)
   // CHECK: store %swift.protocol* @_TMp17protocol_metadata1A
   // CHECK: store %swift.protocol* @_TMp17protocol_metadata1B
@@ -95,7 +95,7 @@ func protocol_types(_ a: A,
   // CHECK: [[O_REF:%.*]] = load i8*, i8** @"\01l_OBJC_PROTOCOL_REFERENCE_$__TtP17protocol_metadata1O_"
   // CHECK: [[O_REF_BITCAST:%.*]] = bitcast i8* [[O_REF]] to %swift.protocol*
   // CHECK: store %swift.protocol* [[O_REF_BITCAST]]
-  // CHECK: call %swift.type* @rt_swift_getExistentialTypeMetadata(i64 4, %swift.protocol** {{%.*}})
+  // CHECK: call %swift.type* @swift_rt_swift_getExistentialTypeMetadata(i64 4, %swift.protocol** {{%.*}})
   reify_metadata(abco)
 }
 

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -92,7 +92,7 @@ bb0(%0 : $*Self):
   // implementation
 
   // CHECK-NEXT: [[WTABLE:%.*]] = bitcast i8** %SelfWitnessTable to i8*
-  // CHECK-NEXT: [[CONTEXT:%.*]] = call noalias %swift.refcounted* @rt_swift_allocObject({{.*}})
+  // CHECK-NEXT: [[CONTEXT:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject({{.*}})
   // CHECK-NEXT: [[LAYOUT:%.*]] = bitcast %swift.refcounted* [[CONTEXT]] to <{ %swift.refcounted, [{{4|8}} x i8], i8* }>*
   // CHECK:      [[WTABLE_ADDR:%.*]] = getelementptr inbounds <{ %swift.refcounted, [{{4|8}} x i8], i8* }>, <{ %swift.refcounted, [{{4|8}} x i8], i8* }>* [[LAYOUT]], i32 0, i32 2
   // CHECK-NEXT: store i8* [[WTABLE]], i8** [[WTABLE_ADDR]]
@@ -132,7 +132,7 @@ bb0(%0 : $@thick Self.Type):
   // implementation
 
   // CHECK-NEXT: [[WTABLE:%.*]] = bitcast i8** %SelfWitnessTable to i8*
-  // CHECK-NEXT: [[CONTEXT:%.*]] = call noalias %swift.refcounted* @rt_swift_allocObject({{.*}})
+  // CHECK-NEXT: [[CONTEXT:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject({{.*}})
   // CHECK-NEXT: [[LAYOUT:%.*]] = bitcast %swift.refcounted* [[CONTEXT]] to <{ %swift.refcounted, [{{4|8}} x i8], i8* }>*
   // CHECK:      [[WTABLE_ADDR:%.*]] = getelementptr inbounds <{ %swift.refcounted, [{{4|8}} x i8], i8* }>, <{ %swift.refcounted, [{{4|8}} x i8], i8* }>* [[LAYOUT]], i32 0, i32 2
   // CHECK-NEXT: store i8* [[WTABLE]], i8** [[WTABLE_ADDR]]
@@ -212,7 +212,7 @@ bb0(%0 : $*ConformingStruct):
 
   // Make sure we can partially apply direct references to default implementations
 
-  // CHECK-NEXT: [[CONTEXT:%.*]] = call noalias %swift.refcounted* @rt_swift_allocObject({{.*}})
+  // CHECK-NEXT: [[CONTEXT:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject({{.*}})
   // CHECK-NEXT: [[LAYOUT:%.*]] = bitcast %swift.refcounted* [[CONTEXT]] to <{ %swift.refcounted, i8* }>*
   // CHECK-NEXT: [[WTABLE:%.*]] = getelementptr inbounds <{ %swift.refcounted, i8* }>, <{ %swift.refcounted, i8* }>* [[LAYOUT]], i32 0, i32 1
   // CHECK-NEXT: store i8* bitcast ([8 x i8*]* @_TWPV19protocol_resilience16ConformingStructS_17ResilientProtocolS_ to i8*), i8** [[WTABLE]]
@@ -287,7 +287,7 @@ bb0(%0 : $*ResilientConformingType):
 
 // CHECK-LABEL: define{{( protected)?}} i8** @_TWaV19protocol_resilience23ResilientConformingType18resilient_protocol22OtherResilientProtocolS_()
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[WTABLE:%.*]] = call i8** @rt_swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @_TWGV19protocol_resilience23ResilientConformingType18resilient_protocol22OtherResilientProtocolS_, %swift.type* null, i8** null)
+// CHECK-NEXT:    [[WTABLE:%.*]] = call i8** @swift_rt_swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @_TWGV19protocol_resilience23ResilientConformingType18resilient_protocol22OtherResilientProtocolS_, %swift.type* null, i8** null)
 // CHECK-NEXT:    ret i8** [[WTABLE]]
 
 

--- a/test/IRGen/runtime_calling_conventions.swift
+++ b/test/IRGen/runtime_calling_conventions.swift
@@ -11,11 +11,11 @@ public class C {
 
 // CHECK-LABEL: define {{(protected )?}}void @_TF27runtime_calling_conventions3fooFCS_1CT_(%C27runtime_calling_conventions1C*)
 // Check that runtime functions use a proper calling convention.
-// CHECK: call void {{.*}} @rt_swift_release
+// CHECK: call void {{.*}} @swift_rt_swift_release
 
 // OPT-CHECK-LABEL: define {{(protected )?}}void @_TF27runtime_calling_conventions3fooFCS_1CT_(%C27runtime_calling_conventions1C*)
 // Check that runtime functions use a proper calling convention.
-// OPT-CHECK: tail call void @rt_swift_release
+// OPT-CHECK: tail call void @swift_rt_swift_release
 
 public func foo(_ c: C) {
 }
@@ -23,13 +23,13 @@ public func foo(_ c: C) {
 // Check that wrappers were generated, have a proper calling convention, linkage
 // and linkonce_odr flags.
 
-// CHECK: define linkonce_odr hidden void @rt_swift_release(%swift.refcounted*) #[[ATTR_REF:[0-9]+]]
+// CHECK: define linkonce_odr hidden void @swift_rt_swift_release(%swift.refcounted*) #[[ATTR_REF:[0-9]+]]
 // CHECK: load void (%swift.refcounted*)*, void (%swift.refcounted*)** @_swift_release
 // CHECK-NEXT: tail call void %load(%swift.refcounted* %0)
 // CHECK-NEXT: ret void
 // CHECK: attributes #[[ATTR_REF]] = { noinline nounwind }
 
-// OPT-CHECK: define linkonce_odr hidden void @rt_swift_release(%swift.refcounted*) local_unnamed_addr #[[ATTR_REF:[0-9]+]]
+// OPT-CHECK: define linkonce_odr hidden void @swift_rt_swift_release(%swift.refcounted*) local_unnamed_addr #[[ATTR_REF:[0-9]+]]
 // OPT-CHECK: load void (%swift.refcounted*)*, void (%swift.refcounted*)** @_swift_release
 // OPT-CHECK-NEXT: tail call void %load(%swift.refcounted* %0)
 // OPT-CHECK-NEXT: ret void

--- a/test/IRGen/sil_witness_methods.sil
+++ b/test/IRGen/sil_witness_methods.sil
@@ -137,7 +137,7 @@ entry:
 }
 
 // CHECK-LABEL: define{{( protected)?}} { i8*, %swift.refcounted* } @partial_apply_concrete_witness() {{.*}} {
-// CHECK:         [[CONTEXT:%.*]] = call noalias %swift.refcounted* @rt_swift_allocObject({{.*}})
+// CHECK:         [[CONTEXT:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject({{.*}})
 // CHECK:         [[LAYOUT:%.*]] = bitcast %swift.refcounted* [[CONTEXT]] to <{ %swift.refcounted, i8* }>*
 // CHECK:         [[WTABLE:%.*]] = getelementptr inbounds <{ %swift.refcounted, i8* }>, <{ %swift.refcounted, i8* }>* [[LAYOUT]], i32 0, i32 1
 // CHECK:         store i8* null, i8** [[WTABLE]]

--- a/test/IRGen/tail_alloc.sil
+++ b/test/IRGen/tail_alloc.sil
@@ -35,7 +35,7 @@ bb0:
 
 // CHECK-LABEL: define{{( protected)?}} {{.*}}* @alloc_on_heap
 // CHECK:      [[M:%[0-9]+]] = call %swift.type* @_TMa[[C:[a-zA-Z0-9_]+]]()
-// CHECK-NEXT: [[O:%[0-9]+]] = call noalias %swift.refcounted* @rt_swift_allocObject(%swift.type* [[M]], i64 28, i64 7) #5
+// CHECK-NEXT: [[O:%[0-9]+]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* [[M]], i64 28, i64 7) #5
 // CHECK-NEXT: [[O2:%[0-9]+]] = bitcast %swift.refcounted* [[O]] to %[[C]]*
 // CHECK-NEXT:  ret %[[C]]* [[O2]]
 sil @alloc_on_heap : $@convention(thin) () -> @owned TestClass {
@@ -47,7 +47,7 @@ bb0:
 
 // CHECK-LABEL: define{{( protected)?}} {{.*}}* @alloc_3_on_heap
 // CHECK:      [[M:%[0-9]+]] = call %swift.type* @_TMa[[C:[a-zA-Z0-9_]+]]()
-// CHECK-NEXT: [[O:%[0-9]+]] = call noalias %swift.refcounted* @rt_swift_allocObject(%swift.type* [[M]], i64 40, i64 7) #5
+// CHECK-NEXT: [[O:%[0-9]+]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* [[M]], i64 40, i64 7) #5
 // CHECK-NEXT: [[O2:%[0-9]+]] = bitcast %swift.refcounted* [[O]] to %[[C]]*
 // CHECK-NEXT:  ret %[[C]]* [[O2]]
 sil @alloc_3_on_heap : $@convention(thin) () -> @owned TestClass {
@@ -63,7 +63,7 @@ bb0:
 // CHECK:      [[M:%[0-9]+]] = call %swift.type* @_TMa[[C:[a-zA-Z0-9_]+]]()
 // CHECK-NEXT: [[S:%[0-9]+]] = mul i64 4, %0
 // CHECK-NEXT: [[A:%[0-9]+]] = add i64 20, [[S]]
-// CHECK-NEXT: [[O:%[0-9]+]] = call noalias %swift.refcounted* @rt_swift_allocObject(%swift.type* [[M]], i64 [[A]], i64 7) #5
+// CHECK-NEXT: [[O:%[0-9]+]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* [[M]], i64 [[A]], i64 7) #5
 // CHECK-NEXT: [[O2:%[0-9]+]] = bitcast %swift.refcounted* [[O]] to %[[C]]*
 // CHECK-NEXT:  ret %[[C]]* [[O2]]
 sil @alloc_non_const_count : $@convention(thin) (Builtin.Word) -> @owned TestClass {
@@ -80,7 +80,7 @@ bb0(%c : $Builtin.Word):
 // CHECK-NEXT: [[S4:%[0-9]+]] = and i64 [[S3]], -4
 // CHECK-NEXT: [[S5:%[0-9]+]] = mul i64 4, %1
 // CHECK-NEXT: [[S6:%[0-9]+]] = add i64 [[S4]], [[S5]]
-// CHECK-NEXT: [[O:%[0-9]+]] = call noalias %swift.refcounted* @rt_swift_allocObject(%swift.type* [[M]], i64 [[S6]], i64 7) #5
+// CHECK-NEXT: [[O:%[0-9]+]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* [[M]], i64 [[S6]], i64 7) #5
 // CHECK-NEXT: [[O2:%[0-9]+]] = bitcast %swift.refcounted* [[O]] to %[[C]]*
 // CHECK-NEXT:  ret %[[C]]* [[O2]]
 sil @alloc_2_non_const_count : $@convention(thin) (Builtin.Word, Builtin.Word) -> @owned TestClass {
@@ -95,7 +95,7 @@ bb0(%c1 : $Builtin.Word, %c2 : $Builtin.Word):
 // CHECK-NEXT: [[S3:%[0-9]+]] = and i64 [[S1]], [[S2]]
 // CHECK-NEXT: [[S4:%[0-9]+]] = mul i64 %stride, %0
 // CHECK-NEXT: [[S5:%[0-9]+]] = add i64 [[S3]], [[S4]]
-// CHECK:      call noalias %swift.refcounted* @rt_swift_allocObject(%swift.type* %{{[0-9]+}}, i64 [[S5]], i64 7) #5
+// CHECK:      call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* %{{[0-9]+}}, i64 [[S5]], i64 7) #5
 // CHECK:      ret
 sil @alloc_generic : $@convention(thin) <T> (Builtin.Word, @thick T.Type) -> @owned TestClass {
 bb0(%0 : $Builtin.Word, %1 : $@thick T.Type):
@@ -113,7 +113,7 @@ bb0(%0 : $Builtin.Word, %1 : $@thick T.Type):
 // CHECK:      [[ALIGN_TMP:%[0-9]+]] = add i64 [[SIZE64]], 3
 // CHECK-NEXT: [[ALIGNED:%[0-9]+]] = and i64 [[ALIGN_TMP]], -4
 // CHECK-NEXT: [[TOTAL_SIZE:%[0-9]+]] = add i64 [[ALIGNED]], 12
-// CHECK-NEXT: [[O:%[0-9]+]] = call noalias %swift.refcounted* @rt_swift_allocObject(%swift.type* %0, i64 [[TOTAL_SIZE]], i64 {{.*}})
+// CHECK-NEXT: [[O:%[0-9]+]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* %0, i64 [[TOTAL_SIZE]], i64 {{.*}})
 // CHECK-NEXT: [[O2:%[0-9]+]] = bitcast %swift.refcounted* [[O]] to %{{.*TestClass}}*
 // CHECK-NEXT:  ret %{{.*TestClass}}* [[O2]]
 sil @alloc_dynamic : $@convention(thin) (@thick TestClass.Type) -> @owned TestClass {

--- a/test/IRGen/typed_boxes.sil
+++ b/test/IRGen/typed_boxes.sil
@@ -7,7 +7,7 @@ import Builtin
 // CHECK-LABEL: define{{( protected)?}} void @pod_box_8_8_a
 sil @pod_box_8_8_a : $@convention(thin) () -> () {
 entry:
-  // CHECK: [[BOX:%.*]] = call noalias %swift.refcounted* @rt_swift_allocObject(%swift.type* {{.*}} [[POD_8_8_METADATA:@metadata[0-9.]*]], {{.*}} [[WORD:i[0-9]+]] 24, [[WORD]] 7)
+  // CHECK: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* {{.*}} [[POD_8_8_METADATA:@metadata[0-9.]*]], {{.*}} [[WORD:i[0-9]+]] 24, [[WORD]] 7)
   %a = alloc_box $Builtin.Int64
   // CHECK-32: [[BOX_RAW:%.*]] = bitcast %swift.refcounted* [[BOX]] to [[POD_8_8_LAYOUT:<\{ %swift.refcounted, \[4 x i8\], \[8 x i8\] \}>]]*
   // CHECK-32: [[BOX_DATA:%.*]] = getelementptr inbounds [[POD_8_8_LAYOUT]], [[POD_8_8_LAYOUT]]* [[BOX_RAW]], i32 0, i32 2
@@ -15,7 +15,7 @@ entry:
   // CHECK-64: [[BOX_DATA:%.*]] = getelementptr inbounds [[POD_8_8_LAYOUT]], [[POD_8_8_LAYOUT]]* [[BOX_RAW]], i32 0, i32 1
   // CHECK: [[BOX_DATA_1:%.*]] = bitcast [8 x i8]* [[BOX_DATA]] to i64*
   %b = project_box %a : $@box Builtin.Int64
-  // CHECK: call void @rt_swift_deallocObject(%swift.refcounted* [[BOX]], [[WORD]] 24, [[WORD]] 7)
+  // CHECK: call void @swift_rt_swift_deallocObject(%swift.refcounted* [[BOX]], [[WORD]] 24, [[WORD]] 7)
   dealloc_box %a : $@box Builtin.Int64
   return undef : $()
 }
@@ -23,7 +23,7 @@ entry:
 // CHECK-LABEL: define{{( protected)?}} void @pod_box_8_8_b
 sil @pod_box_8_8_b : $@convention(thin) () -> () {
 entry:
-  // CHECK: [[BOX:%.*]] = call noalias %swift.refcounted* @rt_swift_allocObject(%swift.type* {{.*}} [[POD_8_8_METADATA]], {{.*}} [[WORD]] 24, [[WORD]] 7)
+  // CHECK: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* {{.*}} [[POD_8_8_METADATA]], {{.*}} [[WORD]] 24, [[WORD]] 7)
   %a = alloc_box $Builtin.FPIEEE64
   // CHECK-32: [[BOX_RAW:%.*]] = bitcast %swift.refcounted* [[BOX]] to [[POD_8_8_LAYOUT:<\{ %swift.refcounted, \[4 x i8\], \[8 x i8\] \}>]]*
   // CHECK-32: [[BOX_DATA:%.*]] = getelementptr inbounds [[POD_8_8_LAYOUT]], [[POD_8_8_LAYOUT]]* [[BOX_RAW]], i32 0, i32 2
@@ -31,7 +31,7 @@ entry:
   // CHECK-64: [[BOX_DATA:%.*]] = getelementptr inbounds [[POD_8_8_LAYOUT]], [[POD_8_8_LAYOUT]]* [[BOX_RAW]], i32 0, i32 1
   // CHECK: [[BOX_DATA_1:%.*]] = bitcast [8 x i8]* [[BOX_DATA]] to double*
   %b = project_box %a : $@box Builtin.FPIEEE64
-  // CHECK: call void @rt_swift_deallocObject(%swift.refcounted* [[BOX]], [[WORD]] 24, [[WORD]] 7)
+  // CHECK: call void @swift_rt_swift_deallocObject(%swift.refcounted* [[BOX]], [[WORD]] 24, [[WORD]] 7)
   dealloc_box %a : $@box Builtin.FPIEEE64
   return undef : $()
 }
@@ -44,14 +44,14 @@ struct OverAligned {
 // CHECK-LABEL: define{{( protected)?}} void @pod_box_32_32
 sil @pod_box_32_32 : $@convention(thin) () -> () {
 entry:
-  // CHECK: [[BOX:%.*]] = call noalias %swift.refcounted* @rt_swift_allocObject(%swift.type* {{.*}} [[POD_32_32_METADATA:@metadata[0-9.]*]], {{.*}} [[WORD]] 64, [[WORD]] 31)
+  // CHECK: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* {{.*}} [[POD_32_32_METADATA:@metadata[0-9.]*]], {{.*}} [[WORD]] 64, [[WORD]] 31)
   %a = alloc_box $OverAligned
   // CHECK-32: [[BOX_RAW:%.*]] = bitcast %swift.refcounted* [[BOX]] to [[POD_32_32_LAYOUT:<\{ %swift.refcounted, \[20 x i8\], \[32 x i8\] \}>]]*
   // CHECK-64: [[BOX_RAW:%.*]] = bitcast %swift.refcounted* [[BOX]] to [[POD_32_32_LAYOUT:<\{ %swift.refcounted, \[16 x i8\], \[32 x i8\] \}>]]*
   // CHECK: [[BOX_DATA:%.*]] = getelementptr inbounds [[POD_32_32_LAYOUT]], [[POD_32_32_LAYOUT]]* [[BOX_RAW]], i32 0, i32 2
   // CHECK: [[BOX_DATA_1:%.*]] = bitcast [32 x i8]* [[BOX_DATA]] to %V11typed_boxes11OverAligned*
   %b = project_box %a : $@box OverAligned
-  // CHECK: call void @rt_swift_deallocObject(%swift.refcounted* [[BOX]], [[WORD]] 64, [[WORD]] 31)
+  // CHECK: call void @swift_rt_swift_deallocObject(%swift.refcounted* [[BOX]], [[WORD]] 64, [[WORD]] 31)
   dealloc_box %a : $@box OverAligned
   return undef : $()
 }
@@ -65,8 +65,8 @@ sil_vtable D {}
 // CHECK-LABEL: define{{( protected)?}} void @rc_box_a
 sil @rc_box_a : $@convention(thin) () -> () {
 entry:
-  // CHECK-32: [[BOX:%.*]] = call noalias %swift.refcounted* @rt_swift_allocObject(%swift.type* {{.*}} [[NATIVE_RC_METADATA:@metadata[0-9.]*]], {{.*}} [[WORD]] 16, [[WORD]] 3)
-  // CHECK-64: [[BOX:%.*]] = call noalias %swift.refcounted* @rt_swift_allocObject(%swift.type* {{.*}} [[NATIVE_RC_METADATA:@metadata[0-9.]*]], {{.*}} [[WORD]] 24, [[WORD]] 7)
+  // CHECK-32: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* {{.*}} [[NATIVE_RC_METADATA:@metadata[0-9.]*]], {{.*}} [[WORD]] 16, [[WORD]] 3)
+  // CHECK-64: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* {{.*}} [[NATIVE_RC_METADATA:@metadata[0-9.]*]], {{.*}} [[WORD]] 24, [[WORD]] 7)
   %a = alloc_box $C
   // CHECK: bitcast %swift.refcounted** {{%.*}} to %C11typed_boxes1C**
   %b = project_box %a : $@box C
@@ -78,8 +78,8 @@ entry:
 sil @rc_box_b : $@convention(thin) () -> () {
 entry:
   // TODO: Should reuse metadata
-  // CHECK-32: [[BOX:%.*]] = call noalias %swift.refcounted* @rt_swift_allocObject(%swift.type* {{.*}} [[NATIVE_RC_METADATA]], {{.*}} [[WORD]] 16, [[WORD]] 3)
-  // CHECK-64: [[BOX:%.*]] = call noalias %swift.refcounted* @rt_swift_allocObject(%swift.type* {{.*}} [[NATIVE_RC_METADATA]], {{.*}} [[WORD]] 24, [[WORD]] 7)
+  // CHECK-32: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* {{.*}} [[NATIVE_RC_METADATA]], {{.*}} [[WORD]] 16, [[WORD]] 3)
+  // CHECK-64: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* {{.*}} [[NATIVE_RC_METADATA]], {{.*}} [[WORD]] 24, [[WORD]] 7)
   %a = alloc_box $D
   // CHECK: bitcast %swift.refcounted** {{%.*}} to %C11typed_boxes1D**
   %b = project_box %a : $@box D
@@ -90,8 +90,8 @@ entry:
 // CHECK-LABEL: define{{( protected)?}} void @unknown_rc_box
 sil @unknown_rc_box : $@convention(thin) () -> () {
 entry:
-  // CHECK-32: [[BOX:%.*]] = call noalias %swift.refcounted* @rt_swift_allocObject(%swift.type* {{.*}} [[UNKNOWN_RC_METADATA:@metadata[0-9.]*]], {{.*}} [[WORD]] 16, [[WORD]] 3)
-  // CHECK-64: [[BOX:%.*]] = call noalias %swift.refcounted* @rt_swift_allocObject(%swift.type* {{.*}} [[UNKNOWN_RC_METADATA:@metadata[0-9.]*]], {{.*}} [[WORD]] 24, [[WORD]] 7)
+  // CHECK-32: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* {{.*}} [[UNKNOWN_RC_METADATA:@metadata[0-9.]*]], {{.*}} [[WORD]] 16, [[WORD]] 3)
+  // CHECK-64: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* {{.*}} [[UNKNOWN_RC_METADATA:@metadata[0-9.]*]], {{.*}} [[WORD]] 24, [[WORD]] 7)
   %a = alloc_box $Builtin.UnknownObject
   %b = project_box %a : $@box Builtin.UnknownObject
   dealloc_box %a : $@box Builtin.UnknownObject

--- a/test/IRGen/typemetadata.sil
+++ b/test/IRGen/typemetadata.sil
@@ -29,7 +29,7 @@ bb0:
 // CHECK:      [[T0:%.*]] = load %swift.type*, %swift.type**  @_TMLC12typemetadata1C, align 8
 // CHECK-NEXT: [[T1:%.*]] = icmp eq %swift.type* [[T0]], null
 // CHECK-NEXT: br i1 [[T1]]
-// CHECK:      [[T0:%.*]] = call %objc_class* @rt_swift_getInitializedObjCClass({{.*}} @_TMfC12typemetadata1C, {{.*}})
+// CHECK:      [[T0:%.*]] = call %objc_class* @swift_rt_swift_getInitializedObjCClass({{.*}} @_TMfC12typemetadata1C, {{.*}})
 // CHECK-NEXT: [[T1:%.*]] = bitcast %objc_class* [[T0]] to %swift.type*
 // CHECK:      store atomic %swift.type* [[T1]], %swift.type** @_TMLC12typemetadata1C release, align 8
 // CHECK-NEXT: br label

--- a/test/IRGen/unowned.sil
+++ b/test/IRGen/unowned.sil
@@ -27,8 +27,8 @@ bb0(%0 : $@sil_unowned C):
   %4 = return %3 : $()
 }
 // CHECK:    define{{( protected)?}} void @test_weak_rr_class([[C]]*) {{.*}} {
-// CHECK:      call void bitcast (void ([[REF]]*)* @rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* %0)
-// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @rt_swift_unownedRelease to void ([[C]]*)*)([[C]]* %0)
+// CHECK:      call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* %0)
+// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRelease to void ([[C]]*)*)([[C]]* %0)
 // CHECK-NEXT: ret void
 
 sil @test_weak_rr_proto : $@convention(thin) (@sil_unowned P) -> () {
@@ -39,8 +39,8 @@ bb0(%0 : $@sil_unowned P):
   %4 = return %3 : $()
 }
 // CHECK:    define{{( protected)?}} void @test_weak_rr_proto(%swift.refcounted*, i8**) {{.*}} {
-// CHECK:      call void @rt_swift_unownedRetain(%swift.refcounted* %0)
-// CHECK:      call void @rt_swift_unownedRelease(%swift.refcounted* %0)
+// CHECK:      call void @swift_rt_swift_unownedRetain(%swift.refcounted* %0)
+// CHECK:      call void @swift_rt_swift_unownedRelease(%swift.refcounted* %0)
 // CHECK-NEXT: ret void
 
 // Value witnesses for A:
@@ -51,7 +51,7 @@ bb0(%0 : $@sil_unowned P):
 // CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds [[A]], [[A]]* [[T0]], i32 0, i32 0
 // CHECK-NEXT: [[T1C:%.*]] = bitcast %swift.unowned* [[T1]] to [[C]]*
 // CHECK-NEXT: [[T2:%.*]] = load [[C]]*, [[C]]** [[T1C]], align 8
-// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @rt_swift_unownedRelease to void ([[C]]*)*)([[C]]* [[T2]])
+// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRelease to void ([[C]]*)*)([[C]]* [[T2]])
 // CHECK-NEXT: ret void
 
 //   initializeBufferWithCopyOfBuffer
@@ -62,7 +62,7 @@ bb0(%0 : $@sil_unowned P):
 // CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds [[A]], [[A]]* [[SRC]], i32 0, i32 0
 // CHECK-NEXT: [[T1C:%.*]] = bitcast %swift.unowned* [[T1]] to [[C]]*
 // CHECK-NEXT: [[T2:%.*]] = load [[C]]*, [[C]]** [[T1C]], align 8
-// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* [[T2]])
+// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* [[T2]])
 // CHECK-NEXT: [[T0C:%.*]] = bitcast %swift.unowned* [[T0]] to [[C]]*
 // CHECK-NEXT: store [[C]]* [[T2]], [[C]]** [[T0C]], align 8
 // CHECK-NEXT: [[T0:%.*]] = bitcast [[A]]* [[DEST]] to [[OPAQUE]]*
@@ -74,7 +74,7 @@ bb0(%0 : $@sil_unowned P):
 // CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds [[A]], [[A]]* [[T0]], i32 0, i32 0
 // CHECK-NEXT: [[T1C:%.*]] = bitcast %swift.unowned* [[T1]] to [[C]]*
 // CHECK-NEXT: [[T2:%.*]] = load [[C]]*, [[C]]** [[T1C]], align 8
-// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @rt_swift_unownedRelease to void ([[C]]*)*)([[C]]* [[T2]])
+// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRelease to void ([[C]]*)*)([[C]]* [[T2]])
 // CHECK-NEXT: ret void
 
 //   initializeBufferWithCopy
@@ -85,7 +85,7 @@ bb0(%0 : $@sil_unowned P):
 // CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds [[A]], [[A]]* [[SRC]], i32 0, i32 0
 // CHECK-NEXT: [[T1C:%.*]] = bitcast %swift.unowned* [[T1]] to [[C]]*
 // CHECK-NEXT: [[T2:%.*]] = load [[C]]*, [[C]]** [[T1C]], align 8
-// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* [[T2]])
+// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* [[T2]])
 // CHECK-NEXT: [[T0C:%.*]] = bitcast %swift.unowned* [[T0]] to [[C]]*
 // CHECK-NEXT: store [[C]]* [[T2]], [[C]]** [[T0C]], align 8
 // CHECK-NEXT: [[T0:%.*]] = bitcast [[A]]* [[DEST]] to [[OPAQUE]]*
@@ -99,7 +99,7 @@ bb0(%0 : $@sil_unowned P):
 // CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds [[A]], [[A]]* [[SRC]], i32 0, i32 0
 // CHECK-NEXT: [[T1C:%.*]] = bitcast %swift.unowned* [[T1]] to [[C]]*
 // CHECK-NEXT: [[T2:%.*]] = load [[C]]*, [[C]]** [[T1C]], align 8
-// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* [[T2]])
+// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* [[T2]])
 // CHECK-NEXT: [[T0C:%.*]] = bitcast %swift.unowned* [[T0]] to [[C]]*
 // CHECK-NEXT: store [[C]]* [[T2]], [[C]]** [[T0C]], align 8
 // CHECK-NEXT: [[T0:%.*]] = bitcast [[A]]* [[DEST]] to [[OPAQUE]]*
@@ -113,11 +113,11 @@ bb0(%0 : $@sil_unowned P):
 // CHECK-NEXT: [[SRC_X:%.*]] = getelementptr inbounds [[A]], [[A]]* [[SRC]], i32 0, i32 0
 // CHECK-NEXT: [[SRC_X_C:%.*]] = bitcast %swift.unowned* [[SRC_X]] to [[C]]*
 // CHECK-NEXT: [[NEW:%.*]] = load [[C]]*, [[C]]** [[SRC_X_C]], align 8
-// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* [[NEW]])
+// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* [[NEW]])
 // CHECK-NEXT: [[DEST_X_C:%.*]] = bitcast %swift.unowned* [[DEST_X]] to [[C]]*
 // CHECK-NEXT: [[OLD:%.*]] = load [[C]]*, [[C]]** [[DEST_X_C]], align 8
 // CHECK-NEXT: store [[C]]* [[NEW]], [[C]]** [[DEST_X_C]], align 8
-// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @rt_swift_unownedRelease to void ([[C]]*)*)([[C]]* [[OLD]])
+// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRelease to void ([[C]]*)*)([[C]]* [[OLD]])
 // CHECK-NEXT: [[T0:%.*]] = bitcast [[A]]* [[DEST]] to [[OPAQUE]]*
 // CHECK-NEXT: ret [[OPAQUE]]* [[T0]]
 
@@ -132,6 +132,6 @@ bb0(%0 : $@sil_unowned P):
 // CHECK-NEXT: [[DEST_X_C:%.*]] = bitcast %swift.unowned* [[DEST_X]] to [[C]]*
 // CHECK-NEXT: [[OLD:%.*]] = load [[C]]*, [[C]]** [[DEST_X_C]], align 8
 // CHECK-NEXT: store [[C]]* [[NEW]], [[C]]** [[DEST_X_C]], align 8
-// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @rt_swift_unownedRelease to void ([[C]]*)*)([[C]]* [[OLD]])
+// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRelease to void ([[C]]*)*)([[C]]* [[OLD]])
 // CHECK-NEXT: [[T0:%.*]] = bitcast [[A]]* [[DEST]] to [[OPAQUE]]*
 // CHECK-NEXT: ret [[OPAQUE]]* [[T0]]

--- a/test/IRGen/unowned_objc.sil
+++ b/test/IRGen/unowned_objc.sil
@@ -34,8 +34,8 @@ bb0(%0 : $@sil_unowned C):
   %4 = return %3 : $()
 }
 // CHECK:    define{{( protected)?}} void @test_weak_rr_class([[C]]*) {{.*}} {
-// CHECK:      call void bitcast (void ([[REF]]*)* @rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* %0)
-// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @rt_swift_unownedRelease to void ([[C]]*)*)([[C]]* %0)
+// CHECK:      call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* %0)
+// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRelease to void ([[C]]*)*)([[C]]* %0)
 // CHECK-NEXT: ret void
 
 // CHECK:    define{{( protected)?}} void @test_unknown_unowned_copies([[UNKNOWN]]*, i8**, [[UNKNOWN]]*, i8**)
@@ -154,7 +154,7 @@ bb0(%p : $P, %q : $P):
 // CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds [[A]], [[A]]* [[T0]], i32 0, i32 0
 // CHECK-NEXT: [[T1C:%.*]] = bitcast %swift.unowned* [[T1]] to [[C]]*
 // CHECK-NEXT: [[T2:%.*]] = load [[C]]*, [[C]]** [[T1C]], align 8
-// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @rt_swift_unownedRelease to void ([[C]]*)*)([[C]]* [[T2]])
+// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRelease to void ([[C]]*)*)([[C]]* [[T2]])
 // CHECK-NEXT: ret void
 
 //   initializeBufferWithCopyOfBuffer
@@ -165,7 +165,7 @@ bb0(%p : $P, %q : $P):
 // CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds [[A]], [[A]]* [[SRC]], i32 0, i32 0
 // CHECK-NEXT: [[T1C:%.*]] = bitcast %swift.unowned* [[T1]] to [[C]]*
 // CHECK-NEXT: [[T2:%.*]] = load [[C]]*, [[C]]** [[T1C]], align 8
-// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* [[T2]])
+// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* [[T2]])
 // CHECK-NEXT: [[T0C:%.*]] = bitcast %swift.unowned* [[T0]] to [[C]]*
 // CHECK-NEXT: store [[C]]* [[T2]], [[C]]** [[T0C]], align 8
 // CHECK-NEXT: [[T0:%.*]] = bitcast [[A]]* [[DEST]] to [[OPAQUE]]*
@@ -177,7 +177,7 @@ bb0(%p : $P, %q : $P):
 // CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds [[A]], [[A]]* [[T0]], i32 0, i32 0
 // CHECK-NEXT: [[T1C:%.*]] = bitcast %swift.unowned* [[T1]] to [[C]]*
 // CHECK-NEXT: [[T2:%.*]] = load [[C]]*, [[C]]** [[T1C]], align 8
-// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @rt_swift_unownedRelease to void ([[C]]*)*)([[C]]* [[T2]])
+// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRelease to void ([[C]]*)*)([[C]]* [[T2]])
 // CHECK-NEXT: ret void
 
 //   initializeBufferWithCopy
@@ -188,7 +188,7 @@ bb0(%p : $P, %q : $P):
 // CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds [[A]], [[A]]* [[SRC]], i32 0, i32 0
 // CHECK-NEXT: [[T1C:%.*]] = bitcast %swift.unowned* [[T1]] to [[C]]*
 // CHECK-NEXT: [[T2:%.*]] = load [[C]]*, [[C]]** [[T1C]], align 8
-// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* [[T2]])
+// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* [[T2]])
 // CHECK-NEXT: [[T0C:%.*]] = bitcast %swift.unowned* [[T0]] to [[C]]*
 // CHECK-NEXT: store [[C]]* [[T2]], [[C]]** [[T0C]], align 8
 // CHECK-NEXT: [[T0:%.*]] = bitcast [[A]]* [[DEST]] to [[OPAQUE]]*
@@ -202,7 +202,7 @@ bb0(%p : $P, %q : $P):
 // CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds [[A]], [[A]]* [[SRC]], i32 0, i32 0
 // CHECK-NEXT: [[T1C:%.*]] = bitcast %swift.unowned* [[T1]] to [[C]]*
 // CHECK-NEXT: [[T2:%.*]] = load [[C]]*, [[C]]** [[T1C]], align 8
-// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* [[T2]])
+// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* [[T2]])
 // CHECK-NEXT: [[T0C:%.*]] = bitcast %swift.unowned* [[T0]] to [[C]]*
 // CHECK-NEXT: store [[C]]* [[T2]], [[C]]** [[T0C]], align 8
 // CHECK-NEXT: [[T0:%.*]] = bitcast [[A]]* [[DEST]] to [[OPAQUE]]*
@@ -216,11 +216,11 @@ bb0(%p : $P, %q : $P):
 // CHECK-NEXT: [[SRC_X:%.*]] = getelementptr inbounds [[A]], [[A]]* [[SRC]], i32 0, i32 0
 // CHECK-NEXT: [[SRC_X_C:%.*]] = bitcast %swift.unowned* [[SRC_X]] to [[C]]*
 // CHECK-NEXT: [[NEW:%.*]] = load [[C]]*, [[C]]** [[SRC_X_C]], align 8
-// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* [[NEW]])
+// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRetain to void ([[C]]*)*)([[C]]* [[NEW]])
 // CHECK-NEXT: [[DEST_X_C:%.*]] = bitcast %swift.unowned* [[DEST_X]] to [[C]]*
 // CHECK-NEXT: [[OLD:%.*]] = load [[C]]*, [[C]]** [[DEST_X_C]], align 8
 // CHECK-NEXT: store [[C]]* [[NEW]], [[C]]** [[DEST_X_C]], align 8
-// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @rt_swift_unownedRelease to void ([[C]]*)*)([[C]]* [[OLD]])
+// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRelease to void ([[C]]*)*)([[C]]* [[OLD]])
 // CHECK-NEXT: [[T0:%.*]] = bitcast [[A]]* [[DEST]] to [[OPAQUE]]*
 // CHECK-NEXT: ret [[OPAQUE]]* [[T0]]
 
@@ -235,6 +235,6 @@ bb0(%p : $P, %q : $P):
 // CHECK-NEXT: [[DEST_X_C:%.*]] = bitcast %swift.unowned* [[DEST_X]] to [[C]]*
 // CHECK-NEXT: [[OLD:%.*]] = load [[C]]*, [[C]]** [[DEST_X_C]], align 8
 // CHECK-NEXT: store [[C]]* [[NEW]], [[C]]** [[DEST_X_C]], align 8
-// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @rt_swift_unownedRelease to void ([[C]]*)*)([[C]]* [[OLD]])
+// CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_rt_swift_unownedRelease to void ([[C]]*)*)([[C]]* [[OLD]])
 // CHECK-NEXT: [[T0:%.*]] = bitcast [[A]]* [[DEST]] to [[OPAQUE]]*
 // CHECK-NEXT: ret [[OPAQUE]]* [[T0]]

--- a/test/IRGen/value_buffers.sil
+++ b/test/IRGen/value_buffers.sil
@@ -62,7 +62,7 @@ entry(%b : $*Builtin.UnsafeValueBuffer, %v : $BigStruct):
 // CHECK: [[SLOT1:%.*]] = load i64
 // CHECK: [[SLOT2:%.*]] = load i64
 // CHECK: [[SLOT3:%.*]] = load i64
-// CHECK-NEXT: [[T0:%.*]] = call noalias i8* @rt_swift_slowAlloc(i64 32, i64 7)
+// CHECK-NEXT: [[T0:%.*]] = call noalias i8* @swift_rt_swift_slowAlloc(i64 32, i64 7)
 // CHECK-NEXT: [[T1:%.*]] = bitcast [24 x i8]* %0 to i8**
 // CHECK-NEXT: store i8* [[T0]], i8** [[T1]], align 8
 // CHECK-NEXT: [[ADDR:%.*]] = bitcast i8* [[T0]] to %V13value_buffers9BigStruct*
@@ -119,5 +119,5 @@ entry(%b : $*Builtin.UnsafeValueBuffer):
 // CHECK-NEXT: entry:
 // CHECK-NEXT: [[T0:%.*]] = bitcast [24 x i8]* %0 to i8**
 // CHECK-NEXT: [[ADDR:%.*]] = load i8*, i8** [[T0]], align 8
-// CHECK-NEXT: call void @rt_swift_slowDealloc(i8* [[ADDR]], i64 32, i64 7)
+// CHECK-NEXT: call void @swift_rt_swift_slowDealloc(i8* [[ADDR]], i64 32, i64 7)
 // CHECK-NEXT: ret void

--- a/test/IRGen/weak.sil
+++ b/test/IRGen/weak.sil
@@ -48,7 +48,7 @@ bb0(%0 : $*A, %1 : $Optional<C>):
 // CHECK-NEXT: %4 = inttoptr
 // CHECK-NEXT: call void bitcast (void ([[WEAK]]*, [[REF]]*)* @swift_weakAssign to void ([[WEAK]]*, [[C]]*)*)([[WEAK]]* [[X]], [[C]]* %4)
 // CHECK-NEXT: %5 = inttoptr i64 %3 to %swift.refcounted*
-// CHECK-NEXT: call void @rt_swift_release([[REF]]* %5)
+// CHECK-NEXT: call void @swift_rt_swift_release([[REF]]* %5)
 // CHECK-NEXT: ret void
 
 struct B {

--- a/test/LLVMPasses/contract.ll
+++ b/test/LLVMPasses/contract.ll
@@ -7,11 +7,11 @@ target triple = "x86_64-apple-macosx10.9"
 %swift.heapmetadata = type { i64 (%swift.refcounted*)*, i64 (%swift.refcounted*)* }
 %swift.bridge = type opaque
 
-declare %swift.refcounted* @rt_swift_allocObject(%swift.heapmetadata* , i64, i64) nounwind
+declare %swift.refcounted* @swift_rt_swift_allocObject(%swift.heapmetadata* , i64, i64) nounwind
 declare %swift.bridge* @swift_bridgeObjectRetain(%swift.bridge*)
 declare void @swift_bridgeObjectRelease(%swift.bridge* )
-declare void @rt_swift_release(%swift.refcounted* nocapture)
-declare void @rt_swift_retain(%swift.refcounted* ) nounwind
+declare void @swift_rt_swift_release(%swift.refcounted* nocapture)
+declare void @swift_rt_swift_retain(%swift.refcounted* ) nounwind
 declare void @swift_unknownRelease(%swift.refcounted* nocapture)
 declare void @swift_unknownRetain(%swift.refcounted* ) nounwind
 declare void @swift_fixLifetime(%swift.refcounted*)
@@ -33,37 +33,37 @@ entry:
 ; CHECK: entry:
 ; CHECK-NEXT: br i1 undef
 ; CHECK: bb1:
-; CHECK-NEXT: tail call void @rt_swift_retain_n(%swift.refcounted* %A, i32 2)
+; CHECK-NEXT: tail call void @swift_rt_swift_retain_n(%swift.refcounted* %A, i32 2)
 ; CHECK-NEXT: call void @noread_user(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @noread_user(%swift.refcounted* %A)
 ; CHECK-NEXT: br label %bb3
 ; CHECK: bb2:
 ; CHECK-NEXT: call void @noread_user(%swift.refcounted* %A)
-; CHECK-NEXT: tail call void @rt_swift_retain(%swift.refcounted* %A)
+; CHECK-NEXT: tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @noread_user(%swift.refcounted* %A)
 ; CHECK-NEXT: br label %bb3
 ; CHECK: bb3:
-; CHECK-NEXT: tail call void @rt_swift_retain(%swift.refcounted* %A)
+; CHECK-NEXT: tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
 ; CHECK-NEXT: ret %swift.refcounted* %A
 define %swift.refcounted* @swift_contractRetainN(%swift.refcounted* %A) {
 entry:
   br i1 undef, label %bb1, label %bb2
 
 bb1:
-  tail call void @rt_swift_retain(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
   call void @noread_user(%swift.refcounted* %A)
-  tail call void @rt_swift_retain(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
   call void @noread_user(%swift.refcounted* %A)
   br label %bb3
 
 bb2:
   call void @noread_user(%swift.refcounted* %A)
-  tail call void @rt_swift_retain(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
   call void @noread_user(%swift.refcounted* %A)
   br label %bb3
 
 bb3:
-  tail call void @rt_swift_retain(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
   ret %swift.refcounted* %A
 }
 
@@ -71,31 +71,31 @@ bb3:
 ; CHECK: entry:
 ; CHECK-NEXT: br i1 undef
 ; CHECK: bb1:
-; CHECK-NEXT: tail call void @rt_swift_retain_n(%swift.refcounted* %A, i32 2)
+; CHECK-NEXT: tail call void @swift_rt_swift_retain_n(%swift.refcounted* %A, i32 2)
 ; CHECK-NEXT: %0 = bitcast %swift.refcounted* %A to %swift.refcounted*
 ; CHECK-NEXT: br label %bb3
 ; CHECK: bb2:
-; CHECK-NEXT: tail call void @rt_swift_retain(%swift.refcounted* %A)
+; CHECK-NEXT: tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
 ; CHECK-NEXT: br label %bb3
 ; CHECK: bb3:
-; CHECK-NEXT: tail call void @rt_swift_retain(%swift.refcounted* %A)
+; CHECK-NEXT: tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
 ; CHECK-NEXT: ret %swift.refcounted* %A
 define %swift.refcounted* @swift_contractRetainNWithRCIdentity(%swift.refcounted* %A) {
 entry:
   br i1 undef, label %bb1, label %bb2
 
 bb1:
-  tail call void @rt_swift_retain(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
   %0 = bitcast %swift.refcounted* %A to %swift.refcounted*
-  tail call void @rt_swift_retain(%swift.refcounted* %0)
+  tail call void @swift_rt_swift_retain(%swift.refcounted* %0)
   br label %bb3
 
 bb2:
-  tail call void @rt_swift_retain(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
   br label %bb3
 
 bb3:
-  tail call void @rt_swift_retain(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
   ret %swift.refcounted* %A
 }
 
@@ -104,36 +104,36 @@ bb3:
 ; CHECK-NEXT: br i1 undef
 ; CHECK: bb1:
 ; CHECK-NEXT: call void @noread_user(%swift.refcounted* %A)
-; CHECK-NEXT: tail call void @rt_swift_release_n(%swift.refcounted* %A, i32 2)
+; CHECK-NEXT: tail call void @swift_rt_swift_release_n(%swift.refcounted* %A, i32 2)
 ; CHECK-NEXT: call void @noread_user(%swift.refcounted* %A)
 ; CHECK-NEXT: br label %bb3
 ; CHECK: bb2:
 ; CHECK-NEXT: call void @noread_user(%swift.refcounted* %A)
-; CHECK-NEXT: tail call void @rt_swift_release(%swift.refcounted* %A)
+; CHECK-NEXT: tail call void @swift_rt_swift_release(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @noread_user(%swift.refcounted* %A)
 ; CHECK-NEXT: br label %bb3
 ; CHECK: bb3:
-; CHECK-NEXT: tail call void @rt_swift_release(%swift.refcounted* %A)
+; CHECK-NEXT: tail call void @swift_rt_swift_release(%swift.refcounted* %A)
 ; CHECK-NEXT: ret %swift.refcounted* %A
 define %swift.refcounted* @swift_contractReleaseN(%swift.refcounted* %A) {
 entry:
   br i1 undef, label %bb1, label %bb2
 
 bb1:
-  tail call void @rt_swift_release(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_release(%swift.refcounted* %A)
   call void @noread_user(%swift.refcounted* %A)
-  tail call void @rt_swift_release(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_release(%swift.refcounted* %A)
   call void @noread_user(%swift.refcounted* %A)
   br label %bb3
 
 bb2:
   call void @noread_user(%swift.refcounted* %A)
-  tail call void @rt_swift_release(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_release(%swift.refcounted* %A)
   call void @noread_user(%swift.refcounted* %A)
   br label %bb3
 
 bb3:
-  tail call void @rt_swift_release(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_release(%swift.refcounted* %A)
   ret %swift.refcounted* %A
 }
 
@@ -142,30 +142,30 @@ bb3:
 ; CHECK-NEXT: br i1 undef
 ; CHECK: bb1:
 ; CHECK-NEXT: %0 = bitcast %swift.refcounted* %A to %swift.refcounted*
-; CHECK-NEXT: tail call void @rt_swift_release_n(%swift.refcounted* %A, i32 2)
+; CHECK-NEXT: tail call void @swift_rt_swift_release_n(%swift.refcounted* %A, i32 2)
 ; CHECK-NEXT: br label %bb3
 ; CHECK: bb2:
-; CHECK-NEXT: tail call void @rt_swift_release(%swift.refcounted* %A)
+; CHECK-NEXT: tail call void @swift_rt_swift_release(%swift.refcounted* %A)
 ; CHECK-NEXT: br label %bb3
 ; CHECK: bb3:
-; CHECK-NEXT: tail call void @rt_swift_release(%swift.refcounted* %A)
+; CHECK-NEXT: tail call void @swift_rt_swift_release(%swift.refcounted* %A)
 ; CHECK-NEXT: ret %swift.refcounted* %A
 define %swift.refcounted* @swift_contractReleaseNWithRCIdentity(%swift.refcounted* %A) {
 entry:
   br i1 undef, label %bb1, label %bb2
 
 bb1:
-  tail call void @rt_swift_release(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_release(%swift.refcounted* %A)
   %0 = bitcast %swift.refcounted* %A to %swift.refcounted*
-  tail call void @rt_swift_release(%swift.refcounted* %0)
+  tail call void @swift_rt_swift_release(%swift.refcounted* %0)
   br label %bb3
 
 bb2:
-  tail call void @rt_swift_release(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_release(%swift.refcounted* %A)
   br label %bb3
 
 bb3:
-  tail call void @rt_swift_release(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_release(%swift.refcounted* %A)
   ret %swift.refcounted* %A
 }
 
@@ -174,112 +174,112 @@ bb3:
 ; read the reference count of the object.
 
 ; CHECK-LABEL: define{{( protected)?}} %swift.refcounted* @swift_contractRetainNWithUnknown(%swift.refcounted* %A) {
-; CHECK-NOT: call %swift.refcounted* @rt_swift_retain_n
+; CHECK-NOT: call %swift.refcounted* @swift_rt_swift_retain_n
 define %swift.refcounted* @swift_contractRetainNWithUnknown(%swift.refcounted* %A) {
 entry:
   br i1 undef, label %bb1, label %bb2
 
 bb1:
-  tail call void @rt_swift_retain(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
-  tail call void @rt_swift_retain(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
   br label %bb3
 
 bb2:
   call void @user(%swift.refcounted* %A)
-  tail call void @rt_swift_retain(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
   br label %bb3
 
 bb3:
-  tail call void @rt_swift_retain(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
   ret %swift.refcounted* %A
 }
 
 ; CHECK-LABEL: define{{( protected)?}} %swift.refcounted* @swift_contractReleaseNWithUnknown(%swift.refcounted* %A) {
-; CHECK-NOT: call void @rt_swift_release_n
+; CHECK-NOT: call void @swift_rt_swift_release_n
 define %swift.refcounted* @swift_contractReleaseNWithUnknown(%swift.refcounted* %A) {
 entry:
   br i1 undef, label %bb1, label %bb2
 
 bb1:
-  tail call void @rt_swift_release(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_release(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
-  tail call void @rt_swift_release(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_release(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
   br label %bb3
 
 bb2:
   call void @user(%swift.refcounted* %A)
-  tail call void @rt_swift_release(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_release(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
   br label %bb3
 
 bb3:
-  tail call void @rt_swift_release(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_release(%swift.refcounted* %A)
   ret %swift.refcounted* %A
 }
 
 ; But do make sure that we can form retainN, releaseN in between such uses
 ; CHECK-LABEL: define{{( protected)?}} %swift.refcounted* @swift_contractRetainNInterleavedWithUnknown(%swift.refcounted* %A) {
 ; CHECK: bb1:
-; CHECK: tail call void @rt_swift_retain(%swift.refcounted* %A)
+; CHECK: tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
-; CHECK-NEXT: tail call void @rt_swift_retain_n(%swift.refcounted* %A, i32 3)
+; CHECK-NEXT: tail call void @swift_rt_swift_retain_n(%swift.refcounted* %A, i32 3)
 ; CHECK-NEXT: call void @noread_user(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @noread_user(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
-; CHECK-NEXT: tail call void @rt_swift_retain_n(%swift.refcounted* %A, i32 2)
+; CHECK-NEXT: tail call void @swift_rt_swift_retain_n(%swift.refcounted* %A, i32 2)
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
-; CHECK-NEXT: tail call void @rt_swift_retain(%swift.refcounted* %A)
+; CHECK-NEXT: tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
 ; CHECK-NEXT: br label %bb3
 
 ; CHECK: bb2:
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
-; CHECK-NEXT: tail call void @rt_swift_retain(%swift.refcounted* %A)
+; CHECK-NEXT: tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
 ; CHECK-NEXT: br label %bb3
 
 ; CHECK: bb3:
-; CHECK-NEXT: tail call void @rt_swift_retain(%swift.refcounted* %A)
+; CHECK-NEXT: tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
 ; CHECK-NEXT: ret %swift.refcounted* %A
 define %swift.refcounted* @swift_contractRetainNInterleavedWithUnknown(%swift.refcounted* %A) {
 entry:
   br i1 undef, label %bb1, label %bb2
 
 bb1:
-  tail call void @rt_swift_retain(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
-  tail call void @rt_swift_retain(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
   call void @noread_user(%swift.refcounted* %A)
-  tail call void @rt_swift_retain(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
   call void @noread_user(%swift.refcounted* %A)
-  tail call void @rt_swift_retain(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
-  tail call void @rt_swift_retain(%swift.refcounted* %A)
-  tail call void @rt_swift_retain(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
-  tail call void @rt_swift_retain(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
   br label %bb3
 
 bb2:
   call void @user(%swift.refcounted* %A)
-  tail call void @rt_swift_retain(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
   br label %bb3
 
 bb3:
-  tail call void @rt_swift_retain(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
   ret %swift.refcounted* %A
 }
 
 ; CHECK-LABEL: define{{( protected)?}} %swift.refcounted* @swift_contractReleaseNInterleavedWithUnknown(%swift.refcounted* %A) {
 ; CHECK: bb1:
-; CHECK-NEXT: @rt_swift_release(
+; CHECK-NEXT: @swift_rt_swift_release(
 ; CHECK-NEXT: @user
 ; CHECK-NEXT: @noread_user
-; CHECK-NEXT: @rt_swift_release_n
+; CHECK-NEXT: @swift_rt_swift_release_n
 ; CHECK-NEXT: @user
 ; CHECK-NEXT: br label %bb3
 define %swift.refcounted* @swift_contractReleaseNInterleavedWithUnknown(%swift.refcounted* %A) {
@@ -287,78 +287,78 @@ entry:
   br i1 undef, label %bb1, label %bb2
 
 bb1:
-  tail call void @rt_swift_release(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_release(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
-  tail call void @rt_swift_release(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_release(%swift.refcounted* %A)
   call void @noread_user(%swift.refcounted* %A)
-  tail call void @rt_swift_release(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_release(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
   br label %bb3
 
 bb2:
   call void @user(%swift.refcounted* %A)
-  tail call void @rt_swift_release(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_release(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
   br label %bb3
 
 bb3:
-  tail call void @rt_swift_release(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_release(%swift.refcounted* %A)
   ret %swift.refcounted* %A
 }
 
 ; CHECK-LABEL: define{{( protected)?}} %swift.refcounted* @swift_contractRetainReleaseNInterleavedWithUnknown(%swift.refcounted* %A) {
 ; CHECK: bb1:
-; CHECK-NEXT: tail call void @rt_swift_retain(%swift.refcounted* %A)
+; CHECK-NEXT: tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @noread_user(%swift.refcounted* %A)
-; CHECK-NEXT: tail call void @rt_swift_release_n(%swift.refcounted* %A, i32 2)
+; CHECK-NEXT: tail call void @swift_rt_swift_release_n(%swift.refcounted* %A, i32 2)
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
-; CHECK-NEXT: tail call void @rt_swift_retain_n(%swift.refcounted* %A, i32 2)
-; CHECK-NEXT: tail call void @rt_swift_release(%swift.refcounted* %A)
+; CHECK-NEXT: tail call void @swift_rt_swift_retain_n(%swift.refcounted* %A, i32 2)
+; CHECK-NEXT: tail call void @swift_rt_swift_release(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @noread_user(%swift.refcounted* %A)
-; CHECK-NEXT: tail call void @rt_swift_release_n(%swift.refcounted* %A, i32 2)
+; CHECK-NEXT: tail call void @swift_rt_swift_release_n(%swift.refcounted* %A, i32 2)
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
 ; CHECK-NEXT: br label %bb3
 ; CHECK: bb2:
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
-; CHECK-NEXT: call void @rt_swift_release(%swift.refcounted* %A)
+; CHECK-NEXT: call void @swift_rt_swift_release(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
 ; CHECK-NEXT: br label %bb3
 
 ; CHECK: bb3:
-; CHECK-NEXT: tail call void @rt_swift_release(%swift.refcounted* %A)
+; CHECK-NEXT: tail call void @swift_rt_swift_release(%swift.refcounted* %A)
 ; CHECK-NEXT: ret %swift.refcounted* %A
 define %swift.refcounted* @swift_contractRetainReleaseNInterleavedWithUnknown(%swift.refcounted* %A) {
 entry:
   br i1 undef, label %bb1, label %bb2
 
 bb1:
-  tail call void @rt_swift_retain(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
-  tail call void @rt_swift_release(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_release(%swift.refcounted* %A)
   call void @noread_user(%swift.refcounted* %A)
-  tail call void @rt_swift_release(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_release(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
-  tail call void @rt_swift_retain(%swift.refcounted* %A)
-  tail call void @rt_swift_retain(%swift.refcounted* %A)
-  tail call void @rt_swift_release(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_retain(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_release(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
-  tail call void @rt_swift_release(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_release(%swift.refcounted* %A)
   call void @noread_user(%swift.refcounted* %A)
-  tail call void @rt_swift_release(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_release(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
   
   br label %bb3
 
 bb2:
   call void @user(%swift.refcounted* %A)
-  tail call void @rt_swift_release(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_release(%swift.refcounted* %A)
   call void @user(%swift.refcounted* %A)
   br label %bb3
 
 bb3:
-  tail call void @rt_swift_release(%swift.refcounted* %A)
+  tail call void @swift_rt_swift_release(%swift.refcounted* %A)
   ret %swift.refcounted* %A
 }
 


### PR DESCRIPTION
Swift uses rt_swift_\* functions to call the Swift runtime without using dyld's stubs. These functions are renamed to swift_rt_\* to reduce the namespace pollution.

rdar://28706212
