### PR TITLE
[gardening] Remove unused variable BorrowDestLoc. Fix inconsistent headers.

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -767,7 +767,7 @@ static void diagnoseSwiftVersion(Optional<version::Version> &vers, Arg *verArg,
   diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
                  verArg->getAsString(Args), verArg->getValue());
 
-  // Check for an unneeded minor version, otherwise just list valid verions
+  // Check for an unneeded minor version, otherwise just list valid versions
   if (vers.hasValue() && !vers.getValue().empty() &&
       vers.getValue().asMajorVersion().isValidEffectiveLanguageVersion()) {
     diags.diagnose(SourceLoc(), diag::note_swift_version_major,

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -2428,7 +2428,7 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
 
   case ValueKind::EndBorrowInst: {
     UnresolvedValueName BorrowDestName, BorrowSourceName;
-    SourceLoc ToLoc, BorrowDestLoc;
+    SourceLoc ToLoc;
     Identifier ToToken;
     SILType BorrowDestTy, BorrowSourceTy;
 

--- a/stdlib/public/SwiftShims/OSOverlayShims.h
+++ b/stdlib/public/SwiftShims/OSOverlayShims.h
@@ -1,4 +1,4 @@
-//===--- OSOverlayShims.h -------------------------------------------------===//
+//===--- OSOverlayShims.h ---------------------------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/stdlib/public/SwiftShims/ObjectiveCOverlayShims.h
+++ b/stdlib/public/SwiftShims/ObjectiveCOverlayShims.h
@@ -1,4 +1,4 @@
-//===--- ObjectiveCOverlayShims.h -----------------------------------------===//
+//===--- ObjectiveCOverlayShims.h -------------------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/stdlib/public/SwiftShims/SafariServicesOverlayShims.h
+++ b/stdlib/public/SwiftShims/SafariServicesOverlayShims.h
@@ -1,4 +1,4 @@
-//===--- SafariServicesOverlayShims.h -------------------------------------===//
+//===--- SafariServicesOverlayShims.h ---------------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/stdlib/public/SwiftShims/XCTestOverlayShims.h
+++ b/stdlib/public/SwiftShims/XCTestOverlayShims.h
@@ -1,4 +1,4 @@
-//===--- XCTestOverlayShims.h -------------------------------------------*-===//
+//===--- XCTestOverlayShims.h -----------------------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/stdlib/public/SwiftShims/XPCOverlayShims.h
+++ b/stdlib/public/SwiftShims/XPCOverlayShims.h
@@ -1,4 +1,4 @@
-//===--- XPCOverlayShims.h ------------------------------------------------===//
+//===--- XPCOverlayShims.h --------------------------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //


### PR DESCRIPTION
The unused variable `BorrowDestLoc` was introduced in c41ead0b723878bda2e15a5a0321a1f40ac70b1d. This PR should probably be reviewed by @gottesmm :-)
