### PR TITLE
[Parse] Create DiagnosticTransaction along with BacktrackingScope

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -350,17 +350,24 @@ public:
   class BacktrackingScope {
     Parser &P;
     ParserPosition PP;
+    DiagnosticTransaction DT;
     bool Backtrack = true;
 
   public:
-    BacktrackingScope(Parser &P) : P(P), PP(P.getParserPosition()) {}
+    BacktrackingScope(Parser &P)
+      : P(P), PP(P.getParserPosition()), DT(P.Diags) {}
 
     ~BacktrackingScope() {
-      if (Backtrack)
+      if (Backtrack) {
         P.backtrackToPosition(PP);
+        DT.abort();
+      }
     }
 
-    void cancelBacktrack() { Backtrack = false; }
+    void cancelBacktrack() {
+      Backtrack = false;
+      DT.commit();
+    }
   };
 
   /// RAII object that, when it is destructed, restores the parser and lexer to

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1453,9 +1453,8 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
 
       // Handle the deprecated 'x.dynamicType' and migrate it to `type(of: x)`
       if (Tok.getText() == "dynamicType") {
-        BacktrackingScope backtrackScope(*this);
         auto range = Result.get()->getSourceRange();
-        auto dynamicTypeExprRange = SourceRange(TokLoc, consumeToken());
+        auto dynamicTypeExprRange = SourceRange(TokLoc, Tok.getLoc());
         diagnose(TokLoc, diag::expr_dynamictype_deprecated)
           .highlight(dynamicTypeExprRange)
           .fixItReplace(dynamicTypeExprRange, ")")

--- a/test/expr/primary/unqualified_name.swift
+++ b/test/expr/primary/unqualified_name.swift
@@ -73,3 +73,14 @@ class C1 : C0 {
   }
 }
 
+struct S1 {
+  init(x: Int) {} // expected-note {{'init(x:)' declared here}}
+
+  func testS1() {
+    _ = S1.init(x:)(1)
+    _ = S1.init(`x`: 1)  // expected-warning {{keyword 'x' does not need to be escaped in argument list}} {{17-18=}} {{19-20=}}
+
+    // Test for unknown token.
+    _ = S1.init(x: 0xG) // expected-error {{expected a digit after integer literal prefix}} expected-error {{missing argument for parameter 'x' in call}}
+  }
+}


### PR DESCRIPTION
to prevent duplicated diagnostics.

For instance, on `Int8(exactly: 0xG)`, the following error was emitted two times:

```
test.swift:1:21: error: expected a digit after integer literal prefix
_ = Int8(exactly: 0xG)
                    ^
test.swift:1:21: error: expected a digit after integer literal prefix
_ = Int8(exactly: 0xG)
                    ^
```

In this change,
`DiagnosticTransaction` is committed on `BacktrackingScope::cancelBacktrack()`,
or aborted during `BacktrackingScope` destruction.
