### PR TITLE
[Don't merge] docs: description of new mangling scheme, version 2

### DIFF
--- a/docs/ABI.rst
+++ b/docs/ABI.rst
@@ -720,152 +720,81 @@ Heap Object Header
 
 Mangling
 --------
+
 ::
 
-  mangled-name ::= '_T' global
+  mangled-name ::= '_S' global
 
 All Swift-mangled names begin with this prefix.
+
+The basic mangling scheme is a list of 'operators' where the operators are
+structured in a post-fix order. For example the mangling may start with an
+identifier but only later in the mangling a type-like operator defines how this
+identifier has to be interpreted::
+
+  4Test3FooC   // The trailing 'C' says that 'Foo' is a class in module 'Test'
+
+
+
+Operators are either identifiers or a sequence of one or more characters,
+like ``C`` for class.
+All operators share the same name-space. Important operators are a single
+character, which means that no other operator may start with the same
+character.
+
+Some less important operators are longer and may also contain one or more
+natural numbers. But it's always important that the demangler can identify the
+end (the last character) of an operator. For example, it's not possible to
+determince the last character if there are two operators ``M`` and ``Ma``:
+``a`` could belong to ``M`` or it could be the first charater of the next
+operator.
+
+The intention of the post-fix order is to optimize for common pre-fixes.
+Regardless, if it's the mangling for a metatype or a function in a module, the
+mangled name will start with the module name (after the ``_S``).
+
+In the following, productions which are only _part_ of an operator, are
+named with uppercase letters.
 
 Globals
 ~~~~~~~
 
 ::
 
-  global ::= 't' type                    // standalone type (for DWARF)
-  global ::= 'M' type                    // type metadata (address point)
+  global ::= type 'h'                    // standalone type (for DWARF)
+  global ::= type 'N'                    // type metadata (address point)
                                          // -- type starts with [BCOSTV]
-  global ::= 'Mf' type                   // 'full' type metadata (start of object)
-  global ::= 'MP' type                   // type metadata pattern
-  global ::= 'Ma' type                   // type metadata access function
-  global ::= 'ML' type                   // type metadata lazy cache variable
-  global ::= 'Mm' type                   // class metaclass
-  global ::= 'Mn' nominal-type           // nominal type descriptor
-  global ::= 'Mp' protocol               // protocol descriptor
-  global ::= 'MR' remote-reflection-record // metadata for remote mirrors
-  global ::= 'PA' .*                     // partial application forwarder
-  global ::= 'PAo' .*                    // ObjC partial application forwarder
-  global ::= 'w' value-witness-kind type // value witness
-  global ::= 'Wa' protocol-conformance   // protocol witness table accessor
-  global ::= 'WG' protocol-conformance   // generic protocol witness table
-  global ::= 'WI' protocol-conformance   // generic protocol witness table instantiation function
-  global ::= 'Wl' type protocol-conformance // lazy protocol witness table accessor
-  global ::= 'WL' protocol-conformance   // lazy protocol witness table cache variable
-  global ::= 'Wo' entity                 // witness table offset
-  global ::= 'WP' protocol-conformance   // protocol witness table
-  global ::= 'Wt' protocol-conformance identifier // associated type metadata accessor
-  global ::= 'WT' protocol-conformance identifier nominal-type // associated type witness table accessor
-  global ::= 'Wv' directness entity      // field offset
-  global ::= 'WV' type                   // value witness table
-  global ::= entity                      // some identifiable thing
-  global ::= 'TO' global                 // ObjC-as-swift thunk
-  global ::= 'To' global                 // swift-as-ObjC thunk
-  global ::= 'TD' global                 // dynamic dispatch thunk
-  global ::= 'Td' global                 // direct method reference thunk
-  global ::= 'TR' reabstract-signature   // reabstraction thunk helper function
-  global ::= 'Tr' reabstract-signature   // reabstraction thunk
+  global ::= type 'Mf'                   // 'full' type metadata (start of object)
+  global ::= type 'MP'                   // type metadata pattern
+  global ::= type 'Ma'                   // type metadata access function
+  global ::= type 'ML'                   // type metadata lazy cache variable
+  global ::= type 'Mm'                   // class metaclass
+  global ::= nominal-type 'Mn'           // nominal type descriptor
+  global ::= protocol 'Mp'               // protocol descriptor
+  global ::= type 'MF'                   // metadata for remote mirrors: field descriptor
+  global ::= type 'MB'                   // metadata for remote mirrors: builtin type descriptor
+  global ::= protocol-conformance 'MA'   // metadata for remote mirrors: associated type descriptor
 
-  global ::= 'TS' specializationinfo '_' mangled-name
-  specializationinfo ::= 'g' passid (type protocol-conformance* '_')+            // Generic specialization info.
-  specializationinfo ::= 'f' passid (funcspecializationarginfo '_')+             // Function signature specialization kind
-  passid ::= integer                                                             // The id of the pass that generated this specialization.
-  funcsigspecializationarginfo ::= 'cl' closurename type*                        // Closure specialized with closed over types in argument order.
-  funcsigspecializationarginfo ::= 'n'                                           // Unmodified argument
-  funcsigspecializationarginfo ::= 'cp' funcsigspecializationconstantproppayload // Constant propagated argument
-  funcsigspecializationarginfo ::= 'd'                                           // Dead argument
-  funcsigspecializationarginfo ::= 'g' 's'?                                      // Owned => Guaranteed and Exploded if 's' present.
-  funcsigspecializationarginfo ::= 's'                                           // Exploded
-  funcsigspecializationarginfo ::= 'k'                                           // Exploded
-  funcsigspecializationconstantpropinfo ::= 'fr' mangled-name
-  funcsigspecializationconstantpropinfo ::= 'g' mangled-name
-  funcsigspecializationconstantpropinfo ::= 'i' 64-bit-integer
-  funcsigspecializationconstantpropinfo ::= 'fl' float-as-64-bit-integer
-  funcsigspecializationconstantpropinfo ::= 'se' stringencoding 'v' md5hash
+  // TODO check this::
+  global ::= .* 'PA'                     // partial application forwarder
+  global ::= .* 'PAo'                    // ObjC partial application forwarder
 
-  global ::= 'TV' global                 // vtable override thunk
-  global ::= 'TW' protocol-conformance entity
-                                         // protocol witness thunk
-  global ::= 'TB' identifier context identifier
-                                         // property behavior initializer thunk
-  global ::= 'Tb' identifier context identifier
-                                         // property behavior setter thunk
+  global ::= type 'w' VALUE-WITNESS-KIND // value witness
+  global ::= protocol-conformance 'Wa'   // protocol witness table accessor
+  global ::= protocol-conformance 'WG'   // generic protocol witness table
+  global ::= protocol-conformance 'WI'   // generic protocol witness table instantiation function
+  global ::= protocol-conformance 'WL'   // lazy protocol witness table cache variable
+  global ::= entity 'Wo'                 // witness table offset
+  global ::= protocol-conformance 'WP'   // protocol witness table
 
-  entity ::= nominal-type                // named type declaration
-  entity ::= static? entity-kind context entity-name
-  entity-kind ::= 'F'                    // function (ctor, accessor, etc.)
-  entity-kind ::= 'v'                    // variable (let/var)
-  entity-kind ::= 'i'                    // subscript ('i'ndex) itself (not the individual accessors)
-  entity-kind ::= 'I'                    // initializer
-  entity-name ::= decl-name type         // named declaration
-  entity-name ::= 'A' index              // default argument generator
-  entity-name ::= 'a' addressor-kind decl-name type     // mutable addressor
-  entity-name ::= 'C' type               // allocating constructor
-  entity-name ::= 'c' type               // non-allocating constructor
-  entity-name ::= 'D'                    // deallocating destructor; untyped
-  entity-name ::= 'd'                    // non-deallocating destructor; untyped
-  entity-name ::= 'g' decl-name type     // getter
-  entity-name ::= 'i'                    // non-local variable initializer
-  entity-name ::= 'l' addressor-kind decl-name type     // non-mutable addressor
-  entity-name ::= 'm' decl-name type     // materializeForSet
-  entity-name ::= 's' decl-name type     // setter
-  entity-name ::= 'U' index type         // explicit anonymous closure expression
-  entity-name ::= 'u' index type         // implicit anonymous closure
-  entity-name ::= 'w' decl-name type     // willSet
-  entity-name ::= 'W' decl-name type     // didSet
-  static ::= 'Z'                         // entity is a static member of a type
-  decl-name ::= identifier
-  decl-name ::= local-decl-name
-  decl-name ::= private-decl-name
-  local-decl-name ::= 'L' index identifier  // locally-discriminated declaration
-  private-decl-name ::= 'P' identifier identifier  // file-discriminated declaration
-  reabstract-signature ::= ('G' generic-signature)? type type
-  addressor-kind ::= 'u'                 // unsafe addressor (no owner)
-  addressor-kind ::= 'O'                 // owning addressor (non-native owner)
-  addressor-kind ::= 'o'                 // owning addressor (native owner)
-  addressor-kind ::= 'p'                 // pinning addressor (native owner)
+  global ::= protocol-conformance identifier 'Wt' // associated type metadata accessor
+  global ::= protocol-conformance identifier nominal-type 'WT' // associated type witness table accessor
+  global ::= type protocol-conformance 'Wl' // lazy protocol witness table accessor
+  global ::= type 'WV'                   // value witness table
+  global ::= entity 'Wv' DIRECTNESS      // field offset
 
-  remote-reflection-record ::= 'f' type                  // field descriptor
-  remote-reflection-record ::= 'a' protocol-conformance  // associated type descriptor
-  remote-reflection-record ::= 'b' type                  // builtin type descriptor
-
-An ``entity`` starts with a ``nominal-type-kind`` (``[COPV]``), a
-substitution (``[Ss]``) of a nominal type, or an ``entity-kind``
-(``[FIiv]``).
-
-An ``entity-name`` starts with ``[AaCcDggis]`` or a ``decl-name``.
-A ``decl-name`` starts with ``[LP]`` or an ``identifier`` (``[0-9oX]``).
-
-A ``context`` starts with either an ``entity``, an ``extension`` (which starts
-with ``[Ee]``), or a ``module``, which might be an ``identifier`` (``[0-9oX]``)
-or a substitution of a module (``[Ss]``).
-
-A global mangling starts with an ``entity`` or ``[MTWw]``.
-
-If a partial application forwarder is for a static symbol, its name will
-start with the sequence ``_TPA_`` followed by the mangled symbol name of the
-forwarder's destination.
-
-A generic specialization mangling consists of a header, specifying the types
-and conformances used to specialize the generic function, followed by the
-full mangled name of the original unspecialized generic symbol.
-
-The first identifier in a ``<private-decl-name>`` is a string that represents
-the file the original declaration came from. It should be considered unique
-within the enclosing module. The second identifier is the name of the entity.
-
-Not all declarations marked ``private`` declarations will use the 
-``<private-decl-name>`` mangling; if the entity's context is enough to uniquely
-identify the entity, the simple ``identifier`` form is preferred.
-
-The types in a ``<reabstract-signature>`` are always non-polymorphic
-``<impl-function-type>`` types.
-
-Direct and Indirect Symbols
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-::
-
-  directness ::= 'd'                         // direct
-  directness ::= 'i'                         // indirect
+  DIRECTNESS ::= 'd'                         // direct
+  DIRECTNESS ::= 'i'                         // indirect
 
 A direct symbol resolves directly to the address of an object.  An
 indirect symbol resolves to the address of a pointer to the object.
@@ -882,22 +811,120 @@ generic arguments, these offsets must be kept in metadata.  Indirect
 field offsets are therefore required when accessing fields in generic
 types where the metadata itself has unknown layout.)
 
