### PR TITLE
Third batch of changelog edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Swift 3.1
 
 * [SR-1009](https://bugs.swift.org/browse/SR-1009):
 
-  Constrained extensions allow same-type constraints between generic parameters and concrete types.
+  Constrained extensions allow same-type constraints between generic parameters and concrete types. This enables you to create extensions, for example, on `Array` with `Int` elements:
 
   ```swift
   extension Array where Element == Int { }
@@ -30,10 +30,11 @@ Swift 3.1
 
 * [SE-0045][]:
 
-  The `Sequence` protocol adds new members `prefix(while:)` and
-  `drop(while:)`.  `prefix(while:)` requests the longest subsequence
-  satisfying a predicate.  `drop(while:)` requests the remaining subsequence
-  after dropping the longest subsequence satisfying a predicate.
+  The `Sequence` protocol adds two new members `prefix(while:)` and
+  `drop(while:)` for common utility. `prefix(while:)` requests the longest subsequence
+  satisfying a predicate.  `drop(while:)` requests the remaining 
+  subsequence after dropping the longest subsequence satisfying a
+  predicate.
 
 Swift 3.0
 ---------
@@ -327,30 +328,31 @@ using the `.dynamicType` member to retrieve the type of an expression should mig
 
 * [SE-0112][]:
 
-  The `NSError` type is now bridged to the Swift `Error` protocol type
-  (formerly called `ErrorProtocol` in Swift 3, `ErrorType` in Swift 2)
-  in Objective-C APIs, much like other Objective-C types are
-  bridged to Swift (e.g., `NSString` being bridged to `String`). For
+  The `NSError` type now bridges to the Swift `Error` protocol type (formerly `ErrorProtocol` in Swift 3, `ErrorType` in Swift 2) 
+  in Objective-C APIs. `NSError` now bridges like other Objective-C types, e.g., `NSString` bridges to `String`.  
+  
+  For
   example, the `UIApplicationDelegate` method
   `applicate(_:didFailToRegisterForRemoteNotificationsWithError:)`
-  changes from accepting an `NSError` argument:
+  previously accepted an `NSError` argument:
 
   ```swift
   optional func application(_ application: UIApplication,
     didFailToRegisterForRemoteNotificationsWithError error: NSError)
   ```
 
-  to accepting an `Error` argument:
+ Now it accepts an `Error` argument:
 
   ```swift
   optional func application(_ application: UIApplication,
     didFailToRegisterForRemoteNotificationsWithError error: Error)
   ```
 
-  Additionally, error types imported from Cocoa[Touch] maintain all of
-  the information in the corresponding `NSError`, so it is no longer
-  necessary to `catch let as NSError` to extract (e.g.) the user-info
-  dictionary. Specific also error types contain typed accessors for
+  Error types imported from Cocoa[Touch] maintain all of
+  the information in the corresponding `NSError`. You no longer `catch let as NSError` to extract, for example, the user-info
+  dictionary. 
+  
+  Specific error types now contain typed accessors for
   their common user-info keys. For example:
 
   ```swift
@@ -359,7 +361,7 @@ using the `.dynamicType` member to retrieve the type of an expression should mig
   }
   ```
 
-  Finally, Swift-defined error types can provide localized error
+  Swift-defined error types can now provide localized error
   descriptions by adopting the new `LocalizedError` protocol, e.g.,
 
   ```swift
@@ -374,14 +376,13 @@ using the `.dynamicType` member to retrieve the type of an expression should mig
   }
   ```
 
-  Similarly, the new `RecoverableError` and `CustomNSError` protocols
+  New `RecoverableError` and `CustomNSError` protocols
   allow additional control over the handling of the error.
 
 * [SE-0060][]:
 
-  Function parameters with default arguments must now be specified in
-  declaration order. A call site must always supply the arguments it provides
-  to a function in their declared order:
+  Function parameters with defaulted arguments are specified in
+  declaration order. Call sites must now supply those arguments using that order:
 
     ```swift
     func requiredArguments(a: Int, b: Int, c: Int) {}
