### PR TITLE
[Compile perf] Use lit tmpdir in scale-test, rdar://29090287

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -976,8 +976,9 @@ config.substitutions.append(('%utils', config.swift_utils))
 config.substitutions.append(('%line-directive', config.line_directive))
 config.substitutions.append(('%gyb', config.gyb))
 config.substitutions.append(('%rth', config.rth))
-config.substitutions.append(('%scale-test', config.scale_test))
-
+config.substitutions.append(('%scale-test',
+                             '{} --swiftc-binary={} --tmpdir=%t'.format(
+                                 config.scale_test, config.swiftc)))
 config.substitutions.append(('%target-sil-opt', config.target_sil_opt))
 config.substitutions.append(('%target-sil-extract', config.target_sil_extract))
 config.substitutions.append(

--- a/utils/scale-test
+++ b/utils/scale-test
@@ -12,7 +12,7 @@
 # values.
 #
 
-import gyb, os, os.path, subprocess
+import gyb, os, os.path, shutil, subprocess
 
 def find_which(p):
     for d in os.environ["PATH"].split(os.pathsep):
@@ -38,20 +38,23 @@ def has_debuginfo(swiftc):
 
 
 def write_input_file(args, ast, d, n):
-    ifile = os.path.join(d, "in%d.swift" % n)
-    with open(ifile,'w+') as f:
+    fname = "in%d.swift" % n
+    pathname = os.path.join(d, fname)
+    with open(pathname,'w+') as f:
         f.write(gyb.execute_template(ast, '', N=n))
-    return ifile
+    return fname
 
 
 def run_once_with_primary(args, ast, rng, primary_idx):
-    import sys, shutil, tempfile, json
+    import sys, tempfile, json
     r = {}
     try:
-        d = tempfile.mkdtemp()
+        if args.tmpdir != None and not os.path.exists(args.tmpdir):
+            os.makedirs(args.tmpdir, 0700)
+        d = tempfile.mkdtemp(dir=args.tmpdir)
         inputs = [write_input_file(args, ast, d, i) for i in rng]
         primary = inputs[primary_idx]
-        ofile = os.path.join(d, "out.o")
+        ofile = "out.o"
 
         mode = "-c"
         if args.parse:
@@ -81,26 +84,26 @@ def run_once_with_primary(args, ast, rng, primary_idx):
             print "running: " + " ".join(command)
 
         if args.dtrace:
-            trace = os.path.join(d, "trace.txt")
+            trace = "trace.txt"
             script = "pid$target:swiftc:*%s*:entry { @[probefunc] = count() }" % args.select
             subprocess.check_call(
                 ["sudo", "dtrace", "-q",
                  "-o", trace,
                  "-b", "256",
                  "-n", script,
-                 "-c", " ".join(command)])
+                 "-c", " ".join(command)], cwd=d)
             r = {fields[0]: int(fields[1]) for fields in
-                 [line.split() for line in open(trace)]
+                 [line.split() for line in open(os.path.join(d, trace))]
                  if len(fields) == 2}
         else:
             if args.debug:
                 command = ["lldb", "--"] + command
-            stats = os.path.join(d, "stats.json")
+            stats = "stats.json"
             argv = command + ["-Xllvm", "-stats",
                               "-Xllvm", "-stats-json",
                               "-Xllvm", "-info-output-file=" + stats]
-            subprocess.check_call(argv)
-            with open(stats) as f:
+            subprocess.check_call(argv, cwd=d)
+            with open(os.path.join(d, stats)) as f:
                 r = json.load(f)
     finally:
         shutil.rmtree(d)
@@ -241,6 +244,9 @@ def main():
     parser.add_argument(
         '--swiftc-binary',
         default="swiftc", help='swift binary to execute')
+    parser.add_argument(
+        '--tmpdir', type=str,
+        default=None, help='directory to create tempfiles in')
     parser.add_argument(
         '--select',
         default="", help='substring of counters/symbols to restrict attention to')

--- a/utils/scale-test
+++ b/utils/scale-test
@@ -12,14 +12,24 @@
 # values.
 #
 
-import gyb, os, os.path, shutil, subprocess
+import argparse
+import json
+import os
+import os.path
+import shutil
+import subprocess
+import sys
+import tempfile
+import gyb
+
 
 def find_which(p):
     for d in os.environ["PATH"].split(os.pathsep):
-        full = os.path.join(d,p)
+        full = os.path.join(d, p)
         if os.path.isfile(full) and os.access(full, os.X_OK):
             return full
     return p
+
 
 # Evidently the debug-symbol reader in dtrace is sufficiently slow and/or buggy
 # that attempting to inject probes into a binary w/ debuginfo is asking for a
@@ -28,7 +38,8 @@ def find_which(p):
 # so we sniff the presence of debug symbols here.
 def has_debuginfo(swiftc):
     swiftc = find_which(swiftc)
-    for line in subprocess.check_output(["dwarfdump", "--file-stats", swiftc]).splitlines():
+    for line in subprocess.check_output(
+            ["dwarfdump", "--file-stats", swiftc]).splitlines():
         if '%' not in line:
             continue
         fields = line.split()
@@ -40,16 +51,15 @@ def has_debuginfo(swiftc):
 def write_input_file(args, ast, d, n):
     fname = "in%d.swift" % n
     pathname = os.path.join(d, fname)
