### PR TITLE
IRGen: Cast the type of class pointer to the storage type

### DIFF
--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -456,6 +456,11 @@ OwnedAddress irgen::projectPhysicalClassMemberAddress(IRGenFunction &IGF,
   case FieldAccess::ConstantDirect: {
     Address baseAddr(base, baseClassTI.getHeapAlignment(IGF.IGM, baseType));
     auto &element = baseClassTI.getElements(IGF.IGM, baseType)[fieldIndex];
+    // We might run into a case where the type of baseAddr is an opaque pointer.
+    if (baseAddr->getType() != baseClassTI.getStorageType()) {
+      baseAddr = IGF.Builder.CreateBitCast(baseAddr,
+                                           baseClassTI.getStorageType());
+    }
     Address memberAddr = element.project(IGF, baseAddr, None);
     // We may need to bitcast the address if the field is of a generic type.
     if (memberAddr.getType()->getElementType() != fieldTI.getStorageType())

--- a/test/IRGen/class_bounded_generics.swift
+++ b/test/IRGen/class_bounded_generics.swift
@@ -261,3 +261,15 @@ func class_bounded_metatype<T: SomeSwiftClass>(_ t : T) {
 class WeakRef<T: AnyObject> {
   weak var value: T?
 }
+
+class A<T> {
+  required init() {}
+}
+
+class M<T, S: A<T>> {
+  private var s: S
+  init() {
+    // Don't crash generating the reference to 's'.
+    s = S.init()
+  }
+}


### PR DESCRIPTION
We can run into an opaque pointer type.

rdar://28684642
