### PR TITLE
SIL: Introduce lowered SILLayouts.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -85,6 +85,7 @@ namespace swift {
   class Substitution;
   class TypeCheckerDebugConsumer;
   class DocComment;
+  class SILBoxType;
 
   enum class KnownProtocolKind : uint8_t;
 
@@ -155,6 +156,8 @@ public:
 
   ~ConstraintCheckerArenaRAII();
 };
+
+class SILLayout; // From SIL
 
 /// \brief Describes either a nominal type declaration or an extension
 /// declaration.
@@ -784,6 +787,10 @@ public:
                             clang::ObjCInterfaceDecl *classDecl,
                             bool forInstance);
 
+  /// Retrieve a generic signature with a single unconstrained type parameter,
+  /// like `<T>`.
+  CanGenericSignature getSingleGenericParameterSignature() const;
+  
   /// Whether our effective Swift version is in the Swift 3 family
   bool isSwiftVersion3() const { return LangOpts.isSwiftVersion3(); }
 
@@ -821,6 +828,12 @@ private:
 
   friend class ArchetypeType;
   friend class ArchetypeBuilder::PotentialArchetype;
+
+  /// Provide context-level uniquing for SIL lowered type layouts.
+  friend SILLayout;
+  llvm::FoldingSet<SILLayout> *&getSILLayouts();
+  friend SILBoxType;
+  llvm::DenseMap<CanType, SILBoxType *> &getSILBoxTypes();
 };
 
 /// Retrieve information about the given Objective-C method for

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -99,7 +99,8 @@ public:
 /// Describes the generic signature of a particular declaration, including
 /// both the generic type parameters and the requirements placed on those
 /// generic parameters.
-class GenericSignature final : public llvm::FoldingSetNode,
+class alignas(1 << TypeAlignInBits) GenericSignature final
+  : public llvm::FoldingSetNode,
     private llvm::TrailingObjects<GenericSignature, GenericTypeParamType *,
                                   Requirement> {
   friend TrailingObjects;

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -538,6 +538,19 @@ namespace llvm {
       return swift::CanType((swift::TypeBase*)P);
     }
   };
+
+  template<>
+  class PointerLikeTypeTraits<swift::CanGenericSignature> {
+  public:
+    static inline swift::CanGenericSignature getFromVoidPointer(void *P) {
+      return swift::CanGenericSignature((swift::GenericSignature*)P);
+    }
+    static inline void *getAsVoidPointer(swift::CanGenericSignature S) {
+      return (void*)S.getPointer();
+    }
+    enum { NumLowBitsAvailable = swift::TypeAlignInBits };
+  };
+  
 } // end namespace llvm
 
 #endif

