### PR TITLE
[SILGen] Don't print double `$` signs in DEBUG output

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -597,7 +597,7 @@ void SILGenModule::preEmitFunction(SILDeclRef constant,
 
   DEBUG(llvm::dbgs() << "lowering ";
         F->printName(llvm::dbgs());
-        llvm::dbgs() << " : $";
+        llvm::dbgs() << " : ";
         F->getLoweredType().print(llvm::dbgs());
         llvm::dbgs() << '\n';
         if (astNode) {


### PR DESCRIPTION
The print function on SILType already prepends a `$` sign to the type resulting in `$$@...`
