### PR TITLE
[swiftc (104 vs. 5183)] Add crasher in swift::Decl::walk(...)

### DIFF
--- a/validation-test/compiler_crashers/28476-anonymous-namespace-verifier-walktodeclpost-swift-decl.swift
+++ b/validation-test/compiler_crashers/28476-anonymous-namespace-verifier-walktodeclpost-swift-decl.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol a:A protocol A:A{struct B{var e=triC:protocol A:a{class A:A{func<


### PR DESCRIPTION
Add test case for crash triggered in `swift::Decl::walk(...)`.

Current number of unresolved compiler crashers: 104 (5183 resolved)

Stack trace:

```
#0 0x00000000031cec28 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31cec28)
#1 0x00000000031cf476 SignalHandler(int) (/path/to/swift/bin/swift+0x31cf476)
#2 0x00007fb4cbe04330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x00007fb4ca5c2c37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
#4 0x00007fb4ca5c6028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
#5 0x0000000000d5b905 (/path/to/swift/bin/swift+0xd5b905)
#6 0x0000000000d595e6 (anonymous namespace)::Verifier::walkToDeclPost(swift::Decl*) (/path/to/swift/bin/swift+0xd595e6)
#7 0x0000000000d660bc (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xd660bc)
#8 0x0000000000d66ae4 (anonymous namespace)::Traversal::visitNominalTypeDecl(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0xd66ae4)
#9 0x0000000000d65bae (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xd65bae)
#10 0x0000000000d66ae4 (anonymous namespace)::Traversal::visitNominalTypeDecl(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0xd66ae4)
#11 0x0000000000d65bae (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xd65bae)
#12 0x0000000000d66ae4 (anonymous namespace)::Traversal::visitNominalTypeDecl(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0xd66ae4)
#13 0x0000000000d65bae (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xd65bae)
#14 0x0000000000d66ae4 (anonymous namespace)::Traversal::visitNominalTypeDecl(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0xd66ae4)
#15 0x0000000000d65bae (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xd65bae)
#16 0x0000000000d65ac4 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd65ac4)
#17 0x0000000000dbafee swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdbafee)
#18 0x0000000000d4d6dc swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0xd4d6dc)
#19 0x0000000000c150b2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc150b2)
#20 0x0000000000938136 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x938136)
#21 0x000000000047ece5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ece5)
#22 0x000000000047db7f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47db7f)
#23 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
#24 0x00007fb4ca5adf45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
#25 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```