### PR TITLE
[swiftc (78 vs. 5175)] Add crasher in swift::TypeRepr::walk(...)

### DIFF
--- a/validation-test/compiler_crashers/28441-swift-typerepr-walk.swift
+++ b/validation-test/compiler_crashers/28441-swift-typerepr-walk.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+func a<T{{var _=[T:b}class b<A>


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeRepr::walk(...)`.

Current number of unresolved compiler crashers: 78 (5175 resolved)

Stack trace:

```
6  swift           0x000000000113673a swift::TypeRepr::walk(swift::ASTWalker&) + 42
9  swift           0x0000000001030a63 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 6547
10 swift           0x0000000001035430 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4320
11 swift           0x0000000000f5ed9f swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 431
12 swift           0x0000000000f6183e swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 942
13 swift           0x0000000000f64a45 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 309
14 swift           0x0000000000f64c4d swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 237
17 swift           0x0000000000f75ff6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
20 swift           0x0000000000fe6d16 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 262
21 swift           0x000000000101293c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 812
22 swift           0x0000000000f618d4 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 1092
25 swift           0x0000000000fe5ab3 swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 355
26 swift           0x0000000000fe5907 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 39
27 swift           0x0000000000fe650c swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 188
29 swift           0x0000000000f9b21b swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1291
30 swift           0x0000000000d11456 swift::CompilerInstance::performSema() + 3350
31 swift           0x000000000085ddee swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 3422
32 swift           0x00000000008252ae main + 2878
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28441-swift-typerepr-walk.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28441-swift-typerepr-walk-dca6bf.o
1.  While type-checking 'a' at validation-test/compiler_crashers/28441-swift-typerepr-walk.swift:9:1
2.  While type-checking expression at [validation-test/compiler_crashers/28441-swift-typerepr-walk.swift:9:10 - line:9:21] RangeText="{var _=[T:b}"
3.  While type-checking declaration 0x5ff47d8 at validation-test/compiler_crashers/28441-swift-typerepr-walk.swift:9:11
4.  While type-checking expression at [validation-test/compiler_crashers/28441-swift-typerepr-walk.swift:9:17 - line:9:20] RangeText="[T:b"
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
