### PR TITLE
[semantic-arc] Bump module format version number.

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 278; // Last change: end_borrow and load_borrow
+const uint16_t VERSION_MINOR = 279; // Last change: copy_value, destroy_value
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;


### PR DESCRIPTION
I had several versions of the copy value, destroy value patch and in one of them
I bumped the module file version number. The one I committed was not one of
those = /.

Sorry Jordan!
