### PR TITLE
[semantic-arc] When comparing load,store instructions for equality, compare their ownership qualifiers as well.

### DIFF
--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -280,7 +280,8 @@ namespace {
     }
 
     bool visitLoadInst(const LoadInst *RHS) {
-      return true;
+      auto LHSQualifier = cast<LoadInst>(LHS)->getOwnershipQualifier();
+      return LHSQualifier == RHS->getOwnershipQualifier();
     }
 
     bool visitLoadBorrowInst(const LoadBorrowInst *RHS) { return true; }
@@ -289,7 +290,8 @@ namespace {
 
     bool visitStoreInst(const StoreInst *RHS) {
       auto *X = cast<StoreInst>(LHS);
-      return (X->getSrc() == RHS->getSrc() && X->getDest() == RHS->getDest());
+      return X->getSrc() == RHS->getSrc() && X->getDest() == RHS->getDest() &&
+        X->getOwnershipQualifier() == RHS->getOwnershipQualifier();
     }
 
     bool visitBindMemoryInst(const BindMemoryInst *RHS) {


### PR DESCRIPTION
[semantic-arc] When comparing load,store instructions for equality, compare their ownership qualifiers as well.

I noticed this by inspection since I had to update this code for load_borrow,
but did not update it for the ownership qualified load/store.

rdar://28685236
