### PR TITLE
[semantic-arc] Qualify most of the stores in SILGen as store [init].

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -464,6 +464,15 @@ public:
                       LoadInst(getSILDebugLocation(Loc), LV, Qualifier));
   }
 
+  /// Convenience function for calling emitLoad on the type lowering for
+  /// non-address values.
+  SILValue emitLoadValueOperation(SILLocation Loc, SILValue LV,
+                                  LoadOwnershipQualifier Qualifier) {
+    assert(LV->getType().isLoadable(F.getModule()));
+    const auto &lowering = getTypeLowering(LV->getType());
+    return lowering.emitLoad(*this, Loc, LV, Qualifier);
+  }
+
   LoadBorrowInst *createLoadBorrow(SILLocation Loc, SILValue LV) {
     assert(LV->getType().isLoadable(F.getModule()));
     return insert(new (F.getModule())
@@ -474,6 +483,15 @@ public:
                          StoreOwnershipQualifier Qualifier) {
     return insert(new (F.getModule()) StoreInst(getSILDebugLocation(Loc), Src,
                                                 DestAddr, Qualifier));
+  }
+
+  /// Convenience function for calling emitStore on the type lowering for
+  /// non-address values.
+  void emitStoreValueOperation(SILLocation Loc, SILValue Src, SILValue DestAddr,
+                               StoreOwnershipQualifier Qualifier) {
+    assert(!Src->getType().isAddress());
+    const auto &lowering = getTypeLowering(Src->getType());
+    return lowering.emitStore(*this, Loc, Src, DestAddr, Qualifier);
   }
 
   EndBorrowInst *createEndBorrow(SILLocation Loc, SILValue Src,

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -13,12 +13,13 @@
 #ifndef SWIFT_SIL_TYPELOWERING_H
 #define SWIFT_SIL_TYPELOWERING_H
 
-#include "swift/AST/CaptureInfo.h"
 #include "swift/ABI/MetadataValues.h"
+#include "swift/AST/CaptureInfo.h"
 #include "swift/SIL/AbstractionPattern.h"
+#include "swift/SIL/SILDeclRef.h"
+#include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILLocation.h"
 #include "swift/SIL/SILValue.h"
-#include "swift/SIL/SILDeclRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/SmallVector.h"
@@ -208,6 +209,21 @@ public:
                                SILValue value,
                                SILValue addr,
                                IsInitialization_t isInit) const = 0;
+
+  /// Emit a store of \p value into \p addr given the StoreOwnershipQualifier
+  /// qual.
+  ///
+  /// This abstracts over the differences in between trivial and non-trivial
+  /// types.
+  virtual void emitStore(SILBuilder &B, SILLocation loc, SILValue value,
+                         SILValue addr, StoreOwnershipQualifier qual) const = 0;
+
+  /// Emit a load from \p addr given the LoadOwnershipQualifier \p qual.
+  ///
+  /// This abstracts over the differences in between trivial and non-trivial
+  /// types.
+  virtual SILValue emitLoad(SILBuilder &B, SILLocation loc, SILValue addr,
+                            LoadOwnershipQualifier qual) const = 0;
 
   /// Put an exact copy of the value in the source address in the
   /// destination address.

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -529,6 +529,16 @@ namespace {
       B.createStore(loc, value, addr, StoreOwnershipQualifier::Unqualified);
     }
 
+    void emitStore(SILBuilder &B, SILLocation loc, SILValue value,
+                   SILValue addr, StoreOwnershipQualifier qual) const override {
+      B.createStore(loc, value, addr, StoreOwnershipQualifier::Trivial);
+    }
+
+    SILValue emitLoad(SILBuilder &B, SILLocation loc, SILValue addr,
+                      LoadOwnershipQualifier qual) const override {
+      return B.createLoad(loc, addr, LoadOwnershipQualifier::Trivial);
+    }
+
     void emitDestroyAddress(SILBuilder &B, SILLocation loc,
                             SILValue addr) const override {
       // Trivial
@@ -582,6 +592,16 @@ namespace {
       B.createStore(loc, newValue, addr, StoreOwnershipQualifier::Unqualified);
       if (!isInit)
         emitDestroyValue(B, loc, oldValue);
+    }
+
+    void emitStore(SILBuilder &B, SILLocation loc, SILValue value,
+                   SILValue addr, StoreOwnershipQualifier qual) const override {
+      B.createStore(loc, value, addr, qual);
+    }
+
+    SILValue emitLoad(SILBuilder &B, SILLocation loc, SILValue addr,
+                      LoadOwnershipQualifier qual) const override {
+      return B.createLoad(loc, addr, qual);
     }
   };
 
@@ -930,6 +950,16 @@ namespace {
                          SILValue newValue, SILValue addr,
                          IsInitialization_t isInit) const override {
       llvm_unreachable("calling emitStoreOfCopy on non-loadable type");
+    }
+
+    void emitStore(SILBuilder &B, SILLocation loc, SILValue value,
+                   SILValue addr, StoreOwnershipQualifier qual) const override {
+      llvm_unreachable("calling emitStore on non-loadable type");
+    }
+
+    SILValue emitLoad(SILBuilder &B, SILLocation loc, SILValue addr,
+                      LoadOwnershipQualifier qual) const override {
+      llvm_unreachable("calling emitLoad on non-loadable type");
     }
 
     void emitDestroyAddress(SILBuilder &B, SILLocation loc,

--- a/lib/SILGen/ManagedValue.cpp
+++ b/lib/SILGen/ManagedValue.cpp
@@ -44,15 +44,16 @@ ManagedValue ManagedValue::copy(SILGenFunction &gen, SILLocation l) {
 
 /// Store a copy of this value with independent ownership into the given
 /// uninitialized address.
-void ManagedValue::copyInto(SILGenFunction &gen, SILValue dest, SILLocation L) {
+void ManagedValue::copyInto(SILGenFunction &gen, SILValue dest,
+                            SILLocation loc) {
   auto &lowering = gen.getTypeLowering(getType());
   if (lowering.isAddressOnly()) {
-    gen.B.createCopyAddr(L, getValue(), dest,
-                         IsNotTake, IsInitialization);
+    gen.B.createCopyAddr(loc, getValue(), dest, IsNotTake, IsInitialization);
     return;
   }
-  lowering.emitCopyValue(gen.B, L, getValue());
-  gen.B.createStore(L, getValue(), dest, StoreOwnershipQualifier::Unqualified);
+
+  SILValue copy = lowering.emitCopyValue(gen.B, loc, getValue());
+  lowering.emitStoreOfCopy(gen.B, loc, copy, dest, IsInitialization);
 }
 
 /// This is the same operation as 'copy', but works on +0 values that don't

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -719,8 +719,8 @@ static Callee prepareArchetypeCallee(SILGenFunction &gen, SILLocation loc,
       // Store the reference into a temporary.
       auto temp =
         gen.emitTemporaryAllocation(selfLoc, ref.getValue()->getType());
-      gen.B.createStore(selfLoc, ref.getValue(), temp,
-                        StoreOwnershipQualifier::Unqualified);
+      gen.B.emitStoreValueOperation(selfLoc, ref.getValue(), temp,
+                                    StoreOwnershipQualifier::Init);
 
       // If we had a cleanup, create a cleanup at the new address.
       return maybeEnterCleanupForTransformed(gen, ref, temp);
@@ -2580,8 +2580,8 @@ static ManagedValue emitMaterializeIntoTemporary(SILGenFunction &gen,
                                                  ManagedValue object) {
   auto temporary = gen.emitTemporaryAllocation(loc, object.getType());
   bool hadCleanup = object.hasCleanup();
-  gen.B.createStore(loc, object.forward(gen), temporary,
-                    StoreOwnershipQualifier::Unqualified);
+  gen.B.emitStoreValueOperation(loc, object.forward(gen), temporary,
+                                StoreOwnershipQualifier::Init);
 
   // The temporary memory is +0 if the value was.
   if (hadCleanup) {

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -104,8 +104,8 @@ emitBridgeNativeToObjectiveC(SILGenFunction &gen,
   if (witnessFnTy.castTo<SILFunctionType>()->getParameters()[0].isIndirect()
       && !swiftValue.getType().isAddress()) {
     auto tmp = gen.emitTemporaryAllocation(loc, swiftValue.getType());
-    gen.B.createStore(loc, swiftValue.getValue(), tmp,
-                      StoreOwnershipQualifier::Unqualified);
+    gen.B.emitStoreValueOperation(loc, swiftValue.getValue(), tmp,
+                                  StoreOwnershipQualifier::Init);
     swiftValue = ManagedValue::forUnmanaged(tmp);
   }
 
@@ -433,8 +433,8 @@ ManagedValue SILGenFunction::emitFuncToBlock(SILLocation loc,
   // Store the function to the block without claiming it, so that it still
   // gets cleaned up in scope. Copying the block will create an independent
   // reference.
-  B.createStore(loc, fn.getValue(), capture,
-                StoreOwnershipQualifier::Unqualified);
+  B.emitStoreValueOperation(loc, fn.getValue(), capture,
+                            StoreOwnershipQualifier::Init);
   auto invokeFn = B.createFunctionRef(loc, thunk);
   
   auto stackBlock = B.createInitBlockStorageHeader(loc, storage, invokeFn,

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -592,8 +592,8 @@ emitBuiltinCastReference(SILGenFunction &gen,
     // a retain. The cast will load the reference from the source temp and
     // store it into a dest temp effectively forwarding the cleanup.
     fromAddr = gen.emitTemporaryAllocation(loc, srcVal->getType());
-    gen.B.createStore(loc, srcVal, fromAddr,
-                      StoreOwnershipQualifier::Unqualified);
+    fromTL.emitStore(gen.B, loc, srcVal, fromAddr,
+                     StoreOwnershipQualifier::Init);
   } else {
     // The cast loads directly from the source address.
     fromAddr = srcVal;
@@ -632,8 +632,8 @@ static ManagedValue emitBuiltinReinterpretCast(SILGenFunction &gen,
     // If the from value is loadable, move it to a buffer.
     if (fromTL.isLoadable()) {
       fromAddr = gen.emitTemporaryAllocation(loc, args[0].getValue()->getType());
-      gen.B.createStore(loc, args[0].getValue(), fromAddr,
-                        StoreOwnershipQualifier::Unqualified);
+      fromTL.emitStore(gen.B, loc, args[0].getValue(), fromAddr,
+                       StoreOwnershipQualifier::Init);
     } else {
       fromAddr = args[0].getValue();
     }

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -359,8 +359,8 @@ SILGenFunction::emitPointerToPointer(SILLocation loc,
   // The generic function currently always requires indirection, but pointers
   // are always loadable.
   auto origBuf = emitTemporaryAllocation(loc, input.getType());
-  B.createStore(loc, input.forward(*this), origBuf,
-                StoreOwnershipQualifier::Unqualified);
+  B.emitStoreValueOperation(loc, input.forward(*this), origBuf,
+                            StoreOwnershipQualifier::Init);
   auto origValue = emitManagedBufferWithCleanup(origBuf);
   
   // Invoke the conversion intrinsic to convert to the destination type.

--- a/lib/SILGen/SILGenDynamicCast.cpp
+++ b/lib/SILGen/SILGenDynamicCast.cpp
@@ -364,8 +364,8 @@ adjustForConditionalCheckedCastOperand(SILLocation loc, ManagedValue src,
     // Okay, if all we need to do is drop the value in an address,
     // this is easy.
     if (!hasAbstraction) {
-      SGF.B.createStore(loc, src.forward(SGF), init->getAddress(),
-                        StoreOwnershipQualifier::Unqualified);
+      SGF.B.emitStoreValueOperation(loc, src.forward(SGF), init->getAddress(),
+                                    StoreOwnershipQualifier::Init);
       init->finishInitialization(SGF);
       return init->getManagedAddress();
     }

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -198,6 +198,8 @@ public:
                 SILBasicBlock::iterator insertInst)
       : SILGenBuilder(gen, &*insertBB, insertInst) {}
 
+  SILGenModule &getSILGenModule() const { return SGM; }
+
   // Metatype instructions use the conformances necessary to instantiate the
   // type.
   

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -987,8 +987,8 @@ namespace {
                                             baseFormalType);
 
             baseAddress = gen.emitTemporaryAllocation(loc, base.getType());
-            gen.B.createStore(loc, base.getValue(), baseAddress,
-                              StoreOwnershipQualifier::Unqualified);
+            gen.B.emitStoreValueOperation(loc, base.getValue(), baseAddress,
+                                          StoreOwnershipQualifier::Init);
           }
           baseMetatype = gen.B.createMetatype(loc, metatypeType);
 
@@ -2131,10 +2131,11 @@ ManagedValue SILGenFunction::emitLoad(SILLocation loc, SILValue addr,
 static void emitUnloweredStoreOfCopy(SILGenBuilder &B, SILLocation loc,
                                      SILValue value, SILValue addr,
                                      IsInitialization_t isInit) {
-  if (isInit)
-    B.createStore(loc, value, addr, StoreOwnershipQualifier::Unqualified);
-  else
+  if (isInit) {
+    B.emitStoreValueOperation(loc, value, addr, StoreOwnershipQualifier::Init);
+  } else {
     B.createAssign(loc, value, addr);
+  }
 }
 
 SILValue SILGenFunction::emitConversionToSemanticRValue(SILLocation loc,

--- a/lib/SILGen/SILGenMaterializeForSet.cpp
+++ b/lib/SILGen/SILGenMaterializeForSet.cpp
@@ -630,8 +630,9 @@ SILValue MaterializeForSetEmitter::emitUsingAddressor(SILGenFunction &gen,
   } else {
     SILValue allocatedCallbackBuffer =
       gen.B.createAllocValueBuffer(loc, owner.getType(), callbackBuffer);
-    gen.B.createStore(loc, owner.forward(gen), allocatedCallbackBuffer,
-                      StoreOwnershipQualifier::Unqualified);
+    gen.B.emitStoreValueOperation(loc, owner.forward(gen),
+                                  allocatedCallbackBuffer,
+                                  StoreOwnershipQualifier::Init);
 
     callback = createAddressorCallback(gen.F, owner.getType(), addressorKind);
   }

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -1445,9 +1445,9 @@ emitCastOperand(SILGenFunction &SGF, SILLocation loc,
     // Okay, if all we need to do is drop the value in an address,
     // this is easy.
     if (!hasAbstraction) {
-      SGF.B.createStore(loc, src.getFinalManagedValue().forward(SGF),
-                        init->getAddress(),
-                        StoreOwnershipQualifier::Unqualified);
+      SGF.B.emitStoreValueOperation(
+          loc, src.getFinalManagedValue().forward(SGF), init->getAddress(),
+          StoreOwnershipQualifier::Init);
       init->finishInitialization(SGF);
       ConsumableManagedValue result =
         { init->getManagedAddress(), src.getFinalConsumption() };

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -366,7 +366,7 @@ static void emitCaptureArguments(SILGenFunction &gen, CapturedValue capture,
     // temporary within the closure to provide this address.
     if (VD->isSettable(VD->getDeclContext())) {
       auto addr = gen.emitTemporaryAllocation(VD, ty);
-      gen.B.createStore(VD, val, addr, StoreOwnershipQualifier::Unqualified);
+      lowering.emitStore(gen.B, VD, val, addr, StoreOwnershipQualifier::Init);
       val = addr;
     }
 

--- a/test/SILGen/accessors.swift
+++ b/test/SILGen/accessors.swift
@@ -40,7 +40,7 @@ func test0(_ ref: A) {
 // CHECK-NEXT: [[TEMP:%.*]] = alloc_stack $OrdinarySub
 // CHECK-NEXT: [[T0:%.*]] = class_method %0 : $A, #A.array!getter.1
 // CHECK-NEXT: [[T1:%.*]] = apply [[T0]](%0)
-// CHECK-NEXT: store [[T1]] to [[TEMP]]
+// CHECK-NEXT: store [[T1]] to [init] [[TEMP]]
 // CHECK-NEXT: [[T0:%.*]] = load [[TEMP]]
 // CHECK-NEXT: // function_ref accessors.OrdinarySub.subscript.getter : (Swift.Int) -> Swift.Int
 // CHECK-NEXT: [[T1:%.*]] = function_ref @_TFV9accessors11OrdinarySubg9subscriptFSiSi
@@ -63,7 +63,7 @@ func test0(_ ref: A) {
 // CHECK:    [[WRITEBACK]]([[CALLBACK_ADDR:%.*]] : $Builtin.RawPointer):
 // CHECK-NEXT: [[CALLBACK:%.*]] = pointer_to_thin_function [[CALLBACK_ADDR]] : $Builtin.RawPointer to $@convention(thin) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout A, @thick A.Type) -> ()
 // CHECK-NEXT: [[TEMP2:%.*]] = alloc_stack $A
-// CHECK-NEXT: store %0 to [[TEMP2]] : $*A
+// CHECK-NEXT: store %0 to [init] [[TEMP2]] : $*A
 // CHECK-NEXT: [[T0:%.*]] = metatype $@thick A.Type
 // CHECK-NEXT: [[T1:%.*]] = address_to_pointer [[ADDR]] : $*OrdinarySub to $Builtin.RawPointer
 // CHECK-NEXT: apply [[CALLBACK]]([[T1]], [[STORAGE]], [[TEMP2]], [[T0]])
@@ -119,7 +119,7 @@ func test1(_ ref: B) {
 // CHECK:    [[WRITEBACK]]([[CALLBACK_ADDR:%.*]] : $Builtin.RawPointer):
 // CHECK-NEXT: [[CALLBACK:%.*]] = pointer_to_thin_function [[CALLBACK_ADDR]] : $Builtin.RawPointer to $@convention(thin) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout B, @thick B.Type) -> ()
 // CHECK-NEXT: [[TEMP2:%.*]] = alloc_stack $B
-// CHECK-NEXT: store %0 to [[TEMP2]] : $*B
+// CHECK-NEXT: store %0 to [init] [[TEMP2]] : $*B
 // CHECK-NEXT: [[T0:%.*]] = metatype $@thick B.Type
 // CHECK-NEXT: [[T1:%.*]] = address_to_pointer [[ADDR]] : $*MutatingSub to $Builtin.RawPointer
 // CHECK-NEXT: apply [[CALLBACK]]([[T1]], [[STORAGE]], [[TEMP2]], [[T0]])
@@ -143,7 +143,7 @@ func test1(_ ref: B) {
 // CHECK:    [[WRITEBACK]]([[CALLBACK_ADDR:%.*]] : $Builtin.RawPointer):
 // CHECK-NEXT: [[CALLBACK:%.*]] = pointer_to_thin_function [[CALLBACK_ADDR]] : $Builtin.RawPointer to $@convention(thin) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout B, @thick B.Type) -> ()
 // CHECK-NEXT: [[TEMP2:%.*]] = alloc_stack $B
-// CHECK-NEXT: store %0 to [[TEMP2]] : $*B
+// CHECK-NEXT: store %0 to [init] [[TEMP2]] : $*B
 // CHECK-NEXT: [[T0:%.*]] = metatype $@thick B.Type
 // CHECK-NEXT: [[T1:%.*]] = address_to_pointer [[ADDR]] : $*MutatingSub to $Builtin.RawPointer
 // CHECK-NEXT: apply [[CALLBACK]]([[T1]], [[STORAGE2]], [[TEMP2]], [[T0]])

--- a/test/SILGen/auto_generated_super_init_call.swift
+++ b/test/SILGen/auto_generated_super_init_call.swift
@@ -19,7 +19,7 @@ class SomeDerivedClass : Parent {
 // CHECK: [[INITCALL1:%[0-9]+]] = function_ref @_TFC30auto_generated_super_init_call6ParentcfT_S0_ : $@convention(method) (@owned Parent) -> @owned Parent
 // CHECK-NEXT: [[RES1:%[0-9]+]] = apply [[INITCALL1]]([[PARENT]])
 // CHECK-NEXT: [[DOWNCAST:%[0-9]+]] = unchecked_ref_cast [[RES1]] : $Parent to $SomeDerivedClass
-// CHECK-NEXT: store [[DOWNCAST]] to [[SELF]] : $*SomeDerivedClass 
+// CHECK-NEXT: store [[DOWNCAST]] to [init] [[SELF]] : $*SomeDerivedClass 
   }
   
   init(x: Int) {

--- a/test/SILGen/boxed_existentials.swift
+++ b/test/SILGen/boxed_existentials.swift
@@ -20,7 +20,7 @@ func test_concrete_erasure(_ x: ClericalError) -> Error {
 // CHECK-LABEL: sil hidden @_TF18boxed_existentials21test_concrete_erasureFOS_13ClericalErrorPs5Error_
 // CHECK:         [[EXISTENTIAL:%.*]] = alloc_existential_box $Error, $ClericalError
 // CHECK:         [[ADDR:%.*]] = project_existential_box $ClericalError in [[EXISTENTIAL]] : $Error
-// CHECK:         store %0 to [[ADDR]] : $*ClericalError
+// CHECK:         store %0 to [init] [[ADDR]] : $*ClericalError
 // CHECK:         return [[EXISTENTIAL]] : $Error
 
 protocol HairType {}
@@ -45,7 +45,8 @@ func test_class_composition_erasure(_ x: HairClass & Error) -> Error {
 // CHECK:         [[VALUE:%.*]] = open_existential_ref [[OLD_EXISTENTIAL:%.*]] : $Error & HairClass to $[[VALUE_TYPE:@opened\(.*\) Error & HairClass]]
 // CHECK:         [[NEW_EXISTENTIAL:%.*]] = alloc_existential_box $Error, $[[VALUE_TYPE]]
 // CHECK:         [[ADDR:%.*]] = project_existential_box $[[VALUE_TYPE]] in [[NEW_EXISTENTIAL]] : $Error
-// CHECK:         store [[VALUE]] to [[ADDR]]
+// CHECK:         [[COPIED_VALUE:%.*]] = copy_value [[VALUE]]
+// CHECK:         store [[COPIED_VALUE]] to [[ADDR]]
 // CHECK:         return [[NEW_EXISTENTIAL]]
 
 func test_property(_ x: Error) -> String {
@@ -71,7 +72,7 @@ func test_property_of_lvalue(_ x: Error) -> String {
 // CHECK:         [[VAR:%.*]] = alloc_box $Error
 // CHECK-NEXT:    [[PVAR:%.*]] = project_box [[VAR]]
 // CHECK-NEXT:    copy_value %0 : $Error
-// CHECK-NEXT:    store %0 to [[PVAR]]
+// CHECK-NEXT:    store %0 to [init] [[PVAR]]
 // CHECK-NEXT:    [[VALUE_BOX:%.*]] = load [[PVAR]]
 // CHECK-NEXT:    copy_value [[VALUE_BOX]]
 // CHECK-NEXT:    [[VALUE:%.*]] = open_existential_box [[VALUE_BOX]] : $Error to $*[[VALUE_TYPE:@opened\(.*\) Error]]

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -157,7 +157,7 @@ func assign_gen<T>(_ x: T, y: Builtin.RawPointer) {
 func init_pod(_ x: Builtin.Int64, y: Builtin.RawPointer) {
   // CHECK: [[ADDR:%.*]] = pointer_to_address {{%.*}} to [strict] $*Builtin.Int64
   // CHECK-NOT: load [[ADDR]]
-  // CHECK: store {{%.*}} to [[ADDR]]
+  // CHECK: store {{%.*}} to [trivial] [[ADDR]]
   // CHECK-NOT: destroy_value [[ADDR]]
   Builtin.initialize(x, y)
 }
@@ -166,7 +166,7 @@ func init_pod(_ x: Builtin.Int64, y: Builtin.RawPointer) {
 func init_obj(_ x: Builtin.NativeObject, y: Builtin.RawPointer) {
   // CHECK: [[ADDR:%.*]] = pointer_to_address {{%.*}} to [strict] $*Builtin.NativeObject
   // CHECK-NOT: load [[ADDR]]
-  // CHECK: store [[SRC:%.*]] to [[ADDR]]
+  // CHECK: store [[SRC:%.*]] to [init] [[ADDR]]
   // CHECK-NOT: destroy_value [[SRC]]
   Builtin.initialize(x, y)
 }
@@ -548,7 +548,7 @@ func reinterpretAddrOnlyToTrivial<T>(_ t: T) -> Int {
 // CHECK-LABEL: sil hidden @_TF8builtins27reinterpretAddrOnlyLoadable
 func reinterpretAddrOnlyLoadable<T>(_ a: Int, _ b: T) -> (T, Int) {
   // CHECK: [[BUF:%.*]] = alloc_stack $Int
-  // CHECK: store {{%.*}} to [[BUF]]
+  // CHECK: store {{%.*}} to [trivial] [[BUF]]
   // CHECK: [[RES1:%.*]] = unchecked_addr_cast [[BUF]] : $*Int to $*T
   // CHECK: copy_addr [[RES1]] to [initialization]
   return (Builtin.reinterpretCast(a) as T,

--- a/test/SILGen/cf_members.swift
+++ b/test/SILGen/cf_members.swift
@@ -53,7 +53,7 @@ public func foo(_ x: Double) {
 
   // CHECK: [[FN:%.*]] = function_ref @IAMStruct1Rotate : $@convention(c) (@in Struct1, Double) -> Struct1
   // CHECK: [[ZVAL:%.*]] = load [[Z]]
-  // CHECK: store [[ZVAL]] to [[ZTMP:%.*]] :
+  // CHECK: store [[ZVAL]] to [trivial] [[ZTMP:%.*]] :
   // CHECK: apply [[FN]]([[ZTMP]], [[X]])
   z = z.translate(radians: x)
 
@@ -98,7 +98,7 @@ public func foo(_ x: Double) {
   // z = h(z, x)
 
   // CHECK: [[ZVAL:%.*]] = load [[Z]]
-  // CHECK: store [[ZVAL]] to [[ZTMP:%.*]] :
+  // CHECK: store [[ZVAL]] to [trivial] [[ZTMP:%.*]] :
   // CHECK: [[GET:%.*]] = function_ref @IAMStruct1GetRadius : $@convention(c) (@in Struct1) -> Double
   // CHECK: apply [[GET]]([[ZTMP]])
   _ = z.radius
@@ -197,7 +197,7 @@ public func foo(_ x: Double) {
 
 // CHECK-LABEL: sil shared [thunk] @_TTOFVSC7Struct19translatefT7radiansSd_S_
 // CHECK:       bb0([[X:%.*]] : $Double, [[SELF:%.*]] : $Struct1):
-// CHECK:         store [[SELF]] to [[TMP:%.*]] :
+// CHECK:         store [[SELF]] to [trivial] [[TMP:%.*]] :
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1Rotate
 // CHECK:         [[RET:%.*]] = apply [[CFUNC]]([[TMP]], [[X]])
 // CHECK:         return [[RET]]

--- a/test/SILGen/class_bound_protocols.swift
+++ b/test/SILGen/class_bound_protocols.swift
@@ -28,7 +28,7 @@ func class_bound_generic<T : ClassBound>(x: T) -> T {
   // CHECK: bb0([[X:%.*]] : $T):
   // CHECK:   [[X_ADDR:%.*]] = alloc_box $T
   // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
-  // CHECK:   store [[X]] to [[PB]]
+  // CHECK:   store [[X]] to [init] [[PB]]
   return x
   // CHECK:   [[X1:%.*]] = load [[PB]]
   // CHECK:   copy_value [[X1]]
@@ -41,7 +41,7 @@ func class_bound_generic_2<T : ClassBound & NotClassBound>(x: T) -> T {
   // CHECK: bb0([[X:%.*]] : $T):
   // CHECK:   [[X_ADDR:%.*]] = alloc_box $T
   // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
-  // CHECK:   store [[X]] to [[PB]]
+  // CHECK:   store [[X]] to [init] [[PB]]
   return x
   // CHECK:   [[X1:%.*]] = load [[PB]]
   // CHECK:   copy_value [[X1]]
@@ -54,7 +54,7 @@ func class_bound_protocol(x: ClassBound) -> ClassBound {
   // CHECK: bb0([[X:%.*]] : $ClassBound):
   // CHECK:   [[X_ADDR:%.*]] = alloc_box $ClassBound
   // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
-  // CHECK:   store [[X]] to [[PB]]
+  // CHECK:   store [[X]] to [init] [[PB]]
   return x
   // CHECK:   [[X1:%.*]] = load [[PB]]
   // CHECK:   copy_value [[X1]]
@@ -68,7 +68,7 @@ func class_bound_protocol_composition(x: ClassBound & NotClassBound)
   // CHECK: bb0([[X:%.*]] : $ClassBound & NotClassBound):
   // CHECK:   [[X_ADDR:%.*]] = alloc_box $ClassBound & NotClassBound
   // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
-  // CHECK:   store [[X]] to [[PB]]
+  // CHECK:   store [[X]] to [init] [[PB]]
   return x
   // CHECK:   [[X1:%.*]] = load [[PB]]
   // CHECK:   copy_value [[X1]]
@@ -97,7 +97,8 @@ func class_bound_to_unbound_existential_upcast
   return x
   // CHECK: [[X_OPENED:%.*]] = open_existential_ref %1 : $ClassBound & NotClassBound to [[OPENED_TYPE:\$@opened(.*) ClassBound & NotClassBound]]
   // CHECK: [[PAYLOAD_ADDR:%.*]] = init_existential_addr %0 : $*NotClassBound, [[OPENED_TYPE]]
-  // CHECK: store [[X_OPENED]] to [[PAYLOAD_ADDR]]
+  // CHECK: [[X_OPENED_COPY:%.*]] = copy_value [[X_OPENED]]
+  // CHECK: store [[X_OPENED_COPY]] to [[PAYLOAD_ADDR]]
 }
 
 // CHECK-LABEL: sil hidden @_TF21class_bound_protocols18class_bound_method

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -201,7 +201,7 @@ func uncaptured_locals(_ x: Int) -> (Int, Int) {
   // CHECK: bb0([[XARG:%[0-9]+]] : $Int):
   // CHECK:   [[XADDR:%[0-9]+]] = alloc_box $Int
   // CHECK:   [[PB:%.*]] = project_box [[XADDR]]
-  // CHECK:   store [[XARG]] to [[PB]]
+  // CHECK:   store [[XARG]] to [trivial] [[PB]]
 
   var y = zero
   // CHECK:   [[YADDR:%[0-9]+]] = alloc_box $Int
@@ -316,7 +316,7 @@ func closeOverLetLValue() {
 // CHECK-LABEL: sil shared @_TFF8closures18closeOverLetLValueFT_T_U_FT_Si
 // CHECK: bb0(%0 : $ClassWithIntProperty):
 // CHECK-NEXT: [[TMP:%.*]] = alloc_stack $ClassWithIntProperty, let, name "a", argno 1
-// CHECK-NEXT: store %0 to [[TMP]] : $*ClassWithIntProperty
+// CHECK-NEXT: store %0 to [init] [[TMP]] : $*ClassWithIntProperty
 // CHECK-NEXT: {{.*}} = load [[TMP]] : $*ClassWithIntProperty
 // CHECK-NEXT: {{.*}} = ref_element_addr {{.*}} : $ClassWithIntProperty, #ClassWithIntProperty.x
 // CHECK-NEXT: {{.*}} = load {{.*}} : $*Int
@@ -513,7 +513,7 @@ class SuperSub : SuperBase {
 // -- TODO: A lot of fussy r/r traffic and owned/unowned conversions here.
 // -- strong +1, unowned +1
 // CHECK:         unowned_retain [[UNOWNED_SELF]]
-// CHECK:         store [[UNOWNED_SELF]] to [[PB]]
+// CHECK:         store [[UNOWNED_SELF]] to [init] [[PB]]
 // CHECK:         [[UNOWNED_SELF:%.*]] = load [[PB]]
 // -- strong +2, unowned +1
 // CHECK:         strong_retain_unowned [[UNOWNED_SELF]]

--- a/test/SILGen/complete_object_init.swift
+++ b/test/SILGen/complete_object_init.swift
@@ -15,7 +15,7 @@ class A {
 // CHECK:   [[X_META:%[0-9]+]] = metatype $@thin X.Type
 // CHECK:   [[X:%[0-9]+]] = apply [[X_INIT]]([[X_META]]) : $@convention(method) (@thin X.Type) -> X
 // CHECK:   [[INIT_RESULT:%[0-9]+]] = apply [[INIT]]([[X]], [[SELFP]]) : $@convention(method) (X, @owned A) -> @owned A
-// CHECK:   store [[INIT_RESULT]] to [[SELF]] : $*A
+// CHECK:   store [[INIT_RESULT]] to [init] [[SELF]] : $*A
 // CHECK:   [[RESULT:%[0-9]+]] = load [[SELF]] : $*A
 // CHECK:   copy_value [[RESULT]] : $A
 // CHECK:   destroy_value [[SELF_BOX]] : $@box A

--- a/test/SILGen/copy_lvalue_peepholes.swift
+++ b/test/SILGen/copy_lvalue_peepholes.swift
@@ -39,7 +39,7 @@ var computed: Int {
 // CHECK-LABEL: sil hidden @_TF21copy_lvalue_peepholes29init_var_from_computed_lvalue
 // CHECK:   [[GETTER:%.*]] = function_ref @_TF21copy_lvalue_peepholesg8computedBi64_
 // CHECK:   [[GOTTEN:%.*]] = apply [[GETTER]]()
-// CHECK:   store [[GOTTEN]] to {{%.*}}
+// CHECK:   store [[GOTTEN]] to [trivial] {{%.*}}
 func init_var_from_computed_lvalue() {
   var y = computed
 }

--- a/test/SILGen/decls.swift
+++ b/test/SILGen/decls.swift
@@ -57,9 +57,9 @@ func tuple_patterns() {
   // CHECK: [[E:%[0-9]+]] = tuple_extract {{.*}}, 0
   // CHECK: [[F:%[0-9]+]] = tuple_extract {{.*}}, 1
   // CHECK: [[H:%[0-9]+]] = tuple_extract {{.*}}, 2
-  // CHECK: store [[E]] to [[PBE]]
-  // CHECK: store [[F]] to [[PBF]]
-  // CHECK: store [[H]] to [[PBH]]
+  // CHECK: store [[E]] to [trivial] [[PBE]]
+  // CHECK: store [[F]] to [trivial] [[PBF]]
+  // CHECK: store [[H]] to [trivial] [[PBH]]
   var (e,f,g,h) : (Int, Float, (), Double) = MRV()
 
   // CHECK: [[IADDR:%[0-9]+]] = alloc_box $Int
@@ -78,7 +78,7 @@ func tuple_patterns() {
   // CHECK: [[J_K_:%[0-9]+]] = apply
   // CHECK: [[J:%[0-9]+]] = tuple_extract {{.*}}, 0
   // CHECK: [[K:%[0-9]+]] = tuple_extract {{.*}}, 2
-  // CHECK: store [[J]] to [[PBJ]]
+  // CHECK: store [[J]] to [trivial] [[PBJ]]
   var (j,_,k,_) : (Int, Float, (), Double) = MRV()
 }
 
@@ -86,10 +86,10 @@ func tuple_patterns() {
 // CHECK: bb0(%0 : $Int, %1 : $Int):
 // CHECK: [[X:%[0-9]+]] = alloc_box $Int
 // CHECK-NEXT: [[PBX:%.*]] = project_box [[X]]
-// CHECK-NEXT: store %0 to [[PBX]]
+// CHECK-NEXT: store %0 to [trivial] [[PBX]]
 // CHECK-NEXT: [[Y:%[0-9]+]] = alloc_box $Int
 // CHECK-NEXT: [[PBY:%[0-9]+]] = project_box [[Y]]
-// CHECK-NEXT: store %1 to [[PBY]]
+// CHECK-NEXT: store %1 to [trivial] [[PBY]]
 func simple_arguments(x: Int, y: Int) -> Int {
   var x = x
   var y = y

--- a/test/SILGen/default_constructor.swift
+++ b/test/SILGen/default_constructor.swift
@@ -72,7 +72,7 @@ class F : E { }
 // CHECK-NEXT: [[ESELF:%[0-9]]] = apply [[E_CTOR]]([[E]]) : $@convention(method) (@owned E) -> @owned E
 
 // CHECK-NEXT: [[ESELFW:%[0-9]+]] = unchecked_ref_cast [[ESELF]] : $E to $F
-// CHECK-NEXT: store [[ESELFW]] to [[SELF]] : $*F
+// CHECK-NEXT: store [[ESELFW]] to [init] [[SELF]] : $*F
 // CHECK-NEXT: [[SELFP:%[0-9]+]] = load [[SELF]] : $*F
 // CHECK-NEXT: copy_value [[SELFP]] : $F
 // CHECK-NEXT: destroy_value [[SELF_BOX]] : $@box F

--- a/test/SILGen/dynamic_lookup.swift
+++ b/test/SILGen/dynamic_lookup.swift
@@ -43,7 +43,7 @@ func direct_to_static_method(_ obj: AnyObject) {
   // CHECK: [[START:[A-Za-z0-9_]+]]([[OBJ:%[0-9]+]] : $AnyObject):
   // CHECK: [[OBJBOX:%[0-9]+]] = alloc_box $AnyObject
   // CHECK-NEXT: [[PBOBJ:%[0-9]+]] = project_box [[OBJBOX]]
-  // CHECK: store [[OBJ]] to [[PBOBJ]] : $*AnyObject
+  // CHECK: store [[OBJ]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK-NEXT: [[OBJCOPY:%[0-9]+]] = load [[PBOBJ]] : $*AnyObject
   // CHECK-NEXT: [[OBJMETA:%[0-9]+]] = existential_metatype $@thick AnyObject.Type, [[OBJCOPY]] : $AnyObject
   // CHECK-NEXT: [[OPENMETA:%[0-9]+]] = open_existential_metatype [[OBJMETA]] : $@thick AnyObject.Type to $@thick (@opened([[UUID:".*"]]) AnyObject).Type
@@ -58,7 +58,7 @@ func opt_to_class(_ obj: AnyObject) {
   // CHECK: [[ENTRY:[A-Za-z0-9]+]]([[PARAM:%[0-9]+]] : $AnyObject)
   // CHECK: [[EXISTBOX:%[0-9]+]] = alloc_box $AnyObject 
   // CHECK-NEXT: [[PBOBJ:%[0-9]+]] = project_box [[EXISTBOX]]
-  // CHECK: store [[PARAM]] to [[PBOBJ]]
+  // CHECK: store [[PARAM]] to [init] [[PBOBJ]]
   // CHECK-NEXT: [[OPTBOX:%[0-9]+]] = alloc_box $Optional<@callee_owned () -> ()>
   // CHECK-NEXT: [[PBOPT:%.*]] = project_box [[OPTBOX]]
   // CHECK-NEXT: [[EXISTVAL:%[0-9]+]] = load [[PBOBJ]] : $*AnyObject
@@ -72,7 +72,7 @@ func opt_to_class(_ obj: AnyObject) {
   // CHECK-NEXT: copy_value [[OBJ_SELF]]
   // CHECK-NEXT: [[PARTIAL:%[0-9]+]] = partial_apply [[UNCURRIED]]([[OBJ_SELF]]) : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> ()
   // CHECK-NEXT: [[THUNK_PAYLOAD:%.*]] = init_enum_data_addr [[OPTIONAL:%[0-9]+]]
-  // CHECK-NEXT: store [[PARTIAL]] to [[THUNK_PAYLOAD]]
+  // CHECK-NEXT: store [[PARTIAL]] to [init] [[THUNK_PAYLOAD]]
   // CHECK-NEXT: inject_enum_addr [[OPTIONAL]]{{.*}}some
   // CHECK-NEXT: br [[CONTBB:[a-zA-Z0-9]+]]
   
@@ -84,7 +84,7 @@ func opt_to_class(_ obj: AnyObject) {
   // Continuation block
   // CHECK: [[CONTBB]]:
   // CHECK-NEXT: [[OPT:%.*]] = load [[OPTTEMP]]
-  // CHECK-NEXT: store [[OPT]] to [[PBOPT]] : $*Optional<@callee_owned () -> ()>
+  // CHECK-NEXT: store [[OPT]] to [init] [[PBOPT]] : $*Optional<@callee_owned () -> ()>
   // CHECK-NEXT: dealloc_stack [[OPTTEMP]]
   var of: (() -> ())! = obj.f
 
@@ -109,7 +109,7 @@ func opt_to_static_method(_ obj: AnyObject) {
   // CHECK: [[ENTRY:[A-Za-z0-9]+]]([[OBJ:%[0-9]+]] : $AnyObject):
   // CHECK: [[OBJBOX:%[0-9]+]] = alloc_box $AnyObject
   // CHECK-NEXT: [[PBOBJ:%[0-9]+]] = project_box [[OBJBOX]]
-  // CHECK: store [[OBJ]] to [[PBOBJ]] : $*AnyObject
+  // CHECK: store [[OBJ]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK-NEXT: [[OPTBOX:%[0-9]+]] = alloc_box $Optional<@callee_owned () -> ()>
   // CHECK-NEXT: [[PBO:%.*]] = project_box [[OPTBOX]]
   // CHECK-NEXT: [[OBJCOPY:%[0-9]+]] = load [[PBOBJ]] : $*AnyObject
@@ -127,7 +127,7 @@ func opt_to_property(_ obj: AnyObject) {
   // CHECK: bb0([[OBJ:%[0-9]+]] : $AnyObject):
   // CHECK: [[OBJ_BOX:%[0-9]+]] = alloc_box $AnyObject
   // CHECK-NEXT: [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
-  // CHECK: store [[OBJ]] to [[PBOBJ]] : $*AnyObject
+  // CHECK: store [[OBJ]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK-NEXT: [[INT_BOX:%[0-9]+]] = alloc_box $Int
   // CHECK-NEXT: project_box [[INT_BOX]]
   // CHECK-NEXT: [[OBJ:%[0-9]+]] = load [[PBOBJ]] : $*AnyObject
@@ -140,7 +140,7 @@ func opt_to_property(_ obj: AnyObject) {
   // CHECK-NEXT: [[BOUND_METHOD:%[0-9]+]] = partial_apply [[METHOD]]([[RAWOBJ_SELF]]) : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> Int
   // CHECK-NEXT: [[VALUE:%[0-9]+]] = apply [[BOUND_METHOD]]() : $@callee_owned () -> Int
   // CHECK-NEXT: [[VALUETEMP:%.*]] = init_enum_data_addr [[OPTTEMP]]
-  // CHECK-NEXT: store [[VALUE]] to [[VALUETEMP]]
+  // CHECK-NEXT: store [[VALUE]] to [trivial] [[VALUETEMP]]
   // CHECK-NEXT: inject_enum_addr [[OPTTEMP]]{{.*}}some
   // CHECK-NEXT: br bb3
   var i: Int = obj.value!
@@ -153,10 +153,10 @@ func direct_to_subscript(_ obj: AnyObject, i: Int) {
   // CHECK: bb0([[OBJ:%[0-9]+]] : $AnyObject, [[I:%[0-9]+]] : $Int):
   // CHECK: [[OBJ_BOX:%[0-9]+]] = alloc_box $AnyObject
   // CHECK-NEXT: [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
-  // CHECK: store [[OBJ]] to [[PBOBJ]] : $*AnyObject
+  // CHECK: store [[OBJ]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK-NEXT: [[I_BOX:%[0-9]+]] = alloc_box $Int
   // CHECK-NEXT: [[PBI:%.*]] = project_box [[I_BOX]]
-  // CHECK-NEXT: store [[I]] to [[PBI]] : $*Int
+  // CHECK-NEXT: store [[I]] to [trivial] [[PBI]] : $*Int
   // CHECK-NEXT: alloc_box $Int
   // CHECK-NEXT: project_box
   // CHECK-NEXT: [[OBJ:%[0-9]+]] = load [[PBOBJ]] : $*AnyObject
@@ -171,7 +171,7 @@ func direct_to_subscript(_ obj: AnyObject, i: Int) {
   // CHECK-NEXT: [[GETTER_WITH_SELF:%[0-9]+]] = partial_apply [[GETTER]]([[OBJ_REF]]) : $@convention(objc_method) (Int, @opened({{.*}}) AnyObject) -> Int
   // CHECK-NEXT: [[RESULT:%[0-9]+]] = apply [[GETTER_WITH_SELF]]([[I]]) : $@callee_owned (Int) -> Int
   // CHECK-NEXT: [[RESULTTEMP:%.*]] = init_enum_data_addr [[OPTTEMP]]
-  // CHECK-NEXT: store [[RESULT]] to [[RESULTTEMP]]
+  // CHECK-NEXT: store [[RESULT]] to [trivial] [[RESULTTEMP]]
   // CHECK-NEXT: inject_enum_addr [[OPTTEMP]]{{.*}}some
   // CHECK-NEXT: br bb3
   var x: Int = obj[i]!
@@ -184,10 +184,10 @@ func opt_to_subscript(_ obj: AnyObject, i: Int) {
   // CHECK: bb0([[OBJ:%[0-9]+]] : $AnyObject, [[I:%[0-9]+]] : $Int):
   // CHECK: [[OBJ_BOX:%[0-9]+]] = alloc_box $AnyObject
   // CHECK-NEXT: [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
-  // CHECK: store [[OBJ]] to [[PBOBJ]] : $*AnyObject
+  // CHECK: store [[OBJ]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK-NEXT: [[I_BOX:%[0-9]+]] = alloc_box $Int
   // CHECK-NEXT: [[PBI:%.*]] = project_box [[I_BOX]]
-  // CHECK-NEXT: store [[I]] to [[PBI]] : $*Int
+  // CHECK-NEXT: store [[I]] to [trivial] [[PBI]] : $*Int
   // CHECK-NEXT: [[OBJ:%[0-9]+]] = load [[PBOBJ]] : $*AnyObject
   // CHECK-NEXT: copy_value [[OBJ]] : $AnyObject
   // CHECK-NEXT: [[OBJ_REF:%[0-9]+]] = open_existential_ref [[OBJ]] : $AnyObject to $@opened({{.*}}) AnyObject
@@ -200,7 +200,7 @@ func opt_to_subscript(_ obj: AnyObject, i: Int) {
   // CHECK-NEXT: [[GETTER_WITH_SELF:%[0-9]+]] = partial_apply [[GETTER]]([[OBJ_REF]]) : $@convention(objc_method) (Int, @opened({{.*}}) AnyObject) -> Int
   // CHECK-NEXT: [[RESULT:%[0-9]+]] = apply [[GETTER_WITH_SELF]]([[I]]) : $@callee_owned (Int) -> Int
   // CHECK-NEXT: [[RESULTTEMP:%.*]] = init_enum_data_addr [[OPTTEMP]]
-  // CHECK-NEXT: store [[RESULT]] to [[RESULTTEMP]]
+  // CHECK-NEXT: store [[RESULT]] to [trivial] [[RESULTTEMP]]
   // CHECK-NEXT: inject_enum_addr [[OPTTEMP]]
   // CHECK-NEXT: br bb3
   obj[i]
@@ -212,7 +212,7 @@ func downcast(_ obj: AnyObject) -> X {
   // CHECK: bb0([[OBJ:%[0-9]+]] : $AnyObject):
   // CHECK: [[OBJ_BOX:%[0-9]+]] = alloc_box $AnyObject
   // CHECK-NEXT: [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
-  // CHECK: store [[OBJ]] to [[PBOBJ]] : $*AnyObject
+  // CHECK: store [[OBJ]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK-NEXT: [[OBJ:%[0-9]+]] = load [[PBOBJ]] : $*AnyObject
   // CHECK-NEXT: copy_value [[OBJ]] : $AnyObject
   // CHECK-NEXT: [[X:%[0-9]+]] = unconditional_checked_cast [[OBJ]] : $AnyObject to $X
@@ -237,7 +237,7 @@ func downcast(_ obj: AnyObject) -> X {
 // CHECK:        [[METHOD:%.*]] = partial_apply [[FN]]([[SELF]]) : $@convention(objc_method) (@opened("{{.*}}") Fruit) -> @autoreleased Juice
 // CHECK:        [[RESULT:%.*]] = apply [[METHOD]]() : $@callee_owned () -> @owned Juice
 // CHECK:        [[PAYLOAD:%.*]] = init_enum_data_addr [[BOX]] : $*Optional<Juice>, #Optional.some!enumelt.1
-// CHECK:        store [[RESULT]] to [[PAYLOAD]]
+// CHECK:        store [[RESULT]] to [init] [[PAYLOAD]]
 // CHECK:        inject_enum_addr [[BOX]] : $*Optional<Juice>, #Optional.some!enumelt.1
 // CHECK:        br bb3
 

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -120,7 +120,7 @@ func testObjCInit(meta: ObjCInit.Type) {
 // CHECK:   [[OBJ:%[0-9]+]] = alloc_ref_dynamic [objc] [[OBJC_META]] : $@objc_metatype ObjCInit.Type, $ObjCInit
 // CHECK:   [[INIT:%[0-9]+]] = class_method [volatile] [[OBJ]] : $ObjCInit, #ObjCInit.init!initializer.1.foreign : (ObjCInit.Type) -> () -> ObjCInit , $@convention(objc_method) (@owned ObjCInit) -> @owned ObjCInit
 // CHECK:   [[RESULT_OBJ:%[0-9]+]] = apply [[INIT]]([[OBJ]]) : $@convention(objc_method) (@owned ObjCInit) -> @owned ObjCInit
-// CHECK:   store [[RESULT_OBJ]] to [[PB]] : $*ObjCInit
+// CHECK:   store [[RESULT_OBJ]] to [init] [[PB]] : $*ObjCInit
 // CHECK:   destroy_value [[O]] : $@box ObjCInit
 // CHECK:   [[RESULT:%[0-9]+]] = tuple ()
 // CHECK:   return [[RESULT]] : $()

--- a/test/SILGen/enum.swift
+++ b/test/SILGen/enum.swift
@@ -84,7 +84,7 @@ func AddressOnly_cases(_ s: S) {
   // CHECK-NEXT:  [[MERE:%.*]] = alloc_stack $AddressOnly
   // CHECK-NEXT:  [[PAYLOAD:%.*]] = init_enum_data_addr [[MERE]]
   // CHECK-NEXT:  [[PAYLOAD_ADDR:%.*]] = init_existential_addr [[PAYLOAD]]
-  // CHECK-NEXT:  store %0 to [[PAYLOAD_ADDR]]
+  // CHECK-NEXT:  store %0 to [trivial] [[PAYLOAD_ADDR]]
   // CHECK-NEXT:  inject_enum_addr [[MERE]]
   // CHECK-NEXT:  destroy_addr [[MERE]]
   // CHECK-NEXT:  dealloc_stack [[MERE]]
@@ -182,7 +182,7 @@ enum Foo { case A(P, String) }
 // CHECK-NEXT:    [[LEFT:%.*]] = tuple_element_addr [[PAYLOAD]] : $*(P, String), 0
 // CHECK-NEXT:    [[RIGHT:%.*]] = tuple_element_addr [[PAYLOAD]] : $*(P, String), 1
 // CHECK-NEXT:    copy_addr [take] %1 to [initialization] [[LEFT]] : $*P
-// CHECK-NEXT:    store %2 to [[RIGHT]]
+// CHECK-NEXT:    store %2 to [init] [[RIGHT]]
 // CHECK-NEXT:    inject_enum_addr %0 : $*Foo, #Foo.A!enumelt.1
 // CHECK:         return
 // CHECK-NEXT:  }

--- a/test/SILGen/erasure_reabstraction.swift
+++ b/test/SILGen/erasure_reabstraction.swift
@@ -5,7 +5,7 @@ class Bar {}
 
 // CHECK: [[CONCRETE:%.*]] = init_existential_addr [[EXISTENTIAL:%.*]] : $*Any, $Foo.Type
 // CHECK: [[METATYPE:%.*]] = metatype $@thick Foo.Type
-// CHECK: store [[METATYPE]] to [[CONCRETE]] : $*@thick Foo.Type
+// CHECK: store [[METATYPE]] to [trivial] [[CONCRETE]] : $*@thick Foo.Type
 let x: Any = Foo.self
 
 
@@ -14,6 +14,6 @@ let x: Any = Foo.self
 // CHECK: [[CLOSURE_THICK:%.*]] = thin_to_thick_function [[CLOSURE]]
 // CHECK: [[REABSTRACTION_THUNK:%.*]] = function_ref @_TTRXFo___XFo_iT__iT__
 // CHECK: [[CLOSURE_REABSTRACTED:%.*]] = partial_apply [[REABSTRACTION_THUNK]]([[CLOSURE_THICK]])
-// CHECK: store [[CLOSURE_REABSTRACTED]] to [[CONCRETE]]
+// CHECK: store [[CLOSURE_REABSTRACTED]] to [init] [[CONCRETE]]
 let y: Any = {() -> () in ()}
 

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -27,7 +27,7 @@ func make_a_cat() throws -> Cat {
 // CHECK-NEXT: [[ADDR:%.*]] = project_existential_box $HomeworkError in [[BOX]] : $Error
 // CHECK-NEXT: [[T0:%.*]] = metatype $@thin HomeworkError.Type
 // CHECK-NEXT: [[T1:%.*]] = enum $HomeworkError, #HomeworkError.TooHard!enumelt
-// CHECK-NEXT: store [[T1]] to [[ADDR]]
+// CHECK-NEXT: store [[T1]] to [init] [[ADDR]]
 // CHECK-NEXT: builtin "willThrow"
 // CHECK-NEXT: throw [[BOX]]
 func dont_make_a_cat() throws -> Cat {
@@ -39,7 +39,7 @@ func dont_make_a_cat() throws -> Cat {
 // CHECK-NEXT: [[ADDR:%.*]] = project_existential_box $HomeworkError in [[BOX]] : $Error
 // CHECK-NEXT: [[T0:%.*]] = metatype $@thin HomeworkError.Type
 // CHECK-NEXT: [[T1:%.*]] = enum $HomeworkError, #HomeworkError.TooMuch!enumelt
-// CHECK-NEXT: store [[T1]] to [[ADDR]]
+// CHECK-NEXT: store [[T1]] to [init] [[ADDR]]
 // CHECK-NEXT: builtin "willThrow"
 // CHECK-NEXT: destroy_addr %1 : $*T
 // CHECK-NEXT: throw [[BOX]]
@@ -71,7 +71,7 @@ func dont_return<T>(_ argument: T) throws -> T {
 //   Merge point for the ternary operator.  Call dont_return with the result.
 // CHECK:    [[TERNARY_CONT]]([[T0:%.*]] : $Cat):
 // CHECK-NEXT: [[ARG_TEMP:%.*]] = alloc_stack $Cat
-// CHECK-NEXT: store [[T0]] to [[ARG_TEMP]]
+// CHECK-NEXT: store [[T0]] to [init] [[ARG_TEMP]]
 // CHECK-NEXT: [[RET_TEMP:%.*]] = alloc_stack $Cat
 // CHECK-NEXT: try_apply [[DR_FN]]<Cat>([[RET_TEMP]], [[ARG_TEMP]]) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> (@out τ_0_0, @error Error), normal [[DR_NORMAL:bb[0-9]+]], error [[DR_ERROR:bb[0-9]+]]
 // CHECK:    [[DR_NORMAL]]({{%.*}} : $()):
@@ -87,7 +87,7 @@ func dont_return<T>(_ argument: T) throws -> T {
 //   Catch dispatch block.
 // CHECK:    [[CATCH:bb[0-9]+]]([[ERROR:%.*]] : $Error):
 // CHECK-NEXT: [[SRC_TEMP:%.*]] = alloc_stack $Error
-// CHECK-NEXT: store [[ERROR]] to [[SRC_TEMP]]
+// CHECK-NEXT: store [[ERROR]] to [init] [[SRC_TEMP]]
 // CHECK-NEXT: [[DEST_TEMP:%.*]] = alloc_stack $HomeworkError
 // CHECK-NEXT: checked_cast_addr_br copy_on_success Error in [[SRC_TEMP]] : $*Error to HomeworkError in [[DEST_TEMP]] : $*HomeworkError, [[IS_HWE:bb[0-9]+]], [[NOT_HWE:bb[0-9]+]]
 
@@ -399,12 +399,12 @@ func test_variadic(_ cat: Cat) throws {
 // CHECK:       [[T0:%.*]] = function_ref @_TF6errors10make_a_catFzT_CS_3Cat : $@convention(thin) () -> (@owned Cat, @error Error)
 // CHECK:       try_apply [[T0]]() : $@convention(thin) () -> (@owned Cat, @error Error), normal [[NORM_0:bb[0-9]+]], error [[ERR_0:bb[0-9]+]]
 // CHECK:     [[NORM_0]]([[CAT0:%.*]] : $Cat):
-// CHECK-NEXT:  store [[CAT0]] to [[ELT0]]
+// CHECK-NEXT:  store [[CAT0]] to [init] [[ELT0]]
 //   Element 1.
 // CHECK-NEXT:  [[T0:%.*]] = integer_literal $Builtin.Word, 1
 // CHECK-NEXT:  [[ELT1:%.*]] = index_addr [[ELT0]] : $*Cat, [[T0]]
 // CHECK-NEXT:  copy_value %0
-// CHECK-NEXT:  store %0 to [[ELT1]]
+// CHECK-NEXT:  store %0 to [init] [[ELT1]]
 //   Element 2.
 // CHECK-NEXT:  [[T0:%.*]] = integer_literal $Builtin.Word, 2
 // CHECK-NEXT:  [[ELT2:%.*]] = index_addr [[ELT0]] : $*Cat, [[T0]]
@@ -412,7 +412,7 @@ func test_variadic(_ cat: Cat) throws {
 // CHECK-NEXT:  [[T0:%.*]] = function_ref @_TF6errors10make_a_catFzT_CS_3Cat : $@convention(thin) () -> (@owned Cat, @error Error)
 // CHECK-NEXT:  try_apply [[T0]]() : $@convention(thin) () -> (@owned Cat, @error Error), normal [[NORM_2:bb[0-9]+]], error [[ERR_2:bb[0-9]+]]
 // CHECK:     [[NORM_2]]([[CAT2:%.*]] : $Cat):
-// CHECK-NEXT:  store [[CAT2]] to [[ELT2]]
+// CHECK-NEXT:  store [[CAT2]] to [init] [[ELT2]]
 //   Element 3.
 // CHECK-NEXT:  [[T0:%.*]] = integer_literal $Builtin.Word, 3
 // CHECK-NEXT:  [[ELT3:%.*]] = index_addr [[ELT0]] : $*Cat, [[T0]]
@@ -420,7 +420,7 @@ func test_variadic(_ cat: Cat) throws {
 // CHECK-NEXT:  [[T0:%.*]] = function_ref @_TF6errors10make_a_catFzT_CS_3Cat : $@convention(thin) () -> (@owned Cat, @error Error)
 // CHECK-NEXT:  try_apply [[T0]]() : $@convention(thin) () -> (@owned Cat, @error Error), normal [[NORM_3:bb[0-9]+]], error [[ERR_3:bb[0-9]+]]
 // CHECK:     [[NORM_3]]([[CAT3:%.*]] : $Cat):
-// CHECK-NEXT:  store [[CAT3]] to [[ELT3]]
+// CHECK-NEXT:  store [[CAT3]] to [init] [[ELT3]]
 //   Complete the call and return.
 // CHECK-NEXT:  try_apply [[TAKE_FN]]([[ARRAY]]) : $@convention(thin) (@owned Array<Cat>) -> @error Error, normal [[NORM_CALL:bb[0-9]+]], error [[ERR_CALL:bb[0-9]+]]
 // CHECK:     [[NORM_CALL]]([[T0:%.*]] : $()):
@@ -581,7 +581,7 @@ func supportStructure(_ b: inout Bridge, name: String) throws {
 // CHECK-NEXT: [[GETTER:%.*]] = function_ref @_TFV6errors6Bridgeg9subscriptFSSVS_5Pylon :
 // CHECK-NEXT: [[T0:%.*]] = apply [[GETTER]]([[INDEX]], [[BASE]])
 // CHECK-NEXT: destroy_value [[BASE]]
-// CHECK-NEXT: store [[T0]] to [[TEMP]]
+// CHECK-NEXT: store [[T0]] to [init] [[TEMP]]
 // CHECK-NEXT: try_apply [[SUPPORT]]([[TEMP]]) : {{.*}}, normal [[BB_NORMAL:bb[0-9]+]], error [[BB_ERROR:bb[0-9]+]]
 
 // CHECK:    [[BB_NORMAL]]
@@ -713,7 +713,7 @@ func testOptionalTry() {
 // CHECK: [[FN:%.+]] = function_ref @_TF6errors10make_a_catFzT_CS_3Cat
 // CHECK-NEXT: try_apply [[FN]]() : $@convention(thin) () -> (@owned Cat, @error Error), normal [[SUCCESS:[^ ]+]], error [[CLEANUPS:[^ ]+]],
 // CHECK: [[SUCCESS]]([[VALUE:%.+]] : $Cat)
-// CHECK-NEXT: store [[VALUE]] to [[BOX_DATA]] : $*Cat
+// CHECK-NEXT: store [[VALUE]] to [init] [[BOX_DATA]] : $*Cat
 // CHECK-NEXT: inject_enum_addr [[PB]] : $*Optional<Cat>, #Optional.some!enumelt.1
 // CHECK-NEXT: br [[DONE:[^ ]+]],
 // CHECK: [[DONE]]:

--- a/test/SILGen/foreign_errors.swift
+++ b/test/SILGen/foreign_errors.swift
@@ -20,7 +20,7 @@ func test0() throws {
   // CHECK: [[ERR_TEMP1:%.*]] = alloc_stack $@sil_unmanaged Optional<NSError>
   // CHECK: [[T0:%.*]] = load [[ERR_TEMP0]]
   // CHECK: [[T1:%.*]] = ref_to_unmanaged [[T0]]
-  // CHECK: store [[T1]] to [[ERR_TEMP1]]
+  // CHECK: store [[T1]] to [trivial] [[ERR_TEMP1]]
   // CHECK: address_to_pointer [[ERR_TEMP1]]
 
   //   Call the method.
@@ -73,7 +73,7 @@ extension NSObject {
 // CHECK:   [[OBJCERR:%.*]] = enum $Optional<NSError>, #Optional.some!enumelt.1, [[T1]] : $NSError
 // CHECK:   [[SETTER:%.*]] = function_ref @_TFVs33AutoreleasingUnsafeMutablePointers7pointeex :
 // CHECK:   [[TEMP:%.*]] = alloc_stack $Optional<NSError>
-// CHECK:   store [[OBJCERR]] to [[TEMP]]
+// CHECK:   store [[OBJCERR]] to [init] [[TEMP]]
 // CHECK:   apply [[SETTER]]<Optional<NSError>>([[TEMP]], [[UNWRAPPED_OUT]])
 // CHECK:   dealloc_stack [[TEMP]]
 // CHECK:   br bb5
@@ -107,7 +107,7 @@ extension NSObject {
 // CHECK:   [[OBJCERR:%.*]] = enum $Optional<NSError>, #Optional.some!enumelt.1, [[T1]] : $NSError
 // CHECK:   [[SETTER:%.*]] = function_ref @_TFVs33AutoreleasingUnsafeMutablePointers7pointeex :
 // CHECK:   [[TEMP:%.*]] = alloc_stack $Optional<NSError>
-// CHECK:   store [[OBJCERR]] to [[TEMP]]
+// CHECK:   store [[OBJCERR]] to [init] [[TEMP]]
 // CHECK:   apply [[SETTER]]<Optional<NSError>>([[TEMP]], [[UNWRAPPED_OUT]])
 // CHECK:   dealloc_stack [[TEMP]]
 // CHECK:   br bb5

--- a/test/SILGen/functions.swift
+++ b/test/SILGen/functions.swift
@@ -276,7 +276,7 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: [[FADDR:%.*]] = project_box [[FBOX]]
   // CHECK: [[FUNC_THIN:%[0-9]+]] = function_ref @_TF9functions19standalone_function{{.*}} : $@convention(thin) (Builtin.Int64, Builtin.Int64) -> Builtin.Int64
   // CHECK: [[FUNC_THICK:%[0-9]+]] = thin_to_thick_function [[FUNC_THIN]]
-  // CHECK: store [[FUNC_THICK]] to [[FADDR]]
+  // CHECK: store [[FUNC_THICK]] to [init] [[FADDR]]
   var f = standalone_function
   // CHECK: [[F:%[0-9]+]] = load [[FADDR]]
   // CHECK: [[I:%[0-9]+]] = load [[IADDR]]

--- a/test/SILGen/guaranteed_self.swift
+++ b/test/SILGen/guaranteed_self.swift
@@ -365,7 +365,7 @@ class D: C {
   // CHECK-NOT:     [[SELF_ADDR]]
   // CHECK:         [[SUPER2:%.*]] = apply {{.*}}([[SUPER1]])
   // CHECK-NEXT:    [[SELF2:%.*]] = unchecked_ref_cast [[SUPER2]]
-  // CHECK-NEXT:    store [[SELF2]] to [[SELF_ADDR]]
+  // CHECK-NEXT:    store [[SELF2]] to [init] [[SELF_ADDR]]
   // CHECK-NOT:     [[SELF_ADDR]]
   // CHECK-NOT:     [[SELF1]]
   // CHECK-NOT:     [[SUPER1]]
@@ -482,7 +482,7 @@ class LetFieldClass {
   // CHECK-NEXT: [[KRAKEN_ADDR:%.*]] = ref_element_addr [[CLS]] : $LetFieldClass, #LetFieldClass.letk
   // CHECK-NEXT: [[KRAKEN2:%.*]] = load [[KRAKEN_ADDR]]
   // CHECK-NEXT: copy_value [[KRAKEN2]]
-  // CHECK-NEXT: store [[KRAKEN2]] to [[PB]]
+  // CHECK-NEXT: store [[KRAKEN2]] to [init] [[PB]]
   // CHECK: [[DESTROY_SHIP_FUN:%.*]] = function_ref @_TF15guaranteed_self11destroyShipFCS_6KrakenT_ : $@convention(thin) (@owned Kraken) -> ()
   // CHECK-NEXT: [[KRAKEN_COPY:%.*]] = load [[PB]]
   // CHECK-NEXT: copy_value [[KRAKEN_COPY]]
@@ -515,7 +515,7 @@ class LetFieldClass {
   // CHECK-NEXT: [[PB:%.*]] = project_box [[KRAKEN_BOX]]
   // CHECK-NEXT: [[KRAKEN_GETTER_FUN:%.*]] = class_method [[CLS]] : $LetFieldClass, #LetFieldClass.vark!getter.1 : (LetFieldClass) -> () -> Kraken , $@convention(method) (@guaranteed LetFieldClass) -> @owned Kraken
   // CHECK-NEXT: [[KRAKEN2:%.*]] = apply [[KRAKEN_GETTER_FUN]]([[CLS]])
-  // CHECK-NEXT: store [[KRAKEN2]] to [[PB]]
+  // CHECK-NEXT: store [[KRAKEN2]] to [init] [[PB]]
   // CHECK: [[DESTROY_SHIP_FUN:%.*]] = function_ref @_TF15guaranteed_self11destroyShipFCS_6KrakenT_ : $@convention(thin) (@owned Kraken) -> ()
   // CHECK-NEXT: [[KRAKEN_COPY:%.*]] = load [[PB]]
   // CHECK-NEXT: copy_value [[KRAKEN_COPY]]

--- a/test/SILGen/if_while_binding.swift
+++ b/test/SILGen/if_while_binding.swift
@@ -164,7 +164,7 @@ func if_multi() {
 
   // CHECK: [[IF_BODY]]([[BVAL:%[0-9]+]] : $String):
   if let a = foo(), var b = bar() {
-    // CHECK:   store [[BVAL]] to [[PB]] : $*String
+    // CHECK:   store [[BVAL]] to [init] [[PB]] : $*String
     // CHECK:   debug_value {{.*}} : $String, let, name "c"
     // CHECK:   destroy_value [[B]]
     // CHECK:   destroy_value [[A]]
@@ -192,7 +192,7 @@ func if_multi_else() {
 
   // CHECK: [[IF_BODY]]([[BVAL:%[0-9]+]] : $String):
   if let a = foo(), var b = bar() {
-    // CHECK:   store [[BVAL]] to [[PB]] : $*String
+    // CHECK:   store [[BVAL]] to [init] [[PB]] : $*String
     // CHECK:   debug_value {{.*}} : $String, let, name "c"
     // CHECK:   destroy_value [[B]]
     // CHECK:   destroy_value [[A]]

--- a/test/SILGen/implicitly_unwrapped_optional.swift
+++ b/test/SILGen/implicitly_unwrapped_optional.swift
@@ -8,7 +8,7 @@ func foo(f f: (() -> ())!) {
 // CHECK:    bb0([[T0:%.*]] : $Optional<@callee_owned () -> ()>):
 // CHECK: [[F:%.*]] = alloc_box $Optional<@callee_owned () -> ()>
 // CHECK-NEXT: [[PF:%.*]] = project_box [[F]]
-// CHECK: store [[T0]] to [[PF]]
+// CHECK: store [[T0]] to [init] [[PF]]
 // CHECK:      [[T1:%.*]] = select_enum_addr [[PF]]
 // CHECK-NEXT: cond_br [[T1]], bb1, bb3
 //   If it does, project and load the value out of the implicitly unwrapped

--- a/test/SILGen/indirect_enum.swift
+++ b/test/SILGen/indirect_enum.swift
@@ -28,9 +28,9 @@ func TreeA_cases<T>(_ t: T, l: TreeA<T>, r: TreeA<T>) {
 // CHECK-NEXT:    [[LEFT:%.*]] = tuple_element_addr [[PB]] : $*(left: TreeA<T>, right: TreeA<T>), 0
 // CHECK-NEXT:    [[RIGHT:%.*]] = tuple_element_addr [[PB]] : $*(left: TreeA<T>, right: TreeA<T>), 1
 // CHECK-NEXT:    copy_value %1
-// CHECK-NEXT:    store %1 to [[LEFT]]
+// CHECK-NEXT:    store %1 to [init] [[LEFT]]
 // CHECK-NEXT:    copy_value %2
-// CHECK-NEXT:    store %2 to [[RIGHT]]
+// CHECK-NEXT:    store %2 to [init] [[RIGHT]]
 // CHECK-NEXT:    [[BRANCH:%.*]] = enum $TreeA<T>, #TreeA.Branch!enumelt.1, [[BOX]]
 // CHECK-NEXT:    destroy_value [[BRANCH]]
 // CHECK-NEXT:    destroy_value %2
@@ -51,7 +51,7 @@ func TreeA_reabstract(_ f: @escaping (Int) -> Int) {
 // CHECK-NEXT:    copy_value %0
 // CHECK:         [[THUNK:%.*]] = function_ref @_TTRXFo_dSi_dSi_XFo_iSi_iSi_
 // CHECK-NEXT:    [[FN:%.*]] = partial_apply [[THUNK]](%0)
-// CHECK-NEXT:    store [[FN]] to [[PB]]
+// CHECK-NEXT:    store [[FN]] to [init] [[PB]]
 // CHECK-NEXT:    [[LEAF:%.*]] = enum $TreeA<(Int) -> Int>, #TreeA.Leaf!enumelt.1, [[BOX]]
 // CHECK-NEXT:    destroy_value [[LEAF]]
 // CHECK-NEXT:    destroy_value %0
@@ -125,9 +125,9 @@ func TreeInt_cases(_ t: Int, l: TreeInt, r: TreeInt) {
 // CHECK-NEXT:    [[LEFT:%.*]] = tuple_element_addr [[PB]]
 // CHECK-NEXT:    [[RIGHT:%.*]] = tuple_element_addr [[PB]]
 // CHECK-NEXT:    copy_value %1
-// CHECK-NEXT:    store %1 to [[LEFT]]
+// CHECK-NEXT:    store %1 to [init] [[LEFT]]
 // CHECK-NEXT:    copy_value %2
-// CHECK-NEXT:    store %2 to [[RIGHT]]
+// CHECK-NEXT:    store %2 to [init] [[RIGHT]]
 // CHECK-NEXT:    [[BRANCH:%.*]] = enum $TreeInt, #TreeInt.Branch!enumelt.1, [[BOX]]
 // CHECK-NEXT:    destroy_value [[BRANCH]]
 // CHECK-NEXT:    destroy_value %2

--- a/test/SILGen/init_ref_delegation.swift
+++ b/test/SILGen/init_ref_delegation.swift
@@ -70,7 +70,7 @@ struct S2 {
     // CHECK:   [[X_META:%[0-9]+]] = metatype $@thin X.Type
     // CHECK:   [[X:%[0-9]+]] = apply [[X_INIT]]([[X_META]]) : $@convention(method) (@thin X.Type) -> X
     // CHECK:   [[X_BOX:%[0-9]+]] = alloc_stack $X
-    // CHECK:   store [[X]] to [[X_BOX]] : $*X
+    // CHECK:   store [[X]] to [trivial] [[X_BOX]] : $*X
     // CHECK:   [[SELF_BOX1:%[0-9]+]] = apply [[S2_DELEG_INIT]]<X>([[X_BOX]], [[S2_META]]) : $@convention(method) <τ_0_0> (@in τ_0_0, @thin S2.Type) -> S2
     // CHECK:   assign [[SELF_BOX1]] to [[SELF]] : $*S2
     // CHECK:   dealloc_stack [[X_BOX]] : $*X
@@ -99,7 +99,7 @@ class C1 {
 
     // CHECK:   [[DELEG_INIT:%[0-9]+]] = class_method [[SELF_FROM_BOX]] : $C1, #C1.init!initializer.1 : (C1.Type) -> (X, X) -> C1 , $@convention(method) (X, X, @owned C1) -> @owned C1
     // CHECK:   [[SELFP:%[0-9]+]] = apply [[DELEG_INIT]]([[X]], [[X]], [[SELF_FROM_BOX]]) : $@convention(method) (X, X, @owned C1) -> @owned C1
-    // CHECK:   store [[SELFP]] to [[SELF]] : $*C1
+    // CHECK:   store [[SELFP]] to [init] [[SELF]] : $*C1
     // CHECK:   [[SELFP:%[0-9]+]] = load [[SELF]] : $*C1
     // CHECK:   copy_value [[SELFP]] : $C1
     // CHECK:   destroy_value [[SELF_BOX]] : $@box C1
@@ -124,7 +124,7 @@ class C1 {
 
     // CHECK:   [[DELEG_INIT:%[0-9]+]] = class_method [[SELF]] : $C2, #C2.init!initializer.1 : (C2.Type) -> (X, X) -> C2 , $@convention(method) (X, X, @owned C2) -> @owned C2
     // CHECK:   [[REPLACE_SELF:%[0-9]+]] = apply [[DELEG_INIT]]([[X]], [[X]], [[SELF]]) : $@convention(method) (X, X, @owned C2) -> @owned C2
-    // CHECK:   store [[REPLACE_SELF]] to [[UNINIT_SELF]] : $*C2
+    // CHECK:   store [[REPLACE_SELF]] to [init] [[UNINIT_SELF]] : $*C2
     // CHECK:   [[VAR_15:%[0-9]+]] = load [[UNINIT_SELF]] : $*C2
     // CHECK:   copy_value [[VAR_15]] : $C2
     // CHECK:   destroy_value [[SELF_BOX]] : $@box C2

--- a/test/SILGen/lazy_globals.swift
+++ b/test/SILGen/lazy_globals.swift
@@ -3,7 +3,7 @@
 // CHECK: sil private @globalinit_[[T:.*]]_func0 : $@convention(thin) () -> () {
 // CHECK:   alloc_global @_Tv12lazy_globals1xSi
 // CHECK:   [[XADDR:%.*]] = global_addr @_Tv12lazy_globals1xSi : $*Int
-// CHECK:   store {{%.*}} to [[XADDR]] : $*Int
+// CHECK:   store {{%.*}} to [trivial] [[XADDR]] : $*Int
 
 // CHECK: sil hidden [global_init] @_TF12lazy_globalsau1xSi : $@convention(thin) () -> Builtin.RawPointer {
 // CHECK:   [[TOKEN_ADDR:%.*]] = global_addr @globalinit_[[T]]_token0 : $*Builtin.Word
@@ -19,7 +19,7 @@ var x: Int = 0
 // CHECK: sil private @globalinit_[[T:.*]]_func1 : $@convention(thin) () -> () {
 // CHECK:   alloc_global @_TZvV12lazy_globals3Foo3fooSi
 // CHECK:   [[XADDR:%.*]] = global_addr @_TZvV12lazy_globals3Foo3fooSi : $*Int
-// CHECK:   store {{.*}} to [[XADDR]] : $*Int
+// CHECK:   store {{.*}} to [trivial] [[XADDR]] : $*Int
 // CHECK:   return
 
 struct Foo {
@@ -43,7 +43,7 @@ struct Foo {
 // CHECK: sil private @globalinit_[[T:.*]]_func3 : $@convention(thin) () -> () {
 // CHECK:   alloc_global @_TZvO12lazy_globals3Bar3barSi
 // CHECK:   [[XADDR:%.*]] = global_addr @_TZvO12lazy_globals3Bar3barSi : $*Int
-// CHECK:   store {{.*}} to [[XADDR]] : $*Int
+// CHECK:   store {{.*}} to [trivial] [[XADDR]] : $*Int
 // CHECK:   return
 
 enum Bar {

--- a/test/SILGen/let_decls.swift
+++ b/test/SILGen/let_decls.swift
@@ -233,7 +233,7 @@ func test_weird_property(_ v : WeirdPropertyTest, i : Int) -> Int {
   var v = v
   // CHECK: [[VBOX:%[0-9]+]] = alloc_box $WeirdPropertyTest
   // CHECK: [[PB:%.*]] = project_box [[VBOX]]
-  // CHECK: store %0 to [[PB]]
+  // CHECK: store %0 to [trivial] [[PB]]
 
   // The setter isn't mutating, so we need to load the box.
   // CHECK: [[VVAL:%[0-9]+]] = load [[PB]]
@@ -460,7 +460,7 @@ struct LetPropertyStruct {
 // CHECK: bb0(%0 : $LetPropertyStruct):
 // CHECK:  [[ABOX:%[0-9]+]] = alloc_box $LetPropertyStruct
 // CHECK:  [[A:%[0-9]+]] = project_box [[ABOX]]
-// CHECK:   store %0 to [[A]] : $*LetPropertyStruct
+// CHECK:   store %0 to [trivial] [[A]] : $*LetPropertyStruct
 // CHECK:   [[STRUCT:%[0-9]+]] = load [[A]] : $*LetPropertyStruct
 // CHECK:   [[PROP:%[0-9]+]] = struct_extract [[STRUCT]] : $LetPropertyStruct, #LetPropertyStruct.lp
 // CHECK:   destroy_value [[ABOX]] : $@box LetPropertyStruct

--- a/test/SILGen/lifetime.swift
+++ b/test/SILGen/lifetime.swift
@@ -131,7 +131,7 @@ func reftype_arg(_ a: Ref) {
     // CHECK: bb0([[A:%[0-9]+]] : $Ref):
     // CHECK: [[AADDR:%[0-9]+]] = alloc_box $Ref
     // CHECK: [[PA:%[0-9]+]] = project_box [[AADDR]]
-    // CHECK: store [[A]] to [[PA]]
+    // CHECK: store [[A]] to [init] [[PA]]
     // CHECK: destroy_value [[AADDR]]
     // CHECK: return
 }
@@ -153,7 +153,7 @@ func reftype_call_store_to_local() {
     // CHECK: = function_ref @_TF8lifetime12reftype_funcFT_CS_3Ref : $@convention(thin) () -> @owned Ref
     // CHECK-NEXT: [[R:%[0-9]+]] = apply
     // CHECK-NOT: copy_value [[R]]
-    // CHECK: store [[R]] to [[PB]]
+    // CHECK: store [[R]] to [init] [[PB]]
     // CHECK-NOT: destroy_value [[R]]
     // CHECK: destroy_value [[A]]
     // CHECK-NOT: destroy_value [[R]]
@@ -177,7 +177,7 @@ func reftype_call_with_arg(_ a: Ref) {
     // CHECK: bb0([[A1:%[0-9]+]] : $Ref):
     // CHECK: [[AADDR:%[0-9]+]] = alloc_box $Ref
     // CHECK: [[PB:%.*]] = project_box [[AADDR]]
-    // CHECK: store [[A1]] to [[PB]]
+    // CHECK: store [[A1]] to [init] [[PB]]
 
     reftype_func_with_arg(a)
     // CHECK: [[RFWA:%[0-9]+]] = function_ref @_TF8lifetime21reftype_func_with_arg
@@ -246,9 +246,9 @@ struct Daleth {
   // CHECK-LABEL: sil hidden @_TFV8lifetime6DalethC{{.*}} : $@convention(method) (@owned Aleph, @owned Beth, @in Unloadable, @thin Daleth.Type) -> @out Daleth {
   // CHECK: bb0([[THIS:%.*]] : $*Daleth, [[A:%.*]] : $Aleph, [[B:%.*]] : $Beth, [[C:%.*]] : $*Unloadable, {{%.*}} : $@thin Daleth.Type):
   // CHECK-NEXT:   [[A_ADDR:%.*]] = struct_element_addr [[THIS]] : $*Daleth, #Daleth.a
-  // CHECK-NEXT:   store [[A]] to [[A_ADDR]]
+  // CHECK-NEXT:   store [[A]] to [init] [[A_ADDR]]
   // CHECK-NEXT:   [[B_ADDR:%.*]] = struct_element_addr [[THIS]] : $*Daleth, #Daleth.b
-  // CHECK-NEXT:   store [[B]] to [[B_ADDR]]
+  // CHECK-NEXT:   store [[B]] to [init] [[B_ADDR]]
   // CHECK-NEXT:   [[C_ADDR:%.*]] = struct_element_addr [[THIS]] : $*Daleth, #Daleth.c
   // CHECK-NEXT:   copy_addr [take] [[C]] to [initialization] [[C_ADDR]]
   // CHECK-NEXT:   tuple ()
@@ -299,7 +299,7 @@ struct Zayin {
   // CHECK-NEXT:   [[THIS_A0_ADDR:%.*]] = tuple_element_addr [[THIS_A_ADDR]] : {{.*}}, 0
   // CHECK-NEXT:   [[THIS_A1_ADDR:%.*]] = tuple_element_addr [[THIS_A_ADDR]] : {{.*}}, 1
   // CHECK-NEXT:   copy_addr [take] [[A0]] to [initialization] [[THIS_A0_ADDR]]
-  // CHECK-NEXT:   store [[A1]] to [[THIS_A1_ADDR]]
+  // CHECK-NEXT:   store [[A1]] to [trivial] [[THIS_A1_ADDR]]
   // CHECK-NEXT:   [[THIS_B_ADDR:%.*]] = struct_element_addr [[THIS]] : $*Zayin, #Zayin.b
   // CHECK-NEXT:   copy_addr [take] [[B]] to [initialization] [[THIS_B_ADDR]]
   // CHECK-NEXT:   tuple ()
@@ -340,7 +340,7 @@ func logical_lvalue_lifetime(_ r: RefWithProp, _ i: Int, _ v: Val) {
   // CHECK: [[PR:%[0-9]+]] = project_box [[RADDR]]
   // CHECK: [[IADDR:%[0-9]+]] = alloc_box $Int
   // CHECK: [[PI:%[0-9]+]] = project_box [[IADDR]]
-  // CHECK: store %1 to [[PI]]
+  // CHECK: store %1 to [trivial] [[PI]]
   // CHECK: [[VADDR:%[0-9]+]] = alloc_box $Val
   // CHECK: [[PV:%[0-9]+]] = project_box [[VADDR]]
 
@@ -367,7 +367,7 @@ func logical_lvalue_lifetime(_ r: RefWithProp, _ i: Int, _ v: Val) {
   // CHECK: {{.*}}([[CALLBACK_ADDR:%.*]] : 
   // CHECK: [[CALLBACK:%.*]] = pointer_to_thin_function [[CALLBACK_ADDR]] : $Builtin.RawPointer to $@convention(thin) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout RefWithProp, @thick RefWithProp.Type) -> ()
   // CHECK: [[TEMP:%.*]] = alloc_stack $RefWithProp
-  // CHECK: store [[R2]] to [[TEMP]]
+  // CHECK: store [[R2]] to [init] [[TEMP]]
   // CHECK: apply [[CALLBACK]]({{.*}}, [[STORAGE]], [[TEMP]], {{%.*}})
 }
 
@@ -425,7 +425,7 @@ class Foo<T> {
     // CHECK: [[THIS:%[0-9]+]] = mark_uninitialized
     // CHECK: [[CHIADDR:%[0-9]+]] = alloc_box $Int
     // CHECK: [[PCHI:%[0-9]+]] = project_box [[CHIADDR]]
-    // CHECK: store [[CHI]] to [[PCHI]]
+    // CHECK: store [[CHI]] to [trivial] [[PCHI]]
 
     // CHECK: ref_element_addr {{.*}}, #Foo.z
 
@@ -618,10 +618,10 @@ class D : B {
     // CHECK: store [[THIS]] to [[THISADDR]]
     // CHECK: [[XADDR:%[0-9]+]] = alloc_box $Int
     // CHECK: [[PX:%[0-9]+]] = project_box [[XADDR]]
-    // CHECK: store [[X]] to [[PX]]
+    // CHECK: store [[X]] to [trivial] [[PX]]
     // CHECK: [[YADDR:%[0-9]+]] = alloc_box $Int
     // CHECK: [[PY:%[0-9]+]] = project_box [[YADDR]]
-    // CHECK: store [[Y]] to [[PY]]
+    // CHECK: store [[Y]] to [trivial] [[PY]]
 
     super.init(y: y)
     // CHECK: [[THIS1:%[0-9]+]] = load [[THISADDR]]

--- a/test/SILGen/materializeForSet.swift
+++ b/test/SILGen/materializeForSet.swift
@@ -11,7 +11,7 @@ class Base {
 // CHECK:   [[ADDR:%.*]] = pointer_to_address [[BUFFER]] : $Builtin.RawPointer to [strict] $*Int
 // CHECK:   [[T0:%.*]] = function_ref @_TFC17materializeForSet4Baseg8computedSi
 // CHECK:   [[T1:%.*]] = apply [[T0]]([[SELF]])
-// CHECK:   store [[T1]] to [[ADDR]] : $*Int
+// CHECK:   store [[T1]] to [trivial] [[ADDR]] : $*Int
 // CHECK:   [[BUFFER:%.*]] = address_to_pointer [[ADDR]]
 // CHECK:   [[T0:%.*]] = function_ref @_TFFC17materializeForSet4Basem8computedSiU_T_ : $@convention(thin) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout Base, @thick Base.Type) -> ()
 // CHECK:   [[T2:%.*]] = thin_function_to_pointer [[T0]]
@@ -76,13 +76,13 @@ extension Derived : Abstractable {}
 // CHECK-NEXT: [[TEMP:%.*]] = alloc_stack $@callee_owned () -> Int
 // CHECK-NEXT: [[FN:%.*]] = class_method [[SELF]] : $Base, #Base.storedFunction!getter.1
 // CHECK-NEXT: [[RESULT:%.*]] = apply [[FN]]([[SELF]])
-// CHECK-NEXT: store [[RESULT]] to [[TEMP]]
+// CHECK-NEXT: store [[RESULT]] to [init] [[TEMP]]
 // CHECK-NEXT: [[RESULT:%.*]] = load [[TEMP]]
 // CHECK-NEXT: copy_value [[RESULT]]
 // CHECK-NEXT: function_ref
 // CHECK-NEXT: [[REABSTRACTOR:%.*]] = function_ref @_TTRXFo__dSi_XFo__iSi_ : $@convention(thin) (@owned @callee_owned () -> Int) -> @out Int
 // CHECK-NEXT: [[T1:%.*]] = partial_apply [[REABSTRACTOR]]([[RESULT]])
-// CHECK-NEXT: store [[T1]] to [[RESULT_ADDR]]
+// CHECK-NEXT: store [[T1]] to [init] [[RESULT_ADDR]]
 // CHECK-NEXT: [[RESULT_PTR:%.*]] = address_to_pointer [[RESULT_ADDR]] : $*@callee_owned () -> @out Int to $Builtin.RawPointer
 // CHECK-NEXT: function_ref
 // CHECK-NEXT: [[T0:%.*]] = function_ref @_TTWC17materializeForSet7DerivedS_12AbstractableS_FFS1_m14storedFunctionFT_wx6ResultU_T_
@@ -118,7 +118,7 @@ extension Derived : Abstractable {}
 // CHECK-NEXT: function_ref
 // CHECK-NEXT: [[REABSTRACTOR:%.*]] = function_ref @_TTRXFo__dSi_XFo__iSi_ : $@convention(thin) (@owned @callee_owned () -> Int) -> @out Int
 // CHECK-NEXT: [[T1:%.*]] = partial_apply [[REABSTRACTOR]]([[RESULT]])
-// CHECK-NEXT: store [[T1]] to [[RESULT_ADDR]]
+// CHECK-NEXT: store [[T1]] to [init] [[RESULT_ADDR]]
 // CHECK-NEXT: [[RESULT_PTR:%.*]] = address_to_pointer [[RESULT_ADDR]] : $*@callee_owned () -> @out Int to $Builtin.RawPointer
 // CHECK-NEXT: function_ref
 // CHECK-NEXT: [[T0:%.*]] = function_ref @_TTWC17materializeForSet7DerivedS_12AbstractableS_FFS1_m19finalStoredFunctionFT_wx6ResultU_T_
@@ -148,12 +148,12 @@ extension Derived : Abstractable {}
 // CHECK-NEXT: [[OUT:%.*]] = alloc_stack $@callee_owned () -> Int
 // CHECK:      [[GETTER:%.*]] = function_ref @_TZFC17materializeForSet4Baseg14staticFunctionFT_Si : $@convention(method) (@thick Base.Type) -> @owned @callee_owned () -> Int
 // CHECK-NEXT: [[VALUE:%.*]] = apply [[GETTER]]([[SELF]]) : $@convention(method) (@thick Base.Type) -> @owned @callee_owned () -> Int
-// CHECK-NEXT: store [[VALUE]] to [[OUT]] : $*@callee_owned () -> Int
+// CHECK-NEXT: store [[VALUE]] to [init] [[OUT]] : $*@callee_owned () -> Int
 // CHECK-NEXT: [[VALUE:%.*]] = load [[OUT]] : $*@callee_owned () -> Int
 // CHECK-NEXT: copy_value [[VALUE]] : $@callee_owned () -> Int
 // CHECK:      [[REABSTRACTOR:%.*]] = function_ref @_TTRXFo__dSi_XFo__iSi_ : $@convention(thin) (@owned @callee_owned () -> Int) -> @out Int
 // CHECK-NEXT: [[NEWVALUE:%.*]] = partial_apply [[REABSTRACTOR]]([[VALUE]])
-// CHECK-NEXT: store [[NEWVALUE]] to [[RESULT_ADDR]] : $*@callee_owned () -> @out Int
+// CHECK-NEXT: store [[NEWVALUE]] to [init] [[RESULT_ADDR]] : $*@callee_owned () -> @out Int
 // CHECK-NEXT: [[ADDR:%.*]] = address_to_pointer [[RESULT_ADDR]] : $*@callee_owned () -> @out Int to $Builtin.RawPointer
 // CHECK:      [[CALLBACK_FN:%.*]] = function_ref @_TTWC17materializeForSet7DerivedS_12AbstractableS_FZFS1_m14staticFunctionFT_wx6ResultU_T_ : $@convention(thin) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout @thick Derived.Type, @thick Derived.Type.Type) -> ()
 // CHECK-NEXT: [[CALLBACK_ADDR:%.*]] = thin_function_to_pointer [[CALLBACK_FN]] : $@convention(thin) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout @thick Derived.Type, @thick Derived.Type.Type) -> () to $Builtin.RawPointer
@@ -213,7 +213,7 @@ class HasDidSet : Base {
 // CHECK:   [[T2:%.*]] = pointer_to_address [[BUFFER]] : $Builtin.RawPointer to [strict] $*Int
 // CHECK:   [[T0:%.*]] = function_ref @_TFC17materializeForSet9HasDidSetg6storedSi
 // CHECK:   [[T1:%.*]] = apply [[T0]]([[SELF]])
-// CHECK:   store [[T1]] to [[T2]] : $*Int
+// CHECK:   store [[T1]] to [trivial] [[T2]] : $*Int
 // CHECK:   [[BUFFER:%.*]] = address_to_pointer [[T2]]
 // CHECK:   [[CALLBACK_FN:%.*]] = function_ref @_TFFC17materializeForSet9HasDidSetm6storedSiU_T_ : $@convention(thin) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout HasDidSet, @thick HasDidSet.Type) -> ()
 // CHECK:   [[CALLBACK_ADDR:%.*]] = thin_function_to_pointer [[CALLBACK_FN]]
@@ -232,7 +232,7 @@ class HasDidSet : Base {
 // CHECK:   [[T2:%.*]] = pointer_to_address [[BUFFER]] : $Builtin.RawPointer to [strict] $*Int
 // CHECK:   [[T0:%.*]] = function_ref @_TFC17materializeForSet9HasDidSetg8computedSi
 // CHECK:   [[T1:%.*]] = apply [[T0]]([[SELF]])
-// CHECK:   store [[T1]] to [[T2]] : $*Int
+// CHECK:   store [[T1]] to [trivial] [[T2]] : $*Int
 // CHECK:   [[BUFFER:%.*]] = address_to_pointer [[T2]]
 // CHECK:   [[CALLBACK_FN:%.*]] = function_ref @_TFFC17materializeForSet9HasDidSetm8computedSiU_T_ : $@convention(thin) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout HasDidSet, @thick HasDidSet.Type) -> ()
 // CHECK:   [[CALLBACK_ADDR:%.*]] = thin_function_to_pointer [[CALLBACK_FN]]
@@ -252,7 +252,7 @@ class HasStoredDidSet {
 // CHECK:   [[T2:%.*]] = pointer_to_address [[BUFFER]] : $Builtin.RawPointer to [strict] $*Int
 // CHECK:   [[T0:%.*]] = function_ref @_TFC17materializeForSet15HasStoredDidSetg6storedSi
 // CHECK:   [[T1:%.*]] = apply [[T0]]([[SELF]])
-// CHECK:   store [[T1]] to [[T2]] : $*Int
+// CHECK:   store [[T1]] to [trivial] [[T2]] : $*Int
 // CHECK:   [[BUFFER:%.*]] = address_to_pointer [[T2]]
 // CHECK:   [[CALLBACK_FN:%.*]] = function_ref @_TFFC17materializeForSet15HasStoredDidSetm6storedSiU_T_ : $@convention(thin) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout HasStoredDidSet, @thick HasStoredDidSet.Type) -> ()
 // CHECK:   [[CALLBACK_ADDR:%.*]] = thin_function_to_pointer [[CALLBACK_FN]]
@@ -280,7 +280,7 @@ class HasWeak {
 // CHECK:   [[T2:%.*]] = pointer_to_address [[BUFFER]] : $Builtin.RawPointer to [strict] $*Optional<HasWeak>
 // CHECK:   [[T0:%.*]] = ref_element_addr [[SELF]] : $HasWeak, #HasWeak.weakvar
 // CHECK:   [[T1:%.*]] = load_weak [[T0]] : $*@sil_weak Optional<HasWeak>
-// CHECK:   store [[T1]] to [[T2]] : $*Optional<HasWeak>
+// CHECK:   store [[T1]] to [init] [[T2]] : $*Optional<HasWeak>
 // CHECK:   [[BUFFER:%.*]] = address_to_pointer [[T2]]
 // CHECK:   [[T0:%.*]] = function_ref @_TFFC17materializeForSet7HasWeakm7weakvarXwGSqS0__U_T_ : $@convention(thin) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout HasWeak, @thick HasWeak.Type) -> () 
 // CHECK:   [[T4:%.*]] = tuple ([[BUFFER]] : $Builtin.RawPointer, {{.*}} : $Optional<Builtin.RawPointer>)
@@ -309,9 +309,9 @@ func improveWizard(_ wizard: inout Wizard) {
 // CHECK-NEXT:  function_ref
 // CHECK-NEXT:  [[GETTER:%.*]] = function_ref @_TFE17materializeForSetPS_5Magicg5hocusSi
 // CHECK-NEXT:  [[WTEMP:%.*]] = alloc_stack $Wizard
-// CHECK-NEXT:  store [[T0]] to [[WTEMP]]
+// CHECK-NEXT:  store [[T0]] to [trivial] [[WTEMP]]
 // CHECK-NEXT:  [[T0:%.*]] = apply [[GETTER]]<Wizard>([[WTEMP]])
-// CHECK-NEXT:  store [[T0]] to [[TEMP]]
+// CHECK-NEXT:  store [[T0]] to [trivial] [[TEMP]]
 //   Call improve.
 // CHECK-NEXT:  apply [[IMPROVE]]([[TEMP]])
 // CHECK-NEXT:  [[T0:%.*]] = load [[TEMP]]

--- a/test/SILGen/metatype_abstraction.swift
+++ b/test/SILGen/metatype_abstraction.swift
@@ -69,7 +69,7 @@ func takeGenericMetatype<T>(_ x: T.Type) {}
 // CHECK-LABEL: sil hidden @_TFs23staticMetatypeToGeneric
 // CHECK:         [[MAT:%.*]] = alloc_stack $@thick S.Type
 // CHECK:         [[META:%.*]] = metatype $@thick S.Type
-// CHECK:         store [[META]] to [[MAT]] : $*@thick S.Type
+// CHECK:         store [[META]] to [trivial] [[MAT]] : $*@thick S.Type
 // CHECK:         apply {{%.*}}<S.Type>([[MAT]])
 func staticMetatypeToGeneric(_ x: S.Type) {
   takeGeneric(x)

--- a/test/SILGen/objc_blocks_bridging.swift
+++ b/test/SILGen/objc_blocks_bridging.swift
@@ -75,7 +75,7 @@ func callBlocks(_ x: Foo,
   // CHECK: [[FOO:%.*]] =  class_method [volatile] %0 : $Foo, #Foo.foo!1.foreign
   // CHECK: [[F_BLOCK_STORAGE:%.*]] = alloc_stack $@block_storage
   // CHECK: [[F_BLOCK_CAPTURE:%.*]] = project_block_storage [[F_BLOCK_STORAGE]]
-  // CHECK: store %1 to [[F_BLOCK_CAPTURE]]
+  // CHECK: store %1 to [init] [[F_BLOCK_CAPTURE]]
   // CHECK: [[F_BLOCK_INVOKE:%.*]] = function_ref @_TTRXFo_dSi_dSi_XFdCb_dSi_dSi_
   // CHECK: [[F_STACK_BLOCK:%.*]] = init_block_storage_header [[F_BLOCK_STORAGE]] : {{.*}}, invoke [[F_BLOCK_INVOKE]]
   // CHECK: [[F_BLOCK:%.*]] = copy_block [[F_STACK_BLOCK]]

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -120,7 +120,7 @@ func passingToId<T: CP, U>(receiver: NSIdLover,
 
   // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
   // CHECK: [[TMP:%.*]] = alloc_stack $KnownUnbridged
-  // CHECK: store [[KNOWN_UNBRIDGED]] to [[TMP]]
+  // CHECK: store [[KNOWN_UNBRIDGED]] to [trivial] [[TMP]]
   // CHECK: [[BRIDGE_ANYTHING:%.*]] = function_ref @_TFs27_bridgeAnythingToObjectiveC
   // CHECK: [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<KnownUnbridged>([[TMP]])
   // CHECK: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
@@ -131,7 +131,7 @@ func passingToId<T: CP, U>(receiver: NSIdLover,
   // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
   // CHECK: [[BRIDGE_OPTIONAL:%.*]] = function_ref @_TFSq19_bridgeToObjectiveCfT_Ps9AnyObject_
   // CHECK: [[TMP:%.*]] = alloc_stack $Optional<String>
-  // CHECK: store [[OPT_STRING]] to [[TMP]]
+  // CHECK: store [[OPT_STRING]] to [init] [[TMP]]
   // CHECK: [[ANYOBJECT:%.*]] = apply [[BRIDGE_OPTIONAL]]<String>([[TMP]])
   // CHECK: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
   receiver.takesId(optionalA)
@@ -139,7 +139,7 @@ func passingToId<T: CP, U>(receiver: NSIdLover,
   // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
   // CHECK: [[BRIDGE_OPTIONAL:%.*]] = function_ref @_TFSq19_bridgeToObjectiveCfT_Ps9AnyObject_
   // CHECK: [[TMP:%.*]] = alloc_stack $Optional<NSString>
-  // CHECK: store [[OPT_NSSTRING]] to [[TMP]]
+  // CHECK: store [[OPT_NSSTRING]] to [init] [[TMP]]
   // CHECK: [[ANYOBJECT:%.*]] = apply [[BRIDGE_OPTIONAL]]<NSString>([[TMP]])
   // CHECK: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
   receiver.takesId(optionalB)
@@ -292,7 +292,7 @@ func passingToNullableId<T: CP, U>(receiver: NSIdLover,
 
   // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
   // CHECK: [[TMP:%.*]] = alloc_stack $KnownUnbridged
-  // CHECK: store [[KNOWN_UNBRIDGED]] to [[TMP]]
+  // CHECK: store [[KNOWN_UNBRIDGED]] to [trivial] [[TMP]]
   // CHECK: [[BRIDGE_ANYTHING:%.*]] = function_ref @_TFs27_bridgeAnythingToObjectiveC
   // CHECK: [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<KnownUnbridged>([[TMP]])
   // CHECK: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[ANYOBJECT]]
@@ -416,7 +416,7 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-NEXT:  destroy_value %0
   // CHECK-NEXT:  [[BLOCK_STORAGE:%.*]] = alloc_stack $@block_storage @callee_owned (@in Any) -> ()
   // CHECK-NEXT:  [[BLOCK_STORAGE_ADDR:%.*]] = project_block_storage [[BLOCK_STORAGE]]
-  // CHECK-NEXT:  store [[RESULT:%.*]] to [[BLOCK_STORAGE_ADDR]]
+  // CHECK-NEXT:  store [[RESULT:%.*]] to [init] [[BLOCK_STORAGE_ADDR]]
   // CHECK:       [[THUNK_FN:%.*]] = function_ref @_TTRXFo_iP___XFdCb_dPs9AnyObject___
   // CHECK-NEXT:  [[BLOCK_HEADER:%.*]] = init_block_storage_header [[BLOCK_STORAGE]] : $*@block_storage @callee_owned (@in Any) -> (), invoke [[THUNK_FN]]
   // CHECK-NEXT:  [[BLOCK:%.*]] = copy_block [[BLOCK_HEADER]]
@@ -487,7 +487,7 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-NEXT:  destroy_value %0
   // CHECK-NEXT:  [[BLOCK_STORAGE:%.*]] = alloc_stack $@block_storage @callee_owned () -> @out Any
   // CHECK-NEXT:  [[BLOCK_STORAGE_ADDR:%.*]] = project_block_storage [[BLOCK_STORAGE]]
-  // CHECK-NEXT:  store [[FUNCTION]] to [[BLOCK_STORAGE_ADDR]]
+  // CHECK-NEXT:  store [[FUNCTION]] to [init] [[BLOCK_STORAGE_ADDR]]
   // CHECK:       [[THUNK_FN:%.*]] = function_ref @_TTRXFo__iP__XFdCb__aPs9AnyObject__
   // CHECK-NEXT:  [[BLOCK_HEADER:%.*]] = init_block_storage_header [[BLOCK_STORAGE]] : $*@block_storage @callee_owned () -> @out Any, invoke [[THUNK_FN]]
   // CHECK-NEXT:  [[BLOCK:%.*]] = copy_block [[BLOCK_HEADER]]
@@ -541,7 +541,7 @@ extension GenericClass {
   func pseudogenericAnyErasure(x: T) -> Any {
     // CHECK: [[ANY_BUF:%.*]] = init_existential_addr %0 : $*Any, $AnyObject
     // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref %1 : $T : $T, $AnyObject
-    // CHECK: store [[ANYOBJECT]] to [[ANY_BUF]]
+    // CHECK: store [[ANYOBJECT]] to [init] [[ANY_BUF]]
     return x
   }
 }

--- a/test/SILGen/objc_protocols.swift
+++ b/test/SILGen/objc_protocols.swift
@@ -242,7 +242,7 @@ func testInitializableExistential(_ im: Initializable.Type, i: Int) -> Initializ
 // CHECK:   [[INIT_WITNESS:%[0-9]+]] = witness_method [volatile] $@opened([[N]]) Initializable, #Initializable.init!initializer.1.foreign, [[ARCHETYPE_META]]{{.*}} : $@convention(objc_method) <τ_0_0 where τ_0_0 : Initializable> (Int, @owned τ_0_0) -> @owned τ_0_0
 // CHECK:   [[I2:%[0-9]+]] = apply [[INIT_WITNESS]]<@opened([[N]]) Initializable>([[I]], [[I2_ALLOC]]) : $@convention(objc_method) <τ_0_0 where τ_0_0 : Initializable> (Int, @owned τ_0_0) -> @owned τ_0_0
 // CHECK:   [[I2_EXIST_CONTAINER:%[0-9]+]] = init_existential_ref [[I2]] : $@opened([[N]]) Initializable : $@opened([[N]]) Initializable, $Initializable
-// CHECK:   store [[I2_EXIST_CONTAINER]] to [[PB]] : $*Initializable
+// CHECK:   store [[I2_EXIST_CONTAINER]] to [init] [[PB]] : $*Initializable
 // CHECK:   [[I2:%[0-9]+]] = load [[PB]] : $*Initializable
 // CHECK:   copy_value [[I2]] : $Initializable
 // CHECK:   destroy_value [[I2_BOX]] : $@box Initializable

--- a/test/SILGen/objc_thunks.swift
+++ b/test/SILGen/objc_thunks.swift
@@ -361,7 +361,7 @@ extension Hoozit {
     var x = X()
     // CHECK: [[CTOR:%[0-9]+]] = class_method [volatile] [[SELF:%[0-9]+]] : $Hoozit, #Hoozit.init!initializer.1.foreign : (Hoozit.Type) -> (Int) -> Hoozit , $@convention(objc_method) (Int, @owned Hoozit) -> @owned Hoozit
     // CHECK: [[NEW_SELF:%[0-9]+]] = apply [[CTOR]]
-    // CHECK: store [[NEW_SELF]] to [[SELFMUI]] : $*Hoozit
+    // CHECK: store [[NEW_SELF]] to [init] [[SELFMUI]] : $*Hoozit
     // CHECK: [[NONNULL:%[0-9]+]] = is_nonnull [[NEW_SELF]] : $Hoozit
     // CHECK-NEXT: cond_br [[NONNULL]], [[NONNULL_BB:bb[0-9]+]], [[NULL_BB:bb[0-9]+]]
     // CHECK: [[NULL_BB]]:

--- a/test/SILGen/objc_witnesses.swift
+++ b/test/SILGen/objc_witnesses.swift
@@ -48,7 +48,7 @@ extension Gizmo : Bells {
 // CHECK:   [[IUO_RESULT:%[0-9]+]] = apply [[INIT]]([[I]], [[META]]) : $@convention(method) (Int, @thick Gizmo.Type) -> @owned Optional<Gizmo>
 // CHECK:   switch_enum [[IUO_RESULT]]
 // CHECK:   [[UNWRAPPED_RESULT:%[0-9]+]] = unchecked_enum_data [[IUO_RESULT]]
-// CHECK:   store [[UNWRAPPED_RESULT]] to [[SELF]] : $*Gizmo
+// CHECK:   store [[UNWRAPPED_RESULT]] to [init] [[SELF]] : $*Gizmo
 
 // Test extension of a native @objc class to conform to a protocol with a
 // subscript requirement. rdar://problem/20371661

--- a/test/SILGen/optional-cast.swift
+++ b/test/SILGen/optional-cast.swift
@@ -17,7 +17,7 @@ class B : A {}
 // CHECK-NEXT: checked_cast_br [[VAL]] : $A to $B, [[IS_B:bb.*]], [[NOT_B:bb[0-9]+]]
 //   If so, materialize that and inject it into x.
 // CHECK:    [[IS_B]]([[T0:%.*]] : $B):
-// CHECK-NEXT: store [[T0]] to [[X_VALUE]] : $*B
+// CHECK-NEXT: store [[T0]] to [init] [[X_VALUE]] : $*B
 // CHECK-NEXT: inject_enum_addr [[PB]] : $*Optional<B>, #Optional.some
 // CHECK-NEXT: br [[CONT:bb[0-9]+]]
 //   If not, destroy_value the A and inject nothing into x.
@@ -166,7 +166,7 @@ public struct TestAddressOnlyStruct<T> {
 // CHECK-NEXT: [[X:%.*]] = alloc_box $Optional<Int>, var, name "x"
 // CHECK-NEXT: [[PB:%.*]] = project_box [[X]]
 // CHECK-NEXT: [[CAST:%.*]] = unchecked_addr_cast [[PB]] : $*Optional<Int> to $*Optional<Int>
-// CHECK-NEXT: store %0 to [[CAST]] : $*Optional<Int>
+// CHECK-NEXT: store %0 to [trivial] [[CAST]] : $*Optional<Int>
 // CHECK-NEXT: destroy_value [[X]] : $@box Optional<Int>
 func testContextualInitOfNonAddrOnlyType(_ a : Int?) {
   var x: Int! = a

--- a/test/SILGen/optional.swift
+++ b/test/SILGen/optional.swift
@@ -28,7 +28,7 @@ func testAddrOnlyCallResult<T>(_ f: (() -> T)?) {
 // CHECK:    bb0([[T0:%.*]] : $Optional<@callee_owned () -> @out T>):
 // CHECK: [[F:%.*]] = alloc_box $Optional<@callee_owned () -> @out T>, var, name "f"
 // CHECK-NEXT: [[PBF:%.*]] = project_box [[F]]
-// CHECK: store [[T0]] to [[PBF]]
+// CHECK: store [[T0]] to [init] [[PBF]]
 // CHECK-NEXT: [[X:%.*]] = alloc_box $Optional<T>, var, name "x"
 // CHECK-NEXT: [[PBX:%.*]] = project_box [[X]]
 // CHECK-NEXT: [[TEMP:%.*]] = init_enum_data_addr [[PBX]]

--- a/test/SILGen/partial_apply_protocol_class_refinement_method.swift
+++ b/test/SILGen/partial_apply_protocol_class_refinement_method.swift
@@ -6,7 +6,7 @@ protocol Q: class, P {}
 // CHECK-LABEL: sil hidden @_TF46partial_apply_protocol_class_refinement_method12partialApplyFPS_1Q_FT_T_
 func partialApply(_ q: Q) -> () -> () {
   // CHECK: [[OPENED:%.*]] = open_existential_ref
-  // CHECK: store [[OPENED]] to [[TMP:%.*]] :
+  // CHECK: store [[OPENED]] to [init] [[TMP:%.*]] :
   // CHECK: copy_addr [[TMP:%.*]] to [initialization] [[CONSUMABLE_TMP:%.*]] :
   // CHECK: apply {{%.*}}<{{.*}}>([[CONSUMABLE_TMP]])
   return q.foo

--- a/test/SILGen/pointer_conversion.swift
+++ b/test/SILGen/pointer_conversion.swift
@@ -198,7 +198,7 @@ func classInoutToPointer() {
   // CHECK: [[WRITEBACK:%.*]] = alloc_stack $@sil_unmanaged C
   // CHECK: [[OWNED:%.*]] = load [[PB]]
   // CHECK: [[UNOWNED:%.*]] = ref_to_unmanaged [[OWNED]]
-  // CHECK: store [[UNOWNED]] to [[WRITEBACK]]
+  // CHECK: store [[UNOWNED]] to [trivial] [[WRITEBACK]]
   // CHECK: [[POINTER:%.*]] = address_to_pointer [[WRITEBACK]]
   // CHECK: [[CONVERT:%.*]] = function_ref @_TFs30_convertInOutToPointerArgument
   // CHECK: apply [[CONVERT]]<AutoreleasingUnsafeMutablePointer<C>>({{%.*}}, [[POINTER]])

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -202,8 +202,8 @@ func logical_struct_in_reftype_set(_ value: inout Val, z1: Int) {
   // CHECK: [[V_R_VP_Z_TUPLE:%[0-9]+]] = apply [[GET_Z_TUPLE_METHOD]]([[LD]])
   // CHECK: [[T0:%.*]] = tuple_extract [[V_R_VP_Z_TUPLE]] : {{.*}}, 0
   // CHECK: [[T1:%.*]] = tuple_extract [[V_R_VP_Z_TUPLE]] : {{.*}}, 1
-  // CHECK: store [[T0]] to [[A0]]
-  // CHECK: store [[T1]] to [[A1]]
+  // CHECK: store [[T0]] to [trivial] [[A0]]
+  // CHECK: store [[T1]] to [trivial] [[A1]]
   // -- write to val.ref.val_prop.z_tuple.1
   // CHECK: [[V_R_VP_Z_TUPLE_1:%[0-9]+]] = tuple_element_addr [[V_R_VP_Z_TUPLE_MAT]] : {{.*}}, 1
   // CHECK: assign [[Z1]] to [[V_R_VP_Z_TUPLE_1]]
@@ -216,7 +216,7 @@ func logical_struct_in_reftype_set(_ value: inout Val, z1: Int) {
   // CHECK: [[WRITEBACK]]([[CALLBACK_ADDR:%.*]] : $Builtin.RawPointer):
   // CHECK: [[CALLBACK:%.*]] = pointer_to_thin_function [[CALLBACK_ADDR]] : $Builtin.RawPointer to $@convention(thin) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout Ref, @thick Ref.Type) -> ()
   // CHECK: [[REF_MAT:%.*]] = alloc_stack $Ref
-  // CHECK: store [[VAL_REF]] to [[REF_MAT]]
+  // CHECK: store [[VAL_REF]] to [init] [[REF_MAT]]
   // CHECK: [[T0:%.*]] = metatype $@thick Ref.Type
   // CHECK: [[T1:%.*]] = address_to_pointer [[VAL_REF_VAL_PROP_MAT]]
   // CHECK: apply [[CALLBACK]]([[T1]], [[STORAGE]], [[REF_MAT]], [[T0]])
@@ -248,8 +248,8 @@ func tuple_in_logical_struct_set(_ value: inout Val, z1: Int) {
   // CHECK: [[Z_TUPLE:%[0-9]+]] = apply [[Z_GET_METHOD]]([[VAL1]])
   // CHECK: [[T0:%.*]] = tuple_extract [[Z_TUPLE]] : {{.*}}, 0
   // CHECK: [[T1:%.*]] = tuple_extract [[Z_TUPLE]] : {{.*}}, 1
-  // CHECK: store [[T0]] to [[A0]]
-  // CHECK: store [[T1]] to [[A1]]
+  // CHECK: store [[T0]] to [trivial] [[A0]]
+  // CHECK: store [[T1]] to [trivial] [[A1]]
   // CHECK: [[Z_TUPLE_1:%[0-9]+]] = tuple_element_addr [[Z_TUPLE_MATERIALIZED]] : {{.*}}, 1
   // CHECK: assign [[Z1]] to [[Z_TUPLE_1]]
   // CHECK: [[Z_TUPLE_MODIFIED:%[0-9]+]] = load [[Z_TUPLE_MATERIALIZED]]
@@ -603,7 +603,7 @@ func local_observing_property(_ arg: Int) {
 // CHECK: bb0([[ARG:%[0-9]+]] : $Int)
 // CHECK: [[BOX:%[0-9]+]] = alloc_box $Int
 // CHECK: [[PB:%.*]] = project_box [[BOX]]
-// CHECK: store [[ARG]] to [[PB]]
+// CHECK: store [[ARG]] to [trivial] [[PB]]
 
 
 
@@ -999,7 +999,7 @@ struct MutatingGetterStruct {
   // CHECK-LABEL: sil hidden @_TZFV10properties20MutatingGetterStruct4test
   // CHECK: [[X:%.*]] = alloc_box $MutatingGetterStruct, var, name "x"
   // CHECK-NEXT: [[PB:%.*]] = project_box [[X]]
-  // CHECK: store {{.*}} to [[PB]] : $*MutatingGetterStruct
+  // CHECK: store {{.*}} to [trivial] [[PB]] : $*MutatingGetterStruct
   // CHECK: apply {{%.*}}([[PB]]) : $@convention(method) (@inout MutatingGetterStruct) -> Int
   static func test() {
     var x = MutatingGetterStruct()

--- a/test/SILGen/property_abstraction.swift
+++ b/test/SILGen/property_abstraction.swift
@@ -39,7 +39,7 @@ func inOutFunc(_ f: inout ((Int) -> Int)) { }
 // CHECK:         [[F_ORIG:%.*]] = load [[F_ADDR]]
 // CHECK:         [[REABSTRACT_FN:%.*]] = function_ref @_TTR
 // CHECK:         [[F_SUBST_IN:%.*]] = partial_apply [[REABSTRACT_FN]]([[F_ORIG]])
-// CHECK:         store [[F_SUBST_IN]] to [[F_SUBST_MAT]]
+// CHECK:         store [[F_SUBST_IN]] to [init] [[F_SUBST_MAT]]
 // CHECK:         apply [[INOUTFUNC]]([[F_SUBST_MAT]])
 // CHECK:         [[F_SUBST_OUT:%.*]] = load [[F_SUBST_MAT]]
 // CHECK:         [[REABSTRACT_FN:%.*]] = function_ref @_TTR

--- a/test/SILGen/property_behavior_init.swift
+++ b/test/SILGen/property_behavior_init.swift
@@ -50,7 +50,7 @@ struct Foo {
     // CHECK: [[SELF:%.*]] = load [[UNINIT_SELF]]
     // CHECK: [[GETTER:%.*]] = function_ref @_TFV22property_behavior_init3Foog1xSi
     // CHECK: [[VALUE:%.*]] = apply [[GETTER]]([[SELF]])
-    // CHECK: store [[VALUE]] to [[INOUT]]
+    // CHECK: store [[VALUE]] to [trivial] [[INOUT]]
     // CHECK: apply [[WHACK]]<Int>([[INOUT]])
     // CHECK: [[VALUE:%.*]] = load [[INOUT]]
     // CHECK: [[SETTER:%.*]] = function_ref @_TFV22property_behavior_init3Foos1xSi

--- a/test/SILGen/protocol_class_refinement.swift
+++ b/test/SILGen/protocol_class_refinement.swift
@@ -34,7 +34,7 @@ func getObjectUID<T: ObjectUID>(x: T) -> (Int, Int, Int, Int) {
   // CHECK: [[X:%.*]] = load [[PB]]
   // CHECK: copy_value [[X]]
   // CHECK: [[X_TMP:%.*]] = alloc_stack
-  // CHECK: store [[X]] to [[X_TMP]]
+  // CHECK: store [[X]] to [init] [[X_TMP]]
   // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
   // CHECK: [[UID:%.*]] = apply [[GET_UID]]<T>([[X_TMP]])
   // CHECK: [[X2:%.*]] = load [[X_TMP]]
@@ -48,7 +48,7 @@ func getObjectUID<T: ObjectUID>(x: T) -> (Int, Int, Int, Int) {
   // CHECK: [[X:%.*]] = load [[PB]]
   // CHECK: copy_value [[X]]
   // CHECK: [[X_TMP:%.*]] = alloc_stack
-  // CHECK: store [[X]] to [[X_TMP]]
+  // CHECK: store [[X]] to [init] [[X_TMP]]
   // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
   // CHECK: [[UID:%.*]] = apply [[GET_UID]]<T>([[X_TMP]])
   // CHECK: [[X2:%.*]] = load [[X_TMP]]
@@ -64,7 +64,7 @@ func getObjectUID<T: ObjectUID>(x: T) -> (Int, Int, Int, Int) {
   // CHECK: [[X:%.*]] = load [[PB]]
   // CHECK: copy_value [[X]]
   // CHECK: [[X_TMP:%.*]] = alloc_stack
-  // CHECK: store [[X]] to [[X_TMP]]
+  // CHECK: store [[X]] to [init] [[X_TMP]]
   // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
   // CHECK: [[UID:%.*]] = apply [[GET_UID]]<T>([[X_TMP]])
   // CHECK: [[X2:%.*]] = load [[X_TMP]]
@@ -86,7 +86,7 @@ func getBaseObjectUID<T: UID where T: Base>(x: T) -> (Int, Int, Int) {
   // CHECK: [[X:%.*]] = load [[PB]]
   // CHECK: copy_value [[X]]
   // CHECK: [[X_TMP:%.*]] = alloc_stack
-  // CHECK: store [[X]] to [[X_TMP]]
+  // CHECK: store [[X]] to [init] [[X_TMP]]
   // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
   // CHECK: [[UID:%.*]] = apply [[GET_UID]]<T>([[X_TMP]])
   // CHECK: [[X2:%.*]] = load [[X_TMP]]
@@ -100,7 +100,7 @@ func getBaseObjectUID<T: UID where T: Base>(x: T) -> (Int, Int, Int) {
   // CHECK: [[X:%.*]] = load [[PB]]
   // CHECK: copy_value [[X]]
   // CHECK: [[X_TMP:%.*]] = alloc_stack
-  // CHECK: store [[X]] to [[X_TMP]]
+  // CHECK: store [[X]] to [init] [[X_TMP]]
   // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
   // CHECK: [[UID:%.*]] = apply [[GET_UID]]<T>([[X_TMP]])
   // CHECK: [[X2:%.*]] = load [[X_TMP]]

--- a/test/SILGen/protocol_extensions.swift
+++ b/test/SILGen/protocol_extensions.swift
@@ -102,7 +102,7 @@ func testD(_ m: MetaHolder, dd: D.Type, d: D) {
   // CHECK: [[RESULT:%.*]] = project_box [[D2]]
   // CHECK: [[FN:%[0-9]+]] = function_ref @_TFE19protocol_extensionsPS_2P111returnsSelf{{.*}}
   // CHECK: [[DCOPY:%[0-9]+]] = alloc_stack $D
-  // CHECK: store [[D]] to [[DCOPY]] : $*D
+  // CHECK: store [[D]] to [init] [[DCOPY]] : $*D
   // CHECK: apply [[FN]]<D>([[RESULT]], [[DCOPY]]) : $@convention(method) <τ_0_0 where τ_0_0 : P1> (@in_guaranteed τ_0_0) -> @out τ_0_0
   var d2: D = d.returnsSelf()
 

--- a/test/SILGen/protocol_optional.swift
+++ b/test/SILGen/protocol_optional.swift
@@ -14,7 +14,7 @@ func optionalMethodGeneric<T : P1>(t t : T) {
   // CHECK: bb0([[T:%[0-9]+]] : $T):
   // CHECK: [[TBOX:%[0-9]+]] = alloc_box $T
   // CHECK-NEXT: [[PT:%[0-9]+]] = project_box [[TBOX]]
-  // CHECK: store [[T]] to [[PT]] : $*T
+  // CHECK: store [[T]] to [init] [[PT]] : $*T
   // CHECK-NEXT: [[OPT_BOX:%[0-9]+]] = alloc_box $Optional<@callee_owned (Int) -> ()>
   // CHECK-NEXT: project_box [[OPT_BOX]]
   // CHECK-NEXT: [[T:%[0-9]+]] = load [[PT]] : $*T
@@ -30,7 +30,7 @@ func optionalPropertyGeneric<T : P1>(t t : T) {
   // CHECK: bb0([[T:%[0-9]+]] : $T):
   // CHECK: [[TBOX:%[0-9]+]] = alloc_box $T
   // CHECK-NEXT: [[PT:%[0-9]+]] = project_box [[TBOX]]
-  // CHECK: store [[T]] to [[PT]] : $*T
+  // CHECK: store [[T]] to [init] [[PT]] : $*T
   // CHECK-NEXT: [[OPT_BOX:%[0-9]+]] = alloc_box $Optional<Int>
   // CHECK-NEXT: project_box [[OPT_BOX]]
   // CHECK-NEXT: [[T:%[0-9]+]] = load [[PT]] : $*T
@@ -46,7 +46,7 @@ func optionalSubscriptGeneric<T : P1>(t t : T) {
   // CHECK: bb0([[T:%[0-9]+]] : $T):
   // CHECK: [[TBOX:%[0-9]+]] = alloc_box $T
   // CHECK-NEXT: [[PT:%[0-9]+]] = project_box [[TBOX]]
-  // CHECK: store [[T]] to [[PT]] : $*T
+  // CHECK: store [[T]] to [init] [[PT]] : $*T
   // CHECK-NEXT: [[OPT_BOX:%[0-9]+]] = alloc_box $Optional<Int>
   // CHECK-NEXT: project_box [[OPT_BOX]]
   // CHECK-NEXT: [[T:%[0-9]+]] = load [[PT]] : $*T

--- a/test/SILGen/reabstract_lvalue.swift
+++ b/test/SILGen/reabstract_lvalue.swift
@@ -16,14 +16,14 @@ func reabstractFunctionInOut() {
   // CHECK: [[PB:%.*]] = project_box [[BOX]]
   // CHECK: [[ARG:%.*]] = function_ref @_TF17reabstract_lvalue9transformFSiSd
   // CHECK: [[THICK_ARG:%.*]] = thin_to_thick_function [[ARG]]
-  // CHECK: store [[THICK_ARG:%.*]] to [[PB]]
+  // CHECK: store [[THICK_ARG:%.*]] to [init] [[PB]]
   // CHECK: [[FUNC:%.*]] = function_ref @_TF17reabstract_lvalue19consumeGenericInOut
   // CHECK: [[ABSTRACTED_BOX:%.*]] = alloc_stack $@callee_owned (@in Int) -> @out Double
   // CHECK: [[THICK_ARG:%.*]] = load [[PB]]
   // CHECK: copy_value [[THICK_ARG]]
   // CHECK: [[THUNK1:%.*]] = function_ref @_TTRXFo_dSi_dSd_XFo_iSi_iSd_
   // CHECK: [[ABSTRACTED_ARG:%.*]] = partial_apply [[THUNK1]]([[THICK_ARG]])
-  // CHECK: store [[ABSTRACTED_ARG]] to [[ABSTRACTED_BOX]]
+  // CHECK: store [[ABSTRACTED_ARG]] to [init] [[ABSTRACTED_BOX]]
   // CHECK: apply [[FUNC]]<(Int) -> Double>([[ABSTRACTED_BOX]])
   // CHECK: [[NEW_ABSTRACTED_ARG:%.*]] = load [[ABSTRACTED_BOX]]
   // CHECK: [[THUNK2:%.*]] = function_ref @_TTRXFo_iSi_iSd_XFo_dSi_dSd_
@@ -41,7 +41,7 @@ func reabstractMetatypeInOut() {
   // CHECK: [[FUNC:%.*]] = function_ref @_TF17reabstract_lvalue19consumeGenericInOut
   // CHECK: [[BOX:%.*]] = alloc_stack $@thick MyMetatypeIsThin.Type
   // CHECK: [[THICK:%.*]] = metatype $@thick MyMetatypeIsThin.Type
-  // CHECK: store [[THICK]] to [[BOX]]
+  // CHECK: store [[THICK]] to [trivial] [[BOX]]
   // CHECK: apply [[FUNC]]<MyMetatypeIsThin.Type>([[BOX]])
   consumeGenericInOut(&thinMetatype)
 }

--- a/test/SILGen/scalar_to_tuple_args.swift
+++ b/test/SILGen/scalar_to_tuple_args.swift
@@ -53,7 +53,7 @@ tupleWithDefaults(x: (x,x))
 // CHECK: [[MEMORY:%.*]] = tuple_extract [[ALLOC_ARRAY]] {{.*}}, 1
 // CHECK: [[ADDR:%.*]] = pointer_to_address [[MEMORY]]
 // CHECK: [[X:%.*]] = load [[X_ADDR]]
-// CHECK: store [[X]] to [[ADDR]]
+// CHECK: store [[X]] to [trivial] [[ADDR]]
 // CHECK: apply [[VARIADIC_FIRST]]([[ARRAY]])
 variadicFirst(x)
 

--- a/test/SILGen/source_location.swift
+++ b/test/SILGen/source_location.swift
@@ -16,8 +16,8 @@ let FILE = #file, LINE = #line
 // CHECK: [[FILE_ADDR:%.*]] = global_addr @_Tv15source_location4FILESS
 // CHECK: [[INPLACE_FILE_VAL:%.*]] = string_literal utf16 "inplace.swift",
 // CHECK: [[INPLACE_FILE:%.*]] = apply {{.*}}([[INPLACE_FILE_VAL]],
-// CHECK: store [[INPLACE_FILE]] to [[FILE_ADDR]]
+// CHECK: store [[INPLACE_FILE]] to [init] [[FILE_ADDR]]
 // CHECK: [[LINE_ADDR:%.*]] = global_addr @_Tv15source_location4LINESi
 // CHECK: [[INPLACE_LINE_VAL:%.*]] = integer_literal $Builtin.Int{{[0-9]+}}, 20000,
 // CHECK: [[INPLACE_LINE:%.*]] = apply {{.*}}([[INPLACE_LINE_VAL]],
-// CHECK: store [[INPLACE_LINE]] to [[LINE_ADDR]]
+// CHECK: store [[INPLACE_LINE]] to [trivial] [[LINE_ADDR]]

--- a/test/SILGen/super_init_refcounting.swift
+++ b/test/SILGen/super_init_refcounting.swift
@@ -18,7 +18,7 @@ class Bar: Foo {
   // CHECK:         [[SUPER_INIT:%[0-9]+]] = function_ref @_TFC22super_init_refcounting3FoocfT_S0_ : $@convention(method) (@owned Foo) -> @owned Foo
   // CHECK:         [[NEW_SELF:%.*]] = apply [[SUPER_INIT]]([[ORIG_SELF_UP]])
   // CHECK:         [[NEW_SELF_DOWN:%.*]] = unchecked_ref_cast [[NEW_SELF]]
-  // CHECK:         store [[NEW_SELF_DOWN]] to [[SELF_MUI]]
+  // CHECK:         store [[NEW_SELF_DOWN]] to [init] [[SELF_MUI]]
   override init() {
     super.init()
   }
@@ -33,7 +33,7 @@ extension Foo {
   // CHECK-NOT:     copy_value [[ORIG_SELF]]
   // CHECK:         [[SUPER_INIT:%.*]] = class_method
   // CHECK:         [[NEW_SELF:%.*]] = apply [[SUPER_INIT]]([[ORIG_SELF]])
-  // CHECK:         store [[NEW_SELF]] to [[SELF_MUI]]
+  // CHECK:         store [[NEW_SELF]] to [init] [[SELF_MUI]]
   convenience init(x: Int) {
     self.init()
   }

--- a/test/SILGen/switch.swift
+++ b/test/SILGen/switch.swift
@@ -963,7 +963,7 @@ func testLabeledScalarPayload(_ lsp: LabeledScalarPayload) -> Any {
   // CHECK: bb1([[TUPLE:%.*]] : $(name: Int)):
   // CHECK:   [[X:%.*]] = tuple_extract [[TUPLE]]
   // CHECK:   [[ANY_X_ADDR:%.*]] = init_existential_addr {{%.*}}, $Int
-  // CHECK:   store [[X]] to [[ANY_X_ADDR]]
+  // CHECK:   store [[X]] to [trivial] [[ANY_X_ADDR]]
   case let .Payload(x):
     return x
   }

--- a/test/SILGen/switch_var.swift
+++ b/test/SILGen/switch_var.swift
@@ -444,10 +444,10 @@ func test_mixed_let_var() {
   case var x where runced():
     // CHECK: [[BOX:%.*]] = alloc_box $String, var, name "x"
     // CHECK: [[PBOX:%.*]] = project_box [[BOX]]
-    // CHECK: store [[VAL]] to [[PBOX]]
+    // CHECK: [[VAL_COPY:%.*]] = copy_value [[VAL]]
+    // CHECK: store [[VAL_COPY]] to [[PBOX]]
     // CHECK: [[A:%.*]] = function_ref @_TF10switch_var1aFT1xSS_T_
     // CHECK: [[X:%.*]] = load [[PBOX]]
-    // CHECK: copy_value [[X]]
     // CHECK: apply [[A]]([[X]])
     a(x: x)
   case let y where funged():
@@ -612,7 +612,7 @@ func test_multiple_patterns5() {
     // CHECK:     [[A_X:%.*]] = tuple_extract
     // CHECK:     [[A_N:%.*]] = tuple_extract
     // CHECK:     [[A_BOX:%.*]] = project_box
-    // CHECK:     store [[A_X]] to [[A_BOX]]
+    // CHECK:     store [[A_X]] to [trivial] [[A_BOX]]
     // CHECK:     [[FUNC_A:%.*]] = function_ref @_TF10switch_var3aaaFT1xRSi_T_
     // CHECK:     apply [[FUNC_A]]([[A_BOX]])
     
@@ -620,13 +620,13 @@ func test_multiple_patterns5() {
     // CHECK:     [[B_N:%.*]] = tuple_extract
     // CHECK:     [[B_X:%.*]] = tuple_extract
     // CHECK:     [[B_BOX:%.*]] = project_box
-    // CHECK:     store [[B_X]] to [[B_BOX]]
+    // CHECK:     store [[B_X]] to [trivial] [[B_BOX]]
     // CHECK:     [[FUNC_B:%.*]] = function_ref @_TF10switch_var3aaaFT1xRSi_T_
     // CHECK:     apply [[FUNC_B]]([[B_BOX]])
     
     // CHECK:   [[C]]({{%.*}} : $(Int, Int, Double)):
     // CHECK:     [[Y_BOX:%.*]] = project_box
-    // CHECK:     store [[Y_X]] to [[Y_BOX]]
+    // CHECK:     store [[Y_X]] to [trivial] [[Y_BOX]]
     // CHECK:     [[FUNC_C:%.*]] = function_ref @_TF10switch_var3aaaFT1xRSi_T_
     // CHECK:     apply [[FUNC_C]]([[Y_BOX]])
     
@@ -634,7 +634,7 @@ func test_multiple_patterns5() {
     // CHECK:     [[Z_X:%.*]] = tuple_extract
     // CHECK:     [[Z_F:%.*]] = tuple_extract
     // CHECK:     [[Z_BOX:%.*]] = project_box
-    // CHECK:     store [[Z_X]] to [[Z_BOX]]
+    // CHECK:     store [[Z_X]] to [trivial] [[Z_BOX]]
     // CHECK:     [[FUNC_Z:%.*]] = function_ref @_TF10switch_var3aaaFT1xRSi_T_
     // CHECK:     apply [[FUNC_Z]]([[Z_BOX]])
     aaa(x: &x)

--- a/test/SILGen/toplevel.swift
+++ b/test/SILGen/toplevel.swift
@@ -14,7 +14,7 @@ func trap() -> Never {
 // CHECK: alloc_global @_Tv8toplevel1xSi
 // CHECK: [[X:%[0-9]+]] = global_addr @_Tv8toplevel1xSi : $*Int
 // CHECK: integer_literal $Builtin.Int2048, 999
-// CHECK: store {{.*}} to [[X]]
+// CHECK: store {{.*}} to [trivial] [[X]]
 
 var x = 999
 
@@ -74,7 +74,7 @@ print_y()
 // CHECK-LABEL: function_ref toplevel.A.__allocating_init
 // CHECK: switch_enum {{%.+}} : $Optional<A>, case #Optional.some!enumelt.1: [[SOME_CASE:.+]], default
 // CHECK: [[SOME_CASE]]([[VALUE:%.+]] : $A):
-// CHECK: store [[VALUE]] to [[BOX:%.+]] : $*A
+// CHECK: store [[VALUE]] to [init] [[BOX:%.+]] : $*A
 // CHECK-NOT: destroy_value
 // CHECK: [[SINK:%.+]] = function_ref @_TF8toplevel8markUsedurFxT_
 // CHECK-NOT: destroy_value

--- a/test/SILGen/toplevel_errors.swift
+++ b/test/SILGen/toplevel_errors.swift
@@ -10,7 +10,7 @@ throw MyError.A
 // CHECK: [[ERR:%.*]] = alloc_existential_box $Error, $MyError
 // CHECK: [[ADDR:%.*]] = project_existential_box $MyError in [[ERR]] : $Error
 // CHECK: [[T0:%.*]] = enum $MyError, #MyError.A!enumelt
-// CHECK: store [[T0]] to [[ADDR]] : $*MyError
+// CHECK: store [[T0]] to [trivial] [[ADDR]] : $*MyError
 // CHECK: builtin "willThrow"([[ERR]] : $Error)
 // CHECK: br bb2([[ERR]] : $Error)
 

--- a/test/SILGen/tuples.swift
+++ b/test/SILGen/tuples.swift
@@ -30,7 +30,7 @@ func testShuffleOpaque() {
 
   // CHECK:      [[T0:%.*]] = function_ref @_TF6tuples7make_xyFT_T1xSi1yPS_1P__
   // CHECK-NEXT: [[T1:%.*]] = apply [[T0]]([[PBX]])
-  // CHECK-NEXT: store [[T1]] to [[PBY]]
+  // CHECK-NEXT: store [[T1]] to [trivial] [[PBY]]
   var (x,y) : (y:P, x:Int) = make_xy()
 
   // CHECK-NEXT: [[PAIR:%.*]] = alloc_box $(y: P, x: Int)
@@ -40,7 +40,7 @@ func testShuffleOpaque() {
   // CHECK-NEXT: // function_ref
   // CHECK-NEXT: [[T0:%.*]] = function_ref @_TF6tuples7make_xyFT_T1xSi1yPS_1P__
   // CHECK-NEXT: [[T1:%.*]] = apply [[T0]]([[PAIR_0]])
-  // CHECK-NEXT: store [[T1]] to [[PAIR_1]]
+  // CHECK-NEXT: store [[T1]] to [trivial] [[PAIR_1]]
   var pair : (y:P, x:Int) = make_xy()
 
   // CHECK-NEXT: // function_ref
@@ -64,7 +64,7 @@ func testShuffleTuple() {
 
   // CHECK:      [[T0:%.*]] = function_ref @_TF6tuples8make_intFT_Si
   // CHECK-NEXT: [[T1:%.*]] = apply [[T0]]()
-  // CHECK-NEXT: store [[T1]] to [[PBY]]
+  // CHECK-NEXT: store [[T1]] to [trivial] [[PBY]]
   // CHECK-NEXT: // function_ref
   // CHECK-NEXT: [[T0:%.*]] = function_ref @_TF6tuples6make_pFT_PS_1P_ 
   // CHECK-NEXT: apply [[T0]]([[PBX]])
@@ -77,7 +77,7 @@ func testShuffleTuple() {
   // CHECK-NEXT: // function_ref
   // CHECK:      [[T0:%.*]] = function_ref @_TF6tuples8make_intFT_Si
   // CHECK-NEXT: [[T1:%.*]] = apply [[T0]]()
-  // CHECK-NEXT: store [[T1]] to [[PAIR_1]]
+  // CHECK-NEXT: store [[T1]] to [trivial] [[PAIR_1]]
   // CHECK-NEXT: // function_ref
   // CHECK-NEXT: [[T0:%.*]] = function_ref @_TF6tuples6make_pFT_PS_1P_ 
     // CHECK-NEXT: apply [[T0]]([[PAIR_0]])

--- a/test/SILGen/unowned.swift
+++ b/test/SILGen/unowned.swift
@@ -32,7 +32,7 @@ _ = AddressOnly(x: C(), p: X())
 // CHECK:   [[X_ADDR:%.*]] = struct_element_addr [[RET]] : $*AddressOnly, #AddressOnly.x
 // CHECK:   [[X_UNOWNED:%.*]] = ref_to_unowned [[X]] : $C to $@sil_unowned C
 // CHECK:   unowned_retain [[X_UNOWNED]] : $@sil_unowned C
-// CHECK:   store [[X_UNOWNED]] to [[X_ADDR]]
+// CHECK:   store [[X_UNOWNED]] to [init] [[X_ADDR]]
 // CHECK:   destroy_value [[X]]
 // CHECK: }
 
@@ -50,7 +50,7 @@ func test0(c c: C) {
 // CHECK-NEXT: [[PBX:%.*]] = project_box [[X]]
 // CHECK-NEXT: [[T2:%.*]] = ref_to_unowned %0 : $C  to $@sil_unowned C
 // CHECK-NEXT: unowned_retain [[T2]] : $@sil_unowned C
-// CHECK-NEXT: store [[T2]] to [[PBX]] : $*@sil_unowned C
+// CHECK-NEXT: store [[T2]] to [init] [[PBX]] : $*@sil_unowned C
 
   a.x = c
 // CHECK-NEXT: [[T1:%.*]] = struct_element_addr [[A]] : $*A, #A.x
@@ -78,7 +78,7 @@ func unowned_local() -> C {
   // CHECK-NEXT: [[PB:%.*]] = project_box [[uc]]
   // CHECK-NEXT: [[tmp1:%.*]] = ref_to_unowned [[c]] : $C to $@sil_unowned C
   // CHECK-NEXT: unowned_retain [[tmp1]]
-  // CHECK-NEXT: store [[tmp1]] to [[PB]]
+  // CHECK-NEXT: store [[tmp1]] to [init] [[PB]]
   unowned let uc = c
 
   // CHECK-NEXT: [[tmp2:%.*]] = load [[PB]]

--- a/test/SILGen/weak.swift
+++ b/test/SILGen/weak.swift
@@ -54,7 +54,7 @@ func test0(c c: C) {
 // CHECK-NEXT:  debug_value_addr %1 : $*@sil_weak Optional<C>, var, name "bC", argno 1
 // CHECK-NEXT:  %3 = alloc_stack $Optional<C>
 // CHECK-NEXT:  %4 = load_weak %1 : $*@sil_weak Optional<C>
-// CHECK-NEXT:  store %4 to %3 : $*Optional<C>
+// CHECK-NEXT:  store %4 to [init] %3 : $*Optional<C>
 func testClosureOverWeak() {
   weak var bC = C()
   takeClosure { bC!.f() }
@@ -68,7 +68,7 @@ class CC {
   // CHECK:  [[PB:%.*]] = project_box [[FOO]]
   // CHECK:  [[X:%.*]] = ref_element_addr %2 : $CC, #CC.x
   // CHECK:  [[VALUE:%.*]] = load_weak [[X]] : $*@sil_weak Optional<CC>
-  // CHECK:  store [[VALUE]] to [[PB]] : $*Optional<CC>
+  // CHECK:  store [[VALUE]] to [init] [[PB]] : $*Optional<CC>
   init() {
     var foo = x
   }

--- a/test/SILGen/witnesses.swift
+++ b/test/SILGen/witnesses.swift
@@ -255,7 +255,7 @@ struct ConformsWithMoreGeneric : X, Y {
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWV9witnesses23ConformsWithMoreGenericS_1XS_FS1_7classes{{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : Classes> (@owned τ_0_0, @inout ConformsWithMoreGeneric) -> @owned τ_0_0 {
   // CHECK:       bb0(%0 : $τ_0_0, %1 : $*ConformsWithMoreGeneric):
   // CHECK-NEXT:    [[SELF_BOX:%.*]] = alloc_stack $τ_0_0
-  // CHECK-NEXT:    store %0 to [[SELF_BOX]] : $*τ_0_0
+  // CHECK-NEXT:    store %0 to [init] [[SELF_BOX]] : $*τ_0_0
   // CHECK-NEXT:    // function_ref witnesses.ConformsWithMoreGeneric.classes
   // CHECK-NEXT:    [[WITNESS_FN:%.*]] = function_ref @_TFV9witnesses23ConformsWithMoreGeneric7classes{{.*}} : $@convention(method) <τ_0_0> (@in τ_0_0, @inout ConformsWithMoreGeneric) -> @out τ_0_0
   // CHECK-NEXT:    [[RESULT_BOX:%.*]] = alloc_stack $τ_0_0
@@ -362,7 +362,7 @@ struct IUOFailableModel : NonFailableRefinement, IUOFailableRequirement {
   // CHECK:   [[INIT:%[0-9]+]] = function_ref @_TFV9witnesses16IUOFailableModelC{{.*}} : $@convention(method) (Int, @thin IUOFailableModel.Type) -> Optional<IUOFailableModel>
   // CHECK:   [[IUO_RESULT:%[0-9]+]] = apply [[INIT]]([[FOO]], [[META]]) : $@convention(method) (Int, @thin IUOFailableModel.Type) -> Optional<IUOFailableModel>
   // CHECK:   [[RESULT:%[0-9]+]] = unchecked_enum_data [[IUO_RESULT]]
-  // CHECK:   store [[RESULT]] to [[SELF]] : $*IUOFailableModel
+  // CHECK:   store [[RESULT]] to [trivial] [[SELF]] : $*IUOFailableModel
   // CHECK:   return
   init!(foo: Int) { return nil }
 }

--- a/test/SILGen/writeback.swift
+++ b/test/SILGen/writeback.swift
@@ -47,7 +47,7 @@ x.foo()
 // CHECK: [[X_TEMP:%.*]] = alloc_stack $Foo
 // CHECK: [[GET_X:%.*]] = function_ref @_TF9writebackg1xVS_3Foo : $@convention(thin) () -> Foo
 // CHECK: [[X:%.*]] = apply [[GET_X]]() : $@convention(thin) () -> Foo
-// CHECK: store [[X]] to [[X_TEMP]]
+// CHECK: store [[X]] to [trivial] [[X_TEMP]]
 // CHECK: apply [[FOO]]([[X_TEMP]]) : $@convention(method) (@inout Foo) -> ()
 // CHECK: [[X1:%.*]] = load [[X_TEMP]] : $*Foo
 // CHECK: [[SET_X:%.*]] = function_ref @_TF9writebacks1xVS_3Foo : $@convention(thin) (Foo) -> ()
@@ -60,7 +60,7 @@ bar(x: &x)
 // CHECK: [[X_TEMP:%.*]] = alloc_stack $Foo
 // CHECK: [[GET_X:%.*]] = function_ref @_TF9writebackg1xVS_3Foo : $@convention(thin) () -> Foo
 // CHECK: [[X:%.*]] = apply [[GET_X]]() : $@convention(thin) () -> Foo
-// CHECK: store [[X]] to [[X_TEMP]] : $*Foo
+// CHECK: store [[X]] to [trivial] [[X_TEMP]] : $*Foo
 // CHECK: apply [[BAR]]([[X_TEMP]]) : $@convention(thin) (@inout Foo) -> ()
 // CHECK: [[X1:%.*]] = load [[X_TEMP]] : $*Foo
 // CHECK: [[SET_X:%.*]] = function_ref @_TF9writebacks1xVS_3Foo : $@convention(thin) (Foo) -> ()

--- a/test/Serialization/always_inline.swift
+++ b/test/Serialization/always_inline.swift
@@ -12,7 +12,7 @@ import def_always_inline
 // SIL: [[RAW:%.+]] = global_addr @_Tv13always_inline3rawSb : $*Bool
 // SIL: [[FUNC:%.+]] = function_ref @_TF17def_always_inline16testAlwaysInlineFT1xSb_Sb : $@convention(thin) (Bool) -> Bool
 // SIL: [[RESULT:%.+]] = apply [[FUNC]]({{%.+}}) : $@convention(thin) (Bool) -> Bool
-// SIL: store [[RESULT]] to [[RAW]] : $*Bool
+// SIL: store [[RESULT]] to [trivial] [[RAW]] : $*Bool
 var raw = testAlwaysInline(x: false)
 
 // SIL: [[FUNC2:%.+]] = function_ref @_TFV17def_always_inline22AlwaysInlineInitStructCfT1xSb_S0_ : $@convention(method) (Bool, @thin AlwaysInlineInitStruct.Type) -> AlwaysInlineInitStruct

--- a/test/Serialization/function.swift
+++ b/test/Serialization/function.swift
@@ -17,7 +17,7 @@ func useEq<T: EqualOperator>(_ x: T, y: T) -> Bool {
 // SIL:   [[RAW:%.+]] = global_addr @_Tv8function3rawSi : $*Int
 // SIL:   [[ZERO:%.+]] = function_ref @_TF8def_func7getZeroFT_Si : $@convention(thin) () -> Int
 // SIL:   [[RESULT:%.+]] = apply [[ZERO]]() : $@convention(thin) () -> Int
-// SIL:   store [[RESULT]] to [[RAW]] : $*Int
+// SIL:   store [[RESULT]] to [trivial] [[RAW]] : $*Int
 var raw = getZero()
 
 // Check that 'raw' is an Int

--- a/test/Serialization/noinline.swift
+++ b/test/Serialization/noinline.swift
@@ -12,7 +12,7 @@ import def_noinline
 // SIL: [[RAW:%.+]] = global_addr @_Tv8noinline3rawSb : $*Bool
 // SIL: [[FUNC:%.+]] = function_ref @_TF12def_noinline12testNoinlineFT1xSb_Sb : $@convention(thin) (Bool) -> Bool
 // SIL: [[RESULT:%.+]] = apply [[FUNC]]({{%.+}}) : $@convention(thin) (Bool) -> Bool
-// SIL: store [[RESULT]] to [[RAW]] : $*Bool
+// SIL: store [[RESULT]] to [trivial] [[RAW]] : $*Bool
 var raw = testNoinline(x: false)
 
 // SIL: [[FUNC2:%.+]] = function_ref @_TFV12def_noinline18NoInlineInitStructCfT1xSb_S0_ : $@convention(method) (Bool, @thin NoInlineInitStruct.Type) -> NoInlineInitStruct

--- a/test/Serialization/transparent.swift
+++ b/test/Serialization/transparent.swift
@@ -12,13 +12,13 @@ import def_transparent
 // SIL: [[RAW:%.+]] = global_addr @_Tv11transparent3rawSb : $*Bool
 // SIL: [[FUNC:%.+]] = function_ref @_TF15def_transparent15testTransparentFT1xSb_Sb : $@convention(thin) (Bool) -> Bool
 // SIL: [[RESULT:%.+]] = apply [[FUNC]]({{%.+}}) : $@convention(thin) (Bool) -> Bool
-// SIL: store [[RESULT]] to [[RAW]] : $*Bool
+// SIL: store [[RESULT]] to [trivial] [[RAW]] : $*Bool
 var raw = testTransparent(x: false)
 
 // SIL: [[TMP:%.+]] = global_addr @_Tv11transparent3tmpVs5Int32 : $*Int32
 // SIL: [[FUNC2:%.+]] = function_ref @_TF15def_transparent11testBuiltinFT_Vs5Int32 : $@convention(thin) () -> Int32
 // SIL: [[RESULT2:%.+]] = apply [[FUNC2]]() : $@convention(thin) () -> Int32
-// SIL: store [[RESULT2]] to [[TMP]] : $*Int32
+// SIL: store [[RESULT2]] to [trivial] [[TMP]] : $*Int32
 var tmp = testBuiltin()
 
 // SIL-LABEL: sil public_external [transparent] [fragile] @_TF15def_transparent15testTransparentFT1xSb_Sb : $@convention(thin) (Bool) -> Bool {


### PR DESCRIPTION
[semantic-arc] Qualify most of the stores in SILGen as store [init].

All of these cases were trivially inits since they involved storing into
a newly created temporary allocation.

rdar://28685236