### PR TITLE
[Type checker] Use DependentMemberType instead of type variables for nested types.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -121,11 +121,6 @@ enum class KnownFoundationEntity {
 /// entity name.
 Optional<KnownFoundationEntity> getKnownFoundationEntity(StringRef name);
 
-/// Callback function used when referring to a type member of a given
-/// type variable.
-typedef std::function<Type(TypeVariableType *, AssociatedTypeDecl *)>
-  GetTypeVariableMemberCallback;
-
 /// \brief Introduces a new constraint checker arena, whose lifetime is
 /// tied to the lifetime of this RAII object.
 class ConstraintCheckerArenaRAII {
@@ -142,8 +137,7 @@ public:
   /// \param allocator The allocator used for allocating any data that
   /// goes into the constraint checker arena.
   ConstraintCheckerArenaRAII(ASTContext &self,
-                             llvm::BumpPtrAllocator &allocator,
-                             GetTypeVariableMemberCallback getTypeMember);
+                             llvm::BumpPtrAllocator &allocator);
 
   ConstraintCheckerArenaRAII(const ConstraintCheckerArenaRAII &) = delete;
   ConstraintCheckerArenaRAII(ConstraintCheckerArenaRAII &&) = delete;
@@ -519,13 +513,6 @@ public:
   const CanType TheIEEE128Type;           /// 128-bit IEEE floating point
   const CanType ThePPC128Type;            /// 128-bit PowerPC 2xDouble
   
-  /// Retrieve a type member of the given base type variable.
-  ///
-  /// Note that this routine is only usable when a constraint system
-  /// is active.
-  Type getTypeVariableMemberType(TypeVariableType *baseTypeVar, 
-                                 AssociatedTypeDecl *assocType);
-
   /// Adds a search path to SearchPathOpts, unless it is already present.
   ///
   /// Does any proper bookkeeping to keep all module loaders up to date as well.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1386,6 +1386,15 @@ ASTContext::getBehaviorConformance(Type conformingType,
   auto conformance = new (*this, AllocationArena::Permanent)
     NormalProtocolConformance(conformingType, conformingInterfaceType,
                               protocol, loc, storage, state);
+
+  if (auto nominal = conformingInterfaceType->getAnyNominal()) {
+    // Note: this is an egregious hack. The conformances need to be associated
+    // with the actual storage declarations.
+    SmallVector<ProtocolConformance *, 2> conformances;
+    if (!nominal->lookupConformance(nominal->getModuleContext(), protocol,
+                                    conformances))
+      nominal->registerProtocolConformance(conformance);
+  }
   return conformance;
 }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1690,17 +1690,11 @@ namespace {
                        locator);
       
       // Its subexpression should be convertible to a tuple (T.Element...).
-      // FIXME: We should really go through the conformance above to extract
-      // the element type, rather than just looking for the element type.
-      // FIXME: Member constraint is still weird here.
-      ConstraintLocatorBuilder builder(locator);
-      auto arrayElementTy = CS.getMemberType(arrayTy, elementAssocTy,
-                                             builder.withPathElement(
-                                               ConstraintLocator::Member),
-                                             /*options=*/0);
+      Type arrayElementTy = DependentMemberType::get(arrayTy, elementAssocTy);
 
       // Introduce conversions from each element to the element type of the
       // array.
