### PR TITLE
[PrintAsObjC] Use of imported generics require the full definition. (#5518)

### DIFF
--- a/test/PrintAsObjC/Inputs/custom-modules/SingleGenericClass.h
+++ b/test/PrintAsObjC/Inputs/custom-modules/SingleGenericClass.h
@@ -1,0 +1,6 @@
+// This file is meant to be included with modules turned off, compiled against
+// the fake clang-importer-sdk.
+#import <Foundation.h>
+
+@interface SingleImportedObjCGeneric<A> : NSObject
+@end

--- a/test/PrintAsObjC/Inputs/custom-modules/module.map
+++ b/test/PrintAsObjC/Inputs/custom-modules/module.map
@@ -19,6 +19,11 @@ module Base {
   }
 }
 
+module SingleGenericClass {
+  header "SingleGenericClass.h"
+  export *
+}
+
 module OverrideBase [system] {
   header "override.h"
   export *

--- a/test/PrintAsObjC/lit.local.cfg
+++ b/test/PrintAsObjC/lit.local.cfg
@@ -5,5 +5,6 @@ config.substitutions.insert(0, ('%check-in-clang',
   '%%clang -fsyntax-only -x objective-c-header -fobjc-arc -fmodules '
   '-fmodules-validate-system-headers '
   '-Weverything -Werror -Wno-unused-macros -Wno-incomplete-module '
+  '-Wno-auto-import '
   '-I %%clang-include-dir '
   '-isysroot %r/Inputs/clang-importer-sdk' % config.test_source_root) )


### PR DESCRIPTION
- **Explanation:** The generated Objective-C header did not properly make sure the definition of an imported Objective-C generic type was included before its use. Current support for a forward `@class` declaration isn't good enough here because that doesn't include arguments, and since any such types will be coming from Objective-C anyway (because Swift can't define Objective-C-compatible generic types) it's safe to just import the original framework. There is a workaround here, though, which is to import the necessary framework before importing the generated header in any .m files.

- **Scope:** Affects generated headers for code using Objective-C generic types other than NSArray, NSSet, and NSDictionary. (In the problem case, these headers weren't valid Objective-C.) 

- **Issue:** rdar://problem/28738008

- **Reviewed by:** @DougGregor 

- **Risk:** This is mostly using an existing code path, just applying it to more types. This may reveal bugs where there weren't any before. Other than that, though, this should be pretty safe—the cases it's designed to affect wouldn't have compiled before.

- **Testing:** Added a compiler regression test, verified that the original example now behaves correctly.