### PR TITLE
[swiftc (86 vs. 5180)] Add crasher at assert((!type->hasTypeParameter() || type->hasError()) && "not fully substituted")

### DIFF
--- a/validation-test/compiler_crashers/28455-type-hastypeparameter-type-haserror-not-fully-substituted-failed.swift
+++ b/validation-test/compiler_crashers/28455-type-hastypeparameter-type-haserror-not-fully-substituted-failed.swift
@@ -1,0 +1,14 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+protocol A{enum S{var f=e
+typealias f:B
+}
+class B<T>:d
+class d:A.B


### PR DESCRIPTION
Add test case for crash triggered in `?`.

Current number of unresolved compiler crashers: 86 (5180 resolved)

Assertion failure in [`lib/AST/GenericEnvironment.cpp (line 69)`](https://github.com/apple/swift/blob/master/lib/AST/GenericEnvironment.cpp#L69):

```
Assertion `(!type->hasTypeParameter() || type->hasError()) && "not fully substituted"' failed.

When executing: swift::Type swift::GenericEnvironment::mapTypeIntoContext(swift::ModuleDecl *, swift::Type) const
```

Assertion context:

```
}

Type GenericEnvironment::mapTypeIntoContext(ModuleDecl *M, Type type) const {
  type = type.subst(M, InterfaceToArchetypeMap, SubstFlags::AllowLoweredTypes);
  assert((!type->hasTypeParameter() || type->hasError()) &&
         "not fully substituted");
  return type;
}

Type GenericEnvironment::mapTypeIntoContext(GenericTypeParamType *type) const {
  auto canTy = type->getCanonicalType();
```
Stack trace:

```
swift: /path/to/swift/lib/AST/GenericEnvironment.cpp:69: swift::Type swift::GenericEnvironment::mapTypeIntoContext(swift::ModuleDecl *, swift::Type) const: Assertion `(!type->hasTypeParameter() || type->hasError()) && "not fully substituted"' failed.
Stack dump:
0.	Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28455-type-hastypeparameter-type-haserror-not-fully-substituted-failed.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28455-type-hastypeparameter-type-haserror-not-fully-substituted-failed-376906.o
1.	While type-checking 'A' at validation-test/compiler_crashers/28455-type-hastypeparameter-type-haserror-not-fully-substituted-failed.swift:10:1
2.	While type-checking expression at [validation-test/compiler_crashers/28455-type-hastypeparameter-type-haserror-not-fully-substituted-failed.swift:10:25 - line:10:25] RangeText="e"
3.	While type-checking 'f' at validation-test/compiler_crashers/28455-type-hastypeparameter-type-haserror-not-fully-substituted-failed.swift:11:1
4.	While resolving type B at [validation-test/compiler_crashers/28455-type-hastypeparameter-type-haserror-not-fully-substituted-failed.swift:11:13 - line:11:13] RangeText="B"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```