### PR TITLE
Add some useful peepholes for the new integer prototype

### DIFF
--- a/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
+++ b/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
@@ -524,6 +524,17 @@ static SILValue simplifyBuiltin(BuiltinInst *BI) {
         return val3;
     }
   }
+  break;
+  case BuiltinValueKind::Shl:
+  case BuiltinValueKind::AShr:
+  case BuiltinValueKind::LShr:
+    auto *RHS = dyn_cast<IntegerLiteralInst>(Args[1]);
+    if (RHS && !RHS->getValue()) {
+      // Shifting a value by 0 bits is equivalent to the value itself.
+      auto LHS = Args[0];
+      return LHS;
+    }
+    break;
   }
   return SILValue();
 }

--- a/test/SILOptimizer/constant_propagation.sil
+++ b/test/SILOptimizer/constant_propagation.sil
@@ -214,7 +214,7 @@ bb0:
   %12 = integer_literal $Builtin.Int32, 12
   %14 = builtin "cmp_ne_Int32"(%11 : $Builtin.Int32, %12 : $Builtin.Int32) : $Builtin.Int1
   %16 = builtin "cmp_sgt_Int32"(%12 : $Builtin.Int32, %11 : $Builtin.Int32) : $Builtin.Int1
-  %18 = builtin "cmp_ult_Int32"(%12 : $Builtin.Int32, %11 : $Builtin.Int32) : $Builtin.Int1
+  %17 = builtin "cmp_ult_Int32"(%12 : $Builtin.Int32, %11 : $Builtin.Int32) : $Builtin.Int1
   %5 = tuple ()
   return %5 : $()
 // CHECK-LABEL: sil @testFoldingIntBinaryPredicates
@@ -223,6 +223,31 @@ bb0:
 // CHECK-NEXT: integer_literal $Builtin.Int1, -1
 // CHECK-NEXT: integer_literal $Builtin.Int1, 0
 // CHECK-NEXT: integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
+}
+
+sil @testFoldingUnsignedIntComparisons : $@convention(thin) (Builtin.Int32) -> () {
+bb0(%0 : $Builtin.Int32):
+  %2 = integer_literal $Builtin.Int1, 0
+  %3 = integer_literal $Builtin.Int32, 0
+  // unsigned value is never less then 0
+  %18 = builtin "cmp_ult_Int32"(%0 : $Builtin.Int32, %3 : $Builtin.Int32) : $Builtin.Int1
+  // unsigned value is always >= 0
+  %19 = builtin "cmp_uge_Int32"(%0 : $Builtin.Int32, %3 : $Builtin.Int32) : $Builtin.Int1
+  // 0 is always <= an unsigned value
+  %20 = builtin "cmp_ule_Int32"(%3 : $Builtin.Int32, %0 : $Builtin.Int32) : $Builtin.Int1
+  // 0 is never greater than an unsigned value
+  %21 = builtin "cmp_ugt_Int32"(%3 : $Builtin.Int32, %0 : $Builtin.Int32) : $Builtin.Int1
+  %5 = tuple ()
+  return %5 : $()
+// CHECK-LABEL: sil @testFoldingUnsignedIntComparisons
+// CHECK: bb0
+// CHECK-NEXT: integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: integer_literal $Builtin.Int1, 0
 // CHECK-NEXT: tuple
 // CHECK-NEXT: return
 }

--- a/test/SILOptimizer/sil_simplify_instrs.sil
+++ b/test/SILOptimizer/sil_simplify_instrs.sil
@@ -263,3 +263,20 @@ bb0(%0 : $BitwiseStruct1):
   %4 = tuple (%1 : $BitwiseStruct1, %3 : $BitwiseStruct1)
   return %4 : $(BitwiseStruct1, BitwiseStruct1)
 }
+
+// simplify_shifts_by_zero
+sil @simplify_shifts_by_zero : $@convention(thin) (Builtin.Int64) -> (Builtin.Int64, Builtin.Int64, Builtin.Int64) {
+bb0(%0 : $Builtin.Int64):
+  %1 = integer_literal $Builtin.Int64, 0
+  %2 = builtin "ashr_Int64"(%0 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int64
+  %3 = builtin "lshr_Int64"(%0 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int64
+  %4 = builtin "shl_Int64"(%0 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int64
+  %5 = tuple (%2 : $Builtin.Int64, %3 : $Builtin.Int64, %4 : $Builtin.Int64)
+  return %5 : $(Builtin.Int64, Builtin.Int64, Builtin.Int64)
+
+// CHECK-LABEL: sil @simplify_shifts_by_zero
+// CHECK: bb0
+// CHECK-NEXT: %1 = tuple (%0 : $Builtin.Int64, %0 : $Builtin.Int64, %0 : $Builtin.Int64)
+// CHECK-NEXT: return %1 : $(Builtin.Int64, Builtin.Int64, Builtin.Int64)
+}
+


### PR DESCRIPTION
Add peepholes for:
- shifts by zero bits
- unsigned comparisons with zero
