### PR TITLE
[Parse] Allow whitespaces before period in superclass-expression

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -743,10 +743,10 @@ ParserResult<Expr> Parser::parseExprSuper(bool isExprBasic) {
                                             /*Implicit=*/false))
     : cast<Expr>(new (Context) ErrorExpr(superLoc));
   
-  if (Tok.is(tok::period)) {
+  if (Tok.isAny(tok::period, tok::period_prefix)) {
     // 'super.' must be followed by a member or initializer ref.
 
-    SourceLoc dotLoc = consumeToken(tok::period);
+    SourceLoc dotLoc = consumeToken();
     
     if (Tok.is(tok::code_complete)) {
       if (CodeCompletion) {

--- a/test/Parse/super.swift
+++ b/test/Parse/super.swift
@@ -26,6 +26,11 @@ class D : B {
     let _: () -> D = self.init // expected-error {{partial application of 'self.init' initializer delegation is not allowed}}
   }
 
+  init(z: Int) {
+    super
+      .init(x: z)
+  }
+
   func super_calls() {
     super.foo        // expected-error {{expression resolves to an unused l-value}}
     super.foo.bar    // expected-error {{value of type 'Int' has no member 'bar'}}
@@ -35,6 +40,8 @@ class D : B {
     super.init() // expected-error{{'super.init' cannot be called outside of an initializer}}
     super.init(0) // expected-error{{'super.init' cannot be called outside of an initializer}}
     super[0]        // expected-error {{expression resolves to an unused l-value}}
+    super
+      .bar()
   }
 
   func bad_super_1() {


### PR DESCRIPTION
Previously:

```
error: expected '.' or '[' after 'super'
    super .init()
          ^
```

I think there's no reason to reject this while accepting `self  .init()`
