### PR TITLE
[swiftc (85 vs. 5179)] Add crasher in ?

### DIFF
--- a/validation-test/compiler_crashers/28453-found-interfacetoarchetypemap-end-missing-generic-parameter-failed.swift
+++ b/validation-test/compiler_crashers/28453-found-interfacetoarchetypemap-end-missing-generic-parameter-failed.swift
@@ -1,0 +1,15 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+protocol a{}protocol a{
+typealias e=a
+typealias e
+protocol a{
+func b:A
+}class A


### PR DESCRIPTION
Add test case for crash triggered in `?`.

Current number of unresolved compiler crashers: 85 (5179 resolved)

Assertion failure in [`lib/AST/GenericEnvironment.cpp (line 77)`](https://github.com/apple/swift/blob/master/lib/AST/GenericEnvironment.cpp#L77):

```
Assertion `found != InterfaceToArchetypeMap.end() && "missing generic parameter"' failed.

When executing: swift::Type swift::GenericEnvironment::mapTypeIntoContext(swift::GenericTypeParamType *) const
```

Assertion context:

```

Type GenericEnvironment::mapTypeIntoContext(GenericTypeParamType *type) const {
  auto canTy = type->getCanonicalType();
  auto found = InterfaceToArchetypeMap.find(canTy.getPointer());
  assert(found != InterfaceToArchetypeMap.end() &&
         "missing generic parameter");
  return found->second;
}

GenericTypeParamType *GenericEnvironment::getSugaredType(
    GenericTypeParamType *type) const {
```
Stack trace:

```
swift: /path/to/swift/lib/AST/GenericEnvironment.cpp:77: swift::Type swift::GenericEnvironment::mapTypeIntoContext(swift::GenericTypeParamType *) const: Assertion `found != InterfaceToArchetypeMap.end() && "missing generic parameter"' failed.
Stack dump:
0.	Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28453-found-interfacetoarchetypemap-end-missing-generic-parameter-failed.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28453-found-interfacetoarchetypemap-end-missing-generic-parameter-failed-d2922d.o
1.	While type-checking 'a' at validation-test/compiler_crashers/28453-found-interfacetoarchetypemap-end-missing-generic-parameter-failed.swift:10:1
2.	While type-checking 'e' at validation-test/compiler_crashers/28453-found-interfacetoarchetypemap-end-missing-generic-parameter-failed.swift:11:1
3.	While type-checking 'b' at validation-test/compiler_crashers/28453-found-interfacetoarchetypemap-end-missing-generic-parameter-failed.swift:14:1
4.	While resolving type A at [validation-test/compiler_crashers/28453-found-interfacetoarchetypemap-end-missing-generic-parameter-failed.swift:14:8 - line:14:8] RangeText="A"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```