### PR TITLE
[gardening] Eliminate warning from build due to uncovered switch.

### DIFF
--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -106,6 +106,7 @@ StringRef swift::getPlatformNameForTriple(const llvm::Triple &triple) {
   case llvm::Triple::NVCL:
   case llvm::Triple::AMDHSA:
   case llvm::Triple::ELFIAMCU:
+  case llvm::Triple::Mesa3D:
     return "";
   case llvm::Triple::Darwin:
   case llvm::Triple::MacOSX:


### PR DESCRIPTION
While building this morning, I noticed a warning that a switch over llvm::Triple was missing a case for Mesa3D. This commit covers the switch by handling Mesa3D like we handle other platforms that the compiler has never been modified to work with.
