### PR TITLE
[swiftc (98 vs. 5181)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28468-segfault-0xd09050-0xd08dfd-0xbe9d76-0xbeb154.swift
+++ b/validation-test/compiler_crashers/28468-segfault-0xd09050-0xd08dfd-0xbe9d76-0xbeb154.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol A{typealias B>typealias B<a>:a}extension A


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 98 (5181 resolved)

Stack trace:

```
#0 0x00000000031d00b8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d00b8)
#1 0x00000000031d0906 SignalHandler(int) (/path/to/swift/bin/swift+0x31d0906)
#2 0x00007f07993a5330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x0000000000ddaea4 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0xddaea4)
#4 0x0000000000ddbf37 swift::TypeBase::isEqual(swift::Type) (/path/to/swift/bin/swift+0xddbf37)
#5 0x0000000000ce946a swift::ArchetypeBuilder::PotentialArchetype::getNestedType(swift::Identifier, swift::ArchetypeBuilder&) (/path/to/swift/bin/swift+0xce946a)
#6 0x0000000000ceb811 swift::ArchetypeBuilder::addConformanceRequirement(swift::ArchetypeBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::RequirementSource, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0xceb811)
#7 0x0000000000cf049d bool llvm::function_ref<bool (swift::Type, swift::SourceLoc)>::callback_fn<swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&)::$_3>(long, swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0xcf049d)
#8 0x0000000000cf0311 std::_Function_handler<void (swift::Type, swift::SourceLoc), swift::ArchetypeBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>)::$_4>::_M_invoke(std::_Any_data const&, swift::Type, swift::SourceLoc) (/path/to/swift/bin/swift+0xcf0311)
#9 0x0000000000ced31f swift::ArchetypeBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>) (/path/to/swift/bin/swift+0xced31f)
#10 0x0000000000ceb4e0 swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0xceb4e0)
#11 0x0000000000ceb28d swift::ArchetypeBuilder::addGenericParameterRequirements(swift::GenericTypeParamDecl*) (/path/to/swift/bin/swift+0xceb28d)
#12 0x0000000000bcb1b6 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::GenericSignature*, swift::GenericEnvironment*, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xbcb1b6)
#13 0x0000000000bcc594 swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, bool, std::function<void (swift::ArchetypeBuilder&)>) (/path/to/swift/bin/swift+0xbcc594)
#14 0x0000000000bccfe0 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0xbccfe0)
#15 0x0000000000b9c4b3 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9c4b3)
#16 0x0000000000c1116f resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc1116f)
#17 0x0000000000c100be resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc100be)
#18 0x0000000000c07a11 resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07a11)
#19 0x0000000000c0770d swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0770d)
#20 0x0000000000c08828 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc08828)
#21 0x0000000000c0871f swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0871f)
#22 0x0000000000c06ea9 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc06ea9)
#23 0x0000000000c13aad bindExtensionDecl(swift::ExtensionDecl*, swift::TypeChecker&) (/path/to/swift/bin/swift+0xc13aad)
#24 0x0000000000c18d75 void llvm::function_ref<void (std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>)>::callback_fn<swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int)::$_2>(long, std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>) (/path/to/swift/bin/swift+0xc18d75)
#25 0x00000000004c36c4 bool llvm::function_ref<bool (std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>)>::callback_fn<swift::FileUnit::forAllVisibleModules(llvm::function_ref<void (std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>)>)::{lambda(std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>)#1}>(long, std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>) (/path/to/swift/bin/swift+0x4c36c4)
#26 0x0000000000dbb2c3 swift::ModuleDecl::forAllVisibleModules(llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, bool, llvm::function_ref<bool (std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>)>) (/path/to/swift/bin/swift+0xdbb2c3)
#27 0x0000000000dbb451 swift::FileUnit::forAllVisibleModules(llvm::function_ref<bool (std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>)>) (/path/to/swift/bin/swift+0xdbb451)
#28 0x0000000000c14aae swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc14aae)
#29 0x0000000000937e46 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x937e46)
#30 0x000000000047ecc5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ecc5)
#31 0x000000000047db5f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47db5f)
#32 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
#33 0x00007f0797b4ef45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
#34 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```