### PR TITLE
[SILOptimizer] Add ctlz support to constant propagation

### DIFF
--- a/test/SILOptimizer/constant_propagation.sil
+++ b/test/SILOptimizer/constant_propagation.sil
@@ -19,6 +19,36 @@ struct UInt64 {
   var value: Builtin.Int64
 }
 
+sil @count_leading_zeros_corner_case : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+ %zero64 = integer_literal $Builtin.Int64, 0
+ %zero1 = integer_literal $Builtin.Int1, 0
+ %ctlz = builtin "int_ctlz_Int64"(%zero64 : $Builtin.Int64, %zero1 : $Builtin.Int1) : $Builtin.Int64
+ return %ctlz : $Builtin.Int64
+ 
+// CHECK-LABEL: sil @count_leading_zeros_corner_case
+// CHECK-NOT: integer_literal $Builtin.Int64, 0
+// CHECK-NOT: integer_literal $Builtin.Int1, 0
+// CHECK-NOT: builtin
+// CHECK: [[RES:%.*]] = integer_literal $Builtin.Int64, 64
+// CHECK-NEXT: return [[RES]] : $Builtin.Int64
+}
+
+sil @count_leading_zeros : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+ %zero64 = integer_literal $Builtin.Int64, 2
+ %zero1 = integer_literal $Builtin.Int1, 0
+ %ctlz = builtin "int_ctlz_Int64"(%zero64 : $Builtin.Int64, %zero1 : $Builtin.Int1) : $Builtin.Int64
+ return %ctlz : $Builtin.Int64
+ 
+// CHECK-LABEL: sil @count_leading_zeros
+// CHECK-NOT: integer_literal $Builtin.Int64, 2
+// CHECK-NOT: integer_literal $Builtin.Int1, 0
+// CHECK-NOT: builtin
+// CHECK: [[RES:%.*]] = integer_literal $Builtin.Int64, 62
+// CHECK-NEXT: return [[RES]] : $Builtin.Int64
+}
+
 // Compute an expression using a chain of arithmetic with overflow instructions: 2 * (2 + 3) - 3
 sil @fold_arithmetic_with_overflow : $@convention(thin) () -> Builtin.Int64 {
 bb0:


### PR DESCRIPTION
radar rdar://problem/29004328

The Ctlz builtin is used by the new integer prototype. Since it is not constant folded, the value is computed dynamically. This in turn results in a more complex CFG.

This PR adds a peephole optimization for computing int_ctlz with constant arguments + adds test-cases to make sure it works
