### PR TITLE
[TypeChecker] Add error message when accessing a type's destructor

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -340,6 +340,9 @@ ERROR(cannot_convert_closure_result_protocol,none,
 ERROR(cannot_convert_closure_result_nil,none,
       "nil is not compatible with closure result type %0", (Type))
 
+ERROR(destructor_not_accessible,none,
+      "deinitializers cannot be accessed", ())
+
 // Array Element
 ERROR(cannot_convert_array_element,none,
       "cannot convert value of type %0 to expected element type %1",

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2774,6 +2774,10 @@ diagnoseUnviableLookupResults(MemberLookupResult &result, Type baseObjTy,
         
       return;
     }
+    case MemberLookupResult::UR_DestructorInaccessible: {
+      diagnose(nameLoc, diag::destructor_not_accessible);
+      return;
+    }
     }
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3016,6 +3016,11 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
   // reasonable choice.
   auto addChoice = [&](ValueDecl *cand, bool isBridged,
                        bool isUnwrappedOptional) {
+    // Destructors cannot be referenced manually
+    if (isa<DestructorDecl>(cand)) {
+      result.addUnviable(cand, MemberLookupResult::UR_DestructorInaccessible);
+      return;
+    }
     // If the result is invalid, skip it.
     TC.validateDecl(cand, true);
     if (cand->isInvalid()) {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -802,6 +802,9 @@ struct MemberLookupResult {
     
     /// The member is inaccessible (e.g. a private member in another file).
     UR_Inaccessible,
+    
+    // A type's destructor cannot be referenced
+    UR_DestructorInaccessible,
   };
   
   /// This is a list of considered, but rejected, candidates, along with a

--- a/test/expr/postfix/dot/dot_keywords.swift
+++ b/test/expr/postfix/dot/dot_keywords.swift
@@ -38,3 +38,19 @@ class SE0071Derived : SE0071Base {
     super.default()
   }
 }
+
+// SR-3043: Diagnostics when accessing deinit
+
+class SR3043Base {
+}
+
+class SR3043Derived: SR3043Base {
+  deinit {
+    super.deinit() // expected-error {{deinitializers cannot be accessed}}
+  }
+}
+
+let sr3043 = SR3043Derived()
+sr3043.deinit() // expected-error {{deinitializers cannot be accessed}}
+sr3043.deinit // expected-error {{deinitializers cannot be accessed}}
+SR3043Derived.deinit() // expected-error {{deinitializers cannot be accessed}}


### PR DESCRIPTION
<!-- What's in this pull request? -->

Trying to access a destructor using `foo.deinit` currently crashes the compiler. This pull requests makes the compiler create error messages instead.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

Resolves [SR-2652](https://bugs.swift.org/browse/SR-2652)/[SR-3043](https://bugs.swift.org/browse/SR-3043).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
