### PR TITLE
WIP fix resilience build

### DIFF
--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -1239,7 +1239,7 @@ extension Set {
 }
 
 extension Set : CustomStringConvertible, CustomDebugStringConvertible {
-  private func makeDescription(isDebug: Bool) -> String {
+  internal func makeDescription(isDebug: Bool) -> String {
     var result = isDebug ? "Set([" : "["
     var first = true
     for member in self {
@@ -2829,6 +2829,7 @@ final internal class _HashableTypedNative${Self}Storage<${TypeParametersDecl}> :
 /// The reason for this is to support storing AnyObject for bridging
 /// with _SwiftDeferredNS${Self}. What functionality actually relies on
 /// Hashable can be found in an extension.
+@_versioned
 internal struct _Native${Self}Buffer<${TypeParameters}> {
 
   internal typealias RawStorage = _RawNative${Self}Storage
@@ -2917,12 +2918,14 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
   }
 
   // This API is unsafe and needs a `_fixLifetime` in the caller.
+  @_versioned
   internal var keys: UnsafeMutablePointer<Key> {
     return _storage.keys.assumingMemoryBound(to: Key.self)
   }
 
 %if Self == 'Dictionary':
   // This API is unsafe and needs a `_fixLifetime` in the caller.
+  @_versioned
   internal var values: UnsafeMutablePointer<Value> {
     return _storage.values.assumingMemoryBound(to: Value.self)
   }


### PR DESCRIPTION
<!-- What's in this pull request? -->

So it seems the problem was there were some non-versioned APIs being called by versioned inline/transparent APIs. I also made some private internal, but I don't think that actually mattered.

This PR moves the resilient build further along, but unfortunately it crashes with:

```
piece is larger than or outside of variable
  call void @llvm.dbg.value(metadata double undef, i64 0, metadata !516, metadata !550), !dbg !518
!516 = !DILocalVariable(name: "inverse", scope: !517, file: !80, line: 241, type: !8)
!550 = !DIExpression(DW_OP_bit_piece, 192, 64)
piece is larger than or outside of variable
  call void @llvm.dbg.value(metadata double undef, i64 0, metadata !516, metadata !553), !dbg !518
!516 = !DILocalVariable(name: "inverse", scope: !517, file: !80, line: 241, type: !8)
!553 = !DIExpression(DW_OP_bit_piece, 256, 64)
piece is larger than or outside of variable
  call void @llvm.dbg.value(metadata double undef, i64 0, metadata !516, metadata !558), !dbg !518
!516 = !DILocalVariable(name: "inverse", scope: !517, file: !80, line: 241, type: !8)
!558 = !DIExpression(DW_OP_bit_piece, 320, 64)
piece is larger than or outside of variable
  tail call void @llvm.dbg.value(metadata double %10, i64 0, metadata !579, metadata !550), !dbg !581
!579 = !DILocalVariable(name: "t", scope: !580, file: !80, line: 195, type: !8)
!550 = !DIExpression(DW_OP_bit_piece, 192, 64)
piece is larger than or outside of variable
  tail call void @llvm.dbg.value(metadata double %12, i64 0, metadata !579, metadata !553), !dbg !581
!579 = !DILocalVariable(name: "t", scope: !580, file: !80, line: 195, type: !8)
!553 = !DIExpression(DW_OP_bit_piece, 256, 64)
piece is larger than or outside of variable
  tail call void @llvm.dbg.value(metadata double %14, i64 0, metadata !579, metadata !558), !dbg !581
!579 = !DILocalVariable(name: "t", scope: !580, file: !80, line: 195, type: !8)
!558 = !DIExpression(DW_OP_bit_piece, 320, 64)
piece is larger than or outside of variable
  tail call void @llvm.dbg.value(metadata double %18, i64 0, metadata !579, metadata !550), !dbg !613
!579 = !DILocalVariable(name: "t", scope: !580, file: !80, line: 195, type: !8)
!550 = !DIExpression(DW_OP_bit_piece, 192, 64)
piece is larger than or outside of variable
  tail call void @llvm.dbg.value(metadata double %20, i64 0, metadata !579, metadata !553), !dbg !613
!579 = !DILocalVariable(name: "t", scope: !580, file: !80, line: 195, type: !8)
!553 = !DIExpression(DW_OP_bit_piece, 256, 64)
piece is larger than or outside of variable
  tail call void @llvm.dbg.value(metadata double %22, i64 0, metadata !579, metadata !558), !dbg !613
!579 = !DILocalVariable(name: "t", scope: !580, file: !80, line: 195, type: !8)
!558 = !DIExpression(DW_OP_bit_piece, 320, 64)
Assertion failed: (!V->hasBrokenDebugInfo() && "Module contains invalid debug info"), function doFinalization, file /Users/Beingessner/dev/mswift/llvm/lib/IR/Verifier.cpp, line 4441.
Stack dump:
0.	Program arguments: /Users/Beingessner/dev/mswift/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/bin/swift -frontend -c /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/AffineTransform.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/Boxing.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/Calendar.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/CharacterSet.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/Data.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/Date.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/DateComponents.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/DateInterval.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/Decimal.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/ExtraStringAPIs.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/FileManager.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/Foundation.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/Hashing.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/IndexPath.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/IndexSet.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/Locale.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/Measurement.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/Notification.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/NSArray.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/NSCoder.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/NSDate.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/NSDictionary.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/NSError.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/NSExpression.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/NSFastEnumeration.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/NSGeometry.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/NSIndexSet.swift /Users/Beingessner/dev/mswift/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/stdlib/public/SDK/Foundation/8/NSNumber.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/NSPredicate.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/NSRange.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/NSSet.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/NSString.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/NSStringAPI.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/NSStringEncodings.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/NSTextCheckingResult.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/NSUndoManager.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/NSURL.swift /Users/Beingessner/dev/mswift/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/stdlib/public/SDK/Foundation/8/NSValue.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/PersonNameComponents.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/ReferenceConvertible.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/String.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/TimeZone.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/URL.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/URLComponents.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/URLRequest.swift /Users/Beingessner/dev/mswift/swift/stdlib/public/SDK/Foundation/UUID.swift -target x86_64-apple-macosx10.9 -enable-objc-interop -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -I /Users/Beingessner/dev/mswift/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/./lib/swift/macosx/x86_64 -F /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/../../../Developer/Library/Frameworks -autolink-force-load -g -module-cache-path /Users/Beingessner/dev/mswift/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/./module-cache -module-link-name swiftFoundation -resource-dir /Users/Beingessner/dev/mswift/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/./lib/swift -D INTERNAL_CHECKS_ENABLED -enable-resilience -O -parse-as-library -module-name Foundation -o /Users/Beingessner/dev/mswift/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/stdlib/public/SDK/Foundation/macosx/x86_64/Foundation.o 
[77/438] Compiling /Users/Beingessner/dev/mswift/build/Ninja-RelWit...Assert/swift-macosx-x86_64/stdlib/public/core/macosx/x86_64/Swift.o
ninja: build stopped: subcommand failed.
utils/build-script: fatal error: command terminated with a non-zero exit status 1, aborting
```

Without any more information, I'm left to assume this is some other unrelated breakage that snuck in while resilience wasn't being tested.