### PR TITLE
Remove dead code that I forgot to remove when implementing parsing of qualified stores.

### DIFF
--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -2519,13 +2519,6 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
 
     SILType ValType = addrVal->getType().getObjectType();
 
-    if (Opcode == ValueKind::StoreInst) {
-      ResultVal = B.createStore(InstLoc,
-                                getLocalValue(from, ValType, InstLoc, B),
-                                addrVal);
-      break;
-    }
-
     assert(Opcode == ValueKind::AssignInst);
     ResultVal = B.createAssign(InstLoc,
                                getLocalValue(from, ValType, InstLoc, B),


### PR DESCRIPTION
Remove dead code that I forgot to remove when implementing parsing of qualified stores

This is just the StoreInst path in the old code in SILParser that jumbled
together parsing StoreWeakInst, StoreInst, AssignInst, and StoreUnownedInst.