@@ -393,8 +394,7 @@ using the `.dynamicType` member to retrieve the type of an expression should mig
     defaultArguments(b: 0, a: 1, c: 2) // error
     ```
 
-    Arbitrary labeled parameters with default arguments may still be elided, as
-    long as the specified arguments follow declaration order:
+    Labeled parameters with default arguments may still be elided, so long as included arguments follow declaration order:
 
     ```swift
     defaultArguments(a: 0) // ok
@@ -405,13 +405,11 @@ using the `.dynamicType` member to retrieve the type of an expression should mig
     defaultArguments(c: 1, b: 2) // error
     ```
 
-* Traps from force-unwrapping nil `Optional`s now show the source location
-  of the force unwrap operator.
+* Traps from force-unwrapping nil `Optional`s now show the source location of the force unwrap operator.
 
 * [SE-0093][]:
 
-  Slice types now have a `base` property that allows public readonly access
-  to their base collections.
+  Slice types add a `base` property that allows public readonly access to their base collections.
 
 * Nested generic functions may now capture bindings from the environment, for example:
 
@@ -442,9 +440,7 @@ using the `.dynamicType` member to retrieve the type of an expression should mig
 
 * [SE-0081][]:
 
-  "Move `where` clause to end of declaration" is implemented, allowing you to
-  write `where` clauses after the signature for a declaration, but before its
-  body.  For example, before:
+  "Move `where` clause to end of declaration" is now implemented. This change allows you to write `where` clauses after a declaration signature and before its body.  For example, before this change was implemented, you'd write:
 
     ```swift
     func anyCommonElements<T : SequenceType, U : SequenceType
@@ -455,7 +451,7 @@ using the `.dynamicType` member to retrieve the type of an expression should mig
     }
     ```
 
-  after:
+  Now the `where` clause appears just before the body:
 
     ```swift
     func anyCommonElements<T : SequenceType, U : SequenceType>(lhs: T, _ rhs: U) -> Bool
@@ -465,22 +461,18 @@ using the `.dynamicType` member to retrieve the type of an expression should mig
     }
     ```
 
-  The old form is still accepted for compatibility, but will eventually be rejected.
+  The old form is currently accepted for compatibility. It will eventually be rejected.
 
 * [SE-0071][]:
 
-  "Allow (most) keywords in member references" is implemented.  This allows the
-  use of members after a dot without backticks, e.g. "foo.default".
+  "Allow (most) keywords in member references" is implemented.  This change allows the use of members after a dot without backticks, e.g. "foo.default", even though `default` is a keyword for `switch` statements.
 
 * [SE-0057][]:
 
   Objective-C lightweight generic classes are now imported as generic types
-  in Swift. Because Objective-C generics are not represented at runtime,
-  there are some limitations on what can be done with them in Swift:
+  in Swift. Some limitations apply because Objective-C generics are not represented at runtime:
 
-  - If an ObjC generic class is used in a checked `as?`, `as!`, or `is` cast,
-    the generic parameters are not checked at runtime. The cast succeeds if the
-    operand is an instance of the ObjC class, regardless of parameters.
+  - When an ObjC generic class is used in a checked `as?`, `as!`, or `is` cast, the generic parameters are not checked at runtime. The cast succeeds if the operand is an instance of the ObjC class, regardless of parameters.
 
     ```swift
     let x = NSFoo<NSNumber>(value: NSNumber(integer: 0))
@@ -488,8 +480,7 @@ using the `.dynamicType` member to retrieve the type of an expression should mig
     let z = y as! NSFoo<NSString> // Succeeds
     ```
 
-  - Swift subclasses can only inherit an ObjC generic class if its generic
-    parameters are fully specified.
+  - Swift subclasses can only inherit from an ObjC generic class when its generic parameters are fully specified.
 
     ```swift
     // Error: Can't inherit ObjC generic class with unbound parameter T
