### PR TITLE
Constraint solver tweaks

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -793,18 +793,21 @@ static PotentialBindings getPotentialBindings(ConstraintSystem &cs,
       result.InvolvesTypeVariables = true;
       continue;
 
-    case ConstraintKind::LiteralConformsTo:
-        // If there is a 'nil' literal constraint, we might need optional
-        // supertype bindings.
-        if (constraint->getProtocol()->isSpecificProtocol(
-              KnownProtocolKind::ExpressibleByNilLiteral))
-          addOptionalSupertypeBindings = true;
-
-        SWIFT_FALLTHROUGH;
-
     case ConstraintKind::ConformsTo:
-    case ConstraintKind::SelfObjectOfProtocol: {
-      // FIXME: Only for LiteralConformsTo?
+    case ConstraintKind::SelfObjectOfProtocol:
+      // Swift 3 allowed the use of default types for normal conformances
+      // to expressible-by-literal protocols.
+      if (tc.Context.LangOpts.EffectiveLanguageVersion[0] >= 4)
+        continue;
+
+      SWIFT_FALLTHROUGH;
+        
+    case ConstraintKind::LiteralConformsTo: {
+      // If there is a 'nil' literal constraint, we might need optional
+      // supertype bindings.
+      if (constraint->getProtocol()->isSpecificProtocol(
+            KnownProtocolKind::ExpressibleByNilLiteral))
+        addOptionalSupertypeBindings = true;
 
       // If there is a default literal type for this protocol, it's a
       // potential binding.

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -906,7 +906,7 @@ static PotentialBindings getPotentialBindings(ConstraintSystem &cs,
       if (auto secondTyvar = second->getAs<TypeVariableType>()) {
         if (cs.getRepresentative(firstTyvar) ==
             cs.getRepresentative(secondTyvar)) {
-          break;
+          continue;
         }
       }
     }

--- a/test/Compatibility/default_literal_generic_args.swift
+++ b/test/Compatibility/default_literal_generic_args.swift
@@ -1,0 +1,13 @@
+// RUN: %target-parse-verify-swift -swift-version 3
+
+// Swift 3 used default literal types even for normal protocol constraints,
+// which led to nonsensical type inference behavior.
+
+func f<T: ExpressibleByIntegerLiteral>(_: T = 0) { }
+f()
+
+struct X<T: ExpressibleByIntegerLiteral> {
+  func g() { }
+}
+
+X().g()

--- a/test/Constraints/default_literals_swift4.swift
+++ b/test/Constraints/default_literals_swift4.swift
@@ -1,0 +1,17 @@
+// RUN: %target-parse-verify-swift -swift-version 4
+
+// Swift 3 used default literal types even for normal protocol constraints,
+// which led to nonsensical type inference behavior.
+
+// expected-note@+1{{in call to function 'f'}}
+func f<T: ExpressibleByIntegerLiteral>(_: T = 0) { }
+
+f() // expected-error{{generic parameter 'T' could not be inferred}}
+
+// expected-note@+1{{'T' declared as parameter to type 'X'}}
+struct X<T: ExpressibleByIntegerLiteral> {
+  func g() { }
+}
+
+X().g() // expected-error{{generic parameter 'T' could not be inferred}}
+// expected-note@-1{{explicitly specify the generic arguments to fix this issue}}

--- a/test/SILGen/default_arguments_generic.swift
+++ b/test/SILGen/default_arguments_generic.swift
@@ -1,29 +1,30 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -swift-version 3 %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -swift-version 4 %s | %FileCheck %s
 
-func foo<T: ExpressibleByIntegerLiteral>(x x: T = 0) { }
+func foo<T: ExpressibleByIntegerLiteral>(_: T.Type, x: T = 0) { }
 
 struct Zim<T: ExpressibleByIntegerLiteral> {
   init(x: T = 0) { }
   init<U: ExpressibleByFloatLiteral>(_ x: T = 0, y: U = 0.5) { }
 
   static func zim(x: T = 0) { }
-  static func zang<U: ExpressibleByFloatLiteral>(_ x: T = 0, y: U = 0.5) { }
+  static func zang<U: ExpressibleByFloatLiteral>(_: U.Type, _ x: T = 0, y: U = 0.5) { }
 }
 
 // CHECK-LABEL: sil hidden @_TF25default_arguments_generic3barFT_T_ : $@convention(thin) () -> () {
 func bar() {
   // CHECK: [[FOO_DFLT:%.*]] = function_ref @_TIF25default_arguments_generic3foo
   // CHECK: apply [[FOO_DFLT]]<Int, Int>
-  foo()
+  foo(Int.self)
   // CHECK: [[ZIM_DFLT:%.*]] = function_ref @_TIZFV25default_arguments_generic3Zim3zim
   // CHECK: apply [[ZIM_DFLT]]<Int, Int>
-  Zim.zim()
+  Zim<Int>.zim()
   // CHECK: [[ZANG_DFLT_0:%.*]] = function_ref @_TIZFV25default_arguments_generic3Zim4zang
   // CHECK: apply [[ZANG_DFLT_0]]<Int, Double, Int, Double>
   // CHECK: [[ZANG_DFLT_1:%.*]] = function_ref @_TIZFV25default_arguments_generic3Zim4zang
   // CHECK: apply [[ZANG_DFLT_1]]<Int, Double, Int, Double>
-  Zim.zang()
+  Zim<Int>.zang(Double.self)
   // CHECK: [[ZANG_DFLT_1:%.*]] = function_ref @_TIZFV25default_arguments_generic3Zim4zang
   // CHECK: apply [[ZANG_DFLT_1]]<Int, Double, Int, Double>
-  Zim.zang(22)
+  Zim<Int>.zang(Double.self, 22)
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->

Various small tweaks to the constraint solver, fixing minor issues on the road toward eliminating most uses of member type constraints.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
