### PR TITLE
[Lexer] Trim comments off operator-identifier before tokenize

### DIFF
--- a/test/Parse/comment_operator.swift
+++ b/test/Parse/comment_operator.swift
@@ -27,3 +27,9 @@ func test6() { _ = 1+/* */2 }                 // expected-error {{'+' is not a p
 _ = foo!// this is dangerous
 _ = 1 +/**/ 2
 _ = 1 +/* hi */2
+
+// Ensure built-in operators are properly tokenized.
+_ =/**/2
+_/**/= 2
+typealias A = () ->/* */()
+func test7(x: Int) { _ = x./* desc */ } // expected-error {{expected member name following '.'}}


### PR DESCRIPTION
Builtin operators followed by comment block used to be tokenized as
normal operators (e.g. `tok::oper_binary_spaced`) instead of dedicated
token(e.g. `tok::equal`).
That causes strange errors:

```
test.swift:1:3: error: use of unresolved operator '='
_ =/* */2
  ^
```
