### PR TITLE
XFAIL collection reflection tests

### DIFF
--- a/validation-test/Reflection/reflect_Array.swift
+++ b/validation-test/Reflection/reflect_Array.swift
@@ -4,6 +4,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME(ABI): This test is too fragile while this type isn't ABI stable
+// REQUIRES: rdar29139967
+
 import SwiftReflectionTest
 
 class TestClass {

--- a/validation-test/Reflection/reflect_Dictionary.swift
+++ b/validation-test/Reflection/reflect_Dictionary.swift
@@ -4,6 +4,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME(ABI): This test is too fragile while this type isn't ABI stable
+// REQUIRES: rdar29139967
+
 import SwiftReflectionTest
 
 class TestClass {

--- a/validation-test/Reflection/reflect_Set.swift
+++ b/validation-test/Reflection/reflect_Set.swift
@@ -4,6 +4,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME(ABI): This test is too fragile while this type isn't ABI stable
+// REQUIRES: rdar29139967
+
 import SwiftReflectionTest
 
 class TestClass {

--- a/validation-test/Reflection/reflect_String.swift
+++ b/validation-test/Reflection/reflect_String.swift
@@ -4,6 +4,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME(ABI): This test is too fragile while this type isn't ABI stable
+// REQUIRES: rdar29139967
+
 import SwiftReflectionTest
 
 class TestClass {

--- a/validation-test/Reflection/reflect_multiple_types.swift
+++ b/validation-test/Reflection/reflect_multiple_types.swift
@@ -4,11 +4,8 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
-// FIXME: Test failing in CI for simulator
-// REQUIRES: OS=macosx
-
-// FIXME: https://bugs.swift.org/browse/SR-2808
-// XFAIL: resilient_stdlib
+// FIXME(ABI): This test is too fragile while these type aren't ABI stable
+// REQUIRES: rdar29139967
 
 import SwiftReflectionTest
 import Foundation


### PR DESCRIPTION
<!-- What's in this pull request? -->
These tests are far too fragile while we're reworking the ABIs of these types. If the pre-merge CI checked all configurations they might be acceptable (though annoying), but as is this is just an easy way to break the build for little value.

I know @dabrahams considers these tests completely inappropriate altogether for relying on stdlib implementation details, but I'm not willing to make that call quite yet. There's arguably some value in these as a limited ABI checker. Even the names of fields and structs is relevant to lldb (for now?).

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

"Fixes" rdar://29127854 (reflect_multiple_types failing on 32-bit)


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

