### PR TITLE
[semantic-arc] Add a new pass called the OwnershipModelEliminator.

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -174,6 +174,9 @@ PASS(MoveCondFailToPreds, "move-cond-fail-to-preds",
      "profitable")
 PASS(NoReturnFolding, "noreturn-folding",
      "Add 'unreachable' after noreturn calls")
+PASS(OwnershipModelEliminator, "ownership-model-eliminator",
+     "Eliminate SIL ownership constructs that are not supported by the whole"
+     " compiler from the IR")
 PASS(RCIdentityDumper, "rc-id-dumper",
      "Dump the RCIdentity of all values in a function")
 // TODO: It makes no sense to have early inliner, late inliner, and

--- a/lib/SILOptimizer/Transforms/CMakeLists.txt
+++ b/lib/SILOptimizer/Transforms/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(TRANSFORMS_SOURCES
+  Transforms/ARCCodeMotion.cpp
   Transforms/AllocBoxToStack.cpp
   Transforms/ArrayCountPropagation.cpp
-  Transforms/ARCCodeMotion.cpp
   Transforms/ArrayElementValuePropagation.cpp
   Transforms/CSE.cpp
   Transforms/ConditionForwarding.cpp
@@ -13,6 +13,7 @@ set(TRANSFORMS_SOURCES
   Transforms/FunctionSignatureOpts.cpp
   Transforms/GenericSpecializer.cpp
   Transforms/MergeCondFail.cpp
+  Transforms/OwnershipModelEliminator.cpp
   Transforms/PerformanceInliner.cpp
   Transforms/RedundantLoadElimination.cpp
   Transforms/RedundantOverflowCheckRemoval.cpp

--- a/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
@@ -1,0 +1,143 @@
+//===- OwnershipModelEliminator.cpp - Eliminate SILOwnership Instructions -===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+///  \file
+///
+///  This file contains a small pass that lowers SIL ownership instructions to
+///  their constituant operations. This will enable us to separate
+///  implementation
+///  of Semantic ARC in SIL and SILGen from ensuring that all of the optimizer
+///  passes respect Semantic ARC. This is done by running this pass right after
+///  SILGen and as the pass pipeline is updated, moving this pass further and
+///  further back in the pipeline.
+///
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-ownership-model-eliminator"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SIL/SILBuilder.h"
+#include "swift/SIL/SILFunction.h"
+
+using namespace swift;
+
+//===----------------------------------------------------------------------===//
+//                               Implementation
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+struct OwnershipModelEliminator : SILFunctionTransform {
+
+  bool processLoad(SILBuilder &B, LoadInst *LI) {
+    auto Qualifier = LI->getOwnershipQualifier();
+
+    // If the qualifier is unqualified, there is nothing further to do
+    // here. Just return.
+    if (Qualifier == LoadOwnershipQualifier::Unqualified)
+      return false;
+
+    // Otherwise, we need to break down the load inst into its unqualified
+    // components.
+    B.setInsertionPoint(LI);
+    B.setCurrentDebugScope(LI->getDebugScope());
+    auto *UnqualifiedLoad = B.createLoad(LI->getLoc(), LI->getOperand());
+
+    // If we have a copy, insert a retain_value. All other copies do not require
+    // more work.
+    if (Qualifier == LoadOwnershipQualifier::Copy) {
+      B.createRetainValue(UnqualifiedLoad->getLoc(), UnqualifiedLoad,
+                          Atomicity::Atomic);
+    }
+
+    // Then remove the qualified load and use the unqualified load as the def of
+    // all of LI's uses.
+    LI->replaceAllUsesWith(UnqualifiedLoad);
+    LI->removeFromParent();
+    return true;
+  }
+
+  bool processStore(SILBuilder &B, StoreInst *SI) {
+    auto Qualifier = SI->getOwnershipQualifier();
+
+    // If the qualifier is unqualified, there is nothing further to do
+    // here. Just return.
+    if (Qualifier == StoreOwnershipQualifier::Unqualified)
+      return false;
+
+    // Otherwise, we need to break down the load.
+    B.setInsertionPoint(SI);
+    B.setCurrentDebugScope(SI->getDebugScope());
+
+    if (Qualifier != StoreOwnershipQualifier::Assign) {
+      // If the ownership qualifier is not an assign, we can just emit an
+      // unqualified store.
+      B.createStore(SI->getLoc(), SI->getSrc(), SI->getDest());
+    } else {
+      // If the ownership qualifier is [assign], then we need to eliminate the
+      // old value.
+      //
+      // 1. Load old value.
+      // 2. Store new value.
+      // 3. Release old value.
+      auto *Old = B.createLoad(SI->getLoc(), SI->getDest());
+      B.createStore(SI->getLoc(), SI->getSrc(), SI->getDest());
+      B.createReleaseValue(SI->getLoc(), Old, Atomicity::Atomic);
+    }
+
+    // Then remove the qualified store.
+    SI->removeFromParent();
+    return true;
+  }
+
+  void run() override {
+    bool MadeChange = false;
+    SILFunction *F = getFunction();
+    SILBuilder B(*F);
+    for (auto &BB : *F) {
+      for (auto II = BB.begin(), IE = BB.end(); II != IE;) {
+        // Since we are going to be potentially removing instructions, we need
+        // to make sure to grab out instruction and increment first.
+        SILInstruction *I = &*II;
+        ++II;
+
+        if (auto *LI = dyn_cast<LoadInst>(I)) {
+          MadeChange |= processLoad(B, LI);
+          continue;
+        }
+
+        auto *SI = dyn_cast<StoreInst>(I);
+        if (!SI)
+          continue;
+
+        MadeChange |= processStore(B, SI);
+      }
+    }
+
+    if (MadeChange) {
+      // If we made any changes, we just changed instructions, so invalidate
+      // that analysis.
+      invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
+    }
+  }
+
+  StringRef getName() override { return "Ownership Model Eliminator"; }
+};
+
+} // end anonymous namespace
+
+//===----------------------------------------------------------------------===//
+//                           Top Level Entry Point
+//===----------------------------------------------------------------------===//
+
+SILTransform *swift::createOwnershipModelEliminator() {
+  return new OwnershipModelEliminator();
+}

--- a/test/SILOptimizer/ownership_model_eliminator.sil
+++ b/test/SILOptimizer/ownership_model_eliminator.sil
@@ -1,0 +1,58 @@
+// RUN: %target-sil-opt -ownership-model-eliminator %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+
+sil @use_native_object : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+sil @use_int32 : $@convention(thin) (Builtin.Int32) -> ()
+
+// CHECK-LABEL: sil @load : $@convention(thin) (@in Builtin.NativeObject, @in Builtin.Int32) -> () {
+// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : $*Builtin.Int32):
+// CHECK: [[LOAD1:%[0-9]+]] = load [[ARG1]] : $*Builtin.NativeObject
+// CHECK: apply {{%[0-9]+}}([[LOAD1]])
+// CHECK: [[LOAD2:%[0-9]+]] = load [[ARG1]] : $*Builtin.NativeObject
+// CHECK: apply {{%[0-9]+}}([[LOAD2]])
+// CHECK: [[LOAD3:%[0-9]+]] = load [[ARG1]] : $*Builtin.NativeObject
+// CHECK: retain_value [[LOAD3]]
+// CHECK: apply {{%[0-9]+}}([[LOAD3]])
+// CHECK: [[LOAD4:%[0-9]+]] = load [[ARG2]] : $*Builtin.Int32
+// CHECK: apply {{%[0-9]+}}([[LOAD4]])
+sil @load : $@convention(thin) (@in Builtin.NativeObject, @in Builtin.Int32) -> () {
+bb0(%0 : $*Builtin.NativeObject, %1 : $*Builtin.Int32):
+  %use_native_object_func = function_ref @use_native_object : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+  %use_int32_func = function_ref @use_int32 : $@convention(thin) (Builtin.Int32) -> ()
+
+  %2 = load %0 : $*Builtin.NativeObject
+  apply %use_native_object_func(%2) : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+
+  %3 = load [take] %0 : $*Builtin.NativeObject
+  apply %use_native_object_func(%3) : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+
+  %4 = load [copy] %0 : $*Builtin.NativeObject
+  apply %use_native_object_func(%4) : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+
+  %5 = load [trivial] %1 : $*Builtin.Int32
+  apply %use_int32_func(%5) : $@convention(thin) (Builtin.Int32) -> ()
+
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @store : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject, @in Builtin.Int32, Builtin.Int32) -> ()
+// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : $Builtin.NativeObject, [[ARG3:%[0-9]+]] : $*Builtin.Int32, [[ARG4:%[0-9]+]] : $Builtin.Int32):
+// CHECK: store [[ARG2]] to [[ARG1]] : $*Builtin.NativeObject
+// CHECK: store [[ARG2]] to [[ARG1]] : $*Builtin.NativeObject
+// CHECK: [[OLDVAL:%[0-9]+]] = load [[ARG1]] : $*Builtin.NativeObject
+// CHECK: store [[ARG2]] to [[ARG1]] : $*Builtin.NativeObject
+// CHECK: release_value [[OLDVAL]]
+// CHECK: store [[ARG4]] to [[ARG3]] : $*Builtin.Int32
+sil @store : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject, @in Builtin.Int32, Builtin.Int32) -> () {
+bb0(%0 : $*Builtin.NativeObject, %1 : $Builtin.NativeObject, %2 : $*Builtin.Int32, %3 : $Builtin.Int32):
+  store %1 to %0 : $*Builtin.NativeObject
+  store %1 to [init] %0 : $*Builtin.NativeObject
+  store %1 to [assign] %0 : $*Builtin.NativeObject
+  store %3 to [trivial] %2 : $*Builtin.Int32
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
[semantic-arc] Add a new pass called the OwnershipModelEliminator that eliminates SILOwnership from the IR.

It currently just breaks up qualified loads/stores into their unqualified
constituant parts.

rdar://28685236
