### PR TITLE
[swiftc (107 vs. 5184)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28481-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
+++ b/validation-test/compiler_crashers/28481-anonymous-namespace-verifier-verifychecked-swift-type-llvm-smallptrset-swift-arc.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class A.func g{{return $0
+== A>()n


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 107 (5184 resolved)

Stack trace:

```
a type variable escaped the type checker#0 0x00000000031cfff8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x31cfff8)
#1 0x00000000031d0846 SignalHandler(int) (/path/to/swift/bin/swift+0x31d0846)
#2 0x00007efdb446a330 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x10330)
#3 0x00007efdb2c28c37 gsignal /build/eglibc-oGUzwX/eglibc-2.19/signal/../nptl/sysdeps/unix/sysv/linux/raise.c:56:0
#4 0x00007efdb2c2c028 abort /build/eglibc-oGUzwX/eglibc-2.19/stdlib/abort.c:91:0
#5 0x0000000000d5c7fc (anonymous namespace)::Verifier::verifyChecked(swift::Type, llvm::SmallPtrSet<swift::ArchetypeType*, 4u>&) (/path/to/swift/bin/swift+0xd5c7fc)
#6 0x0000000000d4f4da (anonymous namespace)::Verifier::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0xd4f4da)
#7 0x0000000000d69394 (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd69394)
#8 0x0000000000d67f5a swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd67f5a)
#9 0x0000000000d67e1c swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd67e1c)
#10 0x0000000000d6ac33 (anonymous namespace)::Traversal::visit(swift::Expr*) (/path/to/swift/bin/swift+0xd6ac33)
#11 0x0000000000d67ebf swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0xd67ebf)
#12 0x0000000000d66f2d (anonymous namespace)::Traversal::visitAbstractFunctionDecl(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xd66f2d)
#13 0x0000000000d66472 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0xd66472)
#14 0x0000000000d66374 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xd66374)
#15 0x0000000000dbb89e swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0xdbb89e)
#16 0x0000000000d4df8c swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0xd4df8c)
#17 0x0000000000c160a2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0xc160a2)
#18 0x0000000000938a56 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0x938a56)
#19 0x000000000047ece5 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47ece5)
#20 0x000000000047db7f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x47db7f)
#21 0x000000000044509a main (/path/to/swift/bin/swift+0x44509a)
#22 0x00007efdb2c13f45 __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:321:0
#23 0x0000000000442816 _start (/path/to/swift/bin/swift+0x442816)
```