### PR TITLE
[stdlib] Make various free functions mutating an _ArrayBufferProtocol into extensions

### DIFF
--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -387,8 +387,8 @@ extension _ArrayBuffer {
       }
       else {
         var refCopy = self
-        refCopy.replace(
-          subRange: i..<(i + 1),
+        refCopy.replaceSubrange(
+          i..<(i + 1),
           with: 1,
           elementsOf: CollectionOfOne(newValue))
       }

--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -124,9 +124,10 @@ internal protocol _ArrayBufferProtocol
   var identity: UnsafeRawPointer { get }
 
   var startIndex: Int { get }
+  var endIndex: Int { get }
 }
 
-extension _ArrayBufferProtocol where Index == Int {
+extension _ArrayBufferProtocol {
 
   internal var subscriptBaseAddress: UnsafeMutablePointer<Element> {
     return firstElementAddress
@@ -175,7 +176,7 @@ extension _ArrayBufferProtocol where Index == Int {
       var j = newValues.startIndex
       for _ in 0..<newCount {
         elements[i] = newValues[j]
-        formIndex(after: &i)
+        i += 1
         newValues.formIndex(after: &j)
       }
       _expectEnd(j, newValues)

--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -73,7 +73,7 @@ internal protocol _ArrayBufferProtocol
   /// - Precondition: This buffer is backed by a uniquely-referenced
   /// `_ContiguousArrayBuffer`.
   mutating func replaceSubrange<C>(
-    _ subRange: Range<Int>,
+    _ subrange: Range<Int>,
     with newCount: Int,
     elementsOf newValues: C
   ) where C : Collection, C.Iterator.Element == Element
@@ -134,32 +134,32 @@ extension _ArrayBufferProtocol {
   }
 
   internal mutating func replaceSubrange<C>(
-    _ subRange: Range<Int>,
+    _ subrange: Range<Int>,
     with newCount: Int,
     elementsOf newValues: C
   ) where C : Collection, C.Iterator.Element == Element {
     _sanityCheck(startIndex == 0, "_SliceBuffer should override this function.")
     let oldCount = self.count
-    let eraseCount = subRange.count
+    let eraseCount = subrange.count
 
     let growth = newCount - eraseCount
     self.count = oldCount + growth
 
     let elements = self.subscriptBaseAddress
-    let oldTailIndex = subRange.upperBound
+    let oldTailIndex = subrange.upperBound
     let oldTailStart = elements + oldTailIndex
     let newTailIndex = oldTailIndex + growth
     let newTailStart = oldTailStart + growth
-    let tailCount = oldCount - subRange.upperBound
+    let tailCount = oldCount - subrange.upperBound
 
     if growth > 0 {
       // Slide the tail part of the buffer forwards, in reverse order
       // so as not to self-clobber.
       newTailStart.moveInitialize(from: oldTailStart, count: tailCount)
 
-      // Assign over the original subRange
+      // Assign over the original subrange
       var i = newValues.startIndex
-      for j in CountableRange(subRange) {
+      for j in CountableRange(subrange) {
         elements[j] = newValues[i]
         newValues.formIndex(after: &i)
       }
@@ -171,8 +171,8 @@ extension _ArrayBufferProtocol {
       _expectEnd(i, newValues)
     }
     else { // We're not growing the buffer
-      // Assign all the new elements into the start of the subRange
-      var i = subRange.lowerBound
+      // Assign all the new elements into the start of the subrange
+      var i = subrange.lowerBound
       var j = newValues.startIndex
       for _ in 0..<newCount {
         elements[i] = newValues[j]
@@ -202,7 +202,7 @@ extension _ArrayBufferProtocol {
         // Assign over the start of the replaced range with the tail
         newTailStart.moveAssign(from: oldTailStart, count: tailCount)
 
-        // Destroy elements remaining after the tail in subRange
+        // Destroy elements remaining after the tail in subrange
         (newTailStart + tailCount).deinitialize(
           count: shrinkage - tailCount)
       }

--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -72,8 +72,8 @@ internal protocol _ArrayBufferProtocol
   ///
   /// - Precondition: This buffer is backed by a uniquely-referenced
   /// `_ContiguousArrayBuffer`.
-  mutating func replace<C>(
-    subRange: Range<Int>,
+  mutating func replaceSubrange<C>(
+    _ subRange: Range<Int>,
     with newCount: Int,
     elementsOf newValues: C
   ) where C : Collection, C.Iterator.Element == Element
@@ -132,8 +132,8 @@ extension _ArrayBufferProtocol where Index == Int {
     return firstElementAddress
   }
 
-  internal mutating func replace<C>(
-    subRange: Range<Int>,
+  internal mutating func replaceSubrange<C>(
+    _ subRange: Range<Int>,
     with newCount: Int,
     elementsOf newValues: C
   ) where C : Collection, C.Iterator.Element == Element {

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1676,7 +1676,7 @@ extension _ArrayBufferProtocol {
   ) where C.Iterator.Element == Element {
 
     let growth = insertCount - bounds.count
-    let newCount = count + growth
+    let newCount = self.count + growth
     var newBuffer = _forceCreateUniqueMutableBuffer(
       newCount: newCount, requiredCapacity: newCount)
 
@@ -1866,7 +1866,6 @@ extension _ArrayBufferProtocol {
     _sanityCheck(requiredCapacity >= countForBuffer)
     _sanityCheck(minNewCapacity >= countForBuffer)
 
-    // FIXME(Typechecker): Swift. prefix shouldn't be necessary (rdar://problem/28947708)
     let minimumCapacity = Swift.max(requiredCapacity,
       minNewCapacity > capacity
          ? _growArrayCapacity(capacity) : capacity)
@@ -1996,8 +1995,7 @@ extension _ArrayBufferProtocol {
 
   internal mutating func _arrayReserve(_ minimumCapacity: Int) {
 
-    let count = self.count
-    // FIXME(Typechecker): shouldn't need Swift. here
+    let oldCount = self.count
     let requiredCapacity = Swift.max(count, minimumCapacity)
 
     if _fastPath(
@@ -2008,8 +2006,9 @@ extension _ArrayBufferProtocol {
     }
 
     var newBuffer = _forceCreateUniqueMutableBuffer(
-      newCount: count, requiredCapacity: requiredCapacity)
-    _arrayOutOfPlaceUpdate(&newBuffer, count, 0, _IgnorePointer())
+      newCount: oldCount, requiredCapacity: requiredCapacity)
+
+    _arrayOutOfPlaceUpdate(&newBuffer, oldCount, 0, _IgnorePointer())
   }
 
   /// Append items from `newItems` to a buffer.
@@ -2025,22 +2024,22 @@ extension _ArrayBufferProtocol {
     }
 
     // This will force uniqueness
-    var count = self.count
-    self._arrayReserve(count + 1)
+    var newCount = self.count
+    _arrayReserve(newCount + 1)
     while true {
-      let capacity = self.capacity
+      let currentCapacity = self.capacity
       let base = self.firstElementAddress
 
-      while (nextItem != nil) && count < capacity {
-        (base + count).initialize(to: nextItem!)
-        count += 1
+      while (nextItem != nil) && newCount < currentCapacity {
+        (base + newCount).initialize(to: nextItem!)
+        newCount += 1
         nextItem = stream.next()
       }
-      self.count = count
+      self.count = newCount
       if nextItem == nil {
         return
       }
-      self._arrayReserve(_growArrayCapacity(capacity))
+      self._arrayReserve(_growArrayCapacity(currentCapacity))
     }
   }
 }

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1214,8 +1214,8 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   @inline(never)
   internal mutating func _copyToNewBuffer(oldCount: Int) {
     let newCount = oldCount + 1
-    var newBuffer = _forceCreateUniqueMutableBuffer(
-      &_buffer, countForNewBuffer: oldCount, minNewCapacity: newCount)
+    var newBuffer = _buffer._forceCreateUniqueMutableBuffer(
+      countForNewBuffer: oldCount, minNewCapacity: newCount)
     _buffer._arrayOutOfPlaceUpdate(
       &newBuffer, oldCount, 0, _IgnorePointer())
   }
@@ -1681,8 +1681,8 @@ internal func _arrayOutOfPlaceReplace<B, C>(
 
   let growth = insertCount - bounds.count
   let newCount = source.count + growth
-  var newBuffer = _forceCreateUniqueMutableBuffer(
-    &source, newCount: newCount, requiredCapacity: newCount)
+  var newBuffer = source._forceCreateUniqueMutableBuffer(
+    newCount: newCount, requiredCapacity: newCount)
 
   source._arrayOutOfPlaceUpdate(
     &newBuffer,
@@ -1823,58 +1823,60 @@ public func += <
 
 //===--- generic helpers --------------------------------------------------===//
 
-/// Create a unique mutable buffer that has enough capacity to hold 'newCount'
-/// elements and at least 'requiredCapacity' elements. Set the count of the new
-/// buffer to 'newCount'. The content of the buffer is uninitialized.
-/// The formula used to compute the new buffers capacity is:
-///   max(requiredCapacity, source.capacity)  if newCount <= source.capacity
-///   max(requiredCapacity, _growArrayCapacity(source.capacity)) otherwise
-@inline(never)
-internal func _forceCreateUniqueMutableBuffer<_Buffer : _ArrayBufferProtocol>(
-  _ source: inout _Buffer, newCount: Int, requiredCapacity: Int
-) -> _ContiguousArrayBuffer<_Buffer.Element> {
-  return _forceCreateUniqueMutableBufferImpl(
-    &source, countForBuffer: newCount, minNewCapacity: newCount,
-    requiredCapacity: requiredCapacity)
-}
+extension _ArrayBufferProtocol {
+  /// Create a unique mutable buffer that has enough capacity to hold 'newCount'
+  /// elements and at least 'requiredCapacity' elements. Set the count of the new
+  /// buffer to 'newCount'. The content of the buffer is uninitialized.
+  /// The formula used to compute the new buffers capacity is:
+  ///   max(requiredCapacity, source.capacity)  if newCount <= source.capacity
+  ///   max(requiredCapacity, _growArrayCapacity(source.capacity)) otherwise
+  @inline(never)
+  internal func _forceCreateUniqueMutableBuffer(
+    newCount: Int, requiredCapacity: Int
+  ) -> _ContiguousArrayBuffer<Element> {
+    return _forceCreateUniqueMutableBufferImpl(
+      countForBuffer: newCount, minNewCapacity: newCount,
+      requiredCapacity: requiredCapacity)
+  }
 
-/// Create a unique mutable buffer that has enough capacity to hold
-/// 'minNewCapacity' elements and set the count of the new buffer to
-/// 'countForNewBuffer'. The content of the buffer uninitialized.
-/// The formula used to compute the new buffers capacity is:
-///   max(minNewCapacity, source.capacity) if minNewCapacity <= source.capacity
-///   max(minNewCapacity, _growArrayCapacity(source.capacity)) otherwise
-@inline(never)
-internal
-func _forceCreateUniqueMutableBuffer<_Buffer : _ArrayBufferProtocol>(
-  _ source: inout _Buffer, countForNewBuffer: Int, minNewCapacity: Int
-) -> _ContiguousArrayBuffer<_Buffer.Element> {
-  return _forceCreateUniqueMutableBufferImpl(
-    &source, countForBuffer: countForNewBuffer, minNewCapacity: minNewCapacity,
-    requiredCapacity: minNewCapacity)
-}
+  /// Create a unique mutable buffer that has enough capacity to hold
+  /// 'minNewCapacity' elements and set the count of the new buffer to
+  /// 'countForNewBuffer'. The content of the buffer uninitialized.
+  /// The formula used to compute the new buffers capacity is:
+  ///   max(minNewCapacity, source.capacity) if minNewCapacity <= source.capacity
+  ///   max(minNewCapacity, _growArrayCapacity(source.capacity)) otherwise
+  @inline(never)
+  internal func _forceCreateUniqueMutableBuffer(
+    countForNewBuffer: Int, minNewCapacity: Int
+  ) -> _ContiguousArrayBuffer<Element> {
+    return _forceCreateUniqueMutableBufferImpl(
+      countForBuffer: countForNewBuffer, minNewCapacity: minNewCapacity,
+      requiredCapacity: minNewCapacity)
+  }
 
-/// Create a unique mutable buffer that has enough capacity to hold
-/// 'minNewCapacity' elements and at least 'requiredCapacity' elements and set
-/// the count of the new buffer to 'countForBuffer'. The content of the buffer
-/// uninitialized.
-/// The formula used to compute the new capacity is:
-///  max(requiredCapacity, source.capacity) if minNewCapacity <= source.capacity
-///  max(requiredCapacity, _growArrayCapacity(source.capacity))  otherwise
-internal func _forceCreateUniqueMutableBufferImpl<_Buffer : _ArrayBufferProtocol>(
-  _ source: inout _Buffer, countForBuffer: Int, minNewCapacity: Int,
-  requiredCapacity: Int
-) -> _ContiguousArrayBuffer<_Buffer.Element> {
-  _sanityCheck(countForBuffer >= 0)
-  _sanityCheck(requiredCapacity >= countForBuffer)
-  _sanityCheck(minNewCapacity >= countForBuffer)
+  /// Create a unique mutable buffer that has enough capacity to hold
+  /// 'minNewCapacity' elements and at least 'requiredCapacity' elements and set
+  /// the count of the new buffer to 'countForBuffer'. The content of the buffer
+  /// uninitialized.
+  /// The formula used to compute the new capacity is:
+  ///  max(requiredCapacity, source.capacity) if minNewCapacity <= source.capacity
+  ///  max(requiredCapacity, _growArrayCapacity(source.capacity))  otherwise
+  internal func _forceCreateUniqueMutableBufferImpl(
+    countForBuffer: Int, minNewCapacity: Int,
+    requiredCapacity: Int
+  ) -> _ContiguousArrayBuffer<Element> {
+    _sanityCheck(countForBuffer >= 0)
+    _sanityCheck(requiredCapacity >= countForBuffer)
+    _sanityCheck(minNewCapacity >= countForBuffer)
 
-  let minimumCapacity = max(
-    requiredCapacity, minNewCapacity > source.capacity
-      ? _growArrayCapacity(source.capacity) : source.capacity)
+    // FIXME(Typechecker): Swift. prefix shouldn't be necessary (rdar://problem/28947708)
+    let minimumCapacity = Swift.max(requiredCapacity,
+      minNewCapacity > capacity
+         ? _growArrayCapacity(capacity) : capacity)
 
-  return _ContiguousArrayBuffer(
-    _uninitializedCount: countForBuffer, minimumCapacity: minimumCapacity)
+    return _ContiguousArrayBuffer(
+      _uninitializedCount: countForBuffer, minimumCapacity: minimumCapacity)
+  }
 }
 
 internal protocol _PointerFunction {
@@ -1993,8 +1995,8 @@ internal func _outlinedMakeUniqueBuffer<_Buffer>(
     return
   }
 
-  var newBuffer = _forceCreateUniqueMutableBuffer(
-    &buffer, newCount: bufferCount, requiredCapacity: bufferCount)
+  var newBuffer = buffer._forceCreateUniqueMutableBuffer(
+    newCount: bufferCount, requiredCapacity: bufferCount)
   buffer._arrayOutOfPlaceUpdate(&newBuffer, bufferCount, 0, _IgnorePointer())
 }
 
@@ -2014,8 +2016,8 @@ internal func _arrayReserve<_Buffer>(
     return
   }
 
-  var newBuffer = _forceCreateUniqueMutableBuffer(
-    &buffer, newCount: count, requiredCapacity: requiredCapacity)
+  var newBuffer = buffer._forceCreateUniqueMutableBuffer(
+    newCount: count, requiredCapacity: requiredCapacity)
   buffer._arrayOutOfPlaceUpdate(&newBuffer, count, 0, _IgnorePointer())
 }
 

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1666,29 +1666,26 @@ internal struct _InitializeMemoryFromCollection<
   var newValues: C
 }
 
-// FIXME(ABI)#14 : add argument labels.
-@inline(never)
-internal func _arrayOutOfPlaceReplace<B, C>(
-  _ source: inout B,
-  _ bounds: Range<Int>,
-  _ newValues: C,
-  _ insertCount: Int
-) where
-  B : _ArrayBufferProtocol,
-  C : Collection,
-  C.Iterator.Element == B.Element,
-  B.Index == Int {
+extension _ArrayBufferProtocol where Index == Int {
+  // FIXME(ABI)#14 : add argument labels.
+  @inline(never)
+  internal mutating func _arrayOutOfPlaceReplace<C : Collection>(
+    _ bounds: Range<Int>,
+    _ newValues: C,
+    _ insertCount: Int
+  ) where C.Iterator.Element == Element {
 
-  let growth = insertCount - bounds.count
-  let newCount = source.count + growth
-  var newBuffer = source._forceCreateUniqueMutableBuffer(
-    newCount: newCount, requiredCapacity: newCount)
+    let growth = insertCount - bounds.count
+    let newCount = count + growth
+    var newBuffer = _forceCreateUniqueMutableBuffer(
+      newCount: newCount, requiredCapacity: newCount)
 
-  source._arrayOutOfPlaceUpdate(
-    &newBuffer,
-    bounds.lowerBound - source.startIndex, insertCount,
-    _InitializeMemoryFromCollection(newValues)
-  )
+    _arrayOutOfPlaceUpdate(
+      &newBuffer,
+      bounds.lowerBound - startIndex, insertCount,
+      _InitializeMemoryFromCollection(newValues)
+    )
+  }  
 }
 
 /// A _debugPrecondition check that `i` has exactly reached the end of
@@ -1767,7 +1764,7 @@ extension ${Self} {
       self._buffer.replace(
         subRange: subrange, with: insertCount, elementsOf: newElements)
     } else {
-      _arrayOutOfPlaceReplace(&self._buffer, subrange, newElements, insertCount)
+      _buffer._arrayOutOfPlaceReplace(subrange, newElements, insertCount)
     }
   }
 }

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1591,7 +1591,7 @@ extension ${Self} {
   ) rethrows -> R {
     let count = self.count
     // Ensure unique storage
-    _outlinedMakeUniqueBuffer(&_buffer, bufferCount: count)
+    _buffer._outlinedMakeUniqueBuffer(bufferCount: count)
 
     // Ensure that body can't invalidate the storage or its bounds by
     // moving self into a temporary working array.
@@ -1985,7 +1985,7 @@ internal struct _IgnorePointer<T> : _PointerFunction {
 extension _ArrayBufferProtocol where Index == Int {
   @_versioned
   @inline(never)
-  internal func _outlinedMakeUniqueBuffer(bufferCount: Int) {
+  internal mutating func _outlinedMakeUniqueBuffer(bufferCount: Int) {
 
     if _fastPath(
         requestUniqueMutableBackingBuffer(minimumCapacity: bufferCount) != nil) {
@@ -1997,13 +1997,14 @@ extension _ArrayBufferProtocol where Index == Int {
     _arrayOutOfPlaceUpdate(&newBuffer, bufferCount, 0, _IgnorePointer())
   }
 
-  internal func _arrayReserve(_ minimumCapacity: Int) {
+  internal mutating func _arrayReserve(_ minimumCapacity: Int) {
 
     let count = self.count
-    let requiredCapacity = max(count, minimumCapacity)
+    // FIXME(Typechecker): shouldn't need Swift. here
+    let requiredCapacity = Swift.max(count, minimumCapacity)
 
     if _fastPath(
-        buffer.requestUniqueMutableBackingBuffer(
+        requestUniqueMutableBackingBuffer(
           minimumCapacity: requiredCapacity) != nil
     ) {
       return
@@ -2033,7 +2034,7 @@ internal func _arrayAppendSequence<Buffer, S>(
 
   // This will force uniqueness
   var count = buffer.count
-  _arrayReserve(&buffer, count + 1)
+  buffer._arrayReserve(count + 1)
   while true {
     let capacity = buffer.capacity
     let base = buffer.firstElementAddress
@@ -2047,7 +2048,7 @@ internal func _arrayAppendSequence<Buffer, S>(
     if nextItem == nil {
       return
     }
-    _arrayReserve(&buffer, _growArrayCapacity(capacity))
+    buffer._arrayReserve(_growArrayCapacity(capacity))
   }
 }
 

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1216,8 +1216,8 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
     let newCount = oldCount + 1
     var newBuffer = _forceCreateUniqueMutableBuffer(
       &_buffer, countForNewBuffer: oldCount, minNewCapacity: newCount)
-    _arrayOutOfPlaceUpdate(
-      &_buffer, &newBuffer, oldCount, 0, _IgnorePointer())
+    _buffer._arrayOutOfPlaceUpdate(
+      &newBuffer, oldCount, 0, _IgnorePointer())
   }
 
   @_semantics("array.make_mutable")
@@ -1684,8 +1684,8 @@ internal func _arrayOutOfPlaceReplace<B, C>(
   var newBuffer = _forceCreateUniqueMutableBuffer(
     &source, newCount: newCount, requiredCapacity: newCount)
 
-  _arrayOutOfPlaceUpdate(
-    &source, &newBuffer,
+  source._arrayOutOfPlaceUpdate(
+    &newBuffer,
     bounds.lowerBound - source.startIndex, insertCount,
     _InitializeMemoryFromCollection(newValues)
   )
@@ -1882,82 +1882,81 @@ internal protocol _PointerFunction {
   func call(_: UnsafeMutablePointer<Element>, count: Int)
 }
 
-/// Initialize the elements of dest by copying the first headCount
-/// items from source, calling initializeNewElements on the next
-/// uninitialized element, and finally by copying the last N items
-/// from source into the N remaining uninitialized elements of dest.
-///
-/// As an optimization, may move elements out of source rather than
-/// copying when it isUniquelyReferenced.
-@inline(never)
-internal func _arrayOutOfPlaceUpdate<_Buffer, Initializer>(
-  _ source: inout _Buffer,
-  _ dest: inout _ContiguousArrayBuffer<_Buffer.Element>,
-  _ headCount: Int, // Count of initial source elements to copy/move
-  _ newCount: Int,  // Number of new elements to insert
-  _ initializeNewElements: Initializer
-) where
-  _Buffer : _ArrayBufferProtocol,
-  Initializer : _PointerFunction,
-  Initializer.Element == _Buffer.Element,
-  _Buffer.Index == Int {
+extension _ArrayBufferProtocol where Index == Int {
+  /// Initialize the elements of dest by copying the first headCount
+  /// items from source, calling initializeNewElements on the next
+  /// uninitialized element, and finally by copying the last N items
+  /// from source into the N remaining uninitialized elements of dest.
+  ///
+  /// As an optimization, may move elements out of source rather than
+  /// copying when it isUniquelyReferenced.
+  @inline(never)
+  internal mutating func _arrayOutOfPlaceUpdate<Initializer>(
+    _ dest: inout _ContiguousArrayBuffer<Element>,
+    _ headCount: Int, // Count of initial source elements to copy/move
+    _ newCount: Int,  // Number of new elements to insert
+    _ initializeNewElements: Initializer
+  ) where
+    Initializer : _PointerFunction,
+    Initializer.Element == Element {
 
-  _sanityCheck(headCount >= 0)
-  _sanityCheck(newCount >= 0)
+    _sanityCheck(headCount >= 0)
+    _sanityCheck(newCount >= 0)
 
-  // Count of trailing source elements to copy/move
-  let tailCount = dest.count - headCount - newCount
-  _sanityCheck(headCount + tailCount <= source.count)
+    // Count of trailing source elements to copy/move
+    let sourceCount = self.count
+    let tailCount = dest.count - headCount - newCount
+    _sanityCheck(headCount + tailCount <= sourceCount)
 
-  let sourceCount = source.count
-  let oldCount = sourceCount - headCount - tailCount
-  let destStart = dest.firstElementAddress
-  let newStart = destStart + headCount
-  let newEnd = newStart + newCount
+    let oldCount = sourceCount - headCount - tailCount
+    let destStart = dest.firstElementAddress
+    let newStart = destStart + headCount
+    let newEnd = newStart + newCount
 
-  // Check to see if we have storage we can move from
-  if let backing = source.requestUniqueMutableBackingBuffer(
-    minimumCapacity: sourceCount) {
+    // Check to see if we have storage we can move from
+    if let backing = requestUniqueMutableBackingBuffer(
+      minimumCapacity: sourceCount) {
 
-    let sourceStart = source.firstElementAddress
-    let oldStart = sourceStart + headCount
+      let sourceStart = firstElementAddress
+      let oldStart = sourceStart + headCount
 
-    // Destroy any items that may be lurking in a _SliceBuffer before
-    // its real first element
-    let backingStart = backing.firstElementAddress
-    let sourceOffset = sourceStart - backingStart
-    backingStart.deinitialize(count: sourceOffset)
+      // Destroy any items that may be lurking in a _SliceBuffer before
+      // its real first element
+      let backingStart = backing.firstElementAddress
+      let sourceOffset = sourceStart - backingStart
+      backingStart.deinitialize(count: sourceOffset)
 
-    // Move the head items
-    destStart.moveInitialize(from: sourceStart, count: headCount)
+      // Move the head items
+      destStart.moveInitialize(from: sourceStart, count: headCount)
 
-    // Destroy unused source items
-    oldStart.deinitialize(count: oldCount)
+      // Destroy unused source items
+      oldStart.deinitialize(count: oldCount)
 
-    initializeNewElements.call(newStart, count: newCount)
+      initializeNewElements.call(newStart, count: newCount)
 
-    // Move the tail items
-    newEnd.moveInitialize(from: oldStart + oldCount, count: tailCount)
+      // Move the tail items
+      newEnd.moveInitialize(from: oldStart + oldCount, count: tailCount)
 
-    // Destroy any items that may be lurking in a _SliceBuffer after
-    // its real last element
-    let backingEnd = backingStart + backing.count
-    let sourceEnd = sourceStart + sourceCount
-    sourceEnd.deinitialize(count: backingEnd - sourceEnd)
-    backing.count = 0
+      // Destroy any items that may be lurking in a _SliceBuffer after
+      // its real last element
+      let backingEnd = backingStart + backing.count
+      let sourceEnd = sourceStart + sourceCount
+      sourceEnd.deinitialize(count: backingEnd - sourceEnd)
+      backing.count = 0
+    }
+    else {
+      let headStart = startIndex
+      let headEnd = headStart + headCount
+      let newStart = _copyContents(
+        subRange: headStart..<headEnd,
+        initializing: destStart)
+      initializeNewElements.call(newStart, count: newCount)
+      let tailStart = headEnd + oldCount
+      let tailEnd = endIndex
+      self._copyContents(subRange: tailStart..<tailEnd, initializing: newEnd)
+    }
+    self = Self(_buffer: dest, shiftedToStartIndex: startIndex)
   }
-  else {
-    let headStart = source.startIndex
-    let headEnd = headStart + headCount
-    let newStart = source._copyContents(
-      subRange: headStart..<headEnd,
-      initializing: destStart)
-    initializeNewElements.call(newStart, count: newCount)
-    let tailStart = headEnd + oldCount
-    let tailEnd = source.endIndex
-    source._copyContents(subRange: tailStart..<tailEnd, initializing: newEnd)
-  }
-  source = _Buffer(_buffer: dest, shiftedToStartIndex: source.startIndex)
 }
 
 internal struct _InitializePointer<T> : _PointerFunction {
@@ -1996,7 +1995,7 @@ internal func _outlinedMakeUniqueBuffer<_Buffer>(
 
   var newBuffer = _forceCreateUniqueMutableBuffer(
     &buffer, newCount: bufferCount, requiredCapacity: bufferCount)
-  _arrayOutOfPlaceUpdate(&buffer, &newBuffer, bufferCount, 0, _IgnorePointer())
+  buffer._arrayOutOfPlaceUpdate(&newBuffer, bufferCount, 0, _IgnorePointer())
 }
 
 internal func _arrayReserve<_Buffer>(
@@ -2017,7 +2016,7 @@ internal func _arrayReserve<_Buffer>(
 
   var newBuffer = _forceCreateUniqueMutableBuffer(
     &buffer, newCount: count, requiredCapacity: requiredCapacity)
-  _arrayOutOfPlaceUpdate(&buffer, &newBuffer, count, 0, _IgnorePointer())
+  buffer._arrayOutOfPlaceUpdate(&newBuffer, count, 0, _IgnorePointer())
 }
 
 /// Append items from `newItems` to `buffer`.

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1746,14 +1746,14 @@ extension ${Self} {
     _precondition(subrange.lowerBound >= self._buffer.startIndex,
       "${Self} replace: subrange start is negative")
 % else:
-    _precondition(subrange.lowerBound >= self._buffer.startIndex,
+    _precondition(subrange.lowerBound >= _buffer.startIndex,
       "${Self} replace: subrange start is before the startIndex")
 % end
 
-    _precondition(subrange.upperBound <= self._buffer.endIndex,
+    _precondition(subrange.upperBound <= _buffer.endIndex,
       "${Self} replace: subrange extends past the end")
 
-    let oldCount = self._buffer.count
+    let oldCount = _buffer.count
     let eraseCount = subrange.count
     let insertCount = numericCast(newElements.count) as Int
     let growth = insertCount - eraseCount

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1982,43 +1982,37 @@ internal struct _IgnorePointer<T> : _PointerFunction {
   }
 }
 
-@_versioned
-@inline(never)
-internal func _outlinedMakeUniqueBuffer<_Buffer>(
-  _ buffer: inout _Buffer, bufferCount: Int
-) where
-  _Buffer : _ArrayBufferProtocol,
-  _Buffer.Index == Int {
+extension _ArrayBufferProtocol where Index == Int {
+  @_versioned
+  @inline(never)
+  internal func _outlinedMakeUniqueBuffer(bufferCount: Int) {
 
-  if _fastPath(
-      buffer.requestUniqueMutableBackingBuffer(minimumCapacity: bufferCount) != nil) {
-    return
+    if _fastPath(
+        requestUniqueMutableBackingBuffer(minimumCapacity: bufferCount) != nil) {
+      return
+    }
+
+    var newBuffer = _forceCreateUniqueMutableBuffer(
+      newCount: bufferCount, requiredCapacity: bufferCount)
+    _arrayOutOfPlaceUpdate(&newBuffer, bufferCount, 0, _IgnorePointer())
   }
 
-  var newBuffer = buffer._forceCreateUniqueMutableBuffer(
-    newCount: bufferCount, requiredCapacity: bufferCount)
-  buffer._arrayOutOfPlaceUpdate(&newBuffer, bufferCount, 0, _IgnorePointer())
-}
+  internal func _arrayReserve(_ minimumCapacity: Int) {
 
-internal func _arrayReserve<_Buffer>(
-  _ buffer: inout _Buffer, _ minimumCapacity: Int
-) where
-  _Buffer : _ArrayBufferProtocol,
-  _Buffer.Index == Int {
+    let count = self.count
+    let requiredCapacity = max(count, minimumCapacity)
 
-  let count = buffer.count
-  let requiredCapacity = max(count, minimumCapacity)
+    if _fastPath(
+        buffer.requestUniqueMutableBackingBuffer(
+          minimumCapacity: requiredCapacity) != nil
+    ) {
+      return
+    }
 
-  if _fastPath(
-      buffer.requestUniqueMutableBackingBuffer(
-        minimumCapacity: requiredCapacity) != nil
-  ) {
-    return
+    var newBuffer = _forceCreateUniqueMutableBuffer(
+      newCount: count, requiredCapacity: requiredCapacity)
+    _arrayOutOfPlaceUpdate(&newBuffer, count, 0, _IgnorePointer())
   }
-
-  var newBuffer = buffer._forceCreateUniqueMutableBuffer(
-    newCount: count, requiredCapacity: requiredCapacity)
-  buffer._arrayOutOfPlaceUpdate(&newBuffer, count, 0, _IgnorePointer())
 }
 
 /// Append items from `newItems` to `buffer`.

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1671,8 +1671,8 @@ extension _ArrayBufferProtocol where Index == Int {
   @inline(never)
   internal mutating func _arrayOutOfPlaceReplace<C : Collection>(
     _ bounds: Range<Int>,
-    _ newValues: C,
-    _ insertCount: Int
+    with newValues: C,
+    count insertCount: Int
   ) where C.Iterator.Element == Element {
 
     let growth = insertCount - bounds.count
@@ -1758,13 +1758,13 @@ extension ${Self} {
     let insertCount = numericCast(newElements.count) as Int
     let growth = insertCount - eraseCount
 
-    if self._buffer.requestUniqueMutableBackingBuffer(
+    if _buffer.requestUniqueMutableBackingBuffer(
       minimumCapacity: oldCount + growth) != nil {
 
-      self._buffer.replace(
+      _buffer.replace(
         subRange: subrange, with: insertCount, elementsOf: newElements)
     } else {
-      _buffer._arrayOutOfPlaceReplace(subrange, newElements, insertCount)
+      _buffer._arrayOutOfPlaceReplace(subrange, with: newElements, count: insertCount)
     }
   }
 }

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1667,7 +1667,6 @@ internal struct _InitializeMemoryFromCollection<
 }
 
 extension _ArrayBufferProtocol {
-  // FIXME(ABI)#14 : add argument labels.
   @inline(never)
   internal mutating func _arrayOutOfPlaceReplace<C : Collection>(
     _ bounds: Range<Int>,

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1301,7 +1301,7 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
       self.reserveCapacity(
         Swift.max(newCount, _growArrayCapacity(capacity)))
       }
-    _arrayAppendSequence(&self._buffer, newElements)
+    _buffer._arrayAppendSequence(newElements)
   }
 
   // An overload of `append(contentsOf:)` that uses the += that is optimized for
@@ -2011,40 +2011,37 @@ extension _ArrayBufferProtocol {
       newCount: count, requiredCapacity: requiredCapacity)
     _arrayOutOfPlaceUpdate(&newBuffer, count, 0, _IgnorePointer())
   }
-}
 
-/// Append items from `newItems` to `buffer`.
-internal func _arrayAppendSequence<Buffer, S>(
-  _ buffer: inout Buffer, _ newItems: S
-) where
-  Buffer : _ArrayBufferProtocol,
-  S : Sequence,
-  S.Iterator.Element == Buffer.Element {
+  /// Append items from `newItems` to a buffer.
+  internal mutating func _arrayAppendSequence<S : Sequence>(
+    _ newItems: S
+  ) where S.Iterator.Element == Element {
 
-  var stream = newItems.makeIterator()
-  var nextItem = stream.next()
+    var stream = newItems.makeIterator()
+    var nextItem = stream.next()
 
-  if nextItem == nil {
-    return
-  }
-
-  // This will force uniqueness
-  var count = buffer.count
-  buffer._arrayReserve(count + 1)
-  while true {
-    let capacity = buffer.capacity
-    let base = buffer.firstElementAddress
-
-    while (nextItem != nil) && count < capacity {
-      (base + count).initialize(to: nextItem!)
-      count += 1
-      nextItem = stream.next()
-    }
-    buffer.count = count
     if nextItem == nil {
       return
     }
-    buffer._arrayReserve(_growArrayCapacity(capacity))
+
+    // This will force uniqueness
+    var count = self.count
+    self._arrayReserve(count + 1)
+    while true {
+      let capacity = self.capacity
+      let base = self.firstElementAddress
+
+      while (nextItem != nil) && count < capacity {
+        (base + count).initialize(to: nextItem!)
+        count += 1
+        nextItem = stream.next()
+      }
+      self.count = count
+      if nextItem == nil {
+        return
+      }
+      self._arrayReserve(_growArrayCapacity(capacity))
+    }
   }
 }
 

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1666,7 +1666,7 @@ internal struct _InitializeMemoryFromCollection<
   var newValues: C
 }
 
-extension _ArrayBufferProtocol where Index == Int {
+extension _ArrayBufferProtocol {
   // FIXME(ABI)#14 : add argument labels.
   @inline(never)
   internal mutating func _arrayOutOfPlaceReplace<C : Collection>(
@@ -1881,7 +1881,7 @@ internal protocol _PointerFunction {
   func call(_: UnsafeMutablePointer<Element>, count: Int)
 }
 
-extension _ArrayBufferProtocol where Index == Int {
+extension _ArrayBufferProtocol {
   /// Initialize the elements of dest by copying the first headCount
   /// items from source, calling initializeNewElements on the next
   /// uninitialized element, and finally by copying the last N items
@@ -1952,7 +1952,7 @@ extension _ArrayBufferProtocol where Index == Int {
       initializeNewElements.call(newStart, count: newCount)
       let tailStart = headEnd + oldCount
       let tailEnd = endIndex
-      self._copyContents(subRange: tailStart..<tailEnd, initializing: newEnd)
+      _copyContents(subRange: tailStart..<tailEnd, initializing: newEnd)
     }
     self = Self(_buffer: dest, shiftedToStartIndex: startIndex)
   }
@@ -1979,7 +1979,7 @@ internal struct _IgnorePointer<T> : _PointerFunction {
   }
 }
 
-extension _ArrayBufferProtocol where Index == Int {
+extension _ArrayBufferProtocol {
   @_versioned
   @inline(never)
   internal mutating func _outlinedMakeUniqueBuffer(bufferCount: Int) {
@@ -2019,8 +2019,7 @@ internal func _arrayAppendSequence<Buffer, S>(
 ) where
   Buffer : _ArrayBufferProtocol,
   S : Sequence,
-  S.Iterator.Element == Buffer.Element,
-  Buffer.Index == Int {
+  S.Iterator.Element == Buffer.Element {
 
   var stream = newItems.makeIterator()
   var nextItem = stream.next()

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1761,8 +1761,8 @@ extension ${Self} {
     if _buffer.requestUniqueMutableBackingBuffer(
       minimumCapacity: oldCount + growth) != nil {
 
-      _buffer.replace(
-        subRange: subrange, with: insertCount, elementsOf: newElements)
+      _buffer.replaceSubrange(
+        subrange, with: insertCount, elementsOf: newElements)
     } else {
       _buffer._arrayOutOfPlaceReplace(subrange, with: newElements, count: insertCount)
     }

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -101,8 +101,8 @@ internal struct _SliceBuffer<Element>
 
     let start = subRange.lowerBound - startIndex + hiddenElementCount
     let end = subRange.upperBound - startIndex + hiddenElementCount
-    native.replace(
-      subRange: start..<end,
+    native.replaceSubrange(
+      start..<end,
       with: insertCount,
       elementsOf: newValues)
 
@@ -153,8 +153,8 @@ internal struct _SliceBuffer<Element>
         let myCount = count
 
         if _slowPath(backingCount > myCount + offset) {
-          native.replace(
-            subRange: (myCount+offset)..<backingCount,
+          native.replaceSubrange(
+            (myCount+offset)..<backingCount,
             with: 0,
             elementsOf: EmptyCollection())
         }

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -79,8 +79,8 @@ internal struct _SliceBuffer<Element>
   /// - Precondition: This buffer is backed by a uniquely-referenced
   ///   `_ContiguousArrayBuffer` and
   ///   `insertCount <= numericCast(newValues.count)`.
-  internal mutating func replace<C>(
-    subRange: Range<Int>,
+  internal mutating func replaceSubrange<C>(
+    _ subrange: Range<Int>,
     with insertCount: Int,
     elementsOf newValues: C
   ) where C : Collection, C.Iterator.Element == Element {
@@ -90,7 +90,7 @@ internal struct _SliceBuffer<Element>
 
     _sanityCheck(_hasNativeBuffer && isUniquelyReferenced())
 
-    let eraseCount = subRange.count
+    let eraseCount = subrange.count
     let growth = insertCount - eraseCount
     let oldCount = count
 
@@ -99,8 +99,8 @@ internal struct _SliceBuffer<Element>
 
     _sanityCheck(native.count + growth <= native.capacity)
 
-    let start = subRange.lowerBound - startIndex + hiddenElementCount
-    let end = subRange.upperBound - startIndex + hiddenElementCount
+    let start = subrange.lowerBound - startIndex + hiddenElementCount
+    let end = subrange.upperBound - startIndex + hiddenElementCount
     native.replaceSubrange(
       start..<end,
       with: insertCount,


### PR DESCRIPTION
This started from the fairly innocent `FIXME(ABI)#14 : add argument labels to conform to naming convention guidelines.` but then evolved into changing a number of generic functions that took an `inout` conforming to `_ArrayBufferProtocol` to be mutating methods on the protocol instead.

Also added a missing `endIndex: Int` declaration to the protocol, which was what appears to have been forcing the need to keep adding `where Index == Int` in various places, and did some other cleanup to make `replace(subRange:)` look more like `RangeReplaceableCollection`'s `replaceSubrange`.

This seems to leave us within striking distance of making `_ArrayBufferProtocol` conform to `RangeReplaceableCollection`, which would tidy up a number of functions that are duplicating functionality that exists there. But that may have performance impact so putting this in first.
