### PR TITLE
[3.0] Implement the "occurs" check before binding type variables

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1248,6 +1248,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, TypeMatchKind kind,
       bool wantRvalue = kind == TypeMatchKind::SameType;
       if (typeVar1) {
         // Simplify the right-hand type and perform the "occurs" check.
+        typeVar1 = getRepresentative(typeVar1);
         type2 = simplifyType(type2);
         if (typeVarOccursInType(typeVar1, type2))
           return formUnsolvedResult();
@@ -1293,10 +1294,11 @@ ConstraintSystem::matchTypes(Type type1, Type type2, TypeMatchKind kind,
         return SolutionKind::Solved;
       }
 
-        // Simplify the left-hand type and perform the "occurs" check.
-        type1 = simplifyType(type1);
-        if (typeVarOccursInType(typeVar2, type1))
-          return formUnsolvedResult();
+      // Simplify the left-hand type and perform the "occurs" check.
+      typeVar2 = getRepresentative(typeVar2);
+      type1 = simplifyType(type1);
+      if (typeVarOccursInType(typeVar2, type1))
+        return formUnsolvedResult();
 
       // If we want an rvalue, get the rvalue.
       if (wantRvalue)
@@ -1316,6 +1318,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, TypeMatchKind kind,
     case TypeMatchKind::BindParamType: {
       if (typeVar2 && !typeVar1) {
         // Simplify the left-hand type and perform the "occurs" check.
+        typeVar2 = getRepresentative(typeVar2);
         type1 = simplifyType(type1);
         if (typeVarOccursInType(typeVar2, type1))
           return formUnsolvedResult();
@@ -1328,6 +1331,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, TypeMatchKind kind,
         return SolutionKind::Solved;
       } else if (typeVar1 && !typeVar2) {
         // Simplify the right-hand type and perform the "occurs" check.
+        typeVar1 = getRepresentative(typeVar1);
         type2 = simplifyType(type2);
         if (typeVarOccursInType(typeVar1, type2))
           return formUnsolvedResult();

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1162,17 +1162,6 @@ static bool allowsBridgingFromObjC(TypeChecker &tc, DeclContext *dc,
   return true;
 }
 
-/// Determine whether the given type variables occurs in the given type.
-static bool typeVarOccursInType(TypeVariableType *typeVar, Type type) {
-  SmallVector<TypeVariableType *, 4> typeVars;
-  type->getTypeVariables(typeVars);
-  for (auto referencedTypeVar : typeVars) {
-    if (referencedTypeVar == typeVar) return true;
-  }
-
-  return false;
-}
-
 ConstraintSystem::SolutionKind
 ConstraintSystem::matchTypes(Type type1, Type type2, TypeMatchKind kind,
                              unsigned flags,

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1162,6 +1162,17 @@ static bool allowsBridgingFromObjC(TypeChecker &tc, DeclContext *dc,
   return true;
 }
 
+/// Determine whether the given type variables occurs in the given type.
+static bool typeVarOccursInType(TypeVariableType *typeVar, Type type) {
+  SmallVector<TypeVariableType *, 4> typeVars;
+  type->getTypeVariables(typeVars);
+  for (auto referencedTypeVar : typeVars) {
+    if (referencedTypeVar == typeVar) return true;
+  }
+
+  return false;
+}
+
 ConstraintSystem::SolutionKind
 ConstraintSystem::matchTypes(Type type1, Type type2, TypeMatchKind kind,
                              unsigned flags,
@@ -1186,6 +1197,21 @@ ConstraintSystem::matchTypes(Type type1, Type type2, TypeMatchKind kind,
   // If the types are obviously equivalent, we're done.
   if (kind != TypeMatchKind::ConformsTo && desugar1->isEqual(desugar2))
     return SolutionKind::Solved;
+
+  auto formUnsolvedResult = [&] {
+    if (flags & TMF_GenerateConstraints) {
+      // Add a new constraint between these types. We consider the current
+      // type-matching problem to the "solved" by this addition, because
+      // this new constraint will be solved at a later point.
+      // Obviously, this must not happen at the top level, or the algorithm
+      // would not terminate.
+      addConstraint(getConstraintKind(kind), type1, type2,
+		    getConstraintLocator(locator));
+      return SolutionKind::Solved;
+    }
+
+    return SolutionKind::Unsolved;
+  };
 
   // If either (or both) types are type variables, unify the type variables.
   if (typeVar1 || typeVar2) {
@@ -1232,6 +1258,11 @@ ConstraintSystem::matchTypes(Type type1, Type type2, TypeMatchKind kind,
       // Provide a fixed type for the type variable.
       bool wantRvalue = kind == TypeMatchKind::SameType;
       if (typeVar1) {
+        // Simplify the right-hand type and perform the "occurs" check.
+        type2 = simplifyType(type2);
+        if (typeVarOccursInType(typeVar1, type2))
+          return formUnsolvedResult();
+
         // If we want an rvalue, get the rvalue.
         if (wantRvalue)
           type2 = type2->getRValueType();
@@ -1273,6 +1304,11 @@ ConstraintSystem::matchTypes(Type type1, Type type2, TypeMatchKind kind,
         return SolutionKind::Solved;
       }
 
+        // Simplify the left-hand type and perform the "occurs" check.
+        type1 = simplifyType(type1);
+        if (typeVarOccursInType(typeVar2, type1))
+          return formUnsolvedResult();
+
       // If we want an rvalue, get the rvalue.
       if (wantRvalue)
         type1 = type1->getRValueType();
@@ -1290,14 +1326,24 @@ ConstraintSystem::matchTypes(Type type1, Type type2, TypeMatchKind kind,
 
     case TypeMatchKind::BindParamType: {
       if (typeVar2 && !typeVar1) {
-        if (auto *iot = dyn_cast<InOutType>(desugar1)) {
+        // Simplify the left-hand type and perform the "occurs" check.
+        type1 = simplifyType(type1);
+        if (typeVarOccursInType(typeVar2, type1))
+          return formUnsolvedResult();
+
+        if (auto *iot = type1->getAs<InOutType>()) {
           assignFixedType(typeVar2, LValueType::get(iot->getObjectType()));
         } else {
           assignFixedType(typeVar2, type1);
         }
         return SolutionKind::Solved;
       } else if (typeVar1 && !typeVar2) {
-        if (auto *lvt = dyn_cast<LValueType>(desugar2)) {
+        // Simplify the right-hand type and perform the "occurs" check.
+        type2 = simplifyType(type2);
+        if (typeVarOccursInType(typeVar1, type2))
+          return formUnsolvedResult();
+
+        if (auto *lvt = type2->getAs<LValueType>()) {
           assignFixedType(typeVar1, InOutType::get(lvt->getObjectType()));
         } else {
           assignFixedType(typeVar1, type2);

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -638,27 +638,6 @@ namespace {
   };
 }
 
-/// Determine whether the given type variables occurs in the given type.
-static bool typeVarOccursInType(ConstraintSystem &cs, TypeVariableType *typeVar,
-                                Type type, bool &involvesOtherTypeVariables) {
-  SmallVector<TypeVariableType *, 4> typeVars;
-  type->getTypeVariables(typeVars);
-  bool result = false;
-  for (auto referencedTypeVar : typeVars) {
-    if (cs.getRepresentative(referencedTypeVar) == typeVar) {
-      result = true;
-      if (involvesOtherTypeVariables)
-        break;
-
-      continue;
-    }
-
-    involvesOtherTypeVariables = true;
-  }
-
-  return result;
-}
-
 /// \brief Return whether a relational constraint between a type variable and a
 /// trivial wrapper type (autoclosure, unary tuple) should result in the type
 /// variable being potentially bound to the value type, as opposed to the
@@ -859,9 +838,10 @@ static PotentialBindings getPotentialBindings(ConstraintSystem &cs,
       // If this variable is in the left-hand side, it is fully bound.
       // FIXME: Can we avoid simplification here by walking the graph? Is it
       // worthwhile?
-      if (typeVarOccursInType(cs, typeVar,
-                              cs.simplifyType(constraint->getFirstType()),
-                              result.InvolvesTypeVariables)) {
+      if (ConstraintSystem::typeVarOccursInType(
+            typeVar,
+            cs.simplifyType(constraint->getFirstType()),
+            &result.InvolvesTypeVariables)) {
         result.FullyBound = true;
       }
       continue;
@@ -873,18 +853,20 @@ static PotentialBindings getPotentialBindings(ConstraintSystem &cs,
       // If our type variable shows up in the base type, there's
       // nothing to do.
       // FIXME: Can we avoid simplification here?
-      if (typeVarOccursInType(cs, typeVar, 
-                              cs.simplifyType(constraint->getFirstType()),
-                              result.InvolvesTypeVariables)) {
+      if (ConstraintSystem::typeVarOccursInType(
+            typeVar,
+            cs.simplifyType(constraint->getFirstType()),
+            &result.InvolvesTypeVariables)) {
         continue;
       }
       
       // If the type variable is in the list of member type
       // variables, it is fully bound.
       // FIXME: Can we avoid simplification here?
-      if (typeVarOccursInType(cs, typeVar, 
-                              cs.simplifyType(constraint->getSecondType()),
-                              result.InvolvesTypeVariables)) {
+      if (ConstraintSystem::typeVarOccursInType(
+            typeVar,
+            cs.simplifyType(constraint->getSecondType()),
+            &result.InvolvesTypeVariables)) {
         result.FullyBound = true;
       }
       continue;
@@ -920,9 +902,11 @@ static PotentialBindings getPotentialBindings(ConstraintSystem &cs,
     } else {
       // Can't infer anything.
       if (!result.InvolvesTypeVariables)
-        typeVarOccursInType(cs, typeVar, first, result.InvolvesTypeVariables);
+        ConstraintSystem::typeVarOccursInType(typeVar, first,
+                                              &result.InvolvesTypeVariables);
       if (!result.InvolvesTypeVariables)
-        typeVarOccursInType(cs, typeVar, second, result.InvolvesTypeVariables);
+        ConstraintSystem::typeVarOccursInType(typeVar, second,
+                                              &result.InvolvesTypeVariables);
       continue;
     }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -103,14 +103,6 @@ bool ConstraintSystem::typeVarOccursInType(TypeVariableType *typeVar,
 void ConstraintSystem::assignFixedType(TypeVariableType *typeVar, Type type,
                                        bool updateState) {
   
-  // If the type to be fixed is an optional type that wraps the type parameter
-  // itself, we do not want to go through with the assignment. To do so would
-  // force the type variable to be adjacent to itself.
-  if (auto optValueType = type->getOptionalObjectType()) {
-    if (optValueType->isEqual(typeVar))
-      return;
-  }
-  
   typeVar->getImpl().assignFixedType(type, getSavedBindings());
 
   if (!updateState)

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1662,17 +1662,12 @@ Type ConstraintSystem::lookThroughImplicitlyUnwrappedOptionalType(Type type) {
   return Type();
 }
 
-Type ConstraintSystem::simplifyType(Type type,
-       llvm::SmallPtrSet<TypeVariableType *, 16> &substituting) {
+Type ConstraintSystem::simplifyType(Type type) {
   return type.transform([&](Type type) -> Type {
     if (auto tvt = dyn_cast<TypeVariableType>(type.getPointer())) {
       tvt = getRepresentative(tvt);
       if (auto fixed = getFixedType(tvt)) {
-        if (substituting.insert(tvt).second) {
-          auto result = simplifyType(fixed, substituting);
-          substituting.erase(tvt);
-          return result;
-        }
+        return simplifyType(fixed);
       }
       
       return tvt;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -77,6 +77,29 @@ void ConstraintSystem::mergeEquivalenceClasses(TypeVariableType *typeVar1,
   }
 }
 
+/// Determine whether the given type variables occurs in the given type.
+bool ConstraintSystem::typeVarOccursInType(TypeVariableType *typeVar,
+                                           Type type,
+                                           bool *involvesOtherTypeVariables) {
+  SmallVector<TypeVariableType *, 4> typeVars;
+  type->getTypeVariables(typeVars);
+  bool result = false;
+  for (auto referencedTypeVar : typeVars) {
+    if (referencedTypeVar == typeVar) {
+      result = true;
+      if (!involvesOtherTypeVariables || *involvesOtherTypeVariables)
+        break;
+
+      continue;
+    }
+
+    if (involvesOtherTypeVariables)
+      *involvesOtherTypeVariables = true;
+  }
+
+  return result;
+}
+
 void ConstraintSystem::assignFixedType(TypeVariableType *typeVar, Type type,
                                        bool updateState) {
   

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1883,10 +1883,7 @@ public:
   ///
   /// The resulting types can be compared canonically, so long as additional
   /// type equivalence requirements aren't introduced between comparisons.
-  Type simplifyType(Type type){
-    llvm::SmallPtrSet<TypeVariableType *, 16> substituting;
-   return simplifyType(type, substituting);
-  }
+  Type simplifyType(Type type);
 
   /// Given a ValueMember, UnresolvedValueMember, or TypeMember constraint,
   /// perform a lookup into the specified base type to find a candidate list.
@@ -1902,22 +1899,7 @@ public:
                                          ConstraintLocator *memberLocator,
                                          bool includeInaccessibleMembers);
 
-private:
-
-  /// \brief Simplify a type, by replacing type variables with either their
-  /// fixed types (if available) or their representatives.
-  ///
-  /// \param type the type to be simplified.
-  ///
-  /// \param substituting the set of type variables that we're already
-  /// substituting for. These type variables will not be substituted again,
-  /// to avoid infinite recursion.
-  ///
-  /// The resulting types can be compared canonically, so long as additional
-  /// type equivalence requirements aren't introduced between comparisons.
-  Type simplifyType(Type type,
-                    llvm::SmallPtrSet<TypeVariableType *, 16> &substituting);
-  
+private:  
   /// \brief Attempt to simplify the given construction constraint.
   ///
   /// \param valueType The type being constructed.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1532,6 +1532,15 @@ public:
                              bool wantRValue,
                              bool retainParens = false);
 
+  /// Determine whether the given type variable occurs within the given type.
+  ///
+  /// This routine assumes that the type has already been fully simplified.
+  ///
+  /// \param involvesOtherTypeVariables if non-null, records whether any other
+  /// type variables are present in the type.
+  static bool typeVarOccursInType(TypeVariableType *typeVar, Type type,
+                                  bool *involvesOtherTypeVariables = nullptr);
+
   /// \brief Assign a fixed type to the given type variable.
   ///
   /// \param typeVar The type variable to bind.

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -402,3 +402,8 @@ func testFixItNested() {
     FullyGeneric<Any>()
   )
 }
+
+// rdar://problem/26845038
+func occursCheck26845038(a: [Int]) {
+  _ = Array(a)[0]
+}

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -141,3 +141,9 @@ protocol PPPP {
 func compare<T: PPPP>(v: T, u: T!) -> Bool {
   return v ++++ u
 }
+
+func sr2752(x: String?, y: String?) {
+  _ = x.map { xx in
+    y.map { _ in "" } ?? "\(xx)"
+  }
+}

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar19343997.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar19343997.swift
@@ -1,0 +1,16 @@
+// RUN: not %target-swift-frontend %s -parse
+
+func ignore<T>(_ parser: (String) -> (T, String)?) -> (String) -> ((), String)? {
+	return { parser($0).map { _ in () } }
+}
+func | <T> (left: (String) -> (T, String)?, right: (String) -> ((), String)?) -> (String) -> (T?, String)? {
+	return { _ in nil }
+}
+
+ignore(" " | "\r" | "\t" | "\n")
+
+// Related: rdar://problem/19924870
+func unit<T>(_ x: T) -> T? { return x }
+func f() -> Int? {
+	return unit(1) ?? unit(2).map { 1 } ?? nil
+}

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar20771765.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar20771765.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend %s -parse
+
+enum Pattern {
+case Specific(title: String?, label: String?, value: AnyObject?)
+case General(String)
+}
+
+extension Pattern : CustomDebugStringConvertible {
+  var debugDescription: String {
+    switch(self) {
+    case let .Specific(title, label, value):
+      let elements = [
+        title.map { "title: \(String(reflecting: $0))" },
+        label.map { "label: \(String(reflecting: $0))" },
+        value.map { "value: \(String(reflecting: $0))" }
+      ].flatMap { $0 }
+      return "x"
+    case let .General(s):
+      return ".General(\(String(reflecting: s))))"
+    }
+  }
+}

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar27879334.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar27879334.swift
@@ -1,0 +1,11 @@
+// RUN: not %target-swift-frontend %s -parse
+
+class N {}
+
+class C {
+  var number: N!
+  var int64: Int64 = 0
+}
+
+let c: C? = C()
+_ = (c!.number ?? 0) == (c?.int64 ?? 0)

--- a/validation-test/Sema/type_checker_crashers_fixed/sr1512.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/sr1512.swift
@@ -1,0 +1,57 @@
+// RUN: not %target-swift-frontend %s -parse
+
+public struct CollectionWrapper<C:RangeReplaceableCollection where C.Index:Comparable> {
+
+	public private(set) var collection : C
+
+	private init(wrappingCollection: C) {
+		collection = wrappingCollection
+	}
+}
+
+// Export Collection API
+
+extension CollectionWrapper : Collection {
+
+	public var startIndex: C.Index { return collection.startIndex }
+	public var endIndex  : C.Index { return collection.endIndex   }
+
+	public func makeIterator() -> C.Iterator {
+		return collection.makeIterator()
+	}
+
+	public subscript (position: C.Index) -> C.Iterator.Element { return collection[position] }
+
+	public subscript (bounds: Range<C.Index>) -> C.SubSequence { return collection[bounds] }
+
+	public func prefix(upTo end: C.Index) -> C.SubSequence { return collection.prefix(upTo: end) }
+
+	public func suffix(from start: C.Index) -> C.SubSequence { return collection.suffix(from: start) }
+
+	public func prefix(through position: C.Index) -> C.SubSequence { return collection.prefix(through: position) }
+
+	public var isEmpty: Bool { return collection.isEmpty }
+
+    public var count: C.IndexDistance { return collection.count }
+
+    public var first: C.Iterator.Element? { return collection.first }
+
+	public func index(after idx: C.Index) -> C.Index { return collection.index(after: idx) }
+
+	public func index(_ idx: C.Index, offsetBy offset: C.IndexDistance, limitedBy limit: C.Index? = nil) -> C.Index {
+		return collection.index(idx, offsetBy: offset, limitedBy: limit)
+	}
+}
+
+// Export RangeReplaceableCollection API
+
+extension CollectionWrapper : RangeReplaceableCollection {
+
+	public init() {
+		self.init(wrappingCollection: C())
+	}
+
+	public mutating func replaceSubrange<D : Collection where D.Iterator.Element == C.Iterator.Element>(_ subRange: Range<C.Index>, with newElements: D) {
+		collection.replaceSubrange(subRange, with: newElements)
+	}
+}

--- a/validation-test/Sema/type_checker_crashers_fixed/sr1902.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/sr1902.swift
@@ -1,0 +1,22 @@
+// RUN: not %target-swift-frontend %s -parse
+struct A {
+    var a: Int32 { return 0 }
+}
+
+struct B {
+    var b: Int64 { return 0 }
+}
+
+struct C {
+    var c: Int64 { return 0 }
+}
+
+class S {
+    var a: A? = A()
+    var b: B? = B()
+    var c: C? = C()
+    var result: Int64? { return a?.a ?? b?.b ?? c?.c }
+}
+
+let s = S()
+print(s.result)

--- a/validation-test/Sema/type_checker_crashers_fixed/sr2635.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/sr2635.swift
@@ -1,0 +1,62 @@
+// RUN: %target-swift-frontend %s -parse
+
+//
+//  main.swift
+//  TypeBasics
+//
+//  Created by David Scrève on 16/11/2014.
+//  Copyright (c) 2014 David Scrève. All rights reserved.
+//
+
+let constante : String = "Hello World"
+
+
+let constante2 = "Hello World"
+
+let caractere : Character = Array(constante.characters)[0]
+
+let caractere2 : Character = "A"
+
+var variable : String
+
+
+var chaine = "Bonjour le monde"
+
+
+var nombre  : Int = 3
+
+nombre=5
+
+var valeur : Int32
+
+valeur = Int32(nombre)
+
+
+
+print("la valeur vaut : \(valeur)")
+
+
+if (valeur > 3)
+{
+    print(">3")
+}
+else
+{
+    print("<=3")
+}
+
+switch(valeur)
+{
+case 0:
+    print("0");
+    
+case 1,2:
+    print("1");
+    
+case 10...100:
+    print("Interval");
+    
+default:
+    print("default");
+}
+

--- a/validation-test/compiler_crashers_fixed/28362-swift-constraints-constraintgraphnode-getadjacency.swift
+++ b/validation-test/compiler_crashers_fixed/28362-swift-constraints-constraintgraphnode-getadjacency.swift
@@ -5,6 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
 [1,{[1,{[]

--- a/validation-test/compiler_crashers_fixed/28400-swift-nominaltypedecl-prepareextensions.swift
+++ b/validation-test/compiler_crashers_fixed/28400-swift-nominaltypedecl-prepareextensions.swift
@@ -1,0 +1,14 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: %target-swift-frontend %s -parse
+// Discovered by https://github.com/airspeedswift (airspeedswift)
+
+let s1: Set<Int>? = []
+let s2: Set<Int>? = []
+let s3: Set<Int>? = []
+let x = s1 ?? s2 ?? s3 ?? []


### PR DESCRIPTION
<!-- What's in this pull request? -->

Implement the "occurs" check at the appropriate place in the type checker, prior to binding a type variable to a concrete type. This fixes a significant number of type checker crashers, including both obviously-invalid and valid cases.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-2351](https://bugs.swift.org/browse/SR-2351), rdar://problem/27879334, rdar://problem/26845038, SR-1512, SR-1902, SR2635,
SR-2852, SR-2766, rdar://problem/19343997, rdar://problem/19924870, and rdar://problem/20771765.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
