### PR TITLE
Restrict scale-test to macosx, avoid breaking simulators.

### DIFF
--- a/validation-test/compiler_scale/scale_neighbouring_getset.gyb
+++ b/validation-test/compiler_scale/scale_neighbouring_getset.gyb
@@ -1,5 +1,5 @@
 // RUN: %scale-test --sum-multi --parse --begin 5 --end 16 --step 5 --select typeCheckAbstractFunctionBody %s
-// REQUIRES: tools-release
+// REQUIRES: OS=macosx, tools-release
 
 struct Struct${N} {
 % if int(N) > 1:


### PR DESCRIPTION
Small fix to restrict test in PR #5588 from running on a simulator (or anything non-macosx).

Breakage occurred in https://ci.swift.org/job/oss-swift_tools-R_stdlib-RD_test-simulator/335/
Tracking in rdar://29090287
