### PR TITLE
Fix crash in member lookup when base type contains type variables.

### DIFF
--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -718,7 +718,8 @@ public:
     // Does it make sense to substitute types?
     bool shouldSubst = !BaseTy->hasUnboundGenericType() &&
                        !isa<AnyMetatypeType>(BaseTy.getPointer()) &&
-                       !BaseTy->isAnyExistentialType();
+                       !BaseTy->isAnyExistentialType() &&
+                       !BaseTy->hasTypeVariable();
     ModuleDecl *M = DC->getParentModule();
 
     auto FoundSignature = VD->getOverloadSignature();

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6879,6 +6879,9 @@ Expr *TypeChecker::callWitness(Expr *base, DeclContext *dc,
 
   // Find the witness we need to use.
   auto type = base->getType();
+  assert(!type->hasTypeVariable() &&
+         "Building call to witness with unresolved base type!");
+
   if (auto metaType = type->getAs<AnyMetatypeType>())
     type = metaType->getInstanceType();
   

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3196,6 +3196,11 @@ bool swift::isExtensionApplied(DeclContext &DC, Type BaseTy,
   bool Failed = false;
   SmallVector<Type, 3> TypeScratch;
 
+  // Don't allow type variables from an existing constraint system to
+  // leak into the new constraint system created below.
+  assert(!BaseTy->hasTypeVariable() &&
+         "Unexpected type variable in base type!");
+
   // Prepare type substitution map.
   auto GenericArgs = BaseTy->getAllGenericArgs(TypeScratch);
   TypeSubstitutionMap Substitutions;
@@ -3258,6 +3263,9 @@ bool swift::isExtensionApplied(DeclContext &DC, Type BaseTy,
 static bool canSatisfy(Type T1, Type T2, DeclContext &DC, ConstraintKind Kind,
                        bool ReplaceArchetypeWithVariables,
                        bool AllowFreeVariables) {
+  assert(!T1->hasTypeVariable() && !T2->hasTypeVariable() &&
+         "Unexpected type variable in constraint satisfaction testing");
+
   std::unique_ptr<TypeChecker> CreatedTC;
   // If the current ast context has no type checker, create one for it.
   auto *TC = static_cast<TypeChecker*>(DC.getASTContext().getLazyResolver());

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3179,7 +3179,10 @@ bool swift::isExtensionApplied(DeclContext &DC, Type BaseTy,
   ConstraintSystemOptions Options;
   NominalTypeDecl *Nominal = BaseTy->getNominalOrBoundGenericNominal();
   if (!Nominal || !BaseTy->isSpecialized() ||
-      ED->getGenericRequirements().empty())
+      ED->getGenericRequirements().empty() ||
+      // We'll crash if we leak type variables from one constraint
+      // system into the new one created below.
+      BaseTy->hasTypeVariable())
     return true;
   std::unique_ptr<TypeChecker> CreatedTC;
   // If the current ast context has no type checker, create one for it.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5098,7 +5098,7 @@ bool TypeChecker::isProtocolExtensionUsable(DeclContext *dc, Type type,
 
   // If the type still has parameters, the constrained extension is considered
   // unusable.
-  if (type->hasTypeParameter())
+  if (type->hasTypeParameter() || type->hasTypeVariable())
     return false;
 
   // Set up a constraint system where we open the generic parameters of the

--- a/test/Sema/typo_correction.swift
+++ b/test/Sema/typo_correction.swift
@@ -69,3 +69,11 @@ func test_too_many_but_some_better() {
   let match6 = 0
   let x = mtch // expected-error {{use of unresolved identifier 'mtch'}}
 }
+
+// rdar://problem/28387684
+// Don't crash performing typo correction on bound generic types with
+// type variables.
+_ = [Any]().withUnsafeBufferPointer { (buf) -> [Any] in
+  guard let base = buf.baseAddress else { return [] }
+  return (base ..< base + buf.count).m // expected-error {{value of type 'CountableRange<_>' has no member 'm'}}
+}

--- a/validation-test/IDE/crashers_fixed/109-swift-constraints-constraintgraph-change-addedtypevariable.swift
+++ b/validation-test/IDE/crashers_fixed/109-swift-constraints-constraintgraph-change-addedtypevariable.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+assert(Range.b
+v#^A^#

--- a/validation-test/compiler_crashers_fixed/28422-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/28422-swift-genericfunctiontype-get.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not %target-swift-frontend %s -parse
+// REQUIRES: asserts
+func d<T{
+var d
+var d:[T
+struct S{var _=d.j


### PR DESCRIPTION
We were crashing during performTypoCorrection if the base type contained
    type variables.