### PR TITLE
Add a test for bad diagnostic on '&&'.

### DIFF
--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -737,6 +737,11 @@ extension Foo23752537 {
   }
 }
 
+// <rdar://problem/27391581> QoI: Nonsensical "binary operator '&&' cannot be applied to two 'Bool' operands"
+func rdar27391581(_ a : Int, b : Int) -> Int {
+  return a == b && b != 0
+  // expected-error @-1 {{cannot convert return expression of type 'Bool' to return type 'Int'}}
+}
 
 // <rdar://problem/22276040> QoI: not great error message with "withUnsafePointer" sametype constraints
 func read2(_ p: UnsafeMutableRawPointer, maxLength: Int) {}


### PR DESCRIPTION
This was fixed (probably by dd01b7e184a97b4439f537152114f27d353e54a4),
so we should make sure it doesn't regress in the future.