### PR TITLE
[3.0] CapturePromotion: Substitute using callee generic signature instead of caller's.

### DIFF
--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -864,8 +864,8 @@ constructClonedFunction(PartialApplyInst *PAI, FunctionRefInst *FRI,
   TypeSubstitutionMap ContextSubs;
 
   ArrayRef<Substitution> ApplySubs = PAI->getSubstitutions();
-  auto genericSig = F->getLoweredFunctionType()->getGenericSignature();
-  auto *genericParams = F->getContextGenericParams();
+  auto genericSig = PAI->getOrigCalleeType()->getGenericSignature();
+  auto *genericParams = FRI->getReferencedFunction()->getContextGenericParams();
 
   if (!ApplySubs.empty()) {
     InterfaceSubs = genericSig->getSubstitutionMap(ApplySubs);

--- a/test/SILOptimizer/capture_promotion_generic_context.sil
+++ b/test/SILOptimizer/capture_promotion_generic_context.sil
@@ -1,0 +1,52 @@
+// RUN: %target-swift-frontend -emit-sil -O %s | %FileCheck %s
+
+sil_stage raw
+
+import Builtin
+
+typealias Int = Builtin.Int32
+
+// CHECK-LABEL: sil @_TTSf2i__promotable_box : $@convention(thin) (Builtin.Int32) -> Builtin.Int32
+
+sil @promotable_box : $@convention(thin) (@box Int) -> Int {
+entry(%b : $@box Int):
+  %a = project_box %b : $@box Int
+  %v = load %a : $*Int
+  return %v : $Int
+}
+
+// CHECK-LABEL: sil @call_promotable_box_from_generic
+// CHECK:         [[F:%.*]] = function_ref @_TTSf2i__promotable_box
+// CHECK:         partial_apply [[F]](
+
+sil @call_promotable_box_from_generic : $@convention(thin) <T> (@in T, Int) -> @owned @callee_owned () -> Int {
+entry(%0 : $*T, %1 : $Int):
+  destroy_addr %0 : $*T
+  %f = function_ref @promotable_box : $@convention(thin) (@box Int) -> Int
+  %b = alloc_box $Int
+  %a = project_box %b : $@box Int
+  store %1 to %a : $*Int
+  %k = partial_apply %f(%b) : $@convention(thin) (@box Int) -> Int
+  return %k : $@callee_owned () -> Int
+}
+
+protocol P {}
+
+sil @generic_promotable_box : $@convention(thin) <T> (@in T, @box Int) -> Int {
+entry(%0 : $*T, %b : $@box Int):
+  %a = project_box %b : $@box Int
+  %v = load %a : $*Int
+  return %v : $Int
+}
+
+sil @call_generic_promotable_box_from_different_generic : $@convention(thin) <T, U: P> (@in T, @in U, Int) -> @owned @callee_owned (@in U) -> Int {
+entry(%0 : $*T, %1 : $*U, %2 : $Int):
+  destroy_addr %0 : $*T
+  destroy_addr %1 : $*U
+  %f = function_ref @generic_promotable_box : $@convention(thin) <V> (@in V, @box Int) -> Int
+  %b = alloc_box $Int
+  %a = project_box %b : $@box Int
+  store %2 to %a : $*Int
+  %k = partial_apply %f<U>(%b) : $@convention(thin) <V> (@in V, @box Int) -> Int
+  return %k : $@callee_owned (@in U) -> Int
+}


### PR DESCRIPTION
Fixes an assertion failure when a nongeneric closure function is optimized inside a generic context.
