### PR TITLE
[sil] Complement ValueBase::getParentBB() with ValueBase::get{Function,Module}()

### DIFF
--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -29,6 +29,8 @@ namespace swift {
   class ValueBaseUseIterator;
   class ValueUseIterator;
   class SILBasicBlock;
+  class SILFunction;
+  class SILModule;
   class SILInstruction;
   class SILLocation;
   class DominanceInfo;
@@ -119,6 +121,14 @@ public:
   /// If this is a SILArgument or a SILInstruction get its parent basic block,
   /// otherwise return null.
   SILBasicBlock *getParentBB();
+
+  /// If this is a SILArgument or a SILInstruction get its parent function,
+  /// otherwise return null.
+  SILFunction *getFunction();
+
+  /// If this is a SILArgument or a SILInstruction get its parent module,
+  /// otherwise return null.
+  SILModule *getModule();
 };
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,

--- a/lib/SIL/SILValue.cpp
+++ b/lib/SIL/SILValue.cpp
@@ -38,3 +38,19 @@ SILBasicBlock *ValueBase::getParentBB() {
     return Arg->getParent();
   return nullptr;
 }
+
+SILFunction *ValueBase::getFunction() {
+  if (auto Inst = dyn_cast<SILInstruction>(this))
+    return Inst->getFunction();
+  if (auto Arg = dyn_cast<SILArgument>(this))
+    return Arg->getFunction();
+  return nullptr;
+}
+
+SILModule *ValueBase::getModule() {
+  if (auto Inst = dyn_cast<SILInstruction>(this))
+    return &Inst->getModule();
+  if (auto Arg = dyn_cast<SILArgument>(this))
+    return &Arg->getModule();
+  return nullptr;
+}


### PR DESCRIPTION
[sil] Complement ValueBase::getParentBB() with ValueBase::get{Function,Module}()

These APIs work just like getParentBB does, namely they attempt to cast
self to either SILInstruction/SILArgument and if the instance is one of
those classes, using the APIs on said classes to get the relevant
Function or Module. If the dynamic casts fail, then nullptr is returned.

This is just missing API.
