### PR TITLE
[swiftc (76 vs. 5175)] Add crasher in swift::Type::transform(...)

### DIFF
--- a/validation-test/compiler_crashers/28439-swift-type-transform.swift
+++ b/validation-test/compiler_crashers/28439-swift-type-transform.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+func b<T{
+typealias e:T.h{return[.E == e
+var(


### PR DESCRIPTION
Add test case for crash triggered in `swift::Type::transform(...)`.

Current number of unresolved compiler crashers: 76 (5175 resolved)

Stack trace:

```
4  swift           0x00000000011b17fd swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 45
5  swift           0x000000000100781e swift::constraints::ConstraintSystem::openType(swift::Type, swift::constraints::ConstraintLocatorBuilder, llvm::DenseMap<swift::CanType, swift::TypeVariableType*, llvm::DenseMapInfo<swift::CanType>, llvm::detail::DenseMapPair<swift::CanType, swift::TypeVariableType*> >&) + 78
11 swift           0x0000000001134cee swift::Expr::walk(swift::ASTWalker&) + 46
12 swift           0x00000000010522c8 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) + 200
13 swift           0x00000000010786b6 swift::constraints::ConstraintSystem::Candidate::solve() + 358
14 swift           0x000000000107a8a8 swift::constraints::ConstraintSystem::shrink(swift::Expr*) + 280
15 swift           0x000000000107aa21 swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 65
16 swift           0x0000000000f5d42b swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 347
17 swift           0x0000000000f5ff1e swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 942
21 swift           0x000000000102f143 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 6547
22 swift           0x0000000001033b10 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4320
23 swift           0x0000000000f5d47f swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 431
24 swift           0x0000000000f5ff1e swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 942
27 swift           0x0000000000fe4193 swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 355
28 swift           0x0000000000fe3fe7 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 39
29 swift           0x0000000000fe4bec swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 188
31 swift           0x0000000000f998fb swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1291
32 swift           0x0000000000d10cc6 swift::CompilerInstance::performSema() + 3350
33 swift           0x000000000085dd0e swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 3422
34 swift           0x00000000008251ce main + 2878
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28439-swift-type-transform.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28439-swift-type-transform-c12af4.o
1.  While type-checking 'b' at validation-test/compiler_crashers/28439-swift-type-transform.swift:9:1
2.  While type-checking expression at [validation-test/compiler_crashers/28439-swift-type-transform.swift:10:16 - line:11:4] RangeText="{return[.E == e
3.  While type-checking expression at [validation-test/compiler_crashers/28439-swift-type-transform.swift:10:23 - line:10:30] RangeText="[.E == e"
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
