### PR TITLE
Enforce sil ownership sil verifier

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -445,15 +445,19 @@ public:
         getSILDebugLocation(Loc), text.toStringRef(Out), encoding, F));
   }
 
-  LoadInst *createLoad(SILLocation Loc, SILValue LV) {
+  LoadInst *createLoad(
+      SILLocation Loc, SILValue LV,
+      LoadOwnershipQualifier Qualifier = LoadOwnershipQualifier::Unqualified) {
     assert(LV->getType().isLoadable(F.getModule()));
     return insert(new (F.getModule())
-                      LoadInst(getSILDebugLocation(Loc), LV));
+                      LoadInst(getSILDebugLocation(Loc), LV, Qualifier));
   }
 
-  StoreInst *createStore(SILLocation Loc, SILValue Src, SILValue DestAddr) {
-    return insert(new (F.getModule())
-                      StoreInst(getSILDebugLocation(Loc), Src, DestAddr));
+  StoreInst *createStore(SILLocation Loc, SILValue Src, SILValue DestAddr,
+                         StoreOwnershipQualifier Qualifier =
+                             StoreOwnershipQualifier::Unqualified) {
+    return insert(new (F.getModule()) StoreInst(getSILDebugLocation(Loc), Src,
+                                                DestAddr, Qualifier));
   }
   AssignInst *createAssign(SILLocation Loc, SILValue Src, SILValue DestAddr) {
     return insert(new (F.getModule())

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1667,6 +1667,8 @@ static inline llvm::hash_code hash_value(StringLiteralInst::Encoding E) {
   return llvm::hash_value(size_t(E));
 }
 
+// *NOTE* When serializing, we can only represent up to 4 values here. If more
+// qualifiers are added, SIL serialization must be updated.
 enum class LoadOwnershipQualifier {
   Unqualified, Take, Copy, Trivial
 };
@@ -1697,6 +1699,8 @@ public:
   }
 };
 
+// *NOTE* When serializing, we can only represent up to 4 values here. If more
+// qualifiers are added, SIL serialization must be updated.
 enum class StoreOwnershipQualifier {
   Unqualified, Init, Assign, Trivial
 };

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1729,6 +1729,10 @@ public:
   static bool classof(const ValueBase *V) {
     return V->getKind() == ValueKind::StoreInst;
   }
+
+  StoreOwnershipQualifier getOwnershipQualifier() const {
+    return OwnershipQualifier;
+  }
 };
 
 /// AssignInst - Represents an abstract assignment to a memory location, which

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1667,11 +1667,17 @@ static inline llvm::hash_code hash_value(StringLiteralInst::Encoding E) {
   return llvm::hash_value(size_t(E));
 }
 
+enum class LoadOwnershipQualifier {
+  Unqualified, Take, Copy, Trivial
+};
+
 /// LoadInst - Represents a load from a memory location.
 class LoadInst
   : public UnaryInstructionBase<ValueKind::LoadInst>
 {
   friend class SILBuilder;
+
+  LoadOwnershipQualifier OwnershipQualifier;
 
   /// Constructs a LoadInst.
   ///
@@ -1679,9 +1685,20 @@ class LoadInst
   ///
   /// \param LValue The SILValue representing the lvalue (address) to
   ///        use for the load.
-  LoadInst(SILDebugLocation DebugLoc, SILValue LValue)
+  LoadInst(SILDebugLocation DebugLoc, SILValue LValue,
+           LoadOwnershipQualifier Q = LoadOwnershipQualifier::Unqualified)
       : UnaryInstructionBase(DebugLoc, LValue,
-                             LValue->getType().getObjectType()) {}
+                             LValue->getType().getObjectType()),
+        OwnershipQualifier(Q) {}
+
+public:
+  LoadOwnershipQualifier getOwnershipQualifier() const {
+    return OwnershipQualifier;
+  }
+};
+
+enum class StoreOwnershipQualifier {
+  Unqualified, Init, Assign, Trivial
 };
 
 /// StoreInst - Represents a store from a memory location.
