### PR TITLE
[3.0][SourceKit] Initialize pointer as nullptr to fix a crash. rdar://28959889

### DIFF
--- a/test/SourceKit/CodeExpand/code-expand.swift
+++ b/test/SourceKit/CodeExpand/code-expand.swift
@@ -79,3 +79,5 @@ func f1() {
   bar(a : {}}, <#T##d: () -> ()##() -> ()#>)
 }
 // CHECK: bar(a : {}}, <#T##d: () -> ()##() -> ()#>)
+
+foo(withDuration: 1, animations: <#T##() -> Void#>)

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1447,7 +1447,7 @@ private:
   bool containClosure(Expr *E) {
     if (E->getStartLoc().isInvalid())
       return false;
-    EditorPlaceholderExpr *Found;
+    EditorPlaceholderExpr *Found = nullptr;
     ClosureInfo Info;
     ClosureTypeWalker ClosureWalker(SM, Info);
     PlaceholderFinder Finder(E->getStartLoc(), Found);


### PR DESCRIPTION
- Explanation: An uninitialized pointer crashed SourceKit.  
- Scope of Issue: Users who rely on placeholder expansion to insert a closure.
- Origination: Likely Xcode 8.1
- Risk: Low
- Reviewed By:  Argyrios
- Testing: Regression test added
- Directions for QA: Paste `foo(withDuration: 1, animations: <#T##() -> Void#>)` into Xcode editor and double click the placeholder.