### PR TITLE
[gardening] Now that the old TypeLowering::LoweringStyle::Deep is gone, rename TypeLowering::LoweringStyle::DeepNoEnum => TypeLowering::LoweringStyle::Deep.

### DIFF
--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -230,10 +230,7 @@ public:
   virtual void emitDestroyRValue(SILBuilder &B, SILLocation loc,
                                  SILValue value) const = 0;
 
-  enum class LoweringStyle {
-    Shallow,
-    DeepNoEnum
-  };
+  enum class LoweringStyle { Shallow, Deep };
 
   /// Emit a lowered 'release_value' operation.
   ///
@@ -261,9 +258,9 @@ public:
   /// Emit a lowered 'release_value' operation.
   ///
   /// This type must be loadable.
-  void emitLoweredDestroyValueDeepNoEnum(SILBuilder &B, SILLocation loc,
-                                         SILValue value) const {
-    emitLoweredDestroyValue(B, loc, value, LoweringStyle::DeepNoEnum);
+  void emitLoweredDestroyValueDeep(SILBuilder &B, SILLocation loc,
+                                   SILValue value) const {
+    emitLoweredDestroyValue(B, loc, value, LoweringStyle::Deep);
   }
 
   /// Given a primitively loaded value of this type (which must be
@@ -295,9 +292,9 @@ public:
   /// Emit a lowered 'retain_value' operation.
   ///
   /// This type must be loadable.
-  SILValue emitLoweredCopyValueDeepNoEnum(SILBuilder &B, SILLocation loc,
-                                          SILValue value) const {
-    return emitLoweredCopyValue(B, loc, value, LoweringStyle::DeepNoEnum);
+  SILValue emitLoweredCopyValueDeep(SILBuilder &B, SILLocation loc,
+                                    SILValue value) const {
+    return emitLoweredCopyValue(B, loc, value, LoweringStyle::Deep);
   }
 
   /// Given a primitively loaded value of this type (which must be

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -714,8 +714,8 @@ namespace {
       case LoweringStyle::Shallow:
         Fn = &TypeLowering::emitDestroyValue;
         break;
-      case LoweringStyle::DeepNoEnum:
-        Fn = &TypeLowering::emitLoweredDestroyValueDeepNoEnum;
+      case LoweringStyle::Deep:
+        Fn = &TypeLowering::emitLoweredDestroyValueDeep;
         break;
       }
 

--- a/lib/SILOptimizer/Transforms/SILLowerAggregateInstrs.cpp
+++ b/lib/SILOptimizer/Transforms/SILLowerAggregateInstrs.cpp
@@ -110,7 +110,7 @@ static bool expandCopyAddr(CopyAddrInst *CA) {
     IsTake_t IsTake = CA->isTakeOfSrc();
     if (IsTake_t::IsNotTake == IsTake) {
       TL.emitLoweredCopyValue(Builder, CA->getLoc(), New,
-                              TypeLowering::LoweringStyle::DeepNoEnum);
+                              TypeLowering::LoweringStyle::Deep);
     }
 
     // If we are not initializing:
@@ -119,7 +119,7 @@ static bool expandCopyAddr(CopyAddrInst *CA) {
     // release_value %old : $*T
     if (Old) {
       TL.emitLoweredDestroyValue(Builder, CA->getLoc(), Old,
-                                 TypeLowering::LoweringStyle::DeepNoEnum);
+                                 TypeLowering::LoweringStyle::Deep);
     }
   }
 
@@ -151,7 +151,7 @@ static bool expandDestroyAddr(DestroyAddrInst *DA) {
                                       LoadOwnershipQualifier::Unqualified);
     auto &TL = Module.getTypeLowering(Type);
     TL.emitLoweredDestroyValue(Builder, DA->getLoc(), LI,
-                               TypeLowering::LoweringStyle::DeepNoEnum);
+                               TypeLowering::LoweringStyle::Deep);
   }
 
   ++NumExpand;
@@ -173,7 +173,7 @@ static bool expandReleaseValue(ReleaseValueInst *DV) {
 
   auto &TL = Module.getTypeLowering(Type);
   TL.emitLoweredDestroyValue(Builder, DV->getLoc(), Value,
-                             TypeLowering::LoweringStyle::DeepNoEnum);
+                             TypeLowering::LoweringStyle::Deep);
 
   DEBUG(llvm::dbgs() << "    Expanding Destroy Value: " << *DV);
 
@@ -196,7 +196,7 @@ static bool expandRetainValue(RetainValueInst *CV) {
 
   auto &TL = Module.getTypeLowering(Type);
   TL.emitLoweredCopyValue(Builder, CV->getLoc(), Value,
-                          TypeLowering::LoweringStyle::DeepNoEnum);
+                          TypeLowering::LoweringStyle::Deep);
 
   DEBUG(llvm::dbgs() << "    Expanding Copy Value: " << *CV);
 

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -348,7 +348,7 @@ static void replaceDestroy(DestroyAddrInst *DAI, SILValue NewValue) {
   auto Ty = DAI->getOperand()->getType();
   auto &TL = DAI->getModule().getTypeLowering(Ty);
   TL.emitLoweredDestroyValue(Builder, DAI->getLoc(), NewValue,
-                             Lowering::TypeLowering::LoweringStyle::DeepNoEnum);
+                             Lowering::TypeLowering::LoweringStyle::Deep);
   DAI->eraseFromParent();
 }
 


### PR DESCRIPTION
[gardening] Now that the old TypeLowering::LoweringStyle::Deep is gone, rename TypeLowering::LoweringStyle::DeepNoEnum => TypeLowering::LoweringStyle::Deep.
