### PR TITLE
[Parse] isNonNull() check before constructing InOutTypeRepr

### DIFF
--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -142,7 +142,7 @@ ParserResult<TypeRepr> Parser::parseTypeSimple(Diag<> MessageID,
   }
 
   // If we parsed an inout modifier, prepend it.
-  if (InOutLoc.isValid())
+  if (InOutLoc.isValid() && ty.isNonNull())
     ty = makeParserResult(new (Context) InOutTypeRepr(ty.get(),
                                                       InOutLoc));
 

--- a/validation-test/SIL/crashers/003-swift-parser-parsetypesimple.sil
+++ b/validation-test/SIL/crashers/003-swift-parser-parsetypesimple.sil
@@ -1,3 +1,0 @@
-// RUN: not --crash %target-sil-opt %s
-// REQUIRES: asserts
-func x:inout p<

--- a/validation-test/SIL/crashers_fixed/003-swift-parser-parsetypesimple.sil
+++ b/validation-test/SIL/crashers_fixed/003-swift-parser-parsetypesimple.sil
@@ -1,0 +1,3 @@
+// RUN: not %target-sil-opt %s
+// REQUIRES: asserts
+func x:inout p<

--- a/validation-test/SIL/crashers_fixed/046-swift-parser-parsetypesimpleorcomposition.sil
+++ b/validation-test/SIL/crashers_fixed/046-swift-parser-parsetypesimpleorcomposition.sil
@@ -1,3 +1,3 @@
-// RUN: not --crash %target-sil-opt %s
+// RUN: not %target-sil-opt %s
 // REQUIRES: asserts
 {struct R{func o:inout p<


### PR DESCRIPTION
Fixes 2 compiler crashers

Minimum repro was:

``` swift
let _: inout p<
```