+::
+
+  global ::= global 'TO'                 // ObjC-as-swift thunk
+  global ::= global 'To'                 // swift-as-ObjC thunk
+  global ::= global 'TD'                 // dynamic dispatch thunk
+  global ::= global 'Td'                 // direct method reference thunk
+  global ::= global 'TV'                 // vtable override thunk
+  global ::= protocol-conformance entity 'TW' // protocol witness thunk
+  global ::= context identifier identifier 'TB' // property behavior initializer thunk
+  global ::= context identifier identifier 'Tb' // property behavior setter thunk
+  global ::= entity specialization
+  global ::= entity                      // some identifiable thing
+  global ::= type type generic-signature? 'T' REABSTRACT-THUNK-TYPE   // reabstraction thunk helper function
+
+  REABSTRACT-THUNK-TYPE ::= 'R' reabstraction thunk helper function
+  REABSTRACT-THUNK-TYPE ::= 'r' reabstraction thunk
+
+The types in a reabstraction thunk helper function are always non-polymorphic
+``<impl-function-type>`` types.
+
+::
+
+  VALUE-WITNESS-KIND ::= 'al'           // allocateBuffer
+  VALUE-WITNESS-KIND ::= 'ca'           // assignWithCopy
+  VALUE-WITNESS-KIND ::= 'ta'           // assignWithTake
+  VALUE-WITNESS-KIND ::= 'de'           // deallocateBuffer
+  VALUE-WITNESS-KIND ::= 'xx'           // destroy
+  VALUE-WITNESS-KIND ::= 'XX'           // destroyBuffer
+  VALUE-WITNESS-KIND ::= 'Xx'           // destroyArray
+  VALUE-WITNESS-KIND ::= 'CP'           // initializeBufferWithCopyOfBuffer
+  VALUE-WITNESS-KIND ::= 'Cp'           // initializeBufferWithCopy
+  VALUE-WITNESS-KIND ::= 'cp'           // initializeWithCopy
+  VALUE-WITNESS-KIND ::= 'TK'           // initializeBufferWithTakeOfBuffer
+  VALUE-WITNESS-KIND ::= 'Tk'           // initializeBufferWithTake
+  VALUE-WITNESS-KIND ::= 'tk'           // initializeWithTake
+  VALUE-WITNESS-KIND ::= 'pr'           // projectBuffer
+  VALUE-WITNESS-KIND ::= 'xs'           // storeExtraInhabitant
+  VALUE-WITNESS-KIND ::= 'xg'           // getExtraInhabitantIndex
+  VALUE-WITNESS-KIND ::= 'Cc'           // initializeArrayWithCopy
+  VALUE-WITNESS-KIND ::= 'Tt'           // initializeArrayWithTakeFrontToBack
+  VALUE-WITNESS-KIND ::= 'tT'           // initializeArrayWithTakeBackToFront
+  VALUE-WITNESS-KIND ::= 'ug'           // getEnumTag
+  VALUE-WITNESS-KIND ::= 'up'           // destructiveProjectEnumData
+  VALUE-WITNESS-KIND ::= 'ui'           // destructiveInjectEnumTag
+
+``<VALUE-WITNESS-KIND>`` differentiates the kinds of value
+witness functions for a type.
+
+Entities
+~~~~~~~~
+
+::
+
+  entity ::= nominal-type                // named type declaration
+  entity ::= context entity-spec
+
+  // The leading type is the function type
+  entity-spec ::= type 'fC'       // allocating constructor
+  entity-spec ::= type 'fc'       // non-allocating constructor
+  entity-spec ::= type 'fU' INDEX // explicit anonymous closure expression
+  entity-spec ::= type 'fu' INDEX // implicit anonymous closure
+  entity-spec ::= 'fD'            // deallocating destructor; untyped
+  entity-spec ::= 'fd'            // non-deallocating destructor; untyped
+
+  entity-spec ::= ENTITY-KIND 'A' INDEX      // default argument generator
+  entity-spec ::= ENTITY-KIND 'i'            // non-local variable initializer
+  entity-spec ::= type decl-name 'F'         // function (shortcut for 'fe')
+  entity-spec ::= type decl-name ENTITY-KIND 'e'
+  entity-spec ::= type decl-name ENTITY-KIND FUNC-KIND
+
+  ENTITY-KIND ::= 'f' STATIC?                // function (ctor, accessor, etc.)
+  ENTITY-KIND ::= 'v' STATIC?                // variable (let/var)
+  ENTITY-KIND ::= 'i' STATIC?                // subscript ('i'ndex) itself (not the individual accessors)
+  ENTITY-KIND ::= 'I' STATIC?                // initializer
+
+  STATIC ::= 'Z'                             // entity is a static member of a type
+                                         
+  FUNC-KIND ::= 'm'                          // materializeForSet
+  FUNC-KIND ::= 's'                          // setter
+  FUNC-KIND ::= 'g'                          // getter
+  FUNC-KIND ::= 'w'                          // willSet
+  FUNC-KIND ::= 'W'                          // didSet
+  FUNC-KIND ::= 'a' ADDRESSOR-KIND           // mutable addressor
+  FUNC-KIND ::= 'l' ADDRESSOR-KIND           // non-mutable addressor
+                                         
+  ADDRESSOR-KIND ::= 'u'                     // unsafe addressor (no owner)
+  ADDRESSOR-KIND ::= 'O'                     // owning addressor (non-native owner)
+  ADDRESSOR-KIND ::= 'o'                     // owning addressor (native owner)
+  ADDRESSOR-KIND ::= 'p'                     // pinning addressor (native owner)
+
+  decl-name ::= identifier
+  decl-name ::= identifier 'L' INDEX         // locally-discriminated declaration
+  decl-name ::= identifier identifier 'l'    // file-discriminated declaration
+
+The first identifier in a file-discriminated ``<decl-name>>`` is a string that
+represents the file the original declaration came from.
+It should be considered unique within the enclosing module.
+The second identifier is the name of the entity.
+Not all declarations marked ``private`` declarations will use this mangling;
+if the entity's context is enough to uniquely identify the entity, the simple
+``identifier`` form is preferred.
+
 Declaration Contexts
 ~~~~~~~~~~~~~~~~~~~~
