### PR TITLE
[sourcekit] Introduce a lazy representation for DocumentStructure responses

### DIFF
--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/CompactArray.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/CompactArray.h
@@ -21,7 +21,9 @@ namespace sourcekitd {
 class CompactArrayBuilderImpl {
 public:
   std::unique_ptr<llvm::MemoryBuffer> createBuffer() const;
+  void appendTo(llvm::SmallVectorImpl<char> &Buf) const;
 
+  size_t sizeInBytes() const;
   bool empty() const;
 
 protected:
@@ -35,30 +37,12 @@ protected:
 
 private:
   unsigned getOffsetForString(llvm::StringRef Str);
+  void copyInto(char *BufPtr, size_t Length) const;
 
   llvm::SmallVector<uint8_t, 256> EntriesBuffer;
   llvm::SmallString<256> StringBuffer;
 };
 
-template <typename ...EntryTypes>
-class CompactArrayBuilder : public CompactArrayBuilderImpl {
-public:
-  void addEntry(EntryTypes... Args) {
-    add(Args...);
-  }
-
-private:
-  template <typename T, typename ...Targs>
-  void add(T Val, Targs... Args) {
-    add(Val);
-    add(Args...);
-  }
-
-  template <typename T>
-  void add(T Val) {
-    addImpl(Val);
-  }
-};
 
 template <typename T>
 struct CompactArrayField {
@@ -86,6 +70,31 @@ struct CompactArrayEntriesSizer<T> {
   static constexpr size_t getByteSize() {
     return CompactArrayField<T>::getByteSize();
   }
+};
+
+template <typename ...EntryTypes>
+class CompactArrayBuilder : public CompactArrayBuilderImpl {
+public:
+  void addEntry(EntryTypes... Args) {
+    add(Args...);
+    count += 1;
+  }
+
+  size_t size() const { return count; }
+
+private:
+  template <typename T, typename ...Targs>
+  void add(T Val, Targs... Args) {
+    add(Val);
+    add(Args...);
+  }
+
+  template <typename T>
+  void add(T Val) {
+    addImpl(Val);
+  }
+
+  size_t count = 0;
 };
 
 class CompactArrayReaderImpl {

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/DocStructureArray.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/DocStructureArray.h
@@ -1,0 +1,55 @@
+//===--- DocStructureArray.h - ----------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SOURCEKITD_DOC_STRUCTURE_ARRAY_H
+#define LLVM_SOURCEKITD_DOC_STRUCTURE_ARRAY_H
+
+#include "sourcekitd/Internal.h"
+#include "llvm/ADT/SmallString.h"
+
+namespace sourcekitd {
+
+VariantFunctions *getVariantFunctionsForDocStructureArray();
+VariantFunctions *getVariantFunctionsForDocStructureElementArray();
+VariantFunctions *getVariantFunctionsForInheritedTypesArray();
+VariantFunctions *getVariantFunctionsForAttributesArray();
+
+class DocStructureArrayBuilder {
+public:
+  DocStructureArrayBuilder();
+  ~DocStructureArrayBuilder();
+
+  void beginSubStructure(unsigned Offset, unsigned Length,
+                         SourceKit::UIdent Kind, SourceKit::UIdent AccessLevel,
+                         SourceKit::UIdent SetterAccessLevel,
+                         unsigned NameOffset, unsigned NameLength,
+                         unsigned BodyOffset, unsigned BodyLength,
+                         llvm::StringRef DisplayName, llvm::StringRef TypeName,
+                         llvm::StringRef RuntimeName,
+                         llvm::StringRef SelectorName,
+                         llvm::ArrayRef<llvm::StringRef> InheritedTypes,
+                         llvm::ArrayRef<SourceKit::UIdent> Attrs);
+
+  void addElement(SourceKit::UIdent Kind, unsigned Offset, unsigned Length);
+
+  void endSubStructure();
+
+  std::unique_ptr<llvm::MemoryBuffer> createBuffer();
+
+private:
+  struct Implementation;
+  Implementation &impl;
+};
+
+} // end namespace sourcekitd
+
+#endif // LLVM_SOURCEKITD_DOC_STRUCTURE_ARRAY_H

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
@@ -47,6 +47,10 @@ enum class CustomBufferKind {
   TokenAnnotationsArray,
   DocSupportAnnotationArray,
   CodeCompletionResultsArray,
+  DocStructureArray,
+  InheritedTypesArray,
+  DocStructureElementArray,
+  AttributesArray,
 };
 
 class ResponseBuilder {

--- a/tools/SourceKit/tools/sourcekitd/lib/API/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(sourcekitdAPI_sources
   CodeCompletionResultsArray.cpp
   CompactArray.cpp
+  DocStructureArray.cpp
   DocSupportAnnotationArray.cpp
   Requests.cpp
   sourcekitdAPI-Common.cpp

--- a/tools/SourceKit/tools/sourcekitd/lib/API/CompactArray.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/CompactArray.cpp
@@ -43,8 +43,12 @@ void CompactArrayBuilderImpl::addImpl(StringRef Val) {
 }
 
 void CompactArrayBuilderImpl::addImpl(UIdent Val) {
-  sourcekitd_uid_t uid = SKDUIDFromUIdent(Val);
-  addScalar(uid, EntriesBuffer);
+  if (Val.isValid()) {
+    sourcekitd_uid_t uid = SKDUIDFromUIdent(Val);
+    addScalar(uid, EntriesBuffer);
+  } else {
+    addScalar(sourcekitd_uid_t(nullptr), EntriesBuffer);
+  }
 }
 
 void CompactArrayBuilderImpl::addImpl(Optional<llvm::StringRef> Val) {
@@ -67,25 +71,35 @@ unsigned CompactArrayBuilderImpl::getOffsetForString(StringRef Str) {
 
 std::unique_ptr<llvm::MemoryBuffer>
 CompactArrayBuilderImpl::createBuffer() const {
-  size_t EntriesBufSize = EntriesBuffer.size();
   std::unique_ptr<llvm::MemoryBuffer> Buf;
-  Buf = llvm::MemoryBuffer::getNewUninitMemBuffer(
-      sizeof(uint64_t) +
-      EntriesBufSize +
-      StringBuffer.size());
+  Buf = llvm::MemoryBuffer::getNewUninitMemBuffer(sizeInBytes());
+  copyInto(const_cast<char *>(Buf->getBufferStart()), Buf->getBufferSize());
+  return Buf;
+}
 
-  char *BufPtr = (char*)Buf->getBufferStart();
-  *reinterpret_cast<uint64_t*>(BufPtr) = EntriesBufSize;
-  BufPtr += sizeof(uint64_t);
+void CompactArrayBuilderImpl::appendTo(SmallVectorImpl<char> &Buf) const {
+  size_t OrigSize = Buf.size();
+  size_t NewSize = OrigSize + sizeInBytes();
+  Buf.resize(NewSize);
+  copyInto(Buf.data() + OrigSize, NewSize - OrigSize);
+}
+
+void CompactArrayBuilderImpl::copyInto(char *BufPtr, size_t Length) const {
+  uint64_t EntriesBufSize = EntriesBuffer.size();
+  assert(Length >= sizeInBytes());
+  memcpy(BufPtr, &EntriesBufSize, sizeof(EntriesBufSize));
+  BufPtr += sizeof(EntriesBufSize);
   memcpy(BufPtr, EntriesBuffer.data(), EntriesBufSize);
   BufPtr += EntriesBufSize;
   memcpy(BufPtr, StringBuffer.data(), StringBuffer.size());
-
-  return Buf;
 }
 
 bool CompactArrayBuilderImpl::empty() const {
   return EntriesBuffer.empty();
+}
+
+size_t CompactArrayBuilderImpl::sizeInBytes() const {
+  return sizeof(uint64_t) + EntriesBuffer.size() + StringBuffer.size();
 }
 
 template <typename T>

--- a/tools/SourceKit/tools/sourcekitd/lib/API/DocStructureArray.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/DocStructureArray.cpp
@@ -1,0 +1,569 @@
+//===--- DocStructureArray.cpp --------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "sourcekitd/DocStructureArray.h"
+#include "DictionaryKeys.h"
+#include "SourceKit/Core/LLVM.h"
+#include "SourceKit/Support/UIdent.h"
+#include "sourcekitd/CompactArray.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace SourceKit;
+using namespace sourcekitd;
+
+namespace {
+struct Node {
+  // Scalars
+  unsigned Offset;
+  unsigned Length;
+  UIdent Kind;
+  UIdent AccessLevel;
+  UIdent SetterAccessLevel;
+  unsigned NameOffset;
+  unsigned NameLength;
+  unsigned BodyOffset;
+  unsigned BodyLength;
+  std::string DisplayName;
+  std::string TypeName;
+  std::string RuntimeName;
+  std::string SelectorName;
+  // Arrays
+  unsigned InheritedTypesOffset;
+  unsigned AttrsOffset;
+
+  // Children
+  struct Element {
+    UIdent Kind;
+    unsigned Offset;
+    unsigned Length;
+  };
+  SmallVector<Element, 4> elements;
+  SmallVector<unsigned, 4> childIndices;
+};
+}
+
+struct DocStructureArrayBuilder::Implementation {
+  typedef CompactArrayBuilder<StringRef> InheritedTypesBuilder;
+  SmallVector<char, 256> inheritedTypesBuffer;
+  typedef CompactArrayBuilder<UIdent> AttrsBuilder;
+  SmallVector<char, 256> attrsBuffer;
+  typedef CompactArrayBuilder<UIdent, unsigned, unsigned> ElementsBuilder;
+  SmallVector<char, 256> elementsBuffer;
+  typedef CompactArrayBuilder<unsigned> StructureArrayBuilder;
+  SmallVector<char, 256> structureArrayBuffer;
+
+  CompactArrayBuilder<unsigned,            // Offset
+                      unsigned,            // Length
+                      UIdent,              // Kind
+                      UIdent,              // AccessLevel
+                      UIdent,              // SetterAccessLevel
+                      unsigned,            // NameOffset
+                      unsigned,            // NameLength
+                      unsigned,            // BodyOffset
+                      unsigned,            // BodyLength
+                      Optional<StringRef>, // DisplayName
+                      Optional<StringRef>, // TypeName
+                      Optional<StringRef>, // RuntimeName
+                      Optional<StringRef>, // SelectorName
+                      unsigned,            // InheritedTypesOffset
+                      unsigned,            // AttrsOffset
+                      unsigned,            // ElementsOffset
+                      unsigned             // ChildrenOffset
+                      >
+      structureBuilder;
+
+  SmallVector<Node, 8> structure;
+  SmallVector<unsigned, 16> topIndices;
+
+  unsigned addInheritedTypes(ArrayRef<StringRef> inheritedTypes);
+  unsigned addAttrs(ArrayRef<UIdent> attrs);
+  unsigned addElements(ArrayRef<Node::Element> elements);
+  unsigned addChildren(ArrayRef<unsigned> offsets);
+
+  Implementation();
+};
+
+DocStructureArrayBuilder::Implementation::Implementation() {
+  // For each kind of compact array, fill in the first entry in the buffer as
+  // empty so we don't duplicate empty arrays anywhere.
+  InheritedTypesBuilder().appendTo(inheritedTypesBuffer);
+  AttrsBuilder().appendTo(attrsBuffer);
+  ElementsBuilder().appendTo(elementsBuffer);
+  StructureArrayBuilder().appendTo(structureArrayBuffer);
+}
+
+unsigned DocStructureArrayBuilder::Implementation::addInheritedTypes(
+    ArrayRef<StringRef> inheritedTypes) {
+  if (inheritedTypes.empty())
+    return 0;
+
+  InheritedTypesBuilder builder;
+  for (StringRef type : inheritedTypes)
+    builder.addEntry(type);
+
+  unsigned offset = inheritedTypesBuffer.size();
+  builder.appendTo(inheritedTypesBuffer);
+  return offset;
+}
+
+unsigned
+DocStructureArrayBuilder::Implementation::addAttrs(ArrayRef<UIdent> attrs) {
+  if (attrs.empty())
+    return 0;
+
+  AttrsBuilder builder;
+  for (UIdent uid : attrs)
+    builder.addEntry(uid);
+
+  unsigned offset = attrsBuffer.size();
+  builder.appendTo(attrsBuffer);
+  return offset;
+}
+
+unsigned DocStructureArrayBuilder::Implementation::addElements(
+    ArrayRef<Node::Element> elements) {
+  if (elements.empty())
+    return 0;
+
+  ElementsBuilder builder;
+  for (auto &element : elements)
+    builder.addEntry(element.Kind, element.Offset, element.Length);
+
+  unsigned offset = elementsBuffer.size();
+  builder.appendTo(elementsBuffer);
+  return offset;
+}
+
+unsigned DocStructureArrayBuilder::Implementation::addChildren(
+    ArrayRef<unsigned> offsets) {
+  if (offsets.empty())
+    return 0;
+
+  StructureArrayBuilder builder;
+  for (unsigned value : offsets)
+    builder.addEntry(value);
+
+  unsigned offset = structureArrayBuffer.size();
+  builder.appendTo(structureArrayBuffer);
+  return offset;
+}
+
+DocStructureArrayBuilder::DocStructureArrayBuilder()
+    : impl(*new Implementation()) {}
+DocStructureArrayBuilder::~DocStructureArrayBuilder() { delete &impl; }
+
+void DocStructureArrayBuilder::beginSubStructure(
+    unsigned Offset, unsigned Length, SourceKit::UIdent Kind,
+    SourceKit::UIdent AccessLevel, SourceKit::UIdent SetterAccessLevel,
+    unsigned NameOffset, unsigned NameLength, unsigned BodyOffset,
+    unsigned BodyLength, StringRef DisplayName, StringRef TypeName,
+    StringRef RuntimeName, StringRef SelectorName,
+    ArrayRef<StringRef> InheritedTypes, ArrayRef<UIdent> Attrs) {
+
+  Node node = {
+      Offset,
+      Length,
+      Kind,
+      AccessLevel,
+      SetterAccessLevel,
+      NameOffset,
+      NameLength,
+      BodyOffset,
+      BodyLength,
+      DisplayName,
+      TypeName,
+      RuntimeName,
+      SelectorName,
+      impl.addInheritedTypes(InheritedTypes),
+      impl.addAttrs(Attrs),
+      {}, // elements
+      {}, // children
+  };
+
+  impl.structure.push_back(std::move(node));
+}
+
+void DocStructureArrayBuilder::addElement(SourceKit::UIdent Kind,
+                                          unsigned Offset, unsigned Length) {
+  impl.structure.back().elements.push_back({Kind, Offset, Length});
+}
+
+void DocStructureArrayBuilder::endSubStructure() {
+  Node node = impl.structure.pop_back_val();
+  unsigned index = impl.structureBuilder.size();
+  if (!impl.structure.empty()) {
+    impl.structure.back().childIndices.push_back(index);
+  } else {
+    impl.topIndices.push_back(index);
+  }
+
+  // Canonicalize empty strings to None for the CompactArray.
+  auto str = [](StringRef str) -> Optional<StringRef> {
+    return str.empty() ? None : Optional<StringRef>(str);
+  };
+
+  impl.structureBuilder.addEntry(
+      node.Offset, node.Length, node.Kind, node.AccessLevel,
+      node.SetterAccessLevel, node.NameOffset, node.NameLength, node.BodyOffset,
+      node.BodyLength, str(node.DisplayName), str(node.TypeName),
+      str(node.RuntimeName), str(node.SelectorName), node.InheritedTypesOffset,
+      node.AttrsOffset, impl.addElements(node.elements),
+      impl.addChildren(node.childIndices));
+}
+
+std::unique_ptr<llvm::MemoryBuffer> DocStructureArrayBuilder::createBuffer() {
+  assert(impl.structure.empty());
+  uint64_t topOffset = impl.addChildren(impl.topIndices);
+
+  size_t inheritedTypesBufferSize = impl.inheritedTypesBuffer.size();
+  size_t attrsBufferSize = impl.attrsBuffer.size();
+  size_t elementsBufferSize = impl.elementsBuffer.size();
+  size_t structureArrayBufferSize = impl.structureArrayBuffer.size();
+  size_t structureBufferSize = impl.structureBuilder.sizeInBytes();
+
+  // Header:
+  // * offset of each section start (5)
+  // * offset of top structure array (relative to structure array section) (1)
+  size_t headerSize = sizeof(uint64_t) * 6;
+
+  auto result = llvm::MemoryBuffer::getNewUninitMemBuffer(
+      inheritedTypesBufferSize + attrsBufferSize + elementsBufferSize +
+      structureArrayBufferSize + structureBufferSize + headerSize);
+
+  char *start = const_cast<char *>(result->getBufferStart());
+  char *headerPtr = start;
+  char *ptr = start + headerSize;
+
+  auto addBuffer = [&](ArrayRef<char> buffer) {
+    uint64_t offset = ptr - start;
+    memcpy(headerPtr, &offset, sizeof(offset));
+    headerPtr += sizeof(offset);
+    auto bytes = sizeof(buffer[0]) * buffer.size();
+    memcpy(ptr, buffer.data(), bytes);
+    ptr += bytes;
+  };
+  addBuffer(impl.structureArrayBuffer);
+  SmallVector<char, 256> structureBuffer;
+  impl.structureBuilder.appendTo(structureBuffer);
+  addBuffer(structureBuffer);
+  addBuffer(impl.elementsBuffer);
+  addBuffer(impl.attrsBuffer);
+  addBuffer(impl.inheritedTypesBuffer);
+
+  assert(ptr == result->getBufferEnd());
+  assert(headerPtr == start + (headerSize - sizeof(topOffset)));
+  memcpy(headerPtr, &topOffset, sizeof(topOffset));
+
+  return result;
+}
+
+namespace {
+struct OutNode {
+  // Scalars
+  unsigned Offset;
+  unsigned Length;
+  sourcekitd_uid_t Kind;
+  sourcekitd_uid_t AccessLevel;
+  sourcekitd_uid_t SetterAccessLevel;
+  unsigned NameOffset;
+  unsigned NameLength;
+  unsigned BodyOffset;
+  unsigned BodyLength;
+  const char *DisplayName;
+  const char *TypeName;
+  const char *RuntimeName;
+  const char *SelectorName;
+  // Arrays
+  unsigned InheritedTypesOffset;
+  unsigned AttrsOffset;
+  unsigned ElementsOffset;
+  unsigned ChildIndicesOffset;
+};
+
+class DocStructureArrayReader {
+public:
+  DocStructureArrayReader(void *buffer);
+
+  OutNode readStructure(size_t index);
+  CompactArrayReader<unsigned> readStructureArray(size_t offset);
+
+  void *getElementsBuffer(size_t offset) const {
+    return (char *)getElementsBufferStart() + offset;
+  }
+  void *getInheritedTypesBuffer(size_t offset) const {
+    return (char *)getInheritedTypesBufferStart() + offset;
+  }
+  void *getAttrsBuffer(size_t offset) const {
+    return (char *)getAttrsBufferStart() + offset;
+  }
+
+private:
+  void *getStructureArrayBufferStart() const { return getBufferStart(0); }
+  void *getStructureBufferStart() const { return getBufferStart(1); }
+  void *getElementsBufferStart() const { return getBufferStart(2); }
+  void *getAttrsBufferStart() const { return getBufferStart(3); }
+  void *getInheritedTypesBufferStart() const { return getBufferStart(4); }
+  size_t getTopStructureArrayOffset() const { return getHeaderValue(5); }
+
+  uint64_t getHeaderValue(unsigned index) const;
+  void *getBufferStart(unsigned index) const;
+
+private:
+  void *buffer;
+
+  typedef CompactArrayReader<unsigned,         // Offset
+                             unsigned,         // Length
+                             sourcekitd_uid_t, // Kind
+                             sourcekitd_uid_t, // AccessLevel
+                             sourcekitd_uid_t, // SetterAccessLevel
+                             unsigned,         // NameOffset
+                             unsigned,         // NameLength
+                             unsigned,         // BodyOffset
+                             unsigned,         // BodyLength
+                             const char *,     // DisplayName
+                             const char *,     // TypeName
+                             const char *,     // RuntimeName
+                             const char *,     // SelectorName
+                             unsigned,         // InheritedTypesOffset
+                             unsigned,         // AttrsOffset
+                             unsigned,         // ElementsOffset
+                             unsigned          // ChildrenOffset
+                             >
+      StructureReader;
+};
+}
+
+DocStructureArrayReader::DocStructureArrayReader(void *buffer)
+    : buffer(buffer) {}
+
+OutNode DocStructureArrayReader::readStructure(size_t index) {
+  OutNode result;
+  StructureReader reader(getStructureBufferStart());
+  reader.readEntries(
+      index, result.Offset, result.Length, result.Kind, result.AccessLevel,
+      result.SetterAccessLevel, result.NameOffset, result.NameLength,
+      result.BodyOffset, result.BodyLength, result.DisplayName, result.TypeName,
+      result.RuntimeName, result.SelectorName, result.InheritedTypesOffset,
+      result.AttrsOffset, result.ElementsOffset, result.ChildIndicesOffset);
+  return result;
+}
+
+CompactArrayReader<unsigned>
+DocStructureArrayReader::readStructureArray(size_t offset) {
+  if (offset == ~size_t(0))
+    offset = getTopStructureArrayOffset();
+  void *arrayBuffer = (char *)getStructureArrayBufferStart() + offset;
+  return CompactArrayReader<unsigned>(arrayBuffer);
+}
+
+void *DocStructureArrayReader::getBufferStart(unsigned index) const {
+  return (char *)buffer + getHeaderValue(index);
+}
+
+uint64_t DocStructureArrayReader::getHeaderValue(unsigned index) const {
+  uint64_t headerField;
+  memcpy(&headerField, (uint64_t*)buffer + index, sizeof(headerField));
+  return headerField;
+}
+
+#define APPLY(K, Ty, Field)                                                    \
+  do {                                                                         \
+    sourcekitd_uid_t key = SKDUIDFromUIdent(K);                                \
+    sourcekitd_variant_t var = make##Ty##Variant(Field);                       \
+    if (!applier(key, var))                                                    \
+      return false;                                                            \
+  } while (0)
+
+namespace {
+struct ElementReader {
+  typedef CompactArrayReader<sourcekitd_uid_t, unsigned, unsigned>
+      CompactArrayReaderTy;
+
+  static bool
+  dictionary_apply(void *buffer, size_t index,
+                   sourcekitd_variant_dictionary_applier_t applier) {
+
+    CompactArrayReaderTy reader(buffer);
+    sourcekitd_uid_t kind;
+    unsigned offset;
+    unsigned length;
+    reader.readEntries(index, kind, offset, length);
+    APPLY(KeyKind, UID, kind);
+    APPLY(KeyOffset, Int, offset);
+    APPLY(KeyLength, Int, length);
+    return true;
+  }
+};
+
+struct InheritedTypeReader {
+  typedef CompactArrayReader<const char *> CompactArrayReaderTy;
+
+  static bool
+  dictionary_apply(void *buffer, size_t index,
+                   sourcekitd_variant_dictionary_applier_t applier) {
+
+    CompactArrayReaderTy reader(buffer);
+    const char *value = nullptr;
+    reader.readEntries(index, value);
+    if (value)
+      APPLY(KeyName, String, value);
+    return true;
+  }
+};
+
+struct AttributesReader {
+  typedef CompactArrayReader<sourcekitd_uid_t> CompactArrayReaderTy;
+
+  static bool
+  dictionary_apply(void *buffer, size_t index,
+                   sourcekitd_variant_dictionary_applier_t applier) {
+
+    CompactArrayReaderTy reader(buffer);
+    sourcekitd_uid_t value;
+    reader.readEntries(index, value);
+    APPLY(KeyAttribute, UID, value);
+    return true;
+  }
+};
+
+struct DocStructureReader {
+  static bool
+  dictionary_apply(void *buffer, size_t index,
+                   sourcekitd_variant_dictionary_applier_t applier) {
+    auto reader = DocStructureArrayReader(buffer);
+    auto node = reader.readStructure(index);
+
+    APPLY(KeyOffset, Int, node.Offset);
+    APPLY(KeyLength, Int, node.Length);
+    APPLY(KeyKind, UID, node.Kind);
+    if (node.AccessLevel)
+      APPLY(KeyAccessibility, UID, node.AccessLevel);
+    if (node.SetterAccessLevel)
+      APPLY(KeySetterAccessibility, UID, node.SetterAccessLevel);
+    APPLY(KeyNameOffset, Int, node.NameOffset);
+    APPLY(KeyNameLength, Int, node.NameLength);
+    if (node.BodyOffset || node.BodyLength) {
+      APPLY(KeyBodyOffset, Int, node.BodyOffset);
+      APPLY(KeyBodyLength, Int, node.BodyLength);
+    }
+    if (node.DisplayName)
+      APPLY(KeyName, String, node.DisplayName);
+    if (node.TypeName)
+      APPLY(KeyTypeName, String, node.TypeName);
+    if (node.RuntimeName)
+      APPLY(KeyRuntimeName, String, node.RuntimeName);
+    if (node.SelectorName)
+      APPLY(KeySelectorName, String, node.SelectorName);
+
+#define APPLY_ARRAY(Kind, Buf, Key, Off)                                       \
+  do {                                                                         \
+    sourcekitd_uid_t key = SKDUIDFromUIdent(Key);                              \
+    sourcekitd_variant_t var = {                                               \
+        {(uintptr_t)getVariantFunctionsFor##Kind##Array(), (uintptr_t)Buf,     \
+         Off}};                                                                \
+    if (!applier(key, var))                                                    \
+      return false;                                                            \
+  } while (0)
+
+    if (node.InheritedTypesOffset) {
+      void *buf = reader.getInheritedTypesBuffer(node.InheritedTypesOffset);
+      APPLY_ARRAY(InheritedTypes, buf, KeyInheritedTypes, 0);
+    }
+    if (node.AttrsOffset) {
+      void *buf = reader.getAttrsBuffer(node.AttrsOffset);
+      APPLY_ARRAY(Attributes, buf, KeyAttributes, 0);
+    }
+    if (node.ElementsOffset) {
+      void *buf = reader.getElementsBuffer(node.ElementsOffset);
+      APPLY_ARRAY(DocStructureElement, buf, KeyElements, 0);
+    }
+    if (node.ChildIndicesOffset) {
+      APPLY_ARRAY(DocStructure, buffer, KeySubStructure,
+                  node.ChildIndicesOffset);
+    }
+    return true;
+  }
+};
+
+// data[0] = DocStructureArrayFuncs::funcs
+// data[1] = buffer for DocStructureArrayReader
+// data[2] = structure array offset
+struct DocStructureArrayFuncs {
+  static sourcekitd_variant_type_t get_type(sourcekitd_variant_t var) {
+    return SOURCEKITD_VARIANT_TYPE_ARRAY;
+  }
+
+  static size_t array_get_count(sourcekitd_variant_t array) {
+    void *buffer = (void *)array.data[1];
+    size_t offset = array.data[2];
+    return DocStructureArrayReader(buffer)
+        .readStructureArray(offset)
+        .getCount();
+  }
+
+  static sourcekitd_variant_t array_get_value(sourcekitd_variant_t array,
+                                              size_t index) {
+    void *buffer = (void *)array.data[1];
+    size_t offset = array.data[2];
+
+    auto reader = DocStructureArrayReader(buffer).readStructureArray(offset);
+    assert(index < reader.getCount());
+    unsigned structureIndex;
+    reader.readEntries(index, structureIndex);
+
+    return {{(uintptr_t)&CompactVariantFuncs<DocStructureReader>::Funcs,
+             (uintptr_t)buffer, structureIndex}};
+  }
+
+  static VariantFunctions funcs;
+};
+} // end anonymous namespace
+
+VariantFunctions DocStructureArrayFuncs::funcs = {
+    get_type,
+    nullptr /*AnnotArray_array_apply*/,
+    nullptr /*AnnotArray_array_get_bool*/,
+    array_get_count,
+    nullptr /*AnnotArray_array_get_int64*/,
+    nullptr /*AnnotArray_array_get_string*/,
+    nullptr /*AnnotArray_array_get_uid*/,
+    array_get_value,
+    nullptr /*AnnotArray_bool_get_value*/,
+    nullptr /*AnnotArray_dictionary_apply*/,
+    nullptr /*AnnotArray_dictionary_get_bool*/,
+    nullptr /*AnnotArray_dictionary_get_int64*/,
+    nullptr /*AnnotArray_dictionary_get_string*/,
+    nullptr /*AnnotArray_dictionary_get_value*/,
+    nullptr /*AnnotArray_dictionary_get_uid*/,
+    nullptr /*AnnotArray_string_get_length*/,
+    nullptr /*AnnotArray_string_get_ptr*/,
+    nullptr /*AnnotArray_int64_get_value*/,
+    nullptr /*AnnotArray_uid_get_value*/
+};
+
+VariantFunctions *sourcekitd::getVariantFunctionsForDocStructureElementArray() {
+  return &CompactArrayFuncs<ElementReader>::Funcs;
+}
+
+VariantFunctions *sourcekitd::getVariantFunctionsForInheritedTypesArray() {
+  return &CompactArrayFuncs<InheritedTypeReader>::Funcs;
+}
+
+VariantFunctions *sourcekitd::getVariantFunctionsForAttributesArray() {
+  return &CompactArrayFuncs<AttributesReader>::Funcs;
+}
+
+VariantFunctions *sourcekitd::getVariantFunctionsForDocStructureArray() {
+  return &DocStructureArrayFuncs::funcs;
+}

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
@@ -12,6 +12,7 @@
 
 #include "DictionaryKeys.h"
 #include "sourcekitd/CodeCompletionResultsArray.h"
+#include "sourcekitd/DocStructureArray.h"
 #include "sourcekitd/DocSupportAnnotationArray.h"
 #include "sourcekitd/TokenAnnotationsArray.h"
 #include "sourcekitd/RequestResponsePrinterBase.h"
@@ -593,9 +594,14 @@ static sourcekitd_variant_type_t XPCVar_get_type(sourcekitd_variant_t var) {
       return SOURCEKITD_VARIANT_TYPE_ARRAY;
     case CustomBufferKind::CodeCompletionResultsArray:
       return SOURCEKITD_VARIANT_TYPE_ARRAY;
+    case CustomBufferKind::DocStructureArray:
+    case CustomBufferKind::InheritedTypesArray:
+    case CustomBufferKind::DocStructureElementArray:
+    case CustomBufferKind::AttributesArray:
+      return SOURCEKITD_VARIANT_TYPE_ARRAY;
     }
   }
-  
+
   llvm::report_fatal_error("sourcekitd object did not resolve to a known type");
 }
 
@@ -727,6 +733,18 @@ static sourcekitd_variant_t variantFromXPCObject(xpc_object_t obj) {
                 (uintptr_t)CUSTOM_BUF_START(obj), 0 }};
     case CustomBufferKind::CodeCompletionResultsArray:
       return {{ (uintptr_t)getVariantFunctionsForCodeCompletionResultsArray(),
+                (uintptr_t)CUSTOM_BUF_START(obj), 0 }};
+    case CustomBufferKind::DocStructureArray:
+      return {{ (uintptr_t)getVariantFunctionsForDocStructureArray(),
+                (uintptr_t)CUSTOM_BUF_START(obj), ~size_t(0) }};
+    case CustomBufferKind::InheritedTypesArray:
+      return {{ (uintptr_t)getVariantFunctionsForInheritedTypesArray(),
+                (uintptr_t)CUSTOM_BUF_START(obj), 0 }};
+    case CustomBufferKind::DocStructureElementArray:
+      return {{ (uintptr_t)getVariantFunctionsForDocStructureElementArray(),
+                (uintptr_t)CUSTOM_BUF_START(obj), 0 }};
+    case CustomBufferKind::AttributesArray:
+      return {{ (uintptr_t)getVariantFunctionsForAttributesArray(),
                 (uintptr_t)CUSTOM_BUF_START(obj), 0 }};
     }
   }


### PR DESCRIPTION
Previously, document structure responses were created using XPC
dictionaries, but this forced deserialization of the large nested
dictionaries no matter what the access pattern was.  The new format uses
our custom buffer machinery, and only deserializes dictionaries that are
actually needed.

The performance improvement is around 25% for an editor.open, and 35-40%
for an editor.replacetext request in the large files I've tested. The
performance improvements are in serialization (inside the service),
deserialization (client), and disposal of the response object (client).

rdar://problem/28789756
