### PR TITLE
[semantic-arc] Add a flag to SILBuilder called isParsing to allow for SILBuilder to ignore invariants while parsing.

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -51,8 +51,20 @@ class SILBuilder {
   /// only by SILGen or SIL deserializers.
   SILOpenedArchetypesTracker *OpenedArchetypesTracker = nullptr;
 
+  /// True if this SILBuilder is being used for parsing.
+  ///
+  /// This is important since in such a case, we want to not perform any
+  /// Ownership Verification in SILBuilder. This functionality is very useful
+  /// for determining if qualified or unqualified instructions are being created
+  /// in appropriate places, but prevents us from inferring ownership
+  /// qualification of functions when parsing. The ability to perform this
+  /// inference is important since otherwise, we would need to update all SIL
+  /// test cases while bringing up SIL ownership.
+  bool isParsing = false;
+
 public:
-  SILBuilder(SILFunction &F) : F(F), BB(0) {}
+  SILBuilder(SILFunction &F, bool isParsing = false)
+      : F(F), BB(0), isParsing(isParsing) {}
 
   SILBuilder(SILFunction &F, SmallVectorImpl<SILInstruction *> *InsertedInstrs)
       : F(F), BB(0), InsertedInstrs(InsertedInstrs) {}

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -4103,7 +4103,7 @@ bool Parser::parseDeclSIL() {
       // Parse the basic block list.
       FunctionState.OwnershipEvaluator.reset(FunctionState.F);
       SILOpenedArchetypesTracker OpenedArchetypesTracker(*FunctionState.F);
-      SILBuilder B(*FunctionState.F);
+      SILBuilder B(*FunctionState.F, /*isParsing*/ true);
       // Track the archetypes just like SILGen. This
       // is required for adding typedef operands to instructions.
       B.setOpenedArchetypesTracker(&OpenedArchetypesTracker);


### PR DESCRIPTION
[semantic-arc] Add a flag to SILBuilder called isParsing to allow for SILBuilder to ignore invariants while parsing.

I am going to add asserts to SILBuilder to ensure that the leaf level functions
that create qualified ownership and unqualified ownership instructions assert if
one attempts to create functions with the wrong ownership qualification.

This creates problems in the parser though since we apply the ownership
qualification heuristic to SILInstructions after we have created the instruction
via SILBuilder. I could change the ownership model evaluator to have special
methods for various instructions, but I think that would introduce more
decentralized code in the Parser which I want to avoid. Instead this commit just
introduces a small isParsing flag that is set by SILParser on its SILBuilder
that will cause these invariants to be ignored. Since the bool is used in the
actual asserts themselves they are at the call site where they have an effect,
making it very clear what is going on.

rdar://28851920
