### PR TITLE
[semantic-arc] Change TypeLowering APIs to use the words {Copy,Destroy}Value instead of {Retain,Release}Value. NFC.

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1489,7 +1489,7 @@ public:
   void emitRetainValueOperation(SILLocation Loc, SILValue v) {
     assert(!v->getType().isAddress());
     auto &lowering = getTypeLowering(v->getType());
-    return lowering.emitRetainValue(*this, Loc, v);
+    lowering.emitCopyValue(*this, Loc, v);
   }
 
   /// Convenience function for calling TypeLowering.emitRelease on the type
@@ -1497,7 +1497,7 @@ public:
   void emitReleaseValueOperation(SILLocation Loc, SILValue v) {
     assert(!v->getType().isAddress());
     auto &lowering = getTypeLowering(v->getType());
-    lowering.emitReleaseValue(*this, Loc, v);
+    lowering.emitDestroyValue(*this, Loc, v);
   }
 
   SILValue emitTupleExtract(SILLocation Loc, SILValue Operand, unsigned FieldNo,

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -238,7 +238,7 @@ public:
   /// Emit a lowered 'release_value' operation.
   ///
   /// This type must be loadable.
-  virtual void emitLoweredReleaseValue(SILBuilder &B, SILLocation loc,
+  virtual void emitLoweredDestroyValue(SILBuilder &B, SILLocation loc,
                                        SILValue value,
                                        LoweringStyle loweringStyle) const = 0;
 
@@ -246,24 +246,24 @@ public:
                                     SILValue value,
                                     LoweringStyle loweringStyle) const {
     if (loweringStyle != LoweringStyle::Shallow)
-      return emitLoweredReleaseValue(B, loc, value, loweringStyle);
-    return emitReleaseValue(B, loc, value);
+      return emitLoweredDestroyValue(B, loc, value, loweringStyle);
+    return emitDestroyValue(B, loc, value);
   }
 
   /// Emit a lowered 'release_value' operation.
   ///
   /// This type must be loadable.
-  void emitLoweredReleaseValueShallow(SILBuilder &B, SILLocation loc,
+  void emitLoweredDestroyValueShallow(SILBuilder &B, SILLocation loc,
                                       SILValue value) const {
-    emitLoweredReleaseValue(B, loc, value, LoweringStyle::Shallow);
+    emitLoweredDestroyValue(B, loc, value, LoweringStyle::Shallow);
   }
 
   /// Emit a lowered 'release_value' operation.
   ///
   /// This type must be loadable.
-  void emitLoweredReleaseValueDeepNoEnum(SILBuilder &B, SILLocation loc,
+  void emitLoweredDestroyValueDeepNoEnum(SILBuilder &B, SILLocation loc,
                                          SILValue value) const {
-    emitLoweredReleaseValue(B, loc, value, LoweringStyle::DeepNoEnum);
+    emitLoweredDestroyValue(B, loc, value, LoweringStyle::DeepNoEnum);
   }
 
   /// Given a primitively loaded value of this type (which must be
@@ -274,30 +274,30 @@ public:
   /// example, it performs an unowned_release on a value of [unknown]
   /// type.  It is therefore not necessarily the right thing to do on
   /// a semantic load.
-  virtual void emitReleaseValue(SILBuilder &B, SILLocation loc,
+  virtual void emitDestroyValue(SILBuilder &B, SILLocation loc,
                                 SILValue value) const = 0;
 
   /// Emit a lowered 'retain_value' operation.
   ///
   /// This type must be loadable.
-  virtual void emitLoweredRetainValue(SILBuilder &B, SILLocation loc,
+  virtual void emitLoweredCopyValue(SILBuilder &B, SILLocation loc,
                                     SILValue value,
                                     LoweringStyle style) const = 0;
 
   /// Emit a lowered 'retain_value' operation.
   ///
   /// This type must be loadable.
-  void emitLoweredRetainValueShallow(SILBuilder &B, SILLocation loc,
+  void emitLoweredCopyValueShallow(SILBuilder &B, SILLocation loc,
                                    SILValue value) const {
-    emitLoweredRetainValue(B, loc, value, LoweringStyle::Shallow);
+    emitLoweredCopyValue(B, loc, value, LoweringStyle::Shallow);
   }
 
   /// Emit a lowered 'retain_value' operation.
   ///
   /// This type must be loadable.
   void emitLoweredRetainValueDeepNoEnum(SILBuilder &B, SILLocation loc,
-                                      SILValue value) const {
-    emitLoweredRetainValue(B, loc, value, LoweringStyle::DeepNoEnum);
+                                        SILValue value) const {
+    emitLoweredCopyValue(B, loc, value, LoweringStyle::DeepNoEnum);
   }
 
   /// Given a primitively loaded value of this type (which must be
@@ -307,16 +307,16 @@ public:
   /// with exactly the same semantics.  For example, it performs an
   /// unowned_retain on a value of [unknown] type.  It is therefore
   /// not necessarily the right thing to do on a semantic load.
-  virtual void emitRetainValue(SILBuilder &B, SILLocation loc,
+  virtual void emitCopyValue(SILBuilder &B, SILLocation loc,
                              SILValue value) const = 0;
 
   void emitLoweredCopyChildValue(SILBuilder &B, SILLocation loc,
                                  SILValue value,
                                  LoweringStyle style) const {
     if (style != LoweringStyle::Shallow) {
-      emitLoweredRetainValue(B, loc, value, style);
+      emitLoweredCopyValue(B, loc, value, style);
     } else {
-      emitRetainValue(B, loc, value);
+      emitCopyValue(B, loc, value);
     }
   }
 

--- a/lib/SIL/DynamicCasts.cpp
+++ b/lib/SIL/DynamicCasts.cpp
@@ -781,7 +781,7 @@ namespace {
     SILValue getOwnedScalar(Source source, const TypeLowering &srcTL) {
       assert(!source.isAddress());
       if (!source.shouldTake())
-        srcTL.emitRetainValue(B, Loc, source.Value);
+        srcTL.emitCopyValue(B, Loc, source.Value);
       return source.Value;
     }
 
@@ -1217,7 +1217,7 @@ emitIndirectConditionalCastWithScalar(SILBuilder &B, Module *M,
     SILValue succValue =
       new (B.getModule()) SILArgument(scalarSuccBB, targetValueType);
     if (!shouldTakeOnSuccess(consumption))
-      targetTL.emitRetainValue(B, loc, succValue);
+      targetTL.emitCopyValue(B, loc, succValue);
     targetTL.emitStoreOfCopy(B, loc, succValue, dest, IsInitialization);
     B.createBranch(loc, indirectSuccBB);
   }
@@ -1225,7 +1225,7 @@ emitIndirectConditionalCastWithScalar(SILBuilder &B, Module *M,
   // Emit the failure block.
   if (shouldDestroyOnFailure(consumption)) {
     B.setInsertionPoint(scalarFailBB);
-    srcTL.emitReleaseValue(B, loc, srcValue);
+    srcTL.emitDestroyValue(B, loc, srcValue);
     B.createBranch(loc, indirectFailBB);
   }
 }

--- a/lib/SILGen/ManagedValue.cpp
+++ b/lib/SILGen/ManagedValue.cpp
@@ -33,7 +33,7 @@ ManagedValue ManagedValue::copy(SILGenFunction &gen, SILLocation l) {
   assert(!lowering.isTrivial() && "trivial value has cleanup?");
   
   if (!lowering.isAddressOnly()) {
-    lowering.emitRetainValue(gen.B, l, getValue());
+    lowering.emitCopyValue(gen.B, l, getValue());
     return gen.emitManagedRValueWithCleanup(getValue(), lowering);
   }
   
@@ -51,7 +51,7 @@ void ManagedValue::copyInto(SILGenFunction &gen, SILValue dest, SILLocation L) {
                          IsNotTake, IsInitialization);
     return;
   }
-  lowering.emitRetainValue(gen.B, L, getValue());
+  lowering.emitCopyValue(gen.B, L, getValue());
   gen.B.createStore(L, getValue(), dest);
 }
 
@@ -65,7 +65,7 @@ ManagedValue ManagedValue::copyUnmanaged(SILGenFunction &gen, SILLocation loc) {
   
   SILValue result;
   if (!lowering.isAddressOnly()) {
-    lowering.emitRetainValue(gen.B, loc, getValue());
+    lowering.emitCopyValue(gen.B, loc, getValue());
     result = getValue();
   } else {
     result = gen.emitTemporaryAllocation(loc, getType());

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -2422,7 +2422,7 @@ RValue SILGenFunction::emitApply(
 
     case ResultConvention::Unowned:
       // Unretained. Retain the value.
-      resultTL.emitRetainValue(B, loc, result);
+      resultTL.emitCopyValue(B, loc, result);
       break;
     }
 

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -898,7 +898,7 @@ static SILValue emitObjCUnconsumedArgument(SILGenFunction &gen,
     return tmp;
   }
 
-  lowering.emitRetainValue(gen.B, loc, arg);
+  lowering.emitCopyValue(gen.B, loc, arg);
   return arg;
 }
 

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -279,8 +279,8 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
       selfValue = B.createLoad(cleanupLoc, selfLV);
       
       // Emit a retain of the loaded value, since we return it +1.
-      lowering.emitRetainValue(B, cleanupLoc, selfValue);
-      
+      lowering.emitCopyValue(B, cleanupLoc, selfValue);
+
       // Inject the self value into an optional if the constructor is failable.
       if (ctor->getFailability() != OTK_None) {
         selfValue = B.createEnum(ctor, selfValue,

--- a/lib/SILGen/SILGenDynamicCast.cpp
+++ b/lib/SILGen/SILGenDynamicCast.cpp
@@ -233,7 +233,7 @@ namespace {
                                         SGFContext ctx) {
       // Retain the result if this is copy-on-success.
       if (!shouldTakeOnSuccess(consumption))
-        origTargetTL.emitRetainValue(SGF.B, Loc, value);
+        origTargetTL.emitCopyValue(SGF.B, Loc, value);
 
       // Enter a cleanup for the +1 result.
       ManagedValue result

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -59,7 +59,7 @@ ManagedValue SILGenFunction::emitManagedRetain(SILLocation loc,
     return ManagedValue::forUnmanaged(v);
   assert(!lowering.isAddressOnly() && "cannot retain an unloadable type");
 
-  lowering.emitRetainValue(B, loc, v);
+  lowering.emitCopyValue(B, loc, v);
   return emitManagedRValueWithCleanup(v, lowering);
 }
 
@@ -1356,7 +1356,7 @@ ManagedValue SILGenFunction::getManagedValue(SILLocation loc,
 
   // If it's an object, retain and enter a release cleanup.
   if (valueTy.isObject()) {
-    valueTL.emitRetainValue(B, loc, value.getValue());
+    valueTL.emitCopyValue(B, loc, value.getValue());
     return emitManagedRValueWithCleanup(value.getValue(), valueTL);
   }
 

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -722,7 +722,7 @@ static ManagedValue manageParam(SILGenFunction &gen,
   // must retain them even if we're in a context that can accept a +0 value.
   case ParameterConvention::Direct_Unowned:
     gen.getTypeLowering(paramValue->getType())
-          .emitRetainValue(gen.B, loc, paramValue);
+        .emitCopyValue(gen.B, loc, paramValue);
     SWIFT_FALLTHROUGH;
   case ParameterConvention::Direct_Owned:
     return gen.emitManagedRValueWithCleanup(paramValue);
@@ -2104,7 +2104,7 @@ void ResultPlanner::execute(ArrayRef<SILValue> innerDirectResults,
                        "reabstraction of returns_inner_pointer function");
       SWIFT_FALLTHROUGH;
     case ResultConvention::Unowned:
-      resultTL.emitRetainValue(Gen.B, Loc, resultValue);
+      resultTL.emitCopyValue(Gen.B, Loc, resultValue);
       return Gen.emitManagedRValueWithCleanup(resultValue, resultTL);
     }
     llvm_unreachable("bad result convention!");

--- a/lib/SILOptimizer/Analysis/ArraySemantic.cpp
+++ b/lib/SILOptimizer/Analysis/ArraySemantic.cpp
@@ -665,7 +665,7 @@ bool swift::ArraySemanticsCall::replaceByValue(SILValue V) {
   SILBuilderWithScope Builder(SemanticsCall);
   auto &ValLowering = Builder.getModule().getTypeLowering(V->getType());
   if (hasGetElementDirectResult()) {
-    ValLowering.emitRetainValue(Builder, SemanticsCall->getLoc(), V);
+    ValLowering.emitCopyValue(Builder, SemanticsCall->getLoc(), V);
     SemanticsCall->replaceAllUsesWith(V);
   } else {
     auto Dest = SemanticsCall->getArgument(0);
@@ -675,7 +675,7 @@ bool swift::ArraySemanticsCall::replaceByValue(SILValue V) {
     if (!ASI)
       return false;
 
-    ValLowering.emitRetainValue(Builder, SemanticsCall->getLoc(), V);
+    ValLowering.emitCopyValue(Builder, SemanticsCall->getLoc(), V);
     ValLowering.emitStoreOfCopy(Builder, SemanticsCall->getLoc(), V, Dest,
                                 IsInitialization_t::IsInitialization);
   }

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -536,7 +536,7 @@ ClosureCloner::visitStrongReleaseInst(StrongReleaseInst *Inst) {
       SILFunction &F = getBuilder().getFunction();
       auto &typeLowering = F.getModule().getTypeLowering(I->second->getType());
       SILBuilderWithPostProcess<ClosureCloner, 1> B(this, Inst);
-      typeLowering.emitReleaseValue(B, Inst->getLoc(), I->second);
+      typeLowering.emitDestroyValue(B, Inst->getLoc(), I->second);
       return;
     }
   }

--- a/lib/SILOptimizer/Transforms/SILLowerAggregateInstrs.cpp
+++ b/lib/SILOptimizer/Transforms/SILLowerAggregateInstrs.cpp
@@ -107,7 +107,7 @@ static bool expandCopyAddr(CopyAddrInst *CA) {
     //   retain_value %new : $*T
     IsTake_t IsTake = CA->isTakeOfSrc();
     if (IsTake_t::IsNotTake == IsTake) {
-      TL.emitLoweredRetainValue(Builder, CA->getLoc(), New,
+      TL.emitLoweredCopyValue(Builder, CA->getLoc(), New,
                               TypeLowering::LoweringStyle::DeepNoEnum);
     }
 
@@ -116,7 +116,7 @@ static bool expandCopyAddr(CopyAddrInst *CA) {
     //   *or*
     // release_value %old : $*T
     if (Old) {
-      TL.emitLoweredReleaseValue(Builder, CA->getLoc(), Old,
+      TL.emitLoweredDestroyValue(Builder, CA->getLoc(), Old,
                                  TypeLowering::LoweringStyle::DeepNoEnum);
     }
   }
@@ -146,7 +146,7 @@ static bool expandDestroyAddr(DestroyAddrInst *DA) {
     // If we have a type with reference semantics, emit a load/strong release.
     LoadInst *LI = Builder.createLoad(DA->getLoc(), Addr);
     auto &TL = Module.getTypeLowering(Type);
-    TL.emitLoweredReleaseValue(Builder, DA->getLoc(), LI,
+    TL.emitLoweredDestroyValue(Builder, DA->getLoc(), LI,
                                TypeLowering::LoweringStyle::DeepNoEnum);
   }
 
@@ -168,7 +168,7 @@ static bool expandReleaseValue(ReleaseValueInst *DV) {
          "release_value should never be called on a non-loadable type.");
 
   auto &TL = Module.getTypeLowering(Type);
-  TL.emitLoweredReleaseValue(Builder, DV->getLoc(), Value,
+  TL.emitLoweredDestroyValue(Builder, DV->getLoc(), Value,
                              TypeLowering::LoweringStyle::DeepNoEnum);
 
   DEBUG(llvm::dbgs() << "    Expanding Destroy Value: " << *DV);
@@ -191,9 +191,9 @@ static bool expandRetainValue(RetainValueInst *CV) {
          "types.");
 
   auto &TL = Module.getTypeLowering(Type);
-  TL.emitLoweredRetainValue(Builder, CV->getLoc(), Value,
+  TL.emitLoweredCopyValue(Builder, CV->getLoc(), Value,
                           TypeLowering::LoweringStyle::DeepNoEnum);
-  
+
   DEBUG(llvm::dbgs() << "    Expanding Copy Value: " << *CV);
 
   ++NumExpand;

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -347,7 +347,7 @@ static void replaceDestroy(DestroyAddrInst *DAI, SILValue NewValue) {
 
   auto Ty = DAI->getOperand()->getType();
   auto &TL = DAI->getModule().getTypeLowering(Ty);
-  TL.emitLoweredReleaseValue(Builder, DAI->getLoc(), NewValue,
+  TL.emitLoweredDestroyValue(Builder, DAI->getLoc(), NewValue,
                              Lowering::TypeLowering::LoweringStyle::DeepNoEnum);
   DAI->eraseFromParent();
 }


### PR DESCRIPTION
[semantic-arc] Change TypeLowering APIs to use the words {Copy,Destroy}Value instead of {Retain,Release}Value. NFC.

This is an attempt to separate functional from superficial changes in the
semantic arc changes.

rdar://28851920
