### PR TITLE
[Serialization] (De-)serialize witnesses completely.

### DIFF
--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -56,6 +56,9 @@ public:
     return subMap;
   }
 
+  /// Retrieve the conformances for the given type.
+  ArrayRef<ProtocolConformanceRef> getConformances(CanType type) const;
+
   void addSubstitution(CanType type, Type replacement);
 
   void addConformances(CanType type, ArrayRef<ProtocolConformanceRef> conformances);

--- a/include/swift/AST/Witness.h
+++ b/include/swift/AST/Witness.h
@@ -81,7 +81,7 @@ class ValueDecl;
 /// environment are those of the context of the protocol conformance (\c U
 /// and \c V, in the example above) and the innermost generic parameters are
 /// those of the generic requirement (\c T, in the example above). The
-/// \c Witness class contains this syntheetic environment (both its generic
+/// \c Witness class contains this synthetic environment (both its generic
 /// signature and a generic environment providing archetypes), a substitution
 /// map that allows one to map the interface types of the requirement into
 /// the interface types of the synthetic domain, and the set of substitutions

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -710,10 +710,14 @@ public:
   /// Reads a substitution record from \c DeclTypeCursor.
   ///
   /// If the record at the cursor is not a substitution, returns None.
-  Optional<Substitution> maybeReadSubstitution(llvm::BitstreamCursor &Cursor);
+  Optional<Substitution> maybeReadSubstitution(llvm::BitstreamCursor &Cursor,
+                                               GenericEnvironment *genericEnv =
+                                                nullptr);
 
   /// Recursively reads a protocol conformance from the given cursor.
-  ProtocolConformanceRef readConformance(llvm::BitstreamCursor &Cursor);
+  ProtocolConformanceRef readConformance(llvm::BitstreamCursor &Cursor,
+                                         GenericEnvironment *genericEnv =
+                                           nullptr);
 
   /// Read the given normal conformance from the current module file.
   NormalProtocolConformance *

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 280; // Last change: function qualified ownership
+const uint16_t VERSION_MINOR = 281; // Last change: complete witnesses
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1893,7 +1893,7 @@ struct ASTNodeBase {};
           }
 
           // Check the witness substitutions.
