### PR TITLE
Fix generic method overrides

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -866,6 +866,14 @@ public:
   Type getTypeOfMember(ModuleDecl *module, Type memberType,
                        const DeclContext *memberDC);
 
+  /// Get the type of a superclass member as seen from the subclass,
+  /// substituting generic parameters, dynamic Self return, and the
+  /// 'self' argument type as appropriate.
+  Type adjustSuperclassMemberDeclType(const ValueDecl *decl,
+                                      const ValueDecl *parentDecl,
+                                      Type memberType,
+                                      LazyResolver *resolver);
+
   /// Return T if this type is Optional<T>; otherwise, return the null type.
   Type getOptionalObjectType();
 

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -2041,10 +2041,14 @@ SILConstantInfo TypeConverter::getConstantOverrideInfo(SILDeclRef derived,
   auto selfInterfaceTy = derivedInterfaceTy.getInput()->getRValueInstanceType();
 
   auto overrideInterfaceTy =
-      selfInterfaceTy->getTypeOfMember(M.getSwiftModule(), baseInterfaceTy,
-                                       base.getDecl()->getDeclContext());
+      selfInterfaceTy->adjustSuperclassMemberDeclType(
+          derived.getDecl(), base.getDecl(), baseInterfaceTy,
+          /*resolver=*/nullptr);
 
-  // Copy generic signature from derived to the override type
+  // Copy generic signature from derived to the override type, to handle
+  // the case where the base member is not generic (because the base class
+  // is concrete) but the derived member is generic (because the derived
+  // class is generic).
   if (auto derivedInterfaceFnTy = derivedInterfaceTy->getAs<GenericFunctionType>()) {
     auto overrideInterfaceFnTy = overrideInterfaceTy->castTo<AnyFunctionType>();
     overrideInterfaceTy =
@@ -2052,23 +2056,6 @@ SILConstantInfo TypeConverter::getConstantOverrideInfo(SILDeclRef derived,
                                  overrideInterfaceFnTy->getInput(),
                                  overrideInterfaceFnTy->getResult(),
                                  overrideInterfaceFnTy->getExtInfo());
-  }
-
-  // Replace occurrences of 'Self' in the signature with the derived type.
-  // FIXME: these should all be modeled with a DynamicSelfType.
-  overrideInterfaceTy =
-      overrideInterfaceTy->replaceSelfParameterType(selfInterfaceTy);
-  
-  bool hasDynamicSelf = false;
-  if (auto funcDecl = dyn_cast<FuncDecl>(derived.getDecl()))
-    hasDynamicSelf = funcDecl->hasDynamicSelf();
-  else if (isa<ConstructorDecl>(derived.getDecl()))
-    hasDynamicSelf = true;
-  
-  if (hasDynamicSelf) {
-    overrideInterfaceTy =
-        overrideInterfaceTy->replaceCovariantResultType(selfInterfaceTy,
-                                                        base.uncurryLevel + 1);
   }
 
   // Lower the formal AST type.

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -206,7 +206,7 @@ Type CompleteGenericTypeResolver::resolveDependentMemberType(
   // concrete type, or resolve its components down to another dependent member.
   if (auto alias = nestedPA->getTypeAliasDecl()) {
     return TC.substMemberTypeWithBase(DC->getParentModule(), alias,
-                                      baseTy, true);
+                                      baseTy);
   }
   
   Identifier name = ref->getIdentifier();

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -369,8 +369,7 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
 
     // Substitute the base into the member's type.
     auto memberType = substMemberTypeWithBase(dc->getParentModule(),
-                                              typeDecl, type,
-                                              /*isTypeReference=*/true);
+                                              typeDecl, type);
 
     // FIXME: It is not clear why this substitution can fail, but the
     // standard library won't build without this check.

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -337,7 +337,7 @@ Type TypeChecker::resolveTypeInContext(
           }
 
           return substMemberTypeWithBase(parentDC->getParentModule(), typeDecl,
-                                         fromType, /*isTypeReference=*/true);
+                                         fromType);
         }
       }
 
@@ -378,7 +378,7 @@ Type TypeChecker::resolveTypeInContext(
         }
 
         return substMemberTypeWithBase(parentDC->getParentModule(), typeDecl,
-                                       fromType, /*isTypeReference=*/true);
+                                       fromType);
       }
 
       if (auto superclassTy = getSuperClassOf(fromType))
