### PR TITLE
stdlib: Make Unsafe{Mutable,}BufferPointer @_fixed_layout to work around rdar://18157434

### DIFF
--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -36,6 +36,11 @@ public struct UnsafeBufferPointerIterator<Element>
 /// underlying elements.
 ///
 /// The pointer should be aligned to `MemoryLayout<Element>.alignment`.
+
+// FIXME: rdar://18157434 - until this is fixed, this has to be fixed layout
+// to avoid a hang in Foundation, which has the following setup:
+// struct A { struct B { let x: UnsafeMutableBufferPointer<...> } let b: B }
+@_fixed_layout
 public struct Unsafe${Mutable}BufferPointer<Element>
   : _${Mutable}Indexable, ${Mutable}Collection, RandomAccessCollection {
 


### PR DESCRIPTION
This was causing the resilient build on Linux to hang when building swiftpm, because of a peculiar usage of nested types:

```
private struct JSONReader {
    struct UnicodeSource {
        let buffer: UnsafeBufferPointer<UInt8>
    }

    let source: UnicodeSource
}
```