### PR TITLE
[type-lowering] Delete dead code that has to do with LoweringStyle::Deep.

### DIFF
--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -232,7 +232,6 @@ public:
 
   enum class LoweringStyle {
     Shallow,
-    Deep,
     DeepNoEnum
   };
 
@@ -257,14 +256,6 @@ public:
   void emitLoweredReleaseValueShallow(SILBuilder &B, SILLocation loc,
                                       SILValue value) const {
     emitLoweredReleaseValue(B, loc, value, LoweringStyle::Shallow);
-  }
-
-  /// Emit a lowered 'release_value' operation.
-  ///
-  /// This type must be loadable.
-  void emitLoweredReleaseValueDeep(SILBuilder &B, SILLocation loc,
-                                   SILValue value) const {
-    emitLoweredReleaseValue(B, loc, value, LoweringStyle::Deep);
   }
 
   /// Emit a lowered 'release_value' operation.
@@ -299,14 +290,6 @@ public:
   void emitLoweredRetainValueShallow(SILBuilder &B, SILLocation loc,
                                    SILValue value) const {
     emitLoweredRetainValue(B, loc, value, LoweringStyle::Shallow);
-  }
-
-  /// Emit a lowered 'retain_value' operation.
-  ///
-  /// This type must be loadable.
-  void emitLoweredRetainValueDeep(SILBuilder &B, SILLocation loc,
-                                SILValue value) const {
-    emitLoweredRetainValue(B, loc, value, LoweringStyle::Deep);
   }
 
   /// Emit a lowered 'retain_value' operation.


### PR DESCRIPTION
This code is not used anywhere in tree. If we have need for it, we can always
revert this commit.

We use DeepNoEnum. We should probably rename DeepNoEnum to just Deep once this code is gone.

rdar://28851920