@@ -1690,8 +1707,10 @@ class StoreInst : public SILInstruction {
 
 private:
   FixedOperandList<2> Operands;
+  StoreOwnershipQualifier OwnershipQualifier;
 
-  StoreInst(SILDebugLocation DebugLoc, SILValue Src, SILValue Dest);
+  StoreInst(SILDebugLocation DebugLoc, SILValue Src, SILValue Dest,
+            StoreOwnershipQualifier Qualifier);
 
 public:
   enum {

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 275; // Last change: remove some unused bits
+const uint16_t VERSION_MINOR = 276; // Last change: add load inst, store inst
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -1482,6 +1482,58 @@ bool SILParser::parseSILDebugLocation(SILLocation &L, SILBuilder &B,
   return false;
 }
 
+static bool parseLoadOwnershipQualifier(LoadOwnershipQualifier &Result,
+                                        SILParser &P) {
+  StringRef Str;
+  // If we do not parse '[' ... ']', we have unqualified. Set value and return.
+  if (!parseSILOptional(Str, P)) {
+    Result = LoadOwnershipQualifier::Unqualified;
+    return false;
+  }
+
+  // Then try to parse one of our other qualifiers. We do not support parsing
+  // unqualified here so we use that as our fail value.
+  auto Tmp = llvm::StringSwitch<LoadOwnershipQualifier>(Str)
+                 .Case("take", LoadOwnershipQualifier::Take)
+                 .Case("copy", LoadOwnershipQualifier::Copy)
+                 .Case("trivial", LoadOwnershipQualifier::Trivial)
+                 .Default(LoadOwnershipQualifier::Unqualified);
+
+  // Thus return true (following the conventions in this file) if we fail.
+  if (Tmp == LoadOwnershipQualifier::Unqualified)
+    return true;
+
+  // Otherwise, assign Result and return false.
+  Result = Tmp;
+  return false;
+}
+
+static bool parseStoreOwnershipQualifier(StoreOwnershipQualifier &Result,
+                                         SILParser &P) {
+  StringRef Str;
+  // If we do not parse '[' ... ']', we have unqualified. Set value and return.
+  if (!parseSILOptional(Str, P)) {
+    Result = StoreOwnershipQualifier::Unqualified;
+    return false;
+  }
+
+  // Then try to parse one of our other qualifiers. We do not support parsing
+  // unqualified here so we use that as our fail value.
+  auto Tmp = llvm::StringSwitch<StoreOwnershipQualifier>(Str)
+                 .Case("init", StoreOwnershipQualifier::Init)
+                 .Case("assign", StoreOwnershipQualifier::Assign)
+                 .Case("trivial", StoreOwnershipQualifier::Trivial)
+                 .Default(StoreOwnershipQualifier::Unqualified);
+
+  // Thus return true (following the conventions in this file) if we fail.
+  if (Tmp == StoreOwnershipQualifier::Unqualified)
+    return true;
+
+  // Otherwise, assign Result and return false.
+  Result = Tmp;
+  return false;
+}
+
 /// sil-instruction-def ::= (sil-value-name '=')? sil-instruction
 ///                         (',' sil-scope-ref)? (',' sil-loc)?
 bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
@@ -1872,7 +1924,6 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
     UNARY_INSTRUCTION(IsUnique)
     UNARY_INSTRUCTION(IsUniqueOrPinned)
     UNARY_INSTRUCTION(DestroyAddr)
-    UNARY_INSTRUCTION(Load)
     UNARY_INSTRUCTION(CondFail)
     REFCOUNTING_INSTRUCTION(StrongPin)
     REFCOUNTING_INSTRUCTION(StrongRetain)
@@ -1899,6 +1950,19 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
      ResultVal = B.createDebugValue(InstLoc, Val, VarInfo);
    else
      ResultVal = B.createDebugValueAddr(InstLoc, Val, VarInfo);
+   break;
+ }
+
+ case ValueKind::LoadInst: {
+   LoadOwnershipQualifier Qualifier;
+   SourceLoc AddrLoc;
+
+   if (parseLoadOwnershipQualifier(Qualifier, *this) ||
+       parseTypedValueRef(Val, AddrLoc, B) || parseSILDebugLocation(InstLoc, B))
+     return true;
+
+   SILType Type = Val->getType();
+   ResultVal = B.createLoad(InstLoc, Val, Qualifier);
    break;
  }
 
@@ -2317,8 +2381,43 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
     break;
   }
 
