### PR TITLE
Refactor SILDeclRef constructors

### DIFF
--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -51,6 +51,15 @@ public:
     }
   }
 
+  /// Get the natural uncurry level for the embedded function which is the number
+  /// of parameter lists minus one. Functions with local captures have an extra
+  /// level for the capture context.
+  unsigned getNaturalUncurryLevel() const {
+    assert(getParameterLists().size() >= 1 && "no arguments for func?!");
+    unsigned Level = getParameterLists().size() - 1;
+    return getCaptureInfo().hasLocalCaptures() ? Level + 1 : Level;
+  }
+
   CaptureInfo &getCaptureInfo() const {
     if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>())
       return AFD->getCaptureInfo();

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -155,7 +155,7 @@ static unsigned getNaturalUncurryLevelAndKind(ValueDecl *vd,
     assertNoSet();
     setOrCheck(Kind::GlobalAccessor, Kind::GlobalGetter,
                Kind::StoredPropertyInitializer);
-    auto var = cast<VarDecl>(vd);
+    auto *var = cast<VarDecl>(vd);
     assert(!var->getDeclContext()->isLocalContext() &&
            "can't reference local var as global var");
     assert(var->hasStorage() && "can't reference computed var as global var");

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -162,8 +162,22 @@ static unsigned getNaturalUncurryLevelAndKind(ValueDecl *vd,
     (void)var;
     return 0;
   }
-  default:
-    llvm_unreachable("unhandled kind of ValueDecl for SILDeclRef");
+
+  case DeclKind::GenericTypeParam:
+  case DeclKind::AssociatedType:
+  case DeclKind::TypeAlias:
+  case DeclKind::Enum:
+  case DeclKind::Struct:
+  case DeclKind::Protocol:
+  case DeclKind::Module:
+  case DeclKind::Param:
+  case DeclKind::Subscript:
+    llvm_unreachable("invalid kind of ValueDecl for SILDeclRef");
+
+#define VALUE_DECL(...)
+#define DECL(Id, Parent) case DeclKind::Id:
+#include "swift/AST/DeclNodes.def"
+    llvm_unreachable("impossible value decl");
   }
 }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -439,7 +439,7 @@ emitRValueForDecl(SILLocation loc, ConcreteDeclRef declRef, Type ncRefType,
   // sort.
 
   unsigned uncurryLevel = 0;
-  if (auto fd = dyn_cast<FuncDecl>(decl))
+  if (auto *fd = dyn_cast<FuncDecl>(decl))
     uncurryLevel = AnyFunctionRef(fd).getNaturalUncurryLevel();
   auto silDeclRef = SILDeclRef(decl, ResilienceExpansion::Minimal, uncurryLevel);
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -438,16 +438,9 @@ emitRValueForDecl(SILLocation loc, ConcreteDeclRef declRef, Type ncRefType,
   // If the referenced decl isn't a VarDecl, it should be a constant of some
   // sort.
 
-  // If the referenced decl is a local func with context, then the SILDeclRef
-  // uncurry level is one deeper (for the context vars).
-  bool hasLocalCaptures = false;
   unsigned uncurryLevel = 0;
-  if (auto *fd = dyn_cast<FuncDecl>(decl)) {
-    hasLocalCaptures = fd->getCaptureInfo().hasLocalCaptures();
-    if (hasLocalCaptures)
-      ++uncurryLevel;
-  }
-
+  if (auto fd = dyn_cast<FuncDecl>(decl))
+    uncurryLevel = AnyFunctionRef(fd).getNaturalUncurryLevel();
   auto silDeclRef = SILDeclRef(decl, ResilienceExpansion::Minimal, uncurryLevel);
 
   ManagedValue result = emitClosureValue(loc, silDeclRef, refType,


### PR DESCRIPTION
This addresses a FIXME and reduces code/logic duplication in the `SILDeclRef` constructors.
