### PR TITLE
[QoI] Improve "never used" diagnostics

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2559,11 +2559,15 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
       //  ->
       //    _ = foo()
       if (auto *pbd = var->getParentPatternBinding())
-        if (pbd->getSingleVar() == var && pbd->getInit(0) != nullptr) {
+        if (pbd->getSingleVar() == var && pbd->getInit(0) != nullptr &&
+            !isa<TypedPattern>(pbd->getPatternList()[0].getPattern())) {
           unsigned varKind = var->isLet();
+          SourceRange replaceRange(
+              pbd->getStartLoc(),
+              pbd->getPatternList()[0].getPattern()->getEndLoc());
           TC.diagnose(var->getLoc(), diag::pbd_never_used,
                       var->getName(), varKind)
-            .fixItReplace(SourceRange(pbd->getLoc(), var->getLoc()), "_");
+            .fixItReplace(replaceRange, "_");
           continue;
         }
       

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -842,7 +842,7 @@ func testOptionalTryNeverFails() {
 // CHECK-NEXT:   return [[VOID]] : $()
 // CHECK-NEXT: } // end sil function '_TF6errors28testOptionalTryNeverFailsVarFT_T_'
 func testOptionalTryNeverFailsVar() {
-  var unit: ()? = try? () // expected-warning {{no calls to throwing functions occur within 'try' expression}} expected-warning {{initialization of variable 'unit' was never used; consider replacing with assignment to '_' or removing it}}
+  var unit: ()? = try? () // expected-warning {{no calls to throwing functions occur within 'try' expression}} expected-warning {{variable 'unit' was never used; consider replacing with '_' or removing it}}
 }
 
 // CHECK-LABEL: sil hidden @_TF6errors36testOptionalTryNeverFailsAddressOnly

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -246,3 +246,9 @@ func test(_ a : Int?, b : Any) {
 
 }
 
+func test2() {
+  let a = 4 // expected-warning {{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}} {{3-8=_}}
+  var ( b ) = 6 // expected-warning {{initialization of variable 'b' was never used; consider replacing with assignment to '_' or removing it}} {{3-12=_}}
+  var c: Int = 4 // expected-warning {{variable 'c' was never used; consider replacing with '_' or removing it}} {{7-8=_}}
+  let (d): Int = 9 // expected-warning {{immutable value 'd' was never used; consider replacing with '_' or removing it}} {{8-9=_}}
+}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -456,7 +456,7 @@ func stringliterals(_ d: [String: Int]) {
     "something else")"
   // expected-error @-2 {{unterminated string literal}} expected-error @-1 {{unterminated string literal}}
 
-  // expected-warning @+2 {{initialization of variable 'x2' was never used; consider replacing with assignment to '_' or removing it}}
+  // expected-warning @+2 {{variable 'x2' was never used; consider replacing with '_' or removing it}}
   // expected-error @+1 {{unterminated string literal}}
   var x2 : () = ("hello" + "
   ;

--- a/test/expr/postfix/dot/init_ref_delegation.swift
+++ b/test/expr/postfix/dot/init_ref_delegation.swift
@@ -334,7 +334,7 @@ class TestNestedExpr {
 
   convenience init(a: Int) {
     let x: () = self.init() // expected-error {{initializer delegation ('self.init') cannot be nested in another statement}}
-    // expected-warning@-1 {{initialization of immutable value 'x' was never used; consider replacing with assignment to '_' or removing it}}
+    // expected-warning@-1 {{immutable value 'x' was never used; consider replacing with '_' or removing it}}
   }
 
   convenience init(b: Int) {
@@ -348,7 +348,7 @@ class TestNestedExpr {
 
   convenience init(d: Int) {
     let x: () = self.init(fail: true)! // expected-error {{initializer delegation ('self.init') cannot be nested in another statement}}
-    // expected-warning@-1 {{initialization of immutable value 'x' was never used; consider replacing with assignment to '_' or removing it}}
+    // expected-warning@-1 {{immutable value 'x' was never used; consider replacing with '_' or removing it}}
   }
 
   convenience init(e: Int) {
@@ -362,7 +362,7 @@ class TestNestedExpr {
 
   convenience init(g: Int) {
     let x: () = try! self.init(error: true) // expected-error {{initializer delegation ('self.init') cannot be nested in another statement}}
-    // expected-warning@-1 {{initialization of immutable value 'x' was never used; consider replacing with assignment to '_' or removing it}}
+    // expected-warning@-1 {{immutable value 'x' was never used; consider replacing with '_' or removing it}}
   }
 
   convenience init(h: Int) {
@@ -378,7 +378,7 @@ class TestNestedExpr {
 class TestNestedExprSub : TestNestedExpr {
   init(a: Int) {
     let x: () = super.init() // expected-error {{initializer chaining ('super.init') cannot be nested in another statement}}
-    // expected-warning@-1 {{initialization of immutable value 'x' was never used; consider replacing with assignment to '_' or removing it}}
+    // expected-warning@-1 {{immutable value 'x' was never used; consider replacing with '_' or removing it}}
   }
 
   init(b: Int) {
@@ -392,7 +392,7 @@ class TestNestedExprSub : TestNestedExpr {
 
   init(d: Int) {
     let x: () = super.init(fail: true)! // expected-error {{initializer chaining ('super.init') cannot be nested in another statement}}
-    // expected-warning@-1 {{initialization of immutable value 'x' was never used; consider replacing with assignment to '_' or removing it}}
+    // expected-warning@-1 {{immutable value 'x' was never used; consider replacing with '_' or removing it}}
   }
 
   init(e: Int) {
@@ -406,7 +406,7 @@ class TestNestedExprSub : TestNestedExpr {
 
   init(g: Int) {
     let x: () = try! super.init(error: true) // expected-error {{initializer chaining ('super.init') cannot be nested in another statement}}
-    // expected-warning@-1 {{initialization of immutable value 'x' was never used; consider replacing with assignment to '_' or removing it}}
+    // expected-warning@-1 {{immutable value 'x' was never used; consider replacing with '_' or removing it}}
   }
 
   init(h: Int) {


### PR DESCRIPTION
On `let (x) = some`, we should remove r-paren as well. → `_ = some`
On `let x: Int = some`, we can't remove `let` introducer. → `let _: Int = some`