### PR TITLE
[SR-2988][stdlib] Don't try to construct invalid `UnicodeScalar`s

### DIFF
--- a/stdlib/public/SDK/Foundation/CharacterSet.swift
+++ b/stdlib/public/SDK/Foundation/CharacterSet.swift
@@ -17,6 +17,10 @@ private func _utfRangeToNSRange(_ inRange : Range<UnicodeScalar>) -> NSRange {
     return NSMakeRange(Int(inRange.lowerBound.value), Int(inRange.upperBound.value - inRange.lowerBound.value))
 }
 
+private func _utfRangeToNSRange(_ inRange : ClosedRange<UnicodeScalar>) -> NSRange {
+    return NSMakeRange(Int(inRange.lowerBound.value), Int(inRange.upperBound.value - inRange.lowerBound.value + 1))
+}
+
 internal final class _SwiftNSCharacterSet : _SwiftNativeNSCharacterSet, _SwiftNativeFoundationType {
     internal typealias ImmutableType = NSCharacterSet
     internal typealias MutableType = NSMutableCharacterSet
@@ -104,8 +108,7 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
     ///
     /// It is the caller's responsibility to ensure that the values represent valid `UnicodeScalar` values, if that is what is desired.
     public init(charactersIn range: ClosedRange<UnicodeScalar>) {
-        let halfOpenRange = range.lowerBound..<UnicodeScalar(range.upperBound.value + 1)!
-        _wrapped = _SwiftNSCharacterSet(immutableObject: NSCharacterSet(range: _utfRangeToNSRange(halfOpenRange)))
+        _wrapped = _SwiftNSCharacterSet(immutableObject: NSCharacterSet(range: _utfRangeToNSRange(range)))
     }
 
     /// Initialize with the characters in the given string.
@@ -292,8 +295,7 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
     ///
     /// It is the caller's responsibility to ensure that the values represent valid `UnicodeScalar` values, if that is what is desired.
     public mutating func insert(charactersIn range: ClosedRange<UnicodeScalar>) {
-        let halfOpenRange = range.lowerBound..<UnicodeScalar(range.upperBound.value + 1)!
-        let nsRange = _utfRangeToNSRange(halfOpenRange)
+        let nsRange = _utfRangeToNSRange(range)
         _applyUnmanagedMutation {
             $0.addCharacters(in: nsRange)
         }
@@ -309,8 +311,7 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
 
     /// Remove a closed range of integer values from the `CharacterSet`.
     public mutating func remove(charactersIn range: ClosedRange<UnicodeScalar>) {
-        let halfOpenRange = range.lowerBound..<UnicodeScalar(range.upperBound.value + 1)!
-        let nsRange = _utfRangeToNSRange(halfOpenRange)
+        let nsRange = _utfRangeToNSRange(range)
         _applyUnmanagedMutation {
             $0.removeCharacters(in: nsRange)
         }

--- a/test/stdlib/TestCharacterSet.swift
+++ b/test/stdlib/TestCharacterSet.swift
@@ -101,7 +101,19 @@ class TestCharacterSet : TestCharacterSetSuper {
         let result = testString.trimmingCharacters(in: asciiLowercase)
         expectEqual(result, expected)
     }
-    
+
+    func testClosedRanges_SR_2988() {
+      // "CharacterSet.insert(charactersIn: ClosedRange) crashes on a closed ClosedRange<UnicodeScalar> containing U+D7FF"
+      let problematicChar = UnicodeScalar(0xD7FF)!
+      let range = capitalA...problematicChar
+      var characters = CharacterSet(charactersIn: range) // this should not crash
+      expectTrue(characters.contains(problematicChar))
+      characters.remove(charactersIn: range) // this should not crash
+      expectTrue(!characters.contains(problematicChar))
+      characters.insert(charactersIn: range) // this should not crash
+      expectTrue(characters.contains(problematicChar))
+    }
+
     func testInsertAndRemove() {
         var asciiUppercase = CharacterSet(charactersIn: UnicodeScalar(0x41)!...UnicodeScalar(0x5A)!)
         expectTrue(asciiUppercase.contains(UnicodeScalar(0x49)!))


### PR DESCRIPTION
When inserting a closed range/creating a `CharacterSet` from a closed range we must not try to convert this range to a half open one by incrementing the `upperBound` `UnicodeScalar` because not all integer values are valid values for `UnicodeScalar`.

Resolves [SR-2988](https://bugs.swift.org/browse/SR-2988).