### PR TITLE
[swiftc (89 vs. 5180)] Add crasher at assert(!resultReplacement->isTypeParameter() && "Can't be dependent")

### DIFF
--- a/validation-test/compiler_crashers/28458-resultreplacement-istypeparameter-cant-be-dependent.swift
+++ b/validation-test/compiler_crashers/28458-resultreplacement-istypeparameter-cant-be-dependent.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+protocol C{struct D:C{enum A{case J(f}typealias F=Self}typealias f typealias F


### PR DESCRIPTION
Add test case for crash triggered in `?`.

Current number of unresolved compiler crashers: 89 (5180 resolved)

Assertion failure in [`lib/Sema/TypeCheckProtocol.cpp (line 2038)`](https://github.com/apple/swift/blob/master/lib/Sema/TypeCheckProtocol.cpp#L2038):

```
Assertion `!resultReplacement->isTypeParameter() && "Can't be dependent"' failed.

When executing: swift::Substitution getArchetypeSubstitution(swift::TypeChecker &, swift::DeclContext *, swift::ArchetypeType *, swift::Type)
```

Assertion context:

```
static Substitution getArchetypeSubstitution(TypeChecker &tc,
                                             DeclContext *dc,
                                             ArchetypeType *archetype,
                                             Type replacement) {
  Type resultReplacement = replacement;
  assert(!resultReplacement->isTypeParameter() && "Can't be dependent");
  SmallVector<ProtocolConformanceRef, 4> conformances;

  bool isError =
    replacement->hasError() || replacement->getCanonicalType()->hasError();
  assert((archetype != nullptr || isError) &&
```
Stack trace:

```
0  swift           0x00000000031dc7e8
1  swift           0x00000000031dd066
2  libpthread.so.0 0x00007f084b84f330
3  libc.so.6       0x00007f084a00dc37 gsignal + 55
4  libc.so.6       0x00007f084a011028 abort + 328
5  libc.so.6       0x00007f084a006bf6
6  libc.so.6       0x00007f084a006ca2
7  swift           0x0000000000c0841e
8  swift           0x0000000000c068f2
9  swift           0x0000000000c003e8
10 swift           0x0000000000bfc53a
11 swift           0x0000000000df2293
12 swift           0x0000000000df21d8
13 swift           0x0000000000c25b52
14 swift           0x0000000000c309bc
15 swift           0x0000000000c2f89e
16 swift           0x0000000000c27171
17 swift           0x0000000000c26e6d
18 swift           0x0000000000c27f88
19 swift           0x0000000000c28a32
20 swift           0x0000000000c27e7f
21 swift           0x0000000000c26615
22 swift           0x0000000000bcf9d6
23 swift           0x0000000000bc19f6
24 swift           0x0000000000bcaa0b
25 swift           0x0000000000bc1976
26 swift           0x0000000000bcab8b
27 swift           0x0000000000bc1986
28 swift           0x0000000000bcbb0b
29 swift           0x0000000000bc19a6
30 swift           0x0000000000bc17e6
31 swift           0x0000000000c342ff
32 swift           0x0000000000957dd6
33 swift           0x00000000004a050e
34 swift           0x00000000004674de
35 libc.so.6       0x00007f0849ff8f45 __libc_start_main + 245
36 swift           0x0000000000464be6
```