### PR TITLE
Revert "Revert "Make the option of building using the host clang the default""

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -81,7 +81,7 @@ KNOWN_SETTINGS=(
     cmake                       ""               "path to the cmake binary"
     distcc                      ""               "use distcc in pump mode"
     distcc-pump                 ""               "the path to distcc pump executable. This argument is required if distcc is set."
-    build-runtime-with-host-compiler   ""        "use the host c++ compiler to build everything"
+    build-runtime-with-host-compiler   "1"       "use the host c++ compiler to build everything"
     cmake-generator             "Unix Makefiles" "kind of build system to generate; see output of 'cmake --help' for choices"
     verbose-build               ""               "print the commands executed during the build"
     install-prefix              ""               "installation prefix"


### PR DESCRIPTION
Reverts apple/swift#5369

This broke a build because it invoked a version of the linker that does not support armv7s. Reverting for now while we get a fix.
