### PR TITLE
[ConstraintSystem] Inference of inout for closure parameters in generic contexts

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3294,8 +3294,11 @@ namespace {
       //
       // FIXME: This is also computed when the constraint system is set up.
       auto destTy = cs.computeAssignDestType(expr->getDest(), expr->getLoc());
-      if (!destTy)
+      if (!destTy) {
+        cs.TC.diagnose(expr->getLoc(), diag::type_of_expression_is_ambiguous)
+          .highlight(expr->getSourceRange());
         return nullptr;
+      }
       expr->getDest()->propagateLValueAccessKind(AccessKind::Write);
 
       // Convert the source to the simplified destination type.

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1889,7 +1889,7 @@ namespace {
 
         // Otherwise, create a fresh type variable.
         Type ty = CS.createTypeVariable(CS.getConstraintLocator(locator),
-                                        /*options=*/0);
+                                        TVO_CanBeInOut);
         
         param->overwriteType(ty);
       }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1410,6 +1410,22 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     case ConstraintKind::ArgumentConversion:
     case ConstraintKind::OperatorArgumentTupleConversion:
     case ConstraintKind::OperatorArgumentConversion:
+      if (type1->is<InOutType>() && typeVar2 &&
+          typeVar2->getImpl().canBeInOut()) {
+        // Upgrade type2 to an InOutType
+        auto inOutType1 = type1->getAs<InOutType>();
+        
+        unsigned typeVar3Options = typeVar2->getImpl().getOptions();
+        typeVar3Options &= ~TVO_CanBeInOut;
+        auto typeVar3 = createTypeVariable(getConstraintLocator(locator),
+                                           typeVar3Options);
+        auto inOutType3 = InOutType::get(typeVar3);
+        
+        addConstraint(ConstraintKind::Equal, typeVar2, inOutType3, locator);
+        return matchTypes(inOutType1->getObjectType(), typeVar3, kind, flags,
+                          locator);
+      }
+        
       // We couldn't solve this constraint. If only one of the types is a type
       // variable, perhaps we can do something with it below.
       if (typeVar1 && typeVar2) {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -56,7 +56,7 @@ void TypeVariableType::Implementation::print(llvm::raw_ostream &OS) {
 }
 
 SavedTypeVariableBinding::SavedTypeVariableBinding(TypeVariableType *typeVar)
-  : TypeVarAndOptions(typeVar, typeVar->getImpl().Options),
+  : TypeVar(typeVar), TypeVarOptions(typeVar->getImpl().Options),
     ParentOrFixed(typeVar->getImpl().ParentOrFixed) { }
 
 void SavedTypeVariableBinding::restore() {
@@ -2683,6 +2683,8 @@ void ConstraintSystem::print(raw_ostream &out) {
     tv->getImpl().print(out);
     if (tv->getImpl().canBindToLValue())
       out << " [lvalue allowed]";
+    if (tv->getImpl().canBeInOut())
+      out << " [inout allowed]";
     if (tv->getImpl().mustBeMaterializable())
       out << " [must be materializable]";
     auto rep = getRepresentative(tv);

--- a/test/expr/closure/inference.swift
+++ b/test/expr/closure/inference.swift
@@ -45,3 +45,23 @@ func sr1976<T>(_ closure: (inout T) -> Void) {
 }
 
 sr1976({ $0 += 2 })
+
+// SR-3073: UnresolvedDotExpr in single expression closure
+
+func sr3073<S, T>(_ closure:(inout S, T) -> ()) {}
+
+sr3073({ $0.number1 = $1 }) //expected-error {{type of expression is ambiguous without more context}}
+
+struct SR3073Lense<Whole, Part> {
+  let set: (inout Whole, Part) -> ()
+}
+
+struct SR3073 {
+  var number1: Int
+  
+  func lenses() {
+    let _: SR3073Lense<SR3073, Int> = SR3073Lense(
+      set: { $0.number1 = $1 }
+    )
+  }
+}

--- a/test/expr/closure/inference.swift
+++ b/test/expr/closure/inference.swift
@@ -38,3 +38,10 @@ var nestedClosuresWithBrokenInference = { f: Int in {} }
     // expected-error@-2 {{consecutive statements on a line must be separated by ';'}} {{44-44=;}}
     // expected-error@-3 {{expected expression}}
     // expected-error@-4 {{use of unresolved identifier 'f'}}
+
+// SR-1976/SR-3073: Inference of inout
+
+func sr1976<T>(_ closure: (inout T) -> Void) {
+}
+
+sr1976({ $0 += 2 })

--- a/test/stdlib/UnsafePointerDiagnostics.swift
+++ b/test/stdlib/UnsafePointerDiagnostics.swift
@@ -137,3 +137,8 @@ func unsafeRawBufferPointerConversions(
   _ = UnsafeMutableRawBufferPointer(start: orp, count: 1) // expected-error {{cannot convert value of type 'UnsafeRawPointer?' to expected argument type 'UnsafeMutableRawPointer?'}}
   _ = UnsafeRawBufferPointer(start: orp, count: 1)
 }
+
+func pointerInoutEquality(i: Int, p: UnsafeMutablePointer<Int>?) {
+  var i = i
+  _ = (p == &i)
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
### Problem

In generic contexts, the `inout` annotation for closure parameters was not inferred anymore, e.g. the following code failed to compile ([SR-1976](https://bugs.swift.org/browse/SR-1976)):

```
func foo<T>(_ closure: (inout T) -> Void) {}
foo({ $0 += 2 }) // error: ambigous use of operator '+='
```

while the non-generic version

```
func foo(_ closure: (inout Int) -> Void) {}
foo({ $0 += 2 })
```

compiles fine.

If the closure included a member access of the `inout` argument, this even a compiler crash ([SR-3053](https://bugs.swift.org/browse/SR-3053)/[SR-3073](https://bugs.swift.org/browse/SR-3073)):

```
struct MyType {
  var number1: Int
}
func set<S, T>(_ closure:(inout S, T) -> ()) {}
set({ $0.number1 = $1 })
```
### Solution

When encountering a subtype constraint (`type1 subtype type2`) where `type1` is an `inout` type and `type2` is not, we introduce a new type variable `type3` and check if `type2 == inout type3` can hold. This guards against cases like the following where we need the asymetric `inout` relationship.

```
func pointerInoutEquality(i: Int, p: UnsafeMutablePointer<Int>?) {
  var i = i
  _ = (p == &i) // <- This is the interesting line
}
```

Otherwise, we replace the original constraint by the two constraints `type2 == inout type3` and `removedInOutLayerFromType1 subtype type3` that upgrade `type2` to `inout`.
### Some notes
- I don't actually feel that `CSSimplify` is the right place to make the choice if a type needs to be `inout` or not, but couldn't find a way to do it in `CSSolve`. Using a disjunction constraint would require having a conjunction constraint as well but I couldn't find such a thing.
- Removing the type variable in the end feels fairly ugly but otherwise we get a false warning about not unwrapping `UnsafeMutablePointer` in the example above.
- For backtracking changes to the constraint system, it seems like there used to be `ConstraintGraphScope` but that didn't work for me and doesn't seem to be used anymore -> we might remove the class
