### PR TITLE
Fix testing when distcc is enabled.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2769,7 +2769,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 # NOTE: In dry-run mode, build_dir might not exist yet. In that
                 #       case, -n query will fail. So, in dry-run mode,
                 #       we don't expand test script.
-                if [[ ! "${DRY_RUN}" && "${CMAKE_GENERATOR}" == Ninja ]] && !( "${build_cmd[@]}" --version 2>&1 | grep -i -q llbuild ); then
+                if [[ ! "${DRY_RUN}" && "${CMAKE_GENERATOR}" == Ninja ]] && !( "${build_cmd[@]}" --version 2>&1 | grep -i -q llbuild ) && [[ -z "${DISTCC_PUMP}" ]]; then
                     # Ninja buffers command output to avoid scrambling the output
                     # of parallel jobs, which is awesome... except that it
                     # interferes with the progress meter when testing.  Instead of


### PR DESCRIPTION
DaveA recently improved how we handle distcc with
880bd30286ec3f7a4739e30b5aca16295086477f. Sadly this commit hit a landmine bug
created by a hack. Specifically there is some sort of code that is attempting to
sed ninja output (I don't completely understand what it is doing). My fix here
unblocks testing with distcc by just not using the hack when compiling with
distcc-pump.

I filed rdar://28874166 to investigate this issue.
