### PR TITLE
[Compile perf] Make scale-test conditional on assertions, rdar://2909…

### DIFF
--- a/validation-test/compiler_scale/scale_neighbouring_getset.gyb
+++ b/validation-test/compiler_scale/scale_neighbouring_getset.gyb
@@ -1,5 +1,5 @@
 // RUN: %scale-test --sum-multi --parse --begin 5 --end 16 --step 5 --select typeCheckAbstractFunctionBody %s
-// REQUIRES: OS=macosx, tools-release
+// REQUIRES: OS=macosx, tools-release, assertions
 
 struct Struct${N} {
 % if int(N) > 1:


### PR DESCRIPTION
Finally reproduced the failure in rdar://29090287, it's just a "release-no-asserts" build which I hardly ever check; turns out that completely disables stats-gathering, so there's no output and the test fails.

Apologies for the delay.