### PR TITLE
Disable typo-correction after fatal errors

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -434,6 +434,9 @@ namespace swift {
     void setShowDiagnosticsAfterFatalError(bool val = true) {
       showDiagnosticsAfterFatalError = val;
     }
+    bool getShowDiagnosticsAfterFatalError() {
+      return showDiagnosticsAfterFatalError;
+    }
 
     /// \brief Whether to skip emitting warnings
     void setSuppressWarnings(bool val) { suppressWarnings = val; }
@@ -508,6 +511,9 @@ namespace swift {
 
     void setShowDiagnosticsAfterFatalError(bool val = true) {
       state.setShowDiagnosticsAfterFatalError(val);
+    }
+    bool getShowDiagnosticsAfterFatalError() {
+      return state.getShowDiagnosticsAfterFatalError();
     }
 
     /// \brief Whether to skip emitting warnings

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -504,7 +504,10 @@ void TypeChecker::performTypoCorrection(DeclContext *DC, DeclRefKind refKind,
                                         NameLookupOptions lookupOptions,
                                         LookupResult &result,
                                         unsigned maxResults) {
-  if (getLangOpts().DisableTypoCorrection)
+  // Disable typo-correction if we won't show the diagnostic anyway.
+  if (getLangOpts().DisableTypoCorrection ||
+      (Diags.hasFatalErrorOccurred() &&
+       !Diags.getShowDiagnosticsAfterFatalError()))
     return;
 
   // Fill in a collection of the most reasonable entries.

--- a/test/Sema/typo_correction.swift
+++ b/test/Sema/typo_correction.swift
@@ -1,6 +1,11 @@
 // RUN: %target-parse-verify-swift
 // RUN: not %target-swift-frontend -parse -disable-typo-correction %s 2>&1 | %FileCheck %s -check-prefix=DISABLED
+// RUN: not %target-swift-frontend -parse -DIMPORT_FAIL %s 2>&1 | %FileCheck %s -check-prefix=DISABLED
 // DISABLED-NOT: did you mean
+
+#if IMPORT_FAIL
+import NoSuchModule
+#endif
 
 // This is close enough to get typo-correction.
 func test_short_and_close() {


### PR DESCRIPTION
If we won't show the diagnostics anyway, don't go to the trouble of
performing the typo-corrections, which can be expensive.  This is really
helpful if there is a module import failure, which may cause many names
to fail to resolve and would otherwise trigger typo-correction.

rdar://problem/29003372