### PR TITLE
Set ownership qualifier flag on SILFunctions instead of as a global flag

### DIFF
--- a/include/swift/SIL/InstructionUtils.h
+++ b/include/swift/SIL/InstructionUtils.h
@@ -73,6 +73,48 @@ SILValue stripIndexingInsts(SILValue V);
 /// intrinsic call.
 SILValue stripExpectIntrinsic(SILValue V);
 
+/// A utility class for evaluating whether a newly parsed or deserialized
+/// function has qualified or unqualified ownership.
+///
+/// The reason that we are using this is that we would like to avoid needing to
+/// add code to the SILParser or to the Serializer to support this temporary
+/// staging concept of a function having qualified or unqualified
+/// ownership. Once SemanticARC is complete, SILFunctions will always have
+/// qualified ownership, so the notion of an unqualified ownership function will
+/// no longer exist.
+///
+/// Thus we note that there are three sets of instructions in SIL from an
+/// ownership perspective:
+///
+///    a. ownership qualified instructions
+///    b. ownership unqualified instructions
+///    c. instructions that do not have ownership semantics (think literals,
+///       geps, etc).
+///
+/// The set of functions can be split into ownership qualified and ownership
+/// unqualified using the rules that:
+///
+///    a. a function can never contain both ownership qualified and ownership
+///       unqualified instructions.
+///    b. a function that contains only instructions without ownership semantics
+///       is considered ownership qualified.
+///
+/// Thus we can know when parsing/serializing what category of function we have
+/// and set the bit appropriately.
+class FunctionOwnershipEvaluator {
+  NullablePtr<SILFunction> F;
+  bool HasOwnershipQualifiedInstruction = false;
+
+public:
+  FunctionOwnershipEvaluator() {}
+  FunctionOwnershipEvaluator(SILFunction *F) : F(F) {}
+  void reset(SILFunction *NewF) {
+    F = NewF;
+    HasOwnershipQualifiedInstruction = false;
+  }
+  bool evaluate(const SILInstruction &I);
+};
+
 } // end namespace swift
 
 #endif

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -176,6 +176,17 @@ private:
   ///    method itself. In this case we need to create a vtable stub for it.
   bool Zombie = false;
 
