### PR TITLE
[SourceKit] Add a SourceKitd test argument -pos-end.

### DIFF
--- a/test/SourceKit/RangeInfo/basic.swift
+++ b/test/SourceKit/RangeInfo/basic.swift
@@ -31,6 +31,13 @@ struct S { func foo() {} }
 // RUN: %sourcekitd-test -req=range -pos=3:1 -length 55 %s -- %s | %FileCheck %s -check-prefix=CHECK9
 // RUN: %sourcekitd-test -req=range -pos=4:1 -length 36 %s -- %s | %FileCheck %s -check-prefix=CHECK10
 
+// RUN: %sourcekitd-test -req=range -pos=8:1 -end-pos 8:32 %s -- %s | %FileCheck %s -check-prefix=CHECK5
+// RUN: %sourcekitd-test -req=range -pos=9:1 -end-pos 9:26 %s -- %s | %FileCheck %s -check-prefix=CHECK6
+// RUN: %sourcekitd-test -req=range -pos=10:1 -end-pos 10:27 %s -- %s | %FileCheck %s -check-prefix=CHECK7
+// RUN: %sourcekitd-test -req=range -pos=3:1 -end-pos=4:26 %s -- %s | %FileCheck %s -check-prefix=CHECK8
+// RUN: %sourcekitd-test -req=range -pos=3:1 -end-pos=5:13 %s -- %s | %FileCheck %s -check-prefix=CHECK9
+// RUN: %sourcekitd-test -req=range -pos=4:1 -end-pos=5:13 %s -- %s | %FileCheck %s -check-prefix=CHECK10
+
 // CHECK1-DAG: <kind>source.lang.swift.range.singleexpression</kind>
 // CHECK1-DAG: <content>1 + 2</content>
 // CHECK1-DAG: <type>Int</type>

--- a/tools/SourceKit/tools/sourcekitd-test/Options.td
+++ b/tools/SourceKit/tools/sourcekitd-test/Options.td
@@ -87,3 +87,6 @@ def interested_usr : Separate<["-"], "interested-usr">,
 
 def async : Flag<["-"], "async">,
   HelpText<"Perform request asynchronously">;
+
+def end_pos : Separate<["-"], "end-pos">, HelpText<"line:col">;
+def end_pos_EQ : Joined<["-"], "end-pos=">, Alias<end_pos>;

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -164,6 +164,13 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
       break;
     }
 
+    case OPT_end_pos: {
+      auto linecol = parseLineCol(InputArg->getValue());
+      EndLine = linecol.first;
+      EndCol = linecol.second;
+      break;
+    }
+
     case OPT_line:
       if (StringRef(InputArg->getValue()).getAsInteger(10, Line)) {
         llvm::errs() << "error: expected integer for 'line'\n";

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -63,6 +63,8 @@ struct TestOptions {
   std::string InterestedUSR;
   unsigned Line = 0;
   unsigned Col = 0;
+  unsigned EndLine = 0;
+  unsigned EndCol = 0;
   unsigned Offset = 0;
   unsigned Length = 0;
   llvm::Optional<std::string> ReplaceText;

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -543,12 +543,17 @@ static int handleTestInvocation(ArrayRef<const char *> Args,
       sourcekitd_request_dictionary_set_int64(Req, KeyOffset, ByteOffset);
     }
     break;
-  case SourceKitRequest::RangeInfo:
+  case SourceKitRequest::RangeInfo: {
     sourcekitd_request_dictionary_set_uid(Req, KeyRequest, RequestRangeInfo);
     sourcekitd_request_dictionary_set_int64(Req, KeyOffset, ByteOffset);
-    sourcekitd_request_dictionary_set_int64(Req, KeyLength, Opts.Length);
+    auto Length = Opts.Length;
+    if (Opts.Length == 0 && Opts.EndLine > 0) {
+      auto EndOff = resolveFromLineCol(Opts.EndLine, Opts.EndCol, SourceFile);
+      Length = EndOff - ByteOffset;
+    }
+    sourcekitd_request_dictionary_set_int64(Req, KeyLength, Length);
     break;
-
+  }
   case SourceKitRequest::RelatedIdents:
     sourcekitd_request_dictionary_set_uid(Req, KeyRequest, RequestRelatedIdents);
     sourcekitd_request_dictionary_set_int64(Req, KeyOffset, ByteOffset);


### PR DESCRIPTION
Manually specifying range length is laborious and error-prone; this
commit adds an argument -end-pos=Line:Column to specify the end
position of a given range under test.