### PR TITLE
[gardening] Fix recently introduced typos (chcek → check, elimianted → eliminated, identifer → identifier, inferrable → inferable, scrach → scratch, vlaue → value)

### DIFF
--- a/include/swift/Basic/Version.h
+++ b/include/swift/Basic/Version.h
@@ -149,7 +149,7 @@ std::pair<unsigned, unsigned> getSwiftNumericVersion();
 std::string getSwiftFullVersion(Version effectiveLanguageVersion =
                                 Version::getCurrentLanguageVersion());
 
-/// Retrieves the repository revision number (or identifer) from which                               
+/// Retrieves the repository revision number (or identifier) from which
 /// this Swift was built.
 std::string getSwiftRevision();
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -727,13 +727,13 @@ static bool shouldBindToValueType(Constraint *constraint)
   }
 }
 
-/// Find the set of type variables that are inferrable from the given type.
+/// Find the set of type variables that are inferable from the given type.
 ///
 /// \param type The type to search.
-/// \param typeVars Collects the type variables that are inferrable from the
+/// \param typeVars Collects the type variables that are inferable from the
 /// given type. This set is not cleared, so that multiple types can be explored
 /// and introduce their results into the same set.
-static void findInferrableTypeVars(
+static void findInferableTypeVars(
               Type type,
               SmallPtrSetImpl<TypeVariableType *> &typeVars) {
   type = type->getCanonicalType();
@@ -931,7 +931,7 @@ static PotentialBindings getPotentialBindings(ConstraintSystem &cs,
 
       // If this variable is in the left-hand side, it is fully bound.
       SmallPtrSet<TypeVariableType *, 4> typeVars;
-      findInferrableTypeVars(cs.simplifyType(constraint->getFirstType()),
+      findInferableTypeVars(cs.simplifyType(constraint->getFirstType()),
                              typeVars);
       if (typeVars.count(typeVar))
         result.FullyBound = true;
@@ -940,7 +940,7 @@ static PotentialBindings getPotentialBindings(ConstraintSystem &cs,
 
       // If this and another type variable occur, this result involves
       // type variables.
-      findInferrableTypeVars(cs.simplifyType(constraint->getSecondType()),
+      findInferableTypeVars(cs.simplifyType(constraint->getSecondType()),
                              typeVars);
       if (typeVars.size() > 1 && typeVars.count(typeVar))
         result.InvolvesTypeVariables = true;
@@ -1003,10 +1003,10 @@ static PotentialBindings getPotentialBindings(ConstraintSystem &cs,
       if (result.InvolvesTypeVariables) continue;
 
       // Check whether both this type and another type variable are
-      // inferrable.
+      // inferable.
       SmallPtrSet<TypeVariableType *, 4> typeVars;
-      findInferrableTypeVars(first, typeVars);
-      findInferrableTypeVars(second, typeVars);
+      findInferableTypeVars(first, typeVars);
+      findInferableTypeVars(second, typeVars);
       if (typeVars.size() > 1 && typeVars.count(typeVar))
         result.InvolvesTypeVariables = true;
       continue;

--- a/stdlib/public/core/DropWhile.swift.gyb
+++ b/stdlib/public/core/DropWhile.swift.gyb
@@ -137,7 +137,7 @@ public struct ${Self}<
   Base : ${Collection}
 > : LazyCollectionProtocol, ${Collection} {
 
-  // FIXME(compiler limitation): should be inferrable.
+  // FIXME(compiler limitation): should be inferable.
   public typealias Index = LazyDropWhileIndex<Base>
 
   public var startIndex: Index {

--- a/stdlib/public/core/Map.swift.gyb
+++ b/stdlib/public/core/Map.swift.gyb
@@ -95,7 +95,7 @@ public struct ${Self}<
   Base : ${collectionForTraversal(Traversal)}, Element
 > : LazyCollectionProtocol, ${collectionForTraversal(Traversal)} {
 
-  // FIXME(compiler limitation): should be inferrable.
+  // FIXME(compiler limitation): should be inferable.
   public typealias Index = Base.Index
 
   public var startIndex: Base.Index { return _base.startIndex }

--- a/test/SILGen/lifetime.swift
+++ b/test/SILGen/lifetime.swift
@@ -445,7 +445,7 @@ class Foo<T> {
     // CHECK:   [[THIS_Z:%.*]] = ref_element_addr [[THIS]] : {{.*}}, #Foo.z
     // CHECK:   copy_addr [take] {{.*}} to [[THIS_Z]]
 
-    // -- Then initialize #Foo.x using the earlier stored vlaue of CHI to THIS_Z.
+    // -- Then initialize #Foo.x using the earlier stored value of CHI to THIS_Z.
     x = chi
     // CHECK:   [[THIS_X:%[0-9]+]] = ref_element_addr [[THIS]] : {{.*}}, #Foo.x
     // CHECK:   copy_addr [[PCHI]] to [[THIS_X]]

--- a/test/SILGen/objc_extensions.swift
+++ b/test/SILGen/objc_extensions.swift
@@ -75,7 +75,7 @@ extension Sub {
     // CHECK:    destroy_value [[SELF_COPY]]
     // CHECK:    [[DIDSET_NOTIFIER:%.*]] = function_ref @_TFC15objc_extensions3SubW4propGSQSS_ : $@convention(method) (@owned Optional<String>, @guaranteed Sub) -> ()
     // CHECK:    [[COPIED_OLD_NSSTRING_BRIDGED_CAST:%.*]] = copy_value [[OLD_NSSTRING_BRIDGED_CAST]]
-    // This is an identity cast that should be elimianted by SILGen peepholes.
+    // This is an identity cast that should be eliminated by SILGen peepholes.
     // CHECK:    [[COPIED_OLD_NSSTRING_BRIDGED_CAST2:%.*]] = unchecked_bitwise_cast [[COPIED_OLD_NSSTRING_BRIDGED_CAST]]
     // CHECK:    apply [[DIDSET_NOTIFIER]]([[COPIED_OLD_NSSTRING_BRIDGED_CAST2]], [[SELF]])
     // CHECK:    destroy_value [[OLD_NSSTRING_BRIDGED_CAST]]

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -315,7 +315,7 @@ public:
   bool operator!=(const SDKNode &Other) const { return !((*this) == Other); }
 
   ArrayRef<NodeAnnotation>
-    getAnnotations(std::vector<NodeAnnotation> &Scrach) const;
+    getAnnotations(std::vector<NodeAnnotation> &Scratch) const;
   bool isLeaf() const { return Children.empty(); }
   SDKNodeKind getKind() const { return SDKNodeKind(TheKind); }
   StringRef getName() const { return Name; }


### PR DESCRIPTION
Changes:
* chcek → check
* elimianted → eliminated
* identifer → identifier
* inferrable → inferable
* scrach → scratch
* vlaue → value
