### PR TITLE
[3.0]: [build-script-impl]: Fixes version number on Linux from 3.0 to 3.0.x

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1808,6 +1808,9 @@ for host in "${ALL_HOSTS[@]}"; do
 
     case "${COMPILER_VENDOR}" in
         none)
+            swift_cmake_options=(
+                -DSWIFT_VERSION="${SWIFT_USER_VISIBLE_VERSION}"
+            )
             ;;
         apple)
             llvm_cmake_options=(


### PR DESCRIPTION
Linux reports 3.0 instead of 3.0.x.

Testing then asking to merge.
