### PR TITLE
[SR-2860] Change the way comments are exported to Doxygen

### DIFF
--- a/test/Inputs/comment_to_something_conversion.swift
+++ b/test/Inputs/comment_to_something_conversion.swift
@@ -109,10 +109,9 @@ public enum A012_AttachToEntities {
 
 @objc public class ClosingComments {
 // CHECK: {{.*}}DocCommentAsXML=none
-
   /// Some comment. */
   public func closingComment() {}
-// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>closingComment()</Name><USR>s:F14swift_ide_test28codeListingWithOtherLanguageFT_T_</USR><Declaration>public func closingComment()</Declaration><Abstract><Para>Some comment. */</Para></Function>]
+// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>closingComment()</Name><USR>s:FC14swift_ide_test15ClosingComments14closingCommentFT_T_</USR><Declaration>public func closingComment()</Declaration><Abstract><Para>Some comment. */</Para></Abstract></Function>]
 }
 
 @objc public class ClosureContainer {

--- a/test/Inputs/comment_to_something_conversion.swift
+++ b/test/Inputs/comment_to_something_conversion.swift
@@ -51,6 +51,17 @@ public enum A012_AttachToEntities {
 @objc public protocol A013_AttachToEntities {}
 // CHECK: {{.*}}DocCommentAsXML=[<Class file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>A013_AttachToEntities</Name><USR>s:P14swift_ide_test21A013_AttachToEntities</USR><Declaration>@objc public protocol A013_AttachToEntities</Declaration><Abstract><Para>Aaa.  A013.</Para></Abstract></Class>]
 
+@objc public class ATXHeaders {
+// CHECK: {{.*}}DocCommentAsXML=none
+  /// LEVEL ONE
+  /// =========
+  ///
+  /// LEVEL TWO
+  /// ---------
+  public func f0() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test10ATXHeaders2f0FT_T_</USR><Declaration>public func f0()</Declaration><Discussion><rawHTML><![CDATA[<h1>]]></rawHTML>LEVEL ONE<rawHTML><![CDATA[</h1>]]></rawHTML><rawHTML><![CDATA[<h2>]]></rawHTML>LEVEL TWO<rawHTML><![CDATA[</h2>]]></rawHTML></Discussion></Function>]
+}
+
 @objc public class AutomaticLink {
 // CHECK: {{.*}}DocCommentAsXML=none
   /// And now for a URL.
@@ -69,17 +80,6 @@ public enum A012_AttachToEntities {
   /// > Ccc.
   public func f0() {}
 // CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test10BlockQuote2f0FT_T_</USR><Declaration>public func f0()</Declaration><Abstract><Para>Aaa.</Para></Abstract><Discussion><Para>Bbb.</Para><Para>Ccc.</Para></Discussion></Function>]
-}
-
-@objc public class ATXHeaders {
-// CHECK: {{.*}}DocCommentAsXML=none
-  /// LEVEL ONE
-  /// =========
-  ///
-  /// LEVEL TWO
-  /// ---------
-  public func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test10ATXHeaders2f0FT_T_</USR><Declaration>public func f0()</Declaration><Discussion><rawHTML><![CDATA[<h1>]]></rawHTML>LEVEL ONE<rawHTML><![CDATA[</h1>]]></rawHTML><rawHTML><![CDATA[<h2>]]></rawHTML>LEVEL TWO<rawHTML><![CDATA[</h2>]]></rawHTML></Discussion></Function>]
 }
 
 @objc public class Brief {
@@ -156,6 +156,14 @@ public enum A012_AttachToEntities {
 // CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test9CodeBlock2f0FT_T_</USR><Declaration>public func f0()</Declaration><Abstract><Para>This is how you use this code.</Para></Abstract><Discussion><CodeListing language="swift"><zCodeLineNumbered><![CDATA[f0() // WOW!]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[f0() // WOW!]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[f0() // WOW!]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></Function>]
 }
 
+@objc public class Emphasis {
+// CHECK: {{.*}}DocCommentAsXML=none
+  /// Aaa *bbb* ccc.
+  /// Aaa _bbb_ ccc.
+  public func f0() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test8Emphasis2f0FT_T_</USR><Declaration>public func f0()</Declaration><Abstract><Para>Aaa <emphasis>bbb</emphasis> ccc. Aaa <emphasis>bbb</emphasis> ccc.</Para></Abstract></Function>]
+}
+
 @objc public class EmptyComments {
 // CHECK: {{.*}}DocCommentAsXML=none
 
@@ -181,14 +189,6 @@ public enum A012_AttachToEntities {
    */
   public func f4() {}
 // CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f4()</Name><USR>s:FC14swift_ide_test13EmptyComments2f4FT_T_</USR><Declaration>public func f4()</Declaration><Abstract><Para>Aaa.</Para></Abstract></Function>]
-}
-
-@objc public class Emphasis {
-// CHECK: {{.*}}DocCommentAsXML=none
-  /// Aaa *bbb* ccc.
-  /// Aaa _bbb_ ccc.
-  public func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test8Emphasis2f0FT_T_</USR><Declaration>public func f0()</Declaration><Abstract><Para>Aaa <emphasis>bbb</emphasis> ccc. Aaa <emphasis>bbb</emphasis> ccc.</Para></Abstract></Function>]
 }
 
 @objc public class HasThrowingFunction {
@@ -221,6 +221,38 @@ public enum A012_AttachToEntities {
   public func f0() {}
 }
 
+@objc public class IndentedBlockComment {
+// CHECK: {{.*}}DocCommentAsXML=none
+  /**
+      Brief.
+
+      First paragraph line.
+      Second paragraph line.
+
+      Now for a code sample:
+
+          var x = 1
+          // var y = 2
+          var z = 3
+  */
+  public func f1() {}
+// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f1()</Name><USR>s:FC14swift_ide_test20IndentedBlockComment2f1FT_T_</USR><Declaration>public func f1()</Declaration><Abstract><Para>Brief.</Para></Abstract><Discussion><Para>First paragraph line. Second paragraph line.</Para><Para>Now for a code sample:</Para><CodeListing language="swift"><zCodeLineNumbered><![CDATA[var x = 1]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// var y = 2]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[var z = 3]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></Function>]
+  /**
+                        Hugely indented brief.
+
+                        First paragraph line.
+                        Second paragraph line.
+
+                        Now for a code sample:
+
+                            var x = 1
+                            // var y = 2
+                            var z = 3
+  */
+  public func f2() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f2()</Name><USR>s:FC14swift_ide_test20IndentedBlockComment2f2FT_T_</USR><Declaration>public func f2()</Declaration><Abstract><Para>Hugely indented brief.</Para></Abstract><Discussion><Para>First paragraph line. Second paragraph line.</Para><Para>Now for a code sample:</Para><CodeListing language="swift"><zCodeLineNumbered><![CDATA[var x = 1]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// var y = 2]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[var z = 3]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></Function>]
+}
+
 @objc public class InlineCode {
 // CHECK: {{.*}}DocCommentAsXML=none
   /// Aaa `bbb` ccc.
@@ -233,6 +265,27 @@ public enum A012_AttachToEntities {
 /// Aaa [bbb](/path/to/something) ccc.
 public func f0() {}
 // CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test10InlineLink2f0FT_T_</USR><Declaration>public func f0()</Declaration><Abstract><Para>Aaa <Link href="/path/to/something">bbb</Link> ccc.</Para></Abstract></Function>]
+}
+
+@objc public class MultiLineBrief {
+// CHECK: {{.*}}DocCommentAsXML=none
+
+  /// Brief first line.
+  /// Brief after softbreak.
+  ///
+  /// Some paragraph text.
+  public func f0() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test14MultiLineBrief2f0FT_T_</USR><Declaration>public func f0()</Declaration><Abstract><Para>Brief first line. Brief after softbreak.</Para></Abstract><Discussion><Para>Some paragraph text.</Para></Discussion></Function>]
+}
+
+@objc public class OrderedList {
+// CHECK: {{.*}}DocCommentAsXML=none
+/// 1. Aaa.
+///
+/// 2. Bbb.
+///    Ccc.
+public func f0() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test11OrderedList2f0FT_T_</USR><Declaration>public func f0()</Declaration><Discussion><List-Number><Item><Para>Aaa.</Para></Item><Item><Para>Bbb. Ccc.</Para></Item></List-Number></Discussion></Function>]
 }
 
 /// - parameter x: A number
@@ -294,16 +347,6 @@ public func f3(_ first: Int, second: Double, third: Float) {}
 ///   Fff.
 public func f4() {}
 // CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f4()</Name><USR>s:FC14swift_ide_test15ParamAndReturns2f4FT_T_</USR><Declaration>public func f4()</Declaration><Abstract><Para>Aaa.  f4.</Para></Abstract><ResultDiscussion><Para>Eee. Fff.</Para></ResultDiscussion></Function>]
-}
-
-@objc public class OrderedList {
-// CHECK: {{.*}}DocCommentAsXML=none
-/// 1. Aaa.
-///
-/// 2. Bbb.
-///    Ccc.
-public func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test11OrderedList2f0FT_T_</USR><Declaration>public func f0()</Declaration><Discussion><List-Number><Item><Para>Aaa.</Para></Item><Item><Para>Bbb. Ccc.</Para></Item></List-Number></Discussion></Function>]
 }
 
 @objc public class ParameterOutline{
@@ -399,49 +442,6 @@ public func f0(_ x: Int, y: Int, z: Int) {}
   ///   - Fff.
   public func f0() {}
 // CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test13UnorderedList2f0FT_T_</USR><Declaration>public func f0()</Declaration><Discussion><List-Bullet><Item><Para>Aaa.</Para></Item><Item><Para>Bbb. Ccc.</Para></Item></List-Bullet><List-Bullet><Item><Para>Ddd.</Para></Item><Item><Para>Eee.</Para><List-Bullet><Item><Para>Fff.</Para></Item></List-Bullet></Item></List-Bullet></Discussion></Function>]
-}
-
-@objc public class IndentedBlockComment {
-// CHECK: {{.*}}DocCommentAsXML=none
-  /**
-      Brief.
-
-      First paragraph line.
-      Second paragraph line.
-
-      Now for a code sample:
-
-          var x = 1
-          // var y = 2
-          var z = 3
-  */
-  public func f1() {}
-// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f1()</Name><USR>s:FC14swift_ide_test20IndentedBlockComment2f1FT_T_</USR><Declaration>public func f1()</Declaration><Abstract><Para>Brief.</Para></Abstract><Discussion><Para>First paragraph line. Second paragraph line.</Para><Para>Now for a code sample:</Para><CodeListing language="swift"><zCodeLineNumbered><![CDATA[var x = 1]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// var y = 2]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[var z = 3]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></Function>]
-  /**
-                        Hugely indented brief.
-
-                        First paragraph line.
-                        Second paragraph line.
-
-                        Now for a code sample:
-
-                            var x = 1
-                            // var y = 2
-                            var z = 3
-  */
-  public func f2() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f2()</Name><USR>s:FC14swift_ide_test20IndentedBlockComment2f2FT_T_</USR><Declaration>public func f2()</Declaration><Abstract><Para>Hugely indented brief.</Para></Abstract><Discussion><Para>First paragraph line. Second paragraph line.</Para><Para>Now for a code sample:</Para><CodeListing language="swift"><zCodeLineNumbered><![CDATA[var x = 1]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// var y = 2]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[var z = 3]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></Function>]
-}
-
-@objc public class MultiLineBrief {
-// CHECK: {{.*}}DocCommentAsXML=none
-
-  /// Brief first line.
-  /// Brief after softbreak.
-  ///
-  /// Some paragraph text.
-  public func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test14MultiLineBrief2f0FT_T_</USR><Declaration>public func f0()</Declaration><Abstract><Para>Brief first line. Brief after softbreak.</Para></Abstract><Discussion><Para>Some paragraph text.</Para></Discussion></Function>]
 }
 
 /// Brief.

--- a/test/Inputs/comment_to_something_conversion.swift
+++ b/test/Inputs/comment_to_something_conversion.swift
@@ -107,6 +107,14 @@ public enum A012_AttachToEntities {
 // CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f3()</Name><USR>s:FC14swift_ide_test5Brief2f3FT_T_</USR><Declaration>public func f3()</Declaration><Abstract><Para>Aaa.</Para></Abstract><Discussion><Para>Bbb.</Para></Discussion></Function>]
 }
 
+@objc public class ClosingComments {
+// CHECK: {{.*}}DocCommentAsXML=none
+
+  /// Some comment. */
+  public func closingComment() {}
+// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>closingComment()</Name><USR>s:F14swift_ide_test28codeListingWithOtherLanguageFT_T_</USR><Declaration>public func closingComment()</Declaration><Abstract><Para>Some comment. */</Para></Function>]
+}
+
 @objc public class ClosureContainer {
 /// Partially applies a binary operator.
 ///

--- a/test/PrintAsObjC/Inputs/comments-expected-output.h
+++ b/test/PrintAsObjC/Inputs/comments-expected-output.h
@@ -103,6 +103,16 @@ SWIFT_CLASS("_TtC8comments5Brief")
 @end
 
 
+SWIFT_CLASS("_TtC8comments15ClosingComments")
+@interface ClosingComments
+/**
+  Some comment. */
+*/
+- (void)closingComment;
+- (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
+@end
+
+
 SWIFT_CLASS("_TtC8comments16ClosureContainer")
 @interface ClosureContainer
 /**

--- a/test/PrintAsObjC/Inputs/comments-expected-output.h
+++ b/test/PrintAsObjC/Inputs/comments-expected-output.h
@@ -4,32 +4,22 @@ SWIFT_CLASS("_TtC8comments4A000")
 @end
 
 
-/**
-  Aaa.  A010.  Bbb.
-*/
+/// Aaa.  A010.  Bbb.
 SWIFT_CLASS("_TtC8comments21A010_AttachToEntities")
 @interface A010_AttachToEntities
-/**
-  Aaa.  init().
-*/
+/// Aaa.  init().
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 - (NSInteger)objectAtIndexedSubscript:(NSInteger)i SWIFT_WARN_UNUSED_RESULT;
 - (void)setObject:(NSInteger)newValue atIndexedSubscript:(NSInteger)i;
-/**
-  Aaa.  v1.
-*/
+/// Aaa.  v1.
 @property (nonatomic) NSInteger v1;
-/**
-  Aaa.  v2.
-*/
+/// Aaa.  v2.
 SWIFT_CLASS_PROPERTY(@property (nonatomic, class, readonly) NSInteger v2;)
 + (NSInteger)v2 SWIFT_WARN_UNUSED_RESULT;
 @end
 
 
-/**
-  Aaa.  A013.
-*/
+/// Aaa.  A013.
 SWIFT_PROTOCOL("_TtP8comments21A013_AttachToEntities_")
 @protocol A013_AttachToEntities
 @end
@@ -37,10 +27,8 @@ SWIFT_PROTOCOL("_TtP8comments21A013_AttachToEntities_")
 
 SWIFT_CLASS("_TtC8comments10ATXHeaders")
 @interface ATXHeaders
-/**
-  <h1>LEVEL ONE</h1>
-  <h2>LEVEL TWO</h2>
-*/
+/// <h1>LEVEL ONE</h1>
+/// <h2>LEVEL TWO</h2>
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -48,10 +36,8 @@ SWIFT_CLASS("_TtC8comments10ATXHeaders")
 
 SWIFT_CLASS("_TtC8comments13AutomaticLink")
 @interface AutomaticLink
-/**
-  And now for a URL.
-  <a href="http://developer.apple.com/swift/">http://developer.apple.com/swift/</a>
-*/
+/// And now for a URL.
+/// <a href="http://developer.apple.com/swift/">http://developer.apple.com/swift/</a>
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -59,17 +45,15 @@ SWIFT_CLASS("_TtC8comments13AutomaticLink")
 
 SWIFT_CLASS("_TtC8comments10BlockQuote")
 @interface BlockQuote
-/**
-  Aaa.
-  <blockquote>
-  Bbb.
-
-  </blockquote>
-  <blockquote>
-  Ccc.
-
-  </blockquote>
-*/
+/// Aaa.
+/// <blockquote>
+/// Bbb.
+///
+/// </blockquote>
+/// <blockquote>
+/// Ccc.
+///
+/// </blockquote>
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -77,27 +61,19 @@ SWIFT_CLASS("_TtC8comments10BlockQuote")
 
 SWIFT_CLASS("_TtC8comments5Brief")
 @interface Brief
-/**
-  Aaa.
-*/
+/// Aaa.
 - (void)f0;
-/**
-  Aaa.
-  Bbb.
-*/
+/// Aaa.
+/// Bbb.
 - (void)f1;
-/**
-  Aaa.
-  <blockquote>
-  Bbb.
-
-  </blockquote>
-*/
+/// Aaa.
+/// <blockquote>
+/// Bbb.
+///
+/// </blockquote>
 - (void)f2;
-/**
-  Aaa.
-  Bbb.
-*/
+/// Aaa.
+/// Bbb.
 - (void)f3;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -105,9 +81,7 @@ SWIFT_CLASS("_TtC8comments5Brief")
 
 SWIFT_CLASS("_TtC8comments15ClosingComments")
 @interface ClosingComments
-/**
-  Some comment. */
-*/
+/// Some comment. */
 - (void)closingComment;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -115,74 +89,68 @@ SWIFT_CLASS("_TtC8comments15ClosingComments")
 
 SWIFT_CLASS("_TtC8comments16ClosureContainer")
 @interface ClosureContainer
-/**
-  Partially applies a binary operator.
-  \param a The left-hand side to partially apply.
-
-  \param combine A binary operator.
-
-  \a combine parameters:
-  <ul>
-  <li>
-  lhs: The left-hand side of the operator
-  </li>
-  <li>
-  rhs: The right-hand side of the operator
-  </li>
-  </ul>
-
-
-  \a combine returns: A result.
-
-  \a combine error: Nothing.
-
-*/
+/// Partially applies a binary operator.
+/// \param a The left-hand side to partially apply.
+///
+/// \param combine A binary operator.
+///
+/// \a combine parameters:
+/// <ul>
+/// <li>
+/// lhs: The left-hand side of the operator
+/// </li>
+/// <li>
+/// rhs: The right-hand side of the operator
+/// </li>
+/// </ul>
+///
+///
+/// \a combine returns: A result.
+///
+/// \a combine error: Nothing.
+///
 - (void)closureParameterExplodedExplodedWithA:(NSInteger)a combine:(SWIFT_NOESCAPE NSInteger (^ _Nonnull)(NSInteger, NSInteger))combine;
-/**
-  Partially applies a binary operator.
-  \param a The left-hand side to partially apply.
-
-  \param combine A binary operator.
-
-  \a combine parameters:
-  <ul>
-  <li>
-  lhs: The left-hand side of the operator
-  </li>
-  <li>
-  rhs: The right-hand side of the operator
-  </li>
-  </ul>
-
-
-  \a combine returns: A result.
-
-  \a combine error: Nothing.
-
-*/
+/// Partially applies a binary operator.
+/// \param a The left-hand side to partially apply.
+///
+/// \param combine A binary operator.
+///
+/// \a combine parameters:
+/// <ul>
+/// <li>
+/// lhs: The left-hand side of the operator
+/// </li>
+/// <li>
+/// rhs: The right-hand side of the operator
+/// </li>
+/// </ul>
+///
+///
+/// \a combine returns: A result.
+///
+/// \a combine error: Nothing.
+///
 - (void)closureParameterOutlineExplodedWithA:(NSInteger)a combine:(SWIFT_NOESCAPE NSInteger (^ _Nonnull)(NSInteger, NSInteger))combine;
-/**
-  Partially applies a binary operator.
-  \param a The left-hand side to partially apply.
-
-  \param combine A binary operator.
-
-  \a combine parameters:
-  <ul>
-  <li>
-  lhs: The left-hand side of the operator
-  </li>
-  <li>
-  rhs: The right-hand side of the operator
-  </li>
-  </ul>
-
-
-  \a combine returns: A result.
-
-  \a combine error: Nothing.
-
-*/
+/// Partially applies a binary operator.
+/// \param a The left-hand side to partially apply.
+///
+/// \param combine A binary operator.
+///
+/// \a combine parameters:
+/// <ul>
+/// <li>
+/// lhs: The left-hand side of the operator
+/// </li>
+/// <li>
+/// rhs: The right-hand side of the operator
+/// </li>
+/// </ul>
+///
+///
+/// \a combine returns: A result.
+///
+/// \a combine error: Nothing.
+///
 - (void)closureParameterOutlineOutlineWithA:(NSInteger)a combine:(SWIFT_NOESCAPE NSInteger (^ _Nonnull)(NSInteger, NSInteger))combine;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -190,14 +158,13 @@ SWIFT_CLASS("_TtC8comments16ClosureContainer")
 
 SWIFT_CLASS("_TtC8comments9CodeBlock")
 @interface CodeBlock
-/**
-  This is how you use this code.
-  \code
-  f0() // WOW!
-  f0() // WOW!
-  f0() // WOW!
-
-  \endcode*/
+/// This is how you use this code.
+/// \code
+/// f0() // WOW!
+/// f0() // WOW!
+/// f0() // WOW!
+///
+/// \endcode
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -205,10 +172,8 @@ SWIFT_CLASS("_TtC8comments9CodeBlock")
 
 SWIFT_CLASS("_TtC8comments8Emphasis")
 @interface Emphasis
-/**
-  Aaa <em>bbb</em> ccc.
-  Aaa <em>bbb</em> ccc.
-*/
+/// Aaa <em>bbb</em> ccc.
+/// Aaa <em>bbb</em> ccc.
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -216,22 +181,15 @@ SWIFT_CLASS("_TtC8comments8Emphasis")
 
 SWIFT_CLASS("_TtC8comments13EmptyComments")
 @interface EmptyComments
-/**
-*/
+///
 - (void)f0;
-/**
-  Aaa.
-*/
+/// Aaa.
 - (void)f1;
-/**
-*/
+///
 - (void)f2;
-/**
-*/
+///
 - (void)f3;
-/**
-  Aaa.
-*/
+/// Aaa.
 - (void)f4;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -239,14 +197,12 @@ SWIFT_CLASS("_TtC8comments13EmptyComments")
 
 SWIFT_CLASS("_TtC8comments19HasThrowingFunction")
 @interface HasThrowingFunction
-/**
-  Might throw something.
-  \param x A number
-
-
-  throws:
-  An error if <code>x == 0</code>
-*/
+/// Might throw something.
+/// \param x A number
+///
+///
+/// throws:
+/// An error if <code>x == 0</code>
 - (void)f1:(NSInteger)x;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -254,11 +210,9 @@ SWIFT_CLASS("_TtC8comments19HasThrowingFunction")
 
 SWIFT_CLASS("_TtC8comments15HorizontalRules")
 @interface HorizontalRules
-/**
-  Briefly.
-  <hr/>
-  The end.
-*/
+/// Briefly.
+/// <hr/>
+/// The end.
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -266,9 +220,7 @@ SWIFT_CLASS("_TtC8comments15HorizontalRules")
 
 SWIFT_CLASS("_TtC8comments16ImplicitNameLink")
 @interface ImplicitNameLink
-/**
-  <a href="https://www.apple.com/">Apple</a>
-*/
+/// <a href="https://www.apple.com/">Apple</a>
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -276,29 +228,27 @@ SWIFT_CLASS("_TtC8comments16ImplicitNameLink")
 
 SWIFT_CLASS("_TtC8comments20IndentedBlockComment")
 @interface IndentedBlockComment
-/**
-  Brief.
-  First paragraph line.
-  Second paragraph line.
-  Now for a code sample:
-  \code
-  var x = 1
-  // var y = 2
-  var z = 3
-
-  \endcode*/
+/// Brief.
+/// First paragraph line.
+/// Second paragraph line.
+/// Now for a code sample:
+/// \code
+/// var x = 1
+/// // var y = 2
+/// var z = 3
+///
+/// \endcode
 - (void)f1;
-/**
-  Hugely indented brief.
-  First paragraph line.
-  Second paragraph line.
-  Now for a code sample:
-  \code
-  var x = 1
-  // var y = 2
-  var z = 3
-
-  \endcode*/
+/// Hugely indented brief.
+/// First paragraph line.
+/// Second paragraph line.
+/// Now for a code sample:
+/// \code
+/// var x = 1
+/// // var y = 2
+/// var z = 3
+///
+/// \endcode
 - (void)f2;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -306,9 +256,7 @@ SWIFT_CLASS("_TtC8comments20IndentedBlockComment")
 
 SWIFT_CLASS("_TtC8comments10InlineCode")
 @interface InlineCode
-/**
-  Aaa <code>bbb</code> ccc.
-*/
+/// Aaa <code>bbb</code> ccc.
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -316,9 +264,7 @@ SWIFT_CLASS("_TtC8comments10InlineCode")
 
 SWIFT_CLASS("_TtC8comments10InlineLink")
 @interface InlineLink
-/**
-  Aaa <a href="/path/to/something">bbb</a> ccc.
-*/
+/// Aaa <a href="/path/to/something">bbb</a> ccc.
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -326,11 +272,9 @@ SWIFT_CLASS("_TtC8comments10InlineLink")
 
 SWIFT_CLASS("_TtC8comments14MultiLineBrief")
 @interface MultiLineBrief
-/**
-  Brief first line.
-  Brief after softbreak.
-  Some paragraph text.
-*/
+/// Brief first line.
+/// Brief after softbreak.
+/// Some paragraph text.
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -338,75 +282,61 @@ SWIFT_CLASS("_TtC8comments14MultiLineBrief")
 
 SWIFT_CLASS("_TtC8comments11OrderedList")
 @interface OrderedList
-/**
-  <ol>
-    <li>
-      Aaa.
-    </li>
-    <li>
-      Bbb.
-      Ccc.
-    </li>
-  </ol>
-*/
+/// <ol>
+///   <li>
+///     Aaa.
+///   </li>
+///   <li>
+///     Bbb.
+///     Ccc.
+///   </li>
+/// </ol>
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
 
 
-/**
-  \param x A number
-
-*/
+/// \param x A number
+///
 SWIFT_CLASS("_TtC8comments15ParamAndReturns")
 @interface ParamAndReturns
-/**
-  Aaa.  f0.
-  \param first Bbb.
-
-  \param second Ccc.  Ddd.
-  Eee.
-
-*/
+/// Aaa.  f0.
+/// \param first Bbb.
+///
+/// \param second Ccc.  Ddd.
+/// Eee.
+///
 - (void)f0:(NSInteger)first second:(double)second;
-/**
-  Aaa.  f1.
-  \param first Bbb.
-
-
-  returns:
-  Ccc.
-  Ddd.
-*/
+/// Aaa.  f1.
+/// \param first Bbb.
+///
+///
+/// returns:
+/// Ccc.
+/// Ddd.
 - (void)f1:(NSInteger)first;
-/**
-  Aaa.  f2.
-  \param first 
-
-  \param second Aaa.
-
-  \param third 
-  Bbb.
-
-*/
+/// Aaa.  f2.
+/// \param first 
+///
+/// \param second Aaa.
+///
+/// \param third 
+/// Bbb.
+///
 - (void)f2:(NSInteger)first second:(double)second third:(float)third;
-/**
-  Aaa.  f3.
-  \param first Bbb.
-
-  \param second Ccc.
-
-  \param third Ddd.
-
-*/
+/// Aaa.  f3.
+/// \param first Bbb.
+///
+/// \param second Ccc.
+///
+/// \param third Ddd.
+///
 - (void)f3:(NSInteger)first second:(double)second third:(float)third;
-/**
-  Aaa.  f4.
-
-  returns:
-  Eee.
-  Fff.
-*/
+/// Aaa.  f4.
+///
+/// returns:
+/// Eee.
+/// Fff.
 - (void)f4;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -414,14 +344,12 @@ SWIFT_CLASS("_TtC8comments15ParamAndReturns")
 
 SWIFT_CLASS("_TtC8comments16ParameterOutline")
 @interface ParameterOutline
-/**
-  \param x A number
-
-  \param y A number
-
-  \param z A number
-
-*/
+/// \param x A number
+///
+/// \param y A number
+///
+/// \param z A number
+///
 - (void)f0:(NSInteger)x y:(NSInteger)y z:(NSInteger)z;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -429,22 +357,20 @@ SWIFT_CLASS("_TtC8comments16ParameterOutline")
 
 SWIFT_CLASS("_TtC8comments22ParameterOutlineMiddle")
 @interface ParameterOutlineMiddle
-/**
-  <ul>
-    <li>
-      This line should remain.
-    </li>
-    <li>
-      This line should also remain.
-    </li>
-  </ul>
-  \param x A number
-
-  \param y A number
-
-  \param z A number
-
-*/
+/// <ul>
+///   <li>
+///     This line should remain.
+///   </li>
+///   <li>
+///     This line should also remain.
+///   </li>
+/// </ul>
+/// \param x A number
+///
+/// \param y A number
+///
+/// \param z A number
+///
 - (void)f0:(NSInteger)x y:(NSInteger)y z:(NSInteger)z;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -458,11 +384,9 @@ SWIFT_CLASS("_TtC8comments13ReferenceLink")
 
 SWIFT_CLASS("_TtC8comments7Returns")
 @interface Returns
-/**
-
-  returns:
-  A number
-*/
+///
+/// returns:
+/// A number
 - (NSInteger)f0 SWIFT_WARN_UNUSED_RESULT;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -470,10 +394,8 @@ SWIFT_CLASS("_TtC8comments7Returns")
 
 SWIFT_CLASS("_TtC8comments18SeparateParameters")
 @interface SeparateParameters
-/**
-  \param x A number
-
-*/
+/// \param x A number
+///
 - (void)f0:(NSInteger)x y:(NSInteger)y;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -481,14 +403,12 @@ SWIFT_CLASS("_TtC8comments18SeparateParameters")
 
 SWIFT_CLASS("_TtC8comments13SetextHeaders")
 @interface SetextHeaders
-/**
-  <h1>LEVEL ONE</h1>
-  <h2>LEVEL TWO</h2>
-  <h3>LEVEL THREE</h3>
-  <h4>LEVEL FOUR</h4>
-  <h5>LEVEL FIVE</h5>
-  <h5>LEVEL SIX</h5>
-*/
+/// <h1>LEVEL ONE</h1>
+/// <h2>LEVEL TWO</h2>
+/// <h3>LEVEL THREE</h3>
+/// <h4>LEVEL FOUR</h4>
+/// <h5>LEVEL FIVE</h5>
+/// <h5>LEVEL SIX</h5>
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -496,10 +416,8 @@ SWIFT_CLASS("_TtC8comments13SetextHeaders")
 
 SWIFT_CLASS("_TtC8comments14StrongEmphasis")
 @interface StrongEmphasis
-/**
-  Aaa <em>bbb</em> ccc.
-  Aaa <em>bbb</em> ccc.
-*/
+/// Aaa <em>bbb</em> ccc.
+/// Aaa <em>bbb</em> ccc.
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -507,30 +425,28 @@ SWIFT_CLASS("_TtC8comments14StrongEmphasis")
 
 SWIFT_CLASS("_TtC8comments13UnorderedList")
 @interface UnorderedList
-/**
-  <ul>
-    <li>
-      Aaa.
-    </li>
-    <li>
-      Bbb.
-      Ccc.
-    </li>
-  </ul>
-  <ul>
-    <li>
-      Ddd.
-    </li>
-    <li>
-      Eee.
-      <ul>
-        <li>
-          Fff.
-        </li>
-      </ul>
-    </li>
-  </ul>
-*/
+/// <ul>
+///   <li>
+///     Aaa.
+///   </li>
+///   <li>
+///     Bbb.
+///     Ccc.
+///   </li>
+/// </ul>
+/// <ul>
+///   <li>
+///     Ddd.
+///   </li>
+///   <li>
+///     Eee.
+///     <ul>
+///       <li>
+///         Fff.
+///       </li>
+///     </ul>
+///   </li>
+/// </ul>
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end

--- a/test/PrintAsObjC/cdecl.swift
+++ b/test/PrintAsObjC/cdecl.swift
@@ -8,9 +8,7 @@
 
 // REQUIRES: objc_interop
 
-// CHECK: /**
-// CHECK-NEXT: What a nightmare!
-// CHECK: */
+// CHECK: /// What a nightmare!
 // CHECK-LABEL: double (^ _Nonnull block_nightmare(SWIFT_NOESCAPE float (^ _Nonnull x)(NSInteger)))(char);
 
 /// What a nightmare!

--- a/test/PrintAsObjC/enums.swift
+++ b/test/PrintAsObjC/enums.swift
@@ -74,14 +74,9 @@ import Foundation
   func methodNotExportedToObjC() {}
 }
 
-// CHECK: /**
-// CHECK-NEXT: Foo: A feer, a female feer.
-// CHECK-NEXT: */
-
+// CHECK: /// Foo: A feer, a female feer.
 // CHECK-NEXT: typedef SWIFT_ENUM(NSInteger, FooComments) {
-// CHECK: /**
-// CHECK-NEXT: Zim: A zeer, a female zeer.
-// CHECK: */
+// CHECK: /// Zim: A zeer, a female zeer.
 // CHECK-NEXT:   FooCommentsZim = 0,
 // CHECK-NEXT:   FooCommentsZang = 1,
 // CHECK-NEXT:   FooCommentsZung = 2,


### PR DESCRIPTION
**What's in this PR?**

SR-2860 describes a problem where some comments in Swift may generate an invalid Objective C header file `<ProjectName>-Swift.h`, rendering the project not compilable.

This PR fixes that problem by exporting comments with `///` instead of `/** */`. Swift to Objective C conversion routines in PrintAsObjC appear to print documentation comments using the Doxygen converter (`DoxygenConverter` class).

**How is it done?**

For easy reviewing, commit by commit, this PR does:
1. Small refactoring that sorts test cases from `test/Inputs/comment_to_something_conversion.swift` alphabetically, as encouraged by its header comment.
2. Add a failing test case for this bug to the suite.
3. Modify the code in `DoxygenConverter` and existing tests so that comments are exported with `///` to Doxygen.

I can squash them into a single commit after review, if necessary.

Resolves [SR-2860](https://bugs.swift.org/browse/SR-2860).
