### PR TITLE
Revert "[cmake]: Ensure that swift-api-digester rebuilds before tests are run."

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,8 +41,7 @@ function(get_test_dependencies SDK result_var_name)
 
   set(deps_binaries
       swift swift-ide-test sil-opt swift-llvm-opt swift-demangle sil-extract
-      lldb-moduleimport-test swift-reflection-dump swift-remoteast-test
-      swift-api-digester)
+      lldb-moduleimport-test swift-reflection-dump swift-remoteast-test)
   if(NOT SWIFT_BUILT_STANDALONE)
     list(APPEND deps_binaries FileCheck arcmt-test c-arcmt-test c-index-test
          clang llc llvm-cov llvm-dwarfdump llvm-link llvm-profdata not)


### PR DESCRIPTION
Reverts apple/swift#5505

Due to this error, I am reverting PR apple/swift#5505. 

```
--- check-swift-validation-linux-x86_64 ---
ninja: error: 'bin/swift-api-digester', needed by 'test/CMakeFiles/check-swift-validation-linux-x86_64', missing and no known rule to make it
-- check-swift-validation-linux-x86_64 finished --

```
