### PR TITLE
[CodeCompletion] Using the default constraints generator for TupleExpr.

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1609,7 +1609,7 @@ namespace {
       return expr->getType();
     }
 
-    virtual Type visitTupleExpr(TupleExpr *expr) {
+    Type visitTupleExpr(TupleExpr *expr) {
       // The type of a tuple expression is simply a tuple of the types of
       // its subexpressions.
       SmallVector<TupleTypeElt, 4> elements;
@@ -3005,16 +3005,6 @@ public:
     if (Target != Expr) {
       // If expr is not the target, do the default constraint generation.
       return ConstraintGenerator::visitParenExpr(Expr);
-    }
-    // Otherwise, create a type variable saying we know nothing about this expr.
-    assert(!VT && "cannot reassign type variable.");
-    return VT = createFreeTypeVariableType(Expr);
-  }
-
-  Type visitTupleExpr(TupleExpr *Expr) override {
-    if (Target != Expr) {
-      // If expr is not the target, do the default constraint generation.
-      return ConstraintGenerator::visitTupleExpr(Expr);
     }
     // Otherwise, create a type variable saying we know nothing about this expr.
     assert(!VT && "cannot reassign type variable.");

--- a/test/IDE/complete_crashes.swift
+++ b/test/IDE/complete_crashes.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=BAD_MEMBERS_1 | %FileCheck %s -check-prefix=BAD_MEMBERS_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=BAD_MEMBERS_2 | %FileCheck %s -check-prefix=BAD_MEMBERS_2
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CLOSURE_CALLED_IN_PLACE_1 | %FileCheck %s -check-prefix=WITH_GLOBAL
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RDAR_28991372 | %FileCheck %s -check-prefix=RDAR_28991372
 
 class BadMembers1 {
   var prop: Int {
@@ -188,3 +189,10 @@ conn.handler = { (msgID, msg) in
   }
 }
 // RDAR_22769393: Begin completions
+
+struct S_RDAR_28991372 {
+  init(x: Int, y: Int) {}
+}
+
+S_RDAR_28991372(x: #^RDAR_28991372^#, y: <#T##Int#>)
+// RDAR_28991372: Begin completions


### PR DESCRIPTION
    [CodeCompletion] Using the default constraints generator for TupleExpr
    when inferring the type of unresolved members. rdar://28991372

    When code completing, we used to create a type variable to represent the type
    of an entire tuple expression. However, recent improvements on parser make this
    step unnecessary and crash-prone. Thus, we use the default constraint
    generator to interpret tuple expressions.