+
+These manglings identify the enclosing context in which an entity was declared,
+such as its enclosing module, function, or nominal type.
 
 ::
 
   context ::= module
-  context ::= extension
   context ::= entity
-  module ::= substitution                    // other substitution
-  module ::= identifier                      // module name
-  module ::= known-module                    // abbreviation
-  extension ::= 'E' module entity
-  extension ::= 'e' module generic-signature entity
-
-These manglings identify the enclosing context in which an entity was declared,
-such as its enclosing module, function, or nominal type.
+  context ::= entity 'E'
+  context ::= entity generic-signature 'e'
 
 An ``extension`` mangling is used whenever an entity's declaration context is
 an extension *and* the entity being extended is in a different module. In this
@@ -909,318 +936,34 @@ constraints on the extension are mangled in its generic signature.
 When mangling the context of a local entity within a constructor or
 destructor, the non-allocating or non-deallocating variant is used.
 
+::
+
+  module ::= substitution                    // other substitution
+  module ::= identifier                      // module name
+  module ::= known-module                    // abbreviation
+
+  known-module ::= 's'                       // Swift
+  known-module ::= 'SC'                      // C
+  known-module ::= 'So'                      // Objective-C
+
+The Objective-C module is used as the context for mangling Objective-C
+classes as ``<type>``\ s.
+
+
 Types
 ~~~~~
 
 ::
 
