### PR TITLE
[swiftc (82 vs. 5179)] Add crasher in ?

### DIFF
--- a/validation-test/compiler_crashers/28450-underlyingty-gettype-isnull-getting-invalid-underlying-type-failed.swift
+++ b/validation-test/compiler_crashers/28450-underlyingty-gettype-isnull-getting-invalid-underlying-type-failed.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+class B{
+typealias f:d typealias d:A
+let d=c
+protocol A


### PR DESCRIPTION
Add test case for crash triggered in `?`.

Current number of unresolved compiler crashers: 82 (5179 resolved)

Assertion failure in [`include/swift/AST/Decl.h (line 2375)`](https://github.com/apple/swift/blob/master/include/swift/AST/Decl.h#L2375):

```
Assertion `!UnderlyingTy.getType().isNull() && "getting invalid underlying type"' failed.

When executing: swift::Type swift::TypeAliasDecl::getUnderlyingType() const
```

Assertion context:

```

  /// getUnderlyingType - Returns the underlying type, which is
  /// assumed to have been set.
  Type getUnderlyingType() const {
    assert(!UnderlyingTy.getType().isNull() &&
           "getting invalid underlying type");
    return UnderlyingTy.getType();
  }

  /// computeType - Compute the type (and declared type) of this type alias;
  /// can only be called after the alias type has been resolved.
```
Stack trace:

```
swift: /path/to/swift/include/swift/AST/Decl.h:2375: swift::Type swift::TypeAliasDecl::getUnderlyingType() const: Assertion `!UnderlyingTy.getType().isNull() && "getting invalid underlying type"' failed.
Stack dump:
0.	Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28450-underlyingty-gettype-isnull-getting-invalid-underlying-type-failed.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28450-underlyingty-gettype-isnull-getting-invalid-underlying-type-failed-770015.o
1.	While type-checking 'B' at validation-test/compiler_crashers/28450-underlyingty-gettype-isnull-getting-invalid-underlying-type-failed.swift:10:1
2.	While type-checking 'f' at validation-test/compiler_crashers/28450-underlyingty-gettype-isnull-getting-invalid-underlying-type-failed.swift:11:1
3.	While resolving type d at [validation-test/compiler_crashers/28450-underlyingty-gettype-isnull-getting-invalid-underlying-type-failed.swift:11:13 - line:11:13] RangeText="d"
4.	While type-checking 'd' at validation-test/compiler_crashers/28450-underlyingty-gettype-isnull-getting-invalid-underlying-type-failed.swift:11:15
5.	While type-checking expression at [validation-test/compiler_crashers/28450-underlyingty-gettype-isnull-getting-invalid-underlying-type-failed.swift:12:7 - line:12:7] RangeText="c"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```