### PR TITLE
swift_build_support: do not raise exception when capturing shell with…

### DIFF
--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -123,6 +123,8 @@ def capture(command, stderr=None, env=None, dry_run=None, echo=True,
             "command terminated with a non-zero exit status " +
             str(e.returncode) + ", aborting")
     except OSError as e:
+        if optional:
+            return None
         diagnostics.fatal(
             "could not execute '" + quote_command(command) +
             "': " + e.strerror)

--- a/utils/swift_build_support/tests/test_shell.py
+++ b/utils/swift_build_support/tests/test_shell.py
@@ -76,7 +76,9 @@ class ShellTestCase(unittest.TestCase):
                           allow_non_zero_exit=True), "foo\n")
 
         with self.assertRaises(SystemExit):
-            shell.capture(["**not-a-command**"], optional=True)
+            shell.capture(["**not-a-command**"], optional=False)
+
+        self.assertIsNone(shell.capture(["**not-a-command**"], optional=True))
 
     def test_rmtree(self):
         shell.dry_run = False


### PR DESCRIPTION
This fixes one of https://bugs.swift.org/browse/SR-2966 failed tests when testing environment trying to instantiate FreeBSD toolchain on Linux and `sysctl` is not in the PATH