+  case ValueKind::StoreInst: {
+    UnresolvedValueName From;
+    SourceLoc ToLoc, AddrLoc;
+    Identifier ToToken;
+    SILValue AddrVal;
+    StoreOwnershipQualifier Qualifier;
+    if (parseValueName(From) ||
+        parseSILIdentifier(ToToken, ToLoc, diag::expected_tok_in_sil_instr,
+                           "to"))
+      return true;
+
+    if (parseStoreOwnershipQualifier(Qualifier, *this))
+      return true;
+
+    if (parseTypedValueRef(AddrVal, AddrLoc, B) ||
+        parseSILDebugLocation(InstLoc, B))
+      return true;
+
+    if (ToToken.str() != "to") {
+      P.diagnose(ToLoc, diag::expected_tok_in_sil_instr, "to");
+      return true;
+    }
+
+    if (!AddrVal->getType().isAddress()) {
+      P.diagnose(AddrLoc, diag::sil_operand_not_address, "destination",
+                 OpcodeName);
+      return true;
+    }
+
+    SILType ValType = AddrVal->getType().getObjectType();
+
+    ResultVal = B.createStore(InstLoc, getLocalValue(From, ValType, InstLoc, B),
+                              AddrVal, Qualifier);
+    break;
+  }
+
   case ValueKind::AssignInst:
-  case ValueKind::StoreInst:
   case ValueKind::StoreUnownedInst:
   case ValueKind::StoreWeakInst: {
     UnresolvedValueName from;

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -656,8 +656,11 @@ uint64_t StringLiteralInst::getCodeUnitCount() {
   return Length;
 }
 
-StoreInst::StoreInst(SILDebugLocation Loc, SILValue Src, SILValue Dest)
-    : SILInstruction(ValueKind::StoreInst, Loc), Operands(this, Src, Dest) {}
+StoreInst::StoreInst(
+    SILDebugLocation Loc, SILValue Src, SILValue Dest,
+    StoreOwnershipQualifier Qualifier = StoreOwnershipQualifier::Unqualified)
+    : SILInstruction(ValueKind::StoreInst, Loc), Operands(this, Src, Dest),
+      OwnershipQualifier(Qualifier) {}
 
 AssignInst::AssignInst(SILDebugLocation Loc, SILValue Src, SILValue Dest)
     : SILInstruction(ValueKind::AssignInst, Loc), Operands(this, Src, Dest) {}

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1006,14 +1006,55 @@ public:
     }
     llvm_unreachable("bad string literal encoding");
   }
+
   void visitStringLiteralInst(StringLiteralInst *SLI) {
     *this << getStringEncodingName(SLI->getEncoding())
           << QuotedString(SLI->getValue());
   }
