### PR TITLE
[Devirtualizer] Handle default witnesses for generic requirements.

### DIFF
--- a/test/SILOptimizer/devirt_default_witness_method.sil
+++ b/test/SILOptimizer/devirt_default_witness_method.sil
@@ -5,6 +5,10 @@ import Builtin
 import Swift
 import SwiftShims
 
+public protocol P { }
+public protocol Q : P { }
+extension Int : P, Q { }
+
 public protocol ResilientProtocol {
   func defaultA()
 }
@@ -35,6 +39,28 @@ sil_witness_table <T> ConformingGenericStruct<T> : ResilientProtocol module prot
   method #ResilientProtocol.defaultA!1: @defaultA
 }
 
+public protocol ResilientProtocolWithGeneric {
+  func defaultB<T: Q>(_: T)
+}
+
+sil @defaultB : $@convention(witness_method) <Self where Self : ResilientProtocolWithGeneric><T where T : P> (@in T, @in_guaranteed Self) -> () {
+bb0(%0 : $*T, %1 : $*Self):
+  %result = tuple ()
+  return %result : $()
+}
+
+sil_default_witness_table ResilientProtocolWithGeneric {
+  method #ResilientProtocolWithGeneric.defaultB!1: @defaultB
+}
+
+extension ConformingGenericStruct : ResilientProtocolWithGeneric {
+  func defaultB<T>(_: T)
+}
+
+sil_witness_table <T> ConformingGenericStruct<T> : ResilientProtocolWithGeneric module protocol_resilience {
+  method #ResilientProtocolWithGeneric.defaultB!1: @defaultB
+}
+
 // CHECK-LABEL: sil hidden @test_devirt_of_default_witness_method : $@convention(thin) (@in_guaranteed ConformingStruct) -> ()
 // CHECK:       bb0(%0 : $*ConformingStruct):
 // CHECK:         [[FN:%.*]] = function_ref @defaultA : $@convention(witness_method) <τ_0_0 where τ_0_0 : ResilientProtocol> (@in_guaranteed τ_0_0) -> ()
@@ -58,5 +84,18 @@ sil hidden @test_devirt_of_generic_default_witness_method : $@convention(thin) (
 bb0(%0 : $*ConformingGenericStruct<Int>):
   %fn = witness_method $ConformingGenericStruct<Int>, #ResilientProtocol.defaultA!1 : $@convention(witness_method) <T where T : ResilientProtocol> (@in_guaranteed T) -> ()
   %result = apply %fn<ConformingGenericStruct<Int>>(%0) : $@convention(witness_method) <T where T : ResilientProtocol> (@in_guaranteed T) -> ()
+  return %result : $()
+}
+
+// CHECK-LABEL: test_devirt_of_inner_generic_default_witness_method
+// CHECK:       bb0(%0 : $*ConformingGenericStruct<Int>, %1 : $*Int):
+// CHECK:       [[FN:%[0-9]+]] = function_ref @defaultB : $@convention(witness_method) <τ_0_0 where τ_0_0 : ResilientProtocolWithGeneric><τ_1_0 where τ_1_0 : P> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
+// CHECK:       [[RESULT:%[0-9]+]] = apply [[FN]]<ConformingGenericStruct<Int>, Int>(%1, %0) : $@convention(witness_method) <τ_0_0 where τ_0_0 : ResilientProtocolWithGeneric><τ_1_0 where τ_1_0 : P> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
+// CHECK:       return [[RESULT]] : $()
+// CHECK:     }
+sil hidden @test_devirt_of_inner_generic_default_witness_method : $@convention(thin) (@in_guaranteed ConformingGenericStruct<Int>, @in Int) -> () {
+bb0(%0 : $*ConformingGenericStruct<Int>, %1 : $*Int):
+  %fn = witness_method $ConformingGenericStruct<Int>, #ResilientProtocolWithGeneric.defaultB!1 : $@convention(witness_method) <T where T : ResilientProtocolWithGeneric><U where U : Q> (@in U, @in_guaranteed T) -> ()
+  %result = apply %fn<ConformingGenericStruct<Int>, Int>(%1, %0) : $@convention(witness_method) <T where T : ResilientProtocolWithGeneric><U where U : Q> (@in U, @in_guaranteed T) -> ()
   return %result : $()
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
The witness thunks for default witnesses are different from the
witness thunks for normal witnesses, because default witnesses take
`Self` (the whole conforming type) rather than having it substituted
away. Cope with this difference while still substituting the innermost
generic parameters for a generic requirement.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->