### PR TITLE
Remove Darwin module's dependency on ctypes.h

### DIFF
--- a/test/ClangModules/MixedSource/Inputs/mixed-with-header.swift
+++ b/test/ClangModules/MixedSource/Inputs/mixed-with-header.swift
@@ -24,7 +24,7 @@ public func testProtocolWrapper(_ conformer: ForwardClassUser) {
    conformer.consumeForwardClass(conformer.forward)
 }
 
-public func testStruct(_ p: Point) -> Point {
+public func testStruct(_ p: Point2D) -> Point2D {
    var result = p
    result.y += 5
    return result

--- a/test/ClangModules/MixedSource/import-mixed-with-header.swift
+++ b/test/ClangModules/MixedSource/import-mixed-with-header.swift
@@ -27,5 +27,5 @@ func testCrossReferences(_ derived: Derived) {
   _ = obj.safeOverrideProto(ForwardProtoAdopter()) as NSObject
 
   testProtocolWrapper(ProtoConformer())
-  _ = testStruct(Point(x: 2,y: 3))
+  _ = testStruct(Point2D(x: 2,y: 3))
 }

--- a/test/ClangModules/MixedSource/mixed-target-using-header.swift
+++ b/test/ClangModules/MixedSource/mixed-target-using-header.swift
@@ -39,7 +39,7 @@ func testProtocolWrapper(_ conformer: ForwardClassUser) {
 }
 testProtocolWrapper(ProtoConformer())
 
-func testStruct(_ p: Point) -> Point {
+func testStruct(_ p: Point2D) -> Point2D {
   var result = p
   result.y += 5
   return result

--- a/test/Inputs/clang-importer-sdk/usr/include/AppKit.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/AppKit.h
@@ -1,4 +1,5 @@
 @import Foundation;
+@import ctypes;
 
 @protocol NSAppearanceCustomization <NSObject>
 @end

--- a/test/Inputs/clang-importer-sdk/usr/include/MacTypes.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/MacTypes.h
@@ -1,7 +1,20 @@
 #ifndef __MACTYPES__
 #define __MACTYPES__
 
-#include "ctypes.h"
+#define STDLIB_TEST(TYPE, NAME) extern NAME NAME##_test
+#define STDLIB_TYPEDEF(TYPE, NAME) \
+  typedef TYPE NAME; \
+  STDLIB_TEST(TYPE, NAME)
+
+STDLIB_TYPEDEF(__INT8_TYPE__, SInt8);
+STDLIB_TYPEDEF(__INT16_TYPE__, SInt16);
+STDLIB_TYPEDEF(__INT32_TYPE__, SInt32);
+
+STDLIB_TYPEDEF(__UINT8_TYPE__, UInt8);
+STDLIB_TYPEDEF(__UINT16_TYPE__, UInt16);
+STDLIB_TYPEDEF(__UINT32_TYPE__, UInt32);
+
+#include <stdint.h>
 
 typedef SInt32                          Fixed;
 typedef Fixed *                         FixedPtr;


### PR DESCRIPTION
Upstream cfe change r284797 requires that the Darwin module only depend on its submodules. This means it cannot depend on ctypes, so we need to split up this dependency in the swift test suite.