### PR TITLE
Updated TupleExpr's getSourceRange to inspect child elements source ranges

### DIFF
--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1322,14 +1322,26 @@ SourceRange TupleExpr::getSourceRange() const {
   } else if (getNumElements() == 0) {
     return { SourceLoc(), SourceLoc() };
   } else {
-    start = getElement(0)->getStartLoc();
+    // Scan forward for the first valid source loc.
+    for (Expr *expr : getElements()) {
+      start = expr->getStartLoc();
+      if (start.isValid()) {
+        break;
+      }
+    }
   }
   
   if (hasTrailingClosure() || RParenLoc.isInvalid()) {
     if (getNumElements() == 0) {
       return { SourceLoc(), SourceLoc() };
     } else {
-      end = getElements().back()->getEndLoc();
+      // Scan backwards for a valid source loc.
+      for (Expr *expr : reversed(getElements())) {
+        end = expr->getEndLoc();
+        if (end.isValid()) {
+          break;
+        }
+      }
     }
   } else {
     end = RParenLoc;

--- a/unittests/AST/SourceLocTests.cpp
+++ b/unittests/AST/SourceLocTests.cpp
@@ -141,7 +141,7 @@ TEST(SourceLoc, TupleExpr) {
       DeclNameLoc());
   
   auto four = new (C.Ctx) UnresolvedDeclRefExpr(
-      C.Ctx.getIdentifier("three"),
+      C.Ctx.getIdentifier("four"),
       DeclRefKind::Ordinary,
       DeclNameLoc(start.getAdvancedLoc(4)));
   


### PR DESCRIPTION
```
In a TupleExpr, if the parens are both invalid, then you can only have a
valid range iff both the first element and last element have valid ranges.
Source ranges also have the property:
  Start.isValid() == End.isValid()
For example, given the buffer "one", of the form:
(tuple_expr
  (declref_expr range=[test.swift:1:0 - line:1:2] ...)
  (declref_expr range=invalid ...))
the range of this TupleExpr is SourceLoc() (invalid).
      v invalid                v invalid
      (     one,         two   )
      valid ^    invalid ^
COL:  xxxxxx012xxxxxxxxxxxxxxxxx
but the SourceRange of 'one' is 1:0 - 1:2.
```

Also added triple and quadruple tests.
