### PR TITLE
[gardening] Remove unused argument otherArg in isFavoredParamAndArg(…)

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -506,7 +506,6 @@ namespace {
                             Type paramTy,
                             Expr *arg,
                             Type argTy,
-                            Expr *otherArg = nullptr,
                             Type otherArgTy = Type()) {
     // Determine the argument type.
     argTy = argTy->getLValueOrInOutObjectType();
@@ -925,9 +924,9 @@ namespace {
       
       return
         (isFavoredParamAndArg(CS, firstParamTy, firstArg, firstArgTy,
-                              secondArg, secondArgTy) ||
+                              secondArgTy) ||
          isFavoredParamAndArg(CS, secondParamTy, secondArg, secondArgTy,
-                              firstArg, firstArgTy)) &&
+                              firstArgTy)) &&
          firstParamTy->isEqual(secondParamTy) &&
         (!contextualTy || contextualTy->isEqual(resultTy));
     };


### PR DESCRIPTION
Remove unused argument `otherArg` in `isFavoredParamAndArg(…)`.

The argument `otherArg` was added in commit 49b833b.

This should probably be reviewed by @DougGregor.
