### PR TITLE
Push the debug info for the artificial error inout argument up to SIL.

### DIFF
--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -187,10 +187,8 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
   assert(!selfTy.getClassOrBoundGenericClass()
          && "can't emit a class ctor here");
 
-  // Self is a curried argument and thus comes last.
-  unsigned N = ctor->getParameterList(1)->size() + 1;
   // Allocate the local variable for 'self'.
-  emitLocalVariableWithCleanup(selfDecl, false, N)->finishInitialization(*this);
+  emitLocalVariableWithCleanup(selfDecl, false)->finishInitialization(*this);
   
   // Mark self as being uninitialized so that DI knows where it is and how to
   // check for it.

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -202,7 +202,8 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
   }
   
   // Emit the prolog.
-  emitProlog(ctor->getParameterList(1), ctor->getResultType(), ctor);
+  emitProlog(ctor->getParameterList(1), ctor->getResultType(), ctor,
+             ctor->hasThrows());
   emitConstructorMetatypeArg(*this, ctor);
 
   // Create a basic block to jump to for the implicit 'self' return.
@@ -563,7 +564,7 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
   // Emit the prolog for the non-self arguments.
   // FIXME: Handle self along with the other body patterns.
   emitProlog(ctor->getParameterList(1),
-             TupleType::getEmpty(F.getASTContext()), ctor);
+             TupleType::getEmpty(F.getASTContext()), ctor, ctor->hasThrows());
 
   SILType selfTy = getLoweredLoadableType(selfDecl->getType());
   SILValue selfArg = new (SGM.M) SILArgument(F.begin(), selfTy, selfDecl);

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -468,7 +468,7 @@ void SILGenFunction::emitFunction(FuncDecl *fd) {
   MagicFunctionName = SILGenModule::getMagicFunctionName(fd);
 
   Type resultTy = fd->getResultType();
-  emitProlog(fd, fd->getParameterLists(), resultTy);
+  emitProlog(fd, fd->getParameterLists(), resultTy, fd->hasThrows());
   prepareEpilog(resultTy, fd->hasThrows(), CleanupLocation(fd));
 
   emitProfilerIncrement(fd->getBody());
@@ -480,7 +480,8 @@ void SILGenFunction::emitFunction(FuncDecl *fd) {
 void SILGenFunction::emitClosure(AbstractClosureExpr *ace) {
   MagicFunctionName = SILGenModule::getMagicFunctionName(ace);
 
-  emitProlog(ace, ace->getParameters(), ace->getResultType());
+  emitProlog(ace, ace->getParameters(), ace->getResultType(),
+             ace->isBodyThrowing());
   prepareEpilog(ace->getResultType(), ace->isBodyThrowing(),
                 CleanupLocation(ace));
   if (auto *ce = dyn_cast<ClosureExpr>(ace)) {
@@ -858,7 +859,7 @@ void SILGenFunction::emitGeneratorFunction(SILDeclRef function, Expr *value) {
   // is not going to be ever used anyway.
   overrideLocationForMagicIdentifiers = SourceLoc();
 
-  emitProlog({ }, value->getType(), function.getDecl()->getDeclContext());
+  emitProlog({}, value->getType(), function.getDecl()->getDeclContext(), false);
   prepareEpilog(value->getType(), false, CleanupLocation::get(Loc));
   emitReturnExpr(Loc, value);
   emitEpilog(Loc);

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -709,14 +709,18 @@ public:
   //===--------------------------------------------------------------------===//
   // Memory management
   //===--------------------------------------------------------------------===//
-  
+
+  /// Emit debug info for the artificial error inout argument.
+  void emitErrorArgument(SILLocation Loc, unsigned ArgNo);
+
   /// emitProlog - Generates prolog code to allocate and clean up mutable
   /// storage for closure captures and local arguments.
   void emitProlog(AnyFunctionRef TheClosure,
-                  ArrayRef<ParameterList*> paramPatterns, Type resultType);
+                  ArrayRef<ParameterList *> paramPatterns, Type resultType,
+                  bool throws);
   /// returns the number of variables in paramPatterns.
-  unsigned emitProlog(ArrayRef<ParameterList*> paramPatterns,
-                      Type resultType, DeclContext *DeclCtx);
+  unsigned emitProlog(ArrayRef<ParameterList *> paramPatterns, Type resultType,
+                      DeclContext *DeclCtx, bool throws);
 
   /// Create SILArguments in the entry block that bind all the values
   /// of the given pattern suitably for being forwarded.

--- a/test/DebugInfo/Errors.swift
+++ b/test/DebugInfo/Errors.swift
@@ -10,7 +10,7 @@ func simple(_ placeholder: Int64) throws -> () {
   // CHECK: define {{.*}}void @_TF6Errors6simpleFzVs5Int64T_(i64, %swift.refcounted*, %swift.error**)
   // CHECK: call void @llvm.dbg.declare
   // CHECK: call void @llvm.dbg.declare({{.*}}, metadata ![[ERROR:[0-9]+]], metadata ![[DEREF:[0-9]+]])
-  // CHECK: ![[ERROR]] = !DILocalVariable(name: "$error", arg: 3,
+  // CHECK: ![[ERROR]] = !DILocalVariable(name: "$error", arg: 2,
   // CHECK-SAME:              type: ![[ERRTY:.*]], flags: DIFlagArtificial)
   // CHECK: ![[ERRTY]] = !DICompositeType({{.*}}identifier: "_TtPs5Error_"
   // CHECK: ![[DEREF]] = !DIExpression(DW_OP_deref)

--- a/test/DebugInfo/generic_enum_closure.swift
+++ b/test/DebugInfo/generic_enum_closure.swift
@@ -9,8 +9,10 @@ struct CErrorOr<T>
     // CHECK-NOT: define
     // This is a SIL-level debug_value_addr instruction.
     // CHECK: call void @llvm.dbg.value({{.*}}, metadata ![[SELF:.*]], metadata !{{[0-9]+}})
-    // CHECK-DAG: ![[T1:.*]] = !DICompositeType({{.*}}identifier: "_TtGV20generic_enum_closure8CErrorOrQq_S0__"
-    // CHECK-DAG: ![[SELF]] = !DILocalVariable(name: "self", arg:{{.*}} type: ![[T1]]
+    // CHECK: ![[SELF]] = !DILocalVariable(name: "self", scope
+    // CHECK-SAME:                         type: ![[T1:.*]])
+    // CHECK: ![[T1]] = !DICompositeType(
+    // CHECK-SAME: identifier: "_TtGV20generic_enum_closure8CErrorOrQq_S0__"
     value = .none
   }
   func isError() -> Bool {

--- a/test/DebugInfo/self.swift
+++ b/test/DebugInfo/self.swift
@@ -16,8 +16,9 @@ public func f() {
 // CHECK: define {{.*}} @_TFV4self11stuffStructCfT_S0_(
 // CHECK-NEXT: entry:
 // CHECK-NEXT: %[[ALLOCA:.*]] = alloca %V4self11stuffStruct, align {{(4|8)}}
-// CHECK: call void @llvm.dbg.declare(metadata %V4self11stuffStruct* %[[ALLOCA]], metadata ![[SELF:.*]], metadata !{{[0-9]+}}), !db
+// CHECK: call void @llvm.dbg.declare(metadata %V4self11stuffStruct* %[[ALLOCA]],
+// CHECK-SAME: metadata ![[SELF:.*]], metadata !{{[0-9]+}}), !dbg
 // CHECK: ![[STUFFSTRUCT:.*]] = !DICompositeType(tag: DW_TAG_structure_type, name: "stuffStruct",{{.*}}identifier
-// CHECK: ![[SELF]] = !DILocalVariable(name: "self", arg: 1,
+// CHECK: ![[SELF]] = !DILocalVariable(name: "self", scope
 // CHECK-SAME:                         type: ![[STUFFSTRUCT]]
 

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -347,8 +347,9 @@ func feedCat() throws -> Int {
   }
 }
 // CHECK-LABEL: sil hidden @_TF6errors7feedCatFzT_Si : $@convention(thin) () -> (Int, @error Error)
-// CHECK:   %0 = function_ref @_TF6errors13preferredFoodFzT_OS_7CatFood : $@convention(thin) () -> (CatFood, @error Error)
-// CHECK:   try_apply %0() : $@convention(thin) () -> (CatFood, @error Error), normal bb1, error bb5
+// CHECK: debug_value undef : $Error, var, name "$error", argno 1
+// CHECK:   %1 = function_ref @_TF6errors13preferredFoodFzT_OS_7CatFood : $@convention(thin) () -> (CatFood, @error Error)
+// CHECK:   try_apply %1() : $@convention(thin) () -> (CatFood, @error Error), normal bb1, error bb5
 // CHECK: bb1([[VAL:%.*]] : $CatFood):
 // CHECK:   switch_enum [[VAL]] : $CatFood, case #CatFood.Canned!enumelt: bb2, case #CatFood.Dry!enumelt: bb3
 // CHECK: bb5([[ERROR:%.*]] : $Error)
@@ -366,6 +367,7 @@ func getHungryCat(_ food: CatFood) throws -> Cat {
 // errors.getHungryCat  throws (errors.CatFood) -> errors.Cat
 // CHECK-LABEL: sil hidden @_TF6errors12getHungryCatFzOS_7CatFoodCS_3Cat : $@convention(thin) (CatFood) -> (@owned Cat, @error Error)
 // CHECK: bb0(%0 : $CatFood):
+// CHECK:   debug_value undef : $Error, var, name "$error", argno 2
 // CHECK:   switch_enum %0 : $CatFood, case #CatFood.Canned!enumelt: bb1, case #CatFood.Dry!enumelt: bb3
 // CHECK: bb1:
 // CHECK:   [[FN:%.*]] = function_ref @_TF6errors10make_a_catFzT_CS_3Cat : $@convention(thin) () -> (@owned Cat, @error Error)
@@ -385,6 +387,7 @@ func test_variadic(_ cat: Cat) throws {
   try take_many_cats(make_a_cat(), cat, make_a_cat(), make_a_cat())
 }
 // CHECK-LABEL: sil hidden @_TF6errors13test_variadicFzCS_3CatT_
+// CHECK:       debug_value undef : $Error, var, name "$error", argno 2
 // CHECK:       [[TAKE_FN:%.*]] = function_ref @_TF6errors14take_many_catsFztGSaCS_3Cat__T_ : $@convention(thin) (@owned Array<Cat>) -> @error Error
 // CHECK:       [[N:%.*]] = integer_literal $Builtin.Word, 4
 // CHECK:       [[T0:%.*]] = function_ref @_TFs27_allocateUninitializedArray

--- a/test/SILGen/foreign_errors.swift
+++ b/test/SILGen/foreign_errors.swift
@@ -152,13 +152,15 @@ func testArgs() throws {
   try ErrorProne.consume(nil)
 }
 // CHECK: sil hidden @_TF14foreign_errors8testArgsFzT_T_ : $@convention(thin) () -> @error Error
-// CHECK:   class_method [volatile] %0 : $@thick ErrorProne.Type, #ErrorProne.consume!1.foreign : (ErrorProne.Type) -> (Any!) throws -> () , $@convention(objc_method) (Optional<AnyObject>, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> ObjCBool
+// CHECK:   debug_value undef : $Error, var, name "$error", argno 1
+// CHECK:   class_method [volatile] %1 : $@thick ErrorProne.Type, #ErrorProne.consume!1.foreign : (ErrorProne.Type) -> (Any!) throws -> () , $@convention(objc_method) (Optional<AnyObject>, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> ObjCBool
 
 func testBridgedResult() throws {
   let array = try ErrorProne.collection(withCount: 0)
 }
 // CHECK: sil hidden @_TF14foreign_errors17testBridgedResultFzT_T_ : $@convention(thin) () -> @error Error {
-// CHECK:   class_method [volatile] %0 : $@thick ErrorProne.Type, #ErrorProne.collection!1.foreign : (ErrorProne.Type) -> (Int) throws -> [Any] , $@convention(objc_method) (Int, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> @autoreleased Optional<NSArray>
+// CHECK:   debug_value undef : $Error, var, name "$error", argno 1
+// CHECK:   class_method [volatile] %1 : $@thick ErrorProne.Type, #ErrorProne.collection!1.foreign : (ErrorProne.Type) -> (Int) throws -> [Any] , $@convention(objc_method) (Int, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> @autoreleased Optional<NSArray>
 
 // rdar://20861374
 // Clear out the self box before delegating.

--- a/test/SILOptimizer/throw_inline.swift
+++ b/test/SILOptimizer/throw_inline.swift
@@ -8,9 +8,10 @@ public func foo() throws -> Int32 {
 }
 
 // CHECK-LABEL: _TF12throw_inline3foo
-// CHECK: %0 = integer_literal $Builtin.Int32, 999
-// CHECK: %1 = struct $Int32 (%0 : $Builtin.Int32)
-// CHECK: return %1 : $Int32
+// CHECK: debug_value undef : $Error, var, name "$error", argno 1
+// CHECK: %1 = integer_literal $Builtin.Int32, 999
+// CHECK: %2 = struct $Int32 (%1 : $Builtin.Int32)
+// CHECK: return %2 : $Int32
 func bar() throws  -> Int32 {
   return try foo()
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

Previously IRGen was using a heuristic to assign the argument number
to the $error variable that was not generally correct for optimizaed
code. This patch inserts a debug_value instruction in SILGen and thus
assigns the ArgNo together with all the other function arguments. This
is more robust and faster than than the old heuristic.

rdar://problem/28748323
