### PR TITLE
Finish lazy constraints

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4156,6 +4156,7 @@ ConstraintSystem::addConstraintImpl(ConstraintKind kind, Type first,
   TypeMatchOptions subflags = TMF_GenerateConstraints;
   switch (kind) {
   case ConstraintKind::Equal:
+  case ConstraintKind::Bind:
   case ConstraintKind::BindParam:
   case ConstraintKind::Subtype:
   case ConstraintKind::Conversion:
@@ -4187,16 +4188,6 @@ ConstraintSystem::addConstraintImpl(ConstraintKind kind, Type first,
 
   case ConstraintKind::Defaultable:
     return simplifyDefaultableConstraint(first, second, subflags, locator);
-
-  case ConstraintKind::Bind: { // FIXME: This should go through matchTypes() above
-    // FALLBACK CASE: do the slow thing.
-    auto c = Constraint::create(*this, kind, first, second, DeclName(),
-                                FunctionRefKind::Compound,
-                                getConstraintLocator(locator));
-    if (isFavored) c->setFavored();
-    addConstraint(c);
-    return SolutionKind::Solved;
-  }
 
   case ConstraintKind::ValueMember:
   case ConstraintKind::UnresolvedValueMember:

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -333,37 +333,6 @@ ConstraintLocator *ConstraintSystem::getConstraintLocator(
   return getConstraintLocator(anchor, path, builder.getSummaryFlags());
 }
 
-bool ConstraintSystem::addConstraint(Constraint *constraint) {
-  switch (simplifyConstraint(*constraint)) {
-  case SolutionKind::Error:
-    if (!failedConstraint) {
-      failedConstraint = constraint;
-    }
-
-    if (solverState) {
-      solverState->retiredConstraints.push_front(constraint);
-      solverState->generatedConstraints.push_back(constraint);
-    }
-
-    return false;
-
-  case SolutionKind::Solved:
-    // This constraint has already been solved; there is nothing more
-    // to do.
-    // Record solved constraint.
-    if (solverState) {
-      solverState->retiredConstraints.push_front(constraint);
-      solverState->generatedConstraints.push_back(constraint);
-    }
-
-    return true;
-
-  case SolutionKind::Unsolved:
-    addUnsolvedConstraint(constraint);
-    return false;
-  }
-}
-
 TypeVariableType *
 ConstraintSystem::getMemberType(TypeVariableType *baseTypeVar, 
                                 AssociatedTypeDecl *assocType,

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1389,6 +1389,12 @@ void ConstraintSystem::addOverloadSet(Type boundType,
                                       OverloadChoice *favoredChoice) {
   assert(!choices.empty() && "Empty overload set");
 
+  // If there is a single choice, add the bind overload directly.
+  if (choices.size() == 1) {
+    addBindOverloadConstraint(boundType, choices.front(), locator);
+    return;
+  }
+
   SmallVector<Constraint *, 4> overloads;
   
   // As we do for other favored constraints, if a favored overload has been

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1373,12 +1373,6 @@ public:
   /// emits an error message.
   void diagnoseFailureForExpr(Expr *expr);
 
-  /// \brief Add a newly-allocated constraint after attempting to simplify
-  /// it.
-  ///
-  /// \returns true if this constraint was solved.
-  bool addConstraint(Constraint *constraint);
-
   /// \brief Add a constraint to the constraint system.
   void addConstraint(ConstraintKind kind, Type first, Type second,
                      ConstraintLocatorBuilder locator,

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1490,7 +1490,7 @@ public:
     if (isFavored)
       constraint->setFavored();
 
-    addConstraint(constraint);
+    addUnsolvedConstraint(constraint);
   }
 
   /// Whether we should add a new constraint to capture a failure.


### PR DESCRIPTION
<!-- What's in this pull request? -->

Finish moving over to lazily-created constraints for all kinds of constraints. This is all NFC, but finally kills off the "create a constraint just to immediately simplify it" code path entirely in the solver.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
