### PR TITLE
Store a GenericSignature in GenericEnvironment

### DIFF
--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -258,7 +258,7 @@ public:
   GenericSignature *getGenericSignature();
 
   /// \brief Build the generic environment.
-  GenericEnvironment *getGenericEnvironment();
+  GenericEnvironment *getGenericEnvironment(GenericSignature *signature);
 
   /// Infer requirements from the given type, recursively.
   ///

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -21,8 +21,8 @@
 #include "swift/AST/ClangNode.h"
 #include "swift/AST/ConcreteDeclRef.h"
 #include "swift/AST/DefaultArgumentKind.h"
-#include "swift/AST/GenericSignature.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/TypeAlignments.h"
 #include "swift/AST/Witness.h"
@@ -1458,7 +1458,9 @@ public:
   }
 
   /// Retrieve the generic signature for this extension.
-  GenericSignature *getGenericSignature() const { return GenericEnv ? GenericEnv->getGenericSignature() : nullptr; }
+  GenericSignature *getGenericSignature() const {
+    return GenericEnv ? GenericEnv->getGenericSignature() : nullptr;
+  }
 
   /// Retrieve the generic context for this extension.
   GenericEnvironment *getGenericEnvironment() const { return GenericEnv; }
@@ -4539,15 +4541,14 @@ protected:
 
   ImportAsMemberStatus IAMStatus;
 
