### PR TITLE
[SILOptimizer] Remove Identity instructions - Peephole in SimplifyInstruction

### DIFF
--- a/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
+++ b/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
@@ -477,9 +477,20 @@ static SILValue simplifyBuiltin(BuiltinInst *BI) {
   switch (Builtin.ID) {
   default: break;
 
+  case BuiltinValueKind::SExtOrBitCast: {
+    const SILValue &Op = Args[0];
+    // extOrBitCast_N_N(x) -> x
+    if (Op->getType() == BI->getType())
+      return Op;
+  }
+  break;
+
   case BuiltinValueKind::TruncOrBitCast: {
     const SILValue &Op = Args[0];
     SILValue Result;
+    // truncOrBitCast_N_N(x) -> x
+    if (Op->getType() == BI->getType())
+      return Op;
     // trunc(extOrBitCast(x)) -> x
     if (match(Op, m_ExtOrBitCast(m_SILValue(Result)))) {
       // Truncated back to the same bits we started with.

--- a/test/SILOptimizer/sil_simplify_instrs.sil
+++ b/test/SILOptimizer/sil_simplify_instrs.sil
@@ -96,6 +96,28 @@ bb0(%x : $Builtin.Word):
 // CHECK: return %0 : $Builtin.Word
 }
 
+// Simplify trunc((x)) -> x with same type
+sil @fold_trunc_n_to_n : $@convention(thin) (Builtin.Int64) -> Builtin.Int64 {
+bb0(%x : $Builtin.Int64):
+  %trunc = builtin "truncOrBitCast_Int64_Word"(%x : $Builtin.Int64) : $Builtin.Int64
+  return %trunc : $Builtin.Int64
+
+// CHECK-LABEL: sil @fold_trunc_n_to_n
+// CHECK-NOT: builtin
+// CHECK: return %0 : $Builtin.Int64
+}
+
+// Simplify sext((x)) -> x with same type
+sil @fold_sext_n_to_n : $@convention(thin) (Builtin.Int64) -> Builtin.Int64 {
+bb0(%x : $Builtin.Int64):
+  %trunc = builtin "sextOrBitCast_Int64_Int64"(%x : $Builtin.Int64) : $Builtin.Int64
+  return %trunc : $Builtin.Int64
+
+// CHECK-LABEL: sil @fold_sext_n_to_n
+// CHECK-NOT: builtin
+// CHECK: return %0 : $Builtin.Int64
+}
+
 class IntClass {
   @sil_stored var value: Builtin.Int32 { get set }
   init(value: Builtin.Int32)


### PR DESCRIPTION
radar rdar://problem/29056555

Encountered patterns of extOrBitCast_Int64_Int64(x) -> x and truncOrBitCast_Int64_Int64(x) -> x

These instructions are basically identity instruction when the two types are the same.

PR adds support for this pattern in SimplifyInstruction + unit test(s)