### PR TITLE
[swiftc (97 vs. 5180)] Add crasher in ?

### DIFF
--- a/validation-test/compiler_crashers/28466-segfault-0xc27624-0xc2741f-0xc25bb5-0xbcdbbb.swift
+++ b/validation-test/compiler_crashers/28466-segfault-0xc27624-0xc2741f-0xc25bb5-0xbcdbbb.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{associatedtype b<T>func c:[T


### PR DESCRIPTION
Add test case for crash triggered in `?`.

Current number of unresolved compiler crashers: 97 (5180 resolved)

Stack trace:

```
0  swift           0x00000000031dec28
1  swift           0x00000000031df4a6
2  libpthread.so.0 0x00007f0acf905330
3  swift           0x0000000000dc5ddc
4  swift           0x0000000000c27031
5  swift           0x0000000000c3272c
6  swift           0x0000000000c30dfb
7  swift           0x0000000000c28ee1
8  swift           0x0000000000c28bdd
9  swift           0x0000000000c29cf8
10 swift           0x0000000000c29df4
11 swift           0x0000000000c29bef
12 swift           0x0000000000c28379
13 swift           0x0000000000bd028b
14 swift           0x0000000000bc3656
15 swift           0x0000000000bc3456
16 swift           0x0000000000c22acf
17 swift           0x0000000000c21bf5
18 swift           0x0000000000c221a6
19 swift           0x0000000000c4007c
20 swift           0x0000000000baeb04
21 swift           0x0000000000c22b24
22 swift           0x0000000000c22346
23 swift           0x0000000000c360fa
24 swift           0x0000000000958b26
25 swift           0x00000000004a050e
26 swift           0x00000000004674de
27 libc.so.6       0x00007f0ace0aef45 __libc_start_main + 245
28 swift           0x0000000000464be6
```