### PR TITLE
Move unit test to more appropriate class

### DIFF
--- a/validation-test/stdlib/SpriteKit.swift
+++ b/validation-test/stdlib/SpriteKit.swift
@@ -46,7 +46,7 @@ SpriteKitTests.test("getRed(_:green:blue:alpha:)") {
 
 if #available(OSX 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *) {
   SpriteKitTests.test("SKNode.setValue(_:forAttribute:)") {
-    let node = SKNode()
+    let node = SKSpriteNode()
     let attrVal = SKAttributeValue(float: 2.0)
     node.setValue(attrVal, forAttribute: "test")
     expectEqual(node.attributeValues["test"], attrVal)


### PR DESCRIPTION
Moving from `SKNode` to `SKSpriteNode`.