### PR TITLE
Invalidate nested ProtocolDecl

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3921,6 +3921,7 @@ public:
       TC.diagnose(NTD->getLoc(),
                   diag::unsupported_nested_protocol,
                   NTD->getName());
+      NTD->setInvalid();
       return true;
     }
 

--- a/test/decl/nested/protocol.swift
+++ b/test/decl/nested/protocol.swift
@@ -43,7 +43,6 @@ protocol Racoon {
 
 enum OuterEnum {
   protocol C {} // expected-error{{protocol 'C' cannot be nested inside another declaration}}
-  // expected-note@-1{{'C' previously declared here}}
-  case C(C) // expected-error{{invalid redeclaration of 'C'}}
+  case C(C)
 }
 

--- a/validation-test/compiler_crashers_fixed/28351-swift-functiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/28351-swift-functiontype-get.swift
@@ -5,5 +5,5 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 extension A{{}protocol A}protocol A:class{protocol A{}typealias e:A

--- a/validation-test/compiler_crashers_fixed/28424-swift-valuedecl-getformalaccessscope.swift
+++ b/validation-test/compiler_crashers_fixed/28424-swift-valuedecl-getformalaccessscope.swift
@@ -5,5 +5,5 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 func<{{protocol A{func<extension{enum B:A


### PR DESCRIPTION
Fixes 2 compiler crashers.

CC: @slavapestov 
