### PR TITLE
Fixed a bug in StmtConditionElement::getSourceRange where it would create invalid source ranges

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4248,11 +4248,13 @@ public:
   SourceLoc getLoc() const { return EqualLoc; }
   SourceLoc getStartLoc() const {
     if (!isFolded()) return EqualLoc;
-    return (Dest->isImplicit() ? Src->getStartLoc() : Dest->getStartLoc());
+    return ( Dest->getStartLoc().isValid()
+           ? Dest->getStartLoc()
+           : Src->getStartLoc());
   }
   SourceLoc getEndLoc() const {
     if (!isFolded()) return EqualLoc;
-    return (Src->isImplicit() ? Dest->getEndLoc() : Src->getEndLoc());
+    return (Src->getEndLoc().isValid() ? Src->getEndLoc() : Dest->getEndLoc());
   }
   
   /// True if the node has been processed by binary expression folding.

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -326,18 +326,7 @@ SourceLoc StmtConditionElement::getStartLoc() const {
   case StmtConditionElement::CK_Availability:
     return getAvailability()->getStartLoc();
   case StmtConditionElement::CK_PatternBinding:
-    SourceLoc Start;
-    if (IntroducerLoc.isValid())
-      Start = IntroducerLoc;
-    else
-      Start = getPattern()->getStartLoc();
-    
-    SourceLoc End = getInitializer()->getEndLoc();
-    if (Start.isValid() && End.isValid()) {
-      return Start;
-    } else {
-      return SourceLoc();
-    }
+    return getSourceRange().Start;
   }
 }
 
@@ -348,18 +337,7 @@ SourceLoc StmtConditionElement::getEndLoc() const {
   case StmtConditionElement::CK_Availability:
     return getAvailability()->getEndLoc();
   case StmtConditionElement::CK_PatternBinding:
-    SourceLoc Start;
-    if (IntroducerLoc.isValid())
-      Start = IntroducerLoc;
-    else
-      Start = getPattern()->getStartLoc();
-  
-    SourceLoc End = getInitializer()->getEndLoc();
-    if (Start.isValid() && End.isValid()) {
-      return End;
-    } else {
-      return SourceLoc();
-    }
+    return getSourceRange().End;
   }
 }
 

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -309,8 +309,13 @@ SourceRange StmtConditionElement::getSourceRange() const {
       Start = IntroducerLoc;
     else
       Start = getPattern()->getStartLoc();
-
-    return SourceRange(Start, getInitializer()->getEndLoc());
+    
+    SourceLoc End = getInitializer()->getEndLoc();
+    if (Start.isValid() && End.isValid()) {
+      return SourceRange(Start, End);
+    } else {
+      return SourceRange();
+    }
   }
 }
 
@@ -321,9 +326,18 @@ SourceLoc StmtConditionElement::getStartLoc() const {
   case StmtConditionElement::CK_Availability:
     return getAvailability()->getStartLoc();
   case StmtConditionElement::CK_PatternBinding:
+    SourceLoc Start;
     if (IntroducerLoc.isValid())
-      return IntroducerLoc;
-    return getPattern()->getStartLoc();
+      Start = IntroducerLoc;
+    else
+      Start = getPattern()->getStartLoc();
+    
+    SourceLoc End = getInitializer()->getEndLoc();
+    if (Start.isValid() && End.isValid()) {
+      return Start;
+    } else {
+      return SourceLoc();
+    }
   }
 }
 
@@ -334,7 +348,18 @@ SourceLoc StmtConditionElement::getEndLoc() const {
   case StmtConditionElement::CK_Availability:
     return getAvailability()->getEndLoc();
   case StmtConditionElement::CK_PatternBinding:
-    return getInitializer()->getEndLoc();
+    SourceLoc Start;
+    if (IntroducerLoc.isValid())
+      Start = IntroducerLoc;
+    else
+      Start = getPattern()->getStartLoc();
+  
+    SourceLoc End = getInitializer()->getEndLoc();
+    if (Start.isValid() && End.isValid()) {
+      return End;
+    } else {
+      return SourceLoc();
+    }
   }
 }
 

--- a/unittests/AST/SourceLocTests.cpp
+++ b/unittests/AST/SourceLocTests.cpp
@@ -50,6 +50,12 @@ TEST(SourceLoc, AssignExpr) {
       C.Ctx.getIdentifier("bb"),
       DeclNameLoc(start.getAdvancedLoc(3)),
       /*implicit*/false);
