### PR TITLE
[SR-3168] Add fix-it for "'optional' can only be applied to protocol members"

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -8400,8 +8400,8 @@ static void validateAttributes(TypeChecker &TC, Decl *D) {
   // Only protocol members can be optional.
   if (auto *OA = Attrs.getAttribute<OptionalAttr>()) {
     if (!isa<ProtocolDecl>(D->getDeclContext())) {
-      TC.diagnose(OA->getLocation(),
-                  diag::optional_attribute_non_protocol);
+      TC.diagnose(OA->getLocation(), diag::optional_attribute_non_protocol)
+        .fixItRemove(OA->getRange());
       D->getAttrs().removeAttribute(OA);
     } else if (!cast<ProtocolDecl>(D->getDeclContext())->isObjC()) {
       TC.diagnose(OA->getLocation(),

--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -306,3 +306,7 @@ protocol P1 {}
 protocol P2 {}
 var a : protocol<P1, P2>?
 var a2 : protocol<P1>= 17
+
+class TestOptionalMethodFixit {
+  optional func test() {}
+}

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -309,3 +309,7 @@ protocol P1 {}
 protocol P2 {}
 var a : (P1 & P2)?
 var a2 : P1= 17 as! P1
+
+class TestOptionalMethodFixit {
+  func test() {}
+}

--- a/test/decl/protocol/req/optional.swift
+++ b/test/decl/protocol/req/optional.swift
@@ -204,18 +204,18 @@ func optionalSubscriptExistential(_ t: P1) {
 // -----------------------------------------------------------------------
 
 // optional cannot be used on non-protocol declarations
-optional var optError: Int = 10 // expected-error{{'optional' can only be applied to protocol members}}
+optional var optError: Int = 10 // expected-error{{'optional' can only be applied to protocol members}} {{1-10=}}
 
 optional struct optErrorStruct { // expected-error{{'optional' modifier cannot be applied to this declaration}} {{1-10=}}
-  optional var ivar: Int // expected-error{{'optional' can only be applied to protocol members}}
-  optional func foo() { } // expected-error{{'optional' can only be applied to protocol members}}
+  optional var ivar: Int // expected-error{{'optional' can only be applied to protocol members}} {{3-12=}}
+  optional func foo() { } // expected-error{{'optional' can only be applied to protocol members}} {{3-12=}}
 }
 
 optional class optErrorClass { // expected-error{{'optional' modifier cannot be applied to this declaration}} {{1-10=}}
-  optional var ivar: Int = 0 // expected-error{{'optional' can only be applied to protocol members}}
-  optional func foo() { } // expected-error{{'optional' can only be applied to protocol members}}
+  optional var ivar: Int = 0 // expected-error{{'optional' can only be applied to protocol members}} {{3-12=}}
+  optional func foo() { } // expected-error{{'optional' can only be applied to protocol members}} {{3-12=}}
 }
-  
+
 protocol optErrorProtocol {
   optional func foo(_ x: Int) // expected-error{{'optional' can only be applied to members of an @objc protocol}}
 }


### PR DESCRIPTION
This PR adds a fixit for cases in which the keyword "optional" is incorrectly applied to class or struct methods.

Resolves [SR-3168](https://bugs.swift.org/browse/SR-3168).
