### PR TITLE
SourceKit: adapt for SVN r284681

### DIFF
--- a/tools/SourceKit/include/SourceKit/Support/Logging.h
+++ b/tools/SourceKit/include/SourceKit/Support/Logging.h
@@ -105,7 +105,7 @@ public:
 /// \endcode
 #define LOG_SECTION(NAME, LEVEL) \
   if (LogRef Log = SourceKit::Logger::make(NAME, SourceKit::Logger::Level::LEVEL))
-#define LOG_FUNC_SECTION(LEVEL) LOG_SECTION(LLVM_FUNCTION_NAME, LEVEL)
+#define LOG_FUNC_SECTION(LEVEL) LOG_SECTION(__func__, LEVEL)
 #define LOG_FUNC_SECTION_WARN LOG_FUNC_SECTION(Warning)
 
 #define LOG(NAME, LEVEL, msg) LOG_SECTION(NAME, LEVEL) \


### PR DESCRIPTION
<!-- What's in this pull request? -->

Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

LLVM SVN r284681 replaced `LLVM_FUNCTION_NAME` with `__func__` as all supported
compilers support that keyword now.  The holdout was MSVC, and swift requires
clang, so this is always supported.  NFC.