+  /// True if SILOwnership is enabled for this function. It is always false when
+  /// the SILOption HasQualifiedOwnership is not set. When the SILOption
+  /// HasQualifiedOwnership /is/ set, this value is initialized to true. Once
+  /// the
+  /// OwnershipModelEliminator runs on the function, it is set to false.
+  ///
+  /// This enables the verifier to easily prove that before the Ownership Model
+  /// Eliminator runs on a function, we only see a non-semantic-arc world and
+  /// after the pass runs, we only see a semantic-arc world.
+  Optional<bool> HasQualifiedOwnership;
+
   SILFunction(SILModule &module, SILLinkage linkage,
               StringRef mangledName, CanSILFunctionType loweredType,
               GenericEnvironment *genericEnv,
@@ -280,6 +291,30 @@ public:
   
   /// Returns true if this function is dead, but kept in the module's zombie list.
   bool isZombie() const { return Zombie; }
+
+  /// Returns true if this function has qualified ownership instructions in it.
+  Optional<bool> hasQualifiedOwnership() const {
+    if (HasQualifiedOwnership.hasValue())
+      return HasQualifiedOwnership.getValue();
+    return None;
+  }
+
+  /// Returns true if this function has unqualified ownership instructions in
+  /// it.
+  Optional<bool> hasUnqualifedOwnership() const {
+    if (HasQualifiedOwnership.hasValue())
+      return !HasQualifiedOwnership.getValue();
+    return None;
+  }
+
+  /// Sets the HasQualifiedOwnership flag to false. This signals to SIL that no
+  /// ownership instructions should be in this function any more.
+  void setUnqualifiedOwnership() {
+    assert(
+        HasQualifiedOwnership.hasValue() &&
+        "Should never set unqualified ownership when SILOwnership is disabled");
+    HasQualifiedOwnership = false;
+  }
 
   /// Returns the calling convention used by this entry point.
   SILFunctionTypeRepresentation getRepresentation() const {

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -729,8 +729,7 @@ public:
 
   /// verify - Run the IR verifier to make sure that the SILFunction follows
   /// invariants.
-  void verify(bool SingleFunction = true,
-              bool EnforceSILOwnership = false) const;
+  void verify(bool SingleFunction = true) const;
 
   /// Pretty-print the SILFunction.
   void dump(bool Verbose) const;

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -553,7 +553,7 @@ public:
 
   /// \brief Run the SIL verifier to make sure that all Functions follow
   /// invariants.
-  void verify(bool EnforceSILOwnership = false) const;
+  void verify() const;
 
   /// Pretty-print the module.
   void dump(bool Verbose = false) const;

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -102,7 +102,6 @@ class SILVerifier : public SILVerifierBase<SILVerifier> {
   const SILInstruction *CurInstruction = nullptr;
   DominanceInfo *Dominance = nullptr;
   bool SingleFunction = true;
-  bool EnforceSILOwnership;
 
   SILVerifier(const SILVerifier&) = delete;
   void operator=(const SILVerifier&) = delete;
@@ -129,6 +128,12 @@ public:
   }
 #define require(condition, complaint) \
   _require(bool(condition), complaint ": " #condition)
+#define requireTrueOrNone(condition, complaint)                                \
+  _require(!condition.hasValue() || bool(condition.getValue()),                \
+           complaint ": " #condition)
+#define requireFalseOrNone(condition, complaint)                               \
+  _require(!condition.hasValue() || !bool(condition.getValue()),               \
+           complaint ": " #condition)
 
   template <class T> typename CanTypeWrapperTraits<T>::type
   _requireObjectType(SILType type, const Twine &valueDescription,
@@ -407,11 +412,10 @@ public:
     }
   }
 
-  SILVerifier(const SILFunction &F, bool SingleFunction = true,
-              bool EnforceSILOwnership = false)
+  SILVerifier(const SILFunction &F, bool SingleFunction = true)
       : M(F.getModule().getSwiftModule()), F(F), TC(F.getModule().Types),
-        OpenedArchetypes(F), Dominance(nullptr), SingleFunction(SingleFunction),
-        EnforceSILOwnership(EnforceSILOwnership) {
+        OpenedArchetypes(F), Dominance(nullptr),
+        SingleFunction(SingleFunction) {
     if (F.isExternalDeclaration())
       return;
       
@@ -1118,16 +1122,24 @@ public:
     case LoadOwnershipQualifier::Unqualified:
       // We should not see loads with unqualified ownership when SILOwnership is
       // enabled.
-      require(!EnforceSILOwnership, "Invalid load with unqualified ownership");
+      requireFalseOrNone(
+          F.hasQualifiedOwnership(),
+          "Load with unqualified ownership in a qualified function");
       break;
     case LoadOwnershipQualifier::Copy:
     case LoadOwnershipQualifier::Take:
+      requireTrueOrNone(
+          F.hasQualifiedOwnership(),
+          "Load with qualified ownership in an unqualified function");
       // TODO: Could probably make this a bit stricter.
       require(!LI->getType().isTrivial(LI->getModule()),
               "load [copy] or load [take] can only be applied to non-trivial "
               "types");
       break;
     case LoadOwnershipQualifier::Trivial:
+      requireTrueOrNone(
+          F.hasQualifiedOwnership(),
+          "Load with qualified ownership in an unqualified function");
       require(LI->getType().isTrivial(LI->getModule()),
               "A load with trivial ownership must load a trivial type");
       break;
@@ -1135,6 +1147,9 @@ public:
   }
 
   void checkLoadBorrowInst(LoadBorrowInst *LBI) {
+    requireTrueOrNone(
+        F.hasQualifiedOwnership(),
+        "Inst with qualified ownership in a function that is not qualified");
     require(LBI->getType().isObject(), "Result of load must be an object");
     require(LBI->getType().isLoadable(LBI->getModule()),
             "Load must have a loadable type");
@@ -1145,6 +1160,9 @@ public:
   }
 
   void checkEndBorrowInst(EndBorrowInst *EBI) {
+    requireTrueOrNone(
+        F.hasQualifiedOwnership(),
+        "Inst with qualified ownership in a function that is not qualified");
     // We allow for end_borrow to express relationships in between addresses and
     // values, but we require that the types are the same ignoring value
     // category.
@@ -1169,16 +1187,23 @@ public:
     case StoreOwnershipQualifier::Unqualified:
       // We should not see loads with unqualified ownership when SILOwnership is
       // enabled.
-      require(!EnforceSILOwnership, "Invalid load with unqualified ownership");
+      requireFalseOrNone(F.hasQualifiedOwnership(),
+                         "Invalid load with unqualified ownership");
       break;
     case StoreOwnershipQualifier::Init:
     case StoreOwnershipQualifier::Assign:
+      requireTrueOrNone(
+          F.hasQualifiedOwnership(),
+          "Inst with qualified ownership in a function that is not qualified");
       // TODO: Could probably make this a bit stricter.
       require(!SI->getSrc()->getType().isTrivial(SI->getModule()),
               "store [init] or store [assign] can only be applied to "
               "non-trivial types");
       break;
     case StoreOwnershipQualifier::Trivial:
+      requireTrueOrNone(
+          F.hasQualifiedOwnership(),
+          "Inst with qualified ownership in a function that is not qualified");
       require(SI->getSrc()->getType().isTrivial(SI->getModule()),
               "A store with trivial ownership must store a trivial type");
       break;
@@ -3510,12 +3535,12 @@ public:
 
 /// verify - Run the SIL verifier to make sure that the SILFunction follows
 /// invariants.
-void SILFunction::verify(bool SingleFunction, bool EnforceSILOwnership) const {
+void SILFunction::verify(bool SingleFunction) const {
 #ifndef NDEBUG
   // Please put all checks in visitSILFunction in SILVerifier, not here. This
   // ensures that the pretty stack trace in the verifier is included with the
   // back trace when the verifier crashes.
-  SILVerifier(*this, SingleFunction, EnforceSILOwnership).verify();
+  SILVerifier(*this, SingleFunction).verify();
 #endif
 }
 
@@ -3645,7 +3670,7 @@ void SILGlobalVariable::verify() const {
 }
 
 /// Verify the module.
-void SILModule::verify(bool EnforceSILOwnership) const {
+void SILModule::verify() const {
 #ifndef NDEBUG
   // Uniquing set to catch symbol name collisions.
   llvm::StringSet<> symbolNames;
@@ -3656,7 +3681,7 @@ void SILModule::verify(bool EnforceSILOwnership) const {
       llvm::errs() << "Symbol redefined: " << f.getName() << "!\n";
       assert(false && "triggering standard assertion failure routine");
     }
-    f.verify(/*SingleFunction=*/false, EnforceSILOwnership);
+    f.verify(/*SingleFunction=*/false);
   }
 
   // Check all globals.

--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -86,12 +86,11 @@ bool swift::runSILDiagnosticPasses(SILModule &Module) {
     return Ctx.hadError();
   }
 
-  // If SILOwnership is enabled, run the ownership model eliminator
+  // If SILOwnership is enabled, run the ownership model eliminator.
   if (Module.getOptions().EnableSILOwnership) {
     PM.addOwnershipModelEliminator();
     PM.runOneIteration();
     PM.resetAndRemoveTransformations();
-    Module.verify(true);
   }
 
   // Otherwise run the rest of diagnostics.

--- a/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
@@ -137,8 +137,12 @@ namespace {
 
 struct OwnershipModelEliminator : SILFunctionTransform {
   void run() override {
-    bool MadeChange = false;
     SILFunction *F = getFunction();
+    // We should only run this when SILOwnership is enabled.
+    assert(F->getModule().getOptions().EnableSILOwnership &&
+           "Can not run ownership model eliminator when SIL ownership is not "
+           "enabled");
+    bool MadeChange = false;
     SILBuilder B(*F);
     OwnershipModelEliminatorVisitor Visitor(B);
 
@@ -158,6 +162,10 @@ struct OwnershipModelEliminator : SILFunctionTransform {
       // that analysis.
       invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
     }
+
+    // Now that we have lowered to unqualified ownership, set the unqualified
+    // ownership flag on the function.
+    F->setUnqualifiedOwnership();
   }
 
   StringRef getName() override { return "Ownership Model Eliminator"; }

--- a/lib/Serialization/DeserializeSIL.h
+++ b/lib/Serialization/DeserializeSIL.h
@@ -10,9 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/Serialization/ModuleFile.h"
 #include "SILFormat.h"
+#include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/SILModule.h"
+#include "swift/Serialization/ModuleFile.h"
 #include "swift/Serialization/SerializedSILLoader.h"
 
 #include "llvm/ADT/DenseMap.h"
@@ -83,6 +84,7 @@ namespace swift {
     /// Read a SIL instruction within a given SIL basic block.
     bool readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
                             SILBuilder &Builder,
+                            FunctionOwnershipEvaluator &OwnershipEvaluator,
                             unsigned RecordKind,
                             SmallVectorImpl<uint64_t> &scratch);
 

--- a/test/SILOptimizer/ownership_model_eliminator.sil
+++ b/test/SILOptimizer/ownership_model_eliminator.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -ownership-model-eliminator %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-ownership -ownership-model-eliminator %s | %FileCheck %s
 
 sil_stage canonical
 
@@ -9,8 +9,6 @@ sil @use_int32 : $@convention(thin) (Builtin.Int32) -> ()
 
 // CHECK-LABEL: sil @load : $@convention(thin) (@in Builtin.NativeObject, @in Builtin.Int32) -> () {
 // CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : $*Builtin.Int32):
-// CHECK: [[LOAD1:%[0-9]+]] = load [[ARG1]] : $*Builtin.NativeObject
-// CHECK: apply {{%[0-9]+}}([[LOAD1]])
 // CHECK: [[LOAD2:%[0-9]+]] = load [[ARG1]] : $*Builtin.NativeObject
 // CHECK: apply {{%[0-9]+}}([[LOAD2]])
 // CHECK: [[LOAD3:%[0-9]+]] = load [[ARG1]] : $*Builtin.NativeObject
@@ -22,9 +20,6 @@ sil @load : $@convention(thin) (@in Builtin.NativeObject, @in Builtin.Int32) -> 
 bb0(%0 : $*Builtin.NativeObject, %1 : $*Builtin.Int32):
   %use_native_object_func = function_ref @use_native_object : $@convention(thin) (@owned Builtin.NativeObject) -> ()
   %use_int32_func = function_ref @use_int32 : $@convention(thin) (Builtin.Int32) -> ()
-
-  %2 = load %0 : $*Builtin.NativeObject
-  apply %use_native_object_func(%2) : $@convention(thin) (@owned Builtin.NativeObject) -> ()
 
   %3 = load [take] %0 : $*Builtin.NativeObject
   apply %use_native_object_func(%3) : $@convention(thin) (@owned Builtin.NativeObject) -> ()
@@ -42,14 +37,12 @@ bb0(%0 : $*Builtin.NativeObject, %1 : $*Builtin.Int32):
 // CHECK-LABEL: sil @store : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject, @in Builtin.Int32, Builtin.Int32) -> ()
 // CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : $Builtin.NativeObject, [[ARG3:%[0-9]+]] : $*Builtin.Int32, [[ARG4:%[0-9]+]] : $Builtin.Int32):
 // CHECK: store [[ARG2]] to [[ARG1]] : $*Builtin.NativeObject
-// CHECK: store [[ARG2]] to [[ARG1]] : $*Builtin.NativeObject
 // CHECK: [[OLDVAL:%[0-9]+]] = load [[ARG1]] : $*Builtin.NativeObject
 // CHECK: store [[ARG2]] to [[ARG1]] : $*Builtin.NativeObject
 // CHECK: release_value [[OLDVAL]]
 // CHECK: store [[ARG4]] to [[ARG3]] : $*Builtin.Int32
 sil @store : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject, @in Builtin.Int32, Builtin.Int32) -> () {
 bb0(%0 : $*Builtin.NativeObject, %1 : $Builtin.NativeObject, %2 : $*Builtin.Int32, %3 : $Builtin.Int32):
-  store %1 to %0 : $*Builtin.NativeObject
   store %1 to [init] %0 : $*Builtin.NativeObject
   store %1 to [assign] %0 : $*Builtin.NativeObject
   store %3 to [trivial] %2 : $*Builtin.Int32


### PR DESCRIPTION
[semantic-arc] As staging detail, add a HasQualifiedOwnership flag on all SILFunctions.

Over the past day or so I have been thinking about how we are going to need to
manage verification of semantic ARC semantics in the pass pipeline. Specifically
the Eliminator pass really needs to be a function pass to ensure that we can
transparently put it at any stage of the optimization pipeline. This means that
just having a flag on the SILVerifier that states whether or not ownership is
enabled is not sufficient for our purposes. Instead, while staging in the SIL
ownership model, we need a bit on all SILFunctions to state whether the function
has been run through the ownership model eliminator so that the verifier can
ensure that we are in a world with "SIL ownership" or in a world without "SIL
ownership", never in a world with only some "SIL ownership" instructions. We
embed this distinction in SIL by creating the concept of a function with
"qualified ownership" and a function with "unqualified ownership".

Define a function with "qualified ownership" as a function that contains no
instructions with "unqualified ownership" (i.e. unqualified load) and a function
with "unqualified ownership" as a function containing such no "ownership
qualified" instructions (i.e. load [copy]) and at least 1 unqualified ownership
instruction.

This PR embeds this distinction into SILFunction in a manner that is
transparently ignored when compiling with SIL ownership disabled. This is done
by representing qualified or unqualified ownership via an optional Boolean on
SILFunction. If the Boolean is None, then SILOwnership is not enabled and the
verifier/passes can work as appropriate. If the Boolean is not None, then it
states whether or not the function has been run through the Ownership Model
Eliminator and thus what invariants the verifier should enforce.

How does this concept flow through the compilation pipeline for functions in a
given module? When SIL Ownership is enabled, all SILFunctions that are produced
in a given module start with "qualified ownership" allowing them to contain SIL
ownership instructions. After the Ownership Model eliminator has run, the
Ownership Model sets the "unqualified" ownership flag on the SILFunction stating
that no more ownership qualified instructions are allowed to be seen in the
given function.

But what about functions that are parsed or are deserialized from another
module? Luckily, given the manner in which we have categories our functions, we
can categorize functions directly without needing to add anything to the parser
or to the deserializer. This is done by enforcing that it is illegal to have a
function with qualified ownership and unqualified ownership instructions and
asserting that functions without either are considered qualified.

rdar://28685236
