### PR TITLE
fixup header symlink issue due to clang 3.8 assumption

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -1933,7 +1933,7 @@ iterations with -O",
         "--clang-user-visible-version",
         help="User-visible version of the embedded Clang and LLVM compilers",
         type=arguments.type.clang_compiler_version,
-        default="3.8.0",
+        default="4.0.0",
         metavar="MAJOR.MINOR.PATCH")
     parser.add_argument(
         "--swift-compiler-version",

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -165,7 +165,7 @@ KNOWN_SETTINGS=(
     native-clang-tools-path     ""               "directory that contains Clang tools that are executable on the build machine"
     native-swift-tools-path     ""               "directory that contains Swift tools that are executable on the build machine"
     compiler-vendor             "none"           "compiler vendor name [none,apple]"
-    clang-user-visible-version  "3.8.0"          "user-visible version of the embedded Clang and LLVM compilers"
+    clang-user-visible-version  "4.0.0"          "user-visible version of the embedded Clang and LLVM compilers"
     swift-user-visible-version  "3.0"            "user-visible version of the Swift language"
     swift-compiler-version      ""               "string that indicates a compiler version for Swift"
     clang-compiler-version      ""               "string that indicates a compiler version for Clang"

--- a/utils/swift_build_support/swift_build_support/products/llvm.py
+++ b/utils/swift_build_support/swift_build_support/products/llvm.py
@@ -46,7 +46,7 @@ class LLVM(product.Product):
         return [
             "-DCLANG_VENDOR=Apple",
             "-DCLANG_VENDOR_UTI=com.apple.compilers.llvm.clang",
-            # This is safe since we always provide a default of 3.8.0
+            # This is safe since we always provide a default.
             "-DPACKAGE_VERSION={}".format(self.args.clang_user_visible_version)
         ]
 


### PR DESCRIPTION
The master-next branch brought in clang 4.0 in a recent merge.
Fix the CI that is breaking when trying to link in the 3.8-specific
headers.

Candidate fix for broken master-next CI.
