### PR TITLE
[SourceKit] The initial implementation of range-info request.

### DIFF
--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -195,6 +195,35 @@ private:
   bool visitSubscriptReference(ValueDecl *D, CharSourceRange Range,
                                bool IsOpenBracket) override;
 };
+
+enum class RangeKind : int8_t{
+  Invalid = -1,
+  Expression,
+  SingleStatement,
+};
+
+struct ResolvedRangeInfo {
+  RangeKind Kind;
+  Type Ty;
+  StringRef Content;
+  ResolvedRangeInfo(RangeKind Kind, Type Ty, StringRef Content) : Kind(Kind),
+    Ty(Ty), Content(Content) {}
+};
+
+class RangeResolver : public SourceEntityWalker {
+  struct Implementation;
+  Implementation &Impl;
+  bool walkToExprPre(Expr *E) override;
+  bool walkToExprPost(Expr *E) override;
+  bool walkToStmtPre(Stmt *S) override;
+  bool walkToStmtPost(Stmt *S) override;
+  bool walkToDeclPre(Decl *D, CharSourceRange Range) override;
+  bool walkToDeclPost(Decl *D) override;
+public:
+  RangeResolver(SourceFile &File, SourceLoc Start, SourceLoc End);
+  ResolvedRangeInfo resolve();
+  ~RangeResolver();
+};
 } // namespace ide
 
 } // namespace swift

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -298,6 +298,8 @@ public:
   static SourceLoc getLocForStartOfToken(SourceManager &SM, unsigned BufferID,
                                          unsigned Offset);
 
+  static SourceLoc getLocForStartOfToken(SourceManager &SM, SourceLoc Loc);
+
   /// Retrieve the start location of the line containing the given location.
   /// the given location.
   static SourceLoc getLocForStartOfLine(SourceManager &SM, SourceLoc Loc);

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1901,6 +1901,15 @@ static const char *findStartOfLine(const char *bufStart, const char *current) {
   return current;
 }
 