-          auto witness = normal->getWitness(req, nullptr);
+          const auto &witness = normal->getWitness(req, nullptr);
 
           if (witness.requiresSubstitution()) {
             GenericEnv.push_back(witness.getSyntheticEnvironment());

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -106,6 +106,13 @@ addConformances(CanType type, ArrayRef<ProtocolConformanceRef> conformances) {
   (void) result;
 }
 
+ArrayRef<ProtocolConformanceRef> SubstitutionMap::
+getConformances(CanType type) const {
+  auto known = conformanceMap.find(type.getPointer());
+  if (known == conformanceMap.end()) return { };
+  return known->second;
+}
+
 void SubstitutionMap::
 addParent(CanType type, CanType parent, AssociatedTypeDecl *assocType) {
   assert(type && parent && assocType);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -450,7 +450,9 @@ Pattern *ModuleFile::maybeReadPattern() {
   }
 }
 
-ProtocolConformanceRef ModuleFile::readConformance(llvm::BitstreamCursor &Cursor){
+ProtocolConformanceRef ModuleFile::readConformance(
+                                             llvm::BitstreamCursor &Cursor,
+                                             GenericEnvironment *genericEnv) {
   using namespace decls_block;
 
   SmallVector<uint64_t, 16> scratch;
@@ -475,6 +477,10 @@ ProtocolConformanceRef ModuleFile::readConformance(llvm::BitstreamCursor &Cursor
 
     ASTContext &ctx = getContext();
     Type conformingType = getType(conformingTypeID);
+    if (genericEnv) {
+      conformingType = genericEnv->mapTypeIntoContext(getAssociatedModule(),
+                                                      conformingType);
+    }
 
     PrettyStackTraceType trace(getAssociatedModule()->getASTContext(),
                                "reading specialized conformance for",
@@ -483,12 +489,13 @@ ProtocolConformanceRef ModuleFile::readConformance(llvm::BitstreamCursor &Cursor
     // Read the substitutions.
     SmallVector<Substitution, 4> substitutions;
     while (numSubstitutions--) {
-      auto sub = maybeReadSubstitution(Cursor);
+      auto sub = maybeReadSubstitution(Cursor, genericEnv);
       assert(sub.hasValue() && "Missing substitution?");
       substitutions.push_back(*sub);
     }
 
-    ProtocolConformanceRef genericConformance = readConformance(Cursor);
+    ProtocolConformanceRef genericConformance =
+      readConformance(Cursor, genericEnv);
     PrettyStackTraceDecl traceTo("... to", genericConformance.getRequirement());
 
     assert(genericConformance.isConcrete() && "Abstract generic conformance?");
@@ -505,11 +512,17 @@ ProtocolConformanceRef ModuleFile::readConformance(llvm::BitstreamCursor &Cursor
 
     ASTContext &ctx = getContext();
     Type conformingType = getType(conformingTypeID);
+    if (genericEnv) {
+      conformingType = genericEnv->mapTypeIntoContext(getAssociatedModule(),
+                                                      conformingType);
+    }
+
     PrettyStackTraceType trace(getAssociatedModule()->getASTContext(),
                                "reading inherited conformance for",
                                conformingType);
 
-    ProtocolConformanceRef inheritedConformance = readConformance(Cursor);
+    ProtocolConformanceRef inheritedConformance =
+      readConformance(Cursor, genericEnv);
     PrettyStackTraceDecl traceTo("... to",
                                  inheritedConformance.getRequirement());
 
@@ -541,8 +554,7 @@ ProtocolConformanceRef ModuleFile::readConformance(llvm::BitstreamCursor &Cursor
     auto module = getModule(moduleID);
 
     SmallVector<ProtocolConformance *, 2> conformances;
-    nominal->lookupConformance(module, proto,
-                               conformances);
+    nominal->lookupConformance(module, proto, conformances);
     PrettyStackTraceModuleFile traceMsg(
         "If you're seeing a crash here, check that your SDK and dependencies "
         "are at least as new as the versions used to build", this);
@@ -641,7 +653,8 @@ NormalProtocolConformance *ModuleFile::readNormalConformance(
 }
 
 Optional<Substitution>
-ModuleFile::maybeReadSubstitution(llvm::BitstreamCursor &cursor) {
+ModuleFile::maybeReadSubstitution(llvm::BitstreamCursor &cursor,
+                                  GenericEnvironment *genericEnv) {
   BCOffsetRAII lastRecordOffset(cursor);
 
   auto entry = cursor.advance(AF_DontPopBlockAtEnd);
@@ -661,6 +674,10 @@ ModuleFile::maybeReadSubstitution(llvm::BitstreamCursor &cursor) {
                                                           numConformances);
 
   auto replacementTy = getType(replacementID);
+  if (genericEnv) {
+    replacementTy = genericEnv->mapTypeIntoContext(getAssociatedModule(),
+                                                   replacementTy);
+  }
 
   SmallVector<ProtocolConformanceRef, 4> conformanceBuf;
   while (numConformances--) {
@@ -4206,17 +4223,85 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
   ASTContext &ctx = getContext();
   ArrayRef<uint64_t>::iterator rawIDIter = rawIDs.begin();
 
-  WitnessMap witnesses;
   while (valueCount--) {
-    auto first = cast<ValueDecl>(getDecl(*rawIDIter++));
-    auto second = cast_or_null<ValueDecl>(getDecl(*rawIDIter++));
-    assert(second || first->getAttrs().hasAttribute<OptionalAttr>() ||
-           first->getAttrs().isUnavailable(ctx));
-    (void) ctx;
-    if (second)
-      witnesses.insert(std::make_pair(first, second));
-    else
-      witnesses.insert(std::make_pair(first, Witness()));
+    auto req = cast<ValueDecl>(getDecl(*rawIDIter++));
+    auto witness = cast_or_null<ValueDecl>(getDecl(*rawIDIter++));
+    assert(witness ||
+           req->getAttrs().hasAttribute<OptionalAttr>() ||
+           req->getAttrs().isUnavailable(ctx));
+    if (!witness) {
+      conformance->setWitness(req, Witness());
+      continue;
+    }
+
+    // Generic signature and environment.
+    GenericSignature *syntheticSig = nullptr;
+    GenericEnvironment *syntheticEnv = nullptr;
+    if (unsigned numGenericParams = *rawIDIter++) {
+      // Generic parameters.
+      SmallVector<GenericTypeParamType *, 2> genericParams;
+      while (numGenericParams--) {
+        genericParams.push_back(
+          getType(*rawIDIter++)->castTo<GenericTypeParamType>());
+      }
+
+      // Generic requirements.
+      SmallVector<Requirement, 4> requirements;
+      readGenericRequirements(requirements);
+
+      // Form the generic signature for the synthetic environment.
+      syntheticSig = GenericSignature::get(genericParams, requirements);
+
+      // Create an archetype builder, which will help us create the
+      // synthetic environment.
+      ArchetypeBuilder builder(*getAssociatedModule(), ctx.Diags);
+      builder.addGenericSignature(syntheticSig, nullptr);
+      builder.finalize(SourceLoc());
+      syntheticEnv = builder.getGenericEnvironment();
+    }
+
+    // Requirement -> synthetic map.
+    SubstitutionMap reqToSyntheticMap;
+    bool hasReqToSyntheticMap = false;
+    if (unsigned numEntries = *rawIDIter++) {
+      hasReqToSyntheticMap = true;
+      while (numEntries--) {
+        auto first = getType(*rawIDIter++);
+        auto second = getType(*rawIDIter++);
+        reqToSyntheticMap.addSubstitution(first->getCanonicalType(), second);
+
+        if (unsigned numConformances = *rawIDIter++) {
+          SmallVector<ProtocolConformanceRef, 2> conformances;
+          while (numConformances--) {
+            conformances.push_back(readConformance(DeclTypeCursor));
+          }
+          reqToSyntheticMap.addConformances(first->getCanonicalType(),
+                                            ctx.AllocateCopy(conformances));
+        }
+      }
+    }
+
+    // Witness substitutions.
+    SmallVector<Substitution, 4> witnessSubstitutions;
+    if (unsigned numWitnessSubstitutions = *rawIDIter++) {
+      while (numWitnessSubstitutions--) {
+        auto sub = maybeReadSubstitution(DeclTypeCursor, syntheticEnv);
+        witnessSubstitutions.push_back(*sub);
+      }
+    }
+
+    // Handle simple witnesses.
+    if (witnessSubstitutions.empty() && !syntheticSig && !syntheticEnv &&
+        !hasReqToSyntheticMap) {
+      conformance->setWitness(req, Witness(witness));
+      continue;
+    }
+
+    // Set the witness.
+    conformance->setWitness(req,
+                            Witness(witness, witnessSubstitutions,
+                                    syntheticSig, syntheticEnv,
+                                    reqToSyntheticMap));
   }
   assert(rawIDIter <= rawIDs.end() && "read too much");
 
@@ -4232,15 +4317,11 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
   }
   assert(rawIDIter <= rawIDs.end() && "read too much");
 
+
   // Set type witnesses.
   for (auto typeWitness : typeWitnesses) {
     conformance->setTypeWitness(typeWitness.first, typeWitness.second.first,
                                 typeWitness.second.second);
-  }
-
-  // Set witnesses.
-  for (auto witness : witnesses) {
-    conformance->setWitness(witness.first, witness.second);
   }
 }
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1032,13 +1032,52 @@ void Serializer::writeNormalConformance(
                        ProtocolType::compareProtocols);
 
   conformance->forEachValueWitness(nullptr,
-                                   [&](ValueDecl *req,
-                                       ConcreteDeclRef witness) {
-    data.push_back(addDeclRef(req));
-    data.push_back(addDeclRef(witness.getDecl()));
-    assert(witness.getDecl() || req->getAttrs().hasAttribute<OptionalAttr>()
-           || req->getAttrs().isUnavailable(req->getASTContext()));
-    ++numValueWitnesses;
+    [&](ValueDecl *req, Witness witness) {
+      data.push_back(addDeclRef(req));
+      data.push_back(addDeclRef(witness.getDecl()));
+      assert(witness.getDecl() || req->getAttrs().hasAttribute<OptionalAttr>()
+             || req->getAttrs().isUnavailable(req->getASTContext()));
+
+      // If there is no witness, we're done.
+      if (!witness.getDecl()) return;
+
+      // If no substitution is required, all of the data structures are of
+      // length zero.
+      if (!witness.requiresSubstitution()) {
+        data.push_back(0); // generic parameters
+        data.push_back(0); // requirement-to-synthetic map
+        data.push_back(0); // witness substitutions
+        return;
+      }
+
+      if (auto genericSig = witness.getSyntheticSignature()) {
+        // Generic parameters.
+        data.push_back(genericSig->getGenericParams().size());
+        for (auto gp : genericSig->getGenericParams())
+          data.push_back(addTypeRef(gp));
+
+        // Requirements come at the end.
+      } else {
+        data.push_back(0);
+      }
+
+      // Mapping from the requirement's interface types to the interface
+      // types of the synthetic environment.
+      // FIXME: non-deterministic ordering
+      const auto &reqToSyntheticMap =
+        witness.getRequirementToSyntheticMap().getMap();
+      data.push_back(reqToSyntheticMap.size());
+      for (const auto &entry : reqToSyntheticMap) {
+        data.push_back(addTypeRef(entry.first));
+        data.push_back(addTypeRef(entry.second));
+        auto conformances =
+          witness.getRequirementToSyntheticMap().getConformances(
+                                             entry.first->getCanonicalType());
+        data.push_back(conformances.size());
+        // Conformances come at the end.
+      }
+      data.push_back(witness.getSubstitutions().size());
+      ++numValueWitnesses;
   });
 
   conformance->forEachTypeWitness(/*resolver=*/nullptr,
@@ -1069,6 +1108,33 @@ void Serializer::writeNormalConformance(
                      DeclTypeAbbrCodes);
   }
 
+  conformance->forEachValueWitness(nullptr,
+                                   [&](ValueDecl *req, Witness witness) {
+   // Bail out early for simple witnesses.
+   if (!witness.getDecl() || !witness.requiresSubstitution()) return;
+
+   // Write the generic requirements of the synthetic environment.
+   if (auto genericSig = witness.getSyntheticSignature())
+     writeGenericRequirements(genericSig->getRequirements());
+
+   // Write conformances for the requirement-to-synthetic environment map.
+   const auto &reqToSyntheticMap =
+     witness.getRequirementToSyntheticMap().getMap();
+   for (const auto &entry : reqToSyntheticMap) {
+     auto conformances =
+       witness.getRequirementToSyntheticMap().getConformances(
+                                              entry.first->getCanonicalType());
+     for (auto conformance : conformances) {
+       writeConformance(conformance, DeclTypeAbbrCodes);
+     }
+   }
+
+   // Write the witness substitutions.
+   writeSubstitutions(witness.getSubstitutions(),
+                      DeclTypeAbbrCodes,
+                      witness.getSyntheticEnvironment());
+  });
+
   conformance->forEachTypeWitness(/*resolver=*/nullptr,
                                   [&](AssociatedTypeDecl *assocType,
                                       const Substitution &witness,
@@ -1080,13 +1146,15 @@ void Serializer::writeNormalConformance(
 
 void
 Serializer::writeConformance(ProtocolConformance *conformance,
-                             const std::array<unsigned, 256> &abbrCodes) {
-  writeConformance(ProtocolConformanceRef(conformance), abbrCodes);
+                             const std::array<unsigned, 256> &abbrCodes,
+                             GenericEnvironment *genericEnv) {
+  writeConformance(ProtocolConformanceRef(conformance), abbrCodes, genericEnv);
 }
 
 void
 Serializer::writeConformance(ProtocolConformanceRef conformanceRef,
-                             const std::array<unsigned, 256> &abbrCodes) {
+                             const std::array<unsigned, 256> &abbrCodes,
+                             GenericEnvironment *genericEnv) {
   using namespace decls_block;
 
   if (conformanceRef.isAbstract()) {
@@ -1123,13 +1191,16 @@ Serializer::writeConformance(ProtocolConformanceRef conformanceRef,
     auto conf = cast<SpecializedProtocolConformance>(conformance);
     auto substitutions = conf->getGenericSubstitutions();
     unsigned abbrCode = abbrCodes[SpecializedProtocolConformanceLayout::Code];
+    auto type = conf->getType();
+    if (genericEnv)
+      type = genericEnv->mapTypeOutOfContext(const_cast<ModuleDecl *>(M), type);
     SpecializedProtocolConformanceLayout::emitRecord(Out, ScratchRecord,
                                                      abbrCode,
-                                                     addTypeRef(conf->getType()),
+                                                     addTypeRef(type),
                                                      substitutions.size());
-    writeSubstitutions(substitutions, abbrCodes);
+    writeSubstitutions(substitutions, abbrCodes, genericEnv);
 
-    writeConformance(conf->getGenericConformance(), abbrCodes);
+    writeConformance(conf->getGenericConformance(), abbrCodes, genericEnv);
     break;
   }
 
@@ -1138,11 +1209,14 @@ Serializer::writeConformance(ProtocolConformanceRef conformanceRef,
     unsigned abbrCode
       = abbrCodes[InheritedProtocolConformanceLayout::Code];
 
-    InheritedProtocolConformanceLayout::emitRecord(
-      Out, ScratchRecord, abbrCode,
-      addTypeRef(conformance->getType()));
+    auto type = conf->getType();
+    if (genericEnv)
+      type = genericEnv->mapTypeOutOfContext(const_cast<ModuleDecl *>(M), type);
 
-    writeConformance(conf->getInheritedConformance(), abbrCodes);
+    InheritedProtocolConformanceLayout::emitRecord(
+      Out, ScratchRecord, abbrCode, addTypeRef(type));
+
+    writeConformance(conf->getInheritedConformance(), abbrCodes, genericEnv);
     break;
   }
   }
@@ -1168,17 +1242,26 @@ Serializer::writeConformances(ArrayRef<ProtocolConformance*> conformances,
 
 void
 Serializer::writeSubstitutions(ArrayRef<Substitution> substitutions,
-                               const std::array<unsigned, 256> &abbrCodes) {
+                               const std::array<unsigned, 256> &abbrCodes,
+                               GenericEnvironment *genericEnv) {
   using namespace decls_block;
   auto abbrCode = abbrCodes[BoundGenericSubstitutionLayout::Code];
+
   for (auto &sub : substitutions) {
+    auto replacementType = sub.getReplacement();
+    if (genericEnv) {
+      replacementType =
+        genericEnv->mapTypeOutOfContext(const_cast<ModuleDecl *>(M),
+                                        replacementType);
+    }
+
     BoundGenericSubstitutionLayout::emitRecord(
       Out, ScratchRecord, abbrCode,
-      addTypeRef(sub.getReplacement()),
+      addTypeRef(replacementType),
       sub.getConformances().size());
 
     for (auto conformance : sub.getConformances()) {
-      writeConformance(conformance, abbrCodes);
+      writeConformance(conformance, abbrCodes, genericEnv);
     }
   }
 }

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -401,19 +401,32 @@ public:
 
   /// Writes a list of generic substitutions. abbrCode is needed to support
   /// usage out of decl block.
+  ///
+  /// \param genericEnv When provided, the generic environment that describes
+  /// the archetypes within the substitutions. The replacement types within
+  /// the substitution will be mapped out of the generic environment before
+  /// being written.
   void writeSubstitutions(ArrayRef<Substitution> substitutions,
-                          const std::array<unsigned, 256> &abbrCodes);
+                          const std::array<unsigned, 256> &abbrCodes,
+                          GenericEnvironment *genericEnv = nullptr);
 
   /// Write a normal protocol conformance.
   void writeNormalConformance(const NormalProtocolConformance *conformance);
 
   /// Writes a protocol conformance.
+  ///
+  /// \param genericEnv When provided, the generic environment that describes
+  /// the archetypes within the substitutions. The replacement types within
+  /// the substitution will be mapped out of the generic environment before
+  /// being written.
   void writeConformance(ProtocolConformanceRef conformance,
-                        const std::array<unsigned, 256> &abbrCodes);
+                        const std::array<unsigned, 256> &abbrCodes,
+                        GenericEnvironment *genericEnv = nullptr);
 
   /// Writes a protocol conformance.
   void writeConformance(ProtocolConformance *conformance,
-                        const std::array<unsigned, 256> &abbrCodes);
+                        const std::array<unsigned, 256> &abbrCodes,
+                        GenericEnvironment *genericEnv = nullptr);
 
   /// Writes a generic environment.
   void writeGenericEnvironment(GenericEnvironment *env,


### PR DESCRIPTION
<!-- What's in this pull request? -->
The witnesses in a NormalProtocolConformance have never been
completely serialized, because their substitutions involved a weird
mix of archetypes that blew up the deserialization code. So, only the
witness declarations themselves got serialized. Many clients (the type
checker, SourceKit, etc.) didn't need the extra information, but some
clients (e.g., the SIL optimizers) would end up recomputing this
information. Ick.

Now, serialize the complete Witness structure along with the AST,
including information about the synthetic environment, complete
substitutions, etc. This should obsolete some redundant code paths in
the SIL optimization infrastructure.

This (de-)serialization code takes a new-ish approach to serializing
the synthetic environment in that it avoids serializing any
archetypes. Rather, it maps everything back to interface types during
serialization, and deserialization forms a new generic environment
(with new archetypes!) on-the-fly, mapping deserialized types back
into that environment (and to those archetypes). This way, we don't
have to maintain identity of archetypes in the deserialization code,
and might get some better re-use of the archetypes.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
More of [rdar://problem/24079818](rdar://problem/24079818).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
