### PR TITLE
[semantic-arc] Make sure that the ownership model eliminator sets the unqualified flag before it runs.

### DIFF
--- a/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
@@ -151,6 +151,10 @@ namespace {
 struct OwnershipModelEliminator : SILFunctionTransform {
   void run() override {
     SILFunction *F = getFunction();
+
+    // Set F to have unqualified ownership.
+    F->setUnqualifiedOwnership();
+
     bool MadeChange = false;
     SILBuilder B(*F);
     OwnershipModelEliminatorVisitor Visitor(B);
@@ -171,10 +175,6 @@ struct OwnershipModelEliminator : SILFunctionTransform {
       // that analysis.
       invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
     }
-
-    // Now that we have lowered to unqualified ownership, set the unqualified
-    // ownership flag on the function.
-    F->setUnqualifiedOwnership();
   }
 
   StringRef getName() override { return "Ownership Model Eliminator"; }


### PR DESCRIPTION
[semantic-arc] Make sure that the ownership model eliminator sets the unqualified flag before it runs.

Otherwise, we will trigger verification in SILBuilder when I insert verification there?!

rdar://28851920
