### PR TITLE
[semantic-arc] Eliminate default {Load,Store}OwnershipQualification argument to SILBuilder::create{Load,Store}(...)

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -457,9 +457,8 @@ public:
         getSILDebugLocation(Loc), text.toStringRef(Out), encoding, F));
   }
 
-  LoadInst *createLoad(
-      SILLocation Loc, SILValue LV,
-      LoadOwnershipQualifier Qualifier = LoadOwnershipQualifier::Unqualified) {
+  LoadInst *createLoad(SILLocation Loc, SILValue LV,
+                       LoadOwnershipQualifier Qualifier) {
     assert(LV->getType().isLoadable(F.getModule()));
     return insert(new (F.getModule())
                       LoadInst(getSILDebugLocation(Loc), LV, Qualifier));
@@ -472,8 +471,7 @@ public:
   }
 
   StoreInst *createStore(SILLocation Loc, SILValue Src, SILValue DestAddr,
-                         StoreOwnershipQualifier Qualifier =
-                             StoreOwnershipQualifier::Unqualified) {
+                         StoreOwnershipQualifier Qualifier) {
     return insert(new (F.getModule()) StoreInst(getSILDebugLocation(Loc), Src,
                                                 DestAddr, Qualifier));
   }

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -660,9 +660,9 @@ template<typename ImplClass>
 void
 SILCloner<ImplClass>::visitLoadInst(LoadInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
-  doPostProcess(Inst,
-    getBuilder().createLoad(getOpLocation(Inst->getLoc()),
-                            getOpValue(Inst->getOperand())));
+  doPostProcess(Inst, getBuilder().createLoad(getOpLocation(Inst->getLoc()),
+                                              getOpValue(Inst->getOperand()),
+                                              Inst->getOwnershipQualifier()));
 }
 
 template <typename ImplClass>
@@ -676,10 +676,10 @@ void SILCloner<ImplClass>::visitLoadBorrowInst(LoadBorrowInst *Inst) {
 template <typename ImplClass>
 void SILCloner<ImplClass>::visitStoreInst(StoreInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
-  doPostProcess(Inst,
-    getBuilder().createStore(getOpLocation(Inst->getLoc()),
-                             getOpValue(Inst->getSrc()),
-                             getOpValue(Inst->getDest())));
+  doPostProcess(Inst, getBuilder().createStore(getOpLocation(Inst->getLoc()),
+                                               getOpValue(Inst->getSrc()),
+                                               getOpValue(Inst->getDest()),
+                                               Inst->getOwnershipQualifier()));
 }
 
 template <typename ImplClass>

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -494,7 +494,8 @@ namespace {
   public:
     void emitDestroyAddress(SILBuilder &B, SILLocation loc,
                             SILValue addr) const override {
-      SILValue value = B.createLoad(loc, addr);
+      SILValue value =
+          B.createLoad(loc, addr, LoadOwnershipQualifier::Unqualified);
       emitDestroyValue(B, loc, value);
     }
 
@@ -519,13 +520,13 @@ namespace {
 
     SILValue emitLoadOfCopy(SILBuilder &B, SILLocation loc, SILValue addr,
                             IsTake_t isTake) const override {
-      return B.createLoad(loc, addr);
+      return B.createLoad(loc, addr, LoadOwnershipQualifier::Unqualified);
     }
 
     void emitStoreOfCopy(SILBuilder &B, SILLocation loc,
                          SILValue value, SILValue addr,
                          IsInitialization_t isInit) const override {
-      B.createStore(loc, value, addr);
+      B.createStore(loc, value, addr, StoreOwnershipQualifier::Unqualified);
     }
 
     void emitDestroyAddress(SILBuilder &B, SILLocation loc,
@@ -565,7 +566,8 @@ namespace {
 
     SILValue emitLoadOfCopy(SILBuilder &B, SILLocation loc,
                             SILValue addr, IsTake_t isTake) const override {
-      SILValue value = B.createLoad(loc, addr);
+      SILValue value =
+          B.createLoad(loc, addr, LoadOwnershipQualifier::Unqualified);
       if (!isTake)
         emitCopyValue(B, loc, value);
       return value;
@@ -575,8 +577,9 @@ namespace {
                          SILValue newValue, SILValue addr,
                          IsInitialization_t isInit) const override {
       SILValue oldValue;
-      if (!isInit) oldValue = B.createLoad(loc, addr);
-      B.createStore(loc, newValue, addr);
+      if (!isInit)
+        oldValue = B.createLoad(loc, addr, LoadOwnershipQualifier::Unqualified);
+      B.createStore(loc, newValue, addr, StoreOwnershipQualifier::Unqualified);
       if (!isInit)
         emitDestroyValue(B, loc, oldValue);
     }

--- a/lib/SILGen/ManagedValue.cpp
+++ b/lib/SILGen/ManagedValue.cpp
@@ -52,7 +52,7 @@ void ManagedValue::copyInto(SILGenFunction &gen, SILValue dest, SILLocation L) {
     return;
   }
   lowering.emitCopyValue(gen.B, L, getValue());
-  gen.B.createStore(L, getValue(), dest);
+  gen.B.createStore(L, getValue(), dest, StoreOwnershipQualifier::Unqualified);
 }
 
 /// This is the same operation as 'copy', but works on +0 values that don't

--- a/lib/SILGen/RValue.cpp
+++ b/lib/SILGen/RValue.cpp
@@ -105,7 +105,7 @@ public:
         // loaded.  Except it's not really an invariant, because
         // argument emission likes to lie sometimes.
         if (eltTI.isLoadable()) {
-          elt = gen.B.createLoad(loc, elt);
+          elt = gen.B.createLoad(loc, elt, LoadOwnershipQualifier::Unqualified);
         }
       }
 

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -121,7 +121,8 @@ emitBridgeNativeToObjectiveC(SILGenFunction &gen,
   if (witnessFnTy.castTo<SILFunctionType>()->getParameters()[0].isIndirect()
       && !swiftValue.getType().isAddress()) {
     auto tmp = gen.emitTemporaryAllocation(loc, swiftValue.getType());
-    gen.B.createStore(loc, swiftValue.getValue(), tmp);
+    gen.B.createStore(loc, swiftValue.getValue(), tmp,
+                      StoreOwnershipQualifier::Unqualified);
     swiftValue = ManagedValue::forUnmanaged(tmp);
   }
 
@@ -449,7 +450,8 @@ ManagedValue SILGenFunction::emitFuncToBlock(SILLocation loc,
   // Store the function to the block without claiming it, so that it still
   // gets cleaned up in scope. Copying the block will create an independent
   // reference.
-  B.createStore(loc, fn.getValue(), capture);
+  B.createStore(loc, fn.getValue(), capture,
+                StoreOwnershipQualifier::Unqualified);
   auto invokeFn = B.createFunctionRef(loc, thunk);
   
   auto stackBlock = B.createInitBlockStorageHeader(loc, storage, invokeFn,

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -592,7 +592,8 @@ emitBuiltinCastReference(SILGenFunction &gen,
     // a retain. The cast will load the reference from the source temp and
     // store it into a dest temp effectively forwarding the cleanup.
     fromAddr = gen.emitTemporaryAllocation(loc, srcVal->getType());
-    gen.B.createStore(loc, srcVal, fromAddr);
+    gen.B.createStore(loc, srcVal, fromAddr,
+                      StoreOwnershipQualifier::Unqualified);
   } else {
     // The cast loads directly from the source address.
     fromAddr = srcVal;
@@ -606,7 +607,8 @@ emitBuiltinCastReference(SILGenFunction &gen,
     return gen.emitManagedBufferWithCleanup(toAddr);
 
   // Load the destination value.
-  auto result = gen.B.createLoad(loc, toAddr);
+  auto result =
+      gen.B.createLoad(loc, toAddr, LoadOwnershipQualifier::Unqualified);
   return gen.emitManagedRValueWithCleanup(result);
 }
 
@@ -630,7 +632,8 @@ static ManagedValue emitBuiltinReinterpretCast(SILGenFunction &gen,
     // If the from value is loadable, move it to a buffer.
     if (fromTL.isLoadable()) {
       fromAddr = gen.emitTemporaryAllocation(loc, args[0].getValue()->getType());
-      gen.B.createStore(loc, args[0].getValue(), fromAddr);
+      gen.B.createStore(loc, args[0].getValue(), fromAddr,
+                        StoreOwnershipQualifier::Unqualified);
     } else {
       fromAddr = args[0].getValue();
     }
@@ -640,7 +643,8 @@ static ManagedValue emitBuiltinReinterpretCast(SILGenFunction &gen,
     // Load and retain the destination value if it's loadable. Leave the cleanup
     // on the original value since we don't know anything about it's type.
     if (toTL.isLoadable()) {
-      SILValue val = gen.B.createLoad(loc, toAddr);
+      SILValue val =
+          gen.B.createLoad(loc, toAddr, LoadOwnershipQualifier::Unqualified);
       return gen.emitManagedRetain(loc, val, toTL);
     }
     // Leave the cleanup on the original value.

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -275,8 +275,9 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
     
     if (!lowering.isAddressOnly()) {
       // Otherwise, load and return the final 'self' value.
-      selfValue = B.createLoad(cleanupLoc, selfLV);
-      
+      selfValue =
+          B.createLoad(cleanupLoc, selfLV, LoadOwnershipQualifier::Unqualified);
+
       // Emit a retain of the loaded value, since we return it +1.
       lowering.emitCopyValue(B, cleanupLoc, selfValue);
 
@@ -581,7 +582,8 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
     if (NeedsBoxForSelf) {
       SILLocation prologueLoc = RegularLocation(ctor);
       prologueLoc.markAsPrologue();
-      B.createStore(prologueLoc, selfArg, VarLocs[selfDecl].value);
+      B.createStore(prologueLoc, selfArg, VarLocs[selfDecl].value,
+                    StoreOwnershipQualifier::Unqualified);
     } else {
       selfArg = B.createMarkUninitialized(selfDecl, selfArg, MUKind);
       VarLocs[selfDecl] = VarLoc::get(selfArg);
@@ -667,8 +669,9 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
       // Emit the call to super.init() right before exiting from the initializer.
       if (Expr *SI = ctor->getSuperInitCall())
         emitRValue(SI);
-      
-      selfArg = B.createLoad(cleanupLoc, VarLocs[selfDecl].value);
+
+      selfArg = B.createLoad(cleanupLoc, VarLocs[selfDecl].value,
+                             LoadOwnershipQualifier::Unqualified);
     }
     
     // We have to do a retain because we are returning the pointer +1.

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -249,7 +249,8 @@ ManagedValue SILGenFunction::emitUncheckedGetOptionalValueFrom(SILLocation loc,
                                         someDecl, origPayloadTy);
   
     if (optTL.isLoadable())
-      payloadVal = B.createLoad(loc, payloadVal);
+      payloadVal =
+          B.createLoad(loc, payloadVal, LoadOwnershipQualifier::Unqualified);
   }
 
   // Produce a correctly managed value.
@@ -358,7 +359,8 @@ SILGenFunction::emitPointerToPointer(SILLocation loc,
   // The generic function currently always requires indirection, but pointers
   // are always loadable.
   auto origBuf = emitTemporaryAllocation(loc, input.getType());
-  B.createStore(loc, input.forward(*this), origBuf);
+  B.createStore(loc, input.forward(*this), origBuf,
+                StoreOwnershipQualifier::Unqualified);
   auto origValue = emitManagedBufferWithCleanup(origBuf);
   
   // Invoke the conversion intrinsic to convert to the destination type.

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -91,7 +91,8 @@ void TupleInitialization::copyOrInitValueInto(SILGenFunction &SGF,
     if (value->getType().isAddress()) {
       member = SGF.B.createTupleElementAddr(loc, value, i, fieldTy);
       if (!fieldTL.isAddressOnly())
-        member = SGF.B.createLoad(loc, member);
+        member =
+            SGF.B.createLoad(loc, member, LoadOwnershipQualifier::Unqualified);
     } else {
       member = SGF.B.createTupleExtract(loc, value, i, fieldTy);
     }
@@ -712,7 +713,8 @@ emitEnumMatch(ManagedValue value, EnumElementDecl *ElementDecl,
                                                      ElementDecl, eltTy);
     // Load a loadable data value.
     if (eltTL.isLoadable())
-      eltValue = SGF.B.createLoad(loc, eltValue);
+      eltValue =
+          SGF.B.createLoad(loc, eltValue, LoadOwnershipQualifier::Unqualified);
   } else {
     // Otherwise, we're consuming this as a +1 value.
     value.forward(SGF);
@@ -726,7 +728,8 @@ emitEnumMatch(ManagedValue value, EnumElementDecl *ElementDecl,
     SILValue boxedValue = SGF.B.createProjectBox(loc, eltMV.getValue(), 0);
     auto &boxedTL = SGF.getTypeLowering(boxedValue->getType());
     if (boxedTL.isLoadable())
-      boxedValue = SGF.B.createLoad(loc, boxedValue);
+      boxedValue = SGF.B.createLoad(loc, boxedValue,
+                                    LoadOwnershipQualifier::Unqualified);
 
     // We must treat the boxed value as +0 since it may be shared. Copy it if
     // nontrivial.

--- a/lib/SILGen/SILGenDynamicCast.cpp
+++ b/lib/SILGen/SILGenDynamicCast.cpp
@@ -140,7 +140,8 @@ namespace {
         //emission.
         scalarOperandValue = operand.forward(SGF);
         if (scalarOperandValue->getType().isAddress()) {
-          scalarOperandValue = SGF.B.createLoad(Loc, scalarOperandValue);
+          scalarOperandValue = SGF.B.createLoad(
+              Loc, scalarOperandValue, LoadOwnershipQualifier::Unqualified);
         }
         SGF.B.createCheckedCastBranch(Loc, /*exact*/ false, scalarOperandValue,
                                       origTargetTL.getLoweredType(),
@@ -363,7 +364,8 @@ adjustForConditionalCheckedCastOperand(SILLocation loc, ManagedValue src,
     // Okay, if all we need to do is drop the value in an address,
     // this is easy.
     if (!hasAbstraction) {
-      SGF.B.createStore(loc, src.forward(SGF), init->getAddress());
+      SGF.B.createStore(loc, src.forward(SGF), init->getAddress(),
+                        StoreOwnershipQualifier::Unqualified);
       init->finishInitialization(SGF);
       return init->getManagedAddress();
     }

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3243,7 +3243,8 @@ public:
   RValue get(SILGenFunction &gen, SILLocation loc,
              ManagedValue base, SGFContext c) && override {
     // Load the value at +0.
-    SILValue owned = gen.B.createLoad(loc, base.getUnmanagedValue());
+    SILValue owned = gen.B.createLoad(loc, base.getUnmanagedValue(),
+                                      LoadOwnershipQualifier::Unqualified);
     // Convert it to unowned.
     auto refType = owned->getType().getSwiftRValueType();
     auto unownedType = SILType::getPrimitiveObjectType(

--- a/lib/SILGen/SILGenForeignError.cpp
+++ b/lib/SILGen/SILGenForeignError.cpp
@@ -268,7 +268,8 @@ void SILGenFunction::emitForeignErrorBlock(SILLocation loc,
   // conditionally claiming the value.  In practice, claiming it
   // unconditionally is fine because we want to assume it's nil in the
   // other path.
-  SILValue errorV = B.createLoad(loc, errorSlot.forward(*this));
+  SILValue errorV = B.createLoad(loc, errorSlot.forward(*this),
+                                 LoadOwnershipQualifier::Unqualified);
   ManagedValue error = emitManagedRValueWithCleanup(errorV);
 
   // Turn the error into an Error value.
@@ -384,7 +385,8 @@ emitErrorIsNonNilErrorCheck(SILGenFunction &gen, SILLocation loc,
   // If we're suppressing the check, just don't check.
   if (suppressErrorCheck) return;
 
-  SILValue optionalError = gen.B.createLoad(loc, errorSlot.getValue());
+  SILValue optionalError = gen.B.createLoad(
+      loc, errorSlot.getValue(), LoadOwnershipQualifier::Unqualified);
 
   ASTContext &ctx = gen.getASTContext();
 

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -334,7 +334,8 @@ static bool isProtocolClass(Type t) {
 static ManagedValue emitManagedLoad(SILGenFunction &gen, SILLocation loc,
                                     ManagedValue addr,
                                     const TypeLowering &addrTL) {
-  auto loadedValue = gen.B.createLoad(loc, addr.forward(gen));
+  auto loadedValue = gen.B.createLoad(loc, addr.forward(gen),
+                                      LoadOwnershipQualifier::Unqualified);
   return gen.emitManagedRValueWithCleanup(loadedValue, addrTL);
 }
 
@@ -2181,7 +2182,8 @@ void ResultPlanner::execute(ArrayRef<SILValue> innerDirectResults,
 
     case Operation::DirectToIndirect: {
       auto result = claimNextInnerDirectResult(op.InnerResult);
-      Gen.B.createStore(Loc, result.forward(Gen), op.OuterResultAddr);
+      Gen.B.createStore(Loc, result.forward(Gen), op.OuterResultAddr,
+                        StoreOwnershipQualifier::Unqualified);
       continue;
     }
 
@@ -2189,7 +2191,9 @@ void ResultPlanner::execute(ArrayRef<SILValue> innerDirectResults,
       auto resultAddr = op.InnerResultAddr;
       auto &resultTL = Gen.getTypeLowering(resultAddr->getType());
       auto result = Gen.emitManagedRValueWithCleanup(
-                                 Gen.B.createLoad(Loc, resultAddr), resultTL);
+          Gen.B.createLoad(Loc, resultAddr,
+                           LoadOwnershipQualifier::Unqualified),
+          resultTL);
       addOuterDirectResult(result, op.OuterResult);
       continue;
     }

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -366,7 +366,7 @@ static void emitCaptureArguments(SILGenFunction &gen, CapturedValue capture,
     // temporary within the closure to provide this address.
     if (VD->isSettable(VD->getDeclContext())) {
       auto addr = gen.emitTemporaryAllocation(VD, ty);
-      gen.B.createStore(VD, val, addr);
+      gen.B.createStore(VD, val, addr, StoreOwnershipQualifier::Unqualified);
       val = addr;
     }
 

--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -292,7 +292,8 @@ void EagerDispatch::emitDispatchTo(SILFunction *NewFunc) {
   auto VoidTy = Builder.getModule().Types.getEmptyTupleType();
   if (StoreResultTo) {
     // Store the direct result to the original result address.
-    Builder.createStore(Loc, Result, StoreResultTo);
+    Builder.createStore(Loc, Result, StoreResultTo,
+                        StoreOwnershipQualifier::Unqualified);
     // And return Void.
     Result = Builder.createTuple(Loc, VoidTy, { });
   }
@@ -399,7 +400,8 @@ emitArgumentConversion(SmallVectorImpl<SILValue> &CallArgs) {
       } else {
         // An argument is converted from indirect to direct. Instead of the
         // address we pass the loaded value.
-        SILValue Val = Builder.createLoad(Loc, CastArg);
+        SILValue Val = Builder.createLoad(Loc, CastArg,
+                                          LoadOwnershipQualifier::Unqualified);
         CallArgs.push_back(Val);
       }
     } else {

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -178,7 +178,7 @@ emitElementAddress(unsigned EltNo, SILLocation Loc, SILBuilder &B) const {
       if (auto *NTD =
              cast_or_null<NominalTypeDecl>(PointeeType->getAnyNominal())) {
         if (isa<ClassDecl>(NTD) && Ptr->getType().isAddress())
-          Ptr = B.createLoad(Loc, Ptr);
+          Ptr = B.createLoad(Loc, Ptr, LoadOwnershipQualifier::Unqualified);
         for (auto *VD : NTD->getStoredProperties()) {
           auto FieldType = VD->getType()->getCanonicalType();
           unsigned NumFieldElements = getElementCountRec(FieldType, false);
@@ -372,7 +372,8 @@ static SILValue scalarizeLoad(LoadInst *LI,
   SmallVector<SILValue, 4> ElementTmps;
   
   for (unsigned i = 0, e = ElementAddrs.size(); i != e; ++i) {
-    auto *SubLI = B.createLoad(LI->getLoc(), ElementAddrs[i]);
+    auto *SubLI = B.createLoad(LI->getLoc(), ElementAddrs[i],
+                               LoadOwnershipQualifier::Unqualified);
     ElementTmps.push_back(SubLI);
   }
   
@@ -855,7 +856,8 @@ void ElementUseCollector::collectUses(SILValue Pointer, unsigned BaseEltNo) {
         getScalarizedElements(SI->getOperand(0), ElementTmps, SI->getLoc(), B);
         
         for (unsigned i = 0, e = ElementAddrs.size(); i != e; ++i)
-          B.createStore(SI->getLoc(), ElementTmps[i], ElementAddrs[i]);
+          B.createStore(SI->getLoc(), ElementTmps[i], ElementAddrs[i],
+                        StoreOwnershipQualifier::Unqualified);
         SI->eraseFromParent();
         continue;
       }

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -575,8 +575,9 @@ AggregateAvailableValues(SILInstruction *Inst, SILType LoadTy,
   // otherwise emit a load of the value.
   auto Val = AvailableValues[FirstElt];
   if (!Val.first)
-    return B.createLoad(Inst->getLoc(), Address);
-  
+    return B.createLoad(Inst->getLoc(), Address,
+                        LoadOwnershipQualifier::Unqualified);
+
   SILValue EltVal = ExtractSubElement(Val.first, Val.second, B, Inst->getLoc());
   // It must be the same type as LoadTy if available.
   assert(EltVal->getType() == LoadTy &&

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -225,7 +225,8 @@ void PartialApplyCombiner::releaseTemporaries() {
     for (auto *EndPoint : PAFrontier) {
       Builder.setInsertionPoint(EndPoint);
       if (!TmpType.isAddressOnly(PAI->getModule())) {
-        auto *Load = Builder.createLoad(PAI->getLoc(), Op);
+        auto *Load = Builder.createLoad(PAI->getLoc(), Op,
+                                        LoadOwnershipQualifier::Unqualified);
         Builder.createReleaseValue(PAI->getLoc(), Load, Atomicity::Atomic);
       } else {
         Builder.createDestroyAddr(PAI->getLoc(), Op);

--- a/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
@@ -257,7 +257,8 @@ SILCombiner::visitUncheckedAddrCastInst(UncheckedAddrCastInst *UADCI) {
     UI++;
 
     // Insert a new load from our source and bitcast that as appropriate.
-    LoadInst *NewLoad = Builder.createLoad(Loc, Op);
+    LoadInst *NewLoad =
+        Builder.createLoad(Loc, Op, LoadOwnershipQualifier::Unqualified);
     auto *BitCast = Builder.createUncheckedBitCast(Loc, NewLoad,
                                                     OutputTy.getObjectType());
     // Replace all uses of the old load with the new bitcasted result and erase
@@ -321,11 +322,13 @@ SILCombiner::visitUncheckedRefCastAddrInst(UncheckedRefCastAddrInst *URCI) {
  
   SILLocation Loc = URCI->getLoc();
   Builder.setCurrentDebugScope(URCI->getDebugScope());
-  LoadInst *load = Builder.createLoad(Loc, URCI->getSrc());
+  LoadInst *load = Builder.createLoad(Loc, URCI->getSrc(),
+                                      LoadOwnershipQualifier::Unqualified);
   auto *cast = Builder.tryCreateUncheckedRefCast(Loc, load,
                                                  DestTy.getObjectType());
   assert(cast && "SILBuilder cannot handle reference-castable types");
-  Builder.createStore(Loc, cast, URCI->getDest());
+  Builder.createStore(Loc, cast, URCI->getDest(),
+                      StoreOwnershipQualifier::Unqualified);
 
   return eraseInstFromFunction(*URCI);
 }

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -115,7 +115,8 @@ SILInstruction *SILCombiner::visitSwitchEnumAddrInst(SwitchEnumAddrInst *SEAI) {
 
   Builder.setCurrentDebugScope(SEAI->getDebugScope());
   SILBasicBlock *Default = SEAI->hasDefault() ? SEAI->getDefaultBB() : 0;
-  LoadInst *EnumVal = Builder.createLoad(SEAI->getLoc(), SEAI->getOperand());
+  LoadInst *EnumVal = Builder.createLoad(SEAI->getLoc(), SEAI->getOperand(),
+                                         LoadOwnershipQualifier::Unqualified);
   Builder.createSwitchEnum(SEAI->getLoc(), EnumVal, Default, Cases);
   return eraseInstFromFunction(*SEAI);
 }
@@ -157,8 +158,8 @@ SILInstruction *SILCombiner::visitSelectEnumAddrInst(SelectEnumAddrInst *SEAI) {
     Cases.push_back(SEAI->getCase(i));
 
   SILValue Default = SEAI->hasDefault() ? SEAI->getDefaultResult() : SILValue();
-  LoadInst *EnumVal = Builder.createLoad(SEAI->getLoc(),
-                                          SEAI->getEnumOperand());
+  LoadInst *EnumVal = Builder.createLoad(SEAI->getLoc(), SEAI->getEnumOperand(),
+                                         LoadOwnershipQualifier::Unqualified);
   auto *I = Builder.createSelectEnum(SEAI->getLoc(), EnumVal, SEAI->getType(),
                                      Default, Cases);
   return I;
@@ -394,7 +395,8 @@ SILInstruction *SILCombiner::visitLoadInst(LoadInst *LI) {
   // (load (upcast-ptr %x)) -> (upcast-ref (load %x))
   Builder.setCurrentDebugScope(LI->getDebugScope());
   if (auto *UI = dyn_cast<UpcastInst>(LI->getOperand())) {
-    auto NewLI = Builder.createLoad(LI->getLoc(), UI->getOperand());
+    auto NewLI = Builder.createLoad(LI->getLoc(), UI->getOperand(),
+                                    LoadOwnershipQualifier::Unqualified);
     return Builder.createUpcast(LI->getLoc(), NewLI, LI->getType());
   }
 
@@ -441,7 +443,8 @@ SILInstruction *SILCombiner::visitLoadInst(LoadInst *LI) {
     // a new projection. Create the new address projection.
     auto I = Proj.createAddressProjection(Builder, LI->getLoc(), LI->getOperand());
     LastProj = &Proj;
-    LastNewLoad = Builder.createLoad(LI->getLoc(), I.get());
+    LastNewLoad = Builder.createLoad(LI->getLoc(), I.get(),
+                                     LoadOwnershipQualifier::Unqualified);
     replaceInstUsesWith(*Inst, LastNewLoad);
     eraseInstFromFunction(*Inst);
   }
@@ -776,7 +779,8 @@ SILCombiner::visitInjectEnumAddrInst(InjectEnumAddrInst *IEAI) {
     EnumInst *E =
       Builder.createEnum(IEAI->getLoc(), SILValue(), IEAI->getElement(),
                           IEAI->getOperand()->getType().getObjectType());
-    Builder.createStore(IEAI->getLoc(), E, IEAI->getOperand());
+    Builder.createStore(IEAI->getLoc(), E, IEAI->getOperand(),
+                        StoreOwnershipQualifier::Unqualified);
     return eraseInstFromFunction(*IEAI);
   }
 
@@ -892,7 +896,8 @@ SILCombiner::visitInjectEnumAddrInst(InjectEnumAddrInst *IEAI) {
     EnumInst *E = Builder.createEnum(
         DataAddrInst->getLoc(), SI->getSrc(), DataAddrInst->getElement(),
         DataAddrInst->getOperand()->getType().getObjectType());
-    Builder.createStore(DataAddrInst->getLoc(), E, DataAddrInst->getOperand());
+    Builder.createStore(DataAddrInst->getLoc(), E, DataAddrInst->getOperand(),
+                        StoreOwnershipQualifier::Unqualified);
     // Cleanup.
     eraseInstFromFunction(*SI);
     eraseInstFromFunction(*DataAddrInst);
@@ -938,11 +943,13 @@ SILCombiner::visitInjectEnumAddrInst(InjectEnumAddrInst *IEAI) {
                                               EnumInitOperand->get()->getType());
   EnumInitOperand->set(AllocStack);
   Builder.setInsertionPoint(std::next(SILBasicBlock::iterator(AI)));
-  SILValue Load(Builder.createLoad(DataAddrInst->getLoc(), AllocStack));
+  SILValue Load(Builder.createLoad(DataAddrInst->getLoc(), AllocStack,
+                                   LoadOwnershipQualifier::Unqualified));
   EnumInst *E = Builder.createEnum(
       DataAddrInst->getLoc(), Load, DataAddrInst->getElement(),
       DataAddrInst->getOperand()->getType().getObjectType());
-  Builder.createStore(DataAddrInst->getLoc(), E, DataAddrInst->getOperand());
+  Builder.createStore(DataAddrInst->getLoc(), E, DataAddrInst->getOperand(),
+                      StoreOwnershipQualifier::Unqualified);
   Builder.createDeallocStack(DataAddrInst->getLoc(), AllocStack);
   eraseInstFromFunction(*DataAddrInst);
   return eraseInstFromFunction(*IEAI);
@@ -1012,7 +1019,8 @@ visitUncheckedTakeEnumDataAddrInst(UncheckedTakeEnumDataAddrInst *TEDAI) {
     LoadInst *L = cast<LoadInst>(U->getUser());
 
     // Insert a new Load of the enum and extract the data from that.
-    auto *Ld = Builder.createLoad(Loc, EnumAddr);
+    auto *Ld =
+        Builder.createLoad(Loc, EnumAddr, LoadOwnershipQualifier::Unqualified);
     auto *D = Builder.createUncheckedEnumData(Loc, Ld, EnumElt, PayloadType);
 
     // Replace all uses of the old load with the data and erase the old load.
@@ -1223,7 +1231,8 @@ SILInstruction *SILCombiner::visitFixLifetimeInst(FixLifetimeInst *FLI) {
   Builder.setCurrentDebugScope(FLI->getDebugScope());
   if (auto *AI = dyn_cast<AllocStackInst>(FLI->getOperand())) {
     if (FLI->getOperand()->getType().isLoadable(FLI->getModule())) {
-      auto Load = Builder.createLoad(FLI->getLoc(), AI);
+      auto Load = Builder.createLoad(FLI->getLoc(), AI,
+                                     LoadOwnershipQualifier::Unqualified);
       return Builder.createFixLifetime(FLI->getLoc(), Load);
     }
   }

--- a/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
@@ -1194,7 +1194,8 @@ bool DSEContext::run() {
       SILInstruction *Inst = cast<SILInstruction>(I->first);
       auto *IT = &*std::next(Inst->getIterator());
       SILBuilderWithScope Builder(IT);
-      Builder.createStore(Inst->getLoc(), I->second, Inst);
+      Builder.createStore(Inst->getLoc(), I->second, Inst,
+                          StoreOwnershipQualifier::Unqualified);
     }
     // Delete the dead stores.
     for (auto &I : getBlockState(&BB)->DeadStores) {

--- a/lib/SILOptimizer/Transforms/SILLowerAggregateInstrs.cpp
+++ b/lib/SILOptimizer/Transforms/SILLowerAggregateInstrs.cpp
@@ -81,7 +81,8 @@ static bool expandCopyAddr(CopyAddrInst *CA) {
   SILBuilderWithScope Builder(CA);
 
   // %new = load %0 : $*T
-  LoadInst *New = Builder.createLoad(CA->getLoc(), Source);
+  LoadInst *New = Builder.createLoad(CA->getLoc(), Source,
+                                     LoadOwnershipQualifier::Unqualified);
 
   SILValue Destination = CA->getDest();
 
@@ -98,7 +99,8 @@ static bool expandCopyAddr(CopyAddrInst *CA) {
     IsInitialization_t IsInit = CA->isInitializationOfDest();
     LoadInst *Old = nullptr;
     if (IsInitialization_t::IsNotInitialization == IsInit) {
-      Old = Builder.createLoad(CA->getLoc(), Destination);
+      Old = Builder.createLoad(CA->getLoc(), Destination,
+                               LoadOwnershipQualifier::Unqualified);
     }
 
     // If we are not taking and have a reference type:
@@ -122,7 +124,8 @@ static bool expandCopyAddr(CopyAddrInst *CA) {
   }
 
   // Create the store.
-  Builder.createStore(CA->getLoc(), New, Destination);
+  Builder.createStore(CA->getLoc(), New, Destination,
+                      StoreOwnershipQualifier::Unqualified);
 
   ++NumExpand;
   return true;
@@ -144,7 +147,8 @@ static bool expandDestroyAddr(DestroyAddrInst *DA) {
   // If we have a non-trivial type...
   if (!Type.isTrivial(Module)) {
     // If we have a type with reference semantics, emit a load/strong release.
-    LoadInst *LI = Builder.createLoad(DA->getLoc(), Addr);
+    LoadInst *LI = Builder.createLoad(DA->getLoc(), Addr,
+                                      LoadOwnershipQualifier::Unqualified);
     auto &TL = Module.getTypeLowering(Type);
     TL.emitLoweredDestroyValue(Builder, DA->getLoc(), LI,
                                TypeLowering::LoweringStyle::DeepNoEnum);

--- a/lib/SILOptimizer/Transforms/SILSROA.cpp
+++ b/lib/SILOptimizer/Transforms/SILSROA.cpp
@@ -233,7 +233,8 @@ void SROAMemoryUseAnalyzer::chopUpAlloca(std::vector<AllocStackInst *> &Worklist
     SILBuilderWithScope B(LI);
     llvm::SmallVector<SILValue, 4> Elements;
     for (auto *NewAI : NewAllocations)
-      Elements.push_back(B.createLoad(LI->getLoc(), NewAI));
+      Elements.push_back(B.createLoad(LI->getLoc(), NewAI,
+                                      LoadOwnershipQualifier::Unqualified));
     auto *Agg = createAgg(B, LI->getLoc(), LI->getType().getObjectType(),
                           Elements);
     LI->replaceAllUsesWith(Agg);
@@ -246,7 +247,8 @@ void SROAMemoryUseAnalyzer::chopUpAlloca(std::vector<AllocStackInst *> &Worklist
     for (unsigned EltNo : indices(NewAllocations))
       B.createStore(SI->getLoc(),
                     createAggProjection(B, SI->getLoc(), SI->getSrc(), EltNo),
-                    NewAllocations[EltNo]);
+                    NewAllocations[EltNo],
+                    StoreOwnershipQualifier::Unqualified);
     SI->eraseFromParent();
   }
 

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -91,7 +91,8 @@ void GenericCloner::populateCloned() {
         // Store the new direct parameter to the alloc_stack.
         auto *NewArg =
           new (M) SILArgument(ClonedEntryBB, mappedType, OrigArg->getDecl());
-        getBuilder().createStore(Loc, NewArg, ASI);
+        getBuilder().createStore(Loc, NewArg, ASI,
+                                 StoreOwnershipQualifier::Unqualified);
 
         // Try to create a new debug_value from an existing debug_value_addr.
         for (Operand *ArgUse : OrigArg->getUses()) {
@@ -125,8 +126,9 @@ void GenericCloner::populateCloned() {
       if (ReturnValueAddr) {
         // The result is converted from indirect to direct. We have to load the
         // returned value from the alloc_stack.
-        ReturnValue = getBuilder().createLoad(ReturnValueAddr->getLoc(),
-                                              ReturnValueAddr);
+        ReturnValue =
+            getBuilder().createLoad(ReturnValueAddr->getLoc(), ReturnValueAddr,
+                                    LoadOwnershipQualifier::Unqualified);
       }
       for (AllocStackInst *ASI : reverse(AllocStacks)) {
         getBuilder().createDeallocStack(ASI->getLoc(), ASI);

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -271,7 +271,8 @@ static ApplySite replaceWithSpecializedCallee(ApplySite AI,
       } else {
         // An argument is converted from indirect to direct. Instead of the
         // address we pass the loaded value.
-        SILValue Val = Builder.createLoad(Loc, Op.get());
+        SILValue Val = Builder.createLoad(Loc, Op.get(),
+                                          LoadOwnershipQualifier::Unqualified);
         Arguments.push_back(Val);
       }
     } else {
@@ -296,7 +297,8 @@ static ApplySite replaceWithSpecializedCallee(ApplySite AI,
       SILArgument *Arg =
         ResultBB->replaceBBArg(0, StoreResultTo->getType().getObjectType());
       // Store the direct result to the original result address.
-      Builder.createStore(Loc, Arg, StoreResultTo);
+      Builder.createStore(Loc, Arg, StoreResultTo,
+                          StoreOwnershipQualifier::Unqualified);
     }
     return NewTAI;
   }
@@ -305,7 +307,8 @@ static ApplySite replaceWithSpecializedCallee(ApplySite AI,
     if (StoreResultTo) {
       // Store the direct result to the original result address.
       fixUsedVoidType(A, Loc, Builder);
-      Builder.createStore(Loc, NewAI, StoreResultTo);
+      Builder.createStore(Loc, NewAI, StoreResultTo,
+                          StoreOwnershipQualifier::Unqualified);
     }
     A->replaceAllUsesWith(NewAI);
     return NewAI;
@@ -401,7 +404,8 @@ static SILFunction *createReabstractionThunk(const ReabstractionInfo &ReInfo,
         SILType Ty = SpecArg->getType().getAddressType();
         SILArgument *NewArg = new (M) SILArgument(EntryBB, Ty,
                                                   SpecArg->getDecl());
-        auto *ArgVal = Builder.createLoad(Loc, NewArg);
+        auto *ArgVal = Builder.createLoad(Loc, NewArg,
+                                          LoadOwnershipQualifier::Unqualified);
         Arguments.push_back(ArgVal);
       }
     } else {
@@ -433,7 +437,8 @@ static SILFunction *createReabstractionThunk(const ReabstractionInfo &ReInfo,
   }
   if (ReturnValueAddr) {
     // Need to store the direct results to the original indirect address.
-    Builder.createStore(Loc, ReturnValue, ReturnValueAddr);
+    Builder.createStore(Loc, ReturnValue, ReturnValueAddr,
+                        StoreOwnershipQualifier::Unqualified);
     SILType VoidTy = OrigPAI->getSubstCalleeType()->getSILResult();
     assert(VoidTy.isVoid());
     ReturnValue = Builder.createTuple(Loc, VoidTy, { });

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1455,7 +1455,8 @@ optimizeBridgedObjCToSwiftCast(SILInstruction *Inst,
     }
 
     // Generate a load for the source argument.
-    auto *Load = Builder.createLoad(Loc, Src);
+    auto *Load =
+        Builder.createLoad(Loc, Src, LoadOwnershipQualifier::Unqualified);
     // Try to convert the source into the expected ObjC type first.
 
 
@@ -1694,7 +1695,7 @@ optimizeBridgedSwiftToObjCCast(SILInstruction *Inst,
   auto FnRef = Builder.createFunctionRef(Loc, BridgedFunc);
   if (Src->getType().isAddress() && !ParamTypes[0].isIndirect()) {
     // Create load
-    Src = Builder.createLoad(Loc, Src);
+    Src = Builder.createLoad(Loc, Src, LoadOwnershipQualifier::Unqualified);
   }
 
   // Compensate different owning conventions of the replaced cast instruction
@@ -1795,7 +1796,8 @@ optimizeBridgedSwiftToObjCCast(SILInstruction *Inst,
            "of the source operand");
     auto CastedValue = SILValue(
         (ConvTy == DestTy) ? NewI : Builder.createUpcast(Loc, NewAI, DestTy));
-    NewI = Builder.createStore(Loc, CastedValue, Dest);
+    NewI = Builder.createStore(Loc, CastedValue, Dest,
+                               StoreOwnershipQualifier::Unqualified);
   }
 
   if (Dest) {
@@ -2169,7 +2171,8 @@ optimizeCheckedCastAddrBranchInst(CheckedCastAddrBranchInst *Inst) {
           SuccessBB->createBBArg(Dest->getType().getObjectType(), nullptr);
           B.setInsertionPoint(SuccessBB->begin());
           // Store the result
-          B.createStore(Loc, SuccessBB->getBBArg(0), Dest);
+          B.createStore(Loc, SuccessBB->getBBArg(0), Dest,
+                        StoreOwnershipQualifier::Unqualified);
           EraseInstAction(Inst);
           return NewI;
         }
@@ -2477,7 +2480,8 @@ optimizeUnconditionalCheckedCastAddrInst(UnconditionalCheckedCastAddrInst *Inst)
     if (!resultTL.isAddressOnly()) {
       auto undef = SILValue(SILUndef::get(DestType.getObjectType(),
                                           Builder.getModule()));
-      Builder.createStore(Loc, undef, Dest);
+      Builder.createStore(Loc, undef, Dest,
+                          StoreOwnershipQualifier::Unqualified);
     }
     auto *TrapI = Builder.createBuiltinTrap(Loc);
     Inst->replaceAllUsesWithUndef();


### PR DESCRIPTION
[semantic-arc] Eliminate default {Load,Store}OwnershipQualification argument to SILBuilder::create{Load,Store}(...)

Today, loads and stores are treated as having @unowned(unsafe) ownership
semantics. This leaves the user to specify ownership changes on the loaded or
stored value independently of the load/store by inserting ARC operations. With
the change to Semantic SIL, this will no longer be true. Instead loads, stores
have ownership semantics that one must reason about such as copy, take, and
trivial.

This change moves us closer to that world by eliminating the default
OwnershipQualification argument from create{Load,Store}. This means that the
compiler developer cannot ignore reasoning about the ownership semantics of the
memory operation that they are creating.

Operationally, this is a NFC change since I have just gone through the compiler
and updated all places where we create loads, stores to pass in the former
default argument ({Load,Store}OwnershipQualifier::Unqualified), to
SILBuilder::create{Load,Store}(...). For now, one can just do that in situations
where one needs to create loads/stores, but over time, I am going to tighten the
semantics up via the verifier.

rdar://28685236
