### PR TITLE
SR-2208: Improve failure diagnostics for apply expressions

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -5229,6 +5229,8 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
       callExpr->setFn(operatorRef);
   };
 
+  auto fnType = fnExpr->getType()->getRValueType();
+
   // If we have a contextual type, and if we have an ambiguously typed function
   // result from our previous check, we re-type-check it using this contextual
   // type to inform the result type of the callee.
@@ -5241,14 +5243,33 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
       (isUnresolvedOrTypeVarType(fnExpr->getType()) ||
        (fnExpr->getType()->is<AnyFunctionType>() &&
         fnExpr->getType()->hasUnresolvedType()))) {
+    // FIXME: Prevent typeCheckChildIndependently from transforming expressions,
+    // because if we try to typecheck OSR expression with contextual type,
+    // it'll end up converting it into DeclRefExpr based on contextual info,
+    // instead let's try to get a type without applying and filter callee
+    // candidates later on.
     CalleeListener listener(CS->getContextualType());
-    fnExpr = typeCheckChildIndependently(callExpr->getFn(), Type(),
-                                         CTP_CalleeResult, TCC_ForceRecheck,
-                                         &listener);
-    if (!fnExpr) return true;
+
+    if (auto OSR = dyn_cast<OverloadSetRefExpr>(fnExpr)) {
+      assert(!OSR->getReferencedDecl() && "unexpected declaration reference");
+
+      ConcreteDeclRef decl = nullptr;
+      Optional<Type> type = CS->TC.getTypeOfExpressionWithoutApplying(
+          fnExpr, CS->DC, decl, FreeTypeVariableBinding::UnresolvedType,
+          &listener);
+
+      if (type.hasValue())
+        fnType = type.getValue()->getRValueType();
+    } else {
+      fnExpr = typeCheckChildIndependently(callExpr->getFn(), Type(),
+                                           CTP_CalleeResult, TCC_ForceRecheck,
+                                           &listener);
+      if (!fnExpr)
+        return true;
+
+      fnType = fnExpr->getType()->getRValueType();
+    }
   }
-  
-  auto fnType = fnExpr->getType()->getRValueType();
 
   // If we resolved a concrete expression for the callee, and it has
   // non-function/non-metatype type, then we cannot call it!
@@ -5291,7 +5312,37 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
   // Collect a full candidate list of callees based on the partially type
   // checked function.
   CalleeCandidateInfo calleeInfo(fnExpr, hasTrailingClosure, CS);
-  
+
+  // Filter list of the candidates based on the known function type.
+  if (auto fn = fnType->getAs<AnyFunctionType>()) {
+    using Closeness = CalleeCandidateInfo::ClosenessResultTy;
+
+    auto isGenericType = [](Type type) -> bool {
+      if (type->hasError() || type->hasTypeVariable() ||
+          type->hasUnresolvedType())
+        return false;
+
+      return type->isCanonical() && type->isUnspecializedGeneric();
+    };
+
+    calleeInfo.filterList([&](UncurriedCandidate candidate) -> Closeness {
+      auto resultType = candidate.getResultType();
+      if (!resultType)
+        return {CC_GeneralMismatch, {}};
+
+      // FIXME: Handle matching of the generic types properly.
+      // Currently we don't filter result types containing generic parametes
+      // because there is no easy way to do that, and candidate set is going
+      // to be pruned by matching of the argument types later on anyway, so
+      // it's better to over report than to be too conservative.
+      if ((isGenericType(resultType) && isGenericType(fn->getResult())) ||
+          resultType->isEqual(fn->getResult()))
+        return {CC_ExactMatch, {}};
+
+      return {CC_GeneralMismatch, {}};
+    });
+  }
+
   // Filter the candidate list based on the argument we may or may not have.
   calleeInfo.filterContextualMemberList(callExpr->getArg());
 
@@ -5433,7 +5484,23 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
     // conversion failure.
     if (calleeInfo.closeness == CC_ExactMatch)
       return false;
