### PR TITLE
[swift-format] add option to indent switch block

### DIFF
--- a/include/swift/IDE/Formatting.h
+++ b/include/swift/IDE/Formatting.h
@@ -17,7 +17,9 @@ namespace swift {
 namespace ide {
 
 struct CodeFormatOptions {
+public:
   bool UseTabs = false;
+  bool IndentSwitchCase = false;
   unsigned IndentWidth = 4;
   unsigned TabWidth = 4;
 };

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -336,6 +336,11 @@ def use_tabs : Flag<["-"], "use-tabs">, Group<code_formatting_Group>,
   Flags<[NoInteractiveOption, NoBatchOption, SwiftFormatOption]>,
   HelpText<"Use tabs for indentation.">;
 
+def indent_switch_case : Flag<["-"], "indent-switch-case">,
+  Group<code_formatting_Group>,
+  Flags<[NoInteractiveOption, NoBatchOption, SwiftFormatOption]>,
+  HelpText<"Indent cases in switch statements.">;
+
 def in_place : Flag<["-"], "in-place">, Group<code_formatting_Group>,
   Flags<[NoInteractiveOption, NoBatchOption, SwiftFormatOption]>,
   HelpText<"Overwrite input file with formatted file.">;

--- a/test/swift-format/main.swift
+++ b/test/swift-format/main.swift
@@ -4,12 +4,23 @@
 // RUN: diff -u %s.indent2.response %t.response
 // RUN: %swift-format -use-tabs %s >%t.response
 // RUN: diff -u %s.tabs.response %t.response
-// RUN: %swift-format -line-range 12:18 %s >%t.response
+// RUN: %swift-format -line-range 24:29 %s >%t.response
 // RUN: diff -u %s.lines.response %t.response
+// RUN: %swift-format -indent-switch-case %s >%t.response
+// RUN: diff -u %s.indentswitch.response %t.response
 
 import Foundation
 
-func collatz(n: Int) {
+func collatz(n: Int, m: String?) {
+switch m {
+    case .some(let s):
+            print(s)
+case .none:
+print("nothing")
+default:
+    print("not possible")
+break
+    }
  var r: Int
     if n%2 == 0 {
           r = n/2

--- a/test/swift-format/main.swift.indent2.response
+++ b/test/swift-format/main.swift.indent2.response
@@ -4,12 +4,23 @@
 // RUN: diff -u %s.indent2.response %t.response
 // RUN: %swift-format -use-tabs %s >%t.response
 // RUN: diff -u %s.tabs.response %t.response
-// RUN: %swift-format -line-range 12:18 %s >%t.response
+// RUN: %swift-format -line-range 24:29 %s >%t.response
 // RUN: diff -u %s.lines.response %t.response
+// RUN: %swift-format -indent-switch-case %s >%t.response
+// RUN: diff -u %s.indentswitch.response %t.response
 
 import Foundation
 
-func collatz(n: Int) {
+func collatz(n: Int, m: String?) {
+  switch m {
+  case .some(let s):
+    print(s)
+  case .none:
+    print("nothing")
+  default:
+    print("not possible")
+    break
+  }
   var r: Int
   if n%2 == 0 {
     r = n/2

--- a/test/swift-format/main.swift.indentswitch.response
+++ b/test/swift-format/main.swift.indentswitch.response
@@ -13,13 +13,13 @@ import Foundation
 
 func collatz(n: Int, m: String?) {
     switch m {
-    case .some(let s):
-        print(s)
-    case .none:
-        print("nothing")
-    default:
-        print("not possible")
-        break
+        case .some(let s):
+            print(s)
+        case .none:
+            print("nothing")
+        default:
+            print("not possible")
+            break
     }
     var r: Int
     if n%2 == 0 {

--- a/test/swift-format/main.swift.lines.response
+++ b/test/swift-format/main.swift.lines.response
@@ -4,12 +4,23 @@
 // RUN: diff -u %s.indent2.response %t.response
 // RUN: %swift-format -use-tabs %s >%t.response
 // RUN: diff -u %s.tabs.response %t.response
-// RUN: %swift-format -line-range 12:18 %s >%t.response
+// RUN: %swift-format -line-range 24:29 %s >%t.response
 // RUN: diff -u %s.lines.response %t.response
+// RUN: %swift-format -indent-switch-case %s >%t.response
+// RUN: diff -u %s.indentswitch.response %t.response
 
 import Foundation
 
-func collatz(n: Int) {
+func collatz(n: Int, m: String?) {
+switch m {
+    case .some(let s):
+            print(s)
+case .none:
+print("nothing")
+default:
+    print("not possible")
+break
+    }
     var r: Int
     if n%2 == 0 {
         r = n/2

--- a/test/swift-format/main.swift.tabs.response
+++ b/test/swift-format/main.swift.tabs.response
@@ -4,12 +4,23 @@
 // RUN: diff -u %s.indent2.response %t.response
 // RUN: %swift-format -use-tabs %s >%t.response
 // RUN: diff -u %s.tabs.response %t.response
-// RUN: %swift-format -line-range 12:18 %s >%t.response
+// RUN: %swift-format -line-range 24:29 %s >%t.response
 // RUN: diff -u %s.lines.response %t.response
+// RUN: %swift-format -indent-switch-case %s >%t.response
+// RUN: diff -u %s.indentswitch.response %t.response
 
 import Foundation
 
-func collatz(n: Int) {
+func collatz(n: Int, m: String?) {
+	switch m {
+	case .some(let s):
+		print(s)
+	case .none:
+		print("nothing")
+	default:
+		print("not possible")
+		break
+	}
 	var r: Int
 	if n%2 == 0 {
 		r = n/2

--- a/tools/driver/swift_format_main.cpp
+++ b/tools/driver/swift_format_main.cpp
@@ -79,10 +79,8 @@ private:
   std::string MainExecutablePath;
   std::string OutputFilename = "-";
   std::vector<std::string> InputFilenames;
-  bool UseTabs = false;
+  CodeFormatOptions FormatOptions;
   bool InPlace = false;
-  unsigned TabWidth = 4;
-  unsigned IndentWidth = 4;
   std::vector<std::string> LineRanges;
 
   bool parseLineRange(StringRef Input, unsigned &FromLine, unsigned &ToLine) {
@@ -117,18 +115,21 @@ public:
     }
 
     if (ParsedArgs.getLastArg(OPT_use_tabs))
-      UseTabs = true;
+      FormatOptions.UseTabs = true;
+
+    if (ParsedArgs.getLastArg(OPT_indent_switch_case))
+      FormatOptions.IndentSwitchCase = true;
 
     if (ParsedArgs.getLastArg(OPT_in_place))
       InPlace = true;
 
     if (const Arg *A = ParsedArgs.getLastArg(OPT_tab_width))
-      if (StringRef(A->getValue()).getAsInteger(10, TabWidth))
+      if (StringRef(A->getValue()).getAsInteger(10, FormatOptions.TabWidth))
         Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
                        A->getAsString(ParsedArgs), A->getValue());
 
     if (const Arg *A = ParsedArgs.getLastArg(OPT_indent_width))
-      if (StringRef(A->getValue()).getAsInteger(10, IndentWidth))
+      if (StringRef(A->getValue()).getAsInteger(10, FormatOptions.IndentWidth))
         Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
                        A->getAsString(ParsedArgs), A->getValue());
 
@@ -186,11 +187,6 @@ public:
     if (LineRanges.empty()) {
       LineRanges.push_back("1:" + std::to_string(UINT_MAX));
     }
-
-    CodeFormatOptions FormatOptions;
-    FormatOptions.UseTabs = UseTabs;
-    FormatOptions.IndentWidth = IndentWidth;
-    FormatOptions.TabWidth = TabWidth;
 
     std::string Output = Doc.memBuffer().getBuffer();
     for (unsigned Range = 0; Range < LineRanges.size(); ++Range) {


### PR DESCRIPTION
add a boolean option to indent switch's block:

```swift
// with -indent-switch-case
switch xyz {
  case .x:
    doSomething()
  default:
    break
}
```

```swift
// without -indent-switch-case
switch xyz {
case .x:
  doSomething()
default:
  break
}
```

This option is only exposed by the `swift-format` command. The rest of `IDE/Formatting` is not affected.