### PR TITLE
Fix build breakage on linux where swift version is still 3.0

### DIFF
--- a/test/Parse/ConditionalCompilation/language_version.swift
+++ b/test/Parse/ConditionalCompilation/language_version.swift
@@ -49,10 +49,12 @@
 // Check that an extra .0 doesn't make a version "bigger"; NB this test only
 // tests the fix on 3.0.1, but that's the swift version the fix was backported
 // to. On master, the fix is tested by language_version_explicit.swift
+#if swift(>=3.0.1)
 #if swift(>=3.0.1.0)
 #else
   // This shouldn't emit any diagnostics.
   asdf asdf asdf asdf
+#endif
 #endif
 
 #if swift(>=2.0, *) // expected-error {{expected only one argument to platform condition}}


### PR DESCRIPTION
Marks the 3.0.1-specific testcase added in 113cbe0 as 3.0.1 specific, such that it does not break on linux, which appears to still be building as 3.0.