@@ -499,9 +490,7 @@ using the `.dynamicType` member to retrieve the type of an expression should mig
     class SwiftFoo2<T>: NSFoo<NSString> { }
     ```
 
-  - Swift can extend ObjC generic classes, but the extensions cannot be
-    constrained, and definitions inside the extension do not have access to
-    the class's generic parameters.
+  - Swift can extend ObjC generic classes but the extensions cannot be constrained, and definitions inside the extension don't have access to the class's generic parameters.
 
     ```swift
     extension NSFoo {
@@ -516,33 +505,21 @@ using the `.dynamicType` member to retrieve the type of an expression should mig
     }
     ```
 
-  - Foundation container classes `NS[Mutable]Array`, `NS[Mutable]Set`, and
-    `NS[Mutable]Dictionary` are still imported as nongeneric classes for
-    the time being.
+  - Foundation container classes `NS[Mutable]Array`, `NS[Mutable]Set`, and `NS[Mutable]Dictionary` are still imported as nongeneric classes for the time being.
 
 * [SE-0036][]:
 
   Enum elements can no longer be accessed as instance members in instance methods.
 
-* As part of the changes for [SE-0055][] (see below), the *pointee* types of
-  imported pointers (e.g. the `id` in `id *`) are no longer assumed to always
-  be `_Nullable` even if annotated otherwise. However, an implicit or explicit
-  annotation of `_Null_unspecified` on a pointee type is still imported as
-  `Optional`.
+  * As part of the changes for [SE-0055][] (see below), the *pointee* types of imported pointers (e.g. the `id` in `id *`) are no longer assumed to always be `_Nullable` even if annotated otherwise. 
+  * An implicit or explicit annotation of `_Null_unspecified` on a pointee type still imports as `Optional`.
 
 * [SE-0055][]:
 
   The types `UnsafePointer`, `UnsafeMutablePointer`,
-  `AutoreleasingUnsafeMutablePointer`, `OpaquePointer`, `Selector`, and `Zone`
-  (formerly `NSZone`) now represent non-nullable pointers, i.e. pointers that
-  are never `nil`. A nullable pointer is now represented using `Optional`, e.g.
-  `UnsafePointer<Int>?` For types imported from C, non-object pointers (such as
-  `int *`) now have their nullability taken into account.
+  `AutoreleasingUnsafeMutablePointer`, `OpaquePointer`, `Selector`, and `Zone` (formerly `NSZone`) now represent non-nullable pointers, i.e. pointers that are never `nil`. A nullable pointer is now represented using `Optional`, e.g. `UnsafePointer<Int>?` For types imported from C, non-object pointers (such as `int *`) now have their nullability taken into account.
 
-  One possible area of difficulty is passing a nullable pointer to a function
-  that uses C variadics. Swift will not permit this directly, so as a
-  workaround please use the following idiom to pass it as a pointer-sized
-  integer value instead:
+  One possible area of difficulty is passing a nullable pointer to a function that uses C variadics. Swift will not permit this directly. As a workaround, use the following idiom to pass a pointer-sized integer value instead:
 
   ```swift
   unsafeBitCast(nullablePointer, to: Int.self)
@@ -550,10 +527,7 @@ using the `.dynamicType` member to retrieve the type of an expression should mig
 
 * [SE-0046][]:
 
-  Function parameters now have consistent labeling across all function
-  parameters. With this update the first parameter declarations will
-  now match the existing behavior of the second and later parameters.
-  This change makes the language simpler.
+  Function parameters adopt consistent labeling across all function parameters. With this update, first parameter declarations match the existing behavior of the second and later parameters. This change makes the language simpler.
 
   Functions that were written and called as follows:
 
@@ -565,7 +539,7 @@ using the `.dynamicType` member to retrieve the type of an expression should mig
   bar(a: 3, b: 4)
   ```
 
-  will now be written as (to achieve the same behavior):
+  Are now written as follows with the same behavior at call sites:
 
   ```swift
   func foo(_ x: Int, y: Int) {}
@@ -577,27 +551,24 @@ using the `.dynamicType` member to retrieve the type of an expression should mig
 
 * [SE-0037][]:
 
-  Comments are now treated as whitespace when determining whether an operator is
-  prefix, postfix, or binary. For example, these now work:
+  Comments are now treated as whitespace when determining whether an operator is prefix, postfix, or binary. For example, these now work:
 
   ```swift
   if /*comment*/!foo { ... }
   1 +/*comment*/2
   ```
 
