### PR TITLE
Added new frontend flag to accelerate clang importer

### DIFF
--- a/include/swift/ClangImporter/ClangImporterOptions.h
+++ b/include/swift/ClangImporter/ClangImporterOptions.h
@@ -70,6 +70,10 @@ public:
 
   /// If true ignore the swift bridged attribute.
   bool DisableSwiftBridgeAttr = false;
+
+  /// When set, don't validate module system headers. If a header is modified
+  /// and this is not set, clang will rebuild the module.
+  bool DisableModulesValidateSystemHeaders = false;
 };
 
 } // end namespace swift

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -227,6 +227,9 @@ def disable_sil_linking : Flag<["-"], "disable-sil-linking">,
 def dump_clang_diagnostics : Flag<["-"], "dump-clang-diagnostics">,
   HelpText<"Dump Clang diagnostics to stderr">;
 
+def disable_modules_validate_system_headers : Flag<["-"], "disable-modules-validate-system-headers">,
+  HelpText<"Disable modules validate system headers in the clang importer">;
+
 def emit_verbose_sil : Flag<["-"], "emit-verbose-sil">,
   HelpText<"Emit locations during SIL emission">;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -228,7 +228,7 @@ def dump_clang_diagnostics : Flag<["-"], "dump-clang-diagnostics">,
   HelpText<"Dump Clang diagnostics to stderr">;
 
 def disable_modules_validate_system_headers : Flag<["-"], "disable-modules-validate-system-headers">,
-  HelpText<"Disable modules validate system headers in the clang importer">;
+  HelpText<"Disable validating system headers in the Clang importer">;
 
 def emit_verbose_sil : Flag<["-"], "emit-verbose-sil">,
   HelpText<"Emit locations during SIL emission">;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -344,10 +344,6 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
           SHIMS_INCLUDE_FLAG, searchPathOpts.RuntimeResourcePath,
       });
 
-  if (!importerOpts.DisableModulesValidateSystemHeaders) {
-    invocationArgStrs.push_back("-fmodules-validate-system-headers");
-  }
-
   // Set C language options.
   if (triple.isOSDarwin()) {
     invocationArgStrs.insert(invocationArgStrs.end(), {
@@ -485,6 +481,10 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
 
     invocationArgStrs.push_back("-fapinotes-cache-path=");
     invocationArgStrs.back().append(moduleCachePath);
+  }
+
+  if (!importerOpts.DisableModulesValidateSystemHeaders) {
+    invocationArgStrs.push_back("-fmodules-validate-system-headers");
   }
 
   if (importerOpts.DetailedPreprocessingRecord) {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -326,7 +326,6 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
 
           // Enable modules
           "-fmodules",
-          "-fmodules-validate-system-headers",
           "-Werror=non-modular-include-in-framework-module",
           // Enable implicit module maps (implied by "-fmodules")
           "-fimplicit-module-maps",
@@ -344,6 +343,10 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
 
           SHIMS_INCLUDE_FLAG, searchPathOpts.RuntimeResourcePath,
       });
+
+  if (!importerOpts.DisableModulesValidateSystemHeaders) {
+    invocationArgStrs.push_back("-fmodules-validate-system-headers");
+  }
 
   // Set C language options.
   if (triple.isOSDarwin()) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -965,6 +965,8 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts,
 
   Opts.DisableSwiftBridgeAttr |= Args.hasArg(OPT_disable_swift_bridge_attr);
 
+  Opts.DisableModulesValidateSystemHeaders |= Args.hasArg(OPT_disable_modules_validate_system_headers);
+
   return false;
 }
 


### PR DESCRIPTION
This patch adds a new frontend flag `-disable-modules-validate-system-headers` that stops the clang importer from passing `-fmodules-validate-system-headers`. See clang for why you would want to pass this flag.
