### PR TITLE
[test] make a constant_struct_with_padding work when cross-compiling.

### DIFF
--- a/test/IRGen/constant_struct_with_padding.sil
+++ b/test/IRGen/constant_struct_with_padding.sil
@@ -1,4 +1,4 @@
-// RUN: %swift -assume-parsing-unqualified-ownership-sil -module-name main %s -emit-ir -o - | %FileCheck %s
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -module-name main %s -emit-ir -o - | %FileCheck %s
 
 sil_stage canonical
 


### PR DESCRIPTION
Addresses rdar://problem/29173452.