### PR TITLE
SILGen/IRGen: Lower protocol witness thunks for ObjC lightweight generics as pseudogeneric.

### DIFF
--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -548,6 +548,7 @@ NON_SIL_TYPE(LValue)
 CanSILFunctionType getNativeSILFunctionType(SILModule &M,
                         Lowering::AbstractionPattern orig,
                         CanAnyFunctionType substInterface,
+                        Optional<SILDeclRef> constant = None,
                         SILDeclRef::Kind kind = SILDeclRef::Kind::Func);
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, SILType T) {

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -143,12 +143,17 @@ PolymorphicConvention::PolymorphicConvention(IRGenModule &IGM,
   : IGM(IGM), M(*IGM.getSwiftModule()), FnType(fnType) {
   initGenerics();
 
+  auto rep = fnType->getRepresentation();
+
   if (fnType->isPseudogeneric()) {
+    // Protocol witnesses still get Self metadata no matter what. The type
+    // parameters of Self are pseudogeneric, though.
+    if (rep == SILFunctionTypeRepresentation::WitnessMethod)
+      considerWitnessSelf(fnType);
+
     addPseudogenericFulfillments();
     return;
   }
-
-  auto rep = fnType->getRepresentation();
 
   if (rep == SILFunctionTypeRepresentation::WitnessMethod) {
     // Protocol witnesses always derive all polymorphic parameter

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -1031,6 +1031,7 @@ static CanSILFunctionType getNativeSILFunctionType(SILModule &M,
 CanSILFunctionType swift::getNativeSILFunctionType(SILModule &M,
                                        AbstractionPattern origType,
                                        CanAnyFunctionType substInterfaceType,
+                                       Optional<SILDeclRef> constant,
                                        SILDeclRef::Kind kind) {
   AnyFunctionType::ExtInfo extInfo;
 
@@ -1043,7 +1044,7 @@ CanSILFunctionType swift::getNativeSILFunctionType(SILModule &M,
     extInfo = substInterfaceType->getExtInfo();
   }
   return ::getNativeSILFunctionType(M, origType, substInterfaceType,
-                                    extInfo, None, kind);
+                                    extInfo, constant, kind);
 }
 
 //===----------------------------------------------------------------------===//
@@ -2066,6 +2067,7 @@ SILConstantInfo TypeConverter::getConstantOverrideInfo(SILDeclRef derived,
   // Build the SILFunctionType for the vtable thunk.
   CanSILFunctionType fnTy = getNativeSILFunctionType(M, basePattern,
                                                      overrideLoweredInterfaceTy,
+                                                     derived,
                                                      derived.kind);
 
   {

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1889,7 +1889,8 @@ SILGenModule::emitProtocolWitness(ProtocolConformance *conformance,
   // Lower the witness thunk type with the requirement's abstraction level.
   auto witnessSILFnType = getNativeSILFunctionType(M,
                                                    AbstractionPattern(reqtOrigTy),
-                                                   reqtSubstTy);
+                                                   reqtSubstTy,
+                                                   witness);
 
   // Mangle the name of the witness thunk.
   std::string nameBuffer;

--- a/test/IRGen/Inputs/objc_generic_protocol_conformance.h
+++ b/test/IRGen/Inputs/objc_generic_protocol_conformance.h
@@ -1,0 +1,7 @@
+@import Foundation;
+
+@interface Foo <T> : NSObject
+
+- (void)foo;
+
+@end

--- a/test/IRGen/objc_generic_protocol_conformance.swift
+++ b/test/IRGen/objc_generic_protocol_conformance.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen %s -import-objc-header %S/Inputs/objc_generic_protocol_conformance.h | %FileCheck --check-prefix=SIL %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir %s -import-objc-header %S/Inputs/objc_generic_protocol_conformance.h | %FileCheck --check-prefix=IR %s
+
+// REQUIRES: objc_interop
+
+protocol P {
+  func foo()
+}
+
+extension Foo: P {}
+
+// SIL-LABEL: sil hidden [transparent] [thunk] @_TTWuRxs9AnyObjectrGCSo3Foo{{.*}} @pseudogeneric
+// IR-LABEL: define hidden void @_TTWuRxs9AnyObjectrGCSo3Foo{{.*}}(%CSo3Foo** noalias nocapture dereferenceable(8), %swift.type*{{( %Self)?}}, i8**{{( %SelfWitnessTable)?}})


### PR DESCRIPTION
Fixes rdar://problem/28873860, where we would miscompile when lightweight generic classes were extended to conform to Swift protocols because we tried to emit parameters for the class's generic parameters for the witness entry points. Prevent this by lowering the witness into a pseudogeneric function in SILGen, and teaching IRGen to do the right thing for a witness with pseudogeneric parameters.
