### PR TITLE
SILGen: Pass down right substitutions when getting a read-only local property.

### DIFF
--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -434,6 +434,11 @@ public:
   void emitMarkFunctionEscapeForTopLevelCodeGlobals(SILLocation loc,
                                                 const CaptureInfo &captureInfo);
 
+  /// Get the substitutions necessary to invoke a non-member (global or local)
+  /// property.
+  ArrayRef<Substitution>
+  getNonMemberVarDeclSubstitutions(VarDecl *var);
+
 private:
   /// Emit the deallocator for a class that uses the objc allocator.
   void emitObjCAllocatorDestructor(ClassDecl *cd, DestructorDecl *dd);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -430,7 +430,8 @@ emitRValueForDecl(SILLocation loc, ConcreteDeclRef declRef, Type ncRefType,
       selfSource = ArgumentSource(loc, std::move(metatypeRV));
     }
     return emitGetAccessor(loc, getter,
-                           ArrayRef<Substitution>(), std::move(selfSource),
+                           SGM.getNonMemberVarDeclSubstitutions(var),
+                           std::move(selfSource),
                            /*isSuper=*/false, isDirectAccessorUse,
                            RValue(), C);
   }

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1577,14 +1577,14 @@ LValue SILGenLValue::visitExpr(Expr *e, AccessKind accessKind) {
   llvm_unreachable("unimplemented lvalue expr");
 }
 
-static ArrayRef<Substitution>
-getNonMemberVarDeclSubstitutions(SILGenModule &SGM, VarDecl *var) {
+ArrayRef<Substitution>
+SILGenModule::getNonMemberVarDeclSubstitutions(VarDecl *var) {
   ArrayRef<Substitution> substitutions;
   auto *dc = var->getDeclContext();
   if (auto *genericEnv = dc->getGenericEnvironmentOfContext()) {
     auto *genericSig = dc->getGenericSignatureOfContext();
     substitutions = genericEnv->getForwardingSubstitutions(
-        SGM.SwiftModule, genericSig);
+        SwiftModule, genericSig);
   }
   return substitutions;
 }
@@ -1600,7 +1600,7 @@ addNonMemberVarDeclAddressorComponent(SILGenModule &SGM, VarDecl *var,
   auto typeData = getPhysicalStorageTypeData(SGM, var, formalRValueType);
   SILType storageType = SGM.Types.getLoweredType(var->getType()).getAddressType();
   lvalue.add<AddressorComponent>(var, /*isSuper=*/ false, /*direct*/ true,
-                                 getNonMemberVarDeclSubstitutions(SGM, var),
+                                 SGM.getNonMemberVarDeclSubstitutions(var),
                                  CanType(), typeData, storageType);
 }
 
@@ -1631,7 +1631,7 @@ static LValue emitLValueForNonMemberVarDecl(SILGenFunction &gen,
   case AccessStrategy::DirectToAccessor: {
     auto typeData = getLogicalStorageTypeData(gen.SGM, formalRValueType);
     lv.add<GetterSetterComponent>(var, /*isSuper=*/false, /*direct*/ true,
-                                  getNonMemberVarDeclSubstitutions(gen.SGM, var),
+                                  gen.SGM.getNonMemberVarDeclSubstitutions(var),
                                   CanType(), typeData);
     break;
   }

--- a/test/SILGen/generic_local_property.swift
+++ b/test/SILGen/generic_local_property.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+
+func use<T>(_: T) {}
+
+// CHECK-LABEL: sil hidden @_TF22generic_local_property3foourFT1xx1ySi_T_
+func foo<T>(x: T, y: Int) {
+  var mutable: Int {
+    get {
+      use(x)
+      return y
+    }
+    set {
+      use(x)
+    }
+  }
+
+  var readonly: Int {
+    get {
+      use(x)
+      return y
+    }
+  }
+
+  // CHECK-LABEL: function_ref (foo<A> (x : A, y : Int) -> ()).(readonly #1).getter
+  _ = readonly
+  // CHECK-LABEL: function_ref (foo<A> (x : A, y : Int) -> ()).(mutable #1).getter
+  _ = mutable
+  // CHECK-LABEL: function_ref (foo<A> (x : A, y : Int) -> ()).(mutable #1).setter
+  mutable = y
+}


### PR DESCRIPTION
Fixes rdar://problem/28933116.