### PR TITLE
Fix crash in member lookup when base type contains type variables.

### DIFF
--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -718,7 +718,8 @@ public:
     // Does it make sense to substitute types?
     bool shouldSubst = !BaseTy->hasUnboundGenericType() &&
                        !isa<AnyMetatypeType>(BaseTy.getPointer()) &&
-                       !BaseTy->isAnyExistentialType();
+                       !BaseTy->isAnyExistentialType() &&
+                       !BaseTy->hasTypeVariable();
     ModuleDecl *M = DC->getParentModule();
 
     auto FoundSignature = VD->getOverloadSignature();

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6793,6 +6793,9 @@ Expr *TypeChecker::callWitness(Expr *base, DeclContext *dc,
 
   // Find the witness we need to use.
   auto type = base->getType();
+  assert(!type->hasTypeVariable() &&
+         "Building call to witness with unresolved base type!");
+
   if (auto metaType = type->getAs<AnyMetatypeType>())
     type = metaType->getInstanceType();
   

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3101,6 +3101,11 @@ bool swift::isExtensionApplied(DeclContext &DC, Type BaseTy,
   bool Failed = false;
   SmallVector<Type, 3> TypeScratch;
 
+  // Don't allow type variables from an existing constraint system to
+  // leak into the new constraint system created below.
+  assert(!BaseTy->hasTypeVariable() &&
+         "Unexpected type variable in base type!");
+
   // Prepare type substitution map.
   TypeSubstitutionMap Substitutions = BaseTy->getMemberSubstitutions(ED);
   auto resolveType = [&](Type Ty) {
@@ -3144,6 +3149,9 @@ bool swift::isExtensionApplied(DeclContext &DC, Type BaseTy,
 static bool canSatisfy(Type T1, Type T2, DeclContext &DC, ConstraintKind Kind,
                        bool ReplaceArchetypeWithVariables,
                        bool AllowFreeVariables) {
+  assert(!T1->hasTypeVariable() && !T2->hasTypeVariable() &&
+         "Unexpected type variable in constraint satisfaction testing");
+
   std::unique_ptr<TypeChecker> CreatedTC;
   // If the current ast context has no type checker, create one for it.
   auto *TC = static_cast<TypeChecker*>(DC.getASTContext().getLazyResolver());

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5445,7 +5445,7 @@ bool TypeChecker::isProtocolExtensionUsable(DeclContext *dc, Type type,
 
   // If the type still has parameters, the constrained extension is considered
   // unusable.
-  if (type->hasTypeParameter())
+  if (type->hasTypeParameter() || type->hasTypeVariable())
     return false;
 
   // Set up a constraint system where we open the generic parameters of the

--- a/test/Sema/typo_correction.swift
+++ b/test/Sema/typo_correction.swift
@@ -69,3 +69,11 @@ func test_too_many_but_some_better() {
   let match6 = 0
   let x = mtch // expected-error {{use of unresolved identifier 'mtch'}}
 }
+
+// rdar://problem/28387684
+// Don't crash performing typo correction on bound generic types with
+// type variables.
+_ = [Any]().withUnsafeBufferPointer { (buf) -> [Any] in
+  guard let base = buf.baseAddress else { return [] }
+  return (base ..< base + buf.count).m // expected-error {{value of type 'CountableRange<_>' has no member 'm'}}
+}


### PR DESCRIPTION
It's possible some of the asserts will eventually migrate to something
like test-and-return, but at least for now let's ensure that we know
when this is happening.

This is not comprehensive. There are other places we are creating fresh
constraint systems and then creating constraints using type variables
from a pre-existing constraint systems.