### PR TITLE
[swiftc (87 vs. 5180)] Add crasher: UNREACHABLE executed at swift/lib/AST/Module.cpp:614

### DIFF
--- a/validation-test/compiler_crashers/28456-unreachable-executed-at-swift-lib-ast-module-cpp-614.swift
+++ b/validation-test/compiler_crashers/28456-unreachable-executed-at-swift-lib-ast-module-cpp-614.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol a{typealias B<>:a{}associatedtype e
+struct B<T>:a{
+var:e
+class B<T>:a


### PR DESCRIPTION
Add test case for crash triggered in `?`.

Current number of unresolved compiler crashers: 87 (5180 resolved)

Stack trace:

```
Stack dump:
0.	Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28456-unreachable-executed-at-swift-lib-ast-module-cpp-614.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28456-unreachable-executed-at-swift-lib-ast-module-cpp-614-10867a.o
1.	While type-checking 'a' at validation-test/compiler_crashers/28456-unreachable-executed-at-swift-lib-ast-module-cpp-614.swift:9:1
2.	While resolving type e at [validation-test/compiler_crashers/28456-unreachable-executed-at-swift-lib-ast-module-cpp-614.swift:11:5 - line:11:5] RangeText="e"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```