### PR TITLE
IRGen: Don't emit reflection metadata for builtin types unless we're …

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -180,7 +180,7 @@ protected:
   // Collect any builtin types referenced from this type.
   void addBuiltinTypeRefs(CanType type) {
     type.visit([&](Type t) {
-      if (t->is<BuiltinType>())
+      if (IGM.getSwiftModule()->isStdlibModule() && t->is<BuiltinType>())
         IGM.BuiltinTypes.insert(CanType(t));
 
       // We need size/alignment information for imported value types,


### PR DESCRIPTION
Fixes rdar://problem/28924516.
