### PR TITLE
Skip lldb tests in Swift smoke test preset

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -831,6 +831,7 @@ dash-dash
 install-foundation
 install-libdispatch
 reconfigure
+skip-test-lldb
 
 
 [preset: buildbot_linux_1404_no_lldb]


### PR DESCRIPTION
Skipping LLDB test suite due to failing tests, which is blocking PR testing. 

```
=============
Issue Details
=============
FAIL: test_fp_register_write_dwarf (functionalities/register/register_command/TestRegisters.py)
FAIL: test_fp_register_write_dwo (functionalities/register/register_command/TestRegisters.py)
FAIL: test_fp_register_write_gmodules (functionalities/register/register_command/TestRegisters.py)
FAIL: test_fp_special_purpose_register_read_dwarf (functionalities/register/register_command/TestRegisters.py)
FAIL: test_fp_special_purpose_register_read_dwo (functionalities/register/register_command/TestRegisters.py)
FAIL: test_fp_special_purpose_register_read_gmodules (functionalities/register/register_command/TestRegisters.py)
FAIL: test_grp_register_save_restore_works_no_suffix_llgs (tools/lldb-server/TestGdbRemoteRegisterState.py)
FAIL: test_grp_register_save_restore_works_with_suffix_llgs (tools/lldb-server/TestGdbRemoteRegisterState.py)
FAIL: test_p_returns_correct_data_size_for_each_qRegisterInfo_attach_llgs (tools/lldb-server/TestLldbGdbServer.py)
FAIL: test_p_returns_correct_data_size_for_each_qRegisterInfo_launch_llgs (tools/lldb-server/TestLldbGdbServer.py)
FAIL: test_register_commands_dwarf (functionalities/register/register_command/TestRegisters.py)
FAIL: test_register_commands_dwo (functionalities/register/register_command/TestRegisters.py)
FAIL: test_register_commands_gmodules (functionalities/register/register_command/TestRegisters.py)
FAIL: test_register_expressions_dwarf (functionalities/register/register_command/TestRegisters.py)
FAIL: test_register_expressions_dwo (functionalities/register/register_command/TestRegisters.py)
FAIL: test_register_expressions_gmodules (functionalities/register/register_command/TestRegisters.py)
FAIL: test_setpgid_dwarf (expression_command/expr-in-syscall/TestExpressionInSyscall.py)
FAIL: test_setpgid_dwarf (functionalities/process_group/TestChangeProcessGroup.py)
FAIL: test_setpgid_dwo (expression_command/expr-in-syscall/TestExpressionInSyscall.py)
FAIL: test_setpgid_dwo (functionalities/process_group/TestChangeProcessGroup.py)
FAIL: test_setpgid_gmodules (functionalities/process_group/TestChangeProcessGroup.py)
FAIL: test_setpgid_gmodules (expression_command/expr-in-syscall/TestExpressionInSyscall.py)
FAIL: test_with_python_dwarf (functionalities/return-value/TestReturnValue.py)
FAIL: test_with_python_dwo (functionalities/return-value/TestReturnValue.py)
FAIL: test_with_python_gmodules (functionalities/return-value/TestReturnValue.py)

```