### PR TITLE
Remove dead code in SIL linker and small refactoring of SILDeclRef::mangle

### DIFF
--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -234,11 +234,14 @@ struct SILDeclRef {
   
   SILLocation getAsRegularLocation() const;
 
+  enum class ManglingKind {
+    Default,
+    VTableMethod,
+    DynamicThunk,
+  };
+
   /// Produce a mangled form of this constant.
-  ///
-  /// If 'prefix' is non-empty, it will be used in place of the standard '_T'
-  /// prefix.
-  std::string mangle(StringRef prefix = {}) const;
+  std::string mangle(ManglingKind MKind = ManglingKind::Default) const;
 
   /// True if the SILDeclRef references a function.
   bool isFunc() const {

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -423,13 +423,6 @@ public:
   bool linkFunction(SILFunction *Fun,
                     LinkingMode LinkAll = LinkingMode::LinkNormal);
 
-  /// Attempt to link a function by declaration. Returns true if linking
-  /// succeeded, false otherwise.
-  ///
-  /// \return false if the linking failed.
-  bool linkFunction(SILDeclRef Decl,
-                    LinkingMode LinkAll = LinkingMode::LinkNormal);
-
   /// Attempt to link a function by mangled name. Returns true if linking
   /// succeeded, false otherwise.
   ///

--- a/include/swift/Serialization/SerializedSILLoader.h
+++ b/include/swift/Serialization/SerializedSILLoader.h
@@ -90,7 +90,6 @@ public:
   ~SerializedSILLoader();
 
   SILFunction *lookupSILFunction(SILFunction *Callee);
-  SILFunction *lookupSILFunction(SILDeclRef Decl);
   SILFunction *
   lookupSILFunction(StringRef Name, bool declarationOnly = false,
                     SILLinkage linkage = SILLinkage::Private);

--- a/lib/SIL/Linker.cpp
+++ b/lib/SIL/Linker.cpp
@@ -79,30 +79,6 @@ bool SILLinkerVisitor::processFunction(SILFunction *F) {
 }
 
 /// Process Decl, recursively deserializing any thing Decl may reference.
-bool SILLinkerVisitor::processDeclRef(SILDeclRef Decl) {
-  if (Mode == LinkingMode::LinkNone)
-    return false;
-
-  // If F is a declaration, first deserialize it.
-  auto *NewFn = Loader->lookupSILFunction(Decl);
-  if (!NewFn || NewFn->isExternalDeclaration())
-    return false;
-
-  if (!shouldImportFunction(NewFn)) {
-    return false;
-  }
-
-  ++NumFuncLinked;
-
-  // Try to transitively deserialize everything referenced by NewFn.
-  Worklist.push_back(NewFn);
-  process();
-
-  // Since we successfully processed at least one function, return true.
-  return true;
-}
-
-/// Process Decl, recursively deserializing any thing Decl may reference.
 bool SILLinkerVisitor::processFunction(StringRef Name) {
   if (Mode == LinkingMode::LinkNone)
     return false;

--- a/lib/SIL/Linker.h
+++ b/lib/SIL/Linker.h
@@ -62,10 +62,6 @@ public:
   /// with this Name.
   bool hasFunction(StringRef Name, SILLinkage Linkage);
 
-  /// Process Decl, recursively deserializing any thing that
-  /// the SILFunction corresponding to Decl may reference.
-  bool processDeclRef(SILDeclRef Decl);
-
   /// Deserialize the VTable mapped to C if it exists and all SIL the VTable
   /// transitively references.
   ///

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -486,10 +486,6 @@ bool SILModule::linkFunction(SILFunction *Fun, SILModule::LinkingMode Mode) {
   return SILLinkerVisitor(*this, getSILLoader(), Mode).processFunction(Fun);
 }
 
-bool SILModule::linkFunction(SILDeclRef Decl, SILModule::LinkingMode Mode) {
-  return SILLinkerVisitor(*this, getSILLoader(), Mode).processDeclRef(Decl);
-}
-
 bool SILModule::linkFunction(StringRef Name, SILModule::LinkingMode Mode) {
   return SILLinkerVisitor(*this, getSILLoader(), Mode).processFunction(Name);
 }

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -33,7 +33,7 @@ using namespace Lowering;
 SILFunction *SILGenModule::getDynamicThunk(SILDeclRef constant,
                                            SILConstantInfo constantInfo) {
   // Mangle the constant with a _TTD header.
-  auto name = constant.mangle("_TTD");
+  auto name = constant.mangle(SILDeclRef::ManglingKind::DynamicThunk);
 
   IsFragile_t isFragile = IsNotFragile;
   if (makeModuleFragile)
@@ -80,7 +80,7 @@ SILGenModule::emitVTableMethod(SILDeclRef derived, SILDeclRef base) {
   // TODO: If we allocated a new vtable slot for the derived method, then
   // further derived methods would potentially need multiple thunks, and we
   // would need to mangle the base method into the symbol as well.
-  auto name = derived.mangle("_TTV");
+  auto name = derived.mangle(SILDeclRef::ManglingKind::VTableMethod);
 
   // If we already emitted this thunk, reuse it.
   // TODO: Allocating new vtable slots for derived methods with different ABIs

--- a/lib/Serialization/SerializedSILLoader.cpp
+++ b/lib/Serialization/SerializedSILLoader.cpp
@@ -57,24 +57,6 @@ SILFunction *SerializedSILLoader::lookupSILFunction(SILFunction *Callee) {
   return retVal;
 }
 
-SILFunction *SerializedSILLoader::lookupSILFunction(SILDeclRef Decl) {
-  llvm::SmallString<32> Name;
-  Decl.mangle(Name);
-  // It is possible that one module has a declaration of a SILFunction, while
-  // another has the full definition.
-  SILFunction *retVal = nullptr;
-  for (auto &Des : LoadedSILSections) {
-    if (auto Func = Des->lookupSILFunction(Name)) {
-      DEBUG(llvm::dbgs() << "Deserialized " << Func->getName() << " from "
-            << Des->getModuleIdentifier().str() << "\n");
-      if (!Func->empty())
-        return Func;
-      retVal = Func;
-    }
-  }
-  return retVal;
-}
-
 SILFunction *SerializedSILLoader::lookupSILFunction(StringRef Name,
                                                     bool declarationOnly,
                                                     SILLinkage Linkage) {


### PR DESCRIPTION
Remove dead code in SIL linker
... which is not only dead but also broken.

Small refactoring of SILDeclRef::mangle

Instead of passing a mangling prefix as a string, just pass the kind of mangling. This will ease the transition to the new mangling scheme.
NFC