-  type ::= 'Bb'                              // Builtin.BridgeObject
-  type ::= 'BB'                              // Builtin.UnsafeValueBuffer
-  type ::= 'Bf' natural '_'                  // Builtin.Float<n>
-  type ::= 'Bi' natural '_'                  // Builtin.Int<n>
-  type ::= 'BO'                              // Builtin.UnknownObject
-  type ::= 'Bo'                              // Builtin.NativeObject
-  type ::= 'Bp'                              // Builtin.RawPointer
-  type ::= 'Bv' natural type                 // Builtin.Vec<n>x<type>
-  type ::= 'Bw'                              // Builtin.Word
-  type ::= nominal-type
-  type ::= associated-type
-  type ::= 'a' context identifier            // Type alias (DWARF only)
-  type ::= 'b' type type                     // objc block function type
-  type ::= 'c' type type                     // C function pointer type
-  type ::= 'F' throws-annotation? type type  // function type
-  type ::= 'f' throws-annotation? type type  // uncurried function type  
-  type ::= 'G' type <type>+ '_'              // generic type application
-  type ::= 'K' type type                     // @auto_closure function type
-  type ::= 'M' type                          // metatype without representation
-  type ::= 'XM' metatype-repr type           // metatype with representation
-  type ::= 'P' protocol-list '_'             // protocol type
-  type ::= 'PM' type                         // existential metatype without representation
-  type ::= 'XPM' metatype-repr type          // existential metatype with representation
-  type ::= archetype
-  type ::= 'R' type                          // inout
-  type ::= 'T' tuple-element* '_'            // tuple
-  type ::= 't' tuple-element* '_'            // variadic tuple
-  type ::= 'Xo' type                         // @unowned type
-  type ::= 'Xu' type                         // @unowned(unsafe) type
-  type ::= 'Xw' type                         // @weak type
-  type ::= 'XF' impl-function-type           // function implementation type
-  type ::= 'Xf' type type                    // @thin function type
-  type ::= 'Xb' type                         // SIL @box type
-  nominal-type ::= known-nominal-type
   nominal-type ::= substitution
-  nominal-type ::= nominal-type-kind declaration-name
+  nominal-type ::= context decl-name nominal-type-kind
+
   nominal-type-kind ::= 'C'                  // class
   nominal-type-kind ::= 'O'                  // enum
   nominal-type-kind ::= 'V'                  // struct
-  declaration-name ::= context decl-name
-  archetype ::= 'Q' index                    // archetype with depth=0, idx=N
-  archetype ::= 'Qd' index index             // archetype with depth=M+1, idx=N
-  archetype ::= associated-type
-  archetype ::= qualified-archetype
-  associated-type ::= substitution
-  associated-type ::= 'Q' protocol-context     // self type of protocol
-  associated-type ::= 'Q' archetype identifier // associated type
-  qualified-archetype ::= 'Qq' index context   // archetype+context (DWARF only)
-  protocol-context ::= 'P' protocol
-  tuple-element ::= identifier? type
-  metatype-repr ::= 't'                      // Thin metatype representation
-  metatype-repr ::= 'T'                      // Thick metatype representation
-  metatype-repr ::= 'o'                      // ObjC metatype representation
-  throws-annotation ::= 'z'                  // 'throws' annotation on function types
 
+  nominal-type ::= known-nominal-type
 
