### PR TITLE
[swiftc (81 vs. 5179)] Add crasher in ?

### DIFF
--- a/validation-test/compiler_crashers/28449-impl-getgraphindex-typevariables-size-out-of-bounds-index-failed.swift
+++ b/validation-test/compiler_crashers/28449-impl-getgraphindex-typevariables-size-out-of-bounds-index-failed.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+for in.E={return $0 c


### PR DESCRIPTION
Add test case for crash triggered in `?`.

Current number of unresolved compiler crashers: 81 (5179 resolved)

Assertion failure in [`lib/Sema/ConstraintGraph.cpp (line 50)`](https://github.com/apple/swift/blob/master/lib/Sema/ConstraintGraph.cpp#L50):

```
Assertion `impl.getGraphIndex() < TypeVariables.size() && "Out-of-bounds index"' failed.

When executing: std::pair<ConstraintGraphNode &, unsigned int> swift::constraints::ConstraintGraph::lookupNode(swift::TypeVariableType *)
```

Assertion context:

```
std::pair<ConstraintGraphNode &, unsigned>
ConstraintGraph::lookupNode(TypeVariableType *typeVar) {
  // Check whether we've already created a node for this type variable.
  auto &impl = typeVar->getImpl();
  if (auto nodePtr = impl.getGraphNode()) {
    assert(impl.getGraphIndex() < TypeVariables.size() && "Out-of-bounds index");
    assert(TypeVariables[impl.getGraphIndex()] == typeVar &&
           "Type variable mismatch");
    return { *nodePtr, impl.getGraphIndex() };
  }

```
Stack trace:

```
swift: /path/to/swift/lib/Sema/ConstraintGraph.cpp:50: std::pair<ConstraintGraphNode &, unsigned int> swift::constraints::ConstraintGraph::lookupNode(swift::TypeVariableType *): Assertion `impl.getGraphIndex() < TypeVariables.size() && "Out-of-bounds index"' failed.
Stack dump:
0.	Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28449-impl-getgraphindex-typevariables-size-out-of-bounds-index-failed.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28449-impl-getgraphindex-typevariables-size-out-of-bounds-index-failed-6fc8cd.o
1.	While type-checking expression at [validation-test/compiler_crashers/28449-impl-getgraphindex-typevariables-size-out-of-bounds-index-failed.swift:10:7 - line:10:21] RangeText=".E={return $0 c"
2.	While type-checking expression at [validation-test/compiler_crashers/28449-impl-getgraphindex-typevariables-size-out-of-bounds-index-failed.swift:10:7 - line:10:21] RangeText=".E={return $0 c"
3.	While type-checking expression at [validation-test/compiler_crashers/28449-impl-getgraphindex-typevariables-size-out-of-bounds-index-failed.swift:10:18 - line:10:18] RangeText="$"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```