### PR TITLE
1. Use correct URLs in thunk

### DIFF
--- a/stdlib/public/SDK/Foundation/FileManager.swift
+++ b/stdlib/public/SDK/Foundation/FileManager.swift
@@ -17,7 +17,7 @@ internal func NS_Swift_NSFileManager_replaceItemAtURL_withItemAtURL_backupItemNa
     _ self_: AnyObject,
     _ originalItemURL: AnyObject,
     _ newItemURL: AnyObject,
-    _ backupItemName: String?,
+    _ backupItemName: NSString?,
     _ options: FileManager.ItemReplacementOptions,
     _ error: NSErrorPointer) -> NSURL?
 
@@ -31,7 +31,7 @@ extension FileManager {
     @available(*, deprecated, renamed:"replaceItemAt(_:withItemAt:backupItemName:options:)")
     public func replaceItemAtURL(originalItemURL: NSURL, withItemAtURL newItemURL: NSURL, backupItemName: String? = nil, options: FileManager.ItemReplacementOptions = []) throws -> NSURL? {
         var error: NSError?
-        if let result = NS_Swift_NSFileManager_replaceItemAtURL_withItemAtURL_backupItemName_options(self, originalItemURL, newItemURL, backupItemName, options, &error) {
+        if let result = NS_Swift_NSFileManager_replaceItemAtURL_withItemAtURL_backupItemName_options(self, originalItemURL, newItemURL, backupItemName as NSString?, options, &error) {
             return result
         }
         throw error!
@@ -40,7 +40,7 @@ extension FileManager {
     @available(OSX 10.6, iOS 4.0, *)
     public func replaceItemAt(_ originalItemURL: URL, withItemAt newItemURL: URL, backupItemName: String? = nil, options: FileManager.ItemReplacementOptions = []) throws -> NSURL? {
         var error: NSError?
-        if let result = NS_Swift_NSFileManager_replaceItemAtURL_withItemAtURL_backupItemName_options(self, originalItemURL as NSURL, newItemURL as NSURL, backupItemName, options, &error) {
+        if let result = NS_Swift_NSFileManager_replaceItemAtURL_withItemAtURL_backupItemName_options(self, originalItemURL as NSURL, newItemURL as NSURL, backupItemName as NSString?, options, &error) {
             return result
         }
         throw error!

--- a/stdlib/public/SDK/Foundation/FileManagerThunks.m
+++ b/stdlib/public/SDK/Foundation/FileManagerThunks.m
@@ -17,19 +17,19 @@ NS_Swift_NSFileManager_replaceItemAtURL_withItemAtURL_backupItemName_options(
     NSFileManager *NS_RELEASES_ARGUMENT _Nonnull self_,
     NSURL *NS_RELEASES_ARGUMENT _Nonnull originalItemURL,
     NSURL *NS_RELEASES_ARGUMENT _Nonnull newItemURL,
-    NSString *NS_RELEASES_ARGUMENT _Nonnull backupItemName, NSUInteger options,
+    NSString *NS_RELEASES_ARGUMENT _Nullable backupItemName, NSUInteger options,
     NSError *_Nullable *_Nullable error) {
 
   NSURL *result = nil;
-  [self_ replaceItemAtURL:originalItemURL
-            withItemAtURL:originalItemURL
-           backupItemName:backupItemName
-                  options:(NSFileManagerItemReplacementOptions)options
-         resultingItemURL:&result
-                    error:error];
+  BOOL success = [self_ replaceItemAtURL:originalItemURL
+                           withItemAtURL:newItemURL
+                          backupItemName:backupItemName
+                                 options:(NSFileManagerItemReplacementOptions)options
+                        resultingItemURL:&result
+                                   error:error];
   [self_ release];
   [originalItemURL release];
   [newItemURL release];
   [backupItemName release];
-  return [result retain];
+  return success ? [result retain] : nil;
 }

--- a/test/stdlib/TestFileManager.swift
+++ b/test/stdlib/TestFileManager.swift
@@ -1,0 +1,84 @@
+// Copyright (c) 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+//
+// RUN: %target-clang %S/Inputs/FoundationBridge/FoundationBridge.m -c -o %t/FoundationBridgeObjC.o -g
+// RUN: %target-build-swift %s -I %S/Inputs/FoundationBridge/ -Xlinker %t/FoundationBridgeObjC.o -o %t/TestFileManager
+
+// RUN: %target-run %t/TestFileManager > %t.txt
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+
+#if FOUNDATION_XCTEST
+import XCTest
+class TestFileManagerSuper : XCTestCase { }
+#else
+import StdlibUnittest
+class TestFileManagerSuper { }
+#endif
+
+class TestFileManager : TestFileManagerSuper {
+    func testReplaceItem() {
+        let fm = FileManager.default
+        
+        // Temporary directory
+        let dirPath = (NSTemporaryDirectory() as NSString).appendingPathComponent(NSUUID().uuidString)
+        try! fm.createDirectory(atPath: dirPath, withIntermediateDirectories: true, attributes: nil)
+        defer { try! FileManager.default.removeItem(atPath: dirPath) }
+        
+        let filePath = (dirPath as NSString).appendingPathComponent("temp_file")
+        try! "1".write(toFile: filePath, atomically: true, encoding: String.Encoding.utf8)
+        
+        let newItemPath = (dirPath as NSString).appendingPathComponent("temp_file_new")
+        try! "2".write(toFile: newItemPath, atomically: true, encoding: String.Encoding.utf8)
+        
+        let result = try! fm.replaceItemAt(URL(fileURLWithPath:filePath, isDirectory:false), withItemAt:URL(fileURLWithPath:newItemPath, isDirectory:false))
+        expectEqual(result!.path, filePath)
+        
+        let fromDisk = try! String(contentsOf: URL(fileURLWithPath:filePath, isDirectory:false), encoding: String.Encoding.utf8)
+        expectEqual(fromDisk, "2")
+
+    }
+    
+    func testReplaceItem_error() {
+        let fm = FileManager.default
+        
+        // Temporary directory
+        let dirPath = (NSTemporaryDirectory() as NSString).appendingPathComponent(NSUUID().uuidString)
+        try! fm.createDirectory(atPath: dirPath, withIntermediateDirectories: true, attributes: nil)
+        defer { try! FileManager.default.removeItem(atPath: dirPath) }
+        
+        let filePath = (dirPath as NSString).appendingPathComponent("temp_file")
+        try! "1".write(toFile: filePath, atomically: true, encoding: String.Encoding.utf8)
+        
+        let newItemPath = (dirPath as NSString).appendingPathComponent("temp_file_new")
+        // Don't write the file.
+        
+        var threw = false
+        do {
+            let _ = try fm.replaceItemAt(URL(fileURLWithPath:filePath, isDirectory:false), withItemAt:URL(fileURLWithPath:newItemPath, isDirectory:false))
+        } catch {
+            threw = true
+        }
+        expectTrue(threw, "Should have thrown")
+
+    }
+}
+
+#if !FOUNDATION_XCTEST
+var FMTests = TestSuite("TestFileManager")
+FMTests.test("testReplaceItem") { TestFileManager().testReplaceItem() }
+FMTests.test("testReplaceItem_error") { TestFileManager().testReplaceItem_error() }
+
+runAllTests()
+#endif
+


### PR DESCRIPTION
<!-- What's in this pull request? -->

Fixes for various bugs in the overlay implementation of `FileManager.replaceItemAt()` and a test to verify the API.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
