### PR TITLE
[swiftc (84 vs. 5179)] Add crasher in ?

### DIFF
--- a/validation-test/compiler_crashers/28452-this-genericenv-already-have-generic-context-failed.swift
+++ b/validation-test/compiler_crashers/28452-this-genericenv-already-have-generic-context-failed.swift
@@ -1,0 +1,16 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+protocol C{{
+}
+typealias F
+func g
+struct D:C{
+func g<T where T=F>func g
+func g


### PR DESCRIPTION
Add test case for crash triggered in `?`.

Current number of unresolved compiler crashers: 84 (5179 resolved)

Assertion failure in [`include/swift/AST/Decl.h (line 4613)`](https://github.com/apple/swift/blob/master/include/swift/AST/Decl.h#L4613):

```
Assertion `!this->GenericEnv && "already have generic context?"' failed.

When executing: void swift::AbstractFunctionDecl::setGenericEnvironment(swift::GenericEnvironment *)
```

Assertion context:

```
  /// Retrieve the generic context for this function.
  GenericEnvironment *getGenericEnvironment() const { return GenericEnv; }

  /// Set the generic context of this function.
  void setGenericEnvironment(GenericEnvironment *GenericEnv) {
    assert(!this->GenericEnv && "already have generic context?");
    this->GenericEnv = GenericEnv;
  }

  // Expose our import as member status
  bool isImportAsMember() const { return IAMStatus.isImportAsMember(); }
```
Stack trace:

```
swift: /path/to/swift/include/swift/AST/Decl.h:4613: void swift::AbstractFunctionDecl::setGenericEnvironment(swift::GenericEnvironment *): Assertion `!this->GenericEnv && "already have generic context?"' failed.
Stack dump:
0.	Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28452-this-genericenv-already-have-generic-context-failed.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28452-this-genericenv-already-have-generic-context-failed-1a320e.o
1.	While type-checking 'C' at validation-test/compiler_crashers/28452-this-genericenv-already-have-generic-context-failed.swift:10:1
2.	While resolving type F at [validation-test/compiler_crashers/28452-this-genericenv-already-have-generic-context-failed.swift:15:18 - line:15:18] RangeText="F"
3.	While type-checking 'g' at validation-test/compiler_crashers/28452-this-genericenv-already-have-generic-context-failed.swift:15:20
4.	While type-checking 'g' at validation-test/compiler_crashers/28452-this-genericenv-already-have-generic-context-failed.swift:15:1
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```