-  void visitLoadInst(LoadInst *LI) { *this << getIDAndType(LI->getOperand()); }
-  void visitStoreInst(StoreInst *SI) {
-    *this << getID(SI->getSrc()) << " to " << getIDAndType(SI->getDest());
+
+  void printLoadOwnershipQualifier(LoadOwnershipQualifier Qualifier) {
+    switch (Qualifier) {
+    case LoadOwnershipQualifier::Unqualified:
+      return;
+    case LoadOwnershipQualifier::Take:
+      *this << "[take] ";
+      return;
+    case LoadOwnershipQualifier::Copy:
+      *this << "[copy] ";
+      return;
+    case LoadOwnershipQualifier::Trivial:
+      *this << "[trivial] ";
+      return;
+    }
   }
+
+  void visitLoadInst(LoadInst *LI) {
+    printLoadOwnershipQualifier(LI->getOwnershipQualifier());
+    *this << getIDAndType(LI->getOperand());
+  }
+
+  void printStoreOwnershipQualifier(StoreOwnershipQualifier Qualifier) {
+    switch (Qualifier) {
+    case StoreOwnershipQualifier::Unqualified:
+      return;
+    case StoreOwnershipQualifier::Init:
+      *this << "[init] ";
+      return;
+    case StoreOwnershipQualifier::Assign:
+      *this << "[assign] ";
+      return;
+    case StoreOwnershipQualifier::Trivial:
+      *this << "[trivial] ";
+      return;
+    }
+  }
+
+  void visitStoreInst(StoreInst *SI) {
+    *this << getID(SI->getSrc()) << " to ";
+    printStoreOwnershipQualifier(SI->getOwnershipQualifier());
+    *this << getIDAndType(SI->getDest());
+  }
+
   void visitAssignInst(AssignInst *AI) {
     *this << getID(AI->getSrc()) << " to " << getIDAndType(AI->getDest());
   }

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1018,7 +1018,9 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
   case ValueKind::ReturnInst:
   case ValueKind::ThrowInst: {
     unsigned Attr = 0;
-    if (auto *LWI = dyn_cast<LoadWeakInst>(&SI))
+    if (auto *LI = dyn_cast<LoadInst>(&SI))
+      Attr = unsigned(LI->getOwnershipQualifier());
+    else if (auto *LWI = dyn_cast<LoadWeakInst>(&SI))
       Attr = LWI->isTake();
     else if (auto *LUI = dyn_cast<LoadUnownedInst>(&SI))
       Attr = LUI->isTake();
@@ -1273,6 +1275,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       operand = cast<StoreUnownedInst>(&SI)->getDest();
       value = cast<StoreUnownedInst>(&SI)->getSrc();
     } else if (SI.getKind() == ValueKind::StoreInst) {
+      Attr = unsigned(cast<StoreInst>(&SI)->getOwnershipQualifier());
       operand = cast<StoreInst>(&SI)->getDest();
       value = cast<StoreInst>(&SI)->getSrc();
     } else if (SI.getKind() == ValueKind::AssignInst) {

--- a/test/IRGen/ownership_qualified_memopts.sil
+++ b/test/IRGen/ownership_qualified_memopts.sil
@@ -1,0 +1,118 @@
+// First parse this and then emit a *.sib. Then read in the *.sib, then recreate
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+
+import Builtin
+
+// CHECK-LABEL: define {{.*}}void @unqualified_load
+// CHECK: load
+// CHECK-NOT: retain
+// CHECK-NOT: release
+// CHECK: ret void
+sil @unqualified_load : $@convention(thin) (@in Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject):
+  load %0 : $*Builtin.NativeObject
+  %1 = tuple()
+  return %1 : $()
+}
+
+// CHECK-LABEL: define {{.*}}void @take_load
+// CHECK-NOT: retain
+// CHECK: load
+// CHECK-NOT: retain
+// CHECK: ret void
+sil @take_load : $@convention(thin) (@in Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject):
+  load [take] %0 : $*Builtin.NativeObject
+  %1 = tuple()
+  return %1 : $()
+}
+
+// CHECK-LABEL: define {{.*}}void @copy_load
+// CHECK: load
+// CHECK: retain
+// CHECK: ret void
+sil @copy_load : $@convention(thin) (@in Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject):
+  load [copy] %0 : $*Builtin.NativeObject
+  %1 = tuple()
+  return %1 : $()
+}
+
+// CHECK-LABEL: define {{.*}}void @trivial_load
+// CHECK-NOT: retain
+// CHECK: load
+// CHECK-NOT: retain
+// CHECK: ret void
+sil @trivial_load : $@convention(thin) (@in Builtin.Int32) -> () {
+bb0(%0 : $*Builtin.Int32):
+  load [trivial] %0 : $*Builtin.Int32
+  %1 = tuple()
+  return %1 : $()
+}
+
+// CHECK-LABEL: define {{.*}}void @unqualified_store
+// CHECK-NOT: load
+// CHECK-NOT: release
+// CHECK: store
+// CHECK-NOT: load
+// CHECK-NOT: release
+// CHECK: ret void
+sil @unqualified_store : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject, %1 : $Builtin.NativeObject):
+  store %1 to %0 : $*Builtin.NativeObject
+  %2 = tuple()
+  return %2 : $()
+}
+
+// CHECK-LABEL: define {{.*}}void @init_store
+// CHECK-NOT: load
+// CHECK-NOT: release
+// CHECK: store
+// CHECK-NOT: load
+// CHECK-NOT: release
+// CHECK: ret void
+sil @init_store : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject, %1 : $Builtin.NativeObject):
+  store %1 to [init] %0 : $*Builtin.NativeObject
+  %2 = tuple()
+  return %2 : $()
+}
+
+// CHECK-LABEL: define {{.*}}void @assign_store
+// CHECK: load
+// CHECK: store
+// CHECK: release
+// CHECK: ret void
+sil @assign_store : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject, %1 : $Builtin.NativeObject):
+  store %1 to [assign] %0 : $*Builtin.NativeObject
+  %2 = tuple()
+  return %2 : $()
+}
+
+struct Foo {
+  var i: Builtin.Int32
+  var b: Builtin.NativeObject
+}
+
+sil @assign_store_2 : $@convention(thin) (@in Foo, Foo) -> () {
+bb0(%0 : $*Foo, %1 : $Foo):
+  %2 = load [copy] %0 : $*Foo
+  store %1 to [assign] %0 : $*Foo
+  %3 = tuple()
+  return %3 : $()
+}
+
+// CHECK-LABEL: define {{.*}}void @trivial_store
+// CHECK-NOT: load
+// CHECK-NOT: release
+// CHECK: store
+// CHECK-NOT: load
+// CHECK-NOT: release
+// CHECK: ret void
+sil @trivial_store : $@convention(thin) (@in Builtin.Int32, Builtin.Int32) -> () {
+bb0(%0 : $*Builtin.Int32, %1 : $Builtin.Int32):
+  store %1 to [trivial] %0 : $*Builtin.Int32
+  %2 = tuple()
+  return %2 : $()
+}

