### PR TITLE
[SyntaxColor] Restrict the keywords colored as identifiers to just those that can be used as argument labels

### DIFF
--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -47,23 +47,6 @@ struct SyntaxModelContext::Implementation {
       SrcMgr(SrcFile.getASTContext().SourceMgr) {}
 };
 
-static bool canFindSurroundingParens(ArrayRef<Token> Toks,
-                                    const unsigned Current) {
-  bool LeftOk = false;
-  bool RightOk = false;
-  for (unsigned Offset = 1; ; Offset ++) {
-    if (Current < Offset || Current + Offset >= Toks.size())
-      return false;
-    auto &L = Toks[Current - Offset];
-    auto &R = Toks[Current + Offset];
-    LeftOk |= L.getKind() == tok::l_paren;
-    RightOk |= R.getKind() == tok::r_paren;
-    if (LeftOk && RightOk)
-      return true;
-  }
-  llvm_unreachable("unreachable exit condition");
-}
-
 SyntaxModelContext::SyntaxModelContext(SourceFile &SrcFile)
   : Impl(*new Implementation(SrcFile)) {
   const bool IsPlayground = Impl.LangOpts.Playground;
@@ -115,19 +98,22 @@ SyntaxModelContext::SyntaxModelContext(SourceFile &SrcFile)
 #define KEYWORD(X) case tok::kw_##X:
 #include "swift/Parse/Tokens.def"
 #undef KEYWORD
-        if (Tok.getKind() != tok::kw__ &&
-            0 < I && I < Tokens.size() - 1 &&
-            (Tokens[I-1].getKind() == tok::l_paren ||
-             Tokens[I-1].getKind() == tok::comma) &&
-            (Tokens[I+1].getKind() == tok::colon ||
-             Tokens[I+1].getKind() == tok::identifier ||
-             Tokens[I+1].isKeyword()) &&
-            canFindSurroundingParens(Tokens, I)) {
-          // Keywords are allowed as argument labels and should be treated as
-          // identifiers.  The exception is '_' which is not a name.
-          Kind = SyntaxNodeKind::Identifier;
-        } else {
-          Kind = SyntaxNodeKind::Keyword;
+        Kind = SyntaxNodeKind::Keyword;
+        // Some keywords can be used as an argument labels. If this one can and
+        // is being used as one, treat it as an identifier instead.
+        if (Tok.canBeArgumentLabel() && !Tok.is(tok::kw__) &&
+            0 < I && I < Tokens.size() - 1) {
+          auto prev = Tokens[I - 1];
+          auto next = Tokens[I + 1];
+          if ((prev.is(tok::identifier) || prev.isKeyword()) && I > 1)
+            prev = Tokens[I - 2];
+          else if ((next.is(tok::identifier) || next.isKeyword()) &&
+                   I < Tokens.size() - 2)
+            next = Tokens[I + 2];
+
+          if ((prev.is(tok::l_paren) || prev.is(tok::comma)) &&
+              next.is(tok::colon))
+            Kind = SyntaxNodeKind::Identifier;
         }
         break;
 

--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -273,7 +273,7 @@ func test3(o: AnyObject) {
   let x = o as! MyCls
 }
 
-// CHECK: <kw>func</kw> test4(inout a: <type>Int</type>) {{{$}}
+// CHECK: <kw>func</kw> test4(<kw>inout</kw> a: <type>Int</type>) {{{$}}
 func test4(inout a: Int) {
   // CHECK: <kw>if</kw> <kw>#available</kw> (<kw>OSX</kw> >= <float>10.10</float>, <kw>iOS</kw> >= <float>8.01</float>) {<kw>let</kw> OSX = <str>"iOS"</str>}}{{$}}
   if #available (OSX >= 10.10, iOS >= 8.01) {let OSX = "iOS"}}
@@ -580,6 +580,15 @@ func foo2(O1 : Int?, O2: Int?, O3: Int?) {
 // CHECK:  <kw>guard</kw> <kw>let</kw> <kw>_</kw> = O1, <kw>var</kw> <kw>_</kw> = O2, <kw>let</kw> <kw>_</kw> = O3 <kw>else</kw> { }
   if let _ = O1, var _ = O2, let _ = O3 {}
 // CHECK: <kw>if</kw> <kw>let</kw> <kw>_</kw> = O1, <kw>var</kw> <kw>_</kw> = O2, <kw>let</kw> <kw>_</kw> = O3 {}
+}
+
+func keywordInCaseAndLocalArgLabel(_ for: Int, for in: Int, class _: Int) {
+// CHECK:  <kw>func</kw> keywordInCaseAndLocalArgLabel(<kw>_</kw> for: <type>Int</type>, for in: <type>Int</type>, class <kw>_</kw>: <type>Int</type>) {
+  switch(`for`, `in`) {
+  case (let x, let y):
+// CHECK: <kw>case</kw> (<kw>let</kw> x, <kw>let</kw> y):
+    print(x, y)
+  }
 }
 
 // Keep this as the last test


### PR DESCRIPTION
<!-- What's in this pull request? -->
Most keywords can be used as argument labels. When they are they shouldn't be
colored as a keyword. This patch fixes three issues with this:
-  keywords as local argument labels (where an external label was also present)
were still colored as keywords
- 'let', 'var', and 'inout' cannot be used as argument labels, but were colored
as identifiers rather than keywords when used like one
- the check to see if a keyword token is being used as an argument label wasn't
quite restrictive enough, e.g. treating the 'let's in 'case (let x, let y):' as
identifiers.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/29098176.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
