### PR TITLE
Rdar 27397701 synthesized get set typechecking

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4593,7 +4593,9 @@ DynamicSelfType *FuncDecl::getDynamicSelfInterface() const {
 
 SourceRange FuncDecl::getSourceRange() const {
   SourceLoc StartLoc = getStartLoc();
-  if (StartLoc.isInvalid()) return SourceRange();
+  if (StartLoc.isInvalid() ||
+      getBodyKind() == BodyKind::Synthesize)
+    return SourceRange();
 
   if (getBodyKind() == BodyKind::Unparsed ||
       getBodyKind() == BodyKind::Skipped)

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -763,8 +763,7 @@ void swift::addTrivialAccessorsToStorage(AbstractStorageDecl *storage,
 
   // Synthesize and type-check the body of the getter.
   synthesizeTrivialGetter(getter, storage, TC);
-  TC.typeCheckDecl(getter, true);
-  TC.typeCheckDecl(getter, false);
+  TC.validateDecl(getter);
 
   if (setter) {
     if (isDynamic)
@@ -772,8 +771,7 @@ void swift::addTrivialAccessorsToStorage(AbstractStorageDecl *storage,
 
     // Synthesize and type-check the body of the setter.
     synthesizeTrivialSetter(setter, storage, setterValueParam, TC);
-    TC.typeCheckDecl(setter, true);
-    TC.typeCheckDecl(setter, false);
+    TC.validateDecl(setter);
   }
 
   auto *DC = storage->getDeclContext();

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3615,6 +3615,21 @@ public:
       }
     }
 
+    // Typecheck any accessors that were previously synthesized
+    // (that were previously only validated at point of synthesis)
+    if (auto getter = VD->getGetter()) {
+      if (getter->hasBody()) {
+        TC.typeCheckDecl(getter, true);
+        TC.typeCheckDecl(getter, false);
+      }
+    }
+    if (auto setter = VD->getSetter()) {
+      if (setter->hasBody()) {
+        TC.typeCheckDecl(setter, true);
+        TC.typeCheckDecl(setter, false);
+      }
+    }
+
     TC.checkDeclAttributes(VD);
   }
 

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -505,6 +505,7 @@ static void typeCheckFunctionsAndExternalDecls(TypeChecker &TC) {
 
   } while (currentFunctionIdx < TC.definedFunctions.size() ||
            currentExternalDef < TC.Context.ExternalDefinitions.size() ||
+           !TC.ValidatedTypes.empty() ||
            !TC.UsedConformances.empty());
 
   // FIXME: Horrible hack. Store this somewhere more appropriate.

--- a/validation-test/compiler_scale/scale_neighbouring_getset.gyb
+++ b/validation-test/compiler_scale/scale_neighbouring_getset.gyb
@@ -1,0 +1,10 @@
+// RUN: %scale-test --sum-multi --parse --begin 5 --end 16 --step 5 --select typeCheckAbstractFunctionBody %s
+// REQUIRES: tools-release
+
+struct Struct${N} {
+% if int(N) > 1:
+    var Field : Struct${int(N)-1}?
+% else:
+    var Field : Int?
+% end
+}


### PR DESCRIPTION
Addresses redundant typechecking of getter/setter function bodies outside of the primary file.
This is responsible for unnecessary quadratic work when doing a multi-file compilation.
PR also includes more scale-testing machinery, and a regression test that uses it.

Resolves [SR-2901](https://bugs.swift.org/browse/SR-2901).
Resolves rdar://27397701
