### PR TITLE
[swiftc (80 vs. 5179)] Add crasher in ?

### DIFF
--- a/validation-test/compiler_crashers/28448-dist-nested-type-should-have-matched-associated-type-failed.swift
+++ b/validation-test/compiler_crashers/28448-dist-nested-type-should-have-matched-associated-type-failed.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+extension A{func c:f.c:typealias e:A{}}protocol A{typealias f{}typealias e


### PR DESCRIPTION
Add test case for crash triggered in `?`.

Current number of unresolved compiler crashers: 80 (5179 resolved)

Assertion failure in [`lib/AST/ArchetypeBuilder.cpp (line 1693)`](https://github.com/apple/swift/blob/master/lib/AST/ArchetypeBuilder.cpp#L1693):

```
Assertion `dist > 0 && "nested type should have matched associated type"' failed.

When executing: swift::Identifier typoCorrectNestedType(ArchetypeBuilder::PotentialArchetype *)
```

Assertion context:

```
        continue;

      unsigned dist = name.edit_distance(assocType->getName().str(),
                                         /*allowReplacements=*/true,
                                         maxScore);
      assert(dist > 0 && "nested type should have matched associated type");
      if (bestEditDistance == 0 || dist == bestEditDistance) {
        bestEditDistance = dist;
        maxScore = bestEditDistance;
        bestMatches.push_back(assocType->getName());
      } else if (dist < bestEditDistance) {
```
Stack trace:

```
swift: /path/to/swift/lib/AST/ArchetypeBuilder.cpp:1693: swift::Identifier typoCorrectNestedType(ArchetypeBuilder::PotentialArchetype *): Assertion `dist > 0 && "nested type should have matched associated type"' failed.
Stack dump:
0.	Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28448-dist-nested-type-should-have-matched-associated-type-failed.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28448-dist-nested-type-should-have-matched-associated-type-failed-6ab04f.o
1.	While type-checking extension of A at validation-test/compiler_crashers/28448-dist-nested-type-should-have-matched-associated-type-failed.swift:10:1
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```