### PR TITLE
[swiftc (79 vs. 5179)] Add crasher in ?

### DIFF
--- a/validation-test/compiler_crashers/28447-result-case-not-implemented-failed.swift
+++ b/validation-test/compiler_crashers/28447-result-case-not-implemented-failed.swift
@@ -1,0 +1,16 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+t c
+let : {{
+return $0
+== Int
+struct B
+}
+g:


### PR DESCRIPTION
Add test case for crash triggered in `?`.

Current number of unresolved compiler crashers: 79 (5179 resolved)

Assertion failure in [`lib/AST/Type.cpp (line 1280)`](https://github.com/apple/swift/blob/master/lib/AST/Type.cpp#L1280):

```
Assertion `Result && "Case not implemented!"' failed.

When executing: swift::CanType swift::TypeBase::getCanonicalType()
```

Assertion context:

```
  }
  }

  // Cache the canonical type for future queries.
  assert(Result && "Case not implemented!");
  CanonicalType = Result;
  return CanType(Result);
}

```

Stack trace:

```
swift: /path/to/swift/lib/AST/Type.cpp:1280: swift::CanType swift::TypeBase::getCanonicalType(): Assertion `Result && "Case not implemented!"' failed.
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28447-result-case-not-implemented-failed.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28447-result-case-not-implemented-failed-778155.o
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