-  This also means that comments can no longer appear between a unary operator
-  and its argument.
+  Comments can no longer appear between a unary operator and its argument.
+  
   ```swift
   foo/* comment */! // no longer works
   ```
 
-  Any parse errors resulting from this change can be resolved by moving the
-  comment outside of the expression.
+ Parse errors resulting from this change can be resolved by moving the comment outside the expression.
 
 * [SE-0031][]:
 
-  The location of the inout attribute has been moved to after the `:` and
-  before the parameter type.
+  The location of the inout attribute moves to after the colon (`:`) and before the parameter type.
 
   ```swift
   func foo(inout x: Int) {
@@ -613,13 +584,11 @@ using the `.dynamicType` member to retrieve the type of an expression should mig
 
 * [SE-0053][]:
 
-  `let` is no longer accepted as a parameter attribute for functions.
-  The compiler provides a fixit to remove it from the function declaration.
+  `let` is no longer accepted as a parameter attribute for functions. The compiler provides a fixit to remove it from the function declaration.
 
 * [SE-0003][]:
 
-  `var` is no longer accepted as a parameter attribute for functions.
-  The compiler provides a fixit to create a shadow copy in the function body.
+  `var` is no longer accepted as a parameter attribute for functions. The compiler provides a fixit to create a shadow copy in the function body.
 
   ```swift
   func foo(var x: Int) {
@@ -634,20 +603,39 @@ using the `.dynamicType` member to retrieve the type of an expression should mig
   }
   ```
 
-* The "none" members of imported NS_OPTIONS option sets are marked as unavailable
-  when they are imported.  Use `[]` to make an empty option set, instead of a
-  None member.
+* The "none" members of imported NS_OPTIONS option sets are marked as unavailable when they are imported.  Use `[]` to make an empty option set, instead of a None member.
 
-* [SE-0043][] landed, adding the ability to declare variables in multiple
-  patterns in cases.
+* [SE-0043][] 
 
-* Renamification landed, so the Clang importer imports ObjC symbols
-  substantially differently.  *Someone should expand on this point.*
+  Adds the ability to declare variables in multiple patterns in cases.
 
-* [SE-0040][] landed, changing attributes from using `=` in parameters lists
+* [SE-0005][] 
+
+  Allows the Clang importer to import ObjC symbols using substantially different Swift-like naming paradigms:
+
+  * These updates generalize the use of `swift_name`, allowing arbitrary C and Objective-C entity import names. This adds fine-grained control over the import process.
+  * Redundant type names are pruned (`documentForURL(_: NSURL)` becomes `document(for: URL)`). Selectors are guaranteed to never be empty, to be transformed into Swift keywords, to be vacuously named (like `get`, `set`, `with`, `for`). Additional pruning rules preserve readability and sense.
+  * Common arguments are sensibly defaulted where the Objective-C API strongly hints at the need for a default argument. (For example,  nullable trailing closures default to `nil`, option sets to `[]`, and `NSDictionary` parameters to `[:]`.) First argument labels are added for defaulted arguments.
+  * Boolean properties are prepended with `is`, and read as assertions on the receiver.
+  * Non-type values, including enumerators, are lowerecased.
+  * Classes that implement `compare(_:) -> NSComparisonResult` automatically import as `Comparable`.
+
+* [SE-0040][] 
+
+  Attributes change from using `=` in parameters lists
   to using `:`, aligning with function call syntax.
+  
+  ```
+  // before
+  @available(*, unavailable, renamed="MyRenamedProtocol")
+  
+  // after
+  @available(*, unavailable, renamed: "MyRenamedProtocol")
+  ```
 
-* Generic typealiases are now supported, e.g.:
+* [SE-0048][] 
+ 
+  Generic typealiases are now supported. For example:
 
   ```swift
   typealias StringDictionary<T> = Dictionary<String, T>
