### PR TITLE
[SourceKit] Cherry-pick fix for mangling archetype in cursor-info. rdar://29053290

### DIFF
--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -31,6 +31,7 @@ static inline StringRef getUSRSpacePrefix() {
 }
 
 bool ide::printTypeUSR(Type Ty, raw_ostream &OS) {
+  assert(!Ty->hasArchetype() && "cannot have contextless archetypes mangled.");
   using namespace Mangle;
   Mangler Mangler(true);
   Mangler.mangleTypeForDebugger(Ty->getRValueType(), nullptr);

--- a/test/SourceKit/CursorInfo/crash2.swift
+++ b/test/SourceKit/CursorInfo/crash2.swift
@@ -1,0 +1,11 @@
+protocol P {
+  func meth()
+}
+
+func foo (t : P) {
+  t.meth()
+}
+
+// RUN: %sourcekitd-test -req=cursor -pos=6:5 %s -- %s | %FileCheck %s -check-prefix=CASE1
+
+// CASE1: source.lang.swift.ref.function.method.instance (2:8-2:14)

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -666,7 +666,7 @@ static bool passCursorInfoForDecl(const ValueDecl *VD,
   unsigned MangledTypeEnd = SS.size();
 
   unsigned MangledContainerTypeStart = SS.size();
-  if (ContainerTy) {
+  if (ContainerTy && !ContainerTy->hasArchetype()) {
     llvm::raw_svector_ostream OS(SS);
     SwiftLangSupport::printTypeUSR(ContainerTy, OS);
   }


### PR DESCRIPTION
- Explanation: Mangling archetypes without decl contexts crashed SourceKit. This commit cherry-picks the walk-around by avoiding printing USRs for any types that contain archetypes. This fix is for crash-avoiding but not the optimal. The thorough fix is tracked by rdar://29053842
- Scope of Issue: Cursor-info request of SourceKit
- Origination: Likely Xcode 8.1
- Risk: Low
- Reviewed By: @akyrtzi 
- Testing: Regression test added
- Directions for QA: Paste the code snippet  
```
protocol P {
  func meth()
}

func foo (t : P) {
  t.meth()
}
```
to Xcode editor and query cursor-info on the call of `meth()`.