-  type ::= 'u' generic-signature type        // generic type
-  type ::= 'x'                               // generic param, depth=0, idx=0
-  type ::= 'q' generic-param-index           // dependent generic parameter
-  type ::= 'q' type assoc-type-name          // associated type of non-generic param
-  type ::= 'w' generic-param-index assoc-type-name // associated type
-  type ::= 'W' generic-param-index assoc-type-name+ '_' // associated type at depth
-
-  generic-param-index ::= 'x'                // depth = 0,   idx = 0
-  generic-param-index ::= index              // depth = 0,   idx = N+1
-  generic-param-index ::= 'd' index index    // depth = M+1, idx = N
-
-``<type>`` never begins or ends with a number.
-``<type>`` never begins with an underscore.
-``<type>`` never begins with ``d``.
-``<type>`` never begins with ``z``.
-
-Note that protocols mangle differently as types and as contexts. A protocol
-context always consists of a single protocol name and so mangles without a
-trailing underscore. A protocol type can have zero, one, or many protocol bounds
-which are juxtaposed and terminated with a trailing underscore.
-
-::
-
-  assoc-type-name ::= ('P' protocol-name)? identifier
-  assoc-type-name ::= substitution
-
-Associated types use an abbreviated mangling when the base generic parameter
-or associated type is constrained by a single protocol requirement. The
-associated type in this case can be referenced unambiguously by name alone.
-If the base has multiple conformance constraints, then the protocol name is
-mangled in to disambiguate.
-
-::
-
-  impl-function-type ::=
-    impl-callee-convention impl-function-attribute* generic-signature? '_'
-    impl-parameter* '_' impl-result* '_'
-  impl-callee-convention ::= 't'              // thin
-  impl-callee-convention ::= impl-convention  // thick, callee transferred with given convention
-  impl-convention ::= 'a'                     // direct, autoreleased
-  impl-convention ::= 'd'                     // direct, no ownership transfer
-  impl-convention ::= 'D'                     // direct, no ownership transfer,
-                                              // dependent on 'self' parameter
-  impl-convention ::= 'g'                     // direct, guaranteed
-  impl-convention ::= 'e'                     // direct, deallocating
-  impl-convention ::= 'i'                     // indirect, ownership transfer
-  impl-convention ::= 'l'                     // indirect, inout
-  impl-convention ::= 'G'                     // indirect, guaranteed
-  impl-convention ::= 'o'                     // direct, ownership transfer
-  impl-convention ::= 'z' impl-convention     // error result
-  impl-function-attribute ::= 'Cb'            // compatible with C block invocation function
-  impl-function-attribute ::= 'Cc'            // compatible with C global function
-  impl-function-attribute ::= 'Cm'            // compatible with Swift method
-  impl-function-attribute ::= 'CO'            // compatible with ObjC method
-  impl-function-attribute ::= 'Cw'            // compatible with protocol witness
-  impl-function-attribute ::= 'G'             // generic
-  impl-function-attribute ::= 'g'             // pseudogeneric
-  impl-parameter ::= impl-convention type
-  impl-result ::= impl-convention type
-
-For the most part, manglings follow the structure of formal language
-types.  However, in some cases it is more useful to encode the exact
-implementation details of a function type.
-
-Any ``<impl-function-attribute>`` productions must appear in the order
-in which they are specified above: e.g. a pseudogeneric C function is
-mangled with ``Ccg``.  ``g`` and ``G`` are exclusive and mark the presence
-of a generic signature immediately following.
-
-Note that the convention and function-attribute productions do not
-need to be disambiguated from the start of a ``<type>``.
-
-Generics
-~~~~~~~~
-
-::
-
-  protocol-conformance ::= ('u' generic-signature)? type protocol module
-
-``<protocol-conformance>`` refers to a type's conformance to a protocol. The
-named module is the one containing the extension or type declaration that
-declared the conformance.
-
-::
-
-  // Property behavior conformance
-  protocol-conformance ::= ('u' generic-signature)?
-                           'b' identifier context identifier protocol
-
-Property behaviors are implemented using private protocol conformances.
-
-::
-
-  generic-signature ::= (generic-param-count+)? ('R' requirement*)? 'r'
-  generic-param-count ::= 'z'       // zero parameters
-  generic-param-count ::= index     // N+1 parameters
-  requirement ::= type-param protocol-name // protocol requirement
-  requirement ::= type-param type          // base class requirement
-                                           // type starts with [CS]
-  requirement ::= type-param 'z' type      // 'z'ame-type requirement
-
-  // Special type mangling for type params that saves the initial 'q' on
-  // generic params
-  type-param ::= generic-param-index       // generic parameter
-  type-param ::= 'w' generic-param-index assoc-type-name // associated type
-  type-param ::= 'W' generic-param-index assoc-type-name+ '_'
-
-A generic signature begins by describing the number of generic parameters at
-each depth of the signature, followed by the requirements. As a special case,
-no ``generic-param-count`` values indicates a single generic parameter at
-the outermost depth::
-
-  urFq_q_                           // <T_0_0> T_0_0 -> T_0_0
-  u_0_rFq_qd_0_                     // <T_0_0><T_1_0, T_1_1> T_0_0 -> T_1_1
-
-Value Witnesses
-~~~~~~~~~~~~~~~
-
-TODO: document these
-
-::
-
-  value-witness-kind ::= 'al'           // allocateBuffer
-  value-witness-kind ::= 'ca'           // assignWithCopy
-  value-witness-kind ::= 'ta'           // assignWithTake
-  value-witness-kind ::= 'de'           // deallocateBuffer
-  value-witness-kind ::= 'xx'           // destroy
-  value-witness-kind ::= 'XX'           // destroyBuffer
-  value-witness-kind ::= 'Xx'           // destroyArray
-  value-witness-kind ::= 'CP'           // initializeBufferWithCopyOfBuffer
-  value-witness-kind ::= 'Cp'           // initializeBufferWithCopy
-  value-witness-kind ::= 'cp'           // initializeWithCopy
-  value-witness-kind ::= 'TK'           // initializeBufferWithTakeOfBuffer
-  value-witness-kind ::= 'Tk'           // initializeBufferWithTake
-  value-witness-kind ::= 'tk'           // initializeWithTake
-  value-witness-kind ::= 'pr'           // projectBuffer
-  value-witness-kind ::= 'xs'           // storeExtraInhabitant
-  value-witness-kind ::= 'xg'           // getExtraInhabitantIndex
-  value-witness-kind ::= 'Cc'           // initializeArrayWithCopy
-  value-witness-kind ::= 'Tt'           // initializeArrayWithTakeFrontToBack
-  value-witness-kind ::= 'tT'           // initializeArrayWithTakeBackToFront
-  value-witness-kind ::= 'ug'           // getEnumTag
-  value-witness-kind ::= 'up'           // destructiveProjectEnumData
-  value-witness-kind ::= 'ui'           // destructiveInjectEnumTag
-
-``<value-witness-kind>`` differentiates the kinds of value
-witness functions for a type.
-
-Identifiers
-~~~~~~~~~~~
-
-::
-
-  identifier ::= natural identifier-start-char identifier-char*
-  identifier ::= 'o' operator-fixity natural operator-char+
-
-  operator-fixity ::= 'p'                    // prefix operator
-  operator-fixity ::= 'P'                    // postfix operator
-  operator-fixity ::= 'i'                    // infix operator
-
-  operator-char ::= 'a'                      // & 'and'
-  operator-char ::= 'c'                      // @ 'commercial at'
-  operator-char ::= 'd'                      // / 'divide'
-  operator-char ::= 'e'                      // = 'equals'
-  operator-char ::= 'g'                      // > 'greater'
-  operator-char ::= 'l'                      // < 'less'
-  operator-char ::= 'm'                      // * 'multiply'
-  operator-char ::= 'n'                      // ! 'not'
-  operator-char ::= 'o'                      // | 'or'
-  operator-char ::= 'p'                      // + 'plus'
-  operator-char ::= 'q'                      // ? 'question'
-  operator-char ::= 'r'                      // % 'remainder'
-  operator-char ::= 's'                      // - 'subtract'
-  operator-char ::= 't'                      // ~ 'tilde'
-  operator-char ::= 'x'                      // ^ 'xor'
-  operator-char ::= 'z'                      // . 'zperiod'
-
-``<identifier>`` is run-length encoded: the natural indicates how many
-characters follow.  Operator characters are mapped to letter characters as
-given. In neither case can an identifier start with a digit, so
-there's no ambiguity with the run-length.
-
-::
-
-  identifier ::= 'X' natural identifier-start-char identifier-char*
-  identifier ::= 'X' 'o' operator-fixity natural identifier-char*
-
-Identifiers that contain non-ASCII characters are encoded using the Punycode
-algorithm specified in RFC 3492, with the modifications that ``_`` is used
-as the encoding delimiter, and uppercase letters A through J are used in place
-of digits 0 through 9 in the encoding character set. The mangling then
-consists of an ``X`` followed by the run length of the encoded string and the
-encoded string itself. For example, the identifier ``vergüenza`` is mangled
-to ``X12vergenza_JFa``. (The encoding in standard Punycode would be
-``vergenza-95a``)
-
-Operators that contain non-ASCII characters are mangled by first mapping the
-ASCII operator characters to letters as for pure ASCII operator names, then
-Punycode-encoding the substituted string. The mangling then consists of
-``Xo`` followed by the fixity, run length of the encoded string, and the encoded
-string itself. For example, the infix operator ``«+»`` is mangled to
-``Xoi7p_qcaDc`` (``p_qcaDc`` being the encoding of the substituted
-string ``«p»``).
-
-Substitutions
-~~~~~~~~~~~~~
-
-::
-
-  substitution ::= 'S' index
-
-``<substitution>`` is a back-reference to a previously mangled entity. The mangling
-algorithm maintains a mapping of entities to substitution indices as it runs.
-When an entity that can be represented by a substitution (a module, nominal
-type, or protocol) is mangled, a substitution is first looked for in the
-substitution map, and if it is present, the entity is mangled using the
-associated substitution index. Otherwise, the entity is mangled normally, and
-it is then added to the substitution map and associated with the next
-available substitution index.
-
-For example, in mangling a function type
-``(zim.zang.zung, zim.zang.zung, zim.zippity) -> zim.zang.zoo`` (with module
-``zim`` and class ``zim.zang``),
-the recurring contexts ``zim``, ``zim.zang``, and ``zim.zang.zung``
-will be mangled using substitutions after being mangled
-for the first time. The first argument type will mangle in long form,
-``CC3zim4zang4zung``, and in doing so, ``zim`` will acquire substitution ``S_``,
-``zim.zang`` will acquire substitution ``S0_``, and ``zim.zang.zung`` will
-acquire ``S1_``. The second argument is the same as the first and will mangle
-using its substitution, ``S1_``. The
-third argument type will mangle using the substitution for ``zim``,
-``CS_7zippity``. (It also acquires substitution ``S2_`` which would be used
-if it mangled again.) The result type will mangle using the substitution for
-``zim.zang``, ``CS0_3zoo`` (and acquire substitution ``S3_``). The full
-function type thus mangles as ``fTCC3zim4zang4zungS1_CS_7zippity_CS0_3zoo``.
-
-::
-
-  substitution ::= 's'
-
-The special substitution ``s`` is used for the ``Swift`` standard library
-module.
-
-Predefined Substitutions
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-::
-
-  known-module ::= 's'                       // Swift
-  known-module ::= 'SC'                      // C
-  known-module ::= 'So'                      // Objective-C
   known-nominal-type ::= 'Sa'                // Swift.Array
   known-nominal-type ::= 'Sb'                // Swift.Bool
   known-nominal-type ::= 'Sc'                // Swift.UnicodeScalar
