### PR TITLE
[swiftc (105 vs. 5183)] Add crasher in swift::TypeChecker::validateDecl

### DIFF
--- a/validation-test/compiler_crashers/28477-anonymous-namespace-declchecker-visitconstructordecl-swift-constructordecl.swift
+++ b/validation-test/compiler_crashers/28477-anonymous-namespace-declchecker-visitconstructordecl-swift-constructordecl.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+extension A{init(){}typealias e:A{}}protocol A{init(){}typealias e


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::validateDecl`.

Current number of unresolved compiler crashers: 105 (5183 resolved)

Stack trace:

```
#0 0x00000000031cec28 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31cec28)
#1 0x00000000031cf476 SignalHandler(int) (/path/to/swift/bin/swift+0x31cf476)
#2 0x00007f7e5b53c330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x0000000000bacfa0 (anonymous namespace)::DeclChecker::visitConstructorDecl(swift::ConstructorDecl*) (/path/to/swift/bin/swift+0xbacfa0)
#4 0x0000000000ba22f6 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba22f6)
#5 0x0000000000b9c02a swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9c02a)
#6 0x0000000000ba2c49 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba2c49)
#7 0x0000000000b9c02a swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9c02a)
#8 0x0000000000d8782b swift::ProtocolDecl::existentialTypeSupportedSlow(swift::LazyResolver*) (/path/to/swift/bin/swift+0xd8782b)
#9 0x0000000000c0cb9f (anonymous namespace)::UnsupportedProtocolVisitor::visitIdentTypeRepr(swift::IdentTypeRepr*) (/path/to/swift/bin/swift+0xc0cb9f)
#10 0x0000000000c0c99f (anonymous namespace)::UnsupportedProtocolVisitor::walkToTypeReprPre(swift::TypeRepr*) (/path/to/swift/bin/swift+0xc0c99f)
#11 0x0000000000d65f4d (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xd65f4d)
#12 0x0000000000d65ac4 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd65ac4)
#13 0x0000000000c0c8f9 swift::TypeChecker::checkUnsupportedProtocolType(swift::Decl*) (/path/to/swift/bin/swift+0xc0c8f9)
#14 0x0000000000ba30da (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba30da)
#15 0x0000000000b9c02a swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) (/path/to/swift/bin/swift+0xb9c02a)
#16 0x0000000000ce7bcf swift::ArchetypeBuilder::PotentialArchetype::getNestedType(swift::Identifier, swift::ArchetypeBuilder&) (/path/to/swift/bin/swift+0xce7bcf)
#17 0x0000000000cea161 swift::ArchetypeBuilder::addConformanceRequirement(swift::ArchetypeBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::RequirementSource, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0xcea161)
#18 0x0000000000cec09e swift::ArchetypeBuilder::addRequirement(swift::Requirement const&, swift::RequirementSource) (/path/to/swift/bin/swift+0xcec09e)
#19 0x0000000000cedf00 swift::ArchetypeBuilder::addGenericSignature(swift::GenericSignature*, swift::GenericEnvironment*, bool) (/path/to/swift/bin/swift+0xcedf00)
#20 0x0000000000bcb086 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::GenericSignature*, swift::GenericEnvironment*, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0xbcb086)
#21 0x0000000000bcb85a checkGenericFuncSignature(swift::TypeChecker&, swift::ArchetypeBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0xbcb85a)
#22 0x0000000000bcb578 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbcb578)
#23 0x0000000000bad1ee (anonymous namespace)::DeclChecker::visitConstructorDecl(swift::ConstructorDecl*) (/path/to/swift/bin/swift+0xbad1ee)
#24 0x0000000000ba22f6 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba22f6)
#25 0x0000000000baac7b (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0xbaac7b)
#26 0x0000000000ba21b0 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0xba21b0)
#27 0x0000000000ba2116 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0xba2116)
#28 0x0000000000c14eff swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc14eff)
#29 0x0000000000938136 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x938136)
#30 0x000000000047ece5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ece5)
#31 0x000000000047db7f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47db7f)
#32 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
#33 0x00007f7e59ce5f45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
#34 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```