### PR TITLE
[Constraint solver] Only allocate/record constraints if they can't immediately be simplified

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -641,9 +641,7 @@ namespace {
         fallbackConstraintsDisjunction
       };
       
-      CS.addConstraint(Constraint::createDisjunction(CS,
-                                                     aggregateConstraints,
-                                                     csLoc));
+      CS.addDisjunctionConstraint(aggregateConstraints, csLoc);
       break;
     }
   }
@@ -1202,21 +1200,12 @@ namespace {
         auto returnTyV = CS.createTypeVariable(locator, /*options=*/0);
         auto methodTy = FunctionType::get(segmentTyV, returnTyV);
 
-        CS.addConstraint(Constraint::create(CS, ConstraintKind::Conversion,
-                                            segment->getType(),
-                                            segmentTyV,
-                                            Identifier(),
-                                            FunctionRefKind::Compound,
-                                            locator));
+        CS.addConstraint(ConstraintKind::Conversion, segment->getType(),
+                         segmentTyV, locator);
 
         DeclName segmentName(C, C.Id_init, { C.Id_stringInterpolationSegment });
-        CS.addConstraint(Constraint::create(CS, ConstraintKind::ValueMember,
-                                            tvMeta,
-                                            methodTy,
-                                            segmentName,
-                                            FunctionRefKind::DoubleApply,
-                                            locator));
-
+        CS.addValueMemberConstraint(tvMeta, segmentName, methodTy,
+                                    FunctionRefKind::DoubleApply, locator);
       }
       
       return tv;
@@ -2530,9 +2519,7 @@ namespace {
                                   toType, locator);
         coerceConstraint->setFavored();
         auto constraints = { coerceConstraint, downcastConstraint };
