### PR TITLE
[SIL] Add test case for crash triggered in swift::Parser::parseTypeSimpleOrComposition(…)

### DIFF
--- a/validation-test/SIL/crashers/046-swift-parser-parsetypesimpleorcomposition.sil
+++ b/validation-test/SIL/crashers/046-swift-parser-parsetypesimpleorcomposition.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+{struct R{func o:inout p<


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:1: error: statement cannot begin with a closure expression
{struct R{func o:inout p<
^
<stdin>:3:1: note: explicitly discard the result of the closure by assigning to '_'
{struct R{func o:inout p<
^
_ =
<stdin>:3:17: error: expected '(' in argument list of function declaration
{struct R{func o:inout p<
                ^
<stdin>:3:17: error: expected '->' after function parameter tuple
{struct R{func o:inout p<
                ^
                 ->
<stdin>:3:26: error: expected type
{struct R{func o:inout p<
                         ^
sil-opt: /path/to/swift/include/swift/Parse/ParserResult.h:73: T *swift::ParserResult<swift::TypeRepr>::get() const [T = swift::TypeRepr]: Assertion `getPtrOrNull() && "not checked for nullptr"' failed.
8  sil-opt         0x0000000000b22bdd swift::Parser::parseTypeSimpleOrComposition(swift::Diag<>, bool) + 29
9  sil-opt         0x0000000000b22844 swift::Parser::parseType(swift::Diag<>, bool) + 212
10 sil-opt         0x0000000000b58ea0 swift::Parser::parseFunctionSignature(swift::Identifier, swift::DeclName&, llvm::SmallVectorImpl<swift::ParameterList*>&, swift::Parser::DefaultArgumentInfo&, swift::SourceLoc&, bool&, swift::TypeRepr*&) + 1232
11 sil-opt         0x0000000000b3cab5 swift::Parser::parseDeclFunc(swift::SourceLoc, swift::StaticSpellingKind, swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&) + 3781
12 sil-opt         0x0000000000b30e97 swift::Parser::parseDecl(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) + 2983
14 sil-opt         0x0000000000adc44c swift::Parser::parseList(swift::tok, swift::SourceLoc, swift::SourceLoc&, swift::tok, bool, bool, swift::Diag<>, std::function<swift::ParserStatus ()>) + 348
15 sil-opt         0x0000000000b38865 swift::Parser::parseDeclStruct(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&) + 1861
16 sil-opt         0x0000000000b30f82 swift::Parser::parseDecl(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) + 3218
17 sil-opt         0x0000000000b12d79 swift::Parser::parseBraceItems(llvm::SmallVectorImpl<swift::ASTNode>&, swift::BraceItemListKind, swift::BraceItemListKind) + 889
18 sil-opt         0x0000000000b50af2 swift::Parser::parseExprClosure() + 962
19 sil-opt         0x0000000000b49635 swift::Parser::parseExprPostfix(swift::Diag<>, bool) + 2853
20 sil-opt         0x0000000000b488fd swift::Parser::parseExprUnary(swift::Diag<>, bool) + 509
21 sil-opt         0x0000000000b481f1 swift::Parser::parseExprSequenceElement(swift::Diag<>, bool) + 97
22 sil-opt         0x0000000000b4738e swift::Parser::parseExprSequence(swift::Diag<>, bool, bool) + 158
23 sil-opt         0x0000000000b47247 swift::Parser::parseExprImpl(swift::Diag<>, bool) + 151
24 sil-opt         0x0000000000b11486 swift::Parser::parseExprOrStmt(swift::ASTNode&) + 422
25 sil-opt         0x0000000000b13140 swift::Parser::parseBraceItems(llvm::SmallVectorImpl<swift::ASTNode>&, swift::BraceItemListKind, swift::BraceItemListKind) + 1856
26 sil-opt         0x0000000000b26cea swift::Parser::parseTopLevel() + 170
27 sil-opt         0x0000000000ad8d40 swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) + 208
28 sil-opt         0x00000000008021e3 swift::CompilerInstance::performSema() + 3315
29 sil-opt         0x00000000007e8d3c main + 1852
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  With parser at source location: <stdin>:3:26
```
