### PR TITLE
Fix test for 32 bit platforms by removing align from FileCheck pattern.

### DIFF
--- a/test/IRGen/copy_value_destroy_value.sil
+++ b/test/IRGen/copy_value_destroy_value.sil
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -parse-sil -emit-ir %s | %FileCheck %s
+// REQUIRES: OS=macosx
 
 // Make sure that we are using type lowering and that we are handling the return
 // value correctly.


### PR DESCRIPTION
Fix test for 32 bit platforms by removing align from FileCheck pattern.
