### PR TITLE
Change stdlib swiftc's to depend on .swiftmodule's instead of .o's

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -446,6 +446,7 @@ endfunction()
 #   _add_swift_library_single(
 #     target
 #     name
+#     [MODULE_TARGET]
 #     [SHARED]
 #     [STATIC]
 #     [SDK sdk]
@@ -473,6 +474,9 @@ endfunction()
 #
 # name
 #   Name of the library (e.g., swiftParse).
+#
+# MODULE_TARGET
+#   Name of the module target (e.g., swiftParse-swiftmodule-IOS-armv7).
 #
 # SHARED
 #   Build a shared library.
@@ -543,7 +547,7 @@ function(_add_swift_library_single target name)
       API_NOTES_NON_OVERLAY DONT_EMBED_BITCODE)
   cmake_parse_arguments(SWIFTLIB_SINGLE
     "${SWIFTLIB_SINGLE_options}"
-    "SDK;ARCHITECTURE;INSTALL_IN_COMPONENT;DEPLOYMENT_VERSION_IOS"
+    "MODULE_TARGET;SDK;ARCHITECTURE;INSTALL_IN_COMPONENT;DEPLOYMENT_VERSION_IOS"
     "DEPENDS;LINK_LIBRARIES;FRAMEWORK_DEPENDS;FRAMEWORK_DEPENDS_WEAK;LLVM_COMPONENT_DEPENDS;C_COMPILE_FLAGS;SWIFT_COMPILE_FLAGS;LINK_FLAGS;PRIVATE_LINK_LIBRARIES;INTERFACE_LINK_LIBRARIES;INCORPORATE_OBJECT_LIBRARIES;FILE_DEPENDS"
     ${ARGN})
 
@@ -682,6 +686,7 @@ function(_add_swift_library_single target name)
   # just any swiftmodule files that are associated with them.
   handle_swift_sources(
       swift_object_dependency_target
+      swift_module_dependency_target
       SWIFTLIB_SINGLE_SOURCES
       SWIFTLIB_SINGLE_EXTERNAL_SOURCES ${name}
       DEPENDS
@@ -699,6 +704,13 @@ function(_add_swift_library_single target name)
       ${SWIFTLIB_SINGLE_IS_SDK_OVERLAY_keyword}
       INSTALL_IN_COMPONENT "${SWIFTLIB_INSTALL_IN_COMPONENT}")
   add_swift_source_group("${SWIFTLIB_SINGLE_EXTERNAL_SOURCES}")
+
+  # If there were any swift sources, then a .swiftmodule may have been created.
+  # If that is the case, then add a target which is an alias of the module files.
+  if(NOT "${SWIFTLIB_SINGLE_MODULE_TARGET}" STREQUAL "" AND NOT "${swift_module_dependency_target}" STREQUAL "")
+    add_custom_target("${SWIFTLIB_SINGLE_MODULE_TARGET}"
+                      DEPENDS ${swift_module_dependency_target})
+  endif()
 
   set(VARIANT_SUFFIX "-${SWIFT_SDK_${SWIFTLIB_SINGLE_SDK}_LIB_SUBDIR}-${SWIFTLIB_SINGLE_ARCHITECTURE}")
   set(SWIFTLIB_INCORPORATED_OBJECT_LIBRARIES_EXPRESSIONS)
@@ -874,6 +886,7 @@ function(_add_swift_library_single target name)
         ${SWIFTLIB_SINGLE_DEPENDS}
         ${gyb_dependency_targets}
         "${swift_object_dependency_target}"
+        "${swift_module_dependency_target}"
         ${LLVM_COMMON_DEPENDS})
 
   # HACK: On some systems or build directory setups, CMake will not find static
@@ -1320,6 +1333,8 @@ function(add_swift_library name)
         # Configure variables for this subdirectory.
         set(VARIANT_SUFFIX "-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
         set(VARIANT_NAME "${name}${VARIANT_SUFFIX}")
+        set(MODULE_VARIANT_SUFFIX "-swiftmodule${VARIANT_SUFFIX}")
+        set(MODULE_VARIANT_NAME "${name}${MODULE_VARIANT_SUFFIX}")
 
         # Map dependencies over to the appropriate variants.
         set(swiftlib_link_libraries)
@@ -1352,23 +1367,17 @@ function(add_swift_library name)
               ${SWIFTLIB_SWIFT_MODULE_DEPENDS_LINUX})
         endif()
 
