### PR TITLE
[swiftc (77 vs. 5175)] Add crasher in swift::TypeChecker::resolveIdentifierType(...)

### DIFF
--- a/validation-test/compiler_crashers/28440-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/compiler_crashers/28440-swift-typechecker-resolveidentifiertype.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+typealias f=(let a{let a={var:f.t


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::resolveIdentifierType(...)`.

Current number of unresolved compiler crashers: 77 (5175 resolved)

Assertion failure in [`lib/Sema/TypeCheckNameLookup.cpp (line 256)`](https://github.com/apple/swift/blob/master/lib/Sema/TypeCheckNameLookup.cpp#L256):

```
Assertion `!type->is<TupleType>()' failed.

When executing: swift::LookupResult swift::TypeChecker::lookupMember(swift::DeclContext *, swift::Type, swift::DeclName, NameLookupOptions)
```

Assertion context:

```
  // We handle our own overriding/shadowing filtering.
  subOptions &= ~NL_RemoveOverridden;
  subOptions &= ~NL_RemoveNonVisible;

  // We can't have tuple types here; they need to be handled elsewhere.
  assert(!type->is<TupleType>());

  // Local function that performs lookup.
  auto doLookup = [&]() {
    result.clear();

```

Stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckNameLookup.cpp:256: swift::LookupResult swift::TypeChecker::lookupMember(swift::DeclContext *, swift::Type, swift::DeclName, NameLookupOptions): Assertion `!type->is<TupleType>()' failed.
10 swift           0x0000000000feb94d swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 157
12 swift           0x0000000000fec95f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 159
13 swift           0x0000000000feb0f5 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 277
14 swift           0x0000000000fb646f swift::TypeChecker::typeCheckPattern(swift::Pattern*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) + 991
17 swift           0x0000000000f746d6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
20 swift           0x0000000000fe53f6 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 262
21 swift           0x000000000101101c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 812
22 swift           0x0000000000f5ffb4 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 1092
23 swift           0x0000000000f63125 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 309
24 swift           0x0000000000f6332d swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 237
27 swift           0x0000000000f746d6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
30 swift           0x0000000000fe4193 swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 355
31 swift           0x0000000000fe3fe7 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 39
32 swift           0x0000000000fe4bec swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 188
34 swift           0x0000000000f998fb swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1291
35 swift           0x0000000000d10cc6 swift::CompilerInstance::performSema() + 3350
36 swift           0x000000000085dd0e swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 3422
37 swift           0x00000000008251ce main + 2878
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28440-swift-typechecker-resolveidentifiertype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28440-swift-typechecker-resolveidentifiertype-b3204a.o
1.  While type-checking getter for a at validation-test/compiler_crashers/28440-swift-typechecker-resolveidentifiertype.swift:10:18
2.  While type-checking declaration 0x6dfbb00 at validation-test/compiler_crashers/28440-swift-typechecker-resolveidentifiertype.swift:10:20
3.  While type-checking expression at [validation-test/compiler_crashers/28440-swift-typechecker-resolveidentifiertype.swift:10:26 - line:10:33] RangeText="{var:f.t"
4.  While type-checking declaration 0x6dfba68 at validation-test/compiler_crashers/28440-swift-typechecker-resolveidentifiertype.swift:10:27
5.  While resolving type f.t at [validation-test/compiler_crashers/28440-swift-typechecker-resolveidentifiertype.swift:10:31 - line:10:33] RangeText="f.t"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
