### PR TITLE
IRGen: Derive the proper formal Self type for @convention(*method) methods on Optional.

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2344,23 +2344,40 @@ void irgen::emitWitnessTableRefs(IRGenFunction &IGF,
   }
 }
 
-static CanType getSubstSelfType(CanSILFunctionType substFnType) {
+static CanType getSubstSelfType(ModuleDecl *M,
+                                CanSILFunctionType origFnType,
+                                ArrayRef<Substitution> subs) {
   // Grab the apparent 'self' type.  If there isn't a 'self' type,
   // we're not going to try to access this anyway.
-  assert(!substFnType->getParameters().empty());
+  assert(!origFnType->getParameters().empty());
 
-  auto selfParam = substFnType->getParameters().back();
-  CanType substInputType = selfParam.getType();
+  auto selfParam = origFnType->getParameters().back();
+  CanType inputType = selfParam.getType();
   // If the parameter is a direct metatype parameter, this is a static method
   // of the instance type. We can assume this because:
   // - metatypes cannot directly conform to protocols
   // - even if they could, they would conform as a value type 'self' and thus
   //   be passed indirectly as an @in or @inout parameter.
-  if (auto meta = dyn_cast<MetatypeType>(substInputType)) {
+  if (auto meta = dyn_cast<MetatypeType>(inputType)) {
     if (!selfParam.isIndirect())
-      substInputType = meta.getInstanceType();
+      inputType = meta.getInstanceType();
   }
-  return substInputType;
+  
+  // Substitute the `self` type.
+  // FIXME: This has to be done as a formal AST type substitution rather than
+  // a SIL function type substitution, because some nominal types (viz
+  // Optional) have type lowering recursively applied to their type parameters.
+  // Substituting into the original lowered function type like this is still
+  // problematic if we ever allow methods or protocol conformances on structural
+  // types; we'd really need to separately record the formal Self type in the
+  // SIL function type to make that work, which could be managed by having a
+  // "substituted generic signature" concept.
+  if (!subs.empty()) {
+    auto subMap = origFnType->getGenericSignature()->getSubstitutionMap(subs);
+    inputType = inputType.subst(M, subMap, SubstOptions())->getCanonicalType();
+  }
+  
+  return inputType;
 }
 
 namespace {
@@ -2375,7 +2392,7 @@ namespace {
               WitnessMetadata *witnessMetadata, Explosion &out);
 
   private:
-    void emitEarlySources(CanSILFunctionType substFnType, Explosion &out) {
+    void emitEarlySources(ArrayRef<Substitution> subs, Explosion &out) {
       for (auto &source : getSources()) {
         switch (source.getKind()) {
         // Already accounted for in the parameters.
@@ -2385,7 +2402,8 @@ namespace {
 
         // Needs a special argument.
         case MetadataSource::Kind::GenericLValueMetadata: {
-          out.add(IGF.emitTypeMetadataRef(getSubstSelfType(substFnType)));
+          out.add(IGF.emitTypeMetadataRef(getSubstSelfType(IGF.getSwiftModule(),
+                                                           FnType, subs)));
           continue;
         }
 
@@ -2417,7 +2435,7 @@ void EmitPolymorphicArguments::emit(CanSILFunctionType substFnType,
                                     WitnessMetadata *witnessMetadata,
                                     Explosion &out) {
   // Add all the early sources.
-  emitEarlySources(substFnType, out);
+  emitEarlySources(subs, out);
 
   // For now, treat all archetypes independently.
   enumerateUnfulfilledRequirements([&](GenericRequirement requirement) {
@@ -2441,7 +2459,8 @@ void EmitPolymorphicArguments::emit(CanSILFunctionType substFnType,
 
     case MetadataSource::Kind::SelfMetadata: {
       assert(witnessMetadata && "no metadata structure for witness method");
-      auto self = IGF.emitTypeMetadataRef(getSubstSelfType(substFnType));
+      auto self = IGF.emitTypeMetadataRef(getSubstSelfType(IGF.getSwiftModule(),
+                                                           FnType, subs));
       witnessMetadata->SelfMetadata = self;
       continue;
     }
@@ -2501,11 +2520,13 @@ NecessaryBindings::forFunctionInvocations(IRGenModule &IGM,
       continue;
 
     case MetadataSource::Kind::GenericLValueMetadata:
-      bindings.addTypeMetadata(getSubstSelfType(substType));
+      bindings.addTypeMetadata(getSubstSelfType(IGM.getSwiftModule(),
+                                                origType, subs));
       continue;
 
     case MetadataSource::Kind::SelfMetadata:
-      bindings.addTypeMetadata(getSubstSelfType(substType));
+      bindings.addTypeMetadata(getSubstSelfType(IGM.getSwiftModule(),
+                                                origType, subs));
       continue;
 
     case MetadataSource::Kind::SelfWitnessTable:

--- a/test/IRGen/lowered_optional_self_metadata.sil
+++ b/test/IRGen/lowered_optional_self_metadata.sil
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -emit-ir %s 
+sil_stage canonical
+
+import Swift
+
+// SR-3021: Ensure we pass the Self type metadata for Optional methods using the
+// formal Optional type and not a lowered SIL type.
+
+// CHECK-LABEL: @_TMaGSqFT_T__
+
+sil @optional_method : $@convention(method) <T> (@in_guaranteed Optional<T>) -> ()
+sil @optional_witness_method : $@convention(witness_method) <T> (@in_guaranteed Optional<T>) -> ()
+
+sil @call_optional_method_with_lowered_function : $@convention(thin) (@in_guaranteed Optional<@callee_owned (@in ()) -> @out ()>) -> () {
+entry(%x : $*Optional<@callee_owned (@in ()) -> @out ()>):
+  %f = function_ref @optional_method : $@convention(method) <T> (@in_guaranteed Optional<T>) -> ()
+  apply %f<() -> ()>(%x) : $@convention(method) <T> (@in_guaranteed Optional<T>) -> ()
+  %g = function_ref @optional_witness_method : $@convention(witness_method) <T> (@in_guaranteed Optional<T>) -> ()
+  apply %g<() -> ()>(%x) : $@convention(witness_method) <T> (@in_guaranteed Optional<T>) -> ()
+  %p = partial_apply %f<() -> ()>() : $@convention(method) <T> (@in_guaranteed Optional<T>) -> ()
+  %q = partial_apply %g<() -> ()>() : $@convention(witness_method) <T> (@in_guaranteed Optional<T>) -> ()
+  return undef : $()
+}


### PR DESCRIPTION
Now that Optional's type parameter can be lowered, we can't make the assumption that a substituted nominal type in SIL is usable as-is as a formal type. At this moment, we can at least still rely on the fact that only nominals have methods, so we can at least go up to the original unsubstituted function type, extract the Self type from there, and do formal AST type substitution on it. This is still only a stopgap solution that wouldn't necessarily work once we start allowing conformances to be added to structural types, or even constrained extensions on Optional such as 'extension <T: class, U: class> Optional<(T) -> U>, but is good enough to fix SR-3021 for the language today. We would need something like the "substituted generic signature" concept to fully fix this.
