### PR TITLE
Eliminate witness markers

### DIFF
--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -35,12 +35,6 @@ enum class RequirementKind : unsigned {
   /// A same-type requirement T == U, where T and U are types that shall be
   /// equivalent.
   SameType,
-  /// A marker that indicates where the witness for the given (first)
-  /// type should be located.
-  ///
-  /// FIXME: This is a crutch used to help us eliminate various walks over
-  /// "all archetypes".
-  WitnessMarker
 
   // Note: there is code that packs this enum in a 2-bit bitfield.  Audit users
   // when adding enumerators.
@@ -56,10 +50,8 @@ public:
   /// Create a conformance or same-type requirement.
   Requirement(RequirementKind kind, Type first, Type second)
     : FirstTypeAndKind(first, kind), SecondType(second) {
-    if (kind != RequirementKind::WitnessMarker) {
-      assert(first);
-      assert(second);
-    }
+    assert(first);
+    assert(second);
   }
 
   /// \brief Determine the kind of requirement.

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 282; // Last change: @_inlineable
+const uint16_t VERSION_MINOR = 283; // Last change: witness markers removed
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;
@@ -236,9 +236,8 @@ static inline OperatorKind getStableFixity(DeclKind kind) {
 // VERSION_MAJOR.
 enum GenericRequirementKind : uint8_t {
   Conformance = 0,
-  SameType,
-  WitnessMarker,
-  Superclass
+  SameType    = 1,
+  Superclass  = 2,
 };
 using GenericRequirementKindField = BCFixed<2>;
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3542,8 +3542,7 @@ void GenericSignature::Profile(llvm::FoldingSetNodeID &ID,
 
   for (auto &reqt : requirements) {
     ID.AddPointer(reqt.getFirstType().getPointer());
-    if (reqt.getKind() != RequirementKind::WitnessMarker)
-      ID.AddPointer(reqt.getSecondType().getPointer());
+    ID.AddPointer(reqt.getSecondType().getPointer());
     ID.AddInteger(unsigned(reqt.getKind()));
   }
 }
@@ -4056,8 +4055,7 @@ CanGenericSignature ASTContext::getSingleGenericParameterSignature() const {
     return theSig;
   
   auto param = GenericTypeParamType::get(0, 0, *this);
-  auto witnessReqt = Requirement(RequirementKind::WitnessMarker, param, Type());
-  auto sig = GenericSignature::get(param, witnessReqt);;
+  auto sig = GenericSignature::get(param, { });
   auto canonicalSig = CanGenericSignature(sig);
   Impl.SingleGenericParameterSignature = canonicalSig;
   return canonicalSig;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -233,8 +233,6 @@ struct SynthesizedExtensionAnalyzer::Implementation {
     assert(Ext->getGenericSignature() && "No generic signature.");
     for (auto Req : Ext->getGenericSignature()->getRequirements()) {
       auto Kind = Req.getKind();
-      if (Kind == RequirementKind::WitnessMarker)
-        continue;
 
       Type First = Req.getFirstType().subst(
           M, subMap, SubstOptions());
@@ -251,9 +249,6 @@ struct SynthesizedExtensionAnalyzer::Implementation {
       Second = Second->getCanonicalType();
 
       switch (Kind) {
-        case RequirementKind::WitnessMarker:
-          break;
-
         case RequirementKind::Conformance:
         case RequirementKind::Superclass:
           if (!canPossiblyConvertTo(First, Second, *DC))
@@ -1208,7 +1203,6 @@ static unsigned getDepthOfRequirement(const Requirement &req) {
   switch (req.getKind()) {
   case RequirementKind::Conformance:
   case RequirementKind::Superclass:
-  case RequirementKind::WitnessMarker:
     return getDepthOfType(req.getFirstType());
 
   case RequirementKind::SameType: {
@@ -1337,9 +1331,6 @@ void PrintAST::printSingleDepthOfGenericSignature(
     // Print the requirements.
     bool isFirstReq = true;
     for (const auto &req : requirements) {
-      if (req.getKind() == RequirementKind::WitnessMarker)
-        continue;
-
       auto first = req.getFirstType();
       auto second = req.getSecondType();
 
@@ -1387,9 +1378,6 @@ void PrintAST::printRequirement(const Requirement &req) {
   case RequirementKind::SameType:
     Printer << " == ";
     break;
-
-  case RequirementKind::WitnessMarker:
-    llvm_unreachable("Handled above");
   }
   printType(req.getSecondType());
 }
@@ -4119,9 +4107,6 @@ void GenericSignature::dump() const {
 
 void Requirement::dump() const {
   switch (getKind()) {
-  case RequirementKind::WitnessMarker:
-    llvm::errs() << "witness_marker: ";
-    break;
   case RequirementKind::Conformance:
     llvm::errs() << "conforms_to: ";
     break;

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -196,14 +196,8 @@ getBuiltinGenericFunction(Identifier Id,
     GenericParamTypes.push_back(gp->getDeclaredType()
                                   ->castTo<GenericTypeParamType>());
   }
-  // Create witness markers for all of the generic param types.
-  SmallVector<Requirement, 2> requirements;
-  for (auto param : GenericParamTypes) {
-    requirements.push_back(Requirement(RequirementKind::WitnessMarker,
-                                       param, Type()));
-  }
   GenericSignature *Sig =
-      GenericSignature::get(GenericParamTypes, requirements);
+    GenericSignature::get(GenericParamTypes, { });
   GenericEnvironment *Env =
       GenericEnvironment::get(Context, GenericParamTypes,
                               InterfaceToArchetypeMap);

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -152,6 +152,121 @@ GenericSignature::getSubstitutionMap(ArrayRef<Substitution> subs) const {
   return result;
 }
 
+bool GenericSignature::enumeratePairedRequirements(
+               llvm::function_ref<bool(Type, ArrayRef<Requirement>)> fn) const {
+  // We'll be walking through the list of requirements.
+  ArrayRef<Requirement> reqs = getRequirements();
+  unsigned curReqIdx = 0, numReqs = reqs.size();
+
+  /// Local function to skip over witness marker requirements. Returns \c true
+  /// if we hit the end.
+  auto skipWitnessMarkers = [&] {
+    while (curReqIdx != numReqs &&
+           reqs[curReqIdx].getKind() == RequirementKind::WitnessMarker)
+      ++curReqIdx;
+
+    return curReqIdx == numReqs;
+  };
+
+  // ... and walking through the list of generic parameters.
+  ArrayRef<GenericTypeParamType *> genericParams = getGenericParams();
+  unsigned curGenericParamIdx = 0, numGenericParams = genericParams.size();
+
+  /// Local function to 'catch up' to the next dependent type we're going to
+  /// visit, calling the function for each of the generic parameters in the
+  /// generic parameter list prior to this parameter.
+  auto enumerateGenericParamsUpToDependentType = [&](CanType depTy) -> bool {
+    // Figure out where we should stop when enumerating generic parameters.
+    unsigned stopDepth, stopIndex;
+    if (auto gp = dyn_cast_or_null<GenericTypeParamType>(depTy)) {
+      stopDepth = gp->getDepth();
+      stopIndex = gp->getIndex();
+    } else {
+      stopDepth = genericParams.back()->getDepth() + 1;
+      stopIndex = 0;
+    }
+
+    // Enumerate generic parameters up to the stopping point, calling the
+    // callback function for each one
+    while (curGenericParamIdx != numGenericParams) {
+      auto curGenericParam = genericParams[curGenericParamIdx];
+
+      // If the current generic parameter is before our stopping point, call
+      // the function.
+      if (curGenericParam->getDepth() < stopDepth ||
+          (curGenericParam->getDepth() == stopDepth &&
+           curGenericParam->getIndex() < stopIndex)) {
+        if (fn(curGenericParam, { })) return true;
+        ++curGenericParamIdx;
+        continue;
+      }
+
+      // If the current generic parameter is at our stopping point, we're
+      // done.
+      if (curGenericParam->getDepth() == stopDepth &&
+          curGenericParam->getIndex() == stopIndex) {
+        ++curGenericParamIdx;
+        return false;
+      }
+
+      // Otherwise, there's nothing to do.
+      break;
+    }
+
+    return false;
+  };
+
+  // Walk over all of the requirements.
+  while (!skipWitnessMarkers()) {
+    // "Catch up" by enumerating generic parameters up to this dependent type.
+    CanType depTy = reqs[curReqIdx].getFirstType()->getCanonicalType();
+    if (enumerateGenericParamsUpToDependentType(depTy)) return true;
+
+    // Utility to skip over non-conformance constraints that apply to this
+    // type.
+    bool sawSameTypeConstraint = false;
+    auto skipNonConformanceConstraints = [&] {
+      while (curReqIdx != numReqs &&
+             reqs[curReqIdx].getKind() != RequirementKind::Conformance &&
+             reqs[curReqIdx].getFirstType()->getCanonicalType() == depTy) {
+        // Record whether we saw a same-type constraint mentioning this type.
+        if (reqs[curReqIdx].getKind() == RequirementKind::SameType)
+          sawSameTypeConstraint = true;
+
+        ++curReqIdx;
+        if (skipWitnessMarkers()) break;
+      }
+    };
+
+    // First, skip past any non-conformance constraints on this type.
+    skipNonConformanceConstraints();
+
+    // Collect all of the conformance constraints for this dependent type.
+    unsigned startIdx = curReqIdx;
+    unsigned endIdx = curReqIdx;
+    while (curReqIdx != numReqs &&
+           reqs[curReqIdx].getKind() == RequirementKind::Conformance &&
+           reqs[curReqIdx].getFirstType()->getCanonicalType() == depTy) {
+      ++curReqIdx;
+      endIdx = curReqIdx;
+      if (skipWitnessMarkers()) break;
+    }
+
+    // Skip any trailing non-conformance constraints.
+    skipNonConformanceConstraints();
+
+    // If there were any conformance constraints, or we have a generic
+    // parameter we can't skip, invoke the callback.
+    if ((startIdx != endIdx ||
+         (isa<GenericTypeParamType>(depTy) && !sawSameTypeConstraint)) &&
+        fn(depTy, reqs.slice(startIdx, endIdx-startIdx)))
+      return true;
+  }
+
+  // Catch up on any remaining generic parameters.
+  return enumerateGenericParamsUpToDependentType(CanType());
+}
+
 void
 GenericSignature::getSubstitutionMap(ArrayRef<Substitution> subs,
                                      SubstitutionMap &result) const {
@@ -173,63 +288,48 @@ GenericSignature::getSubstitutionMap(ArrayRef<Substitution> subs,
   assert(subs.empty() && "did not use all substitutions?!");
 }
 
+SmallVector<Type, 4> GenericSignature::getAllDependentTypes() const {
+  SmallVector<Type, 4> result;
+  enumeratePairedRequirements([&](Type type, ArrayRef<Requirement>) {
+    result.push_back(type);
+    return false;
+  });
+
+  return result;
+}
+
 void GenericSignature::
 getSubstitutions(ModuleDecl &mod,
                  const TypeSubstitutionMap &subs,
                  GenericSignature::LookupConformanceFn lookupConformance,
                  SmallVectorImpl<Substitution> &result) const {
-  auto &ctx = getASTContext();
+  // Enumerate all of the requirements that require substitution.
+  enumeratePairedRequirements([&](Type depTy, ArrayRef<Requirement> reqs) {
+    auto &ctx = getASTContext();
 
-  Type currentReplacement;
-  SmallVector<ProtocolConformanceRef, 4> currentConformances;
+    // Compute the replacement type.
+    Type currentReplacement = depTy.subst(&mod, subs);
+    if (!currentReplacement)
+      currentReplacement = ErrorType::get(depTy);
 
-  for (const auto &req : getRequirements()) {
-    auto depTy = req.getFirstType()->getCanonicalType();
-
-    switch (req.getKind()) {
-    case RequirementKind::Conformance: {
-      // Get the conformance and record it.
+    // Collect the conformances.
+    SmallVector<ProtocolConformanceRef, 4> currentConformances;
+    for (auto req: reqs) {
+      assert(req.getKind() == RequirementKind::Conformance);
       auto protoType = req.getSecondType()->castTo<ProtocolType>();
       currentConformances.push_back(
-          lookupConformance(depTy, currentReplacement, protoType));
-      break;
+        lookupConformance(depTy->getCanonicalType(), currentReplacement,
+                          protoType));
     }
 
-    case RequirementKind::Superclass:
-      // Superclass requirements aren't recorded in substitutions.
-      break;
-
-    case RequirementKind::SameType:
-      // Same-type requirements aren't recorded in substitutions.
-      break;
-
-    case RequirementKind::WitnessMarker:
-      // Flush the current conformances.
-      if (currentReplacement) {
-        result.push_back({
-          currentReplacement,
-          ctx.AllocateCopy(currentConformances)
-        });
-        currentConformances.clear();
-      }
-
-      // Each witness marker starts a new substitution.
-      currentReplacement = req.getFirstType().subst(&mod, subs);
-      if (!currentReplacement)
-        currentReplacement = ErrorType::get(req.getFirstType());
-
-      break;
-    }
-  }
-
-  // Flush the final conformances.
-  if (currentReplacement) {
+    // Add it to the final substitution list.
     result.push_back({
       currentReplacement,
-      ctx.AllocateCopy(currentConformances),
+      ctx.AllocateCopy(currentConformances)
     });
-    currentConformances.clear();
-  }
+
+    return false;
+  });
 }
 
 void GenericSignature::

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -158,16 +158,6 @@ bool GenericSignature::enumeratePairedRequirements(
   ArrayRef<Requirement> reqs = getRequirements();
   unsigned curReqIdx = 0, numReqs = reqs.size();
 
-  /// Local function to skip over witness marker requirements. Returns \c true
-  /// if we hit the end.
-  auto skipWitnessMarkers = [&] {
-    while (curReqIdx != numReqs &&
-           reqs[curReqIdx].getKind() == RequirementKind::WitnessMarker)
-      ++curReqIdx;
-
-    return curReqIdx == numReqs;
-  };
-
   // ... and walking through the list of generic parameters.
   ArrayRef<GenericTypeParamType *> genericParams = getGenericParams();
   unsigned curGenericParamIdx = 0, numGenericParams = genericParams.size();
@@ -217,7 +207,7 @@ bool GenericSignature::enumeratePairedRequirements(
   };
 
   // Walk over all of the requirements.
-  while (!skipWitnessMarkers()) {
+  while (curReqIdx != numReqs) {
     // "Catch up" by enumerating generic parameters up to this dependent type.
     CanType depTy = reqs[curReqIdx].getFirstType()->getCanonicalType();
     if (enumerateGenericParamsUpToDependentType(depTy)) return true;
@@ -234,7 +224,6 @@ bool GenericSignature::enumeratePairedRequirements(
           sawSameTypeConstraint = true;
 
         ++curReqIdx;
-        if (skipWitnessMarkers()) break;
       }
     };
 
@@ -249,7 +238,6 @@ bool GenericSignature::enumeratePairedRequirements(
            reqs[curReqIdx].getFirstType()->getCanonicalType() == depTy) {
       ++curReqIdx;
       endIdx = curReqIdx;
-      if (skipWitnessMarkers()) break;
     }
 
     // Skip any trailing non-conformance constraints.

--- a/lib/AST/Mangle.cpp
+++ b/lib/AST/Mangle.cpp
@@ -528,10 +528,6 @@ Type Mangler::getDeclTypeForMangling(const ValueDecl *decl,
       requirementsBuf.clear();
       for (auto &reqt : sig->getRequirements()) {
         switch (reqt.getKind()) {
-        case RequirementKind::WitnessMarker:
-          // Not needed for mangling.
-          continue;
-
         case RequirementKind::Conformance:
         case RequirementKind::Superclass:
           // We don't need the requirement if the constrained type is above the
@@ -637,9 +633,6 @@ mangle_requirements:
   // Mangle the requirements.
   for (auto &reqt : requirements) {
     switch (reqt.getKind()) {
-    case RequirementKind::WitnessMarker:
-      break;
-        
     case RequirementKind::Conformance:
       if (!didMangleRequirement) {
         Buffer << 'R';

--- a/lib/AST/TypeWalker.cpp
+++ b/lib/AST/TypeWalker.cpp
@@ -101,9 +101,6 @@ class Traversal : public TypeVisitor<Traversal, bool>
         if (doIt(req.getSecondType()))
           return true;
         break;
-
-      case RequirementKind::WitnessMarker:
-        break;
       }
     }
 

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -212,7 +212,6 @@ void PolymorphicConvention::enumerateRequirements(const RequirementCallback &cal
       // Ignore these; they don't introduce extra requirements.
       case RequirementKind::Superclass:
       case RequirementKind::SameType:
-      case RequirementKind::WitnessMarker:
         continue;
 
       case RequirementKind::Conformance: {

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1921,13 +1921,8 @@ public:
     require(selfGenericParam->getDepth() == 0
             && selfGenericParam->getIndex() == 0,
             "method should be polymorphic on Self parameter at depth 0 index 0");
-    auto selfMarker
-      = methodType->getGenericSignature()->getRequirements()[0];
-    require(selfMarker.getKind() == RequirementKind::WitnessMarker
-            && selfMarker.getFirstType()->isEqual(selfGenericParam),
-            "method's Self parameter should appear first in requirements");
     auto selfRequirement
-      = methodType->getGenericSignature()->getRequirements()[1];
+      = methodType->getGenericSignature()->getRequirements()[0];
     require(selfRequirement.getKind() == RequirementKind::Conformance
             && selfRequirement.getFirstType()->isEqual(selfGenericParam)
             && selfRequirement.getSecondType()->getAs<ProtocolType>()

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3119,8 +3119,6 @@ bool swift::isExtensionApplied(DeclContext &DC, Type BaseTy,
       case RequirementKind::SameType:
         createMemberConstraint(Req, ConstraintKind::Equal);
         break;
-      case RequirementKind::WitnessMarker:
-        break;
     }
   }
   if (Failed)

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -965,9 +965,6 @@ void ConstraintSystem::openGeneric(
       addConstraint(ConstraintKind::Bind, firstTy, secondTy, locatorPtr);
       break;
     }
-
-    case RequirementKind::WitnessMarker:
-      break;
   }
   }
 }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1453,16 +1453,12 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
     // If we're on to a new dependent type, flush the conformances gathered
     // thus far.
     CanType canFirstType = req.getFirstType()->getCanonicalType();
-    if (req.getKind() != RequirementKind::WitnessMarker &&
-        canFirstType != currentType) {
+    if (canFirstType != currentType) {
       if (currentType) flushConformances();
       currentType = canFirstType;
     }
 
     switch (req.getKind()) {
-    case RequirementKind::WitnessMarker:
-      break;
-
     case RequirementKind::Conformance: {
       // Get the conformance and record it.
       auto firstType = req.getFirstType().subst(subMap);

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -1006,9 +1006,6 @@ bool TypeChecker::checkGenericArguments(DeclContext *dc, SourceLoc loc,
         return true;
       }
       continue;
-      
-    case RequirementKind::WitnessMarker:
-      continue;
     }
   }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1081,9 +1081,6 @@ RequirementEnvironment::RequirementEnvironment(
   RequirementSource source(RequirementSource::Explicit, SourceLoc());
   for (auto &reqReq : reqSig->getRequirements()) {
     switch (reqReq.getKind()) {
-    case RequirementKind::WitnessMarker:
-      break;
-
     case RequirementKind::Conformance: {
       // Substitute the constrained types.
       auto first = reqReq.getFirstType().subst(reqToSyntheticEnvMap);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -831,13 +831,6 @@ void ModuleFile::readGenericRequirements(
                                            first, second));
         break;
       }
-      case GenericRequirementKind::WitnessMarker: {
-        auto first = getType(rawTypeIDs[0]);
-
-        requirements.push_back(Requirement(RequirementKind::WitnessMarker,
-                                           first, Type()));
-        break;
-      }
       default:
         // Unknown requirement kind. Drop the requirement and continue, but log
         // an error so that we don't actually try to generate code.

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -932,7 +932,6 @@ static uint8_t getRawStableRequirementKind(RequirementKind kind) {
   CASE(Conformance)
   CASE(Superclass)
   CASE(SameType)
-  CASE(WitnessMarker)
   }
 #undef CASE
 }

--- a/test/Generics/associated_type_typo.swift
+++ b/test/Generics/associated_type_typo.swift
@@ -37,12 +37,9 @@ func typoAssoc4<T : P2>(_: T) where T.Assocp2.assoc : P3 {}
 
 // CHECK-GENERIC-LABEL: .typoAssoc4@
 // CHECK-GENERIC-NEXT: Requirements:
-// CHECK-GENERIC-NEXT:   T witness marker
 // CHECK-GENERIC-NEXT:   T : P2 [explicit
-// CHECK-GENERIC-NEXT:   T[.P2].AssocP2 witness marker
 // CHECK-GENERIC-NEXT:   T[.P2].AssocP2 : P1 [protocol
 // CHECK-GENERIC-NEXT:   T[.P2].AssocP2 == T.AssocP2 [redundant]
-// CHECK-GENERIC-NEXT:   T[.P2].AssocP2[.P1].Assoc witness marker
 // CHECK-GENERIC-NEXT:   T[.P2].AssocP2[.P1].Assoc : P3 [explicit
 // CHECK-GENERIC-NEXT:   T[.P2].AssocP2[.P1].Assoc == T[.P2].AssocP2.Assoc [redundant]
 // CHECK-GENERIC-NEXT: Generic signature

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -57,7 +57,6 @@ class Fox : P1 {
 class Box<T : Fox> {
 // CHECK-LABEL: .unpack@
 // CHECK-NEXT: Requirements:
-// CHECK-NEXT:   T witness marker
 // CHECK-NEXT:   T : Fox [outer]
   func unpack(_ x: X1<T>) {}
 }
@@ -76,13 +75,11 @@ struct V<T : Canidae> {}
 
 // CHECK-LABEL: .inferSuperclassRequirement1@
 // CHECK-NEXT: Requirements:
-// CHECK-NEXT:   T witness marker
 // CHECK-NEXT:   T : Canidae
 func inferSuperclassRequirement1<T : Carnivora>(_ v: V<T>) {}
 
 // CHECK-LABEL: .inferSuperclassRequirement2@
 // CHECK-NEXT: Requirements:
-// CHECK-NEXT:   T witness marker
 // CHECK-NEXT:   T : Canidae
 func inferSuperclassRequirement2<T : Canidae>(_ v: U<T>) {}
 
@@ -114,11 +111,8 @@ struct Model_P3_P4_Eq<T : P3, U : P4> where T.P3Assoc == U.P4Assoc {}
 
 // CHECK-LABEL: .inferSameType1@
 // CHECK-NEXT: Requirements:
-// CHECK-NEXT:   T witness marker
 // CHECK-NEXT:   T : P3 [inferred @ {{.*}}:32]
-// CHECK-NEXT:   U witness marker
 // CHECK-NEXT:   U : P4 [inferred @ {{.*}}:32]
-// CHECK-NEXT:   T[.P3].P3Assoc witness marker
 // CHECK-NEXT:   T[.P3].P3Assoc : P1 [redundant @ {{.*}}:18]
 // CHECK-NEXT:   T[.P3].P3Assoc : P2 [protocol @ {{.*}}:18]
 // CHECK-NEXT:   T[.P3].P3Assoc == U[.P4].P4Assoc [inferred @ {{.*}}32]
@@ -126,11 +120,8 @@ func inferSameType1<T, U>(_ x: Model_P3_P4_Eq<T, U>) { }
 
 // CHECK-LABEL: .inferSameType2@
 // CHECK-NEXT: Requirements:
-// CHECK-NEXT:   T witness marker
 // CHECK-NEXT:   T : P3 [explicit @ {{.*}}requirement_inference.swift:{{.*}}:25]
-// CHECK-NEXT:   U witness marker
 // CHECK-NEXT:   U : P4 [explicit @ {{.*}}requirement_inference.swift:{{.*}}:33]
-// CHECK-NEXT:   T[.P3].P3Assoc witness marker
 // CHECK-NEXT:   T[.P3].P3Assoc : P1 [redundant @ {{.*}}requirement_inference.swift:{{.*}}:18]
 // CHECK-NEXT:   T[.P3].P3Assoc : P2 [protocol @ {{.*}}requirement_inference.swift:{{.*}}:18]
 // CHECK-NEXT:   T[.P3].P3Assoc == U[.P4].P4Assoc [explicit @ {{.*}}requirement_inference.swift:{{.*}}:75]
@@ -138,10 +129,8 @@ func inferSameType2<T : P3, U : P4>(_: T) where U.P4Assoc : P2, T.P3Assoc == U.P
 
 // CHECK-LABEL: .inferSameType3@
 // CHECK-NEXT: Requirements:
-// CHECK-NEXT:   T witness marker
 // CHECK-NEXT:   T : PCommonAssoc1 [explicit @ {{.*}}requirement_inference.swift:{{.*}}:25]
 // CHECK-NEXT:   T : PCommonAssoc2 [explicit @ {{.*}}requirement_inference.swift:{{.*}}:76]
-// CHECK-NEXT:   T[.PCommonAssoc1].CommonAssoc witness marker
 // CHECK-NEXT:   T[.PCommonAssoc1].CommonAssoc : P1 [explicit @ {{.*}}requirement_inference.swift:{{.*}}:68]
 // CHECK-NEXT:   T[.PCommonAssoc1].CommonAssoc == T[.PCommonAssoc2].CommonAssoc [redundant @ {{.*}}requirement_inference.swift:{{.*}}:76]
 // CHECK-NEXT: Generic signature

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -64,7 +64,6 @@ extension P2 where Self.T : C {
 
 // CHECK: superclassConformance1
 // CHECK: Requirements:
-// CHECK-NEXT: T witness marker
 // CHECK-NEXT: T : C [explicit @
 // CHECK-NEXT: T : P3 [redundant @
 // CHECK-NEXT: T[.P3].T == C.T [redundant]
@@ -73,7 +72,6 @@ func superclassConformance1<T>(t: T) where T : C, T : P3 {}
 
 // CHECK: superclassConformance2
 // CHECK: Requirements:
-// CHECK-NEXT: T witness marker
 // CHECK-NEXT: T : C [explicit @
 // CHECK-NEXT: T : P3 [redundant @
 // CHECK-NEXT: T[.P3].T == C.T [redundant]
@@ -86,7 +84,6 @@ class C2 : C, P4 { }
 
 // CHECK: superclassConformance3
 // CHECK: Requirements:
-// CHECK-NEXT: T witness marker
 // CHECK-NEXT: T : C2 [explicit @
 // CHECK-NEXT: T : P4 [redundant @
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : C2>

--- a/test/IRGen/partial_apply_forwarder.sil
+++ b/test/IRGen/partial_apply_forwarder.sil
@@ -18,7 +18,7 @@ public protocol Observer {
 sil hidden @witness_method : $@convention(thin) <S where S : Observable><O where O : Observer, S.Result == O.Result> (@in S) -> @owned @callee_owned (@in O) -> () {
 bb0(%0 : $*S):
   %1 = witness_method $S, #Observable.subscribe!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
-  %2 = partial_apply %1<S, O, S.Result>(%0) : $@convention(witness_method) <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
+  %2 = partial_apply %1<S, O>(%0) : $@convention(witness_method) <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
   return %2 : $@callee_owned (@in O) -> ()
 }
 

--- a/test/SIL/Parser/generic_signature_with_depth.swift
+++ b/test/SIL/Parser/generic_signature_with_depth.swift
@@ -20,7 +20,7 @@ protocol mmExt : mmCollectionType {
 
 // CHECK-LABEL:  @_TF28generic_signature_with_depth4testu0_RxS_5mmExt_S0_Wx9Generator7Element_zW_S1_S2__rFTxq__x : $@convention(thin) <EC1, EC2 where EC1 : mmExt, EC2 : mmExt, EC1.Generator.Element == EC2.Generator.Element> (@in EC1, @in EC2) -> @out EC1 {
 // CHECK: witness_method $EC1, #mmExt.extend!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : mmExt><τ_1_0 where τ_1_0 : mmSequenceType, τ_0_0.Generator.Element == τ_1_0.Generator.Element> (@in τ_1_0, @inout τ_0_0) -> ()
-// CHECK: apply {{%[0-9]+}}<EC1, EC2, EC1.Generator.Element>({{%[0-9]+}}, {{%[0-9]+}}) : $@convention(witness_method) <τ_0_0 where τ_0_0 : mmExt><τ_1_0 where τ_1_0 : mmSequenceType, τ_0_0.Generator.Element == τ_1_0.Generator.Element> (@in τ_1_0, @inout τ_0_0) -> ()
+// CHECK: apply {{%[0-9]+}}<EC1, EC2>({{%[0-9]+}}, {{%[0-9]+}}) : $@convention(witness_method) <τ_0_0 where τ_0_0 : mmExt><τ_1_0 where τ_1_0 : mmSequenceType, τ_0_0.Generator.Element == τ_1_0.Generator.Element> (@in τ_1_0, @inout τ_0_0) -> ()
 
 func test<
    EC1 : mmExt,

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -269,9 +269,6 @@ static void initDocGenericParams(const Decl *D, DocEntityInfo &Info) {
     proto = typeDC->getAsProtocolOrProtocolExtensionContext();
 
   for (auto &Req : GenericSig->getRequirements()) {
-    if (Req.getKind() == RequirementKind::WitnessMarker)
-      continue;
-
     // Skip protocol Self requirement.
     if (proto &&
         Req.getKind() == RequirementKind::Conformance &&

--- a/tools/swift-ide-test/ModuleAPIDiff.cpp
+++ b/tools/swift-ide-test/ModuleAPIDiff.cpp
@@ -764,9 +764,6 @@ public:
             sma::SameTypeRequirement{convertToTypeName(Req.getFirstType()),
                                      convertToTypeName(Req.getSecondType())});
         break;
-      case RequirementKind::WitnessMarker:
-        // This RequirementKind is a hack; skip it.
-        break;
       }
     }
     return ResultGS;


### PR DESCRIPTION
This pull request eliminates the notion of "witness markers" from the frontend. To do so, introduce a new operation on generic signatures,
`enumeratePairedRequirements()`, which invokes a callback with each
(dependent type, set-of-conformance-requirements) pair that needs to
be recorded within substitutions. Switch the last two remaining
consumers of witness markers (`GenericSignature::getAllDependentTypes()`
and `GenericSignature::getSubstitutions()`) over to this new entrypoint. Then delete all notions of witness markers.