-  AbstractFunctionDecl(DeclKind Kind, DeclContext *Parent,
-                       DeclName Name, SourceLoc NameLoc,
-                       bool Throws, SourceLoc ThrowsLoc,
+  AbstractFunctionDecl(DeclKind Kind, DeclContext *Parent, DeclName Name,
+                       SourceLoc NameLoc, bool Throws, SourceLoc ThrowsLoc,
                        unsigned NumParameterLists,
                        GenericParamList *GenericParams)
       : ValueDecl(Kind, Parent, Name, NameLoc),
         DeclContext(DeclContextKind::AbstractFunctionDecl, Parent),
-        Body(nullptr), GenericParams(nullptr),
-        GenericEnv(nullptr), ThrowsLoc(ThrowsLoc) {
+        Body(nullptr), GenericParams(nullptr), GenericEnv(nullptr),
+        ThrowsLoc(ThrowsLoc) {
     setBodyKind(BodyKind::None);
     setGenericParams(GenericParams);
     AbstractFunctionDeclBits.NumParameterLists = NumParameterLists;

--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -90,8 +90,7 @@ public:
                      ArrayRef<Substitution> subs,
                      SubstitutionMap &subMap) const;
 
-  ArrayRef<Substitution>
-  getForwardingSubstitutions(ModuleDecl *M) const;
+  ArrayRef<Substitution> getForwardingSubstitutions(ModuleDecl *M) const;
 
   void dump() const;
 };

--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -19,6 +19,7 @@
 
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SubstitutionMap.h"
+#include "swift/AST/GenericSignature.h"
 
 namespace swift {
 
@@ -28,13 +29,17 @@ class GenericTypeParamType;
 /// Describes the mapping between archetypes and interface types for the
 /// generic parameters of a DeclContext.
 class GenericEnvironment final {
-  SmallVector<GenericTypeParamType *, 4> GenericParams;
+  GenericSignature *Signature;
   TypeSubstitutionMap ArchetypeToInterfaceMap;
   TypeSubstitutionMap InterfaceToArchetypeMap;
 
 public:
+  GenericSignature *getGenericSignature() const {
+    return Signature;
+  }
+
   ArrayRef<GenericTypeParamType *> getGenericParams() const {
-    return GenericParams;
+    return Signature->getGenericParams();
   }
 
   const TypeSubstitutionMap &getArchetypeToInterfaceMap() const {
@@ -45,12 +50,12 @@ public:
     return InterfaceToArchetypeMap;
   }
 
-  GenericEnvironment(ArrayRef<GenericTypeParamType *> genericParamTypes,
+  GenericEnvironment(GenericSignature *signature,
                      TypeSubstitutionMap interfaceToArchetypeMap);
 
   static
   GenericEnvironment * get(ASTContext &ctx,
-                           ArrayRef<GenericTypeParamType *> genericParamTypes,
+                           GenericSignature *signature,
                            TypeSubstitutionMap interfaceToArchetypeMap);
 
   /// Make vanilla new/delete illegal.

--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -17,7 +17,6 @@
 #ifndef SWIFT_AST_GENERIC_ENVIRONMENT_H
 #define SWIFT_AST_GENERIC_ENVIRONMENT_H
 
-#include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/GenericSignature.h"
 

--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -83,18 +83,16 @@ public:
   /// with contextual types instead of interface types.
   SubstitutionMap
   getSubstitutionMap(ModuleDecl *mod,
-                     GenericSignature *sig,
                      ArrayRef<Substitution> subs) const;
 
   /// Same as above, but updates an existing map.
   void
   getSubstitutionMap(ModuleDecl *mod,
-                     GenericSignature *sig,
                      ArrayRef<Substitution> subs,
                      SubstitutionMap &subMap) const;
 
   ArrayRef<Substitution>
-  getForwardingSubstitutions(ModuleDecl *M, GenericSignature *sig) const;
+  getForwardingSubstitutions(ModuleDecl *M) const;
 
   void dump() const;
 };

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -19,6 +19,7 @@
 
 #include "swift/AST/Attr.h"
 #include "swift/AST/DeclContext.h"
+#include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/Type.h"
 #include "swift/AST/TypeAlignments.h"
@@ -367,7 +368,6 @@ class FunctionTypeRepr : public TypeRepr {
   // we can have polymorphic function values.
   GenericParamList *GenericParams;
   GenericEnvironment *GenericEnv;
-  GenericSignature *GenericSig;
 
   TypeRepr *ArgsTy;
   TypeRepr *RetTy;
@@ -380,19 +380,13 @@ public:
     : TypeRepr(TypeReprKind::Function),
       GenericParams(genericParams),
       GenericEnv(nullptr),
-      GenericSig(nullptr),
       ArgsTy(argsTy), RetTy(retTy),
       ArrowLoc(arrowLoc), ThrowsLoc(throwsLoc) {
   }
 
   GenericParamList *getGenericParams() const { return GenericParams; }
   GenericEnvironment *getGenericEnvironment() const { return GenericEnv; }
-  GenericSignature *getGenericSignature() const { return GenericSig; }
-
-  void setGenericSignature(GenericSignature *genericSig) {
-    assert(GenericSig == nullptr);
-    GenericSig = genericSig;
-  }
+  GenericSignature *getGenericSignature() const { return GenericEnv ? GenericEnv->getGenericSignature() : nullptr; }
 
   void setGenericEnvironment(GenericEnvironment *genericEnv) {
     assert(GenericEnv == nullptr);

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -386,7 +386,9 @@ public:
 
   GenericParamList *getGenericParams() const { return GenericParams; }
   GenericEnvironment *getGenericEnvironment() const { return GenericEnv; }
-  GenericSignature *getGenericSignature() const { return GenericEnv ? GenericEnv->getGenericSignature() : nullptr; }
+  GenericSignature *getGenericSignature() const {
+    return GenericEnv ? GenericEnv->getGenericSignature() : nullptr;
+  }
 
   void setGenericEnvironment(GenericEnvironment *genericEnv) {
     assert(GenericEnv == nullptr);

--- a/include/swift/AST/Witness.h
+++ b/include/swift/AST/Witness.h
@@ -92,7 +92,6 @@ class Witness {
     /// The witness declaration, along with the substitutions needed to use
     /// the witness declaration from the synthetic environment.
     ConcreteDeclRef declRef;
-    GenericSignature *syntheticSignature;
     GenericEnvironment *syntheticEnvironment;
     SubstitutionMap reqToSyntheticEnvMap;
   };
@@ -116,14 +115,12 @@ public:
   /// \param substitutions The substitutions required to use the witness from
   /// the synthetic environment.
   ///
-  /// \param syntheticSig The generic signature for the synthetic environment.
-  ///
   /// \param syntheticEnv The synthetic environment.
   ///
   /// \param reqToSyntheticEnvMap The mapping from the interface types of the
   /// requirement into the interface types of the synthetic environment.
   Witness(ValueDecl *decl, ArrayRef<Substitution> substitutions,
-          GenericSignature *syntheticSig, GenericEnvironment *syntheticEnv,
+          GenericEnvironment *syntheticEnv,
           SubstitutionMap reqToSyntheticEnvMap);
 
   /// Retrieve the witness declaration reference, which includes the
@@ -164,7 +161,10 @@ public:
   /// Retrieve the generic signature of the synthetic environment.
   GenericSignature *getSyntheticSignature() const {
     assert(requiresSubstitution() && "No substitutions required for witness");
-    return storage.get<StoredWitness *>()->syntheticSignature;
+    if (auto *env = getSyntheticEnvironment())
+      return env->getGenericSignature();
+    else
+      return nullptr;
   }
 
   /// Retrieve the synthetic generic environment.

--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -41,8 +41,7 @@ class TypeSubstCloner : public SILClonerWithScopes<ImplClass> {
 
   void computeSubsMap() {
     if (auto *env = Original.getGenericEnvironment()) {
-      auto sig = Original.getLoweredFunctionType()->getGenericSignature();
-      SubsMap = env->getSubstitutionMap(SwiftMod, sig, ApplySubs);
+      SubsMap = env->getSubstitutionMap(SwiftMod, ApplySubs);
     }
   }
 

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -440,15 +440,20 @@ private:
                                      GenericParamList *outerParams = nullptr);
 
   /// Reads a set of requirements from \c DeclTypeCursor.
-  void readGenericRequirements(SmallVectorImpl<Requirement> &requirements);
+  void readGenericRequirements(SmallVectorImpl<Requirement> &requirements,
+                               llvm::BitstreamCursor &Cursor);
 
   /// Reads a GenericEnvironment from \c DeclTypeCursor.
+  ///
+  /// The optional requirements are used to construct the signature without
+  /// attempting to deserialize any requirements, such as when reading SIL.
   ///
   /// Also returns the set of generic parameters read, in order, to help with
   /// forming a GenericSignature.
   GenericEnvironment *readGenericEnvironment(
       SmallVectorImpl<GenericTypeParamType *> &paramTypes,
-      llvm::BitstreamCursor &Cursor);
+      llvm::BitstreamCursor &Cursor,
+      Optional<ArrayRef<Requirement>> optRequirements = None);
 
   /// Reads a GenericEnvironment followed by requirements from \c DeclTypeCursor.
   ///

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -447,11 +447,7 @@ private:
   ///
   /// The optional requirements are used to construct the signature without
   /// attempting to deserialize any requirements, such as when reading SIL.
-  ///
-  /// Also returns the set of generic parameters read, in order, to help with
-  /// forming a GenericSignature.
   GenericEnvironment *readGenericEnvironment(
-      SmallVectorImpl<GenericTypeParamType *> &paramTypes,
       llvm::BitstreamCursor &Cursor,
       Optional<ArrayRef<Requirement>> optRequirements = None);
 

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -457,13 +457,10 @@ private:
 
   /// Reads a GenericEnvironment followed by requirements from \c DeclTypeCursor.
   ///
-  /// Returns the GenericEnvironment and the signature formed from the
-  /// generic parameters of the environment, together with the
-  /// read requirements.
+  /// Returns the GenericEnvironment.
   ///
   /// Returns nullptr if there's no generic signature here.
-  std::pair<GenericSignature *, GenericEnvironment *>
-  maybeReadGenericSignature();
+  GenericEnvironment *maybeReadGenericEnvironment();
 
   /// Populates the vector with members of a DeclContext from \c DeclTypeCursor.
   ///

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -45,7 +45,6 @@ namespace swift {
   class FileUnit;
   class GenericEnvironment;
   class GenericParamList;
-  class GenericSignature;
   class IRGenOptions;
   class LangOptions;
   class ModuleDecl;
@@ -210,10 +209,9 @@ namespace swift {
                               bool ProduceDiagnostics = true);
 
   /// Expose TypeChecker's handling of GenericParamList to SIL parsing.
-  std::pair<GenericSignature *, GenericEnvironment *>
-  handleSILGenericParams(ASTContext &Ctx,
-                         GenericParamList *genericParams,
-                         DeclContext *DC);
+  GenericEnvironment *handleSILGenericParams(ASTContext &Ctx,
+                                             GenericParamList *genericParams,
+                                             DeclContext *DC);
 
   /// Turn the given module into SIL IR.
   ///

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3583,9 +3583,9 @@ GenericSignature *GenericSignature::get(ArrayRef<GenericTypeParamType *> params,
 
 GenericEnvironment *
 GenericEnvironment::get(ASTContext &ctx,
-                        ArrayRef<GenericTypeParamType *> genericParamTypes,
+                        GenericSignature *signature,
                         TypeSubstitutionMap interfaceToArchetypeMap) {
-  return new (ctx) GenericEnvironment(genericParamTypes,
+  return new (ctx) GenericEnvironment(signature,
                                       interfaceToArchetypeMap);
 }
 

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -2087,13 +2087,11 @@ GenericSignature *ArchetypeBuilder::getGenericSignature() {
   return sig;
 }
 
-GenericEnvironment *ArchetypeBuilder::getGenericEnvironment() {
-  SmallVector<GenericTypeParamType *, 4> genericParamTypes;
+GenericEnvironment *ArchetypeBuilder::getGenericEnvironment(GenericSignature *signature) {
   TypeSubstitutionMap interfaceToArchetypeMap;
 
   for (auto pair : Impl->PotentialArchetypes) {
     auto paramTy = pair.second->getGenericParam();
-    genericParamTypes.push_back(paramTy);
 
     auto archetypeTy = pair.second->getType(*this).getAsArchetype();
     auto concreteTy = pair.second->getType(*this).getAsConcreteType();
@@ -2105,7 +2103,8 @@ GenericEnvironment *ArchetypeBuilder::getGenericEnvironment() {
       llvm_unreachable("broken generic parameter");
   }
 
-  return GenericEnvironment::get(Context, genericParamTypes,
+
+  return GenericEnvironment::get(Context, signature,
                                  interfaceToArchetypeMap);
 }
 

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -199,7 +199,7 @@ getBuiltinGenericFunction(Identifier Id,
   GenericSignature *Sig =
     GenericSignature::get(GenericParamTypes, { });
   GenericEnvironment *Env =
-      GenericEnvironment::get(Context, GenericParamTypes,
+      GenericEnvironment::get(Context, Sig,
                               InterfaceToArchetypeMap);
 
   Type InterfaceType = GenericFunctionType::get(Sig, ArgParamType, ResType,

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -236,7 +236,6 @@ getBuiltinGenericFunction(Identifier Id,
                                TypeLoc::withoutLoc(ResBodyType), DC);
     
   func->setInterfaceType(InterfaceType);
-  func->setGenericSignature(Sig);
   func->setGenericEnvironment(Env);
   func->setImplicit();
   func->setAccessibility(Accessibility::Public);

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -89,8 +89,7 @@ GenericTypeParamType *GenericEnvironment::getSugaredType(
 }
 
 ArrayRef<Substitution>
-GenericEnvironment::getForwardingSubstitutions(
-    ModuleDecl *M, GenericSignature *sig) const {
+GenericEnvironment::getForwardingSubstitutions(ModuleDecl *M) const {
   auto lookupConformanceFn =
       [&](CanType original, Type replacement, ProtocolType *protoType)
           -> ProtocolConformanceRef {
@@ -105,16 +104,14 @@ GenericEnvironment::getForwardingSubstitutions(
 
 SubstitutionMap GenericEnvironment::
 getSubstitutionMap(ModuleDecl *mod,
-                   GenericSignature *sig,
                    ArrayRef<Substitution> subs) const {
   SubstitutionMap result;
-  getSubstitutionMap(mod, getGenericSignature(), subs, result);
+  getSubstitutionMap(mod, subs, result);
   return result;
 }
 
 void GenericEnvironment::
 getSubstitutionMap(ModuleDecl *mod,
-                   GenericSignature *sig,
                    ArrayRef<Substitution> subs,
                    SubstitutionMap &result) const {
   for (auto depTy : getGenericSignature()->getAllDependentTypes()) {

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -16,6 +16,7 @@
 
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/ProtocolConformance.h"
 
 using namespace swift;
 

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -14,8 +14,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/AST/ASTContext.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/ASTContext.h"
 #include "swift/AST/ProtocolConformance.h"
 
 using namespace swift;

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -379,10 +379,9 @@ SpecializedProtocolConformance::getTypeWitnessSubstAndDecl(
   auto conformingModule = conformingDC->getParentModule();
 
   auto *genericEnv = GenericConformance->getGenericEnvironment();
-  auto *genericSig = GenericConformance->getGenericSignature();
 
   auto substitutionMap = genericEnv->getSubstitutionMap(
-      conformingModule, genericSig, GenericSubstitutions);
+      conformingModule, GenericSubstitutions);
 
   auto genericWitnessAndDecl
     = GenericConformance->getTypeWitnessSubstAndDecl(assocType, resolver);
@@ -534,10 +533,9 @@ ProtocolConformance::getInheritedConformance(ProtocolDecl *protocol) const {
     auto *conformingDC = spec->getDeclContext();
     auto *conformingModule = conformingDC->getParentModule();
 
-    auto *sig = conformingDC->getGenericSignatureOfContext();
     auto *env = conformingDC->getGenericEnvironmentOfContext();
 
-    auto subMap = env->getSubstitutionMap(conformingModule, sig, subs);
+    auto subMap = env->getSubstitutionMap(conformingModule, subs);
 
     auto r = inherited->subst(conformingModule, getType(), subMap);
     assert(getType()->isEqual(r->getType())

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -37,9 +37,8 @@ Witness::Witness(ValueDecl *decl, ArrayRef<Substitution> substitutions,
 
   auto declRef = ConcreteDeclRef(ctx, decl, substitutions);
   auto storedMem = ctx.Allocate(sizeof(StoredWitness), alignof(StoredWitness));
-  auto stored =
-    new (storedMem) StoredWitness{declRef, syntheticEnv,
-                                  std::move(reqToSynthesizedEnvMap)};
+  auto stored = new (storedMem)
+      StoredWitness{declRef, syntheticEnv, std::move(reqToSynthesizedEnvMap)};
   ctx.addDestructorCleanup(*stored);
 
   storage = stored;
@@ -379,8 +378,8 @@ SpecializedProtocolConformance::getTypeWitnessSubstAndDecl(
 
   auto *genericEnv = GenericConformance->getGenericEnvironment();
 
-  auto substitutionMap = genericEnv->getSubstitutionMap(
-      conformingModule, GenericSubstitutions);
+  auto substitutionMap =
+      genericEnv->getSubstitutionMap(conformingModule, GenericSubstitutions);
 
   auto genericWitnessAndDecl
     = GenericConformance->getTypeWitnessSubstAndDecl(assocType, resolver);

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -31,7 +31,6 @@
 using namespace swift;
 
 Witness::Witness(ValueDecl *decl, ArrayRef<Substitution> substitutions,
-                 GenericSignature *syntheticSig,
                  GenericEnvironment *syntheticEnv,
                  SubstitutionMap reqToSynthesizedEnvMap) {
   auto &ctx = decl->getASTContext();
@@ -39,7 +38,7 @@ Witness::Witness(ValueDecl *decl, ArrayRef<Substitution> substitutions,
   auto declRef = ConcreteDeclRef(ctx, decl, substitutions);
   auto storedMem = ctx.Allocate(sizeof(StoredWitness), alignof(StoredWitness));
   auto stored =
-    new (storedMem) StoredWitness{declRef, syntheticSig, syntheticEnv,
+    new (storedMem) StoredWitness{declRef, syntheticEnv,
                                   std::move(reqToSynthesizedEnvMap)};
   ctx.addDestructorCleanup(*stored);
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3556,7 +3556,8 @@ namespace {
 
         // Calculate the correct bound-generic extended type.
         SmallVector<Type, 2> genericArgs;
-        for (auto paramTy : env->getGenericSignature()->getInnermostGenericParams()) {
+        for (auto paramTy :
+             env->getGenericSignature()->getInnermostGenericParams()) {
           genericArgs.push_back(env->mapTypeIntoContext(paramTy));
         }
         Type extendedType =
@@ -6840,10 +6841,8 @@ DeclContext *ClangImporter::Implementation::importDeclContextImpl(
 }
 
 // Calculate the generic environment from an imported generic param list.
-GenericEnvironment *
-ClangImporter::Implementation::
-buildGenericEnvironment(GenericParamList *genericParams,
-                        DeclContext *dc) {
+GenericEnvironment *ClangImporter::Implementation::buildGenericEnvironment(
+    GenericParamList *genericParams, DeclContext *dc) {
   ArchetypeBuilder builder(*dc->getParentModule(), SwiftContext.Diags);
   for (auto param : *genericParams)
     builder.addGenericParameter(param);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1290,7 +1290,6 @@ static FuncDecl *buildSubscriptGetterDecl(ClangImporter::Implementation &Impl,
       TypeLoc::withoutLoc(elementTy), dc, getter->getClangNode());
   thunk->setBodyResultType(elementTy);
   thunk->setInterfaceType(interfaceType);
-  thunk->setGenericSignature(dc->getGenericSignatureOfContext());
   thunk->setGenericEnvironment(dc->getGenericEnvironmentOfContext());
 
   thunk->setAccessibility(getOverridableAccessibility(dc));
@@ -1354,7 +1353,6 @@ static FuncDecl *buildSubscriptSetterDecl(ClangImporter::Implementation &Impl,
       TypeLoc::withoutLoc(TupleType::getEmpty(C)), dc, setter->getClangNode());
   thunk->setBodyResultType(TupleType::getEmpty(C));
   thunk->setInterfaceType(interfaceType);
-  thunk->setGenericSignature(dc->getGenericSignatureOfContext());
   thunk->setGenericEnvironment(dc->getGenericEnvironmentOfContext());
 
   thunk->setAccessibility(getOverridableAccessibility(dc));
@@ -3323,7 +3321,6 @@ namespace {
       result->setBodyResultType(resultTy);
       result->setType(type);
       result->setInterfaceType(interfaceType);
-      result->setGenericSignature(dc->getGenericSignatureOfContext());
       result->setGenericEnvironment(dc->getGenericEnvironmentOfContext());
 
       // Optional methods in protocols.
@@ -3558,7 +3555,6 @@ namespace {
         GenericEnvironment *env;
         std::tie(sig, env) = Impl.buildGenericSignature(genericParams, result);
 
-        result->setGenericSignature(sig);
         result->setGenericEnvironment(env);
 
         // Calculate the correct bound-generic extended type.
@@ -3722,7 +3718,6 @@ namespace {
       GenericEnvironment *env;
       std::tie(sig, env) = Impl.buildGenericSignature(result->getGenericParams(), dc);
 
-      result->setGenericSignature(sig);
       result->setGenericEnvironment(env);
 
       result->setMemberLoader(&Impl, 0);
@@ -3852,7 +3847,6 @@ namespace {
           GenericEnvironment *env;
           std::tie(sig, env) = Impl.buildGenericSignature(genericParams, dc);
 
-          result->setGenericSignature(sig);
           result->setGenericEnvironment(env);
         }
       } else {
@@ -4341,14 +4335,12 @@ Decl *SwiftDeclConverter::importSwift2TypeAlias(const clang::NamedDecl *decl,
 
   // Handle generic types.
   GenericParamList *genericParams = nullptr;
-  GenericSignature *genericSig = nullptr;
   GenericEnvironment *genericEnv = nullptr;
   auto underlyingType = typeDecl->getDeclaredInterfaceType();
 
   if (auto generic = dyn_cast<GenericTypeDecl>(typeDecl)) {
     if (generic->getGenericSignature() && !isa<ProtocolDecl>(typeDecl)) {
       genericParams = generic->getGenericParams();
-      genericSig = generic->getGenericSignature();
       genericEnv = generic->getGenericEnvironment();
 
       underlyingType =
@@ -4372,7 +4364,6 @@ Decl *SwiftDeclConverter::importSwift2TypeAlias(const clang::NamedDecl *decl,
       Impl.importSourceLoc(decl->getLocation()),
       TypeLoc::withoutLoc(underlyingType), genericParams, dc);
   alias->computeType();
-  alias->setGenericSignature(genericSig);
   alias->setGenericEnvironment(genericEnv);
 
   // Record that this is the Swift 2 version of this declaration.
@@ -4802,7 +4793,6 @@ Decl *SwiftDeclConverter::importGlobalAsMethod(const clang::FunctionDecl *decl,
       getGenericMethodType(dc, fnType->castTo<AnyFunctionType>());
   result->setType(fnType);
   result->setInterfaceType(interfaceType);
-  result->setGenericSignature(dc->getGenericSignatureOfContext());
   result->setGenericEnvironment(dc->getGenericEnvironmentOfContext());
 
   result->setBodyResultType(swiftResultTy);
@@ -5382,7 +5372,6 @@ ConstructorDecl *SwiftDeclConverter::importConstructor(
 
   result->setInitializerInterfaceType(interfaceInitType);
   result->setInterfaceType(interfaceAllocType);
-  result->setGenericSignature(dc->getGenericSignatureOfContext());
   result->setGenericEnvironment(dc->getGenericEnvironmentOfContext());
 
   result->setType(allocType);
@@ -6979,7 +6968,6 @@ ClangImporter::Implementation::importDeclContextOf(
     GenericEnvironment *env;
     std::tie(sig, env) = buildGenericSignature(ext->getGenericParams(), ext);
 
-    ext->setGenericSignature(sig);
     ext->setGenericEnvironment(env);
   }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -6883,7 +6883,7 @@ buildGenericSignature(GenericParamList *genericParams,
   }
 
   auto *sig = builder.getGenericSignature();
-  auto *env = builder.getGenericEnvironment();
+  auto *env = builder.getGenericEnvironment(sig);
 
   return std::make_pair(sig, env);
 }

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -721,9 +721,9 @@ public:
   Decl *importMirroredDecl(const clang::NamedDecl *decl, DeclContext *dc,
                            bool useSwift2Name, ProtocolDecl *proto);
 
-  /// \brief Utility function for building simple generic signatures.
-  std::pair<GenericSignature *, GenericEnvironment *>
-  buildGenericSignature(GenericParamList *genericParams, DeclContext *dc);
+  /// \brief Utility function for building simple generic environments.
+  GenericEnvironment *buildGenericEnvironment(GenericParamList *genericParams,
+                                              DeclContext *dc);
 
   /// \brief Import the given Clang declaration context into Swift.
   ///

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -282,7 +282,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
                                                  fnTR->getThrowsLoc(),
                                                  fnTR->getArrowLoc(),
                                                  fnTR->getResultTypeRepr());
-              newTR->setGenericSignature(fnTR->getGenericSignature());
+              newTR->setGenericEnvironment(fnTR->getGenericEnvironment());
               param.Type = newTR;
               param.SpecifierKind = ParsedParameter::Let;
               param.LetVarInOutLoc = SourceLoc();

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -888,7 +888,6 @@ bool SILParser::parseSILType(SILType &Result,
     if (auto generics = fnType->getGenericParams()) {
       std::tie(GenericSig, GenericEnv) =
           handleSILGenericParams(P.Context, generics, &P.SF);
-      fnType->setGenericSignature(GenericSig);
       fnType->setGenericEnvironment(GenericEnv);
     }
   }
@@ -2963,7 +2962,6 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
         GenericSignature *genericSig;
         std::tie(genericSig, genericEnv) =
             handleSILGenericParams(P.Context, generics, &P.SF);
-        fnType->setGenericSignature(genericSig);
         fnType->setGenericEnvironment(genericEnv);
       }
     }

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -1334,7 +1334,7 @@ bool getApplySubstitutionsFromParsed(
                              ArrayRef<ParsedSubstitution> parses,
                              SmallVectorImpl<Substitution> &subs) {
   if (parses.empty()) {
-    assert (!env);
+    assert(!env);
     return false;
   }
 
@@ -1814,8 +1814,7 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
         P.diagnose(P.Tok, diag::sil_substitutions_on_non_polymorphic_type);
         return true;
       }
-      if (getApplySubstitutionsFromParsed(*this, genericEnv,
-                                          parsedSubs, subs))
+      if (getApplySubstitutionsFromParsed(*this, genericEnv, parsedSubs, subs))
         return true;
     }
     
@@ -3787,8 +3786,7 @@ bool SILParser::parseCallInstruction(SILLocation InstLoc,
       P.diagnose(TypeLoc, diag::sil_substitutions_on_non_polymorphic_type);
       return true;
     }
-    if (getApplySubstitutionsFromParsed(*this, GenericEnv,
-                                        parsedSubs, subs))
+    if (getApplySubstitutionsFromParsed(*this, GenericEnv, parsedSubs, subs))
       return true;
   }
 
@@ -4041,9 +4039,7 @@ bool Parser::parseDeclSIL() {
     // the scope.
     Scope Body(this, ScopeKind::FunctionBody);
     GenericEnvironment *GenericEnv;
-    if (FunctionState.parseSILType(FnType,
-                                   GenericEnv,
-                                   true/*IsFuncDecl*/))
+    if (FunctionState.parseSILType(FnType, GenericEnv, true /*IsFuncDecl*/))
       return true;
     auto SILFnType = FnType.getAs<SILFunctionType>();
     if (!SILFnType || !FnType.isObject()) {
@@ -4450,17 +4446,16 @@ ProtocolConformance *SILParser::parseProtocolConformanceHelper(
       return nullptr;
     ProtocolDecl *dummy;
     GenericEnvironment *specializedEnv;
-    auto genericConform = parseProtocolConformance(
-        dummy, specializedEnv,
-        localScope);
+    auto genericConform =
+        parseProtocolConformance(dummy, specializedEnv, localScope);
     if (!genericConform)
       return nullptr;
     if (P.parseToken(tok::r_paren, diag::expected_sil_witness_rparen))
       return nullptr;
 
     SmallVector<Substitution, 4> subs;
-    if (getApplySubstitutionsFromParsed(*this, specializedEnv,
-                                        parsedSubs, subs))
+    if (getApplySubstitutionsFromParsed(*this, specializedEnv, parsedSubs,
+                                        subs))
       return nullptr;
 
     auto result = P.Context.getSpecializedConformance(

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -217,23 +217,20 @@ namespace {
     /// @{ Type parsing.
     bool parseASTType(CanType &result);
     bool parseSILType(SILType &Result,
-                      GenericSignature *&genericSig,
                       GenericEnvironment *&genericEnv,
                       bool IsFuncDecl = false);
     bool parseSILType(SILType &Result) {
-      GenericSignature *IgnoredSig;
       GenericEnvironment *IgnoredEnv;
-      return parseSILType(Result, IgnoredSig, IgnoredEnv);
+      return parseSILType(Result, IgnoredEnv);
     }
     bool parseSILType(SILType &Result, SourceLoc &TypeLoc) {
       TypeLoc = P.Tok.getLoc();
       return parseSILType(Result);
     }
     bool parseSILType(SILType &Result, SourceLoc &TypeLoc,
-                      GenericSignature *&GenericSig,
                       GenericEnvironment *&GenericEnv) {
       TypeLoc = P.Tok.getLoc();
-      return parseSILType(Result, GenericSig, GenericEnv);
+      return parseSILType(Result, GenericEnv);
     }
     /// @}
 
@@ -294,14 +291,12 @@ namespace {
                             GenericEnvironment *GenericEnv=nullptr);
 
     ProtocolConformance *parseProtocolConformance(ProtocolDecl *&proto,
-                             GenericSignature *&genericSig,
                              GenericEnvironment *&genericEnv,
                              bool localScope);
     ProtocolConformance *parseProtocolConformance() {
       ProtocolDecl *dummy;
-      GenericSignature *sig;
       GenericEnvironment *env;
-      return parseProtocolConformance(dummy, sig, env, true);
+      return parseProtocolConformance(dummy, env, true);
     }
 
     Optional<llvm::coverage::Counter>
@@ -842,10 +837,8 @@ bool SILParser::parseASTType(CanType &result) {
 ///     '$' '*'? attribute-list (generic-params)? type
 ///
 bool SILParser::parseSILType(SILType &Result,
-                             GenericSignature *&GenericSig,
                              GenericEnvironment *&GenericEnv,
                              bool IsFuncDecl){
-  GenericSig = nullptr;
   GenericEnv = nullptr;
 
   if (P.parseToken(tok::sil_dollar, diag::expected_sil_type))
@@ -886,8 +879,7 @@ bool SILParser::parseSILType(SILType &Result,
 
   if (auto fnType = dyn_cast<FunctionTypeRepr>(TyR.get())) {
     if (auto generics = fnType->getGenericParams()) {
-      std::tie(GenericSig, GenericEnv) =
-          handleSILGenericParams(P.Context, generics, &P.SF);
+      GenericEnv = handleSILGenericParams(P.Context, generics, &P.SF);
       fnType->setGenericEnvironment(GenericEnv);
     }
   }
@@ -1338,22 +1330,21 @@ static bool getConformancesForSubstitution(Parser &P,
 /// from a SILFunctionType.
 bool getApplySubstitutionsFromParsed(
                              SILParser &SP,
-                             GenericSignature *sig,
                              GenericEnvironment *env,
                              ArrayRef<ParsedSubstitution> parses,
                              SmallVectorImpl<Substitution> &subs) {
   if (parses.empty()) {
-    assert (!sig && !env);
+    assert (!env);
     return false;
   }
 
-  assert(sig && env);
+  assert(env);
 
   auto loc = parses[0].loc;
 
   // Collect conformance requirements in a convenient form.
   llvm::DenseMap<TypeBase *, SmallVector<ProtocolDecl *, 2>> conformsTo;
-  for (auto reqt : sig->getRequirements()) {
+  for (auto reqt : env->getGenericSignature()->getRequirements()) {
     if (reqt.getKind() == RequirementKind::Conformance) {
       auto canTy = reqt.getFirstType()->getCanonicalType();
       auto nominal = reqt.getSecondType()->getAnyNominal();
@@ -1362,7 +1353,7 @@ bool getApplySubstitutionsFromParsed(
   }
 
   // The replacement is for the corresponding dependent type by ordering.
-  for (auto depTy : sig->getAllDependentTypes()) {
+  for (auto depTy : env->getGenericSignature()->getAllDependentTypes()) {
 
     auto canTy = depTy->getCanonicalType().getPointer();
 
@@ -1811,7 +1802,6 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
     assert(foundBuiltins.size() == 1 && "ambiguous builtin name?!");
 
     auto *builtinFunc = cast<FuncDecl>(foundBuiltins[0]);
-    GenericSignature *genericSig = builtinFunc->getGenericSignature();
     GenericEnvironment *genericEnv = builtinFunc->getGenericEnvironment();
     
     SmallVector<ParsedSubstitution, 4> parsedSubs;
@@ -1820,11 +1810,11 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
       return true;
     
     if (!parsedSubs.empty()) {
-      if (!genericSig) {
+      if (!genericEnv) {
         P.diagnose(P.Tok, diag::sil_substitutions_on_non_polymorphic_type);
         return true;
       }
-      if (getApplySubstitutionsFromParsed(*this, genericSig, genericEnv,
+      if (getApplySubstitutionsFromParsed(*this, genericEnv,
                                           parsedSubs, subs))
         return true;
     }
@@ -2332,7 +2322,6 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
                         SetterFuncName, SelfName;
     SmallVector<ParsedSubstitution, 4> ParsedInitStorageSubs,
                                        ParsedSetterSubs;
-    GenericSignature *InitStorageSig, *SetterSig;
     GenericEnvironment *InitStorageEnv, *SetterEnv;
     SILType InitStorageTy, SetterTy;
     
@@ -2344,7 +2333,7 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
         || parseValueName(StorageName)
         || P.parseToken(tok::r_paren, diag::expected_tok_in_sil_instr, ")")
         || P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":")
-        || parseSILType(InitStorageTy, InitStorageSig, InitStorageEnv)
+        || parseSILType(InitStorageTy, InitStorageEnv)
         || P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",")
         || parseValueName(SetterFuncName)
         || parseSubstitutions(ParsedSetterSubs)
@@ -2352,7 +2341,7 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
         || parseValueName(SelfName)
         || P.parseToken(tok::r_paren, diag::expected_tok_in_sil_instr, ")")
         || P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":")
-        || parseSILType(SetterTy, SetterSig, SetterEnv)
+        || parseSILType(SetterTy, SetterEnv)
         || parseSILDebugLocation(InstLoc, B))
       return true;
     
@@ -2362,9 +2351,9 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
     SILValue SetterFunc = getLocalValue(SetterFuncName, SetterTy, InstLoc, B);
     
     SmallVector<Substitution, 4> InitStorageSubs, SetterSubs;
-    if (getApplySubstitutionsFromParsed(*this, InitStorageSig, InitStorageEnv,
+    if (getApplySubstitutionsFromParsed(*this, InitStorageEnv,
                                         ParsedInitStorageSubs, InitStorageSubs)
-        || getApplySubstitutionsFromParsed(*this, SetterSig, SetterEnv,
+        || getApplySubstitutionsFromParsed(*this, SetterEnv,
                                            ParsedSetterSubs, SetterSubs))
       return true;
     
@@ -2959,9 +2948,7 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
       if (auto generics = fnType->getGenericParams()) {
         assert(!Ty.wasValidated() && Ty.getType().isNull());
 
-        GenericSignature *genericSig;
-        std::tie(genericSig, genericEnv) =
-            handleSILGenericParams(P.Context, generics, &P.SF);
+        genericEnv = handleSILGenericParams(P.Context, generics, &P.SF);
         fnType->setGenericEnvironment(genericEnv);
       }
     }
@@ -3688,7 +3675,6 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
     
     UnresolvedValueName invokeName;
     SILType invokeTy;
-    GenericSignature *invokeGenericSig;
     GenericEnvironment *invokeGenericEnv;
     
     SILType blockType;
@@ -3702,7 +3688,7 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
         parseValueName(invokeName) ||
         parseSubstitutions(parsedSubs) ||
         P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":") ||
-        parseSILType(invokeTy, invokeGenericSig, invokeGenericEnv) ||
+        parseSILType(invokeTy, invokeGenericEnv) ||
         P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
         parseSILIdentifier(type, typeLoc,
                            diag::expected_tok_in_sil_instr, "type") ||
@@ -3723,12 +3709,11 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
     
     SmallVector<Substitution, 4> subs;
     if (!parsedSubs.empty()) {
-      if (!invokeGenericSig) {
+      if (!invokeGenericEnv) {
         P.diagnose(typeLoc, diag::sil_substitutions_on_non_polymorphic_type);
         return true;
       }
       if (getApplySubstitutionsFromParsed(*this,
-                                          invokeGenericSig,
                                           invokeGenericEnv,
                                           parsedSubs, subs))
         return true;
@@ -3784,11 +3769,10 @@ bool SILParser::parseCallInstruction(SILLocation InstLoc,
 
   SILType Ty;
   SourceLoc TypeLoc;
-  GenericSignature *GenericSig = nullptr;
   GenericEnvironment *GenericEnv = nullptr;
   if (P.parseToken(tok::r_paren, diag::expected_tok_in_sil_instr, ")") ||
       P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":") ||
-      parseSILType(Ty, TypeLoc, GenericSig, GenericEnv))
+      parseSILType(Ty, TypeLoc, GenericEnv))
     return true;
 
   auto FTI = Ty.getAs<SILFunctionType>();
@@ -3799,11 +3783,11 @@ bool SILParser::parseCallInstruction(SILLocation InstLoc,
 
   SmallVector<Substitution, 4> subs;
   if (!parsedSubs.empty()) {
-    if (!GenericSig) {
+    if (!GenericEnv) {
       P.diagnose(TypeLoc, diag::sil_substitutions_on_non_polymorphic_type);
       return true;
     }
-    if (getApplySubstitutionsFromParsed(*this, GenericSig, GenericEnv,
+    if (getApplySubstitutionsFromParsed(*this, GenericEnv,
                                         parsedSubs, subs))
       return true;
   }
@@ -4056,10 +4040,9 @@ bool Parser::parseDeclSIL() {
     // Construct a Scope for the function body so TypeAliasDecl can be added to
     // the scope.
     Scope Body(this, ScopeKind::FunctionBody);
-    GenericSignature *GenericSig;
     GenericEnvironment *GenericEnv;
     if (FunctionState.parseSILType(FnType,
-                                   GenericSig, GenericEnv,
+                                   GenericEnv,
                                    true/*IsFuncDecl*/))
       return true;
     auto SILFnType = FnType.getAs<SILFunctionType>();
@@ -4095,8 +4078,7 @@ bool Parser::parseDeclSIL() {
       // Resolve specialization attributes after setting GenericEnv.
       for (auto &Attr : SpecAttrs) {
         SmallVector<Substitution, 4> Subs;
-        if (getApplySubstitutionsFromParsed(FunctionState,
-                                            GenericSig, GenericEnv,
+        if (getApplySubstitutionsFromParsed(FunctionState, GenericEnv,
                                             Attr.subs, Subs)) {
           return true;
         }
@@ -4415,7 +4397,6 @@ static NormalProtocolConformance *parseNormalProtocolConformance(Parser &P,
 /// Note that generic-parameter-list is already parsed before calling this.
 ProtocolConformance *SILParser::parseProtocolConformance(
            ProtocolDecl *&proto,
-           GenericSignature *&genericSig,
            GenericEnvironment *&genericEnv,
            bool localScope) {
   // Parse generic params for the protocol conformance. We need to make sure
@@ -4425,13 +4406,11 @@ ProtocolConformance *SILParser::parseProtocolConformance(
     GenericsScope.emplace(&P, ScopeKind::Generics);
 
   // Make sure we don't leave it uninitialized in the caller
-  genericSig = nullptr;
   genericEnv = nullptr;
 
   auto *genericParams = P.maybeParseGenericParams().getPtrOrNull();
   if (genericParams) {
-    std::tie(genericSig, genericEnv) =
-        handleSILGenericParams(P.Context, genericParams, &P.SF);
+    genericEnv = handleSILGenericParams(P.Context, genericParams, &P.SF);
   }
 
   ProtocolConformance *retVal =
@@ -4470,10 +4449,9 @@ ProtocolConformance *SILParser::parseProtocolConformanceHelper(
     if (P.parseToken(tok::l_paren, diag::expected_sil_witness_lparen))
       return nullptr;
     ProtocolDecl *dummy;
-    GenericSignature *specializedSig;
     GenericEnvironment *specializedEnv;
     auto genericConform = parseProtocolConformance(
-        dummy, specializedSig, specializedEnv,
+        dummy, specializedEnv,
         localScope);
     if (!genericConform)
       return nullptr;
@@ -4481,7 +4459,7 @@ ProtocolConformance *SILParser::parseProtocolConformanceHelper(
       return nullptr;
 
     SmallVector<Substitution, 4> subs;
-    if (getApplySubstitutionsFromParsed(*this, specializedSig, specializedEnv,
+    if (getApplySubstitutionsFromParsed(*this, specializedEnv,
                                         parsedSubs, subs))
       return nullptr;
 
@@ -4542,10 +4520,8 @@ bool Parser::parseSILWitnessTable() {
 
   // Parse the protocol conformance.
   ProtocolDecl *proto;
-  GenericSignature *witnessSig;
   GenericEnvironment *witnessEnv;
   auto conf = WitnessState.parseProtocolConformance(proto,
-                                                    witnessSig,
                                                     witnessEnv,
                                                     false/*localScope*/);
   WitnessState.GenericEnv = witnessEnv;
@@ -4981,13 +4957,12 @@ bool Parser::parseSILScope() {
     SourceLoc FnLoc = Tok.getLoc();
     // We need to turn on InSILBody to parse the function reference.
     Lexer::SILBodyRAII Tmp(*L);
-    GenericSignature *IgnoredSig;
     GenericEnvironment *IgnoredEnv;
     Scope S(this, ScopeKind::TopLevel);
     Scope Body(this, ScopeKind::FunctionBody);
     if ((ScopeState.parseGlobalName(FnName)) ||
         parseToken(tok::colon, diag::expected_sil_colon_value_ref) ||
-        ScopeState.parseSILType(Ty, IgnoredSig, IgnoredEnv, true))
+        ScopeState.parseSILType(Ty, IgnoredEnv, true))
       return true;
 
     // The function doesn't exist yet. Create a zombie forward declaration.

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -547,9 +547,8 @@ ArrayRef<Substitution> SILFunction::getForwardingSubstitutions() {
   if (!env)
     return {};
 
-  auto sig = getLoweredFunctionType()->getGenericSignature();
   auto *M = getModule().getSwiftModule();
-  ForwardingSubs = env->getForwardingSubstitutions(M, sig);
+  ForwardingSubs = env->getForwardingSubstitutions(M);
 
   return *ForwardingSubs;
 }

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1964,8 +1964,7 @@ public:
 
     // Map interface types to archetypes.
     if (auto *env = constantInfo.GenericEnv) {
-      auto sig = constantInfo.SILFnType->getGenericSignature();
-      auto subs = env->getForwardingSubstitutions(M, sig);
+      auto subs = env->getForwardingSubstitutions(M);
       methodTy = methodTy->substGenericArgs(F.getModule(), M, subs);
     }
     assert(!methodTy->isPolymorphic());

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -78,11 +78,9 @@ emitBridgeNativeToObjectiveC(SILGenFunction &gen,
     // FIXME: Substitute the type substitutions into the witness, because
     // SpecializedProtocolConformance::getWitness() doesn't do it for us.
     GenericEnvironment *witnessEnv = witness.getSyntheticEnvironment();
-    GenericSignature *witnessSig = witness.getSyntheticSignature();
-    
+
     SubstitutionMap typeSubMap = witnessEnv
       ->getSubstitutionMap(gen.SGM.SwiftModule,
-                           witnessSig,
                            typeSubstitutions);
     for (auto sub : witnessSubstitutions) {
       substitutionsBuf.push_back(sub.subst(gen.SGM.SwiftModule, typeSubMap));

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -490,9 +490,8 @@ void SILGenFunction::emitClassConstructorAllocator(ConstructorDecl *ctor) {
   // Call the initializer.
   ArrayRef<Substitution> forwardingSubs;
   if (auto *genericEnv = ctor->getGenericEnvironmentOfContext()) {
-    auto *genericSig = ctor->getGenericSignatureOfContext();
     forwardingSubs = genericEnv->getForwardingSubstitutions(
-        SGM.SwiftModule, genericSig);
+        SGM.SwiftModule);
   }
   std::tie(initVal, initTy, subs)
     = emitSiblingMethodRef(Loc, selfValue, initConstant, forwardingSubs);
@@ -882,9 +881,8 @@ void SILGenFunction::emitMemberInitializers(DeclContext *dc,
         ArrayRef<Substitution> subs;
         auto *genericEnv = dc->getGenericEnvironmentOfContext();
         if (genericEnv) {
-          auto *genericSig = dc->getGenericSignatureOfContext();
           subs = genericEnv->getForwardingSubstitutions(
-              SGM.SwiftModule, genericSig);
+              SGM.SwiftModule);
         }
 
         // Get the type of the initialization result, in terms

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -490,8 +490,7 @@ void SILGenFunction::emitClassConstructorAllocator(ConstructorDecl *ctor) {
   // Call the initializer.
   ArrayRef<Substitution> forwardingSubs;
   if (auto *genericEnv = ctor->getGenericEnvironmentOfContext()) {
-    forwardingSubs = genericEnv->getForwardingSubstitutions(
-        SGM.SwiftModule);
+    forwardingSubs = genericEnv->getForwardingSubstitutions(SGM.SwiftModule);
   }
   std::tie(initVal, initTy, subs)
     = emitSiblingMethodRef(Loc, selfValue, initConstant, forwardingSubs);
@@ -881,8 +880,7 @@ void SILGenFunction::emitMemberInitializers(DeclContext *dc,
         ArrayRef<Substitution> subs;
         auto *genericEnv = dc->getGenericEnvironmentOfContext();
         if (genericEnv) {
-          subs = genericEnv->getForwardingSubstitutions(
-              SGM.SwiftModule);
+          subs = genericEnv->getForwardingSubstitutions(SGM.SwiftModule);
         }
 
         // Get the type of the initialization result, in terms

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -815,8 +815,7 @@ void SILGenFunction::emitCurryThunk(ValueDecl *vd,
   ArrayRef<Substitution> subs;
   auto constantInfo = getConstantInfo(to);
   if (auto *env = constantInfo.GenericEnv) {
-    auto sig = constantInfo.SILFnType->getGenericSignature();
-    subs = env->getForwardingSubstitutions(SGM.SwiftModule, sig);
+    subs = env->getForwardingSubstitutions(SGM.SwiftModule);
   }
 
   SILValue toFn = getNextUncurryLevelRef(*this, vd, to, from.isDirectReference,

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1582,8 +1582,7 @@ SILGenModule::getNonMemberVarDeclSubstitutions(VarDecl *var) {
   ArrayRef<Substitution> substitutions;
   auto *dc = var->getDeclContext();
   if (auto *genericEnv = dc->getGenericEnvironmentOfContext()) {
-    substitutions = genericEnv->getForwardingSubstitutions(
-        SwiftModule);
+    substitutions = genericEnv->getForwardingSubstitutions(SwiftModule);
   }
   return substitutions;
 }

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1582,9 +1582,8 @@ SILGenModule::getNonMemberVarDeclSubstitutions(VarDecl *var) {
   ArrayRef<Substitution> substitutions;
   auto *dc = var->getDeclContext();
   if (auto *genericEnv = dc->getGenericEnvironmentOfContext()) {
-    auto *genericSig = dc->getGenericSignatureOfContext();
     substitutions = genericEnv->getForwardingSubstitutions(
-        SwiftModule, genericSig);
+        SwiftModule);
   }
   return substitutions;
 }

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1390,7 +1390,6 @@ void TypeChecker::completePropertyBehaviorParameter(VarDecl *VD,
                      TypeLoc::withoutLoc(SubstBodyResultTy), DC);
 
   Parameter->setInterfaceType(SubstInterfaceTy);
-  Parameter->setGenericSignature(genericSig);
   Parameter->setGenericEnvironment(genericEnv);
 
   // Mark the method to be final, implicit, and private.  In a class, this
@@ -2121,9 +2120,8 @@ swift::createDesignatedInitOverride(TypeChecker &tc,
   auto selfType = configureImplicitSelf(tc, ctor);
 
   // Set the interface type of the initializer.
-  ctor->setGenericSignature(classDecl->getGenericSignatureOfContext());
   ctor->setGenericEnvironment(classDecl->getGenericEnvironmentOfContext());
-  tc.configureInterfaceType(ctor);
+  tc.configureInterfaceType(ctor, ctor->getGenericSignature());
 
   // Set the contextual type of the initializer. This will go away one day.
   configureConstructorType(ctor, selfType, bodyParams->getType(ctx));

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -271,7 +271,6 @@ deriveEquatable_enum_eq(TypeChecker &tc, Decl *parentDecl, EnumDecl *enumDecl) {
   Type interfaceTy;
   Type selfIfaceTy = eqDecl->computeInterfaceSelfType(false);
   if (auto genericSig = parentDC->getGenericSignatureOfContext()) {
-    eqDecl->setGenericSignature(genericSig);
     eqDecl->setGenericEnvironment(parentDC->getGenericEnvironmentOfContext());
 
     Type enumIfaceTy = parentDC->getDeclaredInterfaceType();
@@ -425,7 +424,6 @@ deriveHashable_enum_hashValue(TypeChecker &tc, Decl *parentDecl,
   Type interfaceType;
   Type selfIfaceType = getterDecl->computeInterfaceSelfType(false);
   if (auto sig = parentDC->getGenericSignatureOfContext()) {
-    getterDecl->setGenericSignature(sig);
     getterDecl->setGenericEnvironment(parentDC->getGenericEnvironmentOfContext());
     interfaceType = GenericFunctionType::get(sig, selfIfaceType, methodType,
                                              AnyFunctionType::ExtInfo());

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -319,7 +319,6 @@ static ConstructorDecl *deriveRawRepresentable_init(TypeChecker &tc,
   Type allocIfaceType;
   Type initIfaceType;
   if (auto sig = parentDC->getGenericSignatureOfContext()) {
-    initDecl->setGenericSignature(sig);
     initDecl->setGenericEnvironment(parentDC->getGenericEnvironmentOfContext());
 
     allocIfaceType = GenericFunctionType::get(sig, selfInterfaceType,

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -147,7 +147,6 @@ FuncDecl *DerivedConformance::declareDerivedPropertyGetter(TypeChecker &tc,
                                          propertyInterfaceType);
   Type selfInterfaceType = getterDecl->computeInterfaceSelfType(false);
   if (auto sig = parentDC->getGenericSignatureOfContext()) {
-    getterDecl->setGenericSignature(sig);
     getterDecl->setGenericEnvironment(
         parentDC->getGenericEnvironmentOfContext());
     interfaceType = GenericFunctionType::get(sig, selfInterfaceType,

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7461,10 +7461,9 @@ void TypeChecker::validateAccessibility(ValueDecl *D) {
 
 /// Check the generic parameters of an extension, recursively handling all of
 /// the parameter lists within the extension.
-static
-std::tuple<GenericEnvironment *, Type>
-checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext,
-                            Type type, GenericParamList *genericParams) {
+static std::tuple<GenericEnvironment *, Type>
+checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext, Type type,
+                            GenericParamList *genericParams) {
   // Find the nominal type declaration and its parent type.
   Type parentType;
   NominalTypeDecl *nominal;
@@ -7484,16 +7483,14 @@ checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext,
   GenericEnvironment *parentEnv = nullptr;
   Type newParentType = parentType;
   if (parentType) {
-    std::tie(parentEnv, newParentType) =
-        checkExtensionGenericParams(
-                      tc, ext, parentType,
-                      nominal->getGenericParams()
-                        ? genericParams->getOuterParameters()
-                        : genericParams);
-
+    std::tie(parentEnv, newParentType) = checkExtensionGenericParams(
+        tc, ext, parentType, nominal->getGenericParams()
+                                 ? genericParams->getOuterParameters()
+                                 : genericParams);
   }
   // Avoid having to remember null checks on parentEnv below.
-  GenericSignature *parentSig = parentEnv ? parentEnv->getGenericSignature() : nullptr;
+  GenericSignature *parentSig =
+      parentEnv ? parentEnv->getGenericSignature() : nullptr;
 
   // If we don't have generic parameters at this level, just build the result.
   if (!nominal->getGenericParams()) {
@@ -7621,10 +7618,8 @@ void TypeChecker::validateExtension(ExtensionDecl *ext) {
 
     // Check generic parameters.
     GenericEnvironment *env;
-    std::tie(env, extendedType) =
-        checkExtensionGenericParams(*this, ext,
-                                    ext->getExtendedType(),
-                                    ext->getGenericParams());
+    std::tie(env, extendedType) = checkExtensionGenericParams(
+        *this, ext, ext->getExtendedType(), ext->getGenericParams());
 
     ext->getExtendedTypeLoc().setType(extendedType);
     ext->setGenericEnvironment(env);
@@ -7654,8 +7649,7 @@ void TypeChecker::validateExtension(ExtensionDecl *ext) {
 
     GenericEnvironment *env;
     std::tie(env, extendedType) =
-        checkExtensionGenericParams(*this, ext, proto,
-                                    ext->getGenericParams());
+        checkExtensionGenericParams(*this, ext, proto, ext->getGenericParams());
 
     ext->getExtendedTypeLoc().setType(extendedType);
     ext->setGenericEnvironment(env);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -741,7 +741,7 @@ TypeChecker::handleSILGenericParams(GenericParamList *genericParams,
     checkGenericParamList(&builder, genericParams, parentSig, parentEnv,
                           nullptr);
     parentSig = genericSig;
-    parentEnv = builder.getGenericEnvironment();
+    parentEnv = builder.getGenericEnvironment(parentSig);
     finalizeGenericParamList(genericParams, parentSig, parentEnv, DC);
   }
 
@@ -4868,7 +4868,7 @@ public:
 
       // Assign archetypes.
       auto *sig = FD->getGenericSignature();
-      auto *env = builder.getGenericEnvironment();
+      auto *env = builder.getGenericEnvironment(sig);
       FD->setGenericEnvironment(env);
 
       TC.finalizeGenericParamList(gp, sig, env, FD);
@@ -6531,7 +6531,7 @@ public:
 
       // Assign archetypes.
       auto *sig = CD->getGenericSignature();
-      auto *env = builder.getGenericEnvironment();
+      auto *env = builder.getGenericEnvironment(sig);
       CD->setGenericEnvironment(env);
 
       TC.finalizeGenericParamList(gp, sig, env, CD);
@@ -7547,7 +7547,7 @@ checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext,
   tc.checkGenericParamList(&builder, genericParams, parentSig, parentEnv, nullptr);
   inferExtendedTypeReqs(builder);
 
-  auto *env = builder.getGenericEnvironment();
+  auto *env = builder.getGenericEnvironment(sig);
 
   tc.finalizeGenericParamList(genericParams, sig, env, ext);
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -710,7 +710,7 @@ ArchetypeBuilder TypeChecker::createArchetypeBuilder(Module *mod) {
 }
 
 /// Expose TypeChecker's handling of GenericParamList to SIL parsing.
-std::pair<GenericSignature *, GenericEnvironment *>
+GenericEnvironment *
 TypeChecker::handleSILGenericParams(GenericParamList *genericParams,
                                     DeclContext *DC) {
 
@@ -745,7 +745,7 @@ TypeChecker::handleSILGenericParams(GenericParamList *genericParams,
     finalizeGenericParamList(genericParams, parentSig, parentEnv, DC);
   }
 
-  return std::make_pair(parentSig, parentEnv);
+  return parentEnv;
 }
 
 /// Check whether the given type representation will be

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4843,7 +4843,7 @@ public:
     if (auto gp = FD->getGenericParams()) {
       gp->setOuterParameters(FD->getDeclContext()->getGenericParamsOfContext());
 
-      TC.validateGenericFuncSignature(FD);
+      auto *sig = TC.validateGenericFuncSignature(FD);
 
       // Create a fresh archetype builder.
       ArchetypeBuilder builder =
@@ -4867,13 +4867,12 @@ public:
       TC.revertGenericFuncSignature(FD);
 
       // Assign archetypes.
-      auto *sig = FD->getGenericSignature();
       auto *env = builder.getGenericEnvironment(sig);
       FD->setGenericEnvironment(env);
 
       TC.finalizeGenericParamList(gp, sig, env, FD);
     } else if (FD->getDeclContext()->getGenericSignatureOfContext()) {
-      TC.validateGenericFuncSignature(FD);
+      (void)TC.validateGenericFuncSignature(FD);
       if (!FD->hasType()) {
         // Revert all of the types within the signature of the function.
         TC.revertGenericFuncSignature(FD);
@@ -4892,7 +4891,7 @@ public:
       return;
 
     if (!FD->getGenericSignatureOfContext())
-      TC.configureInterfaceType(FD);
+      TC.configureInterfaceType(FD, FD->getGenericSignature());
 
     if (FD->isInvalid())
       return;
@@ -6515,7 +6514,7 @@ public:
       // Write up generic parameters and check the generic parameter list.
       gp->setOuterParameters(CD->getDeclContext()->getGenericParamsOfContext());
 
-      TC.validateGenericFuncSignature(CD);
+      auto *sig = TC.validateGenericFuncSignature(CD);
 
       auto builder = TC.createArchetypeBuilder(CD->getModuleContext());
       auto *parentSig = CD->getDeclContext()->getGenericSignatureOfContext();
@@ -6530,13 +6529,12 @@ public:
       TC.revertGenericFuncSignature(CD);
 
       // Assign archetypes.
-      auto *sig = CD->getGenericSignature();
       auto *env = builder.getGenericEnvironment(sig);
       CD->setGenericEnvironment(env);
 
       TC.finalizeGenericParamList(gp, sig, env, CD);
     } else if (CD->getDeclContext()->getGenericSignatureOfContext()) {
-      TC.validateGenericFuncSignature(CD);
+      (void)TC.validateGenericFuncSignature(CD);
 
       // Revert all of the types within the signature of the constructor.
       TC.revertGenericFuncSignature(CD);
@@ -6560,7 +6558,7 @@ public:
                                  CD->getParameterList(1)->getType(TC.Context));
 
         if (!CD->getGenericSignatureOfContext())
-          TC.configureInterfaceType(CD);
+          TC.configureInterfaceType(CD, CD->getGenericSignature());
       }
     }
 
@@ -6696,7 +6694,7 @@ public:
     Type SelfTy = configureImplicitSelf(TC, DD);
 
     if (DD->getDeclContext()->getGenericSignatureOfContext()) {
-      TC.validateGenericFuncSignature(DD);
+      (void)TC.validateGenericFuncSignature(DD);
       DD->setGenericEnvironment(
           DD->getDeclContext()->getGenericEnvironmentOfContext());
     }
@@ -6709,7 +6707,7 @@ public:
     }
 
     if (!DD->getGenericSignatureOfContext())
-      TC.configureInterfaceType(DD);
+      TC.configureInterfaceType(DD, DD->getGenericSignature());
 
     if (!DD->hasType()) {
       Type FnTy;
@@ -7628,7 +7626,6 @@ void TypeChecker::validateExtension(ExtensionDecl *ext) {
                                     ext->getGenericParams());
 
     ext->getExtendedTypeLoc().setType(extendedType);
-    ext->setGenericSignature(sig);
     ext->setGenericEnvironment(env);
     return;
   }
@@ -7661,7 +7658,6 @@ void TypeChecker::validateExtension(ExtensionDecl *ext) {
                                     ext->getGenericParams());
 
     ext->getExtendedTypeLoc().setType(extendedType);
-    ext->setGenericSignature(sig);
     ext->setGenericEnvironment(env);
 
     // Speculatively ban extension of AnyObject; it won't be a

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -852,7 +852,7 @@ void TypeChecker::validateGenericTypeSignature(GenericTypeDecl *typeDecl) {
   auto *parentEnv = dc->getGenericEnvironmentOfContext();
   checkGenericParamList(&builder, gp, parentSig, parentEnv, nullptr);
 
-  auto *env = builder.getGenericEnvironment();
+  auto *env = builder.getGenericEnvironment(sig);
   typeDecl->setGenericEnvironment(env);
 
   finalizeGenericParamList(gp, sig, env, typeDecl);

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -457,7 +457,8 @@ static Type getResultType(TypeChecker &TC, FuncDecl *fn, Type resultType) {
   return resultType;
 }
 
-GenericSignature *TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl *func) {
+GenericSignature *
+TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl *func) {
   bool invalid = false;
 
   // Create the archetype builder.
@@ -513,7 +514,8 @@ GenericSignature *TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl
   return sig;
 }
 
-void TypeChecker::configureInterfaceType(AbstractFunctionDecl *func, GenericSignature *sig) {
+void TypeChecker::configureInterfaceType(AbstractFunctionDecl *func,
+                                         GenericSignature *sig) {
   Type funcTy;
   Type initFuncTy;
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1130,7 +1130,7 @@ RequirementEnvironment::RequirementEnvironment(
 
   // Produce the generic signature and environment.
   syntheticSignature = builder.getGenericSignature();
-  syntheticEnvironment = builder.getGenericEnvironment();
+  syntheticEnvironment = builder.getGenericEnvironment(syntheticSignature);
 }
 
 static RequirementMatch

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -418,7 +418,6 @@ namespace {
     swift::Witness getWitness(ASTContext &ctx,
                               RequirementEnvironment &&reqEnvironment) const {
       return swift::Witness(this->Witness, WitnessSubstitutions,
-                            reqEnvironment.getSyntheticSignature(),
                             reqEnvironment.getSyntheticEnvironment(),
                             reqEnvironment.takeRequirementToSyntheticMap());
     }

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -734,8 +734,7 @@ bool swift::performTypeLocChecking(ASTContext &Ctx, TypeLoc &T,
 
 /// Expose TypeChecker's handling of GenericParamList to SIL parsing.
 GenericEnvironment *
-swift::handleSILGenericParams(ASTContext &Ctx,
-                              GenericParamList *genericParams,
+swift::handleSILGenericParams(ASTContext &Ctx, GenericParamList *genericParams,
                               DeclContext *DC) {
   return TypeChecker(Ctx).handleSILGenericParams(genericParams, DC);
 }

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -733,7 +733,7 @@ bool swift::performTypeLocChecking(ASTContext &Ctx, TypeLoc &T,
 }
 
 /// Expose TypeChecker's handling of GenericParamList to SIL parsing.
-std::pair<GenericSignature *, GenericEnvironment *>
+GenericEnvironment *
 swift::handleSILGenericParams(ASTContext &Ctx,
                               GenericParamList *genericParams,
                               DeclContext *DC) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1011,12 +1011,13 @@ public:
                                  ExtensionDecl *protocolExtension) override;
 
   /// Configure the interface type of a function declaration.
-  void configureInterfaceType(AbstractFunctionDecl *func);
+  void configureInterfaceType(AbstractFunctionDecl *func,
+                              GenericSignature *sig);
 
   /// Validate the signature of a generic function.
   ///
   /// \param func The generic function.
-  void validateGenericFuncSignature(AbstractFunctionDecl *func);
+  GenericSignature *validateGenericFuncSignature(AbstractFunctionDecl *func);
 
   /// Revert the signature of a generic function to its pre-type-checked state,
   /// so that it can be type checked again when we have resolved its generic

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -743,9 +743,8 @@ public:
   void checkUnsupportedProtocolType(Stmt *stmt);
 
   /// Expose TypeChecker's handling of GenericParamList to SIL parsing.
-  std::pair<GenericSignature *, GenericEnvironment *>
-  handleSILGenericParams(GenericParamList *genericParams,
-                         DeclContext *DC);
+  GenericEnvironment *handleSILGenericParams(GenericParamList *genericParams,
+                                             DeclContext *DC);
 
   /// \brief Resolves a TypeRepr to a type.
   ///

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -851,12 +851,12 @@ void ModuleFile::readGenericRequirements(
 }
 
 GenericEnvironment *ModuleFile::readGenericEnvironment(
-    SmallVectorImpl<GenericTypeParamType *> &paramTypes,
     llvm::BitstreamCursor &Cursor,
     Optional<ArrayRef<Requirement>> optRequirements) {
   using namespace decls_block;
 
   SmallVector<uint64_t, 8> scratch;
+  SmallVector<GenericTypeParamType *, 4> paramTypes;
   StringRef blobData;
 
   TypeSubstitutionMap interfaceToArchetypeMap;
@@ -956,10 +956,8 @@ GenericEnvironment *ModuleFile::readGenericEnvironment(
                                  interfaceToArchetypeMap);
 }
 
-GenericEnvironment *
-ModuleFile::maybeReadGenericEnvironment() {
-  SmallVector<GenericTypeParamType *, 4> paramTypes;
-  return readGenericEnvironment(paramTypes, DeclTypeCursor);
+GenericEnvironment *ModuleFile::maybeReadGenericEnvironment() {
+  return readGenericEnvironment(DeclTypeCursor);
 }
 
 bool ModuleFile::readMembers(SmallVectorImpl<Decl *> &Members) {
@@ -2399,8 +2397,7 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
     if (declOrOffset.isComplete())
       return declOrOffset;
 
-    SmallVector<GenericTypeParamType *, 2> genericParamTypes;
-    auto *genericEnv = readGenericEnvironment(genericParamTypes, DeclTypeCursor);
+    auto *genericEnv = readGenericEnvironment(DeclTypeCursor);
 
     // Resolve the name ids.
     SmallVector<Identifier, 2> argNames;
@@ -2609,8 +2606,7 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
     // DeclContext for now.
     GenericParamList *genericParams = maybeReadGenericParams(DC);
 
-    SmallVector<GenericTypeParamType *, 2> genericParamTypes;
-    auto *genericEnv = readGenericEnvironment(genericParamTypes, DeclTypeCursor);
+    auto *genericEnv = readGenericEnvironment(DeclTypeCursor);
 
     auto staticSpelling = getActualStaticSpellingKind(rawStaticSpelling);
     if (!staticSpelling.hasValue()) {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -956,17 +956,10 @@ GenericEnvironment *ModuleFile::readGenericEnvironment(
                                  interfaceToArchetypeMap);
 }
 
-std::pair<GenericSignature *, GenericEnvironment *>
-ModuleFile::maybeReadGenericSignature() {
+GenericEnvironment *
+ModuleFile::maybeReadGenericEnvironment() {
   SmallVector<GenericTypeParamType *, 4> paramTypes;
-
-  // Read the generic environment.
-  auto env = readGenericEnvironment(paramTypes, DeclTypeCursor);
-
-  if (env == nullptr)
-    return std::make_pair(nullptr, nullptr);
-
-  return std::make_pair(env->getGenericSignature(), env);
+  return readGenericEnvironment(paramTypes, DeclTypeCursor);
 }
 
 bool ModuleFile::readMembers(SmallVectorImpl<Decl *> &Members) {
@@ -2235,12 +2228,8 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
     declOrOffset = alias;
 
     if (genericParams) {
-      GenericSignature *sig;
-      GenericEnvironment *env;
-
-      std::tie(sig, env) = maybeReadGenericSignature();
-
-      assert(sig && "generic typealias without signature");
+      auto *env = maybeReadGenericEnvironment();
+      assert(env && "generic typealias without environment");
       alias->setGenericEnvironment(env);
     }
 
@@ -2368,11 +2357,7 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
     if (isImplicit)
       theStruct->setImplicit();
 
-    GenericSignature *sig;
-    GenericEnvironment *env;
-
-    std::tie(sig, env) = maybeReadGenericSignature();
-
+    auto *env = maybeReadGenericEnvironment();
     theStruct->setGenericEnvironment(env);
 
     theStruct->computeType();
@@ -2814,11 +2799,7 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
     if (auto genericParams = maybeReadGenericParams(DC))
       proto->setGenericParams(genericParams);
 
-    GenericSignature *sig;
-    GenericEnvironment *env;
-
-    std::tie(sig, env) = maybeReadGenericSignature();
-
+    auto *env = maybeReadGenericEnvironment();
     proto->setGenericEnvironment(env);
 
     if (isImplicit)
@@ -2994,11 +2975,7 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
     if (requiresStoredPropertyInits)
       theClass->setRequiresStoredPropertyInits(true);
 
-    GenericSignature *sig;
-    GenericEnvironment *env;
-
-    std::tie(sig, env) = maybeReadGenericSignature();
-
+    auto *env = maybeReadGenericEnvironment();
     theClass->setGenericEnvironment(env);
 
     theClass->computeType();
@@ -3054,11 +3031,7 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
       theEnum->setImplicit();
     theEnum->setRawType(getType(rawTypeID));
 
-    GenericSignature *sig;
-    GenericEnvironment *env;
-
-    std::tie(sig, env) = maybeReadGenericSignature();
-
+    auto *env = maybeReadGenericEnvironment();
     theEnum->setGenericEnvironment(env);
 
     theEnum->computeType();
@@ -3241,11 +3214,7 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
     GenericParamList *genericParams = maybeReadGenericParams(DC);
     extension->setGenericParams(genericParams);
 
-    GenericSignature *sig;
-    GenericEnvironment *env;
-
-    std::tie(sig, env) = maybeReadGenericSignature();
-
+    auto *env = maybeReadGenericEnvironment();
     extension->setGenericEnvironment(env);
 
     extension->setMemberLoader(this, DeclTypeCursor.GetCurrentBitNo());

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2241,7 +2241,6 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
       std::tie(sig, env) = maybeReadGenericSignature();
 
       assert(sig && "generic typealias without signature");
-      alias->setGenericSignature(sig);
       alias->setGenericEnvironment(env);
     }
 
@@ -2374,7 +2373,6 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
 
     std::tie(sig, env) = maybeReadGenericSignature();
 
-    theStruct->setGenericSignature(sig);
     theStruct->setGenericEnvironment(env);
 
     theStruct->computeType();
@@ -2456,8 +2454,6 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
     // its generic parameters.
     ctor->setType(getType(signatureID));
     if (auto interfaceType = getType(interfaceID)) {
-      if (auto genericFnType = interfaceType->getAs<GenericFunctionType>())
-        ctor->setGenericSignature(genericFnType->getGenericSignature());
       ctor->setInterfaceType(interfaceType);
     }
 
@@ -2693,8 +2689,6 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
 
     // Set the interface type.
     if (auto interfaceType = getType(interfaceTypeID)) {
-      if (auto genericFnType = interfaceType->getAs<GenericFunctionType>())
-        fn->setGenericSignature(genericFnType->getGenericSignature());
       fn->setInterfaceType(interfaceType);
     }
 
@@ -2825,7 +2819,6 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
 
     std::tie(sig, env) = maybeReadGenericSignature();
 
-    proto->setGenericSignature(sig);
     proto->setGenericEnvironment(env);
 
     if (isImplicit)
@@ -3006,7 +2999,6 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
 
     std::tie(sig, env) = maybeReadGenericSignature();
 
-    theClass->setGenericSignature(sig);
     theClass->setGenericEnvironment(env);
 
     theClass->computeType();
@@ -3067,7 +3059,6 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
 
     std::tie(sig, env) = maybeReadGenericSignature();
 
-    theEnum->setGenericSignature(sig);
     theEnum->setGenericEnvironment(env);
 
     theEnum->computeType();
@@ -3255,7 +3246,6 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
 
     std::tie(sig, env) = maybeReadGenericSignature();
 
-    extension->setGenericSignature(sig);
     extension->setGenericEnvironment(env);
 
     extension->setMemberLoader(this, DeclTypeCursor.GetCurrentBitNo());
@@ -3299,8 +3289,6 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
     dtor->setType(getType(signatureID));
 
     auto interfaceType = getType(interfaceID);
-    if (auto genericFnType = interfaceType->getAs<GenericFunctionType>())
-      dtor->setGenericSignature(genericFnType->getGenericSignature());
     dtor->setInterfaceType(interfaceType);
 
     dtor->setGenericEnvironment(DC->getGenericEnvironmentOfContext());
@@ -4314,7 +4302,7 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
     // Set the witness.
     conformance->setWitness(req,
                             Witness(witness, witnessSubstitutions,
-                                    syntheticSig, syntheticEnv,
+                                    syntheticEnv,
                                     reqToSyntheticMap));
   }
   assert(rawIDIter <= rawIDs.end() && "read too much");

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4265,10 +4265,8 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
     }
 
     // Set the witness.
-    conformance->setWitness(req,
-                            Witness(witness, witnessSubstitutions,
-                                    syntheticEnv,
-                                    reqToSyntheticMap));
+    conformance->setWitness(req, Witness(witness, witnessSubstitutions,
+                                         syntheticEnv, reqToSyntheticMap));
   }
   assert(rawIDIter <= rawIDs.end() && "read too much");
 

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -493,7 +493,10 @@ SILFunction *SILDeserializer::readSILFunction(DeclID FID,
   GenericEnvironment *genericEnv = nullptr;
   if (!declarationOnly) {
     SmallVector<GenericTypeParamType *, 4> genericParamTypes;
-    genericEnv = MF->readGenericEnvironment(genericParamTypes, SILCursor);
+    auto signature = fn->getLoweredFunctionType()->getGenericSignature();
+    genericEnv = MF->readGenericEnvironment(
+        genericParamTypes, SILCursor,
+        signature ? signature->getRequirements() : ArrayRef<Requirement>());
   }
 
   // If the next entry is the end of the block, then this function has

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -492,10 +492,9 @@ SILFunction *SILDeserializer::readSILFunction(DeclID FID,
 
   GenericEnvironment *genericEnv = nullptr;
   if (!declarationOnly) {
-    SmallVector<GenericTypeParamType *, 4> genericParamTypes;
     auto signature = fn->getLoweredFunctionType()->getGenericSignature();
     genericEnv = MF->readGenericEnvironment(
-        genericParamTypes, SILCursor,
+        SILCursor,
         signature ? signature->getRequirements() : ArrayRef<Requirement>());
   }
 

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -245,7 +245,8 @@ private:
   bool writeGenericParams(const GenericParamList *genericParams);
 
   /// Writes a set of generic requirements.
-  void writeGenericRequirements(ArrayRef<Requirement> requirements);
+  void writeGenericRequirements(ArrayRef<Requirement> requirements,
+                                const std::array<unsigned, 256> &abbrCodes);
 
   /// Writes a list of protocol conformances.
   void writeConformances(ArrayRef<ProtocolConformanceRef> conformances,
@@ -430,8 +431,8 @@ public:
 
   /// Writes a generic environment.
   void writeGenericEnvironment(GenericEnvironment *env,
-                         const std::array<unsigned, 256> &abbrCodes);
-
+                               const std::array<unsigned, 256> &abbrCodes,
+                               bool SILMode);
 };
 } // end namespace serialization
 } // end namespace swift

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -376,7 +376,7 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
   // Write the body's context archetypes, unless we don't actually have a body.
   if (!F.isExternalDeclaration()) {
     if (auto genericEnv = F.getGenericEnvironment())
-      S.writeGenericEnvironment(genericEnv, SILAbbrCodes);
+      S.writeGenericEnvironment(genericEnv, SILAbbrCodes, true);
   }
 
   // Assign a unique ID to each basic block of the SILFunction.


### PR DESCRIPTION
Almost every place that manipulates a GenericEnvironment also has a GenericSignature, so packaging them together makes life easier.