### PR TITLE
[ClangImporter] C static-qualified array params are non-nullable.

### DIFF
--- a/lib/ClangImporter/ClangAdapter.h
+++ b/lib/ClangImporter/ClangAdapter.h
@@ -139,11 +139,15 @@ bool isUnavailableInSwift(const clang::Decl *decl, const PlatformAvailability &,
 
 /// Determine the optionality of the given Clang parameter.
 ///
+/// \param swiftLanguageVersion What version of Swift we're using, which affects
+/// how optionality is inferred.
+///
 /// \param param The Clang parameter.
 ///
 /// \param knownNonNull Whether a function- or method-level "nonnull" attribute
 /// applies to this parameter.
-OptionalTypeKind getParamOptionality(const clang::ParmVarDecl *param,
+OptionalTypeKind getParamOptionality(version::Version swiftLanguageVersion,
+                                     const clang::ParmVarDecl *param,
                                      bool knownNonNull);
 }
 }

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -713,6 +713,8 @@ static bool omitNeedlessWordsInFunctionName(
     Optional<unsigned> errorParamIndex, bool returnsSelf, bool isInstanceMethod,
     NameImporter &nameImporter) {
   clang::ASTContext &clangCtx = nameImporter.getClangContext();
+  const version::Version &swiftLanguageVersion =
+      nameImporter.getLangOpts().EffectiveLanguageVersion;
 
   // Collect the parameter type names.
   StringRef firstParamName;
@@ -741,7 +743,8 @@ static bool omitNeedlessWordsInFunctionName(
     bool hasDefaultArg =
         ClangImporter::Implementation::inferDefaultArgument(
             param->getType(),
-            getParamOptionality(param, !nonNullArgs.empty() && nonNullArgs[i]),
+            getParamOptionality(swiftLanguageVersion, param,
+                                !nonNullArgs.empty() && nonNullArgs[i]),
             nameImporter.getIdentifier(baseName), numParams, argumentName,
             i == 0, isLastParameter, nameImporter) != DefaultArgumentKind::None;
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1550,7 +1550,8 @@ ParameterList *ClangImporter::Implementation::importFunctionParameterList(
 
     // Check nullability of the parameter.
     OptionalTypeKind OptionalityOfParam =
-        getParamOptionality(param, !nonNullArgs.empty() && nonNullArgs[index]);
+        getParamOptionality(SwiftContext.LangOpts.EffectiveLanguageVersion,
+                            param, !nonNullArgs.empty() && nonNullArgs[index]);
 
     ImportTypeKind importKind = ImportTypeKind::Parameter;
     if (param->hasAttr<clang::CFReturnsRetainedAttr>())
@@ -1933,8 +1934,9 @@ Type ClangImporter::Implementation::importMethodType(
 
     // Check nullability of the parameter.
     OptionalTypeKind optionalityOfParam
-      = getParamOptionality(param,
-                            !nonNullArgs.empty() && nonNullArgs[paramIndex]);
+        = getParamOptionality(SwiftContext.LangOpts.EffectiveLanguageVersion,
+                              param,
+                              !nonNullArgs.empty() && nonNullArgs[paramIndex]);
 
     bool allowNSUIntegerAsIntInParam = isFromSystemModule;
     if (allowNSUIntegerAsIntInParam) {

--- a/test/ClangImporter/ctypes_parse.swift
+++ b/test/ClangImporter/ctypes_parse.swift
@@ -222,4 +222,9 @@ func testArrays() {
 
   nullableArrayParameters([], [], [])
   nullableArrayParameters(nil, nil, nil)
+
+  // It would also be nice to warn here about the arrays being too short, but
+  // that's probably beyond us for a while.
+  staticBoundsArray([])
+  staticBoundsArray(nil) // no-error
 }

--- a/test/ClangImporter/ctypes_parse_swift4.swift
+++ b/test/ClangImporter/ctypes_parse_swift4.swift
@@ -1,0 +1,10 @@
+// RUN: %target-parse-verify-swift %clang-importer-sdk -swift-version 4
+
+import ctypes
+
+func testArrays() {
+  // It would also be nice to warn here about the arrays being too short, but
+  // that's probably beyond us for a while.
+  staticBoundsArray([])
+  staticBoundsArray(nil) // expected-error {{nil is not compatible with expected argument type 'UnsafePointer<Int8>'}}
+}

--- a/test/Inputs/clang-importer-sdk/usr/include/ctypes.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ctypes.h
@@ -265,6 +265,7 @@ typedef struct ModRM {
 // Arrays
 //===---
 void useArray(char x[4], char y[], char z[][8]);
+void staticBoundsArray(const char x[static 4]);
 
 typedef const int FourConstInts[4];
 void nonnullArrayParameters(const char x[_Nonnull], void * const _Nullable y[_Nonnull], _Nonnull FourConstInts z);


### PR DESCRIPTION
> If the keyword `static` also appears within the `[` and `]` of the array type derivation, then for each call to the function, the value of the corresponding actual argument shall provide access to the first element of an array with at least as many elements as specified by the size expression. (C11 6.7.6.3p7)

Limit this change to Swift 4 so as not to break existing code, though use of `static` in this way is rare to begin with and passing nil would probably be an error anyway.

Small part of rdar://problem/25846421.