### PR TITLE
[sil] When printing out SILFunctions add mangled name after closing '{' in a comment.

### DIFF
--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1869,9 +1869,9 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
 
     SILPrinter(PrintCtx, (Aliases.empty() ? nullptr : &Aliases))
         .print(this);
-    OS << "}";
+    OS << "} // end sil function '" << getName() << '\'';
   }
-  
+
   OS << "\n\n";
 }
       

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -1484,7 +1484,8 @@ else:
   %3void = tuple ()
 // CHECK-NEXT: return %5 : $()
   return %3void : $()
-} // CHECK: {{^}$}}
+}
+// CHECK: } // end sil function 'value_names'
 
 class Resource {}
 struct Value { var x: Resource }

--- a/test/SILGen/default_arguments_imported.swift
+++ b/test/SILGen/default_arguments_imported.swift
@@ -11,7 +11,7 @@ func testGizmo(gizmo: Gizmo) {
   // CHECK: class_method [volatile] [[SELF:%[0-9]+]] : $Gizmo, #Gizmo.enumerateSubGizmos!1.foreign
   // CHECK: function_ref @_TFSqCfT10nilLiteralT__GSqx_
   gizmo.enumerateSubGizmos()
-} // CHECK: {{^}$}}
+} // CHECK: } // end sil function '_TF26default_arguments_imported9testGizmoFT5gizmoCSo5Gizmo_T_'
 
 // CHECK-LABEL: sil hidden @_TF26default_arguments_imported21testNonnullDictionaryFT5gizmoCSo5Gizmo_T_
 func testNonnullDictionary(gizmo: Gizmo) {
@@ -19,7 +19,7 @@ func testNonnullDictionary(gizmo: Gizmo) {
   // CHECK-NOT: nilLiteral
   // CHECK: function_ref @_TFVs10DictionaryCft17dictionaryLiteralGSaTxq____GS_xq__
   gizmo.doTheThing()
-} // CHECK: {{^}$}}
+} // CHECK: } // end sil function '_TF26default_arguments_imported21testNonnullDictionaryFT5gizmoCSo5Gizmo_T_'
 
 // CHECK-LABEL: sil hidden @_TF26default_arguments_imported22testNullableDictionaryFT5gizmoCSo5Gizmo_T_
 func testNullableDictionary(gizmo: Gizmo) {
@@ -27,4 +27,4 @@ func testNullableDictionary(gizmo: Gizmo) {
   // CHECK-NOT: dictionaryLiteral
   // CHECK: function_ref @_TFSqCfT10nilLiteralT__GSqx_
   gizmo.doTheOtherThing()
-} // CHECK: {{^}$}}
+} // CHECK: } // end sil function '_TF26default_arguments_imported22testNullableDictionaryFT5gizmoCSo5Gizmo_T_'

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -324,7 +324,7 @@ func testForceTryMultiple() {
 // CHECK: [[CLEANUPS_2]]([[ERROR:%.+]] : $Error):
 // CHECK-NEXT: destroy_value [[VALUE_1]] : $Cat
 // CHECK-NEXT: br [[FAILURE]]([[ERROR]] : $Error)
-// CHECK: {{^}$}}
+// CHECK: } // end sil function '_TF6errors20testForceTryMultipleFT_T_'
 
 // Make sure we balance scopes correctly inside a switch.
 // <rdar://problem/20923654>
@@ -700,7 +700,7 @@ func testForcePeephole(_ f: () throws -> Int?) -> Int {
 // CHECK-NEXT: br [[DONE]]([[NONE]] : $Optional<Cat>)
 // CHECK: [[CLEANUPS]]([[ERROR:%.+]] : $Error):
 // CHECK-NEXT: br [[FAILURE]]([[ERROR]] : $Error)
-// CHECK: {{^}$}}
+// CHECK: } // end sil function '_TF6errors15testOptionalTryFT_T_'
 func testOptionalTry() {
   _ = try? make_a_cat()
 }
@@ -726,7 +726,7 @@ func testOptionalTry() {
 // CHECK-NEXT: br [[DONE]]
 // CHECK: [[CLEANUPS]]([[ERROR:%.+]] : $Error):
 // CHECK-NEXT: br [[FAILURE]]([[ERROR]] : $Error)
-// CHECK: {{^}$}}
+// CHECK: } // end sil function '_TF6errors18testOptionalTryVarFT_T_'
 func testOptionalTryVar() {
   var cat = try? make_a_cat() // expected-warning {{initialization of variable 'cat' was never used; consider replacing with assignment to '_' or removing it}}
 }
@@ -756,7 +756,7 @@ func testOptionalTryVar() {
 // CHECK: [[CLEANUPS]]([[ERROR:%.+]] : $Error):
 // CHECK-NEXT: dealloc_stack [[ARG_BOX]] : $*T
 // CHECK-NEXT: br [[FAILURE]]([[ERROR]] : $Error)
-// CHECK: {{^}$}}
+// CHECK: } // end sil function '_TF6errors26testOptionalTryAddressOnlyurFxT_'
 func testOptionalTryAddressOnly<T>(_ obj: T) {
   _ = try? dont_return(obj)
 }
@@ -786,7 +786,7 @@ func testOptionalTryAddressOnly<T>(_ obj: T) {
 // CHECK: [[CLEANUPS]]([[ERROR:%.+]] : $Error):
 // CHECK-NEXT: dealloc_stack [[ARG_BOX]] : $*T
 // CHECK-NEXT: br [[FAILURE]]([[ERROR]] : $Error)
-// CHECK: {{^}$}}
+// CHECK: } // end sil function '_TF6errors29testOptionalTryAddressOnlyVarurFxT_'
 func testOptionalTryAddressOnlyVar<T>(_ obj: T) {
   var copy = try? dont_return(obj) // expected-warning {{initialization of variable 'copy' was never used; consider replacing with assignment to '_' or removing it}}
 }
@@ -815,7 +815,7 @@ func testOptionalTryAddressOnlyVar<T>(_ obj: T) {
 // CHECK: [[CLEANUPS_2]]([[ERROR:%.+]] : $Error):
 // CHECK-NEXT: destroy_value [[VALUE_1]] : $Cat
 // CHECK-NEXT: br [[FAILURE]]([[ERROR]] : $Error)
-// CHECK: {{^}$}}
+// CHECK: } // end sil function '_TF6errors23testOptionalTryMultipleFT_T_'
 func testOptionalTryMultiple() {
   _ = try? (make_a_cat(), make_a_cat())
 }
@@ -826,7 +826,7 @@ func testOptionalTryMultiple() {
 // CHECK-NEXT:   = enum $Optional<()>, #Optional.some!enumelt.1, [[VALUE]]
 // CHECK-NEXT:   [[VOID:%.+]] = tuple ()
 // CHECK-NEXT:   return [[VOID]] : $()
-// CHECK: {{^}$}}
+// CHECK: } // end sil function '_TF6errors25testOptionalTryNeverFailsFT_T_'
 func testOptionalTryNeverFails() {
   _ = try? () // expected-warning {{no calls to throwing functions occur within 'try' expression}}
 }
@@ -840,7 +840,7 @@ func testOptionalTryNeverFails() {
 // CHECK-NEXT:   destroy_value [[BOX]] : $@box Optional<()>
 // CHECK-NEXT:   [[VOID:%.+]] = tuple ()
 // CHECK-NEXT:   return [[VOID]] : $()
-// CHECK-NEXT: {{^}$}}
+// CHECK-NEXT: } // end sil function '_TF6errors28testOptionalTryNeverFailsVarFT_T_'
 func testOptionalTryNeverFailsVar() {
   var unit: ()? = try? () // expected-warning {{no calls to throwing functions occur within 'try' expression}} expected-warning {{initialization of variable 'unit' was never used; consider replacing with assignment to '_' or removing it}}
 }
@@ -856,7 +856,7 @@ func testOptionalTryNeverFailsVar() {
 // CHECK-NEXT:   destroy_addr %0 : $*T
 // CHECK-NEXT:   [[VOID:%.+]] = tuple ()
 // CHECK-NEXT:   return [[VOID]] : $()
-// CHECK-NEXT: {{^}$}}
+// CHECK-NEXT: } // end sil function '_TF6errors36testOptionalTryNeverFailsAddressOnlyurFxT_'
 func testOptionalTryNeverFailsAddressOnly<T>(_ obj: T) {
   _ = try? obj // expected-warning {{no calls to throwing functions occur within 'try' expression}}
 }
@@ -872,7 +872,7 @@ func testOptionalTryNeverFailsAddressOnly<T>(_ obj: T) {
 // CHECK-NEXT:   destroy_addr %0 : $*T
 // CHECK-NEXT:   [[VOID:%.+]] = tuple ()
 // CHECK-NEXT:   return [[VOID]] : $()
-// CHECK-NEXT: {{^}$}}
+// CHECK: } // end sil function '_TFC6errors13OtherErrorSubCfT_S0_'
 func testOptionalTryNeverFailsAddressOnlyVar<T>(_ obj: T) {
   var copy = try? obj // expected-warning {{no calls to throwing functions occur within 'try' expression}} expected-warning {{initialization of variable 'copy' was never used; consider replacing with assignment to '_' or removing it}}
 }

--- a/test/SILGen/objc_bridged_results.swift
+++ b/test/SILGen/objc_bridged_results.swift
@@ -17,7 +17,7 @@ func testNonnull(_ obj: Test) -> [Any] {
   // CHECK: destroy_value %0 : $Test
   // CHECK: return [[RESULT]] : $Array<Any>
   return obj.nonnullArray
-} // CHECK: {{^}$}}
+} // CHECK: } // end sil function '_TF20objc_bridged_results11testNonnullFCSo4TestGSaP__'
 
 // CHECK-LABEL: sil hidden @_TF20objc_bridged_results12testNullableFCSo4TestGSqGSaP___
 func testNullable(_ obj: Test) -> [Any]? {
@@ -44,7 +44,7 @@ func testNullable(_ obj: Test) -> [Any]? {
   // CHECK: destroy_value %0 : $Test
   // CHECK: return [[RESULT]] : $Optional<Array<Any>>
   return obj.nullableArray
-} // CHECK: {{^}$}}
+} // CHECK: } // end sil function '_TF20objc_bridged_results12testNullableFCSo4TestGSqGSaP___'
 
 // CHECK-LABEL: sil hidden @_TF20objc_bridged_results19testNullUnspecifiedFCSo4TestGSQGSaP___
 func testNullUnspecified(_ obj: Test) -> [Any]! {
@@ -70,7 +70,7 @@ func testNullUnspecified(_ obj: Test) -> [Any]! {
   // CHECK: destroy_value %0 : $Test
   // CHECK: return [[RESULT]] : $Optional<Array<Any>>
   return obj.nullUnspecifiedArray
-} // CHECK: {{^}$}}
+} // CHECK: } // end sil function '_TF20objc_bridged_results19testNullUnspecifiedFCSo4TestGSQGSaP___'
 
 
 // CHECK-LABEL: sil hidden @_TF20objc_bridged_results21testNonnullDictionaryFCSo4TestGVs10DictionaryVs11AnyHashableP__
@@ -83,7 +83,7 @@ func testNonnullDictionary(_ obj: Test) -> [AnyHashable: Any] {
   // CHECK: destroy_value %0 : $Test
   // CHECK: return [[RESULT]] : $Dictionary<AnyHashable, Any>
   return obj.nonnullDictionary
-} // CHECK: {{^}$}}
+} // CHECK: } // end sil function '_TF20objc_bridged_results21testNonnullDictionaryFCSo4TestGVs10DictionaryVs11AnyHashableP__'
 
 // CHECK-LABEL: sil hidden @_TF20objc_bridged_results14testNonnullSetFCSo4TestGVs3SetVs11AnyHashable_
 func testNonnullSet(_ obj: Test) -> Set<AnyHashable> {
@@ -95,7 +95,7 @@ func testNonnullSet(_ obj: Test) -> Set<AnyHashable> {
   // CHECK: destroy_value %0 : $Test
   // CHECK: return [[RESULT]] : $Set<AnyHashable>
   return obj.nonnullSet
-} // CHECK: {{^}$}}
+} // CHECK: } // end sil function '_TF20objc_bridged_results14testNonnullSetFCSo4TestGVs3SetVs11AnyHashable_'
 
 // CHECK-LABEL: sil hidden @_TF20objc_bridged_results17testNonnullStringFCSo4TestSS
 func testNonnullString(_ obj: Test) -> String {
@@ -107,7 +107,7 @@ func testNonnullString(_ obj: Test) -> String {
   // CHECK: destroy_value %0 : $Test
   // CHECK: return [[RESULT]] : $String
   return obj.nonnullString
-} // CHECK: {{^}$}}
+} // CHECK: } // end sil function '_TF20objc_bridged_results17testNonnullStringFCSo4TestSS'
 
 // CHECK-LABEL: sil hidden @_TF20objc_bridged_results13testClassPropFT_SS
 func testClassProp() -> String {
@@ -120,7 +120,7 @@ func testClassProp() -> String {
   // CHECK: [[RESULT:%[0-9]+]] = apply [[CONVERT]]([[COCOA_VAL]], [[STRING_META]]) : $@convention(method) (@owned Optional<NSString>, @thin String.Type) -> @owned String
   // CHECK: return [[RESULT]] : $String
   return Test.nonnullSharedString
-} // CHECK: {{^}$}}
+} // CHECK: } // end sil function '_TF20objc_bridged_results13testClassPropFT_SS'
 
 
 // Note: This doesn't really "work" in that it doesn't accept a nil value the
@@ -136,7 +136,7 @@ func testNonnullSubscript(_ obj: Test) -> [Any] {
   // CHECK: destroy_value %0 : $Test
   // CHECK: return [[RESULT]] : $Array<Any>
   return obj[0]
-} // CHECK: {{^}$}}
+} // CHECK: } // end sil function '_TF20objc_bridged_results20testNonnullSubscriptFCSo4TestGSaP__'
 
 
 // CHECK-LABEL: sil hidden @_TF20objc_bridged_results19testPerformSelectorFCSo8NSObjectT_
@@ -145,4 +145,4 @@ func testPerformSelector(_ obj: NSObject) {
   // CHECK: [[RESULT:%[0-9]+]] = apply [[METHOD]]({{%[0-9]+}}, {{%[0-9]+}}, %0)
   _ = obj.perform("foo", with: nil)
   // CHECK-NOT: {{(retain|release).+}}[[RESULT]]
-} // CHECK: {{^}$}}
+} // CHECK: } // end sil function '_TF20objc_bridged_results19testPerformSelectorFCSo8NSObjectT_'

--- a/test/SILGen/testable-multifile-other.swift
+++ b/test/SILGen/testable-multifile-other.swift
@@ -29,7 +29,7 @@ func test(internalFoo: FooImpl, publicFoo: PublicFooImpl) {
 // CHECK: = apply [[IMPL_1]]<FooImpl>({{%.+}}) : $@convention(method) <τ_0_0 where τ_0_0 : HasDefaultFoo> (@in_guaranteed τ_0_0) -> ()
 // CHECK: [[IMPL_2:%.+]] = function_ref @_TFE23TestableMultifileHelperPS_13HasDefaultFoo3foofT_T_
 // CHECK: = apply [[IMPL_2]]<PublicFooImpl>({{%.+}}) : $@convention(method) <τ_0_0 where τ_0_0 : HasDefaultFoo> (@in_guaranteed τ_0_0) -> ()
-// CHECK: {{^}$}}
+// CHECK: } // end sil function '_TF4main4testFT11internalFooVS_7FooImpl9publicFooVS_13PublicFooImpl_T_'
 
 func test(internalSub: Sub, publicSub: PublicSub) {
   internalSub.foo()
@@ -39,5 +39,5 @@ func test(internalSub: Sub, publicSub: PublicSub) {
 // CHECK-LABEL: sil hidden @_TF4main4testFT11internalSubCS_3Sub9publicSubCS_9PublicSub_T_
 // CHECK: = class_method %0 : $Sub, #Sub.foo!1
 // CHECK: = class_method %1 : $PublicSub, #PublicSub.foo!1
-// CHECK: {{^}$}}
+// CHECK: } // end sil function '_TF4main4testFT11internalSubCS_3Sub9publicSubCS_9PublicSub_T_'
 

--- a/test/SILGen/testable-multifile.swift
+++ b/test/SILGen/testable-multifile.swift
@@ -22,11 +22,11 @@ public struct PublicFooImpl: Fooable, HasDefaultFoo {}
 
 // CHECK-LABEL: sil{{.*}} @_TTWV4main7FooImplS_7FooableS_FS1_3foofT_T_ : $@convention(witness_method) (@in_guaranteed FooImpl) -> () {
 // CHECK: function_ref @_TFE23TestableMultifileHelperPS_13HasDefaultFoo3foofT_T_
-// CHECK: {{^}$}}
+// CHECK: } // end sil function '_TTWV4main7FooImplS_7FooableS_FS1_3foofT_T_'
 
 // CHECK-LABEL: sil{{.*}} @_TTWV4main13PublicFooImplS_7FooableS_FS1_3foofT_T_ : $@convention(witness_method) (@in_guaranteed PublicFooImpl) -> () {
 // CHECK: function_ref @_TFE23TestableMultifileHelperPS_13HasDefaultFoo3foofT_T_
-// CHECK: {{^}$}}
+// CHECK: } // end sil function '_TTWV4main13PublicFooImplS_7FooableS_FS1_3foofT_T_'
 
 private class PrivateSub: Base {
   fileprivate override func foo() {}

--- a/test/SILOptimizer/cast_promote.sil
+++ b/test/SILOptimizer/cast_promote.sil
@@ -82,13 +82,13 @@ bb0(%0 : $*NativeProto, %1 : $AnyObject):
 
 class B {}
 
-// CHECK-LABEL: sil @load_unchecked_addr_cast_to_unchecked_ref_cast_load : $@convention(thin) (@inout Optional<B>) -> (Builtin.NativeObject, Optional<Builtin.NativeObject>) {
+// CHECK-LABEL: sil @load_uncheckedaddrcast_to_uncheckedrefcast_load : $@convention(thin) (@inout Optional<B>) -> (Builtin.NativeObject, Optional<Builtin.NativeObject>) {
 // CHECK-NOT: unchecked_addr_cast
 // CHECK: unchecked_ref_cast
 // CHECK-NOT: unchecked_addr_cast
 // CHECK: unchecked_ref_cast
 // CHECK-NOT: unchecked_addr_cast
-sil @load_unchecked_addr_cast_to_unchecked_ref_cast_load : $@convention(thin) (@inout Optional<B>) -> (Builtin.NativeObject, Optional<Builtin.NativeObject>) {
+sil @load_uncheckedaddrcast_to_uncheckedrefcast_load : $@convention(thin) (@inout Optional<B>) -> (Builtin.NativeObject, Optional<Builtin.NativeObject>) {
 bb0(%0 : $*Optional<B>):
   %1 = unchecked_addr_cast %0 : $*Optional<B> to $*Builtin.NativeObject
   %2 = unchecked_addr_cast %0 : $*Optional<B> to $*Optional<Builtin.NativeObject>

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -1465,9 +1465,9 @@ sil @generic_call_with_indirect_result : $@convention(thin) <T> (@in T) -> @out 
 sil @generic_call_without_indirect_result : $@convention(thin) <T> (@in T) -> Bool
 sil @generic_call_with_direct_result : $@convention(thin) <T> (T) -> T
 
-// CHECK-LABEL: sil @generic_partial_apply : $@convention(thin) () -> () {
+// CHECK-LABEL: sil @generic_partialapply : $@convention(thin) () -> () {
 // CHECK-NOT: partial_apply
-sil @generic_partial_apply : $@convention(thin) () -> () {
+sil @generic_partialapply : $@convention(thin) () -> () {
 bb0:
   %0 = function_ref @generic_call_with_indirect_result : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
   %1 = function_ref @generic_call_without_indirect_result : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Bool
@@ -1806,12 +1806,12 @@ struct FakeInt32 {
   var val : Builtin.Int32
 }
 
-// CHECK-LABEL: sil @loadable_switch_enum_addr_promotion : $@convention(thin) (@in FakeOptional<Builtin.RawPointer>) -> () {
+// CHECK-LABEL: sil @loadable_switchenumaddr_promotion : $@convention(thin) (@in FakeOptional<Builtin.RawPointer>) -> () {
 // CHECK-NOT: switch_enum_addr
 // CHECK: load
 // CHECK-NEXT: switch_enum
 // CHECK-NOT: switch_enum_addr
-sil @loadable_switch_enum_addr_promotion : $@convention(thin) (@in FakeOptional<Builtin.RawPointer>) -> () {
+sil @loadable_switchenumaddr_promotion : $@convention(thin) (@in FakeOptional<Builtin.RawPointer>) -> () {
 bb0(%0 : $*FakeOptional<Builtin.RawPointer>):
   switch_enum_addr %0 : $*FakeOptional<Builtin.RawPointer>, case #FakeOptional.some!enumelt.1: bb1, case #FakeOptional.none!enumelt: bb2
 

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -649,8 +649,8 @@ class C {
   init(v: Int32)
 }
 
-// CHECK-LABEL: @redundant_switch_enum
-sil @redundant_switch_enum : $@convention(thin) (@owned Optional<C>) -> Int32 {
+// CHECK-LABEL: @redundant_switchenum
+sil @redundant_switchenum : $@convention(thin) (@owned Optional<C>) -> Int32 {
 bb0(%0 : $Optional<C>):
   switch_enum %0 : $Optional<C>, case #Optional.some!enumelt.1: bb1, case #Optional.none!enumelt: bb2
 

--- a/test/SILOptimizer/unreachable_dealloc_stack.sil
+++ b/test/SILOptimizer/unreachable_dealloc_stack.sil
@@ -12,8 +12,8 @@ class TheClass {}
 // an undef operand, but that we do later remove it in the diagnostics
 // passes.
 
-// CHECK-LABEL: sil @unreachable_dealloc_stack
-sil @unreachable_dealloc_stack: $@convention(method) (@guaranteed TheClass) -> () {
+// CHECK-LABEL: sil @unreachable_deallocstack
+sil @unreachable_deallocstack: $@convention(method) (@guaranteed TheClass) -> () {
 bb0(%0 : $TheClass):
   %1 = function_ref @nada : $@convention(c) (Builtin.Int32) -> Never
   %2 = integer_literal $Builtin.Int32, 0

--- a/test/Serialization/Inputs/def_basic_objc.sil
+++ b/test/Serialization/Inputs/def_basic_objc.sil
@@ -18,7 +18,7 @@ bb0(%0 : $@thick NSObject.Type):
 
   %void = tuple ()
   return %void : $()
-} // CHECK: {{^}$}}
+} // CHECK: } // end sil function 'objc_classes'
 
 class Bas : NSObject {
   var strRealProp : String


### PR DESCRIPTION
[sil] When printing out SILFunctions add mangled name after the closing brace of the SILFunction.

This ensures that we can write FileCheck patterns that match the end of sil
functions. Just using a FileCheck pattern against a brace is not sufficient in
the context of checking the SIL emitted by SILGen. This is because we could match a
different function's body and match the closing brace against the other
function's end brace.

With this change, one can be specific by checking:

// CHECK: } {{.*}} end sil function '<mangled name>'

The inspiration for this change is rdar://28685236. While updating SILGen tests
for that I have found many instances of SILGen tests pattern matching against
the wrong function bodies. This change will allow me to eliminate these problems
robustly.

rdar://29077869