### PR TITLE
[cmake]: Ensure that swift-api-digester rebuilds before tests are run.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,7 +41,8 @@ function(get_test_dependencies SDK result_var_name)
 
   set(deps_binaries
       swift swift-ide-test sil-opt swift-llvm-opt swift-demangle sil-extract
-      lldb-moduleimport-test swift-reflection-dump swift-remoteast-test)
+      lldb-moduleimport-test swift-reflection-dump swift-remoteast-test
+      swift-api-digester)
   if(NOT SWIFT_BUILT_STANDALONE)
     list(APPEND deps_binaries FileCheck arcmt-test c-arcmt-test c-index-test
          clang llc llvm-cov llvm-dwarfdump llvm-link llvm-profdata not)


### PR DESCRIPTION
Running `ninja check-swift` didn't rebuild `swift-api-digester`.

Fixes rdar://problem/28953348
