### PR TITLE
[swiftc (86 vs. 5179)] Add crasher at assert(hasVal)

### DIFF
--- a/validation-test/compiler_crashers/28454-hasval-failed.swift
+++ b/validation-test/compiler_crashers/28454-hasval-failed.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+.A[]


### PR DESCRIPTION
Add test case for crash triggered in `?`.

Current number of unresolved compiler crashers: 86 (5179 resolved)

Assertion failure in `llvm/include/llvm/ADT/Optional.h (line 138)`:

```
Assertion `hasVal' failed.

When executing: T &&llvm::Optional<swift::constraints::SelectedOverload>::operator*() && [T = swift::constraints::SelectedOverload]
```

Assertion context:

```
    return hasValue() ? getValue() : std::forward<U>(value);
  }

#if LLVM_HAS_RVALUE_REFERENCE_THIS
  T&& getValue() && { assert(hasVal); return std::move(*getPointer()); }
  T&& operator*() && { assert(hasVal); return std::move(*getPointer()); }

  template <typename U>
  T getValueOr(U &&value) && {
    return hasValue() ? std::move(getValue()) : std::forward<U>(value);
  }
```
Stack trace:

```
swift: /path/to/llvm/include/llvm/ADT/Optional.h:138: T &&llvm::Optional<swift::constraints::SelectedOverload>::operator*() && [T = swift::constraints::SelectedOverload]: Assertion `hasVal' failed.
Stack dump:
0.	Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28454-hasval-failed.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28454-hasval-failed-f00cda.o
1.	While type-checking expression at [validation-test/compiler_crashers/28454-hasval-failed.swift:10:1 - line:10:4] RangeText=".A[]"
2.	While type-checking expression at [validation-test/compiler_crashers/28454-hasval-failed.swift:10:1 - line:10:4] RangeText=".A[]"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```