### PR TITLE
[semantic-arc] In SILGen always assign a copy_value's argument to its result.

### DIFF
--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -718,7 +718,7 @@ namespace {
     void emitDestroyValue(SILBuilder &B, SILLocation loc,
                           SILValue aggValue) const override {
       if (B.getFunction().hasQualifiedOwnership()) {
-        B.emitDestroyValueAndFold(loc, aggValue);
+        B.createDestroyValue(loc, aggValue);
         return;
       }
 
@@ -838,7 +838,7 @@ namespace {
     void emitDestroyValue(SILBuilder &B, SILLocation loc,
                           SILValue value) const override {
       if (B.getFunction().hasQualifiedOwnership()) {
-        B.emitDestroyValueAndFold(loc, value);
+        B.createDestroyValue(loc, value);
         return;
       }
       B.emitReleaseValueAndFold(loc, value);
@@ -850,7 +850,7 @@ namespace {
              "This method should never be called when performing a shallow "
              "destroy value.");
       if (B.getFunction().hasQualifiedOwnership()) {
-        B.emitDestroyValueAndFold(loc, value);
+        B.createDestroyValue(loc, value);
         return;
       }
       B.emitReleaseValueAndFold(loc, value);
@@ -896,7 +896,7 @@ namespace {
     void emitDestroyValue(SILBuilder &B, SILLocation loc,
                           SILValue value) const override {
       if (B.getFunction().hasQualifiedOwnership()) {
-        B.emitDestroyValueAndFold(loc, value);
+        B.createDestroyValue(loc, value);
         return;
       }
       B.emitStrongReleaseAndFold(loc, value);

--- a/lib/SILGen/ManagedValue.cpp
+++ b/lib/SILGen/ManagedValue.cpp
@@ -33,8 +33,7 @@ ManagedValue ManagedValue::copy(SILGenFunction &gen, SILLocation l) {
   assert(!lowering.isTrivial() && "trivial value has cleanup?");
   
   if (!lowering.isAddressOnly()) {
-    lowering.emitCopyValue(gen.B, l, getValue());
-    return gen.emitManagedRValueWithCleanup(getValue(), lowering);
+    return gen.emitManagedRetain(l, getValue(), lowering);
   }
   
   SILValue buf = gen.emitTemporaryAllocation(l, getType());
@@ -66,8 +65,7 @@ ManagedValue ManagedValue::copyUnmanaged(SILGenFunction &gen, SILLocation loc) {
   
   SILValue result;
   if (!lowering.isAddressOnly()) {
-    lowering.emitCopyValue(gen.B, loc, getValue());
-    result = getValue();
+    result = lowering.emitCopyValue(gen.B, loc, getValue());
   } else {
     result = gen.emitTemporaryAllocation(loc, getType());
     gen.B.createCopyAddr(loc, getValue(), result, IsNotTake,IsInitialization);

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -2344,7 +2344,7 @@ RValue SILGenFunction::emitApply(
     case ParameterConvention::Direct_Owned:
       // If the callee will consume the 'self' parameter, let's retain it so we
       // can keep it alive.
-      B.emitCopyValueOperation(loc, lifetimeExtendedSelf);
+      lifetimeExtendedSelf = B.emitCopyValueOperation(loc, lifetimeExtendedSelf);
       break;
     case ParameterConvention::Direct_Guaranteed:
     case ParameterConvention::Direct_Unowned:
@@ -2425,7 +2425,7 @@ RValue SILGenFunction::emitApply(
 
     case ResultConvention::Unowned:
       // Unretained. Retain the value.
-      resultTL.emitCopyValue(B, loc, result);
+      result = resultTL.emitCopyValue(B, loc, result);
       break;
     }
 
@@ -5448,7 +5448,7 @@ static SILValue emitDynamicPartialApply(SILGenFunction &gen,
   // Retain 'self' because the partial apply will take ownership.
   // We can't simply forward 'self' because the partial apply is conditional.
   if (!self->getType().isAddress())
-    gen.B.emitCopyValueOperation(loc, self);
+    self = gen.B.emitCopyValueOperation(loc, self);
 
   SILValue result = gen.B.createPartialApply(loc, method, method->getType(), {},
                                              self, partialApplyTy);

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -883,8 +883,7 @@ static SILValue emitObjCUnconsumedArgument(SILGenFunction &gen,
     return tmp;
   }
 
-  lowering.emitCopyValue(gen.B, loc, arg);
-  return arg;
+  return lowering.emitCopyValue(gen.B, loc, arg);
 }
 
 /// Bridge argument types and adjust retain count conventions for an ObjC thunk.

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -236,7 +236,7 @@ static ManagedValue emitBuiltinDestroy(SILGenFunction &gen,
   
   // Destroy the value indirectly. Canonicalization will promote to loads
   // and releases if appropriate.
-  gen.B.emitDestroyAddrAndFold(loc, addr);
+  gen.B.createDestroyAddr(loc, addr);
   
   return ManagedValue::forUnmanaged(gen.emitEmptyTuple(loc));
 }

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -279,7 +279,7 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
           B.createLoad(cleanupLoc, selfLV, LoadOwnershipQualifier::Unqualified);
 
       // Emit a retain of the loaded value, since we return it +1.
-      lowering.emitCopyValue(B, cleanupLoc, selfValue);
+      selfValue = lowering.emitCopyValue(B, cleanupLoc, selfValue);
 
       // Inject the self value into an optional if the constructor is failable.
       if (ctor->getFailability() != OTK_None) {
@@ -675,7 +675,7 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
     }
     
     // We have to do a retain because we are returning the pointer +1.
-    B.emitCopyValueOperation(cleanupLoc, selfArg);
+    selfArg = B.emitCopyValueOperation(cleanupLoc, selfArg);
 
     // Inject the self value into an optional if the constructor is failable.
     if (ctor->getFailability() != OTK_None) {

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -719,7 +719,7 @@ ManagedValue SILGenFunction::emitProtocolMetatypeToObject(SILLocation loc,
   // reference when we use it to prevent it being released and attempting to
   // deallocate itself. It doesn't matter if we ever actually clean up that
   // retain though.
-  B.createCopyValue(loc, value);
+  value = B.createCopyValue(loc, value);
   return ManagedValue::forUnmanaged(value);
 }
 

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -116,7 +116,7 @@ namespace {
   public:
     CleanupClosureConstant(SILValue closure) : closure(closure) {}
     void emit(SILGenFunction &gen, CleanupLocation l) override {
-      gen.B.emitDestroyValueAndFold(l, closure);
+      gen.B.emitDestroyValueOperation(l, closure);
     }
   };
 }
@@ -208,7 +208,7 @@ public:
 
   void emit(SILGenFunction &gen, CleanupLocation l) override {
     if (v->getType().isAddress())
-      gen.B.emitDestroyAddrAndFold(l, v);
+      gen.B.createDestroyAddr(l, v);
     else
       gen.B.emitDestroyValueOperation(l, v);
   }
@@ -1304,7 +1304,7 @@ void SILGenFunction::destroyLocalVariable(SILLocation silLoc, VarDecl *vd) {
   // For a heap variable, the box is responsible for the value. We just need
   // to give up our retain count on it.
   if (loc.box) {
-    B.emitDestroyValueAndFold(silLoc, loc.box);
+    B.emitDestroyValueOperation(silLoc, loc.box);
     return;
   }
 
@@ -1314,7 +1314,7 @@ void SILGenFunction::destroyLocalVariable(SILLocation silLoc, VarDecl *vd) {
   if (!Val->getType().isAddress())
     B.emitDestroyValueOperation(silLoc, Val);
   else
-    B.emitDestroyAddrAndFold(silLoc, Val);
+    B.createDestroyAddr(silLoc, Val);
 }
 
 void SILGenFunction::deallocateUninitializedLocalVariable(SILLocation silLoc,

--- a/lib/SILGen/SILGenDestructor.cpp
+++ b/lib/SILGen/SILGenDestructor.cpp
@@ -134,7 +134,7 @@ void SILGenFunction::emitClassMemberDestruction(SILValue selfValue,
     if (!ti.isTrivial()) {
       SILValue addr = B.createRefElementAddr(cleanupLoc, selfValue, vd,
                                          ti.getLoweredType().getAddressType());
-      B.emitDestroyAddrAndFold(cleanupLoc, addr);
+      B.createDestroyAddr(cleanupLoc, addr);
     }
   }
 }

--- a/lib/SILGen/SILGenDynamicCast.cpp
+++ b/lib/SILGen/SILGenDynamicCast.cpp
@@ -234,7 +234,7 @@ namespace {
                                         SGFContext ctx) {
       // Retain the result if this is copy-on-success.
       if (!shouldTakeOnSuccess(consumption))
-        origTargetTL.emitCopyValue(SGF.B, Loc, value);
+        value = origTargetTL.emitCopyValue(SGF.B, Loc, value);
 
       // Enter a cleanup for the +1 result.
       ManagedValue result

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -59,7 +59,7 @@ ManagedValue SILGenFunction::emitManagedRetain(SILLocation loc,
     return ManagedValue::forUnmanaged(v);
   assert(!lowering.isAddressOnly() && "cannot retain an unloadable type");
 
-  lowering.emitCopyValue(B, loc, v);
+  v = lowering.emitCopyValue(B, loc, v);
   return emitManagedRValueWithCleanup(v, lowering);
 }
 
@@ -3234,8 +3234,7 @@ public:
     auto strongType = SILType::getPrimitiveObjectType(
               unowned->getType().castTo<UnmanagedStorageType>().getReferentType());
     auto owned = gen.B.createUnmanagedToRef(loc, unowned, strongType);
-    gen.B.createCopyValue(loc, owned);
-    auto ownedMV = gen.emitManagedRValueWithCleanup(owned);
+    auto ownedMV = gen.emitManagedRetain(loc, owned);
     
     // Reassign the +1 storage with it.
     ownedMV.assignInto(gen, loc, base.getUnmanagedValue());

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -546,7 +546,7 @@ emitRValueWithAccessor(SILGenFunction &SGF, SILLocation loc,
   case AddressorKind::Owning:
   case AddressorKind::NativeOwning:
     // Emit the release immediately.
-    SGF.B.emitDestroyValueAndFold(loc, addressorResult.second.forward(SGF));
+    SGF.B.emitDestroyValueOperation(loc, addressorResult.second.forward(SGF));
     break;
   case AddressorKind::NativePinning:
     // Emit the unpin immediately.

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -279,7 +279,7 @@ void SILGenFunction::emitCaptures(SILLocation loc,
         }
       
         // Just retain a by-val let.
-        B.emitCopyValueOperation(loc, Val);
+        Val = B.emitCopyValueOperation(loc, Val);
       } else {
         // If we have a mutable binding for a 'let', such as 'self' in an
         // 'init' method, load it.
@@ -321,8 +321,7 @@ void SILGenFunction::emitCaptures(SILLocation loc,
         if (canGuarantee) {
           capturedArgs.push_back(ManagedValue::forUnmanaged(vl.box));
         } else {
-          B.createCopyValue(loc, vl.box);
-          capturedArgs.push_back(emitManagedRValueWithCleanup(vl.box));
+          capturedArgs.push_back(emitManagedRetain(loc, vl.box));
         }
         escapesToMark.push_back(vl.value);
       } else {

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2242,7 +2242,7 @@ static void emitStoreOfSemanticRValue(SILGenFunction &gen,
     gen.B.createStoreWeak(loc, value, dest, isInit);
 
     // store_weak doesn't take ownership of the input, so cancel it out.
-    gen.B.emitDestroyValueAndFold(loc, value);
+    gen.B.emitDestroyValueOperation(loc, value);
     return;
   }
 
@@ -2254,7 +2254,7 @@ static void emitStoreOfSemanticRValue(SILGenFunction &gen,
       gen.B.createStoreUnowned(loc, value, dest, isInit);
 
       // store_unowned doesn't take ownership of the input, so cancel it out.
-      gen.B.emitDestroyValueAndFold(loc, value);
+      gen.B.emitDestroyValueOperation(loc, value);
       return;
     }
 
@@ -2262,7 +2262,7 @@ static void emitStoreOfSemanticRValue(SILGenFunction &gen,
       gen.B.createRefToUnowned(loc, value, storageType.getObjectType());
     gen.B.createUnownedRetain(loc, unownedValue, Atomicity::Atomic);
     emitUnloweredStoreOfCopy(gen.B, loc, unownedValue, dest, isInit);
-    gen.B.emitDestroyValueAndFold(loc, value);
+    gen.B.emitDestroyValueOperation(loc, value);
     return;
   }
 
@@ -2272,7 +2272,7 @@ static void emitStoreOfSemanticRValue(SILGenFunction &gen,
     auto unmanagedValue =
       gen.B.createRefToUnmanaged(loc, value, storageType.getObjectType());
     emitUnloweredStoreOfCopy(gen.B, loc, unmanagedValue, dest, isInit);
-    gen.B.emitDestroyValueAndFold(loc, value);
+    gen.B.emitDestroyValueOperation(loc, value);
     return;
   }
 
@@ -2362,7 +2362,7 @@ SILValue SILGenFunction::emitConversionFromSemanticValue(SILLocation loc,
 
     SILValue unowned = B.createRefToUnowned(loc, semanticValue, storageType);
     B.createUnownedRetain(loc, unowned, Atomicity::Atomic);
-    B.emitDestroyValueAndFold(loc, semanticValue);
+    B.emitDestroyValueOperation(loc, semanticValue);
     return unowned;
   }
 
@@ -2370,7 +2370,7 @@ SILValue SILGenFunction::emitConversionFromSemanticValue(SILLocation loc,
   if (storageType.is<UnmanagedStorageType>()) {
     SILValue unmanaged =
       B.createRefToUnmanaged(loc, semanticValue, storageType);
-    B.emitDestroyValueAndFold(loc, semanticValue);
+    B.emitDestroyValueOperation(loc, semanticValue);
     return unmanaged;
   }
   

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1171,7 +1171,7 @@ namespace {
       // we've still got a release active.
       SILValue baseValue = (isFinal ? base.forward(gen) : base.getValue());
       if (!isFinal)
-        gen.B.createCopyValue(loc, baseValue);
+        baseValue = gen.B.createCopyValue(loc, baseValue);
 
       gen.B.createStrongUnpin(loc, baseValue, Atomicity::Atomic);
     }
@@ -2162,8 +2162,7 @@ SILValue SILGenFunction::emitConversionToSemanticRValue(SILLocation loc,
     auto result = B.createUnmanagedToRef(loc, src,
               SILType::getPrimitiveObjectType(unmanagedType.getReferentType()));
     // SEMANTIC ARC TODO: Does this need a cleanup?
-    B.createCopyValue(loc, result);
-    return result;
+    return B.createCopyValue(loc, result);
   }
 
   llvm_unreachable("unexpected storage type that differs from type-of-rvalue");
@@ -2207,8 +2206,7 @@ static SILValue emitLoadOfSemanticRValue(SILGenFunction &gen,
     auto result = gen.B.createUnmanagedToRef(loc, value,
             SILType::getPrimitiveObjectType(unmanagedType.getReferentType()));
     // SEMANTIC ARC TODO: Does this need a cleanup?
-    gen.B.createCopyValue(loc, result);
-    return result;
+    return gen.B.createCopyValue(loc, result);
   }
 
   // NSString * must be bridged to String.

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -738,7 +738,7 @@ static ManagedValue manageParam(SILGenFunction &gen,
   // Unowned parameters are only guaranteed at the instant of the call, so we
   // must retain them even if we're in a context that can accept a +0 value.
   case ParameterConvention::Direct_Unowned:
-    gen.getTypeLowering(paramValue->getType())
+    paramValue = gen.getTypeLowering(paramValue->getType())
         .emitCopyValue(gen.B, loc, paramValue);
     SWIFT_FALLTHROUGH;
   case ParameterConvention::Direct_Owned:
@@ -2121,8 +2121,7 @@ void ResultPlanner::execute(ArrayRef<SILValue> innerDirectResults,
                        "reabstraction of returns_inner_pointer function");
       SWIFT_FALLTHROUGH;
     case ResultConvention::Unowned:
-      resultTL.emitCopyValue(Gen.B, Loc, resultValue);
-      return Gen.emitManagedRValueWithCleanup(resultValue, resultTL);
+      return Gen.emitManagedRetain(Loc, resultValue, resultTL);
     }
     llvm_unreachable("bad result convention!");
   };

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -61,7 +61,7 @@ class StrongReleaseCleanup : public Cleanup {
 public:
   StrongReleaseCleanup(SILValue box) : box(box) {}
   void emit(SILGenFunction &gen, CleanupLocation l) override {
-    gen.B.emitDestroyValueAndFold(l, box);
+    gen.B.emitDestroyValueOperation(l, box);
   }
 };
 } // end anonymous namespace

--- a/test/ClangImporter/optional.swift
+++ b/test/ClangImporter/optional.swift
@@ -12,9 +12,11 @@ class A {
     return ""
   }
 // CHECK-LABEL:    sil hidden [thunk] @_TToFC8optional1A3foofT_GSqSS_ : $@convention(objc_method) (A) -> @autoreleased Optional<NSString>
+// CHECK:    bb0([[SELF:%.*]] : $A):
+// CHECK:      [[SELF_COPY:%.*]] = copy_value [[SELF]]
 // CHECK:      [[T0:%.*]] = function_ref @_TFC8optional1A3foofT_GSqSS_
-// CHECK-NEXT: [[T1:%.*]] = apply [[T0]](%0)
-// CHECK-NEXT: destroy_value
+// CHECK-NEXT: [[T1:%.*]] = apply [[T0]]([[SELF_COPY]])
+// CHECK-NEXT: destroy_value [[SELF_COPY]]
 // CHECK:      [[T2:%.*]] = select_enum [[T1]]
 // CHECK-NEXT: cond_br [[T2]]
 //   Something branch: project value, translate, inject into result.
@@ -33,10 +35,13 @@ class A {
 
   @objc func bar(x x : String?) {}
 // CHECK-LABEL:    sil hidden [thunk] @_TToFC8optional1A3barfT1xGSqSS__T_ : $@convention(objc_method) (Optional<NSString>, A) -> ()
-// CHECK:      [[T1:%.*]] = select_enum %0
+// CHECK:    bb0([[ARG:%.*]] : $Optional<NSString>, [[SELF:%.*]] : $A):
+// CHECK:      [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:      [[SELF_COPY:%.*]] = copy_value [[SELF]]
+// CHECK:      [[T1:%.*]] = select_enum [[ARG_COPY]]
 // CHECK-NEXT: cond_br [[T1]]
 //   Something branch: project value, translate, inject into result.
-// CHECK:      [[NSSTR:%.*]] = unchecked_enum_data %0
+// CHECK:      [[NSSTR:%.*]] = unchecked_enum_data [[ARG_COPY]]
 // CHECK:      [[T0:%.*]] = function_ref @_TZFE10FoundationSS36_unconditionallyBridgeFromObjectiveCfGSqCSo8NSString_SS
 //   Make a temporary initialized string that we're going to clobber as part of the conversion process (?).
 // CHECK-NEXT: [[NSSTR_BOX:%.*]] = enum $Optional<NSString>, #Optional.some!enumelt.1, [[NSSTR]] : $NSString
@@ -50,8 +55,8 @@ class A {
 //   Continuation.
 // CHECK:      bb3([[T0:%.*]] : $Optional<String>):
 // CHECK:      [[T1:%.*]] = function_ref @_TFC8optional1A3barfT1xGSqSS__T_
-// CHECK-NEXT: [[T2:%.*]] = apply [[T1]]([[T0]], %1)
-// CHECK-NEXT: destroy_value %1
+// CHECK-NEXT: [[T2:%.*]] = apply [[T1]]([[T0]], [[SELF_COPY]])
+// CHECK-NEXT: destroy_value [[SELF_COPY]]
 // CHECK-NEXT: return [[T2]] : $()
 }
 

--- a/test/SILGen/address_only_types.swift
+++ b/test/SILGen/address_only_types.swift
@@ -34,7 +34,8 @@ func address_only_return(_ x: Unloadable, y: Int) -> Unloadable {
   // CHECK: bb0([[RET:%[0-9]+]] : $*Unloadable, [[XARG:%[0-9]+]] : $*Unloadable, [[YARG:%[0-9]+]] : $Builtin.Int64):
   // CHECK-NEXT: debug_value_addr [[XARG]] : $*Unloadable, let, name "x"
   // CHECK-NEXT: debug_value [[YARG]] : $Builtin.Int64, let, name "y"
-  // CHECK-NEXT: copy_addr [take] [[XARG]] to [initialization] [[RET]]
+  // CHECK-NEXT: copy_addr [[XARG]] to [initialization] [[RET]]
+  // CHECK-NEXT: destroy_addr [[XARG]]
   // CHECK-NEXT: [[VOID:%[0-9]+]] = tuple ()
   // CHECK-NEXT: return [[VOID]]
   return x
@@ -52,7 +53,8 @@ func address_only_conditional_missing_return(_ x: Unloadable) -> Unloadable {
   switch Bool.true_ {
   case .true_:
   // CHECK: [[TRUE]]:
-  // CHECK:   copy_addr [take] %1 to [initialization] %0 : $*Unloadable
+    // CHECK:   copy_addr %1 to [initialization] %0 : $*Unloadable
+    // CHECK:   destroy_addr %1
   // CHECK:   return
     return x
   case .false_:

--- a/test/SILGen/auto_closures.swift
+++ b/test/SILGen/auto_closures.swift
@@ -3,9 +3,12 @@
 struct Bool {}
 var false_ = Bool()
 
-// CHECK-LABEL: sil hidden @_TF13auto_closures17call_auto_closure
+// CHECK-LABEL: sil hidden @_TF13auto_closures17call_auto_closureFKT_VS_4BoolS0_ : $@convention(thin) (@owned @callee_owned () -> Bool) -> Bool
 func call_auto_closure(_ x: @autoclosure () -> Bool) -> Bool {
-  // CHECK: [[RET:%.*]] = apply %0()
+  // CHECK: bb0([[CLOSURE:%.*]] : $@callee_owned () -> Bool):
+  // CHECK: [[CLOSURE_COPY:%.*]] = copy_value [[CLOSURE]]
+  // CHECK: [[RET:%.*]] = apply [[CLOSURE_COPY]]()
+  // CHECK: destroy_value [[CLOSURE]]
   // CHECK: return [[RET]]
   return x()
 }
@@ -34,9 +37,13 @@ public class Base {
 
 public class Sub : Base {
   // CHECK-LABEL: sil hidden @_TFC13auto_closures3Subg1xVS_4Bool : $@convention(method) (@guaranteed Sub) -> Bool {
-  // CHECK: [[AUTOCLOSURE:%.*]] = function_ref @_TFFC13auto_closures3Subg1xVS_4Boolu_KT_S1_ : $@convention(thin) (@owned Sub) -> Bool
-  // CHECK: = partial_apply [[AUTOCLOSURE]](%0)
-  // CHECK: return {{%.*}} : $Bool
+  // CHECK: bb0([[SELF:%.*]] : $Sub):
+  // CHECK: [[AUTOCLOSURE_CONSUMER:%.*]] = function_ref @_TF13auto_closures17call_auto_closureFKT_VS_4BoolS0_ : $@convention(thin)
+  // CHECK: [[AUTOCLOSURE_FUNC:%.*]] = function_ref @_TFFC13auto_closures3Subg1xVS_4Boolu_KT_S1_ : $@convention(thin) (@owned Sub) -> Bool
+  // CHECK: [[SELF_COPY:%.*]] = copy_value [[SELF]]
+  // CHECK: [[AUTOCLOSURE:%.*]] = partial_apply [[AUTOCLOSURE_FUNC]]([[SELF_COPY]])
+  // CHECK: [[RET:%.*]] = apply [[AUTOCLOSURE_CONSUMER]]([[AUTOCLOSURE]])
+  // CHECK: return [[RET]] : $Bool
   // CHECK: }
 
   // CHECK-LABEL: sil shared [transparent] @_TFFC13auto_closures3Subg1xVS_4Boolu_KT_S1_ : $@convention(thin) (@owned Sub) -> Bool {

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -174,7 +174,8 @@ func init_obj(_ x: Builtin.NativeObject, y: Builtin.RawPointer) {
 // CHECK-LABEL: sil hidden @_TF8builtins8init_gen
 func init_gen<T>(_ x: T, y: Builtin.RawPointer) {
   // CHECK: [[ADDR:%.*]] = pointer_to_address {{%.*}} to [strict] $*T
-  // CHECK: copy_addr [take] {{%.*}} to [initialization]  [[ADDR]]
+  // CHECK: copy_addr [[OTHER_LOC:%.*]] to [initialization]  [[ADDR]]
+  // CHECK: destroy_addr [[OTHER_LOC]]
   Builtin.initialize(x, y)
 }
 
@@ -312,8 +313,8 @@ func obj_to_raw_pointer(_ c: Builtin.NativeObject) -> Builtin.RawPointer {
 // CHECK-LABEL: sil hidden @_TF8builtins22class_from_raw_pointer
 func class_from_raw_pointer(_ p: Builtin.RawPointer) -> C {
   // CHECK: [[C:%.*]] = raw_pointer_to_ref [[RAW:%.*]] to $C
-  // CHECK: copy_value [[C]]
-  // CHECK: return [[C]]
+  // CHECK: [[C_COPY:%.*]] = copy_value [[C]]
+  // CHECK: return [[C_COPY]]
   return Builtin.bridgeFromRawPointer(p)
 }
 
@@ -324,24 +325,24 @@ func class_archetype_from_raw_pointer<T : C>(_ p: Builtin.RawPointer) -> T {
 // CHECK-LABEL: sil hidden @_TF8builtins20obj_from_raw_pointer
 func obj_from_raw_pointer(_ p: Builtin.RawPointer) -> Builtin.NativeObject {
   // CHECK: [[C:%.*]] = raw_pointer_to_ref [[RAW:%.*]] to $Builtin.NativeObject
-  // CHECK: copy_value [[C]]
-  // CHECK: return [[C]]
+  // CHECK: [[C_COPY:%.*]] = copy_value [[C]]
+  // CHECK: return [[C_COPY]]
   return Builtin.bridgeFromRawPointer(p)
 }
 
 // CHECK-LABEL: sil hidden @_TF8builtins28unknown_obj_from_raw_pointer
 func unknown_obj_from_raw_pointer(_ p: Builtin.RawPointer) -> Builtin.UnknownObject {
   // CHECK: [[C:%.*]] = raw_pointer_to_ref [[RAW:%.*]] to $Builtin.UnknownObject
-  // CHECK: copy_value [[C]]
-  // CHECK: return [[C]]
+  // CHECK: [[C_COPY:%.*]] = copy_value [[C]]
+  // CHECK: return [[C_COPY]]
   return Builtin.bridgeFromRawPointer(p)
 }
 
 // CHECK-LABEL: sil hidden @_TF8builtins28existential_from_raw_pointer
 func existential_from_raw_pointer(_ p: Builtin.RawPointer) -> AnyObject {
   // CHECK: [[C:%.*]] = raw_pointer_to_ref [[RAW:%.*]] to $AnyObject
-  // CHECK: copy_value [[C]]
-  // CHECK: return [[C]]
+  // CHECK: [[C_COPY:%.*]] = copy_value [[C]]
+  // CHECK: return [[C_COPY]]
   return Builtin.bridgeFromRawPointer(p)
 }
 
@@ -388,11 +389,16 @@ func allocWithTailElems_3<T1, T2, T3>(n1: Builtin.Word, ty1: T1.Type, n2: Builti
 
 // CHECK-LABEL: sil hidden @_TF8builtins16projectTailElems
 func projectTailElems<T>(h: Header, ty: T.Type) -> Builtin.RawPointer {
-  // CHECK: [[TA:%.*]] = ref_tail_addr %0 : $Header
-  // CHECK: [[A2P:%.*]] = address_to_pointer [[TA]]
-  // CHECK: return [[A2P]]
+  // CHECK: bb0([[ARG1:%.*]] : $Header
+  // CHECK:   [[ARG1_COPY:%.*]] = copy_value [[ARG1]]
+  // CHECK:   [[TA:%.*]] = ref_tail_addr [[ARG1_COPY]] : $Header
+  // CHECK:   [[A2P:%.*]] = address_to_pointer [[TA]]
+  // CHECK:   destroy_value [[ARG1_COPY]]
+  // CHECK:   destroy_value [[ARG1]]
+  // CHECK:   return [[A2P]]
   return Builtin.projectTailElems(h, ty)
 }
+// CHECK: } // end sil function '_TF8builtins16projectTailElemsurFT1hCS_6Header2tyMx_Bp'
 
 // CHECK-LABEL: sil hidden @_TF8builtins11getTailAddr
 func getTailAddr<T1, T2>(start: Builtin.RawPointer, i: Builtin.Word, ty1: T1.Type, ty2: T2.Type) -> Builtin.RawPointer {
@@ -473,11 +479,16 @@ func canBeClassMetatype<T>(_: T) {
   Builtin.canBeClass(TT.self)
 }
 
-// CHECK-LABEL: sil hidden @_TF8builtins11fixLifetime
+// CHECK-LABEL: sil hidden @_TF8builtins11fixLifetimeFCS_1CT_ : $@convention(thin) (@owned C) -> () {
 func fixLifetime(_ c: C) {
-  // CHECK: fix_lifetime %0 : $C
+  // CHECK: bb0([[ARG:%.*]] : $C):
+  // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+  // CHECK:   fix_lifetime [[ARG_COPY]] : $C
+  // CHECK:   destroy_value [[ARG_COPY]]
+  // CHECK:   destroy_value [[ARG]]
   Builtin.fixLifetime(c)
 }
+// CHECK: } // end sil function '_TF8builtins11fixLifetimeFCS_1CT_'
 
 // CHECK-LABEL: sil hidden @_TF8builtins20assert_configuration
 func assert_configuration() -> Builtin.Int32 {
@@ -493,8 +504,14 @@ func assumeNonNegative(_ x: Builtin.Word) -> Builtin.Word {
   // CHECK: return [[APPLY]] : $Builtin.Word
 }
 
-// CHECK-LABEL: sil hidden @_TF8builtins11autorelease
-// CHECK: autorelease_value %0
+// CHECK-LABEL: sil hidden @_TF8builtins11autoreleaseFCS_1OT_ : $@convention(thin) (@owned O) -> () {
+// ==> SEMANTIC ARC TODO: This will be unbalanced... should we allow it?
+// CHECK: bb0([[ARG:%.*]] : $O):
+// CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:   autorelease_value [[ARG_COPY]]
+// CHECK:   destroy_value [[ARG_COPY]]
+// CHECK:   destroy_value [[ARG]]
+// CHECK: } // end sil function '_TF8builtins11autoreleaseFCS_1OT_'
 func autorelease(_ o: O) {
   Builtin.autorelease(o)
 }
@@ -511,19 +528,21 @@ func unreachable() {
 }
 
 // CHECK-LABEL: sil hidden @_TF8builtins15reinterpretCastFTCS_1C1xBw_TBwCS_1DGSqS0__S0__ : $@convention(thin) (@owned C, Builtin.Word) -> (Builtin.Word, @owned D, @owned Optional<C>, @owned C)
-// CHECK:       bb0(%0 : $C, %1 : $Builtin.Word):
+// CHECK:       bb0([[ARG1:%.*]] : $C, [[ARG2:%.*]] : $Builtin.Word):
 // CHECK-NEXT:    debug_value
 // CHECK-NEXT:    debug_value
-// CHECK-NEXT:    copy_value %0 : $C
-// CHECK-NEXT:    unchecked_trivial_bit_cast %0 : $C to $Builtin.Word
-// CHECK-NEXT:    unchecked_ref_cast %0 : $C to $D
-// CHECK-NEXT:    unchecked_ref_cast %0 : $C to $Optional<C>
-// CHECK-NEXT:    unchecked_bitwise_cast %1 : $Builtin.Word to $C
-// CHECK-NEXT:    copy_value %{{.*}} : $C
-// CHECK-NOT:     copy_value
-// CHECK-NOT:     destroy_value
-// CHECK-NOT:     destroy_value
-// CHECK:         return
+// CHECK-NEXT:    [[ARG1_COPY1:%.*]] = copy_value [[ARG1]] : $C
+// CHECK-NEXT:    [[ARG1_TRIVIAL:%.*]] = unchecked_trivial_bit_cast [[ARG1_COPY1]] : $C to $Builtin.Word
+// CHECK-NEXT:    [[ARG1_COPY2:%.*]] = copy_value [[ARG1]] : $C
+// CHECK-NEXT:    [[ARG1_COPY2_CASTED:%.*]] = unchecked_ref_cast [[ARG1_COPY2]] : $C to $D
+// CHECK-NEXT:    [[ARG1_COPY3:%.*]] = copy_value [[ARG1]]
+// CHECK-NEXT:    [[ARG1_COPY3_CAST:%.*]] = unchecked_ref_cast [[ARG1_COPY3]] : $C to $Optional<C>
+// CHECK-NEXT:    [[ARG2_OBJ_CASTED:%.*]] = unchecked_bitwise_cast [[ARG2]] : $Builtin.Word to $C
+// CHECK-NEXT:    [[ARG2_OBJ_CASTED_COPIED:%.*]] = copy_value [[ARG2_OBJ_CASTED]] : $C
+// CHECK-NEXT:    destroy_value [[ARG1_COPY1]]
+// CHECK-NEXT:    destroy_value [[ARG1]]
+// CHECK-NEXT:    [[RESULT:%.*]] = tuple ([[ARG1_TRIVIAL]] : $Builtin.Word, [[ARG1_COPY2_CASTED]] : $D, [[ARG1_COPY3_CAST]] : $Optional<C>, [[ARG2_OBJ_CASTED_COPIED:%.*]] : $C)
+// CHECK:         return [[RESULT]]
 func reinterpretCast(_ c: C, x: Builtin.Word) -> (Builtin.Word, D, C?, C) {
   return (Builtin.reinterpretCast(c) as Builtin.Word,
           Builtin.reinterpretCast(c) as D,
@@ -578,22 +597,23 @@ func castBitPatternFromBridgeObject(_ bo: Builtin.BridgeObject) -> Builtin.Word 
 }
 
 // CHECK-LABEL: sil hidden @_TF8builtins8pinUnpin
-// CHECK:       bb0(%0 : $Builtin.NativeObject):
+// CHECK:       bb0([[ARG:%.*]] : $Builtin.NativeObject):
 // CHECK-NEXT:    debug_value
 func pinUnpin(_ object : Builtin.NativeObject) {
-// CHECK-NEXT:    copy_value %0 : $Builtin.NativeObject
-// CHECK-NEXT:    [[HANDLE:%.*]] = strong_pin %0 : $Builtin.NativeObject
+// CHECK-NEXT:    [[ARG_COPY:%.*]] = copy_value [[ARG]] : $Builtin.NativeObject
+// CHECK-NEXT:    [[HANDLE:%.*]] = strong_pin [[ARG_COPY]] : $Builtin.NativeObject
 // CHECK-NEXT:    debug_value
-// CHECK-NEXT:    destroy_value %0 : $Builtin.NativeObject
+// CHECK-NEXT:    destroy_value [[ARG_COPY]] : $Builtin.NativeObject
   let handle : Builtin.NativeObject? = Builtin.tryPin(object)
 
-// CHECK-NEXT:    copy_value [[HANDLE]] : $Optional<Builtin.NativeObject>
-// CHECK-NEXT:    strong_unpin [[HANDLE]] : $Optional<Builtin.NativeObject>
+// CHECK-NEXT:    [[HANDLE_COPY:%.*]] = copy_value [[HANDLE]] : $Optional<Builtin.NativeObject>
+// CHECK-NEXT:    strong_unpin [[HANDLE_COPY]] : $Optional<Builtin.NativeObject>
+// ==> SEMANTIC ARC TODO: This looks like a mispairing or a weird pairing.
   Builtin.unpin(handle)
 
 // CHECK-NEXT:    tuple ()
 // CHECK-NEXT:    destroy_value [[HANDLE]] : $Optional<Builtin.NativeObject>
-// CHECK-NEXT:    destroy_value %0 : $Builtin.NativeObject
+// CHECK-NEXT:    destroy_value [[ARG]] : $Builtin.NativeObject
 // CHECK-NEXT:    [[T0:%.*]] = tuple ()
 // CHECK-NEXT:    return [[T0]] : $()
 }
@@ -716,9 +736,13 @@ func refcast_generic_any<T>(_ o: T) -> AnyObject {
   return Builtin.castReference(o)
 }
 
-// CHECK-LABEL: sil hidden @_TF8builtins17refcast_class_any
-// CHECK: unchecked_ref_cast %0 : $A to $AnyObject
-// CHECK-NEXT: return
+// CHECK-LABEL: sil hidden @_TF8builtins17refcast_class_anyFCS_1APs9AnyObject_ :
+// CHECK: bb0([[ARG:%.*]] : $A):
+// CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:   [[ARG_COPY_CASTED:%.*]] = unchecked_ref_cast [[ARG_COPY]] : $A to $AnyObject
+// CHECK:   destroy_value [[ARG]]
+// CHECK:   return [[ARG_COPY_CASTED]]
+// CHECK: } // end sil function '_TF8builtins17refcast_class_anyFCS_1APs9AnyObject_'
 func refcast_class_any(_ o: A) -> AnyObject {
   return Builtin.castReference(o)
 }
@@ -729,9 +753,13 @@ func refcast_punknown_any(_ o: PUnknown) -> AnyObject {
   return Builtin.castReference(o)
 }
 
-// CHECK-LABEL: sil hidden @_TF8builtins18refcast_pclass_any
-// CHECK: unchecked_ref_cast %0 : $PClass to $AnyObject
-// CHECK-NEXT: return
+// CHECK-LABEL: sil hidden @_TF8builtins18refcast_pclass_anyFPS_6PClass_Ps9AnyObject_ :
+// CHECK: bb0([[ARG:%.*]] : $PClass):
+// CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:   [[ARG_COPY_CAST:%.*]] = unchecked_ref_cast [[ARG_COPY]] : $PClass to $AnyObject
+// CHECK:   destroy_value [[ARG]]
+// CHECK:   return [[ARG_COPY_CAST]]
+// CHECK: } // end sil function '_TF8builtins18refcast_pclass_anyFPS_6PClass_Ps9AnyObject_'
 func refcast_pclass_any(_ o: PClass) -> AnyObject {
   return Builtin.castReference(o)
 }
@@ -744,12 +772,14 @@ func refcast_any_punknown(_ o: AnyObject) -> PUnknown {
 
 // CHECK-LABEL: sil hidden @_TF8builtins22unsafeGuaranteed_class
 // CHECK: bb0([[P:%.*]] : $A):
-// CHECK:   copy_value  [[P]]
-// CHECK:   [[T:%.*]] = builtin "unsafeGuaranteed"<A>([[P]] : $A)
+// CHECK:   [[P_COPY:%.*]] = copy_value  [[P]]
+// CHECK:   [[T:%.*]] = builtin "unsafeGuaranteed"<A>([[P_COPY]] : $A)
 // CHECK:   [[R:%.*]] = tuple_extract [[T]] : $(A, Builtin.Int8), 0
 // CHECK:   [[K:%.*]] = tuple_extract [[T]] : $(A, Builtin.Int8), 1
 // CHECK:   destroy_value [[R]] : $A
-// CHECK:   return [[P]] : $A
+// CHECK:   [[P_COPY:%.*]] = copy_value [[P]]
+// CHECK:   destroy_value [[P]]
+// CHECK:   return [[P_COPY]] : $A
 // CHECK: }
 func unsafeGuaranteed_class(_ a: A) -> A {
   Builtin.unsafeGuaranteed(a)
@@ -758,12 +788,14 @@ func unsafeGuaranteed_class(_ a: A) -> A {
 
 // CHECK-LABEL: _TF8builtins24unsafeGuaranteed_generic
 // CHECK: bb0([[P:%.*]] : $T):
-// CHECK:   copy_value  [[P]]
-// CHECK:   [[T:%.*]] = builtin "unsafeGuaranteed"<T>([[P]] : $T)
+// CHECK:   [[P_COPY:%.*]] = copy_value  [[P]]
+// CHECK:   [[T:%.*]] = builtin "unsafeGuaranteed"<T>([[P_COPY]] : $T)
 // CHECK:   [[R:%.*]] = tuple_extract [[T]] : $(T, Builtin.Int8), 0
 // CHECK:   [[K:%.*]] = tuple_extract [[T]] : $(T, Builtin.Int8), 1
 // CHECK:   destroy_value [[R]] : $T
-// CHECK:   return [[P]] : $T
+// CHECK:   [[P_RETURN:%.*]] = copy_value [[P]]
+// CHECK:   destroy_value [[P]]
+// CHECK:   return [[P_RETURN]] : $T
 // CHECK: }
 func unsafeGuaranteed_generic<T: AnyObject> (_ a: T) -> T {
   Builtin.unsafeGuaranteed(a)
@@ -772,8 +804,8 @@ func unsafeGuaranteed_generic<T: AnyObject> (_ a: T) -> T {
 
 // CHECK_LABEL: sil hidden @_TF8builtins31unsafeGuaranteed_generic_return
 // CHECK: bb0([[P:%.*]] : $T):
-// CHECK:   copy_value [[P]]
-// CHECK:   [[T:%.*]] = builtin "unsafeGuaranteed"<T>([[P]] : $T)
+// CHECK:   [[P_COPY:%.*]] = copy_value [[P]]
+// CHECK:   [[T:%.*]] = builtin "unsafeGuaranteed"<T>([[P_COPY]] : $T)
 // CHECK:   [[R]] = tuple_extract [[T]] : $(T, Builtin.Int8), 0
 // CHECK:   [[K]] = tuple_extract [[T]] : $(T, Builtin.Int8), 1
 // CHECK:   destroy_value [[P]]

--- a/test/SILGen/cf_members.swift
+++ b/test/SILGen/cf_members.swift
@@ -37,10 +37,11 @@ public func foo(_ x: Double) {
   z = makeMetatype().init(value: x)
 
   // CHECK: [[THUNK:%.*]] = function_ref @_TTOFVSC7Struct1CFT5valueSd_S_
-  // CHECK: [[SELF:%.*]] = metatype $@thin Struct1.Type
-  // CHECK: [[A:%.*]] = apply [[THUNK]]([[SELF]])
+  // CHECK: [[SELF_META:%.*]] = metatype $@thin Struct1.Type
+  // CHECK: [[A:%.*]] = apply [[THUNK]]([[SELF_META]])
+  // CHECK: [[A_COPY:%.*]] = copy_value [[A]]
   let a: (Double) -> Struct1 = Struct1.init(value:)
-  // CHECK: apply [[A]]([[X]])
+  // CHECK: apply [[A_COPY]]([[X]])
   z = a(x)
 
   // TODO: Support @convention(c) references that only capture thin metatype
@@ -60,8 +61,9 @@ public func foo(_ x: Double) {
   // CHECK: [[THUNK:%.*]] = function_ref [[THUNK_NAME:@_TTOFVSC7Struct19translateFT7radiansSd_S_]]
   // CHECK: [[ZVAL:%.*]] = load [[Z]]
   // CHECK: [[C:%.*]] = apply [[THUNK]]([[ZVAL]])
+  // CHECK: [[C_COPY:%.*]] = copy_value [[C]]
   let c: (Double) -> Struct1 = z.translate(radians:)
-  // CHECK: apply [[C]]([[X]])
+  // CHECK: apply [[C_COPY]]([[X]])
   z = c(x)
   // CHECK: [[THUNK:%.*]] = function_ref [[THUNK_NAME]]
   // CHECK: thin_to_thick_function [[THUNK]]
@@ -83,8 +85,9 @@ public func foo(_ x: Double) {
   // CHECK: [[THUNK:%.*]] = function_ref @_TTOFVSC7Struct15scaleFSdS_
   // CHECK: [[ZVAL:%.*]] = load [[Z]]
   // CHECK: [[F:%.*]] = apply [[THUNK]]([[ZVAL]])
+  // CHECK: [[F_COPY:%.*]] = copy_value [[F]]
   let f = z.scale
-  // CHECK: apply [[F]]([[X]])
+  // CHECK: apply [[F_COPY]]([[X]])
   z = f(x)
   // CHECK: [[THUNK:%.*]] = function_ref @_TTOFVSC7Struct15scaleFSdS_
   // CHECK: thin_to_thick_function [[THUNK]]
@@ -126,8 +129,9 @@ public func foo(_ x: Double) {
   // CHECK: [[THUNK:%.*]] = function_ref @_TTOZFVSC7Struct112staticMethodFT_Vs5Int32 
   // CHECK: [[SELF:%.*]] = metatype
   // CHECK: [[I:%.*]] = apply [[THUNK]]([[SELF]])
+  // CHECK: [[I_COPY:%.*]] = copy_value [[I]]
   let i = Struct1.staticMethod
-  // CHECK: apply [[I]]()
+  // CHECK: apply [[I_COPY]]()
   y = i()
 
   // TODO: Support @convention(c) references that only capture thin metatype
@@ -188,6 +192,7 @@ public func foo(_ x: Double) {
   //   = Struct1.selfComesThird(a:b:x:)
   // p(z, y, 0, x)
 }
+// CHECK: } // end sil function '_TF10cf_members3foo{{.*}}'
 
 // CHECK-LABEL: sil shared [thunk] @_TTOFVSC7Struct1CfT5valueSd_S_
 // CHECK:       bb0([[X:%.*]] : $Double, [[SELF:%.*]] : $@thin Struct1.Type):

--- a/test/SILGen/class_bound_protocols.swift
+++ b/test/SILGen/class_bound_protocols.swift
@@ -28,10 +28,14 @@ func class_bound_generic<T : ClassBound>(x: T) -> T {
   // CHECK: bb0([[X:%.*]] : $T):
   // CHECK:   [[X_ADDR:%.*]] = alloc_box $@box T
   // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
-  // CHECK:   store [[X]] to [init] [[PB]]
+  // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
+  // CHECK:   store [[X_COPY]] to [init] [[PB]]
   return x
   // CHECK:   [[X1:%.*]] = load [[PB]]
+  // SEMANTIC ARC TODO: This next line should be [[X1_COPY]]
   // CHECK:   copy_value [[X1]]
+  // CHECK:   destroy_value [[X_ADDR]]
+  // CHECK:   destroy_value [[X]]
   // CHECK:   return [[X1]]
 }
 
@@ -41,9 +45,11 @@ func class_bound_generic_2<T : ClassBound & NotClassBound>(x: T) -> T {
   // CHECK: bb0([[X:%.*]] : $T):
   // CHECK:   [[X_ADDR:%.*]] = alloc_box $@box T
   // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
-  // CHECK:   store [[X]] to [init] [[PB]]
+  // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
+  // CHECK:   store [[X_COPY]] to [init] [[PB]]
   return x
   // CHECK:   [[X1:%.*]] = load [[PB]]
+  // SEMANTIC ARC TODO: This next line should be [[X1_COPY]]
   // CHECK:   copy_value [[X1]]
   // CHECK:   return [[X1]]
 }
@@ -54,10 +60,12 @@ func class_bound_protocol(x: ClassBound) -> ClassBound {
   // CHECK: bb0([[X:%.*]] : $ClassBound):
   // CHECK:   [[X_ADDR:%.*]] = alloc_box $@box ClassBound
   // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
-  // CHECK:   store [[X]] to [init] [[PB]]
+  // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
+  // CHECK:   store [[X_COPY]] to [init] [[PB]]
   return x
   // CHECK:   [[X1:%.*]] = load [[PB]]
-  // CHECK:   copy_value [[X1]]
+  // CHECK:   [[X1_COPY:%.*]] = copy_value [[X1]]
+  // SEMANTIC ARC TODO: This next line should be [[X1_COPY]]
   // CHECK:   return [[X1]]
 }
 
@@ -68,10 +76,12 @@ func class_bound_protocol_composition(x: ClassBound & NotClassBound)
   // CHECK: bb0([[X:%.*]] : $ClassBound & NotClassBound):
   // CHECK:   [[X_ADDR:%.*]] = alloc_box $@box (ClassBound & NotClassBound)
   // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
-  // CHECK:   store [[X]] to [init] [[PB]]
+  // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
+  // CHECK:   store [[X_COPY]] to [init] [[PB]]
   return x
   // CHECK:   [[X1:%.*]] = load [[PB]]
   // CHECK:   copy_value [[X1]]
+  // SEMANTIC ARC TODO: This should be [[X1_COPY]]
   // CHECK:   return [[X1]]
 }
 
@@ -82,14 +92,18 @@ func class_bound_erasure(x: ConcreteClass) -> ClassBound {
   // CHECK: return [[PROTO]]
 }
 
-// CHECK-LABEL: sil hidden @_TF21class_bound_protocols30class_bound_existential_upcast
+// CHECK-LABEL: sil hidden @_TF21class_bound_protocols30class_bound_existential_upcastFT1xPS_10ClassBoundS_11ClassBound2__PS0__ :
 func class_bound_existential_upcast(x: ClassBound & ClassBound2)
 -> ClassBound {
   return x
-  // CHECK: [[OPENED:%.*]] = open_existential_ref {{%.*}} : $ClassBound & ClassBound2 to [[OPENED_TYPE:\$@opened(.*) ClassBound & ClassBound2]]
-  // CHECK: [[PROTO:%.*]] = init_existential_ref [[OPENED]] : [[OPENED_TYPE]] : [[OPENED_TYPE]], $ClassBound
-  // CHECK: return [[PROTO]]
+  // CHECK: bb0([[ARG:%.*]] : $ClassBound & ClassBound2):
+  // CHECK:   [[OPENED:%.*]] = open_existential_ref [[ARG]] : $ClassBound & ClassBound2 to [[OPENED_TYPE:\$@opened(.*) ClassBound & ClassBound2]]
+  // CHECK:   [[OPENED_COPY:%.*]] = copy_value [[OPENED]]
+  // CHECK:   [[PROTO:%.*]] = init_existential_ref [[OPENED_COPY]] : [[OPENED_TYPE]] : [[OPENED_TYPE]], $ClassBound
+  // CHECK:   destroy_value [[ARG]]
+  // CHECK:   return [[PROTO]]
 }
+// CHECK: } // end sil function '_TF21class_bound_protocols30class_bound_existential_upcastFT1xPS_10ClassBoundS_11ClassBound2__PS0__'
 
 // CHECK-LABEL: sil hidden @_TF21class_bound_protocols41class_bound_to_unbound_existential_upcast
 func class_bound_to_unbound_existential_upcast

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -24,22 +24,29 @@ func return_local_generic_function_with_captures<A, R>(_ a: A) -> (A) -> R {
   return f
 }
 
-// CHECK-LABEL: sil hidden @_TF8closures17read_only_capture
+// CHECK-LABEL: sil hidden @_TF8closures17read_only_captureFSiSi : $@convention(thin) (Int) -> Int {
 func read_only_capture(_ x: Int) -> Int {
   var x = x
   // CHECK: bb0([[X:%[0-9]+]] : $Int):
-  // CHECK: [[XBOX:%[0-9]+]] = alloc_box $@box Int
+  // CHECK:   [[XBOX:%[0-9]+]] = alloc_box $@box Int
+  // SEMANTIC ARC TODO: This is incorrect. We need to do the project_box on the copy.
+  // CHECK:   [[PROJECT:%.*]] = project_box [[XBOX]]
+  // CHECK:   store [[X]] to [trivial] [[PROJECT]]
 
   func cap() -> Int {
     return x
   }
 
   return cap()
-  // CHECK: [[CAP:%[0-9]+]] = function_ref @[[CAP_NAME:_TFF8closures17read_only_capture.*]] : $@convention(thin) (@owned @box Int) -> Int
-  // CHECK: [[RET:%[0-9]+]] = apply [[CAP]]([[XBOX]])
-  // CHECK: destroy_value [[XBOX]]
-  // CHECK: return [[RET]]
+  // CHECK:   [[XBOX_COPY:%.*]] = copy_value [[XBOX]]
+  // SEMANTIC ARC TODO: See above. This needs to happen on the copy_valued box.
+  // CHECK:   mark_function_escape [[PROJECT]]
+  // CHECK:   [[CAP:%[0-9]+]] = function_ref @[[CAP_NAME:_TFF8closures17read_only_capture.*]] : $@convention(thin) (@owned @box Int) -> Int
+  // CHECK:   [[RET:%[0-9]+]] = apply [[CAP]]([[XBOX_COPY]])
+  // CHECK:   destroy_value [[XBOX]]
+  // CHECK:   return [[RET]]
 }
+// CHECK:   } // end sil function '_TF8closures17read_only_captureFSiSi'
 
 // CHECK: sil shared @[[CAP_NAME]]
 // CHECK: bb0([[XBOX:%[0-9]+]] : $@box Int):
@@ -47,14 +54,22 @@ func read_only_capture(_ x: Int) -> Int {
 // CHECK: [[X:%[0-9]+]] = load [[XADDR]]
 // CHECK: destroy_value [[XBOX]]
 // CHECK: return [[X]]
+// } // end sil function '[[CAP_NAME]]'
 
-// CHECK-LABEL: sil hidden @_TF8closures16write_to_capture
+// SEMANTIC ARC TODO: This is a place where we have again project_box too early.
+// CHECK-LABEL: sil hidden @_TF8closures16write_to_captureFSiSi : $@convention(thin) (Int) -> Int {
 func write_to_capture(_ x: Int) -> Int {
   var x = x
   // CHECK: bb0([[X:%[0-9]+]] : $Int):
-  // CHECK: [[XBOX:%[0-9]+]] = alloc_box $@box Int
-  // CHECK: [[X2BOX:%[0-9]+]] = alloc_box $@box Int
-  // CHECK: [[PB:%.*]] = project_box [[X2BOX]]
+  // CHECK:   [[XBOX:%[0-9]+]] = alloc_box $@box Int
+  // CHECK:   [[XBOX_PB:%.*]] = project_box [[XBOX]]
+  // CHECK:   store [[X]] to [trivial] [[XBOX_PB]]
+  // CHECK:   [[X2BOX:%[0-9]+]] = alloc_box $@box Int
+  // CHECK:   [[X2BOX_PB:%.*]] = project_box [[X2BOX]]
+  // CHECK:   copy_addr [[XBOX_PB]] to [initialization] [[X2BOX_PB]]
+  // CHECK:   [[X2BOX_COPY:%.*]] = copy_value [[X2BOX]]
+  // SEMANTIC ARC TODO: This next mark_function_escape should be on a projection from X2BOX_COPY.
+  // CHECK:   mark_function_escape [[X2BOX_PB]]
   var x2 = x
 
   func scribble() {
@@ -62,21 +77,26 @@ func write_to_capture(_ x: Int) -> Int {
   }
 
   scribble()
-  // CHECK: [[SCRIB:%[0-9]+]] = function_ref @[[SCRIB_NAME:_TFF8closures16write_to_capture.*]] : $@convention(thin) (@owned @box Int) -> ()
-  // CHECK: apply [[SCRIB]]([[X2BOX]])
-  // CHECK: [[RET:%[0-9]+]] = load [[PB]]
-  // CHECK: destroy_value [[X2BOX]]
-  // CHECK: destroy_value [[XBOX]]
-  // CHECK: return [[RET]]
+  // CHECK:   [[SCRIB:%[0-9]+]] = function_ref @[[SCRIB_NAME:_TFF8closures16write_to_capture.*]] : $@convention(thin) (@owned @box Int) -> ()
+  // CHECK:   apply [[SCRIB]]([[X2BOX_COPY]])
+  // SEMANTIC ARC TODO: This should load from X2BOX_COPY project. There is an
+  // issue here where after a copy_value, we need to reassign a projection in
+  // some way.
+  // CHECK:   [[RET:%[0-9]+]] = load [[X2BOX_PB]]
+  // CHECK:   destroy_value [[X2BOX]]
+  // CHECK:   destroy_value [[XBOX]]
+  // CHECK:   return [[RET]]
   return x2
 }
+// CHECK:  } // end sil function '_TF8closures16write_to_captureFSiSi'
 
 // CHECK: sil shared @[[SCRIB_NAME]]
 // CHECK: bb0([[XBOX:%[0-9]+]] : $@box Int):
-// CHECK: [[XADDR:%[0-9]+]] = project_box [[XBOX]]
-// CHECK: copy_addr {{%[0-9]+}} to [[XADDR]]
-// CHECK: destroy_value [[XBOX]]
-// CHECK: return
+// CHECK:   [[XADDR:%[0-9]+]] = project_box [[XBOX]]
+// CHECK:   copy_addr {{%[0-9]+}} to [[XADDR]]
+// CHECK:   destroy_value [[XBOX]]
+// CHECK:   return
+// CHECK: } // end sil function '[[SCRIB_NAME]]'
 
 // CHECK-LABEL: sil hidden @_TF8closures21multiple_closure_refs
 func multiple_closure_refs(_ x: Int) -> (() -> Int, () -> Int) {
@@ -94,29 +114,43 @@ func multiple_closure_refs(_ x: Int) -> (() -> Int, () -> Int) {
   // CHECK: return [[RET]]
 }
 
-// CHECK-LABEL: sil hidden @_TF8closures18capture_local_func
+// CHECK-LABEL: sil hidden @_TF8closures18capture_local_funcFSiFT_FT_Si : $@convention(thin) (Int) -> @owned @callee_owned () -> @owned @callee_owned () -> Int {
 func capture_local_func(_ x: Int) -> () -> () -> Int {
+  // CHECK: bb0([[ARG:%.*]] : $Int):
   var x = x
-  // CHECK: [[XBOX:%[0-9]+]] = alloc_box $@box Int
+  // CHECK:   [[XBOX:%[0-9]+]] = alloc_box $@box Int
+  // CHECK:   [[XBOX_PB:%.*]] = project_box [[XBOX]]
+  // CHECK:   store [[ARG]] to [trivial] [[XBOX_PB]]
 
   func aleph() -> Int { return x }
 
   func beth() -> () -> Int { return aleph }
-  // CHECK: [[BETH_REF:%[0-9]+]] = function_ref @[[BETH_NAME:_TFF8closures18capture_local_funcFSiFT_FT_SiL_4bethfT_FT_Si]] : $@convention(thin) (@owned @box Int) -> @owned @callee_owned () -> Int
-  // CHECK: [[BETH_CLOSURE:%[0-9]+]] = partial_apply [[BETH_REF]]([[XBOX]])
+  // CHECK: [[BETH_REF:%.*]] = function_ref @[[BETH_NAME:_TFF8closures18capture_local_funcFSiFT_FT_SiL_4bethfT_FT_Si]] : $@convention(thin) (@owned @box Int) -> @owned @callee_owned () -> Int
+  // CHECK: [[XBOX_COPY:%.*]] = copy_value [[XBOX]]
+  // SEMANTIC ARC TODO: This is incorrect. This should be a project_box from XBOX_COPY.
+  // CHECK: mark_function_escape [[XBOX_PB]]
+  // CHECK: [[BETH_CLOSURE:%[0-9]+]] = partial_apply [[BETH_REF]]([[XBOX_COPY]])
 
   return beth
   // CHECK: destroy_value [[XBOX]]
   // CHECK: return [[BETH_CLOSURE]]
 }
-// CHECK: sil shared @[[ALEPH_NAME:_TFF8closures18capture_local_funcFSiFT_FT_SiL_5alephfT_Si]]
+// CHECK: } // end sil function '_TF8closures18capture_local_funcFSiFT_FT_Si'
+
+// CHECK: sil shared @[[ALEPH_NAME:_TFF8closures18capture_local_funcFSiFT_FT_SiL_5alephfT_Si]] : $@convention(thin) (@owned @box Int) -> Int {
 // CHECK: bb0([[XBOX:%[0-9]+]] : $@box Int):
 
-// CHECK: sil shared @[[BETH_NAME]]
+// CHECK: sil shared @[[BETH_NAME]] : $@convention(thin) (@owned @box Int) -> @owned @callee_owned () -> Int {
 // CHECK: bb0([[XBOX:%[0-9]+]] : $@box Int):
-// CHECK: [[ALEPH_REF:%[0-9]+]] = function_ref @[[ALEPH_NAME]] : $@convention(thin) (@owned @box Int) -> Int
-// CHECK: [[ALEPH_CLOSURE:%[0-9]+]] = partial_apply [[ALEPH_REF]]([[XBOX]])
-// CHECK: return [[ALEPH_CLOSURE]]
+// CHECK:   [[XBOX_PB:%.*]] = project_box [[XBOX]]
+// CHECK:   [[ALEPH_REF:%[0-9]+]] = function_ref @[[ALEPH_NAME]] : $@convention(thin) (@owned @box Int) -> Int
+// CHECK:   [[XBOX_COPY:%.*]] = copy_value [[XBOX]]
+// SEMANTIC ARC TODO: This should be on a PB from XBOX_COPY.
+// CHECK:   mark_function_escape [[XBOX_PB]]
+// CHECK:   [[ALEPH_CLOSURE:%[0-9]+]] = partial_apply [[ALEPH_REF]]([[XBOX_COPY]])
+// CHECK:   destroy_value [[XBOX]]
+// CHECK:   return [[ALEPH_CLOSURE]]
+// CHECK: } // end sil function '[[BETH_NAME]]'
 
 // CHECK-LABEL: sil hidden @_TF8closures22anon_read_only_capture
 func anon_read_only_capture(_ x: Int) -> Int {
@@ -169,8 +203,8 @@ func small_closure_capture_with_argument(_ x: Int) -> (_ y: Int) -> Int {
   return { x + $0 }
   // -- func expression
   // CHECK: [[ANON:%[0-9]+]] = function_ref @[[CLOSURE_NAME:_TFF8closures35small_closure_capture_with_argument.*]] : $@convention(thin) (Int, @owned @box Int) -> Int
-  // CHECK: copy_value [[XBOX]]
-  // CHECK: [[ANON_CLOSURE_APP:%[0-9]+]] = partial_apply [[ANON]]([[XBOX]])
+  // CHECK: [[XBOX_COPY:%.*]] = copy_value [[XBOX]]
+  // CHECK: [[ANON_CLOSURE_APP:%[0-9]+]] = partial_apply [[ANON]]([[XBOX_COPY]])
   // -- return
   // CHECK: destroy_value [[XBOX]]
   // CHECK: return [[ANON_CLOSURE_APP]]
@@ -249,11 +283,15 @@ func takesSomeClassGenerator(_ fn : () -> SomeClass) {}
 func generateWithConstant(_ x : SomeSpecificClass) {
   takesSomeClassGenerator({ x })
 }
-// CHECK-LABEL: sil shared @_TFF8closures20generateWithConstant
-// CHECK:    bb0([[T0:%.*]] : $SomeSpecificClass):
-// CHECK-NEXT: debug_value %0 : $SomeSpecificClass, let, name "x", argno 1
-// CHECK-NEXT: [[T1:%.*]] = upcast [[T0]] : $SomeSpecificClass to $SomeClass
-// CHECK-NEXT: return [[T1]]
+
+// CHECK-LABEL: sil shared @_TFF8closures20generateWithConstantFCS_17SomeSpecificClassT_U_FT_CS_9SomeClass : $@convention(thin) (@owned SomeSpecificClass) -> @owned SomeClass {
+// CHECK: bb0([[T0:%.*]] : $SomeSpecificClass):
+// CHECK:   debug_value [[T0]] : $SomeSpecificClass, let, name "x", argno 1
+// CHECK:   [[T0_COPY:%.*]] = copy_value [[T0]]
+// CHECK:   [[T0_COPY_CASTED:%.*]] = upcast [[T0_COPY]] : $SomeSpecificClass to $SomeClass
+// CHECK:   destroy_value [[T0]]
+// CHECK:   return [[T0_COPY_CASTED]]
+// CHECK: } // end sil function '_TFF8closures20generateWithConstantFCS_17SomeSpecificClassT_U_FT_CS_9SomeClass'
 
 
 // Check the annoying case of capturing 'self' in a derived class 'init'
@@ -313,16 +351,21 @@ func closeOverLetLValue() {
 
 // The let property needs to be captured into a temporary stack slot so that it
 // is loadable even though we capture the value.
-// CHECK-LABEL: sil shared @_TFF8closures18closeOverLetLValueFT_T_U_FT_Si
-// CHECK: bb0(%0 : $ClassWithIntProperty):
-// CHECK-NEXT: [[TMP:%.*]] = alloc_stack $ClassWithIntProperty, let, name "a", argno 1
-// CHECK-NEXT: store %0 to [init] [[TMP]] : $*ClassWithIntProperty
-// CHECK-NEXT: {{.*}} = load [[TMP]] : $*ClassWithIntProperty
-// CHECK-NEXT: {{.*}} = ref_element_addr {{.*}} : $ClassWithIntProperty, #ClassWithIntProperty.x
-// CHECK-NEXT: {{.*}} = load {{.*}} : $*Int
-// CHECK-NEXT: destroy_addr [[TMP]] : $*ClassWithIntProperty
-// CHECK-NEXT: dealloc_stack %1 : $*ClassWithIntProperty
-// CHECK-NEXT:  return
+// CHECK-LABEL: sil shared @_TFF8closures18closeOverLetLValueFT_T_U_FT_Si : $@convention(thin) (@owned ClassWithIntProperty) -> Int {
+// CHECK: bb0([[ARG:%.*]] : $ClassWithIntProperty):
+// CHECK:   [[TMP_CLASS_ADDR:%.*]] = alloc_stack $ClassWithIntProperty, let, name "a", argno 1
+// CHECK:   store [[ARG]] to [init] [[TMP_CLASS_ADDR]] : $*ClassWithIntProperty
+// CHECK:   [[LOADED_CLASS:%.*]] = load [[TMP_CLASS_ADDR]] : $*ClassWithIntProperty
+// CHECK:   [[LOADED_CLASS_COPY:%.*]] = copy_value [[LOADED_CLASS]]
+// SEMANTIC ARC TODO: This should be a ref_element_addr from LOADED_CLASS_COPY.
+// CHECK:   [[INT_IN_CLASS_ADDR:%.*]] = ref_element_addr [[LOADED_CLASS]] : $ClassWithIntProperty, #ClassWithIntProperty.x
+// CHECK:   [[INT_IN_CLASS:%.*]] = load [[INT_IN_CLASS_ADDR]] : $*Int
+// SEMANTIC ARC TODO: This should be a destroy_value on LOADED_CLASS_COPY
+// CHECK:   destroy_value [[LOADED_CLASS]]
+// CHECK:   destroy_addr [[TMP_CLASS_ADDR]] : $*ClassWithIntProperty
+// CHECK:   dealloc_stack %1 : $*ClassWithIntProperty
+// CHECK:   return [[INT_IN_CLASS]]
+// CHECK: } // end sil function '_TFF8closures18closeOverLetLValueFT_T_U_FT_Si'
 
 
 
@@ -355,43 +398,58 @@ class SuperBase {
 }
 class SuperSub : SuperBase {
   override func boom() {}
-  
-  // CHECK-LABEL: sil hidden @_TFC8closures8SuperSub1a
-  // CHECK: [[INNER:%.*]] = function_ref @_TFFC8closures8SuperSub1a
-  // CHECK: = apply [[INNER]](%0)
-  // CHECK: return
+
+  // CHECK-LABEL: sil hidden @_TFC8closures8SuperSub1afT_T_ : $@convention(method) (@guaranteed SuperSub) -> () {
+  // CHECK: bb0([[SELF:%.*]] : $SuperSub):
+  // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
+  // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_1:_TFFC8closures8SuperSub1a.*]] : $@convention(thin) (@owned SuperSub) -> ()
+  // CHECK:   apply [[INNER]]([[SELF_COPY]])
+  // CHECK: } // end sil function '_TFC8closures8SuperSub1afT_T_'
   func a() {
-    // CHECK-LABEL: sil shared @_TFFC8closures8SuperSub1a
-    // CHECK: [[CLASS_METHOD:%.*]] = class_method %0 : $SuperSub, #SuperSub.boom!1
-    // CHECK: = apply [[CLASS_METHOD]](%0)
-    // CHECK: [[SUPER:%.*]] = upcast %0 : $SuperSub to $SuperBase
-    // CHECK: [[SUPER_METHOD:%[0-9]+]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
-    // CHECK: = apply [[SUPER_METHOD]]([[SUPER]])
-    // CHECK: return
+    // CHECK: sil shared @[[INNER_FUNC_1]] : $@convention(thin) (@owned SuperSub) -> () {
+    // CHECK: bb0([[ARG:%.*]] : $SuperSub):
+    // CHECK:   [[CLASS_METHOD:%.*]] = class_method [[ARG]] : $SuperSub, #SuperSub.boom!1
+    // CHECK:   = apply [[CLASS_METHOD]]([[ARG]])
+    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+    // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
+    // CHECK:   [[SUPER_METHOD:%[0-9]+]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
+    // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPER]])
+    // CHECK:   destroy_value [[ARG_COPY_SUPER]]
+    // CHECK:   destroy_value [[ARG]]
+    // CHECK: } // end sil function '[[INNER_FUNC_1]]'
     func a1() {
       self.boom()
       super.boom()
     }
     a1()
   }
-  
-  // CHECK-LABEL: sil hidden @_TFC8closures8SuperSub1b
-  // CHECK: [[INNER:%.*]] = function_ref @_TFFC8closures8SuperSub1b
-  // CHECK: = apply [[INNER]](%0)
-  // CHECK: return
+
+  // CHECK-LABEL: sil hidden @_TFC8closures8SuperSub1bfT_T_ : $@convention(method) (@guaranteed SuperSub) -> () {
+  // CHECK: bb0([[SELF:%.*]] : $SuperSub):
+  // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
+  // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_1:_TFFC8closures8SuperSub1b.*]] : $@convention(thin) (@owned SuperSub) -> ()
+  // CHECK:   = apply [[INNER]]([[SELF_COPY]])
+  // CHECK: } // end sil function '_TFC8closures8SuperSub1bfT_T_'
   func b() {
-    // CHECK-LABEL: sil shared @_TFFC8closures8SuperSub1b
-    // CHECK: [[INNER:%.*]] = function_ref @_TFFFC8closures8SuperSub1b
-    // CHECK: = apply [[INNER]](%0)
-    // CHECK: return
+    // CHECK: sil shared @[[INNER_FUNC_1]] : $@convention(thin) (@owned SuperSub) -> () {
+    // CHECK: bb0([[ARG:%.*]] : $SuperSub):
+    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+    // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_2:_TFFFC8closures8SuperSub1b.*]] : $@convention(thin) (@owned SuperSub) -> ()
+    // CHECK:   = apply [[INNER]]([[ARG_COPY]])
+    // CHECK:   destroy_value [[ARG]]
+    // CHECK: } // end sil function '[[INNER_FUNC_1]]'
     func b1() {
-      // CHECK-LABEL: sil shared @_TFFFC8closures8SuperSub1b
-      // CHECK: [[CLASS_METHOD:%.*]] = class_method %0 : $SuperSub, #SuperSub.boom!1
-      // CHECK: = apply [[CLASS_METHOD]](%0)
-      // CHECK: [[SUPER:%.*]] = upcast %0 : $SuperSub to $SuperBase
-      // CHECK: [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
-      // CHECK: = apply [[SUPER_METHOD]]([[SUPER]])
-      // CHECK: return
+      // CHECK: sil shared @[[INNER_FUNC_2]] : $@convention(thin) (@owned SuperSub) -> () {
+      // CHECK: bb0([[ARG:%.*]] : $SuperSub):
+      // CHECK:   [[CLASS_METHOD:%.*]] = class_method [[ARG]] : $SuperSub, #SuperSub.boom!1
+      // CHECK:   = apply [[CLASS_METHOD]]([[ARG]]) : $@convention(method) (@guaranteed SuperSub) -> ()
+      // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+      // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
+      // CHECK:   [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
+      // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPER]]) : $@convention(method) (@guaranteed SuperBase)
+      // CHECK:   destroy_value [[ARG_COPY_SUPER]]
+      // CHECK:   destroy_value [[ARG]]
+      // CHECK: } // end sil function '[[INNER_FUNC_2]]'
       func b2() {
         self.boom()
         super.boom()
@@ -400,41 +458,62 @@ class SuperSub : SuperBase {
     }
     b1()
   }
-  
-  // CHECK-LABEL: sil hidden @_TFC8closures8SuperSub1c
-  // CHECK: [[INNER:%.*]] = function_ref @_TFFC8closures8SuperSub1c
-  // CHECK: = partial_apply [[INNER]](%0)
-  // CHECK: return
+
+  // CHECK-LABEL: sil hidden @_TFC8closures8SuperSub1cfT_T_ : $@convention(method) (@guaranteed SuperSub) -> () {
+  // CHECK: bb0([[SELF:%.*]] : $SuperSub):
+  // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_1:_TFFC8closures8SuperSub1c.*]] : $@convention(thin) (@owned SuperSub) -> ()
+  // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
+  // CHECK:   [[PA:%.*]] = partial_apply [[INNER]]([[SELF_COPY]])
+  // CHECK:   [[PA_COPY:%.*]] = copy_value [[PA]]
+  // CHECK:   apply [[PA_COPY]]()
+  // CHECK:   destroy_value [[PA]]
+  // CHECK: } // end sil function '_TFC8closures8SuperSub1cfT_T_'
   func c() {
-    // CHECK-LABEL: sil shared @_TFFC8closures8SuperSub1c
-    // CHECK: [[CLASS_METHOD:%.*]] = class_method %0 : $SuperSub, #SuperSub.boom!1
-    // CHECK: = apply [[CLASS_METHOD]](%0)
-    // CHECK: [[SUPER:%.*]] = upcast %0 : $SuperSub to $SuperBase
-    // CHECK: [[SUPER_METHOD:%[0-9]+]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
-    // CHECK: = apply [[SUPER_METHOD]]([[SUPER]])
-    // CHECK: return
+    // CHECK: sil shared @[[INNER_FUNC_1]] : $@convention(thin) (@owned SuperSub) -> ()
+    // CHECK: bb0([[ARG:%.*]] : $SuperSub):
+    // CHECK:   [[CLASS_METHOD:%.*]] = class_method [[ARG]] : $SuperSub, #SuperSub.boom!1
+    // CHECK:   = apply [[CLASS_METHOD]]([[ARG]]) : $@convention(method) (@guaranteed SuperSub) -> ()
+    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+    // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
+    // CHECK:   [[SUPER_METHOD:%[0-9]+]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
+    // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPER]])
+    // CHECK:   destroy_value [[ARG_COPY_SUPER]]
+    // CHECK:   destroy_value [[ARG]]
+    // CHECK: } // end sil function '[[INNER_FUNC_1]]'
     let c1 = { () -> Void in
       self.boom()
       super.boom()
     }
     c1()
   }
-  
-  // CHECK-LABEL: sil hidden @_TFC8closures8SuperSub1d
-  // CHECK: [[INNER:%.*]] = function_ref @_TFFC8closures8SuperSub1d
-  // CHECK: = partial_apply [[INNER]](%0)
-  // CHECK: return
+
+  // CHECK-LABEL: sil hidden @_TFC8closures8SuperSub1dfT_T_ : $@convention(method) (@guaranteed SuperSub) -> () {
+  // CHECK: bb0([[SELF:%.*]] : $SuperSub):
+  // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_1:_TFFC8closures8SuperSub1d.*]] : $@convention(thin) (@owned SuperSub) -> ()
+  // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
+  // CHECK:   [[PA:%.*]] = partial_apply [[INNER]]([[SELF_COPY]])
+  // CHECK:   [[PA_COPY:%.*]] = copy_value [[PA]]
+  // CHECK:   apply [[PA_COPY]]()
+  // CHECK:   destroy_value [[PA]]
+  // CHECK: } // end sil function '_TFC8closures8SuperSub1dfT_T_'
   func d() {
-    // CHECK-LABEL: sil shared @_TFFC8closures8SuperSub1d
-    // CHECK: [[INNER:%.*]] = function_ref @_TFFFC8closures8SuperSub1d
-    // CHECK: = apply [[INNER]](%0)
-    // CHECK: return
+    // CHECK: sil shared @[[INNER_FUNC_1]] : $@convention(thin) (@owned SuperSub) -> () {
+    // CHECK: bb0([[ARG:%.*]] : $SuperSub):
+    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+    // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_2:_TFFFC8closures8SuperSub1d.*]] : $@convention(thin) (@owned SuperSub) -> ()
+    // CHECK:   = apply [[INNER]]([[ARG_COPY]])
+    // CHECK:   destroy_value [[ARG]]
+    // CHECK: } // end sil function '[[INNER_FUNC_1]]'
     let d1 = { () -> Void in
-      // CHECK-LABEL: sil shared @_TFFFC8closures8SuperSub1d
-      // CHECK: [[SUPER:%.*]] = upcast %0 : $SuperSub to $SuperBase
-      // CHECK: [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
-      // CHECK: = apply [[SUPER_METHOD]]([[SUPER]])
-      // CHECK: return
+      // CHECK: sil shared @[[INNER_FUNC_2]] : $@convention(thin) (@owned SuperSub) -> () {
+      // CHECK: bb0([[ARG:%.*]] : $SuperSub):
+      // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+      // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
+      // CHECK:   [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
+      // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPER]])
+      // CHECK:   destroy_value [[ARG_COPY_SUPER]]
+      // CHECK:   destroy_value [[ARG]]
+      // CHECK: } // end sil function '[[INNER_FUNC_2]]'
       func d2() {
         super.boom()
       }
@@ -442,22 +521,35 @@ class SuperSub : SuperBase {
     }
     d1()
   }
-  
-  // CHECK-LABEL: sil hidden @_TFC8closures8SuperSub1e
-  // CHECK: [[INNER:%.*]] = function_ref @_TFFC8closures8SuperSub1e
-  // CHECK: = apply [[INNER]](%0)
-  // CHECK: return
+
+  // CHECK-LABEL: sil hidden @_TFC8closures8SuperSub1efT_T_ : $@convention(method) (@guaranteed SuperSub) -> () {
+  // CHECK: bb0([[SELF:%.*]] : $SuperSub):
+  // CHECK: [[SELF_COPY:%.*]] = copy_value [[SELF]]
+  // CHECK: [[INNER:%.*]] = function_ref @[[INNER_FUNC_NAME1:_TFFC8closures8SuperSub1e.*]] : $@convention(thin)
+  // CHECK: = apply [[INNER]]([[SELF_COPY]])
+  // CHECK: } // end sil function '_TFC8closures8SuperSub1efT_T_'
   func e() {
-    // CHECK-LABEL: sil shared @_TFFC8closures8SuperSub1e
-    // CHECK: [[INNER:%.*]] = function_ref @_TFFFC8closures8SuperSub1e
-    // CHECK: = partial_apply [[INNER]](%0)
-    // CHECK: return
+    // CHECK: sil shared @[[INNER_FUNC_NAME1]] : $@convention(thin)
+    // CHECK: bb0([[ARG:%.*]] : $SuperSub):
+    // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_NAME2:_TFFFC8closures8SuperSub1e.*]] : $@convention(thin)
+    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+    // CHECK:   [[PA:%.*]] = partial_apply [[INNER]]([[ARG_COPY]])
+    // CHECK:   [[PA_COPY:%.*]] = copy_value [[PA]]
+    // CHECK:   apply [[PA_COPY]]() : $@callee_owned () -> ()
+    // CHECK:   destroy_value [[PA]]
+    // CHECK:   destroy_value [[ARG]]
+    // CHECK: } // end sil function '[[INNER_FUNC_NAME1]]'
     func e1() {
-      // CHECK-LABEL: sil shared @_TFFFC8closures8SuperSub1e
-      // CHECK: [[SUPER:%.*]] = upcast %0 : $SuperSub to $SuperBase
-      // CHECK: [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
-      // CHECK: = apply [[SUPER_METHOD]]([[SUPER]])
-      // CHECK: return
+      // CHECK: sil shared @[[INNER_FUNC_NAME2]] : $@convention(thin)
+      // ChECK: bb0([[ARG:%.*]] : $SuperSub):
+      // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+      // CHECK:   [[ARG_COPY_SUPERCAST:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
+      // CHECK:   [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
+      // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPERCAST]])
+      // CHECK:   destroy_value [[ARG_COPY_SUPERCAST]]
+      // CHECK:   destroy_value [[ARG]]
+      // CHECK:   return
+      // CHECK: } // end sil function '[[INNER_FUNC_NAME2]]'
       let e2 = {
         super.boom()
       }
@@ -465,41 +557,68 @@ class SuperSub : SuperBase {
     }
     e1()
   }
-  
-  // CHECK-LABEL: sil hidden @_TFC8closures8SuperSub1f
-  // CHECK: [[INNER:%.*]] = function_ref @_TFFC8closures8SuperSub1f
-  // CHECK: = partial_apply [[INNER]](%0)
-  // CHECK: return
+
+  // CHECK-LABEL: sil hidden @_TFC8closures8SuperSub1ffT_T_ : $@convention(method) (@guaranteed SuperSub) -> () {
+  // CHECK: bb0([[SELF:%.*]] : $SuperSub):
+  // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_1:_TFFC8closures8SuperSub1fFT_T_U_FT_T_]] : $@convention(thin) (@owned SuperSub) -> ()
+  // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
+  // CHECK:   [[PA:%.*]] = partial_apply [[INNER]]([[SELF_COPY]])
+  // CHECK:   destroy_value [[PA]]
+  // CHECK: } // end sil function '_TFC8closures8SuperSub1ffT_T_'
   func f() {
-    // CHECK-LABEL: sil shared @_TFFC8closures8SuperSub1f
-    // CHECK: [[INNER:%.*]] = function_ref @_TFFFC8closures8SuperSub1f
-    // CHECK: = partial_apply [[INNER]](%0)
-    // CHECK: return
+    // CHECK: sil shared @[[INNER_FUNC_1]] : $@convention(thin) (@owned SuperSub) -> () {
+    // CHECK: bb0([[ARG:%.*]] : $SuperSub):
+    // CHECK:   [[TRY_APPLY_AUTOCLOSURE:%.*]] = function_ref @_TFsoi2qqurFzTGSqx_KzT_x_x : $@convention(thin) <τ_0_0> (@in Optional<τ_0_0>, @owned @callee_owned () -> (@out τ_0_0, @error Error)) -> (@out τ_0_0, @error Error)
+    // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_2:_TFFFC8closures8SuperSub1fFT_T_U_FT_T_u_KzT_T_]] : $@convention(thin) (@owned SuperSub) -> @error Error
+    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+    // CHECK:   [[PA:%.*]] = partial_apply [[INNER]]([[ARG_COPY]])
+    // CHECK:   [[REABSTRACT_PA:%.*]] = partial_apply {{.*}}([[PA]])
+    // CHECK:   try_apply [[TRY_APPLY_AUTOCLOSURE]]<()>({{.*}}, {{.*}}, [[REABSTRACT_PA]]) : $@convention(thin) <τ_0_0> (@in Optional<τ_0_0>, @owned @callee_owned () -> (@out τ_0_0, @error Error)) -> (@out τ_0_0, @error Error), normal [[NORMAL_BB:bb1]], error [[ERROR_BB:bb2]]
+    // CHECK: [[NORMAL_BB]]{{.*}}
+    // CHECK:   destroy_value [[ARG]]
+    // CHECK: } // end sil function '[[INNER_FUNC_1]]'
     let f1 = {
-      // CHECK-LABEL: sil shared [transparent] @_TFFFC8closures8SuperSub1f
-      // CHECK: [[SUPER:%.*]] = upcast %0 : $SuperSub to $SuperBase
-      // CHECK: [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
-      // CHECK: = apply [[SUPER_METHOD]]([[SUPER]])
-      // CHECK: return
+      // CHECK: sil shared [transparent] @[[INNER_FUNC_2]]
+      // CHECK: bb0([[ARG:%.*]] : $SuperSub):
+      // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+      // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
+      // CHECK:   [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
+      // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPER]]) : $@convention(method) (@guaranteed SuperBase) -> ()
+      // CHECK:   destroy_value [[ARG_COPY_SUPER]]
+      // CHECK:   destroy_value [[ARG]]
+      // CHECK: } // end sil function '[[INNER_FUNC_2]]'
       nil ?? super.boom()
     }
   }
-  
-  // CHECK-LABEL: sil hidden @_TFC8closures8SuperSub1g
-  // CHECK: [[INNER:%.*]] = function_ref @_TFFC8closures8SuperSub1g
-  // CHECK: = apply [[INNER]](%0)
-  // CHECK: return
+
+  // CHECK-LABEL: sil hidden @_TFC8closures8SuperSub1gfT_T_ : $@convention(method) (@guaranteed SuperSub) -> () {
+  // CHECK: bb0([[SELF:%.*]] : $SuperSub):
+  // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
+  // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_1:_TFFC8closures8SuperSub1g.*]] : $@convention(thin) (@owned SuperSub) -> ()
+  // CHECK:   = apply [[INNER]]([[SELF_COPY]])
+  // CHECK: } // end sil function '_TFC8closures8SuperSub1gfT_T_'
   func g() {
-    // CHECK-LABEL: sil shared @_TFFC8closures8SuperSub1g
-    // CHECK: [[INNER:%.*]] = function_ref @_TFFFC8closures8SuperSub1g
-    // CHECK: = partial_apply [[INNER]](%0)
-    // CHECK: return
+    // CHECK: sil shared @[[INNER_FUNC_1]] : $@convention(thin) (@owned SuperSub) -> ()
+    // CHECK: bb0([[ARG:%.*]] : $SuperSub):
+    // CHECK:   [[TRY_APPLY_FUNC:%.*]] = function_ref @_TFsoi2qqurFzTGSqx_KzT_x_x : $@convention(thin) <τ_0_0> (@in Optional<τ_0_0>, @owned @callee_owned () -> (@out τ_0_0, @error Error)) -> (@out τ_0_0, @error Error)
+    // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_2:_TFFFC8closures8SuperSub1g.*]] : $@convention(thin) (@owned SuperSub) -> @error Error
+    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+    // CHECK:   [[PA:%.*]] = partial_apply [[INNER]]([[ARG_COPY]])
+    // CHECK:   [[REABSTRACT_PA:%.*]] = partial_apply {{%.*}}([[PA]]) : $@convention(thin) (@owned @callee_owned () -> @error Error) -> (@out (), @error Error)
+    // CHECK:   try_apply [[TRY_APPLY_FUNC]]<()>({{.*}}, {{.*}}, [[REABSTRACT_PA]]) : $@convention(thin) <τ_0_0> (@in Optional<τ_0_0>, @owned @callee_owned () -> (@out τ_0_0, @error Error)) -> (@out τ_0_0, @error Error), normal [[NORMAL_BB:bb1]], error [[ERROR_BB:bb2]]
+    // CHECK: [[NORMAL_BB]]{{.*}}
+    // CHECK:   destroy_value [[ARG]]
+    // CHECK: } // end sil function '[[INNER_FUNC_1]]'
     func g1() {
-      // CHECK-LABEL: sil shared [transparent] @_TFFFC8closures8SuperSub1g
-      // CHECK: [[SUPER:%.*]] = upcast %0 : $SuperSub to $SuperBase
-      // CHECK: [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
-      // CHECK: = apply [[SUPER_METHOD]]([[SUPER]])
-      // CHECK: return
+      // CHECK: sil shared [transparent] @[[INNER_FUNC_2]] : $@convention(thin) (@owned SuperSub) -> @error Error {
+      // CHECK: bb0([[ARG:%.*]] : $SuperSub):
+      // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+      // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase
+      // CHECK:   [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
+      // CHECK:   = apply [[SUPER_METHOD]]([[ARG_COPY_SUPER]])
+      // CHECK:   destroy_value [[ARG_COPY_SUPER]]
+      // CHECK:   destroy_value [[ARG]]
+      // CHECK: } // end sil function '[[INNER_FUNC_2]]'
       nil ?? super.boom()
     }
     g1()
@@ -507,14 +626,21 @@ class SuperSub : SuperBase {
 }
 
 // CHECK-LABEL: sil hidden @_TFC8closures24UnownedSelfNestedCapture13nestedCapture{{.*}} : $@convention(method) (@guaranteed UnownedSelfNestedCapture) -> ()
+// -- We enter with an assumed strong +1.
+// CHECK:  bb0([[SELF:%.*]] : $UnownedSelfNestedCapture):
 // CHECK:         [[OUTER_SELF_CAPTURE:%.*]] = alloc_box $@box @sil_unowned UnownedSelfNestedCapture
 // CHECK:         [[PB:%.*]] = project_box [[OUTER_SELF_CAPTURE]]
-// CHECK:         [[UNOWNED_SELF:%.*]] = ref_to_unowned [[SELF_PARAM:%.*]] :
+// -- strong +2
+// CHECK:         [[SELF_COPY:%.*]] = copy_value [[SELF]]
+// CHECK:         [[UNOWNED_SELF:%.*]] = ref_to_unowned [[SELF_COPY]] :
 // -- TODO: A lot of fussy r/r traffic and owned/unowned conversions here.
-// -- strong +1, unowned +1
+// -- strong +2, unowned +1
 // CHECK:         unowned_retain [[UNOWNED_SELF]]
 // CHECK:         store [[UNOWNED_SELF]] to [init] [[PB]]
+// SEMANTIC ARC TODO: This destroy_value should probably be /after/ the load from PB on the next line.
+// CHECK:         destroy_value [[SELF_COPY]]
 // CHECK:         [[UNOWNED_SELF:%.*]] = load [[PB]]
+// -- strong +1, unowned +1
 // -- strong +2, unowned +1
 // CHECK:         strong_retain_unowned [[UNOWNED_SELF]]
 // CHECK:         [[SELF:%.*]] = unowned_to_ref [[UNOWNED_SELF]]
@@ -534,28 +660,32 @@ class SuperSub : SuperBase {
 // -- strong +1, unowned +0
 // CHECK:         destroy_value [[OUTER_SELF_CAPTURE]]
 // -- strong +0, unowned +0
-// CHECK:         return
+// CHECK: } // end sil function '_TFC8closures24UnownedSelfNestedCapture13nestedCapture{{.*}}'
 
 // -- outer closure
 // -- strong +0, unowned +1
-// CHECK-LABEL: sil shared @_TFFC8closures24UnownedSelfNestedCapture13nestedCapture
+// CHECK: sil shared @[[OUTER_CLOSURE_FUN:_TFFC8closures24UnownedSelfNestedCapture13nestedCaptureFT_T_U_FT_FT_S0_]] : $@convention(thin) (@owned @sil_unowned UnownedSelfNestedCapture) -> @owned @callee_owned () -> @owned UnownedSelfNestedCapture {
+// CHECK: bb0([[CAPTURED_SELF:%.*]] : $@sil_unowned UnownedSelfNestedCapture):
 // -- strong +0, unowned +2
-// CHECK:         copy_value [[CAPTURED_SELF:%.*]] :
+// CHECK:         [[CAPTURED_SELF_COPY:%.*]] = copy_value [[CAPTURED_SELF]] :
 // -- closure takes ownership of unowned ref
-// CHECK:         [[INNER_CLOSURE:%.*]] = partial_apply {{%.*}}([[CAPTURED_SELF]])
+// CHECK:         [[INNER_CLOSURE:%.*]] = partial_apply {{%.*}}([[CAPTURED_SELF_COPY]])
 // -- strong +0, unowned +1 (claimed by closure)
 // CHECK:         destroy_value [[CAPTURED_SELF]]
 // CHECK:         return [[INNER_CLOSURE]]
+// CHECK: } // end sil function '[[OUTER_CLOSURE_FUN]]'
 
 // -- inner closure
 // -- strong +0, unowned +1
-// CHECK-LABEL: sil shared @_TFFFC8closures24UnownedSelfNestedCapture13nestedCapture
+// CHECK: sil shared @[[INNER_CLOSURE_FUN:_TFFFC8closures24UnownedSelfNestedCapture13nestedCapture.*]] : $@convention(thin) (@owned @sil_unowned UnownedSelfNestedCapture) -> @owned UnownedSelfNestedCapture {
+// CHECK: bb0([[CAPTURED_SELF:%.*]] : $@sil_unowned UnownedSelfNestedCapture):
 // -- strong +1, unowned +1
 // CHECK:         strong_retain_unowned [[CAPTURED_SELF:%.*]] :
 // CHECK:         [[SELF:%.*]] = unowned_to_ref [[CAPTURED_SELF]]
 // -- strong +1, unowned +0 (claimed by return)
 // CHECK:         destroy_value [[CAPTURED_SELF]]
 // CHECK:         return [[SELF]]
+// CHECK: } // end sil function '[[INNER_CLOSURE_FUN]]'
 class UnownedSelfNestedCapture {
   func nestedCapture() {
     {[unowned self] in { self } }()()
@@ -570,9 +700,14 @@ class ConcreteBase {
 }
 
 // CHECK-LABEL: sil shared @_TFFC8closures14GenericDerived4swimFT_T_U_FT_T_ : $@convention(thin) <Ocean> (@owned GenericDerived<Ocean>) -> ()
-// CHECK:         [[SUPER:%.*]] = upcast %0 : $GenericDerived<Ocean> to $ConcreteBase
-// CHECK:         [[METHOD:%.*]] = function_ref @_TFC8closures12ConcreteBase4swimfT_T_
-// CHECK:         apply [[METHOD]]([[SUPER]]) : $@convention(method) (@guaranteed ConcreteBase) -> ()
+// CHECK: bb0([[ARG:%.*]] : $GenericDerived<Ocean>):
+// CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $GenericDerived<Ocean> to $ConcreteBase
+// CHECK:   [[METHOD:%.*]] = function_ref @_TFC8closures12ConcreteBase4swimfT_T_
+// CHECK:   apply [[METHOD]]([[ARG_COPY_SUPER]]) : $@convention(method) (@guaranteed ConcreteBase) -> ()
+// CHECK:   destroy_value [[ARG_COPY_SUPER]]
+// CHECK:   destroy_value [[ARG]]
+// CHECK: } // end sil function '_TFFC8closures14GenericDerived4swimFT_T_U_FT_T_'
 
 class GenericDerived<Ocean> : ConcreteBase {
   override func swim() {

--- a/test/SILGen/collection_downcast.swift
+++ b/test/SILGen/collection_downcast.swift
@@ -43,8 +43,10 @@ func == (x: BridgedSwift, y: BridgedSwift) -> Bool { return true }
 // CHECK-LABEL: sil hidden @_TF19collection_downcast17testArrayDowncast
 // CHECK: bb0([[ARRAY:%[0-9]+]] : $Array<AnyObject>):
 func testArrayDowncast(_ array: [AnyObject]) -> [BridgedObjC] {
+  // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[ARRAY]]
   // CHECK: [[DOWNCAST_FN:%[0-9]+]] = function_ref @_TFs15_arrayForceCast
-  // CHECK: apply [[DOWNCAST_FN]]<AnyObject, BridgedObjC>([[ARRAY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Array<τ_0_1>
+  // CHECK: apply [[DOWNCAST_FN]]<AnyObject, BridgedObjC>([[ARRAY_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Array<τ_0_1>
+  // CHECK: destroy_value [[ARRAY]]
   return array as! [BridgedObjC]
 }
 
@@ -65,40 +67,51 @@ func testArrayDowncastFromNSArray(_ obj: NSArray) -> [BridgedObjC] {
 // CHECK-LABEL: sil hidden @_TF19collection_downcast28testArrayDowncastConditional
 // CHECK: bb0([[ARRAY:%[0-9]+]] : $Array<AnyObject>):
 func testArrayDowncastConditional(_ array: [AnyObject]) -> [BridgedObjC]? {
+  // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[ARRAY]]
   // CHECK: [[DOWNCAST_FN:%[0-9]+]] = function_ref @_TFs21_arrayConditionalCast
-  // CHECK-NEXT:  apply [[DOWNCAST_FN]]<AnyObject, BridgedObjC>([[ARRAY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Optional<Array<τ_0_1>>
+  // CHECK: apply [[DOWNCAST_FN]]<AnyObject, BridgedObjC>([[ARRAY_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Optional<Array<τ_0_1>>
+  // CHECK: destroy_value [[ARRAY]]
   return array as? [BridgedObjC]
 }
+// CHECK: } // end sil function '_TF19collection_downcast28testArrayDowncastConditional{{.*}}'
 
 // CHECK-LABEL: sil hidden @_TF19collection_downcast12testArrayIsa
 // CHECK: bb0([[ARRAY:%[0-9]+]] : $Array<AnyObject>)
 func testArrayIsa(_ array: [AnyObject]) -> Bool {
+  // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[ARRAY]]
   // CHECK: [[DOWNCAST_FN:%[0-9]+]] = function_ref @_TFs21_arrayConditionalCast
-  // CHECK-NEXT: apply [[DOWNCAST_FN]]<AnyObject, BridgedObjC>([[ARRAY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Optional<Array<τ_0_1>>
+  // CHECK: apply [[DOWNCAST_FN]]<AnyObject, BridgedObjC>([[ARRAY_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Optional<Array<τ_0_1>>
+  // CHECK: destroy_value [[ARRAY]]
   return array is [BridgedObjC] ? true : false
 }
 
 // CHECK-LABEL: sil hidden @_TF19collection_downcast24testArrayDowncastBridged
 // CHECK: bb0([[ARRAY:%[0-9]+]] : $Array<AnyObject>):
 func testArrayDowncastBridged(_ array: [AnyObject]) -> [BridgedSwift] {
+  // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[ARRAY]]
   // CHECK: [[BRIDGE_FN:%[0-9]+]] = function_ref @_TFs15_arrayForceCast
-  // CHECK-NEXT: apply [[BRIDGE_FN]]<AnyObject, BridgedSwift>([[ARRAY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Array<τ_0_1>
+  // CHECK: apply [[BRIDGE_FN]]<AnyObject, BridgedSwift>([[ARRAY_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Array<τ_0_1>
+  // CHECK: destroy_value [[ARRAY]]
   return array as! [BridgedSwift]
 }
 
 // CHECK-LABEL: sil hidden @_TF19collection_downcast35testArrayDowncastBridgedConditional
 // CHECK: bb0([[ARRAY:%[0-9]+]] : $Array<AnyObject>):
 func testArrayDowncastBridgedConditional(_ array: [AnyObject]) -> [BridgedSwift]?{
+  // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[ARRAY]]
   // CHECK: [[BRIDGE_FN:%[0-9]+]] = function_ref @_TFs21_arrayConditionalCast
-  // CHECK-NEXT: apply [[BRIDGE_FN]]<AnyObject, BridgedSwift>([[ARRAY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Optional<Array<τ_0_1>>
+  // CHECK: apply [[BRIDGE_FN]]<AnyObject, BridgedSwift>([[ARRAY_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Optional<Array<τ_0_1>>
+  // CHECK: destroy_value [[ARRAY]]
   return array as? [BridgedSwift]
 }
 
 // CHECK-LABEL: sil hidden @_TF19collection_downcast19testArrayIsaBridged
 // CHECK: bb0([[ARRAY:%[0-9]+]] : $Array<AnyObject>)
 func testArrayIsaBridged(_ array: [AnyObject]) -> Bool {
+  // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[ARRAY]]
   // CHECK: [[DOWNCAST_FN:%[0-9]+]] = function_ref @_TFs21_arrayConditionalCast
-  // CHECK: apply [[DOWNCAST_FN]]<AnyObject, BridgedSwift>([[ARRAY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Optional<Array<τ_0_1>>
+  // CHECK: apply [[DOWNCAST_FN]]<AnyObject, BridgedSwift>([[ARRAY_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Optional<Array<τ_0_1>>
+  // CHECK: destroy_value [[ARRAY]]
   return array is [BridgedSwift] ? true : false
 }
 
@@ -114,8 +127,10 @@ func testDictionaryDowncastFromObject(_ obj: AnyObject)
 // CHECK: bb0([[DICT:%[0-9]+]] : $Dictionary<NSObject, AnyObject>)
 func testDictionaryDowncast(_ dict: Dictionary<NSObject, AnyObject>) 
        -> Dictionary<BridgedObjC, BridgedObjC> {
+  // CHECK: [[DICT_COPY:%.*]] = copy_value [[DICT]]
   // CHECK: [[DOWNCAST_FN:%[0-9]+]] = function_ref @_TFs19_dictionaryDownCast
-  // CHECK-NEXT: apply [[DOWNCAST_FN]]<NSObject, AnyObject, BridgedObjC, BridgedObjC>([[DICT]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
+  // CHECK: apply [[DOWNCAST_FN]]<NSObject, AnyObject, BridgedObjC, BridgedObjC>([[DICT_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
+  // CHECK: destroy_value [[DICT]]
   return dict as! Dictionary<BridgedObjC, BridgedObjC>
 }
 
@@ -123,8 +138,10 @@ func testDictionaryDowncast(_ dict: Dictionary<NSObject, AnyObject>)
 // CHECK: bb0([[DICT:%[0-9]+]] : $Dictionary<NSObject, AnyObject>)
 func testDictionaryDowncastConditional(_ dict: Dictionary<NSObject, AnyObject>) 
        -> Dictionary<BridgedObjC, BridgedObjC>? {
+  // CHECK: [[DICT_COPY:%.*]] = copy_value [[DICT]]
   // CHECK: [[DOWNCAST_FN:%[0-9]+]] = function_ref @_TFs30_dictionaryDownCastConditional
-  // CHECK-NEXT: apply [[DOWNCAST_FN]]<NSObject, AnyObject, BridgedObjC, BridgedObjC>([[DICT]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Optional<Dictionary<τ_0_2, τ_0_3>>
+  // CHECK: apply [[DOWNCAST_FN]]<NSObject, AnyObject, BridgedObjC, BridgedObjC>([[DICT_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Optional<Dictionary<τ_0_2, τ_0_3>>
+  // CHECK: destroy_value [[DICT]]
   return dict as? Dictionary<BridgedObjC, BridgedObjC>
 }
 
@@ -132,8 +149,10 @@ func testDictionaryDowncastConditional(_ dict: Dictionary<NSObject, AnyObject>)
 // CHECK: bb0([[DICT:%[0-9]+]] : $Dictionary<NSObject, AnyObject>)
 func testDictionaryDowncastBridgedVConditional(_ dict: Dictionary<NSObject, AnyObject>) 
        -> Dictionary<BridgedObjC, BridgedSwift>? {
+  // CHECK: [[DICT_COPY:%.*]] = copy_value [[DICT]]
   // CHECK: [[BRIDGE_FN:%[0-9]+]] = function_ref @_TFs30_dictionaryDownCastConditional
-  // CHECK-NEXT: apply [[BRIDGE_FN]]<NSObject, AnyObject, BridgedObjC, BridgedSwift>([[DICT]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Optional<Dictionary<τ_0_2, τ_0_3>>{{.*}} // user: %6
+  // CHECK: apply [[BRIDGE_FN]]<NSObject, AnyObject, BridgedObjC, BridgedSwift>([[DICT_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Optional<Dictionary<τ_0_2, τ_0_3>>{{.*}}
+  // CHECK: destroy_value [[DICT]]
   return dict as? Dictionary<BridgedObjC, BridgedSwift>
 }
 
@@ -141,17 +160,21 @@ func testDictionaryDowncastBridgedVConditional(_ dict: Dictionary<NSObject, AnyO
 // CHECK: bb0([[DICT:%[0-9]+]] : $Dictionary<NSObject, AnyObject>)
 func testDictionaryDowncastBridgedKConditional(_ dict: Dictionary<NSObject, AnyObject>) 
        -> Dictionary<BridgedSwift, BridgedObjC>? {
+  // CHECK: [[DICT_COPY:%.*]] = copy_value [[DICT]]
   // CHECK: [[BRIDGE_FN:%[0-9]+]] = function_ref @_TFs30_dictionaryDownCastConditional
-  // CHECK-NEXT: apply [[BRIDGE_FN]]<NSObject, AnyObject, BridgedSwift, BridgedObjC>([[DICT]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Optional<Dictionary<τ_0_2, τ_0_3>>
+  // CHECK: apply [[BRIDGE_FN]]<NSObject, AnyObject, BridgedSwift, BridgedObjC>([[DICT_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Optional<Dictionary<τ_0_2, τ_0_3>>
+  // CHECK: destroy_value [[DICT]]
   return dict as? Dictionary<BridgedSwift, BridgedObjC>
 }
 
 // CHECK-LABEL: sil hidden @_TF19collection_downcast31testDictionaryDowncastBridgedKV
 // CHECK: bb0([[DICT:%[0-9]+]] : $Dictionary<NSObject, AnyObject>)
 func testDictionaryDowncastBridgedKV(_ dict: Dictionary<NSObject, AnyObject>) 
-       -> Dictionary<BridgedSwift, BridgedSwift> {
+-> Dictionary<BridgedSwift, BridgedSwift> {
+  // CHECK: [[DICT_COPY:%.*]] = copy_value [[DICT]]
   // CHECK: [[BRIDGE_FN:%[0-9]+]] = function_ref @_TFs19_dictionaryDownCast
-  // CHECK-NEXT: apply [[BRIDGE_FN]]<NSObject, AnyObject, BridgedSwift, BridgedSwift>([[DICT]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
+  // CHECK: apply [[BRIDGE_FN]]<NSObject, AnyObject, BridgedSwift, BridgedSwift>([[DICT_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
+  // CHECK: destroy_value [[DICT]]
   return dict as! Dictionary<BridgedSwift, BridgedSwift>
 }
 
@@ -159,8 +182,10 @@ func testDictionaryDowncastBridgedKV(_ dict: Dictionary<NSObject, AnyObject>)
 // CHECK: bb0([[DICT:%[0-9]+]] : $Dictionary<NSObject, AnyObject>)
 func testDictionaryDowncastBridgedKVConditional(_ dict: Dictionary<NSObject, AnyObject>) 
        -> Dictionary<BridgedSwift, BridgedSwift>? {
+  // CHECK: [[DICT_COPY:%.*]] = copy_value [[DICT]]
   // CHECK: [[BRIDGE_FN:%[0-9]+]] = function_ref @_TFs30_dictionaryDownCastConditional
-  // CHECK-NEXT: apply [[BRIDGE_FN]]<NSObject, AnyObject, BridgedSwift, BridgedSwift>([[DICT]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Optional<Dictionary<τ_0_2, τ_0_3>>
+  // CHECK: apply [[BRIDGE_FN]]<NSObject, AnyObject, BridgedSwift, BridgedSwift>([[DICT_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Optional<Dictionary<τ_0_2, τ_0_3>>
+  // CHECK: destroy_value [[DICT]]
   return dict as? Dictionary<BridgedSwift, BridgedSwift>
 }
 
@@ -176,8 +201,10 @@ func testSetDowncastFromObject(_ obj: AnyObject)
 // CHECK: bb0([[SET:%[0-9]+]] : $Set<NSObject>)
 func testSetDowncast(_ dict: Set<NSObject>) 
        -> Set<BridgedObjC> {
+  // CHECK: [[SET_COPY:%.*]] = copy_value [[SET]]
   // CHECK: [[DOWNCAST_FN:%[0-9]+]] = function_ref @_TFs12_setDownCast
-  // CHECK-NEXT: apply [[DOWNCAST_FN]]<NSObject, BridgedObjC>([[SET]]) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Hashable, τ_0_1 : Hashable> (@owned Set<τ_0_0>) -> @owned Set<τ_0_1>
+  // CHECK: apply [[DOWNCAST_FN]]<NSObject, BridgedObjC>([[SET_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Hashable, τ_0_1 : Hashable> (@owned Set<τ_0_0>) -> @owned Set<τ_0_1>
+  // CHECK: destroy_value [[SET]]
   return dict as! Set<BridgedObjC>
 }
 
@@ -185,8 +212,10 @@ func testSetDowncast(_ dict: Set<NSObject>)
 // CHECK: bb0([[SET:%[0-9]+]] : $Set<NSObject>)
 func testSetDowncastConditional(_ dict: Set<NSObject>) 
        -> Set<BridgedObjC>? {
+  // CHECK: [[SET_COPY:%.*]] = copy_value [[SET]]
   // CHECK: [[DOWNCAST_FN:%[0-9]+]] = function_ref @_TFs23_setDownCastConditional
-  // CHECK-NEXT: apply [[DOWNCAST_FN]]<NSObject, BridgedObjC>([[SET]]) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Hashable, τ_0_1 : Hashable> (@owned Set<τ_0_0>) -> @owned Optional<Set<τ_0_1>>
+  // CHECK: apply [[DOWNCAST_FN]]<NSObject, BridgedObjC>([[SET_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Hashable, τ_0_1 : Hashable> (@owned Set<τ_0_0>) -> @owned Optional<Set<τ_0_1>>
+  // CHECK: destroy_value [[SET]]
   return dict as? Set<BridgedObjC>
 }
 
@@ -194,8 +223,10 @@ func testSetDowncastConditional(_ dict: Set<NSObject>)
 // CHECK: bb0([[SET:%[0-9]+]] : $Set<NSObject>)
 func testSetDowncastBridged(_ dict: Set<NSObject>) 
        -> Set<BridgedSwift> {
+  // CHECK: [[SET_COPY:%.*]] = copy_value [[SET]]
   // CHECK: [[DOWNCAST_FN:%[0-9]+]] = function_ref @_TFs12_setDownCast
-  // CHECK-NEXT: apply [[DOWNCAST_FN]]<NSObject, BridgedSwift>([[SET]]) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Hashable, τ_0_1 : Hashable> (@owned Set<τ_0_0>) -> @owned Set<τ_0_1>
+  // CHECK: apply [[DOWNCAST_FN]]<NSObject, BridgedSwift>([[SET_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Hashable, τ_0_1 : Hashable> (@owned Set<τ_0_0>) -> @owned Set<τ_0_1>
+  // CHECK: destroy_value [[SET]]
   return dict as! Set<BridgedSwift>
 }
 
@@ -203,7 +234,9 @@ func testSetDowncastBridged(_ dict: Set<NSObject>)
 // CHECK: bb0([[SET:%[0-9]+]] : $Set<NSObject>)
 func testSetDowncastBridgedConditional(_ dict: Set<NSObject>) 
        -> Set<BridgedSwift>? {
-  return dict as? Set<BridgedSwift>
+  // CHECK: [[SET_COPY:%.*]] = copy_value [[SET]]
   // CHECK: [[DOWNCAST_FN:%[0-9]+]] = function_ref @_TFs23_setDownCastConditional
-  // CHECK: apply [[DOWNCAST_FN]]<NSObject, BridgedSwift>([[SET]]) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Hashable, τ_0_1 : Hashable> (@owned Set<τ_0_0>) -> @owned Optional<Set<τ_0_1>>
+  // CHECK: apply [[DOWNCAST_FN]]<NSObject, BridgedSwift>([[SET_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Hashable, τ_0_1 : Hashable> (@owned Set<τ_0_0>) -> @owned Optional<Set<τ_0_1>>
+  // CHECK: destroy_value [[SET]]
+  return dict as? Set<BridgedSwift>
 }

--- a/test/SILGen/collection_subtype_downcast.swift
+++ b/test/SILGen/collection_subtype_downcast.swift
@@ -3,13 +3,13 @@
 struct S { var x, y: Int }
 
 // CHECK-LABEL: sil hidden @_TF27collection_subtype_downcast14array_downcastFT5arrayGSaP___GSqGSaVS_1S__ :
-// CHECK:    bb0(%0 : $Array<Any>):
-// CHECK-NEXT: debug_value %0
-// CHECK-NEXT: copy_value %0
+// CHECK:    bb0([[ARG:%.*]] : $Array<Any>):
+// CHECK-NEXT: debug_value [[ARG]]
+// CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[ARG]]
 // CHECK-NEXT: // function_ref
 // CHECK-NEXT: [[FN:%.*]] = function_ref @_TFs21_arrayConditionalCastu0_rFGSax_GSqGSaq___
-// CHECK-NEXT: [[RESULT:%.*]] = apply [[FN]]<Any, S>(%0) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Optional<Array<τ_0_1>>
-// CHECK-NEXT: destroy_value %0
+// CHECK-NEXT: [[RESULT:%.*]] = apply [[FN]]<Any, S>([[ARG_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Optional<Array<τ_0_1>>
+// CHECK-NEXT: destroy_value [[ARG]]
 // CHECK-NEXT: return [[RESULT]]
 func array_downcast(array: [Any]) -> [S]? {
   return array as? [S]
@@ -26,13 +26,13 @@ func ==(lhs: S, rhs: S) -> Bool {
 
 // FIXME: This entrypoint name should not be bridging-specific
 // CHECK-LABEL:      sil hidden @_TF27collection_subtype_downcast13dict_downcastFT4dictGVs10DictionaryVS_1SP___GSqGS0_S1_Si__ :
-// CHECK:    bb0(%0 : $Dictionary<S, Any>):
-// CHECK-NEXT: debug_value %0
-// CHECK-NEXT: copy_value %0
+// CHECK:    bb0([[ARG:%.*]] : $Dictionary<S, Any>):
+// CHECK-NEXT: debug_value [[ARG]]
+// CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[ARG]]
 // CHECK-NEXT: // function_ref
 // CHECK-NEXT: [[FN:%.*]] = function_ref @_TFs30_dictionaryDownCastConditionalu2_Rxs8Hashable0_S_rFGVs10Dictionaryxq__GSqGS0_q0_q1___
-// CHECK-NEXT: [[RESULT:%.*]] = apply [[FN]]<S, Any, S, Int>(%0) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Optional<Dictionary<τ_0_2, τ_0_3>>
-// CHECK-NEXT: destroy_value %0
+// CHECK-NEXT: [[RESULT:%.*]] = apply [[FN]]<S, Any, S, Int>([[ARG_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Optional<Dictionary<τ_0_2, τ_0_3>>
+// CHECK-NEXT: destroy_value [[ARG]]
 // CHECK-NEXT: return [[RESULT]]
 func dict_downcast(dict: [S: Any]) -> [S: Int]? {
   return dict as? [S: Int]

--- a/test/SILGen/collection_subtype_upcast.swift
+++ b/test/SILGen/collection_subtype_upcast.swift
@@ -3,13 +3,13 @@
 struct S { var x, y: Int }
 
 // CHECK-LABEL: sil hidden @_TF25collection_subtype_upcast12array_upcastFT5arrayGSaVS_1S__GSaP__ :
-// CHECK:    bb0(%0 : $Array<S>):
-// CHECK-NEXT: debug_value %0
-// CHECK-NEXT: copy_value %0
+// CHECK:    bb0([[ARG:%.*]] : $Array<S>):
+// CHECK-NEXT: debug_value [[ARG]]
+// CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[ARG]]
 // CHECK-NEXT: // function_ref
 // CHECK-NEXT: [[FN:%.*]] = function_ref @_TFs15_arrayForceCastu0_rFGSax_GSaq__
-// CHECK-NEXT: [[RESULT:%.*]] = apply [[FN]]<S, Any>(%0) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Array<τ_0_1>
-// CHECK-NEXT: destroy_value %0
+// CHECK-NEXT: [[RESULT:%.*]] = apply [[FN]]<S, Any>([[ARG_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Array<τ_0_1>
+// CHECK-NEXT: destroy_value [[ARG]]
 // CHECK-NEXT: return [[RESULT]]
 func array_upcast(array: [S]) -> [Any] {
   return array
@@ -26,13 +26,13 @@ func ==(lhs: S, rhs: S) -> Bool {
 
 // FIXME: This entrypoint name should not be bridging-specific
 // CHECK-LABEL:      sil hidden @_TF25collection_subtype_upcast11dict_upcastFT4dictGVs10DictionaryVS_1SSi__GS0_S1_P__ :
-// CHECK:    bb0(%0 : $Dictionary<S, Int>):
-// CHECK-NEXT: debug_value %0
-// CHECK-NEXT: copy_value %0
+// CHECK:    bb0([[ARG:%.*]] : $Dictionary<S, Int>):
+// CHECK-NEXT: debug_value [[ARG]]
+// CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[ARG]]
 // CHECK-NEXT: // function_ref
 // CHECK-NEXT: [[FN:%.*]] = function_ref @_TFs17_dictionaryUpCastu2_Rxs8Hashable0_S_rFGVs10Dictionaryxq__GS0_q0_q1__
-// CHECK-NEXT: [[RESULT:%.*]] = apply [[FN]]<S, Int, S, Any>(%0) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
-// CHECK-NEXT: destroy_value %0
+// CHECK-NEXT: [[RESULT:%.*]] = apply [[FN]]<S, Int, S, Any>([[ARG_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
+// CHECK-NEXT: destroy_value [[ARG]]
 // CHECK-NEXT: return [[RESULT]]
 func dict_upcast(dict: [S: Int]) -> [S: Any] {
   return dict

--- a/test/SILGen/collection_upcast.swift
+++ b/test/SILGen/collection_upcast.swift
@@ -41,50 +41,70 @@ struct BridgedSwift : Hashable, _ObjectiveCBridgeable {
 
 func == (x: BridgedSwift, y: BridgedSwift) -> Bool { return true }
 
-// CHECK-LABEL: sil hidden @_TF17collection_upcast15testArrayUpcast
+// CHECK-LABEL: sil hidden @_TF17collection_upcast15testArrayUpcast{{.*}} :
 // CHECK: bb0([[ARRAY:%[0-9]+]] : $Array<BridgedObjC>): 
 func testArrayUpcast(_ array: [BridgedObjC]) {
+  // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[ARRAY]]
   // CHECK: [[UPCAST_FN:%[0-9]+]] = function_ref @_TFs15_arrayForceCast{{.*}} : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Array<τ_0_1>
-  // CHECK-NEXT: apply [[UPCAST_FN]]<BridgedObjC, AnyObject>([[ARRAY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Array<τ_0_1>
+  // CHECK: [[RESULT:%.*]] = apply [[UPCAST_FN]]<BridgedObjC, AnyObject>([[ARRAY_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Array<τ_0_1>
+  // CHECK: destroy_value [[RESULT]]
+  // CHECK: destroy_value [[ARRAY]]
   let anyObjectArr: [AnyObject] = array
 }
+// CHECK: } // end sil function '_TF17collection_upcast15testArrayUpcast{{.*}}'
 
 // CHECK-LABEL: sil hidden @_TF17collection_upcast22testArrayUpcastBridged
 // CHECK: bb0([[ARRAY:%[0-9]+]] : $Array<BridgedSwift>):
 func testArrayUpcastBridged(_ array: [BridgedSwift]) {
+  // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[ARRAY]]
   // CHECK: [[BRIDGE_FN:%[0-9]+]] = function_ref @_TFs15_arrayForceCast{{.*}} : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Array<τ_0_1>
-  // CHECK-NEXT: apply [[BRIDGE_FN]]<BridgedSwift, AnyObject>([[ARRAY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Array<τ_0_1>
+  // CHECK: [[RESULT:%.*]] = apply [[BRIDGE_FN]]<BridgedSwift, AnyObject>([[ARRAY_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@owned Array<τ_0_0>) -> @owned Array<τ_0_1>
+  // CHECK: destroy_value [[RESULT]]
+  // CHECK: destroy_value [[ARRAY]]
   let anyObjectArr = array as [AnyObject]
 }
+// CHECK: } // end sil function '_TF17collection_upcast22testArrayUpcastBridged{{.*}}'
 
 // CHECK-LABEL: sil hidden @_TF17collection_upcast20testDictionaryUpcast
 // CHECK: bb0([[DICT:%[0-9]+]] : $Dictionary<BridgedObjC, BridgedObjC>):
 func testDictionaryUpcast(_ dict: Dictionary<BridgedObjC, BridgedObjC>) {
+  // CHECK: [[DICT_COPY:%.*]] = copy_value [[DICT]]
   // CHECK: [[UPCAST_FN:%[0-9]+]] = function_ref @_TFs17_dictionaryUpCast{{.*}} : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
-  // CHECK-NEXT: apply [[UPCAST_FN]]<BridgedObjC, BridgedObjC, NSObject, AnyObject>([[DICT]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
+  // CHECK: [[RESULT:%.*]] = apply [[UPCAST_FN]]<BridgedObjC, BridgedObjC, NSObject, AnyObject>([[DICT_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
+  // CHECK: destroy_value [[RESULT]]
+  // CHECK: destroy_value [[DICT]]
   let anyObjectDict: Dictionary<NSObject, AnyObject> = dict
 }
 
 // CHECK-LABEL: sil hidden @_TF17collection_upcast27testDictionaryUpcastBridged
 // CHECK: bb0([[DICT:%[0-9]+]] : $Dictionary<BridgedSwift, BridgedSwift>):
 func testDictionaryUpcastBridged(_ dict: Dictionary<BridgedSwift, BridgedSwift>) {
+  // CHECK: [[DICT_COPY:%.*]] = copy_value [[DICT]]
   // CHECK: [[BRIDGE_FN:%[0-9]+]] = function_ref @_TFs17_dictionaryUpCast
-  // CHECK-NEXT: apply [[BRIDGE_FN]]<BridgedSwift, BridgedSwift, NSObject, AnyObject>([[DICT]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
+  // CHECK: [[RESULT:%.*]] = apply [[BRIDGE_FN]]<BridgedSwift, BridgedSwift, NSObject, AnyObject>([[DICT_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@owned Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
+  // CHECK: destroy_value [[RESULT]]
+  // CHECK: destroy_value [[DICT]]
   let anyObjectDict = dict as Dictionary<NSObject, AnyObject>
 }
 
 // CHECK-LABEL: sil hidden @_TF17collection_upcast13testSetUpcast
 // CHECK: bb0([[SET:%[0-9]+]] : $Set<BridgedObjC>):
 func testSetUpcast(_ dict: Set<BridgedObjC>) {
+  // CHECK: [[SET_COPY:%.*]] = copy_value [[SET]]
   // CHECK: [[BRIDGE_FN:%[0-9]+]] = function_ref @_TFs10_setUpCast{{.*}} : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Hashable, τ_0_1 : Hashable> (@owned Set<τ_0_0>) -> @owned Set<τ_0_1>
-  // CHECK-NEXT: apply [[BRIDGE_FN]]<BridgedObjC, NSObject>([[SET]]) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Hashable, τ_0_1 : Hashable> (@owned Set<τ_0_0>) -> @owned Set<τ_0_1>
+  // CHECK: [[RESULT:%.*]] = apply [[BRIDGE_FN]]<BridgedObjC, NSObject>([[SET_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Hashable, τ_0_1 : Hashable> (@owned Set<τ_0_0>) -> @owned Set<τ_0_1>
+  // CHECK: destroy_value [[RESULT]]
+  // CHECK: destroy_value [[SET]]
   let anyObjectSet: Set<NSObject> = dict
 }
 
 // CHECK-LABEL: sil hidden @_TF17collection_upcast20testSetUpcastBridged
-// CHECK: bb0(%0 : $Set<BridgedSwift>):
+// CHECK: bb0([[SET:%.*]] : $Set<BridgedSwift>):
 func testSetUpcastBridged(_ set: Set<BridgedSwift>) {
+  // CHECK: [[SET_COPY:%.*]] = copy_value [[SET]]
   // CHECK: [[BRIDGE_FN:%[0-9]+]] = function_ref @_TFs10_setUpCast
-  // CHECK: apply [[BRIDGE_FN]]<BridgedSwift, NSObject>([[SET]]) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Hashable, τ_0_1 : Hashable> (@owned Set<τ_0_0>) -> @owned Set<τ_0_1>
+  // CHECK: [[RESULT:%.*]] = apply [[BRIDGE_FN]]<BridgedSwift, NSObject>([[SET_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Hashable, τ_0_1 : Hashable> (@owned Set<τ_0_0>) -> @owned Set<τ_0_1>
+  // CHECK: destroy_value [[RESULT]]
+  // CHECK: destroy_value [[SET]]
   let anyObjectSet = set as Set<NSObject>
 }

--- a/test/SILGen/complete_object_init.swift
+++ b/test/SILGen/complete_object_init.swift
@@ -17,9 +17,9 @@ class A {
 // CHECK:   [[INIT_RESULT:%[0-9]+]] = apply [[INIT]]([[X]], [[SELFP]]) : $@convention(method) (X, @owned A) -> @owned A
 // CHECK:   store [[INIT_RESULT]] to [init] [[SELF]] : $*A
 // CHECK:   [[RESULT:%[0-9]+]] = load [[SELF]] : $*A
-// CHECK:   copy_value [[RESULT]] : $A
+// CHECK:   [[RESULT_COPY:%.*]] = copy_value [[RESULT]] : $A
 // CHECK:   destroy_value [[SELF_BOX]] : $@box A
-// CHECK:   return [[RESULT]] : $A
+// CHECK:   return [[RESULT_COPY]] : $A
 
   // CHECK-LABEL: sil hidden @_TFC20complete_object_init1AC{{.*}} : $@convention(method) (@thick A.Type) -> @owned A
   convenience init() {

--- a/test/SILGen/default_constructor.swift
+++ b/test/SILGen/default_constructor.swift
@@ -56,7 +56,9 @@ class E {
 // CHECK-NEXT: [[VALUE:%[0-9]+]] = apply [[INIT]]() : $@convention(thin) () -> Int64
 // CHECK-NEXT: [[IREF:%[0-9]+]] = ref_element_addr [[SELF]] : $E, #E.i
 // CHECK-NEXT: assign [[VALUE]] to [[IREF]] : $*Int64
-// CHECK-NEXT: return [[SELF]] : $E
+// CHECK-NEXT: [[SELF_COPY:%.*]] = copy_value [[SELF]]
+// CHECK-NEXT: destroy_value [[SELF]]
+// CHECK-NEXT: return [[SELF_COPY]] : $E
 
 class F : E { }
 
@@ -74,9 +76,9 @@ class F : E { }
 // CHECK-NEXT: [[ESELFW:%[0-9]+]] = unchecked_ref_cast [[ESELF]] : $E to $F
 // CHECK-NEXT: store [[ESELFW]] to [init] [[SELF]] : $*F
 // CHECK-NEXT: [[SELFP:%[0-9]+]] = load [[SELF]] : $*F
-// CHECK-NEXT: copy_value [[SELFP]] : $F
+// CHECK-NEXT: [[SELFP_COPY:%.*]] = copy_value [[SELFP]] : $F
 // CHECK-NEXT: destroy_value [[SELF_BOX]] : $@box F
-// CHECK-NEXT: return [[SELFP]] : $F
+// CHECK-NEXT: return [[SELFP_COPY]] : $F
 
 
 // <rdar://problem/19780343> Default constructor for a struct with optional doesn't compile

--- a/test/SILGen/dynamic.swift
+++ b/test/SILGen/dynamic.swift
@@ -424,16 +424,22 @@ public class Base {
 
 public class Sub : Base {
   // CHECK-LABEL: sil hidden @_TFC7dynamic3Subg1xSb : $@convention(method) (@guaranteed Sub) -> Bool {
-  // CHECK: [[AUTOCLOSURE:%.*]] = function_ref @_TFFC7dynamic3Subg1xSbu_KzT_Sb : $@convention(thin) (@owned Sub) -> (Bool, @error Error)
-  // CHECK: = partial_apply [[AUTOCLOSURE]](%0)
-  // CHECK: return {{%.*}} : $Bool
-  // CHECK: }
+  // CHECK: bb0([[SELF:%.*]] : $Sub):
+  // CHECK:     [[AUTOCLOSURE:%.*]] = function_ref @_TFFC7dynamic3Subg1xSbu_KzT_Sb : $@convention(thin) (@owned Sub) -> (Bool, @error Error)
+  // CHECK:     [[SELF_COPY:%.*]] = copy_value [[SELF]]
+  // CHECK:     = partial_apply [[AUTOCLOSURE]]([[SELF_COPY]])
+  // CHECK:     return {{%.*}} : $Bool
+  // CHECK: } // end sil function '_TFC7dynamic3Subg1xSb'
 
   // CHECK-LABEL: sil shared [transparent] @_TFFC7dynamic3Subg1xSbu_KzT_Sb : $@convention(thin) (@owned Sub) -> (Bool, @error Error) {
-  // CHECK: [[SUPER:%.*]] = super_method [volatile] %0 : $Sub, #Base.x!getter.1.foreign : (Base) -> () -> Bool , $@convention(objc_method) (Base) -> ObjCBool
-  // CHECK: = apply [[SUPER]]({{%.*}})
-  // CHECK: return {{%.*}} : $Bool
-  // CHECK: }
+  // CHECK: bb0([[VALUE:%.*]] : $Sub):
+  // CHECK:     [[VALUE_COPY:%.*]] = copy_value [[VALUE]]
+  // CHECK:     [[CASTED_VALUE_COPY:%.*]] = upcast [[VALUE_COPY]]
+  // CHECK:     [[SUPER:%.*]] = super_method [volatile] [[VALUE_COPY]] : $Sub, #Base.x!getter.1.foreign : (Base) -> () -> Bool , $@convention(objc_method) (Base) -> ObjCBool
+  // CHECK:     = apply [[SUPER]]([[CASTED_VALUE_COPY]])
+  // CHECK:     destroy_value [[VALUE_COPY]]
+  // CHECK:     destroy_value [[VALUE]]
+  // CHECK: } // end sil function '_TFFC7dynamic3Subg1xSbu_KzT_Sb'
   override var x: Bool { return false || super.x }
 }
 

--- a/test/SILGen/dynamic_lookup.swift
+++ b/test/SILGen/dynamic_lookup.swift
@@ -23,78 +23,94 @@ class X {
 
 // CHECK-LABEL: sil hidden @_TF14dynamic_lookup15direct_to_class
 func direct_to_class(_ obj: AnyObject) {
-  // CHECK: [[OBJ_SELF:%[0-9]+]] = open_existential_ref [[EX:%[0-9]+]] : $AnyObject to $@opened({{.*}}) AnyObject
-  // CHECK: [[METHOD:%[0-9]+]] = dynamic_method [volatile] [[OBJ_SELF]] : $@opened({{.*}}) AnyObject, #X.f!1.foreign : (X) -> () -> (), $@convention(objc_method) (@opened({{.*}}) AnyObject) -> ()
-  // CHECK: apply [[METHOD]]([[OBJ_SELF]]) : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> ()
+  // CHECK: bb0([[ARG:%.*]] : $AnyObject):
+  // CHECK: [[OPENED_ARG:%[0-9]+]] = open_existential_ref [[ARG]] : $AnyObject to $@opened({{.*}}) AnyObject
+  // CHECK: [[OPENED_ARG_COPY:%.*]] = copy_value [[OPENED_ARG]]
+  // CHECK: [[METHOD:%[0-9]+]] = dynamic_method [volatile] [[OPENED_ARG_COPY]] : $@opened({{.*}}) AnyObject, #X.f!1.foreign : (X) -> () -> (), $@convention(objc_method) (@opened({{.*}}) AnyObject) -> ()
+  // CHECK: apply [[METHOD]]([[OPENED_ARG_COPY]]) : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> ()
+  // CHECK: destroy_value [[OPENED_ARG_COPY]]
+  // CHECK: destroy_value [[ARG]]
   obj.f!()
 }
+// CHECK: } // end sil function '_TF14dynamic_lookup15direct_to_class{{.*}}'
 
 // CHECK-LABEL: sil hidden @_TF14dynamic_lookup18direct_to_protocol
 func direct_to_protocol(_ obj: AnyObject) {
-  // CHECK: [[OBJ_SELF:%[0-9]+]] = open_existential_ref [[EX:%[0-9]+]] : $AnyObject to $@opened({{.*}}) AnyObject
-  // CHECK: [[METHOD:%[0-9]+]] = dynamic_method [volatile] [[OBJ_SELF]] : $@opened({{.*}}) AnyObject, #P.g!1.foreign : <Self where Self : P> (Self) -> () -> (), $@convention(objc_method) (@opened({{.*}}) AnyObject) -> ()
-  // CHECK: apply [[METHOD]]([[OBJ_SELF]]) : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> ()
+  // CHECK: bb0([[ARG:%.*]] : $AnyObject):
+  // CHECK:   [[OPENED_ARG:%[0-9]+]] = open_existential_ref [[ARG]] : $AnyObject to $@opened({{.*}}) AnyObject
+  // CHECK:   [[OPENED_ARG_COPY:%.*]] = copy_value [[OPENED_ARG]]
+  // CHECK:   [[METHOD:%[0-9]+]] = dynamic_method [volatile] [[OPENED_ARG_COPY]] : $@opened({{.*}}) AnyObject, #P.g!1.foreign : <Self where Self : P> (Self) -> () -> (), $@convention(objc_method) (@opened({{.*}}) AnyObject) -> ()
+  // CHECK:   apply [[METHOD]]([[OPENED_ARG_COPY]]) : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> ()
+  // CHECK:   destroy_value [[OPENED_ARG_COPY]]
+  // CHECK:   destroy_value [[ARG]]
   obj.g!()
 }
+// CHECK: } // end sil function '_TF14dynamic_lookup18direct_to_protocol{{.*}}'
 
 // CHECK-LABEL: sil hidden @_TF14dynamic_lookup23direct_to_static_method
 func direct_to_static_method(_ obj: AnyObject) {
+  // CHECK: bb0([[ARG:%.*]] : $AnyObject):
   var obj = obj
-  // CHECK: [[START:[A-Za-z0-9_]+]]([[OBJ:%[0-9]+]] : $AnyObject):
   // CHECK: [[OBJBOX:%[0-9]+]] = alloc_box $@box AnyObject
   // CHECK-NEXT: [[PBOBJ:%[0-9]+]] = project_box [[OBJBOX]]
-  // CHECK: store [[OBJ]] to [init] [[PBOBJ]] : $*AnyObject
+  // CHECK: [[ARG_COPY:%.*]] = copy_value [[ARG]]
+  // CHECK: store [[ARG_COPY]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK-NEXT: [[OBJCOPY:%[0-9]+]] = load [[PBOBJ]] : $*AnyObject
   // CHECK-NEXT: [[OBJMETA:%[0-9]+]] = existential_metatype $@thick AnyObject.Type, [[OBJCOPY]] : $AnyObject
   // CHECK-NEXT: [[OPENMETA:%[0-9]+]] = open_existential_metatype [[OBJMETA]] : $@thick AnyObject.Type to $@thick (@opened([[UUID:".*"]]) AnyObject).Type
   // CHECK-NEXT: [[METHOD:%[0-9]+]] = dynamic_method [volatile] [[OPENMETA]] : $@thick (@opened([[UUID]]) AnyObject).Type, #X.staticF!1.foreign : (X.Type) -> () -> (), $@convention(objc_method) (@thick (@opened([[UUID]]) AnyObject).Type) -> ()
   // CHECK: apply [[METHOD]]([[OPENMETA]]) : $@convention(objc_method) (@thick (@opened([[UUID]]) AnyObject).Type) -> ()
+  // CHECK: destroy_value [[OBJBOX]]
+  // CHECK: destroy_value [[ARG]]
   type(of: obj).staticF!()
 }
+// } // end sil function '_TF14dynamic_lookup23direct_to_static_method{{.*}}'
 
 // CHECK-LABEL: sil hidden @_TF14dynamic_lookup12opt_to_class
 func opt_to_class(_ obj: AnyObject) {
+  // CHECK: bb0([[ARG:%.*]] : $AnyObject):
   var obj = obj
-  // CHECK: [[ENTRY:[A-Za-z0-9]+]]([[PARAM:%[0-9]+]] : $AnyObject)
-  // CHECK: [[EXISTBOX:%[0-9]+]] = alloc_box $@box AnyObject 
-  // CHECK-NEXT: [[PBOBJ:%[0-9]+]] = project_box [[EXISTBOX]]
-  // CHECK: store [[PARAM]] to [init] [[PBOBJ]]
-  // CHECK-NEXT: [[OPTBOX:%[0-9]+]] = alloc_box $@box Optional<@callee_owned () -> ()>
-  // CHECK-NEXT: [[PBOPT:%.*]] = project_box [[OPTBOX]]
-  // CHECK-NEXT: [[EXISTVAL:%[0-9]+]] = load [[PBOBJ]] : $*AnyObject
-  // CHECK-NEXT: copy_value [[EXISTVAL]] : $AnyObject
-  // CHECK-NEXT: [[OBJ_SELF:%[0-9]*]] = open_existential_ref [[EXIST:%[0-9]+]]
-  // CHECK-NEXT: [[OPTTEMP:%.*]] = alloc_stack $Optional<@callee_owned () -> ()>
-  // CHECK-NEXT: dynamic_method_br [[OBJ_SELF]] : $@opened({{.*}}) AnyObject, #X.f!1.foreign, [[HASBB:[a-zA-z0-9]+]], [[NOBB:[a-zA-z0-9]+]]
+  // CHECK:   [[EXISTBOX:%[0-9]+]] = alloc_box $@box AnyObject 
+  // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[EXISTBOX]]
+  // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+  // CHECK:   store [[ARG_COPY]] to [init] [[PBOBJ]]
+  // CHECK:   [[OPTBOX:%[0-9]+]] = alloc_box $@box Optional<@callee_owned () -> ()>
+  // CHECK:   [[PBOPT:%.*]] = project_box [[OPTBOX]]
+  // CHECK:   [[EXISTVAL:%[0-9]+]] = load [[PBOBJ]] : $*AnyObject
+  // CHECK:   [[EXISTVAL_COPY:%.*]] = copy_value [[EXISTVAL]]
+  // SEMANTIC ARC TODO: The next line is incorrect, we should be performing an open_existential_ref on EXISTVAL_COPY, not EXISTVAL
+  // CHECK:   [[OBJ_SELF:%[0-9]*]] = open_existential_ref [[EXISTVAL]]
+  // CHECK:   [[OPT_TMP:%.*]] = alloc_stack $Optional<@callee_owned () -> ()>
+  // CHECK:   dynamic_method_br [[OBJ_SELF]] : $@opened({{.*}}) AnyObject, #X.f!1.foreign, [[HASBB:[a-zA-z0-9]+]], [[NOBB:[a-zA-z0-9]+]]
 
   // Has method BB:
   // CHECK: [[HASBB]]([[UNCURRIED:%[0-9]+]] : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> ()):
-  // CHECK-NEXT: copy_value [[OBJ_SELF]]
-  // CHECK-NEXT: [[PARTIAL:%[0-9]+]] = partial_apply [[UNCURRIED]]([[OBJ_SELF]]) : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> ()
-  // CHECK-NEXT: [[THUNK_PAYLOAD:%.*]] = init_enum_data_addr [[OPTIONAL:%[0-9]+]]
-  // CHECK-NEXT: store [[PARTIAL]] to [init] [[THUNK_PAYLOAD]]
-  // CHECK-NEXT: inject_enum_addr [[OPTIONAL]]{{.*}}some
-  // CHECK-NEXT: br [[CONTBB:[a-zA-Z0-9]+]]
-  
+  // CHECK:   [[OBJ_SELF_COPY:%.*]] = copy_value [[OBJ_SELF]]
+  // CHECK:   [[PARTIAL:%[0-9]+]] = partial_apply [[UNCURRIED]]([[OBJ_SELF_COPY]]) : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> ()
+  // CHECK:   [[THUNK_PAYLOAD:%.*]] = init_enum_data_addr [[OPT_TMP]]
+  // CHECK:   store [[PARTIAL]] to [init] [[THUNK_PAYLOAD]]
+  // CHECK:   inject_enum_addr [[OPT_TMP]] : $*Optional<@callee_owned () -> ()>, #Optional.some!enumelt.1
+  // CHECK:   br [[CONTBB:[a-zA-Z0-9]+]]
+
   // No method BB:
   // CHECK: [[NOBB]]:
-  // CHECK-NEXT: inject_enum_addr [[OPTIONAL]]{{.*}}none
-  // CHECK-NEXT: br [[CONTBB]]
+  // CHECK:   inject_enum_addr [[OPT_TMP]] : {{.*}}, #Optional.none!enumelt
+  // CHECK:   br [[CONTBB]]
 
   // Continuation block
   // CHECK: [[CONTBB]]:
-  // CHECK-NEXT: [[OPT:%.*]] = load [[OPTTEMP]]
-  // CHECK-NEXT: store [[OPT]] to [init] [[PBOPT]] : $*Optional<@callee_owned () -> ()>
-  // CHECK-NEXT: dealloc_stack [[OPTTEMP]]
+  // CHECK:   [[OPT:%.*]] = load [[OPT_TMP]]
+  // CHECK:   store [[OPT]] to [init] [[PBOPT]] : $*Optional<@callee_owned () -> ()>
+  // CHECK:   dealloc_stack [[OPT_TMP]]
   var of: (() -> ())! = obj.f
 
   // Exit
-  // CHECK-NEXT: destroy_value [[OBJ_SELF]] : $@opened({{".*"}}) AnyObject
-  // CHECK-NEXT: destroy_value [[OPTBOX]] : $@box Optional<@callee_owned () -> ()>
-  // CHECK-NEXT: destroy_value [[EXISTBOX]] : $@box AnyObject
-  // CHECK-NEXT: destroy_value %0
-  // CHECK-NEXT: [[RESULT:%[0-9]+]] = tuple ()
-  // CHECK-NEXT: return [[RESULT]] : $()
+  // CHECK:   destroy_value [[OBJ_SELF]] : $@opened({{".*"}}) AnyObject
+  // CHECK:   destroy_value [[OPTBOX]] : $@box Optional<@callee_owned () -> ()>
+  // CHECK:   destroy_value [[EXISTBOX]] : $@box AnyObject
+  // CHECK:   destroy_value %0
+  // CHECK:   [[RESULT:%[0-9]+]] = tuple ()
+  // CHECK:   return [[RESULT]] : $()
 }
 
 // CHECK-LABEL: sil hidden @_TF14dynamic_lookup20forced_without_outer
@@ -106,18 +122,19 @@ func forced_without_outer(_ obj: AnyObject) {
 // CHECK-LABEL: sil hidden @_TF14dynamic_lookup20opt_to_static_method
 func opt_to_static_method(_ obj: AnyObject) {
   var obj = obj
-  // CHECK: [[ENTRY:[A-Za-z0-9]+]]([[OBJ:%[0-9]+]] : $AnyObject):
-  // CHECK: [[OBJBOX:%[0-9]+]] = alloc_box $@box AnyObject
-  // CHECK-NEXT: [[PBOBJ:%[0-9]+]] = project_box [[OBJBOX]]
-  // CHECK: store [[OBJ]] to [init] [[PBOBJ]] : $*AnyObject
-  // CHECK-NEXT: [[OPTBOX:%[0-9]+]] = alloc_box $@box Optional<@callee_owned () -> ()>
-  // CHECK-NEXT: [[PBO:%.*]] = project_box [[OPTBOX]]
-  // CHECK-NEXT: [[OBJCOPY:%[0-9]+]] = load [[PBOBJ]] : $*AnyObject
-  // CHECK-NEXT: [[OBJMETA:%[0-9]+]] = existential_metatype $@thick AnyObject.Type, [[OBJCOPY]] : $AnyObject
-  // CHECK-NEXT: [[OPENMETA:%[0-9]+]] = open_existential_metatype [[OBJMETA]] : $@thick AnyObject.Type to $@thick (@opened
-  // CHECK-NEXT: [[OBJCMETA:%[0-9]+]] = thick_to_objc_metatype [[OPENMETA]]
-  // CHECK-NEXT: [[OPTTEMP:%.*]] = alloc_stack $Optional<@callee_owned () -> ()>
-  // CHECK-NEXT: dynamic_method_br [[OBJCMETA]] : $@objc_metatype (@opened({{".*"}}) AnyObject).Type, #X.staticF!1.foreign, [[HASMETHOD:[A-Za-z0-9_]+]], [[NOMETHOD:[A-Za-z0-9_]+]]
+  // CHECK: bb0([[OBJ:%[0-9]+]] : $AnyObject):
+  // CHECK:   [[OBJBOX:%[0-9]+]] = alloc_box $@box AnyObject
+  // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJBOX]]
+  // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
+  // CHECK:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
+  // CHECK:   [[OPTBOX:%[0-9]+]] = alloc_box $@box Optional<@callee_owned () -> ()>
+  // CHECK:   [[PBO:%.*]] = project_box [[OPTBOX]]
+  // CHECK:   [[OBJCOPY:%[0-9]+]] = load [[PBOBJ]] : $*AnyObject
+  // CHECK:   [[OBJMETA:%[0-9]+]] = existential_metatype $@thick AnyObject.Type, [[OBJCOPY]] : $AnyObject
+  // CHECK:   [[OPENMETA:%[0-9]+]] = open_existential_metatype [[OBJMETA]] : $@thick AnyObject.Type to $@thick (@opened
+  // CHECK:   [[OBJCMETA:%[0-9]+]] = thick_to_objc_metatype [[OPENMETA]]
+  // CHECK:   [[OPTTEMP:%.*]] = alloc_stack $Optional<@callee_owned () -> ()>
+  // CHECK:   dynamic_method_br [[OBJCMETA]] : $@objc_metatype (@opened({{".*"}}) AnyObject).Type, #X.staticF!1.foreign, [[HASMETHOD:[A-Za-z0-9_]+]], [[NOMETHOD:[A-Za-z0-9_]+]]
   var optF: (() -> ())! = type(of: obj).staticF
 }
 
@@ -125,84 +142,89 @@ func opt_to_static_method(_ obj: AnyObject) {
 func opt_to_property(_ obj: AnyObject) {
   var obj = obj
   // CHECK: bb0([[OBJ:%[0-9]+]] : $AnyObject):
-  // CHECK: [[OBJ_BOX:%[0-9]+]] = alloc_box $@box AnyObject
-  // CHECK-NEXT: [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
-  // CHECK: store [[OBJ]] to [init] [[PBOBJ]] : $*AnyObject
-  // CHECK-NEXT: [[INT_BOX:%[0-9]+]] = alloc_box $@box Int
-  // CHECK-NEXT: project_box [[INT_BOX]]
-  // CHECK-NEXT: [[OBJ:%[0-9]+]] = load [[PBOBJ]] : $*AnyObject
-  // CHECK-NEXT: copy_value [[OBJ]] : $AnyObject
-  // CHECK-NEXT: [[RAWOBJ_SELF:%[0-9]+]] = open_existential_ref [[OBJ]] : $AnyObject
-  // CHECK-NEXT: [[OPTTEMP:%.*]] = alloc_stack $Optional<Int>
-  // CHECK-NEXT: dynamic_method_br [[RAWOBJ_SELF]] : $@opened({{.*}}) AnyObject, #X.value!getter.1.foreign, bb1, bb2
+  // CHECK:   [[OBJ_BOX:%[0-9]+]] = alloc_box $@box AnyObject
+  // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
+  // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
+  // CHECK:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
+  // CHECK:   [[INT_BOX:%[0-9]+]] = alloc_box $@box Int
+  // CHECK:   project_box [[INT_BOX]]
+  // CHECK:   [[OBJ:%[0-9]+]] = load [[PBOBJ]] : $*AnyObject
+  // CHECK:   copy_value [[OBJ]] : $AnyObject
+  // CHECK:   [[RAWOBJ_SELF:%[0-9]+]] = open_existential_ref [[OBJ]] : $AnyObject
+  // CHECK:   [[OPTTEMP:%.*]] = alloc_stack $Optional<Int>
+  // CHECK:   dynamic_method_br [[RAWOBJ_SELF]] : $@opened({{.*}}) AnyObject, #X.value!getter.1.foreign, bb1, bb2
   // CHECK: bb1([[METHOD:%[0-9]+]] : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> Int):
-  // CHECK-NEXT: copy_value [[RAWOBJ_SELF]]
-  // CHECK-NEXT: [[BOUND_METHOD:%[0-9]+]] = partial_apply [[METHOD]]([[RAWOBJ_SELF]]) : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> Int
-  // CHECK-NEXT: [[VALUE:%[0-9]+]] = apply [[BOUND_METHOD]]() : $@callee_owned () -> Int
-  // CHECK-NEXT: [[VALUETEMP:%.*]] = init_enum_data_addr [[OPTTEMP]]
-  // CHECK-NEXT: store [[VALUE]] to [trivial] [[VALUETEMP]]
-  // CHECK-NEXT: inject_enum_addr [[OPTTEMP]]{{.*}}some
-  // CHECK-NEXT: br bb3
+  // CHECK:   [[RAWOBJ_SELF_COPY:%.*]] = copy_value [[RAWOBJ_SELF]]
+  // CHECK:   [[BOUND_METHOD:%[0-9]+]] = partial_apply [[METHOD]]([[RAWOBJ_SELF_COPY]]) : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> Int
+  // CHECK:   [[VALUE:%[0-9]+]] = apply [[BOUND_METHOD]]() : $@callee_owned () -> Int
+  // CHECK:   [[VALUETEMP:%.*]] = init_enum_data_addr [[OPTTEMP]]
+  // CHECK:   store [[VALUE]] to [trivial] [[VALUETEMP]]
+  // CHECK:   inject_enum_addr [[OPTTEMP]]{{.*}}some
+  // CHECK:   br bb3
   var i: Int = obj.value!
 }
+// CHECK: } // end sil function '_TF14dynamic_lookup15opt_to_property{{.*}}'
 
 // CHECK-LABEL: sil hidden @_TF14dynamic_lookup19direct_to_subscript
 func direct_to_subscript(_ obj: AnyObject, i: Int) {
   var obj = obj
   var i = i
   // CHECK: bb0([[OBJ:%[0-9]+]] : $AnyObject, [[I:%[0-9]+]] : $Int):
-  // CHECK: [[OBJ_BOX:%[0-9]+]] = alloc_box $@box AnyObject
-  // CHECK-NEXT: [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
-  // CHECK: store [[OBJ]] to [init] [[PBOBJ]] : $*AnyObject
-  // CHECK-NEXT: [[I_BOX:%[0-9]+]] = alloc_box $@box Int
-  // CHECK-NEXT: [[PBI:%.*]] = project_box [[I_BOX]]
-  // CHECK-NEXT: store [[I]] to [trivial] [[PBI]] : $*Int
-  // CHECK-NEXT: alloc_box $@box Int
-  // CHECK-NEXT: project_box
-  // CHECK-NEXT: [[OBJ:%[0-9]+]] = load [[PBOBJ]] : $*AnyObject
-  // CHECK-NEXT: copy_value [[OBJ]] : $AnyObject
-  // CHECK-NEXT: [[OBJ_REF:%[0-9]+]] = open_existential_ref [[OBJ]] : $AnyObject to $@opened({{.*}}) AnyObject
-  // CHECK-NEXT: [[I:%[0-9]+]] = load [[PBI]] : $*Int
-  // CHECK-NEXT: [[OPTTEMP:%.*]] = alloc_stack $Optional<Int>
-  // CHECK-NEXT: dynamic_method_br [[OBJ_REF]] : $@opened({{.*}}) AnyObject, #X.subscript!getter.1.foreign, bb1, bb2
+  // CHECK:   [[OBJ_BOX:%[0-9]+]] = alloc_box $@box AnyObject
+  // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
+  // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
+  // CHECK:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
+  // CHECK:   [[I_BOX:%[0-9]+]] = alloc_box $@box Int
+  // CHECK:   [[PBI:%.*]] = project_box [[I_BOX]]
+  // CHECK:   store [[I]] to [trivial] [[PBI]] : $*Int
+  // CHECK:   alloc_box $@box Int
+  // CHECK:   project_box
+  // CHECK:   [[OBJ:%[0-9]+]] = load [[PBOBJ]] : $*AnyObject
+  // CHECK:   copy_value [[OBJ]] : $AnyObject
+  // CHECK:   [[OBJ_REF:%[0-9]+]] = open_existential_ref [[OBJ]] : $AnyObject to $@opened({{.*}}) AnyObject
+  // CHECK:   [[I:%[0-9]+]] = load [[PBI]] : $*Int
+  // CHECK:   [[OPTTEMP:%.*]] = alloc_stack $Optional<Int>
+  // CHECK:   dynamic_method_br [[OBJ_REF]] : $@opened({{.*}}) AnyObject, #X.subscript!getter.1.foreign, bb1, bb2
 
   // CHECK: bb1([[GETTER:%[0-9]+]] : $@convention(objc_method) (Int, @opened({{.*}}) AnyObject) -> Int):
-  // CHECK-NEXT: copy_value [[OBJ_REF]]
-  // CHECK-NEXT: [[GETTER_WITH_SELF:%[0-9]+]] = partial_apply [[GETTER]]([[OBJ_REF]]) : $@convention(objc_method) (Int, @opened({{.*}}) AnyObject) -> Int
-  // CHECK-NEXT: [[RESULT:%[0-9]+]] = apply [[GETTER_WITH_SELF]]([[I]]) : $@callee_owned (Int) -> Int
-  // CHECK-NEXT: [[RESULTTEMP:%.*]] = init_enum_data_addr [[OPTTEMP]]
-  // CHECK-NEXT: store [[RESULT]] to [trivial] [[RESULTTEMP]]
-  // CHECK-NEXT: inject_enum_addr [[OPTTEMP]]{{.*}}some
-  // CHECK-NEXT: br bb3
+  // CHECK:   [[OBJ_REF_COPY:%.*]] = copy_value [[OBJ_REF]]
+  // CHECK:   [[GETTER_WITH_SELF:%[0-9]+]] = partial_apply [[GETTER]]([[OBJ_REF_COPY]]) : $@convention(objc_method) (Int, @opened({{.*}}) AnyObject) -> Int
+  // CHECK:   [[RESULT:%[0-9]+]] = apply [[GETTER_WITH_SELF]]([[I]]) : $@callee_owned (Int) -> Int
+  // CHECK:   [[RESULTTEMP:%.*]] = init_enum_data_addr [[OPTTEMP]]
+  // CHECK:   store [[RESULT]] to [trivial] [[RESULTTEMP]]
+  // CHECK:   inject_enum_addr [[OPTTEMP]]{{.*}}some
+  // CHECK:   br bb3
   var x: Int = obj[i]!
 }
+// CHECK: } // end sil function '_TF14dynamic_lookup19direct_to_subscript{{.*}}'
 
 // CHECK-LABEL: sil hidden @_TF14dynamic_lookup16opt_to_subscript
 func opt_to_subscript(_ obj: AnyObject, i: Int) {
   var obj = obj
   var i = i
   // CHECK: bb0([[OBJ:%[0-9]+]] : $AnyObject, [[I:%[0-9]+]] : $Int):
-  // CHECK: [[OBJ_BOX:%[0-9]+]] = alloc_box $@box AnyObject
-  // CHECK-NEXT: [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
-  // CHECK: store [[OBJ]] to [init] [[PBOBJ]] : $*AnyObject
-  // CHECK-NEXT: [[I_BOX:%[0-9]+]] = alloc_box $@box Int
-  // CHECK-NEXT: [[PBI:%.*]] = project_box [[I_BOX]]
-  // CHECK-NEXT: store [[I]] to [trivial] [[PBI]] : $*Int
-  // CHECK-NEXT: [[OBJ:%[0-9]+]] = load [[PBOBJ]] : $*AnyObject
-  // CHECK-NEXT: copy_value [[OBJ]] : $AnyObject
-  // CHECK-NEXT: [[OBJ_REF:%[0-9]+]] = open_existential_ref [[OBJ]] : $AnyObject to $@opened({{.*}}) AnyObject
-  // CHECK-NEXT: [[I:%[0-9]+]] = load [[PBI]] : $*Int
-  // CHECK-NEXT: [[OPTTEMP:%.*]] = alloc_stack $Optional<Int>
-  // CHECK-NEXT: dynamic_method_br [[OBJ_REF]] : $@opened({{.*}}) AnyObject, #X.subscript!getter.1.foreign, bb1, bb2
+  // CHECK:   [[OBJ_BOX:%[0-9]+]] = alloc_box $@box AnyObject
+  // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
+  // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
+  // CHECK:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
+  // CHECK:   [[I_BOX:%[0-9]+]] = alloc_box $@box Int
+  // CHECK:   [[PBI:%.*]] = project_box [[I_BOX]]
+  // CHECK:   store [[I]] to [trivial] [[PBI]] : $*Int
+  // CHECK:   [[OBJ:%[0-9]+]] = load [[PBOBJ]] : $*AnyObject
+  // CHECK:   copy_value [[OBJ]] : $AnyObject
+  // CHECK:   [[OBJ_REF:%[0-9]+]] = open_existential_ref [[OBJ]] : $AnyObject to $@opened({{.*}}) AnyObject
+  // CHECK:   [[I:%[0-9]+]] = load [[PBI]] : $*Int
+  // CHECK:   [[OPTTEMP:%.*]] = alloc_stack $Optional<Int>
+  // CHECK:   dynamic_method_br [[OBJ_REF]] : $@opened({{.*}}) AnyObject, #X.subscript!getter.1.foreign, bb1, bb2
 
   // CHECK: bb1([[GETTER:%[0-9]+]] : $@convention(objc_method) (Int, @opened({{.*}}) AnyObject) -> Int):
-  // CHECK-NEXT: copy_value [[OBJ_REF]]
-  // CHECK-NEXT: [[GETTER_WITH_SELF:%[0-9]+]] = partial_apply [[GETTER]]([[OBJ_REF]]) : $@convention(objc_method) (Int, @opened({{.*}}) AnyObject) -> Int
-  // CHECK-NEXT: [[RESULT:%[0-9]+]] = apply [[GETTER_WITH_SELF]]([[I]]) : $@callee_owned (Int) -> Int
-  // CHECK-NEXT: [[RESULTTEMP:%.*]] = init_enum_data_addr [[OPTTEMP]]
-  // CHECK-NEXT: store [[RESULT]] to [trivial] [[RESULTTEMP]]
-  // CHECK-NEXT: inject_enum_addr [[OPTTEMP]]
-  // CHECK-NEXT: br bb3
+  // CHECK:   [[OBJ_REF_COPY:%.*]] = copy_value [[OBJ_REF]]
+  // CHECK:   [[GETTER_WITH_SELF:%[0-9]+]] = partial_apply [[GETTER]]([[OBJ_REF_COPY]]) : $@convention(objc_method) (Int, @opened({{.*}}) AnyObject) -> Int
+  // CHECK:   [[RESULT:%[0-9]+]] = apply [[GETTER_WITH_SELF]]([[I]]) : $@callee_owned (Int) -> Int
+  // CHECK:   [[RESULTTEMP:%.*]] = init_enum_data_addr [[OPTTEMP]]
+  // CHECK:   store [[RESULT]] to [trivial] [[RESULTTEMP]]
+  // CHECK:   inject_enum_addr [[OPTTEMP]]
+  // CHECK:   br bb3
   obj[i]
 }
 
@@ -210,15 +232,16 @@ func opt_to_subscript(_ obj: AnyObject, i: Int) {
 func downcast(_ obj: AnyObject) -> X {
   var obj = obj
   // CHECK: bb0([[OBJ:%[0-9]+]] : $AnyObject):
-  // CHECK: [[OBJ_BOX:%[0-9]+]] = alloc_box $@box AnyObject
-  // CHECK-NEXT: [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
-  // CHECK: store [[OBJ]] to [init] [[PBOBJ]] : $*AnyObject
-  // CHECK-NEXT: [[OBJ:%[0-9]+]] = load [[PBOBJ]] : $*AnyObject
-  // CHECK-NEXT: copy_value [[OBJ]] : $AnyObject
-  // CHECK-NEXT: [[X:%[0-9]+]] = unconditional_checked_cast [[OBJ]] : $AnyObject to $X
-  // CHECK-NEXT: destroy_value [[OBJ_BOX]] : $@box AnyObject
-  // CHECK-NEXT: destroy_value %0
-  // CHECK-NEXT: return [[X]] : $X
+  // CHECK:   [[OBJ_BOX:%[0-9]+]] = alloc_box $@box AnyObject
+  // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
+  // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
+  // CHECK:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
+  // CHECK:   [[OBJ:%[0-9]+]] = load [[PBOBJ]] : $*AnyObject
+  // CHECK:   copy_value [[OBJ]] : $AnyObject
+  // CHECK:   [[X:%[0-9]+]] = unconditional_checked_cast [[OBJ]] : $AnyObject to $X
+  // CHECK:   destroy_value [[OBJ_BOX]] : $@box AnyObject
+  // CHECK:   destroy_value %0
+  // CHECK:   return [[X]] : $X
   return obj as! X
 }
 
@@ -234,12 +257,13 @@ func downcast(_ obj: AnyObject) -> X {
 // CHECK:        dynamic_method_br [[SELF:%.*]] : $@opened("{{.*}}") Fruit, #Fruit.juice!getter.1.foreign, bb1, bb2
 
 // CHECK: bb1([[FN:%.*]] : $@convention(objc_method) (@opened("{{.*}}") Fruit) -> @autoreleased Juice):
-// CHECK:        [[METHOD:%.*]] = partial_apply [[FN]]([[SELF]]) : $@convention(objc_method) (@opened("{{.*}}") Fruit) -> @autoreleased Juice
-// CHECK:        [[RESULT:%.*]] = apply [[METHOD]]() : $@callee_owned () -> @owned Juice
-// CHECK:        [[PAYLOAD:%.*]] = init_enum_data_addr [[BOX]] : $*Optional<Juice>, #Optional.some!enumelt.1
-// CHECK:        store [[RESULT]] to [init] [[PAYLOAD]]
-// CHECK:        inject_enum_addr [[BOX]] : $*Optional<Juice>, #Optional.some!enumelt.1
-// CHECK:        br bb3
+// CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
+// CHECK:   [[METHOD:%.*]] = partial_apply [[FN]]([[SELF_COPY]]) : $@convention(objc_method) (@opened("{{.*}}") Fruit) -> @autoreleased Juice
+// CHECK:   [[RESULT:%.*]] = apply [[METHOD]]() : $@callee_owned () -> @owned Juice
+// CHECK:   [[PAYLOAD:%.*]] = init_enum_data_addr [[BOX]] : $*Optional<Juice>, #Optional.some!enumelt.1
+// CHECK:   store [[RESULT]] to [init] [[PAYLOAD]]
+// CHECK:   inject_enum_addr [[BOX]] : $*Optional<Juice>, #Optional.some!enumelt.1
+// CHECK:   br bb3
 
 // CHECK: bb2:
 // CHECK:        inject_enum_addr [[BOX]] : $*Optional<Juice>, #Optional.none!enumelt

--- a/test/SILGen/extensions_objc.swift
+++ b/test/SILGen/extensions_objc.swift
@@ -27,5 +27,7 @@ func extensionMethodCurrying(_ x: Foo) {
 
 // CHECK-LABEL: sil shared [thunk] @_TFC15extensions_objc3Foo3kayF
 // CHECK:         function_ref @_TTDFC15extensions_objc3Foo3kayf
-// CHECK:       sil shared [transparent] [thunk] @_TTDFC15extensions_objc3Foo3kayf
-// CHECK:         class_method [volatile] %0 : $Foo, #Foo.kay!1.foreign
+// CHECK-LABEL: sil shared [transparent] [thunk] @_TTDFC15extensions_objc3Foo3kayf
+// CHECK:         bb0([[SELF:%.*]] : $Foo):
+// CHECK:           [[SELF_COPY:%.*]] = copy_value [[SELF]]
+// CHECK:           class_method [volatile] [[SELF_COPY]] : $Foo, #Foo.kay!1.foreign

--- a/test/SILGen/function_conversion.swift
+++ b/test/SILGen/function_conversion.swift
@@ -24,8 +24,12 @@ func cToBlock(_ arg: @escaping @convention(c) (Int) -> Int) -> @convention(block
 // ==== Throws variance
 
 // CHECK-LABEL: sil hidden @_TF19function_conversion12funcToThrowsFFT_T_FzT_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> @owned @callee_owned () -> @error Error
-// CHECK:         [[FUNC:%.*]] = convert_function %0 : $@callee_owned () -> () to $@callee_owned () -> @error Error
-// CHECK:         return [[FUNC]]
+// CHECK: bb0([[ARG:%.*]] : $@callee_owned () -> ()):
+// CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:   [[FUNC:%.*]] = convert_function [[ARG_COPY]] : $@callee_owned () -> () to $@callee_owned () -> @error Error
+// CHECK:   destroy_value [[ARG]]
+// CHECK:   return [[FUNC]]
+// CHECK: } // end sil function '_TF19function_conversion12funcToThrowsFFT_T_FzT_T_'
 func funcToThrows(_ x: @escaping () -> ()) -> () throws -> () {
   return x
 }
@@ -51,16 +55,23 @@ func thinToThrows() {
 class Feral {}
 class Domesticated : Feral {}
 
-// CHECK-LABEL: sil hidden @_TF19function_conversion12funcToUpcastFFT_CS_12DomesticatedFT_CS_5Feral : $@convention(thin) (@owned @callee_owned () -> @owned Domesticated) -> @owned @callee_owned () -> @owned Feral
-// CHECK:         [[FUNC:%.*]] = convert_function %0 : $@callee_owned () -> @owned Domesticated to $@callee_owned () -> @owned Feral
-// CHECK:         return [[FUNC]]
+// CHECK-LABEL: sil hidden @_TF19function_conversion12funcToUpcastFFT_CS_12DomesticatedFT_CS_5Feral : $@convention(thin) (@owned @callee_owned () -> @owned Domesticated) -> @owned @callee_owned () -> @owned Feral {
+// CHECK: bb0([[ARG:%.*]] : $@callee_owned () -> @owned Domesticated):
+// CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:   [[FUNC:%.*]] = convert_function [[ARG_COPY]] : $@callee_owned () -> @owned Domesticated to $@callee_owned () -> @owned Feral
+// CHECK:   destroy_value [[ARG]]
+// CHECK:   return [[FUNC]]
+// CHECK: } // end sil function '_TF19function_conversion12funcToUpcastFFT_CS_12DomesticatedFT_CS_5Feral'
 func funcToUpcast(_ x: @escaping () -> Domesticated) -> () -> Feral {
   return x
 }
 
 // CHECK-LABEL: sil hidden @_TF19function_conversion12funcToUpcastFFCS_5FeralT_FCS_12DomesticatedT_ : $@convention(thin) (@owned @callee_owned (@owned Feral) -> ()) -> @owned @callee_owned (@owned Domesticated) -> ()
-// CHECK:         [[FUNC:%.*]] = convert_function %0 : $@callee_owned (@owned Feral) -> () to $@callee_owned (@owned Domesticated) -> (){{.*}} // user: %3
-// CHECK:         return [[FUNC]]
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:   [[FUNC:%.*]] = convert_function [[ARG_COPY]] : $@callee_owned (@owned Feral) -> () to $@callee_owned (@owned Domesticated) -> (){{.*}}
+// CHECK:   destroy_value [[ARG]]
+// CHECK:   return [[FUNC]]
 func funcToUpcast(_ x: @escaping (Feral) -> ()) -> (Domesticated) -> () {
   return x
 }
@@ -324,9 +335,14 @@ func convUpcastMetatype(_ c4: @escaping (Parent.Type, Trivial?) -> Child.Type,
 // ==== Function to existential -- make sure we maximally abstract it
 
 // CHECK-LABEL: sil hidden @_TF19function_conversion19convFuncExistentialFFP_FSiSiT_ : $@convention(thin) (@owned @callee_owned (@in Any) -> @owned @callee_owned (Int) -> Int) -> ()
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:   [[REABSTRACT_THUNK:%.*]] = function_ref @_TTRXFo_iP__oXFo_dSi_dSi__XFo_oXFo_dSi_dSi__iP__
+// CHECK:   [[PA:%.*]] = partial_apply [[REABSTRACT_THUNK]]([[ARG_COPY]])
+// CHECK:   destroy_value [[PA]]
+// CHECK:   destroy_value [[ARG]]
+// CHECK: } // end sil function '_TF19function_conversion19convFuncExistentialFFP_FSiSiT_'
 func convFuncExistential(_ f1: @escaping (Any) -> (Int) -> Int) {
-// CHECK:         function_ref @_TTRXFo_iP__oXFo_dSi_dSi__XFo_oXFo_dSi_dSi__iP__
-// CHECK:         partial_apply %3(%0)
   let _: ((Int) -> Int) -> Any = f1
 }
 

--- a/test/SILGen/function_conversion_objc.swift
+++ b/test/SILGen/function_conversion_objc.swift
@@ -60,8 +60,9 @@ func funcToBlock(_ x: @escaping () -> ()) -> @convention(block) () -> () {
 
 // CHECK-LABEL: sil hidden @_TF24function_conversion_objc11blockToFuncFbT_T_FT_T_ : $@convention(thin) (@owned @convention(block) () -> ()) -> @owned @callee_owned () -> ()
 // CHECK:         [[COPIED:%.*]] = copy_block %0
+// CHECK:         [[COPIED_2:%.*]] = copy_value [[COPIED]]
 // CHECK:         [[THUNK:%.*]] = function_ref @_TTRXFdCb___XFo___
-// CHECK:         [[FUNC:%.*]] = partial_apply [[THUNK]]([[COPIED]])
+// CHECK:         [[FUNC:%.*]] = partial_apply [[THUNK]]([[COPIED_2]])
 // CHECK:         return [[FUNC]]
 func blockToFunc(_ x: @escaping @convention(block) () -> ()) -> () -> () {
   return x

--- a/test/SILGen/generic_closures.swift
+++ b/test/SILGen/generic_closures.swift
@@ -185,9 +185,10 @@ class Class {}
 protocol HasClassAssoc { associatedtype Assoc : Class }
 
 // CHECK-LABEL: sil hidden @_TF16generic_closures34captures_class_constrained_genericuRxS_13HasClassAssocrFTx1fFwx5AssocwxS1__T_
-// CHECK: bb0(%0 : $*T, %1 : $@callee_owned (@owned T.Assoc) -> @owned T.Assoc):
+// CHECK: bb0([[ARG1:%.*]] : $*T, [[ARG2:%.*]] : $@callee_owned (@owned T.Assoc) -> @owned T.Assoc):
 // CHECK: [[GENERIC_FN:%.*]] = function_ref @_TFF16generic_closures34captures_class_constrained_genericuRxS_13HasClassAssocrFTx1fFwx5AssocwxS1__T_U_FT_FQQ_5AssocS2_
-// CHECK: [[CONCRETE_FN:%.*]] = partial_apply [[GENERIC_FN]]<T, T.Assoc>(%1)
+// CHECK: [[ARG2_COPY:%.*]] = copy_value [[ARG2]]
+// CHECK: [[CONCRETE_FN:%.*]] = partial_apply [[GENERIC_FN]]<T, T.Assoc>([[ARG2_COPY]])
 
 func captures_class_constrained_generic<T : HasClassAssoc>(_ x: T, f: @escaping (T.Assoc) -> T.Assoc) {
   let _: () -> (T.Assoc) -> T.Assoc = { f }

--- a/test/SILGen/generic_property_base_lifetime.swift
+++ b/test/SILGen/generic_property_base_lifetime.swift
@@ -13,22 +13,29 @@ protocol ProtocolB {
 }
 
 
-// CHECK-LABEL: sil hidden @_TF30generic_property_base_lifetime21getIntPropExistentialFPS_9ProtocolA_Si
-// CHECK:         [[PROJECTION:%.*]] = open_existential_ref %0
-// CHECK:         copy_value [[PROJECTION]]
-// CHECK:         apply {{%.*}}<@opened{{.*}}>([[PROJECTION]])
-// CHECK:         destroy_value %0
-// CHECK-NOT:     destroy_value
+// CHECK-LABEL: sil hidden @_TF30generic_property_base_lifetime21getIntPropExistentialFPS_9ProtocolA_Si : $@convention(thin) (@owned ProtocolA) -> Int {
+// CHECK: bb0([[ARG:%.*]] : $ProtocolA):
+// CHECK:   [[PROJECTION:%.*]] = open_existential_ref [[ARG]]
+// CHECK:   [[PROJECTION_COPY:%.*]] = copy_value [[PROJECTION]]
+// CHECK:   [[WITNESS_METHOD:%.*]] = witness_method $@opened({{.*}}) ProtocolA, #ProtocolA.intProp!getter.1, [[PROJECTION]]
+// CHECK:   [[RESULT:%.*]] = apply [[WITNESS_METHOD]]<@opened{{.*}}>([[PROJECTION_COPY]])
+// CHECK:   destroy_value [[PROJECTION_COPY]]
+// CHECK:   destroy_value [[ARG]]
+// CHECK:   return [[RESULT]]
+// CHECK: } // end sil function '_TF30generic_property_base_lifetime21getIntPropExistentialFPS_9ProtocolA_Si'
 func getIntPropExistential(_ a: ProtocolA) -> Int {
   return a.intProp
 }
 
-// CHECK-LABEL: sil hidden @_TF30generic_property_base_lifetime21setIntPropExistentialFPS_9ProtocolA_T_
-// CHECK:         [[PROJECTION:%.*]] = open_existential_ref %0
-// CHECK:         copy_value [[PROJECTION]]
-// CHECK:         apply {{%.*}}<@opened{{.*}}>({{%.*}}, [[PROJECTION]])
-// CHECK:         destroy_value %0
-// CHECK_NOT:     destroy_value
+// CHECK-LABEL: sil hidden @_TF30generic_property_base_lifetime21setIntPropExistentialFPS_9ProtocolA_T_ : $@convention(thin) (@owned ProtocolA) -> () {
+// CHECK: bb0([[ARG:%.*]] : $ProtocolA):
+// CHECK:   [[PROJECTION:%.*]] = open_existential_ref [[ARG]]
+// CHECK:   [[PROJECTION_COPY:%.*]] = copy_value [[PROJECTION]]
+// CHECK:   [[WITNESS_METHOD:%.*]] = witness_method $@opened({{.*}}) ProtocolA, #ProtocolA.intProp!setter.1, [[PROJECTION]]
+// CHECK:   apply [[WITNESS_METHOD]]<@opened{{.*}}>({{%.*}}, [[PROJECTION_COPY]])
+// CHECK:   destroy_value [[PROJECTION_COPY]]
+// CHECK:   destroy_value [[ARG]]
+// CHECK: } // end sil function '_TF30generic_property_base_lifetime21setIntPropExistentialFPS_9ProtocolA_T_'
 func setIntPropExistential(_ a: ProtocolA) {
   a.intProp = 0
 }
@@ -72,28 +79,28 @@ func getIntPropGeneric<T: ProtocolB>(_ a: T) -> Int {
   return a.intProp
 }
 
-// CHECK-LABEL: sil hidden @_TF30generic_property_base_lifetime21getIntPropExistentialFPS_9ProtocolO_Si
-// CHECK:         debug_value
-// CHECK-NEXT:    [[PROJECTION:%.*]] = open_existential_ref %0
-// CHECK-NEXT:    copy_value [[PROJECTION]]
-// CHECK-NEXT:    [[METHOD:%.*]] = witness_method
-// CHECK-NEXT:    apply [[METHOD]]<@opened{{.*}}>([[PROJECTION]])
-// CHECK-NEXT:    destroy_value [[PROJECTION]]
-// CHECK-NEXT:    destroy_value %0
-// CHECK-NEXT:    return
+// CHECK-LABEL: sil hidden @_TF30generic_property_base_lifetime21getIntPropExistentialFPS_9ProtocolO_Si : $@convention(thin) (@owned ProtocolO) -> Int {
+// CHECK: bb0([[ARG:%.*]] : $ProtocolO):
+// CHECK:  [[PROJECTION:%.*]] = open_existential_ref [[ARG]]
+// CHECK:  [[PROJECTION_COPY:%.*]] = copy_value [[PROJECTION]]
+// CHECK:  [[METHOD:%.*]] = witness_method [volatile] $@opened({{.*}}) ProtocolO, #ProtocolO.intProp!getter.1.foreign, [[PROJECTION]]
+// CHECK:  apply [[METHOD]]<@opened{{.*}}>([[PROJECTION_COPY]])
+// CHECK:  destroy_value [[PROJECTION_COPY]]
+// CHECK:  destroy_value [[ARG]]
+// CHECK: } // end sil function '_TF30generic_property_base_lifetime21getIntPropExistentialFPS_9ProtocolO_Si'
 func getIntPropExistential(_ a: ProtocolO) -> Int {
   return a.intProp
 }
 
-// CHECK-LABEL: sil hidden @_TF30generic_property_base_lifetime21setIntPropExistentialFPS_9ProtocolO_T_
-// CHECK:         [[PROJECTION:%.*]] = open_existential_ref %0
-// CHECK-NEXT:    copy_value [[PROJECTION]]
-// CHECK:    [[METHOD:%.*]] = witness_method
-// CHECK-NEXT:    apply [[METHOD]]<@opened{{.*}}>({{.*}}, [[PROJECTION]])
-// CHECK-NEXT:    destroy_value [[PROJECTION]]
-// CHECK-NEXT:    destroy_value %0
-// CHECK-NEXT:    tuple ()
-// CHECK-NEXT:    return
+// CHECK-LABEL: sil hidden @_TF30generic_property_base_lifetime21setIntPropExistentialFPS_9ProtocolO_T_ : $@convention(thin) (@owned ProtocolO) -> () {
+// CHECK: bb0([[ARG:%.*]] : $ProtocolO):
+// CHECK:   [[PROJECTION:%.*]] = open_existential_ref [[ARG]]
+// CHECK:   [[PROJECTION_COPY:%.*]] = copy_value [[PROJECTION]]
+// CHECK:   [[METHOD:%.*]] = witness_method [volatile] $@opened({{.*}}) ProtocolO, #ProtocolO.intProp!setter.1.foreign, [[PROJECTION]]
+// CHECK:   apply [[METHOD]]<@opened{{.*}}>({{.*}}, [[PROJECTION_COPY]])
+// CHECK:   destroy_value [[PROJECTION_COPY]]
+// CHECK:   destroy_value [[ARG]]
+// CHECK: } // end sil function '_TF30generic_property_base_lifetime21setIntPropExistentialFPS_9ProtocolO_T_'
 func setIntPropExistential(_ a: ProtocolO) {
   a.intProp = 0
 }

--- a/test/SILGen/generic_tuples.swift
+++ b/test/SILGen/generic_tuples.swift
@@ -6,7 +6,8 @@ func dup<T>(_ x: T) -> (T, T) { return (x,x) }
 // CHECK:      ([[RESULT_0:%.*]] : $*T, [[RESULT_1:%.*]] : $*T, [[XVAR:%.*]] : $*T):
 // CHECK-NEXT: debug_value_addr [[XVAR]] : $*T, let, name "x"
 // CHECK-NEXT: copy_addr [[XVAR]] to [initialization] [[RESULT_0]]
-// CHECK-NEXT: copy_addr [take] [[XVAR]] to [initialization] [[RESULT_1]]
+// CHECK-NEXT: copy_addr [[XVAR]] to [initialization] [[RESULT_1]]
+// CHECK-NEXT: destroy_addr [[XVAR]]
 // CHECK-NEXT: [[T0:%.*]] = tuple ()
 // CHECK-NEXT: return [[T0]]
 

--- a/test/SILGen/guaranteed_closure_context.swift
+++ b/test/SILGen/guaranteed_closure_context.swift
@@ -48,12 +48,12 @@ func guaranteed_captures() {
 
   // -- partial_apply still takes ownership of its arguments.
   // CHECK: [[FN:%.*]] = function_ref [[FN_NAME]]
-  // CHECK: copy_value [[MUTABLE_TRIVIAL_BOX]]
-  // CHECK: copy_value [[MUTABLE_RETAINABLE_BOX]]
-  // CHECK: copy_value [[MUTABLE_ADDRESS_ONLY_BOX]]
-  // CHECK: copy_value [[IMMUTABLE_RETAINABLE]]
+  // CHECK: [[MUTABLE_TRIVIAL_BOX_COPY:%.*]] = copy_value [[MUTABLE_TRIVIAL_BOX]]
+  // CHECK: [[MUTABLE_RETAINABLE_BOX_COPY:%.*]] = copy_value [[MUTABLE_RETAINABLE_BOX]]
+  // CHECK: [[MUTABLE_ADDRESS_ONLY_BOX_COPY:%.*]] = copy_value [[MUTABLE_ADDRESS_ONLY_BOX]]
+  // CHECK: [[IMMUTABLE_RETAINABLE_COPY:%.*]] = copy_value [[IMMUTABLE_RETAINABLE]]
   // CHECK: [[IMMUTABLE_AO_BOX:%.*]] = alloc_box $@box P
-  // CHECK: [[CLOSURE:%.*]] = partial_apply {{.*}}([[MUTABLE_TRIVIAL_BOX]], [[MUTABLE_RETAINABLE_BOX]], [[MUTABLE_ADDRESS_ONLY_BOX]], [[IMMUTABLE_TRIVIAL]], [[IMMUTABLE_RETAINABLE]], [[IMMUTABLE_AO_BOX]])
+  // CHECK: [[CLOSURE:%.*]] = partial_apply {{.*}}([[MUTABLE_TRIVIAL_BOX_COPY]], [[MUTABLE_RETAINABLE_BOX_COPY]], [[MUTABLE_ADDRESS_ONLY_BOX_COPY]], [[IMMUTABLE_TRIVIAL]], [[IMMUTABLE_RETAINABLE_COPY]], [[IMMUTABLE_AO_BOX]])
   // CHECK: apply {{.*}}[[CLOSURE]]
 
   // CHECK-NOT: copy_value [[MUTABLE_TRIVIAL_BOX]]

--- a/test/SILGen/implicitly_unwrapped_optional.swift
+++ b/test/SILGen/implicitly_unwrapped_optional.swift
@@ -4,26 +4,33 @@ func foo(f f: (() -> ())!) {
   var f: (() -> ())! = f
   f?()
 }
-// CHECK:    sil hidden @{{.*}}foo{{.*}} : $@convention(thin) (@owned Optional<@callee_owned () -> ()>) -> () {
-// CHECK:    bb0([[T0:%.*]] : $Optional<@callee_owned () -> ()>):
-// CHECK: [[F:%.*]] = alloc_box $@box Optional<@callee_owned () -> ()>
-// CHECK-NEXT: [[PF:%.*]] = project_box [[F]]
-// CHECK: store [[T0]] to [init] [[PF]]
-// CHECK:      [[T1:%.*]] = select_enum_addr [[PF]]
-// CHECK-NEXT: cond_br [[T1]], bb1, bb3
+// CHECK: sil hidden @{{.*}}foo{{.*}} : $@convention(thin) (@owned Optional<@callee_owned () -> ()>) -> () {
+// CHECK: bb0([[T0:%.*]] : $Optional<@callee_owned () -> ()>):
+// CHECK:   [[F:%.*]] = alloc_box $@box Optional<@callee_owned () -> ()>
+// CHECK:   [[PF:%.*]] = project_box [[F]]
+// CHECK:   [[T0_COPY:%.*]] = copy_value [[T0]]
+// CHECK:   store [[T0_COPY]] to [init] [[PF]]
+// CHECK:   [[T1:%.*]] = select_enum_addr [[PF]]
+// CHECK:   cond_br [[T1]], bb1, bb3
 //   If it does, project and load the value out of the implicitly unwrapped
 //   optional...
-// CHECK:    bb1:
-// CHECK-NEXT: [[FN0_ADDR:%.*]] = unchecked_take_enum_data_addr [[PF]]
-// CHECK-NEXT: [[FN0:%.*]] = load [[FN0_ADDR]]
+// CHECK: bb1:
+// CHECK:   [[FN0_ADDR:%.*]] = unchecked_take_enum_data_addr [[PF]]
+// CHECK:   [[FN0:%.*]] = load [[FN0_ADDR]]
 //   .... then call it
-// CHECK:      apply [[FN0]]()
-// CHECK:      br bb2
-//   (first nothing block)
-// CHECK:    bb3:
-// CHECK-NEXT: enum $Optional<()>, #Optional.none!enumelt
-// CHECK-NEXT: br bb2
+// CHECK:   [[FN0_COPY:%.*]] = copy_value [[FN0]]
+// SEMANTIC ARC TODO: On the next line, we should be calling FN0_COPY, not FN0
+// CHECK:   apply [[FN0]]() : $@callee_owned () -> ()
+// CHECK:   br bb2
+// CHECK: bb2(
+// CHECK:   destroy_value [[F]]
+// CHECK:   destroy_value [[T0]]
+// CHECK:   return
+// CHECK: bb3:
+// CHECK:   enum $Optional<()>, #Optional.none!enumelt
+// CHECK:   br bb2
 //   The rest of this is tested in optional.swift
+// } // end sil function '{{.*}}foo{{.*}}'
 
 func wrap<T>(x x: T) -> T! { return x }
 

--- a/test/SILGen/indirect_enum.swift
+++ b/test/SILGen/indirect_enum.swift
@@ -6,9 +6,9 @@ indirect enum TreeA<T> {
   case Branch(left: TreeA<T>, right: TreeA<T>)
 }
 
-// CHECK-LABEL: sil hidden @_TF13indirect_enum11TreeA_casesurFTx1lGOS_5TreeAx_1rGS0_x__T_
+// CHECK-LABEL: sil hidden @_TF13indirect_enum11TreeA_casesurFTx1lGOS_5TreeAx_1rGS0_x__T_ : $@convention(thin) <T> (@in T, @owned TreeA<T>, @owned TreeA<T>) -> () {
 func TreeA_cases<T>(_ t: T, l: TreeA<T>, r: TreeA<T>) {
-
+// CHECK: bb0([[ARG1:%.*]] : $*T, [[ARG2:%.*]] : $TreeA<T>, [[ARG3:%.*]] : $TreeA<T>):
 // CHECK:         [[METATYPE:%.*]] = metatype $@thin TreeA<T>.Type
 // CHECK-NEXT:    [[NIL:%.*]] = enum $TreeA<T>, #TreeA.Nil!enumelt
 // CHECK-NEXT:    destroy_value [[NIL]]
@@ -17,7 +17,7 @@ func TreeA_cases<T>(_ t: T, l: TreeA<T>, r: TreeA<T>) {
 // CHECK-NEXT:    [[METATYPE:%.*]] = metatype $@thin TreeA<T>.Type
 // CHECK-NEXT:    [[BOX:%.*]] = alloc_box $@box T
 // CHECK-NEXT:    [[PB:%.*]] = project_box [[BOX]]
-// CHECK-NEXT:    copy_addr %0 to [initialization] [[PB]]
+// CHECK-NEXT:    copy_addr [[ARG1]] to [initialization] [[PB]]
 // CHECK-NEXT:    [[LEAF:%.*]] = enum $TreeA<T>, #TreeA.Leaf!enumelt.1, [[BOX]]
 // CHECK-NEXT:    destroy_value [[LEAF]]
   let _ = TreeA<T>.Leaf(t)
@@ -27,37 +27,38 @@ func TreeA_cases<T>(_ t: T, l: TreeA<T>, r: TreeA<T>) {
 // CHECK-NEXT:    [[PB:%.*]] = project_box [[BOX]]
 // CHECK-NEXT:    [[LEFT:%.*]] = tuple_element_addr [[PB]] : $*(left: TreeA<T>, right: TreeA<T>), 0
 // CHECK-NEXT:    [[RIGHT:%.*]] = tuple_element_addr [[PB]] : $*(left: TreeA<T>, right: TreeA<T>), 1
-// CHECK-NEXT:    copy_value %1
-// CHECK-NEXT:    store %1 to [init] [[LEFT]]
-// CHECK-NEXT:    copy_value %2
-// CHECK-NEXT:    store %2 to [init] [[RIGHT]]
+// CHECK-NEXT:    [[ARG2_COPY:%.*]] = copy_value [[ARG2]]
+// CHECK-NEXT:    store [[ARG2_COPY]] to [init] [[LEFT]]
+// CHECK-NEXT:    [[ARG3_COPY:%.*]] = copy_value [[ARG3]]
+// CHECK-NEXT:    store [[ARG3_COPY]] to [init] [[RIGHT]]
 // CHECK-NEXT:    [[BRANCH:%.*]] = enum $TreeA<T>, #TreeA.Branch!enumelt.1, [[BOX]]
 // CHECK-NEXT:    destroy_value [[BRANCH]]
-// CHECK-NEXT:    destroy_value %2
-// CHECK-NEXT:    destroy_value %1
-// CHECK-NEXT:    destroy_addr %0
+// CHECK-NEXT:    destroy_value [[ARG3]]
+// CHECK-NEXT:    destroy_value [[ARG2]]
+// CHECK-NEXT:    destroy_addr [[ARG1]]
   let _ = TreeA<T>.Branch(left: l, right: r)
 
-// CHECK:         return
-
 }
+// CHECK: // end sil function '_TF13indirect_enum11TreeA_casesurFTx1lGOS_5TreeAx_1rGS0_x__T_'
 
-// CHECK-LABEL: sil hidden @_TF13indirect_enum16TreeA_reabstractFFSiSiT_
+
+// CHECK-LABEL: sil hidden @_TF13indirect_enum16TreeA_reabstractFFSiSiT_ : $@convention(thin) (@owned @callee_owned (Int) -> Int) -> () {
 func TreeA_reabstract(_ f: @escaping (Int) -> Int) {
-
+// CHECK: bb0([[ARG:%.*]] : $@callee_owned (Int) -> Int):
 // CHECK:         [[METATYPE:%.*]] = metatype $@thin TreeA<(Int) -> Int>.Type
 // CHECK-NEXT:    [[BOX:%.*]] = alloc_box $@box @callee_owned (@in Int) -> @out Int
 // CHECK-NEXT:    [[PB:%.*]] = project_box [[BOX]]
-// CHECK-NEXT:    copy_value %0
+// CHECK-NEXT:    [[ARG_COPY:%.*]] = copy_value [[ARG]]
 // CHECK:         [[THUNK:%.*]] = function_ref @_TTRXFo_dSi_dSi_XFo_iSi_iSi_
-// CHECK-NEXT:    [[FN:%.*]] = partial_apply [[THUNK]](%0)
+// CHECK-NEXT:    [[FN:%.*]] = partial_apply [[THUNK]]([[ARG_COPY]])
 // CHECK-NEXT:    store [[FN]] to [init] [[PB]]
 // CHECK-NEXT:    [[LEAF:%.*]] = enum $TreeA<(Int) -> Int>, #TreeA.Leaf!enumelt.1, [[BOX]]
 // CHECK-NEXT:    destroy_value [[LEAF]]
-// CHECK-NEXT:    destroy_value %0
+// CHECK-NEXT:    destroy_value [[ARG]]
 // CHECK: return
   let _ = TreeA<(Int) -> Int>.Leaf(f)
 }
+// CHECK: } // end sil function '_TF13indirect_enum16TreeA_reabstractFFSiSiT_'
 
 enum TreeB<T> {
   case Nil
@@ -108,14 +109,14 @@ func TreeB_cases<T>(_ t: T, l: TreeB<T>, r: TreeB<T>) {
 
 // CHECK-LABEL: sil hidden @_TF13indirect_enum13TreeInt_casesFTSi1lOS_7TreeInt1rS0__T_ : $@convention(thin) (Int, @owned TreeInt, @owned TreeInt) -> ()
 func TreeInt_cases(_ t: Int, l: TreeInt, r: TreeInt) {
-
+// CHECK: bb0([[ARG1:%.*]] : $Int, [[ARG2:%.*]] : $TreeInt, [[ARG3:%.*]] : $TreeInt):
 // CHECK:         [[METATYPE:%.*]] = metatype $@thin TreeInt.Type
 // CHECK-NEXT:    [[NIL:%.*]] = enum $TreeInt, #TreeInt.Nil!enumelt
 // CHECK-NEXT:    destroy_value [[NIL]]
   let _ = TreeInt.Nil
 
 // CHECK-NEXT:    [[METATYPE:%.*]] = metatype $@thin TreeInt.Type
-// CHECK-NEXT:    [[LEAF:%.*]] = enum $TreeInt, #TreeInt.Leaf!enumelt.1, %0
+// CHECK-NEXT:    [[LEAF:%.*]] = enum $TreeInt, #TreeInt.Leaf!enumelt.1, [[ARG1]]
 // CHECK-NEXT:    destroy_value [[LEAF]]
   let _ = TreeInt.Leaf(t)
 
@@ -124,19 +125,17 @@ func TreeInt_cases(_ t: Int, l: TreeInt, r: TreeInt) {
 // CHECK-NEXT:    [[PB:%.*]] = project_box [[BOX]]
 // CHECK-NEXT:    [[LEFT:%.*]] = tuple_element_addr [[PB]]
 // CHECK-NEXT:    [[RIGHT:%.*]] = tuple_element_addr [[PB]]
-// CHECK-NEXT:    copy_value %1
-// CHECK-NEXT:    store %1 to [init] [[LEFT]]
-// CHECK-NEXT:    copy_value %2
-// CHECK-NEXT:    store %2 to [init] [[RIGHT]]
+// CHECK-NEXT:    [[ARG2_COPY:%.*]] = copy_value [[ARG2]]
+// CHECK-NEXT:    store [[ARG2_COPY]] to [init] [[LEFT]]
+// CHECK-NEXT:    [[ARG3_COPY:%.*]] = copy_value [[ARG3]]
+// CHECK-NEXT:    store [[ARG3_COPY]] to [init] [[RIGHT]]
 // CHECK-NEXT:    [[BRANCH:%.*]] = enum $TreeInt, #TreeInt.Branch!enumelt.1, [[BOX]]
 // CHECK-NEXT:    destroy_value [[BRANCH]]
-// CHECK-NEXT:    destroy_value %2
-// CHECK-NEXT:    destroy_value %1
+// CHECK-NEXT:    destroy_value [[ARG3]]
+// CHECK-NEXT:    destroy_value [[ARG2]]
   let _ = TreeInt.Branch(left: l, right: r)
-
-// CHECK:         return
-
 }
+// CHECK: } // end sil function '_TF13indirect_enum13TreeInt_casesFTSi1lOS_7TreeInt1rS0__T_'
 
 enum TreeInt {
   case Nil
@@ -155,17 +154,22 @@ func b<T>(_ x: T) {}
 func c<T>(_ x: T, _ y: T) {}
 func d() {}
 
-// CHECK-LABEL: sil hidden @_TF13indirect_enum11switchTreeA
+// CHECK-LABEL: sil hidden @_TF13indirect_enum11switchTreeAurFGOS_5TreeAx_T_ : $@convention(thin) <T> (@owned TreeA<T>) -> () {
 func switchTreeA<T>(_ x: TreeA<T>) {
+  // CHECK: bb0([[ARG:%.*]] : $TreeA<T>):
   // --           x +2
-  // CHECK:       copy_value %0
-  // CHECK:       switch_enum %0 : $TreeA<T>
+  // CHECK:       [[ARG_COPY:%.*]] = copy_value [[ARG]]
+  // CHECK:       switch_enum [[ARG_COPY]] : $TreeA<T>,
+  // CHECK:          case #TreeA.Nil!enumelt: [[NIL_CASE:bb1]],
+  // CHECK:          case #TreeA.Leaf!enumelt.1: [[LEAF_CASE:bb2]],
+  // CHECK:          case #TreeA.Branch!enumelt.1: [[BRANCH_CASE:bb3]],
   switch x {
-  // CHECK:     bb{{.*}}:
+  // CHECK:     [[NIL_CASE]]:
   // CHECK:       function_ref @_TF13indirect_enum1aFT_T_
+  // CHECK:       br [[OUTER_CONT:bb[0-9]+]]
   case .Nil:
     a()
-  // CHECK:     bb{{.*}}([[LEAF_BOX:%.*]] : $@box T):
+  // CHECK:     [[LEAF_CASE]]([[LEAF_BOX:%.*]] : $@box T):
   // CHECK:       [[VALUE:%.*]] = project_box [[LEAF_BOX]]
   // CHECK:       copy_addr [[VALUE]] to [initialization] [[X:%.*]] : $*T
   // CHECK:       function_ref @_TF13indirect_enum1b
@@ -173,22 +177,26 @@ func switchTreeA<T>(_ x: TreeA<T>) {
   // CHECK:       dealloc_stack [[X]]
   // --           x +1
   // CHECK:       destroy_value [[LEAF_BOX]]
-  // CHECK:       br [[OUTER_CONT:bb[0-9]+]]
+  // CHECK:       br [[OUTER_CONT]]
   case .Leaf(let x):
     b(x)
 
-  // CHECK:     bb{{.*}}([[NODE_BOX:%.*]] : $@box (left: TreeA<T>, right: TreeA<T>)):
+  // CHECK:     [[BRANCH_CASE]]([[NODE_BOX:%.*]] : $@box (left: TreeA<T>, right: TreeA<T>)):
   // CHECK:       [[TUPLE_ADDR:%.*]] = project_box [[NODE_BOX]]
   // CHECK:       [[TUPLE:%.*]] = load [[TUPLE_ADDR]]
   // CHECK:       [[LEFT:%.*]] = tuple_extract [[TUPLE]] {{.*}}, 0
   // CHECK:       [[RIGHT:%.*]] = tuple_extract [[TUPLE]] {{.*}}, 1
-  // CHECK:       switch_enum [[RIGHT]] {{.*}}, default [[FAIL_RIGHT:bb[0-9]+]]
+  // CHECK:       switch_enum [[RIGHT]] : $TreeA<T>,
+  // CHECK:          case #TreeA.Leaf!enumelt.1: [[LEAF_CASE_RIGHT:bb[0-9]+]],
+  // CHECK:          default [[FAIL_RIGHT:bb[0-9]+]]
 
-  // CHECK:     bb{{.*}}([[RIGHT_LEAF_BOX:%.*]] : $@box T):
+  // CHECK:     [[LEAF_CASE_RIGHT]]([[RIGHT_LEAF_BOX:%.*]] : $@box T):
   // CHECK:       [[RIGHT_LEAF_VALUE:%.*]] = project_box [[RIGHT_LEAF_BOX]]
-  // CHECK:       switch_enum [[LEFT]] {{.*}}, default [[FAIL_LEFT:bb[0-9]+]]
+  // CHECK:       switch_enum [[LEFT]] : $TreeA<T>,
+  // CHECK:          case #TreeA.Leaf!enumelt.1: [[LEAF_CASE_LEFT:bb[0-9]+]],
+  // CHECK:          default [[FAIL_LEFT:bb[0-9]+]]
   
-  // CHECK:     bb{{.*}}([[LEFT_LEAF_BOX:%.*]] : $@box T):
+  // CHECK:     [[LEAF_CASE_LEFT]]([[LEFT_LEAF_BOX:%.*]] : $@box T):
   // CHECK:       [[LEFT_LEAF_VALUE:%.*]] = project_box [[LEFT_LEAF_BOX]]
   // CHECK:       copy_addr [[LEFT_LEAF_VALUE]]
   // CHECK:       copy_addr [[RIGHT_LEAF_VALUE]]
@@ -207,15 +215,16 @@ func switchTreeA<T>(_ x: TreeA<T>) {
 
   // CHECK:     [[DEFAULT]]:
   // --           x +1
-  // CHECK:       destroy_value %0
+  // CHECK:       destroy_value [[ARG_COPY]]
   default:
     d()
   }
 
   // CHECK:     [[OUTER_CONT:%.*]]:
   // --           x +0
-  // CHECK:       destroy_value %0 : $TreeA<T>
+  // CHECK:       destroy_value [[ARG]] : $TreeA<T>
 }
+// CHECK: } // end sil function '_TF13indirect_enum11switchTreeAurFGOS_5TreeAx_T_'
 
 // CHECK-LABEL: sil hidden @_TF13indirect_enum11switchTreeB
 func switchTreeB<T>(_ x: TreeB<T>) {
@@ -313,20 +322,21 @@ func switchTreeB<T>(_ x: TreeB<T>) {
 
 // CHECK-LABEL: sil hidden @_TF13indirect_enum10guardTreeA
 func guardTreeA<T>(_ tree: TreeA<T>) {
+  // CHECK: bb0([[ARG:%.*]] : $TreeA<T>):
   do {
-    // CHECK:   copy_value %0
-    // CHECK:   switch_enum %0 : $TreeA<T>, case #TreeA.Nil!enumelt: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
+    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+    // CHECK:   switch_enum [[ARG_COPY]] : $TreeA<T>, case #TreeA.Nil!enumelt: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
     // CHECK: [[NO]]:
-    // CHECK:   destroy_value %0
+    // CHECK:   destroy_value [[ARG_COPY]]
     // CHECK: [[YES]]:
-    // CHECK:   destroy_value %0
+    // CHECK:   destroy_value [[ARG_COPY]]
     guard case .Nil = tree else { return }
 
     // CHECK:   [[X:%.*]] = alloc_stack $T
-    // CHECK:   copy_value %0
-    // CHECK:   switch_enum %0 : $TreeA<T>, case #TreeA.Leaf!enumelt.1: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
+    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+    // CHECK:   switch_enum [[ARG_COPY]] : $TreeA<T>, case #TreeA.Leaf!enumelt.1: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
     // CHECK: [[NO]]:
-    // CHECK:   destroy_value %0
+    // CHECK:   destroy_value [[ARG_COPY]]
     // CHECK: [[YES]]([[BOX:%.*]] : $@box T):
     // CHECK:   [[VALUE_ADDR:%.*]] = project_box [[BOX]]
     // CHECK:   [[TMP:%.*]] = alloc_stack
@@ -335,16 +345,16 @@ func guardTreeA<T>(_ tree: TreeA<T>) {
     // CHECK:   destroy_value [[BOX]]
     guard case .Leaf(let x) = tree else { return }
 
-    // CHECK:   copy_value %0
-    // CHECK:   switch_enum %0 : $TreeA<T>, case #TreeA.Branch!enumelt.1: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
+    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+    // CHECK:   switch_enum [[ARG_COPY]] : $TreeA<T>, case #TreeA.Branch!enumelt.1: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
     // CHECK: [[NO]]:
-    // CHECK:   destroy_value %0
+    // CHECK:   destroy_value [[ARG_COPY]]
     // CHECK: [[YES]]([[BOX:%.*]] : $@box (left: TreeA<T>, right: TreeA<T>)):
     // CHECK:   [[VALUE_ADDR:%.*]] = project_box [[BOX]]
     // CHECK:   [[TUPLE:%.*]] = load [[VALUE_ADDR]]
-    // CHECK:   copy_value [[TUPLE]]
-    // CHECK:   [[L:%.*]] = tuple_extract [[TUPLE]]
-    // CHECK:   [[R:%.*]] = tuple_extract [[TUPLE]]
+    // CHECK:   [[TUPLE_COPY:%.*]] = copy_value [[TUPLE]]
+    // CHECK:   [[L:%.*]] = tuple_extract [[TUPLE_COPY]]
+    // CHECK:   [[R:%.*]] = tuple_extract [[TUPLE_COPY]]
     // CHECK:   destroy_value [[BOX]]
     guard case .Branch(left: let l, right: let r) = tree else { return }
 
@@ -354,19 +364,19 @@ func guardTreeA<T>(_ tree: TreeA<T>) {
   }
 
   do {
-    // CHECK:   copy_value %0
-    // CHECK:   switch_enum %0 : $TreeA<T>, case #TreeA.Nil!enumelt: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
+    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+    // CHECK:   switch_enum [[ARG_COPY]] : $TreeA<T>, case #TreeA.Nil!enumelt: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
     // CHECK: [[NO]]:
-    // CHECK:   destroy_value %0
+    // CHECK:   destroy_value [[ARG_COPY]]
     // CHECK: [[YES]]:
-    // CHECK:   destroy_value %0
+    // CHECK:   destroy_value [[ARG_COPY]]
     if case .Nil = tree { }
 
     // CHECK:   [[X:%.*]] = alloc_stack $T
-    // CHECK:   copy_value %0
-    // CHECK:   switch_enum %0 : $TreeA<T>, case #TreeA.Leaf!enumelt.1: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
+    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+    // CHECK:   switch_enum [[ARG_COPY]] : $TreeA<T>, case #TreeA.Leaf!enumelt.1: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
     // CHECK: [[NO]]:
-    // CHECK:   destroy_value %0
+    // CHECK:   destroy_value [[ARG_COPY]]
     // CHECK: [[YES]]([[BOX:%.*]] : $@box T):
     // CHECK:   [[VALUE_ADDR:%.*]] = project_box [[BOX]]
     // CHECK:   [[TMP:%.*]] = alloc_stack
@@ -377,16 +387,16 @@ func guardTreeA<T>(_ tree: TreeA<T>) {
     if case .Leaf(let x) = tree { }
 
 
-    // CHECK:   copy_value %0
-    // CHECK:   switch_enum %0 : $TreeA<T>, case #TreeA.Branch!enumelt.1: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
+    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+    // CHECK:   switch_enum [[ARG_COPY]] : $TreeA<T>, case #TreeA.Branch!enumelt.1: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
     // CHECK: [[NO]]:
-    // CHECK:   destroy_value %0
+    // CHECK:   destroy_value [[ARG_COPY]]
     // CHECK: [[YES]]([[BOX:%.*]] : $@box (left: TreeA<T>, right: TreeA<T>)):
     // CHECK:   [[VALUE_ADDR:%.*]] = project_box [[BOX]]
     // CHECK:   [[TUPLE:%.*]] = load [[VALUE_ADDR]]
-    // CHECK:   copy_value [[TUPLE]]
-    // CHECK:   [[L:%.*]] = tuple_extract [[TUPLE]]
-    // CHECK:   [[R:%.*]] = tuple_extract [[TUPLE]]
+    // CHECK:   [[TUPLE_COPY:%.*]] = copy_value [[TUPLE]]
+    // CHECK:   [[L:%.*]] = tuple_extract [[TUPLE_COPY]]
+    // CHECK:   [[R:%.*]] = tuple_extract [[TUPLE_COPY]]
     // CHECK:   destroy_value [[BOX]]
     // CHECK:   destroy_value [[R]]
     // CHECK:   destroy_value [[L]]
@@ -482,15 +492,21 @@ func guardTreeB<T>(_ tree: TreeB<T>) {
   }
 }
 
+// SEMANTIC ARC TODO: This test needs to be made far more comprehensive.
+// CHECK-LABEL: sil hidden @_TF13indirect_enum35dontDisableCleanupOfIndirectPayloadFOS_18TrivialButIndirectT_ : $@convention(thin) (@owned TrivialButIndirect) -> () {
 func dontDisableCleanupOfIndirectPayload(_ x: TrivialButIndirect) {
-  // CHECK:   switch_enum %0 : $TrivialButIndirect, case #TrivialButIndirect.Direct!enumelt.1:  [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
+  // CHECK: bb0([[ARG:%.*]] : $TrivialButIndirect):
+  // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+  // CHECK:   switch_enum [[ARG_COPY]] : $TrivialButIndirect, case #TrivialButIndirect.Direct!enumelt.1:  [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
   // CHECK: [[NO]]:
-  // CHECK:   destroy_value %0
+  // CHECK:   destroy_value [[ARG_COPY]]
   guard case .Direct(let foo) = x else { return }
 
   // -- Cleanup isn't necessary on "no" path because .Direct is trivial
-  // CHECK:   switch_enum %0 : $TrivialButIndirect, case #TrivialButIndirect.Indirect!enumelt.1:  [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
+  // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+  // CHECK:   switch_enum [[ARG_COPY]] : $TrivialButIndirect, case #TrivialButIndirect.Indirect!enumelt.1:  [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
   // CHECK-NOT: [[NO]]:
   // CHECK: [[YES]]({{.*}}):
   guard case .Indirect(let bar) = x else { return }
 }
+// CHECK: } // end sil function '_TF13indirect_enum35dontDisableCleanupOfIndirectPayloadFOS_18TrivialButIndirectT_'

--- a/test/SILGen/init_ref_delegation.swift
+++ b/test/SILGen/init_ref_delegation.swift
@@ -101,9 +101,9 @@ class C1 {
     // CHECK:   [[SELFP:%[0-9]+]] = apply [[DELEG_INIT]]([[X]], [[X]], [[SELF_FROM_BOX]]) : $@convention(method) (X, X, @owned C1) -> @owned C1
     // CHECK:   store [[SELFP]] to [init] [[SELF]] : $*C1
     // CHECK:   [[SELFP:%[0-9]+]] = load [[SELF]] : $*C1
-    // CHECK:   copy_value [[SELFP]] : $C1
+    // CHECK:   [[SELFP_RESULT:%.*]] = copy_value [[SELFP]] : $C1
     // CHECK:   destroy_value [[SELF_BOX]] : $@box C1
-    // CHECK:   return [[SELFP]] : $C1
+    // CHECK:   return [[SELFP_RESULT]] : $C1
     self.init(x1: x, x2: x)
   }
 
@@ -126,9 +126,9 @@ class C1 {
     // CHECK:   [[REPLACE_SELF:%[0-9]+]] = apply [[DELEG_INIT]]([[X]], [[X]], [[SELF]]) : $@convention(method) (X, X, @owned C2) -> @owned C2
     // CHECK:   store [[REPLACE_SELF]] to [init] [[UNINIT_SELF]] : $*C2
     // CHECK:   [[VAR_15:%[0-9]+]] = load [[UNINIT_SELF]] : $*C2
-    // CHECK:   copy_value [[VAR_15]] : $C2
+    // CHECK:   [[VAR_15_RETURN:%.*]] = copy_value [[VAR_15]] : $C2
     // CHECK:   destroy_value [[SELF_BOX]] : $@box C2
-    // CHECK:   return [[VAR_15]] : $C2
+    // CHECK:   return [[VAR_15_RETURN]] : $C2
     self.init(x1: x, x2: x)
     // CHECK-NOT: sil hidden @_TToFC19init_ref_delegation2C2c{{.*}} : $@convention(objc_method) (X, @owned C2) -> @owned C2 {
   }

--- a/test/SILGen/local_recursion.swift
+++ b/test/SILGen/local_recursion.swift
@@ -15,8 +15,9 @@ func local_recursion(_ x: Int, y: Int) {
 
   // CHECK: [[SELF_RECURSIVE_REF:%.*]] = function_ref [[SELF_RECURSIVE]]
   // CHECK: [[CLOSURE:%.*]] = partial_apply [[SELF_RECURSIVE_REF]]([[X]])
+  // CHECK: [[CLOSURE_COPY:%.*]] = copy_value [[CLOSURE]]
   let sr = self_recursive
-  // CHECK: apply [[CLOSURE]]([[Y]])
+  // CHECK: apply [[CLOSURE_COPY]]([[Y]])
   sr(y)
 
   func mutually_recursive_1(_ a: Int) {
@@ -46,8 +47,9 @@ func local_recursion(_ x: Int, y: Int) {
 
   // CHECK: [[TRANS_CAPTURE_REF:%.*]] = function_ref [[TRANS_CAPTURE]]
   // CHECK: [[CLOSURE:%.*]] = partial_apply [[TRANS_CAPTURE_REF]]([[X]], [[Y]])
+  // CHECK: [[CLOSURE_COPY:%.*]] = copy_value [[CLOSURE]]
   let tc = transitive_capture_2
-  // CHECK: apply [[CLOSURE]]([[X]])
+  // CHECK: apply [[CLOSURE_COPY]]([[X]])
   tc(x)
 
   // CHECK: [[CLOSURE_REF:%.*]] = function_ref @_TFF15local_recursion15local_recursionFTSi1ySi_T_U_FSiT_
@@ -59,7 +61,8 @@ func local_recursion(_ x: Int, y: Int) {
 
   // CHECK: [[CLOSURE_REF:%.*]] = function_ref @_TFF15local_recursion15local_recursionFTSi1ySi_T_U0_FSiT_
   // CHECK: [[CLOSURE:%.*]] = partial_apply [[CLOSURE_REF]]([[X]], [[Y]])
-  // CHECK: apply [[CLOSURE]]([[X]])
+  // CHECK: [[CLOSURE_COPY:%.*]] = copy_value [[CLOSURE]]
+  // CHECK: apply [[CLOSURE_COPY]]([[X]])
   let f: (Int) -> () = {
     self_recursive($0)
     transitive_capture_2($0)

--- a/test/SILGen/metatype_object_conversion.swift
+++ b/test/SILGen/metatype_object_conversion.swift
@@ -31,6 +31,7 @@ func existentialMetatypeToObject(_ x: CP.Type) -> AnyObject {
 // CHECK-LABEL: sil hidden @_TF26metatype_object_conversion23protocolToProtocolClassFT_CSo8Protocol
 func protocolToProtocolClass() -> Protocol {
   // CHECK: [[PROTO:%.*]] = objc_protocol #OP
-  // CHECK: return [[PROTO]]
+  // CHECK: [[COPIED_PROTO:%.*]] = copy_value [[PROTO]]
+  // CHECK: return [[COPIED_PROTO]]
   return OP.self
 }

--- a/test/SILGen/newtype.swift
+++ b/test/SILGen/newtype.swift
@@ -33,9 +33,10 @@ func getRawValue(ed: ErrorDomain) -> String {
 // CHECK-RAW: bb0([[SELF:%[0-9]+]] : $ErrorDomain):
 // CHECK-RAW: [[FORCE_BRIDGE:%[0-9]+]] = function_ref @_forceBridgeFromObjectiveC_bridgeable 
 // CHECK-RAW: [[STORED_VALUE:%[0-9]+]] = struct_extract [[SELF]] : $ErrorDomain, #ErrorDomain._rawValue
+// CHECK-RAW: [[STORED_VALUE_COPY:%.*]] = copy_value [[STORED_VALUE]]
 // CHECK-RAW: [[STRING_META:%[0-9]+]] = metatype $@thick String.Type
 // CHECK-RAW: [[STRING_RESULT_ADDR:%[0-9]+]] = alloc_stack $String
-// CHECK-RAW: apply [[FORCE_BRIDGE]]<String, NSString>([[STRING_RESULT_ADDR]], [[STORED_VALUE]], [[STRING_META]])
+// CHECK-RAW: apply [[FORCE_BRIDGE]]<String, NSString>([[STRING_RESULT_ADDR]], [[STORED_VALUE_COPY]], [[STRING_META]])
 // CHECK-RAW: [[STRING_RESULT:%[0-9]+]] = load [[STRING_RESULT_ADDR]]
 // CHECK-RAW: return [[STRING_RESULT]]
 

--- a/test/SILGen/objc_blocks_bridging.swift
+++ b/test/SILGen/objc_blocks_bridging.swift
@@ -7,40 +7,52 @@
 import Foundation
 
 @objc class Foo {
-  // CHECK-LABEL: sil hidden [thunk] @_TToFC20objc_blocks_bridging3Foo3foo
-  // CHECK:         [[COPY:%.*]] = copy_block %0
+// CHECK-LABEL: sil hidden [thunk] @_TToFC20objc_blocks_bridging3Foo3foofTFSiSi1xSi_Si :
+  // CHECK: bb0([[ARG1:%.*]] : $@convention(block) (Int) -> Int, {{.*}}, [[SELF:%.*]] : $Foo):
+  // CHECK:         [[ARG1_COPY:%.*]] = copy_block [[ARG1]]
+  // CHECK:         [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:         [[THUNK:%.*]] = function_ref @_TTRXFdCb_dSi_dSi_XFo_dSi_dSi_
-  // CHECK:         [[BRIDGED:%.*]] = partial_apply [[THUNK]]([[COPY]])
+  // CHECK:         [[BRIDGED:%.*]] = partial_apply [[THUNK]]([[ARG1_COPY]])
   // CHECK:         [[NATIVE:%.*]] = function_ref @_TFC20objc_blocks_bridging3Foo3foo{{.*}} : $@convention(method) (@owned @callee_owned (Int) -> Int, Int, @guaranteed Foo) -> Int
-  // CHECK:         apply [[NATIVE]]([[BRIDGED]], %1, %2)
+  // CHECK:         apply [[NATIVE]]([[BRIDGED]], {{.*}}, [[SELF_COPY]])
+  // CHECK: } // end sil function '_TToFC20objc_blocks_bridging3Foo3foofTFSiSi1xSi_Si'
   dynamic func foo(_ f: (Int) -> Int, x: Int) -> Int {
     return f(x)
   }
 
-  // CHECK-LABEL: sil hidden [thunk] @_TToFC20objc_blocks_bridging3Foo3bar
-  // CHECK:         [[COPY:%.*]] = copy_block %0
+  // CHECK-LABEL: sil hidden [thunk] @_TToFC20objc_blocks_bridging3Foo3barfTFSSSS1xSS_SS : $@convention(objc_method) (@convention(block) (NSString) -> @autoreleased NSString, NSString, Foo) -> @autoreleased NSString {
+  // CHECK:       bb0([[BLOCK:%.*]] : $@convention(block) (NSString) -> @autoreleased NSString, [[NSSTRING:%.*]] : $NSString, [[SELF:%.*]] : $Foo):
+  // CHECK:         [[BLOCK_COPY:%.*]] = copy_block [[BLOCK]]
+  // CHECK:         [[NSSTRING_COPY:%.*]] = copy_value [[NSSTRING]]
+  // CHECK:         [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:         [[THUNK:%.*]] = function_ref @_TTRXFdCb_dCSo8NSString_aS__XFo_oSS_oSS_
-  // CHECK:         [[BRIDGED:%.*]] = partial_apply [[THUNK]]([[COPY]])
+  // CHECK:         [[BRIDGED:%.*]] = partial_apply [[THUNK]]([[BLOCK_COPY]])
   // CHECK:         [[NATIVE:%.*]] = function_ref @_TFC20objc_blocks_bridging3Foo3bar{{.*}} : $@convention(method) (@owned @callee_owned (@owned String) -> @owned String, @owned String, @guaranteed Foo) -> @owned String
-  // CHECK:         apply [[NATIVE]]([[BRIDGED]], {{%.*}}, %2)
+  // CHECK:         apply [[NATIVE]]([[BRIDGED]], {{%.*}}, [[SELF_COPY]])
+  // CHECK: } // end sil function '_TToFC20objc_blocks_bridging3Foo3barfTFSSSS1xSS_SS'
   dynamic func bar(_ f: (String) -> String, x: String) -> String {
     return f(x)
   }
 
-  // CHECK-LABEL: sil hidden [thunk]  @_TToFC20objc_blocks_bridging3Foo3bas
-  // CHECK:         [[COPY:%.*]] = copy_block %0
+  // CHECK-LABEL: sil hidden [thunk] @_TToFC20objc_blocks_bridging3Foo3basfTFGSqSS_GSqSS_1xGSqSS__GSqSS_ : $@convention(objc_method) (@convention(block) (Optional<NSString>) -> @autoreleased Optional<NSString>, Optional<NSString>, Foo) -> @autoreleased Optional<NSString> {
+  // CHECK:       bb0([[BLOCK:%.*]] : $@convention(block) (Optional<NSString>) -> @autoreleased Optional<NSString>, [[OPT_STRING:%.*]] : $Optional<NSString>, [[SELF:%.*]] : $Foo):
+  // CHECK:         [[BLOCK_COPY:%.*]] = copy_block [[BLOCK]]
+  // CHECK:         [[OPT_STRING_COPY:%.*]] = copy_value [[OPT_STRING]]
+  // CHECK:         [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:         [[THUNK:%.*]] = function_ref @_TTRXFdCb_dGSqCSo8NSString__aGSqS___XFo_oGSqSS__oGSqSS__
-  // CHECK:         [[BRIDGED:%.*]] = partial_apply [[THUNK]]([[COPY]])
+  // CHECK:         [[BRIDGED:%.*]] = partial_apply [[THUNK]]([[BLOCK_COPY]])
   // CHECK:         [[NATIVE:%.*]] = function_ref @_TFC20objc_blocks_bridging3Foo3bas{{.*}} : $@convention(method) (@owned @callee_owned (@owned Optional<String>) -> @owned Optional<String>, @owned Optional<String>, @guaranteed Foo) -> @owned Optional<String>
-  // CHECK:         apply [[NATIVE]]([[BRIDGED]], {{%.*}}, %2)
+  // CHECK:         apply [[NATIVE]]([[BRIDGED]], {{%.*}}, [[SELF_COPY]])
   dynamic func bas(_ f: (String?) -> String?, x: String?) -> String? {
     return f(x)
   }
 
   // CHECK-LABEL: sil hidden [thunk] @_TToFC20objc_blocks_bridging3Foo16cFunctionPointer
   // CHECK:       bb0([[F:%.*]] : $@convention(c) (Int) -> Int, [[X:%.*]] : $Int, [[SELF:%.*]] : $Foo):
+  // CHECK:         [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:         [[NATIVE:%.*]] = function_ref @_TFC20objc_blocks_bridging3Foo16cFunctionPointer
-  // CHECK:         apply [[NATIVE]]([[F]], [[X]], [[SELF]])
+  // CHECK:         apply [[NATIVE]]([[F]], [[X]], [[SELF_COPY]])
+  // CHECK:         destroy_value [[SELF_COPY]]
   dynamic func cFunctionPointer(_ fp: @convention(c) (Int) -> Int, x: Int) -> Int {
     _ = fp(x)
   }
@@ -73,9 +85,10 @@ func callBlocks(_ x: Foo,
   h: @escaping (String?) -> String?
 ) -> (Int, String, String?, String?) {
   // CHECK: [[FOO:%.*]] =  class_method [volatile] %0 : $Foo, #Foo.foo!1.foreign
+  // CHECK: [[CLOSURE_COPY:%.*]] = copy_value %1
   // CHECK: [[F_BLOCK_STORAGE:%.*]] = alloc_stack $@block_storage
   // CHECK: [[F_BLOCK_CAPTURE:%.*]] = project_block_storage [[F_BLOCK_STORAGE]]
-  // CHECK: store %1 to [init] [[F_BLOCK_CAPTURE]]
+  // CHECK: store [[CLOSURE_COPY]] to [init] [[F_BLOCK_CAPTURE]]
   // CHECK: [[F_BLOCK_INVOKE:%.*]] = function_ref @_TTRXFo_dSi_dSi_XFdCb_dSi_dSi_
   // CHECK: [[F_STACK_BLOCK:%.*]] = init_block_storage_header [[F_BLOCK_STORAGE]] : {{.*}}, invoke [[F_BLOCK_INVOKE]]
   // CHECK: [[F_BLOCK:%.*]] = copy_block [[F_STACK_BLOCK]]

--- a/test/SILGen/objc_bridging.swift
+++ b/test/SILGen/objc_bridging.swift
@@ -220,11 +220,11 @@ class Bas : NSObject {
   var strRealProp: String = "Hello"
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TToFC13objc_bridging3Basg11strRealPropSS : $@convention(objc_method) (Bas) -> @autoreleased NSString {
   // CHECK: bb0([[THIS:%.*]] : $Bas):
-  // CHECK:   copy_value [[THIS]] : $Bas
+  // CHECK:   [[THIS_COPY:%.*]] = copy_value [[THIS]] : $Bas
   // CHECK:   // function_ref objc_bridging.Bas.strRealProp.getter
   // CHECK:   [[PROPIMPL:%.*]] = function_ref @_TFC13objc_bridging3Basg11strRealPropSS
-  // CHECK:   [[PROP_COPY:%.*]] = apply [[PROPIMPL]]([[THIS]]) : $@convention(method) (@guaranteed Bas) -> @owned String
-  // CHECK:   destroy_value [[THIS]]
+  // CHECK:   [[PROP_COPY:%.*]] = apply [[PROPIMPL]]([[THIS_COPY]]) : $@convention(method) (@guaranteed Bas) -> @owned String
+  // CHECK:   destroy_value [[THIS_COPY]]
   // CHECK:   [[STRING_TO_NSSTRING:%.*]] = function_ref @_TFE10FoundationSS19_bridgeToObjectiveCfT_CSo8NSString
   // CHECK:   [[NSSTR:%.*]] = apply [[STRING_TO_NSSTRING]]([[PROP_COPY]])
   // CHECK:   return [[NSSTR]]
@@ -239,12 +239,16 @@ class Bas : NSObject {
 
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TToFC13objc_bridging3Bass11strRealPropSS : $@convention(objc_method) (NSString, Bas) -> () {
   // CHECK: bb0([[VALUE:%.*]] : $NSString, [[THIS:%.*]] : $Bas):
+  // CHECK:   [[VALUE_COPY:%.*]] = copy_value [[VALUE]]
+  // CHECK:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
   // CHECK:   [[NSSTRING_TO_STRING:%.*]] = function_ref @_TZFE10FoundationSS36_unconditionallyBridgeFromObjectiveCfGSqCSo8NSString_SS
-  // CHECK:   [[VALUE_BOX:%.*]] = enum $Optional<NSString>, #Optional.some!enumelt.1, [[VALUE]]
+  // CHECK:   [[VALUE_BOX:%.*]] = enum $Optional<NSString>, #Optional.some!enumelt.1, [[VALUE_COPY]]
   // CHECK:   [[STR:%.*]] = apply [[NSSTRING_TO_STRING]]([[VALUE_BOX]]
   
   // CHECK:   [[SETIMPL:%.*]] = function_ref @_TFC13objc_bridging3Bass11strRealPropSS
-  // CHECK:   apply [[SETIMPL]]([[STR]], %1)
+  // CHECK:   apply [[SETIMPL]]([[STR]], [[THIS_COPY]])
+  // CHECK:   destroy_value [[THIS_COPY]]
+  // CHECK: } // end sil function '_TToFC13objc_bridging3Bass11strRealPropSS'
 
   // CHECK-LABEL: sil hidden [transparent] @_TFC13objc_bridging3Bass11strRealPropSS
   // CHECK: bb0(%0 : $String, %1 : $Bas):
@@ -259,21 +263,27 @@ class Bas : NSObject {
   }
   // CHECK-LABEL: sil hidden [thunk] @_TToFC13objc_bridging3Basg11strFakePropSS : $@convention(objc_method) (Bas) -> @autoreleased NSString {
   // CHECK: bb0([[THIS:%.*]] : $Bas):
+  // CHECK:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
   // CHECK:   [[GETTER:%.*]] = function_ref @_TFC13objc_bridging3Basg11strFakePropSS
-  // CHECK:   [[STR:%.*]] = apply [[GETTER]]([[THIS]])
+  // CHECK:   [[STR:%.*]] = apply [[GETTER]]([[THIS_COPY]])
+  // CHECK:   destroy_value [[THIS_COPY]]
   // CHECK:   [[STRING_TO_NSSTRING:%.*]] = function_ref @_TFE10FoundationSS19_bridgeToObjectiveCfT_CSo8NSString
   // CHECK:   [[NSSTR:%.*]] = apply [[STRING_TO_NSSTRING]]([[STR]])
+  // CHECK:   destroy_value [[STR]]
   // CHECK:   return [[NSSTR]]
   // CHECK: }
 
   // CHECK-LABEL: sil hidden [thunk] @_TToFC13objc_bridging3Bass11strFakePropSS : $@convention(objc_method) (NSString, Bas) -> () {
   // CHECK: bb0([[NSSTR:%.*]] : $NSString, [[THIS:%.*]] : $Bas):
+  // CHECK:   [[NSSTR_COPY:%.*]] = copy_value [[NSSTR]]
+  // CHECK:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
   // CHECK:   [[NSSTRING_TO_STRING:%.*]] = function_ref @_TZFE10FoundationSS36_unconditionallyBridgeFromObjectiveCfGSqCSo8NSString_SS
-  // CHECK:   [[NSSTR_BOX:%.*]] = enum $Optional<NSString>, #Optional.some!enumelt.1, [[NSSTR]]
+  // CHECK:   [[NSSTR_BOX:%.*]] = enum $Optional<NSString>, #Optional.some!enumelt.1, [[NSSTR_COPY]]
   // CHECK:   [[STR:%.*]] = apply [[NSSTRING_TO_STRING]]([[NSSTR_BOX]]
   // CHECK:   [[SETTER:%.*]] = function_ref @_TFC13objc_bridging3Bass11strFakePropSS
-  // CHECK:   apply [[SETTER]]([[STR]], [[THIS]])
-  // CHECK: }
+  // CHECK:   apply [[SETTER]]([[STR]], [[THIS_COPY]])
+  // CHECK:   destroy_value [[THIS_COPY]]
+  // CHECK: } // end sil function '_TToFC13objc_bridging3Bass11strFakePropSS'
 
   // -- Bridging thunks for explicitly NSString properties don't convert
   var nsstrRealProp: NSString
@@ -295,21 +305,27 @@ class Bas : NSObject {
   func strResult() -> String { return "" }
   // CHECK-LABEL: sil hidden [thunk] @_TToFC13objc_bridging3Bas9strResult
   // CHECK: bb0([[THIS:%.*]] : $Bas):
+  // CHECK:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
   // CHECK:   [[METHOD:%.*]] = function_ref @_TFC13objc_bridging3Bas9strResult
-  // CHECK:   [[STR:%.*]] = apply [[METHOD]]([[THIS]])
+  // CHECK:   [[STR:%.*]] = apply [[METHOD]]([[THIS_COPY]])
+  // CHECK:   destroy_value [[THIS_COPY]]
   // CHECK:   [[STRING_TO_NSSTRING:%.*]] = function_ref @_TFE10FoundationSS19_bridgeToObjectiveCfT_CSo8NSString
   // CHECK:   [[NSSTR:%.*]] = apply [[STRING_TO_NSSTRING]]([[STR]])
+  // CHECK:   destroy_value [[STR]]
   // CHECK:   return [[NSSTR]]
   // CHECK: }
   func strArg(_ s: String) { }
   // CHECK-LABEL: sil hidden [thunk] @_TToFC13objc_bridging3Bas6strArg
   // CHECK: bb0([[NSSTR:%.*]] : $NSString, [[THIS:%.*]] : $Bas):
+  // CHECK:   [[NSSTR_COPY:%.*]] = copy_value [[NSSTR]]
+  // CHECK:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
   // CHECK:   [[NSSTRING_TO_STRING:%.*]] = function_ref @_TZFE10FoundationSS36_unconditionallyBridgeFromObjectiveCfGSqCSo8NSString_SS
-  // CHECK:   [[NSSTR_BOX:%.*]] = enum $Optional<NSString>, #Optional.some!enumelt.1, [[NSSTR]]
+  // CHECK:   [[NSSTR_BOX:%.*]] = enum $Optional<NSString>, #Optional.some!enumelt.1, [[NSSTR_COPY]]
   // CHECK:   [[STR:%.*]] = apply [[NSSTRING_TO_STRING]]([[NSSTR_BOX]]
   // CHECK:   [[METHOD:%.*]] = function_ref @_TFC13objc_bridging3Bas6strArg
-  // CHECK:   apply [[METHOD]]([[STR]], [[THIS]])
-  // CHECK: }
+  // CHECK:   apply [[METHOD]]([[STR]], [[THIS_COPY]])
+  // CHECK:   destroy_value [[THIS_COPY]]
+  // CHECK: } // end sil function '_TToFC13objc_bridging3Bas6strArgfSST_'
 
   // -- Bridging thunks for explicitly NSString properties don't convert
   func nsstrResult() -> NSString { return NSS }
@@ -330,26 +346,27 @@ class Bas : NSObject {
 
   // CHECK-LABEL: sil hidden [thunk] @_TToFC13objc_bridging3Bas8arrayArg{{.*}} : $@convention(objc_method) (NSArray, Bas) -> ()
   // CHECK: bb0([[NSARRAY:%[0-9]+]] : $NSArray, [[SELF:%[0-9]+]] : $Bas):
-  // CHECK:   copy_value [[NSARRAY]] : $NSArray
-  // CHECK:   copy_value [[SELF]] : $Bas
+  // CHECK:   [[NSARRAY_COPY:%.*]] = copy_value [[NSARRAY]] : $NSArray
+  // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]] : $Bas
   // CHECK:   [[CONV_FN:%[0-9]+]] = function_ref @_TZFE10FoundationSa36_unconditionallyBridgeFromObjectiveCfGSqCSo7NSArray_GSax_
-  // CHECK-NEXT: [[OPT_NSARRAY:%[0-9]+]] = enum $Optional<NSArray>, #Optional.some!enumelt.1, [[NSARRAY]] : $NSArray
-  // CHECK-NEXT: [[ARRAY_META:%[0-9]+]] = metatype $@thin Array<AnyObject>.Type
-  // CHECK-NEXT: [[ARRAY:%[0-9]+]] = apply [[CONV_FN]]<AnyObject>([[OPT_NSARRAY]], [[ARRAY_META]])
+  // CHECK:   [[OPT_NSARRAY:%[0-9]+]] = enum $Optional<NSArray>, #Optional.some!enumelt.1, [[NSARRAY_COPY]] : $NSArray
+  // CHECK:   [[ARRAY_META:%[0-9]+]] = metatype $@thin Array<AnyObject>.Type
+  // CHECK:   [[ARRAY:%[0-9]+]] = apply [[CONV_FN]]<AnyObject>([[OPT_NSARRAY]], [[ARRAY_META]])
   // CHECK:   [[SWIFT_FN:%[0-9]+]] = function_ref @_TFC13objc_bridging3Bas{{.*}} : $@convention(method) (@owned Array<AnyObject>, @guaranteed Bas) -> ()
-  // CHECK:   [[RESULT:%[0-9]+]] = apply [[SWIFT_FN]]([[ARRAY]], [[SELF]]) : $@convention(method) (@owned Array<AnyObject>, @guaranteed Bas) -> ()
-  // CHECK:   destroy_value [[SELF]] : $Bas
+  // CHECK:   [[RESULT:%[0-9]+]] = apply [[SWIFT_FN]]([[ARRAY]], [[SELF_COPY]]) : $@convention(method) (@owned Array<AnyObject>, @guaranteed Bas) -> ()
+  // CHECK:   destroy_value [[SELF_COPY]] : $Bas
   // CHECK:   return [[RESULT]] : $()
   func arrayArg(_ array: [AnyObject]) { }
   
   // CHECK-LABEL: sil hidden [thunk] @_TToFC13objc_bridging3Bas11arrayResult{{.*}} : $@convention(objc_method) (Bas) -> @autoreleased NSArray
   // CHECK: bb0([[SELF:%[0-9]+]] : $Bas):
-  // CHECK:   copy_value [[SELF]] : $Bas
+  // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]] : $Bas
   // CHECK:   [[SWIFT_FN:%[0-9]+]] = function_ref @_TFC13objc_bridging3Bas11arrayResult{{.*}} : $@convention(method) (@guaranteed Bas) -> @owned Array<AnyObject>
-  // CHECK:   [[ARRAY:%[0-9]+]] = apply [[SWIFT_FN]]([[SELF]]) : $@convention(method) (@guaranteed Bas) -> @owned Array<AnyObject>
-  // CHECK:   destroy_value [[SELF]]
+  // CHECK:   [[ARRAY:%[0-9]+]] = apply [[SWIFT_FN]]([[SELF_COPY]]) : $@convention(method) (@guaranteed Bas) -> @owned Array<AnyObject>
+  // CHECK:   destroy_value [[SELF_COPY]]
   // CHECK:   [[CONV_FN:%[0-9]+]] = function_ref @_TFE10FoundationSa19_bridgeToObjectiveCfT_CSo7NSArray
   // CHECK:   [[NSARRAY:%[0-9]+]] = apply [[CONV_FN]]<AnyObject>([[ARRAY]]) : $@convention(method) <τ_0_0> (@guaranteed Array<τ_0_0>) -> @owned NSArray
+  // CHECK:   destroy_value [[ARRAY]]
   // CHECK:   return [[NSARRAY]]
   func arrayResult() -> [AnyObject] { return [] }
 
@@ -358,16 +375,28 @@ class Bas : NSObject {
   var arrayProp: [String] = []
 }
 
-// CHECK-LABEL: sil hidden @_TF13objc_bridging16applyStringBlock
+// CHECK-LABEL: sil hidden @_TF13objc_bridging16applyStringBlock{{.*}} : 
 func applyStringBlock(_ f: @convention(block) (String) -> String, x: String) -> String {
-  // CHECK: [[BLOCK:%.*]] = copy_block %0
-  // CHECK: [[STRING_TO_NSSTRING:%.*]] = function_ref @_TFE10FoundationSS19_bridgeToObjectiveCfT_CSo8NSString
-  // CHECK: [[NSSTR:%.*]] = apply [[STRING_TO_NSSTRING]]
-  // CHECK: [[RES:%.*]] = apply [[BLOCK]]([[NSSTR]]) : $@convention(block) (NSString) -> @autoreleased NSString
-  // CHECK: function_ref @_TZFE10FoundationSS36_unconditionallyBridgeFromObjectiveCfGSqCSo8NSString_SS
-  // CHECK: return {{%.*}} : $String
+  // CHECK: bb0([[BLOCK:%.*]] : $@convention(block) (NSString) -> @autoreleased NSString, [[STRING:%.*]] : $String):
+  // CHECK:   [[BLOCK_COPY:%.*]] = copy_block [[BLOCK]]
+  // CHECK:   [[BLOCK_COPY_COPY:%.*]] = copy_value [[BLOCK_COPY]]
+  // CHECK:   [[STRING_COPY:%.*]] = copy_value [[STRING]]
+  // CHECK:   [[STRING_TO_NSSTRING:%.*]] = function_ref @_TFE10FoundationSS19_bridgeToObjectiveCfT_CSo8NSString
+  // CHECK:   [[NSSTR:%.*]] = apply [[STRING_TO_NSSTRING]]([[STRING_COPY]])
+  // CHECK:   [[RESULT_NSSTR:%.*]] = apply [[BLOCK_COPY_COPY]]([[NSSTR]]) : $@convention(block) (NSString) -> @autoreleased NSString
+  // CHECK:   [[FINAL_BRIDGE:%.*]] = function_ref @_TZFE10FoundationSS36_unconditionallyBridgeFromObjectiveCfGSqCSo8NSString_SS
+  // CHECK:   [[OPTIONAL_NSSTR:%.*]] = enum $Optional<NSString>, #Optional.some!enumelt.1, [[RESULT_NSSTR]]
+  // CHECK:   [[RESULT:%.*]] = apply [[FINAL_BRIDGE]]([[OPTIONAL_NSSTR]], {{.*}}) : $@convention(method) (@owned Optional<NSString>, @thin String.Type) -> @owned String
+  // CHECK:   destroy_value [[NSSTR]]
+  // CHECK:   destroy_value [[STRING_COPY]]
+  // CHECK:   destroy_value [[BLOCK_COPY_COPY]]
+  // CHECK:   destroy_value [[STRING]]
+  // CHECK:   destroy_value [[BLOCK_COPY]]
+  // CHECK:   destroy_value [[BLOCK]]
+  // CHECK:   return [[RESULT]] : $String
   return f(x)
 }
+// CHECK: } // end sil function '_TF13objc_bridging16applyStringBlock{{.*}}'
 
 // CHECK-LABEL: sil hidden @_TF13objc_bridging15bridgeCFunction
 func bridgeCFunction() -> (String!) -> (String!) {

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -25,135 +25,147 @@ func passingToId<T: CP, U>(receiver: NSIdLover,
                            optionalB: NSString?,
                            optionalC: Any?) {
   // CHECK: bb0([[SELF:%.*]] : $NSIdLover,
-  // CHECK: [[STRING:%.*]] : $String
-  // CHECK: [[NSSTRING:%.*]] : $NSString
-  // CHECK: [[OBJECT:%.*]] : $AnyObject
-  // CHECK: [[CLASS_GENERIC:%.*]] : $T
-  // CHECK: [[CLASS_EXISTENTIAL:%.*]] : $CP
-  // CHECK: [[GENERIC:%.*]] : $*U
-  // CHECK: [[EXISTENTIAL:%.*]] : $*P
-  // CHECK: [[ERROR:%.*]] : $Error
-  // CHECK: [[ANY:%.*]] : $*Any
-  // CHECK: [[KNOWN_UNBRIDGED:%.*]] : $KnownUnbridged
-  // CHECK: [[OPT_STRING:%.*]] : $Optional<String>
-  // CHECK: [[OPT_NSSTRING:%.*]] : $Optional<NSString>
-  // CHECK: [[OPT_ANY:%.*]] : $*Optional<Any>
+  // CHECK:   debug_value [[STRING:%.*]] : $String
+  // CHECK:   debug_value [[NSSTRING:%.*]] : $NSString
+  // CHECK:   debug_value [[OBJECT:%.*]] : $AnyObject
+  // CHECK:   debug_value [[CLASS_GENERIC:%.*]] : $T
+  // CHECK:   debug_value [[CLASS_EXISTENTIAL:%.*]] : $CP
+  // CHECK:   debug_value_addr [[GENERIC:%.*]] : $*U
+  // CHECK:   debug_value_addr [[EXISTENTIAL:%.*]] : $*P
+  // CHECK:   debug_value [[ERROR:%.*]] : $Error
+  // CHECK:   debug_value_addr [[ANY:%.*]] : $*Any
+  // CHECK:   debug_value [[KNOWN_UNBRIDGED:%.*]] : $KnownUnbridged
+  // CHECK:   debug_value [[OPT_STRING:%.*]] : $Optional<String>
+  // CHECK:   debug_value [[OPT_NSSTRING:%.*]] : $Optional<NSString>
+  // CHECK:   debug_value_addr [[OPT_ANY:%.*]] : $*Optional<Any>
 
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]]
-  // CHECK: [[BRIDGE_STRING:%.*]] = function_ref @_TFE10FoundationSS19_bridgeToObjectiveC
-  // CHECK: [[BRIDGED:%.*]] = apply [[BRIDGE_STRING]]([[STRING]])
-  // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref [[BRIDGED]] : $NSString : $NSString, $AnyObject
-  // CHECK: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF]]
+  // CHECK:   [[STRING_COPY:%.*]] = copy_value [[STRING]]
+  // CHECK:   [[BRIDGE_STRING:%.*]] = function_ref @_TFE10FoundationSS19_bridgeToObjectiveC
+  // CHECK:   [[BRIDGED:%.*]] = apply [[BRIDGE_STRING]]([[STRING_COPY]])
+  // CHECK:   [[ANYOBJECT:%.*]] = init_existential_ref [[BRIDGED]] : $NSString : $NSString, $AnyObject
+  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK:   destroy_value [[BRIDGED]]
+  // CHECK:   destroy_value [[STRING_COPY]]
   receiver.takesId(string)
 
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref [[NSSTRING]] : $NSString : $NSString, $AnyObject
-  // CHECK: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
+  // CHECK:   [[NSSTRING_COPY:%.*]] = copy_value [[NSSTRING]]
+  // CHECK:   [[ANYOBJECT:%.*]] = init_existential_ref [[NSSTRING_COPY]] : $NSString : $NSString, $AnyObject
+  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK:   destroy_value [[NSSTRING_COPY]]
   receiver.takesId(nsString)
 
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref [[CLASS_GENERIC]] : $T : $T, $AnyObject
-  // CHECK: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
+  // CHECK:   [[CLASS_GENERIC_COPY:%.*]] = copy_value [[CLASS_GENERIC]]
+  // CHECK:   [[ANYOBJECT:%.*]] = init_existential_ref [[CLASS_GENERIC_COPY]] : $T : $T, $AnyObject
+  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK:   destroy_value [[CLASS_GENERIC_COPY]]
   receiver.takesId(classGeneric)
 
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK: apply [[METHOD]]([[OBJECT]], [[SELF]])
+  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
+  // CHECK:   [[OBJECT_COPY:%.*]] = copy_value [[OBJECT]]
+  // CHECK:   apply [[METHOD]]([[OBJECT_COPY]], [[SELF]])
+  // CHECK:   destroy_value [[OBJECT_COPY]]
   receiver.takesId(object)
 
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK: [[OPENED:%.*]] = open_existential_ref [[CLASS_EXISTENTIAL]] : $CP
-  // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref [[OPENED]]
-  // CHECK: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
+  // CHECK:   [[CLASS_EXISTENTIAL_COPY:%.*]] = copy_value [[CLASS_EXISTENTIAL]]
+  // CHECK:   [[OPENED:%.*]] = open_existential_ref [[CLASS_EXISTENTIAL_COPY]] : $CP
+  // CHECK:   [[ANYOBJECT:%.*]] = init_existential_ref [[OPENED]]
+  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK:   destroy_value [[CLASS_EXISTENTIAL_COPY]]
   receiver.takesId(classExistential)
 
   // These cases perform a universal bridging conversion.
 
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK-NEXT: [[COPY:%.*]] = alloc_stack $U
-  // CHECK-NEXT: copy_addr [[GENERIC]] to [initialization] [[COPY]]
-  // CHECK-NEXT: // function_ref _bridgeAnythingToObjectiveC
-  // CHECK-NEXT: [[BRIDGE_ANYTHING:%.*]] = function_ref
-  // CHECK-NEXT: [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<U>([[COPY]])
-  // CHECK-NEXT: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
-  // CHECK-NEXT: destroy_value [[ANYOBJECT]]
-  // CHECK-NEXT: dealloc_stack [[COPY]]
+  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
+  // CHECK:   [[COPY:%.*]] = alloc_stack $U
+  // CHECK:   copy_addr [[GENERIC]] to [initialization] [[COPY]]
+  // CHECK:   // function_ref _bridgeAnythingToObjectiveC
+  // CHECK:   [[BRIDGE_ANYTHING:%.*]] = function_ref
+  // CHECK:   [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<U>([[COPY]])
+  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK:   destroy_value [[ANYOBJECT]]
+  // CHECK:   dealloc_stack [[COPY]]
   receiver.takesId(generic)
 
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK-NEXT: [[COPY:%.*]] = alloc_stack $P
-  // CHECK-NEXT: copy_addr [[EXISTENTIAL]] to [initialization] [[COPY]]
-  // CHECK-NEXT: [[OPENED_COPY:%.*]] = open_existential_addr [[COPY]] : $*P to $*[[OPENED_TYPE:@opened.*P]],
-  // CHECK-NEXT: // function_ref _bridgeAnythingToObjectiveC
-  // CHECK-NEXT: [[BRIDGE_ANYTHING:%.*]] = function_ref
-  // CHECK-NEXT: [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<[[OPENED_TYPE]]>([[OPENED_COPY]])
-  // CHECK-NEXT: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
-  // CHECK-NEXT: destroy_value [[ANYOBJECT]]
-  // CHECK-NEXT: deinit_existential_addr [[COPY]]
-  // CHECK-NEXT: dealloc_stack [[COPY]]
+  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
+  // CHECK:   [[COPY:%.*]] = alloc_stack $P
+  // CHECK:   copy_addr [[EXISTENTIAL]] to [initialization] [[COPY]]
+  // CHECK:   [[OPENED_COPY:%.*]] = open_existential_addr [[COPY]] : $*P to $*[[OPENED_TYPE:@opened.*P]],
+  // CHECK:   // function_ref _bridgeAnythingToObjectiveC
+  // CHECK:   [[BRIDGE_ANYTHING:%.*]] = function_ref
+  // CHECK:   [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<[[OPENED_TYPE]]>([[OPENED_COPY]])
+  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK:   destroy_value [[ANYOBJECT]]
+  // CHECK:   deinit_existential_addr [[COPY]]
+  // CHECK:   dealloc_stack [[COPY]]
   receiver.takesId(existential)
 
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK-NEXT: copy_value [[ERROR]] : $Error
-  // CHECK-NEXT: [[ERROR_BOX:%[0-9]+]] = open_existential_box [[ERROR]] : $Error to $*@opened([[ERROR_ARCHETYPE:"[^"]*"]]) Error
-  // CHECK-NEXT: [[ERROR_STACK:%[0-9]+]] = alloc_stack $@opened([[ERROR_ARCHETYPE]]) Error
-  // CHECK-NEXT: copy_addr [[ERROR_BOX]] to [initialization] [[ERROR_STACK]] : $*@opened([[ERROR_ARCHETYPE]]) Error
-  // CHECK: [[BRIDGE_FUNCTION:%[0-9]+]] = function_ref @_TFs27_bridgeAnythingToObjectiveCurFxPs9AnyObject_
-  // CHECK-NEXT: [[BRIDGED_ERROR:%[0-9]+]] = apply [[BRIDGE_FUNCTION]]<@opened([[ERROR_ARCHETYPE]]) Error>([[ERROR_STACK]])
-  // CHECK-NEXT: apply [[METHOD]]([[BRIDGED_ERROR]], [[SELF]])
-  // CHECK-NEXT: destroy_value [[BRIDGED_ERROR]] : $AnyObject
-  // CHECK-NEXT: dealloc_stack [[ERROR_STACK]] : $*@opened([[ERROR_ARCHETYPE]]) Error
-  // CHECK-NEXT: destroy_value [[ERROR]] : $Error
+  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
+  // CHECK:   [[ERROR_COPY:%.*]] = copy_value [[ERROR]] : $Error
+  // CHECK:   [[ERROR_BOX:%[0-9]+]] = open_existential_box [[ERROR_COPY]] : $Error to $*@opened([[ERROR_ARCHETYPE:"[^"]*"]]) Error
+  // CHECK:   [[ERROR_STACK:%[0-9]+]] = alloc_stack $@opened([[ERROR_ARCHETYPE]]) Error
+  // CHECK:   copy_addr [[ERROR_BOX]] to [initialization] [[ERROR_STACK]] : $*@opened([[ERROR_ARCHETYPE]]) Error
+  // CHECK:   [[BRIDGE_FUNCTION:%[0-9]+]] = function_ref @_TFs27_bridgeAnythingToObjectiveCurFxPs9AnyObject_
+  // CHECK:   [[BRIDGED_ERROR:%[0-9]+]] = apply [[BRIDGE_FUNCTION]]<@opened([[ERROR_ARCHETYPE]]) Error>([[ERROR_STACK]])
+  // CHECK:   apply [[METHOD]]([[BRIDGED_ERROR]], [[SELF]])
+  // CHECK:   destroy_value [[BRIDGED_ERROR]] : $AnyObject
+  // CHECK:   dealloc_stack [[ERROR_STACK]] : $*@opened([[ERROR_ARCHETYPE]]) Error
+  // CHECK:   destroy_value [[ERROR_COPY]] : $Error
   receiver.takesId(error)
 
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK-NEXT: [[COPY:%.*]] = alloc_stack $Any
-  // CHECK-NEXT: copy_addr [[ANY]] to [initialization] [[COPY]]
-  // CHECK-NEXT: [[OPENED_COPY:%.*]] = open_existential_addr [[COPY]] : $*Any to $*[[OPENED_TYPE:@opened.*Any]],
-  // CHECK-NEXT: // function_ref _bridgeAnythingToObjectiveC
-  // CHECK-NEXT: [[BRIDGE_ANYTHING:%.*]] = function_ref
-  // CHECK-NEXT: [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<[[OPENED_TYPE]]>([[OPENED_COPY]])
-  // CHECK-NEXT: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
-  // CHECK-NEXT: destroy_value [[ANYOBJECT]]
-  // CHECK-NEXT: deinit_existential_addr [[COPY]]
-  // CHECK-NEXT: dealloc_stack [[COPY]]
+  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
+  // CHECK:   [[COPY:%.*]] = alloc_stack $Any
+  // CHECK:   copy_addr [[ANY]] to [initialization] [[COPY]]
+  // CHECK:   [[OPENED_COPY:%.*]] = open_existential_addr [[COPY]] : $*Any to $*[[OPENED_TYPE:@opened.*Any]],
+  // CHECK:   // function_ref _bridgeAnythingToObjectiveC
+  // CHECK:   [[BRIDGE_ANYTHING:%.*]] = function_ref
+  // CHECK:   [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<[[OPENED_TYPE]]>([[OPENED_COPY]])
+  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK:   destroy_value [[ANYOBJECT]]
+  // CHECK:   deinit_existential_addr [[COPY]]
+  // CHECK:   dealloc_stack [[COPY]]
   receiver.takesId(any)
 
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK: [[TMP:%.*]] = alloc_stack $KnownUnbridged
-  // CHECK: store [[KNOWN_UNBRIDGED]] to [trivial] [[TMP]]
-  // CHECK: [[BRIDGE_ANYTHING:%.*]] = function_ref @_TFs27_bridgeAnythingToObjectiveC
-  // CHECK: [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<KnownUnbridged>([[TMP]])
-  // CHECK: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
+  // CHECK:   [[TMP:%.*]] = alloc_stack $KnownUnbridged
+  // CHECK:   store [[KNOWN_UNBRIDGED]] to [trivial] [[TMP]]
+  // CHECK:   [[BRIDGE_ANYTHING:%.*]] = function_ref @_TFs27_bridgeAnythingToObjectiveC
+  // CHECK:   [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<KnownUnbridged>([[TMP]])
+  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
   receiver.takesId(knownUnbridged)
 
   // These cases bridge using Optional's _ObjectiveCBridgeable conformance.
 
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK: [[BRIDGE_OPTIONAL:%.*]] = function_ref @_TFSq19_bridgeToObjectiveCfT_Ps9AnyObject_
-  // CHECK: [[TMP:%.*]] = alloc_stack $Optional<String>
-  // CHECK: store [[OPT_STRING]] to [init] [[TMP]]
-  // CHECK: [[ANYOBJECT:%.*]] = apply [[BRIDGE_OPTIONAL]]<String>([[TMP]])
-  // CHECK: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
+  // CHECK:   [[OPT_STRING_COPY:%.*]] = copy_value [[OPT_STRING]]
+  // CHECK:   [[BRIDGE_OPTIONAL:%.*]] = function_ref @_TFSq19_bridgeToObjectiveCfT_Ps9AnyObject_
+  // CHECK:   [[TMP:%.*]] = alloc_stack $Optional<String>
+  // CHECK:   store [[OPT_STRING_COPY]] to [init] [[TMP]]
+  // CHECK:   [[ANYOBJECT:%.*]] = apply [[BRIDGE_OPTIONAL]]<String>([[TMP]])
+  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
   receiver.takesId(optionalA)
 
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK: [[BRIDGE_OPTIONAL:%.*]] = function_ref @_TFSq19_bridgeToObjectiveCfT_Ps9AnyObject_
-  // CHECK: [[TMP:%.*]] = alloc_stack $Optional<NSString>
-  // CHECK: store [[OPT_NSSTRING]] to [init] [[TMP]]
-  // CHECK: [[ANYOBJECT:%.*]] = apply [[BRIDGE_OPTIONAL]]<NSString>([[TMP]])
-  // CHECK: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
+  // CHECK:   [[OPT_NSSTRING_COPY:%.*]] = copy_value [[OPT_NSSTRING]]
+  // CHECK:   [[BRIDGE_OPTIONAL:%.*]] = function_ref @_TFSq19_bridgeToObjectiveCfT_Ps9AnyObject_
+  // CHECK:   [[TMP:%.*]] = alloc_stack $Optional<NSString>
+  // CHECK:   store [[OPT_NSSTRING_COPY]] to [init] [[TMP]]
+  // CHECK:   [[ANYOBJECT:%.*]] = apply [[BRIDGE_OPTIONAL]]<NSString>([[TMP]])
+  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
   receiver.takesId(optionalB)
 
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK: [[TMP:%.*]] = alloc_stack $Optional<Any>
-  // CHECK: copy_addr [[OPT_ANY]] to [initialization] [[TMP]]
-  // CHECK: [[BRIDGE_OPTIONAL:%.*]] = function_ref @_TFSq19_bridgeToObjectiveCfT_Ps9AnyObject_
-  // CHECK: [[ANYOBJECT:%.*]] = apply [[BRIDGE_OPTIONAL]]<Any>([[TMP]])
-  // CHECK: apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
+  // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
+  // CHECK:   [[TMP:%.*]] = alloc_stack $Optional<Any>
+  // CHECK:   copy_addr [[OPT_ANY]] to [initialization] [[TMP]]
+  // CHECK:   [[BRIDGE_OPTIONAL:%.*]] = function_ref @_TFSq19_bridgeToObjectiveCfT_Ps9AnyObject_
+  // CHECK:   [[ANYOBJECT:%.*]] = apply [[BRIDGE_OPTIONAL]]<Any>([[TMP]])
+  // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
   receiver.takesId(optionalC)
 
   // TODO: Property and subscript setters
-
 }
 
 // Workaround for rdar://problem/28318984. Skip the peephole for types with
@@ -223,32 +235,37 @@ func passingToNullableId<T: CP, U>(receiver: NSIdLover,
   // CHECK: [[OPT_OPT_C:%.*]] : $*Optional<Optional<Any>>
 
   // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]]
+  // CHECK: [[STRING_COPY:%.*]] = copy_value [[STRING]]
   // CHECK: [[BRIDGE_STRING:%.*]] = function_ref @_TFE10FoundationSS19_bridgeToObjectiveC
-  // CHECK: [[BRIDGED:%.*]] = apply [[BRIDGE_STRING]]([[STRING]])
+  // CHECK: [[BRIDGED:%.*]] = apply [[BRIDGE_STRING]]([[STRING_COPY]])
   // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref [[BRIDGED]] : $NSString : $NSString, $AnyObject
   // CHECK: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[ANYOBJECT]]
   // CHECK: apply [[METHOD]]([[OPT_ANYOBJECT]], [[SELF]])
   receiver.takesNullableId(string)
 
   // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref [[NSSTRING]] : $NSString : $NSString, $AnyObject
+  // CHECK: [[NSSTRING_COPY:%.*]] = copy_value [[NSSTRING]]
+  // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref [[NSSTRING_COPY]] : $NSString : $NSString, $AnyObject
   // CHECK: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[ANYOBJECT]]
   // CHECK: apply [[METHOD]]([[OPT_ANYOBJECT]], [[SELF]])
   receiver.takesNullableId(nsString)
 
   // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[OBJECT]]
+  // CHECK: [[OBJECT_COPY:%.*]] = copy_value [[OBJECT]]
+  // CHECK: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[OBJECT_COPY]]
   // CHECK: apply [[METHOD]]([[OPT_ANYOBJECT]], [[SELF]])
   receiver.takesNullableId(object)
 
   // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref [[CLASS_GENERIC]] : $T : $T, $AnyObject
+  // CHECK: [[CLASS_GENERIC_COPY:%.*]] = copy_value [[CLASS_GENERIC]]
+  // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref [[CLASS_GENERIC_COPY]] : $T : $T, $AnyObject
   // CHECK: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[ANYOBJECT]]
   // CHECK: apply [[METHOD]]([[OPT_ANYOBJECT]], [[SELF]])
   receiver.takesNullableId(classGeneric)
 
   // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK: [[OPENED:%.*]] = open_existential_ref [[CLASS_EXISTENTIAL]] : $CP
+  // CHECK: [[CLASS_EXISTENTIAL_COPY:%.*]] = copy_value [[CLASS_EXISTENTIAL]]
+  // CHECK: [[OPENED:%.*]] = open_existential_ref [[CLASS_EXISTENTIAL_COPY]] : $CP
   // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref [[OPENED]]
   // CHECK: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[ANYOBJECT]]
   // CHECK: apply [[METHOD]]([[OPT_ANYOBJECT]], [[SELF]])
@@ -281,8 +298,8 @@ func passingToNullableId<T: CP, U>(receiver: NSIdLover,
   receiver.takesNullableId(existential)
 
   // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
-  // CHECK-NEXT: copy_value [[ERROR]] : $Error
-  // CHECK-NEXT: [[ERROR_BOX:%[0-9]+]] = open_existential_box [[ERROR]] : $Error to $*@opened([[ERROR_ARCHETYPE:"[^"]*"]]) Error
+  // CHECK-NEXT: [[ERROR_COPY:%.*]] = copy_value [[ERROR]] : $Error
+  // CHECK-NEXT: [[ERROR_BOX:%[0-9]+]] = open_existential_box [[ERROR_COPY]] : $Error to $*@opened([[ERROR_ARCHETYPE:"[^"]*"]]) Error
   // CHECK-NEXT: [[ERROR_STACK:%[0-9]+]] = alloc_stack $@opened([[ERROR_ARCHETYPE]]) Error
   // CHECK-NEXT: copy_addr [[ERROR_BOX]] to [initialization] [[ERROR_STACK]] : $*@opened([[ERROR_ARCHETYPE]]) Error
   // CHECK: [[BRIDGE_FUNCTION:%[0-9]+]] = function_ref @_TFs27_bridgeAnythingToObjectiveCurFxPs9AnyObject_
@@ -291,7 +308,7 @@ func passingToNullableId<T: CP, U>(receiver: NSIdLover,
   // CHECK-NEXT: apply [[METHOD]]([[BRIDGED_ERROR_OPT]], [[SELF]])
   // CHECK-NEXT: destroy_value [[BRIDGED_ERROR]] : $AnyObject
   // CHECK-NEXT: dealloc_stack [[ERROR_STACK]] : $*@opened([[ERROR_ARCHETYPE]]) Error
-  // CHECK-NEXT: destroy_value [[ERROR]] : $Error
+  // CHECK-NEXT: destroy_value [[ERROR_COPY]] : $Error
   receiver.takesNullableId(error)
 
   // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $NSIdLover,
@@ -318,9 +335,10 @@ func passingToNullableId<T: CP, U>(receiver: NSIdLover,
   receiver.takesNullableId(knownUnbridged)
 
   // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]]
-  // CHECK: select_enum [[OPT_STRING]]
+  // CHECK: [[OPT_STRING_COPY:%.*]] = copy_value [[OPT_STRING]]
+  // CHECK: select_enum [[OPT_STRING_COPY]]
   // CHECK: cond_br
-  // CHECK: [[STRING_DATA:%.*]] = unchecked_enum_data [[OPT_STRING]]
+  // CHECK: [[STRING_DATA:%.*]] = unchecked_enum_data [[OPT_STRING_COPY]]
   // CHECK: [[BRIDGE_STRING:%.*]] = function_ref @_TFE10FoundationSS19_bridgeToObjectiveC
   // CHECK: [[BRIDGED:%.*]] = apply [[BRIDGE_STRING]]([[STRING_DATA]])
   // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref [[BRIDGED]] : $NSString : $NSString, $AnyObject
@@ -334,7 +352,8 @@ func passingToNullableId<T: CP, U>(receiver: NSIdLover,
   receiver.takesNullableId(optNSString)
 
   // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]]
-  // CHECK: apply [[METHOD]]([[OPT_OBJECT]], [[SELF]])
+  // CHECK: [[OPT_OBJECT_COPY:%.*]] = copy_value [[OPT_OBJECT]]
+  // CHECK: apply [[METHOD]]([[OPT_OBJECT_COPY]], [[SELF]])
   receiver.takesNullableId(optObject)
   receiver.takesNullableId(optClassGeneric)
   receiver.takesNullableId(optClassExistential)
@@ -359,14 +378,26 @@ protocol Anyable {
 class SwiftIdLover : NSObject, Anyable {
 
   func methodReturningAny() -> Any {}
+  // SEMANTIC ARC TODO: This is another case of pattern matching the body of one
+  // function in a different function... Just pattern match the unreachable case
+  // to preserve behavior. We should check if it is correct.
+
   // CHECK-LABEL: sil hidden @_TFC17objc_bridging_any12SwiftIdLover18methodReturningAnyfT_P_ : $@convention(method) (@guaranteed SwiftIdLover) -> @out Any
-  // CHECK: [[NATIVE_RESULT:%.*]] = alloc_stack $Any
-  // CHECK: [[NATIVE_IMP:%.*]] = function_ref @_TFC17objc_bridging_any12SwiftIdLover18methodReturningAny
-  // CHECK: apply [[NATIVE_IMP]]([[NATIVE_RESULT]], %0)
-  // CHECK: [[OPEN_RESULT:%.*]] = open_existential_addr [[NATIVE_RESULT]]
-  // CHECK: [[BRIDGE_ANYTHING:%.*]] = function_ref @_TFs27_bridgeAnythingToObjectiveC
-  // CHECK: [[OBJC_RESULT:%.*]] = apply [[BRIDGE_ANYTHING]]<{{.*}}>([[OPEN_RESULT]])
-  // CHECK: return [[OBJC_RESULT]]
+  // CHECK: unreachable
+  // CHECK: } // end sil function '_TFC17objc_bridging_any12SwiftIdLover18methodReturningAnyfT_P_'
+
+  // CHECK-LABEL: sil hidden [thunk] @_TToFC17objc_bridging_any12SwiftIdLover18methodReturningAnyfT_P_ : $@convention(objc_method) (SwiftIdLover) -> @autoreleased AnyObject {
+  // CHECK: bb0([[SELF:%[0-9]+]] : $SwiftIdLover):
+  // CHECK:   [[NATIVE_RESULT:%.*]] = alloc_stack $Any
+  // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]] : $SwiftIdLover
+  // CHECK:   [[NATIVE_IMP:%.*]] = function_ref @_TFC17objc_bridging_any12SwiftIdLover18methodReturningAny
+  // CHECK:   apply [[NATIVE_IMP]]([[NATIVE_RESULT]], [[SELF_COPY]])
+  // CHECK:   destroy_value [[SELF_COPY]]
+  // CHECK:   [[OPEN_RESULT:%.*]] = open_existential_addr [[NATIVE_RESULT]]
+  // CHECK:   [[BRIDGE_ANYTHING:%.*]] = function_ref @_TFs27_bridgeAnythingToObjectiveC
+  // CHECK:   [[OBJC_RESULT:%.*]] = apply [[BRIDGE_ANYTHING]]<{{.*}}>([[OPEN_RESULT]])
+  // CHECK:   return [[OBJC_RESULT]]
+  // CHECK: } // end sil function '_TToFC17objc_bridging_any12SwiftIdLover18methodReturningAnyfT_P_'
 
   func methodReturningOptionalAny() -> Any? {}
   // CHECK-LABEL: sil hidden @_TFC17objc_bridging_any12SwiftIdLover26methodReturningOptionalAny
@@ -375,19 +406,19 @@ class SwiftIdLover : NSObject, Anyable {
 
   func methodTakingAny(a: Any) {}
   // CHECK-LABEL: sil hidden [thunk] @_TToFC17objc_bridging_any12SwiftIdLover15methodTakingAnyfT1aP__T_ : $@convention(objc_method) (AnyObject, SwiftIdLover) -> ()
-  // CHECK:     bb0(%0 : $AnyObject, %1 : $SwiftIdLover):
-  // CHECK-NEXT:  copy_value %0
-  // CHECK-NEXT:  copy_value %1
-  // CHECK-NEXT:  [[OPTIONAL:%.*]] = unchecked_ref_cast %0
+  // CHECK:     bb0([[ARG:%.*]] : $AnyObject, [[SELF:%.*]] : $SwiftIdLover):
+  // CHECK-NEXT:  [[ARG_COPY:%.*]] = copy_value [[ARG]]
+  // CHECK-NEXT:  [[SELF_COPY:%.*]] = copy_value [[SELF]]
+  // CHECK-NEXT:  [[OPTIONAL_ARG_COPY:%.*]] = unchecked_ref_cast [[ARG_COPY]]
   // CHECK-NEXT:  // function_ref
   // CHECK-NEXT:  [[BRIDGE_TO_ANY:%.*]] = function_ref [[BRIDGE_TO_ANY_FUNC:@.*]] :
   // CHECK-NEXT:  [[RESULT:%.*]] = alloc_stack $Any
-  // CHECK-NEXT:  [[RESULT_VAL:%.*]] = apply [[BRIDGE_TO_ANY]]([[RESULT]], [[OPTIONAL]])
+  // CHECK-NEXT:  [[RESULT_VAL:%.*]] = apply [[BRIDGE_TO_ANY]]([[RESULT]], [[OPTIONAL_ARG_COPY]])
   // CHECK-NEXT:  // function_ref
   // CHECK-NEXT:  [[METHOD:%.*]] = function_ref @_TFC17objc_bridging_any12SwiftIdLover15methodTakingAnyfT1aP__T_
-  // CHECK-NEXT:  apply [[METHOD]]([[RESULT]], %1)
+  // CHECK-NEXT:  apply [[METHOD]]([[RESULT]], [[SELF_COPY]])
   // CHECK-NEXT:  dealloc_stack [[RESULT]]
-  // CHECK-NEXT:  destroy_value %1
+  // CHECK-NEXT:  destroy_value [[SELF_COPY]]
   // CHECK-NEXT:  return
 
   func methodTakingOptionalAny(a: Any?) {}
@@ -399,27 +430,27 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-LABEL: sil hidden @_TFC17objc_bridging_any12SwiftIdLover26methodTakingBlockTakingAnyfFP_T_T_ : $@convention(method) (@owned @callee_owned (@in Any) -> (), @guaranteed SwiftIdLover) -> ()
 
   // CHECK-LABEL: sil hidden [thunk] @_TToFC17objc_bridging_any12SwiftIdLover26methodTakingBlockTakingAnyfFP_T_T_ : $@convention(objc_method) (@convention(block) (AnyObject) -> (), SwiftIdLover) -> ()
-  // CHECK:    bb0(%0 : $@convention(block) (AnyObject) -> (), %1 : $SwiftIdLover):
-  // CHECK-NEXT:  [[BLOCK:%.*]] = copy_block %0
-  // CHECK-NEXT:  copy_value %1
+  // CHECK:    bb0([[BLOCK:%.*]] : $@convention(block) (AnyObject) -> (), [[SELF:%.*]] : $SwiftIdLover):
+  // CHECK-NEXT:  [[BLOCK_COPY:%.*]] = copy_block [[BLOCK]]
+  // CHECK-NEXT:  [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:       [[THUNK_FN:%.*]] = function_ref @_TTRXFdCb_dPs9AnyObject___XFo_iP___
-  // CHECK-NEXT:  [[THUNK:%.*]] = partial_apply [[THUNK_FN]]([[BLOCK]])
+  // CHECK-NEXT:  [[THUNK:%.*]] = partial_apply [[THUNK_FN]]([[BLOCK_COPY]])
   // CHECK:       [[METHOD:%.*]] = function_ref @_TFC17objc_bridging_any12SwiftIdLover26methodTakingBlockTakingAnyfFP_T_T_
-  // CHECK-NEXT:  [[RESULT:%.*]] = apply [[METHOD]]([[THUNK]], %1)
-  // CHECK-NEXT:  destroy_value %1
+  // CHECK-NEXT:  [[RESULT:%.*]] = apply [[METHOD]]([[THUNK]], [[SELF_COPY]])
+  // CHECK-NEXT:  destroy_value [[SELF_COPY]]
   // CHECK-NEXT:  return [[RESULT]]
 
   // CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @_TTRXFdCb_dPs9AnyObject___XFo_iP___
-  // CHECK:     bb0(%0 : $*Any, %1 : $@convention(block) (AnyObject) -> ()):
-  // CHECK-NEXT:  [[OPENED:%.*]] = open_existential_addr %0 : $*Any to $*[[OPENED_TYPE:@opened.*Any]],
+  // CHECK:     bb0([[ANY:%.*]] : $*Any, [[BLOCK:%.*]] : $@convention(block) (AnyObject) -> ()):
+  // CHECK-NEXT:  [[OPENED_ANY:%.*]] = open_existential_addr [[ANY]] : $*Any to $*[[OPENED_TYPE:@opened.*Any]],
   // CHECK-NEXT:  // function_ref _bridgeAnythingToObjectiveC
   // CHECK-NEXT:  [[BRIDGE_ANYTHING:%.*]] = function_ref
-  // CHECK-NEXT:  [[BRIDGED:%.*]] = apply [[BRIDGE_ANYTHING]]<[[OPENED_TYPE]]>([[OPENED]])
-  // CHECK-NEXT:  apply %1([[BRIDGED]])
+  // CHECK-NEXT:  [[BRIDGED:%.*]] = apply [[BRIDGE_ANYTHING]]<[[OPENED_TYPE]]>([[OPENED_ANY]])
+  // CHECK-NEXT:  apply [[BLOCK]]([[BRIDGED]])
   // CHECK-NEXT:  [[VOID:%.*]] = tuple ()
-  // CHECK-NEXT:  destroy_value %1
+  // CHECK-NEXT:  destroy_value [[BLOCK]]
   // CHECK-NEXT:  destroy_value [[BRIDGED]]
-  // CHECK-NEXT:  deinit_existential_addr %0
+  // CHECK-NEXT:  deinit_existential_addr [[ANY]]
   // CHECK-NEXT:  return [[VOID]]
 
   func methodTakingBlockTakingAny(_: (Any) -> ()) {}
@@ -427,11 +458,11 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-LABEL: sil hidden @_TFC17objc_bridging_any12SwiftIdLover29methodReturningBlockTakingAnyfT_FP_T_ : $@convention(method) (@guaranteed SwiftIdLover) -> @owned @callee_owned (@in Any) -> ()
 
   // CHECK-LABEL: sil hidden [thunk] @_TToFC17objc_bridging_any12SwiftIdLover29methodReturningBlockTakingAnyfT_FP_T_ : $@convention(objc_method) (SwiftIdLover) -> @autoreleased @convention(block) (AnyObject) -> ()
-  // CHECK:     bb0(%0 : $SwiftIdLover):
-  // CHECK-NEXT:  copy_value %0
+  // CHECK:     bb0([[SELF:%.*]] : $SwiftIdLover):
+  // CHECK-NEXT:  [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:       [[METHOD:%.*]] = function_ref @_TFC17objc_bridging_any12SwiftIdLover29methodReturningBlockTakingAnyfT_FP_T_
-  // CHECK-NEXT:  [[RESULT:%.*]] = apply [[METHOD:%.*]](%0)
-  // CHECK-NEXT:  destroy_value %0
+  // CHECK-NEXT:  [[RESULT:%.*]] = apply [[METHOD:%.*]]([[SELF_COPY]])
+  // CHECK-NEXT:  destroy_value [[SELF_COPY]]
   // CHECK-NEXT:  [[BLOCK_STORAGE:%.*]] = alloc_stack $@block_storage @callee_owned (@in Any) -> ()
   // CHECK-NEXT:  [[BLOCK_STORAGE_ADDR:%.*]] = project_block_storage [[BLOCK_STORAGE]]
   // CHECK-NEXT:  store [[RESULT:%.*]] to [init] [[BLOCK_STORAGE_ADDR]]
@@ -443,12 +474,12 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-NEXT:  return [[BLOCK]]
 
   // CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @_TTRXFo_iP___XFdCb_dPs9AnyObject___ : $@convention(c) (@inout_aliasable @block_storage @callee_owned (@in Any) -> (), AnyObject) -> ()
-  // CHECK:     bb0(%0 : $*@block_storage @callee_owned (@in Any) -> (), %1 : $AnyObject):
-  // CHECK-NEXT:  [[BLOCK_STORAGE_ADDR:%.*]] = project_block_storage %0
+  // CHECK:     bb0([[BLOCK_STORAGE:%.*]] : $*@block_storage @callee_owned (@in Any) -> (), [[ANY:%.*]] : $AnyObject):
+  // CHECK-NEXT:  [[BLOCK_STORAGE_ADDR:%.*]] = project_block_storage [[BLOCK_STORAGE]]
   // CHECK-NEXT:  [[FUNCTION:%.*]] = load [[BLOCK_STORAGE_ADDR]]
-  // CHECK-NEXT:  copy_value [[FUNCTION]]
-  // CHECK-NEXT:  copy_value %1
-  // CHECK-NEXT:  [[OPTIONAL:%.*]] = unchecked_ref_cast %1
+  // CHECK-NEXT:  [[FUNCTION_COPY:%.*]] = copy_value [[FUNCTION]]
+  // CHECK-NEXT:  [[ANY_COPY:%.*]] = copy_value [[ANY]]
+  // CHECK-NEXT:  [[OPTIONAL:%.*]] = unchecked_ref_cast [[ANY_COPY]]
   // CHECK-NEXT:  // function_ref
   // CHECK-NEXT:  [[BRIDGE_TO_ANY:%.*]] = function_ref [[BRIDGE_TO_ANY_FUNC:@.*]] :
   // CHECK-NEXT:  [[RESULT:%.*]] = alloc_stack $Any
@@ -465,19 +496,19 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-LABEL: sil hidden @_TFC17objc_bridging_any12SwiftIdLover29methodTakingBlockReturningAnyfFT_P_T_ : $@convention(method) (@owned @callee_owned () -> @out Any, @guaranteed SwiftIdLover) -> () {
 
   // CHECK-LABEL: sil hidden [thunk] @_TToFC17objc_bridging_any12SwiftIdLover29methodTakingBlockReturningAnyfFT_P_T_ : $@convention(objc_method) (@convention(block) () -> @autoreleased AnyObject, SwiftIdLover) -> ()
-  // CHECK:     bb0(%0 : $@convention(block) () -> @autoreleased AnyObject, %1 : $SwiftIdLover):
-  // CHECK-NEXT:  [[BLOCK:%.*]] = copy_block %0
-  // CHECK-NEXT:  copy_value %1
+  // CHECK:     bb0([[BLOCK:%.*]] : $@convention(block) () -> @autoreleased AnyObject, [[ANY:%.*]] : $SwiftIdLover):
+  // CHECK-NEXT:  [[BLOCK_COPY:%.*]] = copy_block [[BLOCK]]
+  // CHECK-NEXT:  [[ANY_COPY:%.*]] = copy_value [[ANY]]
   // CHECK:       [[THUNK_FN:%.*]] = function_ref @_TTRXFdCb__aPs9AnyObject__XFo__iP__
-  // CHECK-NEXT:  [[THUNK:%.*]] = partial_apply [[THUNK_FN]]([[BLOCK]])
+  // CHECK-NEXT:  [[THUNK:%.*]] = partial_apply [[THUNK_FN]]([[BLOCK_COPY]])
   // CHECK:       [[METHOD:%.*]] = function_ref @_TFC17objc_bridging_any12SwiftIdLover29methodTakingBlockReturningAnyfFT_P_T_
-  // CHECK-NEXT:  [[RESULT:%.*]] = apply [[METHOD]]([[THUNK]], %1)
-  // CHECK-NEXT:  destroy_value %1
+  // CHECK-NEXT:  [[RESULT:%.*]] = apply [[METHOD]]([[THUNK]], [[ANY_COPY]])
+  // CHECK-NEXT:  destroy_value [[ANY_COPY]]
   // CHECK-NEXT:  return [[RESULT]]
 
   // CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @_TTRXFdCb__aPs9AnyObject__XFo__iP__ : $@convention(thin) (@owned @convention(block) () -> @autoreleased AnyObject) -> @out Any
-  // CHECK:     bb0(%0 : $*Any, %1 : $@convention(block) () -> @autoreleased AnyObject):
-  // CHECK-NEXT:  [[BRIDGED:%.*]] = apply %1()
+  // CHECK:     bb0([[ANY_ADDR:%.*]] : $*Any, [[BLOCK:%.*]] : $@convention(block) () -> @autoreleased AnyObject):
+  // CHECK-NEXT:  [[BRIDGED:%.*]] = apply [[BLOCK]]()
   // CHECK-NEXT:  [[OPTIONAL:%.*]] = unchecked_ref_cast [[BRIDGED]]
   // CHECK-NEXT:  // function_ref
   // CHECK-NEXT:  [[BRIDGE_TO_ANY:%.*]] = function_ref [[BRIDGE_TO_ANY_FUNC:@.*]] :
@@ -485,10 +516,10 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-NEXT:  [[RESULT_VAL:%.*]] = apply [[BRIDGE_TO_ANY]]([[RESULT]], [[OPTIONAL]])
 
   // TODO: Should elide the copy
-  // CHECK-NEXT:  copy_addr [take] [[RESULT]] to [initialization] %0
+  // CHECK-NEXT:  copy_addr [take] [[RESULT]] to [initialization] [[ANY_ADDR]]
   // CHECK-NEXT:  [[EMPTY:%.*]] = tuple ()
   // CHECK-NEXT:  dealloc_stack [[RESULT]]
-  // CHECK-NEXT:  destroy_value %1
+  // CHECK-NEXT:  destroy_value [[BLOCK]]
   // CHECK-NEXT:  return [[EMPTY]]
 
   func methodReturningBlockTakingOptionalAny() -> ((Any?) -> ()) {}
@@ -498,11 +529,11 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-LABEL: sil hidden @_TFC17objc_bridging_any12SwiftIdLover32methodReturningBlockReturningAnyfT_FT_P_ : $@convention(method) (@guaranteed SwiftIdLover) -> @owned @callee_owned () -> @out Any
 
   // CHECK-LABEL: sil hidden [thunk] @_TToFC17objc_bridging_any12SwiftIdLover32methodReturningBlockReturningAnyfT_FT_P_ : $@convention(objc_method) (SwiftIdLover) -> @autoreleased @convention(block) () -> @autoreleased AnyObject
-  // CHECK:     bb0(%0 : $SwiftIdLover):
-  // CHECK-NEXT:  copy_value %0
+  // CHECK:     bb0([[SELF:%.*]] : $SwiftIdLover):
+  // CHECK-NEXT:  [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:       [[METHOD:%.*]] = function_ref @_TFC17objc_bridging_any12SwiftIdLover32methodReturningBlockReturningAnyfT_FT_P_
-  // CHECK-NEXT:  [[FUNCTION:%.*]] = apply [[METHOD]](%0)
-  // CHECK-NEXT:  destroy_value %0
+  // CHECK-NEXT:  [[FUNCTION:%.*]] = apply [[METHOD]]([[SELF_COPY]])
+  // CHECK-NEXT:  destroy_value [[SELF_COPY]]
   // CHECK-NEXT:  [[BLOCK_STORAGE:%.*]] = alloc_stack $@block_storage @callee_owned () -> @out Any
   // CHECK-NEXT:  [[BLOCK_STORAGE_ADDR:%.*]] = project_block_storage [[BLOCK_STORAGE]]
   // CHECK-NEXT:  store [[FUNCTION]] to [init] [[BLOCK_STORAGE_ADDR]]
@@ -555,13 +586,17 @@ func dynamicLookup(x: AnyObject) {
 }
 
 extension GenericClass {
-  // CHECK-LABEL: sil hidden @_TFE17objc_bridging_anyCSo12GenericClass23pseudogenericAnyErasurefT1xx_P_
+  // CHECK-LABEL: sil hidden @_TFE17objc_bridging_anyCSo12GenericClass23pseudogenericAnyErasurefT1xx_P_ :
   func pseudogenericAnyErasure(x: T) -> Any {
-    // CHECK: [[ANY_BUF:%.*]] = init_existential_addr %0 : $*Any, $AnyObject
-    // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref %1 : $T : $T, $AnyObject
-    // CHECK: store [[ANYOBJECT]] to [init] [[ANY_BUF]]
+    // CHECK: bb0([[ANY_OUT:%.*]] : $*Any, [[ARG:%.*]] : $T, [[SELF:%.*]] : $GenericClass<T>
+    // CHECK:   [[ANY_BUF:%.*]] = init_existential_addr [[ANY_OUT]] : $*Any, $AnyObject
+    // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+    // CHECK:   [[ANYOBJECT:%.*]] = init_existential_ref [[ARG_COPY]] : $T : $T, $AnyObject
+    // CHECK:   store [[ANYOBJECT]] to [init] [[ANY_BUF]]
+    // CHECK:   destroy_value [[ARG]]
     return x
   }
+  // CHECK: } // end sil function '_TFE17objc_bridging_anyCSo12GenericClass23pseudogenericAnyErasurefT1xx_P_'
 }
 
 // Make sure AnyHashable erasure marks Hashable conformance as used

--- a/test/SILGen/objc_currying.swift
+++ b/test/SILGen/objc_currying.swift
@@ -12,121 +12,198 @@ func curry_pod(_ x: CurryTest) -> (Int) -> Int {
 }
 // CHECK-LABEL: sil hidden @_TF13objc_currying9curry_podFCSo9CurryTestFSiSi : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned (Int) -> Int
 // CHECK:      bb0([[ARG1:%.*]] : $CurryTest):
-// CHECK:         [[THUNK:%.*]] = function_ref [[THUNK_FOO_1:@_TTOFCSo9CurryTest3podFSiSi]] : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned (Int) -> Int
-// CHECK:         copy_value [[ARG1]]
-// CHECK:         [[FN:%.*]] = apply [[THUNK]](%0)
+// CHECK:         [[THUNK:%.*]] = function_ref @[[THUNK_FOO_1:_TTOFCSo9CurryTest3podFSiSi]] : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned (Int) -> Int
+// CHECK:         [[COPIED_ARG1:%.*]] = copy_value [[ARG1]]
+// CHECK:         [[FN:%.*]] = apply [[THUNK]]([[COPIED_ARG1]])
 // CHECK:         destroy_value [[ARG1]]
 // CHECK:         return [[FN]]
+// CHECK: } // end sil function '_TF13objc_currying9curry_podFCSo9CurryTestFSiSi'
 
-// CHECK: sil shared [thunk] [[THUNK_FOO_1]] : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned (Int) -> Int
-// CHECK:   [[THUNK:%.*]] = function_ref [[THUNK_FOO_2:@_TTOFCSo9CurryTest3podfSiSi]]
+// CHECK: sil shared [thunk] @[[THUNK_FOO_1]] : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned (Int) -> Int
+// CHECK:   [[THUNK:%.*]] = function_ref @[[THUNK_FOO_2:_TTOFCSo9CurryTest3podfSiSi]]
 // CHECK:   [[FN:%.*]] = partial_apply [[THUNK]](%0)
 // CHECK:   return [[FN]]
+// CHECK: } // end sil function '[[THUNK_FOO_1]]'
 
-// CHECK: sil shared [thunk] [[THUNK_FOO_2]] : $@convention(method) (Int, @guaranteed CurryTest) -> Int
+// CHECK: sil shared [thunk] @[[THUNK_FOO_2]] : $@convention(method) (Int, @guaranteed CurryTest) -> Int
 // CHECK: bb0([[ARG1:%.*]] : $Int, [[ARG2:%.*]] : $CurryTest):
-// CHECK:   copy_value [[ARG2]]
-// CHECK:   [[METHOD:%.*]] = class_method [volatile] %1 : $CurryTest, #CurryTest.pod!1.foreign
-// CHECK:   [[RESULT:%.*]] = apply [[METHOD]](%0, %1)
-// CHECK:   destroy_value [[ARG2]]
+// CHECK:   [[COPIED_ARG2:%.*]] = copy_value [[ARG2]]
+// CHECK:   [[METHOD:%.*]] = class_method [volatile] [[COPIED_ARG2]] : $CurryTest, #CurryTest.pod!1.foreign
+// CHECK:   [[RESULT:%.*]] = apply [[METHOD]]([[ARG1]], [[COPIED_ARG2]])
+// CHECK:   destroy_value [[COPIED_ARG2]]
 // CHECK:   return [[RESULT]]
+// CHECK: } // end sil function '[[THUNK_FOO_2]]'
 
 func curry_bridged(_ x: CurryTest) -> (String!) -> String! {
   return x.bridged
 }
 // CHECK-LABEL: sil hidden @_TF13objc_currying13curry_bridgedFCSo9CurryTestFGSQSS_GSQSS_ : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned (@owned Optional<String>) -> @owned Optional<String>
-// CHECK:         [[THUNK:%.*]] = function_ref [[THUNK_BAR_1:@_TTOFCSo9CurryTest7bridgedFGSQSS_GSQSS_]]
-// CHECK:         [[FN:%.*]] = apply [[THUNK]](%0)
-// CHECK:         return [[FN]]
-
-// CHECK: sil shared [thunk] [[THUNK_BAR_1]] : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned (@owned Optional<String>) -> @owned Optional<String>
-// CHECK:   [[THUNK:%.*]] = function_ref [[THUNK_BAR_2:@_TTOFCSo9CurryTest7bridgedfGSQSS_GSQSS_]]
-// CHECK:   [[FN:%.*]] = partial_apply [[THUNK]](%0)
+// CHECK: bb0([[ARG1:%.*]] : $CurryTest):
+// CHECK:   [[THUNK:%.*]] = function_ref @[[THUNK_BAR_1:_TTOFCSo9CurryTest7bridgedFGSQSS_GSQSS_]]
+// CHECK:   [[ARG1_COPY:%.*]] = copy_value [[ARG1]]
+// CHECK:   [[FN:%.*]] = apply [[THUNK]]([[ARG1_COPY]])
+// CHECK:   destroy_value [[ARG1]]
 // CHECK:   return [[FN]]
+// CHECK: } // end sil function '_TF13objc_currying13curry_bridgedFCSo9CurryTestFGSQSS_GSQSS_'
 
-// CHECK: sil shared [thunk] [[THUNK_BAR_2]] : $@convention(method) (@owned Optional<String>, @guaranteed CurryTest) -> @owned Optional<String>
-// CHECK:   function_ref @_TFE10FoundationSS19_bridgeToObjectiveCfT_CSo8NSString
-// CHECK:   [[METHOD:%.*]] = class_method [volatile] %1 : $CurryTest, #CurryTest.bridged!1.foreign
-// CHECK:   [[RES:%.*]] = apply [[METHOD]]({{%.*}}, %1) : $@convention(objc_method) (Optional<NSString>, CurryTest) -> @autoreleased Optional<NSString>
-// CHECK:   function_ref @_TZFE10FoundationSS36_unconditionallyBridgeFromObjectiveCfGSqCSo8NSString_SS
-// CHECK:   destroy_value %1
-// CHECK:   return {{%.*}} : $Optional<String>
+// CHECK: sil shared [thunk] @[[THUNK_BAR_1]] : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned (@owned Optional<String>) -> @owned Optional<String>
+// CHECK: bb0([[ARG1:%.*]] : $CurryTest):
+// CHECK:   [[THUNK:%.*]] = function_ref @[[THUNK_BAR_2:_TTOFCSo9CurryTest7bridgedfGSQSS_GSQSS_]]
+// CHECK:   [[FN:%.*]] = partial_apply [[THUNK]]([[ARG1]])
+// CHECK:   return [[FN]]
+// CHECK: } // end sil function '[[THUNK_BAR_1]]'
+
+// CHECK: sil shared [thunk] @[[THUNK_BAR_2]] : $@convention(method) (@owned Optional<String>, @guaranteed CurryTest) -> @owned Optional<String>
+// CHECK: bb0([[OPT_STRING:%.*]] : $Optional<String>, [[SELF:%.*]] : $CurryTest):
+// CHECK:   cond_br {{%.*}}, bb1, bb2
+// CHECK: bb1:
+// CHECK:   [[STRING:%.*]] = unchecked_enum_data [[OPT_STRING]]
+// CHECK:   [[BRIDGING_FUNC:%.*]] = function_ref @_TFE10FoundationSS19_bridgeToObjectiveCfT_CSo8NSString
+// CHECK:   [[NSSTRING:%.*]] = apply [[BRIDGING_FUNC]]([[STRING]])
+// CHECK:   [[OPT_NSSTRING:%.*]] = enum $Optional<NSString>, #Optional.some!enumelt.1, [[NSSTRING]] : $NSString
+// CHECK:   destroy_value [[STRING]]
+// CHECK:   br bb3([[OPT_NSSTRING]] : $Optional<NSString>)
+
+// CHECK: bb2:
+// CHECK:   [[OPT_NONE:%.*]] = enum $Optional<NSString>, #Optional.none!enumelt
+// CHECK:   br bb3([[OPT_NONE]] : $Optional<NSString>)
+
+// CHECK: bb3([[OPT_NSSTRING:%.*]] : $Optional<NSString>):
+// CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
+// CHECK:   [[METHOD:%.*]] = class_method [volatile] [[SELF_COPY]] : $CurryTest, #CurryTest.bridged!1.foreign
+// CHECK:   [[RESULT_OPT_NSSTRING:%.*]] = apply [[METHOD]]([[OPT_NSSTRING]], [[SELF_COPY]]) : $@convention(objc_method) (Optional<NSString>, CurryTest) -> @autoreleased Optional<NSString>
+// CHECK:   [[IS_OPT:%.*]] = select_enum [[RESULT_OPT_NSSTRING]]
+// CHECK:   cond_br [[IS_OPT]], bb4, bb5
+
+// CHECK: bb4:
+// CHECK:   [[RESULT_NSSTRING:%.*]] = unchecked_enum_data [[RESULT_OPT_NSSTRING]]
+// CHECK:   [[BRIDGE_FUNC:%.*]] = function_ref @_TZFE10FoundationSS36_unconditionallyBridgeFromObjectiveCfGSqCSo8NSString_SS
+// CHECK:   [[REWRAP_RESULT_NSSTRING:%.*]] = enum $Optional<NSString>, #Optional.some!enumelt.1, [[RESULT_NSSTRING]]
+// CHECK:   [[RESULT_STRING:%.*]] = apply [[BRIDGE_FUNC]]([[REWRAP_RESULT_NSSTRING]]
+// CHECK:   [[WRAPPED_RESULT_STRING:%.*]] = enum $Optional<String>, #Optional.some!enumelt.1, [[RESULT_STRING]]
+// CHECK:   br bb6([[WRAPPED_RESULT_STRING]] : $Optional<String>)
+
+// CHECK: bb5:
+// CHECK:   [[OPT_NONE:%.*]] = enum $Optional<String>, #Optional.none!enumelt
+// CHECK:   br bb6([[OPT_NONE]] : $Optional<String>)
+
+// CHECK: bb6([[FINAL_RESULT:%.*]] : $Optional<String>):
+// CHECK:   destroy_value [[SELF_COPY]]
+// CHECK:   destroy_value [[OPT_NSSTRING]]
+// CHECK:   return [[FINAL_RESULT]] : $Optional<String>
+// CHECK: } // end sil function '[[THUNK_BAR_2]]'
 
 func curry_returnsInnerPointer(_ x: CurryTest) -> () -> UnsafeMutableRawPointer! {
   return x.returnsInnerPointer
 }
 // CHECK-LABEL: sil hidden @_TF13objc_currying25curry_returnsInnerPointerFCSo9CurryTestFT_GSQSv_ : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned () -> Optional<UnsafeMutableRawPointer> {
-// CHECK:         [[THUNK:%.*]] = function_ref [[THUNK_RETURNSINNERPOINTER:@_TTOFCSo9CurryTest19returnsInnerPointerFT_GSQSv_]]
-// CHECK:         [[FN:%.*]] = apply [[THUNK]](%0)
-// CHECK:         return [[FN]]
+// CHECK: bb0([[SELF:%.*]] : $CurryTest):
+// CHECK:   [[THUNK:%.*]] = function_ref @[[THUNK_RETURNSINNERPOINTER:_TTOFCSo9CurryTest19returnsInnerPointerFT_GSQSv_]]
+// CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
+// CHECK:   [[FN:%.*]] = apply [[THUNK]]([[SELF_COPY]])
+// CHECK:   destroy_value [[SELF]]
+// CHECK:   return [[FN]]
+// CHECK: } // end sil function '_TF13objc_currying25curry_returnsInnerPointerFCSo9CurryTestFT_GSQSv_'
 
-// CHECK: sil shared [thunk] [[THUNK_RETURNSINNERPOINTER]] : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned () -> Optional<UnsafeMutableRawPointer>
-// CHECK:   [[THUNK:%.*]] = function_ref [[THUNK_RETURNSINNERPOINTER_2:@_TTOFCSo9CurryTest19returnsInnerPointerfT_GSQSv_]]
+// CHECK: sil shared [thunk] @[[THUNK_RETURNSINNERPOINTER]] : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned () -> Optional<UnsafeMutableRawPointer>
+// CHECK:   [[THUNK:%.*]] = function_ref @[[THUNK_RETURNSINNERPOINTER_2:_TTOFCSo9CurryTest19returnsInnerPointerfT_GSQSv_]]
 // CHECK:   [[FN:%.*]] = partial_apply [[THUNK]](%0)
 // CHECK:   return [[FN]]
+// CHECK: } // end sil function '[[THUNK_RETURNSINNERPOINTER]]'
 
-// CHECK: sil shared [thunk] @_TTOFCSo9CurryTest19returnsInnerPointerfT_GSQSv_ : $@convention(method) (@guaranteed CurryTest) -> Optional<UnsafeMutableRawPointer>
-// CHECK:  bb0([[ARG1:%.*]] : 
-// CHECK:   copy_value [[ARG1]]
-// CHECK:   [[METHOD:%.*]] = class_method [volatile] %0 : $CurryTest, #CurryTest.returnsInnerPointer!1.foreign
-// CHECK:   [[RES:%.*]] = apply [[METHOD]](%0) : $@convention(objc_method) (CurryTest) -> @unowned_inner_pointer Optional<UnsafeMutableRawPointer>
-// CHECK:   autorelease_value %0
+// CHECK: sil shared [thunk] @[[THUNK_RETURNSINNERPOINTER_2]] : $@convention(method) (@guaranteed CurryTest) -> Optional<UnsafeMutableRawPointer>
+// CHECK:  bb0([[ARG1:%.*]] : $CurryTest):
+// CHECK:   [[ARG1_COPY:%.*]] = copy_value [[ARG1]]
+// CHECK:   [[METHOD:%.*]] = class_method [volatile] [[ARG1_COPY]] : $CurryTest, #CurryTest.returnsInnerPointer!1.foreign
+// CHECK:   [[RES:%.*]] = apply [[METHOD]]([[ARG1_COPY]]) : $@convention(objc_method) (CurryTest) -> @unowned_inner_pointer Optional<UnsafeMutableRawPointer>
+// CHECK:   autorelease_value 
 // CHECK:   return [[RES]]
+// CHECK: } // end sil function '[[THUNK_RETURNSINNERPOINTER_2]]'
 
 // CHECK-LABEL: sil hidden @_TF13objc_currying19curry_pod_AnyObjectFPs9AnyObject_FSiSi : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned (Int) -> Int
-// CHECK:         dynamic_method_br [[SELF:%.*]] : $@opened({{.*}}) AnyObject, #CurryTest.pod!1.foreign, [[HAS_METHOD:bb[0-9]+]]
-// CHECK:       [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (Int, @opened({{.*}}) AnyObject) -> Int):
-// CHECK:         partial_apply [[METHOD]]([[SELF]])
+// CHECK: bb0([[ANY:%.*]] : $AnyObject):
+// CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[ANY]]
+// CHECK:   [[OPENED_ANY_COPY:%.*]] = copy_value [[OPENED_ANY]]
+// CHECK:   dynamic_method_br [[OPENED_ANY_COPY]] : $@opened({{.*}}) AnyObject, #CurryTest.pod!1.foreign, [[HAS_METHOD:bb[0-9]+]]
+// CHECK:   [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (Int, @opened({{.*}}) AnyObject) -> Int):
+// CHECK:   [[OPENED_ANY_COPY_2:%.*]] = copy_value [[OPENED_ANY_COPY]]
+// CHECK:   partial_apply [[METHOD]]([[OPENED_ANY_COPY_2]])
+// CHECK: } // end sil function '_TF13objc_currying19curry_pod_AnyObjectFPs9AnyObject_FSiSi'
 func curry_pod_AnyObject(_ x: AnyObject) -> (Int) -> Int {
   return x.pod!
 }
 
 // normalOwnership requires a thunk to bring the method to Swift conventions
-// CHECK-LABEL: sil hidden @_TF13objc_currying31curry_normalOwnership_AnyObjectFPs9AnyObject_FGSQCSo9CurryTest_GSQS1__
-// CHECK:         dynamic_method_br [[SELF:%.*]] : $@opened({{.*}}) AnyObject, #CurryTest.normalOwnership!1.foreign, [[HAS_METHOD:bb[0-9]+]]
-// CHECK:       [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (Optional<CurryTest>, @opened({{.*}}) AnyObject) -> @autoreleased Optional<CurryTest>):
-// CHECK:         [[PA:%.*]] = partial_apply [[METHOD]]([[SELF]])
-// CHECK:         [[THUNK:%.*]] = function_ref @_TTRXFo_dGSqCSo9CurryTest__oGSqS___XFo_oGSqS___oGSqS___
-// CHECK:         partial_apply [[THUNK]]([[PA]])
+// CHECK-LABEL: sil hidden @_TF13objc_currying31curry_normalOwnership_AnyObjectFPs9AnyObject_FGSQCSo9CurryTest_GSQS1__ : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned (@owned Optional<CurryTest>) -> @owned Optional<CurryTest> {
+// CHECK: bb0([[ANY:%.*]] : $AnyObject):
+// CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[ANY]]
+// CHECK:   [[OPENED_ANY_COPY:%.*]] = copy_value [[OPENED_ANY]]
+// CHECK:   dynamic_method_br [[OPENED_ANY_COPY]] : $@opened({{.*}}) AnyObject, #CurryTest.normalOwnership!1.foreign, [[HAS_METHOD:bb[0-9]+]]
+// CHECK: [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (Optional<CurryTest>, @opened({{.*}}) AnyObject) -> @autoreleased Optional<CurryTest>):
+// CHECK:   [[OPENED_ANY_COPY_2:%.*]] = copy_value [[OPENED_ANY_COPY]]
+// CHECK:   [[PA:%.*]] = partial_apply [[METHOD]]([[OPENED_ANY_COPY_2]])
+// CHECK:   [[THUNK:%.*]] = function_ref @_TTRXFo_dGSqCSo9CurryTest__oGSqS___XFo_oGSqS___oGSqS___
+// CHECK:   partial_apply [[THUNK]]([[PA]])
+// CHECK: } // end sil function '_TF13objc_currying31curry_normalOwnership_AnyObjectFPs9AnyObject_FGSQCSo9CurryTest_GSQS1__'
 func curry_normalOwnership_AnyObject(_ x: AnyObject) -> (CurryTest!) -> CurryTest! {
   return x.normalOwnership!
 }
 
 // weirdOwnership is NS_RETURNS_RETAINED and NS_CONSUMES_SELF so already
 // follows Swift conventions
-// CHECK-LABEL: sil hidden @_TF13objc_currying30curry_weirdOwnership_AnyObjectFPs9AnyObject_FGSQCSo9CurryTest_GSQS1__ : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned (@owned Optional<CurryTest>) -> @owned Optional<CurryTest> 
-// CHECK:         dynamic_method_br [[SELF:%.*]] : $@opened({{.*}}) AnyObject, #CurryTest.weirdOwnership!1.foreign, [[HAS_METHOD:bb[0-9]+]]
-// CHECK:       bb1([[METHOD:%.*]] : $@convention(objc_method) (@owned Optional<CurryTest>, @owned @opened({{.*}}) AnyObject) -> @owned Optional<CurryTest>):
-// CHECK:         partial_apply [[METHOD]]([[SELF]])
+// CHECK-LABEL: sil hidden @_TF13objc_currying30curry_weirdOwnership_AnyObjectFPs9AnyObject_FGSQCSo9CurryTest_GSQS1__ : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned (@owned Optional<CurryTest>) -> @owned Optional<CurryTest>
+// CHECK: bb0([[ANY:%.*]] : $AnyObject):
+// CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[ANY]]
+// CHECK:   [[OPENED_ANY_COPY:%.*]] = copy_value [[OPENED_ANY]]
+// CHECK:   dynamic_method_br [[SELF:%.*]] : $@opened({{.*}}) AnyObject, #CurryTest.weirdOwnership!1.foreign, [[HAS_METHOD:bb[0-9]+]]
+// CHECK: bb1([[METHOD:%.*]] : $@convention(objc_method) (@owned Optional<CurryTest>, @owned @opened({{.*}}) AnyObject) -> @owned Optional<CurryTest>):
+// CHECK:   [[OPENED_ANY_COPY_2:%.*]] = copy_value [[OPENED_ANY_COPY]]
+// CHECK:   partial_apply [[METHOD]]([[OPENED_ANY_COPY_2]])
+// CHECK: } // end sil function '_TF13objc_currying30curry_weirdOwnership_AnyObjectFPs9AnyObject_FGSQCSo9CurryTest_GSQS1__'
 func curry_weirdOwnership_AnyObject(_ x: AnyObject) -> (CurryTest!) -> CurryTest! {
   return x.weirdOwnership!
 }
 
 // bridged requires a thunk to handle bridging conversions
 // CHECK-LABEL: sil hidden @_TF13objc_currying23curry_bridged_AnyObjectFPs9AnyObject_FGSQSS_GSQSS_ : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned (@owned Optional<String>) -> @owned Optional<String>
-// CHECK:         dynamic_method_br [[SELF:%.*]] : $@opened({{.*}}) AnyObject, #CurryTest.bridged!1.foreign, [[HAS_METHOD:bb[0-9]+]]
-// CHECK:       [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (Optional<NSString>, @opened({{.*}}) AnyObject) -> @autoreleased Optional<NSString>):
-// CHECK:         [[PA:%.*]] = partial_apply [[METHOD]]([[SELF]])
-// CHECK:         [[THUNK:%.*]] = function_ref @_TTRXFo_dGSqCSo8NSString__oGSqS___XFo_oGSqSS__oGSqSS__
-// CHECK:         partial_apply [[THUNK]]([[PA]])
+// CHECK: bb0([[ANY:%.*]] : $AnyObject):
+// CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[ANY]]
+// CHECK:   [[OPENED_ANY_COPY:%.*]] = copy_value [[OPENED_ANY]]
+// CHECK:   dynamic_method_br [[OPENED_ANY_COPY]] : $@opened({{.*}}) AnyObject, #CurryTest.bridged!1.foreign, [[HAS_METHOD:bb[0-9]+]]
+// CHECK: [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (Optional<NSString>, @opened({{.*}}) AnyObject) -> @autoreleased Optional<NSString>):
+// CHECK:   [[OPENED_ANY_COPY_2:%.*]] = copy_value [[OPENED_ANY_COPY]]
+// CHECK:   [[PA:%.*]] = partial_apply [[METHOD]]([[OPENED_ANY_COPY_2]])
+// CHECK:   [[THUNK:%.*]] = function_ref @_TTRXFo_dGSqCSo8NSString__oGSqS___XFo_oGSqSS__oGSqSS__
+// CHECK:   partial_apply [[THUNK]]([[PA]])
+// CHECK: } // end sil function '_TF13objc_currying23curry_bridged_AnyObjectFPs9AnyObject_FGSQSS_GSQSS_'
 func curry_bridged_AnyObject(_ x: AnyObject) -> (String!) -> String! {
   return x.bridged!
 }
 
 // check that we substitute Self = AnyObject correctly for Self-returning
 // methods
-// CHECK-LABEL: sil hidden @_TF13objc_currying27curry_returnsSelf_AnyObjectFPs9AnyObject_FT_GSQPS0___
-// CHECK:         dynamic_method_br [[SELF:%.*]] : $@opened({{.*}}) AnyObject, #CurryTest.returnsSelf!1.foreign, [[HAS_METHOD:bb[0-9]+]]
-// CHECK:       [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> @autoreleased Optional<AnyObject>):
-// CHECK:         [[PA:%.*]] = partial_apply [[METHOD]]([[SELF]])
+// CHECK-LABEL: sil hidden @_TF13objc_currying27curry_returnsSelf_AnyObjectFPs9AnyObject_FT_GSQPS0___ : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned () -> @owned Optional<AnyObject> {
+// CHECK: bb0([[ANY:%.*]] : $AnyObject):
+// CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[ANY]]
+// CHECK:   [[OPENED_ANY_COPY:%.*]] = copy_value [[OPENED_ANY]]
+// CHECK:   dynamic_method_br [[OPENED_ANY_COPY]] : $@opened({{.*}}) AnyObject, #CurryTest.returnsSelf!1.foreign, [[HAS_METHOD:bb[0-9]+]]
+// CHECK: [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> @autoreleased Optional<AnyObject>):
+// CHECK:   [[OPENED_ANY_COPY_2:%.*]] = copy_value [[OPENED_ANY_COPY]]
+// CHECK:   [[PA:%.*]] = partial_apply [[METHOD]]([[OPENED_ANY_COPY_2]])
+// CHECK: } // end sil function '_TF13objc_currying27curry_returnsSelf_AnyObjectFPs9AnyObject_FT_GSQPS0___'
 func curry_returnsSelf_AnyObject(_ x: AnyObject) -> () -> AnyObject! {
   return x.returnsSelf!
 }
 
-// CHECK-LABEL: sil hidden @_TF13objc_currying35curry_returnsInnerPointer_AnyObjectFPs9AnyObject_FT_GSQSv_
-// CHECK:         dynamic_method_br [[SELF:%.*]] : $@opened({{.*}}) AnyObject, #CurryTest.returnsInnerPointer!1.foreign, [[HAS_METHOD:bb[0-9]+]]
-// CHECK:       [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> @unowned_inner_pointer Optional<UnsafeMutableRawPointer>):
-// CHECK:         [[PA:%.*]] = partial_apply [[METHOD]]([[SELF]])
+// CHECK-LABEL: sil hidden @_TF13objc_currying35curry_returnsInnerPointer_AnyObjectFPs9AnyObject_FT_GSQSv_ : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned () -> Optional<UnsafeMutableRawPointer> {
+// CHECK: bb0([[ANY:%.*]] : $AnyObject):
+// CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[ANY]]
+// CHECK:   [[OPENED_ANY_COPY:%.*]] = copy_value [[OPENED_ANY]]
+// CHECK:   dynamic_method_br [[OPENED_ANY_COPY]] : $@opened({{.*}}) AnyObject, #CurryTest.returnsInnerPointer!1.foreign, [[HAS_METHOD:bb[0-9]+]]
+// CHECK: [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> @unowned_inner_pointer Optional<UnsafeMutableRawPointer>):
+// CHECK:   [[OPENED_ANY_COPY_2:%.*]] = copy_value [[OPENED_ANY_COPY]]
+// CHECK:   [[PA:%.*]] = partial_apply [[METHOD]]([[OPENED_ANY_COPY_2]])
+// CHECK: } // end sil function '_TF13objc_currying35curry_returnsInnerPointer_AnyObjectFPs9AnyObject_FT_GSQSv_'
 
 func curry_returnsInnerPointer_AnyObject(_ x: AnyObject) -> () -> UnsafeMutableRawPointer! {
   return x.returnsInnerPointer!

--- a/test/SILGen/objc_dealloc.swift
+++ b/test/SILGen/objc_dealloc.swift
@@ -50,10 +50,10 @@ class SwiftGizmo : Gizmo {
   // Objective-C deallocation deinit thunk (i.e., -dealloc).
   // CHECK-LABEL: sil hidden [thunk] @_TToFC12objc_dealloc10SwiftGizmoD : $@convention(objc_method) (SwiftGizmo) -> ()
   // CHECK: bb0([[SELF:%[0-9]+]] : $SwiftGizmo):
-  // CHECK:   copy_value
+  // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
 
   // CHECK:   [[GIZMO_DTOR:%[0-9]+]] = function_ref @_TFC12objc_dealloc10SwiftGizmoD : $@convention(method) (@owned SwiftGizmo) -> ()
-  // CHECK:   [[RESULT:%[0-9]+]] = apply [[GIZMO_DTOR]]([[SELF]]) : $@convention(method) (@owned SwiftGizmo) -> ()
+  // CHECK:   [[RESULT:%[0-9]+]] = apply [[GIZMO_DTOR]]([[SELF_COPY]]) : $@convention(method) (@owned SwiftGizmo) -> ()
   // CHECK:   return [[RESULT]] : $()
 
   // Objective-C IVar initializer (i.e., -.cxx_construct)

--- a/test/SILGen/objc_dictionary_bridging.swift
+++ b/test/SILGen/objc_dictionary_bridging.swift
@@ -13,53 +13,65 @@ import gizmo
   // CHECK-LABEL: sil hidden [thunk] @_TToFC24objc_dictionary_bridging3Foo23bridge_Dictionary_param{{.*}} : $@convention(objc_method) (NSDictionary, Foo) -> ()
   func bridge_Dictionary_param(_ dict: Dictionary<Foo, Foo>) {
     // CHECK: bb0([[NSDICT:%[0-9]+]] : $NSDictionary, [[SELF:%[0-9]+]] : $Foo):
+    // CHECK:   [[NSDICT_COPY:%.*]] = copy_value [[NSDICT]]
+    // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
     // CHECK:   [[CONVERTER:%[0-9]+]] = function_ref @_TZFE10FoundationVs10Dictionary36_unconditionallyBridgeFromObjectiveCfGSqCSo12NSDictionary_GS0_xq__
-    // CHECK-NEXT: [[OPT_NSDICT:%[0-9]+]] = enum $Optional<NSDictionary>, #Optional.some!enumelt.1, [[NSDICT]] : $NSDictionary
-    // CHECK-NEXT: [[DICT_META:%[0-9]+]] = metatype $@thin Dictionary<Foo, Foo>.Type
-    // CHECK-NEXT:   [[DICT:%[0-9]+]] = apply [[CONVERTER]]<Foo, Foo>([[OPT_NSDICT]], [[DICT_META]])
+    // CHECK:   [[OPT_NSDICT:%[0-9]+]] = enum $Optional<NSDictionary>, #Optional.some!enumelt.1, [[NSDICT_COPY]] : $NSDictionary
+    // CHECK:   [[DICT_META:%[0-9]+]] = metatype $@thin Dictionary<Foo, Foo>.Type
+    // CHECK:   [[DICT:%[0-9]+]] = apply [[CONVERTER]]<Foo, Foo>([[OPT_NSDICT]], [[DICT_META]])
 
     // CHECK:   [[SWIFT_FN:%[0-9]+]] = function_ref @_TFC24objc_dictionary_bridging3Foo23bridge_Dictionary_param
-    // CHECK:   [[RESULT:%[0-9]+]] = apply [[SWIFT_FN]]([[DICT]], [[SELF]]) : $@convention(method) (@owned Dictionary<Foo, Foo>, @guaranteed Foo) -> ()
+    // CHECK:   [[RESULT:%[0-9]+]] = apply [[SWIFT_FN]]([[DICT]], [[SELF_COPY]]) : $@convention(method) (@owned Dictionary<Foo, Foo>, @guaranteed Foo) -> ()
+    // CHECK:   destroy_value [[SELF_COPY]]
     // CHECK:   return [[RESULT]] : $()
   }
+  // CHECK: } // end sil function '_TToFC24objc_dictionary_bridging3Foo23bridge_Dictionary_param{{.*}}'
 
   // Bridging dictionary results
   // CHECK-LABEL: sil hidden [thunk] @_TToFC24objc_dictionary_bridging3Foo24bridge_Dictionary_result{{.*}} : $@convention(objc_method) (Foo) -> @autoreleased NSDictionary
   func bridge_Dictionary_result() -> Dictionary<Foo, Foo> { 
     // CHECK: bb0([[SELF:%[0-9]+]] : $Foo):
+    // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
     // CHECK:   [[SWIFT_FN:%[0-9]+]] = function_ref @_TFC24objc_dictionary_bridging3Foo24bridge_Dictionary_result{{.*}} : $@convention(method) (@guaranteed Foo) -> @owned Dictionary<Foo, Foo>
-    // CHECK-NEXT:   [[DICT:%[0-9]+]] = apply [[SWIFT_FN]]([[SELF]]) : $@convention(method) (@guaranteed Foo) -> @owned Dictionary<Foo, Foo>
+    // CHECK:   [[DICT:%[0-9]+]] = apply [[SWIFT_FN]]([[SELF_COPY]]) : $@convention(method) (@guaranteed Foo) -> @owned Dictionary<Foo, Foo>
+    // CHECK:   destroy_value [[SELF_COPY]]
 
     // CHECK:   [[CONVERTER:%[0-9]+]] = function_ref @_TFE10FoundationVs10Dictionary19_bridgeToObjectiveCfT_CSo12NSDictionary
-    // CHECK-NEXT:   [[NSDICT:%[0-9]+]] = apply [[CONVERTER]]<Foo, Foo>([[DICT]]) : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned NSDictionary
-    // CHECK-NEXT:   destroy_value [[DICT]]
-    // CHECK-NEXT:   return [[NSDICT]] : $NSDictionary
+    // CHECK:   [[NSDICT:%[0-9]+]] = apply [[CONVERTER]]<Foo, Foo>([[DICT]]) : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned NSDictionary
+    // CHECK:   destroy_value [[DICT]]
+    // CHECK:   return [[NSDICT]] : $NSDictionary
   }
+  // CHECK: } // end sil function '_TToFC24objc_dictionary_bridging3Foo24bridge_Dictionary_result{{.*}}'
 
   var property: Dictionary<Foo, Foo> = [:]
 
   // Property getter
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TToFC24objc_dictionary_bridging3Foog8propertyGVs10DictionaryS0_S0__ : $@convention(objc_method) (Foo) -> @autoreleased NSDictionary
   // CHECK: bb0([[SELF:%[0-9]+]] : $Foo):
+  // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:   [[GETTER:%[0-9]+]] = function_ref @_TFC24objc_dictionary_bridging3Foog8propertyGVs10DictionaryS0_S0__ : $@convention(method) (@guaranteed Foo) -> @owned Dictionary<Foo, Foo>
-  // CHECK:   [[DICT:%[0-9]+]] = apply [[GETTER]]([[SELF]]) : $@convention(method) (@guaranteed Foo) -> @owned Dictionary<Foo, Foo>
-  
+  // CHECK:   [[DICT:%[0-9]+]] = apply [[GETTER]]([[SELF_COPY]]) : $@convention(method) (@guaranteed Foo) -> @owned Dictionary<Foo, Foo>
+  // CHECK:   destroy_value [[SELF_COPY]]
   // CHECK:   [[CONVERTER:%[0-9]+]] = function_ref @_TFE10FoundationVs10Dictionary19_bridgeToObjectiveCfT_CSo12NSDictionary
   // CHECK:   [[NSDICT:%[0-9]+]] = apply [[CONVERTER]]<Foo, Foo>([[DICT]]) : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned NSDictionary
   // CHECK:   destroy_value [[DICT]]
   // CHECK:   return [[NSDICT]] : $NSDictionary
+  // CHECK: } // end sil function '_TToFC24objc_dictionary_bridging3Foog8propertyGVs10DictionaryS0_S0__'
 
   // Property setter
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TToFC24objc_dictionary_bridging3Foos8propertyGVs10DictionaryS0_S0__ : $@convention(objc_method) (NSDictionary, Foo) -> ()
   // CHECK: bb0([[NSDICT:%[0-9]+]] : $NSDictionary, [[SELF:%[0-9]+]] : $Foo):
-// CHECK:   [[CONVERTER:%[0-9]+]] = function_ref @_TZFE10FoundationVs10Dictionary36_unconditionallyBridgeFromObjectiveCfGSqCSo12NSDictionary_GS0_xq__
-// CHECK: [[OPT_NSDICT:%[0-9]+]] = enum $Optional<NSDictionary>, #Optional.some!enumelt.1, [[NSDICT]] : $NSDictionary
-// CHECK: [[DICT_META:%[0-9]+]] = metatype $@thin Dictionary<Foo, Foo>.Type
-// CHECK:   [[DICT:%[0-9]+]] = apply [[CONVERTER]]<Foo, Foo>([[OPT_NSDICT]], [[DICT_META]])
+  // CHECK:   [[NSDICT_COPY:%.*]] = copy_value [[NSDICT]]
+  // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
+  // CHECK:   [[CONVERTER:%[0-9]+]] = function_ref @_TZFE10FoundationVs10Dictionary36_unconditionallyBridgeFromObjectiveCfGSqCSo12NSDictionary_GS0_xq__
+  // CHECK:   [[OPT_NSDICT:%[0-9]+]] = enum $Optional<NSDictionary>, #Optional.some!enumelt.1, [[NSDICT_COPY]] : $NSDictionary
+  // CHECK:   [[DICT_META:%[0-9]+]] = metatype $@thin Dictionary<Foo, Foo>.Type
+  // CHECK:   [[DICT:%[0-9]+]] = apply [[CONVERTER]]<Foo, Foo>([[OPT_NSDICT]], [[DICT_META]])
 
-// CHECK:   [[SETTER:%[0-9]+]] = function_ref @_TFC24objc_dictionary_bridging3Foos8propertyGVs10DictionaryS0_S0__ : $@convention(method) (@owned Dictionary<Foo, Foo>, @guaranteed Foo) -> ()
-// CHECK:   [[RESULT:%[0-9]+]] = apply [[SETTER]]([[DICT]], [[SELF]]) : $@convention(method) (@owned Dictionary<Foo, Foo>, @guaranteed Foo) -> ()
-// CHECK:   return [[RESULT]] : $()
+  // CHECK:   [[SETTER:%[0-9]+]] = function_ref @_TFC24objc_dictionary_bridging3Foos8propertyGVs10DictionaryS0_S0__ : $@convention(method) (@owned Dictionary<Foo, Foo>, @guaranteed Foo) -> ()
+  // CHECK:   [[RESULT:%[0-9]+]] = apply [[SETTER]]([[DICT]], [[SELF_COPY]]) : $@convention(method) (@owned Dictionary<Foo, Foo>, @guaranteed Foo) -> ()
+  // CHECK:   destroy_value [[SELF_COPY]]
+  // CHECK:   return [[RESULT]] : $()
 
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TToFC24objc_dictionary_bridging3Foog19nonVerbatimProperty{{.*}} : $@convention(objc_method) (Foo) -> @autoreleased NSDictionary
 

--- a/test/SILGen/objc_error.swift
+++ b/test/SILGen/objc_error.swift
@@ -7,17 +7,25 @@
 
 import Foundation
 
-// CHECK-LABEL: sil hidden @_TF10objc_error20NSErrorError_erasureFCSo7NSErrorPs5Error_
-// CHECK:         [[ERROR_TYPE:%.*]] = init_existential_ref %0 : $NSError : $NSError, $Error
-// CHECK:         return [[ERROR_TYPE]]
+// CHECK-LABEL: sil hidden @_TF10objc_error20NSErrorError_erasureFCSo7NSErrorPs5Error_ : $@convention(thin) (@owned NSError) -> @owned Error {
+// CHECK:         bb0([[ERROR:%.*]] : $NSError):
+// CHECK:           [[ERROR_COPY:%.*]] = copy_value [[ERROR]]
+// CHECK:           [[ERROR_TYPE:%.*]] = init_existential_ref [[ERROR_COPY]] : $NSError : $NSError, $Error
+// CHECK:           destroy_value [[ERROR]]
+// CHECK:           return [[ERROR_TYPE]]
+// CHECK:       } // end sil function '_TF10objc_error20NSErrorError_erasureFCSo7NSErrorPs5Error_'
 func NSErrorError_erasure(_ x: NSError) -> Error {
   return x
 }
 
-// CHECK-LABEL: sil hidden @_TF10objc_error30NSErrorError_archetype_erasure
-// CHECK:         [[T0:%.*]] = upcast %0 : $T to $NSError
-// CHECK:         [[ERROR_TYPE:%.*]] = init_existential_ref [[T0]] : $NSError : $NSError, $Error
-// CHECK:         return [[ERROR_TYPE]]
+// CHECK-LABEL: sil hidden @_TF10objc_error30NSErrorError_archetype_erasureuRxCSo7NSErrorrFxPs5Error_ : $@convention(thin) <T where T : NSError> (@owned T) -> @owned Error {
+// CHECK:         bb0([[ERROR:%.*]] : $T):
+// CHECK:           [[ERROR_COPY:%.*]] = copy_value [[ERROR]]
+// CHECK:           [[T0:%.*]] = upcast [[ERROR_COPY]] : $T to $NSError
+// CHECK:           [[ERROR_TYPE:%.*]] = init_existential_ref [[T0]] : $NSError : $NSError, $Error
+// CHECK:           destroy_value [[ERROR]]
+// CHECK:           return [[ERROR_TYPE]]
+// CHECK: } // end sil function '_TF10objc_error30NSErrorError_archetype_erasureuRxCSo7NSErrorrFxPs5Error_'
 func NSErrorError_archetype_erasure<T : NSError>(_ t: T) -> Error {
   return t
 }
@@ -110,10 +118,12 @@ func eraseMyNSError() -> Error {
 func eraseFictionalServerError() -> Error {
   // CHECK-NOT: return
   // CHECK: [[NSERROR:%[0-9]+]] = struct_extract {{.*}} : $FictionalServerError, #FictionalServerError._nsError
-  // CHECK: [[ERROR:%[0-9]+]] = init_existential_ref [[NSERROR]]
+  // CHECK: [[NSERROR_COPY:%.*]] = copy_value [[NSERROR]]
+  // CHECK: [[ERROR:%[0-9]+]] = init_existential_ref [[NSERROR_COPY]]
   // CHECK: return [[ERROR]]
   return FictionalServerError(.meltedDown)
 }
+// CHECK: } // end sil function '_TF10objc_error25eraseFictionalServerErrorFT_Ps5Error_'
 
 // SR-1562
 extension Error {

--- a/test/SILGen/objc_extensions.swift
+++ b/test/SILGen/objc_extensions.swift
@@ -12,10 +12,76 @@ extension Sub {
     didSet {
       // Ignore it.
     }
-    // CHECK-LABEL: sil hidden [transparent] [thunk] @_TToFC15objc_extensions3Subg4propGSQSS_
-    // CHECK: = super_method [volatile] %1 : $Sub, #Base.prop!setter.1.foreign
-    // CHECK: = function_ref @_TFC15objc_extensions3SubW4propGSQSS_
-    // CHECK: }
+
+    // Make sure that we are generating the @objc thunk and are calling the actual method.
+    //
+    // CHECK-LABEL: sil hidden [transparent] [thunk] @_TToFC15objc_extensions3Subg4propGSQSS_ : $@convention(objc_method) (Sub) -> @autoreleased Optional<NSString> {
+    // CHECK: bb0([[SELF:%.*]] : $Sub):
+    // CHECK: [[SELF_COPY:%.*]] = copy_value [[SELF]]
+    // CHECK: [[GETTER_FUNC:%.*]] = function_ref @_TFC15objc_extensions3Subg4propGSQSS_ : $@convention(method) (@guaranteed Sub) -> @owned Optional<String>
+    // CHECK: apply [[GETTER_FUNC]]([[SELF_COPY]])
+    // CHECK: destroy_value [[SELF_COPY]]
+    // CHECK: } // end sil function '_TToFC15objc_extensions3Subg4propGSQSS_'
+
+    // Then check the body of the getter calls the super_method.
+    // CHECK-LABEL: sil hidden [transparent] @_TFC15objc_extensions3Subg4propGSQSS_ : $@convention(method) (@guaranteed Sub) -> @owned Optional<String> {
+    // CHECK: bb0([[SELF:%.*]] : $Sub):
+    // CHECK: [[SELF_COPY:%.*]] = copy_value [[SELF]]
+    // CHECK: [[SELF_COPY_CAST:%.*]] = upcast [[SELF_COPY]] : $Sub to $Base
+    // CHECK: [[SUPER_METHOD:%.*]] = super_method [volatile] [[SELF_COPY]] : $Sub, #Base.prop!getter.1.foreign
+    // CHECK: [[RESULT:%.*]] = apply [[SUPER_METHOD]]([[SELF_COPY_CAST]])
+    // CHECK: bb3(
+    // CHECK: destroy_value [[SELF_COPY]]
+    // CHECK: } // end sil function '_TFC15objc_extensions3Subg4propGSQSS_'
+
+    // Then check the setter @objc thunk.
+    //
+    // TODO: This codegens using a select_enum + cond_br. It would be better to
+    // just use a switch_enum so we can consume the value. This change will be
+    // necessary in a semantic ARC world.
+    //
+    // CHECK-LABEL: sil hidden [thunk] @_TToFC15objc_extensions3Subs4propGSQSS_ : $@convention(objc_method) (Optional<NSString>, Sub) -> () {
+    // CHECK: bb0([[NEW_VALUE:%.*]] : $Optional<NSString>, [[SELF:%.*]] : $Sub):
+    // CHECK: [[SELF_COPY:%.*]] = copy_value [[SELF]] : $Sub
+    // CHECK: bb1:
+    // CHECK: bb3([[BRIDGED_NEW_VALUE:%.*]] : $Optional<String>):
+    // CHECK:   [[NORMAL_FUNC:%.*]] = function_ref @_TFC15objc_extensions3Subs4propGSQSS_ : $@convention(method) (@owned Optional<String>, @guaranteed Sub) -> ()
+    // CHECK:   apply [[NORMAL_FUNC]]([[BRIDGED_NEW_VALUE]], [[SELF_COPY]])
+    // CHECK:   destroy_value [[SELF_COPY]]
+    // CHECK: } // end sil function '_TToFC15objc_extensions3Subs4propGSQSS_'
+
+    // Then check the body of the actually setter value and make sure that we
+    // call the didSet function.
+    // CHECK-LABEL: sil hidden @_TFC15objc_extensions3Subs4propGSQSS_ : $@convention(method) (@owned Optional<String>, @guaranteed Sub) -> () {
+
+    // First we get the old value.
+    // CHECK: bb0([[NEW_VALUE:%.*]] : $Optional<String>, [[SELF:%.*]] : $Sub):
+    // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
+    // CHECK:   [[UPCAST_SELF_COPY:%.*]] = upcast [[SELF_COPY]] : $Sub to $Base
+    // CHECK:   [[GET_SUPER_METHOD:%.*]] = super_method [volatile] [[SELF_COPY]] : $Sub, #Base.prop!getter.1.foreign : (Base) -> () -> String! , $@convention(objc_method) (Base) -> @autoreleased Optional<NSString>
+    // CHECK:   [[OLD_NSSTRING:%.*]] = apply [[GET_SUPER_METHOD]]([[UPCAST_SELF_COPY]])
+
+    // CHECK: bb3([[OLD_NSSTRING_BRIDGED:%.*]] : $Optional<String>):
+    // This next line is completely not needed. But we are emitting it now.
+    // CHECK:   [[OLD_NSSTRING_BRIDGED_CAST:%.*]] = unchecked_bitwise_cast [[OLD_NSSTRING_BRIDGED]]
+    // CHECK:   destroy_value [[SELF_COPY]]
+    // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
+    // CHECK:   [[UPCAST_SELF_COPY:%.*]] = upcast [[SELF_COPY]] : $Sub to $Base
+    // CHECK:   [[SET_SUPER_METHOD:%.*]] = super_method [volatile] [[SELF_COPY]] : $Sub, #Base.prop!setter.1.foreign : (Base) -> (String!) -> () , $@convention(objc_method) (Optional<NSString>, Base) -> ()
+    // CHECK: bb4:
+    // CHECK: bb6([[BRIDGED_NEW_STRING:%.*]] : $Optional<NSString>):
+    // CHECK:    apply [[SET_SUPER_METHOD]]([[BRIDGED_NEW_STRING]], [[UPCAST_SELF_COPY]])
+    // CHECK:    destroy_value [[BRIDGED_NEW_STRING]]
+    // CHECK:    destroy_value [[SELF_COPY]]
+    // CHECK:    [[DIDSET_NOTIFIER:%.*]] = function_ref @_TFC15objc_extensions3SubW4propGSQSS_ : $@convention(method) (@owned Optional<String>, @guaranteed Sub) -> ()
+    // CHECK:    [[COPIED_OLD_NSSTRING_BRIDGED_CAST:%.*]] = copy_value [[OLD_NSSTRING_BRIDGED_CAST]]
+    // This is an identity cast that should be elimianted by SILGen peepholes.
+    // CHECK:    [[COPIED_OLD_NSSTRING_BRIDGED_CAST2:%.*]] = unchecked_bitwise_cast [[COPIED_OLD_NSSTRING_BRIDGED_CAST]]
+    // CHECK:    apply [[DIDSET_NOTIFIER]]([[COPIED_OLD_NSSTRING_BRIDGED_CAST2]], [[SELF]])
+    // CHECK:    destroy_value [[OLD_NSSTRING_BRIDGED_CAST]]
+    // CHECK:    destroy_value [[NEW_VALUE]]
+    // CHECK: } // end sil function '_TFC15objc_extensions3Subs4propGSQSS_'
+
   }
 
   func foo() {
@@ -34,8 +100,12 @@ testOverrideProperty(Sub())
 
 // CHECK-LABEL: sil shared [thunk] @_TFC15objc_extensions3Sub3fooFT_T_
 // CHECK:         function_ref @_TTDFC15objc_extensions3Sub3foofT_T_
+// CHECK: } // end sil function '_TFC15objc_extensions3Sub3fooFT_T_'
 // CHECK:       sil shared [transparent] [thunk] @_TTDFC15objc_extensions3Sub3foofT_T_
-// CHECK:         class_method [volatile] %0 : $Sub, #Sub.foo!1.foreign
+// CHECK:       bb0([[SELF:%.*]] : $Sub):
+// CHECK:         [[SELF_COPY:%.*]] = copy_value [[SELF]]
+// CHECK:         class_method [volatile] [[SELF_COPY]] : $Sub, #Sub.foo!1.foreign
+// CHECK: } // end sil function '_TTDFC15objc_extensions3Sub3foofT_T_'
 func testCurry(_ x: Sub) {
   _ = x.foo
 }
@@ -48,8 +118,11 @@ extension Sub {
 }
 
 class SubSub : Sub {
-// CHECK-LABEL: sil hidden @_TFC15objc_extensions6SubSub14objCBaseMethodfT_T_
-// CHECK:  super_method [volatile] %0 : $SubSub, #Sub.objCBaseMethod!1.foreign : (Sub) -> () -> () , $@convention(objc_method) (Sub) -> ()
+  // CHECK-LABEL: sil hidden @_TFC15objc_extensions6SubSub14objCBaseMethodfT_T_
+  // CHECK: bb0([[SELF:%.*]] : $SubSub):
+  // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
+  // CHECK:   super_method [volatile] [[SELF_COPY]] : $SubSub, #Sub.objCBaseMethod!1.foreign : (Sub) -> () -> () , $@convention(objc_method) (Sub) -> ()
+  // CHECK: } // end sil function '_TFC15objc_extensions6SubSub14objCBaseMethodfT_T_'
   override func objCBaseMethod() {
     super.objCBaseMethod()
   }
@@ -57,8 +130,12 @@ class SubSub : Sub {
 
 extension SubSub {
   // CHECK-LABEL: sil hidden @_TFC15objc_extensions6SubSubs9otherPropSS
-  // CHECK: = super_method [volatile] %1 : $SubSub, #Sub.otherProp!getter.1.foreign
-  // CHECK: = super_method [volatile] %1 : $SubSub, #Sub.otherProp!setter.1.foreign
+  // CHECK: bb0([[NEW_VALUE:%.*]] : $String, [[SELF:%.*]] : $SubSub):
+  // CHECK:   [[SELF_COPY_1:%.*]] = copy_value [[SELF]]
+  // CHECK:   = super_method [volatile] [[SELF_COPY_1]] : $SubSub, #Sub.otherProp!getter.1.foreign
+  // CHECK:   [[SELF_COPY_2:%.*]] = copy_value [[SELF]]
+  // CHECK:   = super_method [volatile] [[SELF_COPY_2]] : $SubSub, #Sub.otherProp!setter.1.foreign
+  // CHECK: } // end sil function '_TFC15objc_extensions6SubSubs9otherPropSS'
   override var otherProp: String {
     didSet {
       // Ignore it.

--- a/test/SILGen/objc_generic_class.swift
+++ b/test/SILGen/objc_generic_class.swift
@@ -18,8 +18,9 @@ class Generic<T>: NSObject {
   // CHECK:       bb0({{%.*}} : $Generic<T>):
   // CHECK-LABEL: sil hidden [thunk] @_TToFC18objc_generic_class7GenericD : $@convention(objc_method) <T> (Generic<T>) -> () {
   // CHECK:       bb0([[SELF:%.*]] : $Generic<T>):
+  // CHECK:         [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:         [[NATIVE:%.*]] = function_ref @_TFC18objc_generic_class7GenericD
-  // CHECK:         apply [[NATIVE]]<T>([[SELF]])
+  // CHECK:         apply [[NATIVE]]<T>([[SELF_COPY]])
   deinit {
     // Don't blow up when 'self' is referenced inside an @objc deinit method
     // of a generic class. <rdar://problem/16325525>

--- a/test/SILGen/objc_imported_generic.swift
+++ b/test/SILGen/objc_imported_generic.swift
@@ -24,25 +24,37 @@ public func genericMethodOnAnyObjectChained(o: AnyObject, b: Bool) -> AnyObject?
   return o.thing?()
 }
 
-// CHECK-LABEL: sil @_TF21objc_imported_generic31genericMethodOnAnyObjectChained
-// CHECK:         dynamic_method_br %4 : $@opened([[TAG:.*]]) AnyObject, #GenericClass.thing!1.foreign, bb1
-// CHECK:       bb1({{%.*}} : $@convention(objc_method) @pseudogeneric (@opened([[TAG]]) AnyObject) -> @autoreleased Optional<AnyObject>):
+// CHECK-LABEL: sil @_TF21objc_imported_generic31genericMethodOnAnyObjectChainedFT1oPs9AnyObject_1bSb_GSqPS0___
+// CHECK: bb0([[ANY:%.*]] : $AnyObject, [[BOOL:%.*]] : $Bool):
+// CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[ANY]]
+// CHECK:   [[OPENED_ANY_COPY:%.*]] = copy_value [[OPENED_ANY]]
+// CHECK:   dynamic_method_br [[OPENED_ANY_COPY]] : $@opened([[TAG:.*]]) AnyObject, #GenericClass.thing!1.foreign, bb1
+// CHECK:   bb1({{%.*}} : $@convention(objc_method) @pseudogeneric (@opened([[TAG]]) AnyObject) -> @autoreleased Optional<AnyObject>):
+// CHECK: } // end sil function '_TF21objc_imported_generic31genericMethodOnAnyObjectChainedFT1oPs9AnyObject_1bSb_GSqPS0___'
 
 public func genericSubscriptOnAnyObject(o: AnyObject, b: Bool) -> AnyObject? {
   return o[0 as UInt16]
 }
 
-// CHECK-LABEL: sil @_TF21objc_imported_generic27genericSubscriptOnAnyObject
-// CHECK:         dynamic_method_br %4 : $@opened([[TAG:.*]]) AnyObject, #GenericClass.subscript!getter.1.foreign, bb1
-// CHECK:       bb1({{%.*}} : $@convention(objc_method) @pseudogeneric (UInt16, @opened([[TAG]]) AnyObject) -> @autoreleased AnyObject):
+// CHECK-LABEL: sil @_TF21objc_imported_generic27genericSubscriptOnAnyObjectFT1oPs9AnyObject_1bSb_GSqPS0___
+// CHECK: bb0([[ANY:%.*]]
+// CHCEK:   [[OPENED_ANY:%.*]] = open_existential_ref [[ANY]]
+// CHECK:   [[OPENED_ANY_COPY:%.*]] = copy_value [[OPENED_ANY]]
+// CHECK:   dynamic_method_br [[OPENED_ANY_COPY]] : $@opened([[TAG:.*]]) AnyObject, #GenericClass.subscript!getter.1.foreign, bb1
+// CHECK:   bb1({{%.*}} : $@convention(objc_method) @pseudogeneric (UInt16, @opened([[TAG]]) AnyObject) -> @autoreleased AnyObject):
+// CHECK: } // end sil function '_TF21objc_imported_generic27genericSubscriptOnAnyObjectFT1oPs9AnyObject_1bSb_GSqPS0___'
 
 public func genericPropertyOnAnyObject(o: AnyObject, b: Bool) -> AnyObject?? {
   return o.propertyThing
 }
 
-// CHECK-LABEL: sil @_TF21objc_imported_generic26genericPropertyOnAnyObject
-// CHECK:         dynamic_method_br %4 : $@opened([[TAG:.*]]) AnyObject, #GenericClass.propertyThing!getter.1.foreign, bb1
-// CHECK:       bb1({{%.*}} : $@convention(objc_method) @pseudogeneric (@opened([[TAG]]) AnyObject) -> @autoreleased Optional<AnyObject>):
+// CHECK-LABEL: sil @_TF21objc_imported_generic26genericPropertyOnAnyObjectFT1oPs9AnyObject_1bSb_GSqGSqPS0____
+// CHECK: bb0([[ANY:%.*]] : $AnyObject, [[BOOL:%.*]] : $Bool):
+// CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[ANY]]
+// CHECK:   [[OPENED_ANY_COPY:%.*]] = copy_value [[OPENED_ANY]]
+// CHECK:   dynamic_method_br [[OPENED_ANY_COPY]] : $@opened([[TAG:.*]]) AnyObject, #GenericClass.propertyThing!getter.1.foreign, bb1
+// CHECK:   bb1({{%.*}} : $@convention(objc_method) @pseudogeneric (@opened([[TAG]]) AnyObject) -> @autoreleased Optional<AnyObject>):
+// CHECK: } // end sil function '_TF21objc_imported_generic26genericPropertyOnAnyObjectFT1oPs9AnyObject_1bSb_GSqGSqPS0____'
 
 public protocol ThingHolder {
   associatedtype Thing

--- a/test/SILGen/objc_init_ref_delegation.swift
+++ b/test/SILGen/objc_init_ref_delegation.swift
@@ -15,9 +15,9 @@ extension Gizmo {
     // CHECK:   [[SELF:%[0-9]+]] = load [[SELFMUI]] : $*Gizmo
     // CHECK:   [[INIT_DELEG:%[0-9]+]] = class_method [volatile] [[SELF]] : $Gizmo, #Gizmo.init!initializer.1.foreign : (Gizmo.Type) -> (Int) -> Gizmo! , $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
     // CHECK:   [[SELF_RET:%[0-9]+]] = apply [[INIT_DELEG]]([[I]], [[SELF]]) : $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
-    // CHECK:   copy_value [[SELF4:%[0-9]+]] : $Gizmo
+    // CHECK:   [[SELF4_COPY:%.*]] = copy_value [[SELF4:%[0-9]+]] : $Gizmo
     // CHECK:   destroy_value [[SELF_BOX:%[0-9]+]] : $@box Gizmo
-    // CHECK:   return [[SELF4]] : $Gizmo
+    // CHECK:   return [[SELF4_COPY]] : $Gizmo
     self.init(bellsOn:i)
   }
 }

--- a/test/SILGen/objc_metatypes.swift
+++ b/test/SILGen/objc_metatypes.swift
@@ -9,16 +9,18 @@ import gizmo
 class A {
   // CHECK-LABEL: sil hidden @_TFC14objc_metatypes1A3foo
 
-  // CHECK-LABEL: sil hidden [thunk] @_TToFC14objc_metatypes1A3foo
+  // CHECK-LABEL: sil hidden [thunk] @_TToFC14objc_metatypes1A3foofMCS_9ObjCClassMS1_
   dynamic func foo(_ m: ObjCClass.Type) -> ObjCClass.Type {
     // CHECK: bb0([[M:%[0-9]+]] : $@objc_metatype ObjCClass.Type, [[SELF:%[0-9]+]] : $A):
-    // CHECK:   copy_value [[SELF]] : $A
+    // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]] : $A
     // CHECK:   [[M_AS_THICK:%[0-9]+]] = objc_to_thick_metatype [[M]] : $@objc_metatype ObjCClass.Type to $@thick ObjCClass.Type
 
     // CHECK:   [[NATIVE_FOO:%[0-9]+]] = function_ref @_TFC14objc_metatypes1A3foo
-    // CHECK:   [[NATIVE_RESULT:%[0-9]+]] = apply [[NATIVE_FOO]]([[M_AS_THICK]], [[SELF]]) : $@convention(method) (@thick ObjCClass.Type, @guaranteed A) -> @thick ObjCClass.Type
+    // CHECK:   [[NATIVE_RESULT:%[0-9]+]] = apply [[NATIVE_FOO]]([[M_AS_THICK]], [[SELF_COPY]]) : $@convention(method) (@thick ObjCClass.Type, @guaranteed A) -> @thick ObjCClass.Type
+    // CHECK:   destroy_value [[SELF_COPY]]
     // CHECK:   [[OBJC_RESULT:%[0-9]+]] = thick_to_objc_metatype [[NATIVE_RESULT]] : $@thick ObjCClass.Type to $@objc_metatype ObjCClass.Type
     // CHECK:   return [[OBJC_RESULT]] : $@objc_metatype ObjCClass.Type
+    // CHECK: } // end sil function '_TToFC14objc_metatypes1A3foofMCS_9ObjCClassMS1_'
     return m
   }
 

--- a/test/SILGen/objc_properties.swift
+++ b/test/SILGen/objc_properties.swift
@@ -154,24 +154,25 @@ class Singleton : NSObject {
 
 class HasUnmanaged : NSObject {
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TToFC15objc_properties12HasUnmanagedg3refGSqGVs9UnmanagedPs9AnyObject___
-  // CHECK: [[NATIVE:%.+]] = function_ref @_TFC15objc_properties12HasUnmanagedg3refGSqGVs9UnmanagedPs9AnyObject___
-  // CHECK: [[RESULT:%.+]] = apply [[NATIVE]](%0)
+  // CHECK: bb0([[CLS:%.*]] : $HasUnmanaged):
+  // CHECK:     [[CLS_COPY:%.*]] = copy_value [[CLS]]
+  // CHECK:     [[NATIVE:%.+]] = function_ref @_TFC15objc_properties12HasUnmanagedg3refGSqGVs9UnmanagedPs9AnyObject___
+  // CHECK:     [[RESULT:%.+]] = apply [[NATIVE]]([[CLS_COPY]])
   // CHECK-NOT: {{(retain|release)}}
-  // CHECK: destroy_value %0 : $HasUnmanaged
+  // CHECK:     destroy_value [[CLS_COPY]] : $HasUnmanaged
   // CHECK-NOT: {{(retain|release)}}
-  // CHECK: return [[RESULT]] : $Optional<Unmanaged<AnyObject>>
+  // CHECK:     return [[RESULT]] : $Optional<Unmanaged<AnyObject>>
+  // CHECK: } // end sil function '_TToFC15objc_properties12HasUnmanagedg3refGSqGVs9UnmanagedPs9AnyObject___'
 
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TToFC15objc_properties12HasUnmanageds3refGSqGVs9UnmanagedPs9AnyObject___
-  // CHECK-NOT: {{(retain|release)}}
-  // CHECK: copy_value %1 : $HasUnmanaged
-  // CHECK-NOT: {{(retain|release)}}
-  // CHECK: [[NATIVE:%.+]] = function_ref @_TFC15objc_properties12HasUnmanageds3refGSqGVs9UnmanagedPs9AnyObject___
-  // CHECK-NOT: {{(retain|release)}}
-  // CHECK: apply [[NATIVE]](%0, %1)
-  // CHECK-NOT: {{(retain|release)}}
-  // CHECK: destroy_value %1 : $HasUnmanaged
-  // CHECK-NOT: {{(retain|release)}}
-  // CHECK: return
+  // CHECK: bb0([[NEW_VALUE:%.*]] : $Optional<Unmanaged<AnyObject>>, [[SELF:%.*]] : $HasUnmanaged):
+  // CHECK-NEXT: [[SELF_COPY:%.*]] = copy_value [[SELF]] : $HasUnmanaged
+  // CHECK-NEXT: // function_ref
+  // CHECK-NEXT: [[NATIVE:%.+]] = function_ref @_TFC15objc_properties12HasUnmanageds3refGSqGVs9UnmanagedPs9AnyObject___
+  // CHECK-NEXT: [[RESULT:%.*]] = apply [[NATIVE]]([[NEW_VALUE]], [[SELF_COPY]])
+  // CHECK-NEXT: destroy_value [[SELF_COPY]] : $HasUnmanaged
+  // CHECK-NEXT: return [[RESULT:%.*]]
+  // CHECK: } // end sil function '_TToFC15objc_properties12HasUnmanageds3refGSqGVs9UnmanagedPs9AnyObject___'
   var ref: Unmanaged<AnyObject>?
 }
 

--- a/test/SILGen/objc_protocols.swift
+++ b/test/SILGen/objc_protocols.swift
@@ -39,46 +39,56 @@ func objc_generic<T : NSRuncing>(_ x: T) -> (NSObject, NSObject) {
   // CHECK: destroy_value [[THIS2]]
 }
 
+// CHECK-LABEL: sil hidden @_TF14objc_protocols26objc_generic_partial_applyuRxS_9NSRuncingrFxT_ : $@convention(thin) <T where T : NSRuncing> (@owned T) -> () {
 func objc_generic_partial_apply<T : NSRuncing>(_ x: T) {
-  // CHECK:      [[FN:%.*]] = function_ref @_TTOFP14objc_protocols9NSRuncing5runceFT_CSo8NSObject
-  // CHECK-NEXT: copy_value %0
-  // CHECK-NEXT: [[METHOD:%.*]] = apply [[FN]]<T>(%0)
-  // CHECK-NEXT: destroy_value [[METHOD]]
+  // CHECK: bb0([[ARG:%.*]] : $T):
+  // CHECK:   [[FN:%.*]] = function_ref @[[THUNK1:_TTOFP14objc_protocols9NSRuncing5runceFT_CSo8NSObject]] :
+  // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+  // CHECK:   [[METHOD:%.*]] = apply [[FN]]<T>([[ARG_COPY]])
+  // CHECK:   destroy_value [[METHOD]]
   _ = x.runce
 
-  // CHECK:      [[FN:%.*]] = function_ref @_TTOFP14objc_protocols9NSRuncing5runceFT_CSo8NSObject
-  // CHECK-NEXT: [[METHOD:%.*]] = partial_apply [[FN]]<T>()
-  // CHECK-NEXT: destroy_value [[METHOD]]
+  // CHECK:   [[FN:%.*]] = function_ref @[[THUNK1]] :
+  // CHECK:   [[METHOD:%.*]] = partial_apply [[FN]]<T>()
+  // CHECK:   destroy_value [[METHOD]]
   _ = T.runce
 
-  // CHECK:      [[FN:%.*]] = function_ref @_TTOZFP14objc_protocols9NSRuncing5minceFT_CSo8NSObject
-  // CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thick T.Type
-  // CHECK-NEXT: [[METHOD:%.*]] = apply [[FN]]<T>([[METATYPE]])
-  // CHECK-NEXT: destroy_value [[METHOD:%.*]]
+  // CHECK:   [[FN:%.*]] = function_ref @[[THUNK2:_TTOZFP14objc_protocols9NSRuncing5minceFT_CSo8NSObject]]
+  // CHECK:   [[METATYPE:%.*]] = metatype $@thick T.Type
+  // CHECK:   [[METHOD:%.*]] = apply [[FN]]<T>([[METATYPE]])
+  // CHECK:   destroy_value [[METHOD:%.*]]
   _ = T.mince
+  // CHECK:   destroy_value [[ARG]]
 }
+// CHECK: } // end sil function '_TF14objc_protocols26objc_generic_partial_applyuRxS_9NSRuncingrFxT_'
 
-// CHECK-LABEL: sil shared [thunk] @_TTOFP14objc_protocols9NSRuncing5runceFT_CSo8NSObject
-// CHECK:      [[FN:%.*]] = function_ref @_TTOFP14objc_protocols9NSRuncing5runcefT_CSo8NSObject
-// CHECK-NEXT: [[METHOD:%.*]] = partial_apply [[FN]]<Self>(%0)
-// CHECK-NEXT: return [[METHOD]]
+// CHECK: sil shared [thunk] @[[THUNK1]] :
+// CHECK: bb0([[SELF:%.*]] : $Self):
+// CHECK:   [[FN:%.*]] = function_ref @[[THUNK1_THUNK:_TTOFP14objc_protocols9NSRuncing5runcefT_CSo8NSObject]] :
+// CHECK:   [[METHOD:%.*]] = partial_apply [[FN]]<Self>([[SELF]])
+// CHECK:   return [[METHOD]]
+// CHECK: } // end sil function '[[THUNK1]]'
 
-// CHECK-LABEL: sil shared [thunk] @_TTOFP14objc_protocols9NSRuncing5runcefT_CSo8NSObject
-// CHECK:      copy_value %0
-// CHECK-NEXT: [[FN:%.*]] = witness_method $Self, #NSRuncing.runce!1.foreign
-// CHECK-NEXT: [[RESULT:%.*]] = apply [[FN]]<Self>(%0)
-// CHECK-NEXT: destroy_value %0
-// CHECK-NEXT: return [[RESULT]]
+// CHECK: sil shared [thunk] @[[THUNK1_THUNK]]
+// CHECK: bb0([[SELF:%.*]] : $Self):
+// CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
+// CHECK:   [[FN:%.*]] = witness_method $Self, #NSRuncing.runce!1.foreign
+// CHECK:   [[RESULT:%.*]] = apply [[FN]]<Self>([[SELF_COPY]])
+// CHECK:   destroy_value [[SELF_COPY]]
+// CHECK:   return [[RESULT]]
+// CHECK: } // end sil function '[[THUNK1_THUNK]]'
 
-// CHECK-LABEL: sil shared [thunk] @_TTOZFP14objc_protocols9NSRuncing5minceFT_CSo8NSObject
-// CHECK:      [[FN:%.*]] = function_ref @_TTOZFP14objc_protocols9NSRuncing5mincefT_CSo8NSObject
-// CHECK-NEXT: [[METHOD:%.*]] = partial_apply [[FN]]<Self>(%0)
-// CHECK-NEXT: return [[METHOD]]
+// CHECK: sil shared [thunk] @[[THUNK2]] :
+// CHECK:   [[FN:%.*]] = function_ref @[[THUNK2_THUNK:_TTOZFP14objc_protocols9NSRuncing5mincefT_CSo8NSObject]]
+// CHECK:   [[METHOD:%.*]] = partial_apply [[FN]]<Self>(%0)
+// CHECK:   return [[METHOD]]
+// CHECK: } // end sil function '[[THUNK2]]'
 
-// CHECK-LABEL: sil shared [thunk] @_TTOZFP14objc_protocols9NSRuncing5mincefT_CSo8NSObject
+// CHECK: sil shared [thunk] @[[THUNK2_THUNK]] :
 // CHECK:      [[FN:%.*]] = witness_method $Self, #NSRuncing.mince!1.foreign
 // CHECK-NEXT: [[RESULT:%.*]] = apply [[FN]]<Self>(%0)
 // CHECK-NEXT: return [[RESULT]]
+// CHECK: } // end sil function '[[THUNK2_THUNK]]'
 
 // CHECK-LABEL: sil hidden  @_TF14objc_protocols13objc_protocol
 func objc_protocol(_ x: NSRuncing) -> (NSObject, NSObject) {
@@ -97,18 +107,21 @@ func objc_protocol(_ x: NSRuncing) -> (NSObject, NSObject) {
   // CHECK: destroy_value [[THIS2_ORIG]]
 }
 
+// CHECK-LABEL: sil hidden @_TF14objc_protocols27objc_protocol_partial_applyFPS_9NSRuncing_T_ : $@convention(thin) (@owned NSRuncing) -> () {
 func objc_protocol_partial_apply(_ x: NSRuncing) {
-  // CHECK: [[THIS1:%.*]] = open_existential_ref %0 : $NSRuncing to $[[OPENED:@opened(.*) NSRuncing]]
-  // CHECK: [[FN:%.*]] = function_ref @_TTOFP14objc_protocols9NSRuncing5runceFT_CSo8NSObject
-  // CHECK: copy_value [[THIS1]]
-  // CHECK: [[RESULT:%.*]] = apply [[FN]]<[[OPENED]]>([[THIS1]])
-  // CHECK: destroy_value [[RESULT]]
-  // CHECK: destroy_value %0
+  // CHECK: bb0([[ARG:%.*]] : $NSRuncing):
+  // CHECK:   [[OPENED_ARG:%.*]] = open_existential_ref [[ARG]] : $NSRuncing to $[[OPENED:@opened(.*) NSRuncing]]
+  // CHECK:   [[FN:%.*]] = function_ref @_TTOFP14objc_protocols9NSRuncing5runceFT_CSo8NSObject
+  // CHECK:   [[OPENED_ARG_COPY:%.*]] = copy_value [[OPENED_ARG]]
+  // CHECK:   [[RESULT:%.*]] = apply [[FN]]<[[OPENED]]>([[OPENED_ARG_COPY]])
+  // CHECK:   destroy_value [[RESULT]]
+  // CHECK:   destroy_value [[ARG]]
   _ = x.runce
 
   // FIXME: rdar://21289579
   // _ = NSRuncing.runce
 }
+// CHECK : } // end sil function '_TF14objc_protocols27objc_protocol_partial_applyFPS_9NSRuncing_T_'
 
 // CHECK-LABEL: sil hidden  @_TF14objc_protocols25objc_protocol_composition
 func objc_protocol_composition(_ x: NSRuncing & NSFunging) {
@@ -231,25 +244,28 @@ extension InformallyFunging: NSFunging { }
   init(int: Int)
 }
 
-// CHECK-LABEL: sil hidden @_TF14objc_protocols28testInitializableExistential
+// CHECK-LABEL: sil hidden @_TF14objc_protocols28testInitializableExistentialFTPMPS_13Initializable_1iSi_PS0__ : $@convention(thin) (@thick Initializable.Type, Int) -> @owned Initializable {
 func testInitializableExistential(_ im: Initializable.Type, i: Int) -> Initializable {
   // CHECK: bb0([[META:%[0-9]+]] : $@thick Initializable.Type, [[I:%[0-9]+]] : $Int):
-// CHECK:   [[I2_BOX:%[0-9]+]] = alloc_box $@box Initializable
-// CHECK:   [[PB:%.*]] = project_box [[I2_BOX]]
-// CHECK:   [[ARCHETYPE_META:%[0-9]+]] = open_existential_metatype [[META]] : $@thick Initializable.Type to $@thick (@opened([[N:".*"]]) Initializable).Type
-// CHECK:   [[ARCHETYPE_META_OBJC:%[0-9]+]] = thick_to_objc_metatype [[ARCHETYPE_META]] : $@thick (@opened([[N]]) Initializable).Type to $@objc_metatype (@opened([[N]]) Initializable).Type
-// CHECK:   [[I2_ALLOC:%[0-9]+]] = alloc_ref_dynamic [objc] [[ARCHETYPE_META_OBJC]] : $@objc_metatype (@opened([[N]]) Initializable).Type, $@opened([[N]]) Initializable
-// CHECK:   [[INIT_WITNESS:%[0-9]+]] = witness_method [volatile] $@opened([[N]]) Initializable, #Initializable.init!initializer.1.foreign, [[ARCHETYPE_META]]{{.*}} : $@convention(objc_method) <τ_0_0 where τ_0_0 : Initializable> (Int, @owned τ_0_0) -> @owned τ_0_0
-// CHECK:   [[I2:%[0-9]+]] = apply [[INIT_WITNESS]]<@opened([[N]]) Initializable>([[I]], [[I2_ALLOC]]) : $@convention(objc_method) <τ_0_0 where τ_0_0 : Initializable> (Int, @owned τ_0_0) -> @owned τ_0_0
-// CHECK:   [[I2_EXIST_CONTAINER:%[0-9]+]] = init_existential_ref [[I2]] : $@opened([[N]]) Initializable : $@opened([[N]]) Initializable, $Initializable
-// CHECK:   store [[I2_EXIST_CONTAINER]] to [init] [[PB]] : $*Initializable
-// CHECK:   [[I2:%[0-9]+]] = load [[PB]] : $*Initializable
-// CHECK:   copy_value [[I2]] : $Initializable
-// CHECK:   destroy_value [[I2_BOX]] : $@box Initializable
-// CHECK:   return [[I2]] : $Initializable
+  // CHECK:   [[I2_BOX:%[0-9]+]] = alloc_box $@box Initializable
+  // CHECK:   [[PB:%.*]] = project_box [[I2_BOX]]
+  // CHECK:   [[ARCHETYPE_META:%[0-9]+]] = open_existential_metatype [[META]] : $@thick Initializable.Type to $@thick (@opened([[N:".*"]]) Initializable).Type
+  // CHECK:   [[ARCHETYPE_META_OBJC:%[0-9]+]] = thick_to_objc_metatype [[ARCHETYPE_META]] : $@thick (@opened([[N]]) Initializable).Type to $@objc_metatype (@opened([[N]]) Initializable).Type
+  // CHECK:   [[I2_ALLOC:%[0-9]+]] = alloc_ref_dynamic [objc] [[ARCHETYPE_META_OBJC]] : $@objc_metatype (@opened([[N]]) Initializable).Type, $@opened([[N]]) Initializable
+  // CHECK:   [[INIT_WITNESS:%[0-9]+]] = witness_method [volatile] $@opened([[N]]) Initializable, #Initializable.init!initializer.1.foreign, [[ARCHETYPE_META]]{{.*}} : $@convention(objc_method) <τ_0_0 where τ_0_0 : Initializable> (Int, @owned τ_0_0) -> @owned τ_0_0
+  // CHECK:   [[I2_COPY:%.*]] = copy_value [[I2_ALLOC]]
+  // CHECK:   [[I2:%[0-9]+]] = apply [[INIT_WITNESS]]<@opened([[N]]) Initializable>([[I]], [[I2_COPY]]) : $@convention(objc_method) <τ_0_0 where τ_0_0 : Initializable> (Int, @owned τ_0_0) -> @owned τ_0_0
+  // CHECK:   [[I2_EXIST_CONTAINER:%[0-9]+]] = init_existential_ref [[I2]] : $@opened([[N]]) Initializable : $@opened([[N]]) Initializable, $Initializable
+  // CHECK:   store [[I2_EXIST_CONTAINER]] to [init] [[PB]] : $*Initializable
+  // CHECK:   [[I2:%[0-9]+]] = load [[PB]] : $*Initializable
+  // CHECK:   [[I2_COPY:%.*]] = copy_value [[I2]] : $Initializable
+  // CHECK:   destroy_value [[I2_BOX]] : $@box Initializable
+  // SEMANTIC ARC TODO: This is incorrect. We should be returning I2_COPY, not I2 here.
+  // CHECK:   return [[I2]] : $Initializable
   var i2 = im.init(int: i)
   return i2
 }
+// CHECK: } // end sil function '_TF14objc_protocols28testInitializableExistentialFTPMPS_13Initializable_1iSi_PS0__'
 
 class InitializableConformer: Initializable {
   @objc required init(int: Int) {}

--- a/test/SILGen/objc_set_bridging.swift
+++ b/test/SILGen/objc_set_bridging.swift
@@ -13,53 +13,61 @@ import gizmo
   // CHECK-LABEL: sil hidden [thunk] @_TToFC17objc_set_bridging3Foo16bridge_Set_param{{.*}} : $@convention(objc_method) (NSSet, Foo) -> ()
   func bridge_Set_param(_ s: Set<Foo>) {
     // CHECK: bb0([[NSSET:%[0-9]+]] : $NSSet, [[SELF:%[0-9]+]] : $Foo):
-    // CHECK:   copy_value [[NSSET]] : $NSSet
-    // CHECK:   copy_value [[SELF]] : $Foo
+    // CHECK:   [[NSSET_COPY:%.*]] = copy_value [[NSSET]] : $NSSet
+    // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]] : $Foo
     // CHECK:   [[CONVERTER:%[0-9]+]] = function_ref @_TZFE10FoundationVs3Set36_unconditionallyBridgeFromObjectiveCfGSqCSo5NSSet_GS0_x_
-    // CHECK: [[OPT_NSSET:%[0-9]+]] = enum $Optional<NSSet>, #Optional.some!enumelt.1, [[NSSET]] : $NSSet
-    // CHECK: [[SET_META:%[0-9]+]] = metatype $@thin Set<Foo>.Type
+    // CHECK:   [[OPT_NSSET:%[0-9]+]] = enum $Optional<NSSet>, #Optional.some!enumelt.1, [[NSSET_COPY]] : $NSSet
+    // CHECK:   [[SET_META:%[0-9]+]] = metatype $@thin Set<Foo>.Type
     // CHECK:   [[SET:%[0-9]+]] = apply [[CONVERTER]]<Foo>([[OPT_NSSET]], [[SET_META]])
     // CHECK:   [[SWIFT_FN:%[0-9]+]] = function_ref @_TFC17objc_set_bridging3Foo16bridge_Set_param{{.*}} : $@convention(method) (@owned Set<Foo>, @guaranteed Foo) -> ()
-    // CHECK:   [[RESULT:%[0-9]+]] = apply [[SWIFT_FN]]([[SET]], [[SELF]]) : $@convention(method) (@owned Set<Foo>, @guaranteed Foo) -> ()
+    // CHECK:   [[RESULT:%[0-9]+]] = apply [[SWIFT_FN]]([[SET]], [[SELF_COPY]]) : $@convention(method) (@owned Set<Foo>, @guaranteed Foo) -> ()
+    // CHECK:   destroy_value [[SELF_COPY]]
     // CHECK:   return [[RESULT]] : $()
   }
+  // CHECK: // end sil function '_TToFC17objc_set_bridging3Foo16bridge_Set_param{{.*}}'
 
   // Bridging set results
   // CHECK-LABEL: sil hidden [thunk] @_TToFC17objc_set_bridging3Foo17bridge_Set_result{{.*}} : $@convention(objc_method) (Foo) -> @autoreleased NSSet {
   func bridge_Set_result() -> Set<Foo> { 
     // CHECK: bb0([[SELF:%[0-9]+]] : $Foo):
-    // CHECK: copy_value [[SELF]] : $Foo
-    // CHECK: [[SWIFT_FN:%[0-9]+]] = function_ref @_TFC17objc_set_bridging3Foo17bridge_Set_result{{.*}} : $@convention(method) (@guaranteed Foo) -> @owned Set<Foo>
-    // CHECK: [[SET:%[0-9]+]] = apply [[SWIFT_FN]]([[SELF]]) : $@convention(method) (@guaranteed Foo) -> @owned Set<Foo>
-    // CHECK: [[CONVERTER:%[0-9]+]] = function_ref @_TFE10FoundationVs3Set19_bridgeToObjectiveCfT_CSo5NSSet
-    // CHECK: [[NSSET:%[0-9]+]] = apply [[CONVERTER]]<Foo>([[SET]]) : $@convention(method) <τ_0_0 where τ_0_0 : Hashable> (@guaranteed Set<τ_0_0>) -> @owned NSSet
-    // CHECK: return [[NSSET]] : $NSSet
+    // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]] : $Foo
+    // CHECK:   [[SWIFT_FN:%[0-9]+]] = function_ref @_TFC17objc_set_bridging3Foo17bridge_Set_result{{.*}} : $@convention(method) (@guaranteed Foo) -> @owned Set<Foo>
+    // CHECK:   [[SET:%[0-9]+]] = apply [[SWIFT_FN]]([[SELF_COPY]]) : $@convention(method) (@guaranteed Foo) -> @owned Set<Foo>
+    // CHECK:   destroy_value [[SELF_COPY]]
+    // CHECK:   [[CONVERTER:%[0-9]+]] = function_ref @_TFE10FoundationVs3Set19_bridgeToObjectiveCfT_CSo5NSSet
+    // CHECK:   [[NSSET:%[0-9]+]] = apply [[CONVERTER]]<Foo>([[SET]]) : $@convention(method) <τ_0_0 where τ_0_0 : Hashable> (@guaranteed Set<τ_0_0>) -> @owned NSSet
+    // CHECK:   destroy_value [[SET]]
+    // CHECK:   return [[NSSET]] : $NSSet
   }
+  // CHECK: } // end sil function '_TToFC17objc_set_bridging3Foo17bridge_Set_result{{.*}}'
 
   var property: Set<Foo> = Set()
 
   // Property getter
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TToFC17objc_set_bridging3Foog8property{{.*}} : $@convention(objc_method) (Foo) -> @autoreleased NSSet
   // CHECK: bb0([[SELF:%[0-9]+]] : $Foo):
-  // CHECK:   copy_value [[SELF]] : $Foo
+  // CHECK:   [[SELF_COPY]] = copy_value [[SELF]] : $Foo
   // CHECK:   [[GETTER:%[0-9]+]] = function_ref @_TFC17objc_set_bridging3Foog8property{{.*}} : $@convention(method) (@guaranteed Foo) -> @owned Set<Foo>
-  // CHECK:   [[SET:%[0-9]+]] = apply [[GETTER]]([[SELF]]) : $@convention(method) (@guaranteed Foo) -> @owned Set<Foo>
+  // CHECK:   [[SET:%[0-9]+]] = apply [[GETTER]]([[SELF_COPY]]) : $@convention(method) (@guaranteed Foo) -> @owned Set<Foo>
+  // CHECK:   destroy_value [[SELF_COPY]]
   // CHECK:   [[CONVERTER:%[0-9]+]] = function_ref @_TFE10FoundationVs3Set19_bridgeToObjectiveCfT_CSo5NSSet
   // CHECK:   [[NSSET:%[0-9]+]] = apply [[CONVERTER]]<Foo>([[SET]]) : $@convention(method) <τ_0_0 where τ_0_0 : Hashable> (@guaranteed Set<τ_0_0>) -> @owned NSSet
+  // CHECK:   destroy_value [[SET]]
   // CHECK:   return [[NSSET]] : $NSSet
+  // CHECK: } // end sil function '_TToFC17objc_set_bridging3Foog8property{{.*}}'
   
   // Property setter
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TToFC17objc_set_bridging3Foos8property{{.*}} : $@convention(objc_method) (NSSet, Foo) -> () {
   // CHECK: bb0([[NSSET:%[0-9]+]] : $NSSet, [[SELF:%[0-9]+]] : $Foo):
-  // CHECK:   copy_value [[NSSET]] : $NSSet
-  // CHECK:   copy_value [[SELF]] : $Foo
+  // CHECK:   [[NSSET_COPY:%.*]] = copy_value [[NSSET]] : $NSSet
+  // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]] : $Foo
   // CHECK:   [[CONVERTER:%[0-9]+]] = function_ref @_TZFE10FoundationVs3Set36_unconditionallyBridgeFromObjectiveCfGSqCSo5NSSet_GS0_x_
-  // CHECK: [[OPT_NSSET:%[0-9]+]] = enum $Optional<NSSet>, #Optional.some!enumelt.1, [[NSSET]] : $NSSet
-    // CHECK: [[SET_META:%[0-9]+]] = metatype $@thin Set<Foo>.Type
+  // CHECK:   [[OPT_NSSET:%[0-9]+]] = enum $Optional<NSSet>, #Optional.some!enumelt.1, [[NSSET_COPY]] : $NSSet
+  // CHECK:   [[SET_META:%[0-9]+]] = metatype $@thin Set<Foo>.Type
   // CHECK:   [[SET:%[0-9]+]] = apply [[CONVERTER]]<Foo>([[OPT_NSSET]], [[SET_META]])
   // CHECK:   [[SETTER:%[0-9]+]] = function_ref @_TFC17objc_set_bridging3Foos8property{{.*}} : $@convention(method) (@owned Set<Foo>, @guaranteed Foo) -> ()
-  // CHECK:   [[RESULT:%[0-9]+]] = apply [[SETTER]]([[SET]], [[SELF]]) : $@convention(method) (@owned Set<Foo>, @guaranteed Foo) -> ()
-  // CHECK:   destroy_value [[SELF]] : $Foo
+  // CHECK:   [[RESULT:%[0-9]+]] = apply [[SETTER]]([[SET]], [[SELF_COPY]]) : $@convention(method) (@owned Set<Foo>, @guaranteed Foo) -> ()
+  // CHECK:   destroy_value [[SELF_COPY]] : $Foo
   // CHECK:   return [[RESULT]] : $()
   
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TToFC17objc_set_bridging3Foog19nonVerbatimProperty{{.*}} : $@convention(objc_method) (Foo) -> @autoreleased NSSet

--- a/test/SILGen/objc_thunks.swift
+++ b/test/SILGen/objc_thunks.swift
@@ -9,12 +9,12 @@ class Hoozit : Gizmo {
   func typical(_ x: Int, y: Gizmo) -> Gizmo { return y }
   // CHECK-LABEL: sil hidden [thunk] @_TToFC11objc_thunks6Hoozit7typical{{.*}} : $@convention(objc_method) (Int, Gizmo, Hoozit) -> @autoreleased Gizmo {
   // CHECK: bb0([[X:%.*]] : $Int, [[Y:%.*]] : $Gizmo, [[THIS:%.*]] : $Hoozit):
-  // CHECK-NEXT:   copy_value [[Y]]
-  // CHECK-NEXT:   copy_value [[THIS]]
+  // CHECK-NEXT:   [[Y_COPY:%.*]] = copy_value [[Y]]
+  // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @_TFC11objc_thunks6Hoozit7typical{{.*}} : $@convention(method) (Int, @owned Gizmo, @guaranteed Hoozit) -> @owned Gizmo
-  // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[X]], [[Y]], [[THIS]]) {{.*}} line:[[@LINE-7]]:8:auto_gen
-  // CHECK-NEXT:   destroy_value [[THIS]] : $Hoozit
+  // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[X]], [[Y_COPY]], [[THIS_COPY]]) {{.*}} line:[[@LINE-7]]:8:auto_gen
+  // CHECK-NEXT:   destroy_value [[THIS_COPY]] : $Hoozit
   // CHECK-NEXT:   return [[RES]] : $Gizmo{{.*}} line:[[@LINE-9]]:8:auto_gen
   // CHECK-NEXT: }
 
@@ -43,11 +43,11 @@ class Hoozit : Gizmo {
   func copyFoo() -> Gizmo { return self }
   // CHECK-LABEL: sil hidden [thunk] @_TToFC11objc_thunks6Hoozit7copyFoo{{.*}} : $@convention(objc_method) (Hoozit) -> @owned Gizmo
   // CHECK: bb0([[THIS:%.*]] : $Hoozit):
-  // CHECK-NEXT:   copy_value [[THIS]]
+  // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @_TFC11objc_thunks6Hoozit7copyFoo{{.*}} : $@convention(method) (@guaranteed Hoozit) -> @owned Gizmo
-  // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[THIS]])
-  // CHECK:        destroy_value [[THIS]]
+  // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[THIS_COPY]])
+  // CHECK:        destroy_value [[THIS_COPY]]
   // CHECK-NEXT:   return [[RES]]
   // CHECK-NEXT: }
 
@@ -56,23 +56,23 @@ class Hoozit : Gizmo {
   func initFoo() -> Gizmo { return self }
   // CHECK-LABEL: sil hidden [thunk] @_TToFC11objc_thunks6Hoozit7initFoo{{.*}} : $@convention(objc_method) (Hoozit) -> @autoreleased Gizmo
   // CHECK: bb0([[THIS:%.*]] : $Hoozit):
-  // CHECK-NEXT:   copy_value [[THIS]]
+  // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @_TFC11objc_thunks6Hoozit7initFoo{{.*}} : $@convention(method) (@guaranteed Hoozit) -> @owned Gizmo
-  // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[THIS]])
-  // CHECK-NEXT:   destroy_value [[THIS]]
+  // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[THIS_COPY]])
+  // CHECK-NEXT:   destroy_value [[THIS_COPY]]
   // CHECK-NEXT:   return [[RES]]
   // CHECK-NEXT: }
 
   var typicalProperty: Gizmo
   // -- getter
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TToFC11objc_thunks6Hoozitg15typicalPropertyCSo5Gizmo : $@convention(objc_method) (Hoozit) -> @autoreleased Gizmo {
-  // CHECK: bb0(%0 : $Hoozit):
-  // CHECK-NEXT:   copy_value %0
+  // CHECK: bb0([[SELF:%.*]] : $Hoozit):
+  // CHECK-NEXT:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK-NEXT:   // function_ref objc_thunks.Hoozit.typicalProperty.getter
   // CHECK-NEXT:   [[GETIMPL:%.*]] = function_ref @_TFC11objc_thunks6Hoozitg15typicalPropertyCSo5Gizmo
-  // CHECK-NEXT:   [[RES:%.*]] = apply [[GETIMPL]](%0)
-  // CHECK-NEXT:   destroy_value %0
+  // CHECK-NEXT:   [[RES:%.*]] = apply [[GETIMPL]]([[SELF_COPY]])
+  // CHECK-NEXT:   destroy_value [[SELF_COPY]]
   // CHECK-NEXT:   return [[RES]] : $Gizmo
   // CHECK-NEXT: }
   
@@ -87,28 +87,33 @@ class Hoozit : Gizmo {
   // -- setter
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TToFC11objc_thunks6Hoozits15typicalPropertyCSo5Gizmo : $@convention(objc_method) (Gizmo, Hoozit) -> () {
   // CHECK: bb0([[VALUE:%.*]] : $Gizmo, [[THIS:%.*]] : $Hoozit):
-  // CHECK-NEXT:   copy_value [[VALUE]] : $Gizmo
-  // CHECK-NEXT:   copy_value [[THIS]] : $Hoozit
-  // CHECK-NEXT:   // function_ref objc_thunks.Hoozit.typicalProperty.setter
-  // CHECK-NEXT:   [[FR:%.*]] = function_ref @_TFC11objc_thunks6Hoozits15typicalPropertyCSo5Gizmo
-  // CHECK-NEXT:   [[RES:%.*]] = apply [[FR]](%0, %1)
-  // CHECK_NEXT:   return [[RES]] line:[[@LINE-19]]:7:auto_gen
+  // CHECK:   [[VALUE_COPY:%.*]] = copy_value [[VALUE]] : $Gizmo
+  // CHECK:   [[THIS_COPY:%.*]] = copy_value [[THIS]] : $Hoozit
+  // CHECK:   // function_ref objc_thunks.Hoozit.typicalProperty.setter
+  // CHECK:   [[FR:%.*]] = function_ref @_TFC11objc_thunks6Hoozits15typicalPropertyCSo5Gizmo
+  // CHECK:   [[RES:%.*]] = apply [[FR]]([[VALUE_COPY]], [[THIS_COPY]])
+  // CHECK:   destroy_value [[THIS_COPY]]
+  // CHECK:   return [[RES]] : $(), scope {{.*}} // id: {{.*}} line:[[@LINE-29]]:7:auto_gen
+  // CHECK: } // end sil function '_TToFC11objc_thunks6Hoozits15typicalPropertyCSo5Gizmo'
 
   // CHECK-LABEL: sil hidden [transparent] @_TFC11objc_thunks6Hoozits15typicalPropertyCSo5Gizmo
-  // CHECK: bb0(%0 : $Gizmo, %1 : $Hoozit):
-  // CHECK:        [[ADDR:%.*]] = ref_element_addr %1 : {{.*}}, #Hoozit.typicalProperty
-  // CHECK-NEXT:   assign %0 to [[ADDR]] : $*Gizmo
+  // CHECK: bb0([[ARG0:%.*]] : $Gizmo, [[ARG1:%.*]] : $Hoozit):
+  // CHECK:   [[ARG0_COPY:%.*]] = copy_value [[ARG0]]
+  // CHECK:   [[ADDR:%.*]] = ref_element_addr [[ARG1]] : {{.*}}, #Hoozit.typicalProperty
+  // CHECK:   assign [[ARG0_COPY]] to [[ADDR]] : $*Gizmo
+  // CHECK:   destroy_value [[ARG0]]
+  // CHECK: } // end sil function '_TFC11objc_thunks6Hoozits15typicalPropertyCSo5Gizmo'
 
   // NS_RETURNS_RETAINED getter by family (-copy)
   var copyProperty: Gizmo
   // -- getter
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TToFC11objc_thunks6Hoozitg12copyPropertyCSo5Gizmo : $@convention(objc_method) (Hoozit) -> @owned Gizmo {
-  // CHECK: bb0(%0 : $Hoozit):
-  // CHECK-NEXT:   copy_value %0
+  // CHECK: bb0([[SELF:%.*]] : $Hoozit):
+  // CHECK-NEXT:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK-NEXT:   // function_ref objc_thunks.Hoozit.copyProperty.getter
   // CHECK-NEXT:   [[FR:%.*]] = function_ref @_TFC11objc_thunks6Hoozitg12copyPropertyCSo5Gizmo
-  // CHECK-NEXT:   [[RES:%.*]] = apply [[FR]](%0)
-  // CHECK-NEXT:   destroy_value %0
+  // CHECK-NEXT:   [[RES:%.*]] = apply [[FR]]([[SELF_COPY]])
+  // CHECK-NEXT:   destroy_value [[SELF_COPY]]
   // CHECK-NEXT:   return [[RES]]
   // CHECK-NEXT: }
 
@@ -122,30 +127,33 @@ class Hoozit : Gizmo {
   // -- setter is normal
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TToFC11objc_thunks6Hoozits12copyPropertyCSo5Gizmo : $@convention(objc_method) (Gizmo, Hoozit) -> () {
   // CHECK: bb0([[VALUE:%.*]] : $Gizmo, [[THIS:%.*]] : $Hoozit):
-  // CHECK-NEXT:   copy_value [[VALUE]]
-  // CHECK-NEXT:   copy_value [[THIS]]
+  // CHECK-NEXT:   [[VALUE_COPY:%.*]] = copy_value [[VALUE]]
+  // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
   // CHECK-NEXT:   // function_ref objc_thunks.Hoozit.copyProperty.setter
   // CHECK-NEXT:   [[FR:%.*]] = function_ref @_TFC11objc_thunks6Hoozits12copyPropertyCSo5Gizmo
-  // CHECK-NEXT:   [[RES:%.*]] = apply [[FR]](%0, %1)
-  // CHECK-NEXT:   destroy_value [[THIS]]
+  // CHECK-NEXT:   [[RES:%.*]] = apply [[FR]]([[VALUE_COPY]], [[THIS_COPY]])
+  // CHECK-NEXT:   destroy_value [[THIS_COPY]]
   // CHECK-NEXT:   return [[RES]]
 
   // CHECK-LABEL: sil hidden [transparent] @_TFC11objc_thunks6Hoozits12copyPropertyCSo5Gizmo
-  // CHECK:        bb0(%0 : $Gizmo, %1 : $Hoozit):
-  // CHECK:   [[ADDR:%.*]] = ref_element_addr %1 : {{.*}}, #Hoozit.copyProperty
-  // CHECK-NEXT:   assign %0 to [[ADDR]]
+  // CHECK: bb0([[ARG1:%.*]] : $Gizmo, [[SELF:%.*]] : $Hoozit):
+  // CHECK:   [[ARG1_COPY:%.*]] = copy_value [[ARG1]]
+  // CHECK:   [[ADDR:%.*]] = ref_element_addr [[SELF]] : {{.*}}, #Hoozit.copyProperty
+  // CHECK:   assign [[ARG1_COPY]] to [[ADDR]]
+  // CHECK:   destroy_value [[ARG1]]
+  // CHECK: } // end sil function '_TFC11objc_thunks6Hoozits12copyPropertyCSo5Gizmo'
 
   var roProperty: Gizmo { return self }
   // -- getter
   // CHECK-LABEL: sil hidden [thunk] @_TToFC11objc_thunks6Hoozitg10roPropertyCSo5Gizmo : $@convention(objc_method) (Hoozit) -> @autoreleased Gizmo {
   // CHECK: bb0([[THIS:%.*]] : $Hoozit):
-  // CHECK-NEXT:   copy_value [[THIS]]
+  // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @_TFC11objc_thunks6Hoozitg10roPropertyCSo5Gizmo : $@convention(method) (@guaranteed Hoozit) -> @owned Gizmo
-  // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[THIS]])
-  // CHECK-NEXT:   destroy_value [[THIS]] : $Hoozit
+  // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[THIS_COPY]])
+  // CHECK-NEXT:   destroy_value [[THIS_COPY]] : $Hoozit
   // CHECK-NEXT:   return [[RES]] : $Gizmo
-  // CHECK-NEXT: }
+  // CHECK-NEXT: } // end sil function '_TToFC11objc_thunks6Hoozitg10roPropertyCSo5Gizmo'
 
   // -- no setter
   // CHECK-NOT: sil hidden [thunk] @_TToFC11objc_thunks6Hoozits10roPropertyCSo5Gizmo
@@ -162,12 +170,12 @@ class Hoozit : Gizmo {
   // -- setter
   // CHECK-LABEL: sil hidden [thunk] @_TToFC11objc_thunks6Hoozits10rwPropertyCSo5Gizmo : $@convention(objc_method) (Gizmo, Hoozit) -> () {
   // CHECK: bb0([[VALUE:%.*]] : $Gizmo, [[THIS:%.*]] : $Hoozit):
-  // CHECK-NEXT:   copy_value [[VALUE]]
-  // CHECK-NEXT:   copy_value [[THIS]]
+  // CHECK-NEXT:   [[VALUE_COPY:%.*]] = copy_value [[VALUE]]
+  // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @_TFC11objc_thunks6Hoozits10rwPropertyCSo5Gizmo : $@convention(method) (@owned Gizmo, @guaranteed Hoozit) -> ()
-  // CHECK-NEXT:   apply [[NATIVE]]([[VALUE]], [[THIS]])
-  // CHECK-NEXT:   destroy_value [[THIS]]
+  // CHECK-NEXT:   apply [[NATIVE]]([[VALUE_COPY]], [[THIS_COPY]])
+  // CHECK-NEXT:   destroy_value [[THIS_COPY]]
   // CHECK-NEXT:   return
   // CHECK-NEXT: }
 
@@ -180,11 +188,11 @@ class Hoozit : Gizmo {
   // -- getter
   // CHECK-LABEL: sil hidden [thunk] @_TToFC11objc_thunks6Hoozitg14copyRWPropertyCSo5Gizmo : $@convention(objc_method) (Hoozit) -> @owned Gizmo {
   // CHECK: bb0([[THIS:%.*]] : $Hoozit):
-  // CHECK-NEXT:   copy_value [[THIS]]
+  // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @_TFC11objc_thunks6Hoozitg14copyRWPropertyCSo5Gizmo : $@convention(method) (@guaranteed Hoozit) -> @owned Gizmo
-  // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[THIS]])
-  // CHECK-NEXT:   destroy_value [[THIS]]
+  // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[THIS_COPY]])
+  // CHECK-NEXT:   destroy_value [[THIS_COPY]]
   // CHECK-NOT:    return
   // CHECK-NEXT:   return [[RES]]
   // CHECK-NEXT: }
@@ -192,12 +200,12 @@ class Hoozit : Gizmo {
   // -- setter is normal
   // CHECK-LABEL: sil hidden [thunk] @_TToFC11objc_thunks6Hoozits14copyRWPropertyCSo5Gizmo : $@convention(objc_method) (Gizmo, Hoozit) -> () {
   // CHECK: bb0([[VALUE:%.*]] : $Gizmo, [[THIS:%.*]] : $Hoozit):
-  // CHECK-NEXT:   copy_value [[VALUE]]
-  // CHECK-NEXT:   copy_value [[THIS]]
+  // CHECK-NEXT:   [[VALUE_COPY:%.*]] = copy_value [[VALUE]]
+  // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @_TFC11objc_thunks6Hoozits14copyRWPropertyCSo5Gizmo : $@convention(method) (@owned Gizmo, @guaranteed Hoozit) -> ()
-  // CHECK-NEXT:   apply [[NATIVE]]([[VALUE]], [[THIS]])
-  // CHECK-NEXT:   destroy_value [[THIS]]
+  // CHECK-NEXT:   apply [[NATIVE]]([[VALUE_COPY]], [[THIS_COPY]])
+  // CHECK-NEXT:   destroy_value [[THIS_COPY]]
   // CHECK-NEXT:   return
   // CHECK-NEXT: }
 
@@ -205,23 +213,23 @@ class Hoozit : Gizmo {
   // -- getter
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TToFC11objc_thunks6Hoozitg12initPropertyCSo5Gizmo : $@convention(objc_method) (Hoozit) -> @autoreleased Gizmo {
   // CHECK: bb0([[THIS:%.*]] : $Hoozit):
-  // CHECK-NEXT:   copy_value [[THIS]]
+  // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @_TFC11objc_thunks6Hoozitg12initPropertyCSo5Gizmo : $@convention(method) (@guaranteed Hoozit) -> @owned Gizmo
-  // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[THIS]])
-  // CHECK-NEXT:   destroy_value [[THIS]]
+  // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[THIS_COPY]])
+  // CHECK-NEXT:   destroy_value [[THIS_COPY]]
   // CHECK-NEXT:   return [[RES]]
   // CHECK-NEXT: }
 
   // -- setter
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TToFC11objc_thunks6Hoozits12initPropertyCSo5Gizmo : $@convention(objc_method) (Gizmo, Hoozit) -> () {
   // CHECK: bb0([[VALUE:%.*]] : $Gizmo, [[THIS:%.*]] : $Hoozit):
-  // CHECK-NEXT:   copy_value [[VALUE]]
-  // CHECK-NEXT:   copy_value [[THIS]]
+  // CHECK-NEXT:   [[VALUE_COPY:%.*]] = copy_value [[VALUE]]
+  // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @_TFC11objc_thunks6Hoozits12initPropertyCSo5Gizmo : $@convention(method) (@owned Gizmo, @guaranteed Hoozit) -> ()
-  // CHECK-NEXT:   apply [[NATIVE]]([[VALUE]], [[THIS]])
-  // CHECK-NEXT:   destroy_value [[THIS]]
+  // CHECK-NEXT:   apply [[NATIVE]]([[VALUE_COPY]], [[THIS_COPY]])
+  // CHECK-NEXT:   destroy_value [[THIS_COPY]]
   // CHECK-NEXT:   return
   // CHECK-NEXT: }
 
@@ -232,23 +240,23 @@ class Hoozit : Gizmo {
   // -- getter
   // CHECK-LABEL: sil hidden [thunk] @_TToFC11objc_thunks6Hoozitg12propComputedCSo5Gizmo : $@convention(objc_method) (Hoozit) -> @autoreleased Gizmo {
   // CHECK: bb0([[THIS:%.*]] : $Hoozit):
-  // CHECK-NEXT:   copy_value [[THIS]]
+  // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @_TFC11objc_thunks6Hoozitg12propComputedCSo5Gizmo : $@convention(method) (@guaranteed Hoozit) -> @owned Gizmo
-  // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[THIS]])
-  // CHECK-NEXT:   destroy_value [[THIS]]
+  // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[THIS_COPY]])
+  // CHECK-NEXT:   destroy_value [[THIS_COPY]]
   // CHECK-NEXT:   return [[RES]]
   // CHECK-NEXT: }
 
   // -- setter
   // CHECK-LABEL: sil hidden [thunk] @_TToFC11objc_thunks6Hoozits12propComputedCSo5Gizmo : $@convention(objc_method) (Gizmo, Hoozit) -> () {
   // CHECK: bb0([[VALUE:%.*]] : $Gizmo, [[THIS:%.*]] : $Hoozit):
-  // CHECK-NEXT:   copy_value [[VALUE]]
-  // CHECK-NEXT:   copy_value [[THIS]]
+  // CHECK-NEXT:   [[VALUE_COPY:%.*]] = copy_value [[VALUE]]
+  // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @_TFC11objc_thunks6Hoozits12propComputedCSo5Gizmo : $@convention(method) (@owned Gizmo, @guaranteed Hoozit) -> ()
-  // CHECK-NEXT:   apply [[NATIVE]]([[VALUE]], [[THIS]])
-  // CHECK-NEXT:   destroy_value [[THIS]]
+  // CHECK-NEXT:   apply [[NATIVE]]([[VALUE_COPY]], [[THIS_COPY]])
+  // CHECK-NEXT:   destroy_value [[THIS_COPY]]
   // CHECK-NEXT:   return
   // CHECK-NEXT: }
 
@@ -277,10 +285,10 @@ class Hoozit : Gizmo {
   // Getter
   // CHECK-LABEL: sil hidden [thunk] @_TToFC11objc_thunks6Hoozitg9subscript{{.*}} : $@convention(objc_method) (Int, Hoozit) -> @autoreleased Hoozit
   // CHECK: bb0([[I:%[0-9]+]] : $Int, [[SELF:%[0-9]+]] : $Hoozit):
-  // CHECK-NEXT:   copy_value [[SELF]] : $Hoozit
+  // CHECK-NEXT:   [[SELF_COPY:%.*]] = copy_value [[SELF]] : $Hoozit
   // CHECK: [[NATIVE:%[0-9]+]] = function_ref @_TFC11objc_thunks6Hoozitg9subscript{{.*}} : $@convention(method) (Int, @guaranteed Hoozit) -> @owned Hoozit
-  // CHECK-NEXT: [[RESULT:%[0-9]+]] = apply [[NATIVE]]([[I]], [[SELF]]) : $@convention(method) (Int, @guaranteed Hoozit) -> @owned Hoozit
-  // CHECK-NEXT: destroy_value [[SELF]]
+  // CHECK-NEXT: [[RESULT:%[0-9]+]] = apply [[NATIVE]]([[I]], [[SELF_COPY]]) : $@convention(method) (Int, @guaranteed Hoozit) -> @owned Hoozit
+  // CHECK-NEXT: destroy_value [[SELF_COPY]]
   // CHECK-NEXT: return [[RESULT]] : $Hoozit
   get {
     return self
@@ -288,13 +296,14 @@ class Hoozit : Gizmo {
 
   // Setter
   // CHECK-LABEL: sil hidden [thunk] @_TToFC11objc_thunks6Hoozits9subscript{{.*}} : $@convention(objc_method) (Hoozit, Int, Hoozit) -> ()
-  // CHECK: bb0([[SELF:%[0-9]+]] : $Hoozit, [[I:%[0-9]+]] : $Int, [[VALUE:%[0-9]+]] : $Hoozit):
-  // CHECK-NEXT: copy_value [[SELF]] : $Hoozit
-  // CHECK_NEXT: copy_value [[VALUE]] : $Hoozit
-  // CHECK: [[NATIVE:%[0-9]+]] = function_ref @_TFC11objc_thunks6Hoozits9subscript{{.*}} : $@convention(method) (@owned Hoozit, Int, @guaranteed Hoozit) -> ()
-  // CHECK-NEXT: [[RESULT:%[0-9]+]] = apply [[NATIVE]]([[SELF]], [[I]], [[VALUE]]) : $@convention(method) (@owned Hoozit, Int, @guaranteed Hoozit) -> ()
-  // CHECK-NEXT: destroy_value [[VALUE]]
-  // CHECK-NEXT: return [[RESULT]] : $()
+  // CHECK: bb0([[VALUE:%[0-9]+]] : $Hoozit, [[I:%[0-9]+]] : $Int, [[SELF:%[0-9]+]] : $Hoozit):
+  // CHECK:   [[VALUE_COPY:%.*]] = copy_value [[VALUE]] : $Hoozit
+  // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]] : $Hoozit
+  // CHECK:   [[NATIVE:%[0-9]+]] = function_ref @_TFC11objc_thunks6Hoozits9subscript{{.*}} : $@convention(method) (@owned Hoozit, Int, @guaranteed Hoozit) -> ()
+  // CHECK:   [[RESULT:%[0-9]+]] = apply [[NATIVE]]([[VALUE_COPY]], [[I]], [[SELF_COPY]]) : $@convention(method) (@owned Hoozit, Int, @guaranteed Hoozit) -> ()
+  // CHECK:   destroy_value [[SELF_COPY]]
+  // CHECK:   return [[RESULT]] : $()
+  // CHECK: } // end sil function '_TToFC11objc_thunks6Hoozits9subscript{{.*}}'
   set {}
   }
 }
@@ -302,11 +311,11 @@ class Hoozit : Gizmo {
 class Wotsit<T> : Gizmo {
   // CHECK-LABEL: sil hidden [thunk] @_TToFC11objc_thunks6Wotsit5plain{{.*}} : $@convention(objc_method) <T> (Wotsit<T>) -> () {
   // CHECK: bb0([[SELF:%.*]] : $Wotsit<T>):
-  // CHECK-NEXT: copy_value [[SELF]] : $Wotsit<T>
+  // CHECK-NEXT: [[SELF_COPY:%.*]] = copy_value [[SELF]] : $Wotsit<T>
   // CHECK-NEXT: // function_ref
   // CHECK-NEXT: [[NATIVE:%.*]] = function_ref @_TFC11objc_thunks6Wotsit5plain{{.*}} : $@convention(method) <τ_0_0> (@guaranteed Wotsit<τ_0_0>) -> ()
-  // CHECK-NEXT: [[RESULT:%.*]] = apply [[NATIVE]]<T>([[SELF]]) : $@convention(method) <τ_0_0> (@guaranteed Wotsit<τ_0_0>) -> ()
-  // CHECK-NEXT: destroy_value [[SELF]] : $Wotsit<T>
+  // CHECK-NEXT: [[RESULT:%.*]] = apply [[NATIVE]]<T>([[SELF_COPY]]) : $@convention(method) <τ_0_0> (@guaranteed Wotsit<τ_0_0>) -> ()
+  // CHECK-NEXT: destroy_value [[SELF_COPY]] : $Wotsit<T>
   // CHECK-NEXT: return [[RESULT]] : $()
   // CHECK-NEXT: }
   func plain() { }
@@ -322,11 +331,11 @@ class Wotsit<T> : Gizmo {
 
   // CHECK-LABEL: sil hidden [thunk] @_TToFC11objc_thunks6Wotsitg11descriptionSS : $@convention(objc_method) <T> (Wotsit<T>) -> @autoreleased NSString {
   // CHECK: bb0([[SELF:%.*]] : $Wotsit<T>):
-  // CHECK-NEXT:   copy_value [[SELF]] : $Wotsit<T>
+  // CHECK-NEXT:   [[SELF_COPY:%.*]] = copy_value [[SELF]] : $Wotsit<T>
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @_TFC11objc_thunks6Wotsitg11descriptionSS : $@convention(method) <τ_0_0> (@guaranteed Wotsit<τ_0_0>) -> @owned String
-  // CHECK-NEXT:   [[RESULT:%.*]] = apply [[NATIVE:%.*]]<T>([[SELF]]) : $@convention(method) <τ_0_0> (@guaranteed Wotsit<τ_0_0>) -> @owned String
-  // CHECK-NEXT:   destroy_value [[SELF]] : $Wotsit<T>
+  // CHECK-NEXT:   [[RESULT:%.*]] = apply [[NATIVE:%.*]]<T>([[SELF_COPY]]) : $@convention(method) <τ_0_0> (@guaranteed Wotsit<τ_0_0>) -> @owned String
+  // CHECK-NEXT:   destroy_value [[SELF_COPY]] : $Wotsit<T>
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[BRIDGE:%.*]] = function_ref @_TFE10FoundationSS19_bridgeToObjectiveCfT_CSo8NSString
   // CHECK-NEXT:   [[NSRESULT:%.*]] = apply [[BRIDGE]]([[RESULT]]) : $@convention(method) (@guaranteed String) -> @owned NSString

--- a/test/SILGen/optional-cast.swift
+++ b/test/SILGen/optional-cast.swift
@@ -3,16 +3,17 @@
 class A {}
 class B : A {}
 
-
-// CHECK-LABEL: sil hidden @_TF4main3foo
+// CHECK-LABEL: sil hidden @_TF4main3fooFGSqCS_1A_T_ : $@convention(thin) (@owned Optional<A>) -> () {
+// CHECK:    bb0([[ARG:%.*]] : $Optional<A>):
 // CHECK:      [[X:%.*]] = alloc_box $@box Optional<B>, var, name "x"
 // CHECK-NEXT: [[PB:%.*]] = project_box [[X]]
 //   Check whether the temporary holds a value.
-// CHECK:      [[T1:%.*]] = select_enum %0
+// CHECK:      [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:      [[T1:%.*]] = select_enum [[ARG_COPY]]
 // CHECK-NEXT: cond_br [[T1]], [[IS_PRESENT:bb.*]], [[NOT_PRESENT:bb[0-9]+]]
 //   If so, pull the value out and check whether it's a B.
 // CHECK:    [[IS_PRESENT]]:
-// CHECK-NEXT: [[VAL:%.*]] = unchecked_enum_data %0 : $Optional<A>, #Optional.some!enumelt.1
+// CHECK-NEXT: [[VAL:%.*]] = unchecked_enum_data [[ARG_COPY]] : $Optional<A>, #Optional.some!enumelt.1
 // CHECK-NEXT: [[X_VALUE:%.*]] = init_enum_data_addr [[PB]] : $*Optional<B>, #Optional.some
 // CHECK-NEXT: checked_cast_br [[VAL]] : $A to $B, [[IS_B:bb.*]], [[NOT_B:bb[0-9]+]]
 //   If so, materialize that and inject it into x.
@@ -40,17 +41,18 @@ func foo(_ y : A?) {
   var x = (y as? B)
 }
 
-// CHECK-LABEL: sil hidden @_TF4main3bar
+// CHECK-LABEL: sil hidden @_TF4main3barFGSqGSqGSqGSqCS_1A____T_ : $@convention(thin) (@owned Optional<Optional<Optional<Optional<A>>>>) -> () {
+// CHECK:    bb0([[ARG:%.*]] : $Optional<Optional<Optional<Optional<A>>>>):
 // CHECK:      [[X:%.*]] = alloc_box $@box Optional<Optional<Optional<B>>>, var, name "x"
 // CHECK-NEXT: [[PB:%.*]] = project_box [[X]]
 
 // Check for some(...)
-// CHECK-NEXT: copy_value %0
-// CHECK:      [[T1:%.*]] = select_enum %0
+// CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:      [[T1:%.*]] = select_enum [[ARG_COPY]]
 // CHECK-NEXT: cond_br [[T1]], [[P:bb.*]], [[NIL_DEPTH2:bb[0-9]+]]
 //   If so, drill down another level and check for some(some(...)).
 // CHECK:    [[P]]:
-// CHECK-NEXT: [[VALUE_OOOA:%.*]] = unchecked_enum_data %0
+// CHECK-NEXT: [[VALUE_OOOA:%.*]] = unchecked_enum_data [[ARG_COPY]]
 // CHECK:      [[T1:%.*]] = select_enum [[VALUE_OOOA]]
 // CHECK-NEXT: cond_br [[T1]], [[PP:bb.*]], [[NIL_DEPTH2:bb[0-9]+]]
 //   If so, drill down another level and check for some(some(some(...))).
@@ -104,14 +106,21 @@ func bar(_ y : A????) {
   var x = (y as? B??)
 }
 
-// CHECK-LABEL: sil hidden @_TF4main3baz
-// CHECK:      [[X:%.*]] = alloc_box $@box Optional<B>, var, name "x"
-// CHECK-NEXT: [[PB:%.*]] = project_box [[X]]
-// CHECK-NEXT: copy_value %0
-// CHECK:      [[T1:%.*]] = select_enum %0
-// CHECK: [[VAL:%.*]] = unchecked_enum_data %0
-// CHECK-NEXT: [[X_VALUE:%.*]] = init_enum_data_addr [[PB]] : $*Optional<B>, #Optional.some
-// CHECK-NEXT: checked_cast_br [[VAL]] : $AnyObject to $B, [[IS_B:bb.*]], [[NOT_B:bb[0-9]+]]
+
+// CHECK-LABEL: sil hidden @_TF4main3bazFGSqPs9AnyObject__T_ : $@convention(thin) (@owned Optional<AnyObject>) -> () {
+// CHECK:       bb0([[ARG:%.*]] : $Optional<AnyObject>):
+// CHECK:         [[X:%.*]] = alloc_box $@box Optional<B>, var, name "x"
+// CHECK-NEXT:    [[PB:%.*]] = project_box [[X]]
+// CHECK-NEXT:    [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:         [[T1:%.*]] = select_enum [[ARG_COPY]]
+// CHECK:       bb1:
+// CHECK:         [[VAL:%.*]] = unchecked_enum_data [[ARG_COPY]]
+// CHECK-NEXT:    [[X_VALUE:%.*]] = init_enum_data_addr [[PB]] : $*Optional<B>, #Optional.some
+// CHECK-NEXT:    checked_cast_br [[VAL]] : $AnyObject to $B, [[IS_B:bb.*]], [[NOT_B:bb[0-9]+]]
+// CHECK:       [[IS_B]](
+// CHECK:       [[NOT_B]]:
+// CHECK:         destroy_value [[VAL]]
+// CHECK: } // end sil function '_TF4main3bazFGSqPs9AnyObject__T_'
 func baz(_ y : AnyObject?) {
   var x = (y as? B)
 }
@@ -129,19 +138,22 @@ func opt_to_opt_trivial(_ x: Int?) -> Int! {
   return x
 }
 
-// CHECK-LABEL: sil hidden @_TF4main20opt_to_opt_referenceFGSQCS_1C_GSqS0__
-// CHECK:       bb0(%0 : $Optional<C>):
-// CHECK-NEXT:  debug_value %0 : $Optional<C>, let, name "x"
-// CHECK-NEXT:  %2 = unchecked_ref_cast %0 : $Optional<C> to $Optional<C>
-// CHECK-NEXT:  return %2 : $Optional<C>
-// CHECK-NEXT:}
+// CHECK-LABEL: sil hidden @_TF4main20opt_to_opt_referenceFGSQCS_1C_GSqS0__ :
+// CHECK:  bb0([[ARG:%.*]] : $Optional<C>):
+// CHECK:    debug_value [[ARG]] : $Optional<C>, let, name "x"
+// CHECK:    [[COPY_ARG:%.*]] = copy_value [[ARG]]
+// CHECK:    [[RESULT:%.*]] = unchecked_ref_cast [[COPY_ARG]] : $Optional<C> to $Optional<C>
+// CHECK:    destroy_value [[ARG]]
+// CHECK:    return [[RESULT]] : $Optional<C>
+// CHECK: } // end sil function '_TF4main20opt_to_opt_referenceFGSQCS_1C_GSqS0__'
 func opt_to_opt_reference(_ x : C!) -> C? { return x }
 
 // CHECK-LABEL: sil hidden @_TF4main22opt_to_opt_addressOnly
 // CHECK:       bb0(%0 : $*Optional<T>, %1 : $*Optional<T>):
 // CHECK-NEXT:  debug_value_addr %1 : $*Optional<T>, let, name "x"
 // CHECK-NEXT:  %3 = unchecked_addr_cast %0 : $*Optional<T> to $*Optional<T>
-// CHECK-NEXT:  copy_addr [take] %1 to [initialization] %3
+// CHECK-NEXT:  copy_addr %1 to [initialization] %3
+// CHECK-NEXT:  destroy_addr %1
 func opt_to_opt_addressOnly<T>(_ x : T!) -> T? { return x }
 
 class C {}

--- a/test/SILGen/optional.swift
+++ b/test/SILGen/optional.swift
@@ -5,13 +5,14 @@ func testCall(_ f: (() -> ())?) {
 }
 // CHECK:    sil hidden @{{.*}}testCall{{.*}}
 // CHECK:    bb0([[T0:%.*]] : $Optional<@callee_owned () -> ()>):
-// CHECK:      [[T1:%.*]] = select_enum %0
+// CHECK:      [[T0_COPY:%.*]] = copy_value [[T0]]
+// CHECK:      [[T1:%.*]] = select_enum [[T0_COPY]]
 // CHECK-NEXT: cond_br [[T1]], bb1, bb3
 //   If it does, project and load the value out of the implicitly unwrapped
 //   optional...
 
 // CHECK: bb1:
-// CHECK-NEXT: [[FN0:%.*]] = unchecked_enum_data %0 : $Optional<@callee_owned () -> ()>, #Optional.some!enumelt.1
+// CHECK-NEXT: [[FN0:%.*]] = unchecked_enum_data [[T0_COPY]] : $Optional<@callee_owned () -> ()>, #Optional.some!enumelt.1
 //   .... then call it
 // CHECK-NEXT: apply [[FN0]]()
 // CHECK:      br bb2(
@@ -19,6 +20,7 @@ func testCall(_ f: (() -> ())?) {
 // CHECK:    bb3:
 // CHECK-NEXT: enum $Optional<()>, #Optional.none!enumelt
 // CHECK-NEXT: br bb2
+// CHECK: } // end sil function '_TF8optional8testCallFGSqFT_T__T_'
 
 func testAddrOnlyCallResult<T>(_ f: (() -> T)?) {
   var f = f
@@ -28,7 +30,8 @@ func testAddrOnlyCallResult<T>(_ f: (() -> T)?) {
 // CHECK:    bb0([[T0:%.*]] : $Optional<@callee_owned () -> @out T>):
 // CHECK: [[F:%.*]] = alloc_box $@box Optional<@callee_owned () -> @out T>, var, name "f"
 // CHECK-NEXT: [[PBF:%.*]] = project_box [[F]]
-// CHECK: store [[T0]] to [init] [[PBF]]
+// CHECK: [[T0_COPY:%.*]] = copy_value [[T0]]
+// CHECK: store [[T0_COPY]] to [init] [[PBF]]
 // CHECK-NEXT: [[X:%.*]] = alloc_box $@box Optional<T>, var, name "x"
 // CHECK-NEXT: [[PBX:%.*]] = project_box [[X]]
 // CHECK-NEXT: [[TEMP:%.*]] = init_enum_data_addr [[PBX]]

--- a/test/SILGen/partial_apply_super.swift
+++ b/test/SILGen/partial_apply_super.swift
@@ -31,11 +31,14 @@ public class GenericParent<A> {
 
 class Child : Parent {
   // CHECK-LABEL: sil hidden @_TFC19partial_apply_super5Child6methodfT_T_ : $@convention(method) (@guaranteed Child) -> ()
-  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
-  // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $Child to $Parent
-  // CHECK: [[SUPER_METHOD:%[0-9]+]] = function_ref @_TTdFC19partial_apply_super6Parent6methodFT_T_ : $@convention(thin) (@owned Parent) -> @owned @callee_owned () -> ()
-  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = apply [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(thin) (@owned Parent) -> @owned @callee_owned () -> ()
-  // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: bb0([[SELF:%.*]] : $Child):
+  // CHECK:   [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
+  // CHECK:   [[CASTED_SELF_COPY:%[0-9]+]] = upcast [[SELF_COPY]] : $Child to $Parent
+  // CHECK:   [[SUPER_METHOD:%[0-9]+]] = function_ref @_TTdFC19partial_apply_super6Parent6methodFT_T_ : $@convention(thin) (@owned Parent) -> @owned @callee_owned () -> ()
+  // CHECK:   [[PARTIAL_APPLY:%[0-9]+]] = apply [[SUPER_METHOD]]([[CASTED_SELF_COPY]]) : $@convention(thin) (@owned Parent) -> @owned @callee_owned () -> ()
+  // CHECK:   apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: } // end sil function '_TFC19partial_apply_super5Child6methodfT_T_'
   override func method() {
     doFoo(super.method)
   }
@@ -50,12 +53,15 @@ class Child : Parent {
     doFoo(super.classMethod)
   }
 
-  // CHECK-LABEL: sil hidden @_TFC19partial_apply_super5Child20callFinalSuperMethodfT_T_ : $@convention(method) (@guaranteed Child) -> () 
-  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
-  // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $Child to $Parent
-  // CHECK: [[SUPER_METHOD:%[0-9]+]] = function_ref @_TFC19partial_apply_super6Parent11finalMethodFT_T_ : $@convention(thin) (@owned Parent) -> @owned @callee_owned () -> ()
-  // CHECK: [[APPLIED_SELF:%[0-9]+]] = apply [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(thin) (@owned Parent) -> @owned @callee_owned () -> ()
-  // CHECK:  apply [[DOFOO]]([[APPLIED_SELF]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK-LABEL: sil hidden @_TFC19partial_apply_super5Child20callFinalSuperMethodfT_T_ : $@convention(method) (@guaranteed Child) -> ()
+  // CHECK: bb0([[SELF:%.*]] : $Child):
+  // CHECK:     [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK:     [[SELF_COPY:%.*]] = copy_value [[SELF]]
+  // CHECK:     [[CASTED_SELF_COPY:%[0-9]+]] = upcast [[SELF_COPY]] : $Child to $Parent
+  // CHECK:     [[SUPER_METHOD:%[0-9]+]] = function_ref @_TFC19partial_apply_super6Parent11finalMethodFT_T_ : $@convention(thin) (@owned Parent) -> @owned @callee_owned () -> ()
+  // CHECK:     [[APPLIED_SELF:%[0-9]+]] = apply [[SUPER_METHOD]]([[CASTED_SELF_COPY]]) : $@convention(thin) (@owned Parent) -> @owned @callee_owned () -> ()
+  // CHECK:     apply [[DOFOO]]([[APPLIED_SELF]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: } // end sil function '_TFC19partial_apply_super5Child20callFinalSuperMethodfT_T_'
   func callFinalSuperMethod() {
     doFoo(super.finalMethod)
   }
@@ -76,11 +82,14 @@ class GenericChild<A> : GenericParent<A> {
     super.init(a: a)
   }
   // CHECK-LABEL: sil hidden @_TFC19partial_apply_super12GenericChild6methodfT_T_ : $@convention(method) <A> (@guaranteed GenericChild<A>) -> ()
-  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
-  // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $GenericChild<A> to $GenericParent<A>
-  // CHECK: [[SUPER_METHOD:%[0-9]+]] = function_ref @_TTdFC19partial_apply_super13GenericParent6methodFT_T_ : $@convention(thin) <τ_0_0> (@owned GenericParent<τ_0_0>) -> @owned @callee_owned () -> ()
-  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = apply [[SUPER_METHOD]]<A>([[CASTED_SELF]]) : $@convention(thin) <τ_0_0> (@owned GenericParent<τ_0_0>) -> @owned @callee_owned () -> ()
-  // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: bb0([[SELF:%.*]] : $GenericChild<A>):
+  // CHECK:     [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK:     [[SELF_COPY:%.*]] = copy_value [[SELF]]
+  // CHECK:     [[CASTED_SELF_COPY:%[0-9]+]] = upcast [[SELF_COPY]] : $GenericChild<A> to $GenericParent<A>
+  // CHECK:     [[SUPER_METHOD:%[0-9]+]] = function_ref @_TTdFC19partial_apply_super13GenericParent6methodFT_T_ : $@convention(thin) <τ_0_0> (@owned GenericParent<τ_0_0>) -> @owned @callee_owned () -> ()
+  // CHECK:     [[PARTIAL_APPLY:%[0-9]+]] = apply [[SUPER_METHOD]]<A>([[CASTED_SELF_COPY]]) : $@convention(thin) <τ_0_0> (@owned GenericParent<τ_0_0>) -> @owned @callee_owned () -> ()
+  // CHECK:     apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: } // end sil function '_TFC19partial_apply_super12GenericChild6methodfT_T_'
   override func method() {
     doFoo(super.method)
   }
@@ -98,11 +107,14 @@ class GenericChild<A> : GenericParent<A> {
 
 class ChildToFixedOutsideParent : OutsideParent {
   // CHECK-LABEL: sil hidden @_TFC19partial_apply_super25ChildToFixedOutsideParent6methodfT_T_
-  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
-  // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $ChildToFixedOutsideParent to $OutsideParent
-  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $ChildToFixedOutsideParent, #OutsideParent.method!1 : (OutsideParent) -> () -> () , $@convention(method) (@guaranteed OutsideParent) -> ()
-  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(method) (@guaranteed OutsideParent) -> ()
-  // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: bb0([[SELF:%.*]] : $ChildToFixedOutsideParent):
+  // CHECK:   [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
+  // CHECK:   [[CASTED_SELF_COPY:%[0-9]+]] = upcast [[SELF_COPY]] : $ChildToFixedOutsideParent to $OutsideParent
+  // CHECK:   [[SUPER_METHOD:%[0-9]+]] = super_method [[SELF_COPY]] : $ChildToFixedOutsideParent, #OutsideParent.method!1 : (OutsideParent) -> () -> () , $@convention(method) (@guaranteed OutsideParent) -> ()
+  // CHECK:   [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF_COPY]]) : $@convention(method) (@guaranteed OutsideParent) -> ()
+  // CHECK:   apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: } // end sil function '_TFC19partial_apply_super25ChildToFixedOutsideParent6methodfT_T_'
   override func method() {
     doFoo(super.method)
   }
@@ -120,11 +132,14 @@ class ChildToFixedOutsideParent : OutsideParent {
 
 class ChildToResilientOutsideParent : ResilientOutsideParent {
   // CHECK-LABEL: sil hidden @_TFC19partial_apply_super29ChildToResilientOutsideParent6methodfT_T_
-  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
-  // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $ChildToResilientOutsideParent to $ResilientOutsideParent
-  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $ChildToResilientOutsideParent, #ResilientOutsideParent.method!1 : (ResilientOutsideParent) -> () -> () , $@convention(method) (@guaranteed ResilientOutsideParent) -> ()
-  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(method) (@guaranteed ResilientOutsideParent) -> ()
-  // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: bb0([[SELF:%.*]] : $ChildToResilientOutsideParent):
+  // CHECK:   [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
+  // CHECK:   [[CASTED_SELF_COPY:%[0-9]+]] = upcast [[SELF_COPY]] : $ChildToResilientOutsideParent to $ResilientOutsideParent
+  // CHECK:   [[SUPER_METHOD:%[0-9]+]] = super_method [[SELF_COPY]] : $ChildToResilientOutsideParent, #ResilientOutsideParent.method!1 : (ResilientOutsideParent) -> () -> () , $@convention(method) (@guaranteed ResilientOutsideParent) -> ()
+  // CHECK:   [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF_COPY]]) : $@convention(method) (@guaranteed ResilientOutsideParent) -> ()
+  // CHECK:   apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: } // end sil function '_TFC19partial_apply_super29ChildToResilientOutsideParent6methodfT_T_'
   override func method() {
     doFoo(super.method)
   }
@@ -142,11 +157,14 @@ class ChildToResilientOutsideParent : ResilientOutsideParent {
 
 class GrandchildToFixedOutsideChild : OutsideChild {
   // CHECK-LABEL: sil hidden @_TFC19partial_apply_super29GrandchildToFixedOutsideChild6methodfT_T_
-  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
-  // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $GrandchildToFixedOutsideChild to $OutsideChild
-  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $GrandchildToFixedOutsideChild, #OutsideChild.method!1 : (OutsideChild) -> () -> () , $@convention(method) (@guaranteed OutsideChild) -> ()
-  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply %5(%4) : $@convention(method) (@guaranteed OutsideChild) -> ()
-  // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: bb0([[SELF:%.*]] : $GrandchildToFixedOutsideChild):
+  // CHECK:     [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK:     [[SELF_COPY:%.*]] = copy_value [[SELF]]
+  // CHECK:     [[CASTED_SELF_COPY:%[0-9]+]] = upcast [[SELF_COPY]] : $GrandchildToFixedOutsideChild to $OutsideChild
+  // CHECK:     [[SUPER_METHOD:%[0-9]+]] = super_method [[SELF_COPY]] : $GrandchildToFixedOutsideChild, #OutsideChild.method!1 : (OutsideChild) -> () -> () , $@convention(method) (@guaranteed OutsideChild) -> ()
+  // CHECK:     [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF_COPY]]) : $@convention(method) (@guaranteed OutsideChild) -> ()
+  // CHECK:     apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: } // end sil function '_TFC19partial_apply_super29GrandchildToFixedOutsideChild6methodfT_T_'
   override func method() {
     doFoo(super.method)
   }
@@ -164,11 +182,14 @@ class GrandchildToFixedOutsideChild : OutsideChild {
 
 class GrandchildToResilientOutsideChild : ResilientOutsideChild {
   // CHECK-LABEL: sil hidden @_TFC19partial_apply_super33GrandchildToResilientOutsideChild6methodfT_T_
-  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
-  // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $GrandchildToResilientOutsideChild to $ResilientOutsideChild
-  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $GrandchildToResilientOutsideChild, #ResilientOutsideChild.method!1 : (ResilientOutsideChild) -> () -> () , $@convention(method) (@guaranteed ResilientOutsideChild) -> ()
-  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(method) (@guaranteed ResilientOutsideChild) -> ()
-  // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: bb0([[SELF:%.*]] : $GrandchildToResilientOutsideChild):
+  // CHECK:     [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK:     [[SELF_COPY:%.*]] = copy_value [[SELF]]
+  // CHECK:     [[CASTED_SELF_COPY:%[0-9]+]] = upcast [[SELF_COPY]] : $GrandchildToResilientOutsideChild to $ResilientOutsideChild
+  // CHECK:     [[SUPER_METHOD:%[0-9]+]] = super_method [[SELF_COPY]] : $GrandchildToResilientOutsideChild, #ResilientOutsideChild.method!1 : (ResilientOutsideChild) -> () -> () , $@convention(method) (@guaranteed ResilientOutsideChild) -> ()
+  // CHECK:     [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF_COPY]]) : $@convention(method) (@guaranteed ResilientOutsideChild) -> ()
+  // CHECK:     apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: } // end sil function '_TFC19partial_apply_super33GrandchildToResilientOutsideChild6methodfT_T_'
   override func method() {
     doFoo(super.method)
   }
@@ -186,11 +207,14 @@ class GrandchildToResilientOutsideChild : ResilientOutsideChild {
 
 class GenericChildToFixedGenericOutsideParent<A> : GenericOutsideParent<A> {
   // CHECK-LABEL: sil hidden @_TFC19partial_apply_super39GenericChildToFixedGenericOutsideParent6methodfT_T_
-  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
-  // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $GenericChildToFixedGenericOutsideParent<A> to $GenericOutsideParent<A>
-  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $GenericChildToFixedGenericOutsideParent<A>, #GenericOutsideParent.method!1 : <A> (GenericOutsideParent<A>) -> () -> () , $@convention(method) <τ_0_0> (@guaranteed GenericOutsideParent<τ_0_0>) -> ()
-  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]<A>([[CASTED_SELF]]) : $@convention(method) <τ_0_0> (@guaranteed GenericOutsideParent<τ_0_0>) -> ()
-  // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: bb0([[SELF:%.*]] : $GenericChildToFixedGenericOutsideParent<A>):
+  // CHECK:     [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK:     [[SELF_COPY:%.*]] = copy_value [[SELF]]
+  // CHECK:     [[CASTED_SELF_COPY:%[0-9]+]] = upcast [[SELF_COPY]] : $GenericChildToFixedGenericOutsideParent<A> to $GenericOutsideParent<A>
+  // CHECK:     [[SUPER_METHOD:%[0-9]+]] = super_method [[SELF_COPY]] : $GenericChildToFixedGenericOutsideParent<A>, #GenericOutsideParent.method!1 : <A> (GenericOutsideParent<A>) -> () -> () , $@convention(method) <τ_0_0> (@guaranteed GenericOutsideParent<τ_0_0>) -> ()
+  // CHECK:     [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]<A>([[CASTED_SELF_COPY]]) : $@convention(method) <τ_0_0> (@guaranteed GenericOutsideParent<τ_0_0>) -> ()
+  // CHECK:     apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: } // end sil function '_TFC19partial_apply_super39GenericChildToFixedGenericOutsideParent6methodfT_T_'
   override func method() {
     doFoo(super.method)
   }
@@ -208,11 +232,14 @@ class GenericChildToFixedGenericOutsideParent<A> : GenericOutsideParent<A> {
 
 class GenericChildToResilientGenericOutsideParent<A> : ResilientGenericOutsideParent<A> {
   // CHECK-LABEL: sil hidden @_TFC19partial_apply_super43GenericChildToResilientGenericOutsideParent6methodfT_T_
-  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
-  // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $GenericChildToResilientGenericOutsideParent<A> to $ResilientGenericOutsideParent<A>
-  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $GenericChildToResilientGenericOutsideParent<A>, #ResilientGenericOutsideParent.method!1 : <A> (ResilientGenericOutsideParent<A>) -> () -> () , $@convention(method) <τ_0_0> (@guaranteed ResilientGenericOutsideParent<τ_0_0>) -> ()
-  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]<A>([[CASTED_SELF]]) : $@convention(method) <τ_0_0> (@guaranteed ResilientGenericOutsideParent<τ_0_0>) -> ()
-  // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: bb0([[SELF:%.*]] : $GenericChildToResilientGenericOutsideParent<A>):
+  // CHECK:     [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK:     [[SELF_COPY:%.*]] = copy_value [[SELF]]
+  // CHECK:     [[CASTED_SELF_COPY:%[0-9]+]] = upcast [[SELF_COPY]] : $GenericChildToResilientGenericOutsideParent<A> to $ResilientGenericOutsideParent<A>
+  // CHECK:     [[SUPER_METHOD:%[0-9]+]] = super_method [[SELF_COPY]] : $GenericChildToResilientGenericOutsideParent<A>, #ResilientGenericOutsideParent.method!1 : <A> (ResilientGenericOutsideParent<A>) -> () -> () , $@convention(method) <τ_0_0> (@guaranteed ResilientGenericOutsideParent<τ_0_0>) -> ()
+  // CHECK:     [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]<A>([[CASTED_SELF_COPY]]) : $@convention(method) <τ_0_0> (@guaranteed ResilientGenericOutsideParent<τ_0_0>) -> ()
+  // CHECK:     apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: } // end sil function '_TFC19partial_apply_super43GenericChildToResilientGenericOutsideParent6methodfT_T_'
   override func method() {
     doFoo(super.method)
   }

--- a/test/SILGen/pointer_conversion.swift
+++ b/test/SILGen/pointer_conversion.swift
@@ -205,8 +205,8 @@ func classInoutToPointer() {
   // CHECK: apply [[TAKES_PLUS_ZERO]]
   // CHECK: [[UNOWNED_OUT:%.*]] = load [[WRITEBACK]]
   // CHECK: [[OWNED_OUT:%.*]] = unmanaged_to_ref [[UNOWNED_OUT]]
-  // CHECK: copy_value [[OWNED_OUT]]
-  // CHECK: assign [[OWNED_OUT]] to [[PB]]
+  // CHECK: [[OWNED_OUT_COPY:%.*]] = copy_value [[OWNED_OUT]]
+  // CHECK: assign [[OWNED_OUT_COPY]] to [[PB]]
 
   var cq: C? = C()
   takesPlusZeroOptionalPointer(&cq)

--- a/test/SILGen/property_abstraction.swift
+++ b/test/SILGen/property_abstraction.swift
@@ -10,13 +10,15 @@ struct Foo<T, U> {
   var g: T
 }
 
-// CHECK-LABEL: sil hidden @_TF20property_abstraction4getF
-// CHECK:         bb0([[X_ORIG:%.*]] : $Foo<Int, Int>):
+// CHECK-LABEL: sil hidden @_TF20property_abstraction4getF{{.*}} : 
+// CHECK:       bb0([[X_ORIG:%.*]] : $Foo<Int, Int>):
 // CHECK:         [[F_ORIG:%.*]] = struct_extract [[X_ORIG]] : $Foo<Int, Int>, #Foo.f
-// CHECK:         copy_value [[F_ORIG]]
+// CHECK:         [[F_ORIG_COPY:%.*]] = copy_value [[F_ORIG]]
 // CHECK:         [[REABSTRACT_FN:%.*]] = function_ref @_TTR
-// CHECK:         [[F_SUBST:%.*]] = partial_apply [[REABSTRACT_FN]]([[F_ORIG]])
+// CHECK:         [[F_SUBST:%.*]] = partial_apply [[REABSTRACT_FN]]([[F_ORIG_COPY]])
+// CHECK:         destroy_value [[X_ORIG]]
 // CHECK:         return [[F_SUBST]]
+// CHECK:       } // end sil function '_TF20property_abstraction4getF{{.*}}'
 func getF(_ x: Foo<Int, Int>) -> (Int) -> Int {
   return x.f
 }

--- a/test/SILGen/protocol_extensions.swift
+++ b/test/SILGen/protocol_extensions.swift
@@ -686,13 +686,16 @@ extension InitRequirement {
   // CHECK:       bb0([[OUT:%.*]] : $*Self, [[ARG:%.*]] : $D, [[SELF_TYPE:%.*]] : $@thick Self.Type):
   init(d: D) {
   // CHECK:         [[DELEGATEE:%.*]] = witness_method $Self, #InitRequirement.init!allocator.1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : InitRequirement> (@owned C, @thick τ_0_0.Type) -> @out τ_0_0
-  // CHECK:         [[ARG_UP:%.*]] = upcast [[ARG]]
-  // CHECK:         apply [[DELEGATEE]]<Self>({{%.*}}, [[ARG_UP]], [[SELF_TYPE]])
+  // CHECK:         [[ARG_COPY:%.*]] = copy_value [[ARG]]
+  // CHECK:         [[ARG_COPY_CAST:%.*]] = upcast [[ARG_COPY]]
+  // CHECK:         apply [[DELEGATEE]]<Self>({{%.*}}, [[ARG_COPY_CAST]], [[SELF_TYPE]])
     self.init(c: d)
   }
+  // CHECK: } // end sil function '_TFE19protocol_extensionsPS_15InitRequirementC{{.*}}'
 
-  // CHECK-LABEL: sil hidden @_TFE19protocol_extensionsPS_15InitRequirementC{{.*}}
+  // CHECK-LABEL: sil hidden @_TFE19protocol_extensionsPS_15InitRequirementC{{.*}} : $@convention(method)
   // CHECK:         function_ref @_TFE19protocol_extensionsPS_15InitRequirementC{{.*}}
+  // CHECK: } // end sil function '_TFE19protocol_extensionsPS_15InitRequirementC{{.*}}'
   init(d2: D) {
     self.init(d: d2)
   }
@@ -706,8 +709,10 @@ extension ClassInitRequirement {
   // CHECK-LABEL: sil hidden @_TFE19protocol_extensionsPS_20ClassInitRequirementC{{.*}} : $@convention(method) <Self where Self : ClassInitRequirement> (@owned D, @thick Self.Type) -> @owned Self
   // CHECK:       bb0([[ARG:%.*]] : $D, [[SELF_TYPE:%.*]] : $@thick Self.Type):
   // CHECK:         [[DELEGATEE:%.*]] = witness_method $Self, #ClassInitRequirement.init!allocator.1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : ClassInitRequirement> (@owned C, @thick τ_0_0.Type) -> @owned τ_0_0
-  // CHECK:         [[ARG_UP:%.*]] = upcast [[ARG]]
-  // CHECK:         apply [[DELEGATEE]]<Self>([[ARG_UP]], [[SELF_TYPE]])
+  // CHECK:         [[ARG_COPY:%.*]] = copy_value [[ARG]]
+  // CHECK:         [[ARG_COPY_CAST:%.*]] = upcast [[ARG_COPY]]
+  // CHECK:         apply [[DELEGATEE]]<Self>([[ARG_COPY_CAST]], [[SELF_TYPE]])
+  // CHECK: } // end sil function '_TFE19protocol_extensionsPS_20ClassInitRequirementC{{.*}}'
   init(d: D) {
     self.init(c: d)
   }
@@ -730,9 +735,12 @@ extension ObjCInitRequirement {
   // CHECK:         [[OBJC_SELF_TYPE:%.*]] = thick_to_objc_metatype [[SELF_TYPE]]
   // CHECK:         [[SELF:%.*]] = alloc_ref_dynamic [objc] [[OBJC_SELF_TYPE]] : $@objc_metatype Self.Type, $Self
   // CHECK:         [[WITNESS:%.*]] = witness_method [volatile] $Self, #ObjCInitRequirement.init!initializer.1.foreign : $@convention(objc_method) <τ_0_0 where τ_0_0 : ObjCInitRequirement> (OC, OC, @owned τ_0_0) -> @owned τ_0_0
-  // CHECK:         [[UPCAST1:%.*]] = upcast [[ARG]]
-  // CHECK:         [[UPCAST2:%.*]] = upcast [[ARG]]
-  // CHECK:         apply [[WITNESS]]<Self>([[UPCAST1]], [[UPCAST2]], [[SELF]])
+  // CHECK:         [[ARG_COPY_1:%.*]] = copy_value [[ARG]]
+  // CHECK:         [[ARG_COPY_1_UPCAST:%.*]] = upcast [[ARG_COPY_1]]
+  // CHECK:         [[ARG_COPY_2:%.*]] = copy_value [[ARG]]
+  // CHECK:         [[ARG_COPY_2_UPCAST:%.*]] = upcast [[ARG_COPY_2]]
+  // CHECK:         apply [[WITNESS]]<Self>([[ARG_COPY_1_UPCAST]], [[ARG_COPY_2_UPCAST]], [[SELF]])
+  // CHECK: } // end sil function '_TFE19protocol_extensionsPS_19ObjCInitRequirementC{{.*}}'
   init(d: OD) {
     self.init(c: d, d: d)
   }

--- a/test/SILGen/protocol_optional.swift
+++ b/test/SILGen/protocol_optional.swift
@@ -12,50 +12,59 @@
 func optionalMethodGeneric<T : P1>(t t : T) {
   var t = t
   // CHECK: bb0([[T:%[0-9]+]] : $T):
-  // CHECK: [[TBOX:%[0-9]+]] = alloc_box $@box T
-  // CHECK-NEXT: [[PT:%[0-9]+]] = project_box [[TBOX]]
-  // CHECK: store [[T]] to [init] [[PT]] : $*T
-  // CHECK-NEXT: [[OPT_BOX:%[0-9]+]] = alloc_box $@box Optional<@callee_owned (Int) -> ()>
-  // CHECK-NEXT: project_box [[OPT_BOX]]
-  // CHECK-NEXT: [[T:%[0-9]+]] = load [[PT]] : $*T
-  // CHECK-NEXT: copy_value [[T]] : $T
-  // CHECK-NEXT: alloc_stack $Optional<@callee_owned (Int) -> ()>
-  // CHECK-NEXT: dynamic_method_br [[T]] : $T, #P1.method!1.foreign
+  // CHECK:   [[TBOX:%[0-9]+]] = alloc_box $@box T
+  // CHECK:   [[PT:%[0-9]+]] = project_box [[TBOX]]
+  // CHECK:   [[T_COPY:%.*]] = copy_value [[T]]
+  // CHECK:   store [[T_COPY]] to [init] [[PT]] : $*T
+  // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box $@box Optional<@callee_owned (Int) -> ()>
+  // CHECK:   project_box [[OPT_BOX]]
+  // CHECK:   [[T:%[0-9]+]] = load [[PT]] : $*T
+  // CHECK:   [[T_COPY:%.*]] = copy_value [[T]] : $T
+  // CHECK:   alloc_stack $Optional<@callee_owned (Int) -> ()>
+  // SEMANTIC ARC TODO: This should be a branch on T_COPY.
+  // CHECK:   dynamic_method_br [[T]] : $T, #P1.method!1.foreign
   var methodRef = t.method
 }
+// CHECK: } // end sil function '{{.*}}optionalMethodGeneric{{.*}}'
 
 // CHECK-LABEL: sil hidden @_TF17protocol_optional23optionalPropertyGeneric{{.*}} : $@convention(thin) <T where T : P1> (@owned T) -> ()
 func optionalPropertyGeneric<T : P1>(t t : T) {
   var t = t
   // CHECK: bb0([[T:%[0-9]+]] : $T):
-  // CHECK: [[TBOX:%[0-9]+]] = alloc_box $@box T
-  // CHECK-NEXT: [[PT:%[0-9]+]] = project_box [[TBOX]]
-  // CHECK: store [[T]] to [init] [[PT]] : $*T
-  // CHECK-NEXT: [[OPT_BOX:%[0-9]+]] = alloc_box $@box Optional<Int>
-  // CHECK-NEXT: project_box [[OPT_BOX]]
-  // CHECK-NEXT: [[T:%[0-9]+]] = load [[PT]] : $*T
-  // CHECK-NEXT: copy_value [[T]] : $T
-  // CHECK-NEXT: alloc_stack $Optional<Int>
-  // CHECK-NEXT: dynamic_method_br [[T]] : $T, #P1.prop!getter.1.foreign
+  // CHECK:   [[TBOX:%[0-9]+]] = alloc_box $@box T
+  // CHECK:   [[PT:%[0-9]+]] = project_box [[TBOX]]
+  // CHECK:   [[T_COPY:%.*]] = copy_value [[T]]
+  // CHECK:   store [[T_COPY]] to [init] [[PT]] : $*T
+  // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box $@box Optional<Int>
+  // CHECK:   project_box [[OPT_BOX]]
+  // CHECK:   [[T:%[0-9]+]] = load [[PT]] : $*T
+  // CHECK:   [[T_COPY:%.*]] = copy_value [[T]] : $T
+  // CHECK:   alloc_stack $Optional<Int>
+  // SEMANTIC ARC TODO: This should be a dynamic_method_br on T_COPY, not T.
+  // CHECK:   dynamic_method_br [[T]] : $T, #P1.prop!getter.1.foreign
   var propertyRef = t.prop
 }
+// CHECK: } // end sil function '_TF17protocol_optional23optionalPropertyGeneric{{.*}}'
 
 // CHECK-LABEL: sil hidden @_TF17protocol_optional24optionalSubscriptGeneric{{.*}} : $@convention(thin) <T where T : P1> (@owned T) -> ()
 func optionalSubscriptGeneric<T : P1>(t t : T) {
   var t = t
   // CHECK: bb0([[T:%[0-9]+]] : $T):
-  // CHECK: [[TBOX:%[0-9]+]] = alloc_box $@box T
-  // CHECK-NEXT: [[PT:%[0-9]+]] = project_box [[TBOX]]
-  // CHECK: store [[T]] to [init] [[PT]] : $*T
-  // CHECK-NEXT: [[OPT_BOX:%[0-9]+]] = alloc_box $@box Optional<Int>
-  // CHECK-NEXT: project_box [[OPT_BOX]]
-  // CHECK-NEXT: [[T:%[0-9]+]] = load [[PT]] : $*T
-  // CHECK-NEXT: copy_value [[T]] : $T
-  // CHECK: [[INTCONV:%[0-9]+]] = function_ref @_TFSiC
-  // CHECK-NEXT: [[INT64:%[0-9]+]] = metatype $@thin Int.Type
-  // CHECK-NEXT: [[FIVELIT:%[0-9]+]] = integer_literal $Builtin.Int2048, 5
-  // CHECK-NEXT: [[FIVE:%[0-9]+]] = apply [[INTCONV]]([[FIVELIT]], [[INT64]]) : $@convention(method) (Builtin.Int2048, @thin Int.Type) -> Int
-  // CHECK-NEXT: alloc_stack $Optional<Int>
-  // CHECK-NEXT: dynamic_method_br [[T]] : $T, #P1.subscript!getter.1.foreign
+  // CHECK:   [[TBOX:%[0-9]+]] = alloc_box $@box T
+  // CHECK:   [[PT:%[0-9]+]] = project_box [[TBOX]]
+  // CHECK:   [[T_COPY:%.*]] = copy_value [[T]]
+  // CHECK:   store [[T_COPY]] to [init] [[PT]] : $*T
+  // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box $@box Optional<Int>
+  // CHECK:   project_box [[OPT_BOX]]
+  // CHECK:   [[T:%[0-9]+]] = load [[PT]] : $*T
+  // CHECK:   [[T_COPY:%.*]] = copy_value [[T]] : $T
+  // CHECK:   [[INTCONV:%[0-9]+]] = function_ref @_TFSiC
+  // CHECK:   [[INT64:%[0-9]+]] = metatype $@thin Int.Type
+  // CHECK:   [[FIVELIT:%[0-9]+]] = integer_literal $Builtin.Int2048, 5
+  // CHECK:   [[FIVE:%[0-9]+]] = apply [[INTCONV]]([[FIVELIT]], [[INT64]]) : $@convention(method) (Builtin.Int2048, @thin Int.Type) -> Int
+  // CHECK:   alloc_stack $Optional<Int>
+  // SEMANTIC ARC TODO: This should be a dynamic_method_br on T_COPY, not T.
+  // CHECK:   dynamic_method_br [[T]] : $T, #P1.subscript!getter.1.foreign
   var subscriptRef = t[5]
 }
+// CHECK: } // end sil function '_TF17protocol_optional24optionalSubscriptGeneric{{.*}}'

--- a/test/SILGen/struct_resilience.swift
+++ b/test/SILGen/struct_resilience.swift
@@ -26,8 +26,9 @@ func functionWithResilientTypes(_ s: Size, f: (Size) -> Size) -> Size {
 // CHECK:         [[RESULT:%.*]] = apply [[FN]]([[SIZE_BOX]])
   _ = s.h
 
+// CHECK:         [[COPIED_CLOSURE:%.*]] = copy_value %2
 // CHECK:         copy_addr %1 to [initialization] [[SIZE_BOX:%.*]] : $*Size
-// CHECK:         apply %2(%0, [[SIZE_BOX]])
+// CHECK:         apply [[COPIED_CLOSURE]](%0, [[SIZE_BOX]])
 // CHECK:         return
   return f(s)
 }
@@ -66,7 +67,8 @@ func functionWithFixedLayoutTypes(_ p: Point, f: (Point) -> Point) -> Point {
 // CHECK:         [[RESULT:%.*]] = struct_extract %0 : $Point, #Point.y
   _ = p.y
 
-// CHECK:         [[NEW_POINT:%.*]] = apply %1(%0)
+// CHECK:         [[COPIED_CLOSURE:%.*]] = copy_value %1
+// CHECK:         [[NEW_POINT:%.*]] = apply [[COPIED_CLOSURE]](%0)
 // CHECK:         return [[NEW_POINT]]
   return f(p)
 }
@@ -143,8 +145,9 @@ public func functionWithMyResilientTypes(_ s: MySize, f: (MySize) -> MySize) -> 
 // CHECK:         [[RESULT:%.*]] = load [[RESULT_ADDR]] : $*Int
   _ = s.h
 
+// CHECK:         [[CLOSURE_COPY:%.*]] = copy_value %2
 // CHECK:         copy_addr %1 to [initialization] [[SIZE_BOX:%.*]] : $*MySize
-// CHECK:         apply %2(%0, [[SIZE_BOX]])
+// CHECK:         apply [[CLOSURE_COPY]](%0, [[SIZE_BOX]])
 // CHECK:         return
   return f(s)
 }

--- a/test/SILGen/super.swift
+++ b/test/SILGen/super.swift
@@ -32,16 +32,26 @@ public class Parent {
 }
 
 public class Child : Parent {
-  // CHECK-LABEL: sil @_TFC5super5Childg8propertySS
-  // CHECK:         [[CASTED_SELF:%[0-9]+]] = upcast %0 : $Child to $Parent
+  // CHECK-LABEL: sil @_TFC5super5Childg8propertySS : $@convention(method) (@guaranteed Child) -> @owned String {
+  // CHECK:       bb0([[SELF:%.*]] : $Child):
+  // CHECK:         [[SELF_COPY:%.*]] = copy_value [[SELF]]
+  // CHECK:         [[CASTED_SELF_COPY:%[0-9]+]] = upcast [[SELF_COPY]] : $Child to $Parent
   // CHECK:         [[SUPER_METHOD:%[0-9]+]] = function_ref @_TFC5super6Parentg8propertySS : $@convention(method) (@guaranteed Parent) -> @owned String
+  // CHECK:         [[RESULT:%.*]] = apply [[SUPER_METHOD]]([[CASTED_SELF_COPY]])
+  // CHECK:         destroy_value [[CASTED_SELF_COPY]]
+  // CHECK:         return [[RESULT]]
   public override var property: String {
     return super.property
   }
 
-  // CHECK-LABEL: sil @_TFC5super5Childg13otherPropertySS
-  // CHECK:         [[CASTED_SELF:%[0-9]+]] = upcast %0 : $Child to $Parent
+  // CHECK-LABEL: sil @_TFC5super5Childg13otherPropertySS : $@convention(method) (@guaranteed Child) -> @owned String {
+  // CHECK:       bb0([[SELF:%.*]] : $Child):
+  // CHECK:         [[COPIED_SELF:%.*]] = copy_value [[SELF]]
+  // CHECK:         [[CASTED_SELF_COPY:%[0-9]+]] = upcast [[COPIED_SELF]] : $Child to $Parent
   // CHECK:         [[SUPER_METHOD:%[0-9]+]] = function_ref @_TFC5super6Parentg13finalPropertySS
+  // CHECK:         [[RESULT:%.*]] = apply [[SUPER_METHOD]]([[CASTED_SELF_COPY]])
+  // CHECK:         destroy_value [[CASTED_SELF_COPY]]
+  // CHECK:         return [[RESULT]]
   public var otherProperty: String {
     return super.finalProperty
   }

--- a/test/SILGen/switch.swift
+++ b/test/SILGen/switch.swift
@@ -430,135 +430,194 @@ class D1 : C {}
 class D2 : D1 {}
 class E : C {}
 
-// CHECK-LABEL: sil hidden @_TF6switch16test_isa_class_1FT1xCS_1B_T_
+// CHECK-LABEL: sil hidden @_TF6switch16test_isa_class_1FT1xCS_1B_T_ : $@convention(thin) (@owned B) -> () {
 func test_isa_class_1(x: B) {
-  // CHECK: copy_value %0
+  // CHECK: bb0([[X:%.*]] : $B):
+  // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
+  // CHECK:   checked_cast_br [[X_COPY]] : $B to $D1, [[IS_D1:bb[0-9]+]], [[IS_NOT_D1:bb[0-9]+]]
   switch x {
-  // CHECK:   checked_cast_br [[X:%.*]] : $B to $D1, [[IS_D1:bb[0-9]+]], [[IS_NOT_D1:bb[0-9]+]]
 
   // CHECK: [[IS_D1]]([[CAST_D1:%.*]]):
-  // CHECK:   function_ref @_TF6switch6runcedFT_Sb
+  // CHECK:   [[CAST_D1_COPY:%.*]] = copy_value [[CAST_D1]]
+  // CHECK:   function_ref @_TF6switch6runcedFT_Sb : $@convention(thin) () -> Bool
   // CHECK:   cond_br {{%.*}}, [[YES_CASE1:bb[0-9]+]], [[NO_CASE1:bb[0-9]+]]
 
   // CHECK: [[YES_CASE1]]:
   case is D1 where runced():
-  // CHECK:   destroy_value [[CAST_D1]]
+  // CHECK:   destroy_value [[CAST_D1_COPY]]
+  // CHECK:   destroy_value [[X_COPY]]
   // CHECK:   function_ref @_TF6switch1aFT_T_
   // CHECK:   br [[CONT:bb[0-9]+]]
     a()
 
   // CHECK: [[NO_CASE1]]:
-  // CHECK: [[IS_NOT_D1]]:
-  // CHECK:   checked_cast_br [[X]] : $B to $D2, [[IS_D2:bb[0-9]+]], [[IS_NOT_D2:bb[0-9]+]]
+  // CHECK:   destroy_value [[CAST_D1_COPY]]
+  // CHECK:   br [[NEXT_CASE:bb5]]
 
-  // CHECK: [[IS_D2]]([[CAST_D2:%.*]]):
+  // CHECK: [[IS_NOT_D1]]:
+  // CHECK:   br [[NEXT_CASE]]
+
+  // CHECK: [[NEXT_CASE]]
+  // CHECK:   checked_cast_br [[X_COPY]] : $B to $D2, [[IS_D2:bb[0-9]+]], [[IS_NOT_D2:bb[0-9]+]]
   case is D2:
-  // CHECK:   destroy_value %0
+  // CHECK: [[IS_D2]]([[CAST_D2:%.*]]):
+  // CHECK:   [[CAST_D2_COPY:%.*]] = copy_value [[CAST_D2]]
+  // CHECK:   destroy_value [[CAST_D2_COPY]]
+  // CHECK:   destroy_value [[X_COPY]]
   // CHECK:   function_ref @_TF6switch1bFT_T_
   // CHECK:   br [[CONT]]
     b()
 
   // CHECK: [[IS_NOT_D2]]:
-  // CHECK:   checked_cast_br [[X]] : $B to $E, [[IS_E:bb[0-9]+]], [[IS_NOT_E:bb[0-9]+]]
+  // CHECK:   br [[NEXT_CASE:bb8]]
 
+  // CHECK: [[NEXT_CASE]]:
+  // CHECK:   checked_cast_br [[X_COPY]] : $B to $E, [[IS_E:bb[0-9]+]], [[IS_NOT_E:bb[0-9]+]]
+  case is E where funged():
   // CHECK: [[IS_E]]([[CAST_E:%.*]]):
+  // CHECK:   [[CAST_E_COPY:%.*]] = copy_value [[CAST_E]]
   // CHECK:   function_ref @_TF6switch6fungedFT_Sb
   // CHECK:   cond_br {{%.*}}, [[CASE3:bb[0-9]+]], [[NO_CASE3:bb[0-9]+]]
 
-  case is E where funged():
   // CHECK: [[CASE3]]:
+  // CHECK:   destroy_value [[CAST_E_COPY]]
+  // CHECK:   destroy_value [[X_COPY]]
   // CHECK:   function_ref @_TF6switch1cFT_T_
   // CHECK:   br [[CONT]]
     c()
 
   // CHECK: [[NO_CASE3]]:
-  // CHECK: [[IS_NOT_E]]:
-  // CHECK:   checked_cast_br [[X]] : $B to $C, [[IS_C:bb[0-9]+]], [[IS_NOT_C:bb[0-9]+]]
+  // CHECK:   destroy_value [[CAST_E_COPY]]
+  // CHECK:   br [[NEXT_CASE:bb13]]
 
-  // CHECK: [[IS_C]]([[CAST_C:%.*]]):
+  // CHECK: [[IS_NOT_E]]:
+  // CHECK:   br [[NEXT_CASE]]
+
+  // CHECK: [[NEXT_CASE]]
+  // CHECK:   checked_cast_br [[X_COPY]] : $B to $C, [[IS_C:bb[0-9]+]], [[IS_NOT_C:bb[0-9]+]]
+
   case is C:
+  // CHECK: [[IS_C]]([[CAST_C:%.*]]):
+  // CHECK:   [[CAST_C_COPY:%.*]] = copy_value [[CAST_C]]
+  // CHECK:   destroy_value [[CAST_C_COPY]]
+  // CHECK:   destroy_value [[X_COPY]]
   // CHECK:   function_ref @_TF6switch1dFT_T_
   // CHECK:   br [[CONT]]
     d()
 
   // CHECK: [[IS_NOT_C]]:
+  // CHECK:   br [[NEXT_CASE:bb16]]
+
+  // CHECK: [[NEXT_CASE]]:
   default:
-  // CHECK:   destroy_value [[X]]
-  // CHECK:  function_ref @_TF6switch1eFT_T_
-  // CHECK:  br [[CONT]]
+  // CHECK:    destroy_value [[X_COPY]]
+  // CHECK:    function_ref @_TF6switch1eFT_T_
+  // CHECK:    br [[CONT]]
     e()
   }
   // CHECK: [[CONT]]:
-  // CHECK: destroy_value %0
+  // CHECK:   [[F_FUNC:%.*]] = function_ref @_TF6switch1fFT_T_ : $@convention(thin) () -> ()
+  // CHECK:   apply [[F_FUNC]]()
+  // CHECK:   destroy_value [[X]]
   f()
 }
+// CHECK: } // end sil function '_TF6switch16test_isa_class_1FT1xCS_1B_T_'
 
-// CHECK-LABEL: sil hidden @_TF6switch16test_isa_class_2FT1xCS_1B_Ps9AnyObject_
+// CHECK-LABEL: sil hidden @_TF6switch16test_isa_class_2FT1xCS_1B_Ps9AnyObject_ : $@convention(thin)
 func test_isa_class_2(x: B) -> AnyObject {
-  // CHECK:   copy_value [[X:%0]]
+  // CHECK: bb0([[X:%.*]] : $B):
+  // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
   switch x {
-  // CHECK:   checked_cast_br [[X]] : $B to $D1, [[IS_D1:bb[0-9]+]], [[IS_NOT_D1:bb[0-9]+]]
 
-  // CHECK: [[IS_D1]]([[CAST_D1:%.*]]):
-  // CHECK:   copy_value [[CAST_D1]]
+  // CHECK:   checked_cast_br [[X_COPY]] : $B to $D1, [[IS_D1:bb[0-9]+]], [[IS_NOT_D1:bb[0-9]+]]
+  case let y as D1 where runced():
+  // CHECK: [[IS_D1]]([[CAST_D1:%.*]] : $D1):
+  // CHECK:   [[CAST_D1_COPY:%.*]] = copy_value [[CAST_D1]]
   // CHECK:   function_ref @_TF6switch6runcedFT_Sb
   // CHECK:   cond_br {{%.*}}, [[CASE1:bb[0-9]+]], [[NO_CASE1:bb[0-9]+]]
 
-  case let y as D1 where runced():
   // CHECK: [[CASE1]]:
   // CHECK:   function_ref @_TF6switch1aFT_T_
-  // CHECK:   [[RET:%.*]] = init_existential_ref [[CAST_D1]]
-  // CHECK:   destroy_value [[X]] : $B
+  // CHECK:   [[CAST_D1_COPY_COPY:%.*]] = copy_value [[CAST_D1_COPY]]
+  // CHECK:   [[RET:%.*]] = init_existential_ref [[CAST_D1_COPY_COPY]]
+  // CHECK:   destroy_value [[CAST_D1_COPY]]
+  // CHECK:   destroy_value [[X_COPY]] : $B
   // CHECK:   br [[CONT:bb[0-9]+]]([[RET]] : $AnyObject)
     a()
     return y
 
   // CHECK: [[NO_CASE1]]:
-  // CHECK:   destroy_value [[CAST_D1]]
+  // CHECK:   destroy_value [[CAST_D1_COPY]]
+  // CHECK:   br [[NEXT_CASE:bb5]]
+  
   // CHECK: [[IS_NOT_D1]]:
-  // CHECK:   checked_cast_br [[X]] : $B to $D2, [[CASE2:bb[0-9]+]], [[IS_NOT_D2:bb[0-9]+]]
+  // CHECK:   br [[NEXT_CASE]]
 
+  // CHECK: [[NEXT_CASE]]:
+  // CHECK:   checked_cast_br [[X_COPY]] : $B to $D2, [[CASE2:bb[0-9]+]], [[IS_NOT_D2:bb[0-9]+]]
   case let y as D2:
   // CHECK: [[CASE2]]([[CAST_D2:%.*]]):
+  // CHECK:   [[CAST_D2_COPY:%.*]] = copy_value [[CAST_D2]]
   // CHECK:   function_ref @_TF6switch1bFT_T_
-  // CHECK:   [[RET:%.*]] = init_existential_ref [[CAST_D2]]
+  // CHECK:   [[CAST_D2_COPY_COPY:%.*]] = copy_value [[CAST_D2_COPY]]
+  // CHECK:   [[RET:%.*]] = init_existential_ref [[CAST_D2_COPY_COPY]]
+  // CHECK:   destroy_value [[CAST_D2_COPY]]
+  // CHECK:   destroy_value [[X_COPY]]
   // CHECK:   br [[CONT]]([[RET]] : $AnyObject)
     b()
     return y
 
   // CHECK: [[IS_NOT_D2]]:
-  // CHECK:   checked_cast_br [[X]] : $B to $E, [[IS_E:bb[0-9]+]], [[IS_NOT_E:bb[0-9]+]]
+  // CHECK:   br [[NEXT_CASE:bb8]]
 
+  // CHECK: [[NEXT_CASE]]:
+  // CHECK:   checked_cast_br [[X_COPY]] : $B to $E, [[IS_E:bb[0-9]+]], [[IS_NOT_E:bb[0-9]+]]
+  case let y as E where funged():
   // CHECK: [[IS_E]]([[CAST_E:%.*]]):
-  // CHECK:   copy_value [[CAST_E]]
+  // CHECK:   [[CAST_E_COPY:%.*]] = copy_value [[CAST_E]]
   // CHECK:   function_ref @_TF6switch6fungedFT_Sb
   // CHECK:   cond_br {{%.*}}, [[CASE3:bb[0-9]+]], [[NO_CASE3:bb[0-9]+]]
 
-  case let y as E where funged():
   // CHECK: [[CASE3]]:
   // CHECK:   function_ref @_TF6switch1cFT_T_
-  // CHECK:   [[RET:%.*]] = init_existential_ref [[CAST_E]]
-  // CHECK:   destroy_value [[X]] : $B
+  // CHECK:   [[CAST_E_COPY_COPY:%.*]] = copy_value [[CAST_E_COPY]]
+  // CHECK:   [[RET:%.*]] = init_existential_ref [[CAST_E_COPY_COPY]]
+  // CHECK:   destroy_value [[CAST_E_COPY]]
+  // CHECK:   destroy_value [[X_COPY]] : $B
   // CHECK:   br [[CONT]]([[RET]] : $AnyObject)
     c()
     return y
 
   // CHECK: [[NO_CASE3]]:
-  // CHECK    destroy_value [[CAST_E]]
+  // CHECK    destroy_value [[CAST_E_COPY]]
+  // CHECK:   br [[NEXT_CASE:bb13]]
+
   // CHECK: [[IS_NOT_E]]:
-  // CHECK:   checked_cast_br [[X]] : $B to $C, [[CASE4:bb[0-9]+]], [[IS_NOT_C:bb[0-9]+]]
+  // CHECK:   br [[NEXT_CASE]]
+
+  // CHECK: [[NEXT_CASE]]
+  // CHECK:   checked_cast_br [[X_COPY]] : $B to $C, [[CASE4:bb[0-9]+]], [[IS_NOT_C:bb[0-9]+]]
   case let y as C:
   // CHECK: [[CASE4]]([[CAST_C:%.*]]):
+  // CHECK:   [[CAST_C_COPY:%.*]] = copy_value [[CAST_C]]
   // CHECK:   function_ref @_TF6switch1dFT_T_
-  // CHECK:   [[RET:%.*]] = init_existential_ref [[CAST_C]]
+  // CHECK:   [[CAST_C_COPY_COPY:%.*]] = copy_value [[CAST_C_COPY]]
+  // CHECK:   [[RET:%.*]] = init_existential_ref [[CAST_C_COPY_COPY]]
+  // CHECK:   destroy_value [[CAST_C_COPY]]
+  // CHECK:   destroy_value [[X_COPY]]
   // CHECK:   br [[CONT]]([[RET]] : $AnyObject)
     d()
     return y
 
   // CHECK: [[IS_NOT_C]]:
+  // CHECK:   br [[NEXT_CASE:bb16]]
+
+  // CHECK: [[NEXT_CASE]]:
   default:
+  // CHECK:   destroy_value [[X_COPY]]
   // CHECK:   function_ref @_TF6switch1eFT_T_
-  // CHECK:   [[RET:%.*]] = init_existential_ref [[X]]
+  // CHECK:   [[X_COPY_2:%.*]] = copy_value [[X]]
+  // CHECK:   [[RET:%.*]] = init_existential_ref [[X_COPY_2]]
   // CHECK:   br [[CONT]]([[RET]] : $AnyObject)
     e()
     return x
@@ -568,6 +627,7 @@ func test_isa_class_2(x: B) -> AnyObject {
   // CHECK:   destroy_value [[X]]
   // CHECK:   return [[T0]]
 }
+// CHECK: } // end sil function '_TF6switch16test_isa_class_2FT1xCS_1B_Ps9AnyObject_'
 
 enum MaybePair {
   case Neither
@@ -657,16 +717,16 @@ func test_union_2(u: MaybePair) {
   d()
 }
 
-// CHECK-LABEL: sil hidden  @_TF6switch12test_union_3FT1uOS_9MaybePair_T_
+// CHECK-LABEL: sil hidden  @_TF6switch12test_union_3FT1uOS_9MaybePair_T_ : $@convention(thin) (@owned MaybePair) -> () {
 func test_union_3(u: MaybePair) {
-  // CHECK:   copy_value [[SUBJECT:%0]]
+  // CHECK: bb0([[ARG:%.*]] : $MaybePair):
+  // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+  // CHECK:   switch_enum [[SUBJECT]] : $MaybePair,
+  // CHECK:     case #MaybePair.Neither!enumelt: [[IS_NEITHER:bb[0-9]+]],
+  // CHECK:     case #MaybePair.Left!enumelt.1: [[IS_LEFT:bb[0-9]+]],
+  // CHECK:     case #MaybePair.Right!enumelt.1: [[IS_RIGHT:bb[0-9]+]],
+  // CHECK:     default [[DEFAULT:bb[0-9]+]]
   switch u {
-  // CHECK: switch_enum [[SUBJECT]] : $MaybePair,
-  // CHECK:   case #MaybePair.Neither!enumelt: [[IS_NEITHER:bb[0-9]+]],
-  // CHECK:   case #MaybePair.Left!enumelt.1: [[IS_LEFT:bb[0-9]+]],
-  // CHECK:   case #MaybePair.Right!enumelt.1: [[IS_RIGHT:bb[0-9]+]],
-  // CHECK:   default [[DEFAULT:bb[0-9]+]]
-
   // CHECK: [[IS_NEITHER]]:
   case .Neither:
   // CHECK:   function_ref @_TF6switch1aFT_T_
@@ -688,7 +748,7 @@ func test_union_3(u: MaybePair) {
 
   // CHECK: [[DEFAULT]]:
   // -- Ensure the fully-opaque value is destroyed in the default case.
-  // CHECK:   destroy_value [[SUBJECT]] :
+  // CHECK:   destroy_value [[ARG_COPY]] :
   // CHECK:   function_ref @_TF6switch1dFT_T_
   // CHECK:   br [[CONT]]
 
@@ -697,9 +757,9 @@ func test_union_3(u: MaybePair) {
   }
 
   // CHECK: [[CONT]]:
-  // CHECK-NOT: switch_enum [[SUBJECT]]
+  // CHECK-NOT: switch_enum [[ARG]]
   // CHECK:   function_ref @_TF6switch1eFT_T_
-  // CHECK:   destroy_value [[SUBJECT]]
+  // CHECK:   destroy_value [[ARG]]
   e()
 }
 

--- a/test/SILGen/types.swift
+++ b/test/SILGen/types.swift
@@ -4,7 +4,7 @@ class C {
   var member: Int = 0
 
   // Methods have method calling convention.
-  // CHECK-LABEL: sil hidden @_TFC5types1C3foo{{.*}} : $@convention(method) (Int, @guaranteed C) -> () {
+  // CHECK-LABEL: sil hidden @_TFC5types1C3foofT1xSi_T_ : $@convention(method) (Int, @guaranteed C) -> () {
   func foo(x x: Int) {
     // CHECK: bb0([[X:%[0-9]+]] : $Int, [[THIS:%[0-9]+]] : $C):
     member = x
@@ -13,9 +13,8 @@ class C {
     // CHECK: [[FN:%[0-9]+]] = class_method %1 : $C, #C.member!setter.1
     // CHECK: apply [[FN]](%0, %1) : $@convention(method) (Int, @guaranteed C) -> ()
     // CHECK-NOT: destroy_value
-
-
   }
+  // CHECK: } // end sil function '_TFC5types1C3foofT1xSi_T_'
 }
 
 struct S {

--- a/test/SILGen/witnesses.swift
+++ b/test/SILGen/witnesses.swift
@@ -188,11 +188,11 @@ func <~>(_ x: ConformingClass, y: ConformingClass) -> ConformingClass { return x
 extension ConformingClass : ClassBounded { }
 // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWC9witnesses15ConformingClassS_12ClassBoundedS_FS1_9selfTypes{{.*}} : $@convention(witness_method) (@owned ConformingClass, @guaranteed ConformingClass) -> @owned ConformingClass {
 // CHECK:  bb0([[C0:%.*]] : $ConformingClass, [[C1:%.*]] : $ConformingClass):
-// CHECK-NEXT:    copy_value [[C1]]
+// CHECK-NEXT:    [[C1_COPY:%.*]] = copy_value [[C1]]
 // CHECK-NEXT:    function_ref
 // CHECK-NEXT:    [[FUN:%.*]] = function_ref @_TFC9witnesses15ConformingClass9selfTypes
-// CHECK-NEXT:    [[RESULT:%.*]] = apply [[FUN]]([[C0]], [[C1]]) : $@convention(method) (@owned ConformingClass, @guaranteed ConformingClass) -> @owned ConformingClass
-// CHECK-NEXT:    destroy_value [[C1]]
+// CHECK-NEXT:    [[RESULT:%.*]] = apply [[FUN]]([[C0]], [[C1_COPY]]) : $@convention(method) (@owned ConformingClass, @guaranteed ConformingClass) -> @owned ConformingClass
+// CHECK-NEXT:    destroy_value [[C1_COPY]]
 // CHECK-NEXT:    return [[RESULT]] : $ConformingClass
 // CHECK-NEXT:  }
 


### PR DESCRIPTION
This ensures that ownership is properly propagated forward through the use-def
graph.

This was the work that was stymied by issues relating to SILBuilder performing local ARC dataflow. I ripped out that local dataflow in 6f4e2ab391f70773803fe8a5cc2a1170da786466 and added a cheap ARC guaranteed dataflow pass that performs the same optimization.

Also in the process of doing this work, I found that there were many SILGen tests that were either pattern matching in the wrong functions or had wrong CHECK lines (for instance CHECK_NEXT). I fixed all of these issues and also expanded many of the tests so that they verify ownership. The only work I left for a future PR is that there are certain places in tests where we are using the projection from an original value, instead of a copy. I marked those with a message SEMANTIC ARC TODO so that they are easy to find.

rdar://28685236