### PR TITLE
Fix crash in member lookup when base type contains type variables.

### DIFF
--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -718,7 +718,8 @@ public:
     // Does it make sense to substitute types?
     bool shouldSubst = !BaseTy->hasUnboundGenericType() &&
                        !isa<AnyMetatypeType>(BaseTy.getPointer()) &&
-                       !BaseTy->isAnyExistentialType();
+                       !BaseTy->isAnyExistentialType() &&
+                       !BaseTy->hasTypeVariable();
     ModuleDecl *M = DC->getParentModule();
 
     auto FoundSignature = VD->getOverloadSignature();

--- a/test/Sema/typo_correction.swift
+++ b/test/Sema/typo_correction.swift
@@ -69,3 +69,11 @@ func test_too_many_but_some_better() {
   let match6 = 0
   let x = mtch // expected-error {{use of unresolved identifier 'mtch'}}
 }
+
+// rdar://problem/28387684
+// Don't crash performing typo correction on bound generic types with
+// type variables.
+_ = [Any]().withUnsafeBufferPointer { (buf) -> [Any] in
+  guard let base = buf.baseAddress else { return [] }
+  return (base ..< base + buf.count).m // expected-error {{value of type 'CountableRange<_>' has no member 'm'}}
+}

--- a/validation-test/IDE/crashers/109-swift-constraints-constraintgraph-change-addedtypevariable.swift
+++ b/validation-test/IDE/crashers/109-swift-constraints-constraintgraph-change-addedtypevariable.swift
@@ -1,4 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
-assert(Range.b
-v#^A^#

--- a/validation-test/IDE/crashers_fixed/109-swift-constraints-constraintgraph-change-addedtypevariable.swift
+++ b/validation-test/IDE/crashers_fixed/109-swift-constraints-constraintgraph-change-addedtypevariable.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+assert(Range.b
+v#^A^#

--- a/validation-test/compiler_crashers_fixed/28422-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/28422-swift-genericfunctiontype-get.swift
@@ -5,7 +5,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
 func d<T{
 var d


### PR DESCRIPTION
We were crashing during performTypoCorrection if the base type contained
type variables.

rdar://problem/28387684