-    with open(pathname,'w+') as f:
+    with open(pathname, 'w+') as f:
         f.write(gyb.execute_template(ast, '', N=n))
     return fname
 
 
 def run_once_with_primary(args, ast, rng, primary_idx):
-    import sys, tempfile, json
     r = {}
     try:
-        if args.tmpdir != None and not os.path.exists(args.tmpdir):
+        if args.tmpdir is not None and not os.path.exists(args.tmpdir):
             os.makedirs(args.tmpdir, 0700)
         d = tempfile.mkdtemp(dir=args.tmpdir)
         inputs = [write_input_file(args, ast, d, i) for i in rng]
@@ -85,7 +95,8 @@ def run_once_with_primary(args, ast, rng, primary_idx):
 
         if args.dtrace:
             trace = "trace.txt"
-            script = "pid$target:swiftc:*%s*:entry { @[probefunc] = count() }" % args.select
+            script = ("pid$target:swiftc:*%s*:entry { @[probefunc] = count() }"
+                      % args.select)
             subprocess.check_call(
                 ["sudo", "dtrace", "-q",
                  "-o", trace,
@@ -108,7 +119,7 @@ def run_once_with_primary(args, ast, rng, primary_idx):
     finally:
         shutil.rmtree(d)
 
-    return {k:v for (k,v) in r.items() if args.select in k}
+    return {k: v for (k, v) in r.items() if args.select in k}
 
 
 def run_once(args, ast, rng):
@@ -124,6 +135,7 @@ def run_once(args, ast, rng):
         return cumulative
     else:
         return run_once_with_primary(args, ast, rng, -1)
+
 
 def run_many(args):
 
@@ -148,25 +160,24 @@ def run_many(args):
 
 
 def linear_regression(x, y):
-   # By the book: https://en.wikipedia.org/wiki/Simple_linear_regression
-   n = len(x)
-   assert n == len(y)
-   if n == 0:
-       return 0, 0
-   prod_sum = 0
-   sum_x = sum(x)
-   sum_y = sum(y)
-   sum_prod = sum(a * b for a, b in zip(x, y))
-   sum_x_sq = sum(a ** 2 for a in x)
-   mean_x = sum_x/n
-   mean_y = sum_y/n
-   mean_prod = sum_prod/n
-   mean_x_sq = sum_x_sq/n
-   covar_xy = mean_prod - mean_x * mean_y
-   var_x = mean_x_sq - mean_x**2
-   slope = covar_xy / var_x
-   inter = mean_y - slope * mean_x
-   return slope, inter
+    # By the book: https://en.wikipedia.org/wiki/Simple_linear_regression
+    n = len(x)
+    assert n == len(y)
+    if n == 0:
+        return 0, 0
+    sum_x = sum(x)
+    sum_y = sum(y)
+    sum_prod = sum(a * b for a, b in zip(x, y))
+    sum_x_sq = sum(a ** 2 for a in x)
+    mean_x = sum_x/n
+    mean_y = sum_y/n
+    mean_prod = sum_prod/n
+    mean_x_sq = sum_x_sq/n
+    covar_xy = mean_prod - mean_x * mean_y
+    var_x = mean_x_sq - mean_x**2
+    slope = covar_xy / var_x
+    inter = mean_y - slope * mean_x
+    return slope, inter
 
 
 def report(args, rng, runs):
@@ -199,7 +210,6 @@ def report(args, rng, runs):
 
 
 def main():
-    import argparse, sys
     parser = argparse.ArgumentParser()
     parser.add_argument(
         'file', type=argparse.FileType(),
@@ -249,7 +259,7 @@ def main():
         default=None, help='directory to create tempfiles in')
     parser.add_argument(
         '--select',
-        default="", help='substring of counters/symbols to restrict attention to')
+        default="", help='substring of counters/symbols to limit attention to')
     parser.add_argument(
         '--debug', action='store_true',
         default=False, help='invoke lldb on each scale test')
@@ -278,6 +288,7 @@ def main():
     if report(args, rng, runs):
         exit(1)
     exit(0)
+
 
 if __name__ == '__main__':
     main()

--- a/validation-test/compiler_scale/scale_neighbouring_getset.gyb
+++ b/validation-test/compiler_scale/scale_neighbouring_getset.gyb
@@ -1,9 +1,6 @@
 // RUN: %scale-test --sum-multi --parse --begin 5 --end 16 --step 5 --select typeCheckAbstractFunctionBody %s
 // REQUIRES: OS=macosx, tools-release
 
-// FIXME: this test has been failing in CI
-// REQUIRES: rdar29090287
-
 struct Struct${N} {
 % if int(N) > 1:
     var Field : Struct${int(N)-1}?


### PR DESCRIPTION
This PR makes the `scale-test` script and `lit.cfg` configury a little more precise in its use of paths, to try to work around some CI failures we were seeing. Changes are:

  - Use the exact `swiftc` path rather than searching $PATH
  - Pass and use the lit `%t` test tempdir rather than letting python's `tempfile` search for one
  - Run the subprocess with cwd set to the tempdir, not passing full paths

The second change is likely the one that was causing the CI failure (`lit.py` scrubs the environment of the subprocess, meaning `scale-test` was putting files in `/tmp/...` not `/var/folders/...`) but the first and third changes here improve the precision and reduce the chatter of the subprocess along the way.

The CI breakage is tracked in rdar://29090287

