### PR TITLE
[Type checker] Recurse into statements when cleaning type variables.

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1301,12 +1301,6 @@ void CleanupIllFormedExpressionRAII::doIt(Expr *expr, ASTContext &Context) {
       }
       return true;
     }
-
-    // Don't walk into statements.  This handles the BraceStmt in
-    // non-single-expr closures, so we don't walk into their body.
-    std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
-      return { false, S };
-    }
   };
   
   if (expr)

--- a/validation-test/compiler_crashers_fixed/28413-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28413-swift-typebase-getcanonicaltype.swift
@@ -5,7 +5,11 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-guard{{return $0
+// RUN: not %target-swift-frontend %s -parse
+t c
+let : {{
+return $0
 == Int
-p
+struct B
+}
+g:

--- a/validation-test/compiler_crashers_fixed/28470-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
+++ b/validation-test/compiler_crashers_fixed/28470-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
@@ -5,11 +5,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
-t c
-let : {{
-return $0
+// RUN: not %target-swift-frontend %s -emit-ir
+guard{{return $0
 == Int
-struct B
-}
-g:
+p


### PR DESCRIPTION
<!-- What's in this pull request? -->


<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

Resolves two crashes, one of which (28470) is affecting the buildbots
but not my local builds.