### PR TITLE
SIL: fix a bug which can cause the stack nesting to get broken by loop unrolling

### DIFF
--- a/lib/SIL/LoopInfo.cpp
+++ b/lib/SIL/LoopInfo.cpp
@@ -36,12 +36,12 @@ SILLoopInfo::SILLoopInfo(SILFunction *F, DominanceInfo *DT) {
 }
 
 bool SILLoop::canDuplicate(SILInstruction *I) const {
-  // The dealloc_stack of an alloc_stack must be in the loop, otherwise the
-  // dealloc_stack will be fed by a phi node of two alloc_stacks.
-  if (auto *Alloc = dyn_cast<AllocStackInst>(I)) {
-    for (auto *UI : Alloc->getUses()) {
-      if (auto *Dealloc = dyn_cast<DeallocStackInst>(UI->getUser())) {
-        if (!contains(Dealloc->getParent()))
+  // The deallocation of a stack allocation must be in the loop, otherwise the
+  // deallocation will be fed by a phi node of two allocations.
+  if (I->isAllocatingStack()) {
+    for (auto *UI : I->getUses()) {
+      if (UI->getUser()->isDeallocatingStack()) {
+        if (!contains(UI->getUser()->getParent()))
           return false;
       }
     }
@@ -76,6 +76,8 @@ bool SILLoop::canDuplicate(SILInstruction *I) const {
     return false;
   }
 
+  assert(I->isTriviallyDuplicatable() &&
+    "Code here must match isTriviallyDuplicatable in SILInstruction");
   return true;
 }
 

--- a/test/SILOptimizer/loop_unroll.sil
+++ b/test/SILOptimizer/loop_unroll.sil
@@ -70,3 +70,71 @@ bb3:
  %8 = tuple()
  return %8 : $()
 }
+
+class B {}
+
+// CHECK-LABEL: sil @unroll_with_stack_allocation
+// CHECK: = alloc_ref [stack]
+// CHECK: dealloc_ref [stack]
+// CHECK: = alloc_ref [stack]
+// CHECK: dealloc_ref [stack]
+// CHECK: }
+sil @unroll_with_stack_allocation : $@convention(thin) () -> () {
+bb0:
+ %0 = integer_literal $Builtin.Int64, 0
+ %1 = integer_literal $Builtin.Int64, 1
+ %2 = integer_literal $Builtin.Int64, 2
+ %3 = integer_literal $Builtin.Int1, 1
+ br bb1(%0 : $Builtin.Int64)
+
+bb1(%4 : $Builtin.Int64):
+  %a = alloc_ref [stack] $B
+  br bb2
+
+bb2:
+  %5 = builtin "sadd_with_overflow_Int64"(%4 : $Builtin.Int64, %1 : $Builtin.Int64, %3 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %6 = tuple_extract %5 : $(Builtin.Int64, Builtin.Int1), 0
+  %7 = builtin "cmp_eq_Int64"(%6 : $Builtin.Int64, %2 : $Builtin.Int64) : $Builtin.Int1
+  dealloc_ref [stack] %a : $B
+  cond_br %7, bb4, bb3
+
+bb3:
+  br bb1(%6 : $Builtin.Int64)
+
+bb4:
+  %8 = tuple()
+  return %8 : $()
+}
+
+// CHECK-LABEL: sil @dont_copy_stack_allocation_with_dealloc_outside_loop
+// CHECK:   = alloc_ref [stack]
+// CHECK: bb2:
+// CHECK:   dealloc_ref [stack]
+// CHECK: bb3:
+// CHECK:   dealloc_ref [stack]
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
+sil @dont_copy_stack_allocation_with_dealloc_outside_loop : $@convention(thin) () -> () {
+bb0:
+ %0 = integer_literal $Builtin.Int64, 0
+ %1 = integer_literal $Builtin.Int64, 1
+ %2 = integer_literal $Builtin.Int64, 2
+ %3 = integer_literal $Builtin.Int1, 1
+ br bb1(%0 : $Builtin.Int64)
+
+bb1(%4 : $Builtin.Int64):
+  %a = alloc_ref [stack] $B
+  %5 = builtin "sadd_with_overflow_Int64"(%4 : $Builtin.Int64, %1 : $Builtin.Int64, %3 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %6 = tuple_extract %5 : $(Builtin.Int64, Builtin.Int1), 0
+  %7 = builtin "cmp_eq_Int64"(%6 : $Builtin.Int64, %2 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %7, bb3, bb2
+
+bb2:
+  dealloc_ref [stack] %a : $B
+  br bb1(%6 : $Builtin.Int64)
+
+bb3:
+  dealloc_ref [stack] %a : $B
+  %8 = tuple()
+  return %8 : $()
+}


### PR DESCRIPTION
We must not unroll a loop with alloc_ref [stack] if a dealloc_stack is outside the loop.

related to rdar://problem/28878079
