### PR TITLE
Rdar 28786959 3.0 branch if swift 3 digit version

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -128,6 +128,7 @@ public:
   bool ArgumentIsParameter = false;
 
   bool InPoundLineEnvironment = false;
+  bool InPoundIfEnvironment = false;
 
   LocalContext *CurLocalContext = nullptr;
 

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -293,15 +293,18 @@ bool operator>=(const class Version &lhs,
   if (lhs.empty())
     return true;
 
-  auto n = std::min(lhs.size(), rhs.size());
+  auto n = std::max(lhs.size(), rhs.size());
 
   for (size_t i = 0; i < n; ++i) {
-    if (lhs[i] < rhs[i])
+    auto lv = i < lhs.size() ? lhs[i] : 0;
+    auto rv = i < rhs.size() ? rhs[i] : 0;
+    if (lv < rv)
       return false;
-    else if (lhs[i] > rhs[i])
+    else if (lv > rv)
       return true;
   }
-  return lhs.size() >= rhs.size();
+  // Equality
+  return true;
 }
 
 std::pair<unsigned, unsigned> getSwiftNumericVersion() {

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1430,8 +1430,9 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
         SourceLoc nameLoc = consumeToken(tok::integer_literal);
         
         // Don't allow '.<integer literal>' following a numeric literal
-        // expression.
-        if (Result.isNonNull() && isa<NumberLiteralExpr>(Result.get())) {
+        // expression (unless in #if env, for 1.2.3.4 version numbers)
+        if (!InPoundIfEnvironment &&
+            Result.isNonNull() && isa<NumberLiteralExpr>(Result.get())) {
           diagnose(nameLoc, diag::numeric_literal_numeric_member)
             .highlight(Result.get()->getSourceRange());
           continue;

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1759,7 +1759,7 @@ Parser::evaluateConditionalCompilationExpr(Expr *condition) {
 ParserResult<Stmt> Parser::parseStmtIfConfig(BraceItemListKind Kind) {
   StructureMarkerRAII ParsingDecl(*this, Tok.getLoc(),
                                   StructureMarkerKind::IfConfig);
-
+  llvm::SaveAndRestore<bool> S(InPoundIfEnvironment, true);
   ConditionalCompilationExprState ConfigState;
   bool foundActive = false;
   SmallVector<IfConfigStmtClause, 4> Clauses;

--- a/test/Parse/ConditionalCompilation/language_version.swift
+++ b/test/Parse/ConditionalCompilation/language_version.swift
@@ -43,8 +43,7 @@
 #if swift("") // expected-error {{unexpected platform condition argument: expected a unary comparison, such as '>=2.2'}}
 #endif
 
-// We won't expect three version components to work for now.
-#if swift(>=2.2.1) // expected-error {{expected named member of numeric literal}}
+#if swift(>=2.2.1)
 #endif
 
 #if swift(>=2.0, *) // expected-error {{expected only one argument to platform condition}}

--- a/test/Parse/ConditionalCompilation/language_version.swift
+++ b/test/Parse/ConditionalCompilation/language_version.swift
@@ -46,6 +46,15 @@
 #if swift(>=2.2.1)
 #endif
 
+// Check that an extra .0 doesn't make a version "bigger"; NB this test only
+// tests the fix on 3.0.1, but that's the swift version the fix was backported
+// to. On master, the fix is tested by language_version_explicit.swift
+#if swift(>=3.0.1.0)
+#else
+  // This shouldn't emit any diagnostics.
+  asdf asdf asdf asdf
+#endif
+
 #if swift(>=2.0, *) // expected-error {{expected only one argument to platform condition}}
 #endif
 


### PR DESCRIPTION
Cherry-pick of PR against master: #5440

Initial PR description:

Two changes, close relatives.

First change enables writing #if swift(>=3.0.1) by contextually inhibiting an early diagnostic in the parser that's currently blocking the initial semi-parse that runs before the Version parser kicks in.

Second change weakens our sense of logical order and logical equality on Version structures such that 4 == 4.0 == 4.0.0 (that is, versions are considered to have as many trailing zeroes as necessary). The function evaluating versions you are allowed to pass on the command line is tightened opposite this change, so you still can't say -swift-version 4.0 (only -swift-version 4) but it means that if someone writes #if swift(>=4.0) it'll work, rather than the current behaviour, that thinks 4 < 4.0.

Resolves SR-2908.
