### PR TITLE
Remove dead code related to tracking favored constraints.

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -2277,13 +2277,6 @@ bool ConstraintSystem::solveSimplified(
       DisjunctionChoices.push_back({locator, index});
     }
 
-    // Determine whether we're handling a favored constraint in subsystem.
-    const bool willBeHandlingFavoredConstraint
-      = constraint->isFavored() || HandlingFavoredConstraint;
-    llvm::SaveAndRestore<bool> handlingFavoredConstraint(
-                                 HandlingFavoredConstraint,
-                                 willBeHandlingFavoredConstraint);
-
     // Simplify this term in the disjunction.
     switch (simplifyConstraint(*constraint)) {
     case SolutionKind::Error:

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -893,10 +893,6 @@ private:
   /// solution it represents.
   Score CurrentScore;
 
-  /// Whether this constraint system is processing a favored
-  /// constraint.
-  bool HandlingFavoredConstraint = false;
-
   SmallVector<TypeVariableType *, 16> TypeVariables;
 
   /// Maps expressions to types for choosing a favored overload


### PR DESCRIPTION
At one point this was added in order to inhibit some bridging
conversions while we are handling favored constraints, but that code has
been removed now, making this dead.

Noticed by inspection.