### PR TITLE
IRGen: Don't emit reflection metadata for builtin types unless we're … [3.0]

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -180,7 +180,7 @@ protected:
   // Collect any builtin types referenced from this type.
   void addBuiltinTypeRefs(CanType type) {
     type.visit([&](Type t) {
-      if (t->is<BuiltinType>())
+      if (IGM.getSwiftModule()->isStdlibModule() && t->is<BuiltinType>())
         IGM.BuiltinTypes.insert(CanType(t));
 
       // We need size/alignment information for imported value types,


### PR DESCRIPTION
- Description: Fixes an issue that was coming up in release builds with optimization enabled.

- Scope of the issue: Affects anyone building Swift projects with reflection enabled (which is the default).

- Risk: Low.

- Tested: No automated test, but user project that exhibited the issue now builds.

- Reviewed by: @bitjammer 

- Bug: rdar://problem/28924516