### PR TITLE
Fix example snippet in Bool.swift

### DIFF
--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -26,7 +26,7 @@
 ///     print(containsTen)
 ///     // Prints "false"
 ///
-///     let (a, b) == (100, 101)
+///     let (a, b) = (100, 101)
 ///     let aFirst = a < b
 ///     print(aFirst)
 ///     // Prints "true"


### PR DESCRIPTION
<!-- What's in this pull request? -->

This PR updates one of the example snippets in `Bool.swift` which does not compile because it is a syntax error.

Because this is a trivial change and does not even touch the code (only comments) at all, I guess a CI build should not be necessary?

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
