### PR TITLE
[3.0] QoI improvements for `@objc` optional near-miss warnings

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4743,18 +4743,6 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
   // If there were any unsatisfied requirements, check whether there
   // are any near-matches we should diagnose.
   if (!unsatisfiedReqs.empty() && !anyInvalid) {
-    // Collect the set of witnesses that came from this context.
-    llvm::SmallPtrSet<ValueDecl *, 16> knownWitnesses;
-    for (auto conformance : conformances) {
-      conformance->forEachValueWitness(
-        nullptr,
-        [&](ValueDecl *req, ConcreteDeclRef witness) {
-          // If there is a witness, record it if it's within this context.
-          if (witness.getDecl() && witness.getDecl()->getDeclContext() == dc)
-            knownWitnesses.insert(witness.getDecl());
-         });
-    }
-
     // Find all of the members that aren't used to satisfy
     // requirements, and check whether they are close to an
     // unsatisfied or defaulted requirement.
@@ -4764,8 +4752,12 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
       auto value = dyn_cast<ValueDecl>(member);
       if (!value) continue;
       if (isa<TypeDecl>(value)) continue;
-      if (knownWitnesses.count(value) > 0) continue;
       if (!value->getFullName()) continue;
+      
+      // If this member is a witness to any @objc requirement, ignore it.
+      if (!findWitnessedObjCRequirements(value, /*anySingleRequirement=*/true)
+            .empty())
+        continue;
 
       // Find the unsatisfied requirements with the nearest-matching
       // names.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4753,7 +4753,11 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
       if (!value) continue;
       if (isa<TypeDecl>(value)) continue;
       if (!value->getFullName()) continue;
-      
+
+      // If this declaration overrides another declaration, the signature is
+      // fixed; don't complain about near misses.
+      if (value->getOverriddenDecl()) continue;
+
       // If this member is a witness to any @objc requirement, ignore it.
       if (!findWitnessedObjCRequirements(value, /*anySingleRequirement=*/true)
             .empty())

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4387,12 +4387,13 @@ combineBaseNameAndFirstArgument(Identifier baseName,
 /// Compute the scope between two potentially-matching names, which is
 /// effectively the sum of the edit distances between the corresponding
 /// argument labels.
-static unsigned scorePotentiallyMatchingNames(DeclName lhs, DeclName rhs,
-                                              bool isFunc,
-                                              unsigned limit) {
+static Optional<unsigned> scorePotentiallyMatchingNames(DeclName lhs,
+                                                        DeclName rhs,
+                                                        bool isFunc,
+                                                        unsigned limit) {
   // If there are a different number of argument labels, we're done.
   if (lhs.getArgumentNames().size() != rhs.getArgumentNames().size())
-    return limit;
+    return None;
 
   // Score the base name match. If there is a first argument for a
   // function, include its text along with the base name's text.
@@ -4414,14 +4415,14 @@ static unsigned scorePotentiallyMatchingNames(DeclName lhs, DeclName rhs,
 
     score = lhsFirstName.edit_distance(rhsFirstName.str(), true, limit);
   }
-  if (score >= limit) return limit;
+  if (score > limit) return None;
 
   // Compute the edit distance between matching argument names.
   for (unsigned i = isFunc ? 1 : 0; i < lhs.getArgumentNames().size(); ++i) {
     score += scoreIdentifiers(lhs.getArgumentNames()[i],
                               rhs.getArgumentNames()[i],
                               limit - score);
-    if (score >= limit) return limit;
+    if (score > limit) return None;
   }
 
   return score;
@@ -4440,8 +4441,10 @@ static Optional<DeclName> omitNeedlessWords(TypeChecker &tc, ValueDecl *value) {
 }
 
 /// Determine the score between two potentially-matching declarations.
-static unsigned scorePotentiallyMatching(TypeChecker &tc, ValueDecl *req,
-                                         ValueDecl *witness, unsigned limit) {
+static Optional<unsigned> scorePotentiallyMatching(TypeChecker &tc,
+                                                   ValueDecl *req,
+                                                   ValueDecl *witness,
+                                                   unsigned limit) {
   DeclName reqName = req->getFullName();
   DeclName witnessName = witness->getFullName();
 
@@ -4571,12 +4574,12 @@ static bool shouldWarnAboutPotentialWitness(ValueDecl *req,
   }
 
   // If the score is relatively high, don't warn: this is probably
-  // unrelated.  Allow about one typo for every two properly-typed
+  // unrelated.  Allow about one typo for every four properly-typed
   // characters, which prevents completely-wacky suggestions in many
   // cases.
   unsigned reqNameLen = getNameLength(req->getFullName());
   unsigned witnessNameLen = getNameLength(witness->getFullName());
-  if (score > (std::min(reqNameLen, witnessNameLen) + 1) / 3)
+  if (score > (std::min(reqNameLen, witnessNameLen)) / 4)
     return false;
 
   return true;
@@ -4773,16 +4776,17 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
 
         // Score this particular optional requirement.
         auto score = scorePotentiallyMatching(*this, req, value, bestScore);
+        if (!score) continue;
 
         // If the score is better than the best we've seen, update the best
         // and clear out the list.
-        if (score < bestScore) {
+        if (*score < bestScore) {
           bestOptionalReqs.clear();
-          bestScore = score;
+          bestScore = *score;
         }
 
         // If this score matches the (possible new) best score, record it.
-        if (score == bestScore && bestScore < UINT_MAX)
+        if (*score == bestScore)
           bestOptionalReqs.push_back(req);
       }
 

--- a/test/decl/protocol/conforms/near_miss_objc.swift
+++ b/test/decl/protocol/conforms/near_miss_objc.swift
@@ -119,3 +119,18 @@ class C7a : P7 {
   // expected-note@-4{{make 'method(foo:)' private to silence this warning}}
 }
 
+// Don't complain about near-misses that satisfy other protocol
+// requirements.
+@objc protocol P8 {
+  @objc optional func foo(exactMatch: Int)
+}
+
+@objc protocol P9 : P8 {
+  @objc optional func foo(nearMatch: Int)
+}
+
+class C8Super : P8 { }
+
+class C9Sub : C8Super, P9 {
+  func foo(exactMatch: Int) { }
+}

--- a/test/decl/protocol/conforms/near_miss_objc.swift
+++ b/test/decl/protocol/conforms/near_miss_objc.swift
@@ -144,3 +144,12 @@ class C10Super {
 class C10Sub : C10Super, P8 {
   override func foo(nearMatch: Int) { }
 }
+
+// Be more strict about near misses than we had previously.
+@objc protocol P11 {
+  @objc optional func foo(wibble: Int)
+}
+
+class C11 : P11 {
+  func f(waggle: Int) { } // no warning
+}

--- a/test/decl/protocol/conforms/near_miss_objc.swift
+++ b/test/decl/protocol/conforms/near_miss_objc.swift
@@ -119,7 +119,7 @@ class C7a : P7 {
   // expected-note@-4{{make 'method(foo:)' private to silence this warning}}
 }
 
-// Don't complain about near-misses that satisfy other protocol
+// Don't complain about near misses that satisfy other protocol
 // requirements.
 @objc protocol P8 {
   @objc optional func foo(exactMatch: Int)
@@ -133,4 +133,14 @@ class C8Super : P8 { }
 
 class C9Sub : C8Super, P9 {
   func foo(exactMatch: Int) { }
+}
+
+// Don't complain about overriding methods that are near misses;
+// the user cannot make it satisfy the protocol requirement.
+class C10Super {
+  func foo(nearMatch: Int) { }
+}
+
+class C10Sub : C10Super, P8 {
+  override func foo(nearMatch: Int) { }
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->

This PR introduces three localized fixes to improve the near-miss warnings for declarations that are similar to `@objc` optional requirements:

1) Don't warn if the declaration satisfied any `@objc` protocol requirement
2) Don't warn if it's already an override of something
3) Tighten up the heuristics so we warn less

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [rdar://problem/27348369](rdar://problem/27348369), [rdar://problem/28524237](rdar://problem/28524237), [rdar://problem/26380688](rdar://problem/26380688)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
