### PR TITLE
[Type checker] Recurse into statements when cleaning type variables, …

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2411,12 +2411,6 @@ public:
         TS->Patterns.insert({ P, P->getType() });
         return { true, P };
       }
-
-      // Don't walk into statements.  This handles the BraceStmt in
-      // non-single-expr closures, so we don't walk into their body.
-      std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
-        return { false, S };
-      }
     };
 
     E->walk(ExprCleanserImpl(this));

--- a/validation-test/compiler_crashers_fixed/28474-unreachable-executed-at-swift-lib-ast-type-cpp-1325.swift
+++ b/validation-test/compiler_crashers_fixed/28474-unreachable-executed-at-swift-lib-ast-type-cpp-1325.swift
@@ -5,5 +5,5 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 b<n([print{$0


### PR DESCRIPTION


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

…harder.

Resolved crasher #28474, which is failing to crash reliably on CI. Just fix it.