@@ -1238,21 +981,355 @@ Predefined Substitutions
   known-nominal-type ::= 'SS'                // Swift.String
   known-nominal-type ::= 'Su'                // Swift.UInt
 
-``<known-module>`` and ``<known-nominal-type>`` are built-in substitutions for
-certain common entities.  Like any other substitution, they all start
-with 'S'.
+  protocol ::= context decl-name
 
-The Objective-C module is used as the context for mangling Objective-C
-classes as ``<type>``\ s.
+  type ::= 'Bb'                              // Builtin.BridgeObject
+  type ::= 'BB'                              // Builtin.UnsafeValueBuffer
+  type ::= 'Bf' NATURAL '_'                  // Builtin.Float<n>
+  type ::= 'Bi' NATURAL '_'                  // Builtin.Int<n>
+  type ::= 'BO'                              // Builtin.UnknownObject
+  type ::= 'Bo'                              // Builtin.NativeObject
+  type ::= 'Bp'                              // Builtin.RawPointer
+  type ::= type 'Bv' NATURAL                 // Builtin.Vec<n>x<type>
+  type ::= 'Bw'                              // Builtin.Word
+  type ::= context identifier 'a'            // Type alias (DWARF only)
+  type ::= type type 'c' THROWS-ANNOTATION?  // function type
+  type ::= type type 'cu' THROWS-ANNOTATION?  // uncurried function type  
 
-Indexes
-~~~~~~~
+  THROWS-ANNOTATION ::= 'z'                  // 'throws' annotation on function types
+
+  type ::= type type 'cb'                    // objc block function type
+  type ::= type type 'cc'                    // C function pointer type
+  type ::= type '_' type* 'G'                // generic type application
+  type ::= type type 'K'                     // @auto_closure function type
+  type ::= type 'm'                          // metatype without representation
+  type ::= type 'Xm'                         // existential metatype without representation
+  type ::= type 'Xo'                         // @unowned type
+  type ::= type 'Xu'                         // @unowned(unsafe) type
+  type ::= type 'Xw'                         // @weak type
+  type ::= impl-function-type 'XF'           // function implementation type
+  type ::= type type 'Xf'                    // @thin function type
+  type ::= type 'Xb'                         // SIL @box type
+  type ::= type 'XM' METATYPE-REPR           // metatype with representation
+  type ::= type 'Xp' METATYPE-REPR           // existential metatype with representation
+
+  METATYPE-REPR ::= 't'                      // Thin metatype representation
+  METATYPE-REPR ::= 'T'                      // Thick metatype representation
+  METATYPE-REPR ::= 'o'                      // ObjC metatype representation
+
+  type ::= archetype
+  type ::= associated-type
+  type ::= nominal-type
+  type ::= protocol '_' protocol* 'p'        // protocol type
+  type ::= 'pp'                              // empty protocol type
+  type ::= type 'z'                          // inout
+  type ::= tuple
+  type ::= type generic-signature 'u'        // generic type
+  type ::= 'x'                               // generic param, depth=0, idx=0
+  type ::= 'q' GENERIC-PARAM-INDEX           // dependent generic parameter
+  type ::= type assoc-type-name 'qa'         // associated type of non-generic param
+  type ::= assoc-type
+
+  tuple ::= tuple-element '_' tuple_element* 't'  // tuple
+  tuple ::= tuple-element '_' tuple_element* 'z'  // variadic tuple
+  tuple ::= 'tt'                             // empty tuple
+
+  tuple-element ::= type identifier?
+
+  assoc-type ::= assoc-type-name 'Qy' GENERIC-PARAM-INDEX  // associated type
+  assoc-type ::= assoc-type-name '_' assoc-type-name* 'QY' GENERIC-PARAM-INDEX // associated type at depth
+
+  archetype ::= 'Q' INDEX                    // archetype with depth=0, idx=N
+  archetype ::= 'Qd' INDEX INDEX             // archetype with depth=M+1, idx=N
+  archetype ::= context 'Qq' INDEX           // archetype+context (DWARF only)
+  archetype ::= associated-type
+
+  associated-type ::= substitution
+  associated-type ::= protocol 'QP'          // self type of protocol
+  associated-type ::= archetype identifier 'Qa' // associated type
+  
+  assoc-type-name ::= substitution
+  assoc-type-name ::= (protocol '_')? identifier
+
+Associated types use an abbreviated mangling when the base generic parameter
+or associated type is constrained by a single protocol requirement. The
+associated type in this case can be referenced unambiguously by name alone.
+If the base has multiple conformance constraints, then the protocol name is
+mangled in to disambiguate.
 
 ::
 
-  index ::= '_'                              // 0
-  index ::= natural '_'                      // N+1
-  natural ::= [0-9]+
+  impl-function-type ::=
+    tuple tuple generic-signature? 'I'
+    IMPL-CALLEE-CONVENTION IMPL-FUNCTION-ATTRIBUTE* IMPL-CALLEE-CONVENTION* '_'
 