@@ -1142,8 +1142,7 @@ static Type resolveNestedIdentTypeComponent(
 
     // Otherwise, simply substitute the parent type into the member.
     memberType = TC.substMemberTypeWithBase(DC->getParentModule(), typeDecl,
-                                            parentTy,
-                                            /*isTypeReference=*/true);
+                                            parentTy);
 
     // Propagate failure.
     if (!memberType || memberType->hasError()) return memberType;
@@ -2797,21 +2796,18 @@ Type TypeResolver::buildProtocolType(
 }
 
 Type TypeChecker::substMemberTypeWithBase(Module *module,
-                                          const ValueDecl *member,
-                                          Type baseTy, bool isTypeReference) {
-  Type memberType = isTypeReference
-                      ? cast<TypeDecl>(member)->getDeclaredInterfaceType()
-                      : member->getInterfaceType();
-  if (isTypeReference) {
-    // The declared interface type for a generic type will have the type
-    // arguments; strip them off.
-    if (auto nominalTypeDecl = dyn_cast<NominalTypeDecl>(member)) {
-      if (auto boundGenericTy = memberType->getAs<BoundGenericType>()) {
-        memberType = UnboundGenericType::get(
-                       const_cast<NominalTypeDecl *>(nominalTypeDecl),
-                       boundGenericTy->getParent(),
-                       Context);
-      }
+                                          const TypeDecl *member,
+                                          Type baseTy) {
+  Type memberType = member->getDeclaredInterfaceType();
+
+  // The declared interface type for a generic type will have the type
+  // arguments; strip them off.
+  if (auto nominalTypeDecl = dyn_cast<NominalTypeDecl>(member)) {
+    if (auto boundGenericTy = memberType->getAs<BoundGenericType>()) {
+      memberType = UnboundGenericType::get(
+                     const_cast<NominalTypeDecl *>(nominalTypeDecl),
+                     boundGenericTy->getParent(),
+                     Context);
     }
   }
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -855,17 +855,14 @@ public:
                                     bool isGenericSignature,
                                     GenericTypeResolver *resolver);
 
-  /// \brief Substitute the given base type into the type of the given member,
-  /// producing the effective type that the member will have.
+  /// \brief Substitute the given base type into the type of the given nested type,
+  /// producing the effective type that the nested type will have.
   ///
   /// \param module The module in which the substitution will be performed.
   /// \param member The member whose type projection is being computed.
   /// \param baseTy The base type that will be substituted for the 'Self' of the
   /// member.
-  /// \param isTypeReference Whether this is a reference to a type declaration
-  /// within a type context.
-  Type substMemberTypeWithBase(Module *module, const ValueDecl *member,
-                               Type baseTy, bool isTypeReference);
+  Type substMemberTypeWithBase(Module *module, const TypeDecl *member, Type baseTy);
 
   /// \brief Retrieve the superclass type of the given type, or a null type if
   /// the type has no supertype.

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -59,13 +59,15 @@ internal var _emptyArrayStorage : _EmptyArrayStorage {
     Builtin.addressof(&_swiftEmptyArrayStorage))
 }
 
-// FIXME(ABI)#141 : This whole class is a workaround for
-// <rdar://problem/18560464> Can't override generic method in generic
-// subclass.  If it weren't for that bug, we'd override
-// _withVerbatimBridgedUnsafeBuffer directly in
-// _ContiguousArrayStorage<Element>.
-// rdar://problem/19341002
-class _ContiguousArrayStorage1 : _ContiguousArrayStorageBase {
+// The class that implements the storage for a ContiguousArray<Element>
+@_versioned
+final class _ContiguousArrayStorage<Element> : _ContiguousArrayStorageBase {
+
+  deinit {
+    _elementPointer.deinitialize(count: countAndCapacity.count)
+    _fixLifetime(self)
+  }
+
 #if _runtime(_ObjC)
   /// If the `Element` is bridged verbatim, invoke `body` on an
   /// `UnsafeBufferPointer` to the elements and return the result.
@@ -82,28 +84,7 @@ class _ContiguousArrayStorage1 : _ContiguousArrayStorageBase {
 
   /// If `Element` is bridged verbatim, invoke `body` on an
   /// `UnsafeBufferPointer` to the elements.
-  internal func _withVerbatimBridgedUnsafeBufferImpl(
-    _ body: (UnsafeBufferPointer<AnyObject>) throws -> Void
-  ) rethrows {
-    _sanityCheckFailure(
-      "Must override _withVerbatimBridgedUnsafeBufferImpl in derived classes")
-  }
-#endif
-}
-
-// The class that implements the storage for a ContiguousArray<Element>
-@_versioned
-final class _ContiguousArrayStorage<Element> : _ContiguousArrayStorage1 {
-
-  deinit {
-    _elementPointer.deinitialize(count: countAndCapacity.count)
-    _fixLifetime(self)
-  }
-
-#if _runtime(_ObjC)
-  /// If `Element` is bridged verbatim, invoke `body` on an
-  /// `UnsafeBufferPointer` to the elements.
-  internal final override func _withVerbatimBridgedUnsafeBufferImpl(
+  internal final func _withVerbatimBridgedUnsafeBufferImpl(
     _ body: (UnsafeBufferPointer<AnyObject>) throws -> Void
   ) rethrows {
     if _isBridgedVerbatimToObjectiveC(Element.self) {

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -22,6 +22,7 @@ import SwiftShims
 /// of a decoding error.
 /// 
 /// - SeeAlso: `UnicodeCodec.decode(next:)`
+@_fixed_layout
 public enum UnicodeDecodingResult : Equatable {
   /// A decoded Unicode scalar value.
   case scalarValue(UnicodeScalar)

--- a/test/SILGen/vtable_thunks_reabstraction.swift
+++ b/test/SILGen/vtable_thunks_reabstraction.swift
@@ -92,3 +92,33 @@ class ConcreteOptional<X>: Opaque<S?> {
   override func variantOptionality(x: S??) -> S? { return x! }
 }
  */
+
+// Make sure we remap the method's innermost generic parameters
+// to the correct depth
+class GenericBase<T> {
+  func doStuff<U>(t: T, u: U) {}
+  init<U>(t: T, u: U) {}
+}
+
+class ConcreteSub : GenericBase<Int> {
+  override func doStuff<U>(t: Int, u: U) {
+    super.doStuff(t: t, u: u)
+  }
+  override init<U>(t: Int, u: U) {
+    super.init(t: t, u: u)
+  }
+}
+
+class ConcreteBase {
+  init<U>(t: Int, u: U) {}
+  func doStuff<U>(t: Int, u: U) {}
+}
+
+class GenericSub<T> : ConcreteBase {
+  override init<U>(t: Int, u: U) {
+    super.init(t: t, u: u)
+  }
+  override func doStuff<U>(t: Int, u: U) {
+    super.doStuff(t: t, u: u)
+  }
+}

--- a/test/attr/attr_override.swift
+++ b/test/attr/attr_override.swift
@@ -380,4 +380,25 @@ class MismatchOptional3 : MismatchOptionalBase {
   override func result() -> Optional<Int> { return nil } // expected-error {{cannot override instance method result type 'Int' with optional type 'Optional<Int>'}} {{none}}
 }
 
+// Make sure we remap the method's innermost generic parameters
+// to the correct depth
+class GenericBase<T> {
+  func doStuff<U>(t: T, u: U) {}
+  init<U>(t: T, u: U) {}
+}
 
+class ConcreteSub : GenericBase<Int> {
+  override func doStuff<U>(t: Int, u: U) {}
+  override init<U>(t: Int, u: U) {}
+}
+
+class ConcreteBase {
+  init<U>(t: Int, u: U) {}
+  func doStuff<U>(t: Int, u: U) {}
+
+}
+
+class GenericSub<T> : ConcreteBase {
+  override init<U>(t: Int, u: U) {}
+  override func doStuff<U>(t: Int, u: U) {}
+}


### PR DESCRIPTION
This fixes a tricky corner case where method overrides did not work in the following case:
- the method itself had generic parameters
- the base class was generic and the derived class was not, or vice versa

Eg,

```
class Base { func generic<T>(t: T) {} }
class Derived<U> : Base { override func generic<T>(t: T) {} }
```

Fixes rdar://problem/18560464, https://bugs.swift.org/browse/SR-2427,
https://bugs.swift.org/browse/SR-2721.
