### PR TITLE
[Driver] Show incremental is off with bitcode, WMO

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -413,9 +413,22 @@ std::unique_ptr<Compilation> Driver::buildCompilation(
   bool ShowIncrementalBuildDecisions =
     ArgList->hasArg(options::OPT_driver_show_incremental);
 
-  bool Incremental = ArgList->hasArg(options::OPT_incremental) &&
-    !ArgList->hasArg(options::OPT_whole_module_optimization) &&
-    !ArgList->hasArg(options::OPT_embed_bitcode);
+  bool Incremental = ArgList->hasArg(options::OPT_incremental);
+  if (ArgList->hasArg(options::OPT_whole_module_optimization)) {
+    if (Incremental && ShowIncrementalBuildDecisions) {
+      llvm::outs() << "Incremental compilation has been disabled, because it "
+                   << "is not compatible with whole module optimization.";
+    }
+    Incremental = false;
+  }
+  if (ArgList->hasArg(options::OPT_embed_bitcode)) {
+    if (Incremental && ShowIncrementalBuildDecisions) {
+      llvm::outs() << "Incremental compilation has been disabled, because it "
+                   << "is not currently compatible with embedding LLVM IR "
+                   << "bitcode.";
+    }
+    Incremental = false;
+  }
 
   bool SaveTemps = ArgList->hasArg(options::OPT_save_temps);
   bool ContinueBuildingAfterErrors =

--- a/test/Driver/Dependencies/Inputs/update-dependencies.py
+++ b/test/Driver/Dependencies/Inputs/update-dependencies.py
@@ -35,7 +35,10 @@ import sys
 
 assert sys.argv[1] == '-frontend'
 
-if '-primary-file' in sys.argv:
+# NB: The bitcode options automatically specify a -primary-file, even in cases
+#     where we do not wish to use a dependencies file in the test.
+if '-primary-file' in sys.argv \
+        and '-embed-bitcode' not in sys.argv and '-emit-bc' not in sys.argv:
     primaryFile = sys.argv[sys.argv.index('-primary-file') + 1]
     depsFile = sys.argv[sys.argv.index(
         '-emit-reference-dependencies-path') + 1]

--- a/test/Driver/Dependencies/driver-show-incremental-conflicting-arguments.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-conflicting-arguments.swift
@@ -1,0 +1,31 @@
+// Test that when:
+//
+// 1. Using -incremental -v -driver-show-incremental, but...
+// 2. ...options that disable incremental compilation, such as whole module
+//    optimization or bitcode embedding are specified...
+//
+// ...then the driver prints a message indicating that incremental compilation
+// is disabled. If both are specified, the driver should only print one message.
+
+
+// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %S/Inputs/touch.py 443865900 %t/*
+// RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
+
+// RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
+// CHECK-INCREMENTAL-NOT: Incremental compilation has been disabled
+// CHECK-INCREMENTAL: Queuing main.swift (initial)
+
+// RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -whole-module-optimization -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-WMO %s
+// CHECK-WMO: Incremental compilation has been disabled{{.*}}whole module optimization
+// CHECK-WMO-NOT: Queuing main.swift (initial)
+
+// RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -embed-bitcode -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-BITCODE %s
+// CHECK-BITCODE: Incremental compilation has been disabled{{.*}}LLVM IR bitcode
+// CHECK-BITCODE-NOT: Queuing main.swift (initial)
+
+// RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -whole-module-optimization -embed-bitcode -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-WMO-AND-BITCODE %s
+// CHECK-WMO-AND-BITCODE: Incremental compilation has been disabled{{.*}}whole module optimization
+// CHECK-WMO-AND-BITCODE-NOT: Incremental compilation has been disabled
+// CHECK-WMO-AND-BITCODE-NOT: Queuing main.swift (initial)
+


### PR DESCRIPTION
<!-- What's in this pull request? -->

SR-2855 suggests `-driver-show-incremental` not only print information about why certain files are included in incremental compilation, but also print out why incremental compilation may be disabled altogether.

Add a message for two such reasons:
1. When whole module compilation is enabled, since optimizations for WMO require a full rebuild.
2. When embedding LLVM IR bitcode, which needs to be re-generated.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Addresses one part of [SR-2855](https://bugs.swift.org/browse/SR-2855).

---

The change to `update-dependencies.py` is an ugly hack. Let me know if you have an idea that's better.
