### PR TITLE
[3.0] SILGen: Skip the value-to-id peephole for types with nontrivial SIL lowering.

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3160,6 +3160,7 @@ namespace {
                                              SILParameterInfo param) {
       // If we're bridging a concrete type to `id` via Any, skip the Any
       // boxing.
+      
       // TODO: Generalize. Similarly, when bridging from NSFoo -> Foo -> NSFoo,
       // we should elide the bridge altogether and pass the original object.
       auto paramObjTy = param.getType();
@@ -3175,9 +3176,8 @@ namespace {
                                             origParamType, param);
       
       return SGF.emitNativeToBridgedValue(emitted.loc,
-                                      std::move(emitted.value).getScalarValue(),
-                                      Rep, param.getType());
-                                      
+                    std::move(emitted.value).getAsSingleValue(SGF, emitted.loc),
+                    Rep, param.getType());
     }
     
     enum class ExistentialPeepholeOptionality {
@@ -3266,15 +3266,24 @@ namespace {
                                                AbstractionPattern origParamType,
                                                SILParameterInfo param) {
       auto origArgExpr = argExpr;
-      (void) origArgExpr;
       // Look through existential erasures.
       ExistentialPeepholeOptionality optionality;
       std::tie(argExpr, optionality) = lookThroughExistentialErasures(argExpr);
       
+      // TODO: Only do the peephole for trivially-lowered types, since we
+      // unfortunately don't plumb formal types through
+      // emitNativeToBridgedValue, so can't correctly construct the
+      // substitution for the call to _bridgeAnythingToObjectiveC for function
+      // or metatype values.
+      if (!argExpr->getType()->isLegalSILType()) {
+        argExpr = origArgExpr;
+        optionality = ExistentialPeepholeOptionality::Nonoptional;
+      }
+      
       // Emit the argument.
       auto contexts = getRValueEmissionContexts(loweredSubstArgType, param);
       ManagedValue emittedArg = SGF.emitRValue(argExpr, contexts.ForEmission)
-        .getScalarValue();
+        .getAsSingleValue(SGF, argExpr);
       
       // Early exit if we already exactly match the parameter type.
       if (emittedArg.getType() == param.getSILType()) {

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -153,6 +153,24 @@ func passingToId<T: CP, U>(receiver: NSIdLover,
   receiver.takesId(optionalC)
 
   // TODO: Property and subscript setters
+
+}
+
+// Workaround for rdar://problem/28318984. Skip the peephole for types with
+// nontrivial SIL lowerings because we don't correctly form the substitutions
+// for a generic _bridgeAnythingToObjectiveC call.
+func zim() {}
+struct Zang {}
+// CHECK-LABEL: sil hidden @_TF17objc_bridging_any27typesWithNontrivialLoweringFT8receiverCSo9NSIdLover_T_
+func typesWithNontrivialLowering(receiver: NSIdLover) {
+  // CHECK: init_existential_addr {{%.*}} : $*Any, $() -> ()
+  receiver.takesId(zim)
+  // CHECK: init_existential_addr {{%.*}} : $*Any, $Zang.Type
+  receiver.takesId(Zang.self)
+  // CHECK: init_existential_addr {{%.*}} : $*Any, $(() -> (), Zang.Type)
+  receiver.takesId((zim, Zang.self))
+  // CHECK: apply {{%.*}}<(Int, String)>
+  receiver.takesId((0, "one"))
 }
 
 // CHECK-LABEL: sil hidden @_TF17objc_bridging_any19passingToNullableId


### PR DESCRIPTION
The `emitNativeToBridgedValue` code is not well-factored to pass down the formal type of the value being bridged, which is necessary to build a generic call to _bridgeAnythingToObjectiveC in the fallback case. To work around this issue, disable the expression peephole when the type is not a valid lowered SIL type as is. Short-term fix for rdar://problem/28318984.