### PR TITLE
[swiftc (103 vs. 5181)] Add crasher in swift::constraints::ConstraintGraph::Change::addedTypeVariable(...)

### DIFF
--- a/validation-test/compiler_crashers/28473-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
+++ b/validation-test/compiler_crashers/28473-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+[.h{l
+return $0


### PR DESCRIPTION
Add test case for crash triggered in `swift::constraints::ConstraintGraph::Change::addedTypeVariable(...)`.

Current number of unresolved compiler crashers: 103 (5181 resolved)

Assertion failure in [`lib/Sema/ConstraintGraph.cpp (line 52)`](https://github.com/apple/swift/blob/master/lib/Sema/ConstraintGraph.cpp#L52):

```
Assertion `TypeVariables[impl.getGraphIndex()] == typeVar && "Type variable mismatch"' failed.

When executing: std::pair<ConstraintGraphNode &, unsigned int> swift::constraints::ConstraintGraph::lookupNode(swift::TypeVariableType *)
```

Assertion context:

```
  // Check whether we've already created a node for this type variable.
  auto &impl = typeVar->getImpl();
  if (auto nodePtr = impl.getGraphNode()) {
    assert(impl.getGraphIndex() < TypeVariables.size() && "Out-of-bounds index");
    assert(TypeVariables[impl.getGraphIndex()] == typeVar &&
           "Type variable mismatch");
    return { *nodePtr, impl.getGraphIndex() };
  }

  // Allocate the new node.
  auto nodePtr = new ConstraintGraphNode(typeVar);
```
Stack trace:

```
#0 0x00000000031d08f8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d08f8)
#1 0x00000000031d1146 SignalHandler(int) (/path/to/swift/bin/swift+0x31d1146)
#2 0x00007f42b8fb5330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x00007f42b7773c37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
#4 0x00007f42b7777028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
#5 0x00007f42b776cbf6 __assert_fail_base /build/eglibc-oGUzwX/eglibc-2.19/assert/assert.c:92:0
#6 0x00007f42b776cca2 (/lib/x86_64-linux-gnu/libc.so.6+0x2fca2)
#7 0x0000000000ca5c00 swift::constraints::ConstraintGraph::Change::addedTypeVariable(swift::TypeVariableType*) (/path/to/swift/bin/swift+0xca5c00)
#8 0x0000000000ca76b2 swift::constraints::ConstraintGraph::addConstraint(swift::constraints::Constraint*) (/path/to/swift/bin/swift+0xca76b2)
#9 0x0000000000c7d690 swift::constraints::ConstraintSystem::matchTypes(swift::Type, swift::Type, swift::constraints::ConstraintKind, swift::OptionSet<swift::constraints::ConstraintSystem::TypeMatchFlags, unsigned int>, swift::constraints::ConstraintLocatorBuilder) (/path/to/swift/bin/swift+0xc7d690)
#10 0x0000000000c86ea9 swift::constraints::ConstraintSystem::addConstraintImpl(swift::constraints::ConstraintKind, swift::Type, swift::Type, swift::constraints::ConstraintLocatorBuilder, bool) (/path/to/swift/bin/swift+0xc86ea9)
#11 0x0000000000c7fa2e swift::constraints::ConstraintSystem::addConstraint(swift::constraints::ConstraintKind, swift::Type, swift::Type, swift::constraints::ConstraintLocatorBuilder, bool) (/path/to/swift/bin/swift+0xc7fa2e)
#12 0x0000000000cb38c9 swift::constraints::ConstraintSystem::getTypeOfReference(swift::ValueDecl*, bool, bool, swift::FunctionRefKind, swift::constraints::ConstraintLocatorBuilder, swift::DeclRefExpr const*) (/path/to/swift/bin/swift+0xcb38c9)
#13 0x0000000000cb6050 swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator*, swift::Type, swift::constraints::OverloadChoice) (/path/to/swift/bin/swift+0xcb6050)
#14 0x0000000000c67604 swift::ASTVisitor<(anonymous namespace)::ConstraintGenerator, swift::Type, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0xc67604)
#15 0x0000000000c6e650 (anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xc6e650)
#16 0x0000000000d673f5 swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd673f5)
#17 0x0000000000c63538 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) (/path/to/swift/bin/swift+0xc63538)
#18 0x0000000000c8dabd swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0xc8dabd)
#19 0x0000000000b8af9b swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xb8af9b)
#20 0x0000000000b8da8e swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xb8da8e)
#21 0x0000000000c43845 (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*) (/path/to/swift/bin/swift+0xc43845)
#22 0x0000000000c42e28 (anonymous namespace)::FailureDiagnosis::diagnoseAmbiguousMultiStatementClosure(swift::ClosureExpr*) (/path/to/swift/bin/swift+0xc42e28)
#23 0x0000000000c450c8 std::_Function_handler<swift::Expr* (swift::Expr*), (anonymous namespace)::FailureDiagnosis::diagnoseAmbiguity(swift::Expr*)::$_19>::_M_invoke(std::_Any_data const&, swift::Expr*) (/path/to/swift/bin/swift+0xc450c8)
#24 0x0000000000da3a1f swift::Expr::forEachChildExpr(std::function<swift::Expr* (swift::Expr*)> const&)::ChildWalker::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0xda3a1f)
#25 0x0000000000d6a32e (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd6a32e)
#26 0x0000000000d6a94d (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd6a94d)
#27 0x0000000000d6a8e4 (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd6a8e4)
#28 0x0000000000d673de swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd673de)
#29 0x0000000000d9d4e8 swift::Expr::forEachChildExpr(std::function<swift::Expr* (swift::Expr*)> const&) (/path/to/swift/bin/swift+0xd9d4e8)
#30 0x0000000000c41283 (anonymous namespace)::FailureDiagnosis::diagnoseAmbiguity(swift::Expr*) (/path/to/swift/bin/swift+0xc41283)
#31 0x0000000000c3c203 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc3c203)
#32 0x0000000000c42950 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc42950)
#33 0x0000000000b8afef swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xb8afef)
#34 0x0000000000b8da8e swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xb8da8e)
#35 0x0000000000c43845 (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*) (/path/to/swift/bin/swift+0xc43845)
#36 0x0000000000c467ac (anonymous namespace)::FailureDiagnosis::typeCheckArbitrarySubExprIndependently(swift::Expr*, swift::OptionSet<TCCFlags, unsigned int>) (/path/to/swift/bin/swift+0xc467ac)
#37 0x0000000000c3fd2a (anonymous namespace)::FailureDiagnosis::diagnoseConstraintFailure() (/path/to/swift/bin/swift+0xc3fd2a)
#38 0x0000000000c3c1f2 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0xc3c1f2)
#39 0x0000000000c42950 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0xc42950)
#40 0x0000000000b8afef swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0xb8afef)
#41 0x0000000000b8da8e swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0xb8da8e)
#42 0x0000000000c019c4 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xc019c4)
#43 0x0000000000c011e6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0xc011e6)
#44 0x0000000000c1514a swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc1514a)
#45 0x0000000000938136 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x938136)
#46 0x000000000047ece5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ece5)
#47 0x000000000047db7f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47db7f)
#48 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
#49 0x00007f42b775ef45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
#50 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```