### PR TITLE
Check for null or error type and return if we hit either.

### DIFF
--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -536,6 +536,12 @@ public:
     // Casting to an ObjC class doesn't require the metadata of its type
     // parameters, if any.
     if (auto cast = dyn_cast<CheckedCastExpr>(E)) {
+      // If we failed to resolve the written type, we've emitted an
+      // earlier diagnostic and should bail.
+      auto toTy = cast->getCastTypeLoc().getType();
+      if (!toTy || toTy->hasError())
+        return false;
+
       if (auto clas = dyn_cast_or_null<ClassDecl>(
                          cast->getCastTypeLoc().getType()->getAnyNominal())) {
         if (clas->usesObjCGenericsModel()) {

--- a/test/expr/cast/array_downcast_Foundation.swift
+++ b/test/expr/cast/array_downcast_Foundation.swift
@@ -58,3 +58,11 @@ func testDowncastOptionalObjectConditional(obj: AnyObject?!) -> [String]?? {
   return obj as? [String]?
 }
 
+// Do not crash examining the casted-to (or tested) type if it is
+// invalid (null or error_type).
+class rdar28583595 : NSObject {
+  public func test(i: Int) {
+    if i is Array {} // expected-error {{generic parameter 'Element' could not be inferred}}
+    // expected-note@-1 {{explicitly specify the generic arguments to fix this issue}}
+  }
+}


### PR DESCRIPTION
In usesTypeMetadataOfFormalType(), bail out if we're checking a cast and
the casted-to type is null or error_type. We would have already emitted
a diagnostic on the function body by this point and this avoids crashing
immediately after.

Suggestions on a better place for the test would be welcome. The crash
requires the cast to be in the body of a function in an NSObject-derived
cast.

Resolves rdar://problem/28583595.
