### PR TITLE
Add REQUIRES: asserts to 016-swift-mangle-mangler-mangleidentifier.swift

### DIFF
--- a/validation-test/IDE/crashers/016-swift-mangle-mangler-mangleidentifier.swift
+++ b/validation-test/IDE/crashers/016-swift-mangle-mangler-mangleidentifier.swift
@@ -1,2 +1,3 @@
 // RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
 var d{let:{func a#^A^#


### PR DESCRIPTION
At some point this test stopped crashing unless you have assertions
enabled.

rdar://problem/29186276