### PR TITLE
[QoI] Add fix-it for missing arguments

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4766,7 +4766,7 @@ static bool diagnoseSingleCandidateFailures(CalleeCandidateInfo &CCI,
       if (auto FT = param.Ty->getAs<AnyFunctionType>())
         if (FT->isAutoClosure())
           Ty = FT->getResult();
-      insertText << "<#T##" << Ty << "#>";
+      insertText << "<#" << Ty << "#>";
       if (argIdx == 0 && insertableEndIdx != 0)
         insertText << ", ";
 

--- a/test/Constraints/diag_missing_arg.swift
+++ b/test/Constraints/diag_missing_arg.swift
@@ -1,0 +1,156 @@
+// RUN: %target-parse-verify-swift
+
+func nonNamedFunc(_ x: Int) {} // expected-note * {{here}}
+nonNamedFunc() // expected-error {{missing argument for parameter #1 in call}} {{14-14=<#T##Int#>}}
+
+func namedFunc(x: Int) {} // expected-note * {{here}}
+namedFunc() // expected-error {{missing argument for parameter 'x' in call}} {{11-11=x: <#T##Int#>}}
+
+func inoutFunc(x: inout Int) {} // expected-note * {{here}}
+inoutFunc() // expected-error {{missing argument for parameter 'x' in call}} {{11-11=x: &<#T##Int#>}}
+
+func autoclosureFunc(x: @autoclosure () -> Int) {} // expected-note * {{here}}
+autoclosureFunc() // expected-error {{missing argument for parameter 'x' in call}} {{17-17=x: <#T##Int#>}}
+
+func attributedFunc(x: @convention(c) () -> Int32) {} // expected-note * {{here}}
+attributedFunc() // expected-error {{missing argument for parameter 'x' in call}} {{16-16=x: <#T##@convention(c) () -> Int32#>}}
+
+func attributedInOutFunc(x: inout @convention(c) () -> Int32) {} // expected-note * {{here}}
+attributedInOutFunc() // expected-error {{missing argument for parameter 'x' in call}} {{21-21=x: &<#T##@convention(c) () -> Int32#>}}
+
+func genericFunc1<T>(x: T) {} // expected-note * {{here}}
+genericFunc1() // expected-error {{missing argument for parameter 'x' in call}} {{14-14=x: <#T##T#>}}
+
+protocol P {}
+func genericFunc2<T : P>(x: T) {} // expected-note * {{here}}
+genericFunc2() // expected-error {{missing argument for parameter 'x' in call}} {{14-14=x: <#T##T#>}}
+
+typealias MyInt = Int
+func aliasedFunc(x: MyInt) {} // expected-note * {{here}}
+aliasedFunc() // expected-error {{missing argument for parameter 'x' in call}} {{13-13=x: <#T##MyInt#>}}
+
+func trailingClosureSingle1(x: Int, y: () -> Int) {} // expected-note * {{here}}
+trailingClosureSingle1 { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{23-23=(x: <#T##Int#>)}}
+trailingClosureSingle1() { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{24-24=x: <#T##Int#>}}
+
+func trailingClosureSingle2(x: () -> Int, y: Int) {} // expected-note * {{here}}
+// FIXME: Bad diagnostics.
+trailingClosureSingle2 { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{23-23=(x: <#T##() -> Int#>)}}
+trailingClosureSingle2() { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{24-24=x: <#T##() -> Int#>}}
+
+func trailingClosureMulti1(x: Int, y: Int, z: () -> Int) {} // expected-note * {{here}}
+trailingClosureMulti1(y: 1) { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{23-23=x: <#T##Int#>, }}
+trailingClosureMulti1(x: 1) { 1 } // expected-error {{missing argument for parameter 'y' in call}} {{27-27=, y: <#T##Int#>}}
+trailingClosureMulti1(x: 1, y: 1) // expected-error {{missing argument for parameter 'z' in call}} {{33-33=, z: <#T##() -> Int#>}}
+
+func trailingClosureMulti2(x: Int, y: () -> Int, z: Int) {} // expected-note * {{here}}
+trailingClosureMulti2 { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{22-22=(x: <#T##Int#>)}}
+// FIXME: Bad diagnostics.
+trailingClosureMulti2() { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{23-23=x: <#T##Int#>}}
+trailingClosureMulti2(x: 1) { 1 } // expected-error {{missing argument for parameter 'y' in call}} {{27-27=, y: <#T##() -> Int#>}}
+
+func param2Func(x: Int, y: Int) {} // expected-note * {{here}}
+param2Func(x: 1) // expected-error {{missing argument for parameter 'y' in call}} {{16-16=, y: <#T##Int#>}}
+param2Func(y: 1) // expected-error {{missing argument for parameter 'x' in call}} {{12-12=x: <#T##Int#>, }}
+
+func param2FuncNonNamed1(_ x: Int, y: String) {} // expected-note * {{here}}
+param2FuncNonNamed1(1) // expected-error {{missing argument for parameter 'y' in call}} {{22-22=, y: <#T##String#>}}
+param2FuncNonNamed1(y: "foo") // expected-error {{missing argument for parameter #1 in call}} {{21-21=<#T##Int#>, }}
+
+func param2FuncNonNamed2(x: Int, _ y: String) {} // expected-note * {{here}}
+param2FuncNonNamed2(x: 1) // expected-error {{missing argument for parameter #2 in call}} {{25-25=, <#T##String#>}}
+param2FuncNonNamed2("foo") // expected-error {{missing argument for parameter 'x' in call}} {{21-21=x: <#T##Int#>, }}
+
+func param2FuncNonNamed3(_ x: Int, _ y: String) {} // expected-note * {{here}}
+param2FuncNonNamed3(1) // expected-error {{missing argument for parameter #2 in call}} {{22-22=, <#T##String#>}}
+param2FuncNonNamed3("foo") // expected-error {{missing argument for parameter #2 in call}} {{26-26=, <#T##String#>}}
+                           // FIXME: Bad diagnostic. Could this be #1?
+
+func param3Func(x: Int, y: Int, z: Int) {} // expected-note * {{here}}
+param3Func(x: 1, y: 1) // expected-error {{missing argument for parameter 'z' in call}} {{22-22=, z: <#T##Int#>}}
+param3Func(x: 1, z: 1) // expected-error {{missing argument for parameter 'y' in call}} {{16-16=, y: <#T##Int#>}}
+param3Func(y: 1, z: 1) // expected-error {{missing argument for parameter 'x' in call}} {{12-12=x: <#T##Int#>, }}
+
+func hasDefault1(x: Int, y: Int = 1) {} // expected-note * {{here}}
+hasDefault1(x: 1) // ok
+hasDefault1(y: 1) // expected-error {{missing argument for parameter 'x' in call}} {{13-13=x: <#T##Int#>, }}
+
+func hasDefault2(x: Int = 1, y: Int) {} // expected-note * {{here}}
+hasDefault2(x: 1) // expected-error {{missing argument for parameter 'y' in call}} {{17-17=, y: <#T##Int#>}}
+hasDefault2(y: 1) // ok
+
+struct S { init(x: Int, y: () -> Int) {} } // expected-note * {{here}}
+_ = S(x: 1) // expected-error {{missing argument for parameter 'y' in call}} {{11-11=, y: <#T##() -> Int#>}}
+_ = S(y: { 1 }) // expected-error {{missing argument for parameter 'x' in call}} {{7-7=x: <#T##Int#>, }}
+_ = S { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{6-6=(x: <#T##Int#>)}}
+_ = S() { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{7-7=x: <#T##Int#>}}
+
+struct S1 {
+  subscript(x x: Int, y y: () -> Int) -> Int { get { return 1 } set { } } // expected-note * {{here}}
+}
+var s1 = S1()
+_ = s1[x: 1, y: {1}]  // Ok.
+_ = s1[x: 1] { 1 } // Ok.
+_ = s1[x: 1] // expected-error {{missing argument for parameter 'y' in call}} {{12-12=, y: <#T##() -> Int#>}}
+_ = s1[y: { 1 }] // expected-error {{missing argument for parameter 'x' in call}} {{8-8=x: <#T##Int#>, }}
+_ = s1[] { 1 } // expected-error {{cannot convert value of type '() -> Int' to expected argument type '(x: Int, y: () -> Int)'}} {{none}}
+_ = s1 { 1 } // expected-error {{cannot call value of non-function type 'S1'}} {{none}}
+_ = s1[] // expected-error {{missing argument for parameter 'x' in call}} {{8-8=x: <#T##Int#>}}
+s1[x: 1, y: {1}] = 1 // Ok.
+s1[x: 1] { 1 } = 1 // Ok.
+s1[x: 1] = 1 // expected-error {{missing argument for parameter 'y' in call}} {{8-8=, y: <#T##() -> Int#>}}
+s1[y: { 1 }] = 1 // expected-error {{missing argument for parameter 'x' in call}} {{4-4=x: <#T##Int#>, }}
+s1[] { 1 } = 1 // expected-error {{cannot convert value of type '() -> Int' to expected argument type '(x: Int, y: () -> Int)'}} {{none}}
+
+struct S2 {
+  subscript(x: Int, y: () -> Int) -> Int { get { return 1 } set { } } // expected-note * {{here}}
+}
+var s2 = S2()
+_ = s2[1, {1}]  // Ok.
+_ = s2[1] { 1 } // Ok.
+_ = s2[1] // expected-error {{cannot convert value of type 'Int' to expected argument type '(Int, () -> Int)'}} {{none}}
+_ = s2[{ 1 }] // expected-error {{cannot convert value of type '() -> Int' to expected argument type '(Int, () -> Int)'}} {{none}}
+_ = s2[] { 1 } // expected-error {{cannot convert value of type '() -> Int' to expected argument type '(Int, () -> Int)'}} {{none}}
+_ = s2 { 1 } // expected-error {{cannot call value of non-function type 'S2'}} {{none}}
+_ = s2[] // expected-error {{missing argument for parameter #1 in call}} {{8-8=<#T##Int#>}}
+s2[1, {1}] = 1 // Ok.
+s2[1] { 1 } = 1 // Ok.
+s2[1] = 1 // expected-error {{cannot convert value of type 'Int' to expected argument type '(Int, () -> Int)'}} {{none}}
+s2[{ 1 }] = 1 // expected-error {{cannot convert value of type '() -> Int' to expected argument type '(Int, () -> Int)'}} {{none}}
+s2[] { 1 } = 1 // expected-error {{cannot convert value of type '() -> Int' to expected argument type '(Int, () -> Int)'}} {{none}}
+
+struct S3 {
+      subscript(x x: Int, y y: Int, z z: (Int) -> Int) -> Int { get { return 1 } set { } } // expected-note * {{here}}
+}
+var s3 = S3()
+_ = s3[y: 1] { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{8-8=x: <#T##Int#>, }}
+_ = s3[x: 1] { 1 } // expected-error {{missing argument for parameter 'y' in call}} {{12-12=, y: <#T##Int#>}}
+_ = s3[x: 1, y: 1] // expected-error {{missing argument for parameter 'z' in call}} {{18-18=, z: <#T##(Int) -> Int#>}}
+s3[y: 1] { 1 } = 1 // expected-error {{missing argument for parameter 'x' in call}} {{4-4=x: <#T##Int#>, }}
+s3[x: 1] { 1 } = 1 // expected-error {{missing argument for parameter 'y' in call}} {{8-8=, y: <#T##Int#>}}
+s3[x: 1, y: 1] = 1 // expected-error {{missing argument for parameter 'z' in call}} {{14-14=, z: <#T##(Int) -> Int#>}}
+
+struct S4 {
+      subscript(x: Int, y: Int, z: (Int) -> Int) -> Int { get { return 1 } set { } } // expected-note * {{here}}
+}
+var s4 = S4()
+_ = s4[1] { 1 } // expected-error {{missing argument for parameter #2 in call}} {{9-9=, <#T##Int#>}}
+_ = s4[1, 1] // expected-error {{missing argument for parameter #3 in call}} {{12-12=, <#T##(Int) -> Int#>}}
+s4[1] { 1 } = 1 // expected-error {{missing argument for parameter #2 in call}} {{5-5=, <#T##Int#>}}
+s4[1, 1] = 1 // expected-error {{missing argument for parameter #3 in call}} {{8-8=, <#T##(Int) -> Int#>}}
+
+func multiLine(x: Int, y: Int, z: Int) {} // expected-note * {{here}}
+multiLine(
+) // expected-error {{missing argument for parameter 'x' in call}} {{1-1=x: <#T##Int#>}}
+multiLine(
+  y: 1, // expected-error {{missing argument for parameter 'x' in call}} {{3-3=x: <#T##Int#>, }}
+  z: 1
+)
+multiLine(
+  x: 1, // expected-error {{missing argument for parameter 'y' in call}} {{7-7=, y: <#T##Int#>}}
+  z: 1
+)
+multiLine(
+  x: 1,
+  y: 1 // expected-error {{missing argument for parameter 'z' in call}} {{7-7=, z: <#T##Int#>}}
+)

--- a/test/Constraints/diag_missing_arg.swift
+++ b/test/Constraints/diag_missing_arg.swift
@@ -1,89 +1,89 @@
 // RUN: %target-parse-verify-swift
 
 func nonNamedFunc(_ x: Int) {} // expected-note * {{here}}
-nonNamedFunc() // expected-error {{missing argument for parameter #1 in call}} {{14-14=<#T##Int#>}}
+nonNamedFunc() // expected-error {{missing argument for parameter #1 in call}} {{14-14=<#Int#>}}
 
 func namedFunc(x: Int) {} // expected-note * {{here}}
-namedFunc() // expected-error {{missing argument for parameter 'x' in call}} {{11-11=x: <#T##Int#>}}
+namedFunc() // expected-error {{missing argument for parameter 'x' in call}} {{11-11=x: <#Int#>}}
 
 func inoutFunc(x: inout Int) {} // expected-note * {{here}}
-inoutFunc() // expected-error {{missing argument for parameter 'x' in call}} {{11-11=x: &<#T##Int#>}}
+inoutFunc() // expected-error {{missing argument for parameter 'x' in call}} {{11-11=x: &<#Int#>}}
 
 func autoclosureFunc(x: @autoclosure () -> Int) {} // expected-note * {{here}}
-autoclosureFunc() // expected-error {{missing argument for parameter 'x' in call}} {{17-17=x: <#T##Int#>}}
+autoclosureFunc() // expected-error {{missing argument for parameter 'x' in call}} {{17-17=x: <#Int#>}}
 
 func attributedFunc(x: @convention(c) () -> Int32) {} // expected-note * {{here}}
-attributedFunc() // expected-error {{missing argument for parameter 'x' in call}} {{16-16=x: <#T##@convention(c) () -> Int32#>}}
+attributedFunc() // expected-error {{missing argument for parameter 'x' in call}} {{16-16=x: <#@convention(c) () -> Int32#>}}
 
 func attributedInOutFunc(x: inout @convention(c) () -> Int32) {} // expected-note * {{here}}
-attributedInOutFunc() // expected-error {{missing argument for parameter 'x' in call}} {{21-21=x: &<#T##@convention(c) () -> Int32#>}}
+attributedInOutFunc() // expected-error {{missing argument for parameter 'x' in call}} {{21-21=x: &<#@convention(c) () -> Int32#>}}
 
 func genericFunc1<T>(x: T) {} // expected-note * {{here}}
-genericFunc1() // expected-error {{missing argument for parameter 'x' in call}} {{14-14=x: <#T##T#>}}
+genericFunc1() // expected-error {{missing argument for parameter 'x' in call}} {{14-14=x: <#T#>}}
 
 protocol P {}
 func genericFunc2<T : P>(x: T) {} // expected-note * {{here}}
-genericFunc2() // expected-error {{missing argument for parameter 'x' in call}} {{14-14=x: <#T##T#>}}
+genericFunc2() // expected-error {{missing argument for parameter 'x' in call}} {{14-14=x: <#T#>}}
 
 typealias MyInt = Int
 func aliasedFunc(x: MyInt) {} // expected-note * {{here}}
-aliasedFunc() // expected-error {{missing argument for parameter 'x' in call}} {{13-13=x: <#T##MyInt#>}}
+aliasedFunc() // expected-error {{missing argument for parameter 'x' in call}} {{13-13=x: <#MyInt#>}}
 
 func trailingClosureSingle1(x: Int, y: () -> Int) {} // expected-note * {{here}}
-trailingClosureSingle1 { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{23-23=(x: <#T##Int#>)}}
-trailingClosureSingle1() { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{24-24=x: <#T##Int#>}}
+trailingClosureSingle1 { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{23-23=(x: <#Int#>)}}
+trailingClosureSingle1() { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{24-24=x: <#Int#>}}
 
 func trailingClosureSingle2(x: () -> Int, y: Int) {} // expected-note * {{here}}
 // FIXME: Bad diagnostics.
-trailingClosureSingle2 { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{23-23=(x: <#T##() -> Int#>)}}
-trailingClosureSingle2() { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{24-24=x: <#T##() -> Int#>}}
+trailingClosureSingle2 { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{23-23=(x: <#() -> Int#>)}}
+trailingClosureSingle2() { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{24-24=x: <#() -> Int#>}}
 
 func trailingClosureMulti1(x: Int, y: Int, z: () -> Int) {} // expected-note * {{here}}
-trailingClosureMulti1(y: 1) { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{23-23=x: <#T##Int#>, }}
-trailingClosureMulti1(x: 1) { 1 } // expected-error {{missing argument for parameter 'y' in call}} {{27-27=, y: <#T##Int#>}}
-trailingClosureMulti1(x: 1, y: 1) // expected-error {{missing argument for parameter 'z' in call}} {{33-33=, z: <#T##() -> Int#>}}
+trailingClosureMulti1(y: 1) { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{23-23=x: <#Int#>, }}
+trailingClosureMulti1(x: 1) { 1 } // expected-error {{missing argument for parameter 'y' in call}} {{27-27=, y: <#Int#>}}
+trailingClosureMulti1(x: 1, y: 1) // expected-error {{missing argument for parameter 'z' in call}} {{33-33=, z: <#() -> Int#>}}
 
 func trailingClosureMulti2(x: Int, y: () -> Int, z: Int) {} // expected-note * {{here}}
-trailingClosureMulti2 { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{22-22=(x: <#T##Int#>)}}
+trailingClosureMulti2 { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{22-22=(x: <#Int#>)}}
 // FIXME: Bad diagnostics.
-trailingClosureMulti2() { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{23-23=x: <#T##Int#>}}
-trailingClosureMulti2(x: 1) { 1 } // expected-error {{missing argument for parameter 'y' in call}} {{27-27=, y: <#T##() -> Int#>}}
+trailingClosureMulti2() { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{23-23=x: <#Int#>}}
+trailingClosureMulti2(x: 1) { 1 } // expected-error {{missing argument for parameter 'y' in call}} {{27-27=, y: <#() -> Int#>}}
 
 func param2Func(x: Int, y: Int) {} // expected-note * {{here}}
-param2Func(x: 1) // expected-error {{missing argument for parameter 'y' in call}} {{16-16=, y: <#T##Int#>}}
-param2Func(y: 1) // expected-error {{missing argument for parameter 'x' in call}} {{12-12=x: <#T##Int#>, }}
+param2Func(x: 1) // expected-error {{missing argument for parameter 'y' in call}} {{16-16=, y: <#Int#>}}
+param2Func(y: 1) // expected-error {{missing argument for parameter 'x' in call}} {{12-12=x: <#Int#>, }}
 
 func param2FuncNonNamed1(_ x: Int, y: String) {} // expected-note * {{here}}
-param2FuncNonNamed1(1) // expected-error {{missing argument for parameter 'y' in call}} {{22-22=, y: <#T##String#>}}
-param2FuncNonNamed1(y: "foo") // expected-error {{missing argument for parameter #1 in call}} {{21-21=<#T##Int#>, }}
+param2FuncNonNamed1(1) // expected-error {{missing argument for parameter 'y' in call}} {{22-22=, y: <#String#>}}
+param2FuncNonNamed1(y: "foo") // expected-error {{missing argument for parameter #1 in call}} {{21-21=<#Int#>, }}
 
 func param2FuncNonNamed2(x: Int, _ y: String) {} // expected-note * {{here}}
-param2FuncNonNamed2(x: 1) // expected-error {{missing argument for parameter #2 in call}} {{25-25=, <#T##String#>}}
-param2FuncNonNamed2("foo") // expected-error {{missing argument for parameter 'x' in call}} {{21-21=x: <#T##Int#>, }}
+param2FuncNonNamed2(x: 1) // expected-error {{missing argument for parameter #2 in call}} {{25-25=, <#String#>}}
+param2FuncNonNamed2("foo") // expected-error {{missing argument for parameter 'x' in call}} {{21-21=x: <#Int#>, }}
 
 func param2FuncNonNamed3(_ x: Int, _ y: String) {} // expected-note * {{here}}
-param2FuncNonNamed3(1) // expected-error {{missing argument for parameter #2 in call}} {{22-22=, <#T##String#>}}
-param2FuncNonNamed3("foo") // expected-error {{missing argument for parameter #2 in call}} {{26-26=, <#T##String#>}}
+param2FuncNonNamed3(1) // expected-error {{missing argument for parameter #2 in call}} {{22-22=, <#String#>}}
+param2FuncNonNamed3("foo") // expected-error {{missing argument for parameter #2 in call}} {{26-26=, <#String#>}}
                            // FIXME: Bad diagnostic. Could this be #1?
 
 func param3Func(x: Int, y: Int, z: Int) {} // expected-note * {{here}}
-param3Func(x: 1, y: 1) // expected-error {{missing argument for parameter 'z' in call}} {{22-22=, z: <#T##Int#>}}
-param3Func(x: 1, z: 1) // expected-error {{missing argument for parameter 'y' in call}} {{16-16=, y: <#T##Int#>}}
-param3Func(y: 1, z: 1) // expected-error {{missing argument for parameter 'x' in call}} {{12-12=x: <#T##Int#>, }}
+param3Func(x: 1, y: 1) // expected-error {{missing argument for parameter 'z' in call}} {{22-22=, z: <#Int#>}}
+param3Func(x: 1, z: 1) // expected-error {{missing argument for parameter 'y' in call}} {{16-16=, y: <#Int#>}}
+param3Func(y: 1, z: 1) // expected-error {{missing argument for parameter 'x' in call}} {{12-12=x: <#Int#>, }}
 
 func hasDefault1(x: Int, y: Int = 1) {} // expected-note * {{here}}
 hasDefault1(x: 1) // ok
-hasDefault1(y: 1) // expected-error {{missing argument for parameter 'x' in call}} {{13-13=x: <#T##Int#>, }}
+hasDefault1(y: 1) // expected-error {{missing argument for parameter 'x' in call}} {{13-13=x: <#Int#>, }}
 
 func hasDefault2(x: Int = 1, y: Int) {} // expected-note * {{here}}
-hasDefault2(x: 1) // expected-error {{missing argument for parameter 'y' in call}} {{17-17=, y: <#T##Int#>}}
+hasDefault2(x: 1) // expected-error {{missing argument for parameter 'y' in call}} {{17-17=, y: <#Int#>}}
 hasDefault2(y: 1) // ok
 
 struct S { init(x: Int, y: () -> Int) {} } // expected-note * {{here}}
-_ = S(x: 1) // expected-error {{missing argument for parameter 'y' in call}} {{11-11=, y: <#T##() -> Int#>}}
-_ = S(y: { 1 }) // expected-error {{missing argument for parameter 'x' in call}} {{7-7=x: <#T##Int#>, }}
-_ = S { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{6-6=(x: <#T##Int#>)}}
-_ = S() { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{7-7=x: <#T##Int#>}}
+_ = S(x: 1) // expected-error {{missing argument for parameter 'y' in call}} {{11-11=, y: <#() -> Int#>}}
+_ = S(y: { 1 }) // expected-error {{missing argument for parameter 'x' in call}} {{7-7=x: <#Int#>, }}
+_ = S { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{6-6=(x: <#Int#>)}}
+_ = S() { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{7-7=x: <#Int#>}}
 
 struct S1 {
   subscript(x x: Int, y y: () -> Int) -> Int { get { return 1 } set { } } // expected-note * {{here}}
@@ -91,15 +91,15 @@ struct S1 {
 var s1 = S1()
 _ = s1[x: 1, y: {1}]  // Ok.
 _ = s1[x: 1] { 1 } // Ok.
-_ = s1[x: 1] // expected-error {{missing argument for parameter 'y' in call}} {{12-12=, y: <#T##() -> Int#>}}
-_ = s1[y: { 1 }] // expected-error {{missing argument for parameter 'x' in call}} {{8-8=x: <#T##Int#>, }}
+_ = s1[x: 1] // expected-error {{missing argument for parameter 'y' in call}} {{12-12=, y: <#() -> Int#>}}
+_ = s1[y: { 1 }] // expected-error {{missing argument for parameter 'x' in call}} {{8-8=x: <#Int#>, }}
 _ = s1[] { 1 } // expected-error {{cannot convert value of type '() -> Int' to expected argument type '(x: Int, y: () -> Int)'}} {{none}}
 _ = s1 { 1 } // expected-error {{cannot call value of non-function type 'S1'}} {{none}}
-_ = s1[] // expected-error {{missing argument for parameter 'x' in call}} {{8-8=x: <#T##Int#>}}
+_ = s1[] // expected-error {{missing argument for parameter 'x' in call}} {{8-8=x: <#Int#>}}
 s1[x: 1, y: {1}] = 1 // Ok.
 s1[x: 1] { 1 } = 1 // Ok.
-s1[x: 1] = 1 // expected-error {{missing argument for parameter 'y' in call}} {{8-8=, y: <#T##() -> Int#>}}
-s1[y: { 1 }] = 1 // expected-error {{missing argument for parameter 'x' in call}} {{4-4=x: <#T##Int#>, }}
+s1[x: 1] = 1 // expected-error {{missing argument for parameter 'y' in call}} {{8-8=, y: <#() -> Int#>}}
+s1[y: { 1 }] = 1 // expected-error {{missing argument for parameter 'x' in call}} {{4-4=x: <#Int#>, }}
 s1[] { 1 } = 1 // expected-error {{cannot convert value of type '() -> Int' to expected argument type '(x: Int, y: () -> Int)'}} {{none}}
 
 struct S2 {
@@ -112,7 +112,7 @@ _ = s2[1] // expected-error {{cannot convert value of type 'Int' to expected arg
 _ = s2[{ 1 }] // expected-error {{cannot convert value of type '() -> Int' to expected argument type '(Int, () -> Int)'}} {{none}}
 _ = s2[] { 1 } // expected-error {{cannot convert value of type '() -> Int' to expected argument type '(Int, () -> Int)'}} {{none}}
 _ = s2 { 1 } // expected-error {{cannot call value of non-function type 'S2'}} {{none}}
-_ = s2[] // expected-error {{missing argument for parameter #1 in call}} {{8-8=<#T##Int#>}}
+_ = s2[] // expected-error {{missing argument for parameter #1 in call}} {{8-8=<#Int#>}}
 s2[1, {1}] = 1 // Ok.
 s2[1] { 1 } = 1 // Ok.
 s2[1] = 1 // expected-error {{cannot convert value of type 'Int' to expected argument type '(Int, () -> Int)'}} {{none}}
@@ -123,34 +123,34 @@ struct S3 {
       subscript(x x: Int, y y: Int, z z: (Int) -> Int) -> Int { get { return 1 } set { } } // expected-note * {{here}}
 }
 var s3 = S3()
-_ = s3[y: 1] { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{8-8=x: <#T##Int#>, }}
-_ = s3[x: 1] { 1 } // expected-error {{missing argument for parameter 'y' in call}} {{12-12=, y: <#T##Int#>}}
-_ = s3[x: 1, y: 1] // expected-error {{missing argument for parameter 'z' in call}} {{18-18=, z: <#T##(Int) -> Int#>}}
-s3[y: 1] { 1 } = 1 // expected-error {{missing argument for parameter 'x' in call}} {{4-4=x: <#T##Int#>, }}
-s3[x: 1] { 1 } = 1 // expected-error {{missing argument for parameter 'y' in call}} {{8-8=, y: <#T##Int#>}}
-s3[x: 1, y: 1] = 1 // expected-error {{missing argument for parameter 'z' in call}} {{14-14=, z: <#T##(Int) -> Int#>}}
+_ = s3[y: 1] { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{8-8=x: <#Int#>, }}
+_ = s3[x: 1] { 1 } // expected-error {{missing argument for parameter 'y' in call}} {{12-12=, y: <#Int#>}}
+_ = s3[x: 1, y: 1] // expected-error {{missing argument for parameter 'z' in call}} {{18-18=, z: <#(Int) -> Int#>}}
+s3[y: 1] { 1 } = 1 // expected-error {{missing argument for parameter 'x' in call}} {{4-4=x: <#Int#>, }}
+s3[x: 1] { 1 } = 1 // expected-error {{missing argument for parameter 'y' in call}} {{8-8=, y: <#Int#>}}
+s3[x: 1, y: 1] = 1 // expected-error {{missing argument for parameter 'z' in call}} {{14-14=, z: <#(Int) -> Int#>}}
 
 struct S4 {
       subscript(x: Int, y: Int, z: (Int) -> Int) -> Int { get { return 1 } set { } } // expected-note * {{here}}
 }
 var s4 = S4()
-_ = s4[1] { 1 } // expected-error {{missing argument for parameter #2 in call}} {{9-9=, <#T##Int#>}}
-_ = s4[1, 1] // expected-error {{missing argument for parameter #3 in call}} {{12-12=, <#T##(Int) -> Int#>}}
-s4[1] { 1 } = 1 // expected-error {{missing argument for parameter #2 in call}} {{5-5=, <#T##Int#>}}
-s4[1, 1] = 1 // expected-error {{missing argument for parameter #3 in call}} {{8-8=, <#T##(Int) -> Int#>}}
+_ = s4[1] { 1 } // expected-error {{missing argument for parameter #2 in call}} {{9-9=, <#Int#>}}
+_ = s4[1, 1] // expected-error {{missing argument for parameter #3 in call}} {{12-12=, <#(Int) -> Int#>}}
+s4[1] { 1 } = 1 // expected-error {{missing argument for parameter #2 in call}} {{5-5=, <#Int#>}}
+s4[1, 1] = 1 // expected-error {{missing argument for parameter #3 in call}} {{8-8=, <#(Int) -> Int#>}}
 
 func multiLine(x: Int, y: Int, z: Int) {} // expected-note * {{here}}
 multiLine(
-) // expected-error {{missing argument for parameter 'x' in call}} {{1-1=x: <#T##Int#>}}
+) // expected-error {{missing argument for parameter 'x' in call}} {{1-1=x: <#Int#>}}
 multiLine(
-  y: 1, // expected-error {{missing argument for parameter 'x' in call}} {{3-3=x: <#T##Int#>, }}
+  y: 1, // expected-error {{missing argument for parameter 'x' in call}} {{3-3=x: <#Int#>, }}
   z: 1
 )
 multiLine(
-  x: 1, // expected-error {{missing argument for parameter 'y' in call}} {{7-7=, y: <#T##Int#>}}
+  x: 1, // expected-error {{missing argument for parameter 'y' in call}} {{7-7=, y: <#Int#>}}
   z: 1
 )
 multiLine(
   x: 1,
-  y: 1 // expected-error {{missing argument for parameter 'z' in call}} {{7-7=, z: <#T##Int#>}}
+  y: 1 // expected-error {{missing argument for parameter 'z' in call}} {{7-7=, z: <#Int#>}}
 )


### PR DESCRIPTION
Add insertion fix-it with placeholder for missing arguments.

given:
```swift
func fn1(foo : Int, bar: String, baz: Float) {}
fn1(foo: 1, baz: 0.2)

func fn2(foo : Int, bar: (Int) -> Void) {}
fn2 { print($0) }
```

<pre>
<b>test.swift:2:4: error: missing argument for parameter 'bar' in call</b>
fn1(foo: 1, baz: 0.2)
          ^
          , bar: <#String#>
<b>test.swift:5:5: error: missing argument for parameter 'foo' in call</b>
fn2 { print($0) }
   ^
   (foo: <#Int#>)
</pre>

