### PR TITLE
[semantic-arc] Handle the rest of the unqualified mem opts in SILGen.

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -459,6 +459,12 @@ public:
 
   LoadInst *createLoad(SILLocation Loc, SILValue LV,
                        LoadOwnershipQualifier Qualifier) {
+    assert((Qualifier != LoadOwnershipQualifier::Unqualified) ||
+           F.hasUnqualifiedOwnership() &&
+               "Unqualified inst in qualified function");
+    assert((Qualifier == LoadOwnershipQualifier::Unqualified) ||
+           F.hasQualifiedOwnership() &&
+               "Qualified inst in unqualified function");
     assert(LV->getType().isLoadable(F.getModule()));
     return insert(new (F.getModule())
                       LoadInst(getSILDebugLocation(Loc), LV, Qualifier));
@@ -481,6 +487,12 @@ public:
 
   StoreInst *createStore(SILLocation Loc, SILValue Src, SILValue DestAddr,
                          StoreOwnershipQualifier Qualifier) {
+    assert((Qualifier != StoreOwnershipQualifier::Unqualified) ||
+           F.hasUnqualifiedOwnership() &&
+               "Unqualified inst in qualified function");
+    assert((Qualifier == StoreOwnershipQualifier::Unqualified) ||
+           F.hasQualifiedOwnership() &&
+               "Qualified inst in unqualified function");
     return insert(new (F.getModule()) StoreInst(getSILDebugLocation(Loc), Src,
                                                 DestAddr, Qualifier));
   }

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -301,9 +301,11 @@ public:
     : Operands(operands) {}
 
   /// A simple iterator adapter.
-  class iterator {
+  class iterator : public std::iterator<std::forward_iterator_tag,
+                                        SILValue, ptrdiff_t> {
     const Operand *Ptr;
   public:
+    iterator() = default;
     iterator(const Operand *ptr) : Ptr(ptr) {}
     SILValue operator*() const { assert(Ptr); return Ptr->get(); }
     SILValue operator->() const { return operator*(); }

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -3996,6 +3996,9 @@ bool SILParser::parseSILBasicBlock(SILBuilder &B) {
 
   bool AssumeUnqualifiedOwnershipWhenParsing =
     F->getModule().getOptions().AssumeUnqualifiedOwnershipWhenParsing;
+  if (AssumeUnqualifiedOwnershipWhenParsing) {
+    F->setUnqualifiedOwnership();
+  }
   do {
     if (parseSILInstruction(BB, B))
       return true;
@@ -4003,9 +4006,8 @@ bool SILParser::parseSILBasicBlock(SILBuilder &B) {
     // Qualification. For more details, see the comment on the
     // FunctionOwnershipEvaluator class.
     SILInstruction *ParsedInst = &*BB->rbegin();
-    if (AssumeUnqualifiedOwnershipWhenParsing) {
-      F->setUnqualifiedOwnership();
-    } else if (!OwnershipEvaluator.evaluate(ParsedInst)) {
+    if (!AssumeUnqualifiedOwnershipWhenParsing &&
+        !OwnershipEvaluator.evaluate(ParsedInst)) {
       P.diagnose(ParsedInst->getLoc().getSourceLoc(),
                  diag::found_unqualified_instruction_in_qualified_function,
                  F->getName());

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1123,24 +1123,21 @@ public:
     case LoadOwnershipQualifier::Unqualified:
       // We should not see loads with unqualified ownership when SILOwnership is
       // enabled.
-      requireTrueAndSILOwnership(
-          this, F.hasUnqualifiedOwnership(),
-          "Load with unqualified ownership in a qualified function");
+      require(F.hasUnqualifiedOwnership(),
+              "Load with unqualified ownership in a qualified function");
       break;
     case LoadOwnershipQualifier::Copy:
     case LoadOwnershipQualifier::Take:
-      requireTrueAndSILOwnership(
-          this, F.hasQualifiedOwnership(),
-          "Load with qualified ownership in an unqualified function");
+      require(F.hasQualifiedOwnership(),
+              "Load with qualified ownership in an unqualified function");
       // TODO: Could probably make this a bit stricter.
       require(!LI->getType().isTrivial(LI->getModule()),
               "load [copy] or load [take] can only be applied to non-trivial "
               "types");
       break;
     case LoadOwnershipQualifier::Trivial:
-      requireTrueAndSILOwnership(
-          this, F.hasQualifiedOwnership(),
-          "Load with qualified ownership in an unqualified function");
+      require(F.hasQualifiedOwnership(),
+              "Load with qualified ownership in an unqualified function");
       require(LI->getType().isTrivial(LI->getModule()),
               "A load with trivial ownership must load a trivial type");
       break;
@@ -1148,8 +1145,8 @@ public:
   }
 
   void checkLoadBorrowInst(LoadBorrowInst *LBI) {
-    requireTrueAndSILOwnership(
-        this, F.hasQualifiedOwnership(),
+    require(
+        F.hasQualifiedOwnership(),
         "Inst with qualified ownership in a function that is not qualified");
     require(LBI->getType().isObject(), "Result of load must be an object");
     require(LBI->getType().isLoadable(LBI->getModule()),
@@ -1161,8 +1158,8 @@ public:
   }
 
   void checkEndBorrowInst(EndBorrowInst *EBI) {
-    requireTrueAndSILOwnership(
-        this, F.hasQualifiedOwnership(),
+    require(
+        F.hasQualifiedOwnership(),
         "Inst with qualified ownership in a function that is not qualified");
     // We allow for end_borrow to express relationships in between addresses and
     // values, but we require that the types are the same ignoring value
@@ -1188,13 +1185,13 @@ public:
     case StoreOwnershipQualifier::Unqualified:
       // We should not see loads with unqualified ownership when SILOwnership is
       // enabled.
-      requireTrueAndSILOwnership(this, F.hasUnqualifiedOwnership(),
-                                 "Invalid load with unqualified ownership");
+      require(F.hasUnqualifiedOwnership(),
+              "Qualified store in function with unqualified ownership?!");
       break;
     case StoreOwnershipQualifier::Init:
     case StoreOwnershipQualifier::Assign:
-      requireTrueAndSILOwnership(
-          this, F.hasQualifiedOwnership(),
+      require(
+          F.hasQualifiedOwnership(),
           "Inst with qualified ownership in a function that is not qualified");
       // TODO: Could probably make this a bit stricter.
       require(!SI->getSrc()->getType().isTrivial(SI->getModule()),
@@ -1202,8 +1199,8 @@ public:
               "non-trivial types");
       break;
     case StoreOwnershipQualifier::Trivial:
-      requireTrueAndSILOwnership(
-          this, F.hasQualifiedOwnership(),
+      require(
+          F.hasQualifiedOwnership(),
           "Inst with qualified ownership in a function that is not qualified");
       require(SI->getSrc()->getType().isTrivial(SI->getModule()),
               "A store with trivial ownership must store a trivial type");

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -494,8 +494,7 @@ namespace {
   public:
     void emitDestroyAddress(SILBuilder &B, SILLocation loc,
                             SILValue addr) const override {
-      SILValue value =
-          B.createLoad(loc, addr, LoadOwnershipQualifier::Unqualified);
+      SILValue value = emitLoad(B, loc, addr, LoadOwnershipQualifier::Take);
       emitDestroyValue(B, loc, value);
     }
 
@@ -520,23 +519,29 @@ namespace {
 
     SILValue emitLoadOfCopy(SILBuilder &B, SILLocation loc, SILValue addr,
                             IsTake_t isTake) const override {
-      return B.createLoad(loc, addr, LoadOwnershipQualifier::Unqualified);
+      return emitLoad(B, loc, addr, LoadOwnershipQualifier::Trivial);
     }
 
     void emitStoreOfCopy(SILBuilder &B, SILLocation loc,
                          SILValue value, SILValue addr,
                          IsInitialization_t isInit) const override {
-      B.createStore(loc, value, addr, StoreOwnershipQualifier::Unqualified);
+      emitStore(B, loc, value, addr, StoreOwnershipQualifier::Trivial);
     }
 
     void emitStore(SILBuilder &B, SILLocation loc, SILValue value,
                    SILValue addr, StoreOwnershipQualifier qual) const override {
-      B.createStore(loc, value, addr, StoreOwnershipQualifier::Trivial);
+      if (B.getFunction().hasQualifiedOwnership()) {
+        B.createStore(loc, value, addr, StoreOwnershipQualifier::Trivial);
+        return;
+      }
+      B.createStore(loc, value, addr, StoreOwnershipQualifier::Unqualified);
     }
 
     SILValue emitLoad(SILBuilder &B, SILLocation loc, SILValue addr,
                       LoadOwnershipQualifier qual) const override {
-      return B.createLoad(loc, addr, LoadOwnershipQualifier::Trivial);
+      if (B.getFunction().hasQualifiedOwnership())
+        return B.createLoad(loc, addr, LoadOwnershipQualifier::Trivial);
+      return B.createLoad(loc, addr, LoadOwnershipQualifier::Unqualified);
     }
 
     void emitDestroyAddress(SILBuilder &B, SILLocation loc,
@@ -576,32 +581,57 @@ namespace {
 
     SILValue emitLoadOfCopy(SILBuilder &B, SILLocation loc,
                             SILValue addr, IsTake_t isTake) const override {
-      SILValue value =
-          B.createLoad(loc, addr, LoadOwnershipQualifier::Unqualified);
-      if (!isTake)
-        emitCopyValue(B, loc, value);
-      return value;
+      auto qual =
+          isTake ? LoadOwnershipQualifier::Take : LoadOwnershipQualifier::Copy;
+      return emitLoad(B, loc, addr, qual);
     }
 
     void emitStoreOfCopy(SILBuilder &B, SILLocation loc,
                          SILValue newValue, SILValue addr,
                          IsInitialization_t isInit) const override {
-      SILValue oldValue;
-      if (!isInit)
-        oldValue = B.createLoad(loc, addr, LoadOwnershipQualifier::Unqualified);
-      B.createStore(loc, newValue, addr, StoreOwnershipQualifier::Unqualified);
-      if (!isInit)
-        emitDestroyValue(B, loc, oldValue);
+      auto qual = isInit ? StoreOwnershipQualifier::Init
+                         : StoreOwnershipQualifier::Assign;
+      emitStore(B, loc, newValue, addr, qual);
     }
 
     void emitStore(SILBuilder &B, SILLocation loc, SILValue value,
                    SILValue addr, StoreOwnershipQualifier qual) const override {
-      B.createStore(loc, value, addr, qual);
+      if (B.getFunction().hasQualifiedOwnership()) {
+        B.createStore(loc, value, addr, qual);
+        return;
+      }
+
+      if (qual != StoreOwnershipQualifier::Assign) {
+        B.createStore(loc, value, addr, StoreOwnershipQualifier::Unqualified);
+        return;
+      }
+
+      // If the ownership qualifier is [assign], then we need to eliminate the
+      // old value.
+      //
+      // 1. Load old value.
+      // 2. Store new value.
+      // 3. Release old value.
+      SILValue old =
+          B.createLoad(loc, addr, LoadOwnershipQualifier::Unqualified);
+      B.createStore(loc, value, addr, StoreOwnershipQualifier::Unqualified);
+      B.emitDestroyValueOperation(loc, old);
     }
 
     SILValue emitLoad(SILBuilder &B, SILLocation loc, SILValue addr,
                       LoadOwnershipQualifier qual) const override {
-      return B.createLoad(loc, addr, qual);
+      if (B.getFunction().hasQualifiedOwnership())
+        return B.createLoad(loc, addr, qual);
+
+      SILValue loadValue =
+          B.createLoad(loc, addr, LoadOwnershipQualifier::Unqualified);
+
+      // If we do not have a copy, just return the value...
+      if (qual != LoadOwnershipQualifier::Copy)
+        return loadValue;
+
+      // Otherwise, emit the copy value operation.
+      return B.emitCopyValueOperation(loc, loadValue);
     }
   };
 

--- a/lib/SILGen/RValue.cpp
+++ b/lib/SILGen/RValue.cpp
@@ -105,7 +105,7 @@ public:
         // loaded.  Except it's not really an invariant, because
         // argument emission likes to lie sometimes.
         if (eltTI.isLoadable()) {
-          elt = gen.B.createLoad(loc, elt, LoadOwnershipQualifier::Unqualified);
+          elt = eltTI.emitLoad(gen.B, loc, elt, LoadOwnershipQualifier::Take);
         }
       }
 

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -607,8 +607,7 @@ emitBuiltinCastReference(SILGenFunction &gen,
     return gen.emitManagedBufferWithCleanup(toAddr);
 
   // Load the destination value.
-  auto result =
-      gen.B.createLoad(loc, toAddr, LoadOwnershipQualifier::Unqualified);
+  auto result = toTL.emitLoad(gen.B, loc, toAddr, LoadOwnershipQualifier::Take);
   return gen.emitManagedRValueWithCleanup(result);
 }
 
@@ -643,9 +642,7 @@ static ManagedValue emitBuiltinReinterpretCast(SILGenFunction &gen,
     // Load and retain the destination value if it's loadable. Leave the cleanup
     // on the original value since we don't know anything about it's type.
     if (toTL.isLoadable()) {
-      SILValue val =
-          gen.B.createLoad(loc, toAddr, LoadOwnershipQualifier::Unqualified);
-      return gen.emitManagedRetain(loc, val, toTL);
+      return gen.emitManagedLoadCopy(loc, toAddr, toTL);
     }
     // Leave the cleanup on the original value.
     if (toTL.isTrivial())

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -275,11 +275,8 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
     
     if (!lowering.isAddressOnly()) {
       // Otherwise, load and return the final 'self' value.
-      selfValue =
-          B.createLoad(cleanupLoc, selfLV, LoadOwnershipQualifier::Unqualified);
-
-      // Emit a retain of the loaded value, since we return it +1.
-      selfValue = lowering.emitCopyValue(B, cleanupLoc, selfValue);
+      selfValue = lowering.emitLoad(B, cleanupLoc, selfLV,
+                                    LoadOwnershipQualifier::Copy);
 
       // Inject the self value into an optional if the constructor is failable.
       if (ctor->getFailability() != OTK_None) {
@@ -582,8 +579,9 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
     if (NeedsBoxForSelf) {
       SILLocation prologueLoc = RegularLocation(ctor);
       prologueLoc.markAsPrologue();
-      B.createStore(prologueLoc, selfArg, VarLocs[selfDecl].value,
-                    StoreOwnershipQualifier::Unqualified);
+      // SEMANTIC ARC TODO: When the verifier is complete, review this.
+      B.emitStoreValueOperation(prologueLoc, selfArg, VarLocs[selfDecl].value,
+                                StoreOwnershipQualifier::Init);
     } else {
       selfArg = B.createMarkUninitialized(selfDecl, selfArg, MUKind);
       VarLocs[selfDecl] = VarLoc::get(selfArg);
@@ -670,12 +668,19 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
       if (Expr *SI = ctor->getSuperInitCall())
         emitRValue(SI);
 
-      selfArg = B.createLoad(cleanupLoc, VarLocs[selfDecl].value,
-                             LoadOwnershipQualifier::Unqualified);
+      selfArg = B.emitLoadValueOperation(cleanupLoc, VarLocs[selfDecl].value,
+                                         LoadOwnershipQualifier::Copy);
+    } else {
+      // We have to do a retain because we are returning the pointer +1.
+      //
+      // SEMANTIC ARC TODO: When the verifier is complete, we will need to
+      // change this to selfArg = B.emitCopyValueOperation(...). Currently due
+      // to the way that SILGen performs folding of copy_value, destroy_value,
+      // the returned selfArg may be deleted causing us to have a
+      // dead-pointer. Instead just use the old self value since we have a
+      // class.
+      selfArg = B.emitCopyValueOperation(cleanupLoc, selfArg);
     }
-    
-    // We have to do a retain because we are returning the pointer +1.
-    selfArg = B.emitCopyValueOperation(cleanupLoc, selfArg);
 
     // Inject the self value into an optional if the constructor is failable.
     if (ctor->getFailability() != OTK_None) {

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -250,7 +250,7 @@ ManagedValue SILGenFunction::emitUncheckedGetOptionalValueFrom(SILLocation loc,
   
     if (optTL.isLoadable())
       payloadVal =
-          B.createLoad(loc, payloadVal, LoadOwnershipQualifier::Unqualified);
+          optTL.emitLoad(B, loc, payloadVal, LoadOwnershipQualifier::Take);
   }
 
   // Produce a correctly managed value.

--- a/lib/SILGen/SILGenDynamicCast.cpp
+++ b/lib/SILGen/SILGenDynamicCast.cpp
@@ -140,8 +140,8 @@ namespace {
         //emission.
         scalarOperandValue = operand.forward(SGF);
         if (scalarOperandValue->getType().isAddress()) {
-          scalarOperandValue = SGF.B.createLoad(
-              Loc, scalarOperandValue, LoadOwnershipQualifier::Unqualified);
+          scalarOperandValue = SGF.B.emitLoadValueOperation(
+              Loc, scalarOperandValue, LoadOwnershipQualifier::Take);
         }
         SGF.B.createCheckedCastBranch(Loc, /*exact*/ false, scalarOperandValue,
                                       origTargetTL.getLoweredType(),

--- a/lib/SILGen/SILGenForeignError.cpp
+++ b/lib/SILGen/SILGenForeignError.cpp
@@ -260,7 +260,7 @@ emitBridgeReturnValueForForeignError(SILLocation loc,
 /// which loads from the error slot and jumps to the error slot.
 void SILGenFunction::emitForeignErrorBlock(SILLocation loc,
                                            SILBasicBlock *errorBB,
-                                           ManagedValue errorSlot) {
+                                           Optional<ManagedValue> errorSlot) {
   SavedInsertionPoint savedIP(*this, errorBB, FunctionSection::Postmatter);
 
   // Load the error (taking responsibility for it).  In theory, this
@@ -268,8 +268,17 @@ void SILGenFunction::emitForeignErrorBlock(SILLocation loc,
   // conditionally claiming the value.  In practice, claiming it
   // unconditionally is fine because we want to assume it's nil in the
   // other path.
-  SILValue errorV = B.createLoad(loc, errorSlot.forward(*this),
-                                 LoadOwnershipQualifier::Unqualified);
+  SILValue errorV;
+  if (errorSlot.hasValue()) {
+    errorV = B.emitLoadValueOperation(loc, errorSlot.getValue().forward(*this),
+                                      LoadOwnershipQualifier::Take);
+  } else {
+    // If we are not provided with an errorSlot value, then we are passed the
+    // unwrapped optional error as the argument of the errorBB. This value is
+    // passed at +1 meaning that we still need to create a cleanup for errorV.
+    errorV = errorBB->getBBArg(0);
+  }
+
   ManagedValue error = emitManagedRValueWithCleanup(errorV);
 
   // Turn the error into an Error value.
@@ -385,20 +394,24 @@ emitErrorIsNonNilErrorCheck(SILGenFunction &gen, SILLocation loc,
   // If we're suppressing the check, just don't check.
   if (suppressErrorCheck) return;
 
-  SILValue optionalError = gen.B.createLoad(
-      loc, errorSlot.getValue(), LoadOwnershipQualifier::Unqualified);
+  SILValue optionalError = gen.B.emitLoadValueOperation(
+      loc, errorSlot.forward(gen), LoadOwnershipQualifier::Take);
 
   ASTContext &ctx = gen.getASTContext();
 
   // Switch on the optional error.
   SILBasicBlock *errorBB = gen.createBasicBlock(FunctionSection::Postmatter);
+  errorBB->createBBArg(optionalError->getType().unwrapAnyOptionalType());
   SILBasicBlock *contBB = gen.createBasicBlock();
   gen.B.createSwitchEnum(loc, optionalError, /*default*/ nullptr,
                          { { ctx.getOptionalSomeDecl(), errorBB },
                            { ctx.getOptionalNoneDecl(), contBB } });
 
-  // Emit the error block.  Just be lazy and reload the error there.
-  gen.emitForeignErrorBlock(loc, errorBB, errorSlot);
+  // Emit the error block. Pass in none for the errorSlot since we have passed
+  // in the errorSlot as our BB argument so we can pass ownership correctly. In
+  // emitForeignErrorBlock, we will create the appropriate cleanup for the
+  // argument.
+  gen.emitForeignErrorBlock(loc, errorBB, None);
 
   // Return the result.
   gen.B.emitBlock(contBB);

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1155,7 +1155,11 @@ public:
   ManagedValue emitManagedRetain(SILLocation loc, SILValue v);
   ManagedValue emitManagedRetain(SILLocation loc, SILValue v,
                                  const TypeLowering &lowering);
-  
+
+  ManagedValue emitManagedLoadCopy(SILLocation loc, SILValue v);
+  ManagedValue emitManagedLoadCopy(SILLocation loc, SILValue v,
+                                   const TypeLowering &lowering);
+
   ManagedValue emitManagedRValueWithCleanup(SILValue v);
   ManagedValue emitManagedRValueWithCleanup(SILValue v,
                                             const TypeLowering &lowering);
@@ -1447,9 +1451,8 @@ public:
                                        SILValue foreignErrorSlot,
                                  const ForeignErrorConvention &foreignError);
 
-  void emitForeignErrorBlock(SILLocation loc,
-                             SILBasicBlock *errorBB,
-                             ManagedValue errorSlot);
+  void emitForeignErrorBlock(SILLocation loc, SILBasicBlock *errorBB,
+                             Optional<ManagedValue> errorSlot);
 
   void emitForeignErrorCheck(SILLocation loc,
                              SmallVectorImpl<ManagedValue> &directResults,

--- a/test/IRGen/constant_struct_with_padding.sil
+++ b/test/IRGen/constant_struct_with_padding.sil
@@ -1,4 +1,4 @@
-// RUN: %swift -module-name main %s -emit-ir -o - | %FileCheck %s
+// RUN: %swift -assume-parsing-unqualified-ownership-sil -module-name main %s -emit-ir -o - | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/IRGen/ownership_qualified_memopts.sil
+++ b/test/IRGen/ownership_qualified_memopts.sil
@@ -1,19 +1,7 @@
 // First parse this and then emit a *.sib. Then read in the *.sib, then recreate
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
 
 import Builtin
-
-// CHECK-LABEL: define {{.*}}void @unqualified_load
-// CHECK: load
-// CHECK-NOT: retain
-// CHECK-NOT: release
-// CHECK: ret void
-sil @unqualified_load : $@convention(thin) (@in Builtin.NativeObject) -> () {
-bb0(%0 : $*Builtin.NativeObject):
-  load %0 : $*Builtin.NativeObject
-  %1 = tuple()
-  return %1 : $()
-}
 
 // CHECK-LABEL: define {{.*}}void @take_load
 // CHECK-NOT: retain
@@ -48,20 +36,6 @@ bb0(%0 : $*Builtin.Int32):
   load [trivial] %0 : $*Builtin.Int32
   %1 = tuple()
   return %1 : $()
-}
-
-// CHECK-LABEL: define {{.*}}void @unqualified_store
-// CHECK-NOT: load
-// CHECK-NOT: release
-// CHECK: store
-// CHECK-NOT: load
-// CHECK-NOT: release
-// CHECK: ret void
-sil @unqualified_store : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
-bb0(%0 : $*Builtin.NativeObject, %1 : $Builtin.NativeObject):
-  store %1 to %0 : $*Builtin.NativeObject
-  %2 = tuple()
-  return %2 : $()
 }
 
 // CHECK-LABEL: define {{.*}}void @init_store

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir -assume-parsing-unqualified-ownership-sil -disable-objc-attr-requires-foundation-module | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/SIL/Parser/apply_with_conformance.sil
+++ b/test/SIL/Parser/apply_with_conformance.sil
@@ -28,7 +28,7 @@ bb0(%0 : $S, %1 : $X):
   // function_ref test.S.foo (test.S)<A : test.P>(A) -> ()
   %4 = function_ref @_TFV4test1S3foofS0_US_1P__FQ_T_ : $@convention(method) <τ_0_0 where τ_0_0 : P> (@in τ_0_0, S) -> () // user: %7
   %5 = alloc_stack $X                             // users: %6, %7, %8
-  store %1 to %5 : $*X                          // id: %6
+  store %1 to [trivial] %5 : $*X                          // id: %6
   %7 = apply %4<X>(%5, %0) : $@convention(method) <τ_0_0 where τ_0_0 : P> (@in τ_0_0, S) -> ()
   dealloc_stack %5 : $*X         // id: %8
   %9 = tuple ()                                   // user: %10

--- a/test/SIL/Parser/apply_with_substitution.sil
+++ b/test/SIL/Parser/apply_with_substitution.sil
@@ -11,7 +11,7 @@ sil @_TF4test3fooFT1fGSqFT_T___T_ : $@convention(thin) (@owned Optional<@callee_
 bb0(%0 : $Optional<@callee_owned (@in ()) -> @out ()>):
   %1 = alloc_box $@box Optional<@callee_owned (@in ()) -> @out ()>  // var f    // users: %2, %6, %32
   %1a = project_box %1 : $@box Optional<@callee_owned (@in ()) -> @out ()>, 0
-  store %0 to %1a : $*Optional<@callee_owned (@in ()) -> @out ()>         // id: %2
+  store %0 to [init] %1a : $*Optional<@callee_owned (@in ()) -> @out ()>         // id: %2
   %3 = alloc_stack $Optional<()>                  // users: %22, %28, %30, %31
   %4 = alloc_stack $()                            // users: %12, %22, %25
   %5 = alloc_stack $Optional<@callee_owned (@in ()) -> @out ()>            // users: %6, %8, %10, %11, %16, %24
@@ -25,7 +25,7 @@ bb2:                                              // Preds: bb0
   %15 = alloc_stack $@callee_owned (@in ()) -> @out () // users: %16, %17, %23
   // CHECK: apply %{{[0-9]+}}<() -> ()>(%{{[0-9]+}}, %{{[0-9]+}}) : $@convention(thin) <τ_0_0> (@in Optional<τ_0_0>) -> @out τ_0_0
   %16 = apply %14<() -> ()>(%15, %5) : $@convention(thin) <τ_0_0> (@in Optional<τ_0_0>) -> @out τ_0_0
-  %17 = load %15 : $*@callee_owned (@in ()) -> @out () // user: %19
+  %17 = load [take] %15 : $*@callee_owned (@in ()) -> @out () // user: %19
   %18 = function_ref @_TTRXFo_iT__iT__XFo__dT__ : $@convention(thin) (@owned @callee_owned (@in ()) -> @out ()) -> () // user: %19
   %19 = partial_apply %18(%17) : $@convention(thin) (@owned @callee_owned (@in ()) -> @out ()) -> () // user: %20
   %20 = apply %19() : $@callee_owned () -> ()
@@ -38,9 +38,9 @@ bb2:                                              // Preds: bb0
   br bb4                                          // id: %26
 
 bb4:                                              // Preds: bb2 bb3
-  %30 = load %3 : $*Optional<()>
+  %30 = load [trivial] %3 : $*Optional<()>
   dealloc_stack %3 : $*Optional<()> // id: %31
-  strong_release %1 : $@box Optional<@callee_owned (@in ()) -> @out ()>
+  destroy_value %1 : $@box Optional<@callee_owned (@in ()) -> @out ()>
   %33 = tuple ()                                  // user: %34
   return %33 : $()                                // id: %34
 }

--- a/test/SIL/Parser/array_roundtrip.swift
+++ b/test/SIL/Parser/array_roundtrip.swift
@@ -1,2 +1,2 @@
-// RUN: %target-swift-frontend %s -emit-sil -Ounchecked | %target-sil-opt
+// RUN: %target-swift-frontend %s -emit-sil -Ounchecked | %target-sil-opt -assume-parsing-unqualified-ownership-sil
 var W = [UInt32](repeating: 0, count: 16)

--- a/test/SIL/Parser/bound_generic.sil
+++ b/test/SIL/Parser/bound_generic.sil
@@ -11,7 +11,7 @@ sil @_TF9optional3fooFT1fGSqFT_T___T_ : $@convention(thin) (@owned Optional<@cal
 bb0(%0 : $Optional<@callee_owned (@in ()) -> (@out ())>):
   %1 = alloc_box $@box Optional<@callee_owned (@in ()) -> (@out ())>
   %1a = project_box %1 : $@box Optional<@callee_owned (@in ()) -> (@out ())>, 0
-  store %0 to %1a : $*Optional<@callee_owned (@in ()) -> (@out ())>
+  store %0 to [init] %1a : $*Optional<@callee_owned (@in ()) -> (@out ())>
   %3 = alloc_stack $Optional<()>
   %4 = alloc_stack $()
   %5 = alloc_stack $Optional<@callee_owned (@in ()) -> (@out ())>
@@ -35,9 +35,9 @@ bb3:
   br bb4
 
 bb4:
-  %30 = load %3 : $*Optional<()>
+  %30 = load [trivial] %3 : $*Optional<()>
   dealloc_stack %3 : $*Optional<()>
-  strong_release %1 : $@box Optional<@callee_owned (@in ()) -> (@out ())>
+  destroy_value %1 : $@box Optional<@callee_owned (@in ()) -> (@out ())>
   %33 = tuple ()
   return %33 : $()
 }

--- a/test/SIL/Parser/generics.sil
+++ b/test/SIL/Parser/generics.sil
@@ -68,15 +68,15 @@ bb0:
   %1 = mark_uninitialized [var] %0 : $*Builtin.Int64
   %2 = global_addr @f : $*@callee_owned (Builtin.Int32) -> ()
   %3 = function_ref @_TF16generic_closures24generic_curried_functionU___FT1xQ__FT1yQ0__T_ : $@convention(thin) <τ_0_0, τ_0_1> (@in τ_0_0) -> @owned @callee_owned (@in τ_0_1) -> ()
-  %4 = load %1 : $*Builtin.Int64
+  %4 = load [trivial] %1 : $*Builtin.Int64
   %5 = alloc_stack $Builtin.Int64
-  store %4 to %5 : $*Builtin.Int64
+  store %4 to [trivial] %5 : $*Builtin.Int64
   // CHECK: apply %{{[0-9]+}}<{{.*}}Int64, {{.*}}Int32>(%{{.*}}) : $@convention(thin) <τ_0_0, τ_0_1> (@in τ_0_0) -> @owned @callee_owned (@in τ_0_1) -> ()
   %7 = apply %3<Builtin.Int64, Builtin.Int32>(%5) : $@convention(thin) <τ_0_0, τ_0_1> (@in τ_0_0) -> @owned @callee_owned (@in τ_0_1) -> ()
   %8 = function_ref @_TTRXFo_iBi32__dT__XFo_dBi32__dT__ : $@convention(thin) (Builtin.Int32, @owned @callee_owned (@in Builtin.Int32) -> ()) -> ()
   // CHECK: partial_apply %{{[0-9]+}}(%{{[0-9]+}}) : $@convention(thin) (Builtin.Int32, @owned @callee_owned (@in Builtin.Int32) -> ()) -> ()
   %9 = partial_apply %8(%7) : $@convention(thin) (Builtin.Int32, @owned @callee_owned (@in Builtin.Int32) -> ()) -> ()
-  store %9 to %2 : $*@callee_owned (Builtin.Int32) -> ()
+  store %9 to [init] %2 : $*@callee_owned (Builtin.Int32) -> ()
   dealloc_stack %5 : $*Builtin.Int64
   %12 = tuple ()
   return %12 : $()

--- a/test/SIL/Parser/indirect_enum.sil
+++ b/test/SIL/Parser/indirect_enum.sil
@@ -38,7 +38,7 @@ entry(%e : $*TreeB<T>):
   %b = destroy_addr %a : $*T
 
   %c = unchecked_take_enum_data_addr %e : $*TreeB<T>, #TreeB.Branch!enumelt.1
-  %d = load %c : $*@box (left: TreeB<T>, right: TreeB<T>)
+  %d = load [take] %c : $*@box (left: TreeB<T>, right: TreeB<T>)
 
   return undef : $()
 }
@@ -46,7 +46,7 @@ entry(%e : $*TreeB<T>):
 sil @indirect_enum_case_loadable : $@convention(thin) (@owned TreeInt) -> () {
 entry(%e : $TreeInt):
   %a = unchecked_enum_data %e : $TreeInt, #TreeInt.Leaf!enumelt.1
-  store %a to undef : $*Int
+  store %a to [trivial] undef : $*Int
 
   %c = unchecked_enum_data %e : $TreeInt, #TreeInt.Branch!enumelt.1
   %d = project_box %c : $@box (left: TreeInt, right: TreeInt), 0

--- a/test/SIL/Parser/overloaded_member.sil
+++ b/test/SIL/Parser/overloaded_member.sil
@@ -22,20 +22,18 @@ bb0(%0 : $A, %1 : $X):
   %2a = project_box %2 : $@box X, 0
   %3 = alloc_box $@box A
   %3a = project_box %3 : $@box A, 0
-  store %0 to %3a : $*A
+  store %0 to [trivial] %3a : $*A
   %5 = mark_uninitialized [delegatingself] %1 : $X
-  store %5 to %2a : $*X
-  %7 = load %2a : $*X
-  strong_retain %7 : $X
+  store %5 to [init] %2a : $*X
+  %7 = load [copy] %2a : $*X
   // CHECK: class_method [volatile] %{{[0-9]+}} : $X, #X.init!initializer.1.foreign : (X.Type) -> (A, A) -> X , $@convention(objc_method) (A, A, @owned X) -> @owned X
   %9 = class_method [volatile] %7 : $X, #X.init!initializer.1.foreign : (X.Type) -> (A, A) -> X , $@convention(objc_method) (A, A, @owned X) -> @owned X
-  %10 = load %3a : $*A
-  %11 = load %3a : $*A
+  %10 = load [trivial] %3a : $*A
+  %11 = load [trivial] %3a : $*A
   %12 = apply %9(%10, %11, %7) : $@convention(objc_method) (A, A, @owned X) -> @owned X
   assign %12 to %2a : $*X
-  strong_release %3 : $@box A
-  %15 = load %2a : $*X
-  strong_retain %15 : $X
-  strong_release %2 : $@box X
+  destroy_value %3 : $@box A
+  %15 = load [copy] %2a : $*X
+  destroy_value %2 : $@box X
   return %15 : $X
 }

--- a/test/SIL/Parser/typed_boxes.sil
+++ b/test/SIL/Parser/typed_boxes.sil
@@ -9,8 +9,8 @@ entry(%x : $Int):
   %b = alloc_box $@box Int
   // CHECK: [[PB:%.*]] = project_box [[B]] : $@box Int, 0
   %ba = project_box %b : $@box Int, 0
-  // CHECK: store [[X:%.*]] to [[PB]] : $*Int
-  store %x to %ba : $*Int
+  // CHECK: store [[X:%.*]] to [trivial] [[PB]] : $*Int
+  store %x to [trivial] %ba : $*Int
   // CHECK: dealloc_box [[B]] : $@box Int
   dealloc_box %b : $@box Int
   return undef : $()

--- a/test/SIL/Parser/witness_protocol_from_import.sil
+++ b/test/SIL/Parser/witness_protocol_from_import.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-silgen | %FileCheck %s
+// RUN: %target-swift-frontend %s -assume-parsing-unqualified-ownership-sil -emit-silgen | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SIL/Serialization/borrow.sil
+++ b/test/SIL/Serialization/borrow.sil
@@ -1,9 +1,9 @@
 // First parse this and then emit a *.sib. Then read in the *.sib, then recreate
 // RUN: rm -rfv %t
 // RUN: mkdir %t
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s -emit-sib -o %t/tmp.sib -module-name borrow
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %t/tmp.sib -o %t/tmp.2.sib -module-name borrow
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %t/tmp.2.sib -module-name borrow | %FileCheck %s
+// RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name borrow
+// RUN: %target-sil-opt %t/tmp.sib -o %t/tmp.2.sib -module-name borrow
+// RUN: %target-sil-opt %t/tmp.2.sib -module-name borrow | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SIL/Serialization/clang_conformances.swift
+++ b/test/SIL/Serialization/clang_conformances.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/clang_conformances.sil -module-name clang_conformances -import-objc-header %S/Inputs/clang_conformances_helper.h
+// RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/clang_conformances.sil -module-name clang_conformances -import-objc-header %S/Inputs/clang_conformances_helper.h -assume-parsing-unqualified-ownership-sil
 // RUN: %target-swift-frontend -emit-sil -o %t -I %t -primary-file %s -module-name main -O
 
 // REQUIRES: objc_interop

--- a/test/SIL/Serialization/ownership_qualified_memopts.sil
+++ b/test/SIL/Serialization/ownership_qualified_memopts.sil
@@ -1,9 +1,9 @@
 // First parse this and then emit a *.sib. Then read in the *.sib, then recreate
 // RUN: rm -rfv %t
 // RUN: mkdir %t
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s -emit-sib -o %t/tmp.sib -module-name ownership_qualified_memopts
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %t/tmp.sib -o %t/tmp.2.sib -module-name ownership_qualified_memopts
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %t/tmp.2.sib -module-name ownership_qualified_memopts | %FileCheck %s
+// RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name ownership_qualified_memopts
+// RUN: %target-sil-opt %t/tmp.sib -o %t/tmp.2.sib -module-name ownership_qualified_memopts
+// RUN: %target-sil-opt %t/tmp.2.sib -module-name ownership_qualified_memopts | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SIL/Serialization/projection_lowered_type_parse.sil
+++ b/test/SIL/Serialization/projection_lowered_type_parse.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-module %s -module-name Swift -sil-serialize-all -module-link-name swiftCore -parse-as-library -parse-sil -parse-stdlib -o - | %target-sil-opt -assume-parsing-unqualified-ownership-sil -module-name=Swift
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-module %s -module-name Swift -sil-serialize-all -module-link-name swiftCore -parse-as-library -parse-sil -parse-stdlib -o - | %target-sil-opt -assume-parsing-unqualified-ownership-sil -module-name=Swift
 
 struct A {
   var f : () -> ()

--- a/test/SIL/Serialization/witness_tables.sil
+++ b/test/SIL/Serialization/witness_tables.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -parse-as-library -sil-serialize-all -module-name witness_tables -emit-module -o - %s | %target-sil-opt -assume-parsing-unqualified-ownership-sil -module-name witness_tables | %FileCheck %s
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -parse-as-library -sil-serialize-all -module-name witness_tables -emit-module -o - %s | %target-sil-opt -assume-parsing-unqualified-ownership-sil -module-name witness_tables | %FileCheck %s
 
 protocol AssocReqt {
   func requiredMethod()

--- a/test/SIL/printer_include_decls.swift
+++ b/test/SIL/printer_include_decls.swift
@@ -1,7 +1,7 @@
 // RUN: rm -f %t.*
 // RUN: %target-swift-frontend -emit-sil %s -o %t.sil
 // RUN: %FileCheck --input-file=%t.sil %s
-// RUN: %target-swift-frontend -emit-silgen %t.sil -module-name=printer_include_decl | %FileCheck %s
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-silgen %t.sil -module-name=printer_include_decl | %FileCheck %s
 
 var x: Int
 // CHECK: var x: Int

--- a/test/SILGen/accessors.swift
+++ b/test/SILGen/accessors.swift
@@ -41,7 +41,7 @@ func test0(_ ref: A) {
 // CHECK-NEXT: [[T0:%.*]] = class_method %0 : $A, #A.array!getter.1
 // CHECK-NEXT: [[T1:%.*]] = apply [[T0]](%0)
 // CHECK-NEXT: store [[T1]] to [init] [[TEMP]]
-// CHECK-NEXT: [[T0:%.*]] = load [[TEMP]]
+// CHECK-NEXT: [[T0:%.*]] = load [take] [[TEMP]]
 // CHECK-NEXT: // function_ref accessors.OrdinarySub.subscript.getter : (Swift.Int) -> Swift.Int
 // CHECK-NEXT: [[T1:%.*]] = function_ref @_TFV9accessors11OrdinarySubg9subscriptFSiSi
 // CHECK-NEXT: [[VALUE:%.*]] = apply [[T1]]([[INDEX1]], [[T0]])

--- a/test/SILGen/auto_generated_super_init_call.swift
+++ b/test/SILGen/auto_generated_super_init_call.swift
@@ -14,7 +14,7 @@ class SomeDerivedClass : Parent {
     y = 42
 // CHECK-LABEL: sil hidden @_TFC30auto_generated_super_init_call16SomeDerivedClassc{{.*}} : $@convention(method) (@owned SomeDerivedClass) -> @owned SomeDerivedClass
 // CHECK: integer_literal $Builtin.Int2048, 42
-// CHECK: [[SELFLOAD:%[0-9]+]] = load [[SELF:%[0-9]+]] : $*SomeDerivedClass
+// CHECK: [[SELFLOAD:%[0-9]+]] = load_borrow [[SELF:%[0-9]+]] : $*SomeDerivedClass
 // CHECK-NEXT: [[PARENT:%[0-9]+]] = upcast [[SELFLOAD]] : $SomeDerivedClass to $Parent
 // CHECK: [[INITCALL1:%[0-9]+]] = function_ref @_TFC30auto_generated_super_init_call6ParentcfT_S0_ : $@convention(method) (@owned Parent) -> @owned Parent
 // CHECK-NEXT: [[RES1:%[0-9]+]] = apply [[INITCALL1]]([[PARENT]])
@@ -40,16 +40,18 @@ class SomeDerivedClass : Parent {
     
 // CHECK-LABEL: sil hidden @_TFC30auto_generated_super_init_call16SomeDerivedClassc{{.*}} : $@convention(method) (Bool, @owned SomeDerivedClass) -> @owned SomeDerivedClass    
 // CHECK: bb4:
-// CHECK: [[SELFLOAD:%[0-9]+]] = load [[SELF:%[0-9]+]] : $*SomeDerivedClass
-// CHECK: function_ref @_TFC30auto_generated_super_init_call6ParentcfT_S0_ : $@convention(method) (@owned Parent) -> @owned Parent,
-// CHECK-NEXT: apply
-// CHECK-NEXT: unchecked_ref_cast
-// CHECK-NEXT: store
-// CHECK-NEXT: load
-// CHECK-NEXT: copy_value
-// CHECK-NEXT: destroy_value
-// CHECK-NEXT: return
+// SEMANTIC ARC TODO: Another case of needing a mutable load_borrow.
+// CHECK: [[SELFLOAD:%[0-9]+]] = load_borrow [[SELF:%[0-9]+]] : $*SomeDerivedClass
+// CHECK: [[SELFLOAD_PARENT_CAST:%.*]] = upcast [[SELFLOAD]]
+// CHECK: [[PARENT_INIT:%.*]] = function_ref @_TFC30auto_generated_super_init_call6ParentcfT_S0_ : $@convention(method) (@owned Parent) -> @owned Parent,
+// CHECK: [[PARENT:%.*]] = apply [[PARENT_INIT]]([[SELFLOAD_PARENT_CAST]])
+// CHECK: [[SELFAGAIN:%.*]] = unchecked_ref_cast [[PARENT]]
+// CHECK: store [[SELFAGAIN]] to [init] [[SELF]]
+// CHECK: [[SELFLOAD:%.*]] = load [copy] [[SELF]]
+// CHECK: destroy_value
+// CHECK: return [[SELFLOAD]]
   }
+// CHECK: } // end sil function '_TFC30auto_generated_super_init_call16SomeDerivedClassc{{.*}}'
 
   // One init has a call to super init. Make sure we don't insert more than one.
   init(b: Bool, i: Int) {

--- a/test/SILGen/boxed_existentials.swift
+++ b/test/SILGen/boxed_existentials.swift
@@ -49,7 +49,7 @@ func test_class_composition_erasure(_ x: HairClass & Error) -> Error {
 // CHECK:         [[NEW_EXISTENTIAL:%.*]] = alloc_existential_box $Error, $[[VALUE_TYPE]]
 // CHECK:         [[ADDR:%.*]] = project_existential_box $[[VALUE_TYPE]] in [[NEW_EXISTENTIAL]] : $Error
 // CHECK:         [[COPIED_VALUE:%.*]] = copy_value [[VALUE]]
-// CHECK:         store [[COPIED_VALUE]] to [[ADDR]]
+// CHECK:         store [[COPIED_VALUE]] to [init] [[ADDR]]
 // CHECK:         return [[NEW_EXISTENTIAL]]
 
 func test_property(_ x: Error) -> String {
@@ -78,9 +78,7 @@ func test_property_of_lvalue(_ x: Error) -> String {
 // CHECK:         [[PVAR:%.*]] = project_box [[VAR]]
 // CHECK:         [[ARG_COPY:%.*]] = copy_value [[ARG]] : $Error
 // CHECK:         store [[ARG_COPY]] to [init] [[PVAR]]
-// CHECK:         [[VALUE_BOX:%.*]] = load [[PVAR]]
-// CHECK:         [[VALUE_BOX_COPY:%.*]] = copy_value [[VALUE_BOX]]
-// ==> SEMANTIC ARC TODO: The next line should take VALUE_BOX_COPY, not VALUE_BOX
+// CHECK:         [[VALUE_BOX:%.*]] = load [copy] [[PVAR]]
 // CHECK:         [[VALUE:%.*]] = open_existential_box [[VALUE_BOX]] : $Error to $*[[VALUE_TYPE:@opened\(.*\) Error]]
 // CHECK:         [[COPY:%.*]] = alloc_stack $[[VALUE_TYPE]]
 // CHECK:         copy_addr [[VALUE]] to [initialization] [[COPY]]
@@ -88,13 +86,11 @@ func test_property_of_lvalue(_ x: Error) -> String {
 // CHECK:         [[RESULT:%.*]] = apply [[METHOD]]<[[VALUE_TYPE]]>([[COPY]])
 // CHECK:         destroy_addr [[COPY]]
 // CHECK:         dealloc_stack [[COPY]]
-// ==> SEMANTIC ARC TODO: The next line should take VALUE_BOX_COPY, not VALUE_BOX.
 // CHECK:         destroy_value [[VALUE_BOX]]
 // CHECK:         destroy_value [[VAR]]
 // CHECK:         destroy_value [[ARG]]
 // CHECK:         return [[RESULT]]
 // CHECK:      } // end sil function '_TF18boxed_existentials23test_property_of_lvalueFPs5Error_SS'
-
 extension Error {
   final func extensionMethod() { }
 }
@@ -140,9 +136,8 @@ func test_open_existential_semantics(_ guaranteed: Error,
   // GUARANTEED-NOT: destroy_value [[GUARANTEED]]
   guaranteed.extensionMethod()
 
-  // CHECK: [[IMMEDIATE:%.*]] = load [[PB]]
+  // CHECK: [[IMMEDIATE:%.*]] = load [copy] [[PB]]
   // -- need a copy_value to guarantee
-  // CHECK: copy_value [[IMMEDIATE]]
   // CHECK: [[VALUE:%.*]] = open_existential_box [[IMMEDIATE]]
   // CHECK: [[METHOD:%.*]] = function_ref
   // CHECK-NOT: copy_addr
@@ -152,9 +147,8 @@ func test_open_existential_semantics(_ guaranteed: Error,
   //    out.
   // CHECK: destroy_value [[IMMEDIATE]]
 
-  // GUARANTEED: [[IMMEDIATE:%.*]] = load [[PB]]
+  // GUARANTEED: [[IMMEDIATE:%.*]] = load [copy] [[PB]]
   // -- need a copy_value to guarantee
-  // GUARANTEED: copy_value [[IMMEDIATE]]
   // GUARANTEED: [[VALUE:%.*]] = open_existential_box [[IMMEDIATE]]
   // GUARANTEED: [[METHOD:%.*]] = function_ref
   // GUARANTEED: apply [[METHOD]]<{{.*}}>([[VALUE]])
@@ -195,8 +189,7 @@ func erasure_to_any(_ guaranteed: Error, _ immediate: Error) -> Any {
     // CHECK-NOT: destroy_value [[GUAR]]
     return guaranteed
   } else if true {
-    // CHECK:     [[IMMEDIATE:%.*]] = load [[PB]]
-    // CHECK:     copy_value [[IMMEDIATE]]
+    // CHECK:     [[IMMEDIATE:%.*]] = load [copy] [[PB]]
     // CHECK:     [[FROM_VALUE:%.*]] = open_existential_box [[IMMEDIATE]]
     // CHECK:     [[TO_VALUE:%.*]] = init_existential_addr [[OUT]]
     // CHECK:     copy_addr [[FROM_VALUE]] to [initialization] [[TO_VALUE]]

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -18,7 +18,7 @@ func foo(_ x: Builtin.Int1, y: Builtin.Int1) -> Builtin.Int1 {
 // CHECK-LABEL: sil hidden @_TF8builtins8load_pod
 func load_pod(_ x: Builtin.RawPointer) -> Builtin.Int64 {
   // CHECK: [[ADDR:%.*]] = pointer_to_address {{%.*}} to [strict] $*Builtin.Int64
-  // CHECK: [[VAL:%.*]] = load [[ADDR]]
+  // CHECK: [[VAL:%.*]] = load [trivial] [[ADDR]]
   // CHECK: return [[VAL]]
   return Builtin.load(x)
 }
@@ -26,8 +26,7 @@ func load_pod(_ x: Builtin.RawPointer) -> Builtin.Int64 {
 // CHECK-LABEL: sil hidden @_TF8builtins8load_obj
 func load_obj(_ x: Builtin.RawPointer) -> Builtin.NativeObject {
   // CHECK: [[ADDR:%.*]] = pointer_to_address {{%.*}} to [strict] $*Builtin.NativeObject
-  // CHECK: [[VAL:%.*]] = load [[ADDR]]
-  // CHECK: copy_value [[VAL]]
+  // CHECK: [[VAL:%.*]] = load [copy] [[ADDR]]
   // CHECK: return [[VAL]]
   return Builtin.load(x)
 }
@@ -35,7 +34,7 @@ func load_obj(_ x: Builtin.RawPointer) -> Builtin.NativeObject {
 // CHECK-LABEL: sil hidden @_TF8builtins12load_raw_pod
 func load_raw_pod(_ x: Builtin.RawPointer) -> Builtin.Int64 {
   // CHECK: [[ADDR:%.*]] = pointer_to_address {{%.*}} to $*Builtin.Int64
-  // CHECK: [[VAL:%.*]] = load [[ADDR]]
+  // CHECK: [[VAL:%.*]] = load [trivial] [[ADDR]]
   // CHECK: return [[VAL]]
   return Builtin.loadRaw(x)
 }
@@ -43,8 +42,7 @@ func load_raw_pod(_ x: Builtin.RawPointer) -> Builtin.Int64 {
 // CHECK-LABEL: sil hidden @_TF8builtins12load_raw_obj
 func load_raw_obj(_ x: Builtin.RawPointer) -> Builtin.NativeObject {
   // CHECK: [[ADDR:%.*]] = pointer_to_address {{%.*}} to $*Builtin.NativeObject
-  // CHECK: [[VAL:%.*]] = load [[ADDR]]
-  // CHECK: copy_value [[VAL]]
+  // CHECK: [[VAL:%.*]] = load [copy] [[ADDR]]
   // CHECK: return [[VAL]]
   return Builtin.loadRaw(x)
 }
@@ -59,7 +57,7 @@ func load_gen<T>(_ x: Builtin.RawPointer) -> T {
 // CHECK-LABEL: sil hidden @_TF8builtins8move_pod
 func move_pod(_ x: Builtin.RawPointer) -> Builtin.Int64 {
   // CHECK: [[ADDR:%.*]] = pointer_to_address {{%.*}} to [strict] $*Builtin.Int64
-  // CHECK: [[VAL:%.*]] = load [[ADDR]]
+  // CHECK: [[VAL:%.*]] = load [trivial] [[ADDR]]
   // CHECK: return [[VAL]]
   return Builtin.take(x)
 }
@@ -67,7 +65,7 @@ func move_pod(_ x: Builtin.RawPointer) -> Builtin.Int64 {
 // CHECK-LABEL: sil hidden @_TF8builtins8move_obj
 func move_obj(_ x: Builtin.RawPointer) -> Builtin.NativeObject {
   // CHECK: [[ADDR:%.*]] = pointer_to_address {{%.*}} to [strict] $*Builtin.NativeObject
-  // CHECK: [[VAL:%.*]] = load [[ADDR]]
+  // CHECK: [[VAL:%.*]] = load [take] [[ADDR]]
   // CHECK-NOT: copy_value [[VAL]]
   // CHECK: return [[VAL]]
   return Builtin.take(x)
@@ -559,7 +557,7 @@ func reinterpretAddrOnly<T, U>(_ t: T) -> U {
 // CHECK-LABEL: sil hidden @_TF8builtins28reinterpretAddrOnlyToTrivial
 func reinterpretAddrOnlyToTrivial<T>(_ t: T) -> Int {
   // CHECK: [[ADDR:%.*]] = unchecked_addr_cast [[INPUT:%.*]] : $*T to $*Int
-  // CHECK: [[VALUE:%.*]] = load [[ADDR]]
+  // CHECK: [[VALUE:%.*]] = load [trivial] [[ADDR]]
   // CHECK: destroy_addr [[INPUT]]
   return Builtin.reinterpretCast(t)
 }
@@ -572,7 +570,7 @@ func reinterpretAddrOnlyLoadable<T>(_ a: Int, _ b: T) -> (T, Int) {
   // CHECK: copy_addr [[RES1]] to [initialization]
   return (Builtin.reinterpretCast(a) as T,
   // CHECK: [[RES:%.*]] = unchecked_addr_cast {{%.*}} : $*T to $*Int
-  // CHECK: load [[RES]]
+  // CHECK: load [trivial] [[RES]]
           Builtin.reinterpretCast(b) as Int)
 }
 

--- a/test/SILGen/casts.swift
+++ b/test/SILGen/casts.swift
@@ -70,7 +70,7 @@ struct S : P {}
 // CHECK:   checked_cast_addr_br take_always P in [[COPY]] : $*P to S in [[TMP]] : $*S, bb1, bb2
 //   Success block.
 // CHECK: bb1:
-// CHECK:   [[T0:%.*]] = load [[TMP]] : $*S
+// CHECK:   [[T0:%.*]] = load [trivial] [[TMP]] : $*S
 // CHECK:   [[T1:%.*]] = enum $Optional<S>, #Optional.some!enumelt.1, [[T0]] : $S
 // CHECK:   dealloc_stack [[TMP]]
 // CHECK:   br bb3([[T1]] : $Optional<S>)

--- a/test/SILGen/cf_members.swift
+++ b/test/SILGen/cf_members.swift
@@ -18,7 +18,7 @@ public func importAsUnaryInit() {
 public func foo(_ x: Double) {
 // CHECK: bb0([[X:%.*]] : $Double):
   // CHECK: [[GLOBALVAR:%.*]] = global_addr @IAMStruct1GlobalVar
-  // CHECK: [[ZZ:%.*]] = load [[GLOBALVAR]]
+  // CHECK: [[ZZ:%.*]] = load [trivial] [[GLOBALVAR]]
   let zz = Struct1.globalVar
   // CHECK: assign [[ZZ]] to [[GLOBALVAR]]
   Struct1.globalVar = zz
@@ -53,13 +53,13 @@ public func foo(_ x: Double) {
   z.invert()
 
   // CHECK: [[FN:%.*]] = function_ref @IAMStruct1Rotate : $@convention(c) (@in Struct1, Double) -> Struct1
-  // CHECK: [[ZVAL:%.*]] = load [[Z]]
+  // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
   // CHECK: store [[ZVAL]] to [trivial] [[ZTMP:%.*]] :
   // CHECK: apply [[FN]]([[ZTMP]], [[X]])
   z = z.translate(radians: x)
 
   // CHECK: [[THUNK:%.*]] = function_ref [[THUNK_NAME:@_TTOFVSC7Struct19translateFT7radiansSd_S_]]
-  // CHECK: [[ZVAL:%.*]] = load [[Z]]
+  // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
   // CHECK: [[C:%.*]] = apply [[THUNK]]([[ZVAL]])
   // CHECK: [[C_COPY:%.*]] = copy_value [[C]]
   let c: (Double) -> Struct1 = z.translate(radians:)
@@ -78,12 +78,12 @@ public func foo(_ x: Double) {
   // z = e(z, x)
 
   // CHECK: [[FN:%.*]] = function_ref @IAMStruct1Scale
-  // CHECK: [[ZVAL:%.*]] = load [[Z]]
+  // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
   // CHECK: apply [[FN]]([[ZVAL]], [[X]])
   z = z.scale(x)
 
   // CHECK: [[THUNK:%.*]] = function_ref @_TTOFVSC7Struct15scaleFSdS_
-  // CHECK: [[ZVAL:%.*]] = load [[Z]]
+  // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
   // CHECK: [[F:%.*]] = apply [[THUNK]]([[ZVAL]])
   // CHECK: [[F_COPY:%.*]] = copy_value [[F]]
   let f = z.scale
@@ -92,7 +92,7 @@ public func foo(_ x: Double) {
   // CHECK: [[THUNK:%.*]] = function_ref @_TTOFVSC7Struct15scaleFSdS_
   // CHECK: thin_to_thick_function [[THUNK]]
   let g = Struct1.scale
-  // CHECK: [[ZVAL:%.*]] = load [[Z]]
+  // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
   z = g(z)(x)
 
   // TODO: If we implement SE-0042, this should directly reference the
@@ -100,17 +100,17 @@ public func foo(_ x: Double) {
   // let h: @convention(c) (Struct1, Double) -> Struct1 = Struct1.scale
   // z = h(z, x)
 
-  // CHECK: [[ZVAL:%.*]] = load [[Z]]
+  // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
   // CHECK: store [[ZVAL]] to [trivial] [[ZTMP:%.*]] :
   // CHECK: [[GET:%.*]] = function_ref @IAMStruct1GetRadius : $@convention(c) (@in Struct1) -> Double
   // CHECK: apply [[GET]]([[ZTMP]])
   _ = z.radius
-  // CHECK: [[ZVAL:%.*]] = load [[Z]]
+  // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
   // CHECK: [[SET:%.*]] = function_ref @IAMStruct1SetRadius : $@convention(c) (Struct1, Double) -> ()
   // CHECK: apply [[SET]]([[ZVAL]], [[X]])
   z.radius = x
 
-  // CHECK: [[ZVAL:%.*]] = load [[Z]]
+  // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
   // CHECK: [[GET:%.*]] = function_ref @IAMStruct1GetAltitude : $@convention(c) (Struct1) -> Double
   // CHECK: apply [[GET]]([[ZVAL]])
   _ = z.altitude
@@ -118,7 +118,7 @@ public func foo(_ x: Double) {
   // CHECK: apply [[SET]]([[Z]], [[X]])
   z.altitude = x
   
-  // CHECK: [[ZVAL:%.*]] = load [[Z]]
+  // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
   // CHECK: [[GET:%.*]] = function_ref @IAMStruct1GetMagnitude : $@convention(c) (Struct1) -> Double
   // CHECK: apply [[GET]]([[ZVAL]])
   _ = z.magnitude
@@ -165,7 +165,7 @@ public func foo(_ x: Double) {
   _ = makeMetatype().getOnlyProperty
 
   // CHECK: [[FN:%.*]] = function_ref @IAMStruct1SelfComesLast : $@convention(c) (Double, Struct1) -> ()
-  // CHECK: [[ZVAL:%.*]] = load [[Z]]
+  // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
   // CHECK: apply [[FN]]([[X]], [[ZVAL]])
   z.selfComesLast(x: x)
   let k: (Double) -> () = z.selfComesLast(x:)
@@ -178,7 +178,7 @@ public func foo(_ x: Double) {
   // m(z, x)
 
   // CHECK: [[FN:%.*]] = function_ref @IAMStruct1SelfComesThird : $@convention(c) (Int32, Float, Struct1, Double) -> ()
-  // CHECK: [[ZVAL:%.*]] = load [[Z]]
+  // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
   // CHECK: apply [[FN]]({{.*}}, {{.*}}, [[ZVAL]], [[X]])
   z.selfComesThird(a: y, b: 0, x: x)
   let n: (Int32, Float, Double) -> () = z.selfComesThird(a:b:x:)

--- a/test/SILGen/complete_object_init.swift
+++ b/test/SILGen/complete_object_init.swift
@@ -8,18 +8,17 @@ class A {
 // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $@box A
 // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
 // CHECK:   [[SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*A
-// CHECK:   store [[SELF_PARAM]] to [[SELF]] : $*A
-// CHECK:   [[SELFP:%[0-9]+]] = load [[SELF]] : $*A
+// CHECK:   store [[SELF_PARAM]] to [init] [[SELF]] : $*A
+// CHECK:   [[SELFP:%[0-9]+]] = load_borrow [[SELF]] : $*A
 // CHECK:   [[INIT:%[0-9]+]] = class_method [[SELFP]] : $A, #A.init!initializer.1 : (A.Type) -> (X) -> A , $@convention(method) (X, @owned A) -> @owned A
 // CHECK:   [[X_INIT:%[0-9]+]] = function_ref @_TFV20complete_object_init1XC{{.*}} : $@convention(method) (@thin X.Type) -> X
 // CHECK:   [[X_META:%[0-9]+]] = metatype $@thin X.Type
 // CHECK:   [[X:%[0-9]+]] = apply [[X_INIT]]([[X_META]]) : $@convention(method) (@thin X.Type) -> X
 // CHECK:   [[INIT_RESULT:%[0-9]+]] = apply [[INIT]]([[X]], [[SELFP]]) : $@convention(method) (X, @owned A) -> @owned A
 // CHECK:   store [[INIT_RESULT]] to [init] [[SELF]] : $*A
-// CHECK:   [[RESULT:%[0-9]+]] = load [[SELF]] : $*A
-// CHECK:   [[RESULT_COPY:%.*]] = copy_value [[RESULT]] : $A
+// CHECK:   [[RESULT:%[0-9]+]] = load [copy] [[SELF]] : $*A
 // CHECK:   destroy_value [[SELF_BOX]] : $@box A
-// CHECK:   return [[RESULT_COPY]] : $A
+// CHECK:   return [[RESULT]] : $A
 
   // CHECK-LABEL: sil hidden @_TFC20complete_object_init1AC{{.*}} : $@convention(method) (@thick A.Type) -> @owned A
   convenience init() {

--- a/test/SILGen/copy_lvalue_peepholes.swift
+++ b/test/SILGen/copy_lvalue_peepholes.swift
@@ -47,7 +47,7 @@ func init_var_from_computed_lvalue() {
 // CHECK-LABEL: sil hidden @_TF21copy_lvalue_peepholes27assign_computed_from_lvalue
 // CHECK:   [[Y:%.*]] = alloc_box
 // CHECK:   [[PBY:%.*]] = project_box [[Y]]
-// CHECK:   [[Y_VAL:%.*]] = load [[PBY]]
+// CHECK:   [[Y_VAL:%.*]] = load [trivial] [[PBY]]
 // CHECK:   [[SETTER:%.*]] = function_ref @_TF21copy_lvalue_peepholess8computedBi64_
 // CHECK:   apply [[SETTER]]([[Y_VAL]])
 func assign_computed_from_lvalue(y: Int) {

--- a/test/SILGen/decls.swift
+++ b/test/SILGen/decls.swift
@@ -66,7 +66,7 @@ func tuple_patterns() {
   // CHECK: [[PBI:%.*]] = project_box [[IADDR]]
   // CHECK-NOT: alloc_box $@box Float
   // CHECK: copy_addr [[AADDR]] to [initialization] [[PBI]]
-  // CHECK: [[B:%[0-9]+]] = load [[BADDR]]
+  // CHECK: [[B:%[0-9]+]] = load [trivial] [[BADDR]]
   // CHECK-NOT: store [[B]]
   var (i,_) = (a, b)
 
@@ -120,7 +120,7 @@ func load_from_global() -> Int {
   // CHECK: [[ACCESSOR:%[0-9]+]] = function_ref @_TF5declsau6globalSi
   // CHECK: [[PTR:%[0-9]+]] = apply [[ACCESSOR]]()
   // CHECK: [[ADDR:%[0-9]+]] = pointer_to_address [[PTR]]
-  // CHECK: [[VALUE:%[0-9]+]] = load [[ADDR]]
+  // CHECK: [[VALUE:%[0-9]+]] = load [trivial] [[ADDR]]
   // CHECK: return [[VALUE]]
 }
 

--- a/test/SILGen/default_constructor.swift
+++ b/test/SILGen/default_constructor.swift
@@ -67,18 +67,18 @@ class F : E { }
 // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box $@box F
 // CHECK-NEXT: project_box [[SELF_BOX]]
 // CHECK-NEXT: [[SELF:%[0-9]+]] = mark_uninitialized [derivedself]
-// CHECK-NEXT: store [[ORIGSELF]] to [[SELF]] : $*F
-// CHECK-NEXT: [[SELFP:%[0-9]+]] = load [[SELF]] : $*F
+// CHECK-NEXT: store [[ORIGSELF]] to [init] [[SELF]] : $*F
+// SEMANTIC ARC TODO: This is incorrect. Why are we doing a +0 produce and passing off to a +1 consumer. This should be a copy. Or a mutable borrow perhaps?
+// CHECK-NEXT: [[SELFP:%[0-9]+]] = load_borrow [[SELF]] : $*F
 // CHECK-NEXT: [[E:%[0-9]]] = upcast [[SELFP]] : $F to $E
 // CHECK: [[E_CTOR:%[0-9]+]] = function_ref @_TFC19default_constructor1EcfT_S0_ : $@convention(method) (@owned E) -> @owned E
 // CHECK-NEXT: [[ESELF:%[0-9]]] = apply [[E_CTOR]]([[E]]) : $@convention(method) (@owned E) -> @owned E
 
 // CHECK-NEXT: [[ESELFW:%[0-9]+]] = unchecked_ref_cast [[ESELF]] : $E to $F
 // CHECK-NEXT: store [[ESELFW]] to [init] [[SELF]] : $*F
-// CHECK-NEXT: [[SELFP:%[0-9]+]] = load [[SELF]] : $*F
-// CHECK-NEXT: [[SELFP_COPY:%.*]] = copy_value [[SELFP]] : $F
+// CHECK-NEXT: [[SELFP:%[0-9]+]] = load [copy] [[SELF]] : $*F
 // CHECK-NEXT: destroy_value [[SELF_BOX]] : $@box F
-// CHECK-NEXT: return [[SELFP_COPY]] : $F
+// CHECK-NEXT: return [[SELFP]] : $F
 
 
 // <rdar://problem/19780343> Default constructor for a struct with optional doesn't compile

--- a/test/SILGen/downcast_reabstraction.swift
+++ b/test/SILGen/downcast_reabstraction.swift
@@ -3,7 +3,7 @@
 // CHECK-LABEL: sil hidden @_TF22downcast_reabstraction19condFunctionFromAnyFP_T_ 
 // CHECK:         checked_cast_addr_br take_always Any in [[IN:%.*]] : $*Any to () -> () in [[OUT:%.*]] : $*@callee_owned (@in ()) -> @out (), [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
 // CHECK:       [[YES]]:
-// CHECK:         [[ORIG_VAL:%.*]] = load [[OUT]]
+// CHECK:         [[ORIG_VAL:%.*]] = load [take] [[OUT]]
 // CHECK:         [[REABSTRACT:%.*]] = function_ref @_TTRXFo_iT__iT__XFo___
 // CHECK:         [[SUBST_VAL:%.*]] = partial_apply [[REABSTRACT]]([[ORIG_VAL]])
 
@@ -15,7 +15,7 @@ func condFunctionFromAny(_ x: Any) {
 
 // CHECK-LABEL: sil hidden @_TF22downcast_reabstraction21uncondFunctionFromAnyFP_T_ : $@convention(thin) (@in Any) -> () {
 // CHECK:         unconditional_checked_cast_addr take_always Any in [[IN:%.*]] : $*Any to () -> () in [[OUT:%.*]] : $*@callee_owned (@in ()) -> @out ()
-// CHECK:         [[ORIG_VAL:%.*]] = load [[OUT]]
+// CHECK:         [[ORIG_VAL:%.*]] = load [take] [[OUT]]
 // CHECK:         [[REABSTRACT:%.*]] = function_ref @_TTRXFo_iT__iT__XFo___
 // CHECK:         [[SUBST_VAL:%.*]] = partial_apply [[REABSTRACT]]([[ORIG_VAL]])
 // CHECK:         apply [[SUBST_VAL]]()

--- a/test/SILGen/enum.swift
+++ b/test/SILGen/enum.swift
@@ -95,7 +95,7 @@ func AddressOnly_cases(_ s: S) {
   // CHECK-NEXT:  [[METATYPE:%.*]] = metatype $@thin AddressOnly.Type
   // CHECK-NEXT:  [[PHANTOM:%.*]] = alloc_stack $AddressOnly
   // CHECK-NEXT:  [[PAYLOAD:%.*]] = init_enum_data_addr [[PHANTOM]] : $*AddressOnly, #AddressOnly.phantom!enumelt.1
-  // CHECK-NEXT:  store %0 to [[PAYLOAD]]
+  // CHECK-NEXT:  store %0 to [trivial] [[PAYLOAD]]
   // CHECK-NEXT:  inject_enum_addr [[PHANTOM]] : $*AddressOnly, #AddressOnly.phantom!enumelt.1
   // CHECK-NEXT:  destroy_addr [[PHANTOM]]
   // CHECK-NEXT:  dealloc_stack [[PHANTOM]]

--- a/test/SILGen/enum_resilience.swift
+++ b/test/SILGen/enum_resilience.swift
@@ -17,7 +17,7 @@ import resilient_enum
 // CHECK-NEXT:    br bb6
 // CHECK:       bb3:
 // CHECK-NEXT:    [[INDIRECT_ADDR:%.*]] = unchecked_take_enum_data_addr [[BOX]]
-// CHECK-NEXT:    [[INDIRECT:%.*]] = load [[INDIRECT_ADDR]]
+// CHECK-NEXT:    [[INDIRECT:%.*]] = load [take] [[INDIRECT_ADDR]]
 // CHECK-NEXT:    [[PAYLOAD:%.*]] = project_box [[INDIRECT]]
 // CHECK-NEXT:    destroy_value [[INDIRECT]]
 // CHECK-NEXT:    dealloc_stack [[BOX]]

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -75,7 +75,7 @@ func dont_return<T>(_ argument: T) throws -> T {
 // CHECK-NEXT: [[RET_TEMP:%.*]] = alloc_stack $Cat
 // CHECK-NEXT: try_apply [[DR_FN]]<Cat>([[RET_TEMP]], [[ARG_TEMP]]) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> (@out τ_0_0, @error Error), normal [[DR_NORMAL:bb[0-9]+]], error [[DR_ERROR:bb[0-9]+]]
 // CHECK:    [[DR_NORMAL]]({{%.*}} : $()):
-// CHECK-NEXT: [[T0:%.*]] = load [[RET_TEMP]] : $*Cat
+// CHECK-NEXT: [[T0:%.*]] = load [take] [[RET_TEMP]] : $*Cat
 // CHECK-NEXT: dealloc_stack [[RET_TEMP]]
 // CHECK-NEXT: dealloc_stack [[ARG_TEMP]]
 // CHECK-NEXT: br [[RETURN:bb[0-9]+]]([[T0]] : $Cat)
@@ -93,7 +93,7 @@ func dont_return<T>(_ argument: T) throws -> T {
 
 //   Catch HomeworkError.
 // CHECK:    [[IS_HWE]]:
-// CHECK-NEXT: [[T0:%.*]] = load [[DEST_TEMP]] : $*HomeworkError
+// CHECK-NEXT: [[T0:%.*]] = load [take] [[DEST_TEMP]] : $*HomeworkError
 // CHECK-NEXT: switch_enum [[T0]] : $HomeworkError, case #HomeworkError.CatAteIt!enumelt.1: [[MATCH:bb[0-9]+]], default [[NO_MATCH:bb[0-9]+]]
 
 //   Catch HomeworkError.CatAteIt.
@@ -213,7 +213,7 @@ protocol Doomed {
 // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWV6errors12DoomedStructS_6DoomedS_FS1_5check{{.*}} : $@convention(witness_method) (@in_guaranteed DoomedStruct) -> @error Error
 // CHECK:      [[TEMP:%.*]] = alloc_stack $DoomedStruct
 // CHECK:      copy_addr %0 to [initialization] [[TEMP]]
-// CHECK:      [[SELF:%.*]] = load [[TEMP]] : $*DoomedStruct
+// CHECK:      [[SELF:%.*]] = load [trivial] [[TEMP]] : $*DoomedStruct
 // CHECK:      [[T0:%.*]] = function_ref @_TFV6errors12DoomedStruct5check{{.*}} : $@convention(method) (DoomedStruct) -> @error Error
 // CHECK-NEXT: try_apply [[T0]]([[SELF]])
 // CHECK:    bb1([[T0:%.*]] : $()):
@@ -231,7 +231,7 @@ struct DoomedStruct : Doomed {
 // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWC6errors11DoomedClassS_6DoomedS_FS1_5check{{.*}} : $@convention(witness_method) (@in_guaranteed DoomedClass) -> @error Error {
 // CHECK:      [[TEMP:%.*]] = alloc_stack $DoomedClass
 // CHECK:      copy_addr %0 to [initialization] [[TEMP]]
-// CHECK:      [[SELF:%.*]] = load [[TEMP]] : $*DoomedClass
+// CHECK:      [[SELF:%.*]] = load [take] [[TEMP]] : $*DoomedClass
 // CHECK:      [[T0:%.*]] = class_method [[SELF]] : $DoomedClass, #DoomedClass.check!1 : (DoomedClass) -> () throws -> () , $@convention(method) (@guaranteed DoomedClass) -> @error Error
 // CHECK-NEXT: try_apply [[T0]]([[SELF]])
 // CHECK:    bb1([[T0:%.*]] : $()):
@@ -251,7 +251,7 @@ class DoomedClass : Doomed {
 // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWV6errors11HappyStructS_6DoomedS_FS1_5check{{.*}} : $@convention(witness_method) (@in_guaranteed HappyStruct) -> @error Error
 // CHECK:      [[TEMP:%.*]] = alloc_stack $HappyStruct
 // CHECK:      copy_addr %0 to [initialization] [[TEMP]]
-// CHECK:      [[SELF:%.*]] = load [[TEMP]] : $*HappyStruct
+// CHECK:      [[SELF:%.*]] = load [trivial] [[TEMP]] : $*HappyStruct
 // CHECK:      [[T0:%.*]] = function_ref @_TFV6errors11HappyStruct5check{{.*}} : $@convention(method) (HappyStruct) -> ()
 // CHECK:      [[T1:%.*]] = apply [[T0]]([[SELF]])
 // CHECK:      [[T1:%.*]] = tuple ()
@@ -264,7 +264,7 @@ struct HappyStruct : Doomed {
 // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWC6errors10HappyClassS_6DoomedS_FS1_5check{{.*}} : $@convention(witness_method) (@in_guaranteed HappyClass) -> @error Error
 // CHECK:      [[TEMP:%.*]] = alloc_stack $HappyClass
 // CHECK:      copy_addr %0 to [initialization] [[TEMP]]
-// CHECK:      [[SELF:%.*]] = load [[TEMP]] : $*HappyClass
+// CHECK:      [[SELF:%.*]] = load [take] [[TEMP]] : $*HappyClass
 // CHECK:      [[T0:%.*]] = class_method [[SELF]] : $HappyClass, #HappyClass.check!1 : (HappyClass) -> () -> () , $@convention(method) (@guaranteed HappyClass) -> ()
 // CHECK:      [[T1:%.*]] = apply [[T0]]([[SELF]])
 // CHECK:      [[T1:%.*]] = tuple ()
@@ -285,7 +285,7 @@ func testThunk(_ fn: () throws -> Int) throws -> Int {
 // CHECK: bb0(%0 : $*Int, %1 : $@callee_owned () -> (Int, @error Error)):
 // CHECK:   try_apply %1()
 // CHECK: bb1([[T0:%.*]] : $Int):
-// CHECK:   store [[T0]] to %0 : $*Int
+// CHECK:   store [[T0]] to [trivial] %0 : $*Int
 // CHECK:   [[T0:%.*]] = tuple ()
 // CHECK:   return [[T0]]
 // CHECK: bb2([[T0:%.*]] : $Error):
@@ -481,11 +481,11 @@ class BaseThrowingInit : HasThrowingInit {
 // CHECK:      [[PB:%.*]] = project_box [[BOX]]
 // CHECK:      [[MARKED_BOX:%.*]] = mark_uninitialized [derivedself] [[PB]]
 //   Initialize subField.
-// CHECK:      [[T0:%.*]] = load [[MARKED_BOX]]
+// CHECK:      [[T0:%.*]] = load_borrow [[MARKED_BOX]]
 // CHECK-NEXT: [[T1:%.*]] = ref_element_addr [[T0]] : $BaseThrowingInit, #BaseThrowingInit.subField
 // CHECK-NEXT: assign %1 to [[T1]]
 //   Super delegation.
-// CHECK-NEXT: [[T0:%.*]] = load [[MARKED_BOX]]
+// CHECK-NEXT: [[T0:%.*]] = load_borrow [[MARKED_BOX]]
 // CHECK-NEXT: [[T2:%.*]] = upcast [[T0]] : $BaseThrowingInit to $HasThrowingInit
 // CHECK: [[T3:%[0-9]+]] = function_ref @_TFC6errors15HasThrowingInitcfzT5valueSi_S0_ : $@convention(method) (Int, @owned HasThrowingInit) -> (@owned HasThrowingInit, @error Error)
 // CHECK-NEXT: apply [[T3]](%0, [[T2]])
@@ -585,19 +585,16 @@ func supportStructure(_ b: inout Bridge, name: String) throws {
 // CHECK-NEXT: [[INDEX_COPY_1:%.*]] = copy_value [[ARG2]] : $String
 // CHECK-NEXT: [[INDEX_COPY_2:%.*]] = copy_value [[INDEX_COPY_1]] : $String
 // CHECK-NEXT: [[TEMP:%.*]] = alloc_stack $Pylon
-// CHECK-NEXT: [[BASE:%.*]] = load [[ARG1]] : $*Bridge
-// CHECK-NEXT: [[BASE_COPY:%.*]] = copy_value [[BASE]]
+// CHECK-NEXT: [[BASE:%.*]] = load [copy] [[ARG1]] : $*Bridge
 // CHECK-NEXT: // function_ref
 // CHECK-NEXT: [[GETTER:%.*]] = function_ref @_TFV6errors6Bridgeg9subscriptFSSVS_5Pylon :
-// ==> SEMANTIC ARC TODO: Next line [[BASE]] should be [[BASE_COPY]]
 // CHECK-NEXT: [[T0:%.*]] = apply [[GETTER]]([[INDEX_COPY_1]], [[BASE]])
-// ==> SEMANTIC ARC TODO: Next line [[BASE]] should be [[BASE_COPY]]
 // CHECK-NEXT: destroy_value [[BASE]]
 // CHECK-NEXT: store [[T0]] to [init] [[TEMP]]
 // CHECK-NEXT: try_apply [[SUPPORT]]([[TEMP]]) : {{.*}}, normal [[BB_NORMAL:bb[0-9]+]], error [[BB_ERROR:bb[0-9]+]]
 
 // CHECK:    [[BB_NORMAL]]
-// CHECK-NEXT: [[T0:%.*]] = load [[TEMP]]
+// CHECK-NEXT: [[T0:%.*]] = load [take] [[TEMP]]
 // CHECK-NEXT: // function_ref
 // CHECK-NEXT: [[SETTER:%.*]] = function_ref @_TFV6errors6Bridges9subscriptFSSVS_5Pylon :
 // CHECK-NEXT: apply [[SETTER]]([[T0]], [[INDEX_COPY_2]], [[ARG1]])
@@ -609,12 +606,10 @@ func supportStructure(_ b: inout Bridge, name: String) throws {
 //   We end up with ugly redundancy here because we don't want to
 //   consume things during cleanup emission.  It's questionable.
 // CHECK:    [[BB_ERROR]]([[ERROR:%.*]] : $Error):
-// CHECK-NEXT: [[T0:%.*]] = load [[TEMP]]
-// CHECK-NEXT: [[T0_COPY:%.*]] = copy_value [[T0]]
+// CHECK-NEXT: [[T0:%.*]] = load [copy] [[TEMP]]
 // CHECK-NEXT: [[INDEX_COPY_2_COPY:%.*]] = copy_value [[INDEX_COPY_2]]
 // CHECK-NEXT: // function_ref
 // CHECK-NEXT: [[SETTER:%.*]] = function_ref @_TFV6errors6Bridges9subscriptFSSVS_5Pylon :
-// ==> SEMANTIC ARC TODO: T0 on the next line should be T0_COPY
 // CHECK-NEXT: apply [[SETTER]]([[T0]], [[INDEX_COPY_2_COPY]], [[ARG1]])
 // CHECK-NEXT: destroy_addr [[TEMP]]
 // CHECK-NEXT: dealloc_stack [[TEMP]]

--- a/test/SILGen/expressions.swift
+++ b/test/SILGen/expressions.swift
@@ -220,7 +220,7 @@ func generic_member_ref<T>(_ x: Generic<T>) -> Int {
   // CHECK: bb0([[XADDR:%[0-9]+]] : $*Generic<T>):
   return x.mono_member
   // CHECK: [[MEMBER_ADDR:%[0-9]+]] = struct_element_addr {{.*}}, #Generic.mono_member
-  // CHECK: load [[MEMBER_ADDR]]
+  // CHECK: load [trivial] [[MEMBER_ADDR]]
 }
 
 // CHECK-LABEL: sil hidden @_TF11expressions24bound_generic_member_ref
@@ -229,7 +229,7 @@ func bound_generic_member_ref(_ x: Generic<UnicodeScalar>) -> Int {
   // CHECK: bb0([[XADDR:%[0-9]+]] : $Generic<UnicodeScalar>):
   return x.mono_member
   // CHECK: [[MEMBER_ADDR:%[0-9]+]] = struct_element_addr {{.*}}, #Generic.mono_member
-  // CHECK: load [[MEMBER_ADDR]]
+  // CHECK: load [trivial] [[MEMBER_ADDR]]
 }
 
 // CHECK-LABEL: sil hidden @_TF11expressions6coerce
@@ -449,21 +449,21 @@ func if_expr(_ a: Bool, b: Bool, x: Int, y: Int, z: Int) -> Int {
     : b
     ? y
     : z
-  // CHECK:   [[A:%[0-9]+]] = load [[PBA]]
+  // CHECK:   [[A:%[0-9]+]] = load [trivial] [[PBA]]
   // CHECK:   [[ACOND:%[0-9]+]] = apply {{.*}}([[A]])
   // CHECK:   cond_br [[ACOND]], [[IF_A:bb[0-9]+]], [[ELSE_A:bb[0-9]+]]
   // CHECK: [[IF_A]]:
-  // CHECK:   [[XVAL:%[0-9]+]] = load [[PBX]]
+  // CHECK:   [[XVAL:%[0-9]+]] = load [trivial] [[PBX]]
   // CHECK:   br [[CONT_A:bb[0-9]+]]([[XVAL]] : $Int)
   // CHECK: [[ELSE_A]]:
-  // CHECK:   [[B:%[0-9]+]] = load [[PBB]]
+  // CHECK:   [[B:%[0-9]+]] = load [trivial] [[PBB]]
   // CHECK:   [[BCOND:%[0-9]+]] = apply {{.*}}([[B]])
   // CHECK:   cond_br [[BCOND]], [[IF_B:bb[0-9]+]], [[ELSE_B:bb[0-9]+]]
   // CHECK: [[IF_B]]:
-  // CHECK:   [[YVAL:%[0-9]+]] = load [[PBY]]
+  // CHECK:   [[YVAL:%[0-9]+]] = load [trivial] [[PBY]]
   // CHECK:   br [[CONT_B:bb[0-9]+]]([[YVAL]] : $Int)
   // CHECK: [[ELSE_B]]:
-  // CHECK:   [[ZVAL:%[0-9]+]] = load [[PBZ]]
+  // CHECK:   [[ZVAL:%[0-9]+]] = load [trivial] [[PBZ]]
   // CHECK:   br [[CONT_B:bb[0-9]+]]([[ZVAL]] : $Int)
   // CHECK: [[CONT_B]]([[B_RES:%[0-9]+]] : $Int):
   // CHECK:   br [[CONT_A:bb[0-9]+]]([[B_RES]] : $Int)

--- a/test/SILGen/force_cast_chained_optional.swift
+++ b/test/SILGen/force_cast_chained_optional.swift
@@ -19,8 +19,10 @@ class D: C {}
 // CHECK:         br [[TRAP:bb[0-9]+]]
 // CHECK:       [[SOME_BAR]]:
 // CHECK:         [[PAYLOAD_ADDR:%.*]] = unchecked_take_enum_data_addr {{%.*}} : $*Optional<Bar>
-// CHECK:         [[BAR:%.*]] = load [[PAYLOAD_ADDR]]
-// CHECK:         class_method {{%.*}} : $Bar, #Bar.bas!getter.1 : (Bar) -> () -> C! , $@convention(method) (@guaranteed Bar) ->
+// CHECK:         [[BAR:%.*]] = load [copy] [[PAYLOAD_ADDR]]
+// CHECK:         [[METHOD:%.*]] = class_method [[BAR]] : $Bar, #Bar.bas!getter.1 : (Bar) -> () -> C! , $@convention(method) (@guaranteed Bar) ->
+// CHECK:         apply [[METHOD]]([[BAR]])
+// CHECK:         destroy_value [[BAR]]
 // CHECK:         unconditional_checked_cast {{%.*}} : $C to $D
 // CHECK:       [[TRAP]]:
 // CHECK:         unreachable

--- a/test/SILGen/function_conversion.swift
+++ b/test/SILGen/function_conversion.swift
@@ -360,9 +360,9 @@ func convFuncExistential(_ f1: @escaping (Any) -> (Int) -> Int) {
 // CHECK:         return
 
 // CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @_TTRXFo_dSi_dSi_XFo_iSi_iSi_ : $@convention(thin) (@in Int, @owned @callee_owned (Int) -> Int) -> @out Int
-// CHECK:         load %1 : $*Int
+// CHECK:         load [trivial] %1 : $*Int
 // CHECK-NEXT:    apply %2(%3)
-// CHECK-NEXT:    store {{.*}} to %0
+// CHECK-NEXT:    store {{.*}} to [trivial] %0
 // CHECK:         return
 
 // ==== Class-bound archetype upcast

--- a/test/SILGen/functions.swift
+++ b/test/SILGen/functions.swift
@@ -110,8 +110,8 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: [[KADDR:%.*]] = project_box [[KBOX]]
 
   // CHECK: [[FUNC:%[0-9]+]] = function_ref @_TF9functions19standalone_function{{.*}} : $@convention(thin) (Builtin.Int64, Builtin.Int64) -> Builtin.Int64
-  // CHECK: [[I:%[0-9]+]] = load [[IADDR]]
-  // CHECK: [[J:%[0-9]+]] = load [[JADDR]]
+  // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
+  // CHECK: [[J:%[0-9]+]] = load [trivial] [[JADDR]]
   // CHECK: apply [[FUNC]]([[I]], [[J]])
   standalone_function(i, j)
 
@@ -120,8 +120,8 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: [[ST_ADDR:%.*]] = alloc_box $@box SomeStruct
   // CHECK: [[CTOR:%.*]] = function_ref @_TFV9functions10SomeStructC{{.*}} : $@convention(method) (Builtin.Int64, Builtin.Int64, @thin SomeStruct.Type) -> SomeStruct
   // CHECK: [[METATYPE:%.*]] = metatype $@thin SomeStruct.Type
-  // CHECK: [[I:%.*]] = load [[IADDR]]
-  // CHECK: [[J:%.*]] = load [[JADDR]]
+  // CHECK: [[I:%.*]] = load [trivial] [[IADDR]]
+  // CHECK: [[J:%.*]] = load [trivial] [[JADDR]]
   // CHECK: apply [[CTOR]]([[I]], [[J]], [[METATYPE]]) : $@convention(method) (Builtin.Int64, Builtin.Int64, @thin SomeStruct.Type) -> SomeStruct
   var st = SomeStruct(x: i, y: j)
 
@@ -138,15 +138,16 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: [[CADDR:%.*]] = project_box [[CBOX]]
   // CHECK: [[FUNC:%[0-9]+]] = function_ref @_TFC9functions9SomeClassC{{.*}} : $@convention(method) (Builtin.Int64, Builtin.Int64, @thick SomeClass.Type) -> @owned SomeClass
   // CHECK: [[META:%[0-9]+]] = metatype $@thick SomeClass.Type
-  // CHECK: [[I:%[0-9]+]] = load [[IADDR]]
-  // CHECK: [[J:%[0-9]+]] = load [[JADDR]]
+  // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
+  // CHECK: [[J:%[0-9]+]] = load [trivial] [[JADDR]]
   // CHECK: [[C:%[0-9]+]] = apply [[FUNC]]([[I]], [[J]], [[META]])
   var c = SomeClass(x: i, y: j)
 
-  // CHECK: [[C:%[0-9]+]] = load [[CADDR]]
+  // CHECK: [[C:%[0-9]+]] = load [copy] [[CADDR]]
   // CHECK: [[METHOD:%[0-9]+]] = class_method [[C]] : {{.*}}, #SomeClass.method!1
-  // CHECK: [[I:%[0-9]+]] = load [[IADDR]]
+  // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
   // CHECK: apply [[METHOD]]([[I]], [[C]])
+  // CHECK: destroy_value [[C]]
   c.method(i)
 
   // -- Curry 'self' onto unapplied methods dispatched using class_method.
@@ -155,47 +156,53 @@ func calls(_ i:Int, j:Int, k:Int) {
   var cm1 = SomeClass.method(c)
   cm1(i)
 
-  // CHECK: [[C:%[0-9]+]] = load [[CADDR]]
+  // CHECK: [[C:%[0-9]+]] = load [copy] [[CADDR]]
   // CHECK: [[METHOD:%[0-9]+]] = class_method [[C]] : {{.*}}, #SomeClass.method!1
-  // CHECK: [[I:%[0-9]+]] = load [[IADDR]]
+  // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
   // CHECK: apply [[METHOD]]([[I]], [[C]])
+  // CHECK: destroy_value [[C]]
   SomeClass.method(c)(i)
 
   // -- Curry the Type onto static method argument lists.
   
-  // CHECK: [[C:%[0-9]+]] = load [[CADDR]]
-  // CHECK: [[METHOD:%[0-9]+]] = class_method [[META:%[0-9]+]] : {{.*}}, #SomeClass.static_method!1
-  // CHECK: [[I:%[0-9]+]] = load [[IADDR]]
+  // CHECK: [[C:%[0-9]+]] = load_borrow [[CADDR]]
+  // CHECK: [[META:%.*]] = value_metatype $@thick SomeClass.Type, [[C]]
+  // CHECK: [[METHOD:%[0-9]+]] = class_method [[META]] : {{.*}}, #SomeClass.static_method!1
+  // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
   // CHECK: apply [[METHOD]]([[I]], [[META]])
   type(of: c).static_method(i)
 
   // -- Curry property accesses.
 
   // -- FIXME: class_method-ify class getters.
-  // CHECK: [[C:%[0-9]+]] = load [[CADDR]]
+  // CHECK: [[C:%[0-9]+]] = load [copy] [[CADDR]]
   // CHECK: [[GETTER:%[0-9]+]] = class_method {{.*}} : $SomeClass, #SomeClass.someProperty!getter.1
   // CHECK: apply [[GETTER]]([[C]])
+  // CHECK: destroy_value [[C]]
   i = c.someProperty
 
-  // CHECK: [[C:%[0-9]+]] = load [[CADDR]]
-  // CHECK: [[I:%[0-9]+]] = load [[IADDR]]
+  // CHECK: [[C:%[0-9]+]] = load [copy] [[CADDR]]
+  // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
   // CHECK: [[SETTER:%[0-9]+]] = class_method [[C]] : $SomeClass, #SomeClass.someProperty!setter.1 : (SomeClass) -> (Builtin.Int64) -> ()
   // CHECK: apply [[SETTER]]([[I]], [[C]])
+  // CHECK: destroy_value [[C]]
   c.someProperty = i
 
-  // CHECK: [[C:%[0-9]+]] = load [[CADDR]]
-  // CHECK: [[J:%[0-9]+]] = load [[JADDR]]
-  // CHECK: [[K:%[0-9]+]] = load [[KADDR]]
+  // CHECK: [[C:%[0-9]+]] = load [copy] [[CADDR]]
+  // CHECK: [[J:%[0-9]+]] = load [trivial] [[JADDR]]
+  // CHECK: [[K:%[0-9]+]] = load [trivial] [[KADDR]]
   // CHECK: [[GETTER:%[0-9]+]] = class_method [[C]] : $SomeClass, #SomeClass.subscript!getter.1 : (SomeClass) -> (Builtin.Int64, Builtin.Int64) -> Builtin.Int64 , $@convention(method) (Builtin.Int64, Builtin.Int64, @guaranteed SomeClass) -> Builtin.Int64
   // CHECK: apply [[GETTER]]([[J]], [[K]], [[C]])
+  // CHECK: destroy_value [[C]]
   i = c[j, k]
 
-  // CHECK: [[C:%[0-9]+]] = load [[CADDR]]
-  // CHECK: [[I:%[0-9]+]] = load [[IADDR]]
-  // CHECK: [[J:%[0-9]+]] = load [[JADDR]]
-  // CHECK: [[K:%[0-9]+]] = load [[KADDR]]
+  // CHECK: [[C:%[0-9]+]] = load [copy] [[CADDR]]
+  // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
+  // CHECK: [[J:%[0-9]+]] = load [trivial] [[JADDR]]
+  // CHECK: [[K:%[0-9]+]] = load [trivial] [[KADDR]]
   // CHECK: [[SETTER:%[0-9]+]] = class_method [[C]] : $SomeClass, #SomeClass.subscript!setter.1 : (SomeClass) -> (Builtin.Int64, Builtin.Int64, Builtin.Int64) -> () , $@convention(method) (Builtin.Int64, Builtin.Int64, Builtin.Int64, @guaranteed SomeClass) -> ()
   // CHECK: apply [[SETTER]]([[K]], [[I]], [[J]], [[C]])
+  // CHECK: destroy_value [[C]]
   c[i, j] = k
 
   // -- Curry the projected concrete value in an existential (or its Type)
@@ -209,7 +216,7 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: copy_addr [[PADDR]] to [initialization] [[TEMP]]
   // CHECK: [[PVALUE:%[0-9]+]] = open_existential_addr [[TEMP]] : $*SomeProtocol to $*[[OPENED:@opened(.*) SomeProtocol]]
   // CHECK: [[PMETHOD:%[0-9]+]] = witness_method $[[OPENED]], #SomeProtocol.method!1
-  // CHECK: [[I:%[0-9]+]] = load [[IADDR]]
+  // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
   // CHECK: apply [[PMETHOD]]<[[OPENED]]>([[I]], [[PVALUE]])
   // CHECK: destroy_addr [[PVALUE]]
   // CHECK: deinit_existential_addr [[TEMP]]
@@ -218,13 +225,13 @@ func calls(_ i:Int, j:Int, k:Int) {
 
   // CHECK: [[PVALUE:%[0-9]+]] = open_existential_addr [[PADDR:%.*]] : $*SomeProtocol to $*[[OPENED:@opened(.*) SomeProtocol]]
   // CHECK: [[PMETHOD:%[0-9]+]] = witness_method $[[OPENED]], #SomeProtocol.method!1
-  // CHECK: [[I:%[0-9]+]] = load [[IADDR]]
+  // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
   // CHECK: apply [[PMETHOD]]<[[OPENED]]>([[I]], [[PVALUE]])
   var sp : SomeProtocol = ConformsToSomeProtocol()
   sp.method(i)
 
   // FIXME: [[PMETHOD:%[0-9]+]] = witness_method $[[OPENED:@opened(.*) SomeProtocol]], #SomeProtocol.static_method!1
-  // FIXME: [[I:%[0-9]+]] = load [[IADDR]]
+  // FIXME: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
   // FIXME: apply [[PMETHOD]]([[I]], [[PMETA]])
   // Needs existential metatypes
   //type(of: p).static_method(i)
@@ -238,25 +245,28 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: apply [[CTOR_GEN]]<Builtin.Int64>([[META]])
   var g = SomeGeneric<Builtin.Int64>()
 
-  // CHECK: [[G:%[0-9]+]] = load [[GADDR]]
+  // CHECK: [[G:%[0-9]+]] = load [copy] [[GADDR]]
   // CHECK: [[METHOD_GEN:%[0-9]+]] = class_method [[G]] : {{.*}}, #SomeGeneric.method!1
   // CHECK: [[TMPI:%.*]] = alloc_stack $Builtin.Int64
   // CHECK: [[TMPR:%.*]] = alloc_stack $Builtin.Int64
   // CHECK: apply [[METHOD_GEN]]<{{.*}}>([[TMPR]], [[TMPI]], [[G]])
+  // CHECK: destroy_value [[G]]
   g.method(i)
 
-  // CHECK: [[G:%[0-9]+]] = load [[GADDR]]
+  // CHECK: [[G:%[0-9]+]] = load [copy] [[GADDR]]
   // CHECK: [[METHOD_GEN:%[0-9]+]] = class_method [[G]] : {{.*}}, #SomeGeneric.generic!1
   // CHECK: [[TMPJ:%.*]] = alloc_stack $Builtin.Int64
   // CHECK: [[TMPR:%.*]] = alloc_stack $Builtin.Int64
   // CHECK: apply [[METHOD_GEN]]<{{.*}}>([[TMPR]], [[TMPJ]], [[G]])
+  // CHECK: destroy_value [[G]]
   g.generic(j)
 
-  // CHECK: [[C:%[0-9]+]] = load [[CADDR]]
+  // CHECK: [[C:%[0-9]+]] = load [copy] [[CADDR]]
   // CHECK: [[METHOD_GEN:%[0-9]+]] = class_method [[C]] : {{.*}}, #SomeClass.generic!1
   // CHECK: [[TMPK:%.*]] = alloc_stack $Builtin.Int64
   // CHECK: [[TMPR:%.*]] = alloc_stack $Builtin.Int64
   // CHECK: apply [[METHOD_GEN]]<{{.*}}>([[TMPR]], [[TMPK]], [[C]])
+  // CHECK: destroy_value [[C]]
   c.generic(k)
 
   // FIXME: curried generic entry points
@@ -278,25 +288,25 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: [[FUNC_THICK:%[0-9]+]] = thin_to_thick_function [[FUNC_THIN]]
   // CHECK: store [[FUNC_THICK]] to [init] [[FADDR]]
   var f = standalone_function
-  // CHECK: [[F:%[0-9]+]] = load [[FADDR]]
-  // CHECK: [[I:%[0-9]+]] = load [[IADDR]]
-  // CHECK: [[J:%[0-9]+]] = load [[JADDR]]
+  // CHECK: [[F:%[0-9]+]] = load [copy] [[FADDR]]
+  // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
+  // CHECK: [[J:%[0-9]+]] = load [trivial] [[JADDR]]
   // CHECK: apply [[F]]([[I]], [[J]])
   f(i, j)
 
   // CHECK: [[HOF:%[0-9]+]] = function_ref @_TF9functions21higher_order_function{{.*}} : $@convention(thin) {{.*}}
   // CHECK: [[FUNC_THIN:%[0-9]+]] = function_ref @_TF9functions19standalone_function{{.*}} : $@convention(thin) (Builtin.Int64, Builtin.Int64) -> Builtin.Int64
   // CHECK: [[FUNC_THICK:%[0-9]+]] = thin_to_thick_function [[FUNC_THIN]]
-  // CHECK: [[I:%[0-9]+]] = load [[IADDR]]
-  // CHECK: [[J:%[0-9]+]] = load [[JADDR]]
+  // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
+  // CHECK: [[J:%[0-9]+]] = load [trivial] [[JADDR]]
   // CHECK: apply [[HOF]]([[FUNC_THICK]], [[I]], [[J]])
   higher_order_function(standalone_function, i, j)
 
   // CHECK: [[HOF2:%[0-9]+]] = function_ref @_TF9functions22higher_order_function2{{.*}} : $@convention(thin) {{.*}}
   // CHECK: [[FUNC_THIN:%[0-9]+]] = function_ref @_TF9functions19standalone_function{{.*}} : $@convention(thin) (Builtin.Int64, Builtin.Int64) -> Builtin.Int64
   // CHECK: [[FUNC_THICK:%.*]] = thin_to_thick_function [[FUNC_THIN]]
-  // CHECK: [[I:%[0-9]+]] = load [[IADDR]]
-  // CHECK: [[J:%[0-9]+]] = load [[JADDR]]
+  // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
+  // CHECK: [[J:%[0-9]+]] = load [trivial] [[JADDR]]
   // CHECK: apply [[HOF2]]([[FUNC_THICK]], [[I]], [[J]])
   higher_order_function2(standalone_function, i, j)
 }

--- a/test/SILGen/generic_casts.swift
+++ b/test/SILGen/generic_casts.swift
@@ -41,7 +41,7 @@ func opaque_archetype_to_class_archetype
 <T:NotClassBound, U:ClassBound> (_ t:T) -> U {
   return t as! U
   // CHECK: unconditional_checked_cast_addr take_always T in {{%.*}} : $*T to U in [[DOWNCAST_ADDR:%.*]] : $*U
-  // CHECK: [[DOWNCAST:%.*]] = load [[DOWNCAST_ADDR]] : $*U
+  // CHECK: [[DOWNCAST:%.*]] = load [take] [[DOWNCAST_ADDR]] : $*U
   // CHECK: return [[DOWNCAST]] : $U
 }
 
@@ -58,7 +58,7 @@ func class_archetype_to_class_archetype
 <T:ClassBound, U:ClassBound>(_ t:T) -> U {
   return t as! U
   // CHECK: unconditional_checked_cast_addr {{.*}} T in {{%.*}} : $*T to U in [[DOWNCAST_ADDR:%.*]] : $*U
-  // CHECK: [[DOWNCAST:%.*]] = load [[DOWNCAST_ADDR]]
+  // CHECK: [[DOWNCAST:%.*]] = load [take] [[DOWNCAST_ADDR]]
   // CHECK: return [[DOWNCAST]] : $U
 }
 
@@ -89,7 +89,7 @@ func opaque_archetype_to_loadable_concrete
 <T:NotClassBound>(_ t:T) -> S {
   return t as! S
   // CHECK: unconditional_checked_cast_addr take_always T in {{%.*}} : $*T to S in [[DOWNCAST_ADDR:%.*]] : $*S
-  // CHECK: [[DOWNCAST:%.*]] = load [[DOWNCAST_ADDR]] : $*S
+  // CHECK: [[DOWNCAST:%.*]] = load [trivial] [[DOWNCAST_ADDR]] : $*S
   // CHECK: return [[DOWNCAST]] : $S
 }
 
@@ -141,7 +141,7 @@ func opaque_existential_to_class_archetype
 <T:ClassBound>(_ p:NotClassBound) -> T {
   return p as! T
   // CHECK: unconditional_checked_cast_addr take_always NotClassBound in {{%.*}} : $*NotClassBound to T in [[DOWNCAST_ADDR:%.*]] : $*T
-  // CHECK: [[DOWNCAST:%.*]] = load [[DOWNCAST_ADDR]] : $*T
+  // CHECK: [[DOWNCAST:%.*]] = load [take] [[DOWNCAST_ADDR]] : $*T
   // CHECK: return [[DOWNCAST]] : $T
 }
 
@@ -157,7 +157,7 @@ func class_existential_to_class_archetype
 <T:ClassBound>(_ p:ClassBound) -> T {
   return p as! T
   // CHECK: unconditional_checked_cast_addr {{.*}} ClassBound in {{%.*}} : $*ClassBound to T in [[DOWNCAST_ADDR:%.*]] : $*T
-  // CHECK: [[DOWNCAST:%.*]] = load [[DOWNCAST_ADDR]]
+  // CHECK: [[DOWNCAST:%.*]] = load [take] [[DOWNCAST_ADDR]]
   // CHECK: return [[DOWNCAST]] : $T
 }
 
@@ -185,7 +185,7 @@ func opaque_existential_is_addr_only_concrete(_ p: NotClassBound) -> Bool {
 func opaque_existential_to_loadable_concrete(_ p: NotClassBound) -> S {
   return p as! S
   // CHECK:   unconditional_checked_cast_addr take_always NotClassBound in {{%.*}} : $*NotClassBound to S in [[DOWNCAST_ADDR:%.*]] : $*S
-  // CHECK: [[DOWNCAST:%.*]] = load [[DOWNCAST_ADDR]] : $*S
+  // CHECK: [[DOWNCAST:%.*]] = load [trivial] [[DOWNCAST_ADDR]] : $*S
   // CHECK: return [[DOWNCAST]] : $S
 }
 

--- a/test/SILGen/guaranteed_self.swift
+++ b/test/SILGen/guaranteed_self.swift
@@ -103,7 +103,7 @@ struct S: Fooable {
 // CHECK:       bb0({{.*}} [[SELF_ADDR:%.*]] : $*S):
 // CHECK:         [[SELF_COPY:%.*]] = alloc_stack $S
 // CHECK:         copy_addr [[SELF_ADDR]] to [initialization] [[SELF_COPY]]
-// CHECK:         [[SELF:%.*]] = load [[SELF_COPY]]
+// CHECK:         [[SELF:%.*]] = load [take] [[SELF_COPY]]
 // CHECK:         destroy_value [[SELF]]
 // CHECK-NOT:     destroy_value [[SELF]]
 // CHECK-NOT:     destroy_addr [[SELF_COPY]]
@@ -119,8 +119,7 @@ struct S: Fooable {
 // in the implementation
 // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWV15guaranteed_self1SS_7FooableS_FS1_3bas{{.*}} : $@convention(witness_method) (@inout S) -> ()
 // CHECK:       bb0([[SELF_ADDR:%.*]] : $*S):
-// CHECK:         [[SELF:%.*]] = load [[SELF_ADDR]]
-// CHECK:         copy_value [[SELF]]
+// CHECK:         [[SELF:%.*]] = load [copy] [[SELF_ADDR]]
 // CHECK:         destroy_value [[SELF]]
 // CHECK-NOT:     destroy_value [[SELF]]
 
@@ -129,7 +128,7 @@ struct S: Fooable {
 // CHECK:       bb0([[SELF_ADDR:%.*]] : $*S):
 // CHECK:         [[SELF_COPY:%.*]] = alloc_stack $S
 // CHECK:         copy_addr [[SELF_ADDR]] to [initialization] [[SELF_COPY]]
-// CHECK:         [[SELF:%.*]] = load [[SELF_COPY]]
+// CHECK:         [[SELF:%.*]] = load [take] [[SELF_COPY]]
 // CHECK:         destroy_value [[SELF]]
 // CHECK-NOT:     destroy_value [[SELF]]
 // CHECK-NOT:     destroy_addr [[SELF_COPY]]
@@ -150,7 +149,7 @@ struct S: Fooable {
 // CHECK:       bb0([[SELF_ADDR:%.*]] : $*S):
 // CHECK:         [[SELF_COPY:%.*]] = alloc_stack $S
 // CHECK:         copy_addr [[SELF_ADDR]] to [initialization] [[SELF_COPY]]
-// CHECK:         [[SELF:%.*]] = load [[SELF_COPY]]
+// CHECK:         [[SELF:%.*]] = load [take] [[SELF_COPY]]
 // CHECK:         destroy_value [[SELF]]
 // CHECK-NOT:     destroy_value [[SELF]]
 // CHECK-NOT:     destroy_addr [[SELF_COPY]]
@@ -171,7 +170,7 @@ struct S: Fooable {
 // CHECK:       bb0([[SELF_ADDR:%.*]] : $*S):
 // CHECK:         [[SELF_COPY:%.*]] = alloc_stack $S
 // CHECK:         copy_addr [[SELF_ADDR]] to [initialization] [[SELF_COPY]]
-// CHECK:         [[SELF:%.*]] = load [[SELF_COPY]]
+// CHECK:         [[SELF:%.*]] = load [take] [[SELF_COPY]]
 // CHECK:         destroy_value [[SELF]]
 // CHECK-NOT:     destroy_value [[SELF]]
 // CHECK-NOT:     destroy_addr [[SELF_COPY]]
@@ -182,7 +181,7 @@ struct S: Fooable {
 // CHECK:       bb0({{.*}} [[SELF_ADDR:%.*]] : $*S):
 // CHECK:         [[SELF_COPY:%.*]] = alloc_stack $S
 // CHECK:         copy_addr [[SELF_ADDR]] to [initialization] [[SELF_COPY]]
-// CHECK:         [[SELF:%.*]] = load [[SELF_COPY]]
+// CHECK:         [[SELF:%.*]] = load [take] [[SELF_COPY]]
 // CHECK:         destroy_value [[SELF]]
 // CHECK-NOT:     destroy_value [[SELF]]
 // CHECK-NOT:     destroy_addr [[SELF_COPY]]
@@ -191,8 +190,7 @@ struct S: Fooable {
 // Witness thunk for prop3 nonmutating materializeForSet
 // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWV15guaranteed_self1SS_7FooableS_FS1_m5prop3Si : $@convention(witness_method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout S) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>)
 // CHECK:       bb0({{.*}} [[SELF_ADDR:%.*]] : $*S):
-// CHECK:         [[SELF:%.*]] = load [[SELF_ADDR]]
-// CHECK:         copy_value [[SELF]]
+// CHECK:         [[SELF:%.*]] = load [copy] [[SELF_ADDR]]
 // CHECK:         destroy_value [[SELF]]
 // CHECK-NOT:     destroy_value [[SELF]]
 // CHECK:       }
@@ -364,9 +362,9 @@ class D: C {
   // CHECK:         [[SELF_BOX:%.*]] = alloc_box $@box D
   // CHECK-NEXT:    [[PB:%.*]] = project_box [[SELF_BOX]]
   // CHECK-NEXT:    [[SELF_ADDR:%.*]] = mark_uninitialized [derivedself] [[PB]]
-  // CHECK-NEXT:    store [[SELF]] to [[SELF_ADDR]]
+  // CHECK-NEXT:    store [[SELF]] to [init] [[SELF_ADDR]]
   // CHECK-NOT:     [[SELF_ADDR]]
-  // CHECK:         [[SELF1:%.*]] = load [[SELF_ADDR]]
+  // CHECK:         [[SELF1:%.*]] = load_borrow [[SELF_ADDR]]
   // CHECK-NEXT:    [[SUPER1:%.*]] = upcast [[SELF1]]
   // CHECK-NOT:     [[SELF_ADDR]]
   // CHECK:         [[SUPER2:%.*]] = apply {{.*}}([[SUPER1]])
@@ -377,10 +375,9 @@ class D: C {
   // CHECK-NOT:     [[SUPER1]]
   // CHECK-NOT:     [[SELF2]]
   // CHECK-NOT:     [[SUPER2]]
-  // CHECK:         [[SELF_FINAL:%.*]] = load [[SELF_ADDR]]
-  // CHECK-NEXT:    [[SELF_FINAL_COPY:%.*]] = copy_value [[SELF_FINAL]]
+  // CHECK:         [[SELF_FINAL:%.*]] = load [copy] [[SELF_ADDR]]
   // CHECK-NEXT:    destroy_value [[SELF_BOX]]
-  // CHECK-NEXT:    return [[SELF_FINAL_COPY]]
+  // CHECK-NEXT:    return [[SELF_FINAL]]
   required init() {
     super.init()
   }
@@ -414,7 +411,7 @@ func AO_curryThunk<T>(_ ao: AO<T>) -> ((AO<T>) -> (Int) -> ()/*, Int -> ()*/) {
 // CHECK: bb0([[ARG0_PTR:%.*]] : $*FakeElement, [[ARG1_PTR:%.*]] : $*FakeArray):
 // CHECK: [[GUARANTEED_COPY_STACK_SLOT:%.*]] = alloc_stack $FakeArray
 // CHECK: copy_addr [[ARG1_PTR]] to [initialization] [[GUARANTEED_COPY_STACK_SLOT]]
-// CHECK: [[ARG0:%.*]] = load [[ARG0_PTR]]
+// CHECK: [[ARG0:%.*]] = load [trivial] [[ARG0_PTR]]
 // CHECK: function_ref (extension in guaranteed_self):guaranteed_self.SequenceDefaults._constrainElement
 // CHECK: [[FUN:%.*]] = function_ref @_{{.*}}
 // CHECK: apply [[FUN]]<FakeArray>([[ARG0]], [[GUARANTEED_COPY_STACK_SLOT]])
@@ -475,24 +472,21 @@ class LetFieldClass {
   // CHECK-LABEL: sil hidden @_TFC15guaranteed_self13LetFieldClass10letkMethod{{.*}} : $@convention(method) (@guaranteed LetFieldClass) -> () {
   // CHECK: bb0([[CLS:%.*]] : $LetFieldClass):
   // CHECK: [[KRAKEN_ADDR:%.*]] = ref_element_addr [[CLS]] : $LetFieldClass, #LetFieldClass.letk
-  // CHECK-NEXT: [[KRAKEN:%.*]] = load [[KRAKEN_ADDR]]
+  // CHECK-NEXT: [[KRAKEN:%.*]] = load_borrow [[KRAKEN_ADDR]]
   // CHECK-NEXT: [[KRAKEN_METH:%.*]] = class_method [[KRAKEN]]
   // CHECK-NEXT: apply [[KRAKEN_METH]]([[KRAKEN]])
   // CHECK-NEXT: [[KRAKEN_ADDR:%.*]] = ref_element_addr [[CLS]] : $LetFieldClass, #LetFieldClass.letk
-  // CHECK-NEXT: [[KRAKEN:%.*]] = load [[KRAKEN_ADDR]]
-  // CHECK-NEXT: copy_value [[KRAKEN]]
+  // CHECK-NEXT: [[KRAKEN:%.*]] = load [copy] [[KRAKEN_ADDR]]
   // CHECK: [[DESTROY_SHIP_FUN:%.*]] = function_ref @_TF15guaranteed_self11destroyShipFCS_6KrakenT_ : $@convention(thin) (@owned Kraken) -> ()
   // CHECK-NEXT: [[KRAKEN_COPY:%.*]] = copy_value [[KRAKEN]]
   // CHECK-NEXT: apply [[DESTROY_SHIP_FUN]]([[KRAKEN_COPY]])
   // CHECK-NEXT: [[KRAKEN_BOX:%.*]] = alloc_box $@box Kraken
   // CHECK-NEXT: [[PB:%.*]] = project_box [[KRAKEN_BOX]]
   // CHECK-NEXT: [[KRAKEN_ADDR:%.*]] = ref_element_addr [[CLS]] : $LetFieldClass, #LetFieldClass.letk
-  // CHECK-NEXT: [[KRAKEN2:%.*]] = load [[KRAKEN_ADDR]]
-  // CHECK-NEXT: copy_value [[KRAKEN2]]
+  // CHECK-NEXT: [[KRAKEN2:%.*]] = load [copy] [[KRAKEN_ADDR]]
   // CHECK-NEXT: store [[KRAKEN2]] to [init] [[PB]]
   // CHECK: [[DESTROY_SHIP_FUN:%.*]] = function_ref @_TF15guaranteed_self11destroyShipFCS_6KrakenT_ : $@convention(thin) (@owned Kraken) -> ()
-  // CHECK-NEXT: [[KRAKEN_COPY:%.*]] = load [[PB]]
-  // CHECK-NEXT: copy_value [[KRAKEN_COPY]]
+  // CHECK-NEXT: [[KRAKEN_COPY:%.*]] = load [copy] [[PB]]
   // CHECK-NEXT: apply [[DESTROY_SHIP_FUN]]([[KRAKEN_COPY]])
   // CHECK-NEXT: destroy_value [[KRAKEN_BOX]]
   // CHECK-NEXT: destroy_value [[KRAKEN]]
@@ -524,8 +518,7 @@ class LetFieldClass {
   // CHECK-NEXT: [[KRAKEN2:%.*]] = apply [[KRAKEN_GETTER_FUN]]([[CLS]])
   // CHECK-NEXT: store [[KRAKEN2]] to [init] [[PB]]
   // CHECK: [[DESTROY_SHIP_FUN:%.*]] = function_ref @_TF15guaranteed_self11destroyShipFCS_6KrakenT_ : $@convention(thin) (@owned Kraken) -> ()
-  // CHECK-NEXT: [[KRAKEN_COPY:%.*]] = load [[PB]]
-  // CHECK-NEXT: copy_value [[KRAKEN_COPY]]
+  // CHECK-NEXT: [[KRAKEN_COPY:%.*]] = load [copy] [[PB]]
   // CHECK-NEXT: apply [[DESTROY_SHIP_FUN]]([[KRAKEN_COPY]])
   // CHECK-NEXT: destroy_value [[KRAKEN_BOX]]
   // CHECK-NEXT: destroy_value [[KRAKEN]]

--- a/test/SILGen/implicitly_unwrapped_optional.swift
+++ b/test/SILGen/implicitly_unwrapped_optional.swift
@@ -14,12 +14,10 @@ func foo(f f: (() -> ())!) {
 // CHECK:   cond_br [[T1]], bb1, bb3
 //   If it does, project and load the value out of the implicitly unwrapped
 //   optional...
-// CHECK: bb1:
-// CHECK:   [[FN0_ADDR:%.*]] = unchecked_take_enum_data_addr [[PF]]
-// CHECK:   [[FN0:%.*]] = load [[FN0_ADDR]]
+// CHECK:    bb1:
+// CHECK-NEXT: [[FN0_ADDR:%.*]] = unchecked_take_enum_data_addr [[PF]]
+// CHECK-NEXT: [[FN0:%.*]] = load [copy] [[FN0_ADDR]]
 //   .... then call it
-// CHECK:   [[FN0_COPY:%.*]] = copy_value [[FN0]]
-// SEMANTIC ARC TODO: On the next line, we should be calling FN0_COPY, not FN0
 // CHECK:   apply [[FN0]]() : $@callee_owned () -> ()
 // CHECK:   br bb2
 // CHECK: bb2(

--- a/test/SILGen/import_as_member.swift
+++ b/test/SILGen/import_as_member.swift
@@ -8,7 +8,7 @@ public func returnGlobalVar() -> Double {
 }
 // SIL-LABEL: sil {{.*}}returnGlobalVar{{.*}} () -> Double {
 // SIL:   %0 = global_addr @IAMStruct1GlobalVar : $*Double
-// SIL:   %2 = load %0 : $*Double
+// SIL:   %2 = load [trivial] %0 : $*Double
 // SIL:   return %2 : $Double
 // SIL-NEXT: }
 

--- a/test/SILGen/indirect_enum.swift
+++ b/test/SILGen/indirect_enum.swift
@@ -94,7 +94,7 @@ func TreeB_cases<T>(_ t: T, l: TreeB<T>, r: TreeB<T>) {
 // CHECK-NEXT:    copy_addr %2 to [initialization] [[RIGHT]] : $*TreeB<T>
 // CHECK-NEXT:    [[BRANCH:%.*]] = alloc_stack $TreeB<T>
 // CHECK-NEXT:    [[PAYLOAD:%.*]] = init_enum_data_addr [[BRANCH]]
-// CHECK-NEXT:    store [[BOX]] to [[PAYLOAD]]
+// CHECK-NEXT:    store [[BOX]] to [init] [[PAYLOAD]]
 // CHECK-NEXT:    inject_enum_addr [[BRANCH]] : $*TreeB<T>, #TreeB.Branch!enumelt.1
 // CHECK-NEXT:    destroy_addr [[BRANCH]]
 // CHECK-NEXT:    dealloc_stack [[BRANCH]]
@@ -183,7 +183,7 @@ func switchTreeA<T>(_ x: TreeA<T>) {
 
   // CHECK:     [[BRANCH_CASE]]([[NODE_BOX:%.*]] : $@box (left: TreeA<T>, right: TreeA<T>)):
   // CHECK:       [[TUPLE_ADDR:%.*]] = project_box [[NODE_BOX]]
-  // CHECK:       [[TUPLE:%.*]] = load [[TUPLE_ADDR]]
+  // CHECK:       [[TUPLE:%.*]] = load_borrow [[TUPLE_ADDR]]
   // CHECK:       [[LEFT:%.*]] = tuple_extract [[TUPLE]] {{.*}}, 0
   // CHECK:       [[RIGHT:%.*]] = tuple_extract [[TUPLE]] {{.*}}, 1
   // CHECK:       switch_enum [[RIGHT]] : $TreeA<T>,
@@ -259,7 +259,7 @@ func switchTreeB<T>(_ x: TreeB<T>) {
   // CHECK:       copy_addr [[SCRATCH]] to [initialization] [[TREE_COPY:%.*]] :
   // CHECK:       [[TREE_ADDR:%.*]] = unchecked_take_enum_data_addr [[TREE_COPY]]
   // --           box +1 immutable
-  // CHECK:       [[BOX:%.*]] = load [[TREE_ADDR]]
+  // CHECK:       [[BOX:%.*]] = load [take] [[TREE_ADDR]]
   // CHECK:       [[TUPLE:%.*]] = project_box [[BOX]]
   // CHECK:       [[LEFT:%.*]] = tuple_element_addr [[TUPLE]]
   // CHECK:       [[RIGHT:%.*]] = tuple_element_addr [[TUPLE]]
@@ -351,7 +351,7 @@ func guardTreeA<T>(_ tree: TreeA<T>) {
     // CHECK:   destroy_value [[ARG_COPY]]
     // CHECK: [[YES]]([[BOX:%.*]] : $@box (left: TreeA<T>, right: TreeA<T>)):
     // CHECK:   [[VALUE_ADDR:%.*]] = project_box [[BOX]]
-    // CHECK:   [[TUPLE:%.*]] = load [[VALUE_ADDR]]
+    // CHECK:   [[TUPLE:%.*]] = load [take] [[VALUE_ADDR]]
     // CHECK:   [[TUPLE_COPY:%.*]] = copy_value [[TUPLE]]
     // CHECK:   [[L:%.*]] = tuple_extract [[TUPLE_COPY]]
     // CHECK:   [[R:%.*]] = tuple_extract [[TUPLE_COPY]]
@@ -393,7 +393,7 @@ func guardTreeA<T>(_ tree: TreeA<T>) {
     // CHECK:   destroy_value [[ARG_COPY]]
     // CHECK: [[YES]]([[BOX:%.*]] : $@box (left: TreeA<T>, right: TreeA<T>)):
     // CHECK:   [[VALUE_ADDR:%.*]] = project_box [[BOX]]
-    // CHECK:   [[TUPLE:%.*]] = load [[VALUE_ADDR]]
+    // CHECK:   [[TUPLE:%.*]] = load [take] [[VALUE_ADDR]]
     // CHECK:   [[TUPLE_COPY:%.*]] = copy_value [[TUPLE]]
     // CHECK:   [[L:%.*]] = tuple_extract [[TUPLE_COPY]]
     // CHECK:   [[R:%.*]] = tuple_extract [[TUPLE_COPY]]
@@ -434,7 +434,7 @@ func guardTreeB<T>(_ tree: TreeB<T>) {
     // CHECK:   destroy_addr [[TMP]]
     // CHECK: [[YES]]:
     // CHECK:   [[BOX_ADDR:%.*]] = unchecked_take_enum_data_addr [[TMP]]
-    // CHECK:   [[BOX:%.*]] = load [[BOX_ADDR]]
+    // CHECK:   [[BOX:%.*]] = load [take] [[BOX_ADDR]]
     // CHECK:   [[TUPLE_ADDR:%.*]] = project_box [[BOX]]
     // CHECK:   copy_addr [[TUPLE_ADDR]] to [initialization] [[TUPLE_COPY:%.*]] :
     // CHECK:   [[L_COPY:%.*]] = tuple_element_addr [[TUPLE_COPY]]
@@ -478,7 +478,7 @@ func guardTreeB<T>(_ tree: TreeB<T>) {
     // CHECK:   destroy_addr [[TMP]]
     // CHECK: [[YES]]:
     // CHECK:   [[BOX_ADDR:%.*]] = unchecked_take_enum_data_addr [[TMP]]
-    // CHECK:   [[BOX:%.*]] = load [[BOX_ADDR]]
+    // CHECK:   [[BOX:%.*]] = load [take] [[BOX_ADDR]]
     // CHECK:   [[TUPLE_ADDR:%.*]] = project_box [[BOX]]
     // CHECK:   copy_addr [[TUPLE_ADDR]] to [initialization] [[TUPLE_COPY:%.*]] :
     // CHECK:   [[L_COPY:%.*]] = tuple_element_addr [[TUPLE_COPY]]

--- a/test/SILGen/init_ref_delegation.swift
+++ b/test/SILGen/init_ref_delegation.swift
@@ -19,7 +19,7 @@ struct S {
     // CHECK-NEXT:   [[REPLACEMENT_SELF:%[0-9]+]] = apply [[S_DELEG_INIT]]([[X]], [[SELF_META]]) : $@convention(method) (X, @thin S.Type) -> S
     self.init(x: X())
     // CHECK-NEXT:   assign [[REPLACEMENT_SELF]] to [[SELF]] : $*S
-    // CHECK-NEXT:   [[SELF_BOX1:%[0-9]+]] = load [[SELF]] : $*S
+    // CHECK-NEXT:   [[SELF_BOX1:%[0-9]+]] = load [trivial] [[SELF]] : $*S
     // CHECK-NEXT:   destroy_value [[SELF_BOX]] : $@box S
     // CHECK-NEXT:   return [[SELF_BOX1]] : $S
   }
@@ -46,7 +46,7 @@ enum E {
     // CHECK:   [[X:%[0-9]+]] = apply [[E_DELEG_INIT]]([[X_META]]) : $@convention(method) (@thin X.Type) -> X
     // CHECK:   [[S:%[0-9]+]] = apply [[X_INIT]]([[X]], [[E_META]]) : $@convention(method) (X, @thin E.Type) -> E
     // CHECK:   assign [[S:%[0-9]+]] to [[E_SELF]] : $*E
-    // CHECK:   [[E_BOX1:%[0-9]+]] = load [[E_SELF]] : $*E
+    // CHECK:   [[E_BOX1:%[0-9]+]] = load [trivial] [[E_SELF]] : $*E
     self.init(x: X())
     // CHECK:   destroy_value [[E_BOX]] : $@box E
     // CHECK:   return [[E_BOX1:%[0-9]+]] : $E
@@ -74,7 +74,7 @@ struct S2 {
     // CHECK:   [[SELF_BOX1:%[0-9]+]] = apply [[S2_DELEG_INIT]]<X>([[X_BOX]], [[S2_META]]) : $@convention(method) <τ_0_0> (@in τ_0_0, @thin S2.Type) -> S2
     // CHECK:   assign [[SELF_BOX1]] to [[SELF]] : $*S2
     // CHECK:   dealloc_stack [[X_BOX]] : $*X
-    // CHECK:   [[SELF_BOX4:%[0-9]+]] = load [[SELF]] : $*S2
+    // CHECK:   [[SELF_BOX4:%[0-9]+]] = load [trivial] [[SELF]] : $*S2
     self.init(t: X())
     // CHECK:   destroy_value [[SELF_BOX]] : $@box S2
     // CHECK:   return [[SELF_BOX4]] : $S2
@@ -94,16 +94,15 @@ class C1 {
     // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $@box C1
     // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
     // CHECK:   [[SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*C1
-    // CHECK:   store [[ORIG_SELF]] to [[SELF]] : $*C1
-    // CHECK:   [[SELF_FROM_BOX:%[0-9]+]] = load [[SELF]] : $*C1
+    // CHECK:   store [[ORIG_SELF]] to [init] [[SELF]] : $*C1
+    // CHECK:   [[SELF_FROM_BOX:%[0-9]+]] = load_borrow [[SELF]] : $*C1
 
     // CHECK:   [[DELEG_INIT:%[0-9]+]] = class_method [[SELF_FROM_BOX]] : $C1, #C1.init!initializer.1 : (C1.Type) -> (X, X) -> C1 , $@convention(method) (X, X, @owned C1) -> @owned C1
     // CHECK:   [[SELFP:%[0-9]+]] = apply [[DELEG_INIT]]([[X]], [[X]], [[SELF_FROM_BOX]]) : $@convention(method) (X, X, @owned C1) -> @owned C1
     // CHECK:   store [[SELFP]] to [init] [[SELF]] : $*C1
-    // CHECK:   [[SELFP:%[0-9]+]] = load [[SELF]] : $*C1
-    // CHECK:   [[SELFP_RESULT:%.*]] = copy_value [[SELFP]] : $C1
+    // CHECK:   [[SELFP:%[0-9]+]] = load [copy] [[SELF]] : $*C1
     // CHECK:   destroy_value [[SELF_BOX]] : $@box C1
-    // CHECK:   return [[SELFP_RESULT]] : $C1
+    // CHECK:   return [[SELFP]] : $C1
     self.init(x1: x, x2: x)
   }
 
@@ -119,16 +118,18 @@ class C1 {
     // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $@box C2
     // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
     // CHECK:   [[UNINIT_SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*C2
-    // CHECK:   store [[ORIG_SELF]] to [[UNINIT_SELF]] : $*C2
-    // CHECK:   [[SELF:%[0-9]+]] = load [[UNINIT_SELF]] : $*C2
+    // CHECK:   store [[ORIG_SELF]] to [init] [[UNINIT_SELF]] : $*C2
+    // SEMANTIC ARC TODO: Another case of us doing a borrow and passing
+    // something in @owned. I think we will need some special help for
+    // definite-initialization.
+    // CHECK:   [[SELF:%[0-9]+]] = load_borrow [[UNINIT_SELF]] : $*C2
 
     // CHECK:   [[DELEG_INIT:%[0-9]+]] = class_method [[SELF]] : $C2, #C2.init!initializer.1 : (C2.Type) -> (X, X) -> C2 , $@convention(method) (X, X, @owned C2) -> @owned C2
     // CHECK:   [[REPLACE_SELF:%[0-9]+]] = apply [[DELEG_INIT]]([[X]], [[X]], [[SELF]]) : $@convention(method) (X, X, @owned C2) -> @owned C2
     // CHECK:   store [[REPLACE_SELF]] to [init] [[UNINIT_SELF]] : $*C2
-    // CHECK:   [[VAR_15:%[0-9]+]] = load [[UNINIT_SELF]] : $*C2
-    // CHECK:   [[VAR_15_RETURN:%.*]] = copy_value [[VAR_15]] : $C2
+    // CHECK:   [[VAR_15:%[0-9]+]] = load [copy] [[UNINIT_SELF]] : $*C2
     // CHECK:   destroy_value [[SELF_BOX]] : $@box C2
-    // CHECK:   return [[VAR_15_RETURN]] : $C2
+    // CHECK:   return [[VAR_15]] : $C2
     self.init(x1: x, x2: x)
     // CHECK-NOT: sil hidden @_TToFC19init_ref_delegation2C2c{{.*}} : $@convention(objc_method) (X, @owned C2) -> @owned C2 {
   }

--- a/test/SILGen/materializeForSet.swift
+++ b/test/SILGen/materializeForSet.swift
@@ -22,9 +22,9 @@ class Base {
 
 // CHECK-LABEL: sil hidden [transparent] @_TFFC17materializeForSet4Basem8computedSiU_T_ : $@convention(thin) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout Base, @thick Base.Type) -> () {
 // CHECK: bb0([[BUFFER:%.*]] : $Builtin.RawPointer, [[STORAGE:%.*]] : $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : $*Base, [[SELFTYPE:%.*]] : $@thick Base.Type):
-// CHECK:   [[T0:%.*]] = load [[SELF]]
+// CHECK:   [[T0:%.*]] = load_borrow [[SELF]]
 // CHECK:   [[T1:%.*]] = pointer_to_address [[BUFFER]] : $Builtin.RawPointer to [strict] $*Int
-// CHECK:   [[T2:%.*]] = load [[T1]] : $*Int
+// CHECK:   [[T2:%.*]] = load [trivial] [[T1]] : $*Int
 // CHECK:   [[SETTER:%.*]] = function_ref @_TFC17materializeForSet4Bases8computedSi
 // CHECK:   apply [[SETTER]]([[T2]], [[T0]])
 
@@ -71,14 +71,13 @@ extension Derived : Abstractable {}
 // CHECK: sil hidden [transparent] [thunk] @_TTWC17materializeForSet7DerivedS_12AbstractableS_FS1_m14storedFunction
 // CHECK: bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $*Derived):
 // CHECK-NEXT: [[RESULT_ADDR:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*@callee_owned () -> @out Int
-// CHECK-NEXT: [[T0:%.*]] = load %2 : $*Derived
+// CHECK-NEXT: [[T0:%.*]] = load_borrow %2 : $*Derived
 // CHECK-NEXT: [[SELF:%.*]] = upcast [[T0]] : $Derived to $Base
 // CHECK-NEXT: [[TEMP:%.*]] = alloc_stack $@callee_owned () -> Int
 // CHECK-NEXT: [[FN:%.*]] = class_method [[SELF]] : $Base, #Base.storedFunction!getter.1
 // CHECK-NEXT: [[RESULT:%.*]] = apply [[FN]]([[SELF]])
 // CHECK-NEXT: store [[RESULT]] to [init] [[TEMP]]
-// CHECK-NEXT: [[RESULT:%.*]] = load [[TEMP]]
-// CHECK-NEXT: copy_value [[RESULT]]
+// CHECK-NEXT: [[RESULT:%.*]] = load [copy] [[TEMP]]
 // CHECK-NEXT: function_ref
 // CHECK-NEXT: [[REABSTRACTOR:%.*]] = function_ref @_TTRXFo__dSi_XFo__iSi_ : $@convention(thin) (@owned @callee_owned () -> Int) -> @out Int
 // CHECK-NEXT: [[T1:%.*]] = partial_apply [[REABSTRACTOR]]([[RESULT]])
@@ -95,10 +94,10 @@ extension Derived : Abstractable {}
 
 // CHECK: sil hidden [transparent] @_TTWC17materializeForSet7DerivedS_12AbstractableS_FFS1_m14storedFunctionFT_wx6ResultU_T_ : $@convention(thin) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout Derived, @thick Derived.Type) -> ()
 // CHECK: bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $*Derived, %3 : $@thick Derived.Type):
-// CHECK-NEXT: [[T0:%.*]] = load %2 : $*Derived
+// CHECK-NEXT: [[T0:%.*]] = load_borrow %2 : $*Derived
 // CHECK-NEXT: [[SELF:%.*]] = upcast [[T0]] : $Derived to $Base
 // CHECK-NEXT: [[RESULT_ADDR:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*@callee_owned () -> @out Int
-// CHECK-NEXT: [[VALUE:%.*]] = load [[RESULT_ADDR]] : $*@callee_owned () -> @out Int
+// CHECK-NEXT: [[VALUE:%.*]] = load [take] [[RESULT_ADDR]] : $*@callee_owned () -> @out Int
 // CHECK-NEXT: function_ref
 // CHECK-NEXT: [[REABSTRACTOR:%.*]] = function_ref @_TTRXFo__iSi_XFo__dSi_ : $@convention(thin) (@owned @callee_owned () -> @out Int) -> Int
 // CHECK-NEXT: [[NEWVALUE:%.*]] = partial_apply [[REABSTRACTOR]]([[VALUE]])
@@ -110,11 +109,10 @@ extension Derived : Abstractable {}
 // CHECK: sil hidden [transparent] [thunk] @_TTWC17materializeForSet7DerivedS_12AbstractableS_FS1_m19finalStoredFunction
 // CHECK: bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $*Derived):
 // CHECK-NEXT: [[RESULT_ADDR:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*@callee_owned () -> @out Int
-// CHECK-NEXT: [[T0:%.*]] = load %2 : $*Derived
+// CHECK-NEXT: [[T0:%.*]] = load_borrow %2 : $*Derived
 // CHECK-NEXT: [[SELF:%.*]] = upcast [[T0]] : $Derived to $Base
 // CHECK-NEXT: [[ADDR:%.*]] = ref_element_addr [[SELF]] : $Base, #Base.finalStoredFunction
-// CHECK-NEXT: [[RESULT:%.*]] = load [[ADDR]]
-// CHECK-NEXT: copy_value [[RESULT]]
+// CHECK-NEXT: [[RESULT:%.*]] = load [copy] [[ADDR]]
 // CHECK-NEXT: function_ref
 // CHECK-NEXT: [[REABSTRACTOR:%.*]] = function_ref @_TTRXFo__dSi_XFo__iSi_ : $@convention(thin) (@owned @callee_owned () -> Int) -> @out Int
 // CHECK-NEXT: [[T1:%.*]] = partial_apply [[REABSTRACTOR]]([[RESULT]])
@@ -129,11 +127,11 @@ extension Derived : Abstractable {}
 
 // CHECK: sil hidden [transparent] @_TTWC17materializeForSet7DerivedS_12AbstractableS_FFS1_m19finalStoredFunctionFT_wx6ResultU_T_ :
 // CHECK: bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $*Derived, %3 : $@thick Derived.Type):
-// CHECK-NEXT: [[T0:%.*]] = load %2 : $*Derived
+// CHECK-NEXT: [[T0:%.*]] = load_borrow %2 : $*Derived
 // CHECK-NEXT: [[SELF:%.*]] = upcast [[T0]] : $Derived to $Base
 // CHECK-NEXT: [[RESULT_ADDR:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*@callee_owned () -> @out Int
-// CHECK-NEXT: [[VALUE:%.*]] = load [[RESULT_ADDR]] : $*@callee_owned () -> @out Int
-// CHECK-NEXT: function_ref
+// CHECK-NEXT: [[VALUE:%.*]] = load [take] [[RESULT_ADDR]] : $*@callee_owned () -> @out Int
+// CHECK-NEXT: // function_ref
 // CHECK-NEXT: [[REABSTRACTOR:%.*]] = function_ref @_TTRXFo__iSi_XFo__dSi_ : $@convention(thin) (@owned @callee_owned () -> @out Int) -> Int
 // CHECK-NEXT: [[NEWVALUE:%.*]] = partial_apply [[REABSTRACTOR]]([[VALUE]])
 // CHECK-NEXT: [[ADDR:%.*]] = ref_element_addr [[SELF]] : $Base, #Base.finalStoredFunction
@@ -149,8 +147,7 @@ extension Derived : Abstractable {}
 // CHECK:      [[GETTER:%.*]] = function_ref @_TZFC17materializeForSet4Baseg14staticFunctionFT_Si : $@convention(method) (@thick Base.Type) -> @owned @callee_owned () -> Int
 // CHECK-NEXT: [[VALUE:%.*]] = apply [[GETTER]]([[SELF]]) : $@convention(method) (@thick Base.Type) -> @owned @callee_owned () -> Int
 // CHECK-NEXT: store [[VALUE]] to [init] [[OUT]] : $*@callee_owned () -> Int
-// CHECK-NEXT: [[VALUE:%.*]] = load [[OUT]] : $*@callee_owned () -> Int
-// CHECK-NEXT: copy_value [[VALUE]] : $@callee_owned () -> Int
+// CHECK-NEXT: [[VALUE:%.*]] = load [copy] [[OUT]] : $*@callee_owned () -> Int
 // CHECK:      [[REABSTRACTOR:%.*]] = function_ref @_TTRXFo__dSi_XFo__iSi_ : $@convention(thin) (@owned @callee_owned () -> Int) -> @out Int
 // CHECK-NEXT: [[NEWVALUE:%.*]] = partial_apply [[REABSTRACTOR]]([[VALUE]])
 // CHECK-NEXT: store [[NEWVALUE]] to [init] [[RESULT_ADDR]] : $*@callee_owned () -> @out Int
@@ -165,10 +162,10 @@ extension Derived : Abstractable {}
 
 // CHECK-LABEL: sil hidden [transparent] @_TTWC17materializeForSet7DerivedS_12AbstractableS_FZFS1_m14staticFunctionFT_wx6ResultU_T_
 // CHECK: bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $*@thick Derived.Type, %3 : $@thick Derived.Type.Type):
-// CHECK-NEXT: [[SELF:%.*]] = load %2 : $*@thick Derived.Type
+// CHECK-NEXT: [[SELF:%.*]] = load_borrow %2 : $*@thick Derived.Type
 // CHECK-NEXT: [[BASE_SELF:%.*]] = upcast [[SELF]] : $@thick Derived.Type to $@thick Base.Type
 // CHECK-NEXT: [[BUFFER:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*@callee_owned () -> @out Int
-// CHECK-NEXT: [[VALUE:%.*]] = load [[BUFFER]] : $*@callee_owned () -> @out Int
+// CHECK-NEXT: [[VALUE:%.*]] = load [take] [[BUFFER]] : $*@callee_owned () -> @out Int
 // CHECK:      [[REABSTRACTOR:%.*]] = function_ref @_TTRXFo__iSi_XFo__dSi_ : $@convention(thin) (@owned @callee_owned () -> @out Int) -> Int
 // CHECK-NEXT: [[NEWVALUE:%.*]] = partial_apply [[REABSTRACTOR]]([[VALUE]]) : $@convention(thin) (@owned @callee_owned () -> @out Int) -> Int
 // CHECK:      [[SETTER_FN:%.*]] = function_ref @_TZFC17materializeForSet4Bases14staticFunctionFT_Si : $@convention(method) (@owned @callee_owned () -> Int, @thick Base.Type) -> ()
@@ -264,9 +261,9 @@ class HasStoredDidSet {
 
 // CHECK-LABEL: sil hidden [transparent] @_TFFC17materializeForSet15HasStoredDidSetm6storedSiU_T_ : $@convention(thin) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout HasStoredDidSet, @thick HasStoredDidSet.Type) -> () {
 // CHECK: bb0([[BUFFER:%.*]] : $Builtin.RawPointer, [[STORAGE:%.*]] : $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : $*HasStoredDidSet, [[METATYPE:%.*]] : $@thick HasStoredDidSet.Type):
-// CHECK:   [[SELF_VALUE:%.*]] = load [[SELF]] : $*HasStoredDidSet
+// CHECK:   [[SELF_VALUE:%.*]] = load_borrow [[SELF]] : $*HasStoredDidSet
 // CHECK:   [[BUFFER_ADDR:%.*]] = pointer_to_address [[BUFFER]] : $Builtin.RawPointer to [strict] $*Int
-// CHECK:   [[VALUE:%.*]] = load [[BUFFER_ADDR]] : $*Int
+// CHECK:   [[VALUE:%.*]] = load [trivial] [[BUFFER_ADDR]] : $*Int
 // CHECK:   [[SETTER_FN:%.*]] = function_ref @_TFC17materializeForSet15HasStoredDidSets6storedSi : $@convention(method) (Int, @guaranteed HasStoredDidSet) -> ()
 // CHECK:   apply [[SETTER_FN]]([[VALUE]], [[SELF_VALUE]]) : $@convention(method) (Int, @guaranteed HasStoredDidSet) -> ()
 // CHECK:   return
@@ -305,7 +302,7 @@ func improveWizard(_ wizard: inout Wizard) {
 // CHECK:       [[IMPROVE:%.*]] = function_ref @_TF17materializeForSet7improveFRSiT_ :
 // CHECK-NEXT:  [[TEMP:%.*]] = alloc_stack $Int
 //   Call the getter and materialize the result in the temporary.
-// CHECK-NEXT:  [[T0:%.*]] = load [[WIZARD:.*]] : $*Wizard
+// CHECK-NEXT:  [[T0:%.*]] = load [trivial] [[WIZARD:.*]] : $*Wizard
 // CHECK-NEXT:  function_ref
 // CHECK-NEXT:  [[GETTER:%.*]] = function_ref @_TFE17materializeForSetPS_5Magicg5hocusSi
 // CHECK-NEXT:  [[WTEMP:%.*]] = alloc_stack $Wizard
@@ -314,7 +311,7 @@ func improveWizard(_ wizard: inout Wizard) {
 // CHECK-NEXT:  store [[T0]] to [trivial] [[TEMP]]
 //   Call improve.
 // CHECK-NEXT:  apply [[IMPROVE]]([[TEMP]])
-// CHECK-NEXT:  [[T0:%.*]] = load [[TEMP]]
+// CHECK-NEXT:  [[T0:%.*]] = load [trivial] [[TEMP]]
 // CHECK-NEXT:  function_ref
 // CHECK-NEXT:  [[SETTER:%.*]] = function_ref @_TFE17materializeForSetPS_5Magics5hocusSi
 // CHECK-NEXT:  apply [[SETTER]]<Wizard>([[T0]], [[WIZARD]])

--- a/test/SILGen/metatype_abstraction.swift
+++ b/test/SILGen/metatype_abstraction.swift
@@ -18,7 +18,7 @@ struct GenericMetatype<T> {
 
 // CHECK-LABEL: sil hidden @_TFs26genericMetatypeFromGeneric
 // CHECK:         [[ADDR:%.*]] = struct_element_addr {{%.*}} : $*Generic<T.Type>, #Generic.value
-// CHECK:         [[META:%.*]] = load [[ADDR]] : $*@thick T.Type
+// CHECK:         [[META:%.*]] = load [trivial] [[ADDR]] : $*@thick T.Type
 // CHECK:         return [[META]] : $@thick T.Type
 // CHECK:       }
 func genericMetatypeFromGeneric<T>(_ x: Generic<T.Type>) -> T.Type {
@@ -27,7 +27,7 @@ func genericMetatypeFromGeneric<T>(_ x: Generic<T.Type>) -> T.Type {
 }
 // CHECK-LABEL: sil hidden @_TFs26dynamicMetatypeFromGeneric
 // CHECK:         [[ADDR:%.*]] = struct_element_addr {{%.*}} : $*Generic<C.Type>, #Generic.value
-// CHECK:         [[META:%.*]] = load [[ADDR]] : $*@thick C.Type
+// CHECK:         [[META:%.*]] = load [trivial] [[ADDR]] : $*@thick C.Type
 // CHECK:         return [[META]] : $@thick C.Type
 // CHECK:       }
 func dynamicMetatypeFromGeneric(_ x: Generic<C.Type>) -> C.Type {
@@ -44,7 +44,7 @@ func staticMetatypeFromGeneric(_ x: Generic<S.Type>) -> S.Type {
 
 // CHECK-LABEL: sil hidden @_TFs34genericMetatypeFromGenericMetatype
 // CHECK:         [[ADDR:%.*]] = struct_element_addr {{%.*}} : $*GenericMetatype<T>, #GenericMetatype.value
-// CHECK:         [[META:%.*]] = load [[ADDR]] : $*@thick T.Type
+// CHECK:         [[META:%.*]] = load [trivial] [[ADDR]] : $*@thick T.Type
 // CHECK:         return [[META]] : $@thick T.Type
 // CHECK:       }
 func genericMetatypeFromGenericMetatype<T>(_ x: GenericMetatype<T>)-> T.Type {
@@ -55,7 +55,7 @@ func genericMetatypeFromGenericMetatype<T>(_ x: GenericMetatype<T>)-> T.Type {
 // CHECK:         [[XBOX:%[0-9]+]] = alloc_box $@box GenericMetatype<C>
 // CHECK:         [[PX:%[0-9]+]] = project_box [[XBOX]]
 // CHECK:         [[ADDR:%.*]] = struct_element_addr [[PX]] : $*GenericMetatype<C>, #GenericMetatype.value
-// CHECK:         [[META:%.*]] = load [[ADDR]] : $*@thick C.Type
+// CHECK:         [[META:%.*]] = load [trivial] [[ADDR]] : $*@thick C.Type
 // CHECK:         return [[META]] : $@thick C.Type
 // CHECK:       }
 func dynamicMetatypeFromGenericMetatype(_ x: GenericMetatype<C>) -> C.Type {
@@ -90,7 +90,7 @@ func dynamicMetatypeToGeneric(_ x: C.Type) {
 // CHECK-LABEL: sil hidden @_TFs32dynamicMetatypeToGenericMetatypeFMCs1CT_
 // CHECK:         [[XBOX:%[0-9]+]] = alloc_box $@box (@thick C.Type)
 // CHECK:         [[PX:%[0-9]+]] = project_box [[XBOX]]
-// CHECK:         [[META:%.*]] = load [[PX]] : $*@thick C.Type
+// CHECK:         [[META:%.*]] = load [trivial] [[PX]] : $*@thick C.Type
 // CHECK:         apply {{%.*}}<C>([[META]]) : $@convention(thin) <τ_0_0> (@thick τ_0_0.Type) -> ()
 func dynamicMetatypeToGenericMetatype(_ x: C.Type) {
   var x = x

--- a/test/SILGen/nested_generics.swift
+++ b/test/SILGen/nested_generics.swift
@@ -229,7 +229,7 @@ class SubclassOfInner<T, U> : OuterRing<T>.InnerRing<U> {
 // CHECK: bb0([[T:%[0-9]+]] : $*τ_0_0, [[U:%[0-9]+]] : $*τ_1_0, [[V:%[0-9]+]] : $*τ_2_0, [[TOut:%[0-9]+]] : $*τ_0_0, [[UOut:%[0-9]+]] : $*τ_1_0, [[VOut:%[0-9]+]] : $*τ_2_0, [[SELF:%[0-9]+]] : $*OuterRing<τ_0_0>.InnerRing<τ_1_0>):
 // CHECK:   [[SELF_COPY:%[0-9]+]] = alloc_stack $OuterRing<τ_0_0>.InnerRing<τ_1_0>
 // CHECK:   copy_addr [[SELF]] to [initialization] [[SELF_COPY]] : $*OuterRing<τ_0_0>.InnerRing<τ_1_0>
-// CHECK:   [[SELF_COPY_VAL:%[0-9]+]] = load [[SELF_COPY]] : $*OuterRing<τ_0_0>.InnerRing<τ_1_0>
+// CHECK:   [[SELF_COPY_VAL:%[0-9]+]] = load [take] [[SELF_COPY]] : $*OuterRing<τ_0_0>.InnerRing<τ_1_0>
 // CHECK:   [[METHOD:%[0-9]+]] = class_method [[SELF_COPY_VAL]] : $OuterRing<τ_0_0>.InnerRing<τ_1_0>, #OuterRing.InnerRing.method!1 : <T><U><V> (OuterRing<T>.InnerRing<U>) -> (T, U, V) -> (T, U, V) , $@convention(method) <τ_0_0><τ_1_0><τ_2_0> (@in τ_0_0, @in τ_1_0, @in τ_2_0, @guaranteed OuterRing<τ_0_0>.InnerRing<τ_1_0>) -> (@out τ_0_0, @out τ_1_0, @out τ_2_0)
 // CHECK:   apply [[METHOD]]<τ_0_0, τ_1_0, τ_2_0>([[T]], [[U]], [[V]], [[TOut]], [[UOut]], [[VOut]], [[SELF_COPY_VAL]]) : $@convention(method) <τ_0_0><τ_1_0><τ_2_0> (@in τ_0_0, @in τ_1_0, @in τ_2_0, @guaranteed OuterRing<τ_0_0>.InnerRing<τ_1_0>) -> (@out τ_0_0, @out τ_1_0, @out τ_2_0)
 // CHECK:   [[RESULT:%[0-9]+]] = tuple ()

--- a/test/SILGen/newtype.swift
+++ b/test/SILGen/newtype.swift
@@ -37,7 +37,7 @@ func getRawValue(ed: ErrorDomain) -> String {
 // CHECK-RAW: [[STRING_META:%[0-9]+]] = metatype $@thick String.Type
 // CHECK-RAW: [[STRING_RESULT_ADDR:%[0-9]+]] = alloc_stack $String
 // CHECK-RAW: apply [[FORCE_BRIDGE]]<String>([[STRING_RESULT_ADDR]], [[STORED_VALUE_COPY]], [[STRING_META]])
-// CHECK-RAW: [[STRING_RESULT:%[0-9]+]] = load [[STRING_RESULT_ADDR]]
+// CHECK-RAW: [[STRING_RESULT:%[0-9]+]] = load [take] [[STRING_RESULT_ADDR]]
 // CHECK-RAW: return [[STRING_RESULT]]
 
 class ObjCTest {

--- a/test/SILGen/objc_bridging.swift
+++ b/test/SILGen/objc_bridging.swift
@@ -233,8 +233,7 @@ class Bas : NSObject {
 
   // CHECK-LABEL: sil hidden [transparent] @_TFC13objc_bridging3Basg11strRealPropSS
   // CHECK:   [[PROP_ADDR:%.*]] = ref_element_addr %0 : {{.*}}, #Bas.strRealProp
-  // CHECK:   [[PROP:%.*]] = load [[PROP_ADDR]]
-  // CHECK:   copy_value [[PROP]] : $String
+  // CHECK:   [[PROP:%.*]] = load [copy] [[PROP_ADDR]]
 
 
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TToFC13objc_bridging3Bass11strRealPropSS : $@convention(objc_method) (NSString, Bas) -> () {
@@ -499,7 +498,7 @@ func updateFridgeTemp(_ home: APPHouse, delta: Double) {
   // CHECK: apply [[PLUS_EQ]]([[TEMP]], [[DELTA]])
 
   // Setter
-  // CHECK: [[FRIDGE:%[0-9]+]] = load [[TEMP_FRIDGE]] : $*Refrigerator
+  // CHECK: [[FRIDGE:%[0-9]+]] = load [trivial] [[TEMP_FRIDGE]] : $*Refrigerator
   // CHECK: [[SETTER:%[0-9]+]] = class_method [volatile] [[HOME]] : $APPHouse, #APPHouse.fridge!setter.1.foreign
   // CHECK: [[BRIDGE_TO_FN:%[0-9]+]] = function_ref @_TFV10Appliances12Refrigerator19_bridgeToObjectiveCfT_CSo15APPRefrigerator
   // CHECK: [[OBJC_ARG:%[0-9]+]] = apply [[BRIDGE_TO_FN]]([[FRIDGE]])

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -476,8 +476,7 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @_TTRXFo_iP___XFdCb_dPs9AnyObject___ : $@convention(c) (@inout_aliasable @block_storage @callee_owned (@in Any) -> (), AnyObject) -> ()
   // CHECK:     bb0([[BLOCK_STORAGE:%.*]] : $*@block_storage @callee_owned (@in Any) -> (), [[ANY:%.*]] : $AnyObject):
   // CHECK-NEXT:  [[BLOCK_STORAGE_ADDR:%.*]] = project_block_storage [[BLOCK_STORAGE]]
-  // CHECK-NEXT:  [[FUNCTION:%.*]] = load [[BLOCK_STORAGE_ADDR]]
-  // CHECK-NEXT:  [[FUNCTION_COPY:%.*]] = copy_value [[FUNCTION]]
+  // CHECK-NEXT:  [[FUNCTION:%.*]] = load [copy] [[BLOCK_STORAGE_ADDR]]
   // CHECK-NEXT:  [[ANY_COPY:%.*]] = copy_value [[ANY]]
   // CHECK-NEXT:  [[OPTIONAL:%.*]] = unchecked_ref_cast [[ANY_COPY]]
   // CHECK-NEXT:  // function_ref
@@ -547,8 +546,7 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @_TTRXFo__iP__XFdCb__aPs9AnyObject__ : $@convention(c) (@inout_aliasable @block_storage @callee_owned () -> @out Any) -> @autoreleased AnyObject
   // CHECK:     bb0(%0 : $*@block_storage @callee_owned () -> @out Any):
   // CHECK-NEXT:  [[BLOCK_STORAGE_ADDR:%.*]] = project_block_storage %0
-  // CHECK-NEXT:  [[FUNCTION:%.*]] = load [[BLOCK_STORAGE_ADDR]]
-  // CHECK-NEXT:  copy_value [[FUNCTION]]
+  // CHECK-NEXT:  [[FUNCTION:%.*]] = load [copy] [[BLOCK_STORAGE_ADDR]]
   // CHECK-NEXT:  [[RESULT:%.*]] = alloc_stack $Any
   // CHECK-NEXT:  apply [[FUNCTION]]([[RESULT]])
   // CHECK-NEXT:  [[OPENED:%.*]] = open_existential_addr [[RESULT]] : $*Any to $*[[OPENED_TYPE:@opened.*Any]],

--- a/test/SILGen/objc_final.swift
+++ b/test/SILGen/objc_final.swift
@@ -22,7 +22,7 @@ func callFoo(_ x: Foo) {
 
   // Final @objc properties are still accessed directly.
   // CHECK: [[PROP:%.*]] = ref_element_addr {{%.*}} : $Foo, #Foo.prop
-  // CHECK: load [[PROP]] : $*Int
+  // CHECK: load [trivial] [[PROP]] : $*Int
   let prop = x.prop
   // CHECK: [[PROP:%.*]] = ref_element_addr {{%.*}} : $Foo, #Foo.prop
   // CHECK: assign {{%.*}} to [[PROP]] : $*Int

--- a/test/SILGen/objc_init_ref_delegation.swift
+++ b/test/SILGen/objc_init_ref_delegation.swift
@@ -11,13 +11,14 @@ extension Gizmo {
     // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $@box Gizmo
     // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
     // CHECK:   [[SELFMUI:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*Gizmo
-    // CHECK:   store [[ORIG_SELF]] to [[SELFMUI]] : $*Gizmo
-    // CHECK:   [[SELF:%[0-9]+]] = load [[SELFMUI]] : $*Gizmo
+    // CHECK:   store [[ORIG_SELF]] to [init] [[SELFMUI]] : $*Gizmo
+    // SEMANTIC ARC TODO: Another case of needing a mutable borrow load.
+    // CHECK:   [[SELF:%[0-9]+]] = load_borrow [[SELFMUI]] : $*Gizmo
     // CHECK:   [[INIT_DELEG:%[0-9]+]] = class_method [volatile] [[SELF]] : $Gizmo, #Gizmo.init!initializer.1.foreign : (Gizmo.Type) -> (Int) -> Gizmo! , $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
     // CHECK:   [[SELF_RET:%[0-9]+]] = apply [[INIT_DELEG]]([[I]], [[SELF]]) : $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
-    // CHECK:   [[SELF4_COPY:%.*]] = copy_value [[SELF4:%[0-9]+]] : $Gizmo
+    // CHECK:   [[SELF4:%.*]] = load [copy] [[SELFMUI]]
     // CHECK:   destroy_value [[SELF_BOX:%[0-9]+]] : $@box Gizmo
-    // CHECK:   return [[SELF4_COPY]] : $Gizmo
+    // CHECK:   return [[SELF4]] : $Gizmo
     self.init(bellsOn:i)
   }
 }

--- a/test/SILGen/objc_protocols.swift
+++ b/test/SILGen/objc_protocols.swift
@@ -257,10 +257,8 @@ func testInitializableExistential(_ im: Initializable.Type, i: Int) -> Initializ
   // CHECK:   [[I2:%[0-9]+]] = apply [[INIT_WITNESS]]<@opened([[N]]) Initializable>([[I]], [[I2_COPY]]) : $@convention(objc_method) <τ_0_0 where τ_0_0 : Initializable> (Int, @owned τ_0_0) -> @owned τ_0_0
   // CHECK:   [[I2_EXIST_CONTAINER:%[0-9]+]] = init_existential_ref [[I2]] : $@opened([[N]]) Initializable : $@opened([[N]]) Initializable, $Initializable
   // CHECK:   store [[I2_EXIST_CONTAINER]] to [init] [[PB]] : $*Initializable
-  // CHECK:   [[I2:%[0-9]+]] = load [[PB]] : $*Initializable
-  // CHECK:   [[I2_COPY:%.*]] = copy_value [[I2]] : $Initializable
+  // CHECK:   [[I2:%[0-9]+]] = load [copy] [[PB]] : $*Initializable
   // CHECK:   destroy_value [[I2_BOX]] : $@box Initializable
-  // SEMANTIC ARC TODO: This is incorrect. We should be returning I2_COPY, not I2 here.
   // CHECK:   return [[I2]] : $Initializable
   var i2 = im.init(int: i)
   return i2

--- a/test/SILGen/objc_thunks.swift
+++ b/test/SILGen/objc_thunks.swift
@@ -80,8 +80,7 @@ class Hoozit : Gizmo {
   // CHECK: bb0(%0 : $Hoozit):
   // CHECK-NEXT:   debug_value %0
   // CHECK-NEXT:   [[ADDR:%.*]] = ref_element_addr %0 : {{.*}}, #Hoozit.typicalProperty
-  // CHECK-NEXT:   [[RES:%.*]] = load [[ADDR]] {{.*}}
-  // CHECK-NEXT:   copy_value [[RES]] : $Gizmo
+  // CHECK-NEXT:   [[RES:%.*]] = load [copy] [[ADDR]] {{.*}}
   // CHECK-NEXT:   return [[RES]]
 
   // -- setter
@@ -93,7 +92,7 @@ class Hoozit : Gizmo {
   // CHECK:   [[FR:%.*]] = function_ref @_TFC11objc_thunks6Hoozits15typicalPropertyCSo5Gizmo
   // CHECK:   [[RES:%.*]] = apply [[FR]]([[VALUE_COPY]], [[THIS_COPY]])
   // CHECK:   destroy_value [[THIS_COPY]]
-  // CHECK:   return [[RES]] : $(), scope {{.*}} // id: {{.*}} line:[[@LINE-29]]:7:auto_gen
+  // CHECK:   return [[RES]] : $(), scope {{.*}} // id: {{.*}} line:[[@LINE-28]]:7:auto_gen
   // CHECK: } // end sil function '_TToFC11objc_thunks6Hoozits15typicalPropertyCSo5Gizmo'
 
   // CHECK-LABEL: sil hidden [transparent] @_TFC11objc_thunks6Hoozits15typicalPropertyCSo5Gizmo
@@ -120,8 +119,7 @@ class Hoozit : Gizmo {
   // CHECK-LABEL: sil hidden [transparent] @_TFC11objc_thunks6Hoozitg12copyPropertyCSo5Gizmo
   // CHECK: bb0(%0 : $Hoozit):
   // CHECK:        [[ADDR:%.*]] = ref_element_addr %0 : {{.*}}, #Hoozit.copyProperty
-  // CHECK-NEXT:   [[RES:%.*]] = load [[ADDR]]
-  // CHECK-NEXT:   copy_value [[RES]] 
+  // CHECK-NEXT:   [[RES:%.*]] = load [copy] [[ADDR]]
   // CHECK-NEXT:   return [[RES]]
 
   // -- setter is normal

--- a/test/SILGen/objc_witnesses.swift
+++ b/test/SILGen/objc_witnesses.swift
@@ -31,7 +31,7 @@ class Phoûx : NSObject, Fooable {
 // CHECK:      bb0([[IN_ADDR:%.*]] : 
 // CHECK:         [[STACK_SLOT:%.*]] = alloc_stack $Phoûx
 // CHECK:         copy_addr [[IN_ADDR]] to [initialization] [[STACK_SLOT]]
-// CHECK:         [[VALUE:%.*]] = load [[STACK_SLOT]]
+// CHECK:         [[VALUE:%.*]] = load [take] [[STACK_SLOT]]
 // CHECK:         class_method [[VALUE]] : $Phoûx, #Phoûx.foo!1
 
 protocol Bells {

--- a/test/SILGen/optional.swift
+++ b/test/SILGen/optional.swift
@@ -41,8 +41,7 @@ func testAddrOnlyCallResult<T>(_ f: (() -> T)?) {
 //   If so, pull out the value...
 // CHECK:    bb1:
 // CHECK-NEXT: [[T1:%.*]] = unchecked_take_enum_data_addr [[PBF]]
-// CHECK-NEXT: [[T0:%.*]] = load [[T1]]
-// CHECK-NEXT: copy_value
+// CHECK-NEXT: [[T0:%.*]] = load [copy] [[T1]]
 //   ...evaluate the rest of the suffix...
 // CHECK-NEXT: apply [[T0]]([[TEMP]])
 //   ...and coerce to T?

--- a/test/SILGen/pointer_conversion.swift
+++ b/test/SILGen/pointer_conversion.swift
@@ -83,7 +83,7 @@ func arrayToPointer() {
   // CHECK: [[TAKES_MUTABLE_POINTER:%.*]] = function_ref @_TF18pointer_conversion19takesMutablePointer
   // CHECK: [[CONVERT_MUTABLE:%.*]] = function_ref @_TFs37_convertMutableArrayToPointerArgument
   // CHECK: [[OWNER:%.*]] = apply [[CONVERT_MUTABLE]]<Int, UnsafeMutablePointer<Int>>([[POINTER_BUF:%[0-9]*]],
-  // CHECK: [[POINTER:%.*]] = load [[POINTER_BUF]]
+  // CHECK: [[POINTER:%.*]] = load [trivial] [[POINTER_BUF]]
   // CHECK: apply [[TAKES_MUTABLE_POINTER]]([[POINTER]])
   // CHECK: destroy_value [[OWNER]]
 
@@ -91,7 +91,7 @@ func arrayToPointer() {
   // CHECK: [[TAKES_CONST_POINTER:%.*]] = function_ref @_TF18pointer_conversion17takesConstPointerFGSPSi_T_
   // CHECK: [[CONVERT_CONST:%.*]] = function_ref @_TFs35_convertConstArrayToPointerArgument
   // CHECK: [[OWNER:%.*]] = apply [[CONVERT_CONST]]<Int, UnsafePointer<Int>>([[POINTER_BUF:%[0-9]*]],
-  // CHECK: [[POINTER:%.*]] = load [[POINTER_BUF]]
+  // CHECK: [[POINTER:%.*]] = load [trivial] [[POINTER_BUF]]
   // CHECK: apply [[TAKES_CONST_POINTER]]([[POINTER]])
   // CHECK: destroy_value [[OWNER]]
 
@@ -99,7 +99,7 @@ func arrayToPointer() {
   // CHECK: [[TAKES_MUTABLE_RAW_POINTER:%.*]] = function_ref @_TF18pointer_conversion22takesMutableRawPointerFSvT_ :
   // CHECK: [[CONVERT_MUTABLE:%.*]] = function_ref @_TFs37_convertMutableArrayToPointerArgument
   // CHECK: [[OWNER:%.*]] = apply [[CONVERT_MUTABLE]]<Int, UnsafeMutableRawPointer>([[POINTER_BUF:%[0-9]*]],
-  // CHECK: [[POINTER:%.*]] = load [[POINTER_BUF]]
+  // CHECK: [[POINTER:%.*]] = load [trivial] [[POINTER_BUF]]
   // CHECK: apply [[TAKES_MUTABLE_RAW_POINTER]]([[POINTER]])
   // CHECK: destroy_value [[OWNER]]
 
@@ -107,7 +107,7 @@ func arrayToPointer() {
   // CHECK: [[TAKES_CONST_RAW_POINTER:%.*]] = function_ref @_TF18pointer_conversion20takesConstRawPointerFSVT_ :
   // CHECK: [[CONVERT_CONST:%.*]] = function_ref @_TFs35_convertConstArrayToPointerArgument
   // CHECK: [[OWNER:%.*]] = apply [[CONVERT_CONST]]<Int, UnsafeRawPointer>([[POINTER_BUF:%[0-9]*]],
-  // CHECK: [[POINTER:%.*]] = load [[POINTER_BUF]]
+  // CHECK: [[POINTER:%.*]] = load [trivial] [[POINTER_BUF]]
   // CHECK: apply [[TAKES_CONST_RAW_POINTER]]([[POINTER]])
   // CHECK: destroy_value [[OWNER]]
 }
@@ -118,7 +118,7 @@ func stringToPointer(_ s: String) {
   // CHECK: [[TAKES_CONST_VOID_POINTER:%.*]] = function_ref @_TF18pointer_conversion21takesConstVoidPointerFSV
   // CHECK: [[CONVERT_STRING:%.*]] = function_ref @_TFs40_convertConstStringToUTF8PointerArgument
   // CHECK: [[OWNER:%.*]] = apply [[CONVERT_STRING]]<UnsafeRawPointer>([[POINTER_BUF:%[0-9]*]],
-  // CHECK: [[POINTER:%.*]] = load [[POINTER_BUF]]
+  // CHECK: [[POINTER:%.*]] = load [trivial] [[POINTER_BUF]]
   // CHECK: apply [[TAKES_CONST_VOID_POINTER]]([[POINTER]])
   // CHECK: destroy_value [[OWNER]]
 
@@ -126,7 +126,7 @@ func stringToPointer(_ s: String) {
   // CHECK: [[TAKES_CONST_RAW_POINTER:%.*]] = function_ref @_TF18pointer_conversion20takesConstRawPointerFSV
   // CHECK: [[CONVERT_STRING:%.*]] = function_ref @_TFs40_convertConstStringToUTF8PointerArgument
   // CHECK: [[OWNER:%.*]] = apply [[CONVERT_STRING]]<UnsafeRawPointer>([[POINTER_BUF:%[0-9]*]],
-  // CHECK: [[POINTER:%.*]] = load [[POINTER_BUF]]
+  // CHECK: [[POINTER:%.*]] = load [trivial] [[POINTER_BUF]]
   // CHECK: apply [[TAKES_CONST_RAW_POINTER]]([[POINTER]])
   // CHECK: destroy_value [[OWNER]]
 }
@@ -196,14 +196,14 @@ func classInoutToPointer() {
   takesPlusZeroPointer(&c)
   // CHECK: [[TAKES_PLUS_ZERO:%.*]] = function_ref @_TF18pointer_conversion20takesPlusZeroPointerFGVs33AutoreleasingUnsafeMutablePointerCS_1C_T_
   // CHECK: [[WRITEBACK:%.*]] = alloc_stack $@sil_unmanaged C
-  // CHECK: [[OWNED:%.*]] = load [[PB]]
+  // CHECK: [[OWNED:%.*]] = load_borrow [[PB]]
   // CHECK: [[UNOWNED:%.*]] = ref_to_unmanaged [[OWNED]]
   // CHECK: store [[UNOWNED]] to [trivial] [[WRITEBACK]]
   // CHECK: [[POINTER:%.*]] = address_to_pointer [[WRITEBACK]]
   // CHECK: [[CONVERT:%.*]] = function_ref @_TFs30_convertInOutToPointerArgument
   // CHECK: apply [[CONVERT]]<AutoreleasingUnsafeMutablePointer<C>>({{%.*}}, [[POINTER]])
   // CHECK: apply [[TAKES_PLUS_ZERO]]
-  // CHECK: [[UNOWNED_OUT:%.*]] = load [[WRITEBACK]]
+  // CHECK: [[UNOWNED_OUT:%.*]] = load [trivial] [[WRITEBACK]]
   // CHECK: [[OWNED_OUT:%.*]] = unmanaged_to_ref [[UNOWNED_OUT]]
   // CHECK: [[OWNED_OUT_COPY:%.*]] = copy_value [[OWNED_OUT]]
   // CHECK: assign [[OWNED_OUT_COPY]] to [[PB]]

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -32,8 +32,8 @@ func physical_tuple_rvalue() -> Int {
 // CHECK-LABEL: sil hidden  @_TF10properties16tuple_assignment
 func tuple_assignment(_ a: inout Int, b: inout Int) {
   // CHECK: bb0([[A_ADDR:%[0-9]+]] : $*Int, [[B_ADDR:%[0-9]+]] : $*Int):
-  // CHECK: [[B:%[0-9]+]] = load [[B_ADDR]]
-  // CHECK: [[A:%[0-9]+]] = load [[A_ADDR]]
+  // CHECK: [[B:%[0-9]+]] = load [trivial] [[B_ADDR]]
+  // CHECK: [[A:%[0-9]+]] = load [trivial] [[A_ADDR]]
   // CHECK: assign [[B]] to [[A_ADDR]]
   // CHECK: assign [[A]] to [[B_ADDR]]
   (a, b) = (b, a)
@@ -182,7 +182,7 @@ func logical_struct_in_reftype_set(_ value: inout Val, z1: Int) {
   value.ref.val_prop.z_tuple.1 = z1
   // -- val.ref
   // CHECK: [[VAL_REF_ADDR:%[0-9]+]] = struct_element_addr [[VAL]] : $*Val, #Val.ref
-  // CHECK: [[VAL_REF:%[0-9]+]] = load [[VAL_REF_ADDR]]
+  // CHECK: [[VAL_REF:%[0-9]+]] = load [copy] [[VAL_REF_ADDR]]
   // -- getters and setters
   // -- val.ref.val_prop
   // CHECK: [[STORAGE:%.*]] = alloc_stack $Builtin.UnsafeValueBuffer
@@ -195,8 +195,7 @@ func logical_struct_in_reftype_set(_ value: inout Val, z1: Int) {
   // CHECK: [[T1:%[0-9]+]] = pointer_to_address [[T0]] : $Builtin.RawPointer to [strict] $*Val
   // CHECK: [[VAL_REF_VAL_PROP_MAT:%.*]] = mark_dependence [[T1]] : $*Val on [[VAL_REF]]
   // CHECK: [[V_R_VP_Z_TUPLE_MAT:%[0-9]+]] = alloc_stack $(Int, Int)
-  // CHECK: [[LD:%[0-9]+]] = load [[VAL_REF_VAL_PROP_MAT]]
-  // CHECK: copy_value [[LD]]
+  // CHECK: [[LD:%[0-9]+]] = load [copy] [[VAL_REF_VAL_PROP_MAT]]
   // -- val.ref.val_prop.z_tuple
   // CHECK: [[GET_Z_TUPLE_METHOD:%[0-9]+]] = function_ref @_TFV10properties3Valg7z_tupleT
   // CHECK: [[A0:%.*]] = tuple_element_addr [[V_R_VP_Z_TUPLE_MAT]] : {{.*}}, 0
@@ -210,7 +209,7 @@ func logical_struct_in_reftype_set(_ value: inout Val, z1: Int) {
   // CHECK: [[V_R_VP_Z_TUPLE_1:%[0-9]+]] = tuple_element_addr [[V_R_VP_Z_TUPLE_MAT]] : {{.*}}, 1
   // CHECK: assign [[Z1]] to [[V_R_VP_Z_TUPLE_1]]
   // -- writeback to val.ref.val_prop.z_tuple
-  // CHECK: [[WB_V_R_VP_Z_TUPLE:%[0-9]+]] = load [[V_R_VP_Z_TUPLE_MAT]]
+  // CHECK: [[WB_V_R_VP_Z_TUPLE:%[0-9]+]] = load [trivial] [[V_R_VP_Z_TUPLE_MAT]]
   // CHECK: [[SET_Z_TUPLE_METHOD:%[0-9]+]] = function_ref @_TFV10properties3Vals7z_tupleT
   // CHECK: apply [[SET_Z_TUPLE_METHOD]]({{%[0-9]+, %[0-9]+}}, [[VAL_REF_VAL_PROP_MAT]])
   // -- writeback to val.ref.val_prop
@@ -242,8 +241,7 @@ func tuple_in_logical_struct_set(_ value: inout Val, z1: Int) {
   // CHECK: bb0([[VAL:%[0-9]+]] : $*Val, [[Z1:%[0-9]+]] : $Int):
   value.z_tuple.1 = z1
   // CHECK: [[Z_TUPLE_MATERIALIZED:%[0-9]+]] = alloc_stack $(Int, Int)
-  // CHECK: [[VAL1:%[0-9]+]] = load [[VAL]]
-  // CHECK: copy_value [[VAL1]]
+  // CHECK: [[VAL1:%[0-9]+]] = load [copy] [[VAL]]
   // CHECK: [[Z_GET_METHOD:%[0-9]+]] = function_ref @_TFV10properties3Valg7z_tupleT
   // CHECK: [[A0:%.*]] = tuple_element_addr [[Z_TUPLE_MATERIALIZED]] : {{.*}}, 0
   // CHECK: [[A1:%.*]] = tuple_element_addr [[Z_TUPLE_MATERIALIZED]] : {{.*}}, 1
@@ -254,7 +252,7 @@ func tuple_in_logical_struct_set(_ value: inout Val, z1: Int) {
   // CHECK: store [[T1]] to [trivial] [[A1]]
   // CHECK: [[Z_TUPLE_1:%[0-9]+]] = tuple_element_addr [[Z_TUPLE_MATERIALIZED]] : {{.*}}, 1
   // CHECK: assign [[Z1]] to [[Z_TUPLE_1]]
-  // CHECK: [[Z_TUPLE_MODIFIED:%[0-9]+]] = load [[Z_TUPLE_MATERIALIZED]]
+  // CHECK: [[Z_TUPLE_MODIFIED:%[0-9]+]] = load [trivial] [[Z_TUPLE_MATERIALIZED]]
   // CHECK: [[Z_SET_METHOD:%[0-9]+]] = function_ref @_TFV10properties3Vals7z_tupleT
   // CHECK: apply [[Z_SET_METHOD]]({{%[0-9]+, %[0-9]+}}, [[VAL]])
   // CHECK: dealloc_stack [[Z_TUPLE_MATERIALIZED]]
@@ -469,7 +467,7 @@ struct DidSetWillSetTests: ForceAccessors {
       // CHECK-NEXT: // function_ref properties.takeInt
       // CHECK-NEXT: [[TAKEINTFN:%.*]] = function_ref @_TF10properties7takeInt
       // CHECK-NEXT: [[FIELDPTR:%.*]] = struct_element_addr %1 : $*DidSetWillSetTests, #DidSetWillSetTests.a
-      // CHECK-NEXT: [[A:%.*]] = load [[FIELDPTR]] : $*Int
+      // CHECK-NEXT: [[A:%.*]] = load [trivial] [[FIELDPTR]] : $*Int
       // CHECK-NEXT: apply [[TAKEINTFN]]([[A]]) : $@convention(thin) (Int) -> ()
 
       takeInt(newA)
@@ -491,7 +489,7 @@ struct DidSetWillSetTests: ForceAccessors {
       // CHECK-NEXT: // function_ref properties.takeInt (Swift.Int) -> ()
       // CHECK-NEXT: [[TAKEINTFN:%.*]] = function_ref @_TF10properties7takeInt
       // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr %1 : $*DidSetWillSetTests, #DidSetWillSetTests.a
-      // CHECK-NEXT: [[A:%.*]] = load [[AADDR]] : $*Int
+      // CHECK-NEXT: [[A:%.*]] = load [trivial] [[AADDR]] : $*Int
       // CHECK-NEXT: apply [[TAKEINTFN]]([[A]]) : $@convention(thin) (Int) -> ()
 
       a = zero  // reassign, but don't infinite loop.
@@ -527,7 +525,7 @@ struct DidSetWillSetTests: ForceAccessors {
   // CHECK-NEXT: debug_value_addr %1
 
   // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr %1 : $*DidSetWillSetTests, #DidSetWillSetTests.a
-  // CHECK-NEXT: [[OLDVAL:%.*]] = load [[AADDR]] : $*Int
+  // CHECK-NEXT: [[OLDVAL:%.*]] = load [trivial] [[AADDR]] : $*Int
   // CHECK-NEXT: debug_value [[OLDVAL]] : $Int, let, name "tmp"
 
   // CHECK-NEXT: // function_ref {{.*}}.DidSetWillSetTests.a.willset : Swift.Int
@@ -672,7 +670,7 @@ func propertyWithDidSetTakingOldValue() {
 // CHECK-NEXT:  debug_value [[ARG1]] : $Int, let, name "newValue", argno 1
 // CHECK-NEXT:  [[ARG2_PB:%.*]] = project_box [[ARG2]]
 // CHECK-NEXT:  debug_value_addr [[ARG2_PB]] : $*Int, var, name "p", argno 2
-// CHECK-NEXT:  [[ARG2_PB_VAL:%.*]] = load [[ARG2_PB]] : $*Int
+// CHECK-NEXT:  [[ARG2_PB_VAL:%.*]] = load [trivial] [[ARG2_PB]] : $*Int
 // CHECK-NEXT:  debug_value [[ARG2_PB_VAL]] : $Int
 // CHECK-NEXT:  assign [[ARG1]] to [[ARG2_PB]] : $*Int
 // CHECK-NEXT:  [[ARG2_COPY:%.*]] = copy_value [[ARG2]] : $@box Int
@@ -852,7 +850,7 @@ func genericProps(_ x: GenericClass<String>) {
   // CHECK: class_method %0 : $GenericClass<String>, #GenericClass.y!getter.1
   let _ = x.y
   // CHECK: [[Z:%.*]] = ref_element_addr %0 : $GenericClass<String>, #GenericClass.z
-  // CHECK: load [[Z]] : $*String
+  // CHECK: load [copy] [[Z]] : $*String
   let _ = x.z
 }
 
@@ -872,10 +870,10 @@ class ClassWithLetProperty {
   // We shouldn't have any dynamic dispatch within this method, just load p.
   func ReturnConstant() -> Int { return p }
 // CHECK-LABEL: sil hidden @_TFC10properties20ClassWithLetProperty14ReturnConstant
-// CHECK:       bb0(%0 : $ClassWithLetProperty):
+// CHECK:       bb0([[ARG:%.*]] : $ClassWithLetProperty):
 // CHECK-NEXT:    debug_value
-// CHECK-NEXT:    [[PTR:%[0-9]+]] = ref_element_addr %0 : $ClassWithLetProperty, #ClassWithLetProperty.p
-// CHECK-NEXT:    [[VAL:%[0-9]+]] = load [[PTR]] : $*Int
+// CHECK-NEXT:    [[PTR:%[0-9]+]] = ref_element_addr [[ARG]] : $ClassWithLetProperty, #ClassWithLetProperty.p
+// CHECK-NEXT:    [[VAL:%[0-9]+]] = load [trivial] [[PTR]] : $*Int
 // CHECK-NEXT:   return [[VAL]] : $Int
 
 
@@ -900,7 +898,7 @@ class r19254812Derived: r19254812Base{
 // CHECK: [[SELFMUI:%[0-9]+]] = mark_uninitialized [derivedself] 
 
 // Initialization of the pi field: no copy_values/releases.
-// CHECK:  [[SELF:%[0-9]+]] = load [[SELFMUI]] : $*r19254812Derived
+// CHECK:  [[SELF:%[0-9]+]] = load_borrow [[SELFMUI]] : $*r19254812Derived
 // CHECK-NEXT:  [[PIPTR:%[0-9]+]] = ref_element_addr [[SELF]] : $r19254812Derived, #r19254812Derived.pi
 // CHECK-NEXT:  assign {{.*}} to [[PIPTR]] : $*Double
 
@@ -908,9 +906,9 @@ class r19254812Derived: r19254812Base{
 // CHECK-NOT: copy_value
 
 // Load of the pi field: no copy_values/releases.
-// CHECK:  [[SELF:%[0-9]+]] = load [[SELFMUI]] : $*r19254812Derived
+// CHECK:  [[SELF:%[0-9]+]] = load_borrow [[SELFMUI]] : $*r19254812Derived
 // CHECK-NEXT:  [[PIPTR:%[0-9]+]] = ref_element_addr [[SELF]] : $r19254812Derived, #r19254812Derived.pi
-// CHECK-NEXT:  {{.*}} = load [[PIPTR]] : $*Double
+// CHECK-NEXT:  {{.*}} = load [trivial] [[PIPTR]] : $*Double
 // CHECK: return
 }
 

--- a/test/SILGen/property_abstraction.swift
+++ b/test/SILGen/property_abstraction.swift
@@ -34,19 +34,27 @@ func setF(_ x: inout Foo<Int, Int>, f: @escaping (Int) -> Int) {
 
 func inOutFunc(_ f: inout ((Int) -> Int)) { }
 
-// CHECK-LABEL: sil hidden @_TF20property_abstraction6inOutF
-// CHECK:         [[INOUTFUNC:%.*]] = function_ref @_TF20property_abstraction9inOutFunc
-// CHECK:         [[F_ADDR:%.*]] = struct_element_addr {{%.*}} : $*Foo<Int, Int>, #Foo.f
-// CHECK:         [[F_SUBST_MAT:%.*]] = alloc_stack
-// CHECK:         [[F_ORIG:%.*]] = load [[F_ADDR]]
-// CHECK:         [[REABSTRACT_FN:%.*]] = function_ref @_TTR
-// CHECK:         [[F_SUBST_IN:%.*]] = partial_apply [[REABSTRACT_FN]]([[F_ORIG]])
-// CHECK:         store [[F_SUBST_IN]] to [init] [[F_SUBST_MAT]]
-// CHECK:         apply [[INOUTFUNC]]([[F_SUBST_MAT]])
-// CHECK:         [[F_SUBST_OUT:%.*]] = load [[F_SUBST_MAT]]
-// CHECK:         [[REABSTRACT_FN:%.*]] = function_ref @_TTR
-// CHECK:         [[F_ORIG:%.*]] = partial_apply [[REABSTRACT_FN]]([[F_SUBST_OUT]])
-// CHECK:         assign [[F_ORIG]] to [[F_ADDR]]
+// CHECK-LABEL: sil hidden @_TF20property_abstraction6inOutF{{.*}} : 
+// CHECK: bb0([[ARG:%.*]] : $Foo<Int, Int>):
+// CHECK:   [[XBOX:%.*]] = alloc_box $@box Foo<Int, Int>, var, name "x"
+// CHECK:   [[XBOX_PB:%.*]] = project_box [[XBOX]] : $@box Foo<Int, Int>, 0
+// CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:   store [[ARG_COPY]] to [init] [[XBOX_PB]]
+// CHECK:   [[INOUTFUNC:%.*]] = function_ref @_TF20property_abstraction9inOutFunc
+// CHECK:   [[F_ADDR:%.*]] = struct_element_addr [[XBOX_PB]] : $*Foo<Int, Int>, #Foo.f
+// CHECK:   [[F_SUBST_MAT:%.*]] = alloc_stack
+// CHECK:   [[F_ORIG:%.*]] = load [copy] [[F_ADDR]]
+// CHECK:   [[REABSTRACT_FN:%.*]] = function_ref @_TTR
+// CHECK:   [[F_SUBST_IN:%.*]] = partial_apply [[REABSTRACT_FN]]([[F_ORIG]])
+// CHECK:   store [[F_SUBST_IN]] to [init] [[F_SUBST_MAT]]
+// CHECK:   apply [[INOUTFUNC]]([[F_SUBST_MAT]])
+// CHECK:   [[F_SUBST_OUT:%.*]] = load [take] [[F_SUBST_MAT]]
+// CHECK:   [[REABSTRACT_FN:%.*]] = function_ref @_TTR
+// CHECK:   [[F_ORIG:%.*]] = partial_apply [[REABSTRACT_FN]]([[F_SUBST_OUT]])
+// CHECK:   assign [[F_ORIG]] to [[F_ADDR]]
+// CHECK:   destroy_value [[XBOX]]
+// CHECK:   destroy_value [[ARG]]
+// CHECK: } // end sil function '_TF20property_abstraction6inOutF{{.*}}'
 func inOutF(_ x: Foo<Int, Int>) {
   var x = x
   inOutFunc(&x.f)
@@ -70,11 +78,14 @@ struct AddressOnlyLet<T> {
 }
 
 // CHECK-LABEL: sil hidden @_TF20property_abstraction34getAddressOnlyReabstractedProperty{{.*}} : $@convention(thin) (@in AddressOnlyLet<Int>) -> @owned @callee_owned (Int) -> Int
-// CHECK:         [[CLOSURE_ADDR:%.*]] = struct_element_addr {{%.*}} : $*AddressOnlyLet<Int>, #AddressOnlyLet.f
-// CHECK:         [[CLOSURE_ORIG:%.*]] = load [[CLOSURE_ADDR]]
-// CHECK:         [[REABSTRACT:%.*]] = function_ref
-// CHECK:         [[CLOSURE_SUBST:%.*]] = partial_apply [[REABSTRACT]]([[CLOSURE_ORIG]])
-// CHECK:         return [[CLOSURE_SUBST]]
+// CHECK: bb0([[ARG:%.*]] : $*AddressOnlyLet<Int>):
+// CHECK:   [[CLOSURE_ADDR:%.*]] = struct_element_addr {{%.*}} : $*AddressOnlyLet<Int>, #AddressOnlyLet.f
+// CHECK:   [[CLOSURE_ORIG:%.*]] = load [copy] [[CLOSURE_ADDR]]
+// CHECK:   [[REABSTRACT:%.*]] = function_ref
+// CHECK:   [[CLOSURE_SUBST:%.*]] = partial_apply [[REABSTRACT]]([[CLOSURE_ORIG]])
+// CHECK:   destroy_addr [[ARG]]
+// CHECK:   return [[CLOSURE_SUBST]]
+// CHECK: } // end sil function '_TF20property_abstraction34getAddressOnlyReabstractedProperty{{.*}}'
 func getAddressOnlyReabstractedProperty(_ x: AddressOnlyLet<Int>) -> (Int) -> Int {
   return x.f
 }

--- a/test/SILGen/property_behavior_init.swift
+++ b/test/SILGen/property_behavior_init.swift
@@ -40,19 +40,19 @@ struct Foo {
 
     // Reads or inouts use the accessors normally.
 
-    // CHECK: [[SELF:%.*]] = load [[UNINIT_SELF]]
+    // CHECK: [[SELF:%.*]] = load [trivial] [[UNINIT_SELF]]
     // CHECK: [[GETTER:%.*]] = function_ref @_TFV22property_behavior_init3Foog1xSi
     // CHECK: apply [[GETTER]]([[SELF]])
     _ = self.x
 
     // CHECK: [[WHACK:%.*]] = function_ref @_TF22property_behavior_init5whackurFRxT_
     // CHECK: [[INOUT:%.*]] = alloc_stack
-    // CHECK: [[SELF:%.*]] = load [[UNINIT_SELF]]
+    // CHECK: [[SELF:%.*]] = load [trivial] [[UNINIT_SELF]]
     // CHECK: [[GETTER:%.*]] = function_ref @_TFV22property_behavior_init3Foog1xSi
     // CHECK: [[VALUE:%.*]] = apply [[GETTER]]([[SELF]])
     // CHECK: store [[VALUE]] to [trivial] [[INOUT]]
     // CHECK: apply [[WHACK]]<Int>([[INOUT]])
-    // CHECK: [[VALUE:%.*]] = load [[INOUT]]
+    // CHECK: [[VALUE:%.*]] = load [trivial] [[INOUT]]
     // CHECK: [[SETTER:%.*]] = function_ref @_TFV22property_behavior_init3Foos1xSi
     // CHECK: apply [[SETTER]]([[VALUE]], [[UNINIT_SELF]])
     whack(&self.x)

--- a/test/SILGen/protocol_class_refinement.swift
+++ b/test/SILGen/protocol_class_refinement.swift
@@ -31,13 +31,12 @@ func getObjectUID<T: ObjectUID>(x: T) -> (Int, Int, Int, Int) {
   // CHECK: [[XBOX:%.*]] = alloc_box $@box T
   // CHECK: [[PB:%.*]] = project_box [[XBOX]]
   // -- call x.uid()
-  // CHECK: [[X:%.*]] = load [[PB]]
-  // CHECK: copy_value [[X]]
+  // CHECK: [[X:%.*]] = load [copy] [[PB]]
   // CHECK: [[X_TMP:%.*]] = alloc_stack
   // CHECK: store [[X]] to [init] [[X_TMP]]
   // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
   // CHECK: [[UID:%.*]] = apply [[GET_UID]]<T>([[X_TMP]])
-  // CHECK: [[X2:%.*]] = load [[X_TMP]]
+  // CHECK: [[X2:%.*]] = load [take] [[X_TMP]]
   // CHECK: destroy_value [[X2]]
   // -- call set x.clsid
   // CHECK: [[SET_CLSID:%.*]] = witness_method $T, #UID.clsid!setter.1
@@ -45,13 +44,12 @@ func getObjectUID<T: ObjectUID>(x: T) -> (Int, Int, Int, Int) {
   x.clsid = x.uid()
 
   // -- call x.uid()
-  // CHECK: [[X:%.*]] = load [[PB]]
-  // CHECK: copy_value [[X]]
+  // CHECK: [[X:%.*]] = load [copy] [[PB]]
   // CHECK: [[X_TMP:%.*]] = alloc_stack
   // CHECK: store [[X]] to [init] [[X_TMP]]
   // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
   // CHECK: [[UID:%.*]] = apply [[GET_UID]]<T>([[X_TMP]])
-  // CHECK: [[X2:%.*]] = load [[X_TMP]]
+  // CHECK: [[X2:%.*]] = load [take] [[X_TMP]]
   // CHECK: destroy_value [[X2]]
   // -- call nextCLSID from protocol ext
   // CHECK: [[SET_NEXTCLSID:%.*]] = function_ref @_TFE25protocol_class_refinementPS_3UIDs9nextCLSIDSi
@@ -59,15 +57,13 @@ func getObjectUID<T: ObjectUID>(x: T) -> (Int, Int, Int, Int) {
   x.nextCLSID = x.uid()
 
   // -- call x.uid()
-  // CHECK: [[X1:%.*]] = load [[PB]]
-  // CHECK: copy_value [[X1]]
-  // CHECK: [[X:%.*]] = load [[PB]]
-  // CHECK: copy_value [[X]]
+  // CHECK: [[X1:%.*]] = load [copy] [[PB]]
+  // CHECK: [[X:%.*]] = load [copy] [[PB]]
   // CHECK: [[X_TMP:%.*]] = alloc_stack
   // CHECK: store [[X]] to [init] [[X_TMP]]
   // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
   // CHECK: [[UID:%.*]] = apply [[GET_UID]]<T>([[X_TMP]])
-  // CHECK: [[X2:%.*]] = load [[X_TMP]]
+  // CHECK: [[X2:%.*]] = load [take] [[X_TMP]]
   // CHECK: destroy_value [[X2]]
   // -- call secondNextCLSID from class-constrained protocol ext
   // CHECK: [[SET_SECONDNEXT:%.*]] = function_ref @_TFE25protocol_class_refinementPS_9ObjectUIDs15secondNextCLSIDSi
@@ -83,13 +79,12 @@ func getBaseObjectUID<T: UID where T: Base>(x: T) -> (Int, Int, Int) {
   // CHECK: [[XBOX:%.*]] = alloc_box $@box T
   // CHECK: [[PB:%.*]] = project_box [[XBOX]]
   // -- call x.uid()
-  // CHECK: [[X:%.*]] = load [[PB]]
-  // CHECK: copy_value [[X]]
+  // CHECK: [[X:%.*]] = load [copy] [[PB]]
   // CHECK: [[X_TMP:%.*]] = alloc_stack
   // CHECK: store [[X]] to [init] [[X_TMP]]
   // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
   // CHECK: [[UID:%.*]] = apply [[GET_UID]]<T>([[X_TMP]])
-  // CHECK: [[X2:%.*]] = load [[X_TMP]]
+  // CHECK: [[X2:%.*]] = load [take] [[X_TMP]]
   // CHECK: destroy_value [[X2]]
   // -- call set x.clsid
   // CHECK: [[SET_CLSID:%.*]] = witness_method $T, #UID.clsid!setter.1
@@ -97,13 +92,12 @@ func getBaseObjectUID<T: UID where T: Base>(x: T) -> (Int, Int, Int) {
   x.clsid = x.uid()
 
   // -- call x.uid()
-  // CHECK: [[X:%.*]] = load [[PB]]
-  // CHECK: copy_value [[X]]
+  // CHECK: [[X:%.*]] = load [copy] [[PB]]
   // CHECK: [[X_TMP:%.*]] = alloc_stack
   // CHECK: store [[X]] to [init] [[X_TMP]]
   // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
   // CHECK: [[UID:%.*]] = apply [[GET_UID]]<T>([[X_TMP]])
-  // CHECK: [[X2:%.*]] = load [[X_TMP]]
+  // CHECK: [[X2:%.*]] = load [take] [[X_TMP]]
   // CHECK: destroy_value [[X2]]
   // -- call nextCLSID from protocol ext
   // CHECK: [[SET_NEXTCLSID:%.*]] = function_ref @_TFE25protocol_class_refinementPS_3UIDs9nextCLSIDSi

--- a/test/SILGen/protocol_extensions.swift
+++ b/test/SILGen/protocol_extensions.swift
@@ -658,8 +658,7 @@ func test_open_existential_semantics_class(_ guaranteed: CP1,
   // CHECK-NOT: destroy_value %0
   guaranteed.f1()
 
-  // CHECK: [[IMMEDIATE:%.*]] = load [[PB]]
-  // CHECK: copy_value [[IMMEDIATE]]
+  // CHECK: [[IMMEDIATE:%.*]] = load [copy] [[PB]]
   // CHECK: [[VALUE:%.*]] = open_existential_ref [[IMMEDIATE]]
   // CHECK: [[METHOD:%.*]] = function_ref
   // CHECK: apply [[METHOD]]<{{.*}}>([[VALUE]])

--- a/test/SILGen/protocol_optional.swift
+++ b/test/SILGen/protocol_optional.swift
@@ -18,10 +18,8 @@ func optionalMethodGeneric<T : P1>(t t : T) {
   // CHECK:   store [[T_COPY]] to [init] [[PT]] : $*T
   // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box $@box Optional<@callee_owned (Int) -> ()>
   // CHECK:   project_box [[OPT_BOX]]
-  // CHECK:   [[T:%[0-9]+]] = load [[PT]] : $*T
-  // CHECK:   [[T_COPY:%.*]] = copy_value [[T]] : $T
+  // CHECK:   [[T:%[0-9]+]] = load [copy] [[PT]] : $*T
   // CHECK:   alloc_stack $Optional<@callee_owned (Int) -> ()>
-  // SEMANTIC ARC TODO: This should be a branch on T_COPY.
   // CHECK:   dynamic_method_br [[T]] : $T, #P1.method!1.foreign
   var methodRef = t.method
 }
@@ -37,10 +35,8 @@ func optionalPropertyGeneric<T : P1>(t t : T) {
   // CHECK:   store [[T_COPY]] to [init] [[PT]] : $*T
   // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box $@box Optional<Int>
   // CHECK:   project_box [[OPT_BOX]]
-  // CHECK:   [[T:%[0-9]+]] = load [[PT]] : $*T
-  // CHECK:   [[T_COPY:%.*]] = copy_value [[T]] : $T
+  // CHECK:   [[T:%[0-9]+]] = load [copy] [[PT]] : $*T
   // CHECK:   alloc_stack $Optional<Int>
-  // SEMANTIC ARC TODO: This should be a dynamic_method_br on T_COPY, not T.
   // CHECK:   dynamic_method_br [[T]] : $T, #P1.prop!getter.1.foreign
   var propertyRef = t.prop
 }
@@ -56,14 +52,12 @@ func optionalSubscriptGeneric<T : P1>(t t : T) {
   // CHECK:   store [[T_COPY]] to [init] [[PT]] : $*T
   // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box $@box Optional<Int>
   // CHECK:   project_box [[OPT_BOX]]
-  // CHECK:   [[T:%[0-9]+]] = load [[PT]] : $*T
-  // CHECK:   [[T_COPY:%.*]] = copy_value [[T]] : $T
+  // CHECK:   [[T:%[0-9]+]] = load [copy] [[PT]] : $*T
   // CHECK:   [[INTCONV:%[0-9]+]] = function_ref @_TFSiC
   // CHECK:   [[INT64:%[0-9]+]] = metatype $@thin Int.Type
   // CHECK:   [[FIVELIT:%[0-9]+]] = integer_literal $Builtin.Int2048, 5
   // CHECK:   [[FIVE:%[0-9]+]] = apply [[INTCONV]]([[FIVELIT]], [[INT64]]) : $@convention(method) (Builtin.Int2048, @thin Int.Type) -> Int
   // CHECK:   alloc_stack $Optional<Int>
-  // SEMANTIC ARC TODO: This should be a dynamic_method_br on T_COPY, not T.
   // CHECK:   dynamic_method_br [[T]] : $T, #P1.subscript!getter.1.foreign
   var subscriptRef = t[5]
 }

--- a/test/SILGen/protocols.swift
+++ b/test/SILGen/protocols.swift
@@ -245,7 +245,7 @@ class ClassWithGetter : PropertyWithGetter {
 // CHECK: bb0([[C:%.*]] : $*ClassWithGetter):
 // CHECK-NEXT: [[CCOPY:%.*]] = alloc_stack $ClassWithGetter
 // CHECK-NEXT: copy_addr [[C]] to [initialization] [[CCOPY]]
-// CHECK-NEXT: [[CCOPY_LOADED:%.*]] = load [[CCOPY]]
+// CHECK-NEXT: [[CCOPY_LOADED:%.*]] = load [take] [[CCOPY]]
 // CHECK-NEXT: [[FUN:%.*]] = class_method [[CCOPY_LOADED]] : $ClassWithGetter, #ClassWithGetter.a!getter.1 : (ClassWithGetter) -> () -> Int , $@convention(method) (@guaranteed ClassWithGetter) -> Int
 // CHECK-NEXT: apply [[FUN]]([[CCOPY_LOADED]])
 // CHECK-NEXT: destroy_value [[CCOPY_LOADED]]
@@ -271,7 +271,7 @@ class ClassWithGetterSetter : PropertyWithGetterSetter, PropertyWithGetter {
 // CHECK: bb0([[C:%.*]] : $*ClassWithGetterSetter):
 // CHECK-NEXT: [[CCOPY:%.*]] = alloc_stack $ClassWithGetterSetter
 // CHECK-NEXT: copy_addr [[C]] to [initialization] [[CCOPY]]
-// CHECK-NEXT: [[CCOPY_LOADED:%.*]] = load [[CCOPY]]
+// CHECK-NEXT: [[CCOPY_LOADED:%.*]] = load [take] [[CCOPY]]
 // CHECK-NEXT: [[FUN:%.*]] = class_method [[CCOPY_LOADED]] : $ClassWithGetterSetter, #ClassWithGetterSetter.b!getter.1 : (ClassWithGetterSetter) -> () -> Int , $@convention(method) (@guaranteed ClassWithGetterSetter) -> Int
 // CHECK-NEXT: apply [[FUN]]([[CCOPY_LOADED]])
 // CHECK-NEXT: destroy_value [[CCOPY_LOADED]]
@@ -325,7 +325,7 @@ struct StructWithStoredProperty : PropertyWithGetter {
 // CHECK: bb0([[C:%.*]] : $*StructWithStoredProperty):
 // CHECK-NEXT: [[CCOPY:%.*]] = alloc_stack $StructWithStoredProperty
 // CHECK-NEXT: copy_addr [[C]] to [initialization] [[CCOPY]]
-// CHECK-NEXT: [[CCOPY_LOADED:%.*]] = load [[CCOPY]]
+// CHECK-NEXT: [[CCOPY_LOADED:%.*]] = load [trivial] [[CCOPY]]
 // CHECK-NEXT: function_ref
 // CHECK-NEXT: [[FUN:%.*]] = function_ref @_TFV9protocols24StructWithStoredPropertyg1aSi : $@convention(method) (StructWithStoredProperty) -> Int
 // CHECK-NEXT: apply [[FUN]]([[CCOPY_LOADED]])
@@ -355,7 +355,7 @@ struct StructWithStoredClassProperty : PropertyWithGetter {
 // CHECK: bb0([[C:%.*]] : $*StructWithStoredClassProperty):
 // CHECK-NEXT: [[CCOPY:%.*]] = alloc_stack $StructWithStoredClassProperty
 // CHECK-NEXT: copy_addr [[C]] to [initialization] [[CCOPY]]
-// CHECK-NEXT: [[CCOPY_LOADED:%.*]] = load [[CCOPY]]
+// CHECK-NEXT: [[CCOPY_LOADED:%.*]] = load [take] [[CCOPY]]
 // CHECK-NEXT: function_ref
 // CHECK-NEXT: [[FUN:%.*]] = function_ref @_TFV9protocols29StructWithStoredClassPropertyg1aSi : $@convention(method) (@guaranteed StructWithStoredClassProperty) -> Int
 // CHECK-NEXT: apply [[FUN]]([[CCOPY_LOADED]])

--- a/test/SILGen/reabstract.swift
+++ b/test/SILGen/reabstract.swift
@@ -21,9 +21,9 @@ func test0() {
 // CHECK-NEXT: return
 
 // CHECK:    sil shared [transparent] [reabstraction_thunk] [[THUNK]] : $@convention(thin) (@in Int, @owned @callee_owned (Int) -> Optional<Int>) -> @out Optional<Int> {
-// CHECK:      [[T0:%.*]] = load %1 : $*Int
+// CHECK:      [[T0:%.*]] = load [trivial] %1 : $*Int
 // CHECK-NEXT: [[T1:%.*]] = apply %2([[T0]])
-// CHECK-NEXT: store [[T1]] to %0
+// CHECK-NEXT: store [[T1]] to [trivial] %0
 // CHECK-NEXT: tuple ()
 // CHECK-NEXT: return
 

--- a/test/SILGen/reabstract_lvalue.swift
+++ b/test/SILGen/reabstract_lvalue.swift
@@ -19,13 +19,12 @@ func reabstractFunctionInOut() {
   // CHECK: store [[THICK_ARG:%.*]] to [init] [[PB]]
   // CHECK: [[FUNC:%.*]] = function_ref @_TF17reabstract_lvalue19consumeGenericInOut
   // CHECK: [[ABSTRACTED_BOX:%.*]] = alloc_stack $@callee_owned (@in Int) -> @out Double
-  // CHECK: [[THICK_ARG:%.*]] = load [[PB]]
-  // CHECK: copy_value [[THICK_ARG]]
+  // CHECK: [[THICK_ARG:%.*]] = load [copy] [[PB]]
   // CHECK: [[THUNK1:%.*]] = function_ref @_TTRXFo_dSi_dSd_XFo_iSi_iSd_
   // CHECK: [[ABSTRACTED_ARG:%.*]] = partial_apply [[THUNK1]]([[THICK_ARG]])
   // CHECK: store [[ABSTRACTED_ARG]] to [init] [[ABSTRACTED_BOX]]
   // CHECK: apply [[FUNC]]<(Int) -> Double>([[ABSTRACTED_BOX]])
-  // CHECK: [[NEW_ABSTRACTED_ARG:%.*]] = load [[ABSTRACTED_BOX]]
+  // CHECK: [[NEW_ABSTRACTED_ARG:%.*]] = load [take] [[ABSTRACTED_BOX]]
   // CHECK: [[THUNK2:%.*]] = function_ref @_TTRXFo_iSi_iSd_XFo_dSi_dSd_
   // CHECK: [[NEW_ARG:%.*]] = partial_apply [[THUNK2]]([[NEW_ABSTRACTED_ARG]])
   var minimallyAbstracted = transform

--- a/test/SILGen/scalar_to_tuple_args.swift
+++ b/test/SILGen/scalar_to_tuple_args.swift
@@ -26,22 +26,22 @@ inoutWithDefaults(&x)
 inoutWithCallerSideDefaults(&x)
 
 // CHECK: [[SCALAR_WITH_DEFAULTS:%.*]] = function_ref @_TF20scalar_to_tuple_args18scalarWithDefaultsFTSi1ySi1zSi_T_
-// CHECK: [[X:%.*]] = load [[X_ADDR]]
+// CHECK: [[X:%.*]] = load [trivial] [[X_ADDR]]
 // CHECK: [[DEFAULT_Y:%.*]] = apply {{.*}} : $@convention(thin) () -> Int
 // CHECK: [[DEFAULT_Z:%.*]] = apply {{.*}} : $@convention(thin) () -> Int
 // CHECK: apply [[SCALAR_WITH_DEFAULTS]]([[X]], [[DEFAULT_Y]], [[DEFAULT_Z]])
 scalarWithDefaults(x)
 
 // CHECK: [[SCALAR_WITH_CALLER_DEFAULTS:%.*]] = function_ref @_TF20scalar_to_tuple_args28scalarWithCallerSideDefaultsFTSi1ySi_T_
-// CHECK: [[X:%.*]] = load [[X_ADDR]]
+// CHECK: [[X:%.*]] = load [trivial] [[X_ADDR]]
 // CHECK: [[LINE_VAL:%.*]] = integer_literal
 // CHECK: [[LINE:%.*]] = apply {{.*}}([[LINE_VAL]]
 // CHECK: apply [[SCALAR_WITH_CALLER_DEFAULTS]]([[X]], [[LINE]])
 scalarWithCallerSideDefaults(x)
 
 // CHECK: [[TUPLE_WITH_DEFAULTS:%.*]] = function_ref @_TF20scalar_to_tuple_args17tupleWithDefaultsFT1xTSiSi_1ySi1zSi_T_
-// CHECK: [[X1:%.*]] = load [[X_ADDR]]
-// CHECK: [[X2:%.*]] = load [[X_ADDR]]
+// CHECK: [[X1:%.*]] = load [trivial] [[X_ADDR]]
+// CHECK: [[X2:%.*]] = load [trivial] [[X_ADDR]]
 // CHECK: [[DEFAULT_Y:%.*]] = apply {{.*}} : $@convention(thin) () -> Int
 // CHECK: [[DEFAULT_Z:%.*]] = apply {{.*}} : $@convention(thin) () -> Int
 // CHECK: apply [[TUPLE_WITH_DEFAULTS]]([[X1]], [[X2]], [[DEFAULT_Y]], [[DEFAULT_Z]])
@@ -52,7 +52,7 @@ tupleWithDefaults(x: (x,x))
 // CHECK: [[ARRAY:%.*]] = tuple_extract [[ALLOC_ARRAY]] {{.*}}, 0
 // CHECK: [[MEMORY:%.*]] = tuple_extract [[ALLOC_ARRAY]] {{.*}}, 1
 // CHECK: [[ADDR:%.*]] = pointer_to_address [[MEMORY]]
-// CHECK: [[X:%.*]] = load [[X_ADDR]]
+// CHECK: [[X:%.*]] = load [trivial] [[X_ADDR]]
 // CHECK: store [[X]] to [trivial] [[ADDR]]
 // CHECK: apply [[VARIADIC_FIRST]]([[ARRAY]])
 variadicFirst(x)
@@ -60,6 +60,6 @@ variadicFirst(x)
 // CHECK: [[VARIADIC_SECOND:%.*]] = function_ref @_TF20scalar_to_tuple_args14variadicSecondFtSiGSaSi__T_
 // CHECK: [[ALLOC_ARRAY:%.*]] = apply {{.*}} -> (@owned Array<τ_0_0>, Builtin.RawPointer)
 // CHECK: [[ARRAY:%.*]] = tuple_extract [[ALLOC_ARRAY]] {{.*}}, 0
-// CHECK: [[X:%.*]] = load [[X_ADDR]]
+// CHECK: [[X:%.*]] = load [trivial] [[X_ADDR]]
 // CHECK: apply [[VARIADIC_SECOND]]([[X]], [[ARRAY]])
 variadicSecond(x)

--- a/test/SILGen/struct_resilience.swift
+++ b/test/SILGen/struct_resilience.swift
@@ -136,13 +136,13 @@ public func functionWithMyResilientTypes(_ s: MySize, f: (MySize) -> MySize) -> 
   var s2 = s
 
 // CHECK:         [[SRC_ADDR:%.*]] = struct_element_addr %1 : $*MySize, #MySize.w
-// CHECK:         [[SRC:%.*]] = load [[SRC_ADDR]] : $*Int
+// CHECK:         [[SRC:%.*]] = load [trivial] [[SRC_ADDR]] : $*Int
 // CHECK:         [[DEST_ADDR:%.*]] = struct_element_addr [[SIZE_BOX]] : $*MySize, #MySize.w
 // CHECK:         assign [[SRC]] to [[DEST_ADDR]] : $*Int
   s2.w = s.w
 
 // CHECK:         [[RESULT_ADDR:%.*]] = struct_element_addr %1 : $*MySize, #MySize.h
-// CHECK:         [[RESULT:%.*]] = load [[RESULT_ADDR]] : $*Int
+// CHECK:         [[RESULT:%.*]] = load_borrow [[RESULT_ADDR]] : $*Int
   _ = s.h
 
 // CHECK:         [[CLOSURE_COPY:%.*]] = copy_value %2
@@ -182,14 +182,15 @@ public func functionWithMyResilientTypes(_ s: MySize, f: (MySize) -> MySize) -> 
 }
 
 // CHECK-LABEL: sil hidden [transparent] @_TF17struct_resilience27internalTransparentFunctionFVS_6MySizeSi : $@convention(thin) (@in MySize) -> Int
+// CHECK: bb0([[ARG:%.*]] : $*MySize):
 @_transparent func internalTransparentFunction(_ s: MySize) -> Int {
 
   // The body of an internal transparent function will not be inlined into
   // other resilience domains, so we can access storage directly
 
-// CHECK:         [[W_ADDR:%.*]] = struct_element_addr %0 : $*MySize, #MySize.w
-// CHECK-NEXT:    [[RESULT:%.*]] = load [[W_ADDR]] : $*Int
-// CHECK-NEXT:    destroy_addr %0
+// CHECK:         [[W_ADDR:%.*]] = struct_element_addr [[ARG]] : $*MySize, #MySize.w
+// CHECK-NEXT:    [[RESULT:%.*]] = load [trivial] [[W_ADDR]] : $*Int
+// CHECK-NEXT:    destroy_addr [[ARG]]
 // CHECK-NEXT:    return [[RESULT]]
   return s.w
 }

--- a/test/SILGen/super_init_refcounting.swift
+++ b/test/SILGen/super_init_refcounting.swift
@@ -11,7 +11,7 @@ class Bar: Foo {
   // CHECK:         [[SELF_VAR:%.*]] = alloc_box $@box Bar
   // CHECK:         [[PB:%.*]] = project_box [[SELF_VAR]]
   // CHECK:         [[SELF_MUI:%.*]] =  mark_uninitialized [derivedself] [[PB]]
-  // CHECK:         [[ORIG_SELF:%.*]] = load [[SELF_MUI]]
+  // CHECK:         [[ORIG_SELF:%.*]] = load_borrow [[SELF_MUI]]
   // CHECK-NOT:     copy_value [[ORIG_SELF]]
   // CHECK:         [[ORIG_SELF_UP:%.*]] = upcast [[ORIG_SELF]]
   // CHECK-NOT:     copy_value [[ORIG_SELF_UP]]
@@ -29,7 +29,7 @@ extension Foo {
   // CHECK:         [[SELF_VAR:%.*]] = alloc_box $@box Foo
   // CHECK:         [[PB:%.*]] = project_box [[SELF_VAR]]
   // CHECK:         [[SELF_MUI:%.*]] =  mark_uninitialized [delegatingself] [[PB]]
-  // CHECK:         [[ORIG_SELF:%.*]] = load [[SELF_MUI]]
+  // CHECK:         [[ORIG_SELF:%.*]] = load_borrow [[SELF_MUI]]
   // CHECK-NOT:     copy_value [[ORIG_SELF]]
   // CHECK:         [[SUPER_INIT:%.*]] = class_method
   // CHECK:         [[NEW_SELF:%.*]] = apply [[SUPER_INIT]]([[ORIG_SELF]])
@@ -75,16 +75,16 @@ class Good: Foo {
   // CHECK:         [[SELF_BOX:%.*]] = alloc_box $@box Good
   // CHECK:         [[PB:%.*]] = project_box [[SELF_BOX]]
   // CHECK:         [[SELF:%.*]] = mark_uninitialized [derivedself] [[PB]]
-  // CHECK:         store %0 to [[SELF]]
-  // CHECK:         [[SELF_OBJ:%.*]] = load [[SELF]]
+  // CHECK:         store %0 to [init] [[SELF]]
+  // CHECK:         [[SELF_OBJ:%.*]] = load_borrow [[SELF]]
   // CHECK:         [[X_ADDR:%.*]] = ref_element_addr [[SELF_OBJ]] : $Good, #Good.x
   // CHECK:         assign {{.*}} to [[X_ADDR]] : $*Int
-  // CHECK:         [[SELF_OBJ:%.*]] = load [[SELF]] : $*Good
+  // CHECK:         [[SELF_OBJ:%.*]] = load_borrow [[SELF]] : $*Good
   // CHECK:         [[SUPER_OBJ:%.*]] = upcast [[SELF_OBJ]] : $Good to $Foo
   // CHECK:         [[SUPER_INIT:%.*]] = function_ref @_TFC22super_init_refcounting3FoocfSiS0_ : $@convention(method) (Int, @owned Foo) -> @owned Foo
-  // CHECK:         [[SELF_OBJ:%.*]] = load [[SELF]]
+  // CHECK:         [[SELF_OBJ:%.*]] = load_borrow [[SELF]]
   // CHECK:         [[X_ADDR:%.*]] = ref_element_addr [[SELF_OBJ]] : $Good, #Good.x
-  // CHECK:         [[X:%.*]] = load [[X_ADDR]] : $*Int
+  // CHECK:         [[X:%.*]] = load [trivial] [[X_ADDR]] : $*Int
   // CHECK:         apply [[SUPER_INIT]]([[X]], [[SUPER_OBJ]])
   override init() {
     x = 10

--- a/test/SILGen/switch.swift
+++ b/test/SILGen/switch.swift
@@ -323,7 +323,7 @@ func test_isa_1(p: P) {
 
   case is X:
   // CHECK: [[IS_X]]:
-  // CHECK-NEXT: load [[TMPBUF]]
+  // CHECK-NEXT: load [trivial] [[TMPBUF]]
   // CHECK-NEXT: dealloc_stack [[TMPBUF]]
   // CHECK-NEXT: destroy_addr [[PTMPBUF]]
   // CHECK-NEXT: dealloc_stack [[PTMPBUF]]
@@ -873,7 +873,7 @@ func test_union_addr_only_1(u: MaybeAddressOnlyPair) {
 
   // CHECK: [[IS_RIGHT]]:
   // CHECK:   [[STR_ADDR:%.*]] = unchecked_take_enum_data_addr [[ENUM_ADDR]] : $*MaybeAddressOnlyPair, #MaybeAddressOnlyPair.Right!enumelt.1
-  // CHECK:   [[STR:%.*]] = load [[STR_ADDR]]
+  // CHECK:   [[STR:%.*]] = load [take] [[STR_ADDR]]
   case .Right(_):
   // CHECK:   destroy_value [[STR]] : $String
   // CHECK:   function_ref @_TF6switch1cFT_T_

--- a/test/SILGen/switch_abstraction.swift
+++ b/test/SILGen/switch_abstraction.swift
@@ -30,7 +30,7 @@ enum Wacky<A, B> {
 // CHECK: switch_enum_addr [[ENUM:%.*]] : $*Wacky<T, A>, {{.*}} case #Wacky.Bar!enumelt.1: [[DEST:bb[0-9]+]]
 // CHECK: [[DEST]]:
 // CHECK:   [[ORIG_ADDR:%.*]] = unchecked_take_enum_data_addr [[ENUM]] : $*Wacky<T, A>, #Wacky.Bar
-// CHECK:   [[ORIG:%.*]] = load [[ORIG_ADDR]]
+// CHECK:   [[ORIG:%.*]] = load [take] [[ORIG_ADDR]]
 // CHECK:   [[REABSTRACT:%.*]] = function_ref @_TTR
 // CHECK:   [[SUBST:%.*]] = partial_apply [[REABSTRACT]]<T>([[ORIG]])
 func enum_addr_only_to_loadable_with_reabstraction<T>(x x: Wacky<T, A>, a: A)

--- a/test/SILGen/switch_isa.swift
+++ b/test/SILGen/switch_isa.swift
@@ -17,7 +17,7 @@ func testSwitchOnExistential(_ value: Any) {
 // CHECK:   [[BOOL:%.*]] = alloc_stack $Bool
 // CHECK:   checked_cast_addr_br copy_on_success Any in [[ANY]] : $*Any to Bool in [[BOOL]] : $*Bool, [[IS_BOOL:bb[0-9]+]], [[IS_NOT_BOOL:bb[0-9]+]]
 // CHECK: [[IS_BOOL]]:
-// CHECK:   [[T0:%.*]] = load [[BOOL]]
+// CHECK:   [[T0:%.*]] = load [trivial] [[BOOL]]
 
 enum Foo {
   case A

--- a/test/SILGen/switch_var.swift
+++ b/test/SILGen/switch_var.swift
@@ -51,7 +51,7 @@ func test_var_1() {
   // CHECK-NOT: br bb
   case var x:
   // CHECK:   function_ref @_TF10switch_var1aFT1xSi_T_
-  // CHECK:   load [[X]]
+  // CHECK:   load [trivial] [[X]]
   // CHECK:   destroy_value [[XADDR]]
   // CHECK:   br [[CONT:bb[0-9]+]]
     a(x: x)
@@ -68,13 +68,13 @@ func test_var_2() {
   // CHECK:   [[XADDR:%.*]] = alloc_box $@box Int
   // CHECK:   [[X:%.*]] = project_box [[XADDR]]
   // CHECK:   function_ref @_TF10switch_var6runcedFT1xSi_Sb
-  // CHECK:   load [[X]]
+  // CHECK:   load [trivial] [[X]]
   // CHECK:   cond_br {{%.*}}, [[CASE1:bb[0-9]+]], [[NO_CASE1:bb[0-9]+]]
   // -- TODO: Clean up these empty waypoint bbs.
   case var x where runced(x: x):
   // CHECK: [[CASE1]]:
   // CHECK:   function_ref @_TF10switch_var1aFT1xSi_T_
-  // CHECK:   load [[X]]
+  // CHECK:   load [trivial] [[X]]
   // CHECK:   destroy_value [[XADDR]]
   // CHECK:   br [[CONT:bb[0-9]+]]
     a(x: x)
@@ -82,12 +82,12 @@ func test_var_2() {
   // CHECK:   [[YADDR:%.*]] = alloc_box $@box Int
   // CHECK:   [[Y:%.*]] = project_box [[YADDR]]
   // CHECK:   function_ref @_TF10switch_var6fungedFT1xSi_Sb
-  // CHECK:   load [[Y]]
+  // CHECK:   load [trivial] [[Y]]
   // CHECK:   cond_br {{%.*}}, [[CASE2:bb[0-9]+]], [[NO_CASE2:bb[0-9]+]]
   case var y where funged(x: y):
   // CHECK: [[CASE2]]:
   // CHECK:   function_ref @_TF10switch_var1bFT1xSi_T_
-  // CHECK:   load [[Y]]
+  // CHECK:   load [trivial] [[Y]]
   // CHECK:   destroy_value [[YADDR]]
   // CHECK:   br [[CONT]]
     b(x: y)
@@ -98,7 +98,7 @@ func test_var_2() {
   // CHECK:   [[ZADDR:%.*]] = alloc_box $@box Int
   // CHECK:   [[Z:%.*]] = project_box [[ZADDR]]
   // CHECK:   function_ref @_TF10switch_var1cFT1xSi_T_
-  // CHECK:   load [[Z]]
+  // CHECK:   load [trivial] [[Z]]
   // CHECK:   destroy_value [[ZADDR]]
   // CHECK:   br [[CONT]]
     c(x: z)
@@ -121,7 +121,7 @@ func test_var_3() {
   case var x where runced(x: x.0):
   // CHECK: [[CASE1]]:
   // CHECK:   function_ref @_TF10switch_var2aaFT1xTSiSi__T_
-  // CHECK:   load [[X]]
+  // CHECK:   load [trivial] [[X]]
   // CHECK:   destroy_value [[XADDR]]
   // CHECK:   br [[CONT:bb[0-9]+]]
     aa(x: x)
@@ -131,14 +131,14 @@ func test_var_3() {
   // CHECK:   [[Z:%.*]] = alloc_box $@box Int
   // CHECK:   [[Z:%.*]] = project_box [[ZADDR]]
   // CHECK:   function_ref @_TF10switch_var6fungedFT1xSi_Sb
-  // CHECK:   load [[Y]]
+  // CHECK:   load [trivial] [[Y]]
   // CHECK:   cond_br {{%.*}}, [[CASE2:bb[0-9]+]], [[NO_CASE2:bb[0-9]+]]
   case (var y, var z) where funged(x: y):
   // CHECK: [[CASE2]]:
   // CHECK:   function_ref @_TF10switch_var1aFT1xSi_T_
-  // CHECK:   load [[Y]]
+  // CHECK:   load [trivial] [[Y]]
   // CHECK:   function_ref @_TF10switch_var1bFT1xSi_T_
-  // CHECK:   load [[Z]]
+  // CHECK:   load [trivial] [[Z]]
   // CHECK:   destroy_value [[ZADDR]]
   // CHECK:   destroy_value [[YADDR]]
   // CHECK:   br [[CONT]]
@@ -153,7 +153,7 @@ func test_var_3() {
   case var w where ansed(x: w.0):
   // CHECK: [[CASE3]]:
   // CHECK:   function_ref @_TF10switch_var2bbFT1xTSiSi__T_
-  // CHECK:   load [[W]]
+  // CHECK:   load [trivial] [[W]]
   // CHECK:   br [[CONT]]
     bb(x: w)
   // CHECK: [[NO_CASE3]]:
@@ -164,7 +164,7 @@ func test_var_3() {
   // CHECK:   [[VADDR:%.*]] = alloc_box $@box (Int, Int) 
   // CHECK:   [[V:%.*]] = project_box [[VADDR]]
   // CHECK:   function_ref @_TF10switch_var2ccFT1xTSiSi__T_
-  // CHECK:   load [[V]]
+  // CHECK:   load [trivial] [[V]]
   // CHECK:   destroy_value [[VADDR]]
   // CHECK:   br [[CONT]]
     cc(x: v)
@@ -188,17 +188,17 @@ func test_var_4(p p: P) {
   // CHECK:   store
   // CHECK:   [[PAIR_0:%.*]] = tuple_element_addr [[PAIR]] : $*(P, Int), 0
   // CHECK:   [[T0:%.*]] = tuple_element_addr [[PAIR]] : $*(P, Int), 1
-  // CHECK:   [[PAIR_1:%.*]] = load [[T0]] : $*Int
+  // CHECK:   [[PAIR_1:%.*]] = load [trivial] [[T0]] : $*Int
   // CHECK:   [[TMP:%.*]] = alloc_stack $X
   // CHECK:   checked_cast_addr_br copy_on_success P in [[PAIR_0]] : $*P to X in [[TMP]] : $*X, [[IS_X:bb[0-9]+]], [[IS_NOT_X:bb[0-9]+]]
 
   // CHECK: [[IS_X]]:
-  // CHECK:   [[T0:%.*]] = load [[TMP]] : $*X
+  // CHECK:   [[T0:%.*]] = load [trivial] [[TMP]] : $*X
   // CHECK:   [[XADDR:%.*]] = alloc_box $@box Int
   // CHECK:   [[X:%.*]] = project_box [[XADDR]]
-  // CHECK:   store [[PAIR_1]] to [[X]]
+  // CHECK:   store [[PAIR_1]] to [trivial] [[X]]
   // CHECK:   function_ref @_TF10switch_var6runcedFT1xSi_Sb
-  // CHECK:   load [[X]]
+  // CHECK:   load [trivial] [[X]]
   // CHECK:   cond_br {{%.*}}, [[CASE1:bb[0-9]+]], [[NO_CASE1:bb[0-9]+]]
   case (is X, var x) where runced(x: x):
   // CHECK: [[CASE1]]:
@@ -223,18 +223,18 @@ func test_var_4(p p: P) {
   // CHECK:   checked_cast_addr_br copy_on_success P in [[PAIR_0]] : $*P to Y in [[TMP]] : $*Y, [[IS_Y:bb[0-9]+]], [[IS_NOT_Y:bb[0-9]+]]
 
   // CHECK: [[IS_Y]]:
-  // CHECK:   [[T0:%.*]] = load [[TMP]] : $*Y
+  // CHECK:   [[T0:%.*]] = load [trivial] [[TMP]] : $*Y
   // CHECK:   [[YADDR:%.*]] = alloc_box $@box Int
   // CHECK:   [[Y:%.*]] = project_box [[YADDR]]
-  // CHECK:   store [[PAIR_1]] to [[Y]]
+  // CHECK:   store [[PAIR_1]] to [trivial] [[Y]]
   // CHECK:   function_ref @_TF10switch_var6fungedFT1xSi_Sb
-  // CHECK:   load [[Y]]
+  // CHECK:   load [trivial] [[Y]]
   // CHECK:   cond_br {{%.*}}, [[CASE2:bb[0-9]+]], [[NO_CASE2:bb[0-9]+]]
 
   case (is Y, var y) where funged(x: y):
   // CHECK: [[CASE2]]:
   // CHECK:   function_ref @_TF10switch_var1bFT1xSi_T_
-  // CHECK:   load [[Y]]
+  // CHECK:   load [trivial] [[Y]]
   // CHECK:   destroy_value [[YADDR]]
   // CHECK:   dealloc_stack [[TMP]]
   // CHECK:   destroy_addr [[PAIR_0]] : $*P
@@ -274,7 +274,7 @@ func test_var_4(p p: P) {
   // CHECK:   [[WADDR:%.*]] = alloc_box $@box Int
   // CHECK:   [[W:%.*]] = project_box [[WADDR]]
   // CHECK:   function_ref @_TF10switch_var1dFT1xSi_T_
-  // CHECK:   load [[W]]
+  // CHECK:   load [trivial] [[W]]
   // CHECK:   destroy_value [[WADDR]]
   // CHECK:   destroy_addr [[PAIR_0]] : $*P
   // CHECK:   dealloc_stack [[PAIR]]
@@ -454,14 +454,12 @@ func test_mixed_let_var() {
   // CHECK:   [[BOX:%.*]] = alloc_box $@box String, var, name "x"
   // CHECK:   [[PBOX:%.*]] = project_box [[BOX]]
   // CHECK:   [[VAL_COPY:%.*]] = copy_value [[VAL]]
-  // CHECK:   store [[VAL_COPY]] to [[PBOX]]
+  // CHECK:   store [[VAL_COPY]] to [init] [[PBOX]]
   // CHECK:   cond_br {{.*}}, [[CASE1:bb[0-9]+]], [[NOCASE1:bb[0-9]+]]
   case var x where runced():
   // CHECK: [[CASE1]]:
   // CHECK:   [[A:%.*]] = function_ref @_TF10switch_var1aFT1xSS_T_
-  // CHECK:   [[X:%.*]] = load [[PBOX]]
-  // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
-  // SEMANTIC ARC TODO: The next line should pass in X_COPY, not X
+  // CHECK:   [[X:%.*]] = load [copy] [[PBOX]]
   // CHECK:   apply [[A]]([[X]])
   // CHECK:   destroy_value [[BOX]]
   // CHECK:   br [[CONT:bb[0-9]+]]

--- a/test/SILGen/toplevel.swift
+++ b/test/SILGen/toplevel.swift
@@ -49,7 +49,7 @@ if x == 5 {
 }
 
 // CHECK: [[MERGE]]:
-// CHECK: load [[COUNTMUI]]
+// CHECK: load [trivial] [[COUNTMUI]]
 markUsed(count)
 
 

--- a/test/SILGen/unowned.swift
+++ b/test/SILGen/unowned.swift
@@ -63,7 +63,7 @@ func test0(c c: C) {
   // CHECK:   destroy_value [[ARG_COPY]]
 
   a.x = x
-  // CHECK:   [[T2:%.*]] = load [[PBX]] : $*@sil_unowned C     
+  // CHECK:   [[T2:%.*]] = load [take] [[PBX]] : $*@sil_unowned C     
   // CHECK:   strong_retain_unowned  [[T2]] : $@sil_unowned C  
   // CHECK:   [[T3:%.*]] = unowned_to_ref [[T2]] : $@sil_unowned C to $C
   // CHECK:   [[XP:%.*]] = struct_element_addr [[A]] : $*A, #A.x
@@ -91,7 +91,7 @@ func unowned_local() -> C {
   // CHECK: destroy_value [[C_COPY]]
   unowned let uc = c
 
-  // CHECK: [[tmp2:%.*]] = load [[PB_UC]]
+  // CHECK: [[tmp2:%.*]] = load [take] [[PB_UC]]
   // CHECK: strong_retain_unowned [[tmp2]]
   // CHECK: [[tmp3:%.*]] = unowned_to_ref [[tmp2]]
   return uc

--- a/test/SILGen/weak.swift
+++ b/test/SILGen/weak.swift
@@ -26,16 +26,14 @@ func test0(c c: C) {
 // CHECK:      [[X:%.*]] = alloc_box $@box @sil_weak Optional<C>, var, name "x"
 // CHECK-NEXT: [[PBX:%.*]] = project_box [[X]]
 //   Implicit conversion
-// CHECK-NEXT: [[TMP:%.*]] = load [[PBC]] : $*C
-// CHECK-NEXT: copy_value [[TMP]] : $C
+// CHECK-NEXT: [[TMP:%.*]] = load [copy] [[PBC]] : $*C
 // CHECK-NEXT: [[OPTVAL:%.*]] = enum $Optional<C>, #Optional.some!enumelt.1, [[TMP]] : $C
 // CHECK-NEXT: store_weak [[OPTVAL]] to [initialization] [[PBX]] : $*@sil_weak Optional<C>
 // CHECK-NEXT: destroy_value [[OPTVAL]] : $Optional<C>
 
   a.x = c
 //   Implicit conversion
-// CHECK-NEXT: [[TMP:%.*]] = load [[PBC]] : $*C
-// CHECK-NEXT: copy_value [[TMP]] : $C
+// CHECK-NEXT: [[TMP:%.*]] = load [copy] [[PBC]] : $*C
 // CHECK-NEXT: [[OPTVAL:%.*]] = enum $Optional<C>, #Optional.some!enumelt.1, [[TMP]] : $C
 
 //   Drill to a.x

--- a/test/SILGen/witnesses.swift
+++ b/test/SILGen/witnesses.swift
@@ -100,11 +100,11 @@ struct ConformingStruct : X {
   func selfTypes(x: ConformingStruct) -> ConformingStruct { return x }
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWV9witnesses16ConformingStructS_1XS_FS1_9selfTypes{{.*}} : $@convention(witness_method) (@in ConformingStruct, @inout ConformingStruct) -> @out ConformingStruct {
   // CHECK:       bb0(%0 : $*ConformingStruct, %1 : $*ConformingStruct, %2 : $*ConformingStruct):
-  // CHECK-NEXT:    %3 = load %1 : $*ConformingStruct
+  // CHECK-NEXT:    %3 = load [trivial] %1 : $*ConformingStruct
   // CHECK-NEXT:    // function_ref
   // CHECK-NEXT:    %4 = function_ref @_TFV9witnesses16ConformingStruct9selfTypes{{.*}} : $@convention(method) (ConformingStruct, @inout ConformingStruct) -> ConformingStruct
   // CHECK-NEXT:    %5 = apply %4(%3, %2) : $@convention(method) (ConformingStruct, @inout ConformingStruct) -> ConformingStruct
-  // CHECK-NEXT:    store %5 to %0 : $*ConformingStruct
+  // CHECK-NEXT:    store %5 to [trivial] %0 : $*ConformingStruct
   // CHECK-NEXT:    %7 = tuple ()
   // CHECK-NEXT:    return %7 : $()
   // CHECK-NEXT:  }
@@ -152,13 +152,13 @@ struct ConformingStruct : X {
 }
 func <~>(_ x: ConformingStruct, y: ConformingStruct) -> ConformingStruct { return x }
 // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWV9witnesses16ConformingStructS_1XS_ZFS1_oi3ltg{{.*}} : $@convention(witness_method) (@in ConformingStruct, @in ConformingStruct, @thick ConformingStruct.Type) -> @out ConformingStruct {
-// CHECK:       bb0(%0 : $*ConformingStruct, %1 : $*ConformingStruct, %2 : $*ConformingStruct, %3 : $@thick ConformingStruct.Type):
-// CHECK-NEXT:    %4 = load %1 : $*ConformingStruct
-// CHECK-NEXT:    %5 = load %2 : $*ConformingStruct
+// CHECK:       bb0([[ARG1:%.*]] : $*ConformingStruct, [[ARG2:%.*]] : $*ConformingStruct, [[ARG3:%.*]] : $*ConformingStruct, [[ARG4:%.*]] : $@thick ConformingStruct.Type):
+// CHECK-NEXT:    [[LOADED_ARG2:%.*]] = load [trivial] [[ARG2]] : $*ConformingStruct
+// CHECK-NEXT:    [[LOADED_ARG3:%.*]] = load [trivial] [[ARG3]] : $*ConformingStruct
 // CHECK-NEXT:    // function_ref
-// CHECK-NEXT:    %6 = function_ref @_TF9witnessesoi3ltgFTVS_16ConformingStructS0__S0_ : $@convention(thin) (ConformingStruct, ConformingStruct) -> ConformingStruct
-// CHECK-NEXT:    %7 = apply %6(%4, %5) : $@convention(thin) (ConformingStruct, ConformingStruct) -> ConformingStruct
-// CHECK-NEXT:    store %7 to %0 : $*ConformingStruct
+// CHECK-NEXT:    [[FUNC:%.*]] = function_ref @_TF9witnessesoi3ltgFTVS_16ConformingStructS0__S0_ : $@convention(thin) (ConformingStruct, ConformingStruct) -> ConformingStruct
+// CHECK-NEXT:    [[FUNC_RESULT:%.*]] = apply [[FUNC]]([[LOADED_ARG2]], [[LOADED_ARG3]]) : $@convention(thin) (ConformingStruct, ConformingStruct) -> ConformingStruct
+// CHECK-NEXT:    store [[FUNC_RESULT]] to [trivial] [[ARG1]] : $*ConformingStruct
 // CHECK-NEXT:    %9 = tuple ()
 // CHECK-NEXT:    return %9 : $()
 // CHECK-NEXT:  }
@@ -166,18 +166,15 @@ func <~>(_ x: ConformingStruct, y: ConformingStruct) -> ConformingStruct { retur
 final class ConformingClass : X {
   func selfTypes(x: ConformingClass) -> ConformingClass { return x }
   // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWC9witnesses15ConformingClassS_1XS_FS1_9selfTypes{{.*}} : $@convention(witness_method) (@in ConformingClass, @inout ConformingClass) -> @out ConformingClass {
-  // CHECK:       bb0(%0 : $*ConformingClass, %1 : $*ConformingClass, %2 : $*ConformingClass):
+  // CHECK:  bb0([[ARG1:%.*]] : $*ConformingClass, [[ARG2:%.*]] : $*ConformingClass, [[ARG3:%.*]] : $*ConformingClass):
   // -- load and copy_value 'self' from inout witness 'self' parameter
-  // CHECK-NEXT:    %3 = load %2 : $*ConformingClass
-  // CHECK-NEXT:    copy_value %3 : $ConformingClass
-  // CHECK-NEXT:    %5 = load %1 : $*ConformingClass
-  // CHECK:         %6 = function_ref @_TFC9witnesses15ConformingClass9selfTypes 
-  // CHECK-NEXT:    %7 = apply %6(%5, %3) : $@convention(method) (@owned ConformingClass, @guaranteed ConformingClass) -> @owned ConformingClass
-  // CHECK-NEXT:    store %7 to %0 : $*ConformingClass
-  // CHECK-NEXT:    %9 = tuple ()
-  // CHECK-NEXT:    destroy_value %3
-  // CHECK-NEXT:    return %9 : $()
-  // CHECK-NEXT:  }
+  // CHECK:    [[ARG3_LOADED:%.*]] = load [copy] [[ARG3]] : $*ConformingClass
+  // CHECK:    [[ARG2_LOADED:%.*]] = load [take] [[ARG2]] : $*ConformingClass
+  // CHECK:    [[FUNC:%.*]] = function_ref @_TFC9witnesses15ConformingClass9selfTypes 
+  // CHECK:    [[FUNC_RESULT:%.*]] = apply [[FUNC]]([[ARG2_LOADED]], [[ARG3_LOADED]]) : $@convention(method) (@owned ConformingClass, @guaranteed ConformingClass) -> @owned ConformingClass
+  // CHECK:    store [[FUNC_RESULT]] to [init] [[ARG1]] : $*ConformingClass
+  // CHECK:    destroy_value [[ARG3_LOADED]]
+  // CHECK:  } // end sil function '_TTWC9witnesses15ConformingClassS_1XS_FS1_9selfTypes{{.*}}'
   func loadable(x: Loadable) -> Loadable { return x }
   func addrOnly(x: AddrOnly) -> AddrOnly { return x }
   func generic<D>(x: D) -> D { return x }
@@ -260,7 +257,7 @@ struct ConformsWithMoreGeneric : X, Y {
   // CHECK-NEXT:    [[WITNESS_FN:%.*]] = function_ref @_TFV9witnesses23ConformsWithMoreGeneric7classes{{.*}} : $@convention(method) <τ_0_0> (@in τ_0_0, @inout ConformsWithMoreGeneric) -> @out τ_0_0
   // CHECK-NEXT:    [[RESULT_BOX:%.*]] = alloc_stack $τ_0_0
   // CHECK-NEXT:    [[RESULT:%.*]] = apply [[WITNESS_FN]]<τ_0_0>([[RESULT_BOX]], [[SELF_BOX]], %1) : $@convention(method) <τ_0_0> (@in τ_0_0, @inout ConformsWithMoreGeneric) -> @out τ_0_0
-  // CHECK-NEXT:    [[RESULT:%.*]] = load [[RESULT_BOX]] : $*τ_0_0
+  // CHECK-NEXT:    [[RESULT:%.*]] = load [take] [[RESULT_BOX]] : $*τ_0_0
   // CHECK-NEXT:    dealloc_stack [[RESULT_BOX]] : $*τ_0_0
   // CHECK-NEXT:    dealloc_stack [[SELF_BOX]] : $*τ_0_0
   // CHECK-NEXT:    return [[RESULT]] : $τ_0_0
@@ -350,7 +347,7 @@ struct FailableModel: FailableRequirement, IUOFailableRequirement {
   // CHECK: bb0([[SELF:%[0-9]+]] : $*Optional<FailableModel>, [[FOO:%[0-9]+]] : $Int, [[META:%[0-9]+]] : $@thick FailableModel.Type):
   // CHECK: [[FN:%.*]] = function_ref @_TFV9witnesses13FailableModelC{{.*}}
   // CHECK: [[INNER:%.*]] = apply [[FN]](
-  // CHECK: store [[INNER]] to %0
+  // CHECK: store [[INNER]] to [trivial] [[SELF]]
   // CHECK: return
   init?(foo: Int) {}
 }
@@ -493,7 +490,7 @@ class CrashableBase {
 // CHECK:       bb0(%0 : $*GenericCrashable<τ_0_0>):
 // CHECK-NEXT: [[BOX:%.*]] = alloc_stack $GenericCrashable<τ_0_0>
 // CHECK-NEXT: copy_addr %0 to [initialization] [[BOX]] : $*GenericCrashable<τ_0_0>
-// CHECK-NEXT: [[SELF:%.*]] = load [[BOX]] : $*GenericCrashable<τ_0_0>
+// CHECK-NEXT: [[SELF:%.*]] = load [take] [[BOX]] : $*GenericCrashable<τ_0_0>
 // CHECK-NEXT: [[BASE:%.*]] = upcast [[SELF]] : $GenericCrashable<τ_0_0> to $CrashableBase
 // CHECK-NEXT: [[FN:%.*]] = class_method [[BASE]] : $CrashableBase, #CrashableBase.crash!1 : (CrashableBase) -> () -> () , $@convention(method) (@guaranteed CrashableBase) -> ()
 // CHECK-NEXT: apply [[FN]]([[BASE]]) : $@convention(method) (@guaranteed CrashableBase) -> ()

--- a/test/SILGen/witnesses_inheritance.swift
+++ b/test/SILGen/witnesses_inheritance.swift
@@ -35,7 +35,7 @@ class B : A, Barrable {}
 // CHECK-NOT: sil hidden [transparent] [thunk] @_TTWC21witnesses_inheritance1BS_7FooableS_FS1_3foo
 // CHECK-NOT: sil hidden [transparent] [thunk] @_TTWC21witnesses_inheritance1BS_7FooableS_ZFS1_9class_foo
 // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWC21witnesses_inheritance1BS_8BarrableS_FS1_3bar
-// CHECK:         [[B:%.*]] = load {{%.*}} : $*B
+// CHECK:         [[B:%.*]] = load [take] {{%.*}} : $*B
 // CHECK-NEXT:    [[A:%.*]] = upcast [[B]] : $B to $A
 // CHECK-NEXT:    [[METH:%.*]] = class_method [[A]] : $A, #A.bar!1
 // CHECK-LABEL: sil hidden [transparent] [thunk] @_TTWC21witnesses_inheritance1BS_8BarrableS_ZFS1_9class_bar

--- a/test/SILGen/writeback.swift
+++ b/test/SILGen/writeback.swift
@@ -49,7 +49,7 @@ x.foo()
 // CHECK: [[X:%.*]] = apply [[GET_X]]() : $@convention(thin) () -> Foo
 // CHECK: store [[X]] to [trivial] [[X_TEMP]]
 // CHECK: apply [[FOO]]([[X_TEMP]]) : $@convention(method) (@inout Foo) -> ()
-// CHECK: [[X1:%.*]] = load [[X_TEMP]] : $*Foo
+// CHECK: [[X1:%.*]] = load [trivial] [[X_TEMP]] : $*Foo
 // CHECK: [[SET_X:%.*]] = function_ref @_TF9writebacks1xVS_3Foo : $@convention(thin) (Foo) -> ()
 // CHECK: apply [[SET_X]]([[X1]]) : $@convention(thin) (Foo) -> ()
 // CHECK: dealloc_stack [[X_TEMP]] : $*Foo
@@ -62,7 +62,7 @@ bar(x: &x)
 // CHECK: [[X:%.*]] = apply [[GET_X]]() : $@convention(thin) () -> Foo
 // CHECK: store [[X]] to [trivial] [[X_TEMP]] : $*Foo
 // CHECK: apply [[BAR]]([[X_TEMP]]) : $@convention(thin) (@inout Foo) -> ()
-// CHECK: [[X1:%.*]] = load [[X_TEMP]] : $*Foo
+// CHECK: [[X1:%.*]] = load [trivial] [[X_TEMP]] : $*Foo
 // CHECK: [[SET_X:%.*]] = function_ref @_TF9writebacks1xVS_3Foo : $@convention(thin) (Foo) -> ()
 // CHECK: apply [[SET_X]]([[X1]]) : $@convention(thin) (Foo) -> ()
 // CHECK: dealloc_stack [[X_TEMP]] : $*Foo

--- a/test/SILOptimizer/capture_promotion.sil
+++ b/test/SILOptimizer/capture_promotion.sil
@@ -8,7 +8,10 @@
 sil_stage raw
 
 import Builtin
-import Swift
+
+struct Int {
+  var value : Builtin.Int64
+}
 
 class Foo {
   func foo() -> Int

--- a/test/SILOptimizer/capture_promotion_generic_context.sil
+++ b/test/SILOptimizer/capture_promotion_generic_context.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -O %s | %FileCheck %s
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-sil -O %s | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILOptimizer/cast_folding_no_bridging.sil
+++ b/test/SILOptimizer/cast_folding_no_bridging.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -O -emit-sil %s | %FileCheck %s
 // REQUIRES: objc_interop
 
 // FIXME: https://bugs.swift.org/browse/SR-2808

--- a/test/Serialization/sil_partial_apply_ownership.sil
+++ b/test/Serialization/sil_partial_apply_ownership.sil
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
-// RUN: %target-build-swift -emit-module -Xfrontend -disable-diagnostic-passes -Xfrontend -sil-serialize-all -force-single-frontend-invocation -o %t/sil_partial_apply_ownership.swiftmodule %s
-// RUN: %target-build-swift -emit-sil -Xfrontend -sil-link-all -I %t %s | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -assume-parsing-unqualified-ownership-sil -emit-module -Xfrontend -disable-diagnostic-passes -Xfrontend -sil-serialize-all -force-single-frontend-invocation -o %t/sil_partial_apply_ownership.swiftmodule %s
+// RUN: %target-build-swift -Xfrontend -assume-parsing-unqualified-ownership-sil -emit-sil -Xfrontend -sil-link-all -I %t %s | %FileCheck %s
 
 import Builtin
 


### PR DESCRIPTION
[semantic-arc] Handle the rest of the unqualified mem opts in SILGen.

Keep in mind that these are approximations that will not impact correctness
since in all cases I ensured that the SIL will be the same after the
OwnershipModelEliminator has run. The cases that I was unsure of I commented
with SEMANTIC ARC TODO. Once we have the verifier any confusion that may have
occurred here will be dealt with.
    
rdar://28685236