### PR TITLE
Minor ImportName refactoring

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -812,131 +812,6 @@ bool ClangImporter::addSearchPath(StringRef newSearchPath, bool isFramework) {
   return false;
 }
 
-void importer::addEntryToLookupTable(SwiftLookupTable &table,
-                                     clang::NamedDecl *named,
-                                     NameImporter &nameImporter) {
-  // Determine whether this declaration is suppressed in Swift.
-  if (shouldSuppressDeclImport(named)) return;
-
-  // Leave incomplete struct/enum/union types out of the table; Swift only
-  // handles pointers to them.
-  // FIXME: At some point we probably want to be importing incomplete types,
-  // so that pointers to different incomplete types themselves have distinct
-  // types. At that time it will be necessary to make the decision of whether
-  // or not to import an incomplete type declaration based on whether it's
-  // actually the struct backing a CF type:
-  //
-  //    typedef struct CGColor *CGColorRef;
-  //
-  // The best way to do this is probably to change CFDatabase.def to include
-  // struct names when relevant, not just pointer names. That way we can check
-  // both CFDatabase.def and the objc_bridge attribute and cover all our bases.
-  if (auto *tagDecl = dyn_cast<clang::TagDecl>(named)) {
-    if (!tagDecl->getDefinition())
-      return;
-  }
-
-  // If we have a name to import as, add this entry to the table.
-  if (auto importedName = nameImporter.importName(named, None)) {
-    table.addEntry(importedName.Imported, named, importedName.EffectiveContext);
-
-    // Also add the subscript entry, if needed.
-    if (importedName.isSubscriptAccessor())
-      table.addEntry(DeclName(nameImporter.getContext(),
-                              nameImporter.getContext().Id_subscript,
-                              ArrayRef<Identifier>()),
-                     named, importedName.EffectiveContext);
-
-    // Import the Swift 2 name of this entity, and record it as well if it is
-    // different.
-    if (auto swift2Name =
-            nameImporter.importName(named, ImportNameFlags::Swift2Name)) {
-      if (swift2Name.Imported != importedName.Imported)
-        table.addEntry(swift2Name.Imported, named, swift2Name.EffectiveContext);
-    }
-  } else if (auto category = dyn_cast<clang::ObjCCategoryDecl>(named)) {
-    // If the category is invalid, don't add it.
-    if (category->isInvalidDecl()) return;
-
-    table.addCategory(category);
-  }
-
-  // Walk the members of any context that can have nested members.
-  if (isa<clang::TagDecl>(named) ||
-      isa<clang::ObjCInterfaceDecl>(named) ||
-      isa<clang::ObjCProtocolDecl>(named) ||
-      isa<clang::ObjCCategoryDecl>(named)) {
-    clang::DeclContext *dc = cast<clang::DeclContext>(named);
-    for (auto member : dc->decls()) {
-      if (auto namedMember = dyn_cast<clang::NamedDecl>(member))
-        addEntryToLookupTable(table, namedMember, nameImporter);
-    }
-  }
-}
-
-void importer::addMacrosToLookupTable(clang::ASTContext &clangCtx,
-                                      clang::Preprocessor &pp,
-                                      SwiftLookupTable &table,
-                                      ASTContext &SwiftContext) {
-  for (const auto &macro : pp.macros(false)) {
-    // Find the local history of this macro directive.
-    clang::MacroDirective *MD = pp.getLocalMacroDirectiveHistory(macro.first);
-
-    // Walk the history.
-    for (; MD; MD = MD->getPrevious()) {
-      // Don't look at any definitions that are followed by undefs.
-      // FIXME: This isn't quite correct across explicit submodules -- one
-      // submodule might define a macro, while another defines and then
-      // undefines the same macro. If they are processed in that order, the
-      // history will have the undef at the end, and we'll miss the first
-      // definition.
-      if (isa<clang::UndefMacroDirective>(MD))
-        break;
-
-      // Only interested in macro definitions.
-      auto *defMD = dyn_cast<clang::DefMacroDirective>(MD);
-      if (!defMD) continue;
-
-      // Is this definition from this module?
-      auto info = defMD->getInfo();
-      if (!info || info->isFromASTFile()) continue;
-
-      // If we hit a builtin macro, we're done.
-      if (info->isBuiltinMacro()) break;
-
-      // If we hit a macro with invalid or predefined location, we're done.
-      auto loc = defMD->getLocation();
-      if (loc.isInvalid()) break;
-      if (pp.getSourceManager().getFileID(loc) == pp.getPredefinesFileID())
-        break;
-
-      // Add this entry.
-      auto name = importMacroName(macro.first, info, clangCtx, SwiftContext);
-      if (name.empty()) continue;
-      table.addEntry(name, info, clangCtx.getTranslationUnitDecl(), &pp);
-    }
-  }
-}
-
-void importer::finalizeLookupTable(clang::ASTContext &clangCtx,
-                                   clang::Preprocessor &pp,
-                                   SwiftLookupTable &table,
-                                   ASTContext &SwiftContext) {
-  // Resolve any unresolved entries.
-  SmallVector<SwiftLookupTable::SingleEntry, 4> unresolved;
-  if (table.resolveUnresolvedEntries(unresolved)) {
-    // Complain about unresolved entries that remain.
-    for (auto entry : unresolved) {
-      auto decl = entry.get<clang::NamedDecl *>();
-      auto swiftName = decl->getAttr<clang::SwiftNameAttr>();
-
-      SwiftContext.Diags.diagnose(SourceLoc(), diag::unresolvable_clang_decl,
-                                  decl->getNameAsString(),
-                                  swiftName->getName());
-    }
-  }
-}
-
 bool ClangImporter::Implementation::importHeader(
     Module *adapter, StringRef headerName, SourceLoc diagLoc,
     bool trackParsedSymbols,
@@ -997,14 +872,14 @@ bool ClangImporter::Implementation::importHeader(
   for (auto group : allParsedDecls)
     for (auto *D : group)
       if (auto named = dyn_cast<clang::NamedDecl>(D))
-        addEntryToLookupTable(BridgingHeaderLookupTable, named, *nameImporter);
+        addEntryToLookupTable(BridgingHeaderLookupTable, named,
+                              getNameImporter());
 
   pp.EndSourceFile();
   bumpGeneration();
 
   // Add any defined macros to the bridging header lookup table.
-  addMacrosToLookupTable(getClangASTContext(), getClangPreprocessor(),
-                         BridgingHeaderLookupTable, SwiftContext);
+  addMacrosToLookupTable(BridgingHeaderLookupTable, getNameImporter());
 
   // Wrap all Clang imports under a Swift import decl.
   for (auto &Import : BridgeHeaderTopLevelImports) {
@@ -1014,8 +889,7 @@ bool ClangImporter::Implementation::importHeader(
   }
 
   // Finalize the lookup table, which may fail.
-  finalizeLookupTable(getClangASTContext(), getClangPreprocessor(),
-                      BridgingHeaderLookupTable, SwiftContext);
+  finalizeLookupTable(BridgingHeaderLookupTable, getNameImporter());
 
   // FIXME: What do we do if there was already an error?
   if (!hadError && clangDiags.hasErrorOccurred()) {
@@ -1855,12 +1729,11 @@ void ClangImporter::lookupBridgingHeaderDecls(
     }
   }
 
-  auto &ClangCtx = Impl.getClangASTContext();
   auto &ClangPP = Impl.getClangPreprocessor();
   for (clang::IdentifierInfo *II : Impl.BridgeHeaderMacros) {
     if (auto *MI = ClangPP.getMacroInfo(II)) {
       if (filter(MI)) {
-        Identifier Name = importMacroName(II, MI, ClangCtx, Impl.SwiftContext);
+        Identifier Name = Impl.getNameImporter().importMacroName(II, MI);
         if (Decl *imported = Impl.importMacro(Name, MI))
           receiver(imported);
       }
@@ -1937,8 +1810,7 @@ bool ClangImporter::lookupDeclsFromHeader(StringRef Filename,
           auto *II = const_cast<clang::IdentifierInfo*>(MD->getName());
           if (auto *MI = ClangPP.getMacroInfo(II)) {
             if (filter(MI)) {
-              Identifier Name =
-                  importMacroName(II, MI, ClangCtx, Impl.SwiftContext);
+              Identifier Name = Impl.getNameImporter().importMacroName(II, MI);
               if (Decl *imported = Impl.importMacro(Name, MI))
                 receiver(imported);
             }

--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -463,12 +463,10 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
         auto firstMacroInfo = impl.getClangPreprocessor().getMacroInfo(firstID);
         auto secondMacroInfo = impl.getClangPreprocessor().getMacroInfo(
                                                                       secondID);
-        auto firstIdentifier = importMacroName(firstID, firstMacroInfo,
-                                               impl.getClangASTContext(),
-                                               impl.SwiftContext);
-        auto secondIdentifier = importMacroName(secondID, secondMacroInfo,
-                                               impl.getClangASTContext(),
-                                               impl.SwiftContext);
+        auto firstIdentifier =
+            impl.getNameImporter().importMacroName(firstID, firstMacroInfo);
+        auto secondIdentifier =
+            impl.getNameImporter().importMacroName(secondID, secondMacroInfo);
         impl.importMacro(firstIdentifier, firstMacroInfo);
         impl.importMacro(secondIdentifier, secondMacroInfo);
         auto firstIterator = impl.ImportedMacroConstants.find(firstMacroInfo);

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1619,16 +1619,16 @@ bool ClangImporter::shouldIgnoreMacro(StringRef Name,
   return ::shouldIgnoreMacro(Name, Macro);
 }
 
-Identifier importer::importMacroName(
-    const clang::IdentifierInfo *clangIdentifier, const clang::MacroInfo *macro,
-    clang::ASTContext &clangCtx, ASTContext &SwiftContext) {
+Identifier
+NameImporter::importMacroName(const clang::IdentifierInfo *clangIdentifier,
+                              const clang::MacroInfo *macro) {
   // If we're supposed to ignore this macro, return an empty identifier.
   if (::shouldIgnoreMacro(clangIdentifier->getName(), macro))
     return Identifier();
 
   // No transformation is applied to the name.
   StringRef name = clangIdentifier->getName();
-  return SwiftContext.getIdentifier(name);
+  return swiftCtx.getIdentifier(name);
 }
 
 /// Determine the Swift name for a clang decl

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -137,17 +137,12 @@ struct ImportedName {
 /// in "Notification", or it there would be nothing left.
 StringRef stripNotification(StringRef name);
 
-/// Imports the name of the given Clang macro into Swift.
-Identifier importMacroName(const clang::IdentifierInfo *clangIdentifier,
-                           const clang::MacroInfo *macro,
-                           clang::ASTContext &clangCtx,
-                           ASTContext &SwiftContext);
-
 // TODO: I'd like to remove the following
 /// Flags that control the import of names in importFullName.
 enum class ImportNameFlags {
   /// Suppress the factory-method-as-initializer transformation.
   SuppressFactoryMethodAsInit = 0x01,
+
   /// Produce the Swift 2 name of the given entity.
   Swift2Name = 0x02,
 };
@@ -187,6 +182,10 @@ public:
   ImportedName importName(const clang::NamedDecl *decl,
                           ImportNameOptions options);
 
+  /// Imports the name of the given Clang macro into Swift.
+  Identifier importMacroName(const clang::IdentifierInfo *clangIdentifier,
+                             const clang::MacroInfo *macro);
+
   ASTContext &getContext() { return swiftCtx; }
   const LangOptions &getLangOpts() const { return swiftCtx.LangOpts; }
 
@@ -206,7 +205,12 @@ public:
   }
 
   clang::Sema &getClangSema() { return clangSema; }
-  clang::ASTContext &getClangContext() { return getClangSema().getASTContext(); }
+  clang::ASTContext &getClangContext() {
+    return getClangSema().getASTContext();
+  }
+  clang::Preprocessor &getClangPreprocessor() {
+    return getClangSema().getPreprocessor();
+  }
 
 private:
   bool enableObjCInterop() const { return swiftCtx.LangOpts.EnableObjCInterop; }

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1145,22 +1145,6 @@ public:
 
 namespace importer {
 
-/// Add the given named declaration as an entry to the given Swift name
-/// lookup table, including any of its child entries.
-void addEntryToLookupTable(SwiftLookupTable &table, clang::NamedDecl *named,
-                           importer::NameImporter &);
-
-/// Add the macros from the given Clang preprocessor to the given
-/// Swift name lookup table.
-void addMacrosToLookupTable(clang::ASTContext &clangCtx,
-                            clang::Preprocessor &pp, SwiftLookupTable &table,
-                            ASTContext &SwiftContext);
-
-/// Finalize a lookup table, handling any as-yet-unresolved entries
-/// and emitting diagnostics if necessary.
-void finalizeLookupTable(clang::ASTContext &clangCtx, clang::Preprocessor &pp,
-                         SwiftLookupTable &table, ASTContext &SwiftContext);
-
 /// Whether we should suppress the import of the given Clang declaration.
 bool shouldSuppressDeclImport(const clang::Decl *decl);
 

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -16,6 +16,8 @@
 //===----------------------------------------------------------------------===//
 #include "ImporterImpl.h"
 #include "SwiftLookupTable.h"
+#include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/DiagnosticsClangImporter.h"
 #include "swift/Basic/STLExtras.h"
 #include "swift/Basic/Version.h"
 #include "clang/AST/DeclObjC.h"
@@ -1507,6 +1509,136 @@ SwiftNameLookupExtension::hashExtension(llvm::hash_code code) const {
                             inferImportAsMember);
 }
 
+void importer::addEntryToLookupTable(SwiftLookupTable &table,
+                                     clang::NamedDecl *named,
+                                     NameImporter &nameImporter) {
+  // Determine whether this declaration is suppressed in Swift.
+  if (shouldSuppressDeclImport(named))
+    return;
+
+  // Leave incomplete struct/enum/union types out of the table; Swift only
+  // handles pointers to them.
+  // FIXME: At some point we probably want to be importing incomplete types,
+  // so that pointers to different incomplete types themselves have distinct
+  // types. At that time it will be necessary to make the decision of whether
+  // or not to import an incomplete type declaration based on whether it's
+  // actually the struct backing a CF type:
+  //
+  //    typedef struct CGColor *CGColorRef;
+  //
+  // The best way to do this is probably to change CFDatabase.def to include
+  // struct names when relevant, not just pointer names. That way we can check
+  // both CFDatabase.def and the objc_bridge attribute and cover all our bases.
+  if (auto *tagDecl = dyn_cast<clang::TagDecl>(named)) {
+    if (!tagDecl->getDefinition())
+      return;
+  }
+
+  // If we have a name to import as, add this entry to the table.
+  if (auto importedName = nameImporter.importName(named, None)) {
+    table.addEntry(importedName.Imported, named, importedName.EffectiveContext);
+
+    // Also add the subscript entry, if needed.
+    if (importedName.isSubscriptAccessor())
+      table.addEntry(DeclName(nameImporter.getContext(),
+                              nameImporter.getContext().Id_subscript,
+                              ArrayRef<Identifier>()),
+                     named, importedName.EffectiveContext);
+
+    // Import the Swift 2 name of this entity, and record it as well if it is
+    // different.
+    if (auto swift2Name =
+            nameImporter.importName(named, ImportNameFlags::Swift2Name)) {
+      if (swift2Name.Imported != importedName.Imported)
+        table.addEntry(swift2Name.Imported, named, swift2Name.EffectiveContext);
+    }
+  } else if (auto category = dyn_cast<clang::ObjCCategoryDecl>(named)) {
+    // If the category is invalid, don't add it.
+    if (category->isInvalidDecl())
+      return;
+
+    table.addCategory(category);
+  }
+
+  // Walk the members of any context that can have nested members.
+  if (isa<clang::TagDecl>(named) || isa<clang::ObjCInterfaceDecl>(named) ||
+      isa<clang::ObjCProtocolDecl>(named) ||
+      isa<clang::ObjCCategoryDecl>(named)) {
+    clang::DeclContext *dc = cast<clang::DeclContext>(named);
+    for (auto member : dc->decls()) {
+      if (auto namedMember = dyn_cast<clang::NamedDecl>(member))
+        addEntryToLookupTable(table, namedMember, nameImporter);
+    }
+  }
+}
+
+void importer::addMacrosToLookupTable(SwiftLookupTable &table,
+                                      NameImporter &nameImporter) {
+  auto &pp = nameImporter.getClangPreprocessor();
+  for (const auto &macro : pp.macros(false)) {
+    // Find the local history of this macro directive.
+    clang::MacroDirective *MD = pp.getLocalMacroDirectiveHistory(macro.first);
+
+    // Walk the history.
+    for (; MD; MD = MD->getPrevious()) {
+      // Don't look at any definitions that are followed by undefs.
+      // FIXME: This isn't quite correct across explicit submodules -- one
+      // submodule might define a macro, while another defines and then
+      // undefines the same macro. If they are processed in that order, the
+      // history will have the undef at the end, and we'll miss the first
+      // definition.
+      if (isa<clang::UndefMacroDirective>(MD))
+        break;
+
+      // Only interested in macro definitions.
+      auto *defMD = dyn_cast<clang::DefMacroDirective>(MD);
+      if (!defMD)
+        continue;
+
+      // Is this definition from this module?
+      auto info = defMD->getInfo();
+      if (!info || info->isFromASTFile())
+        continue;
+
+      // If we hit a builtin macro, we're done.
+      if (info->isBuiltinMacro())
+        break;
+
+      // If we hit a macro with invalid or predefined location, we're done.
+      auto loc = defMD->getLocation();
+      if (loc.isInvalid())
+        break;
+      if (pp.getSourceManager().getFileID(loc) == pp.getPredefinesFileID())
+        break;
+
+      // Add this entry.
+      auto name = nameImporter.importMacroName(macro.first, info);
+      if (name.empty())
+        continue;
+      table.addEntry(name, info,
+                     nameImporter.getClangContext().getTranslationUnitDecl(),
+                     &pp);
+    }
+  }
+}
+
+void importer::finalizeLookupTable(SwiftLookupTable &table,
+                                   NameImporter &nameImporter) {
+  // Resolve any unresolved entries.
+  SmallVector<SwiftLookupTable::SingleEntry, 4> unresolved;
+  if (table.resolveUnresolvedEntries(unresolved)) {
+    // Complain about unresolved entries that remain.
+    for (auto entry : unresolved) {
+      auto decl = entry.get<clang::NamedDecl *>();
+      auto swiftName = decl->getAttr<clang::SwiftNameAttr>();
+
+      nameImporter.getContext().Diags.diagnose(
+          SourceLoc(), diag::unresolvable_clang_decl, decl->getNameAsString(),
+          swiftName->getName());
+    }
+  }
+}
+
 void SwiftLookupTableWriter::populateTable(SwiftLookupTable &table,
                                            NameImporter &nameImporter) {
   auto &sema = nameImporter.getClangSema();
@@ -1525,10 +1657,10 @@ void SwiftLookupTableWriter::populateTable(SwiftLookupTable &table,
   }
 
   // Add macros to the lookup table.
-  addMacrosToLookupTable(sema.Context, sema.getPreprocessor(), table, swiftCtx);
+  addMacrosToLookupTable(table, nameImporter);
 
   // Finalize the lookup table, which may fail.
-  finalizeLookupTable(sema.Context, sema.getPreprocessor(), table, swiftCtx);
+  finalizeLookupTable(table, nameImporter);
 };
 
 std::unique_ptr<clang::ModuleFileExtensionWriter>

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -398,6 +398,22 @@ public:
   void dump() const;
 };
 
+namespace importer {
+class NameImporter;
+
+/// Add the given named declaration as an entry to the given Swift name
+/// lookup table, including any of its child entries.
+void addEntryToLookupTable(SwiftLookupTable &table, clang::NamedDecl *named,
+                           NameImporter &);
+
+/// Add the macros from the given Clang preprocessor to the given
+/// Swift name lookup table.
+void addMacrosToLookupTable(SwiftLookupTable &table, NameImporter &);
+
+/// Finalize a lookup table, handling any as-yet-unresolved entries
+/// and emitting diagnostics if necessary.
+void finalizeLookupTable(SwiftLookupTable &table, NameImporter &);
+}
 }
 
 namespace llvm {


### PR DESCRIPTION
<!-- What's in this pull request? -->

In preparing for versioned-names:

    [Clang Importer] Simplify and move more lookup table APIs

    [Import Name] Don't import property accessors as init
    
    Avoid importing an ObjC property accessor method as init in Swift,
    preferring to make a class method instead. This will become an
    important corner case for when we get rid of the
    SuppressFactoryMethodAsInit option.



<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
