### PR TITLE
[3.0] Provide a frontend option to disable typo correction.

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -43,6 +43,9 @@ namespace swift {
 
     /// \brief Disable API availability checking.
     bool DisableAvailabilityChecking = false;
+
+    /// \brief Disable typo correction.
+    bool DisableTypoCorrection = false;
     
     /// Whether to warn about "needless" words in declarations.
     bool WarnOmitNeedlessWords = false;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -115,6 +115,9 @@ def serialize_debugging_options : Flag<["-"], "serialize-debugging-options">,
 def autolink_library : Separate<["-"], "autolink-library">,
   HelpText<"Add dependent library">, Flags<[FrontendOption]>;
 
+def disable_typo_correction : Flag<["-"], "disable-typo-correction">,
+  HelpText<"Disable typo correction">;
+
 } // end let Flags = [FrontendOption, NoDriverOption]
 
 def debug_crash_Group : OptionGroup<"<automatic crashing options>">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -755,6 +755,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
       = A->getOption().matches(OPT_enable_access_control);
   }
 
+  Opts.DisableTypoCorrection |= Args.hasArg(OPT_disable_typo_correction);
+
   Opts.CodeCompleteInitsInPostfixExpr |=
       Args.hasArg(OPT_code_complete_inits_in_postfix_expr);
 

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -531,6 +531,9 @@ void TypeChecker::performTypoCorrection(DeclContext *DC, DeclRefKind refKind,
                                         NameLookupOptions lookupOptions,
                                         LookupResult &result,
                                         unsigned maxResults) {
+  if (getLangOpts().DisableTypoCorrection)
+    return;
+
   // Fill in a collection of the most reasonable entries.
   TopCollection<unsigned, ValueDecl*> entries(maxResults);
   auto consumer = makeDeclConsumer([&](ValueDecl *decl,


### PR DESCRIPTION
Per rdar://29207312, add this option to the 3.0 release.