### PR TITLE
[swiftc (79 vs. 5175)] Add crasher in swift::TypeBase::getRValueType(…)

### DIFF
--- a/validation-test/compiler_crashers/28442-swift-typebase-getrvaluetype.swift
+++ b/validation-test/compiler_crashers/28442-swift-typebase-getrvaluetype.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+var f={var f=[]f.init


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getRValueType(...)`.

Current number of unresolved compiler crashers: 79 (5175 resolved)

Assertion failure in [`lib/AST/Type.cpp (line 528)`](https://github.com/apple/swift/blob/master/lib/AST/Type.cpp#L528):

```
Assertion `!t->isLValueType() && "unexpected structural lvalue"' failed.

When executing: swift::Type <anonymous namespace>::GetRValueTypeVisitor::visitType(swift::TypeBase *)
```

Assertion context:

```
  }

  Type visitType(TypeBase *t) {
    // Other types should not structurally contain lvalues.
    assert(!t->isLValueType()
           && "unexpected structural lvalue");
    return t;
  }
};
} // end anonymous namespace

```

Stack trace:

```
swift: /path/to/swift/lib/AST/Type.cpp:528: swift::Type <anonymous namespace>::GetRValueTypeVisitor::visitType(swift::TypeBase *): Assertion `!t->isLValueType() && "unexpected structural lvalue"' failed.
8  swift           0x00000000011ad956 swift::TypeBase::getRValueType() + 22
9  swift           0x00000000010736cb swift::constraints::ConstraintSystem::performMemberLookup(swift::constraints::ConstraintKind, swift::DeclName, swift::Type, swift::FunctionRefKind, swift::constraints::ConstraintLocator*, bool) + 59
11 swift           0x00000000010301c2 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 98
12 swift           0x0000000001036830 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4320
13 swift           0x0000000000f5fa6f swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 431
14 swift           0x0000000000f6250e swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 942
17 swift           0x0000000000fe7796 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 262
18 swift           0x00000000010139cc swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 812
19 swift           0x0000000000f625a4 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) + 1092
20 swift           0x0000000000f65715 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 309
21 swift           0x0000000000f6591d swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 237
24 swift           0x0000000000f76bd6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
26 swift           0x0000000000fe7936 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
27 swift           0x0000000000f9bd7a swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1162
28 swift           0x0000000000d11d16 swift::CompilerInstance::performSema() + 3350
29 swift           0x000000000085e11e swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 3422
30 swift           0x000000000082527e main + 2878
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28442-swift-typebase-getrvaluetype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28442-swift-typebase-getrvaluetype-2d670e.o
1.  While type-checking declaration 0x6cd84a8 at validation-test/compiler_crashers/28442-swift-typebase-getrvaluetype.swift:10:1
2.  While type-checking expression at [validation-test/compiler_crashers/28442-swift-typebase-getrvaluetype.swift:10:7 - line:10:18] RangeText="{var f=[]f.i"
3.  While type-checking expression at [validation-test/compiler_crashers/28442-swift-typebase-getrvaluetype.swift:10:16 - line:10:18] RangeText="f.i"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
