### PR TITLE
Drop witness markers for 'uninteresting' dependent types

### DIFF
--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -393,6 +393,8 @@ SpecializedProtocolConformance::getTypeWitnessSubstAndDecl(
   // Apply the substitution we computed above
   auto specializedType
     = genericWitness.getReplacement().subst(substitutionMap, None);
+  if (!specializedType)
+    specializedType = ErrorType::get(genericWitness.getReplacement());
 
   // If the type witness was unchanged, just copy it directly.
   if (specializedType.getPointer() == genericWitness.getReplacement().getPointer()) {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2810,12 +2810,12 @@ static Type getMemberForBaseType(ConformanceSource conformances,
     }
 
     if (!conformance) return failed();
+    if (!conformance->isConcrete()) return failed();
 
     // If we have an unsatisfied type witness while we're checking the
     // conformances we're supposed to skip this conformance's unsatisfied type
     // witnesses, and we have an unsatisfied type witness, return
     // "missing".
-    assert(conformance->isConcrete());
     if (conformance->getConcrete()->getRootNormalConformance()->getState()
           == ProtocolConformanceState::CheckingTypeWitnesses &&
         !conformance->getConcrete()->hasTypeWitness(assocType, nullptr))

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1332,28 +1332,6 @@ void ValueLifetimeAnalysis::dump() const {
 //                    Casts Optimization and Simplification
 //===----------------------------------------------------------------------===//
 
-/// \brief Get a substitution corresponding to the type witness.
-/// Inspired by ProtocolConformance::getTypeWitnessByName.
-static const Substitution *
-getTypeWitnessByName(ProtocolConformance *conformance, Identifier name) {
-  // Find the named requirement.
-  AssociatedTypeDecl *assocType = nullptr;
-  assert(conformance && "Missing conformance information");
-  auto members = conformance->getProtocol()->lookupDirect(name);
-  for (auto member : members) {
-    assocType = dyn_cast<AssociatedTypeDecl>(member);
-    if (assocType)
-      break;
-  }
-
-  if (!assocType)
-    return nullptr;
-
-  if (!conformance->hasTypeWitness(assocType, nullptr)) {
-    return nullptr;
-  }
-  return &conformance->getTypeWitness(assocType, nullptr);
-}
 
 /// Check if is a bridging cast, i.e. one of the sides is
 /// a bridged type.

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1513,14 +1513,12 @@ optimizeBridgedObjCToSwiftCast(SILInstruction *Inst,
   SmallVector<SILValue, 1> Args;
 
   // Add substitutions
-  SmallVector<Substitution, 2> Subs;
   auto Conformances =
     M.getASTContext().AllocateUninitialized<ProtocolConformanceRef>(1);
   Conformances[0] = ProtocolConformanceRef(Conformance);
-  Subs.push_back(Substitution(Target, Conformances));
-  const Substitution *DepTypeSubst = getTypeWitnessByName(
-      Conformance, M.getASTContext().getIdentifier("_ObjectiveCType"));
-  Subs.push_back(*DepTypeSubst);
+  Substitution Subs[1] = {
+    Substitution(Target, Conformances)
+  };
   auto SILFnTy = FuncRef->getType();
   SILType SubstFnTy = SILFnTy.substGenericArgs(M, Subs);
   SILType ResultTy = SubstFnTy.castTo<SILFunctionType>()->getSILResult();

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1573,26 +1573,9 @@ namespace {
       auto fnGenericParams
         = fn->getGenericSignatureOfContext()->getGenericParams();
 
-      SmallVector<Substitution, 2> Subs;
-      Substitution sub(valueType, Conformances);
-      Subs.push_back(sub);
-
-      // Add substitution for the dependent type T._ObjectiveCType.
-      if (conformsToBridgedToObjectiveC) {
-        auto objcTypeId = tc.Context.Id_ObjectiveCType;
-        auto objcAssocType = cast<AssociatedTypeDecl>(
-                               conformance->getProtocol()->lookupDirect(
-                                 objcTypeId).front());
-        const Substitution &objcSubst = conformance->getTypeWitness(
-                                          objcAssocType, &tc);
-
-        // Create a substitution for the dependent type.
-        Substitution newDepTypeSubst(
-                       objcSubst.getReplacement(),
-                       objcSubst.getConformances());
-
-        Subs.push_back(newDepTypeSubst);
-      }
+      Substitution Subs[1] = {
+        Substitution(valueType, Conformances)
+      };
 
       ConcreteDeclRef fnSpecRef(tc.Context, fn, Subs);
       auto fnRef = new (tc.Context) DeclRefExpr(fnSpecRef,

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -5436,7 +5436,9 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
     if (calleeInfo.closeness == CC_ExactMatch)
       return true;
 
-    if (!CS->getContextualType() || calleeInfo.closeness != CC_ArgumentMismatch)
+    if (!CS->getContextualType() ||
+        (calleeInfo.closeness != CC_ArgumentMismatch &&
+         calleeInfo.closeness != CC_OneGenericArgumentMismatch))
       return false;
 
     CalleeCandidateInfo candidates(fnExpr, hasTrailingClosure, CS);

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1438,11 +1438,11 @@ void TypeChecker::completePropertyBehaviorParameter(VarDecl *VD,
 
 void TypeChecker::completePropertyBehaviorAccessors(VarDecl *VD,
                                        VarDecl *ValueImpl,
+                                       Type valueTy,
                                        ArrayRef<Substitution> SelfInterfaceSubs,
                                        ArrayRef<Substitution> SelfContextSubs) {
   auto selfTy = SelfContextSubs[0].getReplacement();
-  auto valueTy = SelfContextSubs[1].getReplacement();
-  
+
   SmallVector<ASTNode, 3> bodyStmts;
   
   auto makeSelfExpr = [&](FuncDecl *fromAccessor,

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2382,7 +2382,7 @@ public:
       }
 
       std::pair<bool, Pattern*> walkToPatternPre(Pattern *P) override {
-        TS->Patterns.insert({ P, P->getType() });
+        TS->Patterns.insert({ P, P->hasType() ? P->getType() : Type() });
         return { true, P };
       }
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1164,6 +1164,7 @@ public:
   /// property.
   void completePropertyBehaviorAccessors(VarDecl *VD,
                                      VarDecl *ValueImpl,
+                                     Type valueTy,
                                      ArrayRef<Substitution> SelfInterfaceSubs,
                                      ArrayRef<Substitution> SelfContextSubs);
 

--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -134,6 +134,29 @@ public protocol BidirectionalCollection
   ///     
   /// - Complexity: O(1)
   var last: Iterator.Element? { get }
+
+  /// Accesses a contiguous subrange of the collection's elements.
+  ///
+  /// The accessed slice uses the same indices for the same elements as the
+  /// original collection uses. Always use the slice's `startIndex` property
+  /// instead of assuming that its indices start at a particular value.
+  ///
+  /// This example demonstrates getting a slice of an array of strings, finding
+  /// the index of one of the strings in the slice, and then using that index
+  /// in the original array.
+  ///
+  ///     let streets = ["Adams", "Bryant", "Channing", "Douglas", "Evarts"]
+  ///     let streetsSlice = streets[2 ..< streets.endIndex]
+  ///     print(streetsSlice)
+  ///     // Prints "["Channing", "Douglas", "Evarts"]"
+  ///
+  ///     let index = streetsSlice.index(of: "Evarts")    // 4
+  ///     print(streets[index!])
+  ///     // Prints "Evarts"
+  ///
+  /// - Parameter bounds: A range of the collection's indices. The bounds of
+  ///   the range must be valid indices of the collection.
+  subscript(bounds: Range<Index>) -> SubSequence { get }
 }
 
 /// Default implementation for bidirectional collections.

--- a/stdlib/public/core/Indices.swift.gyb
+++ b/stdlib/public/core/Indices.swift.gyb
@@ -107,7 +107,11 @@ public struct ${Self}<
   internal var _endIndex: Elements.Index
 }
 
-extension ${collectionForTraversal(Traversal)} where Indices == ${Self}<Self> {
+extension ${collectionForTraversal(Traversal)}
+%     if Traversal != 'RandomAccess':
+  where Indices == ${Self}<Self>
+%     end
+{
   /// The indices that are valid for subscripting the collection, in ascending
   /// order.
   ///

--- a/stdlib/public/core/RandomAccessCollection.swift
+++ b/stdlib/public/core/RandomAccessCollection.swift
@@ -81,6 +81,29 @@ public protocol RandomAccessCollection :
   ///     }
   ///     // c == MyFancyCollection([2, 4, 6, 8, 10])
   var indices: Indices { get }
+
+  /// Accesses a contiguous subrange of the collection's elements.
+  ///
+  /// The accessed slice uses the same indices for the same elements as the
+  /// original collection uses. Always use the slice's `startIndex` property
+  /// instead of assuming that its indices start at a particular value.
+  ///
+  /// This example demonstrates getting a slice of an array of strings, finding
+  /// the index of one of the strings in the slice, and then using that index
+  /// in the original array.
+  ///
+  ///     let streets = ["Adams", "Bryant", "Channing", "Douglas", "Evarts"]
+  ///     let streetsSlice = streets[2 ..< streets.endIndex]
+  ///     print(streetsSlice)
+  ///     // Prints "["Channing", "Douglas", "Evarts"]"
+  ///
+  ///     let index = streetsSlice.index(of: "Evarts")    // 4
+  ///     print(streets[index!])
+  ///     // Prints "Evarts"
+  ///
+  /// - Parameter bounds: A range of the collection's indices. The bounds of
+  ///   the range must be valid indices of the collection.
+  subscript(bounds: Range<Index>) -> SubSequence { get }
 }
 
 /// Supply the default "slicing" `subscript` for `RandomAccessCollection`

--- a/test/Generics/associated_types.swift
+++ b/test/Generics/associated_types.swift
@@ -160,7 +160,7 @@ protocol A {
 }
 
 protocol B : A {
-  associatedtype e : A = C<Self> // expected-note {{default type 'C<C<a>>' for associated type 'e' (from protocol 'B') does not conform to 'A'}}
+  associatedtype e : A = C<Self>
 }
 
 extension B {
@@ -168,8 +168,14 @@ extension B {
   }
 }
 
-struct C<a : B> : B { // expected-error {{type 'C<a>' does not conform to protocol 'B'}}
+struct C<a : B> : B {
 }
+
+struct CC : B {
+  typealias e = CC
+}
+
+C<CC>().c()
 
 // SR-511
 protocol sr511 {

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -575,7 +575,7 @@ sil hidden_external @complex_generic_function : $@convention(thin) <T where T : 
 sil @partial_apply_complex_generic_function : $@convention(thin) <T where T : P2, T.Y : P2> (Int) -> () {
 bb0(%0 : $Int):
   %fn = function_ref @complex_generic_function : $@convention(thin) <T where T : P2, T.Y : P2> (Int) -> ()
-  %pa = partial_apply %fn <T, T.Y, T.Y.X, T.Y.Y, T.Y.Y.X>(%0) : $@convention(thin) <T where T : P2, T.Y : P1, T.Y : P2, T.Y.X : P0, T.Y.Y : P1, T.Y.Y.X : P0> (Int) -> ()
+  %pa = partial_apply %fn <T, T.Y>(%0) : $@convention(thin) <T where T : P2, T.Y : P1, T.Y : P2> (Int) -> ()
   %result = tuple ()
   return %result : $()
 }

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -76,7 +76,7 @@ bb0(%0 : $*Self):
 
   // CHECK-NEXT: call void @defaultC(%swift.opaque* noalias nocapture %0, %swift.type* %Self, i8** %SelfWitnessTable)
   %fn1 = function_ref @defaultC : $@convention(witness_method) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> ()
-  %ignore1 = apply %fn1<Self, Self.T>(%0) : $@convention(witness_method) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> ()
+  %ignore1 = apply %fn1<Self>(%0) : $@convention(witness_method) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> ()
 
   // Make sure we can do dynamic dispatch to other protocol requirements
   // from a default implementation
@@ -86,7 +86,7 @@ bb0(%0 : $*Self):
   // CHECK-NEXT: [[WITNESS:%.*]] = bitcast i8* [[WITNESS_FN]] to void (%swift.opaque*, %swift.type*, i8**)*
   // CHECK-NEXT: call void [[WITNESS]](%swift.opaque* noalias nocapture %0, %swift.type* %Self, i8** %SelfWitnessTable)
   %fn2 = witness_method $Self, #ResilientProtocol.defaultC!1 : $@convention(witness_method) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> ()
-  %ignore2 = apply %fn2<Self, Self.T>(%0) : $@convention(witness_method) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> ()
+  %ignore2 = apply %fn2<Self>(%0) : $@convention(witness_method) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> ()
 
   // Make sure we can partially apply a static reference to a default
   // implementation
@@ -98,7 +98,7 @@ bb0(%0 : $*Self):
   // CHECK-NEXT: store i8* [[WTABLE]], i8** [[WTABLE_ADDR]]
 
   %fn3 = function_ref @defaultC : $@convention(witness_method) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> ()
-  %ignore3 = partial_apply %fn3<Self, Self.T>() : $@convention(witness_method) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> ()
+  %ignore3 = partial_apply %fn3<Self>() : $@convention(witness_method) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> ()
 
   // CHECK-NEXT: ret void
   %result = tuple ()
@@ -116,7 +116,7 @@ bb0(%0 : $@thick Self.Type):
 
   // CHECK-NEXT: call void @defaultF(%swift.type* %0, %swift.type* %Self, i8** %SelfWitnessTable)
   %fn1 = function_ref @defaultF : $@convention(witness_method) <Self where Self : ResilientProtocol> (@thick Self.Type) -> ()
-  %ignore1 = apply %fn1<Self, Self.T>(%0) : $@convention(witness_method) <Self where Self : ResilientProtocol> (@thick Self.Type) -> ()
+  %ignore1 = apply %fn1<Self>(%0) : $@convention(witness_method) <Self where Self : ResilientProtocol> (@thick Self.Type) -> ()
 
   // Make sure we can do dynamic dispatch to other protocol requirements
   // from a default implementation
@@ -126,7 +126,7 @@ bb0(%0 : $@thick Self.Type):
   // CHECK-NEXT: [[WITNESS:%.*]] = bitcast i8* [[WITNESS_FN]] to void (%swift.type*, %swift.type*, i8**)*
   // CHECK-NEXT: call void [[WITNESS]](%swift.type* %0, %swift.type* %Self, i8** %SelfWitnessTable)
   %fn2 = witness_method $Self, #ResilientProtocol.defaultF!1 : $@convention(witness_method) <Self where Self : ResilientProtocol> (@thick Self.Type) -> ()
-  %ignore2 = apply %fn2<Self, Self.T>(%0) : $@convention(witness_method) <Self where Self : ResilientProtocol> (@thick Self.Type) -> ()
+  %ignore2 = apply %fn2<Self>(%0) : $@convention(witness_method) <Self where Self : ResilientProtocol> (@thick Self.Type) -> ()
 
   // Make sure we can partially apply a static reference to a default
   // implementation
@@ -138,7 +138,7 @@ bb0(%0 : $@thick Self.Type):
   // CHECK-NEXT: store i8* [[WTABLE]], i8** [[WTABLE_ADDR]]
 
   %fn3 = function_ref @defaultF : $@convention(witness_method) <Self where Self : ResilientProtocol> (@thick Self.Type) -> ()
-  %ignore3 = partial_apply %fn3<Self, Self.T>() : $@convention(witness_method) <Self where Self : ResilientProtocol> (@thick Self.Type) -> ()
+  %ignore3 = partial_apply %fn3<Self>() : $@convention(witness_method) <Self where Self : ResilientProtocol> (@thick Self.Type) -> ()
 
   // CHECK-NEXT: ret void
   %result = tuple ()
@@ -196,7 +196,7 @@ bb0(%0 : $*ConformingStruct):
   // CHECK-NEXT: [[SELF:%.*]] = bitcast %V19protocol_resilience16ConformingStruct* %0 to %swift.opaque*
   // CHECK-NEXT: call void @defaultC(%swift.opaque* noalias nocapture [[SELF]], %swift.type* bitcast ({{i32|i64}}* {{.*}}) to %swift.type*), i8** getelementptr inbounds ([8 x i8*], [8 x i8*]* @_TWPV19protocol_resilience16ConformingStructS_17ResilientProtocolS_, i32 0, i32 0))
   %fn1 = function_ref @defaultC : $@convention(witness_method) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> ()
-  %ignore1 = apply %fn1<ConformingStruct, ResilientConformingType>(%0) : $@convention(witness_method) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> ()
+  %ignore1 = apply %fn1<ConformingStruct>(%0) : $@convention(witness_method) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> ()
 
   // CHECK-NEXT: ret void
   %result = tuple ()
@@ -218,7 +218,7 @@ bb0(%0 : $*ConformingStruct):
   // CHECK-NEXT: store i8* bitcast ([8 x i8*]* @_TWPV19protocol_resilience16ConformingStructS_17ResilientProtocolS_ to i8*), i8** [[WTABLE]]
 
   %fn1 = function_ref @defaultC : $@convention(witness_method) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> ()
-  %ignore1 = partial_apply %fn1<ConformingStruct, ResilientConformingType>() : $@convention(witness_method) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> ()
+  %ignore1 = partial_apply %fn1<ConformingStruct>() : $@convention(witness_method) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> ()
 
   // CHECK-NEXT: ret void
   %result = tuple ()
@@ -367,7 +367,7 @@ bb0(%0 : $*ConformsWithResilientAssoc):
   // CHECK-NEXT: call void @doSomethingAssoc(%swift.opaque* noalias nocapture [[ARG]], %swift.type* bitcast ({{i32|i64}}* getelementptr inbounds ({{.*}} @_TMfV19protocol_resilience26ConformsWithResilientAssoc, i32 0, i32 1) to %swift.type*), i8** getelementptr inbounds ([2 x i8*], [2 x i8*]* @_TWPV19protocol_resilience26ConformsWithResilientAssocS_17HasResilientAssocS_, i32 0, i32 0))
 
   %fn = function_ref @doSomethingAssoc : $@convention(thin) <T : HasResilientAssoc> (@in T) -> ()
-  %ignore = apply %fn<ConformsWithResilientAssoc, ResilientConformingType>(%0) : $@convention(thin) <T : HasResilientAssoc> (@in T) -> ()
+  %ignore = apply %fn<ConformsWithResilientAssoc>(%0) : $@convention(thin) <T : HasResilientAssoc> (@in T) -> ()
 
   // CHECK-NEXT: ret void
   %result = tuple ()

--- a/test/IRGen/witness_method.sil
+++ b/test/IRGen/witness_method.sil
@@ -74,7 +74,7 @@ struct SyncUp<Deliverable> : Synergy {
 sil @testGenericWitnessMethod : $@convention(thin) <T> (@in SyncUp<T>) -> @out T {
 entry(%ret : $*T, %self : $*SyncUp<T>):
   %m = witness_method $SyncUp<T>, #Synergy.actionItem!1 : $@convention(witness_method) <U: Synergy> (@in_guaranteed U) -> @out U.LowHangingFruit
-  %z = apply %m<SyncUp<T>, T>(%ret, %self) : $@convention(witness_method) <U: Synergy> (@in_guaranteed U) -> @out U.LowHangingFruit
+  %z = apply %m<SyncUp<T>>(%ret, %self) : $@convention(witness_method) <U: Synergy> (@in_guaranteed U) -> @out U.LowHangingFruit
   return %z : $()
 }
 
@@ -97,6 +97,6 @@ protocol Strategy {
 sil @testArchetypeWitnessMethod : $@convention(thin) <T : Strategy> (@in T) -> @out T.GrowthHack {
 entry(%ret : $*T.GrowthHack, %self : $*T):
   %m = witness_method $T, #Strategy.disrupt!1 : $@convention(witness_method) <U: Strategy> (@in_guaranteed U) -> @out U.GrowthHack
-  %z = apply %m<T, T.GrowthHack>(%ret, %self) : $@convention(witness_method) <U: Strategy> (@in_guaranteed U) -> @out U.GrowthHack
+  %z = apply %m<T>(%ret, %self) : $@convention(witness_method) <U: Strategy> (@in_guaranteed U) -> @out U.GrowthHack
   return %z : $()
 }

--- a/test/SIL/Parser/generic_signature_with_depth.swift
+++ b/test/SIL/Parser/generic_signature_with_depth.swift
@@ -20,7 +20,7 @@ protocol mmExt : mmCollectionType {
 
 // CHECK-LABEL:  @_TF28generic_signature_with_depth4testu0_RxS_5mmExt_S0_Wx9Generator7Element_zW_S1_S2__rFTxq__x : $@convention(thin) <EC1, EC2 where EC1 : mmExt, EC2 : mmExt, EC1.Generator.Element == EC2.Generator.Element> (@in EC1, @in EC2) -> @out EC1 {
 // CHECK: witness_method $EC1, #mmExt.extend!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : mmExt><τ_1_0 where τ_1_0 : mmSequenceType, τ_0_0.Generator.Element == τ_1_0.Generator.Element> (@in τ_1_0, @inout τ_0_0) -> ()
-// CHECK: apply {{%[0-9]+}}<EC1, EC2, EC1.Generator, EC2.Generator, EC1.Generator.Element>({{%[0-9]+}}, {{%[0-9]+}}) : $@convention(witness_method) <τ_0_0 where τ_0_0 : mmExt><τ_1_0 where τ_1_0 : mmSequenceType, τ_0_0.Generator.Element == τ_1_0.Generator.Element> (@in τ_1_0, @inout τ_0_0) -> ()
+// CHECK: apply {{%[0-9]+}}<EC1, EC2, EC1.Generator.Element>({{%[0-9]+}}, {{%[0-9]+}}) : $@convention(witness_method) <τ_0_0 where τ_0_0 : mmExt><τ_1_0 where τ_1_0 : mmSequenceType, τ_0_0.Generator.Element == τ_1_0.Generator.Element> (@in τ_1_0, @inout τ_0_0) -> ()
 
 func test<
    EC1 : mmExt,

--- a/test/SIL/Parser/generics.sil
+++ b/test/SIL/Parser/generics.sil
@@ -102,7 +102,7 @@ bb0(%0 : $*I, %1 : $*Self):
   copy_addr %0 to [initialization] %2 : $*I     // id: %3
   %4 = witness_method $I, #FooProto.value!getter.1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : FooProto, τ_0_0.Assoc : FooProtoHelper> (@in_guaranteed τ_0_0) -> @out τ_0_0.Assoc // user: %6
   %5 = alloc_stack $Self.Assoc                    // users: %6, %8
-  %6 = apply %4<I, Self.Assoc>(%5, %2) : $@convention(witness_method) <τ_0_0 where τ_0_0 : FooProto, τ_0_0.Assoc : FooProtoHelper> (@in_guaranteed τ_0_0) -> @out τ_0_0.Assoc
+  %6 = apply %4<I>(%5, %2) : $@convention(witness_method) <τ_0_0 where τ_0_0 : FooProto, τ_0_0.Assoc : FooProtoHelper> (@in_guaranteed τ_0_0) -> @out τ_0_0.Assoc
   destroy_addr %2 : $*I                         // id: %7
   dealloc_stack %5 : $*Self.Assoc // id: %8
   dealloc_stack %2 : $*I         // id: %9

--- a/test/SILGen/default_arguments_generic.swift
+++ b/test/SILGen/default_arguments_generic.swift
@@ -14,17 +14,17 @@ struct Zim<T: ExpressibleByIntegerLiteral> {
 // CHECK-LABEL: sil hidden @_TF25default_arguments_generic3barFT_T_ : $@convention(thin) () -> () {
 func bar() {
   // CHECK: [[FOO_DFLT:%.*]] = function_ref @_TIF25default_arguments_generic3foo
-  // CHECK: apply [[FOO_DFLT]]<Int, Int>
+  // CHECK: apply [[FOO_DFLT]]<Int>
   foo(Int.self)
   // CHECK: [[ZIM_DFLT:%.*]] = function_ref @_TIZFV25default_arguments_generic3Zim3zim
-  // CHECK: apply [[ZIM_DFLT]]<Int, Int>
+  // CHECK: apply [[ZIM_DFLT]]<Int>
   Zim<Int>.zim()
   // CHECK: [[ZANG_DFLT_0:%.*]] = function_ref @_TIZFV25default_arguments_generic3Zim4zang
-  // CHECK: apply [[ZANG_DFLT_0]]<Int, Double, Int, Double>
+  // CHECK: apply [[ZANG_DFLT_0]]<Int, Double>
   // CHECK: [[ZANG_DFLT_1:%.*]] = function_ref @_TIZFV25default_arguments_generic3Zim4zang
-  // CHECK: apply [[ZANG_DFLT_1]]<Int, Double, Int, Double>
+  // CHECK: apply [[ZANG_DFLT_1]]<Int, Double>
   Zim<Int>.zang(Double.self)
   // CHECK: [[ZANG_DFLT_1:%.*]] = function_ref @_TIZFV25default_arguments_generic3Zim4zang
-  // CHECK: apply [[ZANG_DFLT_1]]<Int, Double, Int, Double>
+  // CHECK: apply [[ZANG_DFLT_1]]<Int, Double>
   Zim<Int>.zang(Double.self, 22)
 }

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -509,7 +509,7 @@ func supportFirstStructure<B: Buildable>(_ b: inout B) throws {
 // CHECK: [[BUFFER:%.*]] = alloc_stack $B.Structure
 // CHECK: [[BUFFER_CAST:%.*]] = address_to_pointer [[BUFFER]] : $*B.Structure to $Builtin.RawPointer
 // CHECK: [[MAT:%.*]] = witness_method $B, #Buildable.firstStructure!materializeForSet.1 :
-// CHECK: [[T1:%.*]] = apply [[MAT]]<B, B.Structure>([[BUFFER_CAST]], [[MATBUFFER]], [[BASE:%[0-9]*]])
+// CHECK: [[T1:%.*]] = apply [[MAT]]<B>([[BUFFER_CAST]], [[MATBUFFER]], [[BASE:%[0-9]*]])
 // CHECK: [[T2:%.*]] = tuple_extract [[T1]] : {{.*}}, 0
 // CHECK: [[CALLBACK:%.*]] = tuple_extract [[T1]] : {{.*}}, 1
 // CHECK: [[T3:%.*]] = pointer_to_address [[T2]] : $Builtin.RawPointer to [strict] $*B.Structure
@@ -540,7 +540,7 @@ func supportStructure<B: Buildable>(_ b: inout B, name: String) throws {
 // CHECK: [[BUFFER:%.*]] = alloc_stack $B.Structure
 // CHECK: [[BUFFER_CAST:%.*]] = address_to_pointer [[BUFFER]] : $*B.Structure to $Builtin.RawPointer
 // CHECK: [[MAT:%.*]] = witness_method $B, #Buildable.subscript!materializeForSet.1 :
-// CHECK: [[T1:%.*]] = apply [[MAT]]<B, B.Structure>([[BUFFER_CAST]], [[MATBUFFER]], [[INDEX_COPY]], [[BASE:%[0-9]*]])
+// CHECK: [[T1:%.*]] = apply [[MAT]]<B>([[BUFFER_CAST]], [[MATBUFFER]], [[INDEX_COPY]], [[BASE:%[0-9]*]])
 // CHECK: [[T2:%.*]] = tuple_extract [[T1]] : {{.*}}, 0
 // CHECK: [[CALLBACK:%.*]] = tuple_extract [[T1]] : {{.*}}, 1
 // CHECK: [[T3:%.*]] = pointer_to_address [[T2]] : $Builtin.RawPointer to [strict] $*B.Structure

--- a/test/SILGen/generic_closures.swift
+++ b/test/SILGen/generic_closures.swift
@@ -188,7 +188,7 @@ protocol HasClassAssoc { associatedtype Assoc : Class }
 // CHECK: bb0([[ARG1:%.*]] : $*T, [[ARG2:%.*]] : $@callee_owned (@owned T.Assoc) -> @owned T.Assoc):
 // CHECK: [[GENERIC_FN:%.*]] = function_ref @_TFF16generic_closures34captures_class_constrained_genericuRxS_13HasClassAssocrFTx1fFwx5AssocwxS1__T_U_FT_FQQ_5AssocS2_
 // CHECK: [[ARG2_COPY:%.*]] = copy_value [[ARG2]]
-// CHECK: [[CONCRETE_FN:%.*]] = partial_apply [[GENERIC_FN]]<T, T.Assoc>([[ARG2_COPY]])
+// CHECK: [[CONCRETE_FN:%.*]] = partial_apply [[GENERIC_FN]]<T>([[ARG2_COPY]])
 
 func captures_class_constrained_generic<T : HasClassAssoc>(_ x: T, f: @escaping (T.Assoc) -> T.Assoc) {
   let _: () -> (T.Assoc) -> T.Assoc = { f }

--- a/test/SILGen/generic_literals.swift
+++ b/test/SILGen/generic_literals.swift
@@ -11,7 +11,7 @@ func genericIntegerLiteral<T : ExpressibleByIntegerLiteral>(x: T) {
   // CHECK: [[LITVAR:%.*]] = alloc_stack $T.IntegerLiteralType
   // CHECK: [[LIT:%.*]] = apply [[BUILTINCONV]]<T.IntegerLiteralType>([[LITVAR]], [[INTLIT]], [[LITMETA]]) : $@convention(witness_method) <τ_0_0 where τ_0_0 : _ExpressibleByBuiltinIntegerLiteral> (Builtin.Int2048, @thick τ_0_0.Type) -> @out τ_0_0
   // CHECK: [[ADDR:%.*]] = alloc_stack $T
-  // CHECK: apply [[TCONV]]<T, T.IntegerLiteralType>([[ADDR]], [[LITVAR]], [[TMETA]]) : $@convention(witness_method) <τ_0_0 where τ_0_0 : ExpressibleByIntegerLiteral> (@in τ_0_0.IntegerLiteralType, @thick τ_0_0.Type) -> @out τ_0_0
+  // CHECK: apply [[TCONV]]<T>([[ADDR]], [[LITVAR]], [[TMETA]]) : $@convention(witness_method) <τ_0_0 where τ_0_0 : ExpressibleByIntegerLiteral> (@in τ_0_0.IntegerLiteralType, @thick τ_0_0.Type) -> @out τ_0_0
 
   x = 17
 }
@@ -27,7 +27,7 @@ func genericFloatingLiteral<T : ExpressibleByFloatLiteral>(x: T) {
   // CHECK: [[FLT_VAL:%.*]] = alloc_stack $T.FloatLiteralType
   // CHECK: apply [[BUILTIN_CONV]]<T.FloatLiteralType>([[FLT_VAL]], [[LIT_VALUE]], [[TFLT_META]]) : $@convention(witness_method) <τ_0_0 where τ_0_0 : _ExpressibleByBuiltinFloatLiteral> (Builtin.FPIEEE{{64|80}}, @thick τ_0_0.Type) -> @out τ_0_0
   // CHECK: [[TVAL:%.*]] = alloc_stack $T
-  // CHECK: apply [[CONV]]<T, T.FloatLiteralType>([[TVAL]], [[FLT_VAL]], [[TMETA]]) : $@convention(witness_method) <τ_0_0 where τ_0_0 : ExpressibleByFloatLiteral> (@in τ_0_0.FloatLiteralType, @thick τ_0_0.Type) -> @out τ_0_0
+  // CHECK: apply [[CONV]]<T>([[TVAL]], [[FLT_VAL]], [[TMETA]]) : $@convention(witness_method) <τ_0_0 where τ_0_0 : ExpressibleByFloatLiteral> (@in τ_0_0.FloatLiteralType, @thick τ_0_0.Type) -> @out τ_0_0
 
   x = 2.5
 }

--- a/test/SILGen/guaranteed_self.swift
+++ b/test/SILGen/guaranteed_self.swift
@@ -417,7 +417,7 @@ func AO_curryThunk<T>(_ ao: AO<T>) -> ((AO<T>) -> (Int) -> ()/*, Int -> ()*/) {
 // CHECK: [[ARG0:%.*]] = load [[ARG0_PTR]]
 // CHECK: function_ref (extension in guaranteed_self):guaranteed_self.SequenceDefaults._constrainElement
 // CHECK: [[FUN:%.*]] = function_ref @_{{.*}}
-// CHECK: apply [[FUN]]<FakeArray, FakeElement, FakeGenerator, FakeElement>([[ARG0]], [[GUARANTEED_COPY_STACK_SLOT]])
+// CHECK: apply [[FUN]]<FakeArray>([[ARG0]], [[GUARANTEED_COPY_STACK_SLOT]])
 // CHECK: destroy_addr [[GUARANTEED_COPY_STACK_SLOT]]
 
 class Z {}

--- a/test/SILGen/newtype.swift
+++ b/test/SILGen/newtype.swift
@@ -36,7 +36,7 @@ func getRawValue(ed: ErrorDomain) -> String {
 // CHECK-RAW: [[STORED_VALUE_COPY:%.*]] = copy_value [[STORED_VALUE]]
 // CHECK-RAW: [[STRING_META:%[0-9]+]] = metatype $@thick String.Type
 // CHECK-RAW: [[STRING_RESULT_ADDR:%[0-9]+]] = alloc_stack $String
-// CHECK-RAW: apply [[FORCE_BRIDGE]]<String, NSString>([[STRING_RESULT_ADDR]], [[STORED_VALUE_COPY]], [[STRING_META]])
+// CHECK-RAW: apply [[FORCE_BRIDGE]]<String>([[STRING_RESULT_ADDR]], [[STORED_VALUE_COPY]], [[STRING_META]])
 // CHECK-RAW: [[STRING_RESULT:%[0-9]+]] = load [[STRING_RESULT_ADDR]]
 // CHECK-RAW: return [[STRING_RESULT]]
 

--- a/test/SILGen/objc_bridged_using_protocol_extension_impl.swift
+++ b/test/SILGen/objc_bridged_using_protocol_extension_impl.swift
@@ -44,13 +44,13 @@ class Bar: NSObject {
 // CHECK-LABEL: sil hidden @_TF42objc_bridged_using_protocol_extension_impl7callBarFT3barCS_3Bar3fooVS_3Foo_T_
 func callBar(bar: Bar, foo: Foo) {
   // CHECK: [[BRIDGE:%.*]] = function_ref @_TFe42objc_bridged_using_protocol_extension_implRxs21_ObjectiveCBridgeablexS_7FooablerS1_19_bridgeToObjectiveCfT_wxPS0_15_ObjectiveCType
-  // CHECK: apply [[BRIDGE]]<Foo, NSObject>
+  // CHECK: apply [[BRIDGE]]<Foo>
   bar.bar(foo)
 }
 
 // CHECK-LABEL:sil hidden @_TF42objc_bridged_using_protocol_extension_impl7callBarFT3barCS_3Bar3genGVS_3GenSiSS__T_ 
 func callBar(bar: Bar, gen: Gen<Int, String>) {
   // CHECK: [[BRIDGE:%.*]] = function_ref @_TFe42objc_bridged_using_protocol_extension_implRxs21_ObjectiveCBridgeablexS_7FooablerS1_19_bridgeToObjectiveCfT_wxPS0_15_ObjectiveCType
-  // CHECK: apply [[BRIDGE]]<Gen<Int, String>, NSObject>
+  // CHECK: apply [[BRIDGE]]<Gen<Int, String>>
   bar.bar(gen)
 }

--- a/test/SILGen/objc_imported_generic.swift
+++ b/test/SILGen/objc_imported_generic.swift
@@ -88,9 +88,9 @@ public func genericBlockBridging<T: Ansible>(x: GenericClass<T>) {
 
 // CHECK-LABEL: sil @_TF21objc_imported_generic20genericBlockBridging
 // CHECK:         [[BLOCK_TO_FUNC:%.*]] = function_ref @_TTRGRxs9AnyObjectx21objc_imported_generic7AnsiblerXFdCb_dx_ax_XFo_ox_ox_
-// CHECK:         partial_apply [[BLOCK_TO_FUNC]]<T, {{.*}}>
+// CHECK:         partial_apply [[BLOCK_TO_FUNC]]<T>
 // CHECK:         [[FUNC_TO_BLOCK:%.*]] = function_ref @_TTRgRxs9AnyObjectx21objc_imported_generic7AnsiblerXFo_ox_ox_XFdCb_dx_ax_
-// CHECK:         init_block_storage_header {{.*}} invoke [[FUNC_TO_BLOCK]]<T,{{.*}}>
+// CHECK:         init_block_storage_header {{.*}} invoke [[FUNC_TO_BLOCK]]<T>
 
 // CHECK-LABEL: sil @_TF21objc_imported_generic20arraysOfGenericParam
 public func arraysOfGenericParam<T: AnyObject>(y: Array<T>) {

--- a/test/SILGen/property_abstraction.swift
+++ b/test/SILGen/property_abstraction.swift
@@ -129,4 +129,4 @@ func setBuilder<F: Factory where F.Product == MyClass>(_ factory: inout F) {
 // CHECK:   [[SETTER:%.*]] = witness_method $F, #Factory.builder!setter.1
 // CHECK:   [[REABSTRACTOR:%.*]] = function_ref @_TTR
 // CHECK:   [[F2:%.*]] = partial_apply [[REABSTRACTOR]]([[F1]])
-// CHECK:   apply [[SETTER]]<F, MyClass>([[F2]], %0)
+// CHECK:   apply [[SETTER]]<F>([[F2]], %0)

--- a/test/SILGen/property_behavior.swift
+++ b/test/SILGen/property_behavior.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-silgen -enable-experimental-property-behaviors %s | %FileCheck %s
+// REQUIRES: property_behavior_value_substitution
 protocol behavior {
   associatedtype Value
 }

--- a/test/SILGen/property_behavior_init.swift
+++ b/test/SILGen/property_behavior_init.swift
@@ -29,7 +29,7 @@ struct Foo {
   init(x: Int) {
     // CHECK: [[UNINIT_SELF:%.*]] = mark_uninitialized [rootself]
     // CHECK: [[UNINIT_STORAGE:%.*]] = struct_element_addr [[UNINIT_SELF]]
-    // CHECK: [[UNINIT_BEHAVIOR:%.*]] = mark_uninitialized_behavior {{.*}}<Foo, Int>([[UNINIT_STORAGE]]) : {{.*}}, {{%.*}}([[UNINIT_SELF]])
+    // CHECK: [[UNINIT_BEHAVIOR:%.*]] = mark_uninitialized_behavior {{.*}}<Foo>([[UNINIT_STORAGE]]) : {{.*}}, {{%.*}}([[UNINIT_SELF]])
 
     // Pure assignments undergo DI analysis so assign to the marking proxy.
 

--- a/test/SILGen/specialize_attr.swift
+++ b/test/SILGen/specialize_attr.swift
@@ -34,7 +34,7 @@ public class CC<T : PP> {
 
 // CHECK-LABEL: sil hidden [_specialize <Int, Float>] @_TF15specialize_attr14specializeThisu0_rFTx1uq__T_ : $@convention(thin) <T, U> (@in T, @in U) -> () {
 
-// CHECK-LABEL: sil [noinline] [_specialize <RR, SS, Float, Int>] @_TFC15specialize_attr2CC3foouRd__S_2QQrfTqd__1gGVS_2GGx__Tqd__GS2_x__ : $@convention(method) <T where T : PP><U where U : QQ> (@in U, GG<T>, @guaranteed CC<T>) -> (@out U, GG<T>) {
+// CHECK-LABEL: sil [noinline] [_specialize <RR, SS>] @_TFC15specialize_attr2CC3foouRd__S_2QQrfTqd__1gGVS_2GGx__Tqd__GS2_x__ : $@convention(method) <T where T : PP><U where U : QQ> (@in U, GG<T>, @guaranteed CC<T>) -> (@out U, GG<T>) {
 
 // -----------------------------------------------------------------------------
 // Test user-specialized subscript accessors.

--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -166,7 +166,7 @@ func for_loops2() {
   // rdar://problem/19316670
   // CHECK: [[NEXT:%[0-9]+]] = function_ref @_TFVs16IndexingIterator4next
   // CHECK-NEXT: alloc_stack $Optional<MyClass>
-  // CHECK-NEXT: apply [[NEXT]]<[MyClass],
+  // CHECK-NEXT: apply [[NEXT]]<[MyClass]
   // CHECK: class_method [[OBJ:%[0-9]+]] : $MyClass, #MyClass.foo!1
   let objects = [MyClass(), MyClass() ]
   for obj in objects {

--- a/test/SILGen/witnesses.swift
+++ b/test/SILGen/witnesses.swift
@@ -22,7 +22,7 @@ func archetype_generic_method<T: X>(x: T, y: Loadable) -> Loadable {
 // CHECK:       }
 
 // CHECK-LABEL: sil hidden @_TF9witnesses32archetype_associated_type_method{{.*}} : $@convention(thin) <T where T : WithAssoc> (@in T, @in T.AssocType) -> @out T
-// CHECK:         apply %{{[0-9]+}}<T, T.AssocType>
+// CHECK:         apply %{{[0-9]+}}<T>
 func archetype_associated_type_method<T: WithAssoc>(x: T, y: T.AssocType) -> T {
   return x.useAssocType(x: y)
 }
@@ -425,12 +425,12 @@ struct GenericParameterNameCollision<T: HasAssoc> :
 
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTW{{.*}}GenericParameterNameCollision{{.*}}GenericParameterNameCollisionProtocol{{.*}}foo{{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : HasAssoc><τ_1_0> (@in τ_1_0, @in_guaranteed GenericParameterNameCollision<τ_0_0>) -> () {
   // CHECK:       bb0(%0 : $*τ_1_0, %1 : $*GenericParameterNameCollision<τ_0_0>):
-  // CHECK:         apply {{%.*}}<τ_0_0, τ_1_0, τ_0_0.Assoc>
+  // CHECK:         apply {{%.*}}<τ_0_0, τ_1_0>
   func foo<U>(_ x: U) {}
 
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTW{{.*}}GenericParameterNameCollision{{.*}}GenericParameterNameCollisionProtocol{{.*}}bar{{.*}} : $@convention(witness_method) <τ_0_0 where τ_0_0 : HasAssoc><τ_1_0> (@owned @callee_owned (@in τ_1_0) -> @out τ_0_0.Assoc, @in_guaranteed GenericParameterNameCollision<τ_0_0>) -> () {
   // CHECK:       bb0(%0 : $@callee_owned (@in τ_1_0) -> @out τ_0_0.Assoc, %1 : $*GenericParameterNameCollision<τ_0_0>):
-  // CHECK:         apply {{%.*}}<τ_0_0, τ_1_0, τ_0_0.Assoc>
+  // CHECK:         apply {{%.*}}<τ_0_0, τ_1_0>
   func bar<V>(_ x: (V) -> T.Assoc) {}
 }
 

--- a/test/SILOptimizer/eager_specialize.sil
+++ b/test/SILOptimizer/eager_specialize.sil
@@ -76,7 +76,7 @@ sil @_TFV16eager_specialize1G12getContainerfwx3Eltx : $@convention(method) <Cont
 bb0(%0 : $*Container, %1 : $*Container.Elt, %2 : $G<Container>):
   %4 = witness_method $Container, #HasElt.init!allocator.1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, @thick τ_0_0.Type) -> @out τ_0_0, scope 20 // user: %6
   %5 = metatype $@thick Container.Type, scope 20 // user: %6
-  %6 = apply %4<Container, Container.Elt>(%0, %1, %5) : $@convention(witness_method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, @thick τ_0_0.Type) -> @out τ_0_0, scope 20
+  %6 = apply %4<Container>(%0, %1, %5) : $@convention(witness_method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, @thick τ_0_0.Type) -> @out τ_0_0, scope 20
   %7 = tuple (), scope 20 // user: %8
   return %7 : $(), scope 20 // id: %8
 }
@@ -89,7 +89,7 @@ sil [_specialize <S, X>] @_TF16eager_specialize19getGenericContaineruRxS_6HasElt
 bb0(%0 : $*T, %1 : $G<T>, %2 : $*T.Elt):
   // function_ref G.getContainer(A.Elt) -> A
   %5 = function_ref @_TFV16eager_specialize1G12getContainerfwx3Eltx : $@convention(method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, G<τ_0_0>) -> @out τ_0_0, scope 6 // user: %6
-  %6 = apply %5<T, T.Elt>(%0, %2, %1) : $@convention(method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, G<τ_0_0>) -> @out τ_0_0, scope 6
+  %6 = apply %5<T>(%0, %2, %1) : $@convention(method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, G<τ_0_0>) -> @out τ_0_0, scope 6
   %7 = tuple (), scope 6 // user: %8
   return %7 : $(), scope 6 // id: %8
 }
@@ -113,7 +113,7 @@ bb0(%0 : $*T, %1 : $G<T>, %2 : $*T.Elt):
 
 // CHECK: bb1:                                              // Preds: bb0
 // CHECK:   %9 = function_ref @_TFV16eager_specialize1G12getContainerfwx3Eltx : $@convention(method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, G<τ_0_0>) -> @out τ_0_0
-// CHECK:   %10 = apply %9<T, T.Elt>(%0, %2, %1) : $@convention(method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, G<τ_0_0>) -> @out τ_0_0
+// CHECK:   %10 = apply %9<T>(%0, %2, %1) : $@convention(method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, G<τ_0_0>) -> @out τ_0_0
 // CHECK:   br bb2
 
 // CHECK: bb2:                                              // Preds: bb3 bb1
@@ -159,7 +159,7 @@ bb0(%0 : $*T, %1 : $*T):
 }
 
 // divideNum<A where ...> (A, den : A) throws -> A
-sil [_specialize <Int, Int, Int, Int, Int>] @_TF16eager_specialize9divideNumuRxs13SignedIntegerrFzTx3denx_x : $@convention(thin) <T where T : SignedInteger, T.IntegerLiteralType : _ExpressibleByBuiltinIntegerLiteral, T.IntegerLiteralType : _ExpressibleByBuiltinIntegerLiteral, T.Stride : SignedNumber, T.Stride.IntegerLiteralType : _ExpressibleByBuiltinIntegerLiteral> (@in T, @in T) -> (@out T, @error Error) {
+sil [_specialize <Int>] @_TF16eager_specialize9divideNumuRxs13SignedIntegerrFzTx3denx_x : $@convention(thin) <T where T : SignedInteger> (@in T, @in T) -> (@out T, @error Error) {
 // %0                                             // user: %19
 // %1                                             // users: %3, %19, %23
 // %2                                             // users: %4, %7, %19, %22

--- a/test/SILOptimizer/specialize_reabstraction.sil
+++ b/test/SILOptimizer/specialize_reabstraction.sil
@@ -47,7 +47,7 @@ bb0(%0 : $Ref<U>, %1 : $*Self):
 sil @merge_curried : $@convention(thin) <Self where Self : RefProto><U> (@in Self) -> @owned @callee_owned (@owned Ref<U>) -> @owned Ref<(Self.T, U)> {
 bb0(%0 : $*Self):
   %1 = function_ref @merge : $@convention(method) <τ_0_0 where τ_0_0 : RefProto><τ_1_0> (@owned Ref<τ_1_0>, @in_guaranteed τ_0_0) -> @owned Ref<(τ_0_0.T, τ_1_0)>
-  %2 = partial_apply %1<Self, U, Self.T>(%0) : $@convention(method) <τ_0_0 where τ_0_0 : RefProto><τ_1_0> (@owned Ref<τ_1_0>, @in_guaranteed τ_0_0) -> @owned Ref<(τ_0_0.T, τ_1_0)>
+  %2 = partial_apply %1<Self, U>(%0) : $@convention(method) <τ_0_0 where τ_0_0 : RefProto><τ_1_0> (@owned Ref<τ_1_0>, @in_guaranteed τ_0_0) -> @owned Ref<(τ_0_0.T, τ_1_0)>
   return %2 : $@callee_owned (@owned Ref<U>) -> @owned Ref<(Self.T, U)>
 }
 
@@ -69,11 +69,11 @@ bb0(%0 : $Val<Bool>, %1 : $Val<Int>):
   // CHECK: [[MERGE:%.*]] = function_ref @_TTSg5GC4main3RefSb_GS0_Sb_S_8RefProtoS__Si__merge_curried
   %3 = function_ref @merge_curried : $@convention(thin) <τ_0_0 where τ_0_0 : RefProto><τ_1_0> (@in τ_0_0) -> @owned @callee_owned (@owned Ref<τ_1_0>) -> @owned Ref<(τ_0_0.T, τ_1_0)>
   // CHECK: [[PARTIAL:%.*]] = partial_apply [[MERGE]]()
-  %4 = partial_apply %3<Ref<Bool>, Int, Bool>() : $@convention(thin) <τ_0_0 where τ_0_0 : RefProto><τ_1_0> (@in τ_0_0) -> @owned @callee_owned (@owned Ref<τ_1_0>) -> @owned Ref<(τ_0_0.T, τ_1_0)>
+  %4 = partial_apply %3<Ref<Bool>, Int>() : $@convention(thin) <τ_0_0 where τ_0_0 : RefProto><τ_1_0> (@in τ_0_0) -> @owned @callee_owned (@owned Ref<τ_1_0>) -> @owned Ref<(τ_0_0.T, τ_1_0)>
   // CHECK-NOT: function_ref @reabstract
   %5 = function_ref @reabstract : $@convention(thin) <τ_0_0 where τ_0_0 : ValProto><τ_1_0> (@owned Ref<τ_0_0.T>, @owned @callee_owned (@in Ref<τ_0_0.T>) -> @owned @callee_owned (@owned Ref<τ_1_0>) -> @owned Ref<(τ_0_0.T, τ_1_0)>) -> @owned @callee_owned (@owned Ref<τ_1_0>) -> @owned Ref<(τ_0_0.T, τ_1_0)>
   // CHECK-NOT: partial_apply
-  %6 = partial_apply %5<Val<Bool>, Int, Bool>(%4) : $@convention(thin) <τ_0_0 where τ_0_0 : ValProto><τ_1_0> (@owned Ref<τ_0_0.T>, @owned @callee_owned (@in Ref<τ_0_0.T>) -> @owned @callee_owned (@owned Ref<τ_1_0>) -> @owned Ref<(τ_0_0.T, τ_1_0)>) -> @owned @callee_owned (@owned Ref<τ_1_0>) -> @owned Ref<(τ_0_0.T, τ_1_0)>
+  %6 = partial_apply %5<Val<Bool>, Int>(%4) : $@convention(thin) <τ_0_0 where τ_0_0 : ValProto><τ_1_0> (@owned Ref<τ_0_0.T>, @owned @callee_owned (@in Ref<τ_0_0.T>) -> @owned @callee_owned (@owned Ref<τ_1_0>) -> @owned Ref<(τ_0_0.T, τ_1_0)>) -> @owned @callee_owned (@owned Ref<τ_1_0>) -> @owned Ref<(τ_0_0.T, τ_1_0)>
   // CHECK: apply [[COERCE]]<Bool, Int, (Bool, Int)>([[PARTIAL]])
   %7 = apply %2<Bool, Int, (Bool, Int)>(%6) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2> (@owned @callee_owned (@owned Ref<τ_0_0>) -> @owned @callee_owned (@owned Ref<τ_0_1>) -> @owned Ref<τ_0_2>) -> @owned @callee_owned (Val<τ_0_1>) -> Val<τ_0_2>
   %8 = apply %7(%1) : $@callee_owned (Val<Int>) -> Val<(Bool, Int)>

--- a/test/Serialization/serialize_attr.swift
+++ b/test/Serialization/serialize_attr.swift
@@ -54,4 +54,4 @@ class CC<T : PP> {
 
 // CHECK-DAG: sil hidden [fragile] [_specialize <Int, Float>] @_TF14serialize_attr14specializeThisu0_rFTx1uq__T_ : $@convention(thin) <T, U> (@in T, @in U) -> () {
 
-// CHECK-DAG: sil hidden [fragile] [noinline] [_specialize <RR, SS, Float, Int>] @_TFC14serialize_attr2CC3foouRd__S_2QQrfTqd__1gGVS_2GGx__Tqd__GS2_x__ : $@convention(method) <T where T : PP><U where U : QQ> (@in U, GG<T>, @guaranteed CC<T>) -> (@out U, GG<T>) {
+// CHECK-DAG: sil hidden [fragile] [noinline] [_specialize <RR, SS>] @_TFC14serialize_attr2CC3foouRd__S_2QQrfTqd__1gGVS_2GGx__Tqd__GS2_x__ : $@convention(method) <T where T : PP><U where U : QQ> (@in U, GG<T>, @guaranteed CC<T>) -> (@out U, GG<T>) {

--- a/test/decl/var/behaviors.swift
+++ b/test/decl/var/behaviors.swift
@@ -1,4 +1,5 @@
 // RUN: %target-parse-verify-swift -enable-experimental-property-behaviors -module-name Main
+// REQUIRES: property_behavior_value_substitution
 
 protocol behavior {
   associatedtype Value

--- a/validation-test/compiler_crashers_fixed/28452-this-genericenv-already-have-generic-context-failed.swift
+++ b/validation-test/compiler_crashers_fixed/28452-this-genericenv-already-have-generic-context-failed.swift
@@ -5,7 +5,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 protocol C{{
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
This pull request removes witness markers for 'uninteresting' dependent types--e.g, those dependent types for which there are no additional protocol conformances required beyond what is implied by other constraints--from substitution lists and the list of "all" dependent types in a generic signature. For example, given something like:

    protocol P { }
    protocol Q {
      associatedtype Assoc : P
    }

a generic signature `<T: Q>` currently would contain witness markers for both `T` and `T.Assoc`, even though everything about `T.Assoc` is recoverable from the conformance of `T` to `Q`. With this change, we would only record a witness marker for `T`.

It's a necessary step toward implementing recursive protocol conformances (because the list of "all" witness markers would be infinite were `Assoc` to conform to `Q`, i.e., `T.Assoc`, `T.Assoc.Assoc`, `T.Assoc.Assoc.Assoc`, etc.). It's also a cleaner way to model the problem, and a step toward eliminating witness markers altogether.

This pull request is still a work-in-progress for two reasons:

* It has an unexpected impact on associated type inference, which hit the standard library in two places that caused breaking. One involves the inferred `Indices` witness for a minimal `RandomAccessCollection` model, and the other involves a change in inference for the `SubSequence` of the existential collections. The former is potentially a bug fix to the type checker that may imply a library change, while the latter appears to be an outright bug in the inference of associated type witnesses.
* It breaks property behaviors, which depend on some dodgy uses of protocols that break when we're forced to use an actual protocol conformance to resolve associated type witnesses.

