### PR TITLE
GlobalOpt: fix linkage and mangling of generated getter functions.

### DIFF
--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -197,6 +197,7 @@ static SILFunction *genGetterFromInit(StoreInst *Store,
   auto *varDecl = SILG->getDecl();
 
   Mangle::Mangler getterMangler;
+  getterMangler.append("_T");
   getterMangler.mangleGlobalGetterEntity(varDecl);
   auto getterName = getterMangler.finalize();
 
@@ -231,7 +232,7 @@ static SILFunction *genGetterFromInit(StoreInst *Store,
       ParameterConvention::Direct_Owned, { }, Results, None,
       Store->getModule().getASTContext());
   auto *GetterF = Store->getModule().getOrCreateFunction(Store->getLoc(),
-      getterName, SILLinkage::PrivateExternal, LoweredType,
+      getterName, SILLinkage::Private, LoweredType,
       IsBare_t::IsBare, IsTransparent_t::IsNotTransparent,
       IsFragile_t::IsFragile);
   GetterF->setDebugScope(Store->getFunction()->getDebugScope());
@@ -470,6 +471,7 @@ static SILFunction *genGetterFromInit(SILFunction *InitF, VarDecl *varDecl) {
   // Generate a getter from the global init function without side-effects.
 
   Mangle::Mangler getterMangler;
+  getterMangler.append("_T");
   getterMangler.mangleGlobalGetterEntity(varDecl);
   auto getterName = getterMangler.finalize();
 
@@ -486,7 +488,7 @@ static SILFunction *genGetterFromInit(SILFunction *InitF, VarDecl *varDecl) {
       ParameterConvention::Direct_Owned, { }, Results, None,
       InitF->getASTContext());
   auto *GetterF = InitF->getModule().getOrCreateFunction(InitF->getLocation(),
-     getterName, SILLinkage::PrivateExternal, LoweredType,
+     getterName, SILLinkage::Private, LoweredType,
       IsBare_t::IsBare, IsTransparent_t::IsNotTransparent,
       IsFragile_t::IsFragile);
   if (InitF->hasUnqualifiedOwnership())

--- a/test/SILOptimizer/globalopt_linkage.swift
+++ b/test/SILOptimizer/globalopt_linkage.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend  -O -Xllvm -sil-disable-pass=Inliner -emit-sil -primary-file %s | %FileCheck %s
+
+// Check if GlobalOpt generates the getters with the right linkage and the right mangling
+
+struct MyStruct {
+  static let StaticVar = 10
+}
+
+let Global = 27
+
+func testit() -> Int {
+  return MyStruct.StaticVar + Global
+}
+
+_ = testit()
+
+// CHECK: sil hidden @{{.*}}testit
+
+// CHECK:      // MyStruct.StaticVar.getter
+// CHECK-NEXT: sil private [fragile] @_{{.*}}StaticVar
+
+// CHECK:      // Global.getter
+// CHECK-NEXT: sil private [fragile] @_{{.*}}Global


### PR DESCRIPTION
fixes undefined symbol linker errors in case those getter functions are not inlined: rdar://problem/28901478