### PR TITLE
[gardening] Fix erroneous assert(c1 || c2 && "message")

### DIFF
--- a/lib/ClangImporter/IAMInference.cpp
+++ b/lib/ClangImporter/IAMInference.cpp
@@ -257,7 +257,8 @@ private:
     ++SuccessImportAsInstanceComputedProperty;
     IAMAccessorKind kind =
         propSpec == "Get" ? IAMAccessorKind::Getter : IAMAccessorKind::Setter;
-    assert(kind == IAMAccessorKind::Getter || pairedAccessor && "no set-only");
+    assert((kind == IAMAccessorKind::Getter || pairedAccessor) &&
+           "no set-only");
 
     return {formDeclName(name), kind, selfIdx, effectiveDC};
   }
@@ -287,7 +288,8 @@ private:
     ++SuccessImportAsStaticComputedProperty;
     IAMAccessorKind kind =
         propSpec == "Get" ? IAMAccessorKind::Getter : IAMAccessorKind::Setter;
-    assert(kind == IAMAccessorKind::Getter || pairedAccessor && "no set-only");
+    assert((kind == IAMAccessorKind::Getter || pairedAccessor) &&
+           "no set-only");
 
     return {formDeclName(name), kind, effectiveDC};
   }

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -92,8 +92,8 @@ public:
     } else if (auto fDecl = dyn_cast<clang::FunctionDecl>(dc)) {
       DC = fDecl->getCanonicalDecl();
     } else {
-      assert(isa<clang::TranslationUnitDecl>(dc) ||
-             isa<clang::ObjCContainerDecl>(dc) &&
+      assert((isa<clang::TranslationUnitDecl>(dc) ||
+              isa<clang::ObjCContainerDecl>(dc)) &&
                  "No other kinds of effective Clang contexts");
       DC = dc;
     }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -100,7 +100,7 @@ static bool readFileList(DiagnosticEngine &diags,
                          const llvm::opt::Arg *filelistPath,
                          const llvm::opt::Arg *primaryFileArg = nullptr,
                          unsigned *primaryFileIndex = nullptr) {
-  assert((primaryFileArg == nullptr) || (primaryFileIndex != nullptr) &&
+  assert((primaryFileArg == nullptr || primaryFileIndex != nullptr) &&
          "did not provide argument for primary file index");
 
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> buffer =

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -477,8 +477,8 @@ static void collectGlobalList(IRGenModule &IGM,
 
   std::for_each(list.begin(), list.end(),
                 [](const llvm::WeakVH &global) {
-    assert(!isa<llvm::GlobalValue>(global) ||
-           !cast<llvm::GlobalValue>(global)->isDeclaration() &&
+    assert((!isa<llvm::GlobalValue>(global) ||
+            !cast<llvm::GlobalValue>(global)->isDeclaration()) &&
            "all globals in the 'used' list must be definitions");
   });
 }

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -892,7 +892,7 @@ void Lexer::lexHexNumber() {
   }
   
   // [pP][+-]?[0-9][0-9_]*
-  assert(*CurPtr == 'p' || *CurPtr == 'P' && "not at a hex float exponent?!");
+  assert((*CurPtr == 'p' || *CurPtr == 'P') && "not at a hex float exponent?!");
   ++CurPtr;
   
   bool signedExponent = false;

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -492,8 +492,8 @@ void Parser::parseTopLevelCodeDeclDelayed() {
 /// Recover from a 'case' or 'default' outside of a 'switch' by consuming up to
 /// the next ':'.
 static ParserResult<Stmt> recoverFromInvalidCase(Parser &P) {
-  assert(P.Tok.is(tok::kw_case) || P.Tok.is(tok::kw_default)
-         && "not case or default?!");
+  assert(P.Tok.isAny(tok::kw_case, tok::kw_default) &&
+         "not case or default?!");
   P.diagnose(P.Tok, diag::case_outside_of_switch, P.Tok.getText());
   P.skipUntil(tok::colon);
   // FIXME: Return an ErrorStmt?

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -494,7 +494,8 @@ bool SILFunction::hasSelfMetadataParam() const {
 
   auto metaTy = dyn_cast<MetatypeType>(silTy.getSwiftRValueType());
   (void)metaTy;
-  assert(!metaTy || metaTy->getRepresentation() != MetatypeRepresentation::Thin
+  assert((!metaTy ||
+          metaTy->getRepresentation() != MetatypeRepresentation::Thin)
          && "Class metatypes are never thin.");
   return true;
 }

--- a/lib/SILGen/SILGenProfiling.cpp
+++ b/lib/SILGen/SILGenProfiling.cpp
@@ -80,8 +80,8 @@ static void walkForProfiling(Decl *D, ASTWalker &Walker) {
 
 ProfilerRAII::ProfilerRAII(SILGenModule &SGM, Decl *D)
     : SGM(SGM), PreviousProfiler(std::move(SGM.Profiler)) {
-  assert(isa<AbstractFunctionDecl>(D) ||
-         isa<TopLevelCodeDecl>(D) && "Cannot create profiler for this decl");
+  assert((isa<AbstractFunctionDecl>(D) || isa<TopLevelCodeDecl>(D)) &&
+         "Cannot create profiler for this decl");
   const auto &Opts = SGM.M.getOptions();
   if (!Opts.GenerateProfile || isUnmappedDecl(D))
     return;

--- a/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
@@ -1117,8 +1117,8 @@ static bool hasUnsafeGuaranteedOperand(SILValue UnsafeGuaranteedValue,
                                        SILValue UnsafeGuaranteedValueOperand,
                                        RCIdentityFunctionInfo &RCII,
                                        SILInstruction &Release) {
-  assert(isa<StrongReleaseInst>(Release) ||
-         isa<ReleaseValueInst>(Release) && "Expecting a release");
+  assert((isa<StrongReleaseInst>(Release) ||
+          isa<ReleaseValueInst>(Release)) && "Expecting a release");
 
   auto RCRoot = RCII.getRCIdentityRoot(Release.getOperand(0));
 

--- a/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
@@ -303,9 +303,8 @@ private:
       return;
     }
 
-    assert(Array ||
-           K == ArrayCallKind::kNone &&
-               "Need to have an array for array semantic functions");
+    assert((Array || K == ArrayCallKind::kNone) &&
+           "Need to have an array for array semantic functions");
 
     // We need to make sure that the array container is not aliased in ways
     // that we don't understand.

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -368,18 +368,18 @@ SILInstruction *SILCombiner::visitAllocStackInst(AllocStackInst *AS) {
 
     if (auto *OEAI = dyn_cast<OpenExistentialAddrInst>(Op->getUser())) {
       for (auto *Op : OEAI->getUses()) {
-        assert(isa<DestroyAddrInst>(Op->getUser()) ||
-               isDebugInst(Op->getUser()) && "Unexpected instruction");
+        assert((isa<DestroyAddrInst>(Op->getUser()) ||
+                isDebugInst(Op->getUser())) && "Unexpected instruction");
         ToDelete.insert(Op->getUser());
       }
     }
 
-    assert(isa<CopyAddrInst>(Op->getUser()) ||
-           isa<OpenExistentialAddrInst>(Op->getUser()) ||
-           isa<DestroyAddrInst>(Op->getUser()) ||
-           isa<DeallocStackInst>(Op->getUser()) ||
-           isa<DeinitExistentialAddrInst>(Op->getUser()) ||
-           isDebugInst(Op->getUser()) && "Unexpected instruction");
+    assert((isa<CopyAddrInst>(Op->getUser()) ||
+            isa<OpenExistentialAddrInst>(Op->getUser()) ||
+            isa<DestroyAddrInst>(Op->getUser()) ||
+            isa<DeallocStackInst>(Op->getUser()) ||
+            isa<DeinitExistentialAddrInst>(Op->getUser()) ||
+            isDebugInst(Op->getUser())) && "Unexpected instruction");
     ToDelete.insert(Op->getUser());
   }
 

--- a/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
@@ -189,7 +189,7 @@ protected:
   /// Return the rc-identity root of the RC instruction, i.e.
   /// retain or release.
   SILValue getRCRoot(SILInstruction *I) {
-    assert(isRetainInstruction(I) || isReleaseInstruction(I) &&
+    assert((isRetainInstruction(I) || isReleaseInstruction(I)) &&
            "Extracting RC root from invalid instruction");
     return getRCRoot(I->getOperand(0));
   }

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -238,7 +238,8 @@ static FunctionRefInst *getDirectCallee(SILInstruction *Call) {
 /// return the index of the parameter used in the body of the function
 /// to represent this operand.
 static size_t getParameterIndexForOperand(Operand *O) {
-  assert(isa<ApplyInst>(O->getUser()) || isa<PartialApplyInst>(O->getUser()) &&
+  assert((isa<ApplyInst>(O->getUser()) ||
+          isa<PartialApplyInst>(O->getUser())) &&
          "Expected apply or partial_apply!");
 
   auto OperandIndex = O->getOperandNumber();

--- a/lib/SILOptimizer/Transforms/CopyForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/CopyForwarding.cpp
@@ -997,7 +997,8 @@ void CopyForwarding::forwardCopiesOf(SILValue Def, SILFunction *F) {
       // continue propagating from this dead-in block. In any case, erase the
       // original Destroy.
       Destroy->eraseFromParent();
-      assert(HasChanged || !DeadInBlocks.empty() && "HasChanged should be set");
+      assert((HasChanged || !DeadInBlocks.empty()) &&
+             "HasChanged should be set");
     }
   }
   // Any blocks containing a DestroyPoints where hoistDestroy did not find a use

--- a/lib/SILOptimizer/Utils/CFG.cpp
+++ b/lib/SILOptimizer/Utils/CFG.cpp
@@ -241,7 +241,7 @@ void swift::changeBranchTarget(TermInst *T, unsigned EdgeIdx,
 
   case TermKind::DynamicMethodBranchInst: {
     auto DMBI = dyn_cast<DynamicMethodBranchInst>(T);
-    assert(EdgeIdx == 0 || EdgeIdx == 1 && "Invalid edge index");
+    assert((EdgeIdx == 0 || EdgeIdx == 1) && "Invalid edge index");
     auto HasMethodBB = !EdgeIdx ? NewDest : DMBI->getHasMethodBB();
     auto NoMethodBB = EdgeIdx ? NewDest : DMBI->getNoMethodBB();
     B.createDynamicMethodBranch(DMBI->getLoc(), DMBI->getOperand(),
@@ -252,7 +252,7 @@ void swift::changeBranchTarget(TermInst *T, unsigned EdgeIdx,
 
   case TermKind::CheckedCastBranchInst: {
     auto CBI = dyn_cast<CheckedCastBranchInst>(T);
-    assert(EdgeIdx == 0 || EdgeIdx == 1 && "Invalid edge index");
+    assert((EdgeIdx == 0 || EdgeIdx == 1) && "Invalid edge index");
     auto SuccessBB = !EdgeIdx ? NewDest : CBI->getSuccessBB();
     auto FailureBB = EdgeIdx ? NewDest : CBI->getFailureBB();
     B.createCheckedCastBranch(CBI->getLoc(), CBI->isExact(), CBI->getOperand(),
@@ -263,7 +263,7 @@ void swift::changeBranchTarget(TermInst *T, unsigned EdgeIdx,
 
   case TermKind::CheckedCastAddrBranchInst: {
     auto CBI = dyn_cast<CheckedCastAddrBranchInst>(T);
-    assert(EdgeIdx == 0 || EdgeIdx == 1 && "Invalid edge index");
+    assert((EdgeIdx == 0 || EdgeIdx == 1) && "Invalid edge index");
     auto SuccessBB = !EdgeIdx ? NewDest : CBI->getSuccessBB();
     auto FailureBB = EdgeIdx ? NewDest : CBI->getFailureBB();
     B.createCheckedCastAddrBranch(CBI->getLoc(), CBI->getConsumptionKind(),
@@ -398,7 +398,8 @@ void swift::replaceBranchTarget(TermInst *T, SILBasicBlock *OldDest,
 
   case TermKind::DynamicMethodBranchInst: {
     auto DMBI = cast<DynamicMethodBranchInst>(T);
-    assert(OldDest == DMBI->getHasMethodBB() || OldDest == DMBI->getNoMethodBB() && "Invalid edge index");
+    assert((OldDest == DMBI->getHasMethodBB() ||
+            OldDest == DMBI->getNoMethodBB()) && "Invalid edge index");
     auto HasMethodBB = OldDest == DMBI->getHasMethodBB() ? NewDest : DMBI->getHasMethodBB();
     auto NoMethodBB = OldDest == DMBI->getNoMethodBB() ? NewDest : DMBI->getNoMethodBB();
     B.createDynamicMethodBranch(DMBI->getLoc(), DMBI->getOperand(),
@@ -409,7 +410,8 @@ void swift::replaceBranchTarget(TermInst *T, SILBasicBlock *OldDest,
 
   case TermKind::CheckedCastBranchInst: {
     auto CBI = cast<CheckedCastBranchInst>(T);
-    assert(OldDest == CBI->getSuccessBB() || OldDest == CBI->getFailureBB() && "Invalid edge index");
+    assert((OldDest == CBI->getSuccessBB() ||
+            OldDest == CBI->getFailureBB()) && "Invalid edge index");
     auto SuccessBB = OldDest == CBI->getSuccessBB() ? NewDest : CBI->getSuccessBB();
     auto FailureBB = OldDest == CBI->getFailureBB() ? NewDest : CBI->getFailureBB();
     B.createCheckedCastBranch(CBI->getLoc(), CBI->isExact(), CBI->getOperand(),
@@ -420,7 +422,8 @@ void swift::replaceBranchTarget(TermInst *T, SILBasicBlock *OldDest,
 
   case TermKind::CheckedCastAddrBranchInst: {
     auto CBI = cast<CheckedCastAddrBranchInst>(T);
-    assert(OldDest == CBI->getSuccessBB() || OldDest == CBI->getFailureBB() && "Invalid edge index");
+    assert((OldDest == CBI->getSuccessBB() ||
+            OldDest == CBI->getFailureBB()) && "Invalid edge index");
     auto SuccessBB = OldDest == CBI->getSuccessBB() ? NewDest : CBI->getSuccessBB();
     auto FailureBB = OldDest == CBI->getFailureBB() ? NewDest : CBI->getFailureBB();
     B.createCheckedCastAddrBranch(CBI->getLoc(), CBI->getConsumptionKind(),

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -214,9 +214,10 @@ Solution ConstraintSystem::finalize(
 
   // Remember the opened existential types.
   for (const auto &openedExistential : OpenedExistentialTypes) {
-    assert(solution.OpenedExistentialTypes.count(openedExistential.first) == 0||
+    assert((solution.OpenedExistentialTypes.count(openedExistential.first)
+             == 0 ||
            solution.OpenedExistentialTypes[openedExistential.first]
-             == openedExistential.second &&
+             == openedExistential.second) &&
            "Already recorded");
     solution.OpenedExistentialTypes.insert(openedExistential);
   }

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -274,8 +274,8 @@ void TypeChecker::checkGenericParamList(ArchetypeBuilder *builder,
   TypeResolutionOptions options;
   DeclContext *lookupDC = genericParams->begin()[0]->getDeclContext();
   if (!lookupDC->isModuleScopeContext()) {
-    assert(isa<GenericTypeDecl>(lookupDC) || isa<ExtensionDecl>(lookupDC) ||
-           isa<AbstractFunctionDecl>(lookupDC) &&
+    assert((isa<GenericTypeDecl>(lookupDC) || isa<ExtensionDecl>(lookupDC) ||
+            isa<AbstractFunctionDecl>(lookupDC)) &&
            "not a proper generic parameter context?");
     options = TR_GenericSignature;
   }    

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -677,7 +677,7 @@ isAnyObjectExistentialType(const ExistentialTypeMetadata *targetType) {
   bool isAnyObjectProtocol =
       protocol->Flags.getSpecialProtocol() == SpecialProtocol::AnyObject;
   // Assert that AnyObject does not need any witness tables. We rely on this.
-  assert(!isAnyObjectProtocol || !protocol->Flags.needsWitnessTable() &&
+  assert((!isAnyObjectProtocol || !protocol->Flags.needsWitnessTable()) &&
          "AnyObject should not require witness tables");
   return isAnyObjectProtocol;
 }


### PR DESCRIPTION
Replace `assert(c1 || c2 && "message")` with `assert((c1 || c2) && "message")`.
 found by @modocache .

Hopefully, NFC.