### PR TITLE
[semantic-arc] When compiing with -enable-sil-ownership, run the Owne…

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -694,7 +694,8 @@ public:
 
   /// verify - Run the IR verifier to make sure that the SILFunction follows
   /// invariants.
-  void verify(bool SingleFunction=true) const;
+  void verify(bool SingleFunction = true,
+              bool EnforceSILOwnership = false) const;
 
   /// Pretty-print the SILFunction.
   void dump(bool Verbose) const;

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -551,7 +551,7 @@ public:
 
   /// \brief Run the SIL verifier to make sure that all Functions follow
   /// invariants.
-  void verify() const;
+  void verify(bool EnforceSILOwnership = false) const;
 
   /// Pretty-print the module.
   void dump(bool Verbose = false) const;

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -3490,12 +3490,12 @@ public:
 
 /// verify - Run the SIL verifier to make sure that the SILFunction follows
 /// invariants.
-void SILFunction::verify(bool SingleFunction) const {
+void SILFunction::verify(bool SingleFunction, bool EnforceSILOwnership) const {
 #ifndef NDEBUG
   // Please put all checks in visitSILFunction in SILVerifier, not here. This
   // ensures that the pretty stack trace in the verifier is included with the
   // back trace when the verifier crashes.
-  SILVerifier(*this, SingleFunction).verify();
+  SILVerifier(*this, SingleFunction, EnforceSILOwnership).verify();
 #endif
 }
 
@@ -3625,7 +3625,7 @@ void SILGlobalVariable::verify() const {
 }
 
 /// Verify the module.
-void SILModule::verify() const {
+void SILModule::verify(bool EnforceSILOwnership) const {
 #ifndef NDEBUG
   // Uniquing set to catch symbol name collisions.
   llvm::StringSet<> symbolNames;
@@ -3636,7 +3636,7 @@ void SILModule::verify() const {
       llvm::errs() << "Symbol redefined: " << f.getName() << "!\n";
       assert(false && "triggering standard assertion failure routine");
     }
-    f.verify(/*SingleFunction=*/ false);
+    f.verify(/*SingleFunction=*/false, EnforceSILOwnership);
   }
 
   // Check all globals.

--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -86,6 +86,14 @@ bool swift::runSILDiagnosticPasses(SILModule &Module) {
     return Ctx.hadError();
   }
 
+  // If SILOwnership is enabled, run the ownership model eliminator
+  if (Module.getOptions().EnableSILOwnership) {
+    PM.addOwnershipModelEliminator();
+    PM.runOneIteration();
+    PM.resetAndRemoveTransformations();
+    Module.verify(true);
+  }
+
   // Otherwise run the rest of diagnostics.
   PM.addCapturePromotion();
   PM.addAllocBoxToStack();


### PR DESCRIPTION
[semantic-arc] When compiing with -enable-sil-ownership, run the OwnershipModelEliminator right after SILGen and verify with SIL Ownership Enabled.

 rdar://28685236
