### PR TITLE
[swiftc (78 vs. 5179)] Add crasher in ?

### DIFF
--- a/validation-test/compiler_crashers/28446-activediagnostic-already-have-an-active-diagnostic-failed.swift
+++ b/validation-test/compiler_crashers/28446-activediagnostic-already-have-an-active-diagnostic-failed.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+class A{let:e=0
+enum e:A


### PR DESCRIPTION
Add test case for crash triggered in `?`.

Current number of unresolved compiler crashers: 78 (5179 resolved)

Assertion failure in [`include/swift/AST/DiagnosticEngine.h (line 614)`](https://github.com/apple/swift/blob/master/include/swift/AST/DiagnosticEngine.h#L614):

```
Assertion `!ActiveDiagnostic && "Already have an active diagnostic"' failed.

When executing: swift::InFlightDiagnostic swift::DiagnosticEngine::diagnose(swift::SourceLoc, Diag<ArgTypes...>, typename detail::PassArgument<ArgTypes>::type...) [ArgTypes = <swift::Type>]
```

Assertion context:

```
    /// the types expected by the diagnostic \p ID.
    template<typename ...ArgTypes>
    InFlightDiagnostic
    diagnose(SourceLoc Loc, Diag<ArgTypes...> ID,
             typename detail::PassArgument<ArgTypes>::type... Args) {
      assert(!ActiveDiagnostic && "Already have an active diagnostic");
      ActiveDiagnostic = Diagnostic(ID, std::move(Args)...);
      ActiveDiagnostic->setLoc(Loc);
      return InFlightDiagnostic(*this);
    }

```

Stack trace:

```
swift: /path/to/swift/include/swift/AST/DiagnosticEngine.h:614: swift::InFlightDiagnostic swift::DiagnosticEngine::diagnose(swift::SourceLoc, Diag<ArgTypes...>, typename detail::PassArgument<ArgTypes>::type...) [ArgTypes = <swift::Type>]: Assertion `!ActiveDiagnostic && "Already have an active diagnostic"' failed.
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28446-activediagnostic-already-have-an-active-diagnostic-failed.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28446-activediagnostic-already-have-an-active-diagnostic-failed-9fd888.o
1.  While type-checking 'A' at validation-test/compiler_crashers/28446-activediagnostic-already-have-an-active-diagnostic-failed.swift:10:1
2.  While type-checking expression at [validation-test/compiler_crashers/28446-activediagnostic-already-have-an-active-diagnostic-failed.swift:10:15 - line:10:15] RangeText="0"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
