### PR TITLE
Suppress silly diagnostics from `@objc` near-miss checking

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4858,7 +4858,11 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
       if (!value) continue;
       if (isa<TypeDecl>(value)) continue;
       if (!value->getFullName()) continue;
-      
+
+      // If this declaration overrides another declaration, the signature is
+      // fixed; don't complain about near misses.
+      if (value->getOverriddenDecl()) continue;
+
       // If this member is a witness to any @objc requirement, ignore it.
       if (!findWitnessedObjCRequirements(value, /*anySingleRequirement=*/true)
             .empty())

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4848,18 +4848,6 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
   // If there were any unsatisfied requirements, check whether there
   // are any near-matches we should diagnose.
   if (!unsatisfiedReqs.empty() && !anyInvalid) {
-    // Collect the set of witnesses that came from this context.
-    llvm::SmallPtrSet<ValueDecl *, 16> knownWitnesses;
-    for (auto conformance : conformances) {
-      conformance->forEachValueWitness(
-        nullptr,
-        [&](ValueDecl *req, ConcreteDeclRef witness) {
-          // If there is a witness, record it if it's within this context.
-          if (witness.getDecl() && witness.getDecl()->getDeclContext() == dc)
-            knownWitnesses.insert(witness.getDecl());
-         });
-    }
-
     // Find all of the members that aren't used to satisfy
     // requirements, and check whether they are close to an
     // unsatisfied or defaulted requirement.
@@ -4869,8 +4857,12 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
       auto value = dyn_cast<ValueDecl>(member);
       if (!value) continue;
       if (isa<TypeDecl>(value)) continue;
-      if (knownWitnesses.count(value) > 0) continue;
       if (!value->getFullName()) continue;
+      
+      // If this member is a witness to any @objc requirement, ignore it.
+      if (!findWitnessedObjCRequirements(value, /*anySingleRequirement=*/true)
+            .empty())
+        continue;
 
       // Find the unsatisfied requirements with the nearest-matching
       // names.

--- a/test/decl/protocol/conforms/near_miss_objc.swift
+++ b/test/decl/protocol/conforms/near_miss_objc.swift
@@ -119,3 +119,18 @@ class C7a : P7 {
   // expected-note@-4{{make 'method(foo:)' private to silence this warning}}
 }
 
+// Don't complain about near-misses that satisfy other protocol
+// requirements.
+@objc protocol P8 {
+  @objc optional func foo(exactMatch: Int)
+}
+
+@objc protocol P9 : P8 {
+  @objc optional func foo(nearMatch: Int)
+}
+
+class C8Super : P8 { }
+
+class C9Sub : C8Super, P9 {
+  func foo(exactMatch: Int) { }
+}

--- a/test/decl/protocol/conforms/near_miss_objc.swift
+++ b/test/decl/protocol/conforms/near_miss_objc.swift
@@ -119,7 +119,7 @@ class C7a : P7 {
   // expected-note@-4{{make 'method(foo:)' private to silence this warning}}
 }
 
-// Don't complain about near-misses that satisfy other protocol
+// Don't complain about near misses that satisfy other protocol
 // requirements.
 @objc protocol P8 {
   @objc optional func foo(exactMatch: Int)
@@ -133,4 +133,14 @@ class C8Super : P8 { }
 
 class C9Sub : C8Super, P9 {
   func foo(exactMatch: Int) { }
+}
+
+// Don't complain about overriding methods that are near misses;
+// the user cannot make it satisfy the protocol requirement.
+class C10Super {
+  func foo(nearMatch: Int) { }
+}
+
+class C10Sub : C10Super, P8 {
+  override func foo(nearMatch: Int) { }
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->

When `@objc` inference was extended to look at the conformances of
superclasses, the code that diagnosed near misses was not similarly
updated, so we could end up producing a near-miss diagnostic on a
declaration that was already a witness to another protocol. Use the
same witness-finding logic that we use for `@objc` inference so this
doesn't happen again.

Also, don't complain about overriding declarations in near-miss checking.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [rdar://problem/27348369](rdar://problem/27348369) and [rdar://problem/28524237](rdar://problem/28524237).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
