### PR TITLE
IRGen: Decend into superclass constraint types when building exemplar archetypes

### DIFF
--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -456,11 +456,6 @@ OwnedAddress irgen::projectPhysicalClassMemberAddress(IRGenFunction &IGF,
   case FieldAccess::ConstantDirect: {
     Address baseAddr(base, baseClassTI.getHeapAlignment(IGF.IGM, baseType));
     auto &element = baseClassTI.getElements(IGF.IGM, baseType)[fieldIndex];
-    // We might run into a case where the type of baseAddr is an opaque pointer.
-    if (baseAddr->getType() != baseClassTI.getStorageType()) {
-      baseAddr = IGF.Builder.CreateBitCast(baseAddr,
-                                           baseClassTI.getStorageType());
-    }
     Address memberAddr = element.project(IGF, baseAddr, None);
     // We may need to bitcast the address if the field is of a generic type.
     if (memberAddr.getType()->getElementType() != fieldTI.getStorageType())


### PR DESCRIPTION
When building exemplar archetypes we would build different exemplars for the
archetype "S: A<T>" of the example below because we would just use the pointer
to the class type ": A<T>" instead of profiling (decending) into the type.
This caused us to end up with different exemplar types for different uses of M
and ultimately several llvm type instances for the same generic type M<S,T>.

 class A<T> {}
 class M<T, S: A<T>> {...}

Also reverts "IRGen: Cast the type of class pointer to the storage type"
 from commit 2d73b3cef29f7141b961451191ea35825a26f7f7 but keeps its test case.

Proper fix for rdar//28684642
