### PR TITLE
[ASTVerifier] Crash in a nice way if the last GenericEnvironment is NULL

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -437,7 +437,7 @@ struct ASTNodeBase {};
           }
 
           // Otherwise, the archetype needs to be from this scope.
-          if (GenericEnv.empty()) {
+          if (GenericEnv.empty() || !GenericEnv.back()) {
             Out << "AST verification error: archetype outside of generic "
                    "context: " << archetype->getString() << "\n";
             return true;


### PR DESCRIPTION
On every `pushScope` the generic environment of this scope is appended
to `GenericEnv`.  If the pushed `DeclContext` isn't generic, `NULL` is
pushed leading to a crash only in `DenseMap::find` if some archetypes
escaped their generic context.