@@ -655,13 +643,12 @@ using the `.dynamicType` member to retrieve the type of an expression should mig
   typealias MatchingTriple<T> = (T, T, T)
   typealias BackwardTriple<T1, T2, T3> = (T3, T2, T1)
   ```
+  
   etc.
 
-* The `@noescape` attribute has been extended to be a more general type attribute.
-  You can now declare values of `@noescape` function type, e.g. in manually
-  curried function signatures.  You can now also declare local variables of
-  `@noescape` type, and use `@noescape` in `typealiases`.  For example, this is now
-  valid code:
+* [SE-0049][] 
+
+  The `@noescape` attribute is extended to be a more general type attribute. You can now declare values of `@noescape` function type, e.g. in manually curried function signatures.  You can now also declare local variables of `@noescape` type, and use `@noescape` in `typealiases`.  For example, this is now valid code:
 
   ```swift
   func apply<T, U>(@noescape f: T -> U,
@@ -670,23 +657,30 @@ using the `.dynamicType` member to retrieve the type of an expression should mig
   }
   ```
 
-* [SE-0034][] has renamed the `#line` directive (which resets the logical
-  source location for diagnostics and debug information) to `#sourceLocation`.
+* [SE-0034][] 
 
-* Curried function syntax has been removed, and now produces a compile-time
-  error.
+  The `#line` directive (which resets the logical
+  source location for diagnostics and debug information) is renamed to `#sourceLocation`.
 
-* Generic signatures can now contain superclass requirements with generic
-  parameter types, for example:
+* [SE-0002][]
+
+  Curried function syntax (with successive parenthesized groups of arguments) is removed, and now produces a compile-time error. Use chained functional return types instead.
+
+```
+// Before
+public func project(function f: FunctionType)(p0: CGPoint, p1: CGPoint)(x: CGFloat) -> CGPoint
+
+// After
+public func project(function f: FunctionType) -> (p0: CGPoint, p1: CGPoint) -> (x: CGFloat) -> CGPoint
+```
+
+* Generic signatures can now contain superclass requirements with generic parameter types, for example:
 
   ```swift
   func f<Food : Chunks<Meat>, Meat : Molerat>(f: Food, m: Meat) {}
   ```
 
-* Section markers are created in ELF binaries through special objects during link time.
-  These objects allow for the deletion of `swift.ld` and the use of non-BFD linkers.
-  A new argument to swiftc is provided to select the linker used, and the gold linker
-  is set as the default for arm-based platforms.
+* Section markers are created in ELF binaries through special objects during link time. These objects allow for the deletion of `swift.ld` and the use of non-BFD linkers. A new argument to swiftc is provided to select the linker used, and the gold linker is set as the default for arm-based platforms.
 
 * Catch blocks in `rethrows` functions may now `throw` errors. For example:
 
@@ -699,6 +693,7 @@ using the `.dynamicType` member to retrieve the type of an expression should mig
         }
     }
     ```
+    
 * Throwing closure arguments of a rethrowing function may now be optional. For example:
 
     ```swift
@@ -709,8 +704,7 @@ using the `.dynamicType` member to retrieve the type of an expression should mig
 
 * [SE-0064][]:
 
-  The Objective-C selectors for the getter or setter of a property can now be
-  referenced with `#selector`. For example:
+  The Objective-C selectors for the getter or setter of a property can now be referenced with `#selector`. For example:
 
     ```swift
     let sel1 = #selector(getter: UIView.backgroundColor) // sel1 has type Selector
@@ -725,7 +719,7 @@ using the `.dynamicType` member to retrieve the type of an expression should mig
     person.valueForKeyPath(#keyPath(Person.bestFriend.lastName))
     ```
 
-**If you are adding a new entry, add it to the top of the file, not here!**
+**Add new entries to the top of this file, not here!**
 
 Swift 2.2
 ---------


### PR DESCRIPTION
@lattner Third (and final) Swift 3 batch of changelog edits. (I stopped at Swift 2.2)

SE-0057 only lightly edited because I did not want to change any meanings. It could use review by a second pair of eyes more familiar with this proposal.

SE-0005 was expanded (per request) and needs secondary review

Since this was the oldest section, I made the lightest edits, trying to preserve meaning but retain as much of the newer structure as possible. I've added a number of examples and tried to add explanations, similar to the newer changelog entries. 