--- a/test/SIL/Parser/ownership_qualified_memopts.sil
+++ b/test/SIL/Parser/ownership_qualified_memopts.sil
@@ -1,0 +1,40 @@
+// We run this through sil-opt twice to test parsing -> printing -> parsing -> printing
+// RUN: %target-sil-opt %s | %target-sil-opt | %FileCheck %s
+
+import Builtin
+
+// CHECK-LABEL: sil @non_trivial : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
+// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : $Builtin.NativeObject):
+// CHECK: load [[ARG1]] : $*Builtin.NativeObject
+// CHECK: load [take] [[ARG1]] : $*Builtin.NativeObject
+// CHECK: load [copy] [[ARG1]] : $*Builtin.NativeObject
+// CHECK: store [[ARG2]] to [[ARG1]] : $*Builtin.NativeObject
+// CHECK: store [[ARG2]] to [init] [[ARG1]] : $*Builtin.NativeObject
+// CHECK: store [[ARG2]] to [assign] [[ARG1]] : $*Builtin.NativeObject
+sil @non_trivial : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject, %1 : $Builtin.NativeObject):
+  load %0 : $*Builtin.NativeObject
+  load [take] %0 : $*Builtin.NativeObject
+  load [copy] %0 : $*Builtin.NativeObject
+  store %1 to %0 : $*Builtin.NativeObject
+  store %1 to [init] %0 : $*Builtin.NativeObject
+  store %1 to [assign] %0 : $*Builtin.NativeObject
+  %2 = tuple()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil @trivial : $@convention(thin) (@in Builtin.Int32, Builtin.Int32) -> () {
+// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.Int32, [[ARG2:%[0-9]+]] : $Builtin.Int32):
+// CHECK: load [[ARG1]] : $*Builtin.Int32
+// CHECK: load [trivial] [[ARG1]] : $*Builtin.Int32
+// CHECK: store [[ARG2]] to [[ARG1]] : $*Builtin.Int32
+// CHECK: store [[ARG2]] to [trivial] [[ARG1]] : $*Builtin.Int32
+sil @trivial : $@convention(thin) (@in Builtin.Int32, Builtin.Int32) -> () {
+bb0(%0 : $*Builtin.Int32, %1 : $Builtin.Int32):
+  load %0 : $*Builtin.Int32
+  load [trivial] %0 : $*Builtin.Int32
+  store %1 to %0 : $*Builtin.Int32
+  store %1 to [trivial] %0 : $*Builtin.Int32
+  %2 = tuple()
+  return %2 : $()
+}

--- a/test/SIL/Serialization/ownership_qualified_memopts.sil
+++ b/test/SIL/Serialization/ownership_qualified_memopts.sil
@@ -1,0 +1,47 @@
+// First parse this and then emit a *.sib. Then read in the *.sib, then recreate
+// RUN: rm -rfv %t
+// RUN: mkdir %t
+// RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name ownership_qualified_memopts
+// RUN: %target-sil-opt %t/tmp.sib -o %t/tmp.2.sib -module-name ownership_qualified_memopts
+// RUN: %target-sil-opt %t/tmp.2.sib -module-name ownership_qualified_memopts | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+
+
+// CHECK-LABEL: sil @trivial : $@convention(thin) (@in Builtin.Int32, Builtin.Int32) -> () {
+// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.Int32, [[ARG2:%[0-9]+]] : $Builtin.Int32):
+// CHECK: load [[ARG1]] : $*Builtin.Int32
+// CHECK: load [trivial] [[ARG1]] : $*Builtin.Int32
+// CHECK: store [[ARG2]] to [[ARG1]] : $*Builtin.Int32
+// CHECK: store [[ARG2]] to [trivial] [[ARG1]] : $*Builtin.Int32
+sil @trivial : $@convention(thin) (@in Builtin.Int32, Builtin.Int32) -> () {
+bb0(%0 : $*Builtin.Int32, %1 : $Builtin.Int32):
+  load %0 : $*Builtin.Int32
+  load [trivial] %0 : $*Builtin.Int32
+  store %1 to %0 : $*Builtin.Int32
+  store %1 to [trivial] %0 : $*Builtin.Int32
+  %2 = tuple()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil @non_trivial : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
+// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : $Builtin.NativeObject):
+// CHECK: load [[ARG1]] : $*Builtin.NativeObject
+// CHECK: load [take] [[ARG1]] : $*Builtin.NativeObject
+// CHECK: load [copy] [[ARG1]] : $*Builtin.NativeObject
+// CHECK: store [[ARG2]] to [[ARG1]] : $*Builtin.NativeObject
+// CHECK: store [[ARG2]] to [init] [[ARG1]] : $*Builtin.NativeObject
+// CHECK: store [[ARG2]] to [assign] [[ARG1]] : $*Builtin.NativeObject
+sil @non_trivial : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject, %1 : $Builtin.NativeObject):
+  load %0 : $*Builtin.NativeObject
+  load [take] %0 : $*Builtin.NativeObject
+  load [copy] %0 : $*Builtin.NativeObject
+  store %1 to %0 : $*Builtin.NativeObject
+  store %1 to [init] %0 : $*Builtin.NativeObject
+  store %1 to [assign] %0 : $*Builtin.NativeObject
+  %2 = tuple()
+  return %2 : $()
+}


### PR DESCRIPTION
This PR adds a disabled by default flag to the SILVerifier called "EnforceSILOwnership". When the flag is enabled, the SILVerifier will verify that SIL Ownership contraints are followed by the IR. Today it just means that unqualified loads/stores are banned from the IR.

rdar://28685236
