### PR TITLE
Fix broken build on ARM

### DIFF
--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -742,8 +742,8 @@ extension ${Self} : _ExpressibleByBuiltinFloatLiteral {
 #else
 
 % builtinFloatLiteralBits = 64
-@_transparent
 extension ${Self} : _ExpressibleByBuiltinFloatLiteral {
+  @_transparent
   public
   init(_builtinFloatLiteral value: Builtin.FPIEEE${builtinFloatLiteralBits}) {
 %   if bits == builtinFloatLiteralBits:


### PR DESCRIPTION
There was a @_transparent extension lurking behind an #if, and CI pull
request testing doesn't build the standard library on ARM.