### PR TITLE
IRGen: give thunks hidden visibility

### DIFF
--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -975,8 +975,8 @@ static llvm::Constant *findSwiftAsObjCThunk(IRGenModule &IGM, SILDeclRef ref) {
   SILFunction *SILFn = IGM.getSILModule().lookUpFunction(ref);
   assert(SILFn && "no IR function for swift-as-objc thunk");
   auto fn = IGM.getAddrOfSILFunction(SILFn, NotForDefinition);
-  fn->setVisibility(llvm::GlobalValue::DefaultVisibility);
   fn->setLinkage(llvm::GlobalValue::InternalLinkage);
+  fn->setVisibility(llvm::GlobalValue::HiddenVisibility);
   fn->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
 
   return llvm::ConstantExpr::getBitCast(fn, IGM.Int8PtrTy);

--- a/test/IRGen/objc-thunk.swift
+++ b/test/IRGen/objc-thunk.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -enable-objc-interop -disable-objc-attr-requires-foundation-module -emit-ir -parse-as-library -parse-stdlib %s -module-name M -o - %s | FileCheck %s
+// REQUIRES: objc_interop
+
+@objc
+public class C {
+  public func f() {}
+}
+
+// CHECK: define internal void @_TToFC1M1C1ffT_T_
+


### PR DESCRIPTION
<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

The thunk already has internal linkage and is marked as an unnamed_addr symbol.
Mark the thunk as hidden visibility rather than default visibility.