### PR TITLE
Revert "Make the option of building using the host clang the default"

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -81,7 +81,7 @@ KNOWN_SETTINGS=(
     cmake                       ""               "path to the cmake binary"
     distcc                      ""               "use distcc in pump mode"
     distcc-pump                 ""               "the path to distcc pump executable. This argument is required if distcc is set."
-    build-runtime-with-host-compiler   "1"       "use the host c++ compiler to build everything"
+    build-runtime-with-host-compiler   ""        "use the host c++ compiler to build everything"
     cmake-generator             "Unix Makefiles" "kind of build system to generate; see output of 'cmake --help' for choices"
     verbose-build               ""               "print the commands executed during the build"
     install-prefix              ""               "installation prefix"


### PR DESCRIPTION
This reverts commit 0b1e8583a1815bc90e22352d01f237953cf89bcf.

No one remembers what problems this caused for the ASan bot when we
tried building the runtime with the just-built clang, so I'm reenabling
it now and we'll see what happens.
