### PR TITLE
[3.0] [Constraint solver] Remove erroneous constraints from the constraint graph

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -352,9 +352,8 @@ bool ConstraintSystem::simplify(bool ContinueAfterFailures) {
 
       if (solverState)
         solverState->retiredConstraints.push_front(constraint);
-      else
-        CG.removeConstraint(constraint);
 
+      CG.removeConstraint(constraint);
       break;
 
     case SolutionKind::Solved:

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar28145033.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar28145033.swift
@@ -1,0 +1,4 @@
+// RUN: not %target-swift-frontend %s -parse
+ 
+let a = [1]
+_ = a.index(of: a.min()) // a.min() returns an optional


### PR DESCRIPTION
<!-- What's in this pull request? -->
When a constraint fails, we retire it... but we also need to remove it
from the constraint graph. Otherwise, we break invariants when
diagnostic generation attempts to continue simplification.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [rdar://rdar28145033](rdar://rdar28145033).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->