### PR TITLE
Do not assume Set/Dictionary are always bound generic types.

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4567,12 +4567,14 @@ void TypeChecker::useObjectiveCBridgeableConformances(DeclContext *dc,
         // of the key type to Hashable.
         if (nominalDecl == TC.Context.getSetDecl() ||
             nominalDecl == TC.Context.getDictionaryDecl()) {
-          auto args = ty->castTo<BoundGenericType>()->getGenericArgs();
-          if (!args.empty()) {
-            auto keyType = args[0];
-            auto *hashableProto =
-              TC.Context.getProtocol(KnownProtocolKind::Hashable);
-            (void)TC.conformsToProtocol(keyType, hashableProto, DC, options);
+          if (auto boundGeneric = ty->getAs<BoundGenericType>()) {
+            auto args = boundGeneric->getGenericArgs();
+            if (!args.empty()) {
+              auto keyType = args[0];
+              auto *hashableProto =
+                TC.Context.getProtocol(KnownProtocolKind::Hashable);
+              (void)TC.conformsToProtocol(keyType, hashableProto, DC, options);
+            }
           }
         }
       }

--- a/validation-test/Sema/type_checker_crashers/rdar28317710.swift
+++ b/validation-test/Sema/type_checker_crashers/rdar28317710.swift
@@ -1,4 +1,0 @@
-// RUN: not --crash %target-swift-frontend %s -parse
-// REQUIRES: OS=macosx
-
-let array = [Dictionary]()

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar28317710.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar28317710.swift
@@ -1,0 +1,4 @@
+// RUN: not %target-swift-frontend %s -parse
+// REQUIRES: OS=macosx
+
+let array = [Dictionary]()


### PR DESCRIPTION
In cases where we cannot infer the types they won't be, so we don't want
to just cast to BoundGenericType when we see these.

Fixes rdar://problem/28317710 and at least one dup (and I think a few
more).