+        # Swift compiles depend on swift modules, while links depend on
+        # linked libraries.  Find targets for both of these here.
         set(swiftlib_module_dependency_targets)
+        set(swiftlib_private_link_libraries_targets)
         foreach(mod ${swiftlib_module_depends_flattened})
           list(APPEND swiftlib_module_dependency_targets
+              "swift${mod}${MODULE_VARIANT_SUFFIX}")
+          list(APPEND swiftlib_private_link_libraries_targets
               "swift${mod}${VARIANT_SUFFIX}")
         endforeach()
 
-        set(swiftlib_framework_depends_flattened ${SWIFTLIB_FRAMEWORK_DEPENDS})
-        if("${sdk}" STREQUAL "OSX")
-          list(APPEND swiftlib_framework_depends_flattened
-              ${SWIFTLIB_FRAMEWORK_DEPENDS_OSX})
-        elseif("${sdk}" STREQUAL "IOS" OR "${sdk}" STREQUAL "IOS_SIMULATOR" OR "${sdk}" STREQUAL "TVOS" OR "${sdk}" STREQUAL "TVOS_SIMULATOR")
-          list(APPEND swiftlib_framework_depends_flattened
-              ${SWIFTLIB_FRAMEWORK_DEPENDS_IOS_TVOS})
-        endif()
-
-        set(swiftlib_private_link_libraries_targets
-            ${swiftlib_module_dependency_targets})
         foreach(lib ${SWIFTLIB_PRIVATE_LINK_LIBRARIES})
           if("${lib}" STREQUAL "ICU_UC")
             list(APPEND swiftlib_private_link_libraries_targets
@@ -1383,6 +1392,15 @@ function(add_swift_library name)
             list(APPEND swiftlib_private_link_libraries_targets "${lib}")
           endif()
         endforeach()
+
+        set(swiftlib_framework_depends_flattened ${SWIFTLIB_FRAMEWORK_DEPENDS})
+        if("${sdk}" STREQUAL "OSX")
+          list(APPEND swiftlib_framework_depends_flattened
+              ${SWIFTLIB_FRAMEWORK_DEPENDS_OSX})
+        elseif("${sdk}" STREQUAL "IOS" OR "${sdk}" STREQUAL "IOS_SIMULATOR" OR "${sdk}" STREQUAL "TVOS" OR "${sdk}" STREQUAL "TVOS_SIMULATOR")
+          list(APPEND swiftlib_framework_depends_flattened
+              ${SWIFTLIB_FRAMEWORK_DEPENDS_IOS_TVOS})
+        endif()
 
         # Collect compiler flags
         set(swiftlib_swift_compile_flags_all ${SWIFTLIB_SWIFT_COMPILE_FLAGS})
@@ -1421,6 +1439,7 @@ function(add_swift_library name)
           ${SWIFTLIB_STATIC_keyword}
           ${SWIFTLIB_OBJECT_LIBRARY_keyword}
           ${SWIFTLIB_SOURCES}
+          MODULE_TARGET ${MODULE_VARIANT_NAME}
           SDK ${sdk}
           ARCHITECTURE ${arch}
           DEPENDS ${SWIFTLIB_DEPENDS}
@@ -1730,6 +1749,7 @@ function(_add_swift_executable_single name)
 
   handle_swift_sources(
       dependency_target
+      unused_module_dependency_target
       SWIFTEXE_SINGLE_SOURCES SWIFTEXE_SINGLE_EXTERNAL_SOURCES ${name}
       DEPENDS
         ${SWIFTEXE_SINGLE_DEPENDS}

--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -6,7 +6,9 @@
 # Usage:
 #   handle_swift_sources(sourcesvar externalvar)
 function(handle_swift_sources
-    dependency_target_out_var_name sourcesvar externalvar name)
+    dependency_target_out_var_name
+    dependency_module_target_out_var_name
+    sourcesvar externalvar name)
   cmake_parse_arguments(SWIFTSOURCES
       "IS_MAIN;IS_STDLIB;IS_STDLIB_CORE;IS_SDK_OVERLAY"
       "SDK;ARCHITECTURE;INSTALL_IN_COMPONENT"
@@ -38,6 +40,7 @@ function(handle_swift_sources
 
   # Clear the result variable.
   set("${dependency_target_out_var_name}" "" PARENT_SCOPE)
+  set("${dependency_module_target_out_var_name}" "" PARENT_SCOPE)
 
   set(result)
   set(swift_sources)
@@ -78,6 +81,7 @@ function(handle_swift_sources
 
     _compile_swift_files(
         dependency_target
+        module_dependency_target
         OUTPUT ${swift_obj}
         SOURCES ${swift_sources}
         DEPENDS ${SWIFTSOURCES_DEPENDS}
@@ -93,6 +97,7 @@ function(handle_swift_sources
         ${STATIC_arg}
         INSTALL_IN_COMPONENT "${SWIFTSOURCES_INSTALL_IN_COMPONENT}")
     set("${dependency_target_out_var_name}" "${dependency_target}" PARENT_SCOPE)
+    set("${dependency_module_target_out_var_name}" "${module_dependency_target}" PARENT_SCOPE)
     list(APPEND result ${swift_obj})
   endif()
 
@@ -134,7 +139,8 @@ endfunction()
 #     [IS_STDLIB]                       # Install produced files.
 #     [EMIT_SIB]                        # Emit the file as a sib file instead of a .o
 #     )
-function(_compile_swift_files dependency_target_out_var_name)
+function(_compile_swift_files
+         dependency_target_out_var_name dependency_module_target_out_var_name)
   cmake_parse_arguments(SWIFTFILE
     "IS_MAIN;IS_STDLIB;IS_STDLIB_CORE;IS_SDK_OVERLAY;EMIT_SIB"
     "OUTPUT;MODULE_NAME;INSTALL_IN_COMPONENT"
@@ -274,6 +280,7 @@ function(_compile_swift_files dependency_target_out_var_name)
   set(module_file)
   set(module_doc_file)
 
+  set(module_command)
   if(NOT SWIFTFILE_IS_MAIN)
     # Determine the directory where the module file should be placed.
     if(SWIFTFILE_MODULE_DIR)
@@ -284,16 +291,15 @@ function(_compile_swift_files dependency_target_out_var_name)
       message(FATAL_ERROR "Don't know where to put the module files")
     endif()
 
+    list(APPEND swift_flags "-parse-as-library")
     if (NOT SWIFTFILE_EMIT_SIB)
       # Right now sib files seem to not be output when we emit a module. So
       # don't emit it.
       set(module_file "${module_dir}/${SWIFTFILE_MODULE_NAME}.swiftmodule")
       set(module_doc_file "${module_dir}/${SWIFTFILE_MODULE_NAME}.swiftdoc")
-      list(APPEND swift_flags
-          "-parse-as-library"
-          "-emit-module" "-emit-module-path" "${module_file}")
-    else()
-      list(APPEND swift_flags "-parse-as-library")
+      list(APPEND module_command
+          "-emit-module"
+          "-o" "${module_file}")
     endif()
 
     list(APPEND command_create_dirs
@@ -366,9 +372,9 @@ function(_compile_swift_files dependency_target_out_var_name)
     set(swift_compiler_tool "${SWIFT_SOURCE_DIR}/utils/check-incremental" "${swift_compiler_tool}")
   endif()
 
-  set(outputs
-    ${SWIFTFILE_OUTPUT} "${module_file}" "${module_doc_file}"
-    ${apinote_files})
+  set(standard_outputs ${SWIFTFILE_OUTPUT})
+  set(apinotes_outputs ${apinote_files})
+  set(module_outputs "${module_file}" "${module_doc_file}")
 
   if(XCODE)
     # HACK: work around an issue with CMake Xcode generator and the Swift
@@ -383,28 +389,73 @@ function(_compile_swift_files dependency_target_out_var_name)
     #
     # To work around this issue we touch the output files so that their mtime
     # always gets updated.
-    set(command_touch_outputs
-      COMMAND "${CMAKE_COMMAND}" -E touch ${outputs})
+    set(command_touch_standard_outputs
+      COMMAND "${CMAKE_COMMAND}" -E touch ${standard_outputs})
+    set(command_touch_apinotes_outputs
+      COMMAND "${CMAKE_COMMAND}" -E touch ${apinotes_outputs})
+    set(command_touch_module_outputs
+      COMMAND "${CMAKE_COMMAND}" -E touch ${module_outputs})
   endif()
 
+  # First generate the obj dirs
+  add_custom_command_target(
+      obj_dirs_dependency_target
+      ${command_create_dirs}
+      COMMAND ""
+      OUTPUT ${obj_dirs}
+      COMMENT "Generating obj dirs for ${first_output}")
+
+  # Generate the api notes if we need them.
+  if (apinotes_outputs)
+    add_custom_command_target(
+        api_notes_dependency_target
+        # Create API notes before compiling, because this will affect the APIs
+        # the overlay sees.
+        ${command_create_apinotes}
+        ${command_touch_apinotes_outputs}
+        COMMAND ""
+        OUTPUT ${apinotes_outputs}
+        DEPENDS
+          ${swift_compiler_tool_dep}
+          ${depends_create_apinotes}
+          ${obj_dirs_dependency_target}
+        COMMENT "Generating API notes ${first_output}")
+  endif()
+
+  # Then we can compile both the object files and the swiftmodule files
+  # in parallel in this target for the object file, and ...
   add_custom_command_target(
       dependency_target
-      ${command_create_dirs}
-      # Create API notes before compiling, because this will affect the APIs
-      # the overlay sees.
-      ${command_create_apinotes}
       COMMAND
         "${line_directive_tool}" "${source_files}" --
         "${swift_compiler_tool}" "${main_command}" ${swift_flags}
         ${output_option} "${source_files}"
-      ${command_touch_outputs}
-      OUTPUT ${outputs}
+      ${command_touch_standard_outputs}
+      OUTPUT ${standard_outputs}
       DEPENDS
         ${swift_compiler_tool_dep}
         ${source_files} ${SWIFTFILE_DEPENDS}
-        ${swift_ide_test_dependency} ${depends_create_apinotes}
+        ${swift_ide_test_dependency} ${api_notes_dependency_target}
+        ${obj_dirs_dependency_target}
       COMMENT "Compiling ${first_output}")
   set("${dependency_target_out_var_name}" "${dependency_target}" PARENT_SCOPE)
+
+  # This is the target to generate the .swiftmodule and .swiftdoc
+  add_custom_command_target(
+      module_dependency_target
+      COMMAND
+        "${line_directive_tool}" "${source_files}" --
+        "${swift_compiler_tool}" "${module_command}" ${swift_flags}
+        "${source_files}"
+      ${command_touch_module_outputs}
+      OUTPUT ${module_outputs}
+      DEPENDS
+        ${swift_compiler_tool_dep}
+        ${source_files} ${SWIFTFILE_DEPENDS}
+        ${swift_ide_test_dependency} ${api_notes_dependency_target}
+        ${obj_dirs_dependency_target}
+      COMMENT "Generating ${module_file}")
+  set("${dependency_module_target_out_var_name}" "${module_dependency_target}" PARENT_SCOPE)
 
   # Make sure the build system knows the file is a generated object file.
   set_source_files_properties(${SWIFTFILE_OUTPUT}


### PR DESCRIPTION
Currently SwiftOnoneSupport.o waits on Swift.o to finish compiling before we start
compiling SwiftOnoneSupport.o.  We don't need the .o for compilation but instead just
need Swift.swiftmodule which we were generating anyway.

This change causes .o and { .swiftmodule, .swiftdoc } to be built independently of each
other.  Downstream compiles only wait on the module while downstream links wait on the .o.

Given that .apinotes are sometimes used by swiftc invocations, this also separates out
apinotes in to its own step which these other commands can both depend on.

The result of this is a 30% improvement in building the stdlib with -R and 20% with -d.
Specifically, -R drops from 3m to 2m and -d drops from 12m to just under 10m.

This was tested with --validation-test which uncovered a missing dependency.  After adding that
in, we now pass the tests.
