### PR TITLE
Fix typo in Bool.swift

### DIFF
--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -242,7 +242,7 @@ extension Bool {
   ///     } else {
   ///         print("Major error: \(error)")
   ///     }
-  ///     // Prints "No major errors detected")
+  ///     // Prints "No major errors detected"
   ///
   /// In this example, `lhs` tests whether `error` is an empty string.
   /// Evaluation of the `||` operator is one of the following:


### PR DESCRIPTION
<!-- What's in this pull request? -->

Fix typo in documentation where the "Prints <result>" comment had a parenthesis at the end, probably from coping and pasting out of the code example.
