### PR TITLE
[Constraint Solver] Don't perform a join when we've adjusted an IUO type

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -961,6 +961,7 @@ static PotentialBindings getPotentialBindings(ConstraintSystem &cs,
 
     // Don't deduce IUO types.
     Type alternateType;
+    bool adjustedIUO = false;
     if (kind == AllowedBindingKind::Supertypes &&
         constraint->getKind() >= ConstraintKind::Conversion &&
         constraint->getKind() <= ConstraintKind::OperatorArgumentConversion) {
@@ -969,6 +970,7 @@ static PotentialBindings getPotentialBindings(ConstraintSystem &cs,
           cs.lookThroughImplicitlyUnwrappedOptionalType(innerType)) {
         type = OptionalType::get(objectType);
         alternateType = objectType;
+        adjustedIUO = true;
       }
     }
 
@@ -995,7 +997,7 @@ static PotentialBindings getPotentialBindings(ConstraintSystem &cs,
     }
 
     if (exactTypes.insert(type->getCanonicalType()).second)
-      addPotentialBinding({type, kind, None});
+      addPotentialBinding({type, kind, None}, /*allowJoinMeet=*/!adjustedIUO);
     if (alternateType &&
         exactTypes.insert(alternateType->getCanonicalType()).second)
       addPotentialBinding({alternateType, kind, None}, /*allowJoinMeet=*/false);

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -130,3 +130,14 @@ func testTernaryWithNil(b: Bool, s: String, i: Int) {
   let t4 = b ? nil : 1
   let _: Double = t4 // expected-error{{value of type 'Int?'}}
 }
+
+// inference with IUOs
+infix operator ++++
+
+protocol PPPP {
+  static func ++++(x: Self, y: Self) -> Bool
+}
+
+func compare<T: PPPP>(v: T, u: T!) -> Bool {
+  return v ++++ u
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->

Fixes an unintentional source-breaking change from Swift 3 regarding implicitly-unwrapped optionals and type inference.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [rdar://problem/28621624](rdar://problem/28621624).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