-        CS.addConstraint(Constraint::createDisjunction(CS, constraints,
-                                                       locator,
-                                                       RememberChoice));
+        CS.addDisjunctionConstraint(constraints, locator, RememberChoice);
       } else {
         // The source type can be explicitly converted to the destination type.
         CS.addConstraint(ConstraintKind::ExplicitConversion, fromType, toType,
@@ -3138,8 +3125,7 @@ bool swift::isExtensionApplied(DeclContext &DC, Type BaseTy,
       return;
     }
     // Add constraints accordingly.
-    CS.addConstraint(Constraint::create(CS, Kind, First, Second, DeclName(),
-                                        FunctionRefKind::Compound, Loc));
+    CS.addConstraint(Kind, First, Second, Loc);
   };
 
   // For every requirement, add a constraint.
@@ -3187,9 +3173,7 @@ static bool canSatisfy(Type T1, Type T2, DeclContext &DC, ConstraintKind Kind,
     T1 = T1.transform(Trans);
     T2 = T2.transform(Trans);
   }
-  CS.addConstraint(Constraint::create(CS, Kind, T1, T2, DeclName(),
-                                      FunctionRefKind::Compound,
-                                      CS.getConstraintLocator(nullptr)));
+  CS.addConstraint(Kind, T1, T2, CS.getConstraintLocator(nullptr));
   SmallVector<Solution, 4> Solutions;
   return AllowFreeVariables ?
           !CS.solve(Solutions, FreeTypeVariableBinding::Allow) :

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3217,22 +3217,6 @@ ConstraintSystem::simplifyMemberConstraint(const Constraint &constraint) {
 }
 
 ConstraintSystem::SolutionKind
-ConstraintSystem::simplifyClassConstraint(const Constraint &constraint){
-  auto baseTy = getFixedTypeRecursive(constraint.getFirstType(), true);
-  if (baseTy->isTypeVariableOrMember())
-    return SolutionKind::Unsolved;
-
-  if (baseTy->getClassOrBoundGenericClass())
-    return SolutionKind::Solved;
-
-  if (auto archetype = baseTy->getAs<ArchetypeType>()) {
-    if (archetype->requiresClass())
-      return SolutionKind::Solved;
-  }
-  return SolutionKind::Error;
-}
-
-ConstraintSystem::SolutionKind
 ConstraintSystem::simplifyDefaultableConstraint(const Constraint &constraint) {
   auto baseTy = getFixedTypeRecursive(constraint.getFirstType(), true);
 
@@ -3444,7 +3428,6 @@ static TypeMatchKind getTypeMatchKind(ConstraintKind kind) {
   case ConstraintKind::OptionalObject:
     llvm_unreachable("optional object constraints don't involve type matches");
       
-  case ConstraintKind::Class:
   case ConstraintKind::Defaultable:
     llvm_unreachable("Type properties don't involve type matches");
 
@@ -4113,9 +4096,6 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
   case ConstraintKind::UnresolvedValueMember:
   case ConstraintKind::TypeMember:
     return simplifyMemberConstraint(constraint);
-
-  case ConstraintKind::Class:
-    return simplifyClassConstraint(constraint);
 
   case ConstraintKind::Defaultable:
     return simplifyDefaultableConstraint(constraint);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3217,20 +3217,6 @@ ConstraintSystem::simplifyMemberConstraint(const Constraint &constraint) {
 }
 
 ConstraintSystem::SolutionKind
-ConstraintSystem::simplifyArchetypeConstraint(const Constraint &constraint) {
-  // Resolve the base type, if we can. If we can't resolve the base type,
-  // then we can't solve this constraint.
-  Type baseTy = getFixedTypeRecursive(constraint.getFirstType(), true);
-  if (baseTy->isTypeVariableOrMember())
-    return SolutionKind::Unsolved;
-
-  if (baseTy->is<ArchetypeType>())
-    return SolutionKind::Solved;
-
-  return SolutionKind::Error;
-}
-
-ConstraintSystem::SolutionKind
 ConstraintSystem::simplifyClassConstraint(const Constraint &constraint){
   auto baseTy = getFixedTypeRecursive(constraint.getFirstType(), true);
   if (baseTy->isTypeVariableOrMember())
@@ -3458,7 +3444,6 @@ static TypeMatchKind getTypeMatchKind(ConstraintKind kind) {
   case ConstraintKind::OptionalObject:
     llvm_unreachable("optional object constraints don't involve type matches");
       
-  case ConstraintKind::Archetype:
   case ConstraintKind::Class:
   case ConstraintKind::Defaultable:
     llvm_unreachable("Type properties don't involve type matches");
@@ -4129,9 +4114,6 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
   case ConstraintKind::TypeMember:
     return simplifyMemberConstraint(constraint);
 
-  case ConstraintKind::Archetype:
-    return simplifyArchetypeConstraint(constraint);
-  
   case ConstraintKind::Class:
     return simplifyClassConstraint(constraint);
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4030,7 +4030,8 @@ bool ConstraintSystem::recordFix(Fix fix, ConstraintLocatorBuilder locator) {
 
 ConstraintSystem::SolutionKind
 ConstraintSystem::simplifyFixConstraint(Fix fix, Type type1, Type type2,
-                                        TypeMatchKind matchKind, TypeMatchOptions flags,
+                                        TypeMatchKind matchKind,
+                                        TypeMatchOptions flags,
                                         ConstraintLocatorBuilder locator) {
   if (recordFix(fix, locator))
     return SolutionKind::Error;
@@ -4063,6 +4064,62 @@ ConstraintSystem::simplifyFixConstraint(Fix fix, Type type1, Type type2,
   }
 }
 
+void ConstraintSystem::addConstraint(ConstraintKind kind, Type first,
+                                     Type second,
+                                     ConstraintLocatorBuilder locator,
+                                     bool isFavored) {
+  assert(first && "Missing first type");
+  assert(second && "Missing second type");
+
+  // Local function to record failures if necessary.
+  auto failed = [&] {
+    // Add a failing constraint, if needed.
+    if (shouldAddNewFailingConstraint()) {
+      auto c = Constraint::create(*this, kind, first, second, DeclName(),
+                                  FunctionRefKind::Compound,
+                                  getConstraintLocator(locator));
+      if (isFavored) c->setFavored();
+      addNewFailingConstraint(c);
+    }
+  };
+
+  TypeMatchOptions subflags = TMF_GenerateConstraints;
+  switch (kind) {
+  case ConstraintKind::Equal:
+  case ConstraintKind::BindParam:
+  case ConstraintKind::Subtype:
+  case ConstraintKind::Conversion:
+  case ConstraintKind::ExplicitConversion:
+  case ConstraintKind::ArgumentConversion:
+  case ConstraintKind::ArgumentTupleConversion:
+  case ConstraintKind::OperatorArgumentTupleConversion:
+  case ConstraintKind::OperatorArgumentConversion:
+    switch (matchTypes(first, second, getTypeMatchKind(kind), subflags,
+                       locator)) {
+    case SolutionKind::Error:
+      return failed();
+
+    case SolutionKind::Unsolved:
+      llvm_unreachable("should have generated constraints");
+
+    case SolutionKind::Solved:
+      return;
+    }
+
+  case ConstraintKind::Bind: // FIXME: This should go through matchTypes() above
+
+  default: {
+    // FALLBACK CASE: do the slow thing.
+    auto c = Constraint::create(*this, kind, first, second, DeclName(),
+                                FunctionRefKind::Compound,
+                                getConstraintLocator(locator));
+    if (isFavored) c->setFavored();
+    addConstraint(c);
+    break;
+  }
+  }
+}
+
 ConstraintSystem::SolutionKind
 ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
   switch (constraint.getKind()) {
@@ -4076,16 +4133,14 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
   case ConstraintKind::ArgumentTupleConversion:
   case ConstraintKind::OperatorArgumentTupleConversion:
   case ConstraintKind::OperatorArgumentConversion: {
-    // For relational constraints, match up the types.
+    // Relational constraints.
     auto matchKind = getTypeMatchKind(constraint.getKind());
 
-    // If there is a fix associated with this constraint, apply it before
-    // we continue.
+    // If there is a fix associated with this constraint, apply it.
     if (auto fix = constraint.getFix()) {
       return simplifyFixConstraint(*fix, constraint.getFirstType(),
                                    constraint.getSecondType(), matchKind,
-                                   TMF_GenerateConstraints,
-                                   constraint.getLocator());
+                                   None, constraint.getLocator());
     }
 
     // If there is a restriction on this constraint, apply it directly rather

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1196,8 +1196,11 @@ ConstraintSystem::matchTypes(Type type1, Type type2, TypeMatchKind kind,
       // this new constraint will be solved at a later point.
       // Obviously, this must not happen at the top level, or the
       // algorithm would not terminate.
-      addConstraint(getConstraintKind(kind), type1, type2,
-                    getConstraintLocator(locator));
+      addUnsolvedConstraint(Constraint::create(*this,
+                                               getConstraintKind(kind),
+                                               type1, type2, DeclName(),
+                                               FunctionRefKind::Compound,
+                                               getConstraintLocator(locator)));
       return SolutionKind::Solved;
     }
 
@@ -3672,7 +3675,9 @@ ConstraintSystem::simplifyRestrictedConstraint(ConversionRestrictionKind restric
                                         getConstraintLocator(locator));
         
         Constraint *disjunctionChoices[] = {int8Con, uint8Con, voidCon};
-        addDisjunctionConstraint(disjunctionChoices, locator);
+        addUnsolvedConstraint(
+          Constraint::createDisjunction(*this, disjunctionChoices,
+                                        getConstraintLocator(locator)));
         return SolutionKind::Solved;
       }
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -688,7 +688,6 @@ static bool shouldBindToValueType(Constraint *constraint)
   case ConstraintKind::ValueMember:
   case ConstraintKind::UnresolvedValueMember:
   case ConstraintKind::TypeMember:
-  case ConstraintKind::Archetype:
   case ConstraintKind::Class:
   case ConstraintKind::Defaultable:
   case ConstraintKind::Disjunction:
@@ -776,7 +775,6 @@ static PotentialBindings getPotentialBindings(ConstraintSystem &cs,
       break;
 
     case ConstraintKind::DynamicTypeOf:
-    case ConstraintKind::Archetype:
     case ConstraintKind::Class:
       // Constraints from which we can't do anything.
       // FIXME: Record this somehow?

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -688,7 +688,6 @@ static bool shouldBindToValueType(Constraint *constraint)
   case ConstraintKind::ValueMember:
   case ConstraintKind::UnresolvedValueMember:
   case ConstraintKind::TypeMember:
-  case ConstraintKind::Class:
   case ConstraintKind::Defaultable:
   case ConstraintKind::Disjunction:
     llvm_unreachable("shouldBindToValueType() may only be called on "
@@ -775,7 +774,6 @@ static PotentialBindings getPotentialBindings(ConstraintSystem &cs,
       break;
 
     case ConstraintKind::DynamicTypeOf:
-    case ConstraintKind::Class:
       // Constraints from which we can't do anything.
       // FIXME: Record this somehow?
       continue;

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -507,6 +507,12 @@ Constraint *Constraint::create(ConstraintSystem &cs, ConstraintKind kind,
     second->getTypeVariables(typeVars);
   uniqueTypeVariables(typeVars);
 
+  // Conformance constraints expect a protocol on the right-hand side, always.
+  assert((kind != ConstraintKind::ConformsTo &&
+          kind != ConstraintKind::LiteralConformsTo &&
+          kind != ConstraintKind::SelfObjectOfProtocol) ||
+         second->is<ProtocolType>());
+
   // Create the constraint.
   unsigned size = totalSizeToAlloc<TypeVariableType*>(typeVars.size());
   void *mem = cs.getAllocator().Allocate(size, alignof(Constraint));

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -82,11 +82,6 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second,
     assert(Member && "Member constraint has no member");
     break;
 
-  case ConstraintKind::Class:
-    assert(!Member && "Type property cannot have a member");
-    assert(Second.isNull() && "Type property with second type");
-    break;
-
   case ConstraintKind::Defaultable:
     assert(!First.isNull());
     assert(!Second.isNull());
@@ -185,10 +180,6 @@ Constraint *Constraint::clone(ConstraintSystem &cs) const {
   case ConstraintKind::Defaultable:
     return create(cs, getKind(), getFirstType(), getSecondType(),
                   getMember(), getFunctionRefKind(), getLocator());
-
-  case ConstraintKind::Class:
-    return create(cs, getKind(), getFirstType(), Type(), DeclName(),
-                  FunctionRefKind::Compound, getLocator());
 
   case ConstraintKind::Disjunction:
     return createDisjunction(cs, getNestedConstraints(), getLocator());
@@ -299,10 +290,6 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm) const {
     break;
   case ConstraintKind::TypeMember:
     Out << "[." << Types.Member << ": type] == ";
-    break;
-  case ConstraintKind::Class:
-    Out << " is a class";
-    skipSecond = true;
     break;
   case ConstraintKind::Defaultable:
     Out << " can default to ";
@@ -481,7 +468,6 @@ gatherReferencedTypeVars(Constraint *constraint,
     SWIFT_FALLTHROUGH;
 
   case ConstraintKind::BindOverload:
-  case ConstraintKind::Class:
   case ConstraintKind::ConformsTo:
   case ConstraintKind::LiteralConformsTo:
   case ConstraintKind::SelfObjectOfProtocol:

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -82,7 +82,6 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second,
     assert(Member && "Member constraint has no member");
     break;
 
-  case ConstraintKind::Archetype:
   case ConstraintKind::Class:
     assert(!Member && "Type property cannot have a member");
     assert(Second.isNull() && "Type property with second type");
@@ -187,7 +186,6 @@ Constraint *Constraint::clone(ConstraintSystem &cs) const {
     return create(cs, getKind(), getFirstType(), getSecondType(),
                   getMember(), getFunctionRefKind(), getLocator());
 
-  case ConstraintKind::Archetype:
   case ConstraintKind::Class:
     return create(cs, getKind(), getFirstType(), Type(), DeclName(),
                   FunctionRefKind::Compound, getLocator());
@@ -301,10 +299,6 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm) const {
     break;
   case ConstraintKind::TypeMember:
     Out << "[." << Types.Member << ": type] == ";
-    break;
-  case ConstraintKind::Archetype:
-    Out << " is an archetype";
-    skipSecond = true;
     break;
   case ConstraintKind::Class:
     Out << " is a class";
@@ -486,7 +480,6 @@ gatherReferencedTypeVars(Constraint *constraint,
     constraint->getSecondType()->getTypeVariables(typeVars);
     SWIFT_FALLTHROUGH;
 
-  case ConstraintKind::Archetype:
   case ConstraintKind::BindOverload:
   case ConstraintKind::Class:
   case ConstraintKind::ConformsTo:

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -115,9 +115,6 @@ enum class ConstraintKind : char {
   /// \brief The first type has a type member with the given name, and the
   /// type of that member, when referenced as a type, is the second type.
   TypeMember,
-  /// \brief The first type is a class or an archetype of a class-bound
-  /// protocol.
-  Class,
   /// \brief The first type can be defaulted to the second (which currently
   /// cannot be dependent).  This is more like a type property than a
   /// relational constraint.
@@ -139,7 +136,8 @@ enum class ConstraintClassification : char {
   /// it a reference type.
   Member,
 
-  /// \brief A property of a single type, such as whether it is an class.
+  /// \brief A property of a single type, such as whether it is defaultable to
+  /// a particular type.
   TypeProperty,
 
   /// \brief A disjunction constraint.
@@ -487,7 +485,6 @@ public:
     case ConstraintKind::TypeMember:
       return ConstraintClassification::Member;
 
-    case ConstraintKind::Class:
     case ConstraintKind::DynamicTypeOf:
     case ConstraintKind::Defaultable:
       return ConstraintClassification::TypeProperty;

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -115,8 +115,6 @@ enum class ConstraintKind : char {
   /// \brief The first type has a type member with the given name, and the
   /// type of that member, when referenced as a type, is the second type.
   TypeMember,
-  /// \brief The first type must be an archetype.
-  Archetype,
   /// \brief The first type is a class or an archetype of a class-bound
   /// protocol.
   Class,
@@ -141,7 +139,7 @@ enum class ConstraintClassification : char {
   /// it a reference type.
   Member,
 
-  /// \brief A property of a single type, such as whether it is an archetype.
+  /// \brief A property of a single type, such as whether it is an class.
   TypeProperty,
 
   /// \brief A disjunction constraint.
@@ -489,7 +487,6 @@ public:
     case ConstraintKind::TypeMember:
       return ConstraintClassification::Member;
 
-    case ConstraintKind::Archetype:
     case ConstraintKind::Class:
     case ConstraintKind::DynamicTypeOf:
     case ConstraintKind::Defaultable:

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -359,16 +359,7 @@ bool ConstraintSystem::addConstraint(Constraint *constraint) {
     return true;
 
   case SolutionKind::Unsolved:
-    // We couldn't solve this constraint; add it to the pile.
-    InactiveConstraints.push_back(constraint);
-
-    // Add this constraint to the constraint graph.
-    CG.addConstraint(constraint);
-
-    if (solverState) {
-      solverState->generatedConstraints.push_back(constraint);
-    }
-
+    addUnsolvedConstraint(constraint);
     return false;
   }
 }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -333,9 +333,7 @@ ConstraintLocator *ConstraintSystem::getConstraintLocator(
   return getConstraintLocator(anchor, path, builder.getSummaryFlags());
 }
 
-bool ConstraintSystem::addConstraint(Constraint *constraint,
-                                     bool isExternallySolved,
-                                     bool simplifyExisting) {
+bool ConstraintSystem::addConstraint(Constraint *constraint) {
   switch (simplifyConstraint(*constraint)) {
   case SolutionKind::Error:
     if (!failedConstraint) {
@@ -344,9 +342,7 @@ bool ConstraintSystem::addConstraint(Constraint *constraint,
 
     if (solverState) {
       solverState->retiredConstraints.push_front(constraint);
-      if (!simplifyExisting) {
-        solverState->generatedConstraints.push_back(constraint);
-      }
+      solverState->generatedConstraints.push_back(constraint);
     }
 
     return false;
@@ -357,27 +353,19 @@ bool ConstraintSystem::addConstraint(Constraint *constraint,
     // Record solved constraint.
     if (solverState) {
       solverState->retiredConstraints.push_front(constraint);
-      if (!simplifyExisting)
-        solverState->generatedConstraints.push_back(constraint);
+      solverState->generatedConstraints.push_back(constraint);
     }
 
-    // Remove the constraint from the constraint graph.
-    if (simplifyExisting)
-      CG.removeConstraint(constraint);
-    
     return true;
 
   case SolutionKind::Unsolved:
     // We couldn't solve this constraint; add it to the pile.
-    if (!isExternallySolved) {
-      InactiveConstraints.push_back(constraint);        
-    }
+    InactiveConstraints.push_back(constraint);
 
     // Add this constraint to the constraint graph.
-    if (!simplifyExisting)
-      CG.addConstraint(constraint);
+    CG.addConstraint(constraint);
 
-    if (!simplifyExisting && solverState) {
+    if (solverState) {
       solverState->generatedConstraints.push_back(constraint);
     }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -395,10 +395,8 @@ ConstraintSystem::getMemberType(TypeVariableType *baseTypeVar,
     // retain the associated type throughout.
     auto loc = getConstraintLocator(locator);
     auto memberTypeVar = createTypeVariable(loc, options);
-    addConstraint(Constraint::create(*this, ConstraintKind::TypeMember,
-                                     baseTypeVar, memberTypeVar, 
-                                     assocType->getName(), 
-                                     FunctionRefKind::Compound, loc));
+    addTypeMemberConstraint(baseTypeVar, assocType->getName(),
+                            memberTypeVar, loc);
     return memberTypeVar;
   });
 }
@@ -431,11 +429,8 @@ namespace {
                            Locator.withPathElement(member));
           auto memberTypeVar = CS.createTypeVariable(locator,
                                                      TVO_PrefersSubtypeBinding);
-          CS.addConstraint(Constraint::create(CS, ConstraintKind::TypeMember,
-                                              baseTypeVar, memberTypeVar,
-                                              member->getName(),
-                                              FunctionRefKind::Compound,
-                                              locator));
+          CS.addTypeMemberConstraint(baseTypeVar, member->getName(),
+                                     memberTypeVar, locator);
           return memberTypeVar;
         }
                                 
@@ -462,11 +457,8 @@ namespace {
                                                    TVO_PrefersSubtypeBinding);
 
         // Bind the member's type variable as a type member of the base.
-        CS.addConstraint(Constraint::create(CS, ConstraintKind::TypeMember,
-                                            baseTypeVar, memberTypeVar, 
-                                            member->getName(),
-                                            FunctionRefKind::Compound,
-                                            locator));
+        CS.addTypeMemberConstraint(baseTypeVar, member->getName(),
+                                   memberTypeVar, locator);
 
         return memberTypeVar;
       });
@@ -1441,13 +1433,8 @@ void ConstraintSystem::addOverloadSet(Type boundType,
     overloads.push_back(Constraint::createBindOverload(*this, boundType, choice,
                                                        locator));
   }
-  
-  auto disjunction = Constraint::createDisjunction(*this, overloads, locator);
-  
-  if (favoredChoice)
-    disjunction->setFavored();
-  
-  addConstraint(disjunction);
+
+  addDisjunctionConstraint(overloads, locator, ForgetChoice, favoredChoice);
 }
 
 void ConstraintSystem::resolveOverload(ConstraintLocator *locator,

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1384,14 +1384,8 @@ public:
 
   /// \brief Add a constraint to the constraint system.
   void addConstraint(ConstraintKind kind, Type first, Type second,
-                     ConstraintLocator *locator, bool isFavored = false) {
-    assert(first && "Missing first type");
-    assert(second && "Missing second type");
-    auto c = Constraint::create(*this, kind, first, second, DeclName(),
-                                FunctionRefKind::Compound, locator);
-    if (isFavored) c->setFavored();
-    addConstraint(c);
-  }
+                     ConstraintLocatorBuilder locator,
+                     bool isFavored = false);
 
   /// Add a new constraint with a restriction on its application.
   void addRestrictedConstraint(ConstraintKind kind,

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1983,9 +1983,6 @@ private:
   /// \brief Attempt to simplify the given DynamicTypeOf constraint.
   SolutionKind simplifyDynamicTypeOfConstraint(const Constraint &constraint);
 
-  /// \brief Attempt to simplify the given class constraint.
-  SolutionKind simplifyClassConstraint(const Constraint &constraint);
-  
   /// \brief Attempt to simplify the given defaultable constraint.
   SolutionKind simplifyDefaultableConstraint(const Constraint &c);
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1393,14 +1393,11 @@ public:
     addConstraint(c);
   }
 
+  /// Add a new constraint with a restriction on its application.
   void addRestrictedConstraint(ConstraintKind kind,
                                ConversionRestrictionKind restriction,
                                Type first, Type second,
-                               ConstraintLocatorBuilder locator) {
-    addConstraint(Constraint::createRestricted(*this, kind, restriction,
-                                               first, second,
-                                               getConstraintLocator(locator)));
-  }
+                               ConstraintLocatorBuilder locator);
 
   /// Add a constraint that binds an overload set to a specific choice.
   void addBindOverloadConstraint(Type boundTy, OverloadChoice choice,
@@ -2002,11 +1999,21 @@ private:
 
   /// \brief Simplify a conversion constraint by applying the given
   /// reduction rule, which is known to apply at the outermost level.
-  SolutionKind simplifyRestrictedConstraint(ConversionRestrictionKind restriction,
-                                            Type type1, Type type2,
-                                            TypeMatchKind matchKind,
-                                            TypeMatchOptions flags,
-                                            ConstraintLocatorBuilder locator);
+  SolutionKind simplifyRestrictedConstraintImpl(
+                 ConversionRestrictionKind restriction,
+                 Type type1, Type type2,
+                 TypeMatchKind matchKind,
+                 TypeMatchOptions flags,
+                 ConstraintLocatorBuilder locator);
+
+  /// \brief Simplify a conversion constraint by applying the given
+  /// reduction rule, which is known to apply at the outermost level.
+  SolutionKind simplifyRestrictedConstraint(
+                 ConversionRestrictionKind restriction,
+                 Type type1, Type type2,
+                 TypeMatchKind matchKind,
+                 TypeMatchOptions flags,
+                 ConstraintLocatorBuilder locator);
 
 public: // FIXME: Public for use by static functions.
   /// \brief Simplify a conversion constraint with a fix applied to it.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1402,8 +1402,7 @@ public:
   /// Add a constraint that binds an overload set to a specific choice.
   void addBindOverloadConstraint(Type boundTy, OverloadChoice choice,
                                  ConstraintLocator *locator) {
-    addConstraint(Constraint::createBindOverload(*this, boundTy, choice, 
-                                                 locator));
+    resolveOverload(locator, boundTy, choice);
   }
 
   /// \brief Add a value member constraint to the constraint system.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1463,6 +1463,20 @@ public:
     addConstraint(constraint);
   }
 
+  /// \brief Add a newly-generated constraint that is known not to be solvable
+  /// right now.
+  void addUnsolvedConstraint(Constraint *constraint) {
+    // We couldn't solve this constraint; add it to the pile.
+    InactiveConstraints.push_back(constraint);
+
+    // Add this constraint to the constraint graph.
+    CG.addConstraint(constraint);
+
+    // Record this as a newly-generated constraint.
+    if (solverState)
+      solverState->generatedConstraints.push_back(constraint);
+  }
+
   /// \brief Remove an inactive constraint from the current constraint graph.
   void removeInactiveConstraint(Constraint *constraint) {
     CG.removeConstraint(constraint);

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1783,8 +1783,6 @@ public:
 public:
   /// \brief Flags that direct type matching.
   enum TypeMatchFlags {
-    TMF_None = 0,
-
     /// \brief Indicates that we are in a context where we should be
     /// generating constraints for any unsolvable problems.
     ///
@@ -1804,12 +1802,16 @@ public:
     TMF_UnwrappingOptional = 0x8,
   };
 
+  /// Options that govern how type matching should proceed.
+  typedef OptionSet<TypeMatchFlags> TypeMatchOptions;
+
 private:
   /// \brief Subroutine of \c matchTypes(), which matches up two tuple types.
   ///
   /// \returns the result of performing the tuple-to-tuple conversion.
   SolutionKind matchTupleTypes(TupleType *tuple1, TupleType *tuple2,
-                                         TypeMatchKind kind, unsigned flags,
+                                         TypeMatchKind kind,
+                               TypeMatchOptions flags,
                                          ConstraintLocatorBuilder locator);
 
   /// \brief Subroutine of \c matchTypes(), which matches a scalar type to
@@ -1817,7 +1819,8 @@ private:
   ///
   /// \returns the result of performing the scalar-to-tuple conversion.
   SolutionKind matchScalarToTupleTypes(Type type1, TupleType *tuple2,
-                                       TypeMatchKind kind, unsigned flags,
+                                       TypeMatchKind kind,
+                                       TypeMatchOptions flags,
                                        ConstraintLocatorBuilder locator);
 
   /// \brief Subroutine of \c matchTypes(), which extracts a scalar value from
@@ -1825,19 +1828,20 @@ private:
   ///
   /// \returns the result of performing the tuple-to-scalar conversion.
   SolutionKind matchTupleToScalarTypes(TupleType *tuple1, Type type2,
-                                       TypeMatchKind kind, unsigned flags,
+                                       TypeMatchKind kind,
+                                       TypeMatchOptions flags,
                                        ConstraintLocatorBuilder locator);
 
   /// \brief Subroutine of \c matchTypes(), which matches up two function
   /// types.
   SolutionKind matchFunctionTypes(FunctionType *func1, FunctionType *func2,
-                                  TypeMatchKind kind, unsigned flags,
+                                  TypeMatchKind kind, TypeMatchOptions flags,
                                   ConstraintLocatorBuilder locator);
 
   /// \brief Subroutine of \c matchTypes(), which matches up a value to a
   /// superclass.
   SolutionKind matchSuperclassTypes(Type type1, Type type2,
-                                    TypeMatchKind kind, unsigned flags,
+                                    TypeMatchKind kind, TypeMatchOptions flags,
                                     ConstraintLocatorBuilder locator);
 
   /// \brief Subroutine of \c matchTypes(), which matches up two types that
@@ -1853,7 +1857,8 @@ private:
   /// but when matching the instance type of a metatype with the instance type
   /// of an existential metatype, since we want an actual conformance check.
   SolutionKind matchExistentialTypes(Type type1, Type type2,
-                                     ConstraintKind kind, unsigned flags,
+                                     ConstraintKind kind,
+                                     TypeMatchOptions flags,
                                      ConstraintLocatorBuilder locator);
 
 public: // FIXME: public due to statics in CSSimplify.cpp
@@ -1875,7 +1880,8 @@ public: // FIXME: public due to statics in CSSimplify.cpp
   ///
   /// \returns the result of attempting to solve this constraint.
   SolutionKind matchTypes(Type type1, Type type2, TypeMatchKind kind,
-                          unsigned flags, ConstraintLocatorBuilder locator);
+                          TypeMatchOptions flags,
+                          ConstraintLocatorBuilder locator);
 
 public:
   /// \brief Resolve the given overload set to the given choice.
@@ -1937,7 +1943,7 @@ private:
   /// occurred.
   SolutionKind simplifyConstructionConstraint(Type valueType, 
                                               FunctionType *fnType,
-                                              unsigned flags,
+                                              TypeMatchOptions flags,
                                               FunctionRefKind functionRefKind,
                                               ConstraintLocator *locator);
 
@@ -1951,7 +1957,8 @@ private:
   SolutionKind simplifyConformsToConstraint(Type type, ProtocolDecl *protocol,
                                             ConstraintKind kind,
                                             ConstraintLocatorBuilder locator,
-                                            unsigned flags);
+                                            TypeMatchOptions flags);
+
   /// \brief Attempt to simplify the given conformance constraint.
   ///
   /// \param type The type being testing.
@@ -1965,7 +1972,7 @@ private:
   SolutionKind simplifyConformsToConstraint(Type type, Type protocol,
                                             ConstraintKind kind,
                                             ConstraintLocatorBuilder locator,
-                                            unsigned flags);
+                                            TypeMatchOptions flags);
 
   /// Attempt to simplify a checked-cast constraint.
   SolutionKind simplifyCheckedCastConstraint(Type fromType, Type toType,
@@ -1998,7 +2005,7 @@ private:
   SolutionKind simplifyRestrictedConstraint(ConversionRestrictionKind restriction,
                                             Type type1, Type type2,
                                             TypeMatchKind matchKind,
-                                            unsigned flags,
+                                            TypeMatchOptions flags,
                                             ConstraintLocatorBuilder locator);
 
 public: // FIXME: Public for use by static functions.
@@ -2006,7 +2013,7 @@ public: // FIXME: Public for use by static functions.
   SolutionKind simplifyFixConstraint(Fix fix,
                                      Type type1, Type type2,
                                      TypeMatchKind matchKind,
-                                     unsigned flags,
+                                     TypeMatchOptions flags,
                                      ConstraintLocatorBuilder locator);
 
 public:

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1448,14 +1448,6 @@ public:
                                      locator));
   }
 
-  /// \brief Add an archetype constraint.
-  void addArchetypeConstraint(Type baseTy, ConstraintLocator *locator) {
-    assert(baseTy);
-    addConstraint(Constraint::create(*this, ConstraintKind::Archetype,
-                                     baseTy, Type(), DeclName(),
-                                     FunctionRefKind::Compound, locator));
-  }
-
   /// \brief Add a disjunction constraint.
   void addDisjunctionConstraint(ArrayRef<Constraint *> constraints,
                                 ConstraintLocatorBuilder locator,
@@ -1990,9 +1982,6 @@ private:
 
   /// \brief Attempt to simplify the given DynamicTypeOf constraint.
   SolutionKind simplifyDynamicTypeOfConstraint(const Constraint &constraint);
-
-  /// \brief Attempt to simplify the given archetype constraint.
-  SolutionKind simplifyArchetypeConstraint(const Constraint &constraint);
 
   /// \brief Attempt to simplify the given class constraint.
   SolutionKind simplifyClassConstraint(const Constraint &constraint);

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1379,16 +1379,8 @@ public:
   /// \brief Add a newly-allocated constraint after attempting to simplify
   /// it.
   ///
-  /// \param isExternallySolved Whether this constraint is being solved
-  /// as an eager simplification, outside of the simplify() loop.
-  ///
-  /// \param simplifyExisting Whether we're simplifying an existing
-  /// constraint rather than introducing a new constraint.
-  ///
   /// \returns true if this constraint was solved.
-  bool addConstraint(Constraint *constraint,
-                     bool isExternallySolved = false,
-                     bool simplifyExisting = false);
+  bool addConstraint(Constraint *constraint);
 
   /// \brief Add a constraint to the constraint system.
   void addConstraint(ConstraintKind kind, Type first, Type second,

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -363,9 +363,6 @@ enum class TypeMatchKind : char {
   /// \brief Require the types to match exactly, but strips lvalueness from
   /// a type when binding to a type variable.
   SameType,
-  /// \brief Require that the first type conform to the second type (which
-  /// must be a protocol).
-  ConformsTo,
   /// \brief Require the first type to be a subtype of the second type
   /// (or be an exact match or trivial subtype).
   Subtype,
@@ -1499,14 +1496,13 @@ public:
   /// Whether we should add a new constraint to capture a failure.
   bool shouldAddNewFailingConstraint() const {
     // Only do this at the top level.
-    return !solverState;
+    return !failedConstraint;
   }
 
   /// Add a new constraint that we know fails.
   void addNewFailingConstraint(Constraint *constraint) {
     assert(shouldAddNewFailingConstraint());
-    if (!failedConstraint)
-      failedConstraint = constraint;
+    failedConstraint = constraint;
   }
 
   /// \brief Add a newly-generated constraint that is known not to be solvable

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2047,22 +2047,14 @@ bool TypeChecker::typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt) {
       
         // Determine the iterator type of the sequence.
         iteratorType = cs.createTypeVariable(Locator, /*options=*/0);
-        cs.addConstraint(Constraint::create(
-                           cs, ConstraintKind::TypeMember,
-                           SequenceType, iteratorType,
-                           tc.Context.Id_Iterator,
-                           FunctionRefKind::Compound,
-                           iteratorLocator));
+        cs.addTypeMemberConstraint(SequenceType, tc.Context.Id_Iterator,
+                                   iteratorType, iteratorLocator);
 
         // Determine the element type of the iterator.
         // FIXME: Should look up the type witness.
         elementType = cs.createTypeVariable(Locator, /*options=*/0);
-        cs.addConstraint(Constraint::create(
-                           cs, ConstraintKind::TypeMember,
-                           iteratorType, elementType,
-                           tc.Context.Id_Element,
-                           FunctionRefKind::Compound,
-                           elementLocator));
+        cs.addTypeMemberConstraint(iteratorType, tc.Context.Id_Element,
+                                   elementType, elementLocator);
       }
       
 


### PR DESCRIPTION
<!-- What's in this pull request? -->

This PR introduces a number of cleanups to the constraint solver centered around ensuring that we don't allocate or record constraints that could be immediately simplified. It is not algorithmically different, but it eliminates extraneous churn from constraints in several places:
- When we went to add a new constraint, we would create a new `Constraint` instance, then simplify it and immediately move it over to the inactive list (possibly to be revisited later).
- When `matchTypes()` would generate a new constraint, it would use the same interface, which caused us to attempt to simplify exactly the same constraint again.

This task isn't 100% complete, because there are still some constraints that are getting preallocated. However, the PR is getting larger than I'd like to keep out of master.

Along the way, kill two kinds of constraints that aren't getting used any more (`Class` and `Archetype`) as well as `TypeMatchKind::ConformsTo`, which had a very weird role.

@rudkx , hopefully this doesn't break what you're working on

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
