### PR TITLE
[swiftc (99 vs. 5181)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28469-segfault-0x4674de-0x464be6.swift
+++ b/validation-test/compiler_crashers/28469-segfault-0x4674de-0x464be6.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol C{func^extension{func^


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 99 (5181 resolved)

Stack trace:

```
#0 0x00000000031d00b8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d00b8)
#1 0x00000000031d0906 SignalHandler(int) (/path/to/swift/bin/swift+0x31d0906)
#2 0x00007f950f71d330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x0000000000ddaea4 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0xddaea4)
#4 0x0000000000d81a24 swift::ExtensionDecl::isConstrainedExtension() const (/path/to/swift/bin/swift+0xd81a24)
#5 0x0000000000bdfaa1 (anonymous namespace)::WitnessChecker::findBestWitness(swift::ValueDecl*, bool*, swift::NormalProtocolConformance*, (anonymous namespace)::RequirementEnvironment const&, llvm::SmallVectorImpl<(anonymous namespace)::RequirementMatch>&, unsigned int&, unsigned int&, bool&) (/path/to/swift/bin/swift+0xbdfaa1)
#6 0x0000000000bdd796 swift::TypeChecker::inferDefaultWitnesses(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0xbdd796)
#7 0x0000000000c15205 swift::finishTypeChecking(swift::SourceFile&) (/path/to/swift/bin/swift+0xc15205)
#8 0x000000000093803a swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x93803a)
#9 0x000000000047ecc5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ecc5)
#10 0x000000000047db5f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47db5f)
#11 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
#12 0x00007f950dec6f45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
#13 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```