### PR TITLE
[swiftc (107 vs. 5183)] Add crasher in swift::TypeVisitor

### DIFF
--- a/validation-test/compiler_crashers/28479-unreachable-executed-at-swift-include-swift-ast-typevisitor-h-39.swift
+++ b/validation-test/compiler_crashers/28479-unreachable-executed-at-swift-include-swift-ast-typevisitor-h-39.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: OS=linux-gnu
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+T>[print{$0{


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeVisitor`.

Current number of unresolved compiler crashers: 107 (5183 resolved)

Stack trace:

```
#0 0x00000000031ce4d8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31ce4d8)
#1 0x00000000031ced26 SignalHandler(int) (/path/to/swift/bin/swift+0x31ced26)
#2 0x00007f5ad9fc2330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x00007f5ad8780c37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
#4 0x00007f5ad8784028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
#5 0x0000000003176eed llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x3176eed)
#6 0x0000000000d340d9 swift::TypeVisitor<(anonymous namespace)::TypePrinter, void>::visit(swift::Type) (/path/to/swift/bin/swift+0xd340d9)
#7 0x0000000000d31754 (anonymous namespace)::TypePrinter::visit(swift::Type) (/path/to/swift/bin/swift+0xd31754)
#8 0x0000000000d31691 swift::Type::print(llvm::raw_ostream&, swift::PrintOptions const&) const (/path/to/swift/bin/swift+0xd31691)
#9 0x0000000000d2bf3a (anonymous namespace)::PrintDecl::printParameter(swift::ParamDecl const*) (/path/to/swift/bin/swift+0xd2bf3a)
#10 0x0000000000d1b717 swift::ASTVisitor<(anonymous namespace)::PrintDecl, void, void, void, void, void, void>::visit(swift::Decl*) (/path/to/swift/bin/swift+0xd1b717)
#11 0x0000000000d1af28 swift::Decl::dump(llvm::raw_ostream&, unsigned int) const (/path/to/swift/bin/swift+0xd1af28)
#12 0x0000000000d5abdd (anonymous namespace)::Verifier::checkErrors(swift::ValueDecl*) (/path/to/swift/bin/swift+0xd5abdd)
#13 0x0000000000d59289 (anonymous namespace)::Verifier::walkToDeclPost(swift::Decl*) (/path/to/swift/bin/swift+0xd59289)
#14 0x0000000000d6587c (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xd6587c)
#15 0x0000000000d6607e (anonymous namespace)::Traversal::visitParameterList(swift::ParameterList*) (/path/to/swift/bin/swift+0xd6607e)
#16 0x0000000000d68554 (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd68554)
#17 0x0000000000d67e04 (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd67e04)
#18 0x0000000000d69f0d (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xd69f0d)
#19 0x0000000000d67e5a (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd67e5a)
#20 0x0000000000d683a4 (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd683a4)
#21 0x0000000000d6831a (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd6831a)
#22 0x0000000000d69f0d (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0xd69f0d)
#23 0x0000000000d67e5a (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd67e5a)
#24 0x0000000000d66dcf swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd66dcf)
#25 0x0000000000d6566e (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xd6566e)
#26 0x0000000000d65284 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd65284)
#27 0x0000000000dba7ae swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdba7ae)
#28 0x0000000000d4ce9c swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0xd4ce9c)
#29 0x0000000000c14e02 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc14e02)
#30 0x0000000000938326 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x938326)
#31 0x000000000047ece5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ece5)
#32 0x000000000047db7f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47db7f)
#33 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
#34 0x00007f5ad876bf45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
#35 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```