### PR TITLE
[CMake] Updates for Android NDK r13

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -230,9 +230,11 @@ function(_add_variant_c_compile_flags)
   endif()
 
   if("${CFLAGS_SDK}" STREQUAL "ANDROID")
+    # FIXME: Instead of hardcoding paths in the Android NDK, these paths should
+    #        be passed in via ENV, as with the Windows build.
     list(APPEND result
-        "-I${SWIFT_ANDROID_NDK_PATH}/sources/cxx-stl/llvm-libc++/libcxx/include"
-        "-I${SWIFT_ANDROID_NDK_PATH}/sources/cxx-stl/llvm-libc++abi/libcxxabi/include"
+        "-I${SWIFT_ANDROID_NDK_PATH}/sources/cxx-stl/llvm-libc++/include"
+        "-I${SWIFT_ANDROID_NDK_PATH}/sources/cxx-stl/llvm-libc++abi/include"
         "-I${SWIFT_ANDROID_NDK_PATH}/sources/android/support/include")
   endif()
 
@@ -1368,7 +1370,13 @@ function(add_swift_library name)
         set(swiftlib_private_link_libraries_targets
             ${swiftlib_module_dependency_targets})
         foreach(lib ${SWIFTLIB_PRIVATE_LINK_LIBRARIES})
-          if(TARGET "${lib}${VARIANT_SUFFIX}")
+          if("${lib}" STREQUAL "ICU_UC")
+            list(APPEND swiftlib_private_link_libraries_targets
+                 "${SWIFT_${sdk}_ICU_UC}")
+          elseif("${lib}" STREQUAL "ICU_I18N")
+            list(APPEND swiftlib_private_link_libraries_targets
+                 "${SWIFT_${sdk}_ICU_I18N}")
+          elseif(TARGET "${lib}${VARIANT_SUFFIX}")
             list(APPEND swiftlib_private_link_libraries_targets
                 "${lib}${VARIANT_SUFFIX}")
           else()

--- a/cmake/modules/FindICU.cmake
+++ b/cmake/modules/FindICU.cmake
@@ -27,6 +27,7 @@ endforeach()
 
 foreach(sdk ANDROID;FREEBSD;LINUX;WINDOWS)
   foreach(MODULE ${ICU_FIND_COMPONENTS})
+    string(TOUPPER "${MODULE}" MODULE)
     if("${SWIFT_${sdk}_ICU_${MODULE}_INCLUDE}" STREQUAL "")
       set(SWIFT_${sdk}_ICU_${MODULE}_INCLUDE ${ICU_${MODULE}_INCLUDE_DIRS})
     endif()

--- a/docs/Android.md
+++ b/docs/Android.md
@@ -34,7 +34,7 @@ To follow along with this guide, you'll need:
    The stdlib is currently only buildable for Android from a Linux environment.
    Before attempting to build for Android, please make sure you are able to build
    for Linux by following the instructions in the Swift project README.
-2. The latest version of the Android NDK (r12 at the time of this writing),
+2. The latest version of the Android NDK (r13 at the time of this writing),
    available to download here:
    http://developer.android.com/ndk/downloads/index.html.
 3. An Android device with remote debugging enabled. We require remote
@@ -52,7 +52,7 @@ the Swift stdlib for Android requires the libiconv and libicu libraries.
 However, you'll need versions of these libraries that work on Android devices.
 
 You may download prebuilt copies of these dependencies, built for Ubuntu 15.10
