### PR TITLE
[Sema] Check hasResult() before getResult() from ReturnStmt

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -6703,9 +6703,11 @@ diagnoseAmbiguousMultiStatementClosure(ClosureExpr *closure) {
     llvm::SaveAndRestore<DeclContext*> SavedDC(CS->DC, closure);
     
     // Otherwise, we're ok to type check the subexpr.
-    auto returnedExpr =
-      typeCheckChildIndependently(RS->getResult(),
-                                  TCC_AllowUnresolvedTypeVariables);
+    Expr *returnedExpr = nullptr;
+    if (RS->hasResult())
+      returnedExpr =
+        typeCheckChildIndependently(RS->getResult(),
+                                    TCC_AllowUnresolvedTypeVariables);
     
     // If we found a type, presuppose it was the intended result and insert a
     // fixit hint.

--- a/validation-test/compiler_crashers_fixed/28390-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/28390-swift-expr-walk.swift
@@ -5,7 +5,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
 .h={return
 class c


### PR DESCRIPTION
Fixes compiler_crashers/28390-swift-expr-walk.swift
