### PR TITLE
Fixing the FloatingPoint.subtracting doc comment

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -569,8 +569,8 @@ public protocol FloatingPoint: Comparable, Arithmetic,
   ///     print(x - 2.25)
   ///     // Prints "5.25"
   ///
-  /// The `subtracting(_:)` method implements the addition operation defined by
-  /// the [IEEE 754 specification][spec].
+  /// The `subtracting(_:)` method implements the subtraction operation
+  /// defined by the [IEEE 754 specification][spec].
   ///
   /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
   ///


### PR DESCRIPTION
The doc comment for the `subtracting` method used to refer to an 'addition operation'.

/cc @natecook1000 