-``<index>`` is a production for encoding numbers in contexts that can't
+  IMPL-CALLEE-CONVENTION ::= 't'              // thin
+  IMPL-CALLEE-CONVENTION ::= IMPL-CONVENTION  // thick, callee transferred with given convention
+
+  IMPL-CONVENTION ::= 'a'                     // direct, autoreleased
+  IMPL-CONVENTION ::= 'd'                     // direct, no ownership transfer
+  IMPL-CONVENTION ::= 'D'                     // direct, no ownership transfer,
+                                              // dependent on 'self' parameter
+  IMPL-CONVENTION ::= 'g'                     // direct, guaranteed
+  IMPL-CONVENTION ::= 'e'                     // direct, deallocating
+  IMPL-CONVENTION ::= 'i'                     // indirect, ownership transfer
+  IMPL-CONVENTION ::= 'l'                     // indirect, inout
+  IMPL-CONVENTION ::= 'G'                     // indirect, guaranteed
+  IMPL-CONVENTION ::= 'o'                     // direct, ownership transfer
+  IMPL-CONVENTION ::= 'z' IMPL-CONVENTION     // error result
+
+  IMPL-FUNCTION-ATTRIBUTE ::= 'Cb'            // compatible with C block invocation function
+  IMPL-FUNCTION-ATTRIBUTE ::= 'Cc'            // compatible with C global function
+  IMPL-FUNCTION-ATTRIBUTE ::= 'Cm'            // compatible with Swift method
+  IMPL-FUNCTION-ATTRIBUTE ::= 'CO'            // compatible with ObjC method
+  IMPL-FUNCTION-ATTRIBUTE ::= 'Cw'            // compatible with protocol witness
+  IMPL-FUNCTION-ATTRIBUTE ::= 'G'             // generic
+  IMPL-FUNCTION-ATTRIBUTE ::= 'H'             // pseudogeneric
+
+For the most part, manglings follow the structure of formal language
+types.  However, in some cases it is more useful to encode the exact
+implementation details of a function type.
+
+The first ``<tuple>`` defines the parameter types, the second ``<tuple>``
+defines the result types. The optional ``<generic-signature>`` is used if
+the ``<IMPL-FUNCTION-ATTRIBUTE>`` has a ``G`` or ``H``.
+
+Any ``<IMPL-FUNCTION-ATTRIBUTE>`` productions must appear in the order
+in which they are specified above: e.g. a pseudogeneric C function is
+mangled with ``CcH``.  ``G`` and ``H`` are exclusive and mark the presence
+of a generic signature.
+
+Generics
+~~~~~~~~
+
+::
+
+  protocol-conformance ::= type protocol module generic-signature?
+
+``<protocol-conformance>`` refers to a type's conformance to a protocol. The
+named module is the one containing the extension or type declaration that
+declared the conformance.
+
+::
+
+  protocol-conformance ::= context identifier protocol identifier generic-signature?  // Property behavior conformance
+
+Property behaviors are implemented using private protocol conformances.
+
+::
+
+  generic-signature ::= requirement* 'r' GENERIC-PARAM-COUNT*
+
+  GENERIC-PARAM-COUNT ::= 'z'                // zero parameters
+  GENERIC-PARAM-COUNT ::= INDEX              // N+1 parameters
+
+  requirement ::= req-spec
+  requirement ::= assoc-type req-spec        // use GENERIC-PARAM-INDEX of assoc-type
+
+  req-spec ::= protocol 'Rp' GENERIC-PARAM-INDEX // protocol requirement
+  req-spec ::= type 'Rb' GENERIC-PARAM-INDEX     // base class requirement, type is a nominal class or a substitution
+  req-spec ::= type 'Rs' GENERIC-PARAM-INDEX     // same-type requirement
+
+  GENERIC-PARAM-INDEX ::= '_'                // depth = 0,   idx = 0
+  GENERIC-PARAM-INDEX ::= INDEX              // depth = 0,   idx = N+1
+  GENERIC-PARAM-INDEX ::= 'd' INDEX INDEX    // depth = M+1, idx = N
+
+
+A generic signature begins with an optional list of requirements.
+The ``<GENERIC-PARAM-COUNT>`` describes the number of generic parameters at
+each depth of the signature. As a special case, no ``<GENERIC-PARAM-COUNT>``
+values indicates a single generic parameter at the outermost depth::
+
+  q_q_cru                           // <T_0_0> T_0_0 -> T_0_0
+  q_qd_0_cr_0_u                     // <T_0_0><T_1_0, T_1_1> T_0_0 -> T_1_1
+
+A generic signature must only preceed an operator character which is different
+from any character in a ``<GENERIC-PARAM-COUNT>``.
+
+Identifiers
+~~~~~~~~~~~
+
+::
+
+  identifier ::= NATURAL IDENTIFIER-STRING
+  
+  IDENTIFIER-STRING ::= IDENTIFIER-START-CHAR IDENTIFIER-CHAR*
+  IDENTIFIER-START-CHAR ::= [_a-zA-Z]
+  IDENTIFIER-CHAR ::= [_a-zA-Z0-9]
+
+``<identifier>`` is run-length encoded: the natural indicates how many
+characters follow. Operator characters are mapped to letter characters as
+given. In neither case can an identifier start with a digit, so
+there's no ambiguity with the run-length.
+
+::
+
+  identifier ::= 'o' OPERATOR-FIXITY NATURAL OPERATOR-CHAR+
+
+  OPERATOR-FIXITY ::= 'p'                    // prefix operator
+  OPERATOR-FIXITY ::= 'P'                    // postfix operator
+  OPERATOR-FIXITY ::= 'i'                    // infix operator
+
+  OPERATOR-CHAR ::= 'a'                      // & 'and'
+  OPERATOR-CHAR ::= 'c'                      // @ 'commercial at'
+  OPERATOR-CHAR ::= 'd'                      // / 'divide'
+  OPERATOR-CHAR ::= 'e'                      // = 'equals'
+  OPERATOR-CHAR ::= 'g'                      // > 'greater'
+  OPERATOR-CHAR ::= 'l'                      // < 'less'
+  OPERATOR-CHAR ::= 'm'                      // * 'multiply'
+  OPERATOR-CHAR ::= 'n'                      // ! 'not'
+  OPERATOR-CHAR ::= 'o'                      // | 'or'
+  OPERATOR-CHAR ::= 'p'                      // + 'plus'
+  OPERATOR-CHAR ::= 'q'                      // ? 'question'
+  OPERATOR-CHAR ::= 'r'                      // % 'remainder'
+  OPERATOR-CHAR ::= 's'                      // - 'subtract'
+  OPERATOR-CHAR ::= 't'                      // ~ 'tilde'
+  OPERATOR-CHAR ::= 'x'                      // ^ 'xor'
+  OPERATOR-CHAR ::= 'z'                      // . 'zperiod'
+
+  identifier ::= '0' ( [0-9]* 'a-z' )* [A-Z] [0-9]* IDENTIFIER-STRING    // identifier with word substitutions
+
+If the run-length start with a ``0`` it the identifier string contains
+word substitutions. A word is a sub-string of an identifier.
+A word starts either with an uppercase letter ``[A-Z]`` if the preceeding
+character is not an uppercase letter. Or it starts with a lowercase letter
+``[a-z]`` if the preceeding character is not a letter ``[a-zA-Z]``.
+A word ends either with a lowercase letter if the next character is not
+a lowercase letter. Or it ends with an uppercase letter if the next character
+is not a letter::
+
+  AbcDefGHI         // contains three words 'Abc', 'Def' and GHI
+  _abc_def_Ghi      // contains three words 'abc', 'def' and Ghi
+
+The words of all identifiers, which are encoded in the current mangling are
+enumerated and assigned to a letter: a = first word, b = second word, etc.
+
+The run-length of an identifier with word substitutions is a sequence of
+numbers and word-references, whereas all but the last word-reference are
+lowercase letters and the last one is an uppercase letter. Let's assume the
+current mangling already encoded the identifier ``AbcDefGHI``::
+
+  02ac1BMy_    // expands to: MyAbcGHI_Def
+
+A maximum of 26 words in a mangling can be used for substitutions.
+
+::
+
+  identifier ::= '00' natural identifier-start-char identifier-char*
+  identifier ::= '00' 'o' operator-fixity natural identifier-char*
+
+Identifiers that contain non-ASCII characters are encoded using the Punycode
+algorithm specified in RFC 3492, with the modifications that ``_`` is used
+as the encoding delimiter, and uppercase letters A through J are used in place
+of digits 0 through 9 in the encoding character set. The mangling then
+consists of an ``00`` followed by the run length of the encoded string and the
+encoded string itself. For example, the identifier ``vergüenza`` is mangled
+to ``0012vergenza_JFa``. (The encoding in standard Punycode would be
+``vergenza-95a``)
+
+Operators that contain non-ASCII characters are mangled by first mapping the
+ASCII operator characters to letters as for pure ASCII operator names, then
+Punycode-encoding the substituted string. The mangling then consists of
+``00o`` followed by the fixity, run length of the encoded string, and the encoded
+string itself. For example, the infix operator ``«+»`` is mangled to
+``00oi7p_qcaDc`` (``p_qcaDc`` being the encoding of the substituted
+string ``«p»``).
+
+Substitutions
+~~~~~~~~~~~~~
+
+::
+
+  substitution ::= 'S' INDEX                  // A single substiution
+
+``<substitution>`` is a back-reference to a previously mangled entity. The mangling
+algorithm maintains a mapping of entities to substitution indices as it runs.
+When an entity that can be represented by a substitution (a module, nominal
+type, or protocol) is mangled, a substitution is first looked for in the
+substitution map, and if it is present, the entity is mangled using the
+associated substitution index. Otherwise, the entity is mangled normally, and
+it is then added to the substitution map and associated with the next
+available substitution index.
+
+For example, in mangling a function type
+``(zim.zang.zung, zim.zang.zung, zim.zippity) -> zim.zang.zoo`` (with module
+``zim`` and class ``zim.zang``),
+the recurring contexts ``zim``, ``zim.zang``, and ``zim.zang.zung``
+will be mangled using substitutions after being mangled
+for the first time. The first argument type will mangle in long form,
+``3zim4zang4zung``, and in doing so, ``zim`` will acquire substitution ``S_``,
+``zim.zang`` will acquire substitution ``S0_``, and ``zim.zang.zung`` will
+acquire ``S1_``. The second argument is the same as the first and will mangle
+using its substitution, ``S1_``. The
+third argument type will mangle using the substitution for ``zim``,
+``S_7zippity``. (It also acquires substitution ``S2_`` which would be used
+if it mangled again.) The result type will mangle using the substitution for
+``zim.zang``, ``S0_3zoo`` (and acquire substitution ``S3_``).
+
+There are some pre-defined substitutions, see ``<known-nominal-type>``.
+
+::
+
+  substitution ::= 'A' [a-z]* [A-Z]           // Multiple consecutive substitutions
+
+If the mangling contains two or more consecutive substitutions, it can be
+abbreviated with the ``A`` substitution. Similar to word-substitutions the
+index is encoded as letters, whereas the last letter is uppercase::
+
+  AaeB      // equivalent to S_S4_S0_
+
+
+Numbers and Indexes
+~~~~~~~~~~~~~~~~~~~
+
+::
+
+  INDEX ::= '_'                               // 0
+  INDEX ::= NATURAL '_'                       // N+1
+  NATURAL ::= [1-9] [0-9]*
+  NATURAL_ZERO ::= [0-9]+
+
+``<INDEX>`` is a production for encoding numbers in contexts that can't
 end in a digit; it's optimized for encoding smaller numbers.
