### PR TITLE
[benchmark][SR-3106] Add benchmarks with 4 different Observers

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -64,6 +64,10 @@ set(SWIFT_BENCH_MODULES
     single-source/NSStringConversion
     single-source/NopDeinit
     single-source/ObjectAllocation
+    single-source/ObserverClosure
+    single-source/ObserverForwarderStruct
+    single-source/ObserverPartiallyAppliedMethod 
+    single-source/ObserverUnappliedMethod 
     single-source/OpenClose
     single-source/Phonebook
     single-source/PolymorphicCalls

--- a/benchmark/single-source/ObserverClosure.swift
+++ b/benchmark/single-source/ObserverClosure.swift
@@ -1,0 +1,29 @@
+
+class Observer {
+  @inline(never)
+  func receive(_ value: Int) {
+  }
+}
+
+class Signal {
+  var observers: [(Int) -> ()] = []
+
+  func subscribe(_ observer: @escaping (Int) -> ()) {
+    observers.append(observer)
+  }
+
+  func send(_ value: Int) {
+    for observer in observers {
+      observer(value)
+    }
+  }
+}
+
+public func run_ObserverClosure(_ iterations: Int) {
+  let signal = Signal()
+  let observer = Observer()
+  for _ in 0 ..< 10_000 * iterations {
+    signal.subscribe { i in observer.receive(i) }
+  }
+  signal.send(1)
+}

--- a/benchmark/single-source/ObserverForwarderStruct.swift
+++ b/benchmark/single-source/ObserverForwarderStruct.swift
@@ -1,0 +1,41 @@
+
+class Observer {
+  @inline(never)
+  func receive(_ value: Int) {
+  }
+}
+
+protocol Sink {
+  func receive(_ value: Int)
+}
+
+struct Forwarder: Sink {
+  let object: Observer
+
+  func receive(_ value: Int) {
+    object.receive(value)
+  }
+}
+
+class Signal {
+  var observers: [Sink] = []
+
+  func subscribe(_ sink: Sink) {
+    observers.append(sink)
+  }
+
+  func send(_ value: Int) {
+    for observer in observers {
+      observer.receive(value)
+    }
+  }
+}
+
+public func run_ObserverForwarderStruct(_ iterations: Int) {
+  let signal = Signal()
+  let observer = Observer()
+  for _ in 0 ..< 10_000 * iterations {
+    signal.subscribe(Forwarder(object: observer))
+  }
+  signal.send(1)
+}

--- a/benchmark/single-source/ObserverPartiallyAppliedMethod.swift
+++ b/benchmark/single-source/ObserverPartiallyAppliedMethod.swift
@@ -1,0 +1,29 @@
+
+class Observer {
+  @inline(never)
+  func receive(_ value: Int) {
+  }
+}
+
+class Signal {
+  var observers: [(Int) -> ()] = []
+
+  func subscribe(_ observer: @escaping (Int) -> ()) {
+    observers.append(observer)
+  }
+
+  func send(_ value: Int) {
+    for observer in observers {
+      observer(value)
+    }
+  }
+}
+
+public func run_ObserverPartiallyAppliedMethod(_ iterations: Int) {
+  let signal = Signal()
+  let observer = Observer()
+  for _ in 0 ..< 10_000 * iterations {
+    signal.subscribe(observer.receive)
+  }
+  signal.send(1)
+}

--- a/benchmark/single-source/ObserverUnappliedMethod.swift
+++ b/benchmark/single-source/ObserverUnappliedMethod.swift
@@ -1,0 +1,43 @@
+
+class Observer {
+  @inline(never)
+  func receive(_ value: Int) {
+  }
+}
+
+protocol Sink {
+  func receive(_ value: Int)
+}
+
+struct Forwarder<Object>: Sink {
+  let object: Object
+  let method: (Object) -> (Int) -> ()
+
+  func receive(_ value: Int) {
+    method(object)(value)
+  }
+}
+
+class Signal {
+  var observers: [Sink] = []
+
+  func subscribe(_ sink: Sink) {
+    observers.append(sink)
+  }
+
+  func send(_ value: Int) {
+    for observer in observers {
+      observer.receive(value)
+    }
+  }
+}
+
+public func run_ObserverUnappliedMethod(_ iterations: Int) {
+  let signal = Signal()
+  let observer = Observer()
+  for _ in 0 ..< 10_000 * iterations {
+    let forwarder = Forwarder(object: observer, method: Observer.receive)
+    signal.subscribe(forwarder)
+  }
+  signal.send(1)
+}

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -68,6 +68,10 @@ import ObjectAllocation
 import ObjectiveCBridging
 import ObjectiveCBridgingStubs
 import ObjectiveCNoBridgingStubs
+import ObserverClosure
+import ObserverForwarderStruct
+import ObserverPartiallyAppliedMethod
+import ObserverUnappliedMethod
 import OpenClose
 import Phonebook
 import PolymorphicCalls
@@ -197,6 +201,10 @@ precommitTests = [
   "ObjectiveCBridgeToNSDictionary": run_ObjectiveCBridgeToNSDictionary,
   "ObjectiveCBridgeToNSSet": run_ObjectiveCBridgeToNSSet,
   "ObjectiveCBridgeToNSString": run_ObjectiveCBridgeToNSString,
+  "ObserverClosure": run_ObserverClosure,
+  "ObserverForwarderStruct": run_ObserverForwarderStruct,
+  "ObserverPartiallyAppliedMethod": run_ObserverPartiallyAppliedMethod,
+  "ObserverUnappliedMethod": run_ObserverUnappliedMethod,
   "OpenClose": run_OpenClose,
   "Phonebook": run_Phonebook,
   "PolymorphicCalls": run_PolymorphicCalls,


### PR DESCRIPTION
<!-- What's in this pull request? -->
This pull request adds four benchmarks to Swift's benchmark suite that highlight optimization opportunities in the implementation of partially applied method invocations and escaping closures.

It augments (but does not resolve) [SR-3106](https://bugs.swift.org/browse/SR-3106), in which I complain about their slowness relative to hand-written forwarding structs.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

Here is a typical run on my system: (2012 15" rMBP):

```
  # TEST                      SAMPLES MIN(μs) MAX(μs) MEAN(μs) SD(μs) MEDIAN(μs) MAX_RSS(B)
 97 ObserverClosure                10    2547    2752     2599      0       2599  308317798
 98 ObserverForwarderStruct        10    1345    1972     1480      0       1480  614535987
 99 ObserverPartiallyAppliedMethod 10    3953    4194     4049      0       4049  267670733
100 ObserverUnappliedMethod        10    2990    3482     3093      0       3093  338796544
```

I'd have expected partially applied method invocations to be just as fast as hand-written method forwarding structs stored inside protocol existentials. In fact, in these benchmarks, they are almost three times slower than that, and two times slower than plain closures.