+SourceLoc Lexer::getLocForStartOfToken(SourceManager &SM, SourceLoc Loc) {
+  Optional<unsigned> BufferIdOp = SM.getIDForBufferIdentifier(SM.
+    getBufferIdentifierForLoc(Loc));
+  if (!BufferIdOp.hasValue())
+    return SourceLoc();
+  return getLocForStartOfToken(SM, BufferIdOp.getValue(),
+    SM.getLocOffsetInBuffer(Loc, BufferIdOp.getValue()));
+}
+
 SourceLoc Lexer::getLocForStartOfToken(SourceManager &SM, unsigned BufferID,
                                        unsigned Offset) {
   CharSourceRange entireRange = SM.getRangeForBuffer(BufferID);

--- a/test/SourceKit/RangeInfo/basic.swift
+++ b/test/SourceKit/RangeInfo/basic.swift
@@ -1,0 +1,37 @@
+func foo() -> Int{
+  var aaa = 1 + 2
+  aaa = aaa + 3
+  if aaa = 3 { aaa = 4 }
+  return aaa
+}
+
+// RUN: %sourcekitd-test -req=range -pos=2:13 -length 5 %s -- %s | %FileCheck %s -check-prefix=CHECK1
+
+// RUN: %sourcekitd-test -req=range -pos=3:3 -length 13 %s -- %s | %FileCheck %s -check-prefix=CHECK2
+// RUN: %sourcekitd-test -req=range -pos=3:1 -length 15 %s -- %s | %FileCheck %s -check-prefix=CHECK2
+
+// RUN: %sourcekitd-test -req=range -pos=4:1 -length 24 %s -- %s | %FileCheck %s -check-prefix=CHECK3
+// RUN: %sourcekitd-test -req=range -pos=4:1 -length 25 %s -- %s | %FileCheck %s -check-prefix=CHECK3
+// RUN: %sourcekitd-test -req=range -pos=4:1 -length 26 %s -- %s | %FileCheck %s -check-prefix=CHECK3
+// RUN: %sourcekitd-test -req=range -pos=4:4 -length 21 %s -- %s | %FileCheck %s -check-prefix=CHECK3
+
+// RUN: %sourcekitd-test -req=range -pos=5:1 -length 12 %s -- %s | %FileCheck %s -check-prefix=CHECK4
+// RUN: %sourcekitd-test -req=range -pos=5:2 -length 11 %s -- %s | %FileCheck %s -check-prefix=CHECK4
+// RUN: %sourcekitd-test -req=range -pos=5:5 -length 8 %s -- %s | %FileCheck %s -check-prefix=CHECK4
+// RUN: %sourcekitd-test -req=range -pos=5:5 -length 9 %s -- %s | %FileCheck %s -check-prefix=CHECK4
+
+// CHECK1-DAG: <kind>source.lang.swift.range.expression</kind>
+// CHECK1-DAG: <content>1 + 2</content>
+// CHECK1-DAG: <type>Int</type>
+
+// CHECK2-DAG: <kind>source.lang.swift.range.expression</kind>
+// CHECK2-DAG: <content>aaa = aaa + 3</content>
+// CHECK2-DAG: <type>()</type>
+
+// CHECK3-DAG: <kind>source.lang.swift.range.singlestatement</kind>
+// CHECK3-DAG: <content>if aaa = 3 { aaa = 4 }</content>
+// CHECK3-DAG: <type></type>
+
+// CHECK4-DAG: <kind>source.lang.swift.range.singlestatement</kind>
+// CHECK4-DAG: <content>return aaa</content>
+// CHECK4-DAG: <type></type>

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -282,6 +282,13 @@ struct CursorInfo {
   bool IsSystem = false;
 };
 
+struct RangeInfo {
+  bool IsCancelled = false;
+  UIdent RangeKind;
+  StringRef ExprType;
+  StringRef RangeContent;
+};
+
 struct RelatedIdentsInfo {
   bool IsCancelled = false;
   /// (Offset,Length) pairs.
@@ -450,6 +457,10 @@ public:
   virtual void getCursorInfo(StringRef Filename, unsigned Offset,
                              ArrayRef<const char *> Args,
                           std::function<void(const CursorInfo &)> Receiver) = 0;
+
+  virtual void getRangeInfo(StringRef Filename, unsigned Offset, unsigned Length,
+                            ArrayRef<const char *> Args,
+                            std::function<void(const RangeInfo&)> Receiver) = 0;
 
   virtual void
   getCursorInfoFromUSR(StringRef Filename, StringRef USR,

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -153,6 +153,9 @@ static UIdent KindStructureElemCondExpr("source.lang.swift.structure.elem.condit
 static UIdent KindStructureElemPattern("source.lang.swift.structure.elem.pattern");
 static UIdent KindStructureElemTypeRef("source.lang.swift.structure.elem.typeref");
 
+static UIdent KindRangeSingleStatement("source.lang.swift.range.singlestatement");
+static UIdent KindRangeExpression("source.lang.swift.range.expression");
+static UIdent KindRangeInvalid("source.lang.swift.range.invalid");
 
 std::unique_ptr<LangSupport>
 SourceKit::createSwiftLangSupport(SourceKit::Context &SKCtx) {
@@ -528,6 +531,14 @@ UIdent SwiftLangSupport::getUIDForSyntaxStructureElementKind(
     case SyntaxStructureElementKind::ConditionExpr: return KindStructureElemCondExpr;
     case SyntaxStructureElementKind::Pattern: return KindStructureElemPattern;
     case SyntaxStructureElementKind::TypeRef: return KindStructureElemTypeRef;
+  }
+}
+SourceKit::UIdent SwiftLangSupport::
+getUIDForRangeKind(swift::ide::RangeKind Kind) {
+  switch (Kind) {
+    case swift::ide::RangeKind::Expression: return KindRangeExpression;
+    case swift::ide::RangeKind::SingleStatement: return KindRangeSingleStatement;
+    case swift::ide::RangeKind::Invalid: return KindRangeInvalid;
   }
 }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -47,6 +47,7 @@ namespace ide {
   enum class SyntaxNodeKind : uint8_t;
   enum class SyntaxStructureKind : uint8_t;
   enum class SyntaxStructureElementKind : uint8_t;
+  enum class RangeKind : int8_t;
   class CodeCompletionConsumer;
 }
 }
@@ -253,6 +254,8 @@ public:
                                            swift::index::SymbolSubKindSet subKinds,
                                            bool isRef);
 
+  static SourceKit::UIdent getUIDForRangeKind(swift::ide::RangeKind Kind);
+
   static std::vector<UIdent> UIDsFromDeclAttributes(const swift::DeclAttributes &Attrs);
 
 
@@ -376,6 +379,10 @@ public:
   void getCursorInfo(StringRef Filename, unsigned Offset,
                      ArrayRef<const char *> Args,
                      std::function<void(const CursorInfo &)> Receiver) override;
+
+  void getRangeInfo(StringRef Filename, unsigned Offset, unsigned Length,
+                    ArrayRef<const char *> Args,
+                    std::function<void(const RangeInfo&)> Receiver) override;
 
   void getCursorInfoFromUSR(
       StringRef Filename, StringRef USR, ArrayRef<const char *> Args,

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -31,6 +31,7 @@
 
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/DeclObjC.h"
+#include "clang/Basic/CharInfo.h"
 #include "clang/Basic/Module.h"
 #include "clang/Index/USRGeneration.h"
 #include "clang/Lex/Lexer.h"
@@ -842,6 +843,82 @@ static bool passCursorInfoForDecl(const ValueDecl *VD,
   return false;
 }
 
+class CursorRangeInfoConsumer : public SwiftASTConsumer {
+protected:
+  SwiftLangSupport &Lang;
+  SwiftInvocationRef ASTInvok;
+  StringRef InputFile;
+  unsigned Offset;
+
+private:
+  const bool TryExistingAST;
+  SmallVector<ImmutableTextSnapshotRef, 4> PreviousASTSnaps;
+
+protected:
+  ArrayRef<ImmutableTextSnapshotRef> getPreviousASTSnaps() {
+    return llvm::makeArrayRef(PreviousASTSnaps);
+  }
+
+public:
+  CursorRangeInfoConsumer(StringRef InputFile, unsigned Offset,
+                          SwiftLangSupport &Lang, SwiftInvocationRef ASTInvok,
+                          bool TryExistingAST)
+    : Lang(Lang), ASTInvok(ASTInvok),InputFile(InputFile), Offset(Offset),
+      TryExistingAST(TryExistingAST) { }
+
+  bool canUseASTWithSnapshots(ArrayRef<ImmutableTextSnapshotRef> Snapshots) override {
+    if (!TryExistingAST) {
+      LOG_INFO_FUNC(High, "will resolve using up-to-date AST");
+      return false;
+    }
+
+    // If there is an existing AST and the offset can be mapped back to the
+    // document snapshot that was used to create it, then use that AST.
+    // The downside is that we may return stale information, but we get the
+    // benefit of increased responsiveness, since the request will not be
+    // blocked waiting on the AST to be fully typechecked.
+
+    ImmutableTextSnapshotRef InputSnap;
+    if (auto EditorDoc = Lang.getEditorDocuments().findByPath(InputFile))
+      InputSnap = EditorDoc->getLatestSnapshot();
+      if (!InputSnap)
+        return false;
+
+    auto mappedBackOffset = [&]()->llvm::Optional<unsigned> {
+      for (auto &Snap : Snapshots) {
+        if (Snap->isFromSameBuffer(InputSnap)) {
+          if (Snap->getStamp() == InputSnap->getStamp())
+            return Offset;
+
+          auto OptOffset = mapOffsetToOlderSnapshot(Offset, InputSnap, Snap);
+          if (!OptOffset.hasValue())
+            return None;
+
+          // Check that the new and old offset still point to the same token.
+          StringRef NewTok = getSourceToken(Offset, InputSnap);
+          if (NewTok.empty())
+            return None;
+          if (NewTok == getSourceToken(OptOffset.getValue(), Snap))
+            return OptOffset;
+
+          return None;
+        }
+      }
+      return None;
+    };
+
+    auto OldOffsetOpt = mappedBackOffset();
+    if (OldOffsetOpt.hasValue()) {
+      Offset = *OldOffsetOpt;
+      PreviousASTSnaps.append(Snapshots.begin(), Snapshots.end());
+      LOG_INFO_FUNC(High, "will try existing AST");
+      return true;
+    }
+
+    LOG_INFO_FUNC(High, "will resolve using up-to-date AST");
+    return false;
+  }
+};
 static void resolveCursor(SwiftLangSupport &Lang,
                           StringRef InputFile, unsigned Offset,
                           SwiftInvocationRef Invok,
@@ -849,14 +926,8 @@ static void resolveCursor(SwiftLangSupport &Lang,
                           std::function<void(const CursorInfo &)> Receiver) {
   assert(Invok);
 
-  class CursorInfoConsumer : public SwiftASTConsumer {
-    std::string InputFile;
-    unsigned Offset;
-    SwiftLangSupport &Lang;
-    SwiftInvocationRef ASTInvok;
-    const bool TryExistingAST;
+  class CursorInfoConsumer : public CursorRangeInfoConsumer {
     std::function<void(const CursorInfo &)> Receiver;
-    SmallVector<ImmutableTextSnapshotRef, 4> PreviousASTSnaps;
 
   public:
     CursorInfoConsumer(StringRef InputFile, unsigned Offset,
@@ -864,65 +935,8 @@ static void resolveCursor(SwiftLangSupport &Lang,
                        SwiftInvocationRef ASTInvok,
                        bool TryExistingAST,
                        std::function<void(const CursorInfo &)> Receiver)
-      : InputFile(InputFile), Offset(Offset),
-        Lang(Lang),
-        ASTInvok(std::move(ASTInvok)),
-        TryExistingAST(TryExistingAST),
-        Receiver(std::move(Receiver)) { }
-
-    bool canUseASTWithSnapshots(
-        ArrayRef<ImmutableTextSnapshotRef> Snapshots) override {
-      if (!TryExistingAST) {
-        LOG_INFO_FUNC(High, "will resolve using up-to-date AST");
-        return false;
-      }
-
-      // If there is an existing AST and the offset can be mapped back to the
-      // document snapshot that was used to create it, then use that AST.
-      // The downside is that we may return stale information, but we get the
-      // benefit of increased responsiveness, since the request will not be
-      // blocked waiting on the AST to be fully typechecked.
-
-      ImmutableTextSnapshotRef InputSnap;
-      if (auto EditorDoc = Lang.getEditorDocuments().findByPath(InputFile))
-        InputSnap = EditorDoc->getLatestSnapshot();
-      if (!InputSnap)
-        return false;
-
-      auto mappedBackOffset = [&]()->llvm::Optional<unsigned> {
-        for (auto &Snap : Snapshots) {
-          if (Snap->isFromSameBuffer(InputSnap)) {
-            if (Snap->getStamp() == InputSnap->getStamp())
-              return Offset;
-
-            auto OptOffset = mapOffsetToOlderSnapshot(Offset, InputSnap, Snap);
-            if (!OptOffset.hasValue())
-              return None;
-
-            // Check that the new and old offset still point to the same token.
-            StringRef NewTok = getSourceToken(Offset, InputSnap);
-            if (NewTok.empty())
-              return None;
-            if (NewTok == getSourceToken(OptOffset.getValue(), Snap))
-              return OptOffset;
-
-            return None;
-          }
-        }
-        return None;
-      };
-
-      auto OldOffsetOpt = mappedBackOffset();
-      if (OldOffsetOpt.hasValue()) {
-        Offset = *OldOffsetOpt;
-        PreviousASTSnaps.append(Snapshots.begin(), Snapshots.end());
-        LOG_INFO_FUNC(High, "will try existing AST");
-        return true;
-      }
-
-      LOG_INFO_FUNC(High, "will resolve using up-to-date AST");
-      return false;
-    }
+    : CursorRangeInfoConsumer(InputFile, Offset, Lang, ASTInvok, TryExistingAST),
+      Receiver(std::move(Receiver)){ }
 
     void handlePrimaryAST(ASTUnitRef AstUnit) override {
       auto &CompIns = AstUnit->getCompilerInstance();
@@ -964,10 +978,10 @@ static void resolveCursor(SwiftLangSupport &Lang,
                                             SemaTok.ContainerType,
                                             SemaTok.ContainerType,
                                             SemaTok.IsRef, BufferID, Lang,
-                                            CompInvok, PreviousASTSnaps,
+                                            CompInvok, getPreviousASTSnaps(),
                                             Receiver);
         if (Failed) {
-          if (!PreviousASTSnaps.empty()) {
+          if (!getPreviousASTSnaps().empty()) {
             // Attempt again using the up-to-date AST.
             resolveCursor(Lang, InputFile, Offset, ASTInvok,
                           /*TryExistingAST=*/false, Receiver);
@@ -997,6 +1011,137 @@ static void resolveCursor(SwiftLangSupport &Lang,
   static const char OncePerASTToken = 0;
   Lang.getASTManager().processASTAsync(Invok, std::move(Consumer), &OncePerASTToken);
 }
+
+static void resolveRange(SwiftLangSupport &Lang,
+                          StringRef InputFile, unsigned Offset, unsigned Length,
+                          SwiftInvocationRef Invok,
+                          bool TryExistingAST,
+                          std::function<void(const RangeInfo&)> Receiver) {
+  assert(Invok);
+
+  class RangeInfoConsumer : public CursorRangeInfoConsumer {
+    unsigned Length;
+    std::function<void(const RangeInfo&)> Receiver;
+
+    static SourceLoc getNonwhitespaceLocBefore(SourceManager &SM,
+                                               unsigned BufferID,
+                                               unsigned Offset) {
+      CharSourceRange entireRange = SM.getRangeForBuffer(BufferID);
+      StringRef Buffer = SM.extractText(entireRange);
+
+      const char *BufStart = Buffer.data();
+      if (Offset >= Buffer.size())
+        return SourceLoc();
+
+      for (unsigned Off = Offset; Off != 0; Off --) {
+        if (!clang::isWhitespace(*(BufStart + Off))) {
+          return SM.getLocForOffset(BufferID, Off);
+        }
+      }
+      return clang::isWhitespace(*BufStart) ? SourceLoc() :
+        SM.getLocForOffset(BufferID, 0);
+    }
+
+    static SourceLoc getNonwhitespaceLocAfter(SourceManager &SM,
+                                              unsigned BufferID,
+                                              unsigned Offset) {
+      CharSourceRange entireRange = SM.getRangeForBuffer(BufferID);
+      StringRef Buffer = SM.extractText(entireRange);
+
+      const char *BufStart = Buffer.data();
+      if (Offset >= Buffer.size())
+        return SourceLoc();
+
+      for (unsigned Off = Offset; Off < Buffer.size(); Off ++) {
+        if (!clang::isWhitespace(*(BufStart + Off))) {
+          return SM.getLocForOffset(BufferID, Off);
+        }
+      }
+      return SourceLoc();
+    }
+
+  public:
+    RangeInfoConsumer(StringRef InputFile, unsigned Offset, unsigned Length,
+                       SwiftLangSupport &Lang, SwiftInvocationRef ASTInvok,
+                       bool TryExistingAST,
+                       std::function<void(const RangeInfo&)> Receiver)
+    : CursorRangeInfoConsumer(InputFile, Offset, Lang, ASTInvok, TryExistingAST),
+      Length(Length), Receiver(std::move(Receiver)){ }
+
+    void handlePrimaryAST(ASTUnitRef AstUnit) override {
+      auto &CompIns = AstUnit->getCompilerInstance();
+
+      unsigned BufferID = AstUnit->getPrimarySourceFile().getBufferID().getValue();
+      SourceManager &SM = CompIns.getSourceMgr();
+      SourceLoc StartLoc = getNonwhitespaceLocAfter(SM, BufferID, Offset);
+      SourceLoc EndLoc = getNonwhitespaceLocBefore(SM, BufferID,
+                                                   Offset + Length - 1);
+
+      StartLoc = Lexer::getLocForStartOfToken(SM, StartLoc);
+      EndLoc = Lexer::getLocForStartOfToken(SM, EndLoc);
+
+      if (StartLoc.isInvalid() || EndLoc.isInvalid()) {
+        Receiver({});
+        return;
+      }
+
+      if (trace::enabled()) {
+        // FIXME: Implement tracing
+      }
+      RangeResolver Resolver(AstUnit->getPrimarySourceFile(), StartLoc, EndLoc);
+      ResolvedRangeInfo Info = Resolver.resolve();
+
+      CompilerInvocation CompInvok;
+      ASTInvok->applyTo(CompInvok);
+      RangeInfo Result;
+      Result.RangeKind = Lang.getUIDForRangeKind(Info.Kind);
+      Result.RangeContent = Info.Content;
+      switch (Info.Kind) {
+      case RangeKind::Expression: {
+        SmallString<64> SS;
+        llvm::raw_svector_ostream OS(SS);
+        Info.Ty.print(OS);
+        Result.ExprType = OS.str();
+        Receiver(Result);
+        return;
+      }
+      case RangeKind::SingleStatement: {
+        Receiver(Result);
+        return;
+      }
+      case RangeKind::Invalid:
+        if (!getPreviousASTSnaps().empty()) {
+          // Attempt again using the up-to-date AST.
+          resolveRange(Lang, InputFile, Offset, Length, ASTInvok,
+                      /*TryExistingAST=*/false, Receiver);
+        } else {
+          Receiver(Result);
+        }
+        return;
+      }
+    }
+
+    void cancelled() override {
+      RangeInfo Info;
+      Info.IsCancelled = true;
+      Receiver(Info);
+    }
+
+    void failed(StringRef Error) override {
+      LOG_WARN_FUNC("range info failed: " << Error);
+      Receiver({});
+    }
+  };
+
+  auto Consumer = std::make_shared<RangeInfoConsumer>(
+    InputFile, Offset, Length, Lang, Invok, TryExistingAST, Receiver);
+  /// FIXME: When request cancellation is implemented and Xcode adopts it,
+  /// don't use 'OncePerASTToken'.
+  static const char OncePerASTToken = 0;
+  Lang.getASTManager().processASTAsync(Invok, std::move(Consumer),
+                                       &OncePerASTToken);
+}
+
 
 void SwiftLangSupport::getCursorInfo(
     StringRef InputFile, unsigned Offset,
@@ -1050,6 +1195,31 @@ void SwiftLangSupport::getCursorInfo(
   }
 
   resolveCursor(*this, InputFile, Offset, Invok, /*TryExistingAST=*/true,
+                Receiver);
+}
+
+void SwiftLangSupport::
+getRangeInfo(StringRef InputFile, unsigned Offset, unsigned Length,
+             ArrayRef<const char *> Args,
+             std::function<void(const RangeInfo&)> Receiver) {
+  if (IFaceGenContexts.get(InputFile)) {
+    // FIXME: return range info for generated interfaces.
+    Receiver(RangeInfo());
+    return;
+  }
+  std::string Error;
+  SwiftInvocationRef Invok = ASTMgr->getInvocation(Args, InputFile, Error);
+  if (!Invok) {
+    // FIXME: Report it as failed request.
+    LOG_WARN_FUNC("failed to create an ASTInvocation: " << Error);
+    Receiver(RangeInfo());
+    return;
+  }
+  if (Length == 0) {
+    Receiver(RangeInfo());
+    return;
+  }
+  resolveRange(*this, InputFile, Offset, Length, Invok, /*TryExistingAST=*/true,
                 Receiver);
 }
 

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -130,6 +130,7 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
         .Case("print-diags", SourceKitRequest::PrintDiags)
         .Case("extract-comment", SourceKitRequest::ExtractComment)
         .Case("module-groups", SourceKitRequest::ModuleGroups)
+        .Case("range", SourceKitRequest::RangeInfo)
         .Default(SourceKitRequest::None);
       if (Request == SourceKitRequest::None) {
         llvm::errs() << "error: invalid request, expected one of "
@@ -137,7 +138,7 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
                "complete.update/complete.cache.ondisk/complete.cache.setpopularapi/"
                "cursor/related-idents/syntax-map/structure/format/expand-placeholder/"
                "doc-info/sema/interface-gen/interface-gen-openfind-usr/find-interface/"
-               "open/edit/print-annotations/print-diags/extract-comment/module-groups\n";
+               "open/edit/print-annotations/print-diags/extract-comment/module-groups/range\n";
         return true;
       }
       break;

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -32,6 +32,7 @@ enum class SourceKitRequest {
   CodeCompleteCacheOnDisk,
   CodeCompleteSetPopularAPI,
   CursorInfo,
+  RangeInfo,
   RelatedIdents,
   SyntaxMap,
   Structure,

--- a/tools/SourceKit/tools/sourcekitd/lib/API/DictionaryKeys.h
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/DictionaryKeys.h
@@ -121,6 +121,7 @@ extern SourceKit::UIdent KeyTypeUsr;
 extern SourceKit::UIdent KeyContainerTypeUsr;
 extern SourceKit::UIdent KeyModuleGroups;
 
+extern SourceKit::UIdent KeyRangeContent;
 /// \brief Used for determining the printing order of dictionary keys.
 bool compareDictKeys(SourceKit::UIdent LHS, SourceKit::UIdent RHS);
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-Common.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-Common.cpp
@@ -120,6 +120,7 @@ UIdent sourcekitd::KeyPopular("key.popular");
 UIdent sourcekitd::KeyUnpopular("key.unpopular");
 UIdent sourcekitd::KeyHide("key.hide");
 UIdent sourcekitd::KeySimplified("key.simplified");
+UIdent sourcekitd::KeyRangeContent("key.rangecontent");
 
 UIdent sourcekitd::KeyIsDeprecated("key.is_deprecated");
 UIdent sourcekitd::KeyIsUnavailable("key.is_unavailable");
@@ -222,7 +223,12 @@ static UIdent *OrderedKeys[] = {
   &KeyIntroduced,
   &KeyDeprecated,
   &KeyObsoleted,
-  &KeyRemoveCache
+  &KeyRemoveCache,
+
+  &KeyTypeInterface,
+  &KeyTypeUsr,
+  &KeyContainerTypeUsr,
+  &KeyModuleGroups,
 };
 
 static unsigned findPrintOrderForDictKey(UIdent Key) {


### PR DESCRIPTION
  Like cursor-info, range info (""source.request.cursorinfo"") answers some
    questions clients have for a code snippet under selection, for instance, the type of a selected
    expression. This commit implements this new quest kind and provides two
    simple information about the selected code: (1) the kind of the
    snippet, currently limited to single-statement and expression; and (2)
    the type of the selected expression. Gradually, we will enrich the
    response to provide more insight into the selected code snippet.