### PR TITLE
[swiftc (76 vs. 5179)] Add crasher in ?

### DIFF
--- a/validation-test/compiler_crashers/28444-resolver-unable-to-resolve-type-witness-failed.swift
+++ b/validation-test/compiler_crashers/28444-resolver-unable-to-resolve-type-witness-failed.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+class d:a{{}var f=b}protocol a{func b{{{}}}typealias d:a{{{}}}typealias b


### PR DESCRIPTION
Add test case for crash triggered in `?`.

Current number of unresolved compiler crashers: 76 (5179 resolved)

Assertion failure in [`lib/AST/ProtocolConformance.cpp (line 271)`](https://github.com/apple/swift/blob/master/lib/AST/ProtocolConformance.cpp#L271):

```
Assertion `resolver && "Unable to resolve type witness"' failed.

When executing: std::pair<const Substitution &, TypeDecl *> swift::NormalProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl *, swift::LazyResolver *) const
```

Assertion context:

```
  if (Resolver)
    resolveLazyInfo();

  auto known = TypeWitnesses.find(assocType);
  if (known == TypeWitnesses.end()) {
    assert(resolver && "Unable to resolve type witness");
    resolver->resolveTypeWitness(this, assocType);
    known = TypeWitnesses.find(assocType);
    assert(known != TypeWitnesses.end() && "Didn't resolve witness?");
  }

```

Stack trace:

```
swift: /path/to/swift/lib/AST/ProtocolConformance.cpp:271: std::pair<const Substitution &, TypeDecl *> swift::NormalProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl *, swift::LazyResolver *) const: Assertion `resolver && "Unable to resolve type witness"' failed.
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28444-resolver-unable-to-resolve-type-witness-failed.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28444-resolver-unable-to-resolve-type-witness-failed-1c716b.o
1.  While type-checking 'd' at validation-test/compiler_crashers/28444-resolver-unable-to-resolve-type-witness-failed.swift:10:1
2.  While type-checking expression at [validation-test/compiler_crashers/28444-resolver-unable-to-resolve-type-witness-failed.swift:10:19 - line:10:19] RangeText="b"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
