### PR TITLE
SILGen: Add AnyHashable erasure support for function conversions [3.0]

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1326,23 +1326,34 @@ RValue RValueEmitter::visitErasureExpr(ErasureExpr *E, SGFContext C) {
   return RValue(SGF, E, mv);
 }
 
-RValue RValueEmitter::visitAnyHashableErasureExpr(AnyHashableErasureExpr *E,
-                                                  SGFContext C) {
+RValue SILGenFunction::emitAnyHashableErasure(SILLocation loc,
+                                              ManagedValue value,
+                                              Type type,
+                                              ProtocolConformanceRef conformance,
+                                              SGFContext C) {
   // Ensure that the intrinsic function exists.
-  auto convertFn = SGF.SGM.getConvertToAnyHashable(E);
-  if (!convertFn) return SGF.emitUndefRValue(E, E->getType());
+  auto convertFn = SGM.getConvertToAnyHashable(loc);
+  if (!convertFn)
+    return emitUndefRValue(
+        loc, getASTContext().getAnyHashableDecl()->getDeclaredType());
 
   // Construct the substitution for T: Hashable.
-  ProtocolConformanceRef conformances[] = { E->getConformance() };
-  Substitution sub(E->getSubExpr()->getType(),
-                   SGF.getASTContext().AllocateCopy(conformances));
+  ProtocolConformanceRef conformances[] = { conformance };
+  Substitution sub(type, getASTContext().AllocateCopy(conformances));
 
+  return emitApplyOfLibraryIntrinsic(loc, convertFn, sub, value, C);
+}
+
+RValue RValueEmitter::visitAnyHashableErasureExpr(AnyHashableErasureExpr *E,
+                                                  SGFContext C) {
   // Emit the source value into a temporary.
   auto sourceOrigType = AbstractionPattern::getOpaque();
   auto source =
     SGF.emitMaterializedRValueAsOrig(E->getSubExpr(), sourceOrigType);
 
-  return SGF.emitApplyOfLibraryIntrinsic(E, convertFn, sub, source, C);
+  return SGF.emitAnyHashableErasure(E, source,
+                                    E->getSubExpr()->getType(),
+                                    E->getConformance(), C);
 }
 
 /// Treating this as a successful operation, turn a CMV into a +1 MV.

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1203,6 +1203,12 @@ public:
   
   void emitReturnExpr(SILLocation loc, Expr *ret);
 
+  RValue emitAnyHashableErasure(SILLocation loc,
+                                ManagedValue value,
+                                Type type,
+                                ProtocolConformanceRef conformance,
+                                SGFContext C);
+
   /// Turn a consumable managed value into a +1 managed value.
   ManagedValue getManagedValue(SILLocation loc,
                                ConsumableManagedValue value);

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -520,6 +520,21 @@ ManagedValue Transform::transform(ManagedValue v,
                                     ctxt);
   }
 
+  // - T : Hashable to AnyHashable
+  if (isa<StructType>(outputSubstType) &&
+      outputSubstType->getAnyNominal() ==
+        SGF.getASTContext().getAnyHashableDecl()) {
+    auto *protocol = SGF.getASTContext().getProtocol(
+        KnownProtocolKind::Hashable);
+    auto conformance = SGF.SGM.M.getSwiftModule()->lookupConformance(
+        inputSubstType, protocol, nullptr);
+    auto result = SGF.emitAnyHashableErasure(Loc, v, inputSubstType,
+                                             *conformance, ctxt);
+    if (result.isInContext())
+      return ManagedValue::forInContext();
+    return std::move(result).getAsSingleValue(SGF, Loc);
+  }
+
   // Should have handled the conversion in one of the cases above.
   llvm_unreachable("Unhandled transform?");
 }

--- a/test/SILGen/function_conversion.swift
+++ b/test/SILGen/function_conversion.swift
@@ -429,3 +429,25 @@ func convTupleScalar(_ f1: @escaping (Q) -> (),
 func convTupleScalarOpaque<T>(_ f: @escaping (T...) -> ()) -> ((_ args: T...) -> ())? {
   return f
 }
+
+// ==== Make sure we support AnyHashable erasure
+
+// CHECK-LABEL: sil hidden @_TF19function_conversion15convAnyHashableuRxs8HashablerFT1tx_T_
+// CHECK:         function_ref @_TFF19function_conversion15convAnyHashableuRxs8HashablerFT1tx_T_U_FTVs11AnyHashableS1__Sb
+// CHECK:         function_ref @_TTRGRxs8HashablerXFo_iVs11AnyHashableiS0__dSb_XFo_ixix_dSb_
+
+// CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @_TTRGRxs8HashablerXFo_iVs11AnyHashableiS0__dSb_XFo_ixix_dSb_ : $@convention(thin) <T where T : Hashable> (@in T, @in T, @owned @callee_owned (@in AnyHashable, @in AnyHashable) -> Bool) -> Bool
+// CHECK:         alloc_stack $AnyHashable
+// CHECK:         function_ref @_swift_convertToAnyHashable
+// CHECK:         apply {{.*}}<T>
+// CHECK:         alloc_stack $AnyHashable
+// CHECK:         function_ref @_swift_convertToAnyHashable
+// CHECK:         apply {{.*}}<T>
+// CHECK:         return
+
+
+func convAnyHashable<T : Hashable>(t: T) {
+  let fn: (T, T) -> Bool = {
+    (x: AnyHashable, y: AnyHashable) in x == y
+  }
+}


### PR DESCRIPTION
- Description: When AnyHashable was added in Swift 3, we forgot to update SILGen's function conversion path to support it.

- Scope of the issue: The bug is pretty obscure but at least in the reported case, it is unclear to the user that AnyHashable is used at all, or what the workaround is.

- Risk: Low.

- Tested: New automated test added.

- Bug: https://bugs.swift.org/browse/SR-2603 and rdar://problem/28787005

- Reviewed by: @jckarter 