### PR TITLE
[swiftc (77 vs. 5179)] Add crasher in ?

### DIFF
--- a/validation-test/compiler_crashers/28445-gp-getouterparameters-proto-getdeclcontext-getgenericparamsofcontext-failed.swift
+++ b/validation-test/compiler_crashers/28445-gp-getouterparameters-proto-getdeclcontext-getgenericparamsofcontext-failed.swift
@@ -1,0 +1,17 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+class A{let f= <c
+protocol A{
+typealias e:A{}
+protocol A{
+extension{
+protocol A{func<{{}
+}typealias e:
+c


### PR DESCRIPTION
Add test case for crash triggered in `?`.

Current number of unresolved compiler crashers: 77 (5179 resolved)

Assertion failure in [`lib/Sema/TypeCheckDecl.cpp (line 7155)`](https://github.com/apple/swift/blob/master/lib/Sema/TypeCheckDecl.cpp#L7155):

```
Assertion `gp->getOuterParameters() == proto->getDeclContext()->getGenericParamsOfContext()' failed.

When executing: void swift::TypeChecker::validateDecl(swift::ValueDecl *, bool)
```

Assertion context:

```
    (void) gp;

    validateGenericTypeSignature(proto);

    assert(gp->getOuterParameters() ==
           proto->getDeclContext()->getGenericParamsOfContext());

    // Record inherited protocols.
    resolveInheritedProtocols(proto);

    validateAttributes(*this, D);
```

Stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckDecl.cpp:7155: void swift::TypeChecker::validateDecl(swift::ValueDecl *, bool): Assertion `gp->getOuterParameters() == proto->getDeclContext()->getGenericParamsOfContext()' failed.
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28445-gp-getouterparameters-proto-getdeclcontext-getgenericparamsofcontext-failed.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28445-gp-getouterparameters-proto-getdeclcontext-getgenericparamsofcontext-failed-cb77c4.o
1.  While type-checking 'A' at validation-test/compiler_crashers/28445-gp-getouterparameters-proto-getdeclcontext-getgenericparamsofcontext-failed.swift:10:1
2.  While type-checking expression at [validation-test/compiler_crashers/28445-gp-getouterparameters-proto-getdeclcontext-getgenericparamsofcontext-failed.swift:10:16 - line:10:17] RangeText="<c"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
