### PR TITLE
[gardening] Make basic.sil round trip by fixing parsing of mark_uninitialized_behavior.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -2246,6 +2246,27 @@ which are not represented as box allocations.
 It is produced by SILGen, and is only valid in Raw SIL.  It is rewritten as
 appropriate by the definitive initialization pass.
 
+mark_uninitialized_behavior
+```````````````````````````
+::
+
+   init-case ::= sil-value sil-apply-substitution-list? '(' sil-value ')' ':' sil-type
+   set-case ::= sil-value sil-apply-substitution-list? '(' sil-value ')' ':' sil-type
+   sil-instruction ::= 'mark_uninitialized_behavior' init-case set-case
+
+   mark_uninitialized_behavior %init<Subs>(%storage) : $T -> U,
+                               %set<Subs>(%self) : $V -> W
+
+Indicates that a logical property is uninitialized at this point and needs to be
+initialized by the end of the function and before any escape point for this
+instruction. Assignments to the property trigger the behavior's ``init`` or
+``set`` logic based on the logical initialization state of the property.
+
+It is expected that the ``init-case`` is passed some sort of storage and the
+``set`` case is passed ``self``.
+
+This is only valid in Raw SIL.
+
 copy_addr
 `````````
 ::

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -2336,7 +2336,8 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
         || parseValueName(SelfName)
         || P.parseToken(tok::r_paren, diag::expected_tok_in_sil_instr, ")")
         || P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":")
-        || parseSILType(SetterTy, SetterSig, SetterEnv))
+        || parseSILType(SetterTy, SetterSig, SetterEnv)
+        || parseSILDebugLocation(InstLoc, B))
       return true;
     
     // Resolve the types of the operands.

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-silgen | %FileCheck %s
+// RUN: %target-sil-opt %s | %target-sil-opt | %FileCheck %s
 
 sil_stage raw // CHECK: sil_stage raw
 

--- a/utils/sil-mode.el
+++ b/utils/sil-mode.el
@@ -67,6 +67,7 @@
 
    ;; SIL Instructions - Accessing Memory.
    `(,(regexp-opt '("load" "store" "assign"  "mark_uninitialized"
+                    "mark_uninitialized_behavior"
                     "mark_function_escape" "copy_addr" "destroy_addr"
                     "index_addr" "index_raw_pointer" "bind_memory" "to")
                   'words) . font-lock-keyword-face)


### PR DESCRIPTION
[gardening] Make basic.sil round trip by fixing parsing of mark_uninitialized_behavior.

Noticed this while preparing copy_value, destroy_value. The problem was that we
were not parsing the SIL Debug Location at the end of
mark_uninitialized_behavior.
