### PR TITLE
Gate the swift-remoteast-test tests on the target matching the host.

### DIFF
--- a/test/RemoteAST/foreign_types.swift
+++ b/test/RemoteAST/foreign_types.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-remoteast-test -sdk %S/../IRGen/Inputs %s | %FileCheck %s
 
+// REQUIRES: swift-remoteast-test
 // REQUIRES: objc_interop
 
 import CoreCooling

--- a/test/RemoteAST/member_offsets.swift
+++ b/test/RemoteAST/member_offsets.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-remoteast-test %s | %FileCheck %s
 
+// REQUIRES: swift-remoteast-test
 // REQUIRES: PTRSIZE=64
 
 @_silgen_name("printTypeMemberOffset")

--- a/test/RemoteAST/nominal_types.swift
+++ b/test/RemoteAST/nominal_types.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-remoteast-test %s | %FileCheck %s
 
+// REQUIRES: swift-remoteast-test
+
 @_silgen_name("printMetadataType")
 func printType(_: Any.Type)
 

--- a/test/RemoteAST/objc_classes.swift
+++ b/test/RemoteAST/objc_classes.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-remoteast-test-with-sdk %s | %FileCheck %s
 
-// REQUIRES: swift_interpreter
+// REQUIRES: swift-remoteast-test
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/RemoteAST/structural_types.swift
+++ b/test/RemoteAST/structural_types.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-remoteast-test %s | %FileCheck %s
 
+// REQUIRES: swift-remoteast-test
+
 @_silgen_name("printMetadataType")
 func printType(_: Any.Type)
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -528,6 +528,13 @@ if platform.system() == 'Darwin' and (run_os == 'macosx' or run_os == 'darwin'):
 elif platform.system() == 'Linux':
     config.available_features.add('swift_interpreter')
 
+# swift-remoteast-test requires the ability to compile and run code
+# for the system we compiled the swift-remoteast-test executable on.
+# This is potentially a stronger constraint than just "can we interpret",
+# but use that as an approximation for now.
+if 'swift_interpreter' in config.available_features:
+    config.available_features.add('swift-remoteast-test')
+
 config.target_swiftmodule_name = "unknown.swiftmodule"
 config.target_swiftdoc_name = "unknown.swiftdoc"
 config.target_runtime = "unknown"


### PR DESCRIPTION
swift-remoteast-test uses the JIT to execute code in its own process.
Even if we theoretically taught the interpreter to perform some sort
of remote interpretation, that would not be sufficient to make
swift-remoteast-test work.  Therefore I've introduced a new lit
feature check specifically for swift-remoteast-test, but set it by
default to be equivalent to swift_interpreter.

Resolves rdar://29103551, in which we managed to build Swift for iOS without having first built a Mac OS X stdlib — a completely reasonable configuration, but one we apparently don't regularly do.