### PR TITLE
[PrintAsObjC] Use of imported generics require the full definition.

### DIFF
--- a/test/PrintAsObjC/Inputs/custom-modules/SingleGenericClass.h
+++ b/test/PrintAsObjC/Inputs/custom-modules/SingleGenericClass.h
@@ -1,0 +1,6 @@
+// This file is meant to be included with modules turned off, compiled against
+// the fake clang-importer-sdk.
+#import <Foundation.h>
+
+@interface SingleImportedObjCGeneric<A> : NSObject
+@end

--- a/test/PrintAsObjC/Inputs/custom-modules/module.map
+++ b/test/PrintAsObjC/Inputs/custom-modules/module.map
@@ -19,6 +19,11 @@ module Base {
   }
 }
 
+module SingleGenericClass {
+  header "SingleGenericClass.h"
+  export *
+}
+
 module OverrideBase [system] {
   header "override.h"
   export *

--- a/test/PrintAsObjC/lit.local.cfg
+++ b/test/PrintAsObjC/lit.local.cfg
@@ -5,5 +5,6 @@ config.substitutions.insert(0, ('%check-in-clang',
   '%%clang -fsyntax-only -x objective-c-header -fobjc-arc -fmodules '
   '-fmodules-validate-system-headers '
   '-Weverything -Werror -Wno-unused-macros -Wno-incomplete-module '
+  '-Wno-auto-import '
   '-I %%clang-include-dir '
   '-isysroot %r/Inputs/clang-importer-sdk' % config.test_source_root) )


### PR DESCRIPTION
I'm not sure why this didn't occur to me in 8282160d: of course if you see a generic type with arguments, you need to see the `@interface` for that type in order to supply the arguments. Maybe I was thinking the generated interface would automatically import anything the module itself imports, but that hasn't ever been true.

rdar://problem/28738008
