### PR TITLE
[sil-mode] Add syntax highlighting for objc_protocol instruction.

### DIFF
--- a/utils/sil-mode.el
+++ b/utils/sil-mode.el
@@ -119,7 +119,8 @@
    `(,(regexp-opt '("init_existential_addr" "deinit_existential_addr"
                     "open_existential_addr" "alloc_existential_box"
                     "init_existential_ref" "project_existential_box"
-                    "open_existential_ref" "open_existential_box")
+                    "open_existential_ref" "open_existential_box"
+                    "objc_protocol")
                   'words) . font-lock-keyword-face)
    ;; Unchecked Conversions
    `(,(regexp-opt '("upcast"


### PR DESCRIPTION
Title says it all.