### PR TITLE
[swiftc (103 vs. 5183)] Add crasher in swift::ConformanceLookupTable::updateLookupTable

### DIFF
--- a/validation-test/compiler_crashers/28475-swift-typechecker-validatedecl-swift-valuedecl-bool.swift
+++ b/validation-test/compiler_crashers/28475-swift-typechecker-validatedecl-swift-valuedecl-bool.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P{func c(array:A.c
+class A:P


### PR DESCRIPTION
Add test case for crash triggered in `swift::ConformanceLookupTable::updateLookupTable`.

Current number of unresolved compiler crashers: 103 (5183 resolved)

Stack trace:

```
#0 0x00000000031cec28 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31cec28)
#1 0x00000000031cf476 SignalHandler(int) (/path/to/swift/bin/swift+0x31cf476)
#2 0x00007fd8c74b5330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x0000000000df0f24 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xdf0f24)
#4 0x0000000000df0861 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xdf0861)
#5 0x0000000000df0e04 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0xdf0e04)
#6 0x0000000000df432e swift::ConformanceLookupTable::getAllProtocols(swift::NominalTypeDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0xdf432e)
#7 0x0000000000dd2fcf swift::NominalTypeDecl::getAllProtocols() const (/path/to/swift/bin/swift+0xdd2fcf)
#8 0x0000000000dc77eb swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const (/path/to/swift/bin/swift+0xdc77eb)
#9 0x0000000000bcfe82 swift::TypeChecker::lookupMemberType(swift::DeclContext*, swift::Type, swift::Identifier, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfe82)
#10 0x0000000000c08070 resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc08070)
#11 0x0000000000c079cd swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc079cd)
#12 0x0000000000c08ae8 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc08ae8)
#13 0x0000000000c089df swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc089df)
#14 0x0000000000c07169 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07169)
#15 0x0000000000bd21f9 validateParameterType(swift::ParamDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeChecker&) (/path/to/swift/bin/swift+0xbd21f9)
#16 0x0000000000bd208b swift::TypeChecker::typeCheckParameterList(swift::ParameterList*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xbd208b)
#17 0x0000000000bcb8e1 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcb8e1)
#18 0x0000000000bcb578 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb578)
#19 0x0000000000baee11 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaee11)
#20 0x0000000000ba2316 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba2316)
#21 0x0000000000b9c02a swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9c02a)
#22 0x0000000000bdd14e swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdd14e)
#23 0x0000000000dd1d0c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd1d0c)
#24 0x0000000000bcf568 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf568)
#25 0x0000000000bcfcf9 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbcfcf9)
#26 0x0000000000bcfae4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfae4)
#27 0x0000000000c10c98 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc10c98)
#28 0x0000000000c0828a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0828a)
#29 0x0000000000c079cd swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc079cd)
#30 0x0000000000c08ae8 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc08ae8)
#31 0x0000000000c089df swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc089df)
#32 0x0000000000c07169 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07169)
#33 0x0000000000bd21f9 validateParameterType(swift::ParamDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeChecker&) (/path/to/swift/bin/swift+0xbd21f9)
#34 0x0000000000bd208b swift::TypeChecker::typeCheckParameterList(swift::ParameterList*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xbd208b)
#35 0x0000000000bcb8e1 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcb8e1)
#36 0x0000000000bcb578 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb578)
#37 0x0000000000baee11 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaee11)
#38 0x0000000000ba2316 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba2316)
#39 0x0000000000b9c02a swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9c02a)
#40 0x0000000000bdd14e swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdd14e)
#41 0x0000000000dd1d0c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd1d0c)
#42 0x0000000000bcf568 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf568)
#43 0x0000000000bcfcf9 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbcfcf9)
#44 0x0000000000bcfae4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfae4)
#45 0x0000000000c10c98 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc10c98)
#46 0x0000000000c0828a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0828a)
#47 0x0000000000c079cd swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc079cd)
#48 0x0000000000c08ae8 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc08ae8)
#49 0x0000000000c089df swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc089df)
#50 0x0000000000c07169 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07169)
#51 0x0000000000bd21f9 validateParameterType(swift::ParamDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeChecker&) (/path/to/swift/bin/swift+0xbd21f9)
#52 0x0000000000bd208b swift::TypeChecker::typeCheckParameterList(swift::ParameterList*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xbd208b)
#53 0x0000000000bcb8e1 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcb8e1)
#54 0x0000000000bcb578 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb578)
#55 0x0000000000baee11 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaee11)
#56 0x0000000000ba2316 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba2316)
#57 0x0000000000b9c02a swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9c02a)
#58 0x0000000000bdd14e swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdd14e)
#59 0x0000000000dd1d0c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd1d0c)
#60 0x0000000000bcf568 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf568)
#61 0x0000000000bcfcf9 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbcfcf9)
#62 0x0000000000bcfae4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfae4)
#63 0x0000000000c10c98 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc10c98)
#64 0x0000000000c0828a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0828a)
#65 0x0000000000c079cd swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc079cd)
#66 0x0000000000c08ae8 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc08ae8)
#67 0x0000000000c089df swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc089df)
#68 0x0000000000c07169 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07169)
#69 0x0000000000bd21f9 validateParameterType(swift::ParamDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeChecker&) (/path/to/swift/bin/swift+0xbd21f9)
#70 0x0000000000bd208b swift::TypeChecker::typeCheckParameterList(swift::ParameterList*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xbd208b)
#71 0x0000000000bcb8e1 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcb8e1)
#72 0x0000000000bcb578 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb578)
#73 0x0000000000baee11 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaee11)
#74 0x0000000000ba2316 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba2316)
#75 0x0000000000b9c02a swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9c02a)
#76 0x0000000000bdd14e swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdd14e)
#77 0x0000000000dd1d0c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd1d0c)
#78 0x0000000000bcf568 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf568)
#79 0x0000000000bcfcf9 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbcfcf9)
#80 0x0000000000bcfae4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfae4)
#81 0x0000000000c10c98 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc10c98)
#82 0x0000000000c0828a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0828a)
#83 0x0000000000c079cd swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc079cd)
#84 0x0000000000c08ae8 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc08ae8)
#85 0x0000000000c089df swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc089df)
#86 0x0000000000c07169 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07169)
#87 0x0000000000bd21f9 validateParameterType(swift::ParamDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeChecker&) (/path/to/swift/bin/swift+0xbd21f9)
#88 0x0000000000bd208b swift::TypeChecker::typeCheckParameterList(swift::ParameterList*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xbd208b)
#89 0x0000000000bcb8e1 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcb8e1)
#90 0x0000000000bcb578 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb578)
#91 0x0000000000baee11 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaee11)
#92 0x0000000000ba2316 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba2316)
#93 0x0000000000b9c02a swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9c02a)
#94 0x0000000000bdd14e swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdd14e)
#95 0x0000000000dd1d0c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd1d0c)
#96 0x0000000000bcf568 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf568)
#97 0x0000000000bcfcf9 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbcfcf9)
#98 0x0000000000bcfae4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfae4)
#99 0x0000000000c10c98 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc10c98)
#100 0x0000000000c0828a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0828a)
#101 0x0000000000c079cd swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc079cd)
#102 0x0000000000c08ae8 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc08ae8)
#103 0x0000000000c089df swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc089df)
#104 0x0000000000c07169 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07169)
#105 0x0000000000bd21f9 validateParameterType(swift::ParamDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeChecker&) (/path/to/swift/bin/swift+0xbd21f9)
#106 0x0000000000bd208b swift::TypeChecker::typeCheckParameterList(swift::ParameterList*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xbd208b)
#107 0x0000000000bcb8e1 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcb8e1)
#108 0x0000000000bcb578 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb578)
#109 0x0000000000baee11 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaee11)
#110 0x0000000000ba2316 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba2316)
#111 0x0000000000b9c02a swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9c02a)
#112 0x0000000000bdd14e swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdd14e)
#113 0x0000000000dd1d0c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd1d0c)
#114 0x0000000000bcf568 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf568)
#115 0x0000000000bcfcf9 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbcfcf9)
#116 0x0000000000bcfae4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfae4)
#117 0x0000000000c10c98 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc10c98)
#118 0x0000000000c0828a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0828a)
#119 0x0000000000c079cd swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc079cd)
#120 0x0000000000c08ae8 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc08ae8)
#121 0x0000000000c089df swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc089df)
#122 0x0000000000c07169 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07169)
#123 0x0000000000bd21f9 validateParameterType(swift::ParamDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeChecker&) (/path/to/swift/bin/swift+0xbd21f9)
#124 0x0000000000bd208b swift::TypeChecker::typeCheckParameterList(swift::ParameterList*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xbd208b)
#125 0x0000000000bcb8e1 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcb8e1)
#126 0x0000000000bcb578 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb578)
#127 0x0000000000baee11 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaee11)
#128 0x0000000000ba2316 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba2316)
#129 0x0000000000b9c02a swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9c02a)
#130 0x0000000000bdd14e swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdd14e)
#131 0x0000000000dd1d0c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd1d0c)
#132 0x0000000000bcf568 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf568)
#133 0x0000000000bcfcf9 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbcfcf9)
#134 0x0000000000bcfae4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfae4)
#135 0x0000000000c10c98 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc10c98)
#136 0x0000000000c0828a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0828a)
#137 0x0000000000c079cd swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc079cd)
#138 0x0000000000c08ae8 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc08ae8)
#139 0x0000000000c089df swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc089df)
#140 0x0000000000c07169 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07169)
#141 0x0000000000bd21f9 validateParameterType(swift::ParamDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeChecker&) (/path/to/swift/bin/swift+0xbd21f9)
#142 0x0000000000bd208b swift::TypeChecker::typeCheckParameterList(swift::ParameterList*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xbd208b)
#143 0x0000000000bcb8e1 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcb8e1)
#144 0x0000000000bcb578 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb578)
#145 0x0000000000baee11 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaee11)
#146 0x0000000000ba2316 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba2316)
#147 0x0000000000b9c02a swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9c02a)
#148 0x0000000000bdd14e swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdd14e)
#149 0x0000000000dd1d0c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd1d0c)
#150 0x0000000000bcf568 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf568)
#151 0x0000000000bcfcf9 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbcfcf9)
#152 0x0000000000bcfae4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfae4)
#153 0x0000000000c10c98 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc10c98)
#154 0x0000000000c0828a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0828a)
#155 0x0000000000c079cd swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc079cd)
#156 0x0000000000c08ae8 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc08ae8)
#157 0x0000000000c089df swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc089df)
#158 0x0000000000c07169 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07169)
#159 0x0000000000bd21f9 validateParameterType(swift::ParamDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeChecker&) (/path/to/swift/bin/swift+0xbd21f9)
#160 0x0000000000bd208b swift::TypeChecker::typeCheckParameterList(swift::ParameterList*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xbd208b)
#161 0x0000000000bcb8e1 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcb8e1)
#162 0x0000000000bcb578 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb578)
#163 0x0000000000baee11 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaee11)
#164 0x0000000000ba2316 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba2316)
#165 0x0000000000b9c02a swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9c02a)
#166 0x0000000000bdd14e swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdd14e)
#167 0x0000000000dd1d0c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd1d0c)
#168 0x0000000000bcf568 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf568)
#169 0x0000000000bcfcf9 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbcfcf9)
#170 0x0000000000bcfae4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfae4)
#171 0x0000000000c10c98 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc10c98)
#172 0x0000000000c0828a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0828a)
#173 0x0000000000c079cd swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc079cd)
#174 0x0000000000c08ae8 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc08ae8)
#175 0x0000000000c089df swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc089df)
#176 0x0000000000c07169 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07169)
#177 0x0000000000bd21f9 validateParameterType(swift::ParamDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeChecker&) (/path/to/swift/bin/swift+0xbd21f9)
#178 0x0000000000bd208b swift::TypeChecker::typeCheckParameterList(swift::ParameterList*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xbd208b)
#179 0x0000000000bcb8e1 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcb8e1)
#180 0x0000000000bcb578 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb578)
#181 0x0000000000baee11 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaee11)
#182 0x0000000000ba2316 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba2316)
#183 0x0000000000b9c02a swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9c02a)
#184 0x0000000000bdd14e swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdd14e)
#185 0x0000000000dd1d0c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd1d0c)
#186 0x0000000000bcf568 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf568)
#187 0x0000000000bcfcf9 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbcfcf9)
#188 0x0000000000bcfae4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfae4)
#189 0x0000000000c10c98 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc10c98)
#190 0x0000000000c0828a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0828a)
#191 0x0000000000c079cd swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc079cd)
#192 0x0000000000c08ae8 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc08ae8)
#193 0x0000000000c089df swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc089df)
#194 0x0000000000c07169 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07169)
#195 0x0000000000bd21f9 validateParameterType(swift::ParamDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeChecker&) (/path/to/swift/bin/swift+0xbd21f9)
#196 0x0000000000bd208b swift::TypeChecker::typeCheckParameterList(swift::ParameterList*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xbd208b)
#197 0x0000000000bcb8e1 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcb8e1)
#198 0x0000000000bcb578 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb578)
#199 0x0000000000baee11 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaee11)
#200 0x0000000000ba2316 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba2316)
#201 0x0000000000b9c02a swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9c02a)
#202 0x0000000000bdd14e swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdd14e)
#203 0x0000000000dd1d0c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd1d0c)
#204 0x0000000000bcf568 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf568)
#205 0x0000000000bcfcf9 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbcfcf9)
#206 0x0000000000bcfae4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfae4)
#207 0x0000000000c10c98 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc10c98)
#208 0x0000000000c0828a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0828a)
#209 0x0000000000c079cd swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc079cd)
#210 0x0000000000c08ae8 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc08ae8)
#211 0x0000000000c089df swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc089df)
#212 0x0000000000c07169 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07169)
#213 0x0000000000bd21f9 validateParameterType(swift::ParamDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeChecker&) (/path/to/swift/bin/swift+0xbd21f9)
#214 0x0000000000bd208b swift::TypeChecker::typeCheckParameterList(swift::ParameterList*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xbd208b)
#215 0x0000000000bcb8e1 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcb8e1)
#216 0x0000000000bcb578 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb578)
#217 0x0000000000baee11 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaee11)
#218 0x0000000000ba2316 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba2316)
#219 0x0000000000b9c02a swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9c02a)
#220 0x0000000000bdd14e swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdd14e)
#221 0x0000000000dd1d0c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd1d0c)
#222 0x0000000000bcf568 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf568)
#223 0x0000000000bcfcf9 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbcfcf9)
#224 0x0000000000bcfae4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfae4)
#225 0x0000000000c10c98 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc10c98)
#226 0x0000000000c0828a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0828a)
#227 0x0000000000c079cd swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc079cd)
#228 0x0000000000c08ae8 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc08ae8)
#229 0x0000000000c089df swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc089df)
#230 0x0000000000c07169 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07169)
#231 0x0000000000bd21f9 validateParameterType(swift::ParamDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeChecker&) (/path/to/swift/bin/swift+0xbd21f9)
#232 0x0000000000bd208b swift::TypeChecker::typeCheckParameterList(swift::ParameterList*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xbd208b)
#233 0x0000000000bcb8e1 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcb8e1)
#234 0x0000000000bcb578 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb578)
#235 0x0000000000baee11 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaee11)
#236 0x0000000000ba2316 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba2316)
#237 0x0000000000b9c02a swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9c02a)
#238 0x0000000000bdd14e swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0xbdd14e)
#239 0x0000000000dd1d0c swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0xdd1d0c)
#240 0x0000000000bcf568 (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0xbcf568)
#241 0x0000000000bcfcf9 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0xbcfcf9)
#242 0x0000000000bcfae4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0xbcfae4)
#243 0x0000000000c10c98 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc10c98)
#244 0x0000000000c0828a resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc0828a)
#245 0x0000000000c079cd swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc079cd)
#246 0x0000000000c08ae8 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0xc08ae8)
#247 0x0000000000c089df swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc089df)
#248 0x0000000000c07169 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0xc07169)
#249 0x0000000000bd21f9 validateParameterType(swift::ParamDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeChecker&) (/path/to/swift/bin/swift+0xbd21f9)
#250 0x0000000000bd208b swift::TypeChecker::typeCheckParameterList(swift::ParameterList*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xbd208b)
#251 0x0000000000bcb8e1 checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcb8e1)
#252 0x0000000000bcb578 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb578)
#253 0x0000000000baee11 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaee11)
#254 0x0000000000ba2316 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba2316)
#255 0x0000000000b9c02a swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9c02a)
```