### PR TITLE
[test] Fix three Driver tests under cross-compilation.

### DIFF
--- a/test/Driver/continue-building-after-errors.swift
+++ b/test/Driver/continue-building-after-errors.swift
@@ -1,5 +1,5 @@
-// RUN: not %swiftc_driver %S/Inputs/error.swift %s 2>&1 | %FileCheck %s
-// RUN: not %swiftc_driver -continue-building-after-errors %S/Inputs/error.swift %s 2>&1 | %FileCheck -check-prefix=CHECK-CONTINUE %s
+// RUN: not %target-build-swift %S/Inputs/error.swift %s 2>&1 | %FileCheck %s
+// RUN: not %target-build-swift -continue-building-after-errors %S/Inputs/error.swift %s 2>&1 | %FileCheck -check-prefix=CHECK-CONTINUE %s
 
 // CHECK: self.bar = self.bar
 // CHECK-NOT: self.baz = self.baz

--- a/test/Driver/driver-time-compilation.swift
+++ b/test/Driver/driver-time-compilation.swift
@@ -1,5 +1,5 @@
-// RUN: %swiftc_driver -parse -driver-time-compilation %s 2>&1 | %FileCheck %s
-// RUN: %swiftc_driver -parse -driver-time-compilation %s %S/../Inputs/empty.swift 2>&1 | %FileCheck -check-prefix CHECK-MULTIPLE %s
+// RUN: %target-build-swift -parse -driver-time-compilation %s 2>&1 | %FileCheck %s
+// RUN: %target-build-swift -parse -driver-time-compilation %s %S/../Inputs/empty.swift 2>&1 | %FileCheck -check-prefix CHECK-MULTIPLE %s
 
 // CHECK: Driver Time Compilation
 // CHECK: Total Execution Time: {{[0-9]+}}.{{[0-9]+}} seconds ({{[0-9]+}}.{{[0-9]+}} wall clock)

--- a/test/Driver/swift-version-default.swift
+++ b/test/Driver/swift-version-default.swift
@@ -1,8 +1,9 @@
-// RUN: %swiftc_driver_plain -parse -Xfrontend -verify %s
+// RUN: %swiftc_driver_plain -target %target-triple -module-cache-path %t -parse -Xfrontend -verify %s
 
 // This test should be updated to match the expected default Swift version
 // when swiftc is invoked directly.
-// It should /not/ follow the version specified when invoking lit.
+// It should /not/ follow the version specified when invoking lit, which means
+// it can't use the %swiftc_driver or %target-build-swift substitutions.
 
 #if swift(>=3)
 asdf // expected-error {{use of unresolved identifier}}


### PR DESCRIPTION
The driver exits out early if there's no stdlib for the target you're compiling for, and these tests didn't pass a target for one reason or another.

rdar://problem/29173390