### PR TITLE
Modernize text formatting prototype

### DIFF
--- a/test/Prototypes/TextFormatting.swift
+++ b/test/Prototypes/TextFormatting.swift
@@ -4,45 +4,23 @@
 // Text Formatting Prototype
 //
 // This file demonstrates the concepts proposed in TextFormatting.rst
+//
+// We may not want the following protocol exactly as-is; it overlaps somewhat
+// with CustomStringConvertible and CustomDebugStringConvertible, and it's not
+// clear whether a protocol is even needed.
 
-// FIXME: Workaround for <rdar://problem/14011860> SubTLF: Default
-// implementations in protocols.
-infix operator ~> { precedence 255 }
+/// A type that supports format() and debugFormat().
+protocol CustomFormatted : CustomStringConvertible, CustomDebugStringConvertible {
 
-/// \brief A thing into which we can stream text
-protocol XOutputStream {
-  mutating
-  func append(_ text: String)
-}
-
-/// \brief Strings are XOutputStreams
-extension String: XOutputStream {
-  mutating
-  func append(_ text: String) {
-    self += text
-  }
-}
-
-/// \brief A thing that can be written to an XOutputStream
-protocol XStreamable {
-  func writeTo<Target: XOutputStream>(_ target: inout Target)
-}
-
-/// \brief A thing that can be printed in the REPL and the Debugger
-///
-/// Everything compiler-magically conforms to this protocol.  To
-/// change the debug representation for a type, you don't need to
-/// declare conformance: simply give the type a debugFormat().
-protocol XDebugPrintable {
-
-  associatedtype DebugRepresentation : XStreamable // = String
-
-  /// \brief Produce a textual representation for the REPL and
+  associatedtype DebugRepresentation : TextOutputStreamable = String
+  associatedtype PrintRepresentation : TextOutputStreamable = DebugRepresentation
+  
+  /// Produce a textual representation for the REPL and
   /// Debugger.
   ///
-  /// Because String is a XStreamable, your implementation of
+  /// Because String is a TextOutputStreamable, your implementation of
   /// debugRepresentation can just return a String.  If you want to write
-  /// directly to the XOutputStream for efficiency reasons,
+  /// directly to the TextOutputStream for efficiency reasons,
   /// (e.g. if your representation is huge), you can return a custom
   /// DebugRepresentation type.
   ///
@@ -53,99 +31,72 @@ protocol XDebugPrintable {
   /// escaped, etc.  A struct Point { var x, y: Int } might be
   /// represented as "Point(x: 3, y: 5)".
   func debugFormat() -> DebugRepresentation
-}
 
-/// \brief Strings are XStreamable
-extension String : XStreamable {
-  func writeTo<Target: XOutputStream>(_ target: inout Target) {
-    target.append(self)
-  }
-}
-
-// FIXME: Should be a method of XDebugPrintable once
-// <rdar://problem/14692224> (Default Implementations in Protocols) is
-// handled
-func toDebugString <T:XDebugPrintable> (_ x: T) -> String {
-  var result = ""
-  x.debugFormat().writeTo(&result)
-  return result
-}
-
-// FIXME: The following should be a method of XPrintable once
-// <rdar://problem/14692224> (Default Implementations in Protocols) is
-// handled
-struct __PrintedFormat {}
-func format() -> __PrintedFormat {
-  return __PrintedFormat()
-}
-func ~> <T:XDebugPrintable> (x: T, _: __PrintedFormat) -> T.DebugRepresentation {
-  return x.debugFormat()
-}
-
-/// \brief A thing that can be xprint()ed and toString()ed.
-///
-/// Conformance to XPrintable is explicit, but if you want to use the
-/// debugFormat() results for your type's format(), all you need
-/// to do is declare conformance to XPrintable, and there's nothing to
-/// implement.
-protocol XPrintable: XDebugPrintable {
-  associatedtype PrintRepresentation: XStreamable = DebugRepresentation
-
-  /// \brief produce a "pretty" textual representation that can be
+  /// produce a "pretty" textual representation that can be
   /// distinct from the debug format.  For example,
   /// String.printRepresentation returns the string itself, without quoting.
   ///
   /// In general you can return a String here, but if you need more
   /// control, we strongly recommend returning a custom Representation
   /// type, e.g. a nested struct of your type.  If you're lazy, you
-  /// can conform to XStreamable directly and just implement its
+  /// can conform to TextOutputStreamable directly and just implement its
   /// write() func.
-  func ~> (x: Self, _: __PrintedFormat) -> PrintRepresentation
+  func format() -> PrintRepresentation
 }
 
-
-// FIXME: The following should be a method of XPrintable once
-// <rdar://problem/14692224> (Default Implementations in Protocols) is
-// handled
-
-/// \brief Simply convert to String
-///
-/// Don't reimplement this: the default implementation always works.
-/// If you must reimplement toString(), make sure its results are
-/// consistent with those of format() (i.e. you shouldn't
-/// change the behavior).
-func toString<T: XPrintable>(_ x: T) -> String {
-  var result = ""
-  (x~>format()).writeTo(&result)
-  return result
+extension CustomFormatted where PrintRepresentation == DebugRepresentation {
+  func format() -> DebugRepresentation { return debugFormat() }
 }
 
-// \brief Streamer for the debug representation of String. When an
-// EscapedStringFormat is written to a XOutputStream, it adds
-// surrounding quotes and escapes special characters.
-struct EscapedStringFormat : XStreamable {
-
-  init(_ s: String) {
-    self._value = s
+/// CustomFormatted's conformance to CustomStringConvertible and
+/// CustomDebugStringConvertible
+extension CustomFormatted {
+  public var description: String {
+    return _description
+  }
+  
+  public var debugDescription: String {
+    return _debugDescription
   }
 
-  func writeTo<Target: XOutputStream>(_ target: inout Target) {
-    target.append("\"")
-    for c in _value.unicodeScalars {
-      target.append(c.escaped(asASCII: true))
+  //===--- Using [debug]description directly might pick up the stdlib -----===//
+  //===--- versions and skew test results, so use these for testing -------===//
+  var _description: String {
+    var result = ""
+    x.format().write(to: &result)
+    return result
+  }
+  
+  var _debugDescription: String {
+    var result = ""
+    x.debugFormat().write(to: &result)
+    return result
+  }
+}
+
+extension String : CustomFormatted {
+  // Streamer for the debug representation of String. When an
+  // EscapedStringFormat is written to a TextOutputStream, it adds
+  // surrounding quotes and escapes special characters.
+  struct EscapedFormat : TextOutputStreamable {
+
+    init(_ s: String) {
+      self._value = s
     }
-    target.append("\"")
+
+    func write<Target: TextOutputStream>(to target: inout Target) {
+      target.write("\"")
+      for c in _value.unicodeScalars {
+        target.write(c.escaped(asASCII: true))
+      }
+      target.write("\"")
+    }
+
+    var _value: String
   }
 
-  var _value: String
-}
-
-// FIXME: In theory, this shouldn't be needed
-extension String: XDebugPrintable {}
-
-extension String : XPrintable {
-  func debugFormat() -> EscapedStringFormat {
-    return EscapedStringFormat(self)
+  func debugFormat() -> EscapedFormat {
+    return EscapedFormat(self)
   }
 
   func format() -> String {
@@ -153,211 +104,177 @@ extension String : XPrintable {
   }
 }
 
-/// \brief An integral type that can be printed
-protocol XPrintableInteger : ExpressibleByIntegerLiteral, Comparable, SignedNumber, XPrintable {
-  func %(lhs: Self, rhs: Self) -> Self
-  func /(lhs: Self, rhs: Self) -> Self
+//===--- Updated Integer APIs ---------------------------------------------===//
+// These will be redundant once the new integer protocols are merged to trunk
+// but in the meantime they give us a decent protocol and explicit conversions
+// among integers.  You can skip this section if only interested in formatting
+//===----------------------------------------------------------------------===//
+public typealias Integer = Swift.Integer & Swift.IntegerArithmetic
 
-  // FIXME: Stand-in for constructor pending <rdar://problem/13695680>
-  // (Constructor requirements in protocols)
-  static func fromInt(_ x: Int) -> Self
-  func toInt() -> Int
+extension Integer {
+  /// Creates an instance with the same value as `i`
+  ///
+  /// - Precondition: `i`'s value is representable by `Self`.
+  init <N: Integer>(_ i: N) {
+    // Implementation based on Egyptian Multiplication of i by 1 allows us to
+    // avoid any mixed-type numeric operations, which the current standard
+    // library doesn't support.  Note: we also don't have a protocol that
+    // provides shift operators, so we use / 2 here.
+    var n = i
+    self = 0
+    if n == 0 { return }
+    
+    if n < 0 {
+      self -= 1 as Self
+    }
+    else {
+      self = 1
+    }
+
+    // compute:
+    //   abs(self) = the greatest power of 2 that divides i.
+    //   n = i / self
+    while (n & 1) == 0 {
+      self += self
+      n = n / 2
+    }
+    n /= 2 // consume the lowest 1-bit in i
+    if n == 0 { return }
+
+    // Accumulate the rest of the 1 bits in i.
+    // invariants:
+    //   abs(a) is a power of 2
+    //   n = i / a
+    var a = self + self
+    while true {
+      if n & 1 != 0 {
+        self += a
+        if n / 2 == 0 { return }
+      }
+      n /= 2
+      a += a
+    }
+  }
 }
+//===--- End Updated Integer APIs -----------------------------------------===//
 
-extension Int : XDebugPrintable {
-  func debugFormat() -> String { return String(self) }
-}
-
-extension Int : XPrintableInteger {
-  static func fromInt(_ x: Int) -> Int { return x }
-  func toInt() -> Int { return self }
-
-  func getValue() -> Int {
-    return self
+/// The way all Integer types are formatted.
+extension CustomFormatted where Self : Integer {
+  func debugFormat() -> IntegerFormat<Self> {
+    return format(radix: 10)
+  }
+  
+  func format(
+    radix: Int = 10, fill: String = " ", width: Int = 0
+  ) -> IntegerFormat<Self> {
+    return IntegerFormat(value: self, radix: radix, fill: fill, width: width)
   }
 }
 
-struct _formatArgs {
-  var radix: Int, fill: String, width: Int
-}
+/// A textual representation for integers
+public struct IntegerFormat<T: Integer> : TextOutputStreamable {
+  public init(value: T, radix: Int, fill: String, width: Int) {
+    self.value = value
+    self.radix = T(radix)
+    self.fill = fill
+    self.width = width
+  }
+  
+  private var value: T
+  private var radix: T, fill: String, width: Int
 
-func format(radix radix: Int = 10, fill: String = " ", width: Int = 0) -> _formatArgs {
-  return _formatArgs(radix: radix, fill: fill, width: width)
-}
+  private func _writePositive<S: TextOutputStream>(
+    _ value: T, _ stream: inout S
+  ) -> Int {
+    if value == 0 {
+      return 0
+    }
 
-// FIXME: this function was a member of RadixFormat, but
-// <rdar://problem/15525229> (SIL verification failed: operand of
-// 'apply' doesn't match function input type) changed all that.
-func _writePositive<T:XPrintableInteger, S: XOutputStream>(
-  _ value: T, _ stream: inout S, _ args: _formatArgs) -> Int
-{
-
-  if value == 0 {
-    return 0
+    let rest: T = value / radix
+    let nDigits = _writePositive(rest, &stream)
+    let digit = UInt32(value % radix)
+    let baseCharOrd : UInt32 = digit <= 9
+      ? UnicodeScalar("0").value 
+      : UnicodeScalar("A").value - 10
+    stream.write(String(UnicodeScalar(baseCharOrd + digit)!))
+    return nDigits + 1
   }
 
-  var radix: T = T.fromInt(args.radix)
-  var rest: T = value / radix
-  var nDigits = _writePositive(rest, &stream, args)
-  var digit = UInt32((value % radix).toInt())
-  var baseCharOrd : UInt32 = digit <= 9 ? UnicodeScalar("0").value 
-                                        : UnicodeScalar("A").value - 10
-  stream.append(String(UnicodeScalar(baseCharOrd + digit)!))
-  return nDigits + 1
-}
+  public func write<Target: TextOutputStream>(to target: inout Target) {
+    var width = 0
+    var result = ""
 
-// FIXME: this function was a member of RadixFormat, but
-// <rdar://problem/15525229> (SIL verification failed: operand of
-// 'apply' doesn't match function input type) changed all that.
-func _writeSigned<T:XPrintableInteger, S: XOutputStream>(
-  _ value: T, _ target: inout S, _ args: _formatArgs
-) {
-  var width = 0
-  var result = ""
-
-  if value == 0 {
-    result = "0"
-    width += 1
-  }
-  else {
-    var absVal = abs(value)
-    if (value < 0) {
-      target.append("-")
+    if value == 0 {
+      result = "0"
       width += 1
     }
-    width += _writePositive(absVal, &result, args)
-  }
+    else {
+      let absVal = value < 0 ? 0 - value : value
+      if (value < 0) {
+        target.write("-")
+        width += 1
+      }
+      width += _writePositive(absVal, &result)
+    }
 
-  while width < args.width {
-    width += 1
-    target.append(args.fill)
-  }
-  target.append(result)
-}
-
-struct RadixFormat<T: XPrintableInteger> : XStreamable {
-  init(value: T, args: _formatArgs) {
-    self.value = value
-    self.args = args
-  }
-
-  func writeTo<S: XOutputStream>(_ target: inout S) {
-    _writeSigned(value, &target, args)
-  }
-
-  typealias DebugRepresentation = String
-  func debugFormat() -> String {
-    return "RadixFormat(" + toDebugString(value) + ", " + toDebugString(args.radix) + ")"
-  }
-
-  var value: T
-  var args: _formatArgs
-}
-
-func ~> <T:XPrintableInteger> (x: T, _: __PrintedFormat) -> RadixFormat<T> {
-  return RadixFormat(value: x, args: format())
-}
-
-func ~> <T:XPrintableInteger> (x: T, args: _formatArgs) -> RadixFormat<T> {
-  return RadixFormat(value: x, args: args)
-}
-
-// ==========
-
-//
-// xprint and xprintln
-//
-
-struct StdoutStream : XOutputStream {
-  func append(_ text: String) { Swift.print(text, terminator: "") }
-  // debugging only
-  func dump() -> String {
-    return "<StdoutStream>"
+    while width < self.width {
+      width += 1
+      target.write(self.fill)
+    }
+    target.write(result)
   }
 }
 
-func xprint<Target: XOutputStream, T: XStreamable>(_ target: inout Target, _ x: T) {
-  x.writeTo(&target)
-}
+extension Int : CustomFormatted {}
+extension UInt : CustomFormatted {}
 
-func xprint<Target: XOutputStream, T: XPrintable>(_ target: inout Target, _ x: T) {
-  xprint(&target, x~>format())
-}
-
-func xprint<T: XPrintable>(_ x: T) {
-  var target = StdoutStream()
-  xprint(&target, x)
-}
-
-func xprint<T: XStreamable>(_ x: T) {
-  var target = StdoutStream()
-  xprint(&target, x)
-}
-
-func xprintln<Target: XOutputStream, T: XPrintable>(_ target: inout Target, _ x: T) {
-  xprint(&target, x)
-  target.append("\n")
-}
-
-func xprintln<Target: XOutputStream, T: XStreamable>(_ target: inout Target, _ x: T) {
-  xprint(&target, x)
-  target.append("\n")
-}
-
-func xprintln<T: XPrintable>(_ x: T) {
-  var target = StdoutStream()
-  xprintln(&target, x)
-}
-
-func xprintln<T: XStreamable>(_ x: T) {
-  var target = StdoutStream()
-  xprintln(&target, x)
-}
-
-func xprintln(_ x: String) {
-  var target = StdoutStream()
-  x.writeTo(&target)
-  "\n".writeTo(&target)
-}
-
-extension String {
-  init <T: XStreamable>(_ x: T) {
-    self = ""
-    xprint(&self, x)
+//===--- Adapter that encloses text in vertical bars, for testing ---------===//
+/// A textual representation that encloses some base `TextOutputStreamable` in
+/// vertical bars, making padding spaces more apparent.
+///
+/// - Note: This is just for the benefit of the tests
+struct Delimited<T: TextOutputStreamable> : TextOutputStreamable {
+  var base: T
+  
+  func write<S: TextOutputStream>(to output: inout S) {
+    "|".write(to: &output)
+    base.write(to: &output)
+    "|".write(to: &output)
   }
 }
 
-func toPrettyString<T: XStreamable>(_ x: T) -> String {
-  var result = "|"
-  xprint(&result, x)
-  result += "|"
-  return result
+extension TextOutputStreamable {
+  /// A textual representation that encloses the plain textual representation of
+  /// `self` in vertical bars, making padding spaces more apparent.
+  ///
+  /// - Note: This is just for the benefit of the tests
+  var delimited : Delimited<Self> {
+    return Delimited(base: self)
+  }
 }
-
-// ===========
+//===--- Tests ------------------------------------------------------------===//
 
 var x = "fubar\n\tbaz"
 
-xprintln(x)
+print(x._description)
 // CHECK: fubar
 // CHECK-NEXT: 	baz
 
-xprintln(toDebugString(x))
+print(x._debugDescription)
 // CHECK-NEXT: "fubar\n\tbaz"
 
-xprintln(toPrettyString(424242~>format(radix:16, width:8)))
+print(424242.format(radix:16, width:8).delimited)
 // CHECK-NEXT: |   67932|
 
 var zero = "0"
-xprintln(toPrettyString(-434343~>format(fill:zero, width:8)))
+print((-434343).format(fill:zero, width:8).delimited)
 // CHECK-NEXT: |-0434343|
 
-xprintln(toPrettyString(-42~>format(radix:13, width:8)))
+print((-42).format(radix:13, width:8).delimited)
 // CHECK-NEXT: |-     33|
 
-xprintln(0x1EADBEEF~>format(radix:16))
+print(0x1EADBEEF.format(radix:16).delimited)
 // CHECK-NEXT: 1EADBEEF
 
-// FIXME: rdar://16168414 this doesn't work in 32-bit
-// xprintln(0xDEADBEEF~>format(radix:16))
-// CHECK-NEXT-not: DEADBEEF
+print((0xDEADBEEF as UInt).format(radix:16).delimited)
+// CHECK-NEXT: DEADBEEF


### PR DESCRIPTION
Since we are thinking about strings I wanted to clean this up and extract any useful ideas.

I think the main idea of value here is that, when generating large amounts of text (as in a web service), or writing a large XML file, a program has to format many individual items such as integers and dates. If these are formatted into stored strings which are then written to a file, the intermediate string is immediately discarded and the work to construct and store it was wasted.

This prototype abstracts formatted representation as `TextOutputStreamable` instances that hold the underlying things being formatted, and push text directly into a `TextOutputStream` instance.

In a world with a `StringProtocol`, though, maybe we don't need `TextOutputStreamable` et al.  There's no reason that models of `StringProtocol` couldn't be built the same way.