+
+Function Specializations
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+  specialization ::= type+ 'TSg' PASSID      // Generic specialization
+  specialization ::= spec-arg* 'TSf' PASSID (ARG-SPEC-KIND '_')+  // Function signature specialization kind
+
+The ``<ARG-SPEC-KIND>`` describes how arguments are specialized.
+Some kinds need arguments, which preceed ``Tsf``.
+
+::
+
+  spec-arg ::= entity
+  spec-arg ::= type
+
+  PASSID ::= '0'                             // AllocBoxToStack,
+  PASSID ::= '1'                             // ClosureSpecializer,
+  PASSID ::= '2'                             // CapturePromotion,
+  PASSID ::= '3'                             // CapturePropagation,
+  PASSID ::= '4'                             // FunctionSignatureOpts,
+  PASSID ::= '5'                             // GenericSpecializer,
+
+  ARG-SPEC-KIND ::= 'c'                      // Consumes n 'type' arguments which are closed over types in argument order
+                                             // and one 'entity' argument which is a closure (= a function)
+  ARG-SPEC-KIND ::= 'n'                      // Unmodified argument
+  ARG-SPEC-KIND ::= 'p' CONST-PROP           // Constant propagated argument
+  ARG-SPEC-KIND ::= 'd'                      // Dead argument
+  ARG-SPEC-KIND ::= 'g' 's'?                 // Owned => Guaranteed and Exploded if 's' present.
+  ARG-SPEC-KIND ::= 's'                      // Exploded
+  ARG-SPEC-KIND ::= 'k'                      // Exploded
+
+  CONST-PROP ::= 'f'                         // Consumes one entity argument which is a function
+  CONST-PROP ::= 'g'                         // Consumes one entity argument which is a global
+  CONST-PROP ::= 'i' NATURAL_ZERO            // 64-bit-integer
+  CONST-PROP ::= 'd' NATURAL_ZERO            // float-as-64-bit-integer
+  CONST-PROP ::= 's' ENCODING NATURAL_ZERO 'v' IDENTIFIER-CHAR // string literal
+
+  ENCODING ::= 'b'                           // utf8
+  ENCODING ::= 'w'                           // utf16
+


### PR DESCRIPTION
This PR is a proposal for a new mangling scheme. It's still draft and probably the grammar contains several bugs. But it should give an idea how it could look like.

These are the main changes:

1) Change the order of the mangling to a post-fix like structure.

This is the biggest change.
It will help to get more common prefixes in the mangled names to optimize the trie in the mach-o object files.
The length of the mangled names will mostly stay the same but the order of 'operands' inside the mangling is more or less reversed.
This change also required to use different 'operator' characters in some cases.

2) Word-substitutions

Similar to the S-substitutions, but finer grained. See section 'Identifiers'.
Reduces the size of mangled names in general.

3) Combined substitutions

A more efficient way to mangle multiple S-substitutions.
Reduces the size of mangled names with lots of substitutions, e.g. specialized functions.

4) Change the '_T' prefix to '_S'

(on John's request)
Because it's basically a completely new mangling scheme.
