### PR TITLE
Change arm linux triples

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -432,12 +432,12 @@ function set_build_options_for_host() {
                     ;;
                 linux-armv6)
                     SWIFT_HOST_VARIANT_ARCH="armv6"
-                    SWIFT_HOST_TRIPLE="armv6-linux-gnueabihf"
+                    SWIFT_HOST_TRIPLE="armv6-unknown-linux-gnueabihf"
                     llvm_target_arch="ARM"
                     ;;
                 linux-armv7)
                     SWIFT_HOST_VARIANT_ARCH="armv7"
-                    SWIFT_HOST_TRIPLE="armv7-linux-gnueabihf"
+                    SWIFT_HOST_TRIPLE="armv7-unknown-linux-gnueabihf"
                     llvm_target_arch="ARM"
                     ;;
                 linux-aarch64)


### PR DESCRIPTION
The previous values are not valid triples. See: https://github.com/apple/swift/pull/2497#issuecomment-256172921

Resolves [SR-3019](https://bugs.swift.org/browse/SR-3019)
