### PR TITLE
Rdar 28786959 if swift 3 digit version

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -122,6 +122,7 @@ public:
   } InVarOrLetPattern = IVOLP_NotInVarOrLet;
 
   bool InPoundLineEnvironment = false;
+  bool InPoundIfEnvironment = false;
 
   LocalContext *CurLocalContext = nullptr;
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1429,8 +1429,9 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
         SourceLoc nameLoc = consumeToken(tok::integer_literal);
         
         // Don't allow '.<integer literal>' following a numeric literal
-        // expression.
-        if (Result.isNonNull() && isa<NumberLiteralExpr>(Result.get())) {
+        // expression (unless in #if env, for 1.2.3.4 version numbers)
+        if (!InPoundIfEnvironment &&
+            Result.isNonNull() && isa<NumberLiteralExpr>(Result.get())) {
           diagnose(nameLoc, diag::numeric_literal_numeric_member)
             .highlight(Result.get()->getSourceRange());
           continue;

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1759,7 +1759,7 @@ Parser::evaluateConditionalCompilationExpr(Expr *condition) {
 ParserResult<Stmt> Parser::parseStmtIfConfig(BraceItemListKind Kind) {
   StructureMarkerRAII ParsingDecl(*this, Tok.getLoc(),
                                   StructureMarkerKind::IfConfig);
-
+  llvm::SaveAndRestore<bool> S(InPoundIfEnvironment, true);
   ConditionalCompilationExprState ConfigState;
   bool foundActive = false;
   SmallVector<IfConfigStmtClause, 4> Clauses;

--- a/test/Parse/ConditionalCompilation/language_version.swift
+++ b/test/Parse/ConditionalCompilation/language_version.swift
@@ -43,8 +43,7 @@
 #if swift("") // expected-error {{unexpected platform condition argument: expected a unary comparison, such as '>=2.2'}}
 #endif
 
-// We won't expect three version components to work for now.
-#if swift(>=2.2.1) // expected-error {{expected named member of numeric literal}}
+#if swift(>=2.2.1)
 #endif
 
 #if swift(>=2.0, *) // expected-error {{expected only one argument to platform condition}}

--- a/test/Parse/ConditionalCompilation/language_version_explicit.swift
+++ b/test/Parse/ConditionalCompilation/language_version_explicit.swift
@@ -7,3 +7,24 @@
   asdf asdf asdf asdf
 #endif
 
+#if swift(>=4.0)
+  let x = 1
+#else
+  // This shouldn't emit any diagnostics.
+  asdf asdf asdf asdf
+#endif
+
+#if swift(>=4.0.0)
+  let y = 1
+#else
+  // This shouldn't emit any diagnostics.
+  asdf asdf asdf asdf
+#endif
+
+#if swift(>=4.0.1)
+  // This shouldn't emit any diagnostics.
+  asdf asdf asdf asdf
+#else
+  let z = 1
+#endif
+


### PR DESCRIPTION
Two changes, close relatives.

First change enables writing `#if swift(>=3.0.1)` by contextually inhibiting an early diagnostic in the parser that's currently blocking the initial semi-parse that runs before the `Version` parser kicks in.

Second change weakens our sense of logical order and logical equality on `Version` structures such that `4` == `4.0` == `4.0.0` (that is, versions are considered to have as many trailing zeroes as necessary). The function evaluating versions you are allowed to _pass_ on the command line is tightened opposite this change, so you still can't say `-swift-version 4.0` (only `-swift-version 4`) but it means that if someone writes `#if swift(>=4.0)` it'll work, rather than the current behaviour, that thinks `4` < `4.0`.

Resolves [SR-2908](https://bugs.swift.org/browse/SR-2908).
