### PR TITLE
Di fixes

### DIFF
--- a/include/swift/SIL/SILLocation.h
+++ b/include/swift/SIL/SILLocation.h
@@ -90,8 +90,13 @@ public:
     const char *Filename;
 
     DebugLoc(unsigned Line = 0, unsigned Column = 0,
-             const char *Filename = nullptr) : Line(Line), Column(Column),
-                                               Filename(Filename) { }
+             const char *Filename = nullptr)
+        : Line(Line), Column(Column), Filename(Filename) {}
+
+    inline bool operator==(const DebugLoc &R) const {
+      return Line == R.Line && Column == R.Column &&
+             StringRef(Filename).equals(R.Filename);
+    }
   };
 
 protected:

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -1178,11 +1178,18 @@ collectClassSelfUses(SILValue ClassPointer, SILType MemorySILType,
       collectUses(REAI, EltNumbering[REAI->getField()]);
       continue;
     }
-    
-    // releases of self are tracked as a release (but retains are just treated
-    // like a normal 'load' use).  In the case of a failing initializer, the
-    // release on the exit path needs to cleanup the partially initialized
-    // elements.
+
+    // retains of self in class constructors can be ignored since we do not care
+    // about the retain that we are producing, but rather the consumer of the
+    // retain. This /should/ be true today and will be verified as true in
+    // Semantic SIL.
+    if (isa<StrongRetainInst>(User)) {
+      continue;
+    }
+
+    // releases of self are tracked as a release. In the case of a failing
+    // initializer, the release on the exit path needs to cleanup the partially
+    // initialized elements.
     if (isa<StrongReleaseInst>(User)) {
       Releases.push_back(User);
       continue;

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -639,6 +639,7 @@ bool LifetimeChecker::isBlockIsReachableFromEntry(SILBasicBlock *BB) {
   return BlocksReachableFromEntry.count(BB);
 }
 
+llvm::cl::opt<bool> VisitDebugInfoLocs("definite-init-visit-debuginfo-locs");
 
 /// shouldEmitError - Check to see if we've already emitted an error at the
 /// specified instruction.  If so, return false.  If not, remember the
@@ -652,12 +653,40 @@ bool LifetimeChecker::shouldEmitError(SILInstruction *Inst) {
     return false;
 
   // Check to see if we've already emitted an error at this location.  If so,
-  // swallow the error.
+  // swallow the error. This is a policy decision.
   SILLocation InstLoc = Inst->getLoc();
-  if (llvm::any_of(EmittedErrorLocs, [&](SILLocation L) -> bool {
-        return L.getSourceLoc() == InstLoc.getSourceLoc();
-      }))
+  SourceLoc InstSourceLoc = InstLoc.getSourceLoc();
+
+  // If we have a real source loc, compare against the other source locs that we
+  // have and return early.
+  if (InstSourceLoc != SourceLoc()) {
+    if (llvm::any_of(EmittedErrorLocs, [&](SILLocation L) -> bool {
+          return L.getSourceLoc() == InstSourceLoc;
+        }))
+      return false;
+    EmittedErrorLocs.push_back(InstLoc);
+    return true;
+  }
+
+  // Otherwise, if we are not supposed to visit debug info locs, just return
+  // true. This means we either had an invalid source loc or a debug info
+  // loc. In either case, we will get back an invalid SourceLoc.
+  if (!VisitDebugInfoLocs || !InstLoc.isDebugInfoLoc()) {
+    EmittedErrorLocs.push_back(InstLoc);
+    return true;
+  }
+
+  // Ok, at this point we know that InstSourceLoc is null and the user asked us
+  // to also check DebugInfo locations.
+  auto &SourceMgr = Inst->getModule().getASTContext().SourceMgr;
+  SILLocation::DebugLoc InstDebugLoc = InstLoc.decodeDebugLoc(SourceMgr);
+  if (llvm::any_of(EmittedErrorLocs, [&](SILLocation Loc) -> bool {
+        if (!Loc.isDebugInfoLoc())
+          return false;
+        return InstDebugLoc == Loc.decodeDebugLoc(SourceMgr);
+      })) {
     return false;
+  }
 
   EmittedErrorLocs.push_back(InstLoc);
   return true;

--- a/test/SILOptimizer/definite_init_uselist_ordering.sil
+++ b/test/SILOptimizer/definite_init_uselist_ordering.sil
@@ -1,0 +1,53 @@
+// RUN: %target-sil-opt -definite-init-visit-debuginfo-locs -enable-sil-verify-all %s -definite-init -verify
+
+sil_stage canonical
+
+import Builtin
+
+// Make sure that no matter the order in which we parse the following sil, we
+// ignore the strong_retain and give the same message.
+class MultipleInitBase {
+  init()
+  init(i: Builtin.Int32)
+  deinit
+}
+
+class MultipleInitDerived : MultipleInitBase {
+  override init()
+  deinit
+  override init(i: Builtin.Int32)
+}
+
+sil_scope 0 { loc "test/SILOptimizer/definite_init_uselist_ordering.sil":1073:72 parent @return_before_strongretain : $@convention(method) (@owned MultipleInitDerived) -> @owned MultipleInitDerived }
+
+sil hidden @return_before_strongretain : $@convention(method) (@owned MultipleInitDerived) -> @owned MultipleInitDerived {
+bb0(%0 : $MultipleInitDerived):
+  %1 = alloc_stack $MultipleInitDerived, let, name "self"
+  %2 = mark_uninitialized [derivedself] %1 : $*MultipleInitDerived
+  store %0 to %2 : $*MultipleInitDerived
+  %4 = load %2 : $*MultipleInitDerived
+  br bb1
+
+bb2:
+  destroy_addr %2 : $*MultipleInitDerived
+  dealloc_stack %1 : $*MultipleInitDerived
+  return %4 : $MultipleInitDerived, loc "test/SILOptimizer/definite_init_uselist_ordering.sil":1098:3, scope 0 // expected-error {{super.init isn't called on all paths before returning from initializer}}
+
+bb1:
+  strong_retain %4 : $MultipleInitDerived, loc "test/SILOptimizer/definite_init_uselist_ordering.sil":1097:3, scope 0
+  br bb2
+}
+
+sil_scope 1 { loc "test/SILOptimizer/definite_init_uselist_ordering.sil":1093:72 parent @strongretain_before_return : $@convention(method) (@owned MultipleInitDerived) -> @owned MultipleInitDerived }
+
+sil hidden @strongretain_before_return : $@convention(method) (@owned MultipleInitDerived) -> @owned MultipleInitDerived {
+bb0(%0 : $MultipleInitDerived):
+  %1 = alloc_stack $MultipleInitDerived, let, name "self", loc "test/SILOptimizer/definite_init_uselist_ordering.sil":1105:8, scope 1
+  %2 = mark_uninitialized [derivedself] %1 : $*MultipleInitDerived, loc "test/SILOptimizer/definite_init_uselist_ordering.sil":1106:8, scope 1
+  store %0 to %2 : $*MultipleInitDerived, loc "test/SILOptimizer/definite_init_uselist_ordering.sil":1107:3, scope 1
+  %4 = load %2 : $*MultipleInitDerived, loc "test/SILOptimizer/definite_init_uselist_ordering.sil":1108:3, scope 1
+  strong_retain %4 : $MultipleInitDerived, loc "test/SILOptimizer/definite_init_uselist_ordering.sil":1109:3, scope 1
+  destroy_addr %2 : $*MultipleInitDerived, loc "test/SILOptimizer/definite_init_uselist_ordering.sil":1109:3, scope 1
+  dealloc_stack %1 : $*MultipleInitDerived, loc "test/SILOptimizer/definite_init_uselist_ordering.sil":1109:3, scope 1
+  return %4 : $MultipleInitDerived, loc "test/SILOptimizer/definite_init_uselist_ordering.sil":1109:3, scope 1 // expected-error {{super.init isn't called on all paths before returning from initializer}}
+}


### PR DESCRIPTION
[DI] When checking class inits for uses of self, ignore `strong_retain`.

This specific issue came up due to my SILGen changes for `copy_value`,
`destroy_value`. Specifically, we used to emit the diagnostic:

```
super.init isn't called on all paths before returning from initializer.
```

After my change, we began to emit:

```
'self' used before super.init call
```

Since the code was:

```
init() {}
```

there is clearly no use, so the new error is incorrect or at minimum
misleading. When I investigated why the change in diagnostic happened, it was
because as a result of my SILGen change, the order of the `strong_retain` and
`return` in the use-list swapped in the following code:

```
%1 = load %0 : $*MultipleInitDerived
strong_retain %1 : $MultipleInitDerived
return %1 : $MultipleInitDerived
```

Before my change, `return` was visited first, causing the correct diagnostic to be
emitted. After my change, the `strong_retain` is visited first causing the second
diagnostic to be emitted. Since we only emit one source error for each
SILLocation, in the 2nd case, the error associated with the `return is not
emitted.

We should not be considering `strong_retain` to be a use that propagates
liveness. The reason why is that a `strong_retain` will always be paired with
some local use that consumes it, whether that is an apply, closure, or a store
into memory. Since we will always have a consuming operation for the retain and
the consuming operation actually is able to be something visible at the source
level to the user (versus the retain), it makes more sense to just ignore
`strong_retain`.

In general though, we should try to be more careful about how we swallow errors
in DI, especially in the light of use-list twiddling. To help with this, I have
added a flag '-definite-init-visit-debuginfo-locs' that causes DI to consider
SIL Location debug info locs when deciding whether or not to swallow
errors. This means one can actually test the error swalling code paths by adding
sil locations to the end of SILInstructions, i.e.:

```
strong_retain %0 : $Builtin.NativeObject, loc "path":col:line
```

Any instruction with the same "path", col, line will from DI's perspective be
treated as generating the same "error" set.

rdar://28851920