--- a/include/swift/AST/TypeAlignments.h
+++ b/include/swift/AST/TypeAlignments.h
@@ -40,6 +40,7 @@ namespace swift {
   class ProtocolDecl;
   class ProtocolConformance;
   class Stmt;
+  class Substitution;
   class TypeVariableType;
   class TypeBase;
   class ValueDecl;

--- a/include/swift/SIL/SILLayout.h
+++ b/include/swift/SIL/SILLayout.h
@@ -1,0 +1,154 @@
+//===--- SILLayout.h - Defines SIL-level aggregate layouts ------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines classes that describe the physical layout of nominal
+// types in SIL, including structs, classes, and boxes. This is distinct from
+// the AST-level layout for several reasons:
+// - It avoids redundant work lowering the layout of aggregates from the AST.
+// - It allows optimizations to manipulate the layout of aggregates without
+//   requiring changes to the AST. For instance, optimizations can eliminate
+//   dead fields from instances or turn invariant fields into global variables.
+// - It allows for SIL-only aggregates to exist, such as boxes.
+// - It improves the robustness of code in the face of resilience. A resilient
+//   type can be modeled in SIL as not having a layout at all, preventing the
+//   inappropriate use of fragile projection and injection operations on the
+//   type.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_LAYOUT_H
+#define SWIFT_SIL_LAYOUT_H
+
+#include "llvm/ADT/PointerIntPair.h"
+#include "swift/AST/GenericSignature.h"
+#include "swift/AST/Identifier.h"
+#include "swift/AST/Types.h"
+#include "swift/SIL/SILAllocated.h"
+#include "swift/SIL/SILType.h"
+
+namespace swift {
+
+/// A field of a SIL aggregate layout.
+class SILField final {
+  enum : unsigned {
+    IsMutable = 0x1,
+  };
+  
+  static constexpr const unsigned NumFlags = 1;
+
+  llvm::PointerIntPair<CanType, NumFlags, unsigned> LoweredTypeAndFlags;
+  
+  static unsigned getFlagsValue(bool Mutable) {
+    unsigned flags = 0;
+    if (Mutable) flags |= IsMutable;
+    
+    assert(flags >> NumFlags == 0
+           && "more flags than flag bits?!");
+    return flags;
+  }
+  
+public:
+  SILField(CanType LoweredType, bool Mutable)
+    : LoweredTypeAndFlags(LoweredType, getFlagsValue(Mutable))
+  {}
+  
+  /// Get the lowered type of the field in the aggregate.
+  ///
+  /// This must be a lowered SIL type. If the containing aggregate is generic,
+  /// then this type specifies the abstraction pattern at which values stored
+  /// in this aggregate should be lowered.
+  CanType getLoweredType() const { return LoweredTypeAndFlags.getPointer(); }
+  
+  SILType getAddressType() const {
+    return SILType::getPrimitiveAddressType(getLoweredType());
+  }
+  SILType getObjectType() const {
+    return SILType::getPrimitiveObjectType(getLoweredType());
+  }
+  
+  /// True if this field is mutable inside its aggregate.
+  ///
+  /// This is only effectively a constraint on shared mutable reference types,
+  /// such as classes and boxes. A value type or uniquely-owned immutable
+  /// reference can always be mutated, since doing so is equivalent to
+  /// destroying the old value and emplacing a new value with the modified
+  /// field in the same place.
+  bool isMutable() const { return LoweredTypeAndFlags.getInt() & IsMutable; }
+};
+
+/// A layout.
+class SILLayout final : public llvm::FoldingSetNode,
+                        private llvm::TrailingObjects<SILLayout, SILField>
+{
+  friend TrailingObjects;
+
+  enum : unsigned {
+    IsMutable = 0x1,
+  };
+  
+  static constexpr const unsigned NumFlags = 1;
+  
+  static unsigned getFlagsValue(bool Mutable) {
+    unsigned flags = 0;
+    if (Mutable)
+      flags |= IsMutable;
+    
+    assert(flags >> NumFlags == 0
+           && "more flags than flag bits?!");
+    return flags;
+  }
+  
+  llvm::PointerIntPair<CanGenericSignature, NumFlags, unsigned>
+    GenericSigAndFlags;
+  
+  unsigned NumFields;
+  
+  SILLayout(CanGenericSignature Signature,
+            ArrayRef<SILField> Fields);
+  
+  SILLayout(const SILLayout &) = delete;
+  SILLayout &operator=(const SILLayout &) = delete;
+public:
+  /// Get or create a layout.
+  static SILLayout *get(ASTContext &C,
+                        CanGenericSignature Generics,
+                        ArrayRef<SILField> Fields);
+  
+  /// Get the generic signature in which this layout exists.
+  CanGenericSignature getGenericSignature() const {
+    return GenericSigAndFlags.getPointer();
+  }
+  
+  /// True if the layout contains any mutable fields.
+  bool isMutable() const {
+    return GenericSigAndFlags.getInt() & IsMutable;
+  }
+  
+  /// Get the fields inside the layout.
+  ArrayRef<SILField> getFields() const {
+    return llvm::makeArrayRef(getTrailingObjects<SILField>(), NumFields);
+  }
+  
+  /// Produce a profile of this layout, for use in a folding set.
+  static void Profile(llvm::FoldingSetNodeID &id,
+                      CanGenericSignature Generics,
+                      ArrayRef<SILField> Fields);
+  
+  /// \brief Produce a profile of this locator, for use in a folding set.
+  void Profile(llvm::FoldingSetNodeID &id) {
+    Profile(id, getGenericSignature(), getFields());
+  }
+};
+
+} // end namespace swift
+
+#endif // SWIFT_SIL_LAYOUT_H

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -29,6 +29,7 @@
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILGlobalVariable.h"
 #include "swift/SIL/Notifications.h"
+#include "swift/SIL/SILLayout.h"
 #include "swift/SIL/SILType.h"
 #include "swift/SIL/SILVTable.h"
 #include "swift/SIL/SILWitnessTable.h"
@@ -91,6 +92,7 @@ private:
   friend class SILDefaultWitnessTable;
   friend class SILFunction;
   friend class SILGlobalVariable;
+  friend class SILLayout;
   friend class SILType;
   friend class SILVTable;
   friend class SILUndef;

--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -21,6 +21,7 @@ add_swift_library(swiftSIL STATIC
   SILGlobalVariable.cpp
   SILInstruction.cpp
   SILInstructions.cpp
+  SILLayout.cpp
   SILLocation.cpp
   SILModule.cpp
   SILOpenedArchetypesTracker.cpp

--- a/lib/SIL/SILLayout.cpp
+++ b/lib/SIL/SILLayout.cpp
@@ -1,0 +1,116 @@
+//===--- SILLayout.cpp - Defines SIL-level aggregate layouts ----*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines classes that describe the physical layout of nominal
+// types in SIL, including structs, classes, and boxes. This is distinct from
+// the AST-level layout for several reasons:
+// - It avoids redundant work lowering the layout of aggregates from the AST.
+// - It allows optimizations to manipulate the layout of aggregates without
+//   requiring changes to the AST. For instance, optimizations can eliminate
+//   dead fields from instances or turn invariant fields into global variables.
+// - It allows for SIL-only aggregates to exist, such as boxes.
+// - It improves the robustness of code in the face of resilience. A resilient
+//   type can be modeled in SIL as not having a layout at all, preventing the
+//   inappropriate use of fragile projection and injection operations on the
+//   type.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SIL/SILLayout.h"
+#include "swift/SIL/SILModule.h"
+
+using namespace swift;
+
+static bool anyMutable(ArrayRef<SILField> Fields) {
+  for (auto &field : Fields) {
+    if (field.isMutable())
+      return true;
+  }
+  return false;
+}
+
+SILLayout *SILLayout::get(ASTContext &C,
+                          CanGenericSignature Generics,
+                          ArrayRef<SILField> Fields) {
+  // Profile the layout parameters.
+  llvm::FoldingSetNodeID id;
+  Profile(id, Generics, Fields);
+  
+  // Return an existing layout if there is one.
+  void *insertPos;
+  auto *&Layouts = C.getSILLayouts();
+  if (!Layouts)
+    Layouts = new llvm::FoldingSet<SILLayout>;
+  
+  if (auto existing = Layouts->FindNodeOrInsertPos(id, insertPos))
+    return existing;
+  
+  // Allocate a new layout.
+  void *memory = C.Allocate(totalSizeToAlloc<SILField>(Fields.size()),
+                            alignof(SILLayout));
+  
+  auto newLayout = ::new (memory) SILLayout(Generics, Fields);
+  Layouts->InsertNode(newLayout, insertPos);
+  return newLayout;
+}
+
+#ifndef NDEBUG
+/// Verify that the types of fields are valid within a given generic signature.
+static void verifyFields(CanGenericSignature Sig, ArrayRef<SILField> Fields) {
+  for (auto &field : Fields) {
+    auto ty = field.getLoweredType();
+    // Layouts should never refer to archetypes, since they represent an
+    // abstract generic type layout.
+    assert(!ty->hasArchetype()
+           && "SILLayout field cannot have an archetype type");
+    assert(!ty->hasTypeVariable()
+           && "SILLayout cannot contain constraint system type variables");
+    if (!ty->hasTypeParameter())
+      continue;
+    field.getLoweredType().findIf([Sig](Type t) -> bool {
+      if (auto gpt = t->getAs<GenericTypeParamType>()) {
+        // Check that the generic param exists in the generic signature.
+        assert(Sig && "generic param in nongeneric layout?");
+        assert(std::find(Sig.getGenericParams().begin(),
+                         Sig.getGenericParams().end(),
+                         gpt->getCanonicalType()) != Sig.getGenericParams().end()
+               && "generic param not declared in generic signature?!");
+      }
+      return false;
+    });
+  }
+}
+#endif
+
+SILLayout::SILLayout(CanGenericSignature Sig,
+                     ArrayRef<SILField> Fields)
+  : GenericSigAndFlags(Sig, getFlagsValue(anyMutable(Fields))),
+    NumFields(Fields.size())
+{
+#ifndef NDEBUG
+  verifyFields(Sig, Fields);
+#endif
+  auto FieldsMem = getTrailingObjects<SILField>();
+  for (unsigned i : indices(Fields)) {
+    new (FieldsMem) SILField(Fields[i]);
+  }
+}
+
+void SILLayout::Profile(llvm::FoldingSetNodeID &id,
+                        CanGenericSignature Generics,
+                        ArrayRef<SILField> Fields) {
+  id.AddPointer(Generics.getPointer());
+  for (auto &field : Fields) {
+    id.AddPointer(field.getLoweredType().getPointer());
+    id.AddBoolean(field.isMutable());
+  }
+}


### PR DESCRIPTION
This gives us a concept we can eventually use to cache the lowered physical layout of fragile structs and classes, and more immediately, concretize the layout of closure boxes in a way that lets us represent the capture of generic environments and multiple captured values without compromising the "nominal" nature of box layouts. To start exercising the basic implementation, change the representation of SILBoxType to be in terms of a SILLayout, though avoid any immediate functionality change by preserving the single-boxed-type interface for now.
