### PR TITLE
[Compile perf] Add various convenience options to scale-test

### DIFF
--- a/utils/scale-test
+++ b/utils/scale-test
@@ -52,13 +52,34 @@ def run_once_with_primary(args, ast, rng, primary_idx):
         inputs = [write_input_file(args, ast, d, i) for i in rng]
         primary = inputs[primary_idx]
         ofile = os.path.join(d, "out.o")
+
         mode = "-c"
         if args.parse:
             mode = "-parse"
+
+        focus = ["-primary-file", primary]
+        if args.whole_module_optimization:
+            focus = ['-whole-module-optimization']
+
+        opts = []
+        if args.optimize:
+            opts = ['-O']
+        elif args.optimize_none:
+            opts = ['-Onone']
+        elif args.optimize_unchecked:
+            opts = ['-Ounchecked']
+
+        extra = args.Xfrontend[:]
+        if args.debuginfo:
+            extra.append('-g')
+
         command = [args.swiftc_binary,
                    "-frontend", mode,
-                   "-o", ofile,
-                   "-primary-file", primary] + inputs
+                   "-o", ofile] + opts + focus + extra + inputs
+
+        if args.trace:
+            print "running: " + " ".join(command)
+
         if args.dtrace:
             trace = os.path.join(d, "trace.txt")
             script = "pid$target:swiftc:*%s*:entry { @[probefunc] = count() }" % args.select
@@ -164,11 +185,10 @@ def report(args, rng, runs):
         b = 0 if abs(b) < 1e-9 else b
         rows.append((b, k, vals))
     rows.sort()
-    tolerance = 1.2
     for (b, k, vals) in rows:
-        if b >= tolerance:
+        if b >= args.threshold:
             bad = True
-        if not args.quiet or b >= tolerance:
+        if not args.quiet or b >= args.threshold:
             print "O(n^%1.1f) : %s" % (b, k)
             if args.values:
                 print "                = ", vals
@@ -186,20 +206,29 @@ def main():
         '--values', action='store_true',
         default=False, help='print stat values')
     parser.add_argument(
+        '--trace', action='store_true',
+        default=False, help='trace compiler invocations')
+    parser.add_argument(
         '--quiet', action='store_true',
         default=False, help='only print superlinear stats')
     parser.add_argument(
-        '--parse', action='store_true',
+        '--threshold', type=float,
+        default=1.2, help='exponent beyond which to consider "bad scaling"')
+    parser.add_argument(
+        '-parse', '--parse', action='store_true',
         default=False, help='only run compiler with -parse')
+    parser.add_argument(
+        '-g', '--debuginfo', action='store_true',
+        default=False, help='run compiler with -g')
+    parser.add_argument(
+        '-wmo', '--whole-module-optimization', action='store_true',
+        default=False, help='run compiler with -whole-module-optimization')
     parser.add_argument(
         '--dtrace', action='store_true',
         default=False, help='use dtrace to sample all functions')
     parser.add_argument(
-        '--multi-file', action='store_true',
-        default=False, help='vary number of input files as well')
-    parser.add_argument(
-        '--sum-multi', action='store_true',
-        default=False, help='simulate a multi-primary run and sum stats')
+        '-Xfrontend', action='append',
+        default=[], help='pass additional args to frontend jobs')
     parser.add_argument(
         '--begin', type=int,
         default=10, help='first value for N')
@@ -218,6 +247,25 @@ def main():
     parser.add_argument(
         '--debug', action='store_true',
         default=False, help='invoke lldb on each scale test')
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        '-O', '--optimize', action='store_true',
+        default=False, help='run compiler with -O')
+    group.add_argument(
+        '-Onone', '--optimize-none', action='store_true',
+        default=False, help='run compiler with -Onone')
+    group.add_argument(
+        '-Ounchecked', '--optimize-unchecked', action='store_true',
+        default=False, help='run compiler with -Ounchecked')
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        '--multi-file', action='store_true',
+        default=False, help='vary number of input files as well')
+    group.add_argument(
+        '--sum-multi', action='store_true',
+        default=False, help='simulate a multi-primary run and sum stats')
 
     args = parser.parse_args(sys.argv[1:])
     (rng, runs) = run_many(args)


### PR DESCRIPTION
This just adds a handful of options to scale-test to cover some variations in testing that others
suggested when I showed the script for feedback: --threshold to modify the "bad perf" exponent
cutoff, -O/-Onone/-Ounchecked/-g for switching on or off various passes, --trace for watching
the frontend jobs execute, -wmo for running multifile tests in -wmo mode, and -Xfrontend for
passing any remaining arguments I'm not handling directly.
