### PR TITLE
[SR-2855] Show args mismatch in -driver-show-incremental

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -342,6 +342,10 @@ static bool populateOutOfDateMap(InputInfoMap &map, StringRef argsHashStr,
   }
 
   if (!optionsMatch) {
+    if (ShowIncrementalBuildDecisions) {
+      llvm::outs() << "Incremental compilation has been disabled, because "
+                   << "different arguments were passed to the compiler.\n";
+    }
     return true;
   }
 

--- a/test/Driver/Dependencies/driver-show-incremental-arguments.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-arguments.swift
@@ -1,0 +1,22 @@
+// Test that when:
+//
+// 1. Using -incremental -v -driver-show-incremental, and...
+// 2. ...the arguments passed to the Swift compiler version differ from the ones
+//    used in the original compilation...
+//
+// ...then the driver prints a message indicating that incremental compilation
+// is disabled.
+
+
+// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %S/Inputs/touch.py 443865900 %t/*
+// RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
+
+// RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
+// CHECK-INCREMENTAL-NOT: Incremental compilation has been disabled
+// CHECK-INCREMENTAL: Queuing main.swift (initial)
+
+// RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-ARGS-MISMATCH %s
+// CHECK-ARGS-MISMATCH: Incremental compilation has been disabled{{.*}}different arguments
+// CHECK-ARGS-MISMATCH-NOT: Queuing main.swift (initial)
+


### PR DESCRIPTION
<!-- What's in this pull request? -->

SR-2855 suggests `-driver-show-incremental` not only print information about why certain files are included in incremental compilation, but also print out why incremental compilation may be disabled altogether.

Add a message for one such reason: when the arguments passed to the Swift compiler don't match the ones used previously.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

This addresses one part of [SR-2855](https://bugs.swift.org/browse/SR-2855).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
