### PR TITLE
always inline Array's getters and setters

### DIFF
--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -291,6 +291,7 @@ internal struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
   }
 
   @_versioned
+  @inline(__always)
   internal func getElement(_ i: Int) -> Element {
     _sanityCheck(i >= 0 && i < count, "Array index out of range")
     return firstElementAddress[i]
@@ -299,9 +300,11 @@ internal struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
   /// Get or set the value of the ith element.
   @_versioned
   internal subscript(i: Int) -> Element {
+    @inline(__always)
     get {
       return getElement(i)
     }
+    @inline(__always)
     nonmutating set {
       _sanityCheck(i >= 0 && i < count, "Array index out of range")
 
@@ -316,6 +319,7 @@ internal struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
   }
 
   /// The number of elements the buffer stores.
+  @_versioned
   internal var count: Int {
     get {
       return _storage.countAndCapacity.count


### PR DESCRIPTION
radar rdar://problem/28257066

Due to inline heuristic changes, Array's getters / setters are not always inlined, as a result some customer's workloads (like the one in the radar above) are 10X slower -

In said workload we are iterating over an array of structs, each struct contains sub-structs and Strings, said sub-structs are not read/modified in the workload, nonetheless, we have to do struct_extract and release_value when accessing the structs - this is caused by a call to `@owned` getter / setter array methods.

adding `@inline(__always)` resolves this performance issue
