### PR TITLE
[Driver] Show incremental is off with bad JSON

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -194,6 +194,20 @@ class Driver::InputInfoMap
 };
 using InputInfoMap = Driver::InputInfoMap;
 
+static bool failedToReadOutOfDateMap(bool ShowIncrementalBuildDecisions,
+                                     StringRef buildRecordPath,
+                                     StringRef reason = "") {
+  if (ShowIncrementalBuildDecisions) {
+    llvm::outs() << "Incremental compilation has been disabled due to "
+                 << "malformed build record file '" << buildRecordPath << "'.";
+    if (!reason.empty()) {
+      llvm::outs() << " " << reason;
+    }
+    llvm::outs() << "\n";
+  }
+  return true;
+}
+
 static bool populateOutOfDateMap(InputInfoMap &map, StringRef argsHashStr,
                                  const InputFileList &inputs,
                                  StringRef buildRecordPath,
@@ -211,11 +225,13 @@ static bool populateOutOfDateMap(InputInfoMap &map, StringRef argsHashStr,
 
   auto I = stream.begin();
   if (I == stream.end() || !I->getRoot())
-    return true;
+    return failedToReadOutOfDateMap(ShowIncrementalBuildDecisions,
+                                    buildRecordPath);
 
   auto *topLevelMap = dyn_cast<yaml::MappingNode>(I->getRoot());
   if (!topLevelMap)
-    return true;
+    return failedToReadOutOfDateMap(ShowIncrementalBuildDecisions,
+                                    buildRecordPath);
   SmallString<64> scratch;
 
   llvm::StringMap<InputInfo> previousInputs;
@@ -269,8 +285,12 @@ static bool populateOutOfDateMap(InputInfoMap &map, StringRef argsHashStr,
     using compilation_record::TopLevelKey;
     if (keyStr == compilation_record::getName(TopLevelKey::Version)) {
       auto *value = dyn_cast<yaml::ScalarNode>(i->getValue());
-      if (!value)
-        return true;
+      if (!value) {
+        auto reason = ("Malformed value for key '" + keyStr + "'.")
+          .toStringRef(scratch);
+        return failedToReadOutOfDateMap(ShowIncrementalBuildDecisions,
+                                        buildRecordPath, reason);
+      }
 
       // NB: We check against
       // swift::version::Version::getCurrentLanguageVersion() here because any
@@ -289,8 +309,12 @@ static bool populateOutOfDateMap(InputInfoMap &map, StringRef argsHashStr,
 
     } else if (keyStr == compilation_record::getName(TopLevelKey::BuildTime)) {
       auto *value = dyn_cast<yaml::SequenceNode>(i->getValue());
-      if (!value)
-        return true;
+      if (!value) {
+        auto reason = ("Malformed value for key '" + keyStr + "'.")
+          .toStringRef(scratch);
+        return failedToReadOutOfDateMap(ShowIncrementalBuildDecisions,
+                                        buildRecordPath, reason);
+      }
       llvm::sys::TimeValue timeVal;
       if (readTimeValue(i->getValue(), timeVal))
         return true;
@@ -298,8 +322,12 @@ static bool populateOutOfDateMap(InputInfoMap &map, StringRef argsHashStr,
 
     } else if (keyStr == compilation_record::getName(TopLevelKey::Inputs)) {
       auto *inputMap = dyn_cast<yaml::MappingNode>(i->getValue());
-      if (!inputMap)
-        return true;
+      if (!inputMap) {
+        auto reason = ("Malformed value for key '" + keyStr + "'.")
+          .toStringRef(scratch);
+        return failedToReadOutOfDateMap(ShowIncrementalBuildDecisions,
+                                        buildRecordPath, reason);
+      }
 
       // FIXME: LLVM's YAML support does incremental parsing in such a way that
       // for-range loops break.

--- a/test/Driver/Dependencies/driver-show-incremental-malformed.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-malformed.swift
@@ -1,0 +1,35 @@
+// Test that when:
+//
+// 1. Using -incremental -v -driver-show-incremental, and...
+// 2. ...the build record file does not contain valid JSON...
+//
+// ...then the driver prints a message indicating that incremental compilation
+// is disabled.
+
+
+// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %S/Inputs/touch.py 443865900 %t/*
+
+// RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
+// RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-INCREMENTAL %s
+// CHECK-INCREMENTAL-NOT: Incremental compilation has been disabled
+// CHECK-INCREMENTAL: Queuing main.swift (initial)
+
+// RUN: rm %t/main~buildrecord.swiftdeps && touch %t/main~buildrecord.swiftdeps
+// RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MALFORMED %s
+
+// RUN: echo 'foo' > %t/main~buildrecord.swiftdeps
+// RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MALFORMED %s
+
+// CHECK-MALFORMED: Incremental compilation has been disabled{{.*}}malformed build record file
+// CHECK-MALFORMED-NOT: Queuing main.swift (initial)
+
+// RUN: echo '{version, inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
+// RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MISSING-KEY %s
+
+// RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs}' > %t/main~buildrecord.swiftdeps
+// RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -g -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json | %FileCheck --check-prefix CHECK-MISSING-KEY %s
+
+// CHECK-MISSING-KEY: Incremental compilation has been disabled{{.*}}malformed build record file{{.*}}Malformed value for key
+// CHECK-MISSING-KEY-NOT: Queuing main.swift (initial)
+


### PR DESCRIPTION
<!-- What's in this pull request? -->

SR-2855 suggests `-driver-show-incremental` not only print information about why certain files are included in incremental compilation, but also print out why incremental compilation may be disabled altogether.

Add a message for one such reason: when the build record file is malformed.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

In combination with #5376, resolves [SR-2855](https://bugs.swift.org/browse/SR-2855).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

---

@jrose-apple Not entirely sure if this is what you had in mind -- the build record file may be "malformed" in any number of ways, after all. This covers the basic cases, I think.
