### PR TITLE
Move property_behavior tests into "Prototypes" dir.

### DIFF
--- a/test/Prototypes/property_behaviors/delayed.swift
+++ b/test/Prototypes/property_behaviors/delayed.swift
@@ -6,6 +6,9 @@
 
 import StdlibUnittest
 
+/// An immutable property with "delayed" initialization semantics. The property
+/// may be set at most once, after which it is not allowed to be mutated.
+/// The property must also be set before it is ever read.
 protocol delayedImmutable {
   associatedtype Value
   var storage: Value? { get set }
@@ -34,41 +37,8 @@ extension delayedImmutable {
   }
 }
 
-protocol lazy {
-  associatedtype Value
-  var storage: Value? { get set }
-  func parameter() -> Value
-}
-extension lazy {
-  var value: Value {
-    mutating get {
-      if let existing = storage {
-        return existing
-      }
-      let value = parameter()
-      storage = value
-      return value
-    }
-    
-    set {
-      storage = newValue
-    }
-  }
-
-  static func initStorage() -> Value? {
-    return nil
-  }
-}
-
-var lazyEvaluated = false
-func evaluateLazy() -> Int {
-  lazyEvaluated = true
-  return 1738
-}
-
 class Foo {
   var x: Int __behavior delayedImmutable
-  var y: Int __behavior lazy { evaluateLazy() }
 }
 
 var DelayedImmutable = TestSuite("DelayedImmutable")
@@ -90,35 +60,6 @@ DelayedImmutable.test("write after initialization") {
   foo.x = 679
   expectCrashLater()
   foo.x = 680
-}
-
-var Lazy = TestSuite("Lazy")
-
-Lazy.test("usage") {
-  let foo = Foo()
-
-  expectFalse(lazyEvaluated)
-  expectEqual(foo.y, 1738)
-  expectTrue(lazyEvaluated)
-
-  lazyEvaluated = false
-  expectEqual(foo.y, 1738)
-  expectFalse(lazyEvaluated)
-
-  foo.y = 36
-  expectEqual(foo.y, 36)
-  expectFalse(lazyEvaluated)
-
-  let foo2 = Foo()
-  expectFalse(lazyEvaluated)
-  foo2.y = 36
-  expectEqual(foo2.y, 36)
-  expectFalse(lazyEvaluated)
-
-  let foo3 = Foo()
-  expectFalse(lazyEvaluated)
-  expectEqual(foo3.y, 1738)
-  expectTrue(lazyEvaluated)
 }
 
 runAllTests()

--- a/test/Prototypes/property_behaviors/lazy.swift
+++ b/test/Prototypes/property_behaviors/lazy.swift
@@ -1,0 +1,78 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: %target-build-swift -Xfrontend -enable-experimental-property-behaviors %s -o %t/a.out
+// RUN: %target-run %t/a.out
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+/// A lazily-initialized, mutable, unsynchronized property. The property's
+/// parameter closure is evaluated the first time the property is read, if
+/// it has not been written to beforehand. No synchronization is provided
+/// for the lazy initialization.
+protocol lazy {
+  associatedtype Value
+  var storage: Value? { get set }
+  func parameter() -> Value
+}
+extension lazy {
+  var value: Value {
+    mutating get {
+      if let existing = storage {
+        return existing
+      }
+      let value = parameter()
+      storage = value
+      return value
+    }
+    
+    set {
+      storage = newValue
+    }
+  }
+
+  static func initStorage() -> Value? {
+    return nil
+  }
+}
+
+var lazyEvaluated = false
+func evaluateLazy() -> Int {
+  lazyEvaluated = true
+  return 1738
+}
+
+class Foo {
+  var y: Int __behavior lazy { evaluateLazy() }
+}
+
+var Lazy = TestSuite("Lazy")
+
+Lazy.test("usage") {
+  let foo = Foo()
+
+  expectFalse(lazyEvaluated)
+  expectEqual(foo.y, 1738)
+  expectTrue(lazyEvaluated)
+
+  lazyEvaluated = false
+  expectEqual(foo.y, 1738)
+  expectFalse(lazyEvaluated)
+
+  foo.y = 36
+  expectEqual(foo.y, 36)
+  expectFalse(lazyEvaluated)
+
+  let foo2 = Foo()
+  expectFalse(lazyEvaluated)
+  foo2.y = 36
+  expectEqual(foo2.y, 36)
+  expectFalse(lazyEvaluated)
+
+  let foo3 = Foo()
+  expectFalse(lazyEvaluated)
+  expectEqual(foo3.y, 1738)
+  expectTrue(lazyEvaluated)
+}
+
+runAllTests()


### PR DESCRIPTION
The "lazy" and "delayed" test cases reflect things we could conceivably bring into the standard library at some point, and the separate files make it more clear to experimenters how the partially-implemented bits of the feature manage to work.
