### PR TITLE
SIL: Construct alloc_box insns with the type of the box.

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -301,10 +301,10 @@ public:
         getSILDebugLocation(Loc), valueType, operand, F, OpenedArchetypes));
   }
 
-  AllocBoxInst *createAllocBox(SILLocation Loc, SILType ElementType,
+  AllocBoxInst *createAllocBox(SILLocation Loc, CanSILBoxType BoxType,
                                SILDebugVariable Var = SILDebugVariable()) {
     Loc.markAsPrologue();
-    return insert(AllocBoxInst::create(getSILDebugLocation(Loc), ElementType, F,
+    return insert(AllocBoxInst::create(getSILDebugLocation(Loc), BoxType, F,
                                        OpenedArchetypes, Var));
   }
 

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -511,7 +511,7 @@ SILCloner<ImplClass>::visitAllocBoxInst(AllocBoxInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   doPostProcess(Inst,
     getBuilder().createAllocBox(getOpLocation(Inst->getLoc()),
-                                getOpType(Inst->getElementType())));
+               this->getOpType(Inst->getType()).template castTo<SILBoxType>()));
 }
 
 template<typename ImplClass>

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -863,11 +863,11 @@ class AllocBoxInst final
 
   TailAllocatedDebugVariable VarInfo;
 
-  AllocBoxInst(SILDebugLocation DebugLoc, SILType ElementType,
+  AllocBoxInst(SILDebugLocation DebugLoc, CanSILBoxType BoxType,
                ArrayRef<SILValue> TypeDependentOperands, SILFunction &F,
                SILDebugVariable Var);
 
-  static AllocBoxInst *create(SILDebugLocation Loc, SILType elementType,
+  static AllocBoxInst *create(SILDebugLocation Loc, CanSILBoxType boxType,
                               SILFunction &F,
                               SILOpenedArchetypesState &OpenedArchetypes,
                               SILDebugVariable Var);

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -1605,7 +1605,7 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
       return true;
     if (parseSILDebugLocation(InstLoc, B))
       return true;
-    ResultVal = B.createAllocBox(InstLoc, Ty, VarInfo);
+    ResultVal = B.createAllocBox(InstLoc, Ty.castTo<SILBoxType>(), VarInfo);
     break;
   }
   case ValueKind::ApplyInst:

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -224,29 +224,29 @@ AllocRefDynamicInst::create(SILDebugLocation DebugLoc, SILFunction &F,
       AllocRefDynamicInst(DebugLoc, ty, objc, ElementTypes, AllOperands);
 }
 
-AllocBoxInst::AllocBoxInst(SILDebugLocation Loc, SILType ElementType,
+AllocBoxInst::AllocBoxInst(SILDebugLocation Loc, CanSILBoxType BoxType,
                            ArrayRef<SILValue> TypeDependentOperands,
                            SILFunction &F, SILDebugVariable Var)
     : AllocationInst(ValueKind::AllocBoxInst, Loc,
-                     SILType::getPrimitiveObjectType(
-                       SILBoxType::get(ElementType.getSwiftRValueType()))),
+                     SILType::getPrimitiveObjectType(BoxType)),
       NumOperands(TypeDependentOperands.size()),
       VarInfo(Var, getTrailingObjects<char>()) {
   TrailingOperandsList::InitOperandsList(getAllOperands().begin(), this,
                                          TypeDependentOperands);
 }
 
-AllocBoxInst *AllocBoxInst::create(SILDebugLocation Loc, SILType ElementType,
+AllocBoxInst *AllocBoxInst::create(SILDebugLocation Loc,
+                                   CanSILBoxType BoxType,
                                    SILFunction &F,
                                    SILOpenedArchetypesState &OpenedArchetypes,
                                    SILDebugVariable Var) {
   SmallVector<SILValue, 8> TypeDependentOperands;
   collectTypeDependentOperands(TypeDependentOperands, OpenedArchetypes, F,
-                               ElementType.getSwiftRValueType());
+                               BoxType);
   void *Buffer = allocateDebugVarCarryingInst<AllocBoxInst>(
       F.getModule(), Var, TypeDependentOperands);
   return ::new (Buffer)
-      AllocBoxInst(Loc, ElementType, TypeDependentOperands, F, Var);
+      AllocBoxInst(Loc, BoxType, TypeDependentOperands, F, Var);
 }
 
 /// getDecl - Return the underlying variable declaration associated with this

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -883,7 +883,7 @@ public:
   }
 
   void visitAllocBoxInst(AllocBoxInst *ABI) {
-    *this << ABI->getElementType();
+    *this << ABI->getType();
     printDebugVar(ABI->getVarInfo());
   }
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3866,7 +3866,8 @@ ManagedValue SILGenFunction::emitInjectEnum(SILLocation loc,
   // throws, we know to deallocate the uninitialized box.
   if (element->isIndirect() ||
       element->getParentEnum()->isIndirect()) {
-    auto *box = B.createAllocBox(loc, payloadTL.getLoweredType());
+    auto boxTy = SILBoxType::get(payloadTL.getLoweredType().getSwiftRValueType());
+    auto *box = B.createAllocBox(loc, boxTy);
     auto *addr = B.createProjectBox(loc, box, 0);
 
     CleanupHandle initCleanup = enterDestroyCleanup(box);

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -282,11 +282,12 @@ public:
     assert(!SGF.VarLocs.count(decl) && "Already have an entry for this decl?");
 
     SILType lType = SGF.getLoweredType(decl->getType()->getRValueType());
+    auto boxType = SILBoxType::get(lType.getSwiftRValueType());
 
     // The variable may have its lifetime extended by a closure, heap-allocate
     // it using a box.
     AllocBoxInst *allocBox =
-        SGF.B.createAllocBox(decl, lType, {decl->isLet(), ArgNo});
+        SGF.B.createAllocBox(decl, boxType, {decl->isLet(), ArgNo});
     SILValue addr = SGF.B.createProjectBox(decl, allocBox, 0);
 
     // Mark the memory as uninitialized, so DI will track it for us.

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -336,8 +336,9 @@ void SILGenFunction::emitCaptures(SILLocation loc,
         // since we could conceivably forward the copied value into the
         // closure context and pass it down to the partially applied function
         // in-place.
-        AllocBoxInst *allocBox =
-          B.createAllocBox(loc, vl.value->getType().getObjectType());
+        auto boxTy = SILBoxType::get(vl.value->getType().getSwiftRValueType());
+        
+        AllocBoxInst *allocBox = B.createAllocBox(loc, boxTy);
         ProjectBoxInst *boxAddress = B.createProjectBox(loc, allocBox, 0);
         B.createCopyAddr(loc, vl.value, boxAddress, IsNotTake,IsInitialization);
         capturedArgs.push_back(emitManagedRValueWithCleanup(allocBox));

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -778,13 +778,18 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
   case ValueKind::DebugValueAddrInst:
     llvm_unreachable("not supported");
 
+  case ValueKind::AllocBoxInst:
+    assert(RecordKind == SIL_ONE_TYPE && "Layout should be OneType.");
+    ResultVal = Builder.createAllocBox(Loc,
+                       cast<SILBoxType>(MF->getType(TyID)->getCanonicalType()));
+    break;
+  
 #define ONETYPE_INST(ID)                      \
   case ValueKind::ID##Inst:                   \
     assert(RecordKind == SIL_ONE_TYPE && "Layout should be OneType.");         \
     ResultVal = Builder.create##ID(Loc,                                        \
                   getSILType(MF->getType(TyID), (SILValueCategory)TyCategory));\
     break;
-  ONETYPE_INST(AllocBox)
   ONETYPE_INST(AllocStack)
   ONETYPE_INST(Metatype)
 #undef ONETYPE_INST

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -650,7 +650,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
   }
   case ValueKind::AllocBoxInst: {
     const AllocBoxInst *ABI = cast<AllocBoxInst>(&SI);
-    writeOneTypeLayout(ABI->getKind(), ABI->getElementType());
+    writeOneTypeLayout(ABI->getKind(), ABI->getType());
     break;
   }
   case ValueKind::AllocRefInst:

--- a/test/IRGen/dynamic_lookup.sil
+++ b/test/IRGen/dynamic_lookup.sil
@@ -54,10 +54,10 @@ bb0(%0 : $X):
 // CHECK: define{{( protected)?}} void @dynamic_lookup_br(%objc_object*)
 sil @dynamic_lookup_br : $@convention(thin) (AnyObject) -> () {
 bb0(%0 : $AnyObject):
-  %1 = alloc_box $AnyObject
+  %1 = alloc_box $@box AnyObject
   %1a = project_box %1 : $@box AnyObject, 0
   store %0 to %1a : $*AnyObject
-  %3 = alloc_box $Optional<() -> ()>
+  %3 = alloc_box $@box Optional<() -> ()>
   %4 = load %1a : $*AnyObject
   strong_retain %4 : $AnyObject
   %6 = open_existential_ref %4 : $AnyObject to $@opened("01234567-89ab-cdef-0123-000000000000") AnyObject
@@ -103,7 +103,7 @@ bb3:
 
 sil @_T1t23dynamic_lookup_propertyFT1xPSo13AnyObject__T_ : $@convention(thin) (AnyObject) -> () {
   bb0(%0 : $AnyObject):
-  %1 = alloc_box $AnyObject
+  %1 = alloc_box $@box AnyObject
   %1a = project_box %1 : $@box AnyObject, 0
   store %0 to %1a : $*AnyObject
   %6 = load %1a : $*AnyObject                // users: %24, %8, %7
@@ -126,9 +126,9 @@ bb3:
 // CHECK-LABEL: define{{( protected)?}} void @_T1t16opt_to_subscriptFT3objPSo13AnyObject_1iSi_T_(%objc_object*, {{(i32|i64)}})
 sil @_T1t16opt_to_subscriptFT3objPSo13AnyObject_1iSi_T_ : $@convention(thin) (AnyObject, Int) -> () {
 bb0(%0 : $AnyObject, %1 : $Int):
-  %2 = alloc_box $AnyObject
+  %2 = alloc_box $@box AnyObject
   %2a = project_box %2 : $@box AnyObject, 0
-  %3 = alloc_box $Int
+  %3 = alloc_box $@box Int
   %3a = project_box %3 : $@box Int, 0
   store %0 to %2a : $*AnyObject
   store %1 to %3a : $*Int

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -559,7 +559,7 @@ sil @empty_box : $@convention(thin) () -> () {
 entry:
   // CHECK: store %swift.refcounted* null
   // CHECK: store %swift.opaque* undef
-  %b = alloc_box $()
+  %b = alloc_box $@box ()
   %ba = project_box %b : $@box (), 0
   %f = function_ref @partial_empty_box : $@convention(thin) (@owned @box (), @inout ()) -> ()
   %g = partial_apply %f(%b, %ba) : $@convention(thin) (@owned @box (), @inout ()) -> ()

--- a/test/IRGen/typed_boxes.sil
+++ b/test/IRGen/typed_boxes.sil
@@ -8,7 +8,7 @@ import Builtin
 sil @pod_box_8_8_a : $@convention(thin) () -> () {
 entry:
   // CHECK: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* {{.*}} [[POD_8_8_METADATA:@metadata[0-9.]*]], {{.*}} [[WORD:i[0-9]+]] 24, [[WORD]] 7)
-  %a = alloc_box $Builtin.Int64
+  %a = alloc_box $@box Builtin.Int64
   // CHECK-32: [[BOX_RAW:%.*]] = bitcast %swift.refcounted* [[BOX]] to [[POD_8_8_LAYOUT:<\{ %swift.refcounted, \[4 x i8\], \[8 x i8\] \}>]]*
   // CHECK-32: [[BOX_DATA:%.*]] = getelementptr inbounds [[POD_8_8_LAYOUT]], [[POD_8_8_LAYOUT]]* [[BOX_RAW]], i32 0, i32 2
   // CHECK-64: [[BOX_RAW:%.*]] = bitcast %swift.refcounted* [[BOX]] to [[POD_8_8_LAYOUT:<\{ %swift.refcounted, \[8 x i8\] \}>]]*
@@ -24,7 +24,7 @@ entry:
 sil @pod_box_8_8_b : $@convention(thin) () -> () {
 entry:
   // CHECK: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* {{.*}} [[POD_8_8_METADATA]], {{.*}} [[WORD]] 24, [[WORD]] 7)
-  %a = alloc_box $Builtin.FPIEEE64
+  %a = alloc_box $@box Builtin.FPIEEE64
   // CHECK-32: [[BOX_RAW:%.*]] = bitcast %swift.refcounted* [[BOX]] to [[POD_8_8_LAYOUT:<\{ %swift.refcounted, \[4 x i8\], \[8 x i8\] \}>]]*
   // CHECK-32: [[BOX_DATA:%.*]] = getelementptr inbounds [[POD_8_8_LAYOUT]], [[POD_8_8_LAYOUT]]* [[BOX_RAW]], i32 0, i32 2
   // CHECK-64: [[BOX_RAW:%.*]] = bitcast %swift.refcounted* [[BOX]] to [[POD_8_8_LAYOUT:<\{ %swift.refcounted, \[8 x i8\] \}>]]*
@@ -45,7 +45,7 @@ struct OverAligned {
 sil @pod_box_32_32 : $@convention(thin) () -> () {
 entry:
   // CHECK: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* {{.*}} [[POD_32_32_METADATA:@metadata[0-9.]*]], {{.*}} [[WORD]] 64, [[WORD]] 31)
-  %a = alloc_box $OverAligned
+  %a = alloc_box $@box OverAligned
   // CHECK-32: [[BOX_RAW:%.*]] = bitcast %swift.refcounted* [[BOX]] to [[POD_32_32_LAYOUT:<\{ %swift.refcounted, \[20 x i8\], \[32 x i8\] \}>]]*
   // CHECK-64: [[BOX_RAW:%.*]] = bitcast %swift.refcounted* [[BOX]] to [[POD_32_32_LAYOUT:<\{ %swift.refcounted, \[16 x i8\], \[32 x i8\] \}>]]*
   // CHECK: [[BOX_DATA:%.*]] = getelementptr inbounds [[POD_32_32_LAYOUT]], [[POD_32_32_LAYOUT]]* [[BOX_RAW]], i32 0, i32 2
@@ -67,7 +67,7 @@ sil @rc_box_a : $@convention(thin) () -> () {
 entry:
   // CHECK-32: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* {{.*}} [[NATIVE_RC_METADATA:@metadata[0-9.]*]], {{.*}} [[WORD]] 16, [[WORD]] 3)
   // CHECK-64: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* {{.*}} [[NATIVE_RC_METADATA:@metadata[0-9.]*]], {{.*}} [[WORD]] 24, [[WORD]] 7)
-  %a = alloc_box $C
+  %a = alloc_box $@box C
   // CHECK: bitcast %swift.refcounted** {{%.*}} to %C11typed_boxes1C**
   %b = project_box %a : $@box C, 0
   dealloc_box %a : $@box C
@@ -80,7 +80,7 @@ entry:
   // TODO: Should reuse metadata
   // CHECK-32: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* {{.*}} [[NATIVE_RC_METADATA]], {{.*}} [[WORD]] 16, [[WORD]] 3)
   // CHECK-64: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* {{.*}} [[NATIVE_RC_METADATA]], {{.*}} [[WORD]] 24, [[WORD]] 7)
-  %a = alloc_box $D
+  %a = alloc_box $@box D
   // CHECK: bitcast %swift.refcounted** {{%.*}} to %C11typed_boxes1D**
   %b = project_box %a : $@box D, 0
   dealloc_box %a : $@box D
@@ -92,7 +92,7 @@ sil @unknown_rc_box : $@convention(thin) () -> () {
 entry:
   // CHECK-32: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* {{.*}} [[UNKNOWN_RC_METADATA:@metadata[0-9.]*]], {{.*}} [[WORD]] 16, [[WORD]] 3)
   // CHECK-64: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* {{.*}} [[UNKNOWN_RC_METADATA:@metadata[0-9.]*]], {{.*}} [[WORD]] 24, [[WORD]] 7)
-  %a = alloc_box $Builtin.UnknownObject
+  %a = alloc_box $@box Builtin.UnknownObject
   %b = project_box %a : $@box Builtin.UnknownObject, 0
   dealloc_box %a : $@box Builtin.UnknownObject
   return undef : $()
@@ -106,7 +106,7 @@ struct Fixed {
 
 sil @fixed_box : $@convention(thin) () -> () {
 entry:
-  %a = alloc_box $Fixed
+  %a = alloc_box $@box Fixed
   %b = project_box %a : $@box Fixed, 0
   dealloc_box %a : $@box Fixed
   return undef : $()
@@ -128,7 +128,7 @@ entry:
   // CHECK: [[ALLOC:%.*]] = call { %swift.refcounted*, %swift.opaque* } @swift_allocBox(%swift.type* [[METADATA]])
   // CHECK: [[BOX:%.*]] = extractvalue { %swift.refcounted*, %swift.opaque* } [[ALLOC]], 0
   // CHECK: [[PTR:%.*]] = extractvalue { %swift.refcounted*, %swift.opaque* } [[ALLOC]], 1
-  %a = alloc_box $Dyn<T>
+  %a = alloc_box $@box Dyn<T>
   // CHECK: [[CAST_PTR:%.*]] = bitcast %swift.opaque* [[PTR]] to %V11typed_boxes3Dyn*
   %b = project_box %a : $@box Dyn<T>, 0
   %f = function_ref @take_dyn : $@convention(thin) <T> (@in Dyn<T>) -> ()
@@ -145,7 +145,7 @@ entry:
   // CHECK: [[ALLOC:%.*]] = call { %swift.refcounted*, %swift.opaque* } @swift_allocBox(%swift.type* %T)
   // CHECK: [[BOX:%.*]] = extractvalue { %swift.refcounted*, %swift.opaque* } [[ALLOC]], 0
   // CHECK: [[PTR:%.*]] = extractvalue { %swift.refcounted*, %swift.opaque* } [[ALLOC]], 1
-  %a = alloc_box $T
+  %a = alloc_box $@box T
   %b = project_box %a : $@box T, 0
   %f = function_ref @take_t : $@convention(thin) <T> (@in T) -> ()
   // CHECK: call void @take_t(%swift.opaque* {{[^,]*}} [[PTR]], {{.*}})

--- a/test/Reflection/box_descriptors.sil
+++ b/test/Reflection/box_descriptors.sil
@@ -16,9 +16,9 @@ class C<T> {}
 sil_vtable C {}
 
 sil @make_some_boxes : $@convention(thin) <T> () -> (@box Int, @box (Int, Int), @box C<T>) {
-  %a = alloc_box $Int
-  %b = alloc_box $(Int, Int)
-  %c = alloc_box $C<T>
+  %a = alloc_box $@box Int
+  %b = alloc_box $@box (Int, Int)
+  %c = alloc_box $@box C<T>
   %result = tuple (%a : $@box Int, %b : $@box (Int, Int), %c : $@box C<T>)
   return %result : $(@box Int, @box (Int, Int), @box C<T>)
 }

--- a/test/Reflection/capture_descriptors.sil
+++ b/test/Reflection/capture_descriptors.sil
@@ -24,7 +24,7 @@ bb0(%i: $Int, %b: $@box Int, %m: $@thin Int.Type, %p: $@thick P.Type):
 sil @concrete_caller1 : $@convention(thin) (Int, @thick P.Type) -> @owned @callee_owned () -> () {
 bb0(%i: $Int, %p: $@thick P.Type):
   %f = function_ref @concrete_callee1 : $@convention(thin) (Int, @owned @box Int, @thin Int.Type, @thick P.Type) -> ()
-  %b = alloc_box $Int
+  %b = alloc_box $@box Int
   %m = metatype $@thin Int.Type
   %c = partial_apply %f(%i, %b, %m, %p) : $@convention(thin) (Int, @owned @box Int, @thin Int.Type, @thick P.Type) -> ()
   return %c : $@callee_owned () -> ()
@@ -60,7 +60,7 @@ sil @concrete_caller2 : $@convention(thin) () -> @owned @callee_owned () -> () {
 bb0:
   %f = function_ref @generic_callee2 : $@convention(thin) <T, U> (@in T, @owned @box U) -> ()
   %i = alloc_stack $Int
-  %b = alloc_box $String
+  %b = alloc_box $@box String
   %c = partial_apply %f<Int, String>(%i, %b) : $@convention(thin) <T, U> (@in T, @owned @box U) -> ()
   dealloc_stack %i : $*Int
   return %c : $@callee_owned () -> ()

--- a/test/SIL/Parser/apply_with_substitution.sil
+++ b/test/SIL/Parser/apply_with_substitution.sil
@@ -9,7 +9,7 @@ import Swift
 // CHECK-LABEL: sil @_TF4test3fooFT1fGSqFT_T___T_ : $@convention(thin) (@owned Optional<@callee_owned (@in ()) -> @out ()>) -> ()
 sil @_TF4test3fooFT1fGSqFT_T___T_ : $@convention(thin) (@owned Optional<@callee_owned (@in ()) -> @out ()>) -> () {
 bb0(%0 : $Optional<@callee_owned (@in ()) -> @out ()>):
-  %1 = alloc_box $Optional<@callee_owned (@in ()) -> @out ()>  // var f    // users: %2, %6, %32
+  %1 = alloc_box $@box Optional<@callee_owned (@in ()) -> @out ()>  // var f    // users: %2, %6, %32
   %1a = project_box %1 : $@box Optional<@callee_owned (@in ()) -> @out ()>, 0
   store %0 to %1a : $*Optional<@callee_owned (@in ()) -> @out ()>         // id: %2
   %3 = alloc_stack $Optional<()>                  // users: %22, %28, %30, %31

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -46,7 +46,7 @@ bb0:                                  // CHECK: bb0:
   %0 = tuple ()                       // CHECK:   %0 = tuple ()
   br bb1                              // CHECK:   br bb1
 bb1:
-  %b = alloc_box $Int               // CHECK:   %2 = alloc_box $Int
+  %b = alloc_box $@box Int               // CHECK:   %2 = alloc_box $@box Int
   %c = integer_literal $Builtin.Word, 1
   // CHECK: integer_literal $Builtin.Word, -1
   %e = integer_literal $Builtin.Word, -1
@@ -65,7 +65,7 @@ bb1:
   return %5 : $()                              // CHECK:   return %5 : $()
 bb2:
   %5 = tuple ()                                // CHECK:   %5 = tuple ()
-  %6 = alloc_box $Int                          // CHECK:   %6 = alloc_box $Int
+  %6 = alloc_box $@box Int                          // CHECK:   %6 = alloc_box $@box Int
   %7 = project_box %6 : $@box Int, 0           // CHECK:   %7 = project_box %6 : $@box Int
 
   br bb1                                       // CHECK:   br bb1
@@ -283,7 +283,7 @@ protocol Bendable { }
 sil @_T4todo18erasure_from_protoFT1xPS_8RuncibleS_8Bendable__PS0__ : $@convention(thin) (@in Bendable & Runcible) -> @out Runcible {
 bb0(%0 : $*Runcible, %1 : $*Bendable & Runcible):
   // CHECK: alloc_box
-  %2 = alloc_box $Bendable & Runcible
+  %2 = alloc_box $@box Bendable & Runcible
   %2a = project_box %2 : $@box Bendable & Runcible, 0
   // CHECK: copy_addr [take] {{.*}} to [initialization] {{.*}} : $*Bendable & Runcible
   %3 = copy_addr [take] %1 to [initialization] %2a : $*Bendable & Runcible
@@ -309,7 +309,7 @@ protocol ClassBound : class {
 // CHECK: $@convention(thin) (ClassBound) -> ()
 sil @_T4todo18class_bound_methodFT1xPS_10ClassBound__T_ : $@convention(thin) (ClassBound) -> () {
 bb0(%0 : $ClassBound):
-  %1 = alloc_box $ClassBound                // CHECK: alloc_box
+  %1 = alloc_box $@box ClassBound                // CHECK: alloc_box
   %1a = project_box %1 : $@box ClassBound, 0
   %2 = store %0 to %1a : $*ClassBound      // CHECK: store
   %3 = load %1a : $*ClassBound             // CHECK: load
@@ -355,7 +355,7 @@ bb0(%0 : $Ref, %1 : $Val, %2 : $@thin Aleph.Type):
 sil @_TV6struct5AlephCfMS0_FT_S0_ : $@convention(thin) (@thin Aleph.Type) -> Aleph {
 bb0(%0 : $@thin Aleph.Type):
   %1 = tuple ()
-  %2 = alloc_box $Aleph       // CHECK: alloc_box
+  %2 = alloc_box $@box Aleph       // CHECK: alloc_box
   %2a = project_box %2 : $@box Aleph, 0
   // CHECK: struct_element_addr {{.*}} : $*Aleph, #Aleph.a
   %5 = struct_element_addr %2a : $*Aleph, #Aleph.a
@@ -421,7 +421,7 @@ sil @_T5tuple5tupleFT_TSiSf_ : $@convention(thin) () -> (Int, Float32)
 // CHECK: $@convention(thin) (Int, Float) -> ()
 sil @_T5tuple13tuple_elementFT1xTSiSf__T_ : $@convention(thin) (Int, Float) -> () {
 bb0(%0 : $Int, %1 : $Float):
-  %2 = alloc_box $(Int, Float)
+  %2 = alloc_box $@box (Int, Float)
   %2a = project_box %2 : $@box (Int, Float), 0
   // CHECK: tuple ({{%.*}} : $Int, {{%.*}} : $Float)
   %3 = tuple (%0 : $Int, %1 : $Float)
@@ -457,10 +457,10 @@ class M {
 // CHECK: $@convention(method) (Int, M) -> ()
 sil @_TC3ref1C3foofS0_FT1xSi_T_ : $@convention(method) (Int, M) -> () {
 bb0(%0 : $Int, %1 : $M):
-  %2 = alloc_box $Int     // CHECK: alloc_box $Int
+  %2 = alloc_box $@box Int     // CHECK: alloc_box $@box Int
   %2a = project_box %2 : $@box Int, 0
   %3 = store %0 to %2a : $*Int
-  %4 = alloc_box $M         // CHECK: alloc_box $M
+  %4 = alloc_box $@box M         // CHECK: alloc_box $@box M
   %4a = project_box %4 : $@box M, 0
   %5 = store %1 to %4a : $*M
   %6 = load %2a : $*Int  // CHECK: load {{.*}} : $*Int
@@ -497,7 +497,7 @@ class E : B { }
 // CHECK: $@convention(thin) (B) -> Builtin.Int1
 sil @_T4null3isaFT1bCS_1B_Sb : $@convention(thin) (B) -> Builtin.Int1 {
 bb0(%0 : $B):
-  %1 = alloc_box $B                           // CHECK: alloc_box
+  %1 = alloc_box $@box B                           // CHECK: alloc_box
   %1a = project_box %1 : $@box B, 0
   %2 = store %0 to %1a : $*B
   %3 = load %1a : $*B                        // CHECK: load
@@ -521,9 +521,9 @@ sil @_TSS32_convertFromBuiltinStringLiteralfMSSFT5valueBp17utf8CodeUnitCountBi64
 
 sil @_T5index5gep64FT1pBp1iBi64__Bp : $@convention(thin) (Builtin.RawPointer, Builtin.Word) -> Builtin.RawPointer {
 bb0(%0 : $Builtin.RawPointer, %1 : $Builtin.Word):
-  %2 = alloc_box $Builtin.RawPointer              // CHECK: alloc_box
+  %2 = alloc_box $@box Builtin.RawPointer              // CHECK: alloc_box
   %2a = project_box %2 : $@box Builtin.RawPointer, 0
-  %3 = alloc_box $Builtin.Word                   // CHECK: alloc_box
+  %3 = alloc_box $@box Builtin.Word                   // CHECK: alloc_box
   %3a = project_box %3 : $@box Builtin.Word, 0
   %4 = store %0 to %2a : $*Builtin.RawPointer
   %5 = store %1 to %3a : $*Builtin.Word
@@ -563,9 +563,9 @@ class SomeSubclass : SomeClass {}
 
 sil @test_class_metatype : $@convention(thin) (SomeClass, SomeSubclass) -> (@thick SomeClass.Type, @thick SomeClass.Type) {
 bb0(%0 : $SomeClass, %1 : $SomeSubclass):
-  %2 = alloc_box $SomeClass                       // CHECK: alloc_box
+  %2 = alloc_box $@box SomeClass                       // CHECK: alloc_box
   %2a = project_box %2 : $@box SomeClass, 0
-  %3 = alloc_box $SomeSubclass                    // CHECK: alloc_box
+  %3 = alloc_box $@box SomeSubclass                    // CHECK: alloc_box
   %3a = project_box %3 : $@box SomeSubclass, 0
   %4 = store %0 to %2a : $*SomeClass
   %5 = store %1 to %3a : $*SomeSubclass
@@ -588,7 +588,7 @@ bb0(%0 : $SomeClass, %1 : $SomeSubclass):
 
 sil @test_value_metatype : $@convention(thin) <T> (@in T) -> (@thick T.Type, @thick T.Type) {
 bb0(%0 : $*T):
-  %1 = alloc_box $T                               // CHECK: alloc_box
+  %1 = alloc_box $@box T                               // CHECK: alloc_box
   %1a = project_box %1 : $@box T, 0
   %2 = copy_addr [take] %0 to [initialization] %1a : $*T
   %3 = metatype $@thick T.Type                       // CHECK: metatype
@@ -605,7 +605,7 @@ bb0(%0 : $*T):
 
 sil @test_existential_metatype : $@convention(thin) (@in SomeProtocol) -> @thick SomeProtocol.Type {
 bb0(%0 : $*SomeProtocol):
-  %1 = alloc_box $SomeProtocol                    // CHECK: alloc_box
+  %1 = alloc_box $@box SomeProtocol                    // CHECK: alloc_box
   %1a = project_box %1 : $@box SomeProtocol, 0
   %2 = copy_addr [take] %0 to [initialization] %1a : $*SomeProtocol
   %4 = alloc_stack $SomeProtocol                    // CHECK: alloc_stack
@@ -672,9 +672,9 @@ bb3(%4 : $Int):
 // CHECK-LABEL: sil @test_builtin
 sil @test_builtin : $@convention(thin) (Builtin.Int1, Builtin.Int1) -> Builtin.Int1 {
 bb0(%0 : $Builtin.Int1, %1 : $Builtin.Int1):
-  %2 = alloc_box $Builtin.Int1
+  %2 = alloc_box $@box Builtin.Int1
   %2a = project_box %2 : $@box Builtin.Int1, 0
-  %3 = alloc_box $Builtin.Int1
+  %3 = alloc_box $@box Builtin.Int1
   %3a = project_box %3 : $@box Builtin.Int1, 0
   store %0 to %2a : $*Builtin.Int1
   store %1 to %3a : $*Builtin.Int1
@@ -709,7 +709,7 @@ bb0:
 // CHECK-LABEL: sil @test_dealloc_box
 sil @test_dealloc_box : $@convention(thin) () -> () {
 bb0:
-  %0 = alloc_box $Class1
+  %0 = alloc_box $@box Class1
   dealloc_box %0 : $@box Class1
   %2 = tuple ()
   return %2 : $()
@@ -765,7 +765,7 @@ sil @closure0 : $@convention(thin) (@box Int, @inout Int) -> ()
 
 sil @closure_test : $@convention(thin) () -> () {
 bb0:
-  %0 = alloc_box $Int                           // users: %10, %8, %8, %7, %4
+  %0 = alloc_box $@box Int                           // users: %10, %8, %8, %7, %4
   %0a = project_box %0 : $@box Int, 0
 
   %5 = function_ref @takes_closure : $@convention(thin) (@callee_owned () -> ()) -> ()
@@ -806,7 +806,7 @@ sil @_T6switch1cFT_T_ : $@convention(thin) () -> ()
 // CHECK-LABEL: sil @test_switch_union : $@convention(thin) (MaybePair) -> ()
 sil @test_switch_union : $@convention(thin) (MaybePair) -> () {
 bb0(%0 : $MaybePair):
-  %1 = alloc_box $MaybePair
+  %1 = alloc_box $@box MaybePair
   %1a = project_box %1 : $@box MaybePair, 0
   store %0 to %1a : $*MaybePair
   %3 = load %1a : $*MaybePair
@@ -968,7 +968,7 @@ struct Spoon : Bendable {
 // CHECK-LABEL: sil @test_init_existential : $@convention(thin) (Spoon) -> @out Bendable
 sil @test_init_existential : $@convention(thin) (Spoon) -> @out Bendable {
 bb0(%0 : $*Bendable, %1 : $Spoon):
-  %2 = alloc_box $Spoon
+  %2 = alloc_box $@box Spoon
   %2a = project_box %2 : $@box Spoon, 0
   store %1 to %2a : $*Spoon
   // CHECK: init_existential_addr %{{.*}} : $*Bendable, $Spoon
@@ -985,7 +985,7 @@ bb0(%0 : $*Bendable, %1 : $Spoon):
 // CHECK-LABEL: sil @test_existential_ref : $@convention(thin) (ConcreteClass) -> ClassP
 sil @test_existential_ref : $@convention(thin) (ConcreteClass) -> ClassP {
 bb0(%0 : $ConcreteClass):
-  %1 = alloc_box $ConcreteClass
+  %1 = alloc_box $@box ConcreteClass
   %1a = project_box %1 : $@box ConcreteClass, 0
   store %0 to %1a : $*ConcreteClass
   %3 = load %1a : $*ConcreteClass
@@ -1040,10 +1040,10 @@ class X {
 // CHECK-LABEL: sil @test_dynamic_lookup_br : $@convention(thin) (AnyObject) -> ()
 sil @test_dynamic_lookup_br : $@convention(thin) (AnyObject) -> () {
 bb0(%0 : $AnyObject):
-  %1 = alloc_box $AnyObject
+  %1 = alloc_box $@box AnyObject
   %1a = project_box %1 : $@box AnyObject, 0
   store %0 to %1a : $*AnyObject
-  %3 = alloc_box $Optional<() -> ()>
+  %3 = alloc_box $@box Optional<() -> ()>
   %4 = load %1a : $*AnyObject
   strong_retain %4 : $AnyObject
   %6 = open_existential_ref %4 : $AnyObject to $@opened("01234567-89ab-cdef-0123-222222222222") AnyObject
@@ -1062,9 +1062,9 @@ bb3:
 
 // CHECK-LABEL: sil @test_mark_fn_escape
 sil @test_mark_fn_escape : $() -> () {
-  %b = alloc_box $Int
+  %b = alloc_box $@box Int
   %ba = project_box %b : $@box Int, 0
-  %c = alloc_box $Int
+  %c = alloc_box $@box Int
   %ca = project_box %c : $@box Int, 0
 
   // CHECK: mark_function_escape {{.*}} : $*Int

--- a/test/SIL/Parser/bound_generic.sil
+++ b/test/SIL/Parser/bound_generic.sil
@@ -9,7 +9,7 @@ import Swift
 // CHECK-LABEL: sil @_TF9optional3fooFT1fGSqFT_T___T_ : $@convention(thin) (@owned Optional<@callee_owned (@in ()) -> @out ()>) -> ()
 sil @_TF9optional3fooFT1fGSqFT_T___T_ : $@convention(thin) (@owned Optional<@callee_owned (@in ()) -> (@out ())>) -> () {
 bb0(%0 : $Optional<@callee_owned (@in ()) -> (@out ())>):
-  %1 = alloc_box $Optional<@callee_owned (@in ()) -> (@out ())>
+  %1 = alloc_box $@box Optional<@callee_owned (@in ()) -> (@out ())>
   %1a = project_box %1 : $@box Optional<@callee_owned (@in ()) -> (@out ())>, 0
   store %0 to %1a : $*Optional<@callee_owned (@in ()) -> (@out ())>
   %3 = alloc_stack $Optional<()>

--- a/test/SIL/Parser/box_types.sil
+++ b/test/SIL/Parser/box_types.sil
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s
+
+import Builtin
+
+// CHECK-LABEL: sil @boxes : $@convention(thin) (@box Builtin.Int32, @box Builtin.Int32) -> () {
+sil @boxes : $@convention(thin) (@box Builtin.Int32, @box Builtin.Int32) -> () {
+// CHECK: bb0(%0 : $@box Builtin.Int32, %1 : $@box Builtin.Int32):
+bb0(%0 : $@box Builtin.Int32, %1 : $@box Builtin.Int32):
+  return undef : $()
+}

--- a/test/SIL/Parser/global_init_attribute.sil
+++ b/test/SIL/Parser/global_init_attribute.sil
@@ -14,7 +14,7 @@ import Swift
 
 sil [global_init] @_TF1gau5MyVarSi : $@convention(thin) () -> Builtin.RawPointer {
 bb0:
-  %b = alloc_box $Int
+  %b = alloc_box $@box Int
   %ba = project_box %b : $@box Int, 0
   %p = address_to_pointer %ba : $*Int to $Builtin.RawPointer
   return %p : $Builtin.RawPointer

--- a/test/SIL/Parser/overloaded_member.sil
+++ b/test/SIL/Parser/overloaded_member.sil
@@ -18,9 +18,9 @@ struct A {
 // CHECK-LABEL: sil @_TFCSo1XcfMS_FT1aV11peer_method1A_S_
 sil @_TFCSo1XcfMS_FT1aV11peer_method1A_S_ : $@convention(method) (A, @owned X) -> @owned X {
 bb0(%0 : $A, %1 : $X):
-  %2 = alloc_box $X
+  %2 = alloc_box $@box X
   %2a = project_box %2 : $@box X, 0
-  %3 = alloc_box $A
+  %3 = alloc_box $@box A
   %3a = project_box %3 : $@box A, 0
   store %0 to %3a : $*A
   %5 = mark_uninitialized [delegatingself] %1 : $X

--- a/test/SIL/Parser/typed_boxes.sil
+++ b/test/SIL/Parser/typed_boxes.sil
@@ -5,8 +5,8 @@ import Swift
 // CHECK-LABEL: sil @alloc_dealloc : $@convention(thin) (Int) -> () {
 sil @alloc_dealloc : $@convention(thin) (Int) -> () {
 entry(%x : $Int):
-  // CHECK: [[B:%.*]] = alloc_box $Int
-  %b = alloc_box $Int
+  // CHECK: [[B:%.*]] = alloc_box $@box Int
+  %b = alloc_box $@box Int
   // CHECK: [[PB:%.*]] = project_box [[B]] : $@box Int, 0
   %ba = project_box %b : $@box Int, 0
   // CHECK: store [[X:%.*]] to [[PB]] : $*Int

--- a/test/SILGen/address_only_types.swift
+++ b/test/SILGen/address_only_types.swift
@@ -168,7 +168,7 @@ func address_only_assignment_from_temp(_ dest: inout Unloadable) {
 func address_only_assignment_from_lv(_ dest: inout Unloadable, v: Unloadable) {
   var v = v
   // CHECK: bb0([[DEST:%[0-9]+]] : $*Unloadable, [[VARG:%[0-9]+]] : $*Unloadable):
-  // CHECK: [[VBOX:%.*]] = alloc_box $Unloadable
+  // CHECK: [[VBOX:%.*]] = alloc_box $@box Unloadable
   // CHECK: [[PBOX:%[0-9]+]] = project_box [[VBOX]]
   // CHECK: copy_addr [[VARG]] to [initialization] [[PBOX]] : $*Unloadable
   dest = v
@@ -210,7 +210,7 @@ func address_only_assignment_from_lv_to_property(_ v: Unloadable) {
 func address_only_var() -> Unloadable {
   // CHECK: bb0([[RET:%[0-9]+]] : $*Unloadable):
   var x = some_address_only_function_1()
-  // CHECK: [[XBOX:%[0-9]+]] = alloc_box $Unloadable
+  // CHECK: [[XBOX:%[0-9]+]] = alloc_box $@box Unloadable
   // CHECK: [[XPB:%.*]] = project_box [[XBOX]]
   // CHECK: apply {{%.*}}([[XPB]])
   return x

--- a/test/SILGen/boxed_existentials.swift
+++ b/test/SILGen/boxed_existentials.swift
@@ -69,7 +69,7 @@ func test_property_of_lvalue(_ x: Error) -> String {
   return x._domain
 }
 // CHECK-LABEL: sil hidden @_TF18boxed_existentials23test_property_of_lvalueFPs5Error_SS
-// CHECK:         [[VAR:%.*]] = alloc_box $Error
+// CHECK:         [[VAR:%.*]] = alloc_box $@box Error
 // CHECK-NEXT:    [[PVAR:%.*]] = project_box [[VAR]]
 // CHECK-NEXT:    copy_value %0 : $Error
 // CHECK-NEXT:    store %0 to [init] [[PVAR]]
@@ -112,9 +112,9 @@ func plusOneError() -> Error { }
 func test_open_existential_semantics(_ guaranteed: Error,
                                      _ immediate: Error) {
   var immediate = immediate
-  // CHECK: [[IMMEDIATE_BOX:%.*]] = alloc_box $Error
+  // CHECK: [[IMMEDIATE_BOX:%.*]] = alloc_box $@box Error
   // CHECK: [[PB:%.*]] = project_box [[IMMEDIATE_BOX]]
-  // GUARANTEED: [[IMMEDIATE_BOX:%.*]] = alloc_box $Error
+  // GUARANTEED: [[IMMEDIATE_BOX:%.*]] = alloc_box $@box Error
   // GUARANTEED: [[PB:%.*]] = project_box [[IMMEDIATE_BOX]]
 
   // CHECK-NOT: copy_value %0
@@ -177,7 +177,7 @@ func test_open_existential_semantics(_ guaranteed: Error,
 // CHECK:       bb0([[OUT:%.*]] : $*Any, [[GUAR:%.*]] : $Error,
 func erasure_to_any(_ guaranteed: Error, _ immediate: Error) -> Any {
   var immediate = immediate
-  // CHECK:       [[IMMEDIATE_BOX:%.*]] = alloc_box $Error
+  // CHECK:       [[IMMEDIATE_BOX:%.*]] = alloc_box $@box Error
   // CHECK:       [[PB:%.*]] = project_box [[IMMEDIATE_BOX]]
   if true {
     // CHECK-NOT: copy_value [[GUAR]]

--- a/test/SILGen/class_bound_protocols.swift
+++ b/test/SILGen/class_bound_protocols.swift
@@ -26,7 +26,7 @@ class ConcreteSubclass : ConcreteClass { }
 func class_bound_generic<T : ClassBound>(x: T) -> T {
   var x = x
   // CHECK: bb0([[X:%.*]] : $T):
-  // CHECK:   [[X_ADDR:%.*]] = alloc_box $T
+  // CHECK:   [[X_ADDR:%.*]] = alloc_box $@box T
   // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
   // CHECK:   store [[X]] to [init] [[PB]]
   return x
@@ -39,7 +39,7 @@ func class_bound_generic<T : ClassBound>(x: T) -> T {
 func class_bound_generic_2<T : ClassBound & NotClassBound>(x: T) -> T {
   var x = x
   // CHECK: bb0([[X:%.*]] : $T):
-  // CHECK:   [[X_ADDR:%.*]] = alloc_box $T
+  // CHECK:   [[X_ADDR:%.*]] = alloc_box $@box T
   // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
   // CHECK:   store [[X]] to [init] [[PB]]
   return x
@@ -52,7 +52,7 @@ func class_bound_generic_2<T : ClassBound & NotClassBound>(x: T) -> T {
 func class_bound_protocol(x: ClassBound) -> ClassBound {
   var x = x
   // CHECK: bb0([[X:%.*]] : $ClassBound):
-  // CHECK:   [[X_ADDR:%.*]] = alloc_box $ClassBound
+  // CHECK:   [[X_ADDR:%.*]] = alloc_box $@box ClassBound
   // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
   // CHECK:   store [[X]] to [init] [[PB]]
   return x
@@ -66,7 +66,7 @@ func class_bound_protocol_composition(x: ClassBound & NotClassBound)
 -> ClassBound & NotClassBound {
   var x = x
   // CHECK: bb0([[X:%.*]] : $ClassBound & NotClassBound):
-  // CHECK:   [[X_ADDR:%.*]] = alloc_box $ClassBound & NotClassBound
+  // CHECK:   [[X_ADDR:%.*]] = alloc_box $@box (ClassBound & NotClassBound)
   // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
   // CHECK:   store [[X]] to [init] [[PB]]
   return x

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -28,7 +28,7 @@ func return_local_generic_function_with_captures<A, R>(_ a: A) -> (A) -> R {
 func read_only_capture(_ x: Int) -> Int {
   var x = x
   // CHECK: bb0([[X:%[0-9]+]] : $Int):
-  // CHECK: [[XBOX:%[0-9]+]] = alloc_box $Int
+  // CHECK: [[XBOX:%[0-9]+]] = alloc_box $@box Int
 
   func cap() -> Int {
     return x
@@ -52,8 +52,8 @@ func read_only_capture(_ x: Int) -> Int {
 func write_to_capture(_ x: Int) -> Int {
   var x = x
   // CHECK: bb0([[X:%[0-9]+]] : $Int):
-  // CHECK: [[XBOX:%[0-9]+]] = alloc_box $Int
-  // CHECK: [[X2BOX:%[0-9]+]] = alloc_box $Int
+  // CHECK: [[XBOX:%[0-9]+]] = alloc_box $@box Int
+  // CHECK: [[X2BOX:%[0-9]+]] = alloc_box $@box Int
   // CHECK: [[PB:%.*]] = project_box [[X2BOX]]
   var x2 = x
 
@@ -97,7 +97,7 @@ func multiple_closure_refs(_ x: Int) -> (() -> Int, () -> Int) {
 // CHECK-LABEL: sil hidden @_TF8closures18capture_local_func
 func capture_local_func(_ x: Int) -> () -> () -> Int {
   var x = x
-  // CHECK: [[XBOX:%[0-9]+]] = alloc_box $Int
+  // CHECK: [[XBOX:%[0-9]+]] = alloc_box $@box Int
 
   func aleph() -> Int { return x }
 
@@ -122,7 +122,7 @@ func capture_local_func(_ x: Int) -> () -> () -> Int {
 func anon_read_only_capture(_ x: Int) -> Int {
   var x = x
   // CHECK: bb0([[X:%[0-9]+]] : $Int):
-  // CHECK: [[XBOX:%[0-9]+]] = alloc_box $Int
+  // CHECK: [[XBOX:%[0-9]+]] = alloc_box $@box Int
   // CHECK: [[PB:%.*]] = project_box [[XBOX]]
 
   return ({ x })()
@@ -143,7 +143,7 @@ func anon_read_only_capture(_ x: Int) -> Int {
 func small_closure_capture(_ x: Int) -> Int {
   var x = x
   // CHECK: bb0([[X:%[0-9]+]] : $Int):
-  // CHECK: [[XBOX:%[0-9]+]] = alloc_box $Int
+  // CHECK: [[XBOX:%[0-9]+]] = alloc_box $@box Int
   // CHECK: [[PB:%.*]] = project_box [[XBOX]]
 
   return { x }()
@@ -164,7 +164,7 @@ func small_closure_capture(_ x: Int) -> Int {
 // CHECK-LABEL: sil hidden @_TF8closures35small_closure_capture_with_argument
 func small_closure_capture_with_argument(_ x: Int) -> (_ y: Int) -> Int {
   var x = x
-  // CHECK: [[XBOX:%[0-9]+]] = alloc_box $Int
+  // CHECK: [[XBOX:%[0-9]+]] = alloc_box $@box Int
 
   return { x + $0 }
   // -- func expression
@@ -199,12 +199,12 @@ func uncaptured_locals(_ x: Int) -> (Int, Int) {
   var x = x
   // -- locals without captures are stack-allocated
   // CHECK: bb0([[XARG:%[0-9]+]] : $Int):
-  // CHECK:   [[XADDR:%[0-9]+]] = alloc_box $Int
+  // CHECK:   [[XADDR:%[0-9]+]] = alloc_box $@box Int
   // CHECK:   [[PB:%.*]] = project_box [[XADDR]]
   // CHECK:   store [[XARG]] to [trivial] [[PB]]
 
   var y = zero
-  // CHECK:   [[YADDR:%[0-9]+]] = alloc_box $Int
+  // CHECK:   [[YADDR:%[0-9]+]] = alloc_box $@box Int
   return (x, y)
 
 }
@@ -507,7 +507,7 @@ class SuperSub : SuperBase {
 }
 
 // CHECK-LABEL: sil hidden @_TFC8closures24UnownedSelfNestedCapture13nestedCapture{{.*}} : $@convention(method) (@guaranteed UnownedSelfNestedCapture) -> ()
-// CHECK:         [[OUTER_SELF_CAPTURE:%.*]] = alloc_box $@sil_unowned UnownedSelfNestedCapture
+// CHECK:         [[OUTER_SELF_CAPTURE:%.*]] = alloc_box $@box @sil_unowned UnownedSelfNestedCapture
 // CHECK:         [[PB:%.*]] = project_box [[OUTER_SELF_CAPTURE]]
 // CHECK:         [[UNOWNED_SELF:%.*]] = ref_to_unowned [[SELF_PARAM:%.*]] :
 // -- TODO: A lot of fussy r/r traffic and owned/unowned conversions here.

--- a/test/SILGen/complete_object_init.swift
+++ b/test/SILGen/complete_object_init.swift
@@ -5,7 +5,7 @@ struct X { }
 class A {
   // CHECK-LABEL: sil hidden @_TFC20complete_object_init1Ac{{.*}} : $@convention(method) (@owned A) -> @owned A
 // CHECK: bb0([[SELF_PARAM:%[0-9]+]] : $A):
-// CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $A
+// CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $@box A
 // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
 // CHECK:   [[SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*A
 // CHECK:   store [[SELF_PARAM]] to [[SELF]] : $*A

--- a/test/SILGen/copy_lvalue_peepholes.swift
+++ b/test/SILGen/copy_lvalue_peepholes.swift
@@ -8,9 +8,9 @@ var zero = getInt()
 func getInt() -> Int { return zero }
 
 // CHECK-LABEL: sil hidden @_TF21copy_lvalue_peepholes20init_var_from_lvalue
-// CHECK:   [[X:%.*]] = alloc_box $Builtin.Int64
+// CHECK:   [[X:%.*]] = alloc_box $@box Builtin.Int64
 // CHECK:   [[PBX:%.*]] = project_box [[X]]
-// CHECK:   [[Y:%.*]] = alloc_box $Builtin.Int64
+// CHECK:   [[Y:%.*]] = alloc_box $@box Builtin.Int64
 // CHECK:   [[PBY:%.*]] = project_box [[Y]]
 // CHECK:   copy_addr [[PBX]] to [initialization] [[PBY]] : $*Builtin.Int64
 func init_var_from_lvalue(x: Int) {
@@ -19,7 +19,7 @@ func init_var_from_lvalue(x: Int) {
 }
 
 // CHECK-LABEL: sil hidden @_TF21copy_lvalue_peepholes22assign_var_from_lvalue
-// CHECK:   [[Y:%.*]] = alloc_box $Builtin.Int64
+// CHECK:   [[Y:%.*]] = alloc_box $@box Builtin.Int64
 // CHECK:   [[PBY:%.*]] = project_box [[Y]]
 // CHECK:   copy_addr [[PBY]] to %0
 func assign_var_from_lvalue(x: inout Int, y: Int) {

--- a/test/SILGen/decls.swift
+++ b/test/SILGen/decls.swift
@@ -31,27 +31,27 @@ func MRV() -> (Int, Float, (), Double) {}
 // CHECK-LABEL: sil hidden @_TF5decls14tuple_patternsFT_T_
 func tuple_patterns() {
   var (a, b) : (Int, Float)
-  // CHECK: [[AADDR1:%[0-9]+]] = alloc_box $Int
+  // CHECK: [[AADDR1:%[0-9]+]] = alloc_box $@box Int
   // CHECK: [[PBA:%.*]] = project_box [[AADDR1]]
   // CHECK: [[AADDR:%[0-9]+]] = mark_uninitialized [var] [[PBA]]
-  // CHECK: [[BADDR1:%[0-9]+]] = alloc_box $Float
+  // CHECK: [[BADDR1:%[0-9]+]] = alloc_box $@box Float
   // CHECK: [[PBB:%.*]] = project_box [[BADDR1]]
   // CHECK: [[BADDR:%[0-9]+]] = mark_uninitialized [var] [[PBB]]
 
   var (c, d) = (a, b)
-  // CHECK: [[CADDR:%[0-9]+]] = alloc_box $Int
+  // CHECK: [[CADDR:%[0-9]+]] = alloc_box $@box Int
   // CHECK: [[PBC:%.*]] = project_box [[CADDR]]
-  // CHECK: [[DADDR:%[0-9]+]] = alloc_box $Float
+  // CHECK: [[DADDR:%[0-9]+]] = alloc_box $@box Float
   // CHECK: [[PBD:%.*]] = project_box [[DADDR]]
   // CHECK: copy_addr [[AADDR]] to [initialization] [[PBC]]
   // CHECK: copy_addr [[BADDR]] to [initialization] [[PBD]]
 
-  // CHECK: [[EADDR:%[0-9]+]] = alloc_box $Int
+  // CHECK: [[EADDR:%[0-9]+]] = alloc_box $@box Int
   // CHECK: [[PBE:%.*]] = project_box [[EADDR]]
-  // CHECK: [[FADDR:%[0-9]+]] = alloc_box $Float
+  // CHECK: [[FADDR:%[0-9]+]] = alloc_box $@box Float
   // CHECK: [[PBF:%.*]] = project_box [[FADDR]]
-  // CHECK: [[GADDR:%[0-9]+]] = alloc_box $()
-  // CHECK: [[HADDR:%[0-9]+]] = alloc_box $Double
+  // CHECK: [[GADDR:%[0-9]+]] = alloc_box $@box ()
+  // CHECK: [[HADDR:%[0-9]+]] = alloc_box $@box Double
   // CHECK: [[PBH:%.*]] = project_box [[HADDR]]
   // CHECK: [[EFGH:%[0-9]+]] = apply
   // CHECK: [[E:%[0-9]+]] = tuple_extract {{.*}}, 0
@@ -62,19 +62,19 @@ func tuple_patterns() {
   // CHECK: store [[H]] to [trivial] [[PBH]]
   var (e,f,g,h) : (Int, Float, (), Double) = MRV()
 
-  // CHECK: [[IADDR:%[0-9]+]] = alloc_box $Int
+  // CHECK: [[IADDR:%[0-9]+]] = alloc_box $@box Int
   // CHECK: [[PBI:%.*]] = project_box [[IADDR]]
-  // CHECK-NOT: alloc_box $Float
+  // CHECK-NOT: alloc_box $@box Float
   // CHECK: copy_addr [[AADDR]] to [initialization] [[PBI]]
   // CHECK: [[B:%[0-9]+]] = load [[BADDR]]
   // CHECK-NOT: store [[B]]
   var (i,_) = (a, b)
 
-  // CHECK: [[JADDR:%[0-9]+]] = alloc_box $Int
+  // CHECK: [[JADDR:%[0-9]+]] = alloc_box $@box Int
   // CHECK: [[PBJ:%.*]] = project_box [[JADDR]]
-  // CHECK-NOT: alloc_box $Float
-  // CHECK: [[KADDR:%[0-9]+]] = alloc_box $()
-  // CHECK-NOT: alloc_box $Double
+  // CHECK-NOT: alloc_box $@box Float
+  // CHECK: [[KADDR:%[0-9]+]] = alloc_box $@box ()
+  // CHECK-NOT: alloc_box $@box Double
   // CHECK: [[J_K_:%[0-9]+]] = apply
   // CHECK: [[J:%[0-9]+]] = tuple_extract {{.*}}, 0
   // CHECK: [[K:%[0-9]+]] = tuple_extract {{.*}}, 2
@@ -84,10 +84,10 @@ func tuple_patterns() {
 
 // CHECK-LABEL: sil hidden @_TF5decls16simple_arguments
 // CHECK: bb0(%0 : $Int, %1 : $Int):
-// CHECK: [[X:%[0-9]+]] = alloc_box $Int
+// CHECK: [[X:%[0-9]+]] = alloc_box $@box Int
 // CHECK-NEXT: [[PBX:%.*]] = project_box [[X]]
 // CHECK-NEXT: store %0 to [trivial] [[PBX]]
-// CHECK-NEXT: [[Y:%[0-9]+]] = alloc_box $Int
+// CHECK-NEXT: [[Y:%[0-9]+]] = alloc_box $@box Int
 // CHECK-NEXT: [[PBY:%[0-9]+]] = project_box [[Y]]
 // CHECK-NEXT: store %1 to [trivial] [[PBY]]
 func simple_arguments(x: Int, y: Int) -> Int {
@@ -105,7 +105,7 @@ func tuple_argument(x: (Int, Float, ())) {
 
 // CHECK-LABEL: sil hidden @_TF5decls14inout_argument
 // CHECK: bb0(%0 : $*Int, %1 : $Int):
-// CHECK: [[X_LOCAL:%[0-9]+]] = alloc_box $Int
+// CHECK: [[X_LOCAL:%[0-9]+]] = alloc_box $@box Int
 // CHECK: [[PBX:%.*]] = project_box [[X_LOCAL]]
 func inout_argument(x: inout Int, y: Int) {
   var y = y
@@ -128,7 +128,7 @@ func load_from_global() -> Int {
 func store_to_global(x: Int) {
   var x = x
   global = x
-  // CHECK: [[XADDR:%[0-9]+]] = alloc_box $Int
+  // CHECK: [[XADDR:%[0-9]+]] = alloc_box $@box Int
   // CHECK: [[PBX:%.*]] = project_box [[XADDR]]
   // CHECK: [[ACCESSOR:%[0-9]+]] = function_ref @_TF5declsau6globalSi
   // CHECK: [[PTR:%[0-9]+]] = apply [[ACCESSOR]]()

--- a/test/SILGen/default_constructor.swift
+++ b/test/SILGen/default_constructor.swift
@@ -28,7 +28,7 @@ struct D {
 
 
 // CHECK-LABEL: sil hidden @_TFV19default_constructor1DC{{.*}} : $@convention(method) (@thin D.Type) -> D
-// CHECK: [[THISBOX:%[0-9]+]] = alloc_box $D
+// CHECK: [[THISBOX:%[0-9]+]] = alloc_box $@box D
 // CHECK: [[THIS:%[0-9]+]] = mark_uninit
 // CHECK: [[INIT:%[0-9]+]] = function_ref @_TIvV19default_constructor1D1iSii
 // CHECK: [[RESULT:%[0-9]+]] = apply [[INIT]]()
@@ -62,7 +62,7 @@ class F : E { }
 
 // CHECK-LABEL: sil hidden @_TFC19default_constructor1Fc{{.*}} : $@convention(method) (@owned F) -> @owned F
 // CHECK: bb0([[ORIGSELF:%[0-9]+]] : $F)
-// CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box $F
+// CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box $@box F
 // CHECK-NEXT: project_box [[SELF_BOX]]
 // CHECK-NEXT: [[SELF:%[0-9]+]] = mark_uninitialized [derivedself]
 // CHECK-NEXT: store [[ORIGSELF]] to [[SELF]] : $*F

--- a/test/SILGen/dynamic_lookup.swift
+++ b/test/SILGen/dynamic_lookup.swift
@@ -41,7 +41,7 @@ func direct_to_protocol(_ obj: AnyObject) {
 func direct_to_static_method(_ obj: AnyObject) {
   var obj = obj
   // CHECK: [[START:[A-Za-z0-9_]+]]([[OBJ:%[0-9]+]] : $AnyObject):
-  // CHECK: [[OBJBOX:%[0-9]+]] = alloc_box $AnyObject
+  // CHECK: [[OBJBOX:%[0-9]+]] = alloc_box $@box AnyObject
   // CHECK-NEXT: [[PBOBJ:%[0-9]+]] = project_box [[OBJBOX]]
   // CHECK: store [[OBJ]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK-NEXT: [[OBJCOPY:%[0-9]+]] = load [[PBOBJ]] : $*AnyObject
@@ -56,10 +56,10 @@ func direct_to_static_method(_ obj: AnyObject) {
 func opt_to_class(_ obj: AnyObject) {
   var obj = obj
   // CHECK: [[ENTRY:[A-Za-z0-9]+]]([[PARAM:%[0-9]+]] : $AnyObject)
-  // CHECK: [[EXISTBOX:%[0-9]+]] = alloc_box $AnyObject 
+  // CHECK: [[EXISTBOX:%[0-9]+]] = alloc_box $@box AnyObject 
   // CHECK-NEXT: [[PBOBJ:%[0-9]+]] = project_box [[EXISTBOX]]
   // CHECK: store [[PARAM]] to [init] [[PBOBJ]]
-  // CHECK-NEXT: [[OPTBOX:%[0-9]+]] = alloc_box $Optional<@callee_owned () -> ()>
+  // CHECK-NEXT: [[OPTBOX:%[0-9]+]] = alloc_box $@box Optional<@callee_owned () -> ()>
   // CHECK-NEXT: [[PBOPT:%.*]] = project_box [[OPTBOX]]
   // CHECK-NEXT: [[EXISTVAL:%[0-9]+]] = load [[PBOBJ]] : $*AnyObject
   // CHECK-NEXT: copy_value [[EXISTVAL]] : $AnyObject
@@ -107,10 +107,10 @@ func forced_without_outer(_ obj: AnyObject) {
 func opt_to_static_method(_ obj: AnyObject) {
   var obj = obj
   // CHECK: [[ENTRY:[A-Za-z0-9]+]]([[OBJ:%[0-9]+]] : $AnyObject):
-  // CHECK: [[OBJBOX:%[0-9]+]] = alloc_box $AnyObject
+  // CHECK: [[OBJBOX:%[0-9]+]] = alloc_box $@box AnyObject
   // CHECK-NEXT: [[PBOBJ:%[0-9]+]] = project_box [[OBJBOX]]
   // CHECK: store [[OBJ]] to [init] [[PBOBJ]] : $*AnyObject
-  // CHECK-NEXT: [[OPTBOX:%[0-9]+]] = alloc_box $Optional<@callee_owned () -> ()>
+  // CHECK-NEXT: [[OPTBOX:%[0-9]+]] = alloc_box $@box Optional<@callee_owned () -> ()>
   // CHECK-NEXT: [[PBO:%.*]] = project_box [[OPTBOX]]
   // CHECK-NEXT: [[OBJCOPY:%[0-9]+]] = load [[PBOBJ]] : $*AnyObject
   // CHECK-NEXT: [[OBJMETA:%[0-9]+]] = existential_metatype $@thick AnyObject.Type, [[OBJCOPY]] : $AnyObject
@@ -125,10 +125,10 @@ func opt_to_static_method(_ obj: AnyObject) {
 func opt_to_property(_ obj: AnyObject) {
   var obj = obj
   // CHECK: bb0([[OBJ:%[0-9]+]] : $AnyObject):
-  // CHECK: [[OBJ_BOX:%[0-9]+]] = alloc_box $AnyObject
+  // CHECK: [[OBJ_BOX:%[0-9]+]] = alloc_box $@box AnyObject
   // CHECK-NEXT: [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
   // CHECK: store [[OBJ]] to [init] [[PBOBJ]] : $*AnyObject
-  // CHECK-NEXT: [[INT_BOX:%[0-9]+]] = alloc_box $Int
+  // CHECK-NEXT: [[INT_BOX:%[0-9]+]] = alloc_box $@box Int
   // CHECK-NEXT: project_box [[INT_BOX]]
   // CHECK-NEXT: [[OBJ:%[0-9]+]] = load [[PBOBJ]] : $*AnyObject
   // CHECK-NEXT: copy_value [[OBJ]] : $AnyObject
@@ -151,13 +151,13 @@ func direct_to_subscript(_ obj: AnyObject, i: Int) {
   var obj = obj
   var i = i
   // CHECK: bb0([[OBJ:%[0-9]+]] : $AnyObject, [[I:%[0-9]+]] : $Int):
-  // CHECK: [[OBJ_BOX:%[0-9]+]] = alloc_box $AnyObject
+  // CHECK: [[OBJ_BOX:%[0-9]+]] = alloc_box $@box AnyObject
   // CHECK-NEXT: [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
   // CHECK: store [[OBJ]] to [init] [[PBOBJ]] : $*AnyObject
-  // CHECK-NEXT: [[I_BOX:%[0-9]+]] = alloc_box $Int
+  // CHECK-NEXT: [[I_BOX:%[0-9]+]] = alloc_box $@box Int
   // CHECK-NEXT: [[PBI:%.*]] = project_box [[I_BOX]]
   // CHECK-NEXT: store [[I]] to [trivial] [[PBI]] : $*Int
-  // CHECK-NEXT: alloc_box $Int
+  // CHECK-NEXT: alloc_box $@box Int
   // CHECK-NEXT: project_box
   // CHECK-NEXT: [[OBJ:%[0-9]+]] = load [[PBOBJ]] : $*AnyObject
   // CHECK-NEXT: copy_value [[OBJ]] : $AnyObject
@@ -182,10 +182,10 @@ func opt_to_subscript(_ obj: AnyObject, i: Int) {
   var obj = obj
   var i = i
   // CHECK: bb0([[OBJ:%[0-9]+]] : $AnyObject, [[I:%[0-9]+]] : $Int):
-  // CHECK: [[OBJ_BOX:%[0-9]+]] = alloc_box $AnyObject
+  // CHECK: [[OBJ_BOX:%[0-9]+]] = alloc_box $@box AnyObject
   // CHECK-NEXT: [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
   // CHECK: store [[OBJ]] to [init] [[PBOBJ]] : $*AnyObject
-  // CHECK-NEXT: [[I_BOX:%[0-9]+]] = alloc_box $Int
+  // CHECK-NEXT: [[I_BOX:%[0-9]+]] = alloc_box $@box Int
   // CHECK-NEXT: [[PBI:%.*]] = project_box [[I_BOX]]
   // CHECK-NEXT: store [[I]] to [trivial] [[PBI]] : $*Int
   // CHECK-NEXT: [[OBJ:%[0-9]+]] = load [[PBOBJ]] : $*AnyObject
@@ -210,7 +210,7 @@ func opt_to_subscript(_ obj: AnyObject, i: Int) {
 func downcast(_ obj: AnyObject) -> X {
   var obj = obj
   // CHECK: bb0([[OBJ:%[0-9]+]] : $AnyObject):
-  // CHECK: [[OBJ_BOX:%[0-9]+]] = alloc_box $AnyObject
+  // CHECK: [[OBJ_BOX:%[0-9]+]] = alloc_box $@box AnyObject
   // CHECK-NEXT: [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
   // CHECK: store [[OBJ]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK-NEXT: [[OBJ:%[0-9]+]] = load [[PBOBJ]] : $*AnyObject

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -114,7 +114,7 @@ class ObjCInit {
 // CHECK: sil hidden @_TF12dynamic_self12testObjCInit{{.*}} : $@convention(thin) (@thick ObjCInit.Type) -> ()
 func testObjCInit(meta: ObjCInit.Type) {
 // CHECK: bb0([[THICK_META:%[0-9]+]] : $@thick ObjCInit.Type):
-// CHECK:   [[O:%[0-9]+]] = alloc_box $ObjCInit
+// CHECK:   [[O:%[0-9]+]] = alloc_box $@box ObjCInit
 // CHECK:   [[PB:%.*]] = project_box [[O]]
 // CHECK:   [[OBJC_META:%[0-9]+]] = thick_to_objc_metatype [[THICK_META]] : $@thick ObjCInit.Type to $@objc_metatype ObjCInit.Type
 // CHECK:   [[OBJ:%[0-9]+]] = alloc_ref_dynamic [objc] [[OBJC_META]] : $@objc_metatype ObjCInit.Type, $ObjCInit
@@ -180,7 +180,7 @@ class Z {
     // Capturing 'self' weak, so we have to pass in a metatype explicitly
     // so that IRGen can recover metadata.
 
-    // CHECK:      [[WEAK_SELF:%.*]] = alloc_box $@sil_weak Optional<Z>
+    // CHECK:      [[WEAK_SELF:%.*]] = alloc_box $@box @sil_weak Optional<Z>
     // CHECK:      [[FN:%.*]] = function_ref @_TFFC12dynamic_self1Z23testDynamicSelfCapturesFT1xSi_DS0_U1_FT_T_ : $@convention(thin) (@owned @box @sil_weak Optional<Z>, @thick Z.Type) -> ()
     // CHECK:      copy_value [[WEAK_SELF]] : $@box @sil_weak Optional<Z>
     // CHECK-NEXT: [[DYNAMIC_SELF:%.*]] = metatype $@thick @dynamic_self Z.Type

--- a/test/SILGen/dynamic_self_reference_storage.swift
+++ b/test/SILGen/dynamic_self_reference_storage.swift
@@ -5,18 +5,18 @@ class Foo {
   func dynamicSelf() -> Self {
     // CHECK: debug_value {{%.*}} : $Foo
     let managedSelf = self
-    // CHECK: alloc_box $@sil_unmanaged Foo
+    // CHECK: alloc_box $@box @sil_unmanaged Foo
     unowned(unsafe) let unmanagedSelf = self
-    // CHECK: alloc_box $@sil_unowned Foo
+    // CHECK: alloc_box $@box @sil_unowned Foo
     unowned(safe) let unownedSelf = self
-    // CHECK: alloc_box $@sil_weak Optional<Foo>
+    // CHECK: alloc_box $@box @sil_weak Optional<Foo>
     weak var weakSelf = self
     // CHECK: debug_value {{%.*}} : $Optional<Foo>
     let optionalSelf = Optional(self)
 
-    // CHECK: alloc_box $@sil_unowned Foo
+    // CHECK: alloc_box $@box @sil_unowned Foo
     let f: () -> () = {[unowned self] in ()}
-    // CHECK: alloc_box $@sil_weak Optional<Foo>
+    // CHECK: alloc_box $@box @sil_weak Optional<Foo>
     let g: () -> () = {[weak self] in ()}
   }
 }

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -468,7 +468,7 @@ class BaseThrowingInit : HasThrowingInit {
   }
 }
 // CHECK: sil hidden @_TFC6errors16BaseThrowingInitc{{.*}} : $@convention(method) (Int, Int, @owned BaseThrowingInit) -> (@owned BaseThrowingInit, @error Error)
-// CHECK:      [[BOX:%.*]] = alloc_box $BaseThrowingInit
+// CHECK:      [[BOX:%.*]] = alloc_box $@box BaseThrowingInit
 // CHECK:      [[PB:%.*]] = project_box [[BOX]]
 // CHECK:      [[MARKED_BOX:%.*]] = mark_uninitialized [derivedself] [[PB]]
 //   Initialize subField.
@@ -707,7 +707,7 @@ func testOptionalTry() {
 
 // CHECK-LABEL: sil hidden @_TF6errors18testOptionalTryVarFT_T_
 // CHECK-NEXT: bb0:
-// CHECK-NEXT: [[BOX:%.+]] = alloc_box $Optional<Cat>
+// CHECK-NEXT: [[BOX:%.+]] = alloc_box $@box Optional<Cat>
 // CHECK-NEXT: [[PB:%.*]] = project_box [[BOX]]
 // CHECK-NEXT: [[BOX_DATA:%.+]] = init_enum_data_addr [[PB]] : $*Optional<Cat>, #Optional.some!enumelt.1
 // CHECK: [[FN:%.+]] = function_ref @_TF6errors10make_a_catFzT_CS_3Cat
@@ -763,7 +763,7 @@ func testOptionalTryAddressOnly<T>(_ obj: T) {
 
 // CHECK-LABEL: sil hidden @_TF6errors29testOptionalTryAddressOnlyVar
 // CHECK: bb0(%0 : $*T):
-// CHECK: [[BOX:%.+]] = alloc_box $Optional<T>
+// CHECK: [[BOX:%.+]] = alloc_box $@box Optional<T>
 // CHECK-NEXT: [[PB:%.*]] = project_box [[BOX]]
 // CHECK-NEXT: [[BOX_DATA:%.+]] = init_enum_data_addr [[PB]] : $*Optional<T>, #Optional.some!enumelt.1
 // CHECK: [[FN:%.+]] = function_ref @_TF6errors11dont_return
@@ -833,7 +833,7 @@ func testOptionalTryNeverFails() {
 
 // CHECK-LABEL: sil hidden @_TF6errors28testOptionalTryNeverFailsVarFT_T_
 // CHECK: bb0:
-// CHECK-NEXT:   [[BOX:%.+]] = alloc_box $Optional<()>
+// CHECK-NEXT:   [[BOX:%.+]] = alloc_box $@box Optional<()>
 // CHECK-NEXT:   [[PB:%.*]] = project_box [[BOX]]
 // CHECK-NEXT:   = init_enum_data_addr [[PB]] : $*Optional<()>, #Optional.some!enumelt.1
 // CHECK-NEXT:   inject_enum_addr [[PB]] : $*Optional<()>, #Optional.some!enumelt.1
@@ -863,7 +863,7 @@ func testOptionalTryNeverFailsAddressOnly<T>(_ obj: T) {
 
 // CHECK-LABEL: sil hidden @_TF6errors39testOptionalTryNeverFailsAddressOnlyVar
 // CHECK: bb0(%0 : $*T):
-// CHECK:   [[BOX:%.+]] = alloc_box $Optional<T>
+// CHECK:   [[BOX:%.+]] = alloc_box $@box Optional<T>
 // CHECK-NEXT:   [[PB:%.*]] = project_box [[BOX]]
 // CHECK-NEXT:   [[BOX_DATA:%.+]] = init_enum_data_addr [[PB]] : $*Optional<T>, #Optional.some!enumelt.1
 // CHECK-NEXT:   copy_addr %0 to [initialization] [[BOX_DATA]] : $*T

--- a/test/SILGen/expressions.swift
+++ b/test/SILGen/expressions.swift
@@ -400,7 +400,7 @@ func tuple() -> (Int, Float) { return (1, 1.0) }
 // CHECK-LABEL: sil hidden @_TF11expressions13tuple_element
 func tuple_element(_ x: (Int, Float)) {
   var x = x
-  // CHECK: [[XADDR:%.*]] = alloc_box $(Int, Float)
+  // CHECK: [[XADDR:%.*]] = alloc_box $@box (Int, Float)
   // CHECK: [[PB:%.*]] = project_box [[XADDR]]
 
   int(x.0)
@@ -433,15 +433,15 @@ func if_expr(_ a: Bool, b: Bool, x: Int, y: Int, z: Int) -> Int {
   var y = y
   var z = z
   // CHECK: bb0({{.*}}):
-  // CHECK: [[AB:%[0-9]+]] = alloc_box $Bool
+  // CHECK: [[AB:%[0-9]+]] = alloc_box $@box Bool
   // CHECK: [[PBA:%.*]] = project_box [[AB]]
-  // CHECK: [[BB:%[0-9]+]] = alloc_box $Bool
+  // CHECK: [[BB:%[0-9]+]] = alloc_box $@box Bool
   // CHECK: [[PBB:%.*]] = project_box [[BB]]
-  // CHECK: [[XB:%[0-9]+]] = alloc_box $Int
+  // CHECK: [[XB:%[0-9]+]] = alloc_box $@box Int
   // CHECK: [[PBX:%.*]] = project_box [[XB]]
-  // CHECK: [[YB:%[0-9]+]] = alloc_box $Int
+  // CHECK: [[YB:%[0-9]+]] = alloc_box $@box Int
   // CHECK: [[PBY:%.*]] = project_box [[YB]]
-  // CHECK: [[ZB:%[0-9]+]] = alloc_box $Int
+  // CHECK: [[ZB:%[0-9]+]] = alloc_box $@box Int
   // CHECK: [[PBZ:%.*]] = project_box [[ZB]]
 
   return a

--- a/test/SILGen/extensions.swift
+++ b/test/SILGen/extensions.swift
@@ -55,7 +55,7 @@ struct Box<T> {
 }
 
 // CHECK-LABEL: sil hidden @_TFV10extensions3BoxCfT1tx_GS0_x_ : $@convention(method) <T> (@in T, @thin Box<T>.Type) -> @out Box<T>
-// CHECK:      [[SELF_BOX:%.*]] = alloc_box $Box<T>
+// CHECK:      [[SELF_BOX:%.*]] = alloc_box $@box Box<T>
 // CHECK-NEXT: [[SELF_ADDR:%.*]] = project_box [[SELF_BOX]] : $@box Box<T>
 // CHECK:      [[SELF_PTR:%.*]] = mark_uninitialized [rootself] [[SELF_ADDR]] : $*Box<T>
 // CHECK:      [[INIT:%.*]] = function_ref @_TIvV10extensions3Box1tGSqx_i : $@convention(thin) <τ_0_0> () -> @out Optional<τ_0_0>

--- a/test/SILGen/foreign_errors.swift
+++ b/test/SILGen/foreign_errors.swift
@@ -170,7 +170,7 @@ class VeryErrorProne : ErrorProne {
   }
 }
 // CHECK:    sil hidden @_TFC14foreign_errors14VeryErrorPronec{{.*}}
-// CHECK:      [[BOX:%.*]] = alloc_box $VeryErrorProne
+// CHECK:      [[BOX:%.*]] = alloc_box $@box VeryErrorProne
 // CHECK:      [[PB:%.*]] = project_box [[BOX]]
 // CHECK:      [[MARKED_BOX:%.*]] = mark_uninitialized [derivedself] [[PB]]
 // CHECK:      [[T0:%.*]] = load [[MARKED_BOX]]

--- a/test/SILGen/functions.swift
+++ b/test/SILGen/functions.swift
@@ -102,11 +102,11 @@ func calls(_ i:Int, j:Int, k:Int) {
   var j = j
   var k = k
   // CHECK: bb0(%0 : $Builtin.Int64, %1 : $Builtin.Int64, %2 : $Builtin.Int64):
-  // CHECK: [[IBOX:%[0-9]+]] = alloc_box $Builtin.Int64
+  // CHECK: [[IBOX:%[0-9]+]] = alloc_box $@box Builtin.Int64
   // CHECK: [[IADDR:%.*]] = project_box [[IBOX]]
-  // CHECK: [[JBOX:%[0-9]+]] = alloc_box $Builtin.Int64
+  // CHECK: [[JBOX:%[0-9]+]] = alloc_box $@box Builtin.Int64
   // CHECK: [[JADDR:%.*]] = project_box [[JBOX]]
-  // CHECK: [[KBOX:%[0-9]+]] = alloc_box $Builtin.Int64
+  // CHECK: [[KBOX:%[0-9]+]] = alloc_box $@box Builtin.Int64
   // CHECK: [[KADDR:%.*]] = project_box [[KBOX]]
 
   // CHECK: [[FUNC:%[0-9]+]] = function_ref @_TF9functions19standalone_function{{.*}} : $@convention(thin) (Builtin.Int64, Builtin.Int64) -> Builtin.Int64
@@ -117,7 +117,7 @@ func calls(_ i:Int, j:Int, k:Int) {
 
   // -- Curry 'self' onto struct method argument lists.
 
-  // CHECK: [[ST_ADDR:%.*]] = alloc_box $SomeStruct
+  // CHECK: [[ST_ADDR:%.*]] = alloc_box $@box SomeStruct
   // CHECK: [[CTOR:%.*]] = function_ref @_TFV9functions10SomeStructC{{.*}} : $@convention(method) (Builtin.Int64, Builtin.Int64, @thin SomeStruct.Type) -> SomeStruct
   // CHECK: [[METATYPE:%.*]] = metatype $@thin SomeStruct.Type
   // CHECK: [[I:%.*]] = load [[IADDR]]
@@ -134,7 +134,7 @@ func calls(_ i:Int, j:Int, k:Int) {
 
   // -- Curry 'self' onto method argument lists dispatched using class_method.
 
-  // CHECK: [[CBOX:%[0-9]+]] = alloc_box $SomeClass
+  // CHECK: [[CBOX:%[0-9]+]] = alloc_box $@box SomeClass
   // CHECK: [[CADDR:%.*]] = project_box [[CBOX]]
   // CHECK: [[FUNC:%[0-9]+]] = function_ref @_TFC9functions9SomeClassC{{.*}} : $@convention(method) (Builtin.Int64, Builtin.Int64, @thick SomeClass.Type) -> @owned SomeClass
   // CHECK: [[META:%[0-9]+]] = metatype $@thick SomeClass.Type
@@ -201,7 +201,7 @@ func calls(_ i:Int, j:Int, k:Int) {
   // -- Curry the projected concrete value in an existential (or its Type)
   // -- onto protocol type methods dispatched using protocol_method.
 
-  // CHECK: [[PBOX:%[0-9]+]] = alloc_box $SomeProtocol
+  // CHECK: [[PBOX:%[0-9]+]] = alloc_box $@box SomeProtocol
   // CHECK: [[PADDR:%.*]] = project_box [[PBOX]]
   var p : SomeProtocol = ConformsToSomeProtocol()
 
@@ -231,7 +231,7 @@ func calls(_ i:Int, j:Int, k:Int) {
 
   // -- Use an apply or partial_apply instruction to bind type parameters of a generic.
 
-  // CHECK: [[GBOX:%[0-9]+]] = alloc_box $SomeGeneric<Builtin.Int64>
+  // CHECK: [[GBOX:%[0-9]+]] = alloc_box $@box SomeGeneric<Builtin.Int64>
   // CHECK: [[GADDR:%.*]] = project_box [[GBOX]]
   // CHECK: [[CTOR_GEN:%[0-9]+]] = function_ref @_TFC9functions11SomeGenericC{{.*}} : $@convention(method) <τ_0_0> (@thick SomeGeneric<τ_0_0>.Type) -> @owned SomeGeneric<τ_0_0>
   // CHECK: [[META:%[0-9]+]] = metatype $@thick SomeGeneric<Builtin.Int64>.Type
@@ -272,7 +272,7 @@ func calls(_ i:Int, j:Int, k:Int) {
   // SIL-level "thin" function values need to be able to convert to
   // "thick" function values when stored, returned, or passed as arguments.
 
-  // CHECK: [[FBOX:%[0-9]+]] = alloc_box $@callee_owned (Builtin.Int64, Builtin.Int64) -> Builtin.Int64
+  // CHECK: [[FBOX:%[0-9]+]] = alloc_box $@box @callee_owned (Builtin.Int64, Builtin.Int64) -> Builtin.Int64
   // CHECK: [[FADDR:%.*]] = project_box [[FBOX]]
   // CHECK: [[FUNC_THIN:%[0-9]+]] = function_ref @_TF9functions19standalone_function{{.*}} : $@convention(thin) (Builtin.Int64, Builtin.Int64) -> Builtin.Int64
   // CHECK: [[FUNC_THICK:%[0-9]+]] = thin_to_thick_function [[FUNC_THIN]]

--- a/test/SILGen/generic_witness.swift
+++ b/test/SILGen/generic_witness.swift
@@ -16,7 +16,7 @@ func foo<B : Runcible>(_ x: B) {
 // CHECK-LABEL: sil hidden @_TF15generic_witness3bar{{.*}} : $@convention(thin) (@in Runcible) -> ()
 func bar(_ x: Runcible) {
   var x = x
-  // CHECK: [[BOX:%.*]] = alloc_box $Runcible
+  // CHECK: [[BOX:%.*]] = alloc_box $@box Runcible
   // CHECK: [[TEMP:%.*]] = alloc_stack $Runcible
   // CHECK: [[EXIST:%.*]] = open_existential_addr [[TEMP]] : $*Runcible to $*[[OPENED:@opened(.*) Runcible]]
   // CHECK: [[METHOD:%.*]] = witness_method $[[OPENED]], #Runcible.runce!1

--- a/test/SILGen/guaranteed_closure_context.swift
+++ b/test/SILGen/guaranteed_closure_context.swift
@@ -10,11 +10,11 @@ struct S {}
 
 // CHECK-LABEL: sil hidden @_TF26guaranteed_closure_context19guaranteed_capturesFT_T_
 func guaranteed_captures() {
-  // CHECK: [[MUTABLE_TRIVIAL_BOX:%.*]] = alloc_box $S
+  // CHECK: [[MUTABLE_TRIVIAL_BOX:%.*]] = alloc_box $@box S
   var mutableTrivial = S()
-  // CHECK: [[MUTABLE_RETAINABLE_BOX:%.*]] = alloc_box $C
+  // CHECK: [[MUTABLE_RETAINABLE_BOX:%.*]] = alloc_box $@box C
   var mutableRetainable = C()
-  // CHECK: [[MUTABLE_ADDRESS_ONLY_BOX:%.*]] = alloc_box $P
+  // CHECK: [[MUTABLE_ADDRESS_ONLY_BOX:%.*]] = alloc_box $@box P
   var mutableAddressOnly: P = C()
 
   // CHECK: [[IMMUTABLE_TRIVIAL:%.*]] = apply {{.*}} -> S
@@ -33,7 +33,7 @@ func guaranteed_captures() {
   // CHECK-NOT: copy_value [[MUTABLE_RETAINABLE_BOX]]
   // CHECK-NOT: copy_value [[MUTABLE_ADDRESS_ONLY_BOX]]
   // CHECK-NOT: copy_value [[IMMUTABLE_RETAINABLE]]
-  // CHECK:     [[IMMUTABLE_AO_BOX:%.*]] = alloc_box $P
+  // CHECK:     [[IMMUTABLE_AO_BOX:%.*]] = alloc_box $@box P
 
   // CHECK: [[FN:%.*]] = function_ref [[FN_NAME:@_TFF26guaranteed_closure_context19guaranteed_capturesFT_T_L_17captureEverythingfT_T_]]
   // CHECK: apply [[FN]]([[MUTABLE_TRIVIAL_BOX]], [[MUTABLE_RETAINABLE_BOX]], [[MUTABLE_ADDRESS_ONLY_BOX]], [[IMMUTABLE_TRIVIAL]], [[IMMUTABLE_RETAINABLE]], [[IMMUTABLE_AO_BOX]])
@@ -52,7 +52,7 @@ func guaranteed_captures() {
   // CHECK: copy_value [[MUTABLE_RETAINABLE_BOX]]
   // CHECK: copy_value [[MUTABLE_ADDRESS_ONLY_BOX]]
   // CHECK: copy_value [[IMMUTABLE_RETAINABLE]]
-  // CHECK: [[IMMUTABLE_AO_BOX:%.*]] = alloc_box $P
+  // CHECK: [[IMMUTABLE_AO_BOX:%.*]] = alloc_box $@box P
   // CHECK: [[CLOSURE:%.*]] = partial_apply {{.*}}([[MUTABLE_TRIVIAL_BOX]], [[MUTABLE_RETAINABLE_BOX]], [[MUTABLE_ADDRESS_ONLY_BOX]], [[IMMUTABLE_TRIVIAL]], [[IMMUTABLE_RETAINABLE]], [[IMMUTABLE_AO_BOX]])
   // CHECK: apply {{.*}}[[CLOSURE]]
 

--- a/test/SILGen/guaranteed_self.swift
+++ b/test/SILGen/guaranteed_self.swift
@@ -355,7 +355,7 @@ class D: C {
 
   // CHECK-LABEL: sil hidden @_TFC15guaranteed_self1Dc{{.*}} : $@convention(method) (@owned D) -> @owned D
   // CHECK:       bb0([[SELF:%.*]] : $D):
-  // CHECK:         [[SELF_BOX:%.*]] = alloc_box $D
+  // CHECK:         [[SELF_BOX:%.*]] = alloc_box $@box D
   // CHECK-NEXT:    [[PB:%.*]] = project_box [[SELF_BOX]]
   // CHECK-NEXT:    [[SELF_ADDR:%.*]] = mark_uninitialized [derivedself] [[PB]]
   // CHECK-NEXT:    store [[SELF]] to [[SELF_ADDR]]
@@ -477,7 +477,7 @@ class LetFieldClass {
   // CHECK: [[DESTROY_SHIP_FUN:%.*]] = function_ref @_TF15guaranteed_self11destroyShipFCS_6KrakenT_ : $@convention(thin) (@owned Kraken) -> ()
   // CHECK-NEXT: copy_value [[KRAKEN]]
   // CHECK-NEXT: apply [[DESTROY_SHIP_FUN]]([[KRAKEN]])
-  // CHECK-NEXT: [[KRAKEN_BOX:%.*]] = alloc_box $Kraken
+  // CHECK-NEXT: [[KRAKEN_BOX:%.*]] = alloc_box $@box Kraken
   // CHECK-NEXT: [[PB:%.*]] = project_box [[KRAKEN_BOX]]
   // CHECK-NEXT: [[KRAKEN_ADDR:%.*]] = ref_element_addr [[CLS]] : $LetFieldClass, #LetFieldClass.letk
   // CHECK-NEXT: [[KRAKEN2:%.*]] = load [[KRAKEN_ADDR]]
@@ -511,7 +511,7 @@ class LetFieldClass {
   // CHECK: [[DESTROY_SHIP_FUN:%.*]] = function_ref @_TF15guaranteed_self11destroyShipFCS_6KrakenT_ : $@convention(thin) (@owned Kraken) -> ()
   // CHECK-NEXT: copy_value [[KRAKEN]]
   // CHECK-NEXT: apply [[DESTROY_SHIP_FUN]]([[KRAKEN]])
-  // CHECK-NEXT: [[KRAKEN_BOX:%.*]] = alloc_box $Kraken
+  // CHECK-NEXT: [[KRAKEN_BOX:%.*]] = alloc_box $@box Kraken
   // CHECK-NEXT: [[PB:%.*]] = project_box [[KRAKEN_BOX]]
   // CHECK-NEXT: [[KRAKEN_GETTER_FUN:%.*]] = class_method [[CLS]] : $LetFieldClass, #LetFieldClass.vark!getter.1 : (LetFieldClass) -> () -> Kraken , $@convention(method) (@guaranteed LetFieldClass) -> @owned Kraken
   // CHECK-NEXT: [[KRAKEN2:%.*]] = apply [[KRAKEN_GETTER_FUN]]([[CLS]])

--- a/test/SILGen/if_expr.swift
+++ b/test/SILGen/if_expr.swift
@@ -32,10 +32,10 @@ func consumeAddressOnly(_: AddressOnly) {}
 // CHECK: sil hidden @_TF7if_expr19addr_only_ternary_1
 func addr_only_ternary_1(x: Bool) -> AddressOnly {
   // CHECK: bb0([[RET:%.*]] : $*AddressOnly, {{.*}}):
-  // CHECK: [[a:%[0-9]+]] = alloc_box $AddressOnly, var, name "a"
+  // CHECK: [[a:%[0-9]+]] = alloc_box $@box AddressOnly, var, name "a"
   // CHECK: [[PBa:%.*]] = project_box [[a]]
   var a : AddressOnly = A()
-  // CHECK: [[b:%[0-9]+]] = alloc_box $AddressOnly, var, name "b"
+  // CHECK: [[b:%[0-9]+]] = alloc_box $@box AddressOnly, var, name "b"
   // CHECK: [[PBb:%.*]] = project_box [[b]]
   var b : AddressOnly = B()
 

--- a/test/SILGen/if_while_binding.swift
+++ b/test/SILGen/if_while_binding.swift
@@ -45,7 +45,7 @@ func if_else_chain() {
   // CHECK:   br [[CONT_X:bb[0-9]+]]
     a(x)
   // CHECK: [[NOX]]:
-  // CHECK:   alloc_box $String, var, name "y"
+  // CHECK:   alloc_box $@box String, var, name "y"
   // CHECK:   switch_enum {{.*}} : $Optional<String>, case #Optional.some!enumelt.1: [[YESY:bb[0-9]+]], default [[ELSE1:bb[0-9]+]]
     // CHECK: [[ELSE1]]:
     // CHECK:   dealloc_box {{.*}} $@box String
@@ -153,7 +153,7 @@ func if_multi() {
 
   // CHECK: [[CHECKBUF2]]([[A:%[0-9]+]] : $String):
   // CHECK:   debug_value [[A]] : $String, let, name "a"
-  // CHECK:   [[B:%[0-9]+]] = alloc_box $String, var, name "b"
+  // CHECK:   [[B:%[0-9]+]] = alloc_box $@box String, var, name "b"
   // CHECK:   [[PB:%[0-9]+]] = project_box [[B]]
   // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt.1: [[IF_BODY:bb.*]], default [[IF_EXIT1a:bb[0-9]+]]
 
@@ -181,7 +181,7 @@ func if_multi_else() {
   // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt.1: [[CHECKBUF2:bb.*]], default [[ELSE:bb[0-9]+]]
   // CHECK: [[CHECKBUF2]]([[A:%[0-9]+]] : $String):
   // CHECK:   debug_value [[A]] : $String, let, name "a"
-  // CHECK:   [[B:%[0-9]+]] = alloc_box $String, var, name "b"
+  // CHECK:   [[B:%[0-9]+]] = alloc_box $@box String, var, name "b"
   // CHECK:   [[PB:%[0-9]+]] = project_box [[B]]
   // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt.1: [[IF_BODY:bb.*]], default [[IF_EXIT1a:bb[0-9]+]]
   
@@ -214,7 +214,7 @@ func if_multi_where() {
   // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt.1: [[CHECKBUF2:bb.*]], default [[ELSE:bb[0-9]+]]
   // CHECK: [[CHECKBUF2]]([[A:%[0-9]+]] : $String):
   // CHECK:   debug_value [[A]] : $String, let, name "a"
-  // CHECK:   [[BBOX:%[0-9]+]] = alloc_box $String, var, name "b"
+  // CHECK:   [[BBOX:%[0-9]+]] = alloc_box $@box String, var, name "b"
   // CHECK:   [[PB:%[0-9]+]] = project_box [[BBOX]]
   // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt.1: [[CHECK_WHERE:bb.*]], default [[IF_EXIT1a:bb[0-9]+]]
   // CHECK: [[IF_EXIT1a]]:

--- a/test/SILGen/implicitly_unwrapped_optional.swift
+++ b/test/SILGen/implicitly_unwrapped_optional.swift
@@ -6,7 +6,7 @@ func foo(f f: (() -> ())!) {
 }
 // CHECK:    sil hidden @{{.*}}foo{{.*}} : $@convention(thin) (@owned Optional<@callee_owned () -> ()>) -> () {
 // CHECK:    bb0([[T0:%.*]] : $Optional<@callee_owned () -> ()>):
-// CHECK: [[F:%.*]] = alloc_box $Optional<@callee_owned () -> ()>
+// CHECK: [[F:%.*]] = alloc_box $@box Optional<@callee_owned () -> ()>
 // CHECK-NEXT: [[PF:%.*]] = project_box [[F]]
 // CHECK: store [[T0]] to [init] [[PF]]
 // CHECK:      [[T1:%.*]] = select_enum_addr [[PF]]

--- a/test/SILGen/indirect_enum.swift
+++ b/test/SILGen/indirect_enum.swift
@@ -15,7 +15,7 @@ func TreeA_cases<T>(_ t: T, l: TreeA<T>, r: TreeA<T>) {
   let _ = TreeA<T>.Nil
 
 // CHECK-NEXT:    [[METATYPE:%.*]] = metatype $@thin TreeA<T>.Type
-// CHECK-NEXT:    [[BOX:%.*]] = alloc_box $T
+// CHECK-NEXT:    [[BOX:%.*]] = alloc_box $@box T
 // CHECK-NEXT:    [[PB:%.*]] = project_box [[BOX]]
 // CHECK-NEXT:    copy_addr %0 to [initialization] [[PB]]
 // CHECK-NEXT:    [[LEAF:%.*]] = enum $TreeA<T>, #TreeA.Leaf!enumelt.1, [[BOX]]
@@ -23,7 +23,7 @@ func TreeA_cases<T>(_ t: T, l: TreeA<T>, r: TreeA<T>) {
   let _ = TreeA<T>.Leaf(t)
 
 // CHECK-NEXT:    [[METATYPE:%.*]] = metatype $@thin TreeA<T>.Type
-// CHECK-NEXT:    [[BOX:%.*]] = alloc_box $(left: TreeA<T>, right: TreeA<T>)
+// CHECK-NEXT:    [[BOX:%.*]] = alloc_box $@box (left: TreeA<T>, right: TreeA<T>)
 // CHECK-NEXT:    [[PB:%.*]] = project_box [[BOX]]
 // CHECK-NEXT:    [[LEFT:%.*]] = tuple_element_addr [[PB]] : $*(left: TreeA<T>, right: TreeA<T>), 0
 // CHECK-NEXT:    [[RIGHT:%.*]] = tuple_element_addr [[PB]] : $*(left: TreeA<T>, right: TreeA<T>), 1
@@ -46,7 +46,7 @@ func TreeA_cases<T>(_ t: T, l: TreeA<T>, r: TreeA<T>) {
 func TreeA_reabstract(_ f: @escaping (Int) -> Int) {
 
 // CHECK:         [[METATYPE:%.*]] = metatype $@thin TreeA<(Int) -> Int>.Type
-// CHECK-NEXT:    [[BOX:%.*]] = alloc_box $@callee_owned (@in Int) -> @out Int
+// CHECK-NEXT:    [[BOX:%.*]] = alloc_box $@box @callee_owned (@in Int) -> @out Int
 // CHECK-NEXT:    [[PB:%.*]] = project_box [[BOX]]
 // CHECK-NEXT:    copy_value %0
 // CHECK:         [[THUNK:%.*]] = function_ref @_TTRXFo_dSi_dSi_XFo_iSi_iSi_
@@ -85,7 +85,7 @@ func TreeB_cases<T>(_ t: T, l: TreeB<T>, r: TreeB<T>) {
   let _ = TreeB<T>.Leaf(t)
 
 // CHECK-NEXT:    [[METATYPE:%.*]] = metatype $@thin TreeB<T>.Type
-// CHECK-NEXT:    [[BOX:%.*]] = alloc_box $(left: TreeB<T>, right: TreeB<T>)
+// CHECK-NEXT:    [[BOX:%.*]] = alloc_box $@box (left: TreeB<T>, right: TreeB<T>)
 // CHECK-NEXT:    [[PB:%.*]] = project_box [[BOX]]
 // CHECK-NEXT:    [[LEFT:%.*]] = tuple_element_addr [[PB]]
 // CHECK-NEXT:    [[RIGHT:%.*]] = tuple_element_addr [[PB]]
@@ -120,7 +120,7 @@ func TreeInt_cases(_ t: Int, l: TreeInt, r: TreeInt) {
   let _ = TreeInt.Leaf(t)
 
 // CHECK-NEXT:    [[METATYPE:%.*]] = metatype $@thin TreeInt.Type
-// CHECK-NEXT:    [[BOX:%.*]] = alloc_box $(left: TreeInt, right: TreeInt)
+// CHECK-NEXT:    [[BOX:%.*]] = alloc_box $@box (left: TreeInt, right: TreeInt)
 // CHECK-NEXT:    [[PB:%.*]] = project_box [[BOX]]
 // CHECK-NEXT:    [[LEFT:%.*]] = tuple_element_addr [[PB]]
 // CHECK-NEXT:    [[RIGHT:%.*]] = tuple_element_addr [[PB]]

--- a/test/SILGen/init_ref_delegation.swift
+++ b/test/SILGen/init_ref_delegation.swift
@@ -7,7 +7,7 @@ struct S {
   // CHECK-LABEL: sil hidden @_TFV19init_ref_delegation1SC{{.*}} : $@convention(method) (@thin S.Type) -> S {
   init() {
     // CHECK: bb0([[SELF_META:%[0-9]+]] : $@thin S.Type):
-    // CHECK-NEXT:   [[SELF_BOX:%[0-9]+]] = alloc_box $S
+    // CHECK-NEXT:   [[SELF_BOX:%[0-9]+]] = alloc_box $@box S
     // CHECK-NEXT:   [[PB:%.*]] = project_box [[SELF_BOX]]
     // CHECK-NEXT:   [[SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*S
     
@@ -35,7 +35,7 @@ enum E {
   // CHECK-LABEL: sil hidden @_TFO19init_ref_delegation1EC{{.*}} : $@convention(method) (@thin E.Type) -> E
   init() {
     // CHECK: bb0([[E_META:%[0-9]+]] : $@thin E.Type):
-    // CHECK:   [[E_BOX:%[0-9]+]] = alloc_box $E
+    // CHECK:   [[E_BOX:%[0-9]+]] = alloc_box $@box E
     // CHECK:   [[PB:%.*]] = project_box [[E_BOX]]
     // CHECK:   [[E_SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*E
 
@@ -60,7 +60,7 @@ struct S2 {
   // CHECK-LABEL: sil hidden @_TFV19init_ref_delegation2S2C{{.*}} : $@convention(method) (@thin S2.Type) -> S2
   init() {
     // CHECK: bb0([[S2_META:%[0-9]+]] : $@thin S2.Type):
-    // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $S2
+    // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $@box S2
     // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
     // CHECK:   [[SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*S2
 
@@ -91,7 +91,7 @@ class C1 {
  // CHECK-LABEL: sil hidden @_TFC19init_ref_delegation2C1c{{.*}} : $@convention(method) (X, @owned C1) -> @owned C1
   convenience init(x: X) {
     // CHECK: bb0([[X:%[0-9]+]] : $X, [[ORIG_SELF:%[0-9]+]] : $C1):
-    // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $C1
+    // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $@box C1
     // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
     // CHECK:   [[SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*C1
     // CHECK:   store [[ORIG_SELF]] to [[SELF]] : $*C1
@@ -116,7 +116,7 @@ class C1 {
   // CHECK-LABEL: sil hidden @_TFC19init_ref_delegation2C2c{{.*}} : $@convention(method) (X, @owned C2) -> @owned C2
   convenience init(x: X) {
     // CHECK: bb0([[X:%[0-9]+]] : $X, [[ORIG_SELF:%[0-9]+]] : $C2):
-    // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $C2
+    // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $@box C2
     // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
     // CHECK:   [[UNINIT_SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*C2
     // CHECK:   store [[ORIG_SELF]] to [[UNINIT_SELF]] : $*C2

--- a/test/SILGen/let_decls.swift
+++ b/test/SILGen/let_decls.swift
@@ -231,7 +231,7 @@ struct WeirdPropertyTest {
 // CHECK-LABEL: sil hidden @{{.*}}test_weird_property
 func test_weird_property(_ v : WeirdPropertyTest, i : Int) -> Int {
   var v = v
-  // CHECK: [[VBOX:%[0-9]+]] = alloc_box $WeirdPropertyTest
+  // CHECK: [[VBOX:%[0-9]+]] = alloc_box $@box WeirdPropertyTest
   // CHECK: [[PB:%.*]] = project_box [[VBOX]]
   // CHECK: store %0 to [trivial] [[PB]]
 
@@ -458,7 +458,7 @@ struct LetPropertyStruct {
 
 // CHECK-LABEL: sil hidden @{{.*}}testLetPropertyAccessOnLValueBase
 // CHECK: bb0(%0 : $LetPropertyStruct):
-// CHECK:  [[ABOX:%[0-9]+]] = alloc_box $LetPropertyStruct
+// CHECK:  [[ABOX:%[0-9]+]] = alloc_box $@box LetPropertyStruct
 // CHECK:  [[A:%[0-9]+]] = project_box [[ABOX]]
 // CHECK:   store %0 to [trivial] [[A]] : $*LetPropertyStruct
 // CHECK:   [[STRUCT:%[0-9]+]] = load [[A]] : $*LetPropertyStruct

--- a/test/SILGen/lifetime.swift
+++ b/test/SILGen/lifetime.swift
@@ -16,7 +16,7 @@ struct Val {
 // CHECK-LABEL: sil hidden @_TF8lifetime13local_valtypeFT_T_
 func local_valtype() {
     var b: Val
-    // CHECK: [[B:%[0-9]+]] = alloc_box $Val
+    // CHECK: [[B:%[0-9]+]] = alloc_box $@box Val
     // CHECK: destroy_value [[B]]
     // CHECK: return
 }
@@ -24,7 +24,7 @@ func local_valtype() {
 // CHECK-LABEL: sil hidden @_TF8lifetime20local_valtype_branch
 func local_valtype_branch(_ a: Bool) {
     var a = a
-    // CHECK: [[A:%[0-9]+]] = alloc_box $Bool
+    // CHECK: [[A:%[0-9]+]] = alloc_box $@box Bool
 
     if a { return }
     // CHECK: cond_br
@@ -32,7 +32,7 @@ func local_valtype_branch(_ a: Bool) {
     // CHECK: br [[EPILOG:bb[0-9]+]]
 
     var x:Int
-    // CHECK: [[X:%[0-9]+]] = alloc_box $Int
+    // CHECK: [[X:%[0-9]+]] = alloc_box $@box Int
 
     if a { return }
     // CHECK: cond_br
@@ -55,7 +55,7 @@ func local_valtype_branch(_ a: Bool) {
         // CHECK: br [[EPILOG]]
 
         var y:Int
-        // CHECK: [[Y:%[0-9]+]] = alloc_box $Int
+        // CHECK: [[Y:%[0-9]+]] = alloc_box $@box Int
 
         if a { break }
         // CHECK: cond_br
@@ -74,7 +74,7 @@ func local_valtype_branch(_ a: Bool) {
 
         if true {
             var z:Int
-            // CHECK: [[Z:%[0-9]+]] = alloc_box $Int
+            // CHECK: [[Z:%[0-9]+]] = alloc_box $@box Int
 
             if a { break }
             // CHECK: cond_br
@@ -129,7 +129,7 @@ func reftype_return() -> Ref {
 func reftype_arg(_ a: Ref) {
     var a = a
     // CHECK: bb0([[A:%[0-9]+]] : $Ref):
-    // CHECK: [[AADDR:%[0-9]+]] = alloc_box $Ref
+    // CHECK: [[AADDR:%[0-9]+]] = alloc_box $@box Ref
     // CHECK: [[PA:%[0-9]+]] = project_box [[AADDR]]
     // CHECK: store [[A]] to [init] [[PA]]
     // CHECK: destroy_value [[AADDR]]
@@ -148,7 +148,7 @@ func reftype_call_ignore_return() {
 // CHECK-LABEL: sil hidden @_TF8lifetime27reftype_call_store_to_localFT_T_
 func reftype_call_store_to_local() {
     var a = reftype_func()
-    // CHECK: [[A:%[0-9]+]] = alloc_box $Ref
+    // CHECK: [[A:%[0-9]+]] = alloc_box $@box Ref
     // CHECK-NEXT: [[PB:%.*]] = project_box [[A]]
     // CHECK: = function_ref @_TF8lifetime12reftype_funcFT_CS_3Ref : $@convention(thin) () -> @owned Ref
     // CHECK-NEXT: [[R:%[0-9]+]] = apply
@@ -175,7 +175,7 @@ func reftype_call_arg() {
 func reftype_call_with_arg(_ a: Ref) {
     var a = a
     // CHECK: bb0([[A1:%[0-9]+]] : $Ref):
-    // CHECK: [[AADDR:%[0-9]+]] = alloc_box $Ref
+    // CHECK: [[AADDR:%[0-9]+]] = alloc_box $@box Ref
     // CHECK: [[PB:%.*]] = project_box [[AADDR]]
     // CHECK: store [[A1]] to [init] [[PB]]
 
@@ -192,7 +192,7 @@ func reftype_call_with_arg(_ a: Ref) {
 func reftype_reassign(_ a: inout Ref, b: Ref) {
     var b = b
     // CHECK: bb0([[AADDR:%[0-9]+]] : $*Ref, [[B1:%[0-9]+]] : $Ref):
-    // CHECK: [[BADDR:%[0-9]+]] = alloc_box $Ref
+    // CHECK: [[BADDR:%[0-9]+]] = alloc_box $@box Ref
     // CHECK: [[PBB:%.*]] = project_box [[BADDR]]
     a = b
     // CHECK: destroy_value
@@ -336,12 +336,12 @@ func logical_lvalue_lifetime(_ r: RefWithProp, _ i: Int, _ v: Val) {
   var r = r
   var i = i
   var v = v
-  // CHECK: [[RADDR:%[0-9]+]] = alloc_box $RefWithProp
+  // CHECK: [[RADDR:%[0-9]+]] = alloc_box $@box RefWithProp
   // CHECK: [[PR:%[0-9]+]] = project_box [[RADDR]]
-  // CHECK: [[IADDR:%[0-9]+]] = alloc_box $Int
+  // CHECK: [[IADDR:%[0-9]+]] = alloc_box $@box Int
   // CHECK: [[PI:%[0-9]+]] = project_box [[IADDR]]
   // CHECK: store %1 to [trivial] [[PI]]
-  // CHECK: [[VADDR:%[0-9]+]] = alloc_box $Val
+  // CHECK: [[VADDR:%[0-9]+]] = alloc_box $@box Val
   // CHECK: [[PV:%[0-9]+]] = project_box [[VADDR]]
 
   // -- Reference types need to be copy_valued as property method args.
@@ -423,7 +423,7 @@ class Foo<T> {
   // CHECK-LABEL: sil hidden @_TFC8lifetime3FoocfT3chiSi_GS0_x_
     // CHECK: bb0([[CHI:%[0-9]+]] : $Int, [[THISIN:%[0-9]+]] : $Foo<T>):
     // CHECK: [[THIS:%[0-9]+]] = mark_uninitialized
-    // CHECK: [[CHIADDR:%[0-9]+]] = alloc_box $Int
+    // CHECK: [[CHIADDR:%[0-9]+]] = alloc_box $@box Int
     // CHECK: [[PCHI:%[0-9]+]] = project_box [[CHIADDR]]
     // CHECK: store [[CHI]] to [trivial] [[PCHI]]
 
@@ -554,7 +554,7 @@ struct Bar {
   // CHECK-LABEL: sil hidden @_TFV8lifetime3BarC{{.*}}
   init() {
     // CHECK: bb0([[METATYPE:%[0-9]+]] : $@thin Bar.Type):
-    // CHECK: [[THISADDRBOX:%[0-9]+]] = alloc_box $Bar
+    // CHECK: [[THISADDRBOX:%[0-9]+]] = alloc_box $@box Bar
     // CHECK: [[PB:%.*]] = project_box [[THISADDRBOX]]
     // CHECK: [[THISADDR:%[0-9]+]] = mark_uninitialized [rootself] [[PB]]
 
@@ -582,7 +582,7 @@ struct Bas<T> {
   init(yy:T) {
     // CHECK: bb0([[THISADDRPTR:%[0-9]+]] : $*Bas<T>, [[YYADDR:%[0-9]+]] : $*T, [[META:%[0-9]+]] : $@thin Bas<T>.Type):
     // CHECK: alloc_box
-    // CHECK: [[THISADDRBOX:%[0-9]+]] = alloc_box $Bas
+    // CHECK: [[THISADDRBOX:%[0-9]+]] = alloc_box $@box Bas
     // CHECK: [[PB:%.*]] = project_box [[THISADDRBOX]]
     // CHECK: [[THISADDR:%[0-9]+]] = mark_uninitialized [rootself] [[PB]]
 
@@ -612,14 +612,14 @@ class D : B {
   init(x: Int, y: Int) {
     var x = x
     var y = y
-    // CHECK: [[THISADDR1:%[0-9]+]] = alloc_box $D
+    // CHECK: [[THISADDR1:%[0-9]+]] = alloc_box $@box D
     // CHECK: [[PTHIS:%[0-9]+]] = project_box [[THISADDR1]]
     // CHECK: [[THISADDR:%[0-9]+]] = mark_uninitialized [derivedself] [[PTHIS]]
     // CHECK: store [[THIS]] to [[THISADDR]]
-    // CHECK: [[XADDR:%[0-9]+]] = alloc_box $Int
+    // CHECK: [[XADDR:%[0-9]+]] = alloc_box $@box Int
     // CHECK: [[PX:%[0-9]+]] = project_box [[XADDR]]
     // CHECK: store [[X]] to [trivial] [[PX]]
-    // CHECK: [[YADDR:%[0-9]+]] = alloc_box $Int
+    // CHECK: [[YADDR:%[0-9]+]] = alloc_box $@box Int
     // CHECK: [[PY:%[0-9]+]] = project_box [[YADDR]]
     // CHECK: store [[Y]] to [trivial] [[PY]]
 
@@ -640,7 +640,7 @@ class D : B {
 // CHECK-LABEL: sil hidden @_TF8lifetime8downcast
 func downcast(_ b: B) {
   var b = b
-  // CHECK: [[BADDR:%[0-9]+]] = alloc_box $B
+  // CHECK: [[BADDR:%[0-9]+]] = alloc_box $@box B
   // CHECK: [[PB:%[0-9]+]] = project_box [[BADDR]]
   (b as! D).foo()
   // CHECK: [[B:%[0-9]+]] = load [[PB]]

--- a/test/SILGen/metatype_abstraction.swift
+++ b/test/SILGen/metatype_abstraction.swift
@@ -52,7 +52,7 @@ func genericMetatypeFromGenericMetatype<T>(_ x: GenericMetatype<T>)-> T.Type {
   return x.value
 }
 // CHECK-LABEL: sil hidden @_TFs34dynamicMetatypeFromGenericMetatypeFGVs15GenericMetatypeCs1C_MS0_
-// CHECK:         [[XBOX:%[0-9]+]] = alloc_box $GenericMetatype<C>
+// CHECK:         [[XBOX:%[0-9]+]] = alloc_box $@box GenericMetatype<C>
 // CHECK:         [[PX:%[0-9]+]] = project_box [[XBOX]]
 // CHECK:         [[ADDR:%.*]] = struct_element_addr [[PX]] : $*GenericMetatype<C>, #GenericMetatype.value
 // CHECK:         [[META:%.*]] = load [[ADDR]] : $*@thick C.Type
@@ -88,7 +88,7 @@ func dynamicMetatypeToGeneric(_ x: C.Type) {
   takeGeneric(x)
 }
 // CHECK-LABEL: sil hidden @_TFs32dynamicMetatypeToGenericMetatypeFMCs1CT_
-// CHECK:         [[XBOX:%[0-9]+]] = alloc_box $@thick C.Type
+// CHECK:         [[XBOX:%[0-9]+]] = alloc_box $@box (@thick C.Type)
 // CHECK:         [[PX:%[0-9]+]] = project_box [[XBOX]]
 // CHECK:         [[META:%.*]] = load [[PX]] : $*@thick C.Type
 // CHECK:         apply {{%.*}}<C>([[META]]) : $@convention(thin) <τ_0_0> (@thick τ_0_0.Type) -> ()

--- a/test/SILGen/newtype.swift
+++ b/test/SILGen/newtype.swift
@@ -17,7 +17,7 @@ func createErrorDomain(str: String) -> ErrorDomain {
 
 // CHECK-RAW-LABEL: sil shared [transparent] [fragile] @_TFVSC11ErrorDomainCfT8rawValueSS_S_
 // CHECK-RAW: bb0([[STR:%[0-9]+]] : $String,
-// CHECK-RAW: [[SELF_BOX:%[0-9]+]] = alloc_box $ErrorDomain, var, name "self"
+// CHECK-RAW: [[SELF_BOX:%[0-9]+]] = alloc_box $@box ErrorDomain, var, name "self"
 // CHECK-RAW: [[SELF:%[0-9]+]] = project_box [[SELF_BOX]]
 // CHECK-RAW: [[UNINIT_SELF:%[0-9]+]] = mark_uninitialized [rootself] [[SELF]]
 // CHECK-RAW: [[BRIDGE_FN:%[0-9]+]] = function_ref @{{.*}}_bridgeToObjectiveC

--- a/test/SILGen/objc_init_ref_delegation.swift
+++ b/test/SILGen/objc_init_ref_delegation.swift
@@ -8,7 +8,7 @@ extension Gizmo {
   // CHECK-LABEL: sil hidden @_TFE24objc_init_ref_delegationCSo5Gizmoc
   convenience init(int i: Int) {
     // CHECK: bb0([[I:%[0-9]+]] : $Int, [[ORIG_SELF:%[0-9]+]] : $Gizmo):
-    // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $Gizmo
+    // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $@box Gizmo
     // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
     // CHECK:   [[SELFMUI:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*Gizmo
     // CHECK:   store [[ORIG_SELF]] to [[SELFMUI]] : $*Gizmo

--- a/test/SILGen/objc_protocols.swift
+++ b/test/SILGen/objc_protocols.swift
@@ -234,7 +234,7 @@ extension InformallyFunging: NSFunging { }
 // CHECK-LABEL: sil hidden @_TF14objc_protocols28testInitializableExistential
 func testInitializableExistential(_ im: Initializable.Type, i: Int) -> Initializable {
   // CHECK: bb0([[META:%[0-9]+]] : $@thick Initializable.Type, [[I:%[0-9]+]] : $Int):
-// CHECK:   [[I2_BOX:%[0-9]+]] = alloc_box $Initializable
+// CHECK:   [[I2_BOX:%[0-9]+]] = alloc_box $@box Initializable
 // CHECK:   [[PB:%.*]] = project_box [[I2_BOX]]
 // CHECK:   [[ARCHETYPE_META:%[0-9]+]] = open_existential_metatype [[META]] : $@thick Initializable.Type to $@thick (@opened([[N:".*"]]) Initializable).Type
 // CHECK:   [[ARCHETYPE_META_OBJC:%[0-9]+]] = thick_to_objc_metatype [[ARCHETYPE_META]] : $@thick (@opened([[N]]) Initializable).Type to $@objc_metatype (@opened([[N]]) Initializable).Type

--- a/test/SILGen/objc_thunks.swift
+++ b/test/SILGen/objc_thunks.swift
@@ -258,7 +258,7 @@ class Hoozit : Gizmo {
 
   // Constructor.
   // CHECK-LABEL: sil hidden @_TFC11objc_thunks6Hoozitc{{.*}} : $@convention(method) (Int, @owned Hoozit) -> @owned Hoozit {
-  // CHECK: [[SELF_BOX:%[0-9]+]] = alloc_box $Hoozit
+  // CHECK: [[SELF_BOX:%[0-9]+]] = alloc_box $@box Hoozit
   // CHECK: [[PB:%.*]] = project_box [[SELF_BOX]]
   // CHECK: [[SELFMUI:%[0-9]+]] = mark_uninitialized [derivedself] [[PB]]
   // CHECK: [[GIZMO:%[0-9]+]] = upcast [[SELF:%[0-9]+]] : $Hoozit to $Gizmo
@@ -354,10 +354,10 @@ extension Hoozit {
 
   // CHECK-LABEL: sil hidden @_TFC11objc_thunks6Hoozitc{{.*}} : $@convention(method) (Double, @owned Hoozit) -> @owned Hoozit
   convenience init(double d: Double) { 
-    // CHECK: [[SELF_BOX:%[0-9]+]] = alloc_box $Hoozit
+    // CHECK: [[SELF_BOX:%[0-9]+]] = alloc_box $@box Hoozit
     // CHECK: [[PB:%.*]] = project_box [[SELF_BOX]]
     // CHECK: [[SELFMUI:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]]
-    // CHECK: [[X_BOX:%[0-9]+]] = alloc_box $X
+    // CHECK: [[X_BOX:%[0-9]+]] = alloc_box $@box X
     var x = X()
     // CHECK: [[CTOR:%[0-9]+]] = class_method [volatile] [[SELF:%[0-9]+]] : $Hoozit, #Hoozit.init!initializer.1.foreign : (Hoozit.Type) -> (Int) -> Hoozit , $@convention(objc_method) (Int, @owned Hoozit) -> @owned Hoozit
     // CHECK: [[NEW_SELF:%[0-9]+]] = apply [[CTOR]]

--- a/test/SILGen/optional-cast.swift
+++ b/test/SILGen/optional-cast.swift
@@ -5,7 +5,7 @@ class B : A {}
 
 
 // CHECK-LABEL: sil hidden @_TF4main3foo
-// CHECK:      [[X:%.*]] = alloc_box $Optional<B>, var, name "x"
+// CHECK:      [[X:%.*]] = alloc_box $@box Optional<B>, var, name "x"
 // CHECK-NEXT: [[PB:%.*]] = project_box [[X]]
 //   Check whether the temporary holds a value.
 // CHECK:      [[T1:%.*]] = select_enum %0
@@ -41,7 +41,7 @@ func foo(_ y : A?) {
 }
 
 // CHECK-LABEL: sil hidden @_TF4main3bar
-// CHECK:      [[X:%.*]] = alloc_box $Optional<Optional<Optional<B>>>, var, name "x"
+// CHECK:      [[X:%.*]] = alloc_box $@box Optional<Optional<Optional<B>>>, var, name "x"
 // CHECK-NEXT: [[PB:%.*]] = project_box [[X]]
 
 // Check for some(...)
@@ -105,7 +105,7 @@ func bar(_ y : A????) {
 }
 
 // CHECK-LABEL: sil hidden @_TF4main3baz
-// CHECK:      [[X:%.*]] = alloc_box $Optional<B>, var, name "x"
+// CHECK:      [[X:%.*]] = alloc_box $@box Optional<B>, var, name "x"
 // CHECK-NEXT: [[PB:%.*]] = project_box [[X]]
 // CHECK-NEXT: copy_value %0
 // CHECK:      [[T1:%.*]] = select_enum %0
@@ -163,7 +163,7 @@ public struct TestAddressOnlyStruct<T> {
 // CHECK-LABEL: sil hidden @_TF4main35testContextualInitOfNonAddrOnlyTypeFGSqSi_T_
 // CHECK: bb0(%0 : $Optional<Int>):
 // CHECK-NEXT: debug_value %0 : $Optional<Int>, let, name "a"
-// CHECK-NEXT: [[X:%.*]] = alloc_box $Optional<Int>, var, name "x"
+// CHECK-NEXT: [[X:%.*]] = alloc_box $@box Optional<Int>, var, name "x"
 // CHECK-NEXT: [[PB:%.*]] = project_box [[X]]
 // CHECK-NEXT: [[CAST:%.*]] = unchecked_addr_cast [[PB]] : $*Optional<Int> to $*Optional<Int>
 // CHECK-NEXT: store %0 to [trivial] [[CAST]] : $*Optional<Int>

--- a/test/SILGen/optional.swift
+++ b/test/SILGen/optional.swift
@@ -26,10 +26,10 @@ func testAddrOnlyCallResult<T>(_ f: (() -> T)?) {
 }
 // CHECK-LABEL: sil hidden @{{.*}}testAddrOnlyCallResult{{.*}} : $@convention(thin) <T> (@owned Optional<@callee_owned () -> @out T>) -> ()
 // CHECK:    bb0([[T0:%.*]] : $Optional<@callee_owned () -> @out T>):
-// CHECK: [[F:%.*]] = alloc_box $Optional<@callee_owned () -> @out T>, var, name "f"
+// CHECK: [[F:%.*]] = alloc_box $@box Optional<@callee_owned () -> @out T>, var, name "f"
 // CHECK-NEXT: [[PBF:%.*]] = project_box [[F]]
 // CHECK: store [[T0]] to [init] [[PBF]]
-// CHECK-NEXT: [[X:%.*]] = alloc_box $Optional<T>, var, name "x"
+// CHECK-NEXT: [[X:%.*]] = alloc_box $@box Optional<T>, var, name "x"
 // CHECK-NEXT: [[PBX:%.*]] = project_box [[X]]
 // CHECK-NEXT: [[TEMP:%.*]] = init_enum_data_addr [[PBX]]
 //   Check whether 'f' holds a value.

--- a/test/SILGen/pointer_conversion.swift
+++ b/test/SILGen/pointer_conversion.swift
@@ -134,7 +134,7 @@ func stringToPointer(_ s: String) {
 // CHECK-LABEL: sil hidden @_TF18pointer_conversion14inoutToPointerFT_T_ 
 func inoutToPointer() {
   var int = 0
-  // CHECK: [[INT:%.*]] = alloc_box $Int
+  // CHECK: [[INT:%.*]] = alloc_box $@box Int
   // CHECK: [[PB:%.*]] = project_box [[INT]]
   takesMutablePointer(&int)
   // CHECK: [[TAKES_MUTABLE:%.*]] = function_ref @_TF18pointer_conversion19takesMutablePointer
@@ -184,7 +184,7 @@ func takesPlusZeroOptionalPointer(_ x: AutoreleasingUnsafeMutablePointer<C?>) {}
 // CHECK-LABEL: sil hidden @_TF18pointer_conversion19classInoutToPointerFT_T_
 func classInoutToPointer() {
   var c = C()
-  // CHECK: [[VAR:%.*]] = alloc_box $C
+  // CHECK: [[VAR:%.*]] = alloc_box $@box C
   // CHECK: [[PB:%.*]] = project_box [[VAR]]
   takesPlusOnePointer(&c)
   // CHECK: [[TAKES_PLUS_ONE:%.*]] = function_ref @_TF18pointer_conversion19takesPlusOnePointer
@@ -223,7 +223,7 @@ func classInoutToPointer() {
 // rdar://problem/21505805
 // CHECK-LABEL: sil hidden @_TF18pointer_conversion22functionInoutToPointerFT_T_
 func functionInoutToPointer() {
-  // CHECK: [[BOX:%.*]] = alloc_box $@callee_owned () -> ()
+  // CHECK: [[BOX:%.*]] = alloc_box $@box @callee_owned () -> ()
   var f: () -> () = {}
 
   // CHECK: [[REABSTRACT_BUF:%.*]] = alloc_stack $@callee_owned (@in ()) -> @out ()

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -10,7 +10,7 @@ func getInt() -> Int { return zero }
 // CHECK: bb0(%0 : $Int):
 func physical_tuple_lvalue(_ c: Int) {
   var x : (Int, Int)
-  // CHECK: [[BOX:%[0-9]+]] = alloc_box $(Int, Int)
+  // CHECK: [[BOX:%[0-9]+]] = alloc_box $@box (Int, Int)
   // CHECK: [[XADDR1:%.*]] = project_box [[BOX]]
   // CHECK: [[XADDR:%[0-9]+]] = mark_uninitialized [var] [[XADDR1]]
   x.1 = c
@@ -90,7 +90,7 @@ struct Val {
 // CHECK-LABEL: sil hidden  @_TF10properties22physical_struct_lvalue
 func physical_struct_lvalue(_ c: Int) {
   var v : Val
-  // CHECK: [[VADDR:%[0-9]+]] = alloc_box $Val
+  // CHECK: [[VADDR:%[0-9]+]] = alloc_box $@box Val
   v.y = c
   // CHECK: assign %0 to [[X_1]]
 }
@@ -322,7 +322,7 @@ func inout_arg(_ x: inout Int) {}
 // CHECK-LABEL: sil hidden  @_TF10properties14physical_inout
 func physical_inout(_ x: Int) {
   var x = x
-  // CHECK: [[XADDR:%[0-9]+]] = alloc_box $Int
+  // CHECK: [[XADDR:%[0-9]+]] = alloc_box $@box Int
   // CHECK: [[PB:%.*]] = project_box [[XADDR]]
   inout_arg(&x)
   // CHECK: [[INOUT_ARG:%[0-9]+]] = function_ref @_TF10properties9inout_arg
@@ -347,7 +347,7 @@ func val_subscript_get(_ v: Val, i: Int) -> Float {
 func val_subscript_set(_ v: Val, i: Int, x: Float) {
   var v = v
   v[i] = x
-  // CHECK: [[VADDR:%[0-9]+]] = alloc_box $Val
+  // CHECK: [[VADDR:%[0-9]+]] = alloc_box $@box Val
   // CHECK: [[PB:%.*]] = project_box [[VADDR]]
   // CHECK: [[SUBSCRIPT_SET_METHOD:%[0-9]+]] = function_ref @_TFV10properties3Vals9subscript
   // CHECK: apply [[SUBSCRIPT_SET_METHOD]]([[X]], [[I]], [[PB]])
@@ -601,7 +601,7 @@ func local_observing_property(_ arg: Int) {
 
 // CHECK-LABEL: sil hidden @{{.*}}local_observing_property
 // CHECK: bb0([[ARG:%[0-9]+]] : $Int)
-// CHECK: [[BOX:%[0-9]+]] = alloc_box $Int
+// CHECK: [[BOX:%[0-9]+]] = alloc_box $@box Int
 // CHECK: [[PB:%.*]] = project_box [[BOX]]
 // CHECK: store [[ARG]] to [trivial] [[PB]]
 
@@ -979,7 +979,7 @@ struct AddressOnlyReadOnlySubscript {
 }
 
 // CHECK-LABEL: sil hidden @_TF10properties43addressOnlyReadOnlySubscriptFromMutableBase
-// CHECK:         [[BASE:%.*]] = alloc_box $AddressOnlyReadOnlySubscript
+// CHECK:         [[BASE:%.*]] = alloc_box $@box AddressOnlyReadOnlySubscript
 // CHECK:         copy_addr [[BASE:%.*]] to [initialization] [[COPY:%.*]] :
 // CHECK:         [[GETTER:%.*]] = function_ref @_TFV10properties28AddressOnlyReadOnlySubscriptg9subscript
 // CHECK:         apply [[GETTER]]({{%.*}}, [[COPY]])
@@ -997,7 +997,7 @@ struct MutatingGetterStruct {
   }
 
   // CHECK-LABEL: sil hidden @_TZFV10properties20MutatingGetterStruct4test
-  // CHECK: [[X:%.*]] = alloc_box $MutatingGetterStruct, var, name "x"
+  // CHECK: [[X:%.*]] = alloc_box $@box MutatingGetterStruct, var, name "x"
   // CHECK-NEXT: [[PB:%.*]] = project_box [[X]]
   // CHECK: store {{.*}} to [trivial] [[PB]] : $*MutatingGetterStruct
   // CHECK: apply {{%.*}}([[PB]]) : $@convention(method) (@inout MutatingGetterStruct) -> Int

--- a/test/SILGen/protocol_class_refinement.swift
+++ b/test/SILGen/protocol_class_refinement.swift
@@ -28,7 +28,7 @@ class Base {}
 // CHECK-LABEL: sil hidden @_TF25protocol_class_refinement12getObjectUID
 func getObjectUID<T: ObjectUID>(x: T) -> (Int, Int, Int, Int) {
   var x = x
-  // CHECK: [[XBOX:%.*]] = alloc_box $T
+  // CHECK: [[XBOX:%.*]] = alloc_box $@box T
   // CHECK: [[PB:%.*]] = project_box [[XBOX]]
   // -- call x.uid()
   // CHECK: [[X:%.*]] = load [[PB]]
@@ -80,7 +80,7 @@ func getObjectUID<T: ObjectUID>(x: T) -> (Int, Int, Int, Int) {
 // CHECK-LABEL: sil hidden @_TF25protocol_class_refinement16getBaseObjectUID
 func getBaseObjectUID<T: UID where T: Base>(x: T) -> (Int, Int, Int) {
   var x = x
-  // CHECK: [[XBOX:%.*]] = alloc_box $T
+  // CHECK: [[XBOX:%.*]] = alloc_box $@box T
   // CHECK: [[PB:%.*]] = project_box [[XBOX]]
   // -- call x.uid()
   // CHECK: [[X:%.*]] = load [[PB]]

--- a/test/SILGen/protocol_extensions.swift
+++ b/test/SILGen/protocol_extensions.swift
@@ -98,7 +98,7 @@ func inout_func(_ n: inout Int) {}
 // CHECK-LABEL: sil hidden @_TF19protocol_extensions5testDFTVS_10MetaHolder2ddMCS_1D1dS1__T_ : $@convention(thin) (MetaHolder, @thick D.Type, @owned D) -> ()
 // CHECK: bb0([[M:%[0-9]+]] : $MetaHolder, [[DD:%[0-9]+]] : $@thick D.Type, [[D:%[0-9]+]] : $D):
 func testD(_ m: MetaHolder, dd: D.Type, d: D) {
-  // CHECK: [[D2:%[0-9]+]] = alloc_box $D
+  // CHECK: [[D2:%[0-9]+]] = alloc_box $@box D
   // CHECK: [[RESULT:%.*]] = project_box [[D2]]
   // CHECK: [[FN:%[0-9]+]] = function_ref @_TFE19protocol_extensionsPS_2P111returnsSelf{{.*}}
   // CHECK: [[DCOPY:%[0-9]+]] = alloc_stack $D
@@ -523,7 +523,7 @@ func testExistentials1(_ p1: P1, b: Bool, i: Int64) {
 // CHECK-LABEL: sil hidden @_TF19protocol_extensions17testExistentials2
 // CHECK: bb0([[P:%[0-9]+]] : $*P1):
 func testExistentials2(_ p1: P1) {
-  // CHECK: [[P1A:%[0-9]+]] = alloc_box $P1
+  // CHECK: [[P1A:%[0-9]+]] = alloc_box $@box P1
   // CHECK: [[PB:%.*]] = project_box [[P1A]]
   // CHECK: [[POPENED:%[0-9]+]] = open_existential_addr [[P]] : $*P1 to $*@opened([[UUID:".*"]]) P1
   // CHECK: [[P1AINIT:%[0-9]+]] = init_existential_addr [[PB]] : $*P1, $@opened([[UUID2:".*"]]) P1
@@ -552,7 +552,7 @@ func testExistentialsGetters(_ p1: P1) {
 // CHECK: bb0([[P:%[0-9]+]] : $*P1, [[B:%[0-9]+]] : $Bool):
 func testExistentialSetters(_ p1: P1, b: Bool) {
   var p1 = p1
-  // CHECK: [[PBOX:%[0-9]+]] = alloc_box $P1
+  // CHECK: [[PBOX:%[0-9]+]] = alloc_box $@box P1
   // CHECK: [[PBP:%[0-9]+]] = project_box [[PBOX]]
   // CHECK-NEXT: copy_addr [[P]] to [initialization] [[PBP]] : $*P1
   // CHECK: [[POPENED:%[0-9]+]] = open_existential_addr [[PBP]] : $*P1 to $*@opened([[UUID:".*"]]) P1
@@ -583,7 +583,7 @@ struct HasAP1 {
 // CHECK: bb0([[HASP1:%[0-9]+]] : $*HasAP1, [[B:%[0-9]+]] : $Bool)
 func testLogicalExistentialSetters(_ hasAP1: HasAP1, _ b: Bool) {
   var hasAP1 = hasAP1
-  // CHECK: [[HASP1_BOX:%[0-9]+]] = alloc_box $HasAP1
+  // CHECK: [[HASP1_BOX:%[0-9]+]] = alloc_box $@box HasAP1
   // CHECK: [[PBHASP1:%[0-9]+]] = project_box [[HASP1_BOX]]
   // CHECK-NEXT: copy_addr [[HASP1]] to [initialization] [[PBHASP1]] : $*HasAP1
   // CHECK: [[P1_COPY:%[0-9]+]] = alloc_stack $P1
@@ -607,7 +607,7 @@ func plusOneP1() -> P1 {}
 func test_open_existential_semantics_opaque(_ guaranteed: P1,
                                             immediate: P1) {
   var immediate = immediate
-  // CHECK: [[IMMEDIATE_BOX:%.*]] = alloc_box $P1
+  // CHECK: [[IMMEDIATE_BOX:%.*]] = alloc_box $@box P1
   // CHECK: [[PB:%.*]] = project_box [[IMMEDIATE_BOX]]
   // CHECK: [[VALUE:%.*]] = open_existential_addr %0
   // CHECK: [[METHOD:%.*]] = function_ref
@@ -647,7 +647,7 @@ func plusOneCP1() -> CP1 {}
 func test_open_existential_semantics_class(_ guaranteed: CP1,
                                            immediate: CP1) {
   var immediate = immediate
-  // CHECK: [[IMMEDIATE_BOX:%.*]] = alloc_box $CP1
+  // CHECK: [[IMMEDIATE_BOX:%.*]] = alloc_box $@box CP1
   // CHECK: [[PB:%.*]] = project_box [[IMMEDIATE_BOX]]
 
   // CHECK-NOT: copy_value %0
@@ -750,7 +750,7 @@ extension ProtoDelegatesToObjC where Self : ObjCInitClass {
   // CHECK-LABEL: sil hidden @_TFe19protocol_extensionsRxCS_13ObjCInitClassxS_20ProtoDelegatesToObjCrS1_C{{.*}}
   // CHECK: bb0([[STR:%[0-9]+]] : $String, [[SELF_META:%[0-9]+]] : $@thick Self.Type):
   init(string: String) {
-    // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $Self
+    // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $@box Self
     // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
     // CHECK:   [[SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*Self
     // CHECK:   [[SELF_META_OBJC:%[0-9]+]] = thick_to_objc_metatype [[SELF_META]] : $@thick Self.Type to $@objc_metatype Self.Type
@@ -776,7 +776,7 @@ extension ProtoDelegatesToRequired where Self : RequiredInitClass {
   // CHECK-LABEL: sil hidden @_TFe19protocol_extensionsRxCS_17RequiredInitClassxS_24ProtoDelegatesToRequiredrS1_C{{.*}} 
   // CHECK: bb0([[STR:%[0-9]+]] : $String, [[SELF_META:%[0-9]+]] : $@thick Self.Type):
   init(string: String) {
-  // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $Self
+  // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $@box Self
   // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
   // CHECK:   [[SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*Self
   // CHECK:   [[SELF_META_AS_CLASS_META:%[0-9]+]] = upcast [[SELF_META]] : $@thick Self.Type to $@thick RequiredInitClass.Type

--- a/test/SILGen/protocol_optional.swift
+++ b/test/SILGen/protocol_optional.swift
@@ -12,10 +12,10 @@
 func optionalMethodGeneric<T : P1>(t t : T) {
   var t = t
   // CHECK: bb0([[T:%[0-9]+]] : $T):
-  // CHECK: [[TBOX:%[0-9]+]] = alloc_box $T
+  // CHECK: [[TBOX:%[0-9]+]] = alloc_box $@box T
   // CHECK-NEXT: [[PT:%[0-9]+]] = project_box [[TBOX]]
   // CHECK: store [[T]] to [init] [[PT]] : $*T
-  // CHECK-NEXT: [[OPT_BOX:%[0-9]+]] = alloc_box $Optional<@callee_owned (Int) -> ()>
+  // CHECK-NEXT: [[OPT_BOX:%[0-9]+]] = alloc_box $@box Optional<@callee_owned (Int) -> ()>
   // CHECK-NEXT: project_box [[OPT_BOX]]
   // CHECK-NEXT: [[T:%[0-9]+]] = load [[PT]] : $*T
   // CHECK-NEXT: copy_value [[T]] : $T
@@ -28,10 +28,10 @@ func optionalMethodGeneric<T : P1>(t t : T) {
 func optionalPropertyGeneric<T : P1>(t t : T) {
   var t = t
   // CHECK: bb0([[T:%[0-9]+]] : $T):
-  // CHECK: [[TBOX:%[0-9]+]] = alloc_box $T
+  // CHECK: [[TBOX:%[0-9]+]] = alloc_box $@box T
   // CHECK-NEXT: [[PT:%[0-9]+]] = project_box [[TBOX]]
   // CHECK: store [[T]] to [init] [[PT]] : $*T
-  // CHECK-NEXT: [[OPT_BOX:%[0-9]+]] = alloc_box $Optional<Int>
+  // CHECK-NEXT: [[OPT_BOX:%[0-9]+]] = alloc_box $@box Optional<Int>
   // CHECK-NEXT: project_box [[OPT_BOX]]
   // CHECK-NEXT: [[T:%[0-9]+]] = load [[PT]] : $*T
   // CHECK-NEXT: copy_value [[T]] : $T
@@ -44,10 +44,10 @@ func optionalPropertyGeneric<T : P1>(t t : T) {
 func optionalSubscriptGeneric<T : P1>(t t : T) {
   var t = t
   // CHECK: bb0([[T:%[0-9]+]] : $T):
-  // CHECK: [[TBOX:%[0-9]+]] = alloc_box $T
+  // CHECK: [[TBOX:%[0-9]+]] = alloc_box $@box T
   // CHECK-NEXT: [[PT:%[0-9]+]] = project_box [[TBOX]]
   // CHECK: store [[T]] to [init] [[PT]] : $*T
-  // CHECK-NEXT: [[OPT_BOX:%[0-9]+]] = alloc_box $Optional<Int>
+  // CHECK-NEXT: [[OPT_BOX:%[0-9]+]] = alloc_box $@box Optional<Int>
   // CHECK-NEXT: project_box [[OPT_BOX]]
   // CHECK-NEXT: [[T:%[0-9]+]] = load [[PT]] : $*T
   // CHECK-NEXT: copy_value [[T]] : $T

--- a/test/SILGen/reabstract_lvalue.swift
+++ b/test/SILGen/reabstract_lvalue.swift
@@ -12,7 +12,7 @@ func transform(_ i: Int) -> Double {
 
 // CHECK-LABEL: sil hidden @_TF17reabstract_lvalue23reabstractFunctionInOutFT_T_ : $@convention(thin) () -> ()
 func reabstractFunctionInOut() {
-  // CHECK: [[BOX:%.*]] = alloc_box $@callee_owned (Int) -> Double
+  // CHECK: [[BOX:%.*]] = alloc_box $@box @callee_owned (Int) -> Double
   // CHECK: [[PB:%.*]] = project_box [[BOX]]
   // CHECK: [[ARG:%.*]] = function_ref @_TF17reabstract_lvalue9transformFSiSd
   // CHECK: [[THICK_ARG:%.*]] = thin_to_thick_function [[ARG]]

--- a/test/SILGen/sil_locations.swift
+++ b/test/SILGen/sil_locations.swift
@@ -145,7 +145,7 @@ func testSwitch() {
   // CHECK: cond_br
   //
     var z: Int = 200
-  // CHECK: [[VAR_Z:%[0-9]+]] = alloc_box $Int, var, name "z"{{.*}}line:[[@LINE-1]]:9
+  // CHECK: [[VAR_Z:%[0-9]+]] = alloc_box $@box Int, var, name "z"{{.*}}line:[[@LINE-1]]:9
   // CHECK: integer_literal $Builtin.Int2048, 200, loc "{{.*}}":[[@LINE-2]]:18
     x = z
   // CHECK:  destroy_value [[VAR_Z]]{{.*}}, loc "{{.*}}":[[@LINE-1]]:9, {{.*}}:cleanup
@@ -186,7 +186,7 @@ func testFor() {
   }
 
   // CHECK-LABEL: sil hidden @_TF13sil_locations7testForFT_T_
-  // CHECK: [[VAR_Y_IN_FOR:%[0-9]+]]  = alloc_box $Int, var, name "y", loc "{{.*}}":[[@LINE-10]]:9
+  // CHECK: [[VAR_Y_IN_FOR:%[0-9]+]]  = alloc_box $@box Int, var, name "y", loc "{{.*}}":[[@LINE-10]]:9
   // CHECK: integer_literal $Builtin.Int2048, 300, loc "{{.*}}":[[@LINE-11]]:18
   // CHECK: destroy_value [[VAR_Y_IN_FOR]] : $@box Int
   // CHECK: br bb{{.*}}, loc "{{.*}}":[[@LINE-10]]:7

--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -501,7 +501,7 @@ func defer_in_generic<T>(_ x: T) {
 // CHECK-LABEL: sil hidden @_TF10statements13defer_mutableFSiT_
 func defer_mutable(_ x: Int) {
   var x = x
-  // CHECK: [[BOX:%.*]] = alloc_box $Int
+  // CHECK: [[BOX:%.*]] = alloc_box $@box Int
   // CHECK-NEXT: project_box [[BOX]]
   // CHECK-NOT: [[BOX]]
   // CHECK: function_ref @_TFF10statements13defer_mutableFSiT_L_6$deferfT_T_ : $@convention(thin) (@inout_aliasable Int) -> ()

--- a/test/SILGen/super_init_refcounting.swift
+++ b/test/SILGen/super_init_refcounting.swift
@@ -8,7 +8,7 @@ class Foo {
 
 class Bar: Foo {
   // CHECK-LABEL: sil hidden @_TFC22super_init_refcounting3Barc
-  // CHECK:         [[SELF_VAR:%.*]] = alloc_box $Bar
+  // CHECK:         [[SELF_VAR:%.*]] = alloc_box $@box Bar
   // CHECK:         [[PB:%.*]] = project_box [[SELF_VAR]]
   // CHECK:         [[SELF_MUI:%.*]] =  mark_uninitialized [derivedself] [[PB]]
   // CHECK:         [[ORIG_SELF:%.*]] = load [[SELF_MUI]]
@@ -26,7 +26,7 @@ class Bar: Foo {
 
 extension Foo {
   // CHECK-LABEL: sil hidden @_TFC22super_init_refcounting3Fooc
-  // CHECK:         [[SELF_VAR:%.*]] = alloc_box $Foo
+  // CHECK:         [[SELF_VAR:%.*]] = alloc_box $@box Foo
   // CHECK:         [[PB:%.*]] = project_box [[SELF_VAR]]
   // CHECK:         [[SELF_MUI:%.*]] =  mark_uninitialized [delegatingself] [[PB]]
   // CHECK:         [[ORIG_SELF:%.*]] = load [[SELF_MUI]]
@@ -72,7 +72,7 @@ class Good: Foo {
   let x: Int
 
   // CHECK-LABEL: sil hidden @_TFC22super_init_refcounting4Goodc
-  // CHECK:         [[SELF_BOX:%.*]] = alloc_box $Good
+  // CHECK:         [[SELF_BOX:%.*]] = alloc_box $@box Good
   // CHECK:         [[PB:%.*]] = project_box [[SELF_BOX]]
   // CHECK:         [[SELF:%.*]] = mark_uninitialized [derivedself] [[PB]]
   // CHECK:         store %0 to [[SELF]]

--- a/test/SILGen/switch_fallthrough.swift
+++ b/test/SILGen/switch_fallthrough.swift
@@ -107,7 +107,7 @@ func test3() {
 // Fallthrough should clean up nested pattern variables from the exited scope.
 func test4() {
   switch (foo(), bar()) {
-  // CHECK:   [[A:%.*]] = alloc_box $(Int, Int)
+  // CHECK:   [[A:%.*]] = alloc_box $@box (Int, Int)
   // CHECK:   cond_br {{%.*}}, [[CASE1:bb[0-9]+]], {{bb[0-9]+}}
   case var a where runced():
   // CHECK: [[CASE1]]:
@@ -118,8 +118,8 @@ func test4() {
   // CHECK:   br [[CONT:bb[0-9]+]]
     ()
 
-  // CHECK:   [[B:%.*]] = alloc_box $Int
-  // CHECK:   [[C:%.*]] = alloc_box $Int
+  // CHECK:   [[B:%.*]] = alloc_box $@box Int
+  // CHECK:   [[C:%.*]] = alloc_box $@box Int
   // CHECK:   cond_br {{%.*}}, [[CASE4:bb[0-9]+]],
   case (var b, var c) where ansed():
   // CHECK: [[CASE4]]:

--- a/test/SILGen/switch_var.swift
+++ b/test/SILGen/switch_var.swift
@@ -46,7 +46,7 @@ func cc(x x: (Int, Int)) {}
 func test_var_1() {
   // CHECK:   function_ref @_TF10switch_var3fooFT_Si
   switch foo() {
-  // CHECK:   [[XADDR:%.*]] = alloc_box $Int
+  // CHECK:   [[XADDR:%.*]] = alloc_box $@box Int
   // CHECK:   [[X:%.*]] = project_box [[XADDR]]
   // CHECK-NOT: br bb
   case var x:
@@ -65,7 +65,7 @@ func test_var_1() {
 func test_var_2() {
   // CHECK:   function_ref @_TF10switch_var3fooFT_Si
   switch foo() {
-  // CHECK:   [[XADDR:%.*]] = alloc_box $Int
+  // CHECK:   [[XADDR:%.*]] = alloc_box $@box Int
   // CHECK:   [[X:%.*]] = project_box [[XADDR]]
   // CHECK:   function_ref @_TF10switch_var6runcedFT1xSi_Sb
   // CHECK:   load [[X]]
@@ -79,7 +79,7 @@ func test_var_2() {
   // CHECK:   br [[CONT:bb[0-9]+]]
     a(x: x)
   // CHECK: [[NO_CASE1]]:
-  // CHECK:   [[YADDR:%.*]] = alloc_box $Int
+  // CHECK:   [[YADDR:%.*]] = alloc_box $@box Int
   // CHECK:   [[Y:%.*]] = project_box [[YADDR]]
   // CHECK:   function_ref @_TF10switch_var6fungedFT1xSi_Sb
   // CHECK:   load [[Y]]
@@ -95,7 +95,7 @@ func test_var_2() {
   // CHECK:   br [[CASE3:bb[0-9]+]]
   case var z:
   // CHECK: [[CASE3]]:
-  // CHECK:   [[ZADDR:%.*]] = alloc_box $Int
+  // CHECK:   [[ZADDR:%.*]] = alloc_box $@box Int
   // CHECK:   [[Z:%.*]] = project_box [[ZADDR]]
   // CHECK:   function_ref @_TF10switch_var1cFT1xSi_T_
   // CHECK:   load [[Z]]
@@ -113,7 +113,7 @@ func test_var_3() {
   // CHECK:   function_ref @_TF10switch_var3fooFT_Si
   // CHECK:   function_ref @_TF10switch_var3barFT_Si
   switch (foo(), bar()) {
-  // CHECK:   [[XADDR:%.*]] = alloc_box $(Int, Int)
+  // CHECK:   [[XADDR:%.*]] = alloc_box $@box (Int, Int)
   // CHECK:   [[X:%.*]] = project_box [[XADDR]]
   // CHECK:   function_ref @_TF10switch_var6runcedFT1xSi_Sb
   // CHECK:   tuple_element_addr [[X]] : {{.*}}, 0
@@ -126,9 +126,9 @@ func test_var_3() {
   // CHECK:   br [[CONT:bb[0-9]+]]
     aa(x: x)
   // CHECK: [[NO_CASE1]]:
-  // CHECK:   [[YADDR:%.*]] = alloc_box $Int
+  // CHECK:   [[YADDR:%.*]] = alloc_box $@box Int
   // CHECK:   [[Y:%.*]] = project_box [[YADDR]]
-  // CHECK:   [[Z:%.*]] = alloc_box $Int
+  // CHECK:   [[Z:%.*]] = alloc_box $@box Int
   // CHECK:   [[Z:%.*]] = project_box [[ZADDR]]
   // CHECK:   function_ref @_TF10switch_var6fungedFT1xSi_Sb
   // CHECK:   load [[Y]]
@@ -145,7 +145,7 @@ func test_var_3() {
     a(x: y)
     b(x: z)
   // CHECK: [[NO_CASE2]]:
-  // CHECK:   [[WADDR:%.*]] = alloc_box $(Int, Int)
+  // CHECK:   [[WADDR:%.*]] = alloc_box $@box (Int, Int)
   // CHECK:   [[W:%.*]] = project_box [[WADDR]]
   // CHECK:   function_ref @_TF10switch_var5ansedFT1xSi_Sb
   // CHECK:   tuple_element_addr [[W]] : {{.*}}, 0
@@ -161,7 +161,7 @@ func test_var_3() {
   // CHECK:   br [[CASE4:bb[0-9]+]]
   case var v:
   // CHECK: [[CASE4]]:
-  // CHECK:   [[VADDR:%.*]] = alloc_box $(Int, Int) 
+  // CHECK:   [[VADDR:%.*]] = alloc_box $@box (Int, Int) 
   // CHECK:   [[V:%.*]] = project_box [[VADDR]]
   // CHECK:   function_ref @_TF10switch_var2ccFT1xTSiSi__T_
   // CHECK:   load [[V]]
@@ -194,7 +194,7 @@ func test_var_4(p p: P) {
 
   // CHECK: [[IS_X]]:
   // CHECK:   [[T0:%.*]] = load [[TMP]] : $*X
-  // CHECK:   [[XADDR:%.*]] = alloc_box $Int
+  // CHECK:   [[XADDR:%.*]] = alloc_box $@box Int
   // CHECK:   [[X:%.*]] = project_box [[XADDR]]
   // CHECK:   store [[PAIR_1]] to [[X]]
   // CHECK:   function_ref @_TF10switch_var6runcedFT1xSi_Sb
@@ -224,7 +224,7 @@ func test_var_4(p p: P) {
 
   // CHECK: [[IS_Y]]:
   // CHECK:   [[T0:%.*]] = load [[TMP]] : $*Y
-  // CHECK:   [[YADDR:%.*]] = alloc_box $Int
+  // CHECK:   [[YADDR:%.*]] = alloc_box $@box Int
   // CHECK:   [[Y:%.*]] = project_box [[YADDR]]
   // CHECK:   store [[PAIR_1]] to [[Y]]
   // CHECK:   function_ref @_TF10switch_var6fungedFT1xSi_Sb
@@ -251,7 +251,7 @@ func test_var_4(p p: P) {
   // CHECK:   br [[NEXT]]
 
   // CHECK: [[NEXT]]:
-  // CHECK:   [[ZADDR:%.*]] = alloc_box $(P, Int)
+  // CHECK:   [[ZADDR:%.*]] = alloc_box $@box (P, Int)
   // CHECK:   [[Z:%.*]] = project_box [[ZADDR]]
   // CHECK:   function_ref @_TF10switch_var5ansedFT1xSi_Sb
   // CHECK:   tuple_element_addr [[Z]] : {{.*}}, 1
@@ -271,7 +271,7 @@ func test_var_4(p p: P) {
   case (_, var w):
   // CHECK: [[CASE4]]:
   // CHECK:   [[PAIR_0:%.*]] = tuple_element_addr [[PAIR]] : $*(P, Int), 0
-  // CHECK:   [[WADDR:%.*]] = alloc_box $Int
+  // CHECK:   [[WADDR:%.*]] = alloc_box $@box Int
   // CHECK:   [[W:%.*]] = project_box [[WADDR]]
   // CHECK:   function_ref @_TF10switch_var1dFT1xSi_T_
   // CHECK:   load [[W]]
@@ -289,7 +289,7 @@ func test_var_5() {
   // CHECK:   function_ref @_TF10switch_var3fooFT_Si
   // CHECK:   function_ref @_TF10switch_var3barFT_Si
   switch (foo(), bar()) {
-  // CHECK:   [[XADDR:%.*]] = alloc_box $(Int, Int)
+  // CHECK:   [[XADDR:%.*]] = alloc_box $@box (Int, Int)
   // CHECK:   [[X:%.*]] = project_box [[XADDR]]
   // CHECK:   cond_br {{%.*}}, [[CASE1:bb[0-9]+]], [[NO_CASE1:bb[0-9]+]]
   case var x where runced(x: x.0):
@@ -297,9 +297,9 @@ func test_var_5() {
   // CHECK:   br [[CONT:bb[0-9]+]]
     a()
   // CHECK: [[NO_CASE1]]:
-  // CHECK:   [[YADDR:%[0-9]+]] = alloc_box $Int
+  // CHECK:   [[YADDR:%[0-9]+]] = alloc_box $@box Int
   // CHECK:   [[Y:%[0-9]+]] = project_box [[YADDR]]
-  // CHECK:   [[ZADDR:%[0-9]+]] = alloc_box $Int
+  // CHECK:   [[ZADDR:%[0-9]+]] = alloc_box $@box Int
   // CHECK:   [[Z:%[0-9]+]] = project_box [[ZADDR]]
   // CHECK:   cond_br {{%.*}}, [[CASE2:bb[0-9]+]], [[NO_CASE2:bb[0-9]+]]
   case (var y, var z) where funged(x: y):
@@ -331,16 +331,16 @@ func test_var_5() {
 func test_var_return() {
   switch (foo(), bar()) {
   case var x where runced():
-    // CHECK: [[XADDR:%[0-9]+]] = alloc_box $(Int, Int)
+    // CHECK: [[XADDR:%[0-9]+]] = alloc_box $@box (Int, Int)
     // CHECK: [[X:%[0-9]+]] = project_box [[XADDR]]
     // CHECK: function_ref @_TF10switch_var1aFT_T_
     // CHECK: destroy_value [[XADDR]]
     // CHECK: br [[EPILOG:bb[0-9]+]]
     a()
     return
-  // CHECK: [[YADDR:%[0-9]+]] = alloc_box $Int
+  // CHECK: [[YADDR:%[0-9]+]] = alloc_box $@box Int
   // CHECK: [[Y:%[0-9]+]] = project_box [[YADDR]]
-  // CHECK: [[ZADDR:%[0-9]+]] = alloc_box $Int
+  // CHECK: [[ZADDR:%[0-9]+]] = alloc_box $@box Int
   // CHECK: [[Z:%[0-9]+]] = project_box [[ZADDR]]
   case (var y, var z) where funged():
     // CHECK: function_ref @_TF10switch_var1bFT_T_
@@ -350,7 +350,7 @@ func test_var_return() {
     b()
     return
   case var w where ansed():
-    // CHECK: [[WADDR:%[0-9]+]] = alloc_box $(Int, Int)
+    // CHECK: [[WADDR:%[0-9]+]] = alloc_box $@box (Int, Int)
     // CHECK: [[W:%[0-9]+]] = project_box [[WADDR]]
     // CHECK: function_ref @_TF10switch_var1cFT_T_
     // CHECK-NOT: destroy_value [[ZADDR]]
@@ -360,7 +360,7 @@ func test_var_return() {
     c()
     return
   case var v:
-    // CHECK: [[VADDR:%[0-9]+]] = alloc_box $(Int, Int)
+    // CHECK: [[VADDR:%[0-9]+]] = alloc_box $@box (Int, Int)
     // CHECK: [[V:%[0-9]+]] = project_box [[VADDR]]
     // CHECK: function_ref @_TF10switch_var1dFT_T_
     // CHECK-NOT: destroy_value [[ZADDR]]
@@ -442,7 +442,7 @@ func test_mixed_let_var() {
   // CHECK: [[VAL:%.*]] = apply [[FOOS]]()
   switch foos() {
   case var x where runced():
-    // CHECK: [[BOX:%.*]] = alloc_box $String, var, name "x"
+    // CHECK: [[BOX:%.*]] = alloc_box $@box String, var, name "x"
     // CHECK: [[PBOX:%.*]] = project_box [[BOX]]
     // CHECK: [[VAL_COPY:%.*]] = copy_value [[VAL]]
     // CHECK: store [[VAL_COPY]] to [[PBOX]]

--- a/test/SILGen/tuples.swift
+++ b/test/SILGen/tuples.swift
@@ -23,9 +23,9 @@ func make_xy() -> (x: Int, y: P) { return (make_int(), make_p()) }
 
 // CHECK-LABEL: sil hidden @_TF6tuples17testShuffleOpaqueFT_T_
 func testShuffleOpaque() {
-  // CHECK: [[X:%.*]] = alloc_box $P
+  // CHECK: [[X:%.*]] = alloc_box $@box P
   // CHECK-NEXT: [[PBX:%.*]] = project_box [[X]]
-  // CHECK: [[Y:%.*]] = alloc_box $Int
+  // CHECK: [[Y:%.*]] = alloc_box $@box Int
   // CHECK-NEXT: [[PBY:%.*]] = project_box [[Y]]
 
   // CHECK:      [[T0:%.*]] = function_ref @_TF6tuples7make_xyFT_T1xSi1yPS_1P__
@@ -33,7 +33,7 @@ func testShuffleOpaque() {
   // CHECK-NEXT: store [[T1]] to [trivial] [[PBY]]
   var (x,y) : (y:P, x:Int) = make_xy()
 
-  // CHECK-NEXT: [[PAIR:%.*]] = alloc_box $(y: P, x: Int)
+  // CHECK-NEXT: [[PAIR:%.*]] = alloc_box $@box (y: P, x: Int)
   // CHECK-NEXT: [[PBPAIR:%.*]] = project_box [[PAIR]]
   // CHECK-NEXT: [[PAIR_0:%.*]] = tuple_element_addr [[PBPAIR]] : $*(y: P, x: Int), 0
   // CHECK-NEXT: [[PAIR_1:%.*]] = tuple_element_addr [[PBPAIR]] : $*(y: P, x: Int), 1
@@ -57,9 +57,9 @@ func testShuffleOpaque() {
 
 // CHECK-LABEL: testShuffleTuple
 func testShuffleTuple() {
-  // CHECK: [[X:%.*]] = alloc_box $P
+  // CHECK: [[X:%.*]] = alloc_box $@box P
   // CHECK-NEXT: [[PBX:%.*]] = project_box [[X]]
-  // CHECK: [[Y:%.*]] = alloc_box $Int
+  // CHECK: [[Y:%.*]] = alloc_box $@box Int
   // CHECK-NEXT: [[PBY:%.*]] = project_box [[Y]]
 
   // CHECK:      [[T0:%.*]] = function_ref @_TF6tuples8make_intFT_Si
@@ -70,7 +70,7 @@ func testShuffleTuple() {
   // CHECK-NEXT: apply [[T0]]([[PBX]])
   var (x,y) : (y:P, x:Int) = (x: make_int(), y: make_p())
 
-  // CHECK-NEXT: [[PAIR:%.*]] = alloc_box $(y: P, x: Int)
+  // CHECK-NEXT: [[PAIR:%.*]] = alloc_box $@box (y: P, x: Int)
   // CHECK-NEXT: [[PBPAIR:%.*]] = project_box [[PAIR]]
   // CHECK-NEXT: [[PAIR_0:%.*]] = tuple_element_addr [[PBPAIR]] : $*(y: P, x: Int), 0
   // CHECK-NEXT: [[PAIR_1:%.*]] = tuple_element_addr [[PBPAIR]] : $*(y: P, x: Int), 1

--- a/test/SILGen/types.swift
+++ b/test/SILGen/types.swift
@@ -27,7 +27,7 @@ struct S {
     var x = x
     // CHECK: bb0([[X:%[0-9]+]] : $Int, [[THIS:%[0-9]+]] : $*S):
     member = x
-    // CHECK: [[XADDR:%[0-9]+]] = alloc_box $Int
+    // CHECK: [[XADDR:%[0-9]+]] = alloc_box $@box Int
     // CHECK: [[X:%[0-9]+]] = project_box [[XADDR]]
     // CHECK: [[MEMBER:%[0-9]+]] = struct_element_addr [[THIS]] : $*S, #S.member
     // CHECK: copy_addr [[X]] to [[MEMBER]]

--- a/test/SILGen/unowned.swift
+++ b/test/SILGen/unowned.swift
@@ -41,12 +41,12 @@ func test0(c c: C) {
 // CHECK:    bb0(%0 : $C):
 
   var a: A
-// CHECK:      [[A1:%.*]] = alloc_box $A
+// CHECK:      [[A1:%.*]] = alloc_box $@box A
 // CHECK:      [[PBA:%.*]] = project_box [[A1]]
 // CHECK:      [[A:%.*]] = mark_uninitialized [var] [[PBA]]
 
   unowned var x = c
-// CHECK:      [[X:%.*]] = alloc_box $@sil_unowned C
+// CHECK:      [[X:%.*]] = alloc_box $@box @sil_unowned C
 // CHECK-NEXT: [[PBX:%.*]] = project_box [[X]]
 // CHECK-NEXT: [[T2:%.*]] = ref_to_unowned %0 : $C  to $@sil_unowned C
 // CHECK-NEXT: unowned_retain [[T2]] : $@sil_unowned C
@@ -74,7 +74,7 @@ func unowned_local() -> C {
   // CHECK: [[c:%.*]] = apply
   let c = C()
 
-  // CHECK: [[uc:%.*]] = alloc_box $@sil_unowned C, let, name "uc"
+  // CHECK: [[uc:%.*]] = alloc_box $@box @sil_unowned C, let, name "uc"
   // CHECK-NEXT: [[PB:%.*]] = project_box [[uc]]
   // CHECK-NEXT: [[tmp1:%.*]] = ref_to_unowned [[c]] : $C to $@sil_unowned C
   // CHECK-NEXT: unowned_retain [[tmp1]]

--- a/test/SILGen/weak.swift
+++ b/test/SILGen/weak.swift
@@ -14,16 +14,16 @@ struct A {
 func test0(c c: C) {
   var c = c
 // CHECK:    bb0(%0 : $C):
-// CHECK:      [[C:%.*]] = alloc_box $C
+// CHECK:      [[C:%.*]] = alloc_box $@box C
 // CHECK-NEXT: [[PBC:%.*]] = project_box [[C]]
 
   var a: A
-// CHECK:      [[A1:%.*]] = alloc_box $A
+// CHECK:      [[A1:%.*]] = alloc_box $@box A
 // CHECK-NEXT: [[PBA:%.*]] = project_box [[A1]]
 // CHECK:      [[A:%.*]] = mark_uninitialized [var] [[PBA]]
 
   weak var x = c
-// CHECK:      [[X:%.*]] = alloc_box $@sil_weak Optional<C>, var, name "x"
+// CHECK:      [[X:%.*]] = alloc_box $@box @sil_weak Optional<C>, var, name "x"
 // CHECK-NEXT: [[PBX:%.*]] = project_box [[X]]
 //   Implicit conversion
 // CHECK-NEXT: [[TMP:%.*]] = load [[PBC]] : $*C
@@ -64,7 +64,7 @@ class CC {
   weak var x: CC?
 
   // CHECK-LABEL: sil hidden @_TFC4weak2CCc
-  // CHECK:  [[FOO:%.*]] = alloc_box $Optional<CC>
+  // CHECK:  [[FOO:%.*]] = alloc_box $@box Optional<CC>
   // CHECK:  [[PB:%.*]] = project_box [[FOO]]
   // CHECK:  [[X:%.*]] = ref_element_addr %2 : $CC, #CC.x
   // CHECK:  [[VALUE:%.*]] = load_weak [[X]] : $*@sil_weak Optional<CC>

--- a/test/SILOptimizer/allocbox_to_stack.sil
+++ b/test/SILOptimizer/allocbox_to_stack.sil
@@ -13,7 +13,7 @@ struct Bool {
 // CHECK-LABEL: sil @simple_promotion
 sil @simple_promotion : $(Int) -> Int {
 bb0(%0 : $Int):
-  %1 = alloc_box $Int
+  %1 = alloc_box $@box Int
   %1a = project_box %1 : $@box Int, 0
   %2 = store %0 to %1a : $*Int
   %3 = load %1a : $*Int
@@ -29,7 +29,7 @@ bb0(%0 : $Int):
 // CHECK-LABEL: sil @double_project_box
 sil @double_project_box : $(Int) -> (Int, Int) {
 bb0(%0 : $Int):
-  %1 = alloc_box $Int
+  %1 = alloc_box $@box Int
   %1a = project_box %1 : $@box Int, 0
   %2 = store %0 to %1a : $*Int
   %3 = load %1a : $*Int
@@ -48,7 +48,7 @@ bb0(%0 : $Int):
 // CHECK-LABEL: sil @init_var
 sil @init_var : $() -> Int {
 bb0:
-  %1 = alloc_box $Int
+  %1 = alloc_box $@box Int
   %1a = project_box %1 : $@box Int, 0
   %3 = load %1a : $*Int
   %4 = strong_release %1 : $@box Int
@@ -65,7 +65,7 @@ bb0:
 // CHECK-LABEL: sil @multi_strong_release
 sil @multi_strong_release : $() -> Int {
 bb0:
-  %1 = alloc_box $Int
+  %1 = alloc_box $@box Int
   %1a = project_box %1 : $@box Int, 0
   %2 = mark_uninitialized [rootself] %1a : $*Int
   %3 = load %2 : $*Int
@@ -92,9 +92,9 @@ sil @struct_tuple_element_addr : $(Int) -> Int {
 bb1(%0 : $Int):
 // CHECK-DAG: [[STRUCT:%.*]] = alloc_stack $TestStruct
 // CHECK-DAG: [[TUPLE:%.*]] = alloc_stack $(Int, Int)
-  %1 = alloc_box $TestStruct
+  %1 = alloc_box $@box TestStruct
   %1a = project_box %1 : $@box TestStruct, 0
-  %a = alloc_box $(Int, Int)
+  %a = alloc_box $@box (Int, Int)
   %aa = project_box %a : $@box (Int, Int), 0
 
   %2 = struct_element_addr %1a : $*TestStruct, #TestStruct.Elt
@@ -125,7 +125,7 @@ sil @callee : $@convention(thin) (@inout Int) -> ()
 sil @inout_nocapture : $@convention(thin) () -> Int {
 bb0:
   // CHECK: alloc_stack
-  %1 = alloc_box $Int
+  %1 = alloc_box $@box Int
   %1a = project_box %1 : $@box Int, 0
   %6 = function_ref @callee : $@convention(thin) (@inout Int) -> ()
   %7 = apply %6(%1a) : $@convention(thin) (@inout Int) -> ()
@@ -149,7 +149,7 @@ sil @test_indirect_return : $@convention(thin) () -> () {
 bb0:
   // CHECK: alloc_stack
   %1 = function_ref @returns_protocol : $@convention(thin) () -> @out P
-  %2 = alloc_box $P
+  %2 = alloc_box $@box P
   %2a = project_box %2 : $@box P, 0
   %3 = apply %1(%2a) : $@convention(thin) () -> @out P
   %5 = strong_release %2 : $@box P
@@ -163,7 +163,7 @@ class SomeClass {}
 // CHECK-LABEL: sil @class_promotion
 sil @class_promotion : $(SomeClass) -> SomeClass {
 bb0(%0 : $SomeClass):
-  %1 = alloc_box $SomeClass
+  %1 = alloc_box $@box SomeClass
   %1a = project_box %1 : $@box SomeClass, 0
   %2 = store %0 to %1a : $*SomeClass
   %3 = load %1a : $*SomeClass
@@ -184,7 +184,7 @@ protocol LogicValue {
 // CHECK-LABEL: @protocols
 sil @protocols : $@convention(thin) (@in LogicValue, @thin Bool.Type) -> Bool {
 bb0(%0 : $*LogicValue, %1 : $@thin Bool.Type):
-  %2 = alloc_box $LogicValue
+  %2 = alloc_box $@box LogicValue
   %2a = project_box %2 : $@box LogicValue, 0
 // CHECK:  %2 = alloc_stack $LogicValue
   copy_addr [take] %0 to [initialization] %2a : $*LogicValue
@@ -206,7 +206,7 @@ class Generic<T> {}
 sil @dealloc_box : $@convention(thin) <T> () -> () {
 bb0:  // CHECK-NEXT: bb0:
       // CHECK-NEXT: alloc_stack
-  %1 = alloc_box $Generic<T>
+  %1 = alloc_box $@box Generic<T>
   dealloc_box %1 : $@box Generic<T>
 
   %0 = tuple ()    // CHECK: tuple ()
@@ -229,7 +229,7 @@ sil @_TC1t9SomeClassCfMS0_FT_S0_ : $@convention(thin) (@thick SomeClass.Type) ->
 sil @union_test : $@convention(thin) () -> () {
 bb0:
 // CHECK: [[UNION:%.*]] = alloc_stack
-  %1 = alloc_box $SomeUnion
+  %1 = alloc_box $@box SomeUnion
   %1a = project_box %1 : $@box SomeUnion, 0
   %2 = function_ref @_TO1t9SomeUnion1yfMS0_FCS_9SomeClassS0_ : $@convention(thin) (@owned SomeClass, @thin SomeUnion.Type) -> @owned SomeUnion // user: %7
   %3 = metatype $@thin SomeUnion.Type
@@ -249,7 +249,7 @@ bb0:
 // CHECK-LABEL: sil @multiple_release_test
 sil @multiple_release_test : $@convention(thin) (Bool) -> Bool {
 bb0(%0 : $Bool):
-  %1 = alloc_box $Bool
+  %1 = alloc_box $@box Bool
   %1a = project_box %1 : $@box Bool, 0
   store %0 to %1a : $*Bool
   strong_retain %1 : $@box Bool
@@ -280,7 +280,7 @@ bb0:
   br bb1
 
 bb1:
-  %1 = alloc_box $Bool
+  %1 = alloc_box $@box Bool
   cond_br undef, bb2, bb3
 
 bb2:
@@ -312,7 +312,7 @@ extension Int : My_Incrementable { }
 // CHECK-LABEL: sil @test_mui
 sil @test_mui : $@convention(thin) (Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1):
-  %2 = alloc_box $SomeClass
+  %2 = alloc_box $@box SomeClass
   %2a = project_box %2 : $@box SomeClass, 0
   // CHECK: [[STACK:%[0-9]+]] = alloc_stack
   %3 = mark_uninitialized [var] %2a : $*SomeClass
@@ -372,7 +372,7 @@ sil @_TF6struct8useStackFT1tSi_T_ : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
   debug_value %0 : $Int, let, name "t" // id: %1
   // CHECK: alloc_stack
-  %2 = alloc_box $Int, var, name "s"                   // users: %3, %6, %7, %7, %9
+  %2 = alloc_box $@box Int, var, name "s"                   // users: %3, %6, %7, %7, %9
   %2a = project_box %2 : $@box Int, 0
   store %0 to %2a : $*Int                        // id: %3
   // function_ref struct.apply (f : () -> Swift.Int) -> Swift.Int
@@ -414,7 +414,7 @@ sil @_TF6struct6useBoxFT1tSi_T_ : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
   debug_value %0 : $Int, let, name "t" // id: %1
   // CHECK: alloc_box
-  %2 = alloc_box $Int, var, name "s"                   // users: %3, %6, %7, %7, %10
+  %2 = alloc_box $@box Int, var, name "s"                   // users: %3, %6, %7, %7, %10
   %2a = project_box %2 : $@box Int, 0
   store %0 to %2a : $*Int                        // id: %3
   // function_ref struct.escape (f : () -> Swift.Int) -> () -> Swift.Int
@@ -451,7 +451,7 @@ sil @closure : $@convention(thin) (@owned @box Int) -> ()
 // CHECK-LABEL: sil @no_final_release
 sil @no_final_release : $@convention(thin) (Int) -> Bool {
 bb0(%0 : $Int):
-  %1 = alloc_box $Int
+  %1 = alloc_box $@box Int
   %1a = project_box %1 : $@box Int, 0
   store %0 to %1a : $*Int
   // function_ref main.(newFoo (Swift.Int) -> Swift.Bool).(modify #1) (())()
@@ -491,7 +491,7 @@ bb0(%0 : $*T):
   %2 = function_ref @mightApply : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@owned @callee_owned () -> @out τ_0_0) -> ()
   %3 = function_ref @closure_to_specialize : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@owned @box τ_0_0) -> @out τ_0_0
   // CHECK-NOT: alloc_box
-  %4 = alloc_box $T
+  %4 = alloc_box $@box T
   %4a = project_box %4 : $@box T, 0
   // CHECK: copy_addr %0 to [initialization] [[STACK]] : $*T
   copy_addr %0 to [initialization] %4a : $*T
@@ -572,7 +572,7 @@ bb0(%0 : $Int, %1 : $*S<Q>):
   debug_value_addr %1 : $*S<Q>
   %4 = function_ref @outer : $@convention(thin) (@owned @callee_owned () -> Bool) -> Bool
   %5 = function_ref @closure1 : $@convention(thin) <τ_0_0 where τ_0_0 : Count> (Int, @owned @box S<τ_0_0>) -> Bool
-  %6 = alloc_box $S<Q>
+  %6 = alloc_box $@box S<Q>
   %6a = project_box %6 : $@box S<Q>, 0
   copy_addr %1 to [initialization] %6a : $*S<Q>
   %8 = partial_apply %5<Q>(%0, %6) : $@convention(thin) <τ_0_0 where τ_0_0 : Count> (Int, @owned @box S<τ_0_0>) -> Bool
@@ -590,7 +590,7 @@ bb0(%0 : $Int, %1 : $*S<T>):
   debug_value_addr %1 : $*S<T>
   %4 = function_ref @outer : $@convention(thin) (@owned @callee_owned () -> Bool) -> Bool
   %5 = function_ref @closure1 : $@convention(thin) <τ_0_0 where τ_0_0 : Count> (Int, @owned @box S<τ_0_0>) -> Bool
-  %6 = alloc_box $S<T>
+  %6 = alloc_box $@box S<T>
   %6a = project_box %6 : $@box S<T>, 0
   copy_addr %1 to [initialization] %6a : $*S<T>
   %8 = partial_apply %5<T>(%0, %6) : $@convention(thin) <τ_0_0 where τ_0_0 : Count> (Int, @owned @box S<τ_0_0>) -> Bool
@@ -607,7 +607,7 @@ bb0(%0 : $Int, %1 : $@box S<T>):
   %2 = project_box %1 : $@box S<T>, 0
   %3 = function_ref @inner : $@convention(thin) (@owned @callee_owned () -> Bool) -> Bool
   %4 = function_ref @closure2 : $@convention(thin) <τ_0_0 where τ_0_0 : Count> (Int, @owned @box S<τ_0_0>) -> Bool
-  %5 = alloc_box $S<T>
+  %5 = alloc_box $@box S<T>
   %5a = project_box %5 : $@box S<T>, 0
   copy_addr %2 to [initialization] %5a : $*S<T>
   %7 = partial_apply %4<T>(%0, %5) : $@convention(thin) <τ_0_0 where τ_0_0 : Count> (Int, @owned @box S<τ_0_0>) -> Bool
@@ -650,7 +650,7 @@ bb0(%0 : $*T, %1 : $*T):
   // CHECK: copy_addr %1 to [initialization] [[STACK]]
   // CHECK: [[APPLIED:%.*]] = function_ref
   %3 = function_ref @applied : $@convention(thin) <τ_0_0> (@owned @box τ_0_0) -> ()
-  %4 = alloc_box $T
+  %4 = alloc_box $@box T
   %4a = project_box %4 : $@box T, 0
   copy_addr %1 to [initialization] %4a : $*T
   // CHECK: [[PARTIAL:%.*]] = partial_apply [[APPLIED]]<T>([[STACK]])

--- a/test/SILOptimizer/arcsequenceopts.sil
+++ b/test/SILOptimizer/arcsequenceopts.sil
@@ -355,7 +355,7 @@ bb0(%0 : $@box Builtin.Int32):
 // CHECK-NEXT: return
 sil @simple_alias_load_use_test : $@convention(thin) (@inout Builtin.Int32) -> () {
 bb0(%0 : $*Builtin.Int32):
-  %1 = alloc_box $Builtin.Int32
+  %1 = alloc_box $@box Builtin.Int32
   %1a = project_box %1 : $@box Builtin.Int32, 0
   %2 = function_ref @user : $@convention(thin) (@box Builtin.Int32) -> ()
   strong_retain %1 : $@box Builtin.Int32
@@ -382,7 +382,7 @@ bb0(%0 : $*Builtin.Int32):
 // CHECK-NEXT: return
 sil @simple_alias_load_use_test_two_release : $@convention(thin) (@inout Builtin.Int32) -> () {
 bb0(%0 : $*Builtin.Int32):
-  %1 = alloc_box $Builtin.Int32
+  %1 = alloc_box $@box Builtin.Int32
   %1a = project_box %1 : $@box Builtin.Int32, 0
   %2 = function_ref @user : $@convention(thin) (@box Builtin.Int32) -> ()
   strong_retain %1 : $@box Builtin.Int32
@@ -479,7 +479,7 @@ sil @clear_state_in_fact_of_autorelease_pool_ops : $@convention(thin) (Builtin.R
 bb0(%0 : $Builtin.RawPointer):
   %1 = function_ref @objc_autoreleasePoolPush : $@convention(thin) () -> Builtin.RawPointer
   %2 = function_ref @objc_autoreleasePoolPop : $@convention(thin) (Builtin.RawPointer) -> ()
-  %3 = alloc_box $Builtin.Int32
+  %3 = alloc_box $@box Builtin.Int32
   strong_retain %3 : $@box Builtin.Int32
   apply %1() : $@convention(thin) () -> Builtin.RawPointer
   strong_release %3 : $@box Builtin.Int32
@@ -498,7 +498,7 @@ bb0(%0 : $Builtin.RawPointer):
 // CHECK: strong_release
 sil @release_can_decrement_other_releases  : $@convention(thin) () -> () {
 bb0:
-  %1 = alloc_box $Builtin.Int32
+  %1 = alloc_box $@box Builtin.Int32
   %2 = alloc_stack $@box Builtin.Int32
   store %1 to %2 : $*@box Builtin.Int32
   %4 = function_ref @user : $@convention(thin) (@box Builtin.Int32) -> ()
@@ -1961,7 +1961,7 @@ bb0(%0 : $@box Builtin.Int32):
 // CHECK-NOT: strong_release
 sil @alloc_box_returns_at_p1 : $@convention(thin) () -> () {
 bb0:
-  %0 = alloc_box $Builtin.Int32
+  %0 = alloc_box $@box Builtin.Int32
   strong_retain %0 : $@box Builtin.Int32
   %3 = function_ref @user : $@convention(thin) (@box Builtin.Int32) -> ()
   apply %3(%0) : $@convention(thin) (@box Builtin.Int32) -> ()

--- a/test/SILOptimizer/capture_promotion.sil
+++ b/test/SILOptimizer/capture_promotion.sil
@@ -31,19 +31,19 @@ sil @dummy_func : $@convention(thin) (Int, Int, Int) -> Int
 sil @test_capture_promotion : $@convention(thin) () -> @owned @callee_owned () -> Int {
 bb0:
   %0 = tuple ()
-  %1 = alloc_box $Foo
+  %1 = alloc_box $@box Foo
   %1a = project_box %1 : $@box Foo, 0
   %2 = function_ref @foo_allocating_init : $@convention(thin) (@thick Foo.Type) -> @owned Foo
   %3 = metatype $@thick Foo.Type
   %4 = apply %2(%3) : $@convention(thin) (@thick Foo.Type) -> @owned Foo
   store %4 to %1a : $*Foo
-  %6 = alloc_box $Baz
+  %6 = alloc_box $@box Baz
   %6a = project_box %6 : $@box Baz, 0
   %7 = function_ref @baz_init : $@convention(thin) (@thin Baz.Type) -> @owned Baz
   %8 = metatype $@thin Baz.Type
   %9 = apply %7(%8) : $@convention(thin) (@thin Baz.Type) -> @owned Baz
   store %9 to %6a : $*Baz
-  %11 = alloc_box $Int
+  %11 = alloc_box $@box Int
   %11a = project_box %11 : $@box Int, 0
   %12 = function_ref @convert_from_integer_literal : $@convention(thin) (Builtin.Word, @thin Int.Type) -> Int
   %13 = metatype $@thin Int.Type
@@ -90,19 +90,19 @@ bb0:
 sil @test_capture_promotion_indirect : $@convention(thin) () -> @owned @callee_owned () -> @out Int {
 bb0:
   %0 = tuple ()
-  %1 = alloc_box $Foo
+  %1 = alloc_box $@box Foo
   %1a = project_box %1 : $@box Foo, 0
   %2 = function_ref @foo_allocating_init : $@convention(thin) (@thick Foo.Type) -> @owned Foo
   %3 = metatype $@thick Foo.Type
   %4 = apply %2(%3) : $@convention(thin) (@thick Foo.Type) -> @owned Foo
   store %4 to %1a : $*Foo
-  %6 = alloc_box $Baz
+  %6 = alloc_box $@box Baz
   %6a = project_box %6 : $@box Baz, 0
   %7 = function_ref @baz_init : $@convention(thin) (@thin Baz.Type) -> @owned Baz
   %8 = metatype $@thin Baz.Type
   %9 = apply %7(%8) : $@convention(thin) (@thin Baz.Type) -> @owned Baz
   store %9 to %6a : $*Baz
-  %11 = alloc_box $Int
+  %11 = alloc_box $@box Int
   %11a = project_box %11 : $@box Int, 0
   %12 = function_ref @convert_from_integer_literal : $@convention(thin) (Builtin.Word, @thin Int.Type) -> Int
   %13 = metatype $@thin Int.Type
@@ -199,7 +199,7 @@ bb0(%0 : $@box Foo, %2 : $@box Baz, %4 : $@box Int):
 sil @test_unpromotable : $@convention(thin) () -> @owned @callee_owned () -> Int {
 bb0:
   %0 = tuple ()
-  %1 = alloc_box $Foo
+  %1 = alloc_box $@box Foo
   %1a = project_box %1 : $@box Foo, 0
   %2 = function_ref @foo_allocating_init : $@convention(thin) (@thick Foo.Type) -> @owned Foo
   %3 = metatype $@thick Foo.Type
@@ -237,10 +237,10 @@ sil @apply : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
 sil @captureWithinGeneric : $@convention(thin) <T> (@inout Int, @inout Int) -> () {
 // CHECK: bb0
 bb0(%0 : $*Int, %1 : $*Int):
-  %2 = alloc_box $Int
+  %2 = alloc_box $@box Int
   %2a = project_box %2 : $@box Int, 0
   copy_addr %0 to [initialization] %2a : $*Int
-  %4 = alloc_box $Int
+  %4 = alloc_box $@box Int
   %4a = project_box %4 : $@box Int, 0
   copy_addr %1 to [initialization] %4a : $*Int
   %6 = function_ref @apply : $@convention(thin) (@owned @callee_owned () -> ()) -> ()

--- a/test/SILOptimizer/capture_promotion_generic_context.sil
+++ b/test/SILOptimizer/capture_promotion_generic_context.sil
@@ -28,7 +28,7 @@ sil @call_promotable_box_from_generic : $@convention(thin) <T> (@in T, Int) -> @
 entry(%0 : $*T, %1 : $Int):
   destroy_addr %0 : $*T
   %f = function_ref @promotable_box : $@convention(thin) (@box Int) -> Int
-  %b = alloc_box $Int
+  %b = alloc_box $@box Int
   %a = project_box %b : $@box Int, 0
   store %1 to %a : $*Int
   %k = partial_apply %f(%b) : $@convention(thin) (@box Int) -> Int
@@ -62,7 +62,7 @@ entry(%0 : $*T, %1 : $*U, %2 : $Int):
   destroy_addr %0 : $*T
   destroy_addr %1 : $*U
   %f = function_ref @generic_promotable_box : $@convention(thin) <V> (@in V, @box Int) -> Int
-  %b = alloc_box $Int
+  %b = alloc_box $@box Int
   %a = project_box %b : $@box Int, 0
   store %2 to %a : $*Int
   %k = partial_apply %f<U>(%b) : $@convention(thin) <V> (@in V, @box Int) -> Int

--- a/test/SILOptimizer/capture_promotion_reachability.sil
+++ b/test/SILOptimizer/capture_promotion_reachability.sil
@@ -27,11 +27,11 @@ func test_reachability_1(b: Builtin.Int1, x: Builtin.Int64, y: Builtin.Int64) {
 // CHECK-LABEL: sil @test_reachability_1
 sil @test_reachability_1 : $@convention(thin) (Builtin.Int1, Builtin.Int64, Builtin.Int64) -> () {
 bb0(%0 : $Builtin.Int1, %1 : $Builtin.Int64, %2 : $Builtin.Int64):
-  %3 = alloc_box $Builtin.Int1
+  %3 = alloc_box $@box Builtin.Int1
   %3a = project_box %3 : $@box Builtin.Int1, 0
-  %4 = alloc_box $Builtin.Int64
+  %4 = alloc_box $@box Builtin.Int64
   %4a = project_box %4 : $@box Builtin.Int64, 0
-  %5 = alloc_box $Builtin.Int64
+  %5 = alloc_box $@box Builtin.Int64
   %5a = project_box %5 : $@box Builtin.Int64, 0
   store %0 to %3a : $*Builtin.Int1
   store %1 to %4a : $*Builtin.Int64
@@ -45,7 +45,7 @@ bb1:
   br bb2
 
 bb2:
-  %14 = alloc_box $@callee_owned () -> Builtin.Int64
+  %14 = alloc_box $@box @callee_owned () -> Builtin.Int64
   %14a = project_box %14 : $@box @callee_owned () -> Builtin.Int64, 0
   // CHECK: [[CLOSURE0_PROMOTE0:%.*]] = function_ref @_TTSf2i__closure0 :
   %15 = function_ref @closure0 : $@convention(thin) (@owned @box Builtin.Int64) -> Builtin.Int64
@@ -109,16 +109,16 @@ func test_reachability_2(b: Builtin.Int1, x: Builtin.Int64, y: Builtin.Int64) {
 // CHECK-LABEL: sil @test_reachability_2
 sil @test_reachability_2 : $@convention(thin) (Builtin.Int1, Builtin.Int64, Builtin.Int64) -> () {
 bb0(%0 : $Builtin.Int1, %1 : $Builtin.Int64, %2 : $Builtin.Int64):
-  %3 = alloc_box $Builtin.Int1
+  %3 = alloc_box $@box Builtin.Int1
   %3a = project_box %3 : $@box Builtin.Int1, 0
-  %4 = alloc_box $Builtin.Int64
+  %4 = alloc_box $@box Builtin.Int64
   %4a = project_box %4 : $@box Builtin.Int64, 0
-  %5 = alloc_box $Builtin.Int64
+  %5 = alloc_box $@box Builtin.Int64
   %5a = project_box %5 : $@box Builtin.Int64, 0
   store %0 to %3a : $*Builtin.Int1
   store %1 to %4a : $*Builtin.Int64
   store %2 to %5a : $*Builtin.Int64
-  %9 = alloc_box $@callee_owned () -> Builtin.Int64
+  %9 = alloc_box $@box @callee_owned () -> Builtin.Int64
   %9a = project_box %9 : $@box @callee_owned () -> Builtin.Int64, 0
   // CHECK: [[CLOSURE2:%.*]] = function_ref @closure2 :
   %10 = function_ref @closure2 : $@convention(thin) (@owned @box Builtin.Int64) -> Builtin.Int64
@@ -191,16 +191,16 @@ func test_reachability_3(b: Builtin.Int1, x: Builtin.Int64, y: Builtin.Int64) {
 // CHECK-LABEL: sil @test_reachability_3
 sil @test_reachability_3 : $@convention(thin) (Builtin.Int1, Builtin.Int64, Builtin.Int64) -> () {
 bb0(%0 : $Builtin.Int1, %1 : $Builtin.Int64, %2 : $Builtin.Int64):
-  %3 = alloc_box $Builtin.Int1
+  %3 = alloc_box $@box Builtin.Int1
   %3a = project_box %3 : $@box Builtin.Int1, 0
-  %4 = alloc_box $Builtin.Int64
+  %4 = alloc_box $@box Builtin.Int64
   %4a = project_box %4 : $@box Builtin.Int64, 0
-  %5 = alloc_box $Builtin.Int64
+  %5 = alloc_box $@box Builtin.Int64
   %5a = project_box %5 : $@box Builtin.Int64, 0
   store %0 to %3a : $*Builtin.Int1
   store %1 to %4a : $*Builtin.Int64
   store %2 to %5a : $*Builtin.Int64
-  %9 = alloc_box $@callee_owned () -> Builtin.Int64
+  %9 = alloc_box $@box @callee_owned () -> Builtin.Int64
   %9a = project_box %9 : $@box @callee_owned () -> Builtin.Int64, 0
   // CHECK: [[CLOSURE4:%.*]] = function_ref @closure4 :
   %10 = function_ref @closure4 : $@convention(thin) (@owned @box Builtin.Int64) -> Builtin.Int64
@@ -271,16 +271,16 @@ func test_reachability_4(b: Builtin.Int1, x: Builtin.Int64, y: Builtin.Int64) {
 // CHECK-LABEL: sil @test_reachability_4
 sil @test_reachability_4 : $@convention(thin) (Builtin.Int1, Builtin.Int64, Builtin.Int64) -> () {
 bb0(%0 : $Builtin.Int1, %1 : $Builtin.Int64, %2 : $Builtin.Int64):
-  %3 = alloc_box $Builtin.Int1
+  %3 = alloc_box $@box Builtin.Int1
   %3a = project_box %3 : $@box Builtin.Int1, 0
-  %4 = alloc_box $Builtin.Int64
+  %4 = alloc_box $@box Builtin.Int64
   %4a = project_box %4 : $@box Builtin.Int64, 0
-  %5 = alloc_box $Builtin.Int64
+  %5 = alloc_box $@box Builtin.Int64
   %5a = project_box %5 : $@box Builtin.Int64, 0
   store %0 to %3a : $*Builtin.Int1
   store %1 to %4a : $*Builtin.Int64
   store %2 to %5a : $*Builtin.Int64
-  %9 = alloc_box $@callee_owned () -> Builtin.Int64
+  %9 = alloc_box $@box @callee_owned () -> Builtin.Int64
   %9a = project_box %9 : $@box @callee_owned () -> Builtin.Int64, 0
   // CHECK: [[CLOSURE6:%.*]] = function_ref @closure6 :
   %10 = function_ref @closure6 : $@convention(thin) (@owned @box Builtin.Int64) -> Builtin.Int64

--- a/test/SILOptimizer/closure_specialize.sil
+++ b/test/SILOptimizer/closure_specialize.sil
@@ -78,10 +78,10 @@ bb0(%0 : $Int):
 // CHECK-LABEL: sil shared @_TFF7specgen6callerFSiT_U_FTSiSi_T_ : $@convention(thin) (Int, Int, Int) -> () {
 sil shared @_TFF7specgen6callerFSiT_U_FTSiSi_T_ : $@convention(thin) (Int, Int, Int) -> () {
 bb0(%0 : $Int, %1 : $Int, %2 : $Int):
-  %5 = alloc_box $Int, var, name "p"                   // users: %6, %10, %14
+  %5 = alloc_box $@box Int, var, name "p"                   // users: %6, %10, %14
   %5a = project_box %5 : $@box Int, 0
   store %0 to %5a : $*Int                        // id: %6
-  %7 = alloc_box $Int, var, name "q"                   // users: %8, %11, %13
+  %7 = alloc_box $@box Int, var, name "q"                   // users: %8, %11, %13
   %7a = project_box %7 : $@box Int, 0
   store %1 to %7a : $*Int                        // id: %8
   // function_ref specgen.callee (Swift.Int, Swift.Int, Swift.Int) -> ()
@@ -444,7 +444,7 @@ bb0(%0 : $*Builtin.Int32, %1 : $@callee_owned (Builtin.Int32) -> ()):
 // CHECK-LABEL: sil @pass_a_closure
 sil @pass_a_closure: $@convention(thin) () -> Builtin.Int32 {
 bb0:
-  %0 = alloc_box $Builtin.Int32, var, name "i"
+  %0 = alloc_box $@box Builtin.Int32, var, name "i"
   %0a = project_box %0 : $@box Builtin.Int32, 0
   %1 = integer_literal $Builtin.Int32, 0
   store %1 to %0a : $*Builtin.Int32

--- a/test/SILOptimizer/cse.sil
+++ b/test/SILOptimizer/cse.sil
@@ -110,7 +110,7 @@ bb0:
 // CHECK-NOT: unchecked_ref_cast
 sil @removeTriviallyDeadInstructions : $@convention(thin) (@owned B) -> () {
 bb0(%0 : $B):
-  %1 = alloc_box $B
+  %1 = alloc_box $@box B
   %1a = project_box %1 : $@box B, 0
   %2 = store %0 to %1a : $*B
   %3 = load %1a : $*B

--- a/test/SILOptimizer/dead_store_elim.sil
+++ b/test/SILOptimizer/dead_store_elim.sil
@@ -197,7 +197,7 @@ bb0:
 // CHECK: return
 sil @store_after_store : $@convention(thin) (@owned B) -> () {
 bb0(%0 : $B):
-  %1 = alloc_box $B
+  %1 = alloc_box $@box B
   %1a = project_box %1 : $@box B, 0
   %2 = store %0 to %1a : $*B
   %3 = store %0 to %1a : $*B

--- a/test/SILOptimizer/definite_init.sil
+++ b/test/SILOptimizer/definite_init.sil
@@ -12,7 +12,7 @@ sil @makesInt : $@convention(thin) () -> Int
 // CHECK-LABEL: sil @use_before_init
 sil @use_before_init : $@convention(thin) () -> Int {
 bb0:
-  %0 = alloc_box $Int
+  %0 = alloc_box $@box Int
   %0a = project_box %0 : $@box Int, 0
   %1 = mark_uninitialized [var] %0a : $*Int // expected-note {{variable defined here}}
   %4 = load %1 : $*Int                // expected-error {{variable '<unknown>' used before being initialized}}
@@ -24,7 +24,7 @@ bb0:
 // CHECK-LABEL: @inout_uninit
 sil @inout_uninit : $@convention(thin) () -> () {
 bb0:
-  %0 = alloc_box $Int
+  %0 = alloc_box $@box Int
   %0a = project_box %0 : $@box Int, 0
   %1 = mark_uninitialized [var] %0a : $*Int // expected-note {{variable defined here}}
 
@@ -49,7 +49,7 @@ bb0:
 // CHECK-LABEL: sil @used_by_inout
 sil @used_by_inout : $@convention(thin) (Int) -> (Int, Int) {
 bb0(%0 : $Int):
-  %91 = alloc_box $Int
+  %91 = alloc_box $@box Int
   %91a = project_box %91 : $@box Int, 0
   %1 = mark_uninitialized [var] %91a : $*Int
 
@@ -76,7 +76,7 @@ sil @returns_generic_struct : $@convention(thin) () -> @out AddressOnlyStruct
 // CHECK-LABEL: sil @call_struct_return_function
 sil @call_struct_return_function : $@convention(thin) () -> Int {
 bb0:
-  %0 = alloc_box $AddressOnlyStruct
+  %0 = alloc_box $@box AddressOnlyStruct
   %0a = project_box %0 : $@box AddressOnlyStruct, 0
   %1 = mark_uninitialized [var] %0a : $*AddressOnlyStruct
 
@@ -92,7 +92,7 @@ bb0:
 // CHECK-LABEL: sil @tuple_elements1
 sil @tuple_elements1 : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
-  %2 = alloc_box $(Int, Int)
+  %2 = alloc_box $@box (Int, Int)
   %2a = project_box %2 : $@box (Int, Int), 0
   %3 = mark_uninitialized [var] %2a : $*(Int, Int) // expected-note {{variable defined here}}
   %4 = tuple_element_addr %3 : $*(Int, Int), 0
@@ -109,7 +109,7 @@ bb0(%0 : $Int):
 // CHECK-LABEL: sil @tuple_elements2
 sil @tuple_elements2 : $@convention(thin) (Int) -> (Int, Int) {
 bb0(%0 : $Int):
-  %2 = alloc_box $(Int, Int)
+  %2 = alloc_box $@box (Int, Int)
   %2a = project_box %2 : $@box (Int, Int), 0
   %3 = mark_uninitialized [var] %2a : $*(Int, Int) // expected-note {{variable defined here}}
   %18 = tuple_element_addr %3 : $*(Int, Int), 0
@@ -127,7 +127,7 @@ bb0(%0 : $Int):
 // CHECK-LABEL: sil @copy_addr1
 sil @copy_addr1 : $@convention(thin) <T> (@in T) -> @out T {
 bb0(%0 : $*T, %1 : $*T):
-  %3 = alloc_box $T
+  %3 = alloc_box $@box T
   %3a = project_box %3 : $@box T, 0
   %4 = mark_uninitialized [var] %3a : $*T
   copy_addr [take] %1 to [initialization] %4 : $*T
@@ -140,7 +140,7 @@ bb0(%0 : $*T, %1 : $*T):
 // CHECK-LABEL: sil @copy_addr2
 sil @copy_addr2 : $@convention(thin) <T> (@in T) -> @out T {
 bb0(%0 : $*T, %1 : $*T):
-  %3 = alloc_box $T
+  %3 = alloc_box $@box T
   %3a = project_box %3 : $@box T, 0
   %4 = mark_uninitialized [var] %3a : $*T // expected-note {{variable defined here}}
   copy_addr %4 to [initialization] %0 : $*T   // expected-error {{variable '<unknown>' used before being initialized}}
@@ -156,7 +156,7 @@ sil @closure0 : $@convention(thin) (@owned @box Int) -> ()
 // CHECK-LABEL: sil @closure_test
 sil @closure_test : $@convention(thin) () -> () {
 bb0:
-  %1 = alloc_box $Int
+  %1 = alloc_box $@box Int
   %1a = project_box %1 : $@box Int, 0
   %0 = mark_uninitialized [var] %1a : $*Int // expected-note {{variable defined here}}
 
@@ -182,7 +182,7 @@ sil @getSomeOptionalClass : $@convention(thin) () -> Optional<SomeClass>
 // CHECK-LABEL: sil @assign_test_trivial
 sil @assign_test_trivial : $@convention(thin) (Int) -> Int {
 bb0(%0 : $Int):
-  %7 = alloc_box $Int
+  %7 = alloc_box $@box Int
   %7a = project_box %7 : $@box Int, 0
   %1 = mark_uninitialized [var] %7a : $*Int
 
@@ -204,7 +204,7 @@ bb0:
   // Assignments of nontrivial types.  The first becomes an initialize (i.e.,
   // lone store), the second becomes an assignment (retain/release dance).
 
-  %b = alloc_box $SomeClass
+  %b = alloc_box $@box SomeClass
   %ba = project_box %b : $@box SomeClass, 0
   %c = mark_uninitialized [var] %ba : $*SomeClass
 
@@ -236,7 +236,7 @@ bb0:
 // CHECK-LABEL: sil @assign_test_addressonly
 sil @assign_test_addressonly : $@convention(thin) <T> (@in T) -> @out T {
 bb0(%0 : $*T, %1 : $*T):
-  %b = alloc_box $T
+  %b = alloc_box $@box T
   %ba = project_box %b : $@box T, 0
   %2 = mark_uninitialized [var] %ba : $*T
 
@@ -266,7 +266,7 @@ bb0:
   // Assignments of weak pointer.  The first becomes an initialize, and the
   // second becomes an assignment.
 
-  %b = alloc_box $@sil_weak Optional<SomeClass>
+  %b = alloc_box $@box @sil_weak Optional<SomeClass>
   %ba = project_box %b : $@box @sil_weak Optional<SomeClass>, 0
   %c = mark_uninitialized [var] %ba : $*@sil_weak Optional<SomeClass> // expected-note {{variable defined here}}
 
@@ -306,7 +306,7 @@ bb0:
   // Assignments of unowned pointer.  The first becomes an initialize, and the
   // second becomes an assignment.
 
-  %b = alloc_box $@sil_unowned SomeClass
+  %b = alloc_box $@box @sil_unowned SomeClass
   %ba = project_box %b : $@box @sil_unowned SomeClass, 0
   %c = mark_uninitialized [var] %ba : $*@sil_unowned SomeClass
 
@@ -358,7 +358,7 @@ struct ContainsNativeObject {
 
 sil @test_struct : $@convention(thin) (@inout ContainsNativeObject) -> () {
 bb0(%0 : $*ContainsNativeObject):
-  %b = alloc_box $ContainsNativeObject
+  %b = alloc_box $@box ContainsNativeObject
   %ba = project_box %b : $@box ContainsNativeObject, 0
   %c = mark_uninitialized [var] %ba : $*ContainsNativeObject
   %1 = load %0 : $*ContainsNativeObject
@@ -631,7 +631,7 @@ sil @superinit : $@convention(method) (@owned RootClassWithIVars) -> @owned Root
 
 sil @derived_test1 :  $@convention(method) (@owned DerivedClassWithIVars) -> @owned DerivedClassWithIVars {
 bb0(%0 : $DerivedClassWithIVars):
-  %1 = alloc_box $DerivedClassWithIVars
+  %1 = alloc_box $@box DerivedClassWithIVars
   %1a = project_box %1 : $@box DerivedClassWithIVars, 0
   %3 = mark_uninitialized [derivedself] %1a : $*DerivedClassWithIVars
   store %0 to %3 : $*DerivedClassWithIVars
@@ -661,7 +661,7 @@ bb0(%0 : $DerivedClassWithIVars):
 
 sil @derived_test2 :  $@convention(method) (@owned DerivedClassWithIVars) -> @owned DerivedClassWithIVars {
 bb0(%0 : $DerivedClassWithIVars):
-  %1 = alloc_box $DerivedClassWithIVars
+  %1 = alloc_box $@box DerivedClassWithIVars
   %1a = project_box %1 : $@box DerivedClassWithIVars, 0
   %3 = mark_uninitialized [derivedself] %1a : $*DerivedClassWithIVars
   store %0 to %3 : $*DerivedClassWithIVars
@@ -842,7 +842,7 @@ bb0(%0 : $DerivedClassWithNontrivialStoredProperties):
 
 // CHECK-LABEL: sil @test_delegating_box_release
 // CHECK: bb0(%0 : $RootClassWithNontrivialStoredProperties):
-// CHECK-NEXT: [[SELFBOX:%[0-9]+]] = alloc_box $RootClassWithNontrivialStoredProperties
+// CHECK-NEXT: [[SELFBOX:%[0-9]+]] = alloc_box $@box RootClassWithNontrivialStoredProperties
 // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[SELFBOX]]
 // CHECK-NEXT: store %0 to [[PB]]
 // CHECK-NEXT: [[SELF:%[0-9]+]] = load [[PB]]
@@ -851,7 +851,7 @@ bb0(%0 : $DerivedClassWithNontrivialStoredProperties):
 // CHECK-NEXT: dealloc_box [[SELFBOX]]
 sil @test_delegating_box_release : $@convention(method) (@owned RootClassWithNontrivialStoredProperties) -> () {
 bb0(%0 : $RootClassWithNontrivialStoredProperties):
-  %2 = alloc_box $RootClassWithNontrivialStoredProperties
+  %2 = alloc_box $@box RootClassWithNontrivialStoredProperties
   %2a = project_box %2 : $@box RootClassWithNontrivialStoredProperties, 0
   %4 = mark_uninitialized [delegatingself] %2a : $*RootClassWithNontrivialStoredProperties
   store %0 to %4 : $*RootClassWithNontrivialStoredProperties
@@ -863,7 +863,7 @@ bb0(%0 : $RootClassWithNontrivialStoredProperties):
 
 // CHECK-LABEL: sil @test_delegating_rvalue_release
 // CHECK: bb0(%0 : $RootClassWithNontrivialStoredProperties):
-// CHECK-NEXT: [[SELFBOX:%[0-9]+]] = alloc_box $RootClassWithNontrivialStoredProperties
+// CHECK-NEXT: [[SELFBOX:%[0-9]+]] = alloc_box $@box RootClassWithNontrivialStoredProperties
 // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[SELFBOX]]
 // CHECK-NEXT: store %0 to [[PB]]
 // CHECK-NEXT: [[SELF:%[0-9]+]] = load [[PB]]
@@ -875,7 +875,7 @@ bb0(%0 : $RootClassWithNontrivialStoredProperties):
 // CHECK-NEXT: dealloc_box [[SELFBOX]]
 sil @test_delegating_rvalue_release : $@convention(method) (@owned RootClassWithNontrivialStoredProperties) -> () {
 bb0(%0 : $RootClassWithNontrivialStoredProperties):
-  %2 = alloc_box $RootClassWithNontrivialStoredProperties
+  %2 = alloc_box $@box RootClassWithNontrivialStoredProperties
   %2a = project_box %2 : $@box RootClassWithNontrivialStoredProperties, 0
   %4 = mark_uninitialized [delegatingself] %2a : $*RootClassWithNontrivialStoredProperties
   store %0 to %4 : $*RootClassWithNontrivialStoredProperties
@@ -912,7 +912,7 @@ bb0(%0 : $DerivedClassWithNontrivialStoredProperties):
 // <rdar://problem/18199087> DI doesn't catch use of super properties lexically inside super.init call
 sil @super_init_out_of_order :  $@convention(method) (@owned DerivedClassWithIVars, Int) -> @owned DerivedClassWithIVars {
 bb0(%0 : $DerivedClassWithIVars, %i : $Int):
-  %1 = alloc_box $DerivedClassWithIVars
+  %1 = alloc_box $@box DerivedClassWithIVars
   %1a = project_box %1 : $@box DerivedClassWithIVars, 0
   %3 = mark_uninitialized [derivedself] %1a : $*DerivedClassWithIVars
   store %0 to %3 : $*DerivedClassWithIVars

--- a/test/SILOptimizer/definite_init_crashes.sil
+++ b/test/SILOptimizer/definite_init_crashes.sil
@@ -15,7 +15,7 @@ struct Triple {
 // CHECK-LABEL: sil @TripleTest
 sil @TripleTest : $@convention(method) (Int, @inout Triple) -> Triple {
 bb0(%0 : $Int, %1 : $*Triple):
-  %4 = alloc_box $Triple
+  %4 = alloc_box $@box Triple
   %4a = project_box %4 : $@box Triple, 0
   %5 = load %1 : $*Triple
   store %5 to %4a : $*Triple
@@ -34,7 +34,7 @@ struct Single {
 // CHECK-LABEL: sil @SingleTest
 sil @SingleTest : $@convention(method) (@inout Single, Int) -> Single {
 bb0(%0 : $*Single, %1 : $Int):
-  %4 = alloc_box $Single
+  %4 = alloc_box $@box Single
   %4a = project_box %4 : $@box Single, 0
   %5 = load %0 : $*Single
   store %5 to %4a : $*Single
@@ -63,7 +63,7 @@ sil @getSomeUnion : $@convention(thin) (@owned SomeClass, @thin SomeUnion.Type) 
 sil @test_union_release : $@convention(thin) () -> () {
 bb0:
   %0 = tuple ()
-  %1 = alloc_box $SomeUnion                       // users: %9, %8
+  %1 = alloc_box $@box SomeUnion                       // users: %9, %8
   %1a = project_box %1 : $@box SomeUnion, 0
   %2 = function_ref @getSomeUnion : $@convention(thin) (@owned SomeClass, @thin SomeUnion.Type) -> @owned SomeUnion // user: %7
   %3 = metatype $@thin SomeUnion.Type               // user: %7

--- a/test/SILOptimizer/diagnose_unreachable.sil
+++ b/test/SILOptimizer/diagnose_unreachable.sil
@@ -137,7 +137,7 @@ bb0:
 // CHECK-LABEL: sil @removeTriviallyDeadInstructions
 sil @removeTriviallyDeadInstructions : $@convention(thin) (@owned B) -> () {
 bb0(%0 : $B):
-  %1 = alloc_box $B
+  %1 = alloc_box $@box B
   %1a = project_box %1 : $@box B, 0
   %2 = store %0 to %1a : $*B                 // CHECK: store
   %3 = load %1a : $*B

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -397,10 +397,10 @@ sil @call_copy_addr_content : $@convention(thin) () -> () {
 // CHECK-NEXT:  End
 sil @test_partial_apply : $@convention(thin) (Int64, @owned X, @owned Y) -> Int64 {
 bb0(%0 : $Int64, %1 : $X, %2 : $Y):
-  %3 = alloc_box $Int64
+  %3 = alloc_box $@box Int64
   %4 = project_box %3 : $@box Int64, 0
   store %0 to %4 : $*Int64
-  %6 = alloc_box $Y
+  %6 = alloc_box $@box Y
   %7 = project_box %6 : $@box Y, 0
   store %2 to %7 : $*Y
   %9 = function_ref @closure1 : $@convention(thin) (@owned X, @owned @box Int64, @owned @box Y) -> Int64
@@ -469,7 +469,7 @@ bb0(%0 : $X, %1 : $@box Y):
 // CHECK-NEXT:  End
 sil @test_escaped_box : $@convention(thin) (Int64) -> Int64 {
 bb0(%0 : $Int64):
-  %1 = alloc_box $Int64
+  %1 = alloc_box $@box Int64
   %2 = project_box %1 : $@box Int64, 0
   store %0 to %2 : $*Int64
 
@@ -512,7 +512,7 @@ sil @takebox :  $@convention(thin) (@owned @box Int64) -> ()
 // CHECK-NEXT:  End
 sil @test_escaped_partial_apply : $@convention(thin) (Int64) -> () {
 bb0(%0 : $Int64):
-  %1 = alloc_box $Int64
+  %1 = alloc_box $@box Int64
   %2 = project_box %1 : $@box Int64, 0
   store %0 to %2 : $*Int64
   %4 = function_ref @closure3 : $@convention(thin) (@owned @box Int64) -> Int64
@@ -749,7 +749,7 @@ sil @unknown_throwing_func : $@convention(thin) (@owned X) -> (@owned X, @error 
 // CHECK-NEXT:  End
 sil @test_release_of_partial_apply_with_box : $@convention(thin) (@owned Y) -> () {
 bb0(%0 : $Y):
-  %1 = alloc_box $Y
+  %1 = alloc_box $@box Y
   %2 = project_box %1 : $@box Y, 0
   store %0 to %2 : $*Y
   %3 = function_ref @take_y_box : $@convention(thin) (@owned @box Y) -> ()

--- a/test/SILOptimizer/inout_deshadow_integration.swift
+++ b/test/SILOptimizer/inout_deshadow_integration.swift
@@ -98,7 +98,7 @@ struct StructWithMutatingMethod {
 // CHECK: }
 
 // CHECK-LABEL: sil hidden @_TFV26inout_deshadow_integration24StructWithMutatingMethod28testStandardLibraryOperators{{.*}} : $@convention(method) (@inout StructWithMutatingMethod) -> () {
-// CHECK-NOT: alloc_box $StructWithMutatingMethod
+// CHECK-NOT: alloc_box $@box StructWithMutatingMethod
 // CHECK-NOT: alloc_stack $StructWithMutatingMethod
 // CHECK: }
 

--- a/test/SILOptimizer/looprotate.sil
+++ b/test/SILOptimizer/looprotate.sil
@@ -45,7 +45,7 @@ sil @looprotate : $@convention(thin) (Int32, @owned Bar) -> Int32 {
 bb0(%0 : $Int32, %25: $Bar):
   %1 = struct_extract %0 : $Int32, #Int32._value
   %2 = integer_literal $Builtin.Int32, 0
-  %30 = alloc_box $Bool
+  %30 = alloc_box $@box Bool
   %30a = project_box %30 : $@box Bool, 0
   br bb1(%1 : $Builtin.Int32, %2 : $Builtin.Int32, %25: $Bar, %30 : $@box Bool, %30a : $*Bool)
 
@@ -120,7 +120,7 @@ sil @looprotate_with_opened_archetype : $@convention(thin) (Int32, @in P) -> Int
 bb0(%0 : $Int32, %25: $*P):
   %1 = struct_extract %0 : $Int32, #Int32._value
   %2 = integer_literal $Builtin.Int32, 0
-  %30 = alloc_box $Bool
+  %30 = alloc_box $@box Bool
   %30a = project_box %30 : $@box Bool, 0
   %40 = open_existential_addr %25 : $*P to $*@opened("C22498FA-CABF-11E5-B9A9-685B35C48C83") P
   br bb1(%1 : $Builtin.Int32, %2 : $Builtin.Int32, %25: $*P, %30 : $@box Bool, %30a : $*Bool)

--- a/test/SILOptimizer/lslocation_expansion.sil
+++ b/test/SILOptimizer/lslocation_expansion.sil
@@ -92,7 +92,7 @@ sil @stack_store : $@convention(thin) () -> () {
 // CHECK-NEXT: [[RET0:%.+]] = alloc_box
 sil @store_after_store : $@convention(thin) (@owned B) -> () {
 bb0(%0 : $B):
-  %1 = alloc_box $B
+  %1 = alloc_box $@box B
   %1a = project_box %1 : $@box B, 0
   %2 = store %0 to %1a : $*B
   %3 = store %0 to %1a : $*B

--- a/test/SILOptimizer/lslocation_reduction.sil
+++ b/test/SILOptimizer/lslocation_reduction.sil
@@ -92,7 +92,7 @@ sil @stack_store : $@convention(thin) () -> () {
 // CHECK-NEXT: [[RET0:%.+]] = alloc_box
 sil @store_after_store : $@convention(thin) (@owned B) -> () {
 bb0(%0 : $B):
-  %1 = alloc_box $B
+  %1 = alloc_box $@box B
   %1a = project_box %1 : $@box B, 0
   %2 = store %0 to %1a : $*B
   %3 = store %0 to %1a : $*B

--- a/test/SILOptimizer/mandatory_inlining.sil
+++ b/test/SILOptimizer/mandatory_inlining.sil
@@ -27,7 +27,7 @@ sil @fromLiteral : $@convention(thin) (Builtin.Int128, @thin Int64.Type) -> Int6
 // CHECK-LABEL: sil [transparent] @test_add : $@convention(thin) (Int64) -> Int64 {
 sil [transparent] @test_add : $@convention(thin) (Int64) -> Int64 {
 bb0(%0 : $Int64):
-  %1 = alloc_box $Int64
+  %1 = alloc_box $@box Int64
   %1a = project_box %1 : $@box Int64, 0
   store %0 to %1a : $*Int64
   %3 = function_ref @plus : $@convention(thin) (Int64, Int64) -> Int64
@@ -44,7 +44,7 @@ bb0(%0 : $Int64):
 // CHECK-LABEL: sil @inline_test_add : $@convention(thin) (Int64) -> Int64 {
 sil @inline_test_add : $@convention(thin) (Int64) -> Int64 {
 // CHECK: [[BB0:.*]]([[VAL0:%.*]] : $Int64):
-  // CHECK: [[VAL1:%.*]] = alloc_box $Int64
+  // CHECK: [[VAL1:%.*]] = alloc_box $@box Int64
   // CHECK: [[PB1:%.*]] = project_box [[VAL1]]
   // CHECK: store [[VAL0]] to [[PB1]]
   // CHECK: [[VAL3:%.*]] = function_ref @plus
@@ -55,7 +55,7 @@ sil @inline_test_add : $@convention(thin) (Int64) -> Int64 {
   // CHECK: [[VAL8:%.*]] = integer_literal $Builtin.Int128, 10
   // CHECK: [[VAL9:%.*]] = apply [[VAL6]]([[VAL8]], [[VAL7]])
   // CHECK: [[VAL10:%.*]] = apply [[VAL4]]([[VAL5]], [[VAL9]])
-  // CHECK: [[VAL11:%.*]] = alloc_box $Int64
+  // CHECK: [[VAL11:%.*]] = alloc_box $@box Int64
   // CHECK: [[PB11:%.*]] = project_box [[VAL11]]
   // CHECK: store [[VAL10]] to [[PB11]]
   // CHECK: [[VAL13:%.*]] = function_ref @plus
@@ -75,7 +75,7 @@ sil @inline_test_add : $@convention(thin) (Int64) -> Int64 {
   // CHECK: return [[VAL25]]
 
 bb0(%0 : $Int64):
-  %1 = alloc_box $Int64
+  %1 = alloc_box $@box Int64
   %1a = project_box %1 : $@box Int64, 0
   store %0 to %1a : $*Int64
   %3 = function_ref @plus : $@convention(thin) (Int64, Int64) -> Int64
@@ -100,7 +100,7 @@ bb0(%0 : $Int64):
 // CHECK-LABEL: sil @inline_twice_test_add : $@convention(thin) (Int64) -> Int64 {
 sil @inline_twice_test_add : $@convention(thin) (Int64) -> Int64 {
 // CHECK: [[BB0:.*]]([[VAL0:%.*]] : $Int64):
-  // CHECK: [[VAL1:%.*]] = alloc_box $Int64
+  // CHECK: [[VAL1:%.*]] = alloc_box $@box Int64
   // CHECK: [[PB1:%.*]] = project_box [[VAL1]]
   // CHECK: store [[VAL0]] to [[PB1]]
   // CHECK: [[VAL3:%.*]] = function_ref @plus
@@ -111,7 +111,7 @@ sil @inline_twice_test_add : $@convention(thin) (Int64) -> Int64 {
   // CHECK: [[VAL8:%.*]] = integer_literal $Builtin.Int128, 10
   // CHECK: [[VAL9:%.*]] = apply [[VAL6]]([[VAL8]], [[VAL7]])
   // CHECK: [[VAL10:%.*]] = apply [[VAL4]]([[VAL5]], [[VAL9]])
-  // CHECK: [[VAL11:%.*]] = alloc_box $Int64
+  // CHECK: [[VAL11:%.*]] = alloc_box $@box Int64
   // CHECK: [[PB11:%.*]] = project_box [[VAL11]]
   // CHECK: store [[VAL10]] to [[PB11]]
   // CHECK: [[VAL13:%.*]] = function_ref @plus
@@ -122,7 +122,7 @@ sil @inline_twice_test_add : $@convention(thin) (Int64) -> Int64 {
   // CHECK: [[VAL18:%.*]] = apply [[VAL15]]([[VAL17]], [[VAL16]])
   // CHECK: [[VAL19:%.*]] = apply [[VAL13]]([[VAL14]], [[VAL18]])
   // CHECK: strong_release [[VAL11]]
-  // CHECK: [[VAL21:%.*]] = alloc_box $Int64
+  // CHECK: [[VAL21:%.*]] = alloc_box $@box Int64
   // CHECK: [[PB21:%.*]] = project_box [[VAL21]]
   // CHECK: store [[VAL19]] to [[PB21]]
   // CHECK: [[VAL23:%.*]] = function_ref @plus
@@ -142,7 +142,7 @@ sil @inline_twice_test_add : $@convention(thin) (Int64) -> Int64 {
   // CHECK: return [[VAL35]]
 
 bb0(%0 : $Int64):
-  %1 = alloc_box $Int64
+  %1 = alloc_box $@box Int64
   %1a = project_box %1 : $@box Int64, 0
   store %0 to %1a : $*Int64
   %3 = function_ref @plus : $@convention(thin) (Int64, Int64) -> Int64
@@ -172,7 +172,7 @@ protocol SomeProtocol {
 // CHECK-LABEL: sil [transparent] @test_existential_metatype : $@convention(thin) (@in SomeProtocol) -> @thick SomeProtocol.Type
 sil [transparent] @test_existential_metatype : $@convention(thin) (@in SomeProtocol) -> @thick SomeProtocol.Type {
 bb0(%0 : $*SomeProtocol):
-  %1 = alloc_box $SomeProtocol
+  %1 = alloc_box $@box SomeProtocol
   %1a = project_box %1 : $@box SomeProtocol, 0
   copy_addr [take] %0 to [initialization] %1a : $*SomeProtocol
   %4 = alloc_stack $SomeProtocol
@@ -187,7 +187,7 @@ bb0(%0 : $*SomeProtocol):
 // CHECK-LABEL: sil @inline_test_existential_metatype : $@convention(thin) (@in SomeProtocol) -> @thick SomeProtocol.Type
 sil @inline_test_existential_metatype : $@convention(thin) (@in SomeProtocol) -> @thick SomeProtocol.Type {
 // CHECK: [[BB0:.*]]([[VAL0:%.*]] : $*SomeProtocol):
-  // CHECK: [[VAL1:%.*]] = alloc_box $SomeProtocol
+  // CHECK: [[VAL1:%.*]] = alloc_box $@box SomeProtocol
   // CHECK: [[PB1:%.*]] = project_box [[VAL1]]
   // CHECK: copy_addr [take] %0 to [initialization] [[PB1]]
   // CHECK: [[VAL4:%.*]] = alloc_stack $SomeProtocol
@@ -221,9 +221,9 @@ sil @bar : $@convention(thin) (Float32) -> Bool
 // CHECK-LABEL: sil [transparent] @test_control_flow : $@convention(thin) (Float, Float) -> Float
 sil [transparent] @test_control_flow : $@convention(thin) (Float, Float) -> Float {
 bb0(%0 : $Float, %1 : $Float):
-  %2 = alloc_box $Float
+  %2 = alloc_box $@box Float
   %2a = project_box %2 : $@box Float, 0
-  %3 = alloc_box $Float
+  %3 = alloc_box $@box Float
   %3a = project_box %3 : $@box Float, 0
   store %0 to %2a : $*Float
   store %1 to %3a : $*Float
@@ -281,7 +281,7 @@ bb6(%39 : $Float):
 sil @inline_test_control_flow : $@convention(thin) (Float) -> Float {
 
 // CHECK: [[BB0:.*]]([[VAL0:%.*]] : $Float):
-  // CHECK: [[VAL1:%.*]] = alloc_box $Float
+  // CHECK: [[VAL1:%.*]] = alloc_box $@box Float
   // CHECK: [[PB1:%.*]] = project_box [[VAL1]]
   // CHECK: store [[VAL0]] to [[PB1]]
   // CHECK: [[VAL3:%.*]] = function_ref @sub_floats
@@ -296,9 +296,9 @@ sil @inline_test_control_flow : $@convention(thin) (Float) -> Float {
   // CHECK: [[VAL12:%.*]] = metatype $@thin Float.Type
   // CHECK: [[VAL13:%.*]] = float_literal $Builtin.FPIEEE64, 0x4000000000000000
   // CHECK: [[VAL14:%.*]] = apply [[VAL11]]([[VAL13]], [[VAL12]])
-  // CHECK: [[VAL15:%.*]] = alloc_box $Float
+  // CHECK: [[VAL15:%.*]] = alloc_box $@box Float
   // CHECK: [[PB15:%.*]] = project_box [[VAL15]]
-  // CHECK: [[VAL16:%.*]] = alloc_box $Float
+  // CHECK: [[VAL16:%.*]] = alloc_box $@box Float
   // CHECK: [[PB16:%.*]] = project_box [[VAL16]]
   // CHECK: store [[VAL10]] to [[PB15]]
   // CHECK: store [[VAL14]] to [[PB16]]
@@ -361,7 +361,7 @@ sil @inline_test_control_flow : $@convention(thin) (Float) -> Float {
   // CHECK: return [[VAL61]]
 
 bb0(%0 : $Float):
-  %1 = alloc_box $Float
+  %1 = alloc_box $@box Float
   %1a = project_box %1 : $@box Float, 0
   store %0 to %1a : $*Float
   %3 = function_ref @sub_floats : $@convention(thin) (Float, Float) -> Float
@@ -453,9 +453,9 @@ sil @true_getter : $@convention(thin) () -> Bool
 
 sil [transparent] @short_circuit_or : $@convention(thin) (Bool, @callee_owned () -> Bool) -> Bool {
 bb0(%0 : $Bool, %1 : $@callee_owned () -> Bool):
-  %2 = alloc_box $Bool
+  %2 = alloc_box $@box Bool
   %2a = project_box %2 : $@box Bool, 0
-  %3 = alloc_box $@callee_owned () -> Bool
+  %3 = alloc_box $@box @callee_owned () -> Bool
   %3a = project_box %3 : $@box @callee_owned () -> Bool, 0
   store %0 to %2a : $*Bool
   store %1 to %3a : $*@callee_owned () -> Bool
@@ -515,9 +515,9 @@ sil @test_short_circuit : $@convention(thin) (Bool, Bool) -> Bool {
   // CHECK: return {{.*}}
 
 bb0(%0 : $Bool, %1 : $Bool):
-  %2 = alloc_box $Bool
+  %2 = alloc_box $@box Bool
   %2a = project_box %2 : $@box Bool, 0
-  %3 = alloc_box $Bool
+  %3 = alloc_box $@box Bool
   %3a = project_box %3 : $@box Bool, 0
   store %0 to %2a : $*Bool
   store %1 to %3a : $*Bool
@@ -557,9 +557,9 @@ sil @test_short_circuit2 : $@convention(thin) (Bool, Bool) -> Bool {
   // CHECK: return {{.*}}
 
 bb0(%0 : $Bool, %1 : $Bool):
-  %2 = alloc_box $Bool
+  %2 = alloc_box $@box Bool
   %2a = project_box %2 : $@box Bool, 0
-  %3 = alloc_box $Bool
+  %3 = alloc_box $@box Bool
   %3a = project_box %3 : $@box Bool, 0
   store %0 to %2a : $*Bool
   store %1 to %3a : $*Bool
@@ -590,7 +590,7 @@ bb0(%0 : $Builtin.Int2048, %1 : $@thin Int64.Type):
 sil @test_with_dead_argument : $@convention(thin) () -> () {
 bb0:
   %0 = tuple ()
-  %1 = alloc_box $Int64
+  %1 = alloc_box $@box Int64
   %1a = project_box %1 : $@box Int64, 0
   %2 = function_ref @convertFromBuiltinIntegerLiteral : $@convention(thin) (Builtin.Int2048, @thin Int64.Type) -> Int64
   %3 = metatype $@thin Int64.Type

--- a/test/SILOptimizer/mem2reg.sil
+++ b/test/SILOptimizer/mem2reg.sil
@@ -53,7 +53,7 @@ sil @multiple_store_vals2 : $@convention(thin) (Int64) -> Int64 {
 bb0(%0 : $Int64):
   %1 = alloc_stack $Int64, var, name "c"               // users: %19, %2
   store %0 to %1 : $*Int64                      // id: %2
-  %3 = alloc_box $Int64, var, name "x"                 // users: %16, %11, %6
+  %3 = alloc_box $@box Int64, var, name "x"                 // users: %16, %11, %6
   %3a = project_box %3 : $@box Int64, 0
   %4 = integer_literal $Builtin.Int64, 2          // users: %9, %5
   %5 = struct $Int64 (%4 : $Builtin.Int64)        // users: %12, %6
@@ -84,7 +84,7 @@ sil @with_loads : $@convention(thin) (Int64) -> Int64 {
 bb0(%0 : $Int64):
   %1 = alloc_stack $Int64, var, name "c"               // users: %19, %2, (%20)
   store %0 to %1 : $*Int64                      // id: %2
-  %3 = alloc_box $Int64, var, name "x"                 // users: %16, %11, %6
+  %3 = alloc_box $@box Int64, var, name "x"                 // users: %16, %11, %6
   %3a = project_box %3 : $@box Int64, 0
   %4 = integer_literal $Builtin.Int64, 2          // users: %9, %5
   %5 = struct $Int64 (%4 : $Builtin.Int64)        // users: %12, %6

--- a/test/SILOptimizer/predictable_memopt.sil
+++ b/test/SILOptimizer/predictable_memopt.sil
@@ -7,10 +7,10 @@ import Swift
 // CHECK-LABEL: sil @simple_reg_promotion
 sil @simple_reg_promotion : $@convention(thin) (Int) -> Int {
 bb0(%0 : $Int):                         // CHECK: bb0(%0 : $Int):
-  %1 = alloc_box $Int
+  %1 = alloc_box $@box Int
   %1a = project_box %1 : $@box Int, 0
   store %0 to %1a : $*Int
-  %3 = alloc_box $Int
+  %3 = alloc_box $@box Int
   %3a = project_box %3 : $@box Int, 0
   %4 = load %1a : $*Int
   store %4 to %3a : $*Int
@@ -26,7 +26,7 @@ bb0(%0 : $Int):                         // CHECK: bb0(%0 : $Int):
 // CHECK-LABEL: sil @tuple_reg_promotion
 sil @tuple_reg_promotion : $@convention(thin) (Int) -> Int {
 bb0(%0 : $Int):                         // CHECK: bb0(%0 : $Int):
-  %1 = alloc_box $(Int, Int)
+  %1 = alloc_box $@box (Int, Int)
   %1a = project_box %1 : $@box (Int, Int), 0
 
   %a = tuple_element_addr %1a : $*(Int, Int), 0
@@ -65,8 +65,8 @@ sil @takes_Int_inout : $@convention(thin) (@inout Int) -> ()
 sil @used_by_inout : $@convention(thin) (Int) -> (Int, Int) {
 bb0(%0 : $Int):
   // This alloc_stack can't be removed since it is used by an inout call.
-  // CHECK: %1 = alloc_box $Int
-  %1 = alloc_box $Int
+  // CHECK: %1 = alloc_box $@box Int
+  %1 = alloc_box $@box Int
   %1a = project_box %1 : $@box Int, 0
   %2 = store %0 to %1a : $*Int
 
@@ -104,7 +104,7 @@ sil @closure0 : $@convention(thin) (@owned @box Int) -> ()
 // CHECK-LABEL: sil @closure_test2
 sil @closure_test2 : $@convention(thin) (Int) -> Int {
 bb0(%1 : $Int):
-  %0 = alloc_box $Int
+  %0 = alloc_box $@box Int
   %0a = project_box %0 : $@box Int, 0
   store %1 to %0a : $*Int  // CHECK: store
 
@@ -132,7 +132,7 @@ sil @getSomeClass : $@convention(thin) () -> @owned SomeClass
 // CHECK-LABEL: sil @assign_test_trivial
 sil @assign_test_trivial : $@convention(thin) (Int) -> Int {
 bb0(%0 : $Int):
-  %1 = alloc_box $Int
+  %1 = alloc_box $@box Int
   %1a = project_box %1 : $@box Int, 0
 
   store %0 to %1a : $*Int
@@ -375,8 +375,8 @@ enum IndirectCase {
 sil @indirect_enum_box : $@convention(thin) (Int) -> IndirectCase {
 // CHECK: bb0([[X:%.*]] : $Int):
 entry(%x : $Int):
-  // CHECK: [[BOX:%.*]] = alloc_box $Int
-  %b = alloc_box $Int
+  // CHECK: [[BOX:%.*]] = alloc_box $@box Int
+  %b = alloc_box $@box Int
   // CHECK: [[PB:%.*]] = project_box [[BOX]]
   %ba = project_box %b : $@box Int, 0
   // CHECK: store [[X]] to [[PB]]

--- a/test/SILOptimizer/redundant_load_elim.sil
+++ b/test/SILOptimizer/redundant_load_elim.sil
@@ -304,7 +304,7 @@ bb0(%0 : $Agg1):
 // CHECK: return
 sil @store_promotion : $@convention(thin) (@owned B) -> () {
 bb0(%0 : $B):
-  %1 = alloc_box $B
+  %1 = alloc_box $@box B
   %1a = project_box %1 : $@box B, 0
   %2 = store %0 to %1a : $*B
   %3 = load %1a : $*B

--- a/test/SILOptimizer/redundant_load_elim_with_casts.sil
+++ b/test/SILOptimizer/redundant_load_elim_with_casts.sil
@@ -72,7 +72,7 @@ struct Wrapper {
 // CHECK: return
 sil @tbaa_class_alias_nonclass : $@convention(thin) (@owned B, @inout Agg1) -> () {
 bb0(%0 : $B, %1 : $*Agg1):
-  %2 = alloc_box $B
+  %2 = alloc_box $@box B
   %2a = project_box %2 : $@box B, 0
   %3 = load %1 : $*Agg1
   %4 = store %3 to %1 : $*Agg1

--- a/test/SILOptimizer/side-effect.sil
+++ b/test/SILOptimizer/side-effect.sil
@@ -176,7 +176,7 @@ bb0(%0 : $Int32):
   store %0 to %a : $*Int32
   %l1 = load %a : $*Int32
 
-  %b = alloc_box $Int32
+  %b = alloc_box $@box Int32
   %ba = project_box %b : $@box Int32, 0
   store %0 to %ba : $*Int32
   %l2 = load %ba : $*Int32

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -142,7 +142,7 @@ bb0:
 // CHECK-NOT: unchecked_ref_cast
 sil @removeTriviallyDeadInstructions : $@convention(thin) (@owned B) -> () {
 bb0(%0 : $B):
-  %1 = alloc_box $B
+  %1 = alloc_box $@box B
   %1a = project_box %1 : $@box B, 0
   %2 = store %0 to %1a : $*B
   %3 = load %1a : $*B

--- a/test/SILOptimizer/sil_locations.sil
+++ b/test/SILOptimizer/sil_locations.sil
@@ -9,7 +9,7 @@ sil @fromLiteral : $@convention(thin) (Builtin.Int128, @thin Int64.Type) -> Int6
 // CHECK-LABEL: sil [transparent] @test_add : $@convention(thin) (Int64) -> Int64 {
 sil [transparent] @test_add : $@convention(thin) (Int64) -> Int64 {
 bb0(%0 : $Int64):
-  %1 = alloc_box $Int64
+  %1 = alloc_box $@box Int64
   %1a = project_box %1 : $@box Int64, 0
   store %0 to %1a : $*Int64
   %3 = function_ref @plus : $@convention(thin) (Int64, Int64) -> Int64
@@ -25,7 +25,7 @@ bb0(%0 : $Int64):
 
 sil @inline_test_add : $@convention(thin) (Int64) -> Int64 {
 bb0(%0 : $Int64):
-  %1 = alloc_box $Int64
+  %1 = alloc_box $@box Int64
   %1a = project_box %1 : $@box Int64, 0
   store %0 to %1a : $*Int64
   %3 = function_ref @plus : $@convention(thin) (Int64, Int64) -> Int64
@@ -49,7 +49,7 @@ bb0(%0 : $Int64):
   // CHECK-LABEL: sil @inline_test_add : $@convention(thin) (Int64) -> Int64 {
   // CHECK: [[VAL9:%.*]] = apply                               {{.*}} line:38:9:sil
   // CHECK: [[VAL10:%.*]] = apply                         {{.*}} line:39:9:sil
-  // CHECK: [[VAL11:%.*]] = alloc_box $Int64,             {{.*}} line:40:9:minlined
+  // CHECK: [[VAL11:%.*]] = alloc_box $@box Int64,             {{.*}} line:40:9:minlined
   // CHECK: [[PB11:%.*]] = project_box [[VAL11]]          {{.*}} line:40:9:minlined
   // CHECK: store [[VAL10]] to [[PB11]]                   {{.*}} line:40:9:minlined
   // CHECK: [[VAL13:%.*]] = function_ref @plus            {{.*}} line:40:9:minlined

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -2632,7 +2632,7 @@ bb2(%16 : $Error):
 // CHECK: br bb1([[PB]] : $*Builtin.Int32)
 sil @simplified_branch_arg_has_result_value_1 : $@convention(thin) (@in Builtin.Int32) -> Builtin.Int32 {
 entry(%0 : $*Builtin.Int32):
-  %b = alloc_box $Builtin.Int32
+  %b = alloc_box $@box Builtin.Int32
   %p = project_box %b : $@box Builtin.Int32, 0
   %i = integer_literal $Builtin.Int32, 0
   store %i to %p : $*Builtin.Int32

--- a/test/SILOptimizer/specialize.sil
+++ b/test/SILOptimizer/specialize.sil
@@ -166,7 +166,7 @@ bb0(%0 : $*T):
   debug_value_addr %0 : $*T, let, name "t" // id: %1
   // function_ref specialize.(getGenericClosure <A>(t : A) -> () -> A).(tmp #1) (())A
   %2 = function_ref @_TFF10specialize17getGenericClosureU__FT1tQ__FT_Q_L_3tmpfT_Q_ : $@convention(thin) <τ_0_0> (@owned @box τ_0_0) -> @out τ_0_0 // user: %5
-  %3 = alloc_box $T                               // users: %4, %5, %5
+  %3 = alloc_box $@box T                               // users: %4, %5, %5
   %3a = project_box %3 : $@box T, 0
   copy_addr %0 to [initialization] %3a : $*T     // id: %4
   %5 = partial_apply %2<T>(%3) : $@convention(thin) <τ_0_0> (@owned @box τ_0_0) -> @out τ_0_0 // user: %7
@@ -296,7 +296,7 @@ bb0(%0 : $*U):
   debug_value_addr %0 : $*U, let, name "y" // id: %1
   // function_ref test4.(boo <A : test4.P, B>(A) -> (Swift.Int32, B) -> Swift.Int32).(closure #1)
   %2 = function_ref @_TFF5test43booUS_1P___FQ_FTVs5Int32Q0__S1_U_FTS1_Q0__S1_ : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : P> (Int32, @in τ_0_1, @owned @box τ_0_0) -> Int32 // user: %5
-  %3 = alloc_box $U                               // users: %4, %5, %5
+  %3 = alloc_box $@box U                               // users: %4, %5, %5
   %3a = project_box %3 : $@box U, 0
   copy_addr %0 to [initialization] %3a : $*U     // id: %4
   %5 = partial_apply %2<U, T>(%3) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : P> (Int32, @in τ_0_1, @owned @box τ_0_0) -> Int32 // user: %7
@@ -374,7 +374,7 @@ bb0(%0 : $*T):
   debug_value_addr %0 : $*T, let, name "x" // id: %1
   // function_ref test4.(gen1 <A : test4.P>(A) -> (Swift.Int32) -> Swift.Int32).(closure #1)
   %2 = function_ref @_TFF5test44gen1US_1P__FQ_FVs5Int32S1_U_FS1_S1_ : $@convention(thin) <τ_0_0 where τ_0_0 : P> (Int32, @owned @box τ_0_0) -> Int32 // user: %5
-  %3 = alloc_box $T                               // users: %4, %5, %5
+  %3 = alloc_box $@box T                               // users: %4, %5, %5
   %3a = project_box %3 : $@box T, 0
   copy_addr %0 to [initialization] %3a : $*T     // id: %4
   %5 = partial_apply %2<T>(%3) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (Int32, @owned @box τ_0_0) -> Int32 // user: %7

--- a/test/SILOptimizer/specialize_metatypes_with_nondefault_representation.sil
+++ b/test/SILOptimizer/specialize_metatypes_with_nondefault_representation.sil
@@ -36,18 +36,18 @@ bb0(%0 : $*T):
 sil @tmp2 : $@convention(thin) () -> () {
 bb0:
   %0 = function_ref @tmp : $@convention(thin) <T> () -> (@out T)
-  %1 = alloc_box $@thick AnyObject.Type
+  %1 = alloc_box $@box @thick AnyObject.Type
   %1a = project_box %1 : $@box @thick AnyObject.Type, 0
-  %2 = alloc_box $@objc_metatype AnyObject.Type
+  %2 = alloc_box $@box @objc_metatype AnyObject.Type
   %2a = project_box %2 : $@box @objc_metatype AnyObject.Type, 0
   %4 = apply %0<@thick AnyObject.Type>(%1a) : $@convention(thin) <T> () -> (@out T)
   %5 = apply %0<@objc_metatype AnyObject.Type>(%2a) : $@convention(thin) <T> () -> (@out T)
 
-  %6 = alloc_box $@thick Builtin.Int32.Type
+  %6 = alloc_box $@box @thick Builtin.Int32.Type
   %6a = project_box %6 : $@box @thick Builtin.Int32.Type, 0
-  %7 = alloc_box $@objc_metatype Builtin.Int32.Type
+  %7 = alloc_box $@box @objc_metatype Builtin.Int32.Type
   %7a = project_box %7 : $@box @objc_metatype Builtin.Int32.Type, 0
-  %8 = alloc_box $@thin Builtin.Int32.Type
+  %8 = alloc_box $@box @thin Builtin.Int32.Type
   %8a = project_box %8 : $@box @thin Builtin.Int32.Type, 0
   %9 = apply %0<@thick Builtin.Int32.Type>(%6a) : $@convention(thin) <T> () -> (@out T)
   %10 = apply %0<@objc_metatype Builtin.Int32.Type>(%7a) : $@convention(thin) <T> () -> (@out T)

--- a/test/SILOptimizer/split_critical_edges.sil
+++ b/test/SILOptimizer/split_critical_edges.sil
@@ -125,10 +125,10 @@ bb0(%0 : $AnyObject, %10: $Builtin.Int1):
   cond_br %10, lookup1, lookup2
 
 lookup1:
-  %1 = alloc_box $AnyObject
+  %1 = alloc_box $@box AnyObject
   %1a = project_box %1 : $@box AnyObject, 0
   store %0 to %1a : $*AnyObject
-  %3 = alloc_box $Optional<() -> ()>
+  %3 = alloc_box $@box Optional<() -> ()>
   %4 = load %1a : $*AnyObject
   strong_retain %4 : $AnyObject
   %6 = open_existential_ref %4 : $AnyObject to $@opened("01234567-89ab-cdef-0123-000000000000") AnyObject
@@ -136,10 +136,10 @@ lookup1:
   dynamic_method_br %7 : $Builtin.UnknownObject, #X.f!1.foreign, bb1, bb2
 
 lookup2:
-  %21 = alloc_box $AnyObject
+  %21 = alloc_box $@box AnyObject
   %21a = project_box %21 : $@box AnyObject, 0
   store %0 to %21a : $*AnyObject
-  %23 = alloc_box $Optional<() -> ()>
+  %23 = alloc_box $@box Optional<() -> ()>
   %24 = load %21a : $*AnyObject
   strong_retain %24 : $AnyObject
   %26 = open_existential_ref %24 : $AnyObject to $@opened("12345678-89ab-cdef-0123-000000000000") AnyObject

--- a/test/SILOptimizer/typed-access-tb-aa.sil
+++ b/test/SILOptimizer/typed-access-tb-aa.sil
@@ -326,13 +326,13 @@ bb0:
 
 sil @builtin_test : $@convention(thin) () -> () {
 bb0:
-  %0 = alloc_box $Builtin.RawPointer
-  %1 = alloc_box $Builtin.NativeObject
-  %2 = alloc_box $Builtin.UnknownObject
-  %3 = alloc_box $Builtin.Int8
-  %4 = alloc_box $Builtin.Int32
-  %5 = alloc_box $Builtin.FPIEEE32
-  %6 = alloc_box $Builtin.FPIEEE64
+  %0 = alloc_box $@box Builtin.RawPointer
+  %1 = alloc_box $@box Builtin.NativeObject
+  %2 = alloc_box $@box Builtin.UnknownObject
+  %3 = alloc_box $@box Builtin.Int8
+  %4 = alloc_box $@box Builtin.Int32
+  %5 = alloc_box $@box Builtin.FPIEEE32
+  %6 = alloc_box $@box Builtin.FPIEEE64
 
   %7 = project_box %0 : $@box Builtin.RawPointer, 0
   %8 = project_box %1 : $@box Builtin.NativeObject, 0
@@ -447,13 +447,13 @@ struct STest_S3 {
 
 sil @struct_tests : $@convention(thin) () -> () {
 
-  %0 = alloc_box $STest_S1
-  %1 = alloc_box $STest_S2
-  %2 = alloc_box $STest_E1
-  %3 = alloc_box $STest_E2
-  %4 = alloc_box $STest_C1
-  %5 = alloc_box $STest_C2
-  %6 = alloc_box $STest_S3
+  %0 = alloc_box $@box STest_S1
+  %1 = alloc_box $@box STest_S2
+  %2 = alloc_box $@box STest_E1
+  %3 = alloc_box $@box STest_E2
+  %4 = alloc_box $@box STest_C1
+  %5 = alloc_box $@box STest_C2
+  %6 = alloc_box $@box STest_S3
 
   %7 = project_box %0 : $@box STest_S1, 0
   %8 = project_box %1 : $@box STest_S2, 0
@@ -471,11 +471,11 @@ sil @struct_tests : $@convention(thin) () -> () {
   %19 = project_box %5 : $@box STest_C2, 0
   %20 = project_box %6 : $@box STest_S3, 0
 
-  %21 = alloc_box $Builtin.RawPointer
-  %22 = alloc_box $Builtin.NativeObject
-  %23 = alloc_box $Builtin.UnknownObject
-  %24 = alloc_box $Builtin.Int32
-  %25 = alloc_box $Builtin.FPIEEE32
+  %21 = alloc_box $@box Builtin.RawPointer
+  %22 = alloc_box $@box Builtin.NativeObject
+  %23 = alloc_box $@box Builtin.UnknownObject
+  %24 = alloc_box $@box Builtin.Int32
+  %25 = alloc_box $@box Builtin.FPIEEE32
 
   %26 = project_box %21 : $@box Builtin.RawPointer, 0
   %27 = project_box %22 : $@box Builtin.NativeObject, 0
@@ -569,13 +569,13 @@ enum ETest_E3 {
 }
 
 sil @enum_tests : $@convention(thin) () -> () {
-  %0 = alloc_box $ETest_S1
-  %1 = alloc_box $ETest_S2
-  %2 = alloc_box $ETest_E1
-  %3 = alloc_box $ETest_E2
-  %4 = alloc_box $ETest_C1
-  %5 = alloc_box $ETest_C2
-  %6 = alloc_box $ETest_E3
+  %0 = alloc_box $@box ETest_S1
+  %1 = alloc_box $@box ETest_S2
+  %2 = alloc_box $@box ETest_E1
+  %3 = alloc_box $@box ETest_E2
+  %4 = alloc_box $@box ETest_C1
+  %5 = alloc_box $@box ETest_C2
+  %6 = alloc_box $@box ETest_E3
 
   %7 = project_box %0 : $@box ETest_S1, 0
   %8 = project_box %1 : $@box ETest_S2, 0
@@ -593,11 +593,11 @@ sil @enum_tests : $@convention(thin) () -> () {
   %19 = project_box %5 : $@box ETest_C2, 0
   %20 = project_box %6 : $@box ETest_E3, 0
 
-  %21 = alloc_box $Builtin.RawPointer
-  %22 = alloc_box $Builtin.NativeObject
-  %23 = alloc_box $Builtin.UnknownObject
-  %24 = alloc_box $Builtin.Int32
-  %25 = alloc_box $Builtin.FPIEEE32
+  %21 = alloc_box $@box Builtin.RawPointer
+  %22 = alloc_box $@box Builtin.NativeObject
+  %23 = alloc_box $@box Builtin.UnknownObject
+  %24 = alloc_box $@box Builtin.Int32
+  %25 = alloc_box $@box Builtin.FPIEEE32
 
   %26 = project_box %21 : $@box Builtin.RawPointer, 0
   %27 = project_box %22 : $@box Builtin.NativeObject, 0
@@ -759,9 +759,9 @@ class CTest_C3 : CTest_C1 {
 protocol AnyObject {}
 
 sil @class_tests : $@convention(thin) () -> () {
-  %0 = alloc_box $CTest_C1
-  %1 = alloc_box $CTest_C2
-  %2 = alloc_box $CTest_C3
+  %0 = alloc_box $@box CTest_C1
+  %1 = alloc_box $@box CTest_C2
+  %2 = alloc_box $@box CTest_C3
 
   %3 = project_box %0 : $@box CTest_C1, 0
   %4 = project_box %1 : $@box CTest_C2, 0
@@ -771,13 +771,13 @@ sil @class_tests : $@convention(thin) () -> () {
   %7 = project_box %1 : $@box CTest_C2, 0
   %8 = project_box %2 : $@box CTest_C3, 0
 
-  %9 = alloc_box $AnyObject
-  %10 = alloc_box $Builtin.RawPointer
-  %11 = alloc_box $Builtin.NativeObject
-  %12 = alloc_box $Builtin.UnknownObject
-  %13 = alloc_box $Builtin.Int8
-  %14 = alloc_box $Builtin.Int32
-  %15 = alloc_box $Builtin.FPIEEE32
+  %9 = alloc_box $@box AnyObject
+  %10 = alloc_box $@box Builtin.RawPointer
+  %11 = alloc_box $@box Builtin.NativeObject
+  %12 = alloc_box $@box Builtin.UnknownObject
+  %13 = alloc_box $@box Builtin.Int8
+  %14 = alloc_box $@box Builtin.Int32
+  %15 = alloc_box $@box Builtin.FPIEEE32
 
   %16 = project_box %9 : $@box AnyObject, 0
   %17 = project_box %10 : $@box Builtin.RawPointer, 0
@@ -903,9 +903,9 @@ enum TTest_E1 {
 }
 
 sil @tuple_tests : $@convention(thin) () -> () {
-  %0 = alloc_box $(Builtin.RawPointer, Builtin.Int64)
-  %1 = alloc_box $(TTest_S1, Builtin.Int64)
-  %2 = alloc_box $(TTest_E1, Builtin.Int64)
+  %0 = alloc_box $@box (Builtin.RawPointer, Builtin.Int64)
+  %1 = alloc_box $@box (TTest_S1, Builtin.Int64)
+  %2 = alloc_box $@box (TTest_E1, Builtin.Int64)
 
   %3 = project_box %0 : $@box (Builtin.RawPointer, Builtin.Int64), 0
   %4 = project_box %1 : $@box (TTest_S1, Builtin.Int64), 0
@@ -915,12 +915,12 @@ sil @tuple_tests : $@convention(thin) () -> () {
   %7 = project_box %1 : $@box (TTest_S1, Builtin.Int64), 0
   %8 = project_box %2 : $@box (TTest_E1, Builtin.Int64), 0
 
-  %9 = alloc_box $Builtin.RawPointer
-  %10 = alloc_box $Builtin.NativeObject
-  %11 = alloc_box $Builtin.UnknownObject
-  %12 = alloc_box $Builtin.Int8
-  %13 = alloc_box $Builtin.Int32
-  %14 = alloc_box $Builtin.FPIEEE32
+  %9 = alloc_box $@box Builtin.RawPointer
+  %10 = alloc_box $@box Builtin.NativeObject
+  %11 = alloc_box $@box Builtin.UnknownObject
+  %12 = alloc_box $@box Builtin.Int8
+  %13 = alloc_box $@box Builtin.Int32
+  %14 = alloc_box $@box Builtin.FPIEEE32
 
   %15 = project_box %9 : $@box Builtin.RawPointer, 0
   %16 = project_box %10 : $@box Builtin.NativeObject, 0

--- a/test/Serialization/Inputs/def_basic.sil
+++ b/test/Serialization/Inputs/def_basic.sil
@@ -68,7 +68,7 @@ bb0:                                  // CHECK: bb0:
   %0 = tuple ()                       // CHECK:   %0 = tuple ()
   br bb1                              // CHECK:   br bb1
 bb1:
-  %b = alloc_box $Int
+  %b = alloc_box $@box Int
   %c = integer_literal $Builtin.Word, 1
   return %0 : $()                     // CHECK:   return %0 : $()
 }
@@ -91,7 +91,7 @@ bb1:
   return %5 : $()
 bb2:
   %5 = tuple ()
-  %6 = alloc_box $Int
+  %6 = alloc_box $@box Int
   %7 = project_box %6 : $@box Int, 0
   br bb1
 }
@@ -251,7 +251,7 @@ protocol Bendable { }
 sil [fragile] @_TF4todo18erasure_from_protoFT1xPS_8RuncibleS_8Bendable__PS0__ : $@convention(thin) (@in Bendable & Runcible) -> (@out Runcible) {
 bb0(%0 : $*Runcible, %1 : $*Bendable & Runcible):
   // CHECK: alloc_box
-  %2 = alloc_box $Bendable & Runcible
+  %2 = alloc_box $@box (Bendable & Runcible)
   %2a = project_box %2 : $@box Bendable & Runcible, 0
   // CHECK: copy_addr [take] {{.*}} to [initialization] {{.*}} : $*Bendable & Runcible
   %3 = copy_addr [take] %1 to [initialization] %2a : $*Bendable & Runcible
@@ -276,7 +276,7 @@ protocol ClassBound : class {
 // CHECK-LABEL: @_TF4todo18class_bound_methodFT1xPS_10ClassBound__T_ : $@convention(thin) (@owned ClassBound) -> ()
 sil [fragile] @_TF4todo18class_bound_methodFT1xPS_10ClassBound__T_ : $@convention(thin) (@owned ClassBound) -> () {
 bb0(%0 : $ClassBound):
-  %1 = alloc_box $ClassBound
+  %1 = alloc_box $@box ClassBound
   %1a = project_box %1 : $@box ClassBound, 0
   %2 = store %0 to %1a : $*ClassBound
   %3 = load %1a : $*ClassBound
@@ -320,7 +320,7 @@ bb0(%0 : $Ref, %1 : $Val, %2 : $@thin Aleph.Type):
 sil [fragile] @_TFV6struct5AlephCfMS0_FT_S0_ : $@convention(thin) (@thin Aleph.Type) -> Aleph {
 bb0(%0 : $@thin Aleph.Type):
   %1 = tuple ()
-  %2 = alloc_box $Aleph       // CHECK: alloc_box
+  %2 = alloc_box $@box Aleph       // CHECK: alloc_box
   %2a = project_box %2 : $@box Aleph, 0
   // CHECK: struct_element_addr {{.*}} : $*Aleph, #Aleph.a
   %5 = struct_element_addr %2a : $*Aleph, #Aleph.a
@@ -388,7 +388,7 @@ sil [fragile] @_TF5tuple5tupleFT_TSiSf_ : $@convention(thin) () -> (Int, Float32
 // CHECK-LABEL: @_TF5tuple13tuple_elementFT1xTSiSf__T_ : $@convention(thin) (Int, Float) -> ()
 sil [fragile] @_TF5tuple13tuple_elementFT1xTSiSf__T_ : $@convention(thin) (Int, Float) -> () {
 bb0(%0 : $Int, %1 : $Float32):
-  %2 = alloc_box $(Int, Float32)
+  %2 = alloc_box $@box (Int, Float32)
   %2a = project_box %2 : $@box (Int, Float32), 0
   %3 = tuple (%0 : $Int, %1 : $Float32)
   %4 = store %3 to %2a : $*(Int, Float32)
@@ -421,10 +421,10 @@ class M {
 // CHECK-LABEL: @_TFC3ref1C3foofS0_FT1xSi_T_ : $@convention(method) (Int, @guaranteed M) -> ()
 sil [fragile] @_TFC3ref1C3foofS0_FT1xSi_T_ : $@convention(method) (Int, @guaranteed M) -> () {
 bb0(%0 : $Int, %1 : $M):
-  %2 = alloc_box $Int
+  %2 = alloc_box $@box Int
   %2a = project_box %2 : $@box Int, 0
   %3 = store %0 to %2a : $*Int
-  %4 = alloc_box $M
+  %4 = alloc_box $@box M
   %4a = project_box %4 : $@box M, 0
   %5 = store %1 to %4a : $*M
   %6 = load %2a : $*Int
@@ -446,7 +446,7 @@ class E : B { }
 // CHECK-LABEL: @_TF4null3isaFT1bCS_1B_Sb : $@convention(thin) (B) -> Builtin.Int1
 sil [fragile] @_TF4null3isaFT1bCS_1B_Sb : $@convention(thin) (B) -> Builtin.Int1 {
 bb0(%0 : $B):
-  %1 = alloc_box $B
+  %1 = alloc_box $@box B
   %1a = project_box %1 : $@box B, 0
   %2 = store %0 to %1a : $*B
   %3 = load %1a : $*B
@@ -472,9 +472,9 @@ sil [fragile] @_TFSS32_convertFromBuiltinStringLiteralfMSSFT5valueBp17utf8CodeUn
 // CHECK-LABEL: @_TF5index5gep64FT1pBp1iBi64__Bp : $@convention(thin) (Builtin.RawPointer, Builtin.Word) -> Builtin.RawPointer {
 sil [fragile] @_TF5index5gep64FT1pBp1iBi64__Bp : $@convention(thin) (Builtin.RawPointer, Builtin.Word) -> Builtin.RawPointer {
 bb0(%0 : $Builtin.RawPointer, %1 : $Builtin.Word):
-  %2 = alloc_box $Builtin.RawPointer
+  %2 = alloc_box $@box Builtin.RawPointer
   %2a = project_box %2 : $@box Builtin.RawPointer, 0
-  %3 = alloc_box $Builtin.Word
+  %3 = alloc_box $@box Builtin.Word
   %3a = project_box %3 : $@box Builtin.Word, 0
   %4 = store %0 to %2a : $*Builtin.RawPointer
   %5 = store %1 to %3a : $*Builtin.Word
@@ -513,9 +513,9 @@ class SomeSubclass : SomeClass {}
 // CHECK-LABEL: @test_class_metatype : $@convention(thin) (SomeClass, SomeSubclass) -> (@thick SomeClass.Type, @thick SomeClass.Type) {
 sil [fragile] @test_class_metatype : $@convention(thin) (SomeClass, SomeSubclass) -> (@thick SomeClass.Type, @thick SomeClass.Type) {
 bb0(%0 : $SomeClass, %1 : $SomeSubclass):
-  %2 = alloc_box $SomeClass
+  %2 = alloc_box $@box SomeClass
   %2a = project_box %2 : $@box SomeClass, 0
-  %3 = alloc_box $SomeSubclass
+  %3 = alloc_box $@box SomeSubclass
   %3a = project_box %3 : $@box SomeSubclass, 0
   %4 = store %0 to %2a : $*SomeClass
   %5 = store %1 to %3a : $*SomeSubclass
@@ -542,7 +542,7 @@ bb0(%0 : $SomeClass, %1 : $SomeSubclass):
 // CHECK-LABEL: @test_existential_metatype : $@convention(thin) (@in SomeProtocol) -> @thick SomeProtocol.Type {
 sil [fragile] @test_existential_metatype : $@convention(thin) (@in SomeProtocol) -> @thick SomeProtocol.Type {
 bb0(%0 : $*SomeProtocol):
-  %1 = alloc_box $SomeProtocol
+  %1 = alloc_box $@box SomeProtocol
   %1a = project_box %1 : $@box SomeProtocol, 0
   // CHECK: copy_addr [take] %0 to [initialization] %{{.*}} : $*SomeProtocol
   %2 = copy_addr [take] %0 to [initialization] %1a : $*SomeProtocol
@@ -614,9 +614,9 @@ bb3(%4 : $Int):
 // CHECK-LABEL: sil public_external [fragile] @test_builtin_func_ref
 sil [fragile] @test_builtin_func_ref : $@convention(thin) (Builtin.Int1, Builtin.Int1) -> Builtin.Int1 {
 bb0(%0 : $Builtin.Int1, %1 : $Builtin.Int1):
-  %2 = alloc_box $Builtin.Int1
+  %2 = alloc_box $@box Builtin.Int1
   %2a = project_box %2 : $@box Builtin.Int1, 0
-  %3 = alloc_box $Builtin.Int1
+  %3 = alloc_box $@box Builtin.Int1
   %3a = project_box %3 : $@box Builtin.Int1, 0
   store %0 to %2a : $*Builtin.Int1
   store %1 to %3a : $*Builtin.Int1
@@ -651,7 +651,7 @@ bb0:
 // CHECK-LABEL: sil public_external [fragile] @test_dealloc_box
 sil [fragile] @test_dealloc_box : $@convention(thin) () -> () {
 bb0:
-  %0 = alloc_box $Class1
+  %0 = alloc_box $@box Class1
   dealloc_box %0 : $@box Class1
   %2 = tuple ()
   return %2 : $()
@@ -706,7 +706,7 @@ sil [fragile] @closure0 : $@convention(thin) (@box Int, @inout Int) -> ()
 
 sil [fragile] @closure_test : $@convention(thin) () -> () {
 bb0:
-  %0 = alloc_box $Int                           // users: %10, %8, %8, %7, %4
+  %0 = alloc_box $@box Int                           // users: %10, %8, %8, %7, %4
   %0a = project_box %0 : $@box Int, 0
 
   %5 = function_ref @takes_closure : $@convention(thin) (@callee_owned () -> ()) -> ()
@@ -734,7 +734,7 @@ sil [fragile] @_TF6switch1cFT_T_ : $@convention(thin) () -> ()
 // CHECK-LABEL: sil public_external [fragile] @test_switch_union : $@convention(thin) (MaybePair) -> ()
 sil [fragile] @test_switch_union : $@convention(thin) (MaybePair) -> () {
 bb0(%0 : $MaybePair):
-  %1 = alloc_box $MaybePair
+  %1 = alloc_box $@box MaybePair
   %1a = project_box %1 : $@box MaybePair, 0
   store %0 to %1a : $*MaybePair
   %3 = load %1a : $*MaybePair
@@ -824,7 +824,7 @@ struct Spoon : Bendable {
 // CHECK-LABEL: sil public_external [fragile] @test_init_existential : $@convention(thin) (Spoon) -> @out Bendable
 sil [fragile] @test_init_existential : $@convention(thin) (Spoon) -> @out Bendable {
 bb0(%0 : $*Bendable, %1 : $Spoon):
-  %2 = alloc_box $Spoon
+  %2 = alloc_box $@box Spoon
   %2a = project_box %2 : $@box Spoon, 0
   store %1 to %2a : $*Spoon
   // CHECK: init_existential_addr %{{.*}} : $*Bendable, $Spoon
@@ -841,7 +841,7 @@ bb0(%0 : $*Bendable, %1 : $Spoon):
 // CHECK-LABEL: sil public_external [fragile] @test_existential_ref : $@convention(thin) (ConcreteClass) -> ClassP
 sil [fragile] @test_existential_ref : $@convention(thin) (ConcreteClass) -> ClassP {
 bb0(%0 : $ConcreteClass):
-  %1 = alloc_box $ConcreteClass
+  %1 = alloc_box $@box ConcreteClass
   %1a = project_box %1 : $@box ConcreteClass, 0
   store %0 to %1a : $*ConcreteClass
   %3 = load %1a : $*ConcreteClass
@@ -923,10 +923,10 @@ class X {
 // CHECK-LABEL: sil public_external [fragile] @test_dynamic_lookup_br : $@convention(thin) (AnyObject) -> ()
 sil [fragile] @test_dynamic_lookup_br : $@convention(thin) (AnyObject) -> () {
 bb0(%0 : $AnyObject):
-  %1 = alloc_box $AnyObject
+  %1 = alloc_box $@box AnyObject
   %1a = project_box %1 : $@box AnyObject, 0
   store %0 to %1a : $*AnyObject
-  %3 = alloc_box $Optional<() -> ()>
+  %3 = alloc_box $@box Optional<() -> ()>
   %4 = load %1a : $*AnyObject
   strong_retain %4 : $AnyObject
   // CHECK: open_existential_ref %{{.*}} : $AnyObject to $@opened({{.*}}) AnyObject
@@ -947,9 +947,9 @@ bb3:
 
 // CHECK-LABEL: sil public_external [fragile] @test_mark_fn_escape
 sil [fragile] @test_mark_fn_escape : $@convention(thin) () -> () {
-  %b = alloc_box $Int
+  %b = alloc_box $@box Int
   %ba = project_box %b : $@box Int, 0
-  %c = alloc_box $Int
+  %c = alloc_box $@box Int
   %ca = project_box %c : $@box Int, 0
 
   //mark_function_escape %ba : $*Int

--- a/test/Serialization/sil_box_types.sil
+++ b/test/Serialization/sil_box_types.sil
@@ -1,0 +1,13 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: %target-build-swift -emit-module -Xfrontend -disable-diagnostic-passes -Xfrontend -sil-serialize-all -force-single-frontend-invocation -o %t/sil_box_types.swiftmodule %s
+// RUN: %target-build-swift -emit-sil -Xfrontend -sil-link-all -I %t %s | %FileCheck %s
+
+import Builtin
+
+// CHECK-LABEL: sil @boxes : $@convention(thin) (@box Builtin.Int32, @box Builtin.Int32) -> () {
+sil @boxes : $@convention(thin) (@box Builtin.Int32, @box Builtin.Int32) -> () {
+// CHECK: bb0(%0 : $@box Builtin.Int32, %1 : $@box Builtin.Int32):
+entry(%0 : $@box Builtin.Int32, %1 : $@box Builtin.Int32):
+  return undef : $()
+}

--- a/test/sil-extract/basic.sil
+++ b/test/sil-extract/basic.sil
@@ -17,7 +17,7 @@ sil @makesInt : $@convention(thin) () -> Int64
 // CHECK: }
 sil @use_before_init : $@convention(thin) () -> Int64 {
 bb0:
-  %1 = alloc_box $Int64
+  %1 = alloc_box $@box Int64
   %1a = project_box %1 : $@box Int64, 0
   %2 = load %1a : $*Int64
   %3 = function_ref @inout_uninit : $@convention(thin)() -> ()
@@ -29,7 +29,7 @@ bb0:
 // CHECK-NOT: sil @inout_uninit : $@convention(thin) () -> () {
 sil @inout_uninit : $@convention(thin) () -> () {
 bb0:
-  %1 = alloc_box $Int64
+  %1 = alloc_box $@box Int64
   %1a = project_box %1 : $@box Int64, 0
   %5 = function_ref @takes_Int_inout : $@convention(thin) (@inout Int64) -> ()
   %6 = apply %5(%1a) : $@convention(thin) (@inout Int64) -> ()


### PR DESCRIPTION
This becomes necessary with generalized boxes, since the box type isn't derivable from a single field type.