### PR TITLE
[gardening] Remove unused #define requireTrueAndSILOwnership

### DIFF
--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -132,9 +132,6 @@ public:
   }
 #define require(condition, complaint) \
   _require(bool(condition), complaint ": " #condition)
-#define requireTrueAndSILOwnership(verifier, condition, complaint)             \
-  _require(!verifier->isSILOwnershipEnabled() || bool(condition),              \
-           complaint ": " #condition)
 
   template <class T> typename CanTypeWrapperTraits<T>::type
   _requireObjectType(SILType type, const Twine &valueDescription,


### PR DESCRIPTION
Remove unused `#define requireTrueAndSILOwnership`.

Last `requireTrueAndSILOwnership(…)` usage removed in commit 8d4aac47e8297cd7b2242eb58fca4d853deee3a7 by @gottesmm