+      ConstraintLocatorBuilder builder(locator);
       unsigned index = 0;
       for (auto element : expr->getElements()) {
         CS.addConstraint(ConstraintKind::Conversion,
@@ -1758,18 +1752,10 @@ namespace {
 
       // Its subexpression should be convertible to a tuple ((T.Key,T.Value)...).
       ConstraintLocatorBuilder locatorBuilder(locator);
-      auto dictionaryKeyTy = CS.getMemberType(dictionaryTy,
-                                              keyAssocTy,
-                                              locatorBuilder.withPathElement(
-                                                ConstraintLocator::Member),
-                                              /*options=*/0);
-      /// FIXME: ArrayElementType is a total hack here.
-      auto dictionaryValueTy = CS.getMemberType(dictionaryTy,
-                                                valueAssocTy,
-                                                locatorBuilder.withPathElement(
-                                                  ConstraintLocator::ArrayElementType),
-                                                /*options=*/0);
-      
+      auto dictionaryKeyTy = DependentMemberType::get(dictionaryTy,
+                                                      keyAssocTy);
+      auto dictionaryValueTy = DependentMemberType::get(dictionaryTy,
+                                                        valueAssocTy);
       TupleTypeElt tupleElts[2] = { TupleTypeElt(dictionaryKeyTy),
                                     TupleTypeElt(dictionaryValueTy) };
       Type elementTy = TupleType::get(tupleElts, C);

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -30,6 +30,7 @@ using namespace constraints;
 #define JOIN(X,Y) JOIN2(X,Y)
 #define JOIN2(X,Y) X##Y
 STATISTIC(NumSolutionAttempts, "# of solution attempts");
+STATISTIC(TotalNumTypeVariables, "# of type variables created");
 
 #define CS_STATISTIC(Name, Description) \
   STATISTIC(JOIN2(Overall,Name), Description);
@@ -41,6 +42,16 @@ STATISTIC(NumSolutionAttempts, "# of solution attempts");
   STATISTIC(JOIN2(Largest,Name), Description);
 #include "ConstraintSolverStats.def"
 STATISTIC(LargestSolutionAttemptNumber, "# of the largest solution attempt");
+
+TypeVariableType *ConstraintSystem::createTypeVariable(
+                                     ConstraintLocator *locator,
+                                     unsigned options) {
+  ++TotalNumTypeVariables;
+  auto tv = TypeVariableType::getNew(TC.Context, assignTypeVariableID(),
+                                     locator, options);
+  addTypeVariable(tv);
+  return tv;
+}
 
 /// \brief Check whether the given type can be used as a binding for the given
 /// type variable.

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -215,19 +215,6 @@ void ConstraintGraphNode::removeFixedBinding(TypeVariableType *typeVar) {
   });
 }
 
-TypeVariableType *
-ConstraintGraphNode::getMemberType(Identifier name,
-                                   std::function<TypeVariableType *()> create) {
-  auto known = MemberTypeIndex.find(name);
-  if (known != MemberTypeIndex.end())
-    return MemberTypes[known->second].second;
-
-  auto memberType = create();
-  MemberTypeIndex.insert({name, MemberTypes.size()});
-  MemberTypes.push_back({name, memberType});
-  return memberType;
-}
-
 #pragma mark Graph scope management
 ConstraintGraphScope::ConstraintGraphScope(ConstraintGraph &CG)
   : CG(CG), ParentScope(CG.ActiveScope), NumChanges(CG.Changes.size())
@@ -292,16 +279,6 @@ ConstraintGraph::Change::boundTypeVariable(TypeVariableType *typeVar,
   return result;
 }
 
-ConstraintGraph::Change
-ConstraintGraph::Change::addedMemberType(TypeVariableType *typeVar,
-                                         Identifier name) {
-  Change result;
-  result.Kind = ChangeKind::AddedMemberType;
-  result.MemberType.TypeVar = typeVar;
-  result.MemberType.Name = name;
-  return result;
-}
-
 void ConstraintGraph::Change::undo(ConstraintGraph &cg) {
   /// Temporarily change the active scope to null, so we don't record
   /// any changes made while performing the undo operation.
@@ -332,27 +309,6 @@ void ConstraintGraph::Change::undo(ConstraintGraph &cg) {
   case ChangeKind::BoundTypeVariable:
     cg.unbindTypeVariable(Binding.TypeVar, Binding.FixedType);
     break;
-
-  case ChangeKind::AddedMemberType: {
-    auto &node = cg[MemberType.TypeVar];
-
-    // Erase the member type entry from the 
-    auto known = node.MemberTypeIndex.find(MemberType.Name);
-    assert(known != node.MemberTypeIndex.end() && "Constraint graph corrupted");
-    unsigned index = known->second;
-    node.MemberTypeIndex.erase(known);
-
-    // If this was not the last member type, swap it with the last
-    // member type.
-    if (index != node.MemberTypes.size()-1) {
-      node.MemberTypes[index] = node.MemberTypes.back();
-      node.MemberTypeIndex[node.MemberTypes[index].first] = index;
-    }
-     
-    // Pop off the last member type.
-    node.MemberTypes.pop_back();
-    break;
-  }
   }
 }
 
@@ -424,21 +380,6 @@ void ConstraintGraph::removeConstraint(Constraint *constraint) {
     Changes.push_back(Change::removedConstraint(constraint));
 }
 
-TypeVariableType *ConstraintGraph::getMemberType(
-                    TypeVariableType *typeVar,
-                    Identifier name,
-                    std::function<TypeVariableType *()> create) {
-  auto repTypeVar = CS.getRepresentative(typeVar);
-  auto &node = (*this)[repTypeVar];
-  
-  return node.getMemberType(name, [&]() {
-    auto memberTypeVar = create();  
-    if (ActiveScope)
-      Changes.push_back(Change::addedMemberType(repTypeVar, name));
-    return memberTypeVar;
-  });
-}
-
 void ConstraintGraph::mergeNodes(TypeVariableType *typeVar1, 
                                  TypeVariableType *typeVar2) {
   assert(CS.getRepresentative(typeVar1) == CS.getRepresentative(typeVar2) &&
@@ -462,44 +403,6 @@ void ConstraintGraph::mergeNodes(TypeVariableType *typeVar1,
   // Merge equivalence class from the non-representative type variable.
   auto &nonRepNode = (*this)[typeVarNonRep];
   repNode.addToEquivalenceClass(nonRepNode.getEquivalenceClassUnsafe());
-
-  // Merge member types.
-  for (auto newEquivTypeVar : nonRepNode.getEquivalenceClassUnsafe()) {
-    auto &newEquivNode = newEquivTypeVar == typeVarNonRep
-                           ? nonRepNode
-                           : (*this)[newEquivTypeVar];
-    for (auto memberType : newEquivNode.MemberTypes) {
-      auto repKnown = repNode.MemberTypeIndex.find(memberType.first);
-      if (repKnown == repNode.MemberTypeIndex.end()) {
-        // We haven't seen this member type before. Add it.
-        repNode.MemberTypeIndex.insert({memberType.first, 
-                                        repNode.MemberTypes.size()});
-        repNode.MemberTypes.push_back(memberType);
-        if (ActiveScope)
-          Changes.push_back(Change::addedMemberType(typeVarRep, 
-                                                    memberType.first));
-        continue;
-      }
-
-      // We have seen this member before. If the type variables are
-      // the same, do nothing. This is a fast-patch check.
-      auto repMemberTypeVar = repNode.MemberTypes[repKnown->second].second;
-      if (repMemberTypeVar == memberType.second)
-        continue;
-
-      // Find the representatives for the member type variables.
-      repMemberTypeVar = CS.getRepresentative(repMemberTypeVar);
-      auto otherMemberTypeVar = CS.getRepresentative(memberType.second);
-
-      // If the representatives are equivalent, do nothing.
-      if (repMemberTypeVar == otherMemberTypeVar)
-        continue;
-
-      // We have two different type variables representing the same
-      // member type; merge them.
-      CS.mergeEquivalenceClasses(repMemberTypeVar, otherMemberTypeVar);
-    }
-  }
 }
 
 void ConstraintGraph::bindTypeVariable(TypeVariableType *typeVar, Type fixed) {
@@ -513,6 +416,8 @@ void ConstraintGraph::bindTypeVariable(TypeVariableType *typeVar, Type fixed) {
   auto &node = (*this)[typeVar];
   for (auto otherTypeVar : typeVars) {
     if (knownTypeVars.insert(otherTypeVar).second) {
+      if (typeVar == otherTypeVar) continue;
+
       (*this)[otherTypeVar].addFixedBinding(typeVar);
       node.addFixedBinding(otherTypeVar);
     }
@@ -925,19 +830,6 @@ void ConstraintGraphNode::print(llvm::raw_ostream &out, unsigned indent) {
     }
     out << "\n";
   }
-
-  // Print member types.
-  if (!MemberTypes.empty()) {
-    out.indent(indent + 2);
-    out << "Member types:\n";
-    for (auto memberType : MemberTypes) {
-      out.indent(indent + 4);
-      out << memberType.first.str() << " -> ";
-      memberType.second->print(out);
-      out << "\n";
-    }
-    out << "\n";
-  }
 }
 
 void ConstraintGraphNode::dump() {
@@ -1030,11 +922,6 @@ static void printValue(llvm::raw_ostream &os, unsigned value) {
   os << value;
 }
 
-/// Print an identifier value.
-static void printValue(llvm::raw_ostream &os, Identifier value) {
-  os << value.str();
-}
-
 void ConstraintGraphNode::verify(ConstraintGraph &cg) {
 #define require(condition, complaint) _require(condition, complaint, cg, this)
 #define requireWithContext(condition, complaint, context) \
@@ -1069,14 +956,6 @@ void ConstraintGraphNode::verify(ConstraintGraph &cg) {
             "adjacency information should have been removed");
     require(info.second.NumConstraints <= Constraints.size(),
             "adjacency information has higher degree than # of constraints");
-  }
-
-  // Verify that the member types haven't gotten out of sync.
-  for (auto index : MemberTypeIndex) {
-    require(index.second < MemberTypes.size(), 
-            "member type index out-of-range");
-    requireSameValue(index.first, MemberTypes[index.second].first,
-                     "member type index map provides wrong index into vector");
   }
 
   // Based on the constraints we have, build up a representation of what

--- a/lib/Sema/ConstraintGraph.h
+++ b/lib/Sema/ConstraintGraph.h
@@ -122,16 +122,6 @@ private:
   /// Remove a type variable from the fixed-binding relationship.
   void removeFixedBinding(TypeVariableType *typeVar);
 
-  /// Retrieves the member type of this type variable that corresponds
-  /// to the given name.
-  ///
-  /// \param name The name of the type member.
-  ///
-  /// \param create If the member does not already exist, this
-  /// callback will be invoked to create it.
-  TypeVariableType *getMemberType(Identifier name,
-                                  std::function<TypeVariableType *()> create);
-
   /// The type variable this node represents.
   TypeVariableType *TypeVar;
 
@@ -157,14 +147,6 @@ private:
   /// Note that this field is only valid for type variables that
   /// are representatives of their equivalence classes.
   mutable SmallVector<TypeVariableType *, 2> EquivalenceClass;
-
-  /// A set of (name, type variable) pairs representing the member types of 
-  /// the given type variable.
-  llvm::SmallVector<std::pair<Identifier, TypeVariableType *>, 2> MemberTypes;
-
-  /// A mapping from the names of members of this type variable to an
-  /// index into the \c MemberTypes vector.
-  llvm::SmallDenseMap<Identifier, unsigned> MemberTypeIndex;
 
   /// Print this graph node.
   void print(llvm::raw_ostream &out, unsigned indent);
@@ -216,22 +198,6 @@ public:
 
   /// Remove a constraint from the graph.
   void removeConstraint(Constraint *constraint);
-
-  /// Retrieves the member type of a type variable that corresponds to
-  /// the given name.
-  ///
-  /// \param typeVar The type variable.
-  ///
-  /// \param name The name of the type member.
-  ///
-  /// \param create If the member does not already exist, this
-  /// callback will be invoked to create it.
-  ///
-  /// \returns the type variable representing the named member of the
-  /// given type variable.
-  TypeVariableType *getMemberType(TypeVariableType *typeVar,
-                                  Identifier name,
-                                  std::function<TypeVariableType *()> create);
 
   /// Merge the two nodes for the two given type variables.
   ///
@@ -335,8 +301,6 @@ private:
     ExtendedEquivalenceClass,
     /// Added a fixed binding for a type variable.
     BoundTypeVariable,
-    /// Added a member type.
-    AddedMemberType
   };
 
   /// A change made to the constraint graph.
@@ -366,14 +330,6 @@ private:
         /// The fixed type to which the type variable was bound.
         TypeBase *FixedType;
       } Binding;
-
-      struct {
-        /// The type variable whose member type was created.
-        TypeVariableType *TypeVar;
-
-        /// The name of the member.
-        Identifier Name;
-      } MemberType;
     };
 
   public:
@@ -394,9 +350,6 @@ private:
 
     /// Create a change that bound a type variable to a fixed type.
     static Change boundTypeVariable(TypeVariableType *typeVar, Type fixed);
-
-    /// Create a change that added a member type with the given name.
-    static Change addedMemberType(TypeVariableType *typeVar, Identifier name);
 
     /// Undo this change, reverting the constraint graph to the state it
     /// had prior to this change.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -26,12 +26,7 @@ using namespace constraints;
 ConstraintSystem::ConstraintSystem(TypeChecker &tc, DeclContext *dc,
                                    ConstraintSystemOptions options)
   : TC(tc), DC(dc), Options(options),
-    Arena(tc.Context, Allocator, 
-          [&](TypeVariableType *baseTypeVar, AssociatedTypeDecl *assocType) {
-            return getMemberType(baseTypeVar, assocType,
-                                 ConstraintLocatorBuilder(nullptr),
-                                 /*options=*/0);
-          }),
+    Arena(tc.Context, Allocator),
     CG(*new ConstraintGraph(*this))
 {
   assert(DC && "context required");
@@ -346,13 +341,6 @@ ConstraintLocator *ConstraintSystem::getConstraintLocator(
   SmallVector<LocatorPathElt, 4> path;
   Expr *anchor = builder.getLocatorParts(path);
   return getConstraintLocator(anchor, path, builder.getSummaryFlags());
-}
-
-Type ConstraintSystem::getMemberType(TypeVariableType *baseTypeVar,
-                                     AssociatedTypeDecl *assocType,
-                                     ConstraintLocatorBuilder locator,
-                                     unsigned options) {
-  return DependentMemberType::get(baseTypeVar, assocType);
 }
 
 namespace {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1578,7 +1578,7 @@ Type Solution::simplifyType(TypeChecker &tc, Type type) const {
       return known->second;
     }
 
-        // If this is a dependent member type for which we end up simplifying
+    // If this is a dependent member type for which we end up simplifying
     // the base to a non-type-variable, perform lookup.
     if (auto depMemTy = type->getAs<DependentMemberType>()) {
       // Simplify the base.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1485,10 +1485,10 @@ public:
   /// a new type is created.
   ///
   /// \returns the type variable representing the member type.
-  TypeVariableType *getMemberType(TypeVariableType *baseTypeVar, 
-                                  AssociatedTypeDecl *assocType,
-                                  ConstraintLocatorBuilder locator,
-                                  unsigned options);
+  Type getMemberType(TypeVariableType *baseTypeVar,
+                     AssociatedTypeDecl *assocType,
+                     ConstraintLocatorBuilder locator,
+                     unsigned options);
 
   /// Retrieve the list of inactive constraints.
   ConstraintList &getConstraints() { return InactiveConstraints; }

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1472,24 +1472,6 @@ public:
     InactiveConstraints.erase(constraint);
   }
 
-  /// Retrieve the type that corresponds to the given member of the
-  /// given base type, which may be a newly-created type variable.
-  ///
-  /// \param baseTypeVar The base type variable whose member is being queried.
-  ///
-  /// \param assocType The associated type we're referencing.
-  ///
-  /// \param locator The location used to describe this member access.
-  ///
-  /// \param options Options to be supplied to type variable creation if 
-  /// a new type is created.
-  ///
-  /// \returns the type variable representing the member type.
-  Type getMemberType(TypeVariableType *baseTypeVar,
-                     AssociatedTypeDecl *assocType,
-                     ConstraintLocatorBuilder locator,
-                     unsigned options);
-
   /// Retrieve the list of inactive constraints.
   ConstraintList &getConstraints() { return InactiveConstraints; }
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1203,12 +1203,7 @@ public:
 
   /// \brief Create a new type variable.
   TypeVariableType *createTypeVariable(ConstraintLocator *locator,
-                                       unsigned options) {
-    auto tv = TypeVariableType::getNew(TC.Context, assignTypeVariableID(),
-                                       locator, options);
-    addTypeVariable(tv);
-    return tv;
-  }
+                                       unsigned options);
 
   /// Retrieve the set of active type variables.
   ArrayRef<TypeVariableType *> getTypeVariables() const {

--- a/test/Constraints/array_literal.swift
+++ b/test/Constraints/array_literal.swift
@@ -158,3 +158,17 @@ func joinWithNil(s: String) {
   let a4 = [nil, "hello"]
   let _: Int = a4 // expected-error{{value of type '[String?]'}}
 }
+
+struct OptionSetLike : ExpressibleByArrayLiteral {
+  typealias Element = OptionSetLike
+  init() { }
+
+  init(arrayLiteral elements: OptionSetLike...) { }
+
+  static let option: OptionSetLike = OptionSetLike()
+}
+
+func testOptionSetLike(b: Bool) {
+  let _: OptionSetLike = [ b ? [] : OptionSetLike.option, OptionSetLike.option]
+  let _: OptionSetLike = [ b ? [] : .option, .option]
+}

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -286,7 +286,7 @@ func rdar21078316() {
 
 // <rdar://problem/20978044> QoI: Poor diagnostic when using an incorrect tuple element in a closure
 var numbers = [1, 2, 3]
-zip(numbers, numbers).filter { $0.2 > 1 }  // expected-error {{value of tuple type '(Int, Int)' has no member '2'}}
+zip(numbers, numbers).filter { $0.2 > 1 }  // expected-error {{contextual closure type '(Int, Int) -> Bool' expects 2 arguments, but 1 was used in closure body}}
 
 
 

--- a/test/NameBinding/reference-dependencies.swift
+++ b/test/NameBinding/reference-dependencies.swift
@@ -93,7 +93,7 @@ func <(lhs: IntWrapper, rhs: IntWrapper) -> Bool {
 prefix func ***(lhs: IntWrapper) {}
 
 // This is provided as an operator but not implemented here.
-prefix operator ^^^ {}
+prefix operator ^^^
 
 // CHECK-DAG: "ClassFromOtherFile"
 class Subclass : ClassFromOtherFile {}
@@ -126,9 +126,9 @@ protocol ExpressibleByExtraFloatLiteral
 private protocol ExpressibleByExtraCharLiteral : ExpressibleByUnicodeScalarLiteral {
 }
 
-prefix operator ~~~ {}
+prefix operator ~~~
 protocol ThreeTilde {
-  prefix func ~~~(lhs: Self)
+  prefix static func ~~~(lhs: Self)
 }
 
 private struct ThreeTildeTypeImpl : ThreeTilde {
@@ -141,7 +141,7 @@ func overloadedOnProto<T: ThreeTilde>(_: T) {}
 private prefix func ~~~(_: ThreeTildeTypeImpl) {}
 
 // CHECK-DAG: - "~~~~"
-prefix operator ~~~~ {}
+prefix operator ~~~~
 protocol FourTilde {
   prefix static func ~~~~(arg: Self)
 }
@@ -405,13 +405,9 @@ struct Sentinel2 {}
 // CHECK-DAG: - ["Ps25ExpressibleByFloatLiteral", ""]
 // CHECK-DAG: - !private ["Ps33ExpressibleByUnicodeScalarLiteral", ""]
 // CHECK-DAG: - !private ["Ps10Strideable", "Stride"]
-// CHECK-DAG: - !private ["Sa", "Element"]
 // CHECK-DAG: - !private ["Sa", "reduce"]
 // CHECK-DAG: - !private ["Sb", "_getBuiltinLogicValue"]
 // CHECK-DAG: - ["Sb", "InnerToBool"]
-// CHECK-DAG: - !private ["Vs10Dictionary", "Key"]
-// CHECK-DAG: - !private ["Vs10Dictionary", "Value"]
-// CHECK-DAG: - !private ["V4main17OtherFileIntArray", "Iterator"]
 // CHECK-DAG: - !private ["V4main17OtherFileIntArray", "deinit"]
 // CHECK-DAG: - !private ["V4main18OtherFileOuterType", "InnerType"]
 // CHECK-DAG: - !private ["VV4main18OtherFileOuterType9InnerType", "init"]
@@ -419,9 +415,7 @@ struct Sentinel2 {}
 // CHECK-DAG: - !private ["VV4main26OtherFileSecretTypeWrapper10SecretType", "constant"]
 // CHECK-DAG: - !private ["V4main25OtherFileProtoImplementor", "deinit"]
 // CHECK-DAG: - !private ["V4main26OtherFileProtoImplementor2", "deinit"]
-// CHECK-DAG: - !private ["Vs13EmptyIterator", "Element"]
 // CHECK-DAG: - !private ["Vs13EmptyIterator", "init"]
-// CHECK-DAG: - !private ["Vs16IndexingIterator", "Element"]
 // CHECK-DAG: - ["O4main13OtherFileEnum", "Value"]
 // CHECK-DAG: - !private ["V4main20OtherFileEnumWrapper", "Enum"]
 
@@ -451,7 +445,6 @@ struct Sentinel2 {}
 // CHECK-DAG: !private "Ps10Strideable"
 // CHECK-DAG: !private "Sa"
 // CHECK-DAG: - "Sb"
-// CHECK-DAG: !private "Vs10Dictionary"
 // CHECK-DAG: !private "V4main17OtherFileIntArray"
 // CHECK-DAG: !private "V4main18OtherFileOuterType"
 // CHECK-DAG: !private "VV4main18OtherFileOuterType9InnerType"
@@ -459,7 +452,6 @@ struct Sentinel2 {}
 // CHECK-DAG: !private "V4main25OtherFileProtoImplementor"
 // CHECK-DAG: !private "V4main26OtherFileProtoImplementor2"
 // CHECK-DAG: !private "Vs13EmptyIterator"
-// CHECK-DAG: !private "Vs16IndexingIterator"
 // CHECK-DAG: - "O4main13OtherFileEnum"
 // CHECK-DAG: !private "V4main20OtherFileEnumWrapper"
 // CHECK-DAG: !private "V4main20OtherFileEnumWrapper"

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -221,7 +221,7 @@ func testP4(_ s4a: S4a, s4b: S4b, s4c: S4c, s4d: S4d) {
   s4c.extP4Int() // okay
   var b1 = s4d.extP4a() // okay, "Bool" version
   b1 = true // checks type above
-  s4d.extP4Int() // expected-error{{'Int' is not convertible to 'S4d.AssocP4' (aka 'Bool')}}
+  s4d.extP4Int() // expected-error{{'Bool' is not convertible to 'Int'}}
   _ = b1
 }
 

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -235,7 +235,7 @@ struct WrongIsEqual : IsEqualComparable { // expected-error{{type 'WrongIsEqual'
 //===----------------------------------------------------------------------===//
 
 func existentialSequence(_ e: Sequence) { // expected-error{{has Self or associated type requirements}}
-  var x = e.makeIterator() // expected-error{{'Sequence' is not convertible to '<<error type>>'}}
+  var x = e.makeIterator() // expected-error{{'Sequence' is not convertible to 'Sequence.Iterator'}}
   x.next()
   x.nonexistent()
 }

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar27830834.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar27830834.swift
@@ -1,4 +1,4 @@
 // RUN: %target-swift-frontend %s -parse -verify
 
 var d = [String:String]()
-_ = "\(d.map{ [$0 : $0] })" // expected-error {{type of expression is ambiguous without more context}}
+_ = "\(d.map{ [$0 : $0] })" // expected-error {{contextual closure type specifies '(key: String, value: String)', but 1 was used in closure body, try adding extra parentheses around the single tuple argument}}

--- a/validation-test/compiler_crashers_fixed/28380-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/28380-swift-type-transform.swift
@@ -5,5 +5,5 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 func f<T{{if true as[T.h

--- a/validation-test/compiler_crashers_fixed/28426-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers_fixed/28426-swift-expr-walk.swift
@@ -5,6 +5,5 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
-// REQUIRES: asserts
+// RUN: not %target-swift-frontend %s -parse
 func a<T{if let a<T:T.h{

--- a/validation-test/stdlib/CollectionDiagnostics.swift
+++ b/validation-test/stdlib/CollectionDiagnostics.swift
@@ -65,9 +65,8 @@ struct GoodIndexable : Indexable {
 }
 
 
-// expected-warning@+3 {{'Indexable' is deprecated: it will be removed in Swift 4.0.  Please use 'Collection' instead}}
-// expected-error@+2 {{type 'BadIndexable1' does not conform to protocol '_IndexableBase'}}
-// expected-error@+1 {{type 'BadIndexable1' does not conform to protocol '_Indexable'}}
+// expected-warning@+2 {{'Indexable' is deprecated: it will be removed in Swift 4.0.  Please use 'Collection' instead}}
+// expected-error@+1 {{type 'BadIndexable1' does not conform to protocol '_IndexableBase'}}
 struct BadIndexable1 : Indexable {
   func index(after i: Int) -> Int { return i + 1 }
   var startIndex: Int { return 0 }


### PR DESCRIPTION
In the constraint solver, we've traditionally modeled nested type via
a "type member" constraint of the form

    $T1 = $T0.NameOfTypeMember

and treated $T1 as a type variable. While the solver did generally try
to avoid attempting bindings for $T1 (it would wait until $T0 was
bound, which solves the constraint), on occasion we would get weird
behavior because the solver did try to bind the type
variable.

With this commit, model nested types via DependentMemberType, the same
way we handle (e.g.) the nested type of a generic type parameter. This
solution maintains more information (e.g., we know specifically which
associated type we're referring to), fits in better with the type
system (we know how to deal with dependent members throughout the type
checker, AST, and so on), and is easier to reason able.

This change is a performance optimization for the type checker for a
few reasons. First, it reduces the number of type variables we need to
deal with significantly (we create half as many type variables while
type checking the standard library), and the solver scales poorly with
the number of type variables because it visits all of the
as-yet-unbound type variables at each solving step. Second, it
eliminates a number of redundant by-name lookups in cases where we
already know which associated type we want.

Overall, this change provides a 25% speedup when type-checking the
standard library.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->