### PR TITLE
[SR-2855] Show inputs mismatch in -driver-show-incremental

### DIFF
--- a/test/Driver/Dependencies/driver-show-incremental-inputs.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-inputs.swift
@@ -1,8 +1,8 @@
 // Test that when:
 //
 // 1. Using -incremental -v -driver-show-incremental, and...
-// 2. ...the Swift compiler version used to perform the incremental
-//    compilation differs the original compilation...
+// 2. ...the inputs passed to the Swift compiler version differ from the ones
+//    used in the original compilation...
 //
 // ...then the driver prints a message indicating that incremental compilation
 // is disabled.
@@ -10,16 +10,14 @@
 
 // RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
 // RUN: %S/Inputs/touch.py 443865900 %t/*
-
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
+
 // RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
 // CHECK-INCREMENTAL-NOT: Incremental compilation has been disabled
 // CHECK-INCREMENTAL: Queuing main.swift (initial)
 
-// RUN: echo '{version: "bogus", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-VERSION-MISMATCH %s
-// CHECK-VERSION-MISMATCH: Incremental compilation has been disabled{{.*}}compiler version mismatch
-// CHECK-VERSION-MISMATCH: Compiling with:
-// CHECK-VERSION-MISMATCH: Previously compiled with: bogus
-// CHECK-VERSION-MISMATCH-NOT: Queuing main.swift (initial)
+// RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -c ./main.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INPUTS-MISMATCH %s
+// CHECK-INPUTS-MISMATCH: Incremental compilation has been disabled{{.*}}inputs
+// CHECK-INPUTS-MISMATCH: ./other.swift
+// CHECK-INPUTS-MISMATCH-NOT: Queuing main.swift (initial)
 


### PR DESCRIPTION
<!-- What's in this pull request? -->

SR-2855 suggests `-driver-show-incremental` not only print information about why certain files are included in incremental compilation, but also print out why incremental compilation may be disabled altogether.

Add a message for one such reason: when the inputs passed to the Swift compiler don't match the ones used previously.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

This addresses one part of [SR-2855](https://bugs.swift.org/browse/SR-2855).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
