### PR TITLE
SILGen: Check for a null emission context before dereferencing.

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -275,7 +275,8 @@ RValue Transform::transform(RValue &&input,
   SmallVector<InitializationPtr, 4> eltInitsBuffer;
   MutableArrayRef<InitializationPtr> eltInits;
   auto tupleInit = ctxt.getEmitInto();
-  if (!ctxt.getEmitInto()->canSplitIntoTupleElements()) {
+  if (!ctxt.getEmitInto()
+      || !ctxt.getEmitInto()->canSplitIntoTupleElements()) {
     tupleInit = nullptr;
   } else {
     eltInits = tupleInit->splitIntoTupleElements(SGF, Loc, outputTupleType,

--- a/test/SILGen/reabstract-tuple.swift
+++ b/test/SILGen/reabstract-tuple.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend  -emit-silgen -verify %s
+
+// SR-3090:
+
+class Box<T> {
+    public let value: T
+    
+    public init(_ value: T) {
+        self.value = value
+    }
+}
+
+let box = Box((22, { () in }))
+let foo = box.value.0
+print(foo)


### PR DESCRIPTION
Fixes https://bugs.swift.org/browse/SR-3090.