### PR TITLE
[swiftc (102 vs. 5183)] Add crasher in swift::TypeVisitor

### DIFF
--- a/validation-test/compiler_crashers/28474-unreachable-executed-at-swift-lib-ast-type-cpp-1325.swift
+++ b/validation-test/compiler_crashers/28474-unreachable-executed-at-swift-lib-ast-type-cpp-1325.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+b<n([print{$0


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeVisitor`.

Current number of unresolved compiler crashers: 102 (5183 resolved)

Stack trace:

```
#0 0x00000000031d08f8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31d08f8)
#1 0x00000000031d1146 SignalHandler(int) (/path/to/swift/bin/swift+0x31d1146)
#2 0x00007f24bcd13330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x00007f24bb4d1c37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
#4 0x00007f24bb4d5028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
#5 0x000000000317930d llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x317930d)
#6 0x0000000000d36619 swift::TypeVisitor<(anonymous namespace)::TypePrinter, void>::visit(swift::Type) (/path/to/swift/bin/swift+0xd36619)
#7 0x0000000000d33c94 (anonymous namespace)::TypePrinter::visit(swift::Type) (/path/to/swift/bin/swift+0xd33c94)
#8 0x0000000000d33bd1 swift::Type::print(llvm::raw_ostream&, swift::PrintOptions const&) const (/path/to/swift/bin/swift+0xd33bd1)
#9 0x0000000000d2e47a (anonymous namespace)::PrintDecl::printParameter(swift::ParamDecl const*) (/path/to/swift/bin/swift+0xd2e47a)
#10 0x0000000000d1dc57 swift::ASTVisitor<(anonymous namespace)::PrintDecl, void, void, void, void, void, void>::visit(swift::Decl*) (/path/to/swift/bin/swift+0xd1dc57)
#11 0x0000000000d1d468 swift::Decl::dump(llvm::raw_ostream&, unsigned int) const (/path/to/swift/bin/swift+0xd1d468)
#12 0x0000000000d5d11d (anonymous namespace)::Verifier::checkErrors(swift::ValueDecl*) (/path/to/swift/bin/swift+0xd5d11d)
#13 0x0000000000d5b7c9 (anonymous namespace)::Verifier::walkToDeclPost(swift::Decl*) (/path/to/swift/bin/swift+0xd5b7c9)
#14 0x0000000000d67dbc (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xd67dbc)
#15 0x0000000000d685be (anonymous namespace)::Traversal::visitParameterList(swift::ParameterList*) (/path/to/swift/bin/swift+0xd685be)
#16 0x0000000000d6aa94 (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd6aa94)
#17 0x0000000000d6a344 (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd6a344)
#18 0x0000000000d6c44d (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xd6c44d)
#19 0x0000000000d6a39a (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd6a39a)
#20 0x0000000000d6a8e4 (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd6a8e4)
#21 0x0000000000d6a344 (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd6a344)
#22 0x0000000000d6c44d (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xd6c44d)
#23 0x0000000000d6a39a (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd6a39a)
#24 0x0000000000d6a85a (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd6a85a)
#25 0x0000000000d6c44d (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xd6c44d)
#26 0x0000000000d6a39a (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd6a39a)
#27 0x0000000000d6930f swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd6930f)
#28 0x0000000000d67bae (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xd67bae)
#29 0x0000000000d677c4 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd677c4)
#30 0x0000000000dbccbe swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdbccbe)
#31 0x0000000000d4f3dc swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0xd4f3dc)
#32 0x0000000000c15292 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc15292)
#33 0x0000000000938136 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x938136)
#34 0x000000000047ece5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ece5)
#35 0x000000000047db7f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47db7f)
#36 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
#37 0x00007f24bb4bcf45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
#38 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```