-    
+
+    // If this is not a specific structural problem we can diagnose,
+    // let's check if this is contextual type conversion error.
+    if (CS->getContextualType() &&
+        calleeInfo.closeness == CC_ArgumentMismatch) {
+      CalleeCandidateInfo candidates(fnExpr, hasTrailingClosure, CS);
+
+      // Filter original list of choices based on the deduced type of
+      // argument expression after force re-check.
+      candidates.filterContextualMemberList(argTuple);
+
+      // One of the candidates matches exactly, which means that
+      // this is a contextual type conversion failure, we can't diagnose here.
+      if (candidates.closeness == CC_ExactMatch)
+        return false;
+    }
+
     if (!lhsType->isEqual(rhsType)) {
       diagnose(callExpr->getLoc(), diag::cannot_apply_binop_to_args,
                overloadName, lhsType, rhsType)

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -199,7 +199,7 @@ let d2: Double = 3.14159
 inferDouble2 = d2
 
 // rdar://problem/18269449
-var i1: Int = 1.5 * 3.5 // expected-error {{binary operator '*' cannot be applied to two 'Double' operands}} expected-note {{expected an argument list of type '(Int, Int)'}}
+var i1: Int = 1.5 * 3.5 // expected-error {{cannot convert value of type 'Double' to specified type 'Int'}}
 
 // rdar://problem/18330319
 func rdar18330319(_ s: String, d: [String : AnyObject]) {

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -178,8 +178,7 @@ func perform<T>() {}  // expected-error {{generic parameter 'T' is not used in f
 
 // <rdar://problem/17080659> Error Message QOI - wrong return type in an overload
 func recArea(_ h: Int, w : Int) {
-  return h * w  // expected-error {{no '*' candidates produce the expected contextual result type '()'}}
-  // expected-note @-1 {{overloads for '*' exist with these result types: UInt8, Int8, UInt16, Int16, UInt32, Int32, UInt64, Int64, UInt, Int, Float, Double}}
+  return h * w  // expected-error {{unexpected non-void return value in void function}}
 }
 
 // <rdar://problem/17224804> QoI: Error In Ternary Condition is Wrong
@@ -720,7 +719,8 @@ secondArgumentNotLabeled(10, 20)
 func testImplConversion(a : Float?) -> Bool {}
 func testImplConversion(a : Int?) -> Bool {
   let someInt = 42
-  let a : Int = testImplConversion(someInt) // expected-error {{'testImplConversion' produces 'Bool', not the expected contextual result type 'Int'}}
+  let a : Int = testImplConversion(someInt) // expected-error {{argument labels '(_:)' do not match any available overloads}}
+  // expected-note @-1 {{overloads for 'testImplConversion' exist with these partially matching parameter lists: (a: Float?), (a: Int?)}}
 }
 
 // <rdar://problem/23752537> QoI: Bogus error message: Binary operator '&&' cannot be applied to two 'Bool' operands
@@ -754,7 +754,7 @@ func f23213302() {
 
 // <rdar://problem/24202058> QoI: Return of call to overloaded function in void-return context
 func rdar24202058(a : Int) {
-  return a <= 480 // expected-error {{'<=' produces 'Bool', not the expected contextual result type '()'}}
+  return a <= 480 // expected-error {{unexpected non-void return value in void function}}
 }
 
 // SR-1752: Warning about unused result with ternary operator
@@ -847,3 +847,24 @@ class C2_2505: P_2505 {
 }
 
 let c_2505 = C_2505(arg: [C2_2505()]) // expected-error {{argument labels '(arg:)' do not match any available overloads}} expected-note {{overloads for 'C_2505' exist}}
+
+// Diagnostic message for initialization with binary operations as right side
+let foo1255_3: String = 1 + 2 + 3 // expected-error {{cannot convert value of type 'Int' to specified type 'String'}}
+let foo1255_4: Dictionary<String, String> = ["hello": 1 + 2] // expected-error {{cannot convert value of type 'Int' to expected dictionary value type 'String'}}
+let foo1255_5: Dictionary<String, String> = [(1 + 2): "wolrd"] // expected-error {{cannot convert value of type 'Int' to expected dictionary key type 'String'}}
+let foo1255_6: [String] = [1 + 2 + 3] // expected-error {{cannot convert value of type 'Int' to expected element type 'String'}}
+
+// SR-2208
+struct Foo2208 {
+  func bar(value: UInt) {}
+}
+
+func test2208() {
+  let foo = Foo2208()
+  let a: Int = 1
+  let b: Int = 2
+  let result = a / b
+  foo.bar(value: a / b)  // expected-error {{cannot convert value of type 'Int' to expected argument type 'UInt'}}
+  foo.bar(value: result) // expected-error {{cannot convert value of type 'Int' to expected argument type 'UInt'}}
+  foo.bar(value: UInt(result)) // Ok
+}

--- a/test/Constraints/overload.swift
+++ b/test/Constraints/overload.swift
@@ -129,9 +129,13 @@ func test20886179(_ handlers: [(Int) -> Void], buttonIndex: Int) {
 func overloaded_identity(_ a : Int) -> Int {}
 func overloaded_identity(_ b : Float) -> Float {}
 
-func test_contextual_result() {
-  return overloaded_identity()  // expected-error {{no 'overloaded_identity' candidates produce the expected contextual result type '()'}}
-  // expected-note @-1 {{overloads for 'overloaded_identity' exist with these result types: Int, Float}}
+func test_contextual_result_1() {
+  return overloaded_identity()  // expected-error {{cannot invoke 'overloaded_identity' with no arguments}}
+  // expected-note @-1 {{overloads for 'overloaded_identity' exist with these partially matching parameter lists: (Int), (Float)}}
+}
+
+func test_contextual_result_2() {
+  return overloaded_identity(1)  // expected-error {{unexpected non-void return value in void function}}
 }
 
 // rdar://problem/24128153

--- a/test/Misc/misc_diagnostics.swift
+++ b/test/Misc/misc_diagnostics.swift
@@ -30,11 +30,10 @@ var b: Int = [1, 2, 3] // expected-error{{contextual type 'Int' cannot be used w
 var f1: Float = 2.0
 var f2: Float = 3.0
 
-var dd: Double = f1 - f2 // expected-error{{binary operator '-' cannot be applied to two 'Float' operands}} // expected-note{{expected an argument list of type '(Double, Double)'}}
+var dd: Double = f1 - f2 // expected-error{{cannot convert value of type 'Float' to specified type 'Double'}}
 
 func f() -> Bool {
-  return 1 + 1 // expected-error{{no '+' candidates produce the expected contextual result type 'Bool'}}
-  // expected-note @-1 {{overloads for '+' exist with these result types: UInt8, Int8, UInt16, Int16, UInt32, Int32, UInt64, Int64, UInt, Int, Float, Double}}
+  return 1 + 1 // expected-error{{cannot convert return expression of type 'Int' to return type 'Bool'}}
 }
 
 // Test that nested diagnostics are properly surfaced.
@@ -51,7 +50,8 @@ struct MyArray<Element> {}
 class A {
     var a: MyArray<Int>
     init() {
-        a = MyArray<Int // expected-error{{'<' produces 'Bool', not the expected contextual result type 'MyArray<Int>'}}
+        a = MyArray<Int // expected-error{{binary operator '<' cannot be applied to operands of type 'MyArray<_>.Type' and 'Int.Type'}}
+	// expected-note @-1 {{overloads for '<' exist with these partially matching parameter lists:}}
     }
 }
 
@@ -60,7 +60,7 @@ func retV() { return true } // expected-error {{unexpected non-void return value
 func retAI() -> Int {
     let a = [""]
     let b = [""]
-    return (a + b) // expected-error{{binary operator '+' cannot be applied to two '[String]' operands}} // expected-note{{expected an argument list of type '(Int, Int)'}}
+    return (a + b) // expected-error{{cannot convert return expression of type '[String]' to return type 'Int'}}
 }
 
 func bad_return1() {
@@ -73,15 +73,15 @@ func bad_return2() -> (Int, Int) {
 
 // <rdar://problem/14096697> QoI: Diagnostics for trying to return values from void functions
 func bad_return3(lhs: Int, rhs: Int) {
-  return lhs != 0  // expected-error {{'!=' produces 'Bool', not the expected contextual result type '()'}}
+  return lhs != 0  // expected-error {{unexpected non-void return value in void function}}
 }
 
 class MyBadReturnClass {
   static var intProperty = 42
 }
 
-func ==(lhs: MyBadReturnClass, rhs: MyBadReturnClass) {
-  return MyBadReturnClass.intProperty == MyBadReturnClass.intProperty  // expected-error{{binary operator '==' cannot be applied to two 'Int' operands}} // expected-note{{expected an argument list of type '(MyBadReturnClass, MyBadReturnClass)'}}
+func ==(lhs:MyBadReturnClass, rhs:MyBadReturnClass) {
+  return MyBadReturnClass.intProperty == MyBadReturnClass.intProperty  // expected-error{{unexpected non-void return value in void function}}
 }
 
 

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -9,13 +9,13 @@ protocol FooProtocol {}
 func garbage() -> () {
   var a : Int
   ] this line is invalid, but we will stop at the keyword below... // expected-error{{expected expression}}
-  return a + "a" // expected-error{{no '+' candidates produce the expected contextual result type '()'}} expected-note {{overloads for '+' exist with these result types: UInt8, Int8, UInt16, Int16, UInt32, Int32, UInt64, Int64, UInt, Int, Float, Double}}
+  return a + "a" // expected-error{{binary operator '+' cannot be applied to operands of type 'Int' and 'String'}} expected-note {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (String, String), (Int, UnsafeMutablePointer<Pointee>), (Int, UnsafePointer<Pointee>)}}
 }
 
 func moreGarbage() -> () {
   ) this line is invalid, but we will stop at the declaration... // expected-error{{expected expression}}
   func a() -> Int { return 4 }
-  return a() + "a" // expected-error{{no '+' candidates produce the expected contextual result type '()'}} expected-note {{overloads for '+' exist with these result types: UInt8, Int8, UInt16, Int16, UInt32, Int32, UInt64, Int64, UInt, Int, Float, Double}}
+  return a() + "a" // expected-error{{binary operator '+' cannot be applied to operands of type 'Int' and 'String'}} expected-note {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (String, String), (Int, UnsafeMutablePointer<Pointee>), (Int, UnsafePointer<Pointee>)}}
 }
 
 

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -14,7 +14,7 @@ var closure3a : () -> () -> (Int,Int) = {{ (4, 2) }} // multi-level closing.
 var closure3b : (Int,Int) -> (Int) -> (Int,Int) = {{ (4, 2) }} // expected-error{{contextual type for closure argument list expects 2 arguments, which cannot be implicitly ignored}}  {{52-52=_,_ in }}
 var closure4 : (Int,Int) -> Int = { $0 + $1 }
 var closure5 : (Double) -> Int = {
-       $0 + 1.0 // expected-error {{binary operator '+' cannot be applied to two 'Double' operands}} expected-note {{expected an argument list of type '(Int, Int)'}}
+       $0 + 1.0 // expected-error {{cannot convert value of type 'Double' to closure result type 'Int'}}
 }
 
 var closure6 = $0  // expected-error {{anonymous closure argument not contained in a closure}}
@@ -33,7 +33,7 @@ func funcdecl5(_ a: Int, _ y: Int) {
   
   func6({$0 + $1})       // Closure with two named anonymous arguments
   func6({($0) + $1})    // Closure with sequence expr inferred type
-  func6({($0) + $0})    // // expected-error {{binary operator '+' cannot be applied to two '(Int, Int)' operands}} expected-note {{expected an argument list of type '(Int, Int)'}}
+  func6({($0) + $0})    // // expected-error {{binary operator '+' cannot be applied to two '(Int, Int)' operands}} expected-note {{overloads for '+' exist with these partially matching parameter lists}}
 
 
   var testfunc : ((), Int) -> Int  // expected-note {{'testfunc' declared here}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -51,7 +51,7 @@ func basictest() {
   // expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists:}}
 
 
-  var x9 : Int16 = x8 + 1 // expected-error {{binary operator '+' cannot be applied to operands of type 'Int8' and 'Int'}} expected-note {{expected an argument list of type '(Int16, Int16)'}}
+  var x9 : Int16 = x8 + 1 // expected-error {{cannot convert value of type 'Int8' to specified type 'Int16'}}
 
   // Various tuple types.
   var tuple1 : ()
@@ -757,8 +757,8 @@ func testParenExprInTheWay() {
 
   if (x & 4.0) {}   // expected-error {{binary operator '&' cannot be applied to operands of type 'Int' and 'Double'}} expected-note {{expected an argument list of type '(Int, Int)'}}
 
-  if !(x & 4.0) {}  // expected-error {{no '&' candidates produce the expected contextual result type 'Bool'}}
-  //expected-note @-1 {{overloads for '&' exist with these result types: UInt8, Int8, UInt16, Int16, UInt32, Int32, UInt64, Int64, UInt, Int, T, Self}}
+  if !(x & 4.0) {}  // expected-error {{binary operator '&' cannot be applied to operands of type 'Int' and 'Double'}}
+  //expected-note @-1 {{expected an argument list of type '(Int, Int)'}}
 
   
   if x & x {} // expected-error {{'Int' is not convertible to 'Bool'}}

--- a/test/stdlib/RangeDiagnostics.swift
+++ b/test/stdlib/RangeDiagnostics.swift
@@ -23,8 +23,8 @@ func typeInference_Comparable<C : Comparable>(v: C) {
     expectType(ClosedRange<C>.self, &range)
   }
   do {
-    let r1: Range<C>       = v...v // expected-error {{no '...' candidates produce the expected contextual result type 'Range<C>'}} expected-note {{}}
-    let r2: ClosedRange<C> = v..<v // expected-error {{no '..<' candidates produce the expected contextual result type 'ClosedRange<C>'}} expected-note {{}}
+    let r1: Range<C>       = v...v // expected-error {{cannot convert value of type 'ClosedRange<C>' to specified type 'Range<C>'}}
+    let r2: ClosedRange<C> = v..<v // expected-error {{cannot convert value of type 'Range<C>' to specified type 'ClosedRange<C>'}}
     let r3: CountableRange<C>       = v..<v // expected-error {{type 'C' does not conform to protocol '_Strideable'}}
     let r4: CountableClosedRange<C> = v...v // expected-error {{type 'C' does not conform to protocol '_Strideable'}}
     let r5: CountableRange<C>       = v...v // expected-error {{type 'C' does not conform to protocol '_Strideable'}}
@@ -42,8 +42,8 @@ func typeInference_Strideable<S : Strideable>(v: S) {
     expectType(ClosedRange<S>.self, &range)
   }
   do {
-    let r1: Range<S>       = v...v // expected-error {{no '...' candidates produce the expected contextual result type 'Range<S>'}} expected-note {{}}
-    let r2: ClosedRange<S> = v..<v // expected-error {{no '..<' candidates produce the expected contextual result type 'ClosedRange<S>'}} expected-note {{}}
+    let r1: Range<S>       = v...v // expected-error {{cannot convert value of type 'ClosedRange<S>' to specified type 'Range<S>'}}
+    let r2: ClosedRange<S> = v..<v // expected-error {{cannot convert value of type 'Range<S>' to specified type 'ClosedRange<S>'}}
     let r3: CountableRange<S>       = v..<v // expected-error {{type 'S.Stride' does not conform to protocol 'SignedInteger'}}
     let r4: CountableClosedRange<S> = v...v // expected-error {{type 'S.Stride' does not conform to protocol 'SignedInteger'}}
     let r5: CountableRange<S>       = v...v // expected-error {{type 'S.Stride' does not conform to protocol 'SignedInteger'}}
@@ -62,16 +62,16 @@ func typeInference_StrideableWithSignedIntegerStride<S : Strideable>(v: S)
     expectType(CountableClosedRange<S>.self, &range)
   }
   do {
-    let range: Range<S> = v..<v
+    let _: Range<S> = v..<v
   }
   do {
-    let range: ClosedRange<S> = v...v
+    let _: ClosedRange<S> = v...v
   }
   do {
-    let r1: Range<S>       = v...v // expected-error {{no '...' candidates produce the expected contextual result type 'Range<S>'}} expected-note {{}}
-    let r2: ClosedRange<S> = v..<v // expected-error {{no '..<' candidates produce the expected contextual result type 'ClosedRange<S>'}} expected-note {{}}
-    let r3: CountableRange<S>       = v...v // expected-error {{no '...' candidates produce the expected contextual result type 'CountableRange<S>'}} expected-note {{}}
-    let r4: CountableClosedRange<S> = v..<v // expected-error {{no '..<' candidates produce the expected contextual result type 'CountableClosedRange<S>'}} expected-note {{}}
+    let _: Range<S>       = v...v // expected-error {{cannot convert value of type 'CountableClosedRange<S>' to specified type 'Range<S>'}}
+    let _: ClosedRange<S> = v..<v // expected-error {{cannot convert value of type 'CountableRange<S>' to specified type 'ClosedRange<S>'}}
+    let _: CountableRange<S>       = v...v // expected-error {{cannot convert value of type 'CountableClosedRange<S>' to specified type 'CountableRange<S>'}}
+    let _: CountableClosedRange<S> = v..<v // expected-error {{cannot convert value of type 'CountableRange<S>' to specified type 'CountableClosedRange<S>'}}
   }
 }
 

--- a/validation-test/stdlib/FixedPointDiagnostics.swift.gyb
+++ b/validation-test/stdlib/FixedPointDiagnostics.swift.gyb
@@ -2,13 +2,13 @@
 // RUN: %line-directive %t/main.swift -- %target-swift-frontend -parse -verify %t/main.swift
 
 func testUnaryMinusInUnsigned() {
-  var a: UInt8 = -(1) // expected-error {{}} expected-note * {{}}
+  var a: UInt8 = -(1) // expected-error {{}} expected-note * {{}} expected-warning * {{}}
 
-  var b: UInt16 = -(1) // expected-error {{}} expected-note * {{}}
+  var b: UInt16 = -(1) // expected-error {{}} expected-note * {{}} expected-warning * {{}}
 
-  var c: UInt32 = -(1) // expected-error {{}} expected-note * {{}}
+  var c: UInt32 = -(1) // expected-error {{}} expected-note * {{}} expected-warning * {{}}
 
-  var d: UInt64 = -(1) // expected-error {{}} expected-note * {{}}
+  var d: UInt64 = -(1) // expected-error {{}} expected-note * {{}} expected-warning * {{}}
 }
 
 // Int and UInt are not identical to any fixed-size integer type
@@ -103,7 +103,7 @@ func testMixedSignArithmetic() {
     // disabled by the ambiguity trick.
     //===------------------------------------------------------------------===//
 
-    (x + x) as Stride   // expected-error {{}} expected-note {{}} // not convertible to 'Stride'
+    (x + x) as Stride   // expected-error {{cannot convert value of type '${T}' to type 'Stride' (aka 'Int') in coercion}}
     Stride(1) - ${T}(0) // expected-error {{}} expected-note {{}}
 
     // These tests are expected to start failing when we get improved diagnostics.


### PR DESCRIPTION
<!-- What's in this pull request? -->

Avoid mutating AST when trying to type-check OverloadSetRefExpr with assigned
contextual type because that degrades quality of diagnostics. If contextual type is
assigned to a binary expression and there is no distinct problem with arguments, 
patch tries to double check if there is an "exact match" candidate present in the
original set of callee candidates to distinguish between contextual result conversion
and everything else.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves #44815.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