+  auto destImplicit = new (C.Ctx) UnresolvedDotExpr(
+      destBase,
+      start.getAdvancedLoc(2),
+      C.Ctx.getIdentifier("bb"),
+      DeclNameLoc(start.getAdvancedLoc(3)),
+      /*implicit*/true);
 
   auto sourceBase = new (C.Ctx) UnresolvedDeclRefExpr(
       C.Ctx.getIdentifier("cc"),
@@ -61,6 +67,13 @@ TEST(SourceLoc, AssignExpr) {
       C.Ctx.getIdentifier("dd"),
       DeclNameLoc(start.getAdvancedLoc(11)),
       /*implicit*/false);
+  auto sourceImplicit = new (C.Ctx) UnresolvedDotExpr(
+      sourceBase,
+      start.getAdvancedLoc(10),
+      C.Ctx.getIdentifier("dd"),
+      DeclNameLoc(start.getAdvancedLoc(11)),
+      /*implicit*/true);
+
 
   auto invalid = new (C.Ctx) UnresolvedDeclRefExpr(
       C.Ctx.getIdentifier("invalid"),
@@ -76,8 +89,30 @@ TEST(SourceLoc, AssignExpr) {
   EXPECT_EQ(SourceRange(start, start.getAdvancedLoc(11)),
             complete->getSourceRange());
 
+  // Implicit dest should not change the source range.
+  auto completeImplDest = new (C.Ctx) AssignExpr( destImplicit
+                                                , start.getAdvancedLoc(6)
+                                                , source, /*implicit*/false);
+  EXPECT_EQ(start, completeImplDest->getStartLoc());
+  EXPECT_EQ(start.getAdvancedLoc(6), completeImplDest->getEqualLoc());
+  EXPECT_EQ(start.getAdvancedLoc(6), completeImplDest->getLoc());
+  EXPECT_EQ(start.getAdvancedLoc(11), completeImplDest->getEndLoc());
+  EXPECT_EQ(SourceRange(start, start.getAdvancedLoc(11)),
+            completeImplDest->getSourceRange());
+
+  // Implicit source should not change the source range.
+  auto completeImplSrc = new (C.Ctx) AssignExpr( dest, start.getAdvancedLoc(6)
+                                               , sourceImplicit
+                                               , /*implicit*/false);
+  EXPECT_EQ(start, completeImplSrc->getStartLoc());
+  EXPECT_EQ(start.getAdvancedLoc(6), completeImplSrc->getEqualLoc());
+  EXPECT_EQ(start.getAdvancedLoc(6), completeImplSrc->getLoc());
+  EXPECT_EQ(start.getAdvancedLoc(11), completeImplSrc->getEndLoc());
+  EXPECT_EQ(SourceRange(start, start.getAdvancedLoc(11)),
+            completeImplSrc->getSourceRange());
+
   auto invalidSource = new (C.Ctx) AssignExpr(dest, SourceLoc(), invalid,
-                                              /*implicit*/true);
+                                              /*implicit*/false);
   EXPECT_EQ(start, invalidSource->getStartLoc());
   EXPECT_EQ(SourceLoc(), invalidSource->getEqualLoc());
   EXPECT_EQ(SourceLoc(), invalidSource->getLoc());
@@ -86,7 +121,7 @@ TEST(SourceLoc, AssignExpr) {
             invalidSource->getSourceRange());
 
   auto invalidDest = new (C.Ctx) AssignExpr(invalid, SourceLoc(), source,
-                                            /*implicit*/true);
+                                            /*implicit*/false);
   EXPECT_EQ(start.getAdvancedLoc(8), invalidDest->getStartLoc());
   EXPECT_EQ(SourceLoc(), invalidDest->getEqualLoc());
   EXPECT_EQ(SourceLoc(), invalidDest->getLoc());
@@ -95,7 +130,7 @@ TEST(SourceLoc, AssignExpr) {
             invalidDest->getSourceRange());
 
   auto invalidAll = new (C.Ctx) AssignExpr(invalid, SourceLoc(), invalid,
-                                           /*implicit*/true);
+                                           /*implicit*/false);
   EXPECT_EQ(SourceLoc(), invalidAll->getStartLoc());
   EXPECT_EQ(SourceLoc(), invalidAll->getEqualLoc());
   EXPECT_EQ(SourceLoc(), invalidAll->getLoc());


### PR DESCRIPTION
Fixed a bug in StmtConditionElement::getSourceRange where it would create invalid source ranges.

This bug was causing an assert. Now it creates valid source ranges.