-and Android NDK r12. Click [here](https://github.com/SwiftAndroid/libiconv-libicu-android/releases/download/android-ndk-r12/libiconv-libicu-armeabi-v7a-ubuntu-15.10-ndk-r12.tar.gz)
+and Android NDK r13. Click [here](https://github.com/SwiftAndroid/libiconv-libicu-android/releases/download/android-ndk-r13/libiconv-libicu-armeabi-v7a-ubuntu-15.10-ndk-r13.tar.gz)
 to download, then unzip the archive file.
 
 Alternatively, you may choose to build libiconv and libicu for Android yourself:
@@ -81,7 +81,7 @@ Android NDK, as well as the directories that contain the `libicuuc.so` and
 $ utils/build-script \
     -R \                                       # Build in ReleaseAssert mode.
     --android \                                # Build for Android.
-    --android-ndk /path/to/android-ndk-r12 \   # Path to an Android NDK.
+    --android-ndk /path/to/android-ndk-r13 \   # Path to an Android NDK.
     --android-api-level 21 \                   # The Android API level to target. Swift only supports 21 or greater.
     --android-icu-uc /path/to/libicu-android/armeabi-v7a \
     --android-icu-uc-include /path/to/libicu-android/armeabi-v7a/icu/source/common \
@@ -102,7 +102,7 @@ gold linker in the Android NDK into your `PATH`:
 
 ```
 $ sudo ln -s \
-    /path/to/android-ndk-r12/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/arm-linux-androideabi/bin/ld.gold \
+    /path/to/android-ndk-r13/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/arm-linux-androideabi/bin/ld.gold \
     /usr/bin/armv7-none-linux-androideabi-ld.gold
 ```
 
@@ -112,9 +112,9 @@ source file, targeting Android:
 ```
 $ build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swiftc \                      # The Swift compiler built in the previous step.
     -target armv7-none-linux-androideabi \                                       # Targeting android-armv7.
-    -sdk /path/to/android-ndk-r12/platforms/android-21/arch-arm \                # Use the same NDK path and API version as you used to build the stdlib in the previous step.
-    -L /path/to/android-ndk-r12/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a \   # Link the Android NDK's libc++ and libgcc.
-    -L /path/to/android-ndk-r12/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/lib/gcc/arm-linux-androideabi/4.9 \
+    -sdk /path/to/android-ndk-r13/platforms/android-21/arch-arm \                # Use the same NDK path and API version as you used to build the stdlib in the previous step.
+    -L /path/to/android-ndk-r13/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a \   # Link the Android NDK's libc++ and libgcc.
+    -L /path/to/android-ndk-r13/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/lib/gcc/arm-linux-androideabi/4.9 \
     hello.swift
 ```
 
@@ -155,7 +155,7 @@ $ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/libswi
 In addition, you'll also need to copy the Android NDK's libc++:
 
 ```
-$ adb push /path/to/android-ndk-r12/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a/libc++_shared.so /data/local/tmp
+$ adb push /path/to/android-ndk-r13/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a/libc++_shared.so /data/local/tmp
 ```
 
 Finally, you'll need to copy the `hello` executable you built in the
@@ -198,7 +198,7 @@ $ utils/build-script \
   -R \                                           # Build in ReleaseAssert mode.
   -T \                                           # Run all tests.
   --android \                                    # Build for Android.
-  --android-ndk ~/android-ndk-r12 \              # Path to an Android NDK.
+  --android-ndk ~/android-ndk-r13 \              # Path to an Android NDK.
   --android-ndk-version 21 \
   --android-icu-uc ~/libicu-android/armeabi-v7a/libicuuc.so \
   --android-icu-uc-include ~/libicu-android/armeabi-v7a/icu/source/common \

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -179,7 +179,7 @@ else()
   #  -Wl,--whole-archive swiftRuntime -Wl,--no-whole-archive)
   find_package(ICU REQUIRED COMPONENTS uc i18n)
   list(APPEND swift_core_private_link_libraries
-      ${ICU_UC_LIBRARY} ${ICU_I18N_LIBRARY})
+       ICU_UC ICU_I18N)
 endif()
 
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "CYGWIN")


### PR DESCRIPTION
<!-- What's in this pull request? -->

Fixes the Android build, and makes some adjustments for Android NDK r13.
- Fix FindICU.cmake to properly set the `SWIFT_${sdk}_ICU_UC` and `SWIFT_${sdk}_ICU_I18N` values. These were not properly set because "uc" and "i18n" were lowercase.
- Adapt `add_swift_library` to parse `ICU_UC` and `ICU_I18N` for private link libraries and use the proper `SWIFT_${sdk}_ICU_*` values.
- NDK r13 removes a subdirectory from the llvm-libc++ includes path. Adapt to this change, and add a FIXME to address this issue before it may break again.
- Update the documentation to point to a new libicu download for NDK 13.
