### PR TITLE
[index] Disable typo-correction when indexing

### DIFF
--- a/test/Sema/typo_correction.swift
+++ b/test/Sema/typo_correction.swift
@@ -1,4 +1,6 @@
 // RUN: %target-parse-verify-swift
+// RUN: not %target-swift-frontend -parse -disable-typo-correction %s 2>&1 | %FileCheck %s -check-prefix=DISABLED
+// DISABLED-NOT: did you mean
 
 // This is close enough to get typo-correction.
 func test_short_and_close() {

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -196,7 +196,7 @@ void trace::initTraceFiles(trace::SwiftInvocation &SwiftArgs,
 
 void SwiftLangSupport::indexSource(StringRef InputFile,
                                    IndexingConsumer &IdxConsumer,
-                                   ArrayRef<const char *> Args,
+                                   ArrayRef<const char *> OrigArgs,
                                    StringRef Hash) {
   std::string Error;
   auto InputBuf = ASTMgr->getMemoryBuffer(InputFile, Error);
@@ -213,6 +213,12 @@ void SwiftLangSupport::indexSource(StringRef InputFile,
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
+
+  // Add -disable-typo-correction, since the errors won't be captured in the
+  // response, and it can be expensive to do typo-correction when there are many
+  // errors, which is common in indexing.
+  SmallVector<const char *, 16> Args(OrigArgs.begin(), OrigArgs.end());
+  Args.push_back("-disable-typo-correction");
 
   CompilerInvocation Invocation;
   bool Failed = getASTManager().initCompilerInvocation(Invocation, Args,


### PR DESCRIPTION
The errors won't be captured in the response, and it can be expensive to
do typo-correction when there are many errors, which is common in
indexing.

rdar://problem/28963058