### PR TITLE
[Diagnostics] Extend contextual failure checking to all apply expressions

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -5438,7 +5438,31 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
   }
 
   auto overloadName = calleeInfo.declName;
-  
+
+  // Local function to check if the error with argument type is
+  // related to contextual type information of the enclosing expression
+  // rather than resolution of argument expression itself.
+  auto isContextualConversionFailure = [&](Expr *argExpr) -> bool {
+    // If we found an exact match, this must be a problem with a conversion from
+    // the result of the call to the expected type. Diagnose this as a
+    // conversion failure.
+    if (calleeInfo.closeness == CC_ExactMatch)
+      return true;
+
+    if (!CS->getContextualType() || calleeInfo.closeness != CC_ArgumentMismatch)
+      return false;
+
+    CalleeCandidateInfo candidates(fnExpr, hasTrailingClosure, CS);
+
+    // Filter original list of choices based on the deduced type of
+    // argument expression after force re-check.
+    candidates.filterContextualMemberList(argExpr);
+
+    // One of the candidates matches exactly, which means that
+    // this is a contextual type conversion failure, we can't diagnose here.
+    return candidates.closeness == CC_ExactMatch;
+  };
+
   // Otherwise, we have a generic failure.  Diagnose it with a generic error
   // message now.
   if (isa<BinaryExpr>(callExpr) && isa<TupleExpr>(argExpr)) {
@@ -5478,28 +5502,9 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
         return true;
       }
     }
-    
-    // If we found an exact match, this must be a problem with a conversion from
-    // the result of the call to the expected type.  Diagnose this as a
-    // conversion failure.
-    if (calleeInfo.closeness == CC_ExactMatch)
+
+    if (isContextualConversionFailure(argTuple))
       return false;
-
-    // If this is not a specific structural problem we can diagnose,
-    // let's check if this is contextual type conversion error.
-    if (CS->getContextualType() &&
-        calleeInfo.closeness == CC_ArgumentMismatch) {
-      CalleeCandidateInfo candidates(fnExpr, hasTrailingClosure, CS);
-
-      // Filter original list of choices based on the deduced type of
-      // argument expression after force re-check.
-      candidates.filterContextualMemberList(argTuple);
-
-      // One of the candidates matches exactly, which means that
-      // this is a contextual type conversion failure, we can't diagnose here.
-      if (candidates.closeness == CC_ExactMatch)
-        return false;
-    }
 
     if (!lhsType->isEqual(rhsType)) {
       diagnose(callExpr->getLoc(), diag::cannot_apply_binop_to_args,
@@ -5527,11 +5532,8 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
 
     return true;
   }
-  
-  // If we found an exact match, this must be a problem with a conversion from
-  // the result of the call to the expected type.  Diagnose this as a
-  // conversion failure.
-  if (calleeInfo.closeness == CC_ExactMatch)
+
+  if (isContextualConversionFailure(argExpr))
     return false;
   
   // Generate specific error messages for unary operators.

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -356,3 +356,15 @@ class C_SR_2505 : P_SR_2505 {
 }
 
 let _ = C_SR_2505().call(C_SR_2505())
+
+// <rdar://problem/28909024> Returning incorrect result type from method invocation can result in nonsense diagnostic
+extension Collection {
+  func r28909024(_ predicate: (Iterator.Element)->Bool) -> Index {
+    return startIndex
+  }
+}
+func fn_r28909024(n: Int) {
+  return (0..<10).r28909024 { // expected-error {{unexpected non-void return value in void function}}
+    _ in true
+  }
+}

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -414,8 +414,7 @@ func testSomeCollections(_ sc1: SomeCollection1, sc2: SomeCollection2) {
   _ = mig
 
   var ig = sc2.myGenerate()
-  ig = MyIndexedIterator(container: sc2, index: sc2.myStartIndex) // expected-error{{cannot invoke initializer for type 'MyIndexedIterator<_>' with an argument list of type '(container: SomeCollection2, index: Int)'}}
-  // expected-note @-1 {{expected an argument list of type '(container: C, index: C.Index)'}}
+  ig = MyIndexedIterator(container: sc2, index: sc2.myStartIndex) // expected-error {{cannot assign value of type 'MyIndexedIterator<SomeCollection2>' to type 'OtherIndexedIterator<SomeCollection2>'}}
   _ = ig
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->

Extends support for contextual failure checking from only BinaryExpr to
all of the expressions being diagnosed via FailureDiagnosis::visitApplyExpr.
Such helps to properly diagnose e.g. closures which contextually incorrect
result type or type construction and assignment to a different type.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

As an extension of SR-2208 apply contextual conversion failure checking
to all of the expressions diagnosed via FailureDiagnosis::visitApplyExpr.

Resolves <rdar://problem/28909024>.