### PR TITLE
Add simple benchmark for append(contentsOf:)

### DIFF
--- a/benchmark/single-source/ArrayAppend.swift
+++ b/benchmark/single-source/ArrayAppend.swift
@@ -14,6 +14,7 @@
 
 import TestsUtils
 
+// Append single element
 @inline(never)
 public func run_ArrayAppend(_ N: Int) {
   for _ in 0..<N {
@@ -26,6 +27,7 @@ public func run_ArrayAppend(_ N: Int) {
   }
 }
 
+// Append single element with reserve
 @inline(never)
 public func run_ArrayAppendReserved(_ N: Int) {
   for _ in 0..<N {
@@ -35,6 +37,39 @@ public func run_ArrayAppendReserved(_ N: Int) {
        for _ in 0..<40000 {
          nums.append(1)
        }
+    }
+  }
+}
+
+// Append a sequence. Length of sequence unknown so
+// can't pre-reserve capacity. Should be comparable
+// to append single elements.
+@inline(never)
+public func run_ArrayAppendSequence(_ N: Int) {
+  let seq = stride(from: 0, to: 10_000, by: 1)
+  for _ in 0..<N {
+    for _ in 0..<10 {
+      var nums = [Int]()
+      for _ in 0..<4 {
+        nums.append(contentsOf: seq)
+      }
+    }
+  }
+}
+
+// Append another array. Length of sequence known so
+// can pre-reserve capacity.
+@inline(never)
+public func run_ArrayAppendArray(_ N: Int) {
+  let other = Array(repeating: 1, count: 10_000)
+  for _ in 0..<N {
+    for _ in 0..<10 {
+      var nums = [Int]()
+      for _ in 0..<4 {
+        // note, this uses += rather than append(contentsOf:),
+        // to ensure operator doesn't introduce inefficiency
+        nums += other
+      }
     }
   }
 }

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -106,6 +106,8 @@ precommitTests = [
   "Array2D": run_Array2D,
   "ArrayAppend": run_ArrayAppend,
   "ArrayAppendReserved": run_ArrayAppendReserved,
+  "ArrayAppendSequence": run_ArrayAppendSequence,
+  "ArrayAppendArray": run_ArrayAppendArray,
   "ArrayInClass": run_ArrayInClass,
   "ArrayLiteral": run_ArrayLiteral,
   "ArrayOfGenericPOD": run_ArrayOfGenericPOD,


### PR DESCRIPTION
Adding this simple benchmark in preparation for a handful of ABI-related refactoring changes.

There is room for improvement in these tests, as well as the original single-element appends on which they're based, in terms of:
- picking the actual number of times/elements to append on a more principled basis (current values are arbitrary)
- testing multiple possible types in the array:
  - 1 swift class.
  - struct with 2 swift class.
  - enum with single trivial payload
  - enum with single non-trivial payload
  - enum with multiple trivial payloads
  - enum with multiple non-trivial payloads
  - objective-c class
  - Existential Box.
  - Unspecialized Generic Type

all of which may have different performance characteristics.

But for now this should serve to indicate if most planned changes have significant perf impact.
